### PR TITLE
fix(security): batch close 4 GitHub security alerts (SMI-4499/4501/4502/4504)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2072,16 +2072,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@azure/msal-node/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "devOptional": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -18325,14 +18315,6 @@
         "@types/koa": "*"
       }
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -30979,42 +30961,6 @@
         "protobufjs": "^6.8.8"
       }
     },
-    "node_modules/onnx-proto/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true
-    },
-    "node_modules/onnx-proto/node_modules/protobufjs": {
-      "version": "6.11.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.5.tgz",
-      "integrity": "sha512-OKjVH3hDoXdIZ/s5MLv8O2X0s+wOxGfV7ar6WFSKGaSAxi/6gYn3px5POS4vi+mc/0zCOdL7Jkwrj0oT1Yst2A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
     "node_modules/onnxruntime-common": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
@@ -35539,18 +35485,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "optional": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validator": {

--- a/package.json
+++ b/package.json
@@ -114,6 +114,8 @@
     "h3": "^1.15.9",
     "hono": "^4.12.14",
     "@hono/node-server": "^1.19.13",
+    "protobufjs": "^7.5.5",
+    "uuid": "^14.0.0",
     "vite": "^7.3.2",
     "fast-xml-parser": "^5.5.7",
     "@aws-sdk/xml-builder": ">=3.972.3",

--- a/packages/core/src/audit/remote-audit.ts
+++ b/packages/core/src/audit/remote-audit.ts
@@ -32,11 +32,9 @@ const REQUEST_TIMEOUT_MS = 2000
 const TELEMETRY_ACTOR_KEY = 'skillsmith-telemetry-actor:v1'
 
 function hashForActor(apiKey: string): string {
-  // lgtm[js/insufficient-password-hash] This is deterministic correlation-ID
+  // codeql[js/insufficient-password-hash] Deterministic telemetry actor-ID
   // derivation via HMAC-SHA-256 — not password storage. See TELEMETRY_ACTOR_KEY
-  // doc-comment above for full rationale (false positive in CodeQL's taint
-  // tracking which flags any flow from an API-key-like source into a crypto
-  // function, regardless of construction).
+  // doc-comment above for full rationale.
   return createHmac('sha256', TELEMETRY_ACTOR_KEY).update(apiKey).digest('hex')
 }
 

--- a/packages/mcp-server/src/tools/integration-tools.stub.ts
+++ b/packages/mcp-server/src/tools/integration-tools.stub.ts
@@ -8,6 +8,7 @@
  * Provides in-memory stub implementations for webhook and API key management.
  */
 
+import { randomBytes } from 'node:crypto'
 import type {
   IntegrationService,
   Webhook,
@@ -21,16 +22,11 @@ import type {
 // ============================================================================
 
 function generateStubSecret(): string {
-  const chars = 'abcdef0123456789'
-  return Array.from({ length: 32 }, () => chars[Math.floor(Math.random() * chars.length)]).join('')
+  return randomBytes(16).toString('hex')
 }
 
 function generateStubKey(): string {
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-  return (
-    'sk_int_' +
-    Array.from({ length: 40 }, () => chars[Math.floor(Math.random() * chars.length)]).join('')
-  )
+  return 'sk_int_' + randomBytes(30).toString('base64url')
 }
 
 function computeExpiry(expiresIn?: string): string | null {


### PR DESCRIPTION
## Summary

Closes 4 GitHub security alerts (1 critical Dependabot + 3 high CodeQL):

- **SMI-4499** — re-add `protobufjs: ^7.5.5` global override (closes Dependabot #91 critical RCE). Originally added in SMI-4248 (#607), dropped in SMI-4250 (#610) on the assumption that only ruflo (dev-only) still pulled sub-7.5.5. That was wrong: `@claude-flow/aidefence@3.0.2` (production dep) reaches it via `@xenova/transformers > onnxruntime-web > onnx-proto@4.0.4 → protobufjs@^6.11.0`. Caret declaration → flat override resolves cleanly.
- **SMI-4501** — add `uuid: ^14.0.0` global override (closes Dependabot #95 medium). Three chains affected (gcp-metadata, ruflo plugin, @azure/msal-node); all resolve to 14.0.0 post-install. v4() API used by all three is unchanged in v14.
- **SMI-4502** — replace `Math.random` in `integration-tools.stub.ts` with `crypto.randomBytes` (closes CodeQL #79/#80 high). Stub is re-exported from production-shipped `@skillsmith/mcp-server`. Output format preserved (32 hex chars for whsec_*, 40 base64url chars for sk_int_*).
- **SMI-4504** — replace inert `lgtm[js/insufficient-password-hash]` annotation in `remote-audit.ts` with `// codeql[...]` form (targets CodeQL #85 dismissal). LGTM annotations have been silently no-op since GHAS migration.

## Test plan

- [x] npm install — overrides applied; npm ls protobufjs and npm ls uuid clean
- [x] npm audit --omit=dev — only astro <6.1.6 remaining (PR-2 / SMI-4500 scope)
- [x] npm run lint — clean
- [x] npm run typecheck — clean
- [x] npm test core — 3539/3541 (2 skipped baseline)
- [x] npm test mcp-server — 603/610 (7 todo baseline)
- [x] npm run audit:standards — 50 pass / 5 warns / 0 fail
- [x] npm run format:check — clean
- [ ] CodeQL CI scan after merge confirms #79, #80 close and codeql[] annotation in #85 takes effect (else manual UI dismissal)
- [ ] Dependabot rescan after merge confirms #91, #95 close

## Linear

- https://linear.app/smith-horn-group/issue/SMI-4499
- https://linear.app/smith-horn-group/issue/SMI-4501
- https://linear.app/smith-horn-group/issue/SMI-4502
- https://linear.app/smith-horn-group/issue/SMI-4504

Project: GitHub Security Alerts (April 2026)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

[skip-doc-drift]