### PR TITLE
fix(website): restore missing docs pages from lost commits

### DIFF
--- a/packages/website/src/pages/docs/api.astro
+++ b/packages/website/src/pages/docs/api.astro
@@ -1,0 +1,394 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="API Reference" description="Skillsmith API documentation for developers and integrators">
+  <h1>API Reference</h1>
+
+  <p class="lead">
+    Build integrations with Skillsmith using our TypeScript API. Access skill search,
+    installation, and management programmatically.
+  </p>
+
+  <h2>Installation</h2>
+
+  <pre><code>{`npm install @skillsmith/core`}</code></pre>
+
+  <h2>Quick Start</h2>
+
+  <pre><code>{`import { SkillRegistry, SkillInstaller } from '@skillsmith/core';
+
+// Initialize the registry
+const registry = new SkillRegistry();
+
+// Search for skills
+const results = await registry.search({
+  query: 'testing',
+  trustTier: 'verified',
+  limit: 10
+});
+
+// Install a skill
+const installer = new SkillInstaller();
+await installer.install('community/jest-helper');`}</code></pre>
+
+  <h2>SkillRegistry</h2>
+
+  <p>The main interface for discovering and querying skills.</p>
+
+  <h3>Constructor</h3>
+
+  <pre><code>{`const registry = new SkillRegistry(options?: RegistryOptions);`}</code></pre>
+
+  <h4>RegistryOptions</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>registryUrl</code></td>
+        <td><code>string</code></td>
+        <td>Custom registry URL</td>
+      </tr>
+      <tr>
+        <td><code>cacheEnabled</code></td>
+        <td><code>boolean</code></td>
+        <td>Enable response caching</td>
+      </tr>
+      <tr>
+        <td><code>cacheTtl</code></td>
+        <td><code>number</code></td>
+        <td>Cache TTL in seconds</td>
+      </tr>
+      <tr>
+        <td><code>apiKey</code></td>
+        <td><code>string</code></td>
+        <td>API key for authenticated requests</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>search()</h3>
+
+  <p>Search for skills matching the given criteria.</p>
+
+  <pre><code>{`async search(options: SearchOptions): Promise<SearchResult[]>`}</code></pre>
+
+  <h4>SearchOptions</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Required</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>query</code></td>
+        <td><code>string</code></td>
+        <td>Yes</td>
+        <td>Search query (min 2 characters)</td>
+      </tr>
+      <tr>
+        <td><code>category</code></td>
+        <td><code>Category</code></td>
+        <td>No</td>
+        <td>Filter by category</td>
+      </tr>
+      <tr>
+        <td><code>trustTier</code></td>
+        <td><code>TrustTier</code></td>
+        <td>No</td>
+        <td>Filter by trust tier</td>
+      </tr>
+      <tr>
+        <td><code>minScore</code></td>
+        <td><code>number</code></td>
+        <td>No</td>
+        <td>Minimum quality score (0-100)</td>
+      </tr>
+      <tr>
+        <td><code>limit</code></td>
+        <td><code>number</code></td>
+        <td>No</td>
+        <td>Max results (default: 10)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>Example</h4>
+
+  <pre><code>{`const results = await registry.search({
+  query: 'git',
+  trustTier: 'verified',
+  category: 'devops',
+  minScore: 80,
+  limit: 5
+});
+
+for (const skill of results) {
+  console.log(\`\${skill.id}: \${skill.name}\`);
+}`}</code></pre>
+
+  <h3>getSkill()</h3>
+
+  <p>Get detailed information about a specific skill.</p>
+
+  <pre><code>{`async getSkill(id: string): Promise<Skill | null>`}</code></pre>
+
+  <h4>Example</h4>
+
+  <pre><code>{`const skill = await registry.getSkill('community/jest-helper');
+
+if (skill) {
+  console.log(skill.name);
+  console.log(skill.description);
+  console.log(skill.trustTier);
+  console.log(skill.qualityScore);
+}`}</code></pre>
+
+  <h3>compare()</h3>
+
+  <p>Compare multiple skills side-by-side.</p>
+
+  <pre><code>{`async compare(ids: string[]): Promise<ComparisonResult>`}</code></pre>
+
+  <h4>Example</h4>
+
+  <pre><code>{`const comparison = await registry.compare([
+  'community/jest-helper',
+  'community/vitest-helper'
+]);
+
+console.log(comparison.skills);
+console.log(comparison.differences);
+console.log(comparison.recommendation);`}</code></pre>
+
+  <h2>SkillInstaller</h2>
+
+  <p>Handle skill installation and removal.</p>
+
+  <h3>Constructor</h3>
+
+  <pre><code>{`const installer = new SkillInstaller(options?: InstallerOptions);`}</code></pre>
+
+  <h4>InstallerOptions</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>installPath</code></td>
+        <td><code>string</code></td>
+        <td>Default installation directory</td>
+      </tr>
+      <tr>
+        <td><code>registry</code></td>
+        <td><code>SkillRegistry</code></td>
+        <td>Registry instance to use</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>install()</h3>
+
+  <p>Install a skill to the local environment.</p>
+
+  <pre><code>{`async install(id: string, options?: InstallOptions): Promise<InstallResult>`}</code></pre>
+
+  <h4>InstallOptions</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>path</code></td>
+        <td><code>string</code></td>
+        <td>Override installation path</td>
+      </tr>
+      <tr>
+        <td><code>force</code></td>
+        <td><code>boolean</code></td>
+        <td>Overwrite existing installation</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>Example</h4>
+
+  <pre><code>{`const result = await installer.install('community/jest-helper', {
+  path: '~/.claude/skills',
+  force: true
+});
+
+if (result.success) {
+  console.log(\`Installed to \${result.installPath}\`);
+} else {
+  console.error(result.error);
+}`}</code></pre>
+
+  <h3>uninstall()</h3>
+
+  <p>Remove an installed skill.</p>
+
+  <pre><code>{`async uninstall(id: string): Promise<UninstallResult>`}</code></pre>
+
+  <h3>list()</h3>
+
+  <p>List all installed skills.</p>
+
+  <pre><code>{`async list(): Promise<InstalledSkill[]>`}</code></pre>
+
+  <h2>Types</h2>
+
+  <h3>Skill</h3>
+
+  <pre><code>{`interface Skill {
+  id: string;              // "author/name" format
+  name: string;            // Display name
+  description: string;     // Full description
+  author: string;          // Author identifier
+  version: string;         // Semantic version
+  trustTier: TrustTier;    // Trust level
+  qualityScore: number;    // 0-100 score
+  category: Category;      // Primary category
+  tags: string[];          // Searchable tags
+  dependencies: string[];  // Required dependencies
+  createdAt: Date;         // Creation timestamp
+  updatedAt: Date;         // Last update timestamp
+}`}</code></pre>
+
+  <h3>TrustTier</h3>
+
+  <pre><code>{`type TrustTier = 'verified' | 'community' | 'experimental' | 'unknown';`}</code></pre>
+
+  <h3>Category</h3>
+
+  <pre><code>{`type Category =
+  | 'development'
+  | 'testing'
+  | 'devops'
+  | 'documentation'
+  | 'security'
+  | 'productivity'
+  | 'data'
+  | 'ai'
+  | 'other';`}</code></pre>
+
+  <h3>SearchResult</h3>
+
+  <pre><code>{`interface SearchResult {
+  skill: Skill;
+  score: number;        // Relevance score
+  highlights: string[]; // Matching text highlights
+}`}</code></pre>
+
+  <h2>Error Handling</h2>
+
+  <pre><code>{`import { SkillsmithError, NotFoundError, ValidationError } from '@skillsmith/core';
+
+try {
+  await registry.getSkill('invalid/skill');
+} catch (error) {
+  if (error instanceof NotFoundError) {
+    console.log('Skill not found');
+  } else if (error instanceof ValidationError) {
+    console.log('Invalid skill ID format');
+  } else {
+    throw error;
+  }
+}`}</code></pre>
+
+  <h3>Error Types</h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Error</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>SkillsmithError</code></td>
+        <td>Base error class</td>
+      </tr>
+      <tr>
+        <td><code>NotFoundError</code></td>
+        <td>Skill or resource not found</td>
+      </tr>
+      <tr>
+        <td><code>ValidationError</code></td>
+        <td>Invalid input or parameters</td>
+      </tr>
+      <tr>
+        <td><code>InstallError</code></td>
+        <td>Installation failed</td>
+      </tr>
+      <tr>
+        <td><code>NetworkError</code></td>
+        <td>Network request failed</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Rate Limiting</h2>
+
+  <p>API requests are rate-limited based on your plan:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Plan</th>
+        <th>Requests/Month</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Community</td>
+        <td>1,000</td>
+      </tr>
+      <tr>
+        <td>Individual</td>
+        <td>10,000</td>
+      </tr>
+      <tr>
+        <td>Team</td>
+        <td>100,000</td>
+      </tr>
+      <tr>
+        <td>Enterprise</td>
+        <td>Unlimited</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout">
+    <h4>API Key Required</h4>
+    <p>
+      For higher rate limits and premium features, obtain an API key from your
+      <a href="/account">account settings</a>.
+    </p>
+  </div>
+</DocsLayout>

--- a/packages/website/src/pages/docs/cli.astro
+++ b/packages/website/src/pages/docs/cli.astro
@@ -1,0 +1,385 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="CLI Reference" description="Complete command reference for the Skillsmith CLI">
+  <h1>CLI Reference</h1>
+
+  <p class="lead">
+    The Skillsmith CLI (<code>skillsmith</code> or <code>sklx</code>) provides commands
+    for skill discovery, installation, and management.
+  </p>
+
+  <h2>Installation</h2>
+
+  <pre><code>{`# Global installation
+npm install -g @skillsmith/cli
+
+# Or use npx for one-off commands
+npx @skillsmith/cli <command>`}</code></pre>
+
+  <h2>Core Commands</h2>
+
+  <h3>search</h3>
+
+  <p>Search for skills in the Skillsmith registry.</p>
+
+  <pre><code>{`skillsmith search <query> [options]
+
+# Examples
+skillsmith search testing
+skillsmith search git --tier verified
+skillsmith search --category devops --limit 20`}</code></pre>
+
+  <h4>Options</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Option</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>--tier</code></td>
+        <td>Filter by trust tier (verified, community, experimental)</td>
+        <td>all</td>
+      </tr>
+      <tr>
+        <td><code>--category</code></td>
+        <td>Filter by category</td>
+        <td>all</td>
+      </tr>
+      <tr>
+        <td><code>--min-score</code></td>
+        <td>Minimum quality score (0-100)</td>
+        <td>0</td>
+      </tr>
+      <tr>
+        <td><code>--limit</code></td>
+        <td>Maximum number of results</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td><code>--json</code></td>
+        <td>Output results as JSON</td>
+        <td>false</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>install</h3>
+
+  <p>Install a skill to your local environment.</p>
+
+  <pre><code>{`skillsmith install <skill-id> [options]
+
+# Examples
+skillsmith install jest-helper
+skillsmith install community/git-commit
+skillsmith install anthropic/official-skill --force`}</code></pre>
+
+  <h4>Options</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Option</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>--path</code></td>
+        <td>Installation directory</td>
+        <td>~/.claude/skills/</td>
+      </tr>
+      <tr>
+        <td><code>--force</code></td>
+        <td>Overwrite existing installation</td>
+        <td>false</td>
+      </tr>
+      <tr>
+        <td><code>--dry-run</code></td>
+        <td>Preview without installing</td>
+        <td>false</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>uninstall</h3>
+
+  <p>Remove an installed skill.</p>
+
+  <pre><code>{`skillsmith uninstall <skill-id> [options]
+
+# Examples
+skillsmith uninstall jest-helper
+skillsmith uninstall community/git-commit --confirm`}</code></pre>
+
+  <h4>Options</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Option</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>--confirm</code></td>
+        <td>Skip confirmation prompt</td>
+        <td>false</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>info</h3>
+
+  <p>Get detailed information about a skill.</p>
+
+  <pre><code>{`skillsmith info <skill-id>
+
+# Examples
+skillsmith info jest-helper
+skillsmith info community/git-commit --json`}</code></pre>
+
+  <h3>list</h3>
+
+  <p>List installed skills.</p>
+
+  <pre><code>{`skillsmith list [options]
+
+# Examples
+skillsmith list
+skillsmith list --json
+skillsmith list --path ~/custom/skills`}</code></pre>
+
+  <h3>compare</h3>
+
+  <p>Compare multiple skills side-by-side.</p>
+
+  <pre><code>{`skillsmith compare <skill-id> <skill-id> [...]
+
+# Examples
+skillsmith compare jest-helper vitest-helper
+skillsmith compare skill-a skill-b skill-c --json`}</code></pre>
+
+  <h3>recommend</h3>
+
+  <p>Get personalized skill recommendations.</p>
+
+  <pre><code>{`skillsmith recommend [options]
+
+# Examples
+skillsmith recommend
+skillsmith recommend --context react
+skillsmith recommend --analyze ./package.json`}</code></pre>
+
+  <h4>Options</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Option</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>--context</code></td>
+        <td>Technology context (react, node, python, etc.)</td>
+      </tr>
+      <tr>
+        <td><code>--analyze</code></td>
+        <td>Analyze a file for context</td>
+      </tr>
+      <tr>
+        <td><code>--limit</code></td>
+        <td>Maximum recommendations</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Author Commands</h2>
+
+  <p>Commands for skill authoring and development.</p>
+
+  <h3>author subagent</h3>
+
+  <p>Generate a companion subagent for a skill.</p>
+
+  <pre><code>{`skillsmith author subagent <skill-path> [options]
+
+# Examples
+skillsmith author subagent ./my-skill
+skillsmith author subagent ./my-skill --output ./agents`}</code></pre>
+
+  <h4>Options</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Option</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>--output, -o</code></td>
+        <td>Output directory for generated subagent</td>
+      </tr>
+      <tr>
+        <td><code>--tools</code></td>
+        <td>Override detected tools (comma-separated)</td>
+      </tr>
+      <tr>
+        <td><code>--model</code></td>
+        <td>Model to use (sonnet, opus, haiku)</td>
+      </tr>
+      <tr>
+        <td><code>--skip-claude-md</code></td>
+        <td>Skip CLAUDE.md delegation snippet</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>author transform</h3>
+
+  <p>Transform an existing skill to add subagent support.</p>
+
+  <pre><code>{`skillsmith author transform <skill-path> [options]
+
+# Examples
+skillsmith author transform ./my-skill
+skillsmith author transform ./skills --batch --dry-run`}</code></pre>
+
+  <h4>Options</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Option</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>--dry-run</code></td>
+        <td>Preview changes without writing</td>
+      </tr>
+      <tr>
+        <td><code>--batch</code></td>
+        <td>Process multiple skills in directory</td>
+      </tr>
+      <tr>
+        <td><code>--tools</code></td>
+        <td>Override detected tools</td>
+      </tr>
+      <tr>
+        <td><code>--model</code></td>
+        <td>Model to use</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>validate</h3>
+
+  <p>Validate a skill's structure and metadata.</p>
+
+  <pre><code>{`skillsmith validate <skill-path>
+
+# Examples
+skillsmith validate ./my-skill
+skillsmith validate ~/.claude/skills/jest-helper`}</code></pre>
+
+  <h2>Global Options</h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Option</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>--version</code></td>
+        <td>Show CLI version</td>
+      </tr>
+      <tr>
+        <td><code>--help</code></td>
+        <td>Show help for command</td>
+      </tr>
+      <tr>
+        <td><code>--verbose</code></td>
+        <td>Enable verbose output</td>
+      </tr>
+      <tr>
+        <td><code>--quiet</code></td>
+        <td>Suppress non-essential output</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Configuration</h2>
+
+  <p>The CLI can be configured via environment variables or a config file at <code>~/.skillsmithrc</code>:</p>
+
+  <pre><code>{`# ~/.skillsmithrc
+{
+  "defaultTier": "community",
+  "installPath": "~/.claude/skills",
+  "registry": "https://registry.skillsmith.dev"
+}`}</code></pre>
+
+  <h3>Environment Variables</h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Variable</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>SKILLSMITH_REGISTRY</code></td>
+        <td>Custom registry URL</td>
+      </tr>
+      <tr>
+        <td><code>SKILLSMITH_INSTALL_PATH</code></td>
+        <td>Default installation path</td>
+      </tr>
+      <tr>
+        <td><code>SKILLSMITH_API_KEY</code></td>
+        <td>API key for authenticated requests</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Troubleshooting</h2>
+
+  <h3>Common Issues</h3>
+
+  <div class="callout warning">
+    <h4>Permission Denied</h4>
+    <p>
+      If you see permission errors when installing globally, try using
+      <code>npx @skillsmith/cli</code> instead, or fix npm permissions.
+    </p>
+  </div>
+
+  <div class="callout">
+    <h4>Skill Not Found</h4>
+    <p>
+      Ensure you're using the correct skill ID format (<code>author/name</code>).
+      Use <code>skillsmith search</code> to find available skills.
+    </p>
+  </div>
+</DocsLayout>

--- a/packages/website/src/pages/docs/getting-started.astro
+++ b/packages/website/src/pages/docs/getting-started.astro
@@ -1,0 +1,156 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Getting Started" description="Quick start guide for setting up Skillsmith with Claude Code">
+  <h1>Getting Started</h1>
+
+  <p class="lead">
+    Get Skillsmith up and running in your Claude Code environment in just a few minutes.
+  </p>
+
+  <h2>Prerequisites</h2>
+
+  <p>Before you begin, ensure you have:</p>
+
+  <ul>
+    <li><strong>Claude Code</strong> installed and configured</li>
+    <li><strong>Node.js 18+</strong> (for npx commands)</li>
+    <li><strong>npm</strong> or a compatible package manager</li>
+  </ul>
+
+  <h2>Installation</h2>
+
+  <p>There are two ways to use Skillsmith: as an MCP server (recommended) or via the CLI.</p>
+
+  <h3>Option 1: MCP Server (Recommended)</h3>
+
+  <p>
+    The MCP server integrates directly with Claude Code, allowing you to search and
+    install skills through natural language.
+  </p>
+
+  <p>Add the following to your Claude settings file at <code>~/.claude/settings.json</code>:</p>
+
+  <pre><code>{`{
+  "mcpServers": {
+    "skillsmith": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"]
+    }
+  }
+}`}</code></pre>
+
+  <p>After adding this configuration, restart Claude Code to load the Skillsmith server.</p>
+
+  <h3>Option 2: CLI Installation</h3>
+
+  <p>For command-line access, install the CLI globally:</p>
+
+  <pre><code>{`npm install -g @skillsmith/cli
+
+# Or use npx for one-off commands
+npx @skillsmith/cli search testing`}</code></pre>
+
+  <h2>Verify Installation</h2>
+
+  <h3>MCP Server Verification</h3>
+
+  <p>Ask Claude to verify the Skillsmith server is running:</p>
+
+  <pre><code>{`"List available MCP tools"
+# You should see skillsmith tools like search, install, recommend`}</code></pre>
+
+  <h3>CLI Verification</h3>
+
+  <p>Check the CLI is installed correctly:</p>
+
+  <pre><code>{`skillsmith --version
+# Output: @skillsmith/cli v1.x.x
+
+skillsmith --help
+# Shows available commands`}</code></pre>
+
+  <h2>Your First Skill Search</h2>
+
+  <h3>Using Claude (MCP)</h3>
+
+  <p>Simply ask Claude to search for skills:</p>
+
+  <pre><code>{`"Search for testing skills"
+"Find verified skills for git workflows"
+"Show me skills for React development"`}</code></pre>
+
+  <h3>Using the CLI</h3>
+
+  <p>Search for skills from the command line:</p>
+
+  <pre><code>{`# Search by keyword
+skillsmith search testing
+
+# Filter by trust tier
+skillsmith search git --tier verified
+
+# Filter by category
+skillsmith search --category devops`}</code></pre>
+
+  <h2>Installing Your First Skill</h2>
+
+  <h3>Using Claude (MCP)</h3>
+
+  <pre><code>{`"Install the jest-helper skill"
+"Install community/git-commit"`}</code></pre>
+
+  <h3>Using the CLI</h3>
+
+  <pre><code>{`# Install by name
+skillsmith install jest-helper
+
+# Install by full ID
+skillsmith install community/git-commit`}</code></pre>
+
+  <p>Skills are installed to <code>~/.claude/skills/</code> by default.</p>
+
+  <h2>Understanding Skill IDs</h2>
+
+  <p>Skills are identified by their full ID in the format <code>author/name</code>:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>ID Format</th>
+        <th>Example</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>author/name</code></td>
+        <td><code>community/jest-helper</code></td>
+        <td>Full skill identifier</td>
+      </tr>
+      <tr>
+        <td><code>name</code></td>
+        <td><code>jest-helper</code></td>
+        <td>Short form (searches all authors)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Next Steps</h2>
+
+  <ul>
+    <li><a href="/docs/cli">CLI Reference</a> - Learn all CLI commands</li>
+    <li><a href="/docs/mcp-server">MCP Server</a> - Configure advanced server options</li>
+    <li><a href="/docs/api">API Reference</a> - Build integrations with the Skillsmith API</li>
+  </ul>
+
+  <div class="callout">
+    <h4>Need Help?</h4>
+    <p>
+      If you encounter any issues during setup, check out our
+      <a href="https://github.com/Smith-Horn-Group/skillsmith/issues">GitHub Issues</a>
+      or refer to the troubleshooting section in the CLI reference.
+    </p>
+  </div>
+</DocsLayout>

--- a/packages/website/src/pages/docs/index.astro
+++ b/packages/website/src/pages/docs/index.astro
@@ -1,0 +1,180 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Documentation" description="Learn how to use Skillsmith for Claude Code skill discovery and management">
+  <!-- JSON-LD Schema -->
+  <script type="application/ld+json" slot="head">
+  {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "headline": "Skillsmith Documentation",
+    "description": "Complete documentation for Skillsmith - AI-powered skill discovery and management for Claude Code",
+    "url": "https://skillsmith.app/docs",
+    "author": {
+      "@type": "Organization",
+      "name": "Smith Horn Group"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Skillsmith",
+      "url": "https://skillsmith.app"
+    },
+    "about": {
+      "@type": "SoftwareApplication",
+      "name": "Skillsmith",
+      "applicationCategory": "DeveloperApplication"
+    },
+    "mainEntity": {
+      "@type": "ItemList",
+      "name": "Documentation Sections",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Quickstart Guide",
+          "url": "https://skillsmith.app/docs/quickstart"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Getting Started",
+          "url": "https://skillsmith.app/docs/getting-started"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": "CLI Reference",
+          "url": "https://skillsmith.app/docs/cli"
+        },
+        {
+          "@type": "ListItem",
+          "position": 4,
+          "name": "MCP Server",
+          "url": "https://skillsmith.app/docs/mcp-server"
+        },
+        {
+          "@type": "ListItem",
+          "position": 5,
+          "name": "API Reference",
+          "url": "https://skillsmith.app/docs/api"
+        }
+      ]
+    }
+  }
+  </script>
+
+  <h1>Skillsmith Documentation</h1>
+
+  <p class="lead">
+    Skillsmith is an MCP server for Claude Code skill discovery, installation, and management.
+    It helps you find, evaluate, and install skills for your Claude Code environment.
+  </p>
+
+  <h2>What is Skillsmith?</h2>
+
+  <p>
+    Skillsmith provides a comprehensive toolset for managing Claude Code skills. Whether you're
+    looking for testing utilities, git workflow helpers, or specialized development tools,
+    Skillsmith makes it easy to discover and install the skills you need.
+  </p>
+
+  <h3>Key Features</h3>
+
+  <ul>
+    <li><strong>Skill Discovery</strong> - Search and browse thousands of community skills</li>
+    <li><strong>Smart Recommendations</strong> - Get personalized skill suggestions based on your project</li>
+    <li><strong>Trust Verification</strong> - Know which skills are verified, community-reviewed, or experimental</li>
+    <li><strong>Easy Installation</strong> - Install skills with a single command</li>
+    <li><strong>Skill Comparison</strong> - Compare similar skills side-by-side</li>
+  </ul>
+
+  <h2>Quick Start</h2>
+
+  <p>Get started with Skillsmith in minutes:</p>
+
+  <h3>1. Configure the MCP Server</h3>
+
+  <p>Add Skillsmith to your Claude settings file (<code>~/.claude/settings.json</code>):</p>
+
+  <pre><code>{`{
+  "mcpServers": {
+    "skillsmith": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"]
+    }
+  }
+}`}</code></pre>
+
+  <h3>2. Start Using Skillsmith</h3>
+
+  <p>Once configured, ask Claude to find and install skills:</p>
+
+  <pre><code>{`"Search for testing skills"
+"Find verified skills for git workflows"
+"Install the commit skill"
+"Recommend skills for my React project"`}</code></pre>
+
+  <h2>Documentation Sections</h2>
+
+  <div class="card-grid">
+    <a href="/docs/getting-started" class="doc-card">
+      <h3>Getting Started</h3>
+      <p>Step-by-step guide to set up Skillsmith in your environment.</p>
+    </a>
+
+    <a href="/docs/cli" class="doc-card">
+      <h3>CLI Reference</h3>
+      <p>Complete command reference for the Skillsmith CLI.</p>
+    </a>
+
+    <a href="/docs/mcp-server" class="doc-card">
+      <h3>MCP Server</h3>
+      <p>Learn how to configure and use the MCP server with Claude.</p>
+    </a>
+
+    <a href="/docs/api" class="doc-card">
+      <h3>API Reference</h3>
+      <p>Detailed API documentation for developers and integrators.</p>
+    </a>
+  </div>
+
+  <h2>Trust Tiers</h2>
+
+  <p>Skillsmith categorizes skills by trust level to help you make informed decisions:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Tier</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>verified</code></td>
+        <td>Official Anthropic skills with full security review</td>
+      </tr>
+      <tr>
+        <td><code>community</code></td>
+        <td>Community-reviewed skills with quality checks</td>
+      </tr>
+      <tr>
+        <td><code>experimental</code></td>
+        <td>New or beta skills, use with caution</td>
+      </tr>
+      <tr>
+        <td><code>unknown</code></td>
+        <td>Unverified skills, not recommended for production</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Need Help?</h2>
+
+  <p>
+    If you run into issues or have questions, check out our
+    <a href="https://github.com/Smith-Horn-Group/skillsmith/issues">GitHub Issues</a>
+    or join the community discussion.
+  </p>
+</DocsLayout>

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -1,0 +1,306 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="MCP Server" description="Configure and use the Skillsmith MCP server with Claude Code">
+  <h1>MCP Server</h1>
+
+  <p class="lead">
+    The Skillsmith MCP server integrates directly with Claude Code, enabling natural
+    language skill discovery and management.
+  </p>
+
+  <h2>Overview</h2>
+
+  <p>
+    MCP (Model Context Protocol) servers extend Claude's capabilities by providing
+    additional tools. The Skillsmith MCP server adds tools for searching, installing,
+    and managing Claude Code skills.
+  </p>
+
+  <h2>Configuration</h2>
+
+  <h3>Basic Setup</h3>
+
+  <p>Add Skillsmith to your Claude settings at <code>~/.claude/settings.json</code>:</p>
+
+  <pre><code>{`{
+  "mcpServers": {
+    "skillsmith": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"]
+    }
+  }
+}`}</code></pre>
+
+  <h3>Advanced Configuration</h3>
+
+  <p>For more control, you can specify additional options:</p>
+
+  <pre><code>{`{
+  "mcpServers": {
+    "skillsmith": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"],
+      "env": {
+        "SKILLSMITH_LOG_LEVEL": "debug",
+        "SKILLSMITH_CACHE_TTL": "3600"
+      }
+    }
+  }
+}`}</code></pre>
+
+  <h3>Environment Variables</h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Variable</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>SKILLSMITH_LOG_LEVEL</code></td>
+        <td>Logging level (debug, info, warn, error)</td>
+        <td>info</td>
+      </tr>
+      <tr>
+        <td><code>SKILLSMITH_CACHE_TTL</code></td>
+        <td>Cache time-to-live in seconds</td>
+        <td>1800</td>
+      </tr>
+      <tr>
+        <td><code>SKILLSMITH_REGISTRY</code></td>
+        <td>Custom registry URL</td>
+        <td>default registry</td>
+      </tr>
+      <tr>
+        <td><code>SKILLSMITH_API_KEY</code></td>
+        <td>API key for premium features</td>
+        <td>-</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Available Tools</h2>
+
+  <p>The MCP server provides the following tools to Claude:</p>
+
+  <h3>search</h3>
+
+  <p>Search for skills in the registry.</p>
+
+  <pre><code>{`// Tool: search
+// Parameters:
+{
+  "query": "testing",           // Search term (required)
+  "category": "development",    // Category filter
+  "trust_tier": "verified",     // Trust tier filter
+  "min_score": 70,              // Minimum quality score
+  "limit": 10                   // Max results
+}`}</code></pre>
+
+  <p><strong>Example prompts:</strong></p>
+  <ul>
+    <li>"Search for testing skills"</li>
+    <li>"Find verified skills for git workflows"</li>
+    <li>"Show me devops skills with high quality scores"</li>
+  </ul>
+
+  <h3>get_skill</h3>
+
+  <p>Get detailed information about a specific skill.</p>
+
+  <pre><code>{`// Tool: get_skill
+// Parameters:
+{
+  "id": "community/jest-helper"  // Skill ID (required)
+}`}</code></pre>
+
+  <p><strong>Example prompts:</strong></p>
+  <ul>
+    <li>"Show details for community/jest-helper"</li>
+    <li>"What does the git-commit skill do?"</li>
+  </ul>
+
+  <h3>install_skill</h3>
+
+  <p>Install a skill to the local environment.</p>
+
+  <pre><code>{`// Tool: install_skill
+// Parameters:
+{
+  "id": "community/jest-helper",  // Skill ID (required)
+  "path": "~/.claude/skills",     // Installation path
+  "force": false                  // Overwrite existing
+}`}</code></pre>
+
+  <p><strong>Example prompts:</strong></p>
+  <ul>
+    <li>"Install the jest-helper skill"</li>
+    <li>"Install community/git-commit"</li>
+  </ul>
+
+  <h3>uninstall_skill</h3>
+
+  <p>Remove an installed skill.</p>
+
+  <pre><code>{`// Tool: uninstall_skill
+// Parameters:
+{
+  "id": "community/jest-helper"  // Skill ID (required)
+}`}</code></pre>
+
+  <p><strong>Example prompts:</strong></p>
+  <ul>
+    <li>"Uninstall the jest-helper skill"</li>
+    <li>"Remove community/git-commit"</li>
+  </ul>
+
+  <h3>recommend</h3>
+
+  <p>Get personalized skill recommendations.</p>
+
+  <pre><code>{`// Tool: recommend
+// Parameters:
+{
+  "context": "react",     // Technology context
+  "limit": 5              // Max recommendations
+}`}</code></pre>
+
+  <p><strong>Example prompts:</strong></p>
+  <ul>
+    <li>"Recommend skills for my React project"</li>
+    <li>"What skills would help with Node.js development?"</li>
+  </ul>
+
+  <h3>compare</h3>
+
+  <p>Compare multiple skills side-by-side.</p>
+
+  <pre><code>{`// Tool: compare
+// Parameters:
+{
+  "skill_ids": ["jest-helper", "vitest-helper"]  // 2-5 skill IDs
+}`}</code></pre>
+
+  <p><strong>Example prompts:</strong></p>
+  <ul>
+    <li>"Compare jest-helper and vitest-helper"</li>
+    <li>"What's the difference between these testing skills?"</li>
+  </ul>
+
+  <h3>validate</h3>
+
+  <p>Validate a skill's structure.</p>
+
+  <pre><code>{`// Tool: validate
+// Parameters:
+{
+  "path": "./my-skill"  // Path to skill directory
+}`}</code></pre>
+
+  <p><strong>Example prompts:</strong></p>
+  <ul>
+    <li>"Validate my skill at ./my-skill"</li>
+    <li>"Check if this skill structure is correct"</li>
+  </ul>
+
+  <h2>Usage Examples</h2>
+
+  <h3>Discovering Skills</h3>
+
+  <pre><code>{`You: "I need help with testing in my project. What skills are available?"
+
+Claude: [Uses search tool] I found several testing skills:
+- jest-helper: Comprehensive Jest testing utilities
+- vitest-helper: Vitest integration and helpers
+- playwright-utils: End-to-end testing with Playwright
+...`}</code></pre>
+
+  <h3>Installing and Using Skills</h3>
+
+  <pre><code>{`You: "Install the jest-helper skill and show me how to use it"
+
+Claude: [Uses install_skill tool] I've installed jest-helper to
+~/.claude/skills/jest-helper. This skill provides...`}</code></pre>
+
+  <h3>Comparing Options</h3>
+
+  <pre><code>{`You: "Should I use jest-helper or vitest-helper for my Vite project?"
+
+Claude: [Uses compare tool] Here's a comparison:
+| Feature       | jest-helper | vitest-helper |
+| Vite support  | Limited     | Native        |
+| Speed         | Moderate    | Fast          |
+...`}</code></pre>
+
+  <h2>Trust Tiers</h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Tier</th>
+        <th>Description</th>
+        <th>Review Process</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>verified</code></td>
+        <td>Official Anthropic skills</td>
+        <td>Full security audit</td>
+      </tr>
+      <tr>
+        <td><code>community</code></td>
+        <td>Community-reviewed</td>
+        <td>Peer review + automated checks</td>
+      </tr>
+      <tr>
+        <td><code>experimental</code></td>
+        <td>Beta/new skills</td>
+        <td>Basic validation only</td>
+      </tr>
+      <tr>
+        <td><code>unknown</code></td>
+        <td>Unverified</td>
+        <td>None</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Troubleshooting</h2>
+
+  <h3>Server Not Starting</h3>
+
+  <div class="callout">
+    <h4>Check Node.js Version</h4>
+    <p>Ensure you have Node.js 18+ installed. Run <code>node --version</code> to verify.</p>
+  </div>
+
+  <h3>Tools Not Available</h3>
+
+  <div class="callout">
+    <h4>Verify Configuration</h4>
+    <p>
+      Ensure your <code>~/.claude/settings.json</code> is valid JSON and the
+      MCP server configuration is correct. Restart Claude Code after changes.
+    </p>
+  </div>
+
+  <h3>Enable Debug Logging</h3>
+
+  <pre><code>{`{
+  "mcpServers": {
+    "skillsmith": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"],
+      "env": {
+        "SKILLSMITH_LOG_LEVEL": "debug"
+      }
+    }
+  }
+}`}</code></pre>
+</DocsLayout>

--- a/packages/website/src/pages/docs/quarantine.astro
+++ b/packages/website/src/pages/docs/quarantine.astro
@@ -1,0 +1,400 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Quarantine System" description="Learn how Skillsmith's quarantine system protects you from potentially harmful skills">
+  <h1>Quarantine System</h1>
+
+  <p class="lead">
+    When Skillsmith detects potential security issues in a skill, it places the skill in quarantine
+    to protect your environment. This page explains how the quarantine system works and what to do
+    if you encounter a quarantined skill.
+  </p>
+
+  <h2>What is Quarantine?</h2>
+
+  <p>
+    Quarantine is a protective system that isolates skills with potential security issues.
+    When a skill is quarantined, it cannot be installed until it has been reviewed or the
+    issues have been resolved.
+  </p>
+
+  <p>
+    The quarantine system exists to protect you from:
+  </p>
+
+  <ul>
+    <li>Malicious code that could harm your system</li>
+    <li>Prompt injection attacks that could manipulate Claude</li>
+    <li>Skills that access sensitive files without authorization</li>
+    <li>Low-quality skills that may cause unexpected behavior</li>
+  </ul>
+
+  <h2>Quarantine Severity Levels</h2>
+
+  <p>
+    Quarantined skills are assigned one of four severity levels, each with different implications:
+  </p>
+
+  <div class="severity-levels">
+    <div class="severity severity-malicious">
+      <div class="severity-header">
+        <span class="severity-badge">MALICIOUS</span>
+        <span class="severity-level">Level 4</span>
+      </div>
+      <p class="severity-description">Permanent quarantine &mdash; security threat detected</p>
+      <ul>
+        <li>Cannot be installed under any circumstances</li>
+        <li>Requires security team review</li>
+        <li>Author may be banned from the registry</li>
+      </ul>
+      <p class="severity-example"><strong>Example:</strong> Skill contains jailbreak patterns or known malicious code</p>
+    </div>
+
+    <div class="severity severity-suspicious">
+      <div class="severity-header">
+        <span class="severity-badge">SUSPICIOUS</span>
+        <span class="severity-level">Level 3</span>
+      </div>
+      <p class="severity-description">Manual review required before import allowed</p>
+      <ul>
+        <li>Installation blocked until review completes</li>
+        <li>Security team evaluates within 24-48 hours</li>
+        <li>May be approved, rejected, or downgraded</li>
+      </ul>
+      <p class="severity-example"><strong>Example:</strong> Skill accesses sensitive files without clear justification</p>
+    </div>
+
+    <div class="severity severity-risky">
+      <div class="severity-header">
+        <span class="severity-badge">RISKY</span>
+        <span class="severity-level">Level 2</span>
+      </div>
+      <p class="severity-description">Can import with warnings displayed</p>
+      <ul>
+        <li>Installation allowed with explicit confirmation</li>
+        <li>Warning message explains detected risks</li>
+        <li>User assumes responsibility</li>
+      </ul>
+      <p class="severity-example"><strong>Example:</strong> Skill references external URLs not on the allowlist</p>
+    </div>
+
+    <div class="severity severity-low-quality">
+      <div class="severity-header">
+        <span class="severity-badge">LOW_QUALITY</span>
+        <span class="severity-level">Level 1</span>
+      </div>
+      <p class="severity-description">Can import with reduced quality score</p>
+      <ul>
+        <li>Installation allowed normally</li>
+        <li>Quality score is reduced in search results</li>
+        <li>May indicate incomplete or outdated skill</li>
+      </ul>
+      <p class="severity-example"><strong>Example:</strong> Skill missing required metadata or documentation</p>
+    </div>
+  </div>
+
+  <h2>What Triggers Quarantine</h2>
+
+  <p>Skills can be quarantined for several reasons:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Trigger</th>
+        <th>Typical Severity</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Failed security scan</td>
+        <td>SUSPICIOUS or MALICIOUS</td>
+        <td>Security scan detected critical or high-severity patterns</td>
+      </tr>
+      <tr>
+        <td>User reports</td>
+        <td>SUSPICIOUS</td>
+        <td>Multiple users reported suspicious behavior</td>
+      </tr>
+      <tr>
+        <td>Blocklist match</td>
+        <td>MALICIOUS</td>
+        <td>Skill matches known malicious patterns or authors</td>
+      </tr>
+      <tr>
+        <td>Anomaly detection</td>
+        <td>SUSPICIOUS</td>
+        <td>Sudden behavior change in previously trusted skill</td>
+      </tr>
+      <tr>
+        <td>Missing metadata</td>
+        <td>LOW_QUALITY</td>
+        <td>Required fields missing from SKILL.md</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>User Experience</h2>
+
+  <h3>When Installing a Quarantined Skill</h3>
+
+  <p>If you try to install a quarantined skill, you'll see different messages depending on severity:</p>
+
+  <div class="callout warning">
+    <h4>MALICIOUS Skills</h4>
+    <pre><code>{`Error: This skill has been quarantined for security reasons and cannot be installed.
+Reason: Security threat detected - jailbreak patterns found
+For more information, visit skillsmith.app/docs/quarantine`}</code></pre>
+  </div>
+
+  <div class="callout warning">
+    <h4>SUSPICIOUS Skills</h4>
+    <pre><code>{`Warning: This skill is under review and cannot be installed yet.
+Reason: Accesses sensitive file patterns
+Review status: Pending (estimated 24-48 hours)
+You will be notified when the review is complete.`}</code></pre>
+  </div>
+
+  <div class="callout">
+    <h4>RISKY Skills</h4>
+    <pre><code>{`Warning: This skill has been flagged for the following risks:
+- References external domain: api.example.com
+- Contains high-entropy content (possible obfuscation)
+
+Do you want to proceed with installation? (y/N)`}</code></pre>
+  </div>
+
+  <h3>Checking Quarantine Status</h3>
+
+  <p>You can check if a skill is quarantined before installing:</p>
+
+  <pre><code>{`# Using the CLI
+skillsmith info <skill-id>
+
+# Response includes quarantine status
+{
+  "id": "community/suspicious-skill",
+  "quarantineStatus": {
+    "quarantined": true,
+    "severity": "SUSPICIOUS",
+    "reason": "Accesses sensitive file patterns",
+    "reviewStatus": "pending"
+  }
+}`}</code></pre>
+
+  <h2>For Skill Authors</h2>
+
+  <h3>Checking If Your Skill Is Quarantined</h3>
+
+  <p>Authors can check their skill's quarantine status:</p>
+
+  <pre><code>{`skillsmith info <your-skill-id>
+# Or via the MCP server
+"Check the status of my-skill-name"`}</code></pre>
+
+  <h3>Resolution Process</h3>
+
+  <p>If your skill is quarantined, follow these steps to resolve it:</p>
+
+  <ol>
+    <li>
+      <strong>Review the findings</strong>: Check the quarantine reason to understand what triggered it
+    </li>
+    <li>
+      <strong>Fix the issues</strong>: Update your skill to address the security concerns
+      <ul>
+        <li>Remove or justify external URL references</li>
+        <li>Avoid accessing sensitive file patterns</li>
+        <li>Remove any code that could be misinterpreted as malicious</li>
+      </ul>
+    </li>
+    <li>
+      <strong>Push updates</strong>: Commit your changes to the skill repository
+    </li>
+    <li>
+      <strong>Request re-scan</strong>: The skill will be automatically re-scanned on the next index cycle (typically within 24 hours)
+    </li>
+    <li>
+      <strong>Wait for review</strong>: For SUSPICIOUS or MALICIOUS severity, manual review is required even after fixes
+    </li>
+  </ol>
+
+  <h3>Appeal Process</h3>
+
+  <p>If you believe your skill was incorrectly quarantined (false positive):</p>
+
+  <ol>
+    <li>
+      <strong>Document your case</strong>: Explain why the flagged patterns are legitimate and necessary
+    </li>
+    <li>
+      <strong>Open an issue</strong>: Create an issue at
+      <a href="https://github.com/Smith-Horn-Group/skillsmith/issues" target="_blank" rel="noopener noreferrer">GitHub</a>
+      with label <code>quarantine-appeal</code>
+    </li>
+    <li>
+      <strong>Include evidence</strong>: Provide the skill ID, quarantine reason, and your justification
+    </li>
+    <li>
+      <strong>Await response</strong>: Appeals are typically reviewed within 2-5 business days
+    </li>
+  </ol>
+
+  <h2>Review Timeline</h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Severity</th>
+        <th>Initial Triage</th>
+        <th>Full Review</th>
+        <th>Appeal Resolution</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>MALICIOUS</td>
+        <td>24 hours</td>
+        <td>3-5 days</td>
+        <td>5-10 days</td>
+      </tr>
+      <tr>
+        <td>SUSPICIOUS</td>
+        <td>24-48 hours</td>
+        <td>2-5 days</td>
+        <td>3-7 days</td>
+      </tr>
+      <tr>
+        <td>RISKY</td>
+        <td>Automatic</td>
+        <td>N/A</td>
+        <td>1-3 days</td>
+      </tr>
+      <tr>
+        <td>LOW_QUALITY</td>
+        <td>Automatic</td>
+        <td>N/A</td>
+        <td>1-2 days</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Preventing Quarantine</h2>
+
+  <p>To avoid having your skill quarantined:</p>
+
+  <ul>
+    <li>Follow the <a href="/docs/security#best-practices-for-authors">security best practices for authors</a></li>
+    <li>Run <code>skillsmith validate</code> locally before publishing</li>
+    <li>Avoid external URLs unless absolutely necessary</li>
+    <li>Never access sensitive files (.env, credentials, keys)</li>
+    <li>Include complete metadata in your SKILL.md</li>
+    <li>Submit for verification to get the Verified badge</li>
+  </ul>
+
+  <h2>Related Documentation</h2>
+
+  <ul>
+    <li><a href="/docs/security">Security Model</a> - What we scan for and why</li>
+    <li><a href="/docs/trust-tiers">Trust Tiers</a> - How verification affects trust</li>
+    <li><a href="/docs/cli">CLI Reference</a> - Using the validate command</li>
+  </ul>
+</DocsLayout>
+
+<style>
+  .severity-levels {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    margin: 1.5rem 0;
+  }
+
+  .severity {
+    padding: 1.25rem 1.5rem;
+    border-radius: 0.5rem;
+    border-left: 4px solid;
+  }
+
+  .severity-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .severity-badge {
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  }
+
+  .severity-level {
+    font-size: 0.75rem;
+    color: var(--color-text-muted, #9ca3af);
+  }
+
+  .severity-description {
+    font-weight: 500;
+    margin: 0 0 0.75rem 0;
+  }
+
+  .severity ul {
+    margin: 0 0 0.75rem 0;
+    padding-left: 1.25rem;
+    font-size: 0.9rem;
+  }
+
+  .severity li {
+    margin: 0.25rem 0;
+  }
+
+  .severity-example {
+    font-size: 0.85rem;
+    color: var(--color-text-muted, #9ca3af);
+    margin: 0;
+  }
+
+  .severity-malicious {
+    background: rgba(239, 68, 68, 0.1);
+    border-color: rgb(239, 68, 68);
+  }
+
+  .severity-malicious .severity-badge {
+    background: rgba(239, 68, 68, 0.2);
+    color: rgb(239, 68, 68);
+  }
+
+  .severity-suspicious {
+    background: rgba(249, 115, 22, 0.1);
+    border-color: rgb(249, 115, 22);
+  }
+
+  .severity-suspicious .severity-badge {
+    background: rgba(249, 115, 22, 0.2);
+    color: rgb(249, 115, 22);
+  }
+
+  .severity-risky {
+    background: rgba(234, 179, 8, 0.1);
+    border-color: rgb(234, 179, 8);
+  }
+
+  .severity-risky .severity-badge {
+    background: rgba(234, 179, 8, 0.2);
+    color: rgb(234, 179, 8);
+  }
+
+  .severity-low-quality {
+    background: rgba(156, 163, 175, 0.1);
+    border-color: rgb(156, 163, 175);
+  }
+
+  .severity-low-quality .severity-badge {
+    background: rgba(156, 163, 175, 0.2);
+    color: rgb(156, 163, 175);
+  }
+</style>

--- a/packages/website/src/pages/docs/quickstart.astro
+++ b/packages/website/src/pages/docs/quickstart.astro
@@ -1,0 +1,724 @@
+---
+/**
+ * Skillsmith Quickstart Guide
+ * First-time user guide with two paths:
+ * 1. Happy Path: Claude Code + MCP Server (recommended)
+ * 2. Alternative: Direct CLI usage
+ */
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Quickstart | Skillsmith" description="Get started with Skillsmith in 5 minutes. Two ways to discover and install Claude Code skills.">
+  <!-- JSON-LD HowTo Schema -->
+  <script type="application/ld+json" slot="head">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "HowTo",
+        "name": "How to Set Up Skillsmith with Claude Code (Recommended)",
+        "description": "Install Skillsmith MCP server to discover and install Claude Code skills using natural language",
+        "totalTime": "PT5M",
+        "tool": [
+          {
+            "@type": "HowToTool",
+            "name": "Node.js 18+"
+          },
+          {
+            "@type": "HowToTool",
+            "name": "npm"
+          },
+          {
+            "@type": "HowToTool",
+            "name": "Claude Code"
+          }
+        ],
+        "step": [
+          {
+            "@type": "HowToStep",
+            "position": 1,
+            "name": "Install Claude Code",
+            "text": "Install Claude Code globally using npm: npm install -g @anthropic-ai/claude-code"
+          },
+          {
+            "@type": "HowToStep",
+            "position": 2,
+            "name": "Configure Skillsmith MCP Server",
+            "text": "Add Skillsmith to ~/.claude/settings.json: {\"mcpServers\": {\"skillsmith\": {\"command\": \"npx\", \"args\": [\"-y\", \"@skillsmith/mcp-server\"]}}}"
+          },
+          {
+            "@type": "HowToStep",
+            "position": 3,
+            "name": "Discover Skills",
+            "text": "Navigate to your project directory, start Claude Code with 'claude', and ask: 'What skills would be helpful for this project?'"
+          }
+        ]
+      },
+      {
+        "@type": "HowTo",
+        "name": "How to Use Skillsmith CLI Directly",
+        "description": "Install and use the Skillsmith CLI for skill discovery and installation from any terminal",
+        "totalTime": "PT5M",
+        "tool": [
+          {
+            "@type": "HowToTool",
+            "name": "Node.js 18+"
+          },
+          {
+            "@type": "HowToTool",
+            "name": "npm"
+          }
+        ],
+        "step": [
+          {
+            "@type": "HowToStep",
+            "position": 1,
+            "name": "Install Skillsmith CLI",
+            "text": "Install globally: npm install -g @skillsmith/cli. Or use npx: npx @skillsmith/cli search testing"
+          },
+          {
+            "@type": "HowToStep",
+            "position": 2,
+            "name": "Navigate to Project",
+            "text": "Open terminal and navigate to your project directory where package.json is located"
+          },
+          {
+            "@type": "HowToStep",
+            "position": 3,
+            "name": "Search for Skills",
+            "text": "Search by keyword: skillsmith search testing. Or get recommendations: skillsmith recommend"
+          },
+          {
+            "@type": "HowToStep",
+            "position": 4,
+            "name": "Install Skills",
+            "text": "Install a skill: skillsmith install jest-helper. Skills are installed to ~/.claude/skills/"
+          }
+        ]
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is the recommended way to use Skillsmith?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The recommended way is to use Claude Code with the Skillsmith MCP server. This allows you to discover and install skills using natural language, like asking 'Find skills for this React project' or 'Install the commit helper skill'."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Where are skills installed?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Skills are installed to ~/.claude/skills/ and are automatically available in all your Claude Code sessions."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can I use Skillsmith without Claude Code?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes, you can use the Skillsmith CLI directly in any terminal. Install with 'npm install -g @skillsmith/cli' or use npx without installing."
+            }
+          }
+        ]
+      }
+    ]
+  }
+  </script>
+
+  <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+    <!-- Header -->
+    <div class="mb-12">
+      <h1 class="text-4xl font-bold text-white mb-4">Quickstart Guide</h1>
+      <p class="text-dark-300 text-lg">
+        Get Skillsmith running in 5 minutes. Choose your preferred workflow below.
+      </p>
+    </div>
+
+    <!-- Prerequisites -->
+    <section class="mb-12">
+      <h2 class="text-2xl font-bold text-white mb-4">Before You Begin</h2>
+      <div class="bg-dark-900 border border-dark-700 rounded-lg p-6">
+        <p class="text-dark-300 mb-4">Make sure you have:</p>
+        <ul class="space-y-2 text-dark-300">
+          <li class="flex items-center gap-2">
+            <svg class="w-5 h-5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            </svg>
+            <span><strong class="text-white">Node.js 18+</strong> installed (<code class="text-sm bg-dark-800 px-1.5 py-0.5 rounded">node --version</code> to check)</span>
+          </li>
+          <li class="flex items-center gap-2">
+            <svg class="w-5 h-5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            </svg>
+            <span><strong class="text-white">npm</strong> or another package manager</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Choose Your Path -->
+    <section class="mb-12">
+      <h2 class="text-2xl font-bold text-white mb-6">Choose Your Workflow</h2>
+
+      <div class="grid md:grid-cols-2 gap-6">
+        <!-- Path A: Claude Code -->
+        <a href="#path-claude-code" class="block bg-gradient-to-br from-primary-900/30 to-purple-900/30 border-2 border-primary-500/50 rounded-xl p-6 hover:border-primary-400 transition-colors">
+          <div class="flex items-center gap-3 mb-3">
+            <div class="w-10 h-10 bg-primary-500/20 rounded-lg flex items-center justify-center">
+              <svg class="w-5 h-5 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+              </svg>
+            </div>
+            <div>
+              <span class="text-xs font-semibold uppercase tracking-wider text-primary-400">Recommended</span>
+              <h3 class="text-lg font-bold text-white">Claude Code + MCP</h3>
+            </div>
+          </div>
+          <p class="text-dark-300 text-sm mb-4">
+            Use natural language to discover and install skills. Just ask Claude!
+          </p>
+          <ul class="text-sm text-dark-400 space-y-1">
+            <li>• "Find skills for this React project"</li>
+            <li>• "Install the commit helper skill"</li>
+            <li>• "What testing skills do you recommend?"</li>
+          </ul>
+        </a>
+
+        <!-- Path B: CLI -->
+        <a href="#path-cli" class="block bg-dark-900 border border-dark-700 rounded-xl p-6 hover:border-dark-500 transition-colors">
+          <div class="flex items-center gap-3 mb-3">
+            <div class="w-10 h-10 bg-dark-800 rounded-lg flex items-center justify-center">
+              <svg class="w-5 h-5 text-dark-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+            </div>
+            <div>
+              <span class="text-xs font-semibold uppercase tracking-wider text-dark-500">Alternative</span>
+              <h3 class="text-lg font-bold text-white">Direct CLI</h3>
+            </div>
+          </div>
+          <p class="text-dark-300 text-sm mb-4">
+            Use traditional command-line tools in any terminal.
+          </p>
+          <ul class="text-sm text-dark-400 space-y-1">
+            <li>• <code class="text-xs">skillsmith search testing</code></li>
+            <li>• <code class="text-xs">skillsmith install jest-helper</code></li>
+            <li>• <code class="text-xs">skillsmith list</code></li>
+          </ul>
+        </a>
+      </div>
+    </section>
+
+    <!-- Divider -->
+    <hr class="border-dark-700 my-12" />
+
+    <!-- PATH A: Claude Code + MCP -->
+    <section id="path-claude-code" class="mb-16 scroll-mt-8">
+      <div class="flex items-center gap-3 mb-6">
+        <div class="w-8 h-8 bg-primary-500 rounded-full flex items-center justify-center text-white font-bold">A</div>
+        <h2 class="text-2xl font-bold text-white">Using Claude Code (Recommended)</h2>
+      </div>
+
+      <div class="bg-primary-900/10 border border-primary-800/30 rounded-lg p-4 mb-8">
+        <p class="text-primary-300 text-sm">
+          <strong>What is Claude Code?</strong> Claude Code is Anthropic's official CLI tool that lets you chat with Claude directly in your terminal. Skillsmith integrates with Claude Code via MCP (Model Context Protocol), giving Claude the ability to search and install skills for you.
+        </p>
+      </div>
+
+      <!-- Step 1: Install Claude Code -->
+      <div class="mb-8">
+        <h3 class="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <span class="w-6 h-6 bg-dark-800 rounded-full flex items-center justify-center text-sm">1</span>
+          Install Claude Code (if not already installed)
+        </h3>
+
+        <!-- Platform Tabs -->
+        <div class="bg-dark-900 border border-dark-700 rounded-lg overflow-hidden">
+          <div class="flex border-b border-dark-700">
+            <button class="platform-tab active px-4 py-2 text-sm font-medium" data-platform="mac">macOS</button>
+            <button class="platform-tab px-4 py-2 text-sm font-medium" data-platform="windows">Windows</button>
+            <button class="platform-tab px-4 py-2 text-sm font-medium" data-platform="linux">Linux</button>
+          </div>
+
+          <div class="p-4">
+            <div class="platform-content" data-platform="mac">
+              <pre class="bg-dark-950 rounded p-3 overflow-x-auto"><code class="text-sm text-dark-200"># Install via npm (recommended)
+npm install -g @anthropic-ai/claude-code
+
+# Or via Homebrew
+brew install claude-code</code></pre>
+            </div>
+            <div class="platform-content hidden" data-platform="windows">
+              <pre class="bg-dark-950 rounded p-3 overflow-x-auto"><code class="text-sm text-dark-200"># Install via npm (requires Node.js)
+npm install -g @anthropic-ai/claude-code
+
+# Or download the installer from:
+# https://claude.ai/download</code></pre>
+            </div>
+            <div class="platform-content hidden" data-platform="linux">
+              <pre class="bg-dark-950 rounded p-3 overflow-x-auto"><code class="text-sm text-dark-200"># Install via npm
+npm install -g @anthropic-ai/claude-code
+
+# Or via the install script
+curl -fsSL https://claude.ai/install.sh | sh</code></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Step 2: Configure Skillsmith MCP -->
+      <div class="mb-8">
+        <h3 class="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <span class="w-6 h-6 bg-dark-800 rounded-full flex items-center justify-center text-sm">2</span>
+          Add Skillsmith MCP Server
+        </h3>
+
+        <p class="text-dark-300 mb-4">
+          Add Skillsmith to your Claude Code configuration. This is a one-time setup.
+        </p>
+
+        <!-- Platform Tabs for config -->
+        <div class="bg-dark-900 border border-dark-700 rounded-lg overflow-hidden">
+          <div class="flex border-b border-dark-700">
+            <button class="config-tab active px-4 py-2 text-sm font-medium" data-config="mac">macOS / Linux</button>
+            <button class="config-tab px-4 py-2 text-sm font-medium" data-config="windows">Windows</button>
+          </div>
+
+          <div class="p-4">
+            <div class="config-content" data-config="mac">
+              <p class="text-dark-400 text-sm mb-3">Edit <code class="bg-dark-800 px-1.5 py-0.5 rounded">~/.claude/settings.json</code>:</p>
+              <pre class="bg-dark-950 rounded p-3 overflow-x-auto"><code class="text-sm text-dark-200">{`{
+  "mcpServers": {
+    "skillsmith": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"]
+    }
+  }
+}`}</code></pre>
+            </div>
+            <div class="config-content hidden" data-config="windows">
+              <p class="text-dark-400 text-sm mb-3">Edit <code class="bg-dark-800 px-1.5 py-0.5 rounded">%USERPROFILE%\.claude\settings.json</code>:</p>
+              <pre class="bg-dark-950 rounded p-3 overflow-x-auto"><code class="text-sm text-dark-200">{`{
+  "mcpServers": {
+    "skillsmith": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"]
+    }
+  }
+}`}</code></pre>
+              <p class="text-dark-500 text-xs mt-2">Tip: Open with <code class="bg-dark-800 px-1 rounded">notepad %USERPROFILE%\.claude\settings.json</code></p>
+            </div>
+          </div>
+        </div>
+
+        <p class="text-dark-400 text-sm mt-3">
+          After saving, restart Claude Code to load Skillsmith.
+        </p>
+      </div>
+
+      <!-- Step 3: Use It -->
+      <div class="mb-8">
+        <h3 class="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <span class="w-6 h-6 bg-dark-800 rounded-full flex items-center justify-center text-sm">3</span>
+          Discover Skills for Your Project
+        </h3>
+
+        <p class="text-dark-300 mb-4">
+          Navigate to your project directory and start Claude Code:
+        </p>
+
+        <pre class="bg-dark-900 border border-dark-700 rounded-lg p-4 overflow-x-auto mb-4"><code class="text-sm text-dark-200">cd /path/to/your/project
+claude</code></pre>
+
+        <p class="text-dark-300 mb-4">
+          Now just ask Claude to find skills for your project:
+        </p>
+
+        <div class="bg-dark-900 border border-dark-700 rounded-lg p-4">
+          <div class="space-y-4">
+            <div class="flex gap-3">
+              <div class="w-8 h-8 bg-blue-500/20 rounded-full flex items-center justify-center flex-shrink-0">
+                <span class="text-blue-400 text-sm font-bold">You</span>
+              </div>
+              <div class="bg-dark-800 rounded-lg px-4 py-2 text-dark-200">
+                "What skills would be helpful for this project?"
+              </div>
+            </div>
+            <div class="flex gap-3">
+              <div class="w-8 h-8 bg-purple-500/20 rounded-full flex items-center justify-center flex-shrink-0">
+                <span class="text-purple-400 text-xs font-bold">AI</span>
+              </div>
+              <div class="bg-dark-800 rounded-lg px-4 py-3 text-dark-300 text-sm">
+                <p class="mb-2">Based on your package.json, I can see this is a React project with Jest. Here are some recommended skills:</p>
+                <ul class="list-disc list-inside space-y-1 text-dark-400">
+                  <li><strong class="text-white">community/jest-helper</strong> - Enhanced Jest testing workflows</li>
+                  <li><strong class="text-white">community/react-patterns</strong> - React best practices</li>
+                  <li><strong class="text-white">verified/commit</strong> - Smart commit messages</li>
+                </ul>
+                <p class="mt-2">Would you like me to install any of these?</p>
+              </div>
+            </div>
+            <div class="flex gap-3">
+              <div class="w-8 h-8 bg-blue-500/20 rounded-full flex items-center justify-center flex-shrink-0">
+                <span class="text-blue-400 text-sm font-bold">You</span>
+              </div>
+              <div class="bg-dark-800 rounded-lg px-4 py-2 text-dark-200">
+                "Yes, install the jest-helper skill"
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Success Box -->
+      <div class="bg-green-900/20 border border-green-700/50 rounded-lg p-6">
+        <h4 class="text-green-400 font-semibold mb-2 flex items-center gap-2">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          </svg>
+          You're all set!
+        </h4>
+        <p class="text-dark-300 text-sm">
+          Skills are installed to <code class="bg-dark-800 px-1.5 py-0.5 rounded text-xs">~/.claude/skills/</code> and automatically available in all your Claude Code sessions.
+        </p>
+      </div>
+    </section>
+
+    <!-- Divider -->
+    <hr class="border-dark-700 my-12" />
+
+    <!-- PATH B: Direct CLI -->
+    <section id="path-cli" class="mb-16 scroll-mt-8">
+      <div class="flex items-center gap-3 mb-6">
+        <div class="w-8 h-8 bg-dark-600 rounded-full flex items-center justify-center text-white font-bold">B</div>
+        <h2 class="text-2xl font-bold text-white">Using the CLI Directly</h2>
+      </div>
+
+      <div class="bg-yellow-900/20 border border-yellow-700/50 rounded-lg p-4 mb-8">
+        <p class="text-yellow-300 text-sm">
+          <strong>When to use this:</strong> Use the CLI if you prefer traditional command-line tools, want to script skill management, or are not using Claude Code.
+        </p>
+      </div>
+
+      <!-- Step 1: Install CLI -->
+      <div class="mb-8">
+        <h3 class="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <span class="w-6 h-6 bg-dark-800 rounded-full flex items-center justify-center text-sm">1</span>
+          Install the Skillsmith CLI
+        </h3>
+
+        <div class="bg-dark-900 border border-dark-700 rounded-lg overflow-hidden">
+          <div class="flex border-b border-dark-700">
+            <button class="cli-tab active px-4 py-2 text-sm font-medium" data-cli="global">Global Install</button>
+            <button class="cli-tab px-4 py-2 text-sm font-medium" data-cli="npx">npx (No Install)</button>
+          </div>
+
+          <div class="p-4">
+            <div class="cli-content" data-cli="global">
+              <pre class="bg-dark-950 rounded p-3 overflow-x-auto"><code class="text-sm text-dark-200"># Install globally
+npm install -g @skillsmith/cli
+
+# Verify installation
+skillsmith --version</code></pre>
+              <p class="text-dark-500 text-xs mt-2">After this, <code class="bg-dark-800 px-1 rounded">skillsmith</code> command is available everywhere.</p>
+            </div>
+            <div class="cli-content hidden" data-cli="npx">
+              <pre class="bg-dark-950 rounded p-3 overflow-x-auto"><code class="text-sm text-dark-200"># Run without installing (downloads on first use)
+npx @skillsmith/cli search testing
+
+# Short alias
+npx sklx search testing</code></pre>
+              <p class="text-dark-500 text-xs mt-2">Use <code class="bg-dark-800 px-1 rounded">npx</code> to run without global installation.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Step 2: Navigate to Project -->
+      <div class="mb-8">
+        <h3 class="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <span class="w-6 h-6 bg-dark-800 rounded-full flex items-center justify-center text-sm">2</span>
+          Navigate to Your Project
+        </h3>
+
+        <p class="text-dark-300 mb-4">
+          Open your terminal and navigate to your project directory:
+        </p>
+
+        <div class="bg-dark-900 border border-dark-700 rounded-lg overflow-hidden">
+          <div class="flex border-b border-dark-700">
+            <button class="nav-tab active px-4 py-2 text-sm font-medium" data-nav="mac">macOS / Linux</button>
+            <button class="nav-tab px-4 py-2 text-sm font-medium" data-nav="windows">Windows</button>
+          </div>
+
+          <div class="p-4">
+            <div class="nav-content" data-nav="mac">
+              <pre class="bg-dark-950 rounded p-3 overflow-x-auto"><code class="text-sm text-dark-200"># Navigate to your project
+cd ~/projects/my-react-app
+
+# Verify you're in the right place
+ls package.json</code></pre>
+            </div>
+            <div class="nav-content hidden" data-nav="windows">
+              <pre class="bg-dark-950 rounded p-3 overflow-x-auto"><code class="text-sm text-dark-200"># Navigate to your project
+cd C:\Users\YourName\projects\my-react-app
+
+# Verify you're in the right place
+dir package.json</code></pre>
+            </div>
+          </div>
+        </div>
+
+        <div class="bg-dark-800 border border-dark-600 rounded-lg p-4 mt-4">
+          <p class="text-dark-300 text-sm">
+            <strong class="text-white">Why navigate here?</strong> Skillsmith can analyze your project's <code class="bg-dark-700 px-1 rounded">package.json</code>, dependencies, and file structure to recommend relevant skills.
+          </p>
+        </div>
+      </div>
+
+      <!-- Step 3: Search for Skills -->
+      <div class="mb-8">
+        <h3 class="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <span class="w-6 h-6 bg-dark-800 rounded-full flex items-center justify-center text-sm">3</span>
+          Search for Skills
+        </h3>
+
+        <pre class="bg-dark-900 border border-dark-700 rounded-lg p-4 overflow-x-auto mb-4"><code class="text-sm text-dark-200"># Search by keyword
+skillsmith search testing
+
+# Search with filters
+skillsmith search react --category development
+skillsmith search git --tier verified
+
+# Get recommendations for current project
+skillsmith recommend</code></pre>
+
+        <p class="text-dark-400 text-sm">
+          The <code class="bg-dark-800 px-1.5 py-0.5 rounded">recommend</code> command analyzes your project and suggests relevant skills.
+        </p>
+      </div>
+
+      <!-- Step 4: Install Skills -->
+      <div class="mb-8">
+        <h3 class="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <span class="w-6 h-6 bg-dark-800 rounded-full flex items-center justify-center text-sm">4</span>
+          Install Skills
+        </h3>
+
+        <pre class="bg-dark-900 border border-dark-700 rounded-lg p-4 overflow-x-auto mb-4"><code class="text-sm text-dark-200"># Install by skill name
+skillsmith install jest-helper
+
+# Install by full ID
+skillsmith install community/react-patterns
+
+# Install multiple skills
+skillsmith install jest-helper commit react-patterns</code></pre>
+      </div>
+
+      <!-- Step 5: Verify -->
+      <div class="mb-8">
+        <h3 class="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+          <span class="w-6 h-6 bg-dark-800 rounded-full flex items-center justify-center text-sm">5</span>
+          Verify Installation
+        </h3>
+
+        <pre class="bg-dark-900 border border-dark-700 rounded-lg p-4 overflow-x-auto mb-4"><code class="text-sm text-dark-200"># List installed skills
+skillsmith list
+
+# Show skill details
+skillsmith info jest-helper</code></pre>
+      </div>
+
+      <!-- Success Box -->
+      <div class="bg-green-900/20 border border-green-700/50 rounded-lg p-6">
+        <h4 class="text-green-400 font-semibold mb-2 flex items-center gap-2">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          </svg>
+          Skills Installed!
+        </h4>
+        <p class="text-dark-300 text-sm">
+          Skills are installed to <code class="bg-dark-800 px-1.5 py-0.5 rounded text-xs">~/.claude/skills/</code>. They'll be automatically available when you use Claude Code.
+        </p>
+      </div>
+    </section>
+
+    <!-- CLI Quick Reference -->
+    <section class="mb-12">
+      <h2 class="text-2xl font-bold text-white mb-6">CLI Quick Reference</h2>
+
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm border-collapse">
+          <thead>
+            <tr class="border-b border-dark-700">
+              <th class="text-left py-3 pr-4 text-white font-semibold">Command</th>
+              <th class="text-left py-3 text-white font-semibold">Description</th>
+            </tr>
+          </thead>
+          <tbody class="text-dark-300">
+            <tr class="border-b border-dark-800">
+              <td class="py-3 pr-4"><code class="text-primary-400">skillsmith search &lt;query&gt;</code></td>
+              <td class="py-3">Search for skills</td>
+            </tr>
+            <tr class="border-b border-dark-800">
+              <td class="py-3 pr-4"><code class="text-primary-400">skillsmith install &lt;skill&gt;</code></td>
+              <td class="py-3">Install a skill</td>
+            </tr>
+            <tr class="border-b border-dark-800">
+              <td class="py-3 pr-4"><code class="text-primary-400">skillsmith uninstall &lt;skill&gt;</code></td>
+              <td class="py-3">Remove a skill</td>
+            </tr>
+            <tr class="border-b border-dark-800">
+              <td class="py-3 pr-4"><code class="text-primary-400">skillsmith list</code></td>
+              <td class="py-3">List installed skills</td>
+            </tr>
+            <tr class="border-b border-dark-800">
+              <td class="py-3 pr-4"><code class="text-primary-400">skillsmith recommend</code></td>
+              <td class="py-3">Get project-based recommendations</td>
+            </tr>
+            <tr class="border-b border-dark-800">
+              <td class="py-3 pr-4"><code class="text-primary-400">skillsmith info &lt;skill&gt;</code></td>
+              <td class="py-3">Show skill details</td>
+            </tr>
+            <tr class="border-b border-dark-800">
+              <td class="py-3 pr-4"><code class="text-primary-400">skillsmith --help</code></td>
+              <td class="py-3">Show all commands</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Troubleshooting -->
+    <section class="mb-12">
+      <h2 class="text-2xl font-bold text-white mb-6">Troubleshooting</h2>
+
+      <div class="space-y-4">
+        <details class="bg-dark-900 border border-dark-700 rounded-lg">
+          <summary class="px-4 py-3 cursor-pointer text-white font-medium hover:bg-dark-800 rounded-lg transition-colors">
+            "skillsmith: command not found"
+          </summary>
+          <div class="px-4 pb-4 text-dark-300 text-sm">
+            <p class="mb-2">The CLI isn't installed globally or isn't in your PATH.</p>
+            <p class="mb-2"><strong class="text-white">Solution:</strong></p>
+            <pre class="bg-dark-950 rounded p-2 overflow-x-auto"><code># Reinstall globally
+npm install -g @skillsmith/cli
+
+# Or use npx instead
+npx @skillsmith/cli search testing</code></pre>
+          </div>
+        </details>
+
+        <details class="bg-dark-900 border border-dark-700 rounded-lg">
+          <summary class="px-4 py-3 cursor-pointer text-white font-medium hover:bg-dark-800 rounded-lg transition-colors">
+            Claude Code doesn't show Skillsmith tools
+          </summary>
+          <div class="px-4 pb-4 text-dark-300 text-sm">
+            <p class="mb-2">The MCP server isn't configured or Claude Code needs to restart.</p>
+            <p class="mb-2"><strong class="text-white">Solution:</strong></p>
+            <ol class="list-decimal list-inside space-y-1">
+              <li>Verify <code class="bg-dark-800 px-1 rounded">~/.claude/settings.json</code> has the skillsmith configuration</li>
+              <li>Restart Claude Code completely (quit and reopen)</li>
+              <li>Ask Claude: "List available MCP tools"</li>
+            </ol>
+          </div>
+        </details>
+
+        <details class="bg-dark-900 border border-dark-700 rounded-lg">
+          <summary class="px-4 py-3 cursor-pointer text-white font-medium hover:bg-dark-800 rounded-lg transition-colors">
+            "Permission denied" when installing skills
+          </summary>
+          <div class="px-4 pb-4 text-dark-300 text-sm">
+            <p class="mb-2">The skills directory doesn't exist or has wrong permissions.</p>
+            <p class="mb-2"><strong class="text-white">Solution:</strong></p>
+            <pre class="bg-dark-950 rounded p-2 overflow-x-auto"><code># Create the directory with correct permissions
+mkdir -p ~/.claude/skills
+chmod 755 ~/.claude/skills</code></pre>
+          </div>
+        </details>
+
+        <details class="bg-dark-900 border border-dark-700 rounded-lg">
+          <summary class="px-4 py-3 cursor-pointer text-white font-medium hover:bg-dark-800 rounded-lg transition-colors">
+            Skills installed but not showing in Claude Code
+          </summary>
+          <div class="px-4 pb-4 text-dark-300 text-sm">
+            <p class="mb-2">Claude Code may need to refresh its skill cache.</p>
+            <p class="mb-2"><strong class="text-white">Solution:</strong></p>
+            <ol class="list-decimal list-inside space-y-1">
+              <li>Verify skills are in <code class="bg-dark-800 px-1 rounded">~/.claude/skills/</code></li>
+              <li>Start a new Claude Code session</li>
+              <li>Skills should appear automatically</li>
+            </ol>
+          </div>
+        </details>
+      </div>
+    </section>
+
+    <!-- Next Steps -->
+    <section>
+      <h2 class="text-2xl font-bold text-white mb-6">Next Steps</h2>
+
+      <div class="grid md:grid-cols-3 gap-4">
+        <a href="/skills" class="block bg-dark-900 border border-dark-700 rounded-lg p-5 hover:border-primary-500/50 transition-colors">
+          <h3 class="text-white font-semibold mb-2">Browse Skills</h3>
+          <p class="text-dark-400 text-sm">Explore available skills by category and trust tier.</p>
+        </a>
+        <a href="/docs/cli" class="block bg-dark-900 border border-dark-700 rounded-lg p-5 hover:border-primary-500/50 transition-colors">
+          <h3 class="text-white font-semibold mb-2">CLI Reference</h3>
+          <p class="text-dark-400 text-sm">Complete documentation for all CLI commands.</p>
+        </a>
+        <a href="/docs/mcp-server" class="block bg-dark-900 border border-dark-700 rounded-lg p-5 hover:border-primary-500/50 transition-colors">
+          <h3 class="text-white font-semibold mb-2">MCP Server</h3>
+          <p class="text-dark-400 text-sm">Advanced configuration for the MCP integration.</p>
+        </a>
+      </div>
+    </section>
+  </div>
+
+  <script is:inline>
+    // Tab switching functionality
+    function setupTabs(tabClass, contentClass) {
+      document.querySelectorAll(`.${tabClass}`).forEach(tab => {
+        tab.addEventListener('click', () => {
+          const platform = tab.dataset.platform || tab.dataset.config || tab.dataset.cli || tab.dataset.nav;
+          const group = tab.parentElement;
+
+          // Update active tab
+          group.querySelectorAll(`.${tabClass}`).forEach(t => t.classList.remove('active'));
+          tab.classList.add('active');
+
+          // Show corresponding content
+          const contentContainer = group.parentElement.querySelector('.p-4') || group.nextElementSibling;
+          contentContainer.querySelectorAll(`.${contentClass}`).forEach(c => c.classList.add('hidden'));
+          contentContainer.querySelector(`.${contentClass}[data-platform="${platform}"], .${contentClass}[data-config="${platform}"], .${contentClass}[data-cli="${platform}"], .${contentClass}[data-nav="${platform}"]`)?.classList.remove('hidden');
+        });
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      setupTabs('platform-tab', 'platform-content');
+      setupTabs('config-tab', 'config-content');
+      setupTabs('cli-tab', 'cli-content');
+      setupTabs('nav-tab', 'nav-content');
+    });
+  </script>
+
+  <style>
+    .platform-tab, .config-tab, .cli-tab, .nav-tab {
+      color: #6b7280;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -1px;
+    }
+    .platform-tab:hover, .config-tab:hover, .cli-tab:hover, .nav-tab:hover {
+      color: #d1d5db;
+    }
+    .platform-tab.active, .config-tab.active, .cli-tab.active, .nav-tab.active {
+      color: #38bdf8;
+      border-bottom-color: #38bdf8;
+    }
+  </style>
+</BaseLayout>

--- a/packages/website/src/pages/docs/security.astro
+++ b/packages/website/src/pages/docs/security.astro
@@ -1,0 +1,365 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Security" description="Learn how Skillsmith protects your Claude Code environment through security scanning and trust verification">
+  <h1>Security</h1>
+
+  <p class="lead">
+    Skillsmith protects your Claude Code environment through automated security scanning,
+    trust verification, and a multi-tier defense system.
+  </p>
+
+  <h2>Security Boundaries</h2>
+
+  <p>Skillsmith operates within a layered security model:</p>
+
+  <div class="security-zones">
+    <div class="zone zone-trusted">
+      <h4>Trusted Zone</h4>
+      <ul>
+        <li>Claude model safety guardrails</li>
+        <li>Claude Code runtime sandbox</li>
+        <li>OS-level file access controls</li>
+      </ul>
+    </div>
+
+    <div class="zone zone-semi-trusted">
+      <h4>Semi-Trusted Zone (Skillsmith)</h4>
+      <ul>
+        <li>Curated skill index</li>
+        <li>Quality scoring</li>
+        <li>Static security analysis</li>
+        <li>Trust tier verification</li>
+        <li>Conflict detection</li>
+      </ul>
+    </div>
+
+    <div class="zone zone-untrusted">
+      <h4>Untrusted Zone</h4>
+      <ul>
+        <li>GitHub repositories</li>
+        <li>Third-party skill authors</li>
+        <li>Community registries</li>
+      </ul>
+    </div>
+  </div>
+
+  <h2>What We Scan For</h2>
+
+  <p>Every skill is scanned for security issues before being made available. Findings are categorized by severity:</p>
+
+  <h3>Critical Severity (Blocks Installation)</h3>
+
+  <p>These patterns <strong>always block installation</strong>:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th>Detected Patterns</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Jailbreak Attempts</strong></td>
+        <td>
+          <code>"ignore previous instructions"</code>,
+          <code>"developer mode"</code>,
+          <code>"bypass safety"</code>,
+          <code>"act as an AI without restrictions"</code>
+        </td>
+      </tr>
+      <tr>
+        <td><strong>Malicious URLs</strong></td>
+        <td>External domains not on the allowlist (github.com, anthropic.com, claude.ai are allowed)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>High Severity (Requires Confirmation)</h3>
+
+  <p>These patterns require explicit user confirmation before proceeding:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th>Detected Patterns</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>SSRF Patterns</strong></td>
+        <td>
+          <code>file://</code>, <code>gopher://</code>, <code>ldap://</code> protocols,
+          localhost references, private IP ranges
+        </td>
+      </tr>
+      <tr>
+        <td><strong>Sensitive File Access</strong></td>
+        <td>
+          <code>*.env*</code>, <code>*.pem</code>, <code>*.key</code>,
+          <code>*credentials*</code>, <code>*secrets*</code>
+        </td>
+      </tr>
+      <tr>
+        <td><strong>Dangerous Commands</strong></td>
+        <td>
+          <code>rm -rf</code>, <code>curl</code>/<code>wget</code> to unknown domains,
+          <code>eval</code>/<code>exec</code> with dynamic input
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Medium Severity (Warning Only)</h3>
+
+  <p>These patterns generate warnings but don't block installation:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th>Detected Patterns</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Obfuscation</strong></td>
+        <td>High entropy content, possible base64 payloads, unusual character sequences</td>
+      </tr>
+      <tr>
+        <td><strong>Permission Keywords</strong></td>
+        <td>References to sudo, root, admin, system modification commands</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Threat Model</h2>
+
+  <p>Skillsmith actively mitigates the following threats:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Threat</th>
+        <th>Severity</th>
+        <th>Mitigation</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Malicious SKILL.md</td>
+        <td>Critical</td>
+        <td>Pattern scanning, trust tiers</td>
+        <td><span class="badge badge-active">Active</span></td>
+      </tr>
+      <tr>
+        <td>Prompt injection</td>
+        <td>Critical</td>
+        <td>Pattern detection, entropy analysis</td>
+        <td><span class="badge badge-active">Active</span></td>
+      </tr>
+      <tr>
+        <td>Typosquatting</td>
+        <td>High</td>
+        <td>Levenshtein distance, character substitution detection</td>
+        <td><span class="badge badge-active">Active</span></td>
+      </tr>
+      <tr>
+        <td>Dependency hijacking</td>
+        <td>Medium</td>
+        <td>URL allowlist</td>
+        <td><span class="badge badge-active">Active</span></td>
+      </tr>
+      <tr>
+        <td>Author key compromise</td>
+        <td>Medium</td>
+        <td>Anomaly detection</td>
+        <td><span class="badge badge-planned">Planned</span></td>
+      </tr>
+      <tr>
+        <td>Supply chain attack</td>
+        <td>High</td>
+        <td>Registry signing</td>
+        <td><span class="badge badge-planned">Planned</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Best Practices for Users</h2>
+
+  <div class="callout">
+    <h4>1. Always Check Trust Tier</h4>
+    <p>
+      Before installing a skill, verify its <a href="/docs/trust-tiers">trust tier</a>:
+    </p>
+    <ul>
+      <li><strong>Official/Verified</strong>: Generally safe for production use</li>
+      <li><strong>Community</strong>: Review skill content before installing</li>
+      <li><strong>Unverified</strong>: Only install if you personally trust the author</li>
+    </ul>
+  </div>
+
+  <div class="callout">
+    <h4>2. Review Unverified Skills</h4>
+    <p>For unverified skills, always check:</p>
+    <ul>
+      <li>Read the SKILL.md content for suspicious instructions</li>
+      <li>Look for unusual URLs or command patterns</li>
+      <li>Check the author's GitHub profile and other projects</li>
+    </ul>
+  </div>
+
+  <div class="callout">
+    <h4>3. Use Validation Before Manual Install</h4>
+    <p>
+      Use <code>skillsmith validate &lt;path&gt;</code> to run security scans on locally-downloaded skills.
+    </p>
+  </div>
+
+  <div class="callout">
+    <h4>4. Keep Skillsmith Updated</h4>
+    <p>
+      New security patterns are added regularly. Update with:
+      <code>npx @skillsmith/mcp-server@latest</code>
+    </p>
+  </div>
+
+  <h2>Best Practices for Authors</h2>
+
+  <p>To ensure your skill passes security scans:</p>
+
+  <ol>
+    <li><strong>Avoid external URLs</strong> unless necessary. Prefer documented APIs (github.com, npm registry)</li>
+    <li><strong>Never request sensitive file access</strong>. Don't read .env files or credential stores</li>
+    <li><strong>Be explicit about permissions</strong>. Document what files you read/write and what commands you execute</li>
+    <li><strong>Submit for verification</strong>. Verified skills get more visibility and trust. See <a href="/docs/trust-tiers">Trust Tiers</a></li>
+  </ol>
+
+  <h2>What Happens When Scans Fail</h2>
+
+  <p>
+    Skills that fail security scans are placed in <a href="/docs/quarantine">quarantine</a>.
+    The severity of findings determines what happens next:
+  </p>
+
+  <ul>
+    <li><strong>Critical findings</strong>: Skill cannot be installed</li>
+    <li><strong>High findings</strong>: Manual review required before installation allowed</li>
+    <li><strong>Medium findings</strong>: Skill can be installed with warnings displayed</li>
+  </ul>
+
+  <p>
+    <a href="/docs/quarantine">Learn more about the quarantine system &rarr;</a>
+  </p>
+
+  <h2>Reporting Security Issues</h2>
+
+  <h3>Vulnerabilities in Skillsmith</h3>
+
+  <p>If you discover a vulnerability in Skillsmith itself:</p>
+
+  <ul>
+    <li>Email: <a href="mailto:security@skillsmith.app">security@skillsmith.app</a></li>
+    <li>GitHub: <a href="https://github.com/Smith-Horn-Group/skillsmith/security/advisories" target="_blank" rel="noopener noreferrer">Security Advisories</a></li>
+  </ul>
+
+  <h3>Malicious Skills</h3>
+
+  <p>To report a malicious or suspicious skill:</p>
+
+  <ul>
+    <li>Open an issue on <a href="https://github.com/Smith-Horn-Group/skillsmith/issues" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+    <li>Include the skill ID and specific concern</li>
+    <li>We investigate and blocklist within 24 hours</li>
+  </ul>
+
+  <h2>Related Documentation</h2>
+
+  <ul>
+    <li><a href="/docs/trust-tiers">Trust Tiers</a> - Understand skill verification levels</li>
+    <li><a href="/docs/quarantine">Quarantine System</a> - What happens to flagged skills</li>
+    <li><a href="/privacy">Privacy Policy</a> - How we handle your data</li>
+  </ul>
+</DocsLayout>
+
+<style>
+  .security-zones {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin: 1.5rem 0;
+  }
+
+  .zone {
+    padding: 1rem 1.5rem;
+    border-radius: 0.5rem;
+    border-left: 4px solid;
+  }
+
+  .zone h4 {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .zone ul {
+    margin: 0;
+    padding-left: 1.25rem;
+    font-size: 0.9rem;
+  }
+
+  .zone li {
+    margin: 0.25rem 0;
+  }
+
+  .zone-trusted {
+    background: rgba(34, 197, 94, 0.1);
+    border-color: rgb(34, 197, 94);
+  }
+
+  .zone-trusted h4 {
+    color: rgb(34, 197, 94);
+  }
+
+  .zone-semi-trusted {
+    background: rgba(234, 179, 8, 0.1);
+    border-color: rgb(234, 179, 8);
+  }
+
+  .zone-semi-trusted h4 {
+    color: rgb(234, 179, 8);
+  }
+
+  .zone-untrusted {
+    background: rgba(239, 68, 68, 0.1);
+    border-color: rgb(239, 68, 68);
+  }
+
+  .zone-untrusted h4 {
+    color: rgb(239, 68, 68);
+  }
+
+  .badge {
+    display: inline-block;
+    padding: 0.125rem 0.5rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+
+  .badge-active {
+    background: rgba(34, 197, 94, 0.2);
+    color: rgb(34, 197, 94);
+  }
+
+  .badge-planned {
+    background: rgba(156, 163, 175, 0.2);
+    color: rgb(156, 163, 175);
+  }
+</style>

--- a/packages/website/src/pages/docs/trust-tiers.astro
+++ b/packages/website/src/pages/docs/trust-tiers.astro
@@ -1,0 +1,445 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Trust Tiers" description="Understand Skillsmith's four-tier trust system for evaluating skill safety and quality">
+  <h1>Trust Tiers</h1>
+
+  <p class="lead">
+    Skillsmith uses a four-tier trust system to help you evaluate skill safety before installation.
+    Each tier represents a different level of verification and review.
+  </p>
+
+  <h2>Tier Overview</h2>
+
+  <div class="tier-grid">
+    <div class="tier-card tier-official">
+      <div class="tier-badge">
+        <svg class="tier-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span>Official</span>
+      </div>
+      <p>Anthropic or partner skills</p>
+      <ul>
+        <li>Auto-install: Yes</li>
+        <li>Review required: No</li>
+      </ul>
+    </div>
+
+    <div class="tier-card tier-verified">
+      <div class="tier-badge">
+        <svg class="tier-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+        </svg>
+        <span>Verified</span>
+      </div>
+      <p>Publisher verified, quality checked</p>
+      <ul>
+        <li>Auto-install: Yes</li>
+        <li>Review required: No</li>
+      </ul>
+    </div>
+
+    <div class="tier-card tier-community">
+      <div class="tier-badge">
+        <svg class="tier-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="12" cy="12" r="10" />
+        </svg>
+        <span>Community</span>
+      </div>
+      <p>Basic scan passed, metadata present</p>
+      <ul>
+        <li>Auto-install: No</li>
+        <li>Review required: Recommended</li>
+      </ul>
+    </div>
+
+    <div class="tier-card tier-unverified">
+      <div class="tier-badge">
+        <svg class="tier-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+        <span>Unverified</span>
+      </div>
+      <p>No verification performed</p>
+      <ul>
+        <li>Auto-install: No</li>
+        <li>Review required: Required</li>
+      </ul>
+    </div>
+  </div>
+
+  <h2>Official Tier</h2>
+
+  <div class="tier-detail">
+    <h3>What It Means</h3>
+    <p>
+      Published by Anthropic or trusted partners. These skills undergo a full security review
+      and are maintained with the highest standards.
+    </p>
+
+    <h3>Requirements</h3>
+    <ul>
+      <li>Published under <code>anthropic/</code> namespace</li>
+      <li>Full code review by Anthropic security team</li>
+      <li>Cryptographic signing (planned)</li>
+      <li>Automatic updates deployed</li>
+    </ul>
+
+    <h3>Examples</h3>
+    <p>
+      <code>anthropic/varlock</code>, <code>anthropic/commit</code>, <code>anthropic/governance</code>
+    </p>
+
+    <h3>When to Install</h3>
+    <p>
+      <strong>Always safe.</strong> These skills are maintained by Anthropic and suitable for any environment,
+      including production and enterprise use.
+    </p>
+  </div>
+
+  <h2>Verified Tier</h2>
+
+  <div class="tier-detail">
+    <h3>What It Means</h3>
+    <p>
+      Publisher identity is verified, and the skill meets quality and age requirements.
+      The author is accountable for the skill's behavior.
+    </p>
+
+    <h3>Requirements</h3>
+    <ul>
+      <li>Publisher identity verified via GitHub OAuth</li>
+      <li>Automated security scan passed with no critical/high findings</li>
+      <li>Minimum 10 GitHub stars</li>
+      <li>Published for at least 30 days</li>
+      <li>Has valid LICENSE file</li>
+      <li>Complete README and SKILL.md</li>
+    </ul>
+
+    <h3>Verification Process</h3>
+    <ol>
+      <li>Publisher submits verification request</li>
+      <li>Automated security scan runs</li>
+      <li>Identity verification via GitHub</li>
+      <li>Manual review for edge cases</li>
+      <li>Verified badge granted (renewable annually)</li>
+    </ol>
+
+    <h3>When to Install</h3>
+    <p>
+      <strong>Generally safe.</strong> The publisher is accountable for the skill.
+      Suitable for production use in most cases.
+    </p>
+  </div>
+
+  <h2>Community Tier</h2>
+
+  <div class="tier-detail">
+    <h3>What It Means</h3>
+    <p>
+      The skill passed basic security scans and has required metadata, but the publisher
+      identity has not been verified.
+    </p>
+
+    <h3>Requirements</h3>
+    <ul>
+      <li>Security scan passed (no critical findings)</li>
+      <li>Valid SKILL.md with proper frontmatter</li>
+      <li>Has LICENSE file</li>
+      <li>Has README.md</li>
+      <li>No blocklist matches</li>
+    </ul>
+
+    <h3>What Community Tier Does NOT Guarantee</h3>
+    <ul class="warning-list">
+      <li>Publisher identity</li>
+      <li>Code quality</li>
+      <li>Ongoing maintenance</li>
+      <li>Absence of subtle security issues</li>
+    </ul>
+
+    <h3>When to Install</h3>
+    <p>
+      <strong>Review first.</strong> Check the author's GitHub profile and other projects.
+      Read the SKILL.md content before installing.
+    </p>
+  </div>
+
+  <h2>Unverified Tier</h2>
+
+  <div class="tier-detail">
+    <h3>What It Means</h3>
+    <p>
+      No verification has been performed. The skill may be newly published, failed a security scan,
+      or the author hasn't submitted for verification.
+    </p>
+
+    <h3>Why a Skill Might Be Unverified</h3>
+    <ul>
+      <li>Just published (hasn't been scanned yet)</li>
+      <li>Failed security scan</li>
+      <li>Missing required files (LICENSE, README)</li>
+      <li>Author hasn't submitted for verification</li>
+      <li><a href="/docs/quarantine">Quarantined</a> for suspicious activity</li>
+    </ul>
+
+    <h3>When to Install</h3>
+    <p>
+      <strong>Only if you personally trust the author</strong> or you've manually reviewed all code.
+      Installation requires explicit confirmation:
+    </p>
+
+    <pre><code>{`This skill is unverified. Are you sure you want to install? (y/N)`}</code></pre>
+  </div>
+
+  <h2>Getting Verified</h2>
+
+  <p>To upgrade your skill from Community to Verified:</p>
+
+  <ol>
+    <li>
+      <strong>Ensure requirements are met</strong>
+      <ul>
+        <li>Security scan passes with no critical/high findings</li>
+        <li>At least 10 GitHub stars</li>
+        <li>Published for at least 30 days</li>
+        <li>Complete LICENSE, README, and SKILL.md</li>
+      </ul>
+    </li>
+    <li>
+      <strong>Submit verification request</strong>
+      <p>Visit <a href="https://skillsmith.app/verify">skillsmith.app/verify</a> to start the process</p>
+    </li>
+    <li>
+      <strong>Complete identity verification</strong>
+      <p>Authenticate with your GitHub account to verify publisher identity</p>
+    </li>
+    <li>
+      <strong>Wait for review</strong>
+      <p>Typical review time is 2-5 business days</p>
+    </li>
+    <li>
+      <strong>Maintain verification</strong>
+      <p>Verified status is renewable annually and can be revoked if issues arise</p>
+    </li>
+  </ol>
+
+  <h2>Tier Transitions</h2>
+
+  <h3>Upgrades</h3>
+  <p>Skills can upgrade tiers by meeting higher requirements:</p>
+  <ul>
+    <li><strong>Unverified → Community</strong>: Pass basic security scan, add required metadata</li>
+    <li><strong>Community → Verified</strong>: Submit verification request, meet all Verified requirements</li>
+  </ul>
+
+  <h3>Downgrades</h3>
+  <p>Skills can be downgraded if:</p>
+  <ul>
+    <li>Security scan fails on update</li>
+    <li>Publisher verification expires</li>
+    <li>Reports of malicious behavior</li>
+    <li>Author requests removal</li>
+  </ul>
+
+  <h2>Filtering by Trust Tier</h2>
+
+  <p>Use the <code>--tier</code> filter when searching to find skills at specific trust levels:</p>
+
+  <h3>Using Claude (MCP)</h3>
+
+  <pre><code>{`"Find verified testing skills"
+"Show only official skills"
+"Search for community git helpers"`}</code></pre>
+
+  <h3>Using the CLI</h3>
+
+  <pre><code>{`# Find verified skills only
+skillsmith search testing --tier verified
+
+# Find official Anthropic skills
+skillsmith search --tier official
+
+# Exclude unverified skills
+skillsmith search git --tier community,verified,official`}</code></pre>
+
+  <h2>Recommendations by Use Case</h2>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Scenario</th>
+        <th>Recommended Minimum Tier</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Production code</td>
+        <td><span class="tier-badge-inline tier-verified">Verified</span> or <span class="tier-badge-inline tier-official">Official</span></td>
+      </tr>
+      <tr>
+        <td>Personal projects</td>
+        <td><span class="tier-badge-inline tier-community">Community</span> or higher</td>
+      </tr>
+      <tr>
+        <td>Experimentation</td>
+        <td>Any (with review)</td>
+      </tr>
+      <tr>
+        <td>Enterprise / Regulated</td>
+        <td><span class="tier-badge-inline tier-official">Official</span> only</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Trust Tier in API Responses</h2>
+
+  <p>The <code>get_skill</code> tool returns detailed trust information:</p>
+
+  <pre><code>{`{
+  "id": "community/jest-helper",
+  "trustTier": "verified",
+  "publisherVerified": true,
+  "scanPassed": true,
+  "scanDate": "2026-01-10",
+  "stars": 47,
+  "publishedDays": 89
+}`}</code></pre>
+
+  <h2>Questions?</h2>
+
+  <ul>
+    <li><strong>How do I get verified?</strong> Visit <a href="https://skillsmith.app/verify">skillsmith.app/verify</a></li>
+    <li><strong>Report a suspicious skill:</strong> <a href="mailto:security@skillsmith.app">security@skillsmith.app</a></li>
+    <li><strong>Request tier review:</strong> <a href="mailto:support@skillsmith.app">support@skillsmith.app</a></li>
+  </ul>
+
+  <h2>Related Documentation</h2>
+
+  <ul>
+    <li><a href="/docs/security">Security Model</a> - How security scanning works</li>
+    <li><a href="/docs/quarantine">Quarantine System</a> - What happens to flagged skills</li>
+    <li><a href="/docs/cli">CLI Reference</a> - Search and filter commands</li>
+  </ul>
+</DocsLayout>
+
+<style>
+  .tier-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin: 1.5rem 0;
+  }
+
+  .tier-card {
+    padding: 1.25rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+    background: var(--color-bg-secondary, rgba(255, 255, 255, 0.02));
+  }
+
+  .tier-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+    font-weight: 600;
+  }
+
+  .tier-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .tier-card p {
+    font-size: 0.9rem;
+    color: var(--color-text-muted, #9ca3af);
+    margin: 0 0 0.75rem 0;
+  }
+
+  .tier-card ul {
+    margin: 0;
+    padding-left: 1rem;
+    font-size: 0.85rem;
+  }
+
+  .tier-card li {
+    margin: 0.25rem 0;
+  }
+
+  .tier-official {
+    border-color: rgba(34, 197, 94, 0.3);
+  }
+
+  .tier-official .tier-badge {
+    color: rgb(34, 197, 94);
+  }
+
+  .tier-verified {
+    border-color: rgba(59, 130, 246, 0.3);
+  }
+
+  .tier-verified .tier-badge {
+    color: rgb(59, 130, 246);
+  }
+
+  .tier-community {
+    border-color: rgba(234, 179, 8, 0.3);
+  }
+
+  .tier-community .tier-badge {
+    color: rgb(234, 179, 8);
+  }
+
+  .tier-unverified {
+    border-color: rgba(239, 68, 68, 0.3);
+  }
+
+  .tier-unverified .tier-badge {
+    color: rgb(239, 68, 68);
+  }
+
+  .tier-detail {
+    margin: 1.5rem 0 2.5rem 0;
+    padding-left: 1rem;
+    border-left: 3px solid var(--color-border, rgba(255, 255, 255, 0.1));
+  }
+
+  .tier-detail h3 {
+    font-size: 1rem;
+    margin-top: 1.25rem;
+  }
+
+  .tier-detail h3:first-child {
+    margin-top: 0;
+  }
+
+  .warning-list li {
+    color: rgb(234, 179, 8);
+  }
+
+  .tier-badge-inline {
+    display: inline-block;
+    padding: 0.125rem 0.5rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+
+  .tier-badge-inline.tier-official {
+    background: rgba(34, 197, 94, 0.2);
+    color: rgb(34, 197, 94);
+  }
+
+  .tier-badge-inline.tier-verified {
+    background: rgba(59, 130, 246, 0.2);
+    color: rgb(59, 130, 246);
+  }
+
+  .tier-badge-inline.tier-community {
+    background: rgba(234, 179, 8, 0.2);
+    color: rgb(234, 179, 8);
+  }
+</style>


### PR DESCRIPTION
## Summary
- Restored 9 documentation pages that were lost during a rebase operation
- Recovered from `feature/brand-audit` branch and reflog commit `3f51d3d`
- Fixes 404 errors on all `/docs/*` routes

## Pages Restored
| Page | Source |
|------|--------|
| `api.astro` | `feature/brand-audit` |
| `cli.astro` | `feature/brand-audit` |
| `getting-started.astro` | `feature/brand-audit` |
| `index.astro` | `feature/brand-audit` |
| `mcp-server.astro` | `feature/brand-audit` |
| `quickstart.astro` | `feature/brand-audit` |
| `quarantine.astro` | reflog `3f51d3d` |
| `security.astro` | reflog `3f51d3d` |
| `trust-tiers.astro` | reflog `3f51d3d` |

## Test plan
- [ ] Verify https://skillsmith.app/docs loads after deploy
- [ ] Verify https://skillsmith.app/docs/api loads after deploy
- [ ] Verify all sidebar navigation links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)