### PR TITLE
fix(scripts): SMI-4759 upload-blog-images — invalidate CDN cache on overwrite

### DIFF
--- a/scripts/upload-blog-images.mjs
+++ b/scripts/upload-blog-images.mjs
@@ -64,6 +64,11 @@ async function uploadImage(filePath, publicId) {
     public_id: publicId,
     folder: `blog/${slug}`,
     overwrite: true,
+    // SMI-4759: overwrite alone replaces the original asset but does NOT
+    // purge cached transformation URLs (f_auto,q_auto,w_1200/...) at the
+    // CDN edge. Without invalidate:true, regenerated images appear uploaded
+    // but readers see the prior version until edge TTL expires.
+    invalidate: true,
     resource_type: 'image',
   })
 }


### PR DESCRIPTION
## Summary

- `cloudinary.uploader.upload({ overwrite: true })` replaces the original asset but does NOT purge cached transformation URLs at the CDN edge. After regenerating an article's images, readers continue to see the prior version at `f_auto,q_auto,w_1200/...` URLs until edge TTL expires.
- Adds `invalidate: true` to the upload params so each overwrite triggers CDN invalidation alongside the asset replacement.
- Caught 2026-05-06 regenerating diagrams for the agent-memory-architecture article — byte counts at the live `w_1200` URL stayed identical to pre-regen response (87,927 / 77,204 / 71,700) while a cache-bust at `w_1201` returned fresh derivations (106,417). Manual one-shot `cloudinary.uploader.explicit({ invalidate: true })` fixed it; this PR makes the upload path do it automatically.

Linear: [SMI-4759](https://linear.app/smith-horn-group/issue/SMI-4759)

## Cost

Cloudinary's first 5,000 invalidations/month are free. Realistic project footprint is well under that — typical article regeneration is 3-5 images, monthly volume ≤30.

## Test plan

- [x] Pre-commit hook (lint + format) passed
- [x] `audit:standards` — 54 passed, 5 warnings, 0 failed
- [x] Pre-push hook (full test suite across all 5 workspaces) passed
- [x] Smoke test: re-ran `varlock run -- node scripts/upload-blog-images.mjs agent-memory-architecture docs/internal/articles/images/agent-memory-architecture` after the fix; Cloudinary accepted the new param without error and all 3 uploads succeeded
- [ ] CI green

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)