### PR TITLE
chore: action retro key lessons (version pinning, .gitignore, bare-connection guard)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,7 +134,7 @@ wrangler.toml.local
 supabase/migrations/015_recalculate_quality_scores.sql
 scripts/trigger-quality-recalculation.sh
 docs/irap/
-worktrees/
+.worktrees/
 
 # MCP Registry tokens
 .mcpregistry_*

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "0.4.14",
+    "@skillsmith/core": "^0.4.14",
     "chalk": "5.6.2",
     "cli-table3": "0.6.5",
     "commander": "12.1.0",

--- a/packages/core/src/db/createDatabase.ts
+++ b/packages/core/src/db/createDatabase.ts
@@ -132,8 +132,16 @@ export function createDatabaseSync(path: string = ':memory:', options?: Database
  *
  * @param path - Path to database file, or ':memory:' for in-memory
  * @param options - Database connection options
- * @returns Promise resolving to Database instance
+ * @returns Promise resolving to Database instance (bare connection — caller must call initializeSchema)
  * @throws Error if no database driver is available
+ *
+ * @important This factory returns a **bare connection with no schema tables**. Unlike the
+ * sync path, no schema initialization happens automatically. Always call `initializeSchema(db)`
+ * immediately after for new/application databases:
+ * ```typescript
+ * const db = await createDatabaseAsync(path)
+ * initializeSchema(db)  // required — creates tables if they don't exist
+ * ```
  */
 export async function createDatabaseAsync(
   path: string = ':memory:',

--- a/packages/core/tests/db/database-abstraction.test.ts
+++ b/packages/core/tests/db/database-abstraction.test.ts
@@ -249,6 +249,21 @@ describe('Database Abstraction Layer', () => {
       expect(db.open).toBe(true)
       db.close()
     })
+
+    it('createDatabaseAsync (factory) returns bare connection with no schema tables', async () => {
+      // Regression guard for SMI-2207: createDatabaseAsync is a pure driver factory.
+      // It does NOT call initializeSchema. Callers must do so explicitly.
+      // If this test fails, someone added schema init to the factory — that breaks
+      // L2Cache, EmbeddingService, and HybridSearch which manage their own schemas.
+      if (!isBetterSqlite3Available()) return
+
+      const db = await createDatabaseAsync(':memory:')
+      const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+        name: string
+      }[]
+      expect(tables).toHaveLength(0)
+      db.close()
+    })
   })
 
   describe('BetterSqlite3Database Wrapper', () => {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.26.0",
-    "@skillsmith/core": "0.4.14",
+    "@skillsmith/core": "^0.4.14",
     "esbuild": "0.27.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- `.gitignore`: correct `.worktrees/` glob (same dot-prefix issue as the ESLint fix)
- `packages/cli`, `packages/mcp-server`: loosen `@skillsmith/core` pin to `^0.4.14` — exact pins cause CI to resolve from registry when core version bumps (the root cause of the SMI-2730–2734 session's CI failures)
- `packages/core/src/db/createDatabase.ts`: `@important` JSDoc on `createDatabaseAsync` documenting it returns a bare connection — callers must call `initializeSchema(db)` explicitly
- `packages/core/tests/db/database-abstraction.test.ts`: regression guard test — verifies the factory returns zero tables, catching any future implicit schema init that would break `L2Cache`, `EmbeddingService`, and `HybridSearch`

## Related

Linear: SMI-2741, SMI-2742, SMI-2743, SMI-2744

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npx vitest run packages/core/tests/db/database-abstraction.test.ts` — 21/21 pass

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)