### PR TITLE
fix(mcp-server): detect git-crypt encrypted skills in install_skill — SMI-3221

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,3 +354,4 @@ NEVER proactively create documentation files (*.md) or README files. Only create
 Never save working files, text/mds and tests to the root folder.
 NEVER defer fixes to "later" or "a future pass". If a code review or audit surfaces an issue in scope, fix it immediately in the same PR. Do not label findings as "informational" or "non-blocking" if they can be resolved now.
 NEVER say "worth a note for next time" or "consider X in future". If something is worth noting, act on it immediately: create the Linear issue, update the doc, fix the config. Observations without immediate action are noise.
+After context compaction or session continuation, ALWAYS verify claimed-complete work by reading the actual files before proceeding. Never trust the summary alone — compaction can conflate "planned" with "implemented".

--- a/packages/mcp-server/src/tools/install.helpers.ts
+++ b/packages/mcp-server/src/tools/install.helpers.ts
@@ -256,6 +256,24 @@ export async function lookupSkillFromRegistry(
 // ============================================================================
 
 /**
+ * SMI-3221: Detect git-crypt encrypted content fetched from GitHub.
+ * raw.githubusercontent.com serves encrypted bytes for repos using git-crypt.
+ * The magic header is \x00GITCRYPT (hex 00474954435259505400).
+ */
+export function assertNotEncrypted(content: string, filePath: string): void {
+  if (content.startsWith('\x00GITCRYPT')) {
+    throw new Error(
+      'File "' +
+        filePath +
+        '" is git-crypt encrypted. ' +
+        'The repository uses git-crypt and this file cannot be fetched from GitHub. ' +
+        'Workaround: clone the repo locally, unlock with git-crypt, then install with:\n' +
+        '  cp -r /path/to/repo/.claude/skills/<skill-name> ~/.claude/skills/<skill-name>'
+    )
+  }
+}
+
+/**
  * Fetch file from GitHub
  * SMI-1491: Added optional branch parameter to use branch from repo_url
  */
@@ -280,13 +298,17 @@ export async function fetchFromGitHub(
         throw new Error('Failed to fetch ' + filePath + ': ' + response.status)
       }
 
-      return masterResponse.text()
+      const masterText = await masterResponse.text()
+      assertNotEncrypted(masterText, filePath)
+      return masterText
     }
 
     throw new Error('Failed to fetch ' + filePath + ': ' + response.status)
   }
 
-  return response.text()
+  const text = await response.text()
+  assertNotEncrypted(text, filePath)
+  return text
 }
 
 // ============================================================================

--- a/packages/mcp-server/tests/unit/install-helpers.test.ts
+++ b/packages/mcp-server/tests/unit/install-helpers.test.ts
@@ -20,6 +20,7 @@ import {
   updateManifestSafely,
   lookupSkillFromRegistry,
   fetchFromGitHub,
+  assertNotEncrypted,
 } from '../../src/tools/install.helpers.js'
 import type { ToolContext } from '../../src/context.js'
 
@@ -567,6 +568,38 @@ Use this skill to do things.
     })
   })
 
+  // ==========================================================================
+  // SMI-3221: git-crypt encrypted content detection
+  // ==========================================================================
+
+  describe('assertNotEncrypted', () => {
+    it('does not throw for normal markdown content', () => {
+      expect(() => assertNotEncrypted('# My Skill\n\nThis is a skill.', 'SKILL.md')).not.toThrow()
+    })
+
+    it('does not throw for empty content', () => {
+      expect(() => assertNotEncrypted('', 'SKILL.md')).not.toThrow()
+    })
+
+    it('throws for git-crypt encrypted content', () => {
+      // git-crypt magic header: \x00GITCRYPT followed by encrypted bytes
+      const encrypted = '\x00GITCRYPT\x00\x12\x34\x56'
+      expect(() => assertNotEncrypted(encrypted, 'SKILL.md')).toThrow('git-crypt encrypted')
+    })
+
+    it('includes file path in error message', () => {
+      const encrypted = '\x00GITCRYPT\x00'
+      expect(() => assertNotEncrypted(encrypted, '.claude/skills/my-skill/SKILL.md')).toThrow(
+        '.claude/skills/my-skill/SKILL.md'
+      )
+    })
+
+    it('includes cp -r workaround in error message', () => {
+      const encrypted = '\x00GITCRYPT\x00'
+      expect(() => assertNotEncrypted(encrypted, 'SKILL.md')).toThrow('cp -r')
+    })
+  })
+
   describe('fetchFromGitHub', () => {
     beforeEach(() => {
       vi.clearAllMocks()
@@ -635,6 +668,30 @@ Use this skill to do things.
 
       // Should only call once, no master fallback
       expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    // SMI-3221: git-crypt encrypted content detection in fetch paths
+    it('throws encrypted error when main returns git-crypt content', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('\x00GITCRYPT\x00\x12\x34'),
+      })
+
+      await expect(fetchFromGitHub('owner', 'repo', 'SKILL.md')).rejects.toThrow(
+        'git-crypt encrypted'
+      )
+    })
+
+    it('throws encrypted error when master fallback returns git-crypt content', async () => {
+      // main fails with 404, master returns encrypted content
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 }).mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('\x00GITCRYPT\x00\x56\x78'),
+      })
+
+      await expect(fetchFromGitHub('owner', 'repo', 'SKILL.md')).rejects.toThrow(
+        'git-crypt encrypted'
+      )
     })
   })
 })


### PR DESCRIPTION
## Summary

- Add `assertNotEncrypted()` helper to detect git-crypt magic header (`\x00GITCRYPT`) in fetched content
- Call in both `main` and `master` fallback paths in `fetchFromGitHub()`
- Replace misleading "Invalid SKILL.md: Missing title" with clear encryption error + `cp -r` workaround
- Add post-compaction verification rule to CLAUDE.md Important Instruction Reminders

## Test plan

- [x] 5 unit tests for `assertNotEncrypted` (normal, empty, encrypted detection, file path in message, workaround hint)
- [x] 2 integration tests for `fetchFromGitHub` encrypted response (main + master fallback)
- [x] Full preflight: 6262 tests passing, lint/typecheck/audit clean

Closes SMI-3221

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)