### PR TITLE
fix: markdown lint MD032 in implementation-plan template (SMI-3655)

### DIFF
--- a/.claude/templates/implementation-plan.md
+++ b/.claude/templates/implementation-plan.md
@@ -25,6 +25,7 @@ Reviewed: YYYY-MM-DD | Reviewers: VP Product, VP Engineering, VP Design
 **Solution**: [How it's fixed]
 
 **Files**:
+
 - `path/to/file.ts` — [what changes]
 
 ### 2. [Second change area]
@@ -34,6 +35,7 @@ Reviewed: YYYY-MM-DD | Reviewers: VP Product, VP Engineering, VP Design
 **Solution**: [How it's fixed]
 
 **Files**:
+
 - `path/to/file.ts` — [what changes]
 
 ## Wave 1: [Title]


### PR DESCRIPTION
## Summary

- Add missing blank lines before list blocks at lines 28 and 37 in `.claude/templates/implementation-plan.md`
- Fixes MD032 (blanks-around-lists) markdownlint violations introduced in PR #382

[skip-impl-check] — docs-only fix

## Test plan

- [x] `npx markdownlint-cli2 '.claude/templates/**/*.md'` returns 0 errors
- [x] Pre-commit checks pass

Closes SMI-3655

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)