### PR TITLE
fix(a11y): add missing underline to license contact links

### DIFF
--- a/packages/website/src/pages/license.astro
+++ b/packages/website/src/pages/license.astro
@@ -447,11 +447,11 @@ or indirect.
         <div class="space-y-2">
           <p class="text-dark-300">
             <span class="text-dark-400">General Inquiries:</span>
-            <a href="/contact?topic=general" class="text-primary-400 hover:text-primary-300 ml-2">Contact Form</a>
+            <a href="/contact?topic=general" class="text-primary-400 hover:text-primary-300 underline ml-2">Contact Form</a>
           </p>
           <p class="text-dark-300">
             <span class="text-dark-400">Enterprise Licensing:</span>
-            <a href="/contact?topic=enterprise" class="text-primary-400 hover:text-primary-300 ml-2">Contact Form</a>
+            <a href="/contact?topic=enterprise" class="text-primary-400 hover:text-primary-300 underline ml-2">Contact Form</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add `underline` class to 2 Contact Form links in license.astro footer
- Fixes inconsistency found in code review: privacy.astro and terms.astro had underlines, license.astro did not (WCAG 1.4.1)

## Test plan
- [ ] Verify underlines visible on license page contact links
- [ ] Lighthouse accessibility score remains 100 on /license/

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)