### PR TITLE
feat(mcp-server): SMI-4589 Wave 3 — edit-suggester (apply_with_confirmation for add_domain_qualifier)

### DIFF
--- a/packages/mcp-server/src/audit/audit-report-writer.ts
+++ b/packages/mcp-server/src/audit/audit-report-writer.ts
@@ -31,6 +31,7 @@ import type {
 } from './collision-detector.types.js'
 import type { InventoryEntry } from '../utils/local-inventory.types.js'
 import type { RenameSuggestion } from './rename-engine.types.js'
+import type { RecommendedEdit } from './edit-suggester.types.js'
 
 export interface AuditReportRenderOptions {
   /**
@@ -53,6 +54,19 @@ export interface AuditReportRenderOptions {
    * rendering surface.
    */
   renameSuggestions?: ReadonlyArray<RenameSuggestion>
+  /**
+   * Recommended prose edits to render in the "Recommended Edits"
+   * section (SMI-4589 Wave 3). When provided AND non-empty, the writer
+   * renders each edit as a `diff` fenced markdown block per plan §2.
+   * Pass nothing (or an empty array) to omit the section entirely.
+   *
+   * Wave 4 wires this from `runEditSuggester` outputs; Wave 3 ships
+   * only the rendering surface here. Per the per-template gate
+   * ratified 2026-05-01, only `add_domain_qualifier`-pattern edits
+   * surface in v1; failing-template edits are absent from
+   * `runEditSuggester`'s output entirely.
+   */
+  recommendedEdits?: ReadonlyArray<RecommendedEdit>
 }
 
 export interface AuditReportWriteOptions extends AuditReportRenderOptions {
@@ -99,6 +113,14 @@ export function renderAuditReport(
 
   sections.push(renderRecommendedEdits(opts.renameSuggestions, result.auditId))
 
+  // SMI-4589 Wave 3: prose-edit suggestions render in their own section
+  // immediately after the Wave 2 rename-suggestion section. Empty input
+  // omits the section entirely (no placeholder text — keeps the report
+  // tight when no semantic collisions fired).
+  if (opts.recommendedEdits && opts.recommendedEdits.length > 0) {
+    sections.push(renderRecommendedEditsSection(opts.recommendedEdits))
+  }
+
   // Single trailing newline; sections already terminate with `\n`.
   return sections.join('\n').replace(/\n+$/, '\n')
 }
@@ -118,6 +140,7 @@ export async function writeAuditReport(
   const body = renderAuditReport(result, {
     generatedAt: opts.generatedAt,
     renameSuggestions: opts.renameSuggestions,
+    recommendedEdits: opts.recommendedEdits,
   })
   await fs.writeFile(tmpPath, body, 'utf-8')
   await fs.rename(tmpPath, reportPath)
@@ -249,6 +272,42 @@ function renderRecommendedEdits(
     lines.push(`- Collision id: \`${suggestion.collisionId}\``)
     lines.push(`- Reason: ${suggestion.reason}`)
     lines.push(`- Source: ${suggestion.entry.source_path}`)
+    lines.push('')
+  }
+  return lines.join('\n')
+}
+
+/**
+ * SMI-4589 Wave 3: render the prose-edit suggestions section. Each edit
+ * becomes a markdown block with file/lineRange metadata and a `diff`
+ * fenced code block showing the before/after pair with `-`/`+` line
+ * prefixes — renders with syntax highlighting in GitHub / VSCode.
+ *
+ * Plan §2 mandates the diff block format over separate before/after
+ * plain-text blocks because the unified-diff form gives free
+ * highlighting and a familiar review surface.
+ */
+function renderRecommendedEditsSection(edits: ReadonlyArray<RecommendedEdit>): string {
+  const lines: string[] = []
+  lines.push('## Recommended Edits')
+  lines.push('')
+  for (const edit of edits) {
+    lines.push(`### Recommended edit: differentiate from \`${edit.otherEntry.identifier}\``)
+    lines.push('')
+    lines.push(`**File**: \`${edit.filePath}\``)
+    lines.push(`**Lines**: ${edit.lineRange.start}-${edit.lineRange.end}`)
+    lines.push(`**Pattern**: \`${edit.pattern}\` (${edit.applyMode})`)
+    lines.push('')
+    lines.push('```diff')
+    for (const beforeLine of edit.before.split('\n')) {
+      lines.push(`-${beforeLine}`)
+    }
+    for (const afterLine of edit.after.split('\n')) {
+      lines.push(`+${afterLine}`)
+    }
+    lines.push('```')
+    lines.push('')
+    lines.push(`**Why**: ${edit.rationale}`)
     lines.push('')
   }
   return lines.join('\n')

--- a/packages/mcp-server/src/audit/edit-applier.ts
+++ b/packages/mcp-server/src/audit/edit-applier.ts
@@ -1,0 +1,268 @@
+/**
+ * @fileoverview Edit-applier — file-mutation path for `RecommendedEdit` (SMI-4589 Wave 3 Step 5).
+ * @module @skillsmith/mcp-server/audit/edit-applier
+ *
+ * `applyRecommendedEdit` mutates a SKILL.md or CLAUDE.md file in-place
+ * after the per-template gate has cleared. The mutation flow:
+ *
+ *   1. Registry guard — reject `pattern`s not in `APPLY_TEMPLATE_REGISTRY`.
+ *   2. Stale-before guard — verify file content at `lineRange` matches
+ *      the recorded `before` snippet byte-for-byte.
+ *   3. Backup — `createProseBackup(filePath, 'prose-edit')`.
+ *   4. Atomic write — write to `<filePath>.tmp` then `fs.rename`.
+ *   5. Ledger append — `appendOverride` + `writeLedger` (Wave 2 PR #1).
+ *   6. Return `EditApplyResult` with the inline revert summary
+ *      (decision #10).
+ *
+ * Per-template gate (ratified 2026-05-01): `APPLY_TEMPLATE_REGISTRY` is
+ * a literal allowlist containing only `'add_domain_qualifier'` in v1
+ * (4.10/5 from GPT-5.4 reviewer-#2 scoring). Synthetic edits with
+ * `pattern: 'narrow_scope'` or `'reword_trigger_verb'` are rejected with
+ * `error: 'edit.template_not_in_apply_registry'` and mutate nothing —
+ * the regression guard test asserts this. SMI-4593 reauthors the failing
+ * templates; when their bodies clear the per-template gate, that issue
+ * extends this allowlist.
+ *
+ * Plan: docs/internal/implementation/smi-4589-edit-suggester.md §5.
+ */
+
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs/promises'
+
+import { appendOverride, readLedger, writeLedger } from './namespace-overrides.js'
+import { createProseBackup } from '../tools/install.conflict-helpers.js'
+import type { EditApplyResult } from './edit-applier.types.js'
+import type { EditTemplatePattern, RecommendedEdit } from './edit-suggester.types.js'
+
+/**
+ * Allowlist of template patterns whose `apply_with_confirmation` mode is
+ * registered for file mutation. Per the per-template gate ratified
+ * 2026-05-01, only `add_domain_qualifier` (4.10/5) ships in v1.
+ *
+ * SMI-4593 extends this set when the failing templates clear the gate
+ * post-reauthoring. Plan §6 mandates plan-review verifies this set
+ * matches `goal_6.per_template_gate.verdicts` PASS templates exactly.
+ *
+ * Type-narrow: declared as `ReadonlySet<EditTemplatePattern>` so the
+ * runtime check can't drift from the type union.
+ */
+export const APPLY_TEMPLATE_REGISTRY: ReadonlySet<EditTemplatePattern> =
+  new Set<EditTemplatePattern>(['add_domain_qualifier'])
+
+export interface ApplyRecommendedEditOptions {
+  /**
+   * FK into `~/.skillsmith/audits/<auditId>/result.json`. Persisted in
+   * the ledger entry so revert can re-derive the original collision
+   * context.
+   */
+  auditId: string
+  /**
+   * Apply mode. Only `'apply_with_confirmation'` triggers mutation; any
+   * other value is rejected by registry guard ahead of mutation. The
+   * argument is preserved for forward-compat with v2 LLM-driven mode.
+   */
+  mode: 'apply_with_confirmation'
+}
+
+/**
+ * Apply a `RecommendedEdit` to disk. The agent calls this after
+ * surfacing the edit + receiving user confirmation. Atomic — failure
+ * before mutation leaves the file untouched; failure during mutation
+ * leaves the original file in place via tmp-file + rename semantics.
+ */
+export async function applyRecommendedEdit(
+  edit: RecommendedEdit,
+  opts: ApplyRecommendedEditOptions
+): Promise<EditApplyResult> {
+  // 1. Registry guard. Synthetic edits constructed by tests with a
+  //    failing-template pattern hit this first — no I/O before reject.
+  if (!APPLY_TEMPLATE_REGISTRY.has(edit.pattern)) {
+    return {
+      success: false,
+      collisionId: edit.collisionId,
+      pattern: edit.pattern,
+      filePath: edit.filePath,
+      backupPath: '',
+      ledgerEntryId: '',
+      summary: '',
+      error: {
+        kind: 'edit.template_not_in_apply_registry',
+        pattern: edit.pattern,
+        message: `Template pattern "${edit.pattern}" is not in APPLY_TEMPLATE_REGISTRY; cannot apply. Render in 'manual_review' mode only.`,
+      },
+    }
+  }
+
+  // 2. Stale-before guard. Read the file and verify the snippet at
+  //    lineRange matches byte-for-byte. Any drift → reject.
+  let fileContent: string
+  try {
+    fileContent = await fs.readFile(edit.filePath, 'utf-8')
+  } catch (err) {
+    return failFsError(edit, `read failed: ${(err as Error).message}`)
+  }
+
+  const fileLines = fileContent.split('\n')
+  const startIdx = edit.lineRange.start - 1
+  const endIdx = edit.lineRange.end - 1
+  if (startIdx < 0 || endIdx >= fileLines.length || startIdx > endIdx) {
+    return staleBeforeError(edit, 'line range out of bounds')
+  }
+  const onDiskSnippet = fileLines.slice(startIdx, endIdx + 1).join('\n')
+  if (onDiskSnippet !== edit.before) {
+    return staleBeforeError(edit, 'before snippet mismatch')
+  }
+
+  // 3. Backup BEFORE any mutation. Failure here aborts — never mutate
+  //    without a recoverable backup.
+  let backupPath: string
+  try {
+    const backup = await createProseBackup(edit.filePath, 'prose-edit')
+    backupPath = backup.backupPath
+  } catch (err) {
+    return {
+      success: false,
+      collisionId: edit.collisionId,
+      pattern: edit.pattern,
+      filePath: edit.filePath,
+      backupPath: '',
+      ledgerEntryId: '',
+      summary: '',
+      error: {
+        kind: 'edit.backup_failed',
+        reason: (err as Error).message,
+        message: `Backup failed for ${edit.filePath}; file not mutated.`,
+      },
+    }
+  }
+
+  // 4. Atomic write — splice in the after-snippet at lineRange, write
+  //    to <filePath>.<random>.tmp, fs.rename.
+  const newLines = [
+    ...fileLines.slice(0, startIdx),
+    ...edit.after.split('\n'),
+    ...fileLines.slice(endIdx + 1),
+  ]
+  const newContent = newLines.join('\n')
+  const tmpSuffix = crypto.randomBytes(6).toString('hex')
+  const tmpPath = `${edit.filePath}.${tmpSuffix}.tmp`
+
+  try {
+    await fs.writeFile(tmpPath, newContent, 'utf-8')
+    await fs.rename(tmpPath, edit.filePath)
+  } catch (err) {
+    // Best-effort tmp cleanup; ENOENT is fine.
+    try {
+      await fs.rm(tmpPath, { force: true })
+    } catch {
+      /* swallow */
+    }
+    return {
+      success: false,
+      collisionId: edit.collisionId,
+      pattern: edit.pattern,
+      filePath: edit.filePath,
+      backupPath,
+      ledgerEntryId: '',
+      summary: '',
+      error: {
+        kind: 'edit.fs_error',
+        reason: (err as Error).message,
+        message: `File mutation failed for ${edit.filePath}; backup retained at ${backupPath}.`,
+      },
+    }
+  }
+
+  // 5. Ledger append. We piggyback on the namespace-overrides ledger
+  //    (Wave 2 PR #1) — same last-write-wins atomic semantics. The
+  //    `kind` field accepts only `InventoryKind` values; we encode the
+  //    prose-edit case via `originalIdentifier` = filename + lineRange
+  //    marker so revert can locate the entry by `auditId`.
+  const ledger = await readLedger()
+  const lineMarker = `lines:${edit.lineRange.start}-${edit.lineRange.end}`
+  const updated = appendOverride(ledger, {
+    skillId: null,
+    // SMI-4589 carve-out: prose edits target SKILL.md / CLAUDE.md, not
+    // a renamed inventory artifact. We tag the kind by best-fit
+    // inventory match — `claude_md_rule` for CLAUDE.md edits, `skill`
+    // for SKILL.md edits — to keep the existing ledger union
+    // unchanged. Wave 4 / SMI-4590 may extend the union with a
+    // `'prose_edit'` discriminator if revert ergonomics demand it.
+    kind: edit.category === 'claude_md_trigger_overlap' ? 'claude_md_rule' : 'skill',
+    originalIdentifier: `${edit.filePath}:${lineMarker}`,
+    renamedTo: `${edit.filePath}:${lineMarker}:prose-edit`,
+    originalPath: edit.filePath,
+    renamedPath: edit.filePath,
+    auditId: opts.auditId,
+    reason: edit.rationale,
+  })
+  if (updated !== ledger) {
+    await writeLedger(updated)
+  }
+  const ledgerEntryId =
+    updated === ledger ? '' : (updated.overrides[updated.overrides.length - 1]?.id ?? '')
+
+  // 6. Return success with the inline revert summary literal.
+  return {
+    success: true,
+    collisionId: edit.collisionId,
+    pattern: edit.pattern,
+    filePath: edit.filePath,
+    backupPath,
+    ledgerEntryId,
+    summary: buildSummary(edit.filePath, edit.lineRange, opts.auditId),
+  }
+}
+
+/**
+ * Inline revert-summary literal (decision #10). Mirrors Wave 2's UX —
+ * `sklx audit revert <auditId>` is a Wave 4 (SMI-4590) command surface;
+ * if Wave 4 hasn't shipped at the time this fires, the summary remains
+ * user-facing copy and the command is a no-op until SMI-4590 lands.
+ */
+function buildSummary(
+  filePath: string,
+  lineRange: { start: number; end: number },
+  auditId: string
+): string {
+  // Always emit `start-end` form even on single-line ranges. The Wave 4
+  // CLI surface (`sklx audit revert`) parses the range; a stable two-
+  // number form simplifies the parser and matches the literal copy in
+  // the plan §5: `"Edited <file> lines <range>. To undo: ..."`.
+  const range = `${lineRange.start}-${lineRange.end}`
+  return `Edited ${filePath} lines ${range}. To undo: sklx audit revert ${auditId}`
+}
+
+function staleBeforeError(edit: RecommendedEdit, reason: string): EditApplyResult {
+  return {
+    success: false,
+    collisionId: edit.collisionId,
+    pattern: edit.pattern,
+    filePath: edit.filePath,
+    backupPath: '',
+    ledgerEntryId: '',
+    summary: '',
+    error: {
+      kind: 'edit.stale_before',
+      filePath: edit.filePath,
+      message: `Before snippet mismatch for ${edit.filePath} at lines ${edit.lineRange.start}-${edit.lineRange.end} (${reason}). Re-run detection.`,
+    },
+  }
+}
+
+function failFsError(edit: RecommendedEdit, reason: string): EditApplyResult {
+  return {
+    success: false,
+    collisionId: edit.collisionId,
+    pattern: edit.pattern,
+    filePath: edit.filePath,
+    backupPath: '',
+    ledgerEntryId: '',
+    summary: '',
+    error: {
+      kind: 'edit.fs_error',
+      reason,
+      message: `File access failed for ${edit.filePath}: ${reason}`,
+    },
+  }
+}

--- a/packages/mcp-server/src/audit/edit-applier.types.ts
+++ b/packages/mcp-server/src/audit/edit-applier.types.ts
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview Type vocabulary for the edit-applier (SMI-4589 Wave 3 Step 5).
+ * @module @skillsmith/mcp-server/audit/edit-applier.types
+ *
+ * Mirrors `ApplyRenameResult` (Wave 2 PR #2) so heterogeneous suggestion
+ * lists (rename + edit) can be displayed uniformly by Wave 4's MCP tool
+ * surface. The error union is purpose-narrow — prose-edit failures don't
+ * include any rename-engine codes.
+ *
+ * Plan: docs/internal/implementation/smi-4589-edit-suggester.md §5.
+ */
+
+import type { CollisionId } from './collision-detector.types.js'
+import type { EditTemplatePattern } from './edit-suggester.types.js'
+
+/**
+ * Discriminated errors surfaced by `applyRecommendedEdit`. Callers
+ * `switch` on `kind` rather than parsing the message string.
+ */
+export type EditApplyError =
+  | {
+      /** Edit's source template is not in the apply registry allowlist. */
+      kind: 'edit.template_not_in_apply_registry'
+      pattern: EditTemplatePattern
+      message: string
+    }
+  | {
+      /**
+       * The file content at `lineRange` no longer matches the recorded
+       * `before` snippet — file changed under us between detector run
+       * and apply call. The agent should re-run detection and surface
+       * the fresh suggestion.
+       */
+      kind: 'edit.stale_before'
+      filePath: string
+      message: string
+    }
+  | {
+      kind: 'edit.backup_failed'
+      reason: string
+      message: string
+    }
+  | {
+      kind: 'edit.fs_error'
+      reason: string
+      message: string
+    }
+
+/**
+ * Result of applying a `RecommendedEdit`. `success === false` populates
+ * `error`; `success === true` populates `backupPath`, `ledgerEntryId`,
+ * and the inline revert summary text.
+ */
+export interface EditApplyResult {
+  success: boolean
+  collisionId: CollisionId
+  /** Pattern that produced the edit (for log-grep + telemetry). */
+  pattern: EditTemplatePattern
+  /** Absolute path to the mutated file. */
+  filePath: string
+  /**
+   * Backup directory created by `createProseBackup`. Empty string on
+   * failure. Backup is retained until the 30-day GC sweep.
+   */
+  backupPath: string
+  /** ULID of the appended ledger entry (`ovr_…`). Empty string on failure. */
+  ledgerEntryId: string
+  /**
+   * Inline revert summary (decision #10). Literal text on success:
+   *
+   *   `"Edited <file> lines <range>. To undo: sklx audit revert <auditId>"`
+   *
+   * Empty string on failure.
+   */
+  summary: string
+  /** Discriminated error on failure; `undefined` on success. */
+  error?: EditApplyError
+}

--- a/packages/mcp-server/src/audit/edit-suggester.ts
+++ b/packages/mcp-server/src/audit/edit-suggester.ts
@@ -209,9 +209,9 @@ export async function runEditSuggester(
     let edit: RecommendedEdit | null = null
     for (const content of candidates) {
       if (!content) continue
-      const result = template.generate(flag, { fileContent: content })
-      if (result) {
-        edit = result
+      const generated = template.generate(flag, { fileContent: content })
+      if (generated) {
+        edit = generated
         break
       }
     }

--- a/packages/mcp-server/src/audit/edit-suggester.ts
+++ b/packages/mcp-server/src/audit/edit-suggester.ts
@@ -1,0 +1,355 @@
+/**
+ * @fileoverview Edit-suggester core (SMI-4589 Wave 3 Steps 2-3).
+ * @module @skillsmith/mcp-server/audit/edit-suggester
+ *
+ * Takes the semantic-collision flags from Wave 1's `InventoryAuditResult`
+ * and produces `RecommendedEdit[]` — templated, deterministic prose-edit
+ * suggestions. No LLM calls. No fuzziness.
+ *
+ * Per-template gate (ratified 2026-05-01): v1 ships only
+ * `add_domain_qualifier` (4.10/5 from GPT-5.4 reviewer-#2 scoring). The
+ * other two templates (`narrow_scope` 1.70/5, `reword_trigger_verb`
+ * 2.35/5) FAILED the gate and are NOT shipped in any form — neither as
+ * auto-apply nor as `manual_review`. They route to SMI-4593 for
+ * reauthoring. Test cases 2-3 in `edit-suggester.test.ts` assert empty
+ * output for collisions that would have matched those failing templates,
+ * guarding against accidental re-registration before the gate clears.
+ *
+ * Dispatch pattern (plan §1):
+ *   1. Walk `result.semanticCollisions[]`, collect unique file paths
+ *      across the surviving template's `applies()` checks.
+ *   2. `await Promise.all(uniqueFilePaths.map(fs.readFile))` — single
+ *      parallel read phase. Latency budget is linear in unique-files,
+ *      not templates × collisions.
+ *   3. Iterate flags; for each, walk templates pre-sorted by descending
+ *      `priority`; first `applies()` true wins; `generate()` is
+ *      synchronous over the cached `fileContent`.
+ *   4. Filter null results (template matched but generate() couldn't
+ *      synthesize a valid edit — e.g. file content drifted).
+ *
+ * Plan: docs/internal/implementation/smi-4589-edit-suggester.md §1, §Steps 2-3.
+ */
+
+import * as fs from 'node:fs/promises'
+
+import type { InventoryAuditResult, SemanticCollisionFlag } from './collision-detector.types.js'
+import type { EditTemplate, EditTemplatePattern, RecommendedEdit } from './edit-suggester.types.js'
+
+/**
+ * `add_domain_qualifier` template. Fires for `description_overlap` flags
+ * where one entry has a `meta.tags[0]` value the other lacks. Inserts
+ * `for <tag> tasks` after the trigger verb in the description, narrowing
+ * the trigger surface enough to differentiate from the partner.
+ *
+ * Per-template gate verdict 2026-05-01: 4.10/5 (GPT-5.4 reviewer-#2).
+ * PASS — registered in `APPLY_TEMPLATE_REGISTRY`.
+ */
+const ADD_DOMAIN_QUALIFIER: EditTemplate = {
+  category: 'description_overlap',
+  pattern: 'add_domain_qualifier',
+  priority: 100,
+
+  applies(flag: SemanticCollisionFlag): boolean {
+    // Both entries must carry a description (the prose surface we mutate),
+    // and at least one entry must have a unique tag the other lacks (the
+    // qualifier text we insert). The tag-asymmetry check is the
+    // distinguishing feature of `add_domain_qualifier` versus a hypothetical
+    // `narrow_scope` template — same shape but different remediation.
+    const aTag = pickQualifierTag(flag.entryA, flag.entryB)
+    const bTag = pickQualifierTag(flag.entryB, flag.entryA)
+    if (aTag === null && bTag === null) return false
+    if (!flag.entryA.meta?.description && !flag.entryB.meta?.description) {
+      return false
+    }
+    return true
+  },
+
+  generate(flag: SemanticCollisionFlag, context: { fileContent: string }): RecommendedEdit | null {
+    // Pick the entry on whose file we'll mutate. Prefer the one with a
+    // unique tag (the qualifier text comes from that tag). If both have
+    // unique tags, prefer entryA — deterministic by `applies()` ordering.
+    const aTag = pickQualifierTag(flag.entryA, flag.entryB)
+    const target = aTag !== null ? { entry: flag.entryA, tag: aTag, partner: flag.entryB } : null
+    const fallback =
+      target !== null
+        ? target
+        : (() => {
+            const bTag = pickQualifierTag(flag.entryB, flag.entryA)
+            return bTag !== null ? { entry: flag.entryB, tag: bTag, partner: flag.entryA } : null
+          })()
+    if (!fallback) return null
+
+    const description = fallback.entry.meta?.description
+    if (!description) return null
+
+    // Locate the description block in the file. Skill SKILL.md uses YAML
+    // frontmatter with a `description:` key; we match the description text
+    // verbatim and identify the line range it spans. Multi-line block-scalar
+    // descriptions are handled by line-range expansion (start = first line,
+    // end = last line whose trimmed text appears in the description).
+    const located = locateDescription(context.fileContent, description)
+    if (!located) return null
+
+    // Compose the after-snippet by injecting `for <tag> tasks` after the
+    // first trigger verb in the description. The trigger verb is the first
+    // word matching /^(use|trigger|run|when|whenever|invoke)/i; if none
+    // matches, we prepend `for <tag> tasks: ` to the description body
+    // instead. Either way the edit is deterministic.
+    const after = injectQualifier(located.snippet, fallback.tag)
+    if (after === null || after === located.snippet) {
+      // Snippet didn't change — would emit a no-op edit. Skip.
+      return null
+    }
+
+    const cosine = flag.cosineScore.toFixed(2)
+    const rationale = `differentiates from \`${fallback.partner.identifier}\` (cosine ${cosine}) by inserting domain qualifier "for ${fallback.tag} tasks"`
+
+    return {
+      collisionId: flag.collisionId,
+      category: 'description_overlap',
+      pattern: 'add_domain_qualifier',
+      filePath: fallback.entry.source_path,
+      lineRange: { start: located.startLine, end: located.endLine },
+      before: located.snippet,
+      after,
+      rationale,
+      applyAction: 'recommended_edit',
+      // Per-template gate cleared: ships at apply_with_confirmation.
+      applyMode: 'apply_with_confirmation',
+      otherEntry: {
+        identifier: fallback.partner.identifier,
+        sourcePath: fallback.partner.source_path,
+      },
+    }
+  },
+}
+
+/**
+ * Registry of templates that ship in v1. Pre-sorted by descending
+ * priority. The dispatcher walks this list per flag.
+ *
+ * Wave 3 ships a single template (`add_domain_qualifier`). SMI-4593
+ * reauthors `narrow_scope` and `reword_trigger_verb` and re-registers
+ * them upon clearing the per-template gate.
+ */
+const V1_TEMPLATES: ReadonlyArray<EditTemplate> = [ADD_DOMAIN_QUALIFIER]
+
+/**
+ * Run the edit-suggester over an `InventoryAuditResult`'s semantic
+ * collisions. Returns `RecommendedEdit[]` — one per flag that matches a
+ * registered template AND whose template successfully synthesized a
+ * non-empty edit.
+ *
+ * Order of returned edits: same as `result.semanticCollisions[]` input
+ * order. Tests assert this stability so PR diffs in the audit-report
+ * markdown are deterministic.
+ *
+ * I/O: reads each unique referenced file ONCE, in parallel, before
+ * iterating templates. Templates see only `fileContent` strings, not
+ * paths — keeps templates pure and unit-testable without fixtures on
+ * disk.
+ *
+ * Failure model: any per-flag template error (fileRead failure, snippet
+ * locate failure, `generate()` returning null) skips that flag silently.
+ * The other flags still produce edits. An empty
+ * `result.semanticCollisions[]` short-circuits with no I/O.
+ */
+export async function runEditSuggester(
+  result: InventoryAuditResult,
+  opts?: { templateOverrides?: ReadonlyArray<EditTemplate> }
+): Promise<RecommendedEdit[]> {
+  if (result.semanticCollisions.length === 0) return []
+
+  const templates = sortByPriority(opts?.templateOverrides ?? V1_TEMPLATES)
+  if (templates.length === 0) return []
+
+  // Phase 1: collect unique file paths referenced by any flag whose
+  // partner-pair would feed into a template's `applies()`.
+  const uniquePaths = new Set<string>()
+  for (const flag of result.semanticCollisions) {
+    uniquePaths.add(flag.entryA.source_path)
+    uniquePaths.add(flag.entryB.source_path)
+  }
+
+  // Phase 2: parallel reads. Failed reads degrade to `null` content; the
+  // template will return null when it can't locate the description.
+  const fileCache = new Map<string, string | null>()
+  await Promise.all(
+    Array.from(uniquePaths).map(async (filePath) => {
+      try {
+        const content = await fs.readFile(filePath, 'utf-8')
+        fileCache.set(filePath, content)
+      } catch (err) {
+        // Soft-warn; per plan §Tests case 9 a missing file emits no edit.
+        console.warn(
+          `[edit-suggester] read failed for ${filePath} (${(err as Error).message}); skipping flags that target it`
+        )
+        fileCache.set(filePath, null)
+      }
+    })
+  )
+
+  // Phase 3: iterate flags, dispatch to templates synchronously over
+  // cached content.
+  const edits: RecommendedEdit[] = []
+  for (const flag of result.semanticCollisions) {
+    const template = templates.find((t) => t.applies(flag))
+    if (!template) continue
+
+    // Templates target one of the two entries' files. We let `generate()`
+    // pick which (it has the asymmetry logic). For now, hand it whichever
+    // entry's file content is available — `generate()` will return null
+    // if it needed the other side. We pick entryA's content first since
+    // `add_domain_qualifier`'s `generate` prefers entryA when both have
+    // unique tags.
+    const aContent = fileCache.get(flag.entryA.source_path)
+    const bContent = fileCache.get(flag.entryB.source_path)
+
+    const candidates: Array<string | null> = [aContent ?? null, bContent ?? null]
+    let edit: RecommendedEdit | null = null
+    for (const content of candidates) {
+      if (!content) continue
+      const result = template.generate(flag, { fileContent: content })
+      if (result) {
+        edit = result
+        break
+      }
+    }
+    if (edit) edits.push(edit)
+  }
+
+  return edits
+}
+
+// ---------------------------------------------------------------------------
+// Template helpers (kept inline; ~150-LOC budget for this file)
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable-sort templates by descending priority. Stable to preserve
+ * registration order on ties.
+ */
+function sortByPriority(templates: ReadonlyArray<EditTemplate>): EditTemplate[] {
+  return [...templates].sort((a, b) => b.priority - a.priority)
+}
+
+/**
+ * Pick the first tag from `entry` that does NOT appear in `partner.meta.tags`.
+ * Returns `null` if `entry` has no tags or all tags overlap.
+ */
+function pickQualifierTag(
+  entry: { meta?: { tags?: string[] } },
+  partner: { meta?: { tags?: string[] } }
+): string | null {
+  const ours = entry.meta?.tags ?? []
+  const theirs = new Set(partner.meta?.tags ?? [])
+  for (const tag of ours) {
+    if (typeof tag !== 'string') continue
+    const trimmed = tag.trim()
+    if (!trimmed) continue
+    if (!theirs.has(trimmed)) return trimmed
+  }
+  return null
+}
+
+/**
+ * Locate the `description` text block within `fileContent`. Returns the
+ * matched snippet plus 1-indexed inclusive line range, or `null` if the
+ * description cannot be located (file content drifted since scan time).
+ *
+ * Strategy: split the description into lines (trimmed), then scan
+ * fileContent line-by-line for the first line that matches the first
+ * description line. Once anchored, walk forward to confirm subsequent
+ * description lines match in order. Returns the byte-exact snippet from
+ * the original file (preserves leading whitespace, comments, etc.).
+ */
+function locateDescription(
+  fileContent: string,
+  description: string
+): { snippet: string; startLine: number; endLine: number } | null {
+  const fileLines = fileContent.split('\n')
+  const descLines = description
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+  if (descLines.length === 0) return null
+
+  for (let i = 0; i < fileLines.length; i++) {
+    const fileLine = fileLines[i]?.trim() ?? ''
+    if (!fileLine.includes(descLines[0]!)) continue
+    // Try to match all description lines in order from this anchor.
+    let cursor = i
+    let matched = true
+    for (let j = 0; j < descLines.length; j++) {
+      // Walk forward; allow blank lines between description fragments.
+      while (cursor < fileLines.length) {
+        const candidate = fileLines[cursor]?.trim() ?? ''
+        if (candidate.includes(descLines[j]!)) break
+        if (candidate.length === 0 && j > 0) {
+          cursor++
+          continue
+        }
+        matched = false
+        break
+      }
+      if (!matched || cursor >= fileLines.length) {
+        matched = false
+        break
+      }
+      if (j < descLines.length - 1) cursor++
+    }
+    if (matched) {
+      const startLine = i + 1 // 1-indexed
+      const endLine = cursor + 1
+      const snippet = fileLines.slice(i, cursor + 1).join('\n')
+      return { snippet, startLine, endLine }
+    }
+  }
+  return null
+}
+
+/**
+ * Insert ` for <tag> tasks` after the first trigger verb match in
+ * `snippet`. If no trigger verb is found, prepend `for <tag> tasks: ` to
+ * the description body (after any leading frontmatter prefix like
+ * `description:`).
+ *
+ * Returns the modified snippet, or `null` if the qualifier text is
+ * already present (idempotent — no-op edits are filtered out by caller).
+ */
+function injectQualifier(snippet: string, tag: string): string | null {
+  const qualifierPhrase = `for ${tag} tasks`
+  if (snippet.toLowerCase().includes(qualifierPhrase.toLowerCase())) {
+    // Already qualified.
+    return null
+  }
+
+  // Trigger-verb pattern: case-insensitive match for verb at start of a
+  // word boundary, optionally preceded by `description:` prefix.
+  const triggerVerbPattern = /\b(use|trigger|run|when|whenever|invoke)\b(\s+\w+)?/i
+  const match = triggerVerbPattern.exec(snippet)
+  if (match && match.index >= 0) {
+    const insertAt = match.index + match[0].length
+    return `${snippet.slice(0, insertAt)} ${qualifierPhrase}${snippet.slice(insertAt)}`
+  }
+
+  // No trigger verb: inject after the description-key prefix if present,
+  // else prepend to the snippet body.
+  const descKeyMatch = /^(\s*description\s*:\s*)(.*)$/im.exec(snippet)
+  if (descKeyMatch && descKeyMatch.index >= 0) {
+    const prefix = descKeyMatch[1]!
+    const rest = descKeyMatch[2]!
+    return snippet.replace(descKeyMatch[0], `${prefix}${qualifierPhrase}: ${rest}`)
+  }
+
+  return `${qualifierPhrase}: ${snippet}`
+}
+
+/**
+ * Public registry-key accessor. Re-exports the pattern strings so the
+ * apply-path registry (`edit-applier.ts`) can import a single source of
+ * truth instead of stringly-typed literals.
+ */
+export const V1_TEMPLATE_PATTERNS: ReadonlyArray<EditTemplatePattern> = V1_TEMPLATES.map(
+  (t) => t.pattern
+)

--- a/packages/mcp-server/src/audit/edit-suggester.types.ts
+++ b/packages/mcp-server/src/audit/edit-suggester.types.ts
@@ -1,0 +1,145 @@
+/**
+ * @fileoverview Type vocabulary for the edit-suggester (SMI-4589 Wave 3 Step 1).
+ * @module @skillsmith/mcp-server/audit/edit-suggester.types
+ *
+ * Defines `RecommendedEdit`, `EditCategory`, `EditTemplate` — the public
+ * surface consumed by Wave 3's audit-report writer extension, install
+ * pre-flight wiring, and Wave 4's MCP `apply_recommended_edit` tool surface.
+ *
+ * The shapes are deliberately additive: `RecommendedEdit` does not extend
+ * `RenameSuggestion` (Wave 2) because the `before`/`after` snippet pair has
+ * no analogue in the rename surface — coupling them would force the rename
+ * engine to carry prose-edit fields it never uses.
+ *
+ * Plan: docs/internal/implementation/smi-4589-edit-suggester.md §1.
+ */
+
+import type { CollisionId } from './collision-detector.types.js'
+import type { SemanticCollisionFlag } from './collision-detector.types.js'
+
+/**
+ * Which class of prose collision a `RecommendedEdit` addresses.
+ *
+ * - `description_overlap` — two SKILL.md descriptions semantically overlap
+ *   (cosine ≥0.75). Renaming doesn't help; the descriptions need to
+ *   differentiate.
+ * - `claude_md_trigger_overlap` — two CLAUDE.md trigger phrases semantically
+ *   overlap. Renaming the file doesn't help; the prose needs to change.
+ *
+ * v1 ships only `description_overlap` via the `add_domain_qualifier`
+ * template. `claude_md_trigger_overlap` (paired with the
+ * `reword_trigger_verb` template) FAILED the per-template gate at 2.35/5
+ * and is dropped from v1 — see plan §"Wave 3 ship gate". The category enum
+ * still ships so SMI-4593's reauthored template body has a stable value to
+ * register against without a follow-up type change.
+ */
+export type EditCategory = 'description_overlap' | 'claude_md_trigger_overlap'
+
+/**
+ * The narrow set of template patterns the edit-suggester knows about. v1
+ * ships `add_domain_qualifier` only (4.10/5 from GPT-5.4 reviewer-#2
+ * scoring). The other two templates failed the per-template gate at
+ * 2.35/5 and 1.70/5 respectively; SMI-4593 reauthors them.
+ *
+ * The string union is the canonical allowlist key for
+ * `APPLY_TEMPLATE_REGISTRY` in `edit-applier.ts`. Adding a new pattern
+ * here without registering it in that allowlist is a TS error (the apply
+ * path narrows on the registry literal); adding it to the allowlist
+ * without re-scoring against the per-template gate is caught at
+ * plan-review time per the Wave 3 plan §6.
+ */
+export type EditTemplatePattern = 'add_domain_qualifier' | 'narrow_scope' | 'reword_trigger_verb'
+
+/**
+ * One concrete prose-edit recommendation surfaced by `runEditSuggester`.
+ *
+ * Wave 3 emits these in two surfaces:
+ *
+ * 1. Audit-report writer's "Recommended Edits" section (rendered as a
+ *    `diff` fenced markdown block per plan §2).
+ * 2. `NamespaceWarning.recommendedEdit` field for `description_overlap`
+ *    collisions surfaced at install pre-flight time (plan §3).
+ *
+ * Wave 4's `apply_recommended_edit` MCP tool consumes this shape directly
+ * — `applyMode: 'apply_with_confirmation'` is the green-light for the
+ * tool to mutate the file, gated by `APPLY_TEMPLATE_REGISTRY`.
+ */
+export interface RecommendedEdit {
+  /** Matches the source `SemanticCollisionFlag.collisionId` from Wave 1. */
+  collisionId: CollisionId
+  /** Which prose-collision class this edit addresses. */
+  category: EditCategory
+  /** Template pattern that generated the edit (registry allowlist key). */
+  pattern: EditTemplatePattern
+  /** Absolute path to the file to mutate (SKILL.md or CLAUDE.md). */
+  filePath: string
+  /** 1-indexed inclusive line range covering the `before` snippet. */
+  lineRange: { start: number; end: number }
+  /**
+   * Exact current snippet at `filePath:lineRange`. The applier validates
+   * this matches byte-for-byte before mutating; mismatch returns
+   * `error: 'edit.stale_before'` and the file is untouched.
+   */
+  before: string
+  /**
+   * Templated proposed text. Deterministic — no LLM rewrite. v1 inserts
+   * `for <tag> tasks` after the trigger verb in the description.
+   */
+  after: string
+  /**
+   * Human-readable rationale, e.g.
+   * `"differentiates from skillsmith/release-tools (cosine 0.82)"`.
+   * Surfaced verbatim in the audit-report markdown and in the install
+   * pre-flight warning message.
+   */
+  rationale: string
+  /**
+   * Always `'recommended_edit'`. Distinguishes the prose-edit surface
+   * from Wave 2's rename surface (`'rename_command_file'` etc.) when
+   * agents introspect heterogeneous suggestion lists.
+   */
+  applyAction: 'recommended_edit'
+  /**
+   * `'manual_review'` — render in the audit report only; no mutation
+   * path. `'apply_with_confirmation'` — agent may auto-apply via
+   * `apply_recommended_edit` after user confirmation.
+   *
+   * v1: `add_domain_qualifier` (the only registered template) ships at
+   * `'apply_with_confirmation'`. `runEditSuggester` does NOT emit any
+   * edit at `'manual_review'` mode in v1 — the failing templates are
+   * absent from output entirely per plan R-4/R-8.
+   */
+  applyMode: 'manual_review' | 'apply_with_confirmation'
+  /**
+   * Cross-reference to the partner skill in the original collision flag.
+   * Lets the audit report say "differentiates from <other>" without
+   * forcing the writer to re-read inventory state.
+   */
+  otherEntry: { identifier: string; sourcePath: string }
+}
+
+/**
+ * One template implementation. `applies()` is a synchronous predicate over
+ * the flag; `generate()` is synchronous over `flag + fileContent` (the
+ * dispatcher pre-reads files in parallel before iterating templates per
+ * plan §1 async dispatch pattern).
+ *
+ * Templates return `null` from `generate()` when the flag matches but the
+ * synthesized edit can't be produced (e.g. line-range extraction fails
+ * because the file changed under us). The caller skips silently — the
+ * user still sees the warning + cosine score from Wave 1.
+ */
+export interface EditTemplate {
+  category: EditCategory
+  pattern: EditTemplatePattern
+  /**
+   * Higher fires first within a flag. Tiebreak by registration order —
+   * the dispatcher is stable. v1 ships a single template per category so
+   * priority is informational only, but the field is load-bearing for
+   * the SMI-4593 reauthoring path that may register additional templates
+   * against the same category.
+   */
+  priority: number
+  applies(flag: SemanticCollisionFlag): boolean
+  generate(flag: SemanticCollisionFlag, context: { fileContent: string }): RecommendedEdit | null
+}

--- a/packages/mcp-server/src/audit/edit-suggester.types.ts
+++ b/packages/mcp-server/src/audit/edit-suggester.types.ts
@@ -14,8 +14,7 @@
  * Plan: docs/internal/implementation/smi-4589-edit-suggester.md §1.
  */
 
-import type { CollisionId } from './collision-detector.types.js'
-import type { SemanticCollisionFlag } from './collision-detector.types.js'
+import type { CollisionId, SemanticCollisionFlag } from './collision-detector.types.js'
 
 /**
  * Which class of prose collision a `RecommendedEdit` addresses.

--- a/packages/mcp-server/src/audit/index.ts
+++ b/packages/mcp-server/src/audit/index.ts
@@ -109,3 +109,22 @@ export type {
 export { runBackupGC } from '../tools/install.backup-gc.js'
 
 export type { RunBackupGCOptions, RunBackupGCResult } from '../tools/install.backup-gc.js'
+
+// SMI-4589 Wave 3 — edit-suggester (templated prose-edit recommendations
+// for `description_overlap` semantic collisions).
+export { runEditSuggester, V1_TEMPLATE_PATTERNS } from './edit-suggester.js'
+
+export type {
+  EditCategory,
+  EditTemplate,
+  EditTemplatePattern,
+  RecommendedEdit,
+} from './edit-suggester.types.js'
+
+// SMI-4589 Wave 3 — edit-applier (mutation path for the registered
+// `add_domain_qualifier` template, gated by APPLY_TEMPLATE_REGISTRY).
+export { APPLY_TEMPLATE_REGISTRY, applyRecommendedEdit } from './edit-applier.js'
+
+export type { ApplyRecommendedEditOptions } from './edit-applier.js'
+
+export type { EditApplyError, EditApplyResult } from './edit-applier.types.js'

--- a/packages/mcp-server/src/audit/install-preflight.ts
+++ b/packages/mcp-server/src/audit/install-preflight.ts
@@ -45,6 +45,8 @@ import type { AuditMode, Tier } from '@skillsmith/core/config/audit-mode'
 
 import { generateSuggestionChain } from './suggestion-chain.js'
 import type { RenameAction, RenameSuggestion } from './rename-engine.types.js'
+import { runEditSuggester } from './edit-suggester.js'
+import type { RecommendedEdit } from './edit-suggester.types.js'
 
 /**
  * One synthesized candidate skill being considered for install. The
@@ -336,6 +338,25 @@ export async function runInstallPreflight(
     return { warnings: [], pendingCollision: null, auditId }
   }
 
+  // SMI-4589 Wave 3: run the edit-suggester over the audit result (which
+  // already contains the candidate-augmented inventory). We attach the
+  // matching edit to each semantic NamespaceWarning by collisionId. Edge
+  // cases:
+  //   - Edit-suggester throws → log + degrade to no edits (preserves the
+  //     non-blocking install contract per Wave 2 Edit 2). Failure of the
+  //     edit surface MUST NOT brick the install pre-flight.
+  //   - Non-semantic warnings (`exact`, `generic`) never carry a
+  //     recommendedEdit — the suggester only runs over semanticCollisions.
+  let editsByCollisionId = new Map<string, RecommendedEdit>()
+  try {
+    const recommendedEdits = await runEditSuggester(result)
+    editsByCollisionId = new Map(recommendedEdits.map((e) => [e.collisionId, e]))
+  } catch (err) {
+    console.warn(
+      `[install-preflight] edit-suggester failed (${(err as Error).message}); proceeding without prose edits`
+    )
+  }
+
   // Build a NamespaceWarning + suggestion-chain for each candidate-related
   // flag. We surface the first flag's chain in `pendingCollision` (the
   // dominant collision); all flags surface in `warnings[]`.
@@ -358,6 +379,8 @@ export async function runInstallPreflight(
       existingInventory: inventoryWithoutSelf,
     })
 
+    const recommendedEdit = editsByCollisionId.get(flag.collisionId as string)
+
     warnings.push({
       collisionId: flag.collisionId as CollisionId,
       kind: flag.kind,
@@ -365,6 +388,7 @@ export async function runInstallPreflight(
       message: buildWarningMessage(flag, candidate, built.suggestion.suggested),
       suggestion: built.suggestion,
       auditId,
+      recommendedEdit,
     })
 
     // First candidate-flag becomes the pendingCollision envelope.

--- a/packages/mcp-server/src/audit/install-preflight.ts
+++ b/packages/mcp-server/src/audit/install-preflight.ts
@@ -347,15 +347,7 @@ export async function runInstallPreflight(
   //     edit surface MUST NOT brick the install pre-flight.
   //   - Non-semantic warnings (`exact`, `generic`) never carry a
   //     recommendedEdit — the suggester only runs over semanticCollisions.
-  let editsByCollisionId = new Map<string, RecommendedEdit>()
-  try {
-    const recommendedEdits = await runEditSuggester(result)
-    editsByCollisionId = new Map(recommendedEdits.map((e) => [e.collisionId, e]))
-  } catch (err) {
-    console.warn(
-      `[install-preflight] edit-suggester failed (${(err as Error).message}); proceeding without prose edits`
-    )
-  }
+  const editsByCollisionId = await collectRecommendedEdits(result)
 
   // Build a NamespaceWarning + suggestion-chain for each candidate-related
   // flag. We surface the first flag's chain in `pendingCollision` (the
@@ -416,6 +408,25 @@ function buildWarningMessage(
 ): string {
   const reason = buildReason(flag, candidate.projectedSourcePath)
   return `Namespace ${flag.kind} collision installing "${candidate.identifier}": ${reason}. Suggested rename: "${suggested}".`
+}
+
+/**
+ * SMI-4589 Wave 3: collect recommended edits indexed by collisionId.
+ * Edit-suggester failure degrades silently to an empty map — the
+ * non-blocking install contract from Wave 2 Edit 2 extends here.
+ */
+async function collectRecommendedEdits(
+  result: InventoryAuditResult
+): Promise<Map<string, RecommendedEdit>> {
+  try {
+    const recommendedEdits = await runEditSuggester(result)
+    return new Map(recommendedEdits.map((e) => [e.collisionId as string, e]))
+  } catch (err) {
+    console.warn(
+      `[install-preflight] edit-suggester failed (${(err as Error).message}); proceeding without prose edits`
+    )
+    return new Map()
+  }
 }
 
 /**

--- a/packages/mcp-server/src/audit/namespace-audit.types.ts
+++ b/packages/mcp-server/src/audit/namespace-audit.types.ts
@@ -19,6 +19,7 @@
 
 import type { CollisionId } from './collision-detector.types.js'
 import type { RenameSuggestion } from './rename-engine.types.js'
+import type { RecommendedEdit } from './edit-suggester.types.js'
 
 // `CollisionId` is referenced by `NamespaceWarning.collisionId`; do not remove.
 // `RenameSuggestion` is referenced by `NamespaceWarning.suggestion` and
@@ -52,6 +53,18 @@ export interface NamespaceWarning {
    * suggestion without re-running detection.
    */
   auditId: string
+  /**
+   * SMI-4589 Wave 3: optional prose-edit recommendation surfaced for
+   * `description_overlap` semantic collisions. The agent surfaces the
+   * `RecommendedEdit` alongside the rename suggestion; rename may not
+   * be the right remediation when descriptions semantically overlap.
+   *
+   * Per the per-template gate ratified 2026-05-01, only
+   * `add_domain_qualifier`-pattern edits populate this field in v1.
+   * `kind: 'exact'` and `kind: 'generic'` warnings never carry a
+   * recommended edit (they're text-identifier collisions, not prose).
+   */
+  recommendedEdit?: RecommendedEdit
 }
 
 /**

--- a/packages/mcp-server/src/tools/install.conflict-helpers.ts
+++ b/packages/mcp-server/src/tools/install.conflict-helpers.ts
@@ -122,6 +122,42 @@ export async function createSkillBackup(
 }
 
 /**
+ * SMI-4589 Wave 3: Create a timestamped backup of a single prose file before
+ * an edit-applier mutation (CLAUDE.md or SKILL.md). Reuses `getBackupsDir()`
+ * for path resolution to keep prose backups co-located with skill backups
+ * and inside the canonical install root — `audit-history.ts`'s 30-day GC
+ * sweep covers this directory tree without further configuration.
+ *
+ * Path shape (decision #10): `<getBackupsDir()>/<basename(filePath)>/<timestamp>_<reason>/<basename(filePath)>`.
+ * The leading `<basename>` segment groups all prose backups for the same
+ * file alongside whichever skill or CLAUDE.md the file lives in; the inner
+ * `<basename>` mirrors `createSkillBackup`'s shape so `cleanupOldBackups`
+ * walks both surfaces uniformly.
+ *
+ * Failure mode: throws `Error` on any I/O failure. The caller
+ * (`applyRecommendedEdit`) maps the throw to `error: 'edit.backup_failed'`
+ * so the file-mutation step never runs without a valid backup.
+ *
+ * @param filePath - Absolute path to the prose file (e.g. SKILL.md, CLAUDE.md)
+ * @param reason - Reason for the backup (canonical: `'prose-edit'`)
+ * @returns `{ backupPath }` — absolute path to the created backup directory
+ */
+export async function createProseBackup(
+  filePath: string,
+  reason: string
+): Promise<{ backupPath: string }> {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const baseName = path.basename(filePath)
+  const backupDir = path.join(getBackupsDir(), baseName, `${timestamp}_${reason}`)
+
+  await fs.mkdir(backupDir, { recursive: true })
+  // Single-file copy — preserves byte-for-byte content for revert.
+  await fs.copyFile(filePath, path.join(backupDir, baseName))
+
+  return { backupPath: backupDir }
+}
+
+/**
  * SMI-1865: Recursively copy a directory
  */
 async function copyDirectory(src: string, dest: string): Promise<void> {

--- a/packages/mcp-server/tests/unit/edit-applier.test.ts
+++ b/packages/mcp-server/tests/unit/edit-applier.test.ts
@@ -1,0 +1,199 @@
+/**
+ * @fileoverview Unit tests for SMI-4589 Wave 3 — edit-applier.
+ * @module @skillsmith/mcp-server/tests/unit/edit-applier
+ *
+ * Covers the registry-rejection regression guard from plan §5 (synthetic
+ * edits with `pattern: 'narrow_scope'` / `'reword_trigger_verb'` must be
+ * rejected by `applyRecommendedEdit`'s registry guard, with the file
+ * byte-for-byte unchanged) plus the apply happy path and stale-before
+ * guard.
+ *
+ * Per-template gate (ratified 2026-05-01): only `add_domain_qualifier`
+ * (4.10/5) is in `APPLY_TEMPLATE_REGISTRY`. The regression test guards
+ * against future drift if SMI-4593 inadvertently registers a template
+ * before passing the gate.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { runEditSuggester } from '../../src/audit/edit-suggester.js'
+import { APPLY_TEMPLATE_REGISTRY, applyRecommendedEdit } from '../../src/audit/edit-applier.js'
+import type { EditTemplatePattern, RecommendedEdit } from '../../src/audit/edit-suggester.types.js'
+import {
+  cid,
+  makeAuditResult,
+  makeEntry,
+  makeSemanticFlag,
+  writeSkillMd,
+} from './edit-suggester.fixtures.js'
+
+let TEST_HOME: string
+let ORIGINAL_HOME: string | undefined
+
+beforeEach(() => {
+  TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-edit-applier-'))
+  ORIGINAL_HOME = process.env['HOME']
+  process.env['HOME'] = TEST_HOME
+})
+
+afterEach(() => {
+  if (ORIGINAL_HOME !== undefined) {
+    process.env['HOME'] = ORIGINAL_HOME
+  } else {
+    delete process.env['HOME']
+  }
+  if (TEST_HOME && fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+  }
+})
+
+describe('APPLY_TEMPLATE_REGISTRY contents', () => {
+  it("contains exactly 'add_domain_qualifier' in v1", () => {
+    expect(Array.from(APPLY_TEMPLATE_REGISTRY)).toEqual(['add_domain_qualifier'])
+  })
+})
+
+describe('applyRecommendedEdit — registry-rejection regression guard', () => {
+  it.each<EditTemplatePattern>(['narrow_scope', 'reword_trigger_verb'])(
+    'rejects synthetic edit with failing-template pattern %s without mutating the file',
+    async (pattern) => {
+      const filePath = writeSkillMd(TEST_HOME, {
+        identifier: 'untouched',
+        description: 'Use when running untouched workflows.',
+        tag: 'guarded',
+      })
+      const before = fs.readFileSync(filePath, 'utf-8')
+
+      const synthetic: RecommendedEdit = {
+        collisionId: cid('synthetic-coll'),
+        category:
+          pattern === 'reword_trigger_verb' ? 'claude_md_trigger_overlap' : 'description_overlap',
+        pattern,
+        filePath,
+        lineRange: { start: 1, end: 1 },
+        before: '---',
+        after: '+++',
+        rationale: 'synthetic test edit',
+        applyAction: 'recommended_edit',
+        applyMode: 'apply_with_confirmation',
+        otherEntry: { identifier: 'partner', sourcePath: '/tmp/partner' },
+      }
+
+      const result = await applyRecommendedEdit(synthetic, {
+        auditId: 'aud-synthetic',
+        mode: 'apply_with_confirmation',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.kind).toBe('edit.template_not_in_apply_registry')
+      expect(result.backupPath).toBe('')
+      expect(result.ledgerEntryId).toBe('')
+
+      const after = fs.readFileSync(filePath, 'utf-8')
+      expect(after).toBe(before)
+    }
+  )
+})
+
+describe('applyRecommendedEdit — apply happy path', () => {
+  it('returns the registered summary on apply_with_confirmation success and creates a backup', async () => {
+    const fileA = writeSkillMd(TEST_HOME, {
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const fileB = writeSkillMd(TEST_HOME, {
+      identifier: 'release-helper',
+      description: 'Use when deploying for the release pipeline.',
+      tag: 'community',
+    })
+    const entryA = makeEntry({
+      source_path: fileA,
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const entryB = makeEntry({
+      source_path: fileB,
+      identifier: 'release-helper',
+      description: 'Use when deploying for the release pipeline.',
+      tag: 'community',
+    })
+    const result = makeAuditResult([
+      makeSemanticFlag({ collisionId: 'coll-apply', entryA, entryB }),
+    ])
+    const edits = await runEditSuggester(result)
+    expect(edits).toHaveLength(1)
+    const edit = edits[0]!
+
+    const before = fs.readFileSync(edit.filePath, 'utf-8')
+    const applyResult = await applyRecommendedEdit(edit, {
+      auditId: 'aud-apply-01',
+      mode: 'apply_with_confirmation',
+    })
+
+    expect(applyResult.success).toBe(true)
+    expect(applyResult.error).toBeUndefined()
+    expect(applyResult.summary).toBe(
+      `Edited ${edit.filePath} lines ${edit.lineRange.start}-${edit.lineRange.end}. To undo: sklx audit revert aud-apply-01`
+    )
+    expect(applyResult.backupPath).not.toBe('')
+
+    const after = fs.readFileSync(edit.filePath, 'utf-8')
+    expect(after).not.toBe(before)
+    expect(after).toContain('for anthropic tasks')
+
+    const backupFiles = fs.readdirSync(applyResult.backupPath)
+    expect(backupFiles.length).toBeGreaterThan(0)
+    const backupContent = fs.readFileSync(
+      path.join(applyResult.backupPath, backupFiles[0]!),
+      'utf-8'
+    )
+    expect(backupContent).toBe(before)
+  })
+
+  it('returns edit.stale_before when before snippet has drifted', async () => {
+    const fileA = writeSkillMd(TEST_HOME, {
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const fileB = writeSkillMd(TEST_HOME, {
+      identifier: 'release-helper',
+      description: 'Use when deploying releases.',
+      tag: 'community',
+    })
+    const entryA = makeEntry({
+      source_path: fileA,
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const entryB = makeEntry({
+      source_path: fileB,
+      identifier: 'release-helper',
+      description: 'Use when deploying releases.',
+      tag: 'community',
+    })
+    const result = makeAuditResult([
+      makeSemanticFlag({ collisionId: 'coll-stale', entryA, entryB }),
+    ])
+    const edits = await runEditSuggester(result)
+    expect(edits).toHaveLength(1)
+    const edit = edits[0]!
+
+    fs.writeFileSync(edit.filePath, 'completely different content\n', 'utf-8')
+
+    const applyResult = await applyRecommendedEdit(edit, {
+      auditId: 'aud-stale-01',
+      mode: 'apply_with_confirmation',
+    })
+
+    expect(applyResult.success).toBe(false)
+    expect(applyResult.error?.kind).toBe('edit.stale_before')
+    expect(applyResult.backupPath).toBe('')
+  })
+})

--- a/packages/mcp-server/tests/unit/edit-suggester.fixtures.ts
+++ b/packages/mcp-server/tests/unit/edit-suggester.fixtures.ts
@@ -1,0 +1,110 @@
+/**
+ * @fileoverview Shared test fixtures for SMI-4589 Wave 3 edit-suggester /
+ *               edit-applier unit tests.
+ * @module @skillsmith/mcp-server/tests/unit/edit-suggester.fixtures
+ *
+ * Extracted from `edit-suggester.test.ts` per the 500-LOC pre-commit
+ * file-length gate. The `.fixtures.ts` suffix keeps the file outside
+ * vitest's `**\/*.test.ts` glob — no tests run from this module.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import type {
+  AuditId,
+  CollisionId,
+  InventoryAuditResult,
+  SemanticCollisionFlag,
+} from '../../src/audit/collision-detector.types.js'
+import type { InventoryEntry } from '../../src/utils/local-inventory.types.js'
+
+export const cid = (s: string): CollisionId => s as CollisionId
+export const aid = (s: string): AuditId => s as AuditId
+
+/**
+ * Write a stub SKILL.md to `<TEST_HOME>/.claude/skills/<identifier>/SKILL.md`.
+ * Returns the absolute file path. Caller is responsible for setting
+ * `process.env.HOME = TEST_HOME` before invoking — the helper does NOT
+ * resolve `getCanonicalInstallPath` itself.
+ */
+export function writeSkillMd(
+  testHome: string,
+  args: { identifier: string; description: string; tag?: string }
+): string {
+  const dir = path.join(testHome, '.claude', 'skills', args.identifier)
+  fs.mkdirSync(dir, { recursive: true })
+  const tagLine = args.tag ? `tags:\n  - ${args.tag}\n` : ''
+  const content = [
+    '---',
+    `name: ${args.identifier}`,
+    `description: ${args.description}`,
+    tagLine.trimEnd(),
+    '---',
+    '',
+    `# ${args.identifier}`,
+    '',
+  ]
+    .filter((l) => l.length > 0 || l === '')
+    .join('\n')
+  const filePath = path.join(dir, 'SKILL.md')
+  fs.writeFileSync(filePath, content, 'utf-8')
+  return filePath
+}
+
+export function makeEntry(args: {
+  source_path: string
+  identifier: string
+  description: string
+  tag?: string
+}): InventoryEntry {
+  return {
+    kind: 'skill',
+    source_path: args.source_path,
+    identifier: args.identifier,
+    triggerSurface: [args.identifier],
+    meta: {
+      description: args.description,
+      tags: args.tag ? [args.tag] : [],
+    },
+  }
+}
+
+export function makeSemanticFlag(args: {
+  collisionId: string
+  entryA: InventoryEntry
+  entryB: InventoryEntry
+  cosineScore?: number
+}): SemanticCollisionFlag {
+  return {
+    kind: 'semantic',
+    collisionId: cid(args.collisionId),
+    entryA: args.entryA,
+    entryB: args.entryB,
+    cosineScore: args.cosineScore ?? 0.82,
+    overlappingPhrases: [
+      { phrase1: 'Use when deploying', phrase2: 'Use when deploying', similarity: 0.9 },
+    ],
+    severity: 'warning',
+    reason: `semantic overlap (cosine ${(args.cosineScore ?? 0.82).toFixed(2)})`,
+  }
+}
+
+export function makeAuditResult(flags: SemanticCollisionFlag[]): InventoryAuditResult {
+  const inventory = flags.flatMap((f) => [f.entryA, f.entryB])
+  return {
+    auditId: aid('aud_test_01'),
+    inventory,
+    exactCollisions: [],
+    genericFlags: [],
+    semanticCollisions: flags,
+    summary: {
+      totalEntries: inventory.length,
+      totalFlags: flags.length,
+      errorCount: 0,
+      warningCount: flags.length,
+      durationMs: 1,
+      passDurations: { exact: 0, generic: 0, semantic: 1 },
+    },
+  }
+}

--- a/packages/mcp-server/tests/unit/edit-suggester.test.ts
+++ b/packages/mcp-server/tests/unit/edit-suggester.test.ts
@@ -1,0 +1,384 @@
+/**
+ * @fileoverview Unit tests for SMI-4589 Wave 3 — edit-suggester core (10 cases).
+ * @module @skillsmith/mcp-server/tests/unit/edit-suggester
+ *
+ * Covers the 10 cases enumerated in
+ * `docs/internal/implementation/smi-4589-edit-suggester.md` §Tests.
+ * Apply-path tests (registry rejection + apply success/stale-before)
+ * live in `edit-applier.test.ts` to keep both files under the 500-LOC
+ * pre-commit gate.
+ *
+ * Per-template gate (ratified 2026-05-01): only `add_domain_qualifier`
+ * (4.10/5) ships in v1. Cases 2-3 assert the failing templates produce
+ * NO `RecommendedEdit` from `runEditSuggester` — they're absent from
+ * Wave 3 output entirely per plan R-4/R-8.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { runEditSuggester } from '../../src/audit/edit-suggester.js'
+import type { InventoryEntry } from '../../src/utils/local-inventory.types.js'
+import {
+  makeAuditResult,
+  makeEntry,
+  makeSemanticFlag,
+  writeSkillMd,
+} from './edit-suggester.fixtures.js'
+
+let TEST_HOME: string
+let ORIGINAL_HOME: string | undefined
+
+beforeEach(() => {
+  TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-edit-suggester-'))
+  ORIGINAL_HOME = process.env['HOME']
+  process.env['HOME'] = TEST_HOME
+})
+
+afterEach(() => {
+  if (ORIGINAL_HOME !== undefined) {
+    process.env['HOME'] = ORIGINAL_HOME
+  } else {
+    delete process.env['HOME']
+  }
+  if (TEST_HOME && fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+  }
+})
+
+describe('runEditSuggester — case 1: add_domain_qualifier fires for asymmetric tags', () => {
+  it('emits a RecommendedEdit with `for <tag> tasks` injected after the trigger verb', async () => {
+    const fileA = writeSkillMd(TEST_HOME, {
+      identifier: 'release-tools',
+      description: 'Use when deploying to production. Handles release notes.',
+      tag: 'anthropic',
+    })
+    const fileB = writeSkillMd(TEST_HOME, {
+      identifier: 'release-helper',
+      description: 'Use when deploying for the release pipeline. Handles changelogs.',
+      tag: 'community',
+    })
+    const entryA = makeEntry({
+      source_path: fileA,
+      identifier: 'release-tools',
+      description: 'Use when deploying to production. Handles release notes.',
+      tag: 'anthropic',
+    })
+    const entryB = makeEntry({
+      source_path: fileB,
+      identifier: 'release-helper',
+      description: 'Use when deploying for the release pipeline. Handles changelogs.',
+      tag: 'community',
+    })
+
+    const result = makeAuditResult([
+      makeSemanticFlag({ collisionId: 'coll-01', entryA, entryB, cosineScore: 0.82 }),
+    ])
+
+    const edits = await runEditSuggester(result)
+    expect(edits).toHaveLength(1)
+    const edit = edits[0]!
+    expect(edit.pattern).toBe('add_domain_qualifier')
+    expect(edit.category).toBe('description_overlap')
+    expect(edit.applyMode).toBe('apply_with_confirmation')
+    expect(edit.applyAction).toBe('recommended_edit')
+    expect(edit.after).toContain('for anthropic tasks')
+    expect(edit.before).not.toContain('for anthropic tasks')
+    expect(edit.otherEntry.identifier).toBe('release-helper')
+    expect(edit.collisionId).toBe('coll-01')
+    expect(edit.rationale).toContain('cosine 0.82')
+  })
+})
+
+describe('runEditSuggester — case 2: narrow_scope-shape collision emits NO edit (template not registered)', () => {
+  it('returns empty when no entry has a unique tag', async () => {
+    const fileA = writeSkillMd(TEST_HOME, {
+      identifier: 'deployer-a',
+      description: 'Use when deploying releases.',
+      tag: 'shared',
+    })
+    const fileB = writeSkillMd(TEST_HOME, {
+      identifier: 'deployer-b',
+      description: 'Use when deploying releases.',
+      tag: 'shared',
+    })
+    const entryA = makeEntry({
+      source_path: fileA,
+      identifier: 'deployer-a',
+      description: 'Use when deploying releases.',
+      tag: 'shared',
+    })
+    const entryB = makeEntry({
+      source_path: fileB,
+      identifier: 'deployer-b',
+      description: 'Use when deploying releases.',
+      tag: 'shared',
+    })
+
+    const result = makeAuditResult([
+      makeSemanticFlag({ collisionId: 'coll-narrow-shape', entryA, entryB }),
+    ])
+    const edits = await runEditSuggester(result)
+    expect(edits).toHaveLength(0)
+  })
+})
+
+describe('runEditSuggester — case 3: reword_trigger_verb-shape (CLAUDE.md) emits NO edit', () => {
+  it('returns empty for claude_md_rule entries (template not registered in v1)', async () => {
+    const claudeMdPath = path.join(TEST_HOME, 'CLAUDE.md')
+    fs.writeFileSync(
+      claudeMdPath,
+      '## Trigger phrases\n- Use when deploying\n- Use when deploying\n',
+      'utf-8'
+    )
+    const entryA: InventoryEntry = {
+      kind: 'claude_md_rule',
+      source_path: claudeMdPath,
+      identifier: 'rule-a',
+      triggerSurface: ['Use when deploying'],
+      meta: { description: 'Use when deploying' },
+    }
+    const entryB: InventoryEntry = {
+      kind: 'claude_md_rule',
+      source_path: claudeMdPath,
+      identifier: 'rule-b',
+      triggerSurface: ['Use when deploying'],
+      meta: { description: 'Use when deploying' },
+    }
+    const result = makeAuditResult([
+      makeSemanticFlag({ collisionId: 'coll-claude-md', entryA, entryB }),
+    ])
+    const edits = await runEditSuggester(result)
+    expect(edits).toHaveLength(0)
+  })
+})
+
+describe('runEditSuggester — case 4: flag matching no template skipped, others still produce edits', () => {
+  it('isolates per-flag dispatch — non-matching flag does not poison matching flag', async () => {
+    const fileA = writeSkillMd(TEST_HOME, {
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const fileB = writeSkillMd(TEST_HOME, {
+      identifier: 'release-helper',
+      description: 'Use when deploying for the release pipeline.',
+      tag: 'community',
+    })
+    const entryA = makeEntry({
+      source_path: fileA,
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const entryB = makeEntry({
+      source_path: fileB,
+      identifier: 'release-helper',
+      description: 'Use when deploying for the release pipeline.',
+      tag: 'community',
+    })
+    const entryC = makeEntry({
+      source_path: fileA,
+      identifier: 'shared-c',
+      description: 'Use when deploying releases.',
+      tag: 'shared',
+    })
+    const entryD = makeEntry({
+      source_path: fileB,
+      identifier: 'shared-d',
+      description: 'Use when deploying releases.',
+      tag: 'shared',
+    })
+
+    const result = makeAuditResult([
+      makeSemanticFlag({ collisionId: 'coll-match', entryA, entryB }),
+      makeSemanticFlag({ collisionId: 'coll-skip', entryA: entryC, entryB: entryD }),
+    ])
+    const edits = await runEditSuggester(result)
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.collisionId).toBe('coll-match')
+  })
+})
+
+describe('runEditSuggester — case 5: line-range extraction matches file content byte-for-byte', () => {
+  it("`before` snippet equals fileLines.slice(start-1, end).join('\\n')", async () => {
+    const fileA = writeSkillMd(TEST_HOME, {
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const fileB = writeSkillMd(TEST_HOME, {
+      identifier: 'release-helper',
+      description: 'Use when deploying for the release pipeline.',
+      tag: 'community',
+    })
+    const entryA = makeEntry({
+      source_path: fileA,
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const entryB = makeEntry({
+      source_path: fileB,
+      identifier: 'release-helper',
+      description: 'Use when deploying for the release pipeline.',
+      tag: 'community',
+    })
+    const result = makeAuditResult([makeSemanticFlag({ collisionId: 'coll-byte', entryA, entryB })])
+    const edits = await runEditSuggester(result)
+    expect(edits).toHaveLength(1)
+    const edit = edits[0]!
+
+    const fileLines = fs.readFileSync(edit.filePath, 'utf-8').split('\n')
+    const startIdx = edit.lineRange.start - 1
+    const endIdx = edit.lineRange.end - 1
+    const reconstructed = fileLines.slice(startIdx, endIdx + 1).join('\n')
+    expect(edit.before).toBe(reconstructed)
+  })
+})
+
+describe('runEditSuggester — case 6: multiple flags on the same file produce independent edits', () => {
+  it('emits one RecommendedEdit per matching flag, stable in input order', async () => {
+    const fileA = writeSkillMd(TEST_HOME, {
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const fileB = writeSkillMd(TEST_HOME, {
+      identifier: 'release-helper-1',
+      description: 'Use when deploying for stage one.',
+      tag: 'community',
+    })
+    const fileC = writeSkillMd(TEST_HOME, {
+      identifier: 'release-helper-2',
+      description: 'Use when deploying for stage two.',
+      tag: 'enterprise',
+    })
+    const entryA = makeEntry({
+      source_path: fileA,
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const entryB = makeEntry({
+      source_path: fileB,
+      identifier: 'release-helper-1',
+      description: 'Use when deploying for stage one.',
+      tag: 'community',
+    })
+    const entryC = makeEntry({
+      source_path: fileC,
+      identifier: 'release-helper-2',
+      description: 'Use when deploying for stage two.',
+      tag: 'enterprise',
+    })
+    const result = makeAuditResult([
+      makeSemanticFlag({ collisionId: 'coll-multi-1', entryA, entryB }),
+      makeSemanticFlag({ collisionId: 'coll-multi-2', entryA, entryB: entryC }),
+    ])
+    const edits = await runEditSuggester(result)
+    expect(edits.length).toBeGreaterThanOrEqual(2)
+    expect(edits[0]!.collisionId).toBe('coll-multi-1')
+    expect(edits[1]!.collisionId).toBe('coll-multi-2')
+  })
+})
+
+describe('runEditSuggester — case 7: applyMode is apply_with_confirmation for shipped template', () => {
+  it("returned edit's applyMode equals 'apply_with_confirmation'", async () => {
+    const fileA = writeSkillMd(TEST_HOME, {
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const fileB = writeSkillMd(TEST_HOME, {
+      identifier: 'release-helper',
+      description: 'Use when deploying releases.',
+      tag: 'community',
+    })
+    const entryA = makeEntry({
+      source_path: fileA,
+      identifier: 'release-tools',
+      description: 'Use when deploying to production.',
+      tag: 'anthropic',
+    })
+    const entryB = makeEntry({
+      source_path: fileB,
+      identifier: 'release-helper',
+      description: 'Use when deploying releases.',
+      tag: 'community',
+    })
+    const result = makeAuditResult([makeSemanticFlag({ collisionId: 'coll-mode', entryA, entryB })])
+    const edits = await runEditSuggester(result)
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.applyMode).toBe('apply_with_confirmation')
+  })
+})
+
+describe('runEditSuggester — case 8: otherEntry cross-references the partner', () => {
+  it('otherEntry.identifier matches the partner in the original SemanticCollisionFlag', async () => {
+    const fileA = writeSkillMd(TEST_HOME, {
+      identifier: 'tool-alpha',
+      description: 'Use when running alpha workflows.',
+      tag: 'alpha-only',
+    })
+    const fileB = writeSkillMd(TEST_HOME, {
+      identifier: 'tool-beta',
+      description: 'Use when running beta workflows.',
+      tag: 'beta-only',
+    })
+    const entryA = makeEntry({
+      source_path: fileA,
+      identifier: 'tool-alpha',
+      description: 'Use when running alpha workflows.',
+      tag: 'alpha-only',
+    })
+    const entryB = makeEntry({
+      source_path: fileB,
+      identifier: 'tool-beta',
+      description: 'Use when running beta workflows.',
+      tag: 'beta-only',
+    })
+    const result = makeAuditResult([
+      makeSemanticFlag({ collisionId: 'coll-other', entryA, entryB }),
+    ])
+    const edits = await runEditSuggester(result)
+    expect(edits).toHaveLength(1)
+    const edit = edits[0]!
+    expect(edit.otherEntry.identifier).toBe('tool-beta')
+    expect(edit.otherEntry.sourcePath).toBe(fileB)
+  })
+})
+
+describe('runEditSuggester — case 9: missing file produces no exception, no edit', () => {
+  it('soft-warns and skips when source_path does not exist', async () => {
+    const missingPath = path.join(TEST_HOME, 'does-not-exist', 'SKILL.md')
+    const partnerPath = path.join(TEST_HOME, 'also-missing', 'SKILL.md')
+    const entryA = makeEntry({
+      source_path: missingPath,
+      identifier: 'phantom-a',
+      description: 'Use when running phantom tasks.',
+      tag: 'phantom',
+    })
+    const entryB = makeEntry({
+      source_path: partnerPath,
+      identifier: 'phantom-b',
+      description: 'Use when running phantom tasks.',
+      tag: 'partner',
+    })
+    const result = makeAuditResult([
+      makeSemanticFlag({ collisionId: 'coll-missing', entryA, entryB }),
+    ])
+    const edits = await runEditSuggester(result)
+    expect(edits).toHaveLength(0)
+  })
+})
+
+describe('runEditSuggester — case 10: empty semanticCollisions short-circuits', () => {
+  it('returns empty array with no I/O', async () => {
+    const result = makeAuditResult([])
+    const edits = await runEditSuggester(result)
+    expect(edits).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Ships the templated prose-edit-suggestion path for `description_overlap` semantic collisions (Wave 3 of SMI-4584 Consumer Namespace Audit).
- Per the per-template gate ratified 2026-05-01, only `add_domain_qualifier` (4.10/5 GPT-5.4 reviewer-#2) clears and registers in `APPLY_TEMPLATE_REGISTRY` for `apply_with_confirmation`. The other two templates (`narrow_scope` 1.70/5, `reword_trigger_verb` 2.35/5) FAILED the gate and are NOT shipped in any form (not auto-apply, not `manual_review`); routed to **SMI-4593** for reauthor.
- Wave 4 (SMI-4590) is strict-stack on this; the inline revert summary literal mentions `sklx audit revert <auditId>` which is a Wave 4 CLI surface. Until Wave 4 lands, the command in the summary string is a no-op preview.

## Surfaces shipped

- **`runEditSuggester`** (`packages/mcp-server/src/audit/edit-suggester.ts`, 363 LOC) — produces `RecommendedEdit[]` from semantic flags via single-template registry; templates pre-sorted by descending priority; parallel file-read phase keeps latency linear in unique-files (not templates × collisions).
- **`applyRecommendedEdit`** (`packages/mcp-server/src/audit/edit-applier.ts`, 268 LOC) + **`APPLY_TEMPLATE_REGISTRY`** literal allowlist (`new Set(['add_domain_qualifier'])`):
  - Registry guard rejects failing-template patterns up front with `error: 'edit.template_not_in_apply_registry'`.
  - Stale-before guard verifies file content byte-for-byte; mismatch returns `error: 'edit.stale_before'` and the file is untouched.
  - `createProseBackup` writes to canonical `getBackupsDir()` path (NOT a new path convention).
  - Atomic `tmp + fs.rename` mutation.
  - Ledger append via Wave 2's `appendOverride` (last-write-wins atomic semantics).
  - Inline revert summary literal: `"Edited <file> lines <range>. To undo: sklx audit revert <auditId>"`.
- **Audit-report writer extension** — new "Recommended Edits" section rendered as unified `diff` fenced markdown blocks per plan §2 (`audit-report-writer.ts` 333 LOC, well under 500 cap).
- **`NamespaceWarning.recommendedEdit`** field — `install-preflight.ts` wires `runEditSuggester` over the audit result and attaches matching edits by `collisionId`. Suggester failure degrades to no-edits (preserves Wave 2 Edit 2 non-blocking install contract).

## Tests (15 new)

`packages/mcp-server/tests/unit/edit-suggester.test.ts` — 10 dispatch cases:
1. `add_domain_qualifier` fires for asymmetric tags.
2. `narrow_scope`-shape collision emits NO edit (failing template not registered).
3. `reword_trigger_verb`-shape (CLAUDE.md) emits NO edit (failing template not registered).
4. Mixed flags: non-matching flag does not poison matching flag.
5. Line-range extraction matches file content byte-for-byte.
6. Multiple flags on same file produce independent edits, stable order.
7. `applyMode === 'apply_with_confirmation'` for the shipped template.
8. `otherEntry` cross-references the partner.
9. Missing file produces no exception, no edit.
10. Empty `semanticCollisions` short-circuits with no I/O.

`packages/mcp-server/tests/unit/edit-applier.test.ts`:
- `APPLY_TEMPLATE_REGISTRY` contents assertion.
- Registry-rejection regression guard parameterized over `narrow_scope` + `reword_trigger_verb`: synthetic edits → typed error, file byte-for-byte unchanged.
- Apply happy path with backup verification.
- Stale-before drift guard.

Shared fixtures live in `tests/unit/edit-suggester.fixtures.ts` (110 LOC, outside vitest's `**/*.test.ts` glob).

## Plan-review carryover satisfied

Surface paths verified canonical before edits:
- `createProseBackup` uses `getBackupsDir()` from `install.conflict-helpers.ts:23`.
- Ledger writes via Wave 2's `appendOverride` (NOT a parallel ledger).
- `NamespaceWarning` extended with optional `recommendedEdit` field rather than creating a parallel warning shape.

## Pre-condition (plan checklist line 306)

`scripts/spikes/smi-4586/aggregate-goal6.ts` landed on `spike/smi-4586/run-1` at commit `cb75fe43` — reproduces the per-template means in `goal_6.per_template_gate.verdicts` from `goal6-review-harness.csv`.

## Follow-up

- **SMI-4593** reauthors `narrow_scope` and `reword_trigger_verb` template bodies and re-registers them in `APPLY_TEMPLATE_REGISTRY` upon clearing the per-template gate.

## Test plan

- [ ] CI green (post-merge-verify + PR matrix exercise the new colocated tests via root config + per-package config respectively).
- [ ] Manual verification: render an audit report markdown for a fixture with planted semantic collisions; eyeball that the "Recommended Edits" diff blocks are accurate and copy-paste-clean.
- [ ] No regressions in install-preflight.test.ts (verified locally — 14/14 still pass after the `recommendedEdit` field addition).

## Commits

- `b14fe5c1` feat(mcp-server): SMI-4589 Wave 3 — edit-suggester (apply_with_confirmation for add_domain_qualifier)
- `ebdd1a29` chore(mcp-server): SMI-4589 governance pass — consolidate imports + extract preflight helper

Linear: SMI-4589

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)