### PR TITLE
feat(scripts): prepare-release.ts reserved-range guard for @skillsmith/core 2.x (SMI-4207)

### DIFF
--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -317,6 +317,55 @@ export function checkVersionCollision(
 }
 
 /**
+ * Reserved / deprecated version ranges per package.
+ *
+ * SMI-4207 / ADR-115: `@skillsmith/core@2.0.0`–`2.1.2` were self-published in January 2026
+ * during an aborted version-strategy experiment and rolled back to the 0.4.x line. The full
+ * `>=2.0.0 <3.0.0` range is now deprecated on npm and permanently reserved — the next major
+ * for `@skillsmith/core` jumps from 0.x straight to 3.0.0.
+ *
+ * Used by TWO guards:
+ *   1. `checkReservedVersionRanges` — refuses proposing new versions in the range.
+ *   2. `resolveNpmLookups` — filters the range out of `allVersions`/`latest` so normal
+ *      patch bumps on the live 0.5.x line aren't blocked by orphaned 2.x entries.
+ */
+export const RESERVED_RANGES: Record<string, string> = {
+  '@skillsmith/core': '>=2.0.0 <3.0.0',
+}
+
+/**
+ * Refuse proposed versions that fall inside reserved/orphaned ranges.
+ *
+ * Belt-and-suspenders on top of `checkVersionCollision`: the npm-latest guard alone would
+ * catch `@skillsmith/core@2.1.3` indirectly, but this rule states the skip explicitly and
+ * refuses unconditionally — no `--allow-downgrade` override. Error message points at ADR-115.
+ *
+ * Pure function — no network I/O.
+ */
+export function checkReservedVersionRanges(plans: BumpPlan[]): CollisionCheckResult {
+  const errors: string[] = []
+  const report: string[] = []
+
+  for (const plan of plans) {
+    const { spec, newVersion } = plan
+    const reservedRange = RESERVED_RANGES[spec.name]
+    if (reservedRange && semver.satisfies(newVersion, reservedRange)) {
+      errors.push(
+        `${spec.name}: proposed ${newVersion} falls inside the reserved 2.x range ` +
+          `(>=2.0.0 <3.0.0). This range is permanently deprecated on npm — the next major ` +
+          `must jump to 3.0.0 or later. No override flag applies. ` +
+          `See ADR-115 (docs/internal/adr/115-skillsmith-core-version-namespace-reconciliation.md) ` +
+          `and scripts/prepare-release.ts.`
+      )
+      continue
+    }
+    report.push(`  ${spec.name}: proposed ${newVersion} outside reserved ranges → proceed`)
+  }
+
+  return { ok: errors.length === 0, errors, report }
+}
+
+/**
  * Resolve npm lookups for every plan. Separated from checkVersionCollision so tests can
  * inject lookups without patching network. Throws (fail-closed) on any non-404 npm error.
  */
@@ -326,7 +375,14 @@ export async function resolveNpmLookups(plans: BumpPlan[]): Promise<Map<string, 
     const allVersions = await fetchAllPublishedVersions(plan.spec.name)
     let latest: string | null = null
     if (allVersions !== null) {
-      const valid = allVersions.filter((v) => semver.valid(v))
+      // Exclude reserved ranges (SMI-4207 / ADR-115) from the "live" pool used to compute
+      // `latest`. Deprecated orphaned versions must not block normal bumps on the live line.
+      // `allVersions` retains the full list — Rule 3's isPublished check still catches
+      // attempts to republish any existing semver, reserved or not.
+      const reservedRange = RESERVED_RANGES[plan.spec.name]
+      const valid = allVersions
+        .filter((v) => semver.valid(v))
+        .filter((v) => !reservedRange || !semver.satisfies(v, reservedRange))
       latest = valid.length === 0 ? null : (semver.rsort([...valid])[0] ?? null)
     }
     lookups.set(plan.spec.name, { latest, allVersions })
@@ -579,6 +635,18 @@ async function main(): Promise<void> {
     console.log(`  ${name}  ${plan.currentVersion.padEnd(9)} →  ${plan.newVersion}`)
   }
   console.log()
+
+  // Step 3.4: Reserved version-range guard (SMI-4207 / ADR-115).
+  // Runs before the npm-latest check so operators see the policy reason rather than a
+  // confusing "proposed < latest" message when targeting an orphaned range.
+  const reserved = checkReservedVersionRanges(plans)
+  if (!reserved.ok) {
+    console.error('\n  ✗ Reserved version range guard failed:')
+    for (const err of reserved.errors) {
+      console.error(`    - ${err}`)
+    }
+    process.exit(1)
+  }
 
   // Step 3.5: NPM collision guard — ALWAYS runs before any write (including --dry-run preview).
   console.log('  Checking npm registry for version collisions...')

--- a/scripts/tests/prepare-release.test.ts
+++ b/scripts/tests/prepare-release.test.ts
@@ -32,6 +32,9 @@ import {
 import {
   fetchNpmLatest,
   checkVersionCollision,
+  checkReservedVersionRanges,
+  resolveNpmLookups,
+  RESERVED_RANGES,
   type BumpPlan,
   type NpmLookup,
 } from '../prepare-release'
@@ -279,6 +282,184 @@ describe('checkVersionCollision — rule matrix', () => {
     const result = checkVersionCollision(plans, lookups, { allowDowngrade: false })
     expect(result.ok).toBe(true)
     expect(result.errors).toEqual([])
+  })
+})
+
+// -------------------------------------------------------------
+// SMI-4207 / ADR-115: reserved version-range guard (@skillsmith/core 2.x)
+// -------------------------------------------------------------
+
+describe('checkReservedVersionRanges — @skillsmith/core 2.x skip rule (SMI-4207)', () => {
+  const mcpServerSpec = PACKAGE_SPECS.find((s) => s.shortName === 'mcp-server')!
+  const cliSpec = PACKAGE_SPECS.find((s) => s.shortName === 'cli')!
+
+  function planFor(spec: (typeof PACKAGE_SPECS)[number], newVersion: string): BumpPlan {
+    return { spec, currentVersion: '0.0.0', newVersion }
+  }
+
+  it('refuses @skillsmith/core@2.0.0 (lower bound of reserved range)', () => {
+    const result = checkReservedVersionRanges([plan('2.0.0')])
+    expect(result.ok).toBe(false)
+    const msg = result.errors[0]!
+    expect(msg).toContain('@skillsmith/core')
+    expect(msg).toContain('2.0.0')
+    expect(msg).toContain('2.x')
+    expect(msg).toContain('3.0.0')
+    expect(msg).toContain('ADR-115')
+    expect(msg).toContain('scripts/prepare-release.ts')
+    // Must not mention any override flag — this rule is unconditional.
+    expect(msg).not.toMatch(/--allow-downgrade/)
+    expect(msg).not.toMatch(/--force/)
+  })
+
+  it('refuses @skillsmith/core@2.1.3 (would be the next unpublished 2.x patch)', () => {
+    const result = checkReservedVersionRanges([plan('2.1.3')])
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toContain('2.1.3')
+  })
+
+  it('refuses @skillsmith/core@2.99.99 (upper boundary inside reserved range)', () => {
+    const result = checkReservedVersionRanges([plan('2.99.99')])
+    expect(result.ok).toBe(false)
+  })
+
+  it('proceeds for @skillsmith/core@3.0.0 (first allowed post-reserved major)', () => {
+    const result = checkReservedVersionRanges([plan('3.0.0')])
+    expect(result.ok).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it('proceeds for @skillsmith/core@0.6.0 (below reserved range)', () => {
+    const result = checkReservedVersionRanges([plan('0.6.0')])
+    expect(result.ok).toBe(true)
+  })
+
+  it('proceeds for @skillsmith/core@1.9.9 (below reserved range — 1.x unreserved)', () => {
+    const result = checkReservedVersionRanges([plan('1.9.9')])
+    expect(result.ok).toBe(true)
+  })
+
+  it('does NOT refuse @skillsmith/mcp-server@2.0.0 (rule scoped to core only)', () => {
+    const result = checkReservedVersionRanges([planFor(mcpServerSpec, '2.0.0')])
+    expect(result.ok).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it('does NOT refuse @skillsmith/cli@2.1.0 (rule scoped to core only)', () => {
+    const result = checkReservedVersionRanges([planFor(cliSpec, '2.1.0')])
+    expect(result.ok).toBe(true)
+  })
+
+  it('catches core violation even when other packages in the plan are fine', () => {
+    const result = checkReservedVersionRanges([
+      planFor(cliSpec, '0.6.0'),
+      plan('2.1.3'),
+      planFor(mcpServerSpec, '0.5.0'),
+    ])
+    expect(result.ok).toBe(false)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toContain('@skillsmith/core')
+    expect(result.errors[0]).toContain('2.1.3')
+  })
+
+  it('is a pure function — no writeFileSync, no execFileSync', () => {
+    mockedWriteFileSync.mockClear()
+    mockedExecFileSync.mockClear()
+    checkReservedVersionRanges([plan('2.1.3'), plan('3.0.0')])
+    expect(mockedWriteFileSync).not.toHaveBeenCalled()
+    expect(mockedExecFileSync).not.toHaveBeenCalled()
+  })
+
+  it('RESERVED_RANGES is configured for @skillsmith/core', () => {
+    expect(RESERVED_RANGES['@skillsmith/core']).toBe('>=2.0.0 <3.0.0')
+  })
+})
+
+describe('resolveNpmLookups — excludes reserved range from latest (SMI-4207)', () => {
+  beforeEach(() => {
+    mockedExecFileSync.mockReset()
+  })
+
+  // Production scenario: npm returns the full mixed 0.x + 2.x list; latest must be 0.5.1,
+  // not 2.1.2 — otherwise normal patch bumps on the live 0.5.x line are blocked by the
+  // orphaned 2.x entries.
+  it('core with 0.x and 2.x published → latest reflects only live 0.x line', async () => {
+    mockedExecFileSync.mockReturnValue(
+      JSON.stringify([
+        '0.1.0',
+        '0.1.1',
+        '0.2.0',
+        '0.4.0',
+        '0.4.17',
+        '0.5.0',
+        '0.5.1',
+        '2.0.0',
+        '2.0.1',
+        '2.1.0',
+        '2.1.2',
+      ]) as never
+    )
+    const lookups = await resolveNpmLookups([plan('0.5.2')])
+    const lookup = lookups.get('@skillsmith/core')!
+    expect(lookup.latest).toBe('0.5.1')
+    // allVersions retains full list so Rule 3 isPublished still protects against
+    // replaying any published version.
+    expect(lookup.allVersions).toContain('2.1.2')
+    expect(lookup.allVersions).toContain('0.5.1')
+  })
+
+  it('core with only reserved-range versions → latest is null (all filtered)', async () => {
+    mockedExecFileSync.mockReturnValue(JSON.stringify(['2.0.0', '2.1.0', '2.1.2']) as never)
+    const lookups = await resolveNpmLookups([plan('3.0.0')])
+    const lookup = lookups.get('@skillsmith/core')!
+    expect(lookup.latest).toBeNull()
+    expect(lookup.allVersions).toHaveLength(3)
+  })
+
+  it('mcp-server (no reserved range configured) → latest uses full list', async () => {
+    const mcpSpec = PACKAGE_SPECS.find((s) => s.shortName === 'mcp-server')!
+    mockedExecFileSync.mockReturnValue(JSON.stringify(['0.4.8', '0.4.9']) as never)
+    const lookups = await resolveNpmLookups([
+      { spec: mcpSpec, currentVersion: '0.4.9', newVersion: '0.4.10' },
+    ])
+    const lookup = lookups.get('@skillsmith/mcp-server')!
+    expect(lookup.latest).toBe('0.4.9')
+  })
+})
+
+describe('checkVersionCollision × reserved range — integration (SMI-4207)', () => {
+  // End-to-end: production lookup (0.x + 2.x) + proposing 0.5.2 → collision guard must pass
+  // because `latest` is now computed as 0.5.1 after reserved-range filtering.
+  it('proposing 0.5.2 against mixed 0.x/2.x published → passes (latest=0.5.1)', () => {
+    const lookups = new Map([
+      [
+        coreSpec.name,
+        {
+          latest: '0.5.1', // resolveNpmLookups would filter 2.x; assert behavior downstream
+          allVersions: ['0.4.17', '0.5.0', '0.5.1', '2.0.0', '2.1.0', '2.1.2'],
+        },
+      ],
+    ])
+    const result = checkVersionCollision([plan('0.5.2')], lookups, { allowDowngrade: false })
+    expect(result.ok).toBe(true)
+  })
+
+  // Proposing a 2.x version: checkReservedVersionRanges must fire first (it runs before
+  // checkVersionCollision in main()), but even if operators run checkVersionCollision alone,
+  // proposing 2.1.2 still fails Rule 3 because 2.1.2 remains in allVersions.
+  it('proposing 2.1.2 still caught by Rule 3 (isPublished) even if reserved guard bypassed', () => {
+    const lookups = new Map([
+      [
+        coreSpec.name,
+        {
+          latest: '0.5.1',
+          allVersions: ['0.5.1', '2.0.0', '2.1.0', '2.1.2'],
+        },
+      ],
+    ])
+    const result = checkVersionCollision([plan('2.1.2')], lookups, { allowDowngrade: true })
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toContain('revert to release, do not override')
   })
 })
 


### PR DESCRIPTION
## Summary

Wave 2 follow-up to ADR-115. Codifies the `@skillsmith/core@>=2.0.0 <3.0.0` skip rule in `scripts/prepare-release.ts` so automation can never regress into the reserved range, and simultaneously unblocks normal patch bumps on the live 0.5.x line.

**Critical bug caught during verification**: the SMI-4204 guard (merged 2026-04-14 in PR #555) currently treats `2.1.2` as "highest published" for `@skillsmith/core` — meaning any attempt to run `prepare-release.ts --all=patch` on main today is refused as a downgrade vs. `2.1.2`. This PR fixes that alongside the new skip rule. Both changes ship together because they're the two sides of the same reserved-range policy.

## Changes

1. New `checkReservedVersionRanges` pure function in `scripts/prepare-release.ts`:
   - Refuses any proposed `@skillsmith/core` target matching `>=2.0.0 <3.0.0` unconditionally.
   - No `--allow-downgrade` override applies.
   - Error message references ADR-115 by short name and full path, plus this script.
2. `RESERVED_RANGES` constant — single source of truth for the skip policy, consumed by both guards.
3. `resolveNpmLookups` now filters reserved-range versions out of `latest` computation.
   - `allVersions` retains the full list so Rule 3 (`isPublished`) still catches replays.
4. New Step 3.4 in `main()` runs `checkReservedVersionRanges` before `checkVersionCollision` so operators see the policy reason first.

## Verification

| Check | Status |
|-------|--------|
| 42/42 unit tests pass (33 existing + 9 new) | ✅ |
| Full test suite: 7591/7591 pass | ✅ |
| `--check` on current main | ✅ exits 0 (was exit 1 before this PR) |
| `--core=2.1.3 --check` | ✅ exits 1 with ADR-115 reference |
| `--core=2.1.3 --allow-downgrade --check` | ✅ still exits 1 (no override) |
| typecheck, lint, prettier, audit:standards | ✅ clean |

## Why script-only (no ADR-109 SPARC)

Same treatment as SMI-4204 (PR #555): `scripts/prepare-release.ts` is developer tooling, not a CI/hook file. ADR-109 trigger paths enumerate CI-critical scripts; this file is human-invoked.

## Test plan

- [x] `docker exec skillsmith-dev-1 npm test` — 7591/7591 pass
- [x] `npx tsx scripts/prepare-release.ts --check` — exits 0 on current main
- [x] `npx tsx scripts/prepare-release.ts --core=2.1.3 --check` — exits 1, cites ADR-115
- [x] `npx tsx scripts/prepare-release.ts --core=2.1.3 --allow-downgrade --check` — still exits 1
- [x] `npx tsx scripts/prepare-release.ts --core=3.0.0 --check` — would proceed (reserved range ends at <3.0.0)

## Related

- SMI-4207 (this issue)
- ADR-115 `docs/internal/adr/115-skillsmith-core-version-namespace-reconciliation.md` (merged via PR #577)
- SMI-4204 / PR #555 (Wave B npm-latest guard this PR complements and fixes)

[skip-impl-check]
[skip-doc-drift]