### PR TITLE
fix(a11y): close mismatched heading tags and restore hover state

### DIFF
--- a/packages/website/src/pages/changelog.astro
+++ b/packages/website/src/pages/changelog.astro
@@ -224,8 +224,7 @@ function getBadgeClass(type: string): string {
         </a>
         <a
           href="/contact"
-          class="inline-flex items-center justify-center gap-2 px-6 py-3 text-white rounded-lg transition-colors"
-          style="background-color: #c4593f"
+          class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-[#c4593f] hover:bg-[#a34830] text-white rounded-lg transition-colors"
         >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />

--- a/packages/website/src/pages/license.astro
+++ b/packages/website/src/pages/license.astro
@@ -111,7 +111,7 @@ const lastUpdated = 'January 17, 2026';
         <div class="bg-dark-900 border border-dark-700 rounded-lg p-4">
           <div class="flex items-center gap-3 mb-2">
             <span class="text-green-400 text-xl">✓</span>
-            <h3 class="font-semibold text-white">Using Skillsmith in your development workflow</h4>
+            <h3 class="font-semibold text-white">Using Skillsmith in your development workflow</h3>
           </div>
           <p class="text-dark-400 text-sm ml-8">
             You can use Skillsmith to discover, install, and manage Claude Code skills for your projects.
@@ -122,7 +122,7 @@ const lastUpdated = 'January 17, 2026';
         <div class="bg-dark-900 border border-dark-700 rounded-lg p-4">
           <div class="flex items-center gap-3 mb-2">
             <span class="text-green-400 text-xl">✓</span>
-            <h3 class="font-semibold text-white">Self-hosting for your company</h4>
+            <h3 class="font-semibold text-white">Self-hosting for your company</h3>
           </div>
           <p class="text-dark-400 text-sm ml-8">
             You can deploy Skillsmith on your own servers for use by your team or organization.
@@ -133,7 +133,7 @@ const lastUpdated = 'January 17, 2026';
         <div class="bg-dark-900 border border-dark-700 rounded-lg p-4">
           <div class="flex items-center gap-3 mb-2">
             <span class="text-green-400 text-xl">✓</span>
-            <h3 class="font-semibold text-white">Building integrations and plugins</h4>
+            <h3 class="font-semibold text-white">Building integrations and plugins</h3>
           </div>
           <p class="text-dark-400 text-sm ml-8">
             You can build tools that integrate with Skillsmith, such as IDE plugins, CI/CD integrations,
@@ -144,7 +144,7 @@ const lastUpdated = 'January 17, 2026';
         <div class="bg-dark-900 border border-dark-700 rounded-lg p-4">
           <div class="flex items-center gap-3 mb-2">
             <span class="text-green-400 text-xl">✓</span>
-            <h3 class="font-semibold text-white">Forking and modifying for internal use</h4>
+            <h3 class="font-semibold text-white">Forking and modifying for internal use</h3>
           </div>
           <p class="text-dark-400 text-sm ml-8">
             You can fork Skillsmith and modify it for your organization's specific needs, as long as
@@ -155,7 +155,7 @@ const lastUpdated = 'January 17, 2026';
         <div class="bg-dark-900 border border-red-700/50 rounded-lg p-4">
           <div class="flex items-center gap-3 mb-2">
             <span class="text-red-400 text-xl">✕</span>
-            <h3 class="font-semibold text-white">Offering "Skillsmith as a Service"</h4>
+            <h3 class="font-semibold text-white">Offering "Skillsmith as a Service"</h3>
           </div>
           <p class="text-dark-400 text-sm ml-8">
             You cannot host Skillsmith and offer it as a managed service to customers. This would
@@ -166,7 +166,7 @@ const lastUpdated = 'January 17, 2026';
         <div class="bg-dark-900 border border-red-700/50 rounded-lg p-4">
           <div class="flex items-center gap-3 mb-2">
             <span class="text-red-400 text-xl">✕</span>
-            <h3 class="font-semibold text-white">Rebranding and reselling</h4>
+            <h3 class="font-semibold text-white">Rebranding and reselling</h3>
           </div>
           <p class="text-dark-400 text-sm ml-8">
             You cannot rebrand Skillsmith and sell it as your own product or include it as a

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -225,7 +225,7 @@ const trustTiers = [
       <svg class="w-16 h-16 mx-auto text-dark-600 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
-      <h2 class="text-xl font-semibold text-dark-300 mb-2">No skills found</h3>
+      <h2 class="text-xl font-semibold text-dark-300 mb-2">No skills found</h2>
       <p class="text-dark-500">Try adjusting your search or filters</p>
     </div>
 
@@ -234,7 +234,7 @@ const trustTiers = [
       <svg class="w-16 h-16 mx-auto text-primary-500 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
-      <h2 class="text-xl font-semibold text-dark-300 mb-2">Start Searching</h3>
+      <h2 class="text-xl font-semibold text-dark-300 mb-2">Start Searching</h2>
       <p class="text-dark-500 mb-4">Enter a search term or select a filter to browse skills</p>
       <div class="flex flex-wrap justify-center gap-2 max-w-md mx-auto">
         <button class="search-suggestion px-3 py-1.5 bg-dark-800 border border-dark-700 rounded-lg text-dark-300 hover:text-white hover:border-primary-500 transition-colors text-sm" data-query="testing">testing</button>
@@ -251,7 +251,7 @@ const trustTiers = [
       <svg class="w-16 h-16 mx-auto text-red-500 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
       </svg>
-      <h2 class="text-xl font-semibold text-dark-300 mb-2">Error loading skills</h3>
+      <h2 class="text-xl font-semibold text-dark-300 mb-2">Error loading skills</h2>
       <p id="error-message" class="text-dark-500 mb-4">Something went wrong</p>
       <button id="retry-button" class="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-lg transition-colors">
         Try Again


### PR DESCRIPTION
## Summary
- Fix 6 mismatched `<h3>...</h4>` closing tags in `license.astro`
- Fix 3 mismatched `<h2>...</h3>` closing tags in `skills/index.astro`
- Replace inline `style` with Tailwind `bg-[#c4593f] hover:bg-[#a34830]` on changelog CTA button to restore hover feedback

Found during code review of PR #134.

## Test plan
- [ ] Build passes with zero errors
- [ ] No mismatched heading tags remain (`grep -r '<h[2-3].*</h[3-4]>'`)
- [ ] Changelog CTA button has hover darkening effect

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)