### PR TITLE
fix(ci): remove --ignore-scripts from post-merge-verify install (SMI-4239)

### DIFF
--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -5,13 +5,17 @@ name: Post-Merge Verify
 # that the PR matrix does not exercise.
 #
 # SMI-4220: This workflow runs natively on ubuntu-latest, not inside Docker.
-# Scope is deliberately narrow — typecheck + root vitest config are pure
-# compile-time TS/JS checks. Neither exercises better-sqlite3 or
-# onnxruntime-node native bindings (WASM fallback covers any runtime path).
-# ADR-002 (Docker-first) still applies to package builds, tests that load
-# native modules, and developer workflows; this observer is a scoped
-# exception. If a future root-test starts loading SQLite natively, this
-# workflow will silently pass — add it to a package-level vitest config.
+# ADR-002 (Docker-first) applies to package builds and developer workflows;
+# this CI observer runs natively because the runner environment is
+# reproducible, and adding Docker would roughly double runtime for a
+# non-gating job.
+# SMI-4239: npm ci runs install lifecycle scripts so better-sqlite3 and
+# onnxruntime-node prebuilt binaries are available. The co-located package
+# tests in vitest.config.root-tests.ts load these via new Database() and
+# service contexts — without scripts, module-load fails. This matches the
+# behavior of ci.yml, batch-transform.yml, and all publish workflows.
+# If a new native module enters the dep tree, it must ship prebuilt binaries
+# for linux-x64 on Node 22 — otherwise this workflow will fail at module-load.
 #
 # See docs/internal/implementation/smi-4210-4212-ci-safety-net.md (SMI-4211).
 #
@@ -53,7 +57,7 @@ jobs:
           gh label create post-merge-verify --color FBCA04 --description "Post-merge verification observer" 2>/dev/null || true
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
 
       - name: Typecheck (full workspace)
         run: npm run typecheck


### PR DESCRIPTION
## Summary

- Follow-up to SMI-4238 (PR #575, `3f11b2bd`). That fix eliminated the encrypted-tests cascade; this fix addresses the independent second cause it surfaced.
- Removes `--ignore-scripts` from `.github/workflows/post-merge-verify.yml` so `better-sqlite3` prebuilds install.
- Rewrites the misleading workflow header comment.

## Root cause

`npm ci --ignore-scripts` skips the install lifecycle. Co-located tests in `vitest.config.root-tests.ts` (AdvisoryRepository, MCP-server context tests, CLI audit) load SQLite via `new Database()` and fail at module-load. Observed on post-merge-verify [run 24481412245](https://github.com/smith-horn/skillsmith/actions/runs/24481412245): 15 files / 91 tests failed with `Native SQLite module (better-sqlite3) is not available`.

## Supply-chain parity

`post-merge-verify.yml` was the only workflow in the repo using `--ignore-scripts`. `ci.yml`, `batch-transform.yml`, and all publish workflows already run bare `npm ci`. This change brings post-merge-verify into parity; it does **not** add new supply-chain surface.

## Verification

- **Repro with `--ignore-scripts`**: 15 files / 91 tests failed locally — exact match with CI
- **Fix with plain `npm ci`**: 128/128 files, 2538/2538 tests pass locally
- `npm run typecheck` clean
- `npm run audit:standards` — 0 failures (3 pre-existing warnings untouched)
- `/governance` PASS — 0 issues

## Test plan

- [x] Wave 0 local verification (repro + fix confirmed)
- [x] Pre-commit + governance clean
- [ ] PR CI green
- [ ] Post-merge-verify green on the merge commit
- [ ] Issue #573 auto-closes

[skip-impl-check] — YAML-only workflow change at repo root; `scripts/ci/verify-implementation.ts` classifies this as config (root files don't match its SOURCE_PATTERNS). Per SMI-4238 retro.

Linear: SMI-4239.
Plan: `docs/internal/implementation/smi-4239-post-merge-verify-ignore-scripts.md`

Closes #573

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)