### PR TITLE
feat(mcp-server): SMI-4737 — bound packDomain + token upstream at validators

### DIFF
--- a/packages/mcp-server/src/audit/run-inventory-audit.ts
+++ b/packages/mcp-server/src/audit/run-inventory-audit.ts
@@ -54,6 +54,7 @@ import { runEditSuggester } from './edit-suggester.js'
 import type { RecommendedEdit } from './edit-suggester.types.js'
 import { generateSuggestionChain } from './suggestion-chain.js'
 import type { RenameAction, RenameSuggestion } from './rename-engine.types.js'
+import { FIELD_LIMITS } from '../tools/validate.types.js'
 
 /**
  * Input for {@link runInventoryAudit}. All fields optional — the MCP tool
@@ -228,8 +229,15 @@ function buildRenameSuggestions(
     const action = inventoryKindToRenameAction(target)
     if (action === null) continue // claude_md_rule entries can't be renamed.
 
+    // SMI-4737: defensive cap on filesystem-derived identifier. Filesystem
+    // entries with > 128-char names produce no rename suggestion; the
+    // collision is still surfaced via `result.exactCollisions`.
+    const rawToken = stripLeadingSlash(target.identifier)
+    if (rawToken.length > FIELD_LIMITS.token) {
+      continue
+    }
     const chain = generateSuggestionChain({
-      token: stripLeadingSlash(target.identifier),
+      token: rawToken,
       author: target.meta?.author ?? null,
       packDomain: null,
       tagFallback: target.meta?.tags?.[0] ?? null,

--- a/packages/mcp-server/src/tools/install.test.ts
+++ b/packages/mcp-server/src/tools/install.test.ts
@@ -88,7 +88,7 @@ vi.mock('./install.namespace-gate.js', () => ({
   runNamespaceGate: mockRunNamespaceGate,
 }))
 
-import { installSkill } from './install.js'
+import { installSkill, extractSkillName } from './install.js'
 import type { InstallResult } from './install.types.js'
 
 const HAPPY_RESULT: InstallResult = {
@@ -300,6 +300,62 @@ describe('installSkill() Zod boundary guard (SMI-4288 / #599)', () => {
         'overwrite',
         'bare-name'
       )
+    })
+  })
+
+  // SMI-4737: bound `packDomain` and `token` upstream
+  describe('SMI-4737 — skillId / token boundary caps', () => {
+    it('rejects skillId > 512 chars at the Zod boundary', async () => {
+      const result = await installSkill({ skillId: 'a'.repeat(513) })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Invalid install input')
+      expect(result.error).toContain('skillId exceeds maximum length of 512 chars')
+      expect(mockInstall).not.toHaveBeenCalled()
+    })
+
+    it('accepts skillId at exactly 512 chars when extracted token <= 128 (boundary)', async () => {
+      // 'a'.repeat(383) + '/' + 'b'.repeat(128) = 512 chars total; token = 128 (boundary).
+      const skillId = 'a'.repeat(383) + '/' + 'b'.repeat(128)
+      expect(skillId.length).toBe(512)
+
+      const result = await installSkill({
+        skillId,
+        skipScan: true,
+        skipOptimize: true,
+        confirmed: true,
+      })
+
+      expect(result.success).toBe(true)
+      expect(mockInstall).toHaveBeenCalledTimes(1)
+    })
+
+    it('extractSkillName throws on extracted segment > 128 chars', () => {
+      // 511 chars total — passes Zod 512-cap; extracted segment = 129 — over token cap.
+      const overCap = 'valid/' + 'a'.repeat(129)
+      expect(() => extractSkillName(overCap)).toThrow(/exceeds 128 chars/)
+    })
+
+    it('extractSkillName accepts 128-char extracted segment at boundary', () => {
+      const atCap = 'valid/' + 'a'.repeat(128)
+      expect(extractSkillName(atCap)).toBe('a'.repeat(128))
+    })
+
+    it('installSkill returns structured invalid_skill_id envelope when extractSkillName throws', async () => {
+      // 'a'.repeat(382) + '/' + 'b'.repeat(129) = 512 chars total; passes Zod;
+      // extracted token = 129 → extractSkillName throws → caller wraps.
+      const skillId = 'a'.repeat(382) + '/' + 'b'.repeat(129)
+      expect(skillId.length).toBe(512)
+
+      const result = await installSkill({ skillId })
+
+      expect(result.success).toBe(false)
+      expect(result.skillId).toBe(skillId)
+      expect(result.installPath).toBe('')
+      expect(result.error).toContain('invalid_skill_id')
+      expect(result.error).toContain('128 chars')
+      // Core service must not be invoked when the skillId is rejected upstream.
+      expect(mockInstall).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/mcp-server/src/tools/install.ts
+++ b/packages/mcp-server/src/tools/install.ts
@@ -26,6 +26,7 @@ import type { ToolContext } from '../context.js'
 import { getToolContext } from '../context.js'
 import { CLAUDE_SKILLS_DIR, installInputSchema, type InstallResult } from './install.types.js'
 import { loadManifest, lookupSkillFromRegistry } from './install.helpers.js'
+import { FIELD_LIMITS } from './validate.types.js'
 
 // SMI-1867: Conflict resolution logic (extracted per governance review)
 import { checkForConflicts } from './install.conflict.js'
@@ -75,6 +76,22 @@ function buildValidationError(message: string): InstallResult {
 }
 
 /**
+ * SMI-4737: structured tool-error envelope for `extractSkillName` throws.
+ * Adversarial `skillId` values that survive Zod's 512-char boundary but
+ * produce an over-cap (>128 char) extracted segment are rejected here so
+ * the throw never escapes the MCP handler. Mirrors the `buildValidationError`
+ * shape (application-level failure, not MCP protocol-level `isError`).
+ */
+function buildInvalidSkillIdError(skillId: string, message: string): InstallResult {
+  return {
+    success: false,
+    skillId,
+    installPath: '',
+    error: `invalid_skill_id: ${message}`,
+  }
+}
+
+/**
  * Install a skill from GitHub to the local agent skills directory (~/.claude/skills/).
  *
  * Delegates core logic to SkillInstallationService from @skillsmith/core.
@@ -114,7 +131,17 @@ export async function installSkill(input: unknown, _context?: ToolContext): Prom
   // the install with no side effects. Pre-flight failure is non-blocking
   // (Edit 2) — `runNamespaceGate` swallows internal throws and returns
   // `decision: 'proceed'`.
-  const candidate = buildPreflightCandidate(validInput.skillId)
+  // SMI-4737: extractSkillName (called via buildPreflightCandidate) throws on
+  // over-cap (>128 char) extracted segments; surface as structured envelope.
+  let candidate: CandidateSkill
+  try {
+    candidate = buildPreflightCandidate(validInput.skillId)
+  } catch (err) {
+    return buildInvalidSkillIdError(
+      validInput.skillId,
+      err instanceof Error ? err.message : String(err)
+    )
+  }
   const tier = resolveCallerTier()
   const auditMode = resolveAuditMode({
     tier,
@@ -288,11 +315,29 @@ function readAuditModeOverride() {
 /**
  * Best-effort skill name extraction for conflict pre-check.
  * Does not need to be perfect -- just needs to match manifest keys.
+ *
+ * SMI-4737: throws when the extracted segment exceeds `FIELD_LIMITS.token`
+ * (128 chars). Adversarial `skillId` inputs that survive the Zod 512-char
+ * boundary but produce an over-cap segment are rejected at the derivation
+ * site so they cannot reach `sanitizeSegment`'s defensive 256-char floor
+ * (SMI-4733). Caller sites must wrap in try/catch and surface a structured
+ * tool-error envelope; the throw must not escape the MCP handler.
+ *
+ * Exported for direct unit testing (SMI-4737 tests).
  */
-function extractSkillName(skillId: string): string {
+export function extractSkillName(skillId: string): string {
+  let name: string
   if (skillId.includes('/')) {
     const parts = skillId.split('/')
-    return parts[parts.length - 1]
+    name = parts[parts.length - 1]
+  } else {
+    name = skillId
   }
-  return skillId
+  if (name.length > FIELD_LIMITS.token) {
+    throw new Error(
+      `Extracted skill name exceeds ${FIELD_LIMITS.token} chars (got ${name.length}). ` +
+        `skillId: ${skillId.slice(0, 64)}${skillId.length > 64 ? '...' : ''}`
+    )
+  }
+  return name
 }

--- a/packages/mcp-server/src/tools/install.types.ts
+++ b/packages/mcp-server/src/tools/install.types.ts
@@ -155,7 +155,11 @@ export interface MergeResult {
 
 /** Input schema for install tool */
 export const installInputSchema = z.object({
-  skillId: z.string().min(1).describe('Skill ID or GitHub URL'),
+  skillId: z
+    .string()
+    .min(1)
+    .max(512, 'skillId exceeds maximum length of 512 chars')
+    .describe('Skill ID or GitHub URL'),
   force: z.boolean().default(false).describe('Force reinstall if exists'),
   skipScan: z.boolean().default(false).describe('Skip security scan (not recommended)'),
   /** SMI-1788: Skip optimization transformation */

--- a/packages/mcp-server/src/tools/skill-pack-audit.helpers.ts
+++ b/packages/mcp-server/src/tools/skill-pack-audit.helpers.ts
@@ -131,6 +131,10 @@ export function derivePackDomain(
   allSkills: Array<{ tags?: unknown }>,
   stoplist: GenericTriggersStoplist
 ): string | null {
+  // SMI-4737: bail early on adversarial pack names to avoid wasted work.
+  // Cap is FIELD_LIMITS.packDomain (64) + '-skills'.length (7) = 71.
+  if (packName.length > FIELD_LIMITS.packDomain + '-skills'.length) return null
+
   const genericNamespaces = new Set(stoplist.namespaces.map((n) => n.toLowerCase()))
   const genericWords = new Set(stoplist.triggerWords.map((w) => w.toLowerCase()))
 
@@ -138,7 +142,13 @@ export function derivePackDomain(
   const lowerPack = packName.toLowerCase()
   if (lowerPack.endsWith('-skills') && !genericNamespaces.has(lowerPack)) {
     const prefix = lowerPack.slice(0, -'-skills'.length)
-    if (prefix.length > 0 && !genericNamespaces.has(prefix) && !genericWords.has(prefix)) {
+    // SMI-4737: cap derived prefix at FIELD_LIMITS.packDomain (64).
+    if (
+      prefix.length > 0 &&
+      prefix.length <= FIELD_LIMITS.packDomain &&
+      !genericNamespaces.has(prefix) &&
+      !genericWords.has(prefix)
+    ) {
       return prefix
     }
   }
@@ -170,7 +180,10 @@ export function derivePackDomain(
   // Require the mode to cover at least 2 skills (or the only skill) to avoid
   // picking random one-offs.
   const minSkills = allSkills.length >= 2 ? 2 : 1
-  return bestCount >= minSkills ? bestTag : null
+  if (bestCount < minSkills) return null
+  // SMI-4737: cap derived tag at FIELD_LIMITS.packDomain (64).
+  if (bestTag === null || bestTag.length > FIELD_LIMITS.packDomain) return null
+  return bestTag
 }
 
 /**

--- a/packages/mcp-server/src/tools/validate.types.ts
+++ b/packages/mcp-server/src/tools/validate.types.ts
@@ -76,7 +76,14 @@ export const validateToolSchema = {
 }
 
 /**
- * Maximum field lengths for validation
+ * Maximum field lengths.
+ *
+ * Manifest-field caps (validated via errors.push in validate.helpers.ts):
+ *   name, description, author, version, category, license, tagLength, maxTags
+ *
+ * Derived/extracted caps (validated at the derivation site, fail-fast):
+ *   token       — extracted skill-name segment (SMI-4737)
+ *   packDomain  — derived pack-domain identifier (SMI-4737)
  */
 export const FIELD_LIMITS = {
   name: 64,
@@ -87,6 +94,8 @@ export const FIELD_LIMITS = {
   license: 64,
   tagLength: 32,
   maxTags: 20,
+  token: 128, // SMI-4737: skill-name segment cap (matches author length)
+  packDomain: 64, // SMI-4737: derived pack-domain cap (matches name/category)
 }
 
 /**

--- a/packages/mcp-server/tests/unit/skill-inventory-audit.test.ts
+++ b/packages/mcp-server/tests/unit/skill-inventory-audit.test.ts
@@ -270,3 +270,33 @@ describe('skill_inventory_audit — exclusions filter', () => {
     }
   })
 })
+
+describe('skill_inventory_audit — SMI-4737 token cap on target.identifier', () => {
+  // Defensive cap on filesystem-derived target.identifier. When an inventory
+  // entry's identifier exceeds FIELD_LIMITS.token (128 chars), the audit
+  // pipeline (buildRenameSuggestions in run-inventory-audit.ts) skips
+  // suggestion generation for that flag. The collision is still surfaced
+  // via `exactCollisions`; only the per-flag RenameSuggestion is omitted.
+  it('skips rename suggestion when target.identifier > 128 chars', async () => {
+    const previousHome = process.env['HOME']
+    process.env['HOME'] = TEST_HOME
+    try {
+      const overCapName = 'a'.repeat(129) // 129 > FIELD_LIMITS.token (128)
+      plantSkill(TEST_HOME, overCapName)
+      plantCommand(TEST_HOME, overCapName)
+      const response = await skillInventoryAudit({ homeDir: TEST_HOME })
+      expect(isResponse(response)).toBe(true)
+      if (!isResponse(response)) return
+      // Collision is still reported.
+      expect(response.exactCollisions.length).toBeGreaterThan(0)
+      // But the over-cap identifier produces no rename suggestion.
+      const overCapSuggestion = response.renameSuggestions.find(
+        (s) => s.currentName === overCapName
+      )
+      expect(overCapSuggestion).toBeUndefined()
+    } finally {
+      if (previousHome !== undefined) process.env['HOME'] = previousHome
+      else delete process.env['HOME']
+    }
+  })
+})

--- a/packages/mcp-server/tests/unit/skill-pack-audit.helpers.test.ts
+++ b/packages/mcp-server/tests/unit/skill-pack-audit.helpers.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview Unit tests for skill-pack-audit.helpers — pure helpers.
+ * @module @skillsmith/mcp-server/tests/unit/skill-pack-audit-helpers
+ *
+ * SMI-4737: derivePackDomain returns null when the inferred domain string
+ * exceeds FIELD_LIMITS.packDomain (64 chars). Strategies 1 and 2 each cap
+ * the result independently; an early bail also short-circuits adversarial
+ * pack names before strategy execution.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { derivePackDomain } from '../../src/tools/skill-pack-audit.helpers.js'
+import { FIELD_LIMITS } from '../../src/tools/validate.types.js'
+import type { GenericTriggersStoplist } from '@skillsmith/core'
+
+const EMPTY_STOPLIST: GenericTriggersStoplist = Object.freeze({
+  triggerWords: Object.freeze([]),
+  namespaces: Object.freeze([]),
+  locale: 'en',
+  notes: 'unit-fixture',
+}) as GenericTriggersStoplist
+
+describe('derivePackDomain — SMI-4737 packDomain caps', () => {
+  it('Strategy 1: returns null when stripped prefix > FIELD_LIMITS.packDomain (64)', () => {
+    // 70-char prefix + '-skills' = 77-char pack name; fits under the early-bail
+    // threshold (71 + slack) but exceeds the strategy-1 prefix cap (64).
+    const longPrefix = 'a'.repeat(70)
+    const packName = `${longPrefix}-skills`
+    const result = derivePackDomain(packName, [], EMPTY_STOPLIST)
+    expect(result).toBeNull()
+  })
+
+  it('Strategy 1: returns prefix at the 64-char boundary', () => {
+    const exactPrefix = 'a'.repeat(64)
+    const packName = `${exactPrefix}-skills`
+    const result = derivePackDomain(packName, [], EMPTY_STOPLIST)
+    expect(result).toBe(exactPrefix)
+  })
+
+  it('Strategy 2: returns null when mode tag > FIELD_LIMITS.packDomain (64)', () => {
+    // Pack name does NOT end with `-skills` so Strategy 1 is skipped.
+    // All skills tagged with the same 70-char tag → tag is the mode but
+    // exceeds the cap, so derivation returns null.
+    const longTag = 'b'.repeat(70)
+    const allSkills = [{ tags: [longTag] }, { tags: [longTag] }]
+    const result = derivePackDomain('mypack', allSkills, EMPTY_STOPLIST)
+    expect(result).toBeNull()
+  })
+
+  it('Strategy 2: returns mode tag at the 64-char boundary', () => {
+    const exactTag = 'c'.repeat(FIELD_LIMITS.packDomain)
+    const allSkills = [{ tags: [exactTag] }, { tags: [exactTag] }]
+    const result = derivePackDomain('mypack', allSkills, EMPTY_STOPLIST)
+    expect(result).toBe(exactTag)
+  })
+
+  it('early bail: returns null when packName exceeds 71-char (cap + "-skills") threshold', () => {
+    // 72-char pack name — exceeds the early-bail threshold; both strategies
+    // are skipped entirely.
+    const adversarial = 'd'.repeat(72)
+    const result = derivePackDomain(adversarial, [], EMPTY_STOPLIST)
+    expect(result).toBeNull()
+  })
+
+  it('legitimate domain identifiers pass unchanged (regression guard)', () => {
+    expect(derivePackDomain('planning-skills', [], EMPTY_STOPLIST)).toBe('planning')
+    expect(derivePackDomain('cicd-skills', [], EMPTY_STOPLIST)).toBe('cicd')
+  })
+})


### PR DESCRIPTION
## Summary
- Closes SMI-4737. Follow-up to SMI-4733 (#943, commit `3d649714`).
- Adds upstream caps at parse / derivation time so adversarial manifests are rejected fast instead of silently degrading via SMI-4733's defensive in-`sanitizeSegment` 256-char floor (which stays as layered defense).
- Plan-reviewed (3 Critical, 3 High, 5 Medium, 3 Low — all applied per zero-deferral policy).

## Changes
- **`install.types.ts`** — Zod `.max(512)` on `skillId` at MCP boundary
- **`install.ts`** — `extractSkillName` exported + throws on > 128 chars; caller wraps in try/catch returning structured `invalid_skill_id` envelope
- **`run-inventory-audit.ts`** — defensive `continue` when `target.identifier` > 128
- **`skill-pack-audit.helpers.ts`** — `derivePackDomain` early bail at 71 + Strategy 1/2 cap at 64
- **`validate.types.ts`** — adds `token: 128`, `packDomain: 64` to `FIELD_LIMITS` with JSDoc distinguishing manifest-field vs derived caps

## Tests (12 added)
- `install.test.ts` (+5): Zod boundary, extractSkillName throw, structured envelope
- `skill-inventory-audit.test.ts` (+1): over-cap identifier produces no suggestion
- `skill-pack-audit.helpers.test.ts` (NEW, 6): Strategy 1/2 caps, boundaries, regression

## Test plan
- [x] Typecheck pass, lint 0 warnings (Docker worktree)
- [x] All 12 new tests pass (host vitest)
- [x] SMI-4733 regression (suggestion-chain.test.ts 16/16) still pass
- [ ] CI green (Docker matrix)
- [ ] CodeQL: no new ReDoS alerts; alerts 92 + 93 remain resolved

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)