### PR TITLE
docs(vscode): rewrite CHANGELOG for user-facing prose + document authoring rule

### DIFF
--- a/.claude/development/vscode-publishing-guide.md
+++ b/.claude/development/vscode-publishing-guide.md
@@ -47,6 +47,27 @@ varlock run -- sh -c 'npx @vscode/vsce publish --no-dependencies --pat "$VSCE_SK
 
 TODO: Integrate into `prepare-release.ts` with `--vscode=<bump>` flag (SMI-3702).
 
+## Changelog Authoring
+
+The CHANGELOG ships inside the `.vsix` and renders on the Marketplace "Changelog" tab. Write for a user who has never seen the repo. If a bullet only makes sense with an internal reference, it doesn't belong in the CHANGELOG — put it in the PR description instead.
+
+**Strip** from every entry:
+
+- Linear IDs (`SMI-xxxx`)
+- PR numbers (`#xxx`, `closes #xxx`, `GitHub #xxx`)
+- ADR references (`ADR-xxx`, `per ADR-113`)
+- Internal file paths, helper names, and test-harness wiring (users don't care which helper you extracted)
+- Wave / phase / retro references
+
+| Keep | Strip |
+|------|-------|
+| "Uninstall command — removes an installed skill with a confirmation dialog." | "`skillsmith.uninstallSkill` uses shared `assertInsideRoot` helper. (SMI-4195, closes #485)" |
+| "New setting `skillsmith.mcp.minServerVersion` warns when the MCP server is too old." | "MCP server minimum-version check. (SMI-4194)" |
+| "MCP server is now spawned without a shell, eliminating a command-injection surface." | "Removed `shell: true` from MCP server spawn, replaced with `cross-spawn`. (SMI-3805, GitHub #423)" |
+| "Skill descriptions now render Markdown." | "Extracted shared `SANITIZE_OPTIONS` constant and `renderMarkdown` helper." |
+
+The same rule applies to all public-facing CHANGELOGs in this repo (`packages/*/CHANGELOG.md`, root `CHANGELOG.md`). Internal refs belong in PR descriptions, commit trailers, and retros — not release notes.
+
 ## Pre-Publish Checklist
 
 - [ ] Version bumped in `package.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,8 @@ varlock run -- sh -c 'npx @vscode/vsce publish --no-dependencies --pat "$VSCE_SK
 
 **PAT**: `VSCE_SKILLSMITH` in `.env` (Varlock), `VSCE_PAT` in GitHub Actions. 90-day rotation.
 
+**Changelog**: user-facing only — no `SMI-xxxx`, PR #, ADR, or GitHub issue refs. Ships on the Marketplace "Changelog" tab. See [vscode-publishing-guide.md § Changelog Authoring](.claude/development/vscode-publishing-guide.md#changelog-authoring).
+
 ---
 
 ## Skills & Embedding

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -10,109 +10,98 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- `@vscode/test-electron` integration test harness. Integration tests run on host (not Docker) per ADR-113. New script: `npm run test:integration`. (SMI-4194)
-- Shared `assertInsideRoot` path-containment helper with realpath + `path.relative` and symlink-escape protection. Used by forthcoming uninstall and create commands. (SMI-4194)
-- `skillNameValidation` utility — codegen'd from `@skillsmith/cli` via `scripts/sync-skill-name-validation.mjs`; `audit:standards` enforces drift. (SMI-4194)
-- `src/mcp/McpClient.patterns.md` — wrapper conventions doc for Wave 2–4 tool additions. (SMI-4194)
-- `SkillTreeDataProvider.getInstalledSkills()` and `refreshAndWait()` public API, consumed by forthcoming uninstall command quickPick. (SMI-4194)
-- `viewsWelcome` entry for the skills view now offers both Search and Create actions. (SMI-4194)
-- `skillsmith.uninstallSkill` command — uninstalls an installed skill via the command palette quickPick or the tree view context menu. Destructive action requires modal confirmation showing the skill id and resolved path. Uses shared `assertInsideRoot` to refuse traversal and symlink-escape. Falls back to `fs.rm` when the MCP server is disconnected. (SMI-4195, closes #485)
-- `skillsmith.createSkill` command — 4-step wizard (author → name → description → type) that delegates to the `@skillsmith/cli` via `cross-spawn`. If the CLI is not on `$PATH`, surfaces an actionable error with a one-click copy of the install command and a docs link. Opens the new `SKILL.md` on success and refreshes the installed-skills tree. (SMI-4196, closes #484)
-- `Get Started with Skillsmith` walkthrough with three steps (Discover, Install, Author) accessible from the VS Code Welcome page and `Help: Welcome` command. (SMI-4194)
-- `audit:standards` Check 27 enforces that every `skillsmith.*` command declared in `package.json` has a matching test file under `src/__tests__/`, preventing palette entries from shipping without coverage. (SMI-4194)
-- MCP server minimum-version check. New `skillsmith.mcp.minServerVersion` setting (default `0.4.9`). When the connected MCP server reports a lower `serverInfo.version`, a non-blocking toast offers to copy `npm install -g @skillsmith/mcp-server@latest`. Silent on match or unparseable versions (fail-open). (SMI-4194)
-- Anonymous usage telemetry for parity commands. Respects VS Code's `telemetry.telemetryLevel` and a new `skillsmith.telemetry.enabled` setting (default `true`). Anonymous cohort UUID stored in extension `globalState` — never tied to user accounts. Fire-and-forget POST to `skillsmith.telemetryEndpoint` with a 2s timeout; no endpoint configured by default, so telemetry is a no-op until an operator sets one. Events emitted: `vscode_create_{start,complete,failed,cancelled}` and `vscode_uninstall_{start,complete,failed,cancelled}`. (SMI-4194)
+- **Uninstall Skill** command — remove an installed skill from the command palette or the tree view context menu. Shows a confirmation dialog with the skill id and resolved path before deleting. Works even when the MCP server is disconnected.
+- **Create Skill** command — four-step wizard (author, name, description, type) that scaffolds a new skill and opens its `SKILL.md` when done. Requires the Skillsmith CLI on your `$PATH`; if it's missing, the error surface offers a one-click copy of the install command.
+- **Get Started with Skillsmith** walkthrough (Discover, Install, Author) accessible from the VS Code Welcome page or the `Help: Welcome` command.
+- Skills view now shows both **Search** and **Create** actions when no skills are installed.
+- New setting `skillsmith.mcp.minServerVersion` (default `0.4.9`) — shows a non-blocking toast with an upgrade command when the connected MCP server is older than the configured minimum.
+- Anonymous usage telemetry for the new commands. Off by default: nothing is sent unless an operator configures `skillsmith.telemetryEndpoint`. Respects VS Code's `telemetry.telemetryLevel` and a new `skillsmith.telemetry.enabled` setting. No data is tied to a user account.
+
+### Security
+
+- Uninstall and Create refuse to operate on paths that escape the skills directory via symlink or `..` traversal.
 
 ## [0.1.6] - 2026-04-02
 
 ### Security
 
-- **Shell injection fix**: Removed `shell: true` from MCP server spawn, replaced with `cross-spawn` for safe cross-platform execution (SMI-3805, GitHub #423)
-- Added `validateSpawnArgs()` allowlist in `utils/security.ts` for defense-in-depth input validation
+- MCP server is now spawned without a shell, eliminating a command-injection surface on all platforms.
+- Added an allowlist for MCP spawn arguments as defense in depth.
 
 ### Fixed
 
-- `callTool` no longer throws cryptic errors on malformed MCP responses — defensive JSON.parse with try/catch and response shape validation (SMI-3801, GitHub #433)
-- Detail panel no longer stuck on "Loading..." forever when MCP fails — shows accessible error HTML with retry button (SMI-3802, GitHub #432)
-- Category completion snippet now produces valid YAML with closing quote (SMI-3803, GitHub #425)
-- Hover provider now works on all top-level frontmatter fields (`name`, `description`, `version`, etc.) (SMI-3804, GitHub #424)
+- Malformed MCP responses no longer throw cryptic errors — the extension now shows a readable message and a retry button.
+- The skill detail panel no longer gets stuck on "Loading…" when the MCP server fails; it shows an accessible error with a retry button.
+- The `category` completion snippet now produces valid YAML.
+- Hover docs now work on every top-level frontmatter field (`name`, `description`, `version`, and others).
 
 ### Added
 
-- `getErrorHtml()` with CSP nonce, `aria-live="polite"`, `role="alert"`, and retry button with "Retrying..." feedback
-- `mapErrorToUserMessage()` maps common errors (ECONNREFUSED, JSON parse, etc.) to user-friendly messages
-- 37 new tests across 5 test files
+- Common errors (connection refused, invalid JSON, and similar) now map to plain-language messages in the UI.
 
 ## [0.1.5] - 2026-03-29
 
 ### Fixed
 
-- Inferred GitHub URL fallback no longer produces 404s for `claude-plugins/UUID` skill IDs
-- Community trust badge color meets WCAG AA 4.5:1 contrast ratio (`#ffc107` → `#b8960a`) (SMI-3707)
-- Repository link spans now keyboard-focusable with `tabindex`, `role="link"`, and Enter/Space handler (SMI-3724)
+- The inferred GitHub URL fallback no longer produces 404s for skills whose id uses a UUID segment.
+- The Community trust badge color now meets WCAG AA 4.5:1 contrast.
+- Repository links in the detail panel are now keyboard focusable and activate with Enter or Space.
 
 ### Added
 
-- "No repository URL available" placeholder when no repo URL exists (SMI-3723)
-- Extracted `inferRepositoryUrl()` to `skill-panel-helpers.ts` with UUID rejection and GitHub name validation
-- 10 unit tests for `inferRepositoryUrl`, 6 integration tests for new UX behaviors
+- Clear "No repository URL available" placeholder when a skill has no repo URL, instead of a broken link.
 
 ### Changed
 
-- "View Repository" button only appears for explicit repository URLs (suppressed for inferred)
+- The "View Repository" button only appears when the skill declares an explicit repository URL — it's suppressed when the URL was only inferred.
 
 ## [0.1.4] - 2026-03-29
 
 ### Added
 
-- Markdown rendering for skill descriptions (headers, bullets, links now display correctly)
-- Repository URL carried through from search results (SMI-3722)
-- Inferred GitHub URL fallback for author/name skill IDs with hostname validation
-- Delegated link click handler for markdown content with trusted domain allowlist
-- Confirmation dialog for external links to untrusted domains
-- New test file: skill-panel-html.test.ts (22 tests)
+- Skill descriptions now render Markdown — headers, bullets, and links display correctly.
+- Repository URLs from search results flow through to the detail panel.
+- Fallback GitHub URL inference for skills published with `author/name` ids.
+- Confirmation dialog before opening external links to untrusted domains.
 
 ### Changed
 
-- Extracted shared `SANITIZE_OPTIONS` constant and `renderMarkdown` helper
-- Description section uses `<div>` with markdown rendering instead of plain `<p>`
-- Heading sizes capped at 14px inside description to prevent accidental inflation
+- Heading sizes inside descriptions are capped to prevent oversized text from breaking the layout.
 
 ### Security
 
-- Trusted domain allowlist (github.com, gitlab.com, skillsmith.app) for external links
-- Inferred URLs validated via `new URL()` + hostname check before rendering
+- External links are restricted to a trusted domain allowlist (`github.com`, `gitlab.com`, `skillsmith.app`). Inferred URLs are validated before being rendered.
 
 ## [0.1.3] - 2026-03-28
 
 ### Changed
 
-- Promoted to first stable Marketplace release
-- Added Marketplace publishing infrastructure (README, CHANGELOG, icon, CI workflow)
+- First stable Marketplace release.
 
 ## [0.1.2] - 2026-03-27
 
 ### Added
 
-- SKILL.md content rendering in skill detail panel with markdown-to-HTML sanitization (SMI-3672)
-- 10KB content truncation with expandable "Show full content" button
-- XSS prevention via sanitize-html allowlist (strips script, iframe, event handlers)
+- `SKILL.md` content now renders in the skill detail panel, with Markdown-to-HTML sanitization.
+- Long content is truncated at 10 KB with an expandable "Show full content" button.
+
+### Security
+
+- Rendered skill content is sanitized to strip `script`, `iframe`, and inline event handlers.
 
 ## [0.1.1] - 2026-03-20
 
 ### Added
 
-- MCP client integration for live Skillsmith API data
-- SkillService layer with MCP-first and mock fallback pattern
-- Content mapping from API response to detail panel
+- Live data from the Skillsmith API via the MCP client, with an automatic fallback to mock data when the server is unreachable.
 
 ## [0.1.0] - 2026-03-15
 
 ### Added
 
-- Activity bar icon and sidebar skill tree view
-- Skill search with trust tier and category filtering
-- Skill detail webview panel with score breakdown and metadata
-- Mock data fallback for offline use
-- MCP server auto-connect with configurable timeout and reconnection
-- Install command for one-click skill installation
+- Activity bar icon and sidebar skill tree view.
+- Skill search with trust-tier and category filters.
+- Skill detail panel with score breakdown and metadata.
+- One-click install command.
+- Automatic MCP server connection with configurable timeout and reconnection.
+- Offline mock-data fallback.


### PR DESCRIPTION
## Summary

- Rewrite `packages/vscode-extension/CHANGELOG.md` entries `[0.1.0]` through `[0.2.0]` in user-facing prose. Version numbers and dates preserved; only prose changes.
- Add `## Changelog Authoring` section to `.claude/development/vscode-publishing-guide.md` with a Keep/Strip table so the rule is discoverable before the next bump.
- Add a one-line pointer in CLAUDE.md's VS Code Extension section.

## Why

The CHANGELOG ships inside the `.vsix` and renders on the Marketplace "Changelog" tab. It was leaking internal references (Linear IDs, PR numbers, ADR references, internal file paths, test-harness wiring) that mean nothing to a user downloading the extension.

The absence of a written rule is why the drift happened, so the fix is **rule + cleanup**, not just cleanup.

## Verification

- `rg 'SMI-|closes #|GitHub #|\(PR #|ADR-' packages/vscode-extension/CHANGELOG.md` → 0 matches
- `docker exec skillsmith-dev-1 npx prettier --check <changed files>` → passes
- `docker exec skillsmith-dev-1 npx markdownlint-cli2 <changed files>` → 0 errors

## Out of scope (follow-up)

- Root `CHANGELOG.md` and `packages/{core,mcp-server,cli}/CHANGELOG.md` have the same kind of leakage. Same rule applies. File a follow-up chore.
- `scripts/prepare-release.ts` may be the source of the leakage if it pulls commit subjects verbatim. Investigate separately.

## Test plan

- [ ] CI Markdown Lint + Prettier green
- [ ] Reviewer opens `packages/vscode-extension/CHANGELOG.md` and confirms every bullet reads as release notes a Marketplace user would find useful

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)