### PR TITLE
feat(privacy): add cookie consent banner and GA4 Consent Mode v2

### DIFF
--- a/packages/website/src/components/CookieConsent.astro
+++ b/packages/website/src/components/CookieConsent.astro
@@ -1,0 +1,135 @@
+---
+/**
+ * Cookie Consent Banner
+ *
+ * Implements GA4 Consent Mode v2. Analytics cookies are denied by default
+ * and only granted after the user clicks "Accept". The choice is persisted
+ * in localStorage under `skillsmith_cookie_consent`.
+ *
+ * Related: ADR-107, SMI-2453
+ */
+---
+
+<div id="cookie-consent" class="cookie-banner" role="dialog" aria-label="Cookie consent" hidden>
+  <div class="cookie-inner">
+    <p class="cookie-text">
+      We use cookies and Google Analytics to understand how you use Skillsmith and improve our service.
+      See our <a href="/privacy#cookies">Privacy Policy</a> for details.
+    </p>
+    <div class="cookie-actions">
+      <button type="button" id="cookie-reject" class="cookie-btn cookie-btn-reject">Decline</button>
+      <button type="button" id="cookie-accept" class="cookie-btn cookie-btn-accept">Accept</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .cookie-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 9999;
+    padding: 1rem;
+    pointer-events: none;
+  }
+
+  .cookie-inner {
+    max-width: 640px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    background: #1a1a1f;
+    border: 1px solid #2a2a2f;
+    border-radius: 0.75rem;
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
+    pointer-events: auto;
+  }
+
+  .cookie-text {
+    flex: 1;
+    font-size: 0.875rem;
+    color: #9ca3af;
+    line-height: 1.5;
+  }
+
+  .cookie-text a {
+    color: #E07A5F;
+    text-decoration: none;
+  }
+
+  .cookie-text a:hover {
+    text-decoration: underline;
+  }
+
+  .cookie-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+
+  .cookie-btn {
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    border: none;
+    transition: all 0.2s;
+    font-family: inherit;
+  }
+
+  .cookie-btn-reject {
+    background: transparent;
+    color: #9ca3af;
+    border: 1px solid #2a2a2f;
+  }
+
+  .cookie-btn-reject:hover {
+    border-color: #9ca3af;
+    color: #FAFAFA;
+  }
+
+  .cookie-btn-accept {
+    background: linear-gradient(135deg, #E07A5F 0%, #D4694E 100%);
+    color: white;
+  }
+
+  .cookie-btn-accept:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(224, 122, 95, 0.4);
+  }
+
+  @media (max-width: 640px) {
+    .cookie-inner {
+      flex-direction: column;
+      text-align: center;
+    }
+  }
+</style>
+
+<script is:inline>
+  (function () {
+    var consent = localStorage.getItem('skillsmith_cookie_consent');
+    if (consent) return; // Already made a choice
+
+    var banner = document.getElementById('cookie-consent');
+    if (!banner) return;
+    banner.hidden = false;
+
+    document.getElementById('cookie-accept').addEventListener('click', function () {
+      localStorage.setItem('skillsmith_cookie_consent', 'accepted');
+      if (typeof gtag === 'function') {
+        gtag('consent', 'update', { analytics_storage: 'granted' });
+      }
+      banner.hidden = true;
+    });
+
+    document.getElementById('cookie-reject').addEventListener('click', function () {
+      localStorage.setItem('skillsmith_cookie_consent', 'declined');
+      banner.hidden = true;
+    });
+  })();
+</script>

--- a/packages/website/src/layouts/BaseLayout.astro
+++ b/packages/website/src/layouts/BaseLayout.astro
@@ -13,6 +13,7 @@ import '../styles/global.css';
 import { ClientRouter } from 'astro:transitions';
 import Nav from '../components/Nav.astro';
 import RateLimitToast from '../components/RateLimitToast.astro';
+import CookieConsent from '../components/CookieConsent.astro';
 import { getSupabaseConfig } from '../lib/supabase-config';
 
 interface Props {
@@ -46,14 +47,23 @@ const supabaseConfig = getSupabaseConfig();
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" fetchpriority="low" />
 
-    <!-- Google Analytics (placed after fonts so font fetches get priority) -->
-    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L" fetchpriority="low"></script>
+    <!-- Google Analytics with Consent Mode v2 -->
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+      // Set default consent state BEFORE loading gtag.js
+      var consent = localStorage.getItem('skillsmith_cookie_consent');
+      gtag('consent', 'default', {
+        analytics_storage: consent === 'accepted' ? 'granted' : 'denied',
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+        wait_for_update: 500,
+      });
       gtag('js', new Date());
       gtag('config', 'G-GGZQZM1Y1L');
     </script>
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L" fetchpriority="low"></script>
 
     <!-- Open Graph -->
     <meta property="og:title" content={title} />
@@ -123,6 +133,9 @@ const supabaseConfig = getSupabaseConfig();
 
     <!-- SMI-2150: Rate limit toast for 429 errors -->
     <RateLimitToast />
+
+    <!-- Cookie consent banner (GA4 Consent Mode v2) -->
+    <CookieConsent />
 
     <!-- SMI-2344: Web Vitals RUM tracking (SMI-2363: shared module) -->
     <script>

--- a/packages/website/src/pages/privacy.astro
+++ b/packages/website/src/pages/privacy.astro
@@ -5,7 +5,7 @@
  */
 import BaseLayout from '../layouts/BaseLayout.astro';
 
-const lastUpdated = 'January 17, 2026';
+const lastUpdated = 'February 10, 2026';
 ---
 
 <BaseLayout title="Privacy Policy | Skillsmith" description="Privacy Policy for Skillsmith - Learn how we collect, use, and protect your data.">
@@ -117,6 +117,12 @@ const lastUpdated = 'January 17, 2026';
 
       <div class="space-y-4">
         <div class="bg-dark-900 border border-dark-700 rounded-lg p-4">
+          <h4 class="font-semibold text-white">Google Analytics</h4>
+          <p class="text-dark-400 text-sm">Website analytics and conversion measurement (GA4)</p>
+          <a href="https://policies.google.com/privacy" class="text-primary-400 text-sm hover:text-primary-300" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+        </div>
+
+        <div class="bg-dark-900 border border-dark-700 rounded-lg p-4">
           <h4 class="font-semibold text-white">Supabase</h4>
           <p class="text-dark-400 text-sm">Database and authentication services</p>
           <a href="https://supabase.com/privacy" class="text-primary-400 text-sm hover:text-primary-300" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
@@ -182,14 +188,15 @@ const lastUpdated = 'January 17, 2026';
     <!-- Section 6: Cookies and Tracking -->
     <section id="cookies" class="mb-12">
       <h2 class="text-2xl font-bold text-white mb-6">6. Cookies and Tracking</h2>
-      <p class="text-dark-300 mb-4">We use the following types of cookies:</p>
+      <p class="text-dark-300 mb-4">We use the following types of cookies and tracking technologies:</p>
 
-      <div class="overflow-x-auto">
+      <div class="overflow-x-auto mb-6">
         <table class="w-full text-left border-collapse">
           <thead>
             <tr class="border-b border-dark-700">
               <th class="py-3 pr-4 text-white font-semibold">Type</th>
               <th class="py-3 pr-4 text-white font-semibold">Purpose</th>
+              <th class="py-3 pr-4 text-white font-semibold">Provider</th>
               <th class="py-3 text-white font-semibold">Duration</th>
             </tr>
           </thead>
@@ -197,25 +204,62 @@ const lastUpdated = 'January 17, 2026';
             <tr class="border-b border-dark-800">
               <td class="py-3 pr-4">Essential</td>
               <td class="py-3 pr-4">Authentication and security</td>
+              <td class="py-3 pr-4">Supabase</td>
               <td class="py-3">Session</td>
             </tr>
             <tr class="border-b border-dark-800">
               <td class="py-3 pr-4">Functional</td>
-              <td class="py-3 pr-4">Remember preferences</td>
+              <td class="py-3 pr-4">Remember preferences and cookie consent choice</td>
+              <td class="py-3 pr-4">Skillsmith</td>
               <td class="py-3">1 year</td>
             </tr>
             <tr class="border-b border-dark-800">
               <td class="py-3 pr-4">Analytics</td>
-              <td class="py-3 pr-4">Usage statistics (anonymized)</td>
-              <td class="py-3">1 year</td>
+              <td class="py-3 pr-4">Page views, site navigation, and feature usage</td>
+              <td class="py-3 pr-4">Google Analytics (GA4)</td>
+              <td class="py-3">2 years</td>
+            </tr>
+            <tr class="border-b border-dark-800">
+              <td class="py-3 pr-4">Analytics</td>
+              <td class="py-3 pr-4">Conversion tracking (signup, checkout, purchase)</td>
+              <td class="py-3 pr-4">Google Analytics (GA4)</td>
+              <td class="py-3">2 years</td>
             </tr>
           </tbody>
         </table>
       </div>
 
-      <p class="text-dark-300 mt-4">
-        You can control cookies through your browser settings. Note that disabling certain cookies may
-        affect the functionality of our service.
+      <h3 class="text-xl font-semibold text-white mb-4">Google Analytics</h3>
+      <p class="text-dark-300 mb-4">
+        We use Google Analytics 4 (GA4) to understand how visitors interact with our website. This includes
+        tracking page views, navigation patterns, and conversion events (such as account registration, plan
+        selection, and checkout completion). Google Analytics collects data through cookies and associates it
+        with your browsing activity on our site.
+      </p>
+      <p class="text-dark-300 mb-4">
+        The information collected by Google Analytics is transmitted to and stored by Google on servers in the
+        United States. Google may use this data in accordance with its own
+        <a href="https://policies.google.com/privacy" class="text-primary-400 hover:text-primary-300" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.
+        We do not use Google Analytics for advertising purposes, and we have disabled data sharing with Google
+        for advertising.
+      </p>
+
+      <h3 class="text-xl font-semibold text-white mb-4">Your Cookie Choices</h3>
+      <p class="text-dark-300 mb-4">
+        When you first visit Skillsmith, a cookie consent banner gives you the choice to accept or decline
+        analytics cookies. Analytics cookies are <strong class="text-white">not set until you provide consent</strong>.
+        We use <a href="https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced" class="text-primary-400 hover:text-primary-300" target="_blank" rel="noopener noreferrer">Google Consent Mode v2</a>
+        to ensure your choice is respected.
+      </p>
+      <p class="text-dark-300 mb-4">You can change your cookie preferences at any time by:</p>
+      <ul class="list-disc list-inside text-dark-300 space-y-2 ml-4 mb-4">
+        <li>Clearing your browser's localStorage (which resets your consent choice and shows the banner again)</li>
+        <li>Using your browser's cookie settings to block cookies from <code class="text-primary-400">google-analytics.com</code></li>
+        <li>Installing the <a href="https://tools.google.com/dlpage/gaoptout" class="text-primary-400 hover:text-primary-300" target="_blank" rel="noopener noreferrer">Google Analytics Opt-out Browser Add-on</a></li>
+      </ul>
+      <p class="text-dark-300">
+        Essential cookies (authentication, security) are always active as they are necessary for the service
+        to function. Declining analytics cookies does not affect your ability to use Skillsmith.
       </p>
     </section>
 

--- a/packages/website/src/pages/signup/success.astro
+++ b/packages/website/src/pages/signup/success.astro
@@ -15,14 +15,22 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- Google Analytics -->
-    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L"></script>
+    <!-- Google Analytics with Consent Mode v2 -->
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+      var consent = localStorage.getItem('skillsmith_cookie_consent');
+      gtag('consent', 'default', {
+        analytics_storage: consent === 'accepted' ? 'granted' : 'denied',
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+        wait_for_update: 500,
+      });
       gtag('js', new Date());
       gtag('config', 'G-GGZQZM1Y1L');
     </script>
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L"></script>
 
     <meta name="description" content="Welcome to Skillsmith! Your subscription is now active." />
     <title>Welcome to Skillsmith!</title>
@@ -111,6 +119,38 @@
         <p>&copy; 2026 Smith Horn Group Ltd. All rights reserved.</p>
       </div>
     </footer>
+
+    <!-- Cookie consent banner (standalone page, not using BaseLayout) -->
+    <div id="cookie-consent" style="position:fixed;bottom:0;left:0;right:0;z-index:9999;padding:1rem;pointer-events:none" hidden>
+      <div style="max-width:640px;margin:0 auto;display:flex;align-items:center;gap:1rem;padding:1rem 1.5rem;background:#1a1a1f;border:1px solid #2a2a2f;border-radius:0.75rem;box-shadow:0 -4px 24px rgba(0,0,0,0.4);pointer-events:auto;font-family:'Satoshi',sans-serif">
+        <p style="flex:1;font-size:0.875rem;color:#9ca3af;line-height:1.5;margin:0">
+          We use cookies and Google Analytics to understand how you use Skillsmith.
+          See our <a href="/privacy#cookies" style="color:#E07A5F;text-decoration:none">Privacy Policy</a>.
+        </p>
+        <div style="display:flex;gap:0.5rem;flex-shrink:0">
+          <button id="cookie-reject" type="button" style="padding:0.5rem 1rem;font-size:0.875rem;font-weight:600;border-radius:0.375rem;cursor:pointer;background:transparent;color:#9ca3af;border:1px solid #2a2a2f;font-family:inherit">Decline</button>
+          <button id="cookie-accept" type="button" style="padding:0.5rem 1rem;font-size:0.875rem;font-weight:600;border-radius:0.375rem;cursor:pointer;background:linear-gradient(135deg,#E07A5F,#D4694E);color:white;border:none;font-family:inherit">Accept</button>
+        </div>
+      </div>
+    </div>
+    <script is:inline>
+      (function(){
+        var c=localStorage.getItem('skillsmith_cookie_consent');
+        if(c)return;
+        var b=document.getElementById('cookie-consent');
+        if(!b)return;
+        b.hidden=false;
+        document.getElementById('cookie-accept').addEventListener('click',function(){
+          localStorage.setItem('skillsmith_cookie_consent','accepted');
+          if(typeof gtag==='function')gtag('consent','update',{analytics_storage:'granted'});
+          b.hidden=true;
+        });
+        document.getElementById('cookie-reject').addEventListener('click',function(){
+          localStorage.setItem('skillsmith_cookie_consent','declined');
+          b.hidden=true;
+        });
+      })();
+    </script>
   </body>
 </html>
 


### PR DESCRIPTION
## Summary

- Add cookie consent banner with Accept/Decline buttons (CookieConsent component)
- Implement GA4 Consent Mode v2: `analytics_storage` denied by default, granted only after explicit user consent
- Update privacy policy: add Google Analytics as third-party service, expand cookies section with GA4 specifics, opt-out instructions, and Consent Mode v2 documentation
- Apply consent mode to standalone success.astro page

This satisfies the GA4 data collection acknowledgment requirement:
> "I acknowledge that I have the necessary privacy disclosures and rights from my end users for the collection and processing of their data."

## Test plan

- [ ] First visit shows cookie consent banner at bottom of page
- [ ] Clicking "Accept" hides banner and enables GA4 analytics cookies
- [ ] Clicking "Decline" hides banner, GA4 runs in cookieless mode
- [ ] Refreshing after a choice does not show banner again (localStorage persists)
- [ ] Clearing localStorage re-shows the banner
- [ ] `/privacy#cookies` section lists Google Analytics with details
- [ ] GA4 Realtime report shows events only after Accept
- [ ] Success page (`/signup/success`) also shows consent banner on first visit
- [ ] `astro check` passes with 0 errors/warnings/hints

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)