### PR TITLE
docs(git-crypt): document worktree skill readability check (SMI-2676)

### DIFF
--- a/.claude/development/git-crypt-guide.md
+++ b/.claude/development/git-crypt-guide.md
@@ -90,6 +90,11 @@ The script handles:
 2. Creates worktree with `--no-checkout` to avoid smudge filter errors
 3. Copies git-crypt keys to worktree's gitdir
 4. Checks out files with decryption working
+   - 4b. Initializes submodules (`docs/internal`)
+   - 4c. Scans `.claude/skills/**` for encrypted files; warns with `varlock run -- git-crypt unlock` command if any remain binary (SMI-2676)
+5. Generates Docker override file
+
+**If step 4c warns**: skills like `/launchpad` Stage 4 (`hive-mind-execution`) will silently degrade until git-crypt is unlocked in the worktree. Run the printed unlock command before using `/launchpad`.
 
 ### Manual Method
 


### PR DESCRIPTION
## Summary

Updates `git-crypt-guide.md` Worktree Setup section to reflect the new substeps 4b/4c added in SMI-2676 (PR #181):

- Documents that step 4c scans `.claude/skills/**` for encrypted files and warns with the `varlock run -- git-crypt unlock` command
- Adds a callout explaining that `/launchpad` Stage 4 will degrade silently if skills remain encrypted

Docs-only change — no code modified.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)