### PR TITLE
feat(mcp-server): add skill_outdated tool with dependency status (SMI-3138)

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -32,6 +32,7 @@ import { skillUpdatesToolSchema } from './tools/skill-updates.js'
 import { skillDiffToolSchema } from './tools/skill-diff.js'
 import { skillAuditToolSchema } from './tools/skill-audit.js'
 import { skillPackAuditToolSchema } from './tools/skill-pack-audit.js'
+import { outdatedToolSchema } from './tools/outdated.js'
 import { dispatchToolCall } from './tool-dispatch.js'
 import {
   isFirstRun,
@@ -77,6 +78,7 @@ const toolDefinitions = [
   skillDiffToolSchema,
   skillAuditToolSchema,
   skillPackAuditToolSchema,
+  outdatedToolSchema,
 ]
 
 // Create server

--- a/packages/mcp-server/src/middleware/toolFeatureMapping.ts
+++ b/packages/mcp-server/src/middleware/toolFeatureMapping.ts
@@ -56,6 +56,7 @@ export const TOOL_FEATURES: Record<string, FeatureFlag | null> = {
   skill_validate: null,
   skill_compare: null,
   skill_suggest: null,
+  skill_outdated: null,
 
   // Individual tools
   skill_updates: 'version_tracking',

--- a/packages/mcp-server/src/tool-dispatch.ts
+++ b/packages/mcp-server/src/tool-dispatch.ts
@@ -25,6 +25,7 @@ import { skillUpdatesInputSchema, executeSkillUpdates } from './tools/skill-upda
 import { skillDiffInputSchema, executeSkillDiff } from './tools/skill-diff.js'
 import { skillAuditInputSchema, executeSkillAudit } from './tools/skill-audit.js'
 import { skillPackAuditInputSchema, executeSkillPackAudit } from './tools/skill-pack-audit.js'
+import { outdatedInputSchema, executeOutdated } from './tools/outdated.js'
 import { createLicenseErrorResponse } from './middleware/license.js'
 import type { LicenseMiddleware } from './middleware/license.js'
 import type { QuotaMiddleware } from './middleware/quota.js'
@@ -111,6 +112,9 @@ export async function dispatchToolCall(
 
     case 'index_local':
       return ok(await executeIndexLocal(indexLocalInputSchema.parse(args), toolContext))
+
+    case 'skill_outdated':
+      return ok(await executeOutdated(outdatedInputSchema.parse(args), toolContext))
 
     case 'skill_publish':
       return ok(await executePublish(publishInputSchema.parse(args), toolContext))

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -107,3 +107,13 @@ export type {
   AdvisorySummary,
   SkillAuditResponse,
 } from './skill-audit.js'
+
+// Skill Outdated tool (SMI-3138 Wave 5)
+export { outdatedToolSchema, outdatedInputSchema, executeOutdated } from './outdated.js'
+export type {
+  OutdatedInput,
+  OutdatedSkillInfo,
+  DependencyStatus,
+  OutdatedSummary,
+  OutdatedResponse,
+} from './outdated.js'

--- a/packages/mcp-server/src/tools/outdated.test.ts
+++ b/packages/mcp-server/src/tools/outdated.test.ts
@@ -1,0 +1,272 @@
+/**
+ * @fileoverview Unit tests for skill_outdated MCP tool
+ * @see SMI-3138: Wave 5 — Dependency intelligence outdated tool
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SkillVersionRepository, SkillDependencyRepository } from '@skillsmith/core'
+import { createTestDatabase, closeDatabase } from '../../../core/tests/helpers/database.js'
+import { executeOutdated } from './outdated.js'
+import type { ToolContext } from '../context.js'
+import type { Database } from '../../../core/src/db/database-interface.js'
+import type { SkillManifest } from './install.types.js'
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+vi.mock('./install.helpers.js', () => ({
+  loadManifest: vi.fn(),
+}))
+
+vi.mock('./install.conflict-helpers.js', () => ({
+  hashContent: vi.fn((content: string) => {
+    // Simple deterministic mock hash
+    if (content === 'latest-content') return 'aabbccdd11223344'
+    if (content === 'old-content') return '11223344aabbccdd'
+    return '0000000000000000'
+  }),
+}))
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readFile: vi.fn(),
+    },
+  }
+})
+
+import { loadManifest } from './install.helpers.js'
+import { promises as fs } from 'fs'
+
+const mockedLoadManifest = vi.mocked(loadManifest)
+const mockedReadFile = vi.mocked(fs.readFile)
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeContext(db: Database): ToolContext {
+  return {
+    db,
+    skillDependencyRepository: new SkillDependencyRepository(db),
+  } as unknown as ToolContext
+}
+
+function emptyManifest(): SkillManifest {
+  return { version: '1', installedSkills: {} }
+}
+
+function manifestWithSkills(
+  skills: Array<{ id: string; name: string; installPath: string }>
+): SkillManifest {
+  const installedSkills: SkillManifest['installedSkills'] = {}
+  for (const s of skills) {
+    installedSkills[s.name] = {
+      id: s.id,
+      name: s.name,
+      version: '1.0.0',
+      source: 'registry',
+      installPath: s.installPath,
+      installedAt: '2026-01-01T00:00:00Z',
+      lastUpdated: '2026-01-01T00:00:00Z',
+    }
+  }
+  return { version: '1', installedSkills }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('executeOutdated', () => {
+  let db: Database
+  let versionRepo: SkillVersionRepository
+
+  beforeEach(() => {
+    db = createTestDatabase()
+    versionRepo = new SkillVersionRepository(db)
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    closeDatabase(db)
+  })
+
+  it('returns empty result when manifest has no installed skills', async () => {
+    mockedLoadManifest.mockResolvedValue(emptyManifest())
+
+    const result = await executeOutdated({ include_deps: true }, makeContext(db))
+
+    expect(result.skills).toHaveLength(0)
+    expect(result.summary.total_installed).toBe(0)
+    expect(result.summary.outdated).toBe(0)
+    expect(result.summary.up_to_date).toBe(0)
+    expect(result.summary.unknown).toBe(0)
+    expect(result.summary.missing_deps).toBe(0)
+  })
+
+  it('reports all skills as current when hashes match', async () => {
+    const skillId = 'community/test-skill'
+    mockedLoadManifest.mockResolvedValue(
+      manifestWithSkills([
+        { id: skillId, name: 'test-skill', installPath: '/tmp/skills/test-skill' },
+      ])
+    )
+
+    mockedReadFile.mockResolvedValue('latest-content')
+
+    // Insert a version record with the same hash as hashContent('latest-content')
+    await versionRepo.recordVersion(skillId, 'aabbccdd11223344', '1.2.0')
+
+    const result = await executeOutdated({ include_deps: true }, makeContext(db))
+
+    expect(result.skills).toHaveLength(1)
+    expect(result.skills[0].status).toBe('current')
+    expect(result.skills[0].installed_hash).toBe('aabbccdd')
+    expect(result.skills[0].latest_hash).toBe('aabbccdd')
+    expect(result.skills[0].semver).toBe('1.2.0')
+    expect(result.summary.up_to_date).toBe(1)
+    expect(result.summary.outdated).toBe(0)
+  })
+
+  it('reports skill as outdated when hashes differ', async () => {
+    const skillId = 'community/outdated-skill'
+    mockedLoadManifest.mockResolvedValue(
+      manifestWithSkills([
+        { id: skillId, name: 'outdated-skill', installPath: '/tmp/skills/outdated-skill' },
+      ])
+    )
+
+    // Local content is old → hashContent returns '11223344aabbccdd'
+    mockedReadFile.mockResolvedValue('old-content')
+
+    // Registry has a different hash
+    await versionRepo.recordVersion(skillId, 'aabbccdd11223344', '2.0.0')
+
+    const result = await executeOutdated({ include_deps: true }, makeContext(db))
+
+    expect(result.skills).toHaveLength(1)
+    expect(result.skills[0].status).toBe('outdated')
+    expect(result.skills[0].installed_hash).toBe('11223344')
+    expect(result.skills[0].latest_hash).toBe('aabbccdd')
+    expect(result.skills[0].semver).toBe('2.0.0')
+    expect(result.summary.outdated).toBe(1)
+    expect(result.summary.up_to_date).toBe(0)
+  })
+
+  it('reports unknown when no version history exists', async () => {
+    const skillId = 'community/new-skill'
+    mockedLoadManifest.mockResolvedValue(
+      manifestWithSkills([{ id: skillId, name: 'new-skill', installPath: '/tmp/skills/new-skill' }])
+    )
+    mockedReadFile.mockResolvedValue('latest-content')
+
+    // No version records in DB for this skill
+
+    const result = await executeOutdated({ include_deps: true }, makeContext(db))
+
+    expect(result.skills).toHaveLength(1)
+    expect(result.skills[0].status).toBe('unknown')
+    expect(result.summary.unknown).toBe(1)
+  })
+
+  it('includes dependency status when include_deps is true', async () => {
+    const skillId = 'community/dep-skill'
+    const depSkillId = 'community/required-skill'
+    mockedLoadManifest.mockResolvedValue(
+      manifestWithSkills([
+        { id: skillId, name: 'dep-skill', installPath: '/tmp/skills/dep-skill' },
+        { id: depSkillId, name: 'required-skill', installPath: '/tmp/skills/required-skill' },
+      ])
+    )
+    mockedReadFile.mockResolvedValue('latest-content')
+
+    await versionRepo.recordVersion(skillId, 'aabbccdd11223344', '1.0.0')
+    await versionRepo.recordVersion(depSkillId, 'aabbccdd11223344', '1.0.0')
+
+    // Add a dependency: dep-skill depends on required-skill (which IS installed)
+    const depRepo = new SkillDependencyRepository(db)
+    depRepo.setDependencies(
+      skillId,
+      [
+        {
+          skill_id: skillId,
+          dep_type: 'skill_hard',
+          dep_target: depSkillId,
+          dep_version: '*',
+          dep_source: 'declared',
+          confidence: 1.0,
+          metadata: null,
+        },
+      ],
+      'declared'
+    )
+
+    const result = await executeOutdated({ include_deps: true }, makeContext(db))
+
+    const depSkill = result.skills.find((s) => s.id === skillId)
+    expect(depSkill?.dependencies).toBeDefined()
+    expect(depSkill!.dependencies!.total).toBe(1)
+    expect(depSkill!.dependencies!.satisfied).toHaveLength(1)
+    expect(depSkill!.dependencies!.missing).toHaveLength(0)
+    expect(result.summary.missing_deps).toBe(0)
+  })
+
+  it('omits dependency status when include_deps is false', async () => {
+    const skillId = 'community/no-dep-check'
+    mockedLoadManifest.mockResolvedValue(
+      manifestWithSkills([
+        { id: skillId, name: 'no-dep-check', installPath: '/tmp/skills/no-dep-check' },
+      ])
+    )
+    mockedReadFile.mockResolvedValue('latest-content')
+
+    await versionRepo.recordVersion(skillId, 'aabbccdd11223344', '1.0.0')
+
+    const result = await executeOutdated({ include_deps: false }, makeContext(db))
+
+    expect(result.skills).toHaveLength(1)
+    expect(result.skills[0].dependencies).toBeUndefined()
+  })
+
+  it('counts missing deps in summary when a skill dep is not installed', async () => {
+    const skillId = 'community/lonely-skill'
+    mockedLoadManifest.mockResolvedValue(
+      manifestWithSkills([
+        { id: skillId, name: 'lonely-skill', installPath: '/tmp/skills/lonely-skill' },
+      ])
+    )
+    mockedReadFile.mockResolvedValue('latest-content')
+
+    await versionRepo.recordVersion(skillId, 'aabbccdd11223344', '1.0.0')
+
+    // Add a dependency on a skill that is NOT installed
+    const depRepo = new SkillDependencyRepository(db)
+    depRepo.setDependencies(
+      skillId,
+      [
+        {
+          skill_id: skillId,
+          dep_type: 'skill_hard',
+          dep_target: 'community/missing-skill',
+          dep_version: '*',
+          dep_source: 'declared',
+          confidence: 1.0,
+          metadata: null,
+        },
+      ],
+      'declared'
+    )
+
+    const result = await executeOutdated({ include_deps: true }, makeContext(db))
+
+    const skill = result.skills[0]
+    expect(skill.dependencies!.missing).toHaveLength(1)
+    expect(skill.dependencies!.missing[0]).toContain('missing-skill')
+    expect(result.summary.missing_deps).toBe(1)
+  })
+})

--- a/packages/mcp-server/src/tools/outdated.ts
+++ b/packages/mcp-server/src/tools/outdated.ts
@@ -1,0 +1,279 @@
+/**
+ * @fileoverview skill_outdated MCP tool — check installed skills for updates and dependency status
+ * @module @skillsmith/mcp-server/tools/outdated
+ * @see SMI-3138: Wave 5 — Dependency intelligence outdated tool
+ *
+ * Reads the local manifest (~/.skillsmith/manifest.json), hashes each installed
+ * SKILL.md, and compares against the latest content hash in skill_versions.
+ * Optionally includes dependency satisfaction status from skill_dependencies.
+ *
+ * Tier gate: Community (null feature flag — no license required).
+ *
+ * Hash display: truncated to 8 chars for human readability (full hash stored).
+ */
+
+import { z } from 'zod'
+import { promises as fs } from 'fs'
+import * as path from 'path'
+import { SkillVersionRepository } from '@skillsmith/core'
+import type { SkillDependencyRow } from '@skillsmith/core'
+import type { ToolContext } from '../context.js'
+import { hashContent } from './install.conflict-helpers.js'
+import { loadManifest } from './install.helpers.js'
+import type { SkillManifestEntry } from './install.types.js'
+
+// ============================================================================
+// Input / Output types
+// ============================================================================
+
+/**
+ * Input schema for skill_outdated tool
+ */
+export const outdatedInputSchema = z.object({
+  /** Include dependency satisfaction status in results (default: true) */
+  include_deps: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Include dependency satisfaction status (default: true)'),
+})
+
+export type OutdatedInput = z.infer<typeof outdatedInputSchema>
+
+/**
+ * Dependency satisfaction details for a single skill
+ */
+export interface DependencyStatus {
+  total: number
+  satisfied: string[]
+  missing: string[]
+}
+
+/**
+ * Per-skill outdated information returned by the tool
+ */
+export interface OutdatedSkillInfo {
+  /** Registry skill identifier (e.g. "author/skill-name") */
+  id: string
+  /** 8-char prefix of the locally-installed content hash */
+  installed_hash: string
+  /** 8-char prefix of the latest registry hash */
+  latest_hash: string
+  /** Status of the skill: current, outdated, or unknown (no registry data) */
+  status: 'current' | 'outdated' | 'unknown'
+  /** Semver from the latest version record, if available */
+  semver: string | null
+  /** Dependency satisfaction details (omitted when include_deps is false) */
+  dependencies?: DependencyStatus
+}
+
+/**
+ * Summary counts for the outdated check
+ */
+export interface OutdatedSummary {
+  total_installed: number
+  outdated: number
+  up_to_date: number
+  unknown: number
+  missing_deps: number
+}
+
+/**
+ * Response from skill_outdated tool
+ */
+export interface OutdatedResponse {
+  skills: OutdatedSkillInfo[]
+  summary: OutdatedSummary
+}
+
+// ============================================================================
+// Tool schema (MCP tool definition)
+// ============================================================================
+
+/**
+ * MCP tool definition for skill_outdated
+ */
+export const outdatedToolSchema = {
+  name: 'skill_outdated' as const,
+  description:
+    'Check installed skills for available updates and dependency satisfaction status. ' +
+    'Reads the local manifest, hashes each installed SKILL.md, and compares against the ' +
+    'latest registry state. Community tier — no license required.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      include_deps: {
+        type: 'boolean',
+        description: 'Include dependency satisfaction status (default: true)',
+      },
+    },
+    required: [],
+  },
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Read and hash the installed SKILL.md content.
+ * Returns null if the file cannot be read.
+ */
+async function readInstalledHash(installPath: string): Promise<string | null> {
+  const skillMdPath = path.join(installPath, 'SKILL.md')
+  try {
+    const content = await fs.readFile(skillMdPath, 'utf-8')
+    return hashContent(content)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Check dependency satisfaction for a skill.
+ * - skill_hard / skill_soft / skill_peer: satisfied if dep_target is in installedSkillIds
+ * - mcp_server / model_minimum / other: marked satisfied (best-effort, can't verify)
+ */
+function checkDependencies(
+  deps: SkillDependencyRow[],
+  installedSkillIds: Set<string>
+): DependencyStatus {
+  const satisfied: string[] = []
+  const missing: string[] = []
+
+  for (const dep of deps) {
+    const label = `${dep.dep_type}:${dep.dep_target}`
+
+    if (
+      dep.dep_type === 'skill_hard' ||
+      dep.dep_type === 'skill_soft' ||
+      dep.dep_type === 'skill_peer'
+    ) {
+      if (installedSkillIds.has(dep.dep_target)) {
+        satisfied.push(label)
+      } else {
+        missing.push(label)
+      }
+    } else {
+      // mcp_server, model_minimum, etc. — can't reliably verify, mark satisfied
+      satisfied.push(label)
+    }
+  }
+
+  return { total: deps.length, satisfied, missing }
+}
+
+// ============================================================================
+// Execution
+// ============================================================================
+
+/**
+ * Execute the skill_outdated tool.
+ *
+ * 1. Reads the manifest. If missing/empty, returns an empty result.
+ * 2. For each installed skill, hashes the local SKILL.md and compares
+ *    against the latest entry in skill_versions.
+ * 3. If include_deps is true, queries skill_dependencies for each skill
+ *    and checks whether skill-type deps are installed.
+ *
+ * @param input   Validated tool input
+ * @param context Tool context with database connection
+ * @returns OutdatedResponse with per-skill status and summary
+ */
+export async function executeOutdated(
+  input: OutdatedInput,
+  context: ToolContext
+): Promise<OutdatedResponse> {
+  const manifest = await loadManifest()
+  const entries = Object.values(manifest.installedSkills) as SkillManifestEntry[]
+
+  if (entries.length === 0) {
+    return {
+      skills: [],
+      summary: {
+        total_installed: 0,
+        outdated: 0,
+        up_to_date: 0,
+        unknown: 0,
+        missing_deps: 0,
+      },
+    }
+  }
+
+  const versionRepo = new SkillVersionRepository(context.db)
+  const depRepo = context.skillDependencyRepository
+
+  // Build set of installed skill IDs for dependency checking
+  const installedSkillIds = new Set<string>(entries.map((e) => e.id))
+
+  const skills: OutdatedSkillInfo[] = []
+  let outdatedCount = 0
+  let upToDateCount = 0
+  let unknownCount = 0
+  let missingDepsCount = 0
+
+  for (const entry of entries) {
+    // Hash the currently installed SKILL.md
+    const localHash = await readInstalledHash(entry.installPath)
+
+    // Get latest version from registry cache
+    const history = await versionRepo.getVersionHistory(entry.id, 1)
+
+    let status: 'current' | 'outdated' | 'unknown'
+    let latestHash: string
+    let semver: string | null = null
+
+    if (history.length === 0 || localHash === null) {
+      status = 'unknown'
+      latestHash = localHash?.slice(0, 8) ?? '--------'
+      unknownCount++
+    } else {
+      const latest = history[0]
+      semver = latest.semver
+      latestHash = latest.content_hash.slice(0, 8)
+
+      if (localHash === latest.content_hash) {
+        status = 'current'
+        upToDateCount++
+      } else {
+        status = 'outdated'
+        outdatedCount++
+      }
+    }
+
+    const skillInfo: OutdatedSkillInfo = {
+      id: entry.id,
+      installed_hash: localHash?.slice(0, 8) ?? '--------',
+      latest_hash: latestHash,
+      status,
+      semver,
+    }
+
+    // Dependency satisfaction
+    if (input.include_deps) {
+      const deps = depRepo.getDependencies(entry.id)
+      if (deps.length > 0) {
+        const depStatus = checkDependencies(deps, installedSkillIds)
+        skillInfo.dependencies = depStatus
+        if (depStatus.missing.length > 0) {
+          missingDepsCount++
+        }
+      } else {
+        skillInfo.dependencies = { total: 0, satisfied: [], missing: [] }
+      }
+    }
+
+    skills.push(skillInfo)
+  }
+
+  return {
+    skills,
+    summary: {
+      total_installed: entries.length,
+      outdated: outdatedCount,
+      up_to_date: upToDateCount,
+      unknown: unknownCount,
+      missing_deps: missingDepsCount,
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- New `skill_outdated` MCP tool (community tier) that checks installed skills for updates and dependency satisfaction
- Reads manifest, hashes installed SKILL.md files, compares against registry content hashes from `skill_versions`
- Reports `current`/`outdated`/`unknown` status per skill with 8-char hash prefixes
- Optional `include_deps` flag adds dependency satisfaction checking from `skill_dependencies` table
- Skill-type deps checked against installed manifest; MCP server/model deps marked satisfied (best-effort)

## Wave 5 of 6: Skill Dependency Intelligence Layer
- **Wave 1** (SMI-3134): DB schema migration v10 — merged
- **Wave 2** (SMI-3135): Types + repo + parser — merged
- **Wave 3** (SMI-3136): McpReferenceExtractor + DependencyMerger — merged
- **Wave 4** (SMI-3137): MCP tool surfaces — merged
- **Wave 5** (SMI-3138): skill_outdated + dep status — **this PR**
- Wave 6 (SMI-3139): composes backfill — PR #291

## Test plan
- [x] 7 new tests for `executeOutdated` (outdated.test.ts)
- [x] Empty manifest, current skills, outdated skills, unknown status, dep inclusion/exclusion, missing deps
- [x] All 244 test files pass (6252 tests)
- [x] TypeScript strict mode clean
- [x] ESLint zero warnings
- [x] Prettier formatted
- [x] All files under 500-line limit

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)