### PR TITLE
fix(a11y): hide task-list checkboxes from accessibility tree (SMI-2542)

### DIFF
--- a/packages/website/src/layouts/BlogLayout.astro
+++ b/packages/website/src/layouts/BlogLayout.astro
@@ -192,7 +192,15 @@ const formattedUpdated = updated ? formatDate(updated) : null;
       toc.appendChild(ul);
     }
 
+    function fixTaskListCheckboxes() {
+      document.querySelectorAll('.prose-content .task-list-item input[type="checkbox"]').forEach(cb => {
+        cb.setAttribute('aria-hidden', 'true');
+        cb.setAttribute('tabindex', '-1');
+      });
+    }
+
     document.addEventListener('astro:page-load', initToc);
+    document.addEventListener('astro:page-load', fixTaskListCheckboxes);
   </script>
 </BaseLayout>
 


### PR DESCRIPTION
## Summary
- Add `aria-hidden="true"` and `tabindex="-1"` to markdown task-list checkboxes via JS on `astro:page-load`
- Resolves last remaining Lighthouse accessibility failure on blog posts

## Test plan
- [x] `astro check` — 0 errors
- [x] Pre-push checks — all passed

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)