### PR TITLE
docs: SMI-4252/4254/4255 plans + gitignore ruvector.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,9 @@ wrangler.toml.local
 .claude/hive-mind/
 .claude/scheduled_tasks.lock
 
+# Ruflo (claude-flow) runtime DB created by mcp__ruflo__swarm_init + memory_store
+ruvector.db
+
 # Logarithmic quality score recalculation (internal tooling)
 supabase/migrations/015_recalculate_quality_scores.sql
 scripts/trigger-quality-recalculation.sh


### PR DESCRIPTION
## Summary

- Commits 3 SPARC plans to `docs/internal/implementation/` via submodule bump to `ade614a57f`:
  - **SMI-4252** (microsoft wildcard) — post-execution amendment; original H1-H8 all wrong, RCA was stale Edge Function deploy. Adds Wave 0 Deploy Status Pre-Flight section. SMI-4252 is Done; SMI-4256 filed for systemic fix (auto-deploy + drift detector).
  - **SMI-4254** (detached-HEAD) — executed as Option 0 (reset-and-move-on); main repo now at origin/main.
  - **SMI-4255** (schema_migrations drift) — executed 2026-04-17T18:49Z; versions 065+066 INSERTed via pooler. Table shape correction (`{version, statements, name}`, no `inserted_at` column).
- Adds `ruvector.db` to `.gitignore` (ruflo swarm runtime artifact).

All three plans passed `/plan-review-skill` with VP Engineering + VP Product; all recommendations applied pre-commit.

## Test plan

- [x] Submodule commit pushed: `ade614a` live on `skillsmith-docs` main.
- [x] Submodule pointer in this commit matches: `c20f4ff2` → `ade614a`.
- [x] `.gitignore` diff is 3-line addition, contained.
- [ ] Required CI checks pass (docs-only PR: 2 required).
- [ ] Post-merge `/governance` retro on merged diff.

## Related

- Closes activity for SMI-4254 (Option 0 executed).
- Follow-up tracking: SMI-4256 (edge-function auto-deploy), SMI-4257 (rebase-worktree.sh stash leak).

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)