### PR TITLE
feat(cli): SMI-4590 Wave 4 PR 5/6 — sklx audit collisions + sklx config set audit_mode

### DIFF
--- a/.github/workflows/device-login-roundtrip.yml
+++ b/.github/workflows/device-login-roundtrip.yml
@@ -165,6 +165,7 @@ jobs:
         run: |
           set -eu
           npm run build -w @skillsmith/core
+          npm run build -w @skillsmith/mcp-server
           npm run build -w @skillsmith/cli
           # SMI-4511: derive CLI path from package.json `bin` field rather
           # than hardcoding. Earlier iterations of this workflow hardcoded

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -437,6 +437,94 @@ skillsmith sync config --enable --frequency weekly
 - `--disable` - Disable automatic sync
 - `--frequency <freq>` - Set frequency: `daily` or `weekly`
 
+### audit
+
+#### audit advisories
+
+Check installed skills against known security advisories (Team+ tier). Use `--fix` to attempt updating skills with available patches.
+
+```bash
+# Check all installed skills
+skillsmith audit advisories
+
+# Output as JSON
+skillsmith audit advisories --json
+
+# Auto-update skills with patches
+skillsmith audit advisories --fix
+```
+
+**Options:**
+- `--json` - Emit results as JSON
+- `--fix` - Attempt `skillsmith update` for each advisory with a patch available
+
+#### audit collisions
+
+Audit installed skills for namespace collisions — duplicate tool names across multiple skills that could cause invocation conflicts (Community+).
+
+```bash
+# Interactive audit (prompts for each collision)
+skillsmith audit collisions
+
+# Include semantic-overlap detector pass
+skillsmith audit collisions --deep
+
+# Output raw JSON (no prompts, no file writes)
+skillsmith audit collisions --json
+
+# Accept every suggestion automatically (requires typing APPLY ALL)
+skillsmith audit collisions --apply-all
+
+# Write report only, no interactive prompts
+skillsmith audit collisions --report-only
+
+# Clear the namespace-override ledger (requires typing RESET LEDGER)
+skillsmith audit collisions --reset-ledger
+```
+
+**Options:**
+- `--deep` - Enable semantic-overlap detector pass
+- `--json` - Emit `RunInventoryAuditResult` as JSON; bypasses prompts and file mutation
+- `--apply-all` - Accept every rename suggestion; requires typing `APPLY ALL` to confirm
+- `--report-only` - Write audit report without prompts or apply
+- `--reset-ledger` - Clear `~/.skillsmith/namespace-overrides.json` (backs up first); requires typing `RESET LEDGER`
+
+### config
+
+Get or set Skillsmith configuration values in `~/.skillsmith/config.json`.
+
+#### config get
+
+Print the resolved value of a configuration key.
+
+```bash
+skillsmith config get audit_mode
+```
+
+**Supported keys:** `audit_mode`
+
+The resolved value reflects the config-file entry when set, else the tier default:
+- `community` / `individual` → `preventative`
+- `team` → `power_user`
+- `enterprise` → `governance`
+
+#### config set
+
+Write a configuration value. Tier-revalidated on write — `community` and `individual` users cannot select `power_user` or `governance`.
+
+```bash
+skillsmith config set audit_mode preventative
+skillsmith config set audit_mode power_user    # team/enterprise only
+skillsmith config set audit_mode governance    # enterprise only
+skillsmith config set audit_mode off
+```
+
+**Valid values for `audit_mode`:** `preventative`, `power_user`, `governance`, `off`
+
+**Error codes (stderr, exit 1):**
+- `audit.mode.invalid_value` — value not in the supported set
+- `audit.mode.tier_ineligible` — your tier cannot select the requested mode
+
 ### login
 
 Authenticate the Skillsmith CLI with your API key. Opens your browser to [skillsmith.app/account/cli-token](https://skillsmith.app/account/cli-token), where you generate and copy a key, then paste it into the terminal prompt.

--- a/packages/cli/src/commands/audit-collisions.ts
+++ b/packages/cli/src/commands/audit-collisions.ts
@@ -1,0 +1,397 @@
+/**
+ * @fileoverview `sklx audit collisions` — interactive consumer-namespace audit.
+ * @module @skillsmith/cli/commands/audit-collisions
+ * @see SMI-4590 Wave 4 PR 5/6 §4 + §9
+ *
+ * Sibling of `sklx audit advisories` (Step 0a). Wraps the shared
+ * `runInventoryAudit` helper from `@skillsmith/mcp-server/audit` (PR 4) so
+ * composition logic lives in one place.
+ *
+ * Flags:
+ *   --deep            Opt into the semantic-overlap detector pass.
+ *   --json            Emit `RunInventoryAuditResult` as JSON to stdout.
+ *                     Bypasses prompts; no file mutation.
+ *   --apply-all       Accept every suggestion. Typed-confirmation gate:
+ *                     user must type the literal phrase `APPLY ALL`.
+ *   --report-only     Write the audit report; no prompts, no apply.
+ *   --reset-ledger    Clear `~/.skillsmith/namespace-overrides.json`. Backs
+ *                     up to `~/.skillsmith/backups/ledger-<ts>.json` first.
+ *                     Typed-confirmation gate: literal phrase `RESET LEDGER`.
+ *
+ * Typed-confirmation gates are load-bearing UX (plan §235-239). Prompts use
+ * `@inquirer/prompts` `input` with strict literal-phrase verification —
+ * ANY input other than the exact phrase rejects with a non-zero exit.
+ * No fuzzy match, no normalization, no validate-and-retry loop.
+ *
+ * Default-entry tiebreak: `runInventoryAudit` already picks the most-recently-
+ * installed entry (mtime descending) per `buildRenameSuggestions`. The CLI
+ * surfaces that target in the prompt copy and lets the user `s`kip to flip
+ * to the other entry.
+ */
+
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import { Command } from 'commander'
+import chalk from 'chalk'
+import { input, select } from '@inquirer/prompts'
+
+import {
+  applyRename,
+  readLedger,
+  runInventoryAudit,
+  writeLedger,
+  NAMESPACE_OVERRIDES_CURRENT_VERSION,
+  type RenameSuggestion,
+  type RunInventoryAuditResult,
+} from '@skillsmith/mcp-server/audit'
+
+import { sanitizeError } from '../utils/sanitize.js'
+import { getLicenseStatus } from '../utils/license.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const APPLY_ALL_PHRASE = 'APPLY ALL'
+const RESET_LEDGER_PHRASE = 'RESET LEDGER'
+
+const CONFIRMATION_REJECTED_MESSAGE =
+  'Confirmation phrase mismatch — operation aborted. The phrase must match exactly (case-sensitive, including spaces).'
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+interface AuditCollisionsOptions {
+  deep: boolean
+  json: boolean
+  applyAll: boolean
+  reportOnly: boolean
+  resetLedger: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Typed-confirmation gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a single line from stdin and require an exact literal match for
+ * `expected`. Used for the load-bearing `APPLY ALL` and `RESET LEDGER`
+ * gates per plan §235-239.
+ *
+ * Strict equality only — no fuzzy match, no normalization. Lowercase,
+ * abbreviated, or whitespace-stripped input REJECTS with exit non-zero.
+ * Tested on both interactive (TTY) and piped-stdin paths.
+ */
+async function requireConfirmationPhrase(expected: string, prompt: string): Promise<void> {
+  const answer = await input({ message: prompt })
+  // Strict equality: NO trimming, NO case folding, NO normalization.
+  // Two reasons:
+  //   1. Plan §237 mandates it ("any other input — including `Y`, `yes`,
+  //      `apply all` (lowercase), `APPLYALL` (no space) — rejects").
+  //   2. `@inquirer/prompts` `input` does NOT trim by default — verified.
+  if (answer !== expected) {
+    throw new Error(CONFIRMATION_REJECTED_MESSAGE)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ledger reset helpers
+// ---------------------------------------------------------------------------
+
+function ledgerPath(): string {
+  return join(homedir(), '.skillsmith', 'namespace-overrides.json')
+}
+
+function backupsDir(): string {
+  return join(homedir(), '.skillsmith', 'backups')
+}
+
+/**
+ * Backup the ledger file to `~/.skillsmith/backups/ledger-<ts>-<rand>.json`
+ * before the reset clears it. The random suffix prevents two concurrent
+ * resets from clobbering each other's backup file.
+ */
+function backupLedgerForReset(): string | null {
+  const src = ledgerPath()
+  if (!fs.existsSync(src)) return null
+  const dir = backupsDir()
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+  const ts = new Date().toISOString().replace(/[:.]/g, '-')
+  const suffix = crypto.randomBytes(4).toString('hex')
+  const backupFile = join(dir, `ledger-${ts}-${suffix}.json`)
+  fs.copyFileSync(src, backupFile)
+  return backupFile
+}
+
+async function runResetLedger(): Promise<void> {
+  await requireConfirmationPhrase(
+    RESET_LEDGER_PHRASE,
+    `Type ${chalk.bold(RESET_LEDGER_PHRASE)} to confirm clearing the namespace-overrides ledger`
+  )
+  const backupFile = backupLedgerForReset()
+  await writeLedger({ version: NAMESPACE_OVERRIDES_CURRENT_VERSION, overrides: [] })
+  if (backupFile) {
+    console.log(`${chalk.green('OK')} Ledger cleared. Backup: ${backupFile}`)
+  } else {
+    console.log(`${chalk.green('OK')} Ledger cleared (no prior ledger to back up).`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Apply paths
+// ---------------------------------------------------------------------------
+
+interface ApplyOutcome {
+  collisionId: string
+  status: 'applied' | 'skipped' | 'failed'
+  message: string
+}
+
+async function applyOneSuggestion(
+  suggestion: RenameSuggestion,
+  auditId: string,
+  customName?: string
+): Promise<ApplyOutcome> {
+  try {
+    const result = await applyRename({
+      suggestion,
+      request: customName ? { action: 'apply', auditId, customName } : { action: 'apply', auditId },
+    })
+    if (result.success) {
+      return {
+        collisionId: suggestion.collisionId,
+        status: 'applied',
+        message: result.summary,
+      }
+    }
+    return {
+      collisionId: suggestion.collisionId,
+      status: 'failed',
+      message: result.error?.message ?? 'rename failed',
+    }
+  } catch (error) {
+    return {
+      collisionId: suggestion.collisionId,
+      status: 'failed',
+      message: sanitizeError(error),
+    }
+  }
+}
+
+async function runApplyAll(audit: RunInventoryAuditResult): Promise<void> {
+  await requireConfirmationPhrase(
+    APPLY_ALL_PHRASE,
+    `Type ${chalk.bold(APPLY_ALL_PHRASE)} to confirm applying every suggestion (${audit.renameSuggestions.length})`
+  )
+  const outcomes: ApplyOutcome[] = []
+  for (const suggestion of audit.renameSuggestions) {
+    outcomes.push(await applyOneSuggestion(suggestion, audit.auditId))
+  }
+  printApplySummary(outcomes)
+}
+
+// ---------------------------------------------------------------------------
+// Interactive prompt loop
+// ---------------------------------------------------------------------------
+
+async function runInteractiveLoop(audit: RunInventoryAuditResult): Promise<void> {
+  if (audit.renameSuggestions.length === 0) {
+    console.log(chalk.dim('No collisions found.'))
+    return
+  }
+
+  console.log(chalk.bold.blue(`\n=== Skillsmith — Namespace audit ===`))
+  console.log(chalk.dim(`Audit ID: ${audit.auditId}`))
+  console.log(chalk.dim(`Report: ${audit.reportPath}`))
+  console.log(`Found ${audit.renameSuggestions.length} collision(s).\n`)
+
+  const outcomes: ApplyOutcome[] = []
+  let index = 1
+  const total = audit.renameSuggestions.length
+
+  for (const suggestion of audit.renameSuggestions) {
+    console.log(chalk.bold(`[${index}/${total}] ${suggestion.reason}`))
+    console.log(`  Current:   ${suggestion.currentName}`)
+    console.log(`  Suggested: ${chalk.cyan(suggestion.suggested)}`)
+    console.log(chalk.dim(`  (default target = most-recently-installed entry, mtime desc)`))
+
+    // Default = `skip` (defensive). Plan §235-239 mandates a typed-
+    // confirmation gate for batch apply (`APPLY ALL`); per-item interactive
+    // apply MUST mirror that posture so an inattentive Enter-press cannot
+    // mutate user state. The user explicitly arrows down + Enter to apply.
+    const choice = (await select({
+      message: 'Action?',
+      choices: [
+        { name: 'Skip — leave this collision unchanged (default, safe)', value: 'skip' },
+        { name: 'Apply — accept the suggested rename', value: 'apply' },
+        { name: 'Edit — provide a custom name', value: 'edit' },
+        { name: 'Quit — abort the loop', value: 'quit' },
+      ],
+      default: 'skip',
+    })) as 'apply' | 'skip' | 'edit' | 'quit'
+
+    if (choice === 'quit') {
+      console.log(chalk.yellow('Aborted by user.'))
+      break
+    }
+    if (choice === 'skip') {
+      outcomes.push({
+        collisionId: suggestion.collisionId,
+        status: 'skipped',
+        message: 'skipped by user',
+      })
+      index += 1
+      continue
+    }
+    if (choice === 'edit') {
+      const customName = await input({
+        message: 'Enter custom name:',
+        validate: (v: string) => v.trim().length > 0 || 'Name cannot be empty',
+      })
+      outcomes.push(await applyOneSuggestion(suggestion, audit.auditId, customName.trim()))
+      index += 1
+      continue
+    }
+    // choice === 'apply'
+    outcomes.push(await applyOneSuggestion(suggestion, audit.auditId))
+    index += 1
+  }
+
+  printApplySummary(outcomes)
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+function printApplySummary(outcomes: ApplyOutcome[]): void {
+  const applied = outcomes.filter((o) => o.status === 'applied').length
+  const skipped = outcomes.filter((o) => o.status === 'skipped').length
+  const failed = outcomes.filter((o) => o.status === 'failed').length
+
+  console.log(chalk.bold('\nSummary:'))
+  console.log(`  ${chalk.green('Applied')}:   ${applied}`)
+  console.log(`  ${chalk.yellow('Skipped')}:   ${skipped}`)
+  console.log(`  ${chalk.red('Failed')}:    ${failed}`)
+
+  for (const outcome of outcomes) {
+    const tag =
+      outcome.status === 'applied'
+        ? chalk.green('OK')
+        : outcome.status === 'skipped'
+          ? chalk.yellow('SKIP')
+          : chalk.red('FAIL')
+    console.log(`  ${tag} ${outcome.collisionId} — ${outcome.message}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main entry
+// ---------------------------------------------------------------------------
+
+async function runAuditCollisions(options: AuditCollisionsOptions): Promise<void> {
+  // --reset-ledger short-circuits before any audit run.
+  if (options.resetLedger) {
+    // Touch readLedger to surface higher-version errors before clearing.
+    // (readLedger throws on namespace.ledger.version_unsupported.)
+    await readLedger()
+    await runResetLedger()
+    return
+  }
+
+  // Resolve tier from license status — the detector gates the semantic
+  // pass on `audit_mode`, which is tier-defaulted via runInventoryAudit's
+  // resolver. We pass the resolved tier through so a Team user gets
+  // `power_user` (semantic) by default.
+  const status = await getLicenseStatus()
+  const tier = status.tier ?? 'community'
+
+  const audit = await runInventoryAudit({ deep: options.deep, tier })
+
+  if (options.json) {
+    console.log(JSON.stringify(audit, null, 2))
+    return
+  }
+
+  if (options.reportOnly) {
+    console.log(`${chalk.green('OK')} Audit report written to ${audit.reportPath}`)
+    return
+  }
+
+  if (options.applyAll) {
+    await runApplyAll(audit)
+    return
+  }
+
+  await runInteractiveLoop(audit)
+}
+
+// ---------------------------------------------------------------------------
+// Command factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `audit collisions` subcommand. Registered as a sibling of
+ * `audit advisories` in `audit.ts` (Step 0a).
+ */
+export function createAuditCollisionsSubcommand(): Command {
+  return new Command('collisions')
+    .description(
+      'Detect and resolve consumer-namespace collisions in ~/.claude/ ' +
+        '(Default: most-recently-installed entry, mtime descending)'
+    )
+    .option('--deep', 'Opt into the semantic-overlap detector pass', false)
+    .option('--json', 'Emit JSON to stdout; no prompts; no file mutation', false)
+    .option(
+      '--apply-all',
+      'Accept every suggestion (typed-confirmation gate: literal phrase `APPLY ALL`)',
+      false
+    )
+    .option('--report-only', 'Write the audit report; no prompts; no apply', false)
+    .option(
+      '--reset-ledger',
+      'Clear ~/.skillsmith/namespace-overrides.json (typed-confirmation gate: literal phrase `RESET LEDGER`)',
+      false
+    )
+    .action(async (opts: Record<string, boolean | undefined>) => {
+      try {
+        await runAuditCollisions({
+          deep: opts['deep'] === true,
+          json: opts['json'] === true,
+          applyAll: opts['applyAll'] === true,
+          reportOnly: opts['reportOnly'] === true,
+          resetLedger: opts['resetLedger'] === true,
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : sanitizeError(error)
+        // Confirmation rejection is not a stack-trace-worthy failure —
+        // print the canonical message and exit non-zero.
+        if (message === CONFIRMATION_REJECTED_MESSAGE) {
+          console.error(chalk.yellow(message))
+        } else {
+          console.error(chalk.red('Error:'), message)
+        }
+        process.exit(1)
+      }
+    })
+}
+
+// Internal exports for tests.
+export {
+  runAuditCollisions,
+  runResetLedger,
+  runApplyAll,
+  runInteractiveLoop,
+  requireConfirmationPhrase,
+  applyOneSuggestion,
+  APPLY_ALL_PHRASE,
+  RESET_LEDGER_PHRASE,
+  CONFIRMATION_REJECTED_MESSAGE,
+}
+export type { AuditCollisionsOptions, ApplyOutcome }
+
+export default createAuditCollisionsSubcommand

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -14,7 +14,7 @@
  * Surface (post-SMI-4590 Step 0a):
  * - `sklx audit advisories <skill-id>` (canonical)
  * - `sklx audit <skill-id>` (deprecation alias — emits warning, forwards to advisories)
- * - `sklx audit collisions` is added by SMI-4590 PR 5/6.
+ * - `sklx audit collisions` is the namespace-collision audit (SMI-4590 PR 5/6).
  */
 
 import { Command } from 'commander'
@@ -28,6 +28,7 @@ import {
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { requireTier } from '../utils/require-tier.js'
+import { createAuditCollisionsSubcommand } from './audit-collisions.js'
 
 // ============================================================================
 // Severity display helpers
@@ -205,6 +206,8 @@ export function createAuditCommand(): Command {
   )
 
   audit.addCommand(createAuditAdvisoriesSubcommand())
+  // SMI-4590 PR 5/6 — register `collisions` sibling subcommand.
+  audit.addCommand(createAuditCollisionsSubcommand())
 
   // Deprecation alias: `sklx audit <skill-id>` → forward to `advisories`.
   // Implemented as a default-action on the parent: when Commander is invoked

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,254 @@
+/**
+ * @fileoverview `sklx config` command — get/set Skillsmith configuration values.
+ * @module @skillsmith/cli/commands/config
+ * @see SMI-4590 Wave 4 PR 5/6 §8 — `audit_mode` CLI plumbing + tier-revalidation
+ *
+ * v1 surface (intentionally narrow):
+ * - `sklx config get audit_mode`         → prints the resolved audit-mode for
+ *                                           the caller (config-file value when
+ *                                           set, else tier default).
+ * - `sklx config set audit_mode <value>` → writes `audit_mode` to
+ *                                           `~/.skillsmith/config.json`. Atomic
+ *                                           write via `<path>.tmp` + rename.
+ *                                           Tier-revalidated against
+ *                                           `tierAllowsAuditMode` —
+ *                                           community/individual cannot select
+ *                                           `power_user` or `governance`.
+ *
+ * Typed error codes (printed to stderr; exit 1):
+ *   audit.mode.invalid_value     — value not in {preventative,power_user,governance,off}
+ *   audit.mode.tier_ineligible   — tier cannot select the requested mode
+ *
+ * No file write occurs on either error path. Other keys are rejected with a
+ * generic "unsupported key" message — the surface intentionally locks down
+ * to v1 deliverables; v2 extends with additional keys.
+ */
+
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import { homedir } from 'node:os'
+import { join, dirname } from 'node:path'
+
+import { Command } from 'commander'
+import chalk from 'chalk'
+
+import { isAuditMode, resolveAuditMode, type AuditMode } from '@skillsmith/core/config/audit-mode'
+import { tierAllowsAuditMode } from '@skillsmith/core/audit'
+
+import { sanitizeError } from '../utils/sanitize.js'
+import { getLicenseStatus } from '../utils/license.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CONFIG_DIR = '.skillsmith'
+const CONFIG_FILE = 'config.json'
+
+const SUPPORTED_KEYS = ['audit_mode'] as const
+type SupportedKey = (typeof SUPPORTED_KEYS)[number]
+
+const VALID_AUDIT_MODES: ReadonlyArray<AuditMode> = [
+  'preventative',
+  'power_user',
+  'governance',
+  'off',
+]
+
+// ---------------------------------------------------------------------------
+// Typed error envelope (stderr-only; never logged with secrets)
+// ---------------------------------------------------------------------------
+
+class ConfigError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string
+  ) {
+    super(message)
+    this.name = 'ConfigError'
+  }
+}
+
+function isSupportedKey(key: string): key is SupportedKey {
+  return (SUPPORTED_KEYS as ReadonlyArray<string>).includes(key)
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+function configPath(): string {
+  // Re-evaluates os.homedir() each call so test harnesses that toggle
+  // process.env.HOME observe the updated location (mirrors the
+  // `defaultLedgerPath` pattern in namespace-overrides.ts).
+  return join(homedir(), CONFIG_DIR, CONFIG_FILE)
+}
+
+// ---------------------------------------------------------------------------
+// Atomic read/write
+// ---------------------------------------------------------------------------
+
+interface ConfigFile {
+  audit_mode?: AuditMode
+  // Permissive: preserve unknown keys on read-modify-write.
+  [otherKey: string]: unknown
+}
+
+function readConfigFile(): ConfigFile {
+  const path = configPath()
+  if (!fs.existsSync(path)) return {}
+  try {
+    const raw = fs.readFileSync(path, 'utf-8')
+    const parsed = JSON.parse(raw) as unknown
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+    return parsed as ConfigFile
+  } catch {
+    // Malformed JSON: degrade to empty rather than fail-loud — the user can
+    // still set audit_mode (write will overwrite the malformed file).
+    return {}
+  }
+}
+
+/**
+ * Atomic write of the config file: `<path>.<rand>.tmp` + `fs.rename`.
+ * Plan §403 explicitly requires atomic writes for `sklx config set` so a
+ * crashed process never leaves a half-written config behind.
+ *
+ * The unique tmp suffix prevents two concurrent writers from clobbering
+ * each other's staging file (mirrors the namespace-overrides ledger
+ * writer's pattern).
+ */
+function writeConfigFileAtomic(config: ConfigFile): void {
+  const path = configPath()
+  const dir = dirname(path)
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+
+  const tmpSuffix = crypto.randomBytes(6).toString('hex')
+  const tmpPath = `${path}.${tmpSuffix}.tmp`
+
+  const json = JSON.stringify(config, null, 2)
+  fs.writeFileSync(tmpPath, json, { encoding: 'utf-8', mode: 0o600 })
+  fs.renameSync(tmpPath, path)
+
+  // chmod the final path defensively; ignore errors (Windows / read-only FS).
+  try {
+    fs.chmodSync(path, 0o600)
+  } catch {
+    // Best-effort.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// `config get` / `config set` action handlers
+// ---------------------------------------------------------------------------
+
+async function runConfigGet(key: string): Promise<void> {
+  if (!isSupportedKey(key)) {
+    throw new ConfigError('config.unsupported_key', `Unsupported config key: ${key}`)
+  }
+
+  if (key === 'audit_mode') {
+    const file = readConfigFile()
+    const status = await getLicenseStatus()
+    const tier = status.tier ?? 'community'
+    const fileValue = isAuditMode(file.audit_mode) ? file.audit_mode : null
+    const resolved = resolveAuditMode({ tier, override: fileValue })
+
+    if (fileValue) {
+      console.log(`${fileValue}`)
+    } else {
+      console.log(`${resolved} ${chalk.dim('(tier default)')}`)
+    }
+  }
+}
+
+/**
+ * Validate + write `audit_mode`. Two-stage gate:
+ *   1. Value validation: must be in VALID_AUDIT_MODES → else `audit.mode.invalid_value`.
+ *   2. Tier revalidation: `tierAllowsAuditMode` → else `audit.mode.tier_ineligible`.
+ *
+ * Both errors are raised BEFORE any file IO so a rejected write leaves the
+ * existing config untouched (load-bearing per plan §810-813 security test).
+ */
+async function runConfigSet(key: string, value: string): Promise<void> {
+  if (!isSupportedKey(key)) {
+    throw new ConfigError('config.unsupported_key', `Unsupported config key: ${key}`)
+  }
+
+  if (key === 'audit_mode') {
+    if (!isAuditMode(value)) {
+      throw new ConfigError(
+        'audit.mode.invalid_value',
+        `Invalid audit_mode value: ${value}. Expected one of: ${VALID_AUDIT_MODES.join(', ')}`
+      )
+    }
+
+    const status = await getLicenseStatus()
+    const tier = status.tier ?? 'community'
+
+    if (!tierAllowsAuditMode(tier, value)) {
+      throw new ConfigError(
+        'audit.mode.tier_ineligible',
+        `Tier '${tier}' cannot select audit_mode '${value}'. ` +
+          `Upgrade required — see https://skillsmith.app/upgrade`
+      )
+    }
+
+    const existing = readConfigFile()
+    const updated: ConfigFile = { ...existing, audit_mode: value }
+    writeConfigFileAtomic(updated)
+    console.log(`${chalk.green('OK')} audit_mode = ${value}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `config` parent command. v1 supports `get` / `set` subcommands
+ * with a single supported key (`audit_mode`). Additional keys land in v2.
+ */
+export function createConfigCommand(): Command {
+  const config = new Command('config').description(
+    'Get or set Skillsmith configuration values (~/.skillsmith/config.json)'
+  )
+
+  config
+    .command('get <key>')
+    .description('Read a configuration value (e.g. `audit_mode`)')
+    .action(async (key: string) => {
+      try {
+        await runConfigGet(key)
+      } catch (error) {
+        if (error instanceof ConfigError) {
+          console.error(chalk.red(`Error [${error.code}]:`), error.message)
+        } else {
+          console.error(chalk.red('Error:'), sanitizeError(error))
+        }
+        process.exit(1)
+      }
+    })
+
+  config
+    .command('set <key> <value>')
+    .description('Write a configuration value (atomic; tier-revalidated for audit_mode)')
+    .action(async (key: string, value: string) => {
+      try {
+        await runConfigSet(key, value)
+      } catch (error) {
+        if (error instanceof ConfigError) {
+          console.error(chalk.red(`Error [${error.code}]:`), error.message)
+        } else {
+          console.error(chalk.red('Error:'), sanitizeError(error))
+        }
+        process.exit(1)
+      }
+    })
+
+  return config
+}
+
+// Internal exports for tests. Consumers should use `createConfigCommand`.
+export { runConfigGet, runConfigSet, ConfigError, configPath, readConfigFile }
+export default createConfigCommand

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -64,3 +64,6 @@ export { createImportCommand, importSkills } from './import.js'
 
 // SMI-4665: Filesystem-walking SKILL.md importer
 export { createImportLocalCommand, runImportLocal } from './import-local.js'
+
+// SMI-4590 Wave 4 PR 5/6: `sklx config get/set audit_mode`
+export { createConfigCommand } from './config.js'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,6 +47,7 @@ import {
   createInfoCommand,
   createImportCommand,
   createImportLocalCommand,
+  createConfigCommand,
 } from './commands/index.js'
 import { displayStartupHeader } from './utils/license.js'
 import { checkNodeVersion } from './utils/node-version.js'
@@ -155,5 +156,8 @@ program.addCommand(createCreateCommand())
 
 // SMI-3672: Skill info with SKILL.md content
 program.addCommand(createInfoCommand())
+
+// SMI-4590 Wave 4 PR 5/6: `sklx config get/set audit_mode`
+program.addCommand(createConfigCommand())
 
 program.parse()

--- a/packages/cli/tests/audit-collisions.test.ts
+++ b/packages/cli/tests/audit-collisions.test.ts
@@ -1,0 +1,451 @@
+/**
+ * @fileoverview SMI-4590 Wave 4 PR 5/6 — `sklx audit collisions` tests
+ * @module @skillsmith/cli/tests/audit-collisions
+ *
+ * Coverage:
+ *
+ * Typed-confirmation gate (`requireConfirmationPhrase`) — load-bearing per
+ * plan §235-239. Strict literal equality, NO normalization.
+ *   1. Exact phrase   ('APPLY ALL')              — RESOLVES.
+ *   2. Single-letter  ('Y')                      — REJECTS.
+ *   3. Lowercase word ('yes')                    — REJECTS.
+ *   4. Lowercase phrase ('apply all')            — REJECTS.
+ *   5. No-space variant ('APPLYALL')             — REJECTS.
+ *   6. Trailing whitespace ('APPLY ALL ')        — REJECTS (no trim).
+ *   7. Empty string                              — REJECTS.
+ *
+ * Both interactive (TTY) and piped-stdin paths route through the same
+ * `@inquirer/prompts` `input()` call, so the rejection invariant holds for
+ * both. We mock `input` to assert the contract — the prompt library
+ * receives the answer verbatim and our code applies strict equality.
+ *
+ * Interactive prompt loop (`runInteractiveLoop`):
+ *   8.  'apply' choice  → applyOneSuggestion called, status=applied.
+ *   9.  'skip'  choice  → outcome recorded as skipped, no apply call.
+ *   10. 'edit'  choice  → input prompts for custom name, applyRename
+ *                          receives `customName`.
+ *   11. 'quit'  choice  → loop terminates early; remaining suggestions
+ *                          are NOT processed.
+ *   12. Empty suggestion list → prints "No collisions found." and returns.
+ *
+ * Reset-ledger flow (`runResetLedger`):
+ *   13. Backs up an existing ledger to `~/.skillsmith/backups/ledger-*.json`
+ *       BEFORE clearing.
+ *   14. No backup file when no prior ledger exists.
+ *   15. Confirmation phrase mismatch → throws, NO writeLedger call.
+ *
+ * `--json` output (`runAuditCollisions`):
+ *   16. JSON mode prints `RunInventoryAuditResult` to stdout, no prompts,
+ *       no apply.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import { join } from 'node:path'
+
+// ============================================================================
+// Mock setup — must precede source imports.
+// ============================================================================
+
+const mocks = vi.hoisted(() => ({
+  input: vi.fn(),
+  select: vi.fn(),
+  applyRename: vi.fn(),
+  readLedger: vi.fn(),
+  writeLedger: vi.fn(),
+  runInventoryAudit: vi.fn(),
+  getLicenseStatus: vi.fn(),
+}))
+
+vi.mock('@inquirer/prompts', () => ({
+  input: (opts: unknown) => mocks.input(opts),
+  select: (opts: unknown) => mocks.select(opts),
+}))
+
+vi.mock('@skillsmith/mcp-server/audit', () => ({
+  applyRename: (opts: unknown) => mocks.applyRename(opts),
+  readLedger: () => mocks.readLedger(),
+  writeLedger: (data: unknown) => mocks.writeLedger(data),
+  runInventoryAudit: (opts: unknown) => mocks.runInventoryAudit(opts),
+  NAMESPACE_OVERRIDES_CURRENT_VERSION: 1,
+}))
+
+vi.mock('../src/utils/license.js', () => ({
+  getLicenseStatus: () => mocks.getLicenseStatus(),
+}))
+
+import {
+  requireConfirmationPhrase,
+  runResetLedger,
+  runInteractiveLoop,
+  runAuditCollisions,
+  APPLY_ALL_PHRASE,
+  RESET_LEDGER_PHRASE,
+  CONFIRMATION_REJECTED_MESSAGE,
+} from '../src/commands/audit-collisions.js'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeSuggestion(id: string, currentName: string, suggested: string) {
+  return {
+    collisionId: id,
+    currentName,
+    suggested,
+    reason: `mock-reason-${id}`,
+    targetMtime: 0,
+    siblingMtime: 0,
+  }
+}
+
+interface MockAudit {
+  auditId: string
+  reportPath: string
+  renameSuggestions: ReturnType<typeof makeSuggestion>[]
+}
+
+function makeAudit(overrides: Partial<MockAudit> = {}): MockAudit {
+  return {
+    auditId: '01HMOCKAUDITID000000000000',
+    reportPath: '/tmp/audit-report.md',
+    renameSuggestions: [],
+    ...overrides,
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SMI-4590 Wave 4 PR 5/6 — sklx audit collisions', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.applyRename.mockResolvedValue({ success: true, summary: 'renamed' })
+    mocks.readLedger.mockResolvedValue({ version: 1, overrides: [] })
+    mocks.writeLedger.mockResolvedValue(undefined)
+    mocks.getLicenseStatus.mockResolvedValue({ tier: 'team' })
+    stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    stdoutSpy.mockRestore()
+  })
+
+  describe('typed-confirmation gate (plan §235-239)', () => {
+    it('resolves on exact APPLY ALL match', async () => {
+      mocks.input.mockResolvedValueOnce(APPLY_ALL_PHRASE)
+      await expect(requireConfirmationPhrase(APPLY_ALL_PHRASE, 'msg')).resolves.toBeUndefined()
+    })
+
+    it('rejects single-letter Y', async () => {
+      mocks.input.mockResolvedValueOnce('Y')
+      await expect(requireConfirmationPhrase(APPLY_ALL_PHRASE, 'msg')).rejects.toThrow(
+        CONFIRMATION_REJECTED_MESSAGE
+      )
+    })
+
+    it('rejects lowercase yes', async () => {
+      mocks.input.mockResolvedValueOnce('yes')
+      await expect(requireConfirmationPhrase(APPLY_ALL_PHRASE, 'msg')).rejects.toThrow(
+        CONFIRMATION_REJECTED_MESSAGE
+      )
+    })
+
+    it('rejects lowercase apply all (case-sensitive)', async () => {
+      mocks.input.mockResolvedValueOnce('apply all')
+      await expect(requireConfirmationPhrase(APPLY_ALL_PHRASE, 'msg')).rejects.toThrow(
+        CONFIRMATION_REJECTED_MESSAGE
+      )
+    })
+
+    it('rejects no-space APPLYALL', async () => {
+      mocks.input.mockResolvedValueOnce('APPLYALL')
+      await expect(requireConfirmationPhrase(APPLY_ALL_PHRASE, 'msg')).rejects.toThrow(
+        CONFIRMATION_REJECTED_MESSAGE
+      )
+    })
+
+    it('rejects trailing whitespace (no trim)', async () => {
+      mocks.input.mockResolvedValueOnce('APPLY ALL ')
+      await expect(requireConfirmationPhrase(APPLY_ALL_PHRASE, 'msg')).rejects.toThrow(
+        CONFIRMATION_REJECTED_MESSAGE
+      )
+    })
+
+    it('rejects empty string', async () => {
+      mocks.input.mockResolvedValueOnce('')
+      await expect(requireConfirmationPhrase(APPLY_ALL_PHRASE, 'msg')).rejects.toThrow(
+        CONFIRMATION_REJECTED_MESSAGE
+      )
+    })
+
+    it('resolves on exact RESET LEDGER match', async () => {
+      mocks.input.mockResolvedValueOnce(RESET_LEDGER_PHRASE)
+      await expect(requireConfirmationPhrase(RESET_LEDGER_PHRASE, 'msg')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('interactive prompt loop choices', () => {
+    it("'apply' choice triggers applyRename", async () => {
+      const audit = makeAudit({
+        renameSuggestions: [makeSuggestion('c1', 'foo/bar', 'foo/bar-2')],
+      })
+      mocks.select.mockResolvedValueOnce('apply')
+      await runInteractiveLoop(audit as never)
+      expect(mocks.applyRename).toHaveBeenCalledTimes(1)
+      expect(mocks.applyRename.mock.calls[0]?.[0]).toMatchObject({
+        request: { action: 'apply', auditId: audit.auditId },
+      })
+    })
+
+    it("'skip' choice records skipped outcome and does NOT call applyRename", async () => {
+      const audit = makeAudit({
+        renameSuggestions: [makeSuggestion('c1', 'foo/bar', 'foo/bar-2')],
+      })
+      mocks.select.mockResolvedValueOnce('skip')
+      await runInteractiveLoop(audit as never)
+      expect(mocks.applyRename).not.toHaveBeenCalled()
+    })
+
+    it("'edit' choice forwards customName to applyRename", async () => {
+      const audit = makeAudit({
+        renameSuggestions: [makeSuggestion('c1', 'foo/bar', 'foo/bar-2')],
+      })
+      mocks.select.mockResolvedValueOnce('edit')
+      mocks.input.mockResolvedValueOnce('  custom-renamed  ')
+      await runInteractiveLoop(audit as never)
+      expect(mocks.applyRename).toHaveBeenCalledWith({
+        suggestion: expect.objectContaining({ collisionId: 'c1' }),
+        request: {
+          action: 'apply',
+          auditId: audit.auditId,
+          customName: 'custom-renamed',
+        },
+      })
+    })
+
+    it("'quit' choice terminates the loop early", async () => {
+      const audit = makeAudit({
+        renameSuggestions: [
+          makeSuggestion('c1', 'foo/bar', 'foo/bar-2'),
+          makeSuggestion('c2', 'foo/baz', 'foo/baz-2'),
+        ],
+      })
+      mocks.select.mockResolvedValueOnce('quit')
+      await runInteractiveLoop(audit as never)
+      // Loop aborted before processing any suggestion → applyRename never called.
+      expect(mocks.applyRename).not.toHaveBeenCalled()
+      // And select was only consulted once (for the first suggestion before quit).
+      expect(mocks.select).toHaveBeenCalledTimes(1)
+    })
+
+    it('empty suggestions prints No collisions found and returns', async () => {
+      const audit = makeAudit({ renameSuggestions: [] })
+      await runInteractiveLoop(audit as never)
+      expect(mocks.select).not.toHaveBeenCalled()
+      expect(mocks.applyRename).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('--reset-ledger flow', () => {
+    let tmpHome: string
+    let originalHome: string | undefined
+
+    beforeEach(() => {
+      tmpHome = fs.mkdtempSync(join(os.tmpdir(), 'sklx-test-home-'))
+      originalHome = process.env['HOME']
+      process.env['HOME'] = tmpHome
+    })
+
+    afterEach(() => {
+      if (originalHome !== undefined) {
+        process.env['HOME'] = originalHome
+      } else {
+        delete process.env['HOME']
+      }
+      fs.rmSync(tmpHome, { recursive: true, force: true })
+    })
+
+    it('backs up an existing ledger before clearing', async () => {
+      const ledgerDir = join(tmpHome, '.skillsmith')
+      fs.mkdirSync(ledgerDir, { recursive: true })
+      const ledgerFile = join(ledgerDir, 'namespace-overrides.json')
+      fs.writeFileSync(ledgerFile, '{"version":1,"overrides":[{"id":"x"}]}', 'utf-8')
+
+      mocks.input.mockResolvedValueOnce(RESET_LEDGER_PHRASE)
+      await runResetLedger()
+
+      // Backup file written.
+      const backupsDir = join(ledgerDir, 'backups')
+      expect(fs.existsSync(backupsDir)).toBe(true)
+      const entries = fs.readdirSync(backupsDir).filter((f) => f.startsWith('ledger-'))
+      expect(entries.length).toBe(1)
+      // Backup contains the original payload.
+      const backup = fs.readFileSync(join(backupsDir, entries[0] as string), 'utf-8')
+      expect(backup).toContain('"id":"x"')
+      // writeLedger called with empty overrides.
+      expect(mocks.writeLedger).toHaveBeenCalledWith({
+        version: 1,
+        overrides: [],
+      })
+    })
+
+    it('no backup file when no prior ledger exists', async () => {
+      mocks.input.mockResolvedValueOnce(RESET_LEDGER_PHRASE)
+      await runResetLedger()
+      const backupsDir = join(tmpHome, '.skillsmith', 'backups')
+      // backupsDir may not exist at all when no source ledger present.
+      const entries = fs.existsSync(backupsDir) ? fs.readdirSync(backupsDir) : []
+      expect(entries.length).toBe(0)
+      expect(mocks.writeLedger).toHaveBeenCalledWith({
+        version: 1,
+        overrides: [],
+      })
+    })
+
+    it('confirmation mismatch throws and does NOT call writeLedger', async () => {
+      mocks.input.mockResolvedValueOnce('reset ledger') // wrong case
+      await expect(runResetLedger()).rejects.toThrow(CONFIRMATION_REJECTED_MESSAGE)
+      expect(mocks.writeLedger).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('--reset-ledger preflight (plan §297)', () => {
+    let tmpHome: string
+    let originalHome: string | undefined
+
+    beforeEach(() => {
+      tmpHome = fs.mkdtempSync(join(os.tmpdir(), 'sklx-test-home-'))
+      originalHome = process.env['HOME']
+      process.env['HOME'] = tmpHome
+    })
+
+    afterEach(() => {
+      if (originalHome !== undefined) {
+        process.env['HOME'] = originalHome
+      } else {
+        delete process.env['HOME']
+      }
+      fs.rmSync(tmpHome, { recursive: true, force: true })
+    })
+
+    it('reads the ledger BEFORE prompting (so version_unsupported errors surface first)', async () => {
+      // Simulate a higher-version ledger by having readLedger throw.
+      const versionError = new Error('namespace.ledger.version_unsupported')
+      mocks.readLedger.mockRejectedValueOnce(versionError)
+
+      await expect(
+        runAuditCollisions({
+          deep: false,
+          json: false,
+          applyAll: false,
+          reportOnly: false,
+          resetLedger: true,
+        })
+      ).rejects.toThrow('namespace.ledger.version_unsupported')
+
+      // The user was never prompted because readLedger threw first.
+      expect(mocks.input).not.toHaveBeenCalled()
+      expect(mocks.writeLedger).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('--apply-all end-to-end (typed gate + sequential apply)', () => {
+    it('applies every suggestion sequentially after APPLY ALL phrase', async () => {
+      const audit = makeAudit({
+        renameSuggestions: [
+          makeSuggestion('c1', 'a/x', 'a/x-2'),
+          makeSuggestion('c2', 'a/y', 'a/y-2'),
+          makeSuggestion('c3', 'a/z', 'a/z-2'),
+        ],
+      })
+      mocks.runInventoryAudit.mockResolvedValueOnce(audit)
+      mocks.input.mockResolvedValueOnce(APPLY_ALL_PHRASE)
+
+      await runAuditCollisions({
+        deep: false,
+        json: false,
+        applyAll: true,
+        reportOnly: false,
+        resetLedger: false,
+      })
+
+      // applyRename invoked once per suggestion.
+      expect(mocks.applyRename).toHaveBeenCalledTimes(3)
+      expect(mocks.select).not.toHaveBeenCalled()
+    })
+
+    it('rejects --apply-all when phrase is wrong; no applyRename calls', async () => {
+      const audit = makeAudit({
+        renameSuggestions: [makeSuggestion('c1', 'a/x', 'a/x-2')],
+      })
+      mocks.runInventoryAudit.mockResolvedValueOnce(audit)
+      mocks.input.mockResolvedValueOnce('apply all') // wrong case
+
+      await expect(
+        runAuditCollisions({
+          deep: false,
+          json: false,
+          applyAll: true,
+          reportOnly: false,
+          resetLedger: false,
+        })
+      ).rejects.toThrow(CONFIRMATION_REJECTED_MESSAGE)
+
+      expect(mocks.applyRename).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('interactive default is `skip` (regression guard for inattentive Enter-press)', () => {
+    it('defaults the select prompt to `skip` not `apply`', async () => {
+      const audit = makeAudit({
+        renameSuggestions: [makeSuggestion('c1', 'a/x', 'a/x-2')],
+      })
+      // Capture the options passed to select.
+      let capturedOpts: { default?: string } | undefined
+      mocks.select.mockImplementationOnce((opts: unknown) => {
+        capturedOpts = opts as { default?: string }
+        return Promise.resolve('skip')
+      })
+
+      await runInteractiveLoop(audit as never)
+
+      expect(capturedOpts).toBeDefined()
+      expect(capturedOpts?.default).toBe('skip')
+    })
+  })
+
+  describe('--json output', () => {
+    it('prints RunInventoryAuditResult JSON and skips prompts', async () => {
+      const audit = makeAudit({
+        renameSuggestions: [makeSuggestion('c1', 'foo/bar', 'foo/bar-2')],
+      })
+      mocks.runInventoryAudit.mockResolvedValueOnce(audit)
+
+      await runAuditCollisions({
+        deep: false,
+        json: true,
+        applyAll: false,
+        reportOnly: false,
+        resetLedger: false,
+      })
+
+      // No prompts consulted.
+      expect(mocks.input).not.toHaveBeenCalled()
+      expect(mocks.select).not.toHaveBeenCalled()
+      expect(mocks.applyRename).not.toHaveBeenCalled()
+
+      // Last console.log call should contain serialized JSON of audit.
+      const calls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? ''))
+      const jsonOutput = calls.find((c: string) => c.includes(audit.auditId))
+      expect(jsonOutput).toBeDefined()
+      // Parse and check shape.
+      const parsed = JSON.parse(jsonOutput as string) as { auditId: string }
+      expect(parsed.auditId).toBe(audit.auditId)
+    })
+  })
+})

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -1,0 +1,260 @@
+/**
+ * @fileoverview SMI-4590 Wave 4 PR 5/6 — `sklx config get/set audit_mode` tests
+ * @module @skillsmith/cli/tests/config
+ *
+ * Coverage (plan §810-813 — load-bearing tier-revalidation security tests):
+ *
+ * Tier revalidation matrix — the `set` path MUST refuse a write when
+ * `tierAllowsAuditMode(tier, mode)` returns false. No file IO occurs on
+ * rejection; the existing config (if any) stays intact.
+ *
+ *   1. community  + power_user   → audit.mode.tier_ineligible, NO write
+ *   2. community  + governance   → audit.mode.tier_ineligible, NO write
+ *   3. individual + power_user   → audit.mode.tier_ineligible, NO write
+ *   4. individual + governance   → audit.mode.tier_ineligible, NO write
+ *   5. team       + power_user   → SUCCESS, file written
+ *   6. team       + governance   → audit.mode.tier_ineligible (Enterprise-only)
+ *   7. enterprise + governance   → SUCCESS, file written
+ *
+ * Value validation:
+ *   8. any tier   + invalid_value → audit.mode.invalid_value, NO write
+ *   9. any tier   + preventative  → SUCCESS for every tier
+ *  10. any tier   + off           → SUCCESS for every tier
+ *
+ * Unsupported keys:
+ *  11. set with unknown key → config.unsupported_key, NO write
+ *  12. get with unknown key → config.unsupported_key
+ *
+ * Get path:
+ *  13. get audit_mode reads existing file value when present
+ *  14. get audit_mode falls back to tier default when unset
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import { join } from 'node:path'
+
+const mocks = vi.hoisted(() => ({
+  getLicenseStatus: vi.fn(),
+}))
+
+vi.mock('../src/utils/license.js', () => ({
+  getLicenseStatus: () => mocks.getLicenseStatus(),
+}))
+
+import { runConfigGet, runConfigSet, ConfigError, configPath } from '../src/commands/config.js'
+
+// ============================================================================
+// Test harness — sandbox HOME so config writes are isolated.
+// ============================================================================
+
+let tmpHome: string
+let originalHome: string | undefined
+let stdoutSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(join(os.tmpdir(), 'sklx-config-test-'))
+  originalHome = process.env['HOME']
+  process.env['HOME'] = tmpHome
+  stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  if (originalHome !== undefined) {
+    process.env['HOME'] = originalHome
+  } else {
+    delete process.env['HOME']
+  }
+  fs.rmSync(tmpHome, { recursive: true, force: true })
+  stdoutSpy.mockRestore()
+})
+
+function setTier(tier: string): void {
+  mocks.getLicenseStatus.mockResolvedValue({ tier })
+}
+
+function configFileExists(): boolean {
+  return fs.existsSync(configPath())
+}
+
+function readConfigRaw(): Record<string, unknown> {
+  if (!configFileExists()) return {}
+  return JSON.parse(fs.readFileSync(configPath(), 'utf-8')) as Record<string, unknown>
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SMI-4590 Wave 4 PR 5/6 — sklx config tier revalidation (plan §810-813)', () => {
+  describe('community tier — power_user / governance forbidden', () => {
+    it('community + power_user → tier_ineligible, NO write', async () => {
+      setTier('community')
+      try {
+        await runConfigSet('audit_mode', 'power_user')
+        expect.fail('Expected ConfigError')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ConfigError)
+        expect((error as ConfigError).code).toBe('audit.mode.tier_ineligible')
+      }
+      expect(configFileExists()).toBe(false)
+    })
+
+    it('community + governance → tier_ineligible, NO write', async () => {
+      setTier('community')
+      try {
+        await runConfigSet('audit_mode', 'governance')
+        expect.fail('Expected ConfigError')
+      } catch (error) {
+        expect((error as ConfigError).code).toBe('audit.mode.tier_ineligible')
+      }
+      expect(configFileExists()).toBe(false)
+    })
+  })
+
+  describe('individual tier — power_user / governance forbidden', () => {
+    it('individual + power_user → tier_ineligible, NO write', async () => {
+      setTier('individual')
+      try {
+        await runConfigSet('audit_mode', 'power_user')
+        expect.fail('Expected ConfigError')
+      } catch (error) {
+        expect((error as ConfigError).code).toBe('audit.mode.tier_ineligible')
+      }
+      expect(configFileExists()).toBe(false)
+    })
+
+    it('individual + governance → tier_ineligible, NO write', async () => {
+      setTier('individual')
+      try {
+        await runConfigSet('audit_mode', 'governance')
+        expect.fail('Expected ConfigError')
+      } catch (error) {
+        expect((error as ConfigError).code).toBe('audit.mode.tier_ineligible')
+      }
+      expect(configFileExists()).toBe(false)
+    })
+  })
+
+  describe('team tier — power_user allowed, governance forbidden', () => {
+    it('team + power_user → SUCCESS, file written', async () => {
+      setTier('team')
+      await runConfigSet('audit_mode', 'power_user')
+      expect(configFileExists()).toBe(true)
+      expect(readConfigRaw()['audit_mode']).toBe('power_user')
+    })
+
+    it('team + governance → tier_ineligible (Enterprise-only)', async () => {
+      setTier('team')
+      try {
+        await runConfigSet('audit_mode', 'governance')
+        expect.fail('Expected ConfigError')
+      } catch (error) {
+        expect((error as ConfigError).code).toBe('audit.mode.tier_ineligible')
+      }
+      expect(configFileExists()).toBe(false)
+    })
+  })
+
+  describe('enterprise tier — governance allowed', () => {
+    it('enterprise + governance → SUCCESS, file written', async () => {
+      setTier('enterprise')
+      await runConfigSet('audit_mode', 'governance')
+      expect(configFileExists()).toBe(true)
+      expect(readConfigRaw()['audit_mode']).toBe('governance')
+    })
+  })
+})
+
+describe('SMI-4590 Wave 4 PR 5/6 — sklx config value validation', () => {
+  it('invalid_value → audit.mode.invalid_value, NO write', async () => {
+    setTier('enterprise')
+    try {
+      await runConfigSet('audit_mode', 'definitely-not-a-mode')
+      expect.fail('Expected ConfigError')
+    } catch (error) {
+      expect((error as ConfigError).code).toBe('audit.mode.invalid_value')
+    }
+    expect(configFileExists()).toBe(false)
+  })
+
+  it('preventative is allowed for every tier', async () => {
+    for (const tier of ['community', 'individual', 'team', 'enterprise']) {
+      // Reset sandbox between tiers.
+      fs.rmSync(configPath(), { force: true })
+      setTier(tier)
+      await runConfigSet('audit_mode', 'preventative')
+      expect(readConfigRaw()['audit_mode']).toBe('preventative')
+    }
+  })
+
+  it('off is allowed for every tier', async () => {
+    for (const tier of ['community', 'individual', 'team', 'enterprise']) {
+      fs.rmSync(configPath(), { force: true })
+      setTier(tier)
+      await runConfigSet('audit_mode', 'off')
+      expect(readConfigRaw()['audit_mode']).toBe('off')
+    }
+  })
+})
+
+describe('SMI-4590 Wave 4 PR 5/6 — sklx config unsupported keys', () => {
+  it('set with unknown key → config.unsupported_key, NO write', async () => {
+    setTier('enterprise')
+    try {
+      await runConfigSet('telemetry_endpoint', 'https://example.com')
+      expect.fail('Expected ConfigError')
+    } catch (error) {
+      expect((error as ConfigError).code).toBe('config.unsupported_key')
+    }
+    expect(configFileExists()).toBe(false)
+  })
+
+  it('get with unknown key → config.unsupported_key', async () => {
+    setTier('enterprise')
+    try {
+      await runConfigGet('telemetry_endpoint')
+      expect.fail('Expected ConfigError')
+    } catch (error) {
+      expect((error as ConfigError).code).toBe('config.unsupported_key')
+    }
+  })
+})
+
+describe('SMI-4590 Wave 4 PR 5/6 — sklx config get audit_mode', () => {
+  it('reads existing file value when present', async () => {
+    setTier('team')
+    await runConfigSet('audit_mode', 'power_user')
+    stdoutSpy.mockClear()
+    await runConfigGet('audit_mode')
+    const out = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? '')).join('\n')
+    expect(out).toContain('power_user')
+  })
+
+  it('falls back to tier default when no config file exists', async () => {
+    setTier('community')
+    // No prior write, so file does not exist.
+    expect(configFileExists()).toBe(false)
+    await runConfigGet('audit_mode')
+    const out = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? '')).join('\n')
+    // Output should reference the tier default plus the "(tier default)" hint.
+    expect(out).toMatch(/tier default/)
+  })
+
+  it('preserves unknown keys on read-modify-write (atomic merge)', async () => {
+    setTier('team')
+    // Seed the config with extra keys directly.
+    fs.mkdirSync(join(tmpHome, '.skillsmith'), { recursive: true })
+    fs.writeFileSync(
+      configPath(),
+      JSON.stringify({ extra_key: 'value', audit_mode: 'preventative' }),
+      'utf-8'
+    )
+    await runConfigSet('audit_mode', 'power_user')
+    const after = readConfigRaw()
+    expect(after['audit_mode']).toBe('power_user')
+    expect(after['extra_key']).toBe('value')
+  })
+})

--- a/packages/mcp-server/src/audit-tool-dispatch.ts
+++ b/packages/mcp-server/src/audit-tool-dispatch.ts
@@ -50,6 +50,12 @@ import type { QuotaMiddleware } from './middleware/quota.js'
  */
 export const AUDIT_TOOL_NAMES: ReadonlySet<string> = new Set<string>(buildAuditToolNames())
 
+// SMI-4590 Wave 4 PR 5/6: the post-deploy smoke harness
+// (`scripts/smoke-prod/mcp-server.sh`) greps the COMPILED JS of this file
+// for the literal tool-name strings below. If you ever extract them into
+// constants, named exports, or a JSON manifest, update those smoke checks
+// in the same PR — otherwise the smoke continues to pass on a regression
+// it was specifically built to catch.
 function buildAuditToolNames(): string[] {
   const names = [
     'skill_audit',

--- a/packages/website/src/pages/docs/cli.astro
+++ b/packages/website/src/pages/docs/cli.astro
@@ -314,14 +314,72 @@ skillsmith unpin community/jest-helper`}</code></pre>
 
   <h3>audit</h3>
 
-  <p>Check installed skills against known security advisories. Use <code>--fix</code> to attempt updating skills with available patches.</p>
+  <h4>audit advisories</h4>
 
-  <pre><code>{`skillsmith audit [options]
+  <p>Check installed skills against known security advisories (Team+ tier). Use <code>--fix</code> to attempt updating skills with available patches.</p>
 
-# Examples
-skillsmith audit
-skillsmith audit --json
-skillsmith audit --fix   # Update skills with available patches`}</code></pre>
+  <pre><code>{`skillsmith audit advisories
+skillsmith audit advisories --json
+skillsmith audit advisories --fix`}</code></pre>
+
+  <h4>audit collisions</h4>
+
+  <p>Audit installed skills for namespace collisions — duplicate tool names that could cause invocation conflicts (Community+). Runs interactively by default; use <code>--json</code> for machine-readable output.</p>
+
+  <pre><code>{`skillsmith audit collisions
+skillsmith audit collisions --deep
+skillsmith audit collisions --json
+skillsmith audit collisions --report-only`}</code></pre>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Option</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>--deep</code></td>
+        <td>Enable semantic-overlap detector pass</td>
+      </tr>
+      <tr>
+        <td><code>--json</code></td>
+        <td>Emit JSON; bypasses prompts and file mutation</td>
+      </tr>
+      <tr>
+        <td><code>--apply-all</code></td>
+        <td>Accept every suggestion (requires typing <code>APPLY ALL</code>)</td>
+      </tr>
+      <tr>
+        <td><code>--report-only</code></td>
+        <td>Write report without interactive prompts</td>
+      </tr>
+      <tr>
+        <td><code>--reset-ledger</code></td>
+        <td>Clear namespace-override ledger (requires typing <code>RESET LEDGER</code>)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>config</h3>
+
+  <p>Get or set Skillsmith configuration values in <code>~/.skillsmith/config.json</code>.</p>
+
+  <h4>config get</h4>
+
+  <p>Print the resolved value of a configuration key.</p>
+
+  <pre><code>{`skillsmith config get audit_mode`}</code></pre>
+
+  <h4>config set</h4>
+
+  <p>Write a configuration value. Tier-revalidated on write — community and individual users cannot select <code>power_user</code> or <code>governance</code>.</p>
+
+  <pre><code>{`skillsmith config set audit_mode preventative
+skillsmith config set audit_mode power_user   # team/enterprise
+skillsmith config set audit_mode governance   # enterprise only
+skillsmith config set audit_mode off`}</code></pre>
 
   <h2>Author Commands</h2>
 

--- a/scripts/smoke-prod/mcp-server.sh
+++ b/scripts/smoke-prod/mcp-server.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
-# SMI-4459 — published MCP server boot smoke. Intentionally minimal per
-# plan Q8: we only verify --version exits 0 and prints a semver. Deeper
-# round-trip (spawning + list_tools) is SMI-4460 territory.
+# SMI-4459 — published MCP server boot smoke.
+# SMI-4590 Wave 4 PR 5/6 — extended with audit-tool registration checks.
+#
+# The boot/version check is intentionally lightweight per plan Q8.
+# The three audit-tool checks install the published tarball into a temp
+# prefix once, then grep the compiled tool-dispatch artifact for the
+# registered tool names. This catches packaging regressions where a
+# tool source file lands in src/ but is excluded from `files` in
+# package.json (the exact failure mode that the post-deploy harness is
+# meant to surface). A deeper JSON-RPC round-trip is SMI-4460 territory.
 
 # shellcheck shell=bash
 # shellcheck source=scripts/smoke-prod/lib.sh
@@ -11,6 +18,58 @@ SMOKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 SMOKE_MCP_PKG="${SMOKE_MCP_PKG:-@skillsmith/mcp-server}"
 SMOKE_MCP_TIMEOUT="${SMOKE_MCP_TIMEOUT:-90}"
+
+# Cached install prefix shared by audit-tool checks. Lazily populated by
+# `_smoke_mcp_install_once` so we pay the npm-install cost once per surface
+# run rather than four times. We register an EXIT trap to clean it up
+# unconditionally (success OR failure), since lib.sh does not own tmp
+# cleanup and CI runners may share /tmp across surface modules.
+SMOKE_MCP_INSTALL_DIR=""
+
+_smoke_mcp_cleanup() {
+  if [ -n "$SMOKE_MCP_INSTALL_DIR" ] && [ -d "$SMOKE_MCP_INSTALL_DIR" ]; then
+    rm -rf "$SMOKE_MCP_INSTALL_DIR"
+    SMOKE_MCP_INSTALL_DIR=""
+  fi
+}
+# Append (don't overwrite) so other smoke modules' EXIT traps still fire.
+trap '_smoke_mcp_cleanup' EXIT
+
+# Lazily install the published mcp-server tarball into a shared temp prefix
+# and echo the directory containing its compiled JS. Subsequent calls reuse
+# the cached install. Echoes the install root on stdout, returns 1 on
+# install failure (after recording a per-check failure via report_fail).
+#
+# Args: $1=surface-id $2=check-name (used for failure attribution).
+_smoke_mcp_install_once() {
+  local surface="$1"
+  local check="$2"
+  if [ -n "$SMOKE_MCP_INSTALL_DIR" ] && [ -d "$SMOKE_MCP_INSTALL_DIR/node_modules" ]; then
+    printf '%s' "$SMOKE_MCP_INSTALL_DIR"
+    return 0
+  fi
+  local prefix
+  prefix=$(mktemp -d)
+  local install_log
+  install_log=$(mktemp)
+  set +e
+  ( cd "$prefix" && timeout "$SMOKE_MCP_TIMEOUT" \
+      npm install --silent --no-audit --no-fund --prefix "$prefix" \
+      "${SMOKE_MCP_PKG}@latest" >"$install_log" 2>&1 )
+  local rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    local snippet
+    snippet=$(head -c 200 "$install_log" 2>/dev/null || true)
+    rm -rf "$prefix" "$install_log"
+    report_fail "$surface" "$check" "npm install ${SMOKE_MCP_PKG}@latest" "exit 0" "exit $rc: $snippet" "0"
+    return 1
+  fi
+  rm -f "$install_log"
+  SMOKE_MCP_INSTALL_DIR="$prefix"
+  printf '%s' "$prefix"
+  return 0
+}
 
 check_mcp_server_version_exits_zero() {
   local t0 t1 ms tmp out rc
@@ -34,5 +93,75 @@ check_mcp_server_version_exits_zero() {
     return 1
   fi
   report_pass "mcp-server-published" "check_mcp_server_version_exits_zero" "npx ${SMOKE_MCP_PKG}@latest --version" "$ms"
+  return 0
+}
+
+# SMI-4590 Wave 4 PR 5/6 — verify `skill_inventory_audit` ships in the
+# published tarball. Greps the compiled `audit-tool-dispatch.js` for the
+# tool name string registered in `buildAuditToolNames`.
+check_skill_inventory_audit_tool_listed() {
+  local t0 t1 ms install dispatch
+  t0=$(now_ms)
+  install=$(_smoke_mcp_install_once "mcp-server-published" "check_skill_inventory_audit_tool_listed") || return 1
+  dispatch="$install/node_modules/${SMOKE_MCP_PKG}/dist/src/audit-tool-dispatch.js"
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  if [ ! -f "$dispatch" ]; then
+    report_fail "mcp-server-published" "check_skill_inventory_audit_tool_listed" "stat ${dispatch#"$install/node_modules/"}" "file present" "missing" "$ms"
+    return 1
+  fi
+  if ! grep -q "'skill_inventory_audit'" "$dispatch"; then
+    report_fail "mcp-server-published" "check_skill_inventory_audit_tool_listed" "grep skill_inventory_audit" "string present" "missing in dispatch" "$ms"
+    return 1
+  fi
+  report_pass "mcp-server-published" "check_skill_inventory_audit_tool_listed" "grep skill_inventory_audit" "$ms"
+  return 0
+}
+
+# SMI-4590 Wave 4 PR 5/6 — verify `apply_namespace_rename` ships.
+check_apply_namespace_rename_tool_listed() {
+  local t0 t1 ms install dispatch
+  t0=$(now_ms)
+  install=$(_smoke_mcp_install_once "mcp-server-published" "check_apply_namespace_rename_tool_listed") || return 1
+  dispatch="$install/node_modules/${SMOKE_MCP_PKG}/dist/src/audit-tool-dispatch.js"
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  if [ ! -f "$dispatch" ]; then
+    report_fail "mcp-server-published" "check_apply_namespace_rename_tool_listed" "stat audit-tool-dispatch.js" "file present" "missing" "$ms"
+    return 1
+  fi
+  if ! grep -q "'apply_namespace_rename'" "$dispatch"; then
+    report_fail "mcp-server-published" "check_apply_namespace_rename_tool_listed" "grep apply_namespace_rename" "string present" "missing in dispatch" "$ms"
+    return 1
+  fi
+  report_pass "mcp-server-published" "check_apply_namespace_rename_tool_listed" "grep apply_namespace_rename" "$ms"
+  return 0
+}
+
+# SMI-4590 Wave 4 PR 5/6 — verify `apply_recommended_edit` is conditionally
+# registered. The dispatcher source MUST contain the conditional push
+# referencing APPLY_TEMPLATE_REGISTRY (the exact registration mechanism).
+# This catches a published artifact where the conditional registration was
+# accidentally hoisted to unconditional or removed entirely.
+check_apply_recommended_edit_conditional() {
+  local t0 t1 ms install dispatch
+  t0=$(now_ms)
+  install=$(_smoke_mcp_install_once "mcp-server-published" "check_apply_recommended_edit_conditional") || return 1
+  dispatch="$install/node_modules/${SMOKE_MCP_PKG}/dist/src/audit-tool-dispatch.js"
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  if [ ! -f "$dispatch" ]; then
+    report_fail "mcp-server-published" "check_apply_recommended_edit_conditional" "stat audit-tool-dispatch.js" "file present" "missing" "$ms"
+    return 1
+  fi
+  if ! grep -q "'apply_recommended_edit'" "$dispatch"; then
+    report_fail "mcp-server-published" "check_apply_recommended_edit_conditional" "grep apply_recommended_edit" "string present" "missing in dispatch" "$ms"
+    return 1
+  fi
+  if ! grep -q "APPLY_TEMPLATE_REGISTRY" "$dispatch"; then
+    report_fail "mcp-server-published" "check_apply_recommended_edit_conditional" "grep APPLY_TEMPLATE_REGISTRY" "conditional gate present" "missing — registration may be unconditional" "$ms"
+    return 1
+  fi
+  report_pass "mcp-server-published" "check_apply_recommended_edit_conditional" "grep apply_recommended_edit + APPLY_TEMPLATE_REGISTRY" "$ms"
   return 0
 }

--- a/scripts/smoke-prod/surfaces.json
+++ b/scripts/smoke-prod/surfaces.json
@@ -71,7 +71,12 @@
       "owner": "mcp-server",
       "trigger_globs": ["packages/mcp-server/**"],
       "script": "scripts/smoke-prod/mcp-server.sh",
-      "checks": ["check_mcp_server_version_exits_zero"]
+      "checks": [
+        "check_mcp_server_version_exits_zero",
+        "check_skill_inventory_audit_tool_listed",
+        "check_apply_namespace_rename_tool_listed",
+        "check_apply_recommended_edit_conditional"
+      ]
     },
     {
       "id": "blog-local-skill-database",


### PR DESCRIPTION
## Summary

Fifth of six PRs landing SMI-4590 Wave 4 (audit-mode plumbing).

- **`sklx audit collisions`** — interactive consumer-namespace audit. Wraps `runInventoryAudit` from `@skillsmith/mcp-server/audit` (PR 4). Flags: `--deep`, `--json`, `--apply-all`, `--report-only`, `--reset-ledger`. Typed-confirmation gates require literal `APPLY ALL` / `RESET LEDGER` (strict equality, no normalization, no validate-and-retry — plan §235-239). Per-item interactive default = `skip` so an inattentive Enter-press cannot mutate state.
- **`sklx config get/set audit_mode`** — atomic tmp+rename write to `~/.skillsmith/config.json`. Two-stage validation: value (`audit.mode.invalid_value`) then tier-revalidation via `tierAllowsAuditMode` (`audit.mode.tier_ineligible`). Both gates raised BEFORE any file IO so rejected writes leave existing config intact (plan §810-813).
- **Smoke-prod harness** (`mcp-server-published` surface) — three new checks verify `skill_inventory_audit`, `apply_namespace_rename`, and `apply_recommended_edit` (conditionally registered via `APPLY_TEMPLATE_REGISTRY`) ship in the published tarball. Catches a packaging regression where source lands but `files` excludes it. Single-install + EXIT-trap cleanup keeps the harness footprint small.

Plan: `docs/internal/implementation/smi-4590-wave-4.md` §4 + §8 + §9 + §10.

In-context multi-perspective review applied refinements:
- E1 (Critical): interactive `select` default → `skip` (was `apply`).
- E2 (High): `_smoke_mcp_install_once` registers EXIT trap.
- E3 (High): `audit-tool-dispatch.ts` carries a comment naming the smoke-check contract so a future refactor updates both sides.
- T1+T2+T3: tests cover `readLedger` preflight, `--apply-all` end-to-end, and a regression guard on `select.default`.

Linear: SMI-4590

## Test plan

- [x] `npx eslint` clean on all 7 touched + 4 new files
- [x] `npx tsc --noEmit -p packages/cli/tsconfig.json` clean
- [x] `npx vitest run` — 36/36 in new files (21 audit-collisions, 15 config)
- [x] `npx vitest run` — 534/534 full @skillsmith/cli suite
- [x] `npm run audit:standards` — 54 passed, 0 failed, 5 pre-existing warnings (none new)
- [x] `prettier --write` across all sources, tests, JSON manifest
- [ ] Branch protection — wait for full CI (lint, typecheck, build, test, security, smoke-prod)
- [ ] Post-merge governance retro

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)