### PR TITLE
refactor(tests): SMI-4466 dedupe waitForCounterIncrement + fail-loud env reads

### DIFF
--- a/tests/e2e/api/skills-search-direct.e2e.test.ts
+++ b/tests/e2e/api/skills-search-direct.e2e.test.ts
@@ -19,6 +19,8 @@ import {
   getUsageRow,
   stagingFunctionUrl,
   stagingCredentialsAbsent,
+  getStagingAnonKey,
+  waitForCounterIncrement,
   type ProvisionedUser,
 } from '../fixtures/usage-counter-fixture.js'
 
@@ -43,7 +45,7 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter Direct X-API-Key → usage co
     const url = `${stagingFunctionUrl('skills-search')}?query=react&limit=5`
     const headers = {
       'X-API-Key': user.apiKey,
-      apikey: process.env['STAGING_SUPABASE_ANON_KEY'] ?? '',
+      apikey: getStagingAnonKey(),
       Accept: 'application/json',
     }
 
@@ -61,17 +63,3 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter Direct X-API-Key → usage co
     expect(after.search_count).toBe(before.search_count + 2)
   }, 45_000)
 })
-
-async function waitForCounterIncrement(
-  userId: string,
-  column: 'search_count' | 'get_count' | 'recommend_count',
-  target: number,
-  timeoutMs = 5_000
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    const row = await getUsageRow(userId)
-    if (row[column] >= target) return
-    await new Promise((resolve) => setTimeout(resolve, 250))
-  }
-}

--- a/tests/e2e/cli/usage-counter.e2e.test.ts
+++ b/tests/e2e/cli/usage-counter.e2e.test.ts
@@ -38,6 +38,7 @@ import {
   cleanupTestUser,
   getUsageRow,
   stagingCredentialsAbsent,
+  waitForCounterIncrement,
   type ProvisionedUser,
 } from '../fixtures/usage-counter-fixture.js'
 
@@ -103,22 +104,3 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter CLI ApiClient → usage count
     expect(after.get_count).toBe(before.get_count + 2)
   }, 45_000)
 })
-
-/**
- * Polling helper — increment_api_usage is fire-and-forget downstream of the
- * response. Read the row up to N times, 250ms apart, until the expected value
- * lands or we time out (and let the assertion produce a useful diff).
- */
-async function waitForCounterIncrement(
-  userId: string,
-  column: 'search_count' | 'get_count' | 'recommend_count',
-  target: number,
-  timeoutMs = 5_000
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    const row = await getUsageRow(userId)
-    if (row[column] >= target) return
-    await new Promise((resolve) => setTimeout(resolve, 250))
-  }
-}

--- a/tests/e2e/fixtures/usage-counter-fixture.ts
+++ b/tests/e2e/fixtures/usage-counter-fixture.ts
@@ -407,3 +407,39 @@ export function stagingCredentialsAbsent(): boolean {
     process.env['STAGING_SUPABASE_ANON_KEY']
   )
 }
+
+/**
+ * Read STAGING_SUPABASE_ANON_KEY with the same fail-loud semantics the rest
+ * of the fixture uses for service-role / URL. Tests that build raw fetch
+ * headers (`apikey: ...`) must use this rather than `process.env[...] ?? ''`
+ * — an empty `apikey` header surfaces as a confusing 401 instead of a clear
+ * "missing env" error (SMI-4466).
+ */
+export function getStagingAnonKey(): string {
+  return readEnv('STAGING_SUPABASE_ANON_KEY')
+}
+
+type CounterColumn = 'search_count' | 'get_count' | 'recommend_count'
+
+/**
+ * Polling helper — `increment_api_usage` is fire-and-forget downstream of the
+ * response. Read the row up to N times, 250ms apart, until the expected
+ * counter value lands or we time out. The caller's subsequent `expect(...)`
+ * produces the actual diff if the target wasn't reached.
+ *
+ * Centralized in the fixture so all four E2E suites share one implementation
+ * (SMI-4466 — was previously duplicated 4×).
+ */
+export async function waitForCounterIncrement(
+  userId: string,
+  column: CounterColumn,
+  target: number,
+  timeoutMs = 5_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const row = await getUsageRow(userId)
+    if (row[column] >= target) return
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+}

--- a/tests/e2e/mcp/usage-counter.e2e.test.ts
+++ b/tests/e2e/mcp/usage-counter.e2e.test.ts
@@ -31,6 +31,7 @@ import {
   cleanupTestUser,
   getUsageRow,
   stagingCredentialsAbsent,
+  waitForCounterIncrement,
   type ProvisionedUser,
 } from '../fixtures/usage-counter-fixture.js'
 
@@ -108,17 +109,3 @@ describe.skipIf(skipSuite)('@e2e-usage-counter MCP stdio → usage counter', () 
     expect(after.get_count).toBe(before.get_count + 1)
   }, 45_000)
 })
-
-async function waitForCounterIncrement(
-  userId: string,
-  column: 'search_count' | 'get_count' | 'recommend_count',
-  target: number,
-  timeoutMs = 5_000
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    const row = await getUsageRow(userId)
-    if (row[column] >= target) return
-    await new Promise((resolve) => setTimeout(resolve, 250))
-  }
-}

--- a/tests/e2e/website/account-usage.e2e.test.ts
+++ b/tests/e2e/website/account-usage.e2e.test.ts
@@ -38,6 +38,8 @@ import {
   getUsageRow,
   stagingFunctionUrl,
   stagingCredentialsAbsent,
+  getStagingAnonKey,
+  waitForCounterIncrement,
   type ProvisionedUser,
 } from '../fixtures/usage-counter-fixture.js'
 
@@ -66,7 +68,7 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter Website auth surface → usag
         // and packages/website/src/pages/skills/index.astro before they hit the
         // edge function.
         Authorization: `Bearer ${user.jwt}`,
-        apikey: process.env['STAGING_SUPABASE_ANON_KEY'] ?? '',
+        apikey: getStagingAnonKey(),
         Accept: 'application/json',
       },
     })
@@ -89,7 +91,7 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter Website auth surface → usag
     const res = await fetch(url, {
       headers: {
         // Anon key required by the function gateway, but no user identity.
-        apikey: process.env['STAGING_SUPABASE_ANON_KEY'] ?? '',
+        apikey: getStagingAnonKey(),
         Accept: 'application/json',
       },
     })
@@ -106,17 +108,3 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter Website auth surface → usag
     expect(after.recommend_count).toBe(before.recommend_count)
   }, 30_000)
 })
-
-async function waitForCounterIncrement(
-  userId: string,
-  column: 'search_count' | 'get_count' | 'recommend_count',
-  target: number,
-  timeoutMs = 5_000
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    const row = await getUsageRow(userId)
-    if (row[column] >= target) return
-    await new Promise((resolve) => setTimeout(resolve, 250))
-  }
-}


### PR DESCRIPTION
## Summary

Resolves SMI-4466 — the two findings from PR #772's post-merge governance retro:

1. `waitForCounterIncrement` polling helper was duplicated identically in 4 E2E test files. Moved to `tests/e2e/fixtures/usage-counter-fixture.ts` as a named export.
2. Two negative-case tests had `process.env['STAGING_SUPABASE_ANON_KEY'] ?? ''` silent fallback — an empty `apikey` header surfaced as a confusing 401 instead of a clear missing-env error. Replaced with `getStagingAnonKey()` (thin wrapper around the existing fail-loud `readEnv` pattern).

## Diff

| Change | Lines |
|---|---|
| Removed local copies of `waitForCounterIncrement` × 4 | -64 |
| Added single `waitForCounterIncrement` + `getStagingAnonKey` to fixture (with JSDoc) | +45 |
| **Net** | **-19** |

No behavior change. All 4 E2E tests still self-skip when `STAGING_*` env is absent.

## Test plan

- [x] `prettier --check` clean
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] `git grep -n "function waitForCounterIncrement" tests/` returns exactly one hit (the fixture export)
- [x] `git grep -n "STAGING_SUPABASE_ANON_KEY.*\?\?" tests/` returns 0 hits
- [ ] CI green
- [ ] `npm run test:e2e:usage-counter` against staging (requires repo secrets — gated until next staging run)

## Related

- Surfaced by: post-merge governance retro on PR #772 / commit 55d6b1d6
- Linear: SMI-4466 (parent: SMI-4462; grandparent: SMI-4461)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

[skip-impl-check]