### PR TITLE
fix(scripts): Check 11 & 23 false positives in audit-standards (SMI-3987, SMI-3986)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   threats) and SecurityScanner (SSRF, jailbreak, structural) now both run on every
   skill assessment (#451).
 
+### Fixed
+
+- **audit-standards Check 11 false positives** (2026-04-08, SMI-3987): npm overrides
+  targeting exact-pinned transitive deps are no longer flagged as "ineffective" when
+  npm's dedup machinery actually applied the override. Cross-references `npm ls <dep>`
+  to verify. Eliminated 6 false-positive warnings on current `main`. See PR #492.
+- **audit-standards Check 23 cite-in-body false positives** (2026-04-08, SMI-3987):
+  contextual `SMI-NNNN` citations in commit bodies (e.g., "per SMI-3099 doc") are no
+  longer counted as completion claims. Only subject-line refs and body refs after
+  `closes:`/`fixes:`/`resolves:` markers count. Also extended `NON_SOURCE_PREFIXES`
+  to recognize `fix(deps):`/`chore(deps):` commits as legitimately deps-only (no
+  source-file requirement). See PR #492.
+- **audit-standards Check 23 worktree bug** (2026-04-08, SMI-3986): Check 23 no longer
+  emits `fatal: not a git repository` inside git worktrees. Resolved via
+  `git rev-parse --git-common-dir` for worktree-aware `.git` resolution. See PR #492.
+
 ### Changed
 
 - Rate limits now apply based on your authenticated session tier, not just API key.

--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -1,0 +1,120 @@
+/**
+ * Pure helpers extracted from audit-standards.mjs for SMI-3987 / SMI-3986.
+ *
+ * These are referenced by both:
+ * - scripts/audit-standards.mjs (Check 11 & Check 23)
+ * - scripts/tests/audit-standards.test.ts (unit tests via dynamic ESM import)
+ *
+ * The plan (docs/internal/implementation/smi-3987-3986-audit-standards-fixes.md)
+ * originally called for hoisting these helpers to the top of audit-standards.mjs
+ * itself, matching the convention in scripts/ci/check-supply-chain-pins.mjs.
+ * That convention wraps the CLI body in a `main()` function so dynamic imports
+ * don't trigger side effects. audit-standards.mjs is ~1670 lines and wrapping
+ * its CLI body in `main()` would require indenting every line by 2 spaces — a
+ * pure-mechanical change that bloats the diff and obscures the actual fix.
+ *
+ * Pragmatic adjustment: extract the 3 pure helpers to this small companion
+ * file. The test imports from here directly. audit-standards.mjs imports them
+ * by name and uses them inside its existing check blocks. Same plan-review E3
+ * intent (use real exports, not shadow re-implementation), without the
+ * indentation churn.
+ *
+ * Zero dependencies. No I/O. No side effects.
+ */
+
+/**
+ * Parse a semver-ish version string into [major, minor, patch].
+ * Returns null if the string does not start with `<int>.<int>.<int>`.
+ * Prerelease tags and build metadata are ignored (sufficient for the npm
+ * override specs used in root package.json — none use prereleases).
+ */
+export const parseSemver = (v) => {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(v)
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null
+}
+
+/**
+ * Minimal zero-dep semver subset matching the operators used in root
+ * package.json overrides: ^, ~, >=, >, and exact-literal. Sufficient for
+ * Check 11's "did this override actually take effect?" question. Not a
+ * general-purpose semver implementation — DO NOT use for application code.
+ */
+export const satisfies = (version, spec) => {
+  const vp = parseSemver(version)
+  if (!vp) return false
+  if (spec.startsWith('^')) {
+    const sp = parseSemver(spec.slice(1))
+    if (!sp) return false
+    if (sp[0] > 0) {
+      return vp[0] === sp[0] && (vp[1] > sp[1] || (vp[1] === sp[1] && vp[2] >= sp[2]))
+    }
+    // ^0.x.y is tighter: locks minor
+    return vp[0] === 0 && vp[1] === sp[1] && vp[2] >= sp[2]
+  }
+  if (spec.startsWith('~')) {
+    const sp = parseSemver(spec.slice(1))
+    if (!sp) return false
+    return vp[0] === sp[0] && vp[1] === sp[1] && vp[2] >= sp[2]
+  }
+  if (spec.startsWith('>=')) {
+    const sp = parseSemver(spec.slice(2).trim())
+    if (!sp) return false
+    if (vp[0] !== sp[0]) return vp[0] > sp[0]
+    if (vp[1] !== sp[1]) return vp[1] > sp[1]
+    return vp[2] >= sp[2]
+  }
+  if (spec.startsWith('>')) {
+    const sp = parseSemver(spec.slice(1).trim())
+    if (!sp) return false
+    if (vp[0] !== sp[0]) return vp[0] > sp[0]
+    if (vp[1] !== sp[1]) return vp[1] > sp[1]
+    return vp[2] > sp[2]
+  }
+  // Literal / exact pin
+  return version === spec
+}
+
+// SMI-NNNN extraction patterns for Check 23. Subject-line refs always count
+// as completion claims. Body refs only count when prefixed by a closing
+// keyword (closes/closed/fix/fixes/fixed/resolve/resolves/resolved). The
+// {1,20} cap on the captured run is a sanity bound — realistic max is ~5-10
+// SMIs per marker; cap is documented but not strictly required.
+const SUBJECT_ISSUE_RE = /\b(SMI-\d+)\b/gi
+const CLOSES_MARKER_RE =
+  /\b(closes|closed|fix|fixes|fixed|resolve|resolves|resolved)[:]?\s+((?:SMI-\d+[,\s]*){1,20})/gi
+const BODY_ISSUE_RE = /\bSMI-\d+\b/gi
+
+/**
+ * Return the set of SMI-NNNN refs that this commit CLAIMS to complete.
+ *
+ * Counted as completion claims:
+ *   1. Any SMI-NNNN that appears in the subject line.
+ *   2. SMI-NNNN that appears in the body AFTER a closing keyword
+ *      (closes/closed/fix/fixes/fixed/resolve/resolves/resolved), with or
+ *      without the trailing colon. Example matches:
+ *        - "closes: SMI-1234"
+ *        - "fixes SMI-1234, SMI-5678" (no colon, multiple refs)
+ *        - "Closed: SMI-1234"
+ *
+ * NOT counted (the SMI-3987 cite-in-body false positive fix):
+ *   - SMI refs that appear in the body without a closing keyword prefix.
+ *     Example: "per SMI-3099 doc" → not counted.
+ *
+ * Returns a Set of upper-cased SMI-NNNN strings.
+ */
+export const extractCompletionIssues = (subject, body) => {
+  const out = new Set()
+  let m
+  // Subject line: every SMI-NNNN counts
+  SUBJECT_ISSUE_RE.lastIndex = 0
+  while ((m = SUBJECT_ISSUE_RE.exec(subject))) out.add(m[1].toUpperCase())
+  // Body: only after a closes-marker
+  CLOSES_MARKER_RE.lastIndex = 0
+  while ((m = CLOSES_MARKER_RE.exec(body))) {
+    const run = m[2]
+    let s
+    BODY_ISSUE_RE.lastIndex = 0
+    while ((s = BODY_ISSUE_RE.exec(run))) out.add(s[0].toUpperCase())
+  }
+  return out
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -9,6 +9,7 @@
 import { execSync } from 'child_process'
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
 import { extname, join, relative } from 'path'
+import { satisfies, extractCompletionIssues } from './audit-standards-helpers.mjs'
 
 const RED = '\x1b[31m'
 const GREEN = '\x1b[32m'
@@ -1183,9 +1184,17 @@ console.log(`\n${BOLD}20. Stale Doc Path References in Skills (SMI-2637)${RESET}
   }
 }
 
-// npm override exact-pin check (SMI-3099 lesson)
-// Verifies that all scoped overrides target dependencies with range specifiers (^/~),
-// not exact pins — because npm cannot override exact-pinned versions.
+// npm override exact-pin check (SMI-3099 lesson, SMI-3987 refinement)
+// Flags scoped overrides that target exact-pinned dependencies AND failed to
+// take effect via npm's dedup machinery. CLAUDE.md's `npm overrides` note:
+// "`npm update <pkg>` may resolve it via dedup if another chain pulls in the
+// patched version. Verify with `npm ls <dep>` after update."
+//
+// The original Check 11 (pre-SMI-3987) flagged any override targeting an
+// exact-pinned dep, even when dedup actually applied the override. This
+// caused a 6-warning false positive on SMI-3984's merge. The fix:
+// cross-reference `npm ls <dep>` and only warn when the resolved version(s)
+// disagree with the override constraint.
 {
   const pkgPath = 'package.json'
   if (existsSync(pkgPath)) {
@@ -1193,32 +1202,106 @@ console.log(`\n${BOLD}20. Stale Doc Path References in Skills (SMI-2637)${RESET}
     const overrides = pkg.overrides || {}
     const exactPinIssues = []
 
+    // Walk `npm ls <dep> --all --json` and return every resolved version of
+    // <dep> in the dependency tree. Scope-loose: trust npm's dedup machinery
+    // (per Open Q2 resolution).
+    //
+    // Critical: `npm ls` exits non-zero whenever the tree has ANY problems
+    // (invalid pins, peer conflicts, override inversions). The current `main`
+    // post-SMI-3984 tree is in exactly that state, so every call throws.
+    // **The JSON tree is still written to err.stdout** — we read it and
+    // parse it. Returning [] on every catch would fall through to the
+    // pessimistic warning path and break acceptance criterion #1
+    // (SMI-3987 plan-review E1 blocker).
+    const parseNpmLsTree = (raw) => {
+      if (!raw) return null
+      try {
+        return JSON.parse(raw)
+      } catch {
+        return null
+      }
+    }
+    const getResolvedVersions = (dep) => {
+      let raw = ''
+      try {
+        raw = execSync(`npm ls ${dep} --all --json`, {
+          encoding: 'utf-8',
+          timeout: 10000,
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
+      } catch (err) {
+        // npm ls exits non-zero on ANY tree problem — stdout still contains
+        // valid JSON. Read it. If err.stdout is missing or not parseable,
+        // fall through to raw='' below → returns [] → pessimistic warning.
+        raw = (err && err.stdout && err.stdout.toString('utf-8')) || ''
+      }
+      const tree = parseNpmLsTree(raw)
+      if (!tree) return [] // unparseable → pessimistic warning (safe default)
+      // Walk the tree and collect versions of nodes whose KEY (under
+      // .dependencies) matches the queried dep name. The walk must check
+      // the key, not just the version field — `npm ls <dep>` returns the
+      // FULL chain leading to <dep>, so intermediate nodes are versions of
+      // OTHER packages and would otherwise pollute the result set.
+      const versions = new Set()
+      const walk = (node) => {
+        if (!node || typeof node !== 'object' || !node.dependencies) return
+        for (const [childName, child] of Object.entries(node.dependencies)) {
+          if (childName === dep && child && typeof child.version === 'string') {
+            versions.add(child.version)
+          }
+          walk(child)
+        }
+      }
+      walk(tree)
+      return [...versions].filter((v) => /^\d+\.\d+\.\d+/.test(v))
+    }
+
     for (const [parent, value] of Object.entries(overrides)) {
       if (typeof value !== 'object') continue // global overrides, skip
-      for (const dep of Object.keys(value)) {
-        // Check the actual installed package's dependency specifier
+      for (const [dep, overrideSpec] of Object.entries(value)) {
+        if (dep === '.') continue // parent-version override, not a dep override
+        // Check the actual installed parent's declared dependency specifier
         const parentPkgPath = join('node_modules', parent, 'package.json')
         if (!existsSync(parentPkgPath)) continue
         const parentPkg = JSON.parse(readFileSync(parentPkgPath, 'utf8'))
         const depSpec = parentPkg.dependencies?.[dep] || parentPkg.devDependencies?.[dep]
-        if (
-          depSpec &&
-          !depSpec.startsWith('^') &&
-          !depSpec.startsWith('~') &&
-          !depSpec.startsWith('>')
-        ) {
-          exactPinIssues.push({ parent, dep, spec: depSpec })
+        if (!depSpec) continue
+        if (depSpec.startsWith('^') || depSpec.startsWith('~') || depSpec.startsWith('>')) {
+          continue // parent uses a range, override always works
         }
+
+        // Parent exact-pins the dep. Check whether dedup rescued the override.
+        if (typeof overrideSpec !== 'string') continue // nested object override
+        const resolved = getResolvedVersions(dep)
+        if (resolved.length === 0) {
+          // Couldn't inspect the tree → pessimistic warning (preserves
+          // pre-SMI-3987 safe default).
+          exactPinIssues.push({ parent, dep, spec: depSpec, resolved: null })
+          continue
+        }
+        // Scope-loose per plan-review Open Q2: if ANY resolved version of
+        // the dep satisfies the override, npm's dedup machinery has applied
+        // the override at least somewhere in the tree. Tree-wide unrelated
+        // copies (e.g. @vercel/static-config wants ajv@8.6.3 but eslint-7.x
+        // also brings in ajv@6.14.0) do not invalidate the override —
+        // residual CVEs would be caught by `Security Audit` / `npm audit`,
+        // which is the authoritative check for vulnerability presence.
+        const someEffective = resolved.some((v) => satisfies(v, overrideSpec))
+        if (!someEffective) {
+          exactPinIssues.push({ parent, dep, spec: depSpec, resolved })
+        }
+        // else: override is effective via dedup — silent pass (SMI-3987 fix)
       }
     }
 
     if (exactPinIssues.length > 0) {
       warn(
-        `${exactPinIssues.length} npm override(s) target exact-pinned dependencies (override will not take effect)`,
-        'Remove ineffective overrides and dismiss the alert with documented rationale'
+        `${exactPinIssues.length} npm override(s) target exact-pinned dependencies (override may not take effect)`,
+        'Verify with `npm ls <dep>` and `npm audit`. Remove truly ineffective overrides and dismiss with documented rationale.'
       )
-      exactPinIssues.forEach(({ parent, dep, spec }) => {
-        console.log(`    ${parent} → ${dep}: "${spec}" (exact pin, override ineffective)`)
+      exactPinIssues.forEach(({ parent, dep, spec, resolved }) => {
+        const detail = resolved ? `resolved: ${resolved.join(', ')}` : 'could not inspect tree'
+        console.log(`    ${parent} → ${dep}: "${spec}" (${detail})`)
       })
     } else {
       pass('npm overrides: no exact-pin conflicts detected')
@@ -1384,7 +1467,20 @@ console.log(`\n${BOLD}22. Workflow Inline require() Paths (SMI-3336)${RESET}`)
   }
 }
 
-// 23. Implementation Completeness Spot Check (SMI-3543)
+// 23. Implementation Completeness Spot Check (SMI-3543, SMI-3987, SMI-3986)
+//
+// SMI-3987 fix: only count SMI-NNNN refs as completion claims when they
+// appear in the commit subject line OR after a closing keyword in the body
+// (closes:/fixes:/resolves:). Cite-in-body references (e.g.,
+// "per SMI-3099 limitation doc") no longer count as "done without source".
+// Logic delegated to extractCompletionIssues() in audit-standards-helpers.mjs.
+//
+// SMI-3986 fix: resolve `.git` via `git rev-parse --git-common-dir` so the
+// shallow-clone guard works inside git worktrees (where `.git` is a file
+// containing `gitdir: <main>/.git/worktrees/<name>`, not a directory).
+// Also: downgrade git-failure from `warn(... fatal: ...)` to a clean
+// `pass('Skipped — ...')`. Matches Check 22's skip-as-pass pattern. Noise
+// suppression by design — see commit message for rationale.
 console.log(`\n${BOLD}23. Implementation Completeness Spot Check (SMI-3543)${RESET}`)
 {
   const DONE_PATTERNS = [
@@ -1395,7 +1491,6 @@ console.log(`\n${BOLD}23. Implementation Completeness Spot Check (SMI-3543)${RES
     /\bfinish(es|ed)?\b/i,
     /\bresolv(e|es|ed)\b/i,
   ]
-  const ISSUE_RE = /\b(SMI-\d+)\b/gi
   const SRC_PATTERNS = [
     /^packages\/.*\.(ts|tsx|js|jsx)$/,
     /^supabase\/functions\/.*\.(ts|js)$/,
@@ -1403,81 +1498,113 @@ console.log(`\n${BOLD}23. Implementation Completeness Spot Check (SMI-3543)${RES
   ]
   const SRC_EXCLUDED = [/\.test\.(ts|tsx|js)$/, /\.spec\.(ts|tsx|js)$/, /\.md$/]
 
-  // Non-source conventional commit prefixes (docs, chore, ci, test, refactor, style)
-  const NON_SOURCE_PREFIXES = /^(docs|chore|ci|test|refactor|style)(\(.+\))?!?:/i
+  // Non-source conventional commit prefixes (docs, chore, ci, test, refactor, style),
+  // OR any conventional commit type with `(deps)` scope (e.g. `fix(deps):`,
+  // `chore(deps):`). Deps-only commits legitimately modify package.json /
+  // package-lock.json without touching source files, so requiring source
+  // changes for them is a structural false-positive class. (SMI-3987 fix
+  // surfaced this when commit 8ec28dfa with subject-line SMI ref + deps-only
+  // files was still flagged after the cite-in-body filter was added.)
+  const NON_SOURCE_PREFIXES = /^((docs|chore|ci|test|refactor|style)(\(.+\))?|[a-z]+\(deps\))!?:/i
 
-  // Shallow clone guard — skip when history is incomplete (CI Docker builds)
-  if (existsSync('.git/shallow')) {
-    pass('Skipped — shallow clone detected (limited git history)')
-  } else
-    try {
-      const log = execSync('git log -10 --format=%H%n%B --no-merges', {
-        encoding: 'utf-8',
-        timeout: 5000,
-      })
+  // SMI-3986: worktree-aware git directory resolution. In a worktree, `.git`
+  // is a file (`gitdir: <main>/.git/worktrees/<name>`), not a directory —
+  // the previous `existsSync('.git/shallow')` silently misfired.
+  let gitCommonDir = null
+  try {
+    gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      encoding: 'utf-8',
+      timeout: 2000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    // Not a git checkout, GIT_DIR misaligned, or hook context.
+    pass('Skipped — could not resolve git directory (not a checkout or hook context)')
+  }
 
-      // Parse commit blocks: each block starts with a 40-char SHA
-      const blocks = log.split(/(?=^[0-9a-f]{40}$)/m).filter((b) => b.trim())
-      let suspicious = 0
-      const suspiciousDetails = []
+  if (gitCommonDir !== null) {
+    if (existsSync(join(gitCommonDir, 'shallow'))) {
+      // Shallow clone — limited git history (CI Docker builds, etc.)
+      pass('Skipped — shallow clone detected (limited git history)')
+    } else {
+      try {
+        const log = execSync('git log -10 --format=%H%n%B --no-merges', {
+          encoding: 'utf-8',
+          timeout: 5000,
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
 
-      for (const block of blocks) {
-        const lines = block.trim().split('\n')
-        const sha = lines[0]
-        const message = lines.slice(1).join('\n')
+        // Parse commit blocks: each block starts with a 40-char SHA
+        const blocks = log.split(/(?=^[0-9a-f]{40}$)/m).filter((b) => b.trim())
+        let suspicious = 0
+        const suspiciousDetails = []
 
-        // Check if message references SMI issues with done-like keywords
-        const hasIssue = ISSUE_RE.test(message)
-        ISSUE_RE.lastIndex = 0 // Reset global regex
-        const hasDone = DONE_PATTERNS.some((p) => p.test(message))
-        const isNonSourcePrefix = NON_SOURCE_PREFIXES.test(message)
+        for (const block of blocks) {
+          const lines = block.trim().split('\n')
+          const sha = lines[0]
+          const subject = lines[1] || ''
+          const body = lines.slice(2).join('\n')
+          const fullMsg = `${subject}\n${body}`
 
-        if (!hasIssue || !hasDone || isNonSourcePrefix) continue
+          // SMI-3987: only count subject SMIs and closes-marker body SMIs
+          const completionIssues = extractCompletionIssues(subject, body)
+          if (completionIssues.size === 0) continue
 
-        // Get changed files for this commit
-        try {
-          const files = execSync(`git diff-tree --no-commit-id --name-only -r ${sha}`, {
-            encoding: 'utf-8',
-            timeout: 2000,
-          })
-            .trim()
-            .split('\n')
-            .filter((f) => f)
+          const hasDone = DONE_PATTERNS.some((p) => p.test(fullMsg))
+          if (!hasDone) continue
 
-          const hasSource = files.some((f) => {
-            const isSource = SRC_PATTERNS.some((p) => p.test(f))
-            const isExcluded = SRC_EXCLUDED.some((p) => p.test(f))
-            return isSource && !isExcluded
-          })
+          const isNonSourcePrefix = NON_SOURCE_PREFIXES.test(subject)
+          if (isNonSourcePrefix) continue
 
-          if (!hasSource) {
-            suspicious++
-            const issues = message.match(ISSUE_RE) || []
-            ISSUE_RE.lastIndex = 0
-            suspiciousDetails.push({
-              sha: sha.substring(0, 8),
-              issues: [...new Set(issues.map((i) => i.toUpperCase()))],
+          // Get changed files for this commit
+          try {
+            const files = execSync(`git diff-tree --no-commit-id --name-only -r ${sha}`, {
+              encoding: 'utf-8',
+              timeout: 2000,
+              stdio: ['ignore', 'pipe', 'ignore'],
             })
-          }
-        } catch {
-          // Skip commits that can't be inspected
-        }
-      }
+              .trim()
+              .split('\n')
+              .filter((f) => f)
 
-      if (suspicious === 0) {
-        pass('Last 10 commits: all SMI-referencing "done" commits include source changes')
-      } else {
-        warn(
-          `${suspicious} commit(s) mark issues done without source changes`,
-          'Run npm run audit:drift for a comprehensive check'
-        )
-        for (const d of suspiciousDetails.slice(0, 3)) {
-          console.log(`    ${d.sha}: ${d.issues.join(', ')}`)
+            const hasSource = files.some((f) => {
+              const isSource = SRC_PATTERNS.some((p) => p.test(f))
+              const isExcluded = SRC_EXCLUDED.some((p) => p.test(f))
+              return isSource && !isExcluded
+            })
+
+            if (!hasSource) {
+              suspicious++
+              suspiciousDetails.push({
+                sha: sha.substring(0, 8),
+                issues: [...completionIssues],
+              })
+            }
+          } catch {
+            // Skip commits that can't be inspected (orphaned, missing tree, etc.)
+          }
         }
+
+        if (suspicious === 0) {
+          pass('Last 10 commits: all SMI-referencing "done" commits include source changes')
+        } else {
+          warn(
+            `${suspicious} commit(s) mark issues done without source changes`,
+            'Run npm run audit:drift for a comprehensive check'
+          )
+          for (const d of suspiciousDetails.slice(0, 3)) {
+            console.log(`    ${d.sha}: ${d.issues.join(', ')}`)
+          }
+        }
+      } catch {
+        // SMI-3986: downgrade from warn-with-fatal-string to clean skip-as-pass.
+        // Matches Check 22's pattern for missing infrastructure. Noise
+        // suppression by design — a genuinely corrupt git state will fail
+        // many other checks (pre-push hooks, git log in calling tools, etc.).
+        pass('Skipped — could not inspect git history (hook context or detached state)')
       }
-    } catch (e) {
-      warn('Could not run implementation spot check', e.message)
     }
+  }
 }
 
 // ── Check: Duplicate Shared Constants (SMI-3590) ───────────────────────

--- a/scripts/tests/audit-standards.test.ts
+++ b/scripts/tests/audit-standards.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests for the pure helpers in scripts/audit-standards-helpers.mjs.
+ *
+ * Covers SMI-3987 (Check 11 dedup awareness via `satisfies`) and Check 23
+ * cite-in-body filtering (via `extractCompletionIssues`), plus SMI-3986
+ * (Check 23 worktree-aware `git rev-parse --git-common-dir` resolution).
+ *
+ * The pure helpers are imported via dynamic ESM import from a small
+ * companion file, matching the convention used by
+ * scripts/tests/check-supply-chain-pins.test.ts. The integration test for
+ * `gitCommonDir` uses a real tmpdir-based git repo + worktree (the only
+ * way to validate the SMI-3986 fix end-to-end).
+ */
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { execSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Dynamic ESM import — exact convention from check-supply-chain-pins.test.ts
+const helpers = (await import('../audit-standards-helpers.mjs')) as {
+  parseSemver: (v: string) => [number, number, number] | null
+  satisfies: (version: string, spec: string) => boolean
+  extractCompletionIssues: (subject: string, body: string) => Set<string>
+}
+
+const { parseSemver, satisfies, extractCompletionIssues } = helpers
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Pinned full body of squash-merge commit `8ec28dfa` (SMI-3984). Captured
+ * via `git log -1 --format=%b 8ec28dfa > scripts/tests/fixtures/smi-3984-commit-body.txt`.
+ *
+ * Contains 9 SMI-3984 mentions and 1 SMI-3099 mention, none of which are
+ * after a closes/fixes/resolves marker. The test asserts that
+ * extractCompletionIssues returns ONLY the subject-line SMI ref (SMI-3984),
+ * not any of the body cite mentions. This is the exact regression case from
+ * the SMI-3984 retro that triggered SMI-3987.
+ */
+const FIXTURE_SMI_3984_BODY = readFileSync(
+  join(__dirname, 'fixtures', 'smi-3984-commit-body.txt'),
+  'utf-8'
+)
+
+describe('audit-standards-helpers: parseSemver', () => {
+  it('parses major.minor.patch', () => {
+    expect(parseSemver('1.2.3')).toEqual([1, 2, 3])
+    expect(parseSemver('0.11.13')).toEqual([0, 11, 13])
+    expect(parseSemver('100.200.300')).toEqual([100, 200, 300])
+  })
+
+  it('parses prerelease/build metadata as just the numeric prefix', () => {
+    // sufficient for the override specs in root package.json — none use prereleases
+    expect(parseSemver('1.2.3-rc.1')).toEqual([1, 2, 3])
+    expect(parseSemver('1.2.3+build.42')).toEqual([1, 2, 3])
+  })
+
+  it('returns null for unparseable input', () => {
+    expect(parseSemver('not-a-version')).toBeNull()
+    expect(parseSemver('1.2')).toBeNull() // missing patch
+    expect(parseSemver('')).toBeNull()
+  })
+})
+
+describe('audit-standards-helpers: satisfies', () => {
+  // ── caret ranges (^) on >=1.0.0 ──────────────────────────────────────────
+  it('caret >=1.0.0: matches same major and ≥minor.patch', () => {
+    expect(satisfies('8.18.0', '^8.18.0')).toBe(true)
+    expect(satisfies('8.18.5', '^8.18.0')).toBe(true)
+    expect(satisfies('8.19.0', '^8.18.0')).toBe(true)
+  })
+
+  it('caret >=1.0.0: rejects different major', () => {
+    expect(satisfies('9.0.0', '^8.18.0')).toBe(false)
+    expect(satisfies('7.99.99', '^8.18.0')).toBe(false)
+  })
+
+  it('caret >=1.0.0: rejects below floor', () => {
+    expect(satisfies('8.17.0', '^8.18.0')).toBe(false)
+    expect(satisfies('8.18.0', '^8.18.5')).toBe(false)
+  })
+
+  // ── caret on 0.x (locks minor) ──────────────────────────────────────────
+  it('caret on 0.x: locks minor and matches ≥patch', () => {
+    expect(satisfies('0.11.13', '^0.11.13')).toBe(true)
+    expect(satisfies('0.11.15', '^0.11.13')).toBe(true)
+    expect(satisfies('0.11.99', '^0.11.13')).toBe(true)
+  })
+
+  it('caret on 0.x: rejects different minor', () => {
+    expect(satisfies('0.12.0', '^0.11.13')).toBe(false)
+    expect(satisfies('0.10.99', '^0.11.13')).toBe(false)
+  })
+
+  it('caret on 0.x: rejects below patch floor', () => {
+    expect(satisfies('0.11.12', '^0.11.13')).toBe(false)
+  })
+
+  // ── tilde ranges (~) ────────────────────────────────────────────────────
+  it('tilde: locks minor, allows patch ≥ floor', () => {
+    expect(satisfies('2.8.3', '~2.8.3')).toBe(true)
+    expect(satisfies('2.8.4', '~2.8.3')).toBe(true)
+    expect(satisfies('2.9.0', '~2.8.3')).toBe(false)
+    expect(satisfies('2.8.2', '~2.8.3')).toBe(false)
+  })
+
+  // ── >= and > ────────────────────────────────────────────────────────────
+  it('>= matches at floor and above', () => {
+    expect(satisfies('3.972.3', '>=3.972.3')).toBe(true)
+    expect(satisfies('4.0.0', '>=3.972.3')).toBe(true)
+    expect(satisfies('3.972.2', '>=3.972.3')).toBe(false)
+  })
+
+  it('> matches strictly above floor', () => {
+    expect(satisfies('1.0.1', '>1.0.0')).toBe(true)
+    expect(satisfies('2.0.0', '>1.99.99')).toBe(true)
+    expect(satisfies('1.0.0', '>1.0.0')).toBe(false)
+  })
+
+  // ── exact / literal ─────────────────────────────────────────────────────
+  it('literal pin: exact match only', () => {
+    expect(satisfies('8.18.0', '8.18.0')).toBe(true)
+    expect(satisfies('8.18.1', '8.18.0')).toBe(false)
+  })
+
+  // ── graceful failure ────────────────────────────────────────────────────
+  it('returns false for unparseable inputs', () => {
+    expect(satisfies('invalid', '^1.0.0')).toBe(false)
+    expect(satisfies('1.0.0', '^invalid')).toBe(false)
+    expect(satisfies('invalid', '~1.0.0')).toBe(false)
+    expect(satisfies('1.0.0', '>=invalid')).toBe(false)
+  })
+
+  // ── ground-truth: the 6 SMI-3984 overrides that Check 11 false-positived ─
+  it('SMI-3984 ground truth: yaml@2.8.3 satisfies ^2.8.3', () => {
+    expect(satisfies('2.8.3', '^2.8.3')).toBe(true)
+  })
+
+  it('SMI-3984 ground truth: ajv@8.18.0 satisfies ^8.18.0', () => {
+    expect(satisfies('8.18.0', '^8.18.0')).toBe(true)
+  })
+
+  it('SMI-3984 ground truth: srvx@0.11.15 satisfies ^0.11.13', () => {
+    expect(satisfies('0.11.15', '^0.11.13')).toBe(true)
+  })
+
+  it('SMI-3984 ground truth: minimatch@10.2.5 satisfies ^10.2.3', () => {
+    expect(satisfies('10.2.5', '^10.2.3')).toBe(true)
+  })
+
+  it('SMI-3984 ground truth: smol-toml@1.6.1 satisfies ^1.6.1', () => {
+    expect(satisfies('1.6.1', '^1.6.1')).toBe(true)
+  })
+})
+
+describe('audit-standards-helpers: extractCompletionIssues', () => {
+  it('subject SMI ref counts as completion claim', () => {
+    const result = extractCompletionIssues('fix: remediate vulns (SMI-3984) (#490)', '')
+    expect([...result]).toEqual(['SMI-3984'])
+  })
+
+  it('multiple subject SMI refs all count', () => {
+    const result = extractCompletionIssues('feat: ship (SMI-1, SMI-2)', '')
+    expect([...result].sort()).toEqual(['SMI-1', 'SMI-2'])
+  })
+
+  it('subject SMI normalizes lowercase to uppercase', () => {
+    const result = extractCompletionIssues('fix: smi-1234 cleanup', '')
+    expect([...result]).toEqual(['SMI-1234'])
+  })
+
+  it('body SMI without closes marker is IGNORED (cite-in-body)', () => {
+    const result = extractCompletionIssues(
+      'fix: remediate vulns (SMI-3984)',
+      'per SMI-3099 exact-pin doc'
+    )
+    expect([...result]).toEqual(['SMI-3984'])
+    expect(result.has('SMI-3099')).toBe(false)
+  })
+
+  it('body SMI after closes: marker counts', () => {
+    const result = extractCompletionIssues('fix: x', 'closes: SMI-1234')
+    expect([...result]).toEqual(['SMI-1234'])
+  })
+
+  it('body SMI after Closes: marker (case-insensitive) counts', () => {
+    const result = extractCompletionIssues('fix: x', 'Closes: SMI-1234')
+    expect([...result]).toEqual(['SMI-1234'])
+  })
+
+  it('body SMI after fixes:/Fixed:/Resolved: markers all count', () => {
+    expect([...extractCompletionIssues('fix: x', 'fixes: SMI-1')]).toEqual(['SMI-1'])
+    expect([...extractCompletionIssues('fix: x', 'Fixed: SMI-2')]).toEqual(['SMI-2'])
+    expect([...extractCompletionIssues('fix: x', 'Resolved: SMI-3')]).toEqual(['SMI-3'])
+    expect([...extractCompletionIssues('fix: x', 'closed: SMI-4')]).toEqual(['SMI-4'])
+    expect([...extractCompletionIssues('fix: x', 'resolves: SMI-5')]).toEqual(['SMI-5'])
+  })
+
+  it('comma-separated list after closes: all count', () => {
+    const result = extractCompletionIssues('fix: x', 'Closes: SMI-1234, SMI-5678')
+    expect([...result].sort()).toEqual(['SMI-1234', 'SMI-5678'])
+  })
+
+  it('multi-line markers (closes on one line, fixes on next) both count', () => {
+    const result = extractCompletionIssues('fix: x', 'closes: SMI-1234\nfixes: SMI-5678')
+    expect([...result].sort()).toEqual(['SMI-1234', 'SMI-5678'])
+  })
+
+  it('subject SMI + body closes-marker SMI: both count, cite-in-body refs do not', () => {
+    const result = extractCompletionIssues('fix: x (SMI-1)', 'fixes: SMI-2\n\nreferences: SMI-3')
+    expect([...result].sort()).toEqual(['SMI-1', 'SMI-2'])
+    expect(result.has('SMI-3')).toBe(false)
+  })
+
+  it('bare marker (no colon) still matches — locks PERMISSIVE behavior (Open Q3)', () => {
+    // GitHub linking syntax accepts bare keyword + SMI ref (e.g. "fix SMI-1234")
+    const result = extractCompletionIssues('chore: x', 'fix SMI-1234')
+    expect([...result]).toEqual(['SMI-1234'])
+  })
+
+  it('Co-Authored-By trailer is NOT a closing marker', () => {
+    // Defensive: even if a co-author email contained "SMI-9999@example.com",
+    // the regex requires a closing keyword prefix, so it would not match.
+    const result = extractCompletionIssues(
+      'fix: x (SMI-1)',
+      'Co-Authored-By: Claude <noreply@anthropic.com>\nrefs: SMI-9999'
+    )
+    expect([...result]).toEqual(['SMI-1'])
+    expect(result.has('SMI-9999')).toBe(false)
+  })
+
+  it('SMI ref inside a markdown code block without closes marker is ignored', () => {
+    const body = 'See `SMI-1234` for context\n```\nper SMI-5678\n```'
+    const result = extractCompletionIssues('fix: x', body)
+    expect(result.size).toBe(0)
+  })
+
+  it('empty body returns empty set if subject has no SMI ref', () => {
+    expect(extractCompletionIssues('fix: cleanup', '').size).toBe(0)
+  })
+
+  // ── PINNED REGRESSION FIXTURE: SMI-3984 squash commit body ──────────────
+  it('PINNED REGRESSION (SMI-3984 ground truth): cite-in-body SMI-3099 is NOT counted', () => {
+    // The SMI-3984 squash commit (8ec28dfa) body contains 9 SMI-3984 mentions
+    // and 1 SMI-3099 mention, none after a closes marker. Only the subject's
+    // SMI-3984 should be counted as a completion claim.
+    const subject = 'fix(deps): remediate 33 npm audit findings (SMI-3984) (#490)'
+    const result = extractCompletionIssues(subject, FIXTURE_SMI_3984_BODY)
+    expect([...result]).toEqual(['SMI-3984'])
+    expect(result.has('SMI-3099')).toBe(false)
+  })
+})
+
+describe('audit-standards Check 23: NON_SOURCE_PREFIXES (conventional commit type/scope)', () => {
+  // The NON_SOURCE_PREFIXES regex is defined inside the Check 23 scope block
+  // and is not exported. We re-implement it here for unit-test coverage. The
+  // re-implementation must stay in sync with the version in audit-standards.mjs.
+  const NON_SOURCE_PREFIXES = /^((docs|chore|ci|test|refactor|style)(\(.+\))?|[a-z]+\(deps\))!?:/i
+
+  it('matches docs/chore/ci/test/refactor/style without scope', () => {
+    expect(NON_SOURCE_PREFIXES.test('docs: update readme')).toBe(true)
+    expect(NON_SOURCE_PREFIXES.test('chore: bump version')).toBe(true)
+    expect(NON_SOURCE_PREFIXES.test('ci: update workflow')).toBe(true)
+    expect(NON_SOURCE_PREFIXES.test('test: add coverage')).toBe(true)
+    expect(NON_SOURCE_PREFIXES.test('refactor: simplify')).toBe(true)
+    expect(NON_SOURCE_PREFIXES.test('style: format')).toBe(true)
+  })
+
+  it('matches docs/chore/etc with scope', () => {
+    expect(NON_SOURCE_PREFIXES.test('docs(api): update')).toBe(true)
+    expect(NON_SOURCE_PREFIXES.test('chore(release): 1.0')).toBe(true)
+    expect(NON_SOURCE_PREFIXES.test('refactor(core): split')).toBe(true)
+  })
+
+  it('matches breaking change marker (!)', () => {
+    expect(NON_SOURCE_PREFIXES.test('chore!: drop node 14')).toBe(true)
+    expect(NON_SOURCE_PREFIXES.test('docs(api)!: rename')).toBe(true)
+  })
+
+  it('matches deps-scoped commits regardless of type (SMI-3987)', () => {
+    // The fix that enables this test: deps-scoped commits with any type
+    // (fix, feat, build, etc.) legitimately modify package.json without
+    // source files. Without this branch, the SMI-3984 merge commit
+    // (subject `fix(deps): remediate 33 npm audit findings (SMI-3984) (#490)`)
+    // would still be flagged by Check 23 because `fix(deps):` is not in the
+    // base prefix list and the commit has no source-file changes.
+    expect(NON_SOURCE_PREFIXES.test('fix(deps): bump vite')).toBe(true)
+    expect(NON_SOURCE_PREFIXES.test('feat(deps): add new package')).toBe(true)
+    expect(NON_SOURCE_PREFIXES.test('build(deps): update lockfile')).toBe(true)
+    expect(NON_SOURCE_PREFIXES.test('chore(deps): bump dependencies')).toBe(true)
+  })
+
+  it('does NOT match feat/fix/perf/build without deps scope', () => {
+    // These types should still trigger source-file requirement
+    expect(NON_SOURCE_PREFIXES.test('feat: add api')).toBe(false)
+    expect(NON_SOURCE_PREFIXES.test('fix: bug')).toBe(false)
+    expect(NON_SOURCE_PREFIXES.test('perf: optimize')).toBe(false)
+    expect(NON_SOURCE_PREFIXES.test('feat(api): new endpoint')).toBe(false)
+    expect(NON_SOURCE_PREFIXES.test('fix(server): handle null')).toBe(false)
+  })
+})
+
+describe('audit-standards Check 23: gitCommonDir worktree integration', () => {
+  let tmpRoot: string | null = null
+
+  beforeAll(() => {
+    // Sanity check: git is installed in the test environment
+    try {
+      execSync('git --version', { stdio: 'ignore' })
+    } catch {
+      throw new Error('git is required for the worktree integration test')
+    }
+  })
+
+  afterEach(() => {
+    if (tmpRoot && existsSync(tmpRoot)) {
+      rmSync(tmpRoot, { recursive: true, force: true })
+    }
+    tmpRoot = null
+  })
+
+  it('SMI-3986: git rev-parse --git-common-dir resolves to main .git from inside a worktree', () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'audit-standards-worktree-'))
+    const main = join(tmpRoot, 'main')
+    const wt = join(tmpRoot, 'wt')
+
+    // Create a fresh main repo + one commit
+    const env = {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'test',
+      GIT_AUTHOR_EMAIL: 't@example.com',
+      GIT_COMMITTER_NAME: 'test',
+      GIT_COMMITTER_EMAIL: 't@example.com',
+    }
+    execSync(`git init --quiet "${main}"`, { env })
+    execSync(`git -C "${main}" commit --allow-empty -m init --quiet`, { env })
+    execSync(`git -C "${main}" worktree add --quiet "${wt}"`, { env })
+
+    // Inside the worktree, .git is a FILE (not a directory)
+    expect(existsSync(join(wt, '.git'))).toBe(true)
+    const dotGitContent = readFileSync(join(wt, '.git'), 'utf-8')
+    expect(dotGitContent).toMatch(/^gitdir:/)
+
+    // The fix: git rev-parse --git-common-dir resolves to main's .git
+    const commonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: wt,
+      encoding: 'utf-8',
+    }).trim()
+
+    // Normalize: --git-common-dir may be relative (to wt) OR absolute. Use
+    // path.resolve, which honors absolute paths and otherwise resolves
+    // relative to wt. realpathSync collapses any /private/var <-> /var
+    // symlinks (macOS tmpdir).
+    const resolved = realpathSync(resolve(wt, commonDir))
+    const expected = realpathSync(join(main, '.git'))
+    expect(resolved).toBe(expected)
+
+    // The shallow file is what the audit-standards Check 23 actually checks for
+    expect(existsSync(join(resolved, 'shallow'))).toBe(false)
+  })
+})

--- a/scripts/tests/fixtures/smi-3984-commit-body.txt
+++ b/scripts/tests/fixtures/smi-3984-commit-body.txt
@@ -1,0 +1,299 @@
+* fix(deps): bump vite 7.3.2 / hono 4.12.12 / @hono/node-server 1.19.13 (SMI-3984 wave 1)
+
+Non-breaking patch bumps for 3 npm audit findings, closing 9 GHSA advisories.
+All three are transitive via dev tooling (vitest, @modelcontextprotocol/sdk).
+
+- vite 7.3.1 → 7.3.2
+  closes: GHSA-4w7w-66w2-5vf9 (path traversal in optimized deps .map)
+          GHSA-v2wj-q39q-566r (server.fs.deny bypass via queries)
+          GHSA-p9ff-h696-f583 (arbitrary file read via dev server websocket)
+- hono 4.12.7 → 4.12.12
+  closes: GHSA-26pp-8wgv-hjvm (cookie name validation on write path)
+          GHSA-r5rp-j6wh-rvv4 (non-breaking space prefix bypass in getCookie)
+          GHSA-xpcf-pg52-r92g (incorrect IP matching in ipRestriction for v4-mapped v6)
+          GHSA-xf4j-xp2r-rqqx (path traversal in toSSG)
+          GHSA-wmmm-f939-6g9c (middleware bypass via repeated slashes in serveStatic)
+- @hono/node-server 1.19.10 → 1.19.13
+  closes: GHSA-92pp-h63x-v22m (middleware bypass via repeated slashes in serveStatic)
+
+Overrides added to root package.json with caret minima (matches existing
+undici/rollup/path-to-regexp flat override pattern) so future transitives
+cannot regress below the patched floor:
+  hono: ^4.12.7 → ^4.12.12 (bumped)
+  vite: ^7.3.2 (new)
+  @hono/node-server: ^1.19.13 (new)
+
+Also removed 9 stale lockfile entries for packages/website/node_modules/vitest
+and nested @vitest/vite/vite-node dirs. These were a pre-existing lockfile
+drift from an old vitest@3.2.4 nested install under the website workspace,
+which kept pulling vite@6.4.1 (also in the vulnerable range). After cleanup
+all vite instances now dedupe to 7.3.2.
+
+Verification (per plan VP Eng High #1):
+  npm ls vite → 7 instances of vite@7.3.2 deduped, 0 of vite 6.x
+  npm audit --audit-level=high --omit=dev → 0 (pre-push unblocked)
+  npm audit --audit-level=high (full) → 9 high remaining, all vercel chain (wave 2)
+  npm run build → 6/6 tasks pass
+
+Plan: docs/internal/implementation/smi-3984-npm-vuln-remediation.md
+
+Co-Authored-By: claude-flow <ruv@ruv.net>
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+* fix(deps): scoped overrides for vercel CLI transitive vulns (SMI-3984 wave 2)
+
+Remediates 9 high-severity + 13 moderate vulnerabilities in the vercel CLI
+dependency chain via scoped npm overrides. Vercel CLI stays at 50.38.1 —
+upgrade path checked first per plan VP Eng High #2 pre-check, and
+vercel@50.42.0 was found to still pin vulnerable transitive versions, so
+that upgrade path was skipped (would have wasted one npm install cycle).
+
+Root-cause analysis: all 9 @vercel/* high-sev advisories and 13 moderate
+@vercel/* advisories flow from 3 leaf packages that are exact-pinned by
+their direct @vercel/* parents (CLAUDE.md §"npm overrides" exact-pin
+limitation prevents flat overrides):
+
+  - @vercel/python-analysis@0.11.0 exact-pins:
+      minimatch: "10.1.1"  → override to ^10.2.3 (→ 10.2.5)
+      smol-toml: "1.5.2"   → override to ^1.6.1  (→ 1.6.1)
+  - @vercel/backends@0.0.54 exact-pins:
+      srvx: "0.8.9"        → override to ^0.11.13 (→ 0.11.15)
+  - @vercel/rust exact-pins smol-toml too (redundant override for safety)
+
+Scoped overrides added to root package.json under the exact-pinning parents
+— this is the same pattern already used for yaml-language-server:ajv,
+@modelcontextprotocol/sdk:ajv, and @vercel/routing-utils:ajv. Proven to
+work against exact-pinned transitives.
+
+GHSA advisories closed (VP Eng Med #9 requirement):
+  minimatch:
+    GHSA-3ppc-4f35-3m26 (ReDoS via repeated wildcards; fix 10.2.1)
+    GHSA-7r86-cg39-jmmj (matchOne combinatorial backtracking; fix 10.2.3)
+    GHSA-23c5-xmqv-rm74 (nested extglob catastrophic backtracking; fix 10.2.3)
+  smol-toml:
+    GHSA-v3rj-xjv7-4jmq (DoS via consecutive commented lines; fix 1.6.1)
+  srvx:
+    GHSA-p36q-q72m-gchr (middleware bypass via absolute URI; fix 0.11.13)
+
+The 3-leaf override cascade clears ALL 9 former @vercel/* highs:
+  @vercel/backends, @vercel/build-utils, @vercel/gatsby-plugin-vercel-builder,
+  @vercel/node, @vercel/python, @vercel/python-analysis, @vercel/static-build,
+  minimatch, vercel (top-level meta-advisory)
+
+Scope cap check (VP Product Low #12): plan allowed 6 targets
+(@vercel/build-utils, @vercel/python-analysis, @vercel/node, minimatch,
+smol-toml, srvx). Used 3 leaves (minimatch, smol-toml, srvx) — fewer
+overrides than cap because root-cause analysis showed the other 3 targets
+were transitively vulnerable via these leaves, not independently.
+
+Verification (per plan Wave 2 stopping condition, VP Product High #5):
+  npm audit --audit-level=high → 0 highs (down from 9)
+  npm audit (full)             → 20 moderate, 0 high (down from 30)
+  npm run build                → 6/6 tasks pass (25s)
+  vercel build                 → Build Completed in .vercel/output [25s]
+                                 (VP Eng Med #10 + VP Product Med #11 smoke test)
+  vercel CLI version check     → 50.38.1 (unchanged — no upgrade needed)
+
+Lockfile: full regeneration (rm -f package-lock.json && npm install) to
+eliminate accumulated drift from stale nested installs. Net change is
+~-8000 lines (lockfile was carrying duplicated metadata in nested
+node_modules/* blocks). Package count still ~1895 — no packages added
+or removed beyond the scoped-override targets.
+
+Supply-chain gate (VP Eng High #4): lockfile diff inspected — all registry
+URLs point to registry.npmjs.org, integrity hashes are sha512 format, no
+unexpected package additions beyond the intended override targets.
+
+Plan: docs/internal/implementation/smi-3984-npm-vuln-remediation.md
+
+Co-Authored-By: claude-flow <ruv@ruv.net>
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+* fix(deps): scoped yaml-language-server yaml override (SMI-3984 wave 3)
+
+Clears 5 moderate advisories (yaml + 4 chain dependents) via a single
+scoped npm override on yaml-language-server → yaml.
+
+Root cause: yaml-language-server@1.20.0 exact-pins "yaml": "2.7.1" in its
+package.json, which lands in the vulnerable range (<2.8.3) for GHSA-48c2-
+rrv3-qjmp (stack overflow via deeply nested YAML collections). All OTHER
+yaml paths in the tree already dedupe to 2.8.3; this is the only offender.
+
+A flat "yaml": "^2.8.3" override would NOT work against the exact-pin (per
+CLAUDE.md §"npm overrides" — SMI-3099 exact-pin limitation). Scoped override
+on yaml-language-server forces npm to substitute yaml@2.8.3 under that
+parent, regardless of the parent's declared pin. This is the same pattern
+already used for yaml-language-server:ajv, @modelcontextprotocol/sdk:ajv,
+and the Wave 2 @vercel/python-analysis:{minimatch,smol-toml} overrides.
+
+GHSA advisories closed:
+  yaml:
+    GHSA-48c2-rrv3-qjmp (stack overflow via deeply nested collections; fix 2.8.3)
+
+The 5 cleared moderates (all downstream of the yaml leaf):
+  yaml, yaml-language-server, volar-service-yaml,
+  @astrojs/language-server, @astrojs/check
+
+This avoids the breaking-change `@astrojs/check@0.9.2` downgrade that
+`npm audit fix --force` would have triggered (loses ~1.5 years of Astro
+language server improvements).
+
+Verification (per plan Wave 3 gates):
+  npm audit --audit-level=high         → 0 highs (unchanged)
+  npm audit (full)                     → 15 moderate, 0 high (down from 20)
+  npm ls yaml                          → yaml@2.8.3 deduped under yaml-language-server;
+                                         no 2.7.x anywhere
+  node -e require('yaml')              → version 2.8.3, parse test: [a, b] ✓
+  cd packages/website && astro check   → 94 files, 0 errors, 0 warnings, 0 hints
+                                         (VP Eng High #3 integration gate)
+
+Remaining 15 moderates: 13 @vercel/* chain (downstream of Wave 2 leaves,
+not yet resolved by the minimatch/smol-toml/srvx scope), ajv (existing
+scoped override floor may need bump), vercel (top-level meta). These will
+be addressed in Wave 4 residual cleanup.
+
+Plan: docs/internal/implementation/smi-3984-npm-vuln-remediation.md
+
+Co-Authored-By: claude-flow <ruv@ruv.net>
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+* fix(deps): scoped ajv override for @vercel/static-config (SMI-3984 wave 4)
+
+Final scoped override to clear the 15 residual moderate advisories left
+after Waves 1-3. All 15 traced to a single root cause: ajv <8.18.0
+(ReDoS via $data option, GHSA-7q5c-q4rp-g9j7) pulled in by
+@vercel/static-config, which is a transitive dep of every remaining
+@vercel/* moderate.
+
+The repo already scoped-overrides ajv under yaml-language-server,
+@modelcontextprotocol/sdk, agentdb, and @vercel/routing-utils. Added
+the same scope for @vercel/static-config. Pattern match to existing
+overrides — no new precedent.
+
+Note on global ajv override: cannot use a flat "ajv" override because
+eslint pulls in ajv@6.x (incompatible with 8.x API per CLAUDE.md §npm
+overrides). Scoped-only is correct.
+
+GHSA advisories closed:
+  ajv:
+    GHSA-7q5c-q4rp-g9j7 (ReDoS via $data option; fix 8.18.0)
+
+Cleared 15 moderate advisories via this single override:
+  @vercel/elysia, @vercel/express, @vercel/fastify, @vercel/h3, @vercel/hono,
+  @vercel/hydrogen, @vercel/koa, @vercel/nestjs, @vercel/node, @vercel/redwood,
+  @vercel/remix-builder, @vercel/static-build, @vercel/static-config, ajv, vercel
+
+Verification:
+  npm audit                    → found 0 vulnerabilities (COMPLETE)
+  npm audit --audit-level=high → 0 (unchanged from Wave 2)
+
+This completes the SMI-3984 acceptance criteria: `npm audit
+--audit-level=high` returns 0 AND full audit is clean. No moderates
+remain as open Dependabot alerts — no dismissals needed.
+
+Plan: docs/internal/implementation/smi-3984-npm-vuln-remediation.md
+
+Co-Authored-By: claude-flow <ruv@ruv.net>
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+* fix(deps): add x64 rollup optional deps to lockfile (SMI-3984 ci fix)
+
+CI-only fix for the Wave 2 full-lockfile-regen — the regen ran inside
+the Apple Silicon (arm64) worktree container, which npm used as the
+"current platform" when deciding which optional platform-specific
+native modules to include in package-lock.json. Only arm64 variants
+of @rollup/rollup-linux-* were written, missing the x64 variants that
+GitHub Actions Linux runners need.
+
+CLI E2E Tests failed in CI with:
+  Cannot find module @rollup/rollup-linux-x64-gnu. npm has a bug related
+  to optional dependencies (https://github.com/npm/cli/issues/4828).
+
+This is exactly the documented npm bug. `npm install --os=linux
+--cpu=x64 --include=optional --force` from an arm64 host does not
+resolve the cross-platform optional deps (npm skips them at resolve
+time).
+
+Fix: manually add the missing lockfile entries for
+@rollup/rollup-linux-x64-gnu and @rollup/rollup-linux-x64-musl,
+matching the shape of the existing arm64 entries (version 4.59.0,
+cpu/os restricted, optional: true, no resolved/integrity — npm fetches
+lazily at install time). The rollup root entry's optionalDependencies
+already correctly listed these variants; only the leaf entries were
+missing.
+
+Verification:
+  npm install    → up to date, 0 vulnerabilities
+  npm audit      → 0 vulnerabilities (unchanged)
+  lockfile valid → yes (npm accepts the edit)
+
+Not a new wave — all 18 applied review findings are still satisfied.
+This is a CI compatibility patch for the same lockfile Wave 2 touched.
+
+Co-Authored-By: claude-flow <ruv@ruv.net>
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+* fix(deps): add x64 optional deps for all native packages (SMI-3984 ci fix 2)
+
+Follow-up to d35a5dc5 which only patched rollup. The same Apple Silicon
+lockfile-regen issue affected 17 other native optional-dep packages —
+lightningcss, @tailwindcss/oxide, @rolldown/binding, @oxc-transform,
+@img/sharp, @ruvector/*, @vscode/vsce-sign, ruvector-core, and
+@claude-flow/*/graph-node.
+
+First CI run after d35a5dc5 surfaced the next layer:
+  Cannot find module '../lightningcss.linux-x64-gnu.node'
+
+All 7 test jobs, CLI E2E, Performance Benchmarks, and Security Audit
+failed with variants of the same root cause — the lockfile only had
+arm64 optional entries, and CI's linux-x64 runners couldn't resolve
+the x64 native modules.
+
+Fix: enumerate every arm64 native entry in package-lock.json and
+generate a matching x64 sibling with the same version, license,
+optional: true, and cpu/os restrictions. 23 entries added total
+across 17 native packages.
+
+Regex used (in docker):
+  /^(.+)-linux-arm64(-gnu|-musl|)$/
+
+Verification:
+  npm install → 0 vulnerabilities, lockfile accepted
+  npm audit   → 0 vulnerabilities (unchanged)
+
+This should be the last CI compatibility patch. If more native packages
+emerge as failures, the root-cause fix is to never regenerate lockfiles
+from an Apple Silicon host — use a linux-x64 runner or add explicit
+optionalDependencies entries to each consumer's package.json.
+
+Co-Authored-By: claude-flow <ruv@ruv.net>
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+* docs: bump submodule with SMI-3984 plan file (SMI-3984)
+
+Bumps docs/internal pointer to include the implementation plan at
+implementation/smi-3984-npm-vuln-remediation.md. The plan was reviewed
+via plan-review skill on 2026-04-08 but was never committed — this
+lands it properly.
+
+Also: this triggers the \`Markdown Lint\` required check on the PR
+(path filter: \`docs/internal/**\`), which was stuck pending because
+the PR only touched package.json / package-lock.json.
+
+Co-Authored-By: claude-flow <ruv@ruv.net>
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+* docs: add SMI-3984 npm vuln remediation to CHANGELOG (SMI-3984)
+
+Adds the 33-finding cleanup to the Security section of [Unreleased].
+Also triggers the Markdown Lint required check, which has a path
+filter on **/*.md and didn't run on the dep-only commits.
+
+Co-Authored-By: claude-flow <ruv@ruv.net>
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+---------
+
+Co-authored-by: Ryan Smith <wrsmith108@users.noreply.github.com>
+Co-authored-by: claude-flow <ruv@ruv.net>
+Co-authored-by: Claude <noreply@anthropic.com>


### PR DESCRIPTION
## Summary

Bundled fix for three bugs in `scripts/audit-standards.mjs` surfaced during yesterday's SMI-3984 (PR #490) and SMI-3985 (PR #489) retros:

- **Check 11 false positive**: 6 npm overrides flagged as ineffective when npm dedup actually applied them. Fix cross-references `npm ls <dep>` (reading `err.stdout` in catch — npm ls exits non-zero on tree problems but the JSON is still in stdout). Scope-loose `some()` per plan-review Open Q2.
- **Check 23 cite-in-body false positive**: regex matched `SMI-NNNN` anywhere in commit bodies, so contextual citations like "per SMI-3099 doc" were counted as completion claims. Fix: only count subject-line refs and body refs after closes/fixes/resolves markers.
- **Check 23 worktree bug (SMI-3986)**: emitted `fatal: not a git repository` inside worktrees because it assumed `.git` is a directory. Fix: use `git rev-parse --git-common-dir`.
- **Bonus fix discovered during implementation**: extended `NON_SOURCE_PREFIXES` to also match deps-scoped commits (`fix(deps):`, `chore(deps):`). Without this, AC #3 (commit `8ec28dfa` not flagged) would not hold even with the cite-in-body fix.

## Plan deviation

Plan-review E3 called for hoisting helpers to module-level inside `audit-standards.mjs`, matching the convention in sibling test files. That convention wraps the CLI body in a `main()` function — for `audit-standards.mjs` (~1670 lines), this would require a 1650-line indentation change. Pragmatic adjustment: extract the 3 pure helpers to a small companion file `scripts/audit-standards-helpers.mjs`. Same plan-review intent (real exports, not shadow re-implementation), without the indentation churn.

## Test plan

- [x] Run `npm run audit:standards` — Check 11 ✓ (was 6 warnings), Check 23 ✓ (was 1 warning), compliance 95% (was 93%)
- [x] Run `npx vitest run scripts/tests/audit-standards.test.ts` — 40/40 passing
- [x] Run `npm run lint` — clean
- [x] Run `npm run typecheck` — clean
- [x] Run `npm run format:check` — only auto-generated `docker-compose.override.yml` and `.mcp.json` flagged (worktree-local, not committed)
- [x] Verified Check 23 worktree fix on host via integration test (tmpdir-based real git+worktree)
- [x] Verified Check 23 still skip-as-passes inside Docker (where worktree's `.git` file points to host path that's invalid in container)
- [ ] Watch CI to green
- [ ] Run `/governance` retro on the squash-merged diff
- [ ] Update SMI-3987 + SMI-3986 to Done

## Acceptance criteria (from plan)

1. ✅ Check 11 emits 0 warnings on current `main` post-SMI-3984 (6 flagged overrides all clean)
2. ✅ Check 11 still fires when override truly fails to satisfy
3. ✅ Check 23 does not flag commit `8ec28dfa` (cite-in-body SMI-3099 + deps-only files)
4. ✅ Check 23 still flags synthetic `fix: cleanup (SMI-9999)` with no source files
5. ✅ Check 23 resolves `.git` via `git rev-parse --git-common-dir` in main repo + worktree contexts
6. ✅ git failures emit skip-as-pass instead of `fatal:` in warn output
7. ✅ Scope: 3 source files (audit-standards.mjs, helpers.mjs, test.ts) + 1 fixture. Zero new dependencies.
8. ✅ New vitest test file (40 cases) covers all fixes
9. ✅ No regression in other 23 audit-standards checks
10. ✅ Fix commit uses `fix(scripts):` prefix and touches `.mjs` source — does not retrigger Check 23 on itself

## Related

- Plan: `docs/internal/implementation/smi-3987-3986-audit-standards-fixes.md` (reviewed via plan-review-skill 2026-04-08)
- Linear: SMI-3987 + SMI-3986
- Predecessor retros: `docs/internal/retros/2026-04-09-smi-3984-npm-vuln-remediation.md`, `docs/internal/retros/2026-04-08-smi-3985-dependency-guard.md`

🤖 Generated via /launchpad → SPARC → plan-review → execute

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>