### PR TITLE
fix(mcp-server): map curated trust tier through MCP surface (SMI-4520)

### DIFF
--- a/packages/cli/src/commands/recommend.helpers.ts
+++ b/packages/cli/src/commands/recommend.helpers.ts
@@ -58,6 +58,7 @@ export function isNetworkError(error: unknown): boolean {
 
 /**
  * Get trust badge for display (SMI-1357)
+ * SMI-2381 / SMI-4520: Added 'curated' tier
  */
 export function getTrustBadge(tier: TrustTier): string {
   switch (tier) {
@@ -65,6 +66,8 @@ export function getTrustBadge(tier: TrustTier): string {
       return chalk.green('[VERIFIED]')
     case 'community':
       return chalk.blue('[COMMUNITY]')
+    case 'curated':
+      return chalk.cyan('[CURATED]')
     case 'experimental':
       return chalk.yellow('[EXPERIMENTAL]')
     case 'unknown':

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,11 +6,13 @@
  * Trust tier levels for skill quality assessment
  * NOTE: Database tiers must match database schema (packages/core/src/database/schema.ts)
  * SMI-1809: Added 'local' for local skills from ~/.claude/skills/
+ * SMI-2381: Added 'curated' for third-party publishers opted into the registry
  */
 export type TrustTier =
   | 'verified' // Manually reviewed and verified
   | 'community' // High community ratings
   | 'experimental' // New or beta skills
+  | 'curated' // SMI-2381: Third-party publisher, manually opted in
   | 'unknown' // Not yet assessed
   | 'local' // SMI-1809: Local skills from ~/.claude/skills/
 
@@ -21,6 +23,7 @@ export const TrustTierDescriptions: Record<TrustTier, string> = {
   verified: 'Manually reviewed by the Skillsmith team. High quality and safe to use.',
   community: 'Highly rated by the community. Generally reliable.',
   experimental: 'New or beta skill. Use with caution.',
+  curated: 'Third-party publisher. Manually opted into the registry.',
   unknown: 'Not yet assessed. Review carefully before using.',
   local: 'Local skill from your ~/.claude/skills/ directory. You control this skill.',
 }

--- a/packages/mcp-server/src/__tests__/search.test.ts
+++ b/packages/mcp-server/src/__tests__/search.test.ts
@@ -268,6 +268,19 @@ describe('Search Tool branch coverage', () => {
       expect(result.filters.trustTier).toBe('verified')
     })
 
+    it('should allow search with curated trust_tier filter (SMI-4520)', async () => {
+      // Pre-fix this threw VALIDATION_INVALID_TYPE; post-fix curated must pass through.
+      const result = await executeSearch(
+        {
+          trust_tier: 'curated',
+        },
+        branchContext
+      )
+
+      expect(result.results).toBeDefined()
+      expect(result.filters.trustTier).toBe('curated')
+    })
+
     it('should allow search with only min_score filter', async () => {
       const result = await executeSearch(
         {

--- a/packages/mcp-server/src/__tests__/utils/validation.test.ts
+++ b/packages/mcp-server/src/__tests__/utils/validation.test.ts
@@ -49,6 +49,10 @@ describe('Validation Utilities', () => {
       expect(mapTrustTierToDb('experimental')).toBe('experimental')
     })
 
+    it('should map curated tier (SMI-4520)', () => {
+      expect(mapTrustTierToDb('curated')).toBe('curated')
+    })
+
     it('should map unknown tier', () => {
       expect(mapTrustTierToDb('unknown')).toBe('unknown')
     })
@@ -65,6 +69,11 @@ describe('Validation Utilities', () => {
 
     it('should map experimental tier', () => {
       expect(mapTrustTierFromDb('experimental')).toBe('experimental')
+    })
+
+    it('should map curated tier (SMI-4520)', () => {
+      // Pre-fix this returned 'unknown'; post-fix it must round-trip.
+      expect(mapTrustTierFromDb('curated')).toBe('curated')
     })
 
     it('should map unknown tier', () => {

--- a/packages/mcp-server/src/tools/compare.types.ts
+++ b/packages/mcp-server/src/tools/compare.types.ts
@@ -122,10 +122,12 @@ export type ExtendedSkill = Omit<Skill, 'dependencies'> & {
 /**
  * Trust tier ranking for comparison
  * SMI-1809: Added 'local' tier for local skills
+ * SMI-2381 / SMI-4520: Added 'curated' tier for third-party publishers (same rank as community)
  */
 export const TRUST_TIER_RANK: Record<TrustTier, number> = {
   verified: 4,
   community: 3,
+  curated: 3, // SMI-2381: Third-party publisher, manually vetted — same rank as community
   local: 3, // SMI-1809: Local skills rank same as community (user trusts their own skills)
   experimental: 2,
   unknown: 1,

--- a/packages/mcp-server/src/tools/compliance-tools.ts
+++ b/packages/mcp-server/src/tools/compliance-tools.ts
@@ -75,7 +75,7 @@ export const complianceReportToolSchema = {
 export interface SkillInventoryItem {
   skillId: string
   version: string
-  trustTier: 'verified' | 'community' | 'experimental' | 'unknown'
+  trustTier: 'verified' | 'curated' | 'community' | 'experimental' | 'unknown'
   installedAt: string
   lastUpdated: string
 }

--- a/packages/mcp-server/src/tools/get-skill.ts
+++ b/packages/mcp-server/src/tools/get-skill.ts
@@ -426,6 +426,7 @@ export function formatSkillDetails(response: GetSkillResponse): string {
 /**
  * Format trust tier with visual indicator
  * SMI-1809: Added 'local' tier
+ * SMI-2381 / SMI-4520: Added 'curated' tier
  */
 function formatTrustTier(tier: TrustTier): string {
   switch (tier) {
@@ -433,6 +434,8 @@ function formatTrustTier(tier: TrustTier): string {
       return '[*] VERIFIED'
     case 'community':
       return '[+] COMMUNITY'
+    case 'curated':
+      return '[#] CURATED' // SMI-2381: Third-party publisher
     case 'local':
       return '[@] LOCAL' // SMI-1809: Local skills from ~/.claude/skills/
     case 'experimental':

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -7,7 +7,7 @@
  * Provides skill search functionality with support for:
  * - Full-text search across skill names, descriptions, and authors
  * - Category filtering (development, testing, devops, etc.)
- * - Trust tier filtering (verified, community, experimental, unknown)
+ * - Trust tier filtering (verified, curated, community, experimental, unknown)
  * - Minimum quality score filtering
  *
  * @example
@@ -95,8 +95,9 @@ export const searchToolSchema = {
       },
       trust_tier: {
         type: 'string',
-        description: 'Filter by trust tier level',
-        enum: ['verified', 'community', 'experimental', 'unknown'],
+        description:
+          'Filter by trust tier level (verified, curated, community, experimental, unknown)',
+        enum: ['verified', 'curated', 'community', 'experimental', 'unknown'],
       },
       min_score: {
         type: 'number',
@@ -215,7 +216,7 @@ export async function executeSearch(
   }
 
   // Apply trust tier filter with runtime validation
-  const VALID_TRUST_TIERS = ['verified', 'community', 'experimental', 'unknown'] as const
+  const VALID_TRUST_TIERS = ['verified', 'curated', 'community', 'experimental', 'unknown'] as const
   if (input.trust_tier) {
     if (!VALID_TRUST_TIERS.includes(input.trust_tier as (typeof VALID_TRUST_TIERS)[number])) {
       throw new SkillsmithError(

--- a/packages/mcp-server/src/utils/validation.ts
+++ b/packages/mcp-server/src/utils/validation.ts
@@ -82,8 +82,9 @@ export function parseSkillId(id: string): { source?: string; author: string; nam
 /**
  * Map MCP trust tier to database trust tier.
  *
- * Types are now unified: verified, community, experimental, unknown, local
+ * Types are now unified: verified, community, experimental, curated, unknown, local
  * SMI-1809: Added 'local' for local skills from ~/.claude/skills/
+ * SMI-2381 / SMI-4520: Added 'curated' for third-party publishers
  *
  * @param mcpTier - MCP trust tier
  * @returns Database trust tier
@@ -96,6 +97,8 @@ export function mapTrustTierToDb(mcpTier: MCPTrustTier): DBTrustTier {
       return 'community'
     case 'experimental':
       return 'experimental'
+    case 'curated':
+      return 'curated'
     case 'local':
       return 'local'
     case 'unknown':
@@ -107,8 +110,9 @@ export function mapTrustTierToDb(mcpTier: MCPTrustTier): DBTrustTier {
  * Map database trust tier to MCP trust tier.
  *
  * Accepts string input and validates, returning 'unknown' for invalid values.
- * Types are unified: verified, community, experimental, unknown, local
+ * Types are unified: verified, community, experimental, curated, unknown, local
  * SMI-1809: Added 'local' for local skills from ~/.claude/skills/
+ * SMI-2381 / SMI-4520: Added 'curated' for third-party publishers
  *
  * @param dbTier - Database trust tier (string or typed)
  * @returns MCP trust tier
@@ -121,6 +125,8 @@ export function mapTrustTierFromDb(dbTier: DBTrustTier | string): MCPTrustTier {
       return 'community'
     case 'experimental':
       return 'experimental'
+    case 'curated':
+      return 'curated'
     case 'local':
       return 'local'
     case 'unknown':
@@ -254,6 +260,7 @@ export function getTrustBadge(tier: MCPTrustTier): string {
     verified: '[VERIFIED]',
     community: '[COMMUNITY]',
     experimental: '[EXPERIMENTAL]',
+    curated: '[CURATED]',
     unknown: '[UNKNOWN]',
     local: '[LOCAL]',
   }


### PR DESCRIPTION
## Summary

SMI-2381 added the `'curated'` trust tier for third-party publishers, but the MCP server's mapping helpers and search filter never picked it up. Every curated DB row rendered as `"unknown"` through `get_skill`, and `search` with `trust_tier=curated` threw `VALIDATION_INVALID_TYPE`. SMI-4519 (PR #816) shipped the first production data exercising the tier, making the gap user-visible.

## Changes

- **core** `packages/core/src/types.ts:10` — widen the MCP-facing `TrustTier` union to include `'curated'`. Add the matching `TrustTierDescriptions` entry. (The DB-facing `TrustTier` at `types/skill.ts:15` already had it.)
- **mcp-server** `packages/mcp-server/src/utils/validation.ts` — add `case 'curated'` to `mapTrustTierToDb` and `mapTrustTierFromDb`. Update JSDoc on both. Add `'[CURATED]'` badge to `getTrustBadge`.
- **mcp-server** `packages/mcp-server/src/tools/search.ts:99,98,218` — append `'curated'` to JSON schema enum and `VALID_TRUST_TIERS`. Update schema description so `tools/list` reflects the new option.
- **mcp-server** `packages/mcp-server/src/tools/compare.types.ts:126` — `TRUST_TIER_RANK` Record requires every key; `curated: 3` (same as community).
- **mcp-server** `packages/mcp-server/src/tools/compliance-tools.ts:78` — `SkillInventoryItem.trustTier` literal extended.
- **tests** — round-trip in `validation.test.ts`, filter pass-through in `search.test.ts` (host vitest: 26/26 validation tests pass; search.test.ts has a pre-existing setUp failure unrelated to this change — CI Docker is authoritative).

## Plan

[`docs/internal/implementation/smi-4520-curated-tier-mapping.md`](https://github.com/smith-horn/skillsmith/blob/main/docs/internal/implementation/smi-4520-curated-tier-mapping.md) — full plan-review applied (4 Critical, 3 High, 4 Medium, 2 Low addressed).

## Pre-condition (satisfied)

SMI-4524 (PR #819, `ad0db91b`) merged earlier today. Pooler verification confirms 29 curated rows live in the registry (12 mattpocock + 17 charlie947), so end-to-end smoke against either author exercises the fix.

## Post-merge ops (NOT in this PR)

1. `prepare-release.ts --core=patch --mcp-server=patch` to bump versions (or ride the next weekly release per ADR-114 cadence).
2. `gh workflow run publish.yml -f dry_run=false` — workflow handles dependency-order publish (`@skillsmith/core` first, then `@skillsmith/mcp-server`).
3. Smoke from a fresh MCP subprocess:
   - `mcp__skillsmith__get_skill { id: "mattpocock/tdd" }` → expect `trustTier: "curated"` (was `"unknown"`)
   - `mcp__skillsmith__search { query: "matt pocock", trust_tier: "curated" }` → expect mattpocock rows; no error
   - `mcp__skillsmith__search { query: "social media", trust_tier: "curated" }` → expect charlie947 rows

## Out of scope (filed separately if needed)

Other surfaces still listing only the original 4 tiers but not currently consuming MCP-mapped curated data:
- `packages/website/src/types/index.ts:42`, `components/types.ts:3`
- `packages/cli/src/commands/search.ts:344` (description text only)
- `packages/core/src/api/types.ts:16` `ApiTrustTier`
- `packages/core/src/db/schema-sql.ts:32` CHECK constraint (local SQLite cache)
- `packages/core/src/scoring/QualityScorer.ts:254`, `indexer/GitHubIndexer.ts:330`

These don't block the user-facing MCP fix; they're feature-completion work and can be batched.

## Test plan

- [x] Host vitest validation suite: 26/26 pass (round-trip for curated)
- [x] Diff staged, prettier clean against changed files
- [ ] Docker CI: `tsc --build` clean (was failing on host worktree only — known SMI-4381 false positive with zod 3 vs 4)
- [ ] Post-merge: `prepare-release.ts` + `publish.yml` (separate operator step)
- [ ] Post-publish: fresh `npx -y @skillsmith/mcp-server@latest` smoke against curated rows

Linear: SMI-4520
Related: SMI-4519 (parent), SMI-4524 (PR #819 — pre-condition), SMI-4529 (indexer drop bug, separate)

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)