### PR TITLE
feat(audit): SMI-4456/4457/4458 add R-1/R-2/R-3 surface-drift backstops

### DIFF
--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -250,3 +250,228 @@ export const extractSmokeTestRequiredArrays = (content) => {
   }
   return results
 }
+
+// ============================================================================
+// SMI-4456 / SMI-4457 / SMI-4458: post-merge bug trifecta backstops (R-1/R-2/R-3)
+// ============================================================================
+// These three helpers power audit checks that prevent recurrence of the
+// SMI-4454 surface-drift bug class. See retro:
+//   docs/internal/retros/2026-04-24-smi-4454-post-merge-bug-trifecta.md
+// All pure functions, no I/O — caller drives file reads.
+
+/**
+ * R-1 (SMI-4456): extract every Commander.js subcommand name registered by
+ * the CLI. Combines names from the entry-point (`program.command('x')` and
+ * explicit `.name('x')` overrides) with every `new Command('x')` and
+ * `.alias('x')` declaration in the command factory files.
+ *
+ * @param {string} indexSrc — `packages/cli/src/index.ts` contents.
+ * @param {Record<string, string>} commandSources — map of file path → source
+ *   for every `packages/cli/src/commands/**\/*.ts` file (test files excluded
+ *   by caller).
+ * @returns {Set<string>} every name a user can legally type after `skillsmith`
+ *   or `sklx`. Includes top-level commands, aliases, and known sub-commands.
+ */
+export const extractCliCommandNames = (indexSrc, commandSources) => {
+  const names = new Set()
+  // entry-point: program.command('<name>')
+  for (const m of indexSrc.matchAll(/program\s*\.\s*command\(\s*['"]([a-z][\w-]*)['"]/g)) {
+    names.add(m[1])
+  }
+  // entry-point: .name('<name>') overrides applied at addCommand time
+  for (const m of indexSrc.matchAll(/\.name\(\s*['"]([a-z][\w-]*)['"]\s*\)/g)) {
+    names.add(m[1])
+  }
+  // factories: new Command('<name>') + .alias('<name>')
+  for (const src of Object.values(commandSources)) {
+    const stripped = stripComments(src)
+    for (const m of stripped.matchAll(/new\s+Command\(\s*['"]([a-z][\w-]*)['"]/g)) {
+      names.add(m[1])
+    }
+    for (const m of stripped.matchAll(/\.alias\(\s*['"]([a-z][\w-]*)['"]\s*\)/g)) {
+      names.add(m[1])
+    }
+  }
+  return names
+}
+
+/**
+ * R-1 (SMI-4456): scan CLI source for user-visible hint strings of the form
+ * "Try it: skillsmith <subcmd>", "Run: sklx <subcmd>", etc. Returns each cited
+ * subcommand with its location so the caller can match against the registered
+ * command set.
+ *
+ * Patterns recognized: `(Try it|Run|Visit|Use):\s+(skillsmith|sklx)\s+<word>`.
+ * URL hints (Visit: https://…) are not flagged here — different surface, see
+ * R-2 for URL-shape checks. Comment lines (`//`, `*`) are skipped.
+ *
+ * @param {Record<string, string>} cliSrcByPath — map of file path → source.
+ *   Caller is responsible for excluding test files.
+ * @returns {Array<{file: string, line: number, refToken: string, fullMatch: string}>}
+ */
+export const findCliHintCommandRefs = (cliSrcByPath) => {
+  const out = []
+  // Match the hint marker, an optional opening backtick/quote, then
+  // "skillsmith <word>" or "sklx <word>" on the same line.
+  const HINT_RE = /(?:Try it|Run|Visit|Use):\s+`?(?:skillsmith|sklx)\s+([a-z][\w-]*)/g
+  for (const [file, src] of Object.entries(cliSrcByPath)) {
+    const lines = src.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      const trimmed = line.trim()
+      if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue
+      HINT_RE.lastIndex = 0
+      let m
+      while ((m = HINT_RE.exec(line)) !== null) {
+        out.push({
+          file,
+          line: i + 1,
+          refToken: m[1],
+          fullMatch: m[0],
+        })
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * R-2 (SMI-4457): find website client-side fetches that use a relative
+ * `/functions/v1/...` path instead of the canonical
+ * `${import.meta.env.PUBLIC_API_BASE_URL}/functions/v1/...` (or
+ * `https://api.skillsmith.app/functions/v1/...`). Astro server-render emits
+ * to www.skillsmith.app where `/functions/v1/...` 404s; the bug pattern was
+ * introduced in PR #751 and surfaced as B1 in the SMI-4454 trifecta retro.
+ *
+ * @param {Record<string, string>} websiteSrcByPath — map of file path →
+ *   source for every `packages/website/src/**\/*.{astro,ts}` file.
+ * @returns {Array<{file: string, line: number, snippet: string}>}
+ */
+export const findRelativeFunctionsV1Urls = (websiteSrcByPath) => {
+  const out = []
+  // Quoted-literal path that begins with /functions/v1/. Excludes
+  // `${var}/functions/v1/...` (where the leading `/` is an absolute-path
+  // continuation of an interpolated origin) by requiring the quote/backtick
+  // immediately before the slash.
+  const REL_RE = /['"`]\/functions\/v1\//g
+  for (const [file, src] of Object.entries(websiteSrcByPath)) {
+    const lines = src.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      const trimmed = line.trim()
+      if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue
+      REL_RE.lastIndex = 0
+      if (REL_RE.test(line)) {
+        out.push({
+          file,
+          line: i + 1,
+          snippet: trimmed.length > 120 ? trimmed.slice(0, 117) + '...' : trimmed,
+        })
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * R-3 (SMI-4458): flag PL/pgSQL `CREATE FUNCTION ... RETURNS TABLE(...)`
+ * blocks whose body contains an unqualified `RETURNING <col>` matching one of
+ * the TABLE output column names. PL/pgSQL treats TABLE(...) outputs as
+ * implicit OUT parameters; the RETURNING clause is then ambiguous and
+ * Postgres raises at call time. See B2 in the SMI-4454 trifecta retro.
+ *
+ * Walks migrations in lexicographic order (filename = version) and tracks
+ * the LATEST `CREATE [OR REPLACE] FUNCTION` definition per function name —
+ * so a later migration that re-declares the function with the fix
+ * (qualified column) causes the audit to pass on main.
+ *
+ * Heuristic, not a parser. False positives are possible (cured by aliasing
+ * the table and qualifying the column — harmless either way).
+ *
+ * @param {Record<string, string>} migrationsByPath — map of migration file
+ *   path → source. Lexicographic key order = version order.
+ * @returns {Array<{file: string, line: number, fnName: string, col: string, snippet: string}>}
+ */
+export const findReturningTableAmbiguity = (migrationsByPath) => {
+  const sortedFiles = Object.keys(migrationsByPath).sort()
+  const latestDefs = new Map()
+  const FN_HEADER_RE = /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+([\w.]+)\s*\(/gi
+
+  for (const file of sortedFiles) {
+    const src = migrationsByPath[file]
+    // Locate every `CREATE [OR REPLACE] FUNCTION` start; segment the source
+    // into per-function blocks bounded by the next CREATE FUNCTION (or EOF).
+    // This prevents the regex from skipping a non-TABLE-returning function
+    // and incorrectly matching the next one's RETURNS TABLE block.
+    const headers = []
+    FN_HEADER_RE.lastIndex = 0
+    let h
+    while ((h = FN_HEADER_RE.exec(src)) !== null) {
+      headers.push({ name: h[1], start: h.index })
+    }
+    for (let i = 0; i < headers.length; i++) {
+      const blk = headers[i]
+      const end = i + 1 < headers.length ? headers[i + 1].start : src.length
+      const segment = src.slice(blk.start, end)
+      // Only consider RETURNS TABLE functions written in plpgsql.
+      const tableM = segment.match(/RETURNS\s+TABLE\s*\(([\s\S]*?)\)\s*LANGUAGE\s+plpgsql/i)
+      if (!tableM) continue
+      // Postgres dollar-quoting allows arbitrary tags: $$ ... $$, $function$ ... $function$,
+      // $body$ ... $body$, etc. Capture the tag and require a matching closer.
+      const bodyM = segment.match(/AS\s+\$(\w*)\$([\s\S]*?)\$\1\$/)
+      if (!bodyM) continue
+      const body = bodyM[2]
+      const tableColsRaw = tableM[1]
+      const cols = []
+      for (const part of tableColsRaw.split(',')) {
+        const cm = part.trim().match(/^(\w+)\s+\S/)
+        if (cm) cols.push(cm[1])
+      }
+      const declStartLine = src.slice(0, blk.start).split('\n').length
+      // bodyM.index is relative to `segment`; the actual body content starts
+      // after `AS $$` (length of the prefix before capture group 1).
+      const bodyOffsetInSegment = bodyM.index + bodyM[0].indexOf(body)
+      const bodyStartLine = src.slice(0, blk.start + bodyOffsetInSegment).split('\n').length
+      latestDefs.set(blk.name, {
+        file,
+        declStartLine,
+        bodyStartLine,
+        body,
+        tableCols: cols,
+      })
+    }
+  }
+
+  const violations = []
+  // Match RETURNING followed by a single bareword column name. Reject
+  // qualified refs (`alias.col`) by requiring no `.` immediately before.
+  const RET_RE = /(?<![.\w])RETURNING\s+(\w+)\b/gi
+  for (const [fnName, def] of latestDefs) {
+    if (def.tableCols.length === 0) continue
+    const colSet = new Set(def.tableCols)
+    const lines = def.body.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      if (line.trim().startsWith('--')) continue
+      RET_RE.lastIndex = 0
+      let rm
+      while ((rm = RET_RE.exec(line)) !== null) {
+        const col = rm[1]
+        // Defensive: even with the lookbehind, double-check via per-line
+        // pattern that no `<alias>.<col>` form appears for this column.
+        const qualified = new RegExp(`\\.\\s*${col}\\b`)
+        if (qualified.test(line)) continue
+        if (colSet.has(col)) {
+          violations.push({
+            file: def.file,
+            line: def.bodyStartLine + i,
+            fnName,
+            col,
+            snippet: line.trim().slice(0, 120),
+          })
+        }
+      }
+    }
+  }
+  return violations
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -14,6 +14,10 @@ import {
   extractCompletionIssues,
   collectTsEntryExports,
   extractSmokeTestRequiredArrays,
+  extractCliCommandNames,
+  findCliHintCommandRefs,
+  findRelativeFunctionsV1Urls,
+  findReturningTableAmbiguity,
 } from './audit-standards-helpers.mjs'
 
 const RED = '\x1b[31m'
@@ -2036,6 +2040,135 @@ console.log(`\n${BOLD}30. VS Code Integration Tests Excluded from Host Runners${
         errors.join('; '),
         "Add 'packages/vscode-extension/src/__tests__/integration/**' to both exclude lists — these tests require the vscode module (electron host) and mocha globals."
       )
+    }
+  }
+}
+
+// 31. SMI-4456 (R-1): user-visible CLI hints must reference real subcommands.
+// Catches the SMI-4454 B3 pattern: `Try it: skillsmith skills list` shipped to
+// users despite `skills` not being a registered subcommand. See retro
+// docs/internal/retros/2026-04-24-smi-4454-post-merge-bug-trifecta.md.
+console.log(`\n${BOLD}31. CLI Hint Command Existence (R-1, SMI-4456)${RESET}`)
+{
+  const cliIndexPath = 'packages/cli/src/index.ts'
+  const cliCommandsDir = 'packages/cli/src/commands'
+  if (!existsSync(cliIndexPath) || !existsSync(cliCommandsDir)) {
+    pass('CLI source not present — skipping (not a CLI repo checkout)')
+  } else {
+    try {
+      const indexSrc = readFileSync(cliIndexPath, 'utf8')
+      const cliFiles = getFilesRecursive('packages/cli/src', ['.ts']).filter(
+        (f) => !f.includes('.test.') && !f.includes('.d.ts')
+      )
+      const commandSources = {}
+      const cliSrcByPath = {}
+      for (const f of cliFiles) {
+        const src = readFileSync(f, 'utf8')
+        cliSrcByPath[f] = src
+        if (f.startsWith('packages/cli/src/commands/')) commandSources[f] = src
+      }
+      const registered = extractCliCommandNames(indexSrc, commandSources)
+      const refs = findCliHintCommandRefs(cliSrcByPath)
+      const violations = refs.filter((r) => !registered.has(r.refToken))
+      if (registered.size === 0) {
+        warn('Could not extract any registered CLI command names — heuristic miss?')
+      } else if (refs.length === 0) {
+        pass(
+          `No "Try it:/Run:/Visit:/Use: skillsmith <subcmd>" hints found in CLI source (${registered.size} commands registered)`
+        )
+      } else if (violations.length === 0) {
+        pass(
+          `${refs.length} CLI hint(s) all reference registered subcommands (${registered.size} commands in registry)`
+        )
+      } else {
+        const formatted = violations
+          .map(
+            (v) =>
+              `  ${v.file}:${v.line} → "${v.fullMatch}" (subcommand "${v.refToken}" not registered)`
+          )
+          .join('\n')
+        fail(
+          `CLI hint(s) reference nonexistent subcommands:\n${formatted}`,
+          `Either register the subcommand in packages/cli/src/index.ts (Commander.js .command() / .addCommand()) or change the hint to a real one. Registered set: ${[...registered].sort().join(', ')}`
+        )
+      }
+    } catch (e) {
+      warn(`Could not check CLI hint command existence: ${e.message}`)
+    }
+  }
+}
+
+// 32. SMI-4457 (R-2): website client code must not use relative `/functions/v1/`.
+// Catches the SMI-4454 B1 pattern: PR #751 shipped `'/functions/v1/auth-device-preview'`
+// which Astro SSR resolved against www.skillsmith.app (404), masquerading as
+// "code expired". Canonical pattern (see PR #757):
+//   const API_BASE = import.meta.env.PUBLIC_API_BASE_URL || 'https://api.skillsmith.app'
+console.log(`\n${BOLD}32. Website Edge-Function URL Convention (R-2, SMI-4457)${RESET}`)
+{
+  const websiteSrcDir = 'packages/website/src'
+  if (!existsSync(websiteSrcDir)) {
+    pass('Website source not present — skipping')
+  } else {
+    try {
+      const websiteFiles = getFilesRecursive(websiteSrcDir, ['.astro', '.ts', '.tsx']).filter(
+        (f) => !f.includes('.test.') && !f.includes('.spec.') && !f.includes('.d.ts')
+      )
+      const websiteSrcByPath = {}
+      for (const f of websiteFiles) websiteSrcByPath[f] = readFileSync(f, 'utf8')
+      const violations = findRelativeFunctionsV1Urls(websiteSrcByPath)
+      if (violations.length === 0) {
+        pass(`No relative "/functions/v1/..." URLs in ${websiteFiles.length} website source files`)
+      } else {
+        const formatted = violations.map((v) => `  ${v.file}:${v.line} — ${v.snippet}`).join('\n')
+        fail(
+          `Relative "/functions/v1/..." URL(s) detected (Astro SSR resolves these against the website origin, not the API):\n${formatted}`,
+          `Replace with \`\${import.meta.env.PUBLIC_API_BASE_URL || 'https://api.skillsmith.app'}/functions/v1/...\` or \`\${supabaseUrl}/functions/v1/...\`.`
+        )
+      }
+    } catch (e) {
+      warn(`Could not check website edge-function URL convention: ${e.message}`)
+    }
+  }
+}
+
+// 33. SMI-4458 (R-3): PL/pgSQL `RETURNS TABLE(...)` + unqualified `RETURNING`.
+// Catches the SMI-4454 B2 pattern: `claim_device_token` declared
+// `RETURNS TABLE (status TEXT, user_id UUID)` and used `RETURNING user_id`
+// in an UPDATE — Postgres treats TABLE columns as implicit OUT params,
+// making `user_id` ambiguous between the OUT var and the table column. Bug
+// only fires at runtime on the approved-but-unconsumed branch. See migration
+// 083 for the canonical fix (alias the table, qualify the column).
+console.log(`\n${BOLD}33. PL/pgSQL RETURNS TABLE + RETURNING Ambiguity (R-3, SMI-4458)${RESET}`)
+{
+  const migrationsDir = 'supabase/migrations'
+  if (!existsSync(migrationsDir)) {
+    pass('No migrations directory — skipping')
+  } else {
+    try {
+      const migrationFiles = readdirSync(migrationsDir)
+        .filter((f) => f.endsWith('.sql'))
+        .map((f) => join(migrationsDir, f))
+      const migrationsByPath = {}
+      for (const f of migrationFiles) migrationsByPath[f] = readFileSync(f, 'utf8')
+      const violations = findReturningTableAmbiguity(migrationsByPath)
+      if (violations.length === 0) {
+        pass(
+          `No PL/pgSQL RETURNS TABLE + unqualified RETURNING ambiguity across ${migrationFiles.length} migration(s)`
+        )
+      } else {
+        const formatted = violations
+          .map(
+            (v) =>
+              `  ${v.file}:${v.line} — ${v.fnName}() RETURNING ${v.col} (also a TABLE OUT column)\n    ${v.snippet}`
+          )
+          .join('\n')
+        fail(
+          `PL/pgSQL RETURNS TABLE + unqualified RETURNING detected (ambiguous between OUT var and column):\n${formatted}`,
+          `Alias the table and schema-qualify the RETURNING column. Example: \`UPDATE foo f SET ... RETURNING f.<col> INTO ...\`. The audit walks migrations in version order and only flags the LATEST definition of each function — a later migration with the fix supersedes an earlier broken one.`
+        )
+      }
+    } catch (e) {
+      warn(`Could not check PL/pgSQL RETURNING ambiguity: ${e.message}`)
     }
   }
 }

--- a/scripts/tests/audit-standards-trifecta.test.ts
+++ b/scripts/tests/audit-standards-trifecta.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Tests for SMI-4456 / SMI-4457 / SMI-4458 audit-standards backstops.
+ *
+ * R-1: extractCliCommandNames + findCliHintCommandRefs (SMI-4456)
+ * R-2: findRelativeFunctionsV1Urls (SMI-4457)
+ * R-3: findReturningTableAmbiguity (SMI-4458)
+ *
+ * Lives in its own file (not audit-standards.test.ts) to keep both files
+ * under the 500-line pre-commit gate. Same dynamic-ESM-import convention
+ * as the original.
+ */
+import { describe, expect, it } from 'vitest'
+
+const helpers = (await import('../audit-standards-helpers.mjs')) as {
+  extractCliCommandNames: (indexSrc: string, commandSources: Record<string, string>) => Set<string>
+  findCliHintCommandRefs: (cliSrcByPath: Record<string, string>) => Array<{
+    file: string
+    line: number
+    refToken: string
+    fullMatch: string
+  }>
+  findRelativeFunctionsV1Urls: (websiteSrcByPath: Record<string, string>) => Array<{
+    file: string
+    line: number
+    snippet: string
+  }>
+  findReturningTableAmbiguity: (migrationsByPath: Record<string, string>) => Array<{
+    file: string
+    line: number
+    fnName: string
+    col: string
+    snippet: string
+  }>
+}
+
+const {
+  extractCliCommandNames,
+  findCliHintCommandRefs,
+  findRelativeFunctionsV1Urls,
+  findReturningTableAmbiguity,
+} = helpers
+
+describe('extractCliCommandNames (R-1, SMI-4456)', () => {
+  it('extracts program.command(...) registrations from index', () => {
+    const indexSrc = `
+      program.command('import').description('foo')
+      program.addCommand(createSearchCommand())
+    `
+    const commandSources = {
+      '/cli/src/commands/search.ts': `export function createSearchCommand() { return new Command('search') }`,
+    }
+    const names = extractCliCommandNames(indexSrc, commandSources)
+    expect(names.has('import')).toBe(true)
+    expect(names.has('search')).toBe(true)
+  })
+
+  it('captures .name() overrides applied at addCommand time', () => {
+    const indexSrc = `
+      program.addCommand(createInitCommand().name('init'))
+      program.addCommand(createValidateCommand().name('validate'))
+    `
+    const names = extractCliCommandNames(indexSrc, {})
+    expect(names.has('init')).toBe(true)
+    expect(names.has('validate')).toBe(true)
+  })
+
+  it('captures .alias(...) declarations in command factories', () => {
+    const commandSources = {
+      '/cli/src/commands/manage.ts': `
+        return new Command('list').alias('ls')
+        return new Command('remove').alias('rm').alias('uninstall')
+      `,
+    }
+    const names = extractCliCommandNames('', commandSources)
+    expect(names.has('list')).toBe(true)
+    expect(names.has('ls')).toBe(true)
+    expect(names.has('rm')).toBe(true)
+    expect(names.has('uninstall')).toBe(true)
+  })
+
+  it('ignores command names that appear inside comments', () => {
+    const commandSources = {
+      '/cli/src/commands/foo.ts': `
+        // new Command('skills') — comment-cited name should NOT register
+        return new Command('foo')
+      `,
+    }
+    const names = extractCliCommandNames('', commandSources)
+    expect(names.has('foo')).toBe(true)
+    expect(names.has('skills')).toBe(false)
+  })
+})
+
+describe('findCliHintCommandRefs (R-1, SMI-4456)', () => {
+  it('detects "Try it: skillsmith <subcmd>" hints', () => {
+    const cliSrcByPath = {
+      '/cli/src/commands/login.ts': `
+        console.log(chalk.green('Logged in successfully.'))
+        console.log(chalk.dim('  Try it: skillsmith search mcp'))
+        process.exit(0)
+      `,
+    }
+    const refs = findCliHintCommandRefs(cliSrcByPath)
+    expect(refs).toHaveLength(1)
+    expect(refs[0].refToken).toBe('search')
+    expect(refs[0].file).toBe('/cli/src/commands/login.ts')
+  })
+
+  it('detects all four hint markers across skillsmith and sklx', () => {
+    const cliSrcByPath = {
+      '/cli/src/foo.ts': `
+        // Try it: skillsmith should-be-skipped — comment line
+        log('Run: skillsmith install foo')
+        log('Visit: sklx info bar')
+        log('Use: skillsmith pin bar')
+        log('Try it: sklx search baz')
+      `,
+    }
+    const refs = findCliHintCommandRefs(cliSrcByPath)
+    const tokens = refs.map((r) => r.refToken).sort()
+    expect(tokens).toEqual(['info', 'install', 'pin', 'search'])
+  })
+
+  it('SMI-4454 B3 regression case: "skills list" not in registered set', () => {
+    const cliSrcByPath = {
+      '/cli/src/commands/login.ts': `console.log('  Try it: skillsmith skills list')`,
+    }
+    const registered = new Set(['login', 'search', 'list', 'logout'])
+    const refs = findCliHintCommandRefs(cliSrcByPath)
+    const violations = refs.filter((r) => !registered.has(r.refToken))
+    expect(violations).toHaveLength(1)
+    expect(violations[0].refToken).toBe('skills')
+  })
+
+  it('SMI-4454 B3 fix passes: "search mcp" is registered', () => {
+    const cliSrcByPath = {
+      '/cli/src/commands/login.ts': `console.log('  Try it: skillsmith search mcp')`,
+    }
+    const registered = new Set(['login', 'search', 'list', 'logout'])
+    const refs = findCliHintCommandRefs(cliSrcByPath)
+    const violations = refs.filter((r) => !registered.has(r.refToken))
+    expect(violations).toHaveLength(0)
+  })
+})
+
+describe('findRelativeFunctionsV1Urls (R-2, SMI-4457)', () => {
+  it('flags relative /functions/v1/ string literals', () => {
+    const websiteSrcByPath = {
+      '/website/src/pages/device.astro': `
+        const PREVIEW_URL = '/functions/v1/auth-device-preview'
+        const APPROVE_URL = "/functions/v1/auth-device-approve"
+      `,
+    }
+    const violations = findRelativeFunctionsV1Urls(websiteSrcByPath)
+    expect(violations).toHaveLength(2)
+    expect(violations[0].file).toBe('/website/src/pages/device.astro')
+  })
+
+  it('passes the canonical absolute pattern (PR #757 fix)', () => {
+    const websiteSrcByPath = {
+      '/website/src/pages/device.astro': `
+        const API_BASE = import.meta.env.PUBLIC_API_BASE_URL || 'https://api.skillsmith.app'
+        const PREVIEW_URL = \`\${API_BASE}/functions/v1/auth-device-preview\`
+      `,
+    }
+    const violations = findRelativeFunctionsV1Urls(websiteSrcByPath)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('skips comment lines that mention /functions/v1/', () => {
+    const websiteSrcByPath = {
+      '/website/src/foo.ts': `
+        // The endpoint at '/functions/v1/foo' is the legacy form — DO NOT use
+        const URL = \`\${API_BASE}/functions/v1/foo\`
+      `,
+    }
+    const violations = findRelativeFunctionsV1Urls(websiteSrcByPath)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('reports file:line for every violation', () => {
+    const websiteSrcByPath = {
+      '/website/src/a.ts': `
+        const x = 1
+        const y = '/functions/v1/foo'
+        const z = 3
+      `,
+    }
+    const violations = findRelativeFunctionsV1Urls(websiteSrcByPath)
+    expect(violations).toHaveLength(1)
+    expect(violations[0].line).toBe(3)
+  })
+})
+
+describe('findReturningTableAmbiguity (R-3, SMI-4458)', () => {
+  it('flags unqualified RETURNING <col> matching a TABLE OUT name', () => {
+    const migration = `
+      CREATE OR REPLACE FUNCTION public.foo(p TEXT)
+      RETURNS TABLE (status TEXT, user_id UUID)
+      LANGUAGE plpgsql
+      AS $$
+      DECLARE
+        v_claimed UUID;
+      BEGIN
+        UPDATE public.t
+           SET consumed_at = NOW()
+         WHERE x = p
+        RETURNING user_id INTO v_claimed;
+      END;
+      $$;
+    `
+    const violations = findReturningTableAmbiguity({ '081_foo.sql': migration })
+    expect(violations).toHaveLength(1)
+    expect(violations[0].fnName).toBe('public.foo')
+    expect(violations[0].col).toBe('user_id')
+  })
+
+  it('passes when RETURNING column is qualified with table alias', () => {
+    const migration = `
+      CREATE OR REPLACE FUNCTION public.foo(p TEXT)
+      RETURNS TABLE (status TEXT, user_id UUID)
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        UPDATE public.t AS dc
+           SET consumed_at = NOW()
+         WHERE dc.x = p
+        RETURNING dc.user_id INTO v_claimed;
+      END;
+      $$;
+    `
+    const violations = findReturningTableAmbiguity({ '081_foo.sql': migration })
+    expect(violations).toHaveLength(0)
+  })
+
+  it('lets a later migration supersede an earlier broken definition (SMI-4454 B2 fix)', () => {
+    const broken = `
+      CREATE OR REPLACE FUNCTION public.claim(p TEXT)
+      RETURNS TABLE (status TEXT, user_id UUID)
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        UPDATE public.t SET y = NOW() WHERE x = p
+        RETURNING user_id INTO v_claimed;
+      END;
+      $$;
+    `
+    const fixed = `
+      CREATE OR REPLACE FUNCTION public.claim(p TEXT)
+      RETURNS TABLE (status TEXT, user_id UUID)
+      LANGUAGE plpgsql
+      AS $function$
+      BEGIN
+        UPDATE public.t dc SET y = NOW() WHERE dc.x = p
+        RETURNING dc.user_id INTO v_claimed;
+      END;
+      $function$;
+    `
+    expect(
+      findReturningTableAmbiguity({ '081_first.sql': broken, '083_fix.sql': fixed })
+    ).toHaveLength(0)
+  })
+
+  it('flags when later migration does NOT supersede the broken function', () => {
+    const broken = `
+      CREATE OR REPLACE FUNCTION public.foo(p TEXT)
+      RETURNS TABLE (status TEXT, user_id UUID)
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        UPDATE public.t SET y = NOW() WHERE x = p
+        RETURNING user_id INTO v_claimed;
+      END;
+      $$;
+    `
+    const unrelated = `CREATE INDEX idx_foo ON public.t (x);`
+    const violations = findReturningTableAmbiguity({
+      '081_broken.sql': broken,
+      '084_other.sql': unrelated,
+    })
+    expect(violations).toHaveLength(1)
+    expect(violations[0].fnName).toBe('public.foo')
+  })
+
+  it('handles $function$ dollar-quoting tag (matches migration 083)', () => {
+    const migration = `
+      CREATE OR REPLACE FUNCTION public.foo(p TEXT)
+      RETURNS TABLE (status TEXT, user_id UUID)
+      LANGUAGE plpgsql
+      AS $function$
+      BEGIN
+        UPDATE public.t SET y = NOW() WHERE x = p
+        RETURNING user_id INTO v_claimed;
+      END;
+      $function$;
+    `
+    const violations = findReturningTableAmbiguity({ '083_foo.sql': migration })
+    expect(violations).toHaveLength(1)
+    expect(violations[0].col).toBe('user_id')
+  })
+
+  it('correctly attributes violations across adjacent functions (parser regression)', () => {
+    const migration = `
+      CREATE OR REPLACE FUNCTION public.approve(p TEXT)
+      RETURNS jsonb
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        RETURN '{}'::jsonb;
+      END;
+      $$;
+
+      CREATE OR REPLACE FUNCTION public.claim(p TEXT)
+      RETURNS TABLE (status TEXT, user_id UUID)
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        UPDATE public.t SET y = NOW() WHERE x = p
+        RETURNING user_id INTO v_claimed;
+      END;
+      $$;
+    `
+    const violations = findReturningTableAmbiguity({ '081_two_fns.sql': migration })
+    expect(violations).toHaveLength(1)
+    expect(violations[0].fnName).toBe('public.claim')
+  })
+
+  it('skips RETURNING in SQL line comments', () => {
+    const migration = `
+      CREATE OR REPLACE FUNCTION public.foo(p TEXT)
+      RETURNS TABLE (status TEXT, user_id UUID)
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        -- RETURNING user_id INTO x  -- comment, not real code
+        UPDATE public.t SET y = NOW() WHERE x = p
+        RETURNING dc.user_id INTO v_claimed;
+      END;
+      $$;
+    `
+    const violations = findReturningTableAmbiguity({ '081_foo.sql': migration })
+    expect(violations).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

Adds three static-analysis checks to `scripts/audit-standards.mjs` that catch the SMI-4454 surface-drift bug class from the post-merge bug trifecta retro:

- **R-1 (SMI-4456)** — CLI hint command-existence. Scans `packages/cli/src/**/*.ts` for `Try it/Run/Visit/Use: skillsmith|sklx <subcmd>` hints and asserts the cited subcommand is registered via Commander.js (`.command` / `.addCommand` / `.name` / `.alias`). Catches B3.
- **R-2 (SMI-4457)** — forbid relative `/functions/v1/` URLs in website client code. Greps `packages/website/src/**/*.{astro,ts}`. Astro SSR resolves these against `www.skillsmith.app` (404). Canonical pattern from PR #757 uses `import.meta.env.PUBLIC_API_BASE_URL`. Catches B1.
- **R-3 (SMI-4458)** — PL/pgSQL `RETURNS TABLE` + unqualified `RETURNING` ambiguity. Walks `supabase/migrations/*.sql` in version order, tracks the latest `CREATE OR REPLACE FUNCTION` definition per fn name, flags unqualified `RETURNING <col>` matching one of the function's TABLE output columns. Migration 083 supersedes 081's broken form so the audit passes on main. Handles `$$` and `$function$` dollar-quoting. Catches B2.

Pure helpers live in `scripts/audit-standards-helpers.mjs`; 19 unit tests cover happy path, the B1/B2/B3 regression cases, and a parser regression for adjacent-function attribution.

R-1 will FAIL on CI here until #759 (CLI hint source fix) merges to main — that's the design: R-1 is correctly catching the still-broken `Try it: skillsmith skills list` source on main. After #759 merges, rebase this PR and R-1 will pass.

## Test plan

- [x] `npm run audit:standards` — sections 31/32/33 added, helpers wired
- [x] `npx vitest run scripts/tests/audit-standards-trifecta.test.ts` — 19 tests pass locally
- [x] R-1 self-test: regression case asserts `skills list` fires; fix case asserts `search mcp` passes
- [x] R-2 self-test: regression case asserts relative URL fires; canonical-pattern case passes
- [x] R-3 self-test: regression case fires; supersession by later migration silences it

Refs: `docs/internal/retros/2026-04-24-smi-4454-post-merge-bug-trifecta.md`

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)