### PR TITLE
feat(recommend): add role-based skill recommendations (SMI-1631)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,7 +77,10 @@ export type {
   SearchResult,
   TrustTier,
   CacheEntry,
+  // SMI-1631: Skill roles for role-based recommendations
+  SkillRole,
 } from './types/skill.js'
+export { SKILL_ROLES } from './types/skill.js'
 
 // Search
 export { HybridSearch } from './search/index.js'

--- a/packages/core/src/types/skill.ts
+++ b/packages/core/src/types/skill.ts
@@ -4,6 +4,30 @@
 
 export type TrustTier = 'verified' | 'community' | 'experimental' | 'unknown'
 
+/**
+ * SMI-1631: Skill roles for role-based recommendations
+ * Used to filter and prioritize skills based on their primary purpose
+ */
+export type SkillRole =
+  | 'code-quality'
+  | 'testing'
+  | 'documentation'
+  | 'workflow'
+  | 'security'
+  | 'development-partner'
+
+/**
+ * Valid skill roles array for validation
+ */
+export const SKILL_ROLES: readonly SkillRole[] = [
+  'code-quality',
+  'testing',
+  'documentation',
+  'workflow',
+  'security',
+  'development-partner',
+] as const
+
 export interface Skill {
   id: string
   name: string
@@ -13,6 +37,8 @@ export interface Skill {
   qualityScore: number | null
   trustTier: TrustTier
   tags: string[]
+  /** SMI-1631: Skill roles for role-based filtering */
+  roles?: SkillRole[]
   installable: boolean
   createdAt: string
   updatedAt: string
@@ -27,6 +53,8 @@ export interface SkillCreateInput {
   qualityScore?: number | null
   trustTier?: TrustTier
   tags?: string[]
+  /** SMI-1631: Skill roles for role-based filtering */
+  roles?: SkillRole[]
   installable?: boolean
 }
 
@@ -38,6 +66,8 @@ export interface SkillUpdateInput {
   qualityScore?: number | null
   trustTier?: TrustTier
   tags?: string[]
+  /** SMI-1631: Skill roles for role-based filtering */
+  roles?: SkillRole[]
   installable?: boolean
 }
 

--- a/packages/mcp-server/tests/integration/recommend.integration.test.ts
+++ b/packages/mcp-server/tests/integration/recommend.integration.test.ts
@@ -144,7 +144,7 @@ describe('Recommend Tool Integration', () => {
       for (const rec of result.recommendations) {
         expect(rec.quality_score).toBeGreaterThanOrEqual(0)
         expect(rec.quality_score).toBeLessThanOrEqual(100)
-        expect(['verified', 'community', 'standard', 'unverified']).toContain(rec.trust_tier)
+        expect(['verified', 'community', 'experimental', 'unknown']).toContain(rec.trust_tier)
         expect(rec.reason).toBeDefined()
         expect(rec.similarity_score).toBeGreaterThanOrEqual(0)
         expect(rec.similarity_score).toBeLessThanOrEqual(1)
@@ -295,6 +295,7 @@ describe('Recommend Tool Integration', () => {
         recommendations: [],
         candidates_considered: 0,
         overlap_filtered: 0,
+        role_filtered: 0, // SMI-1631: Added for role-based filtering
         context: {
           installed_count: 0,
           has_project_context: false,


### PR DESCRIPTION
## Summary
- Add `--role` flag to filter and prioritize skills by purpose
- Implement automatic role detection from skill tags via `inferRolesFromTags()`
- Apply +30 quality score boost for role-matched recommendations
- Add comprehensive validation and warning for invalid role input

## Changes
- **packages/core**: Add `SkillRole` type and `SKILL_ROLES` constant
- **packages/cli**: Add `-r/--role` option with validation warning for invalid roles
- **packages/mcp-server**: Add `role` parameter with Zod schema validation
- **tests**: Fix trust tier type mismatch, add CLI role tests

## Valid Roles
- `code-quality` - Code review, linting, best practices
- `testing` - Unit tests, integration tests, coverage
- `documentation` - README, API docs, comments
- `workflow` - Git, CI/CD, deployment
- `security` - Vulnerability scanning, auth
- `development-partner` - AI assistance, pair programming

## Test plan
- [x] 4792 tests passing
- [x] TypeScript typecheck passing
- [x] Pre-commit hooks passing
- [x] Security tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)