### PR TITLE
fix(website): shared Supabase client singleton + Cloudflare CSP (SMI-3595, SMI-3596)

### DIFF
--- a/packages/website/src/components/Nav.astro
+++ b/packages/website/src/components/Nav.astro
@@ -418,7 +418,7 @@ const isActive = (href: string) => {
 </style>
 
 <script>
-  import { createClient } from '@supabase/supabase-js'
+  import { getSupabaseClient } from '../lib/supabase-client'
 
   // Mobile menu toggle
   const menuButton = document.getElementById('nav-mobile-button')
@@ -446,11 +446,9 @@ const isActive = (href: string) => {
     const mobileAuth = document.getElementById('nav-mobile-auth')
     if (!mobileAuth) return
 
-    const config = (window as unknown as { __SUPABASE_CONFIG__?: { url: string; anonKey: string } })
-      .__SUPABASE_CONFIG__
-    if (!config?.url || !config?.anonKey) return
+    const supabase = getSupabaseClient()
+    if (!supabase) return
 
-    const supabase = createClient(config.url, config.anonKey)
     const {
       data: { session },
     } = await supabase.auth.getSession()

--- a/packages/website/src/components/auth/LoginButton.astro
+++ b/packages/website/src/components/auth/LoginButton.astro
@@ -159,7 +159,7 @@ const buttonId = `github-login-${Math.random().toString(36).substring(2, 9)}`
 </style>
 
 <script>
-  import { createClient } from '@supabase/supabase-js'
+  import { getSupabaseClient } from '../../lib/supabase-client'
 
   // UA hint for known in-app browsers that swallow OAuth redirects (SMI-2757)
   function isInAppBrowser(): boolean {
@@ -244,11 +244,8 @@ const buttonId = `github-login-${Math.random().toString(36).substring(2, 9)}`
         const btn = e.currentTarget as HTMLButtonElement
         const redirectTo = btn.dataset.redirect || '/account'
 
-        // Get config from global
-        const config = (
-          window as unknown as { __SUPABASE_CONFIG__?: { url: string; anonKey: string } }
-        ).__SUPABASE_CONFIG__
-        if (!config?.url || !config?.anonKey) {
+        const supabase = getSupabaseClient()
+        if (!supabase) {
           console.error('Supabase config not found — check __SUPABASE_CONFIG__ injection')
           return
         }
@@ -261,8 +258,6 @@ const buttonId = `github-login-${Math.random().toString(36).substring(2, 9)}`
         btn.disabled = true
 
         try {
-          const supabase = createClient(config.url, config.anonKey)
-
           // Fetch OAuth URL without immediately redirecting so we can inspect it
           // and use it in the fallback banner if the redirect is swallowed (SMI-2757)
           const { data, error } = await supabase.auth.signInWithOAuth({

--- a/packages/website/src/components/auth/UserMenu.astro
+++ b/packages/website/src/components/auth/UserMenu.astro
@@ -255,7 +255,7 @@ const { loginRedirect = '/account' } = Astro.props
 </style>
 
 <script>
-  import { createClient } from '@supabase/supabase-js'
+  import { getSupabaseClient } from '../../lib/supabase-client'
 
   // Initialize user menu
   // Uses astro:page-load to reinitialize after ClientRouter view transitions
@@ -267,18 +267,14 @@ const { loginRedirect = '/account' } = Astro.props
     const dropdown = document.getElementById('user-dropdown')
     const logoutBtn = document.getElementById('logout-btn')
 
-    // Get config
-    const config = (window as unknown as { __SUPABASE_CONFIG__?: { url: string; anonKey: string } })
-      .__SUPABASE_CONFIG__
+    const supabase = getSupabaseClient()
 
-    if (!config?.url || !config?.anonKey) {
+    if (!supabase) {
       // No config, show logged out state
       if (loadingState) loadingState.style.display = 'none'
       if (loggedOutState) loggedOutState.style.display = 'block'
       return
     }
-
-    const supabase = createClient(config.url, config.anonKey)
 
     // Check auth state
     const {

--- a/packages/website/src/env.d.ts
+++ b/packages/website/src/env.d.ts
@@ -24,6 +24,7 @@ interface SupabaseWindowConfig {
 declare global {
   interface Window {
     __SUPABASE_CONFIG__?: SupabaseWindowConfig;
+    __SUPABASE_CLIENT__?: import('@supabase/supabase-js').SupabaseClient;
     __AUTH_REDIRECT_TO__?: string;
     /** Google Analytics gtag function (injected by GA script in BaseLayout) */
     gtag?: (...args: unknown[]) => void;

--- a/packages/website/src/layouts/BaseLayout.astro
+++ b/packages/website/src/layouts/BaseLayout.astro
@@ -129,6 +129,14 @@ const supabaseConfig = getSupabaseConfig()
     <script is:inline define:vars={{ supabaseConfig }}>
       window.__SUPABASE_CONFIG__ = supabaseConfig
     </script>
+
+    <!-- Eagerly create Supabase client singleton (SMI-3595) so inline scripts can use window.__SUPABASE_CLIENT__ -->
+    <script>
+      import { getSupabaseClient } from '../lib/supabase-client'
+      document.addEventListener('astro:page-load', () => {
+        getSupabaseClient()
+      })
+    </script>
   </head>
   <body class="bg-dark-950 text-dark-100 min-h-screen antialiased">
     <!-- Skip to main content link for keyboard navigation -->

--- a/packages/website/src/lib/supabase-client.ts
+++ b/packages/website/src/lib/supabase-client.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared Supabase client singleton (SMI-3595)
+ *
+ * All client-side code must use getSupabaseClient() instead of
+ * calling createClient() directly. This avoids multiple GoTrueClient
+ * instances competing for the same auth storage keys.
+ *
+ * Requires window.__SUPABASE_CONFIG__ to be set by the page
+ * (injected via BaseLayout.astro or page-level is:inline script).
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Returns a singleton SupabaseClient, creating it on first call.
+ * Returns null if __SUPABASE_CONFIG__ is missing or incomplete.
+ */
+export function getSupabaseClient(): SupabaseClient | null {
+  if (window.__SUPABASE_CLIENT__) return window.__SUPABASE_CLIENT__
+
+  const config = window.__SUPABASE_CONFIG__
+  if (!config?.url || !config?.anonKey) return null
+
+  window.__SUPABASE_CLIENT__ = createClient(config.url, config.anonKey)
+  return window.__SUPABASE_CLIENT__
+}

--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -553,8 +553,12 @@ const categoryJsonLd =
 
     async function initAuth() {
       try {
-        const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2')
-        const supabase = createClient(config.url, config.anonKey)
+        // Use shared singleton from window.__SUPABASE_CLIENT__ (SMI-3595)
+        const supabase = window.__SUPABASE_CLIENT__
+        if (!supabase) {
+          console.debug('[Skills] No Supabase client, using anon key')
+          return
+        }
         const {
           data: { session },
         } = await supabase.auth.getSession()

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -377,9 +377,12 @@ const trustTiers = [
 
       async function initAuth() {
         try {
-          // Check for logged-in user's session token
-          const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2')
-          const supabase = createClient(config.url, config.anonKey)
+          // Use shared singleton from window.__SUPABASE_CLIENT__ (SMI-3595)
+          const supabase = window.__SUPABASE_CLIENT__
+          if (!supabase) {
+            console.debug('[Skills] No Supabase client, using anon key')
+            return
+          }
           const {
             data: { session },
           } = await supabase.auth.getSession()

--- a/packages/website/vercel.json
+++ b/packages/website/vercel.json
@@ -39,7 +39,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://esm.sh; style-src 'self' 'unsafe-inline' https://api.fontshare.com https://fonts.googleapis.com; font-src 'self' https://cdn.fontshare.com https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://analytics.google.com https://*.supabase.co https://api.skillsmith.app https://api.fontshare.com https://esm.sh; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://api.fontshare.com https://fonts.googleapis.com; font-src 'self' https://cdn.fontshare.com https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://analytics.google.com https://*.supabase.co https://api.skillsmith.app https://api.fontshare.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- **SMI-3595**: Replace multiple `GoTrueClient` instances with a shared singleton (`getSupabaseClient()`) cached on `window.__SUPABASE_CLIENT__`. Eliminates esm.sh CDN dependency — all Supabase imports now use the bundled `@supabase/supabase-js`.
- **SMI-3596**: Add Cloudflare Insights domains to CSP (`static.cloudflareinsights.com` in `script-src`, `cloudflareinsights.com` in `connect-src`). Remove now-unused `esm.sh` entries.

## Changes

- New `lib/supabase-client.ts` — singleton factory with null-safe config check
- `BaseLayout.astro` — eagerly initializes singleton on `astro:page-load` so inline scripts in skills pages can use it
- `Nav.astro`, `UserMenu.astro`, `LoginButton.astro` — import `getSupabaseClient()` instead of `createClient()`
- `skills/index.astro`, `skills/[id].astro` — use `window.__SUPABASE_CLIENT__` instead of `import('https://esm.sh/...')`
- `env.d.ts` — add `__SUPABASE_CLIENT__` to Window type
- `vercel.json` — CSP update (Cloudflare Insights added, esm.sh removed)

## Test plan

- [ ] Visit `/skills` — search and pagination work, no `GoTrueClient` console warning
- [ ] Visit `/skills/<id>` — skill detail loads, JWT auth initializes without esm.sh
- [ ] Log in via GitHub OAuth — UserMenu shows avatar/dropdown, logout works
- [ ] Check browser console — no CSP violations for Cloudflare beacon
- [ ] Mobile nav — auth state reflects correctly (logged in shows Dashboard/Sign out)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)