### PR TITLE
fix(ci): resolve CodeQL advanced config conflict with default setup (SMI-2508)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,8 @@
 name: 'CodeQL'
 
+# SMI-2508: Advanced setup replaces default setup (disabled via API).
+# Covers both javascript-typescript and actions languages.
+
 on:
   push:
     branches: [main]
@@ -15,13 +18,13 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript-typescript']
+        language: ['javascript-typescript', 'actions']
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Disabled CodeQL default setup via GitHub API (`PATCH /code-scanning/default-setup`)
- Added `actions` language to the advanced workflow matrix to maintain full coverage
- Added SMI-2508 comment to workflow file for traceability

## Root Cause
PR #119 added `.github/workflows/codeql.yml` (advanced configuration) but the repo's default CodeQL setup was left enabled. GitHub rejects SARIF uploads from advanced configs when default setup is active:
```
CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled
```

## Changes
- `.github/workflows/codeql.yml`: Added `actions` to language matrix, improved job naming with `(${{ matrix.language }})`
- GitHub Settings: Default CodeQL setup disabled via API

## Test plan
- [ ] Verify `Analyze (javascript-typescript)` passes on this PR
- [ ] Verify `Analyze (actions)` passes on this PR
- [ ] Confirm no duplicate CodeQL runs after merge to main

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)