### PR TITLE
feat(ci): SMI-4446 verify-impl recognises .astro/.mdx + scoped .md surfaces

### DIFF
--- a/scripts/ci/source-patterns.mjs
+++ b/scripts/ci/source-patterns.mjs
@@ -12,13 +12,20 @@
  */
 
 export const SOURCE_PATTERNS = [
-  /^packages\/.*\.(ts|tsx|js|jsx)$/,
+  // SMI-4446: .astro / .mdx are first-class implementation surfaces (Astro pages, content collections)
+  /^packages\/.*\.(ts|tsx|js|jsx|astro|mdx)$/,
   /^supabase\/functions\/.*\.(ts|js)$/,
   /^scripts\/.*\.(ts|js|mjs)$/,
   // SMI-4243: root-level *.config.{ts,mjs,cjs,js} (vitest.config.ts, lint-staged.config.js, etc.)
   /^[^/]+\.config(\.[^./]+)?\.(ts|mjs|cjs|js)$/,
   // SMI-4243: GitHub Actions workflow YAML
   /^\.github\/workflows\/.*\.ya?ml$/,
+  // SMI-4446: narrow .md surfaces — must be specific (broad .md is in DOCS_PATTERNS).
+  // Scoped to user-facing/shipping surfaces: package READMEs, skill bodies, root README.
+  // Other .md (docs/internal, retros, ADRs) stay classified as docs.
+  /^packages\/[^/]+\/README\.md$/,
+  /^packages\/mcp-server\/src\/assets\/skills\/.*\/SKILL\.md$/,
+  /^README\.md$/,
 ]
 
 export const TEST_PATTERNS = [/\.test\.(ts|tsx|js)$/, /\.spec\.(ts|tsx|js)$/]

--- a/scripts/tests/source-patterns.test.ts
+++ b/scripts/tests/source-patterns.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for shared source/test/docs classification patterns (SMI-4446).
+ *
+ * Mirrors the consumer behavior in:
+ *   - scripts/ci/verify-implementation.ts (line ~61)
+ *   - scripts/linear-hook.mjs (line ~96)
+ *
+ * Both call `SOURCE_PATTERNS.some(p => p.test(file))`. We test the same shape
+ * so a regression in either consumer surfaces here first.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { SOURCE_PATTERNS, TEST_PATTERNS, DOCS_PATTERNS } from '../ci/source-patterns.mjs'
+
+const isSource = (path: string): boolean => SOURCE_PATTERNS.some((p) => p.test(path))
+const isTest = (path: string): boolean => TEST_PATTERNS.some((p) => p.test(path))
+const isDocs = (path: string): boolean => DOCS_PATTERNS.some((p) => p.test(path))
+
+describe('SMI-4446: SOURCE_PATTERNS classification', () => {
+  describe('Astro and MDX (new in SMI-4446)', () => {
+    it.each([
+      ['packages/website/src/pages/product.astro', true],
+      ['packages/website/src/components/Header.astro', true],
+      ['packages/website/src/pages/blog/post.mdx', true],
+      ['packages/website/src/layouts/Base.astro', true],
+    ])('%s → isSource=%s', (path, expected) => {
+      expect(isSource(path)).toBe(expected)
+    })
+  })
+
+  describe('Scoped markdown surfaces (new in SMI-4446)', () => {
+    it.each([
+      // Source: package READMEs (ship to npm), root README, skill bodies
+      ['packages/cli/README.md', true],
+      ['packages/core/README.md', true],
+      ['packages/mcp-server/README.md', true],
+      ['README.md', true],
+      ['packages/mcp-server/src/assets/skills/skillsmith/SKILL.md', true],
+      ['packages/mcp-server/src/assets/skills/some-author/some-skill/SKILL.md', true],
+      // NOT source: docs/internal, retros, ADRs, root-level docs
+      ['docs/internal/retros/foo.md', false],
+      ['docs/internal/adr/100-foo.md', false],
+      ['docs/internal/implementation/smi-4652.md', false],
+      ['CHANGELOG.md', false],
+      ['CONTRIBUTING.md', false],
+      ['SECURITY.md', false],
+      // NOT source: nested README inside non-package directory
+      ['scripts/README.md', false],
+      // NOT source: SKILL.md outside the asset bundle
+      ['.claude/skills/governance/SKILL.md', false],
+    ])('%s → isSource=%s', (path, expected) => {
+      expect(isSource(path)).toBe(expected)
+    })
+  })
+
+  describe('Existing source classifications (regression guard)', () => {
+    it.each([
+      ['packages/cli/src/index.ts', true],
+      ['packages/core/src/db/schema.ts', true],
+      ['packages/website/src/utils/helpers.tsx', true],
+      ['supabase/functions/checkout/index.ts', true],
+      ['scripts/ci/foo.ts', true],
+      ['scripts/linear-hook.mjs', true],
+      ['vitest.config.ts', true],
+      ['lint-staged.config.js', true],
+      ['.github/workflows/ci.yml', true],
+      ['.github/workflows/publish.yaml', true],
+    ])('%s → isSource=%s', (path, expected) => {
+      expect(isSource(path)).toBe(expected)
+    })
+  })
+
+  describe('Non-source paths (regression guard)', () => {
+    it.each([
+      ['package.json', false],
+      ['package-lock.json', false],
+      ['turbo.json', false],
+      ['.env.example', false],
+      ['Dockerfile', false],
+      ['docker-compose.yml', false],
+    ])('%s → isSource=%s', (path, expected) => {
+      expect(isSource(path)).toBe(expected)
+    })
+  })
+})
+
+describe('TEST_PATTERNS (regression guard — unchanged by SMI-4446)', () => {
+  it.each([
+    ['packages/cli/src/foo.test.ts', true],
+    ['packages/core/tests/integration/bar.spec.ts', true],
+    ['scripts/tests/source-patterns.test.ts', true],
+    ['packages/cli/src/index.ts', false],
+    ['packages/cli/README.md', false],
+  ])('%s → isTest=%s', (path, expected) => {
+    expect(isTest(path)).toBe(expected)
+  })
+})
+
+describe('DOCS_PATTERNS (regression guard — unchanged by SMI-4446)', () => {
+  it.each([
+    ['docs/internal/retros/foo.md', true],
+    ['CHANGELOG.md', true],
+    ['.claude/skills/governance/SKILL.md', true],
+    ['packages/cli/src/index.ts', false],
+    ['scripts/ci/foo.mjs', false],
+  ])('%s → isDocs=%s', (path, expected) => {
+    expect(isDocs(path)).toBe(expected)
+  })
+})


### PR DESCRIPTION
## Summary

Wave 2 of [SMI-4652 CI Hygiene Trifecta](https://linear.app/smith-horn-group/issue/SMI-4652) (plan: docs/internal/implementation/smi-4652-ci-hygiene-trifecta.md, ships via [smith-horn/skillsmith-docs#106](https://github.com/smith-horn/skillsmith-docs/pull/106)).

Extends `scripts/ci/source-patterns.mjs` `SOURCE_PATTERNS` so the `Verify Implementation Completeness` CI check (and `linear-hook.mjs` Linear status transitions) recognise:

- `packages/**/*.astro` and `*.mdx` (Astro pages, content collections)
- `packages/*/README.md` (user-facing docs that ship with the package)
- `packages/mcp-server/src/assets/skills/**/SKILL.md` (skill bodies)
- root `README.md`

Both consumers (`verify-implementation.ts:61`, `linear-hook.mjs:96`) already iterate via `SOURCE_PATTERNS.some(p => p.test(file))` — no caller changes needed (per plan B-3 resolution).

Adds `scripts/tests/source-patterns.test.ts` (44 cases) covering the new surfaces, regression guards on existing patterns, and assertions that `docs/internal/**` markdown stays classified as docs (not source).

## Why now

Every Astro PR in the SMI-4577/4578/4580 wave (and recent #748 / #853 / #854) hit the false-fail path and required `[skip-impl-check]` body marker. ~5 min per PR.

Wave-2 of three sequenced infra hygiene fixes; Wave 3 (doc-drift) and Wave 1 (Test (root) divergence) follow.

## Test plan

- [x] `docker exec skillsmith-dev-1 npx vitest run scripts/tests/source-patterns.test.ts` — 44/44 pass
- [x] Pre-push hook (preflight + per-workspace tests + format check) — green
- [x] `verify-implementation.ts` and `linear-hook.mjs` consume same regex set; no caller diff needed
- [ ] Wave 2b smoke (post-merge): observe a real `.astro`-only PR pass `Verify Implementation Completeness` without `[skip-impl-check]`

## Plan-review provenance

Plan-reviewed by VP Product / VP Engineering / VP Design (4 BLOCKER + 5 MAJOR findings folded in pre-implementation). Sequencing reversed per M-5 to ship Wave 2 first.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)