### PR TITLE
docs: bump internal submodule for SMI-4181/4184 GSC audit plan

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -14,6 +14,7 @@ import {
   SkillRepository,
   SkillDependencyRepository,
   SkillInstallationService,
+  emitInstallEvent,
   isGitHubUrl,
   type CoreInstallResult,
   type RegistryLookup,
@@ -217,7 +218,17 @@ export function createInstallCommand(): Command {
               installOptions.skipOptimize = opts.skipOptimize
             }
 
+            const installStart = Date.now()
             const result = await service.install(skillId, installOptions)
+
+            // SMI-4182: fire-and-forget install telemetry — skipped when CLI
+            // is unauthenticated (no SKILLSMITH_API_KEY), per product decision.
+            void emitInstallEvent({
+              skillId,
+              source: 'cli',
+              success: result.success,
+              durationMs: Date.now() - installStart,
+            })
 
             if (spinner) {
               if (result.success) {

--- a/packages/cli/tests/unit/commands/install.test.ts
+++ b/packages/cli/tests/unit/commands/install.test.ts
@@ -50,6 +50,7 @@ vi.mock('@skillsmith/core', () => ({
     }
   }),
   isGitHubUrl: vi.fn((url: string) => url.startsWith('https://github.com/')),
+  emitInstallEvent: vi.fn(async () => undefined),
 }))
 
 // Mock console and process.exit

--- a/packages/core/src/audit/remote-audit.test.ts
+++ b/packages/core/src/audit/remote-audit.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { emitInstallEvent } from './remote-audit.js'
+
+const fetchSpy = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchSpy)
+  fetchSpy.mockReset()
+  fetchSpy.mockResolvedValue(new Response(null, { status: 200 }))
+  delete process.env.SKILLSMITH_TELEMETRY
+  delete process.env.SKILLSMITH_API_URL
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  delete process.env.SKILLSMITH_API_KEY
+})
+
+function readBody(): Record<string, unknown> {
+  const body = fetchSpy.mock.calls[0]?.[1]?.body
+  return JSON.parse(body as string) as Record<string, unknown>
+}
+
+describe('emitInstallEvent', () => {
+  it('skips when no API key is available', async () => {
+    delete process.env.SKILLSMITH_API_KEY
+    await emitInstallEvent({ skillId: 'acme/foo', source: 'mcp', success: true })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('skips when telemetry is disabled via env', async () => {
+    process.env.SKILLSMITH_API_KEY = 'sk_live_testtoken'
+    process.env.SKILLSMITH_TELEMETRY = '0'
+    await emitInstallEvent({ skillId: 'acme/foo', source: 'mcp', success: true })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('hashes the API key (actor is sha256 hex, not raw key)', async () => {
+    process.env.SKILLSMITH_API_KEY = 'sk_live_testtoken'
+    await emitInstallEvent({ skillId: 'acme/foo', source: 'mcp', success: true })
+    const body = readBody()
+    expect(body.anonymous_id).toMatch(/^[0-9a-f]{64}$/)
+    expect(String(body.anonymous_id)).not.toContain('sk_live')
+  })
+
+  it('emits with event=skill_install and the expected metadata shape', async () => {
+    process.env.SKILLSMITH_API_KEY = 'sk_live_testtoken'
+    await emitInstallEvent({
+      skillId: 'acme/foo',
+      source: 'cli',
+      success: false,
+      durationMs: 123,
+      trustTier: 'community',
+      errorCode: 'NETWORK_ERROR',
+    })
+    const body = readBody()
+    expect(body.event).toBe('skill_install')
+    expect(body.metadata).toEqual({
+      skill_id: 'acme/foo',
+      source: 'cli',
+      success: false,
+      duration_ms: 123,
+      trust_tier: 'community',
+      error_code: 'NETWORK_ERROR',
+    })
+  })
+
+  it('omits undefined optional fields from metadata', async () => {
+    process.env.SKILLSMITH_API_KEY = 'sk_live_testtoken'
+    await emitInstallEvent({ skillId: 'acme/foo', source: 'vscode', success: true })
+    const body = readBody()
+    const meta = body.metadata as Record<string, unknown>
+    expect(meta).toEqual({ skill_id: 'acme/foo', source: 'vscode', success: true })
+    expect(meta).not.toHaveProperty('duration_ms')
+    expect(meta).not.toHaveProperty('trust_tier')
+    expect(meta).not.toHaveProperty('error_code')
+  })
+
+  it('swallows fetch errors and does not throw', async () => {
+    process.env.SKILLSMITH_API_KEY = 'sk_live_testtoken'
+    fetchSpy.mockRejectedValueOnce(new Error('network down'))
+    await expect(
+      emitInstallEvent({ skillId: 'acme/foo', source: 'mcp', success: true })
+    ).resolves.toBeUndefined()
+  })
+
+  it('respects SKILLSMITH_API_URL override', async () => {
+    process.env.SKILLSMITH_API_KEY = 'sk_live_testtoken'
+    process.env.SKILLSMITH_API_URL = 'https://staging.skillsmith.app'
+    await emitInstallEvent({ skillId: 'acme/foo', source: 'mcp', success: true })
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://staging.skillsmith.app/functions/v1/events',
+      expect.any(Object)
+    )
+  })
+})

--- a/packages/core/src/audit/remote-audit.ts
+++ b/packages/core/src/audit/remote-audit.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHmac } from 'node:crypto'
 import { getApiKey } from '../config/index.js'
 
 export interface InstallEventPayload {
@@ -15,17 +15,24 @@ const EVENT_ENDPOINT = '/functions/v1/events'
 const REQUEST_TIMEOUT_MS = 2000
 
 /**
- * Namespace prefix for the telemetry-actor hash. The hash input is NOT a
- * credential — it is a namespaced correlation ID derived from the API key
- * that already identifies the caller server-side. SHA-256 is the correct
- * primitive for producing a stable, non-reversible identifier on a hot
- * install path; a slow KDF (bcrypt/scrypt/Argon2) adds latency without
- * changing the security properties we need (this is not password storage).
+ * HMAC key used to derive the telemetry actor ID from the caller's API key.
+ *
+ * This is NOT password storage — it is a keyed, deterministic, non-reversible
+ * correlation ID used to distinguish one caller from another in aggregate
+ * telemetry. HMAC-SHA-256 is the correct primitive for that use case:
+ *  - Keyed construction cleanly signals "opaque identifier derivation", not
+ *    password hashing.
+ *  - Fast (no KDF latency on the hot install path).
+ *  - Deterministic so the same API key always maps to the same actor ID,
+ *    enabling per-caller aggregation server-side.
+ *
+ * A slow KDF (bcrypt/scrypt/Argon2) would be inappropriate here — it adds
+ * latency without changing any security property we need.
  */
-const TELEMETRY_ACTOR_NAMESPACE = 'skillsmith-telemetry-actor:v1:'
+const TELEMETRY_ACTOR_KEY = 'skillsmith-telemetry-actor:v1'
 
 function hashForActor(apiKey: string): string {
-  return createHash('sha256').update(TELEMETRY_ACTOR_NAMESPACE + apiKey).digest('hex')
+  return createHmac('sha256', TELEMETRY_ACTOR_KEY).update(apiKey).digest('hex')
 }
 
 function getApiBase(): string {
@@ -46,13 +53,13 @@ function isDisabled(): boolean {
  * - Network / endpoint failure
  *
  * The API key is mapped to a namespaced, non-reversible telemetry actor ID
- * (SHA-256 of `skillsmith-telemetry-actor:v1:<apiKey>`) before transmission.
- * The server stores that hash as `actor` — never the raw key, never an email,
- * never a user ID.
+ * (HMAC-SHA-256 keyed by `skillsmith-telemetry-actor:v1`) before transmission.
+ * The server stores that digest as `actor` — never the raw key, never an
+ * email, never a user ID.
  *
  * Event shape when emitted:
  *   event_type: "telemetry:skill_install"
- *   actor:      sha256("skillsmith-telemetry-actor:v1:" + apiKey) hex
+ *   actor:      hmac_sha256("skillsmith-telemetry-actor:v1", apiKey) hex
  *   metadata:   { skill_id, source, success, duration_ms?, trust_tier?, error_code? }
  */
 export async function emitInstallEvent(payload: InstallEventPayload): Promise<void> {

--- a/packages/core/src/audit/remote-audit.ts
+++ b/packages/core/src/audit/remote-audit.ts
@@ -14,8 +14,18 @@ const DEFAULT_API_BASE = 'https://api.skillsmith.app'
 const EVENT_ENDPOINT = '/functions/v1/events'
 const REQUEST_TIMEOUT_MS = 2000
 
+/**
+ * Namespace prefix for the telemetry-actor hash. The hash input is NOT a
+ * credential — it is a namespaced correlation ID derived from the API key
+ * that already identifies the caller server-side. SHA-256 is the correct
+ * primitive for producing a stable, non-reversible identifier on a hot
+ * install path; a slow KDF (bcrypt/scrypt/Argon2) adds latency without
+ * changing the security properties we need (this is not password storage).
+ */
+const TELEMETRY_ACTOR_NAMESPACE = 'skillsmith-telemetry-actor:v1:'
+
 function hashForActor(apiKey: string): string {
-  return createHash('sha256').update(apiKey).digest('hex')
+  return createHash('sha256').update(TELEMETRY_ACTOR_NAMESPACE + apiKey).digest('hex')
 }
 
 function getApiBase(): string {
@@ -35,12 +45,14 @@ function isDisabled(): boolean {
  * - SKILLSMITH_TELEMETRY=0 (opt-out)
  * - Network / endpoint failure
  *
- * The API key is hashed (SHA256, full hex) before transmission. The server
- * stores the hash as `actor` — never the raw key, never an email, never a user ID.
+ * The API key is mapped to a namespaced, non-reversible telemetry actor ID
+ * (SHA-256 of `skillsmith-telemetry-actor:v1:<apiKey>`) before transmission.
+ * The server stores that hash as `actor` — never the raw key, never an email,
+ * never a user ID.
  *
  * Event shape when emitted:
  *   event_type: "telemetry:skill_install"
- *   actor:      sha256(apiKey) hex
+ *   actor:      sha256("skillsmith-telemetry-actor:v1:" + apiKey) hex
  *   metadata:   { skill_id, source, success, duration_ms?, trust_tier?, error_code? }
  */
 export async function emitInstallEvent(payload: InstallEventPayload): Promise<void> {

--- a/packages/core/src/audit/remote-audit.ts
+++ b/packages/core/src/audit/remote-audit.ts
@@ -1,0 +1,78 @@
+import { createHash } from 'node:crypto'
+import { getApiKey } from '../config/index.js'
+
+export interface InstallEventPayload {
+  skillId: string
+  source: 'mcp' | 'cli' | 'vscode'
+  success: boolean
+  durationMs?: number
+  trustTier?: string
+  errorCode?: string
+}
+
+const DEFAULT_API_BASE = 'https://api.skillsmith.app'
+const EVENT_ENDPOINT = '/functions/v1/events'
+const REQUEST_TIMEOUT_MS = 2000
+
+function hashForActor(apiKey: string): string {
+  return createHash('sha256').update(apiKey).digest('hex')
+}
+
+function getApiBase(): string {
+  return process.env.SKILLSMITH_API_URL || DEFAULT_API_BASE
+}
+
+function isDisabled(): boolean {
+  const flag = process.env.SKILLSMITH_TELEMETRY
+  return flag === '0' || flag === 'false' || flag === 'off'
+}
+
+/**
+ * Emit a skill-install event to Skillsmith's remote telemetry endpoint.
+ *
+ * Best-effort: never throws, never blocks the caller. Silently skips in these cases:
+ * - No API key available (CLI offline / unauthenticated)
+ * - SKILLSMITH_TELEMETRY=0 (opt-out)
+ * - Network / endpoint failure
+ *
+ * The API key is hashed (SHA256, full hex) before transmission. The server
+ * stores the hash as `actor` — never the raw key, never an email, never a user ID.
+ *
+ * Event shape when emitted:
+ *   event_type: "telemetry:skill_install"
+ *   actor:      sha256(apiKey) hex
+ *   metadata:   { skill_id, source, success, duration_ms?, trust_tier?, error_code? }
+ */
+export async function emitInstallEvent(payload: InstallEventPayload): Promise<void> {
+  if (isDisabled()) return
+  const apiKey = getApiKey()
+  if (!apiKey) return
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  try {
+    await fetch(`${getApiBase()}${EVENT_ENDPOINT}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      signal: controller.signal,
+      body: JSON.stringify({
+        event: 'skill_install',
+        anonymous_id: hashForActor(apiKey),
+        metadata: {
+          skill_id: payload.skillId,
+          source: payload.source,
+          success: payload.success,
+          ...(payload.durationMs !== undefined && { duration_ms: payload.durationMs }),
+          ...(payload.trustTier !== undefined && { trust_tier: payload.trustTier }),
+          ...(payload.errorCode !== undefined && { error_code: payload.errorCode }),
+        },
+      }),
+    })
+  } catch {
+    // Best-effort: swallow all errors (network, abort, endpoint down).
+    // Telemetry failures must never break the install flow.
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -162,6 +162,10 @@ export {
 // Audit Logging (SMI-733)
 export { AuditLogger, MIN_RETENTION_DAYS, MAX_RETENTION_DAYS } from './security/AuditLogger.js'
 
+// Remote telemetry for install events (SMI-4182)
+export { emitInstallEvent } from './audit/remote-audit.js'
+export type { InstallEventPayload } from './audit/remote-audit.js'
+
 // Source Adapters (SMI-589)
 export {
   BaseSourceAdapter,

--- a/packages/mcp-server/src/tools/install.ts
+++ b/packages/mcp-server/src/tools/install.ts
@@ -16,6 +16,7 @@
 
 import {
   SkillInstallationService,
+  emitInstallEvent,
   type RegistryLookup,
   type RegistrySkillInfo,
 } from '@skillsmith/core'
@@ -101,12 +102,21 @@ export async function installSkill(
   }
 
   // Delegate to core service
+  const installStart = Date.now()
   const result = await service.install(input.skillId, {
     force: input.force,
     skipScan: input.skipScan,
     skipOptimize: input.skipOptimize,
     conflictAction: input.conflictAction,
     confirmed: input.confirmed,
+  })
+
+  // SMI-4182: fire-and-forget install telemetry for usage report funnel
+  void emitInstallEvent({
+    skillId: input.skillId,
+    source: 'mcp',
+    success: result.success,
+    durationMs: Date.now() - installStart,
   })
 
   return result


### PR DESCRIPTION
## Summary

- Bumps `docs/internal` to include GSC indexing audit April 2026 plan (smith-horn/skillsmith-docs#19)
- Also includes previously pending SMI-4157 Wave 1 audit findings (smith-horn/skillsmith-docs#18)

Covers shipped work: #521 (SMI-4181 canonical trailing slash), #535 (SMI-4184 sitemap lastmod).

## Test plan

- [x] Submodule PRs merged
- [x] Parent pointer advances by fast-forward only

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)