### PR TITLE
fix(dx): add testTimeout + hookTimeout to root vitest config (SMI-3500)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    // SMI-3500: Aggregate pre-push coverage runs (254 files, V8 instrumentation)
+    // create I/O contention that intermittently pushes tests past the 10s default.
+    // Individual tests peak at ~800ms; 15s provides contention margin.
+    // Per-package CI configs are unaffected (they use workspace-level configs).
+    testTimeout: 15_000,
+    hookTimeout: 15_000,
     globals: true,
     environment: 'node',
     include: [


### PR DESCRIPTION
## Summary

- Add `testTimeout: 15_000` and `hookTimeout: 15_000` to root `vitest.config.ts`
- Fixes intermittent pre-push coverage check timeouts caused by I/O contention when 254 test files run under V8 coverage instrumentation

## Root Cause (SPARC Research)

Individual tests peak at ~800ms (well under the 10s default). Timeouts occur under system load when the aggregate coverage run competes for resources with parallel agents and Docker I/O. Failures are flaky, not consistent.

## Approach

- **Evidence-based**: Measured actual test durations before setting thresholds
- **Config-level only**: Zero per-test timeouts (matches existing codebase pattern)
- **Integration config precedent**: Pairs `testTimeout` + `hookTimeout` (like `vitest.config.integration.ts`)
- **No CI impact**: CI uses per-package workspace configs, not the root config

## Plan Review

Reviewed by VP Product, VP Engineering, VP Design — 16 findings incorporated.
Plan: `docs/internal/implementation/smi-3500-pre-push-coverage-timeouts.md`

## Follow-up Issues

- SMI-3502: Split pre-push coverage to per-workspace runs
- SMI-3503: Create shared vitest preset
- SMI-3504: Add timeout wrapper to pre-push docker exec

## Test plan

- [x] `npm run test:coverage` passes (254/254 files, 6510 tests)
- [ ] CI checks pass
- [ ] Pre-push hook completes without `--no-verify`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)