### PR TITLE
refactor(analytics): extract ROI CSV helper to sidecar (governance file-length)

### DIFF
--- a/packages/core/src/analytics/ROIDashboardService.csv.ts
+++ b/packages/core/src/analytics/ROIDashboardService.csv.ts
@@ -1,0 +1,50 @@
+/**
+ * ROI dashboard CSV export helpers — extracted from ROIDashboardService to keep
+ * the main service file under the 500-line governance limit.
+ */
+
+import type { ROIDashboard } from './types.js'
+
+/**
+ * Render a partial ROI dashboard as CSV.
+ * Handles user-only, stakeholder-only, or combined payloads.
+ */
+export function convertROIToCSV(data: Partial<ROIDashboard>): string {
+  const lines: string[] = []
+
+  if (data.user) {
+    lines.push('User ROI Dashboard')
+    lines.push('')
+    lines.push('Metric,Value')
+    lines.push(`User ID,${data.user.userId}`)
+    lines.push(`Total Time Saved (min),${data.user.totalTimeSaved.toFixed(1)}`)
+    lines.push(`Estimated Value (USD),${data.user.estimatedValueUsd.toFixed(2)}`)
+    lines.push('')
+    lines.push('Top Skills')
+    lines.push('Skill ID,Skill Name,Time Saved (min)')
+    for (const skill of data.user.topSkills) {
+      lines.push(`${skill.skillId},${skill.skillName},${skill.timeSaved.toFixed(1)}`)
+    }
+  }
+
+  if (data.stakeholder) {
+    lines.push('Stakeholder ROI Dashboard')
+    lines.push('')
+    lines.push('Metric,Value')
+    lines.push(`Total Users,${data.stakeholder.totalUsers}`)
+    lines.push(`Total Activations,${data.stakeholder.totalActivations}`)
+    lines.push(`Avg Time Saved Per User (min),${data.stakeholder.avgTimeSavedPerUser.toFixed(1)}`)
+    lines.push(`Total Estimated Value (USD),${data.stakeholder.totalEstimatedValue.toFixed(2)}`)
+    lines.push(`Adoption Rate (%),${(data.stakeholder.adoptionRate * 100).toFixed(1)}`)
+    lines.push('')
+    lines.push('Skill Leaderboard')
+    lines.push('Skill ID,Skill Name,User Count,Total Value (USD)')
+    for (const skill of data.stakeholder.skillLeaderboard) {
+      lines.push(
+        `${skill.skillId},${skill.skillName},${skill.userCount},${skill.totalValue.toFixed(2)}`
+      )
+    }
+  }
+
+  return lines.join('\n')
+}

--- a/packages/core/src/analytics/ROIDashboardService.ts
+++ b/packages/core/src/analytics/ROIDashboardService.ts
@@ -11,6 +11,7 @@
 import type { Database as DatabaseType } from '../db/database-interface.js'
 import { ValidationError } from '../validation/validation-error.js'
 import { AnalyticsRepository } from './AnalyticsRepository.js'
+import { convertROIToCSV } from './ROIDashboardService.csv.js'
 import type { ROIDashboard, ROIMetrics, ExportFormat, UsageEvent } from './types.js'
 
 export interface ROIComputeOptions {
@@ -209,7 +210,7 @@ export class ROIDashboardService {
         return JSON.stringify(data, null, 2)
 
       case 'csv':
-        return this.convertROIToCSV(data)
+        return convertROIToCSV(data)
 
       case 'pdf':
         throw new Error('PDF export not yet implemented')
@@ -461,45 +462,5 @@ export class ROIDashboardService {
       estimatedValueUsd: 0,
       computedAt: new Date().toISOString(),
     }
-  }
-
-  private convertROIToCSV(data: Partial<ROIDashboard>): string {
-    const lines: string[] = []
-
-    if (data.user) {
-      lines.push('User ROI Dashboard')
-      lines.push('')
-      lines.push('Metric,Value')
-      lines.push(`User ID,${data.user.userId}`)
-      lines.push(`Total Time Saved (min),${data.user.totalTimeSaved.toFixed(1)}`)
-      lines.push(`Estimated Value (USD),${data.user.estimatedValueUsd.toFixed(2)}`)
-      lines.push('')
-      lines.push('Top Skills')
-      lines.push('Skill ID,Skill Name,Time Saved (min)')
-      for (const skill of data.user.topSkills) {
-        lines.push(`${skill.skillId},${skill.skillName},${skill.timeSaved.toFixed(1)}`)
-      }
-    }
-
-    if (data.stakeholder) {
-      lines.push('Stakeholder ROI Dashboard')
-      lines.push('')
-      lines.push('Metric,Value')
-      lines.push(`Total Users,${data.stakeholder.totalUsers}`)
-      lines.push(`Total Activations,${data.stakeholder.totalActivations}`)
-      lines.push(`Avg Time Saved Per User (min),${data.stakeholder.avgTimeSavedPerUser.toFixed(1)}`)
-      lines.push(`Total Estimated Value (USD),${data.stakeholder.totalEstimatedValue.toFixed(2)}`)
-      lines.push(`Adoption Rate (%),${(data.stakeholder.adoptionRate * 100).toFixed(1)}`)
-      lines.push('')
-      lines.push('Skill Leaderboard')
-      lines.push('Skill ID,Skill Name,User Count,Total Value (USD)')
-      for (const skill of data.stakeholder.skillLeaderboard) {
-        lines.push(
-          `${skill.skillId},${skill.skillName},${skill.userCount},${skill.totalValue.toFixed(2)}`
-        )
-      }
-    }
-
-    return lines.join('\n')
   }
 }


### PR DESCRIPTION
## Summary

Governance retro on the April 2026 8-PR triage batch surfaced `ROIDashboardService.ts` at 505 lines — over the 500-line governance limit. Regression from SMI-1683 / Wave 5B helper additions.

Fix: extract the 39-line `convertROIToCSV` function into `ROIDashboardService.csv.ts`.

- Before: `ROIDashboardService.ts` = 505 lines
- After: `ROIDashboardService.ts` = 467 lines; `ROIDashboardService.csv.ts` = 50 lines
- Pure extraction — zero behavior change
- `ROIDashboardService.test.ts` 25/25 still pass
- `audit:standards` compliance still 96%; file-length warning for this file cleared

Refs SMI-1683. Unblocks future edits to `ROIDashboardService.ts` (any line addition would have tripped the pre-commit `check-file-length.mjs` hook).

## Test plan

- [x] `docker exec skillsmith-dev-1 npm run typecheck`
- [x] `docker exec skillsmith-dev-1 npm test -w packages/core -- ROIDashboardService`
- [x] `docker exec skillsmith-dev-1 npm run audit:standards`

[skip-impl-check] — pure refactor, source changes only, covered by existing tests.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)