### PR TITLE
fix(ci): SMI-4244 vitest SIGTERM fix + SMI-4364 delete canary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -396,20 +396,6 @@ jobs:
           FILTERS: --filter=${{ join(fromJSON(env.PUBLISHABLE_PACKAGES_JSON), ' --filter=') }}
         run: npx turbo build $FILTERS
 
-      # SMI-4188: non-gating website build canary.
-      # Keeps the @astrojs/vercel root-cause follow-up visible as a yellow
-      # warning on every publish run. If this persists week over week, the
-      # linked Linear issue is visibly overdue.
-      - name: Website build canary (non-gating)
-        if: steps.download-docker.outcome == 'success'
-        continue-on-error: true # audit:allow-continue-on-error — visibility canary, not a gate
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}:/app \
-            -w /app \
-            skillsmith-publish:${{ github.sha }} \
-            sh -c "npx turbo build --filter=@skillsmith/website || true"
-
       - name: Run tests (Docker)
         if: steps.download-docker.outcome == 'success'
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -403,11 +403,11 @@ jobs:
             -v ${{ github.workspace }}:/app \
             -w /app \
             skillsmith-publish:${{ github.sha }} \
-            npm test
+            npm test -- --reporter=verbose
 
       - name: Run tests (fallback)
         if: steps.download-docker.outcome == 'failure'
-        run: npm test
+        run: npm test -- --reporter=verbose
 
       - name: Type check (Docker)
         if: steps.download-docker.outcome == 'success'

--- a/packages/core/src/api/client.events.ts
+++ b/packages/core/src/api/client.events.ts
@@ -78,7 +78,16 @@ export function createBatchFlushFn(
  * config changes (e.g. API key rotation) are honored.
  */
 export function buildClientEventBatcher(ctx: () => BatchPostContext): EventBatcher {
-  return createEventBatcher(createBatchFlushFn(ctx))
+  // SMI-4244: suppress process-exit handlers during vitest runs. Each EventBatcher
+  // attaches 3 listeners (beforeExit, SIGINT, SIGTERM). With ~24 test files
+  // instantiating SkillsmithApiClient, we blow Node's default 10-listener
+  // ceiling and emit MaxListenersExceededWarning, which racily coincides with
+  // SIGTERM under CI runner orchestration. VITEST is injected directly by the
+  // vitest runner and is authoritative — NODE_ENV=test leaks from docker-compose.
+  const isTest = process.env.VITEST === 'true'
+  return createEventBatcher(createBatchFlushFn(ctx), {
+    registerExitHandlers: !isTest,
+  })
 }
 
 /**

--- a/packages/core/tests/api/client.events.test.ts
+++ b/packages/core/tests/api/client.events.test.ts
@@ -1,0 +1,105 @@
+/**
+ * SMI-4244: buildClientEventBatcher test-environment detection
+ *
+ * Verifies that EventBatcher instances created via buildClientEventBatcher
+ * do NOT attach process-exit listeners when running under vitest (detected
+ * via process.env.VITEST === 'true'). This prevents MaxListenersExceededWarning
+ * and the racy SIGTERM delivery observed in publish.yml Validate job test runs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { buildClientEventBatcher, type BatchPostContext } from '../../src/api/client.events.js'
+
+describe('SMI-4244: buildClientEventBatcher exit handler suppression', () => {
+  const originalVitest = process.env.VITEST
+
+  const ctx = (): BatchPostContext => ({
+    baseUrl: 'https://example.test',
+    anonKey: 'anon',
+    apiKey: undefined,
+    timeout: 1_000,
+  })
+
+  beforeEach(() => {
+    // Snapshot restored by afterEach; each test sets VITEST explicitly.
+  })
+
+  afterEach(() => {
+    if (originalVitest === undefined) {
+      delete process.env.VITEST
+    } else {
+      process.env.VITEST = originalVitest
+    }
+  })
+
+  it('does NOT attach SIGTERM/SIGINT/beforeExit listeners when VITEST=true', () => {
+    process.env.VITEST = 'true'
+
+    const before = {
+      sigterm: process.listenerCount('SIGTERM'),
+      sigint: process.listenerCount('SIGINT'),
+      beforeExit: process.listenerCount('beforeExit'),
+    }
+
+    const batcher = buildClientEventBatcher(ctx)
+
+    const after = {
+      sigterm: process.listenerCount('SIGTERM'),
+      sigint: process.listenerCount('SIGINT'),
+      beforeExit: process.listenerCount('beforeExit'),
+    }
+
+    expect(after.sigterm).toBe(before.sigterm)
+    expect(after.sigint).toBe(before.sigint)
+    expect(after.beforeExit).toBe(before.beforeExit)
+
+    // Dispose is a no-op when no handlers were attached, but call it for hygiene.
+    batcher.dispose()
+  })
+
+  it('DOES attach SIGTERM/SIGINT/beforeExit listeners when VITEST is unset', () => {
+    delete process.env.VITEST
+
+    const before = {
+      sigterm: process.listenerCount('SIGTERM'),
+      sigint: process.listenerCount('SIGINT'),
+      beforeExit: process.listenerCount('beforeExit'),
+    }
+
+    const batcher = buildClientEventBatcher(ctx)
+
+    const after = {
+      sigterm: process.listenerCount('SIGTERM'),
+      sigint: process.listenerCount('SIGINT'),
+      beforeExit: process.listenerCount('beforeExit'),
+    }
+
+    expect(after.sigterm).toBe(before.sigterm + 1)
+    expect(after.sigint).toBe(before.sigint + 1)
+    expect(after.beforeExit).toBe(before.beforeExit + 1)
+
+    // Clean up so we don't pollute other tests' listener counts.
+    batcher.dispose()
+
+    const cleaned = {
+      sigterm: process.listenerCount('SIGTERM'),
+      sigint: process.listenerCount('SIGINT'),
+      beforeExit: process.listenerCount('beforeExit'),
+    }
+    expect(cleaned.sigterm).toBe(before.sigterm)
+    expect(cleaned.sigint).toBe(before.sigint)
+    expect(cleaned.beforeExit).toBe(before.beforeExit)
+  })
+
+  it('DOES attach listeners when VITEST is set to a non-"true" value', () => {
+    process.env.VITEST = '1'
+
+    const before = process.listenerCount('SIGTERM')
+    const batcher = buildClientEventBatcher(ctx)
+    const after = process.listenerCount('SIGTERM')
+
+    expect(after).toBe(before + 1)
+
+    batcher.dispose()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { sharedTestConfig, coverageDefaults, coverageThresholds } from './vitest
 export default defineConfig({
   test: {
     ...sharedTestConfig,
+    setupFiles: ['./vitest.setup.ts'],
     include: [
       'packages/*/src/**/*.test.ts',
       'packages/*/src/**/*.spec.ts',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,5 @@
+// SMI-4244: lift the default 10-listener ceiling to absorb future modules
+// that attach additional process-exit handlers (mcp-server context.ts,
+// webhook endpoints). Primary fix is in client.events.ts; this is a
+// defense-in-depth ceiling guard, not a root-cause fix.
+process.setMaxListeners(20)


### PR DESCRIPTION
## Summary

Two infra fixes + one partial-fix for CI publish path post-SMI-4361.

| Commit | Issue | Change | Status |
|---|---|---|---|
| `d4efe917` | [SMI-4364](https://linear.app/smith-horn-group/issue/SMI-4364) | Delete `publish.yml > Website build canary (non-gating)` | ✅ Complete |
| `45862e71` | [SMI-4244](https://linear.app/smith-horn-group/issue/SMI-4244) | Suppress `EventBatcher` exit handlers in vitest + `setMaxListeners(20)` + `--reporter=verbose` diagnostic | ⚠️ **Partial** — see below |
| `e0253be7` | docs | Submodule bump for both plans | — |

## SMI-4244 partial-fix status (IMPORTANT — read before merge)

**What was fixed**: `MaxListenersExceededWarning: 11 SIGTERM listeners added to [process]` is **gone**. Verified on dry-run [24648765421](https://github.com/smith-horn/skillsmith/actions/runs/24648765421) — 6,051 log lines, zero warning matches. Primary plan hypothesis was correct: `EventBatcher` attaching 3 listeners per client × 24 test files was triggering the warning.

**What's NOT fixed**: a residual SIGTERM still arrives at ~29s (was ~27s pre-fix). Tests stream 4,901 passes across 137 test files in that window, then SIGTERM. No OOM markers, no vitest timeout markers, no `process.kill` in test code, no visible crash. The MaxListeners warning was likely a **correlated symptom, not the sole cause**. The actual SIGTERM origin needs in-CI instrumentation (e.g. `strace`, `dmesg`, `docker stats`) to identify — static log analysis has been exhausted.

**Why merging is still correct**:
- The listener-leak fix is independently valuable (no warning noise; cleaner test hygiene; `SkillsmithApiClient` lifecycle is now honest about test-vs-production behavior).
- The `setMaxListeners(20)` belt-and-suspenders is a defensible ceiling guard against future regressions.
- The `--reporter=verbose` diagnostic will surface the next investigator's trace data.
- SMI-4364's canary deletion is independently correct.
- **Not merging leaves the listener warning and the canary drift in main unnecessarily.** Local publish fallback continues to work.

**Follow-up**: SMI-4244 will stay Open with an updated comment documenting the partial fix + findings. A new investigation issue (SMI-4365) will track the residual SIGTERM cause with concrete next-experiment proposals (add `docker stats` to the step; run tests with `--pool=forks --poolOptions.forks.singleFork=true` to isolate; add `strace -p $NPM_PID` instrumentation).

## Verification

- Dry-run [24648765421](https://github.com/smith-horn/skillsmith/actions/runs/24648765421): Build + Website canary deletion + extract all ✅. `Run tests (Docker)` ❌ (residual SIGTERM).
- Local (skillsmith-dev-1): full suite 8,056 pass / 8 skip / 7 todo in 15.88s, exit 0, **no MaxListeners warning**.
- New test `packages/core/tests/api/client.events.test.ts`: 3/3 pass — validates VITEST=true opt-out, VITEST unset keeps handlers, VITEST='1' (non-'true') is rejected.

## Test plan

- [x] Local vitest: no MaxListeners warning, full suite green
- [x] New client.events test: 3/3 pass
- [x] YAML parses clean; canary step absent from Validate job step list
- [x] Dry-run confirms Build step green (SMI-4361 fix still working)
- [ ] SMI-4244 follow-up (SMI-4365) filed for residual SIGTERM

[skip-impl-check]

🤖 Generated with [Claude Code](https://claude.com/claude-code)