### PR TITLE
fix(ci): add git-crypt unlock to publish.yml (SMI-3606)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -218,6 +218,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # SMI-3606: Decrypt enterprise source + supabase functions for Docker build context
+      - name: Unlock git-crypt
+        if: ${{ env.GIT_CRYPT_KEY != '' }}
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y git-crypt
+          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          git-crypt unlock /tmp/git-crypt-key
+          rm -f /tmp/git-crypt-key
+          echo "✓ git-crypt unlocked successfully"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -271,6 +283,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # SMI-3606: Decrypt enterprise source for build/test/typecheck/lint
+      - name: Unlock git-crypt
+        if: ${{ env.GIT_CRYPT_KEY != '' }}
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y git-crypt
+          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          git-crypt unlock /tmp/git-crypt-key
+          rm -f /tmp/git-crypt-key
+          echo "✓ git-crypt unlocked successfully"
 
       - name: Download Docker image
         uses: actions/download-artifact@v8
@@ -369,14 +393,24 @@ jobs:
     timeout-minutes: 15
     needs: [pre-publish-check, validate]
     if: |
-      always() &&
-      needs.pre-publish-check.result == 'success' &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.core-exists != 'true'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # SMI-3606: Decrypt for workspace build resolution
+      - name: Unlock git-crypt
+        if: ${{ env.GIT_CRYPT_KEY != '' }}
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y git-crypt
+          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          git-crypt unlock /tmp/git-crypt-key
+          rm -f /tmp/git-crypt-key
+          echo "✓ git-crypt unlocked successfully"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -419,7 +453,6 @@ jobs:
     timeout-minutes: 15
     needs: [pre-publish-check, validate, publish-core]
     if: |
-      always() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.mcp-exists != 'true' &&
       (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')
@@ -427,6 +460,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # SMI-3606: Decrypt for workspace build resolution
+      - name: Unlock git-crypt
+        if: ${{ env.GIT_CRYPT_KEY != '' }}
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y git-crypt
+          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          git-crypt unlock /tmp/git-crypt-key
+          rm -f /tmp/git-crypt-key
+          echo "✓ git-crypt unlocked successfully"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -484,7 +529,6 @@ jobs:
     timeout-minutes: 15
     needs: [pre-publish-check, validate, publish-core]
     if: |
-      always() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.cli-exists != 'true' &&
       (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')
@@ -492,6 +536,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # SMI-3606: Decrypt for workspace build resolution
+      - name: Unlock git-crypt
+        if: ${{ env.GIT_CRYPT_KEY != '' }}
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y git-crypt
+          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          git-crypt unlock /tmp/git-crypt-key
+          rm -f /tmp/git-crypt-key
+          echo "✓ git-crypt unlocked successfully"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -535,7 +591,6 @@ jobs:
     timeout-minutes: 15
     needs: [pre-publish-check, validate, publish-core]
     if: |
-      always() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.enterprise-exists != 'true' &&
       (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')
@@ -543,6 +598,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # SMI-3606: Decrypt enterprise source for build + publish
+      - name: Unlock git-crypt
+        if: ${{ env.GIT_CRYPT_KEY != '' }}
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y git-crypt
+          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          git-crypt unlock /tmp/git-crypt-key
+          rm -f /tmp/git-crypt-key
+          echo "✓ git-crypt unlocked successfully"
 
       - name: Setup Node.js for GitHub Packages
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- Add git-crypt unlock step to 6 jobs in `publish.yml`: docker-build, validate, publish-core, publish-mcp-server, publish-cli, publish-enterprise
- Remove `always()` workaround from 4 publish jobs — validate now passes with decrypted enterprise source
- Uses `$GIT_CRYPT_KEY` env var form (matching all 9 ci.yml instances)

[skip-impl-check]

## Problem
The `validate` job always fails because enterprise source is git-crypt encrypted. The `GIT_CRYPT_KEY` secret has existed since Feb 2026 and is used in 9 ci.yml jobs, but was never added to publish.yml. PR #375 added `always()` workarounds so publishing could bypass validation — this meant **no validation ever ran** during publishes.

## What changes
- 6 unlock steps added (identical pattern to ci.yml)
- `always()` removed from publish-core, publish-mcp-server, publish-cli, publish-enterprise
- `always()` retained on smoke-test and publish-summary (correct — they should report regardless)
- pre-publish-check and smoke-test excluded from unlock (don't need source access)

## Plan
`docs/internal/implementation/smi-3606-git-crypt-publish-yml.md` — SPARC researched, VP reviewed.

## Test plan
- [ ] `gh workflow run publish.yml -f dry_run=false` — validate job passes
- [ ] All publish jobs succeed (skipped if versions already published)
- [ ] Check logs for `✓ git-crypt unlocked successfully` in each job
- [ ] No `always()` on publish jobs

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)