### PR TITLE
fix(website): SMI-4181 add trailing slash to /skills/[category] canonical

### DIFF
--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -208,7 +208,7 @@ const categoryJsonLd =
         ))}
       <link
         rel="canonical"
-        href={`https://www.skillsmith.app/skills/${categoryMeta.slug}`}
+        href={`https://www.skillsmith.app/skills/${categoryMeta.slug}/`}
         slot="head"
       />
 


### PR DESCRIPTION
## Summary

- Fixes GSC "Duplicate without user-selected canonical" for `/skills/productivity/` and `/skills/security/`
- Appends trailing slash to the canonical href in `packages/website/src/pages/skills/[id].astro` so it matches the URL Astro actually serves (trailing-slash)
- Aligns with `BaseLayout.astro`'s default canonical helper (`new URL(Astro.url.pathname, Astro.site).href`), which preserves the trailing slash; the category branch of `[id].astro` had hand-built the string and dropped it

Root cause: canonical without slash → 301 → actual URL with slash → GSC treats it as a redirect loop signal and rejects the canonical. Single-line fix.

Plan: `docs/internal/implementation/gsc-indexing-audit-2026-04.md` (reviewed 2026-04-12).
Follow-up to SMI-3066–3079 (GSC Indexing Fixes, shipped 2026-03-06 commit `0821dc57`).

Linear: [SMI-4181](https://linear.app/smith-horn-group/issue/SMI-4181/fix-skillscategory-canonical-trailing-slash-gsc-dup-without-canonical)

## Test plan

- [x] `docker exec skillsmith-dev-1 npm run build -w packages/website` — 0 errors
- [x] `docker exec skillsmith-dev-1 npm run preflight` — deps satisfied, workspace versions consistent
- [x] `docker exec skillsmith-dev-1 npm run audit:standards` — 95% compliance, 0 failures
- [ ] After Vercel preview: `curl -s https://<preview>.vercel.app/skills/productivity/ | grep canonical` → must show trailing slash
- [ ] After Vercel preview: `curl -I https://<preview>.vercel.app/skills/productivity` (no slash) → expect 301 → `/skills/productivity/`
- [ ] After production deploy: GSC URL Inspection on `/skills/productivity/` and `/skills/security/` → "Request Indexing"
- [ ] Click "Validate Fix" in GSC for Wave 0 items listed in the plan (stale URLs already fixed by prior SMI-3066–3079)

[skip-impl-check] — test file co-update rule: this is an Astro template string change in a non-test-covered route (SSR category page). No existing unit test covers canonical rendering for `[id].astro`. Adding one would require Astro SSR test harness scaffolding — deferred; manual preview-deploy verification is the correct gate.

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>