### PR TITLE
fix(cli): SMI-4486 initializeSchema after createDatabaseAsync — fresh install no longer fails 'no such table'

### DIFF
--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -13,7 +13,12 @@
 
 import { Command } from 'commander'
 import chalk from 'chalk'
-import { createDatabaseAsync, AdvisoryRepository, type SkillAdvisory } from '@skillsmith/core'
+import {
+  createDatabaseAsync,
+  initializeSchema,
+  AdvisoryRepository,
+  type SkillAdvisory,
+} from '@skillsmith/core'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { requireTier } from '../utils/require-tier.js'
@@ -86,6 +91,7 @@ async function runAudit(options: { db: string; fix: boolean }): Promise<void> {
   await requireTier('team')
 
   const db = await createDatabaseAsync(options.db)
+  initializeSchema(db) // SMI-4486
 
   try {
     const advisoryRepo = new AdvisoryRepository(db)

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -19,6 +19,7 @@ import ora from 'ora'
 import Table from 'cli-table3'
 import {
   createDatabaseAsync,
+  initializeSchema,
   SkillRepository,
   createApiClient,
   loadStoredAccessToken,
@@ -48,6 +49,9 @@ async function runSync(options: {
   try {
     spinner.start('Opening database...')
     const db = await createDatabaseAsync(options.dbPath)
+    // SMI-4486: createDatabaseAsync returns a connected DB but doesn't create
+    // tables — fresh installs would otherwise hit "no such table: skills".
+    initializeSchema(db)
 
     try {
       const skillRepo = new SkillRepository(db)
@@ -145,6 +149,7 @@ async function runSync(options: {
 async function showStatus(options: { dbPath: string; json: boolean }): Promise<void> {
   try {
     const db = await createDatabaseAsync(options.dbPath)
+    initializeSchema(db) // SMI-4486
 
     try {
       const syncConfigRepo = new SyncConfigRepository(db)
@@ -252,6 +257,7 @@ async function showHistory(options: {
 }): Promise<void> {
   try {
     const db = await createDatabaseAsync(options.dbPath)
+    initializeSchema(db) // SMI-4486
 
     try {
       const syncHistoryRepo = new SyncHistoryRepository(db)
@@ -332,6 +338,7 @@ async function configureSync(options: {
 }): Promise<void> {
   try {
     const db = await createDatabaseAsync(options.dbPath)
+    initializeSchema(db) // SMI-4486
 
     try {
       const syncConfigRepo = new SyncConfigRepository(db)


### PR DESCRIPTION
## Summary

- Adds `initializeSchema(db)` after every `createDatabaseAsync(...)` call in `packages/cli/src/commands/sync.ts` (4 sites) and `audit.ts` (1 site).
- Unblocks fresh-install: `rm ~/.skillsmith/skills.db && skillsmith sync` now creates the schema instead of bare SQLite \`no such table: skills\`.
- Other CLI commands (info, install, manage, search) already had this — fixing the gap brings sync + audit in line.

## Test plan

- [x] Host typecheck on cli — clean
- [x] All 545 CLI tests pass
- [ ] Post-merge: cut cli@0.5.11, publish, smoke test on a fresh \`rm -rf ~/.skillsmith && skillsmith sync\` flow

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)