### PR TITLE
feat(scripts): SMI-4653 remove-worktree.sh cleans Docker image + volume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ git submodule update --init                           # Init internal docs (auth
 
 **Not encrypted** (always readable): `.claude/settings.json`, `supabase/config.toml`, `.claude/development/`, `.claude/templates/`.
 
-**Worktrees**: Unlock main repo first, then `./scripts/create-worktree.sh`. Remove with `./scripts/remove-worktree.sh --prune`.
+**Worktrees**: Unlock main repo first, then `./scripts/create-worktree.sh`. Remove with `./scripts/remove-worktree.sh --prune`. By default removal also deletes the per-worktree Docker image (`<dir>-dev`) and `_node_modules` volume — pass `--keep-docker` to preserve them.
 
 **Hooks in worktrees (SMI-4377 + SMI-4381 + SMI-4549)**: Pre-commit hooks work inside worktrees via three mechanisms: (1) `.husky/_/` is tracked in git (husky's dispatch stubs) so hook discovery inherits through checkout; (2) `scripts/create-worktree.sh` symlinks the root `node_modules` from the main repo (relative path); (3) **per-package `node_modules` are also symlinked** (relative paths) so workspace-pinned deps (e.g. `zod@3.25.76` in `mcp-server`) resolve correctly without falling through to the hoisted root (which carries `zod@4.x`). **One-time host setup required** (after fresh clone):
 

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -296,6 +296,23 @@ if (existsSync('docker-compose.yml')) {
     } else {
       fail('Volume mount not configured', 'Add ".:/app" to volumes')
     }
+
+    // SMI-4653: assert no service has an explicit `image:` field. Load-bearing
+    // for `remove-worktree.sh`'s `docker compose down --rmi local` cleanup —
+    // adding an `image:` field would silently turn `--rmi local` into a no-op
+    // and orphan worktree images would accumulate again.
+    // Match `^[ \t]*image:` at the start of a line (allowing 2-6 leading spaces),
+    // anywhere in the file. Comments (`# image:`) and substring matches in
+    // values are excluded by anchoring on whitespace-only indent.
+    const imageFieldRegex = /^[ \t]{2,6}image:\s/m
+    if (imageFieldRegex.test(dockerCompose)) {
+      fail(
+        'docker-compose.yml has an explicit `image:` field on a service (SMI-4653)',
+        'Remove the `image:` field; rely on `build:` so `docker compose down --rmi local` in remove-worktree.sh can clean up the per-worktree image. If an `image:` field is genuinely required, update remove-worktree.sh to remove the image by tag explicitly and document the new contract.'
+      )
+    } else {
+      pass('docker-compose.yml has no explicit `image:` fields (SMI-4653 cleanup contract)')
+    }
   } catch (e) {
     fail(`Error reading docker-compose.yml: ${e.message}`)
   }

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -25,7 +25,7 @@ NETWORK_WARN_THRESHOLD=5
 #######################################
 usage() {
     cat << EOF
-Usage: $(basename "$0") <worktree-path> [--force]
+Usage: $(basename "$0") <worktree-path> [--force] [--prune] [--keep-docker]
 
 Remove a git worktree and clean up associated Docker resources.
 
@@ -35,18 +35,22 @@ Arguments:
 Options:
   --force         Force removal even if worktree has dirty files
   --prune         Also prune stale Docker networks
+  --keep-docker   Preserve the per-worktree Docker image and node_modules volume
+                  (default: both are removed alongside the worktree)
   -h, --help      Show this help message and exit
 
 Examples:
   $(basename "$0") worktrees/my-feature
   $(basename "$0") worktrees/my-feature --force
   $(basename "$0") worktrees/my-feature --force --prune
+  $(basename "$0") worktrees/my-feature --keep-docker
 
 What this script does:
   1. Stops Docker containers associated with the worktree
-  2. Removes the git worktree (with --force if specified)
-  3. Checks Docker network count and warns if above threshold
-  4. Optionally prunes stale Docker networks (--prune)
+  2. Removes per-worktree Docker image and node_modules volume (unless --keep-docker)
+  3. Removes the git worktree (with --force if specified)
+  4. Checks Docker network count and warns if above threshold
+  5. Optionally prunes stale Docker networks (--prune)
 
 EOF
 }
@@ -66,6 +70,75 @@ stop_worktree_containers() {
             warn "  Could not stop Docker containers (may already be stopped)"
         fi
     fi
+}
+
+#######################################
+# Remove per-worktree Docker image and node_modules volume
+#
+# IMPORTANT: this function MUST run BEFORE `git worktree remove` because
+# Path A (`docker compose down`) needs the worktree directory (and its
+# docker-compose.override.yml) to still exist. Do NOT reorder.
+#
+# Arguments:
+#   $1 - Worktree path (absolute)
+#
+# Behavior:
+#   - Refuses to operate on the main repo (would destroy active dev resources)
+#   - Path A: `docker compose down --volumes --rmi local` from the worktree dir
+#   - Path B: name-based fallback `docker rmi`/`docker volume rm` (idempotent)
+#######################################
+cleanup_worktree_docker_resources() {
+    local worktree_path="$1"
+
+    if ! command -v docker &>/dev/null; then
+        warn "Docker not found, skipping per-worktree resource cleanup"
+        return 0
+    fi
+
+    # Critical guard: never operate on the main repo. Without this,
+    # misinvoking `remove-worktree.sh /path/to/main` would destroy
+    # `skillsmith-dev` + `skillsmith_node_modules`.
+    local main_dir main_repo
+    main_dir="$(get_main_git_dir "$worktree_path" 2>/dev/null || true)"
+    if [[ -n "$main_dir" ]]; then
+        main_repo="$(dirname "$main_dir")"
+        if [[ "$worktree_path" == "$main_repo" ]]; then
+            error "Refusing to clean Docker resources for the main repo: $worktree_path"
+        fi
+    fi
+
+    # Compose-equivalent project name: lowercase + drop chars outside
+    # [a-z0-9_-]. Matches docker compose v2 ProjectName sanitization.
+    # Plain `basename` would diverge for dirs containing uppercase or
+    # special chars.
+    local project_name
+    project_name="$(basename "$worktree_path" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]//g')"
+
+    # Path A: prefer compose-managed teardown when the override file exists.
+    # `down --volumes --rmi local` removes named volumes declared in compose
+    # AND any image without an explicit `image:` field. NOTE: --rmi local is
+    # load-bearing — if a service in docker-compose.yml gains an explicit
+    # `image:` field, --rmi local becomes a silent no-op and Path B alone
+    # carries the cleanup. The audit-standards check enforces no `image:`
+    # field at lint time.
+    # No `--profile` filter so dev/test/orchestrator all tear down.
+    if [[ -f "$worktree_path/docker-compose.override.yml" ]]; then
+        info "Removing per-worktree Docker image and volumes (compose)..."
+        if (cd "$worktree_path" && docker compose down --volumes --rmi local 2>/dev/null); then
+            success "  Compose teardown complete"
+        else
+            warn "  Compose teardown returned non-zero (continuing with name-based fallback)"
+        fi
+    fi
+
+    # Path B: name-based fallback. Idempotent — these always run, even when
+    # Path A succeeded, to catch any image/volume that compose lost track of
+    # (e.g. previous partial runs, manually-renamed projects).
+    info "Removing Docker resources by derived name..."
+    docker rmi "${project_name}-dev" 2>/dev/null && success "  Removed image $project_name-dev" || true
+    docker volume rm "${project_name}_node_modules" 2>/dev/null && success "  Removed volume ${project_name}_node_modules" || true
+
+    info "Tip: pass --keep-docker on future removals to preserve image + volume."
 }
 
 #######################################
@@ -121,6 +194,7 @@ main() {
     local worktree_path=""
     local force_flag=""
     local prune_flag=false
+    local keep_docker=false
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -135,6 +209,10 @@ main() {
                 ;;
             --prune)
                 prune_flag=true
+                shift
+                ;;
+            --keep-docker)
+                keep_docker=true
                 shift
                 ;;
             -*)
@@ -172,6 +250,25 @@ main() {
         error "Worktree not found at: $worktree_path"
     fi
 
+    # Critical guard: refuse to operate on the main repo BEFORE any side effects.
+    # Without this, stop_worktree_containers below would `docker compose down`
+    # the live skillsmith-dev-1 container if invoked on the main repo path.
+    # Resolves before any docker/git/rm operation runs.
+    local _main_dir _main_repo
+    _main_dir="$(get_main_git_dir "$worktree_path" 2>/dev/null || true)"
+    if [[ -n "$_main_dir" ]]; then
+        _main_repo="$(dirname "$_main_dir")"
+        # Normalize trailing slashes by resolving both paths
+        if [[ -d "$_main_repo" ]]; then
+            _main_repo="$(cd "$_main_repo" && pwd -P)"
+        fi
+        local _resolved_worktree
+        _resolved_worktree="$(cd "$worktree_path" && pwd -P)"
+        if [[ "$_resolved_worktree" == "$_main_repo" ]]; then
+            error "Refusing to remove the main repo as a worktree: $worktree_path"
+        fi
+    fi
+
     echo ""
     info "Removing worktree: $worktree_path"
     echo ""
@@ -184,6 +281,15 @@ main() {
     # check; explicit cleanup keeps intent clear.
     if [[ -L "$worktree_path/node_modules" ]]; then
         rm -f "$worktree_path/node_modules"
+    fi
+
+    # Step 1c: Remove per-worktree Docker image + volume unless opted out.
+    # Must run before `git worktree remove` so the worktree dir (and its
+    # docker-compose.override.yml) are still on disk for compose teardown.
+    if [[ "$keep_docker" == false ]]; then
+        cleanup_worktree_docker_resources "$worktree_path"
+    else
+        info "Skipping per-worktree Docker resource cleanup (--keep-docker)"
     fi
 
     # Step 2: Remove the worktree

--- a/scripts/tests/remove-worktree.test.ts
+++ b/scripts/tests/remove-worktree.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Integration tests for remove-worktree.sh (SMI-4653)
+ *
+ * Verifies the per-worktree Docker resource cleanup added in SMI-4653:
+ *   - Default flow runs `docker compose down --volumes --rmi local`
+ *   - Name-based fallback always runs (`docker rmi`, `docker volume rm`)
+ *   - Compose-fail / rmi-fail paths still continue
+ *   - --keep-docker skips all cleanup
+ *   - Main-repo guard refuses to operate on the main repo
+ *   - Project-name sanitization matches Docker Compose v2 rules
+ *
+ * Tests use a fake `docker` shim on PATH that records invocations.
+ * No real Docker daemon is needed; no git-crypt encryption is used.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync, existsSync, writeFileSync, chmodSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const SCRIPT_PATH = join(__dirname, '..', 'remove-worktree.sh')
+
+/** Shared env for git commands — main as default branch, no global config bleed */
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'Test',
+  GIT_AUTHOR_EMAIL: 'test@test.com',
+  GIT_COMMITTER_NAME: 'Test',
+  GIT_COMMITTER_EMAIL: 'test@test.com',
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null',
+}
+
+function makeTempDir(prefix: string): string {
+  const base = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  return mkdtempSync(base)
+}
+
+function git(cwd: string, args: string): string {
+  return execSync(`git -c init.defaultBranch=main -c protocol.file.allow=always ${args}`, {
+    cwd,
+    encoding: 'utf8',
+    env: GIT_ENV,
+  }).trim()
+}
+
+function sh(cmd: string, opts?: { cwd?: string }): string {
+  return execSync(cmd, { encoding: 'utf8', env: GIT_ENV, ...opts }).trim()
+}
+
+/**
+ * Write a docker shim to `binDir/docker`. Records invocations to `logPath`.
+ * Optional `exitCodesPath` — newline-delimited exit codes consumed in order;
+ * defaults to 0 when exhausted/unset.
+ */
+function writeDockerShim(binDir: string, logPath: string, exitCodesPath?: string): void {
+  const shim = `#!/bin/sh
+echo "$@" >> "${logPath}"
+${
+  exitCodesPath
+    ? `if [ -f "${exitCodesPath}" ] && [ -s "${exitCodesPath}" ]; then
+  code="$(head -n 1 "${exitCodesPath}")"
+  tail -n +2 "${exitCodesPath}" > "${exitCodesPath}.tmp" && mv "${exitCodesPath}.tmp" "${exitCodesPath}"
+  exit "$\{code:-0}"
+fi
+`
+    : ''
+}exit 0
+`
+  const shimPath = join(binDir, 'docker')
+  writeFileSync(shimPath, shim)
+  chmodSync(shimPath, 0o755)
+}
+
+/**
+ * Run remove-worktree.sh with a fake docker on PATH; return logged invocations + script result.
+ * cwd defaults to the binDir's parent (the test's tempRoot) so git/auto-discovery doesn't
+ * pick up the host's vitest cwd repo.
+ */
+function runScriptWithDockerShim(
+  args: string,
+  binDir: string,
+  logPath: string,
+  cwd?: string
+): { status: number; stdout: string; stderr: string; dockerCalls: string[] } {
+  const env = {
+    ...GIT_ENV,
+    PATH: `${binDir}:${GIT_ENV.PATH ?? ''}`,
+  }
+  let result: { status: number; stdout: string; stderr: string }
+  try {
+    const stdout = execSync(`bash "${SCRIPT_PATH}" ${args}`, {
+      encoding: 'utf8',
+      timeout: 30_000,
+      env,
+      cwd,
+    })
+    result = { status: 0, stdout, stderr: '' }
+  } catch (err) {
+    const e = err as { status: number; stdout: string; stderr: string }
+    result = { status: e.status ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' }
+  }
+
+  const dockerCalls = existsSync(logPath)
+    ? readFileSync(logPath, 'utf8')
+        .split('\n')
+        .filter((line) => line.length > 0)
+    : []
+
+  return { ...result, dockerCalls }
+}
+
+/**
+ * Set up a throwaway repo + worktree at the given dir name. Returns paths.
+ * Optionally drops a docker-compose.override.yml in the worktree to trigger Path A.
+ */
+function setupRepoWithWorktree(
+  tempRoot: string,
+  worktreeDirName: string,
+  withComposeOverride = true
+): { repoDir: string; worktreeDir: string } {
+  const repoDir = join(tempRoot, 'repo')
+  const worktreeDir = join(tempRoot, worktreeDirName)
+
+  git(tempRoot, `init "${repoDir}"`)
+  sh(`touch "${join(repoDir, 'README.md')}"`)
+  git(repoDir, 'add README.md')
+  git(repoDir, 'commit -m "initial"')
+
+  git(repoDir, `worktree add -b feat "${worktreeDir}"`)
+
+  if (withComposeOverride) {
+    writeFileSync(join(worktreeDir, 'docker-compose.override.yml'), 'services: {}\n')
+  }
+
+  return { repoDir, worktreeDir }
+}
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+  tempDirs.length = 0
+})
+
+describe('SMI-4653: remove-worktree.sh per-worktree Docker cleanup', () => {
+  it('runs `docker compose down --volumes --rmi local` then name-based fallback', () => {
+    const tempRoot = makeTempDir('rmwt-default')
+    tempDirs.push(tempRoot)
+    const { repoDir, worktreeDir } = setupRepoWithWorktree(tempRoot, 'wt-feature')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    writeDockerShim(binDir, logPath)
+
+    const result = runScriptWithDockerShim(`"${worktreeDir}" --force`, binDir, logPath, repoDir)
+
+    expect(result.status).toBe(0)
+    // Path A: cleanup-side compose down has --volumes --rmi local AND no --profile filter
+    // (so dev/test/orchestrator services all tear down). The pre-existing stop_worktree_containers
+    // does emit `compose --profile dev down` separately — we assert on the exact cleanup string.
+    expect(result.dockerCalls).toContain('compose down --volumes --rmi local')
+    // Path B: fallback rmi + volume rm
+    expect(result.dockerCalls).toContain('rmi wt-feature-dev')
+    expect(result.dockerCalls).toContain('volume rm wt-feature_node_modules')
+  })
+
+  it('--keep-docker skips compose down AND fallback rmi/volume rm', () => {
+    const tempRoot = makeTempDir('rmwt-keep')
+    tempDirs.push(tempRoot)
+    const { repoDir, worktreeDir } = setupRepoWithWorktree(tempRoot, 'wt-keep')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    writeDockerShim(binDir, logPath)
+
+    const result = runScriptWithDockerShim(
+      `"${worktreeDir}" --force --keep-docker`,
+      binDir,
+      logPath,
+      repoDir
+    )
+
+    expect(result.status).toBe(0)
+    // No cleanup-related docker calls. The pre-existing stop_worktree_containers
+    // path may emit `compose --profile dev down` (without --rmi/--volumes), which
+    // is the existing behavior we are preserving — that one is allowed.
+    expect(result.dockerCalls.some((c) => c.includes('--rmi'))).toBe(false)
+    expect(result.dockerCalls.some((c) => c === 'volume rm wt-keep_node_modules')).toBe(false)
+    expect(result.dockerCalls.some((c) => c === 'rmi wt-keep-dev')).toBe(false)
+  })
+
+  it('compose down failing does not block the name-based fallback', () => {
+    const tempRoot = makeTempDir('rmwt-compose-fail')
+    tempDirs.push(tempRoot)
+    const { repoDir, worktreeDir } = setupRepoWithWorktree(tempRoot, 'wt-fail')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    const exitCodesPath = join(tempRoot, 'exit-codes')
+    // First docker call (stop_worktree_containers `compose --profile dev down`) → 0
+    // Second docker call (Path A `compose down --volumes --rmi local`) → 1 (fail)
+    // Subsequent calls → 0 (rmi, volume rm fall through)
+    writeFileSync(exitCodesPath, '0\n1\n0\n0\n')
+    writeDockerShim(binDir, logPath, exitCodesPath)
+
+    const result = runScriptWithDockerShim(`"${worktreeDir}" --force`, binDir, logPath, repoDir)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls).toContain('rmi wt-fail-dev')
+    expect(result.dockerCalls).toContain('volume rm wt-fail_node_modules')
+  })
+
+  it('rmi failing does not block the volume rm step', () => {
+    const tempRoot = makeTempDir('rmwt-rmi-fail')
+    tempDirs.push(tempRoot)
+    const { repoDir, worktreeDir } = setupRepoWithWorktree(tempRoot, 'wt-rmifail')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    const exitCodesPath = join(tempRoot, 'exit-codes')
+    // 0 (stop), 0 (compose down), 1 (rmi fails), 0 (volume rm)
+    writeFileSync(exitCodesPath, '0\n0\n1\n0\n')
+    writeDockerShim(binDir, logPath, exitCodesPath)
+
+    const result = runScriptWithDockerShim(`"${worktreeDir}" --force`, binDir, logPath, repoDir)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls).toContain('rmi wt-rmifail-dev')
+    expect(result.dockerCalls).toContain('volume rm wt-rmifail_node_modules')
+  })
+
+  it('refuses to clean Docker resources for the main repo', () => {
+    const tempRoot = makeTempDir('rmwt-main-guard')
+    tempDirs.push(tempRoot)
+    const { repoDir } = setupRepoWithWorktree(tempRoot, 'wt-main')
+    // create-worktree-style override at the main repo too — script needs to
+    // refuse before touching it.
+    writeFileSync(join(repoDir, 'docker-compose.override.yml'), 'services: {}\n')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    writeDockerShim(binDir, logPath)
+
+    const result = runScriptWithDockerShim(`"${repoDir}"`, binDir, logPath, repoDir)
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr + result.stdout).toMatch(/Refusing to remove the main repo as a worktree/)
+    // No docker side-effects of any kind should have run — guard fires before
+    // stop_worktree_containers, the symlink rm, or the cleanup function.
+    expect(result.dockerCalls.length).toBe(0)
+  })
+
+  it('sanitizes uppercase/special-char dir names to match Docker Compose project name', () => {
+    const tempRoot = makeTempDir('rmwt-sanitize')
+    tempDirs.push(tempRoot)
+    const { repoDir, worktreeDir } = setupRepoWithWorktree(tempRoot, 'SMI-4700_Test')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    writeDockerShim(binDir, logPath)
+
+    const result = runScriptWithDockerShim(`"${worktreeDir}" --force`, binDir, logPath, repoDir)
+
+    expect(result.status).toBe(0)
+    // Sanitization: SMI-4700_Test → smi-4700_test
+    expect(result.dockerCalls).toContain('rmi smi-4700_test-dev')
+    expect(result.dockerCalls).toContain('volume rm smi-4700_test_node_modules')
+  })
+
+  it('idempotent re-run does not error after resources are gone', () => {
+    const tempRoot = makeTempDir('rmwt-idempotent')
+    tempDirs.push(tempRoot)
+    const { repoDir, worktreeDir } = setupRepoWithWorktree(tempRoot, 'wt-idem')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    const exitCodesPath = join(tempRoot, 'exit-codes')
+    // Cleanup ops (compose stop, compose down, rmi, volume rm) → 1 (resources already gone).
+    // network ls (final check_docker_networks call) → 0 so the pipefail-protected pipeline
+    // doesn't blow up. Script should still succeed end-to-end.
+    writeFileSync(exitCodesPath, '1\n1\n1\n1\n0\n')
+    writeDockerShim(binDir, logPath, exitCodesPath)
+
+    const result = runScriptWithDockerShim(`"${worktreeDir}" --force`, binDir, logPath, repoDir)
+
+    expect(result.status).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- `scripts/remove-worktree.sh` now removes the per-worktree `<dir>-dev` Docker image and `<dir>_node_modules` volume by default; `--keep-docker` opts out.
- Critical guard refuses to operate on the main repo (would otherwise stop the live `skillsmith-dev-1` container and destroy `skillsmith-dev` + `skillsmith_node_modules`).
- New audit-standards check enforces the load-bearing contract (no explicit `image:` field in `docker-compose.yml`).

Closes SMI-4653.

## Why

The 2026-05-02 manual cleanup pass reclaimed ~140 GB of orphan Docker resources (16 worktree images, 24 `_node_modules` volumes, 38 GB build cache) — second near-full-disk caused by the same failure mode. Without this fix the cycle repeats.

## What changed

| File | Change |
|---|---|
| `scripts/remove-worktree.sh` | New `cleanup_worktree_docker_resources()` (~50 lines), `--keep-docker` flag, top-of-`main()` main-repo guard, defense-in-depth guard inside cleanup function |
| `scripts/audit-standards.mjs` | New SMI-4653 check: no service in `docker-compose.yml` may declare an explicit `image:` field |
| `scripts/tests/remove-worktree.test.ts` | New (294 lines) — vitest with fake `docker` shim supporting per-invocation exit codes; 7 tests cover default flow, `--keep-docker`, compose-fail fallback, rmi-fail fallback, main-repo guard, sanitization, idempotent re-run |
| `CLAUDE.md` | One-line update to Worktrees section |
| `docs/internal` | Submodule bump to include the implementation plan |

Plan + plan-review (VP Product / VP Engineering / VP Design) at `docs/internal/implementation/smi-4653-remove-worktree-docker-cleanup.md` (rebased onto submodule `origin/main` per the SMI-4568 ancestry-check pattern).

## Implementation notes

- **Path A** (preferred): `docker compose down --volumes --rmi local` from the worktree dir. No `--profile` filter so dev/test/orchestrator profiles all tear down. `--rmi local` is load-bearing — only works while no service has an explicit `image:` field. The audit-standards check pins this contract at lint time.
- **Path B** (fallback): name-based `docker rmi <project>-dev` and `docker volume rm <project>_node_modules`, always runs, idempotent. `<project>` derives from the worktree dir basename via Docker Compose v2 sanitization (lowercase + strip non-`[a-z0-9_-]`).
- **Main-repo guard** at top of `main()` (before any side effects) — verified end-to-end: invoking the script with the main repo path errors out without stopping the running container or removing any image/volume.

## Test plan

- [x] `npx vitest run scripts/tests/remove-worktree.test.ts` — 7 / 7 passing
- [x] `npx vitest run scripts/tests/` — 32 files / 760 tests passing (no regressions)
- [x] `npm run typecheck` — green
- [x] `npm run format:check` — green
- [x] `npm run audit:standards` — new check passes; pre-existing double-encrypted-files failure is unrelated
- [x] **End-to-end with real Docker**: throwaway worktree built `wt-e2e-dev` image + `wt-e2e_node_modules` volume; ran the script; both gone after.
- [x] **Main-repo guard E2E**: ran the script against `/Users/.../skillsmith` (main repo); script errored out, `skillsmith-dev` image / `skillsmith_node_modules` volume / running `skillsmith-dev-1` container all preserved.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)