### PR TITLE
fix(infra): SMI-4549 wave 1 — repair host better-sqlite3 binding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,18 @@ git submodule update --init                           # Init internal docs (auth
 
 **Worktrees**: Unlock main repo first, then `./scripts/create-worktree.sh`. Remove with `./scripts/remove-worktree.sh --prune`.
 
-**Hooks in worktrees (SMI-4377 + SMI-4381)**: Pre-commit hooks work inside worktrees via three mechanisms: (1) `.husky/_/` is tracked in git (husky's dispatch stubs) so hook discovery inherits through checkout; (2) `scripts/create-worktree.sh` symlinks the root `node_modules` from the main repo (relative path); (3) **per-package `node_modules` are also symlinked** (relative paths) so workspace-pinned deps (e.g. `zod@3.25.76` in `mcp-server`) resolve correctly without falling through to the hoisted root (which carries `zod@4.x`). **One-time host setup required** (after fresh clone): `npm install --ignore-scripts` to populate `$REPO_ROOT/node_modules` — Docker named-volume installs don't populate the host path. Caveats: (a) do not run `npm install` in the main repo while a pre-commit is active in a worktree — re-run the commit if it aborts; (b) on **macOS Docker Desktop**, worktree pre-commits fall back to host execution because virtiofs cannot traverse relative symlinks (per-package `node_modules` resolution fails inside the container). The host fallback works correctly thanks to the SMI-4381 per-package symlinks. Linux Docker hosts use the in-container path via `compute_container_wd`. (c) repair existing worktrees with `./scripts/repair-worktrees.sh` (idempotent; backfills both root and per-package symlinks).
+**Hooks in worktrees (SMI-4377 + SMI-4381 + SMI-4549)**: Pre-commit hooks work inside worktrees via three mechanisms: (1) `.husky/_/` is tracked in git (husky's dispatch stubs) so hook discovery inherits through checkout; (2) `scripts/create-worktree.sh` symlinks the root `node_modules` from the main repo (relative path); (3) **per-package `node_modules` are also symlinked** (relative paths) so workspace-pinned deps (e.g. `zod@3.25.76` in `mcp-server`) resolve correctly without falling through to the hoisted root (which carries `zod@4.x`). **One-time host setup required** (after fresh clone):
+
+```bash
+npm install --ignore-scripts             # populate $REPO_ROOT/node_modules (Docker volumes don't)
+./scripts/repair-host-native-deps.sh     # SMI-4549: rebuild better-sqlite3 binding (--ignore-scripts skipped it)
+```
+
+The repair script is idempotent — sub-second `[skip]` exit when the binding already loads. Skipping it leaves the host's retrieval-logs writer (`packages/doc-retrieval-mcp/src/retrieval-log/writer.ts`) silently no-op-ing, which the SMI-4549 retro caught after a 7-day soak window passed with zero captured rows.
+
+**`IS_DOCKER` trap (SMI-4549)**: The retrieval-logs writer no-ops when `process.env.IS_DOCKER === 'true'` because Docker has its own writer path. If you `export IS_DOCKER=true` in a host shell (e.g. sourced from `.env.docker`), the writer will refuse to write on the host too — matching the same zero-rows symptom as a missing native binding. Verify with `printenv IS_DOCKER` (must be empty on host) before debugging instrumentation.
+
+Caveats: (a) do not run `npm install` in the main repo while a pre-commit is active in a worktree — re-run the commit if it aborts; (b) on **macOS Docker Desktop**, worktree pre-commits fall back to host execution because virtiofs cannot traverse relative symlinks (per-package `node_modules` resolution fails inside the container). The host fallback works correctly thanks to the SMI-4381 per-package symlinks. Linux Docker hosts use the in-container path via `compute_container_wd`. (c) repair existing worktrees with `./scripts/repair-worktrees.sh` (idempotent; backfills both root and per-package symlinks AND host native bindings via the SMI-4549 script).
 
 **Rebasing**: `./scripts/rebase-worktree.sh <worktree-path> [target-branch]` handles git-crypt filter management, submodule cross-fetching, and branch verification. Use `--dry-run` to preview. Manual fallback: [git-crypt-guide.md](.claude/development/git-crypt-guide.md#rebasing-with-git-crypt).
 
@@ -453,7 +464,7 @@ A `SessionStart` hook (`scripts/session-start-priming.sh`) writes a transient pr
 | Container won't start | `docker compose --profile dev down && docker volume rm skillsmith_node_modules && docker compose --profile dev up -d` |
 | Native module errors | `docker exec skillsmith-dev-1 npm rebuild better-sqlite3 onnxruntime-node` |
 | Platform mismatch (SIGKILL 137) | `rm -rf packages/*/node_modules/better-sqlite3 packages/*/node_modules/onnxruntime-node` then rebuild |
-| Node ABI mismatch (after Node upgrade) | WASM fallback auto-activates since core 0.4.10. To restore native: `docker exec skillsmith-dev-1 npm rebuild better-sqlite3` |
+| Node ABI mismatch (after Node upgrade) | WASM fallback auto-activates since core 0.4.10. To restore native: `docker exec skillsmith-dev-1 npm rebuild better-sqlite3` (Docker side); `./scripts/repair-host-native-deps.sh` (host side, SMI-4549) |
 | Docker DNS failure | `docker network prune -f` then restart container |
 | Stale CJS artifacts | `docker exec skillsmith-dev-1 bash -c 'find /app/packages -path "*/src/*.js" -not -path "*/node_modules/*" -not -path "*/dist/*" -type f -delete'` |
 | Orphaned agents | `./scripts/cleanup-orphans.sh` (`--dry-run` to preview) |

--- a/scripts/repair-host-native-deps.sh
+++ b/scripts/repair-host-native-deps.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# repair-host-native-deps.sh - Idempotent host-side native binding repair (SMI-4549)
+#
+# The SMI-4381 worktree workflow uses `npm install --ignore-scripts` on the
+# host, which skips node-gyp postinstall and leaves host-only consumers
+# (the retrieval-logs writer in particular, packages/doc-retrieval-mcp/src/
+# retrieval-log/writer.ts) without their compiled native bindings. The
+# writer's openDb() silently catches the load error → logRetrievalEvent
+# no-ops → instrumentation disappears for days. SMI-4549 RCA documents the
+# 7-day soak that ran with zero captured rows.
+#
+# This script restores the binding. It is intentionally CHEAP on a healthy
+# host: the first step is a require() probe that exits in <1s with [skip]
+# when the binding already loads. Only on probe failure does it call
+# `npm rebuild`.
+#
+# Host-only. Inside the Docker dev container (IS_DOCKER=true) the writer
+# itself no-ops, and Docker's own postinstall handles its bindings — this
+# script exits early so it doesn't fight that path.
+#
+# Usage:  ./scripts/repair-host-native-deps.sh
+# Exit:   0 on success ([ok] or [skip]); non-zero with remediation hint on failure.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "$SCRIPT_DIR/_lib.sh"
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+if [[ -z "$REPO_ROOT" ]]; then
+  error "Not in a git repository."
+fi
+
+# Resolve to main repo if invoked from a worktree (writer's binding lives in
+# the main-repo node_modules; per-package symlinks resolve to it via SMI-4381).
+MAIN_GIT_DIR="$(get_main_git_dir "$REPO_ROOT")"
+if [[ "$MAIN_GIT_DIR" != "$REPO_ROOT/.git" ]] && [[ -n "$MAIN_GIT_DIR" ]]; then
+  REPO_ROOT="$(dirname "$MAIN_GIT_DIR")"
+fi
+
+# Guard 1: don't run inside Docker — the container has its own postinstall path.
+if [[ "${IS_DOCKER:-}" == "true" ]] || [[ -f /.dockerenv ]]; then
+  printf '[skip] inside Docker — host-only script; container handles its own postinstall\n'
+  exit 0
+fi
+
+cd "$REPO_ROOT"
+
+probe_binding() {
+  # Returns 0 if better-sqlite3 loads AND can open a database, non-zero otherwise.
+  # The require() alone only loads the JS wrapper — the bindings() lookup
+  # for the native .node file fires on `new Database(...)`. Without the open
+  # call, a host with a missing binding probes green and bypasses the rebuild.
+  # Stderr swallowed — callers print their own diagnostics on failure.
+  node -e "const D=require('better-sqlite3'); new D(':memory:').close()" >/dev/null 2>&1
+}
+
+# Guard 2: cheap healthy-path probe. Should be the FIRST thing this script
+# does so that calls from repair-worktrees.sh stay sub-second on a healthy host.
+if probe_binding; then
+  printf '[skip] better-sqlite3 binding already loaded\n'
+  exit 0
+fi
+
+# Guard 3: Node version sanity — npm rebuild compiles against the *current*
+# Node's headers, but the user may be running a Node that doesn't match the
+# project's pin. Building against the wrong ABI succeeds and then fails on
+# load, which is exactly the failure shape we're trying to prevent recurring.
+NODE_CURRENT="$(node --version | sed 's/^v//')"
+NODE_PINNED=""
+if [[ -f .nvmrc ]]; then
+  NODE_PINNED="$(tr -d '[:space:]' < .nvmrc)"
+fi
+
+if [[ -n "$NODE_PINNED" ]]; then
+  # .nvmrc may be a partial version (e.g. "22.22"); accept any current Node
+  # whose version starts with the pinned prefix.
+  if [[ "$NODE_CURRENT" != "$NODE_PINNED"* ]]; then
+    error "Node version mismatch: current $NODE_CURRENT, pinned $NODE_PINNED (.nvmrc).
+
+  Switch to the pinned Node before rebuilding:
+    nvm use            # reads .nvmrc
+  Then re-run:
+    ./scripts/repair-host-native-deps.sh"
+  fi
+fi
+
+info "better-sqlite3 binding missing/broken; rebuilding from source..."
+info "(this can take 30-60s on first run)"
+
+# Capture rebuild output so we can show the tail on failure without flooding
+# the caller's terminal on success.
+REBUILD_LOG="$(mktemp -t skillsmith-rebuild-better-sqlite3.XXXXXX)"
+trap 'rm -f "$REBUILD_LOG"' EXIT
+
+if ! npm rebuild better-sqlite3 --build-from-source >"$REBUILD_LOG" 2>&1; then
+  printf '\n--- npm rebuild output (tail) ---\n'
+  tail -20 "$REBUILD_LOG"
+  printf '\n'
+  error "npm rebuild better-sqlite3 failed.
+
+  Common causes:
+    - missing build toolchain (Xcode CLT on macOS, build-essential on Linux)
+    - Node header download failure (corporate proxy / offline)
+    - C++ toolchain version mismatch
+
+  Diagnose:
+    cat $REBUILD_LOG
+  Then re-run this script."
+fi
+
+# Re-probe — building succeeded, but did the binding actually load?
+if ! probe_binding; then
+  printf '\n--- npm rebuild output (tail) ---\n'
+  tail -20 "$REBUILD_LOG"
+  printf '\n'
+  error "rebuild completed but require('better-sqlite3') still fails.
+
+  This usually means the rebuild produced a binary for a different Node ABI
+  than the one currently running. Confirm:
+    node -p \"process.versions.modules\"
+  matches the binding path under node_modules/better-sqlite3/lib/binding/.
+
+  Then:
+    rm -rf node_modules/better-sqlite3
+    npm install better-sqlite3
+    ./scripts/repair-host-native-deps.sh"
+fi
+
+printf '[ok] better-sqlite3 binding loaded\n'

--- a/scripts/repair-worktrees.sh
+++ b/scripts/repair-worktrees.sh
@@ -40,3 +40,10 @@ repair_worktrees_node_modules "$REPO_ROOT"
 
 info "Backfilling per-package node_modules symlinks (SMI-4381)..."
 repair_worktrees_package_node_modules "$REPO_ROOT"
+
+# SMI-4549: rebuild host-side native bindings skipped by `npm install
+# --ignore-scripts`. Cheap (sub-second `[skip]`) on a healthy host; rebuilds
+# better-sqlite3 from source if the binding is missing or the require()
+# fails to instantiate. Single-source-of-truth host-setup pass.
+info "Verifying host native bindings (SMI-4549)..."
+"$SCRIPT_DIR/repair-host-native-deps.sh"

--- a/scripts/session-start-priming.sh
+++ b/scripts/session-start-priming.sh
@@ -46,6 +46,44 @@ emit_empty() {
   exit 0
 }
 
+# SMI-4549: Walk up from $1 until a directory is found that contains `.git`
+# as a directory (not a file — worktrees have `.git` as a file pointing to
+# the main repo's gitdir). Mirrors `findMainRepoRoot` in
+# packages/doc-retrieval-mcp/src/retrieval-log/writer.ts:75-93 so the hook's
+# .log file co-locates with the writer's retrieval-logs.db inside the same
+# encoded-project directory under ~/.claude/projects/. Without this, the
+# .log file ends up under the worktree-encoded dir while the DB lives under
+# the main-repo-encoded dir — debug hazard for SMI-4549-like investigations.
+#
+# Hardened per plan-review:
+#   - [[ ]] not [ ] for space-safe path comparisons
+#   - 64-iter max-depth cap (matches writer.ts safety cap)
+#   - explicit set +e around the loop body so unrelated probes don't trip
+#     the script's outer set -euo pipefail
+# Echoes the resolved path on stdout, exits non-zero if nothing found.
+resolve_main_repo_root() {
+  local current depth parent
+  current="$1"
+  depth=0
+  set +e
+  while (( depth < 64 )); do
+    if [[ -d "$current/.git" ]]; then
+      printf '%s\n' "$current"
+      set -e
+      return 0
+    fi
+    parent="$(dirname "$current")"
+    if [[ "$parent" == "$current" ]]; then
+      set -e
+      return 1
+    fi
+    current="$parent"
+    depth=$(( depth + 1 ))
+  done
+  set -e
+  return 1
+}
+
 SOURCE=$(json_get source unknown)
 SESSION_ID=$(json_get session_id unknown)
 CWD=$(json_get cwd "")
@@ -94,7 +132,11 @@ if [ -f "$TRANSIENT" ]; then
 fi
 
 # Gate 4: build query and search.
-LOG_DIR="$HOME/.claude/projects/$(echo "$REPO_ROOT" | sed 's|^/|-|;s|/|-|g')"
+# SMI-4549: encode the *main repo root* (not the worktree path) so .log file
+# co-locates with retrieval-logs.db. From a worktree, $REPO_ROOT is the
+# worktree path; resolve_main_repo_root walks up to the .git-as-directory.
+MAIN_REPO_ROOT="$(resolve_main_repo_root "$REPO_ROOT" 2>/dev/null || echo "$REPO_ROOT")"
+LOG_DIR="$HOME/.claude/projects/$(echo "$MAIN_REPO_ROOT" | sed 's|^/|-|;s|/|-|g')"
 mkdir -p "$LOG_DIR" 2>/dev/null || true
 LOG="$LOG_DIR/session-priming.log"
 


### PR DESCRIPTION
[skip-impl-check] — Wave 1 is shell + markdown only; the implementation lives in `scripts/repair-host-native-deps.sh`, `scripts/session-start-priming.sh`, `scripts/repair-worktrees.sh`. The `verify-implementation.ts` heuristic doesn't recognize bash as source. Wave 2 (`smi-4549-probe-and-marker`) will add the TypeScript implementation.

## Summary

Wave 1 of [SMI-4549](https://linear.app/smith-horn-group/issue/SMI-4549/sessionstart-hook-silently-no-ops-on-real-sessions-only-smoke-test). Restores the host's `better-sqlite3` native binding so the SessionStart priming hook can write `retrieval_events` rows again. SMI-4451 Wave 1's 7-day soak passed silently with 0 captured rows because of this regression — see plan doc for verified RCA.

- New `scripts/repair-host-native-deps.sh` (idempotent, ~17s first run, ~0.05s `[skip]` when healthy). Probe is `new D(':memory:').close()` because `require()` alone only loads the JS wrapper — native `bindings()` lookup fires on instantiation. Refuses on Node version mismatch vs `.nvmrc`.
- `scripts/session-start-priming.sh`: bash port of writer.ts's `findMainRepoRoot` so the hook's `.log` file co-locates with `retrieval-logs.db` even from a worktree. `[[ ]]`, 64-iter cap, `set +e` scoped to the loop body.
- `scripts/repair-worktrees.sh`: invokes the new repair script at the end as the single-source-of-truth host-setup pass.
- `CLAUDE.md`: documents the post-clone two-step (`npm install --ignore-scripts` → `repair-host-native-deps.sh`) and the `IS_DOCKER` host-shell trap.

Wave 2 (`smi-4549-probe-and-marker`, branched off Wave 1 per SMI-2597) will add the loud-fail probe + outage marker + tests so the silent-failure mode itself can't recur.

## Plan + plan-review

Full SPARC plan in [`docs/internal/implementation/smi-4549-session-start-hook-noop.md`](https://github.com/smith-horn/skillsmith-docs/blob/smi-4549-repair-host-binding/implementation/smi-4549-session-start-hook-noop.md). Plan-review applied 13 findings (4 Critical, 6 High, 3 Medium, 3 Low) before any code was written.

Three follow-ups filed:

- SMI-4550 — Migrate writer to `node:sqlite` to remove native dep entirely (Medium)
- SMI-4551 — Daily launchd probe for the operator-inactive failure mode (Low)
- SMI-4552 — Pre-push guard for host-side native binding presence (Medium)

## Test plan

- [x] `bash -n` parse on all 3 modified shell scripts
- [x] `scripts/repair-host-native-deps.sh` end-to-end: rebuild on a host with missing binding (17s); idempotent re-run (`[skip]` in <1s); verified `node_modules/better-sqlite3/build/Release/better_sqlite3.node` exists post-rebuild
- [x] `resolve_main_repo_root` unit tests: 4/4 — main repo path returns main; worktree path returns main (the critical fix); non-git path returns non-zero; path with spaces handled by `[[ ]]`
- [x] End-to-end hook test from worktree cwd: `.log` file written to `~/.claude/projects/-Users-...-skillsmith/session-priming.log` (main-repo encoded), NOT the worktree-encoded dir
- [x] `repair-worktrees.sh` runs end-to-end (1.0s total) with the new SMI-4549 step
- [x] `npm run audit:standards`: 50 passed, 5 warnings, 0 failed
- [x] Pre-commit hooks: prettier clean on `CLAUDE.md`; pre-push tests pass

Wave 1 smoke (post-merge, against main):

- [ ] On a fresh `npm install --ignore-scripts` host, `./scripts/repair-host-native-deps.sh` rebuilds and exits `[ok]`
- [ ] Re-run on healthy host exits `[skip]` in <1s
- [ ] Start a SessionStart-event session on `smi-*` branch; `sqlite3 .../retrieval-logs.db "SELECT … LIMIT 1"` returns a row with real UUID session_id and `hook_outcome='primed'`

Once those land, restart SMI-4498's 7-day soak window from this PR's merge SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
