### PR TITLE
feat(mcp-server): surface dependency intelligence in MCP tools (SMI-3137)

### DIFF
--- a/packages/core/src/exports/repositories.ts
+++ b/packages/core/src/exports/repositories.ts
@@ -133,3 +133,9 @@ export { AdvisoryRepository, type SkillAdvisory } from '../repositories/Advisory
 // ============================================================================
 
 export { CoInstallRepository, type CoInstallSummary } from '../repositories/CoInstallRepository.js'
+
+// ============================================================================
+// Skill Dependency Repository (SMI-3143)
+// ============================================================================
+
+export { SkillDependencyRepository } from '../repositories/SkillDependencyRepository.js'

--- a/packages/core/src/exports/services.ts
+++ b/packages/core/src/exports/services.ts
@@ -306,6 +306,18 @@ export {
 } from '../sync/index.js'
 
 // ============================================================================
+// Dependency Intelligence (SMI-3145, SMI-3146)
+// ============================================================================
+
+export {
+  extractMcpReferences,
+  type McpReference,
+  type McpExtractionResult,
+} from '../analysis/McpReferenceExtractor.js'
+
+export { mergeDependencies, type MergedDependency } from '../analysis/DependencyMerger.js'
+
+// ============================================================================
 // Billing (SMI-1062 to SMI-1070)
 // ============================================================================
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -166,6 +166,8 @@ export interface GetSkillResponse {
   }
   /** SMI-2761: Skills frequently installed alongside this one (≥5 co-installs) */
   also_installed?: AlsoInstalledSkill[]
+  /** SMI-3137: Dependency intelligence data from skill_dependencies table */
+  dependencies?: import('./types/dependencies.js').SkillDependencyRow[]
 }
 
 /**

--- a/packages/mcp-server/src/context.async.ts
+++ b/packages/mcp-server/src/context.async.ts
@@ -26,6 +26,7 @@ import {
   SyncEngine,
   SkillVersionRepository,
   CoInstallRepository,
+  SkillDependencyRepository,
   BackgroundSyncService,
   getApiKey,
   type SyncResult,
@@ -107,6 +108,7 @@ export async function createToolContextAsync(
 
   const skillRepository = new SkillRepository(db)
   const coInstallRepository = new CoInstallRepository(db)
+  const skillDependencyRepository = new SkillDependencyRepository(db)
 
   // SMI-1851: Use shared config module (handles env var > config file precedence)
   const apiKey = options.apiKey || getApiKey()
@@ -231,6 +233,7 @@ export async function createToolContextAsync(
     searchService,
     skillRepository,
     coInstallRepository,
+    skillDependencyRepository,
     sessionInstalledSkillIds: [],
     apiClient,
     distinctId,

--- a/packages/mcp-server/src/context.ts
+++ b/packages/mcp-server/src/context.ts
@@ -35,6 +35,7 @@ import {
   SyncEngine,
   SkillVersionRepository,
   CoInstallRepository,
+  SkillDependencyRepository,
   BackgroundSyncService,
   getApiKey,
   type SyncResult,
@@ -127,6 +128,7 @@ export function createToolContext(options: ToolContextOptions = {}): ToolContext
 
   const skillRepository = new SkillRepository(db)
   const coInstallRepository = new CoInstallRepository(db)
+  const skillDependencyRepository = new SkillDependencyRepository(db)
 
   // SMI-XXXX: Get API key from options, env, or config file
   // SMI-1851: Use shared config module (handles env var > config file precedence)
@@ -262,6 +264,7 @@ export function createToolContext(options: ToolContextOptions = {}): ToolContext
     searchService,
     skillRepository,
     coInstallRepository,
+    skillDependencyRepository,
     sessionInstalledSkillIds: [],
     apiClient,
     distinctId,

--- a/packages/mcp-server/src/context.types.ts
+++ b/packages/mcp-server/src/context.types.ts
@@ -11,6 +11,7 @@ import type {
   SearchService,
   SkillRepository,
   CoInstallRepository,
+  SkillDependencyRepository,
   SkillsmithApiClient,
   BackgroundSyncService,
   DatabaseType,
@@ -33,6 +34,8 @@ export interface ToolContext {
   skillRepository: SkillRepository
   /** Co-install repository for also-installed recommendations (SMI-2761) */
   coInstallRepository: CoInstallRepository
+  /** Skill dependency repository for dependency intelligence (SMI-3137) */
+  skillDependencyRepository: SkillDependencyRepository
   /** SMI-2761: Skill IDs installed in the current session (session-scoped co-install) */
   sessionInstalledSkillIds: string[]
   /** API client for live Supabase API (primary) */

--- a/packages/mcp-server/src/tools/get-skill.ts
+++ b/packages/mcp-server/src/tools/get-skill.ts
@@ -156,10 +156,14 @@ export async function executeGetSkill(
         skill.id
       )
 
+      // SMI-3137: Include dependency data
+      const dependencies = context.skillDependencyRepository.getDependencies(skill.id)
+
       return {
         skill,
         installCommand: skill.installCommand || 'claude skill add ' + skill.id,
         also_installed: alsoInstalled.length > 0 ? alsoInstalled : undefined,
+        dependencies: dependencies.length > 0 ? dependencies : undefined,
         timing: {
           totalMs: Math.round(endTime - startTime),
         },
@@ -219,10 +223,14 @@ export async function executeGetSkill(
   // SMI-2761: Populate also_installed from co-install repository
   const alsoInstalled: AlsoInstalledSkill[] = context.coInstallRepository.getTopCoInstalls(skill.id)
 
+  // SMI-3137: Include dependency data
+  const dbDependencies = context.skillDependencyRepository.getDependencies(skill.id)
+
   return {
     skill,
     installCommand: skill.installCommand || 'claude skill add ' + skill.id,
     also_installed: alsoInstalled.length > 0 ? alsoInstalled : undefined,
+    dependencies: dbDependencies.length > 0 ? dbDependencies : undefined,
     timing: {
       totalMs: Math.round(endTime - startTime),
     },
@@ -321,6 +329,17 @@ export function formatSkillDetails(response: GetSkillResponse): string {
     lines.push('  Status: Not scanned')
   }
   lines.push('')
+
+  // SMI-3137: Dependency intelligence
+  if (response.dependencies && response.dependencies.length > 0) {
+    lines.push('--- Dependencies ---')
+    for (const dep of response.dependencies) {
+      const version = dep.dep_version ? '@' + dep.dep_version : ''
+      const source = dep.dep_source === 'declared' ? '' : ' (inferred)'
+      lines.push('  [' + dep.dep_type + '] ' + dep.dep_target + version + source)
+    }
+    lines.push('')
+  }
 
   // SMI-2761: Co-install recommendations
   if (response.also_installed && response.also_installed.length > 0) {

--- a/packages/mcp-server/src/tools/install.dep-helpers.test.ts
+++ b/packages/mcp-server/src/tools/install.dep-helpers.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @fileoverview Unit tests for install dependency intelligence helpers
+ * @see SMI-3137: Wave 4 — Surface dependency intelligence
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { extractDepIntel, persistDependencies } from './install.dep-helpers.js'
+import type { SkillDependencyRepository } from '@skillsmith/core'
+
+// ============================================================================
+// extractDepIntel tests
+// ============================================================================
+
+describe('extractDepIntel', () => {
+  it('returns empty arrays when no MCP refs exist', () => {
+    const result = extractDepIntel('# Simple skill\n\nNo MCP references here.', null)
+
+    expect(result.dep_inferred_servers).toEqual([])
+    expect(result.dep_declared).toBeUndefined()
+    expect(result.dep_warnings).toEqual([])
+  })
+
+  it('detects inferred MCP servers from content', () => {
+    const content = `
+# My Skill
+
+Use mcp__linear__save_issue to create issues.
+Use mcp__slack__send_message for notifications.
+`
+    const result = extractDepIntel(content, null)
+
+    expect(result.dep_inferred_servers).toContain('linear')
+    expect(result.dep_inferred_servers).toContain('slack')
+    expect(result.dep_warnings).toHaveLength(2)
+    expect(result.dep_warnings[0]).toContain('linear')
+    expect(result.dep_warnings[1]).toContain('slack')
+  })
+
+  it('passes through declared dependencies from metadata', () => {
+    const metadata = {
+      dependencies: {
+        skills: [{ name: 'other/skill', type: 'hard', version: '^1.0.0' }],
+        platform: {
+          mcp_servers: [{ name: 'linear', package: '@anthropic/linear-mcp', required: true }],
+        },
+      },
+    }
+
+    const result = extractDepIntel('# Skill\n\nContent.', metadata)
+
+    expect(result.dep_declared).toBeDefined()
+    expect(result.dep_declared?.skills).toHaveLength(1)
+    expect(result.dep_declared?.platform?.mcp_servers).toHaveLength(1)
+  })
+
+  it('returns undefined dep_declared when metadata has no dependencies', () => {
+    const metadata = { name: 'test-skill' }
+    const result = extractDepIntel('# Skill\n\nContent.', metadata)
+
+    expect(result.dep_declared).toBeUndefined()
+  })
+
+  it('handles null metadata gracefully', () => {
+    const result = extractDepIntel('# Skill with mcp__github__create_issue ref', null)
+
+    expect(result.dep_declared).toBeUndefined()
+    expect(result.dep_inferred_servers).toContain('github')
+  })
+})
+
+// ============================================================================
+// persistDependencies tests
+// ============================================================================
+
+describe('persistDependencies', () => {
+  let mockRepo: SkillDependencyRepository
+
+  beforeEach(() => {
+    mockRepo = {
+      setDependencies: vi.fn(),
+      getDependencies: vi.fn().mockReturnValue([]),
+      getDependenciesBySource: vi.fn().mockReturnValue([]),
+      getDependents: vi.fn().mockReturnValue([]),
+      clearInferred: vi.fn(),
+      clearAll: vi.fn(),
+    } as unknown as SkillDependencyRepository
+  })
+
+  it('does nothing when no dependencies are found', () => {
+    persistDependencies(mockRepo, 'test/skill', '# Simple skill\n\nNo deps.', undefined)
+
+    expect(mockRepo.setDependencies).not.toHaveBeenCalled()
+  })
+
+  it('persists inferred MCP dependencies', () => {
+    const content = '# Skill\n\nUse mcp__linear__save_issue for issues.'
+
+    persistDependencies(mockRepo, 'test/skill', content, undefined)
+
+    expect(mockRepo.setDependencies).toHaveBeenCalled()
+    const callArgs = vi.mocked(mockRepo.setDependencies).mock.calls[0]
+    expect(callArgs[0]).toBe('test/skill')
+    expect(callArgs[1]).toHaveLength(1)
+    expect(callArgs[1][0].dep_target).toBe('linear')
+    expect(callArgs[1][0].dep_type).toBe('mcp_server')
+    expect(callArgs[2]).toBe('inferred_static')
+  })
+
+  it('persists declared dependencies alongside inferred ones', () => {
+    const content = '# Skill\n\nUse mcp__slack__send_message for notifs.'
+    const declared = {
+      skills: [{ name: 'other/skill', type: 'hard' as const, version: '^1.0.0' }],
+    }
+
+    persistDependencies(mockRepo, 'test/skill', content, declared)
+
+    // Should be called once for 'declared' source, once for 'inferred_static' source
+    expect(mockRepo.setDependencies).toHaveBeenCalledTimes(2)
+  })
+
+  it('deduplicates declared MCP servers over inferred', () => {
+    const content = '# Skill\n\nUse mcp__linear__save_issue for issues.'
+    const declared = {
+      platform: {
+        mcp_servers: [{ name: 'linear', package: '@a/b', required: true }],
+      },
+    }
+
+    persistDependencies(mockRepo, 'test/skill', content, declared)
+
+    // Only declared source should be called (linear is deduplicated)
+    expect(mockRepo.setDependencies).toHaveBeenCalledTimes(1)
+    const callArgs = vi.mocked(mockRepo.setDependencies).mock.calls[0]
+    expect(callArgs[2]).toBe('declared')
+  })
+})

--- a/packages/mcp-server/src/tools/install.dep-helpers.ts
+++ b/packages/mcp-server/src/tools/install.dep-helpers.ts
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview Dependency intelligence helpers for install tool
+ * @module @skillsmith/mcp-server/tools/install.dep-helpers
+ * @see SMI-3137: Wave 4 — Surface dependency intelligence in MCP responses
+ *
+ * Extracts and persists dependency data after successful skill installation.
+ * Kept in a companion file to avoid pushing install.ts over the 500-line limit.
+ */
+
+import {
+  extractMcpReferences,
+  mergeDependencies,
+  type SkillDependencyRepository,
+  type DependencyDeclaration,
+  type SkillDependencyRow,
+} from '@skillsmith/core'
+
+/**
+ * Dependency intelligence result included in the install response.
+ */
+export interface DepIntelResult {
+  /** Inferred MCP server names from skill content */
+  dep_inferred_servers: string[]
+  /** Declared dependency block from frontmatter (if present) */
+  dep_declared: DependencyDeclaration | undefined
+  /** Warnings about MCP servers referenced but not configured */
+  dep_warnings: string[]
+}
+
+/**
+ * Extract dependency intelligence from skill content after successful install.
+ *
+ * @param skillMdContent - Raw SKILL.md content
+ * @param metadata - Parsed frontmatter metadata (null if parsing failed)
+ * @returns Dependency intelligence data to include in install response
+ */
+export function extractDepIntel(
+  skillMdContent: string,
+  metadata: Record<string, unknown> | null
+): DepIntelResult {
+  const mcpResult = extractMcpReferences(skillMdContent)
+
+  // Parse declared deps from metadata if present
+  const declared = (metadata?.dependencies as DependencyDeclaration) ?? undefined
+
+  const warnings: string[] = []
+  for (const server of mcpResult.highConfidenceServers) {
+    warnings.push(`MCP server '${server}' is referenced but may not be configured`)
+  }
+
+  return {
+    dep_inferred_servers: mcpResult.servers,
+    dep_declared: declared,
+    dep_warnings: warnings,
+  }
+}
+
+/**
+ * Persist merged dependencies (declared + inferred) to the database.
+ *
+ * Best-effort: silently returns if the skill_dependencies table does not
+ * exist (pre-migration databases).
+ *
+ * @param repo - SkillDependencyRepository instance
+ * @param skillId - Skill ID to associate dependencies with
+ * @param content - Raw SKILL.md content for MCP reference extraction
+ * @param declared - Parsed dependency declaration from frontmatter
+ */
+export function persistDependencies(
+  repo: SkillDependencyRepository,
+  skillId: string,
+  content: string,
+  declared: DependencyDeclaration | undefined
+): void {
+  const mcpResult = extractMcpReferences(content)
+  const merged = mergeDependencies(declared, mcpResult)
+
+  if (merged.length === 0) return
+
+  // Convert MergedDependency[] to SkillDependencyRow[] for the repository
+  const rows: SkillDependencyRow[] = merged.map((dep) => ({
+    skill_id: skillId,
+    dep_type: dep.depType,
+    dep_target: dep.depTarget,
+    dep_version: dep.depVersion,
+    dep_source: dep.depSource,
+    confidence: dep.confidence,
+    metadata: dep.metadata,
+  }))
+
+  // Group by source for setDependencies calls (each call stamps a single source)
+  const bySource = new Map<string, SkillDependencyRow[]>()
+  for (const row of rows) {
+    const existing = bySource.get(row.dep_source) ?? []
+    existing.push(row)
+    bySource.set(row.dep_source, existing)
+  }
+
+  for (const [source, sourceRows] of bySource) {
+    repo.setDependencies(skillId, sourceRows, source as SkillDependencyRow['dep_source'])
+  }
+}

--- a/packages/mcp-server/src/tools/install.ts
+++ b/packages/mcp-server/src/tools/install.ts
@@ -1,36 +1,24 @@
 /**
  * @fileoverview MCP Install Skill Tool for downloading and installing skills
  * @module @skillsmith/mcp-server/tools/install
- * @see {@link https://github.com/wrsmith108/skillsmith|Skillsmith Repository}
  * @see SMI-2741: Split to meet 500-line standard
- *
- * Provides skill installation functionality with:
- * - GitHub repository fetching (supports owner/repo and full URLs)
- * - Automatic security scanning before installation
- * - SKILL.md validation
- * - Manifest tracking of installed skills
- * - Optional file fetching (README.md, examples.md, config.json)
+ * @see SMI-3137: Wave 4 — Dependency intelligence persistence
  *
  * Skills are installed to ~/.claude/skills/ and tracked in ~/.skillsmith/manifest.json
  */
 
-import { SecurityScanner, safeWriteFile } from '@skillsmith/core'
-import type { TrustTier } from '@skillsmith/core'
+import { SecurityScanner, safeWriteFile, type TrustTier } from '@skillsmith/core'
 import * as fs from 'fs/promises'
 import * as path from 'path'
 import * as os from 'os'
 import type { ToolContext } from '../context.js'
 import { getToolContext } from '../context.js'
-
-// Import types
 import {
   TRUST_TIER_SCANNER_OPTIONS,
   CLAUDE_SKILLS_DIR,
   type InstallInput,
   type InstallResult,
 } from './install.types.js'
-
-// Import helpers
 import {
   loadManifest,
   updateManifestSafely,
@@ -49,6 +37,8 @@ import { checkForConflicts, handleMergeAction } from './install.conflict.js'
 
 // SMI-1788/SMI-2741: Optimization layer extracted to companion file
 import { applySkillOptimization } from './install.optimize.js'
+// SMI-3137: Dependency intelligence persistence
+import { extractDepIntel, persistDependencies } from './install.dep-helpers.js'
 
 // SMI-2741: MCP tool definition extracted to companion file
 export { installTool } from './install.tool.js'
@@ -60,21 +50,9 @@ export { installInputSchema, type InstallInput, type InstallResult } from './ins
 /**
  * Install a skill from GitHub to the local Claude Code skills directory.
  *
- * This function:
- * 1. Parses the skill ID or GitHub URL
- * 2. Checks if already installed (returns error unless force=true)
- * 3. Fetches SKILL.md from GitHub (required)
- * 4. Validates SKILL.md content
- * 5. Runs security scan (unless skipScan=true)
- * 6. Creates installation directory at ~/.claude/skills/{skillName}
- * 7. Writes skill files
- * 8. Updates manifest at ~/.skillsmith/manifest.json
- *
- * @param input - Installation parameters
- * @param input.skillId - Skill ID (owner/repo) or full GitHub URL
- * @param input.force - Force reinstall if skill already exists (default: false)
- * @param input.skipScan - Skip security scan (default: false, not recommended)
- * @returns Promise resolving to installation result with success status
+ * @param input - Installation parameters (skillId, force, skipScan)
+ * @param _context - Optional tool context (falls back to singleton)
+ * @returns Installation result with success status, security report, and dep intel
  */
 export async function installSkill(
   input: InstallInput,
@@ -456,6 +434,19 @@ export async function installSkill(
     ])
     context.sessionInstalledSkillIds.push(input.skillId)
 
+    // SMI-3137: Extract and persist dependency intelligence
+    const depIntel = extractDepIntel(skillMdContent, null)
+    try {
+      persistDependencies(
+        context.skillDependencyRepository,
+        input.skillId,
+        skillMdContent,
+        depIntel.dep_declared
+      )
+    } catch {
+      // Dependency persistence is best-effort
+    }
+
     return {
       success: true,
       skillId: input.skillId,
@@ -464,6 +455,7 @@ export async function installSkill(
       trustTier, // SMI-1533: Include trust tier in result
       optimization: optimizationInfo,
       backupPath, // SMI-1895: Include backup path if created during conflict resolution
+      depIntel, // SMI-3137: Dependency intelligence
       tips: generateOptimizedTips(skillName, optimizationInfo, claudeMdSnippet),
     }
   } catch (error) {
@@ -471,20 +463,20 @@ export async function installSkill(
     let safeErrorMessage = 'Installation failed'
     if (error instanceof Error) {
       // Allow specific known error types through
-      if (
-        error.message.includes('already installed') ||
-        error.message.includes('Could not find SKILL.md') ||
-        error.message.includes('registry data quality issue') ||
-        error.message.includes('Invalid SKILL.md') ||
-        error.message.includes('Security scan failed') ||
-        error.message.includes('exceeds maximum length') ||
-        error.message.includes('Refusing to write to symlink') ||
-        error.message.includes('Refusing to write to hardlinked file') ||
-        error.message.includes('Install path escapes skills directory')
-      ) {
+      const knownPrefixes = [
+        'already installed',
+        'Could not find SKILL.md',
+        'registry data quality issue',
+        'Invalid SKILL.md',
+        'Security scan failed',
+        'exceeds maximum length',
+        'Refusing to write to symlink',
+        'Refusing to write to hardlinked file',
+        'Install path escapes skills directory',
+      ]
+      if (knownPrefixes.some((p) => error.message.includes(p))) {
         safeErrorMessage = error.message
       } else {
-        // Log the full error for debugging, return sanitized message
         console.error('[install] Error during installation:', error)
         safeErrorMessage = 'Installation failed due to an internal error'
       }

--- a/packages/mcp-server/src/tools/install.types.ts
+++ b/packages/mcp-server/src/tools/install.types.ts
@@ -188,6 +188,8 @@ export interface InstallResult {
   requiresAction?: ConflictAction[]
   /** SMI-1895: Path to backup file created during conflict resolution */
   backupPath?: string
+  /** SMI-3137: Dependency intelligence extracted during install */
+  depIntel?: import('./install.dep-helpers.js').DepIntelResult
 }
 
 /** Optimization info included in install result */

--- a/packages/mcp-server/src/tools/uninstall.ts
+++ b/packages/mcp-server/src/tools/uninstall.ts
@@ -238,6 +238,15 @@ export async function uninstallSkill(
       // Already removed, continue to update manifest
     }
 
+    // SMI-3137: Clean up dependency records
+    if (_context?.skillDependencyRepository) {
+      try {
+        _context.skillDependencyRepository.clearAll(skillEntry.id)
+      } catch {
+        // Dependency cleanup is best-effort — table may not exist pre-migration
+      }
+    }
+
     // Update manifest
     delete manifest.installedSkills[skillName]
     await saveManifest(manifest)

--- a/packages/mcp-server/src/tools/validate.dep.test.ts
+++ b/packages/mcp-server/src/tools/validate.dep.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @fileoverview Unit tests for validateDependencies helper
+ * @see SMI-3137: Wave 4 — Surface dependency intelligence
+ */
+
+import { describe, it, expect } from 'vitest'
+import { validateDependencies } from './validate.helpers.js'
+
+describe('validateDependencies', () => {
+  it('returns empty array when no dependencies or MCP refs', () => {
+    const errors = validateDependencies({}, 'Just a plain skill body with no MCP calls.')
+    expect(errors).toEqual([])
+  })
+
+  it('warns on deprecated composes field', () => {
+    const metadata = { composes: ['other-skill'] }
+    const errors = validateDependencies(metadata, 'Some body content.')
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].field).toBe('composes')
+    expect(errors[0].severity).toBe('warning')
+    expect(errors[0].message).toContain('deprecated')
+    expect(errors[0].message).toContain('dependencies.skills')
+  })
+
+  it('detects high-confidence MCP references in prose', () => {
+    const body = `
+# My Skill
+
+This skill uses mcp__linear__save_issue to create issues
+and mcp__linear__list_issues to query them.
+`
+    const errors = validateDependencies({}, body)
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].field).toBe('dependencies')
+    expect(errors[0].severity).toBe('warning')
+    expect(errors[0].message).toContain("'linear'")
+    expect(errors[0].message).toContain('dependencies.platform.mcp_servers')
+  })
+
+  it('does not warn on MCP references inside code blocks', () => {
+    const body = `
+# My Skill
+
+Here is an example:
+
+\`\`\`bash
+mcp__linear__save_issue
+\`\`\`
+`
+    const errors = validateDependencies({}, body)
+
+    // Code-block-only references are not high-confidence
+    expect(errors).toEqual([])
+  })
+
+  it('detects multiple high-confidence MCP servers', () => {
+    const body = `
+Use mcp__linear__save_issue for issues.
+Use mcp__slack__send_message for notifications.
+`
+    const errors = validateDependencies({}, body)
+
+    expect(errors).toHaveLength(2)
+    const servers = errors.map((e) => e.message)
+    expect(servers.some((m) => m.includes("'linear'"))).toBe(true)
+    expect(servers.some((m) => m.includes("'slack'"))).toBe(true)
+  })
+
+  it('combines composes warning with MCP ref warnings', () => {
+    const metadata = { composes: ['other-skill'] }
+    const body = 'Use mcp__github__create_issue for tracking.'
+
+    const errors = validateDependencies(metadata, body)
+
+    expect(errors).toHaveLength(2)
+    expect(errors[0].field).toBe('composes')
+    expect(errors[1].field).toBe('dependencies')
+  })
+
+  it('handles empty body gracefully', () => {
+    const errors = validateDependencies({}, '')
+    expect(errors).toEqual([])
+  })
+
+  it('handles empty metadata gracefully', () => {
+    const errors = validateDependencies({}, 'No MCP refs here.')
+    expect(errors).toEqual([])
+  })
+})

--- a/packages/mcp-server/src/tools/validate.helpers.ts
+++ b/packages/mcp-server/src/tools/validate.helpers.ts
@@ -3,6 +3,7 @@
  * @module @skillsmith/mcp-server/tools/validate.helpers
  */
 
+import { extractMcpReferences } from '@skillsmith/core'
 import type { ValidationError } from './validate.types.js'
 import { FIELD_LIMITS, SSRF_PATTERNS, PATH_TRAVERSAL_PATTERNS } from './validate.types.js'
 import { KNOWN_IDES, KNOWN_LLMS } from '../utils/validation.js'
@@ -357,4 +358,48 @@ export function detectClaudeMdModification(body: string): string[] {
   }
 
   return warnings
+}
+
+/**
+ * SMI-3137: Validate dependency declarations and detect inferred MCP dependencies.
+ *
+ * Checks for:
+ * 1. Deprecated 'composes' field (suggest migration to dependencies.skills)
+ * 2. MCP tool references in skill body (suggest declaring in dependencies.platform)
+ *
+ * @param metadata - Parsed frontmatter metadata (may be empty object)
+ * @param body - Skill body content (markdown after frontmatter)
+ * @returns Array of dependency-related validation warnings
+ */
+export function validateDependencies(
+  metadata: Record<string, unknown>,
+  body: string
+): ValidationError[] {
+  const errors: ValidationError[] = []
+
+  // 1. Check for deprecated 'composes' field
+  if (metadata.composes) {
+    errors.push({
+      field: 'composes',
+      message:
+        "'composes' is deprecated. Migrate to 'dependencies.skills' with type: hard/soft/peer.",
+      severity: 'warning',
+    })
+  }
+
+  // 2. Extract MCP references from body
+  const mcpResult = extractMcpReferences(body)
+
+  // 3. For each high-confidence server, add an informational warning
+  for (const server of mcpResult.highConfidenceServers) {
+    errors.push({
+      field: 'dependencies',
+      message:
+        `Inferred MCP dependency: '${server}' (referenced in skill body). ` +
+        'Consider declaring in dependencies.platform.mcp_servers.',
+      severity: 'warning',
+    })
+  }
+
+  return errors
 }

--- a/packages/mcp-server/src/tools/validate.ts
+++ b/packages/mcp-server/src/tools/validate.ts
@@ -38,6 +38,7 @@ import {
   hasPathTraversal,
   validateMetadata,
   detectClaudeMdModification,
+  validateDependencies,
 } from './validate.helpers.js'
 
 // Re-export only public API types (SMI-1718: trimmed internal exports)
@@ -137,6 +138,9 @@ export async function executeValidate(
       severity: 'warning',
     })
   }
+
+  // SMI-3137: Dependency intelligence warnings
+  errors.push(...validateDependencies(metadata ?? {}, body))
 
   // Determine validity
   const hasErrors = errors.some((e) => e.severity === 'error')

--- a/packages/mcp-server/tests/integration/recommend.integration.test.ts
+++ b/packages/mcp-server/tests/integration/recommend.integration.test.ts
@@ -20,6 +20,7 @@ describe('Recommend Tool Integration', () => {
       searchService: ctx.searchService,
       skillRepository: ctx.skillRepository,
       coInstallRepository: ctx.coInstallRepository,
+      skillDependencyRepository: ctx.skillDependencyRepository,
       sessionInstalledSkillIds: [],
       apiClient: ctx.apiClient,
     }

--- a/packages/mcp-server/tests/integration/setup.ts
+++ b/packages/mcp-server/tests/integration/setup.ts
@@ -12,6 +12,7 @@ import {
   closeDatabase,
   SkillRepository,
   CoInstallRepository,
+  SkillDependencyRepository,
   SearchService,
   SkillsmithApiClient,
   type DatabaseType,
@@ -29,6 +30,7 @@ export interface TestDatabaseContext {
   db: DatabaseType
   skillRepository: SkillRepository
   coInstallRepository: CoInstallRepository
+  skillDependencyRepository: SkillDependencyRepository
   sessionInstalledSkillIds: string[]
   searchService: SearchService
   apiClient: SkillsmithApiClient
@@ -44,6 +46,7 @@ export async function createTestDatabase(): Promise<TestDatabaseContext> {
   const db = createDatabase(':memory:')
   const skillRepository = new SkillRepository(db)
   const coInstallRepository = new CoInstallRepository(db)
+  const skillDependencyRepository = new SkillDependencyRepository(db)
   const searchService = new SearchService(db)
 
   // SMI-1183: Create API client in offline mode for tests
@@ -59,6 +62,7 @@ export async function createTestDatabase(): Promise<TestDatabaseContext> {
     db,
     skillRepository,
     coInstallRepository,
+    skillDependencyRepository,
     sessionInstalledSkillIds: [],
     searchService,
     apiClient,

--- a/packages/mcp-server/tests/recommend.test.ts
+++ b/packages/mcp-server/tests/recommend.test.ts
@@ -24,6 +24,7 @@ beforeAll(async () => {
     searchService: testDbContext.searchService,
     skillRepository: testDbContext.skillRepository,
     coInstallRepository: testDbContext.coInstallRepository,
+    skillDependencyRepository: testDbContext.skillDependencyRepository,
     sessionInstalledSkillIds: [],
     apiClient: testDbContext.apiClient,
   }


### PR DESCRIPTION
## Summary
- Wire McpReferenceExtractor + DependencyMerger into 4 MCP tool surfaces: `skill_validate` (warns on deprecated `composes` + undeclared MCP server refs), `install_skill` (extracts + persists dep intel), `get_skill` (returns dependency rows), `uninstall_skill` (cleans up dep records)
- Add `SkillDependencyRepository` to `ToolContext` and test harness
- Export core analysis functions (`extractMcpReferences`, `mergeDependencies`) from barrel modules
- Extract install dep helpers to companion file to keep `install.ts` under 500-line limit

## Wave 4 of 6: Skill Dependency Intelligence Layer
- **Wave 1** (SMI-3134): DB schema migration v10 — merged
- **Wave 2** (SMI-3135): Types + repo + parser — merged
- **Wave 3** (SMI-3136): McpReferenceExtractor + DependencyMerger — merged
- **Wave 4** (SMI-3137): MCP tool surfaces — **this PR**
- Wave 5 (SMI-3138): skill_outdated + hasUpdates
- Wave 6 (SMI-3139): composes backfill

## Test plan
- [x] 7 new tests for `validateDependencies` (validate.dep.test.ts)
- [x] 9 new tests for `extractDepIntel` and `persistDependencies` (install.dep-helpers.test.ts)
- [x] All 243 test files pass (6245 tests)
- [x] TypeScript strict mode clean
- [x] ESLint zero warnings
- [x] Prettier formatted
- [x] All files under 500-line limit
- [x] Standards audit: 34/34 passed

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)