### PR TITLE
docs: bump internal submodule for SMI-4124 retro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ wrangler.toml.local
 # Claude Code runtime files
 .claude/memory.db
 .claude/hive-mind/
+.claude/scheduled_tasks.lock
 
 # Logarithmic quality score recalculation (internal tooling)
 supabase/migrations/015_recalculate_quality_scores.sql


### PR DESCRIPTION
Bumps docs/internal to pick up post-merge retro for SMI-4124 / PR #505.

🤖 Generated with Claude Code