### PR TITLE
chore(release): bump cli 0.5.11 — SMI-4486 schema init fix

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
+## v0.5.11
+
+- **Fix**: SMI-4486 call initializeSchema after createDatabaseAsync in sync + audit (#791)
+
 ## v0.5.10
 
 - **Fix**: SMI-4474 auto-load JWT so logged-in CLI commands count toward quota (#786)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bumps `@skillsmith/cli` 0.5.10 → 0.5.11
- Ships SMI-4486 fix-now to users: `initializeSchema(db)` now runs after `createDatabaseAsync()` in `sync.ts` (4 sites) + `audit.ts` (1 site), so fresh installs no longer fail with `no such table: skills`.

[skip-impl-check]

## Test plan

- [ ] CI green
- [ ] After publish: `npm view @skillsmith/cli@0.5.11 version` returns `0.5.11`
- [ ] Fresh install (`rm -rf ~/.skillsmith && skillsmith sync`) hits "Authentication required" (per SMI-4482), NOT "no such table: skills"

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)