### PR TITLE
perf(website): defer gtag.js to idle + lazy-load web-vitals (SMI-2421, SMI-2420)

### DIFF
--- a/packages/website/src/layouts/BaseLayout.astro
+++ b/packages/website/src/layouts/BaseLayout.astro
@@ -69,6 +69,8 @@ const supabaseConfig = getSupabaseConfig()
     />
 
     <!-- Google Analytics with Consent Mode v2 -->
+    <!-- SMI-2421: Consent setup is synchronous (GA4 Consent Mode v2 requires defaults before gtag.js loads). -->
+    <!-- gtag.js script fetch is deferred to idle time via requestIdleCallback (setTimeout fallback for Safari <16.4). -->
     <script is:inline>
       window.dataLayer = window.dataLayer || []
       function gtag() {
@@ -85,12 +87,19 @@ const supabaseConfig = getSupabaseConfig()
       })
       gtag('js', new Date())
       gtag('config', 'G-GGZQZM1Y1L')
+      // Defer the 149KB gtag.js network fetch until idle — removes it from the critical path
+      function loadGtag() {
+        var s = document.createElement('script')
+        s.async = true
+        s.src = 'https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L'
+        document.head.appendChild(s)
+      }
+      if ('requestIdleCallback' in window) {
+        requestIdleCallback(loadGtag, { timeout: 3000 })
+      } else {
+        setTimeout(loadGtag, 1)
+      }
     </script>
-    <script
-      is:inline
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L"
-      fetchpriority="low"></script>
 
     <!-- Open Graph -->
     <meta property="og:title" content={title} />
@@ -145,8 +154,13 @@ const supabaseConfig = getSupabaseConfig()
     <CookieConsent />
 
     <!-- SMI-2344: Web Vitals RUM tracking (SMI-2363: shared module) -->
+    <!-- SMI-2420: Lazy-load via named export. Non-inline <script> so Astro/Vite can bundle correctly. -->
+    <!-- onLCP registers on astro:page-load (not inside idle callback) to avoid missing LCP events. -->
     <script>
-      import '../scripts/web-vitals'
+      import { registerWebVitals } from '../scripts/web-vitals'
+      document.addEventListener('astro:page-load', () => {
+        registerWebVitals()
+      })
     </script>
   </body>
 </html>

--- a/packages/website/src/pages/login.astro
+++ b/packages/website/src/pages/login.astro
@@ -33,6 +33,7 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
     <link rel="icon" type="image/svg+xml" href="/logo-icon.svg" />
 
     <!-- Google Analytics with Consent Mode v2 -->
+    <!-- SMI-2421: Consent setup synchronous; gtag.js fetch deferred to idle (requestIdleCallback / setTimeout fallback). -->
     <script is:inline>
       window.dataLayer = window.dataLayer || []
       function gtag() {
@@ -48,8 +49,18 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
       })
       gtag('js', new Date())
       gtag('config', 'G-GGZQZM1Y1L')
+      function loadGtag() {
+        var s = document.createElement('script')
+        s.async = true
+        s.src = 'https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L'
+        document.head.appendChild(s)
+      }
+      if ('requestIdleCallback' in window) {
+        requestIdleCallback(loadGtag, { timeout: 3000 })
+      } else {
+        setTimeout(loadGtag, 1)
+      }
     </script>
-    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L"></script>
 
     <meta
       name="description"

--- a/packages/website/src/pages/signup.astro
+++ b/packages/website/src/pages/signup.astro
@@ -52,6 +52,7 @@ const savingsPercent = period === 'annual' ? 17 : 0 // ~17% savings
     <link rel="canonical" href={`${import.meta.env.SITE}/signup/`} />
 
     <!-- Google Analytics with Consent Mode v2 -->
+    <!-- SMI-2421: Consent setup synchronous; gtag.js fetch deferred to idle (requestIdleCallback / setTimeout fallback). -->
     <script is:inline>
       window.dataLayer = window.dataLayer || []
       function gtag() {
@@ -67,8 +68,18 @@ const savingsPercent = period === 'annual' ? 17 : 0 // ~17% savings
       })
       gtag('js', new Date())
       gtag('config', 'G-GGZQZM1Y1L')
+      function loadGtag() {
+        var s = document.createElement('script')
+        s.async = true
+        s.src = 'https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L'
+        document.head.appendChild(s)
+      }
+      if ('requestIdleCallback' in window) {
+        requestIdleCallback(loadGtag, { timeout: 3000 })
+      } else {
+        setTimeout(loadGtag, 1)
+      }
     </script>
-    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L"></script>
 
     <meta
       name="description"

--- a/packages/website/src/scripts/web-vitals.ts
+++ b/packages/website/src/scripts/web-vitals.ts
@@ -1,9 +1,14 @@
 /**
- * Web Vitals RUM tracking (SMI-2344, SMI-2363)
+ * Web Vitals RUM tracking (SMI-2344, SMI-2363, SMI-2420)
  *
  * Shared module for Core Web Vitals reporting.
  * Used by BaseLayout and standalone pages (index.astro).
- * Side-effect import: registers LCP, CLS, INP observers on load.
+ *
+ * SMI-2420: Changed from side-effect import to named export.
+ * Call registerWebVitals() inside an astro:page-load listener to defer
+ * the web-vitals bundle load without missing LCP events.
+ * onLCP must register promptly on page-load — it uses a PerformanceObserver
+ * that cannot capture LCP if registered after the LCP event fires.
  */
 import { onLCP, onCLS, onINP } from 'web-vitals'
 import type { Metric } from 'web-vitals'
@@ -24,6 +29,13 @@ function reportMetric(metric: Metric): void {
   }
 }
 
-onLCP(reportMetric)
-onCLS(reportMetric)
-onINP(reportMetric)
+/**
+ * Register Core Web Vitals observers.
+ * Must be called promptly on astro:page-load — do not defer inside
+ * requestIdleCallback as LCP events may already have fired by idle time.
+ */
+export function registerWebVitals(): void {
+  onLCP(reportMetric)
+  onCLS(reportMetric)
+  onINP(reportMetric)
+}


### PR DESCRIPTION
## Summary

- **SMI-2421**: Defer gtag.js 149KB network fetch off the critical path using `requestIdleCallback` (3s timeout) with `setTimeout(fn, 1)` fallback for Safari <16.4. Consent Mode v2 defaults stay synchronous — only the network fetch moves to idle. Applied to `BaseLayout.astro`, `login.astro`, and `signup.astro`.
- **SMI-2420**: Convert `web-vitals.ts` from a side-effect import to a named export `registerWebVitals()`. `BaseLayout.astro` calls it inside an `astro:page-load` listener. Observers register promptly on page-load (not inside `requestIdleCallback`) to avoid missing LCP events.

## Test plan

- [ ] Load any page — confirm GA4 events still fire (check Network tab for `collect` requests)
- [ ] Confirm gtag.js loads after idle (not in waterfall critical chain)
- [ ] Confirm LCP/CLS/INP metrics still appear in GA4 DebugView
- [ ] Check login.astro and signup.astro — GA4 events fire correctly
- [ ] Safari test: confirm `setTimeout` fallback loads gtag.js within ~1ms

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)