### PR TITLE
fix(deps): force @modelcontextprotocol/sdk ^1.27.1 via npm override to fix Dependabot CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4437,11 +4437,10 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -34745,46 +34744,6 @@
       "peerDependenciesMeta": {
         "@skillsmith/enterprise": {
           "optional": true
-        }
-      }
-    },
-    "packages/mcp-server/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "qs": "^6.14.2",
     "web-vitals": "5.1.0",
     "@modelcontextprotocol/sdk": {
+      ".": "^1.27.1",
       "ajv": "^8.18.0"
     },
     "agentdb": {

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -1514,6 +1514,30 @@ console.log(`\n${BOLD}23. Implementation Completeness Spot Check (SMI-3543)${RES
   }
 }
 
+// npm override drift check: @modelcontextprotocol/sdk override "." must match mcp-server range
+console.log(`\n${BOLD}Override Drift: @modelcontextprotocol/sdk${RESET}`)
+try {
+  const rootPkg = JSON.parse(readFileSync('package.json', 'utf8'))
+  const mcpPkg = JSON.parse(readFileSync('packages/mcp-server/package.json', 'utf8'))
+  const overrideDot = rootPkg.overrides?.['@modelcontextprotocol/sdk']?.['.']
+  const mcpRange = mcpPkg.dependencies?.['@modelcontextprotocol/sdk']
+  if (!overrideDot) {
+    fail(
+      'Missing override "." for @modelcontextprotocol/sdk in root package.json',
+      'Add "." key to force version globally — see docs/internal/implementation/dependabot-mcp-sdk-lock-fix.md'
+    )
+  } else if (overrideDot !== mcpRange) {
+    fail(
+      `Override drift: root override "." is ${overrideDot} but mcp-server declares ${mcpRange}`,
+      'Update root package.json overrides "." to match packages/mcp-server/package.json'
+    )
+  } else {
+    pass(`@modelcontextprotocol/sdk override "." (${overrideDot}) matches mcp-server range`)
+  }
+} catch (e) {
+  warn('Could not check @modelcontextprotocol/sdk override drift: ' + e.message)
+}
+
 // Summary
 console.log('\n' + '━'.repeat(50))
 console.log(`\n${BOLD}📊 Summary${RESET}\n`)


### PR DESCRIPTION
## Summary
- Adds `"."` key to existing `@modelcontextprotocol/sdk` override in root `package.json`, forcing all transitive consumers to resolve `^1.27.1`
- Adds `audit:standards` drift check to ensure override stays in sync with `packages/mcp-server/package.json`
- Unblocks all 10 open Dependabot PRs that fail Docker build with `npm ci: Missing @modelcontextprotocol/sdk@1.27.1`

## Root Cause
When Dependabot regenerates `package-lock.json`, npm deduplicates `@modelcontextprotocol/sdk` to 1.26.0 (satisfying ruflo's `^1.20.1` range) and drops the nested 1.27.1 that mcp-server requires. The `"."` override syntax (documented in `npm help package-json`) forces the SDK version globally while preserving the existing scoped `ajv` override.

## Plan & Review
- SPARC plan: `docs/internal/implementation/dependabot-mcp-sdk-lock-fix.md`
- VP review applied 6 changes (verification consolidation, drift check, shell correctness, ajv verification)

## Test plan
- [x] `npm ls @modelcontextprotocol/sdk` shows 1.27.1 at root, all entries `overridden`
- [x] `npm ls ajv` confirms scoped ajv@8.18.0 under SDK (no ESLint breakage)
- [x] `npm run preflight` passes (ruflo/agentdb compatibility verified)
- [x] Simulated Dependabot: `rm package-lock.json && npm install && npm ci` passes
- [x] `audit:standards` drift check passes
- [ ] CI Docker build passes on this PR
- [ ] After merge, Dependabot PRs pass on rebase

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)