### PR TITLE
fix(deps): resolve minimatch ReDoS (CVE-2026-27903)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2724,29 +2724,6 @@
         }
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -11816,16 +11793,16 @@
       }
     },
     "node_modules/@vercel/python-analysis/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -126,6 +126,9 @@
     "@vercel/routing-utils": {
       "ajv": "^8.18.0"
     },
-    "@tootallnate/once": "^3.0.1"
+    "@tootallnate/once": "^3.0.1",
+    "@vercel/python-analysis": {
+      "minimatch": "^10.2.3"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds scoped npm override for `minimatch` under `@vercel/python-analysis` to force `^10.2.3` (resolves to 10.2.4)
- `@vercel/python-analysis@0.10.1` exact-pins `minimatch@10.1.1` which has combinatorial backtracking ReDoS in `matchOne()` with multiple GLOBSTAR segments
- No newer `@vercel/python-analysis` version available — override is the only fix path

## Test plan

- [ ] CI passes (deps-only change — validation + audit tier)
- [ ] `npm ls minimatch` shows no copies in the `>= 10.0.0, < 10.2.3` range
- [ ] Dependabot alert #25 auto-closes after merge

Resolves: Dependabot alert #25 (GHSA-7r86-cg39-jmmj, CVE-2026-27903)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)