### PR TITLE
feat(seo): Wave 2 — ItemList schema + publisher @id linking

### DIFF
--- a/packages/website/src/pages/blog/[...slug].astro
+++ b/packages/website/src/pages/blog/[...slug].astro
@@ -46,6 +46,7 @@ const jsonLd = {
   },
   "publisher": {
     "@type": "Organization",
+    "@id": "https://www.skillsmith.app/#organization",
     "name": "Skillsmith",
     "logo": {
       "@type": "ImageObject",

--- a/packages/website/src/pages/blog/index.astro
+++ b/packages/website/src/pages/blog/index.astro
@@ -19,32 +19,43 @@ const regularPosts = posts.filter(post => !post.data.featured);
 // Get unique categories
 const categories = [...new Set(posts.map(post => post.data.category).filter(Boolean))];
 
-// JSON-LD structured data (SMI-2514: use set:html pattern for consistency)
+// JSON-LD structured data (SMI-2514, SMI-2517, SMI-2518)
 const blogJsonLd = {
   "@context": "https://schema.org",
-  "@type": "Blog",
-  "name": "Skillsmith Blog",
-  "description": "Tutorials, guides, and insights about building agent skills for AI assistants",
-  "url": "https://www.skillsmith.app/blog",
-  "publisher": {
-    "@type": "Organization",
-    "name": "Skillsmith",
-    "logo": {
-      "@type": "ImageObject",
-      "url": "https://www.skillsmith.app/logo-icon.svg"
-    }
-  },
-  "blogPost": posts.map(post => ({
-    "@type": "BlogPosting",
-    "headline": post.data.title,
-    "description": post.data.description,
-    "datePublished": post.data.date.toISOString(),
-    "author": {
-      "@type": "Person",
-      "name": post.data.author
+  "@graph": [
+    {
+      "@type": "Blog",
+      "name": "Skillsmith Blog",
+      "description": "Tutorials, guides, and insights about building agent skills for AI assistants",
+      "url": "https://www.skillsmith.app/blog",
+      "publisher": {
+        "@type": "Organization",
+        "@id": "https://www.skillsmith.app/#organization",
+        "name": "Skillsmith",
+        "url": "https://www.skillsmith.app"
+      },
+      "blogPost": posts.map(post => ({
+        "@type": "BlogPosting",
+        "headline": post.data.title,
+        "description": post.data.description,
+        "datePublished": post.data.date.toISOString(),
+        "author": {
+          "@type": "Person",
+          "name": post.data.author
+        },
+        "url": `https://www.skillsmith.app/blog/${post.slug}`
+      }))
     },
-    "url": `https://www.skillsmith.app/blog/${post.slug}`
-  }))
+    {
+      "@type": "ItemList",
+      "itemListElement": posts.map((post, index) => ({
+        "@type": "ListItem",
+        "position": index + 1,
+        "name": post.data.title,
+        "url": `https://www.skillsmith.app/blog/${post.slug}`
+      }))
+    }
+  ]
 };
 ---
 

--- a/packages/website/src/pages/docs/index.astro
+++ b/packages/website/src/pages/docs/index.astro
@@ -12,11 +12,11 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
     "description": "Complete documentation for Skillsmith - AI-powered skill discovery and management for development environments",
     "url": "https://www.skillsmith.app/docs",
     "author": {
-      "@type": "Organization",
-      "name": "Smith Horn Group"
+      "@id": "https://www.skillsmith.app/#organization"
     },
     "publisher": {
       "@type": "Organization",
+      "@id": "https://www.skillsmith.app/#organization",
       "name": "Skillsmith",
       "url": "https://www.skillsmith.app"
     },

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -30,7 +30,8 @@ const jsonLd = {
     {
       "@type": "Organization",
       "@id": "https://www.skillsmith.app/#organization",
-      "name": "Smith Horn Group",
+      "name": "Skillsmith",
+      "alternateName": "Smith Horn Group",
       "url": "https://www.skillsmith.app",
       "logo": {
         "@type": "ImageObject",


### PR DESCRIPTION
## Summary

- **SMI-2517**: Add `ItemList` schema to `blog/index.astro` listing all posts with position, name, and URL — enables carousel rich results in Google
- **SMI-2518**: Link `publisher` to Organization `@id` (`https://www.skillsmith.app/#organization`) across blog listing, blog posts, and docs index — connects Knowledge Graph entities

## Changes

| File | Change |
|------|--------|
| `pages/blog/index.astro` | Wrap JSON-LD in `@graph` array, add `ItemList` schema, replace inline publisher with `@id` reference |
| `pages/blog/[...slug].astro` | Add `@id` to publisher Organization |
| `pages/docs/index.astro` | Add `@id` to publisher Organization |

## Test plan

- [ ] Astro build passes with 0 errors, 0 warnings, 0 hints
- [ ] Validate blog index JSON-LD contains both `Blog` and `ItemList` types in `@graph`
- [ ] Verify all publisher objects reference `@id: https://www.skillsmith.app/#organization`
- [ ] Validate with Google Rich Results Test

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)