### PR TITLE
fix(audit): SMI-4733 — replace polynomial-redos regexes with trimEnd + length cap

### DIFF
--- a/packages/mcp-server/src/audit/audit-report-writer.ts
+++ b/packages/mcp-server/src/audit/audit-report-writer.ts
@@ -121,8 +121,11 @@ export function renderAuditReport(
     sections.push(renderRecommendedEditsSection(opts.recommendedEdits))
   }
 
-  // Single trailing newline; sections already terminate with `\n`.
-  return sections.join('\n').replace(/\n+$/, '\n')
+  // Single trailing newline. `trimEnd()` (not `/\n+$/`) is intentional —
+  // see SMI-4733: any non-`\n` trailing whitespace that leaks in is
+  // acceptable to strip in an ASCII report, and the non-regex form
+  // sidesteps polynomial backtracking flagged by CodeQL.
+  return sections.join('\n').trimEnd() + '\n'
 }
 
 /**

--- a/packages/mcp-server/src/audit/suggestion-chain.ts
+++ b/packages/mcp-server/src/audit/suggestion-chain.ts
@@ -33,6 +33,8 @@ import * as crypto from 'node:crypto'
 import type { InventoryEntry } from './collision-detector.types.js'
 import type { SuggestionChain } from './rename-engine.types.js'
 
+const SANITIZE_MAX_LENGTH = 256
+
 /**
  * Compute the deterministic 4-char `shortHash` suffix used at chain tier 3.
  * Exported for tests; in normal flow callers use `generateSuggestionChain`.
@@ -52,6 +54,15 @@ export function computeShortHash(
  * consecutive separators. Mirrors the rule in plan §1 step 1.
  */
 export function sanitizeSegment(raw: string): string {
+  // Defense-in-depth length cap (SMI-4733): guards against polynomial
+  // backtracking on the regex chain below when callers pass unbounded
+  // input (e.g. `packDomain` from manifest, `token` from skillId). An
+  // empty segment falls through tier construction in
+  // `generateSuggestionChain` — same fall-through behavior as a
+  // pathologically un-sanitizable input.
+  if (raw.length > SANITIZE_MAX_LENGTH) {
+    return ''
+  }
   return raw
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')

--- a/packages/mcp-server/tests/unit/audit-report-writer.test.ts
+++ b/packages/mcp-server/tests/unit/audit-report-writer.test.ts
@@ -12,11 +12,13 @@ import * as path from 'node:path'
 import { renderAuditReport, writeAuditReport } from '../../src/audit/audit-report-writer.js'
 import { newAuditId } from '../../src/audit/audit-history.js'
 import type {
+  CollisionId,
   ExactCollisionFlag,
   GenericTokenFlag,
   InventoryAuditResult,
   SemanticCollisionFlag,
 } from '../../src/audit/collision-detector.types.js'
+import type { RecommendedEdit } from '../../src/audit/edit-suggester.types.js'
 import type { InventoryEntry } from '../../src/utils/local-inventory.types.js'
 
 let TEST_DIR: string
@@ -203,6 +205,44 @@ describe('renderAuditReport — full result with all 3 collision kinds', () => {
     // Summary totals reflect 1 error + 2 warnings.
     expect(md).toContain('Errors (exact collisions): 1')
     expect(md).toContain('Warnings (generic + semantic): 2')
+  })
+})
+
+describe('renderAuditReport — SMI-4733 ReDoS hardening', () => {
+  it('handles input with many trailing newlines', () => {
+    // Construct a `RecommendedEdit` whose `before` snippet contains 1000
+    // consecutive `\n` chars. The renderer splits `before` on `\n` and
+    // emits each as a `-`-prefixed diff line — those propagate into the
+    // joined-section input that the trailing-newline trim runs against.
+    // Pre-fix code used `/\n+$/` (polynomial backtracking on this shape);
+    // the trimEnd-based replacement is O(n) linear. Regression gate is
+    // the CodeQL re-scan — we only assert correctness here.
+    const edit: RecommendedEdit = {
+      collisionId: '00112233aabbccdd' as CollisionId,
+      category: 'description_overlap',
+      pattern: 'add_domain_qualifier',
+      filePath: '/tmp/SKILL.md',
+      lineRange: { start: 1, end: 2 },
+      before: '\n'.repeat(1000),
+      after: 'description: ship a release for codehelper tasks',
+      rationale: 'differentiates from another skill',
+      applyAction: 'recommended_edit',
+      applyMode: 'apply_with_confirmation',
+      otherEntry: { identifier: 'release-tools', sourcePath: '/tmp/release-tools/SKILL.md' },
+    }
+    const md = renderAuditReport(emptyResult(), { recommendedEdits: [edit] })
+    expect(md.endsWith('\n')).toBe(true)
+    expect(md.endsWith('\n\n')).toBe(false)
+  })
+
+  it('handles empty result', () => {
+    // Regression test for the `trimEnd()` edge: ensures even a minimally-
+    // populated report (summary header only — no collision sections) ends
+    // with exactly one `\n` and is non-empty.
+    const md = renderAuditReport(emptyResult())
+    expect(md.length).toBeGreaterThan(0)
+    expect(md.endsWith('\n')).toBe(true)
+    expect(md.endsWith('\n\n')).toBe(false)
   })
 })
 

--- a/packages/mcp-server/tests/unit/suggestion-chain.test.ts
+++ b/packages/mcp-server/tests/unit/suggestion-chain.test.ts
@@ -37,6 +37,39 @@ describe('sanitizeSegment', () => {
   it('dedupes consecutive separators', () => {
     expect(sanitizeSegment('foo  bar___baz')).toBe('foo-bar-baz')
   })
+
+  // SMI-4733 ReDoS hardening: defense-in-depth length cap at 256 chars.
+  // Two of four callers (`token`, `packDomain`) have no upstream cap;
+  // unbounded input on the regex chain below caused polynomial backtracking
+  // (CodeQL alert 93). CodeQL re-scan is the regression gate; here we
+  // assert correctness.
+  it('accepts 256-char input at boundary', () => {
+    const input = 'a'.repeat(256)
+    expect(sanitizeSegment(input)).toBe(input)
+  })
+
+  it('returns empty string on input > 256 chars; chain falls through that tier', () => {
+    expect(sanitizeSegment('a'.repeat(257))).toBe('')
+
+    // Over-long `packDomain` must not throw; the suggestion chain falls
+    // through to the no-packDomain shape (tier 1 + tier 3 only) per the
+    // existing empty-segment behavior in `generateSuggestionChain`.
+    const result = generateSuggestionChain({
+      token: 'ship',
+      author: 'anthropic',
+      packDomain: 'x'.repeat(300),
+      authorPath: '/repo/x',
+      existingInventory: [],
+    })
+    expect(result.candidates[0]).toBe('anthropic-ship')
+    expect(result.candidates).toHaveLength(2)
+    expect(result.candidates[1]).toMatch(/^anthropic-ship-[0-9a-f]{4}$/)
+    expect(result.exhausted).toBe(false)
+  })
+
+  it('handles 200 dashes (correctness; no timing assertion)', () => {
+    expect(sanitizeSegment('-'.repeat(200) + 'x')).toBe('x')
+  })
 })
 
 describe('computeShortHash', () => {


### PR DESCRIPTION
## Summary

Closes 2 high-severity CodeQL `js/polynomial-redos` alerts in `packages/mcp-server/src/audit/`:

- **Alert 92** (`audit-report-writer.ts:125`): `/\n+$/` → `trimEnd() + '\n'`. Drops the regex; `String#trimEnd()` is O(n). Reachable via untrusted SKILL.md prose flowing through `RecommendedEdit.before/after` (input-flow audit in plan).
- **Alert 93** (`suggestion-chain.ts:54`): defense-in-depth 256-char input cap on `sanitizeSegment`. Returns `''` on overflow — matches the existing empty-segment fall-through in `generateSuggestionChain` (lines 125-127, 131, 136), so audits keep completing on adversarial manifests instead of throwing. Two of four callers (`token`, `packDomain`) lack upstream caps; SMI-4737 closes that loop.

The regexes themselves are otherwise correct character-class normalization; we keep them intact and add the cap as a guard.

## Plan + review

- Plan: `docs/internal/implementation/smi-4733-redos-audit-regex-hardening.md` (plan-reviewed; 6 VP findings applied — see Review Summary table).
- Follow-up: SMI-4737 (upstream `token` / `packDomain` validation caps in manifest validators).

## Tests (5 new, 25/25 green in Docker)

`audit-report-writer.test.ts` — +2:
- 1000 consecutive `\n` in `RecommendedEdit.before` → output ends with exactly one `\n` (no trailing pile-up).
- Empty `InventoryAuditResult` → output is non-empty + ends with `\n` (`trimEnd()` edge guard).

`suggestion-chain.test.ts` — +3:
- 256-char boundary inclusive.
- 257-char input → `''` AND `generateSuggestionChain` with 300-char `packDomain` falls through tier 2, returns tier-1 + tier-3 candidates, no exception.
- 200 dashes + `'x'` → `'x'` (correctness only; no wall-clock assertion — CodeQL re-scan is the regression gate).

## Verification (in Docker)

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] Targeted vitest 25/25 pass (audit-report-writer 9/9, suggestion-chain 16/16)
- [x] `npm run audit:standards` (54 passed, 0 failures)
- [x] `npm run preflight` clean
- [x] `.mcp.json` not in commit (worktree auto-patch reverted)
- [ ] CI green
- [ ] CodeQL re-scan: alerts 92 + 93 close
- [ ] Post-merge `/governance` retro on squash diff

## Test plan

- [ ] Confirm CodeQL workflow on this PR closes alerts 92 + 93 (no new alerts introduced)
- [ ] All 13 required CI checks green

Refs: SMI-4733 (this fix), SMI-4737 (upstream validation follow-up).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)