### PR TITLE
fix(core): SMI-4486 initializeSchema must run migrations

### DIFF
--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -31,8 +31,8 @@ export {
 } from './migration-runner.js'
 export type { Migration } from './migration-runner.js'
 
-// Re-import for use within this file (openDatabase, openDatabaseAsync)
-import { runMigrationsSafe } from './migration-runner.js'
+// Re-import for use within this file (openDatabase, openDatabaseAsync, initializeSchema)
+import { runMigrations, runMigrationsSafe } from './migration-runner.js'
 
 export type DatabaseType = Database
 
@@ -42,14 +42,19 @@ export type DatabaseType = Database
 export const SCHEMA_VERSION = 13
 
 /**
- * Initialize the database with the complete schema
+ * Initialize the database with the complete schema.
+ *
+ * SCHEMA_SQL only contains the v1 base tables; subsequent versions (skill_versions,
+ * skill_advisories, etc.) are added by migrations. SMI-4486: previously this
+ * recorded SCHEMA_VERSION (=current) directly, which caused runMigrations to
+ * see the DB as already-current and skip every migration — leaving fresh DBs
+ * stuck at v1 schema. Now we mark v1 (idempotent via OR IGNORE) and run
+ * migrations to reach the current version.
  */
 export function initializeSchema(db: DatabaseType): void {
   db.exec(SCHEMA_SQL)
-
-  // Record the schema version
-  const stmt = db.prepare('INSERT OR REPLACE INTO schema_version (version) VALUES (?)')
-  stmt.run(SCHEMA_VERSION)
+  db.prepare('INSERT OR IGNORE INTO schema_version (version) VALUES (1)').run()
+  runMigrations(db)
 }
 
 /** @deprecated Use createDatabaseAsync() — requires better-sqlite3 native module. */

--- a/packages/core/tests/db/migration.test.ts
+++ b/packages/core/tests/db/migration.test.ts
@@ -128,8 +128,10 @@ describe('checkSchemaCompatibility', () => {
 
   it('should return compatible + upgrade when schema is older', () => {
     const db = createTestDb()
-    // Manually downgrade schema version
-    db.prepare('UPDATE schema_version SET version = ?').run(SCHEMA_VERSION - 1)
+    // SMI-4486: schema_version now tracks every applied migration as a row;
+    // getSchemaVersion reads MAX(version). Drop higher-numbered rows to simulate
+    // an older DB rather than UPDATE-ing the column (which collides on PK).
+    db.prepare('DELETE FROM schema_version WHERE version > ?').run(SCHEMA_VERSION - 1)
 
     const result = checkSchemaCompatibility(db)
     expect(result.isCompatible).toBe(true)
@@ -140,8 +142,8 @@ describe('checkSchemaCompatibility', () => {
 
   it('should return downgrade_warning when schema is newer (no breaking changes)', () => {
     const db = createTestDb()
-    // Manually bump schema version beyond current
-    db.prepare('UPDATE schema_version SET version = ?').run(SCHEMA_VERSION + 1)
+    // SMI-4486: append a future-version row instead of UPDATE-ing the column
+    db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(SCHEMA_VERSION + 1)
 
     const result = checkSchemaCompatibility(db)
     expect(result.currentVersion).toBe(SCHEMA_VERSION + 1)
@@ -163,8 +165,8 @@ describe('ensureSchemaCompatibility', () => {
 
   it('should throw for incompatible schema', () => {
     const db = createTestDb()
-    // Set to a very high version that likely has breaking migrations
-    db.prepare('UPDATE schema_version SET version = ?').run(9999)
+    // SMI-4486: append a future-version row to bump MAX(version)
+    db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(9999)
 
     // This may or may not throw depending on migration content
     // At minimum, it should not crash


### PR DESCRIPTION
## Summary

cli@0.5.11 (PR #794) shipped half the SMI-4486 fix: it ensured CLI commands call `initializeSchema(db)` after `createDatabaseAsync(path)` (the factory only opens a connection — schema init is the caller's job). But that exposed a deeper bug — `initializeSchema()` was recording `SCHEMA_VERSION=13` after running `SCHEMA_SQL`, which only contains v1 base tables. `runMigrations` then saw `currentVersion=13` and skipped every migration, leaving fresh DBs stuck at v1 schema.

Smoke evidence (cli@0.5.11 fresh install): `skillsmith sync` got past "no such table: skills" but failed with "no such table: skill_versions" (added by migration v5).

## Fix

`initializeSchema(db)` now:
1. Runs `SCHEMA_SQL` (creates v1 base tables)
2. Inserts `version=1` with `OR IGNORE` (idempotent on existing DBs)
3. Calls `runMigrations(db)` → applies v2..v13

On existing v13 DBs the `OR IGNORE` is a no-op and `runMigrations` finds nothing to do. On fresh DBs the migrations run to current.

Tests updated: `schema_version` now stores one row per applied migration, so tests that previously did `UPDATE schema_version SET version = ?` (which collides on PK with multi-row data) now `DELETE WHERE version > ?` or `INSERT INTO schema_version`.

## Test plan

- [x] `npm test -w @skillsmith/core` — 3539 passed
- [ ] After publish: fresh-install smoke (`rm -rf ~/.skillsmith && skillsmith sync`) does NOT error with "no such table: skills" or "no such table: skill_versions"

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)