### PR TITLE
chore(release): core 0.5.4 + mcp-server 0.4.12 + cli 0.5.7 + vscode 0.2.2

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
+## v0.5.7
+
+- **Refactor**: initSkill throws InitSkillError instead of process.exit (SMI-4314) (#642)
+
 ## v0.5.6
 
 - Version bump

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.5.3",
+    "@skillsmith/core": "^0.5.4",
     "chalk": "5.6.2",
     "cli-table3": "0.6.5",
     "commander": "14.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@skillsmith/core` are documented here.
 
+## v0.5.4
+
+- **Fix**: rename webhook-dlq /retry → /resolve with migration 077 (SMI-4308) (#647)
+- **Feature**: team provisioning on subscription (SMI-4307) (#646)
+- **Fix**: populate UndoSnapshot.backup_path in ActivationManager (SMI-4297) (#644)
+
 ## v0.5.3
 
 - **Fix**: add missing SMI-4240 fields to ApiSearchResultSchema (SMI-4246, SMI-4247) (#611)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.5.3'
+export const VERSION = '0.5.4'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1024.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.69.0",
-    "@skillsmith/core": "^0.5.3",
+    "@skillsmith/core": "^0.5.4",
     "jose": "^6.2.2",
     "zod": "4.2.1"
   },

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/mcp-server` are documented here.
 
+## v0.4.12
+
+- **Fix**: team-workspace uses service-role client post-license-resolution (SMI-4312) (#650)
+
 ## v0.4.11
 
 - Version bump

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.5.3",
+    "@skillsmith/core": "^0.5.4",
     "esbuild": "0.27.2"
   },
   "devDependencies": {

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.4.11",
+  "version": "0.4.12",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -71,7 +71,7 @@ import { createLicenseMiddleware } from './middleware/license.js'
 import { createQuotaMiddleware } from './middleware/quota.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.4.11'
+const PACKAGE_VERSION = '0.4.12'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Skillsmith VS Code extension will be documented in th
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## v0.2.2
+
+- Version bump
+
 ## [Unreleased]
 
 ## [0.2.1] - 2026-04-17

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Discover and install agent skills directly in VS Code",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
[skip-impl-check]
[skip-doc-drift]

## Summary

Routine release cut triggered by CHANGELOG `[Unreleased]` ≥ 15 entries (ADR-114 threshold). Patch bumps across all four published packages.

| Package | Bump | New |
|---|---|---|
| `@skillsmith/core` | patch | 0.5.4 |
| `@skillsmith/mcp-server` | patch | 0.4.12 |
| `@skillsmith/cli` | patch | 0.5.7 |
| `skillsmith-vscode` | patch | 0.2.2 |

Core gets 3 new entries: SMI-4308 webhook-dlq rename, SMI-4307 team provisioning, SMI-4297 UndoSnapshot fix. mcp-server + cli each get 1 entry. vscode is version-bump-only.

npm collision guard passed. `docs/internal` submodule bumped to `fd791147` (companion index.md count resync merged in docs PR #50).

## Expected CI failures (pre-publish)

- **Package Validation** fails because mcp-server/cli declare `@skillsmith/core@^0.5.4` but 0.5.4 isn't published yet — classic release-PR chicken-and-egg. Will pass after `publish.yml` runs post-merge. Admin-merge overrides.

## Test plan

- [x] `prepare-release.ts --dry-run --all=patch` passed
- [x] `prepare-release.ts --all=patch` applied; all 6 version locations updated (package.json × 4, VERSION constants × 2, server.json)
- [x] npm collision guard passed per-package
- [ ] Post-merge: publish via `gh workflow run publish.yml -f dry_run=false` (or local fallback per CLAUDE.md publishing-guide if SMI-4244 Validate still broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)