### PR TITLE
feat: encryption guards + docs for narrowed git-crypt scope (SMI-2606–2608)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,8 @@ jobs:
         uses: actions/checkout@v4
 
       # SMI-2159: Decrypt git-crypt encrypted files before Docker build
-      # Required for supabase/**, docs/**, .claude/** (encrypted for IP protection)
+      # Narrowed scope (SMI-2604): .claude/skills/**, .claude/plans/**, .claude/hive-mind/**,
+      # supabase/functions/**, supabase/migrations/** (docs moved to private submodule)
       - name: Unlock git-crypt
         if: ${{ env.GIT_CRYPT_KEY != '' }}
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ docker exec skillsmith-dev-1 npm run preflight         # All checks before push
 
 **Container management**: `docker compose --profile dev down` (stop), `docker logs skillsmith-dev-1` (logs).
 
+**Submodule**: Run `git submodule update --init` before `docker compose up` if internal docs are needed inside the container. Internal docs are not available inside Docker by default.
+
 ---
 
 ## CI Health Requirements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,14 @@ docker exec skillsmith-dev-1 npm run audit:standards
 
 Pre-commit hooks will automatically run linting and formatting.
 
+## Internal Documentation
+
+Internal documentation is in a private submodule at `docs/internal/`. Access requires Smith Horn GitHub org membership. The `--recurse-submodules` flag is optional when cloning.
+
+```bash
+git submodule update --init          # Init submodule (authorized users only)
+```
+
 ## Questions?
 
 - Check [docs/internal/architecture/](docs/internal/architecture/) for design decisions (requires submodule init)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ node packages/cli/dist/index.js install community/jest-helper
 
 ## Documentation
 
+Internal documentation is in a private submodule at `docs/internal/`. Access requires Smith Horn GitHub org membership. Run `git submodule update --init` after cloning.
+
 - [**Skill Security Guide**](docs/internal/security/skill-security-guide.md) - Understanding skill trust, safety, and how Skillsmith protects you
 - [Getting Started](docs/internal/GETTING_STARTED.md) - Complete setup and usage guide
 - [Engineering Standards](docs/internal/architecture/standards.md) - Code quality policies

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,7 +65,7 @@ Skillsmith implements the following security measures:
 | **SQL Injection Prevention** | Parameterized queries via better-sqlite3 |
 | **Command Injection Prevention** | `execFileSync` with array args; no shell string interpolation |
 | **Secret Management** | Varlock for secret injection; never exposed in terminal output |
-| **Encrypted Documentation** | git-crypt for sensitive docs, configs, and Supabase functions |
+| **Encrypted Code & Config** | git-crypt for `.claude/skills/`, `.claude/plans/`, `.claude/hive-mind/`, `supabase/functions/`, `supabase/migrations/`. Internal docs in private submodule. |
 | **Secret Detection** | Gitleaks configuration for CI/CD |
 | **Dependency Auditing** | npm audit in CI pipeline |
 | **ReDoS Prevention** | User-supplied regex capped at 200 characters |

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -339,6 +339,14 @@ create_worktree() {
     (cd "$worktree_path" && git reset --hard HEAD)
     success "  Files checked out successfully"
 
+    # Step 4b: Initialize submodules (docs/internal)
+    if [[ -f "$worktree_path/.gitmodules" ]]; then
+        info "Initializing submodules..."
+        (cd "$worktree_path" && git submodule update --init 2>/dev/null) && \
+            success "  Submodules initialized" || \
+            warn "Submodule init failed (requires org access for private submodule)"
+    fi
+
     # Step 5: Generate Docker override file (if docker-compose.yml exists)
     if [[ -f "$worktree_path/docker-compose.yml" ]]; then
         info "Step 5/5: Generating Docker override file..."

--- a/scripts/tests/detect-affected.test.ts
+++ b/scripts/tests/detect-affected.test.ts
@@ -118,7 +118,7 @@ describe('SMI-2190: Affected Package Detection', () => {
 
     it('should return undefined for non-package files', () => {
       expect(findPackageForFile('scripts/ci/classify.ts', mockPackages)).toBeUndefined()
-      expect(findPackageForFile('docs/adr/001.md', mockPackages)).toBeUndefined()
+      expect(findPackageForFile('docs/internal/adr/001.md', mockPackages)).toBeUndefined()
       expect(findPackageForFile('README.md', mockPackages)).toBeUndefined()
     })
 
@@ -157,7 +157,7 @@ describe('SMI-2190: Affected Package Detection', () => {
     })
 
     it('should not require all packages for docs changes', () => {
-      const result = requiresAllPackages(['docs/adr/001.md', 'README.md'])
+      const result = requiresAllPackages(['docs/internal/adr/001.md', 'README.md'])
       expect(result.required).toBe(false)
     })
   })
@@ -247,7 +247,7 @@ describe('SMI-2190: Affected Package Detection', () => {
     it('should handle mixed package and non-package files', () => {
       const result = detectAffectedPackages([
         'packages/core/src/index.ts',
-        'docs/adr/001.md',
+        'docs/internal/adr/001.md',
         'scripts/ci/classify.ts',
       ])
 


### PR DESCRIPTION
## Summary

- **SMI-2606**: Document history cleanup decision — `git filter-repo` rejected (breaks PR refs and contributor attribution). Encrypted blobs in history are harmless.
- **SMI-2607**: Add audit checks 18 (no double-encrypted files) and 19 (docs/ directory structure guard) to prevent git-crypt scope drift after narrowing.
- **SMI-2608**: Update documentation across 6 files to reflect narrowed encryption scope and private submodule for internal docs.

## Changes

| File | What |
|------|------|
| `scripts/audit-standards.mjs` | Checks 18 & 19 — double-encryption detection + docs/ structure guard |
| `docs/development/git-crypt-guide.md` | Updated encrypted paths table, added submodule workflow and history cleanup sections |
| `CLAUDE.md` | Added submodule note in Docker section |
| `CONTRIBUTING.md` | Added internal docs access instructions |
| `README.md` | Added submodule documentation note |
| `SECURITY.md` | Updated encryption description to reflect narrowed scope |
| `.github/workflows/ci.yml` | Updated comment for narrowed scope |
| `scripts/create-worktree.sh` | Added submodule init step after worktree creation |
| `scripts/tests/detect-affected.test.ts` | Updated test paths from `docs/adr/` to `docs/internal/adr/` |

## Test plan

- [x] Audit checks 18 & 19 pass locally (`npm run audit:standards`)
- [x] `detect-affected.test.ts` — all 31 tests pass
- [x] Lint passes
- [x] Prettier formatting verified on changed scripts
- [ ] CI docs/config tier checks pass

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)