### PR TITLE
fix(agents): SMI-4757 hoist top-level description in 8 vendored Claude-Flow agents

### DIFF
--- a/.claude/agents/analysis/code-analyzer.md
+++ b/.claude/agents/analysis/code-analyzer.md
@@ -1,5 +1,6 @@
 ---
 name: analyst
+description: Advanced code quality analysis agent for comprehensive code reviews and improvements
 type: code-analyzer
 color: indigo
 priority: high

--- a/.claude/agents/analysis/code-review/analyze-code-quality.md
+++ b/.claude/agents/analysis/code-review/analyze-code-quality.md
@@ -1,5 +1,6 @@
 ---
 name: "code-analyzer"
+description: "Advanced code quality analysis agent for comprehensive code reviews and improvements"
 color: "purple"
 type: "analysis"
 version: "1.0.0"

--- a/.claude/agents/architecture/system-design/arch-system-design.md
+++ b/.claude/agents/architecture/system-design/arch-system-design.md
@@ -1,5 +1,6 @@
 ---
 name: "system-architect"
+description: "Expert agent for system architecture design, patterns, and high-level technical decisions"
 type: "architecture"
 color: "purple"
 version: "1.0.0"

--- a/.claude/agents/data/ml/data-ml-model.md
+++ b/.claude/agents/data/ml/data-ml-model.md
@@ -1,5 +1,6 @@
 ---
 name: "ml-developer"
+description: "Specialized agent for machine learning model development, training, and deployment"
 color: "purple"
 type: "data"
 version: "1.0.0"

--- a/.claude/agents/development/backend/dev-backend-api.md
+++ b/.claude/agents/development/backend/dev-backend-api.md
@@ -1,5 +1,6 @@
 ---
 name: "backend-dev"
+description: "Specialized agent for backend API development, including REST and GraphQL endpoints"
 color: "blue"
 type: "development"
 version: "1.0.0"

--- a/.claude/agents/devops/ci-cd/ops-cicd-github.md
+++ b/.claude/agents/devops/ci-cd/ops-cicd-github.md
@@ -1,5 +1,6 @@
 ---
 name: "cicd-engineer"
+description: "Specialized agent for GitHub Actions CI/CD pipeline creation and optimization"
 type: "devops"
 color: "cyan"
 version: "1.0.0"

--- a/.claude/agents/documentation/api-docs/docs-api-openapi.md
+++ b/.claude/agents/documentation/api-docs/docs-api-openapi.md
@@ -1,5 +1,6 @@
 ---
 name: "api-docs"
+description: "Expert agent for creating and maintaining OpenAPI/Swagger documentation"
 color: "indigo"
 type: "documentation"
 version: "1.0.0"

--- a/.claude/agents/specialized/mobile/spec-mobile-react-native.md
+++ b/.claude/agents/specialized/mobile/spec-mobile-react-native.md
@@ -1,5 +1,6 @@
 ---
 name: "mobile-dev"
+description: "Expert agent for React Native mobile application development across iOS and Android"
 color: "teal"
 type: "specialized"
 version: "1.0.0"


### PR DESCRIPTION
## Summary

- Mechanical fix: hoists `metadata.description` to a top-level `description:` key in 8 vendored Claude-Flow agent files.
- Claude Code's frontmatter parser only reads top-level keys; Ruflo reads `metadata.description`. Both copies stay so both consumers work.
- Resolves the `/doctor` "Failed to parse N agent file(s)" line for these 8 agents.

## Files changed

- `.claude/agents/documentation/api-docs/docs-api-openapi.md`
- `.claude/agents/devops/ci-cd/ops-cicd-github.md`
- `.claude/agents/analysis/code-review/analyze-code-quality.md`
- `.claude/agents/analysis/code-analyzer.md`
- `.claude/agents/development/backend/dev-backend-api.md`
- `.claude/agents/specialized/mobile/spec-mobile-react-native.md`
- `.claude/agents/architecture/system-design/arch-system-design.md`
- `.claude/agents/data/ml/data-ml-model.md`

Note: a 9th agent (the duplicate `code-analyzer` name) is documented as out-of-scope in the plan.

## Test plan

- [x] All 8 files: top-level `description:` present, byte-equal to nested `metadata.description`, nested copy preserved.
- [x] Repo-wide audit: no other agent files lack a top-level `description:` where `metadata.description` exists (i.e. no scope drift).
- [x] `npm run preflight` green inside Docker.
- [x] Full test suite green inside Docker (3,424 passed / 2 skipped).
- [ ] CI checks green.
- [ ] Post-merge: `/doctor` reports 0 agent parse errors for these 8 files.

## Linear

SMI-4757 — https://linear.app/smith-horn-group/issue/SMI-4757

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)