### PR TITLE
fix(ci): merge SARIF runs into single run for CodeQL upload

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -122,11 +122,17 @@ jobs:
                 annotations.join('\\n')
               );
 
-              // Combine SARIF results
+              // Combine SARIF results into a single run (CodeQL rejects multiple runs per category)
+              const allRuns = sarifs.flatMap(s => s.runs || []);
+              const mergedRun = {
+                tool: allRuns[0]?.tool || { driver: { name: 'skillsmith-security-scanner', rules: [] } },
+                results: allRuns.flatMap(r => r.results || []),
+                automationDetails: { id: 'skillsmith-security-scan/' }
+              };
               const combinedSarif = {
                 '\$schema': 'https://json.schemastore.org/sarif-2.1.0.json',
                 version: '2.1.0',
-                runs: sarifs.flatMap(s => s.runs || [])
+                runs: [mergedRun]
               };
               fs.writeFileSync(
                 'security-reports/results.sarif',


### PR DESCRIPTION
## Summary
- CodeQL Action now rejects multiple SARIF runs with the same category (since [July 2025](https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/))
- Merge all per-skill scan results into a single SARIF run instead of flatMapping multiple runs
- Follows up on #312 which fixed the `require()` paths — the scan now completes (27 skills, 0 findings) but the SARIF upload step fails

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, trigger manual Security Scan: `gh workflow run "Security Scan"`
- [ ] Confirm full workflow completes green (scan + SARIF upload)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)