### PR TITLE
fix(a11y): callout heading order and copy button aria-label (SMI-2539)

### DIFF
--- a/packages/website/src/components/DocsCopyButtons.astro
+++ b/packages/website/src/components/DocsCopyButtons.astro
@@ -14,7 +14,7 @@ const { pageTitle, pageDescription } = Astro.props;
   <button
     type="button"
     class="copy-btn copy-llm-btn"
-    aria-label="Copy page content optimized for LLM"
+    aria-label="Copy for LLM"
   >
     <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>

--- a/packages/website/src/layouts/DocsLayout.astro
+++ b/packages/website/src/layouts/DocsLayout.astro
@@ -264,17 +264,19 @@ if (pathSegments.length > 1) {
     border-left-color: #f59e0b;
   }
 
-  .docs-content .callout h4 {
+  .docs-content .callout .callout-heading {
+    font-size: 1rem;
+    font-weight: 600;
     color: #38bdf8;
     margin-top: 0;
     margin-bottom: 0.5rem;
   }
 
-  .docs-content .callout.warning h4 {
+  .docs-content .callout.warning .callout-heading {
     color: #fbbf24;
   }
 
-  .docs-content .callout p {
+  .docs-content .callout p:not(.callout-heading) {
     margin-bottom: 0;
   }
 

--- a/packages/website/src/pages/docs/api.astro
+++ b/packages/website/src/pages/docs/api.astro
@@ -385,7 +385,7 @@ try {
   </table>
 
   <div class="callout">
-    <h4>API Key Required</h4>
+    <p class="callout-heading">API Key Required</p>
     <p>
       For higher rate limits and premium features, obtain an API key from your
       <a href="/account">account settings</a>.

--- a/packages/website/src/pages/docs/cli.astro
+++ b/packages/website/src/pages/docs/cli.astro
@@ -368,7 +368,7 @@ skillsmith validate ~/.claude/skills/jest-helper`}</code></pre>
   <h3>Common Issues</h3>
 
   <div class="callout warning">
-    <h4>Permission Denied</h4>
+    <p class="callout-heading">Permission Denied</p>
     <p>
       If you see permission errors when installing globally, try using
       <code>npx @skillsmith/cli</code> instead, or fix npm permissions.
@@ -376,7 +376,7 @@ skillsmith validate ~/.claude/skills/jest-helper`}</code></pre>
   </div>
 
   <div class="callout">
-    <h4>Skill Not Found</h4>
+    <p class="callout-heading">Skill Not Found</p>
     <p>
       Ensure you're using the correct skill ID format (<code>author/name</code>).
       Use <code>skillsmith search</code> to find available skills.

--- a/packages/website/src/pages/docs/getting-started.astro
+++ b/packages/website/src/pages/docs/getting-started.astro
@@ -125,7 +125,7 @@ skillsmith --help
   </p>
 
   <div class="callout">
-    <h4>Why Configure an API Key?</h4>
+    <p class="callout-heading">Why Configure an API Key?</p>
     <p>
       Without a personal API key, the MCP server uses a shared anonymous key. Your requests
       will work but won't appear on your <a href="/account">Account Dashboard</a>. To track
@@ -172,7 +172,7 @@ EOF`}</code></pre>
 }`}</code></pre>
 
   <div class="callout callout-warning">
-    <h4>Shell Exports Don't Work</h4>
+    <p class="callout-heading">Shell Exports Don't Work</p>
     <p>
       Running <code>export SKILLSMITH_API_KEY=...</code> in your terminal does NOT pass the variable
       to MCP servers. MCP servers run as subprocesses and don't inherit your
@@ -305,7 +305,7 @@ skillsmith install community/git-commit`}</code></pre>
   </ul>
 
   <div class="callout">
-    <h4>Need Help?</h4>
+    <p class="callout-heading">Need Help?</p>
     <p>
       If you encounter any issues during setup, check out our
       <a href="https://github.com/smith-horn/skillsmith/issues">GitHub Issues</a>

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -102,7 +102,7 @@ EOF`}</code></pre>
   <p><strong>Step 3:</strong> Restart your MCP client to load the updated configuration.</p>
 
   <div class="callout">
-    <h4>Security Note</h4>
+    <p class="callout-heading">Security Note</p>
     <p>
       Never paste your API key directly in chat. Always configure it via one of the methods above.
       Your key will be used automatically for all Skillsmith API requests.
@@ -110,7 +110,7 @@ EOF`}</code></pre>
   </div>
 
   <div class="callout callout-warning">
-    <h4>Shell Exports Don't Work</h4>
+    <p class="callout-heading">Shell Exports Don't Work</p>
     <p>
       Running <code>export SKILLSMITH_API_KEY=...</code> in your terminal does NOT pass the variable
       to MCP servers. MCP servers run as subprocesses and don't inherit your
@@ -389,14 +389,14 @@ Assistant: [Uses compare tool] Here's a comparison:
   <h3>Server Not Starting</h3>
 
   <div class="callout">
-    <h4>Check Node.js Version</h4>
+    <p class="callout-heading">Check Node.js Version</p>
     <p>Ensure you have Node.js 18+ installed. Run <code>node --version</code> to verify.</p>
   </div>
 
   <h3>Tools Not Available</h3>
 
   <div class="callout">
-    <h4>Verify Configuration</h4>
+    <p class="callout-heading">Verify Configuration</p>
     <p>
       Ensure your <code>~/.claude/settings.json</code> is valid JSON and the
       MCP server configuration is correct. Restart your MCP client after changes.

--- a/packages/website/src/pages/docs/quarantine.astro
+++ b/packages/website/src/pages/docs/quarantine.astro
@@ -142,14 +142,14 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
   <p>If you try to install a quarantined skill, you'll see different messages depending on severity:</p>
 
   <div class="callout warning">
-    <h4>MALICIOUS Skills</h4>
+    <p class="callout-heading">MALICIOUS Skills</p>
     <pre><code>{`Error: This skill has been quarantined for security reasons and cannot be installed.
 Reason: Security threat detected - jailbreak patterns found
 For more information, visit skillsmith.app/docs/quarantine`}</code></pre>
   </div>
 
   <div class="callout warning">
-    <h4>SUSPICIOUS Skills</h4>
+    <p class="callout-heading">SUSPICIOUS Skills</p>
     <pre><code>{`Warning: This skill is under review and cannot be installed yet.
 Reason: Accesses sensitive file patterns
 Review status: Pending (estimated 24-48 hours)
@@ -157,7 +157,7 @@ You will be notified when the review is complete.`}</code></pre>
   </div>
 
   <div class="callout">
-    <h4>RISKY Skills</h4>
+    <p class="callout-heading">RISKY Skills</p>
     <pre><code>{`Warning: This skill has been flagged for the following risks:
 - References external domain: api.example.com
 - Contains high-entropy content (possible obfuscation)

--- a/packages/website/src/pages/docs/security.astro
+++ b/packages/website/src/pages/docs/security.astro
@@ -192,7 +192,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
   <h2>Best Practices for Users</h2>
 
   <div class="callout">
-    <h4>1. Always Check Trust Tier</h4>
+    <p class="callout-heading">1. Always Check Trust Tier</p>
     <p>
       Before installing a skill, verify its <a href="/docs/trust-tiers">trust tier</a>:
     </p>
@@ -204,7 +204,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
   </div>
 
   <div class="callout">
-    <h4>2. Review Unverified Skills</h4>
+    <p class="callout-heading">2. Review Unverified Skills</p>
     <p>For unverified skills, always check:</p>
     <ul>
       <li>Read the SKILL.md content for suspicious instructions</li>
@@ -214,14 +214,14 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
   </div>
 
   <div class="callout">
-    <h4>3. Use Validation Before Manual Install</h4>
+    <p class="callout-heading">3. Use Validation Before Manual Install</p>
     <p>
       Use <code>skillsmith validate &lt;path&gt;</code> to run security scans on locally-downloaded skills.
     </p>
   </div>
 
   <div class="callout">
-    <h4>4. Keep Skillsmith Updated</h4>
+    <p class="callout-heading">4. Keep Skillsmith Updated</p>
     <p>
       New security patterns are added regularly. Update with:
       <code>npx @skillsmith/mcp-server@latest</code>


### PR DESCRIPTION
## Summary
- Change callout `<h4>` to `<p class="callout-heading">` across all 6 docs pages (17 callouts) to fix heading-order violations where `<h4>` appeared after `<h2>` without intervening `<h3>`
- Update DocsLayout CSS to target `.callout-heading` instead of `.callout h4`
- Fix copy button `aria-label` to include visible text per WCAG 2.5.3

## Test plan
- [x] `astro check` — 0 errors, 0 warnings, 0 hints
- [x] `audit:standards` — passed
- [x] Pre-push security, format, coverage checks — all passed
- [ ] Lighthouse re-audit after deploy to verify heading-order and aria-label fixed

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)