### PR TITLE
chore(eslint): ignore VS Code extension integration tests (SMI-4213)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,10 @@ const globalIgnores = {
     // Deno files have incompatible module semantics; lint them with deno lint instead
     'supabase/functions/**',
     'supabase/migrations/**',
+    // VS Code extension integration tests use @vscode/test-electron and Mocha globals
+    // that aren't represented in the TS project graph; they're executed by the VS Code
+    // test runner, not Vitest. Lint them separately if needed.
+    'packages/vscode-extension/src/__tests__/integration/**',
   ],
 }
 


### PR DESCRIPTION
## Summary

`npm run lint` on main currently emits 3 parser errors for files under `packages/vscode-extension/src/__tests__/integration/` because those files are not represented in any `tsconfig.json` project listed in `eslint.config.js`. They use `@vscode/test-electron` and Mocha globals and are executed by the VS Code test runner, not Vitest.

This PR adds them to the global ignores, matching the precedent set for Astro (website), Deno (supabase functions), and Vitest configs.

Shipping this as a standalone PR so the fix lands on main before the SMI-4210/4211/4212 CI safety-net waves stack on top.

[skip-impl-check] — this is a pure ESLint-config fix with no runtime code changes; no implementation tasks apply.

## Test plan

- [x] `docker exec skillsmith-dev-1 npm run lint` passes locally (no parser errors)
- [x] CI Lint job green (3m48s)
- [ ] All required checks green

Linear: SMI-4213

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>