### PR TITLE
fix(infra): SMI-4451 SessionStart hook — emit hookEventName

### DIFF
--- a/scripts/session-start-priming.sh
+++ b/scripts/session-start-priming.sh
@@ -36,7 +36,7 @@ except Exception:
 emit_json() {
   python3 -c "
 import json, sys
-print(json.dumps({'hookSpecificOutput': {'additionalContext': sys.argv[1] if len(sys.argv) > 1 else ''}}))
+print(json.dumps({'hookSpecificOutput': {'hookEventName': 'SessionStart', 'additionalContext': sys.argv[1] if len(sys.argv) > 1 else ''}}))
 " "$1"
 }
 


### PR DESCRIPTION
## Summary

- Add `hookEventName: "SessionStart"` to the `emit_json` output in `scripts/session-start-priming.sh` so Claude Code's harness validator accepts the payload.
- Without this field, every session start logs `Hook JSON output validation failed — hookSpecificOutput is missing required field "hookEventName"` and the priming `additionalContext` is silently dropped (hook still exits 0, sessions continue).
- Spec doc companion: smith-horn/skillsmith-docs#99 (private submodule, merged). Submodule pointer bump intentionally **not** included here — will land as a separate followup.

## Why

The Claude Code SessionStart hook spec evolved after SMI-4451 Wave 1 Step 7 shipped (PRs `6e6e1a07`, `96a1416c`). The validator now requires `hookEventName` on every `hookSpecificOutput`. The original spec did not document this field, so the implementation never emitted it. Result: priming was a silent no-op for an unknown number of sessions.

## Investigation

The investigation that led to this PR confirmed the failure was scoped to SMI-4451, not the related RuVector / `skillsmith-doc-retrieval` initiative (SMI-4416/4417). RuVector owns the search index that `scripts/session-priming-query.ts` consumes; it does not own the hook entrypoint or its JSON output shape.

## Test plan

- [x] Local: `printf '{"session_id":"t","source":"startup","cwd":"'$PWD'"}' | bash scripts/session-start-priming.sh` emits `hookEventName: "SessionStart"` in the parsed JSON.
- [ ] Restart Claude Code on this branch (or any `smi-*` / `wave-*` branch) and confirm no `SessionStart:startup hook error` line appears.
- [ ] Confirm priming context still loads (transient at `/tmp/session-priming-${SESSION_ID}.md` is non-empty when the index has matches).

[skip-impl-check] — shell-only one-line change, no production source code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)