### PR TITLE
fix(core): pythonIncremental — log init failures, probe WASM candidates (SMI-4315, SMI-4316)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -25,6 +25,9 @@ supabase/migrations/
 
 # Git worktrees - each worktree has its own encrypted content and Prettier config
 .worktrees/
+# Worktrees created outside `.worktrees/` (e.g. top-level `smi-<n>-*` dirs).
+# Each worktree carries its own encrypted / unformatted content tree.
+smi-*/
 
 # Local settings (untracked, varies per developer)
 .claude/settings.local.json

--- a/packages/core/src/analysis/tree-sitter/pythonIncremental.hardening.test.ts
+++ b/packages/core/src/analysis/tree-sitter/pythonIncremental.hardening.test.ts
@@ -1,0 +1,271 @@
+/**
+ * SMI-4315 + SMI-4316: hardening tests for pythonIncremental.
+ *
+ * SMI-4315 — `resolvePythonWasmPath` probes each candidate with
+ * `fs.existsSync` instead of always returning `candidates[0]`. Regression
+ * test for the package-local-fallback case.
+ *
+ * SMI-4316 — both silent catches now emit logger.warn. Tests verify:
+ *   - `parseSync` catch: rate-limited warn keyed per file; payload is
+ *     `{ file, error }` only with error truncated to <=200 chars and no
+ *     `stack` field (no source code leak).
+ *   - `doInit` catch: one-shot warn per parser instance on init failure.
+ *
+ * All SUT access goes through a dynamic `import('./pythonIncremental.js')`
+ * inside the tests so the vi.mock calls below are applied even when vitest
+ * shares its module cache with sibling test files in the same worker.
+ * Mixing static `import { X } from './pythonIncremental.js'` with vi.mock
+ * against the same module has been observed to bypass the mock when a
+ * sibling test file imports the SUT first.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetRateLimiter } from '../../utils/rate-limit.js'
+import type { WebTreeSitterLoader } from './pythonIncremental.js'
+
+// vi.hoisted runs before vi.mock factories; closure-sharing the spy
+// objects avoids the createLogger-spy trap (feedback_logger_spy_pattern).
+const { loggerSpies, existsSyncMock } = vi.hoisted(() => ({
+  loggerSpies: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    auditLog: vi.fn(),
+    securityLog: vi.fn(),
+  },
+  existsSyncMock: vi.fn<(p: string) => boolean>(),
+}))
+
+vi.mock('../../utils/logger.js', () => ({
+  createLogger: () => loggerSpies,
+}))
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+  return { ...actual, existsSync: (p: string) => existsSyncMock(p) }
+})
+
+// Dynamic SUT import so the mocks above definitely apply.
+type SUT = typeof import('./pythonIncremental.js')
+let SUT_CACHE: SUT | null = null
+async function getSUT(): Promise<SUT> {
+  if (!SUT_CACHE) SUT_CACHE = await import('./pythonIncremental.js')
+  return SUT_CACHE
+}
+
+describe('SMI-4315 · resolvePythonWasmPath existsSync probe', () => {
+  beforeEach(() => {
+    existsSyncMock.mockReset()
+  })
+
+  it('returns candidates[0] when the workspace-hoist path exists', async () => {
+    const { resolvePythonWasmPath } = await getSUT()
+    const seen: string[] = []
+    existsSyncMock.mockImplementation((p: string) => {
+      seen.push(p)
+      return true // first candidate hits; loop exits after one probe
+    })
+    const result = resolvePythonWasmPath()
+    expect(result).toMatch(/tree-sitter-python\.wasm$/)
+    expect(seen).toHaveLength(1)
+    expect(result).toBe(seen[0])
+  })
+
+  it('falls back to candidates[1] (package-local) when the hoist is missing', async () => {
+    const { resolvePythonWasmPath } = await getSUT()
+    const seen: string[] = []
+    existsSyncMock.mockImplementation((p: string) => {
+      seen.push(p)
+      return seen.length === 2 // second candidate exists
+    })
+    const result = resolvePythonWasmPath()
+    expect(result).toBe(seen[1])
+    expect(seen).toHaveLength(2)
+    expect(seen[0]).not.toBe(seen[1])
+  })
+
+  it('returns candidates[0] as a stable error anchor when neither exists', async () => {
+    const { resolvePythonWasmPath } = await getSUT()
+    const seen: string[] = []
+    existsSyncMock.mockImplementation((p: string) => {
+      seen.push(p)
+      return false
+    })
+    const result = resolvePythonWasmPath()
+    expect(result).toBe(seen[0])
+    expect(seen).toHaveLength(2)
+  })
+})
+
+describe('SMI-4316 · parseSync catch emits rate-limited warn', () => {
+  beforeEach(() => {
+    loggerSpies.warn.mockReset()
+    resetRateLimiter()
+    // existsSync returns true so the constructor wasm-path resolution is
+    // stable even though we don't actually load WASM in these tests.
+    existsSyncMock.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    resetRateLimiter()
+  })
+
+  /**
+   * Build a parser primed with a cached entry whose `tree.edit` throws on
+   * re-parse. This drives `parseSync` into the catch without needing a
+   * real WASM runtime.
+   */
+  function primeFailingCache(
+    parser: InstanceType<SUT['PythonIncrementalParser']>,
+    filePath: string,
+    error: Error
+  ) {
+    const p = parser as unknown as {
+      parser: { parse: () => unknown }
+      language: unknown
+      queries: unknown
+      cache: Map<string, { tree: unknown; content: string; lastUsed: number; lastResult: null }>
+    }
+    // Force `isReady` true with minimal stubs.
+    p.parser = { parse: () => ({}) }
+    p.language = {}
+    p.queries = {}
+    p.cache.set(filePath, {
+      tree: {
+        edit: () => {
+          throw error
+        },
+        delete: () => {},
+      },
+      content: 'placeholder\n',
+      lastUsed: 1,
+      lastResult: null,
+    })
+  }
+
+  it('emits one warn on the first parseSync failure with safe payload', async () => {
+    const { PythonIncrementalParser } = await getSUT()
+    const parser = new PythonIncrementalParser()
+    const filePath = 'a.py'
+    primeFailingCache(parser, filePath, new Error('simulated parse failure'))
+
+    const result = parser.parseSync('different content\n', filePath)
+    expect(result).toBeNull()
+    expect(loggerSpies.warn).toHaveBeenCalledTimes(1)
+
+    const [message, payload] = loggerSpies.warn.mock.calls[0]
+    expect(message).toContain('parseSync failed')
+    // Strictly { file, error } — no stack, no source content.
+    expect(payload).toEqual({
+      file: filePath,
+      error: 'simulated parse failure',
+    })
+    expect(Object.keys(payload ?? {}).sort()).toEqual(['error', 'file'])
+  })
+
+  it('truncates error messages to <=200 chars (no source code leak)', async () => {
+    const { PythonIncrementalParser } = await getSUT()
+    const parser = new PythonIncrementalParser()
+    const filePath = 'b.py'
+    const longMsg = 'E'.repeat(500)
+    // Include a newline that contains fake "source" content; the formatter
+    // must only keep the first line.
+    const faux = new Error(`${longMsg}\nSECRET_API_KEY=sk_live_should_never_appear`)
+    primeFailingCache(parser, filePath, faux)
+
+    parser.parseSync('xx\n', filePath)
+
+    const payload = loggerSpies.warn.mock.calls[0][1] as { file: string; error: string }
+    expect(payload.error.length).toBeLessThanOrEqual(200)
+    expect(payload.error).not.toContain('\n')
+    expect(payload.error).not.toContain('SECRET_API_KEY')
+  })
+
+  it('rate-limits a hot-loop flood (FIRST_N fire, then 1-in-SAMPLE_EVERY)', async () => {
+    const { PythonIncrementalParser } = await getSUT()
+    const parser = new PythonIncrementalParser()
+    const filePath = 'flood.py'
+    // FIRST_N (5) fires; after that, one-in-SAMPLE_EVERY (100) fires.
+    // 200 events after the first 5 → 2 sampled hits. Total = 7.
+    for (let i = 0; i < 205; i += 1) {
+      primeFailingCache(parser, filePath, new Error(`fail ${i}`))
+      parser.parseSync(`content ${i}\n`, filePath)
+    }
+    expect(loggerSpies.warn).toHaveBeenCalledTimes(7)
+  })
+
+  it('isolates rate-limit buckets across files', async () => {
+    const { PythonIncrementalParser } = await getSUT()
+    const parser = new PythonIncrementalParser()
+    // Drive hot.py well past its FIRST_N + next sampled boundary (5 + 1 = 6).
+    for (let i = 0; i < 50; i += 1) {
+      primeFailingCache(parser, 'hot.py', new Error('x'))
+      parser.parseSync(`content ${i}\n`, 'hot.py')
+    }
+    const hotWarns = loggerSpies.warn.mock.calls.length
+    // hot.py should have burned FIRST_N=5 + 1 sampled (count=6) = 6 warns.
+    expect(hotWarns).toBe(6)
+    // cool.py still gets its own FIRST_N budget, so the very first failure
+    // emits a warn regardless of what hot.py did.
+    primeFailingCache(parser, 'cool.py', new Error('y'))
+    parser.parseSync('ctn\n', 'cool.py')
+    expect(loggerSpies.warn.mock.calls.length).toBe(hotWarns + 1)
+    const cool = loggerSpies.warn.mock.calls.find(
+      (c) => (c[1] as { file: string }).file === 'cool.py'
+    )
+    expect(cool).toBeDefined()
+  })
+})
+
+describe('SMI-4316 · doInit catch emits one-shot warn', () => {
+  beforeEach(() => {
+    loggerSpies.warn.mockReset()
+    resetRateLimiter()
+    existsSyncMock.mockReturnValue(true)
+  })
+
+  it('logs a single warn on init failure with wasmPath + error + stack', async () => {
+    const { PythonIncrementalParser } = await getSUT()
+    const failingLoader: WebTreeSitterLoader = async () => {
+      throw new Error('module not found')
+    }
+    const parser = new PythonIncrementalParser({}, failingLoader)
+    const result = await parser.parse('def x(): pass\n', 'fail.py')
+
+    expect(result).toBeNull()
+    expect(parser.hasFailedInit).toBe(true)
+    expect(loggerSpies.warn).toHaveBeenCalledTimes(1)
+    const [message, payload] = loggerSpies.warn.mock.calls[0]
+    expect(message).toContain('init failed')
+    const p = payload as { wasmPath: string; error: string; stack?: string }
+    expect(p.wasmPath).toMatch(/tree-sitter-python\.wasm$/)
+    expect(p.error).toBe('module not found')
+    expect(typeof p.stack).toBe('string')
+  })
+
+  it('does not warn on a successful parse path (no init failure)', async () => {
+    const { PythonIncrementalParser } = await getSUT()
+    const parser = new PythonIncrementalParser()
+    // Mark ready via stubs; we only assert doInit never fired a warn.
+    const p = parser as unknown as {
+      parser: { parse: () => unknown }
+      language: unknown
+      queries: unknown
+      initFailed: boolean
+    }
+    p.parser = { parse: () => ({ rootNode: {} }) }
+    p.language = {}
+    p.queries = {}
+    p.initFailed = false
+    try {
+      parser.parseSync('def ok(): pass\n', 'ok.py')
+    } catch {
+      // swallow — assertion is on the warn spy, not the parse result.
+    }
+    const initWarns = loggerSpies.warn.mock.calls.filter((c) =>
+      String(c[0]).includes('init failed')
+    )
+    expect(initWarns).toHaveLength(0)
+  })
+})

--- a/packages/core/src/analysis/tree-sitter/pythonIncremental.test.ts
+++ b/packages/core/src/analysis/tree-sitter/pythonIncremental.test.ts
@@ -14,7 +14,21 @@
  * @see docs/internal/implementation/github-wave-5c-tree-sitter-incremental.md
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+
+// Silence warn output from the SMI-4316 hardening paths; behavioural
+// assertions live in pythonIncremental.hardening.test.ts.
+vi.mock('../../utils/logger.js', () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    auditLog: vi.fn(),
+    securityLog: vi.fn(),
+  }),
+}))
+
 import { PythonIncrementalParser, type WebTreeSitterLoader } from './pythonIncremental.js'
 
 describe('PythonIncrementalParser', () => {

--- a/packages/core/src/analysis/tree-sitter/pythonIncremental.ts
+++ b/packages/core/src/analysis/tree-sitter/pythonIncremental.ts
@@ -17,12 +17,22 @@
  * @module analysis/tree-sitter/pythonIncremental
  */
 
+import * as fs from 'node:fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import type { ParseResult } from '../types.js'
 import { calculateEdit, findMinimalEdit, type FileEdit } from '../incremental.js'
+import { createLogger } from '../../utils/logger.js'
+import { rateLimited } from '../../utils/rate-limit.js'
 import type { TreeSitterLanguage, TreeSitterParser, TreeSitterTree } from './manager.js'
 import { PythonQuerySet, extractPythonParseResult, type QueryCtor } from './pythonExtractor.js'
+
+const logger = createLogger('PythonIncrementalParser')
+
+/** First line of a string, truncated to 200 chars. Used to avoid leaking source content into logs. */
+function firstLine(s: string): string {
+  return s.split('\n', 1)[0]?.slice(0, 200) ?? ''
+}
 
 /** Maximum number of cached trees (per SMI-1309 / SMI-4293 spec). */
 const DEFAULT_MAX_TREES = 100
@@ -46,7 +56,7 @@ export function resolvePythonWasmPath(): string {
       'out',
       'tree-sitter-python.wasm'
     ),
-    // Package-local (when not hoisted)
+    // Package-local (npm-registry install consumers without hoist)
     path.resolve(
       here,
       '..',
@@ -59,6 +69,12 @@ export function resolvePythonWasmPath(): string {
       'tree-sitter-python.wasm'
     ),
   ]
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate
+  }
+  // Neither exists on disk; return the first so `doInit()` has a stable
+  // error path to surface. Probe is best-effort — the real load failure
+  // is still caught by `doInit()` below.
   return candidates[0]
 }
 
@@ -214,9 +230,19 @@ export class PythonIncrementalParser {
       const entry = this.cache.get(filePath)
       if (entry) entry.lastResult = result
       return result
-    } catch {
+    } catch (error) {
       // Any failure (corrupt tree, grammar error) invalidates this file's
       // cache and signals the adapter to use regex fallback for this call.
+      // Log rate-limited so a pathological grammar hit cannot flood logs.
+      // Emit only `{ file, error(firstLine, <=200) }` — never the source
+      // content or the stack (tree-sitter errors can quote source lines).
+      if (rateLimited(`python-parse:${filePath}`)) {
+        const message = error instanceof Error ? error.message : String(error)
+        logger.warn('Python parseSync failed; regex fallback for this file', {
+          file: filePath,
+          error: firstLine(message),
+        })
+      }
       this.invalidate(filePath)
       return null
     }
@@ -277,11 +303,20 @@ export class PythonIncrementalParser {
       this.parser = parser
       this.language = language
       this.queries = new PythonQuerySet(deps.Query, language)
-    } catch {
+    } catch (error) {
       this.initFailed = true
       this.parser = null
       this.language = null
       this.queries = null
+      // One-shot warn per parser instance: fires at most once in `doInit`.
+      // Log `{ wasmPath, error, stack }` for operator diagnostics; the WASM
+      // path is not secret, the stack points inside web-tree-sitter /
+      // resolvePythonWasmPath, not user source.
+      logger.warn('Python tree-sitter init failed; regex fallback in use', {
+        wasmPath: this.wasmPath,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      })
     }
   }
 

--- a/packages/core/src/utils/rate-limit.test.ts
+++ b/packages/core/src/utils/rate-limit.test.ts
@@ -1,0 +1,86 @@
+/**
+ * SMI-4316: rateLimited() unit tests.
+ *
+ * Covers:
+ *   1. First-N events (<= FIRST_N) always return true.
+ *   2. Sampled-after-N events follow the 1-in-SAMPLE_EVERY cadence.
+ *   3. Per-key isolation (one key's flood does not starve another key).
+ *   4. Window rollover when `now` advances beyond WINDOW_MS.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { FIRST_N, SAMPLE_EVERY, WINDOW_MS, rateLimited, resetRateLimiter } from './rate-limit.js'
+
+describe('rateLimited', () => {
+  afterEach(() => {
+    resetRateLimiter()
+  })
+
+  it('allows the first FIRST_N calls for a key', () => {
+    const results: boolean[] = []
+    for (let i = 0; i < FIRST_N; i += 1) {
+      results.push(rateLimited('k1'))
+    }
+    expect(results.every((r) => r === true)).toBe(true)
+  })
+
+  it('after FIRST_N, allows one-in-SAMPLE_EVERY', () => {
+    // Burn the first N allowed events.
+    for (let i = 0; i < FIRST_N; i += 1) rateLimited('k2')
+    // Next 2 * SAMPLE_EVERY events should produce exactly 2 allowed.
+    let allowed = 0
+    for (let i = 0; i < 2 * SAMPLE_EVERY; i += 1) {
+      if (rateLimited('k2')) allowed += 1
+    }
+    expect(allowed).toBe(2)
+  })
+
+  it('matches the plan count: 5 firsts + 200 sampled = 7 total allowed', () => {
+    // Mirrors the acceptance test described in the plan.
+    let allowed = 0
+    for (let i = 0; i < FIRST_N; i += 1) {
+      if (rateLimited('k3')) allowed += 1
+    }
+    for (let i = 0; i < 200; i += 1) {
+      if (rateLimited('k3')) allowed += 1
+    }
+    expect(allowed).toBe(FIRST_N + 2)
+  })
+
+  it('isolates per-key: flooding one key does not starve another', () => {
+    // Flood key A well past FIRST_N.
+    for (let i = 0; i < FIRST_N * 3; i += 1) rateLimited('A')
+    // Key B still gets its full FIRST_N window.
+    let bAllowed = 0
+    for (let i = 0; i < FIRST_N; i += 1) {
+      if (rateLimited('B')) bAllowed += 1
+    }
+    expect(bAllowed).toBe(FIRST_N)
+  })
+
+  it('resets the bucket when the window elapses', () => {
+    const t0 = 1_000_000
+    // Exhaust first window at t0.
+    for (let i = 0; i < FIRST_N; i += 1) rateLimited('win', t0)
+    // Next event at t0 is the first sampled hit (count-FIRST_N === 1),
+    // so it passes. Step past that so the next is definitely suppressed.
+    rateLimited('win', t0)
+    expect(rateLimited('win', t0)).toBe(false)
+    // Advance past WINDOW_MS — the next call starts a fresh bucket and
+    // returns true as count-1.
+    const t1 = t0 + WINDOW_MS + 1
+    expect(rateLimited('win', t1)).toBe(true)
+  })
+
+  it('suppresses events after FIRST_N + 1 that are not on the sampled boundary', () => {
+    const t = 5_000
+    // First N pass.
+    for (let i = 0; i < FIRST_N; i += 1) {
+      expect(rateLimited('same-now', t)).toBe(true)
+    }
+    // FIRST_N + 1: first sampled hit, (count - FIRST_N) % SAMPLE_EVERY === 1 → true.
+    expect(rateLimited('same-now', t)).toBe(true)
+    // FIRST_N + 2: (count - FIRST_N) % SAMPLE_EVERY === 2 → false.
+    expect(rateLimited('same-now', t)).toBe(false)
+  })
+})

--- a/packages/core/src/utils/rate-limit.ts
+++ b/packages/core/src/utils/rate-limit.ts
@@ -1,0 +1,61 @@
+/**
+ * Rate Limiter Utility (SMI-4316)
+ *
+ * Token-bucket style rate limiter intended for gating log output. First N
+ * events per window fire unconditionally; after that, one-in-`SAMPLE_EVERY`
+ * is allowed through. Windows reset automatically once `WINDOW_MS` elapses
+ * since the first event in the window.
+ *
+ * Keyed: callers pass a stable string key (e.g. file path or error
+ * signature). Different keys are isolated — a flood on key A does not
+ * starve key B.
+ *
+ * Intended for observability, not security-sensitive throttling.
+ */
+
+type Key = string
+
+interface BucketState {
+  count: number
+  windowStart: number
+}
+
+const BUCKETS = new Map<Key, BucketState>()
+
+/** Window length for a single bucket (1 hour). */
+export const WINDOW_MS = 60 * 60 * 1000
+
+/** First N events per window always pass through. */
+export const FIRST_N = 5
+
+/** After the first N, every Nth subsequent event passes through. */
+export const SAMPLE_EVERY = 100
+
+/**
+ * Return `true` if the event for `key` should be allowed through
+ * (logged / processed), or `false` if it is suppressed by the limiter.
+ *
+ * The first `FIRST_N` events in a window always return `true`. After that,
+ * one-in-`SAMPLE_EVERY` events return `true` until the window rolls over.
+ *
+ * @param key - Stable grouping key (per-file, per-error, etc.)
+ * @param now - Optional timestamp override for tests (defaults to Date.now()).
+ */
+export function rateLimited(key: Key, now: number = Date.now()): boolean {
+  const existing = BUCKETS.get(key)
+  const bucket: BucketState =
+    existing && now - existing.windowStart <= WINDOW_MS ? existing : { count: 0, windowStart: now }
+  bucket.count += 1
+  BUCKETS.set(key, bucket)
+
+  if (bucket.count <= FIRST_N) return true
+  return (bucket.count - FIRST_N) % SAMPLE_EVERY === 1
+}
+
+/**
+ * Reset all buckets. Intended for tests; callers in production should not
+ * need this.
+ */
+export function resetRateLimiter(): void {
+  BUCKETS.clear()
+}


### PR DESCRIPTION
## Summary

- **SMI-4315**: `resolvePythonWasmPath` now probes each candidate with `fs.existsSync` instead of hardcoding `return candidates[0]`. Package-local fallback (npm-registry consumers without workspace hoist) is now reachable.
- **SMI-4316**: Two previously-silent catches in `pythonIncremental.ts` now emit `logger.warn`. `parseSync` catch is rate-limited per file; `doInit` catch is one-shot per parser instance. Both payloads exclude source content — the `parseSync` error message is first-line-only, truncated to ≤200 chars, and does not include a stack.
- Adds small keyed token-bucket rate limiter at `packages/core/src/utils/rate-limit.ts` (WINDOW_MS=1h, FIRST_N=5, SAMPLE_EVERY=100) with per-key isolation.
- Minor: `.prettierignore` broadened to skip top-level `smi-*/` worktree dirs created outside `.worktrees/` (unblocked pre-push from a sibling-session artifact).

## Plan

`docs/internal/implementation/smi-4315-4316-python-incremental-hardening.md`

## Test plan

- [x] `docker exec skillsmith-dev-1 npx vitest run pythonIncremental rate-limit` — 38 tests green
- [x] `docker exec skillsmith-dev-1 npx tsc --noEmit -p packages/core` — clean
- [x] `docker exec skillsmith-dev-1 npx eslint` on changed files — clean
- [x] `docker exec skillsmith-dev-1 npm run format:check` — clean
- [x] `docker exec skillsmith-dev-1 npm run audit:standards` — passed (94% compliance, pre-existing warnings only)
- [x] SMI-4315 regression test: `resolvePythonWasmPath()` falls back to `candidates[1]` when `candidates[0]` does not exist
- [x] SMI-4316 acceptance: `parseSync` flood of 205 failures → exactly 7 warn calls (5 first-N + 2 sampled); `doInit` failure → exactly 1 warn
- [x] No source-code leak: warn payload asserts `{ file, error }` keys only; error is first-line-only ≤200 chars, no `stack`

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)