### PR TITLE
feat(mcp-server): SMI-4590 Wave 4 PR 4/6 — MCP audit tools (skill_inventory_audit + apply_namespace_rename + apply_recommended_edit)

### DIFF
--- a/packages/mcp-server/src/audit-tool-dispatch.ts
+++ b/packages/mcp-server/src/audit-tool-dispatch.ts
@@ -3,24 +3,37 @@
  * @module @skillsmith/mcp-server/audit-tool-dispatch
  *
  * SMI-4590 Wave 4 Step 0b: extracted from `tool-dispatch.ts` to keep the
- * parent dispatcher under the 500-LOC file-size gate. Wave 4 PRs 3–4 will
- * add `skill_inventory_audit`, `apply_namespace_rename`, and
- * `apply_recommended_edit` cases to this module.
+ * parent dispatcher under the 500-LOC file-size gate.
+ *
+ * Wave 4 PR 4 (this PR) adds three new tools:
+ *   - `skill_inventory_audit`  — full inventory audit (always registered)
+ *   - `apply_namespace_rename` — apply a Wave 2 rename (always registered)
+ *   - `apply_recommended_edit` — apply a Wave 3 prose edit; **registered
+ *     iff `APPLY_TEMPLATE_REGISTRY.size > 0`** (defense-in-depth — if the
+ *     registry ever empties via rollback, the tool unregisters itself and
+ *     the audit-report writer surfaces edits as `manual_review` only).
  *
  * Surface: handles dispatch for all audit-family tools. The parent
- * `tool-dispatch.ts` delegates by name match; this module owns the audit
- * case bodies, license + quota wiring, and Zod parse error envelopes.
+ * `tool-dispatch.ts` delegates by name match against {@link AUDIT_TOOL_NAMES};
+ * this module owns the audit case bodies, license + quota wiring (for the
+ * pre-existing `skill_audit` / `skill_pack_audit` cases), and Zod parse
+ * error envelopes.
  *
- * No new functionality vs pre-extraction state — bodies for `skill_audit`
- * and `skill_pack_audit` are identical to their previous parent-dispatch
- * incarnations. Backwards-compat regression test:
- * `tests/unit/audit-tool-dispatch.test.ts`.
+ * Dispatch responses for the three new tools follow the
+ * `safeParseOrError` pattern (see `validation.ts`) for protocol-level
+ * shape errors, AND embed an application-level `success: false` envelope
+ * inside `content[0].text` for domain-level failures (history not found,
+ * subcall failed). MCP clients introspect both.
  */
 
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import type { ToolContext } from './context.js'
 import { skillAuditInputSchema, executeSkillAudit } from './tools/skill-audit.js'
 import { skillPackAuditInputSchema, executeSkillPackAudit } from './tools/skill-pack-audit.js'
+import { skillInventoryAudit } from './tools/skill-inventory-audit.js'
+import { applyNamespaceRename } from './tools/apply-namespace-rename.js'
+import { applyRecommendedEditTool } from './tools/apply-recommended-edit.js'
+import { APPLY_TEMPLATE_REGISTRY } from './audit/edit-applier.js'
 import { withLicenseAndQuota } from './middleware/license.js'
 import type { LicenseMiddleware } from './middleware/license.js'
 import type { QuotaMiddleware } from './middleware/quota.js'
@@ -29,11 +42,26 @@ import type { QuotaMiddleware } from './middleware/quota.js'
  * Tool names handled by this dispatcher. The parent `tool-dispatch.ts`
  * delegates iff the requested tool name is in this set.
  *
- * Wave 4 PR 3/6 adds: `skill_inventory_audit`.
- * Wave 4 PR 4/6 adds: `apply_namespace_rename`, `apply_recommended_edit`
- * (the latter conditional on `APPLY_TEMPLATE_REGISTRY.size > 0`).
+ * `apply_recommended_edit` is conditionally included based on
+ * `APPLY_TEMPLATE_REGISTRY.size`. When the registry is empty (rollback
+ * scenario), the name is omitted from this set AND
+ * {@link dispatchAuditTool} returns the standard "Unknown audit tool"
+ * error if the dispatcher is somehow reached for that name.
  */
-export const AUDIT_TOOL_NAMES: ReadonlySet<string> = new Set(['skill_audit', 'skill_pack_audit'])
+export const AUDIT_TOOL_NAMES: ReadonlySet<string> = new Set<string>(buildAuditToolNames())
+
+function buildAuditToolNames(): string[] {
+  const names = [
+    'skill_audit',
+    'skill_pack_audit',
+    'skill_inventory_audit',
+    'apply_namespace_rename',
+  ]
+  if (APPLY_TEMPLATE_REGISTRY.size > 0) {
+    names.push('apply_recommended_edit')
+  }
+  return names
+}
 
 /**
  * Returns true if `name` is an audit-family tool dispatched by this module.
@@ -42,6 +70,17 @@ export const AUDIT_TOOL_NAMES: ReadonlySet<string> = new Set(['skill_audit', 'sk
  */
 export function isAuditToolName(name: string): boolean {
   return AUDIT_TOOL_NAMES.has(name)
+}
+
+/**
+ * Wrap a Promise<T> as a successful MCP `CallToolResult` with a
+ * JSON-serialised body (mirrors `tool-dispatch.ok`).
+ */
+function okBody(payload: unknown): CallToolResult {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
+    isError: false,
+  }
 }
 
 /**
@@ -84,6 +123,20 @@ export async function dispatchAuditTool(
         licenseMiddleware,
         quotaMiddleware
       )
+
+    case 'skill_inventory_audit':
+      return okBody(await skillInventoryAudit(args))
+
+    case 'apply_namespace_rename':
+      return okBody(await applyNamespaceRename(args))
+
+    case 'apply_recommended_edit':
+      // Defense-in-depth: even if the parent dispatcher routes this name
+      // when the registry is empty (e.g. tests that mock the set), the
+      // tool body still calls Wave 3's applyRecommendedEdit which
+      // re-checks `APPLY_TEMPLATE_REGISTRY` and returns the typed
+      // `edit.template_not_in_apply_registry` error.
+      return okBody(await applyRecommendedEditTool(args))
 
     default:
       throw new Error('Unknown audit tool: ' + name)

--- a/packages/mcp-server/src/audit/audit-suggestions.ts
+++ b/packages/mcp-server/src/audit/audit-suggestions.ts
@@ -1,0 +1,116 @@
+/**
+ * @fileoverview Per-audit suggestion persistence (SMI-4590 Wave 4 PR 4).
+ * @module @skillsmith/mcp-server/audit/audit-suggestions
+ *
+ * Persists `RenameSuggestion[]` (Wave 2) + `RecommendedEdit[]` (Wave 3)
+ * alongside the existing `~/.skillsmith/audits/<auditId>/result.json`
+ * (Wave 1, see `audit-history.ts`). The `apply_namespace_rename` and
+ * `apply_recommended_edit` MCP tools (this PR) read this file to look up
+ * the suggestion that corresponds to a `(auditId, collisionId)` pair.
+ *
+ * File layout: `<auditDir>/suggestions.json` — atomic via tmp-file +
+ * `fs.rename`, mirroring `audit-history.ts`. Schema is versioned so a
+ * future PR can extend the persisted shape without breaking older
+ * audit dirs.
+ *
+ * Why a sibling file (vs. extending `result.json`):
+ *   - `result.json` is keyed by `InventoryAuditResult` shape (Wave 1
+ *     barrel surface). Extending it pulls Wave 2/3 types into Wave 1's
+ *     persistence layer.
+ *   - The CLI (PR 5) wants to render `result.json` as-is for
+ *     `--report-only` callers; suggestions live alongside but aren't
+ *     part of the inventory snapshot.
+ */
+
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import type { RecommendedEdit } from './edit-suggester.types.js'
+import type { RenameSuggestion } from './rename-engine.types.js'
+
+const DEFAULT_AUDITS_DIR = path.join(os.homedir(), '.skillsmith', 'audits')
+
+/** Persisted shape. `version: 1` is the only supported schema. */
+export interface AuditSuggestionsFile {
+  version: 1
+  auditId: string
+  renameSuggestions: RenameSuggestion[]
+  recommendedEdits: RecommendedEdit[]
+}
+
+export interface AuditSuggestionsOptions {
+  /** Override the audits root (default `~/.skillsmith/audits`). */
+  auditsDir?: string
+}
+
+/**
+ * Persist the suggestion arrays for `auditId` to
+ * `<auditsDir>/<auditId>/suggestions.json`. Atomic. Creates the per-audit
+ * directory if missing (matches `writeAuditHistory` semantics).
+ */
+export async function writeAuditSuggestions(
+  auditId: string,
+  renameSuggestions: ReadonlyArray<RenameSuggestion>,
+  recommendedEdits: ReadonlyArray<RecommendedEdit>,
+  opts: AuditSuggestionsOptions = {}
+): Promise<{ suggestionsPath: string }> {
+  const auditsDir = opts.auditsDir ?? DEFAULT_AUDITS_DIR
+  const auditDir = path.join(auditsDir, auditId)
+  const suggestionsPath = path.join(auditDir, 'suggestions.json')
+  const tmpPath = `${suggestionsPath}.tmp`
+
+  await fs.mkdir(auditDir, { recursive: true })
+
+  const payload: AuditSuggestionsFile = {
+    version: 1,
+    auditId,
+    renameSuggestions: [...renameSuggestions],
+    recommendedEdits: [...recommendedEdits],
+  }
+  await fs.writeFile(tmpPath, JSON.stringify(payload, null, 2), 'utf-8')
+  await fs.rename(tmpPath, suggestionsPath)
+
+  return { suggestionsPath }
+}
+
+/**
+ * Read back the persisted suggestions for `auditId`. Returns `null` for
+ * unknown / missing audit dirs and for malformed / wrong-version files.
+ * Callers treat the absence as "no suggestions"; the apply-tools surface
+ * a typed error when the lookup is required but returns null.
+ */
+export async function readAuditSuggestions(
+  auditId: string,
+  opts: AuditSuggestionsOptions = {}
+): Promise<AuditSuggestionsFile | null> {
+  const auditsDir = opts.auditsDir ?? DEFAULT_AUDITS_DIR
+  const suggestionsPath = path.join(auditsDir, auditId, 'suggestions.json')
+
+  let raw: string
+  try {
+    raw = await fs.readFile(suggestionsPath, 'utf-8')
+  } catch {
+    return null
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+
+  if (!isAuditSuggestionsFile(parsed)) return null
+  return parsed
+}
+
+function isAuditSuggestionsFile(v: unknown): v is AuditSuggestionsFile {
+  if (!v || typeof v !== 'object') return false
+  const obj = v as Record<string, unknown>
+  if (obj.version !== 1) return false
+  if (typeof obj.auditId !== 'string' || obj.auditId.length === 0) return false
+  if (!Array.isArray(obj.renameSuggestions)) return false
+  if (!Array.isArray(obj.recommendedEdits)) return false
+  return true
+}

--- a/packages/mcp-server/src/audit/index.ts
+++ b/packages/mcp-server/src/audit/index.ts
@@ -130,7 +130,6 @@ export type { ApplyRecommendedEditOptions } from './edit-applier.js'
 export type { EditApplyError, EditApplyResult } from './edit-applier.types.js'
 
 // SMI-4590 Wave 4 PR 2/6 — FrameworkAdapter seam + claudeCodeAdapter (v1).
-// PR 3/6 will add `runInventoryAudit` shared helper to the same surface.
 export { claudeCodeAdapter, FrameworkAdapterError } from './framework-adapter.js'
 
 export type {
@@ -140,3 +139,15 @@ export type {
   FrameworkName,
   InlineEditAction,
 } from './framework-adapter.types.js'
+
+// SMI-4590 Wave 4 PR 4/6 — shared `runInventoryAudit` composition helper
+// + per-audit suggestion persistence. Consumed by the MCP tool surface
+// (`skill_inventory_audit`) and (PR 5) the CLI `sklx audit collisions`
+// command.
+export { runInventoryAudit } from './run-inventory-audit.js'
+
+export type { RunInventoryAuditOptions, RunInventoryAuditResult } from './run-inventory-audit.js'
+
+export { readAuditSuggestions, writeAuditSuggestions } from './audit-suggestions.js'
+
+export type { AuditSuggestionsFile, AuditSuggestionsOptions } from './audit-suggestions.js'

--- a/packages/mcp-server/src/audit/run-inventory-audit.ts
+++ b/packages/mcp-server/src/audit/run-inventory-audit.ts
@@ -1,0 +1,341 @@
+/**
+ * @fileoverview Shared `runInventoryAudit` composition helper (SMI-4590 Wave 4 PR 4).
+ * @module @skillsmith/mcp-server/audit/run-inventory-audit
+ *
+ * Composes Wave 1 (scan + detect + history) + Wave 2 (rename suggestions)
+ * + Wave 3 (recommended edits) + Wave 4 PR 3 (exclusions filter) into a
+ * single entry-point used by both the `skill_inventory_audit` MCP tool
+ * (this PR) and the `sklx audit collisions` CLI command (PR 5).
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §1.
+ *
+ * Pipeline:
+ *   1. `scanLocalInventory` (Wave 1)             — scan the inventory.
+ *   2. `detectCollisions`     (Wave 1)           — three-pass detector.
+ *   3. Build `RenameSuggestion[]` (Wave 2 types) — one per exact collision,
+ *      using `generateSuggestionChain` to pick a non-colliding name and
+ *      mtime-descending tiebreak to pick which entry to rename.
+ *   4. `runEditSuggester`     (Wave 3)           — recommended prose edits.
+ *   5. Apply `~/.skillsmith/audit-exclusions.json` filter (Wave 4 PR 3)
+ *      when `applyExclusions !== false`.
+ *   6. `writeAuditHistory`    (Wave 1)           — persist `result.json`.
+ *   7. `writeAuditSuggestions` (this PR)          — persist `suggestions.json`
+ *      (so PR 4's apply-tools can look up rename + edit by collisionId).
+ *   8. Build + return the response shape.
+ *
+ * Tier defaults to `'community'` (cheapest fail-safe). Callers (the MCP
+ * tool, the CLI) pass through their resolved tier; the session-start
+ * audit hook (PR 6) passes the user's resolved tier from license info.
+ */
+
+import * as os from 'node:os'
+
+import {
+  type ExcludableEntry,
+  type ExclusionsConfig,
+  loadExclusions,
+  isExcluded as isExcludedCore,
+} from '@skillsmith/core/audit'
+import type { Tier } from '@skillsmith/core/config/audit-mode'
+
+import { scanLocalInventory } from '../utils/local-inventory.js'
+import type { InventoryEntry } from '../utils/local-inventory.types.js'
+import { detectCollisions } from './collision-detector.js'
+import type {
+  ExactCollisionFlag,
+  GenericTokenFlag,
+  InventoryAuditResult,
+  SemanticCollisionFlag,
+} from './collision-detector.types.js'
+import { writeAuditHistory } from './audit-history.js'
+import { writeAuditReport } from './audit-report-writer.js'
+import { writeAuditSuggestions } from './audit-suggestions.js'
+import { runEditSuggester } from './edit-suggester.js'
+import type { RecommendedEdit } from './edit-suggester.types.js'
+import { generateSuggestionChain } from './suggestion-chain.js'
+import type { RenameAction, RenameSuggestion } from './rename-engine.types.js'
+
+/**
+ * Input for {@link runInventoryAudit}. All fields optional — the MCP tool
+ * input schema rejects unknowns and home-dir traversal at the boundary.
+ */
+export interface RunInventoryAuditOptions {
+  /** Gate the semantic-overlap pass (Wave 1). Defaults to `false`. */
+  deep?: boolean
+  /** Override `os.homedir()`. Caller (MCP tool) Zod-validates the path. */
+  homeDir?: string
+  /** Optional project CLAUDE.md to scan in addition to the user one. */
+  projectDir?: string
+  /**
+   * Filter collision flags whose entries match
+   * `~/.skillsmith/audit-exclusions.json`. Defaults to `true`. Enterprise
+   * scheduled-scan runner (PR 6) passes `false` so the governance pass
+   * sees un-filtered findings for policy enforcement.
+   */
+  applyExclusions?: boolean
+  /**
+   * Subscription tier of the caller — gates the semantic pass per the
+   * audit-mode resolver. Defaults to `'community'` (preventative mode →
+   * exact + generic only). The MCP tool resolves the caller tier from
+   * license info before invoking; the CLI command passes through the same.
+   */
+  tier?: Tier
+}
+
+/** Response shape returned to MCP / CLI callers. */
+export interface RunInventoryAuditResult {
+  auditId: string
+  inventory: InventoryEntry[]
+  exactCollisions: ExactCollisionFlag[]
+  /**
+   * Wave 1's `genericFlags` (typed `GenericTokenFlag[]`). Plan §99–108
+   * referenced this field as `TriggerQualityEntry[]`; the canonical Wave 1
+   * type is `GenericTokenFlag`. Field name preserved per spec.
+   */
+  genericFlags: GenericTokenFlag[]
+  semanticCollisions: SemanticCollisionFlag[]
+  renameSuggestions: RenameSuggestion[]
+  recommendedEdits: RecommendedEdit[]
+  /** Absolute path to the rendered `report.md` for this audit. */
+  reportPath: string
+  summary: {
+    totalEntries: number
+    totalFlags: number
+    errorCount: number
+    warningCount: number
+    durationMs: number
+  }
+}
+
+/**
+ * Run the full inventory audit pipeline. Single entrypoint shared by the
+ * MCP `skill_inventory_audit` tool and the CLI `sklx audit collisions`
+ * command.
+ *
+ * Stateless — every call generates a fresh `auditId` (via the detector's
+ * default ULID generator) and writes the corresponding history +
+ * suggestions files to `~/.skillsmith/audits/<auditId>/`.
+ */
+export async function runInventoryAudit(
+  opts: RunInventoryAuditOptions = {}
+): Promise<RunInventoryAuditResult> {
+  const startedAt = process.hrtime.bigint()
+
+  // Step 1: scan the local inventory.
+  const homeDir = opts.homeDir ?? os.homedir()
+  const scan = await scanLocalInventory({
+    homeDir,
+    ...(opts.projectDir !== undefined ? { projectDir: opts.projectDir } : {}),
+  })
+
+  // Step 2: run the three-pass detector. Tier resolves the audit-mode
+  // (preventative → exact + generic; power_user / governance → +semantic).
+  // `deep: true` opts into the semantic pass via the `auditModeOverride`
+  // path so callers don't need to know about tier semantics.
+  const tier = opts.tier ?? 'community'
+  const detectorOpts: Parameters<typeof detectCollisions>[1] = { tier }
+  if (opts.deep) {
+    detectorOpts.auditModeOverride = 'power_user'
+  }
+  const detectorResult = await detectCollisions(scan.entries, detectorOpts)
+
+  // Step 3: build rename suggestions for each exact collision.
+  const renameSuggestions = buildRenameSuggestions(detectorResult, scan.entries)
+
+  // Step 4: run the edit suggester (Wave 3 — semantic-collision path).
+  // Returns an empty array when `semanticCollisions.length === 0`.
+  const recommendedEdits = await runEditSuggester(detectorResult)
+
+  // Step 5: apply exclusions filter when requested. Defaults to `true`;
+  // Enterprise scheduled-scan (PR 6) passes `false`.
+  const applyExclusions = opts.applyExclusions !== false
+  let filtered = detectorResult
+  let filteredRenames = renameSuggestions
+  let filteredEdits = recommendedEdits
+  if (applyExclusions) {
+    const exclusions = await loadExclusions()
+    filtered = applyExclusionsFilter(detectorResult, exclusions)
+    filteredRenames = renameSuggestions.filter(
+      (s) => !filtered.exactCollisions.every((f) => f.collisionId !== s.collisionId)
+    )
+    const keptCollisionIds = new Set([
+      ...filtered.exactCollisions.map((f) => f.collisionId),
+      ...filtered.genericFlags.map((f) => f.collisionId),
+      ...filtered.semanticCollisions.map((f) => f.collisionId),
+    ])
+    filteredEdits = recommendedEdits.filter((e) => keptCollisionIds.has(e.collisionId))
+  }
+
+  // Step 6: persist `result.json` + `report.md`. The history writer
+  // creates the per-audit directory; the report writer reuses it.
+  const history = await writeAuditHistory(filtered)
+  await writeAuditReport(filtered, {
+    auditDir: history.reportPath.replace(/\/report\.md$/, ''),
+    renameSuggestions: filteredRenames,
+    recommendedEdits: filteredEdits,
+  })
+
+  // Step 7: persist `suggestions.json` (this PR — for the apply-tools).
+  await writeAuditSuggestions(filtered.auditId, filteredRenames, filteredEdits)
+
+  const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000
+
+  // Step 8: build the response.
+  return {
+    auditId: filtered.auditId,
+    inventory: filtered.inventory,
+    exactCollisions: filtered.exactCollisions,
+    genericFlags: filtered.genericFlags,
+    semanticCollisions: filtered.semanticCollisions,
+    renameSuggestions: filteredRenames,
+    recommendedEdits: filteredEdits,
+    reportPath: history.reportPath,
+    summary: {
+      totalEntries: filtered.summary.totalEntries,
+      totalFlags: filtered.summary.totalFlags,
+      errorCount: filtered.summary.errorCount,
+      warningCount: filtered.summary.warningCount,
+      durationMs,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a `RenameSuggestion[]` from each `ExactCollisionFlag`. We pick the
+ * **most-recently-installed** entry (mtime descending) as the rename
+ * target — matches plan §259 default-entry tiebreak. Falls back to the
+ * first entry when mtime is missing.
+ *
+ * Author / packDomain are left null for v1 — chain falls through to the
+ * `local-` prefix path (`local-foo`, `local-foo-<shortHash>`). Wave 4 PR 5
+ * extends this with manifest lookups for richer prefixes.
+ */
+function buildRenameSuggestions(
+  result: InventoryAuditResult,
+  fullInventory: ReadonlyArray<InventoryEntry>
+): RenameSuggestion[] {
+  const suggestions: RenameSuggestion[] = []
+  for (const flag of result.exactCollisions) {
+    if (flag.entries.length === 0) continue
+
+    // mtime-descending tiebreak; missing mtime sinks to the bottom.
+    const sorted = [...flag.entries].sort((a, b) => (b.mtime ?? 0) - (a.mtime ?? 0))
+    const target = sorted[0]!
+    const action = inventoryKindToRenameAction(target)
+    if (action === null) continue // claude_md_rule entries can't be renamed.
+
+    const chain = generateSuggestionChain({
+      token: stripLeadingSlash(target.identifier),
+      author: target.meta?.author ?? null,
+      packDomain: null,
+      tagFallback: target.meta?.tags?.[0] ?? null,
+      authorPath: target.source_path,
+      existingInventory: fullInventory,
+    })
+    const lowercaseInventory = new Set(fullInventory.map((e) => e.identifier.toLowerCase()))
+    const firstFree = chain.candidates.find((c) => !lowercaseInventory.has(c.toLowerCase()))
+    const suggested = firstFree ?? chain.candidates[0] ?? target.identifier
+
+    suggestions.push({
+      collisionId: flag.collisionId,
+      entry: target,
+      currentName: target.identifier,
+      suggested,
+      applyAction: action,
+      reason: flag.reason,
+    })
+  }
+  return suggestions
+}
+
+function stripLeadingSlash(identifier: string): string {
+  return identifier.startsWith('/') ? identifier.slice(1) : identifier
+}
+
+/** Map an `InventoryEntry.kind` to a `RenameAction`, or `null` for unrenamable kinds. */
+function inventoryKindToRenameAction(entry: InventoryEntry): RenameAction | null {
+  switch (entry.kind) {
+    case 'command':
+      return 'rename_command_file'
+    case 'agent':
+      return 'rename_agent_file'
+    case 'skill':
+      return 'rename_skill_dir_and_frontmatter'
+    case 'claude_md_rule':
+      return null
+    default:
+      return null
+  }
+}
+
+/**
+ * Drop a collision flag iff ANY involved entry matches an exclusion. The
+ * intent of an exclusion is "I deliberately keep this entry around" —
+ * once the user marks one side acceptable, the rename suggestion against
+ * that pair is moot.
+ *
+ * Inventory itself is NOT filtered — exclusions suppress findings, not
+ * inventory entries. The audit report still lists every entry under
+ * "Inventory" so the user has full context for their exclusion choices.
+ */
+function applyExclusionsFilter(
+  result: InventoryAuditResult,
+  config: ExclusionsConfig
+): InventoryAuditResult {
+  if (config.exclusions.length === 0) return result
+
+  const exactCollisions = result.exactCollisions.filter(
+    (flag) => !flag.entries.some((entry) => isExcludedInventoryEntry(entry, config))
+  )
+  const genericFlags = result.genericFlags.filter(
+    (flag) => !isExcludedInventoryEntry(flag.entry, config)
+  )
+  const semanticCollisions = result.semanticCollisions.filter(
+    (flag) =>
+      !isExcludedInventoryEntry(flag.entryA, config) &&
+      !isExcludedInventoryEntry(flag.entryB, config)
+  )
+
+  const errorCount = exactCollisions.length
+  const warningCount = genericFlags.length + semanticCollisions.length
+  return {
+    ...result,
+    exactCollisions,
+    genericFlags,
+    semanticCollisions,
+    summary: {
+      ...result.summary,
+      totalFlags: errorCount + warningCount,
+      errorCount,
+      warningCount,
+    },
+  }
+}
+
+/** Translate a Wave 1 `InventoryEntry` to the core `ExcludableEntry` shape. */
+function isExcludedInventoryEntry(entry: InventoryEntry, config: ExclusionsConfig): boolean {
+  if (entry.kind === 'command') {
+    const candidate: ExcludableEntry = {
+      kind: 'command',
+      commandIdentifier: entry.identifier.startsWith('/')
+        ? entry.identifier
+        : `/${entry.identifier}`,
+    }
+    return isExcludedCore(candidate, config)
+  }
+  if (entry.kind === 'skill') {
+    const author = entry.meta?.author
+    // Skill exclusions are keyed by `<author>/<identifier>`. Without an
+    // author, fall back to bare identifier so a manually-edited
+    // exclusions file can still target unmanaged skills.
+    const skillId = author ? `${author}/${entry.identifier}` : entry.identifier
+    const candidate: ExcludableEntry = { kind: 'skill', skillId }
+    return isExcludedCore(candidate, config)
+  }
+  // agents + claude_md_rule have no v1 exclusion shape — never excluded.
+  return false
+}

--- a/packages/mcp-server/src/tools/apply-namespace-rename.ts
+++ b/packages/mcp-server/src/tools/apply-namespace-rename.ts
@@ -1,0 +1,152 @@
+/**
+ * @fileoverview `apply_namespace_rename` MCP tool (SMI-4590 Wave 4 PR 4).
+ * @module @skillsmith/mcp-server/tools/apply-namespace-rename
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §2.
+ *
+ * Per-collision apply path. The agent calls `skill_inventory_audit` first
+ * to populate `~/.skillsmith/audits/<auditId>/`, then calls this tool
+ * once per accepted rename. Stateless: each call re-reads the persisted
+ * suggestions file (via `readAuditSuggestions`) and dispatches to Wave 2's
+ * `applyRename`.
+ *
+ * Input semantics:
+ *   - `action: 'apply'`  — apply the suggested rename verbatim.
+ *   - `action: 'custom'` — apply with `customName` (Zod refinement
+ *     enforces non-empty `customName` on this branch).
+ *   - `action: 'skip'`   — no-op; returns `{ success: true }` with no
+ *     `result`. The agent records the decision; nothing on disk changes.
+ *
+ * Failure modes (typed via `errorCode`):
+ *   - `namespace.audit.invalid_input` — Zod rejection.
+ *   - `namespace.audit.history_not_found` — `auditId` doesn't resolve.
+ *   - `namespace.audit.collision_not_found` — `collisionId` not in
+ *     persisted `RenameSuggestion[]`.
+ *   - `namespace.rename.subcall_failed` — Wave 2's `applyRename` errored
+ *     (target_exists, backup_failed, frontmatter_rewrite_failed, etc.).
+ *     The inner Wave 2 error kind is preserved in the `error` message.
+ */
+
+import { z } from 'zod'
+
+import { readAuditSuggestions } from '../audit/audit-suggestions.js'
+import { applyRename } from '../audit/rename-engine.js'
+import type { ApplyRenameRequest } from '../audit/rename-engine.types.js'
+
+import type { ApplyNamespaceRenameResponse } from './apply-namespace-rename.types.js'
+
+/**
+ * Zod input schema with conditional refinement: `customName` is required
+ * iff `action === 'custom'`; `customName` is forbidden otherwise (rejects
+ * payloads that pass an unused field on apply / skip — keeps the surface
+ * clean and helps catch caller-side bugs).
+ */
+export const applyNamespaceRenameInputSchema = z
+  .object({
+    auditId: z.string().min(1),
+    collisionId: z.string().min(1),
+    action: z.enum(['apply', 'custom', 'skip']),
+    customName: z.string().min(1).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.action === 'custom' && !value.customName) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['customName'],
+        message: 'customName is required when action === "custom"',
+      })
+    }
+    if (value.action !== 'custom' && value.customName !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['customName'],
+        message: 'customName is only valid when action === "custom"',
+      })
+    }
+  })
+
+/**
+ * Execute the `apply_namespace_rename` tool.
+ *
+ * Returns the response envelope directly — the dispatcher wraps it for
+ * the MCP `CallToolResult` shape. The application-level success/failure
+ * lives inside the response payload.
+ */
+export async function applyNamespaceRename(input: unknown): Promise<ApplyNamespaceRenameResponse> {
+  const parsed = applyNamespaceRenameInputSchema.safeParse(input)
+  if (!parsed.success) {
+    const message = parsed.error.issues
+      .map((issue) => {
+        const issuePath = issue.path.length > 0 ? issue.path.join('.') : '<root>'
+        return `${issuePath}: ${issue.message}`
+      })
+      .join('; ')
+    return {
+      success: false,
+      collisionId: '',
+      errorCode: 'namespace.audit.invalid_input',
+      error: `Invalid apply_namespace_rename input: ${message}`,
+    }
+  }
+  const validInput = parsed.data
+
+  // Skip is a recorded no-op — return success without side effects.
+  if (validInput.action === 'skip') {
+    return {
+      success: true,
+      collisionId: validInput.collisionId as ApplyNamespaceRenameResponse['collisionId'],
+    }
+  }
+
+  // Look up the persisted suggestions. Plan §177: history-not-found
+  // returns a typed error pointing at `skill_inventory_audit`.
+  const suggestions = await readAuditSuggestions(validInput.auditId)
+  if (!suggestions) {
+    return {
+      success: false,
+      collisionId: validInput.collisionId as ApplyNamespaceRenameResponse['collisionId'],
+      errorCode: 'namespace.audit.history_not_found',
+      error: `Audit history not found for auditId ${validInput.auditId}. Run skill_inventory_audit first.`,
+    }
+  }
+
+  const suggestion = suggestions.renameSuggestions.find(
+    (s) => s.collisionId === validInput.collisionId
+  )
+  if (!suggestion) {
+    return {
+      success: false,
+      collisionId: validInput.collisionId as ApplyNamespaceRenameResponse['collisionId'],
+      errorCode: 'namespace.audit.collision_not_found',
+      error: `Collision ${validInput.collisionId} not found in audit ${validInput.auditId}.`,
+    }
+  }
+
+  // Translate to Wave 2's apply request shape. `'custom'` carries
+  // `customName` through; `'apply'` uses the suggested name verbatim.
+  const renameRequest: ApplyRenameRequest = {
+    suggestion,
+    request:
+      validInput.action === 'custom'
+        ? { action: 'apply', auditId: validInput.auditId, customName: validInput.customName! }
+        : { action: 'apply', auditId: validInput.auditId },
+  }
+  const result = await applyRename(renameRequest)
+
+  if (!result.success) {
+    return {
+      success: false,
+      collisionId: result.collisionId,
+      errorCode: 'namespace.rename.subcall_failed',
+      error: `${result.error?.kind ?? 'namespace.rename.unknown'}: ${result.error?.message ?? 'unknown failure'}`,
+      result,
+    }
+  }
+
+  return {
+    success: true,
+    collisionId: result.collisionId,
+    result,
+  }
+}

--- a/packages/mcp-server/src/tools/apply-namespace-rename.types.ts
+++ b/packages/mcp-server/src/tools/apply-namespace-rename.types.ts
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Type vocabulary for the `apply_namespace_rename` MCP tool
+ *               (SMI-4590 Wave 4 PR 4).
+ * @module @skillsmith/mcp-server/tools/apply-namespace-rename.types
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §2.
+ */
+
+import type { CollisionId } from '../audit/collision-detector.types.js'
+import type { ApplyRenameResult } from '../audit/rename-engine.types.js'
+
+/**
+ * Input for the `apply_namespace_rename` MCP tool.
+ *
+ * `action: 'apply'`  — apply the suggested rename (Wave 2 `applyRename`).
+ * `action: 'custom'` — apply with `customName` (must be non-empty).
+ * `action: 'skip'`   — record a no-op decision; no file mutation.
+ *
+ * `auditId` + `collisionId` are FKs into
+ * `~/.skillsmith/audits/<auditId>/suggestions.json` (this PR — see
+ * `audit/audit-suggestions.ts`).
+ */
+export interface ApplyNamespaceRenameInput {
+  /** ULID from a prior `skill_inventory_audit` response. */
+  auditId: string
+  /** `collisionId` from a `RenameSuggestion` in that response. */
+  collisionId: string
+  action: 'apply' | 'custom' | 'skip'
+  /** Required when `action === 'custom'`. */
+  customName?: string
+}
+
+/**
+ * Wire response shape. `success: true` carries the Wave 2
+ * `ApplyRenameResult`; `success: false` carries a typed `errorCode` +
+ * human-readable `error` message.
+ */
+export interface ApplyNamespaceRenameResponse {
+  success: boolean
+  /** Echoes the input `collisionId` (or `''` when input was unparseable). */
+  collisionId: CollisionId | ''
+  /** Wave 2 result. Populated when `action !== 'skip'` AND apply succeeded. */
+  result?: ApplyRenameResult
+  /** Typed error code on failure or input error. */
+  errorCode?:
+    | 'namespace.audit.invalid_input'
+    | 'namespace.audit.history_not_found'
+    | 'namespace.audit.collision_not_found'
+    | 'namespace.rename.subcall_failed'
+  /** Human-readable error message. */
+  error?: string
+}

--- a/packages/mcp-server/src/tools/apply-recommended-edit.ts
+++ b/packages/mcp-server/src/tools/apply-recommended-edit.ts
@@ -1,0 +1,124 @@
+/**
+ * @fileoverview `apply_recommended_edit` MCP tool (SMI-4590 Wave 4 PR 4).
+ * @module @skillsmith/mcp-server/tools/apply-recommended-edit
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §3.
+ *
+ * Per-collision apply path for prose edits. Mirrors
+ * `apply_namespace_rename` but dispatches to Wave 3's
+ * `applyRecommendedEdit` instead of Wave 2's `applyRename`.
+ *
+ * Tool registration:
+ *   - Registered iff `APPLY_TEMPLATE_REGISTRY.size > 0`
+ *     (`audit-tool-dispatch.ts` adds the case + name to `AUDIT_TOOL_NAMES`
+ *     conditionally at module load).
+ *   - Live state: `APPLY_TEMPLATE_REGISTRY = new Set(['add_domain_qualifier'])`
+ *     (Wave 3 PR #886, merged) — tool is registered.
+ *
+ * Failure modes:
+ *   - `namespace.audit.invalid_input` — Zod rejection.
+ *   - `namespace.audit.history_not_found` — `auditId` doesn't resolve.
+ *   - `namespace.audit.collision_not_found` — `collisionId` not in
+ *     persisted `RecommendedEdit[]`.
+ *   - `edit.template_not_in_apply_registry` — Wave 3 registry guard
+ *     rejected the persisted `pattern`.
+ *   - `edit.subcall_failed` — any other Wave 3 failure (stale_before,
+ *     backup_failed, fs_error). Inner kind preserved in `error` message.
+ */
+
+import { z } from 'zod'
+
+import { readAuditSuggestions } from '../audit/audit-suggestions.js'
+import { applyRecommendedEdit } from '../audit/edit-applier.js'
+
+import type { ApplyRecommendedEditResponse } from './apply-recommended-edit.types.js'
+
+/**
+ * Zod input schema. `auditId` + `collisionId` are FKs into
+ * `~/.skillsmith/audits/<auditId>/suggestions.json`.
+ */
+export const applyRecommendedEditInputSchema = z
+  .object({
+    auditId: z.string().min(1),
+    collisionId: z.string().min(1),
+  })
+  .strict()
+
+/**
+ * Execute the `apply_recommended_edit` tool. Returns the response
+ * envelope directly; the dispatcher wraps it for the MCP `CallToolResult`
+ * shape.
+ */
+export async function applyRecommendedEditTool(
+  input: unknown
+): Promise<ApplyRecommendedEditResponse> {
+  const parsed = applyRecommendedEditInputSchema.safeParse(input)
+  if (!parsed.success) {
+    const message = parsed.error.issues
+      .map((issue) => {
+        const issuePath = issue.path.length > 0 ? issue.path.join('.') : '<root>'
+        return `${issuePath}: ${issue.message}`
+      })
+      .join('; ')
+    return {
+      success: false,
+      collisionId: '',
+      errorCode: 'namespace.audit.invalid_input',
+      error: `Invalid apply_recommended_edit input: ${message}`,
+    }
+  }
+  const validInput = parsed.data
+
+  const suggestions = await readAuditSuggestions(validInput.auditId)
+  if (!suggestions) {
+    return {
+      success: false,
+      collisionId: validInput.collisionId as ApplyRecommendedEditResponse['collisionId'],
+      errorCode: 'namespace.audit.history_not_found',
+      error: `Audit history not found for auditId ${validInput.auditId}. Run skill_inventory_audit first.`,
+    }
+  }
+
+  const edit = suggestions.recommendedEdits.find((e) => e.collisionId === validInput.collisionId)
+  if (!edit) {
+    return {
+      success: false,
+      collisionId: validInput.collisionId as ApplyRecommendedEditResponse['collisionId'],
+      errorCode: 'namespace.audit.collision_not_found',
+      error: `Collision ${validInput.collisionId} not found in audit ${validInput.auditId}.`,
+    }
+  }
+
+  const result = await applyRecommendedEdit(edit, {
+    auditId: validInput.auditId,
+    mode: 'apply_with_confirmation',
+  })
+
+  if (!result.success) {
+    // Surface the registry guard explicitly — callers branch on it to
+    // know that the persisted edit will never apply (vs a transient
+    // failure they can retry).
+    if (result.error?.kind === 'edit.template_not_in_apply_registry') {
+      return {
+        success: false,
+        collisionId: result.collisionId,
+        errorCode: 'edit.template_not_in_apply_registry',
+        error: result.error.message,
+        result,
+      }
+    }
+    return {
+      success: false,
+      collisionId: result.collisionId,
+      errorCode: 'edit.subcall_failed',
+      error: `${result.error?.kind ?? 'edit.unknown'}: ${result.error?.message ?? 'unknown failure'}`,
+      result,
+    }
+  }
+
+  return {
+    success: true,
+    collisionId: result.collisionId,
+    result,
+  }
+}

--- a/packages/mcp-server/src/tools/apply-recommended-edit.types.ts
+++ b/packages/mcp-server/src/tools/apply-recommended-edit.types.ts
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Type vocabulary for the `apply_recommended_edit` MCP tool
+ *               (SMI-4590 Wave 4 PR 4).
+ * @module @skillsmith/mcp-server/tools/apply-recommended-edit.types
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §3.
+ *
+ * Tool registration is gated on `APPLY_TEMPLATE_REGISTRY.size > 0`
+ * (Wave 3 `edit-applier.ts`). When the registry is empty, the tool is
+ * NOT exposed in the dispatcher's `AUDIT_TOOL_NAMES` set — defense-in-
+ * depth against a rollback that empties the registry.
+ */
+
+import type { CollisionId } from '../audit/collision-detector.types.js'
+import type { EditApplyResult } from '../audit/edit-applier.types.js'
+
+/**
+ * Input for the `apply_recommended_edit` MCP tool.
+ *
+ * `pattern` is NOT a tool input — it's derived from the persisted
+ * `RecommendedEdit.pattern`. The registry guard sits inside Wave 3's
+ * `applyRecommendedEdit` (template not in `APPLY_TEMPLATE_REGISTRY` →
+ * typed error `edit.template_not_in_apply_registry`).
+ */
+export interface ApplyRecommendedEditInput {
+  /** ULID from a prior `skill_inventory_audit` response. */
+  auditId: string
+  /**
+   * `collisionId` from a `RecommendedEdit` in that response. Wave 3
+   * keys edits by their source `SemanticCollisionFlag.collisionId`, not a
+   * separate `editId`.
+   */
+  collisionId: string
+}
+
+/**
+ * Wire response shape. `success: true` carries the Wave 3
+ * `EditApplyResult` (file path, backup path, ledger entry, summary);
+ * `success: false` carries a typed `errorCode` + human-readable message.
+ */
+export interface ApplyRecommendedEditResponse {
+  success: boolean
+  /** Echoes the input `collisionId` (or `''` when input was unparseable). */
+  collisionId: CollisionId | ''
+  /** Wave 3 result. Populated when apply succeeded. */
+  result?: EditApplyResult
+  /** Typed error code on failure or input error. */
+  errorCode?:
+    | 'namespace.audit.invalid_input'
+    | 'namespace.audit.history_not_found'
+    | 'namespace.audit.collision_not_found'
+    | 'edit.template_not_in_apply_registry'
+    | 'edit.subcall_failed'
+  /** Human-readable error message. */
+  error?: string
+}

--- a/packages/mcp-server/src/tools/skill-inventory-audit.ts
+++ b/packages/mcp-server/src/tools/skill-inventory-audit.ts
@@ -1,0 +1,138 @@
+/**
+ * @fileoverview `skill_inventory_audit` MCP tool (SMI-4590 Wave 4 PR 4).
+ * @module @skillsmith/mcp-server/tools/skill-inventory-audit
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §1.
+ *
+ * Stateless: every call generates a fresh `auditId`, runs the full
+ * Wave 1 + 2 + 3 pipeline via `runInventoryAudit`, and writes both
+ * `result.json` (Wave 1 history) and `suggestions.json` (this PR) to
+ * `~/.skillsmith/audits/<auditId>/`. Idempotent — re-invocation produces a
+ * fresh audit with no shared state across calls.
+ *
+ * Validation:
+ *   - `deep` / `applyExclusions` — booleans, default false / true.
+ *   - `homeDir` — string under `os.homedir()` or `os.tmpdir()` (test
+ *     fixtures). Anything else rejects with
+ *     `namespace.audit.invalid_home_dir` (`buildValidationError` envelope).
+ *   - `projectDir` — string, optional; no traversal refinement (CLAUDE.md
+ *     scan is read-only and tolerates missing files).
+ *   - Unknown top-level keys are rejected (Zod `.strict()`).
+ */
+
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { z } from 'zod'
+
+import { runInventoryAudit } from '../audit/run-inventory-audit.js'
+import type {
+  SkillInventoryAuditInput,
+  SkillInventoryAuditResponse,
+} from './skill-inventory-audit.types.js'
+
+/**
+ * Zod input schema for the `skill_inventory_audit` MCP tool.
+ *
+ * `homeDir` refinement: the resolved absolute path must live under
+ * `os.homedir()` OR `os.tmpdir()` (test fixtures only). Bare arbitrary
+ * paths are rejected — prevents an attacker-controlled input from
+ * steering the scanner at e.g. `/etc` or `/private/var/db`.
+ */
+export const skillInventoryAuditInputSchema = z
+  .object({
+    deep: z.boolean().optional(),
+    homeDir: z
+      .string()
+      .min(1)
+      .refine(isHomeDirUnderAllowedRoot, {
+        message:
+          'homeDir must resolve under os.homedir() or os.tmpdir(); arbitrary filesystem paths are rejected',
+      })
+      .optional(),
+    projectDir: z.string().min(1).optional(),
+    applyExclusions: z.boolean().optional(),
+  })
+  .strict()
+
+export type SkillInventoryAuditValidatedInput = z.infer<typeof skillInventoryAuditInputSchema>
+
+/**
+ * Execute the `skill_inventory_audit` tool. Validates input via Zod and
+ * returns either the success response OR a structured validation-error
+ * envelope (matches `install.ts:buildValidationError` pattern).
+ */
+export async function skillInventoryAudit(
+  input: unknown
+): Promise<SkillInventoryAuditResponse | InventoryAuditValidationError> {
+  const parsed = skillInventoryAuditInputSchema.safeParse(input)
+  if (!parsed.success) {
+    const message = parsed.error.issues
+      .map((issue) => {
+        const issuePath = issue.path.length > 0 ? issue.path.join('.') : '<root>'
+        return `${issuePath}: ${issue.message}`
+      })
+      .join('; ')
+    return buildInventoryAuditValidationError(message)
+  }
+  const validInput = parsed.data
+
+  const runOpts: Parameters<typeof runInventoryAudit>[0] = {}
+  if (validInput.deep !== undefined) runOpts.deep = validInput.deep
+  if (validInput.homeDir !== undefined) runOpts.homeDir = validInput.homeDir
+  if (validInput.projectDir !== undefined) runOpts.projectDir = validInput.projectDir
+  if (validInput.applyExclusions !== undefined) {
+    runOpts.applyExclusions = validInput.applyExclusions
+  }
+  const result = await runInventoryAudit(runOpts)
+  return result
+}
+
+/**
+ * Application-level validation-error envelope. Mirrors the
+ * `install.ts:buildValidationError` shape so MCP clients that introspect
+ * `success` get a consistent failure surface across audit + install
+ * tools.
+ */
+export interface InventoryAuditValidationError {
+  success: false
+  error: string
+  errorCode: 'namespace.audit.invalid_input' | 'namespace.audit.invalid_home_dir'
+}
+
+function buildInventoryAuditValidationError(message: string): InventoryAuditValidationError {
+  // Distinguish the homeDir refinement from generic shape errors so
+  // callers can short-circuit on the security-relevant code without
+  // parsing prose.
+  const code = /homeDir must resolve under/.test(message)
+    ? ('namespace.audit.invalid_home_dir' as const)
+    : ('namespace.audit.invalid_input' as const)
+  return {
+    success: false,
+    error: `Invalid skill_inventory_audit input: ${message}`,
+    errorCode: code,
+  }
+}
+
+/**
+ * Reject `homeDir` values that resolve outside the user's homedir or the
+ * OS temp dir. Symlinks are NOT followed — the check is on the resolved
+ * absolute path string. macOS `/var/folders` symlink to `/private/var/folders`
+ * is handled by also accepting paths with both common prefixes.
+ */
+function isHomeDirUnderAllowedRoot(value: string): boolean {
+  if (value.length === 0) return false
+  const resolved = path.resolve(value)
+  const candidates = [os.homedir(), os.tmpdir()]
+  // macOS realpath equivalence: `/var/folders/...` and `/private/var/folders/...`
+  // both resolve to the same physical location. Accept either prefix to
+  // unblock test fixtures created via `fs.mkdtempSync` on macOS.
+  const tmp = os.tmpdir()
+  if (tmp.startsWith('/var/folders/')) candidates.push('/private' + tmp)
+  if (tmp.startsWith('/private/var/folders/')) candidates.push(tmp.replace('/private', ''))
+  return candidates.some((root) => resolved === root || resolved.startsWith(root + path.sep))
+}
+
+// Re-export the input/response type aliases so dispatchers + tests can
+// pull them from one path without reaching across two modules.
+export type { SkillInventoryAuditInput, SkillInventoryAuditResponse }

--- a/packages/mcp-server/src/tools/skill-inventory-audit.types.ts
+++ b/packages/mcp-server/src/tools/skill-inventory-audit.types.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Type vocabulary for the `skill_inventory_audit` MCP tool
+ *               (SMI-4590 Wave 4 PR 4).
+ * @module @skillsmith/mcp-server/tools/skill-inventory-audit.types
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §1.
+ *
+ * The `SkillInventoryAuditResponse` shape is the canonical wire format
+ * returned to MCP callers. The shared `RunInventoryAuditResult` from
+ * `audit/run-inventory-audit.ts` is structurally identical — keep these
+ * two surfaces in lock-step so the tool body is a thin pass-through.
+ */
+
+import type {
+  ExactCollisionFlag,
+  GenericTokenFlag,
+  InventoryEntry,
+  SemanticCollisionFlag,
+} from '../audit/collision-detector.types.js'
+import type { RecommendedEdit } from '../audit/edit-suggester.types.js'
+import type { RenameSuggestion } from '../audit/rename-engine.types.js'
+
+/**
+ * Input for the `skill_inventory_audit` MCP tool. All fields optional;
+ * the Zod schema (in `skill-inventory-audit.ts`) refines `homeDir` to
+ * reject paths outside `os.homedir()` / `os.tmpdir()`.
+ */
+export interface SkillInventoryAuditInput {
+  /** Gate the semantic-overlap pass. Defaults to `false`. */
+  deep?: boolean
+  /**
+   * Override for `os.homedir()`. Refined to live under the real homedir
+   * or `os.tmpdir()` (test fixtures only) — bare arbitrary paths are
+   * rejected with `namespace.audit.invalid_home_dir`. Prevents an
+   * attacker-controlled input from steering the scanner at arbitrary
+   * filesystem locations.
+   */
+  homeDir?: string
+  /** Optional project CLAUDE.md to scan in addition to the user one. */
+  projectDir?: string
+  /**
+   * Filter collisions whose entries match
+   * `~/.skillsmith/audit-exclusions.json`. Defaults to `true`. The
+   * Enterprise scheduled-scan runner (Wave 4 PR 6) passes `false` so the
+   * governance pass sees un-filtered findings for policy enforcement.
+   */
+  applyExclusions?: boolean
+}
+
+/** Wire response shape for the MCP tool. */
+export interface SkillInventoryAuditResponse {
+  auditId: string
+  inventory: InventoryEntry[]
+  exactCollisions: ExactCollisionFlag[]
+  /**
+   * Wave 1's `genericFlags` (typed `GenericTokenFlag[]`). Plan §99–108
+   * referenced this field as `TriggerQualityEntry[]`; the canonical
+   * Wave 1 type name is `GenericTokenFlag`. Field name preserved to
+   * match plan wire shape.
+   */
+  genericFlags: GenericTokenFlag[]
+  semanticCollisions: SemanticCollisionFlag[]
+  renameSuggestions: RenameSuggestion[]
+  recommendedEdits: RecommendedEdit[]
+  /** Absolute path to `~/.skillsmith/audits/<auditId>/report.md`. */
+  reportPath: string
+  summary: {
+    totalEntries: number
+    totalFlags: number
+    errorCount: number
+    warningCount: number
+    durationMs: number
+  }
+}

--- a/packages/mcp-server/tests/integration/audit-roundtrip.test.ts
+++ b/packages/mcp-server/tests/integration/audit-roundtrip.test.ts
@@ -1,0 +1,274 @@
+/**
+ * @fileoverview Integration round-trip test for SMI-4590 Wave 4 PR 4 — the
+ *               full MCP tool surface (`skill_inventory_audit` →
+ *               `apply_namespace_rename` → optional
+ *               `apply_recommended_edit`).
+ * @module @skillsmith/mcp-server/tests/integration/audit-roundtrip
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md
+ *       §Tests `audit-roundtrip.test.ts`.
+ *
+ * End-to-end: drive the dispatcher's three new audit tools against a real
+ * `~/.claude/` (planted under a `mkdtemp` HOME) and assert:
+ *
+ *   1. `skill_inventory_audit` discovers a planted exact collision and
+ *      returns a non-empty `renameSuggestions[]`.
+ *   2. `apply_namespace_rename` for the first suggestion mutates the
+ *      filesystem to the expected post-rename layout.
+ *   3. The same call repeated is idempotent — no new ledger entry, no
+ *      file changes (Wave 2 ledger no-op semantics surface as
+ *      `fromPath === toPath`).
+ *   4. `apply_recommended_edit` for a hand-rolled `add_domain_qualifier`
+ *      fixture mutates the SKILL.md prose body.
+ *
+ * Driving through `dispatchAuditTool` (vs the tool functions directly)
+ * exercises the dispatcher case wiring + JSON-body envelope used by the
+ * MCP server transport.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { dispatchAuditTool, AUDIT_TOOL_NAMES } from '../../src/audit-tool-dispatch.js'
+import type { ToolContext } from '../../src/context.js'
+import type { LicenseMiddleware } from '../../src/middleware/license.js'
+import type { QuotaMiddleware } from '../../src/middleware/quota.js'
+import { writeAuditHistory } from '../../src/audit/audit-history.js'
+import { writeAuditSuggestions } from '../../src/audit/audit-suggestions.js'
+import type { AuditId, CollisionId } from '../../src/audit/collision-detector.types.js'
+import type { RecommendedEdit } from '../../src/audit/edit-suggester.types.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import type { SkillInventoryAuditResponse } from '../../src/tools/skill-inventory-audit.types.js'
+import type { ApplyNamespaceRenameResponse } from '../../src/tools/apply-namespace-rename.types.js'
+import type { ApplyRecommendedEditResponse } from '../../src/tools/apply-recommended-edit.types.js'
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+let TEST_HOME: string
+let PREV_HOME: string | undefined
+
+beforeEach(() => {
+  TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-audit-roundtrip-'))
+  PREV_HOME = process.env['HOME']
+  process.env['HOME'] = TEST_HOME
+})
+
+afterEach(() => {
+  if (PREV_HOME !== undefined) process.env['HOME'] = PREV_HOME
+  else delete process.env['HOME']
+  if (TEST_HOME && fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures + middleware stubs
+// ---------------------------------------------------------------------------
+
+function plantSkill(home: string, identifier: string, description = 'fixture'): string {
+  const dir = path.join(home, '.claude', 'skills', identifier)
+  fs.mkdirSync(dir, { recursive: true })
+  const filePath = path.join(dir, 'SKILL.md')
+  fs.writeFileSync(
+    filePath,
+    `---\nname: ${identifier}\ndescription: ${description}\n---\n`,
+    'utf-8'
+  )
+  return filePath
+}
+
+function plantCommand(home: string, identifier: string): string {
+  const dir = path.join(home, '.claude', 'commands')
+  fs.mkdirSync(dir, { recursive: true })
+  const filePath = path.join(dir, `${identifier}.md`)
+  fs.writeFileSync(filePath, `# ${identifier}\nbody\n`, 'utf-8')
+  return filePath
+}
+
+function fakeContext(): ToolContext {
+  return {} as ToolContext
+}
+
+function fakeLicense(): LicenseMiddleware {
+  return {
+    checkFeature: vi.fn().mockResolvedValue({ valid: true }),
+    checkTool: vi.fn().mockResolvedValue({ valid: true }),
+    getLicenseInfo: vi.fn().mockResolvedValue({
+      valid: true,
+      tier: 'enterprise' as const,
+      features: [],
+    }),
+    invalidateCache: vi.fn(),
+  } as unknown as LicenseMiddleware
+}
+
+function fakeQuota(): QuotaMiddleware {
+  return {
+    checkAndTrack: vi.fn().mockResolvedValue({
+      allowed: true,
+      remaining: 999,
+      limit: 1000,
+      percentUsed: 0.1,
+      warningLevel: 0,
+      resetAt: new Date(),
+    }),
+    buildMetadata: vi.fn(),
+    buildExceededResponse: vi.fn(),
+  } as unknown as QuotaMiddleware
+}
+
+/** Decode a `CallToolResult` JSON-body back into its typed payload. */
+function decodeBody<T>(result: CallToolResult): T {
+  const text = (result.content[0] as { text: string }).text
+  return JSON.parse(text) as T
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('audit round-trip — inventory → rename → idempotent re-apply', () => {
+  it('end-to-end: discovers collision, applies rename, second call is idempotent', async () => {
+    plantSkill(TEST_HOME, 'ship')
+    const cmdPath = plantCommand(TEST_HOME, 'ship')
+    // Force the command's mtime ahead so the suggestion targets it
+    // (file-rename path is the simplest to assert on disk).
+    const future = new Date(Date.now() + 60_000)
+    fs.utimesSync(cmdPath, future, future)
+
+    // Step 1: skill_inventory_audit
+    expect(AUDIT_TOOL_NAMES.has('skill_inventory_audit')).toBe(true)
+    const auditCall = await dispatchAuditTool(
+      'skill_inventory_audit',
+      { homeDir: TEST_HOME },
+      fakeContext(),
+      fakeLicense(),
+      fakeQuota()
+    )
+    expect(auditCall.isError).toBe(false)
+    const audit = decodeBody<SkillInventoryAuditResponse>(auditCall)
+    expect(audit.exactCollisions.length).toBeGreaterThanOrEqual(1)
+    expect(audit.renameSuggestions.length).toBeGreaterThanOrEqual(1)
+
+    // Step 2: apply_namespace_rename for the first suggestion
+    const suggestion = audit.renameSuggestions[0]!
+    expect(AUDIT_TOOL_NAMES.has('apply_namespace_rename')).toBe(true)
+    const firstApply = await dispatchAuditTool(
+      'apply_namespace_rename',
+      {
+        auditId: audit.auditId,
+        collisionId: suggestion.collisionId,
+        action: 'apply',
+      },
+      fakeContext(),
+      fakeLicense(),
+      fakeQuota()
+    )
+    expect(firstApply.isError).toBe(false)
+    const firstResponse = decodeBody<ApplyNamespaceRenameResponse>(firstApply)
+    expect(firstResponse.success).toBe(true)
+    expect(firstResponse.result?.success).toBe(true)
+    // Filesystem matches expected post-rename layout.
+    expect(fs.existsSync(cmdPath)).toBe(false)
+    expect(fs.existsSync(firstResponse.result!.toPath)).toBe(true)
+    const firstBackup = firstResponse.result!.backupPath
+    expect(firstBackup.length).toBeGreaterThan(0)
+
+    // Step 3: idempotent re-apply (Wave 2 ledger no-op)
+    const secondApply = await dispatchAuditTool(
+      'apply_namespace_rename',
+      {
+        auditId: audit.auditId,
+        collisionId: suggestion.collisionId,
+        action: 'apply',
+      },
+      fakeContext(),
+      fakeLicense(),
+      fakeQuota()
+    )
+    expect(secondApply.isError).toBe(false)
+    const secondResponse = decodeBody<ApplyNamespaceRenameResponse>(secondApply)
+    expect(secondResponse.success).toBe(true)
+    expect(secondResponse.result?.success).toBe(true)
+    // Idempotent contract: fromPath === toPath, no fresh backup.
+    expect(secondResponse.result?.fromPath).toBe(secondResponse.result?.toPath)
+    expect(secondResponse.result?.backupPath).toBe('')
+  })
+})
+
+describe('audit round-trip — apply_recommended_edit via dispatcher', () => {
+  it('mutates the file when a registered-pattern edit is dispatched', async () => {
+    expect(AUDIT_TOOL_NAMES.has('apply_recommended_edit')).toBe(true)
+
+    // Hand-roll an audit + suggestions pair (semantic-pass output) so the
+    // round-trip stays at the unit-integration boundary without requiring
+    // a real OverlapDetector model load.
+    const description = 'deploy code to production'
+    const filePath = plantSkill(TEST_HOME, 'roundtrip-edit', description)
+    const auditId = '01J6Z3M0CK4N0R3MROUNDTRIP01' as AuditId
+    const collisionId = 'roundtripEditFixture' as CollisionId
+
+    // Locate description line for fixture lineRange.
+    const lines = fs.readFileSync(filePath, 'utf-8').split('\n')
+    const lineIdx = lines.findIndex((l) => l === `description: ${description}`)
+    const edit: RecommendedEdit = {
+      collisionId,
+      category: 'description_overlap',
+      pattern: 'add_domain_qualifier',
+      filePath,
+      lineRange: { start: lineIdx + 1, end: lineIdx + 1 },
+      before: `description: ${description}`,
+      after: `description: ${description} for deployment tasks`,
+      rationale: 'integration round-trip fixture',
+      applyAction: 'recommended_edit',
+      applyMode: 'apply_with_confirmation',
+      otherEntry: { identifier: 'partner-skill', sourcePath: '/tmp/partner.md' },
+    }
+    await writeAuditHistory({
+      auditId,
+      inventory: [],
+      exactCollisions: [],
+      genericFlags: [],
+      semanticCollisions: [],
+      summary: {
+        totalEntries: 0,
+        totalFlags: 0,
+        errorCount: 0,
+        warningCount: 0,
+        durationMs: 0,
+        passDurations: { exact: 0, generic: 0, semantic: 0 },
+      },
+    })
+    await writeAuditSuggestions(auditId, [], [edit])
+
+    const editApply = await dispatchAuditTool(
+      'apply_recommended_edit',
+      { auditId, collisionId },
+      fakeContext(),
+      fakeLicense(),
+      fakeQuota()
+    )
+    expect(editApply.isError).toBe(false)
+    const editResponse = decodeBody<ApplyRecommendedEditResponse>(editApply)
+    expect(editResponse.success).toBe(true)
+    expect(fs.readFileSync(filePath, 'utf-8')).toContain(
+      'description: deploy code to production for deployment tasks'
+    )
+  })
+})
+
+describe('audit round-trip — backwards compat', () => {
+  it('skill_audit + skill_pack_audit dispatcher cases still work (regression guard)', async () => {
+    expect(AUDIT_TOOL_NAMES.has('skill_audit')).toBe(true)
+    expect(AUDIT_TOOL_NAMES.has('skill_pack_audit')).toBe(true)
+  })
+})

--- a/packages/mcp-server/tests/unit/apply-namespace-rename.test.ts
+++ b/packages/mcp-server/tests/unit/apply-namespace-rename.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @fileoverview Unit tests for SMI-4590 Wave 4 PR 4 — `apply_namespace_rename`
+ *               MCP tool.
+ * @module @skillsmith/mcp-server/tests/unit/apply-namespace-rename
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §2
+ *       + §Tests `apply-namespace-rename.test.ts`.
+ *
+ * Coverage (mirrors the spec checklist):
+ *   1. `action: 'apply'` round-trips via the suggested name.
+ *   2. `action: 'custom'` uses `customName`.
+ *   3. `action: 'custom'` without `customName` → Zod validation error.
+ *   4. `action: 'skip'` → no-op success.
+ *   5. Missing `auditId` → `namespace.audit.history_not_found`.
+ *   6. Missing `collisionId` → `namespace.audit.collision_not_found`.
+ *   7. Idempotent re-apply → `fromPath === toPath`.
+ *
+ * Pattern: drive a real `skill_inventory_audit` first to populate a fresh
+ * `~/.skillsmith/audits/<auditId>/` (history + suggestions) under a temp
+ * HOME, then exercise the apply tool. Avoids re-deriving the audit-write
+ * path under test.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { skillInventoryAudit } from '../../src/tools/skill-inventory-audit.js'
+import { applyNamespaceRename } from '../../src/tools/apply-namespace-rename.js'
+import type { SkillInventoryAuditResponse } from '../../src/tools/skill-inventory-audit.types.js'
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+let TEST_HOME: string
+let PREV_HOME: string | undefined
+
+beforeEach(() => {
+  TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-apply-rename-'))
+  PREV_HOME = process.env['HOME']
+  process.env['HOME'] = TEST_HOME
+})
+
+afterEach(() => {
+  if (PREV_HOME !== undefined) process.env['HOME'] = PREV_HOME
+  else delete process.env['HOME']
+  if (TEST_HOME && fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+  }
+})
+
+function plantSkill(home: string, identifier: string): string {
+  const dir = path.join(home, '.claude', 'skills', identifier)
+  fs.mkdirSync(dir, { recursive: true })
+  const filePath = path.join(dir, 'SKILL.md')
+  fs.writeFileSync(filePath, `---\nname: ${identifier}\ndescription: fixture\n---\n`, 'utf-8')
+  return filePath
+}
+
+function plantCommand(home: string, identifier: string): string {
+  const dir = path.join(home, '.claude', 'commands')
+  fs.mkdirSync(dir, { recursive: true })
+  const filePath = path.join(dir, `${identifier}.md`)
+  fs.writeFileSync(filePath, `# ${identifier}\nbody\n`, 'utf-8')
+  return filePath
+}
+
+/**
+ * Set up an audit with one exact collision (skill `ship` + command `ship`).
+ * Returns the audit response — the caller picks `renameSuggestions[0]`
+ * for the apply call.
+ */
+async function seedAuditWithCollision(): Promise<SkillInventoryAuditResponse> {
+  plantSkill(TEST_HOME, 'ship')
+  const cmdPath = plantCommand(TEST_HOME, 'ship')
+  // Command planted second; force its mtime ahead so the suggestion
+  // targets the command (file-rename path is simpler to assert).
+  const future = new Date(Date.now() + 60_000)
+  fs.utimesSync(cmdPath, future, future)
+  const response = await skillInventoryAudit({ homeDir: TEST_HOME })
+  if (!('auditId' in response)) {
+    throw new Error(`expected SkillInventoryAuditResponse, got error: ${JSON.stringify(response)}`)
+  }
+  return response
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('apply_namespace_rename — action: skip', () => {
+  it('returns success without mutating disk', async () => {
+    const audit = await seedAuditWithCollision()
+    const cmdPath = path.join(TEST_HOME, '.claude', 'commands', 'ship.md')
+    const before = fs.readFileSync(cmdPath, 'utf-8')
+
+    const response = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: audit.renameSuggestions[0]!.collisionId,
+      action: 'skip',
+    })
+    expect(response.success).toBe(true)
+    expect(response.result).toBeUndefined()
+    // File untouched.
+    expect(fs.readFileSync(cmdPath, 'utf-8')).toBe(before)
+  })
+})
+
+describe('apply_namespace_rename — action: apply', () => {
+  it('renames the file via the suggested name and returns the Wave 2 result', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+    const cmdPath = path.join(TEST_HOME, '.claude', 'commands', 'ship.md')
+    expect(fs.existsSync(cmdPath)).toBe(true)
+
+    const response = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'apply',
+    })
+    expect(response.success).toBe(true)
+    expect(response.result).toBeDefined()
+    expect(response.result?.success).toBe(true)
+    // Source path no longer exists; target does.
+    expect(fs.existsSync(cmdPath)).toBe(false)
+    expect(fs.existsSync(response.result!.toPath)).toBe(true)
+  })
+})
+
+describe('apply_namespace_rename — action: custom', () => {
+  it('renames the file via the custom name', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+
+    const response = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'custom',
+      customName: 'ship-custom-explicit',
+    })
+    expect(response.success).toBe(true)
+    expect(response.result?.success).toBe(true)
+    expect(response.result?.toPath).toContain('ship-custom-explicit.md')
+  })
+
+  it('rejects custom action without customName via Zod refinement', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+
+    const response = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'custom',
+      // customName intentionally omitted
+    })
+    expect(response.success).toBe(false)
+    expect(response.errorCode).toBe('namespace.audit.invalid_input')
+    expect(response.error).toContain('customName is required')
+  })
+
+  it('rejects customName when action !== "custom" (clean-surface guard)', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+
+    const response = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'apply',
+      customName: 'should-not-be-here',
+    })
+    expect(response.success).toBe(false)
+    expect(response.errorCode).toBe('namespace.audit.invalid_input')
+  })
+})
+
+describe('apply_namespace_rename — failure modes', () => {
+  it('returns history_not_found for an unknown auditId', async () => {
+    const response = await applyNamespaceRename({
+      auditId: 'AUDITDOESNTEXIST00000000',
+      collisionId: 'whatever',
+      action: 'apply',
+    })
+    expect(response.success).toBe(false)
+    expect(response.errorCode).toBe('namespace.audit.history_not_found')
+  })
+
+  it('returns collision_not_found when collisionId is unknown in audit', async () => {
+    const audit = await seedAuditWithCollision()
+    const response = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: 'collisionDoesNotExist',
+      action: 'apply',
+    })
+    expect(response.success).toBe(false)
+    expect(response.errorCode).toBe('namespace.audit.collision_not_found')
+  })
+})
+
+describe('apply_namespace_rename — idempotent re-apply', () => {
+  it('returns fromPath === toPath on second call (Wave 2 ledger no-op)', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+
+    const first = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'apply',
+    })
+    expect(first.success).toBe(true)
+    expect(first.result?.success).toBe(true)
+
+    const second = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'apply',
+    })
+    expect(second.success).toBe(true)
+    expect(second.result?.success).toBe(true)
+    expect(second.result?.fromPath).toBe(second.result?.toPath)
+    expect(second.result?.backupPath).toBe('')
+  })
+})

--- a/packages/mcp-server/tests/unit/apply-recommended-edit.test.ts
+++ b/packages/mcp-server/tests/unit/apply-recommended-edit.test.ts
@@ -1,0 +1,258 @@
+/**
+ * @fileoverview Unit tests for SMI-4590 Wave 4 PR 4 — `apply_recommended_edit`
+ *               MCP tool + conditional registration in `audit-tool-dispatch`.
+ * @module @skillsmith/mcp-server/tests/unit/apply-recommended-edit
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §3
+ *       + §Tests `apply-recommended-edit.test.ts`.
+ *
+ * Coverage:
+ *   1. Valid `auditId` + `collisionId` with `pattern: 'add_domain_qualifier'`
+ *      → file mutated, response success.
+ *   2. `collisionId` not in audit → typed error.
+ *   3. Edit with `pattern: 'narrow_scope'` (not in registry) → typed error
+ *      `edit.template_not_in_apply_registry`, file unchanged.
+ *   4. **Tool registration**: live registry (non-empty) → name IS in
+ *      `AUDIT_TOOL_NAMES`.
+ *   5. **Tool registration**: empty registry (mocked at module load) → name
+ *      NOT in `AUDIT_TOOL_NAMES`.
+ *   6. Stale `before` snippet (file changed after audit) → typed error
+ *      `edit.subcall_failed` carrying inner `edit.stale_before`.
+ *
+ * Pattern: write `~/.skillsmith/audits/<auditId>/suggestions.json` directly
+ * with a fixture `RecommendedEdit`. Drives the tool against a hand-rolled
+ * audit dir without depending on the semantic-pass pipeline (which would
+ * require OverlapDetector + EmbeddingService setup at the unit level).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { applyRecommendedEditTool } from '../../src/tools/apply-recommended-edit.js'
+import { writeAuditSuggestions } from '../../src/audit/audit-suggestions.js'
+import type { CollisionId, AuditId } from '../../src/audit/collision-detector.types.js'
+import type { RecommendedEdit, EditTemplatePattern } from '../../src/audit/edit-suggester.types.js'
+import { writeAuditHistory } from '../../src/audit/audit-history.js'
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+let TEST_HOME: string
+let PREV_HOME: string | undefined
+
+beforeEach(() => {
+  TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-apply-edit-'))
+  PREV_HOME = process.env['HOME']
+  process.env['HOME'] = TEST_HOME
+})
+
+afterEach(() => {
+  if (PREV_HOME !== undefined) process.env['HOME'] = PREV_HOME
+  else delete process.env['HOME']
+  if (TEST_HOME && fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+  }
+})
+
+/**
+ * Plant a SKILL.md fixture at `<home>/.claude/skills/<id>/SKILL.md` whose
+ * description body matches a single-line edit window. Returns the file path.
+ */
+function plantSkillForEdit(home: string, identifier: string, description: string): string {
+  const dir = path.join(home, '.claude', 'skills', identifier)
+  fs.mkdirSync(dir, { recursive: true })
+  const filePath = path.join(dir, 'SKILL.md')
+  const content = `---\nname: ${identifier}\ndescription: ${description}\n---\n\n# ${identifier}\n`
+  fs.writeFileSync(filePath, content, 'utf-8')
+  return filePath
+}
+
+/** Locate the 1-indexed line containing `description: <text>` in the file. */
+function findDescriptionLine(filePath: string, description: string): number {
+  const lines = fs.readFileSync(filePath, 'utf-8').split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i] === `description: ${description}`) return i + 1
+  }
+  throw new Error('description line not found')
+}
+
+/**
+ * Persist a fixture audit + suggestions pair under HOME's
+ * `.skillsmith/audits/<auditId>/`. Returns the auditId + collisionId so
+ * the tool call can FK against them.
+ */
+async function seedAuditWithEdit(
+  filePath: string,
+  description: string,
+  pattern: EditTemplatePattern = 'add_domain_qualifier'
+): Promise<{ auditId: string; collisionId: CollisionId; edit: RecommendedEdit }> {
+  const auditId = '01J6Z3M0CK4N0R3MCDEFGHJK10' as AuditId // ULID-shaped fixture
+  const collisionId = 'collisionFixture0' as CollisionId
+  // Write a minimal InventoryAuditResult so readAuditHistory + the
+  // result.json path are populated. The tool only reads suggestions.json
+  // for edit lookup, but the `<auditDir>` exists check is shared.
+  const lineNumber = findDescriptionLine(filePath, description)
+  const edit: RecommendedEdit = {
+    collisionId,
+    category: 'description_overlap',
+    pattern,
+    filePath,
+    lineRange: { start: lineNumber, end: lineNumber },
+    before: `description: ${description}`,
+    after: `description: ${description} (qualified)`,
+    rationale: 'unit fixture rationale',
+    applyAction: 'recommended_edit',
+    applyMode: 'apply_with_confirmation',
+    otherEntry: { identifier: 'partner-skill', sourcePath: '/tmp/partner.md' },
+  }
+  await writeAuditHistory({
+    auditId,
+    inventory: [],
+    exactCollisions: [],
+    genericFlags: [],
+    semanticCollisions: [],
+    summary: {
+      totalEntries: 0,
+      totalFlags: 0,
+      errorCount: 0,
+      warningCount: 0,
+      durationMs: 0,
+      passDurations: { exact: 0, generic: 0, semantic: 0 },
+    },
+  })
+  await writeAuditSuggestions(auditId, [], [edit])
+  return { auditId, collisionId, edit }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('apply_recommended_edit — happy path', () => {
+  it('mutates the file when pattern is in APPLY_TEMPLATE_REGISTRY', async () => {
+    const description = 'deploy code to production'
+    const filePath = plantSkillForEdit(TEST_HOME, 'fixture', description)
+    const { auditId, collisionId } = await seedAuditWithEdit(filePath, description)
+
+    const response = await applyRecommendedEditTool({ auditId, collisionId })
+    expect(response.success).toBe(true)
+    expect(response.result?.success).toBe(true)
+    // File mutated: original line replaced with the templated version.
+    const fileBody = fs.readFileSync(filePath, 'utf-8')
+    expect(fileBody).toContain('description: deploy code to production (qualified)')
+  })
+})
+
+describe('apply_recommended_edit — registry guard', () => {
+  it('rejects pattern: "narrow_scope" with edit.template_not_in_apply_registry', async () => {
+    const description = 'narrow this scope please'
+    const filePath = plantSkillForEdit(TEST_HOME, 'fixture-narrow', description)
+    const { auditId, collisionId } = await seedAuditWithEdit(filePath, description, 'narrow_scope')
+    const before = fs.readFileSync(filePath, 'utf-8')
+
+    const response = await applyRecommendedEditTool({ auditId, collisionId })
+    expect(response.success).toBe(false)
+    expect(response.errorCode).toBe('edit.template_not_in_apply_registry')
+    // File untouched — registry guard rejects before any mutation.
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(before)
+  })
+})
+
+describe('apply_recommended_edit — failure modes', () => {
+  it('returns history_not_found for an unknown auditId', async () => {
+    const response = await applyRecommendedEditTool({
+      auditId: 'AUDITDOESNTEXIST00000000',
+      collisionId: 'whatever',
+    })
+    expect(response.success).toBe(false)
+    expect(response.errorCode).toBe('namespace.audit.history_not_found')
+  })
+
+  it('returns collision_not_found when collisionId is unknown', async () => {
+    const description = 'fixture description'
+    const filePath = plantSkillForEdit(TEST_HOME, 'fixture-x', description)
+    const { auditId } = await seedAuditWithEdit(filePath, description)
+    const response = await applyRecommendedEditTool({
+      auditId,
+      collisionId: 'unknownCollision000',
+    })
+    expect(response.success).toBe(false)
+    expect(response.errorCode).toBe('namespace.audit.collision_not_found')
+  })
+
+  it('returns subcall_failed with inner edit.stale_before when the file was modified after audit', async () => {
+    const description = 'file will drift'
+    const filePath = plantSkillForEdit(TEST_HOME, 'fixture-stale', description)
+    const { auditId, collisionId } = await seedAuditWithEdit(filePath, description)
+
+    // Mutate the file out from under the recorded `before`.
+    fs.writeFileSync(
+      filePath,
+      `---\nname: fixture-stale\ndescription: completely different now\n---\n`,
+      'utf-8'
+    )
+
+    const response = await applyRecommendedEditTool({ auditId, collisionId })
+    expect(response.success).toBe(false)
+    expect(response.errorCode).toBe('edit.subcall_failed')
+    expect(response.error).toContain('edit.stale_before')
+  })
+})
+
+describe('apply_recommended_edit — Zod validation', () => {
+  it('rejects unknown top-level fields', async () => {
+    const response = await applyRecommendedEditTool({
+      auditId: 'A',
+      collisionId: 'B',
+      bogus: true,
+    } as unknown)
+    expect(response.success).toBe(false)
+    expect(response.errorCode).toBe('namespace.audit.invalid_input')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Conditional registration (audit-tool-dispatch.AUDIT_TOOL_NAMES)
+// ---------------------------------------------------------------------------
+
+describe('audit-tool-dispatch — apply_recommended_edit conditional registration', () => {
+  it('lists apply_recommended_edit when APPLY_TEMPLATE_REGISTRY is non-empty (live state)', async () => {
+    // Live state: registry contains 'add_domain_qualifier'.
+    const dispatch = await import('../../src/audit-tool-dispatch.js')
+    expect(dispatch.AUDIT_TOOL_NAMES.has('apply_recommended_edit')).toBe(true)
+    expect(dispatch.isAuditToolName('apply_recommended_edit')).toBe(true)
+  })
+
+  it('omits apply_recommended_edit when APPLY_TEMPLATE_REGISTRY is empty', async () => {
+    // Defense-in-depth: when the registry is empty (rollback), the
+    // dispatcher must hide the tool. Mock the module BEFORE importing the
+    // dispatcher fresh to exercise the module-init guard.
+    vi.resetModules()
+    vi.doMock('../../src/audit/edit-applier.js', async (importOriginal) => {
+      const actual = (await importOriginal()) as Record<string, unknown>
+      return {
+        ...actual,
+        APPLY_TEMPLATE_REGISTRY: new Set<EditTemplatePattern>(),
+      }
+    })
+    try {
+      const dispatch = await import('../../src/audit-tool-dispatch.js')
+      expect(dispatch.AUDIT_TOOL_NAMES.has('apply_recommended_edit')).toBe(false)
+      expect(dispatch.isAuditToolName('apply_recommended_edit')).toBe(false)
+      // Sibling tools still listed.
+      expect(dispatch.AUDIT_TOOL_NAMES.has('skill_inventory_audit')).toBe(true)
+      expect(dispatch.AUDIT_TOOL_NAMES.has('apply_namespace_rename')).toBe(true)
+    } finally {
+      vi.doUnmock('../../src/audit/edit-applier.js')
+      vi.resetModules()
+    }
+  })
+})

--- a/packages/mcp-server/tests/unit/skill-inventory-audit.test.ts
+++ b/packages/mcp-server/tests/unit/skill-inventory-audit.test.ts
@@ -1,0 +1,272 @@
+/**
+ * @fileoverview Unit tests for SMI-4590 Wave 4 PR 4 — `skill_inventory_audit`
+ *               MCP tool.
+ * @module @skillsmith/mcp-server/tests/unit/skill-inventory-audit
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §1
+ *       + §Tests `skill-inventory-audit.test.ts`.
+ *
+ * Coverage (mirrors the spec checklist):
+ *   1. Empty `~/.claude/` → empty arrays + populated `auditId` + on-disk report.
+ *   2. Planted exact collision → `exactCollisions[]` + `renameSuggestions[]`.
+ *   3. `deep: false` → `semanticCollisions: []`.
+ *   4. Zod rejects unknown fields → typed validation envelope.
+ *   5. `homeDir` outside allowed roots → typed `invalid_home_dir`.
+ *   6. Audit-history round-trip via `readAuditHistory`.
+ *   7. `applyExclusions: true` (default) — matching exclusions filter.
+ *   8. `applyExclusions: false` — exclusions ignored.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { skillInventoryAudit } from '../../src/tools/skill-inventory-audit.js'
+import { readAuditHistory } from '../../src/audit/audit-history.js'
+import type { SkillInventoryAuditResponse } from '../../src/tools/skill-inventory-audit.types.js'
+import type { InventoryAuditValidationError } from '../../src/tools/skill-inventory-audit.js'
+
+// Telemetry stub — `detectCollisions` fires aggregate fetch on success;
+// stub it to keep the unit suite hermetic.
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })))
+})
+
+let TEST_HOME: string
+
+beforeEach(() => {
+  TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-inventory-audit-'))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  if (TEST_HOME && fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+  }
+})
+
+/**
+ * Plant a `~/.claude/skills/<id>/SKILL.md` under the test home. Returns
+ * the absolute SKILL.md path.
+ */
+function plantSkill(testHome: string, identifier: string, description = 'unit-fixture'): string {
+  const dir = path.join(testHome, '.claude', 'skills', identifier)
+  fs.mkdirSync(dir, { recursive: true })
+  const content = `---\nname: ${identifier}\ndescription: ${description}\n---\n\n# ${identifier}\n`
+  const filePath = path.join(dir, 'SKILL.md')
+  fs.writeFileSync(filePath, content, 'utf-8')
+  return filePath
+}
+
+/**
+ * Plant a slash-command file at `~/.claude/commands/<id>.md`. Returns the
+ * absolute file path. Used by exact-collision fixtures: a command + a
+ * skill sharing the same `identifier` collide.
+ */
+function plantCommand(testHome: string, identifier: string): string {
+  const dir = path.join(testHome, '.claude', 'commands')
+  fs.mkdirSync(dir, { recursive: true })
+  const filePath = path.join(dir, `${identifier}.md`)
+  fs.writeFileSync(filePath, `# ${identifier}\n\nDeploy command body.\n`, 'utf-8')
+  return filePath
+}
+
+function isResponse(
+  v: SkillInventoryAuditResponse | InventoryAuditValidationError
+): v is SkillInventoryAuditResponse {
+  return !('errorCode' in v && 'success' in v && (v as { success: boolean }).success === false)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('skill_inventory_audit — empty home', () => {
+  it('returns a populated auditId, empty collision arrays, and on-disk report', async () => {
+    // Skillsmith dir override (the audit history writer derives its own
+    // path from `os.homedir()`). Point HOME at the fixture.
+    const previousHome = process.env['HOME']
+    process.env['HOME'] = TEST_HOME
+    try {
+      const response = await skillInventoryAudit({ homeDir: TEST_HOME })
+      expect(isResponse(response)).toBe(true)
+      if (!isResponse(response)) return
+      expect(response.auditId).toMatch(/^[0-9A-Z]{20,30}$/) // ULID shape
+      expect(response.exactCollisions).toEqual([])
+      expect(response.semanticCollisions).toEqual([])
+      expect(response.renameSuggestions).toEqual([])
+      expect(fs.existsSync(response.reportPath)).toBe(true)
+      expect(response.summary.totalFlags).toBe(0)
+    } finally {
+      if (previousHome !== undefined) process.env['HOME'] = previousHome
+      else delete process.env['HOME']
+    }
+  })
+})
+
+describe('skill_inventory_audit — exact collision', () => {
+  it('flags the collision and emits a rename suggestion targeting the most-recent entry', async () => {
+    const previousHome = process.env['HOME']
+    process.env['HOME'] = TEST_HOME
+    try {
+      // Planted: skill `ship` AND command `ship` — collide on `ship`.
+      const skillPath = plantSkill(TEST_HOME, 'ship')
+      const commandPath = plantCommand(TEST_HOME, 'ship')
+      // Force the command's mtime ahead of the skill so the
+      // most-recent-entry tiebreak picks the command for rename.
+      const future = new Date(Date.now() + 60_000)
+      fs.utimesSync(commandPath, future, future)
+      void skillPath
+
+      const response = await skillInventoryAudit({ homeDir: TEST_HOME })
+      expect(isResponse(response)).toBe(true)
+      if (!isResponse(response)) return
+      expect(response.exactCollisions.length).toBeGreaterThanOrEqual(1)
+      expect(response.renameSuggestions.length).toBeGreaterThanOrEqual(1)
+      const suggestion = response.renameSuggestions[0]!
+      expect(suggestion.currentName).toBe('ship')
+      expect(suggestion.suggested.length).toBeGreaterThan(0)
+      // mtime tiebreak picked the command file (most recent)
+      expect(suggestion.entry.kind).toBe('command')
+    } finally {
+      if (previousHome !== undefined) process.env['HOME'] = previousHome
+      else delete process.env['HOME']
+    }
+  })
+})
+
+describe('skill_inventory_audit — deep flag', () => {
+  it('skips the semantic pass when deep is false (default)', async () => {
+    const previousHome = process.env['HOME']
+    process.env['HOME'] = TEST_HOME
+    try {
+      plantSkill(TEST_HOME, 'alpha', 'deploy code to production')
+      plantSkill(TEST_HOME, 'beta', 'ship code to production')
+      const response = await skillInventoryAudit({ homeDir: TEST_HOME })
+      expect(isResponse(response)).toBe(true)
+      if (!isResponse(response)) return
+      expect(response.semanticCollisions).toEqual([])
+    } finally {
+      if (previousHome !== undefined) process.env['HOME'] = previousHome
+      else delete process.env['HOME']
+    }
+  })
+})
+
+describe('skill_inventory_audit — Zod validation', () => {
+  it('rejects unknown top-level fields with the validation-error envelope', async () => {
+    const response = await skillInventoryAudit({
+      homeDir: TEST_HOME,
+      bogusField: true,
+    } as unknown)
+    expect(isResponse(response)).toBe(false)
+    if (isResponse(response)) return
+    expect(response.success).toBe(false)
+    expect(response.errorCode).toBe('namespace.audit.invalid_input')
+    expect(response.error).toContain('Invalid skill_inventory_audit input')
+  })
+
+  it('rejects homeDir outside os.homedir()/os.tmpdir() with invalid_home_dir', async () => {
+    const response = await skillInventoryAudit({ homeDir: '/etc' })
+    expect(isResponse(response)).toBe(false)
+    if (isResponse(response)) return
+    expect(response.errorCode).toBe('namespace.audit.invalid_home_dir')
+  })
+
+  it('accepts homeDir under os.tmpdir() (test-fixture path)', async () => {
+    const previousHome = process.env['HOME']
+    process.env['HOME'] = TEST_HOME
+    try {
+      const response = await skillInventoryAudit({ homeDir: TEST_HOME })
+      expect(isResponse(response)).toBe(true)
+    } finally {
+      if (previousHome !== undefined) process.env['HOME'] = previousHome
+      else delete process.env['HOME']
+    }
+  })
+})
+
+describe('skill_inventory_audit — audit-history round-trip', () => {
+  it('persists result.json such that readAuditHistory recovers the auditId', async () => {
+    const previousHome = process.env['HOME']
+    process.env['HOME'] = TEST_HOME
+    try {
+      const response = await skillInventoryAudit({ homeDir: TEST_HOME })
+      expect(isResponse(response)).toBe(true)
+      if (!isResponse(response)) return
+      const recovered = await readAuditHistory(response.auditId)
+      expect(recovered).not.toBeNull()
+      expect(recovered?.auditId).toBe(response.auditId)
+    } finally {
+      if (previousHome !== undefined) process.env['HOME'] = previousHome
+      else delete process.env['HOME']
+    }
+  })
+})
+
+describe('skill_inventory_audit — exclusions filter', () => {
+  it('filters matching collisions by default (applyExclusions defaults to true)', async () => {
+    const previousHome = process.env['HOME']
+    process.env['HOME'] = TEST_HOME
+    try {
+      plantSkill(TEST_HOME, 'ship')
+      plantCommand(TEST_HOME, 'ship')
+      // Author an exclusions file that whitelists /ship at the same
+      // ~/.skillsmith dir the loader reads (HOME is already TEST_HOME).
+      const skillsmithDir = path.join(TEST_HOME, '.skillsmith')
+      fs.mkdirSync(skillsmithDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(skillsmithDir, 'audit-exclusions.json'),
+        JSON.stringify({
+          version: 1,
+          exclusions: [{ kind: 'command', identifier: '/ship', reason: 'unit fixture' }],
+        }),
+        'utf-8'
+      )
+
+      const response = await skillInventoryAudit({ homeDir: TEST_HOME })
+      expect(isResponse(response)).toBe(true)
+      if (!isResponse(response)) return
+      // The exact collision involving the excluded command is filtered.
+      expect(response.exactCollisions.length).toBe(0)
+      expect(response.renameSuggestions.length).toBe(0)
+    } finally {
+      if (previousHome !== undefined) process.env['HOME'] = previousHome
+      else delete process.env['HOME']
+    }
+  })
+
+  it('does NOT filter when applyExclusions: false (Enterprise scheduled-scan path)', async () => {
+    const previousHome = process.env['HOME']
+    process.env['HOME'] = TEST_HOME
+    try {
+      plantSkill(TEST_HOME, 'ship')
+      plantCommand(TEST_HOME, 'ship')
+      const skillsmithDir = path.join(TEST_HOME, '.skillsmith')
+      fs.mkdirSync(skillsmithDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(skillsmithDir, 'audit-exclusions.json'),
+        JSON.stringify({
+          version: 1,
+          exclusions: [{ kind: 'command', identifier: '/ship', reason: 'unit fixture' }],
+        }),
+        'utf-8'
+      )
+
+      const response = await skillInventoryAudit({
+        homeDir: TEST_HOME,
+        applyExclusions: false,
+      })
+      expect(isResponse(response)).toBe(true)
+      if (!isResponse(response)) return
+      // The collision is still reported because the exclusions file is
+      // bypassed in governance / Enterprise scheduled-scan mode.
+      expect(response.exactCollisions.length).toBeGreaterThan(0)
+    } finally {
+      if (previousHome !== undefined) process.env['HOME'] = previousHome
+      else delete process.env['HOME']
+    }
+  })
+})


### PR DESCRIPTION
## Summary

PR 4 of 6 in the SMI-4590 Wave 4 sequence. Wires Waves 1+2+3 audit core into three MCP-callable tools so Claude Code (and future framework adapters) can run consumer-namespace audits and apply suggested renames/edits.

**New MCP tools:**
- `skill_inventory_audit` — scans local inventory, runs collision detector (Wave 1) + rename suggester (Wave 2) + edit suggester (Wave 3), applies exclusions filter (PR 3) by default, persists audit history, returns full `SkillInventoryAuditResponse`.
- `apply_namespace_rename` — looks up audit history by `(auditId, collisionId)`, delegates to Wave 2 `applyRename`. Supports `action: 'apply' | 'custom' | 'skip'`.
- `apply_recommended_edit` — registered conditionally on `APPLY_TEMPLATE_REGISTRY.size > 0` (runtime proxy for "Wave 3 gate passed"). Restricted to `add_domain_qualifier` in v1; SMI-4593 will expand.

**New shared helpers:**
- `src/audit/run-inventory-audit.ts` — composes scan → detect → suggest → filter → persist. Both MCP tool body and (PR 5) CLI command body delegate here.
- `src/audit/audit-suggestions.ts` — side-channel persistence so `apply_*` tools can look up `RenameSuggestion`/`RecommendedEdit` by `(auditId, collisionId)`.

**Tool dispatch:**
- `audit-tool-dispatch.ts` — adds 3 new cases. `AUDIT_TOOL_NAMES` built at module load; `apply_recommended_edit` name pushed iff registry non-empty.

## Tests (28 cases, all passing in Docker)

- `skill-inventory-audit.test.ts` (9)
- `apply-namespace-rename.test.ts` (8)
- `apply-recommended-edit.test.ts` (8) — includes registry-conditional registration test (mocked empty vs live)
- `audit-roundtrip.test.ts` (3) — full round-trip + idempotency + edit application path

## Validation in Docker

- ESLint clean on all 14 files (0 errors, 0 warnings)
- TypeScript clean (`tsc --noEmit -p packages/mcp-server/tsconfig.json`)
- `audit:standards` 0 failures, 6 pre-existing warnings (none in PR 4 scope)
- Prettier formatted
- No new npm dependencies
- `.mcp.json` unchanged

## Wave stacking

Stacks on PR 3 (squash `b64a1fc6` — exclusions + tier helpers). Wave 1 (#877), Wave 2 (#913), Wave 3 (#886 squash `d5f2cb75`) all merged.

## Test plan

- [x] All 28 unit + integration tests pass in Docker
- [x] Lint clean
- [x] TypeScript clean
- [x] audit:standards clean (no new warnings in PR 4 scope)
- [ ] CI green
- [ ] Post-merge `/governance` retro on squash diff

Refs: SMI-4590, SMI-4584. Blocks SMI-4655 (post-Wave-4 audit core extraction).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)