### PR TITLE
chore(scripts): sync-main.sh divergence summary (SMI-4212)

### DIFF
--- a/scripts/sync-main.sh
+++ b/scripts/sync-main.sh
@@ -6,8 +6,38 @@
 set -euo pipefail
 
 # Capture all output, filter noise, report result
-output=$(git checkout main 2>&1 && git fetch origin main 2>&1 && git reset --hard origin/main 2>&1) || {
+output=$(git checkout main 2>&1 && git fetch origin main 2>&1) || {
   # On failure, show unfiltered output for debugging
+  echo "$output"
+  exit 1
+}
+
+# SMI-4212: Divergence summary — before we hard-reset, tell the user why local
+# differs from origin/main so they know whether the reset is discarding real work.
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+if [ "$LOCAL" != "$REMOTE" ]; then
+  AHEAD=$(git rev-list --count "$REMOTE..$LOCAL" 2>/dev/null || echo 0)
+  BEHIND=$(git rev-list --count "$LOCAL..$REMOTE" 2>/dev/null || echo 0)
+  if [ "$AHEAD" -gt 0 ]; then
+    echo "Local ahead by $AHEAD commit(s):"
+    git log --oneline "$REMOTE..$LOCAL" 2>/dev/null | sed 's/^/  /' || true
+    # Squash-merge heuristic: if a local commit's tree matches any of the last 50
+    # origin commits, the content is already on main under a different SHA.
+    RECENT_TREES=$(git log origin/main -n 50 --format='%T' 2>/dev/null || true)
+    for sha in $(git rev-list "$REMOTE..$LOCAL" 2>/dev/null || true); do
+      TREE=$(git rev-parse "$sha^{tree}" 2>/dev/null || true)
+      if [ -n "$TREE" ] && echo "$RECENT_TREES" | grep -q "$TREE" 2>/dev/null; then
+        echo "  └─ $sha matches a recent squash-merge on origin (safe to discard)"
+      fi
+    done || true
+  fi
+  if [ "$BEHIND" -gt 0 ]; then
+    echo "Remote ahead by $BEHIND commit(s)"
+  fi
+fi
+
+output=$(git reset --hard origin/main 2>&1) || {
   echo "$output"
   exit 1
 }


### PR DESCRIPTION
## Summary

- Before hard-resetting to `origin/main`, `sync-main.sh` now prints ahead/behind counts and the commits local is ahead by, so the user can tell whether the reset is discarding real work.
- Tree-match heuristic against the last 50 origin commits flags any local commit whose tree already lives on main under a different SHA (the "post-admin-squash redundant local commit" case from SMI-4194 Wave 1).
- Loops wrapped in `|| true`, BEHIND branch uses `if/then` (the `[ ] && echo` form returns non-zero when BEHIND=0 and would kill the script under `set -euo pipefail`).

Origin: SMI-4194 Wave 1 retro — ~10 min lost debugging a silent reset of redundant local commit 7c6460f8 after the PR squash-merged. Plan: `docs/internal/implementation/smi-4210-4212-ci-safety-net.md` §SMI-4212.

## Test plan

- [x] `bash -n scripts/sync-main.sh` — syntax OK
- [x] `docker exec skillsmith-dev-1 npm run audit:standards` — 44 passed, 0 failed, 96% compliance
- [x] Manual smoke: clean state (`LOCAL == REMOTE`) → no divergence output, exits silently
- [x] Manual smoke: crafted redundant local commit (empty, tree matches latest origin) → "Local ahead by 1 commit(s)" + squash-match line prints
- [ ] CI green on all required checks

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

[skip-impl-check] — shell-only PR, no source-test pairing needed