### PR TITLE
fix(session-audit): SMI-4752/4753 — TOCTOU lock + typed dynamic import + malformed-key log + timeout probe

### DIFF
--- a/packages/enterprise/src/audit/scheduled-scan.lock.ts
+++ b/packages/enterprise/src/audit/scheduled-scan.lock.ts
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright 2024-2025 Smith Horn Group Ltd
+
+/**
+ * @fileoverview Lock-file mutex for the Enterprise scheduled-scan runner.
+ * @module @skillsmith/enterprise/audit/scheduled-scan.lock
+ *
+ * Plan: docs/internal/implementation/smi-4590-cli-mcp-framework-adapter.md §7
+ * (SMI-4752 follow-up).
+ *
+ * Why a separate file: keeps `scheduled-scan.ts` under the project's
+ * 500-line cap (`audit:standards` Check 12). The lock module is
+ * self-contained and exercised independently by the concurrent-fire
+ * regression tests.
+ *
+ * Contract:
+ *   - `acquireScanLock(homeDir, onCacheCheck)` returns one of:
+ *     - `{ kind: 'acquired', release }` — caller owns the lock; must
+ *       call `release()` in a `finally` block.
+ *     - `{ kind: 'cached', cached }` — a peer published a result while
+ *       we were inspecting the lock; ride it.
+ *     - `{ kind: 'inflight' }` — fresh, alive lock with no cache hit;
+ *       caller should throw `scheduled_scan.in_flight`.
+ *   - On EACCES/ENOSPC/etc this throws via the `onError` callback (so
+ *     the caller can wrap it in a typed error).
+ *
+ * Cross-platform notes:
+ *   - `O_EXCL` on `fs.open(..., 'wx')` is atomic on macOS APFS, Linux
+ *     ext4/btrfs, and NFSv4. NFSv3 has known issues; not a target.
+ *   - `process.kill(pid, 0)` returns `ESRCH` for dead pids and `EPERM`
+ *     for live-but-foreign pids. Only ESRCH triggers reclaim.
+ */
+
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+/**
+ * Stale-lock reclaim window. Lock files older than this are assumed to
+ * be orphaned (process killed before try/finally could unlink) and are
+ * unlinked on the next acquire attempt. Env-overridable for tests.
+ *
+ * Default 5 minutes — long enough that a real audit (~tens of seconds)
+ * never trips it, short enough that an orphan doesn't block the next
+ * cron tick. Cap at 1h to defend against absurd overrides.
+ */
+const DEFAULT_LOCK_STALE_MS = 5 * 60 * 1000
+const MAX_LOCK_STALE_MS = 60 * 60 * 1000
+
+interface LockPayload {
+  pid: number
+  startedAt: number
+  hostname: string
+}
+
+/**
+ * Counts shape mirrored from the runner — we keep this local rather
+ * than importing from `scheduled-scan.types.ts` so the lock module has
+ * zero coupling to the runner's option/result types.
+ */
+export interface LockCachedResult {
+  auditId: string
+  reportPath: string
+  counts: { exact: number; generic: number; semantic: number }
+}
+
+export type LockAcquireOutcome =
+  | { kind: 'acquired'; release: () => Promise<void> }
+  | { kind: 'cached'; cached: LockCachedResult }
+  | { kind: 'inflight' }
+
+/**
+ * Callback used inside the EEXIST branch to ask the runner whether a
+ * fresh result has materialised since we started inspecting the lock.
+ * The runner's `findRecentAudit` is the canonical source.
+ */
+export type CacheProbe = () => Promise<LockCachedResult | null>
+
+/**
+ * Callback the runner provides to wrap fs errors (EACCES, ENOSPC, etc.)
+ * in its typed `ScheduledScanError`. Keeping the throw out of this
+ * module avoids a circular import.
+ */
+export type FsErrorThrower = (err: unknown) => never
+
+/**
+ * Atomically acquire `~/.skillsmith/audits/.scan.lock` via O_EXCL. On
+ * EEXIST, reclaim the lock if it's stale (older than the configured
+ * window OR the holding PID is dead on this host). If it's fresh and
+ * alive, fall back to the cache or report in-flight.
+ */
+export async function acquireScanLock(
+  homeDir: string,
+  cacheProbe: CacheProbe,
+  throwFsError: FsErrorThrower
+): Promise<LockAcquireOutcome> {
+  const auditsDir = path.join(homeDir, '.skillsmith', 'audits')
+  const lockPath = path.join(auditsDir, '.scan.lock')
+
+  // Ensure parent dir exists with restrictive perms.
+  await fs.mkdir(auditsDir, { recursive: true, mode: 0o700 })
+
+  // Up to 2 attempts: first try, then one retry after stale-lock reclaim.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const acquired = await tryCreateLock(lockPath)
+    if (acquired.kind === 'created') {
+      return {
+        kind: 'acquired',
+        release: async () => {
+          try {
+            await fs.unlink(lockPath)
+          } catch {
+            // Best-effort: another reclaim or filesystem quirk may have
+            // unlinked it already. Not fatal.
+          }
+        },
+      }
+    }
+    if (acquired.kind === 'fs_error') {
+      // Permission/disk/readonly error — bubble up via the runner's
+      // typed error so the caller doesn't loop or silently report
+      // in-flight.
+      throwFsError(acquired.err)
+    }
+
+    // EEXIST. Inspect the holder.
+    const holder = await readLockPayload(lockPath)
+    if (holder === null) {
+      // Unparseable — treat as stale on first attempt only (prevents
+      // infinite loop if a write race keeps producing junk).
+      if (attempt === 0) {
+        await tryUnlinkLock(lockPath)
+        continue
+      }
+      return { kind: 'inflight' }
+    }
+
+    if (isStaleLock(holder)) {
+      if (attempt === 0) {
+        await tryUnlinkLock(lockPath)
+        continue
+      }
+      // Already retried once — don't loop forever. Fall through to
+      // cache check + in-flight handling.
+    }
+
+    // Fresh + alive lock. Re-check the cache: the in-flight peer may
+    // have just published a result while we were inspecting the lock.
+    const cached = await cacheProbe()
+    if (cached !== null) {
+      return { kind: 'cached', cached }
+    }
+    return { kind: 'inflight' }
+  }
+
+  return { kind: 'inflight' }
+}
+
+type CreateLockOutcome =
+  | { kind: 'created' }
+  | { kind: 'exists' }
+  | { kind: 'fs_error'; err: unknown }
+
+async function tryCreateLock(lockPath: string): Promise<CreateLockOutcome> {
+  const payload: LockPayload = {
+    pid: process.pid,
+    startedAt: Date.now(),
+    hostname: os.hostname(),
+  }
+  try {
+    // 'wx' = write-exclusive, atomic O_EXCL create. Throws EEXIST if
+    // the file already exists.
+    const handle = await fs.open(lockPath, 'wx', 0o600)
+    try {
+      await handle.writeFile(JSON.stringify(payload), { encoding: 'utf-8' })
+    } finally {
+      await handle.close()
+    }
+    return { kind: 'created' }
+  } catch (err) {
+    if (isErrnoCode(err, 'EEXIST')) return { kind: 'exists' }
+    // Any other fs error (EACCES, ENOSPC, EROFS) — surface so the caller
+    // can throw an audit_failed instead of pretending the lock is held.
+    return { kind: 'fs_error', err }
+  }
+}
+
+async function readLockPayload(lockPath: string): Promise<LockPayload | null> {
+  try {
+    const raw = await fs.readFile(lockPath, 'utf-8')
+    const parsed = JSON.parse(raw) as Partial<LockPayload>
+    if (
+      typeof parsed.pid !== 'number' ||
+      typeof parsed.startedAt !== 'number' ||
+      typeof parsed.hostname !== 'string'
+    ) {
+      return null
+    }
+    return { pid: parsed.pid, startedAt: parsed.startedAt, hostname: parsed.hostname }
+  } catch {
+    return null
+  }
+}
+
+function isStaleLock(holder: LockPayload): boolean {
+  const now = Date.now()
+  const ageMs = now - holder.startedAt
+  if (ageMs < 0) {
+    // Clock skew or future-dated lock — treat as suspicious but not
+    // stale. Don't reclaim; let the lock owner finish or expire.
+    return false
+  }
+  if (ageMs > resolveLockStaleMs()) return true
+
+  // Same-host PID liveness check. We only treat ESRCH as stale —
+  // EPERM means the PID exists but we can't signal it (different uid),
+  // which is NOT the same as dead.
+  if (holder.hostname === os.hostname()) {
+    if (!isPidAlive(holder.pid)) return true
+  }
+  return false
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    if (isErrnoCode(err, 'ESRCH')) return false
+    // EPERM: PID exists, owned by another uid. Treat as alive (don't
+    // reclaim — would be a no-op anyway since unlink+create might race
+    // with the real owner's release).
+    return true
+  }
+}
+
+function resolveLockStaleMs(): number {
+  const raw = process.env['SKILLSMITH_SCHEDULED_AUDIT_LOCK_STALE_MS']
+  if (!raw) return DEFAULT_LOCK_STALE_MS
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LOCK_STALE_MS
+  return Math.min(parsed, MAX_LOCK_STALE_MS)
+}
+
+async function tryUnlinkLock(lockPath: string): Promise<void> {
+  try {
+    await fs.unlink(lockPath)
+  } catch {
+    // Best-effort.
+  }
+}
+
+function isErrnoCode(err: unknown, code: string): boolean {
+  return typeof err === 'object' && err !== null && (err as NodeJS.ErrnoException).code === code
+}

--- a/packages/enterprise/src/audit/scheduled-scan.ts
+++ b/packages/enterprise/src/audit/scheduled-scan.ts
@@ -28,6 +28,7 @@
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { acquireScanLock } from './scheduled-scan.lock.js'
 import type {
   ScheduledScanErrorCode,
   ScheduledScanOptions,
@@ -102,6 +103,8 @@ export async function runScheduledScan(
   const cacheMinutes = resolveCacheMinutes(opts.cacheMinutes)
 
   // Idempotency cache check — keyed on the resolved homeDir's audits dir.
+  // This is a freshness optimization; the lock-file mutex below is the
+  // correctness gate for concurrent fires (SMI-4752).
   if (!opts.force) {
     const cached = await findRecentAudit(homeDir, cacheMinutes)
     if (cached !== null) {
@@ -114,58 +117,96 @@ export async function runScheduledScan(
     }
   }
 
-  // Fresh audit. Governance mode: deep + un-filtered. The
-  // `runInventoryAudit` import is dynamic to avoid a hard package
-  // cycle (mcp-server lists enterprise as an optional peer dep).
-  let auditResult
-  try {
-    const runInventoryAudit = await loadRunInventoryAudit()
-    auditResult = await runInventoryAudit({
-      deep: true,
-      applyExclusions: false,
-      tier: 'enterprise',
-      homeDir,
-      ...(opts.projectDir !== undefined ? { projectDir: opts.projectDir } : {}),
-    })
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
+  // Lock-file mutex (SMI-4752). A second caller arriving during an
+  // in-flight scan either rides the in-flight peer's cached result
+  // (when it lands) or throws `scheduled_scan.in_flight`. The lock
+  // module is callback-driven (cache probe + fs-error thrower) so it
+  // stays decoupled from the runner's option/result types.
+  const lockOutcome = await acquireScanLock(
+    homeDir,
+    () => findRecentAudit(homeDir, cacheMinutes),
+    (err) => {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new ScheduledScanError(
+        'scheduled_scan.audit_failed',
+        `Failed to acquire scheduled-scan lock: ${message}`
+      )
+    }
+  )
+  if (lockOutcome.kind === 'cached') {
+    return {
+      ...lockOutcome.cached,
+      cached: true,
+      outputDisposition: 'file',
+      durationMs: nsToMs(process.hrtime.bigint() - startedAt),
+    }
+  }
+  if (lockOutcome.kind === 'inflight') {
     throw new ScheduledScanError(
-      'scheduled_scan.audit_failed',
-      `Inventory audit failed during scheduled scan: ${message}`
+      'scheduled_scan.in_flight',
+      'Another scheduled scan is already running for this home directory. ' +
+        'Retry after the in-flight scan completes, or wait for stale-lock reclaim ' +
+        '(default 5 minutes).'
     )
   }
 
-  const counts = {
-    exact: auditResult.exactCollisions.length,
-    generic: auditResult.genericFlags.length,
-    semantic: auditResult.semanticCollisions.length,
-  }
+  // Fresh audit. Governance mode: deep + un-filtered. The
+  // `runInventoryAudit` import is dynamic to avoid a hard package
+  // cycle (mcp-server lists enterprise as an optional peer dep).
+  // try/finally guarantees lock release even on throw.
+  try {
+    let auditResult
+    try {
+      const runInventoryAudit = await loadRunInventoryAudit()
+      auditResult = await runInventoryAudit({
+        deep: true,
+        applyExclusions: false,
+        tier: 'enterprise',
+        homeDir,
+        ...(opts.projectDir !== undefined ? { projectDir: opts.projectDir } : {}),
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new ScheduledScanError(
+        'scheduled_scan.audit_failed',
+        `Inventory audit failed during scheduled scan: ${message}`
+      )
+    }
 
-  // Output dispatch.
-  const output = opts.output ?? { kind: 'file' as const }
-  let outputDisposition: ScheduledScanResult['outputDisposition'] = 'file'
+    const counts = {
+      exact: auditResult.exactCollisions.length,
+      generic: auditResult.genericFlags.length,
+      semantic: auditResult.semanticCollisions.length,
+    }
 
-  if (output.kind === 'webhook') {
-    const webhookOk = await deliverWebhook(output.url, {
+    // Output dispatch.
+    const output = opts.output ?? { kind: 'file' as const }
+    let outputDisposition: ScheduledScanResult['outputDisposition'] = 'file'
+
+    if (output.kind === 'webhook') {
+      const webhookOk = await deliverWebhook(output.url, {
+        auditId: auditResult.auditId,
+        reportPath: auditResult.reportPath,
+        counts,
+      })
+      if (webhookOk) {
+        outputDisposition = 'webhook'
+      } else {
+        await logWebhookFailure(homeDir, output.url, auditResult.auditId)
+        outputDisposition = 'webhook_fallback'
+      }
+    }
+
+    return {
       auditId: auditResult.auditId,
       reportPath: auditResult.reportPath,
+      cached: false,
       counts,
-    })
-    if (webhookOk) {
-      outputDisposition = 'webhook'
-    } else {
-      await logWebhookFailure(homeDir, output.url, auditResult.auditId)
-      outputDisposition = 'webhook_fallback'
+      outputDisposition,
+      durationMs: nsToMs(process.hrtime.bigint() - startedAt),
     }
-  }
-
-  return {
-    auditId: auditResult.auditId,
-    reportPath: auditResult.reportPath,
-    cached: false,
-    counts,
-    outputDisposition,
-    durationMs: nsToMs(process.hrtime.bigint() - startedAt),
+  } finally {
+    await lockOutcome.release()
   }
 }
 

--- a/packages/enterprise/src/audit/scheduled-scan.types.ts
+++ b/packages/enterprise/src/audit/scheduled-scan.types.ts
@@ -56,7 +56,19 @@ export interface ScheduledScanOptions {
    *
    * The cache key is the most-recent `~/.skillsmith/audits/<auditId>/`
    * mtime under the resolved `homeDir`, so each environment has its
-   * own cache — no global racing.
+   * own cache.
+   *
+   * Concurrent-fire correctness (SMI-4752): the mtime cache is a
+   * freshness optimization, NOT a race guard — two callers passing the
+   * cache check ~simultaneously would both invoke `runInventoryAudit`.
+   * The correctness gate is a lock-file mutex at
+   * `~/.skillsmith/audits/.scan.lock` (atomic `O_EXCL` create with
+   * `{ pid, startedAt, hostname }` payload). A second caller seeing a
+   * fresh, alive lock either (a) returns the cached result if a peer
+   * has just produced one, or (b) throws `scheduled_scan.in_flight`.
+   * Stale-lock reclaim windows: `> 5 min old` (env-overridable via
+   * `SKILLSMITH_SCHEDULED_AUDIT_LOCK_STALE_MS`) OR PID dead (`ESRCH`
+   * from `process.kill(pid, 0)`) on the same host.
    */
   cacheMinutes?: number
 
@@ -102,8 +114,16 @@ export interface ScheduledScanResult {
 /**
  * Typed error codes the runner may surface. Surfaced via thrown
  * `ScheduledScanError` (see `scheduled-scan.ts`).
+ *
+ * `scheduled_scan.in_flight` (SMI-4752): another `runScheduledScan` is
+ * holding the lock at `~/.skillsmith/audits/.scan.lock` and no cached
+ * result is available to fall back on. Caller should either back off
+ * and retry, or use `force: true` after waiting for the in-flight peer
+ * (note: `force` does NOT bypass the lock — it bypasses only the cache
+ * read).
  */
 export type ScheduledScanErrorCode =
   | 'scheduled_scan.audit_failed'
   | 'scheduled_scan.invalid_cache_minutes'
   | 'scheduled_scan.invalid_output'
+  | 'scheduled_scan.in_flight'

--- a/packages/enterprise/tests/audit/scheduled-scan.test.ts
+++ b/packages/enterprise/tests/audit/scheduled-scan.test.ts
@@ -249,6 +249,182 @@ describe('runScheduledScan', () => {
   })
 })
 
+describe('runScheduledScan — concurrent-fire lock (SMI-4752)', () => {
+  let tmpHome: string
+  let runScheduledScan: (typeof import('../../src/audit/scheduled-scan.js'))['runScheduledScan']
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'scheduled-scan-lock-test-'))
+    await fs.mkdir(path.join(tmpHome, '.skillsmith'), { recursive: true, mode: 0o700 })
+    mockRunInventoryAudit.mockReset()
+    const mod = await import('../../src/audit/scheduled-scan.js')
+    runScheduledScan = mod.runScheduledScan
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpHome, { recursive: true, force: true })
+    delete process.env['SKILLSMITH_SCHEDULED_AUDIT_LOCK_STALE_MS']
+  })
+
+  it('serializes two concurrent runScheduledScan calls — only one invokes runInventoryAudit', async () => {
+    // Mock runInventoryAudit so it takes long enough for both callers
+    // to be in flight simultaneously, and writes its result.json to
+    // the audits dir so the second caller can pick up the cache.
+    let invocations = 0
+    mockRunInventoryAudit.mockImplementation(async () => {
+      invocations += 1
+      const id = `AUDIT-CONCURRENT-${invocations}`
+      const dir = path.join(tmpHome, '.skillsmith', 'audits', id)
+      await fs.mkdir(dir, { recursive: true, mode: 0o700 })
+      // Simulate audit work — long enough that the second caller enters
+      // the lock-acquire branch while we're still running.
+      await new Promise((r) => setTimeout(r, 100))
+      const resultJson = {
+        exactCollisions: [],
+        genericFlags: [],
+        semanticCollisions: [],
+      }
+      await fs.writeFile(path.join(dir, 'result.json'), JSON.stringify(resultJson))
+      await fs.writeFile(path.join(dir, 'report.md'), '# concurrent test')
+      return {
+        auditId: id,
+        reportPath: path.join(dir, 'report.md'),
+        ...resultJson,
+      }
+    })
+
+    const settled = await Promise.allSettled([
+      runScheduledScan({ homeDir: tmpHome }),
+      runScheduledScan({ homeDir: tmpHome }),
+    ])
+
+    // Exactly one runInventoryAudit invocation.
+    expect(invocations).toBe(1)
+
+    // One caller must have produced a fresh result; the other must
+    // have either ridden the cache (after the peer wrote result.json)
+    // OR thrown ScheduledScanError with code 'scheduled_scan.in_flight'.
+    const fulfilled = settled.filter((s) => s.status === 'fulfilled') as Array<
+      PromiseFulfilledResult<Awaited<ReturnType<typeof runScheduledScan>>>
+    >
+    const rejected = settled.filter((s) => s.status === 'rejected') as Array<PromiseRejectedResult>
+
+    // At least one caller succeeds — the lock-holder.
+    expect(fulfilled.length).toBeGreaterThanOrEqual(1)
+
+    if (rejected.length > 0) {
+      // The losing caller threw — must be the typed in-flight error.
+      const err = rejected[0]?.reason
+      expect(err).toBeInstanceOf(ScheduledScanError)
+      expect((err as ScheduledScanError).code).toBe('scheduled_scan.in_flight')
+    } else {
+      // Both fulfilled — the second one must have ridden the cache.
+      const fresh = fulfilled.find((s) => !s.value.cached)
+      const cached = fulfilled.find((s) => s.value.cached)
+      expect(fresh).toBeDefined()
+      expect(cached).toBeDefined()
+      expect(fresh?.value.auditId).toBe(cached?.value.auditId)
+    }
+
+    // Lock file must be cleaned up.
+    const lockPath = path.join(tmpHome, '.skillsmith', 'audits', '.scan.lock')
+    await expect(fs.access(lockPath)).rejects.toThrow()
+  })
+
+  it('reclaims a stale lock (older than lock-stale window) and proceeds', async () => {
+    // Plant a synthetic stale lock — startedAt 6 minutes ago, default
+    // stale window is 5 minutes.
+    const auditsDir = path.join(tmpHome, '.skillsmith', 'audits')
+    await fs.mkdir(auditsDir, { recursive: true, mode: 0o700 })
+    const lockPath = path.join(auditsDir, '.scan.lock')
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: process.pid, // Real pid — so PID-liveness check would say "alive"
+        startedAt: Date.now() - 6 * 60 * 1000,
+        hostname: os.hostname(),
+      }),
+      { mode: 0o600 }
+    )
+
+    mockRunInventoryAudit.mockResolvedValue({
+      auditId: 'AUDIT-RECLAIM-1',
+      reportPath: 'r',
+      exactCollisions: [],
+      genericFlags: [],
+      semanticCollisions: [],
+    })
+
+    const result = await runScheduledScan({ homeDir: tmpHome })
+    expect(result.cached).toBe(false)
+    expect(result.auditId).toBe('AUDIT-RECLAIM-1')
+    expect(mockRunInventoryAudit).toHaveBeenCalledTimes(1)
+
+    // Lock cleaned up after release.
+    await expect(fs.access(lockPath)).rejects.toThrow()
+  })
+
+  it('reclaims a lock held by a definitely-dead PID', async () => {
+    // PID 0x7fffffff is reserved-ish on Linux/macOS; process.kill(0x7fffffff, 0)
+    // returns ESRCH because no real process can use it.
+    const auditsDir = path.join(tmpHome, '.skillsmith', 'audits')
+    await fs.mkdir(auditsDir, { recursive: true, mode: 0o700 })
+    const lockPath = path.join(auditsDir, '.scan.lock')
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: 0x7fffffff,
+        startedAt: Date.now(), // Fresh — only the dead-PID branch can reclaim it.
+        hostname: os.hostname(),
+      }),
+      { mode: 0o600 }
+    )
+
+    mockRunInventoryAudit.mockResolvedValue({
+      auditId: 'AUDIT-DEADPID-1',
+      reportPath: 'r',
+      exactCollisions: [],
+      genericFlags: [],
+      semanticCollisions: [],
+    })
+
+    const result = await runScheduledScan({ homeDir: tmpHome })
+    expect(result.cached).toBe(false)
+    expect(result.auditId).toBe('AUDIT-DEADPID-1')
+    expect(mockRunInventoryAudit).toHaveBeenCalledTimes(1)
+    await expect(fs.access(lockPath)).rejects.toThrow()
+  })
+
+  it('reclaims an unparseable lock file as stale', async () => {
+    const auditsDir = path.join(tmpHome, '.skillsmith', 'audits')
+    await fs.mkdir(auditsDir, { recursive: true, mode: 0o700 })
+    const lockPath = path.join(auditsDir, '.scan.lock')
+    await fs.writeFile(lockPath, 'not-json{{{')
+
+    mockRunInventoryAudit.mockResolvedValue({
+      auditId: 'AUDIT-JUNK-1',
+      reportPath: 'r',
+      exactCollisions: [],
+      genericFlags: [],
+      semanticCollisions: [],
+    })
+
+    const result = await runScheduledScan({ homeDir: tmpHome })
+    expect(result.auditId).toBe('AUDIT-JUNK-1')
+    expect(mockRunInventoryAudit).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases the lock even when runInventoryAudit throws', async () => {
+    mockRunInventoryAudit.mockRejectedValue(new Error('inventory boom'))
+
+    await expect(runScheduledScan({ homeDir: tmpHome })).rejects.toThrow(ScheduledScanError)
+
+    // Lock must NOT remain after a failure — try/finally guards it.
+    const lockPath = path.join(tmpHome, '.skillsmith', 'audits', '.scan.lock')
+    await expect(fs.access(lockPath)).rejects.toThrow()
+  })
+})
+
 describe('stripUrlSecrets', () => {
   it('strips path and query', () => {
     expect(stripUrlSecrets('https://hooks.slack.com/services/T1/B2/SECRET?x=1')).toBe(

--- a/scripts/lib/session-start-audit-helper.ts
+++ b/scripts/lib/session-start-audit-helper.ts
@@ -48,6 +48,26 @@ interface ResolvedContext {
 }
 
 /**
+ * Function-type alias for the dynamically-imported `runInventoryAudit`.
+ * Mirrors the `RunInventoryAuditFn` pattern in
+ * `packages/enterprise/src/audit/scheduled-scan.ts` so the dynamic
+ * import can be typed without an `any`-cast.
+ */
+type RunInventoryAuditFn = (opts: {
+  deep?: boolean
+  applyExclusions?: boolean
+  tier?: 'community' | 'individual' | 'team' | 'enterprise'
+  homeDir?: string
+  projectDir?: string
+}) => Promise<{
+  auditId: string
+  reportPath: string
+  exactCollisions: unknown[]
+  genericFlags: unknown[]
+  semanticCollisions: unknown[]
+}>
+
+/**
  * The render-input shape EXCLUDES per-entry fields by construction.
  * This is the only data type the renderer is permitted to see — so a
  * future contributor adding "let me print the colliding files inline"
@@ -111,10 +131,15 @@ async function main(): Promise<number> {
   }
 
   // Stage 4: run the audit. Dynamic import — costs nothing for the
-  // 99% Free/Individual path that never reaches here.
-  let runInventoryAudit
+  // 99% Free/Individual path that never reaches here. The `as` cast
+  // mirrors the `RunInventoryAuditFn` pattern in
+  // `packages/enterprise/src/audit/scheduled-scan.ts` so the dynamic
+  // import is typed (no implicit `any` — SMI-4753 finding 1).
+  let runInventoryAudit: RunInventoryAuditFn
   try {
-    const mod = await import('@skillsmith/mcp-server/audit')
+    const mod = (await import('@skillsmith/mcp-server/audit')) as {
+      runInventoryAudit: RunInventoryAuditFn
+    }
     runInventoryAudit = mod.runInventoryAudit
   } catch (err) {
     await logError(home, 'audit_module_load_failed', err)
@@ -199,7 +224,7 @@ function renderForTier(tier: ResolvedContext['tier'], input: RenderInput): Rende
 // ---------------------------------------------------------------------------
 
 async function resolveContext(home: string): Promise<ResolvedContext> {
-  const tier = await resolveTier()
+  const tier = await resolveTier(home)
   const fileMode = await readConfigAuditMode(home)
   const tierAllowsMode =
     fileMode === null ||
@@ -212,7 +237,7 @@ async function resolveContext(home: string): Promise<ResolvedContext> {
   return { tier, auditMode, tierIneligibleOverride }
 }
 
-async function resolveTier(): Promise<ResolvedContext['tier']> {
+async function resolveTier(home: string): Promise<ResolvedContext['tier']> {
   // Try the dynamic import path first (uses the enterprise validator
   // when available). Falls back to community on any failure.
   try {
@@ -241,16 +266,41 @@ async function resolveTier(): Promise<ResolvedContext['tier']> {
   if (!key) return 'community'
   try {
     const parts = key.split('.')
-    if (parts.length < 2) return 'community'
+    if (parts.length < 2) {
+      // Not a JWT shape — log so an Enterprise admin debugging "why am
+      // I getting community output" has a record (SMI-4753 finding 2).
+      await logInfo(home, 'license_key_malformed', { reason: 'not_jwt_shape' })
+      return 'community'
+    }
     const payloadB64 = parts[1] ?? ''
-    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8')) as {
-      tier?: string
+    let payload: { tier?: string }
+    try {
+      payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8')) as {
+        tier?: string
+      }
+    } catch (parseErr) {
+      // JWT shape but un-decodable payload. Log explicitly before
+      // falling through to community (SMI-4753 finding 2). Without
+      // this log, a malformed key looks identical to no key set —
+      // hiding the most common Enterprise misconfiguration mode.
+      await logInfo(home, 'license_key_malformed', {
+        reason: 'payload_decode_failed',
+        message: parseErr instanceof Error ? parseErr.message : String(parseErr),
+      })
+      return 'community'
     }
     if (payload.tier === 'individual' || payload.tier === 'team' || payload.tier === 'enterprise') {
       return payload.tier
     }
-  } catch {
-    // Fall through to community.
+    // Decoded but tier claim missing or unrecognized.
+    await logInfo(home, 'license_key_malformed', { reason: 'tier_claim_missing_or_unknown' })
+  } catch (err) {
+    // Buffer.from itself failing (extremely rare — only on memory
+    // pressure or bizarre input). Log and fall through.
+    await logInfo(home, 'license_key_malformed', {
+      reason: 'unexpected',
+      message: err instanceof Error ? err.message : String(err),
+    })
   }
   return 'community'
 }

--- a/scripts/session-start-audit.sh
+++ b/scripts/session-start-audit.sh
@@ -78,7 +78,11 @@ fi
 TIMEOUT_BIN=""
 if command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_BIN="gtimeout"
-elif command -v timeout >/dev/null 2>&1 && timeout --kill-after=0 0 true >/dev/null 2>&1; then
+elif command -v timeout >/dev/null 2>&1 && timeout 1 true >/dev/null 2>&1; then
+  # Probe with `timeout 1 true` — the simplest invocation that works on
+  # both GNU coreutils and BusyBox/Alpine. The previous probe
+  # (`timeout --kill-after=0 0 true`) used GNU-specific flag syntax and
+  # falsely failed on BusyBox, forcing the job-control fallback. (SMI-4753)
   TIMEOUT_BIN="timeout"
 fi
 

--- a/scripts/tests/session-start-audit.test.sh
+++ b/scripts/tests/session-start-audit.test.sh
@@ -239,6 +239,59 @@ EOF
 }
 
 # ----------------------------------------------------------------------
+# Test 6: malformed SKILLSMITH_LICENSE_KEY → silent stderr (privacy
+# boundary holds for community fallback) AND a `license_key_malformed`
+# entry is appended to the per-day audit log (SMI-4753 finding 2).
+#
+# This invokes the REAL helper (not the stub) so the malformed-key path
+# in resolveTier actually runs. We isolate via HOME so the helper writes
+# to a tmp log dir we can inspect.
+# ----------------------------------------------------------------------
+{
+  REPO=$(mk_test_repo)
+  cp "$HOOK" "$REPO/scripts/session-start-audit.sh"
+  chmod +x "$REPO/scripts/session-start-audit.sh"
+  # Use the real helper from the repo under test.
+  cp "$REPO_ROOT/scripts/lib/session-start-audit-helper.ts" \
+    "$REPO/scripts/lib/session-start-audit-helper.ts"
+
+  TMPHOME=$(mktemp -d -t skillsmith-malformed-home.XXXXXX)
+  STDOUT_FILE=$(mktemp -t skillsmith-hook-stdout.XXXXXX)
+  STDERR_FILE=$(mktemp -t skillsmith-hook-stderr.XXXXXX)
+
+  # Pass HOME=$TMPHOME so the helper writes its log to
+  # $TMPHOME/.skillsmith/logs/. SKILLSMITH_LICENSE_KEY is malformed
+  # (not even JWT-shape).
+  printf '{"source":"startup","cwd":"%s","session_id":"t","transcript_path":""}' "$REPO" \
+    | env HOME="$TMPHOME" SKILLSMITH_LICENSE_KEY='garbage.not.a.jwt' \
+        "$REPO/scripts/session-start-audit.sh" \
+        >"$STDOUT_FILE" 2>"$STDERR_FILE" || true
+
+  STDOUT=$(cat "$STDOUT_FILE")
+  STDERR=$(cat "$STDERR_FILE")
+
+  # Privacy boundary: malformed key falls through to community → silent
+  # stderr (community emits no render). The hook's stdout JSON envelope
+  # is still emitted regardless.
+  assert_contains "malformed-stdout-envelope" '"additionalContext": ""' "$STDOUT"
+  assert_not_contains "malformed-no-render-leak" '[skillsmith]' "$STDERR"
+
+  # The log line MUST contain "license_key_malformed" — that's the whole
+  # point of the SMI-4753 finding-2 fix.
+  TODAY=$(date -u +%Y-%m-%d)
+  LOG_FILE="$TMPHOME/.skillsmith/logs/session-audit-$TODAY.log"
+  if [ ! -f "$LOG_FILE" ]; then
+    echo "FAIL malformed-log-exists: log file $LOG_FILE not created"
+    fail=$((fail + 1))
+  else
+    LOG=$(cat "$LOG_FILE")
+    assert_contains "malformed-log-has-code" 'license_key_malformed' "$LOG"
+  fi
+
+  rm -rf "$REPO" "$TMPHOME" "$STDOUT_FILE" "$STDERR_FILE"
+}
+
+# ----------------------------------------------------------------------
 echo
 echo "SUMMARY: $pass passed, $fail failed"
 if [ "$fail" -gt 0 ]; then


### PR DESCRIPTION
## Summary

PR #956 governance retro identified four follow-ups deferred from SMI-4590 Wave 4 PR 6/6. Resolves all four in scope per CLAUDE.md no-deferral policy.

- **SMI-4752 (MED)** — Lock-file mutex at `~/.skillsmith/audits/.scan.lock` (atomic `O_EXCL`, stale-reclaim, dead-PID reclaim, EACCES/ENOSPC distinguished from EEXIST). New typed error code `scheduled_scan.in_flight`. Lock module split into `scheduled-scan.lock.ts` to keep `scheduled-scan.ts` under the 500-line cap; callback-driven so it has zero coupling to the runner's option/result types.
- **SMI-4753 (MED)** — Typed `RunInventoryAuditFn` for the dynamic `@skillsmith/mcp-server/audit` import in `session-start-audit-helper.ts`; eliminates the implicit-any.
- **SMI-4753 (MED)** — Malformed `SKILLSMITH_LICENSE_KEY` JWT decode now logs `license_key_malformed` (with reason) before falling through to community. Privacy boundary preserved: still silent on Free/Individual.
- **SMI-4753 (LOW)** — `timeout` capability probe in `session-start-audit.sh` switched from `timeout --kill-after=0 0 true` (GNU-only) to `timeout 1 true` (works on BusyBox/Alpine + GNU coreutils).

## Linear

- SMI-4752 (Backlog → Done on merge)
- SMI-4753 (Backlog → Done on merge)
- Parent: SMI-4590 (Wave 4 PR 6/6 retro follow-up)

## Test plan

- [x] **Concurrent serialization**: two parallel `runScheduledScan` calls — exactly one invokes `runInventoryAudit`; the other rides the cache or throws `scheduled_scan.in_flight`. Lock cleanly released.
- [x] **Stale-lock reclaim**: synthetic 6-min-old lock → reclaimed and replaced.
- [x] **Dead-PID reclaim**: lock with PID `0x7fffffff` (ESRCH) → reclaimed.
- [x] **Unparseable-lock reclaim**: junk JSON → treated as stale.
- [x] **Lock release on throw**: `runInventoryAudit` rejects → lock file gone after the throw.
- [x] **Malformed-key logging**: `SKILLSMITH_LICENSE_KEY=garbage.not.a.jwt` → `license_key_malformed` line in `~/.skillsmith/logs/session-audit-<date>.log` AND no `[skillsmith]` render leak on stderr.
- [x] **Existing privacy-boundary suite still green** (14 of 14 bash tests pass, including the new malformed-key assertions).
- [x] All 18 vitest cases pass (`packages/enterprise/tests/audit/scheduled-scan.test.ts`).
- [x] `npm run audit:standards` clean (54 passed, 5 warnings, 0 failed).
- [x] Pre-commit hook passed (full typecheck + lint + format).

## Retro reference

PR #956 governance retro identified these as MED/LOW findings deferred to follow-up. CLAUDE.md no-deferral policy required resolution in scope.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)