### PR TITLE
feat: release automation script for version bumps and changelogs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,14 +303,34 @@ Published as `io.github.smith-horn/skillsmith` on [registry.modelcontextprotocol
 
 ## Publishing Packages
 
-**Preferred method**: `./scripts/publish-packages.sh` — publishes in dependency order with pre-publish tarball verification.
+**Release preparation** (version bump + changelog + commit):
+
+```bash
+docker exec skillsmith-dev-1 npx tsx scripts/prepare-release.ts --all=patch   # bump all
+docker exec skillsmith-dev-1 npx tsx scripts/prepare-release.ts --core=minor --cli=patch  # selective
+docker exec skillsmith-dev-1 npx tsx scripts/prepare-release.ts --dry-run --all=patch  # preview
+```
+
+The script updates all 6 version locations (package.json, VERSION constants, server.json), generates changelog entries, and creates a commit. See `docs/internal/implementation/release-automation.md` for details.
+
+**Publishing — CI workflow** (preferred, avoids local npm auth/OTP issues):
+
+```bash
+git push
+gh workflow run publish.yml -f dry_run=false
+gh run watch <run-id> --exit-status              # Monitor progress
+```
+
+Uses `SKILLSMITH_NPM_TOKEN` secret. Publishes in dependency order (core → mcp-server, cli, enterprise) with validation, smoke tests, and MCP Registry publish. Always try this first.
+
+**Local fallback**: `./scripts/publish-packages.sh` — publishes in dependency order with pre-publish tarball verification. Requires npm auth with 2FA bypass, which is error-prone locally.
 
 **Publish order** (dependencies before consumers):
 
 1. `@skillsmith/core`
 2. `@skillsmith/mcp-server` and `@skillsmith/cli` (both depend on core)
 
-**Pre-publish checklist** (manual publishes):
+**Pre-publish checklist** (manual publishes — only if CI workflow fails):
 
 1. Build in Docker: `docker exec skillsmith-dev-1 npm run build`
 2. Run preflight: `docker exec skillsmith-dev-1 npm run preflight`

--- a/scripts/lib/version-utils.ts
+++ b/scripts/lib/version-utils.ts
@@ -1,0 +1,207 @@
+/**
+ * Version Utilities
+ * Shared types and functions for release automation scripts.
+ */
+
+import { execFileSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+export const ROOT_DIR = join(__dirname, '..', '..')
+
+// --- Types ---
+
+export interface PackageSpec {
+  name: string
+  shortName: string
+  dir: string
+  packageJsonPath: string
+  versionConstFile?: string
+  versionConstPattern?: RegExp
+  versionConstReplacement?: (v: string) => string
+  serverJsonPath?: string
+}
+
+export interface ChangelogEntry {
+  type: string
+  scope?: string
+  message: string
+  hash: string
+  pr?: string
+  breaking: boolean
+}
+
+// --- Package Definitions ---
+
+export const PACKAGE_SPECS: PackageSpec[] = [
+  {
+    name: '@skillsmith/core',
+    shortName: 'core',
+    dir: 'packages/core',
+    packageJsonPath: 'packages/core/package.json',
+    versionConstFile: 'packages/core/src/index.ts',
+    versionConstPattern: /export const VERSION = '[^']+'/,
+    versionConstReplacement: (v: string) => `export const VERSION = '${v}'`,
+  },
+  {
+    name: '@skillsmith/mcp-server',
+    shortName: 'mcp-server',
+    dir: 'packages/mcp-server',
+    packageJsonPath: 'packages/mcp-server/package.json',
+    versionConstFile: 'packages/mcp-server/src/index.ts',
+    versionConstPattern: /const PACKAGE_VERSION = '[^']+'/,
+    versionConstReplacement: (v: string) => `const PACKAGE_VERSION = '${v}'`,
+    serverJsonPath: 'packages/mcp-server/server.json',
+  },
+  {
+    name: '@skillsmith/cli',
+    shortName: 'cli',
+    dir: 'packages/cli',
+    packageJsonPath: 'packages/cli/package.json',
+  },
+]
+
+// Packages that depend on @skillsmith/core (dep gets updated when core bumps)
+export const CORE_DEPENDENTS = [
+  'packages/mcp-server/package.json',
+  'packages/cli/package.json',
+  'packages/enterprise/package.json',
+]
+
+// --- Version Arithmetic ---
+
+export function incrementVersion(current: string, type: 'patch' | 'minor' | 'major'): string {
+  const parts = current.split('.')
+  if (parts.length !== 3) {
+    throw new Error(`Invalid semver: ${current}`)
+  }
+  const [major, minor, patch] = parts.map(Number)
+  if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
+    throw new Error(`Invalid semver: ${current}`)
+  }
+  switch (type) {
+    case 'major':
+      return `${major + 1}.0.0`
+    case 'minor':
+      return `${major}.${minor + 1}.0`
+    case 'patch':
+      return `${major}.${minor}.${patch + 1}`
+  }
+}
+
+export function isValidSemver(version: string): boolean {
+  return /^\d+\.\d+\.\d+$/.test(version)
+}
+
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i]
+  }
+  return 0
+}
+
+// --- File Readers ---
+
+export function readPackageVersion(relPath: string): string {
+  const fullPath = join(ROOT_DIR, relPath)
+  const pkg = JSON.parse(readFileSync(fullPath, 'utf-8'))
+  return pkg.version
+}
+
+export function readVersionConstant(relPath: string, pattern: RegExp): string | null {
+  const fullPath = join(ROOT_DIR, relPath)
+  const content = readFileSync(fullPath, 'utf-8')
+  const match = content.match(pattern)
+  if (!match) return null
+  // Extract version from the matched string (between quotes)
+  const versionMatch = match[0].match(/'([^']+)'/)
+  return versionMatch ? versionMatch[1] : null
+}
+
+// --- Git / Changelog ---
+
+export function parseConventionalCommit(message: string): ChangelogEntry {
+  // Match: type(scope): description (#PR)
+  const conventionalMatch = message.match(
+    /^([a-z]+)(?:\(([^)]+)\))?(!)?:\s*(.+?)(?:\s*\(#(\d+)\))?$/
+  )
+
+  if (conventionalMatch) {
+    return {
+      type: conventionalMatch[1],
+      scope: conventionalMatch[2] || undefined,
+      breaking: conventionalMatch[3] === '!',
+      message: conventionalMatch[4],
+      hash: '',
+      pr: conventionalMatch[5] || undefined,
+    }
+  }
+
+  // Non-conventional: treat as "other"
+  const prMatch = message.match(/\(#(\d+)\)$/)
+  return {
+    type: 'other',
+    message: message.replace(/\s*\(#\d+\)$/, ''),
+    hash: '',
+    breaking: false,
+    pr: prMatch ? prMatch[1] : undefined,
+  }
+}
+
+export function getCommitsSince(since: string, packageDir?: string): ChangelogEntry[] {
+  const args = ['log', '--oneline', '--format=%H|%s', `${since}..HEAD`]
+  if (packageDir) {
+    args.push('--', packageDir)
+  }
+
+  let output: string
+  try {
+    output = execFileSync('git', args, {
+      cwd: ROOT_DIR,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim()
+  } catch {
+    return []
+  }
+
+  if (!output) return []
+
+  return output.split('\n').map((line) => {
+    const [hash, ...messageParts] = line.split('|')
+    const message = messageParts.join('|')
+    const entry = parseConventionalCommit(message)
+    entry.hash = hash.slice(0, 7)
+    return entry
+  })
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  feat: 'Feature',
+  fix: 'Fix',
+  perf: 'Performance',
+  refactor: 'Refactor',
+  docs: 'Docs',
+  test: 'Test',
+  chore: 'Chore',
+  ci: 'CI',
+  other: 'Other',
+}
+
+export function formatChangelogSection(version: string, entries: ChangelogEntry[]): string {
+  // Filter out pure chore/ci/docs commits for changelog
+  const meaningful = entries.filter((e) => !['chore', 'ci', 'docs', 'test'].includes(e.type))
+  const toFormat = meaningful.length > 0 ? meaningful : entries
+
+  const lines: string[] = [`## v${version}`, '']
+  for (const entry of toFormat) {
+    const label = TYPE_LABELS[entry.type] || 'Other'
+    const pr = entry.pr ? ` (#${entry.pr})` : ''
+    lines.push(`- **${label}**: ${entry.message}${pr}`)
+  }
+  return lines.join('\n')
+}

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -1,0 +1,441 @@
+#!/usr/bin/env npx tsx
+/**
+ * Release Preparation Script
+ * Updates all version locations, generates changelog entries, and creates a commit.
+ *
+ * Usage:
+ *   npx tsx scripts/prepare-release.ts --all=patch
+ *   npx tsx scripts/prepare-release.ts --core=minor --cli=patch
+ *   npx tsx scripts/prepare-release.ts --core=0.4.18
+ *   npx tsx scripts/prepare-release.ts --all=patch --dry-run
+ *   npx tsx scripts/prepare-release.ts --all=patch --no-changelog
+ *   npx tsx scripts/prepare-release.ts --all=patch --no-commit
+ */
+
+import { execFileSync } from 'child_process'
+import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { join } from 'path'
+
+import {
+  PACKAGE_SPECS,
+  CORE_DEPENDENTS,
+  ROOT_DIR,
+  incrementVersion,
+  isValidSemver,
+  compareSemver,
+  readPackageVersion,
+  readVersionConstant,
+  getCommitsSince,
+  formatChangelogSection,
+  type PackageSpec,
+} from './lib/version-utils.js'
+
+// --- Types ---
+
+interface BumpPlan {
+  spec: PackageSpec
+  currentVersion: string
+  newVersion: string
+}
+
+interface Options {
+  bumps: Map<string, string>
+  dryRun: boolean
+  noChangelog: boolean
+  noCommit: boolean
+}
+
+// --- Arg Parsing ---
+
+function parseArgs(): Options {
+  const args = process.argv.slice(2)
+  const bumps = new Map<string, string>()
+  let dryRun = false
+  let noChangelog = false
+  let noCommit = false
+
+  for (const arg of args) {
+    if (arg === '--dry-run') {
+      dryRun = true
+    } else if (arg === '--no-changelog') {
+      noChangelog = true
+    } else if (arg === '--no-commit') {
+      noCommit = true
+    } else if (arg.startsWith('--all=')) {
+      const type = arg.split('=')[1]
+      for (const spec of PACKAGE_SPECS) {
+        bumps.set(spec.shortName, type)
+      }
+    } else if (arg.startsWith('--core=')) {
+      bumps.set('core', arg.split('=')[1])
+    } else if (arg.startsWith('--mcp-server=')) {
+      bumps.set('mcp-server', arg.split('=')[1])
+    } else if (arg.startsWith('--cli=')) {
+      bumps.set('cli', arg.split('=')[1])
+    } else if (arg === '--help' || arg === '-h') {
+      printUsage()
+      process.exit(0)
+    } else {
+      console.error(`Unknown argument: ${arg}`)
+      printUsage()
+      process.exit(1)
+    }
+  }
+
+  if (bumps.size === 0) {
+    console.error('Error: No packages specified. Use --all=patch or --core=patch etc.')
+    printUsage()
+    process.exit(1)
+  }
+
+  return { bumps, dryRun, noChangelog, noCommit }
+}
+
+function printUsage(): void {
+  console.log(`
+Usage: npx tsx scripts/prepare-release.ts [options]
+
+Package bumps:
+  --all=<type>          Bump all packages (patch|minor|major)
+  --core=<type|ver>     Bump core (patch|minor|major|X.Y.Z)
+  --mcp-server=<type>   Bump mcp-server
+  --cli=<type|ver>      Bump cli
+
+Options:
+  --dry-run             Preview changes without writing
+  --no-changelog        Skip changelog generation
+  --no-commit           Write files but don't create git commit
+  --help                Show this help
+`)
+}
+
+// --- Version Resolution ---
+
+function resolveVersion(current: string, bumpOrVersion: string): string {
+  if (['patch', 'minor', 'major'].includes(bumpOrVersion)) {
+    return incrementVersion(current, bumpOrVersion as 'patch' | 'minor' | 'major')
+  }
+  if (isValidSemver(bumpOrVersion)) {
+    if (compareSemver(bumpOrVersion, current) <= 0) {
+      throw new Error(`Target version ${bumpOrVersion} must be greater than current ${current}`)
+    }
+    return bumpOrVersion
+  }
+  throw new Error(
+    `Invalid bump type or version: "${bumpOrVersion}". Use patch|minor|major or X.Y.Z`
+  )
+}
+
+// --- Build Bump Plan ---
+
+function buildBumpPlan(bumps: Map<string, string>): BumpPlan[] {
+  const plans: BumpPlan[] = []
+
+  for (const [shortName, bumpType] of bumps) {
+    const spec = PACKAGE_SPECS.find((s) => s.shortName === shortName)
+    if (!spec) {
+      throw new Error(`Unknown package: ${shortName}`)
+    }
+
+    const currentVersion = readPackageVersion(spec.packageJsonPath)
+
+    // Validate version constant is in sync
+    if (spec.versionConstFile && spec.versionConstPattern) {
+      const constVersion = readVersionConstant(spec.versionConstFile, spec.versionConstPattern)
+      if (constVersion && constVersion !== currentVersion) {
+        console.warn(
+          `Warning: ${spec.versionConstFile} has ${constVersion} but package.json has ${currentVersion}`
+        )
+      }
+    }
+
+    const newVersion = resolveVersion(currentVersion, bumpType)
+    plans.push({ spec, currentVersion, newVersion })
+  }
+
+  return plans
+}
+
+// --- File Writers ---
+
+function updatePackageJson(relPath: string, newVersion: string): void {
+  const fullPath = join(ROOT_DIR, relPath)
+  const pkg = JSON.parse(readFileSync(fullPath, 'utf-8'))
+  pkg.version = newVersion
+  writeFileSync(fullPath, JSON.stringify(pkg, null, 2) + '\n')
+}
+
+function updateVersionConstant(spec: PackageSpec, newVersion: string): void {
+  if (!spec.versionConstFile || !spec.versionConstPattern || !spec.versionConstReplacement) {
+    return
+  }
+  const fullPath = join(ROOT_DIR, spec.versionConstFile)
+  let content = readFileSync(fullPath, 'utf-8')
+  content = content.replace(spec.versionConstPattern, spec.versionConstReplacement(newVersion))
+  writeFileSync(fullPath, content)
+}
+
+function updateServerJson(relPath: string, newVersion: string): void {
+  const fullPath = join(ROOT_DIR, relPath)
+  const server = JSON.parse(readFileSync(fullPath, 'utf-8'))
+  server.version = newVersion
+  if (server.packages?.[0]) {
+    server.packages[0].version = newVersion
+  }
+  writeFileSync(fullPath, JSON.stringify(server, null, 2) + '\n')
+}
+
+function updateCoreDependency(newCoreVersion: string): void {
+  for (const relPath of CORE_DEPENDENTS) {
+    const fullPath = join(ROOT_DIR, relPath)
+    if (!existsSync(fullPath)) continue
+    const pkg = JSON.parse(readFileSync(fullPath, 'utf-8'))
+    if (pkg.dependencies?.['@skillsmith/core']) {
+      pkg.dependencies['@skillsmith/core'] = `^${newCoreVersion}`
+      writeFileSync(fullPath, JSON.stringify(pkg, null, 2) + '\n')
+    }
+  }
+}
+
+// --- Changelog ---
+
+function findLastVersionBumpCommit(): string {
+  try {
+    const output = execFileSync('git', ['log', '--oneline', '--format=%H %s', '-50'], {
+      cwd: ROOT_DIR,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim()
+
+    for (const line of output.split('\n')) {
+      const [hash, ...rest] = line.split(' ')
+      const msg = rest.join(' ')
+      if (
+        msg.startsWith('chore(release):') ||
+        msg.startsWith('chore: bump version') ||
+        /^chore:.*bump.*\d+\.\d+\.\d+/.test(msg)
+      ) {
+        return hash
+      }
+    }
+    return 'HEAD~20'
+  } catch {
+    return 'HEAD~20'
+  }
+}
+
+function prependToChangelog(relPath: string, section: string): void {
+  const fullPath = join(ROOT_DIR, relPath)
+  let content: string
+  if (existsSync(fullPath)) {
+    content = readFileSync(fullPath, 'utf-8')
+  } else {
+    content = `# Changelog\n\nAll notable changes to this package are documented here.\n`
+  }
+
+  // Insert after the header (first line starting with #)
+  const headerEnd = content.indexOf('\n## ')
+  if (headerEnd !== -1) {
+    content = content.slice(0, headerEnd) + '\n' + section + '\n' + content.slice(headerEnd)
+  } else {
+    content = content.trimEnd() + '\n\n' + section + '\n'
+  }
+
+  writeFileSync(fullPath, content)
+}
+
+// --- Validation ---
+
+function validatePostWrite(plans: BumpPlan[]): string[] {
+  const errors: string[] = []
+  for (const plan of plans) {
+    const { spec, newVersion } = plan
+    const actual = readPackageVersion(spec.packageJsonPath)
+    if (actual !== newVersion) {
+      errors.push(`${spec.name}: package.json has ${actual}, expected ${newVersion}`)
+    }
+    if (spec.versionConstFile && spec.versionConstPattern) {
+      const constVer = readVersionConstant(spec.versionConstFile, spec.versionConstPattern)
+      if (constVer !== newVersion) {
+        errors.push(`${spec.name}: version constant has ${constVer}, expected ${newVersion}`)
+      }
+    }
+    if (spec.serverJsonPath) {
+      const fullPath = join(ROOT_DIR, spec.serverJsonPath)
+      const server = JSON.parse(readFileSync(fullPath, 'utf-8'))
+      if (server.version !== newVersion) {
+        errors.push(
+          `${spec.name}: server.json version has ${server.version}, expected ${newVersion}`
+        )
+      }
+      if (server.packages?.[0]?.version !== newVersion) {
+        errors.push(
+          `${spec.name}: server.json packages[0].version has ${server.packages?.[0]?.version}, expected ${newVersion}`
+        )
+      }
+    }
+  }
+  return errors
+}
+
+// --- Git ---
+
+function getCurrentBranch(): string {
+  return execFileSync('git', ['branch', '--show-current'], {
+    cwd: ROOT_DIR,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function createCommit(plans: BumpPlan[]): void {
+  const filesToAdd: string[] = []
+
+  for (const plan of plans) {
+    filesToAdd.push(plan.spec.packageJsonPath)
+    if (plan.spec.versionConstFile) filesToAdd.push(plan.spec.versionConstFile)
+    if (plan.spec.serverJsonPath) filesToAdd.push(plan.spec.serverJsonPath)
+    filesToAdd.push(join(plan.spec.dir, 'CHANGELOG.md'))
+  }
+
+  // Add core dependent package.jsons if core was bumped
+  if (plans.some((p) => p.spec.shortName === 'core')) {
+    for (const dep of CORE_DEPENDENTS) {
+      if (existsSync(join(ROOT_DIR, dep))) {
+        filesToAdd.push(dep)
+      }
+    }
+  }
+
+  const existing = filesToAdd.filter((f) => existsSync(join(ROOT_DIR, f)))
+  execFileSync('git', ['add', ...existing], {
+    cwd: ROOT_DIR,
+    stdio: 'inherit',
+  })
+
+  const parts = plans.map((p) => `${p.spec.shortName} ${p.newVersion}`)
+  const message = `chore(release): bump ${parts.join(', ')}`
+
+  execFileSync('git', ['commit', '-m', message], {
+    cwd: ROOT_DIR,
+    stdio: 'inherit',
+  })
+}
+
+// --- Main ---
+
+function main(): void {
+  const options = parseArgs()
+  const { bumps, dryRun, noChangelog, noCommit } = options
+
+  // Step 0: Branch guard
+  const branch = getCurrentBranch()
+  if (branch === 'main') {
+    console.error('Error: Cannot prepare release on main. Create a branch first.')
+    process.exit(1)
+  }
+  console.log(`Branch: ${branch}`)
+
+  // Step 1-3: Build and display plan
+  const plans = buildBumpPlan(bumps)
+
+  const nothingToDo = plans.every((p) => p.currentVersion === p.newVersion)
+  if (nothingToDo) {
+    console.log('Nothing to do — all versions are already at target.')
+    process.exit(0)
+  }
+
+  console.log('\n  Package               Current   →  New')
+  console.log('  ─────────────────────────────────────────')
+  for (const plan of plans) {
+    const name = plan.spec.shortName.padEnd(20)
+    console.log(`  ${name}  ${plan.currentVersion.padEnd(9)} →  ${plan.newVersion}`)
+  }
+  console.log()
+
+  // Step 4: Dry run exit
+  if (dryRun) {
+    console.log('[DRY RUN] No files modified.')
+    process.exit(0)
+  }
+
+  // Step 5: Write all version locations
+  for (const plan of plans) {
+    updatePackageJson(plan.spec.packageJsonPath, plan.newVersion)
+    updateVersionConstant(plan.spec, plan.newVersion)
+    if (plan.spec.serverJsonPath) {
+      updateServerJson(plan.spec.serverJsonPath, plan.newVersion)
+    }
+    console.log(`  ✓ ${plan.spec.name}@${plan.newVersion}`)
+  }
+
+  // Step 6: Update @skillsmith/core dep in dependents
+  const corePlan = plans.find((p) => p.spec.shortName === 'core')
+  if (corePlan) {
+    updateCoreDependency(corePlan.newVersion)
+    console.log(`  ✓ Updated @skillsmith/core dep in dependents`)
+  }
+
+  // Step 7-8: Generate and prepend changelogs
+  if (!noChangelog) {
+    const since = findLastVersionBumpCommit()
+    for (const plan of plans) {
+      const entries = getCommitsSince(since, plan.spec.dir)
+      if (entries.length > 0) {
+        const section = formatChangelogSection(plan.newVersion, entries)
+        prependToChangelog(join(plan.spec.dir, 'CHANGELOG.md'), section)
+        console.log(`  ✓ Changelog: ${plan.spec.shortName} (${entries.length} entries)`)
+      } else {
+        // Create minimal entry
+        const section = `## v${plan.newVersion}\n\n- Version bump`
+        prependToChangelog(join(plan.spec.dir, 'CHANGELOG.md'), section)
+        console.log(`  ✓ Changelog: ${plan.spec.shortName} (version bump only)`)
+      }
+    }
+  }
+
+  // Step 9: Post-write validation
+  const errors = validatePostWrite(plans)
+  if (errors.length > 0) {
+    console.error('\n  ✗ Post-write validation failed:')
+    for (const err of errors) {
+      console.error(`    - ${err}`)
+    }
+    process.exit(1)
+  }
+  console.log('  ✓ Version sync validation passed')
+
+  // Step 10: No-commit exit with warning
+  if (noCommit) {
+    console.log('\n  ⚠ WARNING: Files modified but NOT committed.')
+    console.log('  Modified files:')
+    for (const plan of plans) {
+      console.log(`    - ${plan.spec.packageJsonPath}`)
+      if (plan.spec.versionConstFile) console.log(`    - ${plan.spec.versionConstFile}`)
+      if (plan.spec.serverJsonPath) console.log(`    - ${plan.spec.serverJsonPath}`)
+      console.log(`    - ${plan.spec.dir}/CHANGELOG.md`)
+    }
+    console.log('\n  Run `git add` and `git commit` when ready.')
+    process.exit(0)
+  }
+
+  // Step 11: Commit
+  const preBranch = getCurrentBranch()
+  createCommit(plans)
+
+  // Step 12: Post-commit branch verification
+  const postBranch = getCurrentBranch()
+  if (postBranch !== preBranch) {
+    console.error(`\n  ✗ Branch switched during commit: ${preBranch} → ${postBranch}`)
+    console.error(`  Recovery: git checkout ${preBranch} && git cherry-pick HEAD`)
+    process.exit(1)
+  }
+
+  const parts = plans.map((p) => `${p.spec.shortName}@${p.newVersion}`)
+  console.log(`\n  ✓ Committed: ${parts.join(', ')}`)
+  console.log('\n  Next steps:')
+  console.log('    git push')
+  console.log('    gh workflow run publish.yml -f dry_run=false')
+}
+
+main()

--- a/scripts/tests/prepare-release.test.ts
+++ b/scripts/tests/prepare-release.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for prepare-release script logic
+ * Tests pure functions only; does not execute the script end-to-end.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+
+import {
+  PACKAGE_SPECS,
+  CORE_DEPENDENTS,
+  ROOT_DIR,
+  readPackageVersion,
+  readVersionConstant,
+  isValidSemver,
+  incrementVersion,
+  compareSemver,
+} from '../lib/version-utils'
+
+describe('PACKAGE_SPECS configuration', () => {
+  it('should define all three packages', () => {
+    const names = PACKAGE_SPECS.map((s) => s.shortName)
+    expect(names).toContain('core')
+    expect(names).toContain('mcp-server')
+    expect(names).toContain('cli')
+    expect(PACKAGE_SPECS).toHaveLength(3)
+  })
+
+  it('should point to existing package.json files', () => {
+    for (const spec of PACKAGE_SPECS) {
+      const fullPath = join(ROOT_DIR, spec.packageJsonPath)
+      expect(existsSync(fullPath), `${spec.packageJsonPath} should exist`).toBe(true)
+    }
+  })
+
+  it('should point to existing version constant files', () => {
+    for (const spec of PACKAGE_SPECS) {
+      if (spec.versionConstFile) {
+        const fullPath = join(ROOT_DIR, spec.versionConstFile)
+        expect(existsSync(fullPath), `${spec.versionConstFile} should exist`).toBe(true)
+      }
+    }
+  })
+
+  it('should have version constant patterns that match the files', () => {
+    for (const spec of PACKAGE_SPECS) {
+      if (spec.versionConstFile && spec.versionConstPattern) {
+        const version = readVersionConstant(spec.versionConstFile, spec.versionConstPattern)
+        expect(version, `${spec.versionConstFile} should have a version constant`).toBeTruthy()
+        expect(isValidSemver(version!)).toBe(true)
+      }
+    }
+  })
+
+  it('should have server.json only for mcp-server', () => {
+    const mcpServer = PACKAGE_SPECS.find((s) => s.shortName === 'mcp-server')
+    const others = PACKAGE_SPECS.filter((s) => s.shortName !== 'mcp-server')
+    expect(mcpServer?.serverJsonPath).toBeDefined()
+    for (const spec of others) {
+      expect(spec.serverJsonPath).toBeUndefined()
+    }
+  })
+})
+
+describe('CORE_DEPENDENTS configuration', () => {
+  it('should include mcp-server, cli, and enterprise', () => {
+    expect(CORE_DEPENDENTS).toContain('packages/mcp-server/package.json')
+    expect(CORE_DEPENDENTS).toContain('packages/cli/package.json')
+    expect(CORE_DEPENDENTS).toContain('packages/enterprise/package.json')
+  })
+})
+
+describe('Version sync validation (current repo state)', () => {
+  it('should have matching versions in package.json and version constants', () => {
+    for (const spec of PACKAGE_SPECS) {
+      const pkgVersion = readPackageVersion(spec.packageJsonPath)
+
+      if (spec.versionConstFile && spec.versionConstPattern) {
+        const constVersion = readVersionConstant(spec.versionConstFile, spec.versionConstPattern)
+        expect(constVersion).toBe(
+          pkgVersion,
+          `${spec.name}: index.ts version should match package.json`
+        )
+      }
+    }
+  })
+
+  it('should have matching versions in server.json', () => {
+    const mcpServer = PACKAGE_SPECS.find((s) => s.shortName === 'mcp-server')!
+    const pkgVersion = readPackageVersion(mcpServer.packageJsonPath)
+    const serverJson = JSON.parse(readFileSync(join(ROOT_DIR, mcpServer.serverJsonPath!), 'utf-8'))
+
+    expect(serverJson.version).toBe(pkgVersion)
+    expect(serverJson.packages[0].version).toBe(pkgVersion)
+  })
+})
+
+describe('resolveVersion logic', () => {
+  it('should resolve bump types correctly', () => {
+    expect(incrementVersion('0.4.17', 'patch')).toBe('0.4.18')
+    expect(incrementVersion('0.4.17', 'minor')).toBe('0.5.0')
+    expect(incrementVersion('0.4.17', 'major')).toBe('1.0.0')
+  })
+
+  it('should validate explicit versions are greater than current', () => {
+    expect(compareSemver('0.4.18', '0.4.17')).toBeGreaterThan(0)
+    expect(compareSemver('0.4.17', '0.4.17')).toBe(0)
+    expect(compareSemver('0.4.16', '0.4.17')).toBeLessThan(0)
+  })
+})

--- a/scripts/tests/version-utils.test.ts
+++ b/scripts/tests/version-utils.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for version-utils shared library
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  incrementVersion,
+  isValidSemver,
+  compareSemver,
+  parseConventionalCommit,
+  formatChangelogSection,
+} from '../lib/version-utils'
+
+describe('incrementVersion', () => {
+  it('should increment patch version', () => {
+    expect(incrementVersion('1.2.3', 'patch')).toBe('1.2.4')
+    expect(incrementVersion('0.0.0', 'patch')).toBe('0.0.1')
+    expect(incrementVersion('0.4.17', 'patch')).toBe('0.4.18')
+  })
+
+  it('should increment minor version and reset patch', () => {
+    expect(incrementVersion('1.2.3', 'minor')).toBe('1.3.0')
+    expect(incrementVersion('0.4.17', 'minor')).toBe('0.5.0')
+  })
+
+  it('should increment major version and reset minor/patch', () => {
+    expect(incrementVersion('1.2.3', 'major')).toBe('2.0.0')
+    expect(incrementVersion('0.4.17', 'major')).toBe('1.0.0')
+  })
+
+  it('should throw on invalid semver', () => {
+    expect(() => incrementVersion('1.2', 'patch')).toThrow('Invalid semver')
+    expect(() => incrementVersion('abc', 'patch')).toThrow('Invalid semver')
+    expect(() => incrementVersion('1.2.3.4', 'patch')).toThrow('Invalid semver')
+    expect(() => incrementVersion('1.a.3', 'patch')).toThrow('Invalid semver')
+  })
+})
+
+describe('isValidSemver', () => {
+  it('should accept valid semver strings', () => {
+    expect(isValidSemver('0.0.0')).toBe(true)
+    expect(isValidSemver('1.2.3')).toBe(true)
+    expect(isValidSemver('10.20.30')).toBe(true)
+  })
+
+  it('should reject invalid semver strings', () => {
+    expect(isValidSemver('1.2')).toBe(false)
+    expect(isValidSemver('abc')).toBe(false)
+    expect(isValidSemver('1.2.3-beta')).toBe(false)
+    expect(isValidSemver('v1.2.3')).toBe(false)
+    expect(isValidSemver('')).toBe(false)
+  })
+})
+
+describe('compareSemver', () => {
+  it('should return 0 for equal versions', () => {
+    expect(compareSemver('1.2.3', '1.2.3')).toBe(0)
+  })
+
+  it('should return positive when a > b', () => {
+    expect(compareSemver('1.2.4', '1.2.3')).toBeGreaterThan(0)
+    expect(compareSemver('1.3.0', '1.2.9')).toBeGreaterThan(0)
+    expect(compareSemver('2.0.0', '1.9.9')).toBeGreaterThan(0)
+  })
+
+  it('should return negative when a < b', () => {
+    expect(compareSemver('1.2.3', '1.2.4')).toBeLessThan(0)
+    expect(compareSemver('0.4.17', '0.5.0')).toBeLessThan(0)
+  })
+})
+
+describe('parseConventionalCommit', () => {
+  it('should parse feat commits', () => {
+    const result = parseConventionalCommit('feat: add new feature')
+    expect(result.type).toBe('feat')
+    expect(result.message).toBe('add new feature')
+    expect(result.breaking).toBe(false)
+  })
+
+  it('should parse scoped commits', () => {
+    const result = parseConventionalCommit('fix(core): resolve db issue')
+    expect(result.type).toBe('fix')
+    expect(result.scope).toBe('core')
+    expect(result.message).toBe('resolve db issue')
+  })
+
+  it('should parse PR numbers', () => {
+    const result = parseConventionalCommit('feat: add feature (#123)')
+    expect(result.type).toBe('feat')
+    expect(result.message).toBe('add feature')
+    expect(result.pr).toBe('123')
+  })
+
+  it('should parse breaking changes', () => {
+    const result = parseConventionalCommit('feat!: breaking change')
+    expect(result.type).toBe('feat')
+    expect(result.breaking).toBe(true)
+    expect(result.message).toBe('breaking change')
+  })
+
+  it('should parse scoped breaking changes with PR', () => {
+    const result = parseConventionalCommit('fix(api)!: remove deprecated endpoint (#456)')
+    expect(result.type).toBe('fix')
+    expect(result.scope).toBe('api')
+    expect(result.breaking).toBe(true)
+    expect(result.message).toBe('remove deprecated endpoint')
+    expect(result.pr).toBe('456')
+  })
+
+  it('should handle non-conventional commits as other', () => {
+    const result = parseConventionalCommit('bump version to 1.0.0')
+    expect(result.type).toBe('other')
+    expect(result.message).toBe('bump version to 1.0.0')
+  })
+
+  it('should extract PR from non-conventional commits', () => {
+    const result = parseConventionalCommit('update readme (#789)')
+    expect(result.type).toBe('other')
+    expect(result.pr).toBe('789')
+    expect(result.message).toBe('update readme')
+  })
+})
+
+describe('formatChangelogSection', () => {
+  it('should format entries grouped by type', () => {
+    const entries = [
+      { type: 'feat', message: 'add search', hash: 'abc1234', breaking: false },
+      { type: 'fix', message: 'fix crash', hash: 'def5678', breaking: false, pr: '42' },
+    ]
+    const result = formatChangelogSection('1.0.0', entries)
+    expect(result).toContain('## v1.0.0')
+    expect(result).toContain('**Feature**: add search')
+    expect(result).toContain('**Fix**: fix crash (#42)')
+  })
+
+  it('should filter out chore/ci/docs when meaningful entries exist', () => {
+    const entries = [
+      { type: 'feat', message: 'add feature', hash: 'a', breaking: false },
+      { type: 'chore', message: 'bump deps', hash: 'b', breaking: false },
+      { type: 'ci', message: 'fix pipeline', hash: 'c', breaking: false },
+    ]
+    const result = formatChangelogSection('1.0.0', entries)
+    expect(result).toContain('**Feature**: add feature')
+    expect(result).not.toContain('bump deps')
+    expect(result).not.toContain('fix pipeline')
+  })
+
+  it('should include chore entries when no meaningful entries exist', () => {
+    const entries = [{ type: 'chore', message: 'bump deps', hash: 'a', breaking: false }]
+    const result = formatChangelogSection('1.0.0', entries)
+    expect(result).toContain('**Chore**: bump deps')
+  })
+})

--- a/scripts/validate-versions.ts
+++ b/scripts/validate-versions.ts
@@ -147,6 +147,63 @@ function printReport(report: ValidationReport, jsonOutput: boolean): void {
   }
 }
 
+/**
+ * Validates all 6 version locations are in sync.
+ * Does NOT modify the existing validateVersions() contract.
+ */
+export function validateAllVersionLocations(): ValidationReport {
+  const results: ValidationResult[] = []
+  const errors: string[] = []
+
+  // Run existing server.json checks
+  const serverReport = validateVersions()
+  results.push(...serverReport.results)
+  errors.push(...serverReport.errors)
+
+  // Check core VERSION constant
+  const coreIndexPath = join(ROOT_DIR, 'packages/core/src/index.ts')
+  const corePkgPath = join(ROOT_DIR, 'packages/core/package.json')
+  if (existsSync(coreIndexPath) && existsSync(corePkgPath)) {
+    const corePkgVersion = JSON.parse(readFileSync(corePkgPath, 'utf-8')).version
+    const coreContent = readFileSync(coreIndexPath, 'utf-8')
+    const match = coreContent.match(/export const VERSION = '([^']+)'/)
+    const coreConstVersion = match ? match[1] : null
+
+    if (coreConstVersion && coreConstVersion !== corePkgVersion) {
+      errors.push(
+        `@skillsmith/core: index.ts VERSION (${coreConstVersion}) != package.json (${corePkgVersion})`
+      )
+    }
+    results.push({
+      package: '@skillsmith/core',
+      packageJsonVersion: corePkgVersion,
+      match: coreConstVersion === corePkgVersion,
+      error:
+        coreConstVersion !== corePkgVersion
+          ? `index.ts VERSION (${coreConstVersion}) != package.json (${corePkgVersion})`
+          : undefined,
+    })
+  }
+
+  // Check mcp-server PACKAGE_VERSION constant
+  const mcpIndexPath = join(ROOT_DIR, 'packages/mcp-server/src/index.ts')
+  const mcpPkgPath = join(ROOT_DIR, 'packages/mcp-server/package.json')
+  if (existsSync(mcpIndexPath) && existsSync(mcpPkgPath)) {
+    const mcpPkgVersion = JSON.parse(readFileSync(mcpPkgPath, 'utf-8')).version
+    const mcpContent = readFileSync(mcpIndexPath, 'utf-8')
+    const match = mcpContent.match(/const PACKAGE_VERSION = '([^']+)'/)
+    const mcpConstVersion = match ? match[1] : null
+
+    if (mcpConstVersion && mcpConstVersion !== mcpPkgVersion) {
+      errors.push(
+        `@skillsmith/mcp-server: index.ts PACKAGE_VERSION (${mcpConstVersion}) != package.json (${mcpPkgVersion})`
+      )
+    }
+  }
+
+  return { results, passed: errors.length === 0, errors }
+}
+
 // CLI entry point
 if (process.argv[1]?.includes('validate-versions')) {
   const jsonOutput = process.argv.includes('--json')


### PR DESCRIPTION
## Summary
- New `scripts/prepare-release.ts` — single command to bump all 6 version locations, generate changelogs, and commit
- New `scripts/lib/version-utils.ts` — shared semver arithmetic, conventional commit parsing, changelog formatting
- Extended `scripts/validate-versions.ts` with `validateAllVersionLocations()` (existing function unchanged)
- 29 tests across `scripts/tests/version-utils.test.ts` and `scripts/tests/prepare-release.test.ts`
- Updated CLAUDE.md Publishing section with release prep commands and CI workflow as preferred publish method

## Usage
```bash
docker exec skillsmith-dev-1 npx tsx scripts/prepare-release.ts --all=patch   # bump all
docker exec skillsmith-dev-1 npx tsx scripts/prepare-release.ts --dry-run --all=patch  # preview
git push && gh workflow run publish.yml -f dry_run=false  # publish via CI
```

## Problem
Each release required manual edits to 6 files (3 package.json, 2 version constants, 1 server.json), manually written changelogs, and error-prone local npm auth. This session alone burned significant time on OTP/token issues that the CI workflow avoids.

## Plan
`docs/internal/implementation/release-automation.md` — reviewed by VP Product, VP Engineering, VP Design.

## Follow-up
- SMI-3605: Backfill 11 missing CHANGELOG entries (separate PR)
- PR #375: publish-core `always()` fix (pending GitHub merge API recovery)

## Test plan
- [x] 29 unit tests pass (version arithmetic, conventional commit parsing, repo state validation)
- [x] `--dry-run` shows correct current→new version table
- [x] Full test suite: 263 files, 6733 tests pass
- [x] Typecheck clean, lint clean, prettier clean
- [ ] End-to-end: use script for next actual release

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)