### PR TITLE
chore: restore orphan Wave 1 version bump (SMI-4172)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22381,11 +22381,11 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@skillsmith/core": "^0.4.17",
+        "@skillsmith/core": "^0.5.0",
         "chalk": "5.6.2",
         "cli-table3": "0.6.5",
         "commander": "14.0.3",
@@ -22551,7 +22551,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.4.17",
+      "version": "0.5.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@huggingface/transformers": "3.8.1",
@@ -23750,7 +23750,7 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1024.0",
-        "@skillsmith/core": "^0.4.16",
+        "@skillsmith/core": "^0.5.0",
         "jose": "^6.2.2",
         "zod": "4.2.1"
       },
@@ -23778,11 +23778,11 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.4.17",
+        "@skillsmith/core": "^0.5.0",
         "esbuild": "0.27.2"
       },
       "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.4.17",
+    "@skillsmith/core": "^0.5.0",
     "chalk": "5.6.2",
     "cli-table3": "0.6.5",
     "commander": "14.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
-- **Indexer registers addyosmani/agent-skills as high-trust source** (SMI-4122, PR #499).
+## v0.5.0
+
+- **EventBatcher**: client-side batching of telemetry events (SMI-4119). Reduces `/events` edge invocations.
+- **Indexer registers addyosmani/agent-skills as high-trust source** (SMI-4122).
 
 ## v0.4.17
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.4.17",
+  "version": "0.5.0",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.4.17'
+export const VERSION = '0.5.0'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1024.0",
-    "@skillsmith/core": "^0.4.16",
+    "@skillsmith/core": "^0.5.0",
     "jose": "^6.2.2",
     "zod": "4.2.1"
   },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.4.17",
+    "@skillsmith/core": "^0.5.0",
     "esbuild": "0.27.2"
   },
   "devDependencies": {

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.4.7",
+  "version": "0.4.8",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -71,7 +71,7 @@ import { createLicenseMiddleware } from './middleware/license.js'
 import { createQuotaMiddleware } from './middleware/quota.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.4.7'
+const PACKAGE_VERSION = '0.4.8'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,


### PR DESCRIPTION
## Summary

Aligns git `main` with npm-published reality. Fixes the out-of-band publish drift diagnosed under SMI-4172.

## Background

Wave 1 publish (SMI-4119) on 2026-04-12 shipped:
- @skillsmith/core@0.5.0
- @skillsmith/mcp-server@0.4.8
- @skillsmith/cli@0.5.3

The version-bump commit (`2ad6a294`) was created locally by `prepare-release.ts` during publish, successfully uploaded the tarballs, and npm references it as the 0.5.0 tarball's `gitHead` — but the commit was never pushed to any branch. `git branch -a --contains 2ad6a294` returns empty.

This caused SMI-4120 (Wave 2) to fail silent publish: local `core@0.4.17` → minor bump → `0.5.0` collides with the already-published 0.5.0 → publish workflow skips. I discovered this trying to ship Wave 2.

## Fix

Surgical version-only edits (not `git checkout 2ad6a294 -- packages/` — that commit was based on older main and would revert SMI-4120 client.ts, SMI-4124 skill_pack_audit, SMI-4140/4142 docs).

| Package | From | To |
|---------|------|-----|
| @skillsmith/core | 0.4.17 | 0.5.0 |
| @skillsmith/mcp-server | 0.4.7 | 0.4.8 |
| @skillsmith/cli | 0.5.2 | 0.5.3 |
| @smith-horn/enterprise | 0.1.2 | 0.1.2 (unchanged) |

Consumer core-dep floors raised to `^0.5.0`. VERSION constants, server.json, package-lock.json, and core CHANGELOG updated.

[skip-doc-drift] — versions only reflect work already published on npm; no corresponding docs changes apply.

## Test plan

- [x] Docker-run `npm install` propagates lockfile changes cleanly; 0 vulnerabilities.
- [x] Pre-commit/pre-push hooks green.
- [ ] Post-merge: `prepare-release.ts --core=patch --dry-run` should compute 0.5.1 without colliding with npm.

## Unblocks

- SMI-4120 Wave 2 npm publish (client LRU cache will reach clients).
- Future `prepare-release.ts` runs compute correct next-versions.

Refs: SMI-4172, SMI-4119

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)