### PR TITLE
fix(infra): governance-retro followups for SMI-4525/4528/4534/4531/4533

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS — review requirements for sensitive paths
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Last in wins. Empty file = no required reviewers (default GitHub behavior).
+# Adding entries here ADDS review requirements; it does not remove existing
+# branch protection rules.
+
+# Release pipeline canonical messages (SMI-4531) — verbatim canonical strings
+# in scripts/lib/collision-rules.mjs are stable contracts. Changes require
+# release-eng sign-off so the messages can't drift between callers without
+# intentional sign-off. SMI-4541.
+scripts/lib/collision-rules.mjs        @wrsmith108
+scripts/lib/forbid-local-publish.mjs   @wrsmith108
+scripts/lib/reserved-ranges.mjs        @wrsmith108
+
+# Publish pipeline (SMI-4530, SMI-4534) — collision guard + OIDC auth
+scripts/check-publish-collision.mjs    @wrsmith108
+scripts/prepare-release.ts             @wrsmith108
+.github/workflows/publish.yml          @wrsmith108

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -627,13 +627,17 @@ jobs:
       - name: Install mcp-publisher
         id: install-mcp-publisher
         if: steps.version-check.outputs.exists != 'true'
+        # audit:allow-continue-on-error — SMI-4534: install failure (e.g. curl/network) must
+        # still reach the loud-fail Annotate step; job must not hard-fail here or the GitHub
+        # issue is never filed and the outage is silent.
+        continue-on-error: true
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.3/mcp-publisher_linux_amd64.tar.gz" | tar xz
           chmod +x mcp-publisher
 
       - name: Login to MCP Registry (github-oidc)
         id: registry-login
-        if: steps.version-check.outputs.exists != 'true'
+        if: steps.version-check.outputs.exists != 'true' && steps.install-mcp-publisher.outcome == 'success'
         # audit:allow-continue-on-error — SMI-4534: registry publish is non-load-bearing;
         # npm publish is the binding artifact. Manual recovery: `mcp-publisher login
         # github-oidc` + `mcp-publisher publish` from a maintainer machine. Loud-fail
@@ -653,7 +657,7 @@ jobs:
       - name: Annotate registry publish failure
         if: |
           steps.version-check.outputs.exists != 'true' &&
-          (steps.registry-login.outcome == 'failure' || steps.registry-publish.outcome == 'failure' || steps.registry-publish.conclusion == 'skipped')
+          (steps.install-mcp-publisher.outcome == 'failure' || steps.registry-login.outcome == 'failure' || steps.registry-publish.outcome == 'failure' || steps.registry-publish.conclusion == 'skipped')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGE_VERSION: ${{ steps.version-check.outputs.package_version }}

--- a/scripts/deploy-edge-functions.sh
+++ b/scripts/deploy-edge-functions.sh
@@ -151,8 +151,8 @@ if [[ -n "$FILTER_FUNCTIONS" ]]; then
   TOTAL=$((${#NO_VERIFY_JWT_FUNCTIONS[@]} + ${#VERIFY_JWT_FUNCTIONS[@]}))
   echo "Deploying $TOTAL edge function(s) to project: $PROJECT_REF"
 else
-  TOTAL=30
-  echo "Deploying all 30 edge functions to project: $PROJECT_REF"
+  TOTAL=31
+  echo "Deploying all 31 edge functions to project: $PROJECT_REF"
 fi
 
 echo "=================================================="

--- a/scripts/lib/forbid-local-publish.mjs
+++ b/scripts/lib/forbid-local-publish.mjs
@@ -37,7 +37,7 @@ export function assertCiPublishContext(env = process.env) {
     if (!OVERRIDE_FORMAT.test(override)) {
       console.error(
         'SMI-4533: SKILLSMITH_PUBLISH_OVERRIDE format invalid.\n' +
-          '  Required: SMI-NNNN <rationale, ≥20 chars total>\n' +
+          '  Required: SMI-NNNN <rationale, ≥20 chars after the SMI-NNNN prefix>\n' +
           '  Example: SMI-4499 emergency hotfix for prod incident; CI down 30+ min'
       )
       process.exit(1)

--- a/scripts/tests/forbid-local-publish.test.ts
+++ b/scripts/tests/forbid-local-publish.test.ts
@@ -81,7 +81,7 @@ describe('assertCiPublishContext (SMI-4533)', () => {
 
   // --- Override path ---
 
-  it('accepts a valid override (SMI-NNNN + ≥20 chars total) and appends to the audit log', () => {
+  it('accepts a valid override (SMI-NNNN + ≥20 chars after prefix) and appends to the audit log', () => {
     expect(() =>
       assertCiPublishContext({
         SKILLSMITH_PUBLISH_OVERRIDE: 'SMI-4499 emergency hotfix for prod incident',
@@ -122,7 +122,7 @@ describe('assertCiPublishContext (SMI-4533)', () => {
     expect(mockedAppend).not.toHaveBeenCalled()
   })
 
-  it('refuses an override that is too short (under 20 chars total)', () => {
+  it('refuses an override that is too short (rationale under 20 chars after the SMI prefix)', () => {
     expect(() =>
       assertCiPublishContext({
         SKILLSMITH_PUBLISH_OVERRIDE: 'SMI-1 short',

--- a/tests/e2e/fixtures/usage-counter-fixture.ts
+++ b/tests/e2e/fixtures/usage-counter-fixture.ts
@@ -274,7 +274,7 @@ export async function provisionTestUser(options: ProvisionOptions = {}): Promise
   // bcrypt's input cap is 72 bytes — Supabase Auth rejects longer passwords.
   // The previous `${randomUUID()}-${randomUUID()}` was 73 chars and made
   // /auth/v1/admin/users return a generic 500 unexpected_failure (SMI-4525).
-  // 32 hex × 2 = 64 chars, 256 bits of entropy, well under the limit.
+  // 32 hex × 2 = 64 chars, 244 bits of entropy (2 × 122-bit UUID v4), well under the limit.
   const password = `${randomUUID().replace(/-/g, '')}${randomUUID().replace(/-/g, '')}`
 
   // 1. Create auth user with confirmed email (skip verification).


### PR DESCRIPTION
## Summary

Bundle of 4 post-merge governance-retro findings — all required by CLAUDE.md ("After EVERY PR is merged, run /governance as a retrospective on the full PR diff. Resolve ALL issues it surfaces immediately"):

| Commit | Source PR | Finding |
|---|---|---|
| `507e1846` | #823 (SMI-4528) | `deploy-edge-functions.sh` had `TOTAL=30` hardcoded; bumped to 31 to match actual function count |
| `671aca23` | #820 (SMI-4525) | Fixture password comment overstated the entropy claim; corrected |
| `ba4829f8` | #826 (SMI-4534) | `Install mcp-publisher` step lacked `continue-on-error: true` — a curl/network failure would hard-fail the job before the loud-fail `Annotate` step could run, silently dropping the GitHub issue. Added guard + updated `if:` chain so install failures are caught by `Annotate` |
| `4903c7d4` | #828 (SMI-4531/4533) | (a) Created `.github/CODEOWNERS` pinning `collision-rules.mjs` / `forbid-local-publish.mjs` / `prepare-release.ts` / `publish.yml` (SMI-4531 plan promised this; no CODEOWNERS file existed). (b) Corrected misleading override error message — said "≥20 chars total" but regex required ≥26 |

## Why bundled

Four independent retro-followup fixes; bundling avoids 4 separate PR rounds for trivial corrections. Each commit message stands alone.

## Test plan

- [ ] CI green
- [ ] `audit:standards` continues to pass (caught the SMI-4534 install-step gap during the retro itself)
- [ ] CODEOWNERS syntax validates

## Linear

- SMI-4541 filed under Release Hardening — tracks CODEOWNERS + override-error fixes
- SMI-4525, SMI-4528, SMI-4534 retros: inline commit refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
