### PR TITLE
docs(research): SMI-4380 coverage-gap investigation — Tier 0 path + HT trust-tier findings

### DIFF
--- a/scripts/probe-topics.sh
+++ b/scripts/probe-topics.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SMI-4380 — Count GitHub repos per candidate topic.
+# Uses /search/repositories (30 req/min budget, separate from code-search).
+# Sleep 3s between calls to stay well under that ceiling.
+#
+# Usage: ./scripts/probe-topics.sh [output.tsv]
+
+set -uo pipefail
+
+OUT="${1:-docs/internal/research/topic-counts.tsv}"
+mkdir -p "$(dirname "$OUT")"
+
+TOPICS=(
+  # Claude/Anthropic ecosystem (baseline — already in DEFAULT_TOPICS)
+  claude-code-skill claude-code anthropic-claude claude-skill claude-skills
+  claude-code-plugin claude-plugin
+  # Gemini ecosystem (already in DEFAULT_TOPICS)
+  gemini-skill gemini-cli-skill ai-coding-skill
+  # OpenAI / Codex candidates
+  openai codex chatgpt gpt gpt-4 gpt-4o openai-agents openai-api openai-sdk
+  openai-skill codex-skill gpt-skill
+  # Cursor / IDE candidates
+  cursor cursor-rules cursorrules cursor-mdc cursor-skill cursor-plugin
+  windsurf windsurf-skill
+  cody cody-ai
+  continue continue-dev continue-plugin
+  aider aider-ai
+  zed zed-industries
+  # GitHub Copilot
+  copilot github-copilot copilot-instructions copilot-skill
+  # MCP ecosystem
+  mcp mcp-server model-context-protocol mcp-client mcp-tools
+  # Agent framework names used as topics
+  agent ai-agent autonomous-agent llm-agent agentic-ai agentic
+  langchain llamaindex autogen crewai pydantic-ai mastra dspy autogpt
+  # Local inference
+  ollama llamacpp llama-cpp vllm lmstudio
+  # Other AI model providers
+  perplexity pi pi-ai inflection-ai
+  mistral-ai cohere-ai
+  # Generic skill / plugin terms
+  skill skills plugin plugins
+  ai-skill developer-skill
+  agent-skill mcp-skill
+)
+
+HEADER=$(printf 'topic\tcount\n')
+
+if [[ ! -f "$OUT" ]]; then
+  printf '%s' "$HEADER" > "$OUT"
+fi
+
+probed=$(cut -f1 "$OUT" | tail -n +2)
+
+echo "Probing ${#TOPICS[@]} topics → $OUT"
+echo ""
+
+count=0
+for topic in "${TOPICS[@]}"; do
+  count=$((count + 1))
+  if echo "$probed" | grep -qx "$topic"; then
+    echo "[$count/${#TOPICS[@]}] $topic (already probed, skipping)"
+    continue
+  fi
+  echo "[$count/${#TOPICS[@]}] probing topic:$topic"
+  total=$(gh api -X GET search/repositories -f "q=topic:$topic" -f per_page=1 --jq '.total_count' 2>/dev/null) || total=-1
+  printf '%s\t%s\n' "$topic" "$total" >> "$OUT"
+  sleep 3
+done
+
+echo ""
+echo "Done. Results in $OUT"

--- a/scripts/probe-vendor-orgs.sh
+++ b/scripts/probe-vendor-orgs.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SMI-4380 — Probe vendor GitHub orgs for SKILL-shaped content.
+# Serialized (sleep 7s between code-search calls) to respect the 10 req/min
+# code-search rate limit. Writes incrementally to the output file after each
+# org so a mid-run interruption does not lose progress.
+#
+# Usage: ./scripts/probe-vendor-orgs.sh [output.tsv]
+
+set -uo pipefail
+
+OUT="${1:-docs/internal/research/vendor-org-probes.tsv}"
+RESEARCH_DIR="$(dirname "$OUT")"
+mkdir -p "$RESEARCH_DIR"
+
+# Orgs grouped by category. Order: highest-likelihood first so early truncation
+# still yields useful data.
+ORGS=(
+  # LLM / Foundation models
+  openai anthropics google-gemini google-deepmind huggingface cohereai mistralai
+  ai21labs togethercomputer perplexityai xai-org inflection-ai
+  # AI coding tools / IDEs
+  cursor-ai getcursor sourcegraph continuedev zed-industries replit
+  # Agent frameworks
+  langchain-ai run-llama microsoft joaomdmoura crewaiinc pydantic mastra-ai
+  stanfordnlp Significant-Gravitas
+  # MCP ecosystem
+  modelcontextprotocol
+  # Local inference
+  ollama lmstudio-ai ggerganov vllm-project
+  # Cloud / Infra CLIs
+  aws awslabs Azure GoogleCloudPlatform vercel vercel-labs netlify
+  cloudflare hashicorp digitalocean render-examples railwayapp
+  # Dev platforms / SCM
+  github gitlab-org atlassian slackhq discord linear notionhq figma
+  # Data / DB
+  mongodb postgres redis elastic cockroachdb planetscale supabase
+  neondatabase prisma drizzle-team
+  # APIs / SaaS SDKs
+  stripe twilio resend sendgrid plaid Shopify square intercom getsentry
+  DataDog newrelic honeycombio PostHog segmentio mixpanel amplitude launchdarkly
+  # Runtimes / Package managers
+  nodejs denoland oven-sh npm pnpm yarnpkg docker kubernetes helm astral-sh
+  # Mobile
+  facebook expo flutter ionic-team NativeScript
+)
+
+HEADER="org\tskill_md\tagents_md\tcursorrules\tmdc\tcopilot_instructions\tskills_dir\tclaude_skills\tnote"
+
+# Start fresh if no file exists; otherwise resume (skip orgs already probed).
+if [[ ! -f "$OUT" ]]; then
+  printf '%s\n' "$HEADER" > "$OUT"
+fi
+
+probed=$(cut -f1 "$OUT" | tail -n +2)
+
+probe_one() {
+  local org="$1"
+  local q_skill="filename:SKILL.md user:$org"
+  local q_agents="filename:AGENTS.md user:$org"
+  local q_cursorrules="filename:.cursorrules user:$org"
+  local q_mdc="extension:mdc user:$org"
+  local q_copilot="path:.github/copilot-instructions.md user:$org"
+  local q_skills_dir="path:skills user:$org filename:SKILL.md"
+  local q_claude_skills="path:.claude/skills user:$org"
+
+  local skill_md agents_md cursorrules mdc copilot skills_dir claude_skills note
+  note=""
+
+  # Each call consumes one code-search token. Sleep 7s between calls = safely
+  # under 10/min even if GitHub's rate window is tight.
+  skill_md=$(gh api -X GET search/code -f "q=$q_skill" -f per_page=1 --jq '.total_count' 2>&1) || { note="err_skill:${skill_md:0:40}"; skill_md=-1; }
+  sleep 7
+  agents_md=$(gh api -X GET search/code -f "q=$q_agents" -f per_page=1 --jq '.total_count' 2>&1) || { note="${note} err_agents"; agents_md=-1; }
+  sleep 7
+  cursorrules=$(gh api -X GET search/code -f "q=$q_cursorrules" -f per_page=1 --jq '.total_count' 2>&1) || { note="${note} err_cursorrules"; cursorrules=-1; }
+  sleep 7
+  mdc=$(gh api -X GET search/code -f "q=$q_mdc" -f per_page=1 --jq '.total_count' 2>&1) || { note="${note} err_mdc"; mdc=-1; }
+  sleep 7
+  copilot=$(gh api -X GET search/code -f "q=$q_copilot" -f per_page=1 --jq '.total_count' 2>&1) || { note="${note} err_copilot"; copilot=-1; }
+  sleep 7
+  skills_dir=$(gh api -X GET search/code -f "q=$q_skills_dir" -f per_page=1 --jq '.total_count' 2>&1) || { note="${note} err_skills_dir"; skills_dir=-1; }
+  sleep 7
+  claude_skills=$(gh api -X GET search/code -f "q=$q_claude_skills" -f per_page=1 --jq '.total_count' 2>&1) || { note="${note} err_claude_skills"; claude_skills=-1; }
+  sleep 7
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$org" "$skill_md" "$agents_md" "$cursorrules" "$mdc" "$copilot" "$skills_dir" "$claude_skills" "$note" \
+    >> "$OUT"
+}
+
+echo "Probing ${#ORGS[@]} vendor orgs → $OUT"
+echo "Rate: 7 probes/org × 7s sleep = ~49s/org; total ~$(( ${#ORGS[@]} * 49 / 60 )) min"
+echo ""
+
+count=0
+for org in "${ORGS[@]}"; do
+  count=$((count + 1))
+  if echo "$probed" | grep -qx "$org"; then
+    echo "[$count/${#ORGS[@]}] $org (already probed, skipping)"
+    continue
+  fi
+  echo "[$count/${#ORGS[@]}] probing $org..."
+  probe_one "$org"
+done
+
+echo ""
+echo "Done. Results in $OUT"


### PR DESCRIPTION
## Summary

Investigation under SMI-4118 (Edge Function invocation optimization umbrella) identifies four indexer coverage gaps — the headline finding is that ~62k SKILL.md files exist on GitHub in paths our subdirectory-search fallback doesn't probe.

- Research docs: `docs/internal/research/vendor-org-coverage-2026-04-20.md`, `topic-coverage-investigation-2026-04-20.md` (in submodule commit cd3b770)
- Raw data: `vendor-org-probes.tsv` (18/94 orgs), `topic-counts.tsv` (81 topics)
- Probe scripts: `scripts/probe-vendor-orgs.sh`, `scripts/probe-topics.sh` (re-runnable for 90-day refresh)

## Key findings

1. **Tier 0 path gap (~62k SKILL.md files unreachable)** — subdirectory-search.ts fallback probes `.gemini/skills/`, `.github/skills/`, `skills/` but not `.agents/skills/` (49,792 files), `.codex/skills/` (6,400), `.cursor/skills/` (4,576), `.ai/skills/` (1,052). Prod `skills` table shows exactly 0 skills indexed from these paths. Filed as **[SMI-4385](https://linear.app/smith-horn-group/issue/SMI-4385) (High)**.
2. **Trust-tier bug** — microsoft (175 skills) and Anthropic (60 skills) showing `community` tier despite `HIGH_TRUST_AUTHORS.ts` entries. Only 335 of 15,134 skills are `verified` (2.21%). Filed as **[SMI-4386](https://linear.app/smith-horn-group/issue/SMI-4386) (High)**.
3. **Telemetry gaps** — `skills.skill_path` is NULL for 98% of rows; `audit_logs.metadata` has no `discovery_path` key. Blocks SMI-4385 verification. Filed as **[SMI-4387](https://linear.app/smith-horn-group/issue/SMI-4387) (Medium)**.
4. **DEFAULT_TOPICS cleanup** — 3 of 10 current topics have 0–1 repos on GitHub (`gemini-skill`, `gemini-cli-skill`, `ai-coding-skill`). Filed as **[SMI-4388](https://linear.app/smith-horn-group/issue/SMI-4388) (Low)**.

## Recommendation precedence

1. Ship SMI-4385 (Tier 0 path expansion) — captures most openai/codex skills automatically; no HT entry needed for openai.
2. Ship SMI-4386 before any HT expansion — otherwise HT adds don't elevate trust_tier.
3. Ship SMI-4387 — unlocks yield verification.
4. File Tier A HT additions (sourcegraph, continuedev/continue, togethercomputer) after SMI-4386 ships.
5. Ship SMI-4388 — trivial, frees ~15 s per cron slot.
6. Defer Phase 4 AGENTS.md adapter (huggingface has 106; evaluate after SMI-4385 yield measured).

## Test plan

Docs-only PR — no code tested. Probe scripts have been exercised during the investigation (one-shot runs producing the committed TSVs). They are not wired into CI.

- [ ] Docs build / link check in CI
- [ ] Verify-implementation check passes with `[skip-impl-check]`
- [ ] Submodule PR (smith-horn/skillsmith-docs #cd3b770) merges first or concurrently
- [ ] Follow-up: all 4 Linear issues remain linked to SMI-4380 parent

🤖 Generated with Claude Code