### PR TITLE
feat(website): show active CLI tokens with revoke on /account/cli-token (SMI-2720)

### DIFF
--- a/packages/website/src/pages/account/cli-token.astro
+++ b/packages/website/src/pages/account/cli-token.astro
@@ -154,6 +154,16 @@ const supabaseConfig = getSupabaseConfig()
     <script>
       import { createClient } from '@supabase/supabase-js'
 
+      // XSS-safe HTML escaping helper (module scope — defined once across navigations)
+      function escapeHtml(str: string): string {
+        return str
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;')
+      }
+
       document.addEventListener('astro:page-load', async () => {
         const config = window.__SUPABASE_CONFIG__
         const supabaseUrl = config?.url
@@ -231,16 +241,6 @@ const supabaseConfig = getSupabaseConfig()
           .eq('name', 'CLI Token')
           .order('created_at', { ascending: false })
 
-        // XSS-safe HTML escaping helper
-        function escapeHtml(str: string): string {
-          return str
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;')
-        }
-
         // Render active CLI tokens section
         const tokenCard = document.querySelector('.token-card')
         if (cliKeys && cliKeys.length > 0 && tokenCard) {
@@ -257,7 +257,7 @@ const supabaseConfig = getSupabaseConfig()
                 ${cliKeys
                   .map(
                     (key) => `
-                  <li class="key-item" data-key-id="${escapeHtml(key.id)}">
+                  <li class="key-item">
                     <div class="key-info">
                       <span class="key-prefix">${escapeHtml(key.key_prefix)}&hellip;</span>
                       <span class="key-meta">


### PR DESCRIPTION
## Summary

- Display active CLI tokens on `/account/cli-token` with masked key prefix, creation date, tier badge, and Revoke button — matches the existing revoke UI on `/account`
- Hide the "How to use" instructions card when a token already exists (prevents misleading "click Generate below" copy)
- Add targeted error message when generating while at the key limit, directing the user to revoke first
- All new CSS (`.keys-section`, `.key-item`, `.tier-badge.*`, `.btn-danger`) added inline, consistent with the page's dark palette

## Motivation

After `skillsmith login`, the generated token was invisible on this page. Revoking required navigating to `/account` → Revoke → return to `/account/cli-token`. This PR collapses that to a single page.

## Implementation notes

- Client-side fetch (after `getSession()`) — `cli-token.astro` has no SSR session; matches existing page pattern
- Filter: `name = 'CLI Token'` + `status = 'active'` — no schema change needed
- Revoke UPDATE includes `.eq('user_id', session.user.id)` defense-in-depth; RLS is the primary guard
- `escapeHtml()` at module scope (not inside the event handler) — defined once per page load
- `isLimitError` uses `status 400/429 + includes('limit')` — tolerant of API error message wording changes

## Test plan

- [ ] Log in via `skillsmith login`, visit `/account/cli-token` — active token appears above the generate card
- [ ] Click **Revoke** — confirm dialog, token disappears, page reloads cleanly
- [ ] With active token, instructions card is hidden
- [ ] Click **Generate CLI Token** while at community limit (1 key) — inline error "Revoke it above before generating"
- [ ] After revoke, generate works and new token displays in modal as before
- [ ] VoiceOver: revoke button reads "Revoke CLI token ending in sk_live_xxx"
- [ ] No regression to `/account` revoke flow

## Related

- Linear: [SMI-2720](https://linear.app/smith-horn-group/issue/SMI-2720)
- Plan: `docs/internal/implementation/smi-2720-cli-token-revoke.md` (VP-reviewed, 9 pre-code issues addressed)
- Code review: `docs/internal/code_review/2026-02-24-smi-2720-cli-token-revoke.md` (PASS)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)