### PR TITLE
feat(seo): Wave 1 — URL normalization, dynamic pricing, blog dates

### DIFF
--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -29,13 +29,13 @@ skillsmith list
 
 ## Key Pages
 
-- [Home](https://skillsmith.app/): Product overview and features
-- [Quickstart](https://skillsmith.app/docs/quickstart): First-time setup guide with two paths (MCP client recommended, CLI alternative)
-- [Skills Browser](https://skillsmith.app/skills): Browse and search available skills
-- [Pricing](https://skillsmith.app/pricing): Four tiers - Community (free, 1k API calls), Individual ($9.99, 10k), Team ($25/user, 100k), Enterprise ($55/user, unlimited)
-- [CLI Reference](https://skillsmith.app/docs/cli): Complete CLI command documentation
-- [MCP Server](https://skillsmith.app/docs/mcp-server): MCP integration configuration
-- [API Reference](https://skillsmith.app/docs/api): REST API documentation
+- [Home](https://www.skillsmith.app/): Product overview and features
+- [Quickstart](https://www.skillsmith.app/docs/quickstart): First-time setup guide with two paths (MCP client recommended, CLI alternative)
+- [Skills Browser](https://www.skillsmith.app/skills): Browse and search available skills
+- [Pricing](https://www.skillsmith.app/pricing): Four tiers - Community (free, 1k API calls), Individual ($9.99, 10k), Team ($25/user, 100k), Enterprise ($55/user, unlimited)
+- [CLI Reference](https://www.skillsmith.app/docs/cli): Complete CLI command documentation
+- [MCP Server](https://www.skillsmith.app/docs/mcp-server): MCP integration configuration
+- [API Reference](https://www.skillsmith.app/docs/api): REST API documentation
 
 ## What Are Skills?
 
@@ -99,9 +99,9 @@ Elastic License 2.0 (ELv2)
 
 ## Contact
 
-- Website: https://skillsmith.app
+- Website: https://www.skillsmith.app
 - GitHub: https://github.com/smith-horn/skillsmith
-- Contact: https://skillsmith.app/contact
+- Contact: https://www.skillsmith.app/contact
 
 ## Frequently Asked Questions
 
@@ -119,7 +119,7 @@ A: Add the Skillsmith MCP server to your settings.json, then ask your assistant 
 
 ## Optional
 
-- Logo: https://skillsmith.app/logo-icon.svg
-- Changelog: https://skillsmith.app/changelog
-- Terms: https://skillsmith.app/terms
-- Privacy: https://skillsmith.app/privacy
+- Logo: https://www.skillsmith.app/logo-icon.svg
+- Changelog: https://www.skillsmith.app/changelog
+- Terms: https://www.skillsmith.app/terms
+- Privacy: https://www.skillsmith.app/privacy

--- a/packages/website/public/robots.txt
+++ b/packages/website/public/robots.txt
@@ -57,4 +57,4 @@ Allow: /
 Sitemap: https://www.skillsmith.app/sitemap-index.xml
 
 # LLMs.txt - AI-specific site information
-# See: https://skillsmith.app/llms.txt
+# See: https://www.skillsmith.app/llms.txt

--- a/packages/website/src/content/blog/agent-skill-framework.md
+++ b/packages/website/src/content/blog/agent-skill-framework.md
@@ -3,6 +3,7 @@ title: "Composing Agents, Sub-Agents, Skills, and Sub-Skills: A Decision Framewo
 description: "The architecture decisions that determine whether your AI workflow scales or collapses"
 author: "Ryan Smith"
 date: 2026-01-23
+updated: 2026-01-23
 category: "Guides"
 tags: ["agents", "skills", "architecture", "claude-code", "context-window", "multi-agent"]
 featured: true

--- a/packages/website/src/content/blog/how-skillsmith-indexes-skills.md
+++ b/packages/website/src/content/blog/how-skillsmith-indexes-skills.md
@@ -3,6 +3,7 @@ title: "From GitHub to Search Results: How Skillsmith Indexes and Curates Skills
 description: "A behind-the-scenes look at how Skillsmith discovers, scores, and indexes Claude Code skills—and how to optimize your skills for discovery"
 author: "Skillsmith Team"
 date: 2026-02-02
+updated: 2026-02-02
 category: "Engineering"
 tags: ["indexer", "search", "embeddings", "github", "scoring", "developers"]
 featured: true

--- a/packages/website/src/layouts/DocsLayout.astro
+++ b/packages/website/src/layouts/DocsLayout.astro
@@ -14,7 +14,7 @@ const currentPath = Astro.url.pathname;
 // Build breadcrumb segments from URL path (SMI-2353)
 // Note: Assumes flat docs structure (/docs/page). Nested paths (e.g. /docs/category/page)
 // would need intermediate breadcrumb entries if the docs structure changes.
-const siteOrigin = Astro.site?.origin ?? 'https://skillsmith.app';
+const siteOrigin = Astro.site?.origin ?? 'https://www.skillsmith.app';
 const pathSegments = Astro.url.pathname.split('/').filter(Boolean);
 const breadcrumbs = [
   { name: 'Home', url: `${siteOrigin}/` },

--- a/packages/website/src/pages/blog/[...slug].astro
+++ b/packages/website/src/pages/blog/[...slug].astro
@@ -25,7 +25,7 @@ const { Content } = await post.render();
 const readingTime = calculateReadingTime(post.body ?? '');
 
 // Get site URL from Astro config (SMI-1733)
-const siteUrl = Astro.site?.toString().replace(/\/$/, '') || 'https://skillsmith.app';
+const siteUrl = Astro.site?.toString().replace(/\/$/, '') || 'https://www.skillsmith.app';
 
 // Format dates for JSON-LD
 const datePublished = post.data.date.toISOString();

--- a/packages/website/src/pages/blog/index.astro
+++ b/packages/website/src/pages/blog/index.astro
@@ -18,6 +18,34 @@ const regularPosts = posts.filter(post => !post.data.featured);
 
 // Get unique categories
 const categories = [...new Set(posts.map(post => post.data.category).filter(Boolean))];
+
+// JSON-LD structured data (SMI-2514: use set:html pattern for consistency)
+const blogJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Blog",
+  "name": "Skillsmith Blog",
+  "description": "Tutorials, guides, and insights about building agent skills for AI assistants",
+  "url": "https://www.skillsmith.app/blog",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Skillsmith",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://www.skillsmith.app/logo-icon.svg"
+    }
+  },
+  "blogPost": posts.map(post => ({
+    "@type": "BlogPosting",
+    "headline": post.data.title,
+    "description": post.data.description,
+    "datePublished": post.data.date.toISOString(),
+    "author": {
+      "@type": "Person",
+      "name": post.data.author
+    },
+    "url": `https://www.skillsmith.app/blog/${post.slug}`
+  }))
+};
 ---
 
 <BaseLayout
@@ -25,34 +53,7 @@ const categories = [...new Set(posts.map(post => post.data.category).filter(Bool
   description="Tutorials, guides, and insights about building agent skills for AI assistants"
 >
   <!-- JSON-LD for Blog listing -->
-  <script is:inline type="application/ld+json" slot="head">
-    {JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "Blog",
-      "name": "Skillsmith Blog",
-      "description": "Tutorials, guides, and insights about building agent skills for AI assistants",
-      "url": "https://skillsmith.app/blog",
-      "publisher": {
-        "@type": "Organization",
-        "name": "Skillsmith",
-        "logo": {
-          "@type": "ImageObject",
-          "url": "https://skillsmith.app/logo-icon.svg"
-        }
-      },
-      "blogPost": posts.map(post => ({
-        "@type": "BlogPosting",
-        "headline": post.data.title,
-        "description": post.data.description,
-        "datePublished": post.data.date.toISOString(),
-        "author": {
-          "@type": "Person",
-          "name": post.data.author
-        },
-        "url": `https://skillsmith.app/blog/${post.slug}`
-      }))
-    })}
-  </script>
+  <script is:inline type="application/ld+json" set:html={JSON.stringify(blogJsonLd)} slot="head" />
 
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
     <!-- Header -->

--- a/packages/website/src/pages/docs/index.astro
+++ b/packages/website/src/pages/docs/index.astro
@@ -10,7 +10,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
     "@type": "TechArticle",
     "headline": "Skillsmith Documentation",
     "description": "Complete documentation for Skillsmith - AI-powered skill discovery and management for development environments",
-    "url": "https://skillsmith.app/docs",
+    "url": "https://www.skillsmith.app/docs",
     "author": {
       "@type": "Organization",
       "name": "Smith Horn Group"
@@ -18,7 +18,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
     "publisher": {
       "@type": "Organization",
       "name": "Skillsmith",
-      "url": "https://skillsmith.app"
+      "url": "https://www.skillsmith.app"
     },
     "about": {
       "@type": "SoftwareApplication",
@@ -33,31 +33,31 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
           "@type": "ListItem",
           "position": 1,
           "name": "Quickstart Guide",
-          "url": "https://skillsmith.app/docs/quickstart"
+          "url": "https://www.skillsmith.app/docs/quickstart"
         },
         {
           "@type": "ListItem",
           "position": 2,
           "name": "Getting Started",
-          "url": "https://skillsmith.app/docs/getting-started"
+          "url": "https://www.skillsmith.app/docs/getting-started"
         },
         {
           "@type": "ListItem",
           "position": 3,
           "name": "CLI Reference",
-          "url": "https://skillsmith.app/docs/cli"
+          "url": "https://www.skillsmith.app/docs/cli"
         },
         {
           "@type": "ListItem",
           "position": 4,
           "name": "MCP Server",
-          "url": "https://skillsmith.app/docs/mcp-server"
+          "url": "https://www.skillsmith.app/docs/mcp-server"
         },
         {
           "@type": "ListItem",
           "position": 5,
           "name": "API Reference",
-          "url": "https://skillsmith.app/docs/api"
+          "url": "https://www.skillsmith.app/docs/api"
         }
       ]
     }

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -69,7 +69,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
 
   <h4>Setup</h4>
 
-  <p><strong>Step 1:</strong> Create an account and get your API key at <a href="https://skillsmith.app/account">skillsmith.app/account</a></p>
+  <p><strong>Step 1:</strong> Create an account and get your API key at <a href="https://www.skillsmith.app/account">skillsmith.app/account</a></p>
 
   <p><strong>Step 2:</strong> Configure your API key using one of these methods:</p>
 

--- a/packages/website/src/pages/docs/trust-tiers.astro
+++ b/packages/website/src/pages/docs/trust-tiers.astro
@@ -210,7 +210,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
     </li>
     <li>
       <strong>Submit verification request</strong>
-      <p>Visit <a href="https://skillsmith.app/verify">skillsmith.app/verify</a> to start the process</p>
+      <p>Visit <a href="https://www.skillsmith.app/verify">skillsmith.app/verify</a> to start the process</p>
     </li>
     <li>
       <strong>Complete identity verification</strong>

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -19,6 +19,138 @@ import '../styles/global.css';
 
 // Get Supabase config for auth-aware navigation
 const supabaseConfig = getSupabaseConfig();
+
+// Dynamic priceValidUntil: always end of next year (SMI-2515)
+const priceValidUntil = `${new Date().getFullYear() + 1}-12-31`;
+
+// JSON-LD structured data (extracted from inline script for dynamic date support)
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.skillsmith.app/#organization",
+      "name": "Smith Horn Group",
+      "url": "https://www.skillsmith.app",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.skillsmith.app/logo-icon.svg"
+      },
+      "sameAs": [
+        "https://github.com/smith-horn/skillsmith"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.skillsmith.app/#website",
+      "url": "https://www.skillsmith.app",
+      "name": "Skillsmith",
+      "description": "AI-powered agent skill discovery and management",
+      "publisher": {
+        "@id": "https://www.skillsmith.app/#organization"
+      },
+      "speakable": {
+        "@type": "SpeakableSpecification",
+        "cssSelector": ["h1", "section:first-of-type p"]
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://www.skillsmith.app/#software",
+      "name": "Skillsmith",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Cross-platform",
+      "description": "Discover, install, and manage agent skills. 14,000+ curated skills with semantic search, quality scores, and stack-aware recommendations.",
+      "url": "https://www.skillsmith.app",
+      "author": {
+        "@id": "https://www.skillsmith.app/#organization"
+      },
+      "offers": [
+        {
+          "@type": "Offer",
+          "name": "Community",
+          "price": "0",
+          "priceCurrency": "USD",
+          "priceValidUntil": priceValidUntil,
+          "description": "Free tier with 1,000 API calls/month"
+        },
+        {
+          "@type": "Offer",
+          "name": "Individual",
+          "price": "9.99",
+          "priceCurrency": "USD",
+          "priceValidUntil": priceValidUntil,
+          "billingDuration": "P1M",
+          "description": "10,000 API calls/month with analytics"
+        },
+        {
+          "@type": "Offer",
+          "name": "Team",
+          "price": "25",
+          "priceCurrency": "USD",
+          "priceValidUntil": priceValidUntil,
+          "billingDuration": "P1M",
+          "description": "100,000 API calls/month with team workspaces"
+        },
+        {
+          "@type": "Offer",
+          "name": "Enterprise",
+          "price": "55",
+          "priceCurrency": "USD",
+          "priceValidUntil": priceValidUntil,
+          "billingDuration": "P1M",
+          "description": "Unlimited API calls with SSO, RBAC, and audit logging"
+        }
+      ],
+      "featureList": [
+        "Semantic skill search",
+        "Quality scores (0-100)",
+        "Stack-aware recommendations",
+        "One-click installation",
+        "MCP server integration",
+        "CLI tool"
+      ]
+    },
+    {
+      "@type": "FAQPage",
+      "@id": "https://www.skillsmith.app/#faq",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What are agent skills?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Agent skills are reusable prompt-and-tool bundles that extend AI coding assistants like Claude Code. Each skill teaches your agent a new capability \u2014 from generating commits to running security audits \u2014 without writing custom prompts from scratch."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Is Skillsmith free?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. The Community tier is free forever with 1,000 API calls per month, semantic search, and one-click installation. No credit card required. Paid plans start at $9.99/month for higher limits and analytics."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What AI tools does Skillsmith work with?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Skillsmith works with any AI tool that supports the Model Context Protocol (MCP), including Claude Code, Claude Desktop, Cursor, Windsurf, and other MCP-compatible clients. Install the MCP server and your client discovers skills automatically."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How do I install a skill?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Add the Skillsmith MCP server to your client's settings.json, restart, then ask your AI assistant to search for and install skills. You can also use the Skillsmith CLI: run 'npx @skillsmith/cli search testing' to find skills, then 'npx @skillsmith/cli install author/skill-name' to install."
+          }
+        }
+      ]
+    }
+  ]
+};
 ---
 
 <!DOCTYPE html>
@@ -80,136 +212,8 @@ const supabaseConfig = getSupabaseConfig();
 
   <!-- NO TWITTER: Skillsmith has no Twitter/X account. Do not add twitter: meta tags. See standards-astro.md Section 12. -->
 
-  <!-- JSON-LD Structured Data -->
-  <script is:inline type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@graph": [
-      {
-        "@type": "Organization",
-        "@id": "https://www.skillsmith.app/#organization",
-        "name": "Smith Horn Group",
-        "url": "https://www.skillsmith.app",
-        "logo": {
-          "@type": "ImageObject",
-          "url": "https://www.skillsmith.app/logo-icon.svg"
-        },
-        "sameAs": [
-          "https://github.com/smith-horn/skillsmith"
-        ]
-      },
-      {
-        "@type": "WebSite",
-        "@id": "https://www.skillsmith.app/#website",
-        "url": "https://www.skillsmith.app",
-        "name": "Skillsmith",
-        "description": "AI-powered agent skill discovery and management",
-        "publisher": {
-          "@id": "https://www.skillsmith.app/#organization"
-        },
-        "speakable": {
-          "@type": "SpeakableSpecification",
-          "cssSelector": ["h1", "section:first-of-type p"]
-        }
-      },
-      {
-        "@type": "SoftwareApplication",
-        "@id": "https://www.skillsmith.app/#software",
-        "name": "Skillsmith",
-        "applicationCategory": "DeveloperApplication",
-        "operatingSystem": "Cross-platform",
-        "description": "Discover, install, and manage agent skills. 14,000+ curated skills with semantic search, quality scores, and stack-aware recommendations.",
-        "url": "https://www.skillsmith.app",
-        "author": {
-          "@id": "https://www.skillsmith.app/#organization"
-        },
-        "offers": [
-          {
-            "@type": "Offer",
-            "name": "Community",
-            "price": "0",
-            "priceCurrency": "USD",
-            "priceValidUntil": "2026-12-31",
-            "description": "Free tier with 1,000 API calls/month"
-          },
-          {
-            "@type": "Offer",
-            "name": "Individual",
-            "price": "9.99",
-            "priceCurrency": "USD",
-            "priceValidUntil": "2026-12-31",
-            "billingDuration": "P1M",
-            "description": "10,000 API calls/month with analytics"
-          },
-          {
-            "@type": "Offer",
-            "name": "Team",
-            "price": "25",
-            "priceCurrency": "USD",
-            "priceValidUntil": "2026-12-31",
-            "billingDuration": "P1M",
-            "description": "100,000 API calls/month with team workspaces"
-          },
-          {
-            "@type": "Offer",
-            "name": "Enterprise",
-            "price": "55",
-            "priceCurrency": "USD",
-            "priceValidUntil": "2026-12-31",
-            "billingDuration": "P1M",
-            "description": "Unlimited API calls with SSO, RBAC, and audit logging"
-          }
-        ],
-        "featureList": [
-          "Semantic skill search",
-          "Quality scores (0-100)",
-          "Stack-aware recommendations",
-          "One-click installation",
-          "MCP server integration",
-          "CLI tool"
-        ]
-      },
-      {
-        "@type": "FAQPage",
-        "@id": "https://www.skillsmith.app/#faq",
-        "mainEntity": [
-          {
-            "@type": "Question",
-            "name": "What are agent skills?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Agent skills are reusable prompt-and-tool bundles that extend AI coding assistants like Claude Code. Each skill teaches your agent a new capability — from generating commits to running security audits — without writing custom prompts from scratch."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "Is Skillsmith free?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Yes. The Community tier is free forever with 1,000 API calls per month, semantic search, and one-click installation. No credit card required. Paid plans start at $9.99/month for higher limits and analytics."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "What AI tools does Skillsmith work with?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Skillsmith works with any AI tool that supports the Model Context Protocol (MCP), including Claude Code, Claude Desktop, Cursor, Windsurf, and other MCP-compatible clients. Install the MCP server and your client discovers skills automatically."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "How do I install a skill?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Add the Skillsmith MCP server to your client's settings.json, restart, then ask your AI assistant to search for and install skills. You can also use the Skillsmith CLI: run 'npx @skillsmith/cli search testing' to find skills, then 'npx @skillsmith/cli install author/skill-name' to install."
-            }
-          }
-        ]
-      }
-    ]
-  }
-  </script>
+  <!-- JSON-LD Structured Data (SMI-2515: dynamic priceValidUntil via set:html) -->
+  <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 </head>
 
 <body class="bg-dark-950 text-dark-50 font-sans antialiased">


### PR DESCRIPTION
## Summary

- **SMI-2514**: Normalize all structured data URLs to `https://www.skillsmith.app` across 9 files (llms.txt, robots.txt, index.astro, blog/index.astro, blog/[...slug].astro, docs/index.astro, docs/mcp-server.astro, docs/trust-tiers.astro, DocsLayout.astro)
- **SMI-2515**: Extract index.astro JSON-LD to frontmatter with dynamic `priceValidUntil` (computed as current year + 1, SSR). Eliminates hardcoded `2026-12-31` that would trigger GSC warnings on expiry.
- **SMI-2516**: Add `updated` frontmatter to blog posts for `dateModified` in BlogPosting JSON-LD
- **SMI-2513**: Verify bidirectional cross-linking between `llms.txt` and `llms-full.txt`
- **Bonus**: Convert `blog/index.astro` JSON-LD from raw `{JSON.stringify()}` inline to `set:html` pattern for consistency with all other pages

## Changes

| File | Change |
|------|--------|
| `public/llms.txt` | 14 URLs normalized to `www.` |
| `public/robots.txt` | 1 URL normalized |
| `pages/index.astro` | JSON-LD extracted to frontmatter, dynamic `priceValidUntil` |
| `pages/blog/index.astro` | JSON-LD converted to `set:html` pattern, 3 URLs normalized |
| `pages/blog/[...slug].astro` | 1 fallback URL normalized |
| `pages/docs/index.astro` | 7 URLs normalized |
| `pages/docs/mcp-server.astro` | 1 link URL normalized |
| `pages/docs/trust-tiers.astro` | 1 link URL normalized |
| `layouts/DocsLayout.astro` | 1 fallback URL normalized |
| `content/blog/agent-skill-framework.md` | Added `updated` frontmatter |
| `content/blog/how-skillsmith-indexes-skills.md` | Added `updated` frontmatter |

## Test plan

- [ ] Astro build passes with 0 errors, 0 warnings, 0 hints
- [ ] Verify JSON-LD output on index.astro includes dynamic `priceValidUntil` (not hardcoded 2026)
- [ ] Verify no remaining bare `https://skillsmith.app` (without www) in website source
- [ ] Validate structured data via Google Rich Results Test
- [ ] Verify `blog/index.astro` JSON-LD renders correctly with `set:html` pattern

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)