### PR TITLE
chore(scripts): add pooler-psql.sh canonical helper + CLAUDE.md guidance [skip-impl-check]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,16 @@ varlock run -- npm test         # Run with secrets injected
 
 **Never** `echo $SECRET` or `cat .env`. Never ask users to paste secrets in chat. See [AI Agent Secret Handling](docs/internal/architecture/standards-security.md#411-ai-agent-secret-handling-smi-1956).
 
+**Supabase pooler access**: `SUPABASE_POOLER_URL` in `.env` contains a literal `[YOUR-PASSWORD]` placeholder by design — passwords with URL-special characters (`@ / : !`) break URI parsing, so every caller must build the connection from parts. Use the canonical helper instead of hand-rolling it:
+
+```bash
+echo 'SELECT COUNT(*) FROM skills;' | varlock run -- ./scripts/pooler-psql.sh
+varlock run -- ./scripts/pooler-psql.sh -c 'SELECT version();'
+cat query.sql | varlock run -- ./scripts/pooler-psql.sh
+```
+
+The script routes through the transaction pooler (port 6543) which avoids PostgREST's 8s `statement_timeout` on `audit_logs` LIKE queries (error 57014). Requires Docker container `skillsmith-dev-1` running. See `scripts/pooler-psql.sh` header for the full rationale.
+
 ---
 
 ## Test File Locations (SMI-1780)

--- a/scripts/pooler-psql.sh
+++ b/scripts/pooler-psql.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# pooler-psql.sh — canonical entry point for psql against the Supabase
+# transaction pooler (port 6543). SMI-4380 follow-up.
+#
+# Why this exists: SUPABASE_POOLER_URL in .env is a template — see
+# .env.schema:312-319. The stored value contains `[YOUR-PASSWORD]` as a
+# literal placeholder because passwords with URL-special characters
+# (@ / : !) break URI parsing. Every caller must build the connection
+# from parts via PG env vars. This script is the single canonical place
+# that does that, so sessions don't rediscover the pattern every time.
+#
+# Why the pooler (not db.<ref>.supabase.co:5432): PostgREST aborts
+# audit_logs LIKE queries at statement_timeout 8s (error 57014). Transaction
+# pooler bypasses that. Do not regress away from this.
+#
+# Usage:
+#   varlock run -- ./scripts/pooler-psql.sh -c 'SELECT version();'
+#   echo 'SELECT 1;' | varlock run -- ./scripts/pooler-psql.sh
+#   cat query.sql | varlock run -- ./scripts/pooler-psql.sh
+#   varlock run -- ./scripts/pooler-psql.sh --help
+#
+# Requires:
+#   - Docker container skillsmith-dev-1 running (provides psql 15+)
+#   - `varlock run --` prefix to supply SUPABASE_PROJECT_REF +
+#     SUPABASE_DB_PASSWORD without leaking them to the terminal
+
+set -eu
+
+: "${SUPABASE_PROJECT_REF:?must be set — run via 'varlock run -- ./scripts/pooler-psql.sh ...'}"
+: "${SUPABASE_DB_PASSWORD:?must be set — run via 'varlock run -- ./scripts/pooler-psql.sh ...'}"
+
+exec docker exec -i \
+  -e PGHOST="aws-1-us-east-1.pooler.supabase.com" \
+  -e PGPORT="6543" \
+  -e PGUSER="postgres.${SUPABASE_PROJECT_REF}" \
+  -e PGPASSWORD="${SUPABASE_DB_PASSWORD}" \
+  -e PGDATABASE="postgres" \
+  skillsmith-dev-1 psql "$@"

--- a/scripts/pooler-psql.sh
+++ b/scripts/pooler-psql.sh
@@ -29,6 +29,12 @@ set -eu
 : "${SUPABASE_PROJECT_REF:?must be set — run via 'varlock run -- ./scripts/pooler-psql.sh ...'}"
 : "${SUPABASE_DB_PASSWORD:?must be set — run via 'varlock run -- ./scripts/pooler-psql.sh ...'}"
 
+if ! docker inspect skillsmith-dev-1 --format '{{.State.Running}}' 2>/dev/null | grep -q '^true$'; then
+  echo "error: skillsmith-dev-1 container is not running. Start it with:" >&2
+  echo "  docker compose --profile dev up -d" >&2
+  exit 1
+fi
+
 exec docker exec -i \
   -e PGHOST="aws-1-us-east-1.pooler.supabase.com" \
   -e PGPORT="6543" \

--- a/scripts/tests/pooler-psql.test.sh
+++ b/scripts/tests/pooler-psql.test.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/pooler-psql.sh.
+#
+# Stubs `docker` so no real container is needed. Verifies:
+#   1. Script exits non-zero and prints a useful message when required env
+#      vars are absent.
+#   2. Correct PG env vars are forwarded to docker exec (host, port, user,
+#      database, password).
+#   3. Extra psql flags passed as positional args are forwarded unchanged.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+TARGET="$SCRIPT_DIR/pooler-psql.sh"
+
+if [ ! -x "$TARGET" ]; then
+  echo "FAIL: $TARGET not found or not executable"
+  exit 1
+fi
+
+fail=0
+
+assert_pass() {
+  local name="$1" result="$2"
+  if [ "$result" = "0" ]; then
+    echo "PASS $name"
+  else
+    echo "FAIL $name: expected exit 0, got $result"
+    fail=1
+  fi
+}
+
+assert_fail() {
+  local name="$1" result="$2"
+  if [ "$result" != "0" ]; then
+    echo "PASS $name"
+  else
+    echo "FAIL $name: expected non-zero exit, got 0"
+    fail=1
+  fi
+}
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -qF -- "$needle"; then
+    echo "PASS $name"
+  else
+    echo "FAIL $name: expected to contain '$needle' in: $haystack"
+    fail=1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Build a docker shim that simulates the container running.
+# `docker inspect ... --format ...` returns "true"; `docker exec` records args.
+# ---------------------------------------------------------------------------
+make_docker_shim() {
+  local tmpdir="$1"
+  cat > "$tmpdir/docker" <<'SHIM'
+#!/usr/bin/env bash
+case "$1" in
+  inspect)
+    echo "true"
+    ;;
+  exec)
+    printf '%s\n' "$@" > "$(dirname "$0")/docker_call"
+    ;;
+  *)
+    printf '%s\n' "$@" > "$(dirname "$0")/docker_call"
+    ;;
+esac
+SHIM
+  chmod +x "$tmpdir/docker"
+}
+
+# ---------------------------------------------------------------------------
+# Build a docker shim that simulates the container NOT running.
+# ---------------------------------------------------------------------------
+make_docker_shim_down() {
+  local tmpdir="$1"
+  cat > "$tmpdir/docker" <<'SHIM'
+#!/usr/bin/env bash
+case "$1" in
+  inspect)
+    echo "false"
+    ;;
+  *)
+    echo "error: container not running" >&2
+    exit 1
+    ;;
+esac
+SHIM
+  chmod +x "$tmpdir/docker"
+}
+
+run_script() {
+  local tmpdir="$1"
+  shift
+  PATH="$tmpdir:$PATH" bash "$TARGET" "$@" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: Missing SUPABASE_PROJECT_REF → non-zero exit + helpful message
+# ---------------------------------------------------------------------------
+case1_dir=$(mktemp -d)
+make_docker_shim "$case1_dir"
+case1_tmpout="$case1_dir/out"
+env -i HOME="$HOME" PATH="$case1_dir:/usr/local/bin:/usr/bin:/bin" \
+  SUPABASE_DB_PASSWORD="s3cr3t" \
+  bash "$TARGET" -c 'SELECT 1' >"$case1_tmpout" 2>&1 && case1_rc=0 || case1_rc=$?
+case1_out=$(cat "$case1_tmpout")
+assert_fail "missing_project_ref_exits_nonzero" "$case1_rc"
+assert_contains "missing_project_ref_message" "$case1_out" "SUPABASE_PROJECT_REF"
+rm -rf "$case1_dir"
+
+# ---------------------------------------------------------------------------
+# Case 2: Missing SUPABASE_DB_PASSWORD → non-zero exit + helpful message
+# ---------------------------------------------------------------------------
+case2_dir=$(mktemp -d)
+make_docker_shim "$case2_dir"
+case2_tmpout="$case2_dir/out"
+env -i HOME="$HOME" PATH="$case2_dir:/usr/local/bin:/usr/bin:/bin" \
+  SUPABASE_PROJECT_REF="vrcnzpmndtroqxxoqkzy" \
+  bash "$TARGET" -c 'SELECT 1' >"$case2_tmpout" 2>&1 && case2_rc=0 || case2_rc=$?
+case2_out=$(cat "$case2_tmpout")
+assert_fail "missing_db_password_exits_nonzero" "$case2_rc"
+assert_contains "missing_db_password_message" "$case2_out" "SUPABASE_DB_PASSWORD"
+rm -rf "$case2_dir"
+
+# ---------------------------------------------------------------------------
+# Case 3: Both env vars set → docker exec receives correct PG env vars
+# ---------------------------------------------------------------------------
+case3_dir=$(mktemp -d)
+make_docker_shim "$case3_dir"
+(
+  export SUPABASE_PROJECT_REF="testref123"
+  export SUPABASE_DB_PASSWORD="p@ss!w0rd"
+  PATH="$case3_dir:$PATH" bash "$TARGET" -c 'SELECT 1' >/dev/null 2>&1 || true
+)
+docker_args=$(cat "$case3_dir/docker_call" 2>/dev/null || echo "")
+
+assert_contains "pg_host_passed"     "$docker_args" "PGHOST=aws-1-us-east-1.pooler.supabase.com"
+assert_contains "pg_port_passed"     "$docker_args" "PGPORT=6543"
+assert_contains "pg_user_passed"     "$docker_args" "PGUSER=postgres.testref123"
+assert_contains "pg_password_passed" "$docker_args" "PGPASSWORD=p@ss!w0rd"
+assert_contains "pg_database_passed" "$docker_args" "PGDATABASE=postgres"
+assert_contains "container_name"     "$docker_args" "skillsmith-dev-1"
+rm -rf "$case3_dir"
+
+# ---------------------------------------------------------------------------
+# Case 4: Positional args forwarded to psql after container name
+# ---------------------------------------------------------------------------
+case4_dir=$(mktemp -d)
+make_docker_shim "$case4_dir"
+(
+  export SUPABASE_PROJECT_REF="testref123"
+  export SUPABASE_DB_PASSWORD="hunter2"
+  PATH="$case4_dir:$PATH" bash "$TARGET" -c 'SELECT 42' >/dev/null 2>&1 || true
+)
+docker_args4=$(cat "$case4_dir/docker_call" 2>/dev/null || echo "")
+assert_contains "psql_flag_passthrough"  "$docker_args4" "-c"
+assert_contains "psql_query_passthrough" "$docker_args4" "SELECT 42"
+rm -rf "$case4_dir"
+
+# ---------------------------------------------------------------------------
+# Case 5: Container not running → non-zero exit + helpful docker compose message
+# ---------------------------------------------------------------------------
+case5_dir=$(mktemp -d)
+make_docker_shim_down "$case5_dir"
+case5_tmpout="$case5_dir/out"
+env -i HOME="$HOME" PATH="$case5_dir:/usr/local/bin:/usr/bin:/bin" \
+  SUPABASE_PROJECT_REF="vrcnzpmndtroqxxoqkzy" \
+  SUPABASE_DB_PASSWORD="s3cr3t" \
+  bash "$TARGET" -c 'SELECT 1' >"$case5_tmpout" 2>&1 && case5_rc=0 || case5_rc=$?
+case5_out=$(cat "$case5_tmpout")
+assert_fail    "container_down_exits_nonzero" "$case5_rc"
+assert_contains "container_down_message"      "$case5_out" "skillsmith-dev-1"
+assert_contains "container_down_hint"         "$case5_out" "docker compose"
+rm -rf "$case5_dir"
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+if [ "$fail" -eq 0 ]; then
+  echo "All tests passed."
+  exit 0
+else
+  echo "Some tests FAILED."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

[skip-impl-check] — this is a shell-script + docs-only change; no TypeScript implementation to verify.

SMI-4380 follow-up. Codifies the recurring rediscovery that `SUPABASE_POOLER_URL` in `.env` is a template with a `[YOUR-PASSWORD]` placeholder — passwords with URL-special characters (`@ / : !`) break URI parsing, so every caller must build the connection from parts via PG env vars.

Adds:
- `scripts/pooler-psql.sh` — single canonical entry point; accepts stdin / `-c` / `-f` verbatim. Includes container-running guard (governance catch) with actionable error message.
- `scripts/tests/pooler-psql.test.sh` — 15 shell test cases following the existing `deploy-detection.test.sh` / `create-worktree-hooks.test.sh` convention. Covers missing env vars, PG env var forwarding, arg passthrough, container-down path.
- CLAUDE.md note in Varlock section pointing to the helper + explaining the pooler choice.

Preserves the pooler (port 6543) pattern — do not regress back to PostgREST which times out on `audit_logs` LIKE queries at 8s (error 57014).

## Test plan

- [x] `echo 'SELECT 1;' | varlock run -- ./scripts/pooler-psql.sh` → returns 1 row
- [x] `varlock run -- ./scripts/pooler-psql.sh -c 'SELECT COUNT(*) FROM skills;'` → returns 15,209 (prod skill count)
- [x] Password with special chars flows through via `PGPASSWORD` env var, not URI — no encoding issues
- [x] Missing `SUPABASE_DB_PASSWORD` fails loudly with clear message
- [x] Container-down produces actionable error instead of raw Docker error (governance catch)
- [x] `./scripts/tests/pooler-psql.test.sh` — all 15 cases pass
- [x] Lint + format clean; script uses `set -eu` + `:` guards

## Non-goals

- Not modifying `SUPABASE_POOLER_URL` in `.env` — the placeholder is intentional (see `.env.schema:312-319`)
- Not removing the env var — it's kept as a human-readable connection template

🤖 Generated with [Claude Code](https://claude.com/claude-code)