### PR TITLE
feat(security): Surface security scan results to users (SMI-825, SMI-1632)

### DIFF
--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -554,6 +554,7 @@ export class SkillsmithApiClient {
    * Convert API result to Skill type
    * SMI-1577: Handle optional fields with sensible defaults
    * Uses epoch timestamp as sentinel for missing dates to avoid data integrity issues
+   * SMI-825: Added security scan fields
    */
   static toSkill(result: ApiSearchResult): Skill {
     // Sentinel value for missing timestamps - clearly indicates unknown date
@@ -568,6 +569,11 @@ export class SkillsmithApiClient {
       trustTier: result.trust_tier,
       tags: result.tags || [],
       installable: result.installable ?? false,
+      // SMI-825: Security scan fields (default to not scanned for API results)
+      riskScore: null,
+      securityFindingsCount: 0,
+      securityScannedAt: null,
+      securityPassed: null,
       createdAt: result.created_at ?? UNKNOWN_DATE,
       updatedAt: result.updated_at ?? UNKNOWN_DATE,
     }

--- a/packages/core/src/repositories/IndexerRepository.ts
+++ b/packages/core/src/repositories/IndexerRepository.ts
@@ -98,6 +98,11 @@ interface IndexedSkillRow {
   trust_tier: string
   tags: string
   installable: boolean | null
+  // SMI-825: Security scan columns
+  risk_score: number | null
+  security_findings_count: number | null
+  security_scanned_at: string | null
+  security_passed: number | null // SQLite uses 0/1 for boolean
   created_at: string
   updated_at: string
   last_indexed_at: string | null
@@ -226,6 +231,7 @@ export class IndexerRepository {
 
   /**
    * Convert a database row to an IndexedSkill object
+   * SMI-825: Added security scan fields
    */
   private rowToSkill(row: IndexedSkillRow): IndexedSkill {
     return {
@@ -238,6 +244,11 @@ export class IndexerRepository {
       trustTier: row.trust_tier as TrustTier,
       tags: JSON.parse(row.tags || '[]'),
       installable: row.installable ?? false,
+      // SMI-825: Security scan fields
+      riskScore: row.risk_score,
+      securityFindingsCount: row.security_findings_count ?? 0,
+      securityScannedAt: row.security_scanned_at,
+      securityPassed: row.security_passed === null ? null : row.security_passed === 1,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
       lastIndexedAt: row.last_indexed_at ?? row.updated_at,

--- a/packages/core/src/repositories/SkillRepository.ts
+++ b/packages/core/src/repositories/SkillRepository.ts
@@ -22,6 +22,11 @@ interface SkillRow {
   trust_tier: string
   tags: string
   installable: boolean | null
+  // SMI-825: Security scan columns
+  risk_score: number | null
+  security_findings_count: number | null
+  security_scanned_at: string | null
+  security_passed: number | null // SQLite uses 0/1 for boolean
   created_at: string
   updated_at: string
 }
@@ -55,8 +60,8 @@ export class SkillRepository {
     // Cast to our custom types for better-sqlite3 compatibility
     this.stmts = {
       insert: this.db.prepare(`
-        INSERT INTO skills (id, name, description, author, repo_url, quality_score, trust_tier, tags, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+        INSERT INTO skills (id, name, description, author, repo_url, quality_score, trust_tier, tags, risk_score, security_findings_count, security_scanned_at, security_passed, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
       `) as unknown as typeof this.stmts.insert,
 
       selectById: this.db.prepare(`
@@ -84,6 +89,10 @@ export class SkillRepository {
           quality_score = COALESCE(?, quality_score),
           trust_tier = COALESCE(?, trust_tier),
           tags = COALESCE(?, tags),
+          risk_score = COALESCE(?, risk_score),
+          security_findings_count = COALESCE(?, security_findings_count),
+          security_scanned_at = COALESCE(?, security_scanned_at),
+          security_passed = COALESCE(?, security_passed),
           updated_at = datetime('now')
         WHERE id = ?
       `) as unknown as typeof this.stmts.update,
@@ -112,6 +121,11 @@ export class SkillRepository {
       trustTier: row.trust_tier as Skill['trustTier'],
       tags: JSON.parse(row.tags || '[]'),
       installable: row.installable ?? false,
+      // SMI-825: Security scan fields
+      riskScore: row.risk_score,
+      securityFindingsCount: row.security_findings_count ?? 0,
+      securityScannedAt: row.security_scanned_at,
+      securityPassed: row.security_passed === null ? null : row.security_passed === 1,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     }
@@ -132,7 +146,12 @@ export class SkillRepository {
       input.repoUrl ?? null,
       input.qualityScore ?? null,
       input.trustTier ?? 'unknown',
-      tags
+      tags,
+      // SMI-825: Security scan fields
+      input.riskScore ?? null,
+      input.securityFindingsCount ?? 0,
+      input.securityScannedAt ?? null,
+      input.securityPassed === undefined ? null : input.securityPassed ? 1 : 0
     )
 
     const row = this.stmts.selectById.get(id) as SkillRow
@@ -159,7 +178,12 @@ export class SkillRepository {
             input.repoUrl ?? null,
             input.qualityScore ?? null,
             input.trustTier ?? 'unknown',
-            tags
+            tags,
+            // SMI-825: Security scan fields
+            input.riskScore ?? null,
+            input.securityFindingsCount ?? 0,
+            input.securityScannedAt ?? null,
+            input.securityPassed === undefined ? null : input.securityPassed ? 1 : 0
           )
 
           const row = this.stmts.selectById.get(id) as SkillRow
@@ -244,6 +268,11 @@ export class SkillRepository {
       input.qualityScore ?? null,
       input.trustTier ?? null,
       tags,
+      // SMI-825: Security scan fields
+      input.riskScore ?? null,
+      input.securityFindingsCount ?? null,
+      input.securityScannedAt ?? null,
+      input.securityPassed === undefined ? null : input.securityPassed ? 1 : 0,
       id
     )
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -49,6 +49,20 @@ export interface ScoreBreakdown {
 }
 
 /**
+ * SMI-825: Security scan summary for display
+ */
+export interface SecuritySummary {
+  /** Whether the skill passed security scan (null = not scanned) */
+  passed: boolean | null
+  /** Risk score from 0-100 (lower is safer) */
+  riskScore: number | null
+  /** Number of security findings */
+  findingsCount: number
+  /** When the skill was last scanned */
+  scannedAt: string | null
+}
+
+/**
  * Full skill definition
  */
 export interface Skill {
@@ -64,6 +78,8 @@ export interface Skill {
   scoreBreakdown?: ScoreBreakdown
   tags: string[]
   installCommand?: string
+  /** SMI-825: Security scan summary */
+  security?: SecuritySummary
   createdAt: string
   updatedAt: string
 }
@@ -71,6 +87,7 @@ export interface Skill {
 /**
  * Skill search result (subset of full skill)
  * SMI-1491: Added repository field for transparency about installation source
+ * SMI-825: Added security summary
  */
 export interface SkillSearchResult {
   id: string
@@ -82,6 +99,8 @@ export interface SkillSearchResult {
   score: number
   /** GitHub repository URL (may be undefined for seed data/metadata-only skills) */
   repository?: string
+  /** SMI-825: Security scan summary */
+  security?: SecuritySummary
 }
 
 /**
@@ -91,6 +110,10 @@ export interface SearchFilters {
   category?: SkillCategory
   trustTier?: TrustTier
   minScore?: number
+  /** SMI-825: Only show skills that passed security scan */
+  safeOnly?: boolean
+  /** SMI-825: Maximum risk score (0-100, lower is safer) */
+  maxRiskScore?: number
 }
 
 /**

--- a/packages/core/src/types/skill.ts
+++ b/packages/core/src/types/skill.ts
@@ -40,6 +40,11 @@ export interface Skill {
   /** SMI-1631: Skill roles for role-based filtering */
   roles?: SkillRole[]
   installable: boolean
+  // SMI-825: Security scan fields
+  riskScore: number | null
+  securityFindingsCount: number
+  securityScannedAt: string | null
+  securityPassed: boolean | null
   createdAt: string
   updatedAt: string
 }
@@ -56,6 +61,11 @@ export interface SkillCreateInput {
   /** SMI-1631: Skill roles for role-based filtering */
   roles?: SkillRole[]
   installable?: boolean
+  // SMI-825: Security scan fields
+  riskScore?: number | null
+  securityFindingsCount?: number
+  securityScannedAt?: string | null
+  securityPassed?: boolean | null
 }
 
 export interface SkillUpdateInput {
@@ -69,6 +79,11 @@ export interface SkillUpdateInput {
   /** SMI-1631: Skill roles for role-based filtering */
   roles?: SkillRole[]
   installable?: boolean
+  // SMI-825: Security scan fields
+  riskScore?: number | null
+  securityFindingsCount?: number
+  securityScannedAt?: string | null
+  securityPassed?: boolean | null
 }
 
 export interface SearchOptions {
@@ -78,6 +93,9 @@ export interface SearchOptions {
   trustTier?: TrustTier
   minQualityScore?: number
   category?: string
+  // SMI-825: Security filters
+  safeOnly?: boolean // Only show skills that passed security scan
+  maxRiskScore?: number // Maximum risk score (0-100)
 }
 
 export interface SearchResult {

--- a/packages/mcp-server/src/tools/get-skill.ts
+++ b/packages/mcp-server/src/tools/get-skill.ts
@@ -191,6 +191,13 @@ export async function executeGetSkill(
     scoreBreakdown: undefined, // Breakdown not stored in current schema
     tags: dbSkill.tags || [],
     installCommand: 'claude skill add ' + dbSkill.id,
+    // SMI-825: Security summary
+    security: {
+      passed: dbSkill.securityPassed,
+      riskScore: dbSkill.riskScore,
+      findingsCount: dbSkill.securityFindingsCount,
+      scannedAt: dbSkill.securityScannedAt,
+    },
     createdAt: dbSkill.createdAt,
     updatedAt: dbSkill.updatedAt,
   }
@@ -278,6 +285,29 @@ export function formatSkillDetails(response: GetSkillResponse): string {
   // Tags
   if (skill.tags && skill.tags.length > 0) {
     lines.push('Tags: ' + skill.tags.join(', '))
+  }
+  lines.push('')
+
+  // SMI-825: Security information
+  lines.push('--- Security ---')
+  if (skill.security) {
+    if (skill.security.passed === null) {
+      lines.push('  Status: Not scanned')
+    } else if (skill.security.passed) {
+      lines.push('  Status: PASSED')
+      lines.push('  Risk Score: ' + (skill.security.riskScore ?? 0) + '/100')
+      lines.push('  Findings: ' + (skill.security.findingsCount ?? 0))
+    } else {
+      lines.push('  Status: FAILED')
+      lines.push('  Risk Score: ' + (skill.security.riskScore ?? 0) + '/100 (HIGH)')
+      lines.push('  Findings: ' + (skill.security.findingsCount ?? 0))
+      lines.push('  WARNING: This skill has security issues. Review carefully before use.')
+    }
+    if (skill.security.scannedAt) {
+      lines.push('  Scanned: ' + skill.security.scannedAt)
+    }
+  } else {
+    lines.push('  Status: Not scanned')
   }
   lines.push('')
 


### PR DESCRIPTION
## Summary

Phase 3 Wave 2 implementation for security scan surfacing and recommendation filtering.

### SMI-825: Surface security scan results to users before install (P1 High)
- Added security columns to database: `risk_score`, `security_findings_count`, `security_scanned_at`, `security_passed`
- CLI search shows Security column with pass/risk status
- Added `--safe-only` and `--max-risk` filter options to CLI
- MCP search tool includes security summary in results
- MCP get_skill tool includes full security details

### SMI-1632: Fix recommendations returning collections instead of individual skills (P2 Medium)
- Filter out skill collections from recommendation results (repos ending in `-skills`, `-collection`, etc.)
- Ensures users receive individual installable skills, not entire repositories

## Test plan
- [x] TypeScript typecheck passing
- [x] Security tests passing
- [ ] Manual testing of security column display
- [ ] Manual testing of --safe-only filter

## Linear Issues
- Closes SMI-825
- Closes SMI-1632

🤖 Generated with [Claude Code](https://claude.ai/code) via Phase 3 Wave 2 execution