### PR TITLE
feat(skills): add MCP Decision Engine skill documentation (SMI-1377)

### DIFF
--- a/docs/architecture/mcp-decision-engine-architecture.md
+++ b/docs/architecture/mcp-decision-engine-architecture.md
@@ -1,0 +1,180 @@
+# MCP Decision Engine Architecture
+
+## Overview
+
+The MCP Decision Engine is a standalone Claude Code skill that provides an 8-dimension scoring framework to help users decide between implementing capabilities as Skills (with scripts) vs MCP servers.
+
+## Problem Statement
+
+Users frequently face the decision of whether to implement a capability as:
+- **Skill with scripts**: Lower token overhead, deterministic execution
+- **MCP server**: Real-time data access, dynamic tool discovery
+
+Making the wrong choice can result in:
+- 10-100x token waste (choosing MCP for repeatable tasks)
+- Missed functionality (choosing Skill for real-time needs)
+- Maintenance burden (wrong tool for the job)
+
+## Solution Architecture
+
+### Component Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   mcp-decision-helper Skill                  │
+├─────────────────────────────────────────────────────────────┤
+│  SKILL.md                                                    │
+│  ├── Trigger phrases and invocation                          │
+│  ├── 8-dimension scoring framework                           │
+│  ├── Automatic disqualifier logic                            │
+│  └── Output generation instructions                          │
+├─────────────────────────────────────────────────────────────┤
+│  scripts/                                                    │
+│  └── evaluate.ts                                             │
+│      ├── Score calculation logic                             │
+│      ├── Disqualifier detection                              │
+│      └── Report generation                                   │
+├─────────────────────────────────────────────────────────────┤
+│  templates/                                                  │
+│  ├── skill-template.md (Skill output structure)              │
+│  ├── mcp-template.md (MCP output structure)                  │
+│  └── hybrid-template.md (Combined approach)                  │
+├─────────────────────────────────────────────────────────────┤
+│  references/                                                 │
+│  ├── decision-framework.md (Detailed criteria)               │
+│  └── examples.md (Sample evaluations)                        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Scoring Framework
+
+| Dimension | Skill Indicator (+2) | MCP Indicator (+2) |
+|-----------|---------------------|-------------------|
+| Task Repeatability | Same operation >10x daily | One-off exploration |
+| Data Freshness | Point-in-time acceptable | Real-time required |
+| Token Sensitivity | Budget <50K tokens | Flexible budget |
+| Reliability Needs | Deterministic/auditable | Moderate tolerance |
+| Maintenance Capacity | No DevOps team | Full DevOps available |
+| Integration Scope | Single system | Multi-system orchestration |
+| Discovery Needs | Static, known tools | Dynamic tool discovery |
+| Auth Complexity | Simple/none | OAuth/SSO/enterprise |
+
+### Decision Thresholds
+
+- **Score ≥ 6 for Skills** → Recommend Skill implementation
+- **Score ≥ 6 for MCP** → Recommend MCP server
+- **Mixed scores** → Recommend Hybrid approach
+
+### Automatic Disqualifiers
+
+**Must use MCP (no scoring needed):**
+- Real-time streaming requirement
+- Dynamic tool discovery essential
+- Enterprise SSO/OAuth integration
+- Multi-system orchestration hub
+
+**Must use Skill (no scoring needed):**
+- Token budget <10K per session
+- Deterministic execution audit required
+- No DevOps capacity for server maintenance
+- Highly repetitive operations (>10x daily)
+
+## Data Flow
+
+```
+User Request ("Should I use MCP or Skill for X?")
+        │
+        ▼
+┌─────────────────────┐
+│ Parse Task Context  │
+└─────────┬───────────┘
+          │
+          ▼
+┌─────────────────────┐
+│ Check Disqualifiers │──────► Immediate recommendation
+└─────────┬───────────┘        (if disqualifier triggered)
+          │
+          ▼
+┌─────────────────────┐
+│ Score 8 Dimensions  │
+└─────────┬───────────┘
+          │
+          ▼
+┌─────────────────────┐
+│ Calculate Totals    │
+│ - Skill Score       │
+│ - MCP Score         │
+└─────────┬───────────┘
+          │
+          ▼
+┌─────────────────────┐
+│ Generate Report     │
+│ - Recommendation    │
+│ - Breakdown         │
+│ - Next Steps        │
+└─────────────────────┘
+```
+
+## Output Format
+
+### Evaluation Report Structure
+
+```markdown
+## MCP vs Skill Evaluation: [Task Name]
+
+### Recommendation: [SKILL | MCP | HYBRID]
+
+### Score Breakdown
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| ... | ... | ... |
+
+**Skill Score:** X/16
+**MCP Score:** Y/16
+
+### Token Impact
+
+| Approach | Est. Startup | Est. Per-Task | Daily Total |
+|----------|--------------|---------------|-------------|
+| Skill | ~200 tokens | ~500 tokens | ~5,200 tokens |
+| MCP | ~15,000 tokens | ~2,000 tokens | ~35,000 tokens |
+
+### Recommended Next Steps
+
+1. [Action item 1]
+2. [Action item 2]
+3. [Action item 3]
+```
+
+## Integration Points
+
+### Skill Builder Integration
+
+The MCP Decision Engine should be invoked when:
+- User asks skill-builder to create a new capability
+- User is unsure whether to create a skill or MCP server
+- During architectural planning phases
+
+### Cross-Reference
+
+- Skill Builder can reference: "Run mcp-decision-helper first to determine approach"
+- MCP Decision Engine can reference: "Use skill-builder to implement Skill" or "Use [MCP docs] to implement server"
+
+## Security Considerations
+
+- No external API calls required (fully local)
+- No secrets or credentials needed
+- All evaluation is deterministic
+
+## Token Efficiency
+
+- Skill startup: ~50 tokens (progressive disclosure)
+- Full evaluation: ~500-1,000 tokens
+- Much lighter than analyzing this manually in conversation
+
+## References
+
+- Research: /docs/backlog/skill-optimizations/skills-vs-mcp-research.md
+- Research: /docs/backlog/skill-optimizations/mcp-builder-skill-prompt.md
+- Implementation: /docs/execution/mcp-decision-engine-implementation.md

--- a/docs/execution/mcp-decision-engine-implementation.md
+++ b/docs/execution/mcp-decision-engine-implementation.md
@@ -1,0 +1,380 @@
+# MCP Decision Engine Implementation Plan
+
+**Date:** January 2026
+**Type:** New Skill Creation
+**Location:** `~/.claude/skills/mcp-decision-helper/`
+**Execution Model:** Sequential waves with parallel sub-tasks
+
+---
+
+## Overview
+
+Implementation plan for creating the MCP Decision Engine skill that helps users decide between Skills (with scripts) vs MCP servers using an 8-dimension scoring framework.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│              MCP DECISION ENGINE IMPLEMENTATION              │
+├─────────────────────────────────────────────────────────────┤
+│  Wave 1: Core SKILL.md Creation              ~2 hours       │
+│     └── 8-dimension scoring, disqualifiers, output format   │
+├─────────────────────────────────────────────────────────────┤
+│  Wave 2: Evaluation Script                   ~3 hours       │
+│     └── TypeScript scoring logic with CLI interface         │
+├─────────────────────────────────────────────────────────────┤
+│  Wave 3: Templates                           ~2 hours       │
+│     └── Skill, MCP, and Hybrid output templates             │
+├─────────────────────────────────────────────────────────────┤
+│  Wave 4: References & Examples               ~2 hours       │
+│     └── Decision framework docs and sample evaluations      │
+├─────────────────────────────────────────────────────────────┤
+│  Wave 5: Validation & Testing                ~1 hour        │
+│     └── End-to-end testing and documentation review         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Wave 1: Core SKILL.md Creation
+
+**Est. Time:** ~2 hours
+**Linear Issue:** SMI-XXXX - Create SKILL.md with 8-dimension scoring
+
+### Tasks
+
+1. Create directory structure:
+   ```bash
+   mkdir -p ~/.claude/skills/mcp-decision-helper/{scripts,templates,references}
+   ```
+
+2. Create SKILL.md with:
+   - YAML frontmatter (name, description, triggers)
+   - 8-dimension scoring framework table
+   - Automatic disqualifier logic
+   - Decision thresholds (Score ≥ 6)
+   - Output format specification
+   - Integration instructions
+
+### SKILL.md Structure
+
+```yaml
+---
+name: mcp-decision-helper
+description: Evaluate whether to implement a capability as a Skill or MCP server
+triggers:
+  - "should I use MCP"
+  - "skill vs MCP"
+  - "evaluate integration approach"
+  - "MCP or skill for"
+---
+
+# MCP Decision Helper
+
+## Purpose
+Help users make informed decisions about whether to implement capabilities as Claude Code Skills (with scripts) or MCP servers.
+
+## Quick Decision
+
+### Automatic Disqualifiers
+
+**Must use MCP (skip scoring):**
+- [ ] Real-time streaming requirement
+- [ ] Dynamic tool discovery essential
+- [ ] Enterprise SSO/OAuth integration
+- [ ] Multi-system orchestration hub
+
+**Must use Skill (skip scoring):**
+- [ ] Token budget <10K per session
+- [ ] Deterministic execution audit required
+- [ ] No DevOps capacity available
+- [ ] Highly repetitive operations (>10x daily)
+
+If none of the above apply, proceed to scoring.
+
+## Scoring Framework
+
+Evaluate each dimension on a scale of -2 to +2:
+
+| Dimension | -2 (Strong Skill) | -1 | 0 | +1 | +2 (Strong MCP) |
+|-----------|-------------------|----|----|----|--------------------|
+| Task Repeatability | Same task >10x/day | Frequent | Mixed | Occasional | One-off exploration |
+| Data Freshness | Point-in-time OK | Hourly | Daily | Near-real-time | Real-time required |
+| Token Sensitivity | <10K budget | <50K budget | Moderate | Flexible | Unlimited |
+| Reliability Needs | Must be deterministic | High | Standard | Moderate | Low tolerance OK |
+| Maintenance Capacity | No DevOps | Limited | Moderate | Good | Full DevOps team |
+| Integration Scope | Single system | Few systems | Mixed | Several | Enterprise-wide |
+| Discovery Needs | Static, known | Mostly static | Some dynamic | Often dynamic | Dynamic essential |
+| Auth Complexity | None/API key | Basic auth | OAuth | SSO | Enterprise SSO |
+
+## Decision Thresholds
+
+1. Sum all dimension scores
+2. Apply decision:
+   - **Score ≤ -6**: Strong recommendation for Skill
+   - **Score -5 to +5**: Hybrid approach or case-by-case
+   - **Score ≥ +6**: Strong recommendation for MCP
+
+## Output Generation
+
+After scoring, generate report using templates in `templates/` directory.
+
+## Script Usage
+
+npx tsx ~/.claude/skills/mcp-decision-helper/scripts/evaluate.ts
+
+## Related Skills
+
+- skill-builder: Use to implement if Skill recommended
+- See MCP documentation for MCP implementation
+```
+
+### Acceptance Criteria
+
+- [ ] SKILL.md created with complete scoring framework
+- [ ] Trigger phrases correctly identify skill
+- [ ] Disqualifier logic is clear and actionable
+- [ ] Decision thresholds documented
+
+---
+
+## Wave 2: Evaluation Script
+
+**Est. Time:** ~3 hours
+**Linear Issue:** SMI-XXXX - Create evaluation script (evaluate.ts)
+
+### Tasks
+
+1. Create `scripts/evaluate.ts` with:
+   - Interactive CLI prompts for each dimension
+   - Score calculation logic
+   - Disqualifier detection
+   - Report generation
+   - JSON output option
+
+### Script Interface
+
+```typescript
+interface EvaluationInput {
+  taskDescription: string;
+  dimensions: {
+    repeatability: number;      // -2 to +2
+    dataFreshness: number;      // -2 to +2
+    tokenSensitivity: number;   // -2 to +2
+    reliabilityNeeds: number;   // -2 to +2
+    maintenanceCapacity: number; // -2 to +2
+    integrationScope: number;   // -2 to +2
+    discoveryNeeds: number;     // -2 to +2
+    authComplexity: number;     // -2 to +2
+  };
+  disqualifiers: {
+    realTimeStreaming: boolean;
+    dynamicDiscovery: boolean;
+    enterpriseSSO: boolean;
+    multiSystemOrchestration: boolean;
+    tokenBudgetConstrained: boolean;
+    deterministicRequired: boolean;
+    noDevOps: boolean;
+    highlyRepetitive: boolean;
+  };
+}
+
+interface EvaluationResult {
+  recommendation: 'SKILL' | 'MCP' | 'HYBRID';
+  totalScore: number;
+  breakdown: Record<string, { score: number; rationale: string }>;
+  disqualifiersTriggered: string[];
+  tokenImpact: {
+    skillEstimate: string;
+    mcpEstimate: string;
+    savingsWithSkill: string;
+  };
+  nextSteps: string[];
+}
+```
+
+### Acceptance Criteria
+
+- [ ] Script runs successfully with `npx tsx evaluate.ts`
+- [ ] Interactive prompts work correctly
+- [ ] Disqualifiers override scoring when triggered
+- [ ] JSON output option works
+- [ ] Report generation is readable
+
+---
+
+## Wave 3: Templates
+
+**Est. Time:** ~2 hours
+**Linear Issue:** SMI-XXXX - Create Skill/MCP/Hybrid templates
+
+### Tasks
+
+1. Create `templates/skill-template.md`:
+   - Skill directory structure
+   - SKILL.md scaffolding
+   - scripts/ recommendations
+   - Best practices
+
+2. Create `templates/mcp-template.md`:
+   - MCP server structure (TypeScript/Python)
+   - Configuration for Claude settings
+   - Error handling patterns
+   - Timeout considerations
+
+3. Create `templates/hybrid-template.md`:
+   - Combined approach structure
+   - When to use Skill vs MCP portions
+   - Migration path documentation
+
+### Acceptance Criteria
+
+- [ ] All three templates created
+- [ ] Templates include actionable scaffolding
+- [ ] Best practices documented in each
+- [ ] Copy-paste ready structure
+
+---
+
+## Wave 4: References & Examples
+
+**Est. Time:** ~2 hours
+**Linear Issues:**
+- SMI-XXXX - Create reference documentation
+- SMI-XXXX - Add example evaluations
+
+### Tasks
+
+1. Create `references/decision-framework.md`:
+   - Detailed rationale for each dimension
+   - Scoring guidance with examples
+   - Edge case handling
+
+2. Create `references/examples.md`:
+   - 3-5 sample evaluations
+   - Various outcomes (Skill, MCP, Hybrid)
+   - Real-world scenarios
+
+### Example Evaluations
+
+#### Example 1: Daily Report Generator
+
+**Task**: Generate daily sales reports from CRM data
+
+**Disqualifier Check:**
+- [x] Token budget constrained: Yes (<50K)
+- [x] Highly repetitive: Yes (daily)
+
+**Result**: SKILL (disqualifier triggered)
+
+**Rationale**: Repetitive daily task with constrained tokens. Skill approach saves ~85% tokens over MCP.
+
+#### Example 2: Live Chat Integration
+
+**Task**: Integrate with Slack for real-time notifications
+
+**Disqualifier Check:**
+- [x] Real-time streaming: Yes (live messages)
+
+**Result**: MCP (disqualifier triggered)
+
+**Rationale**: Real-time streaming requirement mandates MCP for WebSocket/event handling.
+
+#### Example 3: GitHub PR Review
+
+**Task**: Review PRs and provide feedback
+
+**Total Score**: -4
+
+**Result**: HYBRID
+
+**Recommendation**: Use Skill for standard review workflow (repeatable), MCP for PR discovery and live status.
+
+### Acceptance Criteria
+
+- [ ] Decision framework covers all dimensions
+- [ ] Examples show diverse outcomes
+- [ ] Rationale is clear and educational
+- [ ] Copy-paste usable for users
+
+---
+
+## Wave 5: Validation & Testing
+
+**Est. Time:** ~1 hour
+**Linear Issue:** SMI-XXXX - Validation testing
+
+### Tasks
+
+1. End-to-end testing:
+   - Invoke skill via trigger phrase
+   - Run evaluation script
+   - Verify output format
+
+2. Documentation review:
+   - All files present
+   - Links working
+   - Examples accurate
+
+3. Integration check:
+   - Skill loads in Claude Code
+   - Templates generate correctly
+
+### Verification Checklist
+
+```bash
+# Verify directory structure
+ls -la ~/.claude/skills/mcp-decision-helper/
+# Expected: SKILL.md, scripts/, templates/, references/
+
+# Test skill invocation (in Claude Code)
+# "Should I use MCP or Skill for a daily report generator?"
+# Expected: Skill triggers and provides evaluation
+
+# Test script directly
+npx tsx ~/.claude/skills/mcp-decision-helper/scripts/evaluate.ts --help
+# Expected: Help text displayed
+
+# Validate SKILL.md syntax
+cat ~/.claude/skills/mcp-decision-helper/SKILL.md | head -20
+# Expected: Valid YAML frontmatter
+```
+
+### Acceptance Criteria
+
+- [ ] All verification commands pass
+- [ ] Skill triggers correctly in Claude Code
+- [ ] Script runs without errors
+- [ ] Templates are complete and usable
+
+---
+
+## Linear Issues Summary
+
+| Issue ID | Title | Type | Est. Hours |
+|----------|-------|------|------------|
+| SMI-XXXX | MCP Decision Engine: Create SKILL.md with 8-dimension scoring | Feature | 2 |
+| SMI-XXXX | MCP Decision Engine: Create evaluation script (evaluate.ts) | Feature | 3 |
+| SMI-XXXX | MCP Decision Engine: Create Skill/MCP/Hybrid templates | Feature | 2 |
+| SMI-XXXX | MCP Decision Engine: Create reference documentation | Docs | 1 |
+| SMI-XXXX | MCP Decision Engine: Add example evaluations | Docs | 1 |
+| SMI-XXXX | MCP Decision Engine: Validation testing | Test | 1 |
+
+**Total Estimated Hours:** 10
+
+---
+
+## Success Metrics
+
+| Metric | Target |
+|--------|--------|
+| Skill triggers correctly | 100% of trigger phrases |
+| Script execution | Zero errors |
+| Documentation completeness | All sections populated |
+| User understanding | Clear decision within 5 minutes |
+
+---
+
+## References
+
+- Architecture: /docs/architecture/mcp-decision-engine-architecture.md
+- Research: /docs/backlog/skill-optimizations/skills-vs-mcp-research.md
+- Research: /docs/backlog/skill-optimizations/mcp-builder-skill-prompt.md

--- a/docs/reviews/2026-01-11-mcp-decision-helper.md
+++ b/docs/reviews/2026-01-11-mcp-decision-helper.md
@@ -1,0 +1,114 @@
+# Code Review: MCP Decision Helper Skill
+
+**Date**: 2026-01-11
+**Reviewer**: Claude Code Review Agent (Hive Mind Execution)
+**Related Issues**: SMI-1377, SMI-1380, SMI-1381, SMI-1382, SMI-1383, SMI-1384, SMI-1385
+**Files Changed**: 7 files created
+
+## Summary
+
+Implementation of the MCP Decision Helper skill at `~/.claude/skills/mcp-decision-helper/`. This skill provides an 8-dimension scoring framework to help users decide between implementing capabilities as Claude Code Skills vs MCP servers.
+
+## Files Reviewed
+
+| File | Lines | Status |
+|------|-------|--------|
+| `SKILL.md` | 159 | PASS |
+| `scripts/evaluate.ts` | 310 | PASS |
+| `templates/skill-template.md` | 176 | PASS |
+| `templates/mcp-template.md` | 272 | PASS |
+| `templates/hybrid-template.md` | 259 | PASS |
+| `references/decision-framework.md` | 239 | PASS |
+| `references/examples.md` | 277 | PASS |
+
+## Review Categories
+
+### Security
+
+- **Status**: PASS
+- **Findings**:
+  - No hardcoded secrets or API keys
+  - Script uses only local filesystem operations
+  - No external network calls in core logic
+  - Environment variables not required for base functionality
+- **Recommendations**: None
+
+### Error Handling
+
+- **Status**: PASS
+- **Findings**:
+  - evaluate.ts has try-catch around main execution
+  - Readline interface properly closed on exit
+  - Invalid input handling for dimension scoring
+- **Recommendations**: None
+
+### Backward Compatibility
+
+- **Status**: PASS (N/A - new skill)
+- **Breaking Changes**: None - this is a new skill creation
+
+### Best Practices
+
+- **Status**: PASS
+- **Findings**:
+  - TypeScript used with proper typing
+  - Progressive disclosure pattern in SKILL.md
+  - Clear YAML frontmatter with triggers
+  - Comprehensive documentation
+  - Script follows CLI conventions (--help, --json)
+- **Recommendations**: None
+
+### Documentation
+
+- **Status**: PASS
+- **Findings**:
+  - SKILL.md provides complete usage guide
+  - All templates include actionable scaffolding
+  - Examples cover diverse scenarios (Skill, MCP, Hybrid)
+  - Decision framework explains all 8 dimensions
+- **Recommendations**: None
+
+### Code Quality
+
+- **Status**: PASS
+- **Findings**:
+  - Clean TypeScript with proper interfaces
+  - Separation of concerns (types, dimensions, disqualifiers, output)
+  - Consistent formatting
+  - No unused variables or imports
+- **Recommendations**: None
+
+## Overall Result
+
+**PASS** - All checks passed, ready for use.
+
+## Verification Checklist
+
+- [x] All 7 files created successfully
+- [x] YAML frontmatter valid in SKILL.md
+- [x] Script runs with `npx tsx evaluate.ts --help`
+- [x] Directory structure follows skill conventions
+- [x] No security vulnerabilities
+- [x] Documentation complete
+
+## Token Impact Analysis
+
+| Metric | Value |
+|--------|-------|
+| SKILL.md size | ~5.5 KB |
+| Total skill size | ~51 KB |
+| Estimated startup tokens | ~200 |
+| Estimated per-evaluation | ~500-1,000 |
+
+This skill is well-optimized for token efficiency with progressive disclosure.
+
+## Issues Found & Resolved
+
+| Issue | Severity | Status |
+|-------|----------|--------|
+| Unused `Disqualifiers` interface in evaluate.ts | Minor | ✅ Fixed |
+
+## References
+
+- [Architecture](../architecture/mcp-decision-engine-architecture.md)
+- [Implementation Plan](../execution/mcp-decision-engine-implementation.md)


### PR DESCRIPTION
## Summary

- Add architecture documentation for MCP Decision Engine skill
- Add implementation plan for Phase 8 development
- Add code review document for skill implementation

The MCP Decision Helper skill provides an 8-dimension scoring framework to help users decide between implementing capabilities as Claude Code Skills vs MCP servers.

### Skill Features

- **8-Dimension Scoring**: Task repeatability, data freshness, token sensitivity, reliability needs, maintenance capacity, integration scope, discovery needs, auth complexity
- **Automatic Disqualifiers**: Quick-path decisions for clear-cut cases
- **Interactive CLI**: `npx tsx evaluate.ts` for guided evaluation
- **Implementation Templates**: Skill, MCP, and Hybrid approaches

### Skill Location

Installed at `~/.claude/skills/mcp-decision-helper/` (user-level skill, not in repo)

### Files Added

| File | Purpose |
|------|---------|
| `docs/architecture/mcp-decision-engine-architecture.md` | System design and scoring framework |
| `docs/execution/mcp-decision-engine-implementation.md` | Wave-based implementation plan |
| `docs/reviews/2026-01-11-mcp-decision-helper.md` | Code review results |

## Test plan

- [x] SKILL.md YAML frontmatter valid
- [x] `npx tsx evaluate.ts --help` runs successfully
- [x] All templates include actionable scaffolding
- [x] Code review passed with no blocking issues

Closes SMI-1377, SMI-1380, SMI-1381, SMI-1382, SMI-1383, SMI-1384, SMI-1385

🤖 Generated with [Claude Code](https://claude.ai/code)