### PR TITLE
feat(ci): add documentation drift detection (SMI-3882–3886)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,28 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+  # SMI-3882: Detect code changes that lack corresponding documentation updates
+  # Non-blocking during 2-week stabilization (continue-on-error: true)
+  doc-drift:
+    name: Documentation Drift Check
+    needs: [classify]
+    if: github.event_name == 'pull_request' && needs.classify.outputs.tier == 'code'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    continue-on-error: true # audit:allow-continue-on-error — stabilization period, not a required check
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npx tsx scripts/ci/check-doc-drift.ts --pr-number ${{ github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   # SMI-1300: Validate package configurations before expensive Docker build
   # Catches scope mismatches for GitHub Packages early
   # Only runs on upstream repo (smith-horn) - skipped on forks

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -1527,6 +1527,100 @@ console.log(`\n${BOLD}23. Implementation Completeness Spot Check (SMI-3543)${RES
   }
 }
 
+// 24. CHANGELOG Currency (SMI-3885)
+console.log(`\n${BOLD}24. CHANGELOG Currency (SMI-3885)${RESET}`)
+{
+  const pkgDirs = existsSync('packages')
+    ? readdirSync('packages').filter((d) => existsSync(join('packages', d, 'package.json')))
+    : []
+
+  // Check root + each package
+  const targets = [
+    { pkgPath: 'package.json', changelogPath: 'CHANGELOG.md', label: 'root' },
+    ...pkgDirs.map((d) => ({
+      pkgPath: join('packages', d, 'package.json'),
+      changelogPath: join('packages', d, 'CHANGELOG.md'),
+      label: `packages/${d}`,
+    })),
+  ]
+
+  let changelogIssues = 0
+  for (const { pkgPath, changelogPath, label } of targets) {
+    if (!existsSync(changelogPath)) continue // Skip packages without CHANGELOG
+
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+      const pkgVersion = pkg.version
+      if (!pkgVersion) continue
+
+      const changelog = readFileSync(changelogPath, 'utf8')
+
+      // Check for [Unreleased] section with content (exemption)
+      const unreleasedMatch = changelog.match(/## \[?Unreleased\]?\s*\n([\s\S]*?)(?=\n## |\n*$)/)
+      if (unreleasedMatch && unreleasedMatch[1].trim().length > 0) continue
+
+      // Extract first version heading: ## [X.Y.Z] or ## vX.Y.Z or ## X.Y.Z
+      const versionMatch = changelog.match(/## \[?v?(\d+\.\d+\.\d+)\]?/)
+      if (!versionMatch) continue
+
+      const changelogVersion = versionMatch[1]
+      if (changelogVersion !== pkgVersion) {
+        changelogIssues++
+        warn(
+          `${label}: CHANGELOG version ${changelogVersion} is behind package.json ${pkgVersion}`,
+          `Update ${changelogPath} with an entry for v${pkgVersion}`
+        )
+      }
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  if (changelogIssues === 0) {
+    pass('All CHANGELOGs are current with their package.json versions')
+  }
+}
+
+// 25. MCP Tool Count (SMI-3886)
+console.log(`\n${BOLD}25. MCP Tool Count (SMI-3886)${RESET}`)
+{
+  const mcpIndexPath = 'packages/mcp-server/src/index.ts'
+  const mcpReadmePath = 'packages/mcp-server/README.md'
+
+  if (!existsSync(mcpIndexPath) || !existsSync(mcpReadmePath)) {
+    warn('MCP tool count check skipped — required files not found')
+  } else {
+    try {
+      const indexContent = readFileSync(mcpIndexPath, 'utf8')
+      // Extract toolDefinitions array and count entries (lines with Schema or Tool suffix)
+      const defMatch = indexContent.match(/const toolDefinitions\s*=\s*\[([\s\S]*?)\]/)
+      const toolCount = defMatch
+        ? defMatch[1].split('\n').filter((l) => l.trim() && !l.trim().startsWith('//')).length
+        : 0
+
+      const readme = readFileSync(mcpReadmePath, 'utf8')
+      // Extract "Available Tools" section up to next heading, then count tool rows
+      const toolsSection = readme.match(
+        /## Available Tools\s*\n[\s\S]*?\n\|[- |]+\n([\s\S]*?)(?=\n## |\n*$)/
+      )
+      const readmeCount = toolsSection
+        ? toolsSection[1].split('\n').filter((l) => /^\|\s*`[a-z_]+`\s*\|/.test(l)).length
+        : 0
+
+      if (toolCount === readmeCount) {
+        pass(`MCP tool count matches: ${toolCount} tools in code and README`)
+      } else {
+        warn(
+          `MCP tool count mismatch: ${toolCount} in toolDefinitions vs ${readmeCount} in README`,
+          `Update ${mcpReadmePath} tools table to match registered tools`
+        )
+      }
+    } catch (e) {
+      warn('Could not check MCP tool count: ' + e.message)
+    }
+  }
+}
+
 // npm override drift check: @modelcontextprotocol/sdk override "." must match mcp-server range
 console.log(`\n${BOLD}Override Drift: @modelcontextprotocol/sdk${RESET}`)
 try {

--- a/scripts/ci/check-doc-drift.ts
+++ b/scripts/ci/check-doc-drift.ts
@@ -1,0 +1,362 @@
+#!/usr/bin/env npx tsx
+/**
+ * CI Documentation Drift Check (SMI-3882)
+ *
+ * Analyzes PR changed files and diff content to detect code changes
+ * that lack corresponding documentation updates.
+ *
+ * Usage:
+ *   npx tsx scripts/ci/check-doc-drift.ts --pr-number 123
+ *
+ * Environment:
+ *   GH_TOKEN - GitHub token for API access (provided by actions/checkout)
+ *
+ * Verdicts:
+ *   pass - No documentation gaps detected
+ *   warn - Advisory gaps detected (non-blocking)
+ *   fail - Required documentation missing
+ *   skip - [skip-doc-drift] in PR body
+ */
+
+import { execFileSync } from 'child_process'
+import { appendFileSync, existsSync } from 'fs'
+
+// --- Types ---
+
+export type Verdict = 'pass' | 'warn' | 'fail' | 'skip'
+
+export interface DocGap {
+  trigger: string
+  surface: string
+  severity: 'fail' | 'warn'
+}
+
+export interface DocDriftResult {
+  verdict: Verdict
+  gaps: DocGap[]
+  reason: string
+}
+
+export interface PrData {
+  title: string
+  body: string
+  files: string[]
+  diff: string
+}
+
+// --- Constants ---
+
+const SKIP_MARKER = '[skip-doc-drift]'
+
+// --- Detection Functions ---
+
+/** Detect new MCP tool registrations without doc updates */
+export function detectNewMcpTools(files: string[], diff: string): DocGap[] {
+  const gaps: DocGap[] = []
+  const indexChanged = files.some((f) => f === 'packages/mcp-server/src/index.ts')
+  if (!indexChanged) return gaps
+
+  // Check for new entries added to toolDefinitions array
+  const addedLines = diff
+    .split('\n')
+    .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+  const hasNewTool = addedLines.some(
+    (line) => /Schema\s*[,\]]/.test(line) || /Tool\s*[,\]]/.test(line)
+  )
+  if (!hasNewTool) return gaps
+
+  const docSurfaces = [
+    'README.md',
+    'packages/mcp-server/README.md',
+    'packages/website/src/pages/docs/mcp-server.astro',
+    'CLAUDE.md',
+  ]
+
+  for (const surface of docSurfaces) {
+    if (!files.includes(surface)) {
+      gaps.push({
+        trigger: 'New MCP tool registered in toolDefinitions',
+        surface,
+        severity: 'fail',
+      })
+    }
+  }
+  return gaps
+}
+
+/** Detect new CLI command registrations without doc updates */
+export function detectNewCliCommands(files: string[], diff: string): DocGap[] {
+  const gaps: DocGap[] = []
+  const cliSrcChanged = files.some(
+    (f) => f.startsWith('packages/cli/src/') && !f.includes('.test.')
+  )
+  if (!cliSrcChanged) return gaps
+
+  // Check for new command registration in diff
+  const addedLines = diff
+    .split('\n')
+    .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+  const hasNewCommand = addedLines.some(
+    (line) => /\.command\(/.test(line) || /registerCommand/.test(line)
+  )
+  if (!hasNewCommand) return gaps
+
+  const docSurfaces = ['packages/website/src/pages/docs/cli.astro', 'packages/cli/README.md']
+
+  for (const surface of docSurfaces) {
+    if (!files.includes(surface)) {
+      gaps.push({
+        trigger: 'New CLI command registered',
+        surface,
+        severity: 'fail',
+      })
+    }
+  }
+  return gaps
+}
+
+/** Detect package version bumps without CHANGELOG updates */
+export function detectVersionBumps(files: string[]): DocGap[] {
+  const gaps: DocGap[] = []
+
+  // Check each package's package.json
+  const pkgJsonFiles = files.filter(
+    (f) => f.match(/^packages\/[^/]+\/package\.json$/) || f === 'package.json'
+  )
+
+  for (const pkgJson of pkgJsonFiles) {
+    const dir = pkgJson === 'package.json' ? '' : pkgJson.replace('/package.json', '')
+    const changelog = dir ? `${dir}/CHANGELOG.md` : 'CHANGELOG.md'
+
+    if (!files.includes(changelog)) {
+      gaps.push({
+        trigger: `Version bump in ${pkgJson}`,
+        surface: changelog,
+        severity: 'fail',
+      })
+    }
+  }
+  return gaps
+}
+
+/** Detect security feature changes without doc updates */
+export function detectSecurityFeatures(files: string[]): DocGap[] {
+  const gaps: DocGap[] = []
+  const securityFiles = files.filter(
+    (f) =>
+      (f.includes('/security/') || f.includes('/pii/') || f.includes('/risk/')) &&
+      !f.includes('.test.')
+  )
+  if (securityFiles.length === 0) return gaps
+
+  if (!files.includes('packages/website/src/pages/docs/security.astro')) {
+    gaps.push({
+      trigger: `Security feature changes (${securityFiles.length} file(s))`,
+      surface: 'packages/website/src/pages/docs/security.astro',
+      severity: 'warn',
+    })
+  }
+  return gaps
+}
+
+/** Detect VS Code extension changes without CHANGELOG updates */
+export function detectVscodeChanges(files: string[]): DocGap[] {
+  const gaps: DocGap[] = []
+  const vscodeSrcChanged = files.some(
+    (f) => f.startsWith('packages/vscode-extension/src/') && !f.includes('.test.')
+  )
+  if (!vscodeSrcChanged) return gaps
+
+  if (!files.includes('packages/vscode-extension/CHANGELOG.md')) {
+    gaps.push({
+      trigger: 'VS Code extension source changes',
+      surface: 'packages/vscode-extension/CHANGELOG.md',
+      severity: 'warn',
+    })
+  }
+  return gaps
+}
+
+/** Detect migration additions without CHANGELOG updates */
+export function detectMigrations(files: string[]): DocGap[] {
+  const gaps: DocGap[] = []
+  const hasMigration = files.some((f) => f.startsWith('packages/core/src/database/migrations/'))
+  if (!hasMigration) return gaps
+
+  if (!files.includes('packages/core/CHANGELOG.md')) {
+    gaps.push({
+      trigger: 'Database migration added',
+      surface: 'packages/core/CHANGELOG.md',
+      severity: 'warn',
+    })
+  }
+  return gaps
+}
+
+// --- Main Logic ---
+
+export function run(prData: PrData): DocDriftResult {
+  // Check escape hatch
+  if (prData.body.includes(SKIP_MARKER)) {
+    return {
+      verdict: 'skip',
+      gaps: [],
+      reason: '[skip-doc-drift] found in PR body — skipping documentation drift check.',
+    }
+  }
+
+  // Only analyze non-test source files — if PR is only tests, no doc requirement
+  const hasNonTestSource = prData.files.some(
+    (f) =>
+      (f.startsWith('packages/') || f.startsWith('scripts/') || f.startsWith('supabase/')) &&
+      /\.(ts|tsx|js|jsx|mjs)$/.test(f) &&
+      !f.includes('.test.') &&
+      !f.includes('.spec.')
+  )
+  if (!hasNonTestSource) {
+    return {
+      verdict: 'pass',
+      gaps: [],
+      reason: 'No non-test source files changed — no documentation requirement.',
+    }
+  }
+
+  // Run all detectors
+  const gaps: DocGap[] = [
+    ...detectNewMcpTools(prData.files, prData.diff),
+    ...detectNewCliCommands(prData.files, prData.diff),
+    ...detectVersionBumps(prData.files),
+    ...detectSecurityFeatures(prData.files),
+    ...detectVscodeChanges(prData.files),
+    ...detectMigrations(prData.files),
+  ]
+
+  if (gaps.length === 0) {
+    return {
+      verdict: 'pass',
+      gaps: [],
+      reason: 'No documentation gaps detected.',
+    }
+  }
+
+  // Highest severity wins
+  const hasFail = gaps.some((g) => g.severity === 'fail')
+  const verdict: Verdict = hasFail ? 'fail' : 'warn'
+
+  const failCount = gaps.filter((g) => g.severity === 'fail').length
+  const warnCount = gaps.filter((g) => g.severity === 'warn').length
+  const parts: string[] = []
+  if (failCount > 0) parts.push(`${failCount} required`)
+  if (warnCount > 0) parts.push(`${warnCount} advisory`)
+
+  return {
+    verdict,
+    gaps,
+    reason: `Documentation drift detected: ${parts.join(', ')} gap(s). Add [skip-doc-drift] to PR body to bypass.`,
+  }
+}
+
+// --- GitHub API ---
+
+function fetchPrData(prNumber: number): PrData {
+  const prJson = execFileSync(
+    'gh',
+    ['pr', 'view', String(prNumber), '--json', 'title,body,files'],
+    { encoding: 'utf-8', timeout: 15000 }
+  )
+
+  const pr = JSON.parse(prJson)
+  const files = (pr.files || []).map((f: { path: string }) => f.path)
+
+  const diff = execFileSync('gh', ['pr', 'diff', String(prNumber)], {
+    encoding: 'utf-8',
+    timeout: 15000,
+  })
+
+  return {
+    title: pr.title || '',
+    body: pr.body || '',
+    files,
+    diff,
+  }
+}
+
+// --- Output ---
+
+function writeSummary(result: DocDriftResult, prNumber: number): void {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY
+  if (!summaryPath) return
+
+  const icon =
+    result.verdict === 'pass'
+      ? 'check'
+      : result.verdict === 'warn'
+        ? 'warning'
+        : result.verdict === 'skip'
+          ? 'information_source'
+          : 'x'
+
+  const lines = [
+    `## :${icon}: Documentation Drift Check — ${result.verdict.toUpperCase()}`,
+    '',
+    `**PR #${prNumber}**`,
+    '',
+    result.reason,
+    '',
+  ]
+
+  if (result.gaps.length > 0) {
+    lines.push('### Detected Gaps', '')
+    lines.push('| Trigger | Missing Surface | Severity |')
+    lines.push('|---------|----------------|----------|')
+    for (const gap of result.gaps) {
+      lines.push(`| ${gap.trigger} | \`${gap.surface}\` | ${gap.severity} |`)
+    }
+    lines.push('')
+  }
+
+  appendFileSync(summaryPath, lines.join('\n') + '\n')
+}
+
+// --- CLI Entry Point ---
+
+function parseArgs(): { prNumber: number } {
+  const args = process.argv.slice(2)
+  const prIdx = args.indexOf('--pr-number')
+  if (prIdx === -1 || !args[prIdx + 1]) {
+    console.error('Usage: check-doc-drift.ts --pr-number <number>')
+    process.exit(1)
+  }
+  const prNumber = parseInt(args[prIdx + 1], 10)
+  if (isNaN(prNumber) || prNumber <= 0) {
+    console.error('Invalid PR number:', args[prIdx + 1])
+    process.exit(1)
+  }
+  return { prNumber }
+}
+
+// Only run when executed directly
+const isDirectExecution = !process.argv[1]?.includes('vitest')
+
+if (isDirectExecution && existsSync('.git')) {
+  try {
+    const { prNumber } = parseArgs()
+    console.log(`Checking documentation drift for PR #${prNumber}...`)
+
+    const prData = fetchPrData(prNumber)
+    const result = run(prData)
+
+    writeSummary(result, prNumber)
+
+    console.log(`Verdict: ${result.verdict}`)
+    console.log(result.reason)
+
+    if (result.verdict === 'fail') {
+      process.exit(1)
+    }
+  } catch (err) {
+    console.error('check-doc-drift failed:', (err as Error).message)
+    // Fail open during rollout — don't block PRs on script errors
+    process.exit(0)
+  }
+}

--- a/scripts/tests/check-doc-drift.test.ts
+++ b/scripts/tests/check-doc-drift.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for CI Documentation Drift Check (SMI-3883)
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  detectNewMcpTools,
+  detectNewCliCommands,
+  detectVersionBumps,
+  detectSecurityFeatures,
+  detectVscodeChanges,
+  detectMigrations,
+  run,
+  type PrData,
+} from '../ci/check-doc-drift'
+
+describe('SMI-3882: check-doc-drift', () => {
+  // Helper to create PrData
+  function prData(overrides: Partial<PrData> = {}): PrData {
+    return {
+      title: 'feat: test PR',
+      body: '',
+      files: [],
+      diff: '',
+      ...overrides,
+    }
+  }
+
+  describe('detectNewMcpTools', () => {
+    it('should detect new MCP tool without README updates (test 1: fail)', () => {
+      const files = ['packages/mcp-server/src/index.ts']
+      const diff = '+  newToolSchema,\n+  anotherSchema]\n'
+      const gaps = detectNewMcpTools(files, diff)
+      expect(gaps.length).toBe(4)
+      expect(gaps.every((g) => g.severity === 'fail')).toBe(true)
+      expect(gaps.map((g) => g.surface)).toContain('README.md')
+      expect(gaps.map((g) => g.surface)).toContain('packages/mcp-server/README.md')
+    })
+
+    it('should pass when MCP tool + README updated (test 2: pass)', () => {
+      const files = [
+        'packages/mcp-server/src/index.ts',
+        'README.md',
+        'packages/mcp-server/README.md',
+        'packages/website/src/pages/docs/mcp-server.astro',
+        'CLAUDE.md',
+      ]
+      const diff = '+  newToolSchema,\n'
+      const gaps = detectNewMcpTools(files, diff)
+      expect(gaps.length).toBe(0)
+    })
+
+    it('should return no gaps when index.ts not changed', () => {
+      const files = ['packages/mcp-server/src/tools/search.ts']
+      const diff = '+  something'
+      const gaps = detectNewMcpTools(files, diff)
+      expect(gaps.length).toBe(0)
+    })
+  })
+
+  describe('detectNewCliCommands', () => {
+    it('should detect new CLI command without doc updates', () => {
+      const files = ['packages/cli/src/commands/new-cmd.ts']
+      const diff = "+  .command('new-cmd')\n"
+      const gaps = detectNewCliCommands(files, diff)
+      expect(gaps.length).toBe(2)
+      expect(gaps.every((g) => g.severity === 'fail')).toBe(true)
+    })
+
+    it('should pass when CLI command + docs updated', () => {
+      const files = [
+        'packages/cli/src/commands/new-cmd.ts',
+        'packages/website/src/pages/docs/cli.astro',
+        'packages/cli/README.md',
+      ]
+      const diff = "+  .command('new-cmd')\n"
+      const gaps = detectNewCliCommands(files, diff)
+      expect(gaps.length).toBe(0)
+    })
+  })
+
+  describe('detectVersionBumps', () => {
+    it('should pass when version bump + CHANGELOG present (test 3: pass)', () => {
+      const files = ['packages/core/package.json', 'packages/core/CHANGELOG.md']
+      const gaps = detectVersionBumps(files)
+      expect(gaps.length).toBe(0)
+    })
+
+    it('should fail when version bump + no CHANGELOG (test 4: fail)', () => {
+      const files = ['packages/core/package.json']
+      const gaps = detectVersionBumps(files)
+      expect(gaps.length).toBe(1)
+      expect(gaps[0].severity).toBe('fail')
+      expect(gaps[0].surface).toBe('packages/core/CHANGELOG.md')
+    })
+
+    it('should check root package.json separately', () => {
+      const files = ['package.json']
+      const gaps = detectVersionBumps(files)
+      expect(gaps.length).toBe(1)
+      expect(gaps[0].surface).toBe('CHANGELOG.md')
+    })
+  })
+
+  describe('detectSecurityFeatures', () => {
+    it('should pass when security files + security.astro present (test 7: pass)', () => {
+      const files = [
+        'packages/core/src/security/scanner.ts',
+        'packages/website/src/pages/docs/security.astro',
+      ]
+      const gaps = detectSecurityFeatures(files)
+      expect(gaps.length).toBe(0)
+    })
+
+    it('should warn when security files + no security.astro (test 8: warn)', () => {
+      const files = ['packages/core/src/security/scanner.ts']
+      const gaps = detectSecurityFeatures(files)
+      expect(gaps.length).toBe(1)
+      expect(gaps[0].severity).toBe('warn')
+    })
+
+    it('should ignore test files in security paths', () => {
+      const files = ['packages/core/src/security/scanner.test.ts']
+      const gaps = detectSecurityFeatures(files)
+      expect(gaps.length).toBe(0)
+    })
+  })
+
+  describe('detectVscodeChanges', () => {
+    it('should warn when VS Code src changes + no CHANGELOG (test 9: warn)', () => {
+      const files = ['packages/vscode-extension/src/extension.ts']
+      const gaps = detectVscodeChanges(files)
+      expect(gaps.length).toBe(1)
+      expect(gaps[0].severity).toBe('warn')
+    })
+
+    it('should pass when VS Code src changes + CHANGELOG present', () => {
+      const files = [
+        'packages/vscode-extension/src/extension.ts',
+        'packages/vscode-extension/CHANGELOG.md',
+      ]
+      const gaps = detectVscodeChanges(files)
+      expect(gaps.length).toBe(0)
+    })
+  })
+
+  describe('detectMigrations', () => {
+    it('should pass when migration + core CHANGELOG present (test 10: pass)', () => {
+      const files = [
+        'packages/core/src/database/migrations/065-new-table.ts',
+        'packages/core/CHANGELOG.md',
+      ]
+      const gaps = detectMigrations(files)
+      expect(gaps.length).toBe(0)
+    })
+
+    it('should warn when migration + no core CHANGELOG', () => {
+      const files = ['packages/core/src/database/migrations/065-new-table.ts']
+      const gaps = detectMigrations(files)
+      expect(gaps.length).toBe(1)
+      expect(gaps[0].severity).toBe('warn')
+    })
+  })
+
+  describe('run (integration)', () => {
+    it('should skip when [skip-doc-drift] in PR body (test 5: skip)', () => {
+      const result = run(
+        prData({
+          body: 'Hotfix: [skip-doc-drift]',
+          files: ['packages/core/package.json'],
+        })
+      )
+      expect(result.verdict).toBe('skip')
+    })
+
+    it('should pass when only test files changed (test 6: pass)', () => {
+      const result = run(
+        prData({
+          files: ['packages/core/src/foo.test.ts', 'packages/mcp-server/src/bar.spec.ts'],
+        })
+      )
+      expect(result.verdict).toBe('pass')
+      expect(result.reason).toContain('No non-test source files')
+    })
+
+    it('should use highest severity when multiple gaps (test 11: highest wins)', () => {
+      const result = run(
+        prData({
+          files: [
+            'packages/core/package.json',
+            'packages/vscode-extension/src/extension.ts',
+            'packages/core/src/index.ts',
+          ],
+          diff: '',
+        })
+      )
+      // Version bump without CHANGELOG = fail, VS Code without CHANGELOG = warn
+      expect(result.verdict).toBe('fail')
+      expect(result.gaps.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('should pass for deps-only PR with no source files (test 12: pass)', () => {
+      const result = run(
+        prData({
+          files: ['package.json', 'package-lock.json'],
+        })
+      )
+      // package.json is not a source file pattern, so no non-test source detected
+      expect(result.verdict).toBe('pass')
+    })
+
+    it('should pass when source changes have no doc requirements', () => {
+      const result = run(
+        prData({
+          files: ['packages/core/src/utils.ts'],
+          diff: '+ export function helper() {}',
+        })
+      )
+      expect(result.verdict).toBe('pass')
+    })
+
+    it('should include gap details in reason when failing', () => {
+      const result = run(
+        prData({
+          files: ['packages/core/package.json', 'packages/core/src/index.ts'],
+          diff: '',
+        })
+      )
+      expect(result.verdict).toBe('fail')
+      expect(result.reason).toContain('Documentation drift detected')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **SMI-3882**: New `scripts/ci/check-doc-drift.ts` — analyzes PR changed files to detect code changes lacking documentation updates. Mirrors `verify-implementation.ts` pattern: exported `run()`, `[skip-doc-drift]` escape hatch, GitHub step summary, 15s `gh` CLI timeout. Six detection rules: MCP tools, CLI commands, version bumps, security features, VS Code extension, and migrations.
- **SMI-3883**: 21 unit tests in `scripts/tests/check-doc-drift.test.ts` covering all detection paths (pass/fail/warn/skip).
- **SMI-3884**: `doc-drift` CI job in `ci.yml` — gated on `tier == 'code'`, PR-only, `continue-on-error: true` for 2-week stabilization period. Pinned action SHAs match existing CI pattern.
- **SMI-3885**: Check 24 (CHANGELOG Currency) in `audit-standards.mjs` — compares package.json version against CHANGELOG heading with `[Unreleased]` exemption. Warn-only.
- **SMI-3886**: Check 25 (MCP Tool Count) in `audit-standards.mjs` — compares `toolDefinitions` array count against mcp-server README tools table. Warn-only.

## Context

24 PRs merged Apr 3–5 with zero public doc updates. This adds automated CI-level detection of code changes that outpace documentation. Implementation plan: `docs/internal/implementation/doc-drift-detection.md`.

The `doc-drift` job runs with `continue-on-error: true` and is **not** added to branch protection. After a 2-week stabilization period with no false positives, SMI-3887 will promote it to a required check.

## Test plan

- [ ] 21/21 unit tests pass: `npx vitest run scripts/tests/check-doc-drift.test.ts`
- [ ] `audit:standards` passes with Checks 24 + 25 present (warn-only, no new failures)
- [ ] `preflight` passes clean
- [ ] CI `doc-drift` job runs on this PR with `continue-on-error: true`
- [ ] Verify `[skip-doc-drift]` escape hatch works (present in this PR body — should skip)

[skip-doc-drift]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)