### PR TITLE
fix(seo): add image to Product structured data (GSC critical)

### DIFF
--- a/packages/website/src/pages/pricing.astro
+++ b/packages/website/src/pages/pricing.astro
@@ -37,6 +37,7 @@ function generateJsonLd(tiers: PricingTier[], faqs: Array<{ question: string; an
         "@type": "Product",
         "name": "Skillsmith",
         "description": "AI-powered skill discovery and management for AI assistants",
+        "image": "https://www.skillsmith.app/og-image.png",
         "brand": { "@type": "Brand", "name": "Skillsmith" },
         "offers": tiers.map(tier => ({
           "@type": "Offer",


### PR DESCRIPTION
## Summary

- Adds `"image": "https://www.skillsmith.app/og-image.png"` to the Product schema on the pricing page
- Resolves the **critical** "Missing field image" warning from Google Search Console
- Required for Product rich results eligibility in SERPs

## Test plan

- [x] Pre-commit TypeScript check passes
- [ ] Validate with Google Rich Results Test post-deploy
- [ ] Monitor GSC — critical warning should clear after recrawl (24-48h)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)