### PR TITLE
chore(ci): move Marketplace version check to validate job (SMI-4210)

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -48,6 +48,27 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Marketplace pre-flight (version collision check)
+        id: preflight
+        run: |
+          VERSION=$(node -e "console.log(require('./packages/vscode-extension/package.json').version)")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          PUBLISHED=$(npx @vscode/vsce show skillsmith.skillsmith-vscode --json 2>/dev/null | node -e "
+            let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+              try { console.log(JSON.parse(d).versions[0].version) } catch { console.log('none') }
+            })
+          " || echo "none")
+          echo "published=$PUBLISHED" >> $GITHUB_OUTPUT
+          echo "## Marketplace Pre-Flight" >> $GITHUB_STEP_SUMMARY
+          if [ "$VERSION" = "$PUBLISHED" ]; then
+            echo "- **Status**: COLLISION" >> $GITHUB_STEP_SUMMARY
+            echo "- **Current published**: $PUBLISHED" >> $GITHUB_STEP_SUMMARY
+            echo "- **Local version**: $VERSION" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Version $VERSION is already published. Bump packages/vscode-extension/package.json 'version' field and add a CHANGELOG entry before re-running."
+            exit 1
+          fi
+          echo "- **Next version target**: $VERSION (current published: $PUBLISHED)" >> $GITHUB_STEP_SUMMARY
+
       - name: Install dependencies
         run: npm ci --workspace=packages/vscode-extension --include-workspace-root
         env:
@@ -97,22 +118,12 @@ jobs:
         env:
           npm_config_engine_strict: false
 
-      - name: Check if version already published
+      - name: Resolve version
         id: version-check
         run: |
           VERSION=$(node -e "console.log(require('./packages/vscode-extension/package.json').version)")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          PUBLISHED=$(npx @vscode/vsce show skillsmith.skillsmith-vscode --json 2>/dev/null | node -e "
-            let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
-              try { console.log(JSON.parse(d).versions[0].version) } catch { console.log('none') }
-            })
-          " || echo "none")
-          echo "published=$PUBLISHED" >> $GITHUB_OUTPUT
-          if [ "$VERSION" = "$PUBLISHED" ]; then
-            echo "::error::Version $VERSION is already published to the Marketplace"
-            exit 1
-          fi
-          echo "Publishing version $VERSION (latest published: $PUBLISHED)"
+          echo "Publishing version $VERSION (pre-flight validated in validate job)"
 
       - name: Build
         run: npm run build -w packages/vscode-extension


### PR DESCRIPTION
## Summary

- Moves the "Check if version already published" step from the `publish` job to the start of the `validate` job in `publish-vscode.yml`.
- Fails in <30s (vs ~5 min previously) when the local version matches what's already on the Marketplace.
- Emits a job summary with `Next version target: X.Y.Z (current published: A.B.C)` so authors can see the target without opening the Marketplace.
- On collision, prints the manual bump path: update `packages/vscode-extension/package.json` `version` field + add a CHANGELOG entry before re-running.

Automated `prepare-release.ts --vscode` bump is deferred to a follow-up issue.

Part of CI Safety Net (SMI-4210/4211/4212). Wave 0 (SMI-4194 lint fix) merged as #566, Wave 1 (SMI-4212 sync-main divergence) merged as #567.

[skip-impl-check]

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `audit:standards` clean (43 passed, 2 warnings, 0 failed — unchanged from baseline)
- [ ] CI green on PR
- [ ] Follow-up: dry-run `publish-vscode.yml` on current published version → fails fast with bump path in summary

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)