### PR TITLE
docs: prod vs staging Supabase refs + SMI-4252 retro pointer (SMI-4252)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,15 @@ Vitest only runs tests matching these patterns. Tests elsewhere are **silently i
 
 ## Supabase Edge Functions
 
+**Project refs — do not confuse (SMI-4252 retro 2026-04-17)**:
+
+| Ref | Role | Used for |
+|-----|------|----------|
+| `vrcnzpmndtroqxxoqkzy` | **Prod** | `.env` `SUPABASE_URL` / `SUPABASE_PROJECT_REF`; all `supabase functions deploy`; `audit_logs` / `v_indexer_health` / `/functions/v1/stats` when validating prod |
+| `ovhcifugwqnzoebwfuku` | Staging | Low-cadence — data lags prod; never curl this when verifying a prod deploy |
+
+When verifying a prod edge function via `curl`, always use `$SUPABASE_URL` (under `varlock run --`) or the literal `https://vrcnzpmndtroqxxoqkzy.supabase.co`. Hardcoding `ovhcifugwqnzoebwfuku` will make a healthy prod deploy look stale — a 2026-04-17 session burned ~7 minutes on this.
+
 | Function | Auth | `--no-verify-jwt` |
 |----------|------|--------------------|
 | `early-access-signup`, `contact-submit`, `stats`, `checkout`, `stripe-webhook`, `events` | Anonymous | Yes |


### PR DESCRIPTION
[skip-impl-check]

## Summary

- Adds a "Project refs — do not confuse" table to `CLAUDE.md` §Supabase Edge Functions so future sessions don't mix up prod (`vrcnzpmndtroqxxoqkzy`) with staging (`ovhcifugwqnzoebwfuku`).
- Advances `docs/internal` submodule pointer to pick up the SMI-4252 session retro and 4 previously-unpushed docs commits (see smith-horn/skillsmith-docs#42).

## Why

A 2026-04-17 session resume wasted ~7 minutes investigating "stats is stale" — the symptom was actually `curl` hitting `ovhcifugwqnzoebwfuku.supabase.co` (staging) while `.env` + deploy + audit queries used `vrcnzpmndtroqxxoqkzy` (prod). Prod stats was always healthy (skillCount=15,111, top indexer run 2026-04-17T19:22 found=1977/indexed=160). CLAUDE.md now documents the distinction.

## Linear

- SMI-4252 (verified, comment `d51cbfcf` with prod stats output)
- SMI-4200 (2026-04-20 checkpoint criteria posted, comment `0e06dc23`)

## Test plan

- [x] CI Docs-only pipeline (2 required checks) passes
- [x] Submodule pointer resolves against skillsmith-docs main (PR #42 already merged as 34107fc2)

Docs-only change (CLAUDE.md + submodule pointer); no source code modifications, hence the `[skip-impl-check]` marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)