### PR TITLE
fix(ci): SMI-4508 retro — SHA-pin actions/cache to match repo convention

### DIFF
--- a/.github/workflows/device-login-roundtrip.yml
+++ b/.github/workflows/device-login-roundtrip.yml
@@ -191,7 +191,7 @@ jobs:
           echo "auth-device-code warmed."
 
       - name: Cache Vercel build cache
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.vercel/cache
           key: vercel-cache-${{ runner.os }}-${{ hashFiles('packages/website/**/*.ts', 'packages/website/**/*.tsx', 'packages/website/**/*.astro', 'packages/website/**/*.mjs', 'packages/website/**/*.json', 'packages/website/vercel.json') }}


### PR DESCRIPTION
## Summary

Governance retro on PR #808 (merged at `62cbcb4e`) surfaced inconsistent action pinning: the new `Cache Vercel build cache` step used `actions/cache@v4` while every other action in the same workflow is SHA-pinned with a `# v<n>` trailing comment.

Pin to the canonical SHA used in `ci.yml` and `website-deploy-staging.yml` (`668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5`) so all `.github/workflows/*.yml` action references stay uniform — Zero Deferral applied.

## Test plan

- [x] Local diff verified one-line change
- [ ] CI green (matrix is config-only — most jobs SKIPPED)
- [ ] Round-trip test still passes (Vercel cache key/restore-key unchanged; only the action's SHA moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)