### PR TITLE
chore(governance): SMI-4592 retro fixes — smoke globs + vercel.json sync audit

### DIFF
--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2514,6 +2514,28 @@ console.log(`\n${BOLD}37. Workflow setup-node node-version drift (SMI-4489)${RES
   }
 }
 
+// SMI-4592: vercel.json sync — root vercel.json (used by git-integrated
+// preview/staging deploys when project rootDirectory=null) and
+// packages/website/vercel.json (used by `vercel --prod` from packages/website/)
+// must stay byte-identical. Drift would mean preview/staging and prod ship
+// different redirects/headers/CSP, and post-deploy smoke can only catch that
+// after the fact. This audit catches it pre-merge.
+console.log(`\n${BOLD}38. vercel.json sync (SMI-4592)${RESET}`)
+try {
+  const rootVercel = readFileSync('vercel.json', 'utf8').trim()
+  const websiteVercel = readFileSync('packages/website/vercel.json', 'utf8').trim()
+  if (rootVercel !== websiteVercel) {
+    fail(
+      'vercel.json drift between repo root and packages/website/',
+      'Run: cp packages/website/vercel.json vercel.json (or vice versa). The git-integrated deploy reads root vercel.json (rootDirectory=null on the Vercel project); `vercel --prod` from packages/website/ reads the website-local copy. They must match or staging and prod ship different redirects/headers.'
+    )
+  } else {
+    pass('vercel.json byte-identical between repo root and packages/website/')
+  }
+} catch (e) {
+  warn('Could not check vercel.json sync: ' + e.message)
+}
+
 // npm override drift check: @modelcontextprotocol/sdk override "." must match mcp-server range
 console.log(`\n${BOLD}Override Drift: @modelcontextprotocol/sdk${RESET}`)
 try {

--- a/scripts/smoke-prod/surfaces.json
+++ b/scripts/smoke-prod/surfaces.json
@@ -24,7 +24,9 @@
       "id": "website-homepage",
       "owner": "website",
       "trigger_globs": [
+        "vercel.json",
         "packages/website/vercel.json",
+        "packages/website/turbo.json",
         "packages/website/astro.config.mjs",
         "packages/website/package.json",
         "packages/website/src/pages/index.astro"


### PR DESCRIPTION
## Summary

Follow-up PR from SMI-4592 governance retro on the merged #859. Three findings fixed:

1. (Medium) `website-homepage` smoke surface `trigger_globs` missed the root `vercel.json` and `packages/website/turbo.json`. Future changes to either would have shipped without smoke coverage.
2. (Medium) Root and `packages/website/vercel.json` are byte-identical with no drift guard. Adds `audit:standards` Section 38 to enforce sync.
3. (High, doc) Backfilled the implementation plan in `docs/internal/implementation/smi-4592-vercel-output-directory.md` with a Review Summary showing planned vs shipped scope (1-line plan → 5 files / 12 commits / 5 distinct error classes).

Submodule companion: `docs/internal#smi-4592-retro` (3e6f6d8) — retro doc + backfilled plan + index resync.

## Test plan

- [ ] `audit:standards` Section 38 passes (vercel.json sync check)
- [ ] No regressions in other audit:standards sections
- [ ] `surfaces.json` schema validates (already JSON-valid)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)