### PR TITLE
fix(core): remove dead V3 imports, add skillsmith-cli to test, migrate to ruflo CLI (SMI-3599, SMI-3600, SMI-3601)

### DIFF
--- a/packages/core/src/embeddings/hnsw-store.ts
+++ b/packages/core/src/embeddings/hnsw-store.ts
@@ -2,7 +2,7 @@
  * SMI-1519: HNSW Embedding Store
  *
  * High-performance vector storage using HNSW index for fast ANN search.
- * Uses claude-flow V3 VectorDB API with automatic fallback to brute-force.
+ * Uses brute-force search (V3 VectorDB unavailable after claude-flow rename).
  *
  * Enable via: SKILLSMITH_USE_HNSW=true
  * @see ADR-009: Embedding Service Fallback Strategy
@@ -398,44 +398,10 @@ export class HNSWEmbeddingStore implements IEmbeddingStore {
     `)
   }
 
-  // IMPORTANT: Keep dynamic import here for V3 lazy loading / graceful degradation
   private async initHNSWIndex(): Promise<void> {
-    try {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore TS2307 — dynamic import; fails at runtime (claude-flow renamed to ruflo), caught by try/catch
-      const vectorDbModule = await import('claude-flow/v3/@claude-flow/cli/dist/src/ruvector/vector-db.js') // prettier-ignore
-      const loaded = await vectorDbModule.loadRuVector()
-      if (!loaded) console.warn('[HNSWEmbeddingStore] ruvector not available')
-
-      this.vectorDB = await vectorDbModule.createVectorDB(this.config.dimensions)
-      const status = vectorDbModule.getStatus()
-      console.log(
-        `[HNSWEmbeddingStore] Initialized: ${status.backend}${status.wasmAccelerated ? ' (WASM)' : ''}`
-      )
-
-      // Rebuild from SQLite
-      if (this.db) {
-        const count = this.db.prepare('SELECT COUNT(*) as c FROM skill_embeddings').get() as {
-          c: number
-        }
-        if (count.c > 0) {
-          console.log(`[HNSWEmbeddingStore] Rebuilding from ${count.c} embeddings...`)
-          const allEmbeddings = this.getAllEmbeddings()
-          for (const [skillId, embedding] of allEmbeddings) {
-            try {
-              const result = this.vectorDB!.insert(embedding, skillId)
-              if (result instanceof Promise) await result
-            } catch (err) {
-              console.warn(`Failed to insert ${skillId}: ${err}`)
-            }
-          }
-          console.log(`[HNSWEmbeddingStore] Index rebuilt with ${allEmbeddings.size} vectors`)
-        }
-      }
-    } catch (err) {
-      console.warn(`[HNSWEmbeddingStore] V3 VectorDB unavailable, using brute-force: ${err}`)
-      this.vectorDB = null
-    }
+    // V3 VectorDB unavailable after claude-flow → ruflo rename (SMI-3600)
+    // @claude-flow/cli restricts subpath imports; always use brute-force search
+    this.vectorDB = null
   }
 
   private distanceToSimilarity(distance: number): number {

--- a/packages/core/src/routing/SONARouter.ts
+++ b/packages/core/src/routing/SONARouter.ts
@@ -283,26 +283,10 @@ export class SONARouter {
   }
 
   private async initializeV3MoE(): Promise<void> {
-    try {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore TS2307 — dynamic import; fails at runtime (claude-flow renamed to ruflo), caught by try/catch
-      const moeModule = await import('claude-flow/v3/@claude-flow/cli/dist/src/ruvector/moe-router.js') // prettier-ignore
-      this.v3MoE = moeModule.getMoERouter()
-      await this.v3MoE!.initialize()
-
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore TS2307 — dynamic import; fails at runtime (claude-flow renamed to ruflo), caught by try/catch
-      const sonaModule = await import('claude-flow/v3/@claude-flow/cli/dist/src/memory/sona-optimizer.js') // prettier-ignore
-      const sonaOptimizer = await sonaModule.getSONAOptimizer()
-      await sonaOptimizer.initialize()
-      this.v3SONA = sonaOptimizer
-
-      console.log('[SONARouter] V3 MoE integration initialized')
-    } catch {
-      console.log('[SONARouter] V3 MoE not available, using local scoring algorithm')
-      this.v3MoE = null
-      this.v3SONA = null
-    }
+    // V3 MoE modules unavailable after claude-flow → ruflo rename (SMI-3600)
+    // @claude-flow/cli restricts subpath imports; always use local scoring
+    this.v3MoE = null
+    this.v3SONA = null
   }
 
   private startHealthChecks(): void {

--- a/packages/core/src/session/SessionManager.helpers.ts
+++ b/packages/core/src/session/SessionManager.helpers.ts
@@ -4,69 +4,7 @@
  */
 
 import { spawn } from 'node:child_process'
-import type {
-  ClaudeFlowMemoryModule,
-  ClaudeFlowMcpModule,
-  CommandExecutor,
-} from './SessionManager.types.js'
-
-// ============================================================================
-// Module Loading State
-// ============================================================================
-
-// Use symbol to distinguish "not yet attempted" from "attempted but failed (undefined)"
-const NOT_LOADED = Symbol('not-loaded')
-let claudeFlowMemory: ClaudeFlowMemoryModule | undefined | typeof NOT_LOADED = NOT_LOADED
-let claudeFlowMcp: ClaudeFlowMcpModule | undefined | typeof NOT_LOADED = NOT_LOADED
-
-// Module paths are constructed dynamically to prevent ESM static analysis
-const CLAUDE_FLOW_BASE = 'claude-flow'
-const MEMORY_MODULE_PATH = '/v3/@claude-flow/cli/dist/src/memory/memory-initializer.js'
-const MCP_MODULE_PATH = '/v3/@claude-flow/cli/dist/src/mcp-client.js'
-
-// ============================================================================
-// Dynamic Module Loaders
-// ============================================================================
-
-/**
- * Lazily load claude-flow memory module
- * Returns undefined if claude-flow is not installed
- *
- * Uses string concatenation for the import path to prevent Node.js
- * ESM static analysis from resolving the module at parse time.
- */
-export async function getClaudeFlowMemory(): Promise<ClaudeFlowMemoryModule | undefined> {
-  if (claudeFlowMemory === NOT_LOADED) {
-    try {
-      // String concatenation prevents static analysis
-      const modulePath = CLAUDE_FLOW_BASE + MEMORY_MODULE_PATH
-      claudeFlowMemory = await import(/* webpackIgnore: true */ modulePath)
-    } catch {
-      claudeFlowMemory = undefined // Mark as attempted but failed
-    }
-  }
-  return claudeFlowMemory === NOT_LOADED ? undefined : claudeFlowMemory
-}
-
-/**
- * Lazily load claude-flow MCP module
- * Returns undefined if claude-flow is not installed
- *
- * Uses string concatenation for the import path to prevent Node.js
- * ESM static analysis from resolving the module at parse time.
- */
-export async function getClaudeFlowMcp(): Promise<ClaudeFlowMcpModule | undefined> {
-  if (claudeFlowMcp === NOT_LOADED) {
-    try {
-      // String concatenation prevents static analysis
-      const modulePath = CLAUDE_FLOW_BASE + MCP_MODULE_PATH
-      claudeFlowMcp = await import(/* webpackIgnore: true */ modulePath)
-    } catch {
-      claudeFlowMcp = undefined // Mark as attempted but failed
-    }
-  }
-  return claudeFlowMcp === NOT_LOADED ? undefined : claudeFlowMcp
-}
+import type { CommandExecutor } from './SessionManager.types.js'
 
 // ============================================================================
 // Constants
@@ -80,18 +18,6 @@ export const MEMORY_KEYS = {
   SESSION_PREFIX: 'session/',
   CHECKPOINT_PREFIX: 'checkpoint/',
 } as const
-
-/**
- * SMI-1518: Feature flag to enable V3 direct API
- * Set CLAUDE_FLOW_USE_V3_API=true to use direct API calls
- * Falls back to spawn-based CLI if not set or if V3 API fails
- */
-export const USE_V3_API = process.env.CLAUDE_FLOW_USE_V3_API === 'true'
-
-/**
- * Default namespace for session memory entries
- */
-export const MEMORY_NAMESPACE = 'skillsmith-sessions'
 
 // ============================================================================
 // Validation

--- a/packages/core/src/session/SessionManager.memory.ts
+++ b/packages/core/src/session/SessionManager.memory.ts
@@ -2,29 +2,23 @@
  * @fileoverview Session Manager Memory and Hook Operations
  * @module @skillsmith/core/session/SessionManager.memory
  * @see SMI-641: Session ID Storage in Claude-Flow Memory
- * @see SMI-1518: V3 API Migration
  * @see SMI-2741: Split from SessionManager.ts to meet 500-line standard
+ * @see SMI-3600: Remove dead V3 dynamic imports (claude-flow → ruflo rename)
+ * @see SMI-3601: Migrate npx claude-flow CLI calls to npx ruflo
  *
- * Standalone functions for claude-flow memory storage, retrieval, deletion,
+ * Standalone functions for ruflo memory storage, retrieval, deletion,
  * and hook invocation. Extracted to keep SessionManager.ts within the
- * 500-line limit while preserving all V3/spawn fallback logic.
+ * 500-line limit.
  */
 
 import type { CommandExecutor, MemoryResult } from './SessionManager.types.js'
-import {
-  getClaudeFlowMemory,
-  getClaudeFlowMcp,
-  MEMORY_KEYS,
-  USE_V3_API,
-  MEMORY_NAMESPACE,
-  validateMemoryKey,
-} from './SessionManager.helpers.js'
+import { validateMemoryKey } from './SessionManager.helpers.js'
 
 /**
- * Store data in claude-flow memory
+ * Store data in ruflo memory
  *
  * SMI-674: Uses spawn() with argument array to prevent command injection
- * SMI-1518: V3 API Migration - Use direct storeEntry() when available
+ * SMI-3601: Migrated from claude-flow to ruflo
  *
  * @param key - Memory key
  * @param value - Value to store
@@ -40,34 +34,14 @@ export async function storeMemoryEntry(
     return { success: false, error: 'Invalid memory key' }
   }
 
-  // SMI-1518, SMI-1609: Try V3 direct API first if enabled
-  if (USE_V3_API) {
-    try {
-      const memoryModule = await getClaudeFlowMemory()
-      if (memoryModule?.storeEntry) {
-        const result = await memoryModule.storeEntry({
-          key,
-          value,
-          namespace: MEMORY_NAMESPACE,
-        })
-        if (result.success) {
-          return { success: true }
-        }
-        console.warn(`V3 storeEntry failed: ${result.error}, falling back to spawn`)
-      }
-    } catch (error) {
-      console.warn(`V3 storeEntry exception: ${error}, falling back to spawn`)
-    }
-  }
-
   try {
-    const args = ['claude-flow', 'memory', 'store', '--key', key, '--value', value]
+    const args = ['ruflo', 'memory', 'store', '--key', key, '--value', value]
 
     if (executor.spawn) {
       await executor.spawn('npx', args)
     } else {
       const escapedValue = value.replace(/'/g, "'\\''")
-      const command = `npx claude-flow memory store --key "${key}" --value '${escapedValue}'`
+      const command = `npx ruflo memory store --key "${key}" --value '${escapedValue}'`
       await executor.execute(command)
     }
     return { success: true }
@@ -80,10 +54,10 @@ export async function storeMemoryEntry(
 }
 
 /**
- * Retrieve data from claude-flow memory
+ * Retrieve data from ruflo memory
  *
  * SMI-674: Uses spawn() with argument array to prevent command injection
- * SMI-1518: V3 API Migration - Use direct getEntry() when available
+ * SMI-3601: Migrated from claude-flow to ruflo
  *
  * @param key - Memory key
  * @param executor - Command executor for spawn/execute fallback
@@ -97,37 +71,15 @@ export async function retrieveMemoryEntry(
     return { success: false, error: 'Invalid memory key' }
   }
 
-  // SMI-1518, SMI-1609: Try V3 direct API first if enabled
-  if (USE_V3_API) {
-    try {
-      const memoryModule = await getClaudeFlowMemory()
-      if (memoryModule?.getEntry) {
-        const result = await memoryModule.getEntry({
-          key,
-          namespace: MEMORY_NAMESPACE,
-        })
-        if (result.success && result.found && result.entry) {
-          return { success: true, data: result.entry.content }
-        }
-        if (result.success && !result.found) {
-          return { success: false, error: 'Key not found' }
-        }
-        console.warn(`V3 getEntry failed: ${result.error}, falling back to spawn`)
-      }
-    } catch (error) {
-      console.warn(`V3 getEntry exception: ${error}, falling back to spawn`)
-    }
-  }
-
   try {
-    const args = ['claude-flow', 'memory', 'get', '--key', key]
+    const args = ['ruflo', 'memory', 'get', '--key', key]
 
     let stdout: string
     if (executor.spawn) {
       const result = await executor.spawn('npx', args)
       stdout = result.stdout
     } else {
-      const command = `npx claude-flow memory get --key "${key}"`
+      const command = `npx ruflo memory get --key "${key}"`
       const result = await executor.execute(command)
       stdout = result.stdout
     }
@@ -141,10 +93,10 @@ export async function retrieveMemoryEntry(
 }
 
 /**
- * Delete data from claude-flow memory
+ * Delete data from ruflo memory
  *
  * SMI-674: Uses spawn() with argument array to prevent command injection
- * SMI-1518: V3 API Migration - Use callMCPTool('memory/delete') when available
+ * SMI-3601: Migrated from claude-flow to ruflo
  *
  * @param key - Memory key to delete
  * @param executor - Command executor for spawn/execute fallback
@@ -158,36 +110,13 @@ export async function deleteMemoryEntry(
     return { success: false, error: 'Invalid memory key' }
   }
 
-  // SMI-1518, SMI-1609: Try V3 MCP API first if enabled
-  if (USE_V3_API) {
-    try {
-      const mcpModule = await getClaudeFlowMcp()
-      if (mcpModule?.callMCPTool) {
-        const result = (await mcpModule.callMCPTool('memory/delete', { key })) as {
-          success: boolean
-          deleted: boolean
-        }
-        if (result.success) {
-          return { success: true }
-        }
-        console.warn(`V3 memory/delete failed, falling back to spawn`)
-      }
-    } catch (error) {
-      const mcpModule = await getClaudeFlowMcp()
-      const MCPClientError = mcpModule?.MCPClientError
-      if (!MCPClientError || !(error instanceof MCPClientError)) {
-        console.warn(`V3 memory/delete exception: ${error}, falling back to spawn`)
-      }
-    }
-  }
-
   try {
-    const args = ['claude-flow', 'memory', 'delete', '--key', key]
+    const args = ['ruflo', 'memory', 'delete', '--key', key]
 
     if (executor.spawn) {
       await executor.spawn('npx', args)
     } else {
-      const command = `npx claude-flow memory delete --key "${key}"`
+      const command = `npx ruflo memory delete --key "${key}"`
       await executor.execute(command)
     }
     return { success: true }
@@ -201,7 +130,7 @@ export async function deleteMemoryEntry(
  * Run pre-task hook
  *
  * SMI-674: Uses spawn() with argument array to prevent command injection
- * SMI-1518: V3 API Migration - Use callMCPTool('hooks/pre-task') when available
+ * SMI-3601: Migrated from claude-flow to ruflo
  *
  * @param description - Task description
  * @param executor - Command executor for spawn/execute fallback
@@ -210,25 +139,9 @@ export async function runPreTaskHook(
   description: string,
   executor: CommandExecutor
 ): Promise<void> {
-  // SMI-1518, SMI-1609: Try V3 MCP API first if enabled
-  if (USE_V3_API) {
-    try {
-      const mcpModule = await getClaudeFlowMcp()
-      if (mcpModule?.callMCPTool) {
-        await mcpModule.callMCPTool('hooks/pre-task', {
-          description,
-          memoryKey: MEMORY_KEYS.CURRENT,
-        })
-        return
-      }
-    } catch {
-      // V3 API not available or failed, fall back to spawn
-    }
-  }
-
   try {
     const args = [
-      'claude-flow',
+      'ruflo',
       'hooks',
       'pre-task',
       '--description',
@@ -241,7 +154,7 @@ export async function runPreTaskHook(
       await executor.spawn('npx', args)
     } else {
       const escapedDesc = description.replace(/'/g, "'\\''")
-      const command = `npx claude-flow hooks pre-task --description '${escapedDesc}' --memory-key "session/current"`
+      const command = `npx ruflo hooks pre-task --description '${escapedDesc}' --memory-key "session/current"`
       await executor.execute(command)
     }
   } catch {
@@ -253,34 +166,19 @@ export async function runPreTaskHook(
  * Run post-task hook
  *
  * SMI-674: Uses spawn() with argument array to prevent command injection
- * SMI-1518: V3 API Migration - Use callMCPTool('hooks/post-task') when available
+ * SMI-3601: Migrated from claude-flow to ruflo
  *
  * @param taskId - Task ID to pass to the hook
  * @param executor - Command executor for spawn/execute fallback
  */
 export async function runPostTaskHook(taskId: string, executor: CommandExecutor): Promise<void> {
-  // SMI-1518, SMI-1609: Try V3 MCP API first if enabled
-  if (USE_V3_API) {
-    try {
-      const mcpModule = await getClaudeFlowMcp()
-      if (mcpModule?.callMCPTool) {
-        await mcpModule.callMCPTool('hooks/post-task', {
-          taskId,
-        })
-        return
-      }
-    } catch {
-      // V3 API not available or failed, fall back to spawn
-    }
-  }
-
   try {
-    const args = ['claude-flow', 'hooks', 'post-task', '--task-id', taskId]
+    const args = ['ruflo', 'hooks', 'post-task', '--task-id', taskId]
 
     if (executor.spawn) {
       await executor.spawn('npx', args)
     } else {
-      const command = `npx claude-flow hooks post-task --task-id "${taskId}"`
+      const command = `npx ruflo hooks post-task --task-id "${taskId}"`
       await executor.execute(command)
     }
   } catch {

--- a/packages/core/src/session/SessionManager.types.ts
+++ b/packages/core/src/session/SessionManager.types.ts
@@ -6,40 +6,6 @@
 import type { SessionData } from './SessionContext.js'
 
 // ============================================================================
-// Claude-Flow Module Types (Dynamic Import)
-// ============================================================================
-
-/**
- * SMI-1685: Type definitions for dynamically imported claude-flow memory module
- * These interfaces define the expected shape of the memory module API
- */
-export interface ClaudeFlowMemoryModule {
-  storeEntry?(params: {
-    key: string
-    value: string
-    namespace: string
-  }): Promise<{ success: boolean; error?: string }>
-  getEntry?(params: { key: string; namespace: string }): Promise<{
-    success: boolean
-    found: boolean
-    entry?: { content: string }
-    error?: string
-  }>
-}
-
-/**
- * SMI-1685: Type definitions for dynamically imported claude-flow MCP module
- * These interfaces define the expected shape of the MCP client API
- */
-export interface ClaudeFlowMcpModule {
-  callMCPTool?(
-    toolName: string,
-    params: Record<string, unknown>
-  ): Promise<{ success: boolean; deleted?: boolean; error?: string }>
-  MCPClientError?: new (message: string) => Error
-}
-
-// ============================================================================
 // Session Options and Results
 // ============================================================================
 

--- a/packages/core/src/session/SessionRecovery.ts
+++ b/packages/core/src/session/SessionRecovery.ts
@@ -76,7 +76,7 @@ export class SessionRecovery {
   private async searchForRecentSession(): Promise<SessionData | null> {
     try {
       // Use claude-flow memory list to find session keys
-      const command = 'npx claude-flow@alpha memory list --pattern "session/*"'
+      const command = 'npx ruflo memory list --pattern "session/*"'
       const { stdout } = await this.executor.execute(command)
 
       // Parse output to find session keys
@@ -287,7 +287,7 @@ export class SessionRecovery {
    */
   private async retrieveCheckpointData(memoryKey: string): Promise<Checkpoint | null> {
     try {
-      const command = `npx claude-flow@alpha memory get --key "${memoryKey}"`
+      const command = `npx ruflo memory get --key "${memoryKey}"`
       const { stdout } = await this.executor.execute(command)
 
       if (!stdout.trim()) {
@@ -305,7 +305,7 @@ export class SessionRecovery {
    */
   private async runSessionRestoreHook(sessionId: string): Promise<void> {
     try {
-      const command = `npx claude-flow@alpha hooks session-restore --session-id "${sessionId}"`
+      const command = `npx ruflo hooks session-restore --session-id "${sessionId}"`
       await this.executor.execute(command)
     } catch {
       // Hooks are optional

--- a/packages/core/src/testing/MultiLLMProvider.ts
+++ b/packages/core/src/testing/MultiLLMProvider.ts
@@ -119,7 +119,7 @@ export class MultiLLMProvider extends EventEmitter {
   private activeRequests: Map<LLMProviderType, number> = new Map()
   private roundRobinIndex = 0
 
-  // IMPORTANT: Keep V3 integration here for lazy loading / graceful degradation
+  // V3 integration disabled (SMI-3600); field retained for close() cleanup path
   private v3ProviderManager: unknown = null
 
   constructor(config: MultiLLMProviderConfig = {}) {
@@ -320,27 +320,11 @@ export class MultiLLMProvider extends EventEmitter {
     }
   }
 
-  // IMPORTANT: Keep dynamic import here for V3 lazy loading / graceful degradation
+  // V3 provider modules unavailable after claude-flow → ruflo rename (SMI-3600)
+  // @claude-flow/cli restricts subpath imports; always use local provider chain
   private async initializeV3Integration(): Promise<void> {
-    try {
-      const { ProviderManager } = await import(
-        // @ts-expect-error - V3 types not available at compile time
-        'claude-flow/providers'
-      )
-
-      this.v3ProviderManager = new ProviderManager(console, null, {
-        providers: this.config.providers,
-        defaultProvider: this.config.defaultProvider,
-        fallbackStrategy: this.config.fallbackStrategy,
-        loadBalancing: this.config.loadBalancing,
-        costOptimization: this.config.costOptimization,
-        monitoring: { enabled: this.config.enableMetrics, metricsInterval: 60000 },
-      })
-
-      this.emit('v3_integration', { enabled: true })
-    } catch {
-      this.emit('v3_integration', { enabled: false, reason: 'V3 not available' })
-    }
+    this.v3ProviderManager = null
+    this.emit('v3_integration', { enabled: false, reason: 'V3 not available' })
   }
 
   private doSelectProvider(request: LLMRequest): LLMProviderType {

--- a/packages/core/tests/session/SessionManager.helpers.test.ts
+++ b/packages/core/tests/session/SessionManager.helpers.test.ts
@@ -6,11 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import {
-  validateMemoryKey,
-  MEMORY_KEYS,
-  MEMORY_NAMESPACE,
-} from '../../src/session/SessionManager.helpers.js'
+import { validateMemoryKey, MEMORY_KEYS } from '../../src/session/SessionManager.helpers.js'
 
 describe('SessionManager.helpers', () => {
   describe('validateMemoryKey', () => {
@@ -116,16 +112,6 @@ describe('SessionManager.helpers', () => {
       expect(validateMemoryKey(MEMORY_KEYS.CURRENT)).toBe(true)
       expect(validateMemoryKey(MEMORY_KEYS.SESSION_PREFIX + 'test')).toBe(true)
       expect(validateMemoryKey(MEMORY_KEYS.CHECKPOINT_PREFIX + '123')).toBe(true)
-    })
-  })
-
-  describe('MEMORY_NAMESPACE', () => {
-    it('exports namespace constant', () => {
-      expect(MEMORY_NAMESPACE).toBe('skillsmith-sessions')
-    })
-
-    it('namespace passes validation', () => {
-      expect(validateMemoryKey(MEMORY_NAMESPACE)).toBe(true)
     })
   })
 })

--- a/packages/core/tests/session/SessionManager.memory.test.ts
+++ b/packages/core/tests/session/SessionManager.memory.test.ts
@@ -1,27 +1,18 @@
 /**
  * SMI-2754: SessionManager Memory Operation Tests
+ * SMI-3600: V3 dynamic import tests removed (dead code after claude-flow → ruflo rename)
+ * SMI-3601: CLI calls migrated from claude-flow to ruflo
  *
  * Tests for storeMemoryEntry, retrieveMemoryEntry, deleteMemoryEntry,
- * runPreTaskHook, and runPostTaskHook.
- *
- * Since USE_V3_API is evaluated at module load time, we mock the helpers
- * module to control getClaudeFlowMemory / getClaudeFlowMcp / USE_V3_API.
+ * runPreTaskHook, and runPostTaskHook — spawn-based CLI path only.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-
-// ============================================================================
-// We mock the helpers module to control USE_V3_API and module loading
-// ============================================================================
+import { describe, it, expect, vi, afterEach } from 'vitest'
 
 vi.mock('../../src/session/SessionManager.helpers.js', () => {
   return {
     validateMemoryKey: (key: string) => /^[a-zA-Z0-9/_-]+$/.test(key) && key.length <= 256,
     MEMORY_KEYS: { CURRENT: 'session/current' },
-    MEMORY_NAMESPACE: 'skillsmith-sessions',
-    USE_V3_API: false, // Start with spawn path; override per test
-    getClaudeFlowMemory: vi.fn(),
-    getClaudeFlowMcp: vi.fn(),
   }
 })
 
@@ -32,7 +23,6 @@ import {
   runPreTaskHook,
   runPostTaskHook,
 } from '../../src/session/SessionManager.memory.js'
-import * as helpers from '../../src/session/SessionManager.helpers.js'
 import type { CommandExecutor } from '../../src/session/SessionManager.types.js'
 
 // ============================================================================
@@ -45,18 +35,6 @@ function makeSpawnExecutor(overrides: Partial<{ stdout: string }> = {}): Command
     spawn: vi.fn().mockResolvedValue({ stdout: overrides.stdout ?? '', stderr: '' }),
   }
 }
-
-function enableV3(enabled: boolean) {
-  // Override the USE_V3_API value in the mocked module
-  // @ts-expect-error - overriding readonly for testing
-  helpers.USE_V3_API = enabled
-}
-
-beforeEach(() => {
-  enableV3(false)
-  vi.mocked(helpers.getClaudeFlowMemory).mockReset()
-  vi.mocked(helpers.getClaudeFlowMcp).mockReset()
-})
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -74,46 +52,24 @@ describe('storeMemoryEntry', () => {
     expect(executor.spawn).not.toHaveBeenCalled()
   })
 
-  it('uses V3 storeEntry when USE_V3_API is true and module is available', async () => {
-    enableV3(true)
-    const storeEntry = vi.fn().mockResolvedValue({ success: true })
-    vi.mocked(helpers.getClaudeFlowMemory).mockResolvedValue({ storeEntry })
-
-    const executor = makeSpawnExecutor()
-    const result = await storeMemoryEntry('session/test', 'my-value', executor)
-
-    expect(result).toEqual({ success: true })
-    expect(storeEntry).toHaveBeenCalledWith({
-      key: 'session/test',
-      value: 'my-value',
-      namespace: 'skillsmith-sessions',
-    })
-    expect(executor.spawn).not.toHaveBeenCalled()
-  })
-
-  it('falls back to spawn when V3 storeEntry returns success:false', async () => {
-    enableV3(true)
-    const storeEntry = vi.fn().mockResolvedValue({ success: false, error: 'V3 error' })
-    vi.mocked(helpers.getClaudeFlowMemory).mockResolvedValue({ storeEntry })
-
-    const executor = makeSpawnExecutor()
-    const result = await storeMemoryEntry('session/fallback', 'value', executor)
-
-    expect(result).toEqual({ success: true })
-    expect(executor.spawn).toHaveBeenCalled()
-  })
-
-  it('uses spawn directly when USE_V3_API is false', async () => {
-    enableV3(false)
+  it('uses spawn with ruflo CLI args', async () => {
     const executor = makeSpawnExecutor()
     const result = await storeMemoryEntry('session/key', 'val', executor)
 
     expect(result).toEqual({ success: true })
     expect(executor.spawn).toHaveBeenCalledWith(
       'npx',
-      expect.arrayContaining(['claude-flow', 'memory', 'store', '--key', 'session/key'])
+      expect.arrayContaining(['ruflo', 'memory', 'store', '--key', 'session/key'])
     )
-    expect(helpers.getClaudeFlowMemory).not.toHaveBeenCalled()
+  })
+
+  it('returns error when spawn fails', async () => {
+    const executor: CommandExecutor = {
+      execute: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      spawn: vi.fn().mockRejectedValue(new Error('spawn failed')),
+    }
+    const result = await storeMemoryEntry('session/key', 'val', executor)
+    expect(result).toEqual({ success: false, error: 'spawn failed' })
   })
 })
 
@@ -128,55 +84,24 @@ describe('retrieveMemoryEntry', () => {
     expect(result).toEqual({ success: false, error: 'Invalid memory key' })
   })
 
-  it('returns data from V3 getEntry when found', async () => {
-    enableV3(true)
-    const getEntry = vi.fn().mockResolvedValue({
-      success: true,
-      found: true,
-      entry: { content: 'stored-value' },
-    })
-    vi.mocked(helpers.getClaudeFlowMemory).mockResolvedValue({ getEntry })
-
-    const executor = makeSpawnExecutor()
-    const result = await retrieveMemoryEntry('session/found', executor)
-
-    expect(result).toEqual({ success: true, data: 'stored-value' })
-    expect(executor.spawn).not.toHaveBeenCalled()
-  })
-
-  it('returns not-found error from V3 when key does not exist', async () => {
-    enableV3(true)
-    const getEntry = vi.fn().mockResolvedValue({
-      success: true,
-      found: false,
-    })
-    vi.mocked(helpers.getClaudeFlowMemory).mockResolvedValue({ getEntry })
-
-    const executor = makeSpawnExecutor()
-    const result = await retrieveMemoryEntry('session/missing', executor)
-
-    expect(result).toEqual({ success: false, error: 'Key not found' })
-    expect(executor.spawn).not.toHaveBeenCalled()
-  })
-
-  it('falls back to spawn when V3 getEntry throws an exception', async () => {
-    enableV3(true)
-    vi.mocked(helpers.getClaudeFlowMemory).mockRejectedValue(new Error('module load error'))
-
-    const executor = makeSpawnExecutor({ stdout: 'spawned-data' })
-    const result = await retrieveMemoryEntry('session/key', executor)
-
-    expect(result).toEqual({ success: true, data: 'spawned-data' })
-    expect(executor.spawn).toHaveBeenCalled()
-  })
-
-  it('uses spawn directly when USE_V3_API is false', async () => {
-    enableV3(false)
+  it('returns data from spawn stdout', async () => {
     const executor = makeSpawnExecutor({ stdout: 'value-from-spawn\n' })
     const result = await retrieveMemoryEntry('session/key', executor)
 
     expect(result).toEqual({ success: true, data: 'value-from-spawn' })
-    expect(helpers.getClaudeFlowMemory).not.toHaveBeenCalled()
+    expect(executor.spawn).toHaveBeenCalledWith(
+      'npx',
+      expect.arrayContaining(['ruflo', 'memory', 'get', '--key', 'session/key'])
+    )
+  })
+
+  it('returns error when spawn fails', async () => {
+    const executor: CommandExecutor = {
+      execute: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      spawn: vi.fn().mockRejectedValue(new Error('get failed')),
+    }
+    const result = await retrieveMemoryEntry('session/key', executor)
+    expect(result).toEqual({ success: false, error: 'get failed' })
   })
 })
 
@@ -191,28 +116,24 @@ describe('deleteMemoryEntry', () => {
     expect(result).toEqual({ success: false, error: 'Invalid memory key' })
   })
 
-  it('returns success when V3 callMCPTool succeeds', async () => {
-    enableV3(true)
-    const callMCPTool = vi.fn().mockResolvedValue({ success: true, deleted: true })
-    vi.mocked(helpers.getClaudeFlowMcp).mockResolvedValue({ callMCPTool })
-
+  it('uses spawn with ruflo CLI args', async () => {
     const executor = makeSpawnExecutor()
     const result = await deleteMemoryEntry('session/to-delete', executor)
 
     expect(result).toEqual({ success: true })
-    expect(callMCPTool).toHaveBeenCalledWith('memory/delete', { key: 'session/to-delete' })
+    expect(executor.spawn).toHaveBeenCalledWith(
+      'npx',
+      expect.arrayContaining(['ruflo', 'memory', 'delete', '--key', 'session/to-delete'])
+    )
   })
 
-  it('falls back to spawn (and returns success) when V3 callMCPTool fails', async () => {
-    enableV3(true)
-    const callMCPTool = vi.fn().mockResolvedValue({ success: false })
-    vi.mocked(helpers.getClaudeFlowMcp).mockResolvedValue({ callMCPTool })
-
-    const executor = makeSpawnExecutor()
+  it('returns success even when spawn throws (delete is best-effort)', async () => {
+    const executor: CommandExecutor = {
+      execute: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      spawn: vi.fn().mockRejectedValue(new Error('delete error')),
+    }
     const result = await deleteMemoryEntry('session/key', executor)
-
     expect(result).toEqual({ success: true })
-    expect(executor.spawn).toHaveBeenCalled()
   })
 })
 
@@ -221,36 +142,17 @@ describe('deleteMemoryEntry', () => {
 // ============================================================================
 
 describe('runPreTaskHook', () => {
-  it('calls V3 MCP pre-task hook when USE_V3_API is true', async () => {
-    enableV3(true)
-    const callMCPTool = vi.fn().mockResolvedValue({})
-    vi.mocked(helpers.getClaudeFlowMcp).mockResolvedValue({ callMCPTool })
-
-    const executor = makeSpawnExecutor()
-    await runPreTaskHook('test description', executor)
-
-    expect(callMCPTool).toHaveBeenCalledWith(
-      'hooks/pre-task',
-      expect.objectContaining({
-        description: 'test description',
-      })
-    )
-    expect(executor.spawn).not.toHaveBeenCalled()
-  })
-
-  it('uses spawn when USE_V3_API is false', async () => {
-    enableV3(false)
+  it('uses spawn with ruflo hooks pre-task args', async () => {
     const executor = makeSpawnExecutor()
     await runPreTaskHook('test description', executor)
 
     expect(executor.spawn).toHaveBeenCalledWith(
       'npx',
-      expect.arrayContaining(['pre-task', '--description', 'test description'])
+      expect.arrayContaining(['ruflo', 'hooks', 'pre-task', '--description', 'test description'])
     )
   })
 
   it('swallows errors and does not throw', async () => {
-    enableV3(false)
     const executor: CommandExecutor = {
       execute: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
       spawn: vi.fn().mockRejectedValue(new Error('hook failed')),
@@ -265,26 +167,21 @@ describe('runPreTaskHook', () => {
 // ============================================================================
 
 describe('runPostTaskHook', () => {
-  it('calls V3 MCP post-task hook when USE_V3_API is true', async () => {
-    enableV3(true)
-    const callMCPTool = vi.fn().mockResolvedValue({})
-    vi.mocked(helpers.getClaudeFlowMcp).mockResolvedValue({ callMCPTool })
-
-    const executor = makeSpawnExecutor()
-    await runPostTaskHook('task-123', executor)
-
-    expect(callMCPTool).toHaveBeenCalledWith('hooks/post-task', { taskId: 'task-123' })
-    expect(executor.spawn).not.toHaveBeenCalled()
-  })
-
-  it('uses spawn when USE_V3_API is false', async () => {
-    enableV3(false)
+  it('uses spawn with ruflo hooks post-task args', async () => {
     const executor = makeSpawnExecutor()
     await runPostTaskHook('task-456', executor)
 
     expect(executor.spawn).toHaveBeenCalledWith(
       'npx',
-      expect.arrayContaining(['post-task', '--task-id', 'task-456'])
+      expect.arrayContaining(['ruflo', 'hooks', 'post-task', '--task-id', 'task-456'])
     )
+  })
+
+  it('swallows errors and does not throw', async () => {
+    const executor: CommandExecutor = {
+      execute: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      spawn: vi.fn().mockRejectedValue(new Error('hook failed')),
+    }
+    await expect(runPostTaskHook('task-789', executor)).resolves.toBeUndefined()
   })
 })

--- a/scripts/tests/detect-affected.test.ts
+++ b/scripts/tests/detect-affected.test.ts
@@ -57,6 +57,13 @@ const mockPackages: PackageInfo[] = [
     dependencies: [],
     devDependencies: [],
   },
+  {
+    name: 'skillsmith-cli',
+    path: '/packages/skillsmith-cli',
+    dirName: 'skillsmith-cli',
+    dependencies: [],
+    devDependencies: [],
+  },
 ]
 
 describe('SMI-2190: Affected Package Detection', () => {


### PR DESCRIPTION
## Summary

Resolves all three remaining backlog issues from the claude-flow → ruflo rename investigation.

- **SMI-3599**: Add `skillsmith-cli` to `mockPackages` in `detect-affected.test.ts` to match the actual 7-package workspace
- **SMI-3600**: Remove dead V3 dynamic imports — `@claude-flow/cli` restricts subpath access via `exports` field, so all V3 integrations were silently failing. Simplifies `initializeV3MoE()`, `initHNSWIndex()`, `initializeV3Integration()` to immediate fallback. Removes dead module loaders, types, and V3 API try blocks from SessionManager
- **SMI-3601**: Migrate all `npx claude-flow` CLI calls to `npx ruflo` in SessionManager.memory.ts and SessionRecovery.ts

**Net: -386 lines of dead code removed.**

## Files changed (10)

| File | Change |
|------|--------|
| `scripts/tests/detect-affected.test.ts` | Add skillsmith-cli to mockPackages |
| `packages/core/src/routing/SONARouter.ts` | Simplify initializeV3MoE() to immediate null |
| `packages/core/src/embeddings/hnsw-store.ts` | Simplify initHNSWIndex() to immediate null |
| `packages/core/src/testing/MultiLLMProvider.ts` | Simplify initializeV3Integration() |
| `packages/core/src/session/SessionManager.helpers.ts` | Remove dead V3 loaders |
| `packages/core/src/session/SessionManager.types.ts` | Remove dead V3 type defs |
| `packages/core/src/session/SessionManager.memory.ts` | Remove V3 try blocks, rename CLI to ruflo |
| `packages/core/src/session/SessionRecovery.ts` | Rename CLI to ruflo |
| `packages/core/tests/session/SessionManager.helpers.test.ts` | Remove dead V3 test |
| `packages/core/tests/session/SessionManager.memory.test.ts` | Remove V3 mocks, update to ruflo |

## Test plan

- [ ] CI Type Check passes (0 errors)
- [ ] All test suites pass (6704 tests locally)
- [ ] `detect-affected.test.ts` passes with 7 packages
- [ ] SessionManager tests validate ruflo spawn paths

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)