### PR TITLE
fix(core): add missing SMI-4240 fields to ApiSearchResultSchema (SMI-4246, SMI-4247)

### DIFF
--- a/packages/core/src/api/schemas.ts
+++ b/packages/core/src/api/schemas.ts
@@ -46,6 +46,14 @@ export const ApiSearchResultSchema = z.object({
   content: z.string().nullable().optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
+  // SMI-4240 / SMI-4246 / SMI-4247: fields added to ApiSkill in types.ts must
+  // also be declared here or Zod strips them before get-skill.ts can read them.
+  // All .optional() — skills-search doesn't select these columns.
+  categories: z.array(z.string()).optional(),
+  security_score: z.number().nullable().optional(),
+  last_scanned_at: z.string().nullable().optional(),
+  security_findings: z.array(z.unknown()).nullable().optional(),
+  quarantined: z.boolean().optional(),
 })
 
 // ============================================================================

--- a/packages/core/tests/api/client.validation.test.ts
+++ b/packages/core/tests/api/client.validation.test.ts
@@ -80,6 +80,45 @@ describe('API Response Validation Schemas', () => {
       const invalidResult = { ...validResult, tags: 'not-an-array' }
       expect(ApiSearchResultSchema.safeParse(invalidResult).success).toBe(false)
     })
+
+    // SMI-4246 / SMI-4247: these fields exist on the ApiSkill interface
+    // (types.ts:52-90) and are returned by the skills-get edge function, but
+    // were missing from ApiSearchResultSchema. Zod's strict-strip mode silently
+    // removed them, so get-skill.ts saw `undefined` and fell back to "not
+    // scanned" / "other" for every skill. This regression test asserts all
+    // five fields survive parsing.
+    it('should preserve SMI-4240 security + categories fields after parsing', () => {
+      const resultWithSecurityAndCategories = {
+        ...validResult,
+        categories: ['Development', 'DevOps'],
+        security_score: 12,
+        last_scanned_at: '2026-04-15T18:32:00Z',
+        security_findings: [{ severity: 'low', rule: 'example' }],
+        quarantined: false,
+      }
+      const parsed = ApiSearchResultSchema.parse(resultWithSecurityAndCategories)
+      expect(parsed.categories).toEqual(['Development', 'DevOps'])
+      expect(parsed.security_score).toBe(12)
+      expect(parsed.last_scanned_at).toBe('2026-04-15T18:32:00Z')
+      expect(parsed.security_findings).toEqual([{ severity: 'low', rule: 'example' }])
+      expect(parsed.quarantined).toBe(false)
+    })
+
+    it('should accept null values for SMI-4240 security fields (never scanned)', () => {
+      const neverScanned = {
+        ...validResult,
+        security_score: null,
+        last_scanned_at: null,
+        security_findings: null,
+      }
+      const result = ApiSearchResultSchema.safeParse(neverScanned)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.security_score).toBeNull()
+        expect(result.data.last_scanned_at).toBeNull()
+        expect(result.data.security_findings).toBeNull()
+      }
+    })
   })
 
   describe('SearchResponseSchema', () => {


### PR DESCRIPTION
## Summary

- **Root cause**: `packages/core/src/api/schemas.ts:33-49` `ApiSearchResultSchema` was missing 5 fields that the `ApiSkill` interface (`types.ts:52-90`) gained in SMI-4240 (`categories`, `security_score`, `last_scanned_at`, `security_findings`, `quarantined`). Zod strips undeclared fields silently, so `get-skill.ts:142-157` always saw `undefined` and the VS Code skill detail view rendered "Not scanned" / "category: other" for every skill.
- **Fix**: Add the 5 fields to the Zod schema with matching nullability/optionality from `types.ts`. All `.optional()` because `skills-search` does not select these columns.
- **Evidence**: Wave 1 of the SMI-4245/4246/4247 plan (`docs/internal/implementation/smi-4245-47-skills-data-quality.md`) tested H3 first (prior 0.05 → posterior 0.98) and confirmed this as the shared root cause for **SMI-4246 Layer A** and **SMI-4247**. plan-review AP3 called out the H3-first test order as a days-saving optimization; it paid off.

## Proof (Zod parse of a real `skills-get` response shape)

```
BEFORE FIX (schema on main):
  categories:        undefined
  security_score:    undefined
  last_scanned_at:   undefined
  quarantined:       undefined
  SecuritySummary:   undefined  → VS Code renders "Not scanned"

AFTER FIX (this PR):
  categories:        ["DevOps"]
  security_score:    8
  last_scanned_at:   "2026-04-10T12:00:00Z"
  security_findings: [{ severity: "low", rule: "deprecated-api" }]
  quarantined:       false

DERIVED SECURITY SUMMARY (from get-skill.ts:142-157):
{
  "passed":        true,
  "riskScore":     8,
  "findingsCount": 1,
  "scannedAt":     "2026-04-10T12:00:00Z"
}
```

## Scope discipline

- Touches `packages/core/src/api/schemas.ts` and `packages/core/tests/api/client.validation.test.ts` only. 2 files, +47 lines, 0 deletions.
- Does **not** touch the indexer, so SMI-4245 URL-template fix (Wave 3) and SMI-4246 Layer B keyword expansion (Wave 4) remain separate PRs.
- No migrations, no env changes, no infra.

## Test plan

- [x] Existing `client.validation.test.ts` (19 tests) still passes
- [x] New test: 5 SMI-4240 fields survive `.parse()` with real values
- [x] New test: security fields accept `null` (never-scanned path)
- [x] `packages/core` typecheck green
- [x] `npm run lint` — zero warnings, zero errors
- [x] `npm run format:check` — clean (excluding worktree-local `.mcp.json` / `docker-compose.override.yml` which are not staged)
- [x] `npm run audit:standards` — 96% compliance, 0 failures
- [x] Smoke test with simulated `skills-get` payload — `SecuritySummary` populates with `scannedAt` and `riskScore` correctly

Links: [SMI-4246](https://linear.app/smith-horn/issue/SMI-4246) · [SMI-4247](https://linear.app/smith-horn/issue/SMI-4247) · plan: `docs/internal/implementation/smi-4245-47-skills-data-quality.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)