### PR TITLE
ci: post-merge verify workflow (SMI-4211)

### DIFF
--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -1,0 +1,80 @@
+name: Post-Merge Verify
+
+# Runs host-equivalent typecheck + root-vitest config after every push to main,
+# catching config drift (e.g. integration-test types, root vitest exclusions)
+# that the PR matrix does not exercise.
+#
+# See docs/internal/implementation/smi-4210-4212-ci-safety-net.md (SMI-4211).
+#
+# Rollback: rename this file to `post-merge-verify.yml.disabled` or set
+# `if: false` on the `verify` job. Close any open auto-issues manually.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'scripts/**'
+      - '.claude/**'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Start Docker dev container
+        run: docker compose --profile dev up -d --wait
+
+      - name: Install dependencies
+        run: docker exec skillsmith-dev-1 npm ci
+
+      - name: Typecheck (full workspace)
+        run: docker exec skillsmith-dev-1 npm run typecheck
+
+      - name: Root vitest config (SMI-3502 runner)
+        run: docker exec skillsmith-dev-1 npx vitest run --config vitest.config.root-tests.ts
+
+      - name: File or update auto-issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="Post-merge verify failed on main"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY=$(cat <<EOF
+          Post-merge verification failed on \`main\`.
+
+          - Commit: ${{ github.sha }}
+          - Run: $RUN_URL
+          - Triggered by: @${{ github.actor }}
+
+          This workflow runs host-equivalent typecheck and the root vitest config
+          (\`vitest.config.root-tests.ts\`) which are not covered by the PR matrix.
+          See \`docs/internal/implementation/smi-4210-4212-ci-safety-net.md\` (SMI-4211).
+          EOF
+          )
+          EXISTING=$(gh issue list \
+            --label post-merge-verify \
+            --state open \
+            --search "$TITLE in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Commenting on existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            echo "Filing new auto-issue"
+            gh issue create \
+              --title "$TITLE ($RUN_URL)" \
+              --body "$BODY" \
+              --label ci-failure,post-merge-verify
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/post-merge-verify.yml` which, on every push to `main`, runs:
  - `docker exec skillsmith-dev-1 npm run typecheck` (full workspace; catches tsconfig drift)
  - `docker exec skillsmith-dev-1 npx vitest run --config vitest.config.root-tests.ts` (root runner not in PR matrix)
- On failure, files a new issue labeled `ci-failure,post-merge-verify` OR comments on an existing open one (dedup).
- Observer, not a gate — excluded from branch protection. Scoped to `push: main` with `paths-ignore` for docs/scripts/.claude.
- Closes Wave 3 of the SMI-4210/4211/4212 CI safety-net plan.

Part of: SMI-4211 (H). Waves 1 and 2 already on main (#567 SMI-4212, #569 SMI-4210).
Plan: `docs/internal/implementation/smi-4210-4212-ci-safety-net.md` §SMI-4211

## Context

PR #562 (SMI-4194 Wave 1) broke host `tsc` and `vitest.config.root-tests.ts` on main even though CI was green, because the PR matrix does not exercise those two runners. Next developer hit the failure in preflight. This workflow closes that gap.

## Rollback

- Rename the workflow file to `post-merge-verify.yml.disabled` via PR, **or**
- Set `if: false` on the `verify` job.
- No state to clean up beyond any open auto-issues (close manually).

False-positive tolerance: <=2 per 7 days acceptable; >2 triggers `paths-ignore` tuning.

## Test plan

- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `audit:standards` passes in Docker (43 passed / 2 warn / 0 fail, 96% compliance)
- [ ] CI checks green on this PR
- [ ] After merge, first self-run on the merge commit reports success (or fails cleanly with an auto-issue)

[skip-impl-check]

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>