### PR TITLE
fix(SMI-4451): Step 7 — graceful host search() load failure

### DIFF
--- a/scripts/session-priming-query.ts
+++ b/scripts/session-priming-query.ts
@@ -27,8 +27,26 @@ import { basename, join } from 'node:path'
 import { parseArgs } from 'node:util'
 import { promisify } from 'node:util'
 import { logRetrievalEvent } from '../packages/doc-retrieval-mcp/src/retrieval-log/writer.js'
-import { search } from '../packages/doc-retrieval-mcp/src/search.js'
 import type { SearchHit } from '../packages/doc-retrieval-mcp/src/types.js'
+
+// search() is dynamically imported inside runQuery — its module loads
+// @ruvector/core's native binding at top-level, which throws on hosts
+// missing the platform-specific optional dep (e.g. ruvector-core-darwin-arm64
+// on macOS without it installed). Top-level static import would crash query.ts
+// at module load before runQuery could log a partial_failure row. Surfaced by
+// the §S9 post-deploy smoke run on 2026-04-25 (host=darwin-arm64).
+type SearchFn = (opts: { query: string; k?: number; minScore?: number }) => Promise<SearchHit[]>
+
+async function loadSearch(): Promise<SearchFn | null> {
+  try {
+    const mod = (await import('../packages/doc-retrieval-mcp/src/search.js')) as {
+      search: SearchFn
+    }
+    return mod.search
+  } catch {
+    return null
+  }
+}
 
 const execFileAsync = promisify(execFile)
 
@@ -227,6 +245,22 @@ export async function runQuery(args: CliArgs): Promise<PrimingResult> {
     [signal1, signal2, signal3].filter(Boolean).join('\n\n'),
     QUERY_CAP_BYTES
   )
+
+  const search = await loadSearch()
+  if (!search) {
+    // @ruvector/core native binding unavailable on this host — log and
+    // gracefully degrade. Common cause: optional platform dep not installed
+    // (e.g. `ruvector-core-darwin-arm64` missing on macOS hosts).
+    logRetrievalEvent({
+      sessionId: args.sessionId,
+      ts: new Date().toISOString(),
+      trigger: 'session_start_priming',
+      query,
+      topKResults: '[]',
+      hookOutcome: 'partial_failure',
+    })
+    return { additionalContext: '' }
+  }
 
   let hits: SearchHit[]
   try {


### PR DESCRIPTION
## Summary

Hotfix to Step 7 (#774) caught by the §S9 post-deploy smoke I ran immediately after merge.

**Bug:** On a host without `@ruvector/core`'s platform-specific optional dep installed (e.g. `ruvector-core-darwin-arm64` missing on macOS), the previous static `import { search } from '...'` at the top of `scripts/session-priming-query.ts` threw at module-load time inside `createRequire('@ruvector/core')` (search.ts:7-9). Result: `runQuery()` never ran, so no `partial_failure` row landed in `retrieval_events` either — silent breakage. The hook still emitted empty `additionalContext` (graceful from the bash side), but the telemetry row was missing, which would have made Step 7b's soak gate blind to this host-environment failure mode.

**Fix:** Defer the search import to a `loadSearch()` async helper that catches the load error and returns `null`. `runQuery()` checks for null, logs a `partial_failure` row, returns empty context. ~35 LOC delta in one file.

## Smoke evidence

Pre-fix (host darwin-arm64 without the optional dep):
```
$ echo '{...startup event...}' | scripts/session-start-priming.sh
{"hookSpecificOutput": {"additionalContext": ""}}
$ sqlite3 retrieval-logs.db 'SELECT hook_outcome, COUNT(*) FROM retrieval_events;'
(empty — no rows)
```

Post-fix:
```
$ echo '{...startup event...}' | scripts/session-start-priming.sh
{"hookSpecificOutput": {"additionalContext": ""}}
$ sqlite3 retrieval-logs.db 'SELECT hook_outcome, ts, session_id FROM retrieval_events;'
partial_failure | 2026-04-25T21:18:56Z | smoke-test-...
partial_failure | 2026-04-25T21:18:22Z | smoke-test-...
```

## Test plan

- [x] 22/22 query.ts tests still pass (`vi.mock` applies to dynamic imports too — existing coverage holds)
- [x] Pre-commit: secrets clean, full typecheck clean, lint clean, format clean
- [x] §S9 smoke now writes the `partial_failure` row as designed
- [ ] Follow-up (separate PR / Step 7b retro): document the host-side `npm install ruvector-core-darwin-arm64` (or platform-equivalent) as one-time setup so users get full priming instead of the partial-failure fallback

## Notes

- The `partial_failure` outcome is the *correct* fallback when the host can't load `@ruvector/core`. The fix doesn't restore priming on that host — it restores observability so we can detect and remediate.
- Step 7b's soak gate already accounts for partial_failure rate (<2% threshold). If darwin-arm64 hosts dominate Skillsmith dev usage, the rate may exceed 2%, which would (correctly) hold Step 7c until the platform dep is installed broadly.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)