### PR TITLE
docs: SMI-4140/4142 sync website api.astro + mcp-server CHANGELOG

### DIFF
--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/mcp-server` are documented here.
 
+## [Unreleased]
+
+- **Fixed**: `webhook_configure` and `api_key_manage` backing tables restored (SMI-4123). In preview until production migration (SMI-4135).
+
 ## v0.4.7
 
 - **Fix: startup crash for new installs** — Bumped `@skillsmith/core` dependency floor from `^0.4.16` to `^0.4.17` to ensure `SkillInstallationService` export is available. Users with cached `core@0.4.16` saw a fatal `SyntaxError` on startup.

--- a/packages/website/src/pages/docs/api.astro
+++ b/packages/website/src/pages/docs/api.astro
@@ -260,6 +260,111 @@ if (result.success) {
 
   <pre><code>{`async list(): Promise<InstalledSkill[]>`}</code></pre>
 
+  <h2>Enterprise Tools</h2>
+
+  <p>
+    The following tools are available on the Enterprise tier via the MCP server.
+    They are currently <em>in preview — availability pending production migration</em>
+    (tracked in SMI-4135). Backing tables are restored in staging (SMI-4123).
+  </p>
+
+  <h3>webhook_configure</h3>
+
+  <p>
+    Configure HMAC-SHA256 signed webhooks for skill events (install, uninstall,
+    update, audit). Enables integration with external systems such as SIEM,
+    incident response, or internal notification pipelines.
+  </p>
+
+  <pre><code>{`async webhookConfigure(options: WebhookConfigureOptions): Promise<WebhookEndpoint>`}</code></pre>
+
+  <h4>WebhookConfigureOptions</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Required</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>url</code></td>
+        <td><code>string</code></td>
+        <td>Yes</td>
+        <td>HTTPS endpoint to receive events</td>
+      </tr>
+      <tr>
+        <td><code>events</code></td>
+        <td><code>string[]</code></td>
+        <td>Yes</td>
+        <td>Event types to subscribe to (e.g. <code>skill.installed</code>)</td>
+      </tr>
+      <tr>
+        <td><code>secret</code></td>
+        <td><code>string</code></td>
+        <td>No</td>
+        <td>HMAC-SHA256 signing secret (auto-generated if omitted)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>
+    Requires the Enterprise tier. Availability is gated on the production
+    migration tracked in SMI-4135; calls will return a feature-unavailable
+    response until then.
+  </p>
+
+  <h3>api_key_manage</h3>
+
+  <p>
+    Manage API keys for programmatic access — list, create, rotate, and revoke
+    keys scoped to your workspace.
+  </p>
+
+  <pre><code>{`async apiKeyManage(options: ApiKeyManageOptions): Promise<ApiKeyResult>`}</code></pre>
+
+  <h4>ApiKeyManageOptions</h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Required</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>action</code></td>
+        <td><code>'list' | 'create' | 'rotate' | 'revoke'</code></td>
+        <td>Yes</td>
+        <td>Operation to perform</td>
+      </tr>
+      <tr>
+        <td><code>keyId</code></td>
+        <td><code>string</code></td>
+        <td>Conditional</td>
+        <td>Required for <code>rotate</code> and <code>revoke</code></td>
+      </tr>
+      <tr>
+        <td><code>label</code></td>
+        <td><code>string</code></td>
+        <td>No</td>
+        <td>Human-readable label for <code>create</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>
+    Requires the Enterprise tier. Availability is gated on the production
+    migration tracked in SMI-4135; calls will return a feature-unavailable
+    response until then.
+  </p>
+
   <h2>Types</h2>
 
   <h3>Skill</h3>


### PR DESCRIPTION
## Summary

Recovery PR for orphan commit content.

Adds `webhook_configure` and `api_key_manage` docs to the public website API reference, mirroring the mcp-server README entries. Both flagged in preview (availability pending SMI-4135 production migration). Also adds an `[Unreleased]` entry to `packages/mcp-server/CHANGELOG.md` for SMI-4123 table restoration.

## Recovery context

The original work was committed as `3093ea1b` on 2026-04-12 20:18 by a parallel session during a git-crypt smudge-filter branch-hijack incident. It landed on a branch that got abandoned and was never pushed. Another session flagged the orphan on 2026-04-13 before reflog expiry would have consumed it.

Content restored via `git checkout 3093ea1b -- <files>` per the MEMORY-documented recovery pattern (cherry-pick / rebase are not safe in this repo due to git-crypt smudge interactions).

## Test plan

- [x] `[skip-impl-check]` in body — doc-only PR.
- [x] CI green (website build, markdown lint).
- [ ] Post-merge: verify `/docs/api` page on skillsmith.app renders the new tool entries correctly.

Refs: SMI-4140, SMI-4142, SMI-4122, SMI-4123, SMI-4135. Original orphan: `3093ea1b`.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)