### PR TITLE
chore(release): bump core 0.5.2, mcp-server 0.4.10, cli 0.5.5 (SMI-4240)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
+## v0.5.5
+
+- **Other**: SMI-4190: release cadence docs — ADR-114 + CHANGELOG backfill + CONTRIBUTING (#552)
+
 ## [Unreleased]
 
 _No unreleased changes._

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.5.1",
+    "@skillsmith/core": "^0.5.2",
     "chalk": "5.6.2",
     "cli-table3": "0.6.5",
     "commander": "14.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@skillsmith/core` are documented here.
 
+## v0.5.2
+
+- **Fix**: restore category/security/repo in skill detail view (SMI-4240) (#583)
+- **Other**: SMI-4190: release cadence docs — ADR-114 + CHANGELOG backfill + CONTRIBUTING (#552)
+
 ## [Unreleased]
 
 - **SMI-4124**: `skill_pack_audit` trigger-quality + namespace collision checks (PR #505).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.5.1'
+export const VERSION = '0.5.2'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1024.0",
-    "@skillsmith/core": "^0.5.1",
+    "@skillsmith/core": "^0.5.2",
     "jose": "^6.2.2",
     "zod": "4.2.1"
   },

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@skillsmith/mcp-server` are documented here.
 
+## v0.4.10
+
+- **Fix**: restore category/security/repo in skill detail view (SMI-4240) (#583)
+- **Other**: SMI-4190: release cadence docs — ADR-114 + CHANGELOG backfill + CONTRIBUTING (#552)
+
 ## [Unreleased]
 
 - **Feature**: SMI-4124 `skill_pack_audit` trigger-quality + namespace collision checks (PR #505).

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.5.1",
+    "@skillsmith/core": "^0.5.2",
     "esbuild": "0.27.2"
   },
   "devDependencies": {

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.4.9",
+  "version": "0.4.10",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -71,7 +71,7 @@ import { createLicenseMiddleware } from './middleware/license.js'
 import { createQuotaMiddleware } from './middleware/quota.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.4.9'
+const PACKAGE_VERSION = '0.4.10'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,


### PR DESCRIPTION
## Summary
Release bump to ship the SMI-4240 fix (merged as #583, SHA `7785a75b`) to npm so end users on `npx @skillsmith/mcp-server` pick up the corrected category / security / repository mappings in the VS Code extension's skill detail view.

- `@skillsmith/core` 0.5.1 → 0.5.2 (additive: `ApiSearchResult`/`ApiSkill` gain optional `categories` + security fields; re-export `SecuritySummary`)
- `@skillsmith/mcp-server` 0.4.9 → 0.4.10 (carries the API-path mapper fix)
- `@skillsmith/cli` 0.5.4 → 0.5.5 (picks up core@0.5.2 dep bump)

No functional changes in this PR — just version bumps + changelog entries. The actual fixes already merged as #583.

[skip-doc-drift]

## Workflow
Per the existing release-branch pattern (e.g. `release/smi-4119-core-minor`): `publish.yml` is triggered on this release branch via `workflow_dispatch`, which publishes `@skillsmith/core@0.5.2` first. Once that lands on npm, the `Package Validation` check (which verifies all declared workspace deps are on npm) re-runs and passes, then the PR can merge.

## Test plan
- [x] `npx tsx scripts/prepare-release.ts` ran cleanly; npm registry collision guard passed
- [x] Version sync validation passed
- [x] `[skip-doc-drift]` added for the docs-drift check (release bump touches no public docs)
- [ ] Trigger `publish.yml --ref release/smi-4240-mcp-0.4.10 -f dry_run=false`; watch until green
- [ ] Post-publish smoke test: open `azure-resource-manager-redis-dotnet` in VS Code, verify category = `development` (not `other`), security shows real status, repo link renders

## Linear
- https://linear.app/smith-horn-group/issue/SMI-4240

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)