### PR TITLE
fix(web): SMI-4443 callback H1 guard + overlay session-blindness (SMI-4401 regression)

### DIFF
--- a/packages/website/src/components/SignedOutOverlay.astro
+++ b/packages/website/src/components/SignedOutOverlay.astro
@@ -60,6 +60,27 @@ import LoginButton from './auth/LoginButton.astro'
     var overlay = document.getElementById('signed-out-overlay')
     if (!overlay) return
 
+    // Session-aware: if a @supabase/supabase-js v2 session exists and is not expired,
+    // remove the overlay immediately. Reads the sb-<project-ref>-auth-token localStorage
+    // key directly to avoid a full client init. Matches the JSDoc contract at :10-11.
+    try {
+      var keys = Object.keys(localStorage)
+      for (var i = 0; i < keys.length; i++) {
+        var k = keys[i]
+        if (k.indexOf('sb-') !== 0 || !/-auth-token$/.test(k)) continue
+        var raw = localStorage.getItem(k)
+        if (!raw) continue
+        var parsed = JSON.parse(raw)
+        var expiresAt = parsed && parsed.expires_at
+        if (typeof expiresAt === 'number' && expiresAt * 1000 > Date.now()) {
+          overlay.remove()
+          return
+        }
+      }
+    } catch (_e) {
+      /* localStorage / JSON.parse failed — fall through to dismissal check */
+    }
+
     // On load: if a non-expired dismissal exists, remove the overlay; otherwise sweep a stale key.
     try {
       var storedUntil = localStorage.getItem(DISMISS_KEY)

--- a/packages/website/src/pages/auth/callback.astro
+++ b/packages/website/src/pages/auth/callback.astro
@@ -321,19 +321,13 @@ const redirectTo =
       const code = (profileError as { code?: string }).code ?? ''
       const SCHEMA_DRIFT_CODES = ['42703', '42P01', 'PGRST204', 'PGRST205']
       if (SCHEMA_DRIFT_CODES.includes(code)) {
-        // Telemetry via the existing `events` edge function (telemetry:* convention).
-        // Fire-and-forget; swallow failures so the redirect still runs for the user.
-        void fetch(`${supabaseUrl}/functions/v1/events`, {
-          method: 'POST',
-          headers: {
-            apikey: supabaseAnonKey,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            event_type: 'telemetry:callback:schema_drift',
-            metadata: { code, path: '/auth/callback', user_id: session.user.id },
-          }),
-        }).catch(() => {})
+        // Schema/cache drift between website deploy and DB migration state. Log to
+        // console so it surfaces in Sentry breadcrumbs / browser devtools. Server-side
+        // telemetry via the `events` edge function is NOT wired here because that fn's
+        // ALLOWED_EVENTS allowlist rejects `callback:schema_drift` and its
+        // sanitizeMetadata strips `code`/`path`/`user_id`. Wiring it would require an
+        // edge fn deploy; not in this hotfix's scope.
+        console.warn('[auth/callback] schema drift detected', { code, path: '/auth/callback' })
         window.location.href = '/complete-profile?next=' + encodeURIComponent(authRedirectTo)
         return
       }

--- a/packages/website/src/pages/auth/callback.astro
+++ b/packages/website/src/pages/auth/callback.astro
@@ -312,10 +312,36 @@ const redirectTo =
       .select('first_name, last_name, profile_completed_at')
       .eq('id', session.user.id)
       .single()
-    // H1: on profile fetch failure, do NOT default-redirect — surface the error instead.
-    // A silent default-redirect to `/complete-profile` on transient network error would trap
-    // already-complete users in the form. Keep them on callback with a clear retry prompt.
+    // H1: branch on Postgres/PostgREST error code so schema-drift (42703 / 42P01 /
+    // PGRST204 / PGRST205) and missing-row (PGRST116) degrade gracefully to
+    // /complete-profile. Only permission-denied (42501) keeps the hard error —
+    // that case represents a real trust-boundary violation, not deploy ordering.
+    // authRedirectTo already passed validateNextParam at :257 — do not rebuild.
     if (profileError) {
+      const code = (profileError as { code?: string }).code ?? ''
+      const SCHEMA_DRIFT_CODES = ['42703', '42P01', 'PGRST204', 'PGRST205']
+      if (SCHEMA_DRIFT_CODES.includes(code)) {
+        // Telemetry via the existing `events` edge function (telemetry:* convention).
+        // Fire-and-forget; swallow failures so the redirect still runs for the user.
+        void fetch(`${supabaseUrl}/functions/v1/events`, {
+          method: 'POST',
+          headers: {
+            apikey: supabaseAnonKey,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            event_type: 'telemetry:callback:schema_drift',
+            metadata: { code, path: '/auth/callback', user_id: session.user.id },
+          }),
+        }).catch(() => {})
+        window.location.href = '/complete-profile?next=' + encodeURIComponent(authRedirectTo)
+        return
+      }
+      if (code === 'PGRST116') {
+        // Profile row missing (0 rows). Send to /complete-profile to create it.
+        window.location.href = '/complete-profile?next=' + encodeURIComponent(authRedirectTo)
+        return
+      }
       showError(
         'We could not verify your profile. Please try again — if it keeps failing, contact us at /contact?topic=signup-help.'
       )


### PR DESCRIPTION
## Summary

- **Overlay fix**: `SignedOutOverlay.astro` now reads the `sb-*-auth-token` localStorage key and removes itself from the DOM when an unexpired Supabase session exists. The JSDoc contract at `:7-11` promised this behavior but the inline script only read the dismissal key.
- **Callback guard**: `auth/callback.astro` H1 guard now branches on `profileError.code` — schema-drift codes (`42703` / `42P01` / `PGRST204` / `PGRST205`) and `PGRST116` (missing row) redirect to `/complete-profile`; only `42501` + unknown keep the hard error.

## Context

Live prod incident: every already-logged-in user who clicks "Sign in with GitHub" on `/skills` hits `/auth/callback?redirect=%2Fskills#` with a **"Verification Failed"** banner. Root cause is two coupled SMI-4401 Wave 2 regressions from PR #719 (`605a8e64`):

1. `SignedOutOverlay` was session-blind, so logged-in users saw the overlay and started a redundant OAuth flow.
2. The callback's H1 guard surfaced "Verification Failed" on *any* `profileError`. With migration 080 still unapplied to prod (confirmed via pooler: `supabase_migrations.schema_migrations` has no `080%` row; `profiles.profile_completed_at` does not exist; PostgREST returns `42703`), every logged-in user hit the banner.

Linear: [SMI-4443](https://linear.app/smith-horn-group/issue/SMI-4443/)
Plan: `docs/internal/implementation/smi-4401-wave2-callback-verification-regression.md`

## Not in this PR

- **Migration 080 apply to prod** — requires explicit user approval. Cannot use `supabase db push` because migration 081 (SMI-4402 Wave 3) has a known pre-apply bug (sibling session's WIP fixes it: `audit_logs.user_id` column doesn't exist). Apply plan: direct `psql -f supabase/migrations/080_profile_completion.sql` on prod + manual `INSERT INTO supabase_migrations.schema_migrations`.
- **Migration-before-website-merge CI gate** — separate Linear issue per ADR-109 (infra change needs SPARC).
- **SSR session gate for SignedOutOverlay** — follow-up. Client-side DOM removal flashes the blur for ~100ms on logged-in users; cleaner long-term is to detect session in `skills/index.astro` frontmatter.
- **Server-side telemetry for schema drift** — requires expanding `events` edge fn's `ALLOWED_EVENTS` + `sanitizeMetadata` allowed keys. Using `console.warn` for now (Sentry breadcrumbs + devtools visibility).
- **`.astro` files invisible to `Verify Implementation Completeness` CI check** — `scripts/ci/source-patterns.mjs` classifies `.ts/.tsx/.js/.jsx` as source but not `.astro`. This PR has two `.astro` source changes but the check cannot see them, so `[skip-impl-check]` is used as the tactical unblock. Follow-up Linear issue files the pattern-gap fix; infra-trigger per ADR-109 so it needs SPARC.

## Test plan

- [ ] After Wave 2 migration apply: incognito → log in → visit `/skills` → overlay does NOT render (DevTools: `document.getElementById('signed-out-overlay') === null`).
- [ ] Log out → visit `/skills` → overlay renders; "Sign in with GitHub" → OAuth → `/auth/callback` → redirect to `/skills` on profile-complete, or `/complete-profile?next=%2Fskills` on profile-incomplete.
- [ ] Before Wave 2 migration apply: logged-in user hitting `/auth/callback` gets redirected to `/complete-profile` (graceful) instead of "Verification Failed" (current broken state). Console logs `[auth/callback] schema drift detected { code: '42703', ... }`.
- [ ] CI green on the 13 required checks.

## Governance

- Self-review found that the originally-proposed `fetch /functions/v1/events` telemetry call would have 400'd every time (event not in `ALLOWED_EVENTS`, metadata keys stripped by `sanitizeMetadata`). Fixed in commit 8ca66d60 by switching to `console.warn`.
- `authRedirectTo` at `callback.astro:257` is already `validateNextParam`'d — open-redirect safe.

[skip-impl-check]

🤖 Generated with [Claude Code](https://claude.ai/claude-code)