### PR TITLE
chore(tooling): linear-api positional args + audit Check 29

### DIFF
--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -1949,6 +1949,47 @@ console.log(`\n${BOLD}29. Smoke-test Export Drift (SMI-4193)${RESET}`)
   }
 }
 
+// 30. VS Code integration tests must be excluded from host typecheck + root vitest.
+// These files import `vscode` / use mocha `suite`/`test` globals and only run under
+// @vscode/test-electron. If they leak into the host tsc/vitest runs they break pre-commit
+// and pre-push hooks on main. Root cause of the SMI-4194 post-merge friction.
+console.log(`\n${BOLD}30. VS Code Integration Tests Excluded from Host Runners${RESET}`)
+{
+  const intDir = 'packages/vscode-extension/src/__tests__/integration'
+  if (!existsSync(intDir)) {
+    pass('No vscode integration tests directory — nothing to check')
+  } else {
+    const tsconfigPath = 'packages/vscode-extension/tsconfig.json'
+    const vitestConfigPath = 'vitest.config.root-tests.ts'
+    const needle = 'src/__tests__/integration/**'
+    const errors = []
+    try {
+      const tsconfig = readFileSync(tsconfigPath, 'utf8')
+      if (!tsconfig.includes(needle)) {
+        errors.push(`${tsconfigPath} exclude list missing '${needle}'`)
+      }
+    } catch {
+      errors.push(`Could not read ${tsconfigPath}`)
+    }
+    try {
+      const vitestConfig = readFileSync(vitestConfigPath, 'utf8')
+      if (!vitestConfig.includes(needle)) {
+        errors.push(`${vitestConfigPath} exclude list missing '${needle}'`)
+      }
+    } catch {
+      errors.push(`Could not read ${vitestConfigPath}`)
+    }
+    if (errors.length === 0) {
+      pass('vscode integration tests excluded from tsconfig + root vitest')
+    } else {
+      fail(
+        errors.join('; '),
+        "Add 'packages/vscode-extension/src/__tests__/integration/**' to both exclude lists — these tests require the vscode module (electron host) and mocha globals."
+      )
+    }
+  }
+}
+
 // npm override drift check: @modelcontextprotocol/sdk override "." must match mcp-server range
 console.log(`\n${BOLD}Override Drift: @modelcontextprotocol/sdk${RESET}`)
 try {

--- a/scripts/linear-api.mjs
+++ b/scripts/linear-api.mjs
@@ -410,10 +410,12 @@ const commands = {
   },
 
   async 'update-status'(args) {
-    const { issue, status } = args
+    const issue = args.issue || args._[1]
+    const { status } = args
 
     if (!issue || !status) {
-      console.error('Error: --issue and --status are required')
+      console.error('Error: issue (positional or --issue) and --status are required')
+      console.error('Example: linear-api.mjs update-status SMI-123 --status done')
       process.exit(1)
     }
 
@@ -423,10 +425,12 @@ const commands = {
   },
 
   async 'add-comment'(args) {
-    const { issue, body } = args
+    const issue = args.issue || args._[1]
+    const body = args.body || args._[2]
 
     if (!issue || !body) {
-      console.error('Error: --issue and --body are required')
+      console.error('Error: issue (positional or --issue) and body (positional or --body) are required')
+      console.error('Example: linear-api.mjs add-comment SMI-123 "Progress update"')
       process.exit(1)
     }
 


### PR DESCRIPTION
Two immediate fixes from the SMI-4194 Wave 1 post-merge retro.

## Fix 1: linear-api.mjs positional args

`update-status` and `add-comment` now accept positional SMI-xxx and body. Matches the natural invocation that tripped us twice during the session.

## Fix 2: audit-standards Check 29

Verifies `packages/vscode-extension/src/__tests__/integration/**` is in both `tsconfig.json` and `vitest.config.root-tests.ts` exclude lists. Root cause of the PR #562 → PR #564 friction.

## Larger frictions (tracked separately)

- SMI-4210 — publish-vscode.yml pre-flight Marketplace version check
- SMI-4211 — post-merge verification on main
- SMI-4212 — sync-main.sh divergence summary

## Test plan

- [x] `docker exec skillsmith-dev-1 node scripts/audit-standards.mjs` — Check 29 passes
- [x] `varlock run -- node scripts/linear-api.mjs add-comment SMI-4194 'test'` works with positional args
- [ ] CI green