### PR TITLE
docs: security advisory blog post for CVE-2026-33768 (SMI-3732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 12 alerts dismissed (packages updated via npm overrides to patched versions)
   - 6 alerts auto-fixed by Dependabot
   - Patched: eslint@9.39.2, fast-xml-parser@5.3.4, diff@8.0.3, tar@7.5.7, hono@4.11.7
+- **CVE-2026-33768 Patch** (2026-03-29): Patched `@astrojs/vercel` path override bypass
+  vulnerability (CVSS 6.5). Upgraded 9.0.3 → 9.0.5 (backported fix for Astro 5
+  compatibility). No evidence of exploitation. See [GHSA-mr6q-rp88-fx84](https://github.com/withastro/astro/security/advisories/GHSA-mr6q-rp88-fx84).
+- **CI Workflow Hardening** (2026-03-29): Added explicit `permissions: contents: read`
+  to `publish-vscode.yml`, restricting default GITHUB_TOKEN scope (CodeQL #75/#76).
 
 ## [0.4.12] - 2026-02-23
 

--- a/packages/website/src/content/blog/security-advisory-cve-2026-33768.md
+++ b/packages/website/src/content/blog/security-advisory-cve-2026-33768.md
@@ -1,0 +1,65 @@
+---
+title: "Security Advisory: Astro Vercel Adapter Path Override Bypass (CVE-2026-33768)"
+description: "We proactively patched a medium-severity vulnerability in the Astro Vercel adapter that could allow path override bypass on server-rendered routes. No evidence of exploitation was found."
+author: "Skillsmith Team"
+date: 2026-03-29
+category: "Engineering"
+tags: ["security", "advisory", "infrastructure", "vercel"]
+featured: false
+draft: false
+---
+
+On March 29, 2026, we patched a medium-severity vulnerability (CVSS 6.5) in our web infrastructure. This advisory provides transparency about the issue, our response, and what it means for your data.
+
+---
+
+## What Happened
+
+The Astro project disclosed [CVE-2026-33768](https://github.com/withastro/astro/security/advisories/GHSA-mr6q-rp88-fx84), a path override bypass vulnerability in the `@astrojs/vercel` adapter. The vulnerability allowed crafted requests to manipulate server-side routing via the `x-astro-path` header or query parameter, potentially bypassing route-level access controls on server-rendered pages.
+
+## Were Skillsmith Users Affected?
+
+**No evidence of exploitation was found.** We reviewed server logs and access patterns prior to patching and observed no suspicious activity targeting this vector.
+
+However, because Skillsmith uses server-rendered (SSR) routes for authenticated pages — including login, account management, and billing — we treated this as a high-urgency fix despite the medium CVSS score.
+
+## What We Did
+
+We applied the patch within hours of the upstream disclosure:
+
+- **Upgraded `@astrojs/vercel`** from 9.0.3 to 9.0.5, which backports the security fix for Astro 5 compatibility
+- **Validated** the fix across all server-rendered routes, including authentication flows and dynamic pages
+- **Hardened CI workflows** with explicit permission scoping (a separate CodeQL finding addressed in the same batch)
+
+The fix required no changes to application code or configuration — only a dependency version bump.
+
+## What You Need to Do
+
+**Nothing.** The patch is deployed to production. No action is required from Skillsmith users. Your API keys, account data, and skill configurations were not exposed.
+
+## Timeline
+
+| Time | Event |
+|------|-------|
+| March 29, 2026 | Upstream advisory published (GHSA-mr6q-rp88-fx84) |
+| March 29, 2026 | Skillsmith team identifies affected routes and assesses risk |
+| March 29, 2026 | Patch applied, tested, and merged ([PR #402](https://github.com/smith-horn/skillsmith/pull/402)) |
+| March 29, 2026 | Deployed to production via Vercel |
+
+## Technical Details
+
+The vulnerability existed in the Vercel adapter's request routing layer. Astro's server-side rendering uses internal headers to coordinate routing between the edge and serverless functions. CVE-2026-33768 allowed external requests to inject these internal routing signals, potentially redirecting server-side processing to unintended routes.
+
+Our deployment uses SSR for 13+ routes (authentication, account management, pricing, and dynamic skill pages), with middleware-based A/B routing that exercises the same path manipulation surface. The `@astrojs/vercel@9.0.5` release patches this by validating and sanitizing routing inputs before they reach the application layer.
+
+## Our Commitment
+
+Security is foundational to Skillsmith. When you install skills through our platform, you trust us to protect your development environment. We take that seriously — from the [multi-layered skill security scanner](/blog/security-quarantine-safe-installation) that protects against malicious skills, to proactive infrastructure patching like this advisory.
+
+If you have questions about this advisory, contact us at [security@skillsmith.app](mailto:security@skillsmith.app).
+
+---
+
+**References:**
+- [GHSA-mr6q-rp88-fx84](https://github.com/withastro/astro/security/advisories/GHSA-mr6q-rp88-fx84) — Upstream advisory
+- [Skillsmith Security Policy](/security) — Vulnerability reporting and disclosure process


### PR DESCRIPTION
## Summary

- Add security advisory blog post at `/blog/security-advisory-cve-2026-33768` for Enterprise/Team customer transparency about the `@astrojs/vercel` path override bypass patch (PR #402)
- Add CHANGELOG.md entries for CVE-2026-33768 patch and CI workflow hardening (CodeQL #75/#76)

## Test plan

- [x] Website builds successfully in Docker (`npm run build -w packages/website`)
- [x] Blog post renders to `dist/client/blog/security-advisory-cve-2026-33768/index.html` (40KB)
- [x] Frontmatter validates against content collection schema
- [x] No new TypeScript or lint errors

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)