### PR TITLE
feat(ci): SMI-4459 post-deploy smoke harness

### DIFF
--- a/.claude/development/smoke-prod-guide.md
+++ b/.claude/development/smoke-prod-guide.md
@@ -1,0 +1,151 @@
+# Smoke-prod harness — operator guide
+
+Post-deploy smoke harness for verifying user-facing surfaces against real
+prod after a merge. Implements layer 4 of the SMI-4454 trifecta gate stack
+(R-1/R-2/R-3 are static-analysis backstops; R-4/runtime smoke is here).
+
+Plan: `docs/internal/implementation/smi-4459-smoke-prod-harness.md`
+Linear: SMI-4459
+
+## What it does
+
+After every merge to main, the workflow `.github/workflows/smoke-prod.yml`
+runs `scripts/smoke-prod.sh` against real prod URLs. Each surface declared
+in `scripts/smoke-prod/surfaces.json` whose `trigger_globs` match a changed
+file is exercised end-to-end. Always-on canaries (e.g. `health`) run on
+every PR's pre-ship CI gate plus every post-deploy run.
+
+Total budget: 60s. Per-call HTTP timeout: 10s. Retry policy: single retry
+with 2s backoff per call. Exit codes: `0` ok, `1` fail, `2` skipped.
+
+## Surfaces covered
+
+| ID | What it checks | Trigger |
+|----|----------------|---------|
+| `health` | `GET $SUPABASE_URL/functions/v1/health` returns 200 | always-on canary |
+| `website-device-page` | `GET https://www.skillsmith.app/device` returns 200 + contains `data-smoke="device-input"` | `packages/website/src/pages/device.astro` change |
+| `edge-fn-auth-device` | `auth-device-code` POST → 200/400 (NOT 404); `auth-device-preview` GET (no JWT) → 401 | `supabase/functions/auth-device-{code,preview,approve,token}/**` change |
+| `cli-published` | `npx -y @skillsmith/cli@latest --help` exits 0 with a `Commands:` section; `--version` exits 0 | `packages/cli/**` change |
+| `mcp-server-published` | `npx -y @skillsmith/mcp-server@latest --version` exits 0 | `packages/mcp-server/**` change |
+
+## Adding a new surface
+
+1. Pick a stable assertion target. For Astro pages, prefer
+   `data-smoke="<id>"` HTML attributes — class names hash per build.
+2. Append an entry to `scripts/smoke-prod/surfaces.json`:
+
+   ```json
+   {
+     "id": "my-new-surface",
+     "owner": "team-name",
+     "trigger_globs": ["packages/website/src/pages/my-page.astro"],
+     "script": "scripts/smoke-prod/website.sh",
+     "checks": ["check_my_new_surface"]
+   }
+   ```
+
+3. Add the check function to the referenced script. Convention:
+
+   ```bash
+   check_my_new_surface() {
+     local url="${SMOKE_WEBSITE_URL}/my-page"
+     local t0 status
+     t0=$(now_ms)
+     status=$(with_retry http_status GET "$url")
+     if [ "$status" = "200" ]; then
+       report_pass "my-new-surface" "check_my_new_surface" "$url" "$(($(now_ms) - t0))"
+       return 0
+     fi
+     report_fail "my-new-surface" "check_my_new_surface" "$url" "200" "$status" "$(($(now_ms) - t0))"
+     return 1
+   }
+   ```
+
+4. Verify locally:
+
+   ```bash
+   varlock run -- ./scripts/smoke-prod.sh --surface=my-new-surface
+   ```
+
+5. The `audit:standards` Section 34 (R-4) will warn if a new edge function
+   or website page lands without a corresponding entry. To intentionally
+   omit, add the path to `scripts/smoke-prod/.surfaces-allowlist.txt`.
+
+## Testing locally
+
+```bash
+# Dry-run — show which surfaces would fire for a synthetic file change.
+SMOKE_CHANGED_FILES="packages/website/src/pages/device.astro" \
+  ./scripts/smoke-prod.sh --dry-run --json
+
+# Real canary against prod (~1s).
+varlock run -- ./scripts/smoke-prod.sh --surface=health
+
+# Full smoke against prod for the current HEAD vs HEAD~1.
+varlock run -- ./scripts/smoke-prod.sh --since=HEAD~1 --json
+```
+
+## Failure triage
+
+When the workflow fails it:
+
+1. Opens (or comments on) a Linear-tracking GitHub issue titled
+   `Smoke-prod failure on <short-sha>` labelled `ci-failure`,`smoke-failure`.
+2. Posts an email to `support@smithhorn.ca` via the `alert-notify` edge
+   function, describing the failed surfaces + URLs + status codes.
+
+Triage steps:
+
+1. **Open the run**: download the `smoke-report` artifact (JSON).
+2. **Reproduce locally**: `varlock run -- ./scripts/smoke-prod.sh --surface=<id>`.
+3. **Classify**:
+   - HTTP 000 / curl error → transient blip; re-run via `gh workflow run smoke-prod.yml`.
+   - HTTP wrong-status / body-fingerprint missing → real regression; revert
+     or hotfix.
+   - Assertion is wrong (smoke-harness bug) → fix the check function;
+     deploy is fine.
+
+## Skipping smoke for a PR
+
+Add `[skip-smoke]` to the PR body OR the merge commit message. The smoke
+workflow scans both. Use sparingly — docs-only PRs don't trigger most
+surfaces anyway (changed-file globbing skips them).
+
+## Manual setup steps
+
+The workflow needs three GitHub Actions secrets, all already present in
+the repo for adjacent jobs:
+
+- `SUPABASE_URL` — used by the `smoke` job for read-only HTTP checks.
+- `SUPABASE_ANON_KEY` — currently unused but reserved for future
+  authenticated smoke (e.g., low-quota anon-key endpoint).
+- `SUPABASE_SERVICE_ROLE_KEY` — used by the `alert` job ONLY (separate
+  job for secret scoping; service-role key never enters the smoke job).
+
+To enable Vercel-deploy-completion triggering, configure a Vercel deploy
+hook that POSTs to GitHub `repository_dispatch` with `event_type:
+vercel-prod-deployed`. See `vercel-deploy-hook.md` for the runbook.
+
+## Phase rollout
+
+- **Phase 1 (week 1)**: warning-only. Workflow runs, files Linear issue
+  on failure, but does NOT post a commit status. Goal: collect 1 week of
+  false-positive data before going load-bearing.
+- **Phase 2 (week 2-3)**: posts `success`/`failure` commit status to the
+  merge SHA so it surfaces visibly on the GitHub UI. No branch protection
+  change (smoke runs after merge).
+- **Phase 3 (later)**: pre-merge variant against staging. Tracked
+  separately under a follow-up SMI per plan-review Q6.
+
+## Telemetry
+
+Every smoke run writes to `audit_logs` with `event_type='smoke:run'` (this
+hook will be wired in a Phase 2 follow-up; current Phase 1 implementation
+relies on the GitHub Actions run history).
+
+The weekly `ops-report` cron will summarize catch rate vs. false-positive
+rate after 4 weeks of data. Targets:
+
+- Catch rate (smoke failure followed by a bugfix PR within 24h): > 0
+  (zero means the harness scope is too shallow).
+- False-positive rate (smoke failure closed as transient/no-fix): < 10%.

--- a/.claude/development/vercel-deploy-hook.md
+++ b/.claude/development/vercel-deploy-hook.md
@@ -1,0 +1,77 @@
+# Vercel deploy hook → smoke-prod trigger
+
+The smoke-prod workflow (`.github/workflows/smoke-prod.yml`) needs to fire
+after Vercel finishes deploying the website. Vercel's webhook surface does
+not natively trigger GitHub workflows, so we route through GitHub's
+`repository_dispatch` API.
+
+Plan: `docs/internal/implementation/smi-4459-smoke-prod-harness.md` § Q1
+Linear: SMI-4459
+
+## One-time setup
+
+Two pieces, both manual:
+
+### 1. GitHub fine-grained PAT for `repository_dispatch`
+
+- Create a fine-grained PAT scoped to the `smith-horn/skillsmith`
+  repository with **only** `Contents: read-only` and `Metadata: read-only`
+  + `Actions: read-and-write`. Expire after 90 days.
+- Store the value in `gh secret set VERCEL_DEPLOY_HOOK_TOKEN` so the
+  hook (whether a Vercel webhook or a GitHub Actions repository_dispatch
+  caller) can authenticate. Note: the workflow itself does NOT consume
+  this token; the secret exists only so the hook caller can be
+  authenticated. GitHub's `repository_dispatch` API requires
+  `Authorization: Bearer <PAT>` from the caller.
+
+```bash
+gh secret set VERCEL_DEPLOY_HOOK_TOKEN < /tmp/pat.txt
+gh secret list  # verify it landed
+```
+
+### 2. Vercel deploy webhook
+
+In the Vercel dashboard for the `skillsmith-website` project:
+
+- Settings → Webhooks → Create Webhook.
+- URL: a small Vercel Function (or a public Worker) that translates the
+  Vercel webhook payload to a GitHub `repository_dispatch` POST. Sample
+  curl the function should make:
+
+  ```bash
+  curl -fsS -X POST \
+    -H "Authorization: Bearer ${GITHUB_PAT}" \
+    -H "Accept: application/vnd.github+json" \
+    https://api.github.com/repos/smith-horn/skillsmith/dispatches \
+    -d '{"event_type":"vercel-prod-deployed","client_payload":{"sha":"<deployment.commitSha>"}}'
+  ```
+
+- Filter event: `deployment.succeeded` AND `target == production`.
+- Confirm with a test deploy: a healthy run shows up in the Actions tab
+  under "Smoke Prod" within ~30s of Vercel reporting the deploy
+  succeeded.
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Smoke workflow never fires after Vercel deploy | Webhook not configured or PAT expired | Verify webhook in Vercel dashboard; rotate PAT (`gh secret set ...`) |
+| Smoke fires for staging deploys too | Webhook missing `target == production` filter | Tighten the filter |
+| Smoke fires twice per merge | Both `Deploy Edge Functions` workflow_run AND vercel hook fired | Acceptable — `concurrency` group dedupes within a SHA window |
+
+## Rotation
+
+The PAT expires every 90 days. To rotate:
+
+1. Generate a fresh fine-grained PAT with the same scopes.
+2. Update the GitHub Actions secret: `gh secret set VERCEL_DEPLOY_HOOK_TOKEN`.
+3. Update the Vercel webhook caller (Vercel Function env var) with the
+   new PAT.
+4. Trigger a no-op website redeploy and confirm smoke fires.
+
+## Out of scope
+
+- Multi-region Vercel deploys (each emits its own webhook; concurrency
+  group dedupes).
+- Preview deploys (only production triggers smoke; preview is gated by
+  the existing `e2e-tests.yml` against the preview URL).

--- a/.claude/development/vercel-deploy-hook.md
+++ b/.claude/development/vercel-deploy-hook.md
@@ -15,8 +15,8 @@ Two pieces, both manual:
 ### 1. GitHub fine-grained PAT for `repository_dispatch`
 
 - Create a fine-grained PAT scoped to the `smith-horn/skillsmith`
-  repository with **only** `Contents: read-only` and `Metadata: read-only`
-  + `Actions: read-and-write`. Expire after 90 days.
+  repository with **only** `Contents: read-only`, `Metadata: read-only`,
+  and `Actions: read-and-write`. Expire after 90 days.
 - Store the value in `gh secret set VERCEL_DEPLOY_HOOK_TOKEN` so the
   hook (whether a Vercel webhook or a GitHub Actions repository_dispatch
   caller) can authenticate. Note: the workflow itself does NOT consume

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,65 @@ jobs:
             fi
           done
 
+  # SMI-4459: Pre-ship validation for the post-deploy smoke harness.
+  # Runs on every code PR. Asserts:
+  #   - bash -n on smoke-prod.sh + per-surface scripts (syntax)
+  #   - shellcheck (lint; same -S warning level as validate-hooks.yml)
+  #   - --dry-run resolves surfaces from a synthetic changed-file set
+  #   - --surface=health canary against real prod (~1s; proves wiring end-to-end)
+  # The harness itself runs post-deploy via .github/workflows/smoke-prod.yml.
+  smoke-prod-validation:
+    name: Smoke Prod Validation
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: bash -n syntax check
+        run: |
+          bash -n scripts/smoke-prod.sh
+          for f in scripts/smoke-prod/*.sh; do bash -n "$f"; done
+
+      - name: shellcheck
+        run: |
+          # -S warning matches validate-hooks.yml convention; SC1091 (can't
+          # follow source) is unavoidable for sourced lib.sh.
+          shellcheck -S warning \
+            scripts/smoke-prod.sh \
+            scripts/smoke-prod/lib.sh \
+            scripts/smoke-prod/website.sh \
+            scripts/smoke-prod/cli.sh \
+            scripts/smoke-prod/mcp-server.sh \
+            scripts/smoke-prod/alert.sh
+
+      - name: surfaces.json valid JSON
+        run: |
+          jq empty scripts/smoke-prod/surfaces.json
+          jq -e '.surfaces | length > 0' scripts/smoke-prod/surfaces.json
+
+      - name: --dry-run resolves canary
+        run: |
+          set -euo pipefail
+          OUT=$(SMOKE_CHANGED_FILES="docs/foo.md" ./scripts/smoke-prod.sh --dry-run --json)
+          echo "$OUT" | jq -e '.matched_surfaces | index("health")' >/dev/null
+
+      - name: --surface=health canary against prod
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+        run: |
+          # Skip if SUPABASE_URL secret is unavailable (forks). The harness
+          # exits 1 with a clear message in that case; in-tree PRs always
+          # have it.
+          if [ -z "${SUPABASE_URL:-}" ]; then
+            echo "::warning::SUPABASE_URL not available — skipping prod canary (likely a fork)"
+            exit 0
+          fi
+          ./scripts/smoke-prod.sh --surface=health --json
+
   # SMI-2595: Validate migration SQL for common issues
   # Catches type mismatches, missing search_path, pg_safeupdate violations
   # Only runs when migration files are changed

--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -1,0 +1,211 @@
+# SMI-4459 — post-deploy smoke harness.
+# Triggers AFTER edge-function deploys finish (workflow_run completion) and
+# after Vercel deploys (repository_dispatch from the Vercel deploy hook).
+# See docs/internal/implementation/smi-4459-smoke-prod-harness.md for the
+# full plan and .claude/development/smoke-prod-guide.md for the operator
+# runbook.
+#
+# Two-job split for secret scoping:
+#   - smoke: SUPABASE_URL + SUPABASE_ANON_KEY only (read-only).
+#   - alert: SUPABASE_SERVICE_ROLE_KEY only (alert-notify POST). Runs on
+#            failure of smoke and only sees the report artifact, not the
+#            harness internals.
+#
+# Phase 1 (week 1, starting on merge): warning-only — no commit-status
+# post; just open a Linear issue + email on failure. Phase 2 wires the
+# commit status. Phase 3 splits a staging variant (separate SMI).
+name: Smoke Prod
+
+on:
+  workflow_run:
+    workflows: ['Deploy Edge Functions', 'CI']
+    types: [completed]
+    branches: [main]
+  repository_dispatch:
+    types: [vercel-prod-deployed]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'SHA to smoke (default: latest main)'
+        required: false
+        type: string
+      surface:
+        description: 'Run a single surface only (default: all matched)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: smoke-prod-${{ github.event.workflow_run.head_sha || github.event.client_payload.sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Skip if the upstream workflow_run failed (no point smoking a broken
+    # deploy). repository_dispatch and workflow_dispatch always run.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'repository_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    outputs:
+      passed: ${{ steps.run.outputs.passed }}
+      report_path: ${{ steps.run.outputs.report_path }}
+    steps:
+      - name: Determine target SHA
+        id: sha
+        env:
+          WF_SHA: ${{ github.event.workflow_run.head_sha }}
+          DISPATCH_SHA: ${{ github.event.client_payload.sha }}
+          INPUT_SHA: ${{ inputs.sha }}
+        run: |
+          set -euo pipefail
+          TARGET_SHA="${INPUT_SHA:-${DISPATCH_SHA:-${WF_SHA:-}}}"
+          if [ -z "$TARGET_SHA" ]; then TARGET_SHA="${{ github.sha }}"; fi
+          echo "sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+          echo "Target SHA: $TARGET_SHA"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.sha.outputs.sha }}
+          fetch-depth: 2
+
+      - name: Detect [skip-smoke] marker
+        id: skip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Check the merge commit message + any associated PR body.
+          if git log -1 --pretty=%B "$TARGET_SHA" | grep -q '\[skip-smoke\]'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Found [skip-smoke] in commit message"
+            exit 0
+          fi
+          PR_NUM=$(gh pr list --search "$TARGET_SHA" --state merged --json number --jq '.[0].number // empty' || true)
+          if [ -n "$PR_NUM" ]; then
+            BODY=$(gh pr view "$PR_NUM" --json body --jq '.body // ""' || true)
+            if printf '%s' "$BODY" | grep -q '\[skip-smoke\]'; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "Found [skip-smoke] in PR #$PR_NUM body"
+              exit 0
+            fi
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Run smoke harness
+        id: run
+        if: steps.skip.outputs.skip != 'true'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          set -euo pipefail
+          REPORT="$RUNNER_TEMP/smoke-report.json"
+          ARGS=(--since=HEAD~1 --json --report="$REPORT")
+          if [ -n "${{ inputs.surface }}" ]; then
+            ARGS+=(--surface="${{ inputs.surface }}")
+          fi
+          set +e
+          ./scripts/smoke-prod.sh "${ARGS[@]}"
+          RC=$?
+          set -e
+          echo "report_path=$REPORT" >> "$GITHUB_OUTPUT"
+          if [ "$RC" = "0" ]; then
+            echo "passed=true" >> "$GITHUB_OUTPUT"
+          elif [ "$RC" = "2" ]; then
+            echo "passed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No surfaces matched (exit 2) — skipping"
+          else
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Upload report artifact
+        if: always() && steps.skip.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-report
+          path: ${{ runner.temp }}/smoke-report.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+  alert:
+    name: Alert on Failure
+    needs: smoke
+    if: failure() && needs.smoke.result == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Download smoke report
+        uses: actions/download-artifact@v4
+        with:
+          name: smoke-report
+          path: ${{ runner.temp }}/
+
+      - name: Post alert + open/update Linear-tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          set -euo pipefail
+          REPORT="$RUNNER_TEMP/smoke-report.json"
+          if [ ! -f "$REPORT" ]; then
+            echo "::error::report missing — cannot alert"
+            exit 1
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
+          SHORT_SHA="${SHA:0:8}"
+
+          # Idempotency: one issue per merge SHA. Adopts the
+          # post-merge-verify.yml lines 70-95 pattern (find-existing,
+          # comment-or-create) so workflow re-runs don't fan-out duplicate
+          # issues. See SMI-4459 plan § Wave 4 idempotency.
+          TITLE="Smoke-prod failure on $SHORT_SHA"
+          BODY="$(cat <<EOF
+          Smoke-prod failed on \`$SHORT_SHA\`.
+
+          - Run: $RUN_URL
+          - Triggered by: ${{ github.event.workflow_run.name || github.event_name }}
+          - Report artifact: smoke-report (download from the run)
+
+          See \`.claude/development/smoke-prod-guide.md\` for triage steps.
+          EOF
+          )"
+          EXISTING=$(gh issue list \
+            --label smoke-failure \
+            --state open \
+            --search "$TITLE in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Commenting on existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            echo "Filing new auto-issue"
+            gh issue create \
+              --title "$TITLE ($RUN_URL)" \
+              --body "$BODY" \
+              --label ci-failure,smoke-failure
+          fi
+
+          # Email via alert-notify (uses service-role key, scoped to this job).
+          ./scripts/smoke-prod/alert.sh \
+            --report "$REPORT" \
+            --run-url "$RUN_URL" \
+            --sha "$SHORT_SHA" || echo "::warning::alert.sh failed; issue still filed"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -52,6 +52,12 @@ description = "Vercel Token"
 regex = '''["\']?[a-zA-Z0-9]{24}["\']?'''
 tags = ["api", "vercel"]
 keywords = ["VERCEL_TOKEN", "vercel"]
+[[rules.allowlists]]
+description = "Allow SHA-pinned GitHub Actions `uses: org/action@<40-hex>` references; SMI-4459 fix"
+regexTarget = "line"
+regexes = [
+  '''uses:\s+[a-zA-Z0-9._/-]+@[a-f0-9]{40}''',
+]
 
 [[rules]]
 id = "clerk-secret"
@@ -103,6 +109,7 @@ regexes = [
   # False positive: handleCorsPreflightRequest function name contains 24+ alphanumeric
   # substring that matches the broad vercel-token rule regex [a-zA-Z0-9]{24}
   '''handleCorsPreflight''',
+
 ]
 
 # Allow specific files that contain examples or tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ Detailed guides extracted via progressive disclosure. CLAUDE.md contains essenti
 | [subagent-tool-permissions-guide.md](.claude/development/subagent-tool-permissions-guide.md) | Subagent tool access by type, foreground/background behavior, skill author checklist |
 | [supabase-migration-safety.md](.claude/development/supabase-migration-safety.md) | Pre/post-apply query catalog, ACCESS EXCLUSIVE lock discipline, rollback convention, pooler rules. Invoke via `supabase-migration-reviewer` skill for automated review. |
 | [ruvector-dev-tooling.md](.claude/development/ruvector-dev-tooling.md) | `skillsmith-doc-retrieval` MCP — local semantic doc search (SMI-4417). Setup, tool surface, privacy boundary, post-commit hook, token-delta gate. |
+| [smoke-prod-guide.md](.claude/development/smoke-prod-guide.md) | Post-deploy smoke harness (SMI-4459). Surface manifest, adding new surfaces, failure triage, phase rollout. |
+| [vercel-deploy-hook.md](.claude/development/vercel-deploy-hook.md) | One-time Vercel→GitHub `repository_dispatch` setup that triggers `smoke-prod.yml` after a website deploy. |
 
 **Implementation plan template**: [.claude/templates/implementation-plan.md](.claude/templates/implementation-plan.md) — use this structure for all plans in `docs/internal/implementation/`.
 
@@ -61,6 +63,8 @@ docker exec skillsmith-dev-1 npm run preflight         # All checks before push
 **New source files must be under 500 lines.** Split into companion files (e.g., `foo.helpers.ts`, `foo.types.ts`) if approaching the limit. The `audit:standards` script enforces this.
 
 **When CI fails**: Don't merge. Check logs. Run `docker exec skillsmith-dev-1 npm run preflight` locally. Create Linear issue if non-trivial.
+
+**Post-deploy smoke (SMI-4459)**: `.github/workflows/smoke-prod.yml` runs `scripts/smoke-prod.sh` against real prod after every merge. Each surface in `scripts/smoke-prod/surfaces.json` whose `trigger_globs` match changed files is exercised end-to-end. Failure → Linear issue + email. Skip via `[skip-smoke]` in PR body. Full guide: [smoke-prod-guide.md](.claude/development/smoke-prod-guide.md).
 
 **npm overrides** (transitive vulnerability fixes in root `package.json`):
 

--- a/packages/website/src/pages/device.astro
+++ b/packages/website/src/pages/device.astro
@@ -24,6 +24,7 @@ const rawCode = Astro.url.searchParams.get('user_code')?.trim().toUpperCase() ??
         <label for="user-code-input" class="field-label">Approval code</label>
         <input
           id="user-code-input"
+          data-smoke="device-input"
           type="text"
           inputmode="text"
           autocomplete="one-time-code"

--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -475,3 +475,45 @@ export const findReturningTableAmbiguity = (migrationsByPath) => {
   }
   return violations
 }
+
+/**
+ * R-4 (SMI-4459): given a list of file paths and a set of trigger globs from
+ * `scripts/smoke-prod/surfaces.json`, return paths NOT covered by any glob
+ * and NOT matched by an allowlist entry. The orchestrator's glob semantics
+ * are mirrored exactly:
+ *   - `prefix/**` matches `prefix/anything/below`
+ *   - `prefix/*`  matches files directly under `prefix/`
+ *   - exact path matches iff equal
+ *
+ * @param {string[]} candidatePaths — paths to check (e.g., every
+ *   `supabase/functions/*\/index.ts` and `packages/website/src/pages/**.astro`).
+ * @param {string[]} surfaceGlobs — flattened set of trigger_globs from all
+ *   surfaces in surfaces.json.
+ * @param {string[]} allowlistGlobs — entries from
+ *   `scripts/smoke-prod/.surfaces-allowlist.txt` (non-empty, non-comment lines).
+ * @returns {string[]} paths that are user-facing but neither covered nor allowlisted.
+ */
+export const findUncoveredSurfacePaths = (candidatePaths, surfaceGlobs, allowlistGlobs) => {
+  const matchesGlob = (file, glob) => {
+    if (glob.endsWith('/**')) {
+      const prefix = glob.slice(0, -3)
+      return file === prefix || file.startsWith(prefix + '/')
+    }
+    if (glob.endsWith('/*')) {
+      const prefix = glob.slice(0, -2)
+      if (!file.startsWith(prefix + '/')) return false
+      const rest = file.slice(prefix.length + 1)
+      return rest.length > 0 && !rest.includes('/')
+    }
+    return file === glob
+  }
+  const matchesAny = (file, globs) => globs.some((g) => matchesGlob(file, g))
+
+  const uncovered = []
+  for (const path of candidatePaths) {
+    if (matchesAny(path, surfaceGlobs)) continue
+    if (matchesAny(path, allowlistGlobs)) continue
+    uncovered.push(path)
+  }
+  return uncovered
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -23,6 +23,7 @@ import {
   findCliHintCommandRefs,
   findRelativeFunctionsV1Urls,
   findReturningTableAmbiguity,
+  findUncoveredSurfacePaths,
 } from './audit-standards-helpers.mjs'
 
 const RED = '\x1b[31m'
@@ -2221,6 +2222,67 @@ console.log(`\n${BOLD}33. PL/pgSQL RETURNS TABLE + RETURNING Ambiguity (R-3, SMI
       }
     } catch (e) {
       warn(`Could not check PL/pgSQL RETURNING ambiguity: ${e.message}`)
+    }
+  }
+}
+
+// 34. SMI-4459 (R-4): every deployed edge function and conversion-critical
+// website page should have a smoke surface in scripts/smoke-prod/surfaces.json
+// (or be explicitly allowlisted in scripts/smoke-prod/.surfaces-allowlist.txt).
+// Warning-only — adding a new edge function is a perfectly valid PR; this
+// just nudges the author to add the smoke entry in the same PR. The R-1/R-2/R-3
+// backstops above catch string-shape drift; R-4 catches "shipped a surface
+// nobody verifies."
+console.log(`\n${BOLD}34. Smoke Surface Coverage (R-4, SMI-4459)${RESET}`)
+{
+  const surfacesJsonPath = 'scripts/smoke-prod/surfaces.json'
+  const allowlistPath = 'scripts/smoke-prod/.surfaces-allowlist.txt'
+  if (!existsSync(surfacesJsonPath)) {
+    pass('surfaces.json not present — skipping (smoke-prod harness not yet wired)')
+  } else {
+    try {
+      const surfaces = JSON.parse(readFileSync(surfacesJsonPath, 'utf8'))
+      const surfaceGlobs = (surfaces.surfaces || []).flatMap((s) => s.trigger_globs || [])
+      let allowlistGlobs = []
+      if (existsSync(allowlistPath)) {
+        allowlistGlobs = readFileSync(allowlistPath, 'utf8')
+          .split('\n')
+          .map((l) => l.trim())
+          .filter((l) => l.length > 0 && !l.startsWith('#'))
+      }
+      // Candidate paths: every supabase/functions/<name>/index.ts AND every
+      // packages/website/src/pages/**/*.astro file. Walk both trees.
+      const candidates = []
+      const fnDir = 'supabase/functions'
+      if (existsSync(fnDir)) {
+        for (const entry of readdirSync(fnDir, { withFileTypes: true })) {
+          if (!entry.isDirectory()) continue
+          if (entry.name.startsWith('_')) continue
+          const idx = `${fnDir}/${entry.name}/index.ts`
+          if (existsSync(idx)) candidates.push(idx)
+        }
+      }
+      const pagesDir = 'packages/website/src/pages'
+      if (existsSync(pagesDir)) {
+        for (const f of getFilesRecursive(pagesDir, ['.astro'])) {
+          candidates.push(f)
+        }
+      }
+      const uncovered = findUncoveredSurfacePaths(candidates, surfaceGlobs, allowlistGlobs)
+      if (candidates.length === 0) {
+        pass('No edge functions or website pages found — skipping')
+      } else if (uncovered.length === 0) {
+        pass(
+          `All ${candidates.length} user-facing surface(s) covered by surfaces.json or allowlist`
+        )
+      } else {
+        const formatted = uncovered.map((p) => `  ${p}`).join('\n')
+        warn(
+          `${uncovered.length} surface(s) not covered by surfaces.json and not allowlisted:\n${formatted}\n  Add a surface entry to scripts/smoke-prod/surfaces.json or document the exclusion in scripts/smoke-prod/.surfaces-allowlist.txt.`
+        )
+      }
+    } catch (e) {
+      warn(`Could not check smoke surface coverage: ${e.message}`)
     }
   }
 }

--- a/scripts/smoke-prod.sh
+++ b/scripts/smoke-prod.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# SMI-4459 — post-deploy smoke harness orchestrator.
+#
+# Usage:
+#   scripts/smoke-prod.sh [--dry-run] [--surface=<id>] [--since=<git-ref>] [--report=<path>]
+#
+# --dry-run        Resolve surfaces from the changed-file set; print the plan;
+#                  do NOT make network calls. Exit 0 on shape-valid plan.
+# --surface=<id>   Run only the named surface (always-run canary still runs).
+# --since=<ref>    Compute changed files via `git diff --name-only <ref> HEAD`.
+#                  Defaults to HEAD~1 in CI; in dev, falls back to "all surfaces".
+# --report=<path>  Write JSON report to this path. Defaults to /dev/null when
+#                  not set; emit JSON to stdout if --json is passed.
+# --json           Emit JSON report to stdout (suppresses table). Compatible
+#                  with --report (writes both).
+#
+# Exit codes:
+#   0 — all matched surfaces passed
+#   1 — one or more failed
+#   2 — opt-out via [skip-smoke] OR no surfaces matched
+#
+# Conventions: ASCII-only output, no `set -x`, 60s total budget enforced
+# via foreground SECONDS check. Per-call HTTP timeouts in lib.sh.
+
+set -euo pipefail
+
+SMOKE_PROD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/smoke-prod"
+# shellcheck disable=SC1091
+. "$SMOKE_PROD_DIR/lib.sh"
+
+DRY_RUN="${SMOKE_DRY_RUN:-0}"
+SINGLE_SURFACE=""
+SINCE_REF=""
+REPORT_PATH=""
+EMIT_JSON=0
+SMOKE_BUDGET_SEC="${SMOKE_BUDGET_SEC:-60}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --surface=*) SINGLE_SURFACE="${1#*=}"; shift ;;
+    --since=*) SINCE_REF="${1#*=}"; shift ;;
+    --report=*) REPORT_PATH="${1#*=}"; shift ;;
+    --json) EMIT_JSON=1; shift ;;
+    -h|--help)
+      sed -n '2,25p' "$0"
+      exit 0
+      ;;
+    *)
+      smoke_warn "unknown arg: $1"
+      exit 2
+      ;;
+  esac
+done
+
+# ---- skip-smoke marker -------------------------------------------------
+if [ -n "${SMOKE_PR_BODY:-}" ] && printf '%s' "$SMOKE_PR_BODY" | grep -q '\[skip-smoke\]'; then
+  smoke_log "PR body contains [skip-smoke] — exit 2"
+  exit 2
+fi
+if git log -1 --pretty=%B 2>/dev/null | grep -q '\[skip-smoke\]'; then
+  smoke_log "merge commit contains [skip-smoke] — exit 2"
+  exit 2
+fi
+
+# ---- load surfaces.json ------------------------------------------------
+SURFACES_JSON="$SMOKE_PROD_DIR/surfaces.json"
+if [ ! -f "$SURFACES_JSON" ]; then
+  smoke_warn "surfaces.json missing at $SURFACES_JSON"
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  smoke_warn "jq required but not installed"
+  exit 1
+fi
+
+# ---- resolve changed-files set ----------------------------------------
+CHANGED_FILES=""
+if [ -n "${SMOKE_CHANGED_FILES:-}" ]; then
+  CHANGED_FILES="$SMOKE_CHANGED_FILES"
+elif [ -n "$SINCE_REF" ]; then
+  if ! CHANGED_FILES=$(git diff --name-only "$SINCE_REF" HEAD 2>/dev/null); then
+    smoke_warn "git diff $SINCE_REF..HEAD failed; defaulting to all surfaces"
+    CHANGED_FILES=""
+  fi
+fi
+
+# ---- match surfaces ----------------------------------------------------
+# Bash glob matching against trigger_globs. `**` is treated as `*` here
+# for simplicity — we expand each glob via shell extglob below. Surfaces
+# with always_run=true match unconditionally.
+
+# Bash 3.2 (macOS default) lacks globstar; we use case-pattern matching
+# (see _glob_matches_any below) and convert `**` → `*` defensively. CI
+# runners (ubuntu-latest) have bash 5.x but we keep the lowest-common-
+# denominator surface so the harness is invokable from a dev box.
+shopt -s extglob nullglob 2>/dev/null || true
+
+_glob_matches_any() {
+  # _glob_matches_any FILE GLOB1 [GLOB2 ...]
+  # Returns 0 if FILE matches any GLOB; else 1.
+  #
+  # Glob semantics (lowest common denominator across bash 3.2 and 5.x):
+  #   - `prefix/**` matches FILE iff FILE startswith `prefix/`
+  #   - `prefix/*`  matches FILE iff FILE startswith `prefix/` AND has no further `/`
+  #   - exact path matches iff FILE equals the glob
+  # No support for inner `*` segments or `?` — surfaces.json sticks to
+  # path-prefix patterns by convention. The R-4 audit-standards check
+  # (Section 34) uses the same matcher to enforce coverage.
+  local file="$1"; shift
+  local g
+  for g in "$@"; do
+    case "$g" in
+      *'/**')
+        local prefix="${g%/**}"
+        case "$file" in
+          "$prefix"/*) return 0 ;;
+          "$prefix") return 0 ;;
+        esac
+        ;;
+      *'/*')
+        local prefix="${g%/*}"
+        # Match files directly under prefix/ (no deeper slashes).
+        local rest="${file#"$prefix"/}"
+        if [ "$rest" != "$file" ] && [ "${rest%%/*}" = "$rest" ]; then
+          return 0
+        fi
+        ;;
+      *)
+        if [ "$file" = "$g" ]; then return 0; fi
+        ;;
+    esac
+  done
+  return 1
+}
+
+# Build the matched-surface set. Output: one surface ID per line.
+_select_surfaces() {
+  local n
+  n=$(jq -r '.surfaces | length' "$SURFACES_JSON")
+  local i=0
+  while [ "$i" -lt "$n" ]; do
+    local id always trigger_count
+    id=$(jq -r ".surfaces[$i].id" "$SURFACES_JSON")
+    always=$(jq -r ".surfaces[$i].always_run // false" "$SURFACES_JSON")
+    if [ -n "$SINGLE_SURFACE" ]; then
+      if [ "$id" = "$SINGLE_SURFACE" ] || [ "$always" = "true" ]; then
+        printf '%s\n' "$id"
+      fi
+      i=$((i + 1))
+      continue
+    fi
+    if [ "$always" = "true" ]; then
+      printf '%s\n' "$id"
+      i=$((i + 1))
+      continue
+    fi
+    if [ -z "$CHANGED_FILES" ]; then
+      # No `--since`/CHANGED_FILES — full-smoke mode (manual run).
+      printf '%s\n' "$id"
+      i=$((i + 1))
+      continue
+    fi
+    trigger_count=$(jq -r ".surfaces[$i].trigger_globs | length" "$SURFACES_JSON")
+    local globs=()
+    local j=0
+    while [ "$j" -lt "$trigger_count" ]; do
+      globs+=("$(jq -r ".surfaces[$i].trigger_globs[$j]" "$SURFACES_JSON")")
+      j=$((j + 1))
+    done
+    local matched=0
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      if _glob_matches_any "$f" "${globs[@]}"; then
+        matched=1
+        break
+      fi
+    done <<< "$CHANGED_FILES"
+    if [ "$matched" = "1" ]; then
+      printf '%s\n' "$id"
+    fi
+    i=$((i + 1))
+  done
+}
+
+MATCHED=$(_select_surfaces | sort -u)
+
+if [ -z "$MATCHED" ]; then
+  smoke_log "no surfaces matched — exit 2"
+  exit 2
+fi
+
+smoke_log "matched surfaces: $(printf '%s' "$MATCHED" | tr '\n' ' ')"
+
+# ---- dry-run: print plan, validate JSON shape, exit ------------------
+if [ "$DRY_RUN" = "1" ]; then
+  smoke_log "DRY RUN — no network calls"
+  PLAN=$(printf '%s\n' "$MATCHED" | jq -R . | jq -sc '{dry_run: true, matched_surfaces: .}')
+  if [ "$EMIT_JSON" = "1" ]; then
+    printf '%s\n' "$PLAN"
+  fi
+  if [ -n "$REPORT_PATH" ]; then
+    printf '%s\n' "$PLAN" > "$REPORT_PATH"
+  fi
+  exit 0
+fi
+
+# ---- run checks -------------------------------------------------------
+START_EPOCH=$(date +%s)
+SECONDS=0
+
+while IFS= read -r surface_id; do
+  [ -z "$surface_id" ] && continue
+  if [ "$SECONDS" -ge "$SMOKE_BUDGET_SEC" ]; then
+    smoke_warn "60s budget exceeded — aborting remaining surfaces"
+    SMOKE_FAIL_COUNT=$((SMOKE_FAIL_COUNT + 1))
+    break
+  fi
+  script_rel=$(jq -r --arg id "$surface_id" '.surfaces[] | select(.id == $id) | .script' "$SURFACES_JSON")
+  if [ -z "$script_rel" ] || [ "$script_rel" = "null" ]; then
+    smoke_warn "surface $surface_id has no script"
+    continue
+  fi
+  script_abs="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../$script_rel"
+  # Resolve the path relative to repo root. ${BASH_SOURCE[0]} is .../scripts/smoke-prod.sh,
+  # so its dirname is .../scripts, and ../scripts/smoke-prod/<file> normalizes correctly.
+  script_abs=$(cd "$(dirname "$script_abs")" 2>/dev/null && pwd)/$(basename "$script_abs") || true
+  if [ ! -f "$script_abs" ]; then
+    smoke_warn "surface $surface_id script not found: $script_rel"
+    continue
+  fi
+  # shellcheck disable=SC1090
+  . "$script_abs"
+  # Run each declared check function. We use process substitution + a
+  # while-read in the parent shell so SMOKE_RESULTS_JSON / counters
+  # accumulate (a `jq | while` pipeline forks the loop into a subshell
+  # and loses state — the orchestrator's report aggregation depends on
+  # parent-shell side effects in lib.sh).
+  while IFS= read -r fn; do
+    if [ -z "$fn" ]; then continue; fi
+    if ! command -v "$fn" >/dev/null 2>&1 && ! declare -f "$fn" >/dev/null 2>&1; then
+      smoke_warn "check function not defined: $fn (surface $surface_id)"
+      continue
+    fi
+    "$fn" || true
+  done < <(jq -r --arg id "$surface_id" '.surfaces[] | select(.id == $id) | .checks[]' "$SURFACES_JSON")
+done <<< "$MATCHED"
+
+# ---- emit report ------------------------------------------------------
+DURATION_MS=$(( SECONDS * 1000 ))
+SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+REPORT_JSON=$(jq -nc \
+  --arg sha "$SHA" \
+  --arg started "$(date -u -r "$START_EPOCH" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  --argjson duration "$DURATION_MS" \
+  --argjson pass "$SMOKE_PASS_COUNT" \
+  --argjson fail "$SMOKE_FAIL_COUNT" \
+  --argjson results "[${SMOKE_RESULTS_JSON}]" \
+  '{smoke_run_id: $sha, started_at: $started, duration_ms: $duration, pass: $pass, fail: $fail, results: $results}')
+
+if [ "$EMIT_JSON" = "1" ]; then
+  printf '%s\n' "$REPORT_JSON"
+fi
+if [ -n "$REPORT_PATH" ]; then
+  printf '%s\n' "$REPORT_JSON" > "$REPORT_PATH"
+fi
+
+if [ "$SMOKE_FAIL_COUNT" -gt 0 ]; then
+  smoke_log "smoke complete: pass=$SMOKE_PASS_COUNT fail=$SMOKE_FAIL_COUNT duration=${DURATION_MS}ms"
+  exit 1
+fi
+smoke_log "smoke complete: pass=$SMOKE_PASS_COUNT fail=0 duration=${DURATION_MS}ms"
+exit 0

--- a/scripts/smoke-prod/.surfaces-allowlist.txt
+++ b/scripts/smoke-prod/.surfaces-allowlist.txt
@@ -1,0 +1,93 @@
+# SMI-4459 R-4 audit-standards backstop allowlist.
+# Paths listed here are intentionally NOT covered by surfaces.json. One
+# path per line. Comments allowed (lines starting with #). Trailing slashes
+# treated literally; globs allowed using shell-style `*` and `**`.
+#
+# Add a new entry only after confirming the surface is genuinely not
+# user-facing or not deployable (e.g., test fixtures, internal RPCs called
+# only from other functions). Document the rationale inline.
+
+# Internal-only edge functions (called by other functions, not user-facing).
+# alert-notify is invoked by smoke-prod itself + cron jobs; smoking it would
+# create a loop and there is no public surface to verify.
+supabase/functions/alert-notify/**
+
+# Cron-only edge functions (no user-facing HTTP surface; verified via the
+# audit_logs ops-report table, not HTTP smoke).
+supabase/functions/indexer/**
+supabase/functions/skills-refresh-metadata/**
+supabase/functions/ops-report/**
+supabase/functions/skills-outreach/**
+supabase/functions/expire-complimentary/**
+supabase/functions/process-pending-subscription/**
+supabase/functions/email-inbound/**
+supabase/functions/advance-notice-email/**
+supabase/functions/skills-outreach-preferences/**
+supabase/functions/admin-grant-subscription/**
+supabase/functions/update-seat-count/**
+supabase/functions/webhook-dlq/**
+
+# Stripe webhook endpoints (require signed payload to exercise; covered by
+# stripe-webhook-monitor.yml independently).
+supabase/functions/stripe-webhook/**
+supabase/functions/checkout/**
+supabase/functions/create-portal-session/**
+supabase/functions/list-invoices/**
+supabase/functions/generate-license/**
+supabase/functions/regenerate-license/**
+
+# Analytics + early-access (low-stakes; may be added later).
+supabase/functions/events/**
+supabase/functions/early-access-signup/**
+supabase/functions/contact-submit/**
+supabase/functions/stats/**
+
+# Skills public API (covered by direct query + indexer health, not smoke).
+supabase/functions/skills-search/**
+supabase/functions/skills-get/**
+supabase/functions/skills-recommend/**
+
+# Shared module (not a deployed function).
+supabase/functions/_shared/**
+
+# Static / secondary website pages — only conversion-critical pages need
+# explicit smoke. Add any new conversion-critical page to surfaces.json.
+packages/website/src/pages/index.astro
+packages/website/src/pages/index-v2.astro
+packages/website/src/pages/index-v3.astro
+packages/website/src/pages/login.astro
+packages/website/src/pages/signup.astro
+packages/website/src/pages/signup/success.astro
+packages/website/src/pages/check-email.astro
+packages/website/src/pages/verify.astro
+packages/website/src/pages/return-to-cli.astro
+packages/website/src/pages/auth/callback.astro
+packages/website/src/pages/auth/confirm.astro
+packages/website/src/pages/auth/forgot-password.astro
+packages/website/src/pages/auth/reset-password.astro
+packages/website/src/pages/blog/**
+packages/website/src/pages/docs/**
+packages/website/src/pages/legal/**
+packages/website/src/pages/marketing/**
+packages/website/src/pages/api/**
+packages/website/src/pages/account/**
+packages/website/src/pages/skills/**
+packages/website/src/pages/early-access.astro
+packages/website/src/pages/early-access/**
+packages/website/src/pages/install.astro
+packages/website/src/pages/pricing.astro
+packages/website/src/pages/contact.astro
+packages/website/src/pages/changelog.astro
+packages/website/src/pages/about.astro
+packages/website/src/pages/faq.astro
+packages/website/src/pages/license.astro
+packages/website/src/pages/privacy.astro
+packages/website/src/pages/terms.astro
+packages/website/src/pages/404.astro
+packages/website/src/pages/500.astro
+packages/website/src/pages/dashboard.astro
+packages/website/src/pages/dashboard/**
+packages/website/src/pages/complete-profile.astro
+packages/website/src/pages/sitemap.xml.ts
+packages/website/src/pages/robots.txt.ts
+packages/website/src/pages/feed.xml.ts

--- a/scripts/smoke-prod/alert.sh
+++ b/scripts/smoke-prod/alert.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SMI-4459 — failure-payload formatter + alert dispatch.
+# Invoked by the workflow's `alert` job (which holds SUPABASE_SERVICE_ROLE_KEY).
+# Reads the smoke report JSON from --report and the workflow run URL from
+# --run-url, formats a human-readable email body, and POSTs to alert-notify.
+
+set -euo pipefail
+# shellcheck source=scripts/smoke-prod/lib.sh
+SMOKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SMOKE_LIB_DIR/lib.sh"
+
+REPORT_FILE=""
+RUN_URL=""
+SHA=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --report) REPORT_FILE="$2"; shift 2 ;;
+    --run-url) RUN_URL="$2"; shift 2 ;;
+    --sha) SHA="$2"; shift 2 ;;
+    *) smoke_warn "unknown arg: $1"; shift ;;
+  esac
+done
+
+if [ -z "$REPORT_FILE" ] || [ ! -f "$REPORT_FILE" ]; then
+  smoke_warn "alert.sh: --report file missing or not provided"
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  smoke_warn "alert.sh: jq required but not installed"
+  exit 1
+fi
+
+# Pluck failed surfaces + checks for the subject line.
+FAILED_SUBJECTS=$(jq -r '.results | map(select(.status == "fail")) | map("\(.surface)::\(.check)") | join(", ")' "$REPORT_FILE")
+if [ -z "$FAILED_SUBJECTS" ]; then
+  smoke_warn "alert.sh: no failures in report — nothing to alert"
+  exit 0
+fi
+
+SUBJECT="Smoke-prod FAILED: $FAILED_SUBJECTS"
+
+# Format a body table (one line per failed result).
+BODY=$(jq -r --arg run "$RUN_URL" --arg sha "$SHA" '
+  "Smoke-prod failure on " + $sha + "\n" +
+  "Run: " + $run + "\n\n" +
+  "Failures:\n" +
+  (.results | map(select(.status == "fail")) | map(
+    "  - [" + .surface + "] " + .check +
+    "\n    URL: " + (.url // "n/a") +
+    "\n    Expected: " + (.expected // "n/a") +
+    "\n    Actual: " + (.actual // "n/a")
+  ) | join("\n\n"))
+' "$REPORT_FILE")
+
+# POST to alert-notify. Caller MUST have SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.
+if [ -z "${SUPABASE_URL:-}" ] || [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+  smoke_warn "alert.sh: SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY missing — printing payload only"
+  printf 'Subject: %s\n\n%s\n' "$SUBJECT" "$BODY"
+  exit 0
+fi
+
+PAYLOAD=$(jq -nc \
+  --arg to "support@smithhorn.ca" \
+  --arg subject "$SUBJECT" \
+  --arg body "$BODY" \
+  '{to: $to, subject: $subject, body: $body}')
+
+curl --silent --show-error --fail \
+  --max-time 15 \
+  -X POST \
+  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "content-type: application/json" \
+  -d "$PAYLOAD" \
+  "${SUPABASE_URL}/functions/v1/alert-notify" \
+  >/dev/null
+smoke_log "alert posted to alert-notify"

--- a/scripts/smoke-prod/cli.sh
+++ b/scripts/smoke-prod/cli.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SMI-4459 — published CLI smoke checks.
+# Boot smoke ONLY (per plan-review Edit 3). We deliberately do NOT regex
+# the source for command names — that misses commands registered via
+# program.addCommand(createXxxCommand()) factories. Instead, we verify the
+# published binary boots (--help exits 0 and lists at least one command;
+# --version exits 0 and prints a semver). The R-1 audit-standards check
+# (Section 31) covers source-vs-hint drift at lint time; this surface
+# verifies the binary itself is reachable + runnable on npm.
+
+# shellcheck shell=bash
+# shellcheck source=scripts/smoke-prod/lib.sh
+SMOKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SMOKE_LIB_DIR/lib.sh"
+
+SMOKE_CLI_PKG="${SMOKE_CLI_PKG:-@skillsmith/cli}"
+# Bound npx — fresh-install can pull large native deps (better-sqlite3,
+# onnxruntime-node), so we allow up to 90s here. The orchestrator's 60s
+# total budget still caps the run; this is the per-check ceiling.
+SMOKE_CLI_TIMEOUT="${SMOKE_CLI_TIMEOUT:-90}"
+
+# ---- check_cli_help_lists_known_commands ------------------------------
+# Runs `npx -y @skillsmith/cli@latest --help` in a clean tmpdir. Asserts:
+#   1. exit 0
+#   2. stdout contains a "Commands:" section header (Commander.js convention)
+#   3. at least one indented command line follows
+check_cli_help_lists_known_commands() {
+  local t0 t1 ms tmp out rc
+  t0=$(now_ms)
+  tmp=$(mktemp -d)
+  set +e
+  out=$(cd "$tmp" && timeout "$SMOKE_CLI_TIMEOUT" npx -y "${SMOKE_CLI_PKG}@latest" --help 2>&1)
+  rc=$?
+  set -e
+  rm -rf "$tmp"
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+
+  if [ "$rc" -ne 0 ]; then
+    local snippet="${out:0:200}"
+    report_fail "cli-published" "check_cli_help_lists_known_commands" "npx ${SMOKE_CLI_PKG}@latest --help" "exit 0" "exit $rc: $snippet" "$ms"
+    return 1
+  fi
+  if ! printf '%s' "$out" | grep -q '^Commands:'; then
+    report_fail "cli-published" "check_cli_help_lists_known_commands" "npx ${SMOKE_CLI_PKG}@latest --help" "Commands: section" "missing-commands-section" "$ms"
+    return 1
+  fi
+  # At least one indented command-name token after "Commands:".
+  if ! printf '%s' "$out" | awk '/^Commands:/{flag=1;next} flag && /^[[:space:]]+[a-z]/{found=1; exit} END{exit !found}'; then
+    report_fail "cli-published" "check_cli_help_lists_known_commands" "npx ${SMOKE_CLI_PKG}@latest --help" "≥1 command listed" "no-commands-after-section" "$ms"
+    return 1
+  fi
+  report_pass "cli-published" "check_cli_help_lists_known_commands" "npx ${SMOKE_CLI_PKG}@latest --help" "$ms"
+  return 0
+}
+
+# ---- check_cli_version_exits_zero ------------------------------------
+# Smallest possible smoke: --version exits 0 and stdout contains a semver.
+check_cli_version_exits_zero() {
+  local t0 t1 ms tmp out rc
+  t0=$(now_ms)
+  tmp=$(mktemp -d)
+  set +e
+  out=$(cd "$tmp" && timeout "$SMOKE_CLI_TIMEOUT" npx -y "${SMOKE_CLI_PKG}@latest" --version 2>&1)
+  rc=$?
+  set -e
+  rm -rf "$tmp"
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+
+  if [ "$rc" -ne 0 ]; then
+    local snippet="${out:0:200}"
+    report_fail "cli-published" "check_cli_version_exits_zero" "npx ${SMOKE_CLI_PKG}@latest --version" "exit 0" "exit $rc: $snippet" "$ms"
+    return 1
+  fi
+  if ! printf '%s' "$out" | grep -qE '[0-9]+\.[0-9]+\.[0-9]+'; then
+    report_fail "cli-published" "check_cli_version_exits_zero" "npx ${SMOKE_CLI_PKG}@latest --version" "semver" "${out:0:80}" "$ms"
+    return 1
+  fi
+  report_pass "cli-published" "check_cli_version_exits_zero" "npx ${SMOKE_CLI_PKG}@latest --version" "$ms"
+  return 0
+}

--- a/scripts/smoke-prod/lib.sh
+++ b/scripts/smoke-prod/lib.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# SMI-4459 — smoke-prod shared helpers.
+# Sourced (not executed) by scripts/smoke-prod.sh and per-surface modules.
+# Conventions: ASCII-only output, no `set -x` (secret-leak risk), all HTTP
+# calls bounded by a 10s timeout, single retry with 2s backoff.
+
+# shellcheck shell=bash
+
+# Per-call HTTP timeout. The orchestrator enforces a separate 60s total
+# budget on top of these.
+SMOKE_HTTP_TIMEOUT="${SMOKE_HTTP_TIMEOUT:-10}"
+
+# Result accumulators populated by report_pass/report_fail. The orchestrator
+# reads these at the end to format the summary table / JSON.
+SMOKE_RESULTS_JSON=""
+SMOKE_FAIL_COUNT=0
+SMOKE_PASS_COUNT=0
+
+# ---- logging -------------------------------------------------------------
+
+smoke_log() {
+  # Write to stderr so the orchestrator's stdout stays clean for --json.
+  printf '[smoke] %s\n' "$*" >&2
+}
+
+smoke_warn() {
+  printf '[smoke] WARN: %s\n' "$*" >&2
+}
+
+# ---- HTTP helpers --------------------------------------------------------
+
+# http_status METHOD URL [curl-args...]
+# Echoes the HTTP status code (or "000" on connection failure) to stdout.
+# Discards the body.
+http_status() {
+  local method="$1"
+  local url="$2"
+  shift 2
+  curl --silent --show-error \
+    --max-time "$SMOKE_HTTP_TIMEOUT" \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    --request "$method" \
+    "$@" \
+    "$url" 2>/dev/null || echo "000"
+}
+
+# http_body METHOD URL [curl-args...]
+# Echoes "STATUS\nBODY" to stdout (status on first line, body after).
+# Caller separates with `IFS=$'\n' read -d '' status body`.
+http_body() {
+  local method="$1"
+  local url="$2"
+  shift 2
+  local tmp
+  tmp=$(mktemp)
+  local status
+  status=$(curl --silent --show-error \
+    --max-time "$SMOKE_HTTP_TIMEOUT" \
+    --output "$tmp" \
+    --write-out '%{http_code}' \
+    --request "$method" \
+    "$@" \
+    "$url" 2>/dev/null) || status="000"
+  printf '%s\n' "$status"
+  cat "$tmp"
+  rm -f "$tmp"
+}
+
+# with_retry CMD [ARGS...]
+# Runs CMD; if the last line of stdout is "000" (connection failure) or the
+# command exits non-zero, retries once after 2s.
+with_retry() {
+  local out
+  if out=$("$@" 2>&1); then
+    if [[ "$out" != *"000"* ]]; then
+      printf '%s' "$out"
+      return 0
+    fi
+  fi
+  smoke_log "transient failure, retrying in 2s..."
+  sleep 2
+  "$@"
+}
+
+# ---- assertions ----------------------------------------------------------
+
+assert_eq() {
+  # assert_eq ACTUAL EXPECTED LABEL
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    return 0
+  fi
+  smoke_warn "$label: expected '$expected', got '$actual'"
+  return 1
+}
+
+assert_contains() {
+  # assert_contains HAYSTACK NEEDLE LABEL
+  local haystack="$1" needle="$2" label="$3"
+  case "$haystack" in
+    *"$needle"*) return 0 ;;
+    *)
+      smoke_warn "$label: expected to find '$needle' in body (truncated 200 chars: ${haystack:0:200})"
+      return 1
+      ;;
+  esac
+}
+
+# ---- result reporting ----------------------------------------------------
+
+# report_pass SURFACE CHECK URL [DURATION_MS]
+report_pass() {
+  local surface="$1" check="$2" url="${3:-}" ms="${4:-0}"
+  SMOKE_PASS_COUNT=$((SMOKE_PASS_COUNT + 1))
+  smoke_log "PASS $surface :: $check ($url) ${ms}ms"
+  _append_result "$surface" "$check" "$url" "" "" "pass" "$ms"
+}
+
+# report_fail SURFACE CHECK URL EXPECTED ACTUAL [DURATION_MS]
+report_fail() {
+  local surface="$1" check="$2" url="${3:-}" expected="${4:-}" actual="${5:-}" ms="${6:-0}"
+  SMOKE_FAIL_COUNT=$((SMOKE_FAIL_COUNT + 1))
+  smoke_log "FAIL $surface :: $check ($url) expected='$expected' actual='$actual' ${ms}ms"
+  _append_result "$surface" "$check" "$url" "$expected" "$actual" "fail" "$ms"
+}
+
+# Internal: append a single JSON object to SMOKE_RESULTS_JSON.
+_append_result() {
+  local surface="$1" check="$2" url="$3" expected="$4" actual="$5" status="$6" ms="$7"
+  # JSON-escape values via jq if available; otherwise fall back to a minimal
+  # printf escape (sufficient for HTTP statuses and ASCII URLs).
+  local entry
+  if command -v jq >/dev/null 2>&1; then
+    entry=$(jq -nc \
+      --arg surface "$surface" \
+      --arg check "$check" \
+      --arg url "$url" \
+      --arg expected "$expected" \
+      --arg actual "$actual" \
+      --arg status "$status" \
+      --argjson ms "$ms" \
+      '{surface: $surface, check: $check, url: $url, expected: $expected, actual: $actual, status: $status, ms: $ms}')
+  else
+    entry=$(printf '{"surface":"%s","check":"%s","url":"%s","expected":"%s","actual":"%s","status":"%s","ms":%d}' \
+      "$surface" "$check" "$url" "$expected" "$actual" "$status" "$ms")
+  fi
+  if [ -z "$SMOKE_RESULTS_JSON" ]; then
+    SMOKE_RESULTS_JSON="$entry"
+  else
+    SMOKE_RESULTS_JSON="${SMOKE_RESULTS_JSON},${entry}"
+  fi
+}
+
+# now_ms — milliseconds since epoch. Falls back to seconds*1000 when
+# `date +%N` is unavailable (BSD date on macOS).
+now_ms() {
+  local ns
+  ns=$(date +%s%N 2>/dev/null || true)
+  case "$ns" in
+    *N) printf '%d' "$(( $(date +%s) * 1000 ))" ;;
+    "") printf '%d' "$(( $(date +%s) * 1000 ))" ;;
+    *) printf '%d' "$(( ns / 1000000 ))" ;;
+  esac
+}

--- a/scripts/smoke-prod/mcp-server.sh
+++ b/scripts/smoke-prod/mcp-server.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SMI-4459 — published MCP server boot smoke. Intentionally minimal per
+# plan Q8: we only verify --version exits 0 and prints a semver. Deeper
+# round-trip (spawning + list_tools) is SMI-4460 territory.
+
+# shellcheck shell=bash
+# shellcheck source=scripts/smoke-prod/lib.sh
+SMOKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SMOKE_LIB_DIR/lib.sh"
+
+SMOKE_MCP_PKG="${SMOKE_MCP_PKG:-@skillsmith/mcp-server}"
+SMOKE_MCP_TIMEOUT="${SMOKE_MCP_TIMEOUT:-90}"
+
+check_mcp_server_version_exits_zero() {
+  local t0 t1 ms tmp out rc
+  t0=$(now_ms)
+  tmp=$(mktemp -d)
+  set +e
+  out=$(cd "$tmp" && timeout "$SMOKE_MCP_TIMEOUT" npx -y "${SMOKE_MCP_PKG}@latest" --version 2>&1)
+  rc=$?
+  set -e
+  rm -rf "$tmp"
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+
+  if [ "$rc" -ne 0 ]; then
+    local snippet="${out:0:200}"
+    report_fail "mcp-server-published" "check_mcp_server_version_exits_zero" "npx ${SMOKE_MCP_PKG}@latest --version" "exit 0" "exit $rc: $snippet" "$ms"
+    return 1
+  fi
+  if ! printf '%s' "$out" | grep -qE '[0-9]+\.[0-9]+\.[0-9]+'; then
+    report_fail "mcp-server-published" "check_mcp_server_version_exits_zero" "npx ${SMOKE_MCP_PKG}@latest --version" "semver" "${out:0:80}" "$ms"
+    return 1
+  fi
+  report_pass "mcp-server-published" "check_mcp_server_version_exits_zero" "npx ${SMOKE_MCP_PKG}@latest --version" "$ms"
+  return 0
+}

--- a/scripts/smoke-prod/surfaces.json
+++ b/scripts/smoke-prod/surfaces.json
@@ -1,0 +1,50 @@
+{
+  "$comment": "SMI-4459 surface manifest. Each surface declares trigger_globs (paths whose change implies the surface needs smoking), the script that owns its checks, and the check function names (defined inside that script). Adding a surface = appending one entry. The audit-standards R-4 backstop (Section 34) walks edge-functions + website pages and warns when a path matches no surface. The 'health' canary is always-on (zero trigger_globs) so every PR exercises the harness against real prod.",
+  "version": 1,
+  "surfaces": [
+    {
+      "id": "health",
+      "owner": "always-on-canary",
+      "trigger_globs": ["supabase/functions/health/**"],
+      "always_run": true,
+      "script": "scripts/smoke-prod/website.sh",
+      "checks": ["check_health_edge_fn"]
+    },
+    {
+      "id": "website-device-page",
+      "owner": "website",
+      "trigger_globs": [
+        "packages/website/src/pages/device.astro",
+        "packages/website/src/pages/device/**"
+      ],
+      "script": "scripts/smoke-prod/website.sh",
+      "checks": ["check_device_page_renders"]
+    },
+    {
+      "id": "edge-fn-auth-device",
+      "owner": "edge-functions",
+      "trigger_globs": [
+        "supabase/functions/auth-device-code/**",
+        "supabase/functions/auth-device-preview/**",
+        "supabase/functions/auth-device-approve/**",
+        "supabase/functions/auth-device-token/**"
+      ],
+      "script": "scripts/smoke-prod/website.sh",
+      "checks": ["check_auth_device_code_reachable", "check_auth_device_preview_requires_jwt"]
+    },
+    {
+      "id": "cli-published",
+      "owner": "cli",
+      "trigger_globs": ["packages/cli/**"],
+      "script": "scripts/smoke-prod/cli.sh",
+      "checks": ["check_cli_help_lists_known_commands", "check_cli_version_exits_zero"]
+    },
+    {
+      "id": "mcp-server-published",
+      "owner": "mcp-server",
+      "trigger_globs": ["packages/mcp-server/**"],
+      "script": "scripts/smoke-prod/mcp-server.sh",
+      "checks": ["check_mcp_server_version_exits_zero"]
+    }
+  ]
+}

--- a/scripts/smoke-prod/website.sh
+++ b/scripts/smoke-prod/website.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# SMI-4459 — website + edge-function smoke checks.
+# Read-only. Uses curl with a 10s timeout per call. Single 2s-backoff retry
+# on transient failure (HTTP 000 or curl error).
+
+# shellcheck shell=bash
+# shellcheck source=scripts/smoke-prod/lib.sh
+SMOKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$SMOKE_LIB_DIR/lib.sh"
+
+SMOKE_WEBSITE_URL="${SMOKE_WEBSITE_URL:-https://www.skillsmith.app}"
+# SUPABASE_URL must be supplied by the caller (env/secret). Fail loudly if absent.
+SMOKE_SUPABASE_URL="${SUPABASE_URL:-}"
+
+_require_supabase_url() {
+  if [ -z "$SMOKE_SUPABASE_URL" ]; then
+    smoke_warn "SUPABASE_URL not set — skipping edge-fn check"
+    return 1
+  fi
+  return 0
+}
+
+# ---- check_health_edge_fn ---------------------------------------------
+# Always-on canary. Hits the public health endpoint; 200 + JSON body. Used
+# every PR (including --dry-run sanity) to prove the harness wiring works.
+check_health_edge_fn() {
+  _require_supabase_url || { report_fail "health" "check_health_edge_fn" "" "SUPABASE_URL" "unset"; return 1; }
+  local url="${SMOKE_SUPABASE_URL}/functions/v1/health"
+  local t0 t1 ms status
+  t0=$(now_ms)
+  status=$(with_retry http_status GET "$url")
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  if [ "$status" = "200" ]; then
+    report_pass "health" "check_health_edge_fn" "$url" "$ms"
+    return 0
+  fi
+  report_fail "health" "check_health_edge_fn" "$url" "200" "$status" "$ms"
+  return 1
+}
+
+# ---- check_device_page_renders ----------------------------------------
+# Verifies the /device page renders the device-input form (not the expired
+# fallback). Uses the data-smoke="device-input" attribute as a stable
+# fingerprint (see Q3 of the plan).
+check_device_page_renders() {
+  local url="${SMOKE_WEBSITE_URL}/device"
+  local t0 t1 ms resp status body
+  t0=$(now_ms)
+  resp=$(with_retry http_body GET "$url") || true
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  status=$(printf '%s' "$resp" | head -n1)
+  body=$(printf '%s' "$resp" | tail -n +2)
+
+  if [ "$status" != "200" ]; then
+    report_fail "website-device-page" "check_device_page_renders" "$url" "200" "$status" "$ms"
+    return 1
+  fi
+  if ! assert_contains "$body" 'data-smoke="device-input"' "device-page-content"; then
+    report_fail "website-device-page" "check_device_page_renders" "$url" 'data-smoke="device-input"' "missing-fingerprint" "$ms"
+    return 1
+  fi
+  report_pass "website-device-page" "check_device_page_renders" "$url" "$ms"
+  return 0
+}
+
+# ---- check_auth_device_code_reachable ---------------------------------
+# POSTs an empty JSON body. Function deployed and routing → 400 (validation
+# error). 404 = function never deployed (the SMI-4252-class regression we
+# want to surface). 200 is also acceptable in case the validator changes.
+check_auth_device_code_reachable() {
+  _require_supabase_url || { report_fail "edge-fn-auth-device" "check_auth_device_code_reachable" "" "SUPABASE_URL" "unset"; return 1; }
+  local url="${SMOKE_SUPABASE_URL}/functions/v1/auth-device-code"
+  local t0 t1 ms status
+  t0=$(now_ms)
+  status=$(with_retry http_status POST "$url" -H 'content-type: application/json' -d '{}')
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  case "$status" in
+    200|400)
+      report_pass "edge-fn-auth-device" "check_auth_device_code_reachable" "$url" "$ms"
+      return 0
+      ;;
+    404)
+      report_fail "edge-fn-auth-device" "check_auth_device_code_reachable" "$url" "200|400" "404 (function not deployed?)" "$ms"
+      return 1
+      ;;
+    *)
+      report_fail "edge-fn-auth-device" "check_auth_device_code_reachable" "$url" "200|400" "$status" "$ms"
+      return 1
+      ;;
+  esac
+}
+
+# ---- check_auth_device_preview_requires_jwt ---------------------------
+# GET without auth. Gateway-verified function → 401 with no JWT. 200 means
+# JWT verification is broken (dangerous; the cousins-of-B1 class).
+check_auth_device_preview_requires_jwt() {
+  _require_supabase_url || { report_fail "edge-fn-auth-device" "check_auth_device_preview_requires_jwt" "" "SUPABASE_URL" "unset"; return 1; }
+  local url="${SMOKE_SUPABASE_URL}/functions/v1/auth-device-preview"
+  local t0 t1 ms status
+  t0=$(now_ms)
+  status=$(with_retry http_status GET "$url")
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  if [ "$status" = "401" ]; then
+    report_pass "edge-fn-auth-device" "check_auth_device_preview_requires_jwt" "$url" "$ms"
+    return 0
+  fi
+  report_fail "edge-fn-auth-device" "check_auth_device_preview_requires_jwt" "$url" "401" "$status" "$ms"
+  return 1
+}

--- a/scripts/tests/audit-standards-trifecta.test.ts
+++ b/scripts/tests/audit-standards-trifecta.test.ts
@@ -1,9 +1,10 @@
 /**
- * Tests for SMI-4456 / SMI-4457 / SMI-4458 audit-standards backstops.
+ * Tests for SMI-4456 / SMI-4457 / SMI-4458 / SMI-4459 audit-standards backstops.
  *
  * R-1: extractCliCommandNames + findCliHintCommandRefs (SMI-4456)
  * R-2: findRelativeFunctionsV1Urls (SMI-4457)
  * R-3: findReturningTableAmbiguity (SMI-4458)
+ * R-4: findUncoveredSurfacePaths (SMI-4459)
  *
  * Lives in its own file (not audit-standards.test.ts) to keep both files
  * under the 500-line pre-commit gate. Same dynamic-ESM-import convention
@@ -31,6 +32,11 @@ const helpers = (await import('../audit-standards-helpers.mjs')) as {
     col: string
     snippet: string
   }>
+  findUncoveredSurfacePaths: (
+    candidatePaths: string[],
+    surfaceGlobs: string[],
+    allowlistGlobs: string[]
+  ) => string[]
 }
 
 const {
@@ -38,6 +44,7 @@ const {
   findCliHintCommandRefs,
   findRelativeFunctionsV1Urls,
   findReturningTableAmbiguity,
+  findUncoveredSurfacePaths,
 } = helpers
 
 describe('extractCliCommandNames (R-1, SMI-4456)', () => {
@@ -340,5 +347,65 @@ describe('findReturningTableAmbiguity (R-3, SMI-4458)', () => {
     `
     const violations = findReturningTableAmbiguity({ '081_foo.sql': migration })
     expect(violations).toHaveLength(0)
+  })
+})
+
+describe('findUncoveredSurfacePaths (R-4, SMI-4459)', () => {
+  it('flags an edge function with no surface entry and no allowlist', () => {
+    const candidates = ['supabase/functions/new-fn/index.ts']
+    const surfaceGlobs = ['supabase/functions/auth-device-code/**']
+    const allowlist: string[] = []
+    expect(findUncoveredSurfacePaths(candidates, surfaceGlobs, allowlist)).toEqual([
+      'supabase/functions/new-fn/index.ts',
+    ])
+  })
+
+  it('passes a covered surface (prefix/** glob)', () => {
+    const candidates = ['supabase/functions/auth-device-code/index.ts']
+    const surfaceGlobs = ['supabase/functions/auth-device-code/**']
+    expect(findUncoveredSurfacePaths(candidates, surfaceGlobs, [])).toEqual([])
+  })
+
+  it('passes an allowlisted surface', () => {
+    const candidates = ['supabase/functions/indexer/index.ts']
+    const surfaceGlobs: string[] = []
+    const allowlist = ['supabase/functions/indexer/**']
+    expect(findUncoveredSurfacePaths(candidates, surfaceGlobs, allowlist)).toEqual([])
+  })
+
+  it('passes an exact-path allowlist entry', () => {
+    const candidates = ['packages/website/src/pages/index.astro']
+    const allowlist = ['packages/website/src/pages/index.astro']
+    expect(findUncoveredSurfacePaths(candidates, [], allowlist)).toEqual([])
+  })
+
+  it('flags a website page not in surfaces or allowlist (SMI-4459 use case)', () => {
+    const candidates = [
+      'packages/website/src/pages/device.astro',
+      'packages/website/src/pages/checkout-new.astro',
+    ]
+    const surfaceGlobs = ['packages/website/src/pages/device.astro']
+    const allowlist: string[] = []
+    expect(findUncoveredSurfacePaths(candidates, surfaceGlobs, allowlist)).toEqual([
+      'packages/website/src/pages/checkout-new.astro',
+    ])
+  })
+
+  it('prefix/* matches files at depth-1 only, not deeper', () => {
+    const candidates = [
+      'packages/website/src/pages/foo.astro',
+      'packages/website/src/pages/blog/post.astro',
+    ]
+    const allowlist = ['packages/website/src/pages/*']
+    // foo.astro is depth-1 (allowlisted); blog/post.astro is depth-2 (not).
+    expect(findUncoveredSurfacePaths(candidates, [], allowlist)).toEqual([
+      'packages/website/src/pages/blog/post.astro',
+    ])
+  })
+
+  it('mirrors the orchestrator glob semantics for prefix/** equality', () => {
+    // surfaces.json uses `path/**` globs. A file at exactly `path` (no
+    // trailing slash) should match. Edge case for completeness.
+    expect(findUncoveredSurfacePaths(['a/b'], ['a/b/**'], [])).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

- Layer 4 of the SMI-4454 trifecta gate stack: runtime smoke against real prod after every merge.
- New `scripts/smoke-prod.sh` orchestrator + per-surface modules + declarative `surfaces.json`; new `.github/workflows/smoke-prod.yml` workflow with two-job split for secret scoping.
- Audit-standards Section 34 (R-4) warns when an edge function or website page lands without a smoke entry.

## Surfaces covered

| ID | What it checks | Trigger |
|----|----------------|---------|
| `health` | `GET $SUPABASE_URL/functions/v1/health` returns 200 | always-on canary (every PR + every post-deploy) |
| `website-device-page` | `/device` returns 200 + contains `data-smoke="device-input"` | `packages/website/src/pages/device.astro` change |
| `edge-fn-auth-device` | `auth-device-code` POST → 200/400 (NOT 404); `auth-device-preview` GET (no JWT) → 401 | `supabase/functions/auth-device-{code,preview,approve,token}/**` change |
| `cli-published` | `npx -y @skillsmith/cli@latest --help` exits 0 with `Commands:` section; `--version` exits 0 | `packages/cli/**` change |
| `mcp-server-published` | `npx -y @skillsmith/mcp-server@latest --version` exits 0 | `packages/mcp-server/**` change |

R-4 (Section 34 of `audit-standards.mjs`) covers the rest as a warn-mode backstop using `scripts/smoke-prod/.surfaces-allowlist.txt` for intentional exclusions.

## Manual setup steps

These two are **NOT** in the PR — must be done by an admin after merge:

1. **Vercel deploy hook**: configure a Vercel webhook on the website project that POSTs `repository_dispatch` to GitHub with `event_type: vercel-prod-deployed`. Full runbook: `.claude/development/vercel-deploy-hook.md`.
2. **GitHub Actions secret**: `gh secret set VERCEL_DEPLOY_HOOK_TOKEN` with a fine-grained PAT (Contents read, Metadata read, Actions read+write). 90-day rotation per `vercel-deploy-hook.md`.

Without these, smoke-prod still runs on `Deploy Edge Functions` workflow_run completion + manual `workflow_dispatch`; only the Vercel-triggered path requires them.

## Phase rollout

- **Phase 1 (week 1, starting on merge)**: warning-only. Workflow runs and files Linear issues + emails on failure but does NOT post a commit status. Goal: collect 1 week of false-positive data.
- **Phase 2 (week 2-3)**: commit-status `success`/`failure` posted to merge SHA so it surfaces in the GitHub UI. No branch protection change (smoke runs after merge).
- **Phase 3 (later)**: staging-variant pre-merge gate. Tracked separately under a follow-up SMI per plan-review Q6.

Migration drift / publish.yml chain deferred per plan-review Q5/Q10.

## Test plan

- [x] `bash -n` clean on `scripts/smoke-prod.sh` and all `scripts/smoke-prod/*.sh`
- [x] `--dry-run` matches expected surfaces for synthetic file changes (`device.astro` → `health, website-device-page`; `auth-device-code/index.ts` → `health, edge-fn-auth-device`; `packages/cli/src/commands/login.ts` → `health, cli-published`; `docs/foo.md` → `health` only)
- [x] `--surface=health` against real prod returns 200 in ~470ms
- [x] `audit:standards` passes with Section 34 reporting "All 78 user-facing surface(s) covered"
- [x] `vitest run scripts/tests/audit-standards-trifecta.test.ts` — 26 tests pass (19 trifecta + 7 R-4)
- [x] Prettier clean on every changed file
- [x] `.mcp.json` reverted (create-worktree.sh patch not committed)
- [ ] (post-merge) Trigger one full real run via `workflow_dispatch`; confirm Linear issue + email path with a deliberate canary failure
- [ ] (post-merge) Configure Vercel deploy hook + GH Actions secret per runbook

## Plan + Linear

- Plan: `docs/internal/implementation/smi-4459-smoke-prod-harness.md`
- Parent retro: SMI-4454
- Linear: SMI-4459 (In Progress)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)