### PR TITLE
fix(cli): SMI-4289 author init error handling + helpers extraction (closes #602)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,7 +12,11 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
-_No unreleased changes._
+- **Fix**: `skillsmith author init` now reports a friendly error and cleans up
+  partial output when a file operation fails. When an init is run against a
+  pre-existing directory that the user confirms to overwrite, the existing
+  directory is preserved on mid-scaffold failure instead of being removed
+  (SMI-4289, closes #602).
 
 ## v0.5.4
 

--- a/packages/cli/src/commands/author/init.helpers.ts
+++ b/packages/cli/src/commands/author/init.helpers.ts
@@ -1,0 +1,151 @@
+/**
+ * SMI-4289: author init error-handling helpers (closes #602)
+ *
+ * Extracted from init.ts to keep it under the 500-line limit and to isolate
+ * the scaffold logic so it can return a typed result instead of throwing.
+ * Throwing from initSkill() was causing double-error-print because the outer
+ * createInitCommand().action() handler re-printed the same error.
+ *
+ * Design notes:
+ * - scaffoldSkillDirectory catches all fs errors and returns { ok, error }.
+ * - rollbackPartialScaffold removes the skill directory ONLY when the mkdir
+ *   at line ~128 of init.ts created it fresh (createdFresh === true). When
+ *   the user confirmed an overwrite of a pre-existing directory
+ *   (createdFresh === false), rollback is a no-op to avoid destroying the
+ *   user's existing files on mid-write failure.
+ */
+
+import { mkdir, writeFile, rm } from 'fs/promises'
+import { join } from 'path'
+
+import { SKILL_MD_TEMPLATE, README_MD_TEMPLATE } from '../../templates/index.js'
+import { sanitizeError } from '../../utils/sanitize.js'
+
+/**
+ * Input for scaffoldSkillDirectory.
+ */
+export interface ScaffoldInput {
+  /** Absolute path to the skill directory to populate. */
+  skillDir: string
+  /** Skill name (used in templates). */
+  skillName: string
+  /** Skill description (used in templates). */
+  description: string
+  /** Skill author (used in templates). */
+  author: string
+  /** Skill category (used in templates). */
+  category: string
+  /**
+   * True if the skillDir was created by this invocation (fresh mkdir).
+   * False if the directory pre-existed and the user confirmed overwrite.
+   *
+   * Controls rollback behaviour on failure:
+   * - true: on error, rm -rf skillDir (best-effort cleanup)
+   * - false: on error, leave skillDir alone (user's pre-existing files preserved)
+   */
+  createdFresh: boolean
+}
+
+/**
+ * Result of scaffoldSkillDirectory. Never throws — callers should branch on `ok`.
+ */
+export type ScaffoldResult = { ok: true } | { ok: false; error: string }
+
+/**
+ * Create subdirectories, render templates, and write SKILL.md, README.md,
+ * example.js, and .gitignore into `skillDir`.
+ *
+ * On any fs failure, best-effort rollback is attempted (see
+ * `rollbackPartialScaffold`) and the sanitized error is returned as a string.
+ * No exception escapes this function for fs-level failures.
+ */
+export async function scaffoldSkillDirectory(input: ScaffoldInput): Promise<ScaffoldResult> {
+  const { skillDir, skillName, description, author, category, createdFresh } = input
+
+  try {
+    await mkdir(join(skillDir, 'scripts'), { recursive: true })
+    await mkdir(join(skillDir, 'resources'), { recursive: true })
+
+    const skillMdContent = SKILL_MD_TEMPLATE.replace(/\{\{name\}\}/g, skillName)
+      .replace(/\{\{description\}\}/g, description)
+      .replace(/\{\{author\}\}/g, author)
+      .replace(/\{\{category\}\}/g, category)
+      .replace(/\{\{date\}\}/g, new Date().toISOString().split('T')[0] || '')
+      .replace(/\{\{behavioralClassification\}\}/g, '')
+
+    await writeFile(join(skillDir, 'SKILL.md'), skillMdContent, 'utf-8')
+
+    const readmeContent = README_MD_TEMPLATE.replace(/\{\{name\}\}/g, skillName).replace(
+      /\{\{description\}\}/g,
+      description
+    )
+    await writeFile(join(skillDir, 'README.md'), readmeContent, 'utf-8')
+
+    const placeholderScript = `#!/usr/bin/env node
+/**
+ * ${skillName} - Example Script
+ *
+ * Add your skill's automation scripts here.
+ */
+
+console.log('${skillName} script executed');
+`
+    await writeFile(join(skillDir, 'scripts', 'example.js'), placeholderScript, 'utf-8')
+
+    const gitignore = `# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Environment
+.env
+.env.local
+
+# OS files
+.DS_Store
+Thumbs.db
+`
+    await writeFile(join(skillDir, '.gitignore'), gitignore, 'utf-8')
+
+    return { ok: true }
+  } catch (error) {
+    await rollbackPartialScaffold(skillDir, createdFresh)
+    return { ok: false, error: sanitizeError(error) }
+  }
+}
+
+/**
+ * Best-effort cleanup of a partially-scaffolded skill directory.
+ *
+ * CRITICAL: This function must only remove `skillDir` (the skill directory
+ * itself). It must NEVER receive or operate on `targetPath` (the parent
+ * directory the user passed via --path) — doing so would rm -rf the user's
+ * chosen parent directory.
+ *
+ * When `createdFresh === false`, the directory pre-existed before this init
+ * invocation (user confirmed overwrite earlier). Removing it would destroy
+ * the user's existing files, so this function no-ops.
+ *
+ * When `createdFresh === true`, the directory was created by the current
+ * init invocation. Best-effort `rm -rf` is safe because only partial scaffold
+ * output lives there.
+ *
+ * Any rollback failure is swallowed — the original scaffold error is the
+ * user-facing failure; rollback is defence-in-depth.
+ */
+export async function rollbackPartialScaffold(
+  skillDir: string,
+  createdFresh: boolean
+): Promise<void> {
+  if (!createdFresh) {
+    // User's pre-existing directory — do not remove.
+    return
+  }
+
+  try {
+    await rm(skillDir, { recursive: true, force: true })
+  } catch {
+    // Swallow — best-effort cleanup; original failure is what matters.
+  }
+}

--- a/packages/cli/src/commands/author/init.ts
+++ b/packages/cli/src/commands/author/init.ts
@@ -14,10 +14,10 @@ import { dirname, join, resolve } from 'path'
 import { createHash } from 'crypto'
 import { SkillParser } from '@skillsmith/core'
 
-import { SKILL_MD_TEMPLATE, README_MD_TEMPLATE } from '../../templates/index.js'
 import { sanitizeError } from '../../utils/sanitize.js'
 import { validateSkillName } from '../../utils/skill-name.js'
 import { printValidationResult } from './utils.js'
+import { scaffoldSkillDirectory } from './init.helpers.js'
 
 /**
  * SMI-1473: Options for non-interactive init command
@@ -103,9 +103,14 @@ export async function initSkill(
 
   const skillDir = resolve(targetPath, skillName)
 
-  // Check if directory already exists
+  // SMI-4289: Track whether this invocation created the directory fresh.
+  // Used by the scaffold helper to decide if rollback can safely rm -rf
+  // on mid-scaffold failure. When false (user confirmed overwrite of
+  // pre-existing dir), rollback MUST no-op to protect the user's files.
+  let skillDirPreExisted = false
   try {
     await stat(skillDir)
+    skillDirPreExisted = true
     // Skip confirmation if --yes flag is set
     if (!options.yes) {
       const overwrite = await confirm({
@@ -123,72 +128,42 @@ export async function initSkill(
 
   const spinner = ora('Creating skill structure...').start()
 
+  // SMI-4289: mkdir is outside the scaffold helper so we can detect EACCES
+  // / EPERM / ENOSPC here and set createdFresh appropriately. If mkdir
+  // itself fails on a fresh path, there is no partial directory to roll
+  // back — we simply report the error.
+  let createdFresh = false
   try {
-    // Create directory structure
     await mkdir(skillDir, { recursive: true })
-    await mkdir(join(skillDir, 'scripts'), { recursive: true })
-    await mkdir(join(skillDir, 'resources'), { recursive: true })
-
-    // Generate SKILL.md from template
-    const skillMdContent = SKILL_MD_TEMPLATE.replace(/\{\{name\}\}/g, skillName)
-      .replace(/\{\{description\}\}/g, description)
-      .replace(/\{\{author\}\}/g, author)
-      .replace(/\{\{category\}\}/g, category)
-      .replace(/\{\{date\}\}/g, new Date().toISOString().split('T')[0] || '')
-      .replace(/\{\{behavioralClassification\}\}/g, '')
-
-    await writeFile(join(skillDir, 'SKILL.md'), skillMdContent, 'utf-8')
-
-    // Generate README.md from template
-    const readmeContent = README_MD_TEMPLATE.replace(/\{\{name\}\}/g, skillName).replace(
-      /\{\{description\}\}/g,
-      description
-    )
-
-    await writeFile(join(skillDir, 'README.md'), readmeContent, 'utf-8')
-
-    // Create placeholder script
-    const placeholderScript = `#!/usr/bin/env node
-/**
- * ${skillName} - Example Script
- *
- * Add your skill's automation scripts here.
- */
-
-console.log('${skillName} script executed');
-`
-    await writeFile(join(skillDir, 'scripts', 'example.js'), placeholderScript, 'utf-8')
-
-    // Create .gitignore
-    const gitignore = `# Dependencies
-node_modules/
-
-# Build output
-dist/
-
-# Environment
-.env
-.env.local
-
-# OS files
-.DS_Store
-Thumbs.db
-`
-    await writeFile(join(skillDir, '.gitignore'), gitignore, 'utf-8')
-
-    spinner.succeed(`Created skill at ${skillDir}`)
-
-    console.log(chalk.bold('\nNext steps:'))
-    console.log(chalk.dim(`  1. cd ${skillDir}`))
-    console.log(chalk.dim('  2. Edit SKILL.md to customize your skill'))
-    console.log(chalk.dim('  3. Add scripts to the scripts/ directory'))
-    console.log(chalk.dim('  4. Run skillsmith validate to check your skill'))
-    console.log(chalk.dim('  5. Run skillsmith publish to prepare for sharing'))
-    console.log()
+    createdFresh = !skillDirPreExisted
   } catch (error) {
     spinner.fail(`Failed to create skill: ${sanitizeError(error)}`)
-    throw error
+    process.exit(1)
   }
+
+  const result = await scaffoldSkillDirectory({
+    skillDir,
+    skillName,
+    description,
+    author,
+    category,
+    createdFresh,
+  })
+
+  if (!result.ok) {
+    spinner.fail(`Failed to create skill: ${result.error}`)
+    process.exit(1)
+  }
+
+  spinner.succeed(`Created skill at ${skillDir}`)
+
+  console.log(chalk.bold('\nNext steps:'))
+  console.log(chalk.dim(`  1. cd ${skillDir}`))
+  console.log(chalk.dim('  2. Edit SKILL.md to customize your skill'))
+  console.log(chalk.dim('  3. Add scripts to the scripts/ directory'))
+  console.log(chalk.dim('  4. Run skillsmith validate to check your skill'))
+  console.log(chalk.dim('  5. Run skillsmith publish to prepare for sharing'))
+  console.log()
 }
 
 /**

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -1,0 +1,282 @@
+/**
+ * SMI-4289: author init error handling tests (closes #602)
+ *
+ * Covers the 6 cases from the wave plan:
+ * 1. Happy path (fresh dir, all writes succeed) → { ok: true } + files on disk
+ * 2. mkdir EACCES on fresh path → { ok: false }, no partial directory remains
+ * 3. writeFile fails mid-scaffold with createdFresh=true → rollback deletes skillDir
+ * 4. writeFile fails mid-scaffold with createdFresh=false (overwrite) → NO rollback
+ * 5. Double-print regression: error printed exactly once
+ * 6. Exit code is 1 on failure (validated via process.exit stub)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdir, rm, stat, readFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import {
+  scaffoldSkillDirectory,
+  rollbackPartialScaffold,
+} from '../src/commands/author/init.helpers.js'
+
+/**
+ * Create a unique tmp directory for each test (race-safe with Date.now + random).
+ */
+async function makeTmpDir(prefix: string): Promise<string> {
+  const dir = join(
+    tmpdir(),
+    `smi-4289-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  )
+  await mkdir(dir, { recursive: true })
+  return dir
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('SMI-4289: scaffoldSkillDirectory', () => {
+  let tmpRoot: string
+
+  beforeEach(async () => {
+    tmpRoot = await makeTmpDir('scaffold')
+  })
+
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('case 1: happy path — fresh dir, all writes succeed → { ok: true } + files on disk', async () => {
+    const skillDir = join(tmpRoot, 'happy-skill')
+    await mkdir(skillDir, { recursive: true })
+
+    const result = await scaffoldSkillDirectory({
+      skillDir,
+      skillName: 'happy-skill',
+      description: 'A test skill',
+      author: 'tester',
+      category: 'development',
+      createdFresh: true,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(await exists(join(skillDir, 'SKILL.md'))).toBe(true)
+    expect(await exists(join(skillDir, 'README.md'))).toBe(true)
+    expect(await exists(join(skillDir, 'scripts', 'example.js'))).toBe(true)
+    expect(await exists(join(skillDir, '.gitignore'))).toBe(true)
+    expect(await exists(join(skillDir, 'resources'))).toBe(true)
+
+    const skillMd = await readFile(join(skillDir, 'SKILL.md'), 'utf-8')
+    expect(skillMd).toContain('happy-skill')
+    expect(skillMd).toContain('A test skill')
+  })
+
+  it('case 3: writeFile fails mid-scaffold with createdFresh=true → rollback deletes skillDir', async () => {
+    const skillDir = join(tmpRoot, 'fresh-fail')
+    await mkdir(skillDir, { recursive: true })
+
+    // Create a `SKILL.md` as a directory so writeFile throws EISDIR mid-scaffold.
+    await mkdir(join(skillDir, 'SKILL.md'), { recursive: true })
+
+    const result = await scaffoldSkillDirectory({
+      skillDir,
+      skillName: 'fresh-fail',
+      description: 'x',
+      author: 'x',
+      category: 'development',
+      createdFresh: true,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(typeof result.error).toBe('string')
+      expect(result.error.length).toBeGreaterThan(0)
+    }
+    // rollback removed the whole skillDir
+    expect(await exists(skillDir)).toBe(false)
+  })
+
+  it('case 4: writeFile fails mid-scaffold with createdFresh=false → NO rollback; directory preserved', async () => {
+    const skillDir = join(tmpRoot, 'overwrite-fail')
+    await mkdir(skillDir, { recursive: true })
+
+    // Pre-existing user file that must be preserved on failure
+    const userFile = join(skillDir, 'user-data.txt')
+    await writeFile(userFile, 'IMPORTANT USER DATA', 'utf-8')
+
+    // Trip writeFile(SKILL.md) by making it a non-empty directory
+    await mkdir(join(skillDir, 'SKILL.md'), { recursive: true })
+
+    const result = await scaffoldSkillDirectory({
+      skillDir,
+      skillName: 'overwrite-fail',
+      description: 'x',
+      author: 'x',
+      category: 'development',
+      createdFresh: false,
+    })
+
+    expect(result.ok).toBe(false)
+    // CRITICAL: user data + skillDir still present
+    expect(await exists(skillDir)).toBe(true)
+    expect(await exists(userFile)).toBe(true)
+    const content = await readFile(userFile, 'utf-8')
+    expect(content).toBe('IMPORTANT USER DATA')
+  })
+})
+
+describe('SMI-4289: rollbackPartialScaffold', () => {
+  let tmpRoot: string
+
+  beforeEach(async () => {
+    tmpRoot = await makeTmpDir('rollback')
+  })
+
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('no-ops when createdFresh=false (overwrite path preserves user data)', async () => {
+    const skillDir = join(tmpRoot, 'preserved')
+    await mkdir(skillDir, { recursive: true })
+    await writeFile(join(skillDir, 'keep.txt'), 'user wrote this', 'utf-8')
+
+    await rollbackPartialScaffold(skillDir, false)
+
+    expect(await exists(skillDir)).toBe(true)
+    expect(await exists(join(skillDir, 'keep.txt'))).toBe(true)
+  })
+
+  it('removes skillDir when createdFresh=true', async () => {
+    const skillDir = join(tmpRoot, 'to-remove')
+    await mkdir(skillDir, { recursive: true })
+    await writeFile(join(skillDir, 'partial.txt'), 'scaffold output', 'utf-8')
+
+    await rollbackPartialScaffold(skillDir, true)
+
+    expect(await exists(skillDir)).toBe(false)
+  })
+
+  it('swallows rollback errors silently (best-effort cleanup)', async () => {
+    // Passing a nonexistent path with force:true does not throw (node rm semantics).
+    // Even so, confirm the function itself never rejects on unusual inputs.
+    const ghost = join(tmpRoot, 'does-not-exist')
+    await expect(rollbackPartialScaffold(ghost, true)).resolves.toBeUndefined()
+  })
+})
+
+describe('SMI-4289: initSkill integration (error handling contract)', () => {
+  const logSpy = vi.fn()
+  const errorSpy = vi.fn()
+  const exitSpy = vi.fn() as unknown as (code?: number) => never
+
+  let originalLog: typeof console.log
+  let originalError: typeof console.error
+  let originalExit: typeof process.exit
+  let tmpRoot: string
+
+  beforeEach(async () => {
+    logSpy.mockReset()
+    errorSpy.mockReset()
+    ;(exitSpy as unknown as ReturnType<typeof vi.fn>).mockReset?.()
+    originalLog = console.log
+    originalError = console.error
+    originalExit = process.exit
+    console.log = logSpy
+    console.error = errorSpy
+    // Replace process.exit so we can observe the code without killing the test worker.
+    process.exit = ((code?: number) => {
+      ;(exitSpy as unknown as (c?: number) => void)(code)
+      // Throw a marker so the CLI code path halts like a real exit.
+      throw new Error(`__EXIT__:${code ?? 0}`)
+    }) as typeof process.exit
+    tmpRoot = await makeTmpDir('init')
+  })
+
+  afterEach(async () => {
+    console.log = originalLog
+    console.error = originalError
+    process.exit = originalExit
+    await rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('case 2 + 6: mkdir fails on a path whose parent is not a directory → exit(1), no double-print', async () => {
+    const { initSkill } = await import('../src/commands/author/init.js')
+
+    // Making the *parent* a regular file forces mkdir({ recursive: true })
+    // to reject with ENOTDIR on all POSIX platforms, including root-run CI.
+    // This is more portable than chmod 000 which root ignores.
+    const parentFile = join(tmpRoot, 'not-a-directory')
+    await writeFile(parentFile, 'x', 'utf-8')
+
+    // targetPath points inside that file; init will try to resolve(targetPath, name)
+    // then mkdir, which fails.
+    let caught: unknown
+    try {
+      await initSkill('blocked-skill', parentFile, {
+        description: 'x',
+        author: 'x',
+        category: 'development',
+        yes: true,
+      })
+    } catch (error) {
+      caught = error
+    }
+
+    // The stubbed process.exit throws a marker; confirm exit(1) was called.
+    expect(String(caught)).toContain('__EXIT__:1')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+
+    // Double-print regression guard: the outer createInitCommand().action()
+    // catch would call console.error a second time. initSkill itself must
+    // not call console.error at all for scaffold failures (the spinner
+    // prints via ora, not console.error). The outer wrapper's console.error
+    // is NOT invoked here because we call initSkill directly.
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    // No partial directory left behind on the blocked path.
+    const wouldBeSkillDir = join(parentFile, 'blocked-skill')
+    expect(await exists(wouldBeSkillDir)).toBe(false)
+  })
+
+  it('case 5: scaffold failure prints the failure exactly once (no double-print)', async () => {
+    const { initSkill } = await import('../src/commands/author/init.js')
+
+    // Create the target directory, then create SKILL.md as a directory so
+    // the mkdir at init.ts succeeds (skillDir exists), and writeFile fails
+    // mid-scaffold inside the helper. With createdFresh=false (pre-existing
+    // directory that we confirmed via --yes), rollback is a no-op and the
+    // helper returns { ok: false, error }.
+    const skillDirName = 'collision-skill'
+    const skillDir = join(tmpRoot, skillDirName)
+    await mkdir(skillDir, { recursive: true })
+    await mkdir(join(skillDir, 'SKILL.md'), { recursive: true })
+
+    let caught: unknown
+    try {
+      await initSkill(skillDirName, tmpRoot, {
+        description: 'x',
+        author: 'x',
+        category: 'development',
+        yes: true,
+      })
+    } catch (error) {
+      caught = error
+    }
+
+    expect(String(caught)).toContain('__EXIT__:1')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    // Double-print guard: initSkill must not call console.error — spinner
+    // prints via its own channel (ora). If a re-throw were still in place,
+    // the outer createInitCommand() action handler would have printed via
+    // console.error, but we're invoking initSkill directly so we only
+    // assert that initSkill itself doesn't emit the error twice.
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- Extracts scaffold logic from `author init` into `init.helpers.ts` to get `init.ts` off the 499-line pre-commit limit and to let the scaffold return a typed `{ ok, error }` result instead of throwing.
- Adds `rollbackPartialScaffold(skillDir, createdFresh)` with a **data-loss-safe** guard: if the user confirmed an overwrite of a pre-existing directory (`createdFresh=false`), rollback is a no-op so a mid-scaffold failure never destroys the user's existing files. Passes `skillDir`, **never** the user-provided parent `targetPath`.
- Removes the `spinner.fail(...)` + `throw error` double-catch in `initSkill()`; the outer `createInitCommand().action()` no longer re-prints the same error.

Closes #602.

## Files changed

- `packages/cli/src/commands/author/init.ts` — scaffold block replaced with typed-result handling; adds `createdFresh` tracking around `mkdir`; removes re-throw. 499 → 474 lines.
- `packages/cli/src/commands/author/init.helpers.ts` (new, 151 lines) — `scaffoldSkillDirectory`, `rollbackPartialScaffold`, `ScaffoldInput`, `ScaffoldResult`.
- `packages/cli/tests/init.test.ts` (new, 282 lines, 8 cases).
- `packages/cli/CHANGELOG.md` — Unreleased entry.

## Test plan

- [x] `docker exec <container> npm run preflight` passes.
- [x] `docker exec <container> npm run audit:standards` — 45 passed, 2 warnings, 0 failed, 96% compliance.
- [x] `docker exec <container> npx vitest run` in `packages/cli` — 449/449 tests pass (15 files).
- [x] `init.test.ts` 8 cases cover: happy path; writeFile-fails with createdFresh=true → rollback; writeFile-fails with createdFresh=false → NO rollback, user data preserved; mkdir-fails on bad parent → exit 1, no partial dir; `rollbackPartialScaffold` no-ops on createdFresh=false; rollback removes on createdFresh=true; rollback swallows errors; no-double-print regression.
- [x] Manual CLI repro inside Docker:
  - Parent-is-file → ENOTDIR: friendly sanitized message, no partial directory, exit 1.
  - Pre-existing dir with user file `important.txt` + `--yes` overwrite + SKILL.md directory collision → mid-scaffold EISDIR: user file and directory preserved, error printed once.
  - Happy path on fresh dir → unchanged success output.
- [x] `init.ts` 474 lines (< 500); `init.helpers.ts` 151 lines.
- [x] `init.helpers.ts` 100% coverage (statements/functions/lines), 75% branch.

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>