### PR TITLE
fix(deps): use caret range for jose in enterprise to fix Dependabot CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33517,7 +33517,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.980.0",
         "@skillsmith/core": "^0.4.16",
-        "jose": "5.10.0",
+        "jose": "^5.10.0",
         "zod": "4.2.1"
       },
       "devDependencies": {

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.980.0",
     "@skillsmith/core": "^0.4.16",
-    "jose": "5.10.0",
+    "jose": "^5.10.0",
     "zod": "4.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Changes `jose` from exact pin `"5.10.0"` to caret `"^5.10.0"` in `packages/enterprise/package.json`
- Same class of issue as #371 (MCP SDK override): exact pins cause Dependabot lock file regeneration to drop nested resolutions

## Root Cause
Root `jose` is 6.x (vercel dep), enterprise needs 5.x. Exact pin `"5.10.0"` requires a nested copy, but Dependabot's lock regen drops it. Caret range `"^5.10.0"` ensures npm consistently creates the nested 5.x copy since `^5.10.0` is incompatible with root's `6.1.3`.

## Test plan
- [x] `npm ls jose` shows 6.x at root, 5.10.0 nested under enterprise
- [x] Pre-commit checks pass (typecheck, lint, format)
- [ ] CI Docker build passes

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)