### PR TITLE
fix(security): override qs to ^6.14.2 (CVE-2026-2391)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22865,9 +22865,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "tar": "^7.5.7",
     "hono": "^4.11.7",
     "fast-xml-parser": "^5.3.4",
-    "@modelcontextprotocol/sdk": "1.26.0"
+    "@modelcontextprotocol/sdk": "1.26.0",
+    "qs": "^6.14.2"
   }
 }


### PR DESCRIPTION
## Summary

- Adds npm `overrides` entry for `qs: "^6.14.2"` to fix Dependabot alert #15 (CVE-2026-2391, low severity)
- The `arrayLimit` bypass via comma parsing can cause DoS through memory exhaustion
- All 4 transitive instances (`express`, `@vscode/vsce`, `stripe`) now resolve to `6.14.2`

## Test plan

- [x] `npm ls qs` confirms all instances at `6.14.2`
- [x] `npm run build` passes (6/6 Turborepo tasks)
- [x] `npm test` passes (199 files, 5787 tests)
- [x] Pre-commit checks pass (secrets, typecheck, lint, format)
- [x] Pre-push checks pass (security tests, npm audit, coverage)
- [ ] Dependabot alert #15 auto-closes after merge

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)