### PR TITLE
feat(session-start-hook): SMI-4590 Wave 4 PR 6/6 — tier-gated audit hook + Enterprise scheduled-scan

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -148,6 +148,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/scripts/session-start-priming.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/session-start-audit.sh"
           }
         ]
       }

--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -69,9 +69,10 @@ jobs:
 
       - name: Install root devDeps (tsx for session-audit hook tests)
         # audit:carveout-pure-js — bash hook tests invoke `npx --no-install tsx`,
-        # which resolves from `node_modules/.bin/tsx` (root devDep). Pure JS,
-        # no native bindings; matches the SMI-4647 carve-out pattern.
-        run: npm ci --ignore-scripts --no-audit --no-fund --omit=optional
+        # which resolves from `node_modules/.bin/tsx` (root devDep). tsx pulls
+        # esbuild, which requires platform-specific optional deps
+        # (`@esbuild/linux-x64`); do NOT pass `--omit=optional` here.
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Hooks unit tests
         run: |

--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -8,6 +8,9 @@
 # SIGTERM thread) suggest gating it only after proven stable.
 name: Validate Hooks
 
+env:
+  NODE_VERSION: '22'
+
 on:
   pull_request:
     paths:
@@ -16,7 +19,10 @@ on:
       - 'scripts/remove-worktree.sh'
       - 'scripts/repair-worktrees.sh'
       - 'scripts/_lib.sh'
+      - 'scripts/session-start-audit.sh'
+      - 'scripts/lib/session-start-audit-helper.ts'
       - 'scripts/tests/create-worktree-hooks.test.sh'
+      - 'scripts/tests/session-start-audit.test.sh'
       - 'scripts/check-file-length.mjs'
       - 'lint-staged.config.js'
       - '.github/workflows/validate-hooks.yml'
@@ -41,7 +47,9 @@ jobs:
             scripts/create-worktree.sh \
             scripts/remove-worktree.sh \
             scripts/repair-worktrees.sh \
-            scripts/tests/create-worktree-hooks.test.sh
+            scripts/session-start-audit.sh \
+            scripts/tests/create-worktree-hooks.test.sh \
+            scripts/tests/session-start-audit.test.sh
 
       - name: Syntax check (bash -n)
         run: |
@@ -49,9 +57,20 @@ jobs:
           bash -n scripts/create-worktree.sh
           bash -n scripts/remove-worktree.sh
           bash -n scripts/repair-worktrees.sh
+          bash -n scripts/session-start-audit.sh
           bash -n scripts/tests/create-worktree-hooks.test.sh
+          bash -n scripts/tests/session-start-audit.test.sh
           sh -n .husky/pre-commit
+
+      - name: Setup Node (for session-audit hook tsx invocations)
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install tsx (root devDep, for session-audit hook tests)
+        run: npm ci --ignore-scripts --no-audit --no-fund --omit=optional || npm i -g tsx
 
       - name: Hooks unit tests
         run: |
           bash scripts/tests/create-worktree-hooks.test.sh
+          bash scripts/tests/session-start-audit.test.sh

--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -67,8 +67,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Install tsx (root devDep, for session-audit hook tests)
-        run: npm ci --ignore-scripts --no-audit --no-fund --omit=optional || npm i -g tsx
+      - name: Install root devDeps (tsx for session-audit hook tests)
+        # audit:carveout-pure-js — bash hook tests invoke `npx --no-install tsx`,
+        # which resolves from `node_modules/.bin/tsx` (root devDep). Pure JS,
+        # no native bindings; matches the SMI-4647 carve-out pattern.
+        run: npm ci --ignore-scripts --no-audit --no-fund --omit=optional
 
       - name: Hooks unit tests
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,9 @@ Vitest only runs tests matching these patterns. Tests elsewhere are **silently i
 | `compare` | Compare 2-5 skills side-by-side |
 | `skill_diff` | Diff two installed skill versions side-by-side |
 | `skill_audit` | Audit skill for security advisories (Team+) |
+| `skill_inventory_audit` | Audit local `~/.claude/` inventory for namespace collisions; returns rename + edit suggestions (SMI-4590) |
+| `apply_namespace_rename` | Apply a rename suggestion from an audit (`apply` / `custom` / `skip`) (SMI-4590) |
+| `apply_recommended_edit` | Apply a recommended prose edit; gated on `APPLY_TEMPLATE_REGISTRY` (SMI-4590) |
 | `audit_export` | Export audit log events for a time range (Enterprise) |
 | `audit_query` | Query audit logs with filters (Enterprise) |
 | `siem_export` | Export audit events for SIEM ingestion (Enterprise) |
@@ -257,7 +260,7 @@ Vitest only runs tests matching these patterns. Tests elsewhere are **silently i
 
 **Trust tiers**: verified (official), community (reviewed), experimental (new/beta).
 
-**CLI**: `skillsmith` or `sklx` — `author subagent/transform/mcp-init`, `sync/status/config`. See [ADR-018](docs/internal/adr/018-registry-sync-system.md).
+**CLI**: `skillsmith` or `sklx` — `author subagent/transform/mcp-init`, `sync/status/config`. See [ADR-018](docs/internal/adr/018-registry-sync-system.md). New in SMI-4590: `sklx audit collisions` (namespace audit, opposite of legacy `sklx audit advisories` security-advisory checker), `sklx config get audit_mode` / `sklx config set audit_mode <preventative|power_user|governance|off>` (tier-revalidated; Free/Individual cannot select `power_user`/`governance`).
 
 ---
 
@@ -351,6 +354,8 @@ npx supabase functions deploy auth-device-preview
 | Edge Function Deploy | On merge to main | GitHub Actions (`deploy-edge-functions.yml`) |
 | Device-login round-trip e2e | Nightly 06:00 UTC + paths-filtered PR (SMI-4460) | GitHub Actions (`device-login-roundtrip.yml`) |
 | Device-login audit_logs cleanup | Sundays 04:00 UTC (SMI-4460) | GitHub Actions (`device-login-roundtrip-cleanup.yml`) |
+| Skillsmith Scheduled Audit (Enterprise governance pass) | On-demand via `runScheduledScan` (SMI-4590); deep + un-filtered findings | `@skillsmith/enterprise/audit` (`runScheduledScan`); idempotent within `SKILLSMITH_SCHEDULED_AUDIT_CACHE_MIN` (default 5 min) |
+| Session-start audit hook (Team/Enterprise) | Per session start, debounced 24h (SMI-4590) | `scripts/session-start-audit.sh` → `scripts/lib/session-start-audit-helper.ts`; tier-gated render (Free/Individual silent) |
 
 Alerts to `support@smithhorn.ca` via Resend on failures. All jobs log to `audit_logs` table. Manual trigger & audit log details: [deployment-guide.md](.claude/development/deployment-guide.md#monitoring--alerts).
 
@@ -444,6 +449,8 @@ varlock run -- sh -c 'npx @vscode/vsce publish --no-dependencies --pat "$VSCE_SK
 
 A `SessionStart` hook (`scripts/session-start-priming.sh`) injects a per-session priming index into initial context as `additionalContext`. Fires only on `source=startup` and `smi-*`/`wave-*` branches. Disable with `SKILLSMITH_DOC_RETRIEVAL_DISABLE_PRIMING=1`. **Memory adapter prerequisite**: requires `SKILLSMITH_PROJECT_DIR_ENCODED` set in `.env` — without it, host-scope memory files don't reach the index. Full mechanism (per-class rank boost SMI-4468, outage marker, env vars): see [ruvector-dev-tooling.md § Session Priming (SMI-4451)](.claude/development/ruvector-dev-tooling.md#session-priming-smi-4451).
 
+**Session-start audit hook (SMI-4590)**: a sibling `SessionStart` hook (`scripts/session-start-audit.sh` → `scripts/lib/session-start-audit-helper.ts`) runs the namespace-audit (`runInventoryAudit`) for Team/Enterprise tiers, debounced 24h via `~/.skillsmith/last-audit.json`. Output is privacy-gated: Free/Individual emit zero output (intentional — silence is not a bug, audit is a paid feature). Team gets a one-line collapsed summary on stderr; Enterprise gets a path-only pointer on stderr. Helper stdout is always empty (priming hook owns the `additionalContext` slot). Bounded 5-second wall clock; helper failure is fail-soft (always exits 0). Disable: `SKILLSMITH_SESSION_AUDIT_DISABLE=1`. Logs: `~/.skillsmith/logs/session-audit-<date>.log` (30-day rotation, opportunistic).
+
 ---
 
 ## Troubleshooting
@@ -460,6 +467,7 @@ A `SessionStart` hook (`scripts/session-start-priming.sh`) injects a per-session
 | Stale CJS artifacts | `docker exec skillsmith-dev-1 bash -c 'find /app/packages -path "*/src/*.js" -not -path "*/node_modules/*" -not -path "*/dist/*" -type f -delete'` |
 | Orphaned agents | `./scripts/cleanup-orphans.sh` (`--dry-run` to preview) |
 | Symlink outside skills root skipped (SMI-4287) | LocalFilesystemAdapter rejects symlinks whose target resolves outside `rootDir` (GitHub #600). Set `allowSymlinksOutsideRoot: true` in `LocalFilesystemConfig` to opt in; caller accepts the security tradeoff. |
+| Session-start audit hook produces unexpected stderr at session start (SMI-4590) | Disable temporarily: `export SKILLSMITH_SESSION_AUDIT_DISABLE=1`. Check `~/.skillsmith/logs/session-audit-<date>.log` for the resolution code (`tier_resolution_failed`, `audit_run_failed`, etc.). Free/Individual tiers should see no output at all — if you do, check that `SKILLSMITH_LICENSE_KEY` env is unset and `~/.skillsmith/config.json` `audit_mode` is unset or `preventative`. |
 
 **Detailed diagnostics** (Symptoms / Root Cause / Fix): [docker-guide.md](.claude/development/docker-guide.md#troubleshooting)
 

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -44,6 +44,7 @@
     "zod": "4.2.1"
   },
   "devDependencies": {
+    "@skillsmith/mcp-server": "*",
     "@smithy/config-resolver": "4.4.13",
     "@smithy/core": "3.23.12",
     "@smithy/middleware-endpoint": "4.4.27",
@@ -53,6 +54,14 @@
     "@smithy/types": "4.13.1",
     "@smithy/util-retry": "4.1.2",
     "vitest": "4.1.2"
+  },
+  "peerDependencies": {
+    "@skillsmith/mcp-server": "*"
+  },
+  "peerDependenciesMeta": {
+    "@skillsmith/mcp-server": {
+      "optional": true
+    }
   },
   "files": [
     "dist"

--- a/packages/enterprise/src/audit/index.ts
+++ b/packages/enterprise/src/audit/index.ts
@@ -70,3 +70,15 @@ export * from './retention/index.js'
 
 // Export from streaming
 export * from './streaming/index.js'
+
+// SMI-4590 Wave 4 PR 6/6 — Enterprise scheduled-scan governance runner.
+// Named export only (no `export *`) to avoid name-collisions with the
+// existing AuditLogger surface above.
+export { runScheduledScan, ScheduledScanError, stripUrlSecrets } from './scheduled-scan.js'
+
+export type {
+  ScheduledScanOptions,
+  ScheduledScanOutput,
+  ScheduledScanResult,
+  ScheduledScanErrorCode,
+} from './scheduled-scan.types.js'

--- a/packages/enterprise/src/audit/scheduled-scan.ts
+++ b/packages/enterprise/src/audit/scheduled-scan.ts
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright 2024-2025 Smith Horn Group Ltd
+
+/**
+ * @fileoverview Enterprise scheduled-scan governance runner.
+ * @module @skillsmith/enterprise/audit/scheduled-scan
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §7
+ * (Wave 4 PR 6/6, SMI-4590).
+ *
+ * Composes `runInventoryAudit({ deep: true, applyExclusions: false })`
+ * with:
+ *   - Idempotency cache (default 5 min, env-overridable)
+ *   - Output dispatch (file default OR webhook fallback-to-file)
+ *   - Webhook URL secret stripping on failure logging
+ *
+ * Why `applyExclusions: false`: the governance pass MUST see un-filtered
+ * findings so policy enforcement doesn't get blindfolded by a user-curated
+ * exclusions file. The exclusions file remains useful for the per-session
+ * Team-tier hook (PR 6's session-start helper) — that's where users opt
+ * into "this collision is fine".
+ *
+ * Privacy: URL path/query is stripped before logging. Webhook URLs of the
+ * form `https://hooks.slack.com/services/T123/B456/SECRETKEY` only have
+ * `https://hooks.slack.com` recorded on delivery failure.
+ */
+
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import type {
+  ScheduledScanErrorCode,
+  ScheduledScanOptions,
+  ScheduledScanResult,
+} from './scheduled-scan.types.js'
+
+/**
+ * Resolve `runInventoryAudit` via dynamic import. Avoids a hard package
+ * cycle: `@skillsmith/mcp-server` already declares
+ * `@skillsmith/enterprise` as an optional peer dep, so a static
+ * `import { runInventoryAudit } from '@skillsmith/mcp-server/audit'`
+ * here would close the cycle. Dynamic import keeps the cycle lazy and
+ * lets the type system see the function shape via the `import type` of
+ * the helper's options/result while runtime resolution stays deferred.
+ */
+type RunInventoryAuditFn = (opts: {
+  deep?: boolean
+  applyExclusions?: boolean
+  tier?: 'community' | 'individual' | 'team' | 'enterprise'
+  homeDir?: string
+  projectDir?: string
+}) => Promise<{
+  auditId: string
+  reportPath: string
+  exactCollisions: unknown[]
+  genericFlags: unknown[]
+  semanticCollisions: unknown[]
+}>
+
+async function loadRunInventoryAudit(): Promise<RunInventoryAuditFn> {
+  // Module path is a static string so bundlers can analyze it; the
+  // dynamic-import wrapping is only what defers cycle resolution.
+  const mod = (await import('@skillsmith/mcp-server/audit')) as {
+    runInventoryAudit: RunInventoryAuditFn
+  }
+  return mod.runInventoryAudit
+}
+
+const DEFAULT_CACHE_MINUTES = 5
+const MIN_CACHE_MINUTES = 1
+const MAX_CACHE_MINUTES = 1440 // 24h
+const WEBHOOK_TIMEOUT_MS = 10_000
+
+/**
+ * Typed error for runner failures. Carries a `code` field so callers (CI
+ * workflows, Enterprise admin tooling) can branch without string-matching.
+ */
+export class ScheduledScanError extends Error {
+  readonly code: ScheduledScanErrorCode
+
+  constructor(code: ScheduledScanErrorCode, message: string) {
+    super(message)
+    this.name = 'ScheduledScanError'
+    this.code = code
+  }
+}
+
+/**
+ * Run the Enterprise governance audit. Idempotent within the cache
+ * window — returns the cached `auditId` + `reportPath` if a recent audit
+ * dir is present.
+ *
+ * @throws {ScheduledScanError} On underlying audit failure or invalid
+ *   options. Webhook delivery failures do NOT throw — they fall back to
+ *   file output and surface via `outputDisposition: 'webhook_fallback'`.
+ */
+export async function runScheduledScan(
+  opts: ScheduledScanOptions = {}
+): Promise<ScheduledScanResult> {
+  const startedAt = process.hrtime.bigint()
+  const homeDir = opts.homeDir ?? os.homedir()
+  const cacheMinutes = resolveCacheMinutes(opts.cacheMinutes)
+
+  // Idempotency cache check — keyed on the resolved homeDir's audits dir.
+  if (!opts.force) {
+    const cached = await findRecentAudit(homeDir, cacheMinutes)
+    if (cached !== null) {
+      return {
+        ...cached,
+        cached: true,
+        outputDisposition: 'file',
+        durationMs: nsToMs(process.hrtime.bigint() - startedAt),
+      }
+    }
+  }
+
+  // Fresh audit. Governance mode: deep + un-filtered. The
+  // `runInventoryAudit` import is dynamic to avoid a hard package
+  // cycle (mcp-server lists enterprise as an optional peer dep).
+  let auditResult
+  try {
+    const runInventoryAudit = await loadRunInventoryAudit()
+    auditResult = await runInventoryAudit({
+      deep: true,
+      applyExclusions: false,
+      tier: 'enterprise',
+      homeDir,
+      ...(opts.projectDir !== undefined ? { projectDir: opts.projectDir } : {}),
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new ScheduledScanError(
+      'scheduled_scan.audit_failed',
+      `Inventory audit failed during scheduled scan: ${message}`
+    )
+  }
+
+  const counts = {
+    exact: auditResult.exactCollisions.length,
+    generic: auditResult.genericFlags.length,
+    semantic: auditResult.semanticCollisions.length,
+  }
+
+  // Output dispatch.
+  const output = opts.output ?? { kind: 'file' as const }
+  let outputDisposition: ScheduledScanResult['outputDisposition'] = 'file'
+
+  if (output.kind === 'webhook') {
+    const webhookOk = await deliverWebhook(output.url, {
+      auditId: auditResult.auditId,
+      reportPath: auditResult.reportPath,
+      counts,
+    })
+    if (webhookOk) {
+      outputDisposition = 'webhook'
+    } else {
+      await logWebhookFailure(homeDir, output.url, auditResult.auditId)
+      outputDisposition = 'webhook_fallback'
+    }
+  }
+
+  return {
+    auditId: auditResult.auditId,
+    reportPath: auditResult.reportPath,
+    cached: false,
+    counts,
+    outputDisposition,
+    durationMs: nsToMs(process.hrtime.bigint() - startedAt),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resolveCacheMinutes(explicit: number | undefined): number {
+  const candidate = explicit ?? readEnvCacheMinutes() ?? DEFAULT_CACHE_MINUTES
+  if (!Number.isFinite(candidate) || candidate < MIN_CACHE_MINUTES) {
+    throw new ScheduledScanError(
+      'scheduled_scan.invalid_cache_minutes',
+      `cacheMinutes must be >= ${MIN_CACHE_MINUTES}, got ${candidate}`
+    )
+  }
+  if (candidate > MAX_CACHE_MINUTES) {
+    throw new ScheduledScanError(
+      'scheduled_scan.invalid_cache_minutes',
+      `cacheMinutes must be <= ${MAX_CACHE_MINUTES}, got ${candidate}`
+    )
+  }
+  return candidate
+}
+
+function readEnvCacheMinutes(): number | null {
+  const raw = process.env['SKILLSMITH_SCHEDULED_AUDIT_CACHE_MIN']
+  if (!raw) return null
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
+ * Walk `~/.skillsmith/audits/` looking for the most-recent audit dir
+ * whose `result.json` mtime is within `cacheMinutes`. Returns
+ * `{ auditId, reportPath, counts }` or null.
+ *
+ * The cache key is implicitly per-`homeDir` because the audits dir is
+ * rooted there — multiple environments (test, dev, prod) each have
+ * their own cache.
+ */
+async function findRecentAudit(
+  homeDir: string,
+  cacheMinutes: number
+): Promise<{
+  auditId: string
+  reportPath: string
+  counts: { exact: number; generic: number; semantic: number }
+} | null> {
+  const auditsDir = path.join(homeDir, '.skillsmith', 'audits')
+  let entries: string[]
+  try {
+    entries = await fs.readdir(auditsDir)
+  } catch {
+    return null
+  }
+
+  const now = Date.now()
+  const cutoffMs = cacheMinutes * 60 * 1000
+  let mostRecent: { auditId: string; mtimeMs: number; reportPath: string } | null = null
+
+  for (const entry of entries) {
+    const resultPath = path.join(auditsDir, entry, 'result.json')
+    let stat
+    try {
+      stat = await fs.stat(resultPath)
+    } catch {
+      continue
+    }
+    const ageMs = now - stat.mtimeMs
+    if (ageMs > cutoffMs) continue
+    if (mostRecent === null || stat.mtimeMs > mostRecent.mtimeMs) {
+      mostRecent = {
+        auditId: entry,
+        mtimeMs: stat.mtimeMs,
+        reportPath: path.join(auditsDir, entry, 'report.md'),
+      }
+    }
+  }
+
+  if (mostRecent === null) return null
+
+  // Derive counts from the cached result.json so callers don't have to
+  // re-read it themselves.
+  let counts = { exact: 0, generic: 0, semantic: 0 }
+  try {
+    const resultRaw = await fs.readFile(
+      path.join(auditsDir, mostRecent.auditId, 'result.json'),
+      'utf-8'
+    )
+    const parsed = JSON.parse(resultRaw) as {
+      exactCollisions?: unknown[]
+      genericFlags?: unknown[]
+      semanticCollisions?: unknown[]
+    }
+    counts = {
+      exact: Array.isArray(parsed.exactCollisions) ? parsed.exactCollisions.length : 0,
+      generic: Array.isArray(parsed.genericFlags) ? parsed.genericFlags.length : 0,
+      semantic: Array.isArray(parsed.semanticCollisions) ? parsed.semanticCollisions.length : 0,
+    }
+  } catch {
+    // Counts are best-effort; cached path is the source of truth.
+  }
+
+  return {
+    auditId: mostRecent.auditId,
+    reportPath: mostRecent.reportPath,
+    counts,
+  }
+}
+
+interface WebhookPayload {
+  auditId: string
+  reportPath: string
+  counts: { exact: number; generic: number; semantic: number }
+}
+
+async function deliverWebhook(url: string, payload: WebhookPayload): Promise<boolean> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS)
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    })
+    return response.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Append a webhook failure record. Strips path + query from the URL —
+ * scheme+host only — because webhook URLs commonly carry secrets in
+ * path segments (e.g., Slack `/services/T../B../SECRET`).
+ */
+async function logWebhookFailure(homeDir: string, url: string, auditId: string): Promise<void> {
+  const logPath = path.join(homeDir, '.skillsmith', 'scheduled-scan-webhook-failures.log')
+  const entry = {
+    timestamp: new Date().toISOString(),
+    url: stripUrlSecrets(url),
+    auditId,
+  }
+  try {
+    await fs.mkdir(path.dirname(logPath), { recursive: true, mode: 0o700 })
+    await fs.appendFile(logPath, JSON.stringify(entry) + '\n', { mode: 0o600 })
+  } catch {
+    // Best-effort: failure to log is not fatal.
+  }
+}
+
+/**
+ * Reduce a webhook URL to `<scheme>://<host>` so secrets in path or
+ * query never reach the failure log. Falls back to `'<unparseable>'`
+ * if URL parsing throws.
+ */
+export function stripUrlSecrets(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.protocol}//${parsed.host}`
+  } catch {
+    return '<unparseable>'
+  }
+}
+
+function nsToMs(ns: bigint): number {
+  return Number(ns) / 1_000_000
+}

--- a/packages/enterprise/src/audit/scheduled-scan.types.ts
+++ b/packages/enterprise/src/audit/scheduled-scan.types.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright 2024-2025 Smith Horn Group Ltd
+
+/**
+ * @fileoverview Types for the Enterprise scheduled-scan governance pass.
+ * @module @skillsmith/enterprise/audit/scheduled-scan.types
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §7
+ * (Wave 4 PR 6/6, SMI-4590).
+ *
+ * The runner exists so an Enterprise admin's scheduled job (cron, GitHub
+ * Actions, manual invocation) can produce a governance-grade audit pass
+ * with `applyExclusions: false` — un-filtered findings for policy review.
+ *
+ * The runner is idempotent within a configurable cache window (default 5
+ * minutes, env `SKILLSMITH_SCHEDULED_AUDIT_CACHE_MIN`) so duplicate fires
+ * (CI retries, manual reruns) don't double-scan.
+ */
+
+/**
+ * Output sink for the scheduled-scan result. Webhook delivery is
+ * best-effort: a delivery failure falls back to file output and records
+ * the failure in `~/.skillsmith/scheduled-scan-webhook-failures.log`
+ * (scheme+host only — never path/query, which can carry secrets).
+ */
+export type ScheduledScanOutput = { kind: 'file'; path?: string } | { kind: 'webhook'; url: string }
+
+export interface ScheduledScanOptions {
+  /**
+   * Override `os.homedir()`. Tests stub this to a tmp dir.
+   */
+  homeDir?: string
+
+  /**
+   * Optional project CLAUDE.md to include in the inventory scan. Mirrors
+   * `runInventoryAudit`'s `projectDir` plumbing.
+   */
+  projectDir?: string
+
+  /**
+   * Output destination. Defaults to `{ kind: 'file' }` which writes the
+   * canonical audit dir under `~/.skillsmith/audits/<auditId>/`. When
+   * `kind === 'webhook'` the runner POSTs the result JSON to `url`; on
+   * delivery failure falls back to file output.
+   *
+   * URL secrets in path/query are NEVER logged on failure — only
+   * `<scheme>://<host>` is recorded.
+   */
+  output?: ScheduledScanOutput
+
+  /**
+   * Idempotency cache window in minutes. A re-run within this window
+   * returns the cached `auditId` + `reportPath` without re-invoking
+   * `runInventoryAudit`. Default: 5 minutes (configurable via env
+   * `SKILLSMITH_SCHEDULED_AUDIT_CACHE_MIN`, clamped `[1, 1440]`).
+   *
+   * The cache key is the most-recent `~/.skillsmith/audits/<auditId>/`
+   * mtime under the resolved `homeDir`, so each environment has its
+   * own cache — no global racing.
+   */
+  cacheMinutes?: number
+
+  /**
+   * Force a re-run even if the cache window says we're current. Useful
+   * for manual `--force` re-runs by Enterprise admins.
+   */
+  force?: boolean
+}
+
+export interface ScheduledScanResult {
+  /** Audit ID (cached or freshly generated). */
+  auditId: string
+
+  /** Absolute path to the rendered `report.md`. */
+  reportPath: string
+
+  /**
+   * `true` if the result came from the idempotency cache (i.e. a recent
+   * audit dir was found and re-used). `false` if a fresh audit was run.
+   */
+  cached: boolean
+
+  /** Counts surfaced for the runner caller (e.g. CI workflow summary). */
+  counts: {
+    exact: number
+    generic: number
+    semantic: number
+  }
+
+  /**
+   * Output disposition. `'file'` means the audit dir is the only output.
+   * `'webhook'` means the webhook delivery succeeded. `'webhook_fallback'`
+   * means the webhook failed and the file output was used; the failure
+   * was logged to `~/.skillsmith/scheduled-scan-webhook-failures.log`.
+   */
+  outputDisposition: 'file' | 'webhook' | 'webhook_fallback'
+
+  /** Total wall-clock duration in milliseconds. */
+  durationMs: number
+}
+
+/**
+ * Typed error codes the runner may surface. Surfaced via thrown
+ * `ScheduledScanError` (see `scheduled-scan.ts`).
+ */
+export type ScheduledScanErrorCode =
+  | 'scheduled_scan.audit_failed'
+  | 'scheduled_scan.invalid_cache_minutes'
+  | 'scheduled_scan.invalid_output'

--- a/packages/enterprise/tests/audit/scheduled-scan.test.ts
+++ b/packages/enterprise/tests/audit/scheduled-scan.test.ts
@@ -1,0 +1,266 @@
+/**
+ * @fileoverview Unit tests for the Enterprise scheduled-scan runner.
+ * @module @skillsmith/enterprise/audit/scheduled-scan.test
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §7
+ * (Wave 4 PR 6/6, SMI-4590).
+ *
+ * Coverage:
+ *   - Idempotency cache hit (recent audit dir → return cached)
+ *   - Idempotency cache miss (no audit dir → run fresh)
+ *   - Cache window override via `cacheMinutes`
+ *   - Force flag bypasses cache
+ *   - `applyExclusions: false` propagates to runInventoryAudit
+ *   - Webhook delivery success
+ *   - Webhook delivery failure → fallback to file + failure log
+ *   - URL secret stripping (path/query never logged)
+ *   - Invalid cacheMinutes → ScheduledScanError
+ */
+
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ScheduledScanError, stripUrlSecrets } from '../../src/audit/scheduled-scan.js'
+
+// Mock @skillsmith/mcp-server/audit so we can control runInventoryAudit
+// without invoking the real audit pipeline (which scans the host inventory).
+const mockRunInventoryAudit = vi.fn()
+vi.mock('@skillsmith/mcp-server/audit', () => ({
+  get runInventoryAudit() {
+    return mockRunInventoryAudit
+  },
+}))
+
+describe('runScheduledScan', () => {
+  let tmpHome: string
+  // Late-binding import — the dynamic-import branch in scheduled-scan.ts
+  // resolves the mock above only after vi.mock is wired.
+  let runScheduledScan: (typeof import('../../src/audit/scheduled-scan.js'))['runScheduledScan']
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'scheduled-scan-test-'))
+    await fs.mkdir(path.join(tmpHome, '.skillsmith'), { recursive: true, mode: 0o700 })
+    mockRunInventoryAudit.mockReset()
+    const mod = await import('../../src/audit/scheduled-scan.js')
+    runScheduledScan = mod.runScheduledScan
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpHome, { recursive: true, force: true })
+    delete process.env['SKILLSMITH_SCHEDULED_AUDIT_CACHE_MIN']
+  })
+
+  it('returns a fresh audit when no cache present', async () => {
+    mockRunInventoryAudit.mockResolvedValue({
+      auditId: 'AUDIT-FRESH-1',
+      reportPath: path.join(tmpHome, '.skillsmith', 'audits', 'AUDIT-FRESH-1', 'report.md'),
+      exactCollisions: [{}, {}],
+      genericFlags: [{}],
+      semanticCollisions: [],
+    })
+
+    const result = await runScheduledScan({ homeDir: tmpHome })
+
+    expect(result.cached).toBe(false)
+    expect(result.auditId).toBe('AUDIT-FRESH-1')
+    expect(result.counts).toEqual({ exact: 2, generic: 1, semantic: 0 })
+    expect(result.outputDisposition).toBe('file')
+    expect(mockRunInventoryAudit).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates applyExclusions:false and tier:enterprise to runInventoryAudit', async () => {
+    mockRunInventoryAudit.mockResolvedValue({
+      auditId: 'A',
+      reportPath: 'r',
+      exactCollisions: [],
+      genericFlags: [],
+      semanticCollisions: [],
+    })
+
+    await runScheduledScan({ homeDir: tmpHome })
+
+    expect(mockRunInventoryAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applyExclusions: false,
+        deep: true,
+        tier: 'enterprise',
+        homeDir: tmpHome,
+      })
+    )
+  })
+
+  it('returns the cached result when a recent audit dir exists', async () => {
+    // Plant a recent audit dir.
+    const auditDir = path.join(tmpHome, '.skillsmith', 'audits', 'AUDIT-CACHED-1')
+    await fs.mkdir(auditDir, { recursive: true })
+    await fs.writeFile(
+      path.join(auditDir, 'result.json'),
+      JSON.stringify({
+        exactCollisions: [{ a: 1 }],
+        genericFlags: [],
+        semanticCollisions: [{ b: 2 }, { c: 3 }],
+      })
+    )
+    await fs.writeFile(path.join(auditDir, 'report.md'), '# test')
+
+    const result = await runScheduledScan({ homeDir: tmpHome, cacheMinutes: 60 })
+
+    expect(result.cached).toBe(true)
+    expect(result.auditId).toBe('AUDIT-CACHED-1')
+    expect(result.counts).toEqual({ exact: 1, generic: 0, semantic: 2 })
+    expect(mockRunInventoryAudit).not.toHaveBeenCalled()
+  })
+
+  it('skips the cache when force:true is passed', async () => {
+    const auditDir = path.join(tmpHome, '.skillsmith', 'audits', 'AUDIT-CACHED-2')
+    await fs.mkdir(auditDir, { recursive: true })
+    await fs.writeFile(
+      path.join(auditDir, 'result.json'),
+      JSON.stringify({ exactCollisions: [], genericFlags: [], semanticCollisions: [] })
+    )
+    mockRunInventoryAudit.mockResolvedValue({
+      auditId: 'AUDIT-FORCED-1',
+      reportPath: 'r',
+      exactCollisions: [],
+      genericFlags: [],
+      semanticCollisions: [],
+    })
+
+    const result = await runScheduledScan({
+      homeDir: tmpHome,
+      cacheMinutes: 60,
+      force: true,
+    })
+
+    expect(result.cached).toBe(false)
+    expect(result.auditId).toBe('AUDIT-FORCED-1')
+    expect(mockRunInventoryAudit).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats audits older than cacheMinutes as a miss', async () => {
+    const auditDir = path.join(tmpHome, '.skillsmith', 'audits', 'AUDIT-STALE-1')
+    await fs.mkdir(auditDir, { recursive: true })
+    const resultPath = path.join(auditDir, 'result.json')
+    await fs.writeFile(
+      resultPath,
+      JSON.stringify({ exactCollisions: [], genericFlags: [], semanticCollisions: [] })
+    )
+    // Set mtime to 1 hour ago.
+    const oldTime = Date.now() / 1000 - 3600
+    await fs.utimes(resultPath, oldTime, oldTime)
+
+    mockRunInventoryAudit.mockResolvedValue({
+      auditId: 'AUDIT-FRESH-2',
+      reportPath: 'r',
+      exactCollisions: [],
+      genericFlags: [],
+      semanticCollisions: [],
+    })
+
+    // 5-min cache window — 1h-old audit is stale.
+    const result = await runScheduledScan({ homeDir: tmpHome, cacheMinutes: 5 })
+
+    expect(result.cached).toBe(false)
+    expect(mockRunInventoryAudit).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects invalid cacheMinutes', async () => {
+    await expect(runScheduledScan({ homeDir: tmpHome, cacheMinutes: 0 })).rejects.toThrow(
+      ScheduledScanError
+    )
+    await expect(runScheduledScan({ homeDir: tmpHome, cacheMinutes: 100_000 })).rejects.toThrow(
+      ScheduledScanError
+    )
+  })
+
+  it('reads the cache window from SKILLSMITH_SCHEDULED_AUDIT_CACHE_MIN env', async () => {
+    process.env['SKILLSMITH_SCHEDULED_AUDIT_CACHE_MIN'] = '60'
+    const auditDir = path.join(tmpHome, '.skillsmith', 'audits', 'AUDIT-ENV-1')
+    await fs.mkdir(auditDir, { recursive: true })
+    await fs.writeFile(
+      path.join(auditDir, 'result.json'),
+      JSON.stringify({ exactCollisions: [], genericFlags: [], semanticCollisions: [] })
+    )
+    const oldTime = Date.now() / 1000 - 1800 // 30 min ago — within 60-min env cache.
+    await fs.utimes(path.join(auditDir, 'result.json'), oldTime, oldTime)
+
+    const result = await runScheduledScan({ homeDir: tmpHome })
+
+    expect(result.cached).toBe(true)
+    expect(mockRunInventoryAudit).not.toHaveBeenCalled()
+  })
+
+  it('wraps audit failures in ScheduledScanError', async () => {
+    mockRunInventoryAudit.mockRejectedValue(new Error('inventory boom'))
+    await expect(runScheduledScan({ homeDir: tmpHome })).rejects.toThrow(ScheduledScanError)
+  })
+
+  it('marks output as webhook on successful delivery', async () => {
+    mockRunInventoryAudit.mockResolvedValue({
+      auditId: 'AUDIT-WH-1',
+      reportPath: 'r',
+      exactCollisions: [],
+      genericFlags: [],
+      semanticCollisions: [],
+    })
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }))
+
+    const result = await runScheduledScan({
+      homeDir: tmpHome,
+      output: { kind: 'webhook', url: 'https://example.com/hook' },
+    })
+
+    expect(result.outputDisposition).toBe('webhook')
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    fetchSpy.mockRestore()
+  })
+
+  it('falls back to file output and logs a redacted failure on webhook error', async () => {
+    mockRunInventoryAudit.mockResolvedValue({
+      auditId: 'AUDIT-WH-2',
+      reportPath: 'r',
+      exactCollisions: [],
+      genericFlags: [],
+      semanticCollisions: [],
+    })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'))
+
+    // URL with secrets in path — must NEVER reach the failure log verbatim.
+    const secretUrl = 'https://hooks.slack.com/services/T1/B2/SECRETKEY?token=opaque'
+    const result = await runScheduledScan({
+      homeDir: tmpHome,
+      output: { kind: 'webhook', url: secretUrl },
+    })
+
+    expect(result.outputDisposition).toBe('webhook_fallback')
+
+    const logPath = path.join(tmpHome, '.skillsmith', 'scheduled-scan-webhook-failures.log')
+    const logRaw = await fs.readFile(logPath, 'utf-8')
+    expect(logRaw).toContain('https://hooks.slack.com')
+    // The path and query MUST be stripped — never logged.
+    expect(logRaw).not.toContain('SECRETKEY')
+    expect(logRaw).not.toContain('opaque')
+    expect(logRaw).not.toContain('/services/')
+    fetchSpy.mockRestore()
+  })
+})
+
+describe('stripUrlSecrets', () => {
+  it('strips path and query', () => {
+    expect(stripUrlSecrets('https://hooks.slack.com/services/T1/B2/SECRET?x=1')).toBe(
+      'https://hooks.slack.com'
+    )
+  })
+
+  it('preserves port', () => {
+    expect(stripUrlSecrets('http://example.com:8080/x/y')).toBe('http://example.com:8080')
+  })
+
+  it('returns "<unparseable>" for invalid URLs', () => {
+    expect(stripUrlSecrets('not a url')).toBe('<unparseable>')
+  })
+})

--- a/scripts/lib/session-start-audit-helper.ts
+++ b/scripts/lib/session-start-audit-helper.ts
@@ -1,0 +1,414 @@
+#!/usr/bin/env tsx
+/**
+ * SMI-4590 Wave 4 PR 6/6 — SessionStart audit helper.
+ *
+ * Invoked by `scripts/session-start-audit.sh` after gate checks pass.
+ * Resolves the caller's tier + audit_mode, applies a 24h debounce, and
+ * runs `runInventoryAudit` for Team/Enterprise users only. Output is
+ * tier-gated:
+ *   - community / individual  → empty stdout (no findings rendered).
+ *   - team                    → ONE-LINE collapsed summary on stderr; empty stdout.
+ *   - enterprise              → ONE-LINE pointer to report path on stderr; empty stdout.
+ *   - tier resolution failure → silent (community fallback). Never default-to-leak.
+ *
+ * Privacy boundary (LOAD-BEARING):
+ *   - Per-entry detail (file paths, identifiers, embeddings) MUST NEVER
+ *     reach stdout or stderr — only counts and the audit report path.
+ *   - The `renderForTier` helper takes a typed `RenderInput` shape that
+ *     EXCLUDES per-entry fields, so per-entry leakage is a type error.
+ *   - Free/Individual paths NEVER load the audit pipeline (`runInventoryAudit`
+ *     is dynamically imported AFTER the tier gate, so the 99% Free path
+ *     pays nothing for the gated module).
+ *
+ * Why .ts (not .mjs): cross-package TypeScript imports require tsx
+ * runtime resolution. Pure Node .mjs cannot import from packages/*\/src.
+ * Precedent: `scripts/session-priming-query.ts` (SMI-4451 Wave 1).
+ *
+ * Why dynamic import for getLicenseStatus: scripts/lib/ should not
+ * statically depend on `packages/cli/src/utils/license-validation.ts`
+ * (direction-of-dependency violation — CLI is a leaf). Dynamic import
+ * lets the helper bridge into the CLI utility without coupling the
+ * scripts/ build to a CLI rebuild.
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §6.
+ */
+
+import { execFile } from 'node:child_process'
+import * as fs from 'node:fs/promises'
+import { homedir } from 'node:os'
+import * as path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileP = promisify(execFile)
+
+// 24h debounce for the per-session audit. Configurable via env for tests.
+const DEFAULT_DEBOUNCE_HOURS = 24
+
+interface ResolvedContext {
+  tier: 'community' | 'individual' | 'team' | 'enterprise'
+  auditMode: 'preventative' | 'power_user' | 'governance' | 'off'
+  /** True when the user manually edited config to a tier-ineligible mode. */
+  tierIneligibleOverride: boolean
+}
+
+/**
+ * The render-input shape EXCLUDES per-entry fields by construction.
+ * This is the only data type the renderer is permitted to see — so a
+ * future contributor adding "let me print the colliding files inline"
+ * cannot do so without changing the type signature, which gets caught
+ * in code review.
+ */
+interface RenderInput {
+  counts: { exact: number; generic: number; semantic: number }
+  reportPath: string
+}
+
+interface RenderOutput {
+  /** Reserved — always '' for the audit hook (priming hook owns stdout). */
+  stdout: string
+  /** Human-readable summary for the terminal. */
+  stderr: string
+}
+
+async function main(): Promise<number> {
+  const home = homedir()
+  await opportunisticLogRotation(home)
+
+  // Stage 1: resolve tier + mode. Failures fall through to a silent
+  // community-equivalent return (NEVER default-to-leak).
+  let ctx: ResolvedContext
+  try {
+    ctx = await resolveContext(home)
+  } catch (err) {
+    await logError(home, 'tier_resolution_failed', err)
+    return 0
+  }
+
+  // Stage 2: short-circuit for any tier/mode that should not run an audit.
+  // Free/Individual + community-default = silent. mode='off' = silent.
+  // tierIneligibleOverride = silent (defense-in-depth).
+  if (ctx.tierIneligibleOverride) {
+    await logInfo(home, 'tier_disqualified', { tier: ctx.tier, auditMode: ctx.auditMode })
+    return 0
+  }
+  if (ctx.auditMode === 'off') {
+    await logInfo(home, 'user_opted_out', { tier: ctx.tier })
+    return 0
+  }
+  if (ctx.auditMode === 'preventative') {
+    await logInfo(
+      home,
+      ctx.tier === 'community' || ctx.tier === 'individual'
+        ? 'tier_preventative'
+        : 'mode_not_continuous',
+      { tier: ctx.tier }
+    )
+    return 0
+  }
+
+  // Stage 3: 24h debounce.
+  const debounceHours = readDebounceHours()
+  const lastAuditPath = path.join(home, '.skillsmith', 'last-audit.json')
+  if (await isDebounced(lastAuditPath, debounceHours)) {
+    await logInfo(home, 'debounced', { tier: ctx.tier })
+    return 0
+  }
+
+  // Stage 4: run the audit. Dynamic import — costs nothing for the
+  // 99% Free/Individual path that never reaches here.
+  let runInventoryAudit
+  try {
+    const mod = await import('@skillsmith/mcp-server/audit')
+    runInventoryAudit = mod.runInventoryAudit
+  } catch (err) {
+    await logError(home, 'audit_module_load_failed', err)
+    return 0
+  }
+
+  let auditResult
+  try {
+    auditResult = await runInventoryAudit({
+      deep: ctx.auditMode === 'governance',
+      applyExclusions: true,
+      tier: ctx.tier,
+      homeDir: home,
+    })
+  } catch (err) {
+    await logError(home, 'audit_run_failed', err)
+    return 0
+  }
+
+  // Stage 5: render via the typed-input gate. Per-entry fields are NOT
+  // in `RenderInput`, so they cannot leak.
+  const renderInput: RenderInput = {
+    counts: {
+      exact: auditResult.exactCollisions.length,
+      generic: auditResult.genericFlags.length,
+      semantic: auditResult.semanticCollisions.length,
+    },
+    reportPath: auditResult.reportPath,
+  }
+  const rendered = renderForTier(ctx.tier, renderInput)
+
+  // stdout contract: empty (priming hook owns the additionalContext slot).
+  if (rendered.stdout.length > 0) {
+    process.stdout.write(rendered.stdout)
+  }
+  if (rendered.stderr.length > 0) {
+    process.stderr.write(rendered.stderr + '\n')
+  }
+
+  // Stage 6: persist the lastAuditAt marker for the 24h debounce.
+  await writeLastAudit(lastAuditPath, auditResult.auditId)
+
+  return 0
+}
+
+// ---------------------------------------------------------------------------
+// Render branch (tier → output channels)
+// ---------------------------------------------------------------------------
+
+/**
+ * Single, alphabetized switch on tier. Free/Individual hard-coded to
+ * empty output. Per-entry fields are NOT accepted in `RenderInput`, so
+ * a future "leak the colliding paths inline" change requires editing
+ * the type signature first — caught in review.
+ */
+function renderForTier(tier: ResolvedContext['tier'], input: RenderInput): RenderOutput {
+  switch (tier) {
+    case 'community':
+    case 'individual':
+      // Privacy boundary: NO output for free tiers.
+      return { stdout: '', stderr: '' }
+    case 'team':
+      return {
+        stdout: '',
+        stderr:
+          `[skillsmith] Skill audit: ` +
+          `${input.counts.exact} exact, ` +
+          `${input.counts.generic} generic, ` +
+          `${input.counts.semantic} semantic. ` +
+          `Report: ${input.reportPath}`,
+      }
+    case 'enterprise':
+      return {
+        stdout: '',
+        stderr: `[skillsmith] Skill audit complete. Full report: ${input.reportPath}`,
+      }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tier + mode resolution
+// ---------------------------------------------------------------------------
+
+async function resolveContext(home: string): Promise<ResolvedContext> {
+  const tier = await resolveTier()
+  const fileMode = await readConfigAuditMode(home)
+  const tierAllowsMode =
+    fileMode === null ||
+    tier === 'team' ||
+    tier === 'enterprise' ||
+    fileMode === 'preventative' ||
+    fileMode === 'off'
+  const tierIneligibleOverride = !tierAllowsMode
+  const auditMode = tierAllowsMode && fileMode !== null ? fileMode : tierDefault(tier)
+  return { tier, auditMode, tierIneligibleOverride }
+}
+
+async function resolveTier(): Promise<ResolvedContext['tier']> {
+  // Try the dynamic import path first (uses the enterprise validator
+  // when available). Falls back to community on any failure.
+  try {
+    const mod = (await import('../../packages/cli/src/utils/license-validation.js')) as {
+      getLicenseStatus: () => Promise<{ tier?: string; valid?: boolean }>
+    }
+    const status = await mod.getLicenseStatus()
+    if (
+      status.tier === 'community' ||
+      status.tier === 'individual' ||
+      status.tier === 'team' ||
+      status.tier === 'enterprise'
+    ) {
+      return status.tier
+    }
+  } catch {
+    // Fall through to env-based fallback.
+  }
+
+  // Fallback: minimal env-based resolution. Decode the JWT payload's
+  // `tier` claim WITHOUT signature verification — privacy boundary
+  // protects against accidental output (screen-share, coworker), not
+  // against self-attack. Self-claiming Enterprise unlocks
+  // runInventoryAudit against the user's own machine — no data exits.
+  const key = process.env['SKILLSMITH_LICENSE_KEY']
+  if (!key) return 'community'
+  try {
+    const parts = key.split('.')
+    if (parts.length < 2) return 'community'
+    const payloadB64 = parts[1] ?? ''
+    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8')) as {
+      tier?: string
+    }
+    if (payload.tier === 'individual' || payload.tier === 'team' || payload.tier === 'enterprise') {
+      return payload.tier
+    }
+  } catch {
+    // Fall through to community.
+  }
+  return 'community'
+}
+
+function tierDefault(tier: ResolvedContext['tier']): ResolvedContext['auditMode'] {
+  switch (tier) {
+    case 'community':
+    case 'individual':
+      return 'preventative'
+    case 'team':
+      return 'power_user'
+    case 'enterprise':
+      return 'governance'
+  }
+}
+
+async function readConfigAuditMode(home: string): Promise<ResolvedContext['auditMode'] | null> {
+  const configPath = path.join(home, '.skillsmith', 'config.json')
+  try {
+    const raw = await fs.readFile(configPath, 'utf-8')
+    const parsed = JSON.parse(raw) as { audit_mode?: unknown }
+    const v = parsed.audit_mode
+    if (v === 'preventative' || v === 'power_user' || v === 'governance' || v === 'off') {
+      return v
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Debounce + last-audit marker
+// ---------------------------------------------------------------------------
+
+function readDebounceHours(): number {
+  const raw = process.env['SKILLSMITH_SESSION_AUDIT_DEBOUNCE_HOURS']
+  if (!raw) return DEFAULT_DEBOUNCE_HOURS
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_DEBOUNCE_HOURS
+  return parsed
+}
+
+async function isDebounced(lastAuditPath: string, hours: number): Promise<boolean> {
+  try {
+    const raw = await fs.readFile(lastAuditPath, 'utf-8')
+    const parsed = JSON.parse(raw) as { lastAuditAt?: string }
+    if (!parsed.lastAuditAt) return false
+    const lastMs = Date.parse(parsed.lastAuditAt)
+    if (!Number.isFinite(lastMs)) return false
+    return Date.now() - lastMs < hours * 60 * 60 * 1000
+  } catch {
+    return false
+  }
+}
+
+async function writeLastAudit(lastAuditPath: string, auditId: string): Promise<void> {
+  try {
+    await fs.mkdir(path.dirname(lastAuditPath), { recursive: true, mode: 0o700 })
+    const tmp = lastAuditPath + '.tmp'
+    await fs.writeFile(
+      tmp,
+      JSON.stringify({ auditId, lastAuditAt: new Date().toISOString() }, null, 2),
+      { mode: 0o600 }
+    )
+    await fs.rename(tmp, lastAuditPath)
+  } catch {
+    // Best-effort.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+async function appendLog(
+  home: string,
+  level: string,
+  code: string,
+  payload: unknown
+): Promise<void> {
+  const today = new Date().toISOString().slice(0, 10)
+  const logDir = path.join(home, '.skillsmith', 'logs')
+  const logPath = path.join(logDir, `session-audit-${today}.log`)
+  try {
+    await fs.mkdir(logDir, { recursive: true, mode: 0o700 })
+    await fs.appendFile(
+      logPath,
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level,
+        code,
+        payload: serializeForLog(payload),
+      }) + '\n',
+      { mode: 0o600 }
+    )
+  } catch {
+    // Best-effort.
+  }
+}
+
+function serializeForLog(payload: unknown): unknown {
+  if (payload instanceof Error) {
+    return { name: payload.name, message: payload.message }
+  }
+  return payload
+}
+
+async function logInfo(home: string, code: string, payload: unknown): Promise<void> {
+  await appendLog(home, 'info', code, payload)
+}
+
+async function logError(home: string, code: string, err: unknown): Promise<void> {
+  await appendLog(home, 'error', code, err)
+}
+
+/**
+ * Sweep `~/.skillsmith/logs/session-audit-*.log` files older than 30
+ * days. Best-effort, fail-soft. Cap iteration to keep the hook bounded.
+ */
+async function opportunisticLogRotation(home: string): Promise<void> {
+  const logDir = path.join(home, '.skillsmith', 'logs')
+  try {
+    const entries = await fs.readdir(logDir)
+    const cutoffMs = Date.now() - 30 * 24 * 60 * 60 * 1000
+    let swept = 0
+    for (const entry of entries) {
+      if (swept >= 64) break // Bounded iteration.
+      if (!entry.startsWith('session-audit-') || !entry.endsWith('.log')) continue
+      const full = path.join(logDir, entry)
+      try {
+        const stat = await fs.stat(full)
+        if (stat.mtimeMs < cutoffMs) {
+          await fs.unlink(full)
+          swept++
+        }
+      } catch {
+        // skip
+      }
+    }
+  } catch {
+    // Best-effort.
+  }
+}
+
+// Suppress the "execFile imported but unused" lint hit. Reserved for
+// future hook-internal subprocess gating; keep the import path warm so
+// the helper file pattern matches scripts/session-priming-query.ts.
+void execFileP
+
+main()
+  .then((code) => {
+    process.exit(code)
+  })
+  .catch(() => {
+    process.exit(0) // Always exit 0 — never block the hook.
+  })

--- a/scripts/lib/session-start-audit-helper.ts
+++ b/scripts/lib/session-start-audit-helper.ts
@@ -33,13 +33,9 @@
  * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §6.
  */
 
-import { execFile } from 'node:child_process'
 import * as fs from 'node:fs/promises'
 import { homedir } from 'node:os'
 import * as path from 'node:path'
-import { promisify } from 'node:util'
-
-const execFileP = promisify(execFile)
 
 // 24h debounce for the per-session audit. Configurable via env for tests.
 const DEFAULT_DEBOUNCE_HOURS = 24
@@ -399,11 +395,6 @@ async function opportunisticLogRotation(home: string): Promise<void> {
     // Best-effort.
   }
 }
-
-// Suppress the "execFile imported but unused" lint hit. Reserved for
-// future hook-internal subprocess gating; keep the import path warm so
-// the helper file pattern matches scripts/session-priming-query.ts.
-void execFileP
 
 main()
   .then((code) => {

--- a/scripts/session-start-audit.sh
+++ b/scripts/session-start-audit.sh
@@ -85,17 +85,11 @@ fi
 # Stage B: invoke the helper via tsx with a 5-second wall-clock cap. The
 # helper's stdout is REDIRECTED to /dev/null — only stderr reaches the
 # user terminal. The hook's own stdout is the fixed JSON envelope.
-run_with_timeout_bin() {
-  "$TIMEOUT_BIN" --kill-after=2s 5s npx --no-install tsx "$HELPER" >/dev/null 2>&1 || true
-  # Note: stderr isn't preserved through the redirect above by design —
-  # tier output is rendered by the helper directly to fd 2 of THIS
-  # subshell. Below we re-invoke to capture stderr. See run_capture.
-}
-
-# Capture helper stderr so we can stream it to the hook's stderr after
-# the timeout cap completes. The helper writes ONE line on success;
-# anything more is treated as overflow and truncated to keep the hook
-# bounded.
+#
+# Capture helper stderr to a tmp file so we can stream it to the hook's
+# stderr after the timeout cap completes. The helper writes ONE line on
+# success; anything more is treated as overflow and truncated at 8 KB
+# to keep the hook bounded.
 run_capture() {
   local stderr_file
   stderr_file=$(mktemp -t skillsmith-audit-stderr.XXXXXX) || return 0
@@ -132,9 +126,5 @@ run_capture() {
 }
 
 run_capture
-
-# Suppress the "unused function" complaint. Kept for documentation of
-# the silent fast-path used during early Stage B development.
-: "${TIMEOUT_BIN}" "${run_with_timeout_bin:-}"
 
 emit_empty_and_exit

--- a/scripts/session-start-audit.sh
+++ b/scripts/session-start-audit.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SMI-4590 Wave 4 PR 6/6 — SessionStart audit hook (tier-gated continuous monitoring).
+#
+# Spec: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §6.
+#
+# Reads JSON event on stdin (Claude Code SessionStart format):
+#   { "session_id": "uuid", "source": "startup"|"resume"|"compact",
+#     "cwd": "/abs/path", "transcript_path": "..." }
+# Writes JSON to stdout: { "hookSpecificOutput": { "hookEventName": "SessionStart", "additionalContext": "" } }
+#
+# stdout is ALWAYS empty additionalContext — the priming hook
+# (session-start-priming.sh) owns the additionalContext slot. This hook's
+# user-visible output goes to stderr (visible in terminal, NOT in
+# Claude's model context).
+#
+# Always exits 0 (best-effort). Bounded execution: 5-second wall clock
+# via capability-probed gtimeout/timeout/job-control fallback so a stuck
+# helper never blocks Claude Code startup.
+#
+# Disable: SKILLSMITH_SESSION_AUDIT_DISABLE=1.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+emit_empty_and_exit() {
+  python3 -c 'import json,sys; print(json.dumps({"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":""}}))'
+  exit 0
+}
+
+# Gate 0: opt-out via env var.
+if [ "${SKILLSMITH_SESSION_AUDIT_DISABLE:-0}" = "1" ]; then
+  emit_empty_and_exit
+fi
+
+# Parse stdin for source + cwd. Anything missing → fall through to silent.
+SOURCE=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('source', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+
+CWD=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('cwd', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+
+# Gate 1: source must be 'startup'. Resume / compact / unknown → silent.
+if [ "$SOURCE" != "startup" ]; then
+  emit_empty_and_exit
+fi
+
+# Gate 2: cwd must exist and be a git repo (mirrors priming hook).
+if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
+  emit_empty_and_exit
+fi
+REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "")
+if [ -z "$REPO_ROOT" ]; then
+  emit_empty_and_exit
+fi
+
+# Resolve the helper path. If missing (e.g., running on an older checkout),
+# fail soft.
+HELPER="$REPO_ROOT/scripts/lib/session-start-audit-helper.ts"
+if [ ! -f "$HELPER" ]; then
+  emit_empty_and_exit
+fi
+
+# Stage A: capability-probe a usable timeout binary (mirror priming hook
+# precedent for macOS hosts that lack both `gtimeout` and `timeout`).
+TIMEOUT_BIN=""
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="gtimeout"
+elif command -v timeout >/dev/null 2>&1 && timeout --kill-after=0 0 true >/dev/null 2>&1; then
+  TIMEOUT_BIN="timeout"
+fi
+
+# Stage B: invoke the helper via tsx with a 5-second wall-clock cap. The
+# helper's stdout is REDIRECTED to /dev/null — only stderr reaches the
+# user terminal. The hook's own stdout is the fixed JSON envelope.
+run_with_timeout_bin() {
+  "$TIMEOUT_BIN" --kill-after=2s 5s npx --no-install tsx "$HELPER" >/dev/null 2>&1 || true
+  # Note: stderr isn't preserved through the redirect above by design —
+  # tier output is rendered by the helper directly to fd 2 of THIS
+  # subshell. Below we re-invoke to capture stderr. See run_capture.
+}
+
+# Capture helper stderr so we can stream it to the hook's stderr after
+# the timeout cap completes. The helper writes ONE line on success;
+# anything more is treated as overflow and truncated to keep the hook
+# bounded.
+run_capture() {
+  local stderr_file
+  stderr_file=$(mktemp -t skillsmith-audit-stderr.XXXXXX) || return 0
+  if [ -n "$TIMEOUT_BIN" ]; then
+    "$TIMEOUT_BIN" --kill-after=2s 5s npx --no-install tsx "$HELPER" \
+      >/dev/null 2>"$stderr_file" || true
+  else
+    # Job-control fallback: launch helper, watchdog SIGTERM at 5s, SIGKILL at 7s.
+    # Both helper and watchdog are launched in disowned subshells so bash's
+    # job-control completion notices ("Terminated: 15") don't leak to fd 2.
+    set -m
+    (
+      npx --no-install tsx "$HELPER" >/dev/null 2>"$stderr_file"
+    ) &
+    local pid=$!
+    (
+      sleep 5
+      kill -TERM "-$pid" 2>/dev/null || true
+      sleep 2
+      kill -KILL "-$pid" 2>/dev/null || true
+    ) >/dev/null 2>&1 &
+    local wd=$!
+    wait "$pid" 2>/dev/null || true
+    kill "$wd" 2>/dev/null || true
+    wait "$wd" 2>/dev/null || true
+  fi
+
+  # Cap output at 8 KB to defend against runaway helper bugs. The helper
+  # is supposed to emit exactly one line.
+  if [ -s "$stderr_file" ]; then
+    head -c 8192 "$stderr_file" >&2 || true
+  fi
+  rm -f "$stderr_file"
+}
+
+run_capture
+
+# Suppress the "unused function" complaint. Kept for documentation of
+# the silent fast-path used during early Stage B development.
+: "${TIMEOUT_BIN}" "${run_with_timeout_bin:-}"
+
+emit_empty_and_exit

--- a/scripts/tests/session-start-audit.test.sh
+++ b/scripts/tests/session-start-audit.test.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# SMI-4590 Wave 4 PR 6/6 — Session-start audit hook tests.
+#
+# Privacy-boundary regression suite. Mocks the helper to a fixed-output
+# stub so the bash hook's gating, timeout, and stdout/stderr channel
+# discipline can be tested without invoking the real audit pipeline.
+#
+# Run: bash scripts/tests/session-start-audit.test.sh
+#
+# Required for ADR-109 review: validates the LOAD-BEARING privacy
+# boundary (Free/Individual emit zero output) and the bounded-execution
+# guarantee (5-second cap; helper hang must not block the hook).
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+HOOK="$REPO_ROOT/scripts/session-start-audit.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: $HOOK is not executable"
+  exit 1
+fi
+
+fail=0
+pass=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name: expected='$expected' actual='$actual'"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name: '$needle' not in '$haystack'"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo "FAIL $name: '$needle' WAS in '$haystack' (privacy leak)"
+    fail=$((fail + 1))
+  else
+    echo "PASS $name"
+    pass=$((pass + 1))
+  fi
+}
+
+# A throwaway repo + helper-stub directory. The hook resolves
+# "$REPO_ROOT/scripts/lib/session-start-audit-helper.ts" relative to the
+# CWD's git toplevel — so we construct a temp git repo whose
+# scripts/lib/session-start-audit-helper.ts is a stub we control.
+mk_test_repo() {
+  local dir
+  dir=$(mktemp -d -t skillsmith-hook-test.XXXXXX)
+  git -C "$dir" init -q
+  mkdir -p "$dir/scripts/lib"
+  echo "$dir"
+}
+
+# Build a stub helper that emits a fixed stderr line and exits 0. Args:
+# $1 = path to stub, $2 = stderr text. Escapes the line via printf %q so
+# embedded quotes don't break the JS string.
+mk_stub_helper() {
+  local stub="$1" line="$2"
+  # JSON-encode the line for safe JS embedding.
+  local quoted
+  quoted=$(printf '%s' "$line" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+  {
+    printf '%s\n' '#!/usr/bin/env tsx'
+    printf 'process.stderr.write(%s);\n' "$quoted"
+    printf '%s\n' 'process.stderr.write("\n");'
+    printf '%s\n' 'process.exit(0);'
+  } > "$stub"
+  chmod +x "$stub"
+}
+
+# Wrap the hook invocation. We need to point the helper-resolution at
+# our stub repo (the hook reads CWD from stdin's "cwd" field), and we
+# must replace the real helper with the stub. Because the hook resolves
+# the helper inside REPO_ROOT (the test repo's own toplevel), we copy
+# the real hook script into the test repo to make the resolution local.
+run_hook() {
+  local repo="$1" source="$2" stderr_text="$3"
+  local mock_helper="$repo/scripts/lib/session-start-audit-helper.ts"
+  cp "$HOOK" "$repo/scripts/session-start-audit.sh"
+  chmod +x "$repo/scripts/session-start-audit.sh"
+  mk_stub_helper "$mock_helper" "$stderr_text"
+
+  # Invoke. Capture stdout + stderr separately.
+  local stdout_file stderr_file
+  stdout_file=$(mktemp -t skillsmith-hook-stdout.XXXXXX)
+  stderr_file=$(mktemp -t skillsmith-hook-stderr.XXXXXX)
+  printf '{"source":"%s","cwd":"%s","session_id":"t","transcript_path":""}' \
+    "$source" "$repo" \
+    | "$repo/scripts/session-start-audit.sh" >"$stdout_file" 2>"$stderr_file"
+  echo "STDOUT_FILE=$stdout_file"
+  echo "STDERR_FILE=$stderr_file"
+}
+
+# ----------------------------------------------------------------------
+# Test 1: stdout is ALWAYS the fixed JSON envelope with empty additionalContext.
+# ----------------------------------------------------------------------
+{
+  REPO=$(mk_test_repo)
+  out_lines=$(run_hook "$REPO" startup 'team-render-line')
+  STDOUT_FILE=$(echo "$out_lines" | grep '^STDOUT_FILE=' | sed 's/STDOUT_FILE=//')
+  STDERR_FILE=$(echo "$out_lines" | grep '^STDERR_FILE=' | sed 's/STDERR_FILE=//')
+  STDOUT=$(cat "$STDOUT_FILE")
+  STDERR=$(cat "$STDERR_FILE")
+
+  # The stdout JSON must contain the exact fixed envelope.
+  assert_contains "stdout-has-hookEventName" '"hookEventName": "SessionStart"' "$STDOUT"
+  assert_contains "stdout-has-empty-additionalContext" '"additionalContext": ""' "$STDOUT"
+
+  # CRITICAL: the helper's stderr text must NOT have been routed through
+  # stdout. Privacy boundary: stdout = additionalContext = model context.
+  assert_not_contains "stdout-no-team-render-leak" 'team-render-line' "$STDOUT"
+
+  # And stderr should carry the helper's render line (terminal channel).
+  assert_contains "stderr-has-render" 'team-render-line' "$STDERR"
+
+  rm -rf "$REPO" "$STDOUT_FILE" "$STDERR_FILE"
+}
+
+# ----------------------------------------------------------------------
+# Test 2: source != 'startup' → silent fast-path. Helper not invoked.
+# ----------------------------------------------------------------------
+{
+  REPO=$(mk_test_repo)
+  out_lines=$(run_hook "$REPO" resume 'should-not-appear')
+  STDOUT_FILE=$(echo "$out_lines" | grep '^STDOUT_FILE=' | sed 's/STDOUT_FILE=//')
+  STDERR_FILE=$(echo "$out_lines" | grep '^STDERR_FILE=' | sed 's/STDERR_FILE=//')
+  STDOUT=$(cat "$STDOUT_FILE")
+  STDERR=$(cat "$STDERR_FILE")
+
+  assert_contains "resume-stdout-envelope" '"additionalContext": ""' "$STDOUT"
+  # Helper must not have run on resume.
+  assert_not_contains "resume-helper-skipped" 'should-not-appear' "$STDERR"
+
+  rm -rf "$REPO" "$STDOUT_FILE" "$STDERR_FILE"
+}
+
+# ----------------------------------------------------------------------
+# Test 3: SKILLSMITH_SESSION_AUDIT_DISABLE=1 → silent fast-path.
+# ----------------------------------------------------------------------
+{
+  REPO=$(mk_test_repo)
+  cp "$HOOK" "$REPO/scripts/session-start-audit.sh"
+  chmod +x "$REPO/scripts/session-start-audit.sh"
+  mk_stub_helper "$REPO/scripts/lib/session-start-audit-helper.ts" 'should-not-appear'
+
+  STDOUT_FILE=$(mktemp -t skillsmith-hook-stdout.XXXXXX)
+  STDERR_FILE=$(mktemp -t skillsmith-hook-stderr.XXXXXX)
+  printf '{"source":"startup","cwd":"%s","session_id":"t","transcript_path":""}' "$REPO" \
+    | env SKILLSMITH_SESSION_AUDIT_DISABLE=1 "$REPO/scripts/session-start-audit.sh" \
+        >"$STDOUT_FILE" 2>"$STDERR_FILE"
+  STDOUT=$(cat "$STDOUT_FILE")
+  STDERR=$(cat "$STDERR_FILE")
+
+  assert_contains "disabled-stdout-envelope" '"additionalContext": ""' "$STDOUT"
+  assert_not_contains "disabled-helper-skipped" 'should-not-appear' "$STDERR"
+
+  rm -rf "$REPO" "$STDOUT_FILE" "$STDERR_FILE"
+}
+
+# ----------------------------------------------------------------------
+# Test 4: missing helper → silent fast-path.
+# ----------------------------------------------------------------------
+{
+  REPO=$(mk_test_repo)
+  cp "$HOOK" "$REPO/scripts/session-start-audit.sh"
+  chmod +x "$REPO/scripts/session-start-audit.sh"
+  # Intentionally do NOT create a helper stub.
+
+  STDOUT_FILE=$(mktemp -t skillsmith-hook-stdout.XXXXXX)
+  STDERR_FILE=$(mktemp -t skillsmith-hook-stderr.XXXXXX)
+  printf '{"source":"startup","cwd":"%s","session_id":"t","transcript_path":""}' "$REPO" \
+    | "$REPO/scripts/session-start-audit.sh" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+  STDOUT=$(cat "$STDOUT_FILE")
+
+  assert_contains "missing-helper-stdout-envelope" '"additionalContext": ""' "$STDOUT"
+
+  rm -rf "$REPO" "$STDOUT_FILE" "$STDERR_FILE"
+}
+
+# ----------------------------------------------------------------------
+# Test 5: bounded execution — slow helper does NOT block beyond 7s.
+# Skipped when neither gtimeout nor timeout is available AND the host
+# lacks the job-control fallback's prerequisites (rare).
+# ----------------------------------------------------------------------
+{
+  REPO=$(mk_test_repo)
+  cp "$HOOK" "$REPO/scripts/session-start-audit.sh"
+  chmod +x "$REPO/scripts/session-start-audit.sh"
+
+  # Helper that sleeps 30s — must be killed by the 5-second cap.
+  # Wrapped in async IIFE for compatibility with tsx default mode.
+  cat > "$REPO/scripts/lib/session-start-audit-helper.ts" <<'EOF'
+;(async () => {
+  await new Promise((r) => setTimeout(r, 30000))
+  process.exit(0)
+})()
+EOF
+
+  STDOUT_FILE=$(mktemp -t skillsmith-hook-stdout.XXXXXX)
+  STDERR_FILE=$(mktemp -t skillsmith-hook-stderr.XXXXXX)
+
+  start_s=$(date +%s)
+  printf '{"source":"startup","cwd":"%s","session_id":"t","transcript_path":""}' "$REPO" \
+    | "$REPO/scripts/session-start-audit.sh" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+  end_s=$(date +%s)
+  elapsed=$(( end_s - start_s ))
+
+  if [ "$elapsed" -le 10 ]; then
+    echo "PASS bounded-execution-${elapsed}s"
+    pass=$((pass + 1))
+  else
+    echo "FAIL bounded-execution: took ${elapsed}s (expected <= 10s)"
+    fail=$((fail + 1))
+  fi
+
+  STDOUT=$(cat "$STDOUT_FILE")
+  assert_contains "slow-helper-stdout-envelope" '"additionalContext": ""' "$STDOUT"
+
+  rm -rf "$REPO" "$STDOUT_FILE" "$STDERR_FILE"
+}
+
+# ----------------------------------------------------------------------
+echo
+echo "SUMMARY: $pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Final wave of SMI-4590 (Wave 4, PR 6/6). Wires the consumer namespace audit (Waves 1-3) into a per-session monitoring hook for paid tiers and adds an idempotent governance-pass runner for Enterprise admins.

- **Tier-gated session-start hook** (`scripts/session-start-audit.sh` + `scripts/lib/session-start-audit-helper.ts`) — runs `runInventoryAudit` for Team/Enterprise tiers, debounced 24h. Free/Individual emit zero output (privacy boundary). Bounded 5-second wall clock; fail-soft.
- **Enterprise scheduled-scan runner** (`packages/enterprise/src/audit/scheduled-scan.ts`) — `runScheduledScan` with idempotency cache (default 5 min, env-overridable), webhook delivery with file fallback, URL secret stripping.
- **CLAUDE.md** updates — MCP Tools table (`skill_inventory_audit`, `apply_namespace_rename`, `apply_recommended_edit`), CLI section (`audit collisions`, `config get/set audit_mode`), Monitoring & Alerts table (Skillsmith Scheduled Audit + Session-start audit hook rows), Session Priming sibling-hook details, Troubleshooting row.

## Privacy boundary (load-bearing)

- Free/Individual emit NO output. Render fn typed input excludes per-entry fields so leakage is a type error, not a code-review gotcha.
- Tier resolution failure defaults to community-silent (never default to leak). Specific resolution-failure code logged to `~/.skillsmith/logs/session-audit-<date>.log` for triage.
- Helper stdout always empty — priming hook owns the additionalContext slot. Audit summary goes to stderr (terminal-visible, NOT in Claude's model context).
- Webhook URL secrets stripped to scheme+host before any logging.

## ADR-109 compliance

Plan: `docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md` §6, §7 (SPARC).

Inline plan-review (VP Product / VP Engineering / VP Security) verdict: APPROVE_WITH_CHANGES — all 10 required changes applied. Post-commit `/governance` retro surfaced 3 additional findings (dead `execFile` import, dead `run_with_timeout_bin` function, redundant tsx install fallback) — all fixed in follow-up commit `5e47b153` before PR opened.

## Test plan

- [x] 11/11 bash tests pass (`bash scripts/tests/session-start-audit.test.sh`) — privacy-boundary regression suite (stdout JSON envelope, stderr-not-leaked-to-stdout, source!=startup fast-path, SKILLSMITH_SESSION_AUDIT_DISABLE=1, missing helper, 5-second bounded execution via slow-helper SIGTERM)
- [x] 13/13 Vitest tests pass (`docker exec ... vitest run packages/enterprise/tests/audit/scheduled-scan.test.ts`) — idempotency cache hit/miss/force, applyExclusions:false propagation, webhook success + fallback-to-file, URL secret stripping (`SECRETKEY`/`opaque` confirmed not in failure log)
- [x] `audit:standards` 92% (54 pass / 5 warnings / 0 fail) — workflow Check 37 NODE_VERSION drift fixed; remaining warnings are pre-existing
- [x] `tsc -p packages/enterprise/tsconfig.json --noEmit` clean
- [x] ESLint clean (zero errors, zero warnings)
- [x] Pre-commit (typecheck + lint-staged + check-file-length) passed both commits

Manual smoke (post-merge):
- [ ] Free/Individual: `unset SKILLSMITH_LICENSE_KEY` and start a new Claude Code session — no audit output to terminal
- [ ] Team: with valid Team license — collapsed-summary line on terminal stderr, `~/.skillsmith/last-audit.json` written
- [ ] Enterprise: with valid Enterprise license — path-pointer line on terminal stderr
- [ ] `SKILLSMITH_SESSION_AUDIT_DISABLE=1` — silent in all tiers

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)