### PR TITLE
feat(smoke): SMI-4744 generate-license prod smoke credentials

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -464,6 +464,25 @@ CLOUDINARY_API_SECRET=
 CLOUDINARY_URL=
 
 # =============================================================================
+# SMOKE TEST CREDENTIALS (SMI-4744)
+# =============================================================================
+
+# Dedicated Individual-tier test account for generate-license prod smoke test.
+# Account: smoke-individual@smithhorn-test.internal (user 56bae961-ed7f-4eb6-b7b9-39d0c0bfd69f)
+# Usage: varlock run -- ./scripts/smoke-generate-license.sh
+# Re-provision: varlock run -- python3 /tmp/setup_smoke_user.py (or admin PUT /auth/v1/admin/users/{id})
+# @type=string @sensitive=false @required=false
+TEST_SMOKE_INDIVIDUAL_EMAIL=
+
+# Supabase UUID of the Individual-tier smoke account (non-sensitive, for reference)
+# @type=string(pattern=^[0-9a-f-]{36}$) @sensitive=false @required=false
+TEST_SMOKE_INDIVIDUAL_USER_ID=
+
+# Password for the Individual-tier smoke account (email+password auth)
+# @type=string @sensitive @required=false
+TEST_SMOKE_INDIVIDUAL_PASSWORD=
+
+# =============================================================================
 # SKILLSMITH FEATURE FLAGS
 # =============================================================================
 

--- a/scripts/smoke-generate-license.sh
+++ b/scripts/smoke-generate-license.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SMI-4744 — Post-deploy smoke test for generate-license (Individual tier).
+#
+# Signs in as the dedicated smoke test account, generates a license key,
+# verifies the response, and revokes the key. Requires varlock secrets.
+#
+# Usage:
+#   varlock run -- ./scripts/smoke-generate-license.sh
+#
+# Required env (loaded by varlock):
+#   SUPABASE_URL
+#   SUPABASE_ANON_KEY
+#   SUPABASE_SERVICE_ROLE_KEY
+#   TEST_SMOKE_INDIVIDUAL_EMAIL
+#   TEST_SMOKE_INDIVIDUAL_PASSWORD
+#
+# Exit codes: 0 = pass, 1 = fail
+
+set -euo pipefail
+
+: "${SUPABASE_URL:?must be set}"
+: "${SUPABASE_ANON_KEY:?must be set}"
+: "${SUPABASE_SERVICE_ROLE_KEY:?must be set}"
+: "${TEST_SMOKE_INDIVIDUAL_EMAIL:?must be set — run scripts/setup_smoke_user.py to provision}"
+: "${TEST_SMOKE_INDIVIDUAL_PASSWORD:?must be set — run scripts/setup_smoke_user.py to provision}"
+
+TIMEOUT=10
+
+_curl() {
+  curl --silent --max-time "$TIMEOUT" "$@"
+}
+
+echo "[smoke:generate-license] Signing in as ${TEST_SMOKE_INDIVIDUAL_EMAIL}..."
+SESSION=$(_curl -X POST \
+  "${SUPABASE_URL}/auth/v1/token?grant_type=password" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"${TEST_SMOKE_INDIVIDUAL_EMAIL}\",\"password\":\"${TEST_SMOKE_INDIVIDUAL_PASSWORD}\"}")
+
+ACCESS_TOKEN=$(echo "$SESSION" | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null)
+if [ -z "$ACCESS_TOKEN" ]; then
+  echo "[smoke:generate-license] FAIL — sign-in failed (check TEST_SMOKE_INDIVIDUAL_PASSWORD in varlock)"
+  exit 1
+fi
+echo "[smoke:generate-license] Sign-in OK"
+
+echo "[smoke:generate-license] Calling generate-license..."
+RESULT=$(_curl -X POST \
+  "${SUPABASE_URL}/functions/v1/generate-license" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"smoke-test-key"}')
+
+KEY_PREFIX=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('key_prefix',''))" 2>/dev/null)
+KEY_ID=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null)
+TIER=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tier',''))" 2>/dev/null)
+ERROR=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error',''))" 2>/dev/null)
+
+if [ -z "$KEY_PREFIX" ] || [ "$KEY_PREFIX" = "None" ]; then
+  echo "[smoke:generate-license] FAIL — no key_prefix in response"
+  echo "$RESULT"
+  exit 1
+fi
+
+echo "[smoke:generate-license] Key generated — prefix=${KEY_PREFIX}, tier=${TIER}, id=${KEY_ID}"
+
+if [ -n "$KEY_ID" ] && [ "$KEY_ID" != "None" ]; then
+  echo "[smoke:generate-license] Revoking smoke key ${KEY_ID}..."
+  _curl -X PATCH \
+    "${SUPABASE_URL}/rest/v1/license_keys?id=eq.${KEY_ID}" \
+    -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+    -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+    -H "Content-Type: application/json" \
+    -d '{"status":"revoked"}' > /dev/null
+  echo "[smoke:generate-license] Key revoked."
+fi
+
+echo "[smoke:generate-license] PASS"

--- a/tests/e2e/api/license-key-generation.e2e.test.ts
+++ b/tests/e2e/api/license-key-generation.e2e.test.ts
@@ -30,7 +30,7 @@ const STAGING_ANON_KEY = process.env.STAGING_SUPABASE_ANON_KEY
 
 const skipReason =
   !STAGING_URL || !STAGING_SERVICE_KEY || !STAGING_ANON_KEY
-    ? 'STAGING_SUPABASE_* env vars missing — run via: varlock run -- npx vitest run tests/e2e/license-key-generation.e2e.test.ts'
+    ? 'STAGING_SUPABASE_* env vars missing — run via: varlock run -- npx vitest run --config vitest.e2e.config.ts tests/e2e/api/license-key-generation.e2e.test.ts'
     : ''
 
 const describeIfStaged = skipReason ? describe.skip : describe


### PR DESCRIPTION
## Summary

- Adds `scripts/smoke-generate-license.sh` — signs in as dedicated Individual-tier smoke account, calls `generate-license`, verifies `key_prefix`, revokes the test key
- Adds `TEST_SMOKE_INDIVIDUAL_EMAIL`, `TEST_SMOKE_INDIVIDUAL_USER_ID`, `TEST_SMOKE_INDIVIDUAL_PASSWORD` to `.env.schema`
- Smoke account `smoke-individual@smithhorn-test.internal` provisioned in prod (Individual tier, profile complete, `generate-license` verified working)

**Usage** (post-deploy smoke):
```bash
varlock run -- ./scripts/smoke-generate-license.sh
```

Resolves the post-deploy smoke gap from SMI-4740 where `TEST_JWT_INDIVIDUAL` was missing from varlock.

## Test plan

- [x] `scripts/smoke-generate-license.sh` executed against prod — PASS (key generated + revoked)
- [ ] `.env.schema` lint passes (config-only change, 2 CI checks)

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)