### PR TITLE
chore(core): complete WASM SQLite migration (SMI-2721, SMI-2742)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ packages/**/*.d.ts.map
 !packages/**/vitest.config.ts
 # Allow hand-written type declarations (not generated)
 !packages/**/src/types/*.d.ts
+# SMI-2742: Ambient module declaration for fts5-sql-bundle
+!packages/core/src/db/drivers/fts5-sql-bundle.d.ts
 !packages/**/eslint.config.js
 !packages/**/astro.config.mjs
 vitest.config.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@eslint/js": "^9.17.0",
         "@octokit/auth-app": "8.1.2",
         "@types/node": "20.19.30",
-        "@types/sql.js": "1.4.9",
         "@typescript-eslint/eslint-plugin": "8.56.1",
         "@typescript-eslint/parser": "8.56.1",
         "@vitest/coverage-v8": "4.0.16",
@@ -10514,13 +10513,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/emscripten": {
-      "version": "1.41.5",
-      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
-      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -10789,17 +10781,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/sql.js": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.9.tgz",
-      "integrity": "sha512-ep8b36RKHlgWPqjNG9ToUrPiwkhwh0AEzy883mO5Xnd+cL6VBH1EvSjBAAuxLUFF2Vn/moE3Me6v9E1Lo+48GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/emscripten": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/tedious": {
       "version": "4.0.14",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@eslint/js": "^9.17.0",
     "@octokit/auth-app": "8.1.2",
     "@types/node": "20.19.30",
-    "@types/sql.js": "1.4.9",
     "@typescript-eslint/eslint-plugin": "8.56.1",
     "@typescript-eslint/parser": "8.56.1",
     "@vitest/coverage-v8": "4.0.16",

--- a/packages/cli/src/utils/skills-directory.ts
+++ b/packages/cli/src/utils/skills-directory.ts
@@ -9,8 +9,10 @@ import { join } from 'path'
 import { homedir } from 'os'
 import {
   SkillParser,
-  createDatabase,
+  createDatabaseAsync,
+  initializeSchema,
   SkillVersionRepository,
+  type Database,
   type TrustTier,
 } from '@skillsmith/core'
 import { DEFAULT_DB_PATH } from '../config.js'
@@ -60,10 +62,11 @@ export async function getSkillsFromDirectory(
 
   // Open the version repository if a db path was provided
   let versionRepo: SkillVersionRepository | null = null
-  let dbConn: ReturnType<typeof createDatabase> | null = null
+  let dbConn: Database | null = null
   if (dbPath) {
     try {
-      dbConn = createDatabase(dbPath)
+      dbConn = await createDatabaseAsync(dbPath)
+      initializeSchema(dbConn)
       versionRepo = new SkillVersionRepository(dbConn)
     } catch {
       // DB not available yet — fall back to hasUpdates: false

--- a/packages/core/src/db/drivers/fts5-sql-bundle.d.ts
+++ b/packages/core/src/db/drivers/fts5-sql-bundle.d.ts
@@ -1,0 +1,35 @@
+/**
+ * SMI-2742: Ambient module declaration for fts5-sql-bundle
+ *
+ * Interfaces match the runtime shapes used by sqljsDriver.ts (lines 27-49).
+ * This replaces the inline Fts5SqlBundleModule cast and enables typed dynamic imports.
+ */
+declare module 'fts5-sql-bundle' {
+  type SqlJsValue = string | number | null | Uint8Array
+  type SqlJsBindParams = SqlJsValue[] | Record<string, SqlJsValue>
+
+  interface SqlJsStatic {
+    Database: new (data?: ArrayLike<number> | Buffer | null) => SqlJsDatabase
+  }
+
+  interface SqlJsDatabase {
+    run(sql: string): void
+    prepare(sql: string): SqlJsStatement
+    export(): Uint8Array
+    close(): void
+  }
+
+  interface SqlJsStatement {
+    bind(params?: SqlJsBindParams): boolean
+    step(): boolean
+    get(): SqlJsValue[]
+    getColumnNames(): string[]
+    reset(): void
+    free(): void
+  }
+
+  type InitSqlJsFn = (config?: object) => Promise<SqlJsStatic>
+
+  export const initSqlJs: InitSqlJsFn
+  export default function initSqlJs(config?: object): Promise<SqlJsStatic>
+}

--- a/packages/core/src/db/drivers/sqljsDriver.ts
+++ b/packages/core/src/db/drivers/sqljsDriver.ts
@@ -48,13 +48,6 @@ interface SqlJsStatement {
 type SqlJsValue = string | number | null | Uint8Array
 type SqlJsBindParams = SqlJsValue[] | Record<string, SqlJsValue>
 
-// fts5-sql-bundle export shapes (ESM named, ESM default with named, CJS interop)
-type InitSqlJsFn = (config?: object) => Promise<SqlJsStatic>
-interface Fts5SqlBundleModule {
-  initSqlJs?: InitSqlJsFn
-  default?: InitSqlJsFn & { initSqlJs?: InitSqlJsFn; default?: InitSqlJsFn }
-}
-
 // Cached sql.js module to avoid reloading WASM
 let sqlJsModule: SqlJsStatic | null = null
 
@@ -70,15 +63,17 @@ async function loadSqlJs(): Promise<SqlJsStatic> {
   try {
     // Dynamic import to avoid loading at module evaluation time
     // Using fts5-sql-bundle for FTS5 full-text search support
-    // Handle both ESM and CJS module formats. fts5-sql-bundle's declared types
-    // don't fully reflect its runtime export shapes, so we cast through unknown.
-    const module = (await import('fts5-sql-bundle')) as unknown as Fts5SqlBundleModule
-    // Extract initSqlJs function from various export shapes:
-    // - ESM named export: module.initSqlJs
-    // - ESM default with named: module.default.initSqlJs
-    // - CJS interop: module.default.default
-    const initSqlJs =
-      module.initSqlJs || module.default?.initSqlJs || module.default?.default || module.default
+    // Typed via ambient declaration in fts5-sql-bundle.d.ts (SMI-2742)
+    const module = await import('fts5-sql-bundle')
+    // Extract initSqlJs from the typed module. The .d.ts declares the named export;
+    // the fallback chain handles CJS interop shapes at runtime (module.default.initSqlJs,
+    // module.default.default). These edge cases require a Record cast.
+    type InitFn = (config?: object) => Promise<SqlJsStatic>
+    const fallback = module.default as unknown as
+      | (InitFn & { initSqlJs?: InitFn; default?: InitFn })
+      | undefined
+    const initSqlJs: InitFn | undefined =
+      module.initSqlJs || fallback?.initSqlJs || fallback?.default || fallback
 
     if (!initSqlJs) {
       throw new Error('[Skillsmith] fts5-sql-bundle: could not locate initSqlJs export')


### PR DESCRIPTION
## Summary

- **SMI-2742**: Add ambient `fts5-sql-bundle.d.ts` module declaration, replacing inline `Fts5SqlBundleModule` cast in `sqljsDriver.ts`
- **SMI-2721**: Migrate last sync `createDatabase()` call in CLI `skills-directory.ts` to `await createDatabaseAsync()` + `initializeSchema()` — fixes silent data loss where barrel export resolves to raw factory (no schema)
- Remove unused `@types/sql.js` from root devDependencies

## Test plan

- [ ] `docker exec skillsmith-dev-1 npm run build` — 0 errors
- [ ] `docker exec skillsmith-dev-1 npm test` — 0 failures
- [ ] `docker exec skillsmith-dev-1 npx tsc --noEmit` — 0 type errors
- [ ] `rg 'createDatabase\(' packages/cli/src` → 0 sync call sites
- [ ] `rg 'as unknown as Fts5SqlBundleModule' packages/core` → 0 results
- [ ] `skillsmith search <query>` smoke test (CLI uses async DB path)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)