### PR TITLE
fix(website): SMI-4660 gap-disclosure alignment — followup to merged rebrand PRs

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -131,7 +131,7 @@
           {
             "id": "skillsmith.walkthrough.install",
             "title": "Install a skill",
-            "description": "Install any skill to `~/.claude/skills` with one click from the Search Results view.\n[Open Skillsmith Sidebar](command:workbench.view.extension.skillsmith)",
+            "description": "Install any skill with one click from the Search Results view.\n[Open Skillsmith Sidebar](command:workbench.view.extension.skillsmith)",
             "media": {
               "markdown": "resources/walkthrough/install.md"
             }

--- a/packages/website/src/content/blog/inside-the-local-skill-database.md
+++ b/packages/website/src/content/blog/inside-the-local-skill-database.md
@@ -19,7 +19,7 @@ When you run a Skillsmith search through the MCP server, the CLI, or the VS Code
 
 A quick orientation before we go deep: **MCP** (Model Context Protocol) is the standard agents use to talk to external tools — Claude Code, Cursor, Copilot, Codex, Windsurf and others all speak it. **FTS5** is SQLite's built-in full-text search module: tokenize text, build an inverted index, rank results, all inside the database file with no external service. **HNSW** (hierarchical navigable small world) is a graph index that makes vector search fast by checking only a small fraction of the dataset per query. **ONNX** (Open Neural Network Exchange) is a portable ML model format with a runtime that runs inference on CPU — no GPU, no API call. We'll explain the rest as they come up.
 
-Jump to: [Where the DB lives](#where-the-db-lives) · [Schema tour](#schema-tour) · [FTS5 default](#fts5-the-default-search-path) · [Semantic search](#semantic-search-opt-in) · [`sync`](#sync-the-diff-algorithm) · [`import`](#import-the-other-direction) · [Tradeoffs](#tradeoffs)
+Jump to: [Where the DB lives](#where-the-db-lives) · [Schema tour](#schema-tour) · [FTS5 default](#fts5-the-default-search-path) · [Semantic search](#semantic-search-opt-in) · [`sync`](#sync-the-diff-algorithm) · [Tradeoffs](#tradeoffs)
 
 ## Two posts, two halves
 
@@ -104,18 +104,10 @@ The shape of an incremental run:
 A few things `sync` does *not* do, by design:
 
 - **It does not recompute embeddings.** Embeddings are populated lazily when semantic search is enabled — keeping them out of the sync path means the default `sync` is fast and doesn't pin you to the model download.
-- **It does not delete locally installed skills.** `~/.claude/skills/` is your file system, not ours. `sync` only mutates the registry cache.
+- **It does not delete locally installed skills.** Your client's skills directory (default `~/.claude/skills/` for Claude Code) is your file system, not ours. `sync` only mutates the registry cache.
 - **It does not re-run security scans.** Those are server-side artifacts; we cache the result.
 
 Typical incremental run is on the order of tens of seconds, dominated by registry API latency rather than local CPU.
-
-## `import` — the other direction
-
-`sync` flows registry → cache. `import` flows the other way: it walks `~/.claude/skills/` (or any directory you point it at), parses each `SKILL.md` (the markdown-with-frontmatter file format that defines an agent skill — name, description, trigger phrases, and the prompt body), and writes the result into the same `skills` table. The implementation lives in `packages/cli/src/import.ts`.
-
-This matters for two cases. First, hand-installed skills — skills you copied into `~/.claude/skills/` from a teammate's repo or your own scratch — show up in search after `import` even if they were never published to the registry. Second, locally authored skills under active development; `import` lets you `search` for your own work-in-progress alongside everything else.
-
-`import` writes to the same table `sync` does, so a subsequent `sync --force` will overwrite locally imported rows if the registry has a same-id record. This is intentional; the registry is the source of truth for published skills.
 
 ## Tradeoffs
 

--- a/packages/website/src/pages/docs/faq.astro
+++ b/packages/website/src/pages/docs/faq.astro
@@ -30,8 +30,8 @@ const faqCategories: FAQCategory[] = [
         answer: "Skillsmith is an agent skill platform for AI assistants. It helps you find, install, compare, and manage skills that enhance your development environment with specialized capabilities."
       },
       {
-        question: "How do I install Skillsmith?",
-        answer: "Add Skillsmith to your MCP client settings by configuring the MCP server. Add the following to your ~/.claude/settings.json: {\"mcpServers\": {\"skillsmith\": {\"command\": \"npx\", \"args\": [\"-y\", \"@skillsmith/mcp-server\"]}}}"
+        question: "How do I add Skillsmith to my MCP client?",
+        answer: "Skillsmith works with any MCP-compatible agent. Per-client config snippets for Claude Code, Cursor, GitHub Copilot, Windsurf, and Codex CLI are in the main README at https://github.com/smith-horn/skillsmith#quick-setup. After adding to your client settings, restart the client and try a Skillsmith tool."
       },
       {
         question: "Is Skillsmith free to use?",
@@ -121,7 +121,7 @@ const faqCategories: FAQCategory[] = [
       },
       {
         question: "Where does Skillsmith store skill data, and what does sync do?",
-        answer: "The MCP server and CLI share one local SQLite database at ~/.skillsmith/skills.db (overridable with SKILLSMITH_DB_PATH); the VS Code extension uses it transitively because it spawns the MCP server. The DB caches skill metadata and an FTS5 full-text index (SQLite's built-in keyword search — fast, ranked, no external service) for instant offline lookup. There is no vector virtual table by default — semantic search is opt-in (SKILLSMITH_USE_HNSW=true) and uses an in-memory vector index over 384-dim ONNX embeddings (Open Neural Network Exchange — a portable ML model format with a runtime that runs inference on CPU, no GPU or API call required), with the embedding blobs cached in SQLite. skillsmith sync does an incremental pull from the registry API: it fetches changes since lastSyncAt, dedupes, upserts only rows whose content_hash or updated_at has moved, and records the run in sync_history. sync does not recompute embeddings — those generate on demand if semantic search is enabled. skillsmith import goes the other direction: it reads SKILL.md files from ~/.claude/skills/ into the same database. Net effect: fast offline keyword search, optional opt-in semantic search, no metadata leaves your machine after sync, in exchange for some disk and a sync cadence you control. Full deep dive: /blog/inside-the-local-skill-database."
+        answer: "The MCP server and CLI share one local SQLite database at ~/.skillsmith/skills.db (overridable with SKILLSMITH_DB_PATH); the VS Code extension uses it transitively because it spawns the MCP server. The DB caches skill metadata and an FTS5 full-text index (SQLite's built-in keyword search — fast, ranked, no external service) for instant offline lookup. There is no vector virtual table by default — semantic search is opt-in (SKILLSMITH_USE_HNSW=true) and uses an in-memory vector index over 384-dim ONNX embeddings (Open Neural Network Exchange — a portable ML model format with a runtime that runs inference on CPU, no GPU or API call required), with the embedding blobs cached in SQLite. skillsmith sync does an incremental pull from the registry API: it fetches changes since lastSyncAt, dedupes, upserts only rows whose content_hash or updated_at has moved, and records the run in sync_history. sync does not recompute embeddings — those generate on demand if semantic search is enabled. Net effect: fast offline keyword search, optional opt-in semantic search, no metadata leaves your machine after sync, in exchange for some disk and a sync cadence you control. Full deep dive: /blog/inside-the-local-skill-database."
       }
     ]
   },

--- a/packages/website/src/pages/product.astro
+++ b/packages/website/src/pages/product.astro
@@ -125,7 +125,7 @@ const matrix: CapabilityRow[] = [
     capability: 'Team workspaces / audit export / SIEM / RBAC',
     mcp: 'yes',
     cli: 'no',
-    vscode: 'via MCP',
+    vscode: 'no',
   },
   {
     capability: 'Single API key works across all three',
@@ -179,8 +179,9 @@ function cellClass(value: string): string {
   <section class="product-matrix">
     <h2>Capability comparison</h2>
     <p class="product-matrix-caption">
-      Capabilities marked <em>via MCP</em> for VS Code mean the extension exposes them by spawning the
-      MCP server in the background.
+      Capabilities marked <em>via MCP</em> for VS Code mean the extension actively spawns the MCP server
+      to deliver them — not every tool the MCP server happens to expose. Team workspaces, audit export,
+      SIEM, and RBAC are MCP-only and have no VS Code UI affordance today.
     </p>
     <div class="product-matrix-scroll">
       <table class="product-matrix-table">


### PR DESCRIPTION
## Summary

Followup sweep PR aligning four merged rebrand PRs (#852, #853, #854, #857 — SMI-4570/4571/4572/4575) with code-side gap fixes shipped in parallel by another session (SMI-4577 HNSW, SMI-4578/4580 multi-client install). Four findings, four edits, one PR.

## Findings + fixes

| # | Severity | SMI | Surface | Fix |
|---|---|---|---|---|
| C1 | Urgent | SMI-4661 | blog `inside-the-local-skill-database.md` + `docs/faq.astro` | Removed the entire `## import — the other direction` section + ToC link. Removed the matching sentence from FAQ. The `skillsmith import` filesystem walker described in both surfaces does not exist — the real `skillsmith import` walks a GitHub topic into the registry DB. |
| C2 | High | SMI-4662 | `pages/product.astro` matrix row 128 | Changed `vscode: 'via MCP'` → `vscode: 'no'` for "Team workspaces / audit export / SIEM / RBAC". MCP server exposes those tools; VS Code extension exposes 7 commands, none of them admin/team. Updated footnote to clarify "via MCP" scope. |
| H1 | High | SMI-4663 | `docs/faq.astro` line 34 | Replaced single-client `~/.claude/settings.json` answer with multi-client pointer to README's `#quick-setup` section (Claude Code, Cursor, Copilot, Windsurf, Codex CLI). |
| H2 | Medium | SMI-4664 | `vscode-extension/package.json` walkthrough | Dropped `~/.claude/skills` mention from the install walkthrough description — extension supports 5 clients post-SMI-4578. |
| M1 | cosmetic (rolled into C1) | — | blog line 107 | Rephrased "`~/.claude/skills/` is your file system, not ours" → "Your client's skills directory (default `~/.claude/skills/` for Claude Code) is your file system, not ours". |

## Verification

- `docker exec skillsmith-dev-1 sh -c 'cd packages/website && npm run build'` — clean
- `docker exec skillsmith-dev-1 npm run lint` — clean
- `docker exec skillsmith-dev-1 npm run typecheck` — clean
- `docker exec skillsmith-dev-1 npm run format:check` — clean
- `docker exec skillsmith-dev-1 npm run audit:standards` — **52 passed, 5 warnings, 0 failed** (no new warnings vs main baseline of 7; baseline warnings are all pre-existing — File Length, Script Docker Compliance, Migration Standards, Migration search_path, Smoke Surface Coverage)
- `grep -rn "import-the-other-direction" packages/website/` — 0 hits
- `grep -rn "skillsmith import" packages/website/` — 0 hits
- `grep -nE "via MCP" packages/website/src/pages/product.astro` — only on truthful rows (lines 56, 62, 68 — search/get/install, skill_suggest, skill_compare) plus the footnote

## Smoke fingerprint impact

`scripts/smoke-prod/website.sh`:
- `check_blog_local_db_renders` fingerprints page title `'Inside the Local Skill Database'` — unchanged
- `check_product_page_renders` fingerprints hero (`'MCP for any agent. CLI for the terminal.'`) and `'Capability comparison'` — both unchanged

No fingerprint updates needed.

## Test plan

- [ ] CI green (13 required checks)
- [ ] Vercel preview shows blog with no `import` section + clean ToC
- [ ] Vercel preview shows /product matrix with VS Code cell blank for team/admin row
- [ ] Vercel preview shows FAQ "How do I add Skillsmith to my MCP client?" pointing at README
- [ ] No console errors on /blog/inside-the-local-skill-database, /product, or /docs/faq

Closes SMI-4661, SMI-4662, SMI-4663, SMI-4664. Refs SMI-4660 (parent), SMI-4582 polish item #5.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

[skip-impl-check]