### PR TITLE
fix(ci): SMI-4372 deploy workflow _shared/ detection short-circuit

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -92,29 +92,12 @@ jobs:
             echo "functions=$INPUT_FUNCTION_NAME" >> "$GITHUB_OUTPUT"
             echo "Deploying specific function: $INPUT_FUNCTION_NAME"
           else
-            # Detect changed functions from the merge commit
-            # Uses sed instead of grep -oP for portability (no PCRE dependency)
-            CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'supabase/functions/' \
-              | sed -n 's|supabase/functions/\([^/]*\)/.*|\1|p' \
-              | grep -v '^_shared$' \
-              | sort -u \
-              | paste -sd ',' -)
-            if [ -z "$CHANGED" ]; then
-              echo "No function changes detected (may be _shared only)"
-              # If _shared changed, deploy all — shared code affects every function
-              if git diff --name-only HEAD~1 HEAD -- 'supabase/functions/_shared/' | grep -q .; then
-                echo "mode=all" >> "$GITHUB_OUTPUT"
-                echo "functions=" >> "$GITHUB_OUTPUT"
-                echo "_shared/ changed — deploying ALL functions"
-              else
-                echo "mode=none" >> "$GITHUB_OUTPUT"
-                echo "functions=" >> "$GITHUB_OUTPUT"
-              fi
-            else
-              echo "mode=changed" >> "$GITHUB_OUTPUT"
-              echo "functions=$CHANGED" >> "$GITHUB_OUTPUT"
-              echo "Changed functions: $CHANGED"
-            fi
+            # push-triggered auto-deploy: delegate to the classifier script so
+            # the detection logic is unit-testable (scripts/tests/deploy-detection.test.sh).
+            # Priority: _shared/ → all, specific fns → changed, else → none.
+            # The _shared/ branch MUST fire first so mixed-scope PRs fan out to every
+            # caller — a specific fn plus _shared/ is not a partial deploy.
+            ./scripts/classify-deploy-mode.sh >> "$GITHUB_OUTPUT"
           fi
 
       - name: Deploy

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,0 +1,36 @@
+# SMI-4372: validate deploy-edge-functions classifier + test harness before merge.
+# Keeps detection logic honest — a shell regression in classify-deploy-mode.sh
+# can silently ship partial deploys (the original SMI-4372 bug).
+name: Validate Deploy Workflow
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/deploy-edge-functions.yml'
+      - '.github/workflows/validate-workflows.yml'
+      - 'scripts/classify-deploy-mode.sh'
+      - 'scripts/tests/deploy-detection.test.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  detection-test:
+    name: Detection Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: shellcheck
+        run: |
+          shellcheck scripts/classify-deploy-mode.sh scripts/tests/deploy-detection.test.sh
+
+      - name: Syntax check (bash -n)
+        run: |
+          bash -n scripts/classify-deploy-mode.sh
+          bash -n scripts/tests/deploy-detection.test.sh
+
+      - name: Detection unit tests
+        run: |
+          bash scripts/tests/deploy-detection.test.sh

--- a/scripts/classify-deploy-mode.sh
+++ b/scripts/classify-deploy-mode.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Classifies edge-function deploy scope by diffing HEAD~1..HEAD.
+# Prints two lines to stdout (consumed by deploy-edge-functions.yml via
+# `./scripts/classify-deploy-mode.sh >> "$GITHUB_OUTPUT"`):
+#   mode=<all|changed|none>
+#   functions=<comma-separated|empty>
+#
+# Priority order (MUST be preserved — prior layout silently partial-deployed
+# mixed-scope PRs because _shared/ was a fallback, not a first-class branch):
+#   1. _shared/ changed → mode=all  (fan out: shared code affects every caller)
+#   2. specific fns     → mode=changed
+#   3. nothing          → mode=none
+set -euo pipefail
+
+# Guard against non-squash merges. Branch protection enforces squash today,
+# but drift is silent: a true merge commit has multiple parents, HEAD~1 picks
+# one arbitrarily, and cross-lineage file changes fall off the detection radar.
+parent_count=$(git log --pretty=%P -1 HEAD | wc -w | tr -d '[:space:]')
+if [ "$parent_count" -gt 1 ]; then
+  echo "::warning::Non-squash merge detected at HEAD ($parent_count parents); detection may be incomplete" >&2
+fi
+
+# Priority 1: _shared/ → full fanout
+if git diff --name-only HEAD~1 HEAD -- 'supabase/functions/_shared/' | grep -q .; then
+  echo "mode=all"
+  echo "functions="
+  echo "_shared/ changed — deploying ALL functions" >&2
+  exit 0
+fi
+
+# Priority 2: specific fns changed. Priority 1 already ruled out _shared/, so
+# the sed pipeline cannot emit '_shared' — no grep -v filter needed.
+CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'supabase/functions/' \
+  | sed -n 's|supabase/functions/\([^/]*\)/.*|\1|p' \
+  | sort -u \
+  | paste -sd ',' -)
+if [ -n "$CHANGED" ]; then
+  echo "mode=changed"
+  echo "functions=$CHANGED"
+  echo "Changed functions: $CHANGED" >&2
+  exit 0
+fi
+
+# Priority 3: nothing to deploy
+echo "mode=none"
+echo "functions="
+echo "No function changes detected" >&2

--- a/scripts/tests/deploy-detection.test.sh
+++ b/scripts/tests/deploy-detection.test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/classify-deploy-mode.sh.
+#
+# Stubs `git diff --name-only HEAD~1 HEAD` output via a wrapper shim on $PATH,
+# invokes the classifier, and asserts stdout matches expected mode/functions.
+# Covers all three priority branches + edge cases (mixed-scope, multi-fn,
+# non-fn changes).
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+CLASSIFIER="$SCRIPT_DIR/classify-deploy-mode.sh"
+
+if [ ! -x "$CLASSIFIER" ]; then
+  echo "FAIL: $CLASSIFIER not found or not executable"
+  exit 1
+fi
+
+fail=0
+run_case() {
+  local name="$1" diff_output="$2" expected_mode="$3" expected_functions="$4"
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  # Persist the full stubbed diff to a file so the shim can re-read + filter it.
+  printf '%s' "$diff_output" > "$tmpdir/all_changed"
+  if [ -n "$diff_output" ]; then printf '\n' >> "$tmpdir/all_changed"; fi
+
+  # Shim: `git diff --name-only HEAD~1 HEAD -- <pathspec>` filters the stubbed
+  # file list by the pathspec (real git behavior). `git log ...` returns a
+  # single parent so the non-squash-merge warning stays quiet. Any other git
+  # subcommand falls through to the real binary.
+  cat > "$tmpdir/git" <<'SHIM'
+#!/usr/bin/env bash
+case "$1" in
+  diff)
+    # args: diff --name-only HEAD~1 HEAD -- <pathspec>
+    # Extract the pathspec (last arg). We emit lines from the stubbed file
+    # that start with the pathspec — mirrors how `git diff -- <pathspec>`
+    # restricts output to that path.
+    pathspec=""
+    for arg in "$@"; do pathspec="$arg"; done
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      case "$line" in
+        "$pathspec"*) echo "$line" ;;
+      esac
+    done < "$(dirname "$0")/all_changed"
+    ;;
+  log)
+    echo 'abc123'
+    ;;
+  *)
+    exec /usr/bin/env -i PATH=/usr/bin:/bin git "$@"
+    ;;
+esac
+SHIM
+  chmod +x "$tmpdir/git"
+
+  local actual actual_mode actual_fns
+  actual=$(PATH="$tmpdir:$PATH" bash "$CLASSIFIER" 2>/dev/null || true)
+  actual_mode=$(echo "$actual" | awk -F= '/^mode=/ {print $2}')
+  actual_fns=$(echo "$actual" | awk -F= '/^functions=/ {print $2}')
+
+  if [ "$actual_mode" = "$expected_mode" ] && [ "$actual_fns" = "$expected_functions" ]; then
+    echo "PASS $name"
+  else
+    echo "FAIL $name: got mode='$actual_mode' functions='$actual_fns' expected mode='$expected_mode' functions='$expected_functions'"
+    fail=1
+  fi
+  rm -rf "$tmpdir"
+}
+
+# Case 1: _shared/ only → mode=all
+run_case "shared_only" \
+  "supabase/functions/_shared/cors.ts" \
+  "all" ""
+
+# Case 2: specific fn only → mode=changed
+run_case "specific_only" \
+  "supabase/functions/events/index.ts" \
+  "changed" "events"
+
+# Case 3: THE SMI-4372 CASE — mixed _shared/ + specific fn → mode=all
+run_case "mixed_scope" \
+  "supabase/functions/_shared/cors.ts
+supabase/functions/events/index.ts" \
+  "all" ""
+
+# Case 4: two specific fns, no _shared/ → mode=changed with both (alphabetized)
+run_case "multi_specific" \
+  "supabase/functions/events/index.ts
+supabase/functions/stats/index.ts" \
+  "changed" "events,stats"
+
+# Case 5: nothing relevant → mode=none
+run_case "none" "" "none" ""
+
+# Case 6: migration changed but no fn code → mode=none
+run_case "migration_only" \
+  "supabase/migrations/077_foo.sql" \
+  "none" ""
+
+# Case 7: _shared/ subdir file (deeper than first-level) → mode=all
+run_case "shared_subdir" \
+  "supabase/functions/_shared/auth/jwt.ts" \
+  "all" ""
+
+if [ "$fail" -eq 1 ]; then
+  echo ""
+  echo "FAILURES above"
+  exit 1
+fi
+
+echo ""
+echo "all 7 cases passed"


### PR DESCRIPTION
## Summary

- Bug: `deploy-edge-functions.yml` nested the `_shared/` full-deploy branch inside `[ -z "$CHANGED" ]`, so mixed-scope PRs (`_shared/` + specific fn) silently partial-deployed. SMI-4366 Wave 4b+4c landed 2026-04-20 bundling a `_shared/license.ts` rate-limit change with `events/index.ts` attribution — only `events` auto-deployed, 24 other functions ran stale shared code until manual `deploy_all=true` recovery ~7 min later.
- Fix: extract detection to `scripts/classify-deploy-mode.sh` with a flat priority — `_shared/` → `all`, specific → `changed`, else `none`. Workflow becomes a thin invocation.
- Safety: `scripts/tests/deploy-detection.test.sh` harness covers 7 cases including the SMI-4372 mixed-scope regression. CI gate `validate-workflows.yml` runs shellcheck + `bash -n` + unit tests on every PR touching the classifier or workflow.

## Plan-review findings (all resolved in-scope)

| # | Severity | Resolution |
|---|----------|------------|
| B1 | BLOCKING | Test harness lands in this PR, not deferred |
| H1 | HIGH | Non-squash-merge guard (`::warning::` if `HEAD` has >1 parent) |
| H2 | HIGH | Dead `grep -v '^_shared$'` filter removed (unreachable once `_shared/` check fires first) |
| H3 | HIGH | `cancel-in-progress=false` tolerance documented in plan risk register; SMI-4373 follow-up filed for queue-depth alert |
| M1 | MEDIUM | Dropped inline SMI refs from YAML; kept plain-English rationale |
| M2 | MEDIUM | Synthetic post-merge verification PR promoted to required step |

## Plan

`docs/internal/implementation/smi-4372-deploy-workflow-shared-detection.md` — https://github.com/smith-horn/skillsmith-docs/pull/60 (companion)

## Related

- SMI-4366 umbrella (exposed this bug)
- SMI-4371 (orthogonal Verify-step false-red — NOT addressed here)
- SMI-4256 (originating workflow ticket)
- SMI-4373 (filed — queue-depth alert follow-up)

## Test plan

- [ ] `validate-workflows.yml` green on this PR (shellcheck + bash -n + 7 unit tests)
- [ ] Preflight remains green — no app-code changes
- [ ] **POST-MERGE REQUIRED**: synthetic mixed-scope PR (whitespace edit to `supabase/functions/_shared/cors.ts` + whitespace edit to `supabase/functions/events/index.ts`) merges with `mode=all` in log and `Deployed: 25 | Failed: 0`
- [ ] Revert the synthetic PR after verification so project history stays clean
- [ ] SMI-4372 Linear issue updated with merge SHA
- [ ] MEMORY.md + CLAUDE.md workaround warning removed once prod-verified

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)