### PR TITLE
feat(SMI-4468): per-class rank boost + gate-harness rerank wiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -450,6 +450,8 @@ varlock run -- sh -c 'npx @vscode/vsce publish --no-dependencies --pat "$VSCE_SK
 
 A `SessionStart` hook (`scripts/session-start-priming.sh`) writes a transient priming index to `/tmp/session-priming-${SESSION_ID}.md` and pipes the same content into initial context as `additionalContext`. Fires only on `source=startup` and `smi-*`/`wave-*` branches; otherwise no-op. The transient file is mode 0600 and swept after 24h. Disable with `SKILLSMITH_DOC_RETRIEVAL_DISABLE_PRIMING=1`. The underlying retrieval index lives in `packages/doc-retrieval-mcp/`.
 
+**Per-class rank boost (SMI-4468)**: `rerank.ts` multiplies similarity by 1.5x for `class: feedback`/`project` chunks and 0.85x for `class: wave-spec`/`plans-review` chunks before applying absorption/supersession penalties. Tunable via `SKILLSMITH_DOC_RETRIEVAL_BOOST_MEMORY` and `SKILLSMITH_DOC_RETRIEVAL_DAMPEN_PROCESS` (clamped to [0.1, 5.0]).
+
 ---
 
 ## Troubleshooting

--- a/packages/doc-retrieval-mcp/src/rerank.test.ts
+++ b/packages/doc-retrieval-mcp/src/rerank.test.ts
@@ -7,7 +7,14 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { bm25Score, buildIdf, minMaxNormalize, rerank, tokenize } from './rerank.js'
+import {
+  bm25Score,
+  buildIdf,
+  classBoostFactor,
+  minMaxNormalize,
+  rerank,
+  tokenize,
+} from './rerank.js'
 import type { ChunkStoredMetadata, SearchHit } from './types.js'
 
 function makeHit(
@@ -251,5 +258,131 @@ describe('rerank — BM25 helpers (exported for unit coverage)', () => {
 
   it('minMaxNormalize returns [] for empty input', () => {
     expect(minMaxNormalize([])).toEqual([])
+  })
+})
+
+describe('rerank — SMI-4468 per-class boost', () => {
+  afterEach(() => {
+    delete process.env.SKILLSMITH_DOC_RETRIEVAL_BOOST_MEMORY
+    delete process.env.SKILLSMITH_DOC_RETRIEVAL_DAMPEN_PROCESS
+  })
+
+  it('classBoostFactor returns 1.0 when meta is undefined or class missing', () => {
+    expect(classBoostFactor(undefined)).toBe(1.0)
+    const noClass: ChunkStoredMetadata = {
+      file_path: 'x',
+      line_start: 1,
+      line_end: 1,
+      heading_chain: [],
+      text: '',
+    }
+    expect(classBoostFactor(noClass)).toBe(1.0)
+  })
+
+  it('classBoostFactor returns 1.0 for empty or unrecognized class arrays', () => {
+    const empty = makeHit('e', 0.5, 'x', { class: [] })
+    expect(classBoostFactor(empty.meta)).toBe(1.0)
+    const unknown = makeHit('u', 0.5, 'x', { class: ['markdown-doc', 'retro'] })
+    expect(classBoostFactor(unknown.meta)).toBe(1.0)
+  })
+
+  it('boosts feedback-class similarity by default 1.5x', () => {
+    const fb = makeHit('feedback', 0.4, 'feedback content', { class: ['feedback'] })
+    const out = rerank([fb], 'q')
+    // 0.4 * 1.5 = 0.6 (no penalty applies)
+    expect(out[0].score).toBeCloseTo(0.6, 4)
+    expect(out[0].similarity).toBe(0.4) // raw signal preserved
+  })
+
+  it('boosts project-class similarity by default 1.5x', () => {
+    const proj = makeHit('proj', 0.4, 'project content', { class: ['project'] })
+    const out = rerank([proj], 'q')
+    expect(out[0].score).toBeCloseTo(0.6, 4)
+  })
+
+  it('dampens wave-spec class by default 0.85x', () => {
+    const wave = makeHit('wave', 0.6, 'wave spec', { class: ['wave-spec'] })
+    const out = rerank([wave], 'q')
+    expect(out[0].score).toBeCloseTo(0.51, 4) // 0.6 * 0.85
+  })
+
+  it('dampens plans-review class by default 0.85x', () => {
+    const pr = makeHit('pr', 0.6, 'plan review', { class: ['plans-review'] })
+    const out = rerank([pr], 'q')
+    expect(out[0].score).toBeCloseTo(0.51, 4)
+  })
+
+  it('memory boost wins when both memory and process classes co-occur', () => {
+    // Defensive: schema drift could produce co-occurrence; memory provenance
+    // should always win because the chunk is at minimum a feedback chunk.
+    const mixed = makeHit('mixed', 0.4, 'content', { class: ['feedback', 'wave-spec'] })
+    const out = rerank([mixed], 'q')
+    expect(out[0].score).toBeCloseTo(0.6, 4) // 0.4 * 1.5 (memory boost), not 0.34 (dampener)
+  })
+
+  it('boost stacks with absorption cap — boosted+absorbed hits the 0.5 ceiling', () => {
+    // 0.9 * 1.5 = 1.35 (boosted), then * 0.5 = 0.675, capped to 0.5.
+    // Without the cap, boost would smuggle the absorbed chunk past its
+    // canonical replacement; the cap holds that line.
+    const absorbed = makeHit('a', 0.9, 'x', {
+      class: ['feedback'],
+      absorbed_by: 'canonical.md',
+    })
+    const out = rerank([absorbed], 'q')
+    expect(out[0].score).toBe(0.5)
+  })
+
+  it('dampener stacks with supersession penalty', () => {
+    const dampened = makeHit('d', 0.8, 'x', {
+      class: ['wave-spec'],
+      supersedes: 'newer.md',
+    })
+    const out = rerank([dampened], 'q')
+    // 0.8 * 0.85 * 0.5 = 0.34
+    expect(out[0].score).toBeCloseTo(0.34, 4)
+  })
+
+  it('env override SKILLSMITH_DOC_RETRIEVAL_BOOST_MEMORY changes the boost factor', () => {
+    process.env.SKILLSMITH_DOC_RETRIEVAL_BOOST_MEMORY = '2.0'
+    const fb = makeHit('fb', 0.3, 'feedback', { class: ['feedback'] })
+    const out = rerank([fb], 'q')
+    expect(out[0].score).toBeCloseTo(0.6, 4) // 0.3 * 2.0
+  })
+
+  it('env override SKILLSMITH_DOC_RETRIEVAL_DAMPEN_PROCESS changes the dampener', () => {
+    process.env.SKILLSMITH_DOC_RETRIEVAL_DAMPEN_PROCESS = '0.5'
+    const wave = makeHit('w', 0.8, 'wave', { class: ['wave-spec'] })
+    const out = rerank([wave], 'q')
+    expect(out[0].score).toBeCloseTo(0.4, 4) // 0.8 * 0.5
+  })
+
+  it('malformed env values fall back to defaults', () => {
+    process.env.SKILLSMITH_DOC_RETRIEVAL_BOOST_MEMORY = 'not-a-number'
+    const fb = makeHit('fb', 0.4, 'feedback', { class: ['feedback'] })
+    const out = rerank([fb], 'q')
+    expect(out[0].score).toBeCloseTo(0.6, 4) // default 1.5
+  })
+
+  it('negative or zero env values fall back to defaults', () => {
+    process.env.SKILLSMITH_DOC_RETRIEVAL_BOOST_MEMORY = '-2.0'
+    const fb = makeHit('fb', 0.4, 'feedback', { class: ['feedback'] })
+    const out = rerank([fb], 'q')
+    expect(out[0].score).toBeCloseTo(0.6, 4)
+  })
+
+  it('extreme env values clamp to [0.1, 5.0] range', () => {
+    process.env.SKILLSMITH_DOC_RETRIEVAL_BOOST_MEMORY = '999'
+    const fb = makeHit('fb', 0.1, 'feedback', { class: ['feedback'] })
+    const out = rerank([fb], 'q')
+    expect(out[0].score).toBeCloseTo(0.5, 4) // 0.1 * clamp(999, 5.0) = 0.5
+  })
+
+  it('reorders feedback chunk above unboosted longer doc with same similarity', () => {
+    // Demonstrates the SMI-4468 use case: short feedback chunk previously
+    // tied with longer impl-doc on cosine; boost gives it the edge.
+    const feedback = makeHit('fb', 0.5, 'feedback bullet', { class: ['feedback'] })
+    const impl = makeHit('impl', 0.5, 'impl doc body')
+    const out = rerank([impl, feedback], 'q')
+    expect(out[0].id).toBe('fb') // boosted to 0.75 vs unboosted 0.5
   })
 })

--- a/packages/doc-retrieval-mcp/src/rerank.ts
+++ b/packages/doc-retrieval-mcp/src/rerank.ts
@@ -30,7 +30,7 @@
  *     correct; a per-call flag would invite drift.
  */
 
-import type { SearchHit } from './types.js'
+import type { ChunkStoredMetadata, SearchHit } from './types.js'
 
 // Absorption demotion cap (SMI-4450 plan-review M3): replace hard ×0.3 multiply
 // with `min(similarity * 0.5, 0.5)` so a high-similarity absorbed chunk still
@@ -43,6 +43,18 @@ const ABSORPTION_CEILING = 0.5
 // IS in the index and will rank above the superseded entry, so a clean halve
 // is sufficient.
 const SUPERSESSION_HALVE_FACTOR = 0.5
+
+// SMI-4468 — Per-class rank boost defaults. Wave 1 ship gate halted at 2/6 on
+// 2026-04-25 because short feedback/project memory chunks (1-2 chunks each)
+// were outranked by longer impl docs covering the same topic. Boost factor
+// rewrites that imbalance by scaling similarity before the existing penalties.
+// Defaults are starting values; sweep via env to refine without code change.
+const DEFAULT_BOOST_MEMORY = 1.5
+const DEFAULT_DAMPEN_PROCESS = 0.85
+const BOOST_MIN = 0.1
+const BOOST_MAX = 5.0
+const MEMORY_CLASSES = new Set(['feedback', 'project'])
+const PROCESS_CLASSES = new Set(['wave-spec', 'plans-review'])
 
 // Phase 2 BM25 constants per SPARC §S6.
 const BM25_K1 = 1.5
@@ -79,25 +91,68 @@ export function rerank(hits: SearchHit[], query: string): SearchHit[] {
 }
 
 /**
- * Apply absorption + supersession penalties to a single hit.
+ * Apply class-boost + absorption + supersession penalties to a single hit.
  *
- * Returns a NEW hit with `score` rewritten and `similarity` preserved (so
- * downstream consumers can still see the raw embedding signal). When neither
- * penalty applies, returns a structurally-equal copy with `score === similarity`
- * (already true by construction in `search.ts`).
+ * Order matters: class boost runs FIRST, so a boosted-but-absorbed chunk's
+ * post-cap score still respects the 0.5 ceiling (boost cannot smuggle a
+ * superseded artifact above its canonical replacement). Returns a NEW hit
+ * with `score` rewritten and `similarity` preserved (downstream consumers
+ * see the raw embedding signal untouched).
  */
 function applyPenalties(hit: SearchHit): SearchHit {
   const absorbed = hit.meta?.absorbed_by
   const supersedes = hit.meta?.supersedes
 
-  let score = hit.similarity
+  const boosted = hit.similarity * classBoostFactor(hit.meta)
+
+  let score = boosted
   if (typeof absorbed === 'string' && absorbed.length > 0) {
-    score = Math.min(hit.similarity * ABSORPTION_HALVE_FACTOR, ABSORPTION_CEILING)
+    score = Math.min(boosted * ABSORPTION_HALVE_FACTOR, ABSORPTION_CEILING)
   } else if (typeof supersedes === 'string' && supersedes.length > 0) {
-    score = hit.similarity * SUPERSESSION_HALVE_FACTOR
+    score = boosted * SUPERSESSION_HALVE_FACTOR
   }
 
   return { ...hit, score }
+}
+
+/**
+ * SMI-4468 — Return the per-class similarity multiplier for a chunk.
+ *
+ * - `feedback` / `project` → boost (default 1.5x, env
+ *   `SKILLSMITH_DOC_RETRIEVAL_BOOST_MEMORY`). Lifts focused memory chunks
+ *   above longer process docs covering the same topic.
+ * - `wave-spec` / `plans-review` → dampen (default 0.85x, env
+ *   `SKILLSMITH_DOC_RETRIEVAL_DAMPEN_PROCESS`). Verbose process docs that
+ *   crowd memory chunks out of the cosine top-K.
+ * - All other classes (or missing/empty `class` array) → 1.0 (no change).
+ *
+ * If a chunk lists both a memory class and a process class, the memory
+ * boost wins — by construction these classes don't co-occur in the
+ * adapter, but defending against schema drift is cheap.
+ */
+export function classBoostFactor(meta: ChunkStoredMetadata | undefined): number {
+  const classes = meta?.class
+  if (!Array.isArray(classes) || classes.length === 0) return 1.0
+  if (classes.some((c) => MEMORY_CLASSES.has(c))) {
+    return readBoostFactor('SKILLSMITH_DOC_RETRIEVAL_BOOST_MEMORY', DEFAULT_BOOST_MEMORY)
+  }
+  if (classes.some((c) => PROCESS_CLASSES.has(c))) {
+    return readBoostFactor('SKILLSMITH_DOC_RETRIEVAL_DAMPEN_PROCESS', DEFAULT_DAMPEN_PROCESS)
+  }
+  return 1.0
+}
+
+/**
+ * Parse an env-supplied boost factor; clamp to [BOOST_MIN, BOOST_MAX] to keep
+ * malformed values (NaN, negative, huge) from corrupting ranking. Returns the
+ * default when env is unset or unparseable.
+ */
+function readBoostFactor(envVar: string, fallback: number): number {
+  const raw = process.env[envVar]
+  if (raw === undefined || raw === '') return fallback
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback
+  return Math.max(BOOST_MIN, Math.min(BOOST_MAX, parsed))
 }
 
 /**

--- a/scripts/tests/retro-reversal-pairs.test.ts
+++ b/scripts/tests/retro-reversal-pairs.test.ts
@@ -228,13 +228,30 @@ describe.skipIf(REAL_MODE)('Step 8 — runner gate (mocked)', () => {
 // Real-mode gate. Skipped unless RETRO_REVERSAL_PAIRS_REAL=1 is set so CI
 // (no native binding, no populated index) does not break.
 describe.runIf(REAL_MODE)('Step 8 — runner gate (REAL index)', () => {
-  it('training set passes ≥ 5/6 against the real RuVector index', async () => {
+  // Per `rerank.ts` header contract and SPARC §S6 plan-review H3, the
+  // production retrieval flow is: search(k=20, preRerank=true) → rerank →
+  // minScore filter → truncate to k=5. SMI-4468 surfaced that the original
+  // gate harness called search(k=5) directly, bypassing rerank entirely —
+  // so absorption penalties, BM25/MMR fallback, and per-class boost were
+  // all dead code at the gate. This wrapper exercises the documented flow.
+  const POOL_SIZE = 20
+  const TOP_K = 5
+  const MIN_SCORE = 0.35
+
+  async function gateSearch(query: string): Promise<SearchHit[]> {
     const { search } = await import('../../packages/doc-retrieval-mcp/src/search.js')
+    const { rerank } = await import('../../packages/doc-retrieval-mcp/src/rerank.js')
+    const pool = await search({ query, k: POOL_SIZE, preRerank: true })
+    const reranked = rerank(pool, query)
+    return reranked.filter((h) => h.score >= MIN_SCORE).slice(0, TOP_K)
+  }
+
+  it('training set passes ≥ 5/6 against the real RuVector index', async () => {
     const pairs = loadPairs(TRAINING_PATH)
     let passed = 0
     const failures: string[] = []
     for (const p of pairs) {
-      const hits = await search({ query: p.query, k: 5, minScore: 0.35 })
+      const hits = await gateSearch(p.query)
       if (pairPasses(p, hits)) {
         passed++
       } else {
@@ -260,10 +277,9 @@ describe.runIf(REAL_MODE)('Step 8 — runner gate (REAL index)', () => {
       // Pre-soak window — held-out empty by design. Skip.
       return
     }
-    const { search } = await import('../../packages/doc-retrieval-mcp/src/search.js')
     let passed = 0
     for (const p of heldOut) {
-      const hits = await search({ query: p.query, k: 5, minScore: 0.35 })
+      const hits = await gateSearch(p.query)
       if (pairPasses(p, hits)) passed++
     }
     // Held-out gate per §S7: pass at >= same rate as training (5/6 ≈ 0.833).


### PR DESCRIPTION
## Summary

- Adds per-class similarity multiplier in `rerank.ts`: 1.5x for `class: feedback`/`project`, 0.85x for `class: wave-spec`/`plans-review`. Boost runs before absorption cap so boosted+absorbed still hits the 0.5 ceiling. Tunable via `SKILLSMITH_DOC_RETRIEVAL_BOOST_MEMORY` / `SKILLSMITH_DOC_RETRIEVAL_DAMPEN_PROCESS` (clamped to [0.1, 5.0]).
- Wires the Step 8 6-pair gate's real-mode block through the documented `search(k=20, preRerank=true) → rerank → minScore filter → top-5` pipeline. The original gate called `search({k:5})` directly, making absorption/supersession penalties (Step 6), BM25/MMR fallback, and the SMI-4468 boost all dead code at the gate.

## Context

Wave 1 ship gate halted on 2026-04-25 at 2/6. Standalone, this PR's boost cannot move the gate — see SMI-4473 (#PR-stacked-on-this) for the actual ship-gate fix. SMI-4468's boost remains a necessary multiplier once memory chunks land in the corpus.

## Test plan

- [x] `npx vitest run packages/doc-retrieval-mcp/src/rerank.test.ts` — 40 tests pass (25 existing + 15 new)
- [x] `npm run audit:standards` — 49 passed / 0 failed / 4 pre-existing warnings
- [x] `tsc --noEmit -p packages/doc-retrieval-mcp/tsconfig.json` — clean
- [x] `eslint` + `prettier --check` — clean
- [x] Real-mode 6-pair gate after SMI-4473 reindex — 6/6

## Linear

- SMI-4468 (https://linear.app/smith-horn-group/issue/SMI-4468)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)