### PR TITLE
feat(indexer): SMI-4408 blocklist non-skill repos in GitHub importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,8 @@ docs/strategy/
 # a child when the parent directory itself is excluded.
 /data/*
 !/data/skills-security-allowlist.json
+# SMI-4408: indexer blocklist for non-skill repos (imported-skill ingest filter).
+!/data/indexer-blocklist.json
 /output/
 test-results/
 playwright-report/

--- a/data/indexer-blocklist.json
+++ b/data/indexer-blocklist.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "updatedAt": "2026-04-21",
+  "blocked": [
+    {
+      "repo": "vinayaksavle/UploadDownloadPDF",
+      "reason": "ASP.NET MVC file-upload tutorial (C#). README contains 'multipart/form-data' which triggers data_exfiltration 'upload' pattern. Not a Claude Code skill — surfaced by SMI-4396 Wave 2 scan as a post-tuning residual.",
+      "addedBy": "ryansmith108",
+      "addedAt": "2026-04-21"
+    },
+    {
+      "repo": "Sfedfcv/redesigned-pancake",
+      "reason": "GitHub docs-repo mirror with misleading name (random-generator). Unrelated to Claude Code skills — surfaced by SMI-4396 Wave 2 scan as a post-tuning residual.",
+      "addedBy": "ryansmith108",
+      "addedAt": "2026-04-21"
+    }
+  ]
+}

--- a/packages/core/src/scripts/github-import/blocklist.ts
+++ b/packages/core/src/scripts/github-import/blocklist.ts
@@ -1,0 +1,167 @@
+/**
+ * SMI-4408: Indexer blocklist for non-skill repos.
+ *
+ * Loads data/indexer-blocklist.json and produces a BlocklistMatcher consumed
+ * by the main() CLI in import-github-skills.ts. The filter runs between
+ * deduplicateSkills() and saveOutput() so blocked repos never reach
+ * data/imported-skills.json.
+ *
+ * Tactical fix for known-bad repos. The structural fix (require a
+ * signal-of-intent signal per ingested repo) is tracked as Tier 2
+ * follow-up under ADR-109 SPARC.
+ *
+ * Design invariants:
+ * - Exact-match only (`owner/name`, case-sensitive) — no wildcards. Keeps
+ *   scope tight and auditable. If wildcards become necessary, file a
+ *   follow-up issue rather than widening this module.
+ * - Malformed entries throw at load (fail-safe toward ingestion rejection
+ *   would be wrong here — ingestion should NOT proceed with an unverified
+ *   blocklist file).
+ * - version=1 contract: future schema changes must bump and handle migration.
+ */
+
+import * as fs from 'fs'
+
+export interface BlocklistEntry {
+  /** GitHub full_name: `owner/name`. Exact match, case-sensitive. */
+  repo: string
+  /** Why this entry is blocked — human-readable, required. */
+  reason: string
+  /** Who added the entry — required for audit trail. */
+  addedBy: string
+  /** YYYY-MM-DD string — required. */
+  addedAt: string
+}
+
+export interface BlocklistFile {
+  version: 1
+  updatedAt: string
+  blocked: BlocklistEntry[]
+}
+
+export interface BlocklistMatcher {
+  /**
+   * True when `repo` (format: `owner/name`) appears in the blocklist. Exact
+   * match, case-sensitive.
+   */
+  isBlocked(repo: string): boolean
+  /** Expose entries for audit-logging in the import summary. */
+  entries(): readonly BlocklistEntry[]
+}
+
+const REQUIRED_ENTRY_FIELDS: Array<keyof BlocklistEntry> = ['repo', 'reason', 'addedBy', 'addedAt']
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+const REPO_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+function validateEntryShape(entry: unknown, entryIndex: number): BlocklistEntry {
+  if (typeof entry !== 'object' || entry === null) {
+    throw new Error(`Blocklist entry #${entryIndex} is not an object`)
+  }
+  const e = entry as Record<string, unknown>
+  for (const field of REQUIRED_ENTRY_FIELDS) {
+    if (typeof e[field] !== 'string' || (e[field] as string).length === 0) {
+      throw new Error(
+        `Blocklist entry #${entryIndex} missing or empty required field: ${String(field)}`
+      )
+    }
+  }
+  if (!REPO_PATTERN.test(e.repo as string)) {
+    throw new Error(
+      `Blocklist entry #${entryIndex} repo must be 'owner/name' (GitHub full_name), got: ${String(e.repo)}`
+    )
+  }
+  if (!DATE_PATTERN.test(e.addedAt as string)) {
+    throw new Error(
+      `Blocklist entry #${entryIndex} addedAt must be YYYY-MM-DD, got: ${String(e.addedAt)}`
+    )
+  }
+  return e as unknown as BlocklistEntry
+}
+
+/**
+ * Parse a raw blocklist file object. Throws on malformed shape or missing
+ * required fields. Callers must catch.
+ */
+export function parseBlocklistFile(raw: unknown): BlocklistFile {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('Blocklist file root must be an object')
+  }
+  const r = raw as Record<string, unknown>
+  if (r.version !== 1) {
+    throw new Error(`Unsupported blocklist file version: ${String(r.version)} (expected 1)`)
+  }
+  if (typeof r.updatedAt !== 'string' || !DATE_PATTERN.test(r.updatedAt)) {
+    throw new Error(`Blocklist file updatedAt must be YYYY-MM-DD, got: ${String(r.updatedAt)}`)
+  }
+  if (!Array.isArray(r.blocked)) {
+    throw new Error('Blocklist file .blocked must be an array')
+  }
+  const entries = r.blocked.map((entry, i) => validateEntryShape(entry, i))
+  const seen = new Set<string>()
+  for (const entry of entries) {
+    if (seen.has(entry.repo)) {
+      throw new Error(`Blocklist file contains duplicate entry: ${entry.repo}`)
+    }
+    seen.add(entry.repo)
+  }
+  return { version: 1, updatedAt: r.updatedAt, blocked: entries }
+}
+
+class SetBackedMatcher implements BlocklistMatcher {
+  private readonly blocked: Set<string>
+  private readonly entryList: readonly BlocklistEntry[]
+
+  constructor(entries: BlocklistEntry[]) {
+    this.blocked = new Set(entries.map((e) => e.repo))
+    this.entryList = entries
+  }
+
+  isBlocked(repo: string): boolean {
+    return this.blocked.has(repo)
+  }
+
+  entries(): readonly BlocklistEntry[] {
+    return this.entryList
+  }
+}
+
+/**
+ * Empty matcher — blocks nothing. Used when the blocklist file is absent or
+ * callers want to opt out without conditional plumbing.
+ */
+export const EMPTY_BLOCKLIST: BlocklistMatcher = {
+  isBlocked(): boolean {
+    return false
+  },
+  entries(): readonly BlocklistEntry[] {
+    return []
+  },
+}
+
+/**
+ * Load + validate a blocklist JSON file and return a matcher.
+ *
+ * If `path` does not exist, returns EMPTY_BLOCKLIST (no-op). A malformed
+ * file throws so the importer refuses to proceed with a corrupt blocklist.
+ */
+export function loadBlocklist(path: string): BlocklistMatcher {
+  if (!fs.existsSync(path)) {
+    return EMPTY_BLOCKLIST
+  }
+  const raw = fs.readFileSync(path, 'utf-8')
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(`Blocklist file ${path} is not valid JSON: ${(err as Error).message}`)
+  }
+  const file = parseBlocklistFile(parsed)
+  return new SetBackedMatcher(file.blocked)
+}
+
+/** Build a matcher from an in-memory entry list (test + inline use). */
+export function buildBlocklist(entries: BlocklistEntry[]): BlocklistMatcher {
+  entries.forEach((entry, i) => validateEntryShape(entry, i))
+  return new SetBackedMatcher(entries)
+}

--- a/packages/core/src/scripts/github-import/index.ts
+++ b/packages/core/src/scripts/github-import/index.ts
@@ -65,6 +65,8 @@ async function _main(): Promise<void> {
     total_found: 0,
     total_imported: 0,
     duplicates_removed: 0,
+    blocked_count: 0,
+    blocked_repos: [],
     queries_completed: [],
     errors: [],
     started_at: new Date().toISOString(),

--- a/packages/core/src/scripts/github-import/types.ts
+++ b/packages/core/src/scripts/github-import/types.ts
@@ -122,6 +122,10 @@ export interface ImportStats {
   total_found: number
   total_imported: number
   duplicates_removed: number
+  /** SMI-4408: count of post-dedup skills dropped by the indexer blocklist. */
+  blocked_count: number
+  /** SMI-4408: the repos (owner/name) that were blocked this run, for audit. */
+  blocked_repos: string[]
   queries_completed: string[]
   errors: string[]
   started_at: string

--- a/packages/core/src/scripts/import-github-skills.ts
+++ b/packages/core/src/scripts/import-github-skills.ts
@@ -27,7 +27,12 @@ import { log, sleep } from './github-import/utils.js'
 import { checkRateLimit, fetchGitHubSearch } from './github-import/github-client.js'
 import { saveCheckpoint, loadCheckpoint, clearCheckpoint } from './github-import/checkpoint.js'
 import { deduplicateSkills } from './github-import/deduplication.js'
+import { loadBlocklist } from './github-import/blocklist.js'
 import { saveOutput } from './github-import/output.js'
+
+// SMI-4408: blocklist file path — mirror the OUTPUT_PATH env-override pattern
+// so the importer can be pointed at a non-default blocklist in CI/test runs.
+const BLOCKLIST_PATH = process.env.INDEXER_BLOCKLIST_PATH || './data/indexer-blocklist.json'
 
 async function main(): Promise<void> {
   const startTime = Date.now()
@@ -56,6 +61,8 @@ async function main(): Promise<void> {
     total_found: 0,
     total_imported: 0,
     duplicates_removed: 0,
+    blocked_count: 0,
+    blocked_repos: [],
     queries_completed: [],
     errors: [],
     started_at: new Date().toISOString(),
@@ -68,6 +75,10 @@ async function main(): Promise<void> {
     if (checkpoint) {
       allSkills = checkpoint.skills
       stats = checkpoint.stats
+      // SMI-4408: backfill new stats fields if resuming from a pre-SMI-4408
+      // checkpoint (JSON load casts to Checkpoint but old files lack fields).
+      if (typeof stats.blocked_count !== 'number') stats.blocked_count = 0
+      if (!Array.isArray(stats.blocked_repos)) stats.blocked_repos = []
       const lastQueryIndex = SEARCH_QUERIES.findIndex((q) => q.name === checkpoint.last_query)
       if (lastQueryIndex >= 0) {
         startQueryIndex = lastQueryIndex
@@ -142,16 +153,41 @@ async function main(): Promise<void> {
   log('Deduplicating results...')
   const { unique, duplicateCount } = deduplicateSkills(allSkills)
   stats.duplicates_removed = duplicateCount
-  stats.total_imported = unique.length
   log(`Removed ${duplicateCount} duplicates`)
-  log(`Final count: ${unique.length} unique skills`)
+  log(`Post-dedup count: ${unique.length} unique skills`)
+  console.log()
+
+  // SMI-4408: Apply indexer blocklist — filters known non-skill repos
+  // before they reach data/imported-skills.json. Exact owner/name match.
+  log('Applying indexer blocklist...')
+  const blocklist = loadBlocklist(BLOCKLIST_PATH)
+  const filtered: ImportedSkill[] = []
+  const blockedRepos: string[] = []
+  for (const skill of unique) {
+    const repoKey = `${skill.author}/${skill.name}`
+    if (blocklist.isBlocked(repoKey)) {
+      blockedRepos.push(repoKey)
+    } else {
+      filtered.push(skill)
+    }
+  }
+  stats.blocked_count = blockedRepos.length
+  stats.blocked_repos = blockedRepos
+  stats.total_imported = filtered.length
+  log(`Blocked ${blockedRepos.length} non-skill repo(s)`)
+  if (blockedRepos.length > 0) {
+    for (const repo of blockedRepos) {
+      log(`  - ${repo}`)
+    }
+  }
+  log(`Final count: ${filtered.length} skills`)
   console.log()
 
   stats.completed_at = new Date().toISOString()
   stats.duration_ms = Date.now() - startTime
 
   log('Saving output...')
-  saveOutput(unique, stats)
+  saveOutput(filtered, stats)
   clearCheckpoint()
 
   console.log()
@@ -160,6 +196,7 @@ async function main(): Promise<void> {
   console.log('======================================================================')
   console.log(`  Total Found:        ${stats.total_found}`)
   console.log(`  Duplicates Removed: ${stats.duplicates_removed}`)
+  console.log(`  Blocked (SMI-4408): ${stats.blocked_count}`)
   console.log(`  Total Imported:     ${stats.total_imported}`)
   console.log(`  Duration:           ${(stats.duration_ms! / 1000).toFixed(2)}s`)
   console.log(`  Queries Completed:  ${stats.queries_completed.join(', ')}`)

--- a/packages/core/tests/github-import/blocklist.test.ts
+++ b/packages/core/tests/github-import/blocklist.test.ts
@@ -1,0 +1,242 @@
+/**
+ * SMI-4408: Indexer blocklist tests.
+ *
+ * Covers:
+ *  - Exact-match blocking (owner/name, case-sensitive)
+ *  - Non-blocklisted repos pass through
+ *  - Empty/missing blocklist file returns EMPTY_BLOCKLIST (no-op)
+ *  - Schema validation: version=1, required fields, valid repo format, valid dates
+ *  - Duplicate entries rejected at load
+ *  - Malformed JSON rejected at load
+ *  - Ship-it sanity check: data/indexer-blocklist.json parses and contains
+ *    the 2 known-bad entries from SMI-4396 Wave 2 residuals.
+ */
+
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import {
+  buildBlocklist,
+  EMPTY_BLOCKLIST,
+  loadBlocklist,
+  parseBlocklistFile,
+} from '../../src/scripts/github-import/blocklist.js'
+import type { BlocklistEntry } from '../../src/scripts/github-import/blocklist.js'
+
+const VALID_ENTRY: BlocklistEntry = {
+  repo: 'vinayaksavle/UploadDownloadPDF',
+  reason: 'ASP.NET MVC tutorial, not a Claude skill',
+  addedBy: 'ryansmith108',
+  addedAt: '2026-04-21',
+}
+
+// ------------------------ matcher behavior ------------------------
+
+describe('BlocklistMatcher (SMI-4408)', () => {
+  it('blocks exact-match owner/name (case-sensitive)', () => {
+    const matcher = buildBlocklist([VALID_ENTRY])
+    expect(matcher.isBlocked('vinayaksavle/UploadDownloadPDF')).toBe(true)
+  })
+
+  it('does not block case-mismatched repo (exact match)', () => {
+    const matcher = buildBlocklist([VALID_ENTRY])
+    expect(matcher.isBlocked('vinayaksavle/uploaddownloadpdf')).toBe(false)
+    expect(matcher.isBlocked('Vinayaksavle/UploadDownloadPDF')).toBe(false)
+  })
+
+  it('does not block non-blocklisted repos', () => {
+    const matcher = buildBlocklist([VALID_ENTRY])
+    expect(matcher.isBlocked('anthropics/skills')).toBe(false)
+    expect(matcher.isBlocked('smith-horn/skill-image-pipeline')).toBe(false)
+  })
+
+  it('does not match partial strings (substring not allowed)', () => {
+    const matcher = buildBlocklist([VALID_ENTRY])
+    expect(matcher.isBlocked('vinayaksavle/UploadDownloadPDF-extra')).toBe(false)
+    expect(matcher.isBlocked('other/vinayaksavle/UploadDownloadPDF')).toBe(false)
+  })
+
+  it('exposes entries() for audit-log output', () => {
+    const matcher = buildBlocklist([VALID_ENTRY])
+    const entries = matcher.entries()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toEqual(VALID_ENTRY)
+  })
+
+  it('EMPTY_BLOCKLIST blocks nothing', () => {
+    expect(EMPTY_BLOCKLIST.isBlocked('anything/at-all')).toBe(false)
+    expect(EMPTY_BLOCKLIST.entries()).toEqual([])
+  })
+})
+
+// ------------------------ schema validation ------------------------
+
+describe('parseBlocklistFile (SMI-4408)', () => {
+  const validFile = {
+    version: 1,
+    updatedAt: '2026-04-21',
+    blocked: [VALID_ENTRY],
+  }
+
+  it('parses a valid file', () => {
+    const result = parseBlocklistFile(validFile)
+    expect(result.version).toBe(1)
+    expect(result.updatedAt).toBe('2026-04-21')
+    expect(result.blocked).toHaveLength(1)
+    expect(result.blocked[0]).toEqual(VALID_ENTRY)
+  })
+
+  it('rejects non-object root', () => {
+    expect(() => parseBlocklistFile(null)).toThrow(/must be an object/i)
+    expect(() => parseBlocklistFile('string')).toThrow(/must be an object/i)
+    // Arrays pass typeof === 'object' but fail on missing `version` field.
+    expect(() => parseBlocklistFile([])).toThrow(/unsupported blocklist file version/i)
+  })
+
+  it('rejects unsupported version', () => {
+    expect(() => parseBlocklistFile({ ...validFile, version: 2 })).toThrow(
+      /unsupported blocklist file version/i
+    )
+    expect(() => parseBlocklistFile({ ...validFile, version: 0 })).toThrow(
+      /unsupported blocklist file version/i
+    )
+  })
+
+  it('rejects invalid updatedAt', () => {
+    expect(() => parseBlocklistFile({ ...validFile, updatedAt: '04/21/2026' })).toThrow(
+      /updatedAt must be YYYY-MM-DD/i
+    )
+    expect(() => parseBlocklistFile({ ...validFile, updatedAt: 42 })).toThrow(
+      /updatedAt must be YYYY-MM-DD/i
+    )
+  })
+
+  it('rejects blocked field when not an array', () => {
+    expect(() => parseBlocklistFile({ ...validFile, blocked: {} })).toThrow(
+      /blocked must be an array/i
+    )
+  })
+
+  it('rejects entry with missing required field', () => {
+    for (const field of ['repo', 'reason', 'addedBy', 'addedAt']) {
+      const badEntry = { ...VALID_ENTRY } as Record<string, unknown>
+      delete badEntry[field]
+      expect(() => parseBlocklistFile({ ...validFile, blocked: [badEntry] })).toThrow(
+        new RegExp(`missing or empty required field: ${field}`, 'i')
+      )
+    }
+  })
+
+  it('rejects entry with empty required field', () => {
+    expect(() =>
+      parseBlocklistFile({ ...validFile, blocked: [{ ...VALID_ENTRY, reason: '' }] })
+    ).toThrow(/missing or empty required field: reason/i)
+  })
+
+  it('rejects malformed repo string', () => {
+    const bad = ['no-slash', '/leading', 'trailing/', 'too/many/slashes', 'has spaces/ok']
+    for (const repo of bad) {
+      expect(() =>
+        parseBlocklistFile({ ...validFile, blocked: [{ ...VALID_ENTRY, repo }] })
+      ).toThrow(/repo must be 'owner\/name'/i)
+    }
+  })
+
+  it('accepts GitHub-valid repo names with common punctuation', () => {
+    const good = ['foo/bar', 'foo-bar/baz.qux', 'Foo123/Bar_v2', 'org.name/repo-name']
+    for (const repo of good) {
+      expect(() =>
+        parseBlocklistFile({ ...validFile, blocked: [{ ...VALID_ENTRY, repo }] })
+      ).not.toThrow()
+    }
+  })
+
+  it('rejects invalid addedAt format', () => {
+    expect(() =>
+      parseBlocklistFile({ ...validFile, blocked: [{ ...VALID_ENTRY, addedAt: 'yesterday' }] })
+    ).toThrow(/addedAt must be YYYY-MM-DD/i)
+  })
+
+  it('rejects duplicate repo entries', () => {
+    expect(() =>
+      parseBlocklistFile({
+        ...validFile,
+        blocked: [VALID_ENTRY, { ...VALID_ENTRY, addedAt: '2026-04-22' }],
+      })
+    ).toThrow(/duplicate entry: vinayaksavle\/UploadDownloadPDF/i)
+  })
+
+  it('non-object entry rejected with index', () => {
+    expect(() =>
+      parseBlocklistFile({ ...validFile, blocked: [VALID_ENTRY, 'string-entry'] })
+    ).toThrow(/entry #1 is not an object/i)
+  })
+})
+
+// ------------------------ loadBlocklist ------------------------
+
+describe('loadBlocklist (SMI-4408)', () => {
+  it('returns EMPTY_BLOCKLIST when file is absent', () => {
+    const tmp = path.join(os.tmpdir(), `blocklist-absent-${Date.now()}.json`)
+    const matcher = loadBlocklist(tmp)
+    expect(matcher).toBe(EMPTY_BLOCKLIST)
+    expect(matcher.isBlocked('anything/at-all')).toBe(false)
+  })
+
+  it('throws on malformed JSON', () => {
+    const tmp = path.join(os.tmpdir(), `blocklist-malformed-${Date.now()}.json`)
+    fs.writeFileSync(tmp, '{ not valid json')
+    try {
+      expect(() => loadBlocklist(tmp)).toThrow(/is not valid JSON/i)
+    } finally {
+      fs.unlinkSync(tmp)
+    }
+  })
+
+  it('throws on invalid schema', () => {
+    const tmp = path.join(os.tmpdir(), `blocklist-invalid-${Date.now()}.json`)
+    fs.writeFileSync(tmp, JSON.stringify({ version: 2, updatedAt: '2026-04-21', blocked: [] }))
+    try {
+      expect(() => loadBlocklist(tmp)).toThrow(/unsupported blocklist file version/i)
+    } finally {
+      fs.unlinkSync(tmp)
+    }
+  })
+
+  it('loads a valid file', () => {
+    const tmp = path.join(os.tmpdir(), `blocklist-valid-${Date.now()}.json`)
+    fs.writeFileSync(
+      tmp,
+      JSON.stringify({
+        version: 1,
+        updatedAt: '2026-04-21',
+        blocked: [VALID_ENTRY],
+      })
+    )
+    try {
+      const matcher = loadBlocklist(tmp)
+      expect(matcher.isBlocked('vinayaksavle/UploadDownloadPDF')).toBe(true)
+      expect(matcher.isBlocked('anthropics/skills')).toBe(false)
+    } finally {
+      fs.unlinkSync(tmp)
+    }
+  })
+})
+
+// ------------------------ ship-it sanity ------------------------
+
+describe('data/indexer-blocklist.json (ship-it sanity)', () => {
+  it('is parseable and contains the 2 SMI-4396 Wave 2 residuals', () => {
+    const filePath = path.resolve(__dirname, '../../../../data/indexer-blocklist.json')
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+    const parsed = parseBlocklistFile(raw)
+    expect(parsed.blocked.length).toBe(2)
+    const repos = parsed.blocked.map((e) => e.repo).sort()
+    expect(repos).toEqual(['Sfedfcv/redesigned-pancake', 'vinayaksavle/UploadDownloadPDF'].sort())
+    // Each entry must carry a reason for audit trail.
+    expect(parsed.blocked.every((e) => e.reason.length > 0)).toBe(true)
+    expect(parsed.blocked.every((e) => e.addedBy.length > 0)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Tactical fix for the 2 non-skill repos surfaced as post-Wave-2 residuals by the SMI-4396 imported-skills security scan:

- `vinayaksavle/UploadDownloadPDF` — ASP.NET MVC tutorial (C#), triggers `data_exfiltration: upload` pattern via `multipart/form-data` in its README
- `Sfedfcv/redesigned-pancake` — GitHub docs-repo mirror, misnamed

The scanner is working correctly — both legitimately contain the flagged patterns — but the indexer shouldn't ingest them in the first place. This PR filters them at the source before `data/imported-skills.json` is written.

## Why

Scanner-tuning (SMI-4396 Waves 1+2) cleared 24/26 quarantines. The remaining 2 are structural: non-skill repos that the broad GitHub keyword/topic search accepts. Tightening patterns any further risks missing real attacks. Filtering at ingest is the correct layer.

## Design

- New `data/indexer-blocklist.json` (v1, 2 entries, schema-validated at load, per-entry `reason` + `addedBy` + `addedAt`)
- New `packages/core/src/scripts/github-import/blocklist.ts` — loader, `SetBackedMatcher`, `EMPTY_BLOCKLIST`, `parseBlocklistFile`, `buildBlocklist`. Exact-match only (owner/name, case-sensitive); no wildcards.
- Wired in `import-github-skills.ts` between `deduplicateSkills()` and `saveOutput()`. Env override `INDEXER_BLOCKLIST_PATH` for test runs.
- Stats includes `blocked_count` + `blocked_repos` for audit trail (summary + ImportStats).
- Checkpoint resume backfills new stats fields if loading from a pre-SMI-4408 run.
- Parent `/data/*` stays excluded; `.gitignore` negates `data/indexer-blocklist.json` + keeps the existing `data/skills-security-allowlist.json` negation.

## Out of scope

Structural signal-of-intent filter (require SKILL.md at root / `claude-skill` topic tag / `.claude/` directory) — tracked as Tier 2 follow-up under ADR-109 SPARC. This PR is the narrow tactical fix.

## Test plan

- [x] 23/23 blocklist tests pass (exact-match, case-sensitivity, substring rejection, schema validation, malformed JSON, duplicates, ship-it sanity)
- [x] Typecheck clean across packages/core
- [x] Pre-commit hooks clean (lint, prettier, check-file-length)
- [x] Pre-push hook clean
- [ ] CI merge-queue green
- [ ] Post-merge verification: `jq '.count' quarantine-skills.json` expected 0

## Post-merge verification

```bash
gh workflow run weekly-security-scan.yml -f create_issue=true
gh run watch $(gh run list --workflow=weekly-security-scan.yml --limit=1 --json databaseId --jq '.[0].databaseId')
gh run download $(gh run list --workflow=weekly-security-scan.yml --limit=1 --json databaseId --jq '.[0].databaseId') -n quarantine-skills -D /tmp/smi4408
jq '.count' /tmp/smi4408/quarantine-skills.json  # expect 0
```

Closes SMI-4408.
Parent: SMI-4396.
Follow-up to PR #708 (Wave 2).

Generated with [Ruflo](https://github.com/ruvnet/ruflo)