### PR TITLE
fix(scanner): SMI-4409 retire skill-image-pipeline allowlist entry

### DIFF
--- a/data/skills-security-allowlist.json
+++ b/data/skills-security-allowlist.json
@@ -3,15 +3,6 @@
   "generatedAt": "2026-04-21T18:30:00.000Z",
   "allowlist": [
     {
-      "skillId": "github/smith-horn/skill-image-pipeline",
-      "findingType": "data_exfiltration",
-      "messagePattern": "upload to (?:cloud|cloudinary)",
-      "reason": "Smith Horn's own Cloudinary upload pipeline. 'Upload to Cloudinary' is the declared product purpose (CDN delivery). Quarantined because the pre-SMI-4396 data_exfiltration regex matched 'upload ... to ... cloud' substring-style and did not word-boundary 'Cloudinary'. Wave 2 sources a word-boundary fix at packages/core/src/security/scanner/patterns.ts so this entry can be retired at next review.",
-      "reviewedBy": "ryansmith108",
-      "reviewedAt": "2026-04-21",
-      "expiresAt": "2026-07-21"
-    },
-    {
       "skillId": "github/kcmadden/claude-code-1password-skill",
       "findingType": "sensitive_path",
       "messagePattern": "password|credentials",

--- a/packages/core/tests/skill-scanner/allowlist.test.ts
+++ b/packages/core/tests/skill-scanner/allowlist.test.ts
@@ -375,22 +375,24 @@ describe('loadAllowlist (SMI-4396)', () => {
 // ------------------------ ship-it ------------------------
 
 describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
-  it('is parseable and matches the 5 verified FPs', () => {
+  // SMI-4409: skill-image-pipeline entry retired — SMI-4396 Wave 2 sourced a
+  // \bcloud\b word-boundary at patterns.ts so Cloudinary no longer matches
+  // upload-to-cloud; the allowlist entry became redundant.
+  it('is parseable and matches the 4 verified FPs', () => {
     const filePath = path.resolve(__dirname, '../../../../data/skills-security-allowlist.json')
     const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
     const parsed = parseAllowlistFile(raw)
-    expect(parsed.allowlist.length).toBe(5)
+    expect(parsed.allowlist.length).toBe(4)
     const ids = parsed.allowlist.map((e) => e.skillId).sort()
     expect(ids).toEqual(
       [
         'github/StrategicPromptArchitect-AI/MalPromptSentinel-CC-Skill',
         'github/kcmadden/claude-code-1password-skill',
         'github/rhysha/claude-security-research-skill',
-        'github/smith-horn/skill-image-pipeline',
         'github/straygizmo/mdium',
       ].sort()
     )
-    // All 5 must share the 2026-07-21 (90-day) expiry.
+    // All must share the 2026-07-21 (90-day) expiry.
     expect(parsed.allowlist.every((e) => e.expiresAt === '2026-07-21')).toBe(true)
   })
 })


### PR DESCRIPTION
[skip-impl-check]

## Summary

- Retire the `github/smith-horn/skill-image-pipeline` allowlist entry from `data/skills-security-allowlist.json`. SMI-4396 Wave 2 (PR #708, `342fd097`) added a `\bcloud\b` word-boundary to the `data_exfiltration` upload pattern, so `Cloudinary` no longer matches — the allowlist entry is redundant.
- Update `packages/core/tests/skill-scanner/allowlist.test.ts` ship-it sanity check from 5 → 4 entries.

**Skip-impl-check rationale**: this is a data-only change (`data/skills-security-allowlist.json`) + sympathetic test update. The behavior change lives in PR #708 at the source-pattern level; this PR just removes the now-redundant allowlist entry. No `packages/*/src/**` changes.

## Why

Keep the allowlist honest: entries should only exist when the source pattern genuinely can't be tightened. With the `\bcloud\b` fix live, the `skill-image-pipeline` entry was FP-hiding surface with no purpose.

## Verification

- `packages/core/tests/security/scanner-wave2-fixtures.test.ts` "Cloudinary upload" fixture (the `skill-image-pipeline` truth-teller) passes WITHOUT the allowlist entry — 9/9 Wave 2 fixtures green.
- `packages/core/tests/skill-scanner/allowlist.test.ts` — 24/24 green.

## Post-merge verification

```bash
gh workflow run weekly-security-scan.yml -f create_issue=true
gh run download \$(gh run list --workflow=weekly-security-scan.yml --limit=1 --json databaseId --jq '.[0].databaseId') -n quarantine-skills -D /tmp/smi4409
jq '.count' /tmp/smi4409/quarantine-skills.json  # expect still <= 2
```

## Test plan

- [x] Typecheck clean (packages/core)
- [x] Wave 2 fixtures pass unmodified (scanner-wave2-fixtures.test.ts)
- [x] Allowlist tests pass (ship-it check updated)
- [x] Pre-commit hooks clean (lint, prettier, check-file-length)
- [ ] CI merge-queue green
- [ ] Post-merge quarantine count verification (jq '.count' <= 2)

Closes SMI-4409.
Parent: SMI-4396.
Follow-up to PR #708.

Generated with [Ruflo](https://github.com/ruvnet/ruflo)