### PR TITLE
chore(gitignore): ignore ruflo hive-mind runtime DB files (SMI-4358)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,8 @@ wrangler.toml.local
 
 # Ruflo (claude-flow) runtime DB created by mcp__ruflo__swarm_init + memory_store
 ruvector.db
+agentdb.rvf
+agentdb.rvf.lock
 
 docs/irap/
 .worktrees/


### PR DESCRIPTION
## Summary

- Add `agentdb.rvf` + `agentdb.rvf.lock` to .gitignore under the existing Ruflo block
- Ephemeral state created by `mcp__ruflo__hive-mind_*` tools

Note: submodule bump originally in this PR was dropped — PR #658 already bumped docs/internal past my 09825f0d (April 19 batch docs), so my earlier bump became redundant.

Closes SMI-4358.

## Test plan

- [ ] CI green
- [ ] After merge: `git status` stays clean after next ruflo hive-mind spawn

[skip-impl-check]

🤖 Generated with [Claude Code](https://claude.com/claude-code)