### PR TITLE
fix: retro action items — path migration and cleanup (SMI-2614–2618)

### DIFF
--- a/.claude/agents/architecture/system-design/arch-system-design.md
+++ b/.claude/agents/architecture/system-design/arch-system-design.md
@@ -51,7 +51,7 @@ capabilities:
   
 constraints:
   allowed_paths:
-    - "docs/architecture/**"
+    - "docs/internal/architecture/**"
     - "docs/design/**"
     - "diagrams/**"
     - "*.md"

--- a/.claude/agents/governance-specialist.md
+++ b/.claude/agents/governance-specialist.md
@@ -6,7 +6,7 @@ tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
 ---
 
-You are a governance specialist operating in isolation for context efficiency. Your role is to enforce engineering standards from `docs/architecture/standards.md` and execute the governance skill autonomously.
+You are a governance specialist operating in isolation for context efficiency. Your role is to enforce engineering standards from `docs/internal/architecture/standards.md` and execute the governance skill autonomously.
 
 ## Operating Protocol
 
@@ -35,7 +35,7 @@ When verifying before commit:
 When running a retro:
 1. Analyze completed issues and PRs
 2. Gather metrics (issues closed, code review findings, etc.)
-3. Write retro report to `docs/retros/YYYY-MM-DD-<topic>.md`
+3. Write retro report to `docs/internal/retros/YYYY-MM-DD-<topic>.md`
 
 ### Standards Audit
 When auditing compliance:

--- a/packages/core/src/analysis/__tests__/incremental.test.ts
+++ b/packages/core/src/analysis/__tests__/incremental.test.ts
@@ -7,7 +7,7 @@
  * - Incremental parse: < 100ms
  * - Tree cache hit rate: > 80%
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'

--- a/packages/core/src/analysis/__tests__/integration.test.ts
+++ b/packages/core/src/analysis/__tests__/integration.test.ts
@@ -8,7 +8,7 @@
  * - ParserWorkerPool with mixed language batches
  * - ResultAggregator combining results from multiple languages
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'

--- a/packages/core/src/analysis/__tests__/performance.test.ts
+++ b/packages/core/src/analysis/__tests__/performance.test.ts
@@ -9,7 +9,7 @@
  * - Memory budget: 500MB
  * - Cache hit rate: > 80%
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'

--- a/packages/core/src/analysis/adapters/__tests__/python.test.ts
+++ b/packages/core/src/analysis/adapters/__tests__/python.test.ts
@@ -5,7 +5,7 @@
  * Tests cover import/export extraction, function detection,
  * and framework detection rules.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'

--- a/packages/core/src/analysis/adapters/__tests__/typescript.test.ts
+++ b/packages/core/src/analysis/adapters/__tests__/typescript.test.ts
@@ -8,7 +8,7 @@
  * - Async function detection
  * - Backward compatibility with existing analyzer
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'

--- a/packages/core/src/analysis/adapters/base.ts
+++ b/packages/core/src/analysis/adapters/base.ts
@@ -5,7 +5,7 @@
  * Each adapter translates language-specific AST nodes into
  * the unified ParseResult format.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/adapters/base
  */
 

--- a/packages/core/src/analysis/adapters/factory.ts
+++ b/packages/core/src/analysis/adapters/factory.ts
@@ -4,7 +4,7 @@
  * Factory class for creating language adapters with lazy instantiation.
  * Avoids unnecessary adapter creation and provides centralized adapter management.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/adapters/factory
  */
 

--- a/packages/core/src/analysis/adapters/go.ts
+++ b/packages/core/src/analysis/adapters/go.ts
@@ -5,7 +5,7 @@
  * using regex-based parsing. Go uses capitalization-based visibility:
  * identifiers starting with uppercase are exported (public).
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { LanguageAdapter, type SupportedLanguage } from './base.js'

--- a/packages/core/src/analysis/adapters/index.ts
+++ b/packages/core/src/analysis/adapters/index.ts
@@ -5,7 +5,7 @@
  * Exports all language adapter classes and types for multi-language
  * codebase analysis.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 // Base adapter class and types

--- a/packages/core/src/analysis/adapters/java-parsers.ts
+++ b/packages/core/src/analysis/adapters/java-parsers.ts
@@ -4,7 +4,7 @@
  * Parses Maven pom.xml and Gradle build files to extract dependency information.
  * Extracted from java.ts for better modularity.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 /**

--- a/packages/core/src/analysis/adapters/java.ts
+++ b/packages/core/src/analysis/adapters/java.ts
@@ -8,7 +8,7 @@
  * - Generics in class and method declarations
  * - Interfaces, abstract classes, enums, and annotation types
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { LanguageAdapter, type SupportedLanguage } from './base.js'

--- a/packages/core/src/analysis/adapters/python-frameworks.ts
+++ b/packages/core/src/analysis/adapters/python-frameworks.ts
@@ -4,7 +4,7 @@
  * Framework detection rules for common Python frameworks and libraries.
  * Extracted from python.ts for better modularity.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import type { FrameworkRule } from './base.js'

--- a/packages/core/src/analysis/adapters/python.ts
+++ b/packages/core/src/analysis/adapters/python.ts
@@ -5,7 +5,7 @@
  * imports, exports, and function definitions using regex-based
  * parsing with optional tree-sitter support for incremental parsing.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { LanguageAdapter, type SupportedLanguage, type FrameworkRule } from './base.js'

--- a/packages/core/src/analysis/adapters/rust-parsers.ts
+++ b/packages/core/src/analysis/adapters/rust-parsers.ts
@@ -4,7 +4,7 @@
  * Parses Cargo.toml files to extract dependency information.
  * Extracted from rust.ts for better modularity.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 /**

--- a/packages/core/src/analysis/adapters/rust.ts
+++ b/packages/core/src/analysis/adapters/rust.ts
@@ -5,7 +5,7 @@
  * using regex-based parsing. Rust uses explicit `pub` visibility modifiers
  * for public items.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { LanguageAdapter, type SupportedLanguage } from './base.js'

--- a/packages/core/src/analysis/adapters/typescript.ts
+++ b/packages/core/src/analysis/adapters/typescript.ts
@@ -4,7 +4,7 @@
  * TypeScript/JavaScript adapter using the existing TypeScript compiler API.
  * Falls back to tree-sitter for incremental parsing (SMI-1309).
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { LanguageAdapter, type SupportedLanguage } from './base.js'

--- a/packages/core/src/analysis/aggregator.ts
+++ b/packages/core/src/analysis/aggregator.ts
@@ -5,7 +5,7 @@
  * Aggregates parse results from multiple languages into unified context.
  * Collects imports, exports, and functions across all analyzed files.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/aggregator
  */
 

--- a/packages/core/src/analysis/cache.ts
+++ b/packages/core/src/analysis/cache.ts
@@ -5,7 +5,7 @@
  * LRU cache for parse results with content hash validation.
  * Provides memory-based eviction to prevent memory exhaustion.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/cache
  */
 

--- a/packages/core/src/analysis/file-streamer.ts
+++ b/packages/core/src/analysis/file-streamer.ts
@@ -4,7 +4,7 @@
  * Memory-efficient file reading with streaming support for large files.
  * Provides generators for processing files without loading all into memory.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/file-streamer
  */
 

--- a/packages/core/src/analysis/incremental-parser.ts
+++ b/packages/core/src/analysis/incremental-parser.ts
@@ -7,7 +7,7 @@
  *
  * Performance target: < 100ms for incremental parse
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/incremental-parser
  */
 

--- a/packages/core/src/analysis/incremental.ts
+++ b/packages/core/src/analysis/incremental.ts
@@ -5,7 +5,7 @@
  * Enables efficient incremental parsing by detecting minimal
  * edit regions between old and new content.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/incremental
  */
 

--- a/packages/core/src/analysis/index.ts
+++ b/packages/core/src/analysis/index.ts
@@ -8,7 +8,7 @@
  * to extract context for skill recommendations.
  *
  * @see ADR-010: Codebase Analysis Scope
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 // Main analyzer class

--- a/packages/core/src/analysis/language-detector.ts
+++ b/packages/core/src/analysis/language-detector.ts
@@ -7,7 +7,7 @@
  * - Magic bytes detection
  * - Statistical analysis of keywords
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/language-detector
  */
 

--- a/packages/core/src/analysis/memory-monitor.ts
+++ b/packages/core/src/analysis/memory-monitor.ts
@@ -4,7 +4,7 @@
  * Monitors memory usage and triggers cleanup when thresholds are exceeded.
  * Integrates with ParseCache for memory pressure handling.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/memory-monitor
  */
 

--- a/packages/core/src/analysis/metrics.ts
+++ b/packages/core/src/analysis/metrics.ts
@@ -9,7 +9,7 @@
  * - Memory usage (gauge)
  * - Error counts by type (counter)
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/metrics
  */
 

--- a/packages/core/src/analysis/router.ts
+++ b/packages/core/src/analysis/router.ts
@@ -7,7 +7,7 @@
  * Detects file language and dispatches to appropriate adapter.
  * Manages adapter registry and provides unified access to framework rules.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/router
  */
 

--- a/packages/core/src/analysis/tree-cache.ts
+++ b/packages/core/src/analysis/tree-cache.ts
@@ -7,7 +7,7 @@
  * Tree-sitter trees hold native resources and must be explicitly
  * deleted to free memory. This cache handles that lifecycle.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/tree-cache
  */
 

--- a/packages/core/src/analysis/tree-sitter/manager.ts
+++ b/packages/core/src/analysis/tree-sitter/manager.ts
@@ -4,7 +4,7 @@
  * Manages tree-sitter parser instances with lazy loading.
  * Uses web-tree-sitter (WASM) to avoid native module conflicts.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @see ADR-002: Docker glibc Requirement
  * @module analysis/tree-sitter/manager
  */

--- a/packages/core/src/analysis/tree-sitter/queries/go.scm
+++ b/packages/core/src/analysis/tree-sitter/queries/go.scm
@@ -3,7 +3,7 @@
 ; Tree-sitter queries for extracting imports, exports, functions,
 ; and type definitions from Go source files.
 ;
-; @see docs/architecture/multi-language-analysis.md
+; @see docs/internal/architecture/multi-language-analysis.md
 
 ; ==================================
 ; Package Declaration

--- a/packages/core/src/analysis/tree-sitter/queries/java.scm
+++ b/packages/core/src/analysis/tree-sitter/queries/java.scm
@@ -3,7 +3,7 @@
 ; Tree-sitter queries for extracting imports, exports, functions,
 ; and type definitions from Java source files.
 ;
-; @see docs/architecture/multi-language-analysis.md
+; @see docs/internal/architecture/multi-language-analysis.md
 
 ; ==================================
 ; Package Declaration

--- a/packages/core/src/analysis/tree-sitter/queries/python.scm
+++ b/packages/core/src/analysis/tree-sitter/queries/python.scm
@@ -4,7 +4,7 @@
 ; from Python files using tree-sitter.
 ;
 ; These queries will be used for incremental parsing in SMI-1309.
-; @see docs/architecture/multi-language-analysis.md
+; @see docs/internal/architecture/multi-language-analysis.md
 
 ; ====================
 ; Import Statements

--- a/packages/core/src/analysis/tree-sitter/queries/rust.scm
+++ b/packages/core/src/analysis/tree-sitter/queries/rust.scm
@@ -3,7 +3,7 @@
 ; Tree-sitter queries for extracting imports, exports, functions,
 ; and type definitions from Rust source files.
 ;
-; @see docs/architecture/multi-language-analysis.md
+; @see docs/internal/architecture/multi-language-analysis.md
 
 ; ==================================
 ; Use Statements

--- a/packages/core/src/analysis/tree-sitter/queries/typescript.scm
+++ b/packages/core/src/analysis/tree-sitter/queries/typescript.scm
@@ -4,7 +4,7 @@
 ; from TypeScript/JavaScript files using tree-sitter.
 ;
 ; These queries will be used for incremental parsing in SMI-1309.
-; @see docs/architecture/multi-language-analysis.md
+; @see docs/internal/architecture/multi-language-analysis.md
 
 ; ====================
 ; Import Statements

--- a/packages/core/src/analysis/types.ts
+++ b/packages/core/src/analysis/types.ts
@@ -6,7 +6,7 @@
  * Type definitions for multi-language codebase analysis.
  *
  * @see ADR-010: Codebase Analysis Scope
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/types
  */
 

--- a/packages/core/src/analysis/worker-pool.ts
+++ b/packages/core/src/analysis/worker-pool.ts
@@ -5,7 +5,7 @@
  * Uses Node.js worker_threads for true parallelism,
  * bypassing the single-threaded event loop limitation.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/worker-pool
  */
 

--- a/packages/core/src/analysis/worker-types.ts
+++ b/packages/core/src/analysis/worker-types.ts
@@ -4,7 +4,7 @@
  * Type definitions for the worker thread pool.
  * Extracted from worker-pool.ts for better modularity.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/worker-types
  */
 

--- a/packages/core/src/analysis/worker-utils.ts
+++ b/packages/core/src/analysis/worker-utils.ts
@@ -4,7 +4,7 @@
  * Utility functions for the worker thread pool.
  * Extracted from worker-pool.ts for better modularity.
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  * @module analysis/worker-utils
  */
 

--- a/packages/core/tests/adapters-factory.test.ts
+++ b/packages/core/tests/adapters-factory.test.ts
@@ -7,7 +7,7 @@
  * - Caching behavior
  * - Extension mapping
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'

--- a/packages/core/tests/integration/neural/e2e-learning.test.ts
+++ b/packages/core/tests/integration/neural/e2e-learning.test.ts
@@ -11,7 +11,7 @@
  * 4. Learning persists across session restart
  *
  * @see packages/core/src/learning/interfaces.ts
- * @see docs/execution/phase5-testing-execution.md
+ * @see docs/internal/execution/phase5-testing-execution.md
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'

--- a/packages/core/tests/integration/neural/personalization.test.ts
+++ b/packages/core/tests/integration/neural/personalization.test.ts
@@ -15,7 +15,7 @@
  * 8. Personalization disabled by user preference
  *
  * @see packages/core/src/learning/interfaces.ts
- * @see docs/execution/phase5-testing-execution.md
+ * @see docs/internal/execution/phase5-testing-execution.md
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'

--- a/packages/core/tests/integration/neural/preference-learner.test.ts
+++ b/packages/core/tests/integration/neural/preference-learner.test.ts
@@ -17,7 +17,7 @@
  * 10. Profile persistence across sessions
  *
  * @see packages/core/src/learning/interfaces.ts
- * @see docs/execution/phase5-testing-execution.md
+ * @see docs/internal/execution/phase5-testing-execution.md
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'

--- a/packages/core/tests/integration/neural/privacy.test.ts
+++ b/packages/core/tests/integration/neural/privacy.test.ts
@@ -13,7 +13,7 @@
  * 6. Privacy audit log records all operations
  *
  * @see packages/core/src/learning/interfaces.ts
- * @see docs/execution/phase5-testing-execution.md
+ * @see docs/internal/execution/phase5-testing-execution.md
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'

--- a/packages/core/tests/integration/neural/signal-collection.test.ts
+++ b/packages/core/tests/integration/neural/signal-collection.test.ts
@@ -15,7 +15,7 @@
  * 8. Query signals by date range
  *
  * @see packages/core/src/learning/interfaces.ts
- * @see docs/execution/phase5-testing-execution.md
+ * @see docs/internal/execution/phase5-testing-execution.md
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'

--- a/packages/core/tests/language-detector.test.ts
+++ b/packages/core/tests/language-detector.test.ts
@@ -7,7 +7,7 @@
  * - Statistical keyword analysis
  * - Confidence scoring
  *
- * @see docs/architecture/multi-language-analysis.md
+ * @see docs/internal/architecture/multi-language-analysis.md
  */
 
 import { describe, it, expect } from 'vitest'

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -163,17 +163,15 @@ try {
   fail(`Error checking test files: ${e.message}`)
 }
 
-// 5. Standards.md exists (supports both old path and submodule path)
+// 5. Standards.md exists (in private submodule)
 console.log(`\n${BOLD}5. Documentation${RESET}`)
-const standardsPath = existsSync('docs/architecture/standards.md')
-  ? 'docs/architecture/standards.md'
-  : existsSync('docs/internal/architecture/standards.md')
-    ? 'docs/internal/architecture/standards.md'
-    : null
+const standardsPath = existsSync('docs/internal/architecture/standards.md')
+  ? 'docs/internal/architecture/standards.md'
+  : null
 if (standardsPath) {
   pass(`standards.md exists (${standardsPath})`)
 } else {
-  // Standards may be in private submodule not initialized in this environment
+  // Standards are in private submodule — not available without org access
   warn('standards.md not found (init submodule: git submodule update --init)')
 }
 
@@ -183,19 +181,15 @@ if (existsSync('CLAUDE.md')) {
   fail('CLAUDE.md not found', 'Create at project root')
 }
 
-// 6. ADR Directory (supports both old path and submodule path)
+// 6. ADR Directory (in private submodule)
 console.log(`\n${BOLD}6. Architecture Decision Records${RESET}`)
-const adrPath = existsSync('docs/adr')
-  ? 'docs/adr'
-  : existsSync('docs/internal/adr')
-    ? 'docs/internal/adr'
-    : null
+const adrPath = existsSync('docs/internal/adr') ? 'docs/internal/adr' : null
 if (adrPath) {
   const adrs = readdirSync(adrPath).filter((f) => f.endsWith('.md'))
   pass(`${adrPath}/ exists with ${adrs.length} ADRs`)
 } else {
-  // ADRs may be in private submodule not initialized in this environment
-  warn('docs/adr/ not found (init submodule: git submodule update --init)')
+  // ADRs are in private submodule — not available without org access
+  warn('docs/internal/adr/ not found (init submodule: git submodule update --init)')
 }
 
 // 7. Pre-commit Hooks

--- a/scripts/pre-impl-check.mjs
+++ b/scripts/pre-impl-check.mjs
@@ -102,11 +102,9 @@ function getTypeScriptFiles(dir) {
  * @returns {object} Naming conventions object
  */
 function loadNamingConventions() {
-  const standardsPath = existsSync(join(ROOT_DIR, 'docs/architecture/standards.md'))
-    ? join(ROOT_DIR, 'docs/architecture/standards.md')
-    : existsSync(join(ROOT_DIR, 'docs/internal/architecture/standards.md'))
-      ? join(ROOT_DIR, 'docs/internal/architecture/standards.md')
-      : null
+  const standardsPath = existsSync(join(ROOT_DIR, 'docs/internal/architecture/standards.md'))
+    ? join(ROOT_DIR, 'docs/internal/architecture/standards.md')
+    : null
   if (!standardsPath) {
     return null
   }
@@ -449,12 +447,10 @@ async function main() {
 
     section('General Pre-Implementation Checks')
 
-    // Check standards.md exists (supports both old path and submodule path)
-    const stdPath = existsSync(join(ROOT_DIR, 'docs/architecture/standards.md'))
-      ? join(ROOT_DIR, 'docs/architecture/standards.md')
-      : existsSync(join(ROOT_DIR, 'docs/internal/architecture/standards.md'))
-        ? join(ROOT_DIR, 'docs/internal/architecture/standards.md')
-        : null
+    // Check standards.md exists (in private submodule)
+    const stdPath = existsSync(join(ROOT_DIR, 'docs/internal/architecture/standards.md'))
+      ? join(ROOT_DIR, 'docs/internal/architecture/standards.md')
+      : null
     if (stdPath) {
       pass('standards.md exists and is accessible')
     } else {

--- a/scripts/pre-push-check.sh
+++ b/scripts/pre-push-check.sh
@@ -57,8 +57,9 @@ if [ -f .gitattributes ] && grep -q "filter=git-crypt" .gitattributes 2>/dev/nul
     done < <(git diff --name-only 2>/dev/null)
 
     if [ $SMUDGE_ARTIFACT_COUNT -gt 0 ]; then
-      echo -e "${YELLOW}⚠️  Detected ${SMUDGE_ARTIFACT_COUNT} git-crypt smudge artifacts (excluded from format checks)${NC}"
+      echo -e "${YELLOW}⚠️  Detected ${SMUDGE_ARTIFACT_COUNT} git-crypt smudge artifacts${NC}"
       echo -e "${YELLOW}   These are expected in git-crypt repos and do not affect push safety.${NC}"
+      echo -e "${YELLOW}   Encrypted paths are excluded from Prettier via .prettierignore.${NC}"
     fi
   fi
 fi


### PR DESCRIPTION
## Summary
- **SMI-2614**: Fix misleading smudge artifact message in `pre-push-check.sh` — clarifies that encrypted paths are excluded via `.prettierignore`
- **SMI-2615**: Update 3 stale `docs/architecture/` refs in `.claude/agents/` files to `docs/internal/` paths
- **SMI-2616**: Migrate 44 JSDoc `@see` references across `packages/core/` from `docs/architecture/` and `docs/execution/` to `docs/internal/` paths
- **SMI-2617**: Remove 4 dead old-path fallback ternaries in `audit-standards.mjs` and `pre-impl-check.mjs`
- **SMI-2618**: Document double-smudge recovery technique in `docs/development/git-crypt-guide.md`

## Context
These are the 5 action items from the [git-crypt remediation retrospective](https://github.com/smith-horn/skillsmith/blob/main/docs/internal/retros/2026-02-17-git-crypt-remediation.md). All changes are cosmetic (comments, docs, dead code removal) — no runtime behavior changes.

## Test plan
- [ ] CI typecheck passes (JSDoc changes are comment-only)
- [ ] CI lint passes (no new warnings)
- [ ] `npm run audit:standards` passes with submodule initialized
- [ ] Verify zero remaining `docs/architecture/` refs in `packages/core/` source files

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)