### PR TITLE
fix(ci): SMI-4372 governance-retro follow-ups (M1, M2, m1, m2)

### DIFF
--- a/scripts/classify-deploy-mode.sh
+++ b/scripts/classify-deploy-mode.sh
@@ -33,7 +33,7 @@ fi
 CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'supabase/functions/' \
   | sed -n 's|supabase/functions/\([^/]*\)/.*|\1|p' \
   | sort -u \
-  | paste -sd ',' -)
+  | paste -s -d ',' -)
 if [ -n "$CHANGED" ]; then
   echo "mode=changed"
   echo "functions=$CHANGED"

--- a/scripts/tests/deploy-detection.test.sh
+++ b/scripts/tests/deploy-detection.test.sh
@@ -50,7 +50,7 @@ case "$1" in
     echo 'abc123'
     ;;
   *)
-    exec /usr/bin/env -i PATH=/usr/bin:/bin git "$@"
+    exec /usr/bin/env git "$@"
     ;;
 esac
 SHIM
@@ -105,6 +105,22 @@ run_case "shared_subdir" \
   "supabase/functions/_shared/auth/jwt.ts" \
   "all" ""
 
+# Case 8: function rename (git diff --name-only --no-renames emits both old + new
+# paths — we want the new fn name in output). Simulates `git mv` of a fn dir.
+run_case "function_rename" \
+  "supabase/functions/old-name/index.ts
+supabase/functions/new-name/index.ts" \
+  "changed" "new-name,old-name"
+
+# Case 9: function deletion. `git diff --name-only` lists deleted files — the
+# sed pipeline will emit the deleted fn name. Deploy step will then fail
+# loudly at the Supabase CLI rather than silently shipping partial state.
+# This is expected behavior — covered here so we'd notice if classifier
+# started swallowing deletes.
+run_case "function_deletion" \
+  "supabase/functions/deprecated-fn/index.ts" \
+  "changed" "deprecated-fn"
+
 if [ "$fail" -eq 1 ]; then
   echo ""
   echo "FAILURES above"
@@ -112,4 +128,4 @@ if [ "$fail" -eq 1 ]; then
 fi
 
 echo ""
-echo "all 7 cases passed"
+echo "all 9 cases passed"


### PR DESCRIPTION
## Summary

Follow-up to SMI-4372 (PR #691 `e1185027`) addressing governance-retrospective findings. Zero-deferral: all MEDIUM + MINOR findings fixed in this PR.

`[skip-impl-check]` — this is a shell-script quality fixup + test case additions; no new product feature to verify.

## Findings addressed

| # | Severity | Fix |
|---|----------|-----|
| M1 | MEDIUM | `scripts/tests/deploy-detection.test.sh` shim: drop `env -i PATH=...` fallback (was wiping HOME / .gitconfig; latent fragility for future cases that exercise fallback) |
| M2 | MEDIUM | `scripts/classify-deploy-mode.sh`: `paste -sd ',' -` → `paste -s -d ',' -` (explicit form is safer cross-platform; original comment called out portability as design concern) |
| m1 | MINOR | Add rename test case (function dir renamed via `git mv` — classifier emits both old + new names correctly) |
| m2 | MINOR | Add delete test case (function dir deletion — classifier emits deleted fn name, deploy step fails loudly at Supabase CLI; documents expected behavior) |

Test count: 7 → 9 cases. All pass. Shellcheck clean.

## Deferred to separate SPARC

**H1 (HIGH — `validate-workflows.yml` path-gating prevents use as a required-branch-protection check)** filed as SMI-4375 for ADR-109 SPARC treatment. Requires a structural SMI-3999-pattern refactor of the workflow (unconditional `on: pull_request` + `detect-changes` job + job-level `needs + if`).

## Test plan

- [x] `bash scripts/tests/deploy-detection.test.sh` → 9/9 pass
- [x] `shellcheck scripts/classify-deploy-mode.sh scripts/tests/deploy-detection.test.sh` → clean
- [ ] `Validate Deploy Workflow` CI gate green on PR

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)