### PR TITLE
docs(ci): add jq empty-string guard and worktree reset footgun warning (SMI-3010, SMI-3011)

### DIFF
--- a/.claude/development/ci-reference.md
+++ b/.claude/development/ci-reference.md
@@ -101,3 +101,21 @@ If required checks are stuck or GitHub Actions is down:
 ```bash
 gh api repos/Smith-Horn/skillsmith/branches/main/protection -X PUT --input .github/branch-protection.json
 ```
+
+## Wave Merge CI Polling (SMI-3010)
+
+When monitoring CI between sequential wave merges, always use `${VAR:-0}` not `$VAR` for `jq | length` results:
+
+```bash
+# WRONG — returns "" when statusCheckRollup is empty (checks not yet started)
+FAILED=$(gh pr view $PR --json statusCheckRollup \
+  --jq '[.statusCheckRollup[] | select(.conclusion == "FAILURE")] | length')
+[ "$FAILED" != "0" ] && echo "FAILED"  # "" != "0" is TRUE → false FAILURE
+
+# CORRECT — defaults to 0 when jq returns empty string
+FAILED=$(gh pr view $PR --json statusCheckRollup \
+  --jq '[.statusCheckRollup[] | select(.conclusion == "FAILURE")] | length')
+[ "${FAILED:-0}" != "0" ] && echo "FAILED"
+```
+
+**Rule**: Always wait for Wave N CI to show green before starting Wave N+1 rebase. Starting early saves <30s but risks a reflog recovery if Wave N's checks later fail.

--- a/.claude/development/git-crypt-guide.md
+++ b/.claude/development/git-crypt-guide.md
@@ -168,6 +168,22 @@ cd worktrees/<name> && git reset --hard HEAD
 
 Includes Docker network cleanup. Use `--force` flag if smudge artifacts block removal.
 
+### Worktree `git reset` Footgun (SMI-3011)
+
+**Worktrees share branch refs with the main repo.** Running `git reset --hard` inside a worktree moves the branch pointer in every checkout of that branch.
+
+```bash
+# DANGEROUS — this also moves smi-foo in the main repo
+cd .worktrees/smi-foo && git reset --hard origin/e2e-testing
+
+# SAFE — selectively restore files without touching branch pointers
+git checkout <sha> -- supabase/functions/my-fn/index.ts
+```
+
+If you need to land your Wave work after an accidental reset, use `git reflog` in the main repo to find the pre-reset commit and `git checkout <sha> -- <exclusive-files>` to restore only the files that belong to that wave.
+
+**Key rule**: Never use `git reset` inside a worktree for file-restoration purposes. Use `git checkout <sha> -- <paths>` instead.
+
 ### Important
 
 Git-crypt must be unlocked in the **main repo first** before creating worktrees:


### PR DESCRIPTION
## Summary

- **ci-reference.md**: Documents the `${FAILED:-0}` pattern for wave merge CI poll scripts. When `statusCheckRollup` is empty (checks not yet started), `jq | length` returns `""` not `"0"`, so `[ "$FAILED" != "0" ]` evaluates true → false FAILURE. Added correct/incorrect examples and the wave sequencing rule.
- **git-crypt-guide.md**: Adds a "Worktree `git reset` Footgun" section documenting that `git reset --hard` inside a worktree silently moves the shared branch ref in the main repo. Safe alternative: `git checkout <sha> -- <paths>`.

Both fixes close retro action items from SMI-2978 (2026-03-04-smi-2978-outreach-preferences retro).

## Test plan

- [ ] Docs-only CI passes (Secret Scan + Markdown Lint)
- [ ] Content matches the retro findings in `docs/internal/retros/2026-03-04-smi-2978-outreach-preferences.md`

Closes SMI-3010, SMI-3011