### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ wrangler.toml.local
 # Claude Code runtime files
 .claude/memory.db
 .claude/hive-mind/
+.claude/scheduled_tasks.lock
 
 # Logarithmic quality score recalculation (internal tooling)
 supabase/migrations/015_recalculate_quality_scores.sql


### PR DESCRIPTION
## Summary
- Add `.claude/scheduled_tasks.lock` to `.gitignore`

Claude Code runtime lock file from the ScheduleWakeup feature. Local-only, surfaces in `git status` otherwise.

[skip-impl-check]

## Test plan
- [x] `git status` clean after ignore rule added