### PR TITLE
ci(publish): resolve @astrojs/vercel canary failure (SMI-4209)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -268,11 +268,20 @@ jobs:
           retention-days: 1
 
       - name: Extract node_modules from Docker image
+        # SMI-4209: capture nested per-package node_modules alongside root.
+        # npm nests deps that can't be hoisted (e.g. @astrojs/vercel@10.0.4 under
+        # packages/website/ due to peer-dep conflicts). If the extract only grabs
+        # /app/node_modules, Astro's ESM config resolver fails at
+        # packages/website/astro.config.mjs → @astrojs/vercel.
         run: |
           docker create --name extract-deps skillsmith-publish:${{ github.sha }}
           docker cp extract-deps:/app/node_modules /tmp/node_modules
+          mkdir -p /tmp/packages
+          for pkg in cli core enterprise mcp-server vscode-extension website; do
+            docker cp "extract-deps:/app/packages/$pkg/node_modules" "/tmp/packages/$pkg/node_modules" 2>/dev/null || true
+          done
           docker rm extract-deps
-          tar -czf /tmp/node_modules.tar.gz -C /tmp node_modules
+          tar -czf /tmp/node_modules.tar.gz -C /tmp node_modules packages
 
       - name: Upload node_modules artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -273,11 +273,13 @@ jobs:
         # packages/website/ due to peer-dep conflicts). If the extract only grabs
         # /app/node_modules, Astro's ESM config resolver fails at
         # packages/website/astro.config.mjs → @astrojs/vercel.
+        # Packages enumerated from the image (not hardcoded) so future workspaces
+        # are covered automatically.
         run: |
           docker create --name extract-deps skillsmith-publish:${{ github.sha }}
           docker cp extract-deps:/app/node_modules /tmp/node_modules
           mkdir -p /tmp/packages
-          for pkg in cli core enterprise mcp-server vscode-extension website; do
+          docker run --rm skillsmith-publish:${{ github.sha }} sh -c 'ls /app/packages' | while read -r pkg; do
             docker cp "extract-deps:/app/packages/$pkg/node_modules" "/tmp/packages/$pkg/node_modules" 2>/dev/null || true
           done
           docker rm extract-deps


### PR DESCRIPTION
## Summary

- Fix Path 1b from SMI-4209 SPARC plan — extend `publish.yml` extract step to capture nested `packages/*/node_modules` alongside root.
- Root cause (Wave 1 diagnosis): npm nests `@astrojs/vercel@10.0.4` under `packages/website/node_modules/` because peer-dep conflicts prevent hoisting. The previous extract step (`docker cp extract-deps:/app/node_modules /tmp/node_modules`) only captured root, so Astro's ESM config resolver failed when the validate job mounted the (incomplete) workspace over the image's `/app`.
- Packages enumerated from the image at runtime (`ls /app/packages`) rather than hardcoded — governance review flagged the hardcoded list as a silent-drift risk if a new workspace is ever added.

[skip-impl-check]

## Diagnosis evidence

Wave 1 Linear comment on [SMI-4209](https://linear.app/smith-horn-group/issue/SMI-4209) contains the full investigation, including faithful CI reproduction (exact matching Vite module-runner stack frame from failed run `24362993170`) and H2 inspection showing `@astrojs/vercel` exists only in `packages/website/node_modules/@astrojs/vercel`, not at root.

## Verification

Local canary repro (plan §Wave 2 Step 2, mandatory):

1. `docker buildx build --target dev -t skillsmith-publish:local .`
2. Simulate CI extract (root + nested) into temp workspace via the exact commands this PR introduces.
3. `docker run --rm -v "$TMPWS:/app" -w /app skillsmith-publish:local sh -c "npx turbo build --filter=@skillsmith/website"` → **EXIT=0**, website builds clean with `[@astrojs/vercel] Bundling function` and `[@astrojs/vercel] Copying static files` both running (26s cache-cold).
4. Pre-fix simulation (root-only extract): same command → **EXIT=1**, reproduces exact CI stack frame (`config.js:33984:34`).

Standards audit clean locally (44 passed, 0 failed, 96% compliance). Prettier clean at repo path. Diff well under plan's ≤15-line publish.yml budget (12 insertions / 1 deletion on `publish.yml`; submodule pointer bump from rebase).

## Risk

Single workflow step modified (`publish.yml:270–287`). Validate and Publish jobs otherwise unchanged. Artifact size grows ~+124 MB uncompressed (~50–70 MB gzipped, driven mostly by core 62 MB and website 55 MB); `compression-level: 1` already configured at line 287 (speed over size). Subsequent `tar -xzf` into `github.workspace` merges cleanly — fresh checkout has no `packages/*/node_modules` to collide with.

## Rollback

Revert the two commits (`04b4c0ee`, `6b31a6f0`). `publish.yml` returns to pre-change state; no image rebuild required.

## Deferred work

**Gate promotion** (removing `continue-on-error: true` from the canary at `publish.yml:378`) is explicitly deferred to Wave 3 per the SPARC plan, after two consecutive green publish runs with at least one cache-cold cycle (plan §Wave 3 Step 1). Do not collapse gate promotion into this PR.

Orthogonal to [SMI-4244](https://linear.app/smith-horn-group/issue/SMI-4244) (publish.yml Validate kills vitest via SIGTERM) — that failure happens in a later step and does not block this fix.

## Test plan

- [ ] CI preflight clean (lint, format:check, audit:standards, typecheck, tests)
- [ ] Next triggered `publish.yml` run (release or `workflow_dispatch`) shows the canary step exits 0, no `@astrojs/vercel` error in logs
- [ ] Next publish run shows artifact `node-modules-publish` contains `packages/*/node_modules` alongside root `node_modules` (verifiable via workflow logs)
- [ ] Wave 3 (separate PR) promotes canary to gate after two green cycles

Plan: [docs/internal/implementation/smi-4209-astrojs-vercel-publish-container.md](https://github.com/smith-horn/skillsmith/blob/main/docs/internal/implementation/smi-4209-astrojs-vercel-publish-container.md)
ADR-109: infra change, SPARC + plan-review signed off before edit.