### PR TITLE
fix(website): skills page quality score and API endpoint bugs (SMI-1606, SMI-1607)

### DIFF
--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -232,7 +232,7 @@ const { id } = Astro.params;
       trustBadge.className = `px-3 py-1 text-sm font-medium rounded-full border ${trustBadgeClasses[trustTier] || trustBadgeClasses.unknown}`;
 
       // Quality score
-      const score = skill.quality_score ?? skill.score ?? 0;
+      const score = (skill.quality_score ?? skill.score ?? 0) * 100;
       const scoreColor = score >= 80 ? 'text-green-400' : score >= 60 ? 'text-yellow-400' : 'text-red-400';
       const scoreEl = document.getElementById('skill-score');
       scoreEl.textContent = `${Math.round(score)}%`;
@@ -311,7 +311,7 @@ const { id } = Astro.params;
     // Fetch skill details
     async function fetchSkill() {
       try {
-        const response = await fetch(`${API_BASE}/skill/${encodeURIComponent(skillId)}`);
+        const response = await fetch(`${API_BASE}/skills-get/${encodeURIComponent(skillId)}`);
 
         if (!response.ok) {
           if (response.status === 404) {
@@ -320,8 +320,11 @@ const { id } = Astro.params;
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
 
-        const skill = await response.json();
-        renderSkill(skill);
+        const result = await response.json();
+        if (!result.data) {
+          throw new Error(result.error || 'Invalid response from server');
+        }
+        renderSkill(result.data);
       } catch (error) {
         // Log in dev only, user sees error via showError()
         if (import.meta.env?.DEV) console.error('Fetch error:', error);

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -233,7 +233,7 @@ const trustTiers = [
     // Create skill card HTML
     function createSkillCard(skill) {
       const trustClass = trustBadgeClasses[skill.trust_tier] || trustBadgeClasses.unknown;
-      const score = skill.quality_score ?? skill.score ?? 0;
+      const score = (skill.quality_score ?? skill.score ?? 0) * 100;
       const scoreColor = score >= 80 ? 'text-green-400' : score >= 60 ? 'text-yellow-400' : 'text-red-400';
 
       return `


### PR DESCRIPTION
## Summary
- Fix quality score displaying "1%" instead of proper percentages (e.g., 95%)
- Fix skill detail page infinite loading spinner

## Related Issues
- SMI-1606: Quality score scale conversion bug
- SMI-1607: Skill detail page API endpoint mismatch

## Changes

### Quality Score Scale Conversion
- Database stores `quality_score` as 0-1 decimal (e.g., 0.95)
- Frontend was comparing raw value against 80/60 thresholds
- `Math.round(0.95)` = 1, displayed as "1%"
- **Fix**: Multiply by 100 before display and comparison

### Skill Detail Page Loading
- Changed API endpoint from `/skill/` to `/skills-get/`
- Fixed response parsing to extract `result.data` from wrapper object
- Added null check for defensive error handling

## Files Changed
- `packages/website/src/pages/skills/index.astro`
- `packages/website/src/pages/skills/[id].astro`

## Test plan
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Security tests pass
- [ ] Navigate to `/skills` page - verify quality scores show proper percentages
- [ ] Click on a skill card - verify detail page loads without infinite spinner
- [ ] Verify skill data (name, author, description, quality score) renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)