### PR TITLE
fix: update generate-retro.mjs output path for submodule migration (SMI-2608)

### DIFF
--- a/scripts/generate-retro.mjs
+++ b/scripts/generate-retro.mjs
@@ -380,7 +380,8 @@ async function main() {
 
     // Determine output path
     const outputPath =
-      output || `docs/retros/phase-${phase.toLowerCase().replace(/\s+/g, '-')}-generated.md`
+      output ||
+      `docs/internal/retros/phase-${phase.toLowerCase().replace(/\s+/g, '-')}-generated.md`
 
     if (dryRun) {
       console.log('\n--- DRY RUN OUTPUT ---\n')


### PR DESCRIPTION
## Summary
- Fixes default retro output path from `docs/retros/` to `docs/internal/retros/` to match the private submodule structure after git-crypt remediation
- Without this fix, `generate-retro.mjs` throws `ENOENT` when run without an explicit `--output` flag

## Test plan
- [ ] Verify `docs/internal/retros/` exists in the private submodule
- [ ] Run `node scripts/generate-retro.mjs --dry-run` to confirm path in output

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)