### PR TITLE
fix(core): add createTestDatabase() helper — prevent migration trap in tests (SMI-2749)

### DIFF
--- a/packages/core/tests/SkillVersionRepository.test.ts
+++ b/packages/core/tests/SkillVersionRepository.test.ts
@@ -4,20 +4,16 @@
  * Tests for skill version hash tracking (SMI-skill-version-tracking Wave 1).
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { createDatabase, closeDatabase } from '../src/db/schema.js'
-import { MIGRATION_V5_SQL } from '../src/db/migrations/v5-skill-versions.js'
+import { createTestDatabase, closeDatabase } from './helpers/database.js'
 import { SkillVersionRepository } from '../src/repositories/SkillVersionRepository.js'
-import type { Database } from '../src/db/database-interface.js'
+import type { Database } from './helpers/database.js'
 
 describe('SkillVersionRepository', () => {
   let db: Database
   let repo: SkillVersionRepository
 
   beforeEach(() => {
-    db = createDatabase(':memory:')
-    // initializeSchema sets SCHEMA_VERSION=5 but only runs SCHEMA_SQL — the
-    // skill_versions table lives in the v5 migration, so we run it explicitly.
-    db.exec(MIGRATION_V5_SQL)
+    db = createTestDatabase()
     repo = new SkillVersionRepository(db)
   })
 

--- a/packages/core/tests/helpers/database.ts
+++ b/packages/core/tests/helpers/database.ts
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Test database helpers — prevents "no such table" for migrated tables
+ * @see SMI-2749
+ *
+ * Use createTestDatabase() instead of createDatabase(':memory:') whenever tests
+ * need tables that only exist in migration files (e.g. skill_versions).
+ *
+ * WHY THIS EXISTS:
+ * createDatabase(':memory:') calls initializeSchema(), which records SCHEMA_VERSION=5
+ * directly in schema_version WITHOUT running the intermediate migration SQLs.
+ * runMigrations() then sees version=5 and skips all migrations — a no-op.
+ * Tables defined only in migration SQL (not in SCHEMA_SQL) are never created.
+ * Example: skill_versions is in MIGRATION_V5_SQL, not SCHEMA_SQL.
+ *
+ * createTestDatabase() iterates MIGRATIONS directly (no version gate) so every
+ * migration's SQL runs unconditionally. New migrations added to MIGRATIONS are
+ * automatically included — no change required here.
+ */
+
+import { createDatabase, MIGRATIONS } from '../../src/db/schema.js'
+import type { Database } from '../../src/db/database-interface.js'
+
+// Re-exported for test convenience — tests only need to import from this module
+export { closeDatabase } from '../../src/db/schema.js'
+export type { Database } from '../../src/db/database-interface.js'
+
+/**
+ * Create an in-memory SQLite database with ALL schema + migrations applied.
+ *
+ * Safe to use for any test that needs migrated tables (e.g. skill_versions,
+ * sync_config, sync_history). Forward-compatible: new migrations added to
+ * MIGRATIONS are included automatically.
+ *
+ * @returns Database with full schema + all migrations applied
+ */
+export function createTestDatabase(): Database {
+  // createDatabase() calls initializeSchema() — runs SCHEMA_SQL (handling FTS5 triggers
+  // and multi-statement SQL correctly) and stamps SCHEMA_VERSION in schema_version.
+  const db = createDatabase()
+
+  // Run all migrations unconditionally (no version gate) so tables that only exist in
+  // migration SQL (not SCHEMA_SQL) are created. db.exec() handles multi-statement SQL
+  // natively — no semicolon split needed.
+  //
+  // "duplicate column" errors are caught: some migration SQL adds columns that are
+  // already included in the canonical SCHEMA_SQL. Those errors are expected and safe.
+  for (const migration of MIGRATIONS) {
+    try {
+      db.exec(migration.sql)
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      if (!msg.includes('duplicate column')) throw error
+    }
+    db.prepare('INSERT OR REPLACE INTO schema_version (version) VALUES (?)').run(migration.version)
+  }
+
+  return db
+}


### PR DESCRIPTION
## Summary

- Adds `packages/core/tests/helpers/database.ts` with `createTestDatabase()` helper
- Removes the explicit `db.exec(MIGRATION_V5_SQL)` workaround from `SkillVersionRepository.test.ts`
- Root cause: `createDatabase(':memory:')` calls `initializeSchema()` which stamps `SCHEMA_VERSION=5` without running migration SQL — tables only in migration files are never created

## How it works

`createTestDatabase()` uses `createDatabase()` for correct base-schema initialization, then runs all `MIGRATIONS` entries unconditionally (no version gate). Forward-compatible: new migrations are automatically included with no changes needed here.

## Related

- Linear: [SMI-2749](https://linear.app/smith-horn-group/issue/SMI-2749)
- Plan: `docs/internal/implementation/smi-2747-2749-smudge-filter-fixes.md` (v1.1, plan-reviewed)
- Documented in retro: `docs/internal/retros/2026-02-24-wave-1-skill-version-tracking.md`

## Test plan

- [x] All 20 `SkillVersionRepository` tests pass with `createTestDatabase()` — no explicit migration SQL in setup
- [x] `schema.ts` not modified — still 490 lines (under 500-line gate)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)