### PR TITLE
refactor(website): extract sitemap-lastmod helpers + tests (SMI-4186)

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -1,29 +1,18 @@
-import { readFileSync, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { defineConfig } from 'astro/config'
 import sitemap from '@astrojs/sitemap'
 import vercel from '@astrojs/vercel'
 import tailwindcss from '@tailwindcss/vite'
+import { computeFallback, getLastmodFor, loadBlogDates } from './src/lib/sitemap-lastmod.mjs'
 
 // SMI-4184: sitemap lastmod for GSC Discovered-not-indexed.
-// Build a slug → ISO date map from blog frontmatter (sync, at config eval).
-// Non-blog pages get a fixed fallback so lastmod stays stable between builds
-// (Google penalizes per-build churn).
+// Blog dates sourced from frontmatter at config eval; non-blog pages get a
+// stable fallback (Google penalizes per-build lastmod churn). Empty dir →
+// static fallback, so the config never emits Invalid Date.
 const BLOG_DIR = join(dirname(fileURLToPath(import.meta.url)), 'src/content/blog')
-const BLOG_DATES = new Map()
-for (const file of readdirSync(BLOG_DIR).filter((f) => f.endsWith('.md'))) {
-  const src = readFileSync(join(BLOG_DIR, file), 'utf8')
-  const match = src.match(/^---\n([\s\S]*?)\n---/)
-  if (!match) continue
-  const updated = match[1].match(/^updated:\s*(\S+)/m)?.[1]
-  const date = match[1].match(/^date:\s*(\S+)/m)?.[1]
-  const iso = updated || date
-  if (iso) BLOG_DATES.set(file.replace(/\.md$/, ''), new Date(iso).toISOString())
-}
-const FALLBACK_LASTMOD = new Date(
-  Math.max(...Array.from(BLOG_DATES.values()).map((d) => new Date(d).getTime()))
-).toISOString()
+const BLOG_DATES = loadBlogDates(BLOG_DIR)
+const FALLBACK_LASTMOD = computeFallback(BLOG_DATES)
 
 // https://astro.build/config
 export default defineConfig({
@@ -70,11 +59,7 @@ export default defineConfig({
           item.changefreq = 'monthly'
         }
 
-        // SMI-4184: emit <lastmod> so GSC prioritizes crawl.
-        // Blog posts → frontmatter `updated` or `date`; others → most-recent-post date.
-        const blogMatch = pathname.match(/^\/blog\/([^/]+)\/?$/)
-        const blogDate = blogMatch && BLOG_DATES.get(blogMatch[1])
-        item.lastmod = blogDate || FALLBACK_LASTMOD
+        item.lastmod = getLastmodFor(pathname, BLOG_DATES, FALLBACK_LASTMOD)
 
         return item
       },

--- a/packages/website/src/lib/sitemap-lastmod.mjs
+++ b/packages/website/src/lib/sitemap-lastmod.mjs
@@ -1,0 +1,37 @@
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Static fallback used when blog dir is missing/empty. Kept deterministic
+// across builds so Google doesn't see per-build <lastmod> churn.
+export const STATIC_FALLBACK_LASTMOD = '2026-04-13T00:00:00.000Z'
+
+export function loadBlogDates(blogDir) {
+  const map = new Map()
+  if (!existsSync(blogDir)) return map
+  for (const file of readdirSync(blogDir).filter((f) => f.endsWith('.md'))) {
+    const src = readFileSync(join(blogDir, file), 'utf8')
+    const match = src.match(/^---\n([\s\S]*?)\n---/)
+    if (!match) continue
+    const updated = match[1].match(/^updated:\s*(\S+)/m)?.[1]
+    const date = match[1].match(/^date:\s*(\S+)/m)?.[1]
+    const iso = updated || date
+    if (iso) {
+      const parsed = new Date(iso)
+      if (!Number.isNaN(parsed.getTime())) {
+        map.set(file.replace(/\.md$/, ''), parsed.toISOString())
+      }
+    }
+  }
+  return map
+}
+
+export function computeFallback(blogDates) {
+  if (blogDates.size === 0) return STATIC_FALLBACK_LASTMOD
+  const max = Math.max(...Array.from(blogDates.values()).map((d) => new Date(d).getTime()))
+  return new Date(max).toISOString()
+}
+
+export function getLastmodFor(pathname, blogDates, fallback) {
+  const m = pathname.match(/^\/blog\/([^/]+)\/?$/)
+  return (m && blogDates.get(m[1])) || fallback
+}

--- a/packages/website/src/lib/sitemap-lastmod.test.ts
+++ b/packages/website/src/lib/sitemap-lastmod.test.ts
@@ -1,0 +1,104 @@
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  STATIC_FALLBACK_LASTMOD,
+  computeFallback,
+  getLastmodFor,
+  loadBlogDates,
+} from './sitemap-lastmod.mjs'
+
+describe('sitemap-lastmod', () => {
+  let tmp: string
+
+  beforeAll(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sitemap-lastmod-'))
+    mkdirSync(join(tmp, 'blog'), { recursive: true })
+    writeFileSync(
+      join(tmp, 'blog', 'with-updated.md'),
+      '---\ntitle: a\ndate: 2026-01-10\nupdated: 2026-03-01\n---\nbody'
+    )
+    writeFileSync(
+      join(tmp, 'blog', 'with-date-only.md'),
+      '---\ntitle: b\ndate: 2026-02-15\n---\nbody'
+    )
+    writeFileSync(join(tmp, 'blog', 'no-frontmatter.md'), 'no frontmatter here')
+    writeFileSync(join(tmp, 'blog', 'bad-date.md'), '---\ndate: not-a-date\n---\nbody')
+    writeFileSync(join(tmp, 'blog', 'skip.txt'), 'not markdown')
+  })
+
+  afterAll(() => rmSync(tmp, { recursive: true, force: true }))
+
+  describe('loadBlogDates', () => {
+    it('prefers updated over date', () => {
+      const dates = loadBlogDates(join(tmp, 'blog'))
+      expect(dates.get('with-updated')).toBe(new Date('2026-03-01').toISOString())
+    })
+
+    it('falls back to date when updated is missing', () => {
+      const dates = loadBlogDates(join(tmp, 'blog'))
+      expect(dates.get('with-date-only')).toBe(new Date('2026-02-15').toISOString())
+    })
+
+    it('skips files without frontmatter', () => {
+      const dates = loadBlogDates(join(tmp, 'blog'))
+      expect(dates.has('no-frontmatter')).toBe(false)
+    })
+
+    it('skips unparseable dates', () => {
+      const dates = loadBlogDates(join(tmp, 'blog'))
+      expect(dates.has('bad-date')).toBe(false)
+    })
+
+    it('ignores non-markdown files', () => {
+      const dates = loadBlogDates(join(tmp, 'blog'))
+      expect(dates.has('skip')).toBe(false)
+    })
+
+    it('returns empty Map for non-existent dir', () => {
+      const dates = loadBlogDates(join(tmp, 'does-not-exist'))
+      expect(dates.size).toBe(0)
+    })
+  })
+
+  describe('computeFallback', () => {
+    it('returns static fallback when Map is empty', () => {
+      expect(computeFallback(new Map())).toBe(STATIC_FALLBACK_LASTMOD)
+    })
+
+    it('returns most-recent ISO date from non-empty Map', () => {
+      const map = new Map([
+        ['a', '2026-01-01T00:00:00.000Z'],
+        ['b', '2026-03-15T00:00:00.000Z'],
+        ['c', '2026-02-01T00:00:00.000Z'],
+      ])
+      expect(computeFallback(map)).toBe('2026-03-15T00:00:00.000Z')
+    })
+  })
+
+  describe('getLastmodFor', () => {
+    const blogDates = new Map([['post-a', '2026-03-01T00:00:00.000Z']])
+    const fallback = '2026-04-01T00:00:00.000Z'
+
+    it('returns blog date for matching /blog/:slug/ URL', () => {
+      expect(getLastmodFor('/blog/post-a/', blogDates, fallback)).toBe('2026-03-01T00:00:00.000Z')
+    })
+
+    it('matches /blog/:slug without trailing slash', () => {
+      expect(getLastmodFor('/blog/post-a', blogDates, fallback)).toBe('2026-03-01T00:00:00.000Z')
+    })
+
+    it('returns fallback for non-blog URL', () => {
+      expect(getLastmodFor('/docs/cli/', blogDates, fallback)).toBe(fallback)
+    })
+
+    it('returns fallback for blog URL with unknown slug', () => {
+      expect(getLastmodFor('/blog/unknown/', blogDates, fallback)).toBe(fallback)
+    })
+
+    it('returns fallback for blog index', () => {
+      expect(getLastmodFor('/blog/', blogDates, fallback)).toBe(fallback)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Governance retro follow-up for #535. Addresses both LOW action items:

1. **Empty-dir guard** — `STATIC_FALLBACK_LASTMOD` export prevents `Math.max(...[])` → `Invalid Date` if `src/content/blog/` is ever empty
2. **Testability** — extracts `loadBlogDates`, `computeFallback`, `getLastmodFor` into `src/lib/sitemap-lastmod.mjs`; adds 13 Vitest cases

Net **-17 lines** in `astro.config.mjs` despite adding the guard.

## Test plan

- [x] \`cd packages/website && npx vitest run src/lib/sitemap-lastmod.test.ts\` → 13/13 pass
- [x] \`npm run build -w packages/website\` → sitemap-0.xml carries \`<lastmod>\` on all 30 entries
- [x] \`npm run preflight\` → green
- [x] Sample URLs preserved: \`/blog/dependency-intelligence/\` → \`2026-03-10\`; \`/docs/cli/\` → fallback

## Test coverage

| Area | Cases |
|---|---|
| \`loadBlogDates\` | 6 — updated/date precedence, missing frontmatter, bad dates, non-md files, missing dir |
| \`computeFallback\` | 2 — empty Map → static, non-empty → max date |
| \`getLastmodFor\` | 5 — matching slug (w/ and w/o trailing slash), unknown slug, non-blog URL, \`/blog/\` index |

[skip-impl-check]

Closes SMI-4186

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)