### PR TITLE
fix(infra): SMI-4698 add Docker-active guard to repair-worktrees.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,8 @@ Caveats: (a) do not run `npm install` in the main repo while a pre-commit is act
 
 …it is **expected** and the hook is doing the right thing. If the message is followed by `❌ Host node_modules missing in worktree.`, run `./scripts/repair-worktrees.sh` to backfill the symlinks + native bindings.
 
+**Caveat (SMI-4698)**: the **native-rebuild step** of `./scripts/repair-worktrees.sh` aborts if a `skillsmith*-dev-N` container is running — it would otherwise overwrite the container's ELF native bindings via the symlinked `node_modules`. Symlink-repair steps run safely regardless. Stop the container first (`docker compose --profile dev down`), or pass `--force-with-active-docker` and run `docker exec -w /app skillsmith-dev-1 npm rebuild better-sqlite3 onnxruntime-node` afterward to restore the container's bindings.
+
 **Rebasing**: `./scripts/rebase-worktree.sh <worktree-path> [target-branch]` handles git-crypt filter management, submodule cross-fetching, and branch verification. Use `--dry-run` to preview. Manual fallback: [git-crypt-guide.md](.claude/development/git-crypt-guide.md#rebasing-with-git-crypt).
 
 **Full guide**: [git-crypt-guide.md](.claude/development/git-crypt-guide.md)
@@ -486,6 +488,7 @@ A `SessionStart` hook (`scripts/session-start-priming.sh`) writes a transient pr
 | Native module errors | `docker exec skillsmith-dev-1 npm rebuild better-sqlite3 onnxruntime-node` |
 | Platform mismatch (SIGKILL 137) | `rm -rf packages/*/node_modules/better-sqlite3 packages/*/node_modules/onnxruntime-node` then rebuild |
 | Node ABI mismatch (after Node upgrade) | WASM fallback auto-activates since core 0.4.10. To restore native: `docker exec skillsmith-dev-1 npm rebuild better-sqlite3` (Docker side); `./scripts/repair-host-native-deps.sh` (host side, SMI-4549) |
+| "invalid ELF header" inside Docker after running `repair-worktrees.sh` (SMI-4698) | `docker exec -w /app skillsmith-dev-1 npm rebuild better-sqlite3 onnxruntime-node` |
 | Docker DNS failure | `docker network prune -f` then restart container |
 | Stale CJS artifacts | `docker exec skillsmith-dev-1 bash -c 'find /app/packages -path "*/src/*.js" -not -path "*/node_modules/*" -not -path "*/dist/*" -type f -delete'` |
 | Orphaned agents | `./scripts/cleanup-orphans.sh` (`--dry-run` to preview) |

--- a/scripts/repair-worktrees.sh
+++ b/scripts/repair-worktrees.sh
@@ -11,7 +11,17 @@
 # Safe to run repeatedly. Skips worktrees that already have node_modules
 # (symlink or real directory). Never touches the main repository.
 #
-# Usage: ./scripts/repair-worktrees.sh
+# SMI-4698: the native-rebuild step (repair-host-native-deps.sh) writes
+# host-arch (Mach-O on macOS) `*.node` binaries into the symlinked
+# node_modules. Because per-package node_modules are symlinked between
+# the host and the running Docker dev container, that rebuild overwrites
+# the container's ELF (linux-x64) binary, breaking every test inside
+# Docker until `docker exec ... npm rebuild` runs. The guard below
+# refuses to run the native-rebuild step when a `skillsmith*-dev-N`
+# container is detected, unless --force-with-active-docker is set.
+# Symlink-repair phases run unconditionally (no binary writes).
+#
+# Usage: ./scripts/repair-worktrees.sh [--force-with-active-docker]
 #
 
 set -euo pipefail
@@ -19,6 +29,87 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=_lib.sh
 source "$SCRIPT_DIR/_lib.sh"
+
+# SMI-4698: --force-with-active-docker bypasses the running-container guard
+# on the native-rebuild step. CLI flag (matches remove-worktree.sh /
+# rebase-worktree.sh convention), not env var.
+FORCE_WITH_ACTIVE_DOCKER=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --force-with-active-docker)
+            FORCE_WITH_ACTIVE_DOCKER=true
+            shift
+            ;;
+        -h|--help)
+            cat <<EOF
+Usage: $(basename "$0") [--force-with-active-docker]
+
+Repairs node_modules symlinks (SMI-4377/SMI-4381) and host native bindings
+(SMI-4549) across every git worktree. Safe to run repeatedly.
+
+Options:
+    --force-with-active-docker
+        Run the native-rebuild step even when a skillsmith dev container
+        is detected. The rebuild writes host-arch binaries into the
+        symlinked node_modules and clobbers the container's ELF *.node
+        files; you must run \`docker exec -w /app <container> npm rebuild
+        better-sqlite3 onnxruntime-node\` afterward to restore them.
+        See SMI-4698.
+EOF
+            exit 0
+            ;;
+        *)
+            error "Unknown option: $1 (try --help)"
+            ;;
+    esac
+done
+
+# SMI-4698: gate the native-rebuild step (repair-host-native-deps.sh) when
+# a running Docker container shares the symlinked node_modules. Symlink
+# repair is safe with active Docker — only this step writes binaries.
+check_docker_safety_for_rebuild() {
+    if [ "$FORCE_WITH_ACTIVE_DOCKER" = true ]; then
+        warn "  --force-with-active-docker set — proceeding despite active container."
+        warn "  After this script completes, run:"
+        warn "    docker exec -w /app <container-name> npm rebuild better-sqlite3 onnxruntime-node"
+        warn "  to restore the container's ELF native bindings."
+        return 0
+    fi
+    if ! command -v docker >/dev/null 2>&1; then
+        return 0  # No docker CLI — no risk
+    fi
+    # S-3: bound the daemon-query at 5s so a wedged Docker socket can't
+    # hang the script forever. `timeout` returns 124 on expiry; we treat
+    # any non-zero exit as "couldn't determine state" and proceed without
+    # the guard rather than blocking legitimate repair.
+    local active rc=0
+    active="$(timeout 5 docker ps --format '{{.Names}}' 2>/dev/null)" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        warn "  docker ps failed or timed out (rc=$rc); proceeding without guard."
+        return 0
+    fi
+    # S-1: container regex matches default `skillsmith-dev-1` plus
+    # COMPOSE_PROJECT_NAME variants like `skillsmith-prod-dev-1` or
+    # `skillsmith-feat-dev-2`. The `-dev-N` suffix anchor avoids
+    # false-positives on unrelated `skillsmith-cli` / `skillsmith-web`
+    # containers.
+    local match
+    match="$(echo "$active" | grep -E '^skillsmith.*-dev-[0-9]+$' || true)"
+    if [ -z "$match" ]; then
+        return 0
+    fi
+    error "Active Docker container detected: $match
+
+repair-worktrees.sh would rebuild host-arch native bindings (better-sqlite3,
+onnxruntime-node) into the symlinked node_modules. This corrupts the
+container's ELF binary and breaks all tests inside Docker.
+
+Choose one:
+  1. Stop the container first:  docker compose --profile dev down
+  2. Rebuild on Docker side:     docker exec -w /app $match npm rebuild better-sqlite3 onnxruntime-node
+  3. Force (then rebuild Docker side):  ./scripts/repair-worktrees.sh --force-with-active-docker"
+}
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
 if [[ -z "$REPO_ROOT" ]]; then
@@ -40,6 +131,12 @@ repair_worktrees_node_modules "$REPO_ROOT"
 
 info "Backfilling per-package node_modules symlinks (SMI-4381)..."
 repair_worktrees_package_node_modules "$REPO_ROOT"
+
+# SMI-4698: gate the native-rebuild step on active-Docker detection.
+# Symlink-repair phases above run unconditionally — they don't touch
+# binary contents. Only the rebuild step below would clobber the
+# container's ELF *.node files.
+check_docker_safety_for_rebuild
 
 # SMI-4549: rebuild host-side native bindings skipped by `npm install
 # --ignore-scripts`. Cheap (sub-second `[skip]`) on a healthy host; rebuilds

--- a/scripts/tests/_lib/git-fixture-env.ts
+++ b/scripts/tests/_lib/git-fixture-env.ts
@@ -27,7 +27,7 @@
  *   `tmpdir()`, so callers see `/private/var/folders/…` on macOS rather than
  *   the `/var/folders/…` symlink. Same root-cause class as SMI-4692.
  *
- * The `audit-standards` Audit-30 check (SMI-4693) enforces that every test
+ * The `audit-standards` Audit-39 check (SMI-4693) enforces that every test
  * file that spawns `git` against a temp repo imports this helper.
  */
 import { mkdtempSync, realpathSync } from 'node:fs'

--- a/scripts/tests/git-fixture-isolation.test.ts
+++ b/scripts/tests/git-fixture-isolation.test.ts
@@ -12,7 +12,7 @@
  * whether `GIT_DIR` was the original env-leak vector.
  *
  * If a future regression breaks the helper, this file is the early-warning.
- * Audit-30 in `scripts/audit-standards.mjs` is the second line of defence.
+ * Audit-39 in `scripts/audit-standards.mjs` is the second line of defence.
  */
 import { execFileSync } from 'node:child_process'
 import { realpathSync, rmSync } from 'node:fs'
@@ -195,9 +195,9 @@ describe('SMI-4693: end-to-end — fixture spawn does not mutate parent worktree
   })
 })
 
-describe('SMI-4693 (B-2): Audit-30 broadened regex covers spawnSync + execFileSync + execSync', () => {
+describe('SMI-4693 (B-2): Audit-39 broadened regex covers spawnSync + execFileSync + execSync', () => {
   // Regex copy here MUST stay in lockstep with the one in
-  // scripts/audit-standards.mjs (Audit-30). If you change one, change both
+  // scripts/audit-standards.mjs (Audit-39). If you change one, change both
   // and update this test. The audit's primary defence is its own runtime
   // self-test (Wave 3 Step 2 §1 of the plan) — this is a cheap unit guard.
   const SPAWNS_GIT =
@@ -227,7 +227,7 @@ describe('SMI-4693 (B-2): Audit-30 broadened regex covers spawnSync + execFileSy
 // relative-prefixed string ending in `_lib/git-fixture-env(.js)?`.
 const HAS_HELPER_IMPORT = /from ['"]\.\.?\/[^'"]*_lib\/git-fixture-env(?:\.js)?['"]/
 
-describe('SMI-4693 (B-2): Audit-30 import-detection regex', () => {
+describe('SMI-4693 (B-2): Audit-39 import-detection regex', () => {
   // Same lockstep contract: keep in sync with scripts/audit-standards.mjs.
   it('matches relative imports from _lib/git-fixture-env (any depth)', () => {
     expect(
@@ -251,7 +251,7 @@ describe('SMI-4693 (B-2): Audit-30 import-detection regex', () => {
   })
 })
 
-describe('SMI-4693 (B-2 self-test): Audit-30 flags fixtures missing the helper', () => {
+describe('SMI-4693 (B-2 self-test): Audit-39 flags fixtures missing the helper', () => {
   // Synthetic file content — no I/O, just text matching.
   function checkFixture(text: string): { violation: boolean } {
     const spawnsGit = SPAWNS_GIT_RE.test(text)

--- a/scripts/tests/repair-worktrees-docker-guard.test.ts
+++ b/scripts/tests/repair-worktrees-docker-guard.test.ts
@@ -1,0 +1,256 @@
+/**
+ * SMI-4698: regression tests for repair-worktrees.sh's Docker-active guard.
+ *
+ * Asserts:
+ *   1. With no `docker` CLI on PATH, the script proceeds (no guard fired).
+ *   2. With a `docker` shim that returns nothing from `docker ps`, the
+ *      script proceeds.
+ *   3. With a shim that returns `skillsmith-dev-1`, the script aborts
+ *      (exit 1) with the expected error naming the container, AND the
+ *      native-rebuild step is NOT invoked.
+ *   4. With `--force-with-active-docker` + the same shim, the script
+ *      proceeds with a warning AND the rebuild step IS invoked.
+ *   5. Symlink-repair phases run unconditionally — even when the guard
+ *      fires, both symlink-repair functions are invoked before abort.
+ *   6. Container regex matches `skillsmith-prod-dev-1` (S-1).
+ *
+ * Tests copy `repair-worktrees.sh` and `_lib.sh` into a temp dir alongside
+ * a stub `repair-host-native-deps.sh`. SCRIPT_DIR resolution makes the
+ * stub the only `repair-host-native-deps.sh` in scope, so we can detect
+ * whether it was invoked without running a real `npm rebuild`.
+ *
+ * No real Docker daemon is needed; no git-crypt encryption.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { execSync, spawnSync } from 'child_process'
+import { rmSync, existsSync, writeFileSync, chmodSync, mkdirSync, copyFileSync } from 'fs'
+import { join } from 'path'
+
+import { makeFixtureEnv, makeFixtureTempDir } from './_lib/git-fixture-env.js'
+
+const REPO_SCRIPTS_DIR = join(__dirname, '..')
+const SOURCE_REPAIR_SH = join(REPO_SCRIPTS_DIR, 'repair-worktrees.sh')
+const SOURCE_LIB_SH = join(REPO_SCRIPTS_DIR, '_lib.sh')
+
+const GIT_ENV = makeFixtureEnv()
+
+function git(cwd: string, args: string): string {
+  return execSync(`git -c init.defaultBranch=main -c protocol.file.allow=always ${args}`, {
+    cwd,
+    encoding: 'utf8',
+    env: GIT_ENV,
+  }).trim()
+}
+
+/**
+ * Set up a test workspace:
+ *   tempRoot/
+ *     repo/                       — real git repo with mocked node_modules/.bin/lint-staged
+ *       scripts/
+ *         repair-worktrees.sh     — copied from source
+ *         _lib.sh                 — copied from source
+ *         repair-host-native-deps.sh — stub that records invocation
+ *     bin/                        — fake-shim PATH dir for `docker`
+ *     docker.log                  — docker shim invocation log
+ *     rebuild.log                 — repair-host-native-deps.sh stub invocation log
+ */
+function setupRepo(tempRoot: string): {
+  repoDir: string
+  binDir: string
+  dockerLog: string
+  rebuildLog: string
+} {
+  const repoDir = join(tempRoot, 'repo')
+  const scriptsDir = join(repoDir, 'scripts')
+  const binDir = join(tempRoot, 'bin')
+  const dockerLog = join(tempRoot, 'docker.log')
+  const rebuildLog = join(tempRoot, 'rebuild.log')
+
+  mkdirSync(scriptsDir, { recursive: true })
+  mkdirSync(binDir, { recursive: true })
+
+  // Init git repo (script calls `git rev-parse --show-toplevel`)
+  git(tempRoot, `init "${repoDir}"`)
+  writeFileSync(join(repoDir, 'README.md'), '# test\n')
+  git(repoDir, 'add README.md')
+  git(repoDir, 'commit -m "initial"')
+
+  // Mock host node_modules/.bin/lint-staged (assert_host_node_modules check)
+  const binNm = join(repoDir, 'node_modules', '.bin')
+  mkdirSync(binNm, { recursive: true })
+  const lintStagedStub = join(binNm, 'lint-staged')
+  writeFileSync(lintStagedStub, '#!/bin/sh\nexit 0\n')
+  chmodSync(lintStagedStub, 0o755)
+
+  // Copy real repair-worktrees.sh + _lib.sh
+  copyFileSync(SOURCE_REPAIR_SH, join(scriptsDir, 'repair-worktrees.sh'))
+  chmodSync(join(scriptsDir, 'repair-worktrees.sh'), 0o755)
+  copyFileSync(SOURCE_LIB_SH, join(scriptsDir, '_lib.sh'))
+
+  // Stub repair-host-native-deps.sh — records invocation, exits 0
+  const stubRebuild = `#!/bin/sh
+echo "called with $*" >> "${rebuildLog}"
+exit 0
+`
+  writeFileSync(join(scriptsDir, 'repair-host-native-deps.sh'), stubRebuild)
+  chmodSync(join(scriptsDir, 'repair-host-native-deps.sh'), 0o755)
+
+  return { repoDir, binDir, dockerLog, rebuildLog }
+}
+
+/**
+ * Write a docker shim that prints `dockerPsOutput` for `docker ps ...`
+ * invocations, recording all calls to logPath. Pass empty string to
+ * simulate "no containers running".
+ */
+function writeDockerShim(binDir: string, logPath: string, dockerPsOutput: string): void {
+  // Quote the output for embedding in the shell shim
+  const escaped = dockerPsOutput.replace(/'/g, `'\\''`)
+  const shim = `#!/bin/sh
+echo "$@" >> "${logPath}"
+case "$1" in
+  ps)
+    printf '%s' '${escaped}'
+    if [ -n '${escaped}' ]; then printf '\\n'; fi
+    exit 0
+    ;;
+esac
+exit 0
+`
+  const shimPath = join(binDir, 'docker')
+  writeFileSync(shimPath, shim)
+  chmodSync(shimPath, 0o755)
+}
+
+/**
+ * Run repair-worktrees.sh inside the staged repo. PATH is restricted to
+ * binDir + system dirs so a real `docker` on the host doesn't leak in.
+ * If `binDir` is undefined, the test simulates "no docker CLI on PATH".
+ */
+function runScript(
+  repoDir: string,
+  args: string,
+  binDir?: string
+): { status: number; stdout: string; stderr: string } {
+  // Minimal PATH so `docker` is not picked up from the host.
+  // /usr/bin and /bin are needed for git, bash, basename, sed, etc.
+  const restrictedPath = binDir ? `${binDir}:/usr/bin:/bin` : `/usr/bin:/bin`
+  const env = { ...GIT_ENV, PATH: restrictedPath }
+  const scriptPath = join(repoDir, 'scripts', 'repair-worktrees.sh')
+  // spawnSync captures stdout + stderr regardless of exit status, unlike
+  // execSync which only surfaces stderr on non-zero exit. The force-flag
+  // test asserts on stderr-routed warn() output during a successful run.
+  const argv = args.length > 0 ? args.split(/\s+/).filter(Boolean) : []
+  const r = spawnSync('bash', [scriptPath, ...argv], {
+    encoding: 'utf8',
+    timeout: 30_000,
+    env,
+    cwd: repoDir,
+  })
+  return {
+    status: r.status ?? 1,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+  }
+}
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true })
+  }
+  tempDirs.length = 0
+})
+
+describe('SMI-4698: repair-worktrees.sh Docker-active guard', () => {
+  it('proceeds when no `docker` CLI is on PATH (no guard fired)', () => {
+    const tempRoot = makeFixtureTempDir('rw-guard-no-docker')
+    tempDirs.push(tempRoot)
+    const { repoDir, rebuildLog } = setupRepo(tempRoot)
+
+    // No binDir → restricted PATH excludes any host `docker`
+    const result = runScript(repoDir, '')
+
+    expect(result.status).toBe(0)
+    // Rebuild step ran (guard didn't fire because no docker CLI was found)
+    expect(existsSync(rebuildLog)).toBe(true)
+  })
+
+  it('proceeds when `docker ps` returns no matching containers', () => {
+    const tempRoot = makeFixtureTempDir('rw-guard-no-match')
+    tempDirs.push(tempRoot)
+    const { repoDir, binDir, rebuildLog } = setupRepo(tempRoot)
+    writeDockerShim(binDir, join(tempRoot, 'docker.log'), '')
+
+    const result = runScript(repoDir, '', binDir)
+
+    expect(result.status).toBe(0)
+    expect(existsSync(rebuildLog)).toBe(true)
+  })
+
+  it('aborts when `skillsmith-dev-1` is running and skips the rebuild step', () => {
+    const tempRoot = makeFixtureTempDir('rw-guard-active')
+    tempDirs.push(tempRoot)
+    const { repoDir, binDir, rebuildLog } = setupRepo(tempRoot)
+    writeDockerShim(binDir, join(tempRoot, 'docker.log'), 'skillsmith-dev-1')
+
+    const result = runScript(repoDir, '', binDir)
+
+    expect(result.status).not.toBe(0)
+    const combined = result.stderr + result.stdout
+    expect(combined).toMatch(/Active Docker container detected/)
+    expect(combined).toMatch(/skillsmith-dev-1/)
+    // Rebuild step was NOT invoked (guard fired and exited first)
+    expect(existsSync(rebuildLog)).toBe(false)
+  })
+
+  it('--force-with-active-docker bypasses the guard and runs rebuild with a warning', () => {
+    const tempRoot = makeFixtureTempDir('rw-guard-force')
+    tempDirs.push(tempRoot)
+    const { repoDir, binDir, rebuildLog } = setupRepo(tempRoot)
+    writeDockerShim(binDir, join(tempRoot, 'docker.log'), 'skillsmith-dev-1')
+
+    const result = runScript(repoDir, '--force-with-active-docker', binDir)
+
+    expect(result.status).toBe(0)
+    expect(result.stderr + result.stdout).toMatch(/--force-with-active-docker set/)
+    // Rebuild step DID run despite active container
+    expect(existsSync(rebuildLog)).toBe(true)
+  })
+
+  it('symlink-repair phases run unconditionally even when the guard aborts', () => {
+    // The symlink-repair functions iterate `git worktree list` and do nothing
+    // if no worktrees exist beyond the main repo — but they MUST be called
+    // before the guard. We verify by checking the script's own info-line
+    // output, which is emitted right before each phase invocation.
+    const tempRoot = makeFixtureTempDir('rw-guard-symlinks-first')
+    tempDirs.push(tempRoot)
+    const { repoDir, binDir } = setupRepo(tempRoot)
+    writeDockerShim(binDir, join(tempRoot, 'docker.log'), 'skillsmith-dev-1')
+
+    const result = runScript(repoDir, '', binDir)
+
+    expect(result.status).not.toBe(0)
+    const combined = result.stderr + result.stdout
+    // Both symlink-repair info banners must appear BEFORE the guard's error
+    expect(combined).toMatch(/Repairing worktrees missing node_modules symlink/)
+    expect(combined).toMatch(/Backfilling per-package node_modules symlinks/)
+    // And the guard error must appear too
+    expect(combined).toMatch(/Active Docker container detected/)
+  })
+
+  it('container regex matches `skillsmith-prod-dev-1` (S-1: COMPOSE_PROJECT_NAME variant)', () => {
+    const tempRoot = makeFixtureTempDir('rw-guard-prod-variant')
+    tempDirs.push(tempRoot)
+    const { repoDir, binDir, rebuildLog } = setupRepo(tempRoot)
+    writeDockerShim(binDir, join(tempRoot, 'docker.log'), 'skillsmith-prod-dev-1')
+
+    const result = runScript(repoDir, '', binDir)
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr + result.stdout).toMatch(/skillsmith-prod-dev-1/)
+    expect(existsSync(rebuildLog)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a `--force-with-active-docker` guard to `scripts/repair-worktrees.sh` that aborts the **native-rebuild step** when a `skillsmith-*-dev-N` container is running. Symlink-repair phases continue unconditionally (B-2).
- Bundles a small SMI-4693 retro followup (`ca845076`) that corrects six "Audit-30" → "Audit-39" comment references in `scripts/tests/_lib/git-fixture-env.ts` and `scripts/tests/git-fixture-isolation.test.ts`. The audit number drift was caught by the post-merge governance retro on PR #924.

## Why

On 2026-05-03, during recovery from the SMI-4681 cascade, `./scripts/repair-worktrees.sh` rebuilt host-arch (Mach-O, arm64) bindings for `better-sqlite3` and `onnxruntime-node` while `skillsmith-dev-1` was running. The per-package \`node_modules\` are symlinked between host and Docker (SMI-4381), so the rebuilt host \`*.node\` artefacts overwrote the container's ELF copies. The next \`docker exec ... vitest\` failed 113 colocated tests with \`SqliteError: invalid ELF header\`. Recovery was \`docker exec -w /app skillsmith-dev-1 npm rebuild ...\`, but the trap was undocumented in CLAUDE.md and unguarded in the script.

Plan: \`docs/internal/implementation/smi-4698-repair-worktrees-docker-guard.md\`. Plan-review verdict APPROVE_WITH_CHANGES; B-1, B-2, S-1, S-2, S-3 all applied.

## What changes

- \`scripts/repair-worktrees.sh\` (~99 LOC modified) — flag parsing for \`--force-with-active-docker\`; \`check_docker_safety_for_rebuild()\` helper; invocation immediately before the native-rebuild step. Container regex \`^skillsmith.*-dev-[0-9]+\$\` (S-1) covers default + custom \`COMPOSE_PROJECT_NAME\`. \`timeout 5 docker ps\` (S-3) handles daemon hangs.
- \`scripts/tests/repair-worktrees-docker-guard.test.ts\` — new regression test (~256 LOC), 6 assertions per plan: no-docker proceeds; empty \`docker ps\` proceeds; active container aborts with named error; \`--force-with-active-docker\` proceeds with warning; symlink-only path succeeds with active container (B-2); regex covers \`skillsmith-prod-dev-1\`.
- \`CLAUDE.md\` — adds Troubleshooting row for the \"invalid ELF header\" symptom; appends Worktrees-section caveat about the rebuild step being gated.
- SMI-4693 retro followup (commit \`ca845076\`): six comment label corrections, no behavioural change.

## Test plan

- [x] \`docker exec skillsmith-dev-1 npm run audit:standards\` — 0 failed
- [x] \`docker exec skillsmith-dev-1 npm run lint\` — 0 errors
- [x] New \`repair-worktrees-docker-guard.test.ts\` — 6 assertions pass in Docker
- [x] Manual smoke: with \`skillsmith-dev-1\` running, \`./scripts/repair-worktrees.sh\` aborts with the expected three-route error message; \`--force-with-active-docker\` proceeds with the warning
- [ ] CI green (required checks)

## Linear

- SMI-4698 (this PR)
- SMI-4693 retro: clean, fix bundled here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>