### PR TITLE
fix(core): SMI-4556 pin web-tree-sitter@0.25.10 + SMI-4557 PR-matrix coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,13 @@ updates:
       - 'npm'
     reviewers:
       - 'ryansmith108'
+    ignore:
+      # SMI-4556: web-tree-sitter ≥ 0.26 fails to load Python grammar from
+      # tree-sitter-wasms (getDylinkMetadata throws — ABI/loader incompatibility).
+      # tree-sitter-wasms@0.1.13 is the latest and has not been rebuilt against
+      # tree-sitter 0.26.x. Re-evaluate when tree-sitter-wasms ≥ 0.2 ships.
+      - dependency-name: 'web-tree-sitter'
+        versions: ['>=0.26.0']
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,10 @@ Vitest only runs tests matching these patterns. Tests elsewhere are **silently i
 
 **Common mistakes**: `scripts/__tests__/` (use `scripts/tests/`), `packages/core/test/` (use `tests/` plural), `src/foo.test.ts` (must be inside a package). Reference: `vitest.config.ts`.
 
+**SMI-3502 split rationale**: colocated `packages/*/src/**/*.test.ts` tests run only in `vitest.config.root-tests.ts` (post-merge-verify). Per-package configs use `tests/**/*.test.ts` only — including `src/**` everywhere previously caused CI OOM at 147 files (vs 120 with memory benchmarks excluded).
+
+**SMI-4557 carve-out**: `packages/core/src/analysis/tree-sitter/**/*.test.ts` is included in `packages/core/vitest.config.ts` so PR matrix catches dependabot bumps to `web-tree-sitter` / `tree-sitter-*` deps before merge. Subtree is small (~4 files) and well below SMI-3502's 147-file OOM threshold. Driven by SMI-4556 — 0.26.x bump merged green and broke `post-merge-verify` for ~14 commits before detection.
+
 ---
 
 ## Skillsmith MCP Tools

--- a/package-lock.json
+++ b/package-lock.json
@@ -27927,6 +27927,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/web-vitals": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
@@ -28674,7 +28688,7 @@
         "stripe": "20.3.0",
         "tree-sitter-wasms": "0.1.13",
         "typescript": "5.9.3",
-        "web-tree-sitter": "0.26.8",
+        "web-tree-sitter": "0.25.10",
         "zod": "4.2.1"
       },
       "devDependencies": {
@@ -28701,12 +28715,6 @@
           "optional": true
         }
       }
-    },
-    "packages/core/node_modules/web-tree-sitter": {
-      "version": "0.26.8",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.8.tgz",
-      "integrity": "sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==",
-      "license": "MIT"
     },
     "packages/doc-retrieval-mcp": {
       "name": "@skillsmith/doc-retrieval-mcp",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@skillsmith/core` are documented here.
 
+## [Unreleased]
+
+- **Fix**: pin `web-tree-sitter` to 0.25.10 (revert dependabot bump #682). 0.26.x's WASM loader rejects the Python grammar binary published by `tree-sitter-wasms@0.1.13` — `getDylinkMetadata` throws inside `Language.load()`. Upstream `tree-sitter-wasms` has not been rebuilt against tree-sitter 0.26.x yet. (SMI-4556, closes #821)
+- **Test**: cover `src/analysis/tree-sitter/**/*.test.ts` in `packages/core/vitest.config.ts` so PR matrix catches future tree-sitter dep-bump regressions before merge — small carve-out from the SMI-3502 split (SMI-4557)
+
 ## v0.5.8
 
 - **Fix**: SMI-4563 native SQLite driver now installs automatically via npm `optionalDependencies` (was: silent WASM fallback on every fresh `npx` consumer). `better-sqlite3@11.10.0` is now declared optional so npm attempts native install on supported platforms; the WASM path remains a true fallback for hosts without a C toolchain.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,7 @@
     "stripe": "20.3.0",
     "tree-sitter-wasms": "0.1.13",
     "typescript": "5.9.3",
-    "web-tree-sitter": "0.26.8",
+    "web-tree-sitter": "0.25.10",
     "zod": "4.2.1"
   },
   "optionalDependencies": {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -4,7 +4,13 @@ import { sharedTestConfig, coverageDefaults } from '../../vitest.preset'
 export default defineConfig({
   test: {
     ...sharedTestConfig,
-    include: ['tests/**/*.test.ts'],
+    include: [
+      'tests/**/*.test.ts',
+      // SMI-4557: cover tree-sitter colocated tests in PR matrix to catch
+      // dependabot bumps to web-tree-sitter / tree-sitter-* deps before merge.
+      // Carve-out from SMI-3502 split — small subtree (~4 files), no CI OOM risk.
+      'src/analysis/tree-sitter/**/*.test.ts',
+    ],
     coverage: {
       ...coverageDefaults,
     },


### PR DESCRIPTION
## Summary

- **SMI-4556**: Pin `web-tree-sitter` to `0.25.10` (revert dependabot bump #682). Closes #821.
- **SMI-4557**: Carve out `src/analysis/tree-sitter/**` in `packages/core/vitest.config.ts` so PR matrix catches future tree-sitter dep-bump regressions.
- Dependabot ignore for `web-tree-sitter >=0.26.0` until `tree-sitter-wasms` ≥ 0.2 ships.

## Root cause

`web-tree-sitter@0.26.8` rejects the Python grammar binary published by `tree-sitter-wasms@0.1.13` (latest). Captured failure stack:

```text
Error:
    at failIf (web-tree-sitter.js:1927:28)
    at getDylinkMetadata (web-tree-sitter.js:1944:7)
    at Object.loadWebAssemblyModule (web-tree-sitter.js:2268:20)
    at Function.load (web-tree-sitter.js:1506:25)
    at PythonIncrementalParser.doInit (pythonIncremental.ts:301:24)
```

Classic ABI/loader incompatibility. `tree-sitter-wasms` upstream has not been rebuilt against tree-sitter 0.26.x. Forward-fix would require either a tree-sitter-wasms@0.2 (does not exist) or replacing the package with `tree-sitter-python` directly — both out of scope for the 1 SPARC-day time-box specified in the plan.

## Why this slipped past PR matrix

`vitest.config.root-tests.ts` includes `packages/*/src/**/*.test.ts` and only runs in `post-merge-verify.yml`. Per-package `packages/core/vitest.config.ts` did NOT include `src/**/*.test.ts` (SMI-3502 split, OOM at 147 files). The colocated `tree-sitter/*.test.ts` was invisible to PR CI. The carve-out in this PR closes that gap for `tree-sitter/**` specifically — ~4 files, well below SMI-3502's 147-file threshold.

## Test plan

- [x] `docker exec skillsmith-dev-1 npx vitest run -c vitest.config.root-tests.ts packages/core/src/analysis/tree-sitter/queryExtractionMatchesOrExceedsRegex.test.ts` — 12/12 passing post-fix (was 12/12 failing pre-fix on every commit since 2026-04-28)
- [x] `cd packages/core && npx vitest run -c vitest.config.ts src/analysis/tree-sitter/queryExtractionMatchesOrExceedsRegex.test.ts` — 12/12 passing under the new per-package include glob (regression guard works)
- [x] Pre-push hook ran full `packages/core` suite: 3539 passing, 2 skipped
- [ ] Watch `post-merge-verify` on merge — must be green within 15 min on the merge commit AND on the next post-merge commit. Rollback if either red within 4h.

## Plan / Linear

- Plan: `docs/internal/implementation/gh-issue-triage-2026-04-29.md`
- SMI-4556 (regression), SMI-4557 (regression guard)
- Sibling tickets in the same plan: SMI-4558 (security scan close-out → #702 + #789), SMI-4559 (drift hygiene → #676) — separate PRs

## What does NOT change

- `packages/core/src/analysis/tree-sitter/pythonIncremental.ts` is unchanged; the loader works correctly under 0.25.10.
- No public API changes.
- No behavioural changes to PR-matrix tests except adding the tree-sitter subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)