### PR TITLE
chore(release): bump core 0.4.18, mcp-server 0.4.8, cli 0.5.3

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
+## v0.5.3
+
+- **Docs**: bump internal submodule for SMI-4181/4184 GSC audit plan (#539)
+
 ## v0.5.2 (2026-03-24)
 
 - **Unified Install Command**: `skillsmith install` now supports both registry names and GitHub URLs (SMI-3484).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.4.17",
+    "@skillsmith/core": "^0.4.18",
     "chalk": "5.6.2",
     "cli-table3": "0.6.5",
     "commander": "14.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@skillsmith/core` are documented here.
 
+## v0.4.18
+
+- **Fix**: SMI-4182 suppress CodeQL false positive on telemetry hash
+- **Feature**: SMI-4120 response caching + Cache-Control (#516)
+
 ## [Unreleased]
 
 - **Indexer registers addyosmani/agent-skills as high-trust source** (SMI-4122, PR #499).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.4.17'
+export const VERSION = '0.4.18'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1024.0",
-    "@skillsmith/core": "^0.4.16",
+    "@skillsmith/core": "^0.4.18",
     "jose": "^6.2.2",
     "zod": "4.2.1"
   },

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@skillsmith/mcp-server` are documented here.
 
+## v0.4.8
+
+- **Docs**: bump internal submodule for SMI-4181/4184 GSC audit plan (#539)
+- **Docs**: sync website api.astro + mcp-server CHANGELOG (SMI-4140, SMI-4142) (#518)
+- **Docs**: SMI-4122/4123 sync — mcp-server README + CHANGELOGs (#514)
+
 ## [Unreleased]
 
 - **Fixed**: `webhook_configure` and `api_key_manage` backing tables restored (SMI-4123). In preview until production migration (SMI-4135).

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.4.17",
+    "@skillsmith/core": "^0.4.18",
     "esbuild": "0.27.2"
   },
   "devDependencies": {

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,9 +8,13 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.4.7",
+  "version": "0.4.8",
   "_meta": {
-    "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
+    "io.skillsmith/categories": [
+      "developer-tools",
+      "ai-agents",
+      "skill-management"
+    ],
     "io.skillsmith/keywords": [
       "claude-code",
       "agent-skills",
@@ -23,7 +27,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -71,7 +71,7 @@ import { createLicenseMiddleware } from './middleware/license.js'
 import { createQuotaMiddleware } from './middleware/quota.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.4.7'
+const PACKAGE_VERSION = '0.4.8'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,


### PR DESCRIPTION
Publishes SMI-4182 install-event emission so MCP + CLI install handlers in real user installations start emitting `telemetry:skill_install` to audit_logs. Unblocks the SMI-4157 usage report funnel section, which currently shows installs=0 because no client has the new emission code yet.

Version bumps only — no new functionality beyond what merged in PR #539.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)