### PR TITLE
fix(ci): correct dist paths in security-scan workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -68,9 +68,9 @@ jobs:
 
           # Run the security scanner on all skills
           node -e "
-            const { SecurityScanner } = require('./packages/core/dist/security/index.js');
-            const { SkillRepository } = require('./packages/core/dist/repositories/SkillRepository.js');
-            const { openDatabase } = require('./packages/core/dist/db/schema.js');
+            const { SecurityScanner } = require('./packages/core/dist/src/security/index.js');
+            const { SkillRepository } = require('./packages/core/dist/src/repositories/SkillRepository.js');
+            const { openDatabase } = require('./packages/core/dist/src/db/schema.js');
             const fs = require('fs');
             const path = require('path');
 


### PR DESCRIPTION
## Summary
- Fix 3 broken `require()` paths in the weekly Security Scan workflow
- Turborepo builds to `dist/src/`, not `dist/` — the `src/` segment was missing
- This scan has been failing every week since at least 2026-02-15

## Test plan
- [ ] Verify CI passes on this PR (docs-only change tier — workflow YAML)
- [ ] Trigger manual Security Scan run after merge: `gh workflow run "Security Scan"`
- [ ] Confirm scan completes without `Cannot find module` error

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)