### PR TITLE
docs(dev): index mcp-tools-guide and email-templates

### DIFF
--- a/.claude/development/index.md
+++ b/.claude/development/index.md
@@ -12,11 +12,13 @@ Developer guides for local development, testing, and debugging.
 | [deployment-guide.md](deployment-guide.md) | Edge function deployment, CORS, website, monitoring & alerts |
 | [claude-flow-guide.md](claude-flow-guide.md) | Agent spawning, swarm orchestration, hive mind, SPARC modes |
 | [mcp-registry.md](mcp-registry.md) | MCP Registry publishing workflow and CI setup |
+| [mcp-tools-guide.md](mcp-tools-guide.md) | Skillsmith MCP server tool reference, authentication, CLI |
 | [benchmarks.md](benchmarks.md) | V3 migration performance benchmarks and metrics |
 | [edge-function-patterns.md](edge-function-patterns.md) | Supabase Edge Function patterns and Deno gotchas |
 | [neural-testing.md](neural-testing.md) | Neural integration testing guide |
 | [stripe-testing.md](stripe-testing.md) | Stripe CLI testing setup and webhooks |
 | [stripe-billing-portal.md](stripe-billing-portal.md) | Stripe billing portal integration |
+| [email-templates.md](email-templates.md) | Supabase Auth email template source (SMI-2758) |
 | [publishing-guide.md](publishing-guide.md) | npm package publishing, CI workflow, local fallback |
 | [vscode-publishing-guide.md](vscode-publishing-guide.md) | VS Code Marketplace publishing, PAT rotation, troubleshooting |
 | [cloudinary-guide.md](cloudinary-guide.md) | Blog image upload workflow, URL transforms, folder conventions |
@@ -30,7 +32,9 @@ Developer guides for local development, testing, and debugging.
 - **Deployment**: Edge function deploy commands, CORS config, website deployment
 - **Claude-Flow**: Agent types, swarm init, SPARC modes, hive mind configs
 - **MCP Registry**: Publishing, version sync, CI automation
+- **MCP Tools**: Skillsmith MCP tool reference, auth methods, CLI usage
 - **Benchmarks**: Query performance, embedding timing, migration metrics
 - **Edge Functions**: Deno patterns, Supabase query handling
 - **Neural Testing**: EmbeddingService tests, ONNX runtime validation
 - **Stripe**: Webhook testing, checkout flows, subscription testing, billing portal
+- **Email Templates**: Supabase Auth template source, Resend SMTP setup


### PR DESCRIPTION
## Summary
- Adds `mcp-tools-guide.md` and `email-templates.md` rows to the `.claude/development/index.md` developer-docs table — both files were tracked in the repo but absent from the index.
- Adds matching Quick Links entries so the bullet list stays consistent with the table.
- Single-file change, 4 lines added, no removals.

## Test plan
- [x] `docker exec skillsmith-dev-1 npx markdownlint-cli2 '.claude/development/index.md'` — 0 errors
- [x] `docker exec skillsmith-dev-1 npm run audit:standards` — 95% compliance (no regression)
- [ ] CI runs cleanly on a pure doc-only PR
- [ ] All 12 required checks pass or post skip-as-success (verifies the load-bearing assumption that `ci.yml`'s required checks satisfy branch protection when `ci.yml` is fully suppressed by `paths-ignore`)

## Note
Also serves as Finding #3 pre-merge verification for SMI-3997 carrier PR #493 (https://github.com/smith-horn/skillsmith/pull/493). The verification confirms the load-bearing assumption from the SMI-3997 SPARC plan that workflow-never-triggered equals context-missing for required checks under current branch protection — specifically, whether a file path that matches `ci.yml`'s `paths-ignore` list (here: `.claude/development/**`) yields skip-as-success for all 12 required checks, satisfying branch protection without the old `.md` touch workaround.

Refs: SMI-3997

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>