### PR TITLE
feat(ci): add Dependency Guard job for supply-chain pin drift (SMI-3985)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,71 @@ jobs:
       - name: Audit workspace dependency versions
         run: node scripts/verify-publish-deps.mjs --ci
 
+  # SMI-3985: Supply-chain pin drift guard for the three Wave 1 hardening
+  # surfaces that are NOT covered by `Standards Compliance` (audit-standards
+  # Check 12, packages/*/package.json only) or `Security Audit` (npm audit):
+  #   A. GitHub-native license + OpenSSF scorecard review (pull_request only)
+  #   B. Deterministic drift guard: .mcp.json @latest, esm.sh semver pins,
+  #      third-party GH Actions SHA pins
+  # Lands as non-required; promote to required after calibration (see
+  # docs/internal/implementation/supply-chain-hardening.md §Wave 1.5).
+  dependency-guard:
+    name: Dependency Guard
+    needs: [classify]
+    if: |
+      needs.classify.outputs.tier == 'deps' ||
+      needs.classify.outputs.tier == 'code' ||
+      needs.classify.outputs.tier == 'config'
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      # SMI-2159: supabase/functions/** is git-crypt encrypted. Fork PRs do
+      # not receive secrets.GIT_CRYPT_KEY; the drift script below detects the
+      # GITCRYPT magic header and emits a coverage-skipped warning (not a
+      # failure) when unlock did not run. Pattern copied from ci.yml:662-672.
+      - name: Unlock git-crypt
+        if: ${{ env.GIT_CRYPT_KEY != '' }}
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y git-crypt
+          echo "${{ secrets.GIT_CRYPT_KEY }}" | base64 -d > /tmp/git-crypt-key
+          git-crypt unlock /tmp/git-crypt-key
+          rm -f /tmp/git-crypt-key
+
+      # A. GitHub-native dependency review — license + OpenSSF scorecard.
+      #    Complements (does NOT duplicate) the existing `Security Audit` job
+      #    which already runs `npm audit --audit-level=high --omit=dev`.
+      #    The action only runs on pull_request events; the drift guard below
+      #    still runs on push-to-main.
+      - name: Dependency Review
+        if: github.event_name == 'pull_request'
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
+      # B. Drift guard for the three Wave 1 hardened surfaces NOT covered by
+      #    `Standards Compliance` / `Security Audit`: esm.sh CDN imports,
+      #    .mcp.json @latest tags, third-party GH Actions SHA pins.
+      #    audit-standards.mjs Check 12 already runs in the `Standards
+      #    Compliance` job (ci.yml:1276) — do NOT call it again here.
+      - name: Supply-chain drift guard
+        run: node scripts/ci/check-supply-chain-pins.mjs
+
   # SMI-1903: Validate Edge Function structure and configuration
   # Ensures all functions have proper structure and are categorized
   edge-function-validation:

--- a/scripts/ci/check-supply-chain-pins.mjs
+++ b/scripts/ci/check-supply-chain-pins.mjs
@@ -307,7 +307,11 @@ export function formatFindingsMarkdown(all, esmStats) {
     lines.push('| File | Rule | Issue | Fix |')
     lines.push('|---|---|---|---|')
     for (const f of all) {
-      const esc = (s) => String(s).replace(/\|/g, '\\|').replace(/\n/g, ' ')
+      // Escape backslashes first, then pipes, then newlines. Order matters:
+      // if we escape `|` before `\`, a literal `\` in input would be re-escaped
+      // into `\\` which could then be interpreted as an escape for the pipe we
+      // just added. CodeQL js/incomplete-sanitization enforces this ordering.
+      const esc = (s) => String(s).replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ')
       lines.push(
         `| \`${esc(f.file)}\` | ${esc(f.rule)} | ${esc(f.message)} | ${esc(f.remediation)} |`
       )

--- a/scripts/ci/check-supply-chain-pins.mjs
+++ b/scripts/ci/check-supply-chain-pins.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+/**
+ * Supply-chain pin drift guard (SMI-3985).
+ *
+ * Enforces exact pinning for the three Wave 1 hardening surfaces that are NOT
+ * covered by `Standards Compliance` (audit-standards Check 12, which only
+ * covers packages/*\/package.json) or `Security Audit` (npm audit):
+ *
+ *   1. `.mcp.json` — no `@latest` in any command/args string.
+ *   2. `supabase/functions/**\/*.ts` — esm.sh imports must be full semver (x.y.z).
+ *      Git-crypt encrypted files (fork PRs without GIT_CRYPT_KEY) are counted
+ *      and reported as a skipped-coverage warning to $GITHUB_STEP_SUMMARY but
+ *      do NOT fail the check.
+ *   3. `.github/workflows/**\/*.yml` — third-party actions (owner not in the
+ *      first-party allowlist) must be pinned to a 40-char SHA.
+ *
+ * Deterministic: no network, no LLM, zero dependencies. Runs in < 500ms.
+ *
+ * @see docs/internal/implementation/supply-chain-hardening.md (Wave 1.5)
+ * @see .github/workflows/ci.yml (`dependency-guard` job)
+ */
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
+import { join, dirname, relative } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..', '..')
+const CI = !!process.env.GITHUB_ACTIONS
+const SUMMARY = process.env.GITHUB_STEP_SUMMARY || ''
+
+// ---------------------------------------------------------------------------
+// First-party action owners that are allowed to use tag refs (`@v4`, `@main`).
+// GitHub/Actions-owned actions are accepted as-is because they are signed by
+// GitHub itself. Everything else MUST be SHA-pinned.
+// ---------------------------------------------------------------------------
+const FIRST_PARTY_OWNERS = new Set(['actions', 'github'])
+
+const SHA_REGEX = /^[a-f0-9]{40}$/
+const SEMVER_REGEX = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/
+const GITCRYPT_MAGIC = Buffer.from([0x00, 0x47, 0x49, 0x54, 0x43, 0x52, 0x59, 0x50, 0x54])
+
+// ---------------------------------------------------------------------------
+// Reporting helpers
+// ---------------------------------------------------------------------------
+const findings = []
+const warnings = []
+
+function fail(file, rule, message, remediation) {
+  findings.push({ file, rule, message, remediation })
+}
+
+function warn(file, rule, message) {
+  warnings.push({ file, rule, message })
+}
+
+async function writeSummary(text) {
+  if (!SUMMARY) return
+  try {
+    const { appendFileSync } = await import('fs')
+    appendFileSync(SUMMARY, text + '\n')
+  } catch {
+    /* non-fatal in local runs */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+export function walk(dir, matcher, results = []) {
+  if (!existsSync(dir)) return results
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.git') continue
+    const full = join(dir, entry)
+    let s
+    try {
+      s = statSync(full)
+    } catch {
+      continue
+    }
+    if (s.isDirectory()) {
+      walk(full, matcher, results)
+    } else if (s.isFile() && matcher(full)) {
+      results.push(full)
+    }
+  }
+  return results
+}
+
+export function isGitCryptEncrypted(absPath) {
+  try {
+    const fd = readFileSync(absPath)
+    if (fd.length < GITCRYPT_MAGIC.length) return false
+    return fd.subarray(0, GITCRYPT_MAGIC.length).equals(GITCRYPT_MAGIC)
+  } catch {
+    return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Check 1: `.mcp.json` — no `@latest`
+// ---------------------------------------------------------------------------
+export function checkMcpJson(mcpPath) {
+  const localFindings = []
+  if (!existsSync(mcpPath)) return localFindings
+
+  let raw
+  try {
+    raw = readFileSync(mcpPath, 'utf-8')
+  } catch (err) {
+    localFindings.push({
+      file: '.mcp.json',
+      rule: 'mcp-latest',
+      message: `Failed to read .mcp.json: ${err.message}`,
+      remediation: 'Check file permissions.',
+    })
+    return localFindings
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    localFindings.push({
+      file: '.mcp.json',
+      rule: 'mcp-latest',
+      message: `Invalid JSON in .mcp.json: ${err.message}`,
+      remediation: 'Run `jq . .mcp.json` to diagnose.',
+    })
+    return localFindings
+  }
+
+  // Recursively walk every string and flag `@latest`.
+  const visit = (node, path) => {
+    if (node == null) return
+    if (typeof node === 'string') {
+      if (node.includes('@latest')) {
+        localFindings.push({
+          file: '.mcp.json',
+          rule: 'mcp-latest',
+          message: `Found "${node}" at ${path} — @latest is banned (supply-chain drift).`,
+          remediation: `Run \`npm view ${node.split('@latest')[0]} version\` to get the current version, then pin it explicitly.`,
+        })
+      }
+      return
+    }
+    if (Array.isArray(node)) {
+      node.forEach((item, i) => visit(item, `${path}[${i}]`))
+      return
+    }
+    if (typeof node === 'object') {
+      for (const [k, v] of Object.entries(node)) {
+        visit(v, path ? `${path}.${k}` : k)
+      }
+    }
+  }
+  visit(parsed, '')
+  return localFindings
+}
+
+// ---------------------------------------------------------------------------
+// Check 2: esm.sh imports in Supabase edge functions must be full semver.
+// ---------------------------------------------------------------------------
+const ESM_SH_IMPORT_REGEX = /from\s+['"]https:\/\/esm\.sh\/(@?[A-Za-z0-9][\w./-]*?)@([^'"]+)['"]/g
+
+export function extractEsmShPins(source) {
+  const pins = []
+  let match
+  // Reset regex state between calls (exec with /g is stateful).
+  ESM_SH_IMPORT_REGEX.lastIndex = 0
+  while ((match = ESM_SH_IMPORT_REGEX.exec(source)) !== null) {
+    pins.push({ pkg: match[1], version: match[2] })
+  }
+  return pins
+}
+
+export function checkEsmShPin(pin) {
+  // Strip any trailing path or query fragment (e.g. `2.47.0/dist-src`).
+  const versionOnly = pin.version.split(/[/?]/)[0]
+  if (!SEMVER_REGEX.test(versionOnly)) {
+    return {
+      ok: false,
+      message: `esm.sh import "${pin.pkg}@${pin.version}" is not full semver (expected x.y.z).`,
+      remediation: `Run \`npm view ${pin.pkg} version\` to get the latest x.y.z and pin it explicitly.`,
+    }
+  }
+  return { ok: true }
+}
+
+export function checkSupabaseFunctions(rootDir) {
+  const localFindings = []
+  let encryptedCount = 0
+  let scannedCount = 0
+
+  const fnRoot = join(rootDir, 'supabase', 'functions')
+  if (!existsSync(fnRoot)) return { findings: localFindings, encryptedCount, scannedCount }
+
+  const tsFiles = walk(fnRoot, (p) => p.endsWith('.ts'))
+  for (const abs of tsFiles) {
+    if (isGitCryptEncrypted(abs)) {
+      encryptedCount++
+      continue
+    }
+    scannedCount++
+    let source
+    try {
+      source = readFileSync(abs, 'utf-8')
+    } catch {
+      continue
+    }
+    const pins = extractEsmShPins(source)
+    for (const pin of pins) {
+      const result = checkEsmShPin(pin)
+      if (!result.ok) {
+        localFindings.push({
+          file: relative(rootDir, abs),
+          rule: 'esm-sh-semver',
+          message: result.message,
+          remediation: result.remediation,
+        })
+      }
+    }
+  }
+  return { findings: localFindings, encryptedCount, scannedCount }
+}
+
+// ---------------------------------------------------------------------------
+// Check 3: Third-party GitHub Actions must be SHA-pinned.
+// ---------------------------------------------------------------------------
+// Matches `uses: owner/repo@ref` or `uses: owner/repo/path@ref`.
+// Ignores local action refs (`uses: ./foo`) and Docker refs (`uses: docker://...`).
+const USES_REGEX = /^\s*(?:-\s*)?uses:\s*['"]?([^\s'"#]+)['"]?/gm
+
+export function parseUsesRef(line) {
+  // Expected: `owner/repo[/path]@ref`
+  const atIdx = line.lastIndexOf('@')
+  if (atIdx < 0) return null
+  const ownerRepo = line.slice(0, atIdx)
+  const ref = line.slice(atIdx + 1)
+  const slashIdx = ownerRepo.indexOf('/')
+  if (slashIdx < 0) return null
+  const owner = ownerRepo.slice(0, slashIdx)
+  if (owner === '.' || owner === '..' || owner.startsWith('docker:')) return null
+  return { owner, repo: ownerRepo.slice(slashIdx + 1), ref, raw: line }
+}
+
+export function checkWorkflowUses(ref) {
+  if (FIRST_PARTY_OWNERS.has(ref.owner)) return { ok: true }
+  if (SHA_REGEX.test(ref.ref)) return { ok: true }
+  return {
+    ok: false,
+    message: `Third-party action "${ref.owner}/${ref.repo}@${ref.ref}" is not SHA-pinned.`,
+    remediation: `Run \`gh api repos/${ref.owner}/${ref.repo}/git/refs/tags/${ref.ref} --jq '.object.sha'\` to resolve the SHA.`,
+  }
+}
+
+export function checkWorkflows(rootDir) {
+  const localFindings = []
+  const wfRoot = join(rootDir, '.github', 'workflows')
+  if (!existsSync(wfRoot)) return localFindings
+
+  const ymlFiles = walk(wfRoot, (p) => p.endsWith('.yml') || p.endsWith('.yaml'))
+  for (const abs of ymlFiles) {
+    let source
+    try {
+      source = readFileSync(abs, 'utf-8')
+    } catch {
+      continue
+    }
+    // Strip full-line YAML comments before scanning so commented-out
+    // examples don't trigger false positives.
+    const cleaned = source
+      .split('\n')
+      .map((l) => (l.trimStart().startsWith('#') ? '' : l))
+      .join('\n')
+
+    USES_REGEX.lastIndex = 0
+    let match
+    while ((match = USES_REGEX.exec(cleaned)) !== null) {
+      const ref = parseUsesRef(match[1])
+      if (!ref) continue
+      const result = checkWorkflowUses(ref)
+      if (!result.ok) {
+        localFindings.push({
+          file: relative(rootDir, abs),
+          rule: 'workflow-sha-pin',
+          message: result.message,
+          remediation: result.remediation,
+        })
+      }
+    }
+  }
+  return localFindings
+}
+
+// ---------------------------------------------------------------------------
+// Report assembly
+// ---------------------------------------------------------------------------
+export function formatFindingsMarkdown(all, esmStats) {
+  const lines = []
+  lines.push('## Supply-chain drift guard')
+  lines.push('')
+  if (all.length === 0) {
+    lines.push('All three drift checks passed.')
+  } else {
+    lines.push(`Found **${all.length}** drift violation(s):`)
+    lines.push('')
+    lines.push('| File | Rule | Issue | Fix |')
+    lines.push('|---|---|---|---|')
+    for (const f of all) {
+      const esc = (s) => String(s).replace(/\|/g, '\\|').replace(/\n/g, ' ')
+      lines.push(
+        `| \`${esc(f.file)}\` | ${esc(f.rule)} | ${esc(f.message)} | ${esc(f.remediation)} |`
+      )
+    }
+  }
+  if (esmStats && esmStats.encryptedCount > 0) {
+    lines.push('')
+    lines.push(
+      `> esm.sh drift coverage skipped for ${esmStats.encryptedCount} encrypted file(s) — fork PR, \`GIT_CRYPT_KEY\` unavailable. Re-validated on post-merge push.`
+    )
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Main (only when invoked directly, not during tests).
+// ---------------------------------------------------------------------------
+export async function main(rootDir = ROOT) {
+  const mcpFindings = checkMcpJson(join(rootDir, '.mcp.json'))
+  const esmResult = checkSupabaseFunctions(rootDir)
+  const wfFindings = checkWorkflows(rootDir)
+  const all = [...mcpFindings, ...esmResult.findings, ...wfFindings]
+
+  const summary = formatFindingsMarkdown(all, {
+    encryptedCount: esmResult.encryptedCount,
+    scannedCount: esmResult.scannedCount,
+  })
+  await writeSummary(summary)
+
+  if (esmResult.encryptedCount > 0) {
+    console.warn(
+      `[supply-chain] esm.sh drift coverage skipped for ${esmResult.encryptedCount} encrypted file(s) — fork PR, GIT_CRYPT_KEY unavailable.`
+    )
+  }
+
+  if (all.length === 0) {
+    console.log(
+      `[supply-chain] OK — scanned ${esmResult.scannedCount} edge function .ts files, .mcp.json, and all workflow YAMLs.`
+    )
+    return 0
+  }
+
+  for (const f of all) {
+    const annotation = `::error file=${f.file}::${f.message} ${f.remediation}`
+    if (CI) console.log(annotation)
+    else console.error(`  FAIL: ${f.file}: ${f.message}\n         ${f.remediation}`)
+  }
+  console.error(`[supply-chain] FAILED — ${all.length} drift violation(s).`)
+  return 1
+}
+
+// Only run main() when this file is the entry point.
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]
+if (invokedDirectly) {
+  main().then((code) => process.exit(code))
+}

--- a/scripts/tests/check-supply-chain-pins.test.ts
+++ b/scripts/tests/check-supply-chain-pins.test.ts
@@ -398,5 +398,26 @@ describe('SMI-3985: check-supply-chain-pins', () => {
       expect(md).toContain('esm.sh drift coverage skipped for 3 encrypted file')
       expect(md).toContain('GIT_CRYPT_KEY')
     })
+
+    it('escapes backslashes before pipes to avoid ambiguous markdown (CodeQL js/incomplete-sanitization)', () => {
+      // If input already contains a literal `\|`, a naive escape of only `|`
+      // would produce `\\|` which is ambiguous. Escaping `\` first yields
+      // `\\\|` (backslash-backslash then escaped-pipe) — unambiguous.
+      const md = formatFindingsMarkdown(
+        [
+          {
+            file: 'path\\with\\backslash.ts',
+            rule: 'esm-sh-pin',
+            message: 'bad\\|input',
+            remediation: 'fix|it',
+          },
+        ],
+        { encryptedCount: 0, scannedCount: 0 }
+      )
+      // Backslash doubled, then pipe escaped
+      expect(md).toContain('path\\\\with\\\\backslash.ts')
+      expect(md).toContain('bad\\\\\\|input')
+      expect(md).toContain('fix\\|it')
+    })
   })
 })

--- a/scripts/tests/check-supply-chain-pins.test.ts
+++ b/scripts/tests/check-supply-chain-pins.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Tests for CI Supply-Chain Pin Drift Guard (SMI-3985).
+ *
+ * Covers the three Wave 1.5 drift checks:
+ *   1. `.mcp.json` — no `@latest` in command/args strings
+ *   2. esm.sh imports in supabase/functions/**\/*.ts — must be full x.y.z
+ *   3. Third-party GitHub Actions in .github/workflows/**\/*.yml — must be
+ *      40-char SHA-pinned (first-party actions/* and github/* excluded)
+ *
+ * Also verifies the git-crypt magic-byte skip path for fork PRs that lack
+ * GIT_CRYPT_KEY access to the encrypted supabase/functions tree.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// Dynamic import because the module is .mjs (ESM, no .ts transpilation).
+const mod = await import('../ci/check-supply-chain-pins.mjs')
+const {
+  checkMcpJson,
+  checkSupabaseFunctions,
+  checkWorkflows,
+  extractEsmShPins,
+  checkEsmShPin,
+  parseUsesRef,
+  checkWorkflowUses,
+  isGitCryptEncrypted,
+  formatFindingsMarkdown,
+} = mod as {
+  checkMcpJson: (p: string) => Array<{ file: string; rule: string; message: string }>
+  checkSupabaseFunctions: (root: string) => {
+    findings: Array<{ file: string; rule: string; message: string }>
+    encryptedCount: number
+    scannedCount: number
+  }
+  checkWorkflows: (root: string) => Array<{ file: string; rule: string; message: string }>
+  extractEsmShPins: (src: string) => Array<{ pkg: string; version: string }>
+  checkEsmShPin: (pin: { pkg: string; version: string }) => { ok: boolean; message?: string }
+  parseUsesRef: (line: string) => { owner: string; repo: string; ref: string; raw: string } | null
+  checkWorkflowUses: (ref: { owner: string; repo: string; ref: string }) => {
+    ok: boolean
+    message?: string
+  }
+  isGitCryptEncrypted: (p: string) => boolean
+  formatFindingsMarkdown: (
+    all: Array<{ file: string; rule: string; message: string; remediation: string }>,
+    stats?: { encryptedCount: number; scannedCount: number }
+  ) => string
+}
+
+describe('SMI-3985: check-supply-chain-pins', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'scpin-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  // -------------------------------------------------------------------------
+  // Check 1: .mcp.json
+  // -------------------------------------------------------------------------
+  describe('checkMcpJson', () => {
+    it('passes on a clean .mcp.json with pinned versions', () => {
+      const p = join(tmp, '.mcp.json')
+      writeFileSync(
+        p,
+        JSON.stringify({
+          mcpServers: {
+            skillsmith: { command: 'npx', args: ['-y', '@skillsmith/mcp-server'] },
+            ruflo: { command: 'npx', args: ['ruflo@3.5.51', 'mcp', 'start'] },
+          },
+        })
+      )
+      expect(checkMcpJson(p)).toEqual([])
+    })
+
+    it('fails when any string contains @latest', () => {
+      const p = join(tmp, '.mcp.json')
+      writeFileSync(
+        p,
+        JSON.stringify({
+          mcpServers: {
+            bad: { command: 'npx', args: ['ruflo@latest', 'mcp', 'start'] },
+          },
+        })
+      )
+      const findings = checkMcpJson(p)
+      expect(findings).toHaveLength(1)
+      expect(findings[0].rule).toBe('mcp-latest')
+      expect(findings[0].message).toContain('@latest')
+    })
+
+    it('fails on nested @latest deep in a config object', () => {
+      const p = join(tmp, '.mcp.json')
+      writeFileSync(
+        p,
+        JSON.stringify({
+          mcpServers: {
+            nested: {
+              command: 'npx',
+              env: { CMD: 'some-other-tool@latest' },
+            },
+          },
+        })
+      )
+      const findings = checkMcpJson(p)
+      expect(findings).toHaveLength(1)
+      expect(findings[0].message).toContain('some-other-tool@latest')
+    })
+
+    it('returns an empty array when .mcp.json is missing', () => {
+      const p = join(tmp, '.mcp.json')
+      expect(checkMcpJson(p)).toEqual([])
+    })
+
+    it('fails with a clear message on invalid JSON', () => {
+      const p = join(tmp, '.mcp.json')
+      writeFileSync(p, '{not json')
+      const findings = checkMcpJson(p)
+      expect(findings).toHaveLength(1)
+      expect(findings[0].message).toMatch(/Invalid JSON/)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Check 2: esm.sh semver
+  // -------------------------------------------------------------------------
+  describe('extractEsmShPins', () => {
+    it('extracts stripe and supabase-js imports', () => {
+      const src = `
+        import Stripe from 'https://esm.sh/stripe@20.4.1'
+        import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.47.0'
+      `
+      const pins = extractEsmShPins(src)
+      expect(pins).toHaveLength(2)
+      expect(pins).toContainEqual({ pkg: 'stripe', version: '20.4.1' })
+      expect(pins).toContainEqual({ pkg: '@supabase/supabase-js', version: '2.47.0' })
+    })
+
+    it('ignores non-esm.sh imports', () => {
+      const src = `
+        import foo from 'https://other.cdn/foo@1.2.3'
+        import bar from './local'
+      `
+      expect(extractEsmShPins(src)).toHaveLength(0)
+    })
+  })
+
+  describe('checkEsmShPin', () => {
+    it('accepts full semver x.y.z', () => {
+      expect(checkEsmShPin({ pkg: 'stripe', version: '20.4.1' }).ok).toBe(true)
+    })
+
+    it('accepts semver with prerelease tag', () => {
+      expect(checkEsmShPin({ pkg: 'stripe', version: '20.4.1-beta.1' }).ok).toBe(true)
+    })
+
+    it('rejects major-only version', () => {
+      const r = checkEsmShPin({ pkg: 'stripe', version: '20' })
+      expect(r.ok).toBe(false)
+      expect(r.message).toContain('not full semver')
+    })
+
+    it('rejects minor-only version', () => {
+      const r = checkEsmShPin({ pkg: '@supabase/supabase-js', version: '2.47' })
+      expect(r.ok).toBe(false)
+    })
+
+    it('accepts semver followed by a subpath fragment', () => {
+      // esm.sh permits paths like `stripe@20.4.1/lib/foo`; strip before validating.
+      expect(checkEsmShPin({ pkg: 'stripe', version: '20.4.1/lib/foo' }).ok).toBe(true)
+    })
+  })
+
+  describe('checkSupabaseFunctions (integration)', () => {
+    it('passes when every .ts file has exact-pinned esm.sh imports', () => {
+      const fnDir = join(tmp, 'supabase', 'functions', 'checkout')
+      mkdirSync(fnDir, { recursive: true })
+      writeFileSync(join(fnDir, 'index.ts'), "import Stripe from 'https://esm.sh/stripe@20.4.1'\n")
+      const result = checkSupabaseFunctions(tmp)
+      expect(result.findings).toHaveLength(0)
+      expect(result.encryptedCount).toBe(0)
+      expect(result.scannedCount).toBe(1)
+    })
+
+    it('fails when a .ts file has a major-only esm.sh pin', () => {
+      const fnDir = join(tmp, 'supabase', 'functions', 'bad')
+      mkdirSync(fnDir, { recursive: true })
+      writeFileSync(join(fnDir, 'index.ts'), "import Stripe from 'https://esm.sh/stripe@20'\n")
+      const result = checkSupabaseFunctions(tmp)
+      expect(result.findings).toHaveLength(1)
+      expect(result.findings[0].rule).toBe('esm-sh-semver')
+      expect(result.findings[0].file).toContain('supabase/functions/bad/index.ts')
+    })
+
+    it('skips git-crypt encrypted files and reports encryptedCount', () => {
+      const fnDir = join(tmp, 'supabase', 'functions', 'encrypted')
+      mkdirSync(fnDir, { recursive: true })
+      // First 9 bytes are the git-crypt magic header \x00GITCRYPT.
+      const encrypted = Buffer.concat([
+        Buffer.from([0x00, 0x47, 0x49, 0x54, 0x43, 0x52, 0x59, 0x50, 0x54]),
+        Buffer.from('garbage-after-nonce'),
+      ])
+      writeFileSync(join(fnDir, 'index.ts'), encrypted)
+      const result = checkSupabaseFunctions(tmp)
+      expect(result.findings).toHaveLength(0)
+      expect(result.encryptedCount).toBe(1)
+      expect(result.scannedCount).toBe(0)
+    })
+
+    it('returns no findings and no scans when the directory is absent', () => {
+      const result = checkSupabaseFunctions(tmp)
+      expect(result.findings).toHaveLength(0)
+      expect(result.encryptedCount).toBe(0)
+      expect(result.scannedCount).toBe(0)
+    })
+  })
+
+  describe('isGitCryptEncrypted', () => {
+    it('returns true for a file with the GITCRYPT magic header', () => {
+      const p = join(tmp, 'encrypted.ts')
+      writeFileSync(p, Buffer.from([0x00, 0x47, 0x49, 0x54, 0x43, 0x52, 0x59, 0x50, 0x54, 0xff]))
+      expect(isGitCryptEncrypted(p)).toBe(true)
+    })
+
+    it('returns false for a plaintext file', () => {
+      const p = join(tmp, 'plain.ts')
+      writeFileSync(p, "import Stripe from 'https://esm.sh/stripe@20.4.1'\n")
+      expect(isGitCryptEncrypted(p)).toBe(false)
+    })
+
+    it('returns false for an empty file', () => {
+      const p = join(tmp, 'empty.ts')
+      writeFileSync(p, '')
+      expect(isGitCryptEncrypted(p)).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Check 3: Workflow SHA pinning
+  // -------------------------------------------------------------------------
+  describe('parseUsesRef', () => {
+    it('parses a typical SHA-pinned third-party action', () => {
+      const r = parseUsesRef('actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd')
+      expect(r).not.toBeNull()
+      expect(r!.owner).toBe('actions')
+      expect(r!.repo).toBe('checkout')
+      expect(r!.ref).toBe('de0fac2e4500dabe0009e67214ff5f5447ce83dd')
+    })
+
+    it('parses an owner/repo/subpath action', () => {
+      const r = parseUsesRef('foo/bar/setup@abc123')
+      expect(r).not.toBeNull()
+      expect(r!.owner).toBe('foo')
+      expect(r!.repo).toBe('bar/setup')
+      expect(r!.ref).toBe('abc123')
+    })
+
+    it('returns null for local action refs', () => {
+      expect(parseUsesRef('./local-action')).toBeNull()
+    })
+
+    it('returns null for docker refs', () => {
+      expect(parseUsesRef('docker://alpine:3')).toBeNull()
+    })
+
+    it('returns null for lines without @ref', () => {
+      expect(parseUsesRef('owner/repo')).toBeNull()
+    })
+  })
+
+  describe('checkWorkflowUses', () => {
+    const sha = 'a'.repeat(40)
+
+    it('accepts first-party actions/* with a tag ref', () => {
+      expect(checkWorkflowUses({ owner: 'actions', repo: 'checkout', ref: 'v4' }).ok).toBe(true)
+    })
+
+    it('accepts first-party github/* with a tag ref', () => {
+      expect(checkWorkflowUses({ owner: 'github', repo: 'codeql-action', ref: 'v3' }).ok).toBe(true)
+    })
+
+    it('accepts third-party action SHA-pinned', () => {
+      expect(checkWorkflowUses({ owner: 'docker', repo: 'build-push-action', ref: sha }).ok).toBe(
+        true
+      )
+    })
+
+    it('rejects third-party action with a tag ref', () => {
+      const r = checkWorkflowUses({ owner: 'docker', repo: 'build-push-action', ref: 'v6' })
+      expect(r.ok).toBe(false)
+      expect(r.message).toContain('not SHA-pinned')
+    })
+
+    it('rejects third-party action with a short hex ref', () => {
+      const r = checkWorkflowUses({ owner: 'docker', repo: 'build-push-action', ref: 'abc1234' })
+      expect(r.ok).toBe(false)
+    })
+
+    it('accepts Dependabot-style batch SHA update (any 40-char hex is fine)', () => {
+      // Simulates a Dependabot PR bumping multiple third-party action SHAs.
+      const shas = ['a'.repeat(40), 'b'.repeat(40), '0123456789abcdef0123456789abcdef01234567']
+      for (const s of shas) {
+        expect(checkWorkflowUses({ owner: 'docker', repo: 'build-push-action', ref: s }).ok).toBe(
+          true
+        )
+      }
+    })
+  })
+
+  describe('checkWorkflows (integration)', () => {
+    it('passes when all third-party actions are SHA-pinned', () => {
+      const wfDir = join(tmp, '.github', 'workflows')
+      mkdirSync(wfDir, { recursive: true })
+      writeFileSync(
+        join(wfDir, 'ci.yml'),
+        [
+          'jobs:',
+          '  build:',
+          '    runs-on: ubuntu-latest',
+          '    steps:',
+          '      - uses: actions/checkout@v4',
+          '      - uses: docker/build-push-action@' + 'a'.repeat(40),
+          '      - uses: github/codeql-action@v3',
+          '',
+        ].join('\n')
+      )
+      const findings = checkWorkflows(tmp)
+      expect(findings).toHaveLength(0)
+    })
+
+    it('fails when a third-party action uses a tag ref', () => {
+      const wfDir = join(tmp, '.github', 'workflows')
+      mkdirSync(wfDir, { recursive: true })
+      writeFileSync(
+        join(wfDir, 'ci.yml'),
+        ['jobs:', '  build:', '    steps:', '      - uses: docker/build-push-action@v6', ''].join(
+          '\n'
+        )
+      )
+      const findings = checkWorkflows(tmp)
+      expect(findings).toHaveLength(1)
+      expect(findings[0].rule).toBe('workflow-sha-pin')
+      expect(findings[0].message).toContain('docker/build-push-action@v6')
+    })
+
+    it('ignores commented-out uses: lines', () => {
+      const wfDir = join(tmp, '.github', 'workflows')
+      mkdirSync(wfDir, { recursive: true })
+      writeFileSync(
+        join(wfDir, 'ci.yml'),
+        ['jobs:', '  build:', '    steps:', '      # - uses: docker/build-push-action@v6', ''].join(
+          '\n'
+        )
+      )
+      const findings = checkWorkflows(tmp)
+      expect(findings).toHaveLength(0)
+    })
+
+    it('returns no findings when .github/workflows is absent', () => {
+      expect(checkWorkflows(tmp)).toHaveLength(0)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Report formatting
+  // -------------------------------------------------------------------------
+  describe('formatFindingsMarkdown', () => {
+    it('produces a pass summary when no findings', () => {
+      const md = formatFindingsMarkdown([], { encryptedCount: 0, scannedCount: 5 })
+      expect(md).toContain('passed')
+      expect(md).not.toContain('skipped')
+    })
+
+    it('renders a markdown table with findings', () => {
+      const md = formatFindingsMarkdown(
+        [
+          {
+            file: '.mcp.json',
+            rule: 'mcp-latest',
+            message: 'Found @latest',
+            remediation: 'Pin it',
+          },
+        ],
+        { encryptedCount: 0, scannedCount: 0 }
+      )
+      expect(md).toContain('| File | Rule | Issue | Fix |')
+      expect(md).toContain('`.mcp.json`')
+      expect(md).toContain('mcp-latest')
+    })
+
+    it('adds a skipped-coverage warning when encryptedCount > 0', () => {
+      const md = formatFindingsMarkdown([], { encryptedCount: 3, scannedCount: 10 })
+      expect(md).toContain('esm.sh drift coverage skipped for 3 encrypted file')
+      expect(md).toContain('GIT_CRYPT_KEY')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds a new `Dependency Guard` job to `.github/workflows/ci.yml` closing the drift loop on the April 3 supply-chain hardening (PR #437). Three deterministic checks (esm.sh exact pins, `.mcp.json` no-@latest, third-party GH Actions SHA pins) plus GitHub's `dependency-review-action` for license + OpenSSF scorecard.

- Does **not** duplicate existing `Standards Compliance` (Check 12) or `Security Audit` (npm audit) required checks — strictly additive
- Handles git-crypt encrypted `supabase/functions/**` on fork PRs: drift script detects `\0GITCRYPT` magic header and emits a coverage-skipped warning instead of failing
- Accepts Dependabot batch SHA updates (any `@[a-f0-9]{40}` passes regardless of tag comment)

Lands as **non-required** check. Calibration window: max 14 days OR 5 clean PRs, whichever comes first, before promoting via `.github/branch-protection.json`.

See Linear [SMI-3985](https://linear.app/smith-horn-group/issue/SMI-3985) and `docs/internal/implementation/supply-chain-hardening.md` §Wave 1.5.

## Test plan

- [ ] CI green on this PR
- [ ] \`Dependency Guard\` job appears in the PR checks list
- [ ] Job runs for this PR (tier=code) and produces \`\$GITHUB_STEP_SUMMARY\` with drift-guard + dependency-review tables
- [ ] Runtime < 4 minutes (git-crypt install adds ~20s)
- [ ] 37 unit tests in \`scripts/tests/check-supply-chain-pins.test.ts\` pass
- [ ] Post-merge: confirm job skips with "success (skipped)" status on a docs-only follow-up PR

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>