### PR TITLE
fix(deps): resolve lodash prototype pollution (GHSA-xxjr-mmjv-4gpg)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21076,9 +21076,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary

- `npm audit fix` updated lodash to resolve prototype pollution in `_.unset` and `_.omit` (GHSA-xxjr-mmjv-4gpg)
- Reduces audit findings from 16 → 15 moderate (remaining 15 are ajv in Vercel builders — not fixable without breaking Vercel CLI upgrade)
- Lockfile-only change (3 lines)

## Test plan

- [ ] CI passes (deps-only change)
- [ ] `npm audit` shows 15 moderate (down from 16)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)