### PR TITLE
fix(smoke): governance retro SMI-4744 — quota-monitor allowlist + submodule bump

### DIFF
--- a/.claude/development/deployment-guide.md
+++ b/.claude/development/deployment-guide.md
@@ -36,15 +36,30 @@ npx supabase functions deploy list-invoices --no-verify-jwt
 
 **Note**: `verify_jwt` is also configured in `supabase/config.toml` for local development. Production deployments require the `--no-verify-jwt` flag explicitly.
 
-### Adding New Anonymous Functions (SMI-1900)
+### Adding New Edge Functions
 
-CI validates anonymous function configuration. When adding a new one:
+When creating a new edge function:
 
-1. Add `[functions.<name>]` with `verify_jwt = false` to `supabase/config.toml`
-2. Add deploy command to the list above
-3. Add function name to `ANONYMOUS_FUNCTIONS` array in `scripts/audit-standards.mjs`
+1. Add `[functions.<name>]` with `verify_jwt = false` to `supabase/config.toml` (anonymous functions only)
+2. Add deploy command to the CLAUDE.md deploy list and the list above
+3. Add function name to `NO_VERIFY_JWT_FUNCTIONS` in `scripts/audit-standards.mjs` (anonymous only)
+4. **Add to `.surfaces-allowlist.txt` or `surfaces.json`** — `audit:standards` Check 36 will warn if you skip this. Cron-only/internal functions belong in `.surfaces-allowlist.txt` with a rationale comment; user-facing functions belong in `surfaces.json`. Omitting this step requires a follow-up PR to fix the warning.
 
 CI will fail if any anonymous function is missing from `config.toml` or CLAUDE.md.
+
+### Supabase Admin API (GoTrue v2)
+
+Gotchas when using `POST/PUT /auth/v1/admin/users` (e.g., provisioning smoke test accounts):
+
+| Operation | Method | Path | Notes |
+|-----------|--------|------|-------|
+| Create user | POST | `/auth/v1/admin/users` | Use `email_confirm: true` to skip email verification |
+| Update user (set password, metadata) | **PUT** | `/auth/v1/admin/users/{id}` | **PATCH returns 405** — GoTrue v2 uses PUT |
+| Sign in (get JWT) | POST | `/auth/v1/token?grant_type=password` | Use `email` + `password` in JSON body |
+
+**OTP magic links are browser-only**: `POST /auth/v1/admin/generate_link` returns a redirect URL that terminates at the app's `/auth/confirm` page (302 → browser flow). The `hashed_token` is at the top level of the response, not inside `properties`. This flow cannot be used for server-side JWT exchange — use email+password credentials instead.
+
+**Smoke test credential pattern**: Generate passwords with Python `secrets.token_urlsafe(24)` and write directly to `.env` — never `echo $PASSWORD` or print in curl output. Set via `PUT /auth/v1/admin/users/{id}` with `{ "password": "..." }` in the JSON body.
 
 ### Auto-Deploy on Merge (SMI-4256)
 

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2456,7 +2456,7 @@ console.log(`\n${BOLD}36. Smoke Surface Coverage (R-4, SMI-4459)${RESET}`)
       } else {
         const formatted = uncovered.map((p) => `  ${p}`).join('\n')
         warn(
-          `${uncovered.length} surface(s) not covered by surfaces.json and not allowlisted:\n${formatted}\n  Add a surface entry to scripts/smoke-prod/surfaces.json or document the exclusion in scripts/smoke-prod/.surfaces-allowlist.txt.`
+          `${uncovered.length} surface(s) not covered by surfaces.json and not allowlisted:\n${formatted}\n  User-facing → add to scripts/smoke-prod/surfaces.json.\n  Cron-only/internal → add to scripts/smoke-prod/.surfaces-allowlist.txt with rationale comment.\n  See .claude/development/deployment-guide.md § "Adding New Edge Functions".`
         )
       }
     } catch (e) {

--- a/scripts/smoke-prod/.surfaces-allowlist.txt
+++ b/scripts/smoke-prod/.surfaces-allowlist.txt
@@ -26,6 +26,7 @@ supabase/functions/skills-outreach-preferences/**
 supabase/functions/admin-grant-subscription/**
 supabase/functions/update-seat-count/**
 supabase/functions/webhook-dlq/**
+supabase/functions/quota-monitor/**
 
 # Stripe webhook endpoints (require signed payload to exercise; covered by
 # stripe-webhook-monitor.yml independently).


### PR DESCRIPTION
## Summary
- Adds `supabase/functions/quota-monitor/**` to `.surfaces-allowlist.txt` — cron-only function (GitHub Actions every 30 min) with no user-facing HTTP surface, same category as `indexer`, `ops-report`, etc.
- Bumps `docs/internal` submodule: SMI-4744 retro, SMI-4740 retro backfill, implementation plans for SMI-4733/4736/4737/4740/4741, `retros/index.md` updated

These are the two findings from the post-merge governance retro on PR #957 (SMI-4744).

## Test plan
- [ ] `docker exec skillsmith-dev-1 npm run audit:standards` → 0 failures, 5 warnings (down from 6 before this PR)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)