### PR TITLE
feat(mcp-server): SMI-4588 namespace overrides ledger + shared audit types (Wave 2 PR 1/4)

### DIFF
--- a/packages/mcp-server/src/audit/index.ts
+++ b/packages/mcp-server/src/audit/index.ts
@@ -56,3 +56,31 @@ export type {
   InventoryAuditResult,
   SemanticCollisionFlag,
 } from './collision-detector.types.js'
+
+// SMI-4588 Wave 2 PR #1 — namespace-overrides ledger surface.
+export {
+  appendOverride,
+  findOverride,
+  readLedger,
+  readLedgerResult,
+  writeLedger,
+} from './namespace-overrides.js'
+
+export type { LedgerPathOptions } from './namespace-overrides.js'
+
+export { CURRENT_VERSION as NAMESPACE_OVERRIDES_CURRENT_VERSION } from './namespace-overrides.types.js'
+
+export type {
+  LedgerVersion,
+  LedgerVersionUnsupportedError,
+  OverrideRecord,
+  OverridesLedger,
+  ReadLedgerResult,
+} from './namespace-overrides.types.js'
+
+// SMI-4588 Wave 2 PR #1 — shared namespace-audit types (PRs #3/#4 consumers).
+export type {
+  NamespaceWarning,
+  PendingCollision,
+  RenameSuggestionRef,
+} from './namespace-audit.types.js'

--- a/packages/mcp-server/src/audit/namespace-audit.types.ts
+++ b/packages/mcp-server/src/audit/namespace-audit.types.ts
@@ -1,0 +1,110 @@
+/**
+ * @fileoverview Shared namespace-audit type vocabulary (SMI-4588 Wave 2 Step 1, PR #1).
+ * @module @skillsmith/mcp-server/audit/namespace-audit.types
+ *
+ * `NamespaceWarning` and `PendingCollision` live here — not in
+ * `tools/install.types.ts` and not in `audit/install-preflight.ts` — to break
+ * the `tools → audit → tools` cycle that would otherwise form between
+ * `install-preflight.ts` (which constructs them) and `install.types.ts`
+ * (which embeds them in `InstallResult`). The shared file is depended on by
+ * both sides; neither side depends on the other.
+ *
+ * Wave 2 plan §4 + Edit 3 — placed in Step 1 so PRs #3/#4 import without
+ * rework.
+ *
+ * Forward-declaration note: `RenameSuggestion` lands in
+ * `./rename-engine.types.ts` in PR #2 of the Wave 2 stack. PR #1 ships only
+ * the ledger reader/writer, which does not reference `NamespaceWarning` or
+ * `PendingCollision`. To avoid a phantom dependency on a not-yet-shipped
+ * file, the suggestion field is typed structurally below using
+ * `RenameSuggestionRef` — a minimal shape pinned to the spec in plan §1.
+ * PR #2 replaces the ref with `import type { RenameSuggestion } from
+ * './rename-engine.types.js'`; both shapes are structurally compatible.
+ */
+
+import type { CollisionId } from './collision-detector.types.js'
+
+/**
+ * Forward-declaration shim for `RenameSuggestion` (defined in
+ * `./rename-engine.types.ts` as of Wave 2 PR #2). The shape mirrors the spec
+ * in `docs/internal/implementation/smi-4588-rename-engine-ledger-install.md`
+ * §1 verbatim. PR #2 widens this into the full canonical type and replaces
+ * the alias below with a direct import.
+ */
+export interface RenameSuggestionRef {
+  collisionId: CollisionId
+  /** `'rename_command_file' | 'rename_agent_file' | 'rename_skill_dir_and_frontmatter'`. */
+  applyAction: string
+  currentName: string
+  /** First non-colliding candidate from `generateSuggestionChain`. */
+  suggested: string
+  reason: string
+}
+
+/**
+ * A non-blocking namespace collision surfaced by the install pre-flight
+ * (Wave 2 PR #3). `power_user` and `governance` modes return one of these
+ * per detected collision in `InstallResult.warnings[]`; the agent surfaces
+ * the suggestion to the user but the install still proceeds.
+ */
+export interface NamespaceWarning {
+  /** Stable across audit runs — derived via `deriveCollisionId`. */
+  collisionId: CollisionId
+  /** Matches the source collision flag's `kind`. */
+  kind: 'exact' | 'generic' | 'semantic'
+  /** Always `'warning'` — `NamespaceWarning` never blocks install. */
+  severity: 'warning'
+  /** User-facing message (rendered verbatim to the agent). */
+  message: string
+  /**
+   * Suggested rename for the agent to surface. Constructed by
+   * `generateRenameSuggestions` (Wave 2 PR #2). Walking the suggestion
+   * chain is the agent's job — `suggestion` is the first non-colliding
+   * candidate.
+   */
+  suggestion: RenameSuggestionRef
+  /**
+   * FK to the audit history written by `runInstallPreflight` (PR #3). Lets
+   * a later `apply_namespace_rename` call (Wave 4) re-read the original
+   * suggestion without re-running detection.
+   */
+  auditId: string
+}
+
+/**
+ * Blocking-mode envelope for `audit_mode: 'preventative'` installs (Wave 2
+ * PR #3, decision #2). When pre-flight detects a collision, `install_skill`
+ * returns `installComplete: false` plus this envelope. The agent calls
+ * `apply_namespace_rename({ auditId, action: 'apply' })` (Wave 4) and then
+ * re-invokes `install_skill`.
+ *
+ * The `suggestionChain[]` carries up to 3 ordered candidates per
+ * decision #11; the agent walks the chain and picks the first non-colliding
+ * one. `chainExhausted` is `true` when all 3 collide and the agent must
+ * escalate to the human via `customName`.
+ */
+export interface PendingCollision {
+  /** ULID — passed back to `apply_namespace_rename`. */
+  auditId: string
+  /**
+   * First non-colliding candidate from `generateSuggestionChain`. The agent
+   * surfaces this to the user as the recommended rename.
+   */
+  suggestedRename: RenameSuggestionRef
+  /**
+   * Up to 3 candidates from `generateSuggestionChain` (decision #11). The
+   * agent has the full chain so it can present alternatives without
+   * re-querying.
+   */
+  suggestionChain: string[]
+  /**
+   * `true` when all 3 chain candidates collide. The agent must escalate to
+   * the human and call `apply_namespace_rename({ customName: '…' })`.
+   */
+  chainExhausted: boolean
+  /**
+   * Human-readable remediation hint, e.g.
+   * `"call apply_namespace_rename({ auditId, action: 'apply' }) then re-invoke install_skill"`.
+   */
+  remediationHint: string
+}

--- a/packages/mcp-server/src/audit/namespace-overrides.ts
+++ b/packages/mcp-server/src/audit/namespace-overrides.ts
@@ -1,0 +1,256 @@
+/**
+ * @fileoverview Atomic reader/writer for the namespace-overrides ledger
+ *               (SMI-4588 Wave 2 Step 1, PR #1).
+ * @module @skillsmith/mcp-server/audit/namespace-overrides
+ *
+ * Persists `~/.skillsmith/namespace-overrides.json` — the load-bearing
+ * artifact that makes consumer-side namespace renames durable across pack
+ * version bumps. Conceptually equivalent to git's `rerere` but for
+ * namespace identifiers.
+ *
+ * Atomicity: every write goes through `<path>.tmp` + `fs.rename`. On read,
+ * a missing file degrades gracefully to an empty ledger; malformed JSON
+ * surfaces as a typed `namespace.ledger.malformed` discriminator (the
+ * caller decides whether to log + reset, never silently). A
+ * higher-than-supported `version` returns
+ * `namespace.ledger.version_unsupported` rather than a silent empty
+ * ledger — see plan §2 Edit 6.
+ *
+ * Concurrent-write boundary: last-write-wins on a single Node event loop
+ * via `<path>.tmp` + `fs.rename`. Multi-process scenarios (two MCP
+ * instances on the same machine) can lose one write under a tight race;
+ * documented as a known limitation in the plan. If multi-process safety
+ * becomes load-bearing, a future revision adds advisory locking via
+ * `proper-lockfile`.
+ */
+
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { ulid } from 'ulid'
+
+import {
+  CURRENT_VERSION,
+  type LedgerVersionUnsupportedError,
+  type OverrideRecord,
+  type OverridesLedger,
+  type ReadLedgerResult,
+} from './namespace-overrides.types.js'
+
+const DEFAULT_LEDGER_PATH = path.join(os.homedir(), '.skillsmith', 'namespace-overrides.json')
+
+const ULID_PREFIX = 'ovr_'
+
+export interface LedgerPathOptions {
+  /** Override the ledger path (default `~/.skillsmith/namespace-overrides.json`). */
+  ledgerPath?: string
+}
+
+/**
+ * Empty ledger sentinel — used when the file is missing or malformed.
+ * Returned by value so callers never share state with a private const.
+ */
+function emptyLedger(): OverridesLedger {
+  return { version: CURRENT_VERSION, overrides: [] }
+}
+
+/**
+ * Read the ledger from disk and return a tagged union. Missing file →
+ * `{ kind: 'ok', ledger: <empty> }`. Malformed JSON →
+ * `{ kind: 'namespace.ledger.malformed', reason }`. `version > CURRENT_VERSION`
+ * → `{ kind: 'namespace.ledger.version_unsupported', found, expected }`.
+ *
+ * Callers that want the simpler "read or empty" semantics should use
+ * `readLedger()` (below) which collapses the discriminator.
+ */
+export async function readLedgerResult(opts: LedgerPathOptions = {}): Promise<ReadLedgerResult> {
+  const ledgerPath = opts.ledgerPath ?? DEFAULT_LEDGER_PATH
+
+  let raw: string
+  try {
+    raw = await fs.readFile(ledgerPath, 'utf-8')
+  } catch (err) {
+    // ENOENT — missing file degrades to an empty ledger. Anything else
+    // (permission denied, EISDIR, etc.) bubbles as malformed so the
+    // caller can decide whether to alert.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { kind: 'ok', ledger: emptyLedger() }
+    }
+    return {
+      kind: 'namespace.ledger.malformed',
+      reason: `read failed: ${(err as Error).message}`,
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    return {
+      kind: 'namespace.ledger.malformed',
+      reason: `parse failed: ${(err as Error).message}`,
+    }
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { kind: 'namespace.ledger.malformed', reason: 'top-level is not an object' }
+  }
+
+  const candidate = parsed as Partial<OverridesLedger>
+  const versionValue = candidate.version
+  if (typeof versionValue !== 'number' || !Number.isInteger(versionValue) || versionValue < 1) {
+    return {
+      kind: 'namespace.ledger.malformed',
+      reason: `invalid version: ${String(versionValue)}`,
+    }
+  }
+
+  if (versionValue > CURRENT_VERSION) {
+    return {
+      kind: 'namespace.ledger.version_unsupported',
+      found: versionValue,
+      expected: CURRENT_VERSION,
+    } satisfies LedgerVersionUnsupportedError
+  }
+
+  if (!Array.isArray(candidate.overrides)) {
+    return { kind: 'namespace.ledger.malformed', reason: 'overrides is not an array' }
+  }
+
+  // Shape verified; cast back to the canonical type. Per-record validation
+  // is intentionally minimal — additive future fields are preserved by the
+  // writer's read-modify-write cycle.
+  return {
+    kind: 'ok',
+    ledger: { version: CURRENT_VERSION, overrides: candidate.overrides as OverrideRecord[] },
+  }
+}
+
+/**
+ * Convenience wrapper: returns the ledger directly, collapsing the
+ * `malformed` branch to an empty ledger plus a `console.warn`. Higher-
+ * version files still bubble a thrown error — silently empty-ing a
+ * higher-version ledger would corrupt forward-compat (plan §2 Edit 6).
+ *
+ * For callers that need the typed discriminator, use `readLedgerResult`.
+ */
+export async function readLedger(opts: LedgerPathOptions = {}): Promise<OverridesLedger> {
+  const result = await readLedgerResult(opts)
+  switch (result.kind) {
+    case 'ok':
+      return result.ledger
+    case 'namespace.ledger.malformed':
+      // Malformed → degrade to empty + warn. Install must not break.
+      console.warn(`[namespace-overrides] ledger malformed (${result.reason}); using empty ledger`)
+      return emptyLedger()
+    case 'namespace.ledger.version_unsupported': {
+      // Higher-version file: bubble as a typed error — silently empty-ing
+      // would shadow the user's persisted renames on a downgrade.
+      const err = new Error(
+        `namespace-overrides ledger version ${String(result.found)} is newer than supported version ${String(result.expected)}`
+      ) as Error & { kind: typeof result.kind; found: number; expected: number }
+      err.kind = result.kind
+      err.found = result.found
+      err.expected = result.expected
+      throw err
+    }
+    default: {
+      // Exhaustiveness — TS verifies via `never`.
+      const _exhaustive: never = result
+      throw new Error(`unreachable: ${String(_exhaustive)}`)
+    }
+  }
+}
+
+/**
+ * Write the ledger atomically: `<path>.tmp` + `fs.rename`. Creates the
+ * parent directory on first run with `recursive: true` (mirrors
+ * audit-history.ts E-MISS-2 fix).
+ */
+export async function writeLedger(
+  ledger: OverridesLedger,
+  opts: LedgerPathOptions = {}
+): Promise<void> {
+  const ledgerPath = opts.ledgerPath ?? DEFAULT_LEDGER_PATH
+  // Per-call unique tmp path: two concurrent writers must not clobber
+  // each other's staging file (a fixed `<path>.tmp` would race on the
+  // writeFile + rename interleaving and surface as ENOENT on rename).
+  // The unique suffix preserves last-write-wins on the rename target
+  // while making the staging step independent.
+  const tmpSuffix = crypto.randomBytes(6).toString('hex')
+  const tmpPath = `${ledgerPath}.${tmpSuffix}.tmp`
+
+  await fs.mkdir(path.dirname(ledgerPath), { recursive: true })
+
+  // Always serialize at CURRENT_VERSION; readers gate on it.
+  const normalized: OverridesLedger = { version: CURRENT_VERSION, overrides: ledger.overrides }
+  const json = JSON.stringify(normalized, null, 2)
+  try {
+    await fs.writeFile(tmpPath, json, 'utf-8')
+    await fs.rename(tmpPath, ledgerPath)
+  } catch (err) {
+    // Best-effort cleanup of stranded tmp file. ENOENT here is fine —
+    // the rename may have already moved the tmp out from under us.
+    try {
+      await fs.rm(tmpPath, { force: true })
+    } catch {
+      // swallow
+    }
+    throw err
+  }
+}
+
+/**
+ * Pure helper: append a new override to a ledger and return a new copy.
+ * Original ledger is not mutated. The caller is responsible for
+ * persisting the result via `writeLedger` (separation of concerns —
+ * tests can build ledgers without touching disk).
+ *
+ * Idempotency: if an override with the same
+ * `(skillId, kind, originalIdentifier, renamedTo)` quadruple already
+ * exists, the input is returned unchanged. The caller can detect the
+ * no-op by reference equality (`appended === ledger`).
+ */
+export function appendOverride(
+  ledger: OverridesLedger,
+  override: Omit<OverrideRecord, 'id' | 'appliedAt'>
+): OverridesLedger {
+  const duplicate = ledger.overrides.find(
+    (existing) =>
+      existing.skillId === override.skillId &&
+      existing.kind === override.kind &&
+      existing.originalIdentifier === override.originalIdentifier &&
+      existing.renamedTo === override.renamedTo
+  )
+  if (duplicate) {
+    return ledger
+  }
+
+  const fullRecord: OverrideRecord = {
+    ...override,
+    id: `${ULID_PREFIX}${ulid()}`,
+    appliedAt: new Date().toISOString(),
+  }
+  return { version: ledger.version, overrides: [...ledger.overrides, fullRecord] }
+}
+
+/**
+ * Pure lookup: find an override by `(skillId, kind, originalIdentifier)`.
+ * `skillId` may be omitted for local/unregistered artifacts; in that case
+ * only `kind` + `originalIdentifier` are matched. Returns the first match
+ * or `null`.
+ */
+export function findOverride(
+  ledger: OverridesLedger,
+  query: { skillId?: string | null; kind?: OverrideRecord['kind']; originalIdentifier: string }
+): OverrideRecord | null {
+  const match = ledger.overrides.find((entry) => {
+    if (entry.originalIdentifier !== query.originalIdentifier) return false
+    if (query.kind !== undefined && entry.kind !== query.kind) return false
+    if (query.skillId !== undefined && entry.skillId !== query.skillId) return false
+    return true
+  })
+  return match ?? null
+}

--- a/packages/mcp-server/src/audit/namespace-overrides.types.ts
+++ b/packages/mcp-server/src/audit/namespace-overrides.types.ts
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview Type vocabulary for the namespace-overrides ledger
+ *               (SMI-4588 Wave 2 Step 1, PR #1).
+ * @module @skillsmith/mcp-server/audit/namespace-overrides.types
+ *
+ * Schema for `~/.skillsmith/namespace-overrides.json`. Modeled on the
+ * dependency-intelligence persistence pattern (SMI-3137). The schema is
+ * versioned; `CURRENT_VERSION` is bumped only when the on-disk shape
+ * changes incompatibly. Reader/writer live in `./namespace-overrides.ts`.
+ *
+ * Plan: docs/internal/implementation/smi-4588-rename-engine-ledger-install.md §2.
+ */
+
+import type { InventoryKind } from '../utils/local-inventory.types.js'
+
+/**
+ * Current ledger schema version. Bumped only when the on-disk shape
+ * changes incompatibly. Read-path behavior:
+ *
+ * - `version === CURRENT_VERSION` → return as-is.
+ * - `version < CURRENT_VERSION` → caller may run a `migrateLedger` shim
+ *   (currently no historical versions exist, so any value below 1 is
+ *   unreachable in practice).
+ * - `version > CURRENT_VERSION` → reader returns a typed
+ *   `namespace.ledger.version_unsupported` error rather than silently
+ *   degrading to an empty ledger (plan §2 Edit 6).
+ */
+export const CURRENT_VERSION = 1 as const
+
+export type LedgerVersion = typeof CURRENT_VERSION
+
+/**
+ * One applied rename. Persisted in `~/.skillsmith/namespace-overrides.json`
+ * under `overrides[]`. ULID `id` lets later operations (revert, replay,
+ * forensics) reference the entry without depending on `(skillId, kind,
+ * originalIdentifier)` triple equality.
+ */
+export interface OverrideRecord {
+  /** ULID prefixed with `ovr_` for log-grep readability. */
+  id: string
+  /**
+   * Skillsmith manifest skill id (`<author>/<name>`) when the renamed
+   * artifact is a registered skill, else `null` for local/unregistered
+   * commands and agents.
+   */
+  skillId: string | null
+  /**
+   * Which inventory kind this override applies to. Mirrors
+   * `InventoryKind` from local-inventory so a single ledger covers skills,
+   * commands, agents, and CLAUDE.md rules (the last for future use; Wave 2
+   * does not write claude_md_rule entries).
+   */
+  kind: InventoryKind
+  /**
+   * The original triggering identifier — e.g. `/ship` for a command,
+   * `code-review` for a skill name. This is the field the install-time
+   * ledger replay matches against when deciding whether to re-apply a
+   * rename.
+   */
+  originalIdentifier: string
+  /**
+   * The chosen renamed identifier — e.g. `/anthropic-ship`,
+   * `anthropic-code-review`.
+   */
+  renamedTo: string
+  /** Absolute path to the original on-disk artifact at apply time. */
+  originalPath: string
+  /** Absolute path to the renamed on-disk artifact post-apply. */
+  renamedPath: string
+  /** ISO-8601 timestamp recorded by the writer (UTC). */
+  appliedAt: string
+  /**
+   * FK to `~/.skillsmith/audits/<auditId>/result.json`. Lets a forensic
+   * lookup re-derive the original collision context.
+   */
+  auditId: string
+  /**
+   * Human-readable reason — e.g.
+   * `"collision with skillsmith/release-tools /ship"`. Surfaced verbatim
+   * in the audit-report writer (Wave 2 PR #4 extension).
+   */
+  reason: string
+}
+
+/**
+ * On-disk shape of `~/.skillsmith/namespace-overrides.json`.
+ *
+ * `version` is required and validated on read. Unknown future fields are
+ * preserved on read-modify-write at the writer layer (additive
+ * extensions don't break older clients), but any `version` strictly
+ * greater than `CURRENT_VERSION` triggers a typed error per plan §2.
+ */
+export interface OverridesLedger {
+  version: LedgerVersion
+  overrides: OverrideRecord[]
+}
+
+/**
+ * Typed error returned by `readLedger` when the on-disk file declares a
+ * higher version than this client understands. The reader does NOT throw
+ * — it returns this discriminator so callers can decide whether to abort
+ * or fall back. Plan §2 Edit 6.
+ */
+export interface LedgerVersionUnsupportedError {
+  kind: 'namespace.ledger.version_unsupported'
+  found: number
+  expected: LedgerVersion
+}
+
+/**
+ * Discriminated union returned by `readLedger`. The success branch is the
+ * ledger; the error branches are typed so callers `switch` on `kind` and
+ * never silently absorb a higher-version file as empty.
+ */
+export type ReadLedgerResult =
+  | { kind: 'ok'; ledger: OverridesLedger }
+  | LedgerVersionUnsupportedError
+  | { kind: 'namespace.ledger.malformed'; reason: string }

--- a/packages/mcp-server/tests/unit/namespace-overrides.test.ts
+++ b/packages/mcp-server/tests/unit/namespace-overrides.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for SMI-4588 Wave 2 Step 1 — namespace-overrides ledger.
+ * PR #1 of the Wave 2 stack.
+ *
+ * Coverage (8 cases per plan §Step 1 + §Tests `namespace-overrides.test.ts`):
+ *   1. Read empty / missing file returns an empty ledger.
+ *   2. Append + read round-trip preserves entries.
+ *   3. `version > CURRENT_VERSION` returns typed
+ *      `namespace.ledger.version_unsupported` (NOT silently empty).
+ *   4. Concurrent-write boundary (last-write-wins on a single process).
+ *   5. Malformed JSON returns the typed `namespace.ledger.malformed`
+ *      discriminator (and `readLedger` warns + degrades to empty).
+ *   6. Atomic write semantics — no `.tmp` file remains after success.
+ *   7. Idempotency — appending the same entry twice is detected.
+ *   8. Round-trip preserves ULID order (insertion order).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import * as fsp from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import {
+  appendOverride,
+  findOverride,
+  readLedger,
+  readLedgerResult,
+  writeLedger,
+} from '../../src/audit/namespace-overrides.js'
+import {
+  CURRENT_VERSION,
+  type OverrideRecord,
+  type OverridesLedger,
+} from '../../src/audit/namespace-overrides.types.js'
+
+let TEST_HOME: string
+let LEDGER_PATH: string
+
+beforeEach(() => {
+  TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-overrides-'))
+  LEDGER_PATH = path.join(TEST_HOME, '.skillsmith', 'namespace-overrides.json')
+})
+
+afterEach(() => {
+  if (TEST_HOME && fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+  }
+  vi.restoreAllMocks()
+})
+
+function makeOverrideInput(
+  overrides: Partial<Omit<OverrideRecord, 'id' | 'appliedAt'>> = {}
+): Omit<OverrideRecord, 'id' | 'appliedAt'> {
+  return {
+    skillId: 'anthropic/code-helper',
+    kind: 'command',
+    originalIdentifier: '/ship',
+    renamedTo: '/anthropic-ship',
+    originalPath: '/Users/test/.claude/commands/ship.md',
+    renamedPath: '/Users/test/.claude/commands/anthropic-ship.md',
+    auditId: '01HXYAUDIT00000000000000000',
+    reason: 'collision with skillsmith/release-tools /ship',
+    ...overrides,
+  }
+}
+
+describe('readLedger / readLedgerResult', () => {
+  it('returns an empty ledger when the file does not exist (case 1)', async () => {
+    expect(fs.existsSync(LEDGER_PATH)).toBe(false)
+    const ledger = await readLedger({ ledgerPath: LEDGER_PATH })
+    expect(ledger.version).toBe(CURRENT_VERSION)
+    expect(ledger.overrides).toEqual([])
+  })
+
+  it('readLedgerResult also returns ok+empty for missing file', async () => {
+    const result = await readLedgerResult({ ledgerPath: LEDGER_PATH })
+    expect(result.kind).toBe('ok')
+    if (result.kind === 'ok') {
+      expect(result.ledger.overrides).toEqual([])
+    }
+  })
+
+  it('throws a typed error when version is greater than CURRENT_VERSION (case 3)', async () => {
+    await fsp.mkdir(path.dirname(LEDGER_PATH), { recursive: true })
+    await fsp.writeFile(LEDGER_PATH, JSON.stringify({ version: 99, overrides: [] }))
+
+    // readLedgerResult: returns the typed discriminator, not silent empty.
+    const result = await readLedgerResult({ ledgerPath: LEDGER_PATH })
+    expect(result.kind).toBe('namespace.ledger.version_unsupported')
+    if (result.kind === 'namespace.ledger.version_unsupported') {
+      expect(result.found).toBe(99)
+      expect(result.expected).toBe(CURRENT_VERSION)
+    }
+
+    // readLedger: throws (does NOT silently degrade) — plan §2 Edit 6.
+    await expect(readLedger({ ledgerPath: LEDGER_PATH })).rejects.toMatchObject({
+      kind: 'namespace.ledger.version_unsupported',
+      found: 99,
+      expected: CURRENT_VERSION,
+    })
+  })
+
+  it('returns malformed discriminator for invalid JSON; readLedger warns + degrades (case 5)', async () => {
+    await fsp.mkdir(path.dirname(LEDGER_PATH), { recursive: true })
+    await fsp.writeFile(LEDGER_PATH, '{not json at all')
+
+    const typedResult = await readLedgerResult({ ledgerPath: LEDGER_PATH })
+    expect(typedResult.kind).toBe('namespace.ledger.malformed')
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const ledger = await readLedger({ ledgerPath: LEDGER_PATH })
+    expect(ledger.overrides).toEqual([])
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/ledger malformed/)
+  })
+})
+
+describe('writeLedger + readLedger round-trip', () => {
+  it('round-trips a single appended entry (case 2)', async () => {
+    const empty = await readLedger({ ledgerPath: LEDGER_PATH })
+    const updated = appendOverride(empty, makeOverrideInput())
+    await writeLedger(updated, { ledgerPath: LEDGER_PATH })
+
+    const restored = await readLedger({ ledgerPath: LEDGER_PATH })
+    expect(restored.overrides).toHaveLength(1)
+    const entry = restored.overrides[0]!
+    expect(entry.originalIdentifier).toBe('/ship')
+    expect(entry.renamedTo).toBe('/anthropic-ship')
+    expect(entry.id).toMatch(/^ovr_[0-9A-HJKMNP-TV-Z]{26}$/)
+    expect(entry.appliedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+  })
+
+  it('atomic write — no .tmp file remains after success (case 6)', async () => {
+    const empty = await readLedger({ ledgerPath: LEDGER_PATH })
+    const updated = appendOverride(empty, makeOverrideInput())
+    await writeLedger(updated, { ledgerPath: LEDGER_PATH })
+
+    // Writer uses a unique-suffix tmp filename per call (concurrency
+    // hardening). Assert no stray `*.tmp` file remains in the ledger
+    // directory after a successful write.
+    const dir = path.dirname(LEDGER_PATH)
+    const stragglers = fs.readdirSync(dir).filter((entry) => entry.endsWith('.tmp'))
+    expect(stragglers).toEqual([])
+    expect(fs.existsSync(LEDGER_PATH)).toBe(true)
+  })
+
+  it('preserves insertion order across round-trip (case 8)', async () => {
+    let ledger = await readLedger({ ledgerPath: LEDGER_PATH })
+    ledger = appendOverride(ledger, makeOverrideInput({ originalIdentifier: '/first' }))
+    ledger = appendOverride(ledger, makeOverrideInput({ originalIdentifier: '/second' }))
+    ledger = appendOverride(ledger, makeOverrideInput({ originalIdentifier: '/third' }))
+    await writeLedger(ledger, { ledgerPath: LEDGER_PATH })
+
+    const restored = await readLedger({ ledgerPath: LEDGER_PATH })
+    expect(restored.overrides.map((o) => o.originalIdentifier)).toEqual([
+      '/first',
+      '/second',
+      '/third',
+    ])
+  })
+
+  it('concurrent writes — last-write-wins on a single process (case 4)', async () => {
+    // Two writers race on the same ledger path. The atomic
+    // tmp+rename strategy guarantees the file is never corrupt; one of
+    // the two writes wins. We assert the winning ledger validates and
+    // contains exactly one of the two entries (not interleaved bytes).
+    const writerA = (async () => {
+      const ledger = await readLedger({ ledgerPath: LEDGER_PATH })
+      const next = appendOverride(ledger, makeOverrideInput({ originalIdentifier: '/A' }))
+      await writeLedger(next, { ledgerPath: LEDGER_PATH })
+    })()
+    const writerB = (async () => {
+      const ledger = await readLedger({ ledgerPath: LEDGER_PATH })
+      const next = appendOverride(ledger, makeOverrideInput({ originalIdentifier: '/B' }))
+      await writeLedger(next, { ledgerPath: LEDGER_PATH })
+    })()
+    await Promise.all([writerA, writerB])
+
+    // File must parse cleanly — no half-written JSON.
+    const restored = await readLedger({ ledgerPath: LEDGER_PATH })
+    const ids = restored.overrides.map((o) => o.originalIdentifier).sort()
+    // Last-write-wins on a single event loop: one writer's snapshot
+    // overwrites the other. The surviving ledger contains exactly one
+    // of /A or /B — never both, never neither, never garbage.
+    expect(ids.length).toBe(1)
+    expect(['/A', '/B']).toContain(ids[0])
+  })
+})
+
+describe('appendOverride', () => {
+  it('returns a new ledger; the input is not mutated', () => {
+    const initial: OverridesLedger = { version: CURRENT_VERSION, overrides: [] }
+    const next = appendOverride(initial, makeOverrideInput())
+    expect(initial.overrides).toEqual([]) // input untouched
+    expect(next.overrides).toHaveLength(1)
+    expect(next).not.toBe(initial)
+  })
+
+  it('detects duplicates by (skillId, kind, originalIdentifier, renamedTo) — case 7 idempotency', () => {
+    const initial: OverridesLedger = { version: CURRENT_VERSION, overrides: [] }
+    const once = appendOverride(initial, makeOverrideInput())
+    const twice = appendOverride(once, makeOverrideInput())
+    expect(twice.overrides).toHaveLength(1)
+    // Identity check: duplicate append returns the unchanged ledger by reference.
+    expect(twice).toBe(once)
+  })
+
+  it('treats different renamedTo for the same identifier as a new entry', () => {
+    const initial: OverridesLedger = { version: CURRENT_VERSION, overrides: [] }
+    const a = appendOverride(initial, makeOverrideInput({ renamedTo: '/anthropic-ship' }))
+    const b = appendOverride(a, makeOverrideInput({ renamedTo: '/release-ship' }))
+    expect(b.overrides).toHaveLength(2)
+  })
+
+  it('generates ULID-prefixed ids and ISO timestamps', () => {
+    const initial: OverridesLedger = { version: CURRENT_VERSION, overrides: [] }
+    const next = appendOverride(initial, makeOverrideInput())
+    const entry = next.overrides[0]!
+    expect(entry.id).toMatch(/^ovr_[0-9A-HJKMNP-TV-Z]{26}$/)
+    expect(() => new Date(entry.appliedAt).toISOString()).not.toThrow()
+  })
+})
+
+describe('findOverride', () => {
+  it('returns the matching record when (skillId, kind, originalIdentifier) all match', () => {
+    let ledger: OverridesLedger = { version: CURRENT_VERSION, overrides: [] }
+    ledger = appendOverride(ledger, makeOverrideInput())
+    const match = findOverride(ledger, {
+      skillId: 'anthropic/code-helper',
+      kind: 'command',
+      originalIdentifier: '/ship',
+    })
+    expect(match).not.toBeNull()
+    expect(match?.renamedTo).toBe('/anthropic-ship')
+  })
+
+  it('returns null when no match exists', () => {
+    const ledger: OverridesLedger = { version: CURRENT_VERSION, overrides: [] }
+    const match = findOverride(ledger, { originalIdentifier: '/nonexistent' })
+    expect(match).toBeNull()
+  })
+
+  it('matches identifier-only when skillId/kind are omitted', () => {
+    let ledger: OverridesLedger = { version: CURRENT_VERSION, overrides: [] }
+    ledger = appendOverride(ledger, makeOverrideInput({ skillId: null }))
+    const match = findOverride(ledger, { originalIdentifier: '/ship' })
+    expect(match?.skillId).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds the persistent ledger reader/writer (`namespace-overrides.ts`) for consumer namespace rename history at `~/.skillsmith/namespace-overrides.json`. Atomic writes via per-call unique `<path>.<rand>.tmp` + `fs.rename`; tagged-union return for missing/malformed/version-unsupported.
- Adds the shared audit type vocabulary (`namespace-audit.types.ts`) holding `NamespaceWarning` + `PendingCollision`. Lives in `mcp-server/src/audit/` to break the future `tools → audit → tools` cycle when PR #3 wires `install-preflight` ↔ `install.types` (plan-review Edit 3).
- Forward-compat: schema version > `CURRENT_VERSION` returns typed `namespace.ledger.version_unsupported` (never silently empty — plan-review Edit 6).
- Bumps the `docs/internal` submodule pointer to `1c03d4b` (revised Wave 2 + Wave 4 plans).

This is **PR 1 of 4** in the Wave 2 stack. Subsequent PRs branch from this one.

| File | LOC | Role |
|---|---|---|
| `audit/namespace-overrides.ts` | 256 | Ledger reader/writer (atomic + idempotent append) |
| `audit/namespace-overrides.types.ts` | 118 | Local types + `ReadLedgerResult` discriminator |
| `audit/namespace-audit.types.ts` | 110 | Shared `NamespaceWarning` / `PendingCollision` + `RenameSuggestionRef` shim |
| `audit/index.ts` | 86 | Barrel re-exports (modified) |
| `tests/unit/namespace-overrides.test.ts` | 250 | 15 cases — version mismatch, malformed JSON, atomic-write, idempotency |

## Test plan

- [ ] CI green on all 13 required checks
- [ ] `docker exec skillsmith-dev-1 npx vitest run packages/mcp-server/tests/unit/namespace-overrides.test.ts` → 15/15 pass
- [ ] `docker exec skillsmith-dev-1 npm run audit:standards` → no new warnings (51 passed pre-existing)
- [ ] No `.mcp.json` in diff (worktree-local auto-patch reverted before commit)
- [ ] Submodule pointer descends from `1c03d4b`

## Refs

- Plan: `docs/internal/implementation/smi-4588-rename-engine-ledger-install.md` §Step 1
- Linear: SMI-4588
- Stack: PR 1 of 4 — next PR (`Steps 2-4`: rename engine + frontmatter helpers + apply paths) branches from this PR's tip

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)