### PR TITLE
fix(ci): smoke test heredoc delimiter not found — printf %s → %b (SMI-3762)

### DIFF
--- a/.github/workflows/website-deploy-staging.yml
+++ b/.github/workflows/website-deploy-staging.yml
@@ -417,7 +417,7 @@ jobs:
 
           # Output results for summary (SMI-2141: use printf instead of echo -e)
           echo "results<<EOF" >> $GITHUB_OUTPUT
-          printf "%s" "$RESULTS" >> $GITHUB_OUTPUT
+          printf "%b" "$RESULTS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
           # Output runtime metrics (SMI-2142)


### PR DESCRIPTION
## Summary

- One-character fix: `printf "%s"` → `printf "%b"` in smoke test step
- `%s` doesn't interpret `\n` as newlines, so the `GITHUB_OUTPUT` `EOF` delimiter never appears on its own line
- `%b` interprets backslash escapes, fixing the multiline output format
- All 4 smoke test pages were returning 200 — only the output formatting was broken

## Test plan

- [ ] Merge and trigger staging deploy — smoke test step should pass
- [ ] GitHub step summary shows formatted table with one row per page

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)