### PR TITLE
fix(infra): SMI-4454 add auth-device-preview to edge-fn allowlists

### DIFF
--- a/scripts/deploy-edge-functions.sh
+++ b/scripts/deploy-edge-functions.sh
@@ -106,6 +106,7 @@ NO_VERIFY_JWT_FUNCTIONS=(
 VERIFY_JWT_FUNCTIONS=(
   alert-notify
   auth-device-approve
+  auth-device-preview
   expire-complimentary
   indexer
   ops-report

--- a/scripts/validate-edge-functions.sh
+++ b/scripts/validate-edge-functions.sh
@@ -49,6 +49,7 @@ AUTHENTICATED_FUNCTIONS=(
   "skills-outreach-preferences"
   "webhook-dlq"
   "auth-device-approve"
+  "auth-device-preview"
 )
 
 # Service role functions (scheduled jobs, internal)


### PR DESCRIPTION
## Summary

Follow-up to #751 — adds `auth-device-preview` to the two allowlists that the SMI-4454 PR missed:

- `scripts/validate-edge-functions.sh` → `AUTHENTICATED_FUNCTIONS`
- `scripts/deploy-edge-functions.sh` → `VERIFY_JWT_FUNCTIONS`

Without these, `deploy-edge-functions.yml` reports "Not categorized" + "NOT DEPLOYED" and fails (run 24910423062). Function is already live on prod via manual `npx supabase functions deploy auth-device-preview`; this patch restores the automated path for future changes.

Memory: `feedback_edge_function_allowlists.md` — this is the SMI-4356 drift pattern we've seen before.

`[skip-impl-check]` — this PR is scripts-only config (two array additions), no source-code/test changes.

## Test plan

- [x] Function deployed manually to prod (verified in Supabase dashboard)
- [ ] Post-merge: `deploy-edge-functions.yml` succeeds on next edge function change

🤖 Generated with [Claude Code](https://claude.com/claude-code)