### PR TITLE
chore(release): bump cli 0.5.10 — SMI-4474 JWT auto-load

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
+## v0.5.10
+
+- **Fix**: SMI-4474 auto-load JWT so logged-in CLI commands count toward quota (#786)
+- **Fix**: SMI-4454 post-login hint — 'skills list' → 'search mcp' (cli 0.5.9) (#759)
+
 ## v0.5.9
 
 - Version bump

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Bumps `@skillsmith/cli` to 0.5.10. Ships the SMI-4474 JWT auto-load fix to logged-in users (PR #786, commit `9c2d65dd`).

After this lands, `skillsmith sync`, `info`, and `recommend` attach the stored JWT from `~/.skillsmith/config.json` to every API call, so logged-in users count toward their tier quota instead of going anonymous.

## Test plan

- [x] `prepare-release.ts --dry-run --cli=patch` passed (npm collision guard clean)
- [ ] CI green
- [ ] Post-merge: `gh workflow run publish.yml -f dry_run=false` to publish to npm registry
- [ ] Post-publish: `npx tsx scripts/smoke-test-published.ts @skillsmith/cli 0.5.10` to verify the published tarball resolves and runs

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)