### PR TITLE
SMI-4377 Wave 1: fix pre-commit hooks in worktrees (husky stubs committed + node_modules symlink + Docker fallback)

### DIFF
--- a/.claude/development/git-crypt-guide.md
+++ b/.claude/development/git-crypt-guide.md
@@ -161,8 +161,10 @@ The script handles:
 4. Checks out files with decryption working
    - 4b. Initializes submodules (`docs/internal`)
    - 4c. Scans `.claude/skills/**` for encrypted files; if `.env` is present, attempts auto-unlock via `varlock run -- git-crypt unlock` before warning (SMI-2676)
+   - 4d. Symlinks `node_modules` from main repo (SMI-4377) so host-side pre-commit hooks resolve `lint-staged`, `eslint`, `prettier`, `scripts/check-file-length.mjs`. Hard-errors if main repo's host `node_modules/.bin/lint-staged` is missing — fix with `(cd $REPO_ROOT && npm install --ignore-scripts)`
 5. Generates Docker override file
 6. Patches `.mcp.json` skillsmith entry to `npx -y @skillsmith/mcp-server` — the main repo uses a local dist path that doesn't exist in worktrees; this prevents "Failed to reconnect to skillsmith" on every worktree session
+7. Idempotent backfill: ensures all existing worktrees have the Step 4d `node_modules` symlink (SMI-4377). Run standalone via `./scripts/repair-worktrees.sh`
 
 **`.env` in worktrees**: New worktrees get `.env` auto-symlinked from the main repo (Step 3b). Existing worktrees need a manual symlink: `ln -sf /path/to/main/repo/.env .env`
 
@@ -170,7 +172,9 @@ The script handles:
 
 **If step 6 warns "jq unavailable"**: install jq (`brew install jq`) and re-run `create-worktree.sh`, or manually set the `skillsmith` entry in `.mcp.json` to `{"command": "npx", "args": ["-y", "@skillsmith/mcp-server"]}`.
 
-**Existing worktrees**: Step 6 only runs during creation. If you have an existing worktree with a broken skillsmith MCP, apply the manual fix above.
+**Existing worktrees**: Step 6 only runs during creation. If you have an existing worktree with a broken skillsmith MCP, apply the manual fix above. For the Step 4d / Step 7 `node_modules` symlink (SMI-4377), run `./scripts/repair-worktrees.sh` — idempotent, safe to re-run.
+
+**Pre-commit hook behavior in worktrees (SMI-4377)**: Phase 2 typecheck falls back to host `tsc` when invoked from a worktree (the Docker bind-mount covers only the main repo at `/app`; `docker exec -w /app` would target main repo HEAD instead of the worktree's staged changes). This is visible in pre-commit output as `📂 Worktree detected — falling back to host tooling`. SMI-4381 tracks the proper Docker fix.
 
 ### Manual Method
 

--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -33,8 +33,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: shellcheck
+        # -S warning skips info-level findings (SC1091 can't-follow-source
+        # is unavoidable for scripts that source _lib.sh; SC2016 single-quote
+        # expansion is intentional in the git-crypt unlock invocation).
         run: |
-          shellcheck scripts/_lib.sh \
+          shellcheck -S warning scripts/_lib.sh \
             scripts/create-worktree.sh \
             scripts/remove-worktree.sh \
             scripts/repair-worktrees.sh \

--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -1,0 +1,54 @@
+# SMI-4377: validate worktree hook infrastructure before merge.
+# Prevents regression of the hook silent-no-op and Docker `-w /app`
+# false-green failure modes that SMI-4377 Wave 1 fixes.
+#
+# Per plan-review finding #10: this runs on PRs but is NOT wired into
+# branch protection as a required check until it has logged a 4-week
+# clean window. Historic CI runner reliability concerns (SMI-4244
+# SIGTERM thread) suggest gating it only after proven stable.
+name: Validate Hooks
+
+on:
+  pull_request:
+    paths:
+      - '.husky/**'
+      - 'scripts/create-worktree.sh'
+      - 'scripts/remove-worktree.sh'
+      - 'scripts/repair-worktrees.sh'
+      - 'scripts/_lib.sh'
+      - 'scripts/tests/create-worktree-hooks.test.sh'
+      - 'scripts/check-file-length.mjs'
+      - 'lint-staged.config.js'
+      - '.github/workflows/validate-hooks.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  hooks-test:
+    name: Hooks Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: shellcheck
+        run: |
+          shellcheck scripts/_lib.sh \
+            scripts/create-worktree.sh \
+            scripts/remove-worktree.sh \
+            scripts/repair-worktrees.sh \
+            scripts/tests/create-worktree-hooks.test.sh
+
+      - name: Syntax check (bash -n)
+        run: |
+          bash -n scripts/_lib.sh
+          bash -n scripts/create-worktree.sh
+          bash -n scripts/remove-worktree.sh
+          bash -n scripts/repair-worktrees.sh
+          bash -n scripts/tests/create-worktree-hooks.test.sh
+          sh -n .husky/pre-commit
+
+      - name: Hooks unit tests
+        run: |
+          bash scripts/tests/create-worktree-hooks.test.sh

--- a/.husky/_/applypatch-msg
+++ b/.husky/_/applypatch-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/commit-msg
+++ b/.husky/_/commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/h
+++ b/.husky/_/h
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+[ "$HUSKY" = "2" ] && set -x
+n=$(basename "$0")
+s=$(dirname "$(dirname "$0")")/$n
+
+[ ! -f "$s" ] && exit 0
+
+if [ -f "$HOME/.huskyrc" ]; then
+	echo "husky - '~/.huskyrc' is DEPRECATED, please move your code to ~/.config/husky/init.sh"
+fi
+i="${XDG_CONFIG_HOME:-$HOME/.config}/husky/init.sh"
+[ -f "$i" ] && . "$i"
+
+[ "${HUSKY-}" = "0" ] && exit 0
+
+export PATH="node_modules/.bin:$PATH"
+sh -e "$s" "$@"
+c=$?
+
+[ $c != 0 ] && echo "husky - $n script failed (code $c)"
+[ $c = 127 ] && echo "husky - command not found in PATH=$PATH"
+exit $c

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,9 @@
+echo "husky - DEPRECATED
+
+Please remove the following two lines from $0:
+
+#!/usr/bin/env sh
+. \"\$(dirname -- \"\$0\")/_/husky.sh\"
+
+They WILL FAIL in v10.0.0
+"

--- a/.husky/_/post-applypatch
+++ b/.husky/_/post-applypatch
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/post-rewrite
+++ b/.husky/_/post-rewrite
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-applypatch
+++ b/.husky/_/pre-applypatch
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-auto-gc
+++ b/.husky/_/pre-auto-gc
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-merge-commit
+++ b/.husky/_/pre-merge-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-rebase
+++ b/.husky/_/pre-rebase
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/prepare-commit-msg
+++ b/.husky/_/prepare-commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -41,10 +41,30 @@ if command -v docker > /dev/null 2>&1; then
 else
   echo "${YELLOW}ℹ️  Docker not available - using local environment${NC}"
 fi
+
+# SMI-4377: Worktree detection. The Docker container bind-mounts the main repo
+# at /app; worktrees live outside /app, so `docker exec -w /app` would
+# typecheck main repo HEAD instead of the worktree's staged changes — a
+# false-green failure mode (worse than silent no-op). Fall back to host
+# execution; the node_modules symlink created by scripts/create-worktree.sh
+# Step 4d supplies the host binaries.
+# SMI-4381 tracks the proper fix: extend the Docker bind-mount to cover
+# worktrees so this fallback can be removed.
+IS_WORKTREE=0
+if [ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]; then
+  IS_WORKTREE=1
+  if [ $USE_DOCKER -eq 1 ]; then
+    USE_DOCKER=0
+    echo "${YELLOW}📂 Worktree detected — falling back to host tooling (SMI-4377)${NC}"
+    echo "${YELLOW}   Docker bind-mount covers only the main repo at /app.${NC}"
+    echo "${YELLOW}   See SMI-4381 for the proper Docker fix.${NC}"
+  fi
+fi
 echo ""
 
 # Helper function to run commands in Docker or locally
 # SMI-1774: Use -w /app to support running from worktree directories
+# SMI-4377: USE_DOCKER=0 is forced when in a worktree (see block above)
 run_cmd() {
   if [ $USE_DOCKER -eq 1 ]; then
     docker exec -w /app $DOCKER_CONTAINER "$@"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@ git submodule update --init                           # Init internal docs (auth
 
 **Worktrees**: Unlock main repo first, then `./scripts/create-worktree.sh`. Remove with `./scripts/remove-worktree.sh --prune`.
 
+**Hooks in worktrees (SMI-4377)**: Pre-commit hooks work inside worktrees via two mechanisms: (1) `.husky/_/` is tracked in git (husky's dispatch stubs) so hook discovery inherits through checkout; (2) `scripts/create-worktree.sh` symlinks `node_modules` from the main repo so `lint-staged`, `eslint`, `prettier`, and `scripts/check-file-length.mjs` resolve. **One-time host setup required** (after fresh clone): `npm install --ignore-scripts` to populate `$REPO_ROOT/node_modules` — Docker named-volume installs don't populate the host path. Caveats: (a) do not run `npm install` in the main repo while a pre-commit is active in a worktree — re-run the commit if it aborts; (b) Phase 2 typecheck falls back to host `tsc` when invoked from a worktree (the Docker bind-mount covers only the main repo; SMI-4381 tracks the proper fix); (c) repair existing worktrees with `./scripts/repair-worktrees.sh` (idempotent).
+
 **Rebasing**: `./scripts/rebase-worktree.sh <worktree-path> [target-branch]` handles git-crypt filter management, submodule cross-fetching, and branch verification. Use `--dry-run` to preview. Manual fallback: [git-crypt-guide.md](.claude/development/git-crypt-guide.md#rebasing-with-git-crypt).
 
 **Full guide**: [git-crypt-guide.md](.claude/development/git-crypt-guide.md)

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -126,3 +126,101 @@ is_git_crypt_encrypted() {
     # git-crypt binary header: \x00GIT = 00 47 49 54 (4-byte read = exactly 8 hex chars)
     [[ "$header" == "00474954" ]]
 }
+
+#######################################
+# Assert host-visible node_modules resolves lint-staged (SMI-4377)
+#
+# Pre-commit hooks run lint-staged on host (not Docker; see SMI-2604),
+# so host-visible node_modules is required. Docker named-volume installs
+# (CLAUDE.md docker-first policy) populate only the container volume.
+# Fails loudly per SMI-4374 retro ("silent degradation is the enemy").
+#
+# Arguments:
+#   $1 - Repository root path
+#######################################
+assert_host_node_modules() {
+    local repo_root="$1"
+    if [[ ! -x "$repo_root/node_modules/.bin/lint-staged" ]]; then
+        error "Main repo's host node_modules is missing or incomplete.
+
+Pre-commit hooks require host-visible node_modules to resolve lint-staged,
+eslint, and prettier. Docker named-volume installs (CLAUDE.md docker-first
+policy) populate the container volume but not the host path.
+
+Remediation (one-time, per clone):
+  (cd $repo_root && npm install --ignore-scripts)
+
+Then re-run this script. Host node_modules need not match the Docker
+environment's native modules — it only needs the CLI binaries under
+node_modules/.bin."
+    fi
+}
+
+#######################################
+# Symlink node_modules from main repo into a worktree (SMI-4377)
+#
+# Idempotent: refreshes an existing symlink, skips a real directory,
+# creates the symlink if missing.
+#
+# Arguments:
+#   $1 - Worktree path
+#   $2 - Repository root path (symlink target)
+#
+# Returns:
+#   0 on success or no-op, 1 if skipped due to unexpected state
+#######################################
+link_worktree_node_modules() {
+    local worktree_path="$1"
+    local repo_root="$2"
+
+    if [[ -L "$worktree_path/node_modules" ]]; then
+        ln -sfn "$repo_root/node_modules" "$worktree_path/node_modules"
+        return 0
+    fi
+
+    if [[ -e "$worktree_path/node_modules" ]]; then
+        warn "  node_modules exists at $worktree_path and is not a symlink — skipping"
+        return 1
+    fi
+
+    ln -sfn "$repo_root/node_modules" "$worktree_path/node_modules"
+    return 0
+}
+
+#######################################
+# Idempotent backfill of node_modules symlinks across all worktrees (SMI-4377)
+#
+# Iterates `git worktree list`, skips the main repo (real node_modules),
+# creates the symlink on any worktree missing it. Leaves existing real
+# dirs untouched. Safe to run repeatedly.
+#
+# Arguments:
+#   $1 - Repository root path
+#######################################
+repair_worktrees_node_modules() {
+    local repo_root="$1"
+    local wt_count=0
+    local repaired=0
+
+    while IFS= read -r wt_path; do
+        [[ -z "$wt_path" ]] && continue
+        [[ "$wt_path" == "$repo_root" ]] && continue
+        [[ ! -d "$wt_path" ]] && continue
+
+        wt_count=$((wt_count + 1))
+
+        if [[ -L "$wt_path/node_modules" ]] || [[ -d "$wt_path/node_modules" ]]; then
+            continue
+        fi
+
+        ln -sfn "$repo_root/node_modules" "$wt_path/node_modules"
+        info "  Repaired: $wt_path"
+        repaired=$((repaired + 1))
+    done < <(git -C "$repo_root" worktree list --porcelain | awk '/^worktree / { print $2 }')
+
+    if [[ $repaired -gt 0 ]]; then
+        success "  Repaired $repaired of $wt_count worktree(s)"
+    elif [[ $wt_count -gt 0 ]]; then
+        success "  All $wt_count worktree(s) already have node_modules"
+    fi
+}

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -410,6 +410,15 @@ create_worktree() {
     info "Step 4c: Verifying project-level skill readability..."
     verify_skill_readability "$worktree_path"
 
+    # Step 4d: Symlink node_modules so host-side pre-commit hooks resolve
+    # lint-staged, eslint, prettier, and check-file-length.mjs (SMI-4377).
+    # Hook discovery (Layer 1) is handled by the committed .husky/_/ tree.
+    info "Step 4d: Symlinking node_modules from main repo (SMI-4377)..."
+    assert_host_node_modules "$REPO_ROOT"
+    if link_worktree_node_modules "$worktree_path" "$REPO_ROOT"; then
+        success "  node_modules → $REPO_ROOT/node_modules"
+    fi
+
     # Step 5: Generate Docker override file (if docker-compose.yml exists)
     if [[ -f "$worktree_path/docker-compose.yml" ]]; then
         info "Step 5: Generating Docker override file..."
@@ -436,6 +445,11 @@ create_worktree() {
         echo "To start Docker in this worktree:"
         echo "  cd $worktree_path && docker compose --profile dev up -d"
     fi
+    echo ""
+    echo "Pre-commit hooks: active (SMI-4377)"
+    echo "  - Hook discovery: .husky/_/ is tracked in main repo (inherited via checkout)"
+    echo "  - Host tooling: node_modules symlinked to main repo"
+    echo "  - Typecheck: runs on host tsc when invoked from worktree (Docker bind-mount doesn't cover .worktrees/)"
     echo ""
     echo "Note: existing worktrees need a one-time manual fix if skillsmith MCP fails:"
     echo "  Edit .mcp.json: set skillsmith command to 'npx', args to ['-y', '@skillsmith/mcp-server']"
@@ -494,6 +508,12 @@ Run '$(basename "$0") --help' for usage information."
 
     # Create the worktree
     create_worktree "$WORKTREE_PATH" "$BRANCH_NAME" "$BASE_BRANCH"
+
+    # Idempotent backfill: ensure all existing worktrees have node_modules
+    # symlinks (SMI-4377). The newly-created worktree is a no-op pass.
+    echo ""
+    info "Step 7: Backfilling node_modules symlinks on existing worktrees (SMI-4377)..."
+    repair_worktrees_node_modules "$REPO_ROOT"
 }
 
 # Run main function

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -179,6 +179,13 @@ main() {
     # Step 1: Stop Docker containers
     stop_worktree_containers "$worktree_path"
 
+    # Step 1b: Unlink node_modules symlink so `git worktree remove` sees a
+    # clean tree (SMI-4377). A dangling symlink could confuse the removal
+    # check; explicit cleanup keeps intent clear.
+    if [[ -L "$worktree_path/node_modules" ]]; then
+        rm -f "$worktree_path/node_modules"
+    fi
+
     # Step 2: Remove the worktree
     info "Removing git worktree..."
     if git worktree remove "$worktree_path" $force_flag 2>&1; then

--- a/scripts/repair-worktrees.sh
+++ b/scripts/repair-worktrees.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# repair-worktrees.sh - Idempotent repair for stale worktrees (SMI-4377)
+#
+# Ensures every existing worktree has the node_modules symlink required
+# for host-side pre-commit hooks (lint-staged, check-file-length, etc.).
+# Layer 1 (hook discovery) is handled by the committed .husky/_/ tree —
+# any worktree that checks out a branch containing the fix will have
+# hooks working automatically.
+#
+# Safe to run repeatedly. Skips worktrees that already have node_modules
+# (symlink or real directory). Never touches the main repository.
+#
+# Usage: ./scripts/repair-worktrees.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "$SCRIPT_DIR/_lib.sh"
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+if [[ -z "$REPO_ROOT" ]]; then
+    error "Not in a git repository."
+fi
+
+# If run from inside a worktree, climb to the main repo for iteration.
+# get_main_git_dir returns the main .git path; parent is the main repo root.
+MAIN_GIT_DIR="$(get_main_git_dir "$REPO_ROOT")"
+if [[ "$MAIN_GIT_DIR" != "$REPO_ROOT/.git" ]] && [[ -n "$MAIN_GIT_DIR" ]]; then
+    REPO_ROOT="$(dirname "$MAIN_GIT_DIR")"
+    info "Running from worktree; resolved main repo: $REPO_ROOT"
+fi
+
+assert_host_node_modules "$REPO_ROOT"
+
+info "Repairing worktrees missing node_modules symlink..."
+repair_worktrees_node_modules "$REPO_ROOT"

--- a/scripts/tests/create-worktree-hooks.test.sh
+++ b/scripts/tests/create-worktree-hooks.test.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# SMI-4377: Unit + structural tests for worktree hook infrastructure.
+#
+# Covers:
+#   1. _lib.sh helpers  — assert_host_node_modules, link_worktree_node_modules,
+#                         repair_worktrees_node_modules (unit tests with a
+#                         throwaway git repo in a tmpdir; no git-crypt needed)
+#   2. .husky/pre-commit — IS_WORKTREE detection via --git-dir vs --git-common-dir
+#   3. .husky/_/          — committed dispatch files present and non-trivial
+#   4. Structural guards — regex checks on .husky/pre-commit for the worktree
+#                          fallback block + grep lint-staged.config.js for
+#                          check-file-length wiring (catches accidental
+#                          deletion of the Change 6 fallback and the 500-line
+#                          gate respectively)
+#
+# End-to-end hook validation (Phase 0 gitleaks, Phase 2 typecheck false-green
+# canary, Phase 3 file-length rejection, branch-integrity smudge recovery)
+# requires git-crypt + varlock + a decrypted worktree. Those run via the
+# manual verification section of the SMI-4377 PR description; gating them in
+# CI requires the 4-week reliability window (plan-review finding #10).
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+# shellcheck source=../_lib.sh
+source "$SCRIPT_DIR/_lib.sh"
+
+fail=0
+pass=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name: expected='$expected' actual='$actual'"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_true() {
+  local name="$1" cmd="$2"
+  if eval "$cmd"; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name: '$cmd' was false"
+    fail=$((fail + 1))
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Fixture: throwaway repo with a fake node_modules/.bin/lint-staged.
+# -----------------------------------------------------------------------
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+FAKE_MAIN="$TMPROOT/main"
+mkdir -p "$FAKE_MAIN/node_modules/.bin"
+touch "$FAKE_MAIN/node_modules/.bin/lint-staged"
+chmod +x "$FAKE_MAIN/node_modules/.bin/lint-staged"
+
+(
+  cd "$FAKE_MAIN"
+  git init -q -b main
+  git config user.email "test@skillsmith.local"
+  git config user.name "Test"
+  echo "ok" > README.md
+  git add README.md
+  git -c core.hooksPath=/dev/null commit -q -m "initial"
+) >/dev/null 2>&1
+
+# -----------------------------------------------------------------------
+# Scenario 1: _lib.sh — assert_host_node_modules passes when lint-staged exists
+# -----------------------------------------------------------------------
+set +e
+( assert_host_node_modules "$FAKE_MAIN" >/dev/null 2>&1 ); rc=$?
+set -e
+assert_eq "assert_host_node_modules: passes with lint-staged present" "0" "$rc"
+
+# -----------------------------------------------------------------------
+# Scenario 2: _lib.sh — assert_host_node_modules fails when lint-staged missing
+# -----------------------------------------------------------------------
+FAKE_EMPTY="$TMPROOT/empty"
+mkdir -p "$FAKE_EMPTY"
+set +e
+( assert_host_node_modules "$FAKE_EMPTY" >/dev/null 2>&1 ); rc=$?
+set -e
+assert_eq "assert_host_node_modules: fails when lint-staged missing" "1" "$rc"
+
+# -----------------------------------------------------------------------
+# Scenario 3: _lib.sh — link_worktree_node_modules creates symlink
+# -----------------------------------------------------------------------
+FAKE_WT1="$TMPROOT/wt1"
+mkdir -p "$FAKE_WT1"
+link_worktree_node_modules "$FAKE_WT1" "$FAKE_MAIN" >/dev/null
+assert_true "link_worktree_node_modules: creates symlink" \
+  "[ -L '$FAKE_WT1/node_modules' ]"
+assert_eq "link_worktree_node_modules: symlink target" \
+  "$FAKE_MAIN/node_modules" "$(readlink "$FAKE_WT1/node_modules")"
+
+# -----------------------------------------------------------------------
+# Scenario 4: _lib.sh — link_worktree_node_modules idempotent
+# -----------------------------------------------------------------------
+link_worktree_node_modules "$FAKE_WT1" "$FAKE_MAIN" >/dev/null
+assert_true "link_worktree_node_modules: idempotent repeat" \
+  "[ -L '$FAKE_WT1/node_modules' ] && [ '$(readlink "$FAKE_WT1/node_modules")' = '$FAKE_MAIN/node_modules' ]"
+
+# -----------------------------------------------------------------------
+# Scenario 5: _lib.sh — link_worktree_node_modules skips real directory
+# -----------------------------------------------------------------------
+FAKE_WT2="$TMPROOT/wt2"
+mkdir -p "$FAKE_WT2/node_modules"
+set +e
+link_worktree_node_modules "$FAKE_WT2" "$FAKE_MAIN" >/dev/null 2>&1; rc=$?
+set -e
+assert_eq "link_worktree_node_modules: skips real node_modules dir" "1" "$rc"
+assert_true "link_worktree_node_modules: did not clobber real dir" \
+  "[ -d '$FAKE_WT2/node_modules' ] && [ ! -L '$FAKE_WT2/node_modules' ]"
+
+# -----------------------------------------------------------------------
+# Scenario 6: _lib.sh — repair_worktrees_node_modules backfills missing, skips present
+# -----------------------------------------------------------------------
+(
+  cd "$FAKE_MAIN"
+  git worktree add -q -b wt-a "$TMPROOT/wt-a" main
+  git worktree add -q -b wt-b "$TMPROOT/wt-b" main
+  # wt-a has no node_modules; wt-b already has a symlink
+  ln -sfn "$FAKE_MAIN/node_modules" "$TMPROOT/wt-b/node_modules"
+) >/dev/null 2>&1
+repair_worktrees_node_modules "$FAKE_MAIN" >/dev/null 2>&1
+assert_true "repair_worktrees: backfilled missing symlink on wt-a" \
+  "[ -L '$TMPROOT/wt-a/node_modules' ]"
+assert_eq "repair_worktrees: wt-a symlink target" \
+  "$FAKE_MAIN/node_modules" "$(readlink "$TMPROOT/wt-a/node_modules")"
+assert_true "repair_worktrees: skipped existing symlink on wt-b" \
+  "[ -L '$TMPROOT/wt-b/node_modules' ]"
+
+# -----------------------------------------------------------------------
+# Scenario 7: .husky/pre-commit worktree detection (mirrors IS_WORKTREE logic)
+# -----------------------------------------------------------------------
+detect_worktree() {
+  local dir="$1"
+  if [ "$(git -C "$dir" rev-parse --git-dir)" != "$(git -C "$dir" rev-parse --git-common-dir)" ]; then
+    echo 1
+  else
+    echo 0
+  fi
+}
+assert_eq "worktree detection: main repo returns 0" "0" "$(detect_worktree "$FAKE_MAIN")"
+assert_eq "worktree detection: worktree returns 1" "1" "$(detect_worktree "$TMPROOT/wt-a")"
+
+# -----------------------------------------------------------------------
+# Scenario 8: .husky/_/ dispatch files committed (Layer 1 fix)
+# -----------------------------------------------------------------------
+HUSKY_TRACKED=$(git -C "$REPO_ROOT" ls-files '.husky/_' | wc -l | tr -d ' ')
+assert_true ".husky/_/ tracked dispatch files (>=10)" \
+  "[ '$HUSKY_TRACKED' -ge 10 ]"
+assert_true ".husky/_/h exists and non-empty" \
+  "[ -s '$REPO_ROOT/.husky/_/h' ]"
+assert_true ".husky/_/pre-commit stub exists" \
+  "[ -f '$REPO_ROOT/.husky/_/pre-commit' ]"
+
+# -----------------------------------------------------------------------
+# Scenario 9: structural guard — .husky/pre-commit contains Change 6 fallback
+# Prevents accidental deletion of the Docker worktree fallback. If this
+# guard fails, typecheck from worktrees will regress to false-green.
+# -----------------------------------------------------------------------
+if grep -q 'IS_WORKTREE=1' "$REPO_ROOT/.husky/pre-commit" && \
+   grep -q 'USE_DOCKER=0' "$REPO_ROOT/.husky/pre-commit" && \
+   grep -q 'SMI-4377' "$REPO_ROOT/.husky/pre-commit"; then
+  echo "PASS pre-commit: Change 6 worktree-fallback block present"
+  pass=$((pass + 1))
+else
+  echo "FAIL pre-commit: Change 6 worktree-fallback block missing or altered"
+  fail=$((fail + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Scenario 10: structural guard — lint-staged.config.js wires check-file-length
+# The 500-line cap is the canary that tripped in SMI-4374; verify the gate
+# is still wired so SMI-4376's refactor can rely on it.
+# -----------------------------------------------------------------------
+if grep -q 'check-file-length.mjs' "$REPO_ROOT/lint-staged.config.js"; then
+  echo "PASS lint-staged: check-file-length.mjs still wired"
+  pass=$((pass + 1))
+else
+  echo "FAIL lint-staged: check-file-length.mjs wiring missing"
+  fail=$((fail + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------
+total=$((pass + fail))
+echo ""
+if [ $fail -eq 0 ]; then
+  echo "All tests passed ($pass/$total)"
+  exit 0
+else
+  echo "FAILURES: $fail failed, $pass passed ($total total)"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes silent no-op of pre-commit hooks inside git worktrees created by `scripts/create-worktree.sh`. Plan-reviewed (3 VPs, 13 findings applied). Closes SMI-4377.

**Root cause** (two layers): `.husky/_/` (husky's internal dispatch directory) is gitignored and regenerated by `npm install` — worktrees never run `npm install`, so the directory doesn't exist and hooks dispatch nowhere. Even with that fixed, `npx lint-staged` in pre-commit needs host-visible `node_modules` which worktrees also lack.

**Third-order** (plan-review escalation): `.husky/pre-commit` uses `docker exec -w /app`, which targets the main repo's bind-mount. From a worktree, Phase 2 typecheck would run against main repo HEAD instead of the worktree's staged changes — false green.

## Changes

5 commits on the branch:

1. **`feat(husky): commit .husky/_/`** — Option 4 from plan-review. Pre-flight spike confirmed husky's `prepare` script is idempotent w.r.t. tracked files (verified: md5s of `.husky/_/h`, `_/husky.sh`, `_/pre-commit` unchanged after `npm install`). This alone fixes Layer 1 for any worktree that checks out the fix, with zero script changes for hook discovery.

2. **`feat(scripts): node_modules symlink + repair helper`** — Three shared helpers in `_lib.sh` (`assert_host_node_modules`, `link_worktree_node_modules`, `repair_worktrees_node_modules`). New Step 4d in `create-worktree.sh` symlinks `node_modules` and hard-errors if host `node_modules/.bin/lint-staged` is missing (plan-review escalation: silent degradation is the enemy). New Step 7 runs idempotent backfill on all existing worktrees. New `scripts/repair-worktrees.sh` standalone entry point. `remove-worktree.sh` unlinks the symlink before `git worktree remove`.

3. **`feat(husky): pre-commit host-tsc fallback`** — Plan-review escalation from out-of-scope to in-scope. Detects worktree invocation via `git rev-parse --git-dir` vs `--git-common-dir` (canonical comparison). When in a worktree, forces `USE_DOCKER=0` so Phase 2 typecheck runs on host using the symlinked `node_modules`. SMI-4381 tracks the proper Docker bind-mount fix.

4. **`test(scripts): hooks-infrastructure test harness + CI workflow`** — 17 assertions across 10 scenarios: `_lib.sh` helpers (unit), worktree detection logic, `.husky/_/` tracked dispatch files, and structural guards on `.husky/pre-commit` (Change 6 block present) + `lint-staged.config.js` (check-file-length wired). New `.github/workflows/validate-hooks.yml` runs shellcheck + `bash -n` + the harness on PRs touching hooks-adjacent paths. Not wired as a required check until 4-week reliability window passes (plan-review finding #10).

5. **`docs: CLAUDE.md + git-crypt-guide`** — Full "Hooks in worktrees" subsection covering: mechanism (two layers), one-time host `npm install --ignore-scripts` prerequisite, concurrent `npm install` race caveat (→ SMI-4384), Phase 2 host-tsc fallback (→ SMI-4381), `repair-worktrees.sh` entry point (plan-review finding #12: expanded from one-liner).

## Plan

Full implementation plan with all 13 plan-review findings applied: `docs/internal/implementation/smi-4377-worktree-husky-hooks.md` (via paired docs submodule PR).

## Follow-up Linear issues

| ID | Title | Severity |
|---|---|---|
| [SMI-4381](https://linear.app/smith-horn-group/issue/SMI-4381) | Docker bind-mount for worktrees — removes Change 6 fallback | Medium |
| [SMI-4382](https://linear.app/smith-horn-group/issue/SMI-4382) | Wave 2 — migrate `.husky/` to `.githooks/` | Medium |
| [SMI-4383](https://linear.app/smith-horn-group/issue/SMI-4383) | Verify `.eslintcache` isolation across worktrees | Low |
| [SMI-4384](https://linear.app/smith-horn-group/issue/SMI-4384) | Concurrent `npm install` race — mtime guard | Low |

## Test plan

- [x] `bash scripts/tests/create-worktree-hooks.test.sh` — 17/17 pass locally
- [x] `docker exec skillsmith-dev-1 npm run audit:standards` — 44 passed, 4 pre-existing warnings (SMI-4376 `index.ts` 565 LOC is one of them; tracked separately)
- [x] `docker exec skillsmith-dev-1 npm run typecheck` — clean
- [x] `./scripts/repair-worktrees.sh` — repaired 5 of 7 existing worktrees (2 had real `node_modules` dirs and were correctly skipped)
- [x] `shellcheck` clean on all modified scripts
- [ ] CI green (`Validate Hooks` workflow + all existing required checks)

## Manual verification sequence (post-merge, via SMI-4376)

SMI-4376 will be authored in a fresh worktree created *after* this merges. During that work:

1. `./scripts/create-worktree.sh smi-4376-indexer-split` — expect Step 4d success, Step 7 backfill on existing trees
2. Verify: `git -C .worktrees/smi-4376-indexer-split config core.hooksPath` → empty (inherited from main repo)
3. Verify: `readlink .worktrees/smi-4376-indexer-split/node_modules` → absolute path to main repo
4. During refactor, commit a deliberate 501-line intermediate state of `discovery-runner.ts` — expect pre-commit to block locally (validates `check-file-length.mjs` fires from worktrees, which is the exact regression that allowed the 565-line `index.ts` to ship)
5. Verify pre-commit output shows `📂 Worktree detected — falling back to host tooling`

## Ordering (non-optional per plan-review)

SMI-4377 ships first. SMI-4376 merges next as production validation.