### PR TITLE
test(audit): SMI-4733 governance retro — sharpen test names + comments

### DIFF
--- a/packages/mcp-server/tests/unit/audit-report-writer.test.ts
+++ b/packages/mcp-server/tests/unit/audit-report-writer.test.ts
@@ -236,9 +236,11 @@ describe('renderAuditReport — SMI-4733 ReDoS hardening', () => {
   })
 
   it('handles empty result', () => {
-    // Regression test for the `trimEnd()` edge: ensures even a minimally-
-    // populated report (summary header only — no collision sections) ends
-    // with exactly one `\n` and is non-empty.
+    // Smoke test for the minimally-populated path (summary header only —
+    // no collision sections). Asserts non-empty output ending with exactly
+    // one `\n`. The trailing-newline regression itself is exercised by
+    // the 1000-newline test above; this case just guards against the
+    // empty-section branch returning `''` or losing its terminator.
     const md = renderAuditReport(emptyResult())
     expect(md.length).toBeGreaterThan(0)
     expect(md.endsWith('\n')).toBe(true)

--- a/packages/mcp-server/tests/unit/suggestion-chain.test.ts
+++ b/packages/mcp-server/tests/unit/suggestion-chain.test.ts
@@ -67,7 +67,7 @@ describe('sanitizeSegment', () => {
     expect(result.exhausted).toBe(false)
   })
 
-  it('handles 200 dashes (correctness; no timing assertion)', () => {
+  it('collapses 200 leading dashes to single segment', () => {
     expect(sanitizeSegment('-'.repeat(200) + 'x')).toBe('x')
   })
 })


### PR DESCRIPTION
## Summary

Post-merge `/governance` retro on PR #943 (SMI-4733 ReDoS hardening) surfaced two stylistic Lows in the new tests. Per CLAUDE.md zero-deferral policy ("Do not label findings as 'informational' or 'non-blocking' if they can be resolved now"), fixing in a follow-up PR rather than accepting as-is.

Test-only changes; zero production-code or behavior delta.

## Changes

- `packages/mcp-server/tests/unit/suggestion-chain.test.ts`: rename `'handles 200 dashes (correctness; no timing assertion)'` → `'collapses 200 leading dashes to single segment'`. The parenthetical read as a TODO-shaped disclaimer rather than a behavior name.
- `packages/mcp-server/tests/unit/audit-report-writer.test.ts`: tighten `'handles empty result'` comment so it doesn't claim to test a regression it doesn't actually exercise. The 1000-newline test above is the real ReDoS regression gate; this case is honest smoke coverage of the empty-section branch.

## Verification

- [x] `npx vitest run packages/mcp-server/tests/unit/audit-report-writer.test.ts packages/mcp-server/tests/unit/suggestion-chain.test.ts` — 25/25 pass in Docker
- [x] Pre-commit hook clean (lint + typecheck + format)
- [x] `.mcp.json` not in commit (worktree auto-patch reverted)
- [ ] CI green

## Test plan

- [ ] All required CI checks green
- [ ] No new CodeQL alerts (no source code changed)

Refs: SMI-4733 (parent), governance retro on PR #943.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)