### PR TITLE
fix(website): sitemap lastmod for GSC crawl prioritization (SMI-4184)

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -1,7 +1,29 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
 import { defineConfig } from 'astro/config'
 import sitemap from '@astrojs/sitemap'
 import vercel from '@astrojs/vercel'
 import tailwindcss from '@tailwindcss/vite'
+
+// SMI-4184: sitemap lastmod for GSC Discovered-not-indexed.
+// Build a slug → ISO date map from blog frontmatter (sync, at config eval).
+// Non-blog pages get a fixed fallback so lastmod stays stable between builds
+// (Google penalizes per-build churn).
+const BLOG_DIR = join(dirname(fileURLToPath(import.meta.url)), 'src/content/blog')
+const BLOG_DATES = new Map()
+for (const file of readdirSync(BLOG_DIR).filter((f) => f.endsWith('.md'))) {
+  const src = readFileSync(join(BLOG_DIR, file), 'utf8')
+  const match = src.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) continue
+  const updated = match[1].match(/^updated:\s*(\S+)/m)?.[1]
+  const date = match[1].match(/^date:\s*(\S+)/m)?.[1]
+  const iso = updated || date
+  if (iso) BLOG_DATES.set(file.replace(/\.md$/, ''), new Date(iso).toISOString())
+}
+const FALLBACK_LASTMOD = new Date(
+  Math.max(...Array.from(BLOG_DATES.values()).map((d) => new Date(d).getTime()))
+).toISOString()
 
 // https://astro.build/config
 export default defineConfig({
@@ -47,6 +69,13 @@ export default defineConfig({
           item.priority = 0.5
           item.changefreq = 'monthly'
         }
+
+        // SMI-4184: emit <lastmod> so GSC prioritizes crawl.
+        // Blog posts → frontmatter `updated` or `date`; others → most-recent-post date.
+        const blogMatch = pathname.match(/^\/blog\/([^/]+)\/?$/)
+        const blogDate = blogMatch && BLOG_DATES.get(blogMatch[1])
+        item.lastmod = blogDate || FALLBACK_LASTMOD
+
         return item
       },
     }),


### PR DESCRIPTION
## Summary

- Add `serialize` callback to `@astrojs/sitemap` that emits `<lastmod>` on every URL
- Blog posts use frontmatter `updated`/`date`; other pages use most-recent post date (stable across builds)
- Wave 2 of GSC indexing audit April 2026 — see \`docs/internal/implementation/gsc-indexing-audit-2026-04.md\`

## Root cause

Post-build inspection of \`dist/client/sitemap-0.xml\` showed all 30 URLs missing \`<lastmod>\`. GSC reports 11 URLs in "Discovered - currently not indexed" (7 docs, 4 blog posts) — Google found them via sitemap but couldn't prioritize crawl without freshness signals.

## Verification

\`\`\`bash
docker exec skillsmith-dev-1 bash -c 'cd packages/website && npm run build'
sed 's/<url>/\n<url>/g' packages/website/dist/client/sitemap-0.xml | grep lastmod | wc -l
# → 30 (all URLs have lastmod)
\`\`\`

Sample URLs:
- \`/blog/dependency-intelligence/\` → \`2026-03-10\` (frontmatter)
- \`/blog/agent-skill-framework/\` → \`2026-01-23\` (frontmatter)
- \`/docs/cli/\` → \`2026-04-03\` (fallback)
- \`/docs/quickstart/\` → \`2026-04-03\` (fallback)

## Test plan

- [x] Build succeeds
- [x] \`dist/client/sitemap-0.xml\` contains \`<lastmod>\` on all 30 entries
- [x] Blog post dates match frontmatter
- [x] Non-blog pages get stable fallback (not per-build)
- [x] Preflight passes
- [ ] Post-merge: deploy + GSC "Submit Sitemap" to trigger re-read
- [ ] Post-deploy: monitor GSC Discovered-not-indexed count over 2–4 weeks

Related: SMI-4181 (#521 Wave 1), SMI-3066–3079 (prior auth canonicals/noindex).

[skip-impl-check]

Closes SMI-4184

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)