### PR TITLE
feat(audit): SMI-4587 Wave 1 PR #2 — generic-token pass

### DIFF
--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 - **Bump**: `@skillsmith/core` dep range to `^0.5.8` — pulls in SMI-4563 native SQLite driver auto-install via `optionalDependencies`. mcp-server's own version unchanged; consumers picking up `core@0.5.8` will get the native driver on `npx` install instead of silently falling back to WASM.
 - **Feature**: SMI-4124 `skill_pack_audit` trigger-quality + namespace collision checks (PR #505).
-- **Feature**: SMI-4587 Wave 1 PR #1 — local-inventory scanner across 4 sources (skills/commands/agents/CLAUDE.md), ULID-based audit-history writer at `~/.skillsmith/audit-history/`, and exact-name collision detector. Adds `ulid@3.0.1` dependency. Internal scaffolding for the consumer namespace audit; no user-visible MCP tool changes yet (gated on Wave 1 completion).
+- **Feature**: SMI-4587 Wave 1 PR #1 — local-inventory scanner across 4 sources (skills/commands/agents/CLAUDE.md), ULID-based audit-history writer at `~/.skillsmith/audit-history/`, and exact-name collision detector. Adds `ulid@3.0.1` dependency. Internal scaffolding for the consumer namespace audit; no user-visible MCP tool changes yet (gated on Wave 1 completion). PR #2 wires the generic-token pass via the existing `detectGenericTriggerWords` helper from `skill-pack-audit.helpers.ts`, sharing the curated `GENERIC_TRIGGERS` stoplist and `derivePackDomain` mode-of-tags inference; results surface as `genericFlags` (severity `warning`) on the same `InventoryAuditResult`.
 
 ## v0.4.9
 

--- a/packages/mcp-server/src/audit/collision-detector.helpers.ts
+++ b/packages/mcp-server/src/audit/collision-detector.helpers.ts
@@ -1,16 +1,30 @@
 /**
  * @fileoverview Pure pass functions for the collision detector
- *               (SMI-4587 Wave 1 Step 4).
+ *               (SMI-4587 Wave 1 Steps 4–5).
  * @module @skillsmith/mcp-server/audit/collision-detector.helpers
  *
  * Each pass is a pure function over `InventoryEntry[]`. The orchestrator
- * (`collision-detector.ts`) wires them together. Generic + semantic
- * passes land in subsequent PRs; this PR ships the exact pass only.
+ * (`collision-detector.ts`) wires them together. Wave 1 PR1 shipped the
+ * exact-name pass; this file now also exposes the generic-token pass
+ * (Step 5). Semantic pass lands in a subsequent PR.
  */
 
+import { GENERIC_TRIGGERS } from '@skillsmith/core'
+
 import type { InventoryEntry } from '../utils/local-inventory.types.js'
-import type { ExactCollisionFlag } from './collision-detector.types.js'
+import type { AuditId, ExactCollisionFlag, GenericTokenFlag } from './collision-detector.types.js'
 import { deriveCollisionId } from './audit-history.js'
+import { derivePackDomain, detectGenericTriggerWords } from '../tools/skill-pack-audit.helpers.js'
+
+/**
+ * Stable pack-name input passed to {@link derivePackDomain} when running
+ * the generic-token pass over the user's local inventory. The user's
+ * `~/.claude/` install has no single pack name — using a non-suffixed
+ * sentinel forces `derivePackDomain` to fall through Strategy 1 (which
+ * keys off `-skills` suffixes) and rely on Strategy 2 (mode of per-entry
+ * tags). Centralized here so plan + tests share the same constant.
+ */
+export const LOCAL_INVENTORY_PACK_NAME = 'local-inventory'
 
 /**
  * Normalize an identifier for case-insensitive equality. Mirrors the
@@ -90,4 +104,60 @@ function describeCollision(entries: ReadonlyArray<InventoryEntry>): string {
   }
   const kindList = [...kinds].sort().join(' / ')
   return `${entries.length} entries (${kindList}) share the same identifier "${entries[0]?.identifier ?? ''}"`
+}
+
+/**
+ * Detect generic-trigger-word flags across the local inventory.
+ *
+ * Wraps {@link detectGenericTriggerWords} (the existing skill-pack-audit
+ * helper) and adapts the per-skill flag shape to this audit's
+ * {@link GenericTokenFlag}. Severity is always `warning` here — even
+ * skill-name hits, which the pack helper raises as `error`, are demoted
+ * to `warning` because the inventory audit is detection-only and the
+ * user's existing local install is grandfathered in (rename is opt-in
+ * via Wave 2's apply path).
+ *
+ * `packDomain` is computed once over the entire inventory using
+ * {@link derivePackDomain} with a stable sentinel pack name; Strategy 2
+ * (mode-of-tags) is the load-bearing branch since the user's inventory
+ * has no single pack name. The same `packDomain` is then passed into
+ * every per-entry call, so suggestions like `${packDomain}-${token}`
+ * are consistent across the report.
+ */
+export function detectGenericTokenFlags(
+  inventory: ReadonlyArray<InventoryEntry>,
+  auditId: AuditId
+): GenericTokenFlag[] {
+  const stoplist = GENERIC_TRIGGERS
+  const tagBag = inventory.map((e) => ({ tags: e.meta?.tags }))
+  const packDomain = derivePackDomain(LOCAL_INVENTORY_PACK_NAME, tagBag, stoplist)
+
+  const flags: GenericTokenFlag[] = []
+  for (const entry of inventory) {
+    const wordFlags = detectGenericTriggerWords(
+      entry.meta?.description,
+      entry.identifier,
+      packDomain,
+      stoplist
+    )
+    for (const wf of wordFlags) {
+      flags.push({
+        kind: 'generic',
+        collisionId: deriveCollisionId(auditId, [entry]),
+        identifier: entry.identifier,
+        entry,
+        matchedTokens: [wf.token],
+        severity: 'warning',
+        reason: wf.reason,
+      })
+    }
+  }
+
+  // Stable ordering for downstream consumers: identifier asc, then token asc.
+  flags.sort((a, b) => {
+    const byId = a.identifier.localeCompare(b.identifier)
+    if (byId !== 0) return byId
+    return (a.matchedTokens[0] ?? '').localeCompare(b.matchedTokens[0] ?? '')
+  })
+  return flags
 }

--- a/packages/mcp-server/src/audit/collision-detector.ts
+++ b/packages/mcp-server/src/audit/collision-detector.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Three-pass collision detector for the consumer namespace
- *               audit. Wave 1 PR1 (this file) ships the exact-name pass
- *               only; generic + semantic passes land in subsequent PRs.
+ *               audit. Wave 1 PR1+PR2 ship the exact + generic passes;
+ *               semantic lands in a subsequent PR.
  * @module @skillsmith/mcp-server/audit/collision-detector
  * @see SMI-4587
  *
@@ -11,7 +11,7 @@
 
 import type { InventoryEntry } from '../utils/local-inventory.types.js'
 import type { InventoryAuditResult } from './collision-detector.types.js'
-import { detectExactCollisions } from './collision-detector.helpers.js'
+import { detectExactCollisions, detectGenericTokenFlags } from './collision-detector.helpers.js'
 import { newAuditId } from './audit-history.js'
 
 export interface DetectCollisionsOptions {
@@ -24,12 +24,12 @@ export interface DetectCollisionsOptions {
 }
 
 /**
- * Run the (currently exact-only) collision-detection passes over an
+ * Run the exact + generic-token collision-detection passes over an
  * inventory snapshot.
  *
- * Generic-token + semantic passes return empty arrays in this PR — the
- * surface is stable, so Wave 2/3/4 can consume it now while Steps 5–6
- * land in subsequent PRs.
+ * Semantic-overlap pass returns an empty array in this PR — the surface
+ * is stable, so Wave 2/3/4 can consume it now while Step 6 lands in a
+ * subsequent PR.
  */
 export async function detectCollisions(
   inventory: ReadonlyArray<InventoryEntry>,
@@ -42,8 +42,11 @@ export async function detectCollisions(
   const exactCollisions = detectExactCollisions(inventory, auditId)
   const exactDuration = nsToMs(process.hrtime.bigint() - exactStart)
 
-  // Step 5/6 placeholders — empty arrays until subsequent PRs.
-  const genericFlags: InventoryAuditResult['genericFlags'] = []
+  const genericStart = process.hrtime.bigint()
+  const genericFlags = detectGenericTokenFlags(inventory, auditId)
+  const genericDuration = nsToMs(process.hrtime.bigint() - genericStart)
+
+  // Step 6 placeholder — empty array until the semantic-pass PR lands.
   const semanticCollisions: InventoryAuditResult['semanticCollisions'] = []
 
   const totalDuration = nsToMs(process.hrtime.bigint() - startedAt)
@@ -64,7 +67,7 @@ export async function detectCollisions(
       durationMs: totalDuration,
       passDurations: {
         exact: exactDuration,
-        generic: 0,
+        generic: genericDuration,
         semantic: 0,
       },
     },
@@ -84,4 +87,4 @@ export type {
   InventoryAuditResult,
   SemanticCollisionFlag,
 } from './collision-detector.types.js'
-export { detectExactCollisions } from './collision-detector.helpers.js'
+export { detectExactCollisions, detectGenericTokenFlags } from './collision-detector.helpers.js'

--- a/packages/mcp-server/tests/unit/collision-detector.test.ts
+++ b/packages/mcp-server/tests/unit/collision-detector.test.ts
@@ -1,14 +1,18 @@
 /**
- * Unit tests for SMI-4587 Wave 1 Step 4 — exact-name collision detector.
+ * Unit tests for SMI-4587 Wave 1 Steps 4–5 — exact-name + generic-token
+ * collision detector passes.
  *
- * Generic + semantic passes (Steps 5-6) land in subsequent PRs; their
- * tests in the plan's §Tests block are wrapped as `.skip` here with a
- * comment referencing the next PR.
+ * The semantic pass (Step 6) lands in a subsequent PR; its tests in the
+ * plan's §Tests block are wrapped as `.skip` here with a comment.
  */
 
 import { describe, expect, it } from 'vitest'
 
-import { detectCollisions, detectExactCollisions } from '../../src/audit/collision-detector.js'
+import {
+  detectCollisions,
+  detectExactCollisions,
+  detectGenericTokenFlags,
+} from '../../src/audit/collision-detector.js'
 import { newAuditId } from '../../src/audit/audit-history.js'
 import type { InventoryEntry } from '../../src/utils/local-inventory.types.js'
 
@@ -133,12 +137,43 @@ describe('detectCollisions (orchestrator)', () => {
     expect(result.summary.totalFlags).toBe(1)
   })
 
-  it('genericFlags + semanticCollisions are empty placeholders in this PR', async () => {
+  it('semanticCollisions remains an empty placeholder until the semantic-pass PR lands', async () => {
     const result = await detectCollisions([entry({ identifier: 'x' })])
-    expect(result.genericFlags).toEqual([])
     expect(result.semanticCollisions).toEqual([])
-    expect(result.summary.passDurations.generic).toBe(0)
     expect(result.summary.passDurations.semantic).toBe(0)
+  })
+
+  it('genericFlags is populated when entries carry generic-trigger names', async () => {
+    const result = await detectCollisions([
+      entry({ identifier: 'ship', source_path: '/skills/ship/SKILL.md' }),
+    ])
+    expect(result.genericFlags.length).toBeGreaterThan(0)
+    expect(result.genericFlags[0]?.kind).toBe('generic')
+    expect(result.summary.warningCount).toBe(result.genericFlags.length)
+  })
+
+  it('genericFlags is empty for non-generic identifiers + descriptions', async () => {
+    const result = await detectCollisions([
+      entry({
+        identifier: 'kubernetes-helm-release',
+        meta: { description: 'Manage Helm release rollouts on Kubernetes clusters.' },
+      }),
+      entry({
+        identifier: 'terraform-stack',
+        meta: { description: 'Provision Terraform stacks across cloud accounts.' },
+      }),
+    ])
+    expect(result.genericFlags).toEqual([])
+  })
+
+  it('records generic-pass duration in passDurations.generic when flags are produced', async () => {
+    const result = await detectCollisions([
+      entry({ identifier: 'ship', source_path: '/a' }),
+      entry({ identifier: 'review', source_path: '/b' }),
+    ])
+    expect(result.genericFlags.length).toBeGreaterThan(0)
+    expect(result.summary.passDurations.generic).toBeGreaterThanOrEqual(0)
+    expect(result.summary.durationMs).toBeGreaterThanOrEqual(result.summary.passDurations.generic)
   })
 
   it('empty inventory produces empty result', async () => {
@@ -158,13 +193,105 @@ describe('detectCollisions (orchestrator)', () => {
   })
 })
 
-// Generic + semantic pass tests are deferred to subsequent PRs.
-// See plan §Tests / `collision-detector.test.ts` cases 3-8, 10, 12.
-describe.skip('generic-token + semantic passes (subsequent PRs)', () => {
-  it.skip('Step 5: generic-token via detectGenericTriggerWords (next PR)', () => {
-    /* implemented in SMI-4587 Wave 1 PR2 */
+describe('detectGenericTokenFlags (generic-token pass)', () => {
+  it('flags a stoplist token used as a skill name with severity=warning', () => {
+    const auditId = newAuditId()
+    const inv = [entry({ identifier: 'ship', source_path: '/skills/ship/SKILL.md' })]
+    const flags = detectGenericTokenFlags(inv, auditId)
+    expect(flags).toHaveLength(1)
+    const flag = flags[0]!
+    expect(flag.kind).toBe('generic')
+    expect(flag.identifier).toBe('ship')
+    expect(flag.matchedTokens).toEqual(['ship'])
+    expect(flag.severity).toBe('warning')
+    expect(flag.collisionId).toMatch(/^[0-9a-f]{16}$/)
+    expect(flag.entry.source_path).toBe('/skills/ship/SKILL.md')
   })
+
+  it('flags generic tokens that appear in the description', () => {
+    const auditId = newAuditId()
+    const inv = [
+      entry({
+        identifier: 'kubernetes-helm-release',
+        source_path: '/skills/k8s-helm/SKILL.md',
+        meta: { description: 'Use this skill to ship rollouts to clusters.' },
+      }),
+    ]
+    const flags = detectGenericTokenFlags(inv, auditId)
+    // At least one flag for the description hit "ship"; pack helper may also
+    // surface other generic tokens like "use" depending on the curated list.
+    expect(flags.length).toBeGreaterThan(0)
+    expect(flags.every((f) => f.kind === 'generic')).toBe(true)
+    expect(flags.some((f) => f.matchedTokens.includes('ship'))).toBe(true)
+  })
+
+  it('returns empty when no entries hit the stoplist', () => {
+    const auditId = newAuditId()
+    const inv = [
+      entry({
+        identifier: 'kubernetes-helm-release',
+        meta: {
+          description: 'Manage Helm release rollouts across Kubernetes clusters.',
+        },
+      }),
+      entry({
+        identifier: 'terraform-stack-apply',
+        meta: { description: 'Apply Terraform stack changes for cloud infrastructure.' },
+      }),
+    ]
+    expect(detectGenericTokenFlags(inv, auditId)).toEqual([])
+  })
+
+  it('uses derivePackDomain so the suggested rename reflects mode-of-tags', () => {
+    const auditId = newAuditId()
+    const inv = [
+      entry({
+        identifier: 'plan-roadmap',
+        source_path: '/a',
+        meta: { tags: ['planning'] },
+      }),
+      entry({
+        identifier: 'plan-okrs',
+        source_path: '/b',
+        meta: { tags: ['planning'] },
+      }),
+      entry({
+        identifier: 'misc-helper',
+        source_path: '/c',
+        meta: { tags: ['misc'] },
+      }),
+      // Generic-name skill — should pick up "planning-ship" as the suggestion
+      // because the inferred packDomain is "planning".
+      entry({ identifier: 'ship', source_path: '/d', meta: { tags: ['planning'] } }),
+    ]
+    const flags = detectGenericTokenFlags(inv, auditId)
+    const shipFlag = flags.find((f) => f.identifier === 'ship')
+    expect(shipFlag).toBeDefined()
+    expect(shipFlag?.reason).toContain('planning-ship')
+  })
+
+  it('produces deterministic ordering by identifier then matched token', () => {
+    const auditId = newAuditId()
+    const inv = [
+      entry({ identifier: 'ship', source_path: '/a' }),
+      entry({ identifier: 'review', source_path: '/b' }),
+    ]
+    const flags = detectGenericTokenFlags(inv, auditId)
+    const ids = flags.map((f) => f.identifier)
+    const sorted = [...ids].sort()
+    expect(ids).toEqual(sorted)
+  })
+
+  it('returns empty for an empty inventory', () => {
+    const auditId = newAuditId()
+    expect(detectGenericTokenFlags([], auditId)).toEqual([])
+  })
+})
+
+// Semantic-pass tests are deferred to a subsequent PR.
+// See plan §Tests / `collision-detector.test.ts` case 12.
+describe.skip('semantic pass (subsequent PR)', () => {
   it.skip('Step 6: semantic via OverlapDetector (next PR)', () => {
-    /* implemented in SMI-4587 Wave 1 PR2 */
+    /* implemented in a follow-up PR */
   })
 })


### PR DESCRIPTION
## Summary

Step 5 of the SMI-4587 consumer-namespace audit. Wires the generic-token detection pass into the inventory collision detector by reusing the existing `detectGenericTriggerWords` + `derivePackDomain` helpers from `packages/mcp-server/src/tools/skill-pack-audit.helpers.ts` and the curated `GENERIC_TRIGGERS` stoplist from `@skillsmith/core`.

- New `detectGenericTokenFlags(inventory, auditId)` in `collision-detector.helpers.ts`. Computes one `packDomain` over the entire inventory via `derivePackDomain` (Strategy 2 — mode of per-entry tags), then maps each `GenericWordFlag` to the audit's `GenericTokenFlag` shape with `severity: 'warning'` and a per-entry `collisionId`.
- `detectCollisions` no longer hard-codes `genericFlags: []`; the pass is timed and surfaces in `summary.passDurations.generic`.
- Re-exports `detectGenericTokenFlags` from `collision-detector.ts` so consumers can invoke the pass in isolation (mirrors Step 4's `detectExactCollisions` export).

Stacked on PR #860 (Wave 1 PR #1) per SMI-2597 — branch `smi-4587-wave1-step5-generic-token` is based on `smi-4587-wave1-step1-4-types-scanner-exact`.

Closes part of SMI-4587.

## Boundaries (deliberately out of scope)

- `OverlapDetector` semantic pass — Step 6 (PR #3)
- `audit_mode` resolver wiring — Step 6b (PR #3)
- Telemetry emit — Step 8a (PR #4)
- Submodule pointer bump — handled at merge time

## Test plan

| File | Result |
|---|---|
| `packages/mcp-server/tests/unit/collision-detector.test.ts` | 22 passed, 1 skipped (semantic-pass placeholder) |
| `packages/mcp-server/tests/unit/skill-pack-audit.test.ts` | 35 passed (no regression — shared helpers untouched) |

New cases (9 total):

- `detectGenericTokenFlags` — flags stoplist token used as skill name → severity `warning` + `collisionId` matches `^[0-9a-f]{16}$`
- description-only generic hit → `kind: 'generic'`, `matchedTokens` includes the token
- non-generic name + description → empty `genericFlags`
- mode-of-tags `packDomain` derivation → `ship` collision suggests `planning-ship` via `reason`
- deterministic ordering (identifier asc, then matched token asc)
- empty inventory → `[]`
- `detectCollisions` orchestrator: `genericFlags` populated when entries hit stoplist
- `detectCollisions` orchestrator: `genericFlags` empty for non-generic inputs
- `detectCollisions` orchestrator: `summary.passDurations.generic` recorded

## Verification

- [x] `vitest run packages/mcp-server/tests/unit/collision-detector.test.ts` — 22 passed, 1 skipped
- [x] `vitest run packages/mcp-server/tests/unit/skill-pack-audit.test.ts` — 35 passed (no regression)
- [x] `npm run -w @skillsmith/mcp-server build` — tsc clean
- [x] `npm run lint` — zero errors, zero warnings
- [x] `npm run audit:standards` — 51 passed, 5 pre-existing warnings, 0 failed
- [x] `npm run format:check` — all 3 changed files prettier-formatted
- [x] File-length budget — `collision-detector.helpers.ts` 167 LOC (< 500)

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)