### PR TITLE
feat(core): SMI-4590 Wave 4 PR 3/6 — audit exclusions + tier-revalidation gate

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,11 @@
       "import": "./dist/src/billing/index.js",
       "default": "./dist/src/billing/index.js"
     },
+    "./audit": {
+      "types": "./dist/src/audit/index.d.ts",
+      "import": "./dist/src/audit/index.js",
+      "default": "./dist/src/audit/index.js"
+    },
     "./testkit": {
       "types": "./dist/tests/testkit.d.ts",
       "import": "./dist/tests/testkit.js",

--- a/packages/core/src/audit/exclusions.ts
+++ b/packages/core/src/audit/exclusions.ts
@@ -24,11 +24,7 @@ import { join } from 'node:path'
 import { getConfigDir } from '../config/index.js'
 import type { AuditMode, Tier } from '../config/audit-mode.js'
 
-import type {
-  ExcludableEntry,
-  ExclusionEntry,
-  ExclusionsConfig,
-} from './exclusions.types.js'
+import type { ExcludableEntry, ExclusionEntry, ExclusionsConfig } from './exclusions.types.js'
 
 const EXCLUSIONS_FILE = 'audit-exclusions.json'
 
@@ -54,9 +50,7 @@ export interface LoadExclusionsOptions {
 }
 
 /** Load the exclusions config. Never throws; failures degrade to empty. */
-export async function loadExclusions(
-  opts: LoadExclusionsOptions = {},
-): Promise<ExclusionsConfig> {
+export async function loadExclusions(opts: LoadExclusionsOptions = {}): Promise<ExclusionsConfig> {
   const path = opts.configPath ?? getExclusionsPath()
 
   let raw: string
@@ -82,7 +76,7 @@ export async function loadExclusions(
 
   if (!isExclusionsConfig(parsed)) {
     console.warn(
-      `[audit-exclusions] unrecognized schema at ${path} (expected version: 1) — ignoring file`,
+      `[audit-exclusions] unrecognized schema at ${path} (expected version: 1) — ignoring file`
     )
     return EMPTY_CONFIG
   }

--- a/packages/core/src/audit/exclusions.ts
+++ b/packages/core/src/audit/exclusions.ts
@@ -1,0 +1,155 @@
+/**
+ * @fileoverview Audit exclusions loader + matcher + tier-revalidation gate
+ * (SMI-4590 Wave 4 PR 3).
+ * @module @skillsmith/core/audit/exclusions
+ *
+ * Reads `~/.skillsmith/audit-exclusions.json` and provides {@link isExcluded}
+ * for the inventory collision detector to filter known-acceptable findings,
+ * plus {@link tierAllowsAuditMode} — the write-time / re-resolution gate the
+ * CLI (PR 5) and session-start hook (PR 6) call before persisting or
+ * applying a user-selected `audit_mode`.
+ *
+ * Failure modes (decision #13 verbatim):
+ *   - Missing file → empty config; nothing filtered.
+ *   - Unreadable / malformed JSON → warn-and-empty; no exception.
+ *   - Unknown `version` → warn-and-empty (forward-compat).
+ *
+ * Exclusion match is exact-string per `kind`. No glob / prefix support in
+ * v1 — keep the surface small until users ask.
+ */
+
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+
+import { getConfigDir } from '../config/index.js'
+import type { AuditMode, Tier } from '../config/audit-mode.js'
+
+import type {
+  ExcludableEntry,
+  ExclusionEntry,
+  ExclusionsConfig,
+} from './exclusions.types.js'
+
+const EXCLUSIONS_FILE = 'audit-exclusions.json'
+
+/** Empty default returned when the file is missing or unreadable. */
+const EMPTY_CONFIG: ExclusionsConfig = { version: 1, exclusions: [] }
+
+/**
+ * Resolve the absolute path to the exclusions file. Defaults to
+ * `~/.skillsmith/audit-exclusions.json`. Tests pass `configDir` to
+ * isolate.
+ */
+export function getExclusionsPath(opts?: { configDir?: string }): string {
+  return join(opts?.configDir ?? getConfigDir(), EXCLUSIONS_FILE)
+}
+
+export interface LoadExclusionsOptions {
+  /**
+   * Override the file path. Defaults to {@link getExclusionsPath}().
+   * Test harnesses pass a temp-dir path; production callers should leave
+   * unset.
+   */
+  configPath?: string
+}
+
+/** Load the exclusions config. Never throws; failures degrade to empty. */
+export async function loadExclusions(
+  opts: LoadExclusionsOptions = {},
+): Promise<ExclusionsConfig> {
+  const path = opts.configPath ?? getExclusionsPath()
+
+  let raw: string
+  try {
+    raw = await fs.readFile(path, 'utf-8')
+  } catch (err) {
+    // ENOENT is the expected hot path for users who haven't authored a
+    // file yet. Other read errors (permissions etc.) also fail open —
+    // exclusions are an opt-in suppression mechanism, never load-bearing.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn(`[audit-exclusions] read failed for ${path}: ${(err as Error).message}`)
+    }
+    return EMPTY_CONFIG
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    console.warn(`[audit-exclusions] malformed JSON at ${path} — ignoring file`)
+    return EMPTY_CONFIG
+  }
+
+  if (!isExclusionsConfig(parsed)) {
+    console.warn(
+      `[audit-exclusions] unrecognized schema at ${path} (expected version: 1) — ignoring file`,
+    )
+    return EMPTY_CONFIG
+  }
+  return parsed
+}
+
+function isExclusionsConfig(v: unknown): v is ExclusionsConfig {
+  if (!v || typeof v !== 'object') return false
+  const obj = v as Record<string, unknown>
+  if (obj.version !== 1) return false
+  if (!Array.isArray(obj.exclusions)) return false
+  return obj.exclusions.every(isExclusionEntry)
+}
+
+function isExclusionEntry(v: unknown): v is ExclusionEntry {
+  if (!v || typeof v !== 'object') return false
+  const e = v as Record<string, unknown>
+  if (typeof e.reason !== 'string' || e.reason.length === 0) return false
+  if (e.kind === 'command') {
+    return typeof e.identifier === 'string' && e.identifier.length > 0
+  }
+  if (e.kind === 'skill') {
+    return typeof e.skillId === 'string' && e.skillId.length > 0
+  }
+  return false
+}
+
+/** True when `entry` matches any exclusion in `config`. Exact-match only. */
+export function isExcluded(entry: ExcludableEntry, config: ExclusionsConfig): boolean {
+  return config.exclusions.some((excl) => {
+    if (excl.kind === 'command' && entry.kind === 'command') {
+      return excl.identifier === entry.commandIdentifier
+    }
+    if (excl.kind === 'skill' && entry.kind === 'skill') {
+      return excl.skillId === entry.skillId
+    }
+    return false
+  })
+}
+
+/**
+ * Tier-revalidation gate for `audit_mode` writes (Wave 4 plan §8).
+ *
+ * Applied at three points (defense-in-depth):
+ *   1. CLI write-time: `sklx config set audit_mode <value>` (PR 5)
+ *      rejects with typed error `audit.mode.tier_ineligible` when this
+ *      returns false.
+ *   2. Session-start hook (PR 6): re-resolves to `'preventative'` when
+ *      a manually-edited config violates the gate.
+ *   3. Detector entry-point: hardening boundary in case (1) and (2)
+ *      both miss.
+ *
+ * Eligibility table:
+ *
+ *   |              | preventative | power_user | governance | off |
+ *   |--------------|:------------:|:----------:|:----------:|:---:|
+ *   | community    |      ✓       |     ✗      |     ✗      |  ✓  |
+ *   | individual   |      ✓       |     ✗      |     ✗      |  ✓  |
+ *   | team         |      ✓       |     ✓      |     ✗      |  ✓  |
+ *   | enterprise   |      ✓       |     ✓      |     ✓      |  ✓  |
+ *
+ * `'off'` is allowed for all tiers — turning the audit off is a user
+ * preference, not a paid capability.
+ */
+export function tierAllowsAuditMode(tier: Tier, mode: AuditMode): boolean {
+  if (mode === 'preventative' || mode === 'off') return true
+  if (mode === 'power_user') return tier === 'team' || tier === 'enterprise'
+  if (mode === 'governance') return tier === 'enterprise'
+  return false
+}

--- a/packages/core/src/audit/exclusions.types.ts
+++ b/packages/core/src/audit/exclusions.types.ts
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Types for the audit exclusions file (SMI-4590 Wave 4 PR 3).
+ * @module @skillsmith/core/audit/exclusions.types
+ *
+ * Schema for `~/.skillsmith/audit-exclusions.json`. Version-gated; wraps a
+ * list of per-skill / per-command suppression entries that filter the
+ * inventory audit result before it surfaces to the user. See plan §8 of
+ * `docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md`.
+ */
+
+/** A single suppression entry. Discriminated union on `kind`. */
+export type ExclusionEntry =
+  | {
+      kind: 'command'
+      /** Slash-command identifier, e.g. `'/ship'`. */
+      identifier: string
+      /** Free-text rationale shown in audit output. Required. */
+      reason: string
+    }
+  | {
+      kind: 'skill'
+      /** Skill identifier, e.g. `'anthropic/code-helper'`. */
+      skillId: string
+      /** Free-text rationale shown in audit output. Required. */
+      reason: string
+    }
+
+/** Top-level config wrapper. `version: 1` is the only supported schema. */
+export interface ExclusionsConfig {
+  version: 1
+  exclusions: ExclusionEntry[]
+}
+
+/**
+ * Minimal duck-typed entry shape that {@link isExcluded} accepts.
+ *
+ * Callers map their domain types (e.g. mcp-server's `InventoryEntry` or
+ * `ExactCollisionFlag`) onto this before calling. Keeps `@skillsmith/core`
+ * from depending on `@skillsmith/mcp-server` (which would be circular —
+ * mcp-server depends on core).
+ */
+export interface ExcludableEntry {
+  /** `'command'` for slash-commands; `'skill'` for skill ids. */
+  kind: 'command' | 'skill'
+  /** Required when `kind === 'command'`. */
+  commandIdentifier?: string
+  /** Required when `kind === 'skill'`. */
+  skillId?: string
+}

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Public barrel for the audit shared helpers (SMI-4590 Wave 4 PR 3).
+ * @module @skillsmith/core/audit
+ *
+ * Subpath export: `@skillsmith/core/audit`. Aggregates the audit-mode
+ * resolver (existing, originally added in Wave 1 / SMI-4587) and the
+ * audit-exclusions schema/loader/gate (new in Wave 4 PR 3). Consumers
+ * (`mcp-server`, `cli`, `website`) import from this path; PR 4–6 add
+ * additional exports here as Wave 4 lands.
+ */
+
+export {
+  isAuditMode,
+  resolveAuditMode,
+  tierDefault,
+  type AuditMode,
+  type ResolveAuditModeOptions,
+  type Tier,
+} from '../config/audit-mode.js'
+
+export {
+  getExclusionsPath,
+  isExcluded,
+  loadExclusions,
+  tierAllowsAuditMode,
+  type LoadExclusionsOptions,
+} from './exclusions.js'
+
+export type {
+  ExcludableEntry,
+  ExclusionEntry,
+  ExclusionsConfig,
+} from './exclusions.types.js'
+
+export { emitInstallEvent, type InstallEventPayload } from './remote-audit.js'

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -26,10 +26,6 @@ export {
   type LoadExclusionsOptions,
 } from './exclusions.js'
 
-export type {
-  ExcludableEntry,
-  ExclusionEntry,
-  ExclusionsConfig,
-} from './exclusions.types.js'
+export type { ExcludableEntry, ExclusionEntry, ExclusionsConfig } from './exclusions.types.js'
 
 export { emitInstallEvent, type InstallEventPayload } from './remote-audit.js'

--- a/packages/core/tests/unit/audit/exclusions.test.ts
+++ b/packages/core/tests/unit/audit/exclusions.test.ts
@@ -16,10 +16,7 @@ import {
   loadExclusions,
   tierAllowsAuditMode,
 } from '../../../src/audit/exclusions.js'
-import type {
-  ExcludableEntry,
-  ExclusionsConfig,
-} from '../../../src/audit/exclusions.types.js'
+import type { ExcludableEntry, ExclusionsConfig } from '../../../src/audit/exclusions.types.js'
 
 let tmpDir: string
 let warnSpy: ReturnType<typeof vi.spyOn>
@@ -49,7 +46,7 @@ describe('loadExclusions', () => {
           { kind: 'command', identifier: '/ship', reason: 'Both packs are mine.' },
           { kind: 'skill', skillId: 'anthropic/code-helper', reason: 'Compatibility.' },
         ],
-      }),
+      })
     )
     const config = await loadExclusions({ configPath: path })
     expect(config.version).toBe(1)
@@ -82,7 +79,7 @@ describe('loadExclusions', () => {
       JSON.stringify({
         version: 1,
         exclusions: [{ kind: 'command', identifier: '/ship' }],
-      }),
+      })
     )
     const config = await loadExclusions({ configPath: path })
     expect(config.exclusions).toEqual([])
@@ -94,7 +91,7 @@ describe('loadExclusions', () => {
       JSON.stringify({
         version: 1,
         exclusions: [{ kind: 'mcp-tool', identifier: 'foo', reason: 'no' }],
-      }),
+      })
     )
     const config = await loadExclusions({ configPath: path })
     expect(config.exclusions).toEqual([])
@@ -156,11 +153,9 @@ describe('isExcluded', () => {
 
 describe('tierAllowsAuditMode (test 5: tier-revalidation gate)', () => {
   // Eligibility table from exclusions.ts JSDoc. Each row is one tier.
-  const cases: Array<[
-    Parameters<typeof tierAllowsAuditMode>[0],
-    Parameters<typeof tierAllowsAuditMode>[1],
-    boolean,
-  ]> = [
+  const cases: Array<
+    [Parameters<typeof tierAllowsAuditMode>[0], Parameters<typeof tierAllowsAuditMode>[1], boolean]
+  > = [
     // community
     ['community', 'preventative', true],
     ['community', 'off', true],

--- a/packages/core/tests/unit/audit/exclusions.test.ts
+++ b/packages/core/tests/unit/audit/exclusions.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for the audit exclusions loader, matcher, and tier-revalidation
+ * gate (SMI-4590 Wave 4 PR 3). Mirrors the test plan in §8 of
+ * `docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md`.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getExclusionsPath,
+  isExcluded,
+  loadExclusions,
+  tierAllowsAuditMode,
+} from '../../../src/audit/exclusions.js'
+import type {
+  ExcludableEntry,
+  ExclusionsConfig,
+} from '../../../src/audit/exclusions.types.js'
+
+let tmpDir: string
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'smi-4590-exclusions-'))
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+  warnSpy.mockRestore()
+})
+
+function writeConfig(content: string): string {
+  const path = join(tmpDir, 'audit-exclusions.json')
+  writeFileSync(path, content, 'utf-8')
+  return path
+}
+
+describe('loadExclusions', () => {
+  it('returns parsed config for a valid file (test 1: round-trip)', async () => {
+    const path = writeConfig(
+      JSON.stringify({
+        version: 1,
+        exclusions: [
+          { kind: 'command', identifier: '/ship', reason: 'Both packs are mine.' },
+          { kind: 'skill', skillId: 'anthropic/code-helper', reason: 'Compatibility.' },
+        ],
+      }),
+    )
+    const config = await loadExclusions({ configPath: path })
+    expect(config.version).toBe(1)
+    expect(config.exclusions).toHaveLength(2)
+    expect(config.exclusions[0]).toMatchObject({ kind: 'command', identifier: '/ship' })
+  })
+
+  it('returns empty config when file is missing (test 2: ENOENT)', async () => {
+    const config = await loadExclusions({ configPath: join(tmpDir, 'nope.json') })
+    expect(config).toEqual({ version: 1, exclusions: [] })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns empty config and warns on malformed JSON (test 3)', async () => {
+    const path = writeConfig('{ "version": 1, "exclusions": [')
+    const config = await loadExclusions({ configPath: path })
+    expect(config).toEqual({ version: 1, exclusions: [] })
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('malformed JSON'))
+  })
+
+  it('returns empty config and warns on unknown version (test 4)', async () => {
+    const path = writeConfig(JSON.stringify({ version: 2, exclusions: [] }))
+    const config = await loadExclusions({ configPath: path })
+    expect(config).toEqual({ version: 1, exclusions: [] })
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unrecognized schema'))
+  })
+
+  it('rejects entries missing required fields', async () => {
+    const path = writeConfig(
+      JSON.stringify({
+        version: 1,
+        exclusions: [{ kind: 'command', identifier: '/ship' }],
+      }),
+    )
+    const config = await loadExclusions({ configPath: path })
+    expect(config.exclusions).toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unrecognized schema'))
+  })
+
+  it('rejects entries with unknown kind', async () => {
+    const path = writeConfig(
+      JSON.stringify({
+        version: 1,
+        exclusions: [{ kind: 'mcp-tool', identifier: 'foo', reason: 'no' }],
+      }),
+    )
+    const config = await loadExclusions({ configPath: path })
+    expect(config.exclusions).toEqual([])
+  })
+
+  it('returns empty config on read errors other than ENOENT (warn-and-empty)', async () => {
+    const config = await loadExclusions({ configPath: tmpDir })
+    expect(config).toEqual({ version: 1, exclusions: [] })
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('read failed'))
+  })
+})
+
+describe('getExclusionsPath', () => {
+  it('joins configDir with the standard filename', () => {
+    expect(getExclusionsPath({ configDir: '/tmp/foo' })).toBe('/tmp/foo/audit-exclusions.json')
+  })
+
+  it('falls back to ~/.skillsmith when configDir is unset', () => {
+    const path = getExclusionsPath()
+    expect(path).toMatch(/\.skillsmith[\\/]audit-exclusions\.json$/)
+  })
+})
+
+describe('isExcluded', () => {
+  const config: ExclusionsConfig = {
+    version: 1,
+    exclusions: [
+      { kind: 'command', identifier: '/ship', reason: 'mine' },
+      { kind: 'skill', skillId: 'anthropic/code-helper', reason: 'compat' },
+    ],
+  }
+
+  it('matches a command entry by identifier', () => {
+    const entry: ExcludableEntry = { kind: 'command', commandIdentifier: '/ship' }
+    expect(isExcluded(entry, config)).toBe(true)
+  })
+
+  it('matches a skill entry by skillId', () => {
+    const entry: ExcludableEntry = { kind: 'skill', skillId: 'anthropic/code-helper' }
+    expect(isExcluded(entry, config)).toBe(true)
+  })
+
+  it('does not match when the identifier differs', () => {
+    const entry: ExcludableEntry = { kind: 'command', commandIdentifier: '/other' }
+    expect(isExcluded(entry, config)).toBe(false)
+  })
+
+  it('does not cross kinds (command exclusion does not match a skill entry)', () => {
+    const entry: ExcludableEntry = { kind: 'skill', skillId: '/ship' }
+    expect(isExcluded(entry, config)).toBe(false)
+  })
+
+  it('returns false against an empty config', () => {
+    const empty: ExclusionsConfig = { version: 1, exclusions: [] }
+    const entry: ExcludableEntry = { kind: 'command', commandIdentifier: '/ship' }
+    expect(isExcluded(entry, empty)).toBe(false)
+  })
+})
+
+describe('tierAllowsAuditMode (test 5: tier-revalidation gate)', () => {
+  // Eligibility table from exclusions.ts JSDoc. Each row is one tier.
+  const cases: Array<[
+    Parameters<typeof tierAllowsAuditMode>[0],
+    Parameters<typeof tierAllowsAuditMode>[1],
+    boolean,
+  ]> = [
+    // community
+    ['community', 'preventative', true],
+    ['community', 'off', true],
+    ['community', 'power_user', false],
+    ['community', 'governance', false],
+    // individual
+    ['individual', 'preventative', true],
+    ['individual', 'off', true],
+    ['individual', 'power_user', false],
+    ['individual', 'governance', false],
+    // team
+    ['team', 'preventative', true],
+    ['team', 'off', true],
+    ['team', 'power_user', true],
+    ['team', 'governance', false],
+    // enterprise
+    ['enterprise', 'preventative', true],
+    ['enterprise', 'off', true],
+    ['enterprise', 'power_user', true],
+    ['enterprise', 'governance', true],
+  ]
+
+  it.each(cases)('tier=%s mode=%s -> %s', (tier, mode, expected) => {
+    expect(tierAllowsAuditMode(tier, mode)).toBe(expected)
+  })
+
+  it('Free / Individual users cannot opt into power_user (CLI rejects)', () => {
+    expect(tierAllowsAuditMode('community', 'power_user')).toBe(false)
+    expect(tierAllowsAuditMode('individual', 'power_user')).toBe(false)
+  })
+
+  it('Only Enterprise can select governance', () => {
+    expect(tierAllowsAuditMode('community', 'governance')).toBe(false)
+    expect(tierAllowsAuditMode('individual', 'governance')).toBe(false)
+    expect(tierAllowsAuditMode('team', 'governance')).toBe(false)
+    expect(tierAllowsAuditMode('enterprise', 'governance')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Implements §3 of the Wave 4 plan (`docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md` line 488). Self-contained shared helpers in `@skillsmith/core/audit`; consumed by Wave 4 PRs 4-6 which branch-stack on this PR per SMI-2597.

- `loadExclusions` / `isExcluded` for `~/.skillsmith/audit-exclusions.json` (decision #13 verbatim).
- `tierAllowsAuditMode(tier, mode)` — write-time / re-resolution gate the CLI (PR 5) and session-start hook (PR 6) call before persisting or applying a user-selected `audit_mode`.
- New `./audit` subpath export on `@skillsmith/core` (alongside `./errors`, `./billing`, etc.).

## Files

| Path | LOC | Status |
|------|-----|--------|
| `packages/core/src/audit/exclusions.ts` | ~140 | new |
| `packages/core/src/audit/exclusions.types.ts` | ~48 | new |
| `packages/core/src/audit/index.ts` | ~36 | new (barrel) |
| `packages/core/package.json` | +5 | modify (`./audit` exports entry) |
| `packages/core/tests/unit/audit/exclusions.test.ts` | ~190 | new (32 tests) |

## Test plan

- [x] `npx vitest run packages/core/tests/unit/audit/exclusions.test.ts` — 32/32 green (15ms)
- [x] `npx eslint` on the 4 new files — clean
- [x] `npx tsc --noEmit -p packages/core/tsconfig.json` — clean
- [x] `npm run audit:standards` — 52 ✓ / 6 warn / 0 fail (warnings pre-existing, none in this diff)
- [ ] CI green
- [ ] Post-merge `/governance` retro on the squash diff

## Branch-stack note (SMI-2597)

PRs 4-6 of Wave 4 will branch from this PR's merge SHA, not directly from `main`. PR 4 imports the new exclusions module + barrel exports introduced here; PR 5 adds CLI write-time tier-revalidation calling `tierAllowsAuditMode`; PR 6 adds the session-start hook re-resolution path. All three depend on this slice landing first.

## Why this PR is small

Originally bundled with FrameworkAdapter and tool-dispatch refactor — split out per the plan-reviewed split (`APPROVE_WITH_CHANGES`, amendments applied). PR 2 (FrameworkAdapter) shipped via #913. This is the smallest of the 4 remaining slices and unblocks the rest.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)