### PR TITLE
fix(deps): resolve minimatch ReDoS + @tootallnate/once vulnerabilities (SMI-3097, SMI-3098)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10317,14 +10317,13 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@ts-morph/common": {
@@ -11630,16 +11629,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/@vercel/fun/node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@vercel/fun/node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     },
     "@vercel/routing-utils": {
       "ajv": "^8.18.0"
-    }
+    },
+    "@tootallnate/once": "^3.0.1"
   }
 }


### PR DESCRIPTION
## Summary

- **SMI-3097**: Update `typescript-eslint` to `8.56.1` to resolve minimatch ReDoS (CVE-2026-27903, high severity). The vulnerable `minimatch@10.2.2` in `@typescript-eslint/typescript-estree` is replaced by `minimatch@10.2.4` (patched).
- **SMI-3098**: Add `"@tootallnate/once": "^3.0.1"` npm override to resolve CVE-2026-3449 (low severity). Two transitive paths via `agentdb` and `vercel` CLI now resolve to the patched version.

**Vulnerability count**: 29 → 20 (resolved 9 alerts including the only high-severity one)

## Changes

| Commit | Change | Files |
|--------|--------|-------|
| `abebc867` | Update `@typescript-eslint/*` and `typescript-eslint` to `8.56.1` | `package.json`, `package-lock.json` |
| `97628463` | Add `@tootallnate/once` override `^3.0.1` | `package.json`, `package-lock.json` |

## Verification

- [x] `npm audit` — no high-severity vulnerabilities
- [x] `npm run build` — 6/6 tasks passed
- [x] `npm test` — 236 files, 6158 tests passed
- [x] `npm run audit:standards` — 33/33 passed (97% compliance)
- [x] `npx vercel --version` — `50.11.0` (no downgrade)
- [x] Governance review passed on both commits

## Test plan

- [ ] CI passes all 11 required checks
- [ ] Dependabot alert #25 (minimatch) auto-closes after merge
- [ ] Dependabot alert #35 (@tootallnate/once) auto-closes after merge

## Related

- Plan: `docs/internal/implementation/smi-3097-3098-dependabot-security-fixes.md`
- Remaining vulns tracked: SMI-3099 (ajv), SMI-3100 (lodash, blocked on Astro 6)