### PR TITLE
chore(release): bump cli 0.5.8 — SMI-4454 UX refinement

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
+## v0.5.8
+
+- **Feature**: SMI-4454 CLI login UX — paste feedback + device context on /device (#751)
+- **Fix**: SMI-4447 /account/cli-token auto-detect existing key + SMI-4441 error copy (#749)
+- **Feature**: SMI-4402 Wave 3 — RFC 8628 device-code OAuth flow (CLI/MCP/website) (#740)
+
 ## v0.5.7
 
 - **Refactor**: initSkill throws InitSkillError instead of process.exit (SMI-4314) (#642)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release bump for `@skillsmith/cli@0.5.8`. Ships the SMI-4454 changes (PR #751):

- `--paste-legacy`: ASCII `*` mask + post-paste echo `Received N characters — validating…`
- Device-code flow: CLI now sends `client_meta` (cli_version, node_version, platform, arch, hostname) in `auth-device-code` request so `/device` approve page can surface device identity

Publish workflow triggered separately: https://github.com/smith-horn/skillsmith/actions/runs/24913230375

`[skip-impl-check]` — release bump is version + changelog only, no source changes beyond PR #751 which already merged.

## Test plan

- [x] `prepare-release.ts --cli=patch` — collision guard passed (0.5.8 > 0.5.7)
- [ ] Post-publish: `npm view @skillsmith/cli version` returns `0.5.8`
- [ ] Post-install: `npm install -g @skillsmith/cli@0.5.8` + `skillsmith --version` reports 0.5.8
- [ ] Manual golden path: `skillsmith login` → `/device` shows populated CLI/Platform/Host rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)