### PR TITLE
config: add SUPABASE_POOLER_URL to env schema (SMI-4118)

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -309,6 +309,16 @@ SUPABASE_SERVICE_ROLE_KEY=
 # @type=string @required @sensitive
 SUPABASE_DB_PASSWORD=
 
+# Supabase Pooler Connection URL - Transaction pooler (port 6543)
+# Used for psql queries that time out through PostgREST (e.g. audit_logs LIKE scans
+# on event_type — PostgREST aborts at statement_timeout 8s with code 57014).
+# Shared pooler (IPv4): postgresql://postgres.<ref>:[YOUR-PASSWORD]@aws-<n>-<region>.pooler.supabase.com:6543/postgres
+# Dedicated pooler (IPv6): postgresql://postgres:[YOUR-PASSWORD]@db.<ref>.supabase.co:6543/postgres
+# Leave [YOUR-PASSWORD] as literal placeholder; callers substitute $SUPABASE_DB_PASSWORD at runtime
+# (e.g. via PGPASSWORD env var with psql -h host -U user args).
+# @type=string(startsWith=postgresql://) @required=false @sensitive
+SUPABASE_POOLER_URL=
+
 # =============================================================================
 # POSTHOG TELEMETRY (Phase 6A)
 # =============================================================================


### PR DESCRIPTION
## Summary
- Adds `SUPABASE_POOLER_URL` to `.env.schema` with sensitive/optional annotations and documentation for both Shared (IPv4) and Dedicated (IPv6) pooler forms.
- No code path consumes the variable yet — schema-only. Callers will substitute `$SUPABASE_DB_PASSWORD` at runtime via `PGPASSWORD` (never interpolated into the URL literal).

## Why
PostgREST aborts LIKE scans on `audit_logs.event_type` at `statement_timeout` 8s (code 57014). SMI-4118 Wave 1 spot-check verification needs direct pooler access. Surfaced during 2026-04-12 validation run.

[skip-impl-check]

## Test plan
- [ ] `varlock load` confirms new var is recognized and masked as sensitive
- [ ] Branch protection contexts green (config-only)
- [ ] No secret values introduced (schema annotation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)