### PR TITLE
fix(ci): detect git-crypt lock in root vitest config (SMI-4221)

### DIFF
--- a/.claude/development/ci-reference.md
+++ b/.claude/development/ci-reference.md
@@ -42,7 +42,7 @@ to the exclude list.
 | Workflow            | Unlocks git-crypt | Vitest config                     | Encrypted tests run? |
 |---------------------|-------------------|-----------------------------------|----------------------|
 | Pre-push (`.husky`) | Yes (dev env)     | root + per-package                | Yes                  |
-| `ci.yml` PR matrix  | Yes (action step) | scoped (`scripts/tests supabase`) | Yes                  |
+| `ci.yml` PR matrix  | Yes (action step) | scoped (`scripts/tests supabase/functions`) | Yes                  |
 | `post-merge-verify` | No                | root                              | No (skipped)         |
 
 Coverage trade-off: drift in `supabase/functions/**/*.test.ts` is caught only

--- a/.claude/development/ci-reference.md
+++ b/.claude/development/ci-reference.md
@@ -32,6 +32,24 @@ The CI system classifies changes into tiers to run appropriate checks:
 | `scripts/ci/classify-changes.ts` | Classifies commits into tiers |
 | `scripts/ci/detect-affected.ts` | Detects affected packages |
 
+### Git-Crypt and root vitest config (SMI-4221)
+
+`vitest.config.root-tests.ts` detects git-crypt lock state at load by reading
+the first 9 bytes of `supabase/functions/_shared/cors.ts` and checking for the
+`\x00GITCRYPT` magic header. When locked, it appends `supabase/functions/**`
+to the exclude list.
+
+| Workflow            | Unlocks git-crypt | Vitest config                     | Encrypted tests run? |
+|---------------------|-------------------|-----------------------------------|----------------------|
+| Pre-push (`.husky`) | Yes (dev env)     | root + per-package                | Yes                  |
+| `ci.yml` PR matrix  | Yes (action step) | scoped (`scripts/tests supabase`) | Yes                  |
+| `post-merge-verify` | No                | root                              | No (skipped)         |
+
+Coverage trade-off: drift in `supabase/functions/**/*.test.ts` is caught only
+by the PR matrix, not by post-merge-verify. Accepted because unlocking
+git-crypt in post-merge-verify would duplicate PR-matrix coverage and defeat
+SMI-4211's drift-detection intent. Refs: SMI-4221, SMI-2672.
+
 ## Turborepo Build Orchestration (SMI-2196)
 
 ```bash

--- a/vitest.config.root-tests.ts
+++ b/vitest.config.root-tests.ts
@@ -3,8 +3,28 @@
 // without re-running workspace tests/ directories.
 // Colocated src/ tests are here (not in package configs) because adding them
 // to core's config caused CI OOM (147 files vs 120 with memory benchmarks).
+import { existsSync, readFileSync } from 'node:fs'
 import { defineConfig } from 'vitest/config'
 import { sharedTestConfig } from './vitest.preset'
+
+// SMI-4221: Detect git-crypt lock state at config load. If a known-encrypted
+// sentinel file starts with the git-crypt magic header (\x00GITCRYPT), the
+// working tree is locked here — typical of a vanilla CI checkout without the
+// git-crypt key (e.g. post-merge-verify.yml). Skip encrypted test paths in
+// that case. Pre-push and ci.yml PR matrix both unlock first, so those paths
+// still run there. Ref: SMI-4221, SMI-2672.
+function gitCryptLocked(): boolean {
+  const sentinel = 'supabase/functions/_shared/cors.ts'
+  if (!existsSync(sentinel)) return false
+  try {
+    const head = readFileSync(sentinel).subarray(0, 9).toString('binary')
+    return head.startsWith('\x00GITCRYPT')
+  } catch {
+    return false
+  }
+}
+
+const encryptedPathsExcluded = gitCryptLocked() ? ['supabase/functions/**'] : []
 
 export default defineConfig({
   test: {
@@ -22,6 +42,9 @@ export default defineConfig({
       '**/node_modules/**',
       '**/dist/**',
       'supabase/functions/indexer/**',
+      // In locked CI checkouts, supabase/** is git-crypt ciphertext.
+      // Pre-push and ci.yml matrix decrypt. Refs: SMI-4221, SMI-2672.
+      ...encryptedPathsExcluded,
       // Website tests require Astro tsconfig
       'packages/website/**',
       // VS Code integration tests require the `vscode` module — run via @vscode/test-electron


### PR DESCRIPTION
## Summary

- Fixes post-merge-verify failing red with 91 test failures (run 24477084587, auto-issue #573)
- Adds runtime git-crypt lock detection to `vitest.config.root-tests.ts`; excludes `supabase/functions/**` when the sentinel encrypted file starts with the git-crypt magic header
- Documents the CI vs local asymmetry in `.claude/development/ci-reference.md`

Follow-up to SMI-4220 (PR #572, `be921138`). Plan: `docs/internal/implementation/smi-4221-post-merge-verify-ci-safe.md` (reviewed via `/plan-review-skill`, 11 findings applied).

## Root cause

`vitest.config.root-tests.ts` includes `supabase/functions/**/*.test.ts`, but CI has no git-crypt key — those files are null-byte ciphertext. esbuild `Unexpected "\x00"` errors cascade to co-located package tests (`context.test.ts`, `compare.test.ts`, `get-skill.test.ts`, etc.) in the same Vitest invocation.

## Approach

Detection over env-var gating: reads the first 9 bytes of `supabase/functions/_shared/cors.ts` and checks for `\x00GITCRYPT` magic header. Decouples from `process.env.CI` conventions and ties directly to the actual problem (lock state).

## Verification

- **Unlocked local run** (pre-push parity): 128 files / 2527 tests pass, supabase/functions tests included
- **Simulated-locked run** (sentinel overwritten with `\x00GITCRYPT` bytes): 114 files / 2287 tests pass — confirms co-located-test failures were esbuild cascade from encrypted files in the same pool
- `npm run typecheck` — clean
- `npm run audit:standards` — 96% compliance, 0 failures
- `npx prettier --check` — clean
- `/governance` review — PASS (1 minor doc fix applied)

## Test plan

- [x] Local unlocked vitest: 128 files pass
- [x] Local simulated-locked vitest: 114 files pass (supabase excluded, no cascade)
- [x] Preflight + governance clean
- [ ] CI green (ci.yml PR matrix)
- [ ] Post-merge-verify green on the merge commit
- [ ] Auto-issue #573 closed

Closes #573

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)


[skip-impl-check] — The behavioral change is in `vitest.config.root-tests.ts` at the repo root, which `scripts/ci/verify-implementation.ts` categorizes as `config` (its `SOURCE_PATTERNS` only cover `packages/`, `supabase/functions/`, `scripts/`). This is a legitimate source change despite the file location.
