### PR TITLE
fix(lint): add *.cjs to ESLint global ignores

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ const globalIgnores = {
     '**/coverage/**',
     '**/*.d.ts',
     '**/*.js',
+    '**/*.cjs',
     '**/*.mjs',
     '!eslint.config.js',
     '**/vitest.config.integration.ts',


### PR DESCRIPTION
## Summary

- Adds `**/*.cjs` to the ESLint global ignores in `eslint.config.js`
- The existing ignores covered `**/*.js` and `**/*.mjs` but missed `**/*.cjs`, causing `.claude/helpers/statusline.cjs` to be linted with TypeScript rules
- In CI (where git-crypt is not unlocked), this produced 40 errors and blocked PR merges

## Test plan

- [x] `npm run lint` passes locally (zero errors, zero warnings)
- [x] `npx eslint --debug .claude/helpers/statusline.cjs` confirms file is ignored
- [x] Pre-commit checks pass
- [x] Pre-push checks pass

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)