### PR TITLE
fix(privacy): Consent Mode v2 + cookie banner for standalone pages

### DIFF
--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -39,14 +39,22 @@ const supabaseConfig = getSupabaseConfig();
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" fetchpriority="low" />
 
-  <!-- Google Analytics (placed after fonts so font fetches get priority) -->
-  <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L" fetchpriority="low"></script>
+  <!-- Google Analytics with Consent Mode v2 -->
   <script is:inline>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
+    var consent = localStorage.getItem('skillsmith_cookie_consent');
+    gtag('consent', 'default', {
+      analytics_storage: consent === 'accepted' ? 'granted' : 'denied',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      wait_for_update: 500,
+    });
     gtag('js', new Date());
     gtag('config', 'G-GGZQZM1Y1L');
   </script>
+  <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L" fetchpriority="low"></script>
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/logo-icon.svg" />
@@ -78,12 +86,12 @@ const supabaseConfig = getSupabaseConfig();
     "@graph": [
       {
         "@type": "Organization",
-        "@id": "https://skillsmith.app/#organization",
+        "@id": "https://www.skillsmith.app/#organization",
         "name": "Smith Horn Group",
-        "url": "https://skillsmith.app",
+        "url": "https://www.skillsmith.app",
         "logo": {
           "@type": "ImageObject",
-          "url": "https://skillsmith.app/logo-icon.svg"
+          "url": "https://www.skillsmith.app/logo-icon.svg"
         },
         "sameAs": [
           "https://github.com/smith-horn/skillsmith"
@@ -91,12 +99,12 @@ const supabaseConfig = getSupabaseConfig();
       },
       {
         "@type": "WebSite",
-        "@id": "https://skillsmith.app/#website",
-        "url": "https://skillsmith.app",
+        "@id": "https://www.skillsmith.app/#website",
+        "url": "https://www.skillsmith.app",
         "name": "Skillsmith",
         "description": "AI-powered agent skill discovery and management",
         "publisher": {
-          "@id": "https://skillsmith.app/#organization"
+          "@id": "https://www.skillsmith.app/#organization"
         },
         "speakable": {
           "@type": "SpeakableSpecification",
@@ -105,14 +113,14 @@ const supabaseConfig = getSupabaseConfig();
       },
       {
         "@type": "SoftwareApplication",
-        "@id": "https://skillsmith.app/#software",
+        "@id": "https://www.skillsmith.app/#software",
         "name": "Skillsmith",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Cross-platform",
         "description": "Discover, install, and manage agent skills. 14,000+ curated skills with semantic search, quality scores, and stack-aware recommendations.",
-        "url": "https://skillsmith.app",
+        "url": "https://www.skillsmith.app",
         "author": {
-          "@id": "https://skillsmith.app/#organization"
+          "@id": "https://www.skillsmith.app/#organization"
         },
         "offers": [
           {
@@ -158,7 +166,7 @@ const supabaseConfig = getSupabaseConfig();
       },
       {
         "@type": "FAQPage",
-        "@id": "https://skillsmith.app/#faq",
+        "@id": "https://www.skillsmith.app/#faq",
         "mainEntity": [
           {
             "@type": "Question",
@@ -644,6 +652,38 @@ const supabaseConfig = getSupabaseConfig();
   <!-- SMI-2344: Web Vitals RUM tracking (SMI-2363: shared module) -->
   <script>
     import '../scripts/web-vitals';
+  </script>
+
+  <!-- Cookie consent banner (standalone page, not using BaseLayout) -->
+  <div id="cookie-consent" style="position:fixed;bottom:0;left:0;right:0;z-index:9999;padding:1rem;pointer-events:none" hidden>
+    <div style="max-width:640px;margin:0 auto;display:flex;align-items:center;gap:1rem;padding:1rem 1.5rem;background:#1a1a1f;border:1px solid #2a2a2f;border-radius:0.75rem;box-shadow:0 -4px 24px rgba(0,0,0,0.4);pointer-events:auto;font-family:'Satoshi',sans-serif">
+      <p style="flex:1;font-size:0.875rem;color:#9ca3af;line-height:1.5;margin:0">
+        We use cookies and Google Analytics to understand how you use Skillsmith.
+        See our <a href="/privacy#cookies" style="color:#E07A5F;text-decoration:none">Privacy Policy</a>.
+      </p>
+      <div style="display:flex;gap:0.5rem;flex-shrink:0">
+        <button id="cookie-reject" type="button" style="padding:0.5rem 1rem;font-size:0.875rem;font-weight:600;border-radius:0.375rem;cursor:pointer;background:transparent;color:#9ca3af;border:1px solid #2a2a2f;font-family:inherit">Decline</button>
+        <button id="cookie-accept" type="button" style="padding:0.5rem 1rem;font-size:0.875rem;font-weight:600;border-radius:0.375rem;cursor:pointer;background:linear-gradient(135deg,#E07A5F,#D4694E);color:white;border:none;font-family:inherit">Accept</button>
+      </div>
+    </div>
+  </div>
+  <script is:inline>
+    (function(){
+      var c=localStorage.getItem('skillsmith_cookie_consent');
+      if(c)return;
+      var b=document.getElementById('cookie-consent');
+      if(!b)return;
+      b.hidden=false;
+      document.getElementById('cookie-accept').addEventListener('click',function(){
+        localStorage.setItem('skillsmith_cookie_consent','accepted');
+        if(typeof gtag==='function')gtag('consent','update',{analytics_storage:'granted'});
+        b.hidden=true;
+      });
+      document.getElementById('cookie-reject').addEventListener('click',function(){
+        localStorage.setItem('skillsmith_cookie_consent','declined');
+        b.hidden=true;
+      });
+    })();
   </script>
 
   <!-- Fetch live skill count -->

--- a/packages/website/src/pages/login.astro
+++ b/packages/website/src/pages/login.astro
@@ -31,14 +31,22 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account';
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/logo-icon.svg" />
 
-    <!-- Google Analytics -->
-    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L"></script>
+    <!-- Google Analytics with Consent Mode v2 -->
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+      var consent = localStorage.getItem('skillsmith_cookie_consent');
+      gtag('consent', 'default', {
+        analytics_storage: consent === 'accepted' ? 'granted' : 'denied',
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+        wait_for_update: 500,
+      });
       gtag('js', new Date());
       gtag('config', 'G-GGZQZM1Y1L');
     </script>
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L"></script>
 
     <meta name="description" content="Sign in to your Skillsmith account to manage skills, view your subscription, and access your dashboard." />
     <title>Sign In | Skillsmith</title>
@@ -127,6 +135,38 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account';
         <p class="license-note">Licensed under <a href="https://www.elastic.co/licensing/elastic-license">Elastic License 2.0</a></p>
       </div>
     </footer>
+
+    <!-- Cookie consent banner (standalone page, not using BaseLayout) -->
+    <div id="cookie-consent" style="position:fixed;bottom:0;left:0;right:0;z-index:9999;padding:1rem;pointer-events:none" hidden>
+      <div style="max-width:640px;margin:0 auto;display:flex;align-items:center;gap:1rem;padding:1rem 1.5rem;background:#1a1a1f;border:1px solid #2a2a2f;border-radius:0.75rem;box-shadow:0 -4px 24px rgba(0,0,0,0.4);pointer-events:auto;font-family:'Satoshi',sans-serif">
+        <p style="flex:1;font-size:0.875rem;color:#9ca3af;line-height:1.5;margin:0">
+          We use cookies and Google Analytics to understand how you use Skillsmith.
+          See our <a href="/privacy#cookies" style="color:#E07A5F;text-decoration:none">Privacy Policy</a>.
+        </p>
+        <div style="display:flex;gap:0.5rem;flex-shrink:0">
+          <button id="cookie-reject" type="button" style="padding:0.5rem 1rem;font-size:0.875rem;font-weight:600;border-radius:0.375rem;cursor:pointer;background:transparent;color:#9ca3af;border:1px solid #2a2a2f;font-family:inherit">Decline</button>
+          <button id="cookie-accept" type="button" style="padding:0.5rem 1rem;font-size:0.875rem;font-weight:600;border-radius:0.375rem;cursor:pointer;background:linear-gradient(135deg,#E07A5F,#D4694E);color:white;border:none;font-family:inherit">Accept</button>
+        </div>
+      </div>
+    </div>
+    <script is:inline>
+      (function(){
+        var c=localStorage.getItem('skillsmith_cookie_consent');
+        if(c)return;
+        var b=document.getElementById('cookie-consent');
+        if(!b)return;
+        b.hidden=false;
+        document.getElementById('cookie-accept').addEventListener('click',function(){
+          localStorage.setItem('skillsmith_cookie_consent','accepted');
+          if(typeof gtag==='function')gtag('consent','update',{analytics_storage:'granted'});
+          b.hidden=true;
+        });
+        document.getElementById('cookie-reject').addEventListener('click',function(){
+          localStorage.setItem('skillsmith_cookie_consent','declined');
+          b.hidden=true;
+        });
+      })();
+    </script>
   </body>
 </html>
 

--- a/packages/website/src/pages/signup.astro
+++ b/packages/website/src/pages/signup.astro
@@ -50,14 +50,22 @@ const savingsPercent = period === 'annual' ? 17 : 0; // ~17% savings
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/logo-icon.svg" />
 
-    <!-- Google Analytics -->
-    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L"></script>
+    <!-- Google Analytics with Consent Mode v2 -->
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+      var consent = localStorage.getItem('skillsmith_cookie_consent');
+      gtag('consent', 'default', {
+        analytics_storage: consent === 'accepted' ? 'granted' : 'denied',
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+        wait_for_update: 500,
+      });
       gtag('js', new Date());
       gtag('config', 'G-GGZQZM1Y1L');
     </script>
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L"></script>
 
     <meta name="description" content={`Sign up for Skillsmith ${tierData?.name || ''} plan. ${tierData?.features[0] || 'AI-powered skill discovery for Claude Code.'}`} />
     <title>Sign Up{tierData ? ` - ${tierData.name}` : ''} | Skillsmith</title>
@@ -331,6 +339,38 @@ const savingsPercent = period === 'annual' ? 17 : 0; // ~17% savings
         <p class="license-note">Licensed under <a href="https://www.elastic.co/licensing/elastic-license">Elastic License 2.0</a></p>
       </div>
     </footer>
+
+    <!-- Cookie consent banner (standalone page, not using BaseLayout) -->
+    <div id="cookie-consent" style="position:fixed;bottom:0;left:0;right:0;z-index:9999;padding:1rem;pointer-events:none" hidden>
+      <div style="max-width:640px;margin:0 auto;display:flex;align-items:center;gap:1rem;padding:1rem 1.5rem;background:#1a1a1f;border:1px solid #2a2a2f;border-radius:0.75rem;box-shadow:0 -4px 24px rgba(0,0,0,0.4);pointer-events:auto;font-family:'Satoshi',sans-serif">
+        <p style="flex:1;font-size:0.875rem;color:#9ca3af;line-height:1.5;margin:0">
+          We use cookies and Google Analytics to understand how you use Skillsmith.
+          See our <a href="/privacy#cookies" style="color:#E07A5F;text-decoration:none">Privacy Policy</a>.
+        </p>
+        <div style="display:flex;gap:0.5rem;flex-shrink:0">
+          <button id="cookie-reject" type="button" style="padding:0.5rem 1rem;font-size:0.875rem;font-weight:600;border-radius:0.375rem;cursor:pointer;background:transparent;color:#9ca3af;border:1px solid #2a2a2f;font-family:inherit">Decline</button>
+          <button id="cookie-accept" type="button" style="padding:0.5rem 1rem;font-size:0.875rem;font-weight:600;border-radius:0.375rem;cursor:pointer;background:linear-gradient(135deg,#E07A5F,#D4694E);color:white;border:none;font-family:inherit">Accept</button>
+        </div>
+      </div>
+    </div>
+    <script is:inline>
+      (function(){
+        var c=localStorage.getItem('skillsmith_cookie_consent');
+        if(c)return;
+        var b=document.getElementById('cookie-consent');
+        if(!b)return;
+        b.hidden=false;
+        document.getElementById('cookie-accept').addEventListener('click',function(){
+          localStorage.setItem('skillsmith_cookie_consent','accepted');
+          if(typeof gtag==='function')gtag('consent','update',{analytics_storage:'granted'});
+          b.hidden=true;
+        });
+        document.getElementById('cookie-reject').addEventListener('click',function(){
+          localStorage.setItem('skillsmith_cookie_consent','declined');
+          b.hidden=true;
+        });
+      })();
+    </script>
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Adds GA4 Consent Mode v2 to homepage, login, and signup pages (standalone `<head>`, not using BaseLayout)
- Adds cookie consent banner to all 3 standalone pages (matching BaseLayout's CookieConsent component behavior)
- Normalizes JSON-LD URLs on homepage from `skillsmith.app` to `www.skillsmith.app` to match `astro.config.mjs` site URL

## Context
PR #100 added Consent Mode v2 and cookie consent to BaseLayout, but 3 standalone pages (index, login, signup) have their own `<head>` and were missed. Identified during code review of PR #101.

## Test plan
- [ ] Build passes with 0 errors, 0 warnings
- [ ] Homepage cookie consent banner appears on first visit (no localStorage key)
- [ ] Accepting sets `skillsmith_cookie_consent=accepted` and updates gtag consent
- [ ] Declining sets `skillsmith_cookie_consent=declined` and hides banner
- [ ] Login and signup pages show same consent banner behavior
- [ ] JSON-LD URLs on homepage all use `www.skillsmith.app`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)