### PR TITLE
feat(SMI-4473): wire corpus expansion adapters + memory dir override (restores 6-pair gate)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ docs/irap/
 
 # Blog image generation working directory
 docs/articles/tmp/
+.tmp/

--- a/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.test.ts
+++ b/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.test.ts
@@ -69,6 +69,30 @@ describe('resolveMemoryDir', () => {
     const dir = resolveMemoryDir(FAKE_CWD)
     expect(dir).toBe(memoryDir)
   })
+
+  it('SKILLSMITH_MEMORY_DIR_OVERRIDE bypasses home/encoded-cwd derivation (SMI-4473)', () => {
+    const orig = process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE
+    try {
+      process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE = '/staged/host/memory'
+      expect(resolveMemoryDir('/anything')).toBe('/staged/host/memory')
+      expect(resolveMemoryDir('')).toBe('/staged/host/memory') // override wins even when cwd missing
+    } finally {
+      if (orig === undefined) delete process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE
+      else process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE = orig
+    }
+  })
+
+  it('rejects relative override (must be absolute path)', () => {
+    const orig = process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE
+    try {
+      process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE = 'relative/dir'
+      // Falls through to normal derivation when override is non-absolute.
+      expect(resolveMemoryDir(FAKE_CWD)).toBe(memoryDir)
+    } finally {
+      if (orig === undefined) delete process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE
+      else process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE = orig
+    }
+  })
 })
 
 describe('memory-topic-files adapter — listFiles', () => {

--- a/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.ts
+++ b/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.ts
@@ -175,8 +175,17 @@ function isIndexable(name: string): boolean {
  * the indexer's per-adapter try-free loop and a throw would abort the
  * full ingest run. The SPARC note's "throw on encoding drift" intent is
  * preserved via the roundtrip unit test instead.
+ *
+ * `SKILLSMITH_MEMORY_DIR_OVERRIDE` env (SMI-4473): when set to an absolute
+ * directory path, bypasses the home/encoded-cwd derivation entirely. This
+ * unblocks Docker workflows where `homedir()` returns `/root` and the
+ * host's `~/.claude/projects/<encoded>/memory/` is not bind-mounted —
+ * caller stages the memory files into a path Docker can already read
+ * (e.g., a tmpdir inside the `/app` bind-mount) and points the env at it.
  */
 export function resolveMemoryDir(cwd: string): string | null {
+  const override = process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE
+  if (override && override[0] === '/') return override
   if (!cwd || cwd[0] !== '/') return null
   const encoded = '-' + cwd.slice(1).replace(/\//g, '-')
   const home = homedir()

--- a/packages/doc-retrieval-mcp/src/corpus.config.json
+++ b/packages/doc-retrieval-mcp/src/corpus.config.json
@@ -19,6 +19,16 @@
     "docs/internal/**/*.md",
     "packages/*/README.md"
   ],
+  "adapters": [
+    {
+      "kind": "memory-topic-files",
+      "_rationale": "SMI-4473 — Step 4 corpus expansion shipped this adapter but the previous corpus.config.json never enabled it, so feedback_*.md memory files were 0-chunk and the 6-pair gate failed 2/6 from a corpus coverage gap (not a ranking gap). Inside Docker, requires SKILLSMITH_MEMORY_DIR_OVERRIDE pointing to a path Docker can read."
+    },
+    {
+      "kind": "script-headers",
+      "_rationale": "SMI-4473 — covers pair-5 alternate (scripts/pooler-psql.sh) and gives the indexer first-class coverage of scripts/*.{sh,mjs,ts} headers."
+    }
+  ],
   "requireSubmodule": "docs/internal",
   "_storagePathRationale": "@ruvector/core@0.1.30 creates a SINGLE FILE at the exact storagePath given (not a directory tree as the initial plan assumed). SMI-4426 renamed `rvfPath` to `storagePath`. The indexer creates this as a DIRECTORY and passes join(storageAbs,'vectors') to VectorDb, so the lock (.indexer.lock) and the db file (vectors) coexist inside this directory. Legacy *.rvf gitignore entry kept harmless."
 }


### PR DESCRIPTION
## Summary

- Adds `memory-topic-files` and `script-headers` to `corpus.config.json` `adapters` array. Step 4 corpus expansion shipped these adapters (PR #735 era) but never registered them in config — they've been dead code in production since Step 4.
- Adds `SKILLSMITH_MEMORY_DIR_OVERRIDE` env support to `memory-topic-files.ts` so the indexer running inside Docker can read host memory files via a staged copy under the existing `/app` bind-mount (Docker's `homedir()=/root` and `~/.claude/projects/` is not bind-mounted).
- `.tmp/` added to `.gitignore` so staged memory copies don't leak into commits.

## Context

The Wave 1 ship gate halt retro misdiagnosed the 2/6 result as a ranking problem — \"expected files ARE in the corpus post-reindex (1-79 chunks each)\" came from grep hits in OTHER files mentioning the feedback paths. Actual state: 3 of 4 missing pairs reference paths from adapters that never ran. Halt retro updated with corrected diagnosis (separate PR on docs submodule branch `smi-4451-wave1-halt-retro`).

**Real-mode 6-pair gate after this PR + reindex: 6/6** (was 2/6 baseline; was 2/6 after SMI-4468 alone).

| pair | top-1 hit | source |
|---|---|---|
| 1 | `memory://root/feedback_audit_logs_no_user_id_column.md` | memory-topic-files |
| 2 | `memory://root/feedback_edge_function_allowlists.md` | memory-topic-files |
| 3 | `docs/internal/retros/2026-04-23-smi-4401-wave2-ux.md` | markdown-corpus |
| 4 | `docs/internal/retros/2026-04-20-smi-4361-publish-yml-nested-node-modules.md` | markdown-corpus |
| 5 | `memory://root/feedback_pooler_url_stale_vs_db_password.md` | memory-topic-files |
| 6 | `docs/internal/retros/2026-04-17-smi-4252-prod-verification-and-staging-url-confusion.md` | markdown-corpus |

## Stacked on

#784 (SMI-4468 per-class rank boost + gate-harness rerank wiring). Merge that first.

## Followups

- Adapter→class plumbing: memory adapter sets `kind: 'memory'` but not `class: ['feedback']`. SMI-4468's boost depends on `class` membership tests, so it's currently inert on memory chunks. Worth a small follow-up to detect `feedback_*` / `project_*` filename prefixes and stamp `class` accordingly.
- Native binding install on host (Followup-4 from PR #780 retro): cleaner long-term path than the env-override+stage approach here. Documented in CLAUDE.md as one-time setup.

## Test plan

- [x] `npx vitest run packages/doc-retrieval-mcp/` — 182 tests pass (14 files)
- [x] `npm run audit:standards` — 49 / 0 / 4
- [x] Reindex via `cli.ts reindex --full` — 1296 files / 26818 chunks
- [x] Real-mode 6-pair gate — 6/6 with full per-pair output captured

## Linear

- SMI-4473 (https://linear.app/smith-horn-group/issue/SMI-4473)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)