### PR TITLE
ci: auto-deploy edge functions on merge to main (SMI-4256)

### DIFF
--- a/.claude/development/deployment-guide.md
+++ b/.claude/development/deployment-guide.md
@@ -51,6 +51,7 @@ CI will fail if any anonymous function is missing from `config.toml` or CLAUDE.m
 Edge functions are automatically deployed when changes to `supabase/functions/**` merge to main via `deploy-edge-functions.yml`.
 
 **How it works**:
+
 1. Path filter triggers on `supabase/functions/**` changes to `main`
 2. `git diff HEAD~1 HEAD` detects which function directories changed
 3. Only changed functions deploy (not all 25)
@@ -59,6 +60,7 @@ Edge functions are automatically deployed when changes to `supabase/functions/**
 6. Failure alerts sent to `alert-notify` edge function
 
 **Manual triggers**:
+
 ```bash
 # Deploy a specific function
 gh workflow run deploy-edge-functions.yml -f function_name=health
@@ -68,6 +70,7 @@ gh workflow run deploy-edge-functions.yml -f deploy_all=true
 ```
 
 **Troubleshooting**:
+
 - **Workflow not triggering**: Verify `supabase/functions/**` path filter matches the changed files. Git-crypt encryption does not affect path matching.
 - **git-crypt unlock failure**: `GIT_CRYPT_KEY` secret must be set. Without it, the workflow hard-fails (encrypted blobs cannot be deployed).
 - **Secret rotation**: `SUPABASE_ACCESS_TOKEN` is a Supabase Management API personal access token. Rotate via Supabase dashboard > Account > Access Tokens. Update GitHub secret: `varlock run -- sh -c 'echo "$SUPABASE_ACCESS_TOKEN" | gh secret set SUPABASE_ACCESS_TOKEN'`.

--- a/.claude/development/deployment-guide.md
+++ b/.claude/development/deployment-guide.md
@@ -46,6 +46,34 @@ CI validates anonymous function configuration. When adding a new one:
 
 CI will fail if any anonymous function is missing from `config.toml` or CLAUDE.md.
 
+### Auto-Deploy on Merge (SMI-4256)
+
+Edge functions are automatically deployed when changes to `supabase/functions/**` merge to main via `deploy-edge-functions.yml`.
+
+**How it works**:
+1. Path filter triggers on `supabase/functions/**` changes to `main`
+2. `git diff HEAD~1 HEAD` detects which function directories changed
+3. Only changed functions deploy (not all 25)
+4. `_shared/` changes trigger a full deploy of all functions
+5. Post-deploy verification via `validate-edge-functions.sh --check-deployment`
+6. Failure alerts sent to `alert-notify` edge function
+
+**Manual triggers**:
+```bash
+# Deploy a specific function
+gh workflow run deploy-edge-functions.yml -f function_name=health
+
+# Deploy all 25 functions
+gh workflow run deploy-edge-functions.yml -f deploy_all=true
+```
+
+**Troubleshooting**:
+- **Workflow not triggering**: Verify `supabase/functions/**` path filter matches the changed files. Git-crypt encryption does not affect path matching.
+- **git-crypt unlock failure**: `GIT_CRYPT_KEY` secret must be set. Without it, the workflow hard-fails (encrypted blobs cannot be deployed).
+- **Secret rotation**: `SUPABASE_ACCESS_TOKEN` is a Supabase Management API personal access token. Rotate via Supabase dashboard > Account > Access Tokens. Update GitHub secret: `varlock run -- sh -c 'echo "$SUPABASE_ACCESS_TOKEN" | gh secret set SUPABASE_ACCESS_TOKEN'`.
+
+**Rollback**: `git revert <merge-sha> && git push origin main` triggers a re-deploy of the previous function version. For immediate recovery, use `gh workflow run deploy-edge-functions.yml -f deploy_all=true` after the revert lands on main.
+
 ## CORS Configuration (SMI-1904)
 
 Configured in `supabase/functions/_shared/cors.ts`:

--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -1,0 +1,162 @@
+# SMI-4256: Auto-deploy edge functions on merge to main
+# Prevents SMI-4252-class failures (function merged but never deployed)
+name: Deploy Edge Functions
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/functions/**'
+  workflow_dispatch:
+    inputs:
+      function_name:
+        description: 'Deploy a specific function by name (for manual triggers; leave empty and use deploy_all for full redeploy)'
+        required: false
+        type: string
+      deploy_all:
+        description: 'Deploy ALL 25 functions (ignores function_name)'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: deploy-edge-functions
+  cancel-in-progress: false # Never cancel a deploy mid-flight
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy Edge Functions
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+    steps:
+      - name: Validate secrets
+        run: |
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
+            echo "::error::SUPABASE_ACCESS_TOKEN secret is not set"
+            exit 1
+          fi
+          if [ -z "$SUPABASE_PROJECT_REF" ]; then
+            echo "::error::SUPABASE_PROJECT_REF secret is not set"
+            exit 1
+          fi
+          echo "Secrets validated"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 2 # Need parent commit for diff (assumes squash-merge)
+
+      # REQUIRED — supabase/functions/** is encrypted. Without unlock,
+      # deploy pushes encrypted binary blobs. Hard fail if key is missing.
+      - name: Unlock git-crypt
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        run: |
+          if [ -z "$GIT_CRYPT_KEY" ]; then
+            echo "::error::GIT_CRYPT_KEY secret is not set — cannot deploy encrypted edge functions"
+            exit 1
+          fi
+          sudo apt-get update && sudo apt-get install -y git-crypt
+          echo "$GIT_CRYPT_KEY" | base64 -d > /tmp/git-crypt-key
+          git-crypt unlock /tmp/git-crypt-key
+          rm -f /tmp/git-crypt-key
+          echo "git-crypt unlocked"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+
+      - name: Install Supabase CLI
+        run: npm install -g supabase@latest
+
+      - name: Determine functions to deploy
+        id: detect
+        env:
+          INPUT_DEPLOY_ALL: ${{ inputs.deploy_all }}
+          INPUT_FUNCTION_NAME: ${{ inputs.function_name }}
+        run: |
+          if [ "$INPUT_DEPLOY_ALL" = "true" ]; then
+            echo "mode=all" >> "$GITHUB_OUTPUT"
+            echo "functions=" >> "$GITHUB_OUTPUT"
+            echo "Deploying ALL functions (manual override)"
+          elif [ -n "$INPUT_FUNCTION_NAME" ]; then
+            echo "mode=specific" >> "$GITHUB_OUTPUT"
+            echo "functions=$INPUT_FUNCTION_NAME" >> "$GITHUB_OUTPUT"
+            echo "Deploying specific function: $INPUT_FUNCTION_NAME"
+          else
+            # Detect changed functions from the merge commit
+            # Uses sed instead of grep -oP for portability (no PCRE dependency)
+            CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'supabase/functions/' \
+              | sed -n 's|supabase/functions/\([^/]*\)/.*|\1|p' \
+              | grep -v '^_shared$' \
+              | sort -u \
+              | paste -sd ',' -)
+            if [ -z "$CHANGED" ]; then
+              echo "No function changes detected (may be _shared only)"
+              # If _shared changed, deploy all — shared code affects every function
+              if git diff --name-only HEAD~1 HEAD -- 'supabase/functions/_shared/' | grep -q .; then
+                echo "mode=all" >> "$GITHUB_OUTPUT"
+                echo "functions=" >> "$GITHUB_OUTPUT"
+                echo "_shared/ changed — deploying ALL functions"
+              else
+                echo "mode=none" >> "$GITHUB_OUTPUT"
+                echo "functions=" >> "$GITHUB_OUTPUT"
+              fi
+            else
+              echo "mode=changed" >> "$GITHUB_OUTPUT"
+              echo "functions=$CHANGED" >> "$GITHUB_OUTPUT"
+              echo "Changed functions: $CHANGED"
+            fi
+          fi
+
+      - name: Deploy
+        if: steps.detect.outputs.mode != 'none'
+        run: |
+          ARGS=(--project-ref "$SUPABASE_PROJECT_REF")
+          FUNCTIONS="${{ steps.detect.outputs.functions }}"
+          if [ -n "$FUNCTIONS" ]; then
+            ARGS+=(--functions "$FUNCTIONS")
+          fi
+          ./scripts/deploy-edge-functions.sh "${ARGS[@]}"
+
+      - name: Verify deployment
+        if: steps.detect.outputs.mode != 'none'
+        run: |
+          echo "Verifying deployed functions..."
+          ./scripts/validate-edge-functions.sh --check-deployment
+
+      - name: Generate deploy summary
+        if: always()
+        run: |
+          echo "## Edge Function Deploy" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Status**: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Trigger**: ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Mode**: ${{ steps.detect.outputs.mode }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Functions**: ${{ steps.detect.outputs.functions || 'all' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Commit**: ${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Alert on failure
+        if: failure() && github.event_name == 'push'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          jq -n \
+            --arg type "edge_function_deploy_failure" \
+            --arg source "github-actions" \
+            --arg workflow "deploy-edge-functions" \
+            --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg functions "${{ steps.detect.outputs.functions || 'all' }}" \
+            --arg commit "${{ github.sha }}" \
+            '{type: $type, source: $source, details: {workflow: $workflow, run_url: $run_url, functions: $functions, commit: $commit}}' \
+          | curl -s -X POST "$SUPABASE_URL/functions/v1/alert-notify" \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Content-Type: application/json" \
+            -d @- || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,8 @@ npx supabase functions deploy skills-outreach-preferences --no-verify-jwt
 npx supabase functions deploy admin-grant-subscription --no-verify-jwt
 ```
 
+**Auto-deploy**: Edge functions are automatically deployed when changes to `supabase/functions/**` are merged to main. The `deploy-edge-functions.yml` workflow detects changed functions and deploys only those. `_shared/` changes trigger a full deploy of all 25 functions. Manual full deploy: `gh workflow run deploy-edge-functions.yml -f deploy_all=true`.
+
 **CORS & monitoring details**: [deployment-guide.md](.claude/development/deployment-guide.md)
 
 ---
@@ -285,6 +287,7 @@ npx supabase functions deploy admin-grant-subscription --no-verify-jwt
 | Weekly Analytics | Monday 9 AM UTC | GitHub Actions (`analytics-report.yml`) |
 | Billing Monitor | Monday 9 AM UTC | GitHub Actions |
 | A/B Experiment Results | Monday 9 AM UTC | GitHub Actions (`ab-results.yml`) — creates issue with verdict |
+| Edge Function Deploy | On merge to main | GitHub Actions (`deploy-edge-functions.yml`) |
 
 Alerts to `support@smithhorn.ca` via Resend on failures. All jobs log to `audit_logs` table. Manual trigger & audit log details: [deployment-guide.md](.claude/development/deployment-guide.md#monitoring--alerts).
 

--- a/scripts/deploy-edge-functions.sh
+++ b/scripts/deploy-edge-functions.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# deploy-edge-functions.sh — Deploy all Supabase Edge Functions to a target project
+# deploy-edge-functions.sh — Deploy Supabase Edge Functions to a target project
 #
 # Usage:
-#   ./scripts/deploy-edge-functions.sh --project-ref <ref>
+#   ./scripts/deploy-edge-functions.sh --project-ref <ref> [--functions <name1,name2,...>]
 #
 # Validates the provided ref against known refs in .env before deploying.
-# Reads verify_jwt config from supabase/config.toml.
+# When --functions is omitted, deploys all 25 functions.
+# When --functions is provided, deploys only the listed functions.
 
 set -euo pipefail
 
@@ -13,22 +14,34 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # --- Parse arguments ---
 PROJECT_REF=""
+FILTER_FUNCTIONS=""
 while [[ $# -gt 0 ]]; do
   case $1 in
     --project-ref)
       PROJECT_REF="$2"
       shift 2
       ;;
+    --functions)
+      FILTER_FUNCTIONS="$2"
+      shift 2
+      ;;
     -h|--help)
-      echo "Usage: $0 --project-ref <ref>"
+      echo "Usage: $0 --project-ref <ref> [--functions <name1,name2,...>]"
       echo ""
-      echo "Deploys all 25 Supabase Edge Functions to the specified project."
-      echo "Validates ref against STAGING_SUPABASE_PROJECT_REF and SUPABASE_PROJECT_REF in .env."
+      echo "Deploys Supabase Edge Functions to the specified project."
+      echo "When --functions is omitted, deploys all 25 functions."
+      echo "When --functions is provided, deploys only the listed functions."
+      echo ""
+      echo "Options:"
+      echo "  --project-ref <ref>           Target Supabase project reference (required)"
+      echo "  --functions <name1,name2,...>  Deploy only these functions (comma-separated)"
+      echo ""
+      echo "Validates ref against STAGING_SUPABASE_PROJECT_REF and SUPABASE_PROJECT_REF."
       exit 0
       ;;
     *)
       echo "ERROR: Unknown argument: $1"
-      echo "Usage: $0 --project-ref <ref>"
+      echo "Usage: $0 --project-ref <ref> [--functions <name1,name2,...>]"
       exit 1
       ;;
   esac
@@ -36,7 +49,7 @@ done
 
 if [[ -z "$PROJECT_REF" ]]; then
   echo "ERROR: --project-ref is required"
-  echo "Usage: $0 --project-ref <ref>"
+  echo "Usage: $0 --project-ref <ref> [--functions <name1,name2,...>]"
   exit 1
 fi
 
@@ -98,7 +111,44 @@ VERIFY_JWT_FUNCTIONS=(
   update-seat-count
 )
 
-echo "Deploying 25 edge functions to project: $PROJECT_REF"
+# --- Filter to specific functions if --functions provided ---
+if [[ -n "$FILTER_FUNCTIONS" ]]; then
+  IFS=',' read -ra REQUESTED <<< "$FILTER_FUNCTIONS"
+  FILTERED_NO_VERIFY=()
+  FILTERED_VERIFY=()
+
+  for req in "${REQUESTED[@]}"; do
+    FOUND=false
+    for func in "${NO_VERIFY_JWT_FUNCTIONS[@]}"; do
+      if [[ "$req" == "$func" ]]; then
+        FILTERED_NO_VERIFY+=("$func")
+        FOUND=true
+        break
+      fi
+    done
+    if [[ "$FOUND" == "false" ]]; then
+      for func in "${VERIFY_JWT_FUNCTIONS[@]}"; do
+        if [[ "$req" == "$func" ]]; then
+          FILTERED_VERIFY+=("$func")
+          FOUND=true
+          break
+        fi
+      done
+    fi
+    if [[ "$FOUND" == "false" ]]; then
+      echo "WARNING: Unknown function '$req' — skipping"
+    fi
+  done
+
+  NO_VERIFY_JWT_FUNCTIONS=("${FILTERED_NO_VERIFY[@]}")
+  VERIFY_JWT_FUNCTIONS=("${FILTERED_VERIFY[@]}")
+  TOTAL=$((${#NO_VERIFY_JWT_FUNCTIONS[@]} + ${#VERIFY_JWT_FUNCTIONS[@]}))
+  echo "Deploying $TOTAL edge function(s) to project: $PROJECT_REF"
+else
+  TOTAL=25
+  echo "Deploying all 25 edge functions to project: $PROJECT_REF"
+fi
+
 echo "=================================================="
 
 DEPLOYED=0
@@ -124,17 +174,21 @@ deploy_function() {
   fi
 }
 
-echo ""
-echo "--- Functions with --no-verify-jwt ---"
-for func in "${NO_VERIFY_JWT_FUNCTIONS[@]}"; do
-  deploy_function "$func" "true"
-done
+if [[ ${#NO_VERIFY_JWT_FUNCTIONS[@]} -gt 0 ]]; then
+  echo ""
+  echo "--- Functions with --no-verify-jwt ---"
+  for func in "${NO_VERIFY_JWT_FUNCTIONS[@]}"; do
+    deploy_function "$func" "true"
+  done
+fi
 
-echo ""
-echo "--- Functions with JWT verification ---"
-for func in "${VERIFY_JWT_FUNCTIONS[@]}"; do
-  deploy_function "$func" "false"
-done
+if [[ ${#VERIFY_JWT_FUNCTIONS[@]} -gt 0 ]]; then
+  echo ""
+  echo "--- Functions with JWT verification ---"
+  for func in "${VERIFY_JWT_FUNCTIONS[@]}"; do
+    deploy_function "$func" "false"
+  done
+fi
 
 echo ""
 echo "=================================================="
@@ -145,4 +199,4 @@ if [[ $FAILED -gt 0 ]]; then
   exit 1
 fi
 
-echo "All 25 functions deployed successfully."
+echo "All $TOTAL function(s) deployed successfully."


### PR DESCRIPTION
## Summary

- New `deploy-edge-functions.yml` workflow that auto-deploys edge functions when `supabase/functions/**` changes merge to main
- `scripts/deploy-edge-functions.sh` gains `--functions` flag for selective deploys (backwards-compatible)
- CLAUDE.md and deployment guide updated with auto-deploy docs, rollback strategy, and troubleshooting

Prevents SMI-4252-class failures (function merged but never deployed for 36+ hours).

## Design decisions

- Deploy only changed functions (not all 25) — `_shared/` changes trigger full deploy
- Required git-crypt unlock (hard fail, not conditional)
- `sed`-based function detection (no PCRE/`grep -oP` dependency)
- Post-deploy verification via `validate-edge-functions.sh --check-deployment`
- `jq -n` for alert payload, `|| true` on alert curl
- Input injection defense via env vars (not `${{ }}` interpolation)

## Prerequisites

GitHub secrets `SUPABASE_ACCESS_TOKEN` and `SUPABASE_PROJECT_REF` added via `varlock + gh secret set`.

## Test plan

- [ ] CI passes (typecheck, lint, format, tests, audit:standards)
- [ ] After merge: `gh workflow run deploy-edge-functions.yml -f function_name=health` succeeds
- [ ] After merge: `gh workflow run deploy-edge-functions.yml -f deploy_all=true` deploys all 25
- [ ] Verify workflow does NOT appear in branch protection required checks
- [ ] Verify path filter triggers on next real edge function merge

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)