### PR TITLE
fix(seo,security): code review fixes (SMI-2533)

### DIFF
--- a/packages/mcp-server/tests/performance/search-performance.test.ts
+++ b/packages/mcp-server/tests/performance/search-performance.test.ts
@@ -154,7 +154,7 @@ describe('SMI-797: Performance Validation', () => {
       const result = await executeGetSkill({ id: 'test-org/skill-0' }, context)
       const elapsed = performance.now() - start
 
-      expect(elapsed).toBeLessThan(20)
+      expect(elapsed).toBeLessThan(50)
       expect(result.skill.id).toBe('test-org/skill-0')
     })
 
@@ -176,7 +176,7 @@ describe('SMI-797: Performance Validation', () => {
       const results = await Promise.all(ids.map((id) => executeGetSkill({ id }, context)))
       const elapsed = performance.now() - start
 
-      expect(elapsed).toBeLessThan(100)
+      expect(elapsed).toBeLessThan(200)
       expect(results.every((r) => r.skill !== undefined)).toBe(true)
     })
   })
@@ -274,7 +274,7 @@ describe('SMI-797: Performance Validation', () => {
 
       // Assertions
       expect(metrics.singleSearch).toBeLessThan(50)
-      expect(metrics.singleGet).toBeLessThan(20)
+      expect(metrics.singleGet).toBeLessThan(50)
       expect(metrics.concurrentSearches).toBeLessThan(200)
       expect(metrics.searchGetFlow).toBeLessThan(50)
     })

--- a/packages/website/src/pages/blog/[...slug].astro
+++ b/packages/website/src/pages/blog/[...slug].astro
@@ -37,7 +37,7 @@ const jsonLd = {
   "@type": "BlogPosting",
   "headline": post.data.title,
   "description": post.data.description,
-  "image": post.data.ogImage ?? `${siteUrl}/logo-icon.svg`,
+  "image": post.data.ogImage ?? `${siteUrl}/og-image.png`,
   "datePublished": datePublished,
   "dateModified": dateModified,
   "author": {

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -73,6 +73,7 @@ const jsonLd = {
           "price": "0",
           "priceCurrency": "USD",
           "priceValidUntil": priceValidUntil,
+          "url": "https://www.skillsmith.app/pricing",
           "description": "Free tier with 1,000 API calls/month"
         },
         {
@@ -81,7 +82,7 @@ const jsonLd = {
           "price": "9.99",
           "priceCurrency": "USD",
           "priceValidUntil": priceValidUntil,
-          "billingDuration": "P1M",
+          "url": "https://www.skillsmith.app/pricing",
           "description": "10,000 API calls/month with analytics"
         },
         {
@@ -90,7 +91,7 @@ const jsonLd = {
           "price": "25",
           "priceCurrency": "USD",
           "priceValidUntil": priceValidUntil,
-          "billingDuration": "P1M",
+          "url": "https://www.skillsmith.app/pricing",
           "description": "100,000 API calls/month with team workspaces"
         },
         {
@@ -99,7 +100,7 @@ const jsonLd = {
           "price": "55",
           "priceCurrency": "USD",
           "priceValidUntil": priceValidUntil,
-          "billingDuration": "P1M",
+          "url": "https://www.skillsmith.app/pricing",
           "description": "Unlimited API calls with SSO, RBAC, and audit logging"
         }
       ],

--- a/packages/website/vercel.json
+++ b/packages/website/vercel.json
@@ -38,7 +38,7 @@
           "value": "camera=(), microphone=(), geolocation=()"
         },
         {
-          "key": "Content-Security-Policy-Report-Only",
+          "key": "Content-Security-Policy",
           "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://api.fontshare.com https://fonts.googleapis.com; font-src 'self' https://cdn.fontshare.com https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://analytics.google.com https://*.supabase.co https://api.skillsmith.app https://api.fontshare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
         }
       ]


### PR DESCRIPTION
## Summary
- **M1**: Change BlogPosting image fallback from SVG to `og-image.png` (Google requires raster for rich results)
- **M2**: Remove invalid `billingDuration` from schema.org Offers (not a valid property)
- **M3**: Promote CSP from report-only to enforced `Content-Security-Policy`
- **m1**: Add `url` field to all 4 Offer objects pointing to /pricing
- **m2**: Relax get-skill perf threshold 20ms→50ms, concurrent 100ms→200ms (2-3x Docker/CI rule)

## Test plan
- [x] `astro check` — 0 errors, 0 warnings, 0 hints
- [x] `audit:standards` — 22/22 passed, 0 failures
- [x] Performance tests — 11/11 passed with relaxed thresholds
- [x] Pre-commit (typecheck, lint, format) — all passed
- [x] Pre-push (security tests, npm audit, secrets, format, coverage) — all passed

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)