### PR TITLE
fix(core): remove missed PatternStore V3 import (SMI-3600 retro)

### DIFF
--- a/packages/core/src/learning/PatternStore.ts
+++ b/packages/core/src/learning/PatternStore.ts
@@ -141,15 +141,8 @@ export class PatternStore {
   }
 
   private async initializeV3Integration(): Promise<void> {
-    try {
-      await import(
-        // @ts-expect-error - V3 types not available at compile time
-        'claude-flow/v3/@claude-flow/cli/dist/src/intelligence/index.js'
-      )
-      console.log('[PatternStore] V3 ReasoningBank integration enabled')
-    } catch {
-      console.log('[PatternStore] V3 not available, using standalone mode')
-    }
+    // V3 ReasoningBank unavailable after claude-flow → ruflo rename (SMI-3600)
+    // @claude-flow/cli restricts subpath imports; always use standalone mode
   }
 
   async storePattern(pattern: Pattern, outcome: PatternOutcome): Promise<string> {

--- a/packages/core/src/session/SessionRecovery.ts
+++ b/packages/core/src/session/SessionRecovery.ts
@@ -75,7 +75,7 @@ export class SessionRecovery {
    */
   private async searchForRecentSession(): Promise<SessionData | null> {
     try {
-      // Use claude-flow memory list to find session keys
+      // Use ruflo memory list to find session keys
       const command = 'npx ruflo memory list --pattern "session/*"'
       const { stdout } = await this.executor.execute(command)
 


### PR DESCRIPTION
## Summary

Governance retro on PRs #364-#366 found `PatternStore.ts` still had a dead `claude-flow/v3` dynamic import that was missed in PR #366. Also fixes a stale comment in `SessionRecovery.ts`.

- Simplify `initializeV3Integration()` to immediate no-op (matching SONARouter/hnsw-store pattern)
- Fix "claude-flow" → "ruflo" in code comment

## Test plan

- [ ] CI typecheck passes
- [ ] Tests pass

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)