### PR TITLE
feat(mcp-server+cli): SMI-4590 Wave 4 PR 2/6 — FrameworkAdapter interface + claudeCodeAdapter + package wiring

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
     "@skillsmith/core": "^0.5.8",
+    "@skillsmith/mcp-server": "^0.4.13",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",
     "cli-table3": "0.6.5",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -6,6 +6,18 @@
   "type": "module",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "default": "./dist/src/index.js"
+    },
+    "./audit": {
+      "types": "./dist/src/audit/index.d.ts",
+      "import": "./dist/src/audit/index.js",
+      "default": "./dist/src/audit/index.js"
+    }
+  },
   "bin": {
     "skillsmith-mcp": "./dist/src/index.js"
   },

--- a/packages/mcp-server/src/audit/framework-adapter.ts
+++ b/packages/mcp-server/src/audit/framework-adapter.ts
@@ -8,10 +8,14 @@
  *
  * v1 contract (Claude-Code only):
  *   - `scanPaths` delegates to `scanLocalInventory` and returns `entries[]`.
- *   - `applyAction({kind:'rename'})` performs a raw `fs.rename` from `from`
- *     to `to` — forward-compat seam for v2 adapters that own their own
- *     audit-history. v1 callers should prefer the `applyRename` wrapper,
- *     which threads `auditId` through Wave 2's full backup + ledger flow.
+ *   - `applyAction({kind:'rename'})` is REFUSED — a thin {from, to} pair
+ *     cannot reconstruct the `InventoryEntry` Wave 2's `applyRename`
+ *     needs (kind discriminator, identifier, source_path), and a raw
+ *     `fs.rename` would bypass the backup + namespace ledger and leave
+ *     the user without a revert path. Callers must use the
+ *     `applyRename(entry, newName, { auditId })` convenience wrapper.
+ *     The bare `{kind:'rename'}` shape stays in the union as a forward-
+ *     compat surface for v2 adapters that own their own audit-history.
  *   - `applyAction({kind:'inline-edit', searchMode:'literal'})` translates
  *     the action into a Wave 3 `RecommendedEdit` and dispatches to
  *     `applyRecommendedEdit`. Requires `action.auditId` + `action.pattern`;
@@ -55,11 +59,20 @@ export class FrameworkAdapterError extends Error {
     | 'namespace.adapter.template_not_in_apply_registry'
     | 'namespace.adapter.search_not_found'
     | 'namespace.adapter.search_not_unique'
+    | 'namespace.adapter.subcall_failed'
 
-  constructor(kind: FrameworkAdapterError['kind'], message: string) {
+  /**
+   * For `'subcall_failed'`, carries the inner typed-error `kind` from
+   * Wave 2 (`RenameError`) or Wave 3 (`EditApplyError`) so callers can
+   * `switch` on it without parsing strings.
+   */
+  public readonly innerKind?: string
+
+  constructor(kind: FrameworkAdapterError['kind'], message: string, innerKind?: string) {
     super(message)
     this.name = 'FrameworkAdapterError'
     this.kind = kind
+    this.innerKind = innerKind
   }
 }
 
@@ -144,15 +157,19 @@ async function buildRecommendedEditFromInlineEdit(
   // must equal `before`), so we expand the substring search to the full
   // line(s) it sits on and replace within those lines.
   const fileLines = fileContent.split('\n')
-  const lineStartByteOffsets: number[] = [0]
+  // UTF-16 code-unit offsets (matches `String.indexOf` semantics) for
+  // the start of each line. Not byte offsets — for ASCII content the
+  // two coincide, but multi-byte glyphs (em dashes, emoji) make the
+  // distinction load-bearing if this is ever consumed as a byte index.
+  const lineStartOffsets: number[] = [0]
   for (let i = 0; i < fileLines.length - 1; i++) {
     // +1 for the consumed '\n' separator
-    lineStartByteOffsets.push(lineStartByteOffsets[i] + fileLines[i].length + 1)
+    lineStartOffsets.push(lineStartOffsets[i] + fileLines[i].length + 1)
   }
   // Locate the start line for `firstIndex`.
   let startLine = 1
-  for (let i = lineStartByteOffsets.length - 1; i >= 0; i--) {
-    if (firstIndex >= lineStartByteOffsets[i]) {
+  for (let i = lineStartOffsets.length - 1; i >= 0; i--) {
+    if (firstIndex >= lineStartOffsets[i]) {
       startLine = i + 1
       break
     }
@@ -213,13 +230,17 @@ export const claudeCodeAdapter: FrameworkAdapter = {
   },
   applyAction: async (action: AdapterAction): Promise<void> => {
     if (action.kind === 'rename') {
-      // Forward-compat seam: a raw filesystem rename. v1 callers
-      // should normally prefer `applyRename(entry, newName, opts)` so
-      // the rename is backed up + recorded in the namespace ledger.
-      // This bare path is intentional — v2 adapters that own their
-      // own audit-history use `applyAction` as the unified seam.
-      await fs.rename(action.from, action.to)
-      return
+      // v1 Claude-Code refuses bare `applyAction({kind:'rename'})` — a
+      // raw `fs.rename` would bypass Wave 2's backup + namespace
+      // ledger, leaving the user without a revert path. Callers must
+      // use the `applyRename(entry, newName, { auditId })` convenience
+      // wrapper which routes through Wave 2's full flow. The richer
+      // entry context (kind discriminator, identifier, source_path)
+      // cannot be reconstructed from a thin {from, to} pair.
+      throw new FrameworkAdapterError(
+        'namespace.adapter.missing_context',
+        `claudeCodeAdapter.applyAction({kind:'rename'}) refused — use applyRename(entry, newName, { auditId }) so the rename is backed up + recorded in the namespace ledger`
+      )
     }
     if (action.kind === 'inline-edit') {
       if (action.searchMode === 'regex') {
@@ -237,8 +258,9 @@ export const claudeCodeAdapter: FrameworkAdapter = {
       })
       if (!result.success) {
         throw new FrameworkAdapterError(
-          'namespace.adapter.unsupported_action',
-          `applyRecommendedEdit failed: ${result.error?.message ?? 'unknown'}`
+          'namespace.adapter.subcall_failed',
+          `applyRecommendedEdit failed: ${result.error?.message ?? 'unknown'}`,
+          result.error?.kind
         )
       }
       return
@@ -276,8 +298,9 @@ export const claudeCodeAdapter: FrameworkAdapter = {
     })
     if (!result.success) {
       throw new FrameworkAdapterError(
-        'namespace.adapter.unsupported_action',
-        `applyRename failed: ${result.error?.message ?? 'unknown'}`
+        'namespace.adapter.subcall_failed',
+        `applyRename failed: ${result.error?.message ?? 'unknown'}`,
+        result.error?.kind
       )
     }
   },

--- a/packages/mcp-server/src/audit/framework-adapter.ts
+++ b/packages/mcp-server/src/audit/framework-adapter.ts
@@ -1,0 +1,303 @@
+/**
+ * @fileoverview `claudeCodeAdapter` — v1 implementation of `FrameworkAdapter`.
+ *               Wraps Wave 1's `scanLocalInventory`, Wave 2's `applyRename`,
+ *               and Wave 3's `applyRecommendedEdit` behind a uniform seam.
+ * @module @skillsmith/mcp-server/audit/framework-adapter
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §5.
+ *
+ * v1 contract (Claude-Code only):
+ *   - `scanPaths` delegates to `scanLocalInventory` and returns `entries[]`.
+ *   - `applyAction({kind:'rename'})` performs a raw `fs.rename` from `from`
+ *     to `to` — forward-compat seam for v2 adapters that own their own
+ *     audit-history. v1 callers should prefer the `applyRename` wrapper,
+ *     which threads `auditId` through Wave 2's full backup + ledger flow.
+ *   - `applyAction({kind:'inline-edit', searchMode:'literal'})` translates
+ *     the action into a Wave 3 `RecommendedEdit` and dispatches to
+ *     `applyRecommendedEdit`. Requires `action.auditId` + `action.pattern`;
+ *     missing context throws `namespace.adapter.missing_context`.
+ *   - `applyAction({kind:'inline-edit', searchMode:'regex'})` throws the
+ *     typed error `namespace.adapter.unsupported_search_mode`. Reserved
+ *     for v2 cursorAdapter.
+ *   - Convenience wrappers `applyRename` + `applyEdit` build the right
+ *     `AdapterAction` shape from inventory/edit context and call
+ *     `applyAction`. They do NOT re-implement Wave 2/3 — the rename
+ *     wrapper goes through Wave 2's full path (backup + ledger), and the
+ *     edit wrapper goes through Wave 3's `applyRecommendedEdit`.
+ */
+
+import * as fs from 'node:fs/promises'
+
+import { newAuditId, deriveCollisionId } from './audit-history.js'
+import { applyRecommendedEdit, APPLY_TEMPLATE_REGISTRY } from './edit-applier.js'
+import { applyRename as applyRenameEngine } from './rename-engine.js'
+import type { CollisionId, InventoryEntry } from './collision-detector.types.js'
+import type { RecommendedEdit } from './edit-suggester.types.js'
+import type { RenameAction, RenameSuggestion } from './rename-engine.types.js'
+import { scanLocalInventory } from '../utils/local-inventory.js'
+
+import type {
+  AdapterAction,
+  FileRenameAction,
+  FrameworkAdapter,
+  InlineEditAction,
+} from './framework-adapter.types.js'
+
+/**
+ * Typed error class for adapter-layer failures. Callers `switch` on
+ * `kind` to branch on the failure mode without parsing strings.
+ */
+export class FrameworkAdapterError extends Error {
+  public readonly kind:
+    | 'namespace.adapter.unsupported_search_mode'
+    | 'namespace.adapter.missing_context'
+    | 'namespace.adapter.unsupported_action'
+    | 'namespace.adapter.template_not_in_apply_registry'
+    | 'namespace.adapter.search_not_found'
+    | 'namespace.adapter.search_not_unique'
+
+  constructor(kind: FrameworkAdapterError['kind'], message: string) {
+    super(message)
+    this.name = 'FrameworkAdapterError'
+    this.kind = kind
+  }
+}
+
+/**
+ * Map an `InventoryEntry.kind` to the Wave 2 `RenameAction` discriminator.
+ */
+function inventoryKindToRenameAction(entry: InventoryEntry): RenameAction {
+  switch (entry.kind) {
+    case 'command':
+      return 'rename_command_file'
+    case 'agent':
+      return 'rename_agent_file'
+    case 'skill':
+      return 'rename_skill_dir_and_frontmatter'
+    case 'claude_md_rule':
+      // CLAUDE.md trigger lines are not file-renamable — the inline-edit
+      // path is the right surface for them. Reject so callers cannot
+      // accidentally pass a `claude_md_rule` entry into the rename flow.
+      throw new FrameworkAdapterError(
+        'namespace.adapter.unsupported_action',
+        `inventory kind "claude_md_rule" cannot be renamed; use applyEdit instead`
+      )
+    default: {
+      const exhaustive: never = entry.kind
+      throw new FrameworkAdapterError(
+        'namespace.adapter.unsupported_action',
+        `unknown inventory kind: ${String(exhaustive)}`
+      )
+    }
+  }
+}
+
+/**
+ * Translate an `InlineEditAction` (literal mode) into a Wave 3
+ * `RecommendedEdit`. Locates the literal `search` substring in the file
+ * and computes a 1-indexed inclusive line range covering it.
+ *
+ * Throws if `search` is absent from the file or appears more than once
+ * (Wave 3's stale-before guard requires byte-for-byte exact match at
+ * the recorded `lineRange`).
+ */
+async function buildRecommendedEditFromInlineEdit(
+  action: InlineEditAction
+): Promise<RecommendedEdit> {
+  if (!action.auditId) {
+    throw new FrameworkAdapterError(
+      'namespace.adapter.missing_context',
+      `inline-edit dispatch requires action.auditId for v1 claudeCodeAdapter`
+    )
+  }
+  if (!action.pattern) {
+    throw new FrameworkAdapterError(
+      'namespace.adapter.missing_context',
+      `inline-edit dispatch requires action.pattern for v1 claudeCodeAdapter`
+    )
+  }
+  if (!APPLY_TEMPLATE_REGISTRY.has(action.pattern)) {
+    throw new FrameworkAdapterError(
+      'namespace.adapter.template_not_in_apply_registry',
+      `template pattern "${action.pattern}" is not in APPLY_TEMPLATE_REGISTRY`
+    )
+  }
+
+  const fileContent = await fs.readFile(action.filePath, 'utf-8')
+  const firstIndex = fileContent.indexOf(action.search)
+  if (firstIndex < 0) {
+    throw new FrameworkAdapterError(
+      'namespace.adapter.search_not_found',
+      `literal search string not found in ${action.filePath}`
+    )
+  }
+  const secondIndex = fileContent.indexOf(action.search, firstIndex + 1)
+  if (secondIndex >= 0) {
+    throw new FrameworkAdapterError(
+      'namespace.adapter.search_not_unique',
+      `literal search string occurs more than once in ${action.filePath}; refusing to mutate`
+    )
+  }
+
+  // Compute 1-indexed inclusive line range covering the match. Wave 3's
+  // applier uses line-based slicing (`fileLines.slice(start-1, end).join('\n')`
+  // must equal `before`), so we expand the substring search to the full
+  // line(s) it sits on and replace within those lines.
+  const fileLines = fileContent.split('\n')
+  const lineStartByteOffsets: number[] = [0]
+  for (let i = 0; i < fileLines.length - 1; i++) {
+    // +1 for the consumed '\n' separator
+    lineStartByteOffsets.push(lineStartByteOffsets[i] + fileLines[i].length + 1)
+  }
+  // Locate the start line for `firstIndex`.
+  let startLine = 1
+  for (let i = lineStartByteOffsets.length - 1; i >= 0; i--) {
+    if (firstIndex >= lineStartByteOffsets[i]) {
+      startLine = i + 1
+      break
+    }
+  }
+  // The match may span multiple lines if `search` contains '\n'.
+  const matchLineCount = action.search.split('\n').length
+  const endLine = startLine + matchLineCount - 1
+  // Whole-line `before` = the lines covering the substring match.
+  const beforeLines = fileLines.slice(startLine - 1, endLine).join('\n')
+  // Whole-line `after` = same lines with `search` substituted for `replace`.
+  const afterLines = beforeLines.replace(action.search, action.replace)
+
+  // collisionId is derived from auditId + filePath (single-entry adapter
+  // dispatch). Use a synthetic single-entry InventoryEntry shape solely
+  // to feed `deriveCollisionId`'s sorted-paths input — the resulting
+  // CollisionId is opaque to the caller and stable for the same
+  // (auditId, filePath) pair.
+  const collisionId: CollisionId = deriveCollisionId(action.auditId, [
+    {
+      kind: 'claude_md_rule',
+      source_path: action.filePath,
+      identifier: action.search.slice(0, 64),
+      triggerSurface: [],
+    },
+  ])
+
+  return {
+    collisionId,
+    category: 'description_overlap',
+    pattern: action.pattern,
+    filePath: action.filePath,
+    lineRange: { start: startLine, end: endLine },
+    before: beforeLines,
+    after: afterLines,
+    rationale:
+      'inline-edit dispatched via claudeCodeAdapter.applyAction (literal-mode translation)',
+    applyAction: 'recommended_edit',
+    applyMode: 'apply_with_confirmation',
+    otherEntry: { identifier: '', sourcePath: '' },
+  }
+}
+
+/**
+ * v1 implementation of `FrameworkAdapter` for Claude-Code.
+ */
+export const claudeCodeAdapter: FrameworkAdapter = {
+  name: 'claude-code',
+  describesFiles: () => [
+    '~/.claude/skills/*/SKILL.md',
+    '~/.claude/commands/*.md',
+    '~/.claude/agents/*.md',
+    '~/.claude/CLAUDE.md',
+    '<project>/CLAUDE.md',
+  ],
+  scanPaths: async (homeDir, projectDir) => {
+    const result = await scanLocalInventory({ homeDir, projectDir })
+    return result.entries
+  },
+  applyAction: async (action: AdapterAction): Promise<void> => {
+    if (action.kind === 'rename') {
+      // Forward-compat seam: a raw filesystem rename. v1 callers
+      // should normally prefer `applyRename(entry, newName, opts)` so
+      // the rename is backed up + recorded in the namespace ledger.
+      // This bare path is intentional — v2 adapters that own their
+      // own audit-history use `applyAction` as the unified seam.
+      await fs.rename(action.from, action.to)
+      return
+    }
+    if (action.kind === 'inline-edit') {
+      if (action.searchMode === 'regex') {
+        throw new FrameworkAdapterError(
+          'namespace.adapter.unsupported_search_mode',
+          `searchMode "regex" not supported by v1 claudeCodeAdapter; reserved for v2 cursorAdapter`
+        )
+      }
+      // Literal mode: translate to RecommendedEdit + dispatch to Wave 3.
+      const edit = await buildRecommendedEditFromInlineEdit(action)
+      const result = await applyRecommendedEdit(edit, {
+        // narrowed by buildRecommendedEditFromInlineEdit:
+        auditId: action.auditId as string,
+        mode: 'apply_with_confirmation',
+      })
+      if (!result.success) {
+        throw new FrameworkAdapterError(
+          'namespace.adapter.unsupported_action',
+          `applyRecommendedEdit failed: ${result.error?.message ?? 'unknown'}`
+        )
+      }
+      return
+    }
+    // Exhaustiveness guard.
+    const exhaustive: never = action
+    throw new FrameworkAdapterError(
+      'namespace.adapter.unsupported_action',
+      `unsupported action shape: ${JSON.stringify(exhaustive)}`
+    )
+  },
+  applyRename: async (
+    entry: InventoryEntry,
+    newName: string,
+    opts: { auditId: string }
+  ): Promise<void> => {
+    // Build a minimal RenameSuggestion and call Wave 2's applyRename
+    // for the full backup + ledger + atomic rename flow. The
+    // collisionId is synthetic (derived from auditId + the single
+    // entry's path) — the Wave 2 ledger entry is keyed by
+    // (skillId, kind, originalIdentifier), not by collisionId, so
+    // a synthetic id is acceptable for adapter-mediated renames.
+    const collisionId: CollisionId = deriveCollisionId(opts.auditId, [entry])
+    const suggestion: RenameSuggestion = {
+      collisionId,
+      entry,
+      currentName: entry.identifier,
+      suggested: newName,
+      applyAction: inventoryKindToRenameAction(entry),
+      reason: 'claudeCodeAdapter.applyRename convenience wrapper',
+    }
+    const result = await applyRenameEngine({
+      suggestion,
+      request: { action: 'apply', auditId: opts.auditId },
+    })
+    if (!result.success) {
+      throw new FrameworkAdapterError(
+        'namespace.adapter.unsupported_action',
+        `applyRename failed: ${result.error?.message ?? 'unknown'}`
+      )
+    }
+  },
+  applyEdit: async (edit: RecommendedEdit, opts: { auditId: string }): Promise<void> => {
+    // Convenience wrapper: build an InlineEditAction and dispatch
+    // through applyAction so the literal-mode translation path runs
+    // its registry guard + uniqueness check uniformly.
+    const action: InlineEditAction = {
+      kind: 'inline-edit',
+      filePath: edit.filePath,
+      search: edit.before,
+      replace: edit.after,
+      searchMode: 'literal',
+      auditId: opts.auditId,
+      pattern: edit.pattern,
+    }
+    await claudeCodeAdapter.applyAction(action)
+  },
+}
+
+// Re-export helpers used by tests + callers.
+export { newAuditId }
+export type { FileRenameAction, InlineEditAction }

--- a/packages/mcp-server/src/audit/framework-adapter.types.ts
+++ b/packages/mcp-server/src/audit/framework-adapter.types.ts
@@ -1,0 +1,167 @@
+/**
+ * @fileoverview Type vocabulary for the FrameworkAdapter seam — v1 ships
+ *               `claude-code` only; v2 reserves `cursor`, `copilot`, `aider`,
+ *               `continue`, `cline`. Defines `AdapterAction` (discriminated
+ *               union over `FileRenameAction` + `InlineEditAction`) and the
+ *               adapter interface.
+ * @module @skillsmith/mcp-server/audit/framework-adapter.types
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §1, §5.
+ *
+ * Why this seam exists (per plan §5): `.cursorrules` (Cursor v2) is a
+ * monolithic file with multiple trigger phrases inside a single file; a
+ * `FileRenameAction`-only shape would break Cursor support. Shipping
+ * `InlineEditAction` from v1 is a forcing function that lets v2 swap in
+ * `cursorAdapter` without refactoring call sites.
+ *
+ * v1 contract (claudeCodeAdapter):
+ *   - `FileRenameAction` is supported via convenience wrapper `applyRename`
+ *     which performs the full Wave 2 `applyRename` flow (backup + ledger
+ *     append + atomic rename). The bare `applyAction({kind:'rename'})`
+ *     entry point is a raw transport seam (forward-compat for v2 adapters
+ *     that own their own audit-history); v1 callers should prefer the
+ *     `applyRename` wrapper which threads `auditId` through correctly.
+ *   - `InlineEditAction` with `searchMode: 'literal'` translates to a
+ *     `RecommendedEdit` and dispatches to Wave 3's `applyRecommendedEdit`.
+ *   - `InlineEditAction` with `searchMode: 'regex'` is rejected with the
+ *     typed error `namespace.adapter.unsupported_search_mode`. Reserved
+ *     for v2 cursorAdapter.
+ */
+
+import type { InventoryEntry } from '../utils/local-inventory.types.js'
+import type { RecommendedEdit } from './edit-suggester.types.js'
+
+/**
+ * Set of frameworks the audit pipeline can target. v1 ships `claude-code`
+ * exclusively. The v2 reserved values document the intended extension
+ * surface — adding a new entry here without a matching adapter
+ * implementation is a compile-time signal, not a runtime contract.
+ */
+export type FrameworkName =
+  | 'claude-code'
+  // v2 (reserved — adapters will land in subsequent Linear issues):
+  | 'cursor'
+  | 'copilot'
+  | 'aider'
+  | 'continue'
+  | 'cline'
+
+/**
+ * Rename a single file (or directory + frontmatter for `.claude/skills/`).
+ *
+ * For Claude-Code, this maps to Wave 2's `applyRename` flow: the caller
+ * should normally invoke the `applyRename` convenience wrapper which
+ * builds the action from a full `InventoryEntry` + `auditId`. The bare
+ * `applyAction({kind:'rename'})` entry is a transport seam — it expects
+ * a richer caller-side context to resolve correctly (see `auditId`
+ * field).
+ */
+export interface FileRenameAction {
+  kind: 'rename'
+  /** Absolute path (current). */
+  from: string
+  /** Absolute path (target). */
+  to: string
+  /**
+   * FK into `~/.skillsmith/audits/<auditId>/result.json`. Required by
+   * v1 Claude-Code adapter so the rename can be traced in the namespace
+   * overrides ledger. v2 adapters that own a different audit history
+   * may treat this as optional, hence the optional declaration here.
+   */
+  auditId?: string
+}
+
+/**
+ * In-place edit at a specific point in a file. Required for monolithic
+ * files (`.cursorrules`, freeform CLAUDE.md sections) where renaming
+ * the file itself is meaningless — the edit happens at a section.
+ *
+ * v1 Claude-Code adapter accepts only `searchMode: 'literal'` and
+ * translates the action into a Wave 3 `RecommendedEdit` shape before
+ * dispatching to `applyRecommendedEdit`. `searchMode: 'regex'` is
+ * rejected with `namespace.adapter.unsupported_search_mode`.
+ */
+export interface InlineEditAction {
+  kind: 'inline-edit'
+  /** Absolute path to the file to mutate. */
+  filePath: string
+  /**
+   * Exact substring (when `searchMode === 'literal'`) or regex source
+   * string (when `searchMode === 'regex'`) to locate within the file.
+   */
+  search: string
+  /** Replacement text. */
+  replace: string
+  /**
+   * Required. v1 `claudeCodeAdapter` rejects `'regex'` with the typed
+   * error `namespace.adapter.unsupported_search_mode`. Future v2
+   * `cursorAdapter` supports both modes.
+   */
+  searchMode: 'literal' | 'regex'
+  /**
+   * FK into `~/.skillsmith/audits/<auditId>/result.json`. Required by
+   * v1 Claude-Code adapter so the edit-applier ledger entry is bound
+   * to the originating audit. v2 adapters may treat this as optional,
+   * hence the optional declaration here.
+   */
+  auditId?: string
+  /**
+   * The edit-suggester template pattern that produced this action. v1
+   * Claude-Code adapter passes this through to Wave 3's
+   * `applyRecommendedEdit`, which gates on `APPLY_TEMPLATE_REGISTRY`.
+   * Only `'add_domain_qualifier'` is in the registry in v1.
+   */
+  pattern?: RecommendedEdit['pattern']
+}
+
+/**
+ * Discriminated union over every adapter action shape. The `kind`
+ * literal narrows the union for downstream dispatchers.
+ */
+export type AdapterAction = FileRenameAction | InlineEditAction
+
+/**
+ * Framework adapter — abstracts over `claude-code` (v1), `cursor`,
+ * `copilot`, `aider`, `continue`, `cline` (v2). Wave 4's MCP tools,
+ * the CLI, and Wave 2's install pre-flight all consume the adapter
+ * rather than calling `scanLocalInventory` / `applyRename` /
+ * `applyRecommendedEdit` directly. This is the seam that lets v2 swap
+ * in `cursorAdapter` without touching call sites.
+ */
+export interface FrameworkAdapter {
+  name: FrameworkName
+  /** Glob/path examples for transparency in audit reports. */
+  describesFiles(): string[]
+  /**
+   * Scan the framework's relevant filesystem locations for inventory.
+   * For `claude-code` this wraps Wave 1's `scanLocalInventory`.
+   */
+  scanPaths(homeDir: string, projectDir?: string): Promise<InventoryEntry[]>
+  /**
+   * Required unified entry point. v1 Claude-Code:
+   *   - `kind: 'rename'` — performs a raw `fs.rename` from `from` to
+   *     `to`. Caller is responsible for backup + ledger; the
+   *     `applyRename` convenience wrapper does the full flow.
+   *   - `kind: 'inline-edit'` with `searchMode: 'literal'` — translates
+   *     to a `RecommendedEdit` and dispatches to Wave 3
+   *     `applyRecommendedEdit`. Requires `auditId` + `pattern`.
+   *   - `kind: 'inline-edit'` with `searchMode: 'regex'` — rejected
+   *     with `namespace.adapter.unsupported_search_mode`.
+   */
+  applyAction(action: AdapterAction): Promise<void>
+  /**
+   * Convenience wrapper for the common `claude-code` rename flow:
+   * builds a `FileRenameAction` and forwards. v1 Claude-Code wraps
+   * Wave 2's `applyRename` (full backup + ledger append + atomic
+   * rename). Optional on the interface — v2 adapters that don't have
+   * a per-file rename concept (Cursor) may omit it.
+   */
+  applyRename?(entry: InventoryEntry, newName: string, opts: { auditId: string }): Promise<void>
+  /**
+   * Convenience wrapper for Wave 3's prose-edit surface. v1
+   * Claude-Code builds an `InlineEditAction` with
+   * `searchMode: 'literal'` from the `RecommendedEdit` shape and
+   * forwards to `applyAction`.
+   */
+  applyEdit?(edit: RecommendedEdit, opts: { auditId: string }): Promise<void>
+}

--- a/packages/mcp-server/src/audit/framework-adapter.types.ts
+++ b/packages/mcp-server/src/audit/framework-adapter.types.ts
@@ -139,9 +139,12 @@ export interface FrameworkAdapter {
   scanPaths(homeDir: string, projectDir?: string): Promise<InventoryEntry[]>
   /**
    * Required unified entry point. v1 Claude-Code:
-   *   - `kind: 'rename'` — performs a raw `fs.rename` from `from` to
-   *     `to`. Caller is responsible for backup + ledger; the
-   *     `applyRename` convenience wrapper does the full flow.
+   *   - `kind: 'rename'` — REFUSED. A thin {from, to} pair cannot
+   *     reconstruct the `InventoryEntry` Wave 2's `applyRename` needs;
+   *     a raw `fs.rename` would bypass the backup + namespace ledger.
+   *     Callers must use the `applyRename(entry, newName, opts)`
+   *     convenience wrapper. The shape stays in the union for v2
+   *     adapters that own their own audit-history.
    *   - `kind: 'inline-edit'` with `searchMode: 'literal'` — translates
    *     to a `RecommendedEdit` and dispatches to Wave 3
    *     `applyRecommendedEdit`. Requires `auditId` + `pattern`.

--- a/packages/mcp-server/src/audit/index.ts
+++ b/packages/mcp-server/src/audit/index.ts
@@ -128,3 +128,15 @@ export { APPLY_TEMPLATE_REGISTRY, applyRecommendedEdit } from './edit-applier.js
 export type { ApplyRecommendedEditOptions } from './edit-applier.js'
 
 export type { EditApplyError, EditApplyResult } from './edit-applier.types.js'
+
+// SMI-4590 Wave 4 PR 2/6 — FrameworkAdapter seam + claudeCodeAdapter (v1).
+// PR 3/6 will add `runInventoryAudit` shared helper to the same surface.
+export { claudeCodeAdapter, FrameworkAdapterError } from './framework-adapter.js'
+
+export type {
+  AdapterAction,
+  FileRenameAction,
+  FrameworkAdapter,
+  FrameworkName,
+  InlineEditAction,
+} from './framework-adapter.types.js'

--- a/packages/mcp-server/tests/unit/framework-adapter.test.ts
+++ b/packages/mcp-server/tests/unit/framework-adapter.test.ts
@@ -95,21 +95,26 @@ describe('claudeCodeAdapter.scanPaths', () => {
   })
 })
 
-describe('claudeCodeAdapter.applyAction — rename (raw transport)', () => {
-  it('performs fs.rename from `from` to `to`', async () => {
+describe('claudeCodeAdapter.applyAction — rename refusal (force-uses-applyRename)', () => {
+  it('refuses bare {kind:"rename"} dispatch with namespace.adapter.missing_context and leaves disk untouched', async () => {
     const fromPath = path.join(TEST_HOME, 'src.md')
     const toPath = path.join(TEST_HOME, 'dst.md')
     fs.writeFileSync(fromPath, 'hello', 'utf-8')
 
-    await claudeCodeAdapter.applyAction({
-      kind: 'rename',
-      from: fromPath,
-      to: toPath,
+    await expect(
+      claudeCodeAdapter.applyAction({
+        kind: 'rename',
+        from: fromPath,
+        to: toPath,
+      })
+    ).rejects.toMatchObject({
+      kind: 'namespace.adapter.missing_context',
     })
-
-    expect(fs.existsSync(fromPath)).toBe(false)
-    expect(fs.existsSync(toPath)).toBe(true)
-    expect(fs.readFileSync(toPath, 'utf-8')).toBe('hello')
+    // Disk untouched: refusing the bare path is the whole point — Wave 2's
+    // backup + ledger flow must not be bypassed.
+    expect(fs.existsSync(fromPath)).toBe(true)
+    expect(fs.existsSync(toPath)).toBe(false)
+    expect(fs.readFileSync(fromPath, 'utf-8')).toBe('hello')
   })
 })
 

--- a/packages/mcp-server/tests/unit/framework-adapter.test.ts
+++ b/packages/mcp-server/tests/unit/framework-adapter.test.ts
@@ -1,0 +1,254 @@
+/**
+ * @fileoverview Unit tests for SMI-4590 Wave 4 PR 2/6 — FrameworkAdapter
+ *               seam + claudeCodeAdapter (v1).
+ * @module @skillsmith/mcp-server/tests/unit/framework-adapter
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §5,
+ *       §Tests §framework-adapter.test.ts.
+ *
+ * Coverage:
+ *   1. `claudeCodeAdapter.name === 'claude-code'` + `describesFiles()` non-empty.
+ *   2. `scanPaths()` returns valid `InventoryEntry[]` matching Wave 1's output.
+ *   3. `applyAction({kind:'rename', from, to})` performs a raw `fs.rename`.
+ *   4. `applyAction({kind:'inline-edit', searchMode:'literal', ...})` mutates
+ *      the file via Wave 3's applyRecommendedEdit (registered template only).
+ *   5. `applyAction({kind:'inline-edit', searchMode:'regex', ...})` throws
+ *      `namespace.adapter.unsupported_search_mode` and the file is unchanged.
+ *   6. Convenience wrapper `applyRename(entry, newName, { auditId })` runs
+ *      Wave 2's applyRename flow (backup + ledger + rename) for a command file.
+ *   7. Convenience wrapper `applyEdit(edit, { auditId })` round-trips through
+ *      `applyAction` and mutates the file.
+ *   8. Conformance: `claudeCodeAdapter` satisfies `FrameworkAdapter` (compile-
+ *      time guard via the `const adapter: FrameworkAdapter = claudeCodeAdapter`
+ *      assignment in this file).
+ *   9. Inline-edit with missing `auditId` rejects with
+ *      `namespace.adapter.missing_context`.
+ *  10. Inline-edit with non-registered `pattern` rejects with
+ *      `namespace.adapter.template_not_in_apply_registry`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { newAuditId } from '../../src/audit/audit-history.js'
+import { claudeCodeAdapter, FrameworkAdapterError } from '../../src/audit/framework-adapter.js'
+import type { FrameworkAdapter } from '../../src/audit/framework-adapter.types.js'
+import type { RecommendedEdit } from '../../src/audit/edit-suggester.types.js'
+import type { InventoryEntry } from '../../src/utils/local-inventory.types.js'
+import { writeSkillMd } from './edit-suggester.fixtures.js'
+
+// Compile-time conformance assertion. If `claudeCodeAdapter` ever drifts
+// out of the `FrameworkAdapter` shape, this assignment will fail to
+// type-check during the build step in CI.
+const _conformance: FrameworkAdapter = claudeCodeAdapter
+void _conformance
+
+let TEST_HOME: string
+let ORIGINAL_HOME: string | undefined
+
+beforeEach(() => {
+  TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-framework-adapter-'))
+  ORIGINAL_HOME = process.env['HOME']
+  process.env['HOME'] = TEST_HOME
+})
+
+afterEach(() => {
+  if (ORIGINAL_HOME !== undefined) {
+    process.env['HOME'] = ORIGINAL_HOME
+  } else {
+    delete process.env['HOME']
+  }
+  if (TEST_HOME && fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+  }
+})
+
+describe('claudeCodeAdapter — identity', () => {
+  it('has name "claude-code" and non-empty describesFiles()', () => {
+    expect(claudeCodeAdapter.name).toBe('claude-code')
+    const files = claudeCodeAdapter.describesFiles()
+    expect(files.length).toBeGreaterThan(0)
+    expect(files).toContain('~/.claude/skills/*/SKILL.md')
+  })
+})
+
+describe('claudeCodeAdapter.scanPaths', () => {
+  it('returns InventoryEntry[] from an empty home (no scan errors)', async () => {
+    const entries = await claudeCodeAdapter.scanPaths(TEST_HOME)
+    expect(Array.isArray(entries)).toBe(true)
+    // Empty .claude/ → no entries; the contract is just "Array of InventoryEntry".
+    expect(entries.every((e) => typeof e.identifier === 'string')).toBe(true)
+  })
+
+  it('discovers a SKILL.md created on disk and returns it as a kind:"skill" entry', async () => {
+    writeSkillMd(TEST_HOME, {
+      identifier: 'fixture-skill',
+      description: 'Use when deploying to staging',
+    })
+    const entries = await claudeCodeAdapter.scanPaths(TEST_HOME)
+    const skill = entries.find((e) => e.identifier === 'fixture-skill')
+    expect(skill).toBeDefined()
+    expect(skill?.kind).toBe('skill')
+    expect(skill?.source_path).toContain('SKILL.md')
+  })
+})
+
+describe('claudeCodeAdapter.applyAction — rename (raw transport)', () => {
+  it('performs fs.rename from `from` to `to`', async () => {
+    const fromPath = path.join(TEST_HOME, 'src.md')
+    const toPath = path.join(TEST_HOME, 'dst.md')
+    fs.writeFileSync(fromPath, 'hello', 'utf-8')
+
+    await claudeCodeAdapter.applyAction({
+      kind: 'rename',
+      from: fromPath,
+      to: toPath,
+    })
+
+    expect(fs.existsSync(fromPath)).toBe(false)
+    expect(fs.existsSync(toPath)).toBe(true)
+    expect(fs.readFileSync(toPath, 'utf-8')).toBe('hello')
+  })
+})
+
+describe('claudeCodeAdapter.applyAction — inline-edit', () => {
+  it('rejects searchMode "regex" with namespace.adapter.unsupported_search_mode and leaves the file untouched', async () => {
+    const filePath = path.join(TEST_HOME, 'doc.md')
+    const original = 'Use when deploying to staging'
+    fs.writeFileSync(filePath, original, 'utf-8')
+
+    await expect(
+      claudeCodeAdapter.applyAction({
+        kind: 'inline-edit',
+        filePath,
+        search: 'deploying',
+        replace: 'shipping',
+        searchMode: 'regex',
+        auditId: newAuditId(),
+        pattern: 'add_domain_qualifier',
+      })
+    ).rejects.toMatchObject({
+      kind: 'namespace.adapter.unsupported_search_mode',
+    })
+    // File untouched.
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(original)
+  })
+
+  it('rejects literal-mode dispatch missing auditId with namespace.adapter.missing_context', async () => {
+    const filePath = path.join(TEST_HOME, 'doc.md')
+    fs.writeFileSync(filePath, 'Use when deploying', 'utf-8')
+
+    await expect(
+      claudeCodeAdapter.applyAction({
+        kind: 'inline-edit',
+        filePath,
+        search: 'deploying',
+        replace: 'shipping',
+        searchMode: 'literal',
+        // auditId intentionally omitted
+        pattern: 'add_domain_qualifier',
+      })
+    ).rejects.toBeInstanceOf(FrameworkAdapterError)
+  })
+
+  it('rejects literal-mode dispatch with a non-registered pattern with namespace.adapter.template_not_in_apply_registry', async () => {
+    const filePath = path.join(TEST_HOME, 'doc.md')
+    fs.writeFileSync(filePath, 'Use when deploying', 'utf-8')
+
+    await expect(
+      claudeCodeAdapter.applyAction({
+        kind: 'inline-edit',
+        filePath,
+        search: 'deploying',
+        replace: 'shipping',
+        searchMode: 'literal',
+        auditId: newAuditId(),
+        // narrow_scope is NOT in APPLY_TEMPLATE_REGISTRY in v1.
+        pattern: 'narrow_scope',
+      })
+    ).rejects.toMatchObject({
+      kind: 'namespace.adapter.template_not_in_apply_registry',
+    })
+  })
+})
+
+describe('claudeCodeAdapter.applyEdit — convenience wrapper round-trip', () => {
+  it('round-trips through applyAction and mutates the file (registered template)', async () => {
+    // Build a SKILL.md whose description contains the literal we want
+    // to edit. The applier requires byte-for-byte stale-before match.
+    const skillPath = writeSkillMd(TEST_HOME, {
+      identifier: 'roundtrip-fixture',
+      description: 'Use when deploying',
+    })
+    const original = fs.readFileSync(skillPath, 'utf-8')
+    expect(original).toContain('Use when deploying')
+
+    const auditId = newAuditId()
+    const edit: RecommendedEdit = {
+      // The collisionId here is opaque — Wave 3 applier only uses it as
+      // the ledger FK, not to look up state. The convenience wrapper
+      // builds an InlineEditAction with `before` as the literal search.
+      collisionId: 'cid-roundtrip-0' as RecommendedEdit['collisionId'],
+      category: 'description_overlap',
+      pattern: 'add_domain_qualifier',
+      filePath: skillPath,
+      lineRange: { start: 1, end: 1 }, // recomputed by adapter; ignored by inline-edit translator
+      before: 'Use when deploying',
+      after: 'Use when deploying for release-tools tasks',
+      rationale: 'test',
+      applyAction: 'recommended_edit',
+      applyMode: 'apply_with_confirmation',
+      otherEntry: { identifier: 'other', sourcePath: '/tmp/other' },
+    }
+
+    expect(claudeCodeAdapter.applyEdit).toBeDefined()
+    await claudeCodeAdapter.applyEdit?.(edit, { auditId })
+
+    const updated = fs.readFileSync(skillPath, 'utf-8')
+    expect(updated).toContain('Use when deploying for release-tools tasks')
+    expect(updated).not.toBe(original)
+  })
+})
+
+describe('claudeCodeAdapter.applyRename — convenience wrapper for command files', () => {
+  it('renames a ~/.claude/commands/<name>.md via Wave 2 applyRename + ledger', async () => {
+    // Stage a command file at ~/.claude/commands/foo.md.
+    const commandsDir = path.join(TEST_HOME, '.claude', 'commands')
+    fs.mkdirSync(commandsDir, { recursive: true })
+    const fromPath = path.join(commandsDir, 'foo.md')
+    fs.writeFileSync(fromPath, '# /foo\n', 'utf-8')
+
+    const entry: InventoryEntry = {
+      kind: 'command',
+      source_path: fromPath,
+      identifier: 'foo',
+      triggerSurface: ['/foo'],
+    }
+
+    expect(claudeCodeAdapter.applyRename).toBeDefined()
+    await claudeCodeAdapter.applyRename?.(entry, 'mine-foo', {
+      auditId: newAuditId(),
+    })
+
+    const targetPath = path.join(commandsDir, 'mine-foo.md')
+    expect(fs.existsSync(fromPath)).toBe(false)
+    expect(fs.existsSync(targetPath)).toBe(true)
+  })
+
+  it('rejects rename of a claude_md_rule entry with namespace.adapter.unsupported_action', async () => {
+    const entry: InventoryEntry = {
+      kind: 'claude_md_rule',
+      source_path: path.join(TEST_HOME, '.claude', 'CLAUDE.md'),
+      identifier: 'rule-hash-stub',
+      triggerSurface: ['use when deploying'],
+    }
+
+    await expect(
+      claudeCodeAdapter.applyRename?.(entry, 'whatever', {
+        auditId: newAuditId(),
+      })
+    ).rejects.toBeInstanceOf(FrameworkAdapterError)
+  })
+})


### PR DESCRIPTION
## Scope (PR 2/6 of SMI-4590 Wave 4)

Ships the `FrameworkAdapter` seam (plan §1, §5) so Wave 4's MCP tools, the CLI command (PR 5/6), and Wave 2's install pre-flight can target `claude-code` (v1) without baking the call sites into Wave 1's `scanLocalInventory` / Wave 2's `applyRename` / Wave 3's `applyRecommendedEdit` directly.

Also wires `@skillsmith/mcp-server` as a runtime dep in `@skillsmith/cli` (plan amendment **path (a)**) so PR 5/6 can `import { claudeCodeAdapter } from '@skillsmith/mcp-server/audit'`. SMI-4655 (mcp-server → cli inversion) is deferred per the amendment.

## Files

| File | Status | LOC |
|---|---|---|
| `packages/mcp-server/src/audit/framework-adapter.types.ts` | New | 168 |
| `packages/mcp-server/src/audit/framework-adapter.ts` | New | ~310 |
| `packages/mcp-server/src/audit/index.ts` | Modified | +12 |
| `packages/mcp-server/tests/unit/framework-adapter.test.ts` | New | ~265 |
| `packages/mcp-server/package.json` | Modified | +12 (`exports` field) |
| `packages/cli/package.json` | Modified | +1 (`@skillsmith/mcp-server: ^0.4.13`) |

All source files are well under the 500-LOC pre-commit gate.

## Tests

10 cases in `tests/unit/framework-adapter.test.ts`, all passing:

1. `claudeCodeAdapter.name === 'claude-code'` + `describesFiles()` non-empty.
2. `scanPaths()` returns `InventoryEntry[]` from an empty home (no scan errors).
3. `scanPaths()` discovers a real SKILL.md on disk and returns it as `kind: 'skill'`.
4. `applyAction({kind:'rename', from, to})` is **refused** with `namespace.adapter.missing_context` (post-governance fix — bare path would bypass Wave 2's backup + ledger; callers must use `applyRename(entry, newName, opts)`).
5. `applyAction({kind:'inline-edit', searchMode:'regex', ...})` throws `namespace.adapter.unsupported_search_mode`; file untouched.
6. `applyAction({kind:'inline-edit', searchMode:'literal', ...})` rejects when `auditId` is missing → `namespace.adapter.missing_context`.
7. `applyAction({kind:'inline-edit', searchMode:'literal', pattern: 'narrow_scope'})` rejects with `namespace.adapter.template_not_in_apply_registry` (only `add_domain_qualifier` is registered in v1).
8. `applyEdit(edit, { auditId })` round-trips through `applyAction` and mutates the file (registered template).
9. `applyRename(entry, newName, { auditId })` runs Wave 2's full flow (backup + ledger + atomic rename) for a `~/.claude/commands/<name>.md`.
10. `applyRename` of a `claude_md_rule` entry rejects with `namespace.adapter.unsupported_action` (CLAUDE.md trigger lines are not file-renamable; use `applyEdit` instead).

Compile-time conformance: `const _conformance: FrameworkAdapter = claudeCodeAdapter` in the test file fails to type-check if the adapter ever drifts out of the interface shape.

**Full mcp-server suite**: 790 passed (37 files, 7 todo).

## Plan reference

[`docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md`](https://github.com/smith-horn/skillsmith-docs/blob/smi-4584-consumer-namespace-audit/implementation/smi-4590-cli-mcp-framework-adapter.md) §1 (revision history — `InlineEditAction` amendment), §5 (FrameworkAdapter API).

## Path (a) wiring (mandatory for PR 5/6)

`@skillsmith/cli` now declares `@skillsmith/mcp-server: ^0.4.13` in `dependencies`. PR 5/6's `sklx audit collisions` command imports `claudeCodeAdapter` from `@skillsmith/mcp-server/audit`. SMI-4655 (long-term: invert the dependency so mcp-server pulls cli, not the other way around) is deferred to a later wave.

## Plan ambiguity surfaced + resolved

Plan §5 stub showed `FileRenameAction { kind, from, to }` and hinted `applyAction({kind:'rename'})` should "delegate to Wave 2's applyRename (file-level rename)". But Wave 2's `applyRename` requires a full `RenameSuggestion` (auditId + collisionId + InventoryEntry + RenameAction discriminator) that a thin {from, to} pair cannot reconstruct.

**v1 resolution**:
- Bare `applyAction({kind:'rename'})` is **refused** with `namespace.adapter.missing_context`. A raw `fs.rename` would bypass Wave 2's backup + namespace-overrides ledger and leave the user without a revert path. The shape stays in the union as a forward-compat surface for v2 adapters that own their own audit-history.
- The convenience wrapper `applyRename(entry, newName, { auditId })` is the only correct v1 path. It builds a synthetic `RenameSuggestion` and routes through Wave 2's full flow (idempotency check + backup + atomic rename + ledger append + summary).
- Both action shapes were extended with optional `auditId` (and `pattern` for inline-edit) so v1 dispatches can carry the context Wave 3 requires.

This resolution is documented in `framework-adapter.ts` header + interface JSDoc.

## Forward references

- **PR 3/6**: core helpers `runInventoryAudit` + per-skill exclusions (`packages/core/src/audit/exclusions.ts`).
- **PR 4/6**: MCP tools (`skill_inventory_audit`, `apply_namespace_rename`, conditional `apply_recommended_edit`) — consume the adapter via `import { claudeCodeAdapter } from './audit'`.
- **PR 5/6**: CLI `sklx audit collisions` + `sklx config set audit_mode` — consumes the adapter via `import { claudeCodeAdapter } from '@skillsmith/mcp-server/audit'`.
- **PR 6/6**: tier-gated session-start audit hook + Enterprise scheduled scan + CLAUDE.md update.

## Verification

```
docker run --rm -v <worktree>:/app skillsmith-dev:latest npx vitest run
# 790 passed (37 files)

docker run --rm -v <worktree>:/app skillsmith-dev:latest npx prettier --check <touched files>
# All matched files use Prettier code style!

docker run --rm -v <worktree>:/app skillsmith-dev:latest npx tsc --noEmit  # mcp-server
# clean

docker run --rm -v <worktree>:/app skillsmith-dev:latest npm run audit:standards
# 51 passed, 6 warnings (all pre-existing), 0 failed, 89% compliance
```

## Linear

SMI-4590 — comment posted with commit SHAs `4c84246f` (main) + `cfd10afb` (governance retro fixes).

Side-effect: filed [SMI-4687](https://linear.app/smith-horn-group/issue/SMI-4687) — `memory-topic-files.test.ts` (SMI-4677) does not unset `SKILLSMITH_MEMORY_DIR_OVERRIDE` in `beforeEach`, blocking local pre-push from worktrees that use the standard container. CI is unaffected. Test-only fix.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)