### PR TITLE
fix(ci): rollback BuildKit cache mode=max and fix picomatch vuln (SMI-3547)

### DIFF
--- a/.claude/development/ci-reference.md
+++ b/.claude/development/ci-reference.md
@@ -164,7 +164,7 @@ Three workflows build Docker images with BuildKit GHA cache. All Docker build jo
 
 | Workflow | Scope | Mode | Timeout | Purpose |
 |----------|-------|------|---------|---------|
-| `ci.yml` | `scope=ci` | `mode=max` | 20 min | PR and push CI |
+| `ci.yml` | `scope=ci` | `mode=min` | 20 min | PR and push CI |
 | `e2e-tests.yml` | `scope=e2e` | `mode=min` | 20 min | End-to-end tests |
 | `publish.yml` | `scope=publish` | `mode=min` | 20 min | npm publish |
 
@@ -180,9 +180,7 @@ E2E and publish workflows only use mechanism 2 (no `actions/cache` tarball layer
 **Key decisions**:
 
 - `scope=` isolates each workflow's cache entries. Without scope, workflows evict each other's entries when the 10 GB GHA cache cap is reached.
-- CI uses `mode=max` to cache all intermediate layers (apt-get, base setup). When mechanism 1 misses on a lockfile change, mechanism 2 reuses cached base layers (~2 min savings vs. full rebuild). CI is the most frequent workflow, so it benefits most from intermediate caching.
-- E2E and publish use `mode=min` (final image only) since they run less frequently and the storage tradeoff isn't justified.
-- **Rollback condition**: If CI scope cache exceeds ~4 GB and evicts e2e/publish scope caches within 72h, revert CI to `mode=min`.
+- All workflows use `mode=min` (final image layers only). `mode=max` was trialed for CI in PR #344 (SMI-3539) but rolled back in SMI-3547 after 72h verification showed cache pressure (10.45 GB, publish scope evicted). The marginal benefit (~3–5 min on ~1–2 lockfile-change builds/week) did not justify the cache eviction risk.
 - Check cache usage: `gh api repos/smith-horn/skillsmith/actions/cache/usage`
 - Prune stale caches: `gh api repos/smith-horn/skillsmith/actions/caches --paginate -q '.actions_caches[] | .id' | xargs -I{} gh api -X DELETE repos/smith-horn/skillsmith/actions/caches/{}`
 - **Cache-miss Step Summary** (SMI-3539): ci.yml docker-build writes cache hit/miss status to `$GITHUB_STEP_SUMMARY` so PR authors know when a cold build is expected.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,7 +458,7 @@ jobs:
           load: true
           tags: skillsmith-ci:${{ github.sha }}
           cache-from: type=gha,scope=ci
-          cache-to: type=gha,mode=max,scope=ci
+          cache-to: type=gha,mode=min,scope=ci
           target: dev
 
       # SMI-2194: Save image to cache directory for future runs

--- a/package-lock.json
+++ b/package-lock.json
@@ -35011,6 +35011,7 @@
         "eslint-plugin-astro": "1.5.0",
         "globals": "17.1.0",
         "loupe": "3.2.1",
+        "picomatch": "^4.0.4",
         "prettier": "3.8.1",
         "prettier-plugin-astro": "0.14.1",
         "strip-literal": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,13 @@
     "@tootallnate/once": "^3.0.1",
     "@vercel/python-analysis": {
       "minimatch": "^10.2.3"
+    },
+    "picomatch": "^4.0.4",
+    "anymatch": {
+      "picomatch": "^2.3.2"
+    },
+    "micromatch": {
+      "picomatch": "^2.3.2"
     }
   }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-astro": "1.5.0",
     "globals": "17.1.0",
     "loupe": "3.2.1",
+    "picomatch": "^4.0.4",
     "prettier": "3.8.1",
     "prettier-plugin-astro": "0.14.1",
     "strip-literal": "3.1.0",


### PR DESCRIPTION
## Summary

- Rollback CI BuildKit cache from `mode=max` to `mode=min` after 72h verification showed cache pressure (10.45 GB total, publish scope evicted, builds ~10 min)
- Remediate picomatch high-severity vulnerabilities (GHSA-c2c7-rcm5-vvqj, GHSA-3v7f-55p6-f55p) via npm overrides — all 10 instances resolved from 4.0.3→4.0.4 and 2.3.1→2.3.2
- Update ci-reference.md cache policy documentation

## Context

PR #344 (SMI-3539) re-introduced `mode=max` for CI on 2026-03-22 with a documented rollback condition. SPARC analysis of 7 alternatives (including GitHub paid plans, GHCR registry cache, conditional mode) confirmed rollback as the optimal path. Full analysis: `docs/internal/implementation/ci-cache-mode-max-rollback.md`

Key finding: GitHub's 10 GB cache limit is fixed across all plan tiers — no upgrade path exists.

Supersedes #380 (closed due to stuck CI concurrency group).

[skip-impl-check] — intentionally config/deps-only: CI workflow rollback + vulnerability override

## Test plan

- [x] Build passes (6/6 packages)
- [x] All 6733 tests pass (263 test files)
- [x] npm audit: 0 high-severity vulnerabilities
- [x] Pre-push security checks pass
- [ ] Post-merge: purge stale BuildKit blobs
- [ ] Post-merge: verify cache < 5 GB within 24h
- [ ] Post-merge: verify `index-publish` cache regenerates on next publish run

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)