### PR TITLE
feat(cli+mcp-server): SMI-4590 Wave 4 PR 1/6 — Step 0a (sklx audit advisories) + Step 0b (audit-tool-dispatch extraction)

### DIFF
--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,7 +1,8 @@
 /**
  * @fileoverview skillsmith audit command — CLI security advisory checker
  * @module @skillsmith/cli/commands/audit
- * @see SMI-skill-version-tracking Wave 3
+ * @see SMI-skill-version-tracking Wave 3 (advisories subcommand)
+ * @see SMI-4590 Wave 4 Step 0a — restructured into parent `audit` command
  *
  * Lists active security advisories for installed skills in npm-audit style
  * output. Advisories are published by the Skillsmith team as security
@@ -9,6 +10,11 @@
  *
  * Tier gate: Team (via requireTier).
  * Use --fix to attempt `skillsmith update <skill>` for each advisory with a patch.
+ *
+ * Surface (post-SMI-4590 Step 0a):
+ * - `sklx audit advisories <skill-id>` (canonical)
+ * - `sklx audit <skill-id>` (deprecation alias — emits warning, forwards to advisories)
+ * - `sklx audit collisions` is added by SMI-4590 PR 5/6.
  */
 
 import { Command } from 'commander'
@@ -86,7 +92,12 @@ function printSummary(counts: Record<string, number>): void {
 // Command action
 // ============================================================================
 
-async function runAudit(options: { db: string; fix: boolean }): Promise<void> {
+interface AuditAdvisoriesOptions {
+  db: string
+  fix: boolean
+}
+
+async function runAdvisoriesAudit(options: AuditAdvisoriesOptions): Promise<void> {
   // Team tier required for security advisories
   await requireTier('team')
 
@@ -144,20 +155,23 @@ async function runAudit(options: { db: string; fix: boolean }): Promise<void> {
 }
 
 // ============================================================================
-// Command factory
+// Command factories
 // ============================================================================
 
 /**
- * Create the audit command
+ * Build the `advisories` subcommand. Same body as the pre-SMI-4590 flat
+ * `audit` command — only the surface (parent + name) changed.
+ *
+ * @internal exported for tests; consumers should use {@link createAuditCommand}.
  */
-export function createAuditCommand(): Command {
-  return new Command('audit')
+export function createAuditAdvisoriesSubcommand(): Command {
+  return new Command('advisories')
     .description('Check installed skills for known security advisories (Team tier required)')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
     .option('--fix', 'Attempt to update skills with available patches')
     .action(async (opts: Record<string, string | boolean | undefined>) => {
       try {
-        await runAudit({
+        await runAdvisoriesAudit({
           db: opts['db'] as string,
           fix: (opts['fix'] as boolean) ?? false,
         })
@@ -166,6 +180,66 @@ export function createAuditCommand(): Command {
         process.exit(1)
       }
     })
+}
+
+/**
+ * Deprecation warning for top-level `sklx audit <skill-id>` flat invocation.
+ * Removal target: next minor release.
+ *
+ * @internal exported for tests.
+ */
+export const AUDIT_FLAT_DEPRECATION_NOTICE =
+  "[DEPRECATED] sklx audit <skill-id> is deprecated; use 'sklx audit advisories <skill-id>' instead. This alias will be removed in the next minor version."
+
+/**
+ * Build the parent `audit` command. Subcommands:
+ * - `advisories` — security advisory checker (canonical, Team tier).
+ * - `<skill-id>` (positional fallback) — deprecation alias forwarding to
+ *   `advisories`. Emits a stderr warning. Removed in next minor release.
+ *
+ * `sklx audit collisions` is added by SMI-4590 PR 5/6.
+ */
+export function createAuditCommand(): Command {
+  const audit = new Command('audit').description(
+    'Audit installed skills (advisories, namespace collisions)'
+  )
+
+  audit.addCommand(createAuditAdvisoriesSubcommand())
+
+  // Deprecation alias: `sklx audit <skill-id>` → forward to `advisories`.
+  // Implemented as a default-action on the parent: when Commander is invoked
+  // with positional args that don't match a registered subcommand, emit the
+  // deprecation notice and route to the advisories action.
+  //
+  // We use `.argument('[skillId]')` + `.action()` to capture the positional
+  // fallback. Commander resolves registered subcommands first, so this fires
+  // only for unknown subcommand strings (treated as <skill-id>).
+  audit
+    .argument('[skillId]', 'Legacy positional skill-id (deprecated; use `advisories <skill-id>`)')
+    .option('-d, --db <path>', 'Database file path (deprecated alias)', DEFAULT_DB_PATH)
+    .option('--fix', 'Attempt to update skills with available patches (deprecated alias)')
+    .action(
+      async (skillId: string | undefined, opts: Record<string, string | boolean | undefined>) => {
+        if (skillId === undefined) {
+          // No subcommand and no positional — print parent help.
+          audit.help()
+          return
+        }
+        // Emit deprecation warning to stderr; do not pollute stdout.
+        console.error(chalk.yellow(AUDIT_FLAT_DEPRECATION_NOTICE))
+        try {
+          await runAdvisoriesAudit({
+            db: opts['db'] as string,
+            fix: (opts['fix'] as boolean) ?? false,
+          })
+        } catch (error) {
+          console.error(chalk.red('Error:'), sanitizeError(error))
+          process.exit(1)
+        }
+      }
+    )
+
+  return audit
 }
 
 export default createAuditCommand

--- a/packages/cli/tests/audit-restructure.test.ts
+++ b/packages/cli/tests/audit-restructure.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @fileoverview SMI-4590 Step 0a — `sklx audit` restructure tests
+ * @module @skillsmith/cli/tests/audit-restructure
+ *
+ * Asserts the parent `audit` command surface:
+ * - `sklx audit advisories` is registered as a subcommand.
+ * - `sklx audit <skill-id>` (positional fallback) emits the deprecation
+ *   warning and forwards to the same advisories handler.
+ * - `sklx audit` with no args prints parent help.
+ *
+ * Behavioral coverage of `runAdvisoriesAudit` itself stays under
+ * `audit.ts`'s existing test surface — these tests verify the wiring only.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Command } from 'commander'
+
+// ============================================================================
+// Mock setup — must precede source imports so commander.action() bodies see
+// the mocked deps when they execute.
+// ============================================================================
+
+const mocks = vi.hoisted(() => ({
+  requireTier: vi.fn(async (_tier: string): Promise<void> => undefined),
+  createDatabaseAsync: vi.fn(
+    async (_path: string): Promise<{ close: () => void }> => ({
+      close: () => undefined,
+    })
+  ),
+  initializeSchema: vi.fn((_db: unknown): void => undefined),
+  AdvisoryRepositoryCtor: vi.fn((_db: unknown): void => undefined),
+  getActiveAdvisories: vi.fn((): unknown[] => []),
+}))
+
+vi.mock('@skillsmith/core', () => ({
+  createDatabaseAsync: (path: string) => mocks.createDatabaseAsync(path),
+  initializeSchema: (db: unknown) => mocks.initializeSchema(db),
+  AdvisoryRepository: function AdvisoryRepository(this: unknown, db: unknown) {
+    mocks.AdvisoryRepositoryCtor(db)
+    ;(this as { getActiveAdvisories: () => unknown[] }).getActiveAdvisories =
+      mocks.getActiveAdvisories
+  },
+}))
+
+vi.mock('../src/utils/require-tier.js', () => ({
+  requireTier: (tier: string) => mocks.requireTier(tier),
+}))
+
+import {
+  createAuditCommand,
+  createAuditAdvisoriesSubcommand,
+  AUDIT_FLAT_DEPRECATION_NOTICE,
+} from '../src/commands/audit.js'
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+interface CapturedDb {
+  close: ReturnType<typeof vi.fn>
+}
+
+function setupDbStub(): CapturedDb {
+  const db: CapturedDb = { close: vi.fn() }
+  mocks.createDatabaseAsync.mockResolvedValue(db as unknown as { close: () => void })
+  return db
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SMI-4590 Step 0a — sklx audit restructure', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+  let exitSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.requireTier.mockResolvedValue(undefined)
+    mocks.getActiveAdvisories.mockReturnValue([])
+    stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    // process.exit must throw so test bodies never actually exit the runner.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called')
+    }) as never)
+  })
+
+  afterEach(() => {
+    stderrSpy.mockRestore()
+    stdoutSpy.mockRestore()
+    exitSpy.mockRestore()
+  })
+
+  describe('parent command shape', () => {
+    it('registers `audit` as a parent command with description', () => {
+      const audit = createAuditCommand()
+      expect(audit.name()).toBe('audit')
+      expect(audit.description()).toMatch(/audit/i)
+    })
+
+    it('registers `advisories` as a subcommand', () => {
+      const audit = createAuditCommand()
+      const subcommandNames = audit.commands.map((c) => c.name())
+      expect(subcommandNames).toContain('advisories')
+    })
+  })
+
+  describe('`sklx audit advisories` (canonical)', () => {
+    it('runs the advisories handler', async () => {
+      setupDbStub()
+      const audit = createAuditCommand()
+      const root = new Command().exitOverride()
+      root.addCommand(audit)
+      await root.parseAsync(['node', 'sklx', 'audit', 'advisories'])
+      expect(mocks.requireTier).toHaveBeenCalledWith('team')
+      expect(mocks.createDatabaseAsync).toHaveBeenCalled()
+      expect(mocks.AdvisoryRepositoryCtor).toHaveBeenCalled()
+    })
+
+    it('does NOT emit the deprecation warning', async () => {
+      setupDbStub()
+      const audit = createAuditCommand()
+      const root = new Command().exitOverride()
+      root.addCommand(audit)
+      await root.parseAsync(['node', 'sklx', 'audit', 'advisories'])
+      const warnings = (stderrSpy.mock.calls.flat() as unknown[]).filter(
+        (arg): arg is string => typeof arg === 'string' && arg.includes('DEPRECATED')
+      )
+      expect(warnings).toHaveLength(0)
+    })
+  })
+
+  describe('`sklx audit <skill-id>` deprecation alias', () => {
+    it('emits the deprecation warning to stderr', async () => {
+      setupDbStub()
+      const audit = createAuditCommand()
+      const root = new Command().exitOverride()
+      root.addCommand(audit)
+      await root.parseAsync(['node', 'sklx', 'audit', 'some/skill-id'])
+      const warnings = (stderrSpy.mock.calls.flat() as unknown[]).filter(
+        (arg): arg is string =>
+          typeof arg === 'string' && arg.includes(AUDIT_FLAT_DEPRECATION_NOTICE)
+      )
+      expect(warnings.length).toBeGreaterThan(0)
+    })
+
+    it('forwards to the same advisories handler', async () => {
+      setupDbStub()
+      const audit = createAuditCommand()
+      const root = new Command().exitOverride()
+      root.addCommand(audit)
+      await root.parseAsync(['node', 'sklx', 'audit', 'some/skill-id'])
+      expect(mocks.requireTier).toHaveBeenCalledWith('team')
+      expect(mocks.createDatabaseAsync).toHaveBeenCalled()
+    })
+
+    it('mentions the canonical `audit advisories` form in the warning', () => {
+      expect(AUDIT_FLAT_DEPRECATION_NOTICE).toMatch(/audit advisories/)
+    })
+
+    it('flags the alias as removed in the next minor', () => {
+      expect(AUDIT_FLAT_DEPRECATION_NOTICE).toMatch(/next minor/i)
+    })
+  })
+
+  describe('`sklx audit` with no args', () => {
+    it('prints help (no advisories handler invocation)', async () => {
+      const audit = createAuditCommand()
+      const root = new Command().exitOverride()
+      root.addCommand(audit)
+
+      // commander's `.help()` calls process.exit; our spy throws.
+      await expect(root.parseAsync(['node', 'sklx', 'audit'])).rejects.toThrow()
+
+      expect(mocks.requireTier).not.toHaveBeenCalled()
+      expect(mocks.createDatabaseAsync).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('subcommand factory exports (regression guard)', () => {
+    it('createAuditAdvisoriesSubcommand returns a Command named `advisories`', () => {
+      const cmd = createAuditAdvisoriesSubcommand()
+      expect(cmd.name()).toBe('advisories')
+    })
+
+    it('createAuditCommand returns a Command named `audit`', () => {
+      const cmd = createAuditCommand()
+      expect(cmd.name()).toBe('audit')
+    })
+  })
+})

--- a/packages/mcp-server/src/audit-tool-dispatch.ts
+++ b/packages/mcp-server/src/audit-tool-dispatch.ts
@@ -1,0 +1,91 @@
+/**
+ * @fileoverview Audit-tool dispatch for the Skillsmith MCP server
+ * @module @skillsmith/mcp-server/audit-tool-dispatch
+ *
+ * SMI-4590 Wave 4 Step 0b: extracted from `tool-dispatch.ts` to keep the
+ * parent dispatcher under the 500-LOC file-size gate. Wave 4 PRs 3–4 will
+ * add `skill_inventory_audit`, `apply_namespace_rename`, and
+ * `apply_recommended_edit` cases to this module.
+ *
+ * Surface: handles dispatch for all audit-family tools. The parent
+ * `tool-dispatch.ts` delegates by name match; this module owns the audit
+ * case bodies, license + quota wiring, and Zod parse error envelopes.
+ *
+ * No new functionality vs pre-extraction state — bodies for `skill_audit`
+ * and `skill_pack_audit` are identical to their previous parent-dispatch
+ * incarnations. Backwards-compat regression test:
+ * `tests/unit/audit-tool-dispatch.test.ts`.
+ */
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import type { ToolContext } from './context.js'
+import { skillAuditInputSchema, executeSkillAudit } from './tools/skill-audit.js'
+import { skillPackAuditInputSchema, executeSkillPackAudit } from './tools/skill-pack-audit.js'
+import { withLicenseAndQuota } from './middleware/license.js'
+import type { LicenseMiddleware } from './middleware/license.js'
+import type { QuotaMiddleware } from './middleware/quota.js'
+
+/**
+ * Tool names handled by this dispatcher. The parent `tool-dispatch.ts`
+ * delegates iff the requested tool name is in this set.
+ *
+ * Wave 4 PR 3/6 adds: `skill_inventory_audit`.
+ * Wave 4 PR 4/6 adds: `apply_namespace_rename`, `apply_recommended_edit`
+ * (the latter conditional on `APPLY_TEMPLATE_REGISTRY.size > 0`).
+ */
+export const AUDIT_TOOL_NAMES: ReadonlySet<string> = new Set(['skill_audit', 'skill_pack_audit'])
+
+/**
+ * Returns true if `name` is an audit-family tool dispatched by this module.
+ * Parent dispatcher uses this to route — keeping the routing predicate
+ * colocated with the case bodies prevents drift.
+ */
+export function isAuditToolName(name: string): boolean {
+  return AUDIT_TOOL_NAMES.has(name)
+}
+
+/**
+ * Dispatch an audit-family tool call. Caller must check {@link isAuditToolName}
+ * before invoking; unrecognized names throw `Error('Unknown audit tool: <name>')`.
+ *
+ * @param name              MCP tool name (must be in {@link AUDIT_TOOL_NAMES}).
+ * @param args              Raw tool arguments from the request.
+ * @param toolContext       Initialized database + repository context.
+ * @param licenseMiddleware License validation middleware instance.
+ * @param quotaMiddleware   Quota enforcement middleware instance.
+ * @returns MCP tool response.
+ */
+export async function dispatchAuditTool(
+  name: string,
+  args: Record<string, unknown> | undefined,
+  toolContext: ToolContext,
+  licenseMiddleware: LicenseMiddleware,
+  quotaMiddleware: QuotaMiddleware
+): Promise<CallToolResult> {
+  switch (name) {
+    case 'skill_audit':
+      return withLicenseAndQuota(
+        'skill_audit',
+        args,
+        skillAuditInputSchema,
+        executeSkillAudit,
+        toolContext,
+        licenseMiddleware,
+        quotaMiddleware
+      )
+
+    case 'skill_pack_audit':
+      return withLicenseAndQuota(
+        'skill_pack_audit',
+        args,
+        skillPackAuditInputSchema,
+        executeSkillPackAudit,
+        toolContext,
+        licenseMiddleware,
+        quotaMiddleware
+      )
+
+    default:
+      throw new Error('Unknown audit tool: ' + name)
+  }
+}

--- a/packages/mcp-server/src/middleware/license.gate.ts
+++ b/packages/mcp-server/src/middleware/license.gate.ts
@@ -1,7 +1,7 @@
 // SMI-3911: Unified license + quota gate helpers extracted from license.ts (500-line limit).
 // SMI-4402: profile_incomplete detection and JSON-RPC -32001 response.
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import type { ZodType, ZodTypeDef } from 'zod'
+import type { ZodType } from 'zod'
 import type { ToolContext } from '../context.types.js'
 import type { QuotaMiddleware } from './quota-types.js'
 import { safeParseOrError } from '../validation.js'
@@ -118,7 +118,7 @@ export function createProfileIncompleteResponse(): {
 export async function withLicenseAndQuota<T>(
   toolName: string,
   args: Record<string, unknown> | undefined,
-  schema: ZodType<T, ZodTypeDef, unknown>,
+  schema: ZodType<T>,
   handler: (input: T, ctx: ToolContext) => Promise<unknown>,
   toolContext: ToolContext,
   licenseMiddleware: LicenseMiddleware,

--- a/packages/mcp-server/src/middleware/license.gate.ts
+++ b/packages/mcp-server/src/middleware/license.gate.ts
@@ -1,7 +1,7 @@
 // SMI-3911: Unified license + quota gate helpers extracted from license.ts (500-line limit).
 // SMI-4402: profile_incomplete detection and JSON-RPC -32001 response.
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import type { ZodType } from 'zod'
+import type { ZodType, ZodTypeDef } from 'zod'
 import type { ToolContext } from '../context.types.js'
 import type { QuotaMiddleware } from './quota-types.js'
 import { safeParseOrError } from '../validation.js'
@@ -118,7 +118,7 @@ export function createProfileIncompleteResponse(): {
 export async function withLicenseAndQuota<T>(
   toolName: string,
   args: Record<string, unknown> | undefined,
-  schema: ZodType<T>,
+  schema: ZodType<T, ZodTypeDef, unknown>,
   handler: (input: T, ctx: ToolContext) => Promise<unknown>,
   toolContext: ToolContext,
   licenseMiddleware: LicenseMiddleware,

--- a/packages/mcp-server/src/tool-dispatch.ts
+++ b/packages/mcp-server/src/tool-dispatch.ts
@@ -23,8 +23,7 @@ import { indexLocalInputSchema, executeIndexLocal } from './tools/index-local.js
 import { publishInputSchema, executePublish } from './tools/publish.js'
 import { skillUpdatesInputSchema, executeSkillUpdates } from './tools/skill-updates.js'
 import { skillDiffInputSchema, executeSkillDiff } from './tools/skill-diff.js'
-import { skillAuditInputSchema, executeSkillAudit } from './tools/skill-audit.js'
-import { skillPackAuditInputSchema, executeSkillPackAudit } from './tools/skill-pack-audit.js'
+import { dispatchAuditTool } from './audit-tool-dispatch.js'
 import { outdatedInputSchema, executeOutdated } from './tools/outdated.js'
 import { skillRescanInputSchema, executeSkillRescan } from './tools/skill-rescan.js'
 import {
@@ -206,26 +205,12 @@ export async function dispatchToolCall(
       )
 
     case 'skill_audit':
-      return withLicenseAndQuota(
-        'skill_audit',
-        args,
-        skillAuditInputSchema,
-        executeSkillAudit,
-        toolContext,
-        licenseMiddleware,
-        quotaMiddleware
-      )
-
     case 'skill_pack_audit':
-      return withLicenseAndQuota(
-        'skill_pack_audit',
-        args,
-        skillPackAuditInputSchema,
-        executeSkillPackAudit,
-        toolContext,
-        licenseMiddleware,
-        quotaMiddleware
-      )
+      // SMI-4590 Step 0b: audit-family tools live in `audit-tool-dispatch.ts`
+      // to keep this file under the 500-LOC gate. Wave 4 PRs 3–4 add three
+      // more audit tools (`skill_inventory_audit`, `apply_namespace_rename`,
+      // `apply_recommended_edit`) to that module without growing this one.
+      return dispatchAuditTool(name, args, toolContext, licenseMiddleware, quotaMiddleware)
 
     case 'skill_rescan': {
       const parsed = safeParseOrError(skillRescanInputSchema, args, 'skill_rescan')

--- a/packages/mcp-server/src/validation.ts
+++ b/packages/mcp-server/src/validation.ts
@@ -21,7 +21,7 @@
  */
 
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import type { ZodType, ZodTypeDef } from 'zod'
+import type { ZodType } from 'zod'
 
 /**
  * Discriminated result of a `safeParseOrError` call.
@@ -58,7 +58,7 @@ export type SafeParseResult<T> = { ok: true; data: T } | { ok: false; response: 
  * @returns `{ ok: true, data }` on success, `{ ok: false, response }` on failure.
  */
 export function safeParseOrError<T>(
-  schema: ZodType<T, ZodTypeDef, unknown>,
+  schema: ZodType<T>,
   args: unknown,
   toolName: string
 ): SafeParseResult<T> {

--- a/packages/mcp-server/src/validation.ts
+++ b/packages/mcp-server/src/validation.ts
@@ -21,7 +21,7 @@
  */
 
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import type { ZodType } from 'zod'
+import type { ZodType, ZodTypeDef } from 'zod'
 
 /**
  * Discriminated result of a `safeParseOrError` call.
@@ -58,7 +58,7 @@ export type SafeParseResult<T> = { ok: true; data: T } | { ok: false; response: 
  * @returns `{ ok: true, data }` on success, `{ ok: false, response }` on failure.
  */
 export function safeParseOrError<T>(
-  schema: ZodType<T>,
+  schema: ZodType<T, ZodTypeDef, unknown>,
   args: unknown,
   toolName: string
 ): SafeParseResult<T> {

--- a/packages/mcp-server/tests/unit/audit-tool-dispatch.test.ts
+++ b/packages/mcp-server/tests/unit/audit-tool-dispatch.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @fileoverview SMI-4590 Step 0b — audit-tool-dispatch regression tests
+ * @module @skillsmith/mcp-server/tests/unit/audit-tool-dispatch
+ *
+ * Asserts the extracted dispatcher:
+ * 1. Routes `skill_audit` and `skill_pack_audit` through `withLicenseAndQuota`
+ *    (delegating to the same handlers as the pre-extraction parent).
+ * 2. Throws `Unknown audit tool: <name>` for unrecognized names — the parent
+ *    `tool-dispatch.ts` is responsible for routing predicate; this module
+ *    refuses anything outside `AUDIT_TOOL_NAMES`.
+ * 3. Exposes a stable `AUDIT_TOOL_NAMES` set + `isAuditToolName()` predicate.
+ *
+ * No behavioral change vs pre-Step-0b dispatch — handler bodies were moved,
+ * not modified. This test pins that contract.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock middleware/license BEFORE importing the module under test so the
+// dispatcher's `withLicenseAndQuota` call hits the spy.
+const mocks = vi.hoisted(() => ({
+  withLicenseAndQuota: vi.fn(),
+}))
+
+vi.mock('../../src/middleware/license.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    withLicenseAndQuota: (...args: unknown[]) => mocks.withLicenseAndQuota(...args),
+  }
+})
+
+import {
+  dispatchAuditTool,
+  isAuditToolName,
+  AUDIT_TOOL_NAMES,
+} from '../../src/audit-tool-dispatch.js'
+import type { ToolContext } from '../../src/context.js'
+import type { LicenseMiddleware } from '../../src/middleware/license.js'
+import type { QuotaMiddleware } from '../../src/middleware/quota.js'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function fakeContext(): ToolContext {
+  return {} as ToolContext
+}
+
+function fakeLicense(): LicenseMiddleware {
+  return {
+    checkFeature: vi.fn().mockResolvedValue({ valid: true }),
+    checkTool: vi.fn().mockResolvedValue({ valid: true }),
+    getLicenseInfo: vi.fn().mockResolvedValue({
+      valid: true,
+      tier: 'enterprise' as const,
+      features: [],
+    }),
+    invalidateCache: vi.fn(),
+  } as unknown as LicenseMiddleware
+}
+
+function fakeQuota(): QuotaMiddleware {
+  return {
+    checkAndTrack: vi.fn().mockResolvedValue({
+      allowed: true,
+      remaining: 999,
+      limit: 1000,
+      percentUsed: 0.1,
+      warningLevel: 0,
+      resetAt: new Date(),
+    }),
+    buildMetadata: vi.fn(),
+    buildExceededResponse: vi.fn(),
+  } as unknown as QuotaMiddleware
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SMI-4590 Step 0b — audit-tool-dispatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.withLicenseAndQuota.mockResolvedValue({
+      content: [{ type: 'text' as const, text: '{}' }],
+      isError: false,
+    })
+  })
+
+  describe('AUDIT_TOOL_NAMES set', () => {
+    it('includes the existing pre-extraction tools', () => {
+      expect(AUDIT_TOOL_NAMES.has('skill_audit')).toBe(true)
+      expect(AUDIT_TOOL_NAMES.has('skill_pack_audit')).toBe(true)
+    })
+
+    it('does NOT include non-audit tools (regression guard)', () => {
+      expect(AUDIT_TOOL_NAMES.has('search')).toBe(false)
+      expect(AUDIT_TOOL_NAMES.has('install_skill')).toBe(false)
+      expect(AUDIT_TOOL_NAMES.has('skill_diff')).toBe(false)
+    })
+  })
+
+  describe('isAuditToolName predicate', () => {
+    it('returns true for audit-family tools', () => {
+      expect(isAuditToolName('skill_audit')).toBe(true)
+      expect(isAuditToolName('skill_pack_audit')).toBe(true)
+    })
+
+    it('returns false for non-audit tools', () => {
+      expect(isAuditToolName('search')).toBe(false)
+      expect(isAuditToolName('totally_unknown')).toBe(false)
+    })
+  })
+
+  describe('dispatchAuditTool routing', () => {
+    it('routes skill_audit through withLicenseAndQuota', async () => {
+      await dispatchAuditTool(
+        'skill_audit',
+        { skillId: 'foo/bar' },
+        fakeContext(),
+        fakeLicense(),
+        fakeQuota()
+      )
+      expect(mocks.withLicenseAndQuota).toHaveBeenCalledTimes(1)
+      const call = mocks.withLicenseAndQuota.mock.calls[0]
+      expect(call?.[0]).toBe('skill_audit')
+    })
+
+    it('routes skill_pack_audit through withLicenseAndQuota', async () => {
+      await dispatchAuditTool(
+        'skill_pack_audit',
+        { pack_path: '/tmp/pack' },
+        fakeContext(),
+        fakeLicense(),
+        fakeQuota()
+      )
+      expect(mocks.withLicenseAndQuota).toHaveBeenCalledTimes(1)
+      const call = mocks.withLicenseAndQuota.mock.calls[0]
+      expect(call?.[0]).toBe('skill_pack_audit')
+    })
+
+    it('forwards args verbatim to withLicenseAndQuota', async () => {
+      const args = { skillId: 'verbatim/passthrough', extra: 42 }
+      await dispatchAuditTool('skill_audit', args, fakeContext(), fakeLicense(), fakeQuota())
+      const call = mocks.withLicenseAndQuota.mock.calls[0]
+      expect(call?.[1]).toBe(args)
+    })
+
+    it('throws "Unknown audit tool: <name>" for unrecognized tool names', async () => {
+      await expect(
+        dispatchAuditTool('not_an_audit_tool', {}, fakeContext(), fakeLicense(), fakeQuota())
+      ).rejects.toThrow('Unknown audit tool: not_an_audit_tool')
+      expect(mocks.withLicenseAndQuota).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handler/schema wiring (regression vs pre-extraction)', () => {
+    it('passes the skill_audit Zod schema and executor to withLicenseAndQuota', async () => {
+      await dispatchAuditTool('skill_audit', {}, fakeContext(), fakeLicense(), fakeQuota())
+      const [, , schema, executor] = mocks.withLicenseAndQuota.mock.calls[0] ?? []
+      expect(schema).toBeDefined()
+      expect(typeof executor).toBe('function')
+    })
+
+    it('passes the skill_pack_audit Zod schema and executor to withLicenseAndQuota', async () => {
+      await dispatchAuditTool('skill_pack_audit', {}, fakeContext(), fakeLicense(), fakeQuota())
+      const [, , schema, executor] = mocks.withLicenseAndQuota.mock.calls[0] ?? []
+      expect(schema).toBeDefined()
+      expect(typeof executor).toBe('function')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Wave 4 PR 1 of 6 — purely structural prep that unblocks the rest of the wave from the 500-LOC gate. **No new functionality.**

## Step 0a — `sklx audit advisories` migration + deprecation alias

Existing `sklx audit <skill-id>` (security advisories) flat command would shadow the new `sklx audit collisions` parent command added later in Wave 4. This step rewires under a parent:

- `packages/cli/src/commands/audit.ts` — `createAuditCommand()` now produces `audit advisories` as a Commander subcommand. Same options, same action handler.
- New `audit` parent command (`addCommand(createAuditCommand())`).
- Top-level `sklx audit <skill-id>` deprecation alias prints `[DEPRECATED] sklx audit <skill-id> is deprecated; use 'sklx audit advisories <skill-id>' instead. This alias will be removed in the next minor version.` to stderr and forwards args.
- Tests in `packages/cli/tests/commands/audit-advisories.test.ts` (11 new): canonical path, deprecation alias path, parent-help no-op, advisories no-args, etc.

## Step 0b — `audit-tool-dispatch.ts` extraction

`packages/mcp-server/src/tool-dispatch.ts` was 471 LOC pre-wave; adding 3 new audit tool cases (`skill_inventory_audit`, `apply_namespace_rename`, `apply_recommended_edit`) plus their imports would push past 500. This step extracts the existing audit cases:

- New `packages/mcp-server/src/audit-tool-dispatch.ts` (91 LOC) — `dispatchAuditTool` for `skill_audit` + `skill_pack_audit` cases, with their imports.
- `tool-dispatch.ts` drops to **456 LOC** (was 471). Headroom for Wave 4 PR 4's 3 new cases.
- Tests in `packages/mcp-server/tests/unit/audit-tool-dispatch.test.ts` (10 new).

## Verification

- `audit:standards`: 52 pass, 0 fail, 5 pre-existing warnings (none introduced).
- All file lengths under 500 LOC strict gate (`tool-dispatch.ts` 456, `audit-tool-dispatch.ts` 91, `audit.ts` 246).
- Pre-push: full test suite green (3262 pass, 2 skipped).
- CLI tests: 485 pass.
- mcp-server unit tests: 35 (skill-pack-audit) + 10 (audit-tool-dispatch) + 38 (envelope) + 3 (tool-dispatch comingSoon).

## Plan-amendment context

This PR follows the SMI-4590 plan-review APPROVE_WITH_CHANGES verdict (Path a). 10 plan amendments + 3 governance fixes landed in submodule commits `b85c34c` + `27a05e3` on `smi-4590-wave4-plan-amendments` (worktree pointer bumps `01e5afa8` + `2871177e`). Path (b) — moving audit core to `@skillsmith/core` — deferred to **SMI-4655** as post-Wave-4 architectural cleanup.

## Wave context

- Wave 0 spike (SMI-4586) — DONE
- Wave 1 (SMI-4587) — SHIPPED 2026-05-02
- Wave 2 (SMI-4588) — SHIPPED 2026-05-02
- Wave 3 (SMI-4589) — SHIPPED 2026-05-02 (PR #886, `d5f2cb75`)
- **Wave 4 (SMI-4590)** — this is PR 1/6
- Reviewer-1 calibration via Gemini 2.5 Pro at spike commit `e75569f4` — verdicts aligned

## PR sequence

| PR | Scope |
|----|-------|
| **1/6** | **This PR — Step 0a + 0b structural prep** |
| 2/6 | FrameworkAdapter interface + claudeCodeAdapter + package wiring |
| 3/6 | Core helpers (`runInventoryAudit` + exclusions loader) |
| 4/6 | MCP tools (`skill_inventory_audit`, `apply_namespace_rename`, `apply_recommended_edit`) |
| 5/6 | CLI `sklx audit collisions` + `sklx config set audit_mode` |
| 6/6 | Tier-gated session-start hook + Enterprise scheduled scan |

## References

- Linear: SMI-4590 (Wave 4 parent), SMI-4584 (initiative), SMI-4593 (template reauthor follow-up), SMI-4655 (path b architectural cleanup, post-wave)
- Plan: `docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md`

## Test plan

- [x] `audit:standards` clean
- [x] `lint` clean
- [x] root-tests config (pre-push gate) full pass
- [x] CLI tests cover both old + deprecation alias paths
- [x] tool-dispatch extraction preserves dispatch shape (10 unit tests)
- [ ] CI green
- [ ] Squash-merge gate