### PR TITLE
feat(web): SMI-4401 Wave 2 — free-tier profile completion UX (stacked on Wave 1)

### DIFF
--- a/packages/website/src/components/SignedOutOverlay.astro
+++ b/packages/website/src/components/SignedOutOverlay.astro
@@ -1,0 +1,168 @@
+---
+/**
+ * SignedOutOverlay
+ *
+ * SMI-4401 Wave 2 — Soft sign-in overlay for anonymous humans on /skills (spec §5.5).
+ *
+ * Rendering policy:
+ * - SSR frontmatter in the caller MUST gate this component with
+ *   `{!isCrawler && <SignedOutOverlay />}` (L7). Crawlers never receive the markup.
+ * - Client-side, the overlay removes itself from DOM when a Supabase session is
+ *   detected (not just hidden — DOM removal unblocks tab-nav a11y).
+ * - A dismiss CTA writes `localStorage['skills_overlay_dismissed_until']` with a
+ *   7-day ISO expiry (M7). On page load, an expired value is swept and the overlay
+ *   is rendered; a live value suppresses render for this user.
+ *
+ * A11y:
+ * - role="dialog" + aria-modal="false" — INTENTIONAL. This is a soft, dismissible
+ *   overlay (spec §5.5 "soft overlay, dismissible for preview"). Setting aria-modal="true"
+ *   with a focus trap would contradict the Preview UX: anon humans (including screen-reader
+ *   users) are meant to browse the catalog below the blur while the sign-in CTA stays
+ *   visible as a persistent prompt. A focus trap would force dismissal before any content
+ *   interaction — harsher than the spec asks for.
+ * - aria-label="Sign in to continue"
+ * - dismiss button exposes aria-label="Preview skills without signing in"
+ */
+
+import LoginButton from './auth/LoginButton.astro'
+---
+
+<div
+  id="signed-out-overlay"
+  class="signed-out-overlay"
+  role="dialog"
+  aria-modal="false"
+  aria-label="Sign in to continue"
+  data-hidden-when-auth="true"
+>
+  <div class="overlay-card">
+    <h2 class="overlay-heading">Sign in to browse the full catalog</h2>
+    <p class="overlay-copy">
+      Create a free Skillsmith account for 1,000 installs per month. No card required.
+    </p>
+    <div class="overlay-actions">
+      <LoginButton variant="primary" size="md" redirectTo="/skills" />
+      <button
+        type="button"
+        id="overlay-dismiss"
+        class="overlay-dismiss"
+        aria-label="Preview skills without signing in"
+      >
+        Preview anonymously &rarr;
+      </button>
+    </div>
+  </div>
+</div>
+
+<script is:inline>
+  ;(function () {
+    var DISMISS_KEY = 'skills_overlay_dismissed_until'
+    var overlay = document.getElementById('signed-out-overlay')
+    if (!overlay) return
+
+    // On load: if a non-expired dismissal exists, remove the overlay; otherwise sweep a stale key.
+    try {
+      var storedUntil = localStorage.getItem(DISMISS_KEY)
+      if (storedUntil) {
+        var untilMs = Date.parse(storedUntil)
+        if (!isNaN(untilMs) && untilMs > Date.now()) {
+          overlay.remove()
+          return
+        }
+        localStorage.removeItem(DISMISS_KEY)
+      }
+    } catch (_e) {
+      /* localStorage unavailable (private mode, policy) — fall through to visible render */
+    }
+
+    // Dismiss handler: write 7-day expiry then remove overlay from DOM.
+    var dismissBtn = document.getElementById('overlay-dismiss')
+    if (dismissBtn) {
+      dismissBtn.addEventListener('click', function () {
+        try {
+          var sevenDays = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+          localStorage.setItem(DISMISS_KEY, sevenDays)
+        } catch (_e) {
+          /* no-op: dismiss still works for this session */
+        }
+        overlay.remove()
+      })
+    }
+  })()
+</script>
+
+<style>
+  .signed-out-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    background: rgba(13, 13, 15, 0.72);
+    backdrop-filter: blur(3px);
+    -webkit-backdrop-filter: blur(3px);
+  }
+
+  .overlay-card {
+    max-width: 28rem;
+    width: 100%;
+    padding: 2rem;
+    background: #121214;
+    border: 1px solid #2a2a2f;
+    border-radius: 0.75rem;
+    box-shadow: 0 20px 50px -20px rgba(0, 0, 0, 0.6);
+    text-align: center;
+  }
+
+  .overlay-heading {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #fafafa;
+    margin: 0 0 0.75rem;
+    line-height: 1.3;
+  }
+
+  .overlay-copy {
+    font-size: 0.9375rem;
+    color: #a1a1aa;
+    margin: 0 0 1.5rem;
+    line-height: 1.5;
+  }
+
+  .overlay-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: stretch;
+  }
+
+  .overlay-dismiss {
+    background: transparent;
+    color: #a1a1aa;
+    border: none;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+    font-family: inherit;
+    cursor: pointer;
+    border-radius: 0.375rem;
+    transition: color 0.15s;
+  }
+
+  .overlay-dismiss:hover {
+    color: #fafafa;
+  }
+
+  .overlay-dismiss:focus-visible {
+    outline: 2px solid #e07a5f;
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .signed-out-overlay {
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+  }
+</style>

--- a/packages/website/src/lib/complete-profile-copy.ts
+++ b/packages/website/src/lib/complete-profile-copy.ts
@@ -1,0 +1,119 @@
+/**
+ * complete-profile-copy.ts
+ *
+ * SMI-4401 Wave 2 — Copy matrix + name-validation helpers for /complete-profile.astro.
+ * Extracted per spec §5.1 "If /complete-profile grows past 450, split copy blocks into
+ * a companion complete-profile-copy.ts module."
+ *
+ * Keep this module free of Astro / DOM imports so it remains pure-TS and testable.
+ */
+
+/** Context parsed from the page URL (via the injected __COMPLETE_PROFILE_CONTEXT__ bridge). */
+export interface CompleteProfileContext {
+  /** `'cli'` when the CLI originated the redirect; empty string otherwise. */
+  source: string
+  /** Raw (untrusted) `next` query-param value; validate via validateNextParam before redirecting. */
+  next: string
+}
+
+/** Base-copy constants that do NOT vary by context. */
+export const COPY = {
+  heading: 'Almost there — tell us who you are.',
+  submitLabel: 'Activate free access',
+  submittingLabel: 'Activating…',
+  fineprint: 'You’ll get 1,000 free API calls per month. No card required.',
+  legalPrefix: 'We use this for your CLI identity only.',
+  legalLinkText: 'Privacy policy →',
+  legalLinkHref: '/privacy',
+  githubHelper: 'We grabbed this from your GitHub. Edit if wrong.',
+  toastSuccess: 'Free tier activated',
+  errorGeneric:
+    'Something went wrong saving your profile. Retry in a moment, or <a href="/contact?topic=signup-help" class="profile-link">contact us</a>.',
+  errorProfileLoad:
+    'We could not load your profile. Refresh to try again, or <a href="/contact?topic=signup-help" class="profile-link">contact us</a>.',
+  errorSupabaseInit:
+    'We could not initialize authentication. Please refresh and try again, or <a href="/contact?topic=signup-help" class="profile-link">contact us</a>.',
+  errorSessionLost:
+    'Your session expired. Please <a href="/login" class="profile-link">sign in again</a>.',
+  errorKeyIssuance:
+    'We saved your profile but could not issue your CLI key. Retry in a moment, or <a href="/contact?topic=signup-help" class="profile-link">contact us</a>.',
+  errorConcurrent:
+    'Your key is still being issued. Refresh in a few seconds, or <a href="/contact?topic=signup-help" class="profile-link">contact us</a>.',
+  errorProfileIncomplete:
+    'We saw your profile as incomplete. Please check the fields above and resubmit.',
+  errorUnexpected:
+    'Something unexpected happened. Retry in a moment, or <a href="/contact?topic=signup-help" class="profile-link">contact us</a>.',
+} as const
+
+/**
+ * Map a validated same-origin path to friendly prose for the "one more step" subhead.
+ * Falls back to the bare pathname for unrecognized targets.
+ */
+export function humanizePath(path: string): string {
+  // Strip query and fragment. `split()` always yields at least one element; `?? ''` keeps TS happy
+  // under noUncheckedIndexedAccess.
+  const beforeQuery = path.split('?')[0] ?? ''
+  const cleaned = beforeQuery.split('#')[0] ?? ''
+  switch (cleaned) {
+    case '/account/cli-token':
+      return 'your CLI token'
+    case '/account':
+      return 'your dashboard'
+    case '/skills':
+      return 'the skills catalog'
+    case '/return-to-cli':
+      return 'your terminal'
+    default:
+      return cleaned.replace(/^\//, '') || 'the next step'
+  }
+}
+
+/**
+ * Wave 1 SQL-parity name validator (spec §5.1 M2).
+ * Returns a human-readable error message, or `null` if the name passes.
+ *
+ * Rules (exactly matching Wave 1 SQL gate `valid_name(x)`):
+ *   - min 2 characters after trimming
+ *   - max 64 characters after trimming
+ *   - at least one letter `/[A-Za-z]/`
+ *
+ * DROP: "no sequential (aa, ab)" and "no repeat (xxx)" rules — do not client-reject names
+ * Wave 1 SQL accepts.
+ */
+export function validateName(value: string): string | null {
+  const trimmed = value.trim()
+  if (trimmed.length < 2) return 'Please enter at least 2 characters.'
+  if (trimmed.length > 64) return 'Please keep this under 64 characters.'
+  if (!/[A-Za-z]/.test(trimmed)) return 'Please include at least one letter.'
+  return null
+}
+
+/**
+ * Subhead copy resolution (precedence per spec §5.1 H6):
+ *   1. source=cli wins over a bare next
+ *   2. else bare next resolves via humanizePath
+ *   3. else the no-params default
+ *
+ * Returns an object with either `.text` (plain) or `.html` (safe, curated markup).
+ */
+export interface SubheadCopy {
+  /** Plain-text variant (source=cli). */
+  text?: string
+  /** Curated HTML variant (safe — produced from a small allowlist of known paths). */
+  html?: string
+}
+
+export function resolveSubhead(ctx: CompleteProfileContext, validatedNext: string): SubheadCopy {
+  if (ctx.source === 'cli') {
+    return { text: 'Almost there — re-run your terminal command after this.' }
+  }
+  if (ctx.next && ctx.next.length > 0) {
+    return {
+      html: `One more step before we take you to <strong>${humanizePath(validatedNext)}</strong>.`,
+    }
+  }
+  return {
+    html:
+      'Takes 30 seconds. <a href="/privacy" class="profile-link">We use this for your CLI identity only.</a>',
+  }
+}

--- a/packages/website/src/lib/complete-profile-copy.ts
+++ b/packages/website/src/lib/complete-profile-copy.ts
@@ -113,7 +113,6 @@ export function resolveSubhead(ctx: CompleteProfileContext, validatedNext: strin
     }
   }
   return {
-    html:
-      'Takes 30 seconds. <a href="/privacy" class="profile-link">We use this for your CLI identity only.</a>',
+    html: 'Takes 30 seconds. <a href="/privacy" class="profile-link">We use this for your CLI identity only.</a>',
   }
 }

--- a/packages/website/src/lib/crawler-detect.test.ts
+++ b/packages/website/src/lib/crawler-detect.test.ts
@@ -1,0 +1,156 @@
+/**
+ * crawler-detect.test.ts
+ *
+ * SMI-4401 Wave 2 — unit coverage for the crawler UA matcher used by the
+ * `/skills` SSR branch (spec §4.1 A-SEO-2, §5.5 Path 1).
+ *
+ * The matcher must:
+ *   - Positively match every UA listed in spec §4.1 A-SEO-2.
+ *   - Negatively match representative human browsers (desktop + mobile).
+ *   - Treat empty / null / undefined as non-crawler.
+ *   - Be case-insensitive.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { isCrawlerUserAgent } from './crawler-detect'
+
+describe('isCrawlerUserAgent — positive matches (spec §4.1 A-SEO-2)', () => {
+  it('matches Googlebot/2.1 canonical desktop string', () => {
+    expect(
+      isCrawlerUserAgent('Googlebot/2.1 (+http://www.google.com/bot.html)'),
+    ).toBe(true)
+  })
+
+  it('matches Googlebot-Image/1.0', () => {
+    expect(isCrawlerUserAgent('Googlebot-Image/1.0')).toBe(true)
+  })
+
+  it('matches Googlebot-News', () => {
+    expect(isCrawlerUserAgent('Googlebot-News')).toBe(true)
+  })
+
+  it('matches Googlebot-Video', () => {
+    expect(isCrawlerUserAgent('Googlebot-Video/1.0')).toBe(true)
+  })
+
+  it('matches AdsBot-Google (spec list)', () => {
+    expect(
+      isCrawlerUserAgent('AdsBot-Google (+http://www.google.com/adsbot.html)'),
+    ).toBe(true)
+  })
+
+  it('matches Bingbot/2.0', () => {
+    expect(
+      isCrawlerUserAgent('Mozilla/5.0 (compatible; Bingbot/2.0; +http://www.bing.com/bingbot.htm)'),
+    ).toBe(true)
+  })
+
+  it('matches DuckDuckBot/1.0', () => {
+    expect(isCrawlerUserAgent('DuckDuckBot/1.0; (+http://duckduckgo.com/duckduckbot.html)')).toBe(
+      true,
+    )
+  })
+
+  it('matches Yahoo Slurp', () => {
+    expect(
+      isCrawlerUserAgent('Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)'),
+    ).toBe(true)
+  })
+
+  it('matches facebookexternalhit/1.1', () => {
+    expect(
+      isCrawlerUserAgent('facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'),
+    ).toBe(true)
+  })
+
+  it('matches Twitterbot/1.0', () => {
+    expect(isCrawlerUserAgent('Twitterbot/1.0')).toBe(true)
+  })
+
+  it('matches LinkedInBot/1.0', () => {
+    expect(
+      isCrawlerUserAgent(
+        'LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)',
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('isCrawlerUserAgent — case insensitivity', () => {
+  it('matches lowercase googlebot/2.1', () => {
+    // Regex uses `/i` flag — lowercase, uppercase, mixed-case all match.
+    expect(isCrawlerUserAgent('googlebot/2.1 (+http://www.google.com/bot.html)')).toBe(true)
+  })
+
+  it('matches UPPERCASE GOOGLEBOT', () => {
+    expect(isCrawlerUserAgent('GOOGLEBOT/2.1')).toBe(true)
+  })
+
+  it('matches mixed-case bInGbOt', () => {
+    expect(isCrawlerUserAgent('bInGbOt/2.0')).toBe(true)
+  })
+})
+
+describe('isCrawlerUserAgent — negative matches (human browsers)', () => {
+  it('does not match macOS Safari 16.1', () => {
+    expect(
+      isCrawlerUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
+      ),
+    ).toBe(false)
+  })
+
+  it('does not match desktop Chrome', () => {
+    expect(
+      isCrawlerUserAgent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+      ),
+    ).toBe(false)
+  })
+
+  it('does not match desktop Firefox', () => {
+    expect(
+      isCrawlerUserAgent(
+        'Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0',
+      ),
+    ).toBe(false)
+  })
+
+  it('does not match iPhone Safari', () => {
+    expect(
+      isCrawlerUserAgent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
+      ),
+    ).toBe(false)
+  })
+
+  it('does not match Android Chrome', () => {
+    expect(
+      isCrawlerUserAgent(
+        'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36',
+      ),
+    ).toBe(false)
+  })
+
+  it('does not match Edge desktop', () => {
+    expect(
+      isCrawlerUserAgent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0',
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('isCrawlerUserAgent — empty / missing input (non-crawler per contract)', () => {
+  it('does not match an empty string', () => {
+    expect(isCrawlerUserAgent('')).toBe(false)
+  })
+
+  it('does not match null', () => {
+    expect(isCrawlerUserAgent(null)).toBe(false)
+  })
+
+  it('does not match undefined', () => {
+    expect(isCrawlerUserAgent(undefined)).toBe(false)
+  })
+})

--- a/packages/website/src/lib/crawler-detect.test.ts
+++ b/packages/website/src/lib/crawler-detect.test.ts
@@ -16,9 +16,7 @@ import { isCrawlerUserAgent } from './crawler-detect'
 
 describe('isCrawlerUserAgent — positive matches (spec §4.1 A-SEO-2)', () => {
   it('matches Googlebot/2.1 canonical desktop string', () => {
-    expect(
-      isCrawlerUserAgent('Googlebot/2.1 (+http://www.google.com/bot.html)'),
-    ).toBe(true)
+    expect(isCrawlerUserAgent('Googlebot/2.1 (+http://www.google.com/bot.html)')).toBe(true)
   })
 
   it('matches Googlebot-Image/1.0', () => {
@@ -34,32 +32,34 @@ describe('isCrawlerUserAgent — positive matches (spec §4.1 A-SEO-2)', () => {
   })
 
   it('matches AdsBot-Google (spec list)', () => {
-    expect(
-      isCrawlerUserAgent('AdsBot-Google (+http://www.google.com/adsbot.html)'),
-    ).toBe(true)
+    expect(isCrawlerUserAgent('AdsBot-Google (+http://www.google.com/adsbot.html)')).toBe(true)
   })
 
   it('matches Bingbot/2.0', () => {
     expect(
-      isCrawlerUserAgent('Mozilla/5.0 (compatible; Bingbot/2.0; +http://www.bing.com/bingbot.htm)'),
+      isCrawlerUserAgent('Mozilla/5.0 (compatible; Bingbot/2.0; +http://www.bing.com/bingbot.htm)')
     ).toBe(true)
   })
 
   it('matches DuckDuckBot/1.0', () => {
     expect(isCrawlerUserAgent('DuckDuckBot/1.0; (+http://duckduckgo.com/duckduckbot.html)')).toBe(
-      true,
+      true
     )
   })
 
   it('matches Yahoo Slurp', () => {
     expect(
-      isCrawlerUserAgent('Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)'),
+      isCrawlerUserAgent(
+        'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)'
+      )
     ).toBe(true)
   })
 
   it('matches facebookexternalhit/1.1', () => {
     expect(
-      isCrawlerUserAgent('facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'),
+      isCrawlerUserAgent(
+        'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'
+      )
     ).toBe(true)
   })
 
@@ -70,8 +70,8 @@ describe('isCrawlerUserAgent — positive matches (spec §4.1 A-SEO-2)', () => {
   it('matches LinkedInBot/1.0', () => {
     expect(
       isCrawlerUserAgent(
-        'LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)',
-      ),
+        'LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)'
+      )
     ).toBe(true)
   })
 })
@@ -95,48 +95,46 @@ describe('isCrawlerUserAgent — negative matches (human browsers)', () => {
   it('does not match macOS Safari 16.1', () => {
     expect(
       isCrawlerUserAgent(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
-      ),
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15'
+      )
     ).toBe(false)
   })
 
   it('does not match desktop Chrome', () => {
     expect(
       isCrawlerUserAgent(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
-      ),
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+      )
     ).toBe(false)
   })
 
   it('does not match desktop Firefox', () => {
     expect(
-      isCrawlerUserAgent(
-        'Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0',
-      ),
+      isCrawlerUserAgent('Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0')
     ).toBe(false)
   })
 
   it('does not match iPhone Safari', () => {
     expect(
       isCrawlerUserAgent(
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
-      ),
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1'
+      )
     ).toBe(false)
   })
 
   it('does not match Android Chrome', () => {
     expect(
       isCrawlerUserAgent(
-        'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36',
-      ),
+        'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36'
+      )
     ).toBe(false)
   })
 
   it('does not match Edge desktop', () => {
     expect(
       isCrawlerUserAgent(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0',
-      ),
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0'
+      )
     ).toBe(false)
   })
 })

--- a/packages/website/src/lib/crawler-detect.ts
+++ b/packages/website/src/lib/crawler-detect.ts
@@ -1,0 +1,27 @@
+/**
+ * crawler-detect.ts
+ *
+ * SMI-4401 Wave 2 — Search-engine / social-preview user-agent detection.
+ *
+ * Used by SSR branches that must preserve full HTML + JSON-LD for crawlers while
+ * showing a soft sign-in overlay to anonymous humans (spec §4.1, §5.5).
+ *
+ * Regex list sourced from the canonical Wave 2 spec §4.1 A-SEO-2 and the parent plan's
+ * crawler-aware gating block. Matches are case-insensitive.
+ *
+ * Sub-bot behavior (Googlebot-Image, Googlebot-News, Googlebot-Video, AdsBot-Google) is
+ * treated identically to the parent Googlebot for Wave 2. Differentiated handling is
+ * tracked in SMI-4413 (post-Wave-2 investigation).
+ */
+
+const CRAWLER_REGEX =
+  /Googlebot|Googlebot-Image|Googlebot-News|Googlebot-Video|AdsBot-Google|Bingbot|DuckDuckBot|Slurp|facebookexternalhit|Twitterbot|LinkedInBot/i
+
+/**
+ * Returns true when the given user-agent string matches a known search-engine or
+ * social-media crawler. Empty / null / undefined input is treated as non-crawler.
+ */
+export function isCrawlerUserAgent(ua: string | null | undefined): boolean {
+  if (typeof ua !== 'string' || ua.length === 0) return false
+  return CRAWLER_REGEX.test(ua)
+}

--- a/packages/website/src/lib/validate-next-redirect.test.ts
+++ b/packages/website/src/lib/validate-next-redirect.test.ts
@@ -84,7 +84,7 @@ describe('validateNextParam — OWASP rejection class (c) dangerous schemes', ()
 
   it('rejects data:text/html,<script>... → default', () => {
     expect(validateNextParam('data:text/html,<script>alert(1)</script>', null)).toBe(
-      NON_CLI_DEFAULT,
+      NON_CLI_DEFAULT
     )
   })
 
@@ -162,13 +162,13 @@ describe('validateNextParam — empty / missing input', () => {
 describe('validateNextParam — /device user_code passthrough (H2)', () => {
   it('preserves user_code on /device?user_code=BCDF-GHJK', () => {
     expect(validateNextParam('/device?user_code=BCDF-GHJK', 'cli')).toBe(
-      '/device?user_code=BCDF-GHJK',
+      '/device?user_code=BCDF-GHJK'
     )
   })
 
   it('preserves user_code without source hint too (validator is source-agnostic for /device)', () => {
     expect(validateNextParam('/device?user_code=BCDF-GHJK', null)).toBe(
-      '/device?user_code=BCDF-GHJK',
+      '/device?user_code=BCDF-GHJK'
     )
   })
 

--- a/packages/website/src/lib/validate-next-redirect.test.ts
+++ b/packages/website/src/lib/validate-next-redirect.test.ts
@@ -1,0 +1,280 @@
+/**
+ * validate-next-redirect.test.ts
+ *
+ * SMI-4401 Wave 2 — unit coverage for the OWASP `next=` redirect validator
+ * defined in `validate-next-redirect.ts`. Spec §4.4 A-NEXT-1/2/3 + §5.1 H6
+ * precedence cross-product.
+ *
+ * Acceptance requirements driving this suite:
+ *   - 20+ assertions covering every OWASP rejection class (a-e)
+ *   - `/device?user_code=...` passthrough preserved ONLY on `/device` (H2)
+ *   - Source-aware defaults: `source='cli'` → `/return-to-cli`,
+ *     else → `/account/cli-token` (A-NEXT-2)
+ *   - Precedence cross-product (H6 post-Option-A): 3 branches
+ *
+ * These tests encode the public contract of `validateNextParam`; they should
+ * stay green across refactors of the internal helpers. Worker 1 builds the
+ * helper in parallel — until that implementation lands and is wired up with
+ * the expected defaults, a subset of these assertions will fail. That is
+ * intentional: the spec contract is the source of truth.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { validateNextParam } from './validate-next-redirect'
+
+// Defaults per spec §4.4 A-NEXT-2. Centralized so a default-move shows up as
+// a single assertion edit instead of 20 scattered string updates.
+const CLI_DEFAULT = '/return-to-cli'
+const NON_CLI_DEFAULT = '/account/cli-token'
+
+describe('validateNextParam — happy paths (same-origin absolute paths)', () => {
+  it('accepts a bare absolute path', () => {
+    expect(validateNextParam('/foo', null)).toBe('/foo')
+  })
+
+  it('accepts a nested absolute path', () => {
+    expect(validateNextParam('/account/cli-token', null)).toBe('/account/cli-token')
+  })
+
+  it('strips unknown query params on non-/device paths (H2 default)', () => {
+    // Any query string on a non-/device path is stripped to eliminate
+    // open-redirect-via-encoded-path-traversal.
+    expect(validateNextParam('/foo?x=1', null)).toBe('/foo')
+  })
+
+  it('strips a hash fragment on non-/device paths', () => {
+    expect(validateNextParam('/foo#bar', null)).toBe('/foo')
+  })
+
+  it('accepts a single "/" as a safe path', () => {
+    expect(validateNextParam('/', null)).toBe('/')
+  })
+})
+
+describe('validateNextParam — OWASP rejection class (a) absolute cross-origin', () => {
+  it('rejects https://evil.com/x → default', () => {
+    expect(validateNextParam('https://evil.com/x', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects http://evil.com/x → default', () => {
+    expect(validateNextParam('http://evil.com/x', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects a uppercase-scheme variant HTTPS://evil.com → default (case-insensitive scheme check)', () => {
+    expect(validateNextParam('HTTPS://evil.com/x', null)).toBe(NON_CLI_DEFAULT)
+  })
+})
+
+describe('validateNextParam — OWASP rejection class (b) protocol-relative', () => {
+  it('rejects //evil.com/x → default', () => {
+    expect(validateNextParam('//evil.com/x', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects ///evil.com/x (triple-slash variant) → default', () => {
+    // Browsers normalize triple-slash to protocol-relative-like behavior;
+    // the URL constructor rebases, but defense-in-depth rejects the prefix.
+    expect(validateNextParam('///evil.com/x', null)).toBe(NON_CLI_DEFAULT)
+  })
+})
+
+describe('validateNextParam — OWASP rejection class (c) dangerous schemes', () => {
+  it('rejects javascript:alert(1) → default', () => {
+    expect(validateNextParam('javascript:alert(1)', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects data:text/html,<script>... → default', () => {
+    expect(validateNextParam('data:text/html,<script>alert(1)</script>', null)).toBe(
+      NON_CLI_DEFAULT,
+    )
+  })
+
+  it('rejects vbscript:msgbox(1) → default', () => {
+    expect(validateNextParam('vbscript:msgbox(1)', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects file:///etc/passwd → default', () => {
+    expect(validateNextParam('file:///etc/passwd', null)).toBe(NON_CLI_DEFAULT)
+  })
+})
+
+describe('validateNextParam — OWASP rejection class (d) encoded variants', () => {
+  it('rejects %2F%2Fevil.com (encoded protocol-relative) → default', () => {
+    expect(validateNextParam('%2F%2Fevil.com/x', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects javascript%3Aalert(1) (encoded scheme) → default', () => {
+    // After single decode this becomes `javascript:alert(1)`, which the
+    // post-decode scheme check rejects.
+    expect(validateNextParam('javascript%3Aalert(1)', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects malformed percent-encoding → default', () => {
+    // Triggers decodeURIComponent to throw; the helper must fall back safely
+    // instead of letting the exception propagate.
+    expect(validateNextParam('%E0%A4%A', null)).toBe(NON_CLI_DEFAULT)
+  })
+})
+
+describe('validateNextParam — OWASP rejection class (e) self-reference (POST-submit scope, M5)', () => {
+  it('rejects /complete-profile → default', () => {
+    expect(validateNextParam('/complete-profile', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects /login → default', () => {
+    expect(validateNextParam('/login', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects /signin (legacy alias) → default', () => {
+    expect(validateNextParam('/signin', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects /auth/callback → default', () => {
+    expect(validateNextParam('/auth/callback', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects any /auth/* subtree → default', () => {
+    expect(validateNextParam('/auth/otp', null)).toBe(NON_CLI_DEFAULT)
+  })
+})
+
+describe('validateNextParam — empty / missing input', () => {
+  it('treats empty string as missing → default', () => {
+    expect(validateNextParam('', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('treats null as missing → default', () => {
+    expect(validateNextParam(null, null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('treats undefined as missing → default', () => {
+    expect(validateNextParam(undefined, null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('treats whitespace-only as missing → default', () => {
+    expect(validateNextParam('    ', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('rejects a non-absolute path ("foo") lacking a leading slash → default', () => {
+    expect(validateNextParam('foo', null)).toBe(NON_CLI_DEFAULT)
+  })
+})
+
+describe('validateNextParam — /device user_code passthrough (H2)', () => {
+  it('preserves user_code on /device?user_code=BCDF-GHJK', () => {
+    expect(validateNextParam('/device?user_code=BCDF-GHJK', 'cli')).toBe(
+      '/device?user_code=BCDF-GHJK',
+    )
+  })
+
+  it('preserves user_code without source hint too (validator is source-agnostic for /device)', () => {
+    expect(validateNextParam('/device?user_code=BCDF-GHJK', null)).toBe(
+      '/device?user_code=BCDF-GHJK',
+    )
+  })
+
+  it('returns bare /device when user_code is missing', () => {
+    expect(validateNextParam('/device', null)).toBe('/device')
+  })
+
+  it('drops other unknown params on /device but keeps user_code', () => {
+    // Ampersand injection attempts: anything other than user_code is stripped.
+    // The rebuilt URL must contain only the expected query.
+    const out = validateNextParam('/device?user_code=BCDF-GHJK&foo=bar', null)
+    expect(out).toBe('/device?user_code=BCDF-GHJK')
+  })
+
+  it('does NOT preserve user_code on non-/device paths', () => {
+    // /foo is not a special-case path; all query params must be stripped.
+    expect(validateNextParam('/foo?user_code=BCDF-GHJK', null)).toBe('/foo')
+  })
+})
+
+describe('validateNextParam — source-aware defaults (A-NEXT-2)', () => {
+  it('source=cli + rejected next → /return-to-cli', () => {
+    expect(validateNextParam('https://evil.com/x', 'cli')).toBe(CLI_DEFAULT)
+  })
+
+  it('source=cli + null next → /return-to-cli', () => {
+    expect(validateNextParam(null, 'cli')).toBe(CLI_DEFAULT)
+  })
+
+  it('source="" + rejected next → /account/cli-token', () => {
+    expect(validateNextParam('javascript:alert(1)', '')).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('source=null + rejected next → /account/cli-token', () => {
+    expect(validateNextParam('//evil.com', null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('source=undefined + rejected next → /account/cli-token', () => {
+    expect(validateNextParam('//evil.com', undefined)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('source="web" (unknown hint) + rejected next → /account/cli-token', () => {
+    // Any source value other than the literal 'cli' uses the non-CLI default.
+    expect(validateNextParam('//evil.com', 'web')).toBe(NON_CLI_DEFAULT)
+  })
+})
+
+describe('validateNextParam — precedence cross-product (H6 post-Option-A)', () => {
+  /*
+   * Three explicit branches per spec §5.1:
+   *   1. source=cli wins over a bare next= (CLI originates redirect URL)
+   *   2. next= wins over no-params default when source != 'cli'
+   *   3. No params → no-params default
+   */
+
+  it('branch 1: source=cli AND next=/x → cli default (cli wins over bare next)', () => {
+    // Even with a valid /x, cli source forces the CLI default because the
+    // CLI originates the redirect URL itself. Validated next is discarded.
+    expect(validateNextParam('/x', 'cli')).toBe(CLI_DEFAULT)
+  })
+
+  it('branch 1: source=cli AND next=/account/settings → cli default', () => {
+    // Second assertion for branch 1 using a longer path — guards against
+    // accidentally tuning the behavior to the fixture /x string above.
+    expect(validateNextParam('/account/settings', 'cli')).toBe(CLI_DEFAULT)
+  })
+
+  it('branch 2: no source AND next=/x → /x (validated next wins)', () => {
+    expect(validateNextParam('/x', null)).toBe('/x')
+  })
+
+  it('branch 2: source="" AND next=/x → /x (empty source is not "cli")', () => {
+    expect(validateNextParam('/x', '')).toBe('/x')
+  })
+
+  it('branch 3: no source AND no next → /account/cli-token', () => {
+    expect(validateNextParam(null, null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('branch 3: no source AND empty next → /account/cli-token', () => {
+    expect(validateNextParam('', null)).toBe(NON_CLI_DEFAULT)
+  })
+})
+
+describe('validateNextParam — belt-and-suspenders misc', () => {
+  it('rejects an overly long input (>2048 chars) → default', () => {
+    const huge = '/' + 'a'.repeat(2100)
+    expect(validateNextParam(huge, null)).toBe(NON_CLI_DEFAULT)
+  })
+
+  it('accepts a maximum-length input at the 2048-char boundary', () => {
+    const atBoundary = '/' + 'a'.repeat(2047)
+    expect(validateNextParam(atBoundary, null)).toBe(atBoundary)
+  })
+
+  it('never returns a value that does not start with "/"', () => {
+    // Regression guard: the output contract is "always absolute same-origin".
+    const outputs = [
+      validateNextParam('/foo', null),
+      validateNextParam('https://evil.com', null),
+      validateNextParam(null, 'cli'),
+      validateNextParam('/device?user_code=BCDF-GHJK', null),
+      validateNextParam('', ''),
+    ]
+    for (const out of outputs) {
+      expect(out.startsWith('/')).toBe(true)
+    }
+  })
+})

--- a/packages/website/src/lib/validate-next-redirect.ts
+++ b/packages/website/src/lib/validate-next-redirect.ts
@@ -74,9 +74,23 @@ function isSelfReference(pathname: string): boolean {
  */
 export function validateNextParam(
   next: string | null | undefined,
-  source: string | null | undefined,
+  source: string | null | undefined
 ): string {
   const fallback = defaultFor(source)
+
+  // H6 precedence: source=cli wins over bare next. CLI-originated flows always
+  // land on /return-to-cli regardless of what `next` says — the CLI itself knows
+  // where to send the user; the web form is not the right redirect-resolver.
+  //
+  // Exception (H2 over H6): when `next` targets `/device?user_code=...`, the
+  // device-code passthrough takes precedence even for CLI-sourced requests.
+  // The CLI originates this URL itself (RFC 8628 §3.3) and must be able to
+  // pass the `user_code` through; dropping it would strand the user mid-flow.
+  // We do a lightweight pre-check on the raw string here; the full validation
+  // block below handles all other safety concerns.
+  const isDeviceNext =
+    typeof next === 'string' && /^\/device(\?|$)/.test(next.trim()) && next.includes('user_code=')
+  if (source === 'cli' && !isDeviceNext) return fallback
 
   if (typeof next !== 'string' || next.length === 0) return fallback
 

--- a/packages/website/src/lib/validate-next-redirect.ts
+++ b/packages/website/src/lib/validate-next-redirect.ts
@@ -1,0 +1,142 @@
+/**
+ * validate-next-redirect.ts
+ *
+ * SMI-4401 Wave 2 — OWASP redirect validation helper.
+ *
+ * Callers pass an untrusted `next` query param (plus an optional `source` hint) and
+ * receive a safe absolute-path URL (always starts with `/`) suitable for `window.location.href`.
+ *
+ * Rejected inputs fall back to a source-aware default:
+ *   - `source === 'cli'` → `/return-to-cli`
+ *   - otherwise          → `/account/cli-token`
+ *
+ * OWASP rejection classes (spec §4.4 A-NEXT-1):
+ *   (a) absolute URLs with a different origin              → `https://evil.com/x`
+ *   (b) protocol-relative                                  → `//evil.com/x`
+ *   (c) `javascript:` / `data:` / `vbscript:` schemes      → `javascript:alert(1)`
+ *   (d) encoded variants                                   → `%2F%2Fevil.com`
+ *   (e) self-reference as a post-submit REDIRECT DEST      → `/complete-profile`, `/login`, `/signin`, `/auth/*`
+ *
+ * Self-reference scope (M5): (e) applies ONLY when this validator resolves a POST-SUBMIT
+ * redirect destination. Form-internal navigation (hash anchors, inline error links, back-to-edit)
+ * is not this validator's concern — callers that need a self-reference should use `location.hash`
+ * or a purpose-built helper.
+ *
+ * Parameter precedence (H6, spec §5.1):
+ *   1. `source=cli` wins over a bare `next=` (CLI-originated redirect takes the cli default).
+ *   2. Otherwise a valid `next=` wins over the default.
+ *   3. Otherwise fall through to the no-params default.
+ *
+ * Unknown query-param handling (H2, spec §4.4 A-NEXT-1):
+ *   - By default, unknown query params on `next` are stripped (prevents encoded
+ *     path-traversal via open-redirect).
+ *   - Exception: when the destination path is exactly `/device`, the `user_code` query
+ *     parameter is preserved. Wave 3 RFC 8628 device-code flow relies on
+ *     `/device?user_code=<BCDF-GHJK-or-uuid>` as the canonical approval URL; dropping
+ *     `user_code` would strand CLI users mid-flow.
+ *
+ * Explicit unit test (spec §4.4 A-NEXT-1):
+ *   validateNextParam('/device?user_code=BCDF-GHJK', 'cli') === '/device?user_code=BCDF-GHJK'
+ */
+
+/** Paths that must never be used as a post-submit redirect destination (self-reference guard). */
+const SELF_REFERENCE_PATHS = new Set<string>([
+  '/complete-profile',
+  '/login',
+  '/signin', // legacy alias; intentionally rejected
+])
+
+/** Prefixes whose subtree is rejected as a post-submit redirect destination. */
+const SELF_REFERENCE_PREFIXES: readonly string[] = ['/auth/']
+
+/** Resolve the default destination based on the caller's source hint. */
+function defaultFor(source: string | null | undefined): string {
+  return source === 'cli' ? '/return-to-cli' : '/account/cli-token'
+}
+
+/** True when the destination path is rejected as a self-reference. */
+function isSelfReference(pathname: string): boolean {
+  if (SELF_REFERENCE_PATHS.has(pathname)) return true
+  for (const prefix of SELF_REFERENCE_PREFIXES) {
+    // Match both "/auth" (bare) and "/auth/<anything>" — the auth subtree is never a post-submit destination.
+    const bare = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
+    if (pathname === bare || pathname.startsWith(prefix)) return true
+  }
+  return false
+}
+
+/**
+ * Validate an untrusted `next` redirect target and return a safe same-origin path.
+ *
+ * @param next   - Untrusted query-param value (may be null, undefined, or an attacker-controlled string).
+ * @param source - Optional hint; when `'cli'` it steers the default toward `/return-to-cli`.
+ * @returns      - A safe absolute path that always starts with `/`.
+ */
+export function validateNextParam(
+  next: string | null | undefined,
+  source: string | null | undefined,
+): string {
+  const fallback = defaultFor(source)
+
+  if (typeof next !== 'string' || next.length === 0) return fallback
+
+  // Trim whitespace; extremely long inputs are suspicious — cap at 2048 chars.
+  const trimmed = next.trim()
+  if (trimmed.length === 0 || trimmed.length > 2048) return fallback
+
+  // Reject obviously dangerous schemes on the raw string before any decode.
+  // Case-insensitive; tolerate leading whitespace/tab/newline that may bypass naive checks.
+  if (/^(?:[a-z][a-z0-9+.-]*:)/i.test(trimmed)) {
+    // Any explicit scheme is rejected. We only accept same-origin absolute paths.
+    // This covers javascript:, data:, vbscript:, file:, http:, https:, etc.
+    return fallback
+  }
+
+  // Reject protocol-relative early (raw or encoded).
+  if (trimmed.startsWith('//')) return fallback
+
+  // Decode once to catch encoded protocol-relative / encoded scheme attacks.
+  // If decoding fails, the input is malformed — fall back.
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(trimmed)
+  } catch {
+    return fallback
+  }
+  if (decoded.startsWith('//')) return fallback
+  if (/^(?:[a-z][a-z0-9+.-]*:)/i.test(decoded)) return fallback
+
+  // Same-origin absolute paths must begin with a single `/`.
+  if (!trimmed.startsWith('/')) return fallback
+
+  // Parse as a URL against an arbitrary same-origin base to extract pathname + searchParams safely.
+  // Any URL constructor failure → fall back.
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed, 'https://example.invalid')
+  } catch {
+    return fallback
+  }
+
+  // Belt-and-suspenders: confirm parsing did not relocate us off-origin.
+  if (parsed.origin !== 'https://example.invalid') return fallback
+
+  const { pathname } = parsed
+
+  // Reject self-reference (e) for post-submit destinations.
+  if (isSelfReference(pathname)) return fallback
+
+  // Build the sanitized output path. By default, strip all query params.
+  // Exception (H2): preserve `user_code` when pathname is exactly `/device`.
+  if (pathname === '/device') {
+    const userCode = parsed.searchParams.get('user_code')
+    if (userCode && userCode.length > 0 && userCode.length <= 128) {
+      // Re-encode `user_code` to neutralize any injected ampersands or fragments.
+      return `/device?user_code=${encodeURIComponent(userCode)}`
+    }
+    return '/device'
+  }
+
+  // All other paths: pathname only, no query, no fragment.
+  return pathname
+}

--- a/packages/website/src/pages/account/cli-token.astro
+++ b/packages/website/src/pages/account/cli-token.astro
@@ -217,15 +217,16 @@ const supabaseConfig = getSupabaseConfig()
         } = await supabase.auth.getSession()
 
         if (!session || sessionError) {
-          window.location.href = '/login?redirect=/account/cli-token'
+          // SMI-4401 Wave 2: use new `next=` param (canonical).
+          window.location.href = '/login?next=/account/cli-token'
           return
         }
 
-        // Load profile to show tier info
+        // Load profile to show tier info + Wave 2 grace-window surface (SMI-4401 A-GRACE-1 / M10).
         try {
           const { data: profile } = await supabase
             .from('profiles')
-            .select('tier')
+            .select('tier, profile_grace_until, profile_completed_at')
             .eq('id', session.user.id)
             .single()
 
@@ -235,6 +236,35 @@ const supabaseConfig = getSupabaseConfig()
           if (tierNote) {
             tierNote.textContent = `Your ${tier} plan allows up to ${maxKeys} active key${maxKeys === 1 ? '' : 's'}.`
             tierNote.style.display = 'block'
+          }
+
+          // SMI-4401 Wave 2 A-GRACE-1: render grace-window reminder if grace is active.
+          // Gracefully renders nothing when column is NULL (common pre-grace case).
+          const graceUntilRaw = (profile as { profile_grace_until?: string | null } | null)
+            ?.profile_grace_until
+          if (graceUntilRaw) {
+            const graceUntil = new Date(graceUntilRaw)
+            if (!Number.isNaN(graceUntil.getTime()) && graceUntil.getTime() > Date.now()) {
+              const pageContainer = document.querySelector('.page-container')
+              if (pageContainer) {
+                const humanDate = graceUntil.toLocaleDateString(undefined, {
+                  month: 'long',
+                  day: 'numeric',
+                  year: 'numeric',
+                })
+                const banner = document.createElement('div')
+                banner.className = 'grace-banner'
+                banner.setAttribute('role', 'status')
+                banner.innerHTML = `
+                  <p>
+                    <strong>One more thing</strong> — add your first and last name by
+                    <strong>${escapeHtml(humanDate)}</strong> to keep your key active.
+                    <a href="/complete-profile?next=/account/cli-token">Complete now →</a>
+                  </p>
+                `
+                pageContainer.insertBefore(banner, pageContainer.firstChild)
+              }
+            }
           }
         } catch {
           // Non-critical — tier note is informational only
@@ -249,17 +279,43 @@ const supabaseConfig = getSupabaseConfig()
           .eq('name', 'CLI Token')
           .order('created_at', { ascending: false })
 
-        // Render active CLI tokens section
+        // SMI-4401 Wave 2 C2: humanize a "Last used" timestamp ("2 hours ago", "3 days ago").
+        function humanizeAgo(iso: string | null | undefined): string {
+          if (!iso) return 'Never used'
+          const ts = new Date(iso).getTime()
+          if (Number.isNaN(ts)) return 'Never used'
+          const diffMs = Date.now() - ts
+          if (diffMs < 0) return 'Just now'
+          const minutes = Math.floor(diffMs / 60000)
+          if (minutes < 1) return 'Just now'
+          if (minutes < 60) return `Last used ${minutes} minute${minutes === 1 ? '' : 's'} ago`
+          const hours = Math.floor(minutes / 60)
+          if (hours < 24) return `Last used ${hours} hour${hours === 1 ? '' : 's'} ago`
+          const days = Math.floor(hours / 24)
+          if (days < 30) return `Last used ${days} day${days === 1 ? '' : 's'} ago`
+          const months = Math.floor(days / 30)
+          if (months < 12) return `Last used ${months} month${months === 1 ? '' : 's'} ago`
+          const years = Math.floor(days / 365)
+          return `Last used ${years} year${years === 1 ? '' : 's'} ago`
+        }
+
+        // SMI-4401 Wave 2 C2: last 6 chars of key_prefix for visual recognition.
+        function keyPreviewSuffix(prefix: string | null | undefined): string {
+          if (!prefix) return ''
+          const trimmed = prefix.replace(/_+$/, '')
+          return trimmed.slice(-6)
+        }
+
+        // Render active CLI tokens section — SMI-4401 Wave 2 return-visit state.
         const tokenCard = document.querySelector('.token-card')
         if (cliKeys && cliKeys.length > 0 && tokenCard) {
           const keysHtml = `
-            <section class="keys-section">
-              <h2 class="keys-section-heading">
-                Active CLI Token${cliKeys.length > 1 ? 's' : ''}
+            <section class="keys-section" aria-labelledby="keys-section-heading">
+              <h2 id="keys-section-heading" class="keys-section-heading">
+                Your CLI token is live
               </h2>
               <p class="section-desc">
-                This token is used by the <code>skillsmith</code> CLI. Revoke it here before
-                generating a replacement.
+                Revoke and regenerate here — the old key will stop working immediately.
               </p>
               <ul class="key-list">
                 ${cliKeys
@@ -267,28 +323,33 @@ const supabaseConfig = getSupabaseConfig()
                     (key) => `
                   <li class="key-item">
                     <div class="key-info">
-                      <span class="key-prefix">${escapeHtml(key.key_prefix)}&hellip;</span>
+                      <code class="key-prefix">sk_live_...${escapeHtml(keyPreviewSuffix(key.key_prefix))}</code>
                       <span class="key-meta">
-                        Created ${new Date(key.created_at).toLocaleDateString()}${
-                          key.last_used_at
-                            ? ` &middot; Last used ${new Date(key.last_used_at).toLocaleDateString()}`
-                            : ''
-                        }
+                        ${escapeHtml(humanizeAgo(key.last_used_at))}
+                        &middot; Created ${new Date(key.created_at).toLocaleDateString()}
                       </span>
                       <span class="tier-badge ${escapeHtml(key.tier)}">${escapeHtml(key.tier)}</span>
                     </div>
                     <button
-                      class="revoke-btn btn btn-danger btn-sm"
+                      class="revoke-regen-btn btn btn-danger btn-sm"
                       data-key-id="${escapeHtml(key.id)}"
-                      aria-label="Revoke CLI token ending in ${escapeHtml(key.key_prefix)}"
+                      data-key-prefix="${escapeHtml(key.key_prefix)}"
+                      aria-label="Revoke and regenerate CLI token ending in ${escapeHtml(keyPreviewSuffix(key.key_prefix))}"
                     >
-                      Revoke
+                      Revoke &amp; regenerate
                     </button>
                   </li>
                 `
                   )
                   .join('')}
               </ul>
+              <div
+                id="regen-status"
+                class="regen-status"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+              ></div>
             </section>
           `
           tokenCard.insertAdjacentHTML('beforebegin', keysHtml)
@@ -301,29 +362,181 @@ const supabaseConfig = getSupabaseConfig()
           }
         }
 
-        // Revoke handlers
-        document.querySelectorAll<HTMLButtonElement>('.revoke-btn').forEach((btn) => {
-          btn.addEventListener('click', async () => {
+        // SMI-4401 Wave 2 C2: inject a focus-trapped confirmation modal for Revoke & regenerate.
+        function ensureConfirmModal(): HTMLDivElement {
+          let modal = document.getElementById('revoke-confirm-modal') as HTMLDivElement | null
+          if (modal) return modal
+          modal = document.createElement('div')
+          modal.id = 'revoke-confirm-modal'
+          modal.className = 'revoke-modal-backdrop'
+          modal.setAttribute('role', 'dialog')
+          modal.setAttribute('aria-modal', 'true')
+          modal.setAttribute('aria-labelledby', 'revoke-modal-title')
+          modal.setAttribute('aria-describedby', 'revoke-modal-desc')
+          modal.setAttribute('hidden', 'true')
+          modal.innerHTML = `
+            <div class="revoke-modal">
+              <h2 id="revoke-modal-title">Revoke this key?</h2>
+              <p id="revoke-modal-desc">
+                Revoke this key and generate a new one? Any CLI sessions using the old key will stop working.
+              </p>
+              <div class="revoke-modal-actions">
+                <button type="button" class="btn btn-secondary" data-modal-cancel>Cancel</button>
+                <button type="button" class="btn btn-danger" data-modal-confirm>Confirm</button>
+              </div>
+            </div>
+          `
+          document.body.appendChild(modal)
+          return modal
+        }
+
+        // SMI-4401 Wave 2 C2: flip the UI into first-visit key display with a freshly generated key.
+        function showFreshKey(apiKey: string, keyPrefix: string) {
+          const keysSection = document.querySelector('.keys-section')
+          if (keysSection) {
+            ;(keysSection as HTMLElement).style.display = 'none'
+          }
+          keyValue.textContent = apiKey
+          generateSection.style.display = 'none'
+          keySection.style.display = 'block'
+          const status = document.getElementById('regen-status')
+          if (status) {
+            status.textContent = `New key generated (prefix ${keyPrefix}). Copy it now — it will not be shown again.`
+          }
+        }
+
+        function openConfirmModal(onConfirm: () => void) {
+          const modal = ensureConfirmModal()
+          modal.removeAttribute('hidden')
+          const cancelBtn = modal.querySelector<HTMLButtonElement>('[data-modal-cancel]')
+          const confirmBtn = modal.querySelector<HTMLButtonElement>('[data-modal-confirm]')
+          const previouslyFocused = document.activeElement as HTMLElement | null
+          const focusables = [cancelBtn, confirmBtn].filter(
+            (el): el is HTMLButtonElement => el !== null
+          )
+          if (confirmBtn) confirmBtn.focus()
+
+          function close() {
+            modal.setAttribute('hidden', 'true')
+            cancelBtn?.removeEventListener('click', onCancel)
+            confirmBtn?.removeEventListener('click', onConfirmClick)
+            modal.removeEventListener('keydown', onKeydown)
+            if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+              previouslyFocused.focus()
+            }
+          }
+          function onCancel() {
+            close()
+          }
+          function onConfirmClick() {
+            close()
+            onConfirm()
+          }
+          function onKeydown(ev: KeyboardEvent) {
+            if (ev.key === 'Escape') {
+              ev.preventDefault()
+              close()
+            } else if (ev.key === 'Tab' && focusables.length > 0) {
+              const first = focusables[0]
+              const last = focusables[focusables.length - 1]
+              if (ev.shiftKey && document.activeElement === first) {
+                ev.preventDefault()
+                last.focus()
+              } else if (!ev.shiftKey && document.activeElement === last) {
+                ev.preventDefault()
+                first.focus()
+              }
+            }
+          }
+          cancelBtn?.addEventListener('click', onCancel)
+          confirmBtn?.addEventListener('click', onConfirmClick)
+          modal.addEventListener('keydown', onKeydown)
+        }
+
+        // SMI-4401 Wave 2 C2: Revoke & regenerate handlers — fetch skeleton with full error matrix.
+        document.querySelectorAll<HTMLButtonElement>('.revoke-regen-btn').forEach((btn) => {
+          btn.addEventListener('click', () => {
             const keyId = btn.dataset.keyId
             if (!keyId) return
-            if (!confirm('Are you sure you want to revoke this key? This cannot be undone.')) return
 
-            btn.disabled = true
-            btn.textContent = 'Revoking\u2026'
+            openConfirmModal(async () => {
+              btn.disabled = true
+              const originalText = btn.textContent
+              btn.textContent = 'Regenerating...'
+              btn.setAttribute('aria-busy', 'true')
+              const status = document.getElementById('regen-status')
+              if (status) status.textContent = ''
 
-            const { error } = await supabase
-              .from('license_keys')
-              .update({ status: 'revoked', revoked_at: new Date().toISOString() })
-              .eq('id', keyId)
-              .eq('user_id', session.user.id) // defense-in-depth; RLS also enforces ownership
+              function resetButton() {
+                btn.disabled = false
+                if (originalText) btn.textContent = originalText
+                btn.removeAttribute('aria-busy')
+              }
 
-            if (error) {
-              alert('Failed to revoke token. Please try again.')
-              btn.disabled = false
-              btn.textContent = 'Revoke'
-            } else {
-              location.reload()
-            }
+              function showRegenError(message: string) {
+                if (status) status.textContent = message
+                resetButton()
+              }
+
+              // Refresh session before hitting the edge function.
+              const {
+                data: { session: currentSession },
+              } = await supabase.auth.getSession()
+              if (!currentSession) {
+                showRegenError('Session expired. Please sign in again.')
+                return
+              }
+
+              let response: Response
+              try {
+                response = await fetch(`${supabaseUrl}/functions/v1/regenerate-license`, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${currentSession.access_token}`,
+                    apikey: supabaseAnonKey,
+                  },
+                  body: JSON.stringify({ key_id: keyId }),
+                })
+              } catch {
+                showRegenError('Network error. Check your connection and try again.')
+                return
+              }
+
+              if (response.status === 401) {
+                showRegenError('Your session expired. Please sign in again and retry.')
+                return
+              }
+              if (response.status === 429) {
+                const retryAfter = response.headers.get('Retry-After') ?? '60'
+                showRegenError(`Too many requests. Try again in ${retryAfter} seconds.`)
+                return
+              }
+              if (response.status >= 500) {
+                showRegenError(
+                  'Something went wrong on our end. Try again in a moment, or contact us at /contact?topic=cli-token.'
+                )
+                return
+              }
+              if (!response.ok) {
+                showRegenError('Could not regenerate key. Try again or contact support.')
+                return
+              }
+
+              try {
+                const body = (await response.json()) as {
+                  api_key?: string
+                  key_prefix?: string
+                }
+                if (!body.api_key || !body.key_prefix) {
+                  showRegenError('Unexpected response from server. Please reload the page.')
+                  return
+                }
+                showFreshKey(body.api_key, body.key_prefix)
+              } catch {
+                showRegenError('Could not parse server response. Please reload the page.')
+              }
+            })
           })
         })
 
@@ -799,6 +1012,88 @@ const supabaseConfig = getSupabaseConfig()
       .tier-badge.enterprise {
         background: rgba(245, 158, 11, 0.2);
         color: #f59e0b;
+      }
+
+      /* SMI-4401 Wave 2: grace-window reminder banner. */
+      .grace-banner {
+        background: rgba(234, 179, 8, 0.08);
+        border: 1px solid rgba(234, 179, 8, 0.35);
+        color: #fde68a;
+        border-radius: 10px;
+        padding: 0.75rem 1rem;
+        margin: 0 0 1.5rem;
+      }
+
+      .grace-banner p {
+        margin: 0;
+        font-size: 0.9rem;
+        line-height: 1.5;
+      }
+
+      .grace-banner a {
+        color: #a78bfa;
+        text-decoration: underline;
+        font-weight: 500;
+      }
+
+      .grace-banner a:hover {
+        color: #c4b5fd;
+      }
+
+      /* SMI-4401 Wave 2: post-regenerate aria-live region. */
+      .regen-status {
+        margin-top: 1rem;
+        font-size: 0.875rem;
+        color: #a1a1aa;
+      }
+
+      .regen-status:empty {
+        display: none;
+      }
+
+      /* SMI-4401 Wave 2: focus-trapped revoke confirmation modal. */
+      .revoke-modal-backdrop[hidden] {
+        display: none;
+      }
+
+      .revoke-modal-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.65);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+        z-index: 9999;
+      }
+
+      .revoke-modal {
+        background: #121214;
+        border: 1px solid #2a2a2f;
+        border-radius: 12px;
+        padding: 1.5rem;
+        max-width: 420px;
+        width: 100%;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+      }
+
+      .revoke-modal h2 {
+        font-size: 1.125rem;
+        font-weight: 600;
+        margin: 0 0 0.75rem;
+      }
+
+      .revoke-modal p {
+        color: #a1a1aa;
+        font-size: 0.9375rem;
+        line-height: 1.5;
+        margin: 0 0 1.25rem;
+      }
+
+      .revoke-modal-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.5rem;
       }
     </style>
   </body>

--- a/packages/website/src/pages/auth/callback.astro
+++ b/packages/website/src/pages/auth/callback.astro
@@ -242,14 +242,19 @@ const redirectTo =
 
 <script>
   import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+  import { validateNextParam } from '../../lib/validate-next-redirect'
 
   // Read config injected by SSR script in head
   const config = (window as unknown as { __SUPABASE_CONFIG__?: { url: string; anonKey: string } })
     .__SUPABASE_CONFIG__ || { url: '', anonKey: '' }
   const supabaseUrl = config.url
   const supabaseAnonKey = config.anonKey
-  const authRedirectTo =
+  // SMI-4401 Wave 2: route the SSR-injected redirect through the OWASP validator so a
+  // crafted ?next=https://evil.com or protocol-relative //evil.com cannot bounce users
+  // off-site post-auth. Pre-existing path used `authRedirectTo` raw at window.location.href.
+  const rawRedirect =
     (window as unknown as { __AUTH_REDIRECT_TO__?: string }).__AUTH_REDIRECT_TO__ || '/account'
+  const authRedirectTo = validateNextParam(rawRedirect, '')
 
   // Module-scoped Supabase client. Lazy-initialized on first use so the SSR-injected config is
   // guaranteed present. Shared by the `astro:page-load` handler and `routePostAuth()`.
@@ -317,9 +322,7 @@ const redirectTo =
       return
     }
     const needsProfile =
-      !profile?.profile_completed_at ||
-      !profile?.first_name?.trim() ||
-      !profile?.last_name?.trim()
+      !profile?.profile_completed_at || !profile?.first_name?.trim() || !profile?.last_name?.trim()
     if (needsProfile) {
       // H1 loop-guard: if the user arrived here FROM /complete-profile (referrer check) and
       // we'd just send them back, surface an error instead of looping.

--- a/packages/website/src/pages/auth/callback.astro
+++ b/packages/website/src/pages/auth/callback.astro
@@ -19,7 +19,9 @@ import { getSupabaseConfig } from '../../lib/supabase-config'
 const supabaseConfig = getSupabaseConfig()
 
 // Get redirect URL from query params (for OAuth flows)
-const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
+// H7: accept both `next=` (new canonical param, SMI-4401 Wave 2) and legacy `redirect=`.
+const redirectTo =
+  Astro.url.searchParams.get('next') ?? Astro.url.searchParams.get('redirect') ?? '/account'
 ---
 
 <!doctype html>
@@ -239,7 +241,7 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
 </style>
 
 <script>
-  import { createClient } from '@supabase/supabase-js'
+  import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
   // Read config injected by SSR script in head
   const config = (window as unknown as { __SUPABASE_CONFIG__?: { url: string; anonKey: string } })
@@ -249,11 +251,105 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
   const authRedirectTo =
     (window as unknown as { __AUTH_REDIRECT_TO__?: string }).__AUTH_REDIRECT_TO__ || '/account'
 
-  document.addEventListener('astro:page-load', async () => {
+  // Module-scoped Supabase client. Lazy-initialized on first use so the SSR-injected config is
+  // guaranteed present. Shared by the `astro:page-load` handler and `routePostAuth()`.
+  let _supabaseSingleton: SupabaseClient | null = null
+  function getSupabase(): SupabaseClient | null {
+    if (_supabaseSingleton) return _supabaseSingleton
+    if (!supabaseUrl || !supabaseAnonKey) return null
+    _supabaseSingleton = createClient(supabaseUrl, supabaseAnonKey)
+    return _supabaseSingleton
+  }
+
+  // Module-scoped UI helpers so `routePostAuth()` (also module-scoped) can call them without
+  // capturing closures from `astro:page-load`. The DOM lookups defer to call-time, which is
+  // safe because these are only invoked after `astro:page-load` fires.
+  function showSuccess() {
     const loadingState = document.getElementById('loading-state') as HTMLDivElement | null
     const successState = document.getElementById('success-state') as HTMLDivElement | null
+    if (loadingState) loadingState.style.display = 'none'
+    if (successState) successState.style.display = 'block'
+    // Auto-redirect after 2 seconds
+    setTimeout(() => {
+      window.location.href = authRedirectTo
+    }, 2000)
+  }
+
+  function showError(message?: string) {
+    const loadingState = document.getElementById('loading-state') as HTMLDivElement | null
     const errorState = document.getElementById('error-state') as HTMLDivElement | null
     const errorMessageEl = document.getElementById('error-message') as HTMLParagraphElement | null
+    if (loadingState) loadingState.style.display = 'none'
+    if (errorState) errorState.style.display = 'block'
+    if (message && errorMessageEl) {
+      errorMessageEl.textContent = message
+    }
+  }
+
+  // Module-scoped — shared by all four callback success paths (email signin, email signup,
+  // OAuth signin, OAuth signup). Never inline inside handler closures: keeps behavior identical
+  // across branches and avoids four divergent copies.
+  async function routePostAuth() {
+    const supabase = getSupabase()
+    if (!supabase) {
+      showError('Authentication service not configured')
+      return
+    }
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+    if (!session) {
+      showError('Session lost. Please sign in again.')
+      return
+    }
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('first_name, last_name, profile_completed_at')
+      .eq('id', session.user.id)
+      .single()
+    // H1: on profile fetch failure, do NOT default-redirect — surface the error instead.
+    // A silent default-redirect to `/complete-profile` on transient network error would trap
+    // already-complete users in the form. Keep them on callback with a clear retry prompt.
+    if (profileError) {
+      showError(
+        'We could not verify your profile. Please try again — if it keeps failing, contact us at /contact?topic=signup-help.'
+      )
+      return
+    }
+    const needsProfile =
+      !profile?.profile_completed_at ||
+      !profile?.first_name?.trim() ||
+      !profile?.last_name?.trim()
+    if (needsProfile) {
+      // H1 loop-guard: if the user arrived here FROM /complete-profile (referrer check) and
+      // we'd just send them back, surface an error instead of looping.
+      const cameFromCompleteProfile =
+        typeof document !== 'undefined' &&
+        !!document.referrer &&
+        (() => {
+          try {
+            return (
+              new URL(document.referrer, window.location.origin).pathname === '/complete-profile'
+            )
+          } catch {
+            return false
+          }
+        })()
+      if (cameFromCompleteProfile) {
+        showError(
+          'Something went wrong saving your profile. Try again at /complete-profile or contact us at /contact?topic=signup-help.'
+        )
+        return
+      }
+      const nextParam = encodeURIComponent(authRedirectTo)
+      window.location.href = `/complete-profile?next=${nextParam}`
+      return
+    }
+    showSuccess()
+  }
+
+  document.addEventListener('astro:page-load', async () => {
+    const successState = document.getElementById('success-state') as HTMLDivElement | null
     const dashboardLink = successState?.querySelector(
       'a[href="/account"]'
     ) as HTMLAnchorElement | null
@@ -263,30 +359,12 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
       dashboardLink.href = authRedirectTo
     }
 
-    function showSuccess() {
-      if (loadingState) loadingState.style.display = 'none'
-      if (successState) successState.style.display = 'block'
-      // Auto-redirect after 2 seconds
-      setTimeout(() => {
-        window.location.href = authRedirectTo
-      }, 2000)
-    }
-
-    function showError(message?: string) {
-      if (loadingState) loadingState.style.display = 'none'
-      if (errorState) errorState.style.display = 'block'
-      if (message && errorMessageEl) {
-        errorMessageEl.textContent = message
-      }
-    }
-
     try {
-      if (!supabaseUrl || !supabaseAnonKey) {
+      const supabase = getSupabase()
+      if (!supabase) {
         showError('Authentication service not configured')
         return
       }
-
-      const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
       // Get the hash fragment from URL (Supabase Auth uses hash-based routing)
       const hashParams = new URLSearchParams(window.location.hash.substring(1))
@@ -347,7 +425,8 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
             showError(error.message)
           } else {
             await fetchAndStoreGitHubOrgs()
-            showSuccess()
+            // SMI-4401 Wave 2: gate post-auth on profile completion.
+            await routePostAuth()
           }
         } else {
           // Try to exchange code for session (PKCE flow)
@@ -356,7 +435,7 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
             showError(error.message)
           } else {
             await fetchAndStoreGitHubOrgs()
-            showSuccess()
+            await routePostAuth()
           }
         }
       } else if (type === 'recovery') {
@@ -373,7 +452,7 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
           showError(error.message)
         } else {
           await fetchAndStoreGitHubOrgs()
-          showSuccess()
+          await routePostAuth()
         }
       } else {
         // Check if already logged in
@@ -381,7 +460,10 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
           data: { session },
         } = await supabase.auth.getSession()
         if (session) {
-          showSuccess()
+          // SMI-4401 Wave 2: even for "already-logged-in" fast-path, re-check profile
+          // completion. A user with an incomplete profile who bounces back here must still
+          // be routed through /complete-profile.
+          await routePostAuth()
         } else {
           // No tokens found, try PKCE exchange
           try {
@@ -390,7 +472,7 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
               showError('Invalid or expired verification link. Please request a new one.')
             } else {
               await fetchAndStoreGitHubOrgs()
-              showSuccess()
+              await routePostAuth()
             }
           } catch (pkceError) {
             console.error('PKCE exchange error:', pkceError)

--- a/packages/website/src/pages/auth/callback.astro
+++ b/packages/website/src/pages/auth/callback.astro
@@ -388,6 +388,7 @@ const redirectTo =
       // Must be called BEFORE showSuccess() — showSuccess() starts a 2-second redirect timer.
       // Non-fatal: errors are swallowed so the auth flow always completes.
       async function fetchAndStoreGitHubOrgs() {
+        if (!supabase) return
         try {
           const {
             data: { session: currentSession },

--- a/packages/website/src/pages/blog/rss.xml.ts
+++ b/packages/website/src/pages/blog/rss.xml.ts
@@ -1,5 +1,6 @@
 import rss from '@astrojs/rss'
 import { getCollection } from 'astro:content'
+import type { CollectionEntry } from 'astro:content'
 import type { APIContext } from 'astro'
 
 /**
@@ -7,14 +8,17 @@ import type { APIContext } from 'astro'
  * SMI-2532: RSS feed implementation
  */
 export async function GET(context: APIContext) {
-  const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
-    (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+  const posts = (
+    await getCollection('blog', ({ data }: CollectionEntry<'blog'>) => !data.draft)
+  ).sort(
+    (a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
+      b.data.date.valueOf() - a.data.date.valueOf()
   )
   return rss({
     title: 'Skillsmith Blog',
     description: 'AI-powered agent skill discovery and management',
     site: context.site!,
-    items: posts.map((post) => ({
+    items: posts.map((post: CollectionEntry<'blog'>) => ({
       title: post.data.title,
       pubDate: post.data.date,
       description: post.data.description,

--- a/packages/website/src/pages/check-email.astro
+++ b/packages/website/src/pages/check-email.astro
@@ -1,0 +1,399 @@
+---
+/**
+ * /check-email — Email-verification interstitial
+ *
+ * SMI-4401 Wave 2 — Spec §5.3.
+ *
+ * Serves the 22-user email_verified=FALSE cohort after signup (and any future email-signup
+ * user) with a clear "Check your email" page, a rate-limited resend CTA, and three escape
+ * hatches (H3 — 22-user cohort needs dead-end exits).
+ *
+ * Query params:
+ *   ?email=<addr>  — the email captured at signup (or from signup.astro's fallback localStorage).
+ *   ?next=<path>   — passed through to Supabase `options.emailRedirectTo` on resend.
+ *
+ * M8 — Email resolution order: URL ?email= → localStorage['skillsmith_pending_signup_email'] → fallback copy.
+ * L1 — Resend cooldown persisted in localStorage['skillsmith_resend_cooldown_until:<emailLower>'].
+ * M6 — No client-side profiles.email_verified branch (anon caller cannot SELECT via RLS).
+ */
+
+export const prerender = false
+
+import BaseLayout from '../layouts/BaseLayout.astro'
+
+const rawEmail = Astro.url.searchParams.get('email')?.trim() ?? ''
+const rawNext = Astro.url.searchParams.get('next')?.trim() ?? ''
+// Simple shape check only — full validation happens client-side when resend is invoked.
+const emailFromUrl = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(rawEmail) ? rawEmail : ''
+---
+
+<BaseLayout title="Check your email — Skillsmith" noindex={true}>
+  <section class="check-container">
+    <div class="check-card">
+      <h1 id="check-heading" tabindex="-1" class="check-heading">Check your email</h1>
+
+      <p id="check-subhead" class="check-subhead">
+        We sent a confirmation link to <strong id="email-display">{emailFromUrl}</strong>
+      </p>
+
+      <p id="check-fallback" class="check-fallback" style={emailFromUrl ? 'display: none;' : ''}>
+        Check the email you signed up with for a confirmation link.
+      </p>
+
+      <p class="check-expiry">The link expires in 24 hours.</p>
+
+      <button
+        type="button"
+        id="resend-btn"
+        class="btn btn-primary"
+        aria-label="Resend confirmation email"
+      >
+        <span id="resend-label">Didn&rsquo;t get it? Resend</span>
+      </button>
+
+      <div
+        id="resend-status"
+        role="status"
+        aria-live="polite"
+        class="check-status"
+        style="display: none;"
+      >
+      </div>
+
+      <div id="resend-error" role="alert" class="check-error" style="display: none;"></div>
+
+      <div class="check-footer">
+        <p>
+          Used the wrong email? <a href="/signup" class="check-link">Sign up again &rarr;</a>
+        </p>
+        <p>
+          Already confirmed? <a href="/login" class="check-link">Sign in &rarr;</a>
+        </p>
+        <p>
+          <a
+            href="mailto:support@smithhorn.ca?subject=Confirm%20email%20not%20received"
+            class="check-link"
+          >
+            Check your spam folder
+          </a>
+          &mdash; or contact us.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <script is:inline define:vars={{ emailFromUrl, rawNext }}>
+    window.__CHECK_EMAIL_CTX__ = {
+      emailFromUrl: emailFromUrl,
+      next: rawNext,
+    }
+  </script>
+
+  <script>
+    import { getSupabaseClient } from '../lib/supabase-client'
+
+    const PENDING_EMAIL_KEY = 'skillsmith_pending_signup_email'
+    const COOLDOWN_PREFIX = 'skillsmith_resend_cooldown_until:'
+    const COOLDOWN_MS = 60 * 1000
+
+    document.addEventListener('astro:page-load', () => {
+      const ctx = (window as unknown as { __CHECK_EMAIL_CTX__?: { emailFromUrl: string; next: string } })
+        .__CHECK_EMAIL_CTX__
+      const heading = document.getElementById('check-heading') as HTMLElement | null
+      const emailDisplay = document.getElementById('email-display')
+      const fallback = document.getElementById('check-fallback')
+      const subhead = document.getElementById('check-subhead')
+      const resendBtn = document.getElementById('resend-btn') as HTMLButtonElement | null
+      const resendLabel = document.getElementById('resend-label')
+      const status = document.getElementById('resend-status')
+      const errorEl = document.getElementById('resend-error')
+
+      if (!heading || !emailDisplay || !fallback || !subhead || !resendBtn || !resendLabel || !status || !errorEl) {
+        return
+      }
+
+      // Focus heading for screen readers.
+      try {
+        heading.focus({ preventScroll: true })
+      } catch {
+        /* non-critical */
+      }
+
+      // M8: resolve email from URL → localStorage → fallback copy.
+      let email = ctx?.emailFromUrl ?? ''
+      if (!email) {
+        try {
+          email = localStorage.getItem(PENDING_EMAIL_KEY) ?? ''
+        } catch {
+          email = ''
+        }
+      }
+
+      if (email && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        emailDisplay.textContent = email
+        fallback.style.display = 'none'
+        subhead.style.display = ''
+      } else {
+        subhead.style.display = 'none'
+        fallback.style.display = ''
+        email = ''
+      }
+
+      const next = ctx?.next && ctx.next.length > 0 ? ctx.next : '/account/cli-token'
+
+      // L1: cooldown persistence keyed by email.
+      function cooldownKey(addr: string): string {
+        return COOLDOWN_PREFIX + addr.toLowerCase()
+      }
+
+      function readCooldownUntil(addr: string): number | null {
+        if (!addr) return null
+        try {
+          const raw = localStorage.getItem(cooldownKey(addr))
+          if (!raw) return null
+          const ts = Date.parse(raw)
+          if (isNaN(ts) || ts <= Date.now()) {
+            localStorage.removeItem(cooldownKey(addr))
+            return null
+          }
+          return ts
+        } catch {
+          return null
+        }
+      }
+
+      function writeCooldown(addr: string) {
+        if (!addr) return
+        try {
+          const until = new Date(Date.now() + COOLDOWN_MS).toISOString()
+          localStorage.setItem(cooldownKey(addr), until)
+        } catch {
+          /* no-op */
+        }
+      }
+
+      let cooldownTimer: number | null = null
+
+      function applyCooldownUI(until: number) {
+        if (!resendBtn || !resendLabel) return
+        function tick() {
+          const remaining = Math.max(0, Math.ceil((until - Date.now()) / 1000))
+          if (remaining <= 0) {
+            if (cooldownTimer !== null) {
+              window.clearInterval(cooldownTimer)
+              cooldownTimer = null
+            }
+            if (resendBtn && resendLabel) {
+              resendBtn.disabled = false
+              resendBtn.removeAttribute('aria-disabled')
+              resendLabel.textContent = "Didn't get it? Resend"
+            }
+            return
+          }
+          if (resendBtn && resendLabel) {
+            resendBtn.disabled = true
+            resendBtn.setAttribute('aria-disabled', 'true')
+            resendLabel.textContent = `Resend (${remaining}s)`
+          }
+        }
+        tick()
+        cooldownTimer = window.setInterval(tick, 1000)
+      }
+
+      // Re-apply any pre-existing cooldown on load.
+      const existingUntil = readCooldownUntil(email)
+      if (existingUntil) applyCooldownUI(existingUntil)
+
+      resendBtn.addEventListener('click', async () => {
+        errorEl.style.display = 'none'
+        errorEl.textContent = ''
+        status.style.display = 'none'
+
+        if (!email) {
+          errorEl.textContent =
+            'We could not recover your email. Please sign up again to receive a new link.'
+          errorEl.style.display = 'block'
+          return
+        }
+
+        resendBtn.disabled = true
+        resendBtn.setAttribute('aria-busy', 'true')
+
+        try {
+          const supabase = getSupabaseClient()
+          if (!supabase) {
+            errorEl.textContent = 'Resend failed. Try again in a moment or contact support.'
+            errorEl.style.display = 'block'
+            return
+          }
+
+          const origin = window.location.origin
+          const emailRedirectTo = `${origin}/auth/callback?next=${encodeURIComponent(next)}`
+
+          const { error } = await supabase.auth.resend({
+            type: 'signup',
+            email,
+            options: { emailRedirectTo },
+          })
+
+          if (error) {
+            errorEl.textContent =
+              'Resend failed. Try again in a moment or contact us at support@smithhorn.ca.'
+            errorEl.style.display = 'block'
+            return
+          }
+
+          status.textContent = 'Sent. Check your inbox again in a minute.'
+          status.style.display = 'block'
+          writeCooldown(email)
+          const until = readCooldownUntil(email)
+          if (until) applyCooldownUI(until)
+        } catch {
+          errorEl.textContent =
+            'Resend failed. Try again in a moment or contact us at support@smithhorn.ca.'
+          errorEl.style.display = 'block'
+        } finally {
+          resendBtn.removeAttribute('aria-busy')
+        }
+      })
+    })
+  </script>
+</BaseLayout>
+
+<style>
+  .check-container {
+    max-width: 32rem;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 4rem;
+  }
+
+  .check-card {
+    background: #121214;
+    border: 1px solid #2a2a2f;
+    border-radius: 0.75rem;
+    padding: 2rem;
+  }
+
+  .check-heading {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #fafafa;
+    margin: 0 0 0.75rem;
+    line-height: 1.25;
+  }
+
+  .check-heading:focus-visible {
+    outline: 2px solid #e07a5f;
+    outline-offset: 4px;
+    border-radius: 0.25rem;
+  }
+
+  .check-subhead {
+    font-size: 1rem;
+    color: #d4d4d8;
+    margin: 0 0 0.5rem;
+    line-height: 1.5;
+  }
+
+  #email-display {
+    color: #fafafa;
+    font-weight: 600;
+    word-break: break-all;
+  }
+
+  .check-fallback {
+    font-size: 1rem;
+    color: #d4d4d8;
+    margin: 0 0 0.5rem;
+    line-height: 1.5;
+  }
+
+  .check-expiry {
+    font-size: 0.875rem;
+    color: #a1a1aa;
+    margin: 0 0 1.5rem;
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1.25rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.15s;
+    border: 1px solid transparent;
+  }
+
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .btn-primary {
+    background: #E07A5F;
+    color: #fafafa;
+    border-color: #E07A5F;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background: #D4694E;
+    border-color: #D4694E;
+  }
+
+  .check-status {
+    margin-top: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    background: rgba(34, 197, 94, 0.08);
+    border: 1px solid rgba(34, 197, 94, 0.25);
+    color: #86efac;
+  }
+
+  .check-error {
+    margin-top: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    background: rgba(239, 68, 68, 0.08);
+    border: 1px solid rgba(239, 68, 68, 0.25);
+    color: #fca5a5;
+  }
+
+  .check-footer {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #2a2a2f;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .check-footer p {
+    margin: 0;
+    font-size: 0.875rem;
+    color: #a1a1aa;
+    line-height: 1.5;
+  }
+
+  .check-link {
+    color: #E07A5F;
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  .check-link:hover {
+    text-decoration: underline;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .btn {
+      transition: none;
+    }
+  }
+</style>

--- a/packages/website/src/pages/check-email.astro
+++ b/packages/website/src/pages/check-email.astro
@@ -91,14 +91,16 @@ const emailFromUrl = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(rawEmail) ? rawEmail : ''
 
   <script>
     import { getSupabaseClient } from '../lib/supabase-client'
+    import { validateNextParam } from '../lib/validate-next-redirect'
 
     const PENDING_EMAIL_KEY = 'skillsmith_pending_signup_email'
     const COOLDOWN_PREFIX = 'skillsmith_resend_cooldown_until:'
     const COOLDOWN_MS = 60 * 1000
 
     document.addEventListener('astro:page-load', () => {
-      const ctx = (window as unknown as { __CHECK_EMAIL_CTX__?: { emailFromUrl: string; next: string } })
-        .__CHECK_EMAIL_CTX__
+      const ctx = (
+        window as unknown as { __CHECK_EMAIL_CTX__?: { emailFromUrl: string; next: string } }
+      ).__CHECK_EMAIL_CTX__
       const heading = document.getElementById('check-heading') as HTMLElement | null
       const emailDisplay = document.getElementById('email-display')
       const fallback = document.getElementById('check-fallback')
@@ -108,7 +110,16 @@ const emailFromUrl = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(rawEmail) ? rawEmail : ''
       const status = document.getElementById('resend-status')
       const errorEl = document.getElementById('resend-error')
 
-      if (!heading || !emailDisplay || !fallback || !subhead || !resendBtn || !resendLabel || !status || !errorEl) {
+      if (
+        !heading ||
+        !emailDisplay ||
+        !fallback ||
+        !subhead ||
+        !resendBtn ||
+        !resendLabel ||
+        !status ||
+        !errorEl
+      ) {
         return
       }
 
@@ -139,7 +150,10 @@ const emailFromUrl = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(rawEmail) ? rawEmail : ''
         email = ''
       }
 
-      const next = ctx?.next && ctx.next.length > 0 ? ctx.next : '/account/cli-token'
+      // Validate `next` through the OWASP redirect validator before embedding it in
+      // emailRedirectTo. An unvalidated next param in a confirmation email link would
+      // allow an attacker to craft a phishing URL (open redirect via email).
+      const next = validateNextParam(ctx?.next, null)
 
       // L1: cooldown persistence keyed by email.
       function cooldownKey(addr: string): string {
@@ -335,14 +349,14 @@ const emailFromUrl = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(rawEmail) ? rawEmail : ''
   }
 
   .btn-primary {
-    background: #E07A5F;
+    background: #e07a5f;
     color: #fafafa;
-    border-color: #E07A5F;
+    border-color: #e07a5f;
   }
 
   .btn-primary:hover:not(:disabled) {
-    background: #D4694E;
-    border-color: #D4694E;
+    background: #d4694e;
+    border-color: #d4694e;
   }
 
   .check-status {
@@ -382,7 +396,7 @@ const emailFromUrl = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(rawEmail) ? rawEmail : ''
   }
 
   .check-link {
-    color: #E07A5F;
+    color: #e07a5f;
     text-decoration: none;
     font-weight: 500;
   }

--- a/packages/website/src/pages/complete-profile.astro
+++ b/packages/website/src/pages/complete-profile.astro
@@ -1,0 +1,491 @@
+---
+/**
+ * /complete-profile — Profile-completion form (quid-pro-quo signup)
+ *
+ * SMI-4401 Wave 2 — Spec §5.1.
+ *
+ * Users land here after signup/callback when first_name / last_name / profile_completed_at
+ * are missing on their `profiles` row. Collecting these two fields unlocks free-tier
+ * license-key issuance via the Wave 1 `issue_license_key_if_profile_complete(user_id)` RPC.
+ *
+ * Context params:
+ *   ?source=cli     — CLI-originated 403 recovery; copy leans on "re-run your terminal command".
+ *   ?next=<path>    — post-submit redirect; validated via validateNextParam (§4.4).
+ *
+ * Precedence (H6): source=cli > bare next= > no-params default. (team_invite_token removed per Option A §4.3.)
+ *
+ * Validation (M2): min 2, max 64, trimmed, /[A-Za-z]/ required. Matches Wave 1 SQL gate exactly.
+ * DROP "no sequential / no repeat" — do not client-reject names Wave 1 SQL accepts.
+ *
+ * Tier-cache interim (H9): Wave 2 does NOT call invalidate_tier_cache(user_id). That RPC
+ * doesn't exist yet — see TODO(SMI-4405) in the submit flow below. The TTL bump covers us.
+ */
+
+export const prerender = false
+
+import BaseLayout from '../layouts/BaseLayout.astro'
+
+const rawSource = Astro.url.searchParams.get('source')?.trim() ?? ''
+const rawNext = Astro.url.searchParams.get('next')?.trim() ?? ''
+const source = rawSource === 'cli' ? 'cli' : ''
+// SSR does NOT validate `next` — client-side validator (validateNextParam) handles that on submit.
+// We pass the raw value through so the client can resolve + sanitize in one place.
+---
+
+<BaseLayout title="Complete your profile — Skillsmith" noindex={true}>
+  <section class="profile-container" aria-busy="true" id="profile-main">
+    <!-- Loading skeleton -->
+    <div id="state-loading" class="profile-card" aria-hidden="false">
+      <div class="skeleton skeleton-heading"></div>
+      <div class="skeleton skeleton-sub"></div>
+      <div class="skeleton skeleton-field"></div>
+      <div class="skeleton skeleton-field"></div>
+      <div class="skeleton skeleton-button"></div>
+    </div>
+
+    <!-- Ready state: form -->
+    <div id="state-ready" class="profile-card" style="display: none;">
+      <h1 class="profile-heading">Almost there &mdash; tell us who you are.</h1>
+
+      <p id="profile-subhead" class="profile-subhead"></p>
+
+      <div
+        id="github-helper"
+        class="profile-helper"
+        role="note"
+        style="display: none;"
+      >
+        We grabbed this from your GitHub. Edit if wrong.
+      </div>
+
+      <div
+        id="profile-error-banner"
+        role="alert"
+        class="profile-error-banner"
+        style="display: none;"
+      >
+      </div>
+
+      <form id="profile-form" class="profile-form" novalidate>
+        <fieldset class="profile-fieldset">
+          <legend class="sr-only">Your name</legend>
+
+          <div class="form-group">
+            <label for="first-name" class="form-label">First name</label>
+            <input
+              id="first-name"
+              name="first_name"
+              type="text"
+              required
+              autocomplete="given-name"
+              minlength="2"
+              maxlength="64"
+              aria-describedby="first-name-error"
+              class="form-input"
+            />
+            <p id="first-name-error" class="form-error" role="alert"></p>
+          </div>
+
+          <div class="form-group">
+            <label for="last-name" class="form-label">Last name</label>
+            <input
+              id="last-name"
+              name="last_name"
+              type="text"
+              required
+              autocomplete="family-name"
+              minlength="2"
+              maxlength="64"
+              aria-describedby="last-name-error"
+              class="form-input"
+            />
+            <p id="last-name-error" class="form-error" role="alert"></p>
+          </div>
+        </fieldset>
+
+        <button type="submit" id="submit-btn" class="btn btn-primary btn-full">
+          <span id="submit-label">Activate free access</span>
+          <span id="submit-spinner" class="submit-spinner" style="display: none;" aria-hidden="true">
+            <svg viewBox="0 0 24 24" class="spinner-svg">
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+                fill="none"
+                opacity="0.25"></circle>
+              <path
+                d="M12 2a10 10 0 0 1 10 10"
+                stroke="currentColor"
+                stroke-width="4"
+                fill="none"></path>
+            </svg>
+          </span>
+        </button>
+
+        <p class="profile-fineprint">
+          You&rsquo;ll get 1,000 free API calls per month. No card required.
+        </p>
+
+        <p class="profile-legal">
+          We use this for your CLI identity only. <a href="/privacy" class="profile-link"
+            >Privacy policy &rarr;</a
+          >
+        </p>
+      </form>
+
+      <!-- Success toast -->
+      <div
+        id="profile-toast"
+        role="status"
+        aria-live="polite"
+        class="profile-toast"
+        style="display: none;"
+      >
+        Free tier activated
+      </div>
+    </div>
+  </section>
+
+  <script is:inline define:vars={{ source, rawNext }}>
+    window.__COMPLETE_PROFILE_CONTEXT__ = {
+      source: source,
+      next: rawNext,
+    }
+  </script>
+
+  <script>
+    import { getSupabaseClient } from '../lib/supabase-client'
+    import { validateNextParam } from '../lib/validate-next-redirect'
+    import {
+      COPY,
+      resolveSubhead,
+      validateName,
+      type CompleteProfileContext,
+    } from '../lib/complete-profile-copy'
+
+    document.addEventListener('astro:page-load', async () => {
+      const ctx =
+        (window as unknown as { __COMPLETE_PROFILE_CONTEXT__?: CompleteProfileContext })
+          .__COMPLETE_PROFILE_CONTEXT__ ?? { source: '', next: '' }
+
+      const main = document.getElementById('profile-main')
+      const loading = document.getElementById('state-loading')
+      const ready = document.getElementById('state-ready')
+      const subhead = document.getElementById('profile-subhead')
+      const githubHelper = document.getElementById('github-helper')
+      const banner = document.getElementById('profile-error-banner')
+      const form = document.getElementById('profile-form') as HTMLFormElement | null
+      const firstInput = document.getElementById('first-name') as HTMLInputElement | null
+      const lastInput = document.getElementById('last-name') as HTMLInputElement | null
+      const firstErr = document.getElementById('first-name-error')
+      const lastErr = document.getElementById('last-name-error')
+      const submitBtn = document.getElementById('submit-btn') as HTMLButtonElement | null
+      const submitLabel = document.getElementById('submit-label')
+      const submitSpinner = document.getElementById('submit-spinner')
+      const toast = document.getElementById('profile-toast')
+
+      if (
+        !main ||
+        !loading ||
+        !ready ||
+        !subhead ||
+        !githubHelper ||
+        !banner ||
+        !form ||
+        !firstInput ||
+        !lastInput ||
+        !firstErr ||
+        !lastErr ||
+        !submitBtn ||
+        !submitLabel ||
+        !submitSpinner ||
+        !toast
+      ) {
+        return
+      }
+
+      // Resolve the effective next path client-side through the validator.
+      // Precedence (H6): source=cli wins over bare next; else validated next; else no-params default.
+      const validatedNext = validateNextParam(ctx.next, ctx.source)
+
+      // Copy selection matrix per spec §5.1 — precedence: source=cli > bare next > no-params default.
+      const subheadCopy = resolveSubhead(ctx, validatedNext)
+      if (subheadCopy.text) {
+        subhead.textContent = subheadCopy.text
+      } else if (subheadCopy.html) {
+        subhead.innerHTML = subheadCopy.html
+      }
+
+      const supabase = getSupabaseClient()
+      if (!supabase) {
+        showError(COPY.errorSupabaseInit)
+        revealReady()
+        return
+      }
+
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
+
+      // No session: bounce to /login preserving context through next=.
+      if (!session) {
+        const preserved = new URLSearchParams()
+        preserved.set('next', '/complete-profile')
+        if (ctx.source) preserved.set('source', ctx.source)
+        if (ctx.next) preserved.set('next_after', ctx.next)
+        window.location.href = `/login?${preserved.toString()}`
+        return
+      }
+
+      // Fetch existing profile for pre-fill.
+      const { data: profile, error: profileError } = await supabase
+        .from('profiles')
+        .select('first_name, last_name, tier')
+        .eq('id', session.user.id)
+        .single()
+
+      if (profileError) {
+        showError(COPY.errorProfileLoad)
+        revealReady()
+        return
+      }
+
+      // Pre-fill from existing profile (binds via `value=`, not `placeholder=`).
+      if (profile?.first_name) firstInput.value = profile.first_name
+      if (profile?.last_name) lastInput.value = profile.last_name
+
+      // GitHub helper row (A-GH-3): only when session provider is github.
+      const provider = session.user?.app_metadata?.provider
+      if (provider === 'github' && (firstInput.value || lastInput.value)) {
+        githubHelper.style.display = 'block'
+      }
+
+      revealReady()
+
+      // Focus management: first empty field, else first field.
+      if (!firstInput.value) {
+        firstInput.focus()
+      } else if (!lastInput.value) {
+        lastInput.focus()
+      } else {
+        firstInput.focus()
+      }
+
+      form.addEventListener('submit', (event) => {
+        event.preventDefault()
+        void handleSubmit()
+      })
+
+      function revealReady() {
+        if (!main || !loading || !ready) return
+        loading.style.display = 'none'
+        ready.style.display = ''
+        main.setAttribute('aria-busy', 'false')
+      }
+
+      function showError(html: string) {
+        if (!banner) return
+        banner.innerHTML = html
+        banner.style.display = 'block'
+        // Focus moves to the banner for screen-reader announce.
+        try {
+          banner.setAttribute('tabindex', '-1')
+          ;(banner as HTMLElement).focus({ preventScroll: false })
+        } catch {
+          /* non-critical */
+        }
+      }
+
+      function clearBanner() {
+        if (!banner) return
+        banner.style.display = 'none'
+        banner.innerHTML = ''
+      }
+
+      function setFieldError(
+        input: HTMLInputElement,
+        errEl: HTMLElement,
+        message: string | null,
+      ) {
+        if (message) {
+          input.setAttribute('aria-invalid', 'true')
+          errEl.textContent = message
+          errEl.style.display = 'block'
+        } else {
+          input.removeAttribute('aria-invalid')
+          errEl.textContent = ''
+          errEl.style.display = 'none'
+        }
+      }
+
+      function setSubmitting(isSubmitting: boolean) {
+        if (!submitBtn || !submitLabel || !submitSpinner || !firstInput || !lastInput) return
+        submitBtn.disabled = isSubmitting
+        firstInput.disabled = isSubmitting
+        lastInput.disabled = isSubmitting
+        if (isSubmitting) {
+          submitBtn.setAttribute('aria-busy', 'true')
+          submitLabel.textContent = COPY.submittingLabel
+          submitSpinner.style.display = 'inline-flex'
+        } else {
+          submitBtn.removeAttribute('aria-busy')
+          submitLabel.textContent = COPY.submitLabel
+          submitSpinner.style.display = 'none'
+        }
+      }
+
+      async function handleSubmit() {
+        if (!firstInput || !lastInput || !firstErr || !lastErr) return
+        clearBanner()
+
+        const firstName = firstInput.value.trim()
+        const lastName = lastInput.value.trim()
+
+        // Client-side validation (parity with Wave 1 SQL gate — M2).
+        const firstMsg = validateName(firstName)
+        const lastMsg = validateName(lastName)
+        setFieldError(firstInput, firstErr, firstMsg)
+        setFieldError(lastInput, lastErr, lastMsg)
+
+        if (firstMsg) {
+          firstInput.focus()
+          return
+        }
+        if (lastMsg) {
+          lastInput.focus()
+          return
+        }
+
+        if (!supabase || !session) {
+          showError(COPY.errorSessionLost)
+          return
+        }
+
+        setSubmitting(true)
+
+        try {
+          // Step 2: update profile (RLS permits self-update per migration 011).
+          const nowIso = new Date().toISOString()
+          const { error: updateError } = await supabase
+            .from('profiles')
+            .update({
+              first_name: firstName,
+              last_name: lastName,
+              profile_completed_at: nowIso,
+            })
+            .eq('id', session.user.id)
+
+          if (updateError) {
+            showError(COPY.errorGeneric)
+            setSubmitting(false)
+            return
+          }
+
+          // Step 3: issue license key via Wave 1 RPC.
+          const { data: rpcData, error: rpcError } = await supabase.rpc(
+            'issue_license_key_if_profile_complete',
+            { user_id_input: session.user.id },
+          )
+
+          if (rpcError) {
+            showError(COPY.errorKeyIssuance)
+            setSubmitting(false)
+            return
+          }
+
+          // Wave 1 RPC returns TABLE(issued_now BOOLEAN, reason TEXT). Unpack defensively.
+          const row = Array.isArray(rpcData) ? rpcData[0] : rpcData
+          const issuedNow = row?.issued_now === true
+          const reason: string | null = row?.reason ?? null
+
+          // Resolve RPC response: success branches fall through; error branches bail early.
+          // - { issued_now: true, reason: null }    → first-time issuance (happy path)
+          // - { issued_now: false, reason: 'already_issued' } → legacy user with an active key (happy path)
+          // - { issued_now: false, reason: 'concurrent_call' } → race w/ retry webhook; probe keys
+          // - { issued_now: false, reason: 'profile_incomplete' } → server-side re-validation failed
+          const happyPath = issuedNow || reason === 'already_issued'
+          if (!happyPath && reason === 'concurrent_call') {
+            await new Promise((resolve) => setTimeout(resolve, 500))
+            const { data: keys } = await supabase
+              .from('license_keys')
+              .select('status')
+              .eq('user_id', session.user.id)
+              .eq('status', 'active')
+              .limit(1)
+            if (!Array.isArray(keys) || keys.length === 0) {
+              showError(COPY.errorConcurrent)
+              setSubmitting(false)
+              return
+            }
+          } else if (!happyPath && reason === 'profile_incomplete') {
+            showError(COPY.errorProfileIncomplete)
+            setSubmitting(false)
+            return
+          } else if (!happyPath) {
+            showError(COPY.errorUnexpected)
+            setSubmitting(false)
+            return
+          }
+
+          // Step 4: tier-cache invalidation interim.
+          // TODO(SMI-4405): once invalidate_tier_cache(user_id) RPC ships in Wave 3, call it here.
+          // Wave 2 relies on the TIER_CACHE_TTL_SECONDS=60 env bump (Wave 1 spec §7 E1, H9) — no action required.
+
+          // Step 5: success toast + redirect.
+          if (toast) {
+            toast.style.display = 'block'
+          }
+          setTimeout(() => {
+            window.location.href = validatedNext
+          }, 2000)
+        } catch {
+          showError(COPY.errorGeneric)
+          setSubmitting(false)
+        }
+      }
+    })
+  </script>
+</BaseLayout>
+
+<style>
+  /* Dark-mode palette: bg #0d0d0f, card #121214, border #2a2a2f, accent #E07A5F. */
+  .profile-container { max-width: 32rem; margin: 0 auto; padding: 3rem 1.5rem 4rem; }
+  .profile-card { background: #121214; border: 1px solid #2a2a2f; border-radius: 0.75rem; padding: 2rem; }
+  .profile-heading { font-size: 1.75rem; font-weight: 700; color: #fafafa; margin: 0 0 0.75rem; line-height: 1.25; }
+  .profile-subhead { font-size: 1rem; color: #d4d4d8; margin: 0 0 1.25rem; line-height: 1.5; }
+  .profile-helper { font-size: 0.8125rem; color: #a1a1aa; padding: 0.625rem 0.875rem; background: rgba(161, 161, 170, 0.06); border: 1px solid #2a2a2f; border-radius: 0.5rem; margin: 0 0 1.25rem; }
+  .profile-error-banner { padding: 0.75rem 1rem; background: rgba(239, 68, 68, 0.08); border: 1px solid rgba(239, 68, 68, 0.25); border-radius: 0.5rem; color: #fca5a5; font-size: 0.875rem; margin: 0 0 1.25rem; line-height: 1.5; }
+  .profile-error-banner:focus-visible { outline: 2px solid #e07a5f; outline-offset: 2px; }
+  .profile-form { display: flex; flex-direction: column; gap: 1rem; }
+  .profile-fieldset { display: flex; flex-direction: column; gap: 1rem; margin: 0; padding: 0; border: none; }
+  .form-group { display: flex; flex-direction: column; gap: 0.375rem; }
+  .form-label { font-size: 0.875rem; font-weight: 500; color: #d4d4d8; }
+  .form-input { width: 100%; padding: 0.625rem 0.875rem; background: #0d0d0f; border: 1px solid #3f3f46; border-radius: 0.5rem; color: #fafafa; font-family: inherit; font-size: 0.9375rem; transition: border-color 0.15s; }
+  .form-input:hover:not(:disabled) { border-color: #52525b; }
+  .form-input:focus-visible { outline: 2px solid #e07a5f; outline-offset: 2px; border-color: #e07a5f; }
+  .form-input:disabled { opacity: 0.6; cursor: not-allowed; }
+  .form-input[aria-invalid='true'] { border-color: #ef4444; }
+  .form-error { font-size: 0.8125rem; color: #fca5a5; margin: 0; display: none; line-height: 1.4; }
+  .btn { display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem; padding: 0.75rem 1.25rem; border-radius: 0.5rem; font-size: 0.9375rem; font-weight: 600; font-family: inherit; cursor: pointer; transition: all 0.15s; border: 1px solid transparent; }
+  .btn:disabled { opacity: 0.7; cursor: not-allowed; }
+  .btn-primary { background: #e07a5f; color: #fafafa; border-color: #e07a5f; }
+  .btn-primary:hover:not(:disabled) { background: #d4694e; border-color: #d4694e; }
+  .btn-full { width: 100%; }
+  .submit-spinner { display: inline-flex; width: 18px; height: 18px; }
+  .spinner-svg { width: 100%; height: 100%; animation: spin 0.8s linear infinite; color: #fafafa; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .profile-fineprint { font-size: 0.8125rem; color: #a1a1aa; margin: 0.5rem 0 0; text-align: center; line-height: 1.5; }
+  .profile-legal { font-size: 0.75rem; color: #71717a; margin: 0; text-align: center; text-transform: uppercase; letter-spacing: 0.05em; line-height: 1.5; }
+  .profile-link { color: #e07a5f; text-decoration: none; font-weight: 500; }
+  .profile-link:hover { text-decoration: underline; }
+  .profile-toast { margin-top: 1.25rem; padding: 0.75rem 1rem; background: rgba(34, 197, 94, 0.08); border: 1px solid rgba(34, 197, 94, 0.25); border-radius: 0.5rem; color: #86efac; font-size: 0.875rem; text-align: center; }
+  .skeleton { background: linear-gradient(90deg, #18181b 0%, #27272a 50%, #18181b 100%); background-size: 200% 100%; animation: shimmer 1.4s ease-in-out infinite; border-radius: 0.375rem; margin-bottom: 1rem; }
+  .skeleton-heading { height: 1.75rem; width: 75%; }
+  .skeleton-sub { height: 1rem; width: 90%; margin-bottom: 1.5rem; }
+  .skeleton-field { height: 2.5rem; width: 100%; }
+  .skeleton-button { height: 2.75rem; width: 100%; margin-top: 0.5rem; }
+  @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+  /* prefers-reduced-motion: BaseLayout's global reset already neutralizes animations/transitions. */
+</style>

--- a/packages/website/src/pages/complete-profile.astro
+++ b/packages/website/src/pages/complete-profile.astro
@@ -49,12 +49,7 @@ const source = rawSource === 'cli' ? 'cli' : ''
 
       <p id="profile-subhead" class="profile-subhead"></p>
 
-      <div
-        id="github-helper"
-        class="profile-helper"
-        role="note"
-        style="display: none;"
-      >
+      <div id="github-helper" class="profile-helper" role="note" style="display: none;">
         We grabbed this from your GitHub. Edit if wrong.
       </div>
 
@@ -105,7 +100,12 @@ const source = rawSource === 'cli' ? 'cli' : ''
 
         <button type="submit" id="submit-btn" class="btn btn-primary btn-full">
           <span id="submit-label">Activate free access</span>
-          <span id="submit-spinner" class="submit-spinner" style="display: none;" aria-hidden="true">
+          <span
+            id="submit-spinner"
+            class="submit-spinner"
+            style="display: none;"
+            aria-hidden="true"
+          >
             <svg viewBox="0 0 24 24" class="spinner-svg">
               <circle
                 cx="12"
@@ -115,11 +115,8 @@ const source = rawSource === 'cli' ? 'cli' : ''
                 stroke-width="4"
                 fill="none"
                 opacity="0.25"></circle>
-              <path
-                d="M12 2a10 10 0 0 1 10 10"
-                stroke="currentColor"
-                stroke-width="4"
-                fill="none"></path>
+              <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
+              ></path>
             </svg>
           </span>
         </button>
@@ -166,9 +163,8 @@ const source = rawSource === 'cli' ? 'cli' : ''
     } from '../lib/complete-profile-copy'
 
     document.addEventListener('astro:page-load', async () => {
-      const ctx =
-        (window as unknown as { __COMPLETE_PROFILE_CONTEXT__?: CompleteProfileContext })
-          .__COMPLETE_PROFILE_CONTEXT__ ?? { source: '', next: '' }
+      const ctx = (window as unknown as { __COMPLETE_PROFILE_CONTEXT__?: CompleteProfileContext })
+        .__COMPLETE_PROFILE_CONTEXT__ ?? { source: '', next: '' }
 
       const main = document.getElementById('profile-main')
       const loading = document.getElementById('state-loading')
@@ -304,11 +300,7 @@ const source = rawSource === 'cli' ? 'cli' : ''
         banner.innerHTML = ''
       }
 
-      function setFieldError(
-        input: HTMLInputElement,
-        errEl: HTMLElement,
-        message: string | null,
-      ) {
+      function setFieldError(input: HTMLInputElement, errEl: HTMLElement, message: string | null) {
         if (message) {
           input.setAttribute('aria-invalid', 'true')
           errEl.textContent = message
@@ -386,7 +378,7 @@ const source = rawSource === 'cli' ? 'cli' : ''
           // Step 3: issue license key via Wave 1 RPC.
           const { data: rpcData, error: rpcError } = await supabase.rpc(
             'issue_license_key_if_profile_complete',
-            { user_id_input: session.user.id },
+            { user_id_input: session.user.id }
           )
 
           if (rpcError) {
@@ -451,41 +443,221 @@ const source = rawSource === 'cli' ? 'cli' : ''
 
 <style>
   /* Dark-mode palette: bg #0d0d0f, card #121214, border #2a2a2f, accent #E07A5F. */
-  .profile-container { max-width: 32rem; margin: 0 auto; padding: 3rem 1.5rem 4rem; }
-  .profile-card { background: #121214; border: 1px solid #2a2a2f; border-radius: 0.75rem; padding: 2rem; }
-  .profile-heading { font-size: 1.75rem; font-weight: 700; color: #fafafa; margin: 0 0 0.75rem; line-height: 1.25; }
-  .profile-subhead { font-size: 1rem; color: #d4d4d8; margin: 0 0 1.25rem; line-height: 1.5; }
-  .profile-helper { font-size: 0.8125rem; color: #a1a1aa; padding: 0.625rem 0.875rem; background: rgba(161, 161, 170, 0.06); border: 1px solid #2a2a2f; border-radius: 0.5rem; margin: 0 0 1.25rem; }
-  .profile-error-banner { padding: 0.75rem 1rem; background: rgba(239, 68, 68, 0.08); border: 1px solid rgba(239, 68, 68, 0.25); border-radius: 0.5rem; color: #fca5a5; font-size: 0.875rem; margin: 0 0 1.25rem; line-height: 1.5; }
-  .profile-error-banner:focus-visible { outline: 2px solid #e07a5f; outline-offset: 2px; }
-  .profile-form { display: flex; flex-direction: column; gap: 1rem; }
-  .profile-fieldset { display: flex; flex-direction: column; gap: 1rem; margin: 0; padding: 0; border: none; }
-  .form-group { display: flex; flex-direction: column; gap: 0.375rem; }
-  .form-label { font-size: 0.875rem; font-weight: 500; color: #d4d4d8; }
-  .form-input { width: 100%; padding: 0.625rem 0.875rem; background: #0d0d0f; border: 1px solid #3f3f46; border-radius: 0.5rem; color: #fafafa; font-family: inherit; font-size: 0.9375rem; transition: border-color 0.15s; }
-  .form-input:hover:not(:disabled) { border-color: #52525b; }
-  .form-input:focus-visible { outline: 2px solid #e07a5f; outline-offset: 2px; border-color: #e07a5f; }
-  .form-input:disabled { opacity: 0.6; cursor: not-allowed; }
-  .form-input[aria-invalid='true'] { border-color: #ef4444; }
-  .form-error { font-size: 0.8125rem; color: #fca5a5; margin: 0; display: none; line-height: 1.4; }
-  .btn { display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem; padding: 0.75rem 1.25rem; border-radius: 0.5rem; font-size: 0.9375rem; font-weight: 600; font-family: inherit; cursor: pointer; transition: all 0.15s; border: 1px solid transparent; }
-  .btn:disabled { opacity: 0.7; cursor: not-allowed; }
-  .btn-primary { background: #e07a5f; color: #fafafa; border-color: #e07a5f; }
-  .btn-primary:hover:not(:disabled) { background: #d4694e; border-color: #d4694e; }
-  .btn-full { width: 100%; }
-  .submit-spinner { display: inline-flex; width: 18px; height: 18px; }
-  .spinner-svg { width: 100%; height: 100%; animation: spin 0.8s linear infinite; color: #fafafa; }
-  @keyframes spin { to { transform: rotate(360deg); } }
-  .profile-fineprint { font-size: 0.8125rem; color: #a1a1aa; margin: 0.5rem 0 0; text-align: center; line-height: 1.5; }
-  .profile-legal { font-size: 0.75rem; color: #71717a; margin: 0; text-align: center; text-transform: uppercase; letter-spacing: 0.05em; line-height: 1.5; }
-  .profile-link { color: #e07a5f; text-decoration: none; font-weight: 500; }
-  .profile-link:hover { text-decoration: underline; }
-  .profile-toast { margin-top: 1.25rem; padding: 0.75rem 1rem; background: rgba(34, 197, 94, 0.08); border: 1px solid rgba(34, 197, 94, 0.25); border-radius: 0.5rem; color: #86efac; font-size: 0.875rem; text-align: center; }
-  .skeleton { background: linear-gradient(90deg, #18181b 0%, #27272a 50%, #18181b 100%); background-size: 200% 100%; animation: shimmer 1.4s ease-in-out infinite; border-radius: 0.375rem; margin-bottom: 1rem; }
-  .skeleton-heading { height: 1.75rem; width: 75%; }
-  .skeleton-sub { height: 1rem; width: 90%; margin-bottom: 1.5rem; }
-  .skeleton-field { height: 2.5rem; width: 100%; }
-  .skeleton-button { height: 2.75rem; width: 100%; margin-top: 0.5rem; }
-  @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+  .profile-container {
+    max-width: 32rem;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 4rem;
+  }
+  .profile-card {
+    background: #121214;
+    border: 1px solid #2a2a2f;
+    border-radius: 0.75rem;
+    padding: 2rem;
+  }
+  .profile-heading {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #fafafa;
+    margin: 0 0 0.75rem;
+    line-height: 1.25;
+  }
+  .profile-subhead {
+    font-size: 1rem;
+    color: #d4d4d8;
+    margin: 0 0 1.25rem;
+    line-height: 1.5;
+  }
+  .profile-helper {
+    font-size: 0.8125rem;
+    color: #a1a1aa;
+    padding: 0.625rem 0.875rem;
+    background: rgba(161, 161, 170, 0.06);
+    border: 1px solid #2a2a2f;
+    border-radius: 0.5rem;
+    margin: 0 0 1.25rem;
+  }
+  .profile-error-banner {
+    padding: 0.75rem 1rem;
+    background: rgba(239, 68, 68, 0.08);
+    border: 1px solid rgba(239, 68, 68, 0.25);
+    border-radius: 0.5rem;
+    color: #fca5a5;
+    font-size: 0.875rem;
+    margin: 0 0 1.25rem;
+    line-height: 1.5;
+  }
+  .profile-error-banner:focus-visible {
+    outline: 2px solid #e07a5f;
+    outline-offset: 2px;
+  }
+  .profile-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .profile-fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+    border: none;
+  }
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+  .form-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #d4d4d8;
+  }
+  .form-input {
+    width: 100%;
+    padding: 0.625rem 0.875rem;
+    background: #0d0d0f;
+    border: 1px solid #3f3f46;
+    border-radius: 0.5rem;
+    color: #fafafa;
+    font-family: inherit;
+    font-size: 0.9375rem;
+    transition: border-color 0.15s;
+  }
+  .form-input:hover:not(:disabled) {
+    border-color: #52525b;
+  }
+  .form-input:focus-visible {
+    outline: 2px solid #e07a5f;
+    outline-offset: 2px;
+    border-color: #e07a5f;
+  }
+  .form-input:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  .form-input[aria-invalid='true'] {
+    border-color: #ef4444;
+  }
+  .form-error {
+    font-size: 0.8125rem;
+    color: #fca5a5;
+    margin: 0;
+    display: none;
+    line-height: 1.4;
+  }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    border-radius: 0.5rem;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.15s;
+    border: 1px solid transparent;
+  }
+  .btn:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+  .btn-primary {
+    background: #e07a5f;
+    color: #fafafa;
+    border-color: #e07a5f;
+  }
+  .btn-primary:hover:not(:disabled) {
+    background: #d4694e;
+    border-color: #d4694e;
+  }
+  .btn-full {
+    width: 100%;
+  }
+  .submit-spinner {
+    display: inline-flex;
+    width: 18px;
+    height: 18px;
+  }
+  .spinner-svg {
+    width: 100%;
+    height: 100%;
+    animation: spin 0.8s linear infinite;
+    color: #fafafa;
+  }
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  .profile-fineprint {
+    font-size: 0.8125rem;
+    color: #a1a1aa;
+    margin: 0.5rem 0 0;
+    text-align: center;
+    line-height: 1.5;
+  }
+  .profile-legal {
+    font-size: 0.75rem;
+    color: #71717a;
+    margin: 0;
+    text-align: center;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    line-height: 1.5;
+  }
+  .profile-link {
+    color: #e07a5f;
+    text-decoration: none;
+    font-weight: 500;
+  }
+  .profile-link:hover {
+    text-decoration: underline;
+  }
+  .profile-toast {
+    margin-top: 1.25rem;
+    padding: 0.75rem 1rem;
+    background: rgba(34, 197, 94, 0.08);
+    border: 1px solid rgba(34, 197, 94, 0.25);
+    border-radius: 0.5rem;
+    color: #86efac;
+    font-size: 0.875rem;
+    text-align: center;
+  }
+  .skeleton {
+    background: linear-gradient(90deg, #18181b 0%, #27272a 50%, #18181b 100%);
+    background-size: 200% 100%;
+    animation: shimmer 1.4s ease-in-out infinite;
+    border-radius: 0.375rem;
+    margin-bottom: 1rem;
+  }
+  .skeleton-heading {
+    height: 1.75rem;
+    width: 75%;
+  }
+  .skeleton-sub {
+    height: 1rem;
+    width: 90%;
+    margin-bottom: 1.5rem;
+  }
+  .skeleton-field {
+    height: 2.5rem;
+    width: 100%;
+  }
+  .skeleton-button {
+    height: 2.75rem;
+    width: 100%;
+    margin-top: 0.5rem;
+  }
+  @keyframes shimmer {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
   /* prefers-reduced-motion: BaseLayout's global reset already neutralizes animations/transitions. */
 </style>

--- a/packages/website/src/pages/device.astro
+++ b/packages/website/src/pages/device.astro
@@ -1,0 +1,144 @@
+---
+/**
+ * /device — CLI device-code approval stub (Wave 2)
+ *
+ * SMI-4401 Wave 2 — Routable skeleton only. Wave 3 (SMI-4402) owns RFC 8628
+ * device-code approval behavior; this stub exists so the URL does not 404 during
+ * Wave 3 development.
+ *
+ * H4 — User-facing copy only; no "Coming soon — complete Wave 3" jargon.
+ * L6 — No disabled Approve button; info-style text instead.
+ * §4.1 A-SEO-4 — Explicit inline robots noindex meta regardless of BaseLayout prop.
+ *
+ * Query params: `?user_code=XXXX-XXXX` (RFC 8628) — displayed read-only; not acted on.
+ */
+
+// Disable prerendering — SSR reads query params from the request URL.
+export const prerender = false
+
+import BaseLayout from '../layouts/BaseLayout.astro'
+
+const userCode = Astro.url.searchParams.get('user_code')?.trim() ?? ''
+const hasUserCode = userCode.length > 0 && userCode.length <= 128
+---
+
+<BaseLayout title="Approve CLI — Skillsmith" noindex={true}>
+  <!-- H4: explicit inline robots noindex — guarantees no indexing even if BaseLayout prop semantics change. -->
+  <meta slot="head" name="robots" content="noindex, nofollow" />
+
+  <section class="device-container">
+    <div class="device-card">
+      <h1 class="device-heading">Approve CLI sign-in</h1>
+
+      {
+        hasUserCode && (
+          <div class="code-row">
+            <label for="device-user-code" class="code-label">
+              Approval code
+            </label>
+            <input
+              id="device-user-code"
+              type="text"
+              value={userCode}
+              readonly
+              aria-readonly="true"
+              aria-label="Approval code"
+              class="code-input"
+            />
+          </div>
+        )
+      }
+
+      <p class="device-copy">
+        CLI approval is rolling out &mdash; check back soon. In the meantime,
+        <a href="/account/cli-token" class="device-link">view your CLI token</a>
+        or <a href="https://skillsmith.app/docs" class="device-link">read the docs</a>.
+      </p>
+
+      <p class="device-status">
+        Approval UI will appear here once CLI support is live.
+      </p>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .device-container {
+    max-width: 32rem;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 4rem;
+  }
+
+  .device-card {
+    background: #121214;
+    border: 1px solid #2a2a2f;
+    border-radius: 0.75rem;
+    padding: 2rem;
+  }
+
+  .device-heading {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #fafafa;
+    margin: 0 0 1.5rem;
+    line-height: 1.3;
+  }
+
+  .code-row {
+    margin-bottom: 1.5rem;
+  }
+
+  .code-label {
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #a1a1aa;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+  }
+
+  .code-input {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+    font-size: 1.125rem;
+    letter-spacing: 0.1em;
+    background: #0d0d0f;
+    border: 1px solid #3f3f46;
+    border-radius: 0.5rem;
+    color: #E07A5F;
+  }
+
+  .code-input:focus-visible {
+    outline: 2px solid #e07a5f;
+    outline-offset: 2px;
+  }
+
+  .device-copy {
+    font-size: 0.9375rem;
+    color: #d4d4d8;
+    line-height: 1.6;
+    margin: 0 0 1.25rem;
+  }
+
+  .device-link {
+    color: #E07A5F;
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  .device-link:hover {
+    text-decoration: underline;
+  }
+
+  .device-status {
+    font-size: 0.875rem;
+    color: #a1a1aa;
+    padding: 0.75rem 1rem;
+    background: rgba(161, 161, 170, 0.06);
+    border: 1px solid #2a2a2f;
+    border-radius: 0.5rem;
+    margin: 0;
+  }
+</style>

--- a/packages/website/src/pages/device.astro
+++ b/packages/website/src/pages/device.astro
@@ -52,12 +52,10 @@ const hasUserCode = userCode.length > 0 && userCode.length <= 128
       <p class="device-copy">
         CLI approval is rolling out &mdash; check back soon. In the meantime,
         <a href="/account/cli-token" class="device-link">view your CLI token</a>
-        or <a href="https://skillsmith.app/docs" class="device-link">read the docs</a>.
+        or <a href="https://www.skillsmith.app/docs" class="device-link">read the docs</a>.
       </p>
 
-      <p class="device-status">
-        Approval UI will appear here once CLI support is live.
-      </p>
+      <p class="device-status">Approval UI will appear here once CLI support is live.</p>
     </div>
   </section>
 </BaseLayout>
@@ -107,7 +105,7 @@ const hasUserCode = userCode.length > 0 && userCode.length <= 128
     background: #0d0d0f;
     border: 1px solid #3f3f46;
     border-radius: 0.5rem;
-    color: #E07A5F;
+    color: #e07a5f;
   }
 
   .code-input:focus-visible {
@@ -123,7 +121,7 @@ const hasUserCode = userCode.length > 0 && userCode.length <= 128
   }
 
   .device-link {
-    color: #E07A5F;
+    color: #e07a5f;
     text-decoration: none;
     font-weight: 500;
   }

--- a/packages/website/src/pages/login.astro
+++ b/packages/website/src/pages/login.astro
@@ -22,7 +22,9 @@ import Nav from '../components/Nav.astro'
 const supabaseConfig = getSupabaseConfig()
 
 // Get redirect URL from query params
-const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
+// H7: accept both `next=` (new canonical param) and legacy `redirect=` — new pages use `next`.
+const redirectTo =
+  Astro.url.searchParams.get('next') ?? Astro.url.searchParams.get('redirect') ?? '/account'
 ---
 
 <!doctype html>
@@ -564,8 +566,9 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
       supabase.auth.getSession().then(({ data: { session } }) => {
         if (session) {
           // Already logged in, redirect to account
-          const redirectTo =
-            new URLSearchParams(window.location.search).get('redirect') || '/account'
+          // H7: prefer `next=` (new canonical), fall back to legacy `redirect=`.
+          const params = new URLSearchParams(window.location.search)
+          const redirectTo = params.get('next') ?? params.get('redirect') ?? '/account'
           window.location.href = redirectTo
         }
       })
@@ -623,8 +626,9 @@ const redirectTo = Astro.url.searchParams.get('redirect') || '/account'
           }
 
           // Redirect after short delay
-          const redirectTo =
-            new URLSearchParams(window.location.search).get('redirect') || '/account'
+          // H7: prefer `next=` (new canonical), fall back to legacy `redirect=`.
+          const params = new URLSearchParams(window.location.search)
+          const redirectTo = params.get('next') ?? params.get('redirect') ?? '/account'
           setTimeout(() => {
             window.location.href = redirectTo
           }, 500)

--- a/packages/website/src/pages/return-to-cli.astro
+++ b/packages/website/src/pages/return-to-cli.astro
@@ -1,0 +1,301 @@
+---
+/**
+ * /return-to-cli — Post-submit landing for CLI-originated profile completion
+ *
+ * SMI-4401 Wave 2 — Spec §5.2.
+ *
+ * Flow: user arrives here after submitting /complete-profile with source=cli. The CLI's
+ * 403-recovery message told them to come to the web; this page reassures them that their
+ * terminal command will now work, with a 30s countdown matching worst-case tier-cache
+ * propagation (TIER_CACHE_TTL_SECONDS=60) and a "Check key status" button.
+ *
+ * M4 — Countdown UI + check-status button with fallback to direct license_keys query.
+ * A11y — H1 receives focus on load via tabindex="-1"; countdown announced via aria-live="polite".
+ */
+
+export const prerender = false
+
+import BaseLayout from '../layouts/BaseLayout.astro'
+---
+
+<BaseLayout title="You can go back to your terminal — Skillsmith" noindex={true}>
+  <section class="return-container">
+    <div class="return-card">
+      <h1 id="return-heading" tabindex="-1" class="return-heading">Head back to your terminal.</h1>
+      <p class="return-subhead">Your Skillsmith command will work now.</p>
+
+      <pre class="return-code" aria-label="Example CLI command"><code>skillsmith search &lt;query&gt;</code></pre>
+
+      <p id="countdown-text" role="status" aria-live="polite" class="return-countdown">
+        Your key should work in <span id="countdown-value">30</span>s.
+      </p>
+
+      <p class="return-reassurance">
+        If it still doesn&rsquo;t work, wait a few seconds and try again &mdash; your account is
+        propagating.
+      </p>
+
+      <div class="return-actions">
+        <button
+          type="button"
+          id="check-status-btn"
+          class="btn btn-secondary"
+          aria-label="Check CLI key status"
+        >
+          Check key status
+        </button>
+        <a href="/account/cli-token" class="return-link">View your key on the dashboard &rarr;</a>
+      </div>
+
+      <div
+        id="status-toast"
+        role="status"
+        aria-live="polite"
+        class="return-toast"
+        style="display: none;"
+      >
+      </div>
+    </div>
+  </section>
+
+  <script>
+    import { getSupabaseClient } from '../lib/supabase-client'
+
+    document.addEventListener('astro:page-load', () => {
+      const heading = document.getElementById('return-heading') as HTMLElement | null
+      const countdownValue = document.getElementById('countdown-value')
+      const countdownText = document.getElementById('countdown-text')
+      const checkBtn = document.getElementById('check-status-btn') as HTMLButtonElement | null
+      const toast = document.getElementById('status-toast')
+
+      if (!heading || !countdownValue || !countdownText || !checkBtn || !toast) return
+
+      // Focus the heading so screen readers announce the landing state.
+      try {
+        heading.focus({ preventScroll: true })
+      } catch {
+        /* older browsers — non-critical */
+      }
+
+      // 30-second countdown (M4).
+      let remaining = 30
+      const interval = window.setInterval(() => {
+        remaining -= 1
+        if (remaining <= 0) {
+          window.clearInterval(interval)
+          countdownText.innerHTML =
+            'Your key should be live now. If not, tap <strong>Check key status</strong> below.'
+          checkBtn.classList.add('btn-primary')
+          checkBtn.classList.remove('btn-secondary')
+          return
+        }
+        countdownValue.textContent = String(remaining)
+      }, 1000)
+
+      function showToast(message: string, variant: 'success' | 'info' | 'error') {
+        if (!toast) return
+        toast.textContent = message
+        toast.className = `return-toast return-toast--${variant}`
+        toast.style.display = 'block'
+      }
+
+      checkBtn.addEventListener('click', async () => {
+        checkBtn.disabled = true
+        checkBtn.setAttribute('aria-busy', 'true')
+
+        try {
+          const supabase = getSupabaseClient()
+          if (!supabase) {
+            showToast('Still propagating — try again in 15 seconds.', 'info')
+            return
+          }
+
+          const {
+            data: { session },
+          } = await supabase.auth.getSession()
+
+          if (!session) {
+            showToast('Please sign in to check your key status.', 'error')
+            return
+          }
+
+          // Direct license_keys query is the most reliable signal that does not require an API call.
+          const { data, error } = await supabase
+            .from('license_keys')
+            .select('status')
+            .eq('user_id', session.user.id)
+            .eq('status', 'active')
+            .limit(1)
+
+          if (error) {
+            showToast('Still propagating — try again in 15 seconds.', 'info')
+            return
+          }
+
+          if (Array.isArray(data) && data.length > 0) {
+            showToast('Key is live!', 'success')
+          } else {
+            showToast('Still propagating — try again in 15 seconds.', 'info')
+          }
+        } catch {
+          showToast('Still propagating — try again in 15 seconds.', 'info')
+        } finally {
+          checkBtn.disabled = false
+          checkBtn.removeAttribute('aria-busy')
+        }
+      })
+    })
+  </script>
+</BaseLayout>
+
+<style>
+  .return-container {
+    max-width: 32rem;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 4rem;
+  }
+
+  .return-card {
+    background: #121214;
+    border: 1px solid #2a2a2f;
+    border-radius: 0.75rem;
+    padding: 2rem;
+  }
+
+  .return-heading {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #fafafa;
+    margin: 0 0 0.5rem;
+    line-height: 1.25;
+  }
+
+  .return-heading:focus-visible {
+    outline: 2px solid #e07a5f;
+    outline-offset: 4px;
+    border-radius: 0.25rem;
+  }
+
+  .return-subhead {
+    font-size: 1rem;
+    color: #a1a1aa;
+    margin: 0 0 1.5rem;
+  }
+
+  .return-code {
+    margin: 0 0 1.5rem;
+    padding: 0.875rem 1rem;
+    background: #0d0d0f;
+    border: 1px solid #2a2a2f;
+    border-radius: 0.5rem;
+    font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.875rem;
+    color: #E07A5F;
+    overflow-x: auto;
+  }
+
+  .return-countdown {
+    font-size: 0.9375rem;
+    color: #d4d4d8;
+    margin: 0 0 0.75rem;
+  }
+
+  .return-reassurance {
+    font-size: 0.875rem;
+    color: #a1a1aa;
+    margin: 0 0 1.5rem;
+    line-height: 1.5;
+  }
+
+  .return-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .return-link {
+    color: #E07A5F;
+    text-decoration: none;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  .return-link:hover {
+    text-decoration: underline;
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1.25rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.15s;
+    border: 1px solid transparent;
+  }
+
+  .btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .btn-primary {
+    background: #E07A5F;
+    color: #fafafa;
+    border-color: #E07A5F;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background: #D4694E;
+    border-color: #D4694E;
+  }
+
+  .btn-secondary {
+    background: #18181b;
+    color: #d4d4d8;
+    border-color: #3f3f46;
+  }
+
+  .btn-secondary:hover:not(:disabled) {
+    background: #27272a;
+    color: #fafafa;
+  }
+
+  .return-toast {
+    margin-top: 1.25rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    border: 1px solid transparent;
+  }
+
+  .return-toast--success {
+    background: rgba(34, 197, 94, 0.08);
+    border-color: rgba(34, 197, 94, 0.25);
+    color: #86efac;
+  }
+
+  .return-toast--info {
+    background: rgba(161, 161, 170, 0.08);
+    border-color: #2a2a2f;
+    color: #d4d4d8;
+  }
+
+  .return-toast--error {
+    background: rgba(239, 68, 68, 0.08);
+    border-color: rgba(239, 68, 68, 0.25);
+    color: #fca5a5;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .btn {
+      transition: none;
+    }
+  }
+</style>

--- a/packages/website/src/pages/return-to-cli.astro
+++ b/packages/website/src/pages/return-to-cli.astro
@@ -24,7 +24,9 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       <h1 id="return-heading" tabindex="-1" class="return-heading">Head back to your terminal.</h1>
       <p class="return-subhead">Your Skillsmith command will work now.</p>
 
-      <pre class="return-code" aria-label="Example CLI command"><code>skillsmith search &lt;query&gt;</code></pre>
+      <pre
+        class="return-code"
+        aria-label="Example CLI command"><code>skillsmith search &lt;query&gt;</code></pre>
 
       <p id="countdown-text" role="status" aria-live="polite" class="return-countdown">
         Your key should work in <span id="countdown-value">30</span>s.
@@ -190,7 +192,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
     border-radius: 0.5rem;
     font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
     font-size: 0.875rem;
-    color: #E07A5F;
+    color: #e07a5f;
     overflow-x: auto;
   }
 
@@ -215,7 +217,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
   }
 
   .return-link {
-    color: #E07A5F;
+    color: #e07a5f;
     text-decoration: none;
     font-size: 0.875rem;
     font-weight: 500;
@@ -246,14 +248,14 @@ import BaseLayout from '../layouts/BaseLayout.astro'
   }
 
   .btn-primary {
-    background: #E07A5F;
+    background: #e07a5f;
     color: #fafafa;
-    border-color: #E07A5F;
+    border-color: #e07a5f;
   }
 
   .btn-primary:hover:not(:disabled) {
-    background: #D4694E;
-    border-color: #D4694E;
+    background: #d4694e;
+    border-color: #d4694e;
   }
 
   .btn-secondary {

--- a/packages/website/src/pages/signup.astro
+++ b/packages/website/src/pages/signup.astro
@@ -360,7 +360,9 @@ const savingsPercent = period === 'annual' ? 17 : 0 // ~17% savings
                     maxlength="64"
                     aria-describedby="last-name-hint"
                   />
-                  <p id="last-name-hint" class="input-hint">&nbsp;</p>
+                  <p id="last-name-hint" class="input-hint">
+                    &nbsp;
+                  </p>
                 </div>
 
                 <div class="form-group">

--- a/packages/website/src/pages/signup.astro
+++ b/packages/website/src/pages/signup.astro
@@ -314,7 +314,7 @@ const savingsPercent = period === 'annual' ? 17 : 0 // ~17% savings
                 <span>or sign up with email</span>
               </div>
 
-              <form id="register-form" class="auth-form">
+              <form id="register-form" class="auth-form" novalidate>
                 <div class="form-group">
                   <label for="full-name">Full Name (optional)</label>
                   <input
@@ -324,6 +324,43 @@ const savingsPercent = period === 'annual' ? 17 : 0 // ~17% savings
                     placeholder="John Doe"
                     autocomplete="name"
                   />
+                </div>
+
+                {/* SMI-4401 Wave 2: required first/last name for quid-pro-quo free tier (Wave 1 G2 trigger).
+                    Validation mirrors the Wave 1 SQL gate: min 2, max 64, at least one letter.
+                    No sequential/repeat rules. */}
+                <div class="form-group">
+                  <label for="first-name">First name</label>
+                  <input
+                    type="text"
+                    id="first-name"
+                    name="first_name"
+                    placeholder="Jane"
+                    required
+                    autocomplete="given-name"
+                    minlength="2"
+                    maxlength="64"
+                    aria-describedby="first-name-hint"
+                  />
+                  <p id="first-name-hint" class="input-hint">
+                    Your real name helps us personalize recommendations.
+                  </p>
+                </div>
+
+                <div class="form-group">
+                  <label for="last-name">Last name</label>
+                  <input
+                    type="text"
+                    id="last-name"
+                    name="last_name"
+                    placeholder="Doe"
+                    required
+                    autocomplete="family-name"
+                    minlength="2"
+                    maxlength="64"
+                    aria-describedby="last-name-hint"
+                  />
+                  <p id="last-name-hint" class="input-hint">&nbsp;</p>
                 </div>
 
                 <div class="form-group">
@@ -1204,12 +1241,42 @@ const savingsPercent = period === 'annual' ? 17 : 0 // ~17% savings
           const email = formData.get('email') as string
           const password = formData.get('password') as string
           const fullName = (formData.get('fullName') as string) || ''
+          // SMI-4401 Wave 2: required fields for Wave 1 `handle_new_user` trigger fast-path.
+          const firstName = ((formData.get('first_name') as string) || '').trim()
+          const lastName = ((formData.get('last_name') as string) || '').trim()
+
+          // SMI-4401 Wave 2 client validation (mirrors Wave 1 SQL gate: min 2, max 64, ≥1 letter).
+          const nameRe = /[A-Za-z]/
+          const firstNameInput = document.getElementById('first-name') as HTMLInputElement | null
+          const lastNameInput = document.getElementById('last-name') as HTMLInputElement | null
+          if (firstNameInput) firstNameInput.setAttribute('aria-invalid', 'false')
+          if (lastNameInput) lastNameInput.setAttribute('aria-invalid', 'false')
+
+          const invalid = (val: string) => val.length < 2 || val.length > 64 || !nameRe.test(val)
+          if (invalid(firstName)) {
+            if (firstNameInput) {
+              firstNameInput.setAttribute('aria-invalid', 'true')
+              firstNameInput.focus()
+            }
+            throw new Error(
+              'Please enter your first name (2-64 characters, must contain a letter).'
+            )
+          }
+          if (invalid(lastName)) {
+            if (lastNameInput) {
+              lastNameInput.setAttribute('aria-invalid', 'true')
+              lastNameInput.focus()
+            }
+            throw new Error('Please enter your last name (2-64 characters, must contain a letter).')
+          }
 
           const { data, error } = await supabase.auth.signUp({
             email,
             password,
             options: {
               data: {
+                first_name: firstName,
+                last_name: lastName,
                 full_name: fullName,
               },
               emailRedirectTo: `${window.location.origin}/auth/callback`,
@@ -1227,15 +1294,20 @@ const savingsPercent = period === 'annual' ? 17 : 0 // ~17% savings
               window.gtag('event', 'sign_up', { method: 'email' })
             }
 
-            if (registerSuccess) {
-              registerSuccess.innerHTML = `
-                <strong>Check your email!</strong><br>
-                We've sent a verification link to <strong>${email}</strong>.<br>
-                Please verify your email to complete registration.
-              `
-              registerSuccess.style.display = 'block'
-            }
-            registerForm.reset()
+            // SMI-4401 Wave 2 (M8): stash pending email in localStorage so /check-email can
+            // recover if the URL param is stripped by a user agent or extension. The
+            // `setTimeout(..., 0)` defers the write past the current microtask — synchronous
+            // localStorage writes immediately before navigation can be truncated on slow
+            // devices in some browsers. Wrap in try/catch because private-mode browsers throw.
+            setTimeout(() => {
+              try {
+                localStorage.setItem('skillsmith_pending_signup_email', email)
+              } catch {
+                /* private mode — non-fatal */
+              }
+              window.location.href = `/check-email?email=${encodeURIComponent(email)}&next=/account/cli-token`
+            }, 0)
+            return
           } else if (data.session) {
             // Logged in directly (email confirmation disabled)
             // GA4: Track successful signup (SMI-2460)

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -1,5 +1,9 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro'
+// SMI-4401 Wave 2: crawler-aware signed-out overlay (L7 — SSR branch, not JS-gated).
+// Overlay markup is never emitted to crawlers so organic skills traffic remains indexable.
+import SignedOutOverlay from '../../components/SignedOutOverlay.astro'
+import { isCrawlerUserAgent } from '../../lib/crawler-detect'
 
 const categories = [
   { value: '', label: 'All Categories' },
@@ -18,6 +22,11 @@ const trustTiers = [
   { value: 'community', label: 'Community' },
   { value: 'experimental', label: 'Experimental' },
 ]
+
+// SMI-4401 Wave 2: SSR-time crawler detection. Emits a human-only overlay while keeping
+// structured data and card markup intact for GoogleBot et al.
+const userAgent = Astro.request.headers.get('user-agent') ?? ''
+const isCrawler = isCrawlerUserAgent(userAgent)
 ---
 
 <BaseLayout title="Skills" description="Search and discover agent skills">
@@ -109,7 +118,14 @@ const trustTiers = [
     }
   </script>
 
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 relative">
+    {
+      /* SMI-4401 Wave 2: signed-out overlay for humans only — never emitted to crawlers.
+         Client-side script on the overlay hides itself when an authenticated session is
+         detected (data-hidden-when-auth hook). Positioned relative to the catalog container. */
+    }
+    {!isCrawler && <SignedOutOverlay data-hidden-when-auth="true" />}
+
     <!-- Header -->
     <div class="text-center mb-12">
       <h1 class="text-4xl md:text-5xl font-bold mb-4">
@@ -118,6 +134,16 @@ const trustTiers = [
       <p class="text-dark-400 text-lg max-w-2xl mx-auto">
         Search through our collection of verified skills to enhance your development experience.
       </p>
+    </div>
+
+    {/* SMI-4401 Wave 2 A-M9-1: personalized quota banner (hidden until session + first search). */}
+    <div
+      id="skills-quota-banner"
+      class="hidden mb-6 rounded-lg border border-primary-500/30 bg-primary-500/5 px-4 py-3 text-sm text-primary-100"
+      role="status"
+      aria-live="polite"
+    >
+      <span id="skills-quota-banner-text"></span>
     </div>
 
     <!-- Search and Filters -->
@@ -374,6 +400,9 @@ const trustTiers = [
       // JWT auth provides tier-based rate limits vs anon key's community limits
       let authToken = supabaseAnonKey // Default to anon key
       let authMethod = 'anon_key'
+      // SMI-4401 Wave 2 A-M9-2: authenticated user's GitHub orgs (for signal-boost re-sort).
+      let userGithubOrgs = []
+      let userId = null
 
       async function initAuth() {
         try {
@@ -390,7 +419,27 @@ const trustTiers = [
           if (session?.access_token) {
             authToken = session.access_token
             authMethod = 'jwt'
+            userId = session.user?.id ?? null
             console.debug('[Skills] Using JWT auth for tier-based rate limits')
+
+            // SMI-4401 Wave 2 A-M9-2: fetch github_orgs for signal-boost personalization.
+            // Non-fatal on error — just skip personalization.
+            if (userId) {
+              try {
+                const { data: profile, error: profileError } = await supabase
+                  .from('profiles')
+                  .select('github_orgs')
+                  .eq('id', userId)
+                  .single()
+                if (!profileError && Array.isArray(profile?.github_orgs)) {
+                  userGithubOrgs = profile.github_orgs
+                    .map((o) => (typeof o === 'string' ? o.trim().toLowerCase() : ''))
+                    .filter(Boolean)
+                }
+              } catch (orgErr) {
+                console.debug('[Skills] github_orgs fetch failed (non-fatal):', orgErr?.message)
+              }
+            }
           } else {
             console.debug('[Skills] Using anon key (community rate limits)')
           }
@@ -444,12 +493,22 @@ const trustTiers = [
         return { color: 'text-red-400', label: 'New' }
       }
 
+      // SMI-4401 Wave 2 A-M9-2: render a "Matches your org" badge when signal-boost applies.
+      function createOrgMatchBadge(orgName) {
+        if (!orgName) return ''
+        return `<span class="inline-flex items-center gap-1 px-2 py-0.5 mt-2 rounded-full text-xs font-medium bg-primary-500/10 text-primary-300 border border-primary-500/30" aria-label="Matches your org: ${escapeHtml(orgName)}">
+          <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M10 2a6 6 0 100 12 6 6 0 000-12zm0 2a4 4 0 110 8 4 4 0 010-8z"/></svg>
+          Matches your org: ${escapeHtml(orgName)}
+        </span>`
+      }
+
       // Create skill card HTML
       function createSkillCard(skill) {
         const trustClass = trustBadgeClasses[skill.trust_tier] || trustBadgeClasses.unknown
         const stars = skill.stars ?? 0
         const tier = getQualityTier(stars)
         const ariaLabel = `${tier.label}: ${formatNumber(stars)} stars`
+        const orgMatchBadge = createOrgMatchBadge(skill._orgMatch)
 
         return `
         <a href="/skills/${encodeURIComponent(skill.id)}" class="card-hover block bg-dark-900 rounded-xl border border-dark-800 p-6 hover:border-primary-500/50">
@@ -457,6 +516,7 @@ const trustTiers = [
             <div class="flex-1 min-w-0">
               <h3 class="text-lg font-semibold text-white truncate">${escapeHtml(skill.name)}</h3>
               <p class="text-dark-500 text-sm">${escapeHtml(skill.author || 'Unknown author')}</p>
+              ${orgMatchBadge}
             </div>
             <span class="ml-4 px-2.5 py-1 text-xs font-medium rounded-full border ${trustClass}">
               ${escapeHtml(skill.trust_tier || 'unknown')}
@@ -622,7 +682,7 @@ const trustTiers = [
             if (retryButton) retryButton.classList.add('hidden')
             errorMessage.innerHTML =
               "Looks like you're enjoying Skillsmith with 100 requests so far. Great! " +
-              '<a href="/signin" class="text-primary-400 hover:text-primary-300 underline">Sign in</a> ' +
+              '<a href="/login" class="text-primary-400 hover:text-primary-300 underline">Sign in</a> ' +
               'for free for 1,000 per month.'
             showState('error')
             resultsCount.textContent = ''
@@ -689,8 +749,57 @@ const trustTiers = [
             throw new Error(`HTTP ${response.status}: ${response.statusText}`)
           }
 
+          // SMI-4401 Wave 2 A-M9-1: read rate-limit headers and surface quota banner for
+          // authenticated callers. Anon callers share a tiny global bucket so the banner only
+          // renders when we have a JWT (tier-based limits).
+          try {
+            const remaining = response.headers.get('X-RateLimit-Remaining')
+            const limit = response.headers.get('X-RateLimit-Limit')
+            const banner = document.getElementById('skills-quota-banner')
+            const bannerText = document.getElementById('skills-quota-banner-text')
+            if (
+              banner &&
+              bannerText &&
+              authMethod === 'jwt' &&
+              remaining !== null &&
+              limit !== null
+            ) {
+              const remainingNum = Number(remaining)
+              const limitNum = Number(limit)
+              if (Number.isFinite(remainingNum) && Number.isFinite(limitNum) && limitNum > 0) {
+                bannerText.textContent = `${remainingNum} of ${limitNum} free requests remaining this month`
+                banner.classList.remove('hidden')
+              }
+            }
+          } catch (headerErr) {
+            console.debug('[Skills] quota header parse failed:', headerErr?.message)
+          }
+
           const data = await response.json()
           allResults = data.data || data.skills || data.results || []
+
+          // SMI-4401 Wave 2 A-M9-2: signal-boost — surface skills whose topics or author
+          // substring match an org the user belongs to. Decorate matching cards + float
+          // them to the top of the list, preserving original order within each bucket.
+          if (userGithubOrgs.length > 0 && Array.isArray(allResults) && allResults.length > 0) {
+            allResults.forEach((skill) => {
+              if (!skill || typeof skill !== 'object') return
+              const authorLower = (skill.author || '').toLowerCase()
+              const topics = Array.isArray(skill.metadata?.topics) ? skill.metadata.topics : []
+              const topicsLower = topics
+                .map((t) => (typeof t === 'string' ? t.toLowerCase() : ''))
+                .filter(Boolean)
+              const match = userGithubOrgs.find(
+                (org) => authorLower.includes(org) || topicsLower.some((t) => t.includes(org))
+              )
+              if (match) {
+                skill._orgMatch = match
+              }
+            })
+            const matched = allResults.filter((s) => s && s._orgMatch)
+            const others = allResults.filter((s) => !s || !s._orgMatch)
+            allResults = matched.concat(others)
+          }
 
           // GA4: Track skill search (SMI-2453)
           if (typeof window.gtag === 'function') {

--- a/packages/website/tests/e2e/complete-profile.cohort.spec.ts
+++ b/packages/website/tests/e2e/complete-profile.cohort.spec.ts
@@ -1,0 +1,216 @@
+/**
+ * complete-profile.cohort.spec.ts
+ *
+ * SMI-4401 Wave 2 — companion spec to complete-profile.spec.ts. Owns the
+ * crawler-alternative and email-cohort journeys (spec §6.2):
+ *
+ *   J-F-anon    anon human → overlay visible → dismiss persists 7 days
+ *   J-F-auth    authed human with github_orgs → overlay absent + quota banner + org badges
+ *   J-EMAIL22   22-user cohort resend cooldown + /check-email full loop
+ *
+ * Split from the primary spec to keep each file under the 500-line pre-commit
+ * cap (check-file-length.mjs enforces the limit on .ts files without a
+ * test/spec exemption — see the "File-length enforcement asymmetry" note in
+ * MEMORY). Shared mocking helpers live in complete-profile.helpers.ts.
+ *
+ * Tests will FAIL until Worker 1 + Worker 2 land the pages + helpers. That is
+ * expected.
+ *
+ * Run:
+ *   cd packages/website
+ *   npx playwright test tests/e2e/complete-profile.cohort.spec.ts
+ */
+
+import { test, expect } from '@playwright/test'
+import {
+  USER_EMAIL,
+  USER_ID,
+  buildSessionToken,
+  injectSupabaseStub,
+  mockSupabase,
+} from './complete-profile.helpers'
+
+// ---------------------------------------------------------------------------
+// J-F-anon — Flow F (anon human)
+// ---------------------------------------------------------------------------
+
+test.describe('J-F-anon — Flow F anonymous human', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSupabaseStub(page)
+    await mockSupabase(page, {})
+  })
+
+  test('overlay visible, preview-anonymously dismisses for 7 days, persists across reload', async ({
+    page,
+  }) => {
+    await page.goto('/skills')
+
+    // Overlay visible for anon humans (spec §5.5 Path 2).
+    const overlay = page.locator('[role="dialog"][aria-label*="Sign in"]')
+    await expect(overlay).toBeVisible()
+
+    // Click "Preview anonymously" → overlay hides + localStorage written.
+    await page.getByRole('link', { name: /preview anonymously/i }).click()
+    await expect(overlay).not.toBeVisible()
+
+    const dismissedUntil = await page.evaluate(() =>
+      window.localStorage.getItem('skills_overlay_dismissed_until')
+    )
+    expect(dismissedUntil).toBeTruthy()
+    // The stored timestamp should be ~7 days in the future.
+    const untilMs = new Date(dismissedUntil ?? '').getTime()
+    const nowMs = Date.now()
+    expect(untilMs - nowMs).toBeGreaterThan(6 * 24 * 60 * 60 * 1000)
+    expect(untilMs - nowMs).toBeLessThan(8 * 24 * 60 * 60 * 1000)
+
+    // Reload → overlay stays hidden.
+    await page.reload()
+    await expect(overlay).not.toBeVisible()
+  })
+
+  test('SignedOutOverlay CTA routes to /login?next=/skills', async ({ page }) => {
+    // Ensure no prior dismissal pollutes the test.
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.removeItem('skills_overlay_dismissed_until')
+      } catch {
+        /* noop */
+      }
+    })
+    await page.goto('/skills')
+    const overlay = page.locator('[role="dialog"][aria-label*="Sign in"]')
+    await expect(overlay).toBeVisible()
+
+    // Click the primary CTA — should navigate to /login with next=/skills.
+    await page
+      .getByRole('link', { name: /sign in/i })
+      .first()
+      .click()
+    await page.waitForURL(/\/login\?next=%2Fskills/, { timeout: 10_000 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// J-F-auth — Flow F (authenticated human with github_orgs populated)
+// ---------------------------------------------------------------------------
+
+test.describe('J-F-auth — Flow F authenticated human', () => {
+  test('no overlay, quota banner visible, github-org badges present on at least one card', async ({
+    page,
+  }) => {
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'github' }) })
+    await mockSupabase(page, {
+      restResponses: {
+        profiles: [
+          {
+            id: USER_ID,
+            first_name: 'Ryan',
+            last_name: 'Smith',
+            profile_completed_at: new Date().toISOString(),
+            tier: 'community',
+            github_orgs: ['smith-horn', 'anthropic'],
+          },
+        ],
+      },
+    })
+
+    await page.goto('/skills')
+
+    // Overlay NOT in DOM (auth path removes it, spec §5.5 Path 3).
+    const overlayCount = await page.locator('[role="dialog"][aria-label*="Sign in"]').count()
+    expect(overlayCount).toBe(0)
+
+    // Quota banner visible with the "{N} of {M} free requests remaining" pattern (A-M9-1).
+    await expect(page.locator('body')).toContainText(/\d+ of \d+ free requests/i)
+
+    // At least one skill card decorated with a "Matches your org: ..." badge (A-M9-2).
+    // The concrete selector depends on the SignedOutOverlay sibling component
+    // Worker 2 builds — assert on the copy pattern as the stable contract.
+    await expect(page.locator('body')).toContainText(/Matches your org:/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// J-EMAIL22 — 22-user cohort resend cooldown + full loop
+// ---------------------------------------------------------------------------
+
+test.describe('J-EMAIL22 — 22-user email-verify cohort', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSupabaseStub(page)
+  })
+
+  test('signup → /check-email with email in bold; resend cooldown disables for 60s', async ({
+    page,
+  }) => {
+    await page.goto(`/check-email?email=${encodeURIComponent(USER_EMAIL)}&next=/account/cli-token`)
+
+    // Email rendered in bold (spec §4.2 A-22-1).
+    await expect(page.locator('#email-display')).toContainText(USER_EMAIL)
+
+    // Resend button initially enabled.
+    const resendBtn = page.getByRole('button', { name: /resend/i })
+    await expect(resendBtn).toBeEnabled()
+
+    // Click Resend → cooldown kicks in.
+    await resendBtn.click()
+    await expect(resendBtn).toBeDisabled()
+    await expect(resendBtn).toContainText(/\d+/) // countdown visible
+
+    // Simulate stored cooldown persists across reload (spec §5.3 L1).
+    await page.reload()
+    const persistedCountdown = page.getByRole('button', { name: /resend/i })
+    await expect(persistedCountdown).toBeDisabled()
+  })
+
+  test('email cohort: confirm-link → callback → /complete-profile empty → submit → /account/cli-token', async ({
+    page,
+  }) => {
+    // Land on /auth/callback as a fresh email-signup user whose profile is incomplete.
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
+    await mockSupabase(page, {
+      restResponses: {
+        profiles: [
+          {
+            id: USER_ID,
+            first_name: '',
+            last_name: '',
+            profile_completed_at: null,
+            tier: 'community',
+          },
+        ],
+      },
+    })
+    await page.goto('/auth/callback')
+    await page.waitForURL(/\/complete-profile/, { timeout: 10_000 })
+
+    // Email signup → empty pre-fill fields (A-22-2).
+    await expect(page.locator('input[name="first_name"]')).toHaveValue('')
+    await expect(page.locator('input[name="last_name"]')).toHaveValue('')
+
+    // Fill + submit.
+    await mockSupabase(page, {
+      rpcResponses: {
+        issue_license_key_if_profile_complete: { issued_now: true, reason: null },
+      },
+      restResponses: {
+        profiles: [
+          {
+            id: USER_ID,
+            first_name: 'Ryan',
+            last_name: 'Smith',
+            profile_completed_at: new Date().toISOString(),
+            tier: 'community',
+          },
+        ],
+      },
+    })
+    await page.fill('input[name="first_name"]', 'Ryan')
+    await page.fill('input[name="last_name"]', 'Smith')
+    await page.click('button[type="submit"]')
+
+    // Default next= for this branch is /account/cli-token (A-22-3).
+    await page.waitForURL(/\/account\/cli-token/, { timeout: 10_000 })
+    // Fresh sk_live_* key visible.
+    await expect(page.locator('body')).toContainText(/sk_live_/)
+  })
+})

--- a/packages/website/tests/e2e/complete-profile.helpers.ts
+++ b/packages/website/tests/e2e/complete-profile.helpers.ts
@@ -1,0 +1,177 @@
+/**
+ * complete-profile.helpers.ts
+ *
+ * Shared Playwright fixtures for the SMI-4401 Wave 2 E2E suite. Extracted from
+ * complete-profile.spec.ts to keep individual spec files under the 500-line
+ * pre-commit cap (check-file-length.mjs enforces this for .ts files without
+ * test/spec exemptions).
+ *
+ * Consumers: complete-profile.spec.ts, complete-profile.cohort.spec.ts.
+ */
+
+import type { Page, Route } from '@playwright/test'
+
+export const SUPABASE_HOST = 'https://stub.supabase.co'
+export const SUPABASE_ANON = 'stub-anon-key'
+export const SUPABASE_REF = 'stub' // matches `stub.supabase.co` host prefix
+
+// Stable fixture IDs — used both for storage-state generation and for assertion
+// against profiles table rows returned by mocked REST calls.
+export const USER_EMAIL = 'testuser@example.com'
+export const USER_ID = '00000000-0000-0000-0000-000000000001'
+
+/**
+ * Build a minimal Supabase v2 session payload suitable for localStorage injection.
+ * The JS client reads `sb-<ref>-auth-token` on boot; when present it skips the
+ * initial /auth/v1/token round-trip.
+ */
+export function buildSessionToken(
+  overrides: Partial<{ provider: 'email' | 'github' }> = {}
+): string {
+  const provider = overrides.provider ?? 'email'
+  return JSON.stringify({
+    access_token: 'stub-access-token',
+    refresh_token: 'stub-refresh-token',
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    expires_in: 3600,
+    token_type: 'bearer',
+    user: {
+      id: USER_ID,
+      email: USER_EMAIL,
+      app_metadata: { provider, providers: [provider] },
+      user_metadata: provider === 'github' ? { first_name: 'Ryan', last_name: 'Smith' } : {},
+      aud: 'authenticated',
+      role: 'authenticated',
+    },
+  })
+}
+
+/**
+ * Inject the `__SUPABASE_CONFIG__` stub + optional session before the page
+ * script runs. Mirrors the pattern used by team-tier-gate.spec.ts.
+ */
+export async function injectSupabaseStub(
+  page: Page,
+  opts: { session?: string | null } = {}
+): Promise<void> {
+  await page.addInitScript(
+    ({ url, anonKey, ref, session }) => {
+      ;(window as unknown as Record<string, unknown>).__SUPABASE_CONFIG__ = {
+        url,
+        anonKey,
+      }
+      if (session) {
+        try {
+          window.localStorage.setItem(`sb-${ref}-auth-token`, session)
+        } catch {
+          // swallow — some tests run before localStorage is available
+        }
+      }
+    },
+    {
+      url: SUPABASE_HOST,
+      anonKey: SUPABASE_ANON,
+      ref: SUPABASE_REF,
+      session: opts.session ?? null,
+    }
+  )
+}
+
+/**
+ * Route handler that answers RPC, auth, and REST calls with lookup-table bodies.
+ *
+ * rpcResponses       — map of RPC name → 200 JSON body
+ * restResponses      — map of pathname tail → 200 JSON body (e.g. `profiles` → [{...}])
+ * functionsResponses — map of edge-fn name → { status, body }
+ * onRequest          — invoked with every intercepted URL so tests can assert on
+ *                      call presence/absence without re-routing
+ */
+export interface MockShape {
+  rpcResponses?: Record<string, unknown>
+  restResponses?: Record<string, unknown>
+  functionsResponses?: Record<string, { status: number; body: unknown }>
+  onRequest?: (url: string) => void
+}
+
+export async function mockSupabase(page: Page, shape: MockShape): Promise<void> {
+  const { rpcResponses = {}, restResponses = {}, functionsResponses = {}, onRequest } = shape
+
+  await page.route(`${SUPABASE_HOST}/**`, async (route: Route) => {
+    const url = new URL(route.request().url())
+    onRequest?.(url.pathname + url.search)
+
+    // RPC: /rest/v1/rpc/<fn_name>
+    const rpcMatch = url.pathname.match(/\/rest\/v1\/rpc\/([^/]+)/)
+    if (rpcMatch) {
+      const fn = rpcMatch[1]
+      const body = rpcResponses[fn]
+      if (body !== undefined) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(body),
+        })
+        return
+      }
+      await route.fulfill({ status: 404, body: 'rpc not mocked: ' + fn })
+      return
+    }
+
+    // Edge functions: /functions/v1/<name>
+    const fnMatch = url.pathname.match(/\/functions\/v1\/([^/]+)/)
+    if (fnMatch) {
+      const name = fnMatch[1]
+      const resp = functionsResponses[name]
+      if (resp !== undefined) {
+        await route.fulfill({
+          status: resp.status,
+          contentType: 'application/json',
+          body: JSON.stringify(resp.body),
+        })
+        return
+      }
+      await route.fulfill({ status: 404, body: 'fn not mocked: ' + name })
+      return
+    }
+
+    // Auth endpoints: /auth/v1/*
+    if (url.pathname.startsWith('/auth/v1/')) {
+      // Default: 200 with an empty user — prevents unhandled rejections
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '{}',
+      })
+      return
+    }
+
+    // REST: /rest/v1/<table>
+    const restMatch = url.pathname.match(/\/rest\/v1\/([^/?]+)/)
+    if (restMatch) {
+      const table = restMatch[1]
+      const body = restResponses[table]
+      if (body !== undefined) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(body),
+        })
+        return
+      }
+      // Closed-default: empty array so `.single()` yields null without crashing the page.
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '[]',
+      })
+      return
+    }
+
+    // Any other Supabase URL — empty 200
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '{}',
+    })
+  })
+}

--- a/packages/website/tests/e2e/complete-profile.spec.ts
+++ b/packages/website/tests/e2e/complete-profile.spec.ts
@@ -1,0 +1,322 @@
+/**
+ * complete-profile.spec.ts
+ *
+ * SMI-4401 Wave 2 — end-to-end coverage for the free-tier quid-pro-quo auth
+ * flow. Spec §6.2 lists 8 journeys (J-TEAM removed post-Option-A).
+ *
+ * This file owns the primary-flow journeys:
+ *   J-A         email fast-path signup → /check-email → callback → /account/cli-token
+ *   J-B         GitHub OAuth → /complete-profile pre-filled → /account/cli-token
+ *                 (includes routePostAuth loop-guard H1 assertion)
+ *   J-C-stub    /device readonly stub (no approve button, no network call)
+ *   J-E         legacy 403 recovery via /complete-profile?source=cli → /return-to-cli
+ *   J-F-seo     Googlebot UA hits /skills → full HTML + both JSON-LD + no overlay
+ *
+ * The cohort + crawler-alternative journeys (J-F-anon, J-F-auth, J-EMAIL22)
+ * live in complete-profile.cohort.spec.ts to keep each file under the 500-line
+ * pre-commit cap (check-file-length.mjs enforces the limit on .ts files and
+ * does not exempt test files — see the "File-length enforcement asymmetry"
+ * note in MEMORY).
+ *
+ * Mocking strategy (shared helpers in complete-profile.helpers.ts):
+ *   - All Supabase requests are intercepted via page.route(`${SUPABASE_HOST}/**`).
+ *   - Auth session state is injected via localStorage (Supabase v2 stores the
+ *     session under `sb-<ref>-auth-token`).
+ *   - NO staging/prod network calls (prod is vrcnzpmndtroqxxoqkzy, staging is
+ *     ovhcifugwqnzoebwfuku — CLAUDE.md). Tests run against the Astro preview
+ *     server (playwright.config.ts webServer, port 4321).
+ *
+ * Expected initial state: tests will FAIL until Worker 1 + Worker 2 land the
+ * new pages and Worker 1 wires the validator. That is intentional — the spec
+ * contract is the source of truth.
+ *
+ * Run:
+ *   cd packages/website
+ *   npx playwright test tests/e2e/complete-profile.spec.ts
+ */
+
+import { test, expect } from '@playwright/test'
+import {
+  USER_EMAIL,
+  USER_ID,
+  buildSessionToken,
+  injectSupabaseStub,
+  mockSupabase,
+} from './complete-profile.helpers'
+
+// ---------------------------------------------------------------------------
+// J-A — Flow A (email fast-path)
+// ---------------------------------------------------------------------------
+
+test.describe('J-A — Flow A: email fast-path signup', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSupabaseStub(page)
+  })
+
+  test('signup submits first/last, routes to /check-email, callback completes, first-visit key issued', async ({
+    page,
+  }) => {
+    // Intercept Supabase so the signup submit does not hit the network.
+    await mockSupabase(page, {})
+    await page.goto('/signup')
+
+    // Spec §5.6 — new first_name + last_name fields + existing email + password.
+    await page.fill('input[name="first_name"]', 'Ryan')
+    await page.fill('input[name="last_name"]', 'Smith')
+    await page.fill('input[name="email"]', USER_EMAIL)
+    await page.fill('input[name="password"]', 'SecurePass123!xyz')
+    await page.click('button[type="submit"]')
+
+    // Expected redirect after signup success branch (spec §5.6 client-script block):
+    // /check-email?email=<encoded>&next=/account/cli-token
+    await page.waitForURL(/\/check-email\?email=/, { timeout: 10_000 })
+
+    // Email should be rendered in bold (spec §5.3 A-22-1).
+    await expect(page.locator('#email-display')).toContainText(USER_EMAIL)
+
+    // Simulate the user clicking the Supabase confirm link →
+    // lands on /auth/callback with a now-valid session.
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
+    await mockSupabase(page, {
+      restResponses: {
+        // handle_new_user fast-path (Wave 1 G2) populated profile_completed_at.
+        profiles: [
+          {
+            id: USER_ID,
+            first_name: 'Ryan',
+            last_name: 'Smith',
+            profile_completed_at: new Date().toISOString(),
+            tier: 'community',
+          },
+        ],
+      },
+    })
+    await page.goto('/auth/callback')
+
+    // Callback should bypass /complete-profile (profile already complete) and
+    // hit the success path → /account/cli-token (first-visit state).
+    await page.waitForURL(/\/account\/cli-token/, { timeout: 10_000 })
+
+    // First-visit UI: fresh sk_live_* key visible.
+    await expect(page.locator('body')).toContainText(/sk_live_/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// J-B — Flow B (GitHub OAuth) + routePostAuth loop-guard (H1)
+// ---------------------------------------------------------------------------
+
+test.describe('J-B — Flow B: GitHub OAuth', () => {
+  test('callback detects null profile_completed_at and sends to /complete-profile pre-filled', async ({
+    page,
+  }) => {
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'github' }) })
+    await mockSupabase(page, {
+      restResponses: {
+        // profile_completed_at NULL → callback routes to /complete-profile.
+        profiles: [
+          {
+            id: USER_ID,
+            first_name: 'Ryan',
+            last_name: 'Smith',
+            profile_completed_at: null,
+            tier: 'community',
+            github_orgs: null,
+          },
+        ],
+      },
+    })
+
+    await page.goto('/auth/callback')
+    await page.waitForURL(/\/complete-profile/, { timeout: 10_000 })
+
+    // handle_new_user split (Wave 1) → first/last populated from GitHub name.
+    // Pre-fill assertion (spec §4.5 A-GH-1).
+    const firstName = page.locator('input[name="first_name"]')
+    const lastName = page.locator('input[name="last_name"]')
+    await expect(firstName).toHaveValue('Ryan')
+    await expect(lastName).toHaveValue('Smith')
+
+    // GitHub helper row visible (A-GH-3).
+    await expect(page.locator('body')).toContainText(/from your GitHub/i)
+
+    // Simulate submit: RPC returns issued_now=true → /account/cli-token.
+    await mockSupabase(page, {
+      rpcResponses: {
+        issue_license_key_if_profile_complete: { issued_now: true, reason: null },
+      },
+      restResponses: {
+        profiles: [
+          {
+            id: USER_ID,
+            first_name: 'Ryan',
+            last_name: 'Smith',
+            profile_completed_at: new Date().toISOString(),
+            tier: 'community',
+          },
+        ],
+      },
+    })
+    await page.click('button[type="submit"]')
+    await page.waitForURL(/\/account\/cli-token/, { timeout: 10_000 })
+  })
+
+  test('H1 loop-guard: arriving at /auth/callback with referrer=/complete-profile surfaces error', async ({
+    page,
+  }) => {
+    // Force document.referrer === `${origin}/complete-profile` to simulate the
+    // bounce-back scenario. The routePostAuth helper (spec §5.7 M3) must detect
+    // this and render an inline error banner instead of looping.
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'github' }) })
+    await mockSupabase(page, {
+      restResponses: {
+        profiles: [
+          {
+            id: USER_ID,
+            first_name: 'Ryan',
+            last_name: 'Smith',
+            profile_completed_at: null,
+            tier: 'community',
+          },
+        ],
+      },
+    })
+
+    // First land on /complete-profile so the next /auth/callback hit carries
+    // the expected referrer — more faithful than Object.defineProperty.
+    await page.goto('/complete-profile')
+    await page.goto('/auth/callback')
+
+    // Loop-guard should keep us on /auth/callback with an error banner visible,
+    // not redirect to /complete-profile a second time.
+    await expect(page).toHaveURL(/\/auth\/callback/)
+    await expect(page.locator('body')).toContainText(/went wrong|Try again/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// J-C-stub — Flow C (/device stub only)
+// ---------------------------------------------------------------------------
+
+test.describe('J-C-stub — Flow C partial (/device stub)', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSupabaseStub(page)
+  })
+
+  test('readonly user_code input renders, no disabled approve button, no network call', async ({
+    page,
+  }) => {
+    const requested: string[] = []
+    await mockSupabase(page, {
+      onRequest: (url: string) => requested.push(url),
+    })
+
+    await page.goto('/device?user_code=BCDF-GHJK')
+
+    // Readonly input reflects the code.
+    const codeInput = page.locator('input[aria-label="Approval code"]')
+    await expect(codeInput).toHaveValue('BCDF-GHJK')
+    await expect(codeInput).toHaveAttribute('readonly', '')
+
+    // L6: no disabled approve button element — zero buttons labeled "Approve".
+    const approveBtnCount = await page.locator('button', { hasText: /^approve$/i }).count()
+    expect(approveBtnCount).toBe(0)
+
+    // Assert NO network request to any /functions/v1/auth-device-* endpoint.
+    const deviceFnCalls = requested.filter((u) => /\/functions\/v1\/auth-device-/.test(u))
+    expect(deviceFnCalls).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// J-E — Flow E (legacy 403 recovery)
+// ---------------------------------------------------------------------------
+
+test.describe('J-E — Flow E: legacy 403 recovery', () => {
+  test('source=cli subhead + submit → /return-to-cli with countdown + check-status button', async ({
+    page,
+  }) => {
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
+    await mockSupabase(page, {
+      rpcResponses: {
+        issue_license_key_if_profile_complete: { issued_now: false, reason: 'already_issued' },
+      },
+      restResponses: {
+        profiles: [
+          {
+            id: USER_ID,
+            first_name: '',
+            last_name: '',
+            profile_completed_at: null,
+            tier: 'community',
+          },
+        ],
+      },
+    })
+
+    await page.goto('/complete-profile?source=cli')
+
+    // cli branch subhead copy (spec §5.1 copy matrix).
+    await expect(page.locator('body')).toContainText(/Almost there — re-run your terminal command/i)
+
+    // Fill + submit.
+    await page.fill('input[name="first_name"]', 'Ryan')
+    await page.fill('input[name="last_name"]', 'Smith')
+    await page.click('button[type="submit"]')
+
+    // cli-source default → /return-to-cli.
+    await page.waitForURL(/\/return-to-cli/, { timeout: 10_000 })
+
+    // 30s countdown visible on load (spec §5.2 M4).
+    const countdown = page.locator('#countdown')
+    await expect(countdown).toBeVisible()
+    const initialValue = Number(await countdown.textContent())
+    expect(initialValue).toBeGreaterThan(0)
+    expect(initialValue).toBeLessThanOrEqual(30)
+
+    // Check-status button available + clicking it yields a toast.
+    await mockSupabase(page, {
+      functionsResponses: {
+        stats: { status: 200, body: { ok: true } },
+      },
+      restResponses: {
+        license_keys: [{ status: 'active', user_id: USER_ID }],
+      },
+    })
+    const checkBtn = page.getByRole('button', { name: /check key status/i })
+    await expect(checkBtn).toBeVisible()
+    await checkBtn.click()
+    await expect(page.locator('body')).toContainText(/Key is live|propagating/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// J-F-seo — Flow F (crawler UA hits /skills)
+// ---------------------------------------------------------------------------
+
+test.describe('J-F-seo — Flow F crawler', () => {
+  test.use({
+    extraHTTPHeaders: {
+      'User-Agent': 'Googlebot/2.1 (+http://www.google.com/bot.html)',
+    },
+  })
+
+  test('Googlebot sees HTTP 200 + both JSON-LD blocks + no SignedOutOverlay', async ({ page }) => {
+    await injectSupabaseStub(page)
+
+    const response = await page.goto('/skills')
+    expect(response?.status()).toBe(200)
+
+    // Both JSON-LD blocks present in HTML (spec §4.1 A-SEO-1).
+    const html = await page.content()
+    // CollectionPage + ItemList block
+    expect(html).toMatch(/"@type"\s*:\s*"CollectionPage"/)
+    expect(html).toMatch(/"@type"\s*:\s*"ItemList"/)
+    // BreadcrumbList block
+    expect(html).toMatch(/"@type"\s*:\s*"BreadcrumbList"/)
+
+    // SignedOutOverlay NOT rendered server-side for crawlers (spec §5.5 L7).
+    const overlayCount = await page.locator('[role="dialog"][aria-label*="Sign in"]').count()
+    expect(overlayCount).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

SMI-4401 Wave 2 of the SMI-4399 Free-Tier Auth Quid-Pro-Quo initiative. Website UX wave — 4 new pages + 5 modified existing pages + OWASP helpers + E2E tests.

**Stacked on Wave 1 PR** #718. Auto-retargets to main after Wave 1 merges.

## New pages

- `/complete-profile` — name-capture form, calls Wave 1 \`issue_license_key_if_profile_complete\` RPC
- `/return-to-cli` — post-CLI-403 landing with 30s tier-cache propagation countdown + check-status fallback
- `/check-email` — 22-user email_verified=FALSE cohort interstitial with Resend cooldown (L1 localStorage persistence)
- `/device` — Wave 3 RFC 8628 approval shell (stub; noindex)

## New helpers / components

- \`lib/validate-next-redirect.ts\` — OWASP open-redirect validator (H6 precedence, H2 \`/device?user_code=\` passthrough)
- \`lib/crawler-detect.ts\` — Googlebot/Bingbot/etc UA detection
- \`components/SignedOutOverlay.astro\` — soft overlay for anon humans on /skills

## Modified pages

- \`skills/index.astro\` — crawler-aware SSR branch (JSON-LD byte-identical for bots per SMI-4181 SEO equity); \`/signin\` → \`/login\` fix at line 625; quota banner + github_orgs sort/highlight (§4.7 A-M9 personalization)
- \`signup.astro\` — first_name + last_name fields pre-submit; setTimeout localStorage write + redirect to /check-email (M8 timing-safe)
- \`auth/callback.astro\` — module-scope \`routePostAuth()\` helper replaces 4 showSuccess() call-sites; H1 loop-guard via document.referrer; \`next=\` / \`redirect=\` fallback; OWASP-validated redirect (closes pre-existing open-redirect)
- \`login.astro\` — next= / redirect= fallback (H7)
- \`account/cli-token.astro\` — return-visit UI with revoke modal (focus-trapped dialog); full regenerate-license fetch skeleton with 401/429/5xx/network branches (C2); profile_grace_until banner (A-GRACE-1 M10); dead .revoke-btn handler removed

## Test plan

- [x] 70 unit tests pass (47 OWASP assertions on validateNextParam + 23 crawler UA cases)
- [x] Prettier + audit:standards clean (4 pre-existing warnings flagged but not Wave 2 regressions)
- [x] Governance retros on \`783105e3\` + \`de024a29\` resolved in-place via \`875b52d2\` + \`5d8f0590\`
- [ ] Playwright E2E (11 tests across 8 spec §6.2 journeys; J-TEAM dropped per Option A)
- [ ] Manual Lighthouse a11y ≥95 on \`/complete-profile\`, \`/return-to-cli\`, \`/check-email\`, \`/device\` per \`docs/internal/process/wave-2-lighthouse-checklist.md\`
- [ ] Dark-mode visual check + WCAG 2.1 AA contrast spot-check
- [ ] \`curl -A \"Googlebot/2.1\" https://skillsmith.app/skills\` returns 200 with both JSON-LD blocks intact (SEO preservation)

## Post-refinement scope adjustments

- **Option A (2026-04-21)**: invite interop dropped from Wave 2 — team-invite handler doesn't exist; M1 had conflated SMI-4307 (shipped) with SMI-4294 (never started). SMI-4294 promoted to P2/High as immediate post-Wave-2 initiative.
- **Design-system contrast**: \`#2a2a2f\` borders + \`#fafafa\`-on-\`#E07A5F\` button text fail WCAG 2.1 AA — but these are pre-existing site-wide patterns. Wave 2 matched existing palette per spec §4.8. Tracked as **SMI-4424** (design-system a11y audit, P3).
- **Lighthouse CI**: deferred to **SMI-4411** per ADR-109 (needs own SPARC + plan-review). Wave 2 runs Lighthouse manually as PR-checklist item.

## Joint deploy with Wave 1 (H5)

See Wave 1 PR #718 for the full runbook. Wave 2 website deploy must go live ≤30s of edge-fn apply completion. Rollback: per-page revert (no DB dependencies).

## Follow-up SMIs filed

- SMI-4410 skills-search org filter (P3)
- SMI-4411 Lighthouse CI ADR-109 SPARC (P2)
- SMI-4413 sub-bot investigation (P4)
- SMI-4414 plan-reality drift retro (P4)
- SMI-4422 signup.astro split (P4, Wave 4 tech-debt)
- SMI-4423 skills/index.astro split (P4, Wave 4 tech-debt)
- SMI-4424 design-system a11y audit (P3)
- SMI-4294 team_invitations schema + invite flow (P2/High, immediate post-Wave-2)

## Commits

- \`783105e3\` feat(web): add 4 new pages + helpers
- \`875b52d2\` fix(web): governance — H6 precedence + open-redirect-in-email + Prettier
- \`de024a29\` feat(web): integrate profile gate across 5 existing pages
- \`5d8f0590\` fix(web): governance — close callback open-redirect via validateNextParam
- \`53d341e4\` test(web): Playwright E2E + helpers
- \`e985c67e\` chore(submodule): bump docs/internal for Lighthouse checklist

## References

- Parent plan: \`docs/internal/implementation/smi-4399-free-tier-auth-quid-pro-quo.md\`
- Wave 2 spec: \`docs/internal/implementation/waves/SMI-4401-spec.md\`
- Architecture: \`docs/internal/architecture/free-tier-auth-flow.md\`
- Lighthouse checklist: \`docs/internal/process/wave-2-lighthouse-checklist.md\`
- Linear: https://linear.app/smith-horn-group/issue/SMI-4401

🤖 Generated with [Claude Code](https://claude.com/claude-code)