### PR TITLE
feat(mcp-server,core): SMI-4124 skill_pack_audit trigger-quality + namespace checks

### DIFF
--- a/packages/core/src/data/generic-triggers.json
+++ b/packages/core/src/data/generic-triggers.json
@@ -1,0 +1,35 @@
+{
+  "triggerWords": [
+    "spec",
+    "build",
+    "ship",
+    "test",
+    "deploy",
+    "plan",
+    "review",
+    "run",
+    "check",
+    "fix",
+    "update",
+    "create",
+    "add",
+    "remove",
+    "start",
+    "stop",
+    "send",
+    "get",
+    "list"
+  ],
+  "namespaces": [
+    "agent-skills",
+    "skills",
+    "tools",
+    "utils",
+    "helpers",
+    "misc",
+    "common",
+    "general"
+  ],
+  "locale": "en",
+  "notes": "English only in v1. Follow-up for i18n tracked in SMI-4125."
+}

--- a/packages/core/src/data/generic-triggers.ts
+++ b/packages/core/src/data/generic-triggers.ts
@@ -1,0 +1,32 @@
+/**
+ * @fileoverview Curated stoplist of generic trigger words and namespace tokens
+ * used by `skill_pack_audit` to flag false-trigger-prone skill names/descriptions
+ * and generic pack namespaces.
+ * @module @skillsmith/core/data/generic-triggers
+ * @see SMI-4124
+ *
+ * Edit `generic-triggers.json` (sibling file) to add entries — no code change
+ * required. i18n follow-up tracked in SMI-4125.
+ */
+
+import data from './generic-triggers.json' with { type: 'json' }
+
+/** Typed shape of the curated stoplist. */
+export interface GenericTriggersStoplist {
+  /** Common English/dev verbs that misfire Claude's skill-trigger heuristic. */
+  readonly triggerWords: readonly string[]
+  /** Generic pack namespaces (directory names) that should be domain-qualified. */
+  readonly namespaces: readonly string[]
+  /** ISO 639-1 locale code for this stoplist (v1: "en" only). */
+  readonly locale: string
+  /** Maintenance notes for editors. */
+  readonly notes: string
+}
+
+/** Frozen default stoplist. Consumers should treat as read-only. */
+export const GENERIC_TRIGGERS: GenericTriggersStoplist = Object.freeze({
+  triggerWords: Object.freeze([...data.triggerWords]),
+  namespaces: Object.freeze([...data.namespaces]),
+  locale: data.locale,
+  notes: data.notes,
+}) as GenericTriggersStoplist

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -224,6 +224,10 @@ export { parseRepoUrl, isGitHubUrl, type ParsedRepoUrl } from './utils/github-ur
 // SMI-2274: Safe filesystem operations
 export { safeWriteFile, SymlinkError, HardlinkError } from './utils/safe-fs.js'
 
+// SMI-4124: Curated stoplists for skill_pack_audit trigger-quality checks
+export { GENERIC_TRIGGERS } from './data/generic-triggers.js'
+export type { GenericTriggersStoplist } from './data/generic-triggers.js'
+
 // ============================================================================
 // LIVE SERVICES WORKTREE STUBS (Phase 0 - Conflict Prevention)
 // ============================================================================

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -18,6 +18,6 @@
     "incremental": true,
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
-  "include": ["src/**/*", "tests/**/*"],
+  "include": ["src/**/*", "src/**/*.json", "tests/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/mcp-server/src/tools/skill-pack-audit.helpers.ts
+++ b/packages/mcp-server/src/tools/skill-pack-audit.helpers.ts
@@ -1,0 +1,207 @@
+/**
+ * @fileoverview Generic trigger-word + namespace detection helpers for
+ * `skill_pack_audit`.
+ * @module @skillsmith/mcp-server/tools/skill-pack-audit.helpers
+ * @see SMI-4124
+ *
+ * Pure functions — no I/O, no database access. Tested via
+ * `tests/unit/skill-pack-audit.test.ts`.
+ */
+
+import type { GenericTriggersStoplist } from '@skillsmith/core'
+import { FIELD_LIMITS } from './validate.types.js'
+import type { GenericWordFlag, NamespaceFlag } from './skill-pack-audit.types.js'
+
+/**
+ * Coerce a description value into a plain string. `parseYamlFrontmatter` returns
+ * block-scalar (`description: |`) values as `string[]`, so we join with spaces.
+ * Non-string/non-string-array values yield an empty string.
+ */
+function coerceDescription(description: unknown): string {
+  if (typeof description === 'string') return description
+  if (Array.isArray(description)) {
+    return description.filter((item): item is string => typeof item === 'string').join(' ')
+  }
+  return ''
+}
+
+/** Split cleaned description text into lowercase word tokens. */
+function tokenizeForTriggers(text: string): string[] {
+  // Clamp to the same limit `validate` enforces to prevent quadratic scans
+  // on malicious oversized frontmatter.
+  const clamped = text.slice(0, FIELD_LIMITS.description)
+  // Strip common punctuation / markdown, collapse whitespace.
+  return clamped
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+}
+
+/**
+ * Detect generic trigger words in a skill's name and description.
+ *
+ * - Skill-name hits produce `severity: 'error'` (unconditional false-trigger magnet).
+ * - Description hits produce `severity: 'warning'`.
+ * - `suggested` is `${packDomain}-${token}` when a pack domain is available,
+ *   otherwise `null`.
+ *
+ * @param description - Raw description value from frontmatter (may be string
+ *                      or string[] from block-scalar parsing, or other).
+ * @param skillName   - Skill's `name` frontmatter value (falls back to dir name).
+ * @param packDomain  - Inferred pack domain, or `null` when indeterminate.
+ * @param stoplist    - Curated stoplist from `@skillsmith/core`.
+ * @returns Flags (name errors first, then description warnings).
+ */
+export function detectGenericTriggerWords(
+  description: unknown,
+  skillName: string,
+  packDomain: string | null,
+  stoplist: GenericTriggersStoplist
+): GenericWordFlag[] {
+  const flags: GenericWordFlag[] = []
+  const triggerSet = new Set(stoplist.triggerWords.map((w) => w.toLowerCase()))
+
+  // Name check (error): tokenize on non-alphanumerics so "spec-builder" flags both.
+  const nameTokens = new Set(
+    skillName
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length > 0)
+  )
+  for (const token of nameTokens) {
+    if (triggerSet.has(token)) {
+      flags.push({
+        token,
+        location: 'name',
+        severity: 'error',
+        suggested: packDomain ? `${packDomain}-${token}` : null,
+        reason:
+          `Skill name contains generic trigger word "${token}". ` +
+          `This causes Claude's skill-trigger heuristic to misfire on unrelated prompts. ` +
+          (packDomain
+            ? `Rename to "${packDomain}-${token}" to qualify the scope.`
+            : `Qualify with a domain prefix (e.g. "planning-${token}").`),
+      })
+    }
+  }
+
+  // Description check (warning): full-text tokenization.
+  const descText = coerceDescription(description)
+  if (descText.length > 0) {
+    const descTokens = tokenizeForTriggers(descText)
+    const seen = new Set<string>()
+    for (const token of descTokens) {
+      if (seen.has(token)) continue
+      if (nameTokens.has(token)) continue // already flagged as name error
+      if (triggerSet.has(token)) {
+        seen.add(token)
+        flags.push({
+          token,
+          location: 'description',
+          severity: 'warning',
+          suggested: packDomain ? `${packDomain}-${token}` : null,
+          reason:
+            `Description contains generic trigger word "${token}". ` +
+            `Consider rewording or qualifying the skill's activation phrasing to ` +
+            `avoid false-positive skill triggers.`,
+        })
+      }
+    }
+  }
+
+  return flags
+}
+
+/**
+ * Aggregate per-skill `tags` across a pack to derive a pack domain.
+ *
+ * Priority:
+ * 1. If `packName` ends with `-skills` and is not itself generic, strip the
+ *    suffix and return the prefix (e.g. `planning-skills` → `planning`).
+ * 2. Otherwise, compute the mode of non-generic tags across all skills.
+ * 3. Returns `null` when no domain can be inferred with confidence.
+ *
+ * @param packName  - Pack directory name.
+ * @param allSkills - Per-skill tag arrays (undefined / non-array → ignored).
+ * @param stoplist  - Curated stoplist (for generic-tag filtering).
+ */
+export function derivePackDomain(
+  packName: string,
+  allSkills: Array<{ tags?: unknown }>,
+  stoplist: GenericTriggersStoplist
+): string | null {
+  const genericNamespaces = new Set(stoplist.namespaces.map((n) => n.toLowerCase()))
+  const genericWords = new Set(stoplist.triggerWords.map((w) => w.toLowerCase()))
+
+  // Strategy 1: strip `-skills` suffix from non-generic pack name.
+  const lowerPack = packName.toLowerCase()
+  if (lowerPack.endsWith('-skills') && !genericNamespaces.has(lowerPack)) {
+    const prefix = lowerPack.slice(0, -'-skills'.length)
+    if (prefix.length > 0 && !genericNamespaces.has(prefix) && !genericWords.has(prefix)) {
+      return prefix
+    }
+  }
+
+  // Strategy 2: mode of per-skill tags.
+  const counts = new Map<string, number>()
+  for (const skill of allSkills) {
+    if (!Array.isArray(skill.tags)) continue
+    for (const raw of skill.tags) {
+      if (typeof raw !== 'string') continue
+      const tag = raw.toLowerCase().trim()
+      if (tag.length === 0) continue
+      if (genericNamespaces.has(tag) || genericWords.has(tag)) continue
+      counts.set(tag, (counts.get(tag) ?? 0) + 1)
+    }
+  }
+
+  if (counts.size === 0) return null
+
+  let bestTag: string | null = null
+  let bestCount = 0
+  for (const [tag, count] of counts) {
+    if (count > bestCount) {
+      bestTag = tag
+      bestCount = count
+    }
+  }
+
+  // Require the mode to cover at least 2 skills (or the only skill) to avoid
+  // picking random one-offs.
+  const minSkills = allSkills.length >= 2 ? 2 : 1
+  return bestCount >= minSkills ? bestTag : null
+}
+
+/**
+ * Detect a generic pack namespace.
+ *
+ * @returns NamespaceFlag when the pack name matches a generic namespace,
+ *          otherwise null.
+ */
+export function detectGenericNamespace(
+  packName: string,
+  allSkills: Array<{ tags?: unknown }>,
+  stoplist: GenericTriggersStoplist
+): NamespaceFlag | null {
+  const lowerPack = packName.toLowerCase()
+  const genericNamespaces = new Set(stoplist.namespaces.map((n) => n.toLowerCase()))
+
+  if (!genericNamespaces.has(lowerPack)) return null
+
+  const domain = derivePackDomain(packName, allSkills, stoplist)
+  const suggested = domain ? `${domain}-skills` : null
+  const reason = suggested
+    ? `Pack name "${packName}" is a generic namespace. Rename to "${suggested}" ` +
+      `to reflect its domain (inferred from per-skill tags).`
+    : `Pack name "${packName}" is a generic namespace and per-skill tags do not ` +
+      `converge on a clear domain. Rename to "<domain>-skills" where <domain> is ` +
+      `a specific scope (e.g. "planning-skills", "cicd-skills").`
+
+  return {
+    packName,
+    severity: 'warning',
+    suggested,
+    reason,
+  }
+}

--- a/packages/mcp-server/src/tools/skill-pack-audit.ts
+++ b/packages/mcp-server/src/tools/skill-pack-audit.ts
@@ -20,9 +20,20 @@
 
 import { z } from 'zod'
 import { promises as fs } from 'fs'
-import { join, resolve, sep } from 'path'
-import { SkillsmithError, ErrorCodes } from '@skillsmith/core'
+import { basename, join, resolve, sep } from 'path'
+import { SkillsmithError, ErrorCodes, GENERIC_TRIGGERS } from '@skillsmith/core'
 import { parseYamlFrontmatter, hasPathTraversal } from './validate.helpers.js'
+import {
+  detectGenericTriggerWords,
+  detectGenericNamespace,
+  derivePackDomain,
+} from './skill-pack-audit.helpers.js'
+import type {
+  GenericWordFlag,
+  NamespaceFlag,
+  TriggerQuality,
+  TriggerQualityEntry,
+} from './skill-pack-audit.types.js'
 import type { ToolContext } from '../context.js'
 
 // ============================================================================
@@ -40,9 +51,18 @@ export const skillPackAuditInputSchema = z.object({
       'Absolute path to the skill pack root directory. ' +
         'Must contain a skills/ subdirectory with skill folders each containing SKILL.md.'
     ),
+  check_trigger_quality: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      'When true (default), also flag generic trigger words in skill name/description ' +
+        'and generic pack namespaces with rename suggestions. Set false for ' +
+        'version-drift-only audits (legacy response shape). SMI-4124.'
+    ),
 })
 
-export type SkillPackAuditInput = z.infer<typeof skillPackAuditInputSchema>
+export type SkillPackAuditInput = z.input<typeof skillPackAuditInputSchema>
 
 /**
  * Drift status for a single skill in the pack
@@ -84,6 +104,18 @@ export interface SkillPackAuditResponse {
   noRegistryDataCount: number
   /** Per-skill audit results, sorted alphabetically by name */
   skills: PackSkillEntry[]
+  /**
+   * SMI-4124: Trigger-quality analysis across the pack (generic trigger words
+   * in skill names/descriptions). Present when `check_trigger_quality` is `true`
+   * (default). Omitted when the caller explicitly opts out.
+   */
+  triggerQuality?: TriggerQuality
+  /**
+   * SMI-4124: Namespace-quality flag on the pack itself. Present (possibly
+   * `null`) when `check_trigger_quality` is `true`. `null` = clean pack name.
+   * Omitted when the caller opts out.
+   */
+  namespaceQuality?: NamespaceFlag | null
 }
 
 // ============================================================================
@@ -96,9 +128,12 @@ export interface SkillPackAuditResponse {
 export const skillPackAuditToolSchema = {
   name: 'skill_pack_audit' as const,
   description:
-    'Audit a skill pack directory for version drift by comparing each bundled SKILL.md ' +
-    'version against the Skillsmith registry cache. Reports which skills are current, ' +
-    'outdated, ahead, or missing from the registry. ' +
+    'Audit a skill pack directory for (a) version drift — bundled SKILL.md versions vs. ' +
+    'the Skillsmith registry cache — and (b) trigger-quality issues — generic trigger ' +
+    'words in skill names/descriptions and generic pack namespaces that misfire ' +
+    "Claude's skill-trigger heuristic (SMI-4124). Response is additive: new " +
+    'triggerQuality and namespaceQuality fields appear when check_trigger_quality is ' +
+    'true (default); existing fields (skills, driftCount, etc.) are unchanged. ' +
     'Requires Individual tier or higher.',
   inputSchema: {
     type: 'object' as const,
@@ -107,6 +142,14 @@ export const skillPackAuditToolSchema = {
         type: 'string',
         description:
           'Absolute path to the skill pack root directory (must contain a skills/ subdirectory).',
+      },
+      check_trigger_quality: {
+        type: 'boolean',
+        default: true,
+        description:
+          'When true (default), also flag generic trigger words and generic pack ' +
+          'namespaces with rename suggestions. Set false for version-drift-only audits ' +
+          '(legacy response shape — triggerQuality and namespaceQuality fields omitted).',
       },
     },
     required: ['pack_path'],
@@ -164,6 +207,8 @@ export async function executeSkillPackAudit(
 
   const packPath = resolve(input.pack_path)
   const skillsDir = join(packPath, 'skills')
+  const packName = basename(packPath)
+  const checkTriggerQuality = input.check_trigger_quality !== false
 
   // Discover subdirectories in skills/
   let skillDirNames: string[]
@@ -185,6 +230,10 @@ export async function executeSkillPackAudit(
   }
 
   const skills: PackSkillEntry[] = []
+  // SMI-4124: parallel accumulators for trigger-quality analysis.
+  // We keep these outside PackSkillEntry to preserve the legacy response shape
+  // for callers who opt out of trigger-quality via check_trigger_quality: false.
+  const skillMeta: Array<{ name: string; description: unknown; tags?: unknown }> = []
 
   for (const dirName of skillDirNames) {
     const skillMdPath = join(skillsDir, dirName, 'SKILL.md')
@@ -242,6 +291,14 @@ export async function executeSkillPackAudit(
     }
 
     skills.push({ name, bundledVersion, registryVersion, skillId, status })
+    // Capture description/tags for SMI-4124 trigger-quality analysis. We read
+    // these out of metadata (already parsed) regardless of the flag, since the
+    // cost is trivial; the analysis itself is gated below.
+    skillMeta.push({
+      name,
+      description: metadata?.description,
+      tags: metadata?.tags,
+    })
   }
 
   skills.sort((a, b) => a.name.localeCompare(b.name))
@@ -249,11 +306,104 @@ export async function executeSkillPackAudit(
   const driftCount = skills.filter((s) => s.status === 'outdated' || s.status === 'ahead').length
   const noRegistryDataCount = skills.filter((s) => s.status === 'no_registry_data').length
 
+  // SMI-4124: Trigger-quality + namespace analysis (additive response growth).
+  // When the caller opts out, we omit both fields so the response shape matches
+  // the pre-extension contract byte-for-byte.
+  if (!checkTriggerQuality) {
+    return {
+      packPath,
+      skillCount: skills.length,
+      driftCount,
+      noRegistryDataCount,
+      skills,
+    }
+  }
+
+  const stoplist = GENERIC_TRIGGERS
+  const packDomain = derivePackDomain(packName, skillMeta, stoplist)
+
+  // Per-skill flags (sorted alphabetically by skill name to match `skills`).
+  const sortedMeta = [...skillMeta].sort((a, b) => a.name.localeCompare(b.name))
+  const triggerEntries: TriggerQualityEntry[] = []
+  const nameFlagsByToken = new Map<string, GenericWordFlag[]>()
+
+  for (const meta of sortedMeta) {
+    const flags = detectGenericTriggerWords(meta.description, meta.name, packDomain, stoplist)
+    if (flags.length > 0) {
+      triggerEntries.push({ id: meta.name, flags })
+      // Track name-level flags so we can dedup against a namespace hit below.
+      for (const flag of flags) {
+        if (flag.location === 'name') {
+          const list = nameFlagsByToken.get(flag.token) ?? []
+          list.push(flag)
+          nameFlagsByToken.set(flag.token, list)
+        }
+      }
+    }
+  }
+
+  // Namespace flag + dedup: if the pack name is generic AND a skill-name flag
+  // exists for the same root token, drop the duplicate skill-name error and
+  // fold its reason into the namespace warning's reason.
+  let namespaceFlag = detectGenericNamespace(packName, skillMeta, stoplist)
+  if (namespaceFlag) {
+    const packToken = packName.toLowerCase()
+    // Check if any skill-name flag shares a token with the pack name. Typical
+    // case: pack "skills" and a skill named "skills" — not common — but also
+    // covers partial-token overlap like pack "tools" and skill "build-tools"
+    // (namespace covers the generic concern; skill-name flag is redundant).
+    const overlappingTokens: string[] = []
+    for (const [token] of nameFlagsByToken) {
+      if (packToken === token || packToken.includes(token) || token.includes(packToken)) {
+        overlappingTokens.push(token)
+      }
+    }
+    if (overlappingTokens.length > 0) {
+      // Remove the overlapping name flags from triggerEntries.
+      for (let i = triggerEntries.length - 1; i >= 0; i--) {
+        const entry = triggerEntries[i]!
+        entry.flags = entry.flags.filter(
+          (f) => !(f.location === 'name' && overlappingTokens.includes(f.token))
+        )
+        if (entry.flags.length === 0) {
+          triggerEntries.splice(i, 1)
+        }
+      }
+      // Merge the removed-flag reasoning into the namespace reason.
+      namespaceFlag = {
+        ...namespaceFlag,
+        reason:
+          namespaceFlag.reason +
+          ` Also applies to skill(s) whose name contains the same generic token(s): ` +
+          overlappingTokens.map((t) => `"${t}"`).join(', ') +
+          ` — resolved by renaming the pack namespace.`,
+      }
+    }
+  }
+
+  let totalFlags = 0
+  let errorCount = 0
+  let warningCount = 0
+  for (const entry of triggerEntries) {
+    for (const flag of entry.flags) {
+      totalFlags++
+      if (flag.severity === 'error') errorCount++
+      else warningCount++
+    }
+  }
+
+  const triggerQuality: TriggerQuality = {
+    skills: triggerEntries,
+    summary: { totalFlags, errorCount, warningCount },
+  }
+
   return {
     packPath,
     skillCount: skills.length,
     driftCount,
     noRegistryDataCount,
     skills,
+    triggerQuality,
+    namespaceQuality: namespaceFlag,
   }
 }

--- a/packages/mcp-server/src/tools/skill-pack-audit.types.ts
+++ b/packages/mcp-server/src/tools/skill-pack-audit.types.ts
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview Type definitions for the trigger-quality + namespace extension
+ * of the `skill_pack_audit` tool.
+ * @module @skillsmith/mcp-server/tools/skill-pack-audit.types
+ * @see SMI-4124
+ */
+
+/**
+ * A single generic-word flag on a skill's name or description.
+ */
+export interface GenericWordFlag {
+  /** The flagged token (lowercased). */
+  token: string
+  /** Where the flag was detected. */
+  location: 'name' | 'description'
+  /**
+   * Severity:
+   * - `error` for skill-name hits (unconditional false-trigger magnet).
+   * - `warning` for description-only hits.
+   */
+  severity: 'error' | 'warning'
+  /**
+   * Suggested rename of the form `${packDomain}-${token}`, or `null` when
+   * the pack domain cannot be inferred.
+   */
+  suggested: string | null
+  /** Human-readable explanation of why the token was flagged. */
+  reason: string
+}
+
+/**
+ * A single generic-namespace flag on the pack itself.
+ */
+export interface NamespaceFlag {
+  /** The flagged pack name (directory name). */
+  packName: string
+  /** Always `warning` — namespace is author-level guidance, not a hard error. */
+  severity: 'warning'
+  /**
+   * Suggested rename of the form `${derivedDomain}-skills`, or `null` when
+   * the domain cannot be inferred from per-skill tags.
+   */
+  suggested: string | null
+  /** Human-readable explanation. */
+  reason: string
+}
+
+/**
+ * Per-skill trigger-quality entry. `id` matches `PackSkillEntry.name`
+ * within the same response (the skill's frontmatter `name`, falling back to
+ * the directory name).
+ */
+export interface TriggerQualityEntry {
+  /** Skill identifier (matches PackSkillEntry.name). */
+  id: string
+  /** Generic-word flags detected on this skill. */
+  flags: GenericWordFlag[]
+}
+
+/**
+ * Aggregate trigger-quality result across the whole pack.
+ * Always present in responses when the check ran (even if empty).
+ */
+export interface TriggerQuality {
+  /** Per-skill flag entries. Empty array = clean pack. */
+  skills: TriggerQualityEntry[]
+  /** Roll-up counters. */
+  summary: {
+    totalFlags: number
+    errorCount: number
+    warningCount: number
+  }
+}

--- a/packages/mcp-server/src/tools/validate.helpers.ts
+++ b/packages/mcp-server/src/tools/validate.helpers.ts
@@ -29,6 +29,10 @@ export function parseYamlFrontmatter(content: string): Record<string, unknown> |
   let currentKey: string | null = null
   let arrayBuffer: string[] = []
   let inArray = false
+  // SMI-4124: block-scalar (description: | or >) continuation collection.
+  // YAML block scalars indent their content relative to the key; we collect
+  // any non-key, non-list line as a text line while inArray is true.
+  let inBlockScalar = false
 
   for (const line of lines) {
     const trimmedLine = line.trim()
@@ -44,11 +48,20 @@ export function parseYamlFrontmatter(content: string): Record<string, unknown> |
           .trim()
           .replace(/^["']|["']$/g, '')
         arrayBuffer.push(value)
+        inBlockScalar = false
       }
       continue
     }
 
     const colonIndex = trimmedLine.indexOf(':')
+    if (colonIndex <= 0) {
+      // SMI-4124: block-scalar continuation line (description: | style).
+      // Append as an array entry so coerceDescription can join it.
+      if (currentKey && inArray && inBlockScalar) {
+        arrayBuffer.push(trimmedLine)
+      }
+      continue
+    }
     if (colonIndex > 0) {
       if (currentKey && inArray && arrayBuffer.length > 0) {
         result[currentKey] = arrayBuffer
@@ -62,7 +75,9 @@ export function parseYamlFrontmatter(content: string): Record<string, unknown> |
         currentKey = key
         inArray = true
         arrayBuffer = []
+        inBlockScalar = value === '|' || value === '>'
       } else {
+        inBlockScalar = false
         currentKey = null
         inArray = false
 
@@ -403,3 +418,4 @@ export function validateDependencies(
 
   return errors
 }
+

--- a/packages/mcp-server/src/tools/validate.helpers.ts
+++ b/packages/mcp-server/src/tools/validate.helpers.ts
@@ -418,4 +418,3 @@ export function validateDependencies(
 
   return errors
 }
-

--- a/packages/mcp-server/tests/unit/skill-pack-audit.test.ts
+++ b/packages/mcp-server/tests/unit/skill-pack-audit.test.ts
@@ -461,4 +461,289 @@ describe('skill_pack_audit', () => {
       expect(result.skills[0].status).toBe('outdated')
     })
   })
+
+  // ============================================================================
+  // SMI-4124: Trigger-quality + namespace detection
+  // ============================================================================
+
+  describe('SMI-4124 trigger-quality + namespace checks', () => {
+    async function writeFullSkillMd(
+      dir: string,
+      opts: {
+        name: string
+        description?: string
+        version?: string
+        tags?: string[]
+      }
+    ): Promise<void> {
+      const lines = ['---', `name: ${opts.name}`]
+      if (opts.description !== undefined) lines.push(`description: ${opts.description}`)
+      if (opts.version !== undefined) lines.push(`version: ${opts.version}`)
+      if (opts.tags !== undefined) {
+        lines.push('tags:')
+        for (const tag of opts.tags) lines.push(`  - ${tag}`)
+      }
+      lines.push('---', '')
+      await fs.writeFile(join(dir, 'SKILL.md'), lines.join('\n'))
+    }
+
+    /**
+     * Rename the pack testDir to a specific basename since namespace detection
+     * uses basename(packPath). We create a sibling dir with the desired name.
+     */
+    async function makePackWithName(packName: string): Promise<string> {
+      const parent = await fs.mkdtemp(join(tmpdir(), 'pack-name-test-' + Date.now() + '-'))
+      const packDir = join(parent, packName)
+      await fs.mkdir(packDir)
+      await fs.mkdir(join(packDir, 'skills'))
+      return packDir
+    }
+
+    it('flags a generic trigger word in skill name as error (case 1)', async () => {
+      // Pack name "planning-skills" -> derives domain "planning"
+      const packDir = await makePackWithName('planning-skills')
+      const sDir = join(packDir, 'skills', 'spec')
+      await fs.mkdir(sDir)
+      await writeFullSkillMd(sDir, { name: 'spec', description: 'Unrelated description.' })
+
+      const result = await executeSkillPackAudit({ pack_path: packDir }, toolContext)
+
+      expect(result.triggerQuality).toBeDefined()
+      const entry = result.triggerQuality!.skills.find((s) => s.id === 'spec')
+      expect(entry).toBeDefined()
+      const nameFlag = entry!.flags.find((f) => f.location === 'name' && f.token === 'spec')
+      expect(nameFlag).toBeDefined()
+      expect(nameFlag!.severity).toBe('error')
+      expect(nameFlag!.suggested).toBe('planning-spec')
+      expect(result.triggerQuality!.summary.errorCount).toBeGreaterThanOrEqual(1)
+
+      await fs.rm(packDir, { recursive: true, force: true })
+    })
+
+    it('flags a generic trigger word in description only as warning (case 2)', async () => {
+      const packDir = await makePackWithName('planning-skills')
+      const sDir = join(packDir, 'skills', 'roadmap-planner')
+      await fs.mkdir(sDir)
+      // "build" in description, not in name
+      await writeFullSkillMd(sDir, {
+        name: 'roadmap-planner',
+        description: 'Helps you build out a product roadmap.',
+      })
+
+      const result = await executeSkillPackAudit({ pack_path: packDir }, toolContext)
+
+      const entry = result.triggerQuality!.skills.find((s) => s.id === 'roadmap-planner')
+      expect(entry).toBeDefined()
+      const descFlag = entry!.flags.find((f) => f.token === 'build')
+      expect(descFlag).toBeDefined()
+      expect(descFlag!.location).toBe('description')
+      expect(descFlag!.severity).toBe('warning')
+      expect(descFlag!.suggested).toBe('planning-build')
+
+      await fs.rm(packDir, { recursive: true, force: true })
+    })
+
+    it('tokenizes block-scalar description correctly (case 3)', async () => {
+      const packDir = await makePackWithName('planning-skills')
+      const sDir = join(packDir, 'skills', 'roadmap')
+      await fs.mkdir(sDir)
+      // Block-scalar description (description: |) — parser returns string[]
+      const md =
+        '---\n' +
+        'name: roadmap\n' +
+        'description: |\n' +
+        '  First line mentioning build.\n' +
+        '  Second line mentioning test.\n' +
+        '---\n'
+      await fs.writeFile(join(sDir, 'SKILL.md'), md)
+
+      const result = await executeSkillPackAudit({ pack_path: packDir }, toolContext)
+
+      const entry = result.triggerQuality!.skills.find((s) => s.id === 'roadmap')
+      expect(entry).toBeDefined()
+      const tokens = entry!.flags.map((f) => f.token)
+      expect(tokens).toEqual(expect.arrayContaining(['build', 'test']))
+      // Both are description-level warnings
+      for (const flag of entry!.flags) {
+        expect(flag.location).toBe('description')
+        expect(flag.severity).toBe('warning')
+      }
+
+      await fs.rm(packDir, { recursive: true, force: true })
+    })
+
+    it('clamps oversized description (case 4 — no ReDoS)', async () => {
+      const packDir = await makePackWithName('planning-skills')
+      const sDir = join(packDir, 'skills', 'roadmap')
+      await fs.mkdir(sDir)
+      // Craft >> FIELD_LIMITS.description (1024), embed a trigger word LATE.
+      // If clamp works, "spec" (past byte 1024) should NOT be detected.
+      const padding = 'x '.repeat(700) // ~1400 chars
+      const md =
+        '---\n' + 'name: roadmap\n' + `description: ${padding}spec at the tail.\n` + '---\n'
+      await fs.writeFile(join(sDir, 'SKILL.md'), md)
+
+      const start = Date.now()
+      const result = await executeSkillPackAudit({ pack_path: packDir }, toolContext)
+      const elapsed = Date.now() - start
+      expect(elapsed).toBeLessThan(2000) // nowhere near pathological
+
+      const entry = result.triggerQuality!.skills.find((s) => s.id === 'roadmap')
+      // Either no flags, or flags from the early padding (which has no triggers).
+      if (entry) {
+        const hasSpec = entry.flags.some((f) => f.token === 'spec')
+        expect(hasSpec).toBe(false)
+      }
+
+      await fs.rm(packDir, { recursive: true, force: true })
+    })
+
+    it('derives pack domain from per-skill tags consensus (case 5)', async () => {
+      // Generic namespace "agent-skills" — cannot strip suffix reliably since
+      // it's itself generic. Use tags consensus instead.
+      const packDir = await makePackWithName('agent-skills')
+      const s1 = join(packDir, 'skills', 'research-helper')
+      const s2 = join(packDir, 'skills', 'search-helper')
+      await fs.mkdir(s1)
+      await fs.mkdir(s2)
+      await writeFullSkillMd(s1, {
+        name: 'research-helper',
+        description: 'Assists with research.',
+        tags: ['research', 'retrieval'],
+      })
+      await writeFullSkillMd(s2, {
+        name: 'search-helper',
+        description: 'Helps with search.',
+        tags: ['research', 'retrieval'],
+      })
+
+      const result = await executeSkillPackAudit({ pack_path: packDir }, toolContext)
+
+      expect(result.namespaceQuality).not.toBeNull()
+      expect(result.namespaceQuality!.suggested).toMatch(/^(research|retrieval)-skills$/)
+
+      await fs.rm(packDir, { recursive: true, force: true })
+    })
+
+    it('returns null suggestion when no tag consensus (case 6)', async () => {
+      const packDir = await makePackWithName('tools')
+      const s1 = join(packDir, 'skills', 'alpha')
+      const s2 = join(packDir, 'skills', 'beta')
+      await fs.mkdir(s1)
+      await fs.mkdir(s2)
+      // No tags -> no consensus
+      await writeFullSkillMd(s1, { name: 'alpha', description: 'Alpha skill.' })
+      await writeFullSkillMd(s2, { name: 'beta', description: 'Beta skill.' })
+
+      const result = await executeSkillPackAudit({ pack_path: packDir }, toolContext)
+
+      expect(result.namespaceQuality).not.toBeNull()
+      expect(result.namespaceQuality!.suggested).toBeNull()
+      expect(result.namespaceQuality!.reason).toMatch(/do not converge/i)
+
+      await fs.rm(packDir, { recursive: true, force: true })
+    })
+
+    it('returns present-but-empty triggerQuality and null namespace for clean pack (case 7)', async () => {
+      const packDir = await makePackWithName('planning-skills')
+      const sDir = join(packDir, 'skills', 'roadmap-planner')
+      await fs.mkdir(sDir)
+      await writeFullSkillMd(sDir, {
+        name: 'roadmap-planner',
+        description: 'Assists with roadmaps.',
+      })
+
+      const result = await executeSkillPackAudit({ pack_path: packDir }, toolContext)
+
+      expect(result.triggerQuality).toBeDefined()
+      expect(result.triggerQuality!.skills).toEqual([])
+      expect(result.triggerQuality!.summary).toEqual({
+        totalFlags: 0,
+        errorCount: 0,
+        warningCount: 0,
+      })
+      expect(result.namespaceQuality).toBeNull()
+
+      await fs.rm(packDir, { recursive: true, force: true })
+    })
+
+    it('dedups namespace + same skill-name token into one merged flag (case 8)', async () => {
+      // Pack "tools" is generic; skill named "tools" triggers both flags.
+      const packDir = await makePackWithName('tools')
+      const sDir = join(packDir, 'skills', 'tools')
+      await fs.mkdir(sDir)
+      await writeFullSkillMd(sDir, {
+        name: 'tools',
+        description: 'A meta skill.',
+        tags: ['research', 'retrieval'],
+      })
+      const sDir2 = join(packDir, 'skills', 'research-helper')
+      await fs.mkdir(sDir2)
+      await writeFullSkillMd(sDir2, {
+        name: 'research-helper',
+        description: 'Helps with research.',
+        tags: ['research', 'retrieval'],
+      })
+
+      const result = await executeSkillPackAudit({ pack_path: packDir }, toolContext)
+
+      expect(result.namespaceQuality).not.toBeNull()
+      // The "tools" skill-name flag should have been merged into the namespace.
+      const toolsEntry = result.triggerQuality!.skills.find((s) => s.id === 'tools')
+      if (toolsEntry) {
+        const hasToolsNameFlag = toolsEntry.flags.some(
+          (f) => f.location === 'name' && f.token === 'tools'
+        )
+        expect(hasToolsNameFlag).toBe(false)
+      }
+      // Merged reason references the overlap
+      expect(result.namespaceQuality!.reason).toMatch(/tools/)
+
+      await fs.rm(packDir, { recursive: true, force: true })
+    })
+
+    it('omits trigger-quality fields when check_trigger_quality=false (case 9)', async () => {
+      const packDir = await makePackWithName('tools')
+      const sDir = join(packDir, 'skills', 'spec')
+      await fs.mkdir(sDir)
+      await writeFullSkillMd(sDir, { name: 'spec', description: 'Test.', version: '1.0.0' })
+
+      const result = await executeSkillPackAudit(
+        { pack_path: packDir, check_trigger_quality: false },
+        toolContext
+      )
+
+      expect('triggerQuality' in result).toBe(false)
+      expect('namespaceQuality' in result).toBe(false)
+      // Legacy fields unchanged
+      expect(result.skillCount).toBe(1)
+      expect(Array.isArray(result.skills)).toBe(true)
+
+      await fs.rm(packDir, { recursive: true, force: true })
+    })
+
+    it('preserves legacy response shape for version-drift-only callers (case 10)', async () => {
+      // Simulate a "clean" version-drift audit with the opt-out flag.
+      const packDir = await makePackWithName('planning-skills')
+      const sDir = join(packDir, 'skills', 'roadmap-planner')
+      await fs.mkdir(sDir)
+      await writeFullSkillMd(sDir, {
+        name: 'roadmap-planner',
+        description: 'Clean.',
+        version: '1.0.0',
+      })
+
+      const result = await executeSkillPackAudit(
+        { pack_path: packDir, check_trigger_quality: false },
+        toolContext
+      )
+
+      // Exact legacy keys only
+      expect(Object.keys(result).sort()).toEqual(
+        ['driftCount', 'noRegistryDataCount', 'packPath', 'skillCount', 'skills'].sort()
+      )
+
+      await fs.rm(packDir, { recursive: true, force: true })
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Extend skill_pack_audit with generic-trigger-word and namespace audits
- Non-destructive — emits flags + ${packDomain}-${token} rename suggestions
- Block-scalar YAML description handling in validate.helpers parser

## Test plan
- [x] docker exec skillsmith-dev-1 npm run build
- [x] docker exec skillsmith-dev-1 npm run preflight
- [x] 35/35 skill-pack-audit tests pass
- [x] 75/75 validate tests pass (no regression from YAML parser change)
- [x] audit:standards 95% (40 pass / 2 warn baseline / 0 fail)
- [ ] CI green on all 12 required checks
- [ ] Manual MCP end-to-end against a real agent-skills pack

Linear: SMI-4124
Follow-up: SMI-4125

🤖 Generated with Claude Code