### PR TITLE
fix(infra): SMI-4531+4533 unify collision rules + forbid local-fallback npm publish

### DIFF
--- a/.claude/development/publishing-guide.md
+++ b/.claude/development/publishing-guide.md
@@ -58,7 +58,7 @@ npm publish -w packages/<pkg> --access public
 
 Every accepted override appends a tab-separated row to `~/.skillsmith-publish-overrides.log`:
 
-```
+```text
 2026-04-29T16:42:00.000Z<TAB>SMI-4499 emergency hotfix for prod incident; CI down 30+ min<TAB>local
 ```
 

--- a/.claude/development/publishing-guide.md
+++ b/.claude/development/publishing-guide.md
@@ -14,7 +14,7 @@ docker exec skillsmith-dev-1 npx tsx scripts/prepare-release.ts --dry-run --all=
 
 The script updates all 6 version locations (package.json, VERSION constants, server.json), generates changelog entries, and creates a commit. See `docs/internal/implementation/release-automation.md` for details.
 
-## CI Workflow (Preferred)
+## CI Workflow (the only supported publish path)
 
 ```bash
 git push
@@ -22,49 +22,56 @@ gh workflow run publish.yml -f dry_run=false
 gh run watch <run-id> --exit-status              # Monitor progress
 ```
 
-Uses `SKILLSMITH_NPM_TOKEN` secret. Publishes in dependency order (core → mcp-server, cli, enterprise) with validation, smoke tests, and MCP Registry publish. Always try this first.
+Uses `SKILLSMITH_NPM_TOKEN` secret today; SMI-4539 will flip to npm trusted-publisher OIDC (the `id-token: write` permission is already in place per SMI-4533). Publishes in dependency order (core → mcp-server, cli, enterprise) with validation, smoke tests, and MCP Registry publish.
 
-**Known limitation**: The Validate job builds ALL packages. If an unrelated package (e.g., enterprise) has a build failure, the entire workflow fails. Use the local fallback to publish just the package you need.
+If CI fails, fix CI. Do not reach for a local publish — see [`publish-ci-recovery.md`](../../docs/internal/runbooks/publish-ci-recovery.md) for triage.
 
-## Local Fallback
+## Local Publish — Forbidden (SMI-4533)
 
-When CI fails due to unrelated build issues, publish manually using the `SKILLSMITH_NPM_TOKEN` from `.env`.
+The previous "local fallback" recipe (`source .env && npm publish`) is **gone**. Every publishable package's `prepublishOnly` chains `node ../../scripts/lib/forbid-local-publish.mjs` before build/test, and the script refuses unless invoked from a canonical-repo GitHub Actions runner.
 
-### Token Setup (One-Time)
+Why: every "we couldn't get CI to publish so we did it locally" commit in the changelog mapped to a regression that CI's guards would have caught. Closing this loophole forces the only path that carries our published-version history.
 
-1. Create a **Granular Access Token** at npmjs.com → Access Tokens
-2. Scope: `@skillsmith` organization, read and write
-3. **Enable "Bypass two-factor authentication"** — npm passkey auth does not support OTP via CLI
-4. Save as `SKILLSMITH_NPM_TOKEN` in `.env` (secured via Varlock, annotated in `.env.schema`)
+`npm publish --ignore-scripts` skips `prepublishOnly`. The binding gate is npm trusted-publisher OIDC (SMI-4539 flips it on; SMI-4540 retires the token). Until then, the host-side guard plus token-scoped 2FA and CI-only secret access are the layers in place.
 
-### Publish Command
+## Break-Glass
 
-**Must run from the repo root** — npm ignores `.npmrc` in workspace package directories.
+For genuine emergencies (registry-level outage, multi-hour CI breakage during an active prod incident), the `prepublishOnly` guard accepts an override:
 
 ```bash
-# 1. Inject token into ~/.npmrc (zsh: use printf, not echo — // is interpreted as a path)
-source .env
-printf '%s\n' "//registry.npmjs.org/:_authToken=$SKILLSMITH_NPM_TOKEN" >> ~/.npmrc
+export SKILLSMITH_PUBLISH_OVERRIDE="SMI-NNNN <rationale, ≥20 chars total>"
+# Example:
+export SKILLSMITH_PUBLISH_OVERRIDE="SMI-4499 emergency hotfix for prod incident; CI down 30+ min"
 
-# 2. Publish specific package
-npm publish --ignore-scripts -w packages/<pkg>
-
-# 3. Clean up token immediately
-sed -i '' '/registry.npmjs.org/d' ~/.npmrc
+npm publish -w packages/<pkg> --access public
 ```
 
-### Gotchas
+### Format requirements
 
-| Issue | Cause | Fix |
-|-------|-------|-----|
-| `EOTP` (OTP required) | Token doesn't have bypass 2FA, or npm is using cached login session | `npm logout` first, verify token has bypass enabled on npmjs.com |
-| `ENEEDAUTH` | `.npmrc` in wrong location | Must be `~/.npmrc`, not `packages/<pkg>/.npmrc` (workspaces ignore package-level `.npmrc`) |
-| `zsh: no such file or directory: //registry...` | zsh interprets `//` as path | Use `printf '%s\n' "//..."` instead of `echo "//..."` |
-| `E404 Not Found` on PUT | Not authenticated to `@skillsmith` scope | Check `npm whoami` and token scope |
+- MUST start with `SMI-` followed by digits (the Linear issue tracking the override).
+- MUST include a free-form rationale separated from the issue ref by whitespace.
+- Total length MUST be ≥ 20 characters. Shorter values are refused with `format invalid`.
 
-### Script Fallback
+`OVERRIDE=1` does not work and never will. The format is intentionally awkward to write — every override should be deliberate.
 
-`./scripts/publish-packages.sh` — publishes in dependency order with pre-publish tarball verification. Requires the same token setup above.
+### Audit trail
+
+Every accepted override appends a tab-separated row to `~/.skillsmith-publish-overrides.log`:
+
+```
+2026-04-29T16:42:00.000Z<TAB>SMI-4499 emergency hotfix for prod incident; CI down 30+ min<TAB>local
+```
+
+SMI-4538 tracks the eventual write-through to Supabase `audit_logs` (one place to review, alert on, and grep).
+
+### Process
+
+1. **File the SMI issue first.** Document why CI is unusable, what the operator tried, and the expected impact of publishing without the CI guard chain. Tag with `incident` and the affected package.
+2. **Run the publish with the override set.** The audit log line lands in `~/.skillsmith-publish-overrides.log` automatically.
+3. **Open a Linear retro within 24h.** Title: `Retro: SMI-NNNN local-publish override`. Owner: the operator who ran the publish. Sections: what failed, what was published, what guard the operator skipped, what the post-publish smoke confirmed, and the action item to make this not happen again.
+4. **Update CI.** The retro's first concrete output is a CI fix or a runbook update — never just an incident note.
+
+If the override gets used twice in the same calendar quarter without a permanent CI fix landing in between, escalate; the recovery runbook is no longer load-bearing.
 
 ## Publish Order
 
@@ -72,29 +79,11 @@ Dependencies before consumers:
 
 1. `@skillsmith/core`
 2. `@skillsmith/mcp-server` and `@skillsmith/cli` (both depend on core)
-
-## Pre-Publish Checklist (Manual Publishes Only)
-
-Only needed if the CI workflow fails:
-
-1. Build in Docker: `docker exec skillsmith-dev-1 npm run build`
-2. Run preflight: `docker exec skillsmith-dev-1 npm run preflight`
-3. Verify dependency versions are committed and pushed
-4. Check dependency is published:
-
-   ```bash
-   VERSION=$(node -e "console.log(require('./packages/core/package.json').version)")
-   npm view @skillsmith/core@$VERSION version   # must return the version
-   ```
-
-5. If dependency not published: publish it first with `./scripts/publish-packages.sh core`
-6. Run `npm pack --dry-run` in the package dir to inspect tarball contents
-7. Publish using the command above (Local Fallback section)
-8. Post-publish: `npx tsx scripts/smoke-test-published.ts @skillsmith/<pkg> <version>`
+3. `@smith-horn/enterprise` (private, GitHub Packages)
 
 ## Critical Rules
 
-**Never** publish a consumer before its dependency. **Never** publish with an exact-pinned workspace dep (use `^` prefix). Workspace resolution masks version-pin errors locally — only fresh `npm install` from the registry reveals mismatches. See [retro: mcp-server@0.4.5](../docs/internal/retros/2026-03-19-mcp-server-0.4.5-hotfix.md).
+**Never** publish a consumer before its dependency. **Never** publish with an exact-pinned workspace dep (use `^` prefix). Workspace resolution masks version-pin errors locally — only fresh `npm install` from the registry reveals mismatches. See [retro: mcp-server@0.4.5](../../docs/internal/retros/2026-03-19-mcp-server-0.4.5-hotfix.md).
 
 **Verify dependency floors when adding cross-package imports.** If `mcp-server` starts importing a new export from `core`, bump the dep floor in `mcp-server/package.json` to the core version that introduced that export. The workspace resolves the latest local version, masking floor mismatches — only fresh `npm install` from the registry catches this. See [SMI-3668](https://linear.app/smith-horn-group/issue/SMI-3668).
 

--- a/.env.schema
+++ b/.env.schema
@@ -82,6 +82,8 @@ GITHUB_CLIENT_SECRET=
 VSCE_SKILLSMITH=
 
 # NPM Publish Token - Fine-grained token for @skillsmith packages
+# CI-only secret. Local-publish is forbidden (SMI-4533). Token is deprecated;
+# SMI-4540 tracks deletion after OIDC stabilizes (SMI-4539).
 # Created: March 27, 2026 | Expires: June 25, 2026 (90 days)
 # Get from: npmjs.com → Access Tokens → Generate New Token → Granular Access Token
 # Scope: @skillsmith organization (read and write)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -464,6 +464,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [pre-publish-check, validate]
+    # SMI-4533: id-token: write enables npm trusted-publisher OIDC. Token-based
+    # publish remains the active path (via SKILLSMITH_NPM_TOKEN); SMI-4539 will
+    # flip this to OIDC-exclusive after the token path stabilizes for one
+    # release cycle. SMI-4540 retires the token entirely. Keeping this
+    # job-scoped (not workflow-scoped) for least privilege.
+    permissions:
+      contents: read
+      id-token: write
     if: |
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.core-exists != 'true'
@@ -690,6 +698,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [pre-publish-check, validate, publish-core]
+    # SMI-4533: id-token: write enables npm trusted-publisher OIDC. SMI-4539
+    # will flip this to OIDC-exclusive; token path remains active until then.
+    permissions:
+      contents: read
+      id-token: write
     if: |
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.cli-exists != 'true' &&
@@ -763,6 +776,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [pre-publish-check, validate, publish-core]
+    # SMI-4533: id-token: write enables npm trusted-publisher OIDC. SMI-4539
+    # will flip this to OIDC-exclusive; token path remains active until then.
+    # (Enterprise publishes to GitHub Packages, not npmjs.com; OIDC support
+    # there mirrors npm's trusted-publisher pattern via GITHUB_TOKEN.)
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     if: |
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.enterprise-exists != 'true' &&

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,36 +385,23 @@ gh run watch <run-id> --exit-status              # Monitor progress
 
 Uses `SKILLSMITH_NPM_TOKEN` secret. Publishes in dependency order (core → mcp-server, cli, enterprise) with validation, smoke tests, and MCP Registry publish. Always try this first.
 
-**Local fallback** (when CI fails due to unrelated build issues): Uses `SKILLSMITH_NPM_TOKEN` from `.env` (granular access token with bypass 2FA). See [publishing-guide.md](.claude/development/publishing-guide.md) for full checklist and the working publish command.
+**Local fallback**: **Deprecated (SMI-4533)**: local fallback is forbidden. CI is the only publish path. If CI fails, fix CI; for genuine emergencies see [`docs/internal/runbooks/publish-ci-recovery.md`](docs/internal/runbooks/publish-ci-recovery.md) and the `SKILLSMITH_PUBLISH_OVERRIDE` break-glass in [.claude/development/publishing-guide.md](.claude/development/publishing-guide.md#break-glass).
 
 **Publish order** (dependencies before consumers):
 
 1. `@skillsmith/core`
 2. `@skillsmith/mcp-server` and `@skillsmith/cli` (both depend on core)
 
-**Pre-publish checklist** (manual publishes — only if CI workflow fails):
+**Pre-publish checklist** (CI publish — the only supported path):
 
 1. Build in Docker: `docker exec skillsmith-dev-1 npm run build`
 2. Run preflight: `docker exec skillsmith-dev-1 npm run preflight`
 3. Verify dependency versions are committed and pushed
-4. Check dependency is published:
+4. Trigger CI: `gh workflow run publish.yml -f dry_run=false`
+5. Watch the run: `gh run watch <run-id> --exit-status`
+6. Post-publish (CI smoke-tests automatically; manual fallback): `npx tsx scripts/smoke-test-published.ts @skillsmith/<pkg> <version>`
 
-   ```bash
-   VERSION=$(node -e "console.log(require('./packages/core/package.json').version)")
-   npm view @skillsmith/core@$VERSION version   # must return the version
-   ```
-
-5. If dependency not published: publish it first with `./scripts/publish-packages.sh core`
-6. Run `npm pack --dry-run` in the package dir to inspect tarball contents
-7. Publish (from repo root — workspace `.npmrc` is ignored by npm):
-
-   ```bash
-   source .env && printf '%s\n' "//registry.npmjs.org/:_authToken=$SKILLSMITH_NPM_TOKEN" >> ~/.npmrc
-   npm publish --ignore-scripts -w packages/<pkg>
-   sed -i '' '/registry.npmjs.org/d' ~/.npmrc
-   ```
-
-8. Post-publish: `npx tsx scripts/smoke-test-published.ts @skillsmith/<pkg> <version>`
+If CI fails, do NOT reach for a local publish. Fix the underlying issue. Genuine break-glass: see [publishing-guide.md § Break-Glass](.claude/development/publishing-guide.md#break-glass) (requires `SKILLSMITH_PUBLISH_OVERRIDE=SMI-NNNN <rationale>` and a Linear retro within 24h).
 
 **Never** publish a consumer before its dependency. **Never** publish with an exact-pinned workspace dep (use `^` prefix). Workspace resolution masks version-pin errors locally — only fresh `npm install` from the registry reveals mismatches. See [retro: mcp-server@0.4.5](docs/internal/retros/2026-03-19-mcp-server-0.4.5-hotfix.md).
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "sklx": "dist/src/index.js"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
+    "prepublishOnly": "node ../../scripts/lib/forbid-local-publish.mjs && npm run build && npm run test",
     "build": "tsc",
     "dev": "tsc --watch",
     "import": "node dist/import.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     }
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
+    "prepublishOnly": "node ../../scripts/lib/forbid-local-publish.mjs && npm run build && npm run test",
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -28,7 +28,7 @@
     }
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
+    "prepublishOnly": "node ../../scripts/lib/forbid-local-publish.mjs && npm run build && npm run test",
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -10,7 +10,7 @@
     "skillsmith-mcp": "./dist/src/index.js"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test && chmod +x dist/src/index.js",
+    "prepublishOnly": "node ../../scripts/lib/forbid-local-publish.mjs && npm run build && npm run test && chmod +x dist/src/index.js",
     "build": "tsc",
     "postbuild": "chmod +x dist/src/index.js || true",
     "dev": "tsx watch src/index.ts",

--- a/scripts/check-publish-collision.mjs
+++ b/scripts/check-publish-collision.mjs
@@ -2,18 +2,14 @@
 /**
  * SMI-4188: Pre-publish npm collision mirror guard.
  *
- * Mirrors scripts/prepare-release.ts checkVersionCollision logic as a
- * single-package ESM shim callable directly from GitHub Actions without
- * a tsx runtime. Shares fixtures with prepare-release tests under
+ * Single-package ESM shim callable directly from GitHub Actions without a tsx
+ * runtime. Shares fixtures with prepare-release tests under
  * scripts/tests/fixtures/npm-view/.
  *
- * MUST stay in sync with scripts/prepare-release.ts collision logic.
- * RESERVED_RANGES is now shared via scripts/lib/reserved-ranges.mjs (SMI-4530)
- * so the reserved-range carve-out can never drift between the two guards
- * again — this was the root cause of PR #824's stuck publish. The rest of
- * Rules 1/2/3 (live-pool max, exact-equal-published refusal, error message
- * format) is still duplicated by design (the shim avoids pulling tsx into
- * GitHub Actions). See SMI-4531 for the full unification follow-up.
+ * SMI-4531: Rules 1/2/3 are now consumed from `scripts/lib/collision-rules.mjs`
+ * — the single source of truth shared with `scripts/prepare-release.ts`. Drift
+ * between the two collision implementations was the root cause of PR #824's
+ * stuck publish (SMI-4530 surfaced the partial fix; SMI-4531 closed it).
  *
  * Usage: node scripts/check-publish-collision.mjs <pkg> <targetVersion>
  *
@@ -31,10 +27,11 @@
 import { execFileSync } from 'node:child_process'
 import semver from 'semver'
 
-import { filterReservedVersions, isReserved } from './lib/reserved-ranges.mjs'
+import { evaluateCollisionRules } from './lib/collision-rules.mjs'
 
 /**
  * Evaluate a proposed publish against the registry response.
+ *
  * @param {string} pkg - package name
  * @param {string} targetVersion - proposed version
  * @param {{exec?: typeof execFileSync}} [deps] - for tests
@@ -81,63 +78,18 @@ export function evaluateCollision(pkg, targetVersion, deps = {}) {
     return { code: 1, message: `${pkg}: npm view returned no valid semver entries` }
   }
 
-  // SMI-4530 / ADR-115: refuse proposed versions that fall inside a reserved
-  // range BEFORE computing max — otherwise the diagnostic ("<= highest
-  // published") would be both wrong and misleading. Mirrors prepare-release.ts
-  // checkReservedVersionRanges. No override flag applies.
-  if (semver.valid(targetVersion) && isReserved(pkg, targetVersion, semver)) {
-    return {
-      code: 1,
-      message:
-        `${pkg}: proposed ${targetVersion} falls inside the reserved 2.x range ` +
-        `(>=2.0.0 <3.0.0). This range is permanently deprecated on npm — the next ` +
-        `major must jump to 3.0.0 or later. No override flag applies. ` +
-        `See ADR-115 (docs/internal/adr/115-skillsmith-core-version-namespace-reconciliation.md).`,
-    }
-  }
-
-  // Exact-equal-published check uses the FULL cleaned list, NOT the filtered
-  // live list. The reservation is a "you can't reuse this number" rule — even
-  // versions inside a reserved range are forbidden from republish.
-  if (cleaned.includes(targetVersion)) {
-    // Compute a max for the diagnostic — prefer the live max (post-filter) so
-    // the message is informative; fall back to the unfiltered max if every
-    // published version is reserved.
-    const liveForMessage = filterReservedVersions(pkg, cleaned, semver)
-    const maxForMessage = (liveForMessage.length ? liveForMessage : cleaned).reduce((a, b) =>
-      semver.gt(a, b) ? a : b
-    )
-    return {
-      code: 1,
-      message: `${pkg}: proposed ${targetVersion} is already published on npm (highest published: ${maxForMessage})`,
-    }
-  }
-
+  // Surface invalid-semver targets BEFORE the rule pipeline. Rule 1 already
+  // tolerates invalid semver (it can't classify), so we need the explicit
+  // check here to keep the historical error message stable.
   if (!semver.valid(targetVersion)) {
     return { code: 1, message: `${pkg}: proposed version ${targetVersion} is not a valid semver` }
   }
 
-  // SMI-4530 / ADR-115: filter reserved-range versions out of the "live" pool
-  // used to compute `max`. Orphaned 2.x entries on @skillsmith/core must not
-  // block normal patches on the live 0.5.x line.
-  const live = filterReservedVersions(pkg, cleaned, semver)
-  if (!live.length) {
-    return {
-      code: 0,
-      message: `${pkg}: no live versions published yet (all entries inside reserved range), proceeding`,
-    }
-  }
-
-  const max = live.reduce((a, b) => (semver.gt(a, b) ? a : b))
-
-  if (semver.lte(targetVersion, max)) {
-    return { code: 1, message: `${pkg}: proposed ${targetVersion} <= highest published ${max}` }
-  }
-
-  return {
-    code: 0,
-    message: `${pkg}: proposed ${targetVersion} > highest published ${max}, safe to publish`,
-  }
+  // SMI-4531: delegate to the shared rule pipeline. allowDowngrade is fixed
+  // to false here — the publish.yml guard is intentionally strict; only the
+  // .ts caller (prepare-release) wires the user's --allow-downgrade flag.
+  const result = evaluateCollisionRules(pkg, targetVersion, cleaned, { allowDowngrade: false })
+  return result.ok ? { code: 0, message: result.message } : { code: 1, message: result.message }
 }
 
 // CLI entrypoint. Only runs when invoked directly, not when imported in tests.

--- a/scripts/lib/collision-rules.mjs
+++ b/scripts/lib/collision-rules.mjs
@@ -1,0 +1,178 @@
+// SMI-4531: Single source of truth for the three collision rules shared by
+// scripts/check-publish-collision.mjs (publish.yml guard, sync, single-package)
+// and scripts/prepare-release.ts (release-prep, async, multi-plan). Each rule
+// is a pure function — callers fetch versions and decide what to do with the
+// result (the .mjs guard maps to {code, message}; the .ts caller accumulates
+// {ok, errors[], report[]}).
+//
+// `.mjs` (not `.ts`) so the GitHub Actions guard does not need a tsx runtime;
+// .ts callers import via standard ESM interop.
+//
+// CANONICAL ERROR MESSAGES — STABLE CONTRACT.
+// The three messages below are the public contract for both callers and for
+// the snapshot tests in scripts/tests/collision-rules.test.ts. Any change
+// requires an SMI ref + retro entry. CODEOWNERS pins this file to release-eng
+// so a future author can't drift the strings without sign-off.
+//
+//   Rule 1 (reserved-range, no override):
+//     "${pkg}: proposed ${target} falls inside the reserved 2.x range
+//     (>=2.0.0 <3.0.0). This range is permanently deprecated on npm — the
+//     next major must jump to 3.0.0 or later. No override flag applies. See
+//     ADR-115 (docs/internal/adr/115-skillsmith-core-version-namespace-reconciliation.md)."
+//
+//   Rule 3 (already-published, no override):
+//     "${pkg}: proposed ${target} is already published on npm (highest
+//     published: ${maxForDiagnostic | "(none — all reserved)"}). Different
+//     content under the same version is the failure mode this guard exists
+//     to prevent. Revert to release, do not override."
+//
+//   Rule 2 (live-max <=, overridable in TS via --allow-downgrade):
+//     "${pkg}: proposed ${target} <= highest published ${liveMax}. Note:
+//     "highest published" spans all dist-tags — npm refuses to republish any
+//     existing semver. Suggested next-available: ${suggested}. To override
+//     (TS only): pass --allow-downgrade."
+
+import semver from 'semver'
+
+import { filterReservedVersions, isReserved } from './reserved-ranges.mjs'
+
+/**
+ * Rule 1 — reserved-range refuse (no override).
+ *
+ * @param {string} pkg - package name
+ * @param {string} target - proposed version (must be valid semver)
+ * @returns {{ok: true} | {ok: false, message: string}}
+ */
+export function evaluateReservedRange(pkg, target) {
+  if (!semver.valid(target)) return { ok: true }
+  if (!isReserved(pkg, target, semver)) return { ok: true }
+  return {
+    ok: false,
+    message:
+      `${pkg}: proposed ${target} falls inside the reserved 2.x range (>=2.0.0 <3.0.0). ` +
+      `This range is permanently deprecated on npm — the next major must jump to 3.0.0 or later. ` +
+      `No override flag applies. See ADR-115 (docs/internal/adr/115-skillsmith-core-version-namespace-reconciliation.md).`,
+  }
+}
+
+/**
+ * Rule 3 — exact-equal-published refuse (no override).
+ *
+ * `maxForDiagnostic` is computed from the live (filtered) pool when non-empty,
+ * else from the full pool — matches both prior implementations. When every
+ * entry sits in the reserved range AND the proposed version is not in the
+ * full list, callers should treat this rule as a pass; the caller dispatches
+ * to Rule 2 (which itself short-circuits to "no live versions, proceed" via
+ * its own caller; not this module's concern).
+ *
+ * Special case: when the proposed version IS in the full list AND every
+ * published entry sits in the reserved range, the diagnostic is "(none — all
+ * reserved)" — there is no meaningful live max to display.
+ *
+ * @param {string} pkg
+ * @param {string} target
+ * @param {string[]} allVersions - raw npm view output, post valid-filter
+ * @returns {{ok: true} | {ok: false, message: string, maxForDiagnostic: string | null}}
+ */
+export function evaluateAlreadyPublished(pkg, target, allVersions) {
+  if (!allVersions.includes(target)) return { ok: true }
+  const live = filterReservedVersions(pkg, allVersions, semver)
+  let maxForDiagnostic = null
+  if (live.length > 0) {
+    maxForDiagnostic = live.reduce((a, b) => (semver.gt(a, b) ? a : b))
+  } else if (allVersions.length > 0) {
+    // Fall back to the unfiltered max only when we have something to show.
+    maxForDiagnostic = allVersions.reduce((a, b) => (semver.gt(a, b) ? a : b))
+  }
+  // If every entry is reserved AND the proposed equals one of them, render
+  // the canonical "(none — all reserved)" diagnostic instead of the reserved
+  // version itself — the message is about the live line, not the orphan.
+  const display =
+    live.length === 0 && allVersions.length > 0 ? '(none — all reserved)' : maxForDiagnostic
+  return {
+    ok: false,
+    message:
+      `${pkg}: proposed ${target} is already published on npm (highest published: ${display}). ` +
+      `Different content under the same version is the failure mode this guard exists to prevent. ` +
+      `Revert to release, do not override.`,
+    maxForDiagnostic,
+  }
+}
+
+/**
+ * Rule 2 — proposed <= live max refuse (overridable in TS via allowDowngrade).
+ *
+ * Caller decides whether to honor `allowDowngrade` — pass `true` to make this
+ * always return `{ok: true}` when the underlying check would otherwise refuse.
+ * The publish.yml guard passes `false` (no override); prepare-release passes
+ * the user's flag.
+ *
+ * `live` MUST be the post-`filterReservedVersions` pool. If `live` is empty,
+ * this rule passes (caller has no live anchor — typically wraps with its own
+ * "no live versions, proceeding" message before calling).
+ *
+ * @param {string} pkg
+ * @param {string} target
+ * @param {string[]} live - post-filterReservedVersions pool
+ * @param {{allowDowngrade?: boolean}} [opts]
+ * @returns {{ok: true} | {ok: false, message: string, suggestedNext: string}}
+ */
+export function evaluateLiveMax(pkg, target, live, opts = {}) {
+  if (!semver.valid(target)) return { ok: true }
+  if (!live.length) return { ok: true }
+  const max = live.reduce((a, b) => (semver.gt(a, b) ? a : b))
+  if (semver.gt(target, max)) return { ok: true }
+  if (opts.allowDowngrade) return { ok: true }
+  const suggestedNext = semver.inc(max, 'patch') ?? max
+  return {
+    ok: false,
+    message:
+      `${pkg}: proposed ${target} <= highest published ${max}. ` +
+      `Note: "highest published" spans all dist-tags — npm refuses to republish any existing semver. ` +
+      `Suggested next-available: ${suggestedNext}. ` +
+      `To override (TS only): pass --allow-downgrade.`,
+    suggestedNext,
+  }
+}
+
+/**
+ * Convenience: evaluate Rules 1 → 3 → 2 in canonical order for a single
+ * package and return the first failure. On full pass returns
+ * `{ok: true, message}` with a benign proceed message. Callers that want
+ * per-rule branching (e.g. to emit different reports for Rule 1 vs Rule 2)
+ * should call the individual evaluators.
+ *
+ * Multi-package contract is the CALLER's responsibility — never short-circuit
+ * across packages. Within a single package, the first failing rule wins.
+ *
+ * @param {string} pkg
+ * @param {string} target
+ * @param {string[]} allVersions - raw post-valid-filter list
+ * @param {{allowDowngrade?: boolean}} [opts]
+ * @returns {{ok: true, message: string} | {ok: false, message: string, rule: 1 | 2 | 3, suggestedNext?: string, maxForDiagnostic?: string | null}}
+ */
+export function evaluateCollisionRules(pkg, target, allVersions, opts = {}) {
+  const r1 = evaluateReservedRange(pkg, target)
+  if (!r1.ok) return { ok: false, message: r1.message, rule: 1 }
+
+  const r3 = evaluateAlreadyPublished(pkg, target, allVersions)
+  if (!r3.ok)
+    return { ok: false, message: r3.message, rule: 3, maxForDiagnostic: r3.maxForDiagnostic }
+
+  const live = filterReservedVersions(pkg, allVersions, semver)
+  const r2 = evaluateLiveMax(pkg, target, live, opts)
+  if (!r2.ok) return { ok: false, message: r2.message, rule: 2, suggestedNext: r2.suggestedNext }
+
+  // All three rules pass. Compose a benign proceed message.
+  if (!live.length) {
+    return {
+      ok: true,
+      message: `${pkg}: no live versions published yet (all entries inside reserved range), proceeding`,
+    }
+  }
+  const max = live.reduce((a, b) => (semver.gt(a, b) ? a : b))
+  return {
+    ok: true,
+    message: `${pkg}: proposed ${target} > highest published ${max}, safe to publish`,
+  }
+}

--- a/scripts/lib/forbid-local-publish.mjs
+++ b/scripts/lib/forbid-local-publish.mjs
@@ -1,0 +1,79 @@
+// SMI-4533: Forbid local-fallback npm publish.
+//
+// Wired as `prepublishOnly` in every publishable package's package.json. Refuses
+// unless invoked from a canonical-repo GitHub Actions runner. Override path:
+// `SKILLSMITH_PUBLISH_OVERRIDE=SMI-NNNN <rationale, ≥20 chars>` for genuine
+// break-glass use; the override appends an audit row to
+// `~/.skillsmith-publish-overrides.log` (SMI-4538 tracks the eventual Supabase
+// audit-log write).
+//
+// Caveat: `npm publish --ignore-scripts` skips this hook. The binding registry
+// gate is npm trusted-publisher OIDC (SMI-4539 flips that on after the token
+// path stabilizes; SMI-4540 retires the token entirely).
+//
+// Recovery runbook: docs/internal/runbooks/publish-ci-recovery.md.
+
+import { appendFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// SMI-4533: SMI-NNNN + space + 18+ chars (total ≥ 20 chars after the SMI ref).
+// Prevents `OVERRIDE=1` from becoming idiomatic; forces the operator to write
+// down WHY a local publish is happening, in the same line that's logged.
+const OVERRIDE_FORMAT = /^SMI-\d+\s+\S.{18,}$/
+
+const CANONICAL_REPO = 'smith-horn/skillsmith'
+const RUNBOOK = 'docs/internal/runbooks/publish-ci-recovery.md'
+
+/**
+ * Assert that the current process is running inside a canonical-repo GitHub
+ * Actions runner. Exits the process with code 1 on refusal.
+ *
+ * @param {NodeJS.ProcessEnv} [env] - injected env for tests
+ * @returns {void}
+ */
+export function assertCiPublishContext(env = process.env) {
+  const override = env.SKILLSMITH_PUBLISH_OVERRIDE
+  if (override) {
+    if (!OVERRIDE_FORMAT.test(override)) {
+      console.error(
+        'SMI-4533: SKILLSMITH_PUBLISH_OVERRIDE format invalid.\n' +
+          '  Required: SMI-NNNN <rationale, ≥20 chars total>\n' +
+          '  Example: SMI-4499 emergency hotfix for prod incident; CI down 30+ min'
+      )
+      process.exit(1)
+      return
+    }
+    console.error(`::warning::OVERRIDE: local-publish guard bypassed. Reason: ${override}`)
+    try {
+      appendFileSync(
+        join(env.HOME ?? '/tmp', '.skillsmith-publish-overrides.log'),
+        `${new Date().toISOString()}\t${override}\t${env.GITHUB_REPOSITORY ?? 'local'}\n`
+      )
+    } catch (e) {
+      console.error(`::warning::Failed to write override log: ${e.message}`)
+    }
+    return
+  }
+
+  const isCi = env.CI === 'true' && env.GITHUB_ACTIONS === 'true'
+  const isCanonicalRepo = env.GITHUB_REPOSITORY === CANONICAL_REPO
+  if (!isCi || !isCanonicalRepo) {
+    console.error(
+      'SMI-4533: npm publish must run from CI (publish.yml). Local-fallback bypasses all guards.\n' +
+        '  - Use: gh workflow run publish.yml -f dry_run=false\n' +
+        `  - If CI is broken, fix CI first — see ${RUNBOOK}\n` +
+        '  - Genuine emergency: set SKILLSMITH_PUBLISH_OVERRIDE="SMI-NNNN <rationale>" and document in retro.'
+    )
+    process.exit(1)
+    return
+  }
+}
+
+// CLI entrypoint — only runs when invoked directly via `node ../../scripts/lib/forbid-local-publish.mjs`.
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('forbid-local-publish.mjs')
+
+if (isMain) {
+  assertCiPublishContext()
+}

--- a/scripts/lib/reserved-ranges.mjs
+++ b/scripts/lib/reserved-ranges.mjs
@@ -1,8 +1,7 @@
-// Single source of truth for npm reserved/deprecated version ranges. MUST stay
-// imported by both prepare-release.ts AND check-publish-collision.mjs — drift
-// between the two collision implementations is the failure mode this module
-// exists to prevent. See SMI-4531 for full unification (Rules 1/2/3 still
-// duplicated; only RESERVED_RANGES is shared today).
+// Single source of truth for npm reserved/deprecated version ranges. Consumed
+// by `scripts/lib/collision-rules.mjs` (the unified rule pipeline shared by
+// prepare-release.ts AND check-publish-collision.mjs). Drift between the two
+// collision implementations is the failure mode this module exists to prevent.
 //
 // SMI-4207 / ADR-115: `@skillsmith/core@2.0.0`–`2.1.2` were self-published in
 // January 2026 during an aborted version-strategy experiment and rolled back to

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -33,7 +33,14 @@ import {
 } from './lib/version-utils.js'
 // SMI-4530: shared with scripts/check-publish-collision.mjs. Drift between the
 // two reserved-range definitions was the root cause of PR #824's stuck publish.
-import { RESERVED_RANGES, filterReservedVersions, isReserved } from './lib/reserved-ranges.mjs'
+import { RESERVED_RANGES, filterReservedVersions } from './lib/reserved-ranges.mjs'
+// SMI-4531: full collision-rule unification. Both prepare-release.ts and
+// check-publish-collision.mjs now consume the same per-rule evaluators.
+import {
+  evaluateReservedRange,
+  evaluateAlreadyPublished,
+  evaluateLiveMax,
+} from './lib/collision-rules.mjs'
 
 // --- Types ---
 
@@ -248,13 +255,21 @@ export interface NpmLookup {
  * Evaluate the collision rules for a planned bump against the npm registry state.
  * Pure function — does NOT perform network I/O. Callers must supply lookups.
  *
- * Rule 1 — proposed > npm latest        → proceed.
- * Rule 2 — proposed <= npm latest,
- *          proposed NOT in published list → refuse unless --allow-downgrade.
- * Rule 3 — proposed === npm latest OR
- *          proposed in published list   → refuse UNCONDITIONALLY.
- *                                         --allow-downgrade does NOT override.
- *                                         Error must not mention any flag.
+ * SMI-4531: Rules 3 and 2 are now delegated to the shared
+ * `scripts/lib/collision-rules.mjs` module — same evaluators
+ * `check-publish-collision.mjs` consumes. Rule 1 (reserved-range) lives in
+ * `checkReservedVersionRanges` for legacy ordering reasons (it runs in a
+ * separate pass before this function in `main()`); the wrapper below also
+ * checks Rule 1 defensively so callers that invoke `checkVersionCollision`
+ * alone still get correct precedence.
+ *
+ * Rule 1 — reserved range                → refuse UNCONDITIONALLY (no override).
+ * Rule 3 — proposed in published list    → refuse UNCONDITIONALLY (no override).
+ *                                          Error must not mention any flag.
+ * Rule 2 — proposed <= live max,
+ *          not in published list         → refuse unless --allow-downgrade.
+ *
+ * Multi-package contract: errors accumulate across plans; never short-circuit.
  */
 export function checkVersionCollision(
   plans: BumpPlan[],
@@ -274,46 +289,54 @@ export function checkVersionCollision(
     const { latest, allVersions } = lookup
 
     // New package on npm (E404) — proceed silently.
-    if (latest === null) {
+    if (allVersions === null) {
       report.push(`  ${spec.name}: new on npm (proposed ${newVersion}) → proceed`)
       continue
     }
 
-    const isPublished = (allVersions ?? []).includes(newVersion)
-    const equalsLatest = newVersion === latest
+    // Rule 1 — reserved range (defensive; main() runs checkReservedVersionRanges first).
+    const r1 = evaluateReservedRange(spec.name, newVersion)
+    if (!r1.ok) {
+      errors.push(r1.message)
+      continue
+    }
 
-    // Rule 3: equals-published (or equals-latest) — unconditional refuse.
-    if (isPublished || equalsLatest) {
-      errors.push(
-        `${spec.name}: proposed ${newVersion} is already published on npm (highest published: ${latest}). ` +
-          `Different content under the same version is the failure mode this guard exists to prevent. ` +
-          `See scripts/prepare-release.ts and the release runbook: revert to release, do not override.`
+    // Rule 3 — exact-equal-published (no override).
+    const r3 = evaluateAlreadyPublished(spec.name, newVersion, allVersions)
+    if (!r3.ok) {
+      errors.push(r3.message)
+      continue
+    }
+
+    // Rule 2 — live-max <= refuse (overridable via --allow-downgrade).
+    const live = filterReservedVersions(spec.name, allVersions, semver)
+    if (!live.length) {
+      // No live anchor (every entry is reserved). Proceed — Rule 3 already
+      // covered the "republish any existing version" case.
+      report.push(
+        `  ${spec.name}: proposed ${newVersion} (no live versions published yet, all reserved) → proceed`
       )
       continue
     }
 
-    const cmp = semver.compare(newVersion, latest)
-    if (cmp > 0) {
-      report.push(`  ${spec.name}: proposed ${newVersion} > highest published ${latest} → proceed`)
+    const r2 = evaluateLiveMax(spec.name, newVersion, live, { allowDowngrade: opts.allowDowngrade })
+    if (!r2.ok) {
+      errors.push(r2.message)
       continue
     }
 
-    // Rule 2: proposed < npm latest, not published — refuse unless --allow-downgrade.
-    const suggested = semver.inc(latest, 'patch') ?? latest
-    if (!opts.allowDowngrade) {
-      errors.push(
-        `${spec.name}: proposed ${newVersion} <= highest published ${latest} (package: ${spec.name}, ` +
-          `proposed: ${newVersion}, highest published: ${latest}). ` +
-          `Note: "highest published" spans all dist-tags — not just "latest" — because npm refuses to republish any existing semver. ` +
-          `Suggested next-available target: ${suggested}. ` +
-          `To override: pass --allow-downgrade (rare; only when intentionally reusing a ` +
-          `reserved-but-unpublished semver).`
+    const liveMax = live.reduce((a, b) => (semver.gt(a, b) ? a : b))
+    if (semver.gt(newVersion, liveMax)) {
+      report.push(`  ${spec.name}: proposed ${newVersion} > highest published ${liveMax} → proceed`)
+    } else {
+      // r2.ok was true → either allowDowngrade=true or live was empty.
+      report.push(
+        `  ${spec.name}: proposed ${newVersion} <= highest published ${liveMax} (--allow-downgrade set) → proceed`
       )
-      continue
     }
-    report.push(
-      `  ${spec.name}: proposed ${newVersion} <= highest published ${latest} (--allow-downgrade set) → proceed`
-    )
+    // Suppress unused-variable lint for `latest` — kept on the type for now to
+    // preserve the public NpmLookup shape; downstream consumers may still read it.
+    void latest
   }
 
   return { ok: errors.length === 0, errors, report }
@@ -344,6 +367,10 @@ export { RESERVED_RANGES }
  * catch `@skillsmith/core@2.1.3` indirectly, but this rule states the skip explicitly and
  * refuses unconditionally — no `--allow-downgrade` override. Error message points at ADR-115.
  *
+ * SMI-4531: Thin wrapper around `evaluateReservedRange` from the shared
+ * `scripts/lib/collision-rules.mjs` module. Multi-package contract preserved
+ * — errors accumulate per-plan; never short-circuit.
+ *
  * Pure function — no network I/O.
  */
 export function checkReservedVersionRanges(plans: BumpPlan[]): CollisionCheckResult {
@@ -352,14 +379,9 @@ export function checkReservedVersionRanges(plans: BumpPlan[]): CollisionCheckRes
 
   for (const plan of plans) {
     const { spec, newVersion } = plan
-    if (isReserved(spec.name, newVersion, semver)) {
-      errors.push(
-        `${spec.name}: proposed ${newVersion} falls inside the reserved 2.x range ` +
-          `(>=2.0.0 <3.0.0). This range is permanently deprecated on npm — the next major ` +
-          `must jump to 3.0.0 or later. No override flag applies. ` +
-          `See ADR-115 (docs/internal/adr/115-skillsmith-core-version-namespace-reconciliation.md) ` +
-          `and scripts/prepare-release.ts.`
-      )
+    const result = evaluateReservedRange(spec.name, newVersion)
+    if (!result.ok) {
+      errors.push(result.message)
       continue
     }
     report.push(`  ${spec.name}: proposed ${newVersion} outside reserved ranges → proceed`)

--- a/scripts/tests/check-publish-collision.test.ts
+++ b/scripts/tests/check-publish-collision.test.ts
@@ -57,8 +57,11 @@ describe('evaluateCollision', () => {
     const res = evaluateCollision('@skillsmith/core', '0.5.2', { exec })
     expect(res.code).toBe(1)
     expect(res.message).toContain('already published')
-    // Diagnostic MUST NOT reference any override / bypass flag.
-    expect(res.message).not.toMatch(/override|--allow|--force|bypass|flag/i)
+    // SMI-4531: canonical Rule 3 message reads "do not override" — instruction,
+    // not an offered escape hatch. Diagnostic MUST NOT name any concrete
+    // override / bypass flag the operator could pass.
+    expect(res.message).not.toMatch(/--allow|--force|--bypass/i)
+    expect(res.message).toContain('Revert to release, do not override')
   })
 
   describe('gating path: proposed < latest AND not exact-equal (plan §2 Step 3 issue #1)', () => {

--- a/scripts/tests/collision-rules.test.ts
+++ b/scripts/tests/collision-rules.test.ts
@@ -1,0 +1,233 @@
+/**
+ * SMI-4531: Tests for scripts/lib/collision-rules.mjs.
+ *
+ * Pin the canonical error strings as a stable contract — both
+ * scripts/check-publish-collision.mjs and scripts/prepare-release.ts now
+ * consume this module. Drift between those two implementations was the
+ * SMI-4530 failure mode and must not return.
+ *
+ * MUTATION SAFEGUARD — DO NOT EDIT THESE STRINGS WITHOUT AN SMI REF:
+ *
+ *   Rule 1: "${pkg}: proposed ${target} falls inside the reserved 2.x range
+ *           (>=2.0.0 <3.0.0). This range is permanently deprecated on npm —
+ *           the next major must jump to 3.0.0 or later. No override flag
+ *           applies. See ADR-115 (...)."
+ *
+ *   Rule 3: "${pkg}: proposed ${target} is already published on npm (highest
+ *           published: ${maxForDiagnostic | "(none — all reserved)"}).
+ *           Different content under the same version is the failure mode
+ *           this guard exists to prevent. Revert to release, do not override."
+ *
+ *   Rule 2: "${pkg}: proposed ${target} <= highest published ${liveMax}.
+ *           Note: "highest published" spans all dist-tags — npm refuses to
+ *           republish any existing semver. Suggested next-available:
+ *           ${suggested}. To override (TS only): pass --allow-downgrade."
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  evaluateReservedRange,
+  evaluateAlreadyPublished,
+  evaluateLiveMax,
+  evaluateCollisionRules,
+} from '../lib/collision-rules.mjs'
+
+// ---------------------------------------------------------------------------
+// Rule 1: reserved-range refuse
+// ---------------------------------------------------------------------------
+
+describe('evaluateReservedRange (Rule 1)', () => {
+  it('passes for non-reserved versions', () => {
+    expect(evaluateReservedRange('@skillsmith/core', '0.5.7')).toEqual({ ok: true })
+    expect(evaluateReservedRange('@skillsmith/core', '3.0.0')).toEqual({ ok: true })
+    expect(evaluateReservedRange('@skillsmith/mcp-server', '2.5.0')).toEqual({ ok: true })
+  })
+
+  it('passes for invalid semver (caller surfaces a separate error)', () => {
+    expect(evaluateReservedRange('@skillsmith/core', 'not-a-version')).toEqual({ ok: true })
+  })
+
+  it('refuses @skillsmith/core inside the reserved 2.x range with the canonical message', () => {
+    const res = evaluateReservedRange('@skillsmith/core', '2.5.0')
+    expect(res.ok).toBe(false)
+    expect(res).toMatchObject({ ok: false })
+    if (res.ok) throw new Error('unreachable')
+    expect(res.message).toBe(
+      '@skillsmith/core: proposed 2.5.0 falls inside the reserved 2.x range (>=2.0.0 <3.0.0). ' +
+        'This range is permanently deprecated on npm — the next major must jump to 3.0.0 or later. ' +
+        'No override flag applies. See ADR-115 (docs/internal/adr/115-skillsmith-core-version-namespace-reconciliation.md).'
+    )
+  })
+
+  it('refuses at both range boundaries (2.0.0 and 2.99.99)', () => {
+    expect(evaluateReservedRange('@skillsmith/core', '2.0.0').ok).toBe(false)
+    expect(evaluateReservedRange('@skillsmith/core', '2.99.99').ok).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Rule 3: already-published refuse
+// ---------------------------------------------------------------------------
+
+describe('evaluateAlreadyPublished (Rule 3)', () => {
+  it('passes when target is not in allVersions', () => {
+    expect(evaluateAlreadyPublished('@skillsmith/core', '0.5.10', ['0.5.7', '0.5.8'])).toEqual({
+      ok: true,
+    })
+  })
+
+  it('refuses with the canonical message when target is already published', () => {
+    const res = evaluateAlreadyPublished('@skillsmith/core', '0.5.7', ['0.5.6', '0.5.7', '0.5.8'])
+    expect(res.ok).toBe(false)
+    if (res.ok) throw new Error('unreachable')
+    expect(res.message).toBe(
+      '@skillsmith/core: proposed 0.5.7 is already published on npm (highest published: 0.5.8). ' +
+        'Different content under the same version is the failure mode this guard exists to prevent. ' +
+        'Revert to release, do not override.'
+    )
+    expect(res.maxForDiagnostic).toBe('0.5.8')
+  })
+
+  it('uses live max (post-reserved-filter) for the diagnostic when both live and reserved entries exist', () => {
+    const res = evaluateAlreadyPublished('@skillsmith/core', '0.5.7', [
+      '0.5.6',
+      '0.5.7',
+      '2.0.0',
+      '2.1.2',
+    ])
+    expect(res.ok).toBe(false)
+    if (res.ok) throw new Error('unreachable')
+    // live = [0.5.6, 0.5.7]; max = 0.5.7
+    expect(res.message).toContain('highest published: 0.5.7')
+    expect(res.maxForDiagnostic).toBe('0.5.7')
+  })
+
+  it('renders "(none — all reserved)" when every published entry sits in the reserved range', () => {
+    // Synthetic: target equals one of the reserved entries; nothing live to anchor.
+    const res = evaluateAlreadyPublished('@skillsmith/core', '2.1.2', ['2.0.0', '2.1.0', '2.1.2'])
+    expect(res.ok).toBe(false)
+    if (res.ok) throw new Error('unreachable')
+    expect(res.message).toBe(
+      '@skillsmith/core: proposed 2.1.2 is already published on npm (highest published: (none — all reserved)). ' +
+        'Different content under the same version is the failure mode this guard exists to prevent. ' +
+        'Revert to release, do not override.'
+    )
+  })
+
+  it('does not refuse when allVersions is empty', () => {
+    expect(evaluateAlreadyPublished('@skillsmith/core', '1.0.0', [])).toEqual({ ok: true })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Rule 2: live-max <= refuse (with --allow-downgrade override hook)
+// ---------------------------------------------------------------------------
+
+describe('evaluateLiveMax (Rule 2)', () => {
+  it('passes when proposed > live max', () => {
+    expect(evaluateLiveMax('@skillsmith/core', '0.5.10', ['0.5.7', '0.5.8'])).toEqual({ ok: true })
+  })
+
+  it('passes when live pool is empty', () => {
+    expect(evaluateLiveMax('@skillsmith/core', '1.0.0', [])).toEqual({ ok: true })
+  })
+
+  it('refuses with the canonical message when proposed <= live max', () => {
+    const res = evaluateLiveMax('@skillsmith/core', '0.5.5', ['0.5.7', '0.5.8'])
+    expect(res.ok).toBe(false)
+    if (res.ok) throw new Error('unreachable')
+    expect(res.message).toBe(
+      '@skillsmith/core: proposed 0.5.5 <= highest published 0.5.8. ' +
+        'Note: "highest published" spans all dist-tags — npm refuses to republish any existing semver. ' +
+        'Suggested next-available: 0.5.9. ' +
+        'To override (TS only): pass --allow-downgrade.'
+    )
+    expect(res.suggestedNext).toBe('0.5.9')
+  })
+
+  it('honors allowDowngrade=true', () => {
+    expect(
+      evaluateLiveMax('@skillsmith/core', '0.5.5', ['0.5.7', '0.5.8'], { allowDowngrade: true })
+    ).toEqual({ ok: true })
+  })
+
+  it('passes for invalid semver targets (caller surfaces separately)', () => {
+    expect(evaluateLiveMax('@skillsmith/core', 'garbage', ['0.5.7'])).toEqual({ ok: true })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluateCollisionRules — orchestrator: precedence 1 → 3 → 2
+// ---------------------------------------------------------------------------
+
+describe('evaluateCollisionRules (orchestrator)', () => {
+  it('Rule 1 wins over Rule 3 (reserved AND already-published)', () => {
+    // 2.1.2 is reserved AND published — Rule 1 message must win.
+    const res = evaluateCollisionRules('@skillsmith/core', '2.1.2', ['2.0.0', '2.1.2'])
+    expect(res.ok).toBe(false)
+    if (res.ok) throw new Error('unreachable')
+    expect(res.rule).toBe(1)
+    expect(res.message).toContain('falls inside the reserved 2.x range')
+  })
+
+  it('Rule 3 wins over Rule 2 (already-published AND <= live max)', () => {
+    // 0.5.7 is published AND <= live max 0.5.8 — Rule 3 must win.
+    const res = evaluateCollisionRules('@skillsmith/core', '0.5.7', ['0.5.6', '0.5.7', '0.5.8'])
+    expect(res.ok).toBe(false)
+    if (res.ok) throw new Error('unreachable')
+    expect(res.rule).toBe(3)
+    expect(res.message).toContain('already published on npm')
+  })
+
+  it('Rule 2 fires when Rules 1 and 3 pass but proposed <= live max', () => {
+    const res = evaluateCollisionRules('@skillsmith/core', '0.5.5', ['0.5.6', '0.5.7', '0.5.8'])
+    expect(res.ok).toBe(false)
+    if (res.ok) throw new Error('unreachable')
+    expect(res.rule).toBe(2)
+    expect(res.suggestedNext).toBe('0.5.9')
+  })
+
+  it('passes with proceed message when target > live max and not reserved or published', () => {
+    const res = evaluateCollisionRules('@skillsmith/core', '0.5.10', ['0.5.7', '0.5.8'])
+    expect(res.ok).toBe(true)
+    if (!res.ok) throw new Error('unreachable')
+    expect(res.message).toBe(
+      '@skillsmith/core: proposed 0.5.10 > highest published 0.5.8, safe to publish'
+    )
+  })
+
+  it('passes with "all reserved" proceed message when no live anchor exists', () => {
+    // Synthetic case: every published entry is reserved, target is fresh + non-reserved.
+    const res = evaluateCollisionRules('@skillsmith/core', '0.5.10', ['2.0.0', '2.1.2'])
+    expect(res.ok).toBe(true)
+    if (!res.ok) throw new Error('unreachable')
+    expect(res.message).toBe(
+      '@skillsmith/core: no live versions published yet (all entries inside reserved range), proceeding'
+    )
+  })
+
+  it('honors allowDowngrade only for Rule 2 (Rules 1 and 3 still refuse)', () => {
+    // Rule 1 still refuses with allowDowngrade=true.
+    expect(
+      evaluateCollisionRules('@skillsmith/core', '2.5.0', [], { allowDowngrade: true }).ok
+    ).toBe(false)
+    // Rule 3 still refuses with allowDowngrade=true.
+    expect(
+      evaluateCollisionRules('@skillsmith/core', '0.5.7', ['0.5.7', '0.5.8'], {
+        allowDowngrade: true,
+      }).ok
+    ).toBe(false)
+    // Rule 2 passes with allowDowngrade=true.
+    expect(
+      evaluateCollisionRules('@skillsmith/core', '0.5.5', ['0.5.7', '0.5.8'], {
+        allowDowngrade: true,
+      }).ok
+    ).toBe(true)
+  })
+
+  it('handles a non-reserved package (no Rule 1 carve-out applies)', () => {
+    // @skillsmith/mcp-server has no reserved range; 2.5.0 is fine.
+    const res = evaluateCollisionRules('@skillsmith/mcp-server', '0.5.0', ['0.4.12', '0.4.13'])
+    expect(res.ok).toBe(true)
+  })
+})

--- a/scripts/tests/forbid-local-publish.test.ts
+++ b/scripts/tests/forbid-local-publish.test.ts
@@ -1,0 +1,162 @@
+/**
+ * SMI-4533: Tests for scripts/lib/forbid-local-publish.mjs.
+ *
+ * Pin the contract that `prepublishOnly` refuses local invocations and
+ * accepts only well-formed `SKILLSMITH_PUBLISH_OVERRIDE` values. Process-exit
+ * is mocked so failures don't tear down the test runner.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { appendFileSync } from 'node:fs'
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+  return { ...actual, appendFileSync: vi.fn() }
+})
+
+import { assertCiPublishContext } from '../lib/forbid-local-publish.mjs'
+
+const mockedAppend = vi.mocked(appendFileSync)
+
+describe('assertCiPublishContext (SMI-4533)', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>
+  let errSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    mockedAppend.mockClear()
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      // Throw so call sites short-circuit instead of exiting the test runner.
+      .mockImplementation(((code?: number | string | null | undefined) => {
+        throw new Error(`process.exit(${code ?? 'undefined'})`)
+      }) as never)
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    exitSpy.mockRestore()
+    errSpy.mockRestore()
+  })
+
+  // --- CI path (the happy path) ---
+
+  it('returns silently inside canonical-repo GitHub Actions runner', () => {
+    expect(() =>
+      assertCiPublishContext({
+        CI: 'true',
+        GITHUB_ACTIONS: 'true',
+        GITHUB_REPOSITORY: 'smith-horn/skillsmith',
+      })
+    ).not.toThrow()
+    expect(exitSpy).not.toHaveBeenCalled()
+    expect(mockedAppend).not.toHaveBeenCalled()
+  })
+
+  it('refuses when CI=false (local maintainer laptop)', () => {
+    expect(() => assertCiPublishContext({})).toThrow('process.exit(1)')
+    expect(errSpy).toHaveBeenCalled()
+    const allOutput = errSpy.mock.calls.flat().join(' ')
+    expect(allOutput).toContain('SMI-4533')
+    expect(allOutput).toContain('publish.yml')
+    expect(allOutput).toContain('docs/internal/runbooks/publish-ci-recovery.md')
+  })
+
+  it('refuses when CI=true but not canonical repo (forks publishing their own packages)', () => {
+    expect(() =>
+      assertCiPublishContext({
+        CI: 'true',
+        GITHUB_ACTIONS: 'true',
+        GITHUB_REPOSITORY: 'someone-else/their-fork',
+      })
+    ).toThrow('process.exit(1)')
+  })
+
+  it('refuses when GITHUB_ACTIONS missing (other CI providers)', () => {
+    expect(() =>
+      assertCiPublishContext({
+        CI: 'true',
+        GITHUB_REPOSITORY: 'smith-horn/skillsmith',
+      })
+    ).toThrow('process.exit(1)')
+  })
+
+  // --- Override path ---
+
+  it('accepts a valid override (SMI-NNNN + ≥20 chars total) and appends to the audit log', () => {
+    expect(() =>
+      assertCiPublishContext({
+        SKILLSMITH_PUBLISH_OVERRIDE: 'SMI-4499 emergency hotfix for prod incident',
+        HOME: '/home/test',
+      })
+    ).not.toThrow()
+    expect(exitSpy).not.toHaveBeenCalled()
+    expect(mockedAppend).toHaveBeenCalledTimes(1)
+    const [path, line] = mockedAppend.mock.calls[0]!
+    expect(path).toBe('/home/test/.skillsmith-publish-overrides.log')
+    expect(line).toContain('SMI-4499 emergency hotfix for prod incident')
+    expect(line).toContain('local')
+    // Line should end with a newline.
+    expect(String(line).endsWith('\n')).toBe(true)
+  })
+
+  it('records GITHUB_REPOSITORY in the audit log when present', () => {
+    expect(() =>
+      assertCiPublishContext({
+        SKILLSMITH_PUBLISH_OVERRIDE: 'SMI-4499 emergency hotfix for prod incident',
+        HOME: '/home/test',
+        GITHUB_REPOSITORY: 'smith-horn/skillsmith',
+      })
+    ).not.toThrow()
+    const [, line] = mockedAppend.mock.calls[0]!
+    expect(line).toContain('smith-horn/skillsmith')
+  })
+
+  it('refuses an override missing the SMI- prefix', () => {
+    expect(() =>
+      assertCiPublishContext({
+        SKILLSMITH_PUBLISH_OVERRIDE: 'just because the build is broken right now',
+      })
+    ).toThrow('process.exit(1)')
+    const allOutput = errSpy.mock.calls.flat().join(' ')
+    expect(allOutput).toContain('format invalid')
+    expect(allOutput).toContain('SMI-NNNN')
+    expect(mockedAppend).not.toHaveBeenCalled()
+  })
+
+  it('refuses an override that is too short (under 20 chars total)', () => {
+    expect(() =>
+      assertCiPublishContext({
+        SKILLSMITH_PUBLISH_OVERRIDE: 'SMI-1 short',
+      })
+    ).toThrow('process.exit(1)')
+    expect(mockedAppend).not.toHaveBeenCalled()
+  })
+
+  it('refuses OVERRIDE=1 specifically (the documented anti-pattern)', () => {
+    expect(() =>
+      assertCiPublishContext({
+        SKILLSMITH_PUBLISH_OVERRIDE: '1',
+      })
+    ).toThrow('process.exit(1)')
+  })
+
+  it('still permits the override when CI signals are absent (the whole point of break-glass)', () => {
+    // Local laptop, no CI env — but with a valid override.
+    expect(() =>
+      assertCiPublishContext({
+        SKILLSMITH_PUBLISH_OVERRIDE: 'SMI-4499 emergency hotfix for prod incident',
+        HOME: '/home/test',
+      })
+    ).not.toThrow()
+    expect(mockedAppend).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to /tmp when HOME is unset (audit log still attempted)', () => {
+    expect(() =>
+      assertCiPublishContext({
+        SKILLSMITH_PUBLISH_OVERRIDE: 'SMI-4499 emergency hotfix for prod incident',
+      })
+    ).not.toThrow()
+    const [path] = mockedAppend.mock.calls[0]!
+    expect(path).toBe('/tmp/.skillsmith-publish-overrides.log')
+  })
+})

--- a/scripts/tests/prepare-release.test.ts
+++ b/scripts/tests/prepare-release.test.ts
@@ -259,9 +259,9 @@ describe('checkVersionCollision — rule matrix', () => {
     // Must NOT mention any override flag name
     expect(msg).not.toMatch(/--allow-downgrade/)
     expect(msg).not.toMatch(/--force-version/)
-    // Must point operator at the script and rollback guidance
-    expect(msg).toContain('scripts/prepare-release.ts')
-    expect(msg).toContain('revert to release, do not override')
+    // SMI-4531: canonical Rule 3 message — points operator at rollback, not at the script path.
+    expect(msg).toContain('Revert to release, do not override')
+    expect(msg).toContain('failure mode this guard exists to prevent')
   })
 
   it('Case 4b: proposed is a previously-published (but not latest) version → refuses unconditionally', () => {
@@ -272,7 +272,8 @@ describe('checkVersionCollision — rule matrix', () => {
     expect(result.ok).toBe(false)
     const msg = result.errors[0]!
     expect(msg).not.toMatch(/--allow-downgrade/)
-    expect(msg).toContain('revert to release, do not override')
+    // SMI-4531: canonical Rule 3 message — capitalized "Revert".
+    expect(msg).toContain('Revert to release, do not override')
   })
 
   // Case 6: New package (npm returns E404) → proceeds
@@ -306,7 +307,9 @@ describe('checkReservedVersionRanges — @skillsmith/core 2.x skip rule (SMI-420
     expect(msg).toContain('2.x')
     expect(msg).toContain('3.0.0')
     expect(msg).toContain('ADR-115')
-    expect(msg).toContain('scripts/prepare-release.ts')
+    // SMI-4531: canonical Rule 1 message no longer includes the script path —
+    // the ADR pointer is the durable artifact.
+    expect(msg).toContain('permanently deprecated on npm')
     // Must not mention any override flag — this rule is unconditional.
     expect(msg).not.toMatch(/--allow-downgrade/)
     expect(msg).not.toMatch(/--force/)
@@ -459,7 +462,12 @@ describe('checkVersionCollision × reserved range — integration (SMI-4207)', (
     ])
     const result = checkVersionCollision([plan('2.1.2')], lookups, { allowDowngrade: true })
     expect(result.ok).toBe(false)
-    expect(result.errors[0]).toContain('revert to release, do not override')
+    // SMI-4531: canonical Rule 3 message — capitalized "Revert". With Rule 1
+    // also firing for 2.1.2 (it's reserved), checkVersionCollision's defensive
+    // Rule 1 check wins; either message is acceptable. Assert on the
+    // unconditional-refuse signal that's present in BOTH canonical messages.
+    expect(result.errors[0]).not.toMatch(/--allow-downgrade/)
+    expect(result.errors[0]).toMatch(/reserved 2\.x range|Revert to release/)
   })
 })
 


### PR DESCRIPTION
## Summary

- **SMI-4531**: Extract `scripts/lib/collision-rules.mjs` as the single source of truth for Rules 1/2/3 (reserved-range, exact-equal, live-max-lte). Both `check-publish-collision.mjs` (publish.yml guard, sync) and `prepare-release.ts` (release-prep, async, multi-plan) now import the same evaluators. Drift between the two implementations (the SMI-4530 root cause) is structurally impossible.
- **SMI-4533**: Forbid local-fallback `npm publish` via `prepublishOnly` lifecycle hook on all 4 publishable packages. Trusted-publisher OIDC stanza (`id-token: write`) added to all publish-* jobs; SMI-4539 will flip token→OIDC live after one stable release cycle. Override path (`SKILLSMITH_PUBLISH_OVERRIDE=SMI-NNNN <rationale>`) is strict-format-validated and audit-logged locally; SMI-4538 tracks the Supabase audit-log followup.

## Why batched

Both due 2026-05-31. Both touch publish-pipeline integrity. SMI-4531 has reduced value if SMI-4533 isn't done — drift can re-emerge through local fallback. SMI-4533 has reduced value if SMI-4531 isn't done — a CI-only publish path is only as safe as the guards on it.

## Plan + review

- Plan: `docs/internal/implementation/smi-4531-4533-collision-unification-and-fallback-ban.md`
- Plan-review: 13 findings (1 Critical, 4 High, 5 Medium, 3 Low) — **all applied**.
- Critical (F1): would have silently destroyed existing `prepublishOnly` build+test gate on all 4 packages. Fix: chained, never replaced.

## What changed

| Area | Change |
|---|---|
| **NEW** | `scripts/lib/collision-rules.mjs` (177 LOC) — pure Rule 1/2/3 evaluators + `evaluateCollisionRules` orchestrator |
| **NEW** | `scripts/lib/forbid-local-publish.mjs` (79 LOC) — CI-only publish guard + override format validation + local audit log |
| **NEW** | `scripts/tests/collision-rules.test.ts` (236 LOC, 21 tests) — verbatim canonical-string snapshots |
| **NEW** | `scripts/tests/forbid-local-publish.test.ts` (162 LOC, 11 tests) |
| **NEW** | `docs/internal/runbooks/publish-ci-recovery.md` (137 LOC) — break-glass runbook linked from the guard's error message |
| **REFACTOR** | `scripts/check-publish-collision.mjs` — Rules 1/2/3 inline → `evaluateCollisionRules` call; canonical messages now stable contract |
| **REFACTOR** | `scripts/prepare-release.ts` — `checkReservedVersionRanges`/`checkVersionCollision` are thin wrappers; multi-package error-accumulation contract preserved |
| **MODIFY** | `packages/{core,mcp-server,cli,enterprise}/package.json` — chained guard before existing `npm run build && npm run test` (mcp-server retains trailing `chmod +x dist/src/index.js`) |
| **MODIFY** | `.github/workflows/publish.yml` — `id-token: write` + `packages: write` (enterprise) on publish-{core,cli,enterprise}; mcp-server already had it from SMI-4534 |
| **MODIFY** | `CLAUDE.md` § Publishing — "Local fallback" heading preserved as deprecation stub (anchor stability) |
| **REWRITE** | `.claude/development/publishing-guide.md` — § Break-Glass with override format + retro-required process |
| **MODIFY** | `.env.schema` — `SKILLSMITH_NPM_TOKEN` annotated deprecated (SMI-4540 deletes) |
| **MODIFY** | `docs/internal/index.md` — runbooks count `7 → 8` |

## Test plan

- [ ] CI green (lint, typecheck, audit:standards, format:check)
- [ ] `node scripts/check-publish-collision.mjs @skillsmith/core 0.5.7` — exits 1 with canonical Rule 3 verbatim
- [ ] `node scripts/check-publish-collision.mjs @skillsmith/core 2.5.0` — exits 1 with canonical Rule 1 verbatim
- [ ] `npx tsx scripts/prepare-release.ts --dry-run --all=patch` — same shape as before; multi-package errors accumulate (no cross-package short-circuit)
- [ ] All 32 new tests pass; existing tests for both callers updated to match canonical messages

## Decisions resolved

| Question | Decision |
|---|---|
| Wave 2 strategy | Trusted-publisher OIDC (Option a). npm tier hedge was stale — GA on free org tier since mid-2025. |
| Override format | `SMI-NNNN <rationale, ≥20 chars>`. Anything else refuses with format-invalid. |
| Output shape unification | Per-caller wrappers retained; shared module returns `{ok, message, ...metadata}`. |
| `MCP_REGISTRY_TOKEN`-style cleanup | SMI-4540 (filed) — gated on SMI-4539 OIDC stable for one release cycle. |

## Followups (filed before merge)

- **SMI-4538**: Wave 2.1 Supabase `audit_logs` write for override usage
- **SMI-4539**: OIDC flip-live (Phase 2)
- **SMI-4540**: `.env` token retirement (Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[skip-doc-drift] — package.json changes are `prepublishOnly` script edits, not version bumps; doc-drift detector misclassifies.
