### PR TITLE
docs: GitHub App auth and versioning policy (SMI-1451, SMI-1585)

### DIFF
--- a/docs/architecture/github-app-auth.md
+++ b/docs/architecture/github-app-auth.md
@@ -1,0 +1,147 @@
+# GitHub App Authentication Flow
+
+**Issue**: SMI-1451
+**Status**: Documented
+**Last Updated**: January 2026
+
+## Overview
+
+Skillsmith uses a GitHub App for authenticated access to GitHub's API, enabling:
+- Higher rate limits (5,000 requests/hour vs 60 for unauthenticated)
+- Access to private repositories (when authorized)
+- Repository indexing and skill discovery
+- Installation-based access control
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        GitHub App Flow                          │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────┐     ┌──────────────┐     ┌─────────────────────┐  │
+│  │  User    │────▶│  Install App │────▶│  Installation Token │  │
+│  │  (Org)   │     │  on Repo/Org │     │  (JWT → Token)      │  │
+│  └──────────┘     └──────────────┘     └──────────────────────┘  │
+│                                                 │                │
+│                                                 ▼                │
+│                        ┌────────────────────────────────────┐   │
+│                        │      Skillsmith Indexer            │   │
+│                        │  - Fetch repositories              │   │
+│                        │  - Read SKILL.md files            │   │
+│                        │  - Index to database              │   │
+│                        └────────────────────────────────────┘   │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Authentication Steps
+
+### 1. App Registration
+
+The GitHub App is registered with these permissions:
+- **Contents**: Read (to access SKILL.md files)
+- **Metadata**: Read (required for all apps)
+
+No webhooks are currently configured.
+
+### 2. JWT Generation
+
+```typescript
+import * as jwt from 'jsonwebtoken'
+
+function generateJWT(appId: string, privateKey: string): string {
+  const now = Math.floor(Date.now() / 1000)
+
+  return jwt.sign(
+    {
+      iat: now - 60,           // Issued 60 seconds ago (clock skew)
+      exp: now + (10 * 60),    // Expires in 10 minutes
+      iss: appId,              // GitHub App ID
+    },
+    privateKey,
+    { algorithm: 'RS256' }
+  )
+}
+```
+
+### 3. Installation Token Exchange
+
+```typescript
+async function getInstallationToken(
+  jwt: string,
+  installationId: string
+): Promise<string> {
+  const response = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: 'application/vnd.github+json',
+      },
+    }
+  )
+
+  const data = await response.json()
+  return data.token
+}
+```
+
+### 4. API Requests
+
+```typescript
+async function fetchWithAuth(url: string, token: string): Promise<Response> {
+  return fetch(url, {
+    headers: {
+      Authorization: `token ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+}
+```
+
+## Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `GITHUB_APP_ID` | GitHub App ID | Yes |
+| `GITHUB_APP_PRIVATE_KEY` | RSA private key (PEM format) | Yes |
+| `GITHUB_INSTALLATION_ID` | Installation ID for indexing | Yes |
+
+## Rate Limits
+
+| Endpoint Type | Limit | Reset |
+|---------------|-------|-------|
+| Core API | 5,000/hour | Per installation |
+| Search API | 30/minute | Per installation |
+| GraphQL | 5,000 points/hour | Per installation |
+
+## Security Considerations
+
+1. **Private Key Storage**: The private key should be stored securely:
+   - Use environment variables or secrets management
+   - Never commit to version control
+   - Rotate periodically
+
+2. **Token Expiration**: Installation tokens expire after 1 hour:
+   - Cache tokens with TTL
+   - Refresh before expiration
+   - Handle 401 errors gracefully
+
+3. **Minimal Permissions**: Only request necessary permissions:
+   - Contents:read for SKILL.md access
+   - Metadata:read is always required
+
+## Implementation Files
+
+- `packages/core/src/sources/GitHubSourceAdapter.ts` - Main adapter
+- `packages/core/src/indexer/GitHubIndexer.ts` - Indexing logic
+- `supabase/functions/indexer/index.ts` - Edge function indexer
+
+## See Also
+
+- [GitHub Apps Documentation](https://docs.github.com/en/apps)
+- [Indexer Infrastructure](./indexer-infrastructure.md)
+- [ADR-014: GitHub App Authentication](../adr/014-github-app-authentication.md)

--- a/docs/architecture/versioning-policy.md
+++ b/docs/architecture/versioning-policy.md
@@ -1,0 +1,172 @@
+# Version Governance Policy
+
+**Issue**: SMI-1585
+**Status**: Documented
+**Last Updated**: January 2026
+
+## Overview
+
+This document defines the versioning policy for Skillsmith packages, APIs, and database schemas. Following these guidelines ensures backward compatibility and smooth upgrades for users.
+
+## Semantic Versioning
+
+All Skillsmith packages follow [Semantic Versioning 2.0.0](https://semver.org/):
+
+```
+MAJOR.MINOR.PATCH
+│     │     │
+│     │     └── Bug fixes (backward compatible)
+│     └──────── New features (backward compatible)
+└────────────── Breaking changes
+```
+
+### Version Meanings
+
+| Change Type | Version Bump | Examples |
+|------------|--------------|----------|
+| Breaking change | MAJOR | Removing API endpoints, changing database schema incompatibly |
+| New feature | MINOR | New CLI commands, new API endpoints, new tool options |
+| Bug fix | PATCH | Fixing errors, performance improvements, documentation |
+
+## Package Versioning
+
+### Monorepo Packages
+
+| Package | Version | Sync Policy |
+|---------|---------|-------------|
+| `@skillsmith/core` | Independent | Core functionality, versioned independently |
+| `@skillsmith/mcp-server` | Linked | Matches core for major/minor |
+| `@skillsmith/cli` | Linked | Matches core for major/minor |
+
+### Version Synchronization
+
+Major and minor versions are synchronized across linked packages:
+- When `@skillsmith/core` bumps to `0.4.0`, linked packages also bump to `0.4.x`
+- Patch versions may differ between packages
+
+## API Versioning
+
+### REST API
+
+The Skillsmith API uses URL path versioning:
+
+```
+/api/v1/skills/search
+/api/v2/skills/search  (future)
+```
+
+**Version Lifecycle**:
+1. **Current**: Active development, full support
+2. **Deprecated**: 6-month sunset notice, maintenance only
+3. **Sunset**: Read-only for 3 months, then removed
+
+### Breaking Changes
+
+Changes that require a new API version:
+- Removing or renaming fields in responses
+- Changing field types
+- Removing endpoints
+- Changing authentication requirements
+
+Non-breaking changes (no version bump):
+- Adding new fields to responses
+- Adding new endpoints
+- Adding optional parameters
+- Performance improvements
+
+## Database Schema Versioning
+
+### Schema Version Table
+
+```sql
+CREATE TABLE schema_version (
+  version INTEGER PRIMARY KEY,
+  applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+### Migration Policy
+
+1. **Forward-only**: Migrations only move forward
+2. **Additive**: Prefer adding columns/tables over modifying
+3. **Safe rollback**: Document rollback procedures for each migration
+
+### Version Mapping
+
+| Schema Version | Skillsmith Version | Notes |
+|----------------|-------------------|-------|
+| 1 | 0.1.x | Initial schema |
+| 2 | 0.2.x | Added sync tables |
+| 3 | 0.3.x | Added audit logging |
+
+## Pre-release Versions
+
+### Alpha/Beta Tags
+
+```
+0.4.0-alpha.1  # Early testing, unstable
+0.4.0-beta.1   # Feature complete, may have bugs
+0.4.0-rc.1     # Release candidate, final testing
+```
+
+### Prerelease Policy
+
+- Alpha: Internal testing only
+- Beta: Community testing, breaking changes possible
+- RC: No new features, bug fixes only
+
+## Changelog Requirements
+
+Every version must have a CHANGELOG.md entry:
+
+```markdown
+## [0.4.0] - 2026-01-24
+
+### Added
+- New merge CLI command (SMI-1455)
+
+### Changed
+- Updated security scanner output format (SMI-1454)
+
+### Fixed
+- Schema version mismatch during imports (SMI-1446)
+```
+
+## Release Checklist
+
+Before releasing a new version:
+
+1. [ ] All tests pass
+2. [ ] CHANGELOG.md updated
+3. [ ] Version bumped in package.json files
+4. [ ] API documentation updated (if applicable)
+5. [ ] Migration scripts tested
+6. [ ] Breaking changes documented
+
+## Deprecation Policy
+
+### Deprecation Timeline
+
+1. **Announcement**: Document deprecation with sunset date
+2. **Warning Period**: 3 months minimum
+3. **Sunset**: 3 more months for migration
+4. **Removal**: Feature/API removed
+
+### Deprecation Notice Format
+
+```typescript
+/**
+ * @deprecated Since 0.4.0. Use `newFunction()` instead.
+ * Will be removed in 0.6.0.
+ */
+function oldFunction(): void {
+  console.warn('oldFunction is deprecated. Use newFunction instead.')
+  // ... implementation
+}
+```
+
+## See Also
+
+- [Engineering Standards](./standards.md)
+- [ADR-001: Versioning Strategy](../adr/001-versioning-strategy.md)
+- [CHANGELOG.md](../../CHANGELOG.md)


### PR DESCRIPTION
## Summary
- Add GitHub App authentication flow documentation (SMI-1451)
- Add version governance policy documentation (SMI-1585)

## Changes
- `docs/architecture/github-app-auth.md` - JWT generation, installation token exchange, rate limits
- `docs/architecture/versioning-policy.md` - Semantic versioning, API versioning, deprecation policy

## Test plan
- [x] Documentation renders correctly in markdown preview
- [x] Links to related ADRs are valid
- [x] Code examples are syntactically correct

## Merge Order
This is PR **1 of 6** in the Live Services initiative. Merge first (no code changes).

🤖 Generated with [Claude Code](https://claude.ai/code)