### PR TITLE
docs: post-merge retro — plan-template update + submodule retro+index bump (SMI-4221/4238/4239)

### DIFF
--- a/.claude/templates/implementation-plan.md
+++ b/.claude/templates/implementation-plan.md
@@ -63,3 +63,10 @@ _Add additional waves as needed. Order by risk: database migrations and producti
 - [ ] `docker exec skillsmith-dev-1 npm run preflight`
 - [ ] [Manual testing steps specific to this change]
 - [ ] Linear issue(s) updated with commit SHA
+- [ ] **If this change targets a non-Docker CI workflow** (e.g. `post-merge-verify.yml`,
+      any workflow running on `ubuntu-latest` without the Docker dev container):
+      verify in a clean-install environment — `npm ci` in a fresh clone or after
+      `docker volume rm skillsmith_node_modules`. Do NOT rely on a pre-built Docker
+      volume where native modules (better-sqlite3, onnxruntime-node) are already
+      compiled. The pre-built state masks `--ignore-scripts` and similar install
+      flag errors. (Lesson: SMI-4221/SMI-4239)


### PR DESCRIPTION
## Summary

Post-merge retro follow-up from the SMI-4221/4238/4239 cascade session. Applies the process fix and pulls in the session retro + index correction from the docs submodule.

- `.claude/templates/implementation-plan.md` — Verification section now requires fresh-install testing when a plan targets a non-Docker CI workflow. Pre-built Docker node_modules masked the better-sqlite3 failure in SMI-4238 verification; this rule would have caught it.
- `docs/internal` submodule bump → session retro at `retros/2026-04-15-smi-4221-4239-post-merge-verify-cascade.md` + `index.md` count correction (112 → 120).

## Retrospective highlights

- Wave 0 verification false positive: pre-built native modules in Docker masked the `--ignore-scripts` bug. Template updated.
- Two masking bugs shipped together, discovered sequentially. Rule derived: triage each error class independently.
- `[skip-impl-check]` trap on root config files. Rule derived: PR template for root-config / workflow edits should include marker.
- Linear issue ID drift (plan said SMI-4221, Linear assigned SMI-4238). Rule derived: create Linear issue before opening worktree.
- Subagent committed directly to docs submodule main during retro 2 — caught and rewritten through PR. Rule derived: subagents must follow PR workflow.

Full retro: `docs/internal/retros/2026-04-15-smi-4221-4239-post-merge-verify-cascade.md`

## Test plan

- [x] Retro generated via `/governance` on both #575 and #578 merge commits
- [x] Submodule PR #34 merged
- [ ] CI green

[skip-impl-check] — docs + template + submodule bump only.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)