### PR TITLE
fix(ci): scope e2e-usage-counter to e2e-staging environment (SMI-4521)

### DIFF
--- a/.github/workflows/e2e-usage-counter.yml
+++ b/.github/workflows/e2e-usage-counter.yml
@@ -36,6 +36,8 @@ jobs:
     name: Usage Counter E2E
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # SMI-4521: STAGING_SUPABASE_* secrets are scoped to this environment.
+    environment: e2e-staging
     # Only run after a successful edge-function deploy.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 


### PR DESCRIPTION
## Summary

- Add `environment: e2e-staging` to `e2e-usage-counter.yml` job so `${{ secrets.STAGING_* }}` resolve.
- Mirrors `device-login-roundtrip.yml:94` and `device-login-roundtrip-cleanup.yml:27`.

## Why

First-ever run of `E2E Usage Counter` ([#25032717593](https://github.com/smith-horn/skillsmith/actions/runs/25032717593)) failed at the workflow's own preflight:

```
::error::Required secret STAGING_SUPABASE_URL is not set.
::error::Required secret STAGING_SUPABASE_SERVICE_ROLE_KEY is not set.
::error::Required secret STAGING_SUPABASE_ANON_KEY is not set.
```

The three secrets exist in the `e2e-staging` GitHub Environment (`gh secret list --env e2e-staging` confirms — added 2026-04-26) but the job didn't declare the env, so they resolved as empty.

## Test plan

- [ ] After merge: `gh workflow run e2e-usage-counter.yml --ref main`
- [ ] Confirm "Verify staging secrets are populated" passes
- [ ] Confirm "Run @e2e-usage-counter suite" actually executes

Linear: SMI-4521 (parent SMI-4462)

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)