### PR TITLE
fix(website): apply prettier formatting to blog files

### DIFF
--- a/packages/website/src/content/config.ts
+++ b/packages/website/src/content/config.ts
@@ -1,4 +1,4 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection, z } from 'astro:content'
 
 /**
  * Blog collection schema
@@ -20,6 +20,6 @@ const blog = defineCollection({
     draft: z.boolean().default(false),
     ogImage: z.string().optional(),
   }),
-});
+})
 
-export const collections = { blog };
+export const collections = { blog }

--- a/packages/website/src/utils/blog.ts
+++ b/packages/website/src/utils/blog.ts
@@ -14,9 +14,9 @@
  * // Returns: 5 (for ~1000 words)
  */
 export function calculateReadingTime(content: string): number {
-  const wordsPerMinute = 200;
-  const words = content.split(/\s+/).length;
-  return Math.ceil(words / wordsPerMinute);
+  const wordsPerMinute = 200
+  const words = content.split(/\s+/).length
+  return Math.ceil(words / wordsPerMinute)
 }
 
 /**
@@ -37,5 +37,5 @@ export function formatDate(date: Date, format: 'short' | 'long' = 'long'): strin
     year: 'numeric',
     month: format,
     day: 'numeric',
-  }).format(date);
+  }).format(date)
 }


### PR DESCRIPTION
## Summary
- Remove semicolons from blog files per project Prettier configuration

## Test plan
- [x] `npx prettier --check` passes locally
- [ ] CI lint job passes

## Context
Fixes CI lint failure: https://github.com/smith-horn/skillsmith/actions/runs/21301720471

🤖 Generated with [Claude Code](https://claude.com/claude-code)