### PR TITLE
fix(security): rotate KEY_HMAC_SECRET to env var (SMI-4503, CodeQL #81)

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -320,6 +320,26 @@ SUPABASE_DB_PASSWORD=
 SUPABASE_POOLER_URL=
 
 # =============================================================================
+# INTEGRATION API KEY HASHING (SMI-4503)
+# =============================================================================
+
+# HMAC-SHA-256 secret for hashing Custom Integration API keys before storing in
+# the api_keys table. Replaces the previously hardcoded constant
+# 'skillsmith-api-key' (CodeQL alert #85 / CWE-916). Must be the SAME value
+# across every MCP host that creates or verifies integration API keys —
+# defense-in-depth against api_keys table exfiltration (a leaked DB without the
+# secret cannot be reverse-cracked offline).
+#
+# Threat model is identical to SUPABASE_SERVICE_ROLE_KEY: only Team+ admins
+# touching the integrations surface need this. Distribute via the same channel.
+#
+# Generate via: openssl rand -base64 48
+# Required only when integration tools are invoked. If absent, hashApiKey()
+# fails fast at first call with an actionable error.
+# @type=string(min=32) @required=false @sensitive
+SKILLSMITH_API_KEY_HMAC_SECRET=
+
+# =============================================================================
 # POSTHOG TELEMETRY (Phase 6A)
 # =============================================================================
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -352,6 +352,50 @@ Index local skills from `~/.claude/skills/` directory.
 | `SKILLSMITH_TELEMETRY_ENABLED` | Enable anonymous telemetry | `false` |
 | `SKILLSMITH_USE_WASM` | Force WASM SQLite driver (sql.js) | `false` |
 | `POSTHOG_API_KEY` | PostHog API key (required if telemetry enabled) | - |
+| `SKILLSMITH_API_KEY_HMAC_SECRET` | HMAC secret for hashing Custom Integration API keys before DB storage. Required if you invoke `webhook_configure` or `api_key_manage`. See setup below. | - |
+
+### Custom Integration Setup (Team+ admins)
+
+The `webhook_configure` and `api_key_manage` tools hash secrets server-side via HMAC-SHA-256 before persisting to the shared `api_keys` table. The HMAC key lives in `SKILLSMITH_API_KEY_HMAC_SECRET` rather than as a hardcoded constant — defense-in-depth so a leaked DB cannot be reverse-cracked offline.
+
+**Distribution model**: identical to `SUPABASE_SERVICE_ROLE_KEY`. The same secret value must be set on every MCP host that creates or verifies Custom Integration API keys, otherwise hashes computed on host A won't match hashes verified on host B.
+
+If the variable is missing or shorter than 32 characters when these tools are invoked, the call fails fast with:
+
+```
+SKILLSMITH_API_KEY_HMAC_SECRET must be set to a 32+ character random secret
+before integration tools can be used. Generate one via: openssl rand -base64 48
+```
+
+**First-time provisioning** (Skillsmith admin, once per organization):
+
+```bash
+openssl rand -base64 48
+```
+
+Distribute that value through the same secure channel used for `SUPABASE_SERVICE_ROLE_KEY` (e.g., 1Password vault, encrypted onboarding email). Each Team-tier admin sets it on their own MCP host alongside their other secrets:
+
+```jsonc
+// ~/.claude/settings.json
+{
+  "mcpServers": {
+    "skillsmith": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"],
+      "env": {
+        "SKILLSMITH_API_KEY": "sk_live_your_personal_key",
+        "SKILLSMITH_LICENSE_KEY": "sklic_your_team_license",
+        "SUPABASE_SERVICE_ROLE_KEY": "eyJ...your_service_role_jwt",
+        "SKILLSMITH_API_KEY_HMAC_SECRET": "<the shared 32+ char secret>"
+      }
+    }
+  }
+}
+```
+
+**Rotation**: replace the secret on every host in lockstep. Existing rows in the `api_keys` table become unverifiable after rotation, so coordinate with affected admins or invalidate keys explicitly. As of 2026-04-26 the table has zero rows, so the first rotation post-launch is free.
+
+If you only use Community/Individual tools (search, install, recommend, etc.), this variable is not needed.
 
 ### WASM Fallback (v0.3.18+)
 

--- a/packages/mcp-server/src/tools/integration-tools.service.hash.test.ts
+++ b/packages/mcp-server/src/tools/integration-tools.service.hash.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Tests for hashApiKey and its env-var-backed HMAC secret.
+ * Extracted from integration-tools.service.test.ts to keep that file under
+ * the 500-line cap (SMI-2162). The rest of the integration-tools test
+ * suite still sets the env var via its own top-level beforeAll/afterAll.
+ *
+ * @see SMI-4503: Rotate KEY_HMAC_SECRET to env var
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { createHmac } from 'node:crypto'
+import { hashApiKey } from './integration-tools.service.js'
+
+const TEST_HMAC_SECRET = 'test-hmac-secret-for-vitest-only-32chars-minimum-padding-padding-padding'
+const ORIGINAL_HMAC_SECRET = process.env.SKILLSMITH_API_KEY_HMAC_SECRET
+
+beforeAll(() => {
+  process.env.SKILLSMITH_API_KEY_HMAC_SECRET = TEST_HMAC_SECRET
+})
+
+afterAll(() => {
+  if (ORIGINAL_HMAC_SECRET === undefined) delete process.env.SKILLSMITH_API_KEY_HMAC_SECRET
+  else process.env.SKILLSMITH_API_KEY_HMAC_SECRET = ORIGINAL_HMAC_SECRET
+})
+
+describe('hashApiKey', () => {
+  it('should produce a deterministic SHA-256 HMAC hex hash', () => {
+    const key = 'sk_int_testkey123'
+    const hash = hashApiKey(key)
+
+    const expected = createHmac('sha256', TEST_HMAC_SECRET).update(key).digest('hex')
+    expect(hash).toBe(expected)
+    expect(hash).toHaveLength(64)
+  })
+
+  it('should produce different hashes for different keys', () => {
+    expect(hashApiKey('key-a')).not.toBe(hashApiKey('key-b'))
+  })
+
+  describe('boot validation', () => {
+    afterAll(() => {
+      process.env.SKILLSMITH_API_KEY_HMAC_SECRET = TEST_HMAC_SECRET
+    })
+
+    it('should fail fast when SKILLSMITH_API_KEY_HMAC_SECRET is missing', () => {
+      delete process.env.SKILLSMITH_API_KEY_HMAC_SECRET
+      expect(() => hashApiKey('any-key')).toThrow(/SKILLSMITH_API_KEY_HMAC_SECRET/)
+    })
+
+    it('should fail fast when secret is shorter than 32 characters', () => {
+      process.env.SKILLSMITH_API_KEY_HMAC_SECRET = 'too-short'
+      expect(() => hashApiKey('any-key')).toThrow(/32\+ character/)
+    })
+  })
+})

--- a/packages/mcp-server/src/tools/integration-tools.service.test.ts
+++ b/packages/mcp-server/src/tools/integration-tools.service.test.ts
@@ -5,7 +5,7 @@
  * All tests mock the Supabase client — no real database needed.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest'
 import { createHmac } from 'node:crypto'
 import {
   createRealIntegrationService,
@@ -13,6 +13,21 @@ import {
   computeHmacSignature,
   type SupabaseClient,
 } from './integration-tools.service.js'
+
+// SMI-4503: hashApiKey reads SKILLSMITH_API_KEY_HMAC_SECRET from env. All tests
+// in this file must run with the secret set; the per-describe block below
+// covers the env-var-missing failure mode in isolation.
+const TEST_HMAC_SECRET = 'test-hmac-secret-for-vitest-only-32chars-minimum-padding-padding-padding'
+const ORIGINAL_HMAC_SECRET = process.env.SKILLSMITH_API_KEY_HMAC_SECRET
+
+beforeAll(() => {
+  process.env.SKILLSMITH_API_KEY_HMAC_SECRET = TEST_HMAC_SECRET
+})
+
+afterAll(() => {
+  if (ORIGINAL_HMAC_SECRET === undefined) delete process.env.SKILLSMITH_API_KEY_HMAC_SECRET
+  else process.env.SKILLSMITH_API_KEY_HMAC_SECRET = ORIGINAL_HMAC_SECRET
+})
 
 // ============================================================================
 // Supabase mock factory
@@ -55,23 +70,9 @@ const TEAM_ID = 'team-001'
 
 // ============================================================================
 // Crypto helper tests
+// hashApiKey + env-var boot-validation tests live in
+// integration-tools.service.hash.test.ts (SMI-2162 file-length companion).
 // ============================================================================
-
-describe('hashApiKey', () => {
-  it('should produce a deterministic SHA-256 HMAC hex hash', () => {
-    const key = 'sk_int_testkey123'
-    const hash = hashApiKey(key)
-
-    // Verify it matches raw crypto
-    const expected = createHmac('sha256', 'skillsmith-api-key').update(key).digest('hex')
-    expect(hash).toBe(expected)
-    expect(hash).toHaveLength(64)
-  })
-
-  it('should produce different hashes for different keys', () => {
-    expect(hashApiKey('key-a')).not.toBe(hashApiKey('key-b'))
-  })
-})
 
 describe('computeHmacSignature', () => {
   it('should produce correct HMAC-SHA256 signature', () => {

--- a/packages/mcp-server/src/tools/integration-tools.service.ts
+++ b/packages/mcp-server/src/tools/integration-tools.service.ts
@@ -49,7 +49,6 @@ interface SupabaseListResult {
 // Constants
 // ============================================================================
 
-const KEY_HMAC_SECRET = 'skillsmith-api-key'
 const TEST_RATE_LIMIT_MS = 60_000
 const TEST_DELIVERY_TIMEOUT_MS = 10_000
 const API_KEY_PREFIX_LENGTH = 15 // "sk_int_" (7) + 8 chars
@@ -57,6 +56,30 @@ const API_KEY_PREFIX_LENGTH = 15 // "sk_int_" (7) + 8 chars
 // ============================================================================
 // Crypto helpers
 // ============================================================================
+
+/**
+ * HMAC key for hashing integration API keys. Read from
+ * `SKILLSMITH_API_KEY_HMAC_SECRET` at first use (lazy so process.env writes from
+ * the test harness or boot-time loaders apply). Replaces a previously
+ * hardcoded constant (CodeQL js/insufficient-password-hash, CWE-916) — a known
+ * static key meant a leaked api_keys table could be reverse-cracked offline.
+ *
+ * Must be the same value across every MCP host that creates or verifies
+ * integration API keys; threat model + distribution channel matches
+ * SUPABASE_SERVICE_ROLE_KEY (only Team+ admins touching the integrations
+ * surface need it).
+ */
+function getKeyHmacSecret(): string {
+  const secret = process.env.SKILLSMITH_API_KEY_HMAC_SECRET
+  if (!secret || secret.length < 32) {
+    throw new Error(
+      'SKILLSMITH_API_KEY_HMAC_SECRET must be set to a 32+ character random ' +
+        'secret before integration tools can be used. ' +
+        'Generate one via: openssl rand -base64 48'
+    )
+  }
+  return secret
+}
 
 function generateSigningSecret(): string {
   return 'whsec_' + randomBytes(32).toString('hex')
@@ -68,7 +91,7 @@ function generateApiKey(): string {
 
 /** Hash an API key for storage (one-way) */
 export function hashApiKey(key: string): string {
-  return createHmac('sha256', KEY_HMAC_SECRET).update(key).digest('hex')
+  return createHmac('sha256', getKeyHmacSecret()).update(key).digest('hex')
 }
 
 /** Compute HMAC-SHA256 signature for webhook delivery */


### PR DESCRIPTION
> ⚠️ **DRAFT — DO NOT MERGE until SKILLSMITH_API_KEY_HMAC_SECRET is provisioned in all environments.** Boot will fail-fast if the env var is missing on any MCP host that calls integration tools.

## Summary

Closes CodeQL alert #81 (`js/insufficient-password-hash`, CWE-916). Replaces hardcoded `KEY_HMAC_SECRET = 'skillsmith-api-key'` (visible in published @skillsmith/mcp-server) with `process.env.SKILLSMITH_API_KEY_HMAC_SECRET`.

## Changes

- `packages/mcp-server/src/tools/integration-tools.service.ts` — drop hardcoded constant, add `getKeyHmacSecret()` with fail-fast validation (>=32 chars), `hashApiKey()` reads lazily
- `packages/mcp-server/src/tools/integration-tools.service.test.ts` — top-level beforeAll/afterAll sets env var for all tests; original file kept under 500-line cap (SMI-2162) by extracting hashApiKey tests
- `packages/mcp-server/src/tools/integration-tools.service.hash.test.ts` — **new companion file** (56 lines): 4 tests covering deterministic hash, distinct hashes, fail-fast on missing/short secret
- `.env.schema` — add `SKILLSMITH_API_KEY_HMAC_SECRET` with `@sensitive @type=string(min=32)`. Documents same threat model + distribution as `SUPABASE_SERVICE_ROLE_KEY`.

## Migration

Zero rows in production `api_keys` table verified via pooler-psql on 2026-04-26 (`SELECT COUNT(*) FROM api_keys` returned 0). **No rehash needed.**

## Required deployment ordering (BEFORE merging)

1. Generate the secret: \`openssl rand -base64 48\`
2. Provision in:
   - [ ] Vercel project env (production + preview)
   - [ ] Supabase Edge Functions secrets (if any edge function calls integration tools — currently none, but provision proactively)
   - [ ] GitHub Actions repository secrets
   - [ ] Local dev `.env` (Varlock)
3. Verify with one MCP host: `node -e "process.env.SKILLSMITH_API_KEY_HMAC_SECRET = '<...>'; require('@skillsmith/mcp-server').integrations"` should not throw
4. Mark this PR ready for review

If the env var is missing post-merge, integration tool calls fail fast with: \`SKILLSMITH_API_KEY_HMAC_SECRET must be set to a 32+ character random secret before integration tools can be used. Generate one via: openssl rand -base64 48\`

## Test plan

- [x] \`vitest packages/mcp-server/src/tools/integration-tools.service*\` — 26/26 pass (22 main + 4 hash companion)
- [x] \`npm test -w @skillsmith/mcp-server\` — full suite baseline pass
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` — clean
- [x] \`check-file-length.mjs\` — both test files under 500 (496 main, 56 companion)
- [x] \`npm run audit:standards\` — 91% baseline
- [ ] Env var provisioned in all environments
- [ ] After next CodeQL scan, alert #81 transitions to \`state = fixed\`
- [ ] Move from Draft → Ready when env vars are confirmed in Vercel + GitHub Actions

## Origin

Plan-review on 2026-04-26 caught this. Original triage (in SMI-4504's sibling analysis) classified the alert as a false positive based on input entropy. VP Engineering review correctly identified that the HMAC *key* (not input) was the issue: static key + known algorithm = offline-crackable on DB leak.

## Linear

- https://linear.app/smith-horn-group/issue/SMI-4503
- Project: [GitHub Security Alerts (April 2026)](https://linear.app/smith-horn-group/project/github-security-alerts-april-2026-125371537014)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)