### PR TITLE
fix(ci): add explicit permissions to publish-vscode.yml (SMI-3729)

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -25,6 +25,10 @@ concurrency:
 env:
   NODE_VERSION: '22'
 
+# CodeQL alerts #75, #76 — restrict GITHUB_TOKEN to read-only
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Extension


### PR DESCRIPTION
## Summary

- Add top-level `permissions: contents: read` to `.github/workflows/publish-vscode.yml`
- Restricts default `GITHUB_TOKEN` scope from full-access to read-only
- Both `validate` and `publish` jobs only need `contents: read` — `VSCE_PAT` is a separate marketplace token unaffected by `GITHUB_TOKEN` permissions

[skip-impl-check] — CI workflow metadata change, no source code changes expected

Matches established pattern in `ci.yml` (SMI-2266), `publish.yml`, `docs-only.yml` (SMI-2267), `packaging-test.yml` (SMI-2268), and `website-deploy-staging.yml` (CodeQL #41).

## Test plan

- [x] YAML syntax valid (prettier formatted)
- [x] Pre-commit + pre-push hooks pass
- [ ] CI passes
- [ ] After merge: verify CodeQL alerts #75/#76 auto-close on next scan

## References

- [CodeQL Alert #75](https://github.com/smith-horn/skillsmith/security/code-scanning/75)
- [CodeQL Alert #76](https://github.com/smith-horn/skillsmith/security/code-scanning/76)
- Linear: SMI-3729

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)