### PR TITLE
feat(website): replace early access waitlist with live signup CTAs

### DIFF
--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -40,9 +40,15 @@
 
   <!-- Open Graph -->
   <meta property="og:title" content="Skillsmith - AI Skill Discovery for Claude Code" />
-  <meta property="og:description" content="Find the right Claude Code skills for your stack. 14,000+ curated skills, finally searchable." />
+  <meta property="og:description" content="Find the right Claude Code skills for your stack. 14,000+ curated skills, finally searchable. Get started for free." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://skillsmith.app" />
+  <!-- TODO: Add og:image once design creates /public/og-image.png (1200x630) -->
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Skillsmith - AI Skill Discovery for Claude Code" />
+  <meta name="twitter:description" content="Find the right Claude Code skills for your stack. 14,000+ curated skills, finally searchable. Get started for free." />
 
   <!-- JSON-LD Structured Data -->
   <script type="application/ld+json">
@@ -59,7 +65,7 @@
           "url": "https://skillsmith.app/logo-icon.svg"
         },
         "sameAs": [
-          "https://github.com/Smith-Horn-Group/skillsmith",
+          "https://github.com/smith-horn/skillsmith",
           "https://twitter.com/skillsmith"
         ]
       },
@@ -166,7 +172,7 @@
         <a href="/docs/api" class="text-[#A1A1AA] hover:text-[#E07A5F] transition-colors text-sm font-medium">
           API Docs
         </a>
-        <a href="/signup" class="px-4 py-2 bg-gradient-to-br from-[#E07A5F] to-[#D4694E] rounded-xl text-sm font-medium hover:scale-[1.02] transition-all">
+        <a href="/signup" class="px-4 py-2 bg-gradient-to-br from-[#E07A5F] to-[#D4694E] rounded-xl text-sm font-medium hover:scale-[1.02] transition-all focus-visible:ring-2 focus-visible:ring-[#E07A5F] focus-visible:outline-none">
           Get Started
         </a>
       </div>
@@ -191,13 +197,13 @@
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-6 opacity-0 animate-fade-up" style="animation-delay: 0.3s;">
         <a
           href="/signup"
-          class="px-8 py-4 bg-gradient-to-br from-[#E07A5F] to-[#D4694E] rounded-xl font-bold text-white shadow-cta hover:scale-[1.02] hover:shadow-[0_12px_40px_rgba(224,122,95,0.3)] active:scale-[0.98] transition-all text-center"
+          class="px-8 py-4 bg-gradient-to-br from-[#E07A5F] to-[#D4694E] rounded-xl font-bold text-white shadow-cta hover:scale-[1.02] hover:shadow-[0_12px_40px_rgba(224,122,95,0.3)] active:scale-[0.98] transition-all text-center focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0D0D0F] focus-visible:outline-none"
         >
           Get Started Free →
         </a>
         <a
           href="#mcp-install-block"
-          class="px-8 py-4 border border-white/10 rounded-xl font-medium text-white hover:border-white/20 transition-colors text-center"
+          class="px-8 py-4 border border-white/10 rounded-xl font-medium text-white hover:border-white/20 transition-colors text-center focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0D0D0F] focus-visible:outline-none"
         >
           Install MCP Server
         </a>
@@ -236,15 +242,15 @@
         <button
           type="button"
           id="copy-mcp-config"
-          class="absolute top-4 right-4 px-5 py-2.5 bg-[#E07A5F] hover:bg-[#D4694E] text-white text-sm font-semibold rounded-lg transition-all duration-200 flex items-center gap-2 shadow-lg hover:shadow-xl hover:scale-[1.02] active:scale-[0.98]"
+          class="absolute top-4 right-4 px-5 py-2.5 bg-[#E07A5F] hover:bg-[#D4694E] text-white text-sm font-semibold rounded-lg transition-all duration-200 flex items-center gap-2 shadow-lg hover:shadow-xl hover:scale-[1.02] active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0D0D0F] focus-visible:outline-none"
           aria-label="Copy configuration to clipboard"
         >
           <!-- Copy icon -->
-          <svg id="copy-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+          <svg id="copy-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
           </svg>
           <!-- Checkmark icon (hidden by default) -->
-          <svg id="check-icon" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+          <svg id="check-icon" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
           </svg>
           <span id="copy-text">Copy to Clipboard</span>
@@ -286,7 +292,7 @@
         <!-- Semantic Search -->
         <div class="text-center">
           <div class="w-12 h-12 mx-auto mb-4 flex items-center justify-center">
-            <svg class="w-8 h-8 text-[#E07A5F]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+            <svg class="w-8 h-8 text-[#E07A5F]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
               <path stroke-linecap="round" stroke-linejoin="round" d="M10 10l4 4" />
             </svg>
@@ -298,7 +304,7 @@
         <!-- Quality Scores -->
         <div class="text-center">
           <div class="w-12 h-12 mx-auto mb-4 flex items-center justify-center">
-            <svg class="w-8 h-8 text-[#E07A5F]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+            <svg class="w-8 h-8 text-[#E07A5F]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
             </svg>
           </div>
@@ -309,7 +315,7 @@
         <!-- Stack-Aware -->
         <div class="text-center">
           <div class="w-12 h-12 mx-auto mb-4 flex items-center justify-center">
-            <svg class="w-8 h-8 text-[#E07A5F]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+            <svg class="w-8 h-8 text-[#E07A5F]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
             </svg>
           </div>
@@ -320,7 +326,7 @@
         <!-- One-Click Install -->
         <div class="text-center">
           <div class="w-12 h-12 mx-auto mb-4 flex items-center justify-center">
-            <svg class="w-8 h-8 text-[#E07A5F]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+            <svg class="w-8 h-8 text-[#E07A5F]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
             </svg>
           </div>
@@ -403,13 +409,13 @@
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <a
           href="/signup"
-          class="px-8 py-4 bg-gradient-to-br from-[#E07A5F] to-[#D4694E] rounded-xl font-bold text-white shadow-cta hover:scale-[1.02] hover:shadow-[0_12px_40px_rgba(224,122,95,0.3)] active:scale-[0.98] transition-all text-center"
+          class="px-8 py-4 bg-gradient-to-br from-[#E07A5F] to-[#D4694E] rounded-xl font-bold text-white shadow-cta hover:scale-[1.02] hover:shadow-[0_12px_40px_rgba(224,122,95,0.3)] active:scale-[0.98] transition-all text-center focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0D0D0F] focus-visible:outline-none"
         >
           Create Free Account →
         </a>
         <a
           href="/pricing"
-          class="px-8 py-4 border border-white/10 rounded-xl font-medium text-white hover:border-white/20 transition-colors text-center"
+          class="px-8 py-4 border border-white/10 rounded-xl font-medium text-white hover:border-white/20 transition-colors text-center focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0D0D0F] focus-visible:outline-none"
         >
           View Pricing
         </a>


### PR DESCRIPTION
## Summary

- Replace homepage email capture forms with direct `/signup` CTA buttons
- Update all "early access" language to "get started free"
- Remove unused early-access form handler JavaScript (~100 lines)
- Add secondary CTAs for MCP install and pricing pages

## Changes

| Section | Before | After |
|---------|--------|-------|
| Nav button | "Get Early Access" → `#early-access-hero` | "Get Started" → `/signup` |
| Hero CTA | Email capture form | "Get Started Free" + "Install MCP Server" buttons |
| Social proof | "Early access now open" | "Free tier available — no credit card required" |
| Final CTA | Email capture form | "Create Free Account" + "View Pricing" buttons |
| Meta description | "Get early access" | "Get started for free" |

## Test plan

- [ ] Homepage loads without JavaScript errors
- [ ] "Get Started" nav button links to `/signup`
- [ ] Hero "Get Started Free" button links to `/signup`
- [ ] "Install MCP Server" scrolls to MCP section
- [ ] Final CTA "Create Free Account" links to `/signup`
- [ ] "View Pricing" links to `/pricing`
- [ ] Build passes: `docker exec skillsmith-dev-1 npm run build --workspace=@skillsmith/website`

## Related

- Part of Beta Definition of Done (Wave 1)
- Enables transition from waitlist to live product mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)