### PR TITLE
chore(db): remove stale 071_RESERVED placeholder (SMI-4292 leftover)

### DIFF
--- a/supabase/migrations/071_RESERVED_team_workspaces.placeholder
+++ b/supabase/migrations/071_RESERVED_team_workspaces.placeholder
@@ -1,5 +1,0 @@
--- Migration slot 071 RESERVED for Wave 5A: team_workspaces + workspace_skills + resolve_team_from_license RPC
--- Tracking: SMI-4292 — Team workspaces foundation
--- Plan: docs/internal/implementation/github-wave-5a-team-workspaces.md
--- Plan-review finding C1: foundation schema does not exist; this wave creates it from scratch
--- This file MUST be deleted when the real 071_team_workspaces.sql migration is committed.


### PR DESCRIPTION
## Summary

Wave 5A (SMI-4292, PR #634) created the real `071_team_workspaces.sql` migration but left the `071_RESERVED_team_workspaces.placeholder` reservation file behind. Removing it.

## Impact

None — placeholder is a SQL comment file, supabase CLI ignores `.placeholder` extension. Cleaning it just removes noise from `supabase/migrations/`.

## Test plan

- [x] `docker exec skillsmith-dev-1 npm run preflight` (runs as pre-commit)
- [x] No other migration references the placeholder

[skip-impl-check] — docs/db-housekeeping only, no source code change.

Refs SMI-4292.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)