### PR TITLE
fix(deps): use caret range for @modelcontextprotocol/sdk to fix Dependabot CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34724,7 +34724,7 @@
       "version": "0.4.5",
       "license": "Elastic-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.27.1",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "@skillsmith/core": "^0.4.16",
         "esbuild": "0.27.2"
       },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -21,7 +21,7 @@
     "test:integration": "vitest run --config vitest.config.integration.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.27.1",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@skillsmith/core": "^0.4.16",
     "esbuild": "0.27.2"
   },


### PR DESCRIPTION
## Summary
- Changes `@modelcontextprotocol/sdk` from exact pin `1.27.1` to caret range `^1.27.1` in `packages/mcp-server/package.json`
- All 11 open Dependabot PRs fail with `npm ci` error: `Missing: @modelcontextprotocol/sdk@1.27.1 from lock file`

## Root Cause
When Dependabot regenerates `package-lock.json`, npm deduplicates `@modelcontextprotocol/sdk` to `1.26.0` (satisfying ruflo's `^1.20.1` range) and drops the nested `1.27.1` resolution that the exact pin requires. With `^1.27.1`, npm can hoist `1.27.1` to root since it satisfies all transitive ranges (`^1.20.1`, `^1.24.3`, `^1.25.2`, `^1.27.1`).

## Test plan
- [x] `npm ci --ignore-scripts` passes locally
- [x] `npm run typecheck` passes
- [ ] CI passes on this PR
- [ ] After merge, Dependabot PRs should pass (rebase triggers re-run)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)