### PR TITLE
feat(doc-retrieval-mcp): SMI-4417 Wave 2 — thin semantic-search MCP server

### DIFF
--- a/.claude/development/ruvector-dev-tooling.md
+++ b/.claude/development/ruvector-dev-tooling.md
@@ -1,0 +1,162 @@
+# RuVector Dev Tooling — `skillsmith-doc-retrieval` MCP
+
+Local, private semantic search over the Skillsmith doc corpus. Wraps
+`@ruvector/core` with Skillsmith's existing `EmbeddingService` so agents can
+hit 3 tools (`skill_docs_search`, `skill_docs_reindex`, `skill_docs_status`)
+instead of `Read`-ing whole guides.
+
+Phase 1 of [SMI-4416](https://linear.app/smith-horn-group/issue/SMI-4416) /
+[SMI-4417](https://linear.app/smith-horn-group/issue/SMI-4417). See ADR-117
+for the design rationale and alternatives considered.
+
+---
+
+## Setup (first run)
+
+```bash
+docker compose --profile dev up -d
+docker exec skillsmith-dev-1 npm install
+docker exec skillsmith-dev-1 npm run build -w packages/doc-retrieval-mcp
+
+# Build the initial .rvf — runs on host because we do not index CI artifacts
+git submodule update --init   # required: docs/internal must be present
+node packages/doc-retrieval-mcp/dist/src/cli.js reindex --full
+```
+
+Output lands at `.ruvector/skillsmith-docs.rvf` +
+`.ruvector/metadata.json` + `.ruvector/.index-state.json`. All three are
+git-ignored. `.git-crypt-ignore` is **not** needed — smudge/clean filters
+never run on untracked files.
+
+Restart Claude Code so it picks up the new `.mcp.json` entry.
+
+---
+
+## Tools
+
+| Tool | Purpose | Shape |
+|------|---------|-------|
+| `skill_docs_search` | Semantic doc search | `{ query, k?, min_score?, scope_globs? } → { chunks: [{ id, file_path, line_start, line_end, heading_chain, text, score }] }` |
+| `skill_docs_reindex` | Rebuild / refresh | `{ mode: 'full' \| 'incremental' }` |
+| `skill_docs_status` | Index health check | `{} → { chunkCount, fileCount, lastIndexedSha, lastRunAt, rvfPath, corpusVersion }` |
+
+### Score semantics
+
+Cosine similarity, ∈ `[0, 1]`, higher is better. Default `min_score = 0.30`.
+
+| Range | Meaning |
+|-------|---------|
+| `< 0.25` | Noise |
+| `0.25–0.40` | Weakly related |
+| `0.40–0.60` | Loosely relevant |
+| `0.60–0.80` | Strongly relevant |
+| `> 0.80` | Near-duplicate / exact |
+
+---
+
+## Corpus
+
+Defined in
+[`packages/doc-retrieval-mcp/src/corpus.config.json`](../../packages/doc-retrieval-mcp/src/corpus.config.json):
+`CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `.claude/development/**`,
+`.claude/skills/**/SKILL.md`, `.claude/templates/**`, `docs/internal/**`,
+`packages/*/README.md`. The indexer refuses to start if the
+`docs/internal/` submodule is uninitialized — it would silently omit
+private content otherwise.
+
+## Chunk sizing — design note
+
+`all-MiniLM-L6-v2` has a **256-token hard cap** and `EmbeddingService.embed`
+further truncates input to 1000 chars (~250 tokens). Chunks target
+240 tokens (≈960 chars), overlap 48 tokens. The original plan targeted
+500-token chunks, which was infeasible with this model — the second half
+of every chunk would have been ignored by the encoder. Phase 3
+([SMI-4419](https://linear.app/smith-horn-group/issue/SMI-4419)) revisits
+this if we adopt a longer-context model.
+
+---
+
+## Privacy boundary
+
+1. `.ruvector/` is **git-ignored** and **CI-refused**. The indexer exits
+   non-zero if `CI=true` or `SKILLSMITH_CI=true`. It also refuses to write
+   outside `$REPO_ROOT/.ruvector/`.
+2. `.mcp.json` carries an explicit `disabledTools` block listing 37 Ruflo
+   tools with remote-persistence surfaces (AgentDB, hive-mind_memory,
+   transfer_*, memory_store, etc.). Authoritative list lives in
+   [`docs/internal/architecture/ruflo-tool-classification.md`](../../docs/internal/architecture/ruflo-tool-classification.md)
+   (SMI-4420). Re-audit when Ruflo bumps a minor version.
+3. The corpus includes `docs/internal/**/*.md` (private submodule). The
+   resulting `.rvf` is a searchable index of that content — treat it with
+   the same confidentiality as the submodule itself.
+
+---
+
+## Post-commit hook
+
+`.husky/post-commit` runs an incremental re-index in the background when:
+
+- `$REPO_ROOT/.ruvector/skillsmith-docs.rvf` exists (first run is manual).
+- `packages/doc-retrieval-mcp/dist/src/cli.js` exists (package is built).
+- `CI` and `SKILLSMITH_CI` are unset.
+
+The indexer uses `GIT_OPTIONAL_LOCKS=0` and passes
+`--no-optional-locks` to every `git diff` invocation, avoiding the
+SMI-2536 smudge-filter branch-switch hazard. Hook failure is non-fatal
+and non-blocking.
+
+To disable the auto-reindex: delete the `.rvf` (first-run branch skips),
+or unset the cli by removing `packages/doc-retrieval-mcp/dist/`.
+
+---
+
+## Operations
+
+### Rebuild from scratch
+
+```bash
+rm -rf .ruvector/
+node packages/doc-retrieval-mcp/dist/src/cli.js reindex --full
+```
+
+### Verify a query end-to-end
+
+```bash
+node packages/doc-retrieval-mcp/dist/src/cli.js status
+node -e "import('./packages/doc-retrieval-mcp/dist/src/search.js').then(m => m.search({ query: 'git-crypt worktrees', k: 3 })).then(r => console.log(JSON.stringify(r, null, 2)))"
+```
+
+### Token-delta measurement (Wave 2 Step 6 gate)
+
+```bash
+node scripts/token-delta-harness.mjs run --mode baseline
+node scripts/token-delta-harness.mjs run --mode measured
+node scripts/token-delta-harness.mjs compare
+```
+
+Pass = ≥40% median input-token reduction across the three tasks in
+[`scripts/ruvector-harness-tasks.json`](../../scripts/ruvector-harness-tasks.json).
+Fail = Phase 2 abandoned, retro filed.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `index not built` error from `skill_docs_search` | `node packages/doc-retrieval-mcp/dist/src/cli.js reindex --full` |
+| `required submodule 'docs/internal' is not initialized` | `git submodule update --init` |
+| `refusing to run in CI` | Expected — indexer never runs in CI. |
+| MCP server doesn't appear in Claude Code | Restart Claude Code after editing `.mcp.json`. Run the package build first: `docker exec skillsmith-dev-1 npm run build -w packages/doc-retrieval-mcp`. |
+| Stale results after many edits | `rm -rf .ruvector && node packages/doc-retrieval-mcp/dist/src/cli.js reindex --full` |
+
+---
+
+## Deferred
+
+Phase 2 promotes `skill_docs_search` into `@skillsmith/mcp-server` with
+an `installed`/`registry` scope split (registry side uses pgvector on
+Supabase, not RuVector — Deno cannot load the native module). Phase 3
+evaluates longer-context embedding models and potentially replaces the
+HNSW brute-force fallback in `packages/core/src/embeddings/hnsw-store.ts`
+(SMI-1519 / SMI-4419).

--- a/.claude/development/ruvector-dev-tooling.md
+++ b/.claude/development/ruvector-dev-tooling.md
@@ -1,5 +1,20 @@
 # RuVector Dev Tooling — `skillsmith-doc-retrieval` MCP
 
+> ⚠️ **Runtime status: BLOCKED on [SMI-4426](https://linear.app/smith-horn-group/issue/SMI-4426)**
+>
+> Wave 2 Step 1 ([PR #722](https://github.com/smith-horn/skillsmith/pull/722))
+> ships this package as a **scaffold**. Unit tests cover chunker, metadata
+> store, and config guards (19/19 green), but the `@ruvector/core@0.1.30`
+> integration surface has **not** been runtime-validated. `skill_docs_search`
+> and `skill_docs_reindex` will throw a clear SMI-4426 error at invocation
+> rather than NPE. `skill_docs_status` works (metadata-only). The rest of
+> this guide documents the *intended* end-state — treat it as a spec until
+> SMI-4426 lands.
+>
+> See SMI-4426 for the API mismatch findings (`VectorDb` vs `VectorDB`,
+> `withDimensions(n)` factory, opaque persistence, distance-like scores,
+> platform native bindings).
+
 Local, private semantic search over the Skillsmith doc corpus. Wraps
 `@ruvector/core` with Skillsmith's existing `EmbeddingService` so agents can
 hit 3 tools (`skill_docs_search`, `skill_docs_reindex`, `skill_docs_status`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,7 +693,7 @@ jobs:
           # Copy nested workspace node_modules (for non-hoisted dependencies)
           # docker cp works on stopped containers - no need for docker exec
           # NOTE: Package list must stay consistent with extract-builds step below
-          for pkg in core mcp-server cli enterprise vscode-extension website; do
+          for pkg in core mcp-server cli enterprise vscode-extension website doc-retrieval-mcp; do
             mkdir -p /tmp/packages/$pkg
             if docker cp extract-deps:/app/packages/$pkg/node_modules /tmp/packages/$pkg/ 2>/dev/null; then
               echo "✓ Copied packages/$pkg/node_modules"
@@ -734,6 +734,7 @@ jobs:
             packages/cli/dist
             packages/enterprise/dist
             packages/vscode-extension/dist
+            packages/doc-retrieval-mcp/dist
             packages/website/.astro
             .turbo
             packages/*/.turbo
@@ -752,7 +753,7 @@ jobs:
           docker create --name extract-builds skillsmith-ci:${{ github.sha }}
 
           # Extract dist/ from each package (consistent list with node_modules extraction)
-          for pkg in core mcp-server cli enterprise vscode-extension website; do
+          for pkg in core mcp-server cli enterprise vscode-extension website doc-retrieval-mcp; do
             mkdir -p packages/$pkg
             if docker cp extract-builds:/app/packages/$pkg/dist packages/$pkg/ 2>/dev/null; then
               echo "✓ Extracted packages/$pkg/dist"
@@ -774,7 +775,7 @@ jobs:
           if docker cp extract-builds:/app/.turbo ./ 2>/dev/null; then
             echo "✓ Extracted root .turbo cache"
           fi
-          for pkg in core mcp-server cli enterprise vscode-extension website; do
+          for pkg in core mcp-server cli enterprise vscode-extension website doc-retrieval-mcp; do
             if docker cp extract-builds:/app/packages/$pkg/.turbo packages/$pkg/ 2>/dev/null; then
               echo "✓ Extracted packages/$pkg/.turbo"
             fi

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -115,7 +115,7 @@ jobs:
           docker cp extract-deps:/app/node_modules /tmp/node_modules
 
           # Copy nested workspace node_modules (for non-hoisted dependencies)
-          for pkg in core mcp-server cli enterprise vscode-extension website; do
+          for pkg in core mcp-server cli enterprise vscode-extension website doc-retrieval-mcp; do
             mkdir -p /tmp/packages/$pkg
             if docker cp extract-deps:/app/packages/$pkg/node_modules /tmp/packages/$pkg/ 2>/dev/null; then
               echo "✓ Copied packages/$pkg/node_modules"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ node_modules/
 agentdb.rvf
 agentdb.rvf.lock
 
+# SMI-4417: doc-retrieval-mcp — local-only .rvf corpus index + metadata.
+# Never committed, never built in CI. .rvf is untracked, so smudge/clean
+# filters never run on it — no .git-crypt-ignore entry is needed.
+.ruvector/
+*.rvf
+
 # Build outputs
 dist/
 *.tsbuildinfo

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -50,4 +50,19 @@ fi
 # SMI-710: Sync Linear issues from commit messages (background, non-blocking)
 node "$(dirname "$0")/../scripts/linear-hook.mjs" post-commit &
 
+# SMI-4417: Background incremental re-index of doc corpus.
+# Non-blocking, failure non-fatal, skipped if .rvf absent (first run manual)
+# or in CI. GIT_OPTIONAL_LOCKS=0 + --no-optional-locks inside the indexer
+# prevent SMI-2536 smudge-filter hazards during `git diff` against the index.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$REPO_ROOT" ] && [ -z "$CI" ] && [ -z "$SKILLSMITH_CI" ] \
+  && [ -f "$REPO_ROOT/.ruvector/skillsmith-docs.rvf" ] \
+  && [ -f "$REPO_ROOT/packages/doc-retrieval-mcp/dist/src/cli.js" ]; then
+  (
+    cd "$REPO_ROOT" || exit 0
+    GIT_OPTIONAL_LOCKS=0 nohup node packages/doc-retrieval-mcp/dist/src/cli.js reindex --incremental --quiet \
+      >/dev/null 2>&1 &
+  )
+fi
+
 exit 0

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,6 +5,14 @@
       "command": "node",
       "args": ["./packages/mcp-server/dist/src/index.js"]
     },
+    "skillsmith-doc-retrieval": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./packages/doc-retrieval-mcp/dist/src/server.js"],
+      "env": {
+        "SKILLSMITH_REPO_ROOT": "."
+      }
+    },
     "ruflo": {
       "type": "stdio",
       "command": "npx",
@@ -12,7 +20,46 @@
       "env": {
         "CLAUDE_FLOW_LOG_LEVEL": "info",
         "CLAUDE_FLOW_MEMORY_BACKEND": "sqlite"
-      }
+      },
+      "disabledTools": [
+        "mcp__ruflo__agentdb_pattern-store",
+        "mcp__ruflo__agentdb_pattern-search",
+        "mcp__ruflo__agentdb_hierarchical-store",
+        "mcp__ruflo__agentdb_hierarchical-recall",
+        "mcp__ruflo__agentdb_causal-edge",
+        "mcp__ruflo__agentdb_batch",
+        "mcp__ruflo__agentdb_context-synthesize",
+        "mcp__ruflo__agentdb_semantic-route",
+        "mcp__ruflo__agentdb_feedback",
+        "mcp__ruflo__agentdb_consolidate",
+        "mcp__ruflo__hive-mind_memory",
+        "mcp__ruflo__hive-mind_broadcast",
+        "mcp__ruflo__hive-mind_consensus",
+        "mcp__ruflo__hive-mind_spawn",
+        "mcp__ruflo__hive-mind_join",
+        "mcp__ruflo__hive-mind_init",
+        "mcp__ruflo__transfer_store-search",
+        "mcp__ruflo__transfer_store-download",
+        "mcp__ruflo__transfer_store-featured",
+        "mcp__ruflo__transfer_store-info",
+        "mcp__ruflo__transfer_store-trending",
+        "mcp__ruflo__transfer_plugin-search",
+        "mcp__ruflo__transfer_plugin-featured",
+        "mcp__ruflo__transfer_plugin-official",
+        "mcp__ruflo__transfer_plugin-info",
+        "mcp__ruflo__transfer_ipfs-resolve",
+        "mcp__ruflo__hooks_intelligence_pattern-store",
+        "mcp__ruflo__hooks_intelligence_pattern-search",
+        "mcp__ruflo__memory_store",
+        "mcp__ruflo__memory_search",
+        "mcp__ruflo__memory_search_unified",
+        "mcp__ruflo__memory_migrate",
+        "mcp__ruflo__swarm_init",
+        "mcp__ruflo__claims_handoff",
+        "mcp__ruflo__claims_accept-handoff",
+        "mcp__ruflo__hooks_post-task",
+        "mcp__ruflo__hooks_model-outcome"
+      ]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Detailed guides extracted via progressive disclosure. CLAUDE.md contains essenti
 | [vscode-publishing-guide.md](.claude/development/vscode-publishing-guide.md) | VS Code Marketplace publishing, local/CI workflow, PAT rotation |
 | [subagent-tool-permissions-guide.md](.claude/development/subagent-tool-permissions-guide.md) | Subagent tool access by type, foreground/background behavior, skill author checklist |
 | [supabase-migration-safety.md](.claude/development/supabase-migration-safety.md) | Pre/post-apply query catalog, ACCESS EXCLUSIVE lock discipline, rollback convention, pooler rules. Invoke via `supabase-migration-reviewer` skill for automated review. |
+| [ruvector-dev-tooling.md](.claude/development/ruvector-dev-tooling.md) | `skillsmith-doc-retrieval` MCP — local semantic doc search (SMI-4417). Setup, tool surface, privacy boundary, post-commit hook, token-delta gate. |
 
 **Implementation plan template**: [.claude/templates/implementation-plan.md](.claude/templates/implementation-plan.md) — use this structure for all plans in `docs/internal/implementation/`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY packages/mcp-server/package*.json ./packages/mcp-server/
 COPY packages/cli/package*.json ./packages/cli/
 COPY packages/vscode-extension/package*.json ./packages/vscode-extension/
 COPY packages/website/package*.json ./packages/website/
+COPY packages/doc-retrieval-mcp/package*.json ./packages/doc-retrieval-mcp/
 
 # Install ALL dependencies (including devDependencies for building)
 # Using npm ci for reproducible builds from package-lock.json

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,6 +55,7 @@ const tsConfig = tseslint.config(
           './packages/cli/tsconfig.json',
           './packages/enterprise/tsconfig.json',
           './packages/vscode-extension/tsconfig.json',
+          './packages/doc-retrieval-mcp/tsconfig.json',
         ],
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "skillsmith",
       "version": "0.1.2",
+      "hasInstallScript": true,
       "license": "Elastic-2.0",
       "workspaces": [
         "packages/*"
@@ -4372,6 +4373,15 @@
         }
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "license": "ISC",
@@ -4380,13 +4390,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
-      "version": "7.1.2",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -6639,9 +6642,7 @@
     },
     "node_modules/@ruvector/core": {
       "version": "0.1.30",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -7411,6 +7412,10 @@
     },
     "node_modules/@skillsmith/core": {
       "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@skillsmith/doc-retrieval-mcp": {
+      "resolved": "packages/doc-retrieval-mcp",
       "link": true
     },
     "node_modules/@skillsmith/mcp-server": {
@@ -9575,13 +9580,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@vercel/nft/node_modules/minipass": {
-      "version": "7.1.3",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/@vercel/nft/node_modules/picomatch": {
@@ -13595,6 +13593,22 @@
         "node": ">=20"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "dev": true,
@@ -15051,6 +15065,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jiti": {
@@ -17083,6 +17112,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "dev": true,
@@ -17821,6 +17859,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
       "license": "MIT"
@@ -17989,13 +18033,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.1.3",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-to-regexp": {
@@ -19148,7 +19185,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19162,7 +19198,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19174,7 +19209,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19186,7 +19220,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19200,7 +19233,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20372,13 +20404,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "7.1.2",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/tar/node_modules/minizlib": {
@@ -22244,11 +22269,11 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@skillsmith/core": "^0.5.3",
+        "@skillsmith/core": "^0.5.4",
         "chalk": "5.6.2",
         "cli-table3": "0.6.5",
         "commander": "14.0.3",
@@ -22414,7 +22439,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@huggingface/transformers": "3.8.1",
@@ -22544,6 +22569,65 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "packages/doc-retrieval-mcp": {
+      "name": "@skillsmith/doc-retrieval-mcp",
+      "version": "0.0.1",
+      "license": "Elastic-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@ruvector/core": "0.1.30",
+        "@skillsmith/core": "^0.5.4",
+        "glob": "11.1.0",
+        "zod": "3.25.76"
+      },
+      "bin": {
+        "skillsmith-doc-retrieval": "dist/src/server.js",
+        "skillsmith-doc-retrieval-cli": "dist/src/cli.js"
+      },
+      "devDependencies": {
+        "tsx": "4.21.0",
+        "vitest": "4.1.2"
+      }
+    },
+    "packages/doc-retrieval-mcp/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/doc-retrieval-mcp/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/enterprise": {
       "name": "@smith-horn/enterprise",
       "version": "0.1.2",
@@ -22551,7 +22635,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1024.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.69.0",
-        "@skillsmith/core": "^0.5.3",
+        "@skillsmith/core": "^0.5.4",
         "jose": "^6.2.2",
         "zod": "4.2.1"
       },
@@ -22579,11 +22663,11 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.5.3",
+        "@skillsmith/core": "^0.5.4",
         "esbuild": "0.27.2"
       },
       "bin": {
@@ -22621,7 +22705,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/doc-retrieval-mcp/package.json
+++ b/packages/doc-retrieval-mcp/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@skillsmith/doc-retrieval-mcp",
+  "version": "0.0.1",
+  "description": "Thin MCP server wrapping @ruvector/core for semantic doc retrieval over the Skillsmith corpus (SMI-4417, internal only)",
+  "private": true,
+  "type": "module",
+  "main": "./dist/src/server.js",
+  "bin": {
+    "skillsmith-doc-retrieval": "./dist/src/server.js",
+    "skillsmith-doc-retrieval-cli": "./dist/src/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "postbuild": "chmod +x dist/src/server.js dist/src/cli.js || true",
+    "dev": "tsx watch src/server.ts",
+    "start": "node dist/src/server.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@ruvector/core": "0.1.30",
+    "@skillsmith/core": "^0.5.4",
+    "glob": "11.1.0",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "tsx": "4.21.0",
+    "vitest": "4.1.2"
+  },
+  "license": "Elastic-2.0"
+}

--- a/packages/doc-retrieval-mcp/package.json
+++ b/packages/doc-retrieval-mcp/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "postbuild": "chmod +x dist/src/server.js dist/src/cli.js || true",
+    "postbuild": "cp src/corpus.config.json dist/src/ && chmod +x dist/src/server.js dist/src/cli.js || true",
     "dev": "tsx watch src/server.ts",
     "start": "node dist/src/server.js",
     "test": "vitest run",

--- a/packages/doc-retrieval-mcp/src/cli.ts
+++ b/packages/doc-retrieval-mcp/src/cli.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { runIndexer } from './indexer.js'
+
+async function main(): Promise<void> {
+  const [, , command, ...rest] = process.argv
+  if (command === 'reindex') {
+    const mode = rest.includes('--full') ? 'full' : 'incremental'
+    const quiet = rest.includes('--quiet')
+    const result = await runIndexer(mode, { quiet })
+    if (!quiet) {
+      console.log(JSON.stringify(result, null, 2))
+    }
+    return
+  }
+  if (command === 'status') {
+    const { getStatus } = await import('./status.js')
+    const status = await getStatus()
+    console.log(JSON.stringify(status, null, 2))
+    return
+  }
+  console.error(
+    'Usage: skillsmith-doc-retrieval-cli <reindex [--full|--incremental] [--quiet] | status>'
+  )
+  process.exit(2)
+}
+
+main().catch((err) => {
+  console.error('[doc-retrieval] error:', err instanceof Error ? err.message : err)
+  process.exit(1)
+})

--- a/packages/doc-retrieval-mcp/src/config.ts
+++ b/packages/doc-retrieval-mcp/src/config.ts
@@ -1,0 +1,97 @@
+import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export interface ChunkConfig {
+  targetTokens: number
+  overlapTokens: number
+  minTokens: number
+}
+
+export interface CorpusConfig {
+  rvfPath: string
+  metadataPath: string
+  stateFile: string
+  embeddingDim: number
+  chunk: ChunkConfig
+  globs: string[]
+  requireSubmodule?: string
+}
+
+let cached: CorpusConfig | null = null
+
+export async function loadConfig(configPath?: string): Promise<CorpusConfig> {
+  if (cached && !configPath) return cached
+  const path = configPath ?? defaultConfigPath()
+  const raw = await readFile(path, 'utf8')
+  const parsed = JSON.parse(raw) as CorpusConfig
+  validate(parsed)
+  cached = parsed
+  return parsed
+}
+
+export function resetConfigCache(): void {
+  cached = null
+}
+
+function defaultConfigPath(): string {
+  const here = fileURLToPath(new URL('.', import.meta.url))
+  return resolve(here, 'corpus.config.json')
+}
+
+function validate(c: CorpusConfig): void {
+  if (!c.rvfPath || !c.metadataPath || !c.stateFile) {
+    throw new Error('corpus.config.json: rvfPath, metadataPath, stateFile are required')
+  }
+  if (c.embeddingDim !== 384) {
+    throw new Error(
+      `corpus.config.json: embeddingDim must be 384 (Xenova/all-MiniLM-L6-v2 fixed dim); got ${c.embeddingDim}`
+    )
+  }
+  if (c.chunk.targetTokens < c.chunk.minTokens) {
+    throw new Error('corpus.config.json: chunk.targetTokens must be >= chunk.minTokens')
+  }
+  if (!Array.isArray(c.globs) || c.globs.length === 0) {
+    throw new Error('corpus.config.json: globs must be a non-empty array')
+  }
+}
+
+export function repoRoot(): string {
+  const env = process.env.SKILLSMITH_REPO_ROOT
+  if (env) return resolve(env)
+  return process.cwd()
+}
+
+export function resolveRepoPath(rel: string): string {
+  return join(repoRoot(), rel)
+}
+
+export function assertSafeIndexTarget(absolutePath: string): void {
+  const root = repoRoot()
+  const resolved = resolve(absolutePath)
+  if (!resolved.startsWith(join(root, '.ruvector'))) {
+    throw new Error(
+      `Refusing to write outside $REPO_ROOT/.ruvector: ${resolved}. Safety boundary enforced.`
+    )
+  }
+}
+
+export function assertNotInCi(): void {
+  if (process.env.CI === 'true' || process.env.SKILLSMITH_CI === 'true') {
+    throw new Error(
+      'doc-retrieval-mcp: refusing to run in CI (CI=true or SKILLSMITH_CI=true). The .rvf is local-only and must not be built in CI artifacts.'
+    )
+  }
+}
+
+export function assertSubmoduleInitialized(cfg: CorpusConfig): void {
+  if (!cfg.requireSubmodule) return
+  const submodulePath = resolveRepoPath(cfg.requireSubmodule)
+  const sentinel = join(submodulePath, 'index.md')
+  if (!existsSync(sentinel)) {
+    throw new Error(
+      `doc-retrieval-mcp: required submodule '${cfg.requireSubmodule}' is not initialized (missing ${cfg.requireSubmodule}/index.md). Run: git submodule update --init. Refusing partial index to avoid silently omitting private content.`
+    )
+  }
+}

--- a/packages/doc-retrieval-mcp/src/corpus.config.json
+++ b/packages/doc-retrieval-mcp/src/corpus.config.json
@@ -1,0 +1,23 @@
+{
+  "rvfPath": ".ruvector/skillsmith-docs.rvf",
+  "metadataPath": ".ruvector/metadata.json",
+  "stateFile": ".ruvector/.index-state.json",
+  "embeddingDim": 384,
+  "chunk": {
+    "targetTokens": 240,
+    "overlapTokens": 48,
+    "minTokens": 32,
+    "_rationale": "all-MiniLM-L6-v2 has a 256-token hard cap + EmbeddingService truncates to 1000 chars (~250 tokens). 240 fits under both. Plan's 500-token target was infeasible with this model; re-evaluated for Phase 3 (SMI-4419)."
+  },
+  "globs": [
+    "CLAUDE.md",
+    "CONTRIBUTING.md",
+    "README.md",
+    ".claude/development/**/*.md",
+    ".claude/skills/**/SKILL.md",
+    ".claude/templates/**/*.md",
+    "docs/internal/**/*.md",
+    "packages/*/README.md"
+  ],
+  "requireSubmodule": "docs/internal"
+}

--- a/packages/doc-retrieval-mcp/src/embedding.ts
+++ b/packages/doc-retrieval-mcp/src/embedding.ts
@@ -1,0 +1,34 @@
+import { EmbeddingService } from '@skillsmith/core/embeddings'
+
+let cached: EmbeddingService | null = null
+
+/**
+ * Singleton EmbeddingService (Skillsmith's). Both index-time and query-time
+ * embeddings share this pipeline to keep the cosine space aligned. RuVector's
+ * own ONNX pipeline is NOT used — we pass raw 384-dim vectors into
+ * @ruvector/core via VectorDB.insert / VectorDB.search.
+ *
+ * Note: EmbeddingService truncates input to 1000 chars (~250 tokens). Chunks
+ * must target ≤240 tokens — see corpus.config.json `_rationale`.
+ */
+export async function getEmbedder(): Promise<EmbeddingService> {
+  if (cached) return cached
+  cached = await EmbeddingService.create({})
+  return cached
+}
+
+export async function embed(text: string): Promise<Float32Array> {
+  const svc = await getEmbedder()
+  return svc.embed(text)
+}
+
+export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
+  const svc = await getEmbedder()
+  const items = texts.map((text, i) => ({ id: String(i), text }))
+  const results = await svc.embedBatch(items)
+  return results.map((r) => r.embedding)
+}
+
+export function resetEmbedderCache(): void {
+  cached = null
+}

--- a/packages/doc-retrieval-mcp/src/indexer.helpers.ts
+++ b/packages/doc-retrieval-mcp/src/indexer.helpers.ts
@@ -1,0 +1,190 @@
+import { createHash } from 'node:crypto'
+import type { ChunkConfig, CorpusConfig } from './config.js'
+import type { ChunkMetadata } from './types.js'
+
+const TOKEN_CHAR_RATIO = 4
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / TOKEN_CHAR_RATIO)
+}
+
+interface HeadingLine {
+  level: number
+  text: string
+  lineNumber: number
+}
+
+export interface ParsedMarkdownBlock {
+  headingChain: string[]
+  startLine: number
+  endLine: number
+  content: string
+}
+
+export function parseMarkdown(raw: string): ParsedMarkdownBlock[] {
+  const lines = raw.split('\n')
+  const blocks: ParsedMarkdownBlock[] = []
+  const stack: HeadingLine[] = []
+  let bufferStart = 1
+  let bufferLines: string[] = []
+  let inFence = false
+  let fenceMarker = ''
+
+  const flush = (endLine: number): void => {
+    const content = bufferLines.join('\n').trim()
+    if (content.length === 0) return
+    blocks.push({
+      headingChain: stack.map((h) => h.text),
+      startLine: bufferStart,
+      endLine,
+      content,
+    })
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const lineNo = i + 1
+
+    const fence = line.match(/^(`{3,}|~{3,})/)
+    if (fence) {
+      if (!inFence) {
+        inFence = true
+        fenceMarker = fence[1]
+      } else if (line.startsWith(fenceMarker)) {
+        inFence = false
+      }
+    }
+
+    const headingMatch = !inFence && line.match(/^(#{1,6})\s+(.+)$/)
+    if (headingMatch) {
+      if (bufferLines.length > 0) {
+        flush(lineNo - 1)
+      }
+      const level = headingMatch[1].length
+      while (stack.length > 0 && stack[stack.length - 1].level >= level) {
+        stack.pop()
+      }
+      stack.push({ level, text: headingMatch[2].trim(), lineNumber: lineNo })
+      bufferStart = lineNo
+      bufferLines = [line]
+      continue
+    }
+
+    bufferLines.push(line)
+  }
+
+  if (bufferLines.length > 0) {
+    flush(lines.length)
+  }
+
+  return blocks
+}
+
+export function chunkBlocks(
+  blocks: ParsedMarkdownBlock[],
+  filePath: string,
+  chunkCfg: ChunkConfig
+): ChunkMetadata[] {
+  const chunks: ChunkMetadata[] = []
+  for (const block of blocks) {
+    const blockChunks = splitBlock(block, chunkCfg)
+    for (const c of blockChunks) {
+      if (c.tokens < chunkCfg.minTokens) continue
+      chunks.push(finalize(c, filePath))
+    }
+  }
+  return chunks
+}
+
+interface RawChunk {
+  text: string
+  startLine: number
+  endLine: number
+  tokens: number
+  headingChain: string[]
+}
+
+function splitBlock(block: ParsedMarkdownBlock, cfg: ChunkConfig): RawChunk[] {
+  const lines = block.content.split('\n')
+  const tokensPerLine = lines.map((l) => estimateTokens(l))
+  const total = tokensPerLine.reduce((a, b) => a + b, 0)
+
+  if (total <= cfg.targetTokens) {
+    return [
+      {
+        text: block.content,
+        startLine: block.startLine,
+        endLine: block.endLine,
+        tokens: total,
+        headingChain: block.headingChain,
+      },
+    ]
+  }
+
+  const out: RawChunk[] = []
+  let cursor = 0
+  while (cursor < lines.length) {
+    let tokens = 0
+    let end = cursor
+    while (end < lines.length && tokens + tokensPerLine[end] <= cfg.targetTokens) {
+      tokens += tokensPerLine[end]
+      end++
+    }
+    if (end === cursor) {
+      tokens = tokensPerLine[end]
+      end = cursor + 1
+    }
+    out.push({
+      text: lines.slice(cursor, end).join('\n'),
+      startLine: block.startLine + cursor,
+      endLine: block.startLine + end - 1,
+      tokens,
+      headingChain: block.headingChain,
+    })
+    if (end >= lines.length) break
+    cursor = findOverlapStart(cursor, end, tokensPerLine, cfg.overlapTokens)
+  }
+  return out
+}
+
+function findOverlapStart(
+  currentStart: number,
+  currentEnd: number,
+  tokensPerLine: number[],
+  overlap: number
+): number {
+  let tokens = 0
+  let idx = currentEnd
+  while (idx > currentStart && tokens < overlap) {
+    idx--
+    tokens += tokensPerLine[idx]
+  }
+  const next = idx
+  return next === currentStart ? currentEnd : next
+}
+
+function finalize(raw: RawChunk, filePath: string): ChunkMetadata {
+  const id = chunkId(filePath, raw.startLine, raw.endLine, raw.text)
+  return {
+    id,
+    filePath,
+    lineStart: raw.startLine,
+    lineEnd: raw.endLine,
+    headingChain: raw.headingChain,
+    text: raw.text,
+    tokens: raw.tokens,
+  }
+}
+
+function chunkId(filePath: string, startLine: number, endLine: number, text: string): string {
+  const hash = createHash('sha1')
+    .update(`${filePath}:${startLine}:${endLine}:${text}`)
+    .digest('hex')
+    .slice(0, 16)
+  return `${filePath}#L${startLine}-L${endLine}@${hash}`
+}
+
+export function chunkDocument(raw: string, filePath: string, cfg: CorpusConfig): ChunkMetadata[] {
+  const blocks = parseMarkdown(raw)
+  return chunkBlocks(blocks, filePath, cfg.chunk)
+}

--- a/packages/doc-retrieval-mcp/src/indexer.ts
+++ b/packages/doc-retrieval-mcp/src/indexer.ts
@@ -1,0 +1,260 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { VectorDB } from '@ruvector/core'
+import {
+  loadConfig,
+  resolveRepoPath,
+  assertSafeIndexTarget,
+  assertNotInCi,
+  assertSubmoduleInitialized,
+  type CorpusConfig,
+} from './config.js'
+import { chunkDocument } from './indexer.helpers.js'
+import { MetadataStore } from './metadata-store.js'
+import { embed } from './embedding.js'
+import type { ChunkMetadata, IndexState } from './types.js'
+
+const CORPUS_VERSION = 1
+
+export interface IndexResult {
+  mode: 'full' | 'incremental'
+  filesScanned: number
+  chunksUpserted: number
+  chunksDeleted: number
+  durationMs: number
+}
+
+export async function runIndexer(
+  mode: 'full' | 'incremental',
+  opts: { quiet?: boolean; configPath?: string } = {}
+): Promise<IndexResult> {
+  assertNotInCi()
+  const started = Date.now()
+  const cfg = await loadConfig(opts.configPath)
+  assertSubmoduleInitialized(cfg)
+
+  const rvfAbs = resolveRepoPath(cfg.rvfPath)
+  const metaAbs = resolveRepoPath(cfg.metadataPath)
+  const stateAbs = resolveRepoPath(cfg.stateFile)
+  assertSafeIndexTarget(rvfAbs)
+  assertSafeIndexTarget(metaAbs)
+  assertSafeIndexTarget(stateAbs)
+
+  await mkdir(dirname(rvfAbs), { recursive: true })
+
+  const db = new VectorDB({ dimensions: cfg.embeddingDim, storagePath: rvfAbs })
+  const store = await MetadataStore.load(metaAbs)
+  const prevState = await loadState(stateAbs)
+
+  const files = await resolveFiles(cfg, mode, prevState, opts)
+  const deletedFiles = mode === 'incremental' ? await resolveDeletedFiles(prevState) : []
+
+  let upserted = 0
+  let deleted = 0
+  for (const absPath of deletedFiles) {
+    const rel = toRelPath(absPath)
+    const ids = store.deleteByFile(rel)
+    for (const id of ids) {
+      try {
+        await db.delete(id)
+        deleted++
+      } catch {
+        // swallow — store of truth is MetadataStore, vector DB eventual consistency is fine
+      }
+    }
+  }
+
+  for (const absPath of files) {
+    const rel = toRelPath(absPath)
+    let raw: string
+    try {
+      raw = await readFile(absPath, 'utf8')
+    } catch {
+      continue
+    }
+    const chunks = chunkDocument(raw, rel, cfg)
+    const staleIds = store.deleteByFile(rel)
+    for (const id of staleIds) {
+      if (!chunks.find((c) => c.id === id)) {
+        try {
+          await db.delete(id)
+          deleted++
+        } catch {
+          /* tolerate */
+        }
+      }
+    }
+    for (const chunk of chunks) {
+      const vector = await embed(chunk.text)
+      await db.insert({ id: chunk.id, vector })
+      store.upsert(chunk)
+      upserted++
+    }
+  }
+
+  await store.flush()
+  const nextState: IndexState = {
+    lastIndexedSha: await gitHeadSha(),
+    chunkCountByFile: buildCountMap(store.entries()),
+    lastRunAt: new Date().toISOString(),
+    corpusVersion: CORPUS_VERSION,
+  }
+  await saveState(stateAbs, nextState)
+
+  const result: IndexResult = {
+    mode,
+    filesScanned: files.length,
+    chunksUpserted: upserted,
+    chunksDeleted: deleted,
+    durationMs: Date.now() - started,
+  }
+  if (!opts.quiet) {
+    console.log(
+      `[doc-retrieval] ${mode}: files=${result.filesScanned} upserted=${result.chunksUpserted} deleted=${result.chunksDeleted} dur=${result.durationMs}ms`
+    )
+  }
+  return result
+}
+
+async function resolveFiles(
+  cfg: CorpusConfig,
+  mode: 'full' | 'incremental',
+  prev: IndexState | null,
+  opts: { quiet?: boolean }
+): Promise<string[]> {
+  if (mode === 'full' || !prev?.lastIndexedSha) {
+    return globCorpus(cfg)
+  }
+  const changed = changedMarkdownSince(prev.lastIndexedSha)
+  if (changed === null) {
+    if (!opts.quiet) {
+      console.warn('[doc-retrieval] git diff unavailable; falling back to full scan')
+    }
+    return globCorpus(cfg)
+  }
+  const all = new Set(await globCorpus(cfg))
+  return changed.filter((p) => all.has(p))
+}
+
+async function resolveDeletedFiles(prev: IndexState | null): Promise<string[]> {
+  if (!prev?.lastIndexedSha) return []
+  const deleted = deletedMarkdownSince(prev.lastIndexedSha)
+  if (deleted === null) return []
+  return deleted
+}
+
+async function globCorpus(cfg: CorpusConfig): Promise<string[]> {
+  const { glob } = await import('glob')
+  const out = new Set<string>()
+  for (const pattern of cfg.globs) {
+    const matches = await glob(pattern, {
+      cwd: resolveRepoPath(''),
+      absolute: true,
+      nodir: true,
+      dot: false,
+    })
+    for (const m of matches) out.add(m)
+  }
+  return [...out].sort()
+}
+
+function changedMarkdownSince(sha: string): string[] | null {
+  try {
+    const out = execFileSync(
+      'git',
+      [
+        '--no-optional-locks',
+        'diff',
+        '--name-only',
+        '--diff-filter=AM',
+        `${sha}..HEAD`,
+        '--',
+        '**/*.md',
+      ],
+      {
+        cwd: resolveRepoPath(''),
+        encoding: 'utf8',
+        env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
+      }
+    )
+    return out
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .map((p) => join(resolveRepoPath(''), p))
+  } catch {
+    return null
+  }
+}
+
+function deletedMarkdownSince(sha: string): string[] | null {
+  try {
+    const out = execFileSync(
+      'git',
+      [
+        '--no-optional-locks',
+        'diff',
+        '--name-only',
+        '--diff-filter=D',
+        `${sha}..HEAD`,
+        '--',
+        '**/*.md',
+      ],
+      {
+        cwd: resolveRepoPath(''),
+        encoding: 'utf8',
+        env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
+      }
+    )
+    return out
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .map((p) => join(resolveRepoPath(''), p))
+  } catch {
+    return null
+  }
+}
+
+async function gitHeadSha(): Promise<string | null> {
+  try {
+    return execFileSync('git', ['--no-optional-locks', 'rev-parse', 'HEAD'], {
+      cwd: resolveRepoPath(''),
+      encoding: 'utf8',
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
+    }).trim()
+  } catch {
+    return null
+  }
+}
+
+function buildCountMap(entries: ChunkMetadata[]): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const e of entries) out[e.filePath] = (out[e.filePath] ?? 0) + 1
+  return out
+}
+
+async function loadState(path: string): Promise<IndexState | null> {
+  if (!existsSync(path)) return null
+  try {
+    const raw = await readFile(path, 'utf8')
+    const parsed = JSON.parse(raw) as IndexState
+    if (parsed.corpusVersion !== CORPUS_VERSION) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+async function saveState(path: string, state: IndexState): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, JSON.stringify(state, null, 2), 'utf8')
+}
+
+function toRelPath(abs: string): string {
+  const root = resolveRepoPath('')
+  if (abs.startsWith(root + '/')) return abs.slice(root.length + 1)
+  return abs
+}

--- a/packages/doc-retrieval-mcp/src/indexer.ts
+++ b/packages/doc-retrieval-mcp/src/indexer.ts
@@ -1,22 +1,22 @@
-import { readFile, writeFile, mkdir } from 'node:fs/promises'
-import { existsSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { execFileSync } from 'node:child_process'
-import { VectorDB } from '@ruvector/core'
-import {
-  loadConfig,
-  resolveRepoPath,
-  assertSafeIndexTarget,
-  assertNotInCi,
-  assertSubmoduleInitialized,
-  type CorpusConfig,
-} from './config.js'
-import { chunkDocument } from './indexer.helpers.js'
-import { MetadataStore } from './metadata-store.js'
-import { embed } from './embedding.js'
-import type { ChunkMetadata, IndexState } from './types.js'
-
-const CORPUS_VERSION = 1
+// SMI-4426: Wave 2 Step 1 shipped `@skillsmith/doc-retrieval-mcp` as a scaffold.
+// The RuVector integration is blocked pending a runtime fix. Unit tests cover
+// chunker/metadata-store/config (19/19 green) but the indexer and search code
+// paths have NOT been runtime-validated against `@ruvector/core@0.1.30`.
+//
+// Key API mismatches discovered during Wave 2 Step 6 prep:
+//   - Named export is `VectorDb` (lowercase b), not `VectorDB`
+//   - `VectorDb.withDimensions(n)` static factory, not `new VectorDB({...})`
+//   - No `storagePath` parameter — opaque built-in persistence
+//   - All methods async (return Promises)
+//   - Score is distance-like (~0 = best), not cosine similarity
+//   - Native binding per platform (darwin-arm64 not auto-installed locally)
+//
+// The original scaffold implementation (chunker wiring, git-diff incremental
+// mode, VectorDB insert/delete calls) lives in git history on this branch —
+// see commits before the SMI-4426 runtime guard.
+//
+// SMI-4426 tracks the real integration + persistence design + integration test:
+//   https://linear.app/smith-horn-group/issue/SMI-4426
 
 export interface IndexResult {
   mode: 'full' | 'incremental'
@@ -26,235 +26,15 @@ export interface IndexResult {
   durationMs: number
 }
 
+const RUVECTOR_BLOCKED =
+  'doc-retrieval: RuVector integration is blocked on SMI-4426 ' +
+  '(https://linear.app/smith-horn-group/issue/SMI-4426). ' +
+  'The scaffold in PR #722 (SMI-4417) has not been runtime-validated against ' +
+  '@ruvector/core. See .claude/development/ruvector-dev-tooling.md.'
+
 export async function runIndexer(
-  mode: 'full' | 'incremental',
-  opts: { quiet?: boolean; configPath?: string } = {}
+  _mode: 'full' | 'incremental',
+  _opts: { quiet?: boolean; configPath?: string } = {}
 ): Promise<IndexResult> {
-  assertNotInCi()
-  const started = Date.now()
-  const cfg = await loadConfig(opts.configPath)
-  assertSubmoduleInitialized(cfg)
-
-  const rvfAbs = resolveRepoPath(cfg.rvfPath)
-  const metaAbs = resolveRepoPath(cfg.metadataPath)
-  const stateAbs = resolveRepoPath(cfg.stateFile)
-  assertSafeIndexTarget(rvfAbs)
-  assertSafeIndexTarget(metaAbs)
-  assertSafeIndexTarget(stateAbs)
-
-  await mkdir(dirname(rvfAbs), { recursive: true })
-
-  const db = new VectorDB({ dimensions: cfg.embeddingDim, storagePath: rvfAbs })
-  const store = await MetadataStore.load(metaAbs)
-  const prevState = await loadState(stateAbs)
-
-  const files = await resolveFiles(cfg, mode, prevState, opts)
-  const deletedFiles = mode === 'incremental' ? await resolveDeletedFiles(prevState) : []
-
-  let upserted = 0
-  let deleted = 0
-  for (const absPath of deletedFiles) {
-    const rel = toRelPath(absPath)
-    const ids = store.deleteByFile(rel)
-    for (const id of ids) {
-      try {
-        await db.delete(id)
-        deleted++
-      } catch {
-        // swallow — store of truth is MetadataStore, vector DB eventual consistency is fine
-      }
-    }
-  }
-
-  for (const absPath of files) {
-    const rel = toRelPath(absPath)
-    let raw: string
-    try {
-      raw = await readFile(absPath, 'utf8')
-    } catch {
-      continue
-    }
-    const chunks = chunkDocument(raw, rel, cfg)
-    const staleIds = store.deleteByFile(rel)
-    for (const id of staleIds) {
-      if (!chunks.find((c) => c.id === id)) {
-        try {
-          await db.delete(id)
-          deleted++
-        } catch {
-          /* tolerate */
-        }
-      }
-    }
-    for (const chunk of chunks) {
-      const vector = await embed(chunk.text)
-      await db.insert({ id: chunk.id, vector })
-      store.upsert(chunk)
-      upserted++
-    }
-  }
-
-  await store.flush()
-  const nextState: IndexState = {
-    lastIndexedSha: await gitHeadSha(),
-    chunkCountByFile: buildCountMap(store.entries()),
-    lastRunAt: new Date().toISOString(),
-    corpusVersion: CORPUS_VERSION,
-  }
-  await saveState(stateAbs, nextState)
-
-  const result: IndexResult = {
-    mode,
-    filesScanned: files.length,
-    chunksUpserted: upserted,
-    chunksDeleted: deleted,
-    durationMs: Date.now() - started,
-  }
-  if (!opts.quiet) {
-    console.log(
-      `[doc-retrieval] ${mode}: files=${result.filesScanned} upserted=${result.chunksUpserted} deleted=${result.chunksDeleted} dur=${result.durationMs}ms`
-    )
-  }
-  return result
-}
-
-async function resolveFiles(
-  cfg: CorpusConfig,
-  mode: 'full' | 'incremental',
-  prev: IndexState | null,
-  opts: { quiet?: boolean }
-): Promise<string[]> {
-  if (mode === 'full' || !prev?.lastIndexedSha) {
-    return globCorpus(cfg)
-  }
-  const changed = changedMarkdownSince(prev.lastIndexedSha)
-  if (changed === null) {
-    if (!opts.quiet) {
-      console.warn('[doc-retrieval] git diff unavailable; falling back to full scan')
-    }
-    return globCorpus(cfg)
-  }
-  const all = new Set(await globCorpus(cfg))
-  return changed.filter((p) => all.has(p))
-}
-
-async function resolveDeletedFiles(prev: IndexState | null): Promise<string[]> {
-  if (!prev?.lastIndexedSha) return []
-  const deleted = deletedMarkdownSince(prev.lastIndexedSha)
-  if (deleted === null) return []
-  return deleted
-}
-
-async function globCorpus(cfg: CorpusConfig): Promise<string[]> {
-  const { glob } = await import('glob')
-  const out = new Set<string>()
-  for (const pattern of cfg.globs) {
-    const matches = await glob(pattern, {
-      cwd: resolveRepoPath(''),
-      absolute: true,
-      nodir: true,
-      dot: false,
-    })
-    for (const m of matches) out.add(m)
-  }
-  return [...out].sort()
-}
-
-function changedMarkdownSince(sha: string): string[] | null {
-  try {
-    const out = execFileSync(
-      'git',
-      [
-        '--no-optional-locks',
-        'diff',
-        '--name-only',
-        '--diff-filter=AM',
-        `${sha}..HEAD`,
-        '--',
-        '**/*.md',
-      ],
-      {
-        cwd: resolveRepoPath(''),
-        encoding: 'utf8',
-        env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
-      }
-    )
-    return out
-      .split('\n')
-      .map((l) => l.trim())
-      .filter(Boolean)
-      .map((p) => join(resolveRepoPath(''), p))
-  } catch {
-    return null
-  }
-}
-
-function deletedMarkdownSince(sha: string): string[] | null {
-  try {
-    const out = execFileSync(
-      'git',
-      [
-        '--no-optional-locks',
-        'diff',
-        '--name-only',
-        '--diff-filter=D',
-        `${sha}..HEAD`,
-        '--',
-        '**/*.md',
-      ],
-      {
-        cwd: resolveRepoPath(''),
-        encoding: 'utf8',
-        env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
-      }
-    )
-    return out
-      .split('\n')
-      .map((l) => l.trim())
-      .filter(Boolean)
-      .map((p) => join(resolveRepoPath(''), p))
-  } catch {
-    return null
-  }
-}
-
-async function gitHeadSha(): Promise<string | null> {
-  try {
-    return execFileSync('git', ['--no-optional-locks', 'rev-parse', 'HEAD'], {
-      cwd: resolveRepoPath(''),
-      encoding: 'utf8',
-      env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
-    }).trim()
-  } catch {
-    return null
-  }
-}
-
-function buildCountMap(entries: ChunkMetadata[]): Record<string, number> {
-  const out: Record<string, number> = {}
-  for (const e of entries) out[e.filePath] = (out[e.filePath] ?? 0) + 1
-  return out
-}
-
-async function loadState(path: string): Promise<IndexState | null> {
-  if (!existsSync(path)) return null
-  try {
-    const raw = await readFile(path, 'utf8')
-    const parsed = JSON.parse(raw) as IndexState
-    if (parsed.corpusVersion !== CORPUS_VERSION) return null
-    return parsed
-  } catch {
-    return null
-  }
-}
-
-async function saveState(path: string, state: IndexState): Promise<void> {
-  await mkdir(dirname(path), { recursive: true })
-  await writeFile(path, JSON.stringify(state, null, 2), 'utf8')
-}
-
-function toRelPath(abs: string): string {
-  const root = resolveRepoPath('')
-  if (abs.startsWith(root + '/')) return abs.slice(root.length + 1)
-  return abs
+  throw new Error(RUVECTOR_BLOCKED)
 }

--- a/packages/doc-retrieval-mcp/src/metadata-store.ts
+++ b/packages/doc-retrieval-mcp/src/metadata-store.ts
@@ -1,0 +1,84 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { dirname } from 'node:path'
+import type { ChunkMetadata } from './types.js'
+
+export interface StoredMetadata {
+  version: 1
+  chunks: Record<string, ChunkMetadata>
+}
+
+export class MetadataStore {
+  private data: StoredMetadata
+  private dirty = false
+
+  constructor(
+    private readonly path: string,
+    initial?: StoredMetadata
+  ) {
+    this.data = initial ?? { version: 1, chunks: {} }
+  }
+
+  static async load(path: string): Promise<MetadataStore> {
+    if (!existsSync(path)) return new MetadataStore(path)
+    const raw = await readFile(path, 'utf8')
+    const parsed = JSON.parse(raw) as StoredMetadata
+    if (parsed.version !== 1) {
+      throw new Error(`MetadataStore: unsupported version ${parsed.version}`)
+    }
+    return new MetadataStore(path, parsed)
+  }
+
+  upsert(chunk: ChunkMetadata): void {
+    this.data.chunks[chunk.id] = chunk
+    this.dirty = true
+  }
+
+  delete(id: string): void {
+    if (id in this.data.chunks) {
+      delete this.data.chunks[id]
+      this.dirty = true
+    }
+  }
+
+  deleteByFile(filePath: string): string[] {
+    const removed: string[] = []
+    for (const [id, meta] of Object.entries(this.data.chunks)) {
+      if (meta.filePath === filePath) {
+        delete this.data.chunks[id]
+        removed.push(id)
+      }
+    }
+    if (removed.length > 0) this.dirty = true
+    return removed
+  }
+
+  get(id: string): ChunkMetadata | null {
+    return this.data.chunks[id] ?? null
+  }
+
+  has(id: string): boolean {
+    return id in this.data.chunks
+  }
+
+  size(): number {
+    return Object.keys(this.data.chunks).length
+  }
+
+  fileCount(): number {
+    const set = new Set<string>()
+    for (const meta of Object.values(this.data.chunks)) set.add(meta.filePath)
+    return set.size
+  }
+
+  entries(): ChunkMetadata[] {
+    return Object.values(this.data.chunks)
+  }
+
+  async flush(): Promise<void> {
+    if (!this.dirty) return
+    await mkdir(dirname(this.path), { recursive: true })
+    await writeFile(this.path, JSON.stringify(this.data, null, 2), 'utf8')
+    this.dirty = false
+  }
+}

--- a/packages/doc-retrieval-mcp/src/search.ts
+++ b/packages/doc-retrieval-mcp/src/search.ts
@@ -1,0 +1,70 @@
+import { existsSync } from 'node:fs'
+import { VectorDB } from '@ruvector/core'
+import { loadConfig, resolveRepoPath } from './config.js'
+import { MetadataStore } from './metadata-store.js'
+import { embed } from './embedding.js'
+import type { SearchHit } from './types.js'
+
+export interface SearchOpts {
+  query: string
+  k?: number
+  minScore?: number
+  scopeGlobs?: string[]
+  configPath?: string
+}
+
+const DEFAULT_K = 5
+const DEFAULT_MIN_SCORE = 0.3
+
+export async function search(opts: SearchOpts): Promise<SearchHit[]> {
+  const cfg = await loadConfig(opts.configPath)
+  const rvfAbs = resolveRepoPath(cfg.rvfPath)
+  const metaAbs = resolveRepoPath(cfg.metadataPath)
+
+  if (!existsSync(rvfAbs) || !existsSync(metaAbs)) {
+    throw new Error(
+      'doc-retrieval: index not built. Run: node packages/doc-retrieval-mcp/dist/src/cli.js reindex --full'
+    )
+  }
+
+  const db = new VectorDB({ dimensions: cfg.embeddingDim, storagePath: rvfAbs })
+  const store = await MetadataStore.load(metaAbs)
+  const vector = await embed(opts.query)
+
+  const k = opts.k ?? DEFAULT_K
+  const minScore = opts.minScore ?? DEFAULT_MIN_SCORE
+  const raw = await db.search({ vector, k: Math.max(k * 4, k + 10) })
+
+  const hits: SearchHit[] = []
+  for (const r of raw) {
+    const meta = store.get(r.id)
+    if (!meta) continue
+    if (r.score < minScore) continue
+    if (opts.scopeGlobs && !matchesAny(meta.filePath, opts.scopeGlobs)) continue
+    hits.push({
+      id: meta.id,
+      filePath: meta.filePath,
+      lineStart: meta.lineStart,
+      lineEnd: meta.lineEnd,
+      headingChain: meta.headingChain,
+      text: meta.text,
+      score: r.score,
+    })
+    if (hits.length >= k) break
+  }
+  return hits
+}
+
+function matchesAny(path: string, globs: string[]): boolean {
+  return globs.some((g) => globToRegExp(g).test(path))
+}
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '§§DOUBLESTAR§§')
+    .replace(/\*/g, '[^/]*')
+    .replace(/§§DOUBLESTAR§§/g, '.*')
+    .replace(/\?/g, '.')
+  return new RegExp(`^${escaped}$`)
+}

--- a/packages/doc-retrieval-mcp/src/search.ts
+++ b/packages/doc-retrieval-mcp/src/search.ts
@@ -1,8 +1,4 @@
-import { existsSync } from 'node:fs'
-import { VectorDB } from '@ruvector/core'
-import { loadConfig, resolveRepoPath } from './config.js'
-import { MetadataStore } from './metadata-store.js'
-import { embed } from './embedding.js'
+// SMI-4426: scaffold — see indexer.ts header comment.
 import type { SearchHit } from './types.js'
 
 export interface SearchOpts {
@@ -13,58 +9,12 @@ export interface SearchOpts {
   configPath?: string
 }
 
-const DEFAULT_K = 5
-const DEFAULT_MIN_SCORE = 0.3
+const RUVECTOR_BLOCKED =
+  'doc-retrieval: RuVector integration is blocked on SMI-4426 ' +
+  '(https://linear.app/smith-horn-group/issue/SMI-4426). ' +
+  'The scaffold in PR #722 (SMI-4417) has not been runtime-validated against ' +
+  '@ruvector/core. See .claude/development/ruvector-dev-tooling.md.'
 
-export async function search(opts: SearchOpts): Promise<SearchHit[]> {
-  const cfg = await loadConfig(opts.configPath)
-  const rvfAbs = resolveRepoPath(cfg.rvfPath)
-  const metaAbs = resolveRepoPath(cfg.metadataPath)
-
-  if (!existsSync(rvfAbs) || !existsSync(metaAbs)) {
-    throw new Error(
-      'doc-retrieval: index not built. Run: node packages/doc-retrieval-mcp/dist/src/cli.js reindex --full'
-    )
-  }
-
-  const db = new VectorDB({ dimensions: cfg.embeddingDim, storagePath: rvfAbs })
-  const store = await MetadataStore.load(metaAbs)
-  const vector = await embed(opts.query)
-
-  const k = opts.k ?? DEFAULT_K
-  const minScore = opts.minScore ?? DEFAULT_MIN_SCORE
-  const raw = await db.search({ vector, k: Math.max(k * 4, k + 10) })
-
-  const hits: SearchHit[] = []
-  for (const r of raw) {
-    const meta = store.get(r.id)
-    if (!meta) continue
-    if (r.score < minScore) continue
-    if (opts.scopeGlobs && !matchesAny(meta.filePath, opts.scopeGlobs)) continue
-    hits.push({
-      id: meta.id,
-      filePath: meta.filePath,
-      lineStart: meta.lineStart,
-      lineEnd: meta.lineEnd,
-      headingChain: meta.headingChain,
-      text: meta.text,
-      score: r.score,
-    })
-    if (hits.length >= k) break
-  }
-  return hits
-}
-
-function matchesAny(path: string, globs: string[]): boolean {
-  return globs.some((g) => globToRegExp(g).test(path))
-}
-
-function globToRegExp(glob: string): RegExp {
-  const escaped = glob
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\*\*/g, '§§DOUBLESTAR§§')
-    .replace(/\*/g, '[^/]*')
-    .replace(/§§DOUBLESTAR§§/g, '.*')
-    .replace(/\?/g, '.')
-  return new RegExp(`^${escaped}$`)
+export async function search(_opts: SearchOpts): Promise<SearchHit[]> {
+  throw new Error(RUVECTOR_BLOCKED)
 }

--- a/packages/doc-retrieval-mcp/src/server.ts
+++ b/packages/doc-retrieval-mcp/src/server.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { search } from './search.js'
+import { runIndexer } from './indexer.js'
+import { getStatus } from './status.js'
+
+const SearchArgs = z.object({
+  query: z.string().min(1).describe('Natural-language query over the Skillsmith doc corpus'),
+  k: z.number().int().min(1).max(20).optional().describe('Max results to return (default 5)'),
+  min_score: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe(
+      'Minimum cosine similarity. Default 0.30. <0.25=noise, 0.25-0.40=weak, 0.40-0.60=loose, 0.60-0.80=strong, >0.80=near-duplicate'
+    ),
+  scope_globs: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Optional list of POSIX-style globs to restrict results (e.g. ["docs/internal/adr/**", ".claude/**"]).'
+    ),
+})
+
+const ReindexArgs = z.object({
+  mode: z
+    .enum(['full', 'incremental'])
+    .default('incremental')
+    .describe('full rebuilds from scratch; incremental uses git diff since last run'),
+})
+
+const StatusArgs = z.object({}).strict()
+
+async function handleListTools(): Promise<{ tools: unknown[] }> {
+  return {
+    tools: [
+      {
+        name: 'skill_docs_search',
+        description:
+          'Semantic search over the Skillsmith doc corpus (CLAUDE.md, .claude/development, .claude/skills, docs/internal). Returns top-k chunks with file:line citations. Use this INSTEAD of Read-ing whole docs to answer narrow questions.',
+        inputSchema: jsonSchemaOf(SearchArgs),
+      },
+      {
+        name: 'skill_docs_reindex',
+        description:
+          'Rebuild or refresh the local .ruvector/skillsmith-docs.rvf index. Fails in CI. Fails if the docs/internal submodule is uninitialized.',
+        inputSchema: jsonSchemaOf(ReindexArgs),
+      },
+      {
+        name: 'skill_docs_status',
+        description:
+          'Report chunk count, file count, last-indexed SHA, and last run time for the local corpus index.',
+        inputSchema: jsonSchemaOf(StatusArgs),
+      },
+    ],
+  }
+}
+
+type CallToolResult = { content: Array<{ type: 'text'; text: string }>; isError?: boolean }
+
+async function handleCallTool(req: {
+  params: { name: string; arguments?: Record<string, unknown> }
+}): Promise<CallToolResult> {
+  const { name, arguments: args } = req.params
+  try {
+    if (name === 'skill_docs_search') {
+      const parsed = SearchArgs.parse(args ?? {})
+      const hits = await search({
+        query: parsed.query,
+        k: parsed.k,
+        minScore: parsed.min_score,
+        scopeGlobs: parsed.scope_globs,
+      })
+      return toolJson({ chunks: hits })
+    }
+    if (name === 'skill_docs_reindex') {
+      const parsed = ReindexArgs.parse(args ?? {})
+      const result = await runIndexer(parsed.mode, { quiet: true })
+      return toolJson(result)
+    }
+    if (name === 'skill_docs_status') {
+      const status = await getStatus()
+      return toolJson(status)
+    }
+    return toolError(`Unknown tool: ${name}`)
+  } catch (err) {
+    return toolError(err instanceof Error ? err.message : String(err))
+  }
+}
+
+function toolJson(obj: unknown): CallToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(obj, null, 2) }] }
+}
+
+function toolError(message: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: message }, null, 2) }],
+    isError: true,
+  }
+}
+
+function jsonSchemaOf(schema: z.ZodType): Record<string, unknown> {
+  // Minimal hand-rolled shape — @modelcontextprotocol/sdk tools consume a subset
+  // of JSON Schema, so we mirror the zod shape without pulling zod-to-json-schema.
+  const shape = (
+    schema as unknown as { _def: { shape?: () => Record<string, z.ZodType> } }
+  )._def.shape?.()
+  if (!shape) return { type: 'object', properties: {}, additionalProperties: true }
+  const properties: Record<string, unknown> = {}
+  const required: string[] = []
+  for (const [key, val] of Object.entries(shape)) {
+    properties[key] = zodToJson(val)
+    if (!(val as z.ZodType).isOptional()) required.push(key)
+  }
+  const out: Record<string, unknown> = { type: 'object', properties }
+  if (required.length > 0) out.required = required
+  return out
+}
+
+function zodToJson(z: z.ZodType): Record<string, unknown> {
+  const def = (z as unknown as { _def: { typeName: string; description?: string } })._def
+  const base: Record<string, unknown> = {}
+  if (def.description) base.description = def.description
+  switch (def.typeName) {
+    case 'ZodString':
+      return { type: 'string', ...base }
+    case 'ZodNumber':
+      return { type: 'number', ...base }
+    case 'ZodBoolean':
+      return { type: 'boolean', ...base }
+    case 'ZodArray':
+      return {
+        type: 'array',
+        items: zodToJson((z as unknown as { _def: { type: z.ZodType } })._def.type),
+        ...base,
+      }
+    case 'ZodEnum':
+      return {
+        type: 'string',
+        enum: (z as unknown as { _def: { values: readonly string[] } })._def.values,
+        ...base,
+      }
+    case 'ZodOptional':
+    case 'ZodDefault':
+      return zodToJson((z as unknown as { _def: { innerType: z.ZodType } })._def.innerType)
+    default:
+      return base
+  }
+}
+
+async function main(): Promise<void> {
+  const server = new Server(
+    { name: 'skillsmith-doc-retrieval', version: '0.0.1' },
+    { capabilities: { tools: {} } }
+  )
+  server.setRequestHandler(ListToolsRequestSchema, handleListTools)
+  server.setRequestHandler(CallToolRequestSchema, handleCallTool)
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+}
+
+main().catch((err) => {
+  console.error('[doc-retrieval] fatal:', err instanceof Error ? err.message : err)
+  process.exit(1)
+})

--- a/packages/doc-retrieval-mcp/src/status.ts
+++ b/packages/doc-retrieval-mcp/src/status.ts
@@ -1,0 +1,26 @@
+import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { loadConfig, resolveRepoPath } from './config.js'
+import { MetadataStore } from './metadata-store.js'
+import type { IndexState, StatusInfo } from './types.js'
+
+export async function getStatus(configPath?: string): Promise<StatusInfo> {
+  const cfg = await loadConfig(configPath)
+  const metaAbs = resolveRepoPath(cfg.metadataPath)
+  const stateAbs = resolveRepoPath(cfg.stateFile)
+  const rvfAbs = resolveRepoPath(cfg.rvfPath)
+
+  const store = existsSync(metaAbs) ? await MetadataStore.load(metaAbs) : null
+  const state: IndexState | null = existsSync(stateAbs)
+    ? (JSON.parse(await readFile(stateAbs, 'utf8')) as IndexState)
+    : null
+
+  return {
+    chunkCount: store?.size() ?? 0,
+    fileCount: store?.fileCount() ?? 0,
+    lastIndexedSha: state?.lastIndexedSha ?? null,
+    lastRunAt: state?.lastRunAt ?? null,
+    rvfPath: rvfAbs,
+    corpusVersion: state?.corpusVersion ?? 0,
+  }
+}

--- a/packages/doc-retrieval-mcp/src/types.ts
+++ b/packages/doc-retrieval-mcp/src/types.ts
@@ -1,0 +1,39 @@
+export interface ChunkMetadata {
+  id: string
+  filePath: string
+  lineStart: number
+  lineEnd: number
+  headingChain: string[]
+  text: string
+  tokens: number
+}
+
+export interface ChunkWithVector extends ChunkMetadata {
+  vector: Float32Array
+}
+
+export interface IndexState {
+  lastIndexedSha: string | null
+  chunkCountByFile: Record<string, number>
+  lastRunAt: string
+  corpusVersion: number
+}
+
+export interface SearchHit {
+  id: string
+  filePath: string
+  lineStart: number
+  lineEnd: number
+  headingChain: string[]
+  text: string
+  score: number
+}
+
+export interface StatusInfo {
+  chunkCount: number
+  fileCount: number
+  lastIndexedSha: string | null
+  lastRunAt: string | null
+  rvfPath: string
+  corpusVersion: number
+}

--- a/packages/doc-retrieval-mcp/tests/chunker.test.ts
+++ b/packages/doc-retrieval-mcp/tests/chunker.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseMarkdown,
+  chunkBlocks,
+  chunkDocument,
+  estimateTokens,
+} from '../src/indexer.helpers.js'
+import type { CorpusConfig } from '../src/config.js'
+
+const cfg: CorpusConfig = {
+  rvfPath: '.ruvector/x.rvf',
+  metadataPath: '.ruvector/m.json',
+  stateFile: '.ruvector/s.json',
+  embeddingDim: 384,
+  chunk: { targetTokens: 240, overlapTokens: 48, minTokens: 1 },
+  globs: ['**/*.md'],
+}
+
+describe('estimateTokens', () => {
+  it('uses ~4 chars/token heuristic', () => {
+    expect(estimateTokens('abcd')).toBe(1)
+    expect(estimateTokens('abcde')).toBe(2)
+    expect(estimateTokens('')).toBe(0)
+  })
+})
+
+describe('parseMarkdown', () => {
+  it('splits by headings and tracks heading chain', () => {
+    const doc = [
+      '# Title',
+      '',
+      'Intro.',
+      '',
+      '## Section A',
+      'A body.',
+      '',
+      '### Sub A1',
+      'Sub body.',
+      '',
+      '## Section B',
+      'B body.',
+    ].join('\n')
+    const blocks = parseMarkdown(doc)
+    expect(blocks).toHaveLength(4)
+    expect(blocks[0].headingChain).toEqual(['Title'])
+    expect(blocks[1].headingChain).toEqual(['Title', 'Section A'])
+    expect(blocks[2].headingChain).toEqual(['Title', 'Section A', 'Sub A1'])
+    expect(blocks[3].headingChain).toEqual(['Title', 'Section B'])
+  })
+
+  it('ignores headings inside fenced code blocks', () => {
+    const doc = ['# Real', '', '```md', '## Fake heading', '```', ''].join('\n')
+    const blocks = parseMarkdown(doc)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].headingChain).toEqual(['Real'])
+  })
+
+  it('records accurate line ranges', () => {
+    const doc = ['# H1', 'body1', 'body2', '## H2', 'body3'].join('\n')
+    const blocks = parseMarkdown(doc)
+    expect(blocks[0].startLine).toBe(1)
+    expect(blocks[0].endLine).toBe(3)
+    expect(blocks[1].startLine).toBe(4)
+    expect(blocks[1].endLine).toBe(5)
+  })
+})
+
+describe('chunkBlocks', () => {
+  it('emits one chunk per small block', () => {
+    const blocks = parseMarkdown('# H\nbody')
+    const chunks = chunkBlocks(blocks, 'f.md', cfg.chunk)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].filePath).toBe('f.md')
+    expect(chunks[0].headingChain).toEqual(['H'])
+  })
+
+  it('drops chunks below minTokens', () => {
+    const blocks = parseMarkdown('# H\nx')
+    const strict = { ...cfg.chunk, minTokens: 1000 }
+    const chunks = chunkBlocks(blocks, 'f.md', strict)
+    expect(chunks).toHaveLength(0)
+  })
+
+  it('splits oversize blocks with overlap', () => {
+    const body = Array.from({ length: 200 }, (_, i) => `line ${i} with some text here`).join('\n')
+    const blocks = parseMarkdown(`# H\n${body}`)
+    const chunks = chunkBlocks(blocks, 'long.md', {
+      targetTokens: 50,
+      overlapTokens: 10,
+      minTokens: 5,
+    })
+    expect(chunks.length).toBeGreaterThan(1)
+    // Consecutive chunks must overlap in line coverage
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i].lineStart).toBeLessThanOrEqual(chunks[i - 1].lineEnd)
+    }
+  })
+
+  it('generates stable deterministic ids', () => {
+    const blocks = parseMarkdown('# H\nhello world')
+    const a = chunkBlocks(blocks, 'f.md', cfg.chunk)
+    const b = chunkBlocks(blocks, 'f.md', cfg.chunk)
+    expect(a[0].id).toBe(b[0].id)
+  })
+})
+
+describe('chunkDocument', () => {
+  it('round-trips text content', () => {
+    const raw = '# Title\n\nParagraph one.\n\n## Section\nParagraph two.'
+    const chunks = chunkDocument(raw, 'a.md', cfg)
+    expect(chunks.length).toBeGreaterThan(0)
+    expect(chunks[0].text).toContain('Title')
+    expect(chunks.map((c) => c.filePath)).toEqual(chunks.map(() => 'a.md'))
+  })
+})

--- a/packages/doc-retrieval-mcp/tests/config.test.ts
+++ b/packages/doc-retrieval-mcp/tests/config.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  assertNotInCi,
+  assertSafeIndexTarget,
+  loadConfig,
+  resetConfigCache,
+} from '../src/config.js'
+
+const origCi = process.env.CI
+const origSkillCi = process.env.SKILLSMITH_CI
+const origRepoRoot = process.env.SKILLSMITH_REPO_ROOT
+
+afterEach(() => {
+  process.env.CI = origCi
+  process.env.SKILLSMITH_CI = origSkillCi
+  process.env.SKILLSMITH_REPO_ROOT = origRepoRoot
+  resetConfigCache()
+})
+
+describe('assertNotInCi', () => {
+  it('throws when CI=true', () => {
+    process.env.CI = 'true'
+    expect(() => assertNotInCi()).toThrow(/refusing to run in CI/)
+  })
+  it('throws when SKILLSMITH_CI=true', () => {
+    delete process.env.CI
+    process.env.SKILLSMITH_CI = 'true'
+    expect(() => assertNotInCi()).toThrow(/refusing to run in CI/)
+  })
+  it('permits when neither set', () => {
+    delete process.env.CI
+    delete process.env.SKILLSMITH_CI
+    expect(() => assertNotInCi()).not.toThrow()
+  })
+})
+
+describe('assertSafeIndexTarget', () => {
+  it('permits paths under $REPO_ROOT/.ruvector', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'doc-retrieval-cfg-'))
+    process.env.SKILLSMITH_REPO_ROOT = dir
+    try {
+      expect(() => assertSafeIndexTarget(join(dir, '.ruvector', 'x.rvf'))).not.toThrow()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses paths outside $REPO_ROOT/.ruvector', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'doc-retrieval-cfg-'))
+    process.env.SKILLSMITH_REPO_ROOT = dir
+    try {
+      expect(() => assertSafeIndexTarget('/tmp/anywhere/x.rvf')).toThrow(/Safety boundary/)
+      expect(() => assertSafeIndexTarget(join(dir, 'elsewhere/x.rvf'))).toThrow(/Safety boundary/)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('loadConfig', () => {
+  it('validates required fields and embedding dim', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'doc-retrieval-cfg-'))
+    try {
+      const good = join(dir, 'good.json')
+      await writeFile(
+        good,
+        JSON.stringify({
+          rvfPath: '.ruvector/x.rvf',
+          metadataPath: '.ruvector/m.json',
+          stateFile: '.ruvector/s.json',
+          embeddingDim: 384,
+          chunk: { targetTokens: 240, overlapTokens: 48, minTokens: 8 },
+          globs: ['**/*.md'],
+        })
+      )
+      const cfg = await loadConfig(good)
+      expect(cfg.embeddingDim).toBe(384)
+
+      const bad = join(dir, 'bad.json')
+      resetConfigCache()
+      await writeFile(
+        bad,
+        JSON.stringify({
+          rvfPath: 'x',
+          metadataPath: 'm',
+          stateFile: 's',
+          embeddingDim: 768,
+          chunk: { targetTokens: 100, overlapTokens: 10, minTokens: 10 },
+          globs: ['**/*.md'],
+        })
+      )
+      await expect(loadConfig(bad)).rejects.toThrow(/embeddingDim must be 384/)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/doc-retrieval-mcp/tests/metadata-store.test.ts
+++ b/packages/doc-retrieval-mcp/tests/metadata-store.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { MetadataStore } from '../src/metadata-store.js'
+import type { ChunkMetadata } from '../src/types.js'
+
+let dir: string
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'doc-retrieval-meta-'))
+})
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+function fixture(id: string, filePath = 'a.md'): ChunkMetadata {
+  return {
+    id,
+    filePath,
+    lineStart: 1,
+    lineEnd: 10,
+    headingChain: ['H'],
+    text: 't',
+    tokens: 10,
+  }
+}
+
+describe('MetadataStore', () => {
+  it('round-trips via flush/load', async () => {
+    const path = join(dir, 'm.json')
+    const s1 = new MetadataStore(path)
+    s1.upsert(fixture('a'))
+    s1.upsert(fixture('b'))
+    await s1.flush()
+
+    const s2 = await MetadataStore.load(path)
+    expect(s2.size()).toBe(2)
+    expect(s2.get('a')).not.toBeNull()
+    expect(s2.get('missing')).toBeNull()
+  })
+
+  it('deletes entries by file', async () => {
+    const store = new MetadataStore(join(dir, 'm.json'))
+    store.upsert(fixture('x', 'a.md'))
+    store.upsert(fixture('y', 'a.md'))
+    store.upsert(fixture('z', 'b.md'))
+    expect(store.size()).toBe(3)
+    const removed = store.deleteByFile('a.md')
+    expect(removed.sort()).toEqual(['x', 'y'])
+    expect(store.size()).toBe(1)
+    expect(store.fileCount()).toBe(1)
+  })
+
+  it('tracks file count distinct from chunk count', () => {
+    const store = new MetadataStore(join(dir, 'm.json'))
+    store.upsert(fixture('1', 'a.md'))
+    store.upsert(fixture('2', 'a.md'))
+    store.upsert(fixture('3', 'b.md'))
+    expect(store.size()).toBe(3)
+    expect(store.fileCount()).toBe(2)
+  })
+
+  it('rejects unsupported versions', async () => {
+    const path = join(dir, 'm.json')
+    const { writeFile } = await import('node:fs/promises')
+    await writeFile(path, JSON.stringify({ version: 99, chunks: {} }))
+    await expect(MetadataStore.load(path)).rejects.toThrow(/unsupported version/)
+  })
+})

--- a/packages/doc-retrieval-mcp/tsconfig.json
+++ b/packages/doc-retrieval-mcp/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "composite": true,
+    "incremental": true,
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/doc-retrieval-mcp/vitest.config.ts
+++ b/packages/doc-retrieval-mcp/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+import { sharedTestConfig, coverageDefaults } from '../../vitest.preset'
+
+export default defineConfig({
+  test: {
+    ...sharedTestConfig,
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      ...coverageDefaults,
+    },
+  },
+})

--- a/scripts/ruvector-harness-tasks.json
+++ b/scripts/ruvector-harness-tasks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "git-crypt-worktree-interaction",
+    "prompt": "Explain how git-crypt interacts with worktrees in this repo. List the exact commands for creating a worktree, initializing git-crypt in it, and rebasing a worktree onto main. Cite file:line references."
+  },
+  {
+    "id": "file-length-enforcement",
+    "prompt": "What file-length limits does this repo enforce, where are they checked (hooks vs CI), and how does the pre-commit hook report violations? Reference the actual scripts."
+  },
+  {
+    "id": "plan-review-anti-patterns",
+    "prompt": "Identify anti-patterns to watch for when reviewing implementation plans in this repo. Cite docs/internal retros or plan-review artifacts."
+  }
+]

--- a/scripts/token-delta-harness.mjs
+++ b/scripts/token-delta-harness.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * SMI-4417 Wave 2 Step 6 — Token-delta harness.
+ *
+ * Measures input-token consumption for representative agent tasks with the
+ * skillsmith-doc-retrieval MCP server disabled (baseline) vs enabled
+ * (measured). Produces a reproducible go/no-go artifact for the gate:
+ * ≥40% median reduction across the 3 tasks = pass Phase 2.
+ *
+ * Usage:
+ *   node scripts/token-delta-harness.mjs run --mode baseline
+ *   node scripts/token-delta-harness.mjs run --mode measured
+ *   node scripts/token-delta-harness.mjs compare
+ *
+ * Implementation:
+ *   - Invokes `claude --print --output-format stream-json` per task.
+ *   - Parses stream events, sums `usage.input_tokens` across assistant turns.
+ *   - Writes results to scripts/ruvector-baseline.json (keyed by task + mode).
+ *   - `compare` reads the JSON and emits the delta summary.
+ *
+ * The tasks live in scripts/ruvector-harness-tasks.json so measurements stay
+ * reproducible across sessions.
+ */
+import { spawnSync } from 'node:child_process'
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..')
+const TASKS_PATH = resolve(__dirname, 'ruvector-harness-tasks.json')
+const RESULTS_PATH = resolve(__dirname, 'ruvector-baseline.json')
+
+function loadTasks() {
+  if (!existsSync(TASKS_PATH)) {
+    throw new Error(`Harness tasks not found: ${TASKS_PATH}`)
+  }
+  return JSON.parse(readFileSync(TASKS_PATH, 'utf8'))
+}
+
+function loadResults() {
+  if (!existsSync(RESULTS_PATH)) return { version: 1, runs: {} }
+  return JSON.parse(readFileSync(RESULTS_PATH, 'utf8'))
+}
+
+function saveResults(data) {
+  mkdirSync(dirname(RESULTS_PATH), { recursive: true })
+  writeFileSync(RESULTS_PATH, JSON.stringify(data, null, 2), 'utf8')
+}
+
+function invokeClaude(prompt, mode) {
+  const args = ['--print', '--output-format', 'stream-json', '--permission-mode', 'default']
+  if (mode === 'baseline') {
+    args.push('--mcp-config', '/dev/null')
+  }
+  const result = spawnSync('claude', args, {
+    cwd: REPO_ROOT,
+    input: prompt,
+    encoding: 'utf8',
+    maxBuffer: 100 * 1024 * 1024,
+  })
+  if (result.status !== 0) {
+    throw new Error(`claude exited ${result.status}: ${result.stderr?.slice(0, 500)}`)
+  }
+  return parseStream(result.stdout)
+}
+
+function parseStream(raw) {
+  let totalInput = 0
+  let turns = 0
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    let evt
+    try {
+      evt = JSON.parse(line)
+    } catch {
+      continue
+    }
+    const usage = evt?.message?.usage ?? evt?.usage
+    if (usage && typeof usage.input_tokens === 'number') {
+      totalInput += usage.input_tokens
+      turns++
+    }
+  }
+  return { totalInputTokens: totalInput, turns }
+}
+
+function run(mode) {
+  if (mode !== 'baseline' && mode !== 'measured') {
+    throw new Error(`mode must be 'baseline' or 'measured', got: ${mode}`)
+  }
+  const tasks = loadTasks()
+  const results = loadResults()
+  for (const task of tasks) {
+    const key = task.id
+    results.runs[key] ??= {}
+    const measurement = invokeClaude(task.prompt, mode)
+    results.runs[key][mode] = {
+      totalInputTokens: measurement.totalInputTokens,
+      turns: measurement.turns,
+      capturedAt: new Date().toISOString(),
+    }
+    console.log(
+      `[token-delta] ${key} mode=${mode} input=${measurement.totalInputTokens} turns=${measurement.turns}`
+    )
+  }
+  saveResults(results)
+}
+
+function compare() {
+  const results = loadResults()
+  const deltas = []
+  const rows = []
+  for (const [key, modes] of Object.entries(results.runs ?? {})) {
+    const b = modes.baseline?.totalInputTokens
+    const m = modes.measured?.totalInputTokens
+    if (typeof b !== 'number' || typeof m !== 'number' || b === 0) {
+      rows.push({ task: key, baseline: b ?? null, measured: m ?? null, deltaPct: null })
+      continue
+    }
+    const deltaPct = (1 - m / b) * 100
+    deltas.push(deltaPct)
+    rows.push({ task: key, baseline: b, measured: m, deltaPct: Number(deltaPct.toFixed(1)) })
+  }
+  deltas.sort((a, b) => a - b)
+  const median =
+    deltas.length === 0
+      ? null
+      : deltas.length % 2 === 1
+        ? deltas[(deltas.length - 1) / 2]
+        : (deltas[deltas.length / 2 - 1] + deltas[deltas.length / 2]) / 2
+  console.log(JSON.stringify({ rows, medianReductionPct: median, gate: '>=40' }, null, 2))
+}
+
+function main() {
+  const [, , cmd, ...rest] = process.argv
+  if (cmd === 'run') {
+    const modeIdx = rest.indexOf('--mode')
+    const mode = modeIdx >= 0 ? rest[modeIdx + 1] : null
+    if (!mode) throw new Error('Usage: run --mode <baseline|measured>')
+    run(mode)
+    return
+  }
+  if (cmd === 'compare') {
+    compare()
+    return
+  }
+  console.error('Usage: token-delta-harness.mjs <run --mode baseline|measured | compare>')
+  process.exit(2)
+}
+
+try {
+  main()
+} catch (err) {
+  console.error('[token-delta-harness] error:', err?.message ?? err)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

Phase 1 of [SMI-4416](https://linear.app/smith-horn-group/issue/SMI-4416) / ADR-117 — ships `@skillsmith/doc-retrieval-mcp` as a **scaffold** with runtime guards. The RuVector integration surface is blocked on [SMI-4426](https://linear.app/smith-horn-group/issue/SMI-4426) (runtime fix) before Wave 2 Step 6 (token-delta gate) can run.

## Why scaffold-only

Wave 2 Step 6 prep surfaced material mismatches between the plan assumptions and `@ruvector/core@0.1.30`'s actual runtime surface:

| Aspect | Plan assumed | Actual |
|---|---|---|
| Named export | `VectorDB` | `VectorDb` |
| Construction | `new VectorDB({dimensions, storagePath})` | `VectorDb.withDimensions(n)` static factory |
| Persistence | `.rvf` at `storagePath` | Opaque built-in — no `storagePath` param |
| Methods | Sync | All async |
| Score | Cosine similarity (1.0 = best) | Distance-like (~0 = best) |
| Platform | Cross-platform | Native binding per-OS; darwin-arm64 absent on Mac host |

The ESM `import { VectorDB } from '@ruvector/core'` throws a SyntaxError at module load (CJS module, name doesn't exist) — before any runtime guard could fire. SMI-4426 tracks the real integration + persistence design + integration test.

## What ships here

### Runtime-validated (this PR)
- `@skillsmith/doc-retrieval-mcp` workspace package — MCP server shape, CLI entry points, chunker, metadata store, config guards
- `skill_docs_status` tool works end-to-end (metadata-only, no VectorDb)
- `skill_docs_search` and `skill_docs_reindex` **throw with a clear SMI-4426 pointer** at invocation — agents and the post-commit hook fail loudly, not silently
- 19/19 unit tests green (chunker heading-aware splitter, metadata-store persistence, config CI-refuse + safe-path + submodule-init guards)
- Docs banner on `ruvector-dev-tooling.md` declares runtime status blocked so the rest of the guide reads as intended spec, not lies

### CI infrastructure (this PR, unblocks future workspaces)
- **`Dockerfile`:** `deps` stage COPY missed `packages/doc-retrieval-mcp/package*.json` → `npm ci` silently skipped `glob@11.1.0` → build failed masked by `|| echo "Build completed with warnings"`. Fix: add the missing COPY line
- **`.github/workflows/ci.yml` (×3 loops) + `e2e-tests.yml`:** hardcoded per-package extract lists (`core mcp-server cli enterprise vscode-extension website`) missed `doc-retrieval-mcp` so nested `node_modules` + `dist` + `.turbo` weren't copied out. Fix: add to all four loops. Same class as SMI-4361 workflow pattern drift
- **`eslint.config.js`:** register `packages/doc-retrieval-mcp/tsconfig.json`

### Scaffolding (ready for SMI-4426)
- `.mcp.json` — `skillsmith-doc-retrieval` local-stdio entry + 37-tool Ruflo `disabledTools` block per [SMI-4420 audit](../architecture/ruflo-tool-classification.md)
- `.gitignore` — `.ruvector/` + `*.rvf`
- `.husky/post-commit` — background incremental reindex, inert until `.rvf` exists
- `scripts/token-delta-harness.mjs` + `scripts/ruvector-harness-tasks.json` — Wave 2 Step 6 gate harness (cannot run until SMI-4426)

## Deviations from plan (documented for SMI-4426)

- Chunks target **240 tokens** (not 500). `all-MiniLM-L6-v2` 256-token cap + `EmbeddingService.embed()` truncates to 1000 chars
- Persistence model is unknown (RuVector's built-in is opaque); SMI-4426 must decide JSONL sidecar vs. accept built-in vs. switch library

## Doc-drift bypass

`[skip-doc-drift]` — `packages/doc-retrieval-mcp` is `"private": true` internal dev-tooling (never published to npm), no package CHANGELOG applies. User-facing docs live in `.claude/development/ruvector-dev-tooling.md` and the `CLAUDE.md` sub-doc table.

## Verification

- `docker exec -w /app/.worktrees/smi-4416 skillsmith-dev-1 npm test -w packages/doc-retrieval-mcp` → **19/19 pass**
- `docker exec ... node packages/doc-retrieval-mcp/dist/src/cli.js reindex --full` → clean SMI-4426 error, no NPE
- `docker exec ... node packages/doc-retrieval-mcp/dist/src/cli.js status` → JSON output, fileCount=0 (no index built yet)
- `npm run typecheck / build / lint / audit:standards` → clean (0 errors, pre-existing warnings unchanged)

## Test plan

- [ ] CI green on code-tier checks (13 required)
- [ ] Reviewer confirms: scaffold-with-guards is acceptable ship posture given SMI-4426 has clear DoD
- [ ] Post-merge: `/governance` retro clean
- [ ] SMI-4417 comment with merge SHA + status flipped to Done; SMI-4418 stays blocked

## What this PR does NOT unblock (blocked on SMI-4426)

- Wave 2 Step 6 (token-delta gate)
- Wave 2 Step 7 (safety-boundary test)
- Wave 3 / [SMI-4418](https://linear.app/smith-horn-group/issue/SMI-4418) Phase 2

## Linear

- [SMI-4416](https://linear.app/smith-horn-group/issue/SMI-4416) parent
- [SMI-4417](https://linear.app/smith-horn-group/issue/SMI-4417) Phase 1 — this PR (scaffold + CI fixes + guards)
- [SMI-4426](https://linear.app/smith-horn-group/issue/SMI-4426) — runtime fix (P2, blocks SMI-4417 follow-through)
- [SMI-4420](https://linear.app/smith-horn-group/issue/SMI-4420) Ruflo audit (merged via PR #717, block-list wired here)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
