### PR TITLE
chore(vscode): bump to 0.2.0 for SMI-4194 Wave 1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   skill assessment (#451).
 - Indexer now indexes addyosmani/agent-skills as high-trust source (SMI-4122, PR #499).
 - **Skill pack audit trigger-quality + namespace checks** (SMI-4124, PR #505): `skill_pack_audit` MCP tool now detects low-quality trigger phrases and namespace collisions in installed skill packs. Surfaces actionable findings before publish.
+- **VS Code extension MCP feature parity Wave 1** (SMI-4194, PR #562): `skillsmith.uninstallSkill` command (palette + tree-view context menu, modal confirmation, symlink-escape protection via `assertInsideRoot`, MCP-first with `fs.rm` fallback); `skillsmith.createSkill` 4-step wizard (delegates to `@skillsmith/cli`, actionable error if CLI absent); anonymous usage telemetry with 3-gate opt-out (`vscode.env.isTelemetryEnabled`, `skillsmith.telemetry.enabled`, no hardcoded endpoint); non-blocking MCP server min-version check with copy-to-clipboard action; Get Started walkthrough (Discover / Install / Author steps); `audit:standards` Checks 27 (skillNameValidation codegen drift) and 28 (command–test pairing) added to CI. `events` edge function `ALLOWED_EVENTS` allowlist and `sanitizeMetadata` extended for VS Code telemetry keys.
 
 ### Fixed
 

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-14
+
 ### Added
 
 - `@vscode/test-electron` integration test harness. Integration tests run on host (not Docker) per ADR-113. New script: `npm run test:integration`. (SMI-4194)

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Discover and install agent skills directly in VS Code",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -15,5 +15,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__/integration/**"]
 }

--- a/vitest.config.root-tests.ts
+++ b/vitest.config.root-tests.ts
@@ -24,6 +24,8 @@ export default defineConfig({
       'supabase/functions/indexer/**',
       // Website tests require Astro tsconfig
       'packages/website/**',
+      // VS Code integration tests require the `vscode` module — run via @vscode/test-electron
+      'packages/vscode-extension/src/__tests__/integration/**',
     ],
   },
 })


### PR DESCRIPTION
## Summary

- Bump \`packages/vscode-extension\` to **0.2.0** (minor — new commands, walkthrough, telemetry per semver).
- Marketplace rejected re-publish of 0.1.6 → unblocks the Wave 1 pre-release.
- Exclude \`src/__tests__/integration/**\` from both \`tsconfig.json\` and \`vitest.config.root-tests.ts\` (mocha globals + \`vscode\` module; both only available under @vscode/test-electron).

## Test plan

- [x] typecheck clean in Docker
- [x] root vitest clean
- [ ] CI green
- [ ] Post-merge: retrigger \`publish-vscode.yml\`

Refs: SMI-4194