### PR TITLE
chore(release): bump core 0.5.1, mcp-server 0.4.9, cli 0.5.4

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
+## v0.5.4
+
+- Version bump
+
 ## v0.5.3
 
 - **Docs**: bump internal submodule for SMI-4181/4184 GSC audit plan (#539)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.4.18",
+    "@skillsmith/core": "^0.5.1",
     "chalk": "5.6.2",
     "cli-table3": "0.6.5",
     "commander": "14.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/core` are documented here.
 
+## v0.5.1
+
+- Version bump
+
 ## v0.4.18
 
 - **Fix**: SMI-4182 suppress CodeQL false positive on telemetry hash

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.4.18",
+  "version": "0.5.1",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.4.18'
+export const VERSION = '0.5.1'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1024.0",
-    "@skillsmith/core": "^0.4.18",
+    "@skillsmith/core": "^0.5.1",
     "jose": "^6.2.2",
     "zod": "4.2.1"
   },

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/mcp-server` are documented here.
 
+## v0.4.9
+
+- Version bump
+
 ## v0.4.8
 
 - **Docs**: bump internal submodule for SMI-4181/4184 GSC audit plan (#539)

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.4.18",
+    "@skillsmith/core": "^0.5.1",
     "esbuild": "0.27.2"
   },
   "devDependencies": {

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,13 +8,9 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.4.8",
+  "version": "0.4.9",
   "_meta": {
-    "io.skillsmith/categories": [
-      "developer-tools",
-      "ai-agents",
-      "skill-management"
-    ],
+    "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
       "claude-code",
       "agent-skills",
@@ -27,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -71,7 +71,7 @@ import { createLicenseMiddleware } from './middleware/license.js'
 import { createQuotaMiddleware } from './middleware/quota.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.4.8'
+const PACKAGE_VERSION = '0.4.9'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,


### PR DESCRIPTION
## Summary

- Republishes SMI-4182 install-event emission with new version numbers
- Prior release commit `dedea52e` targeted core 0.4.18 / mcp-server 0.4.8 / cli 0.5.3, but those collide with versions already published 2026-04-12 from `release/smi-4119-core-minor` (which contained pre-SMI-4182 code)
- New versions go past npm's published 0.5.0 / 0.4.8 / 0.5.3 line so SMI-4182 telemetry can ship and start populating the SMI-4157 usage report install-event funnel
- Local publish fallback used (SMI-4182 follow-up: fix publish.yml website scope per ADR-109)

## Test plan

- [x] `docker exec skillsmith-dev-1 npm run build` — green
- [x] Local publish: core@0.5.1, mcp-server@0.4.9, cli@0.5.4 all published to npm
- [x] `npm view @skillsmith/core version` returns 0.5.1
- [x] `npm view @skillsmith/mcp-server version` returns 0.4.9
- [x] `npm view @skillsmith/cli version` returns 0.5.4
- [x] Smoke tests: core PASSED, cli PASSED, mcp-server install/version/init PASSED (cross-deps test has stale expected list — not a release regression)

[skip-impl-check] No implementation changes — version bumps + CHANGELOG entries only.
[skip-doc-drift] Version-bump PR only; no doc-affecting changes.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)