### PR TITLE
SMI-4190: release cadence docs — ADR-114 + CHANGELOG backfill + CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   threats) and SecurityScanner (SSRF, jailbreak, structural) now both run on every
   skill assessment (#451).
 - Indexer now indexes addyosmani/agent-skills as high-trust source (SMI-4122, PR #499).
+- **Skill pack audit trigger-quality + namespace checks** (SMI-4124, PR #505): `skill_pack_audit` MCP tool now detects low-quality trigger phrases and namespace collisions in installed skill packs. Surfaces actionable findings before publish.
 
 ### Fixed
 
 - Restored webhook_endpoints and api_keys tables via migrations 065+066 (SMI-4123, PRs #501/#503/#504). Production deployment tracked in SMI-4135.
+- **Audit log telemetry via pooler** (SMI-4118, PR #508): added `SUPABASE_POOLER_URL` to env schema for audit-logs queries that bypass PostgREST's 8s statement timeout. Contributors can now run pooled validation SQL against production without timing out on `audit_logs` LIKE filters.
 - **audit-standards Check 11 false positives** (2026-04-08, SMI-3987): npm overrides
   targeting exact-pinned transitive deps are no longer flagged as "ineffective" when
   npm's dedup machinery actually applied the override. Cross-references `npm ls <dep>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,8 @@ docker exec skillsmith-dev-1 npx tsx scripts/prepare-release.ts --dry-run --all=
 
 The script updates all 6 version locations (package.json, VERSION constants, server.json), generates changelog entries, and creates a commit. See `docs/internal/implementation/release-automation.md` for details.
 
+**Release cadence**: weekly (Sunday 03:00 UTC) OR when root `CHANGELOG.md [Unreleased]` ≥ 15 entries. Automation per [ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md); contributor-facing docs in [CONTRIBUTING.md § Releases](CONTRIBUTING.md#releases).
+
 **Publishing — CI workflow** (preferred, avoids local npm auth/OTP issues):
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,6 +226,42 @@ docker exec skillsmith-dev-1 npm run audit:standards
 
 Pre-commit hooks will automatically run linting and formatting.
 
+## Releases
+
+Skillsmith publishes four public packages to npm (`@skillsmith/core`, `@skillsmith/mcp-server`, `@skillsmith/cli`, `skillsmith-vscode`) and one private package to GitHub Packages (`@smith-horn/enterprise`). See [ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md) for the full decision record.
+
+### Cadence
+
+- **Weekly**: an automated workflow runs every Sunday at 03:00 UTC. If `[Unreleased]` in root `CHANGELOG.md` is non-empty, it opens a version-bump PR using `scripts/prepare-release.ts --all=patch`. Humans review and merge; nothing auto-merges.
+- **Threshold**: if root `CHANGELOG.md [Unreleased]` accumulates 15 or more entries mid-week, the same workflow fires early. Threshold is configurable via `UNRELEASED_THRESHOLD` and is expected to fire ~2-3×/month at current shipping velocity.
+
+### `[Unreleased]` expectations
+
+- Every user-visible change (feature, fix, deprecation, security patch, non-trivial perf) gets a one-line entry in root `CHANGELOG.md` under `[Unreleased]` in the matching section (`### Added`, `### Fixed`, `### Changed`, `### Security`, `### Dependencies`).
+- Per-package CHANGELOGs (`packages/core/CHANGELOG.md`, etc.) get an `[Unreleased]` entry **only** if the change ships in that package. The root CHANGELOG is the monorepo-wide log; per-package CHANGELOGs are package-specific.
+- Reference the Linear issue (`SMI-NNNN`) and PR number in every entry.
+
+### GitHub Release creation
+
+Two paths, both automatic:
+
+1. **CI publish** (preferred): `gh workflow run publish.yml -f dry_run=false`. On success, a `create-gh-release` job extracts the version's CHANGELOG section and calls `gh release create` per package. Tag convention: `@skillsmith/<name>-v<X.Y.Z>` (matches the 2026-03-07 precedent).
+2. **Local fallback** (`npm publish --ignore-scripts -w`, documented in CLAUDE.md): if used, a scheduled workflow (`detect-release-drift.yml`) runs hourly and creates any missing GH Releases it finds by comparing `npm view <pkg>` against the latest GH Release tag. Drift-healed releases are indistinguishable from CI-created ones downstream.
+
+**If you local-publish, create the GH Release yourself** immediately after:
+
+```bash
+gh release create "@skillsmith/core-v$(jq -r .version packages/core/package.json)" \
+  --title "@skillsmith/core v$(jq -r .version packages/core/package.json)" \
+  --notes-file <(node scripts/extract-changelog-section.mjs --package packages/core --version $(jq -r .version packages/core/package.json))
+```
+
+Reason: between the local publish and the drift detector's next tick (up to 60 min), users installing from npm see the new version without any release notes discoverable via normal channels. The drift detector is a safety net, not the primary path.
+
+### Website changelog
+
+[skillsmith.app/changelog](https://skillsmith.app/changelog) is generated at build time from the GitHub Releases API. No action required from contributors — releases appear on the website when Vercel rebuilds (usually within minutes of a release being published).
+
 ## Internal Documentation
 
 Internal documentation is in a private submodule at `docs/internal/`. Access requires Smith Horn GitHub org membership. The `--recurse-submodules` flag is optional when cloning.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
+## [Unreleased]
+
+_No unreleased changes._
+
 ## v0.5.4
 
-- Version bump
+- **Fix**: Version bump to align with core 0.5.1 and mcp-server 0.4.9 floors (#548).
 
 ## v0.5.3
 
-- **Docs**: bump internal submodule for SMI-4181/4184 GSC audit plan (#539)
+- **Docs**: bump internal submodule for SMI-4181/4184 GSC audit plan (#539).
 
 ## v0.5.2 (2026-03-24)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,18 +2,19 @@
 
 All notable changes to `@skillsmith/core` are documented here.
 
+## [Unreleased]
+
+- **SMI-4124**: `skill_pack_audit` trigger-quality + namespace collision checks (PR #505).
+
 ## v0.5.1
 
-- Version bump
+- **Fix**: SMI-4182 suppress CodeQL false positive on telemetry hash (#550 retro).
 
 ## v0.4.18
 
-- **Fix**: SMI-4182 suppress CodeQL false positive on telemetry hash
-- **Feature**: SMI-4120 response caching + Cache-Control (#516)
-
-## [Unreleased]
-
-- **Indexer registers addyosmani/agent-skills as high-trust source** (SMI-4122, PR #499).
+- **Fix**: SMI-4182 suppress CodeQL false positive on telemetry hash.
+- **Feature**: SMI-4120 response caching + Cache-Control (#516).
+- **Feature**: Indexer registers addyosmani/agent-skills as high-trust source (SMI-4122, PR #499).
 
 ## v0.4.17
 

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,19 +2,20 @@
 
 All notable changes to `@skillsmith/mcp-server` are documented here.
 
+## [Unreleased]
+
+- **Feature**: SMI-4124 `skill_pack_audit` trigger-quality + namespace collision checks (PR #505).
+
 ## v0.4.9
 
-- Version bump
+- **Feature**: SMI-4183 emit `webhook:subscription_tier_changed` audit events from subscription edge function (#538).
 
 ## v0.4.8
 
-- **Docs**: bump internal submodule for SMI-4181/4184 GSC audit plan (#539)
-- **Docs**: sync website api.astro + mcp-server CHANGELOG (SMI-4140, SMI-4142) (#518)
-- **Docs**: SMI-4122/4123 sync — mcp-server README + CHANGELOGs (#514)
-
-## [Unreleased]
-
-- **Fixed**: `webhook_configure` and `api_key_manage` backing tables restored (SMI-4123). In preview until production migration (SMI-4135).
+- **Docs**: bump internal submodule for SMI-4181/4184 GSC audit plan (#539).
+- **Docs**: sync website api.astro + mcp-server CHANGELOG (SMI-4140, SMI-4142) (#518).
+- **Docs**: SMI-4122/4123 sync — mcp-server README + CHANGELOGs (#514).
+- **Fixed**: `webhook_configure` and `api_key_manage` backing tables restored (SMI-4123, PRs #501/#503/#504). In preview until production migration (SMI-4135).
 
 ## v0.4.7
 


### PR DESCRIPTION
[skip-impl-check]

## Summary

Wave 1 of SMI-4144 release cadence work. Docs + decision record + CHANGELOG hygiene only — no workflow / automation code. Stacked PR for SMI-4191 (automation) will follow once this merges.

**What's here:**
- ADR-114 (proposed): Release Cadence + GitHub Release Alignment — hybrid weekly/threshold cadence + hourly drift detector. Closes the local-publish bypass gap.
- Implementation plan at `docs/internal/implementation/smi-4144-release-cadence.md` — two-wave structure, race/parser specs, risk register, plan-review H+M findings applied.
- ADR index: ADR-113 + ADR-114 entries (113 was a pre-existing omission; fixed here per "no-defer" rule).
- **CHANGELOG hygiene**:
  - Root `CHANGELOG.md [Unreleased]`: add SMI-4118 (pooler URL for audit_logs telemetry) and SMI-4124 (skill_pack_audit trigger-quality).
  - `packages/core/CHANGELOG.md`: restructure — the misplaced `[Unreleased]` under v0.4.18 contained SMI-4122, which actually shipped in v0.4.18. Moved into v0.4.18; added fresh `[Unreleased]` at top with SMI-4124.
  - `packages/mcp-server/CHANGELOG.md`: same restructure for SMI-4123 (drained into v0.4.8); added SMI-4183 to v0.4.9; fresh `[Unreleased]` with SMI-4124.
  - `packages/cli/CHANGELOG.md`: added missing `[Unreleased]` section.
- `CONTRIBUTING.md`: new `## Releases` section documenting cadence, `[Unreleased]` expectations, GH Release paths (CI vs local), tag convention, and the recommended manual `gh release create` flow for local publishes.
- `CLAUDE.md`: one-line pointer to the new CONTRIBUTING Releases section.

**Linear**:
- Parent: SMI-4144 (unchanged)
- This PR: SMI-4190
- Blocks: SMI-4191 (automation wave)
- Related follow-up: SMI-4192 (website changelog UX under new cadence density)

**Review scope**: reviewable in ≤15 minutes. No CI workflow files touched → runs on the code-path CI but with trivial diff surface (only `package.json` changes would trigger full CI, and those aren't in this PR; CHANGELOG / CONTRIBUTING / CLAUDE.md changes are pure docs-path per SMI-3999 filter).

## Test plan

- [ ] Docs-path CI green
- [ ] `docs/internal` submodule pointer resolves to smith-horn/skillsmith-docs#23 head
- [ ] ADR-114 renders cleanly on GitHub; index entries resolve
- [ ] Spot-check: root `CHANGELOG.md` [Unreleased] contains SMI-4118 and SMI-4124 entries
- [ ] Spot-check: `packages/cli/CHANGELOG.md` has `[Unreleased]` section
- [ ] Post-merge: update SMI-4190 to Done, comment merge SHA; SMI-4191 becomes unblocked

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
