### PR TITLE
fix(ci): SMI-4391 validate-edge-functions.sh parser + missing functions

### DIFF
--- a/scripts/validate-edge-functions.sh
+++ b/scripts/validate-edge-functions.sh
@@ -43,6 +43,9 @@ AUTHENTICATED_FUNCTIONS=(
   "update-seat-count"
   "generate-license"
   "regenerate-license"
+  "admin-grant-subscription"
+  "skills-outreach-preferences"
+  "webhook-dlq"
 )
 
 # Service role functions (scheduled jobs, internal)
@@ -52,6 +55,9 @@ SERVICE_ROLE_FUNCTIONS=(
   "ops-report"
   "alert-notify"
   "email-inbound"
+  "process-pending-subscription"
+  "expire-complimentary"
+  "skills-outreach"
 )
 
 echo ""
@@ -132,15 +138,27 @@ if [ "$1" = "--check-deployment" ]; then
   if [ -z "$SUPABASE_ACCESS_TOKEN" ] || [ -z "$SUPABASE_PROJECT_REF" ]; then
     echo -e "${YELLOW}  ⚠ SUPABASE_ACCESS_TOKEN or SUPABASE_PROJECT_REF not set, skipping deployment check${NC}"
   else
-    DEPLOYED=$(supabase functions list --project-ref "$SUPABASE_PROJECT_REF" 2>/dev/null | tail -n +2 | awk '{print $1}' || true)
-    for fn in $FUNCTION_DIRS; do
-      if echo "$DEPLOYED" | grep -q "^$fn$"; then
-        echo -e "${GREEN}  ✓ $fn: Deployed${NC}"
-      else
-        echo -e "${RED}  ✗ $fn: NOT DEPLOYED${NC}"
-        ERRORS=$((ERRORS + 1))
-      fi
-    done
+    # Parse pipe-delimited table. Skip header + separator rows (NR > 2), skip
+    # separator rows with few fields (NF > 2 guards against dashes-only rows),
+    # extract the NAME column ($2 when splitting on '|'), trim whitespace.
+    # Prior `awk '{print $1}'` returned the UUID column, causing every function
+    # to be reported NOT DEPLOYED after a Supabase CLI output-format change.
+    DEPLOYED=$(supabase functions list --project-ref "$SUPABASE_PROJECT_REF" 2>/dev/null \
+      | awk -F '|' 'NR > 2 && NF > 2 { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2 }')
+
+    if [ -z "$DEPLOYED" ]; then
+      echo -e "${RED}  ✗ 'supabase functions list' returned no functions — CLI invocation failed or token lacks project access${NC}"
+      ERRORS=$((ERRORS + 1))
+    else
+      for fn in $FUNCTION_DIRS; do
+        if echo "$DEPLOYED" | grep -q "^$fn$"; then
+          echo -e "${GREEN}  ✓ $fn: Deployed${NC}"
+        else
+          echo -e "${RED}  ✗ $fn: NOT DEPLOYED${NC}"
+          ERRORS=$((ERRORS + 1))
+        fi
+      done
+    fi
   fi
   echo ""
 fi


### PR DESCRIPTION
[skip-impl-check] — shell-script-only change (scripts/validate-edge-functions.sh). No production code surface changed.

## Summary

- Fix parser regression in `scripts/validate-edge-functions.sh:135` — `awk '{print $1}'` returned the UUID column from `supabase functions list` pipe-delimited output instead of NAME, causing every function to report NOT DEPLOYED
- Add 6 missing functions to the category arrays (truth source: CLAUDE.md Supabase Edge Functions auth table)
- Add defensive empty-output error so CLI-invocation failures fail loudly instead of silently reporting "26/26 NOT DEPLOYED"

Fixes `deploy-edge-functions.yml` Verify step which has been silently red for 10 consecutive post-merge runs on main since 2026-04-19.

## Root cause

### Bug A — parser regression

Real Supabase CLI output (probed today via `varlock run -- supabase functions list --project-ref $SUPABASE_PROJECT_REF`):

```
   ID                                   | NAME             | SLUG             | STATUS | VERSION | UPDATED_AT
  --------------------------------------|------------------|------------------|--------|---------|-----------
   f126b08d-a928-43ef-ae62-0023557c8046 | skills-search    | skills-search    | ACTIVE | 60      | 2026-04-21 02:28:29
```

Prior `awk '{print $1}'` defaulted to whitespace splitting and returned the ID (e.g., `f126b08d-a928-43ef-ae62-0023557c8046`). The downstream `grep -q "^$fn$"` then could never match function names.

### Bug B — category array drift

Arrays totaled 20 entries; repo has 26 deployed functions. Per CLAUDE.md line 258 auth table, 6 functions were uncategorized: `admin-grant-subscription`, `expire-complimentary`, `process-pending-subscription`, `skills-outreach-preferences`, `skills-outreach`, `webhook-dlq`.

## Test plan

- [x] Local run in the worktree confirms `Total: 26, Errors: 0, Warnings: 0, Validation PASSED`
- [x] CI runs ci.yml Edge Function Validation which invokes the script without `--check-deployment` — Check 1-3 pass with 0 uncategorized warnings
- [ ] Post-merge: `gh workflow run deploy-edge-functions.yml -f deploy_all=true` — expect 26/26 deployed, Validation PASSED
- [ ] Confirm the 10 prior red runs fired `alert-notify`; if not, file a separate alerting incident

## Linear

- Closes SMI-4391
- Parent umbrella: SMI-4389 (Workflow audit cleanup)

## Plan

docs/internal/implementation/2026-04-20-workflow-audit-cleanup.md — Wave 1 Step 2

🤖 Generated with Ruflo hive-mind `hive-1776786093761-5etx9n`