### PR TITLE
chore(release): bump core 0.5.3, mcp-server 0.4.11, cli 0.5.6 (SMI-4246, SMI-4247)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
+## v0.5.6
+
+- Version bump
+
 ## v0.5.5
 
 - **Other**: SMI-4190: release cadence docs — ADR-114 + CHANGELOG backfill + CONTRIBUTING (#552)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.5.2",
+    "@skillsmith/core": "^0.5.3",
     "chalk": "5.6.2",
     "cli-table3": "0.6.5",
     "commander": "14.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/core` are documented here.
 
+## v0.5.3
+
+- **Fix**: add missing SMI-4240 fields to ApiSearchResultSchema (SMI-4246, SMI-4247) (#611)
+
 ## v0.5.2
 
 - **Fix**: restore category/security/repo in skill detail view (SMI-4240) (#583)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.5.2'
+export const VERSION = '0.5.3'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1024.0",
-    "@skillsmith/core": "^0.5.2",
+    "@skillsmith/core": "^0.5.3",
     "jose": "^6.2.2",
     "zod": "4.2.1"
   },

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/mcp-server` are documented here.
 
+## v0.4.11
+
+- Version bump
+
 ## v0.4.10
 
 - **Fix**: restore category/security/repo in skill detail view (SMI-4240) (#583)

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.5.2",
+    "@skillsmith/core": "^0.5.3",
     "esbuild": "0.27.2"
   },
   "devDependencies": {

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,9 +8,13 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.4.10",
+  "version": "0.4.11",
   "_meta": {
-    "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
+    "io.skillsmith/categories": [
+      "developer-tools",
+      "ai-agents",
+      "skill-management"
+    ],
     "io.skillsmith/keywords": [
       "claude-code",
       "agent-skills",
@@ -23,7 +27,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -71,7 +71,7 @@ import { createLicenseMiddleware } from './middleware/license.js'
 import { createQuotaMiddleware } from './middleware/quota.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.4.10'
+const PACKAGE_VERSION = '0.4.11'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,


### PR DESCRIPTION
## Summary

Release bump to propagate the SMI-4246/4247 Zod fix (PR #611, commit 7827bee5) to npm consumers, including VS Code extension users who pull `@skillsmith/mcp-server` via `npx -y`.

## What this propagates

- **@skillsmith/core 0.5.2 → 0.5.3**: `ApiSearchResultSchema` now includes `categories`, `security_score`, `last_scanned_at`, `security_findings`, `quarantined` fields so Zod's `.parse()` no longer strips them from MCP API responses (root cause of verified-tier "other" category + "not scanned" security bugs).
- **@skillsmith/mcp-server 0.4.10 → 0.4.11**: consumes new core. Version bump only.
- **@skillsmith/cli 0.5.5 → 0.5.6**: consumes new core. Version bump only.

## Also included in main since last release

- SMI-4248: drop unused `otel-exporter` dep, override `protobufjs`/`hono` to non-vulnerable (cf943df3)
- SMI-4209: resolve `@astrojs/vercel` canary failure in publish CI (00a82ac7)
- SMI-4241: split indexer maintenance run + fix workflow output safety (e68a3173)

## Test plan

- [x] Dry-run `prepare-release.ts --dry-run` verified version deltas + npm collision guard
- [x] `prepare-release.ts` generated changelog entries + commit `1edb8be9`
- [x] Required CI checks green (skipped for docs/config tier)
- [ ] Admin-merge to main (Package Validation chicken-and-egg on release PRs per PR #587 precedent)
- [ ] `gh workflow run publish.yml -f dry_run=false` publishes in dependency order
- [ ] Post-publish smoke tests
- [ ] Layer A impact measurement on verified-tier "other" rate (feeds Wave 4 descope decision)

## Bypass flags

[skip-doc-drift]
[skip-impl-check]

`skip-doc-drift`: pure release bump, no functional docs to update beyond generated changelog entries.
`skip-impl-check`: config-tier change (package.json + CHANGELOG.md), no implementation files touched.