### PR TITLE
fix(mcp-server): replace deep core import in outdated test

### DIFF
--- a/packages/mcp-server/src/tools/outdated.test.ts
+++ b/packages/mcp-server/src/tools/outdated.test.ts
@@ -8,7 +8,7 @@ import { SkillVersionRepository, SkillDependencyRepository } from '@skillsmith/c
 import { createTestDatabase, closeDatabase } from '../../../core/tests/helpers/database.js'
 import { executeOutdated } from './outdated.js'
 import type { ToolContext } from '../context.js'
-import type { Database } from '../../../core/src/db/database-interface.js'
+import type { Database } from '@skillsmith/core'
 import type { SkillManifest } from './install.types.js'
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Replace deep import `../../../core/src/db/database-interface.js` with `@skillsmith/core` barrel export in `outdated.test.ts`
- Found during post-merge governance review of Waves 4-6 (SMI-3137, SMI-3138, SMI-3139)

## Test plan
- [x] `outdated.test.ts` — 7/7 tests pass with updated import
- [x] Pre-commit hooks pass (typecheck, lint, format)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)