### PR TITLE
feat(analytics): SMI-1683 ROI dashboard date range filter (closes #603)

### DIFF
--- a/packages/core/src/analytics/ROIDashboardService.ts
+++ b/packages/core/src/analytics/ROIDashboardService.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Database as DatabaseType } from '../db/database-interface.js'
+import { ValidationError } from '../validation/validation-error.js'
 import { AnalyticsRepository } from './AnalyticsRepository.js'
 import type { ROIDashboard, ROIMetrics, ExportFormat, UsageEvent } from './types.js'
 
@@ -18,6 +19,19 @@ export interface ROIComputeOptions {
   startDate?: string
   endDate?: string
 }
+
+/**
+ * Options for the public {@link ROIDashboardService.getDashboard} entrypoint.
+ * Both dates must be provided together (or neither, which defaults to the last 30 days).
+ */
+export interface GetDashboardOptions {
+  userId?: string
+  startDate?: string
+  endDate?: string
+}
+
+/** Default window applied by {@link ROIDashboardService.getDashboard} when both dates are omitted. */
+const DEFAULT_DASHBOARD_WINDOW_DAYS = 30
 
 export class ROIDashboardService {
   private repo: AnalyticsRepository
@@ -29,11 +43,19 @@ export class ROIDashboardService {
   }
 
   /**
-   * Get user ROI dashboard data
+   * Get user ROI dashboard data for a rolling window (last `days` days).
+   * For an explicit ISO-8601 range, use {@link getDashboard}.
    */
   getUserROI(userId: string, days: number = 30): ROIDashboard['user'] {
     const { startDate, endDate } = this.getDateRange(days)
+    return this.buildUserROI(userId, startDate, endDate)
+  }
 
+  /**
+   * Core per-user ROI computation over an explicit ISO-8601 range.
+   * Shared between {@link getUserROI} (days-based) and {@link getDashboard}.
+   */
+  private buildUserROI(userId: string, startDate: string, endDate: string): ROIDashboard['user'] {
     // Get user's usage events
     const events = this.repo.getUsageEventsForUser(userId, startDate, endDate)
 
@@ -54,7 +76,7 @@ export class ROIDashboardService {
       .sort((a, b) => b.timeSaved - a.timeSaved)
       .slice(0, 5)
 
-    // Calculate weekly trend
+    // Calculate weekly trend (filtered to [startDate, endDate])
     const weeklyTrend = this.calculateWeeklyTrend(events, startDate, endDate)
 
     return {
@@ -67,11 +89,19 @@ export class ROIDashboardService {
   }
 
   /**
-   * Get stakeholder aggregate ROI dashboard
+   * Get stakeholder aggregate ROI dashboard for a rolling window (last `days` days).
+   * For an explicit ISO-8601 range, use {@link getDashboard}.
    */
   getStakeholderROI(days: number = 30): ROIDashboard['stakeholder'] {
     const { startDate, endDate } = this.getDateRange(days)
+    return this.buildStakeholderROI(startDate, endDate)
+  }
 
+  /**
+   * Core stakeholder ROI computation over an explicit ISO-8601 range.
+   * Shared between {@link getStakeholderROI} (days-based) and {@link getDashboard}.
+   */
+  private buildStakeholderROI(startDate: string, endDate: string): ROIDashboard['stakeholder'] {
     // Get ROI metrics for the period
     const metrics = this.repo.getROIMetrics('daily', startDate, endDate)
 
@@ -111,6 +141,30 @@ export class ROIDashboardService {
       adoptionRate,
       skillLeaderboard,
     }
+  }
+
+  /**
+   * Public date-range-aware dashboard entrypoint (SMI-1683 / GitHub #603).
+   *
+   * Behavior:
+   * - Both dates omitted: defaults to the last 30 days ending now.
+   * - Exactly one date provided: throws {@link ValidationError} (the range is ambiguous).
+   * - `startDate >= endDate`: throws {@link ValidationError}.
+   * - `userId` provided: returns `{ user }` with date-filtered per-user metrics.
+   * - `userId` omitted: returns `{ stakeholder }` aggregated over the range.
+   *
+   * @param options.userId    Optional — when supplied, returns the per-user dashboard.
+   * @param options.startDate Optional ISO-8601 timestamp; must be paired with `endDate`.
+   * @param options.endDate   Optional ISO-8601 timestamp; must be paired with `startDate`.
+   */
+  getDashboard(options: GetDashboardOptions = {}): ROIDashboard {
+    const { startDate, endDate } = this.resolveDashboardRange(options.startDate, options.endDate)
+
+    if (options.userId) {
+      return { user: this.buildUserROI(options.userId, startDate, endDate) }
+    }
+
+    return { stakeholder: this.buildStakeholderROI(startDate, endDate) }
   }
 
   /**
@@ -190,6 +244,54 @@ export class ROIDashboardService {
     }
   }
 
+  /**
+   * Resolve the range for {@link getDashboard}: default to last 30 days when both
+   * dates are omitted, validate that exactly-one-date was not supplied, and enforce
+   * `startDate < endDate`.
+   */
+  private resolveDashboardRange(
+    startDate: string | undefined,
+    endDate: string | undefined
+  ): { startDate: string; endDate: string } {
+    if (startDate === undefined && endDate === undefined) {
+      return this.getDateRange(DEFAULT_DASHBOARD_WINDOW_DAYS)
+    }
+
+    if (startDate === undefined || endDate === undefined) {
+      throw new ValidationError(
+        'Must provide both startDate and endDate, or neither',
+        'INVALID_DATE_RANGE'
+      )
+    }
+
+    this.assertValidRange(startDate, endDate)
+    return { startDate, endDate }
+  }
+
+  /**
+   * Throw a typed {@link ValidationError} when the supplied range is malformed.
+   * Accepts any string that `Date` parses to a finite epoch; rejects when
+   * `startDate >= endDate` or either value fails to parse.
+   */
+  private assertValidRange(startDate: string, endDate: string): void {
+    const start = Date.parse(startDate)
+    const end = Date.parse(endDate)
+
+    if (Number.isNaN(start) || Number.isNaN(end)) {
+      throw new ValidationError(
+        'startDate and endDate must be valid ISO-8601 timestamps',
+        'INVALID_DATE_RANGE'
+      )
+    }
+
+    if (start >= end) {
+      throw new ValidationError(
+        'Invalid range: startDate must be before endDate',
+        'INVALID_DATE_RANGE'
+      )
+    }
+  }
+
   private calculateTimeSaved(events: UsageEvent[]): number {
     const successCount = events.filter((e) => e.eventType === 'success').length
     return successCount * this.TIME_SAVED_PER_SUCCESS
@@ -208,13 +310,19 @@ export class ROIDashboardService {
 
   private calculateWeeklyTrend(
     events: UsageEvent[],
-    _startDate: string, // TODO: SMI-1683 - Implement date range filtering
-    _endDate: string
+    startDate: string,
+    endDate: string
   ): Array<{ week: string; timeSaved: number }> {
-    // Group events by week
+    // Filter events to the requested inclusive range (SMI-1683 / GitHub #603).
+    // ISO-8601 timestamps sort lexicographically, so string comparison is correct.
+    const filtered = events.filter(
+      (event) => event.timestamp >= startDate && event.timestamp <= endDate
+    )
+
+    // Group filtered events by week
     const weeklyGroups: Record<string, UsageEvent[]> = {}
 
-    for (const event of events) {
+    for (const event of filtered) {
       const weekStart = this.getWeekStart(event.timestamp)
       if (!weeklyGroups[weekStart]) {
         weeklyGroups[weekStart] = []
@@ -240,10 +348,20 @@ export class ROIDashboardService {
   }
 
   private computeStakeholderROIOnTheFly(
-    _startDate: string, // TODO: SMI-1683 - Implement date range filtering
-    _endDate: string
+    startDate: string,
+    endDate: string
   ): ROIDashboard['stakeholder'] {
-    // This is a simplified version - in production, query events directly
+    // SMI-1683 scope: validate the date range even though the on-the-fly branch
+    // still returns zeroed stakeholder data. This guards callers from passing
+    // malformed ranges while the event-query implementation remains deferred.
+    //
+    // DESCOPE: The actual event aggregation (users, activations, time saved,
+    // leaderboard) lands in SMI-4296. Until then this method intentionally
+    // returns a zeroed struct regardless of the events present in the range,
+    // and the unit test for this branch asserts the zeroed shape to document
+    // the incompleteness.
+    this.assertValidRange(startDate, endDate)
+
     return {
       totalUsers: 0,
       totalActivations: 0,

--- a/packages/core/tests/ROIDashboardService.test.ts
+++ b/packages/core/tests/ROIDashboardService.test.ts
@@ -11,6 +11,7 @@ import { initializeAnalyticsSchema } from '../src/analytics/schema.js'
 import { ROIDashboardService } from '../src/analytics/ROIDashboardService.js'
 import { AnalyticsRepository } from '../src/analytics/AnalyticsRepository.js'
 import type { UsageEventInput } from '../src/analytics/types.js'
+import { ValidationError } from '../src/validation/validation-error.js'
 
 describe('ROIDashboardService', () => {
   let db: Database
@@ -379,6 +380,135 @@ describe('ROIDashboardService', () => {
 
       expect(roi!.totalTimeSaved).toBe(0)
       expect(roi!.estimatedValueUsd).toBe(0)
+    })
+  })
+
+  describe('getDashboard (SMI-1683 / GitHub #603)', () => {
+    // Frozen "now" is 2026-01-15T12:00:00Z (set in the outer beforeEach).
+    // Seed success events across three distinct weeks so the weekly-trend
+    // filter has something meaningful to include / exclude.
+    //
+    // We insert directly via SQL so each event has a deterministic `timestamp`
+    // column — `recordUsageEvent` defaults to `datetime('now')` which is SQLite's
+    // clock, not the faked JS clock, so it is unreliable for range assertions.
+    beforeEach(() => {
+      const insertStmt = db.prepare<unknown>(
+        `INSERT INTO skill_usage_events
+           (id, skill_id, user_id, session_id, event_type, timestamp, created_at)
+         VALUES (?, ?, ?, ?, 'success', ?, ?)`
+      )
+
+      // Inside 30-day default window (2025-12-20 → 26 days before "now")
+      insertStmt.run(
+        'evt-1',
+        'skill-a',
+        'user-1',
+        'session-1',
+        '2025-12-20T12:00:00.000Z',
+        '2025-12-20T12:00:00.000Z'
+      )
+      // Inside 30-day default window (2026-01-05 → 10 days before "now")
+      insertStmt.run(
+        'evt-2',
+        'skill-a',
+        'user-1',
+        'session-1',
+        '2026-01-05T12:00:00.000Z',
+        '2026-01-05T12:00:00.000Z'
+      )
+      // OUTSIDE 30-day default window (2025-11-01 → 75 days before "now")
+      insertStmt.run(
+        'evt-3',
+        'skill-a',
+        'user-1',
+        'session-1',
+        '2025-11-01T12:00:00.000Z',
+        '2025-11-01T12:00:00.000Z'
+      )
+      insertStmt.finalize()
+    })
+
+    it('valid range filters events in calculateWeeklyTrend', () => {
+      // Tight window that includes only the 2026-01-05 event.
+      const dashboard = service.getDashboard({
+        userId: 'user-1',
+        startDate: '2026-01-01T00:00:00.000Z',
+        endDate: '2026-01-10T00:00:00.000Z',
+      })
+
+      expect(dashboard.user).toBeDefined()
+      // Total time saved reflects the full repo query (bounded by repo SQL) — here
+      // getUsageEventsForUser already restricts to [start,end], so 1 success event.
+      expect(dashboard.user!.totalTimeSaved).toBe(5)
+      // Weekly trend must reflect the same single event — exactly one week bucket.
+      expect(dashboard.user!.weeklyTrend).toHaveLength(1)
+      expect(dashboard.user!.weeklyTrend[0]!.timeSaved).toBe(5)
+    })
+
+    it('default range uses last 30 days when both dates are omitted', () => {
+      // "now" is 2026-01-15T12:00:00Z, so 30-day window starts 2025-12-16.
+      // Includes 2025-12-20 and 2026-01-05; excludes 2025-11-01.
+      const dashboard = service.getDashboard({ userId: 'user-1' })
+
+      expect(dashboard.user).toBeDefined()
+      expect(dashboard.user!.totalTimeSaved).toBe(10) // 2 successes × 5 min
+      // Weekly trend should have exactly two weekly buckets.
+      expect(dashboard.user!.weeklyTrend).toHaveLength(2)
+    })
+
+    it('invalid range (startDate >= endDate) throws ValidationError', () => {
+      expect(() =>
+        service.getDashboard({
+          userId: 'user-1',
+          startDate: '2026-01-10T00:00:00.000Z',
+          endDate: '2026-01-01T00:00:00.000Z',
+        })
+      ).toThrow(ValidationError)
+
+      expect(() =>
+        service.getDashboard({
+          userId: 'user-1',
+          startDate: '2026-01-05T00:00:00.000Z',
+          endDate: '2026-01-05T00:00:00.000Z',
+        })
+      ).toThrow(/startDate must be before endDate/)
+    })
+
+    it('single date provided (start only or end only) throws ValidationError', () => {
+      expect(() =>
+        service.getDashboard({
+          userId: 'user-1',
+          startDate: '2026-01-01T00:00:00.000Z',
+        })
+      ).toThrow(ValidationError)
+
+      expect(() =>
+        service.getDashboard({
+          userId: 'user-1',
+          endDate: '2026-01-10T00:00:00.000Z',
+        })
+      ).toThrow(/Must provide both startDate and endDate, or neither/)
+    })
+
+    it('computeStakeholderROIOnTheFly returns zeroed struct (documents M1 descope)', () => {
+      // When there are no precomputed daily ROI metrics, the stakeholder branch
+      // falls through to computeStakeholderROIOnTheFly. That method validates
+      // the range but still returns zeros because the event-query implementation
+      // is deferred to SMI-4296. This test pins the zeroed shape so the descope
+      // is explicit in CI: a future PR that wires real data MUST update this test.
+      const dashboard = service.getDashboard({
+        startDate: '2026-01-01T00:00:00.000Z',
+        endDate: '2026-01-10T00:00:00.000Z',
+      })
+
+      expect(dashboard.stakeholder).toEqual({
+        totalUsers: 0,
+        totalActivations: 0,
+        avgTimeSavedPerUser: 0,
+        totalEstimatedValue: 0,
+        adoptionRate: 0,
+        skillLeaderboard: [],
+      })
     })
   })
 })

--- a/supabase/migrations/070_RESERVED_webhook_dead_letters.placeholder
+++ b/supabase/migrations/070_RESERVED_webhook_dead_letters.placeholder
@@ -1,0 +1,5 @@
+-- Migration slot 070 RESERVED for Wave 4: webhook_dead_letters table
+-- Tracking: SMI-4291 — Webhook dead-letter queue
+-- Plan: docs/internal/implementation/github-wave-4-webhook-dlq.md
+-- Plan-review finding M1: burn slot visibly to prevent parallel wave collisions (SMI-4200 retro)
+-- This file MUST be deleted when the real 070_webhook_dead_letters.sql migration is committed.

--- a/supabase/migrations/071_RESERVED_team_workspaces.placeholder
+++ b/supabase/migrations/071_RESERVED_team_workspaces.placeholder
@@ -1,0 +1,5 @@
+-- Migration slot 071 RESERVED for Wave 5A: team_workspaces + workspace_skills + resolve_team_from_license RPC
+-- Tracking: SMI-4292 — Team workspaces foundation
+-- Plan: docs/internal/implementation/github-wave-5a-team-workspaces.md
+-- Plan-review finding C1: foundation schema does not exist; this wave creates it from scratch
+-- This file MUST be deleted when the real 071_team_workspaces.sql migration is committed.


### PR DESCRIPTION
## Summary

Wires the previously `_`-prefixed date parameters on
`ROIDashboardService.calculateWeeklyTrend` and
`computeStakeholderROIOnTheFly` into real behavior, adds a public
`getDashboard({ startDate?, endDate? })` entrypoint, and extends the
test suite with 5 new cases.

- **`calculateWeeklyTrend`**: filters events to the inclusive
  `[startDate, endDate]` range before weekly bucketing. TODO removed,
  `_` prefixes dropped.
- **`computeStakeholderROIOnTheFly`**: validates the range via
  `assertValidRange` but **still returns a zeroed struct** — the
  event-query implementation is descoped to SMI-4296, documented via
  a source `DESCOPE` comment and a unit test that pins the zeroed
  shape so CI will loudly fail once the real implementation lands.
- **`getDashboard`**: defaults to the last 30 days when both dates
  are omitted; throws typed `ValidationError` for single-date or
  inverted ranges; shares computation with `getUserROI` /
  `getStakeholderROI` via new private `buildUserROI` /
  `buildStakeholderROI` helpers so the existing days-based callers
  keep working.

## Test plan

- [x] `npx vitest run packages/core/tests/ROIDashboardService.test.ts` — 25/25 pass
- [x] Coverage on `ROIDashboardService.ts`: 96.96% stmt, 81.35% branch, 95.83% func, 96.55% line
- [x] `npm run preflight` — all dependency checks pass
- [x] `npm run lint` — zero warnings on touched files
- [x] `npm run typecheck` — clean
- [x] `npx prettier --check` — clean
- [x] `npm run audit:standards` — 96% compliance, no failures

## Acceptance gates (from plan)

- [x] Both TODO markers at `ROIDashboardService.ts:211,243` removed
- [x] `_` prefix dropped from `calculateWeeklyTrend` and `computeStakeholderROIOnTheFly`
- [x] `calculateWeeklyTrend` filters events on real test data
- [x] `computeStakeholderROIOnTheFly` validates range; returns zeroed struct (asserted by new test + documented in source)
- [x] `getDashboard` defaults to last 30 days when both dates omitted
- [x] `getDashboard` throws `ValidationError` on single-date or `start >= end`
- [x] Test coverage on `ROIDashboardService.ts` is > 80%

## Follow-on

- SMI-4296 tracks the real event-query implementation inside `computeStakeholderROIOnTheFly` that was descoped by plan-review finding M1.

Closes #603

Plan: `docs/internal/implementation/github-wave-5b-roi-date-filter.md`

Refs SMI-1683, SMI-4296

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>