### PR TITLE
fix: Wave 4 - SkillDecomposer configurable keywords and test assertions (SMI-1816, SMI-1820)

### DIFF
--- a/packages/core/src/services/SkillDecomposer.ts
+++ b/packages/core/src/services/SkillDecomposer.ts
@@ -110,13 +110,36 @@ export interface DecomposerOptions {
 
   /** Whether to add "Optimized by Skillsmith" attribution (default: true) */
   addAttribution?: boolean
+
+  /**
+   * Keywords that indicate a section should be extracted as a sub-skill.
+   * Sections with titles containing these keywords will be candidates for extraction.
+   * @default ['api', 'reference', 'example', 'usage', 'advanced', 'configuration', 'troubleshoot', 'appendix']
+   */
+  extractKeywords?: string[]
 }
+
+/**
+ * Default keywords that indicate a section should be extracted as a sub-skill.
+ * These are used when no custom extractKeywords are provided.
+ */
+const DEFAULT_EXTRACT_KEYWORDS = [
+  'api',
+  'reference',
+  'example',
+  'usage',
+  'advanced',
+  'configuration',
+  'troubleshoot',
+  'appendix',
+]
 
 const DEFAULT_OPTIONS: Required<DecomposerOptions> = {
   maxMainSkillLines: 400,
   minExtractableLines: 50,
   addNavigation: true,
   addAttribution: true,
+  extractKeywords: DEFAULT_EXTRACT_KEYWORDS,
 }
 
 /**
@@ -303,17 +326,8 @@ function determineSectionsToExtract(
   // Create a map of section names from analysis for quick lookup
   const extractableNames = new Set(extractableSections.map((s) => s.name.toLowerCase()))
 
-  // Keywords that indicate a section should be extracted
-  const extractKeywords = [
-    'api',
-    'reference',
-    'example',
-    'usage',
-    'advanced',
-    'configuration',
-    'troubleshoot',
-    'appendix',
-  ]
+  // Use configurable keywords (defaults provided via DEFAULT_OPTIONS)
+  const keywords = opts.extractKeywords ?? DEFAULT_EXTRACT_KEYWORDS
 
   for (const section of sections) {
     const lineCount = section.lines.length
@@ -330,7 +344,7 @@ function determineSectionsToExtract(
     // 3. Is a large section (>100 lines)
     const shouldExtract =
       extractableNames.has(titleLower) ||
-      extractKeywords.some((kw) => titleLower.includes(kw)) ||
+      keywords.some((kw) => titleLower.includes(kw)) ||
       lineCount > 100
 
     if (shouldExtract) {

--- a/packages/core/src/services/__tests__/TransformationService.test.ts
+++ b/packages/core/src/services/__tests__/TransformationService.test.ts
@@ -89,7 +89,9 @@ Task("agent3", "task 3")
       )
 
       expect(result.transformed).toBe(true)
-      expect(result.stats.tokenReductionPercent).toBeGreaterThan(0)
+      // Token reduction should be meaningful (>= 10%) but capped at 80%
+      expect(result.stats.tokenReductionPercent).toBeGreaterThanOrEqual(10)
+      expect(result.stats.tokenReductionPercent).toBeLessThanOrEqual(80)
       expect(result.analysis).toBeDefined()
     })
 


### PR DESCRIPTION
## Summary
Wave 4 of SMI-1810 code review fixes for SkillDecomposer and tests.

### Issues
- **SMI-1816**: Add extractKeywords option to DecomposerOptions interface
- **SMI-1820**: Add range bounds to tokenReductionPercent test assertions

### Changes
- Added `extractKeywords?: string[]` to `DecomposerOptions` with JSDoc
- Created `DEFAULT_EXTRACT_KEYWORDS` constant with 8 default keywords
- Updated test to assert tokenReductionPercent is between 10% and 80%

### Test plan
- [x] TypeScript builds without error
- [x] All 42 service tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)