### PR TITLE
fix(a11y): resolve remaining 7 Lighthouse failures

### DIFF
--- a/packages/website/src/pages/changelog.astro
+++ b/packages/website/src/pages/changelog.astro
@@ -224,7 +224,7 @@ function getBadgeClass(type: string): string {
         </a>
         <a
           href="/contact"
-          class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-[#c4593f] hover:bg-[#a34830] text-white rounded-lg transition-colors"
+          class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-[#b8523a] hover:bg-[#a34830] text-white rounded-lg transition-colors"
         >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />

--- a/packages/website/src/pages/docs/faq.astro
+++ b/packages/website/src/pages/docs/faq.astro
@@ -266,7 +266,7 @@ const faqCategories: FAQCategory[] = [
   }
 
   .cta-btn-primary {
-    background: #c4593f;
+    background: #b8523a;
     color: white;
   }
 

--- a/packages/website/src/pages/docs/quickstart.astro
+++ b/packages/website/src/pages/docs/quickstart.astro
@@ -411,7 +411,7 @@ npm install -g @skillsmith/cli
 
 # Verify installation
 skillsmith --version</code></pre>
-              <p class="text-dark-500 text-xs mt-2">After this, <code class="bg-dark-800 px-1 rounded">skillsmith</code> command is available everywhere.</p>
+              <p class="text-dark-500 text-xs mt-2">After this, <code class="bg-dark-800 px-1 rounded text-dark-300">skillsmith</code> command is available everywhere.</p>
             </div>
             <div class="cli-content hidden" data-cli="npx">
               <pre class="bg-dark-950 rounded p-3 overflow-x-auto"><code class="text-sm text-dark-200"># Run without installing (downloads on first use)
@@ -419,7 +419,7 @@ npx @skillsmith/cli search testing
 
 # Short alias
 npx sklx search testing</code></pre>
-              <p class="text-dark-500 text-xs mt-2">Use <code class="bg-dark-800 px-1 rounded">npx</code> to run without global installation.</p>
+              <p class="text-dark-500 text-xs mt-2">Use <code class="bg-dark-800 px-1 rounded text-dark-300">npx</code> to run without global installation.</p>
             </div>
           </div>
         </div>

--- a/packages/website/src/pages/signup/success.astro
+++ b/packages/website/src/pages/signup/success.astro
@@ -373,7 +373,7 @@ import Footer from '../../components/Footer.astro';
 
   .receipt-note a {
     color: #E07A5F;
-    text-decoration: none;
+    text-decoration: underline;
   }
 
   .receipt-note a:hover {

--- a/packages/website/src/styles/global.css
+++ b/packages/website/src/styles/global.css
@@ -329,7 +329,7 @@
 
   /* Code block styles */
   code {
-    @apply font-mono text-sm bg-gray-100 px-1.5 py-0.5 rounded-sm;
+    @apply font-mono text-sm bg-dark-800 px-1.5 py-0.5 rounded-sm;
   }
 
   pre {


### PR DESCRIPTION
## Summary
- Change global `code` background from `bg-gray-100` to `bg-dark-800` — orange `text-primary-400` on light gray was 2.24:1 (needs 4.5:1). Fixes `/license/`, `/privacy/`, `/docs/quickstart/`, `/docs/faq/`
- Darken CTA button from `#c4593f` to `#b8523a` — was 4.33:1, now 4.87:1 with white text. Fixes `/changelog/`, `/faq/`
- Add `text-dark-300` to quickstart code elements inside muted parents — was 4.32:1, now ~10:1
- Add underline to signup success billing link (WCAG 1.4.1). Fixes `/signup/success/`

## Test plan
- [ ] Verify inline `<code>` has dark background across all docs pages
- [ ] Verify CTA buttons on changelog and faq pages have readable white text
- [ ] Verify quickstart CLI code snippets are readable in muted text sections
- [ ] Verify billing link on signup/success is underlined
- [ ] Run Lighthouse accessibility audit on all 7 affected pages

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)