### PR TITLE
fix(cli): SMI-4474 auto-load JWT so logged-in CLI commands count toward quota

### DIFF
--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -13,6 +13,7 @@ import {
   initializeSchema,
   SkillRepository,
   createApiClient,
+  loadStoredAccessToken,
 } from '@skillsmith/core'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
@@ -70,7 +71,9 @@ export function createInfoCommand(): Command {
         // Try API for content if not available locally
         if (!content) {
           try {
-            const apiClient = createApiClient()
+            // SMI-4474: auto-load JWT so logged-in users count toward quota.
+            const jwtToken = await loadStoredAccessToken()
+            const apiClient = createApiClient(jwtToken ? { jwtToken } : {})
             if (!apiClient.isOffline()) {
               const apiResponse = await apiClient.getSkill(skillId, { includeContent: true })
               content = apiResponse.data.content || undefined

--- a/packages/cli/src/commands/recommend.ts
+++ b/packages/cli/src/commands/recommend.ts
@@ -8,7 +8,13 @@
 import { Command } from 'commander'
 import chalk from 'chalk'
 import ora from 'ora'
-import { CodebaseAnalyzer, createApiClient, type SkillRole, SKILL_ROLES } from '@skillsmith/core'
+import {
+  CodebaseAnalyzer,
+  createApiClient,
+  loadStoredAccessToken,
+  type SkillRole,
+  SKILL_ROLES,
+} from '@skillsmith/core'
 import { sanitizeError } from '../utils/sanitize.js'
 
 // Re-export types for public API
@@ -68,7 +74,9 @@ async function runRecommend(targetPath: string, options: RecommendOptions): Prom
     }
 
     // Step 3: Call recommendation API
-    const apiClient = createApiClient()
+    // SMI-4474: auto-load JWT so logged-in users count toward quota.
+    const jwtToken = await loadStoredAccessToken()
+    const apiClient = createApiClient(jwtToken ? { jwtToken } : {})
 
     const apiResponse = await apiClient.getRecommendations({
       stack: stack.slice(0, 10),

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -21,6 +21,7 @@ import {
   createDatabaseAsync,
   SkillRepository,
   createApiClient,
+  loadStoredAccessToken,
   SyncConfigRepository,
   SyncHistoryRepository,
   SyncEngine,
@@ -53,7 +54,10 @@ async function runSync(options: {
       const syncConfigRepo = new SyncConfigRepository(db)
       const syncHistoryRepo = new SyncHistoryRepository(db)
       const skillVersionRepo = new SkillVersionRepository(db)
-      const apiClient = createApiClient()
+      // SMI-4474: auto-load JWT from ~/.skillsmith/config.json so logged-in
+      // users count toward their quota instead of going anonymous.
+      const jwtToken = await loadStoredAccessToken()
+      const apiClient = createApiClient(jwtToken ? { jwtToken } : {})
 
       const syncEngine = new SyncEngine(
         apiClient,

--- a/packages/cli/tests/recommend.errors.test.ts
+++ b/packages/cli/tests/recommend.errors.test.ts
@@ -1,0 +1,304 @@
+/**
+ * SMI-1353: CLI recommend command — error handling, limit validation, trust tier.
+ *
+ * Sibling of recommend.test.ts and recommend.filters.test.ts; see those files
+ * for context. Shared mocks/fixtures live in recommend.test-helpers.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createMockCodebaseContext, createMockApiResponse } from './recommend.test-helpers.js'
+
+const mocks = vi.hoisted(() => ({
+  analyze: vi.fn(),
+  getRecommendations: vi.fn(),
+  spinner: {
+    start: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+    text: '',
+  },
+}))
+
+vi.mock('@skillsmith/core', () => ({
+  CodebaseAnalyzer: class MockCodebaseAnalyzer {
+    analyze(...args: unknown[]) {
+      return mocks.analyze(...args)
+    }
+  },
+  createApiClient: () => ({
+    getRecommendations: (...args: unknown[]) => mocks.getRecommendations(...args),
+  }),
+  // SMI-4474: stub for JWT auto-load (tests don't exercise the JWT path).
+  loadStoredAccessToken: () => Promise.resolve(null),
+  SKILL_ROLES: [
+    'code-quality',
+    'testing',
+    'documentation',
+    'workflow',
+    'security',
+    'development-partner',
+  ] as const,
+}))
+vi.mock('ora', () => ({ default: () => mocks.spinner }))
+
+const mockAnalyze = mocks.analyze
+const mockGetRecommendations = mocks.getRecommendations
+const mockSpinner = mocks.spinner
+
+const originalConsoleLog = console.log
+const originalConsoleError = console.error
+const mockConsoleLog = vi.fn()
+const mockConsoleError = vi.fn()
+
+const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+
+describe('SMI-1353: CLI recommend command — errors / limit / trust tier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    console.log = mockConsoleLog
+    console.error = mockConsoleError
+    mockAnalyze.mockResolvedValue(createMockCodebaseContext())
+    mockGetRecommendations.mockResolvedValue(createMockApiResponse())
+  })
+
+  afterEach(() => {
+    console.log = originalConsoleLog
+    console.error = originalConsoleError
+  })
+
+  // ==========================================================================
+  // Error Handling Tests
+  // ==========================================================================
+
+  describe('error handling', () => {
+    it('should handle CodebaseAnalyzer errors gracefully', async () => {
+      mockAnalyze.mockRejectedValue(new Error('Cannot read directory'))
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '/nonexistent'])
+
+      expect(mockSpinner.fail).toHaveBeenCalledWith('Recommendation failed')
+      expect(mockExit).toHaveBeenCalledWith(1)
+    })
+
+    it('should handle API errors gracefully', async () => {
+      mockGetRecommendations.mockRejectedValue(new Error('API unavailable'))
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      expect(mockSpinner.fail).toHaveBeenCalledWith('Recommendation failed')
+      expect(mockExit).toHaveBeenCalledWith(1)
+    })
+
+    it('should output error as JSON with --json flag on failure', async () => {
+      mockAnalyze.mockRejectedValue(new Error('Analysis failed'))
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.', '--json'])
+
+      const errorOutput = mockConsoleError.mock.calls[0]![0]
+      const parsed = JSON.parse(errorOutput)
+      expect(parsed).toHaveProperty('error')
+    })
+
+    it('should sanitize error messages (remove user paths)', async () => {
+      mockAnalyze.mockRejectedValue(new Error('Error at /Users/secret/project'))
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      const errorCalls = mockConsoleError.mock.calls
+      expect(errorCalls.length).toBeGreaterThan(0)
+    })
+
+    it('should handle network errors with offline fallback', async () => {
+      const context = createMockCodebaseContext()
+      mockAnalyze.mockResolvedValue(context)
+      const networkError = new Error('fetch failed')
+      mockGetRecommendations.mockRejectedValue(networkError)
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      expect(mockSpinner.warn).toHaveBeenCalledWith(expect.stringContaining('Unable to reach API'))
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join('\n')
+      expect(output).toContain('Codebase Analysis')
+    })
+
+    it('should show offline JSON output on network error with --json', async () => {
+      mockAnalyze.mockResolvedValue(createMockCodebaseContext())
+      mockGetRecommendations.mockRejectedValue(new Error('fetch failed'))
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.', '--json'])
+
+      const output = mockConsoleLog.mock.calls[0]![0]
+      const parsed = JSON.parse(output)
+      expect(parsed.offline).toBe(true)
+      expect(parsed.analysis).toBeDefined()
+    })
+  })
+
+  // ==========================================================================
+  // Limit Validation Tests
+  // ==========================================================================
+
+  describe('limit option validation', () => {
+    it('should default to limit 5 when not specified', async () => {
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      expect(mockGetRecommendations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 5,
+        })
+      )
+    })
+
+    it('should clamp limit to minimum of 1', async () => {
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.', '--limit', '0'])
+
+      expect(mockGetRecommendations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 1,
+        })
+      )
+    })
+
+    it('should clamp limit to maximum of 50', async () => {
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.', '--limit', '100'])
+
+      expect(mockGetRecommendations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 50,
+        })
+      )
+    })
+
+    it('should handle non-numeric limit gracefully', async () => {
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.', '--limit', 'invalid'])
+
+      expect(mockGetRecommendations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 5,
+        })
+      )
+    })
+  })
+
+  // ==========================================================================
+  // Trust Tier Handling Tests
+  // ==========================================================================
+
+  describe('trust tier handling', () => {
+    it('should display VERIFIED badge for verified skills', async () => {
+      mockGetRecommendations.mockResolvedValue(
+        createMockApiResponse([
+          {
+            id: 'test/skill',
+            name: 'Verified Skill',
+            description: 'A verified skill',
+            author: 'test',
+            repo_url: null,
+            quality_score: 0.9,
+            trust_tier: 'verified',
+            tags: [],
+            stars: 100,
+            created_at: '2024-01-01',
+            updated_at: '2024-01-01',
+          },
+        ])
+      )
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join('\n')
+      expect(output).toContain('VERIFIED')
+    })
+
+    it('should display COMMUNITY badge for community skills', async () => {
+      mockGetRecommendations.mockResolvedValue(
+        createMockApiResponse([
+          {
+            id: 'test/skill',
+            name: 'Community Skill',
+            description: 'A community skill',
+            author: 'test',
+            repo_url: null,
+            quality_score: 0.7,
+            trust_tier: 'community',
+            tags: [],
+            stars: 50,
+            created_at: '2024-01-01',
+            updated_at: '2024-01-01',
+          },
+        ])
+      )
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join('\n')
+      expect(output).toContain('COMMUNITY')
+    })
+
+    it('should handle unknown trust tier gracefully', async () => {
+      mockGetRecommendations.mockResolvedValue(
+        createMockApiResponse([
+          {
+            id: 'test/skill',
+            name: 'Unknown Tier Skill',
+            description: 'A skill with invalid tier',
+            author: 'test',
+            repo_url: null,
+            quality_score: 0.5,
+            trust_tier: 'invalid_tier',
+            tags: [],
+            stars: 10,
+            created_at: '2024-01-01',
+            updated_at: '2024-01-01',
+          },
+        ])
+      )
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join('\n')
+      expect(output).toContain('UNKNOWN')
+    })
+  })
+})

--- a/packages/cli/tests/recommend.filters.test.ts
+++ b/packages/cli/tests/recommend.filters.test.ts
@@ -1,0 +1,301 @@
+/**
+ * SMI-1353: CLI recommend command — stack building, role-based filtering,
+ * module exports.
+ *
+ * Sibling of recommend.test.ts and recommend.errors.test.ts; see those files
+ * for context. Shared mocks/fixtures live in recommend.test-helpers.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createMockCodebaseContext, createMockApiResponse } from './recommend.test-helpers.js'
+
+const mocks = vi.hoisted(() => ({
+  analyze: vi.fn(),
+  getRecommendations: vi.fn(),
+  spinner: {
+    start: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+    text: '',
+  },
+}))
+
+vi.mock('@skillsmith/core', () => ({
+  CodebaseAnalyzer: class MockCodebaseAnalyzer {
+    analyze(...args: unknown[]) {
+      return mocks.analyze(...args)
+    }
+  },
+  createApiClient: () => ({
+    getRecommendations: (...args: unknown[]) => mocks.getRecommendations(...args),
+  }),
+  // SMI-4474: stub for JWT auto-load (tests don't exercise the JWT path).
+  loadStoredAccessToken: () => Promise.resolve(null),
+  SKILL_ROLES: [
+    'code-quality',
+    'testing',
+    'documentation',
+    'workflow',
+    'security',
+    'development-partner',
+  ] as const,
+}))
+vi.mock('ora', () => ({ default: () => mocks.spinner }))
+
+const mockAnalyze = mocks.analyze
+const mockGetRecommendations = mocks.getRecommendations
+
+const originalConsoleLog = console.log
+const originalConsoleError = console.error
+const mockConsoleLog = vi.fn()
+const mockConsoleError = vi.fn()
+
+vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+
+describe('SMI-1353: CLI recommend command — stack / role filter / exports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    console.log = mockConsoleLog
+    console.error = mockConsoleError
+    mockAnalyze.mockResolvedValue(createMockCodebaseContext())
+    mockGetRecommendations.mockResolvedValue(createMockApiResponse())
+  })
+
+  afterEach(() => {
+    console.log = originalConsoleLog
+    console.error = originalConsoleError
+  })
+
+  // ==========================================================================
+  // Stack Building Tests
+  // ==========================================================================
+
+  describe('stack building from analysis', () => {
+    it('should include framework names in stack (lowercase)', async () => {
+      mockAnalyze.mockResolvedValue(
+        createMockCodebaseContext({
+          frameworks: [
+            { name: 'Next.js', confidence: 0.9, source: 'dep', detectedFrom: [] },
+            { name: 'TailwindCSS', confidence: 0.85, source: 'dep', detectedFrom: [] },
+          ],
+          dependencies: [{ name: 'next', version: '^14.0.0', isDev: false }],
+        })
+      )
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      expect(mockGetRecommendations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stack: expect.arrayContaining(['next.js', 'tailwindcss']),
+        })
+      )
+    })
+
+    it('should include non-dev dependencies in stack', async () => {
+      mockAnalyze.mockResolvedValue(
+        createMockCodebaseContext({
+          frameworks: [{ name: 'Express', confidence: 0.9, source: 'dep', detectedFrom: [] }],
+          dependencies: [
+            { name: 'express', version: '^4.0.0', isDev: false },
+            { name: 'mongoose', version: '^7.0.0', isDev: false },
+          ],
+        })
+      )
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      expect(mockGetRecommendations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stack: expect.arrayContaining(['express', 'mongoose']),
+        })
+      )
+    })
+
+    it('should exclude dev dependencies from stack', async () => {
+      mockAnalyze.mockResolvedValue(
+        createMockCodebaseContext({
+          frameworks: [{ name: 'React', confidence: 0.9, source: 'dep', detectedFrom: [] }],
+          dependencies: [
+            { name: 'react', version: '^18.0.0', isDev: false },
+            { name: 'jest', version: '^29.0.0', isDev: true },
+            { name: 'eslint', version: '^8.0.0', isDev: true },
+          ],
+        })
+      )
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      const call = mockGetRecommendations.mock.calls[0]![0]
+      expect(call.stack).not.toContain('jest')
+      expect(call.stack).not.toContain('eslint')
+      expect(call.stack).toContain('react')
+    })
+
+    it('should limit stack to 10 items', async () => {
+      mockAnalyze.mockResolvedValue(
+        createMockCodebaseContext({
+          frameworks: Array.from({ length: 6 }, (_, i) => ({
+            name: `Framework${i}`,
+            confidence: 0.9,
+            source: 'dep',
+            detectedFrom: [],
+          })),
+          dependencies: Array.from({ length: 12 }, (_, i) => ({
+            name: `dep${i}`,
+            version: '^1.0.0',
+            isDev: false,
+          })),
+        })
+      )
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      const call = mockGetRecommendations.mock.calls[0]![0]
+      expect(call.stack.length).toBeLessThanOrEqual(10)
+    })
+
+    it('should deduplicate stack items', async () => {
+      mockAnalyze.mockResolvedValue(
+        createMockCodebaseContext({
+          frameworks: [{ name: 'React', confidence: 0.9, source: 'dep', detectedFrom: [] }],
+          dependencies: [{ name: 'react', version: '^18.0.0', isDev: false }],
+        })
+      )
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.'])
+
+      const call = mockGetRecommendations.mock.calls[0]![0]
+      const reactCount = call.stack.filter((s: string) => s === 'react').length
+      expect(reactCount).toBe(1)
+    })
+  })
+
+  // ==========================================================================
+  // SMI-1631: Role-Based Filtering Tests
+  // ==========================================================================
+
+  describe('role-based filtering', () => {
+    it('should apply role filtering locally', async () => {
+      mockGetRecommendations.mockResolvedValue(
+        createMockApiResponse([
+          {
+            id: 'test/test-helper',
+            name: 'Test Helper',
+            description: 'Testing utilities',
+            author: 'test',
+            repo_url: null,
+            quality_score: 0.8,
+            trust_tier: 'verified',
+            tags: ['testing', 'jest', 'unit-test'],
+            stars: 100,
+            created_at: '2024-01-01',
+            updated_at: '2024-01-01',
+          },
+        ])
+      )
+
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.', '--role', 'testing', '--json'])
+
+      const output = mockConsoleLog.mock.calls[0]![0]
+      const parsed = JSON.parse(output)
+      expect(parsed.meta.role_filter).toBe('testing')
+    })
+
+    it('should not set role filter for invalid role', async () => {
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.', '--role', 'invalid-role', '--json'])
+
+      const output = mockConsoleLog.mock.calls[0]![0]
+      const parsed = JSON.parse(output)
+      expect(parsed.meta.role_filter).toBeNull()
+    })
+
+    it('should warn user about invalid role', async () => {
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.', '--role', 'not-a-role'])
+
+      const errorOutput = mockConsoleError.mock.calls.map((c) => c[0]).join('\n')
+      expect(errorOutput).toContain('Invalid role')
+      expect(errorOutput).toContain('not-a-role')
+    })
+
+    it('should accept all valid role values', async () => {
+      const validRoles = [
+        'code-quality',
+        'testing',
+        'documentation',
+        'workflow',
+        'security',
+        'development-partner',
+      ]
+
+      for (const role of validRoles) {
+        vi.clearAllMocks()
+        mockAnalyze.mockResolvedValue(createMockCodebaseContext())
+        mockGetRecommendations.mockResolvedValue(createMockApiResponse())
+
+        const { createRecommendCommand } = await import('../src/commands/recommend.js')
+        const cmd = createRecommendCommand()
+
+        await cmd.parseAsync(['node', 'test', '.', '-r', role, '--json'])
+
+        const output = mockConsoleLog.mock.calls[0]![0]
+        const parsed = JSON.parse(output)
+        expect(parsed.meta.role_filter).toBe(role)
+      }
+    })
+
+    it('should include role_filter in JSON output when specified', async () => {
+      const { createRecommendCommand } = await import('../src/commands/recommend.js')
+      const cmd = createRecommendCommand()
+
+      await cmd.parseAsync(['node', 'test', '.', '--role', 'security', '--json'])
+
+      const output = mockConsoleLog.mock.calls[0]![0]
+      const parsed = JSON.parse(output)
+      expect(parsed.meta.role_filter).toBe('security')
+    })
+  })
+
+  // ==========================================================================
+  // Export Tests
+  // ==========================================================================
+
+  describe('module exports', () => {
+    it('should export createRecommendCommand from commands/index', async () => {
+      const indexExports = await import('../src/commands/index.js')
+      expect(indexExports.createRecommendCommand).toBeDefined()
+      expect(typeof indexExports.createRecommendCommand).toBe('function')
+    })
+
+    it('should export createRecommendCommand as default', async () => {
+      const mod = await import('../src/commands/recommend.js')
+      expect(mod.default).toBeDefined()
+      expect(typeof mod.default).toBe('function')
+    })
+  })
+})

--- a/packages/cli/tests/recommend.test-helpers.ts
+++ b/packages/cli/tests/recommend.test-helpers.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared fixtures for the SMI-1353 recommend command test files.
+ *
+ * The full suite was split across three sibling files (`recommend.test.ts`,
+ * `recommend.errors.test.ts`, `recommend.filters.test.ts`) so each file stays
+ * under the 500-line standard. Pure fixtures (no `vi.hoisted`, no mock
+ * factory) live here; each test file owns its own `vi.hoisted` mocks +
+ * `vi.mock(...)` block since vitest doesn't allow exporting hoisted values
+ * across module boundaries.
+ */
+
+/**
+ * Skill data type for mock responses
+ */
+export interface MockSkillData {
+  id: string
+  name: string
+  description: string
+  author: string
+  repo_url: string | null
+  quality_score: number
+  trust_tier: string
+  tags: string[]
+  stars: number
+  created_at: string
+  updated_at: string
+}
+
+/**
+ * Creates a mock CodebaseContext for testing
+ */
+export function createMockCodebaseContext(overrides = {}) {
+  return {
+    rootPath: '/test/project',
+    imports: [],
+    exports: [],
+    functions: [],
+    frameworks: [
+      { name: 'React', confidence: 0.95, source: 'dep', detectedFrom: [] },
+      { name: 'TypeScript', confidence: 0.9, source: 'dep', detectedFrom: [] },
+    ],
+    dependencies: [
+      { name: 'react', version: '^18.0.0', isDev: false },
+      { name: 'typescript', version: '^5.0.0', isDev: true },
+      { name: 'jest', version: '^29.0.0', isDev: true },
+    ],
+    stats: {
+      totalFiles: 42,
+      filesByExtension: { '.ts': 30, '.tsx': 12 },
+      totalLines: 5000,
+    },
+    metadata: {
+      durationMs: 150,
+      version: '1.0.0',
+    },
+    ...overrides,
+  }
+}
+
+/**
+ * Creates a mock API response for recommendations
+ */
+export function createMockApiResponse(skills: MockSkillData[] = []) {
+  return {
+    data:
+      skills.length > 0
+        ? skills
+        : [
+            {
+              id: 'anthropic/jest-helper',
+              name: 'Jest Helper',
+              description: 'Jest testing utilities',
+              author: 'anthropic',
+              repo_url: 'https://github.com/anthropic/jest-helper',
+              quality_score: 0.85,
+              trust_tier: 'verified',
+              tags: ['testing', 'jest'],
+              stars: 150,
+              created_at: '2024-01-01',
+              updated_at: '2024-01-15',
+            },
+            {
+              id: 'community/react-tools',
+              name: 'React Tools',
+              description: 'React development utilities',
+              author: 'community',
+              repo_url: 'https://github.com/community/react-tools',
+              quality_score: 0.72,
+              trust_tier: 'community',
+              tags: ['react', 'development'],
+              stars: 89,
+              created_at: '2024-02-01',
+              updated_at: '2024-02-10',
+            },
+          ],
+    meta: {},
+  }
+}

--- a/packages/cli/tests/recommend.test.ts
+++ b/packages/cli/tests/recommend.test.ts
@@ -1,20 +1,17 @@
 /**
- * SMI-1353: CLI recommend command tests with real behavior assertions
+ * SMI-1353: CLI recommend command — registration + analyzer + API + output.
  *
- * Tests follow London School TDD with mocked dependencies to verify
- * interactions between the recommend command and its collaborators.
+ * Split from the original 1012-line file into three sibling files (this one,
+ * recommend.errors.test.ts, recommend.filters.test.ts) so each stays under
+ * the 500-line standard. Shared mocks/fixtures live in recommend.test-helpers.
  *
  * Parent issue: SMI-1299 (CLI recommend command)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Command } from 'commander'
+import { createMockCodebaseContext, createMockApiResponse } from './recommend.test-helpers.js'
 
-// ============================================================================
-// Mock Setup - Must be before imports
-// ============================================================================
-
-// Create a mocks container that survives hoisting
 const mocks = vi.hoisted(() => ({
   analyze: vi.fn(),
   getRecommendations: vi.fn(),
@@ -37,7 +34,10 @@ vi.mock('@skillsmith/core', () => ({
   createApiClient: () => ({
     getRecommendations: (...args: unknown[]) => mocks.getRecommendations(...args),
   }),
-  // SMI-1631: Add SKILL_ROLES export for role-based filtering
+  // SMI-4474: command imports loadStoredAccessToken for JWT auto-load. Tests
+  // don't exercise the JWT path, so a stub returning null is sufficient — the
+  // command falls through to the createApiClient mock above.
+  loadStoredAccessToken: () => Promise.resolve(null),
   SKILL_ROLES: [
     'code-quality',
     'testing',
@@ -47,128 +47,24 @@ vi.mock('@skillsmith/core', () => ({
     'development-partner',
   ] as const,
 }))
+vi.mock('ora', () => ({ default: () => mocks.spinner }))
 
-vi.mock('ora', () => ({
-  default: () => mocks.spinner,
-}))
-
-// Convenience aliases
 const mockAnalyze = mocks.analyze
 const mockGetRecommendations = mocks.getRecommendations
 const mockSpinner = mocks.spinner
 
-// Mock console.log/error for output verification
 const originalConsoleLog = console.log
 const originalConsoleError = console.error
 const mockConsoleLog = vi.fn()
 const mockConsoleError = vi.fn()
 
-// Mock process.exit
-const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
-
-// ============================================================================
-// Test Fixtures
-// ============================================================================
-
-/**
- * Creates a mock CodebaseContext for testing
- */
-function createMockCodebaseContext(overrides = {}) {
-  return {
-    rootPath: '/test/project',
-    imports: [],
-    exports: [],
-    functions: [],
-    frameworks: [
-      { name: 'React', confidence: 0.95, source: 'dep', detectedFrom: [] },
-      { name: 'TypeScript', confidence: 0.9, source: 'dep', detectedFrom: [] },
-    ],
-    dependencies: [
-      { name: 'react', version: '^18.0.0', isDev: false },
-      { name: 'typescript', version: '^5.0.0', isDev: true },
-      { name: 'jest', version: '^29.0.0', isDev: true },
-    ],
-    stats: {
-      totalFiles: 42,
-      filesByExtension: { '.ts': 30, '.tsx': 12 },
-      totalLines: 5000,
-    },
-    metadata: {
-      durationMs: 150,
-      version: '1.0.0',
-    },
-    ...overrides,
-  }
-}
-
-/**
- * Skill data type for mock responses
- */
-interface MockSkillData {
-  id: string
-  name: string
-  description: string
-  author: string
-  repo_url: string | null
-  quality_score: number
-  trust_tier: string
-  tags: string[]
-  stars: number
-  created_at: string
-  updated_at: string
-}
-
-/**
- * Creates a mock API response for recommendations
- */
-function createMockApiResponse(skills: MockSkillData[] = []) {
-  return {
-    data:
-      skills.length > 0
-        ? skills
-        : [
-            {
-              id: 'anthropic/jest-helper',
-              name: 'Jest Helper',
-              description: 'Jest testing utilities',
-              author: 'anthropic',
-              repo_url: 'https://github.com/anthropic/jest-helper',
-              quality_score: 0.85,
-              trust_tier: 'verified',
-              tags: ['testing', 'jest'],
-              stars: 150,
-              created_at: '2024-01-01',
-              updated_at: '2024-01-15',
-            },
-            {
-              id: 'community/react-tools',
-              name: 'React Tools',
-              description: 'React development utilities',
-              author: 'community',
-              repo_url: 'https://github.com/community/react-tools',
-              quality_score: 0.72,
-              trust_tier: 'community',
-              tags: ['react', 'development'],
-              stars: 89,
-              created_at: '2024-02-01',
-              updated_at: '2024-02-10',
-            },
-          ],
-    meta: {},
-  }
-}
-
-// ============================================================================
-// Tests
-// ============================================================================
+vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
 
 describe('SMI-1353: CLI recommend command', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     console.log = mockConsoleLog
     console.error = mockConsoleError
-
-    // Default successful mock implementations
     mockAnalyze.mockResolvedValue(createMockCodebaseContext())
     mockGetRecommendations.mockResolvedValue(createMockApiResponse())
   })
@@ -176,7 +72,6 @@ describe('SMI-1353: CLI recommend command', () => {
   afterEach(() => {
     console.log = originalConsoleLog
     console.error = originalConsoleError
-    // Note: Don't use vi.restoreAllMocks() as it removes the process.exit mock
   })
 
   // ==========================================================================
@@ -305,9 +200,6 @@ describe('SMI-1353: CLI recommend command', () => {
 
       await cmd.parseAsync(['node', 'test', '.', '-m', '500'])
 
-      // Note: The implementation uses opts['max-files'] but Commander converts to camelCase.
-      // This test verifies the -m short option works and analyzer is called.
-      // The actual maxFiles value depends on implementation's option parsing.
       expect(mockAnalyze).toHaveBeenCalledWith(
         '.',
         expect.objectContaining({
@@ -534,479 +426,6 @@ describe('SMI-1353: CLI recommend command', () => {
 
       const output = mockConsoleLog.mock.calls.map((c) => c[0]).join('\n')
       expect(output).toContain('anthropic/jest-helper')
-    })
-  })
-
-  // ==========================================================================
-  // Error Handling Tests
-  // ==========================================================================
-
-  describe('error handling', () => {
-    it('should handle CodebaseAnalyzer errors gracefully', async () => {
-      mockAnalyze.mockRejectedValue(new Error('Cannot read directory'))
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '/nonexistent'])
-
-      expect(mockSpinner.fail).toHaveBeenCalledWith('Recommendation failed')
-      expect(mockExit).toHaveBeenCalledWith(1)
-    })
-
-    it('should handle API errors gracefully', async () => {
-      mockGetRecommendations.mockRejectedValue(new Error('API unavailable'))
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      expect(mockSpinner.fail).toHaveBeenCalledWith('Recommendation failed')
-      expect(mockExit).toHaveBeenCalledWith(1)
-    })
-
-    it('should output error as JSON with --json flag on failure', async () => {
-      mockAnalyze.mockRejectedValue(new Error('Analysis failed'))
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.', '--json'])
-
-      const errorOutput = mockConsoleError.mock.calls[0]![0]
-      const parsed = JSON.parse(errorOutput)
-      expect(parsed).toHaveProperty('error')
-    })
-
-    it('should sanitize error messages (remove user paths)', async () => {
-      mockAnalyze.mockRejectedValue(new Error('Error at /Users/secret/project'))
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      const errorCalls = mockConsoleError.mock.calls
-      // Error should be sanitized - exact behavior depends on sanitizeError
-      expect(errorCalls.length).toBeGreaterThan(0)
-    })
-
-    it('should handle network errors with offline fallback', async () => {
-      const context = createMockCodebaseContext()
-      mockAnalyze.mockResolvedValue(context)
-      const networkError = new Error('fetch failed')
-      mockGetRecommendations.mockRejectedValue(networkError)
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      // Should show warning and analysis-only results
-      expect(mockSpinner.warn).toHaveBeenCalledWith(expect.stringContaining('Unable to reach API'))
-      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join('\n')
-      expect(output).toContain('Codebase Analysis')
-    })
-
-    it('should show offline JSON output on network error with --json', async () => {
-      mockAnalyze.mockResolvedValue(createMockCodebaseContext())
-      mockGetRecommendations.mockRejectedValue(new Error('fetch failed'))
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.', '--json'])
-
-      const output = mockConsoleLog.mock.calls[0]![0]
-      const parsed = JSON.parse(output)
-      expect(parsed.offline).toBe(true)
-      expect(parsed.analysis).toBeDefined()
-    })
-  })
-
-  // ==========================================================================
-  // Limit Validation Tests
-  // ==========================================================================
-
-  describe('limit option validation', () => {
-    it('should default to limit 5 when not specified', async () => {
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      expect(mockGetRecommendations).toHaveBeenCalledWith(
-        expect.objectContaining({
-          limit: 5,
-        })
-      )
-    })
-
-    it('should clamp limit to minimum of 1', async () => {
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.', '--limit', '0'])
-
-      expect(mockGetRecommendations).toHaveBeenCalledWith(
-        expect.objectContaining({
-          limit: 1,
-        })
-      )
-    })
-
-    it('should clamp limit to maximum of 50', async () => {
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.', '--limit', '100'])
-
-      expect(mockGetRecommendations).toHaveBeenCalledWith(
-        expect.objectContaining({
-          limit: 50,
-        })
-      )
-    })
-
-    it('should handle non-numeric limit gracefully', async () => {
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.', '--limit', 'invalid'])
-
-      // Should fall back to default of 5
-      expect(mockGetRecommendations).toHaveBeenCalledWith(
-        expect.objectContaining({
-          limit: 5,
-        })
-      )
-    })
-  })
-
-  // ==========================================================================
-  // Trust Tier Handling Tests
-  // ==========================================================================
-
-  describe('trust tier handling', () => {
-    it('should display VERIFIED badge for verified skills', async () => {
-      mockGetRecommendations.mockResolvedValue(
-        createMockApiResponse([
-          {
-            id: 'test/skill',
-            name: 'Verified Skill',
-            description: 'A verified skill',
-            author: 'test',
-            repo_url: null,
-            quality_score: 0.9,
-            trust_tier: 'verified',
-            tags: [],
-            stars: 100,
-            created_at: '2024-01-01',
-            updated_at: '2024-01-01',
-          },
-        ])
-      )
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join('\n')
-      expect(output).toContain('VERIFIED')
-    })
-
-    it('should display COMMUNITY badge for community skills', async () => {
-      mockGetRecommendations.mockResolvedValue(
-        createMockApiResponse([
-          {
-            id: 'test/skill',
-            name: 'Community Skill',
-            description: 'A community skill',
-            author: 'test',
-            repo_url: null,
-            quality_score: 0.7,
-            trust_tier: 'community',
-            tags: [],
-            stars: 50,
-            created_at: '2024-01-01',
-            updated_at: '2024-01-01',
-          },
-        ])
-      )
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join('\n')
-      expect(output).toContain('COMMUNITY')
-    })
-
-    it('should handle unknown trust tier gracefully', async () => {
-      mockGetRecommendations.mockResolvedValue(
-        createMockApiResponse([
-          {
-            id: 'test/skill',
-            name: 'Unknown Tier Skill',
-            description: 'A skill with invalid tier',
-            author: 'test',
-            repo_url: null,
-            quality_score: 0.5,
-            trust_tier: 'invalid_tier', // Simulate malformed API response
-            tags: [],
-            stars: 10,
-            created_at: '2024-01-01',
-            updated_at: '2024-01-01',
-          },
-        ])
-      )
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join('\n')
-      expect(output).toContain('UNKNOWN')
-    })
-  })
-
-  // ==========================================================================
-  // Stack Building Tests
-  // ==========================================================================
-
-  describe('stack building from analysis', () => {
-    it('should include framework names in stack (lowercase)', async () => {
-      mockAnalyze.mockResolvedValue(
-        createMockCodebaseContext({
-          frameworks: [
-            { name: 'Next.js', confidence: 0.9, source: 'dep', detectedFrom: [] },
-            { name: 'TailwindCSS', confidence: 0.85, source: 'dep', detectedFrom: [] },
-          ],
-          dependencies: [{ name: 'next', version: '^14.0.0', isDev: false }],
-        })
-      )
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      expect(mockGetRecommendations).toHaveBeenCalledWith(
-        expect.objectContaining({
-          stack: expect.arrayContaining(['next.js', 'tailwindcss']),
-        })
-      )
-    })
-
-    it('should include non-dev dependencies in stack', async () => {
-      mockAnalyze.mockResolvedValue(
-        createMockCodebaseContext({
-          frameworks: [{ name: 'Express', confidence: 0.9, source: 'dep', detectedFrom: [] }],
-          dependencies: [
-            { name: 'express', version: '^4.0.0', isDev: false },
-            { name: 'mongoose', version: '^7.0.0', isDev: false },
-          ],
-        })
-      )
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      expect(mockGetRecommendations).toHaveBeenCalledWith(
-        expect.objectContaining({
-          stack: expect.arrayContaining(['express', 'mongoose']),
-        })
-      )
-    })
-
-    it('should exclude dev dependencies from stack', async () => {
-      // Include one prod dependency to ensure stack is not empty
-      mockAnalyze.mockResolvedValue(
-        createMockCodebaseContext({
-          frameworks: [{ name: 'React', confidence: 0.9, source: 'dep', detectedFrom: [] }],
-          dependencies: [
-            { name: 'react', version: '^18.0.0', isDev: false },
-            { name: 'jest', version: '^29.0.0', isDev: true },
-            { name: 'eslint', version: '^8.0.0', isDev: true },
-          ],
-        })
-      )
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      const call = mockGetRecommendations.mock.calls[0]![0]
-      expect(call.stack).not.toContain('jest')
-      expect(call.stack).not.toContain('eslint')
-      expect(call.stack).toContain('react') // prod dep should be included
-    })
-
-    it('should limit stack to 10 items', async () => {
-      mockAnalyze.mockResolvedValue(
-        createMockCodebaseContext({
-          frameworks: Array.from({ length: 6 }, (_, i) => ({
-            name: `Framework${i}`,
-            confidence: 0.9,
-            source: 'dep',
-            detectedFrom: [],
-          })),
-          dependencies: Array.from({ length: 12 }, (_, i) => ({
-            name: `dep${i}`,
-            version: '^1.0.0',
-            isDev: false,
-          })),
-        })
-      )
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      const call = mockGetRecommendations.mock.calls[0]![0]
-      expect(call.stack.length).toBeLessThanOrEqual(10)
-    })
-
-    it('should deduplicate stack items', async () => {
-      mockAnalyze.mockResolvedValue(
-        createMockCodebaseContext({
-          frameworks: [{ name: 'React', confidence: 0.9, source: 'dep', detectedFrom: [] }],
-          dependencies: [{ name: 'react', version: '^18.0.0', isDev: false }],
-        })
-      )
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.'])
-
-      const call = mockGetRecommendations.mock.calls[0]![0]
-      const reactCount = call.stack.filter((s: string) => s === 'react').length
-      expect(reactCount).toBe(1)
-    })
-  })
-
-  // ==========================================================================
-  // SMI-1631: Role-Based Filtering Tests
-  // ==========================================================================
-
-  describe('role-based filtering', () => {
-    it('should apply role filtering locally', async () => {
-      // Mock a response with skills that have roles inferred from tags
-      mockGetRecommendations.mockResolvedValue(
-        createMockApiResponse([
-          {
-            id: 'test/test-helper',
-            name: 'Test Helper',
-            description: 'Testing utilities',
-            author: 'test',
-            repo_url: null,
-            quality_score: 0.8,
-            trust_tier: 'verified',
-            tags: ['testing', 'jest', 'unit-test'],
-            stars: 100,
-            created_at: '2024-01-01',
-            updated_at: '2024-01-01',
-          },
-        ])
-      )
-
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.', '--role', 'testing', '--json'])
-
-      const output = mockConsoleLog.mock.calls[0]![0]
-      const parsed = JSON.parse(output)
-      // Role filter should be recorded in meta
-      expect(parsed.meta.role_filter).toBe('testing')
-    })
-
-    it('should not set role filter for invalid role', async () => {
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.', '--role', 'invalid-role', '--json'])
-
-      const output = mockConsoleLog.mock.calls[0]![0]
-      const parsed = JSON.parse(output)
-      // Invalid role should not be set
-      expect(parsed.meta.role_filter).toBeNull()
-    })
-
-    it('should warn user about invalid role', async () => {
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.', '--role', 'not-a-role'])
-
-      const errorOutput = mockConsoleError.mock.calls.map((c) => c[0]).join('\n')
-      expect(errorOutput).toContain('Invalid role')
-      expect(errorOutput).toContain('not-a-role')
-    })
-
-    it('should accept all valid role values', async () => {
-      const validRoles = [
-        'code-quality',
-        'testing',
-        'documentation',
-        'workflow',
-        'security',
-        'development-partner',
-      ]
-
-      for (const role of validRoles) {
-        vi.clearAllMocks()
-        mockAnalyze.mockResolvedValue(createMockCodebaseContext())
-        mockGetRecommendations.mockResolvedValue(createMockApiResponse())
-
-        const { createRecommendCommand } = await import('../src/commands/recommend.js')
-        const cmd = createRecommendCommand()
-
-        await cmd.parseAsync(['node', 'test', '.', '-r', role, '--json'])
-
-        const output = mockConsoleLog.mock.calls[0]![0]
-        const parsed = JSON.parse(output)
-        // Role filter should be recorded in meta for valid roles
-        expect(parsed.meta.role_filter).toBe(role)
-      }
-    })
-
-    it('should include role_filter in JSON output when specified', async () => {
-      const { createRecommendCommand } = await import('../src/commands/recommend.js')
-      const cmd = createRecommendCommand()
-
-      await cmd.parseAsync(['node', 'test', '.', '--role', 'security', '--json'])
-
-      const output = mockConsoleLog.mock.calls[0]![0]
-      const parsed = JSON.parse(output)
-      expect(parsed.meta.role_filter).toBe('security')
-    })
-  })
-
-  // ==========================================================================
-  // Export Tests
-  // ==========================================================================
-
-  describe('module exports', () => {
-    it('should export createRecommendCommand from commands/index', async () => {
-      const indexExports = await import('../src/commands/index.js')
-      expect(indexExports.createRecommendCommand).toBeDefined()
-      expect(typeof indexExports.createRecommendCommand).toBe('function')
-    })
-
-    it('should export createRecommendCommand as default', async () => {
-      const mod = await import('../src/commands/recommend.js')
-      expect(mod.default).toBeDefined()
-      expect(typeof mod.default).toBe('function')
     })
   })
 })

--- a/tests/e2e/cli/usage-counter.e2e.test.ts
+++ b/tests/e2e/cli/usage-counter.e2e.test.ts
@@ -2,6 +2,7 @@
  * E2E: API usage counter wire-up via the CLI's @skillsmith/core ApiClient.
  *
  * SMI-4462 Step 2 — covers paths #1 (CLI/JWT) and #2 (CLI/API-key cache hit).
+ * SMI-4474 — adds Test C: full disk-backed JWT auto-load contract.
  *
  * The CLI's local commands (`search`, `info` after seeding) are SQLite-backed
  * and don't traverse the counted endpoints; the CLI hits skills-search/get/
@@ -10,20 +11,24 @@
  * staging, the same code path `cli sync` / `cli recommend` / `cli info`
  * traverse in production.
  *
- * Test A — JWT path: build a `createApiClient({ jwtToken })` directly with the
- *   provisioned user's JWT and call `getSkill`. SMI-4399 Wave 4 (paste-flow
- *   removal) hasn't yet wired auto-load of `loadStoredAccessToken()` into the
- *   factory, so writing JWT to ~/.skillsmith/config.json doesn't currently
- *   propagate; the explicit-config form is the supported surface today and
- *   exercises the same Bearer-header → auth-middleware → incrementUsageCounter
- *   plumbing. (See the SMI-4462 PR body — gap tracked for Wave 4 follow-up.)
+ * Test A — JWT path (explicit-config): build a `createApiClient({ jwtToken })`
+ *   directly with the provisioned user's JWT and call `getSkill`. Confirms the
+ *   Bearer-header → auth-middleware → incrementUsageCounter plumbing works
+ *   independent of the storage layer.
  *
  * Test B — API-key cache hit: critical SMI-2144 regression. Two consecutive
  *   `getSkill` calls within 5s prove the tier-cache short-circuit doesn't skip
  *   the counter increment. If get_count !== 2 after two calls, the wire-up
  *   has regressed.
  *
- * Both tests assert against `user_api_usage.get_count` because skills-get is
+ * Test C — JWT auto-load (SMI-4474): write a credentials file to a fixture
+ *   HOME directory, repoint `process.env.HOME` so `os.homedir()` resolves to
+ *   the fixture, then call `loadStoredAccessToken()` and feed the result into
+ *   `createApiClient`. This is the exact wiring `skillsmith sync/info/recommend`
+ *   now use, and proves a logged-in user's CLI calls land on their counter
+ *   instead of going anonymous (the live regression from 2026-04-25).
+ *
+ * Tests A/B/C assert against `user_api_usage.get_count` because skills-get is
  * the cleanest single-call endpoint (skills-search response shape varies with
  * fixture state on staging; skills-recommend requires payload massaging).
  *
@@ -31,8 +36,11 @@
  * existing `tests/e2e/**` exclude in vitest.config.ts.
  */
 
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { createApiClient } from '@skillsmith/core'
+import { createApiClient, loadStoredAccessToken } from '@skillsmith/core'
 import {
   provisionTestUser,
   cleanupTestUser,
@@ -103,4 +111,55 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter CLI ApiClient → usage count
     const after = await getUsageRow(user.userId)
     expect(after.get_count).toBe(before.get_count + 2)
   }, 45_000)
+
+  it('SMI-4474 auto-load: loadStoredAccessToken → createApiClient increments get_count', async () => {
+    const before = await getUsageRow(user.userId)
+
+    // Build a fixture HOME containing a v2 credentials file. os.homedir() reads
+    // $HOME on POSIX, so swapping process.env.HOME redirects loadCredentials()
+    // to the fixture without touching the developer's real config.
+    const fixtureHome = await mkdtemp(join(tmpdir(), 'smi-4474-'))
+    await mkdir(join(fixtureHome, '.skillsmith'), { recursive: true })
+    await writeFile(
+      join(fixtureHome, '.skillsmith', 'config.json'),
+      JSON.stringify(
+        {
+          accessToken: user.jwt,
+          refreshToken: user.refreshToken,
+          expiresAt: Date.now() + 3_600_000,
+          version: 2,
+        },
+        null,
+        2
+      ),
+      { mode: 0o600 }
+    )
+
+    const originalHome = process.env['HOME']
+    process.env['HOME'] = fixtureHome
+    try {
+      const stored = await loadStoredAccessToken()
+      expect(stored).toBe(user.jwt)
+
+      // This is the exact pattern packages/cli/src/commands/{sync,info,recommend}.ts
+      // now use after SMI-4474. If a future refactor drops the auto-load, the
+      // counter assertion below will catch it.
+      const client = createApiClient(
+        stored ? { baseUrl: STAGING_BASE_URL, jwtToken: stored } : { baseUrl: STAGING_BASE_URL }
+      )
+      const res = await client.getSkill(STAGING_SKILL_ID)
+      expect(res.data?.id).toBe(STAGING_SKILL_ID)
+
+      await waitForCounterIncrement(user.userId, 'get_count', before.get_count + 1)
+      const after = await getUsageRow(user.userId)
+      expect(after.get_count).toBe(before.get_count + 1)
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env['HOME']
+      } else {
+        process.env['HOME'] = originalHome
+      }
+      await rm(fixtureHome, { recursive: true, force: true })
+    }
+  }, 30_000)
 })


### PR DESCRIPTION
## Summary

- `skillsmith sync`, `info`, `recommend` now read the stored JWT from `~/.skillsmith/config.json` via `loadStoredAccessToken()` and attach it to every `createApiClient()` call.
- Logged-in users go from 0/1,000 (counter never moved + 7× rate-limit errors during sync) to authenticated calls that count toward their tier quota.
- E2E suite gains a third test exercising the full disk → `loadStoredAccessToken` → `createApiClient` → counter wiring against staging.

## Background

Live diagnosis on 2026-04-25 with @ryansmith108 — `/account` showed 0/1,000 despite 5× `skillsmith search`, 1× `info`, and 1× `sync`. Root cause: `createApiClient()` at `packages/core/src/api/client.ts:84` only auto-loaded `SKILLSMITH_API_KEY` from env. The JWT written by `skillsmith login` (device-code flow) was stored in `~/.skillsmith/config.json` but the CLI commands never read it back. Concurrently, prod `user_api_usage` showed 13,639 counted calls today across 4 other users using `SKILLSMITH_API_KEY` env path — so the SMI-4461 wire-up worked; the gap was CLI auth resolution.

`loadStoredAccessToken()` already existed in `@skillsmith/core` (added in SMI-4402) and is exported from `index.ts`. The fix was three trivial wiring changes — no new abstraction, no helper file. The factory's existing refresh-on-401 path (`tryRefreshToken` → `storeCredentials`) keeps the refresh contract intact.

## Acceptance criteria (from SMI-4474)

- [x] `sync`/`info`/`recommend` attach `Authorization: Bearer <jwt>` after login (verified by E2E test C reading staging `user_api_usage`)
- [x] `SKILLSMITH_API_KEY` env-var path doesn't regress (precedence still: JWT > env API key > anonymous; controlled by `client.ts:152-156`)
- [x] Refresh path persists new token to disk (unchanged — `tryRefreshToken` already does this via `storeCredentials`)
- [x] E2E test stub from PR #772 finished — Test C now writes JWT to fixture HOME and asserts counter increment

## Test plan

- [x] Host typecheck: `npx tsc -p packages/cli/tsconfig.json --noEmit` — clean
- [x] Lint + format on changed files — clean
- [x] Existing CLI tests: 68/68 pass (`vitest run packages/cli/src/commands`)
- [ ] Post-merge: manual `skillsmith login` + `skillsmith sync` against prod, verify `user_api_usage.search_count` > 0 for the test user, refresh `/account` and confirm non-zero counter
- [ ] Post-merge: scheduled prod-verification agent on 2026-05-01 (`trig_01Tqb6ReZrYk6f4CykrzKxSo`) will pick up the additional counter signal

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)