### PR TITLE
debug(infra): SMI-4494 curl-probe preview server before wait-on

### DIFF
--- a/.github/workflows/device-login-roundtrip.yml
+++ b/.github/workflows/device-login-roundtrip.yml
@@ -189,6 +189,39 @@ jobs:
           nohup npm run preview -- --host 127.0.0.1 --port 4321 > "$GITHUB_WORKSPACE/test-results/preview.log" 2>&1 &
           echo $! > "$GITHUB_WORKSPACE/test-results/preview.pid"
 
+      - name: SMI-4494 diagnostic — probe preview server before wait-on
+        # SMI-4494 hypothesis: vercel adapter + output:'static' makes
+        # `astro preview` bind 4321 (TCP connect succeeds) but `/` never
+        # returns 200 because the adapter expects .vercel/output/ routing,
+        # not the static dist/ that astro preview's built-in server expects.
+        # Capture actual HTTP responses so we know whether to swap to
+        # `npx http-server packages/website/dist` (lightest fix) or escalate
+        # to `vercel dev`. Non-blocking — the existing wait-on timeout
+        # remains the source of truth for the gate.
+        run: |
+          set -u
+          echo "::group::Sleep 5s for preview server boot"
+          sleep 5
+          echo "::endgroup::"
+          echo "::group::TCP port check (port-bind vs HTTP-200 distinction)"
+          (echo > /dev/tcp/127.0.0.1/4321) 2>&1 && echo "TCP 127.0.0.1:4321 OPEN" || echo "TCP 127.0.0.1:4321 CLOSED"
+          echo "::endgroup::"
+          echo "::group::curl /  (verbose, max 10s)"
+          curl -v --max-time 10 http://127.0.0.1:4321/ 2>&1 | head -200 || true
+          echo "::endgroup::"
+          echo "::group::curl /device  (the spec's actual entry page)"
+          curl -v --max-time 10 http://127.0.0.1:4321/device 2>&1 | head -200 || true
+          echo "::endgroup::"
+          echo "::group::curl /index.html  (test if static asset path works)"
+          curl -sS -o /dev/null -w "HTTP %{http_code} size=%{size_download} time=%{time_total}\n" --max-time 10 http://127.0.0.1:4321/index.html || true
+          echo "::endgroup::"
+          echo "::group::dist/ contents (does the static build exist on disk?)"
+          ls -la "$GITHUB_WORKSPACE/packages/website/dist/" 2>&1 | head -30 || echo "dist/ MISSING"
+          echo "::endgroup::"
+          echo "::group::preview.log (server-side view)"
+          cat "$GITHUB_WORKSPACE/test-results/preview.log" 2>&1 | head -50 || true
+          echo "::endgroup::"
+
       - name: Wait for preview server
         # Use 127.0.0.1 to match the --host flag the preview server binds to.
         # wait-on against `localhost` hits IPv6 (::1) first on GH-hosted


### PR DESCRIPTION
## Summary

Diagnostic-only PR for SMI-4494. **Do not merge** — this captures HTTP responses from the runtime preview server so we can choose the lightest fix and revert this probe.

## Hypothesis (from compact handoff)

`packages/website/astro.config.mjs` declares `output: 'static'` AND `adapter: vercel()`. With the vercel adapter, `astro preview` binds the port (TCP connect succeeds) but `/` never returns 200 — the adapter routes through `.vercel/output/`, not the `dist/` that astro preview's built-in server expects.

Evidence so far:
- preview.log: \`astro v6.1.3 ready in 34 ms\` + \`Local http://127.0.0.1:4321/\`
- wait-on times out at 60s polling for HTTP 200 (run [24962929171](https://github.com/smith-horn/skillsmith/actions/runs/24962929171))
- 127.0.0.1 vs localhost fix landed in PR #797 — did not unblock

## What this PR adds

A single non-blocking diagnostic step between \`Start website preview server\` and \`Wait for preview server\`:

1. \`sleep 5\` to let astro boot
2. TCP connect check against 127.0.0.1:4321 (port-bind vs HTTP-200 distinction)
3. \`curl -v\` against \`/\` and \`/device\` (max 10s each)
4. \`curl -w\` against \`/index.html\` (status code + size)
5. \`ls -la dist/\` (verifies the static build exists on disk)
6. \`cat preview.log\` (server-side view)

All non-blocking. wait-on remains the gate.

## Decision tree from the result

| Observation | Likely cause | Lightest fix |
|---|---|---|
| TCP open, all curls 404 / hang | Vercel-adapter routing mismatch | \`npx http-server packages/website/dist -p 4321 -a 127.0.0.1\` |
| TCP open, \`/device\` 200 but \`/\` 404 | Index-page routing only | wait-on path → \`/device\` |
| TCP open, all curls 200 | wait-on parse/timeout regression | Investigate wait-on flags |
| TCP closed | preview never bound | astro preview surface bug — escalate |
| dist/ missing | build step didn't run / wrong cwd | Fix earlier step |

## Test plan

- [ ] CI run completes the diagnostic step (its output is the test artifact)
- [ ] No need to look at the round-trip spec result — wait-on is still expected to time out
- [ ] Author + user pick the resolution from the table above
- [ ] New PR \`fix(infra): SMI-4494 …\` lands, this branch deleted unmerged

[skip-impl-check]