### PR TITLE
fix(infra): SMI-4496/4495 round-trip e2e — IPv4 baseURL + desktop-only spec + recoverable trace artifacts

### DIFF
--- a/.github/workflows/device-login-roundtrip.yml
+++ b/.github/workflows/device-login-roundtrip.yml
@@ -109,7 +109,13 @@ jobs:
       STAGING_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
       E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
       E2E_TEST_USER_ID: ${{ secrets.E2E_TEST_USER_ID }}
-      WEBSITE_BASE_URL: 'http://localhost:4321'
+      # SMI-4496: bind to 127.0.0.1 to match the http-server `-a 127.0.0.1`
+      # flag in the preview-server step. `localhost` resolves to ::1 (IPv6)
+      # first on GH-hosted runners via /etc/hosts, and Chromium's page.goto
+      # against an IPv6 URL hangs indefinitely when http-server only listens
+      # on IPv4 → spec eats its full 2-min budget. Same IPv4-family lesson
+      # as SMI-4493 (wait-on).
+      WEBSITE_BASE_URL: 'http://127.0.0.1:4321'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -219,6 +225,7 @@ jobs:
           name: device-login-roundtrip-${{ github.run_id }}
           path: |
             packages/website/playwright-report/
+            packages/website/test-results/
             test-results/cli-*.log
             test-results/preview.log
           retention-days: 7

--- a/.github/workflows/device-login-roundtrip.yml
+++ b/.github/workflows/device-login-roundtrip.yml
@@ -167,7 +167,16 @@ jobs:
           npm run build -w @skillsmith/core
           npm run build -w @skillsmith/cli
           npm run build -w @skillsmith/website
-          echo "CLI_PATH=$GITHUB_WORKSPACE/packages/cli/dist/index.js" >> "$GITHUB_ENV"
+          # SMI-4507: CLI tsc emits to dist/src/index.js (matches the
+          # `bin` field in packages/cli/package.json:
+          #   "bin": { "skillsmith": "dist/src/index.js", ... }).
+          # Earlier iterations of this workflow hardcoded dist/index.js,
+          # which made every CLI invocation crash with MODULE_NOT_FOUND.
+          # Symptom was the round-trip's 2-min Playwright timeout, with
+          # parseUserCode silently swallowing stream-close before its
+          # own 30s timer could fire — diagnosed via the cli.snapshot()
+          # log captured by SMI-4506.
+          echo "CLI_PATH=$GITHUB_WORKSPACE/packages/cli/dist/src/index.js" >> "$GITHUB_ENV"
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium

--- a/packages/website/tests/e2e/device-login-roundtrip.helpers.ts
+++ b/packages/website/tests/e2e/device-login-roundtrip.helpers.ts
@@ -151,33 +151,47 @@ export function spawnCli(opts: SpawnCliOpts): CliHandle {
 
 const CODE_RE = /│\s*([A-Z0-9]{4})-?([A-Z0-9]{4})\s*│/
 
-/**
- * Drain `stdout` line-by-line until the boxed user_code appears, or
- * timeoutMs elapses.
- */
+// SMI-4507: parseUserCode rejects on stream-close-without-a-code. When the
+// CLI subprocess crashes immediately, stdout closes with no boxed code line.
+// Previous version cleared the 30s timer inside `rl.on('close')` then never
+// settled — eating the full 2-min Playwright budget instead of failing fast.
 export async function parseUserCode(
   stdout: Readable,
   opts: { timeoutMs: number }
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const rl = createInterface({ input: stdout })
-    const timer = setTimeout(() => {
+    let settled = false
+    const settle = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
       rl.removeAllListeners('line')
       rl.close()
-      reject(new Error(`[SMI-4460] parseUserCode timed out after ${opts.timeoutMs}ms`))
-    }, opts.timeoutMs)
-
+      fn()
+    }
+    const timer = setTimeout(
+      () =>
+        settle(() =>
+          reject(new Error(`[SMI-4460] parseUserCode timed out after ${opts.timeoutMs}ms`))
+        ),
+      opts.timeoutMs
+    )
     rl.on('line', (raw) => {
       const line = stripAnsi(raw)
       const m = line.match(CODE_RE)
-      if (m) {
-        clearTimeout(timer)
-        rl.removeAllListeners('line')
-        rl.close()
-        resolve(`${m[1]}${m[2]}`)
-      }
+      if (m) settle(() => resolve(`${m[1]}${m[2]}`))
     })
-    rl.on('close', () => clearTimeout(timer))
+    rl.on('close', () =>
+      settle(() =>
+        reject(
+          new Error(
+            '[SMI-4460] parseUserCode: stdout closed before user_code appeared ' +
+              '(CLI subprocess likely crashed — check cli-*.log for stderr)'
+          )
+        )
+      )
+    )
   })
 }
 

--- a/packages/website/tests/e2e/device-login-roundtrip.helpers.ts
+++ b/packages/website/tests/e2e/device-login-roundtrip.helpers.ts
@@ -31,6 +31,8 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import type { Page } from '@playwright/test'
 import { getConfig } from './device-login-roundtrip.config'
 
+import { withTimeout, STAGING_CALL_TIMEOUT_MS } from './device-login-roundtrip.timeout'
+
 // ─── Process management ───────────────────────────────────────────────────
 
 export interface CliExitResult {
@@ -47,6 +49,12 @@ export interface CliHandle {
   exited: boolean
   /** Resolves when the child exits (or when timeoutMs elapses → SIGTERM). */
   waitForExit(opts: { timeoutMs: number }): Promise<CliExitResult>
+  /**
+   * Snapshot the buffered stdout/stderr without waiting for exit. Lets
+   * `afterEach` dump CLI output when the test hung BEFORE `waitForExit()`
+   * was called — the case where SMI-4506 lost evidence.
+   */
+  snapshot(): { stdout: string; stderr: string }
   /** SIGTERM, then SIGKILL after 5s. Idempotent. */
   kill(): Promise<void>
 }
@@ -91,6 +99,12 @@ export function spawnCli(opts: SpawnCliOpts): CliHandle {
     stderr: child.stderr,
     get exited() {
       return exitedFlag
+    },
+    snapshot() {
+      return {
+        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+      }
     },
     async waitForExit({ timeoutMs }) {
       const timeout = new Promise<{ code: number | null }>((resolve) => {
@@ -276,10 +290,14 @@ export async function signInTestUser(
   const admin = createClient(cfg.supabaseUrl, cfg.supabaseAnonKey, {
     auth: { persistSession: false, autoRefreshToken: false },
   })
-  const { data, error } = await admin.auth.signInWithPassword({
-    email: opts.email,
-    password: opts.password,
-  })
+  const { data, error } = await withTimeout(
+    admin.auth.signInWithPassword({
+      email: opts.email,
+      password: opts.password,
+    }),
+    STAGING_CALL_TIMEOUT_MS,
+    'signInTestUser/signInWithPassword'
+  )
   if (error || !data.session) {
     throw new Error(`[SMI-4460] signInTestUser failed: ${error?.message ?? 'no session'}`)
   }
@@ -335,18 +353,26 @@ export interface DeviceCodeRow {
 }
 
 export async function queryDeviceCode(opts: { userCode: string }): Promise<DeviceCodeRow | null> {
-  const { data, error } = await admin()
-    .from('device_codes')
-    .select('device_code,user_code,user_id,approved_at,consumed_at,expires_at,client_type')
-    // CLI strips dash + uppercases; DB stores raw; normalise both sides.
-    .eq('user_code', opts.userCode.replace(/-/g, '').toUpperCase())
-    .maybeSingle()
+  const { data, error } = await withTimeout(
+    admin()
+      .from('device_codes')
+      .select('device_code,user_code,user_id,approved_at,consumed_at,expires_at,client_type')
+      // CLI strips dash + uppercases; DB stores raw; normalise both sides.
+      .eq('user_code', opts.userCode.replace(/-/g, '').toUpperCase())
+      .maybeSingle(),
+    STAGING_CALL_TIMEOUT_MS,
+    'queryDeviceCode'
+  )
   if (error) throw new Error(`[SMI-4460] queryDeviceCode: ${error.message}`)
   return (data as DeviceCodeRow | null) ?? null
 }
 
 export async function cleanupDeviceCode(deviceCode: string): Promise<void> {
-  const { error } = await admin().from('device_codes').delete().eq('device_code', deviceCode)
+  const { error } = await withTimeout(
+    admin().from('device_codes').delete().eq('device_code', deviceCode),
+    STAGING_CALL_TIMEOUT_MS,
+    'cleanupDeviceCode'
+  )
   if (error) throw new Error(`[SMI-4460] cleanupDeviceCode: ${error.message}`)
 }
 
@@ -370,14 +396,18 @@ export async function queryAuditLogConsumed(opts: {
   sinceMs: number
 }): Promise<AuditLogRow | null> {
   const since = new Date(Date.now() - opts.sinceMs).toISOString()
-  const { data, error } = await admin()
-    .from('audit_logs')
-    .select('id,event_type,metadata,created_at')
-    .eq('event_type', 'auth:device_code:consumed')
-    .contains('metadata', { user_id: opts.userId })
-    .gte('created_at', since)
-    .order('created_at', { ascending: false })
-    .limit(1)
+  const { data, error } = await withTimeout(
+    admin()
+      .from('audit_logs')
+      .select('id,event_type,metadata,created_at')
+      .eq('event_type', 'auth:device_code:consumed')
+      .contains('metadata', { user_id: opts.userId })
+      .gte('created_at', since)
+      .order('created_at', { ascending: false })
+      .limit(1),
+    STAGING_CALL_TIMEOUT_MS,
+    'queryAuditLogConsumed'
+  )
   if (error) throw new Error(`[SMI-4460] queryAuditLogConsumed: ${error.message}`)
   return ((data?.[0] as AuditLogRow | undefined) ?? null) as AuditLogRow | null
 }
@@ -412,11 +442,20 @@ export function cleanupAllTmpdirs(): void {
 import { writeFileSync, mkdirSync, existsSync } from 'node:fs'
 
 /**
- * Write captured stdout/stderr from a CliExitResult to test-results so
- * uploaded artifacts include them on failure. Workflow's artifact
- * upload step globs `test-results/cli-*.log`.
+ * Write captured stdout/stderr to test-results so uploaded artifacts include
+ * them on failure. Workflow's artifact upload step globs
+ * `test-results/cli-*.log`.
+ *
+ * SMI-4506: accepts either a completed `CliExitResult` (preferred — includes
+ * exit code) OR a `{ stdout, stderr }` snapshot from `cli.snapshot()` for
+ * the case where the test hung BEFORE `waitForExit()` ran. The
+ * `inFlight` flag in the dump output makes the difference visible to the
+ * reader.
  */
-export function dumpCliLogs(testId: string, result: CliExitResult): void {
+export function dumpCliLogs(
+  testId: string,
+  source: CliExitResult | { stdout: string; stderr: string }
+): void {
   const dir = 'test-results'
   if (!existsSync(dir)) {
     try {
@@ -425,10 +464,14 @@ export function dumpCliLogs(testId: string, result: CliExitResult): void {
       return
     }
   }
+  const isExitResult = 'code' in source
+  const header = isExitResult
+    ? `--- exit ${(source as CliExitResult).code} ---`
+    : `--- in-flight snapshot (waitForExit not reached — likely SMI-4506 hang) ---`
   try {
     writeFileSync(
       join(dir, `cli-${testId}.log`),
-      `--- exit ${result.code} ---\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}\n`
+      `${header}\n--- stdout ---\n${source.stdout}\n--- stderr ---\n${source.stderr}\n`
     )
   } catch {
     /* swallow */

--- a/packages/website/tests/e2e/device-login-roundtrip.spec.ts
+++ b/packages/website/tests/e2e/device-login-roundtrip.spec.ts
@@ -61,7 +61,12 @@ test.describe('SMI-4460 — Device-code login round-trip (staging)', () => {
   })
 
   test.afterEach(async ({}, testInfo) => {
+    // SMI-4506: dump CLI logs unconditionally. Previously this only ran
+    // when `result` was set (i.e. waitForExit completed), which meant a
+    // hang BEFORE the polling phase produced no CLI evidence at all —
+    // exactly when we need it most. Snapshot the buffered streams instead.
     if (result) dumpCliLogs(testInfo.testId, result)
+    else if (cli) dumpCliLogs(testInfo.testId, cli.snapshot())
     if (deviceCode) {
       try {
         await cleanupDeviceCode(deviceCode)

--- a/packages/website/tests/e2e/device-login-roundtrip.spec.ts
+++ b/packages/website/tests/e2e/device-login-roundtrip.spec.ts
@@ -49,6 +49,17 @@ test.describe('SMI-4460 — Device-code login round-trip (staging)', () => {
   let cli: CliHandle | undefined
   let result: CliExitResult | undefined
 
+  // SMI-4495: CLI flow test — iPhone viewport (mobile, WebKit) provides no
+  // additional coverage and the CI runner only installs Chromium
+  // (`npx playwright install chromium`), so mobile fails immediately with
+  // `webkit-2272/pw_run.sh: Executable doesn't exist`. Scope to desktop only.
+  test.beforeEach(async ({}, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'desktop',
+      'SMI-4495: CLI login flow runs on desktop project only'
+    )
+  })
+
   test.afterEach(async ({}, testInfo) => {
     if (result) dumpCliLogs(testInfo.testId, result)
     if (deviceCode) {

--- a/packages/website/tests/e2e/device-login-roundtrip.timeout.ts
+++ b/packages/website/tests/e2e/device-login-roundtrip.timeout.ts
@@ -1,0 +1,32 @@
+/**
+ * device-login-roundtrip.timeout.ts
+ *
+ * SMI-4506 — small Promise.race timeout wrapper used by the round-trip
+ * helpers. Extracted to a companion file to keep helpers.ts under the
+ * 500-line cap (CLAUDE.md CI Health Requirements).
+ *
+ * supabase-js + node:net don't bail on hung connections, so a single
+ * staging-side stall would eat the entire 2-min Playwright budget with
+ * no useful error. Wrapping every external-system call in withTimeout
+ * gives "fail fast with a real cause" instead.
+ */
+
+/** Race `p` against a timeout that throws a labelled error after `ms`. */
+export async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`[SMI-4506] ${label} timed out after ${ms}ms`)), ms)
+  })
+  try {
+    return await Promise.race([p, timeoutPromise])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+/**
+ * Default per-call deadline for staging Supabase REST/auth calls. 10s gives
+ * cold-start headroom while leaving enough budget that an actual hang is
+ * reported well inside the 2-min Playwright test ceiling.
+ */
+export const STAGING_CALL_TIMEOUT_MS = 10_000


### PR DESCRIPTION
## Summary

Bundle of round-trip e2e fixes — 5 SMIs, 3 commits. Net effect: **failure mode improved from "opaque 2-min generic timeout" → "16.8s actionable error pointing at SMI-4508"**. Each fix is correct independently; bundling preserves diagnostic context.

### Confirmed working in CI

- ✅ **SMI-4495** — `[mobile]` project skipped via `test.beforeEach`. WebKit no longer attempts to launch.
- ✅ **SMI-4505** — `packages/website/test-results/` in upload allowlist. trace.zip + screenshot + error-context recoverable.
- ✅ **SMI-4506** — `withTimeout` on supabase-js helpers + `cli.snapshot()` accessor + unconditional `dumpCliLogs` in `afterEach`. The snapshot is what surfaced the SMI-4507 root cause.
- ✅ **SMI-4507** — workflow `CLI_PATH` typo (was `dist/index.js`, should be `dist/src/index.js` per the CLI's `bin` field) + `parseUserCode` rejects on stream-close-without-a-code (was silently hanging).
- 🛡 **SMI-4496** — IPv4 `WEBSITE_BASE_URL` lands as defense-in-depth (matches SMI-4493 wait-on lesson). Not the operative root cause but correctly addresses a latent defect in the same family.

### Surfaced + filed (next session)

- ⏭ **SMI-4508** — `/device` is SSR-only (`prerender = false`, with SSR session check). `http-server dist/client` can't serve it. Round-trip's last gating bug. Four fix options laid out (vercel CLI / @astrojs/node / prerender carve-out / staging URL); recommended Option A.

## Diff

3 commits / 4 files / +144 / -16

| Commit | SMIs | Files |
|---|---|---|
| `19c8c887` | 4495 / 4496 / 4505 | `device-login-roundtrip.yml` + `.spec.ts` |
| `7bed3d7e` | 4506 | `.helpers.ts` + `.timeout.ts` (new) + `.spec.ts` |
| `cedccf21` | 4507 | `device-login-roundtrip.yml` + `.helpers.ts` |

## Test plan

- [x] All required gates green (Lint, Typecheck, Tests, Build, CodeQL, Standards Compliance, etc.)
- [x] Round-trip `[mobile]` skipped (verified in run 24971517716)
- [x] Round-trip trace.zip recoverable (verified in run 24971517716)
- [x] Round-trip CLI_PATH points to `dist/src/index.js` (verified in run 24972144583 env block)
- [x] Round-trip fails fast at 16.8s with actionable error (was 120s opaque)
- [ ] Round-trip green end-to-end ← **gated on SMI-4508** (separate PR/decision)

## Why land

PR is non-blocking for any required check (round-trip is `continue-on-error: true` in Phase 1 observability mode). All five fixes are real defects in scope; bundling them preserves the diagnostic chain. The cli.snapshot artifact from this PR's run is what made SMI-4507 visible — those fixes are tightly coupled and would have made no sense to split.

## ADR-109 note

Workflow + spec changes. Surgical continuation of the SMI-4493/4494 lineage, all surfaced through the same e2e harness with each fix moving the failure point one layer deeper. No new CI architecture introduced.

## Linear

- Closes [SMI-4495](https://linear.app/smith-horn-group/issue/SMI-4495) (mobile skip — confirmed working)
- Closes [SMI-4505](https://linear.app/smith-horn-group/issue/SMI-4505) (upload-artifact paths — confirmed working)
- Closes [SMI-4506](https://linear.app/smith-horn-group/issue/SMI-4506) (helpers + snapshot — confirmed working, captured the SMI-4507 evidence)
- Closes [SMI-4507](https://linear.app/smith-horn-group/issue/SMI-4507) (CLI_PATH + parseUserCode — confirmed working, CLI now spawns + parses)
- Defense-in-depth for [SMI-4496](https://linear.app/smith-horn-group/issue/SMI-4496) (IPv4 baseURL — keeps issue open until round-trip fully green)
- Filed [SMI-4508](https://linear.app/smith-horn-group/issue/SMI-4508) (SSR runtime — High prio, takes the next layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)