### PR TITLE
fix(core): declare better-sqlite3 as optionalDependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,9 @@
     "typescript": "5.9.3",
     "zod": "4.2.1"
   },
+  "optionalDependencies": {
+    "better-sqlite3": "11.10.0"
+  },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.13",
     "vitest": "4.0.16"


### PR DESCRIPTION
## Summary

- `better-sqlite3` was imported in `betterSqlite3Driver.ts` but not declared in `packages/core/package.json`
- Preflight check (SMI-760) flagged this as an undeclared dependency
- Added to `optionalDependencies` since the WASM fallback is available when the native module is absent (ADR-009)

## Test plan
- [x] `npm run preflight` passes (was failing before this fix)
- [x] TypeScript check passes

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)