### PR TITLE
fix(ci): normalize git-crypt secret reference in publish.yml (SMI-3621)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -224,9 +224,13 @@ jobs:
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
         run: |
+          # Install git-crypt
           sudo apt-get update && sudo apt-get install -y git-crypt
-          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          # Decode and write key file
+          echo "${{ secrets.GIT_CRYPT_KEY }}" | base64 -d > /tmp/git-crypt-key
+          # Unlock repository
           git-crypt unlock /tmp/git-crypt-key
+          # Clean up key file
           rm -f /tmp/git-crypt-key
           echo "✓ git-crypt unlocked successfully"
 
@@ -290,9 +294,13 @@ jobs:
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
         run: |
+          # Install git-crypt
           sudo apt-get update && sudo apt-get install -y git-crypt
-          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          # Decode and write key file
+          echo "${{ secrets.GIT_CRYPT_KEY }}" | base64 -d > /tmp/git-crypt-key
+          # Unlock repository
           git-crypt unlock /tmp/git-crypt-key
+          # Clean up key file
           rm -f /tmp/git-crypt-key
           echo "✓ git-crypt unlocked successfully"
 
@@ -406,9 +414,13 @@ jobs:
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
         run: |
+          # Install git-crypt
           sudo apt-get update && sudo apt-get install -y git-crypt
-          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          # Decode and write key file
+          echo "${{ secrets.GIT_CRYPT_KEY }}" | base64 -d > /tmp/git-crypt-key
+          # Unlock repository
           git-crypt unlock /tmp/git-crypt-key
+          # Clean up key file
           rm -f /tmp/git-crypt-key
           echo "✓ git-crypt unlocked successfully"
 
@@ -467,9 +479,13 @@ jobs:
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
         run: |
+          # Install git-crypt
           sudo apt-get update && sudo apt-get install -y git-crypt
-          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          # Decode and write key file
+          echo "${{ secrets.GIT_CRYPT_KEY }}" | base64 -d > /tmp/git-crypt-key
+          # Unlock repository
           git-crypt unlock /tmp/git-crypt-key
+          # Clean up key file
           rm -f /tmp/git-crypt-key
           echo "✓ git-crypt unlocked successfully"
 
@@ -543,9 +559,13 @@ jobs:
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
         run: |
+          # Install git-crypt
           sudo apt-get update && sudo apt-get install -y git-crypt
-          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          # Decode and write key file
+          echo "${{ secrets.GIT_CRYPT_KEY }}" | base64 -d > /tmp/git-crypt-key
+          # Unlock repository
           git-crypt unlock /tmp/git-crypt-key
+          # Clean up key file
           rm -f /tmp/git-crypt-key
           echo "✓ git-crypt unlocked successfully"
 
@@ -605,9 +625,13 @@ jobs:
         env:
           GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
         run: |
+          # Install git-crypt
           sudo apt-get update && sudo apt-get install -y git-crypt
-          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          # Decode and write key file
+          echo "${{ secrets.GIT_CRYPT_KEY }}" | base64 -d > /tmp/git-crypt-key
+          # Unlock repository
           git-crypt unlock /tmp/git-crypt-key
+          # Clean up key file
           rm -f /tmp/git-crypt-key
           echo "✓ git-crypt unlocked successfully"
 


### PR DESCRIPTION
## Summary

- Change 6 `echo` lines in `publish.yml` from env var form (`$GIT_CRYPT_KEY`) to direct secret reference (`${{ secrets.GIT_CRYPT_KEY }}`) matching `ci.yml` and `e2e-tests.yml`
- Add inline comments (`# Install git-crypt`, `# Decode and write key file`, etc.) matching `ci.yml` pattern
- No functional change — workflow behavior is identical

[skip-impl-check]

## Context

Found during code review of PR #378 (SMI-3606). The inconsistency made grep-based security audits unreliable — `grep 'secrets.GIT_CRYPT_KEY'` found 14 of 20 usages, missing the 6 in `publish.yml`.

## Test plan

- [x] `grep -c 'echo "\$GIT_CRYPT_KEY"' .github/workflows/publish.yml` → 0 (old pattern gone)
- [x] `grep -c 'secrets.GIT_CRYPT_KEY' .github/workflows/publish.yml` → 12 (6 env + 6 echo)
- [x] No functional change — same secret, same base64 decode, same unlock

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)