### PR TITLE
fix(ci): SMI-4393 workflow hygiene — SHA pins, cron staggers, release-cadence output

### DIFF
--- a/.claude/development/ci-reference.md
+++ b/.claude/development/ci-reference.md
@@ -88,10 +88,11 @@ The `main` branch is protected. Config: `.github/branch-protection.json`.
 | Build | ci.yml | Build all packages via Turborepo |
 | Markdown Lint | docs-only.yml | Documentation quality |
 | Verify Implementation Completeness | ci.yml | Verify PRs with SMI refs contain source changes |
+| Dependency Guard | ci.yml | Block known-vulnerable dep upgrades (SMI-3985, promoted 2026-04-21) |
 
 ### How It Works
 
-- **Code PRs**: All 12 checks must pass
+- **Code PRs**: All 13 checks must pass
 - **Docs-only PRs**: Only Secret Scan + Markdown Lint (from `docs-only.yml`)
 - **Mixed PRs**: Full CI runs
 

--- a/.github/workflows/analytics-report.yml
+++ b/.github/workflows/analytics-report.yml
@@ -6,8 +6,10 @@ name: Weekly Analytics Report
 
 on:
   schedule:
-    # Every Monday at 9:00 AM UTC (aligned with ops-report and billing-monitor)
-    - cron: '0 9 * * 1'
+    # SMI-4393: staggered off 09:00 UTC to avoid contention against
+    # ops-report/billing-monitor/linear-drift-audit/user-growth-report
+    # which used to share the same cron slot.
+    - cron: '3 9 * * 1'
   workflow_dispatch:
     inputs:
       days:

--- a/.github/workflows/batch-transform.yml
+++ b/.github/workflows/batch-transform.yml
@@ -13,8 +13,8 @@ name: Batch Skill Transformation
 
 on:
   schedule:
-    # Run weekly on Sunday at 2 AM UTC
-    - cron: '0 2 * * 0'
+    # SMI-4393: offset from security-scan.yml which also fires at 0 2 * * 0
+    - cron: '30 2 * * 0'
   workflow_dispatch:
     inputs:
       limit:

--- a/.github/workflows/billing-monitor.yml
+++ b/.github/workflows/billing-monitor.yml
@@ -5,8 +5,8 @@ name: Billing Monitor
 
 on:
   schedule:
-    # Every Monday at 9 AM UTC
-    - cron: '0 9 * * 1'
+    # SMI-4393: staggered off 09:00 UTC slot (see analytics-report.yml)
+    - cron: '6 9 * * 1'
   workflow_dispatch:
     inputs:
       create_issue:

--- a/.github/workflows/linear-drift-audit.yml
+++ b/.github/workflows/linear-drift-audit.yml
@@ -6,8 +6,8 @@ name: Linear Drift Audit
 
 on:
   schedule:
-    # Monday 9 AM UTC — alongside ops-report
-    - cron: '0 9 * * 1'
+    # SMI-4393: staggered off 09:00 UTC slot (see analytics-report.yml)
+    - cron: '9 9 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -41,10 +41,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/release-cadence.yml
+++ b/.github/workflows/release-cadence.yml
@@ -54,7 +54,15 @@ jobs:
           node scripts/check-unreleased-threshold.mjs --file CHANGELOG.md
           EXIT=$?
           set -e
-          COUNT=$(node scripts/check-unreleased-threshold.mjs --file CHANGELOG.md 2>/dev/null || echo 0)
+          # SMI-4394: pipe through `head -n 1` + whitespace-strip + numeric
+          # sanity check. Prior `|| echo 0` fallback concatenated fallback
+          # stdout with the script's earlier stdout on non-zero exits,
+          # producing multi-line COUNT like "33\n0" which then made
+          # `echo "count=$COUNT" >> $GITHUB_OUTPUT` emit two lines — the
+          # bare "0" tripped GHA's "Invalid format '0'" file-command error
+          # on 2026-04-19 first run.
+          COUNT=$(node scripts/check-unreleased-threshold.mjs --file CHANGELOG.md 2>/dev/null | head -n 1 | tr -d '[:space:]')
+          if ! echo "$COUNT" | grep -qE '^[0-9]+$'; then COUNT=0; fi
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "exit=$EXIT" >> "$GITHUB_OUTPUT"
           echo "## Cadence Check" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/user-growth-report.yml
+++ b/.github/workflows/user-growth-report.yml
@@ -7,8 +7,8 @@ name: Weekly User Growth Report
 
 on:
   schedule:
-    # Every Monday at 9:00 AM UTC (aligned with other Monday reports)
-    - cron: '0 9 * * 1'
+    # SMI-4393: staggered off 09:00 UTC slot (see analytics-report.yml)
+    - cron: '12 9 * * 1'
   workflow_dispatch:
     inputs:
       days:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ docker exec skillsmith-dev-1 npm run preflight         # All checks before push
 
 **Build**: Uses Turborepo (`npm run build`). Legacy fallback: `npm run build:legacy`. See [ADR-106](docs/internal/adr/106-turborepo-build-orchestration.md).
 
-**Branch protection**: 12 required checks for code PRs, 2 for docs-only. Admin bypass for emergencies. Details: [ci-reference.md](.claude/development/ci-reference.md#branch-protection).
+**Branch protection**: 13 required checks for code PRs, 2 for docs-only. Admin bypass for emergencies. Details: [ci-reference.md](.claude/development/ci-reference.md#branch-protection).
 
 ---
 


### PR DESCRIPTION
[skip-impl-check] — workflow YAML + docs only. No TypeScript or production code surface.

## Summary

Bundled Wave 2 hygiene from the 2026-04-20 workflow audit (SMI-4389 umbrella, plan at `docs/internal/implementation/2026-04-20-workflow-audit-cleanup.md`).

- **Pin post-merge-verify.yml** action SHAs (`checkout@v6`, `setup-node@v4` were the only floating-tag pins in the entire workflow corpus; bump setup-node major to align)
- **Stagger Monday 09:00 UTC** 5 workflows off the shared cron slot (keep `ops-report` at `0 9`; shift analytics-report/billing-monitor/linear-drift-audit/user-growth-report to `3/6/9/12 9`)
- **Stagger Sunday 02:00 UTC** batch-transform.yml off the security-scan.yml collision (moves to `30 2 * * 0`)
- **Fix `release-cadence.yml` GITHUB_OUTPUT format bug** (SMI-4394) — the `|| echo 0` fallback concatenated stdouts on non-zero exit, emitting two lines including a bare `0` that tripped GHA's "Invalid format '0'" error
- **Document Dependency Guard as 13th required check** (SMI-3985 / SMI-4390) — promoted 2026-04-21 15:47Z

## Closes

- SMI-4393 (hygiene batch)
- SMI-4394 (release-cadence RCA + fix)

## Parent

SMI-4389 (Workflow audit cleanup umbrella)

## Test plan

- [ ] CI passes on this PR (all 13 required checks including Dependency Guard)
- [ ] Post-merge: monitor next Monday 09:00 UTC burst — workflows should fire at `:00`, `:03`, `:06`, `:09`, `:12` (not all at `:00`)
- [ ] Next `release-cadence.yml` scheduled run 2026-04-26 03:00 UTC should succeed (no "Invalid format" error)

## Hook bypass note

Pre-commit `--no-verify` used per SMI-4381 / SMI-4284 known worktree host-tsc limitation (`web-tree-sitter` TS2307 false positive). Documented inline in the commit message. Diff is workflow YAML + markdown only, so Docker CI exercises the full typecheck.

🤖 Generated with Ruflo hive-mind `hive-1776786093761-5etx9n`