### PR TITLE
fix(website): SMI-4454 /device edge-fn URLs — relative → api.skillsmith.app

### DIFF
--- a/packages/website/src/pages/device.astro
+++ b/packages/website/src/pages/device.astro
@@ -134,12 +134,18 @@ const rawCode = Astro.url.searchParams.get('user_code')?.trim().toUpperCase() ??
 
 <script>
   // SMI-4402: device approval state machine.
-  // Calls /functions/v1/auth-device-approve (gateway-verified JWT).
+  // Calls api.skillsmith.app edge functions (gateway-verified JWT).
   // All supabase-js calls use the global window.__SUPABASE_CLIENT__ injected by BaseLayout.
   // Type declaration lives in src/env.d.ts.
+  //
+  // SMI-4454 fix: URLs were relative ('/functions/v1/...') and resolved to the
+  // website origin, returning Astro's 404. The Supabase edge functions live on
+  // api.skillsmith.app (or the project supabase.co URL). Matches how every
+  // other page calls edge functions (contact, signup, skills, etc.).
 
-  const APPROVE_URL = '/functions/v1/auth-device-approve'
-  const PREVIEW_URL = '/functions/v1/auth-device-preview'
+  const API_BASE = import.meta.env.PUBLIC_API_BASE_URL || 'https://api.skillsmith.app'
+  const APPROVE_URL = `${API_BASE}/functions/v1/auth-device-approve`
+  const PREVIEW_URL = `${API_BASE}/functions/v1/auth-device-preview`
   const COMPLETE_PROFILE_URL = '/complete-profile'
   const LOGIN_URL = '/login'
   const COUNTDOWN_START = 10


### PR DESCRIPTION
## Summary

Follow-up bug fix to PR #751. `APPROVE_URL` and `PREVIEW_URL` in `device.astro` were relative paths (`/functions/v1/auth-device-*`) that resolved to `https://www.skillsmith.app/functions/v1/...` — Astro 404. `fetchPreview` saw 404 → `setState('expired')` → user landed on "This code has expired" even though:

- `device_codes` row was live (not consumed, not expired)
- `get_device_code_preview` RPC returned populated data
- `auth-device-preview` edge function was healthy (401 for missing JWT, as designed)

The missing link: there were **zero** `auth:device_code:preview_requested` audit log entries → no traffic ever reached the function.

Fix = use `import.meta.env.PUBLIC_API_BASE_URL || 'https://api.skillsmith.app'` for the base, matching the convention used by every other page that calls edge functions (contact, signup, skills, cli-token, etc.).

**Note:** This also fixes a latent SMI-4402 bug in `APPROVE_URL` — the device approve flow has been broken the same way since it shipped. Nobody noticed because the CLI wasn't live until today.

`[skip-impl-check]` — single-line URL fix.

## Test plan

- [x] `curl https://api.skillsmith.app/functions/v1/auth-device-preview` → 401 (endpoint reachable)
- [x] `curl https://www.skillsmith.app/functions/v1/auth-device-preview` → 404 Astro page (confirmed the bug)
- [ ] Post-deploy: `skillsmith login` → `/device` shows populated CLI/Platform/Host rows → approve works

🤖 Generated with [Claude Code](https://claude.com/claude-code)