### PR TITLE
chore: remove dead .gitignore entry + document DB migration footguns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,8 +140,7 @@ wrangler.toml.local
 # Ruflo (claude-flow) runtime DB created by mcp__ruflo__swarm_init + memory_store
 ruvector.db
 
-# Logarithmic quality score recalculation (internal tooling)
-supabase/migrations/015_recalculate_quality_scores.sql
+# Logarithmic quality score recalculation (internal tooling, SMI-4208 pending)
 scripts/trigger-quality-recalculation.sh
 docs/irap/
 .worktrees/


### PR DESCRIPTION
## Summary
- Remove dead `.gitignore` entry for `supabase/migrations/015_recalculate_quality_scores.sql` (file deleted during SMI-4135)
- Document DROP TRIGGER IF EXISTS footgun in `standards-database.md` (Pattern 3 Caveat)
- Add migration tracker integrity rule (never INSERT without DDL)
- Add post-SMI-4135 follow-ups consolidated execution plan

## Context
Post-SMI-4135 follow-up items (Wave 1 of consolidated plan). All documentation and config changes — no application code modified.

## Test plan
- [ ] CI passes (docs-only tier expected)
- [ ] `.gitignore` line 144 removed, line 145 preserved
- [ ] `standards-database.md` has Pattern 3 Caveat + Migration Tracker Integrity sections

[skip-impl-check]