### PR TITLE
chore(release): bump core 0.5.5 — restore CLI dependency chain

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.5.4",
+    "@skillsmith/core": "^0.5.5",
     "chalk": "5.6.2",
     "cli-table3": "0.6.5",
     "commander": "14.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/core` are documented here.
 
+## v0.5.5
+
+- Version bump
+
 ## v0.5.4
 
 - **Fix**: rename webhook-dlq /retry → /resolve with migration 077 (SMI-4308) (#647)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.5.4'
+export const VERSION = '0.5.5'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1024.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.69.0",
-    "@skillsmith/core": "^0.5.4",
+    "@skillsmith/core": "^0.5.5",
     "jose": "^6.2.2",
     "zod": "4.2.1"
   },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.5.4",
+    "@skillsmith/core": "^0.5.5",
     "esbuild": "0.27.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Bumps `@skillsmith/core` to 0.5.5 to expose `loadCredentials` + `storeCredentials` (added by SMI-4402 Wave 3 in source but never published).

Without this, a fresh `npm install -g @skillsmith/cli@0.5.8` fails at runtime:
```
SyntaxError: The requested module '@skillsmith/core' does not provide an export named 'loadCredentials'
```

Core@0.5.5 **already published to npm** (local fallback — same reason as the CLI 0.5.8 publish earlier). This PR just lands the version bump + CHANGELOG on main.

`[skip-impl-check]` — release bump only, no source changes.
`[skip-doc-drift]` — prepare-release.ts bumped sibling `@skillsmith/core` dep ranges in cli/enterprise/mcp-server package.json (^0.5.4 → ^0.5.5). Those packages are not being released so their CHANGELOGs stay unchanged. This is a well-known pattern of the release script.

## Test plan

- [x] `npm view @skillsmith/core version` → 0.5.5
- [x] `npm install -g @skillsmith/cli@0.5.8 && skillsmith --version` → 0.5.8 (no import error)
- [x] `skillsmith --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)