### PR TITLE
feat(cli): add non-interactive flags to init command (SMI-1473)

### DIFF
--- a/packages/cli/tests/e2e/author.e2e.test.ts
+++ b/packages/cli/tests/e2e/author.e2e.test.ts
@@ -171,9 +171,18 @@ describe('E2E: skillsmith init', () => {
       assertNoHardcoded(result, 'skillsmith init --help', 'init: help', __filename)
     })
 
-    // Skip: The init command uses inquirer for interactive prompts which cannot be automated in E2E tests
-    it.skip('should create skill scaffold with name', async () => {
-      const result = await runCommand(['init', 'my-new-skill'])
+    // SMI-1473: Using non-interactive flags for E2E testing
+    it('should create skill scaffold with name', async () => {
+      const result = await runCommand([
+        'init',
+        'my-new-skill',
+        '-d',
+        'Test skill description',
+        '-a',
+        'test-author',
+        '-c',
+        'development',
+      ])
 
       recordTiming('init:named', 'skillsmith init name', result.durationMs)
 
@@ -188,12 +197,23 @@ describe('E2E: skillsmith init', () => {
       assertNoHardcoded(result, 'skillsmith init name', 'init: create skill', __filename)
     })
 
-    // Skip: The init command uses inquirer for interactive prompts which cannot be automated in E2E tests
-    it.skip('should create skill scaffold with custom path', async () => {
+    // SMI-1473: Using non-interactive flags for E2E testing
+    it('should create skill scaffold with custom path', async () => {
       const customPath = join(TEST_DIR, 'custom-skills')
       mkdirSync(customPath, { recursive: true })
 
-      const result = await runCommand(['init', 'path-skill', '-p', customPath])
+      const result = await runCommand([
+        'init',
+        'path-skill',
+        '-p',
+        customPath,
+        '-d',
+        'Test skill',
+        '-a',
+        'test',
+        '-c',
+        'development',
+      ])
 
       expect(result.exitCode).toBe(0)
 
@@ -203,9 +223,18 @@ describe('E2E: skillsmith init', () => {
       assertNoHardcoded(result, 'skillsmith init -p custom', 'init: custom path', __filename)
     })
 
-    // Skip: The init command uses inquirer for interactive prompts which cannot be automated in E2E tests
-    it.skip('should create resources directory', async () => {
-      const result = await runCommand(['init', 'resource-skill'])
+    // SMI-1473: Using non-interactive flags for E2E testing
+    it('should create resources directory', async () => {
+      const result = await runCommand([
+        'init',
+        'resource-skill',
+        '-d',
+        'Test skill',
+        '-a',
+        'test',
+        '-c',
+        'development',
+      ])
 
       expect(result.exitCode).toBe(0)
 
@@ -215,9 +244,18 @@ describe('E2E: skillsmith init', () => {
       assertNoHardcoded(result, 'skillsmith init resources', 'init: resources dir', __filename)
     })
 
-    // Skip: The init command uses inquirer for interactive prompts which cannot be automated in E2E tests
-    it.skip('should create scripts directory with example', async () => {
-      const result = await runCommand(['init', 'script-skill'])
+    // SMI-1473: Using non-interactive flags for E2E testing
+    it('should create scripts directory with example', async () => {
+      const result = await runCommand([
+        'init',
+        'script-skill',
+        '-d',
+        'Test skill',
+        '-a',
+        'test',
+        '-c',
+        'development',
+      ])
 
       expect(result.exitCode).toBe(0)
 
@@ -228,21 +266,50 @@ describe('E2E: skillsmith init', () => {
       assertNoHardcoded(result, 'skillsmith init scripts', 'init: scripts dir', __filename)
     })
 
-    // Skip: The init command uses inquirer for interactive prompts which cannot be automated in E2E tests
-    it.skip('should handle existing directory gracefully', async () => {
+    // SMI-1473: Using non-interactive flags for E2E testing
+    it('should handle existing directory gracefully', async () => {
       // Create skill first
-      await runCommand(['init', 'existing-skill'])
+      await runCommand([
+        'init',
+        'existing-skill',
+        '-d',
+        'Test skill',
+        '-a',
+        'test',
+        '-c',
+        'development',
+      ])
 
-      // Try to create again
-      const result = await runCommand(['init', 'existing-skill'])
+      // Try to create again with --yes to auto-confirm overwrite
+      const result = await runCommand([
+        'init',
+        'existing-skill',
+        '-d',
+        'Test skill updated',
+        '-a',
+        'test',
+        '-c',
+        'development',
+        '-y',
+      ])
 
-      // Should fail or warn
+      // Should succeed with --yes flag
+      expect(result.exitCode).toBe(0)
       assertNoHardcoded(result, 'skillsmith init existing', 'init: existing dir', __filename)
     })
 
-    // Skip: The init command uses inquirer for interactive prompts which cannot be automated in E2E tests
-    it.skip('should not contain hardcoded paths in generated files', async () => {
-      const result = await runCommand(['init', 'path-check-skill'])
+    // SMI-1473: Using non-interactive flags for E2E testing
+    it('should not contain hardcoded paths in generated files', async () => {
+      const result = await runCommand([
+        'init',
+        'path-check-skill',
+        '-d',
+        'Test skill',
+        '-a',
+        'test',
+        '-c',
+        'development',
+      ])
 
       expect(result.exitCode).toBe(0)
 


### PR DESCRIPTION
## Summary

Adds non-interactive CLI flags to the `skillsmith init` command, enabling E2E tests to run without interactive prompts.

### New CLI Flags

| Flag | Description |
|------|-------------|
| `-d, --description <text>` | Skill description (skip prompt) |
| `-a, --author <name>` | Skill author (skip prompt) |
| `-c, --category <cat>` | Category: development\|productivity\|communication\|data\|security\|other |
| `-y, --yes` | Auto-confirm directory overwrite |

### Usage Example

```bash
# Fully non-interactive skill initialization
skillsmith init my-skill -d "My skill description" -a "author-name" -c development

# With auto-confirm for existing directory
skillsmith init my-skill -d "desc" -a "me" -c development -y
```

### Changes

- **packages/cli/src/commands/author.ts**
  - Add `InitOptions` interface with optional `description`, `author`, `category`, `yes` fields
  - Add `VALID_CATEGORIES` constant for category validation
  - Update `initSkill()` to accept options and skip prompts when provided
  - Update `createInitCommand()` with new CLI options

- **packages/cli/tests/e2e/author.e2e.test.ts**
  - Unskip 6 init tests that were blocked by interactive prompts
  - Update tests to use new non-interactive flags

### Test Results

All 7 init E2E tests now pass:
- ✅ should display help without errors
- ✅ should create skill scaffold with name
- ✅ should create skill scaffold with custom path
- ✅ should create resources directory
- ✅ should create scripts directory with example
- ✅ should handle existing directory gracefully
- ✅ should not contain hardcoded paths in generated files

## Test plan

- [x] Build passes (`npm run build`)
- [x] TypeScript checks pass (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [x] Init E2E tests pass with new flags
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)