### PR TITLE
fix(ci): resolve Docker build timeouts from cache eviction (SMI-3539)

### DIFF
--- a/.claude/development/ci-reference.md
+++ b/.claude/development/ci-reference.md
@@ -158,21 +158,34 @@ FAILED=$(gh pr view $PR --json statusCheckRollup \
 
 **Rule**: Always wait for Wave N CI to show green before starting Wave N+1 rebase. Starting early saves <30s but risks a reflog recovery if Wave N's checks later fail.
 
-## Docker BuildKit Cache Policy (SMI-3531)
+## Docker BuildKit Cache Policy (SMI-3531, SMI-3539)
 
-Three workflows build Docker images with BuildKit GHA cache:
+Three workflows build Docker images with BuildKit GHA cache. All Docker build jobs have a **20-minute timeout** to accommodate cold builds (~15 min for native module compilation).
 
-| Workflow | Scope | Mode | Purpose |
-|----------|-------|------|---------|
-| `ci.yml` | `scope=ci` | `mode=min` | PR and push CI |
-| `e2e-tests.yml` | `scope=e2e` | `mode=min` | End-to-end tests |
-| `publish.yml` | `scope=publish` | `mode=min` | npm publish |
+| Workflow | Scope | Mode | Timeout | Purpose |
+|----------|-------|------|---------|---------|
+| `ci.yml` | `scope=ci` | `mode=max` | 20 min | PR and push CI |
+| `e2e-tests.yml` | `scope=e2e` | `mode=min` | 20 min | End-to-end tests |
+| `publish.yml` | `scope=publish` | `mode=min` | 20 min | npm publish |
+
+**Dual-layer cache architecture** (ci.yml only):
+
+ci.yml uses two cache mechanisms in sequence:
+
+1. **Mechanism 1** (`actions/cache@v5`): Keyed on `Dockerfile + package-lock.json + .dockerignore + .nvmrc`. On hit, loads a pre-built image tarball and skips Docker build entirely. On miss, falls through to mechanism 2.
+2. **Mechanism 2** (`build-push-action` with BuildKit GHA cache): Runs the full Docker build using BuildKit layer cache.
+
+E2E and publish workflows only use mechanism 2 (no `actions/cache` tarball layer).
 
 **Key decisions**:
 
-- `mode=min` caches only the final image layers (not intermediate). Dockerfile mid-layer changes trigger full rebuild (~6 min) instead of partial. Acceptable tradeoff: Dockerfile changes are rare (~2x/month).
 - `scope=` isolates each workflow's cache entries. Without scope, workflows evict each other's entries when the 10 GB GHA cache cap is reached.
+- CI uses `mode=max` to cache all intermediate layers (apt-get, base setup). When mechanism 1 misses on a lockfile change, mechanism 2 reuses cached base layers (~2 min savings vs. full rebuild). CI is the most frequent workflow, so it benefits most from intermediate caching.
+- E2E and publish use `mode=min` (final image only) since they run less frequently and the storage tradeoff isn't justified.
+- **Rollback condition**: If CI scope cache exceeds ~4 GB and evicts e2e/publish scope caches within 72h, revert CI to `mode=min`.
 - Check cache usage: `gh api repos/smith-horn/skillsmith/actions/cache/usage`
+- Prune stale caches: `gh api repos/smith-horn/skillsmith/actions/caches --paginate -q '.actions_caches[] | .id' | xargs -I{} gh api -X DELETE repos/smith-horn/skillsmith/actions/caches/{}`
+- **Cache-miss Step Summary** (SMI-3539): ci.yml docker-build writes cache hit/miss status to `$GITHUB_STEP_SUMMARY` so PR authors know when a cold build is expected.
 
 ## Artifact Retention Policy (SMI-3531)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,7 +357,7 @@ jobs:
       (needs.package-validation.result == 'success' || needs.package-validation.result == 'skipped')
     name: Build Docker Image
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     outputs:
       image-tag: ${{ steps.meta.outputs.tags }}
@@ -437,7 +437,7 @@ jobs:
           load: true
           tags: skillsmith-ci:${{ github.sha }}
           cache-from: type=gha,scope=ci
-          cache-to: type=gha,mode=min,scope=ci
+          cache-to: type=gha,mode=max,scope=ci
           target: dev
 
       # SMI-2194: Save image to cache directory for future runs
@@ -462,6 +462,19 @@ jobs:
           name: docker-image
           path: /tmp/skillsmith-ci.tar.gz
           retention-days: 1
+
+      # SMI-3539: Surface cache status to PR authors via Step Summary
+      - name: Cache status summary
+        if: always()
+        run: |
+          if [ "${{ steps.docker-image-cache.outputs.cache-hit }}" = "true" ]; then
+            echo "### Docker Build: Cache Hit" >> $GITHUB_STEP_SUMMARY
+            echo "Loaded pre-built image from cache." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### Docker Build: Cache Miss — Full Rebuild" >> $GITHUB_STEP_SUMMARY
+            echo "No cached image found. Full Docker build with native module compilation (~15 min)." >> $GITHUB_STEP_SUMMARY
+            echo "This is expected after lockfile, Dockerfile, or .nvmrc changes." >> $GITHUB_STEP_SUMMARY
+          fi
 
       # SMI-708: Extract pre-compiled node_modules from Docker image
       # This eliminates the need for npm ci in each job (saves ~30-60s per job)

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
   docker-build:
     name: Build Docker Image
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     outputs:
       image-tag: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -212,7 +212,7 @@ jobs:
     if: needs.pre-publish-check.outputs.any-to-publish == 'true'
     name: Build Docker Image
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Increase Docker build timeout from 15→20 min (ci), 10→20 min (e2e, publish) to accommodate cold builds
- Switch CI BuildKit cache from `mode=min` to `mode=max` for intermediate layer caching
- Add cache-miss Step Summary so PR authors see "Full Rebuild (~15 min)" instead of waiting blindly
- Pruned 124 stale unscoped cache entries (~12 GB reclaimed) orphaned by PR #338's scope migration
- Updated ci-reference.md with dual-layer cache architecture docs and rollback condition

## Test plan

- [ ] Docker build job completes within 20-min timeout on this PR's CI run
- [ ] Step Summary shows "Cache Miss — Full Rebuild" on first run
- [ ] Second CI run on same branch shows cache hit and <5 min build
- [ ] `gh api repos/smith-horn/skillsmith/actions/cache/usage` shows reduced total after pruning
- [ ] After 72h, verify CI scope cache doesn't evict e2e/publish scopes

Closes SMI-3539

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)