### PR TITLE
fix(ci): ensure governance label exists before drift audit issue creation

### DIFF
--- a/.github/workflows/linear-drift-audit.yml
+++ b/.github/workflows/linear-drift-audit.yml
@@ -55,6 +55,13 @@ jobs:
             echo "drift_count=0" >> $GITHUB_OUTPUT
           fi
 
+      - name: Ensure governance label exists
+        if: steps.check.outputs.drift_count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create governance --description "Governance and compliance tracking" --color "d93f0b" 2>/dev/null || true
+
       - name: Create or update governance issue
         if: steps.check.outputs.drift_count != '0'
         env:


### PR DESCRIPTION
## Summary
- The `linear-drift-audit.yml` scheduled workflow fails at "Create or update governance issue" because the `governance` label doesn't exist on the repo
- Adds an idempotent step that creates the label if missing (`gh label create ... 2>/dev/null || true`)

Fixes run: https://github.com/smith-horn/skillsmith/actions/runs/23431637611

[skip-impl-check]

## Test plan
- [ ] Trigger workflow manually: `gh workflow run linear-drift-audit.yml`
- [ ] Verify the run passes the label/issue creation step

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)