### PR TITLE
fix(website): SMI-4438 cli-token modal CSS scoping + revoke field name mismatch

### DIFF
--- a/packages/website/src/pages/account/cli-token.astro
+++ b/packages/website/src/pages/account/cli-token.astro
@@ -524,15 +524,17 @@ const supabaseConfig = getSupabaseConfig()
               }
 
               try {
+                // TODO(SMI-4439): regenerate-license returns { key, prefix } while
+                // generate-license returns { key_prefix }. Unify response shapes.
                 const body = (await response.json()) as {
-                  api_key?: string
-                  key_prefix?: string
+                  key?: string
+                  prefix?: string
                 }
-                if (!body.api_key || !body.key_prefix) {
+                if (!body.key || !body.prefix) {
                   showRegenError('Unexpected response from server. Please reload the page.')
                   return
                 }
-                showFreshKey(body.api_key, body.key_prefix)
+                showFreshKey(body.key, body.prefix)
               } catch {
                 showRegenError('Could not parse server response. Please reload the page.')
               }
@@ -1051,12 +1053,14 @@ const supabaseConfig = getSupabaseConfig()
         display: none;
       }
 
-      /* SMI-4401 Wave 2: focus-trapped revoke confirmation modal. */
-      .revoke-modal-backdrop[hidden] {
+      /* SMI-4401 Wave 2: focus-trapped revoke confirmation modal.
+         :global() required — modal is created via document.createElement() and
+         appended to body, so Astro's data-astro-cid scoping never applies. */
+      :global(.revoke-modal-backdrop[hidden]) {
         display: none;
       }
 
-      .revoke-modal-backdrop {
+      :global(.revoke-modal-backdrop) {
         position: fixed;
         inset: 0;
         background: rgba(0, 0, 0, 0.65);
@@ -1067,7 +1071,7 @@ const supabaseConfig = getSupabaseConfig()
         z-index: 9999;
       }
 
-      .revoke-modal {
+      :global(.revoke-modal) {
         background: #121214;
         border: 1px solid #2a2a2f;
         border-radius: 12px;
@@ -1077,20 +1081,20 @@ const supabaseConfig = getSupabaseConfig()
         box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
       }
 
-      .revoke-modal h2 {
+      :global(.revoke-modal h2) {
         font-size: 1.125rem;
         font-weight: 600;
         margin: 0 0 0.75rem;
       }
 
-      .revoke-modal p {
+      :global(.revoke-modal p) {
         color: #a1a1aa;
         font-size: 0.9375rem;
         line-height: 1.5;
         margin: 0 0 1.25rem;
       }
 
-      .revoke-modal-actions {
+      :global(.revoke-modal-actions) {
         display: flex;
         justify-content: flex-end;
         gap: 0.5rem;

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -1542,7 +1542,7 @@ console.log(`\n${BOLD}23. Implementation Completeness Spot Check (SMI-3543)${RES
     /\bresolv(e|es|ed)\b/i,
   ]
   const SRC_PATTERNS = [
-    /^packages\/.*\.(ts|tsx|js|jsx)$/,
+    /^packages\/.*\.(ts|tsx|js|jsx|astro)$/,
     /^supabase\/functions\/.*\.(ts|js)$/,
     /^scripts\/.*\.(ts|js|mjs)$/,
   ]


### PR DESCRIPTION
## Summary

- **Bug 1:** The "Revoke this key?" confirmation dialog on `/account/cli-token` rendered as unstyled DOM nodes at the bottom of the page. `ensureConfirmModal()` creates the element via `document.createElement()` — dynamically created elements never receive Astro's `data-astro-cid-*` scoping attribute, so the modal CSS selectors never matched. Fix: wrap 6 CSS rules with `:global()`.
- **Bug 2:** "Unexpected response from server" on every Revoke & regenerate click. Client read `body.api_key` / `body.key_prefix` but `regenerate-license` returns `{ key, prefix }`. Fix: update destructuring to match the actual response shape. `TODO(SMI-4439)` tracks field-name unification with `generate-license`.
- **Bonus fix:** `audit-standards.mjs` Check 23 now includes `.astro` in `SRC_PATTERNS` so website page commits no longer trigger false "done without source changes" warnings.

## Test plan

- [ ] Navigate to `/account/cli-token` with an existing key
- [ ] Click "Revoke & regenerate" → modal appears centered with dark overlay (not at bottom of page)
- [ ] Click Cancel → modal closes, no action taken
- [ ] Click Confirm → new `sk_live_...` key displayed; no "Unexpected response" error
- [ ] Keyboard: Tab to button → Enter → Tab traps between Cancel/Confirm → Escape closes and restores focus
- [ ] `npm run preflight` passes

Linear: SMI-4438 · follow-up: SMI-4439

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)