### PR TITLE
chore(doc-retrieval-mcp): SMI-4702 governance retro — stale comment fix

### DIFF
--- a/packages/doc-retrieval-mcp/eval/eval-runner.ts
+++ b/packages/doc-retrieval-mcp/eval/eval-runner.ts
@@ -284,15 +284,13 @@ export async function runRealMode(minScore?: number): Promise<import('./metrics.
 async function main(): Promise<void> {
   const opts = parseArgs(process.argv)
 
-  // Ablation delegation — Worker 2 (SMI-4707) will provide ablation-runner.ts.
-  // Dynamic import via string variable avoids a TS2307 compile error while the
-  // file is not yet present; the import is only attempted at runtime with --ablate.
+  // Ablation delegation: ablation-runner.ts is provided by SMI-4702 Worker 2.
+  // Dynamic import keeps the eval-runner module-loadable even if the ablation
+  // runner is ever moved or removed in a future refactor; the import only
+  // resolves at runtime when --ablate is passed.
   if (opts.ablate !== null) {
-    const ablationRunnerPath = './ablation-runner.js'
-
-    const ablationMod = await import(ablationRunnerPath)
-
-    await ablationMod.runAblation(opts.ablate, opts)
+    const { runAblation } = await import('./ablation-runner.js')
+    await runAblation(opts.ablate as 'boost' | 'dampen' | 'floor' | 'bm25', opts)
     return
   }
 


### PR DESCRIPTION
## Summary

Post-merge governance retro on PR #970 (SMI-4702 retrieval eval harness) found a stale code comment in `packages/doc-retrieval-mcp/eval/eval-runner.ts:287`:

- Referenced "SMI-4707" as the future provider of `ablation-runner.ts`. The file was actually shipped by SMI-4702 Worker 2 in the same merged PR. SMI-4707 is a different sibling (Wave 3.6 — re-rank edge tests).
- Described a TS2307 forward-reference workaround that no longer applies.

Replaced with a plain dynamic destructuring import + accurate comment about runtime resolution.

## Notes

- Two additional Low-severity findings from the retro could not ship in this PR due to default-branch protection on `docs-internal` blocking direct submodule pushes:
  1. Code review report at `docs/internal/code_review/2026-05-05-smi-4702-retrieval-eval-harness.md`
  2. `docs/internal/index.md` implementation count drift (240 → 242)

  Both will land via a separate `docs-internal` submodule PR + parent submodule-bump PR.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run tests/eval/` — 65/65 passing (no behavior change; only a code comment + an inline import refactor that preserves runtime semantics)
- [ ] CI green on this PR

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)