### PR TITLE
feat(mcp-server): SMI-4588 rename engine + 3 apply paths (Wave 2 PR 2/4)

### DIFF
--- a/packages/mcp-server/src/audit/index.ts
+++ b/packages/mcp-server/src/audit/index.ts
@@ -79,8 +79,17 @@ export type {
 } from './namespace-overrides.types.js'
 
 // SMI-4588 Wave 2 PR #1 — shared namespace-audit types (PRs #3/#4 consumers).
+export type { NamespaceWarning, PendingCollision } from './namespace-audit.types.js'
+
+// SMI-4588 Wave 2 PR #2 — rename engine + suggestion chain.
+export { applyRename, generateSuggestionChain, REVERT_SUMMARY_PREFIX } from './rename-engine.js'
+
 export type {
-  NamespaceWarning,
-  PendingCollision,
-  RenameSuggestionRef,
-} from './namespace-audit.types.js'
+  ApplyRenameRequest,
+  ApplyRenameResult,
+  RenameAction,
+  RenameActionRequest,
+  RenameError,
+  RenameSuggestion,
+  SuggestionChain,
+} from './rename-engine.types.js'

--- a/packages/mcp-server/src/audit/namespace-audit.types.ts
+++ b/packages/mcp-server/src/audit/namespace-audit.types.ts
@@ -12,34 +12,17 @@
  * Wave 2 plan §4 + Edit 3 — placed in Step 1 so PRs #3/#4 import without
  * rework.
  *
- * Forward-declaration note: `RenameSuggestion` lands in
- * `./rename-engine.types.ts` in PR #2 of the Wave 2 stack. PR #1 ships only
- * the ledger reader/writer, which does not reference `NamespaceWarning` or
- * `PendingCollision`. To avoid a phantom dependency on a not-yet-shipped
- * file, the suggestion field is typed structurally below using
- * `RenameSuggestionRef` — a minimal shape pinned to the spec in plan §1.
- * PR #2 replaces the ref with `import type { RenameSuggestion } from
- * './rename-engine.types.js'`; both shapes are structurally compatible.
+ * `RenameSuggestion` is imported from `./rename-engine.types.js` (PR #2). The
+ * PR #1 forward-declaration shim has been retired now that the canonical
+ * type ships alongside the rename engine.
  */
 
 import type { CollisionId } from './collision-detector.types.js'
+import type { RenameSuggestion } from './rename-engine.types.js'
 
-/**
- * Forward-declaration shim for `RenameSuggestion` (defined in
- * `./rename-engine.types.ts` as of Wave 2 PR #2). The shape mirrors the spec
- * in `docs/internal/implementation/smi-4588-rename-engine-ledger-install.md`
- * §1 verbatim. PR #2 widens this into the full canonical type and replaces
- * the alias below with a direct import.
- */
-export interface RenameSuggestionRef {
-  collisionId: CollisionId
-  /** `'rename_command_file' | 'rename_agent_file' | 'rename_skill_dir_and_frontmatter'`. */
-  applyAction: string
-  currentName: string
-  /** First non-colliding candidate from `generateSuggestionChain`. */
-  suggested: string
-  reason: string
-}
+// `CollisionId` is referenced by `NamespaceWarning.collisionId`; do not remove.
+// `RenameSuggestion` is referenced by `NamespaceWarning.suggestion` and
+// `PendingCollision.suggestedRename`; PR #2 swap-in.
 
 /**
  * A non-blocking namespace collision surfaced by the install pre-flight
@@ -62,7 +45,7 @@ export interface NamespaceWarning {
    * chain is the agent's job — `suggestion` is the first non-colliding
    * candidate.
    */
-  suggestion: RenameSuggestionRef
+  suggestion: RenameSuggestion
   /**
    * FK to the audit history written by `runInstallPreflight` (PR #3). Lets
    * a later `apply_namespace_rename` call (Wave 4) re-read the original
@@ -90,7 +73,7 @@ export interface PendingCollision {
    * First non-colliding candidate from `generateSuggestionChain`. The agent
    * surfaces this to the user as the recommended rename.
    */
-  suggestedRename: RenameSuggestionRef
+  suggestedRename: RenameSuggestion
   /**
    * Up to 3 candidates from `generateSuggestionChain` (decision #11). The
    * agent has the full chain so it can present alternatives without

--- a/packages/mcp-server/src/audit/namespace-overrides.ts
+++ b/packages/mcp-server/src/audit/namespace-overrides.ts
@@ -39,7 +39,17 @@ import {
   type ReadLedgerResult,
 } from './namespace-overrides.types.js'
 
-const DEFAULT_LEDGER_PATH = path.join(os.homedir(), '.skillsmith', 'namespace-overrides.json')
+/**
+ * Default ledger path resolver. Re-evaluates `os.homedir()` on every call so
+ * test harnesses that toggle `process.env.HOME` (mirroring `getBackupsDir`'s
+ * pattern in `tools/install.conflict-helpers.ts`) see the updated location.
+ * A captured-at-module-load constant would freeze the path to the spawning
+ * process's home directory and silently route all writes there — observed
+ * regression during PR #2 test authoring (SMI-4588 Wave 2).
+ */
+function defaultLedgerPath(): string {
+  return path.join(os.homedir(), '.skillsmith', 'namespace-overrides.json')
+}
 
 const ULID_PREFIX = 'ovr_'
 
@@ -66,7 +76,7 @@ function emptyLedger(): OverridesLedger {
  * `readLedger()` (below) which collapses the discriminator.
  */
 export async function readLedgerResult(opts: LedgerPathOptions = {}): Promise<ReadLedgerResult> {
-  const ledgerPath = opts.ledgerPath ?? DEFAULT_LEDGER_PATH
+  const ledgerPath = opts.ledgerPath ?? defaultLedgerPath()
 
   let raw: string
   try {
@@ -173,7 +183,7 @@ export async function writeLedger(
   ledger: OverridesLedger,
   opts: LedgerPathOptions = {}
 ): Promise<void> {
-  const ledgerPath = opts.ledgerPath ?? DEFAULT_LEDGER_PATH
+  const ledgerPath = opts.ledgerPath ?? defaultLedgerPath()
   // Per-call unique tmp path: two concurrent writers must not clobber
   // each other's staging file (a fixed `<path>.tmp` would race on the
   // writeFile + rename interleaving and surface as ENOENT on rename).

--- a/packages/mcp-server/src/audit/rename-engine.apply-paths.ts
+++ b/packages/mcp-server/src/audit/rename-engine.apply-paths.ts
@@ -1,0 +1,137 @@
+/**
+ * @fileoverview Apply-path helpers for the rename engine
+ *               (SMI-4588 Wave 2 Step 4, PR #2).
+ * @module @skillsmith/mcp-server/audit/rename-engine.apply-paths
+ *
+ * Path computation, backup orchestration, and summary formatting helpers
+ * extracted from `rename-engine.ts` to keep the main file <500 LOC per
+ * CLAUDE.md file-size enforcement (Edit 4 / SMI-1865 governance).
+ *
+ * **No backup writer here either** — the canonical `createSkillBackup`
+ * lives in `tools/install.conflict-helpers.ts`; this file orchestrates
+ * single-file staging so that helper can copy a directory worth of one
+ * file. Plan §1 Edit 4 still applies.
+ */
+
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { createSkillBackup } from '../tools/install.conflict-helpers.js'
+import type { OverrideRecord } from './namespace-overrides.types.js'
+import type { RenameAction, RenameError, RenameSuggestion } from './rename-engine.types.js'
+
+/**
+ * Map a `RenameAction` to the `OverrideRecord.kind` field. `command` /
+ * `agent` are 1:1; `rename_skill_dir_and_frontmatter` maps to `skill`.
+ */
+export function actionToKind(action: RenameAction): OverrideRecord['kind'] {
+  switch (action) {
+    case 'rename_command_file':
+      return 'command'
+    case 'rename_agent_file':
+      return 'agent'
+    case 'rename_skill_dir_and_frontmatter':
+      return 'skill'
+  }
+}
+
+/**
+ * Compute the destination path on disk for a rename. For command/agent
+ * files, swap the basename (sans `.md`) with `newName.md`. For skill
+ * directories, rename the directory itself.
+ */
+export function computeDestPath(suggestion: RenameSuggestion, newName: string): string {
+  const src = suggestion.entry.source_path
+  if (suggestion.applyAction === 'rename_skill_dir_and_frontmatter') {
+    return path.join(path.dirname(src), newName)
+  }
+  return path.join(path.dirname(src), `${newName}.md`)
+}
+
+/**
+ * `entry.meta?.author` may carry a slug like `anthropic` or a Skillsmith
+ * manifest skillId like `anthropic/code-helper`. The latter is what the
+ * ledger persists as `skillId`; the former is `null`. Heuristic: contains
+ * `/` ⇒ skillId.
+ */
+export function deriveSkillId(suggestion: RenameSuggestion): string | null {
+  const author = suggestion.entry.meta?.author
+  if (typeof author !== 'string' || author.length === 0) return null
+  return author.includes('/') ? author : null
+}
+
+export function fsErr(reason: string): RenameError {
+  return {
+    kind: 'namespace.rename.fs_error',
+    reason,
+    message: `filesystem error during rename: ${reason}`,
+  }
+}
+
+export async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.stat(target)
+    return true
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw err
+  }
+}
+
+/**
+ * Stage a single command/agent file under a tmp directory so
+ * `createSkillBackup` (which copies a directory) backs up only that file.
+ * Returns the tmp-dir path; the caller removes it after the helper runs.
+ */
+async function stageSingleFileForBackup(srcFile: string): Promise<string> {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'skillsmith-rename-stage-'))
+  await fs.copyFile(srcFile, path.join(tmp, path.basename(srcFile)))
+  return tmp
+}
+
+/**
+ * Run a backup before any on-disk mutation. Returns the backup directory
+ * path on success; throws on failure. The error path is wrapped in a
+ * typed `RenameError` by the caller.
+ *
+ * Backup naming: `<getBackupsDir()>/<skillName>/<timestamp>_namespace-rename/`
+ * via the canonical helper (plan §1 Edit 4).
+ */
+export async function runBackup(suggestion: RenameSuggestion): Promise<string> {
+  const skillName = path.basename(suggestion.entry.source_path).replace(/\.md$/, '')
+  const action = suggestion.applyAction
+  if (action === 'rename_skill_dir_and_frontmatter') {
+    return createSkillBackup(skillName, suggestion.entry.source_path, 'namespace-rename')
+  }
+  // Single-file path — stage, back up the staged dir, clean up.
+  const staged = await stageSingleFileForBackup(suggestion.entry.source_path)
+  try {
+    return await createSkillBackup(skillName, staged, 'namespace-rename')
+  } finally {
+    try {
+      await fs.rm(staged, { recursive: true, force: true })
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/**
+ * Build the inline revert summary (decision #10):
+ *   `"Renamed /<OLD> → /<NEW>. To undo: sklx audit revert <auditId>"`
+ *
+ * For skill renames (no leading `/`), the summary still uses the `/`
+ * prefix per the plan's literal text — agents render it as-is.
+ */
+export function buildSummary(
+  oldIdentifier: string,
+  newIdentifier: string,
+  auditId: string,
+  action: 'apply' | 'revert'
+): string {
+  if (action === 'revert') {
+    return `Reverted /${oldIdentifier} → /${newIdentifier}. Audit: ${auditId}`
+  }
+  return `Renamed /${oldIdentifier} → /${newIdentifier}. To undo: sklx audit revert ${auditId}`
+}

--- a/packages/mcp-server/src/audit/rename-engine.helpers.ts
+++ b/packages/mcp-server/src/audit/rename-engine.helpers.ts
@@ -1,0 +1,247 @@
+/**
+ * @fileoverview Frontmatter-rewrite helpers for the rename engine
+ *               (SMI-4588 Wave 2 Step 3, PR #2).
+ * @module @skillsmith/mcp-server/audit/rename-engine.helpers
+ *
+ * **Frontmatter rewrite only.** Backup is owned by the canonical
+ * `createSkillBackup` helper at `tools/install.conflict-helpers.ts`; the
+ * caller (`rename-engine.ts`) invokes it BEFORE delegating frontmatter work
+ * here. Plan §1 Edit 4 rule is binding — do NOT add a backup writer to this
+ * file.
+ *
+ * The rewrite uses careful line-replacement of the `name:` field rather
+ * than a full YAML re-emit. This preserves comments, block-scalar shapes,
+ * and formatting nuances that a re-emit would lose. Round-trip parsing via
+ * `parseYamlFrontmatter` validates the rewrite before returning.
+ *
+ * Plan: docs/internal/implementation/smi-4588-rename-engine-ledger-install.md §1.
+ */
+
+import { parseYamlFrontmatter } from '../tools/validate.helpers.js'
+
+/**
+ * Frontmatter rewrite errors. Discriminated by `kind` so callers can
+ * handle each case without parsing strings.
+ */
+export type FrontmatterRewriteError =
+  | { kind: 'no_frontmatter'; message: string }
+  | { kind: 'no_name_field'; message: string }
+  | { kind: 'multiple_name_fields'; message: string }
+  | { kind: 'verification_failed'; message: string }
+
+export type FrontmatterRewriteResult =
+  | { ok: true; content: string }
+  | { ok: false; error: FrontmatterRewriteError }
+
+/**
+ * Locate the closing `---` of the frontmatter block. Returns the index
+ * just AFTER the closing fence, or `-1` if no valid block exists.
+ *
+ * Frontmatter must start at byte 0 (after optional UTF-8 BOM stripped at
+ * the seam by the caller, if needed). The opening fence is `---` followed
+ * by a newline; the closing fence is `\n---` followed by a newline or EOF.
+ */
+function findFrontmatterEnd(content: string): number {
+  if (!content.startsWith('---\n') && !content.startsWith('---\r\n')) {
+    return -1
+  }
+  const after = content.indexOf('\n---', 3)
+  if (after === -1) return -1
+
+  // Confirm the closing fence is at the start of a line and is followed by
+  // newline or EOF. Reject `--- foo` style trailing tokens.
+  const fenceStart = after + 1 // index of the second '---'
+  const charAfterFence = content[fenceStart + 3]
+  if (
+    charAfterFence !== undefined &&
+    charAfterFence !== '\n' &&
+    charAfterFence !== '\r' &&
+    charAfterFence !== ' '
+  ) {
+    return -1
+  }
+  // Index of the byte AFTER the closing fence + its terminator.
+  return fenceStart + 3
+}
+
+/**
+ * Rewrite the YAML `name:` field in a SKILL.md frontmatter block,
+ * preserving comments, block-scalar/array shapes, and surrounding lines.
+ *
+ * Constraints:
+ *
+ * - The `name:` field MUST appear exactly once at the top level of the
+ *   frontmatter. Multiple matches return `multiple_name_fields` (signals
+ *   either a malformed file or a nested mapping the simple line-replace
+ *   strategy can't safely handle).
+ * - Quoted values (`name: "old"` / `name: 'old'`) are preserved with their
+ *   original quote style.
+ * - Inline comments (`name: old  # comment`) are preserved.
+ * - Round-trip verified via `parseYamlFrontmatter` post-rewrite.
+ *
+ * The rewrite is careful by design — re-emitting via a YAML library would
+ * destroy comments, alter block-scalar markers, and inflate the diff
+ * surface for review.
+ */
+export function rewriteFrontmatterName(skillMd: string, newName: string): FrontmatterRewriteResult {
+  const fmEnd = findFrontmatterEnd(skillMd)
+  if (fmEnd === -1) {
+    return {
+      ok: false,
+      error: {
+        kind: 'no_frontmatter',
+        message: 'SKILL.md does not start with a `---` frontmatter block',
+      },
+    }
+  }
+
+  // Slice the frontmatter body (between the two `---` fences) and the rest.
+  const headerEnd = skillMd.indexOf('\n', 0) + 1 // after first `---\n`
+  const closingFenceStart = skillMd.lastIndexOf('\n---', fmEnd - 4) // before closing
+  const bodyStart = headerEnd
+  const bodyEnd = closingFenceStart === -1 ? fmEnd - 4 : closingFenceStart
+  const body = skillMd.slice(bodyStart, bodyEnd)
+  const before = skillMd.slice(0, bodyStart)
+  const after = skillMd.slice(bodyEnd)
+
+  // Find the `name:` line(s) at top-level (no leading whitespace). The
+  // simple line-replace strategy refuses to touch nested mappings.
+  const lines = body.split('\n')
+  const nameLineIndices: number[] = []
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+    if (/^name\s*:/.test(line)) {
+      nameLineIndices.push(i)
+    }
+  }
+
+  if (nameLineIndices.length === 0) {
+    return {
+      ok: false,
+      error: {
+        kind: 'no_name_field',
+        message: 'frontmatter has no top-level `name:` field',
+      },
+    }
+  }
+  if (nameLineIndices.length > 1) {
+    return {
+      ok: false,
+      error: {
+        kind: 'multiple_name_fields',
+        message: `frontmatter has ${String(nameLineIndices.length)} top-level \`name:\` fields; refusing to rewrite ambiguously`,
+      },
+    }
+  }
+
+  const idx = nameLineIndices[0]
+  if (idx === undefined) {
+    return {
+      ok: false,
+      error: {
+        kind: 'no_name_field',
+        message: 'frontmatter has no top-level `name:` field',
+      },
+    }
+  }
+  const original = lines[idx] ?? ''
+
+  // Preserve quote style + inline comment. Capture: leading whitespace +
+  // `name:` + space, then the value, then optional `# …` comment trailer.
+  const match = original.match(/^(name\s*:\s*)(.*?)(\s*(?:#.*)?)$/)
+  if (!match) {
+    return {
+      ok: false,
+      error: {
+        kind: 'verification_failed',
+        message: `unable to parse \`name:\` line: ${JSON.stringify(original)}`,
+      },
+    }
+  }
+  const [, head, valuePart, trailer] = match
+
+  // Re-emit the value preserving quote style. Plain → plain, single → single,
+  // double → double. New name must be safely emittable; we conservatively
+  // require it to match `^[A-Za-z0-9_./-]+$` for plain emission and fall back
+  // to double-quoted otherwise.
+  let rewrittenValue: string
+  if (valuePart === undefined || valuePart === '') {
+    return {
+      ok: false,
+      error: {
+        kind: 'verification_failed',
+        message: `\`name:\` has no value: ${JSON.stringify(original)}`,
+      },
+    }
+  } else if (valuePart.startsWith('"') && valuePart.endsWith('"')) {
+    rewrittenValue = `"${escapeForDoubleQuoted(newName)}"`
+  } else if (valuePart.startsWith("'") && valuePart.endsWith("'")) {
+    rewrittenValue = `'${newName.replace(/'/g, "''")}'`
+  } else if (/^[A-Za-z0-9_./-]+$/.test(newName)) {
+    rewrittenValue = newName
+  } else {
+    rewrittenValue = `"${escapeForDoubleQuoted(newName)}"`
+  }
+
+  lines[idx] = `${head ?? ''}${rewrittenValue}${trailer ?? ''}`
+  const newBody = lines.join('\n')
+  const rewritten = `${before}${newBody}${after}`
+
+  // Verify via round-trip parse. The local `parseYamlFrontmatter` is
+  // intentionally simple and does NOT strip trailing inline comments from
+  // scalar values, so a comment on the `name:` line surfaces verbatim in
+  // the parsed string. Strip that here before comparing — the comment is
+  // a property of the SOURCE FILE, not the value, and was preserved by the
+  // line rewrite.
+  const parsed = parseYamlFrontmatter(rewritten)
+  if (parsed === null || typeof parsed['name'] !== 'string') {
+    return {
+      ok: false,
+      error: {
+        kind: 'verification_failed',
+        message: `post-rewrite parse mismatch: expected name=${JSON.stringify(newName)}, got ${JSON.stringify(parsed?.['name'])}`,
+      },
+    }
+  }
+  const parsedName = stripInlineComment(parsed['name']).trim()
+  if (parsedName !== newName) {
+    return {
+      ok: false,
+      error: {
+        kind: 'verification_failed',
+        message: `post-rewrite parse mismatch: expected name=${JSON.stringify(newName)}, got ${JSON.stringify(parsedName)}`,
+      },
+    }
+  }
+
+  return { ok: true, content: rewritten }
+}
+
+/**
+ * Strip a trailing `# comment` from a scalar value, respecting quoted
+ * strings (a `#` inside `"..."` or `'...'` is content, not a comment).
+ * Used only for the post-rewrite verification path — the SOURCE file's
+ * comment is preserved verbatim by the line rewrite.
+ */
+function stripInlineComment(value: string): string {
+  let inSingle = false
+  let inDouble = false
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i]
+    if (ch === '"' && !inSingle) inDouble = !inDouble
+    else if (ch === "'" && !inDouble) inSingle = !inSingle
+    else if (ch === '#' && !inSingle && !inDouble) {
+      return value.slice(0, i)
+    }
+  }
+  return value
+}
+
+/**
+ * Conservative escape for double-quoted YAML scalars: backslashes and
+ * double quotes are escaped; nothing else is touched. Round-trip safe for
+ * the inputs the rename engine produces (sanitized identifiers).
+ */
+function escapeForDoubleQuoted(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}

--- a/packages/mcp-server/src/audit/rename-engine.ts
+++ b/packages/mcp-server/src/audit/rename-engine.ts
@@ -1,0 +1,426 @@
+/**
+ * @fileoverview Rename engine — applies confirmed namespace renames
+ *               (SMI-4588 Wave 2 Step 4, PR #2).
+ * @module @skillsmith/mcp-server/audit/rename-engine
+ *
+ * Three apply paths, gated on `RenameAction`:
+ *
+ * - `rename_command_file` — `~/.claude/commands/foo.md` → `<author>-foo.md`
+ * - `rename_agent_file` — `~/.claude/agents/foo.md` → `<author>-foo.md`
+ * - `rename_skill_dir_and_frontmatter` — rename the directory AND rewrite
+ *   the SKILL.md `name:` frontmatter field.
+ *
+ * Plus `action: 'revert'` semantics: looks up the ledger entry by
+ * `auditId`, performs the inverse rename (back to `originalIdentifier`),
+ * removes the ledger entry, and restores the SKILL.md frontmatter.
+ *
+ * Backups are owned by the canonical `createSkillBackup` helper at
+ * `tools/install.conflict-helpers.ts:87` (plan §1 Edit 4). Single-file
+ * renames stage the file under a tmp directory so the helper (which
+ * expects a source dir) backs up only the relevant file. Backups land in
+ * `~/.claude/skills/.backups/<name>/<timestamp>_namespace-rename/`.
+ *
+ * Idempotency: before mutating, the engine consults the namespace-overrides
+ * ledger. When the same `(skillId, originalIdentifier)` pair is already
+ * in the ledger AND the on-disk filename matches the recorded
+ * `renamedTo`, the call is a no-op (returns success with
+ * `fromPath === toPath` and `backupPath === ''`).
+ *
+ * Disk-vs-ledger divergence: when the ledger has an entry but the on-disk
+ * filename does NOT match `renamedTo`, the engine returns
+ * `namespace.ledger.disk_divergence` rather than silently re-applying.
+ *
+ * Plan: docs/internal/implementation/smi-4588-rename-engine-ledger-install.md §1.
+ */
+
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+import { getBackupsDir } from '../tools/install.conflict-helpers.js'
+import { appendOverride, findOverride, readLedger, writeLedger } from './namespace-overrides.js'
+import {
+  actionToKind,
+  buildSummary,
+  computeDestPath,
+  deriveSkillId,
+  fsErr,
+  pathExists,
+  runBackup,
+} from './rename-engine.apply-paths.js'
+import { rewriteFrontmatterName } from './rename-engine.helpers.js'
+import type {
+  ApplyRenameRequest,
+  ApplyRenameResult,
+  RenameSuggestion,
+} from './rename-engine.types.js'
+
+export { generateSuggestionChain } from './suggestion-chain.js'
+
+/**
+ * Public summary prefix used by the agent / CLI to detect inline revert
+ * messages. Matches plan §1 decision #10 verbatim.
+ */
+export const REVERT_SUMMARY_PREFIX = 'Renamed'
+
+/**
+ * Apply (or revert) a rename. Single entrypoint for Wave 4's MCP tool.
+ * Each apply path runs: idempotency check → backup → mutate → ledger
+ * append → result. Revert: ledger lookup → inverse rename → ledger
+ * remove → result.
+ *
+ * Idempotency contract: re-applying the same suggestion when the ledger
+ * already records it AND on-disk state matches → returns success with
+ * `fromPath === toPath` and `backupPath === ''` (no second backup).
+ *
+ * Disk-vs-ledger divergence: ledger entry exists but on-disk path does
+ * NOT match `renamedTo` → `namespace.ledger.disk_divergence` error;
+ * caller decides whether to `customName` over the divergence.
+ */
+export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenameResult> {
+  const { suggestion, request } = input
+  const auditId = request.auditId
+
+  if (request.action === 'revert') {
+    return revertRename(suggestion, auditId)
+  }
+
+  const newName = request.customName ?? suggestion.suggested
+  const skillId = deriveSkillId(suggestion)
+  const action = suggestion.applyAction
+  const kind = actionToKind(action)
+  const ledger = await readLedger()
+
+  // Idempotency / divergence check: do we already have a ledger entry for
+  // this `(skillId, kind, originalIdentifier)`?
+  const existing = findOverride(ledger, {
+    skillId,
+    kind,
+    originalIdentifier: suggestion.currentName,
+  })
+  if (existing) {
+    const onDiskMatches = await pathExists(existing.renamedPath)
+    if (onDiskMatches) {
+      // Idempotent no-op. Return success without touching disk or ledger.
+      return {
+        success: true,
+        collisionId: suggestion.collisionId,
+        appliedAction: action,
+        appliedRequest: 'apply',
+        fromPath: existing.renamedPath,
+        toPath: existing.renamedPath,
+        backupPath: '',
+        ledgerEntryId: existing.id,
+        summary: buildSummary(suggestion.currentName, existing.renamedTo, auditId, 'apply'),
+      }
+    }
+    // Divergence — ledger says renamedTo, but it's not on disk. Refuse.
+    return {
+      success: false,
+      collisionId: suggestion.collisionId,
+      appliedAction: action,
+      appliedRequest: 'apply',
+      fromPath: suggestion.entry.source_path,
+      toPath: '',
+      backupPath: '',
+      ledgerEntryId: '',
+      summary: '',
+      error: {
+        kind: 'namespace.ledger.disk_divergence',
+        ledgerRenamedTo: existing.renamedTo,
+        onDisk: suggestion.entry.source_path,
+        message: `ledger records rename to ${existing.renamedTo} but no file at ${existing.renamedPath}`,
+        remediationHint:
+          're-run skill_inventory_audit and reapply, or call apply_namespace_rename with customName to overwrite the ledger entry',
+      },
+    }
+  }
+
+  // Compute destination + verify it doesn't already exist (other than as
+  // the source for an idempotent no-op handled above).
+  const destPath = computeDestPath(suggestion, newName)
+  if (destPath !== suggestion.entry.source_path && (await pathExists(destPath))) {
+    return {
+      success: false,
+      collisionId: suggestion.collisionId,
+      appliedAction: action,
+      appliedRequest: 'apply',
+      fromPath: suggestion.entry.source_path,
+      toPath: destPath,
+      backupPath: '',
+      ledgerEntryId: '',
+      summary: '',
+      error: {
+        kind: 'namespace.rename.target_exists',
+        target: destPath,
+        message: `rename target already exists: ${destPath}`,
+      },
+    }
+  }
+
+  // Backup before any mutation.
+  let backupPath: string
+  try {
+    backupPath = await runBackup(suggestion)
+  } catch (err) {
+    return {
+      success: false,
+      collisionId: suggestion.collisionId,
+      appliedAction: action,
+      appliedRequest: 'apply',
+      fromPath: suggestion.entry.source_path,
+      toPath: destPath,
+      backupPath: '',
+      ledgerEntryId: '',
+      summary: '',
+      error: {
+        kind: 'namespace.rename.backup_failed',
+        reason: (err as Error).message,
+        message: `backup failed: ${(err as Error).message}`,
+      },
+    }
+  }
+
+  // Mutate. For skill dirs: rewrite SKILL.md frontmatter, then rename the
+  // directory. For command/agent: just rename.
+  try {
+    if (action === 'rename_skill_dir_and_frontmatter') {
+      const skillMdPath = path.join(suggestion.entry.source_path, 'SKILL.md')
+      let original: string
+      try {
+        original = await fs.readFile(skillMdPath, 'utf-8')
+      } catch (err) {
+        return {
+          success: false,
+          collisionId: suggestion.collisionId,
+          appliedAction: action,
+          appliedRequest: 'apply',
+          fromPath: suggestion.entry.source_path,
+          toPath: destPath,
+          backupPath,
+          ledgerEntryId: '',
+          summary: '',
+          error: fsErr(`reading SKILL.md: ${(err as Error).message}`),
+        }
+      }
+      const rewriteResult = rewriteFrontmatterName(original, newName)
+      if (!rewriteResult.ok) {
+        return {
+          success: false,
+          collisionId: suggestion.collisionId,
+          appliedAction: action,
+          appliedRequest: 'apply',
+          fromPath: suggestion.entry.source_path,
+          toPath: destPath,
+          backupPath,
+          ledgerEntryId: '',
+          summary: '',
+          error: {
+            kind: 'namespace.rename.frontmatter_rewrite_failed',
+            reason: rewriteResult.error.message,
+            message: `frontmatter rewrite failed: ${rewriteResult.error.message}`,
+          },
+        }
+      }
+      await fs.writeFile(skillMdPath, rewriteResult.content, 'utf-8')
+      await fs.rename(suggestion.entry.source_path, destPath)
+    } else {
+      await fs.rename(suggestion.entry.source_path, destPath)
+    }
+  } catch (err) {
+    return {
+      success: false,
+      collisionId: suggestion.collisionId,
+      appliedAction: action,
+      appliedRequest: 'apply',
+      fromPath: suggestion.entry.source_path,
+      toPath: destPath,
+      backupPath,
+      ledgerEntryId: '',
+      summary: '',
+      error: fsErr((err as Error).message),
+    }
+  }
+
+  // Append ledger entry + persist.
+  const updated = appendOverride(ledger, {
+    skillId,
+    kind,
+    originalIdentifier: suggestion.currentName,
+    renamedTo: newName,
+    originalPath: suggestion.entry.source_path,
+    renamedPath: destPath,
+    auditId,
+    reason: suggestion.reason,
+  })
+  // `appendOverride` returns reference-equal ledger when a duplicate
+  // exists. Fresh appends produce a non-equal copy. Either way, persist
+  // the updated state.
+  if (updated !== ledger) {
+    await writeLedger(updated)
+  }
+  const newEntry =
+    updated === ledger
+      ? findOverride(updated, {
+          skillId,
+          kind,
+          originalIdentifier: suggestion.currentName,
+        })
+      : updated.overrides[updated.overrides.length - 1]
+
+  return {
+    success: true,
+    collisionId: suggestion.collisionId,
+    appliedAction: action,
+    appliedRequest: 'apply',
+    fromPath: suggestion.entry.source_path,
+    toPath: destPath,
+    backupPath,
+    ledgerEntryId: newEntry?.id ?? '',
+    summary: buildSummary(suggestion.currentName, newName, auditId, 'apply'),
+  }
+}
+
+/**
+ * Inverse of `applyRename`. Looks up the ledger entry by `auditId`,
+ * renames the file back to `originalIdentifier`, and removes the ledger
+ * entry. Backup is kept for forensics until the 30-day GC sweep.
+ *
+ * Idempotency: calling revert twice on the same `auditId` returns success
+ * with `fromPath === toPath` on the second call (the entry is gone, so
+ * we treat it as a no-op success).
+ */
+async function revertRename(
+  suggestion: RenameSuggestion,
+  auditId: string
+): Promise<ApplyRenameResult> {
+  const ledger = await readLedger()
+  const entry = ledger.overrides.find((o) => o.auditId === auditId)
+  if (!entry) {
+    // Idempotent no-op — already reverted.
+    return {
+      success: true,
+      collisionId: suggestion.collisionId,
+      appliedAction: suggestion.applyAction,
+      appliedRequest: 'revert',
+      fromPath: suggestion.entry.source_path,
+      toPath: suggestion.entry.source_path,
+      backupPath: '',
+      ledgerEntryId: '',
+      summary: buildSummary(suggestion.currentName, suggestion.currentName, auditId, 'revert'),
+    }
+  }
+
+  const action = suggestion.applyAction
+  const onDisk = entry.renamedPath
+  const target = entry.originalPath
+
+  if (!(await pathExists(onDisk))) {
+    return {
+      success: false,
+      collisionId: suggestion.collisionId,
+      appliedAction: action,
+      appliedRequest: 'revert',
+      fromPath: onDisk,
+      toPath: target,
+      backupPath: '',
+      ledgerEntryId: entry.id,
+      summary: '',
+      error: {
+        kind: 'namespace.ledger.disk_divergence',
+        ledgerRenamedTo: entry.renamedTo,
+        onDisk,
+        message: `revert source missing on disk: ${onDisk}`,
+        remediationHint:
+          'restore from ~/.claude/skills/.backups or remove the ledger entry manually',
+      },
+    }
+  }
+
+  if (target !== onDisk && (await pathExists(target))) {
+    return {
+      success: false,
+      collisionId: suggestion.collisionId,
+      appliedAction: action,
+      appliedRequest: 'revert',
+      fromPath: onDisk,
+      toPath: target,
+      backupPath: '',
+      ledgerEntryId: entry.id,
+      summary: '',
+      error: {
+        kind: 'namespace.rename.target_exists',
+        target,
+        message: `revert target already exists: ${target}`,
+      },
+    }
+  }
+
+  // Inverse rename. For skills, also restore the SKILL.md frontmatter
+  // `name:` field to the original identifier. Backup is kept (forensics);
+  // no fresh backup is taken on revert — the apply backup covers this case.
+  try {
+    if (action === 'rename_skill_dir_and_frontmatter') {
+      const skillMdPath = path.join(onDisk, 'SKILL.md')
+      const current = await fs.readFile(skillMdPath, 'utf-8')
+      const restored = rewriteFrontmatterName(current, entry.originalIdentifier)
+      if (!restored.ok) {
+        return {
+          success: false,
+          collisionId: suggestion.collisionId,
+          appliedAction: action,
+          appliedRequest: 'revert',
+          fromPath: onDisk,
+          toPath: target,
+          backupPath: '',
+          ledgerEntryId: entry.id,
+          summary: '',
+          error: {
+            kind: 'namespace.rename.frontmatter_rewrite_failed',
+            reason: restored.error.message,
+            message: `revert frontmatter rewrite failed: ${restored.error.message}`,
+          },
+        }
+      }
+      await fs.writeFile(skillMdPath, restored.content, 'utf-8')
+      await fs.rename(onDisk, target)
+    } else {
+      await fs.rename(onDisk, target)
+    }
+  } catch (err) {
+    return {
+      success: false,
+      collisionId: suggestion.collisionId,
+      appliedAction: action,
+      appliedRequest: 'revert',
+      fromPath: onDisk,
+      toPath: target,
+      backupPath: '',
+      ledgerEntryId: entry.id,
+      summary: '',
+      error: fsErr((err as Error).message),
+    }
+  }
+
+  // Remove the ledger entry.
+  const filtered = {
+    version: ledger.version,
+    overrides: ledger.overrides.filter((o) => o.id !== entry.id),
+  }
+  await writeLedger(filtered)
+
+  return {
+    success: true,
+    collisionId: suggestion.collisionId,
+    appliedAction: action,
+    appliedRequest: 'revert',
+    fromPath: onDisk,
+    toPath: target,
+    backupPath: '',
+    ledgerEntryId: entry.id,
+    summary: buildSummary(entry.renamedTo, entry.originalIdentifier, auditId, 'revert'),
+  }
+}
+
+// Re-export `getBackupsDir` so downstream tooling (Wave 4) can resolve the
+// backup directory without reaching into `tools/install.conflict-helpers.js`.
+export { getBackupsDir }

--- a/packages/mcp-server/src/audit/rename-engine.types.ts
+++ b/packages/mcp-server/src/audit/rename-engine.types.ts
@@ -1,0 +1,168 @@
+/**
+ * @fileoverview Type vocabulary for the rename engine
+ *               (SMI-4588 Wave 2 Steps 2-4, PR #2).
+ * @module @skillsmith/mcp-server/audit/rename-engine.types
+ *
+ * Defines the public surface for `generateSuggestionChain`, `applyRename`,
+ * and the `apply | revert` action discriminator. The shapes here are the
+ * canonical replacement for `RenameSuggestionRef` shipped in
+ * `namespace-audit.types.ts` PR #1 — the structural shape is preserved so
+ * the swap-in is a drop-in replacement.
+ *
+ * Plan: docs/internal/implementation/smi-4588-rename-engine-ledger-install.md §1.
+ */
+
+import type { CollisionId, InventoryEntry } from './collision-detector.types.js'
+
+/**
+ * Three on-disk apply paths. Each maps to a distinct mutation strategy:
+ *
+ * - `rename_command_file` — `~/.claude/commands/foo.md` → `~/.claude/commands/<author>-foo.md`
+ * - `rename_agent_file` — `~/.claude/agents/foo.md` → `~/.claude/agents/<author>-foo.md`
+ * - `rename_skill_dir_and_frontmatter` — rename the directory AND rewrite the
+ *   `name:` field inside SKILL.md frontmatter.
+ */
+export type RenameAction =
+  | 'rename_command_file'
+  | 'rename_agent_file'
+  | 'rename_skill_dir_and_frontmatter'
+
+/**
+ * One concrete rename suggestion attached to a detected collision. PR #1's
+ * `RenameSuggestionRef` shim in `namespace-audit.types.ts` is structurally
+ * compatible with this shape; PR #2 replaces the shim with this canonical
+ * type.
+ *
+ * Wave 4's `apply_namespace_rename` MCP tool accepts a `RenameSuggestion`
+ * (or a `customName` override) plus an action discriminator and dispatches
+ * to `applyRename`.
+ */
+export interface RenameSuggestion {
+  /** Stable across audit runs — derived via `deriveCollisionId`. */
+  collisionId: CollisionId
+  /** The inventory entry whose identifier collides. */
+  entry: InventoryEntry
+  /** Current on-disk identifier (filename without `.md`, or skill name). */
+  currentName: string
+  /**
+   * First non-colliding candidate from `generateSuggestionChain`. Walking
+   * the chain (and selecting alternatives on collision) is the agent's job;
+   * `suggested` is the chain's first viable rename.
+   */
+  suggested: string
+  /** Which on-disk mutation strategy applies. */
+  applyAction: RenameAction
+  /** Human-readable, e.g. `"collision with skillsmith/release-tools /ship"`. */
+  reason: string
+}
+
+/**
+ * Action discriminator for `applyRename`. PR #2 ships `apply` + `revert`;
+ * `customName` (caller supplies override) lands in PR #3 alongside the
+ * install-integration plumbing.
+ */
+export type RenameActionRequest =
+  | { action: 'apply'; auditId: string; customName?: string }
+  | { action: 'revert'; auditId: string }
+
+/**
+ * Top-level apply request. `auditId` is the FK into the audit-history
+ * `~/.skillsmith/audits/<auditId>/result.json` so forensic lookups can
+ * re-derive the original collision context.
+ */
+export interface ApplyRenameRequest {
+  /** Suggestion produced by `generateRenameSuggestions` / chain walk. */
+  suggestion: RenameSuggestion
+  /** `apply` (forward rename) or `revert` (inverse, by ledger lookup). */
+  request: RenameActionRequest
+}
+
+/**
+ * Result of a rename apply (or revert). `success === false` populates
+ * `error` with a typed discriminator; `success === true` populates the
+ * ledger linkage + on-disk paths + the inline revert summary.
+ *
+ * Idempotent re-apply on the same `(skillId, originalIdentifier)` pair is
+ * indicated by `fromPath === toPath` and `backupPath === ''` — callers may
+ * detect a no-op without re-reading the ledger.
+ */
+export interface ApplyRenameResult {
+  success: boolean
+  collisionId: CollisionId
+  appliedAction: RenameAction
+  /** Action that ran — useful when `request.action === 'revert'`. */
+  appliedRequest: RenameActionRequest['action']
+  /** Pre-mutation absolute path. */
+  fromPath: string
+  /** Post-mutation absolute path. Equal to `fromPath` for idempotent no-ops. */
+  toPath: string
+  /**
+   * Backup directory created by `createSkillBackup`. Empty string when the
+   * call was a no-op (idempotent re-apply) — no backup is created in that
+   * case because the on-disk state already matches the ledger.
+   */
+  backupPath: string
+  /** ULID of the appended ledger entry — `''` for revert (ledger entry removed). */
+  ledgerEntryId: string
+  /**
+   * Inline revert summary (decision #10). Populated on success; empty
+   * string on failure. Literal text:
+   *
+   *   `"Renamed /<OLD> → /<NEW>. To undo: sklx audit revert <auditId>"`
+   *
+   * The agent surfaces this directly to the user in tool-response output.
+   */
+  summary: string
+  /** Discriminated error on failure; `undefined` on success. */
+  error?: RenameError
+}
+
+/**
+ * Typed errors surfaced by `applyRename`. Discriminated by `kind` so
+ * callers `switch` rather than parsing strings. Plan §1.
+ */
+export type RenameError =
+  | {
+      kind: 'namespace.rename.target_exists'
+      target: string
+      message: string
+    }
+  | {
+      kind: 'namespace.rename.backup_failed'
+      reason: string
+      message: string
+    }
+  | {
+      kind: 'namespace.rename.frontmatter_rewrite_failed'
+      reason: string
+      message: string
+    }
+  | {
+      kind: 'namespace.rename.fs_error'
+      reason: string
+      message: string
+    }
+  | {
+      kind: 'namespace.ledger.disk_divergence'
+      ledgerRenamedTo: string
+      onDisk: string
+      message: string
+      remediationHint: string
+    }
+  | {
+      kind: 'namespace.rename.revert_not_found'
+      auditId: string
+      message: string
+    }
+
+/**
+ * Output of `generateSuggestionChain`. Up to 3 ordered candidates; if all
+ * three collide, `exhausted: true` and the agent must escalate to the
+ * human via `customName`.
+ */
+export interface SuggestionChain {
+  /** Up to 3 ordered candidates per decision #11. */
+  candidates: string[]
+  /** `true` when all 3 candidates collide. */
+  exhausted: boolean
+}

--- a/packages/mcp-server/src/audit/suggestion-chain.ts
+++ b/packages/mcp-server/src/audit/suggestion-chain.ts
@@ -1,0 +1,170 @@
+/**
+ * @fileoverview 3-tier rename fall-through chain (SMI-4588 Wave 2 Step 2, PR #2).
+ * @module @skillsmith/mcp-server/audit/suggestion-chain
+ *
+ * Generates up to 3 ordered rename candidates per decision #11:
+ *
+ *   1. `${author}-${token}`                            (e.g. `anthropic-ship`)
+ *   2. `${author}-${packDomain}-${token}`              (e.g. `anthropic-codehelper-ship`)
+ *   3. `${author}-${packDomain}-${token}-${shortHash}` (e.g. `anthropic-codehelper-ship-a4f9`)
+ *
+ * Each candidate is checked against the supplied `existingInventory` — when
+ * a candidate collides with another entry's identifier (case-insensitive),
+ * the chain advances to the next tier. If all 3 collide, `exhausted: true`
+ * and the caller surfaces the chain to the user via `customName`.
+ *
+ * Inventory contract (plan §1 Edit 7): `existingInventory` is the
+ * snapshot **before** the candidate skill is appended. Otherwise the
+ * candidate self-collides at tier 1 and cascades unnecessarily. The install
+ * pre-flight maintains two inventory views — `existingInventory` for
+ * suggestion generation, `augmentedInventory` for `detectCollisions`.
+ *
+ * `shortHash` derivation: first 4 hex chars of
+ *   sha256(`${authorPath}/${token}/${packDomain}`)
+ *
+ * Birthday-bound collision-free for inventories <10k entries (Wave 0 spike
+ * §4 — measured 0% on 36-skill fixture, theoretical bound holds).
+ *
+ * Plan: docs/internal/implementation/smi-4588-rename-engine-ledger-install.md §1.
+ */
+
+import * as crypto from 'node:crypto'
+
+import type { InventoryEntry } from './collision-detector.types.js'
+import type { SuggestionChain } from './rename-engine.types.js'
+
+/**
+ * Compute the deterministic 4-char `shortHash` suffix used at chain tier 3.
+ * Exported for tests; in normal flow callers use `generateSuggestionChain`.
+ */
+export function computeShortHash(
+  authorPath: string,
+  token: string,
+  packDomain: string | null
+): string {
+  const input = `${authorPath}/${token}/${packDomain ?? ''}`
+  return crypto.createHash('sha256').update(input).digest('hex').slice(0, 4)
+}
+
+/**
+ * Sanitize an author / tag / token segment for safe use in an identifier.
+ * Lowercases, replaces non-`[a-z0-9]` runs with `-`, trims, and dedupes
+ * consecutive separators. Mirrors the rule in plan §1 step 1.
+ */
+export function sanitizeSegment(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-')
+}
+
+/**
+ * `existingInventory` collides with `candidate` when ANY entry has an
+ * identifier that case-insensitively equals `candidate`. The check is
+ * O(n) per candidate; chain depth is capped at 3 so worst case is O(3n).
+ */
+function collides(candidate: string, inventory: ReadonlyArray<InventoryEntry>): boolean {
+  const needle = candidate.toLowerCase()
+  for (const entry of inventory) {
+    if (entry.identifier.toLowerCase() === needle) {
+      return true
+    }
+  }
+  return false
+}
+
+export interface GenerateSuggestionChainInput {
+  /**
+   * The colliding entry's base token (e.g. `ship` for `/ship`,
+   * `code-helper` for a skill named `code-helper`). Already stripped of
+   * any leading `/` for commands; the chain produces a token-only result
+   * — formatting back to `/foo` is the apply-path's job.
+   */
+  token: string
+  /**
+   * Author segment from manifest. Sanitized inside; pass raw. When
+   * `null`/`''`, tier 1 falls through to using the supplied `tagFallback`.
+   */
+  author: string | null
+  /**
+   * Pack-domain segment (e.g. `codehelper`). Sanitized inside. When
+   * `null`, tier 2 is skipped and tier 3 omits the pack-domain segment.
+   */
+  packDomain: string | null
+  /**
+   * Tag fallback when `author` is unavailable. Already-sanitized values
+   * are accepted; the function re-sanitizes idempotently.
+   */
+  tagFallback?: string | null
+  /**
+   * Repo-relative path used to derive `shortHash` at tier 3. Plan §1 calls
+   * for the entry's `source_path` resolved repo-relative; the caller is
+   * responsible for the resolution since the rename engine has no concept
+   * of "repo root".
+   */
+  authorPath: string
+  /**
+   * Pre-candidate inventory snapshot (Edit 7). MUST NOT contain the
+   * candidate skill — the chain generator self-collides at tier 1
+   * otherwise.
+   */
+  existingInventory: ReadonlyArray<InventoryEntry>
+}
+
+/**
+ * Walk the 3-tier rename fall-through chain (decision #11). Returns up to
+ * 3 ordered candidates and an `exhausted` flag. The caller picks the first
+ * non-colliding candidate as the recommended rename.
+ *
+ * Returns an empty `candidates` array iff `token` itself sanitizes to an
+ * empty string (defensive — pathological inputs).
+ */
+export function generateSuggestionChain(input: GenerateSuggestionChainInput): SuggestionChain {
+  const token = sanitizeSegment(input.token)
+  if (token.length === 0) {
+    return { candidates: [], exhausted: true }
+  }
+
+  const sanitizedAuthor = input.author ? sanitizeSegment(input.author) : ''
+  const sanitizedTag = input.tagFallback ? sanitizeSegment(input.tagFallback) : ''
+  const prefix = sanitizedAuthor.length > 0 ? sanitizedAuthor : sanitizedTag
+
+  // No usable author OR tag fallback → emit a `local-` prefix at tier 1
+  // (matches plan §1's third resolution path). Tiers 2 + 3 also fall back
+  // to `local-` since neither author nor packDomain can be derived.
+  const tierPrefix = prefix.length > 0 ? prefix : 'local'
+
+  const sanitizedPack = input.packDomain ? sanitizeSegment(input.packDomain) : ''
+  const shortHash = computeShortHash(input.authorPath, token, sanitizedPack || null)
+
+  // Tier 1: `${prefix}-${token}`
+  const tier1 = `${tierPrefix}-${token}`
+
+  // Tier 2: `${prefix}-${packDomain}-${token}` (skipped when packDomain absent)
+  const tier2 = sanitizedPack.length > 0 ? `${tierPrefix}-${sanitizedPack}-${token}` : null
+
+  // Tier 3: `${prefix}-${packDomain}-${token}-${shortHash}`
+  // packDomain segment is included only when available.
+  const tier3 =
+    sanitizedPack.length > 0
+      ? `${tierPrefix}-${sanitizedPack}-${token}-${shortHash}`
+      : `${tierPrefix}-${token}-${shortHash}`
+
+  // Build the candidate list, dropping any null tier and de-duplicating
+  // (tier 2 and tier 3 are identical when packDomain is absent — the dedup
+  // ensures the agent doesn't see two equal candidates).
+  const rawCandidates = [tier1, tier2, tier3].filter((c): c is string => c !== null)
+  const candidates: string[] = []
+  for (const c of rawCandidates) {
+    if (!candidates.includes(c)) {
+      candidates.push(c)
+    }
+  }
+
+  // Walk the chain — first non-collider wins; if all collide, the chain is
+  // exhausted and the agent must escalate via `customName`.
+  const exhausted = candidates.every((c) => collides(c, input.existingInventory))
+
+  return { candidates, exhausted }
+}

--- a/packages/mcp-server/tests/unit/rename-engine.test.ts
+++ b/packages/mcp-server/tests/unit/rename-engine.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Unit tests for SMI-4588 Wave 2 Steps 3+4 — frontmatter rewriter + apply paths.
+ * PR #2 of the Wave 2 stack.
+ *
+ * Coverage:
+ *   Frontmatter rewriter:
+ *     1. Round-trip rewrites `name:` while preserving block-scalar `description`.
+ *     2. Inline comments on the `name:` line are preserved.
+ *     3. No frontmatter → `no_frontmatter` error.
+ *     4. No `name:` field → `no_name_field` error.
+ *
+ *   Rename engine apply paths:
+ *     5. `rename_command_file` — backup created, file renamed, ledger appended.
+ *     6. `rename_agent_file` — same coverage.
+ *     7. `rename_skill_dir_and_frontmatter` — directory renamed, frontmatter
+ *        rewritten, ledger appended.
+ *     8. Idempotent re-apply — second call returns success with
+ *        `fromPath === toPath` and `backupPath === ''`.
+ *     9. Disk-vs-ledger divergence → `namespace.ledger.disk_divergence` error.
+ *    10. Rename target collides with existing file → `target_exists` error.
+ *    11. Frontmatter helper does NOT write a backup (Edit 4 contract).
+ *    12. Revert — restores original filename + removes ledger entry.
+ *    13. Revert idempotency — second revert returns success no-op.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as fs from 'node:fs'
+import * as fsp from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { applyRename, getBackupsDir } from '../../src/audit/rename-engine.js'
+import { rewriteFrontmatterName } from '../../src/audit/rename-engine.helpers.js'
+import { readLedger } from '../../src/audit/namespace-overrides.js'
+import type { CollisionId, InventoryEntry } from '../../src/audit/collision-detector.types.js'
+import type { RenameSuggestion } from '../../src/audit/rename-engine.types.js'
+
+let TEST_HOME: string
+let ORIGINAL_HOME: string | undefined
+
+beforeEach(() => {
+  TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-rename-engine-'))
+  ORIGINAL_HOME = process.env['HOME']
+  process.env['HOME'] = TEST_HOME
+})
+
+afterEach(() => {
+  if (ORIGINAL_HOME !== undefined) {
+    process.env['HOME'] = ORIGINAL_HOME
+  } else {
+    delete process.env['HOME']
+  }
+  if (TEST_HOME && fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+  }
+})
+
+const cid = (s: string): CollisionId => s as CollisionId
+
+function makeSuggestion(args: {
+  source_path: string
+  identifier: string
+  applyAction: RenameSuggestion['applyAction']
+  suggested: string
+  author?: string
+}): RenameSuggestion {
+  const entry: InventoryEntry = {
+    kind: args.applyAction === 'rename_skill_dir_and_frontmatter' ? 'skill' : 'command',
+    source_path: args.source_path,
+    identifier: args.identifier,
+    triggerSurface: [args.identifier],
+    meta: args.author ? { author: args.author } : undefined,
+  }
+  return {
+    collisionId: cid('test-collision-01'),
+    entry,
+    currentName: args.identifier,
+    suggested: args.suggested,
+    applyAction: args.applyAction,
+    reason: `collision test for ${args.identifier}`,
+  }
+}
+
+describe('rewriteFrontmatterName', () => {
+  it('preserves block-scalar description across rewrite', () => {
+    const input = [
+      '---',
+      'name: ship',
+      'description: |',
+      '  multiline',
+      '  block',
+      'tags:',
+      '  - release',
+      '---',
+      '# body',
+    ].join('\n')
+    const result = rewriteFrontmatterName(input, 'anthropic-ship')
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.content).toContain('name: anthropic-ship')
+    expect(result.content).toContain('description: |')
+    expect(result.content).toContain('  multiline')
+    expect(result.content).toContain('# body')
+  })
+
+  it('preserves inline comment on name: line', () => {
+    const input = '---\nname: ship  # original\n---\n'
+    const result = rewriteFrontmatterName(input, 'anthropic-ship')
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.content).toContain('# original')
+    expect(result.content).toContain('name: anthropic-ship')
+  })
+
+  it('returns no_frontmatter when content has no `---` block', () => {
+    const result = rewriteFrontmatterName('# body only\n', 'foo')
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.error.kind).toBe('no_frontmatter')
+  })
+
+  it('returns no_name_field when frontmatter has no name', () => {
+    const result = rewriteFrontmatterName('---\ndescription: x\n---\n', 'foo')
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.error.kind).toBe('no_name_field')
+  })
+
+  it('preserves quoted value style', () => {
+    const input = '---\nname: "ship"\n---\n'
+    const result = rewriteFrontmatterName(input, 'anthropic-ship')
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.content).toContain('name: "anthropic-ship"')
+  })
+})
+
+describe('applyRename — rename_command_file', () => {
+  it('backs up, renames, and appends ledger entry', async () => {
+    const cmdDir = path.join(TEST_HOME, '.claude', 'commands')
+    await fsp.mkdir(cmdDir, { recursive: true })
+    const src = path.join(cmdDir, 'ship.md')
+    await fsp.writeFile(src, '---\nname: ship\n---\n# ship command\n', 'utf-8')
+
+    const suggestion = makeSuggestion({
+      source_path: src,
+      identifier: 'ship',
+      applyAction: 'rename_command_file',
+      suggested: 'anthropic-ship',
+    })
+    const result = await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_01' },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.error).toBeUndefined()
+    expect(result.toPath).toBe(path.join(cmdDir, 'anthropic-ship.md'))
+    expect(result.backupPath).toContain(getBackupsDir())
+    expect(fs.existsSync(result.toPath)).toBe(true)
+    expect(fs.existsSync(src)).toBe(false)
+    expect(result.summary).toBe(
+      'Renamed /ship → /anthropic-ship. To undo: sklx audit revert audit_01'
+    )
+
+    const ledger = await readLedger()
+    expect(ledger.overrides).toHaveLength(1)
+    expect(ledger.overrides[0]?.renamedTo).toBe('anthropic-ship')
+    expect(ledger.overrides[0]?.kind).toBe('command')
+  })
+
+  it('returns target_exists when destination already occupied', async () => {
+    const cmdDir = path.join(TEST_HOME, '.claude', 'commands')
+    await fsp.mkdir(cmdDir, { recursive: true })
+    const src = path.join(cmdDir, 'ship.md')
+    const occupied = path.join(cmdDir, 'anthropic-ship.md')
+    await fsp.writeFile(src, '---\nname: ship\n---\n', 'utf-8')
+    await fsp.writeFile(occupied, '---\nname: anthropic-ship\n---\n', 'utf-8')
+
+    const suggestion = makeSuggestion({
+      source_path: src,
+      identifier: 'ship',
+      applyAction: 'rename_command_file',
+      suggested: 'anthropic-ship',
+    })
+    const result = await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_01' },
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.kind).toBe('namespace.rename.target_exists')
+  })
+})
+
+describe('applyRename — rename_agent_file', () => {
+  it('backs up, renames, and appends ledger entry', async () => {
+    const agentDir = path.join(TEST_HOME, '.claude', 'agents')
+    await fsp.mkdir(agentDir, { recursive: true })
+    const src = path.join(agentDir, 'reviewer.md')
+    await fsp.writeFile(src, '---\nname: reviewer\n---\n', 'utf-8')
+
+    const suggestion = makeSuggestion({
+      source_path: src,
+      identifier: 'reviewer',
+      applyAction: 'rename_agent_file',
+      suggested: 'anthropic-reviewer',
+    })
+    const result = await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_02' },
+    })
+    expect(result.success).toBe(true)
+    expect(result.toPath).toBe(path.join(agentDir, 'anthropic-reviewer.md'))
+    const ledger = await readLedger()
+    expect(ledger.overrides[0]?.kind).toBe('agent')
+  })
+})
+
+describe('applyRename — rename_skill_dir_and_frontmatter', () => {
+  it('renames directory and rewrites frontmatter name', async () => {
+    const skillsRoot = path.join(TEST_HOME, '.claude', 'skills')
+    const skillDir = path.join(skillsRoot, 'code-review')
+    await fsp.mkdir(skillDir, { recursive: true })
+    const skillMd = path.join(skillDir, 'SKILL.md')
+    await fsp.writeFile(
+      skillMd,
+      '---\nname: code-review\ndescription: A skill\n---\n# body\n',
+      'utf-8'
+    )
+
+    const suggestion = makeSuggestion({
+      source_path: skillDir,
+      identifier: 'code-review',
+      applyAction: 'rename_skill_dir_and_frontmatter',
+      suggested: 'anthropic-code-review',
+    })
+    const result = await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_03' },
+    })
+    expect(result.success).toBe(true)
+    const newDir = path.join(skillsRoot, 'anthropic-code-review')
+    expect(fs.existsSync(newDir)).toBe(true)
+    expect(fs.existsSync(skillDir)).toBe(false)
+    const rewritten = await fsp.readFile(path.join(newDir, 'SKILL.md'), 'utf-8')
+    expect(rewritten).toContain('name: anthropic-code-review')
+    expect(rewritten).toContain('description: A skill')
+    expect(rewritten).toContain('# body')
+  })
+})
+
+describe('applyRename — idempotency', () => {
+  it('second apply returns no-op success with fromPath === toPath', async () => {
+    const cmdDir = path.join(TEST_HOME, '.claude', 'commands')
+    await fsp.mkdir(cmdDir, { recursive: true })
+    const src = path.join(cmdDir, 'ship.md')
+    await fsp.writeFile(src, '---\nname: ship\n---\n', 'utf-8')
+
+    const suggestion = makeSuggestion({
+      source_path: src,
+      identifier: 'ship',
+      applyAction: 'rename_command_file',
+      suggested: 'anthropic-ship',
+    })
+    const first = await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_04' },
+    })
+    expect(first.success).toBe(true)
+
+    // Re-apply with the SAME suggestion. The on-disk source no longer
+    // exists; the ledger has the entry. Engine should detect the
+    // idempotent state and no-op.
+    const second = await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_04' },
+    })
+    expect(second.success).toBe(true)
+    expect(second.fromPath).toBe(second.toPath)
+    expect(second.backupPath).toBe('')
+    const ledger = await readLedger()
+    // Still only one entry — no duplicate appended.
+    expect(ledger.overrides).toHaveLength(1)
+  })
+
+  it('returns disk_divergence when ledger has entry but on-disk file missing', async () => {
+    const cmdDir = path.join(TEST_HOME, '.claude', 'commands')
+    await fsp.mkdir(cmdDir, { recursive: true })
+    const src = path.join(cmdDir, 'ship.md')
+    await fsp.writeFile(src, '---\nname: ship\n---\n', 'utf-8')
+
+    const suggestion = makeSuggestion({
+      source_path: src,
+      identifier: 'ship',
+      applyAction: 'rename_command_file',
+      suggested: 'anthropic-ship',
+    })
+    await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_05' },
+    })
+
+    // User manually renamed it back. On-disk: `ship.md` exists; ledger
+    // says it should be at `anthropic-ship.md`.
+    const renamed = path.join(cmdDir, 'anthropic-ship.md')
+    await fsp.rename(renamed, src)
+
+    const second = await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_05' },
+    })
+    expect(second.success).toBe(false)
+    expect(second.error?.kind).toBe('namespace.ledger.disk_divergence')
+  })
+})
+
+describe('applyRename — revert', () => {
+  it('reverts a previously applied rename and removes ledger entry', async () => {
+    const cmdDir = path.join(TEST_HOME, '.claude', 'commands')
+    await fsp.mkdir(cmdDir, { recursive: true })
+    const src = path.join(cmdDir, 'ship.md')
+    await fsp.writeFile(src, '---\nname: ship\n---\n', 'utf-8')
+
+    const suggestion = makeSuggestion({
+      source_path: src,
+      identifier: 'ship',
+      applyAction: 'rename_command_file',
+      suggested: 'anthropic-ship',
+    })
+    await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_06' },
+    })
+
+    const reverted = await applyRename({
+      suggestion,
+      request: { action: 'revert', auditId: 'audit_06' },
+    })
+    expect(reverted.success).toBe(true)
+    expect(fs.existsSync(src)).toBe(true)
+    expect(fs.existsSync(path.join(cmdDir, 'anthropic-ship.md'))).toBe(false)
+    const ledger = await readLedger()
+    expect(ledger.overrides).toHaveLength(0)
+  })
+
+  it('revert is idempotent — second revert returns success no-op', async () => {
+    const cmdDir = path.join(TEST_HOME, '.claude', 'commands')
+    await fsp.mkdir(cmdDir, { recursive: true })
+    const src = path.join(cmdDir, 'ship.md')
+    await fsp.writeFile(src, '---\nname: ship\n---\n', 'utf-8')
+
+    const suggestion = makeSuggestion({
+      source_path: src,
+      identifier: 'ship',
+      applyAction: 'rename_command_file',
+      suggested: 'anthropic-ship',
+    })
+    await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_07' },
+    })
+    await applyRename({
+      suggestion,
+      request: { action: 'revert', auditId: 'audit_07' },
+    })
+    const second = await applyRename({
+      suggestion,
+      request: { action: 'revert', auditId: 'audit_07' },
+    })
+    expect(second.success).toBe(true)
+    expect(second.fromPath).toBe(second.toPath)
+  })
+
+  it('reverts a skill rename and restores frontmatter name', async () => {
+    const skillsRoot = path.join(TEST_HOME, '.claude', 'skills')
+    const skillDir = path.join(skillsRoot, 'code-review')
+    await fsp.mkdir(skillDir, { recursive: true })
+    const skillMd = path.join(skillDir, 'SKILL.md')
+    await fsp.writeFile(skillMd, '---\nname: code-review\n---\n', 'utf-8')
+
+    const suggestion = makeSuggestion({
+      source_path: skillDir,
+      identifier: 'code-review',
+      applyAction: 'rename_skill_dir_and_frontmatter',
+      suggested: 'anthropic-code-review',
+    })
+    await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_08' },
+    })
+    const reverted = await applyRename({
+      suggestion,
+      request: { action: 'revert', auditId: 'audit_08' },
+    })
+    expect(reverted.success).toBe(true)
+    const restored = await fsp.readFile(path.join(skillDir, 'SKILL.md'), 'utf-8')
+    expect(restored).toContain('name: code-review')
+    expect(restored).not.toContain('anthropic-code-review')
+  })
+})
+
+describe('Edit 4 — helper does not write a backup', () => {
+  it('rewriteFrontmatterName does not touch ~/.claude/skills/.backups', async () => {
+    // Sanity: the helper is pure (string in, string out). No fs writes.
+    const before = fs.existsSync(getBackupsDir())
+    const result = rewriteFrontmatterName('---\nname: ship\n---\n', 'anthropic-ship')
+    expect(result.ok).toBe(true)
+    const after = fs.existsSync(getBackupsDir())
+    expect(after).toBe(before)
+  })
+})

--- a/packages/mcp-server/tests/unit/suggestion-chain.test.ts
+++ b/packages/mcp-server/tests/unit/suggestion-chain.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for SMI-4588 Wave 2 Step 2 — `generateSuggestionChain`.
+ * PR #2 of the Wave 2 stack.
+ *
+ * Coverage (decision #11 — 3-tier fall-through):
+ *   1. Tier 1 wins when `${author}-${token}` is collision-free.
+ *   2. Tier 2 wins when tier 1 collides; packDomain segment included.
+ *   3. Tier 3 wins when tiers 1 and 2 both collide; shortHash suffix added.
+ *   4. All tiers exhaust → `exhausted: true` and full chain returned.
+ *   5. `packDomain` absent → tier 2 skipped (deduped against tier 3).
+ *   6. `shortHash` is deterministic — same input produces same output.
+ *   7. Pre-candidate inventory contract — candidate skill must NOT be in
+ *      the inventory (Edit 7).
+ *   8. No author + no tag fallback → `local-` prefix (plan §1 path 3).
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import type { InventoryEntry } from '../../src/audit/collision-detector.types.js'
+import {
+  computeShortHash,
+  generateSuggestionChain,
+  sanitizeSegment,
+} from '../../src/audit/suggestion-chain.js'
+
+const entry = (identifier: string, kind: InventoryEntry['kind'] = 'command'): InventoryEntry => ({
+  kind,
+  source_path: `/tmp/${identifier}.md`,
+  identifier,
+  triggerSurface: [identifier],
+})
+
+describe('sanitizeSegment', () => {
+  it('lowercases and replaces non-alphanumerics', () => {
+    expect(sanitizeSegment('Anthropic Inc.')).toBe('anthropic-inc')
+  })
+  it('dedupes consecutive separators', () => {
+    expect(sanitizeSegment('foo  bar___baz')).toBe('foo-bar-baz')
+  })
+})
+
+describe('computeShortHash', () => {
+  it('is deterministic for identical inputs', () => {
+    const a = computeShortHash('/path/to/skill', 'ship', 'codehelper')
+    const b = computeShortHash('/path/to/skill', 'ship', 'codehelper')
+    expect(a).toBe(b)
+    expect(a).toMatch(/^[0-9a-f]{4}$/)
+  })
+  it('differs across inputs', () => {
+    const a = computeShortHash('/p1', 'ship', 'a')
+    const b = computeShortHash('/p2', 'ship', 'a')
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('generateSuggestionChain', () => {
+  it('tier 1 wins when ${author}-${token} is collision-free', () => {
+    const result = generateSuggestionChain({
+      token: 'ship',
+      author: 'anthropic',
+      packDomain: 'codehelper',
+      authorPath: '/repo/anthropic/codehelper',
+      existingInventory: [entry('ship'), entry('release')],
+    })
+    expect(result.exhausted).toBe(false)
+    expect(result.candidates[0]).toBe('anthropic-ship')
+    expect(result.candidates).toHaveLength(3)
+    // Walk: tier 1 does not collide → recommended is tier 1.
+    expect(result.candidates[0]).toBe('anthropic-ship')
+  })
+
+  it('tier 2 wins when tier 1 collides; packDomain segment included', () => {
+    const result = generateSuggestionChain({
+      token: 'ship',
+      author: 'anthropic',
+      packDomain: 'codehelper',
+      authorPath: '/repo/anthropic/codehelper',
+      existingInventory: [entry('anthropic-ship')],
+    })
+    expect(result.candidates[0]).toBe('anthropic-ship')
+    expect(result.candidates[1]).toBe('anthropic-codehelper-ship')
+    expect(result.exhausted).toBe(false)
+  })
+
+  it('tier 3 wins when tiers 1 and 2 collide; shortHash suffix added', () => {
+    const result = generateSuggestionChain({
+      token: 'ship',
+      author: 'anthropic',
+      packDomain: 'codehelper',
+      authorPath: '/repo/anthropic/codehelper',
+      existingInventory: [entry('anthropic-ship'), entry('anthropic-codehelper-ship')],
+    })
+    expect(result.candidates[2]).toMatch(/^anthropic-codehelper-ship-[0-9a-f]{4}$/)
+    expect(result.exhausted).toBe(false)
+  })
+
+  it('all tiers exhausted → exhausted: true', () => {
+    const hash = computeShortHash('/repo/x', 'ship', 'codehelper')
+    const result = generateSuggestionChain({
+      token: 'ship',
+      author: 'anthropic',
+      packDomain: 'codehelper',
+      authorPath: '/repo/x',
+      existingInventory: [
+        entry('anthropic-ship'),
+        entry('anthropic-codehelper-ship'),
+        entry(`anthropic-codehelper-ship-${hash}`),
+      ],
+    })
+    expect(result.exhausted).toBe(true)
+    expect(result.candidates).toHaveLength(3)
+  })
+
+  it('packDomain absent → tier 2 skipped, deduped vs tier 3', () => {
+    const result = generateSuggestionChain({
+      token: 'ship',
+      author: 'anthropic',
+      packDomain: null,
+      authorPath: '/repo/x',
+      existingInventory: [],
+    })
+    // Tier 1 always emitted; tier 2 absent (no packDomain); tier 3 keeps
+    // shortHash suffix without the packDomain segment.
+    expect(result.candidates[0]).toBe('anthropic-ship')
+    // Two candidates total — tier 2 is null, dedupe handles overlap.
+    expect(result.candidates).toHaveLength(2)
+    expect(result.candidates[1]).toMatch(/^anthropic-ship-[0-9a-f]{4}$/)
+  })
+
+  it('no author and no tag fallback → local- prefix', () => {
+    const result = generateSuggestionChain({
+      token: 'ship',
+      author: null,
+      packDomain: null,
+      authorPath: '/repo/x',
+      existingInventory: [],
+    })
+    expect(result.candidates[0]).toBe('local-ship')
+    expect(result.exhausted).toBe(false)
+  })
+
+  it('falls back to tagFallback when author is null', () => {
+    const result = generateSuggestionChain({
+      token: 'ship',
+      author: null,
+      tagFallback: 'release-tools',
+      packDomain: null,
+      authorPath: '/repo/x',
+      existingInventory: [],
+    })
+    expect(result.candidates[0]).toBe('release-tools-ship')
+  })
+
+  it('candidate skill is NOT in pre-candidate inventory (Edit 7)', () => {
+    // The candidate skill itself ("ship") MUST be excluded from the
+    // inventory — otherwise tier 1 would self-collide.
+    const result = generateSuggestionChain({
+      token: 'ship',
+      author: 'anthropic',
+      packDomain: null,
+      authorPath: '/repo/x',
+      // Critically: NOT including entry('ship') here.
+      existingInventory: [entry('release')],
+    })
+    expect(result.candidates[0]).toBe('anthropic-ship')
+    expect(result.exhausted).toBe(false)
+  })
+
+  it('empty token → empty candidates + exhausted', () => {
+    const result = generateSuggestionChain({
+      token: '...',
+      author: 'anthropic',
+      packDomain: null,
+      authorPath: '/repo/x',
+      existingInventory: [],
+    })
+    expect(result.candidates).toHaveLength(0)
+    expect(result.exhausted).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

PR 2 of 4 in the SMI-4588 Wave 2 stack. Ships the rename engine that mutates `~/.claude/skills`, `~/.claude/commands`, and `~/.claude/agents` based on detected namespace collisions, plus the 3-tier suggestion chain.

PR 1 (ledger reader/writer + shared audit types) merged at `ccde9a6b`. PR 3 will wire install integration (preflight, mode gate, ledger replay). PR 4 covers backup GC + integration tests.

Plan: `docs/internal/implementation/smi-4588-rename-engine-ledger-install.md` §Steps 2-4.

## What's in this PR

**New source files**
- `packages/mcp-server/src/audit/rename-engine.ts` (426 LOC) — `applyRename` with 3 apply paths and `revert` semantics
- `packages/mcp-server/src/audit/rename-engine.types.ts` (168 LOC) — canonical `RenameSuggestion`, `ApplyRenameResult`, typed `RenameError` discriminator
- `packages/mcp-server/src/audit/rename-engine.helpers.ts` (247 LOC) — frontmatter rewrite ONLY (Edit 4 contract)
- `packages/mcp-server/src/audit/rename-engine.apply-paths.ts` (137 LOC) — extracted helpers to keep main file <500 LOC
- `packages/mcp-server/src/audit/suggestion-chain.ts` (170 LOC) — 3-tier fall-through chain (decision 11)

**Modified files**
- `packages/mcp-server/src/audit/namespace-audit.types.ts` — `RenameSuggestionRef` shim swapped for canonical `RenameSuggestion`
- `packages/mcp-server/src/audit/namespace-overrides.ts` — fixed pre-existing module-load homedir capture (PR 1 bug); now resolves lazily so tests honoring `process.env.HOME` work correctly
- `packages/mcp-server/src/audit/index.ts` — barrel re-exports for PR 2 surface

**New tests** — 28 cases, all green
- `packages/mcp-server/tests/unit/suggestion-chain.test.ts` (13 cases): each tier, exhaustion, pre-candidate inventory contract (Edit 7), shortHash determinism, no-author/no-tag local- fallback
- `packages/mcp-server/tests/unit/rename-engine.test.ts` (15 cases): frontmatter rewrite (block scalar, inline comment, no-frontmatter, no-name, quoted style), each apply path, idempotency, divergence, target_exists, revert (apply + idempotent revert + skill frontmatter restore), Edit 4 enforcement

## Plan compliance highlights

- **Edit 4** (frontmatter helper has no backup writer): explicit test asserts `rewriteFrontmatterName` does not touch `~/.claude/skills/.backups`. Backup is the caller's job via the canonical `createSkillBackup` from `install.conflict-helpers.ts:87`.
- **Edit 7** (pre-candidate inventory): `generateSuggestionChain` requires the inventory snapshot BEFORE the candidate skill is appended. Explicit test enforces the contract.
- **Decision 10** (inline revert summary): exact literal text `Renamed /X → /Y. To undo: sklx audit revert <auditId>`.
- **Decision 11** (3-tier chain): `${author}-${token}` → `${author}-${packDomain}-${token}` → `+shortHash`. `chainExhausted` flag set when all 3 collide; agent escalates via `customName` (PR 3).
- **`RenameSuggestionRef` swap** documented in PR 1's `namespace-audit.types.ts` is complete; canonical `RenameSuggestion` lives in `rename-engine.types.ts` and is re-exported through the audit barrel.

## Notable bug fix carried into this PR

The `namespace-overrides.ts` ledger reader from PR 1 captured `os.homedir()` at module-load time into a constant. This silently routed test-harness writes to the spawning process's home directory regardless of `process.env.HOME` overrides. PR 2 converts the path resolution to a lazy `defaultLedgerPath()` function — mirrors the canonical `getBackupsDir` pattern in `install.conflict-helpers.ts`. PR 1's tests (15/15) continue to pass; the bug surfaced when authoring PR 2's filesystem-mutation tests.

## Test plan

- [x] `docker exec skillsmith-dev-1 npx vitest run` (mcp-server package): 734 tests pass, 7 todo, 0 failures
- [x] `docker exec skillsmith-dev-1 npx tsc -p packages/mcp-server/tsconfig.json --noEmit`: clean
- [x] `docker exec skillsmith-dev-1 npx eslint packages/mcp-server/src/audit/** packages/mcp-server/tests/unit/{rename-engine,suggestion-chain}.test.ts`: clean
- [x] `docker exec skillsmith-dev-1 npx prettier --check` on all 10 files: clean
- [x] `docker exec skillsmith-dev-1 npm run audit:standards`: 0 failures, 91% compliance (5 pre-existing warnings unrelated to this PR)
- [x] All new files under 500 LOC (largest: rename-engine.ts at 426)
- [x] `/governance` review: clean (no critical/high/medium/low findings)

## Out of scope (handled by later PRs)

- `install-preflight.ts`, `install.ts` modifications — PR 3
- `customName` action discriminator — PR 3 (alongside install integration)
- `install.backup-gc.ts`, integration tests — PR 4

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)