### PR TITLE
feat(website): HomepageCategoryGrid component + Variant B gate + GA4 tracking (Wave 3)

### DIFF
--- a/packages/website/src/components/HomepageCategoryGrid.astro
+++ b/packages/website/src/components/HomepageCategoryGrid.astro
@@ -1,0 +1,120 @@
+---
+/**
+ * HomepageCategoryGrid
+ *
+ * Homepage category discovery section for Variant B of the A/B test.
+ * Shown to users assigned variant-b via the sk_ab_variant cookie.
+ *
+ * Links to /skills/[category] landing pages (Wave 2).
+ * GA4 click tracking wired via data-category + data-variant attributes.
+ *
+ * SMI-2708: Homepage Conversion & A/B Test — Wave 3
+ */
+
+interface Props {
+  abVariant: string
+}
+const { abVariant } = Astro.props
+
+const CATEGORIES = [
+  {
+    slug: 'development',
+    label: 'Development',
+    description: 'Code generation, refactoring, and PR reviews.',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" /></svg>',
+  },
+  {
+    slug: 'integrations',
+    label: 'Integrations',
+    description: 'MCP servers, APIs, and protocol connectors.',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>',
+  },
+  {
+    slug: 'testing',
+    label: 'Testing',
+    description: 'Unit, integration, and end-to-end test automation.',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>',
+  },
+  {
+    slug: 'devops',
+    label: 'DevOps',
+    description: 'CI/CD, Docker, and infrastructure automation.',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>',
+  },
+  {
+    slug: 'documentation',
+    label: 'Documentation',
+    description: 'Changelogs, API docs, and README generation.',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>',
+  },
+  {
+    slug: 'productivity',
+    label: 'Productivity',
+    description: 'Workflow automation and task management.',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>',
+  },
+  {
+    slug: 'security',
+    label: 'Security',
+    description: 'Vulnerability scanning and compliance automation.',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" /></svg>',
+  },
+] as const
+---
+
+<section class="py-20 border-t border-white/[0.06]">
+  <div class="max-w-[1100px] mx-auto px-6">
+    <div class="text-center mb-10">
+      <h2 class="text-2xl sm:text-3xl font-bold mb-3">Browse by Category</h2>
+      <p class="text-[#A1A1AA]">Find the right skills for your workflow</p>
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 mb-10">
+      {
+        CATEGORIES.map((cat) => (
+          <a
+            href={`/skills/${cat.slug}`}
+            class="group flex flex-col gap-3 p-5 rounded-xl border border-white/[0.06] hover:border-primary-500/40 bg-[#18181B]/50 hover:bg-[#18181B] transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0D0D0F]"
+            data-category={cat.slug}
+            data-variant={abVariant}
+          >
+            <div
+              class="w-10 h-10 rounded-lg bg-[#E07A5F]/10 flex items-center justify-center text-primary-400"
+              set:html={cat.icon}
+            />
+            <div>
+              <h3 class="font-semibold text-[#FAFAFA] group-hover:text-white transition-colors text-sm">
+                {cat.label}
+              </h3>
+              <p class="text-xs text-[#A1A1AA] mt-0.5 leading-relaxed">{cat.description}</p>
+            </div>
+          </a>
+        ))
+      }
+    </div>
+
+    <div class="text-center">
+      <a
+        href="/skills"
+        class="text-sm text-primary-400 hover:text-primary-300 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:rounded"
+      >
+        Browse all 14,000+ skills &rarr;
+      </a>
+    </div>
+  </div>
+</section>
+
+<script is:inline define:vars={{ abVariant }}>
+  document.addEventListener('astro:page-load', function () {
+    document.querySelectorAll('[data-category][data-variant]').forEach(function (el) {
+      el.addEventListener('click', function () {
+        if (typeof gtag === 'function') {
+          gtag('event', 'homepage_category_click', {
+            category: el.dataset.category,
+            variant: el.dataset.variant,
+          })
+        }
+      })
+    })
+  })
+</script>

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -16,6 +16,8 @@ import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
 import { getSupabaseConfig } from '../lib/supabase-config'
 import '../styles/global.css'
+import HomepageCategoryGrid from '../components/HomepageCategoryGrid.astro'
+const abVariant = Astro.locals.abVariant
 
 // Get Supabase config for auth-aware navigation
 const supabaseConfig = getSupabaseConfig()
@@ -407,6 +409,7 @@ const jsonLd = {
         </div>
       </section>
 
+      {abVariant === 'variant-b' && <HomepageCategoryGrid abVariant={abVariant} />}
       <!-- Value Props Section -->
       <section class="py-24 border-t border-white/[0.06]">
         <div class="max-w-[1200px] mx-auto px-6">
@@ -868,6 +871,15 @@ const jsonLd = {
             }
           })
         })
+      })
+    </script>
+
+    <!-- GA4: Track A/B variant for all visitors (SMI-2709) -->
+    <script is:inline define:vars={{ abVariant }}>
+      document.addEventListener('astro:page-load', function () {
+        if (typeof gtag === 'function') {
+          gtag('event', 'homepage_ab_variant', { variant: abVariant })
+        }
       })
     </script>
 

--- a/packages/website/src/pages/skills/[category].astro
+++ b/packages/website/src/pages/skills/[category].astro
@@ -13,92 +13,98 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 
 export const prerender = true
 
-const CATEGORIES = [
-  {
-    slug: 'development',
-    label: 'Development',
-    h1: 'Development Skills for Claude Code',
-    metaDescription:
-      'Browse 14,000+ development skills for Claude Code. Code generation, refactoring, PR reviews, and IDE integrations. Free to try.',
-    description:
-      'Skills for software development workflows — code generation, refactoring, PR reviews, and IDE integrations that make Claude Code a better coding partner.',
-    jsonLdDescription:
-      'Claude Code skills for software development workflows including code generation, refactoring, and PR reviews.',
-  },
-  {
-    slug: 'integrations',
-    label: 'Integrations',
-    h1: 'Integration Skills — MCP Servers & APIs',
-    metaDescription:
-      'Connect Claude Code to your tools. Browse MCP server skills, API integrations, and protocol implementations. Free to try.',
-    description:
-      'MCP servers, API integrations, and protocol implementations that connect Claude Code to your existing tools and services.',
-    jsonLdDescription:
-      'Claude Code skills for MCP servers, API integrations, and protocol implementations.',
-  },
-  {
-    slug: 'testing',
-    label: 'Testing',
-    h1: 'Testing Skills for Claude Code',
-    metaDescription:
-      'Automate your tests with Claude Code. Browse skills for Vitest, Jest, Playwright, and more testing frameworks. Free to try.',
-    description:
-      'Testing frameworks and utilities for unit, integration, and end-to-end test automation across all major testing tools.',
-    jsonLdDescription:
-      'Claude Code skills for automated testing including unit tests, integration tests, and end-to-end test automation.',
-  },
-  {
-    slug: 'devops',
-    label: 'DevOps',
-    h1: 'DevOps Skills for Claude Code',
-    metaDescription:
-      'Automate your DevOps pipelines. Browse skills for Docker, CI/CD, Kubernetes, and infrastructure tools. Free to try.',
-    description:
-      'CI/CD, Docker, Kubernetes, and infrastructure automation skills for DevOps workflows and deployment pipelines.',
-    jsonLdDescription:
-      'Claude Code skills for DevOps including CI/CD automation, Docker, Kubernetes, and infrastructure management.',
-  },
-  {
-    slug: 'documentation',
-    label: 'Documentation',
-    h1: 'Documentation Skills for Claude Code',
-    metaDescription:
-      'Generate docs automatically with Claude Code. Browse skills for changelogs, API docs, and README generation. Free to try.',
-    description:
-      'Documentation generation, changelog automation, and API doc skills that keep your docs current with your code.',
-    jsonLdDescription:
-      'Claude Code skills for documentation generation including changelogs, API docs, and README automation.',
-  },
-  {
-    slug: 'productivity',
-    label: 'Productivity',
-    h1: 'Productivity Skills for Claude Code',
-    metaDescription:
-      'Work smarter with Claude Code. Browse skills for workflow automation, task management, and developer productivity. Free to try.',
-    description:
-      'Workflow automation, task management, and productivity skills for developers who want to move faster on every task.',
-    jsonLdDescription:
-      'Claude Code skills for developer productivity including workflow automation and task management.',
-  },
-  {
-    slug: 'security',
-    label: 'Security',
-    h1: 'Security Skills for Claude Code',
-    metaDescription:
-      'Harden your codebase with Claude Code. Browse skills for security scanning, vulnerability detection, and compliance. Free to try.',
-    description:
-      'Security scanning, vulnerability detection, and compliance skills that help you build secure by default.',
-    jsonLdDescription:
-      'Claude Code skills for security scanning, vulnerability detection, and compliance automation.',
-  },
-] as const
-
 export function getStaticPaths() {
+  const CATEGORIES = [
+    {
+      slug: 'development',
+      label: 'Development',
+      h1: 'Development Skills for Claude Code',
+      metaDescription:
+        'Browse 14,000+ development skills for Claude Code. Code generation, refactoring, PR reviews, and IDE integrations. Free to try.',
+      description:
+        'Skills for software development workflows — code generation, refactoring, PR reviews, and IDE integrations that make Claude Code a better coding partner.',
+      jsonLdDescription:
+        'Claude Code skills for software development workflows including code generation, refactoring, and PR reviews.',
+    },
+    {
+      slug: 'integrations',
+      label: 'Integrations',
+      h1: 'Integration Skills — MCP Servers & APIs',
+      metaDescription:
+        'Connect Claude Code to your tools. Browse MCP server skills, API integrations, and protocol implementations. Free to try.',
+      description:
+        'MCP servers, API integrations, and protocol implementations that connect Claude Code to your existing tools and services.',
+      jsonLdDescription:
+        'Claude Code skills for MCP servers, API integrations, and protocol implementations.',
+    },
+    {
+      slug: 'testing',
+      label: 'Testing',
+      h1: 'Testing Skills for Claude Code',
+      metaDescription:
+        'Automate your tests with Claude Code. Browse skills for Vitest, Jest, Playwright, and more testing frameworks. Free to try.',
+      description:
+        'Testing frameworks and utilities for unit, integration, and end-to-end test automation across all major testing tools.',
+      jsonLdDescription:
+        'Claude Code skills for automated testing including unit tests, integration tests, and end-to-end test automation.',
+    },
+    {
+      slug: 'devops',
+      label: 'DevOps',
+      h1: 'DevOps Skills for Claude Code',
+      metaDescription:
+        'Automate your DevOps pipelines. Browse skills for Docker, CI/CD, Kubernetes, and infrastructure tools. Free to try.',
+      description:
+        'CI/CD, Docker, Kubernetes, and infrastructure automation skills for DevOps workflows and deployment pipelines.',
+      jsonLdDescription:
+        'Claude Code skills for DevOps including CI/CD automation, Docker, Kubernetes, and infrastructure management.',
+    },
+    {
+      slug: 'documentation',
+      label: 'Documentation',
+      h1: 'Documentation Skills for Claude Code',
+      metaDescription:
+        'Generate docs automatically with Claude Code. Browse skills for changelogs, API docs, and README generation. Free to try.',
+      description:
+        'Documentation generation, changelog automation, and API doc skills that keep your docs current with your code.',
+      jsonLdDescription:
+        'Claude Code skills for documentation generation including changelogs, API docs, and README automation.',
+    },
+    {
+      slug: 'productivity',
+      label: 'Productivity',
+      h1: 'Productivity Skills for Claude Code',
+      metaDescription:
+        'Work smarter with Claude Code. Browse skills for workflow automation, task management, and developer productivity. Free to try.',
+      description:
+        'Workflow automation, task management, and productivity skills for developers who want to move faster on every task.',
+      jsonLdDescription:
+        'Claude Code skills for developer productivity including workflow automation and task management.',
+    },
+    {
+      slug: 'security',
+      label: 'Security',
+      h1: 'Security Skills for Claude Code',
+      metaDescription:
+        'Harden your codebase with Claude Code. Browse skills for security scanning, vulnerability detection, and compliance. Free to try.',
+      description:
+        'Security scanning, vulnerability detection, and compliance skills that help you build secure by default.',
+      jsonLdDescription:
+        'Claude Code skills for security scanning, vulnerability detection, and compliance automation.',
+    },
+  ] as const
   return CATEGORIES.map((cat) => ({ params: { category: cat.slug }, props: cat }))
 }
 
-type Props = (typeof CATEGORIES)[number]
-const { slug, label, h1, metaDescription, description } = Astro.props as Props
+type Props = {
+  slug: string
+  label: string
+  h1: string
+  metaDescription: string
+  description: string
+  jsonLdDescription: string
+}
+const { slug, label, h1, metaDescription, description } = Astro.props
 
 const canonicalUrl = `https://www.skillsmith.app/skills/${slug}`
 
@@ -139,8 +145,7 @@ const jsonLd = [
         <li><a href="/" class="text-dark-500 hover:text-primary-400 transition-colors">Home</a></li>
         <li class="text-dark-600" aria-hidden="true">/</li>
         <li>
-          <a href="/skills" class="text-dark-500 hover:text-primary-400 transition-colors"
-            >Skills</a
+          <a href="/skills" class="text-dark-500 hover:text-primary-400 transition-colors">Skills</a
           >
         </li>
         <li class="text-dark-600" aria-hidden="true">/</li>


### PR DESCRIPTION
## Summary

- Create `HomepageCategoryGrid.astro` — 7 category cards with WCAG-compliant focus rings, inline SVG icons, GA4 click tracking
- Update `index.astro` (minimal: +12 lines) — import component, conditional render for `variant-b`, GA4 variant dimension tracking
- Also fix `[category].astro` Astro scope bug: `CATEGORIES` moved inside `getStaticPaths()` to fix build error (Astro instance vs static scope)

## Linear

Closes SMI-2708, SMI-2709
Parent: SMI-2699 — Wave 3: Homepage Variant B

## Wave 3 stacking note

This PR is stacked on Wave 1 (`smi-2697-homepage-ab-wave1`) and Wave 2 (`smi-2698-homepage-ab-wave2`). **Merge order**: Wave 1 → Wave 2 → Wave 3. All changes from Wave 1 + Wave 2 are included in this branch.

## Files changed

| File | Change | Lines |
|------|--------|-------|
| `src/components/HomepageCategoryGrid.astro` | New | 120 |
| `src/pages/index.astro` | +12 lines | 1040 |
| `src/pages/skills/[category].astro` | Scope fix for `getStaticPaths()` | 189 |

## A/B experiment design

- **Control** (50%): current homepage, no category grid
- **Variant B** (50%): homepage + `HomepageCategoryGrid` inserted after MCP install section
- Cookie: `sk_ab_variant` (30-day, `SameSite=Lax`, `Secure`)
- Kill switch: `HOMEPAGE_AB_ENABLED=false` in Vercel env → all users get control
- GA4: `homepage_ab_variant` fires for all visitors; `homepage_category_click` fires per card click

## Test plan

- [ ] `docker exec skillsmith-dev-1 npm run build` — 6/6 tasks ✓
- [ ] `docker exec skillsmith-dev-1 npm test` — 5,575 passed ✓
- [ ] `docker exec skillsmith-dev-1 npm run lint` — zero warnings ✓
- [ ] `docker exec skillsmith-dev-1 npm run typecheck` — clean ✓
- [ ] `docker exec skillsmith-dev-1 npm run audit:standards` — 29/29 ✓
- [ ] Verify `HomepageCategoryGrid` renders on homepage with `sk_ab_variant=variant-b` cookie
- [ ] Verify component does NOT render with `sk_ab_variant=control`
- [ ] Verify GA4 `homepage_ab_variant` event fires for both cohorts
- [ ] Verify GA4 `homepage_category_click` fires on card click
- [ ] Verify focus ring visible on category card keyboard navigation (WCAG 2.2 SC 2.4.11)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)