### PR TITLE
feat(SMI-4485): plumb adapter→class so SMI-4468 boost fires on memory chunks

### DIFF
--- a/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.test.ts
+++ b/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.test.ts
@@ -225,6 +225,50 @@ describe('memory-topic-files — wholeFileChunk self-sufficiency (SMI-4450 M3)',
   })
 })
 
+describe('memory-topic-files — class stamping (SMI-4485)', () => {
+  it('stamps class:["feedback"] for feedback_*.md files', async () => {
+    writeFileSync(
+      join(memoryDir, 'feedback_audit.md'),
+      '# Feedback\n\nSome lesson body that fits under targetTokens.\n'
+    )
+    const adapter = createMemoryTopicFilesAdapter()
+    const ctx = makeCtx('full')
+    const files = await adapter.listFiles(ctx)
+    const chunks = await adapter.chunk(files[0], ctx)
+    for (const c of chunks) {
+      expect(c.class).toEqual(['feedback'])
+    }
+  })
+
+  it('stamps class:["project"] for project_*.md files', async () => {
+    writeFileSync(
+      join(memoryDir, 'project_smi_4485.md'),
+      '# Project\n\nSome project context body that fits under targetTokens.\n'
+    )
+    const adapter = createMemoryTopicFilesAdapter()
+    const ctx = makeCtx('full')
+    const files = await adapter.listFiles(ctx)
+    const chunks = await adapter.chunk(files[0], ctx)
+    for (const c of chunks) {
+      expect(c.class).toEqual(['project'])
+    }
+  })
+
+  it('leaves class undefined for memory files without feedback_/project_ prefix', async () => {
+    writeFileSync(
+      join(memoryDir, 'template_author_outreach.md'),
+      '# Template\n\nNot a feedback or project file.\n'
+    )
+    const adapter = createMemoryTopicFilesAdapter()
+    const ctx = makeCtx('full')
+    const files = await adapter.listFiles(ctx)
+    const chunks = await adapter.chunk(files[0], ctx)
+    for (const c of chunks) {
+      expect(c.class).toBeUndefined()
+    }
+  })
+})
+
 describe('memory-topic-files adapter — listDeletedPaths', () => {
   it('returns [] (no delete oracle in Wave 1 per SPARC §S2a edge case c)', async () => {
     const adapter = createMemoryTopicFilesAdapter()

--- a/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.ts
+++ b/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.ts
@@ -130,10 +130,26 @@ async function chunk(file: AdapterFile, ctx: AdapterContext): Promise<ChunkMetad
   // construction sites above — both `wholeFileChunk` and the
   // chunkBlocks map — so the mapper here only merges tags.
   const baseTags = file.tags ?? {}
+  const cls = classifyByFilename(fileBasename)
   return chunks.map((c) => ({
     ...c,
     tags: { ...baseTags, ...(c.tags ?? {}) },
+    ...(cls ? { class: cls } : {}),
   }))
+}
+
+/**
+ * Map auto-memory filename prefixes to the `class` array consumed by
+ * `rerank.ts` per-class boost (SMI-4485 / SMI-4468). Filename convention
+ * is set by the auto-memory system in CLAUDE.md: `feedback_*.md`,
+ * `project_*.md`, `template_*.md`, plus topic-shape names. Only the
+ * unambiguous prefixes get classified here; everything else stays
+ * unclassified (boost factor 1.0).
+ */
+export function classifyByFilename(fileBasename: string): string[] | null {
+  if (fileBasename.startsWith('feedback_')) return ['feedback']
+  if (fileBasename.startsWith('project_')) return ['project']
+  return null
 }
 
 function wholeFileChunk(

--- a/packages/doc-retrieval-mcp/src/indexer.ts
+++ b/packages/doc-retrieval-mcp/src/indexer.ts
@@ -182,6 +182,7 @@ function buildStoredMetadata(
   const lifetime = chunk.lifetime ?? adapter.lifetime
   if (lifetime) blob.lifetime = lifetime
   if (chunk.tags && Object.keys(chunk.tags).length > 0) blob.tags = chunk.tags
+  if (chunk.class && chunk.class.length > 0) blob.class = chunk.class
   return blob
 }
 

--- a/packages/doc-retrieval-mcp/src/types.ts
+++ b/packages/doc-retrieval-mcp/src/types.ts
@@ -21,6 +21,15 @@ export interface ChunkMetadata {
    * verbatim inside the VectorDb metadata JSON blob (no schema change).
    */
   tags?: Record<string, string | number | null>
+  /**
+   * Adapter-emittable classification array (SMI-4485). Persisted into
+   * `ChunkStoredMetadata.class` and consumed by `rerank.ts` for the
+   * SMI-4468 per-class boost (`feedback`/`project` → 1.5x;
+   * `wave-spec`/`plans-review` → 0.85x). Adapters set this when the
+   * source's intent is unambiguous (e.g. `feedback_*.md` filename
+   * prefix → `['feedback']`); leave undefined otherwise.
+   */
+  class?: string[]
 }
 
 export interface ChunkWithVector extends ChunkMetadata {


### PR DESCRIPTION
## Summary

- `ChunkStoredMetadata.class` (added Step 6 / SMI-4451) drives SMI-4468's per-class rank boost (`feedback`/`project` → 1.5x). No adapter populated it; the boost was inert.
- Plumb `class?: string[]` through `ChunkMetadata` → `buildStoredMetadata` → persisted vector blob; stamp `['feedback']` / `['project']` in the `memory-topic-files` adapter from `feedback_*.md` / `project_*.md` filename prefixes.
- 6-pair gate is unaffected (still 6/6 since 2026-04-26); after next reindex, SMI-4468's boost will actually fire on memory chunks.

## Why

Discovered while shipping SMI-4468 + SMI-4473 — the gate passes today on cosine + memory-chunk presence alone. The boost lever exists but doesn't move. This makes the lever real for future query/corpus shifts.

## Out of scope

- Markdown-corpus frontmatter `class:` extraction (separate followup).
- Process-class dampening (`PROCESS_CLASSES = {wave-spec, plans-review}`).
- Reindex of existing chunks — old chunks remain class-less until next reindex; JSON blob is forwards-compatible.

## ADR-109

Not applicable — application code only (`packages/doc-retrieval-mcp/src/`).

## Test plan

- [x] `docker exec skillsmith-dev-1 npm run typecheck`
- [x] `docker exec skillsmith-dev-1 npx vitest run packages/doc-retrieval-mcp/` — 185 / 185 pass (18 in `memory-topic-files.test.ts`, 3 new for SMI-4485 class stamping)
- [x] `docker exec skillsmith-dev-1 npm run lint` — clean
- [x] `docker exec skillsmith-dev-1 npm run format:check` — clean
- [x] `docker exec skillsmith-dev-1 npm run audit:standards` — 50 / 0 / 4 (warnings all pre-existing)
- [x] Governance review — zero findings; push-ready

## Linear

SMI-4485 — In Progress.

## Code review

`docs/internal/code_review/2026-04-26-smi-4485-adapter-class-plumbing.md` (will land in a separate `[skip-impl-check]` doc bump after this PR merges, per prior convention).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)