### PR TITLE
docs(retro): SMI-4740 multi-key license fix retrospective

### DIFF
--- a/tests/e2e/api/license-key-generation.e2e.test.ts
+++ b/tests/e2e/api/license-key-generation.e2e.test.ts
@@ -30,7 +30,7 @@ const STAGING_ANON_KEY = process.env.STAGING_SUPABASE_ANON_KEY
 
 const skipReason =
   !STAGING_URL || !STAGING_SERVICE_KEY || !STAGING_ANON_KEY
-    ? 'STAGING_SUPABASE_* env vars missing — run via: varlock run -- npx vitest run tests/e2e/license-key-generation.e2e.test.ts'
+    ? 'STAGING_SUPABASE_* env vars missing — run via: varlock run -- npx vitest run --config vitest.e2e.config.ts tests/e2e/api/license-key-generation.e2e.test.ts'
     : ''
 
 const describeIfStaged = skipReason ? describe.skip : describe


### PR DESCRIPTION
## Summary

- Adds retrospective for PR #953 / SMI-4740 (multi-key license generation fix)
- Fixes stale path in e2e test skip message (`tests/e2e/` → `tests/e2e/api/`)
- Updates `docs/internal/index.md` folder counts (retros 174→185, implementation 219→238)

## Test plan

- [ ] docs-only + test string change — no functional code paths affected
- [ ] `[skip-impl-check]` not needed (no YAML/config changes)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)