### PR TITLE
fix(cli): bump version to 0.5.1 (SMI-3537)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29338,7 +29338,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.4.3",
+      "version": "0.5.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.4.3",
+  "version": "0.5.1",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps `@skillsmith/cli` from `0.4.3` to `0.5.1` to resolve npm registry version regression
- `0.5.0` was published with exact-pinned `@skillsmith/core@0.4.15`; subsequent squash-merges reverted local to `0.4.3`
- npm disallows republishing used versions, so advancing to `0.5.1`

## Post-merge action
```bash
npm deprecate @skillsmith/cli@0.5.0 "Published with stale core dependency (0.4.15 exact pin). Use >=0.5.1"
```

## Test plan
- [x] `npm run lint` — zero errors
- [x] `npm run format:check` — all formatted
- [x] `npm run typecheck` — clean
- [x] `npm test -w @skillsmith/cli` — 441 tests passed
- [x] Pre-push security + coverage checks passed
- [ ] CI green

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)