### PR TITLE
fix(cli): SMI-4454 post-login hint — 'skills list' → 'search mcp' (cli 0.5.9)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
+## v0.5.9
+
+- Version bump
+
 ## v0.5.8
 
 - **Feature**: SMI-4454 CLI login UX — paste feedback + device context on /device (#751)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -189,7 +189,7 @@ describe('createLoginCommand', () => {
       expect(output).toContain('Logged in successfully')
       // SMI-4447: post-login hint closes the "did it work?" gap that drove users
       // to visit /account/cli-token just to confirm the session worked.
-      expect(output).toContain('Try it: skillsmith skills list')
+      expect(output).toContain('Try it: skillsmith search mcp')
     })
 
     it('LC-3: network error on device-code request exits 5', async () => {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -236,7 +236,7 @@ async function runDeviceCodeFlow(noBrowser: boolean): Promise<void> {
     console.log(chalk.green('\nLogged in successfully.'))
     // SMI-4447: close the "did it work?" gap post-login. A single concrete command the
     // user can run in-terminal beats a URL (phishing-safe, no browser context switch).
-    console.log(chalk.dim('  Try it: skillsmith skills list'))
+    console.log(chalk.dim('  Try it: skillsmith search mcp'))
     process.exit(EXIT.success)
   }
 


### PR DESCRIPTION
## Summary

The post-login hint added in PR #751 said `Try it: skillsmith skills list` — but `skills` is not a valid command. Correct example is `skillsmith search mcp` which also has the bonus of exercising the auth flow (search hits the API, whereas `list` would only show local installs).

First observed 2026-04-24 by Ryan after a successful device-code login:
```
$ skillsmith search mcp    # ← hint was wrong
error: unknown command 'skills'
```

## Changes

- `packages/cli/src/commands/login.ts:239` — `'skillsmith skills list'` → `'skillsmith search mcp'`
- `packages/cli/src/commands/login.test.ts:192` — matching assertion
- CLI bumped to 0.5.9, published to npm

`[skip-impl-check]` — one-line string change + matching test.

## Test plan

- [x] `npm install -g @skillsmith/cli@0.5.9 && skillsmith --version` → 0.5.9
- [ ] `skillsmith logout && skillsmith login` → approve → output ends with `Try it: skillsmith search mcp`
- [ ] `skillsmith search mcp` → runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)