### PR TITLE
feat(doc-retrieval-mcp): SMI-4426 Wave 2 — RuVector runtime fix + real indexer + search wiring

### DIFF
--- a/.claude/development/ruvector-dev-tooling.md
+++ b/.claude/development/ruvector-dev-tooling.md
@@ -1,20 +1,5 @@
 # RuVector Dev Tooling — `skillsmith-doc-retrieval` MCP
 
-> ⚠️ **Runtime status: BLOCKED on [SMI-4426](https://linear.app/smith-horn-group/issue/SMI-4426)**
->
-> Wave 2 Step 1 ([PR #722](https://github.com/smith-horn/skillsmith/pull/722))
-> ships this package as a **scaffold**. Unit tests cover chunker, metadata
-> store, and config guards (19/19 green), but the `@ruvector/core@0.1.30`
-> integration surface has **not** been runtime-validated. `skill_docs_search`
-> and `skill_docs_reindex` will throw a clear SMI-4426 error at invocation
-> rather than NPE. `skill_docs_status` works (metadata-only). The rest of
-> this guide documents the *intended* end-state — treat it as a spec until
-> SMI-4426 lands.
->
-> See SMI-4426 for the API mismatch findings (`VectorDb` vs `VectorDB`,
-> `withDimensions(n)` factory, opaque persistence, distance-like scores,
-> platform native bindings).
-
 Local, private semantic search over the Skillsmith doc corpus. Wraps
 `@ruvector/core` with Skillsmith's existing `EmbeddingService` so agents can
 hit 3 tools (`skill_docs_search`, `skill_docs_reindex`, `skill_docs_status`)
@@ -38,8 +23,8 @@ git submodule update --init   # required: docs/internal must be present
 node packages/doc-retrieval-mcp/dist/src/cli.js reindex --full
 ```
 
-Output lands at `.ruvector/skillsmith-docs.rvf` +
-`.ruvector/metadata.json` + `.ruvector/.index-state.json`. All three are
+Output lands at `.ruvector/skillsmith-docs/vectors` (single-file VectorDb),
+`.ruvector/metadata.json`, and `.ruvector/.index-state.json`. All three are
 git-ignored. `.git-crypt-ignore` is **not** needed — smudge/clean filters
 never run on untracked files.
 
@@ -96,14 +81,13 @@ this if we adopt a longer-context model.
 1. `.ruvector/` is **git-ignored** and **CI-refused**. The indexer exits
    non-zero if `CI=true` or `SKILLSMITH_CI=true`. It also refuses to write
    outside `$REPO_ROOT/.ruvector/`.
-2. `.claude/settings.json` `permissions.deny` lists 37 Ruflo tools with
-   remote-persistence surfaces (AgentDB, hive-mind_memory, transfer_*,
-   memory_store, etc.). Authoritative list lives in
+2. `.claude/settings.json` carries a `permissions.deny` list covering 44 Ruflo
+   tools with remote-persistence surfaces (AgentDB, hive-mind_memory,
+   transfer_*, memory_store, etc.). This is the only Claude Code-enforced
+   mechanism — `.mcp.json` `disabledTools` is silently ignored (SMI-4427).
+   Authoritative list lives in
    [`docs/internal/architecture/ruflo-tool-classification.md`](../../docs/internal/architecture/ruflo-tool-classification.md)
-   (SMI-4420). SMI-4417 initially shipped this block in `.mcp.json` under a
-   `disabledTools` key — that field is not part of the `.mcp.json` schema and
-   is silently ignored; SMI-4427 moved it to the correct enforcement point.
-   Re-audit when Ruflo bumps a minor version.
+   (SMI-4420). Re-audit when Ruflo bumps a minor version.
 3. The corpus includes `docs/internal/**/*.md` (private submodule). The
    resulting `.rvf` is a searchable index of that content — treat it with
    the same confidentiality as the submodule itself.
@@ -114,17 +98,18 @@ this if we adopt a longer-context model.
 
 `.husky/post-commit` runs an incremental re-index in the background when:
 
-- `$REPO_ROOT/.ruvector/skillsmith-docs.rvf` exists (first run is manual).
+- `$REPO_ROOT/.ruvector/skillsmith-docs/vectors` exists (first run is manual).
 - `packages/doc-retrieval-mcp/dist/src/cli.js` exists (package is built).
 - `CI` and `SKILLSMITH_CI` are unset.
+- The `skillsmith-dev-1` Docker container is running (indexer requires the linux-arm64-gnu native binding).
 
 The indexer uses `GIT_OPTIONAL_LOCKS=0` and passes
 `--no-optional-locks` to every `git diff` invocation, avoiding the
 SMI-2536 smudge-filter branch-switch hazard. Hook failure is non-fatal
 and non-blocking.
 
-To disable the auto-reindex: delete the `.rvf` (first-run branch skips),
-or unset the cli by removing `packages/doc-retrieval-mcp/dist/`.
+To disable the auto-reindex: `rm -rf .ruvector/skillsmith-docs/` (first-run
+branch skips), or remove `packages/doc-retrieval-mcp/dist/`.
 
 ---
 

--- a/.claude/development/ruvector-dev-tooling.md
+++ b/.claude/development/ruvector-dev-tooling.md
@@ -53,7 +53,7 @@ Restart Claude Code so it picks up the new `.mcp.json` entry.
 |------|---------|-------|
 | `skill_docs_search` | Semantic doc search | `{ query, k?, min_score?, scope_globs? } → { chunks: [{ id, file_path, line_start, line_end, heading_chain, text, score }] }` |
 | `skill_docs_reindex` | Rebuild / refresh | `{ mode: 'full' \| 'incremental' }` |
-| `skill_docs_status` | Index health check | `{} → { chunkCount, fileCount, lastIndexedSha, lastRunAt, rvfPath, corpusVersion }` |
+| `skill_docs_status` | Index health check | `{} → { chunkCount, fileCount, lastIndexedSha, lastRunAt, storagePath, corpusVersion }` |
 
 ### Score semantics
 

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -50,19 +50,19 @@ fi
 # SMI-710: Sync Linear issues from commit messages (background, non-blocking)
 node "$(dirname "$0")/../scripts/linear-hook.mjs" post-commit &
 
-# SMI-4417: Background incremental re-index of doc corpus.
-# Non-blocking, failure non-fatal, skipped if .rvf absent (first run manual)
-# or in CI. GIT_OPTIONAL_LOCKS=0 + --no-optional-locks inside the indexer
-# prevent SMI-2536 smudge-filter hazards during `git diff` against the index.
+# SMI-4417/SMI-4426: Background incremental re-index of doc corpus.
+# Non-blocking, failure non-fatal, skipped if index absent (first run manual)
+# or in CI. Sentinel is .ruvector/skillsmith-docs/vectors (single DB file per
+# @ruvector/core@0.1.30 — not the legacy .rvf path). Indexer runs inside
+# Docker (SMI-4426: native binding requires linux-arm64-gnu, not darwin-arm64).
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 if [ -n "$REPO_ROOT" ] && [ -z "$CI" ] && [ -z "$SKILLSMITH_CI" ] \
-  && [ -f "$REPO_ROOT/.ruvector/skillsmith-docs.rvf" ] \
-  && [ -f "$REPO_ROOT/packages/doc-retrieval-mcp/dist/src/cli.js" ]; then
-  (
-    cd "$REPO_ROOT" || exit 0
-    GIT_OPTIONAL_LOCKS=0 nohup node packages/doc-retrieval-mcp/dist/src/cli.js reindex --incremental --quiet \
-      >/dev/null 2>&1 &
-  )
+  && [ -f "$REPO_ROOT/.ruvector/skillsmith-docs/vectors" ] \
+  && [ -f "$REPO_ROOT/packages/doc-retrieval-mcp/dist/src/cli.js" ] \
+  && docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^skillsmith-dev-1$'; then
+  nohup docker exec skillsmith-dev-1 \
+    sh -c "cd /app && GIT_OPTIONAL_LOCKS=0 node packages/doc-retrieval-mcp/dist/src/cli.js reindex --incremental --quiet" \
+    >/dev/null 2>&1 &
 fi
 
 exit 0

--- a/packages/doc-retrieval-mcp/src/config.ts
+++ b/packages/doc-retrieval-mcp/src/config.ts
@@ -3,6 +3,22 @@ import { existsSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+/**
+ * Default similarity threshold for skill_docs_search results.
+ *
+ * ADR-117 band table (post-distance→similarity transform, [0, 1], 1 = best):
+ *   <0.20        noise
+ *   0.20 - 0.35  weak
+ *   0.35 - 0.55  loose
+ *   0.55 - 0.75  strong
+ *   >0.75        near-duplicate
+ *
+ * 0.35 mirrors the ADR recommendation. Wave 2 Step 6 token-delta harness
+ * will empirically validate before lock-in; tuning changes land here in
+ * one place (plan-review amendment I).
+ */
+export const DEFAULT_MIN_SIMILARITY = 0.35
+
 export interface ChunkConfig {
   targetTokens: number
   overlapTokens: number
@@ -10,7 +26,13 @@ export interface ChunkConfig {
 }
 
 export interface CorpusConfig {
-  rvfPath: string
+  /**
+   * Directory where @ruvector/core writes `collections/`, `vectors.db`
+   * (redb KV), `metadata.json`, `aliases.json`, and `<basename>.hnsw.*` dumps.
+   * Renamed from `rvfPath` under SMI-4426 — the binding persists a directory
+   * tree, not a single `.rvf` file.
+   */
+  storagePath: string
   metadataPath: string
   stateFile: string
   embeddingDim: number
@@ -41,8 +63,8 @@ function defaultConfigPath(): string {
 }
 
 function validate(c: CorpusConfig): void {
-  if (!c.rvfPath || !c.metadataPath || !c.stateFile) {
-    throw new Error('corpus.config.json: rvfPath, metadataPath, stateFile are required')
+  if (!c.storagePath || !c.metadataPath || !c.stateFile) {
+    throw new Error('corpus.config.json: storagePath, metadataPath, stateFile are required')
   }
   if (c.embeddingDim !== 384) {
     throw new Error(

--- a/packages/doc-retrieval-mcp/src/corpus.config.json
+++ b/packages/doc-retrieval-mcp/src/corpus.config.json
@@ -1,5 +1,5 @@
 {
-  "rvfPath": ".ruvector/skillsmith-docs.rvf",
+  "storagePath": ".ruvector/skillsmith-docs",
   "metadataPath": ".ruvector/metadata.json",
   "stateFile": ".ruvector/.index-state.json",
   "embeddingDim": 384,
@@ -19,5 +19,6 @@
     "docs/internal/**/*.md",
     "packages/*/README.md"
   ],
-  "requireSubmodule": "docs/internal"
+  "requireSubmodule": "docs/internal",
+  "_storagePathRationale": "@ruvector/core@0.1.30 writes a DIRECTORY (collections/, vectors.db redb KV, metadata.json, aliases.json, hnsw dumps), not a single .rvf file. SMI-4426 renamed `rvfPath` to `storagePath` to match reality; legacy *.rvf gitignore entry kept harmless."
 }

--- a/packages/doc-retrieval-mcp/src/corpus.config.json
+++ b/packages/doc-retrieval-mcp/src/corpus.config.json
@@ -20,5 +20,5 @@
     "packages/*/README.md"
   ],
   "requireSubmodule": "docs/internal",
-  "_storagePathRationale": "@ruvector/core@0.1.30 writes a DIRECTORY (collections/, vectors.db redb KV, metadata.json, aliases.json, hnsw dumps), not a single .rvf file. SMI-4426 renamed `rvfPath` to `storagePath` to match reality; legacy *.rvf gitignore entry kept harmless."
+  "_storagePathRationale": "@ruvector/core@0.1.30 creates a SINGLE FILE at the exact storagePath given (not a directory tree as the initial plan assumed). SMI-4426 renamed `rvfPath` to `storagePath`. The indexer creates this as a DIRECTORY and passes join(storageAbs,'vectors') to VectorDb, so the lock (.indexer.lock) and the db file (vectors) coexist inside this directory. Legacy *.rvf gitignore entry kept harmless."
 }

--- a/packages/doc-retrieval-mcp/src/indexer-lock.ts
+++ b/packages/doc-retrieval-mcp/src/indexer-lock.ts
@@ -31,6 +31,11 @@ const DEFAULT_POLL_MS = 100
  * net — SIGKILL still leaves the lock behind, but the next run's kill -0
  * staleness check breaks it.
  *
+ * NOTE: callers MUST validate `storagePath` via `assertSafeIndexTarget` from
+ * `./config.js` BEFORE calling this helper. This helper trusts its input so
+ * it remains testable against tmpdir paths that live outside the normal
+ * `$REPO_ROOT/.ruvector` boundary.
+ *
  * @throws Error('indexer lock timeout ...') when acquisition exceeds timeoutMs
  * while the existing holder remains alive.
  */

--- a/packages/doc-retrieval-mcp/src/indexer-lock.ts
+++ b/packages/doc-retrieval-mcp/src/indexer-lock.ts
@@ -1,0 +1,155 @@
+// SMI-4426: Single-writer discipline for the RuVector storagePath. The native
+// binding provides no OS-level lock, so we coordinate indexer processes via an
+// exclusive-create lockfile inside the storage directory. Stale locks whose
+// holder is dead (kill -0 ESRCH) are broken automatically.
+//
+// Node's built-in fs module has no flock API — this PID-based pattern is the
+// portable alternative (SMI-4426 plan-review amendments A/B).
+
+import { openSync, writeSync, closeSync, readFileSync, unlinkSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+export interface AcquireLockOptions {
+  /** Max time (ms) to wait for an existing lock to clear. Default 30000. */
+  timeoutMs?: number
+  /** Poll interval while waiting (ms). Default 100. */
+  pollMs?: number
+  /** Liveness probe override for tests; real callers rely on process.kill(pid, 0). */
+  probeAlive?: (pid: number) => boolean
+  /** Self-pid override for tests. */
+  selfPid?: number
+  /** Register signal/exit cleanup handlers. Default true. */
+  registerHandlers?: boolean
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000
+const DEFAULT_POLL_MS = 100
+
+/**
+ * Acquire the indexer lock. Returns a release callback the caller MUST invoke
+ * on normal completion. Signal/exit handlers registered on top are a safety
+ * net — SIGKILL still leaves the lock behind, but the next run's kill -0
+ * staleness check breaks it.
+ *
+ * @throws Error('indexer lock timeout ...') when acquisition exceeds timeoutMs
+ * while the existing holder remains alive.
+ */
+export async function acquireIndexerLock(
+  storagePath: string,
+  opts: AcquireLockOptions = {}
+): Promise<() => void> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const pollMs = opts.pollMs ?? DEFAULT_POLL_MS
+  const probeAlive = opts.probeAlive ?? defaultProbeAlive
+  const selfPid = opts.selfPid ?? process.pid
+  const registerHandlers = opts.registerHandlers ?? true
+  const lockPath = join(storagePath, '.indexer.lock')
+
+  mkdirSync(storagePath, { recursive: true })
+
+  const deadline = Date.now() + timeoutMs
+
+  while (true) {
+    try {
+      const fd = openSync(lockPath, 'wx')
+      writeSync(fd, `${selfPid}\n${new Date().toISOString()}\n`)
+      closeSync(fd)
+      return registerRelease(lockPath, registerHandlers)
+    } catch (err) {
+      if (!isEexist(err)) throw err
+
+      if (breakIfStale(lockPath, probeAlive)) {
+        continue
+      }
+
+      if (Date.now() > deadline) {
+        throw new Error(
+          `indexer lock timeout after ${timeoutMs}ms. Held by another live process at ${lockPath}.`
+        )
+      }
+
+      await sleep(pollMs)
+    }
+  }
+}
+
+function breakIfStale(lockPath: string, probeAlive: (pid: number) => boolean): boolean {
+  let raw: string
+  try {
+    raw = readFileSync(lockPath, 'utf8')
+  } catch {
+    return false
+  }
+
+  const pidStr = raw.split('\n')[0]?.trim()
+  const pid = Number.parseInt(pidStr ?? '', 10)
+
+  if (!Number.isFinite(pid) || pid <= 0) {
+    tryUnlink(lockPath)
+    return true
+  }
+
+  if (!probeAlive(pid)) {
+    tryUnlink(lockPath)
+    return true
+  }
+
+  return false
+}
+
+function defaultProbeAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'ESRCH') return false
+    // EPERM: process exists but is owned by another user. Treat as alive so we
+    // don't trample a real writer.
+    return code === 'EPERM'
+  }
+}
+
+function registerRelease(lockPath: string, registerHandlers: boolean): () => void {
+  let released = false
+
+  const release = (): void => {
+    if (released) return
+    released = true
+    tryUnlink(lockPath)
+  }
+
+  if (registerHandlers) {
+    const onSignal = (): void => {
+      release()
+      process.exit(1)
+    }
+    const onUncaught = (err: Error): void => {
+      release()
+      // Re-throw so Node's default handler prints the stack and exits non-zero.
+      throw err
+    }
+    process.once('SIGINT', onSignal)
+    process.once('SIGTERM', onSignal)
+    process.once('exit', release)
+    process.once('uncaughtException', onUncaught)
+  }
+
+  return release
+}
+
+function tryUnlink(path: string): void {
+  try {
+    unlinkSync(path)
+  } catch {
+    // Already gone — concurrent winner deleted it.
+  }
+}
+
+function isEexist(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException).code === 'EEXIST'
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/packages/doc-retrieval-mcp/src/indexer.ts
+++ b/packages/doc-retrieval-mcp/src/indexer.ts
@@ -27,10 +27,9 @@ export interface IndexResult {
 }
 
 const RUVECTOR_BLOCKED =
-  'doc-retrieval: RuVector integration is blocked on SMI-4426 ' +
-  '(https://linear.app/smith-horn-group/issue/SMI-4426). ' +
-  'The scaffold in PR #722 (SMI-4417) has not been runtime-validated against ' +
-  '@ruvector/core. See .claude/development/ruvector-dev-tooling.md.'
+  'doc-retrieval: runIndexer() is blocked on SMI-4426 Wave 2 Step 2. ' +
+  'Wave 2 Step 1 (types + lock helper + score transform + storagePath rename) ' +
+  'shipped in d804515a. See docs/internal/implementation/smi-4426-ruvector-runtime-fix.md.'
 
 export async function runIndexer(
   _mode: 'full' | 'incremental',

--- a/packages/doc-retrieval-mcp/src/indexer.ts
+++ b/packages/doc-retrieval-mcp/src/indexer.ts
@@ -1,22 +1,24 @@
-// SMI-4426: Wave 2 Step 1 shipped `@skillsmith/doc-retrieval-mcp` as a scaffold.
-// The RuVector integration is blocked pending a runtime fix. Unit tests cover
-// chunker/metadata-store/config (19/19 green) but the indexer and search code
-// paths have NOT been runtime-validated against `@ruvector/core@0.1.30`.
-//
-// Key API mismatches discovered during Wave 2 Step 6 prep:
-//   - Named export is `VectorDb` (lowercase b), not `VectorDB`
-//   - `VectorDb.withDimensions(n)` static factory, not `new VectorDB({...})`
-//   - No `storagePath` parameter — opaque built-in persistence
-//   - All methods async (return Promises)
-//   - Score is distance-like (~0 = best), not cosine similarity
-//   - Native binding per platform (darwin-arm64 not auto-installed locally)
-//
-// The original scaffold implementation (chunker wiring, git-diff incremental
-// mode, VectorDB insert/delete calls) lives in git history on this branch —
-// see commits before the SMI-4426 runtime guard.
-//
-// SMI-4426 tracks the real integration + persistence design + integration test:
-//   https://linear.app/smith-horn-group/issue/SMI-4426
+import { readFile, writeFile, unlink, mkdir, readdir } from 'node:fs/promises'
+import type { Dirent } from 'node:fs'
+import { existsSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { execSync } from 'node:child_process'
+import { minimatch } from 'minimatch'
+import { VectorDb } from '@ruvector/core'
+import './ruvector-types.js'
+import {
+  loadConfig,
+  resolveRepoPath,
+  repoRoot,
+  assertNotInCi,
+  assertSafeIndexTarget,
+  assertSubmoduleInitialized,
+} from './config.js'
+import { acquireIndexerLock } from './indexer-lock.js'
+import { MetadataStore } from './metadata-store.js'
+import { embedBatch } from './embedding.js'
+import { chunkDocument } from './indexer.helpers.js'
+import type { IndexState } from './types.js'
 
 export interface IndexResult {
   mode: 'full' | 'incremental'
@@ -26,14 +28,214 @@ export interface IndexResult {
   durationMs: number
 }
 
-const RUVECTOR_BLOCKED =
-  'doc-retrieval: runIndexer() is blocked on SMI-4426 Wave 2 Step 2. ' +
-  'Wave 2 Step 1 (types + lock helper + score transform + storagePath rename) ' +
-  'shipped in d804515a. See docs/internal/implementation/smi-4426-ruvector-runtime-fix.md.'
+const CORPUS_VERSION = 1
 
 export async function runIndexer(
-  _mode: 'full' | 'incremental',
-  _opts: { quiet?: boolean; configPath?: string } = {}
+  mode: 'full' | 'incremental',
+  opts: { quiet?: boolean; configPath?: string } = {}
 ): Promise<IndexResult> {
-  throw new Error(RUVECTOR_BLOCKED)
+  assertNotInCi()
+  const t0 = Date.now()
+
+  const cfg = await loadConfig(opts.configPath)
+  const storageAbs = resolveRepoPath(cfg.storagePath)
+  const metaAbs = resolveRepoPath(cfg.metadataPath)
+  const stateAbs = resolveRepoPath(cfg.stateFile)
+  const vectorsFile = join(storageAbs, 'vectors')
+
+  assertSafeIndexTarget(storageAbs)
+  assertSubmoduleInitialized(cfg)
+
+  const release = await acquireIndexerLock(storageAbs)
+  try {
+    return await doIndex(mode, { storageAbs, metaAbs, stateAbs, vectorsFile, cfg, t0 })
+  } finally {
+    release()
+  }
+}
+
+interface IndexContext {
+  storageAbs: string
+  metaAbs: string
+  stateAbs: string
+  vectorsFile: string
+  cfg: Awaited<ReturnType<typeof loadConfig>>
+  t0: number
+}
+
+async function doIndex(mode: 'full' | 'incremental', ctx: IndexContext): Promise<IndexResult> {
+  const { metaAbs, stateAbs, vectorsFile, cfg, t0 } = ctx
+  const root = repoRoot()
+  const store = await MetadataStore.load(metaAbs)
+
+  let chunksUpserted = 0
+  let chunksDeleted = 0
+  let filesScanned = 0
+
+  if (mode === 'full') {
+    const existingIds = store.entries().map((e) => e.id)
+    for (const id of existingIds) {
+      store.delete(id)
+    }
+    chunksDeleted = existingIds.length
+    if (existsSync(vectorsFile)) {
+      await unlink(vectorsFile)
+    }
+  }
+
+  const db = new VectorDb({
+    dimensions: cfg.embeddingDim,
+    storagePath: vectorsFile,
+    distanceMetric: 'Cosine',
+  })
+
+  const { filesToIndex, deletedFiles } = await resolveFiles(mode, root, cfg, stateAbs)
+
+  for (const relPath of deletedFiles) {
+    const removed = store.deleteByFile(relPath)
+    for (const id of removed) {
+      await db.delete(id)
+      chunksDeleted++
+    }
+  }
+
+  for (const relPath of filesToIndex) {
+    const absPath = join(root, relPath)
+    let raw: string
+    try {
+      raw = await readFile(absPath, 'utf8')
+    } catch {
+      continue
+    }
+
+    if (mode === 'incremental') {
+      const removed = store.deleteByFile(relPath)
+      for (const id of removed) {
+        await db.delete(id)
+        chunksDeleted++
+      }
+    }
+
+    const chunks = chunkDocument(raw, relPath, cfg)
+    if (chunks.length === 0) continue
+
+    const vectors = await embedBatch(chunks.map((c) => c.text))
+    const entries = chunks.map((chunk, i) => ({
+      id: chunk.id,
+      vector: vectors[i],
+      metadata: JSON.stringify({
+        file_path: chunk.filePath,
+        line_start: chunk.lineStart,
+        line_end: chunk.lineEnd,
+        heading_chain: chunk.headingChain,
+        text: chunk.text,
+      }),
+    }))
+
+    await db.insertBatch(entries)
+    for (const chunk of chunks) {
+      store.upsert(chunk)
+      chunksUpserted++
+    }
+    filesScanned++
+  }
+
+  await store.flush()
+
+  const state: IndexState = {
+    lastIndexedSha: currentGitSha(root),
+    chunkCountByFile: buildChunkCountByFile(store),
+    lastRunAt: new Date().toISOString(),
+    corpusVersion: CORPUS_VERSION,
+  }
+  await mkdir(join(root, '.ruvector'), { recursive: true })
+  await writeFile(stateAbs, JSON.stringify(state, null, 2), 'utf8')
+
+  return { mode, filesScanned, chunksUpserted, chunksDeleted, durationMs: Date.now() - t0 }
+}
+
+async function expandGlobs(patterns: string[], cwd: string): Promise<string[]> {
+  let rawEntries: Dirent[]
+  try {
+    rawEntries = (await readdir(cwd, {
+      recursive: true,
+      withFileTypes: true,
+    })) as unknown as Dirent[]
+  } catch {
+    return []
+  }
+  const results = new Set<string>()
+  for (const entry of rawEntries) {
+    if (!entry.isFile()) continue
+    const relPath = relative(cwd, join(entry.parentPath, entry.name))
+    for (const pattern of patterns) {
+      if (minimatch(relPath, pattern, { dot: true })) {
+        results.add(relPath)
+        break
+      }
+    }
+  }
+  return [...results].sort()
+}
+
+async function resolveFiles(
+  mode: 'full' | 'incremental',
+  root: string,
+  cfg: Awaited<ReturnType<typeof loadConfig>>,
+  stateAbs: string
+): Promise<{ filesToIndex: string[]; deletedFiles: string[] }> {
+  if (mode === 'full') {
+    return { filesToIndex: await expandGlobs(cfg.globs, root), deletedFiles: [] }
+  }
+
+  const state: IndexState | null = existsSync(stateAbs)
+    ? (JSON.parse(await readFile(stateAbs, 'utf8')) as IndexState)
+    : null
+
+  const changed = state?.lastIndexedSha
+    ? gitChangedFiles(root, state.lastIndexedSha)
+    : await expandGlobs(cfg.globs, root)
+
+  const allCorpusFiles = new Set(await expandGlobs(cfg.globs, root))
+
+  const filesToIndex = changed.filter(
+    (f: string) => allCorpusFiles.has(f) && existsSync(join(root, f))
+  )
+  const deletedFiles = changed.filter(
+    (f: string) => allCorpusFiles.has(f) && !existsSync(join(root, f))
+  )
+  return { filesToIndex, deletedFiles }
+}
+
+function gitChangedFiles(root: string, baseSha: string): string[] {
+  try {
+    const out = execSync(`git --no-optional-locks diff --name-only ${baseSha}..HEAD`, {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
+    })
+    return out.split('\n').filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+function currentGitSha(root: string): string | null {
+  try {
+    return execSync('git rev-parse HEAD', {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
+    }).trim()
+  } catch {
+    return null
+  }
+}
+
+function buildChunkCountByFile(store: MetadataStore): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const entry of store.entries()) {
+    counts[entry.filePath] = (counts[entry.filePath] ?? 0) + 1
+  }
+  return counts
 }

--- a/packages/doc-retrieval-mcp/src/indexer.ts
+++ b/packages/doc-retrieval-mcp/src/indexer.ts
@@ -208,6 +208,8 @@ async function resolveFiles(
 }
 
 function gitChangedFiles(root: string, baseSha: string): string[] {
+  // Validate SHA format before interpolating into the git range argument.
+  if (!/^[0-9a-f]{40}$/i.test(baseSha)) return []
   try {
     const out = execSync(`git --no-optional-locks diff --name-only ${baseSha}..HEAD`, {
       cwd: root,

--- a/packages/doc-retrieval-mcp/src/ruvector-types.ts
+++ b/packages/doc-retrieval-mcp/src/ruvector-types.ts
@@ -14,7 +14,11 @@ import type {} from '@ruvector/core'
 
 declare module '@ruvector/core' {
   interface VectorEntry {
-    metadata?: Record<string, unknown>
+    // The binding serializes metadata as a plain string (not an object).
+    // Callers must JSON.stringify on insert and JSON.parse on retrieval.
+    // SMI-4426 empirical finding: passing an object throws
+    // "Failed to convert ... into rust type `String`".
+    metadata?: string
   }
 
   interface SearchQuery {
@@ -22,7 +26,8 @@ declare module '@ruvector/core' {
   }
 
   interface SearchResult {
-    metadata?: Record<string, unknown>
+    // Returned as the same JSON string that was stored at insert time.
+    metadata?: string
   }
 
   // `VectorDb.withDimensions(n)` and `CollectionManager` are present at

--- a/packages/doc-retrieval-mcp/src/ruvector-types.ts
+++ b/packages/doc-retrieval-mcp/src/ruvector-types.ts
@@ -1,0 +1,40 @@
+// SMI-4426: @ruvector/core@0.1.30 ships an index.d.ts that lags the native
+// binding. These surfaces work at runtime but are missing from the declared
+// types; without this augmentation callers would reach for `as any` at every
+// boundary. Pure declaration file — no runtime cost.
+//
+// A plain `.d.ts` suffix would be caught by the root `.gitignore`
+// `packages/**/*.d.ts` rule (intended to exclude build output). Keeping the
+// file as `.ts` + module-augmentation syntax produces identical semantics.
+//
+// Forensic rationale documented in
+// docs/internal/implementation/smi-4426-ruvector-runtime-fix.md.
+
+import type {} from '@ruvector/core'
+
+declare module '@ruvector/core' {
+  interface VectorEntry {
+    metadata?: Record<string, unknown>
+  }
+
+  interface SearchQuery {
+    filter?: unknown
+  }
+
+  interface SearchResult {
+    metadata?: Record<string, unknown>
+  }
+
+  // `VectorDb.withDimensions(n)` is present at runtime but deliberately not
+  // augmented here — the documented constructor `new VectorDb({ dimensions,
+  // storagePath, distanceMetric })` is the path Step 2 uses. Adding a static
+  // method to an already-exported class across module boundaries requires
+  // brittle namespace-merging syntax we don't need for correctness.
+
+  class CollectionManager {
+    constructor(options: { storagePath: string })
+    createCollection(name: string, options: { dimensions: number }): Promise<unknown>
+    getCollection(name: string): Promise<unknown>
+    listCollections(): Promise<string[]>
+  }
+}

--- a/packages/doc-retrieval-mcp/src/ruvector-types.ts
+++ b/packages/doc-retrieval-mcp/src/ruvector-types.ts
@@ -25,16 +25,10 @@ declare module '@ruvector/core' {
     metadata?: Record<string, unknown>
   }
 
-  // `VectorDb.withDimensions(n)` is present at runtime but deliberately not
-  // augmented here — the documented constructor `new VectorDb({ dimensions,
-  // storagePath, distanceMetric })` is the path Step 2 uses. Adding a static
-  // method to an already-exported class across module boundaries requires
-  // brittle namespace-merging syntax we don't need for correctness.
-
-  class CollectionManager {
-    constructor(options: { storagePath: string })
-    createCollection(name: string, options: { dimensions: number }): Promise<unknown>
-    getCollection(name: string): Promise<unknown>
-    listCollections(): Promise<string[]>
-  }
+  // `VectorDb.withDimensions(n)` and `CollectionManager` are present at
+  // runtime in @ruvector/core@0.1.30 but deliberately not augmented here —
+  // the documented constructor `new VectorDb({ dimensions, storagePath,
+  // distanceMetric })` is the path Steps 2-3 use, and no current caller
+  // needs `CollectionManager`. YAGNI per CLAUDE.md; add these back if/when
+  // a caller actually needs them.
 }

--- a/packages/doc-retrieval-mcp/src/search.ts
+++ b/packages/doc-retrieval-mcp/src/search.ts
@@ -1,9 +1,10 @@
-// SMI-4426 Wave 2 Step 1: distanceToSimilarity helper landed alongside the
-// remaining throw-stub. Pure utility, no egress surface — parallel-safe with
-// the SMI-4427 Ruflo per-tool denial gate. The search() function stays
-// blocked until Wave 2 Step 3 wires the real query path (gated on SMI-4427
-// merge per the Specification).
-
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { minimatch } from 'minimatch'
+import { VectorDb } from '@ruvector/core'
+import './ruvector-types.js'
+import { loadConfig, resolveRepoPath, DEFAULT_MIN_SIMILARITY } from './config.js'
+import { embedBatch } from './embedding.js'
 import type { SearchHit } from './types.js'
 
 export interface SearchOpts {
@@ -32,11 +33,66 @@ export function distanceToSimilarity(distance: number): number {
   return Math.max(0, Math.min(1, 1 - distance / 2))
 }
 
-const RUVECTOR_BLOCKED =
-  'doc-retrieval: search() is gated on SMI-4427 (Ruflo per-tool denial). ' +
-  'See docs/internal/implementation/smi-4426-ruvector-runtime-fix.md Wave 2 ' +
-  'Step 3. Steps 1-2 land parallel-safely; Step 3+ egress work follows the gate.'
+interface StoredMetadata {
+  file_path: string
+  line_start: number
+  line_end: number
+  heading_chain: string[]
+  text: string
+}
 
-export async function search(_opts: SearchOpts): Promise<SearchHit[]> {
-  throw new Error(RUVECTOR_BLOCKED)
+export async function search(opts: SearchOpts): Promise<SearchHit[]> {
+  const cfg = await loadConfig(opts.configPath)
+  const storageAbs = resolveRepoPath(cfg.storagePath)
+  const vectorsFile = join(storageAbs, 'vectors')
+
+  if (!existsSync(vectorsFile)) return []
+
+  const db = new VectorDb({
+    dimensions: cfg.embeddingDim,
+    storagePath: vectorsFile,
+    distanceMetric: 'Cosine',
+  })
+
+  const queryVecs = await embedBatch([opts.query])
+  const queryVec = new Float32Array(queryVecs[0])
+
+  const k = opts.k ?? 5
+  const minScore = opts.minScore ?? DEFAULT_MIN_SIMILARITY
+
+  const raw = await db.search({ vector: queryVec, k })
+
+  const hits: SearchHit[] = []
+  for (const result of raw) {
+    const similarity = distanceToSimilarity(result.score)
+    if (similarity < minScore) continue
+
+    let meta: StoredMetadata
+    try {
+      meta = JSON.parse(result.metadata ?? '{}') as StoredMetadata
+    } catch {
+      continue
+    }
+
+    if (!meta.file_path) continue
+
+    if (opts.scopeGlobs && opts.scopeGlobs.length > 0) {
+      const matches = opts.scopeGlobs.some((g) => minimatch(meta.file_path, g, { dot: true }))
+      if (!matches) continue
+    }
+
+    const id = String(result.id)
+    hits.push({
+      id,
+      filePath: meta.file_path,
+      lineStart: meta.line_start,
+      lineEnd: meta.line_end,
+      headingChain: meta.heading_chain ?? [],
+      text: meta.text,
+      similarity,
+      score: similarity,
+    })
+  }
+
+  return hits
 }

--- a/packages/doc-retrieval-mcp/src/search.ts
+++ b/packages/doc-retrieval-mcp/src/search.ts
@@ -1,4 +1,9 @@
-// SMI-4426: scaffold — see indexer.ts header comment.
+// SMI-4426 Wave 2 Step 1: distanceToSimilarity helper landed alongside the
+// remaining throw-stub. Pure utility, no egress surface — parallel-safe with
+// the SMI-4427 Ruflo per-tool denial gate. The search() function stays
+// blocked until Wave 2 Step 3 wires the real query path (gated on SMI-4427
+// merge per the Specification).
+
 import type { SearchHit } from './types.js'
 
 export interface SearchOpts {
@@ -9,11 +14,28 @@ export interface SearchOpts {
   configPath?: string
 }
 
+/**
+ * Map an @ruvector/core SearchResult.score value (cosine DISTANCE in [0, 2],
+ * lower is better — the backing crate is `anndists::DistCosine`) to a
+ * similarity in [0, 1] where 1 = best match.
+ *
+ * Slightly-negative inputs (float32 precision artifacts from the native
+ * binding) clamp to 1.0 — the best-match end — NOT 0.0. Distances > 2 clamp
+ * to 0.0 (orthogonal / opposite).
+ *
+ * See docs/internal/implementation/smi-4426-ruvector-runtime-fix.md §What
+ * Changes §1 for the semantic-inversion rationale. PR #722's `SearchHit.score`
+ * held raw distance mislabeled as similarity; this helper restores correctness
+ * at the API boundary.
+ */
+export function distanceToSimilarity(distance: number): number {
+  return Math.max(0, Math.min(1, 1 - distance / 2))
+}
+
 const RUVECTOR_BLOCKED =
-  'doc-retrieval: RuVector integration is blocked on SMI-4426 ' +
-  '(https://linear.app/smith-horn-group/issue/SMI-4426). ' +
-  'The scaffold in PR #722 (SMI-4417) has not been runtime-validated against ' +
-  '@ruvector/core. See .claude/development/ruvector-dev-tooling.md.'
+  'doc-retrieval: search() is gated on SMI-4427 (Ruflo per-tool denial). ' +
+  'See docs/internal/implementation/smi-4426-ruvector-runtime-fix.md Wave 2 ' +
+  'Step 3. Steps 1-2 land parallel-safely; Step 3+ egress work follows the gate.'
 
 export async function search(_opts: SearchOpts): Promise<SearchHit[]> {
   throw new Error(RUVECTOR_BLOCKED)

--- a/packages/doc-retrieval-mcp/src/server.ts
+++ b/packages/doc-retrieval-mcp/src/server.ts
@@ -16,7 +16,7 @@ const SearchArgs = z.object({
     .max(1)
     .optional()
     .describe(
-      'Minimum cosine similarity. Default 0.30. <0.25=noise, 0.25-0.40=weak, 0.40-0.60=loose, 0.60-0.80=strong, >0.80=near-duplicate'
+      'Minimum cosine similarity (post distance→similarity transform). Default 0.35. <0.20=noise, 0.20-0.35=weak, 0.35-0.55=loose, 0.55-0.75=strong, >0.75=near-duplicate'
     ),
   scope_globs: z
     .array(z.string())

--- a/packages/doc-retrieval-mcp/src/status.ts
+++ b/packages/doc-retrieval-mcp/src/status.ts
@@ -8,7 +8,7 @@ export async function getStatus(configPath?: string): Promise<StatusInfo> {
   const cfg = await loadConfig(configPath)
   const metaAbs = resolveRepoPath(cfg.metadataPath)
   const stateAbs = resolveRepoPath(cfg.stateFile)
-  const rvfAbs = resolveRepoPath(cfg.rvfPath)
+  const storagePathAbs = resolveRepoPath(cfg.storagePath)
 
   const store = existsSync(metaAbs) ? await MetadataStore.load(metaAbs) : null
   const state: IndexState | null = existsSync(stateAbs)
@@ -20,7 +20,7 @@ export async function getStatus(configPath?: string): Promise<StatusInfo> {
     fileCount: store?.fileCount() ?? 0,
     lastIndexedSha: state?.lastIndexedSha ?? null,
     lastRunAt: state?.lastRunAt ?? null,
-    rvfPath: rvfAbs,
+    storagePath: storagePathAbs,
     corpusVersion: state?.corpusVersion ?? 0,
   }
 }

--- a/packages/doc-retrieval-mcp/src/types.ts
+++ b/packages/doc-retrieval-mcp/src/types.ts
@@ -26,6 +26,17 @@ export interface SearchHit {
   lineEnd: number
   headingChain: string[]
   text: string
+  /**
+   * Cosine similarity in [0, 1], 1 = best match. Computed from the native
+   * binding's raw distance via `distanceToSimilarity` (SMI-4426).
+   */
+  similarity: number
+  /**
+   * @deprecated Alias for `similarity`. Removal tracked in the follow-up SMI
+   * filed under SMI-4426 Wave 1 Step 3 (plan-review amendment E). Equals
+   * `similarity` by construction — PR #722 emitted raw distance here and the
+   * alias corrects it rather than preserving the mistake.
+   */
   score: number
 }
 
@@ -34,6 +45,7 @@ export interface StatusInfo {
   fileCount: number
   lastIndexedSha: string | null
   lastRunAt: string | null
-  rvfPath: string
+  /** Absolute path to the RuVector storage directory (SMI-4426 rename from `rvfPath`). */
+  storagePath: string
   corpusVersion: number
 }

--- a/packages/doc-retrieval-mcp/tests/chunker.test.ts
+++ b/packages/doc-retrieval-mcp/tests/chunker.test.ts
@@ -8,7 +8,7 @@ import {
 import type { CorpusConfig } from '../src/config.js'
 
 const cfg: CorpusConfig = {
-  rvfPath: '.ruvector/x.rvf',
+  storagePath: '.ruvector/skillsmith-docs',
   metadataPath: '.ruvector/m.json',
   stateFile: '.ruvector/s.json',
   embeddingDim: 384,

--- a/packages/doc-retrieval-mcp/tests/config.test.ts
+++ b/packages/doc-retrieval-mcp/tests/config.test.ts
@@ -68,7 +68,7 @@ describe('loadConfig', () => {
       await writeFile(
         good,
         JSON.stringify({
-          rvfPath: '.ruvector/x.rvf',
+          storagePath: '.ruvector/skillsmith-docs',
           metadataPath: '.ruvector/m.json',
           stateFile: '.ruvector/s.json',
           embeddingDim: 384,
@@ -78,13 +78,14 @@ describe('loadConfig', () => {
       )
       const cfg = await loadConfig(good)
       expect(cfg.embeddingDim).toBe(384)
+      expect(cfg.storagePath).toBe('.ruvector/skillsmith-docs')
 
       const bad = join(dir, 'bad.json')
       resetConfigCache()
       await writeFile(
         bad,
         JSON.stringify({
-          rvfPath: 'x',
+          storagePath: 'x',
           metadataPath: 'm',
           stateFile: 's',
           embeddingDim: 768,
@@ -96,5 +97,33 @@ describe('loadConfig', () => {
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
+  })
+
+  it('rejects missing storagePath explicitly', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'doc-retrieval-cfg-'))
+    try {
+      const bad = join(dir, 'missing-storage.json')
+      resetConfigCache()
+      await writeFile(
+        bad,
+        JSON.stringify({
+          metadataPath: 'm',
+          stateFile: 's',
+          embeddingDim: 384,
+          chunk: { targetTokens: 240, overlapTokens: 48, minTokens: 8 },
+          globs: ['**/*.md'],
+        })
+      )
+      await expect(loadConfig(bad)).rejects.toThrow(/storagePath.*required/)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('DEFAULT_MIN_SIMILARITY', () => {
+  it('exports 0.35 per ADR-117 band table', async () => {
+    const { DEFAULT_MIN_SIMILARITY } = await import('../src/config.js')
+    expect(DEFAULT_MIN_SIMILARITY).toBe(0.35)
   })
 })

--- a/packages/doc-retrieval-mcp/tests/indexer-lock.test.ts
+++ b/packages/doc-retrieval-mcp/tests/indexer-lock.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { acquireIndexerLock } from '../src/indexer-lock.js'
+
+let dir: string
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'doc-retrieval-lock-'))
+})
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('acquireIndexerLock', () => {
+  it('creates the lockfile on happy path and removes it on release', async () => {
+    const release = await acquireIndexerLock(dir, { registerHandlers: false })
+
+    const lockPath = join(dir, '.indexer.lock')
+    expect(existsSync(lockPath)).toBe(true)
+    const held = await readFile(lockPath, 'utf8')
+    expect(held.startsWith(`${process.pid}\n`)).toBe(true)
+
+    release()
+    expect(existsSync(lockPath)).toBe(false)
+  })
+
+  it('breaks a stale lock whose holder is dead (ESRCH)', async () => {
+    await writeFile(join(dir, '.indexer.lock'), `99999\n2020-01-01T00:00:00.000Z\n`)
+
+    const release = await acquireIndexerLock(dir, {
+      registerHandlers: false,
+      probeAlive: (pid) => pid !== 99999,
+    })
+
+    const held = await readFile(join(dir, '.indexer.lock'), 'utf8')
+    expect(held.startsWith(`${process.pid}\n`)).toBe(true)
+    release()
+  })
+
+  it('times out when an alive process holds the lock', async () => {
+    await writeFile(join(dir, '.indexer.lock'), `${process.pid}\n${new Date().toISOString()}\n`)
+
+    await expect(
+      acquireIndexerLock(dir, {
+        registerHandlers: false,
+        probeAlive: () => true,
+        timeoutMs: 200,
+        pollMs: 50,
+      })
+    ).rejects.toThrow(/indexer lock timeout/)
+  })
+
+  it('treats a garbled lock body as stale and reclaims it', async () => {
+    await writeFile(join(dir, '.indexer.lock'), 'not-a-pid\nbad\n')
+
+    const release = await acquireIndexerLock(dir, {
+      registerHandlers: false,
+      probeAlive: () => {
+        throw new Error('probeAlive should not be called for garbled lock')
+      },
+    })
+
+    expect(existsSync(join(dir, '.indexer.lock'))).toBe(true)
+    release()
+  })
+
+  it('release is idempotent', async () => {
+    const release = await acquireIndexerLock(dir, { registerHandlers: false })
+    release()
+    release()
+    expect(existsSync(join(dir, '.indexer.lock'))).toBe(false)
+  })
+
+  it('creates the storage directory if missing', async () => {
+    const nested = join(dir, 'does-not-exist-yet')
+    const release = await acquireIndexerLock(nested, { registerHandlers: false })
+    expect(existsSync(join(nested, '.indexer.lock'))).toBe(true)
+    release()
+  })
+})

--- a/packages/doc-retrieval-mcp/tests/integration/indexer.test.ts
+++ b/packages/doc-retrieval-mcp/tests/integration/indexer.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createRequire } from 'node:module'
+import { mkdtemp, writeFile, rm, mkdir, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { existsSync } from 'node:fs'
+
+// Skip when @ruvector/core native binding is absent (runs in Docker only).
+const _require = createRequire(import.meta.url)
+let nativeAvailable = false
+try {
+  _require('@ruvector/core')
+  nativeAvailable = true
+} catch {
+  nativeAvailable = false
+}
+
+import { runIndexer } from '../../src/indexer.js'
+import { resetConfigCache } from '../../src/config.js'
+import { resetEmbedderCache } from '../../src/embedding.js'
+
+const FIXTURES: Record<string, string> = {
+  'guide-a.md': [
+    '# Guide A',
+    '',
+    '## Section One',
+    '',
+    'This is the first section of Guide A. It covers important topics about the system.',
+    '',
+    '## Section Two',
+    '',
+    'Section two discusses more advanced material for Guide A in detail.',
+  ].join('\n'),
+  'guide-b.md': [
+    '# Guide B',
+    '',
+    '## Introduction',
+    '',
+    'Guide B is about a completely different subject matter entirely.',
+    '',
+    '## Details',
+    '',
+    'The details section of Guide B provides comprehensive coverage of the topic.',
+  ].join('\n'),
+  'guide-c.md': [
+    '# Guide C',
+    '',
+    '## Overview',
+    '',
+    'Guide C provides a high-level overview of the system architecture.',
+    'This file is shorter than the others to test varied chunk counts.',
+  ].join('\n'),
+}
+
+describe.skipIf(!nativeAvailable)('indexer integration (requires @ruvector/core native)', () => {
+  let tmpRoot: string
+  let configPath: string
+  let savedEnv: Record<string, string | undefined>
+
+  beforeEach(async () => {
+    savedEnv = {
+      CI: process.env.CI,
+      SKILLSMITH_CI: process.env.SKILLSMITH_CI,
+      SKILLSMITH_REPO_ROOT: process.env.SKILLSMITH_REPO_ROOT,
+      SKILLSMITH_USE_MOCK_EMBEDDINGS: process.env.SKILLSMITH_USE_MOCK_EMBEDDINGS,
+    }
+    // Disable CI guard and use fast mock embeddings for integration tests
+    delete process.env.CI
+    delete process.env.SKILLSMITH_CI
+    process.env.SKILLSMITH_USE_MOCK_EMBEDDINGS = 'true'
+
+    tmpRoot = await mkdtemp(join(tmpdir(), 'doc-retrieval-int-'))
+    process.env.SKILLSMITH_REPO_ROOT = tmpRoot
+
+    const fixturesDir = join(tmpRoot, 'fixtures')
+    await mkdir(fixturesDir, { recursive: true })
+    for (const [name, content] of Object.entries(FIXTURES)) {
+      await writeFile(join(fixturesDir, name), content, 'utf8')
+    }
+
+    const cfg = {
+      storagePath: '.ruvector/test-docs',
+      metadataPath: '.ruvector/metadata.json',
+      stateFile: '.ruvector/.index-state.json',
+      embeddingDim: 384,
+      chunk: { targetTokens: 240, overlapTokens: 48, minTokens: 8 },
+      globs: ['fixtures/**/*.md'],
+    }
+    configPath = join(tmpRoot, 'test.config.json')
+    await writeFile(configPath, JSON.stringify(cfg), 'utf8')
+  })
+
+  afterEach(async () => {
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key as keyof typeof process.env]
+      else process.env[key as keyof typeof process.env] = val
+    }
+    resetConfigCache()
+    resetEmbedderCache()
+    if (tmpRoot) await rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('full reindex indexes all 3 fixture files and produces chunks', async () => {
+    const result = await runIndexer('full', { configPath })
+
+    expect(result.mode).toBe('full')
+    expect(result.filesScanned).toBe(3)
+    expect(result.chunksUpserted).toBeGreaterThan(0)
+    expect(result.chunksDeleted).toBe(0)
+    expect(result.durationMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('second full reindex replaces all chunks (idempotent chunk count)', async () => {
+    const first = await runIndexer('full', { configPath })
+    resetConfigCache()
+    const second = await runIndexer('full', { configPath })
+
+    expect(second.filesScanned).toBe(first.filesScanned)
+    expect(second.chunksUpserted).toBe(first.chunksUpserted)
+  })
+
+  it('writes state file with lastRunAt and chunksUpserted recorded', async () => {
+    await runIndexer('full', { configPath })
+
+    const stateFile = join(tmpRoot, '.ruvector', '.index-state.json')
+    expect(existsSync(stateFile)).toBe(true)
+    const state = JSON.parse(await (await import('node:fs/promises')).readFile(stateFile, 'utf8'))
+    expect(state.lastRunAt).toBeTruthy()
+    expect(state.corpusVersion).toBe(1)
+    expect(Object.keys(state.chunkCountByFile).length).toBe(3)
+  })
+
+  it('incremental reindex with no prior state indexes all files', async () => {
+    const result = await runIndexer('incremental', { configPath })
+
+    expect(result.mode).toBe('incremental')
+    expect(result.filesScanned).toBe(3)
+    expect(result.chunksUpserted).toBeGreaterThan(0)
+  })
+
+  it('incremental after full only reindexes deleted file chunks', async () => {
+    await runIndexer('full', { configPath })
+    resetConfigCache()
+
+    // Delete one fixture file
+    const fixtureToDelete = join(tmpRoot, 'fixtures', 'guide-c.md')
+    await unlink(fixtureToDelete)
+
+    const result = await runIndexer('incremental', { configPath })
+    // guide-c.md was deleted: its chunks are removed, no new ones for it
+    expect(result.filesScanned).toBe(2) // guide-a and guide-b still present
+  })
+
+  it('refuses to run when CI=true', async () => {
+    process.env.CI = 'true'
+    await expect(runIndexer('full', { configPath })).rejects.toThrow(/refusing to run in CI/)
+  })
+})

--- a/packages/doc-retrieval-mcp/tests/integration/search.test.ts
+++ b/packages/doc-retrieval-mcp/tests/integration/search.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createRequire } from 'node:module'
+import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Skip when @ruvector/core native binding is absent (runs in Docker only).
+const _require = createRequire(import.meta.url)
+let nativeAvailable = false
+try {
+  _require('@ruvector/core')
+  nativeAvailable = true
+} catch {
+  nativeAvailable = false
+}
+
+import { runIndexer } from '../../src/indexer.js'
+import { search } from '../../src/search.js'
+import { resetConfigCache } from '../../src/config.js'
+import { resetEmbedderCache } from '../../src/embedding.js'
+
+const FIXTURES: Record<string, string> = {
+  'guide-a.md': [
+    '# Guide A',
+    '',
+    '## Section One',
+    '',
+    'This is the first section of Guide A. It covers important topics about the system.',
+    '',
+    '## Section Two',
+    '',
+    'Section two discusses more advanced material for Guide A in detail.',
+  ].join('\n'),
+  'guide-b.md': [
+    '# Guide B',
+    '',
+    '## Introduction',
+    '',
+    'Guide B is about a completely different subject matter entirely.',
+    '',
+    '## Details',
+    '',
+    'The details section of Guide B provides comprehensive coverage of the topic.',
+  ].join('\n'),
+}
+
+describe.skipIf(!nativeAvailable)('search integration (requires @ruvector/core native)', () => {
+  let tmpRoot: string
+  let configPath: string
+  let savedEnv: Record<string, string | undefined>
+
+  beforeEach(async () => {
+    savedEnv = {
+      CI: process.env.CI,
+      SKILLSMITH_CI: process.env.SKILLSMITH_CI,
+      SKILLSMITH_REPO_ROOT: process.env.SKILLSMITH_REPO_ROOT,
+      SKILLSMITH_USE_MOCK_EMBEDDINGS: process.env.SKILLSMITH_USE_MOCK_EMBEDDINGS,
+    }
+    delete process.env.CI
+    delete process.env.SKILLSMITH_CI
+    process.env.SKILLSMITH_USE_MOCK_EMBEDDINGS = 'true'
+
+    tmpRoot = await mkdtemp(join(tmpdir(), 'doc-retrieval-search-'))
+    process.env.SKILLSMITH_REPO_ROOT = tmpRoot
+
+    const fixturesDir = join(tmpRoot, 'fixtures')
+    await mkdir(fixturesDir, { recursive: true })
+    for (const [name, content] of Object.entries(FIXTURES)) {
+      await writeFile(join(fixturesDir, name), content, 'utf8')
+    }
+
+    const cfg = {
+      storagePath: '.ruvector/test-docs',
+      metadataPath: '.ruvector/metadata.json',
+      stateFile: '.ruvector/.index-state.json',
+      embeddingDim: 384,
+      chunk: { targetTokens: 240, overlapTokens: 48, minTokens: 8 },
+      globs: ['fixtures/**/*.md'],
+    }
+    configPath = join(tmpRoot, 'test.config.json')
+    await writeFile(configPath, JSON.stringify(cfg), 'utf8')
+
+    await runIndexer('full', { configPath })
+    resetConfigCache()
+  })
+
+  afterEach(async () => {
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key as keyof typeof process.env]
+      else process.env[key as keyof typeof process.env] = val
+    }
+    resetConfigCache()
+    resetEmbedderCache()
+    if (tmpRoot) await rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('returns empty array when vectors file does not exist', async () => {
+    const emptyCfg = {
+      storagePath: '.ruvector/nonexistent',
+      metadataPath: '.ruvector/metadata.json',
+      stateFile: '.ruvector/.index-state.json',
+      embeddingDim: 384,
+      chunk: { targetTokens: 240, overlapTokens: 48, minTokens: 8 },
+      globs: ['fixtures/**/*.md'],
+    }
+    const emptyCfgPath = join(tmpRoot, 'empty.config.json')
+    await writeFile(emptyCfgPath, JSON.stringify(emptyCfg), 'utf8')
+    resetConfigCache()
+
+    const hits = await search({ query: 'system topics', configPath: emptyCfgPath })
+    expect(hits).toEqual([])
+  })
+
+  it('returns hits with similarity in [0, 1] after full index', async () => {
+    const hits = await search({ query: 'system topics', k: 5, configPath })
+
+    expect(hits.length).toBeGreaterThan(0)
+    for (const hit of hits) {
+      expect(hit.similarity).toBeGreaterThanOrEqual(0)
+      expect(hit.similarity).toBeLessThanOrEqual(1)
+      expect(hit.score).toBe(hit.similarity)
+      expect(hit.filePath).toMatch(/^fixtures\//)
+      expect(hit.text).toBeTruthy()
+    }
+  })
+
+  it('respects k limit', async () => {
+    const hits = await search({ query: 'section details coverage', k: 2, configPath })
+    expect(hits.length).toBeLessThanOrEqual(2)
+  })
+
+  it('filters by scopeGlobs', async () => {
+    const all = await search({ query: 'guide section', k: 10, minScore: 0, configPath })
+    expect(all.length).toBeGreaterThan(0)
+
+    const filtered = await search({
+      query: 'guide section',
+      k: 10,
+      minScore: 0,
+      scopeGlobs: ['fixtures/guide-a.md'],
+      configPath,
+    })
+
+    for (const hit of filtered) {
+      expect(hit.filePath).toBe('fixtures/guide-a.md')
+    }
+  })
+
+  it('respects minScore threshold', async () => {
+    const hits = await search({ query: 'section topics', k: 10, minScore: 0.99, configPath })
+    for (const hit of hits) {
+      expect(hit.similarity).toBeGreaterThanOrEqual(0.99)
+    }
+  })
+})

--- a/packages/doc-retrieval-mcp/tests/search.test.ts
+++ b/packages/doc-retrieval-mcp/tests/search.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { distanceToSimilarity } from '../src/search.js'
+
+describe('distanceToSimilarity', () => {
+  it.each([
+    { distance: 0, expected: 1.0 },
+    { distance: 0.5, expected: 0.75 },
+    { distance: 1, expected: 0.5 },
+    { distance: 1.5, expected: 0.25 },
+    { distance: 2, expected: 0.0 },
+  ])('distance=$distance → similarity=$expected', ({ distance, expected }) => {
+    expect(distanceToSimilarity(distance)).toBeCloseTo(expected, 6)
+  })
+
+  it('clamps slight float-32 negatives to 1.0 (best-match end, per plan-review amendment G)', () => {
+    expect(distanceToSimilarity(-1e-7)).toBe(1.0)
+  })
+
+  it('clamps large negatives to 1.0 regardless of magnitude', () => {
+    expect(distanceToSimilarity(-2)).toBe(1.0)
+  })
+
+  it('clamps distance>2 to 0.0 (worst-match end)', () => {
+    expect(distanceToSimilarity(2.5)).toBe(0.0)
+  })
+})


### PR DESCRIPTION
## Summary

Completes SMI-4426 Wave 2: fixes the `@ruvector/core@0.1.30` API mismatch findings from the Wave 1 scaffold and wires real indexer + search paths.

**Step 1** (types, lock, score transform, storagePath rename):
- `ruvector-types.ts` — module augmentation for `VectorEntry.metadata: string` (binding throws if passed an object), `SearchResult.metadata: string`, `SearchQuery.filter`
- `indexer-lock.ts` — PID-based exclusive lockfile at `$storageAbs/.indexer.lock` (single-writer discipline)
- `distanceToSimilarity()` — `Math.max(0, Math.min(1, 1 - distance/2))` (binding returns cosine distance, not similarity)
- `config.ts` — `rvfPath` → `storagePath`, `DEFAULT_MIN_SIMILARITY = 0.35`

**Step 2** (real `runIndexer()`):
- Replaces throw-stub with full indexer: `readdir + minimatch` glob expansion (fixes TS2305 — `node:fs/promises.glob` absent from @types/node@20), `VectorDb({ dimensions, storagePath: vectorsFile, distanceMetric: 'Cosine' })`, `insertBatch` with `JSON.stringify` metadata, incremental diff via `git diff --name-only <sha>..HEAD` with 40-char hex guard
- VectorDb creates a **single file** at `storagePath` — indexer creates `storageAbs/` as a directory and passes `join(storageAbs, 'vectors')` so the lockfile and DB file coexist
- 6 integration tests (`skipIf(!nativeAvailable)` guard for Docker-only native binding)

**Step 3** (real `search()` + docs unblock):
- Opens VectorDb fresh per call (avoids stale state after reindex), embeds query, `db.search()`, parses JSON metadata, applies `distanceToSimilarity`, filters by `minScore` + `scopeGlobs`
- 5 integration tests covering empty index, score range `[0,1]`, k limit, `scopeGlobs` filter, `minScore` threshold
- `ruvector-dev-tooling.md`: BLOCKED banner removed; privacy boundary updated (`disabledTools` → `permissions.deny` per SMI-4427 / PR #732); sentinel path corrected (`.rvf` → `/vectors`); Docker requirement noted in post-commit docs
- `.husky/post-commit`: Docker-exec guard + correct `vectors` sentinel

All 46 tests pass in Docker (46/46). Typecheck and lint clean.

## Test plan

- [ ] `docker exec skillsmith-dev-1 sh -c "cd /app/.worktrees/smi-4426 && npx vitest run packages/doc-retrieval-mcp/tests/"` — all 46 green
- [ ] `docker exec skillsmith-dev-1 sh -c "cd /app/.worktrees/smi-4426 && npx tsc -p packages/doc-retrieval-mcp/tsconfig.json --noEmit"` — no output
- [ ] CI passes (code PR — full ~11 min run)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)