### PR TITLE
SMI-4437 + SMI-4440: Phase 2 abandoned, harness gate assertion

### DIFF
--- a/packages/doc-retrieval-mcp/src/server.ts
+++ b/packages/doc-retrieval-mcp/src/server.ts
@@ -41,7 +41,12 @@ async function handleListTools(): Promise<{ tools: unknown[] }> {
       {
         name: 'skill_docs_search',
         description:
-          'Semantic search over the Skillsmith doc corpus (CLAUDE.md, .claude/development, .claude/skills, docs/internal). Returns top-k chunks with file:line citations. Use this INSTEAD of Read-ing whole docs to answer narrow questions.',
+          "PREFERRED first step for any question about the Skillsmith repo's internal docs " +
+          '(CLAUDE.md, .claude/development, .claude/skills, docs/internal — ADRs, retros, plans, ' +
+          'standards, implementation guides). Returns cited chunks with file:line — much cheaper ' +
+          'than Read+Grep over the same corpus. Examples: "git-crypt worktree workflow", ' +
+          '"file-length limits", "plan-review anti-patterns", "SMI-4434 decisions". ' +
+          'Use Read/Grep/Glob ONLY when you need actual source code or non-indexed files.',
         inputSchema: jsonSchemaOf(SearchArgs),
       },
       {

--- a/scripts/ruvector-baseline.json
+++ b/scripts/ruvector-baseline.json
@@ -1,0 +1,101 @@
+{
+  "version": 2,
+  "runs": {
+    "git-crypt-worktree-interaction": {
+      "baseline": {
+        "totalInputAll": 162594,
+        "inputTokens": 5,
+        "cacheCreationInputTokens": 46186,
+        "cacheReadInputTokens": 116403,
+        "outputTokens": 2450,
+        "costWeightedInput": 69378,
+        "totalCostUsd": 0.2453654,
+        "turns": 7,
+        "toolCalls": {
+          "Read": 3
+        },
+        "capturedAt": "2026-04-24T02:56:18.422Z"
+      },
+      "measured": {
+        "totalInputAll": 107346,
+        "inputTokens": 4,
+        "cacheCreationInputTokens": 46947,
+        "cacheReadInputTokens": 60395,
+        "outputTokens": 2697,
+        "costWeightedInput": 64727,
+        "totalCostUsd": 0.23511875,
+        "turns": 7,
+        "toolCalls": {
+          "Read": 4
+        },
+        "capturedAt": "2026-04-24T03:00:25.952Z"
+      }
+    },
+    "file-length-enforcement": {
+      "baseline": {
+        "totalInputAll": 226284,
+        "inputTokens": 7,
+        "cacheCreationInputTokens": 30534,
+        "cacheReadInputTokens": 195743,
+        "outputTokens": 1018,
+        "costWeightedInput": 57749,
+        "totalCostUsd": 0.1889744,
+        "turns": 10,
+        "toolCalls": {
+          "Glob": 3,
+          "Read": 2,
+          "Grep": 1
+        },
+        "capturedAt": "2026-04-24T02:56:52.555Z"
+      },
+      "measured": {
+        "totalInputAll": 225382,
+        "inputTokens": 7,
+        "cacheCreationInputTokens": 30273,
+        "cacheReadInputTokens": 195102,
+        "outputTokens": 1147,
+        "costWeightedInput": 57358,
+        "totalCostUsd": 0.18974834999999998,
+        "turns": 10,
+        "toolCalls": {
+          "Glob": 3,
+          "Read": 2,
+          "Grep": 1
+        },
+        "capturedAt": "2026-04-24T03:01:05.086Z"
+      }
+    },
+    "plan-review-anti-patterns": {
+      "baseline": {
+        "totalInputAll": 364726,
+        "inputTokens": 2762,
+        "cacheCreationInputTokens": 49500,
+        "cacheReadInputTokens": 312464,
+        "outputTokens": 3597,
+        "costWeightedInput": 95883,
+        "totalCostUsd": 0.34205719999999995,
+        "turns": 18,
+        "toolCalls": {
+          "Read": 12,
+          "Glob": 2
+        },
+        "capturedAt": "2026-04-24T02:59:13.241Z"
+      },
+      "measured": {
+        "totalInputAll": 290040,
+        "inputTokens": 1302,
+        "cacheCreationInputTokens": 59751,
+        "cacheReadInputTokens": 228987,
+        "outputTokens": 3871,
+        "costWeightedInput": 98889,
+        "totalCostUsd": 0.35518035,
+        "turns": 17,
+        "toolCalls": {
+          "Glob": 4,
+          "Read": 5
+        },
+        "capturedAt": "2026-04-24T03:03:07.887Z"
+      }
+    }
+  }
+}

--- a/scripts/tests/token-delta-harness.test.ts
+++ b/scripts/tests/token-delta-harness.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for the pure gate-verdict logic in scripts/token-delta-harness.mjs.
+ *
+ * Covers SMI-4440 additions:
+ *   - gateVerdict: 'PASS' when median reduction >= 40% and MCP tool invoked
+ *   - gateVerdict: 'FAIL' when median reduction < 40%
+ *   - gateVerdict: 'FAIL' when no measured data (m === null / undefined)
+ *   - gateVerdict: 'FAIL_TOOL_NOT_INVOKED' when measured ran but mcpSearchCalls == 0
+ *   - Median calculation: odd and even task counts
+ *   - toolNotInvokedTasks accumulates correctly
+ */
+import { describe, it, expect } from 'vitest'
+
+const { computeGateVerdict } = (await import('../token-delta-harness.mjs')) as {
+  computeGateVerdict: (
+    runs: Record<
+      string,
+      {
+        baseline?: { totalInputAll?: number; totalCostUsd?: number; turns?: number }
+        measured?: {
+          totalInputAll?: number
+          totalCostUsd?: number
+          turns?: number
+          toolCalls?: Record<string, number>
+        }
+      }
+    >
+  ) => {
+    rows: object[]
+    medianReductionPct: number | null
+    gate: string
+    gateVerdict: 'PASS' | 'FAIL' | 'FAIL_TOOL_NOT_INVOKED'
+    toolInvocationFailure: boolean
+    toolNotInvokedTasks: string[]
+  }
+}
+
+const MCP_TOOL = 'mcp__skillsmith-doc-retrieval__skill_docs_search'
+
+function makeRun(
+  baselineTotal: number,
+  measuredTotal: number,
+  mcpCalls: number
+): {
+  baseline: { totalInputAll: number }
+  measured: { totalInputAll: number; toolCalls: Record<string, number> }
+} {
+  return {
+    baseline: { totalInputAll: baselineTotal },
+    measured: { totalInputAll: measuredTotal, toolCalls: { [MCP_TOOL]: mcpCalls } },
+  }
+}
+
+describe('computeGateVerdict', () => {
+  describe('PASS', () => {
+    it('returns PASS when median >= 40% and MCP tool was invoked', () => {
+      const runs = {
+        taskA: makeRun(100_000, 50_000, 3), // 50% reduction
+        taskB: makeRun(200_000, 100_000, 2), // 50% reduction
+        taskC: makeRun(150_000, 75_000, 1), // 50% reduction
+      }
+      const result = computeGateVerdict(runs)
+      expect(result.gateVerdict).toBe('PASS')
+      expect(result.medianReductionPct).toBe(50)
+      expect(result.toolInvocationFailure).toBe(false)
+      expect(result.toolNotInvokedTasks).toEqual([])
+    })
+
+    it('returns PASS at exactly 40% median reduction', () => {
+      const runs = { taskA: makeRun(100_000, 60_000, 1) } // 40% reduction
+      const result = computeGateVerdict(runs)
+      expect(result.gateVerdict).toBe('PASS')
+      expect(result.medianReductionPct).toBe(40)
+    })
+  })
+
+  describe('FAIL', () => {
+    it('returns FAIL when median reduction < 40%', () => {
+      const runs = { taskA: makeRun(100_000, 80_000, 2) } // 20% reduction
+      const result = computeGateVerdict(runs)
+      expect(result.gateVerdict).toBe('FAIL')
+      expect(result.medianReductionPct).toBeCloseTo(20, 5)
+      expect(result.toolInvocationFailure).toBe(false)
+    })
+
+    it('returns FAIL (not FAIL_TOOL_NOT_INVOKED) when measured data is missing', () => {
+      // m === undefined means the measured run never happened
+      const runs = {
+        taskA: { baseline: { totalInputAll: 100_000 }, measured: undefined },
+      }
+      const result = computeGateVerdict(runs)
+      expect(result.gateVerdict).toBe('FAIL')
+      expect(result.medianReductionPct).toBeNull()
+      expect(result.toolInvocationFailure).toBe(false)
+      expect(result.toolNotInvokedTasks).toEqual([])
+    })
+
+    it('returns FAIL with null median when runs is empty', () => {
+      const result = computeGateVerdict({})
+      expect(result.gateVerdict).toBe('FAIL')
+      expect(result.medianReductionPct).toBeNull()
+    })
+
+    it('returns FAIL when baseline is 0 (division guard)', () => {
+      const runs = { taskA: makeRun(0, 50_000, 1) }
+      const result = computeGateVerdict(runs)
+      expect(result.gateVerdict).toBe('FAIL')
+      expect(result.medianReductionPct).toBeNull()
+    })
+  })
+
+  describe('FAIL_TOOL_NOT_INVOKED', () => {
+    it('returns FAIL_TOOL_NOT_INVOKED when measured ran but MCP tool call count is 0', () => {
+      const runs = { taskA: makeRun(100_000, 50_000, 0) } // tool not used
+      const result = computeGateVerdict(runs)
+      expect(result.gateVerdict).toBe('FAIL_TOOL_NOT_INVOKED')
+      expect(result.toolInvocationFailure).toBe(true)
+      expect(result.toolNotInvokedTasks).toEqual(['taskA'])
+    })
+
+    it('accumulates all tasks where MCP tool was not invoked', () => {
+      const runs = {
+        taskA: makeRun(100_000, 50_000, 0),
+        taskB: makeRun(200_000, 100_000, 2), // invoked — should not appear
+        taskC: makeRun(150_000, 90_000, 0),
+      }
+      const result = computeGateVerdict(runs)
+      expect(result.gateVerdict).toBe('FAIL_TOOL_NOT_INVOKED')
+      expect(result.toolNotInvokedTasks).toContain('taskA')
+      expect(result.toolNotInvokedTasks).toContain('taskC')
+      expect(result.toolNotInvokedTasks).not.toContain('taskB')
+    })
+
+    it('takes priority over median check even when median would pass', () => {
+      // 50% reduction but tool not invoked — verdict must be FAIL_TOOL_NOT_INVOKED
+      const runs = { taskA: makeRun(100_000, 50_000, 0) }
+      const result = computeGateVerdict(runs)
+      expect(result.gateVerdict).toBe('FAIL_TOOL_NOT_INVOKED')
+    })
+  })
+
+  describe('median computation', () => {
+    it('uses middle value for odd-count task sets', () => {
+      // Reductions: 10%, 30%, 50% → sorted → median = 30%
+      const runs = {
+        taskA: makeRun(100_000, 90_000, 1), // 10%
+        taskB: makeRun(100_000, 50_000, 1), // 50%
+        taskC: makeRun(100_000, 70_000, 1), // 30%
+      }
+      const result = computeGateVerdict(runs)
+      expect(result.medianReductionPct).toBeCloseTo(30, 5)
+      expect(result.gateVerdict).toBe('FAIL') // 30% < 40%
+    })
+
+    it('averages two middle values for even-count task sets', () => {
+      // Reductions: 20%, 40% → median = 30%
+      const runs = {
+        taskA: makeRun(100_000, 80_000, 1), // 20%
+        taskB: makeRun(100_000, 60_000, 1), // 40%
+      }
+      const result = computeGateVerdict(runs)
+      expect(result.medianReductionPct).toBe(30)
+    })
+  })
+
+  describe('output shape', () => {
+    it('always includes gate field set to ">=40"', () => {
+      const result = computeGateVerdict({})
+      expect(result.gate).toBe('>=40')
+    })
+
+    it('includes deltaPct: null for incomplete rows', () => {
+      const runs = { taskA: { baseline: { totalInputAll: 100_000 } } }
+      const result = computeGateVerdict(runs)
+      const row = result.rows[0] as { deltaPct: null }
+      expect(row.deltaPct).toBeNull()
+    })
+  })
+})

--- a/scripts/token-delta-harness.mjs
+++ b/scripts/token-delta-harness.mjs
@@ -2,34 +2,43 @@
 /**
  * SMI-4417 Wave 2 Step 6 — Token-delta harness.
  *
- * Measures input-token consumption for representative agent tasks with the
- * skillsmith-doc-retrieval MCP server disabled (baseline) vs enabled
- * (measured). Produces a reproducible go/no-go artifact for the gate:
- * ≥40% median reduction across the 3 tasks = pass Phase 2.
+ * Measures total input-context consumption for representative agent tasks
+ * with the skillsmith-doc-retrieval MCP server disabled (baseline) vs
+ * enabled (measured). Produces a reproducible go/no-go artifact for the
+ * gate: >=40% median reduction across the 3 tasks = pass Phase 2.
  *
  * Usage:
  *   node scripts/token-delta-harness.mjs run --mode baseline
  *   node scripts/token-delta-harness.mjs run --mode measured
  *   node scripts/token-delta-harness.mjs compare
  *
- * Implementation:
- *   - Invokes `claude --print --output-format stream-json` per task.
- *   - Parses stream events, sums `usage.input_tokens` across assistant turns.
- *   - Writes results to scripts/ruvector-baseline.json (keyed by task + mode).
- *   - `compare` reads the JSON and emits the delta summary.
+ * Measurement (SMI-4437 fix):
+ *   Earlier revision summed only `usage.input_tokens` (uncached delta),
+ *   which under-counted when tool results flowed through prompt caching.
+ *   Now reads the terminal `result` event's cumulative usage totals and
+ *   reports the full input ingestion across all three buckets:
+ *     - input_tokens                (never-cached)
+ *     - cache_creation_input_tokens (written to cache)
+ *     - cache_read_input_tokens     (read from cache)
+ *   The gate compares `totalInputAll = sum of all three` — the true
+ *   workload the model had to ingest to produce the answer. Tool-use
+ *   events are also counted so we can verify the MCP search tool was
+ *   actually invoked in measured mode.
  *
- * The tasks live in scripts/ruvector-harness-tasks.json so measurements stay
- * reproducible across sessions.
+ * The tasks live in scripts/ruvector-harness-tasks.json so measurements
+ * stay reproducible across sessions.
  */
 import { spawnSync } from 'node:child_process'
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..')
 const TASKS_PATH = resolve(__dirname, 'ruvector-harness-tasks.json')
 const RESULTS_PATH = resolve(__dirname, 'ruvector-baseline.json')
+const EMPTY_MCP_PATH = resolve(tmpdir(), 'token-delta-empty-mcp.json')
 
 function loadTasks() {
   if (!existsSync(TASKS_PATH)) {
@@ -39,7 +48,7 @@ function loadTasks() {
 }
 
 function loadResults() {
-  if (!existsSync(RESULTS_PATH)) return { version: 1, runs: {} }
+  if (!existsSync(RESULTS_PATH)) return { version: 2, runs: {} }
   return JSON.parse(readFileSync(RESULTS_PATH, 'utf8'))
 }
 
@@ -49,9 +58,19 @@ function saveResults(data) {
 }
 
 function invokeClaude(prompt, mode) {
-  const args = ['--print', '--output-format', 'stream-json', '--permission-mode', 'default']
+  const args = [
+    '--print',
+    '--output-format',
+    'stream-json',
+    '--verbose',
+    '--permission-mode',
+    'default',
+    '--model',
+    'claude-sonnet-4-6',
+  ]
   if (mode === 'baseline') {
-    args.push('--mcp-config', '/dev/null')
+    writeFileSync(EMPTY_MCP_PATH, JSON.stringify({ mcpServers: {} }), 'utf8')
+    args.push('--mcp-config', EMPTY_MCP_PATH)
   }
   const result = spawnSync('claude', args, {
     cwd: REPO_ROOT,
@@ -66,8 +85,11 @@ function invokeClaude(prompt, mode) {
 }
 
 function parseStream(raw) {
-  let totalInput = 0
+  let finalUsage = null
+  let totalCostUsd = null
   let turns = 0
+  const toolCalls = {}
+
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue
     let evt
@@ -76,13 +98,41 @@ function parseStream(raw) {
     } catch {
       continue
     }
-    const usage = evt?.message?.usage ?? evt?.usage
-    if (usage && typeof usage.input_tokens === 'number') {
-      totalInput += usage.input_tokens
+    if (evt.type === 'assistant') {
       turns++
+      const content = evt.message?.content ?? []
+      for (const block of content) {
+        if (block?.type === 'tool_use' && block.name) {
+          toolCalls[block.name] = (toolCalls[block.name] ?? 0) + 1
+        }
+      }
+    }
+    if (evt.type === 'result' && evt.usage) {
+      finalUsage = evt.usage
+      if (typeof evt.total_cost_usd === 'number') totalCostUsd = evt.total_cost_usd
     }
   }
-  return { totalInputTokens: totalInput, turns }
+
+  const u = finalUsage ?? {}
+  const inputTokens = u.input_tokens ?? 0
+  const cacheCreation = u.cache_creation_input_tokens ?? 0
+  const cacheRead = u.cache_read_input_tokens ?? 0
+  const outputTokens = u.output_tokens ?? 0
+  const totalInputAll = inputTokens + cacheCreation + cacheRead
+  // Cost-weighted proxy (Sonnet pricing ratios: input=1x, cache_creation=1.25x, cache_read=0.1x)
+  const costWeightedInput = inputTokens + cacheCreation * 1.25 + cacheRead * 0.1
+
+  return {
+    totalInputAll,
+    inputTokens,
+    cacheCreationInputTokens: cacheCreation,
+    cacheReadInputTokens: cacheRead,
+    outputTokens,
+    costWeightedInput: Math.round(costWeightedInput),
+    totalCostUsd,
+    turns,
+    toolCalls,
+  }
 }
 
 function run(mode) {
@@ -94,33 +144,73 @@ function run(mode) {
   for (const task of tasks) {
     const key = task.id
     results.runs[key] ??= {}
-    const measurement = invokeClaude(task.prompt, mode)
+    const m = invokeClaude(task.prompt, mode)
     results.runs[key][mode] = {
-      totalInputTokens: measurement.totalInputTokens,
-      turns: measurement.turns,
+      totalInputAll: m.totalInputAll,
+      inputTokens: m.inputTokens,
+      cacheCreationInputTokens: m.cacheCreationInputTokens,
+      cacheReadInputTokens: m.cacheReadInputTokens,
+      outputTokens: m.outputTokens,
+      costWeightedInput: m.costWeightedInput,
+      totalCostUsd: m.totalCostUsd,
+      turns: m.turns,
+      toolCalls: m.toolCalls,
       capturedAt: new Date().toISOString(),
     }
+    const toolSummary = Object.entries(m.toolCalls)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(',')
     console.log(
-      `[token-delta] ${key} mode=${mode} input=${measurement.totalInputTokens} turns=${measurement.turns}`
+      `[token-delta] ${key} mode=${mode} totalInputAll=${m.totalInputAll} ` +
+        `(in=${m.inputTokens} cache_create=${m.cacheCreationInputTokens} cache_read=${m.cacheReadInputTokens}) ` +
+        `turns=${m.turns} cost=$${m.totalCostUsd?.toFixed(4) ?? 'n/a'} tools=[${toolSummary}]`
     )
   }
   saveResults(results)
 }
 
-function compare() {
-  const results = loadResults()
+/**
+ * Pure verdict computation — exported for unit tests.
+ *
+ * @param {Record<string, { baseline?: { totalInputAll?: number; totalCostUsd?: number; turns?: number }; measured?: { totalInputAll?: number; totalCostUsd?: number; turns?: number; toolCalls?: Record<string, number> } }>} runs
+ * @returns {{ rows: object[]; medianReductionPct: number | null; gate: string; gateVerdict: 'PASS' | 'FAIL' | 'FAIL_TOOL_NOT_INVOKED'; toolInvocationFailure: boolean; toolNotInvokedTasks: string[] }}
+ */
+export function computeGateVerdict(runs) {
   const deltas = []
   const rows = []
-  for (const [key, modes] of Object.entries(results.runs ?? {})) {
-    const b = modes.baseline?.totalInputTokens
-    const m = modes.measured?.totalInputTokens
+  const toolNotInvokedTasks = []
+  for (const [key, modes] of Object.entries(runs ?? {})) {
+    const b = modes.baseline?.totalInputAll
+    const m = modes.measured?.totalInputAll
+    const mcpCalls =
+      modes.measured?.toolCalls?.['mcp__skillsmith-doc-retrieval__skill_docs_search'] ?? 0
+    const toolNotInvoked = typeof m === 'number' && mcpCalls === 0
+    if (toolNotInvoked) toolNotInvokedTasks.push(key)
     if (typeof b !== 'number' || typeof m !== 'number' || b === 0) {
-      rows.push({ task: key, baseline: b ?? null, measured: m ?? null, deltaPct: null })
+      rows.push({
+        task: key,
+        baselineTotalInput: b ?? null,
+        measuredTotalInput: m ?? null,
+        deltaPct: null,
+        mcpSearchCalls: mcpCalls,
+        toolNotInvoked,
+      })
       continue
     }
     const deltaPct = (1 - m / b) * 100
     deltas.push(deltaPct)
-    rows.push({ task: key, baseline: b, measured: m, deltaPct: Number(deltaPct.toFixed(1)) })
+    rows.push({
+      task: key,
+      baselineTotalInput: b,
+      measuredTotalInput: m,
+      deltaPct: Number(deltaPct.toFixed(1)),
+      baselineCost: modes.baseline?.totalCostUsd ?? null,
+      measuredCost: modes.measured?.totalCostUsd ?? null,
+      baselineTurns: modes.baseline?.turns ?? null,
+      measuredTurns: modes.measured?.turns ?? null,
+      mcpSearchCalls: mcpCalls,
+      toolNotInvoked,
+    })
   }
   deltas.sort((a, b) => a - b)
   const median =
@@ -129,7 +219,27 @@ function compare() {
       : deltas.length % 2 === 1
         ? deltas[(deltas.length - 1) / 2]
         : (deltas[deltas.length / 2 - 1] + deltas[deltas.length / 2]) / 2
-  console.log(JSON.stringify({ rows, medianReductionPct: median, gate: '>=40' }, null, 2))
+  const toolInvocationFailure = toolNotInvokedTasks.length > 0
+  const gateVerdict = toolInvocationFailure
+    ? 'FAIL_TOOL_NOT_INVOKED'
+    : typeof median === 'number' && median >= 40
+      ? 'PASS'
+      : 'FAIL'
+  return {
+    rows,
+    medianReductionPct: median,
+    gate: '>=40',
+    gateVerdict,
+    toolInvocationFailure,
+    toolNotInvokedTasks,
+  }
+}
+
+function compare() {
+  const results = loadResults()
+  const verdict = computeGateVerdict(results.runs)
+  console.log(JSON.stringify(verdict, null, 2))
+  if (verdict.gateVerdict !== 'PASS') process.exit(1)
 }
 
 function main() {
@@ -149,9 +259,12 @@ function main() {
   process.exit(2)
 }
 
-try {
-  main()
-} catch (err) {
-  console.error('[token-delta-harness] error:', err?.message ?? err)
-  process.exit(1)
+// Only run CLI when executed directly (not when imported by tests)
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main()
+  } catch (err) {
+    console.error('[token-delta-harness] error:', err?.message ?? err)
+    process.exit(1)
+  }
 }


### PR DESCRIPTION
## Summary

- **SMI-4437** executed Wave 2 Step 6 token-delta gate. Verdict: **FAIL** (median −18.7%, required ≥+40%). Root cause: `skill_docs_search` never called by agent in any of 3 measured runs.
- **SMI-4440** SPARC investigation: description rewrite to "PREFERRED first step…" still produced 0 invocations. **Phase 2 of SMI-4416 abandoned.**
- Harness `compare()` now emits `gateVerdict: PASS | FAIL | FAIL_TOOL_NOT_INVOKED` and exits non-zero unless PASS — prevents noise-driven false-positives (the Exp 2 run showed an apparent −20.5% median that was pure Read variance, not tool savings).
- 13 unit tests cover the gate logic.

**Submodule:** `docs/internal` bump to `f2c6280` (SMI-4440 plan + retro + index count 153→159). Depends on https://github.com/smith-horn/skillsmith-docs/pull/84.

**Linear:** SMI-4440 → Done. SMI-4416 commented with Phase 2 scope-cut. SMI-4442 filed for SMI-4417 harness-audit ancillary.

## Budget

$2.58 of $10 plan budget ($7.42 returned to SMI-4416 pool).

## Test plan

- [x] `docker exec skillsmith-dev-1 npm run typecheck`
- [x] `docker exec skillsmith-dev-1 npm run lint`
- [x] `docker exec skillsmith-dev-1 npm run format:check`
- [x] `docker exec skillsmith-dev-1 npx vitest run scripts/tests/token-delta-harness.test.ts` — 13/13 pass
- [x] `docker exec skillsmith-dev-1 npm run audit:standards` — 43 pass / 5 warn / 0 fail / 90% compliance
- [x] Governance review (1 High + 1 Low fixed in-session)
- [x] Submodule retro + plan + index updated (PR smith-horn/skillsmith-docs#84)

## Follow-up

- SMI-4442: audit SMI-4417 harness claims (/dev/null mcp-config bug meant gate never actually ran before this work)
- SMI-4420: Ruflo remote-persistence + disabledTools policy — unchanged, remains Step 7 blocker

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)