### PR TITLE
fix(infra): SMI-4534 MCP Registry OIDC auth + failure isolation

### DIFF
--- a/.claude/development/mcp-registry.md
+++ b/.claude/development/mcp-registry.md
@@ -70,8 +70,11 @@ The `mcpName` field in `packages/mcp-server/package.json` links the npm package 
 The `publish.yml` workflow automatically publishes to MCP Registry after successful npm publish:
 
 1. npm publish succeeds for `@skillsmith/mcp-server`
-2. CI downloads `mcp-publisher` CLI
-3. CI publishes to registry using `MCP_REGISTRY_TOKEN` secret
+2. CI downloads `mcp-publisher` CLI (pinned to `v1.7.3`; SMI-4537 tracks drift)
+3. CI authenticates via GitHub Actions OIDC (`mcp-publisher login github-oidc`); no static secret needed
+4. CI publishes to registry
+
+**Failure isolation (SMI-4534)**: Registry login + publish steps are marked `continue-on-error: true`; npm publish remains the binding artifact. A loud-fail step files a GitHub issue automatically when the registry path fails.
 
 ### Manual
 
@@ -125,28 +128,19 @@ jq ".version = \"$VERSION\" | .packages[0].version = \"$VERSION\"" server.json >
 
 ## CI Setup
 
-### Required Secrets
+### Required Permissions (SMI-4534)
 
-| Secret | Description | How to Generate |
-|--------|-------------|-----------------|
-| `MCP_REGISTRY_TOKEN` | JWT token for registry auth | See below |
+CI auth uses GitHub Actions OIDC — no static secret. The `publish-mcp-server` job in `publish.yml` declares:
 
-### Generating MCP_REGISTRY_TOKEN
-
-```bash
-# 1. Login (generates tokens locally)
-mcp-publisher login github
-
-# 2. Copy the registry token
-cat ~/.mcpregistry_registry_token
-
-# 3. Add to GitHub Secrets
-# Settings → Secrets and variables → Actions → New repository secret
-# Name: MCP_REGISTRY_TOKEN
-# Value: <paste token>
+```yaml
+permissions:
+  contents: read
+  id-token: write
 ```
 
-**Note**: Tokens expire. If CI fails with 401, regenerate the token.
+`id-token: write` is scoped to this single job (least privilege). The `mcp-publisher login github-oidc` step exchanges the OIDC token for a registry JWT at runtime.
+
+**Pre-2026-04-28**: A static `MCP_REGISTRY_TOKEN` secret was used. mcp-publisher v1.6.0 (2026-04-15) moved token storage to `~/.config/mcp-publisher/` and broke env-var auth. SMI-4534 migrated to OIDC.
 
 ### GitHub Organization Membership
 
@@ -168,10 +162,11 @@ The `mcp-publisher` CLI uses GitHub namespace verification. To publish under `io
 - Ensure npm package has `mcpName` field in package.json
 - Publish to npm **before** publishing to registry
 
-### "Invalid or expired Registry JWT token"
+### CI registry publish failed (loud-fail issue auto-filed)
 
-- Re-run `mcp-publisher login github`
-- Update `MCP_REGISTRY_TOKEN` secret in GitHub
+- Check the `Annotate registry publish failure` step output in the failed run
+- Manual recovery from a maintainer machine: `mcp-publisher login github` + `cd packages/mcp-server && mcp-publisher publish`
+- If recurring, check whether the pinned `mcp-publisher` version (in `publish.yml`) needs a bump (SMI-4537)
 
 ### Token files
 

--- a/.env.schema
+++ b/.env.schema
@@ -88,16 +88,6 @@ VSCE_SKILLSMITH=
 # @type=string(startsWith=npm_) @sensitive @required=false
 SKILLSMITH_NPM_TOKEN=
 
-# =============================================================================
-# MCP REGISTRY (SMI-2158)
-# =============================================================================
-
-# MCP Registry Token - For publishing to MCP Registry (registry.modelcontextprotocol.io)
-# Get from: mcp-publisher login github, then cat ~/.mcpregistry_registry_token
-# Tokens expire periodically - regenerate if CI fails with 401
-# @type=string @required=false @sensitive
-MCP_REGISTRY_TOKEN=
-
 # Anthropic API Key - For Claude API calls
 # @type=string(startsWith=sk-ant-) @sensitive
 # ANTHROPIC_API_KEY=

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -538,6 +538,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [pre-publish-check, validate, publish-core]
+    # SMI-4534: id-token: write enables `mcp-publisher login github-oidc` for the MCP
+    # Registry publish step. Job-scoped (not workflow-scoped) for least privilege —
+    # sibling publish-* jobs do not need OIDC. contents: read overrides the workflow
+    # default of contents: write since this job does not push tags or releases.
+    permissions:
+      contents: read
+      id-token: write
     if: |
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.mcp-exists != 'true' &&
@@ -604,20 +611,78 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.SKILLSMITH_NPM_TOKEN }}
 
-      # SMI-2158: Publish to MCP Registry after npm publish
+      # SMI-2158: Publish to MCP Registry after npm publish.
+      # SMI-4534: pinned to a specific tag (not releases/latest) — mcp-publisher v1.6.0
+      # silently broke the env-var auth flow. Bump intentionally; SMI-4537 tracks drift
+      # detection. Auth via GitHub Actions OIDC (`mcp-publisher login github-oidc`);
+      # MCP_REGISTRY_TOKEN is no longer used.
       - name: Install mcp-publisher
+        id: install-mcp-publisher
         if: steps.version-check.outputs.exists != 'true'
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.3/mcp-publisher_linux_amd64.tar.gz" | tar xz
           chmod +x mcp-publisher
 
-      - name: Publish to MCP Registry
+      - name: Login to MCP Registry (github-oidc)
+        id: registry-login
         if: steps.version-check.outputs.exists != 'true'
+        # audit:allow-continue-on-error — SMI-4534: registry publish is non-load-bearing;
+        # npm publish is the binding artifact. Manual recovery: `mcp-publisher login
+        # github-oidc` + `mcp-publisher publish` from a maintainer machine. Loud-fail
+        # step below files a GitHub issue automatically.
+        continue-on-error: true
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        id: registry-publish
+        if: steps.version-check.outputs.exists != 'true' && steps.registry-login.outcome == 'success'
+        # audit:allow-continue-on-error — SMI-4534: see Login step above.
+        continue-on-error: true
         run: |
           cd packages/mcp-server
           ../../mcp-publisher publish
+
+      - name: Annotate registry publish failure
+        if: |
+          steps.version-check.outputs.exists != 'true' &&
+          (steps.registry-login.outcome == 'failure' || steps.registry-publish.outcome == 'failure' || steps.registry-publish.conclusion == 'skipped')
         env:
-          MCP_REGISTRY_TOKEN: ${{ secrets.MCP_REGISTRY_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_VERSION: ${{ steps.version-check.outputs.package_version }}
+          LOGIN_OUTCOME: ${{ steps.registry-login.outcome }}
+          PUBLISH_OUTCOME: ${{ steps.registry-publish.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## ⚠️ MCP Registry publish failed"
+            echo ""
+            echo "npm publish succeeded for \`@skillsmith/mcp-server@${PACKAGE_VERSION}\`; registry registration did not."
+            echo ""
+            echo "**Login outcome:** ${LOGIN_OUTCOME}"
+            echo "**Publish outcome:** ${PUBLISH_OUTCOME}"
+            echo ""
+            echo "Triage: re-run \`mcp-publisher login github-oidc\` + \`mcp-publisher publish\` from a maintainer machine, or see <https://registry.modelcontextprotocol.io/>."
+          } >> "$GITHUB_STEP_SUMMARY"
+          BODY_FILE=$(mktemp)
+          {
+            echo "Run: ${RUN_URL}"
+            echo ""
+            echo "Login outcome: ${LOGIN_OUTCOME}"
+            echo "Publish outcome: ${PUBLISH_OUTCOME}"
+            echo ""
+            echo "See SMI-4534 for context. Manual recovery:"
+            echo '```bash'
+            echo "mcp-publisher login github-oidc"
+            echo "cd packages/mcp-server && mcp-publisher publish"
+            echo '```'
+          } > "${BODY_FILE}"
+          gh issue create \
+            --title "MCP Registry publish failed for @skillsmith/mcp-server@${PACKAGE_VERSION}" \
+            --label "ci-failure" \
+            --body-file "${BODY_FILE}" \
+            || echo "::warning::gh issue create failed; check Actions log"
+          rm -f "${BODY_FILE}"
 
   # SMI-1319: Use pre-publish-check outputs to skip already-published packages
   publish-cli:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,6 +357,8 @@ Required for hive mind and agent spawning. Auto-configured via `.mcp.json`. Manu
 
 Published as `io.github.smith-horn/skillsmith` on [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/). Auto-published via CI. **Version sync required**: update both `packages/mcp-server/package.json` and `packages/mcp-server/server.json`. Full guide: [mcp-registry.md](.claude/development/mcp-registry.md).
 
+**Auth (SMI-4534)**: GitHub Actions OIDC (`mcp-publisher login github-oidc`); no manual `MCP_REGISTRY_TOKEN` rotation needed. If the registry publish step fails, see `.github/workflows/publish.yml` step "Login to MCP Registry" and the `v1.x.y` mcp-publisher pin in the install step — bump intentionally per SMI-4537. Registry-publish failures are isolated from npm publish (`continue-on-error: true`); a loud-fail step files a GitHub issue automatically.
+
 ---
 
 ## Publishing Packages


### PR DESCRIPTION
## Summary

- Switch MCP Registry publish to GitHub Actions OIDC (`mcp-publisher login github-oidc`); remove obsolete `MCP_REGISTRY_TOKEN`.
- Pin `mcp-publisher` to `v1.7.3` (no more `releases/latest`).
- Isolate registry failures from npm publish: `continue-on-error: true` + auto-file GitHub issue via loud-fail step.

## Why

`publish.yml` run [25078420419](https://github.com/smith-horn/skillsmith/actions/runs/25078420419) failed at the MCP Registry step with `token storage moved to ~/.config/mcp-publisher/`. Root cause: `mcp-publisher@v1.6.0` (2026-04-15, [PR #1166](https://github.com/modelcontextprotocol/registry/pull/1166)) moved token storage from env-var to file-based. The next CI run after that release silently broke because the workflow pinned to `releases/latest`.

`@skillsmith/core@0.5.7` and `@skillsmith/mcp-server@0.4.13` made it to npm but the parent job exited 1, poisoning `Publish Summary`.

## Plan + review

- Plan: `docs/internal/implementation/smi-4534-mcp-registry-auth-fix.md`
- Plan-review: 10 findings (0 Critical, 2 High, 4 Medium, 4 Low) — all applied.

## Test plan

- [ ] CI green (validates YAML, audit:standards, format:check)
- [ ] Post-merge: trigger next mcp-server release → confirm `Login to MCP Registry (github-oidc)` succeeds, registry shows new version
- [ ] Synthetic break test (separate PR per plan §Verification): remove `id-token: write`, confirm loud-fail step files an issue and npm publish still succeeds

## Decisions

| Question | Decision |
|---|---|
| Re-register 0.4.13 manually? | **No** — consumer surfaces verified empty (no `registry.modelcontextprotocol` refs in packages/website/cli/mcp-server; `skillsmith.app/skills` returns 0 hits). 0.4.14+ becomes next registered version. |
| OIDC scope | **Job-level** on `publish-mcp-server` only (least privilege) |
| `MCP_REGISTRY_TOKEN` secret | **Deleted** in this PR (never-defer rule) |

## Followup

- SMI-4537 (filed): audit `releases/latest` patterns across all `.github/workflows/*.yml` + add weekly mcp-publisher pin drift detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)