### PR TITLE
fix(doc-retrieval-mcp): SMI-4433 use createRequire for @ruvector/core CJS interop

### DIFF
--- a/.security-scan-ignore
+++ b/.security-scan-ignore
@@ -16,3 +16,7 @@ scripts/utils/path-validation.ts
 packages/web/**
 src/**
 docs/site/**
+
+# Local vector index (gitignored; metadata.json contains indexed doc text
+# that discusses secret patterns — not actual secrets)
+.ruvector/**

--- a/packages/doc-retrieval-mcp/src/indexer.ts
+++ b/packages/doc-retrieval-mcp/src/indexer.ts
@@ -3,9 +3,14 @@ import type { Dirent } from 'node:fs'
 import { existsSync } from 'node:fs'
 import { join, relative } from 'node:path'
 import { execSync } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { minimatch } from 'minimatch'
-import { VectorDb } from '@ruvector/core'
 import './ruvector-types.js'
+// @ruvector/core is CJS; ESM named imports fail at runtime in Node.js v22.
+// Use createRequire so the module.exports object is accessible as-is.
+const { VectorDb } = createRequire(import.meta.url)(
+  '@ruvector/core'
+) as typeof import('@ruvector/core')
 import {
   loadConfig,
   resolveRepoPath,

--- a/packages/doc-retrieval-mcp/src/search.ts
+++ b/packages/doc-retrieval-mcp/src/search.ts
@@ -1,8 +1,12 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
+import { createRequire } from 'node:module'
 import { minimatch } from 'minimatch'
-import { VectorDb } from '@ruvector/core'
 import './ruvector-types.js'
+// @ruvector/core is CJS; ESM named imports fail at runtime in Node.js v22.
+const { VectorDb } = createRequire(import.meta.url)(
+  '@ruvector/core'
+) as typeof import('@ruvector/core')
 import { loadConfig, resolveRepoPath, DEFAULT_MIN_SIMILARITY } from './config.js'
 import { embedBatch } from './embedding.js'
 import type { SearchHit } from './types.js'


### PR DESCRIPTION
## Summary

- Replaces `import { VectorDb } from '@ruvector/core'` with `createRequire(import.meta.url)('@ruvector/core')` in `indexer.ts` and `search.ts`
- Adds `.ruvector/**` to `.security-scan-ignore` (gitignored index files triggered false-positive secret scanner)

**Root cause:** `@ruvector/core@0.1.30` is a CJS module with no `exports` field. Node.js v22's ESM loader cannot statically resolve named exports from native CJS modules that assign exports dynamically from a native binding — it throws `SyntaxError: Named export 'VectorDb' not found` at module load time. This silently broke both the CLI (`reindex`) and the MCP server after PR #735 was merged.

**Why CI missed it:** Vitest transforms `.ts` source directly via its own pipeline, bypassing the compiled `.js` files and using a more permissive CJS/ESM interop. So 46/46 tests passed in CI while the actual binary was broken.

**Fix:** Use `createRequire` — same pattern already used in the integration test guard (`nativeAvailable` check). Verified: `cli.js reindex --full` now completes (24,060 chunks); all 46 tests still pass.

## Test plan

- [x] `docker exec skillsmith-dev-1 npm test -w packages/doc-retrieval-mcp` — 46/46 green
- [x] `docker exec skillsmith-dev-1 node .worktrees/smi-4368-wave4b/packages/doc-retrieval-mcp/dist/src/cli.js reindex --full` — completes with 24,060 chunks
- [x] Typecheck clean, lint clean, format clean

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)