### PR TITLE
chore(vscode): bump to 0.2.1 for SMI-4240 detail-view fix release

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-17
+
+### Fixed
+
+- Skill detail view now shows **category**, **security scan**, and **repository link** correctly. Previously these fields could render as empty or incorrect values.
+- Repository section is hidden when a skill has no repository URL (previously rendered as an empty stub).
+- Security scan copy now reflects the skill's trust tier — verified skills show "Pending review" while community and experimental skills show "Pending scan" when no scan result is available.
+
 ## [0.2.0] - 2026-04-14
 
 ### Added

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Discover and install agent skills directly in VS Code",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
[skip-impl-check]

## Summary

- Bumps `packages/vscode-extension/package.json` from `0.2.0` → `0.2.1`
- Adds a user-facing `[0.2.1]` entry to `packages/vscode-extension/CHANGELOG.md`
- Ships the SMI-4240 category / security-scan / repository-url detail-view fix (PR #583, commit `7785a75b`) to Marketplace users. Marketplace 0.2.0 was released 2026-04-14, pre-fix.

This is a config + markdown only PR. `[skip-impl-check]` added per memory note — no implementation to verify beyond the version string.

## Test plan

- [x] Local QA (Wave 2) — side-loaded `skillsmith-vscode-0.2.0.vsix` built from main. Verified all four detail-view fields on both wildcard-author skills and `skillsmith/governance`. Confirmed repository section is hidden when no URL. Confirmed "Pending scan" copy for community/unknown tier and "Pending review" for verified tier (tier-aware copy from SMI-4240).
- [x] Targeted gate — `npm run build && typecheck && lint && test` green in Docker
- [x] Pre-push hook — security, audit, format, test, Linear sync all passed
- [ ] CI on PR — required checks
- [ ] After merge — cut `vscode-extension-v0.2.1` GitHub Release to trigger `publish-vscode.yml`
- [ ] Post-publish — `vsce show` confirms 0.2.1, auto-update check, re-run Wave 2 against Marketplace build

Closes out SMI-4240 QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)