### PR TITLE
fix(website): enable SSR for signup page to read tier query param

### DIFF
--- a/packages/website/src/pages/signup.astro
+++ b/packages/website/src/pages/signup.astro
@@ -3,6 +3,7 @@
  * Skillsmith Signup Page
  *
  * SMI-1071: Website Integration - Signup Page with Stripe Checkout
+ * SMI-1700: Enable SSR to read tier query parameter dynamically
  *
  * Reads query parameters:
  * - tier: 'community' | 'individual' | 'team' | 'enterprise'
@@ -11,6 +12,9 @@
  * For paid tiers, initiates Stripe checkout.
  * For community tier, shows free signup form.
  */
+
+// Disable prerendering - this page needs SSR to read query params
+export const prerender = false;
 
 import { PRICING_TIERS } from '../lib/pricing.ts';
 


### PR DESCRIPTION
## Summary

The signup page was prerendered at build time with `output: 'static'`, causing the `?tier=` query parameter to be ignored. All tier variations showed the default Community tier.

**Root Cause:** Astro's static output prerenders pages at build time, so query params are not available.

**Fix:** Add `export const prerender = false` to enable server-side rendering.

## Test Plan

After deployment, verify:
- [ ] `/signup?tier=team` shows Team tier ($25/user/mo) with Stripe checkout
- [ ] `/signup?tier=individual` shows Individual tier ($9.99/mo) with Stripe checkout  
- [ ] `/signup?tier=community` shows Community tier ($0) with registration form
- [ ] `/signup` (no param) defaults to Community tier

Fixes SMI-1700

🤖 Generated with [Claude Code](https://claude.com/claude-code)