### PR TITLE
docs: SMI-4122/4123 sync — website api docs + mcp-server CHANGELOG

### DIFF
--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/mcp-server` are documented here.
 
+## [Unreleased]
+
+- **Fixed**: `webhook_configure` and `api_key_manage` backing tables restored (SMI-4123). In preview until production migration (SMI-4135).
+
 ## v0.4.7
 
 - **Fix: startup crash for new installs** — Bumped `@skillsmith/core` dependency floor from `^0.4.16` to `^0.4.17` to ensure `SkillInstallationService` export is available. Users with cached `core@0.4.16` saw a fatal `SyntaxError` on startup.

--- a/packages/website/src/pages/docs/api.astro
+++ b/packages/website/src/pages/docs/api.astro
@@ -260,6 +260,111 @@ if (result.success) {
 
   <pre><code>{`async list(): Promise<InstalledSkill[]>`}</code></pre>
 
+  <h2>Enterprise Tools</h2>
+
+  <p>
+    The following tools are available on the Enterprise tier via the MCP server.
+    They are currently <em>in preview — availability pending production migration</em>
+    (tracked in SMI-4135). Backing tables are restored in staging (SMI-4123).
+  </p>
+
+  <h3>webhook_configure</h3>
+
+  <p>
+    Configure HMAC-SHA256 signed webhooks for skill events (install, uninstall,
+    update, audit). Enables integration with external systems such as SIEM,
+    incident response, or internal notification pipelines.
+  </p>
+
+  <pre><code>{`async webhookConfigure(options: WebhookConfigureOptions): Promise<WebhookEndpoint>`}</code></pre>
+
+  <h4>WebhookConfigureOptions</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Required</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>url</code></td>
+        <td><code>string</code></td>
+        <td>Yes</td>
+        <td>HTTPS endpoint to receive events</td>
+      </tr>
+      <tr>
+        <td><code>events</code></td>
+        <td><code>string[]</code></td>
+        <td>Yes</td>
+        <td>Event types to subscribe to (e.g. <code>skill.installed</code>)</td>
+      </tr>
+      <tr>
+        <td><code>secret</code></td>
+        <td><code>string</code></td>
+        <td>No</td>
+        <td>HMAC-SHA256 signing secret (auto-generated if omitted)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>
+    Requires the Enterprise tier. Availability is gated on the production
+    migration tracked in SMI-4135; calls will return a feature-unavailable
+    response until then.
+  </p>
+
+  <h3>api_key_manage</h3>
+
+  <p>
+    Manage API keys for programmatic access — list, create, rotate, and revoke
+    keys scoped to your workspace.
+  </p>
+
+  <pre><code>{`async apiKeyManage(options: ApiKeyManageOptions): Promise<ApiKeyResult>`}</code></pre>
+
+  <h4>ApiKeyManageOptions</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Required</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>action</code></td>
+        <td><code>'list' | 'create' | 'rotate' | 'revoke'</code></td>
+        <td>Yes</td>
+        <td>Operation to perform</td>
+      </tr>
+      <tr>
+        <td><code>keyId</code></td>
+        <td><code>string</code></td>
+        <td>Conditional</td>
+        <td>Required for <code>rotate</code> and <code>revoke</code></td>
+      </tr>
+      <tr>
+        <td><code>label</code></td>
+        <td><code>string</code></td>
+        <td>No</td>
+        <td>Human-readable label for <code>create</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>
+    Requires the Enterprise tier. Availability is gated on the production
+    migration tracked in SMI-4135; calls will return a feature-unavailable
+    response until then.
+  </p>
+
   <h2>Types</h2>
 
   <h3>Skill</h3>


### PR DESCRIPTION
## Summary

Stage 4 PR C of the docs-sync launchpad workflow (post SMI-4122/4123).

- Adds `webhook_configure` and `api_key_manage` sections to the public website API reference (`packages/website/src/pages/docs/api.astro`), mirroring the mcp-server README entries. Both flagged "in preview — availability pending production migration" (SMI-4135).
- Adds an `[Unreleased]` entry to `packages/mcp-server/CHANGELOG.md` recording the SMI-4123 backing-table restoration.

Runs in parallel with PR B (#514), which owns `packages/mcp-server/README.md`, root `CHANGELOG.md`, and `packages/core/CHANGELOG.md`. No file overlap with PR B.

## Execution-time decisions

- `api.astro` has no existing preview/beta/experimental Badge component; used a plain-text caveat ("in preview — availability pending production migration (tracked in SMI-4135)") consistent with the page's plain-HTML styling.
- `packages/mcp-server/CHANGELOG.md` was version-anchored only; added a new `[Unreleased]` section at the top matching the root CHANGELOG convention.
- New docs placed as a dedicated "Enterprise Tools" section between `SkillInstaller.list()` and the Types section, since both tools are management-tier and Enterprise-gated.

## Test plan

- [ ] Website build green in CI (Astro typecheck, markdown lint)
- [ ] Docs preview renders webhook_configure + api_key_manage sections with caveat
- [ ] Markdown lint passes on CHANGELOG change
- [ ] No conflicts with PR #514 (disjoint file set)

## Linear refs

- SMI-4140 — website api.astro sync
- SMI-4142 — mcp-server CHANGELOG sync (mcp-server half of Item #6)
- Parents: SMI-4122, SMI-4123 (backing tables); SMI-4135 (production migration)

[skip-impl-check]