### PR TITLE
fix(web,cli): SMI-4447 /account/cli-token auto-detect existing key + SMI-4441 error copy

### DIFF
--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -186,6 +186,9 @@ describe('createLoginCommand', () => {
       )
       const output = consoleLogSpy.mock.calls.flat().join('\n')
       expect(output).toContain('Logged in successfully')
+      // SMI-4447: post-login hint closes the "did it work?" gap that drove users
+      // to visit /account/cli-token just to confirm the session worked.
+      expect(output).toContain('Try it: skillsmith skills list')
     })
 
     it('LC-3: network error on device-code request exits 5', async () => {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -218,6 +218,9 @@ async function runDeviceCodeFlow(noBrowser: boolean): Promise<void> {
 
     await storeCredentials({ ...result.creds, version: 2 })
     console.log(chalk.green('\nLogged in successfully.'))
+    // SMI-4447: close the "did it work?" gap post-login. A single concrete command the
+    // user can run in-terminal beats a URL (phishing-safe, no browser context switch).
+    console.log(chalk.dim('  Try it: skillsmith skills list'))
     process.exit(EXIT.success)
   }
 

--- a/packages/website/src/pages/account/cli-token.astro
+++ b/packages/website/src/pages/account/cli-token.astro
@@ -270,13 +270,15 @@ const supabaseConfig = getSupabaseConfig()
           // Non-critical — tier note is informational only
         }
 
-        // Fetch active CLI tokens for display
+        // SMI-4447: detection query must match `generate-license` enforcement semantics
+        // (name-agnostic, status='active' only). The legacy `name='CLI Token'` filter hid
+        // pre-migration-080 auto-generated keys named 'default' and drove users into a
+        // "Generate" flow that then failed the tier-limit check.
         const { data: cliKeys } = await supabase
           .from('license_keys')
           .select('id, key_prefix, name, tier, created_at, last_used_at')
           .eq('user_id', session.user.id)
           .eq('status', 'active')
-          .eq('name', 'CLI Token')
           .order('created_at', { ascending: false })
 
         // SMI-4401 Wave 2 C2: humanize a "Last used" timestamp ("2 hours ago", "3 days ago").
@@ -309,21 +311,37 @@ const supabaseConfig = getSupabaseConfig()
         // Render active CLI tokens section — SMI-4401 Wave 2 return-visit state.
         const tokenCard = document.querySelector('.token-card')
         if (cliKeys && cliKeys.length > 0 && tokenCard) {
+          // SMI-4447: heading pluralizes on count; origin-note surfaces when any key
+          // has a non-default name (signals legacy auto-generated key from
+          // pre-migration-080 handle_new_user trigger).
+          const heading =
+            cliKeys.length === 1 ? 'Your CLI token is live' : 'Your CLI tokens are live'
+          const hasLegacyName = cliKeys.some((k) => k.name !== 'CLI Token')
+          const originNote = hasLegacyName
+            ? `<p class="key-origin-note">We auto-generated this key when you created your account. You can revoke and regenerate a fresh one below.</p>`
+            : ''
           const keysHtml = `
             <section class="keys-section" aria-labelledby="keys-section-heading">
               <h2 id="keys-section-heading" class="keys-section-heading">
-                Your CLI token is live
+                ${escapeHtml(heading)}
               </h2>
+              ${originNote}
               <p class="section-desc">
                 Revoke and regenerate here — the old key will stop working immediately.
               </p>
               <ul class="key-list">
                 ${cliKeys
-                  .map(
-                    (key) => `
+                  .map((key) => {
+                    const isDefaultName = key.name === 'CLI Token'
+                    const nameWeightClass = isDefaultName ? 'name-default' : 'name-legacy'
+                    return `
                   <li class="key-item">
                     <div class="key-info">
                       <code class="key-prefix">sk_live_...${escapeHtml(keyPreviewSuffix(key.key_prefix))}</code>
+                      <dl class="key-name-dl ${nameWeightClass}">
+                        <dt>Name</dt>
+                        <dd>${escapeHtml(key.name)}</dd>
+                      </dl>
                       <span class="key-meta">
                         ${escapeHtml(humanizeAgo(key.last_used_at))}
                         &middot; Created ${new Date(key.created_at).toLocaleDateString()}
@@ -334,13 +352,14 @@ const supabaseConfig = getSupabaseConfig()
                       class="revoke-regen-btn btn btn-danger btn-sm"
                       data-key-id="${escapeHtml(key.id)}"
                       data-key-prefix="${escapeHtml(key.key_prefix)}"
+                      data-key-name="${escapeHtml(key.name)}"
                       aria-label="Revoke and regenerate CLI token ending in ${escapeHtml(keyPreviewSuffix(key.key_prefix))}"
                     >
                       Revoke &amp; regenerate
                     </button>
                   </li>
                 `
-                  )
+                  })
                   .join('')}
               </ul>
               <div
@@ -380,6 +399,9 @@ const supabaseConfig = getSupabaseConfig()
               <p id="revoke-modal-desc">
                 Revoke this key and generate a new one? Any CLI sessions using the old key will stop working.
               </p>
+              <p id="revoke-modal-origin-note" class="revoke-modal-origin-note" hidden>
+                This key was created automatically when you signed up.
+              </p>
               <div class="revoke-modal-actions">
                 <button type="button" class="btn btn-secondary" data-modal-cancel>Cancel</button>
                 <button type="button" class="btn btn-danger" data-modal-confirm>Confirm</button>
@@ -405,8 +427,19 @@ const supabaseConfig = getSupabaseConfig()
           }
         }
 
-        function openConfirmModal(onConfirm: () => void) {
+        function openConfirmModal(onConfirm: () => void, opts?: { keyName?: string }) {
           const modal = ensureConfirmModal()
+          // SMI-4447: surface origin-note for legacy auto-generated keys so the user
+          // recognizes why an unfamiliar key name appears in their account.
+          const originNote = modal.querySelector<HTMLElement>('#revoke-modal-origin-note')
+          if (originNote) {
+            const isLegacyName = opts?.keyName !== undefined && opts.keyName !== 'CLI Token'
+            if (isLegacyName) {
+              originNote.removeAttribute('hidden')
+            } else {
+              originNote.setAttribute('hidden', 'true')
+            }
+          }
           modal.removeAttribute('hidden')
           const cancelBtn = modal.querySelector<HTMLButtonElement>('[data-modal-cancel]')
           const confirmBtn = modal.querySelector<HTMLButtonElement>('[data-modal-confirm]')
@@ -458,85 +491,117 @@ const supabaseConfig = getSupabaseConfig()
           btn.addEventListener('click', () => {
             const keyId = btn.dataset.keyId
             if (!keyId) return
+            const keyName = btn.dataset.keyName
 
-            openConfirmModal(async () => {
-              btn.disabled = true
-              const originalText = btn.textContent
-              btn.textContent = 'Regenerating...'
-              btn.setAttribute('aria-busy', 'true')
-              const status = document.getElementById('regen-status')
-              if (status) status.textContent = ''
+            openConfirmModal(
+              async () => {
+                btn.disabled = true
+                const originalText = btn.textContent
+                btn.textContent = 'Regenerating...'
+                btn.setAttribute('aria-busy', 'true')
+                const status = document.getElementById('regen-status')
+                if (status) status.textContent = ''
 
-              function resetButton() {
-                btn.disabled = false
-                if (originalText) btn.textContent = originalText
-                btn.removeAttribute('aria-busy')
-              }
-
-              function showRegenError(message: string) {
-                if (status) status.textContent = message
-                resetButton()
-              }
-
-              // Refresh session before hitting the edge function.
-              const {
-                data: { session: currentSession },
-              } = await supabase.auth.getSession()
-              if (!currentSession) {
-                showRegenError('Session expired. Please sign in again.')
-                return
-              }
-
-              let response: Response
-              try {
-                response = await fetch(`${supabaseUrl}/functions/v1/regenerate-license`, {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${currentSession.access_token}`,
-                    apikey: supabaseAnonKey,
-                  },
-                  body: JSON.stringify({ key_id: keyId }),
-                })
-              } catch {
-                showRegenError('Network error. Check your connection and try again.')
-                return
-              }
-
-              if (response.status === 401) {
-                showRegenError('Your session expired. Please sign in again and retry.')
-                return
-              }
-              if (response.status === 429) {
-                const retryAfter = response.headers.get('Retry-After') ?? '60'
-                showRegenError(`Too many requests. Try again in ${retryAfter} seconds.`)
-                return
-              }
-              if (response.status >= 500) {
-                showRegenError(
-                  'Something went wrong on our end. Try again in a moment, or contact us at /contact?topic=cli-token.'
-                )
-                return
-              }
-              if (!response.ok) {
-                showRegenError('Could not regenerate key. Try again or contact support.')
-                return
-              }
-
-              try {
-                const body = (await response.json()) as {
-                  key?: string
-                  key_prefix?: string
+                function resetButton() {
+                  btn.disabled = false
+                  if (originalText) btn.textContent = originalText
+                  btn.removeAttribute('aria-busy')
                 }
-                if (!body.key || !body.key_prefix) {
-                  showRegenError('Unexpected response from server. Please reload the page.')
+
+                function showRegenError(message: string) {
+                  if (status) status.textContent = message
+                  resetButton()
+                }
+
+                // SMI-4441: variant that accepts trusted HTML for error messages that
+                // include a contact-support link + reference code. Callers MUST ensure any
+                // interpolated values (reference codes) are from known-safe sources; user
+                // input is never passed through this path.
+                function showRegenErrorHtml(html: string) {
+                  if (status) status.innerHTML = html
+                  resetButton()
+                }
+
+                // Refresh session before hitting the edge function.
+                const {
+                  data: { session: currentSession },
+                } = await supabase.auth.getSession()
+                if (!currentSession) {
+                  showRegenError('Session expired. Please sign in again.')
                   return
                 }
-                showFreshKey(body.key, body.key_prefix)
-              } catch {
-                showRegenError('Could not parse server response. Please reload the page.')
-              }
-            })
+
+                let response: Response
+                try {
+                  response = await fetch(`${supabaseUrl}/functions/v1/regenerate-license`, {
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json',
+                      Authorization: `Bearer ${currentSession.access_token}`,
+                      apikey: supabaseAnonKey,
+                    },
+                    body: JSON.stringify({ key_id: keyId }),
+                  })
+                } catch {
+                  showRegenError('Network error. Check your connection and try again.')
+                  return
+                }
+
+                if (response.status === 401) {
+                  showRegenError('Your session expired. Please sign in again and retry.')
+                  return
+                }
+                if (response.status === 429) {
+                  const retryAfter = response.headers.get('Retry-After') ?? '60'
+                  showRegenError(`Too many requests. Try again in ${retryAfter} seconds.`)
+                  return
+                }
+                if (response.status >= 500) {
+                  showRegenError(
+                    'Something went wrong on our end. Try again in a moment, or contact us at /contact?topic=cli-token.'
+                  )
+                  return
+                }
+                if (!response.ok) {
+                  showRegenError('Could not regenerate key. Try again or contact support.')
+                  return
+                }
+
+                try {
+                  const body = (await response.json()) as {
+                    key?: string
+                    key_prefix?: string
+                  }
+                  if (!body.key || !body.key_prefix) {
+                    // SMI-4441: payload-shape failure — reload won't help. Give the user a
+                    // concrete action (contact support) with a reference code that support
+                    // can correlate to audit_logs.
+                    const ref = 'ERR-' + crypto.randomUUID().slice(0, 8)
+                    console.error('[cli-token] regenerate-license payload-shape error', {
+                      ref,
+                      body,
+                    })
+                    showRegenErrorHtml(
+                      `Something went wrong on our end. <a href="/contact?topic=cli-token">Contact support</a> and include this reference: <code>${ref}</code>`
+                    )
+                    return
+                  }
+                  showFreshKey(body.key, body.key_prefix)
+                } catch (parseErr) {
+                  // SMI-4441: JSON-parse failure is structurally different from payload-shape;
+                  // distinct reference prefix (`PARSE-`) helps support triage.
+                  const ref = 'PARSE-' + crypto.randomUUID().slice(0, 8)
+                  console.error('[cli-token] regenerate-license JSON-parse error', {
+                    ref,
+                    error: parseErr,
+                  })
+                  showRegenErrorHtml(
+                    `Something went wrong on our end. <a href="/contact?topic=cli-token">Contact support</a> and include this reference: <code>${ref}</code>`
+                  )
+                }
+              },
+              { keyName }
+            )
           })
         })
 
@@ -561,17 +626,26 @@ const supabaseConfig = getSupabaseConfig()
             const data = await response.json()
 
             if (!response.ok) {
-              // Provide a targeted message for key-limit errors; fall back to API message otherwise.
-              // Check status 429/400 and error text to avoid fragile exact-string dependency.
-              const isLimitError =
-                (response.status === 429 || response.status === 400) &&
-                typeof data?.error === 'string' &&
-                data.error.toLowerCase().includes('limit')
+              // SMI-4447 §3: post-fix, this branch should be unreachable under normal page
+              // interaction (detection query now matches enforcement, so users with
+              // existing keys don't see the Generate button). It still fires on races
+              // (key added in another tab, admin-granted out-of-band) — render a
+              // friendly error with an actionable Refresh button.
+              const isTierLimit =
+                response.status === 400 &&
+                typeof data?.current === 'number' &&
+                typeof data?.max === 'number' &&
+                typeof data?.tier === 'string'
 
-              if (isLimitError) {
-                generateError.textContent =
-                  'You already have an active CLI token. Revoke it above before generating a new one.'
+              if (isTierLimit) {
+                generateError.innerHTML =
+                  'Looks like a key was added from another tab. <button type="button" class="refresh-inline-btn" data-action="reload">Refresh</button> to see your current keys.'
                 generateError.style.display = 'block'
+                // Rebind data-action=reload handler on the new button (initial binding
+                // at astro:page-load only covered elements present at that time).
+                generateError
+                  .querySelectorAll<HTMLButtonElement>('[data-action="reload"]')
+                  .forEach((b) => b.addEventListener('click', () => window.location.reload()))
                 generateBtn.disabled = false
                 generateBtn.textContent = 'Generate CLI Token'
                 return
@@ -1012,6 +1086,92 @@ const supabaseConfig = getSupabaseConfig()
       .tier-badge.enterprise {
         background: rgba(245, 158, 11, 0.2);
         color: #f59e0b;
+      }
+
+      /* SMI-4447: semantic key-name block (screen readers announce as "Name: <value>"). */
+      .key-name-dl {
+        display: flex;
+        align-items: baseline;
+        gap: 0.4rem;
+        margin: 0;
+        font-size: 0.8125rem;
+        color: #a1a1aa;
+      }
+
+      .key-name-dl dt {
+        font-weight: 500;
+        color: #71717a;
+      }
+
+      .key-name-dl dd {
+        margin: 0;
+        color: #d4d4d8;
+        max-width: 40ch;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .key-name-dl.name-default dd {
+        font-weight: 400;
+      }
+
+      .key-name-dl.name-legacy dd {
+        font-weight: 500;
+      }
+
+      /* SMI-4447: origin-note surfaces for legacy auto-generated keys. */
+      .key-origin-note {
+        font-size: 0.8125rem;
+        color: #a1a1aa;
+        margin: 0 0 0.75rem;
+        line-height: 1.5;
+      }
+
+      /* SMI-4447: inline Refresh button inside the generate-error message (tier-limit race). */
+      .refresh-inline-btn {
+        background: transparent;
+        border: none;
+        color: #a78bfa;
+        font-weight: 500;
+        font-family: inherit;
+        font-size: inherit;
+        padding: 0;
+        cursor: pointer;
+        text-decoration: underline;
+      }
+
+      .refresh-inline-btn:hover {
+        color: #c4b5fd;
+      }
+
+      /* SMI-4441: error-text needs to tolerate inline links/buttons + <code> snippet. */
+      .error-text a,
+      .error-text code,
+      .regen-status a,
+      .regen-status code {
+        color: #a78bfa;
+      }
+
+      .error-text code,
+      .regen-status code {
+        background: #18181b;
+        border: 1px solid #27272a;
+        border-radius: 4px;
+        padding: 0.05em 0.35em;
+        font-size: 0.85em;
+      }
+
+      /* SMI-4447: revoke-modal conditional origin-note line. */
+      :global(.revoke-modal-origin-note) {
+        color: #a1a1aa;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        margin: 0 0 1rem;
+      }
+
+      :global(.revoke-modal-origin-note[hidden]) {
+        display: none;
       }
 
       /* SMI-4401 Wave 2: grace-window reminder banner. */

--- a/packages/website/src/pages/account/cli-token.astro
+++ b/packages/website/src/pages/account/cli-token.astro
@@ -427,7 +427,7 @@ const supabaseConfig = getSupabaseConfig()
           }
         }
 
-        function openConfirmModal(onConfirm: () => void, opts?: { keyName?: string }) {
+        function openConfirmModal(onConfirm: () => void, opts?: { keyName?: string | undefined }) {
           const modal = ensureConfirmModal()
           // SMI-4447: surface origin-note for legacy auto-generated keys so the user
           // recognizes why an unfamiliar key name appears in their account.

--- a/packages/website/tests/e2e/cli-token.spec.ts
+++ b/packages/website/tests/e2e/cli-token.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * cli-token.spec.ts
+ *
+ * SMI-4447 — /account/cli-token auto-detect existing active key
+ * SMI-4441 — /account/cli-token regenerate-license error-copy hygiene (bundled)
+ *
+ * Covers the three detection scenarios from the plan (Step 5):
+ *   T-1: user has a key named 'CLI Token' → revoke-regen card rendered
+ *   T-2: user has a legacy key named 'default' → revoke-regen card + origin-note + name label
+ *   T-3: user has zero active keys → Generate CLI Token CTA rendered
+ *
+ * Plus:
+ *   T-4: tier-limit race (400 with current/max/tier) → inline Refresh button surfaced
+ *   T-5: regenerate-license payload-shape failure → ERR- reference + /contact link (SMI-4441)
+ *   T-6: regenerate-license JSON-parse failure → PARSE- reference + /contact link (SMI-4441)
+ *
+ * Mocks Supabase via the shared complete-profile.helpers.ts infrastructure so no
+ * staging / prod network calls are made (prod ref vrcnzpmndtroqxxoqkzy — see
+ * CLAUDE.md). Tests run against the Astro preview server (port 4321).
+ */
+
+import { test, expect } from '@playwright/test'
+import { buildSessionToken, injectSupabaseStub, mockSupabase } from './complete-profile.helpers'
+
+const CLI_TOKEN_URL = '/account/cli-token'
+
+const LICENSE_ROW_CLI_TOKEN = {
+  id: '11111111-1111-1111-1111-111111111111',
+  key_prefix: 'sk_live_abcdef',
+  name: 'CLI Token',
+  tier: 'community',
+  created_at: '2026-04-01T00:00:00Z',
+  last_used_at: null,
+}
+
+const LICENSE_ROW_LEGACY_DEFAULT = {
+  id: '22222222-2222-2222-2222-222222222222',
+  key_prefix: 'sk_live_123456',
+  name: 'default',
+  tier: 'community',
+  created_at: '2026-01-15T00:00:00Z',
+  last_used_at: '2026-04-20T12:00:00Z',
+}
+
+const PROFILE_ROW = {
+  tier: 'community',
+  profile_grace_until: null,
+  profile_completed_at: '2026-04-24T00:00:00Z',
+}
+
+test.describe('T-1 — existing "CLI Token"-named key', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
+  })
+
+  test('renders revoke-regen card; no origin-note; name label at default weight', async ({
+    page,
+  }) => {
+    await mockSupabase(page, {
+      restResponses: {
+        profiles: [PROFILE_ROW],
+        license_keys: [LICENSE_ROW_CLI_TOKEN],
+      },
+    })
+    await page.goto(CLI_TOKEN_URL)
+
+    await expect(page.getByRole('heading', { name: 'Your CLI token is live' })).toBeVisible()
+    await expect(page.locator('.key-origin-note')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /Revoke & regenerate/ })).toBeVisible()
+
+    // <dl> semantic markup — SR-friendly labeled property.
+    const nameDl = page.locator('.key-name-dl')
+    await expect(nameDl).toBeVisible()
+    await expect(nameDl.locator('dt')).toHaveText('Name')
+    await expect(nameDl.locator('dd')).toHaveText('CLI Token')
+    await expect(nameDl).toHaveClass(/name-default/)
+  })
+})
+
+test.describe('T-2 — legacy "default"-named key (pre-migration-080 trigger)', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'github' }) })
+  })
+
+  test('renders revoke-regen card, origin-note visible, name label at legacy weight', async ({
+    page,
+  }) => {
+    await mockSupabase(page, {
+      restResponses: {
+        profiles: [PROFILE_ROW],
+        license_keys: [LICENSE_ROW_LEGACY_DEFAULT],
+      },
+    })
+    await page.goto(CLI_TOKEN_URL)
+
+    await expect(page.getByRole('heading', { name: 'Your CLI token is live' })).toBeVisible()
+    await expect(page.locator('.key-origin-note')).toBeVisible()
+    await expect(page.locator('.key-origin-note')).toContainText('auto-generated this key')
+
+    const nameDl = page.locator('.key-name-dl')
+    await expect(nameDl.locator('dd')).toHaveText('default')
+    await expect(nameDl).toHaveClass(/name-legacy/)
+
+    await expect(page.getByRole('button', { name: /Revoke & regenerate/ })).toBeVisible()
+  })
+})
+
+test.describe('T-3 — zero active keys', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
+  })
+
+  test('renders Generate CLI Token CTA; no keys-section, no origin-note', async ({ page }) => {
+    await mockSupabase(page, {
+      restResponses: {
+        profiles: [PROFILE_ROW],
+        license_keys: [],
+      },
+    })
+    await page.goto(CLI_TOKEN_URL)
+
+    await expect(page.getByRole('button', { name: 'Generate CLI Token' })).toBeVisible()
+    await expect(page.locator('.keys-section')).toHaveCount(0)
+    await expect(page.locator('.key-origin-note')).toHaveCount(0)
+  })
+})
+
+test.describe('T-4 — tier-limit race (SMI-4447 §3)', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
+  })
+
+  test('400 with current/max/tier surfaces friendly copy + inline Refresh button', async ({
+    page,
+  }) => {
+    await mockSupabase(page, {
+      restResponses: {
+        profiles: [PROFILE_ROW],
+        license_keys: [],
+      },
+      functionsResponses: {
+        'generate-license': {
+          status: 400,
+          body: {
+            error: 'Maximum 1 active key(s) allowed for community tier',
+            current: 1,
+            max: 1,
+            tier: 'community',
+          },
+        },
+      },
+    })
+    await page.goto(CLI_TOKEN_URL)
+
+    await page.getByRole('button', { name: 'Generate CLI Token' }).click()
+
+    const err = page.locator('#generate-error')
+    await expect(err).toBeVisible()
+    await expect(err).toContainText('Looks like a key was added from another tab')
+    await expect(err.getByRole('button', { name: 'Refresh' })).toBeVisible()
+    // Raw API message must NOT leak to the user.
+    await expect(err).not.toContainText('Maximum 1 active key(s)')
+  })
+})
+
+test.describe('T-5 / T-6 — regenerate-license error copy (SMI-4441)', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
+  })
+
+  test('payload-shape failure shows ERR- reference + contact link (no reload copy)', async ({
+    page,
+  }) => {
+    await mockSupabase(page, {
+      restResponses: {
+        profiles: [PROFILE_ROW],
+        license_keys: [LICENSE_ROW_CLI_TOKEN],
+      },
+      functionsResponses: {
+        'regenerate-license': { status: 200, body: {} }, // missing key + key_prefix
+      },
+    })
+    await page.goto(CLI_TOKEN_URL)
+
+    await page.getByRole('button', { name: /Revoke & regenerate/ }).click()
+    await page.getByRole('button', { name: 'Confirm' }).click()
+
+    const status = page.locator('#regen-status')
+    await expect(status).toContainText('Contact support')
+    await expect(status.locator('code')).toContainText(/^ERR-[0-9a-f]{8}$/)
+    await expect(status).not.toContainText('reload the page')
+    await expect(status.getByRole('link', { name: 'Contact support' })).toHaveAttribute(
+      'href',
+      '/contact?topic=cli-token'
+    )
+  })
+
+  test('JSON-parse failure shows PARSE- reference + contact link', async ({ page }) => {
+    // Return non-JSON body to trip the catch branch.
+    await mockSupabase(page, {
+      restResponses: {
+        profiles: [PROFILE_ROW],
+        license_keys: [LICENSE_ROW_CLI_TOKEN],
+      },
+    })
+    await page.route('**/functions/v1/regenerate-license', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: 'not-json-at-all',
+      })
+    })
+    await page.goto(CLI_TOKEN_URL)
+
+    await page.getByRole('button', { name: /Revoke & regenerate/ }).click()
+    await page.getByRole('button', { name: 'Confirm' }).click()
+
+    const status = page.locator('#regen-status')
+    await expect(status).toContainText('Contact support')
+    await expect(status.locator('code')).toContainText(/^PARSE-[0-9a-f]{8}$/)
+    await expect(status).not.toContainText('reload the page')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the UX regression reported 2026-04-24 where logged-in users visiting `/account/cli-token` with an existing active `license_keys` row (e.g., legacy auto-generated `'default'`-named keys from the pre-migration-080 `handle_new_user` trigger) were shown the "Generate CLI Token" CTA, hit the tier-limit enforcement as a UX surface, and were told to "Revoke an existing key first" with no visible key to revoke.

Root cause: the detection query on `cli-token.astro:279` filtered by `name='CLI Token'`, while the `generate-license` enforcement at `index.ts:140-159` counted ALL active keys. The two sets disagreed on what "existing key" means.

## Changes

### SMI-4447 (primary)
- **§1 detection**: drop `.eq('name', 'CLI Token')` — detection now matches enforcement semantics.
- **§1 heading**: pluralize "Your CLI token is live" / "Your CLI tokens are live" based on count.
- **§2 name label**: semantic `<dl><dt>Name</dt><dd>...</dd></dl>` per card with tiered font-weight (400 default, 500 legacy) + max-width/ellipsis length cap.
- **§2b origin-note**: conditional paragraph under heading when any key name ≠ `'CLI Token'`, explaining auto-generation at signup.
- **§3 tier-limit handler**: replace plain-text `isLimitError` branch with friendly copy + inline `<button>Refresh</button>` (covers the race when a key is added from another tab).
- **§4 CLI hint**: emit `"Try it: skillsmith skills list"` after `"Logged in successfully."` in `login.ts` device-code success path.
- **Revoke modal**: conditional secondary line for legacy-named keys.

### SMI-4441 (bundled)
- **§3b**: replace `"Please reload the page"` copy on `regenerate-license` payload-shape and JSON-parse failures with `ERR-` / `PARSE-` reference codes + a `Contact support` link. Reload does not fix payload-shape bugs; support needs the reference code to correlate with `audit_logs`.

## Test plan

- [x] Playwright spec `packages/website/tests/e2e/cli-token.spec.ts` covers the 3 detection scenarios (T-1/T-2/T-3), tier-limit race (T-4), and SMI-4441 error paths (T-5/T-6) via the shared `complete-profile.helpers.ts` mock infrastructure. No staging / prod network calls.
- [x] `login.test.ts` asserts the new post-login hint string.
- [x] Pre-push host-side checks green: ESLint, Prettier, vitest (all 15 login tests pass).
- [x] Pre-ship baseline captured: 101 users affected (`license_keys` WHERE `name != 'CLI Token'` AND `status='active'`); migration 080 confirmed applied to prod.
- [ ] CI green end-to-end (Astro build + Playwright run via CI Docker).
- [ ] 48h post-merge: re-query pre-ship baseline; count should trend down as legacy users revoke+regenerate.

## Plan

VP-reviewed 2026-04-24 (Product / Engineering / Design primary) with 16 consolidated edits applied:
`docs/internal/implementation/smi-4447-cli-token-auto-detect-existing-key.md`

## CI note — `[skip-impl-check]`

This PR touches only `.astro` + `.ts`. The `Verify Implementation Completeness` check will report "no source code changes" because `SOURCE_PATTERNS` in `scripts/ci/source-patterns.mjs:15` currently regex only matches `.ts/.tsx/.js/.jsx` — not `.astro`. Fix tracked as **SMI-4446** (ADR-109 infra-trigger, SPARC required). Tactical unblock: `[skip-impl-check]` is included below.

`[skip-impl-check]`

Closes SMI-4447
Closes SMI-4441
Parent SMI-4399

🤖 Generated with [Claude Code](https://claude.com/claude-code)