### PR TITLE
fix(scripts): drop stale CategoryRepository from smoke-test required exports (SMI-4189)

### DIFF
--- a/scripts/smoke-test-published.ts
+++ b/scripts/smoke-test-published.ts
@@ -130,11 +130,12 @@ export async function smokeTestPackage(
             console.log('Resolved @skillsmith/core@' + corePkg.version);
 
             // Verify key core exports resolve (these are used by mcp-server)
+            // Source of truth: packages/core/src/index.ts (SMI-4189)
             const core = await import('@skillsmith/core');
             const required = [
               'SkillDependencyRepository', 'SkillsmithApiClient',
               'HybridSearch', 'createDatabaseSync',
-              'SkillRepository', 'CategoryRepository'
+              'SkillRepository'
             ];
             const missing = required.filter(fn => !(fn in core));
             if (missing.length > 0) {


### PR DESCRIPTION
## Summary

- Remove stale `CategoryRepository` entry from the `cross-package-deps` required-exports check in `scripts/smoke-test-published.ts`.
- Add a one-line comment pointing to `packages/core/src/index.ts` as the source of truth.
- [skip-impl-check] [skip-doc-drift]

## Why

`CategoryRepository` is no longer exported from `@skillsmith/core`, but the post-publish smoke test still asserts its presence. Every release's cross-package-deps sub-test fails as a result — confirmed during the SMI-4182 republish on 2026-04-13.

Source-of-truth check against `packages/core/src/index.ts` and `packages/core/src/exports/repositories.ts` confirms the remaining five entries (`SkillDependencyRepository`, `SkillsmithApiClient`, `HybridSearch`, `createDatabaseSync`, `SkillRepository`) are all still exported.

## Test plan

- [x] Smoke test locally: `REPO=$(git rev-parse --show-toplevel) && cd /tmp && env -i HOME=$HOME PATH=$PATH npx tsx "$REPO/scripts/smoke-test-published.ts" @skillsmith/mcp-server 0.4.9` → `Status: PASSED`, all 4 sub-tests green.
- [x] Pre-commit + pre-push hooks passed (typecheck, lint, format, tests).

Linear: SMI-4189

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)