### PR TITLE
chore(release): bump core 0.5.6 — SMI-4486 schema-init fix

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
+## v0.5.12
+
+- **Bump**: requires `@skillsmith/core` ≥ 0.5.6 to pick up the SMI-4486 schema-init fix that finally lets fresh installs run `skillsmith sync` without missing-table errors (#795).
+
 ## v0.5.11
 
 - **Fix**: SMI-4486 call initializeSchema after createDatabaseAsync in sync + audit (#791)

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to `@skillsmith/cli` are documented here.
 
-## v0.5.12
-
-- **Bump**: requires `@skillsmith/core` ≥ 0.5.6 to pick up the SMI-4486 schema-init fix that finally lets fresh installs run `skillsmith sync` without missing-table errors (#795).
-
 ## v0.5.11
 
 - **Fix**: SMI-4486 call initializeSchema after createDatabaseAsync in sync + audit (#791)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.12",
+  "version": "0.5.11",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.5.6",
+    "@skillsmith/core": "^0.5.5",
     "chalk": "5.6.2",
     "cli-table3": "0.6.5",
     "commander": "14.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.5.5",
+    "@skillsmith/core": "^0.5.6",
     "chalk": "5.6.2",
     "cli-table3": "0.6.5",
     "commander": "14.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@skillsmith/core` are documented here.
 
+## v0.5.6
+
+- **Fix**: SMI-4486 `initializeSchema()` now runs migrations after creating base tables; previously recorded SCHEMA_VERSION up front, causing `runMigrations` to skip every migration and leave fresh DBs missing v5+ tables (skill_versions, skill_advisories, etc.) (#795)
+
 ## v0.5.5
 
 - Version bump

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.5.5'
+export const VERSION = '0.5.6'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1024.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.69.0",
-    "@skillsmith/core": "^0.5.5",
+    "@skillsmith/core": "^0.5.6",
     "jose": "^6.2.2",
     "zod": "4.2.1"
   },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.5.5",
+    "@skillsmith/core": "^0.5.6",
     "esbuild": "0.27.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Ships SMI-4486 fix (#795) to npm:

- `@skillsmith/core` 0.5.5 → 0.5.6 — `initializeSchema()` now runs migrations after creating base tables (already published)
- `@skillsmith/cli` 0.5.11 → 0.5.12 — pins `@skillsmith/core` to `^0.5.6` so fresh installs pick up the fix
- `@skillsmith/mcp-server`, `@skillsmith/enterprise` — dep bump to `^0.5.6` (validator requirement; not republished this cycle)

## Why core was pre-published

CI publish workflow is broken (SMI-4480) and the publish-deps validator demands core@0.5.6 on npm before allowing consumers' `^0.5.6` declaration. core@0.5.6 was published manually from this branch with explicit user authorization once the fix was confirmed on main via PR #795.

[skip-impl-check]
[skip-doc-drift]

## Test plan

- [x] core@0.5.6 published to npm
- [ ] CI green
- [ ] After merge: publish cli@0.5.12
- [ ] Fresh-install smoke (`rm -rf ~/.skillsmith && skillsmith sync`) does not error with "no such table" for any table

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)