### PR TITLE
docs: update claude-flow references from @alpha to @3

### DIFF
--- a/.claude/development/claude-flow-guide.md
+++ b/.claude/development/claude-flow-guide.md
@@ -11,7 +11,7 @@ Configured via `.mcp.json` (auto-loaded by Claude Code):
   "mcpServers": {
     "claude-flow": {
       "command": "npx",
-      "args": ["claude-flow@alpha", "mcp", "start"],
+      "args": ["claude-flow@3", "mcp", "start"],
       "env": {
         "CLAUDE_FLOW_LOG_LEVEL": "info",
         "CLAUDE_FLOW_MEMORY_BACKEND": "sqlite"
@@ -21,7 +21,7 @@ Configured via `.mcp.json` (auto-loaded by Claude Code):
 }
 ```
 
-Manual setup: `claude mcp add claude-flow -- npx claude-flow@alpha mcp start`
+Manual setup: `claude mcp add claude-flow -- npx claude-flow@3 mcp start`
 
 Verify: `claude mcp list | grep claude-flow`
 
@@ -115,7 +115,7 @@ Available modes: orchestrator, coder, researcher, tdd, architect, reviewer, debu
 ### MCP Server Setup
 
 ```bash
-claude mcp add claude-flow npx claude-flow@alpha mcp start
+claude mcp add claude-flow npx claude-flow@3 mcp start
 ```
 
 See `.claude/agents/` for available agent definitions.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' ' | xargs -I {} sh -c 'CMD=\"{}\"; if [ -n \"$CMD\" ]; then npx claude-flow@alpha hooks pre-command --command \"$CMD\" --validate-safety true --prepare-resources true 2>/dev/null || true; fi'"
+            "command": "cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' ' | xargs -I {} sh -c 'CMD=\"{}\"; if [ -n \"$CMD\" ]; then npx claude-flow@3 hooks pre-command --command \"$CMD\" --validate-safety true --prepare-resources true 2>/dev/null || true; fi'"
           }
         ]
       },
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks pre-edit --file '{}' --auto-assign-agents true --load-context true"
+            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@3 hooks pre-edit --file '{}' --auto-assign-agents true --load-context true"
           }
         ]
       }
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' ' | xargs -I {} sh -c 'CMD=\"{}\"; if [ -n \"$CMD\" ]; then npx claude-flow@alpha hooks post-command --command \"$CMD\" --success true --track-metrics true --store-results true 2>/dev/null || true; fi'"
+            "command": "cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' ' | xargs -I {} sh -c 'CMD=\"{}\"; if [ -n \"$CMD\" ]; then npx claude-flow@3 hooks post-command --command \"$CMD\" --success true --track-metrics true --store-results true 2>/dev/null || true; fi'"
           }
         ]
       },
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} sh -c 'FILE=\"{}\"; if [ -n \"$FILE\" ]; then npx claude-flow@alpha hooks post-edit --file \"$FILE\" --success true --format true --update-memory true 2>/dev/null || true; fi'"
+            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} sh -c 'FILE=\"{}\"; if [ -n \"$FILE\" ]; then npx claude-flow@3 hooks post-edit --file \"$FILE\" --success true --format true --update-memory true 2>/dev/null || true; fi'"
           }
         ]
       },
@@ -107,7 +107,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow@alpha hooks session-end --generate-summary true --persist-state true --export-metrics true"
+            "command": "npx claude-flow@3 hooks session-end --generate-summary true --persist-state true --export-metrics true"
           }
         ]
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "claude-flow": {
       "command": "npx",
-      "args": ["claude-flow@alpha", "mcp", "start"],
+      "args": ["claude-flow@3", "mcp", "start"],
       "env": {
         "CLAUDE_FLOW_LOG_LEVEL": "info",
         "CLAUDE_FLOW_MEMORY_BACKEND": "sqlite"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ Alerts to `support@smithhorn.ca` via Resend on failures. All jobs log to `audit_
 
 ## Claude-Flow MCP Server
 
-Required for hive mind and agent spawning. Auto-configured via `.mcp.json`. Manual: `claude mcp add claude-flow -- npx claude-flow@alpha mcp start`.
+Required for hive mind and agent spawning. Auto-configured via `.mcp.json`. Manual: `claude mcp add claude-flow -- npx claude-flow@3 mcp start`.
 
 **Tools**: `swarm_init`, `agent_spawn`, `task_orchestrate`, `memory_usage`, `swarm_destroy`.
 


### PR DESCRIPTION
## Summary

- Update claude-flow references from `@alpha` to `@3` after stable release (PR #339)
- Affects: `.mcp.json`, `.claude/settings.json` (hooks), `CLAUDE.md`, claude-flow guide sub-doc
- Historical scripts/prompts left as-is (archived, not actively invoked)

## Test plan

- [x] `.mcp.json` uses `claude-flow@3`
- [x] All 5 hook commands in `.claude/settings.json` updated
- [x] CLAUDE.md manual setup command updated
- [x] Claude-flow guide sub-doc updated (3 occurrences)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)