### PR TITLE
chore(ci): classify root configs and workflow YAML as source (SMI-4243)

### DIFF
--- a/.claude/development/ci-reference.md
+++ b/.claude/development/ci-reference.md
@@ -25,12 +25,15 @@ The CI system classifies changes into tiers to run appropriate checks:
 
 **Important**: Mixed commits (docs + code) trigger full CI. Docs-only commits run lightweight `docs-only.yml`. See [ADR-105](../adr/105-ci-path-filtering.md).
 
+**`verify-implementation.ts` vs `classify-changes.ts` (SMI-4243)**: these answer different questions. `classify-changes.ts` routes a commit to the right CI workflow (tier above). `verify-implementation.ts` asks whether an SMI-referenced PR contains real implementation; its `source` set now includes root-level `*.config.{ts,mjs,cjs,js}` and `.github/workflows/*.{yml,yaml}` so legitimate infra-only PRs pass without `[skip-impl-check]`.
+
 ### CI Scripts
 
 | Script | Purpose |
 |--------|---------|
 | `scripts/ci/classify-changes.ts` | Classifies commits into tiers |
 | `scripts/ci/detect-affected.ts` | Detects affected packages |
+| `scripts/ci/verify-implementation.ts` | Validates SMI-referenced PRs include source changes (SMI-3541, SMI-4243) |
 
 ### Git-Crypt and root vitest config (SMI-4221)
 

--- a/scripts/ci/source-patterns.mjs
+++ b/scripts/ci/source-patterns.mjs
@@ -1,0 +1,26 @@
+/**
+ * Shared file classification patterns (SMI-3540, SMI-3541, SMI-4243).
+ *
+ * Single source of truth for what counts as "source" vs test vs docs.
+ * Consumed by:
+ *   - scripts/ci/verify-implementation.ts — `Verify Implementation Completeness` CI check
+ *   - scripts/linear-hook.mjs — git post-commit hook that drives Linear status transitions
+ *
+ * Keep these lists exhaustive for the classification they represent. Drifting
+ * these between consumers causes CI/hook divergence (the hook says "no source
+ * changes, don't promote" while CI says "pass, has source" or vice versa).
+ */
+
+export const SOURCE_PATTERNS = [
+  /^packages\/.*\.(ts|tsx|js|jsx)$/,
+  /^supabase\/functions\/.*\.(ts|js)$/,
+  /^scripts\/.*\.(ts|js|mjs)$/,
+  // SMI-4243: root-level *.config.{ts,mjs,cjs,js} (vitest.config.ts, lint-staged.config.js, etc.)
+  /^[^/]+\.config(\.[^./]+)?\.(ts|mjs|cjs|js)$/,
+  // SMI-4243: GitHub Actions workflow YAML
+  /^\.github\/workflows\/.*\.ya?ml$/,
+]
+
+export const TEST_PATTERNS = [/\.test\.(ts|tsx|js)$/, /\.spec\.(ts|tsx|js)$/]
+
+export const DOCS_PATTERNS = [/\.md$/, /^\.claude\//, /^docs\//]

--- a/scripts/ci/verify-implementation.ts
+++ b/scripts/ci/verify-implementation.ts
@@ -48,6 +48,10 @@ const SOURCE_PATTERNS = [
   /^packages\/.*\.(ts|tsx|js|jsx)$/,
   /^supabase\/functions\/.*\.(ts|js)$/,
   /^scripts\/.*\.(ts|js|mjs)$/,
+  // SMI-4243: root-level *.config.{ts,mjs,cjs,js} (vitest.config.ts, lint-staged.config.js, etc.)
+  /^[^/]+\.config(\.[^./]+)?\.(ts|mjs|cjs|js)$/,
+  // SMI-4243: GitHub Actions workflow YAML
+  /^\.github\/workflows\/.*\.ya?ml$/,
 ]
 
 const TEST_PATTERNS = [/\.test\.(ts|tsx|js)$/, /\.spec\.(ts|tsx|js)$/]

--- a/scripts/ci/verify-implementation.ts
+++ b/scripts/ci/verify-implementation.ts
@@ -21,6 +21,8 @@
 import { execFileSync } from 'child_process'
 import { appendFileSync, existsSync } from 'fs'
 
+import { SOURCE_PATTERNS, TEST_PATTERNS, DOCS_PATTERNS } from './source-patterns.mjs'
+
 // --- Types ---
 
 export type Verdict = 'pass' | 'warn' | 'fail' | 'skip'
@@ -43,20 +45,6 @@ export interface VerificationResult {
 
 const ISSUE_PATTERN = /\b(SMI-\d+)\b/gi
 const SKIP_MARKER = '[skip-impl-check]'
-
-const SOURCE_PATTERNS = [
-  /^packages\/.*\.(ts|tsx|js|jsx)$/,
-  /^supabase\/functions\/.*\.(ts|js)$/,
-  /^scripts\/.*\.(ts|js|mjs)$/,
-  // SMI-4243: root-level *.config.{ts,mjs,cjs,js} (vitest.config.ts, lint-staged.config.js, etc.)
-  /^[^/]+\.config(\.[^./]+)?\.(ts|mjs|cjs|js)$/,
-  // SMI-4243: GitHub Actions workflow YAML
-  /^\.github\/workflows\/.*\.ya?ml$/,
-]
-
-const TEST_PATTERNS = [/\.test\.(ts|tsx|js)$/, /\.spec\.(ts|tsx|js)$/]
-
-const DOCS_PATTERNS = [/\.md$/, /^\.claude\//, /^docs\//]
 
 const EXCLUDED_FROM_SOURCE = [...TEST_PATTERNS, ...DOCS_PATTERNS]
 

--- a/scripts/linear-hook.mjs
+++ b/scripts/linear-hook.mjs
@@ -20,19 +20,10 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 
-// Source code patterns for implementation verification (SMI-3540)
-const SOURCE_PATTERNS = [
-  /^packages\/.*\.(ts|tsx|js|jsx)$/,
-  /^supabase\/functions\/.*\.(ts|js)$/,
-  /^scripts\/.*\.(ts|js|mjs)$/,
-]
-const EXCLUDED_PATTERNS = [
-  /\.test\.(ts|tsx|js)$/,
-  /\.spec\.(ts|tsx|js)$/,
-  /\.md$/,
-  /^\.claude\//,
-  /^docs\//,
-]
+// SMI-4243: shared with scripts/ci/verify-implementation.ts — single source of truth
+import { SOURCE_PATTERNS, TEST_PATTERNS, DOCS_PATTERNS } from './ci/source-patterns.mjs'
+
+const EXCLUDED_PATTERNS = [...TEST_PATTERNS, ...DOCS_PATTERNS]
 
 // Conventional commit prefixes that do NOT require source code changes
 const NON_SOURCE_PREFIXES = new Set(['docs', 'chore', 'style', 'ci', 'test', 'refactor'])

--- a/scripts/tests/verify-implementation.test.ts
+++ b/scripts/tests/verify-implementation.test.ts
@@ -32,11 +32,33 @@ describe('SMI-3541: verify-implementation', () => {
       expect(categorizeFile('.claude/development/docker-guide.md')).toBe('docs')
     })
 
-    it('should identify config files', () => {
+    it('should identify root config files as source (SMI-4243)', () => {
+      expect(categorizeFile('vitest.config.ts')).toBe('source')
+      expect(categorizeFile('vitest.config.root-tests.ts')).toBe('source')
+      expect(categorizeFile('vitest-e2e.config.ts')).toBe('source')
+      expect(categorizeFile('lint-staged.config.js')).toBe('source')
+      expect(categorizeFile('eslint.config.js')).toBe('source')
+    })
+
+    it('should identify workflow YAML as source (SMI-4243)', () => {
+      expect(categorizeFile('.github/workflows/ci.yml')).toBe('source')
+      expect(categorizeFile('.github/workflows/post-merge-verify.yml')).toBe('source')
+      expect(categorizeFile('.github/workflows/ci.yaml')).toBe('source')
+    })
+
+    it('should still classify JSON configs and non-workflow .github files as config (SMI-4243)', () => {
       expect(categorizeFile('package.json')).toBe('config')
-      expect(categorizeFile('.github/workflows/ci.yml')).toBe('config')
       expect(categorizeFile('tsconfig.json')).toBe('config')
+      expect(categorizeFile('turbo.json')).toBe('config')
+      expect(categorizeFile('.github/CODEOWNERS')).toBe('config')
+      expect(categorizeFile('.github/dependabot.yml')).toBe('config')
       expect(categorizeFile('.eslintrc.json')).toBe('config')
+    })
+
+    it('should NOT reclassify non-config root TS, action YAML, or templates (SMI-4243)', () => {
+      expect(categorizeFile('vitest.preset.ts')).toBe('config')
+      expect(categorizeFile('.github/actions/setup/action.yml')).toBe('config')
+      expect(categorizeFile('.github/PULL_REQUEST_TEMPLATE.md')).toBe('docs')
     })
   })
 


### PR DESCRIPTION
## Summary

- Extends `scripts/ci/verify-implementation.ts` SOURCE_PATTERNS to cover root-level `*.config.{ts,mjs,cjs,js}` and `.github/workflows/*.{yml,yaml}` — legitimate infra-only PRs no longer need the `[skip-impl-check]` marker
- Extracts `SOURCE_PATTERNS`/`TEST_PATTERNS`/`DOCS_PATTERNS` into a shared `scripts/ci/source-patterns.mjs` module so `verify-implementation.ts` (CI check) and `scripts/linear-hook.mjs` (post-commit Linear hook) classify files the same way — eliminates the drift that motivated this PR
- Existing test at `scripts/tests/verify-implementation.test.ts:37` asserting `.github/workflows/ci.yml → config` is flipped to `source`; three new `describe`-blocks lock positive and negative pattern boundaries (20 tests → from 17)

## Why

Retro `docs/internal/retros/2026-04-15-smi-4221-4239-post-merge-verify-cascade.md` §3 captured the `[skip-impl-check]` trap during SMI-4211/4220/4238/4239 shipment. Each of those 4 PRs either forgot the marker (PR #575 wasted one CI cycle) or preemptively added it.

ADR-109 (SPARC + plan-review for infra changes) produces more pure-infra PRs, so the trap compounds.

## Scope

**Included**: root `*.config.{ts,mjs,cjs,js}`, workflow YAML.

**Deliberately excluded**: `package.json`, `tsconfig.json`, `turbo.json`, `.github/CODEOWNERS`, `.github/dependabot.yml`, `.github/ISSUE_TEMPLATE/**`, `.github/actions/*/action.yml`. JSON configs ship routinely without SMI refs — classifying them as source would reduce signal.

Plan: `docs/internal/implementation/smi-4243-verify-impl-source-patterns.md` (lands via separate submodule bump PR).

## Commits

- `28f52bb2` — chore(ci): classify root configs and workflow YAML as source
- `3b7ddbd0` — refactor(ci): extract SOURCE/TEST/DOCS patterns to shared module (governance finding: duplicate `SOURCE_PATTERNS` in `scripts/linear-hook.mjs`)

## Test plan

- [x] `docker exec skillsmith-dev-1 npx vitest run scripts/tests/verify-implementation.test.ts` — 20/20 pass
- [x] `docker exec skillsmith-dev-1 npx vitest run scripts/tests/linear-hook.test.ts` — 14/14 pass (shared-module import resolves)
- [x] `docker exec skillsmith-dev-1 npm run preflight` — clean
- [x] `docker exec skillsmith-dev-1 npm run typecheck` — clean
- [x] `docker exec skillsmith-dev-1 npm run lint` — clean
- [x] `docker exec skillsmith-dev-1 npm run audit:standards` — 96% compliance, no new warnings
- [x] Runtime resolution verified: `node -e "import('./scripts/linear-hook.mjs')"` and `npx tsx scripts/ci/verify-implementation.ts` both load the shared module

## Self-verification

This PR itself does not need `[skip-impl-check]` — it modifies `scripts/ci/**` which is already covered by the existing `scripts/**` source pattern. The new patterns will be exercised by the next infra-only PR (e.g., a workflow tweak tagged with an SMI reference).

Closes SMI-4243