### PR TITLE
fix(scanner): SMI-4765 allowlist prompt-injection-auditor jailbreak FP

### DIFF
--- a/data/skills-security-allowlist.json
+++ b/data/skills-security-allowlist.json
@@ -47,6 +47,15 @@
       "reviewedBy": "ryansmith108",
       "reviewedAt": "2026-04-30",
       "expiresAt": "2026-07-30"
+    },
+    {
+      "skillId": "github/RENJI04/prompt-injection-auditor",
+      "findingType": "jailbreak",
+      "messagePattern": "jailbreak",
+      "reason": "Defensive prompt-injection auditor skill whose SKILL.md enumerates the adversarial techniques it detects ('jailbreak, role manipulation, ...'). Bare /jailbreak/i pattern triggered CRITICAL on a security-tool describing its own subject matter — same class as MalPromptSentinel and claude-security-research-skill (allowlisted under SMI-4558). Triaged 2026-05-06 under SMI-4765 — Wave 2 will replace with contextual patterns. Closes GH #894.",
+      "reviewedBy": "ryansmith108",
+      "reviewedAt": "2026-05-06",
+      "expiresAt": "2026-08-06"
     }
   ]
 }

--- a/packages/core/tests/skill-scanner/allowlist.test.ts
+++ b/packages/core/tests/skill-scanner/allowlist.test.ts
@@ -381,14 +381,18 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
   // SMI-4558 (2026-04-30): skill-protocol-rs added — Rust crate whose repo
   // description advertises a .env loader; bare-keyword sensitive_path regex
   // false-positives until Wave 2 tightens the check.
+  // SMI-4765 (2026-05-06): prompt-injection-auditor added — defensive auditor
+  // skill whose SKILL.md enumerates the jailbreak techniques it detects;
+  // bare /jailbreak/i pattern false-positives until Wave 2 tightens.
   it('is parseable and every entry expires 90 days after review', () => {
     const filePath = path.resolve(__dirname, '../../../../data/skills-security-allowlist.json')
     const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
     const parsed = parseAllowlistFile(raw)
-    expect(parsed.allowlist.length).toBe(5)
+    expect(parsed.allowlist.length).toBe(6)
     const ids = parsed.allowlist.map((e) => e.skillId).sort()
     expect(ids).toEqual(
       [
+        'github/RENJI04/prompt-injection-auditor',
         'github/RobinGase/skill-protocol-rs',
         'github/StrategicPromptArchitect-AI/MalPromptSentinel-CC-Skill',
         'github/kcmadden/claude-code-1password-skill',


### PR DESCRIPTION
## Summary

- Append `github/RENJI04/prompt-injection-auditor` to `data/skills-security-allowlist.json` to clear a false-positive CRITICAL flagged by the 2026-05-03 weekly security scan.
- Bump the ship-it sanity test from 5→6 entries and add the new ID to the expected list.

## Why this is a false positive

The skill is itself a defensive prompt-injection / jailbreak auditor — its SKILL.md enumerates the adversarial techniques it detects. The bare `/jailbreak/i` regex matched the literal word "jailbreak" in subject-matter prose.

Identical class to three prior allowlist entries from SMI-4558 (PR #840):
- `MalPromptSentinel-CC-Skill` — privilege_escalation
- `claude-security-research-skill` — sensitive_path "secrets"
- `RobinGase/skill-protocol-rs` — sensitive_path ".env"

Wave 2 scanner tightening (require contextual patterns, not bare keywords) will eliminate this class. Entry expires 2026-08-06.

## Test plan

- [x] `data/skills-security-allowlist.json` validates as JSON
- [x] `packages/core/tests/skill-scanner/allowlist.test.ts` passes (24/24) inside Docker
- [x] `audit:standards` clean (no new warnings)
- [ ] CI green
- [ ] Re-run `weekly-security-scan.yml` after merge → expect `quarantine_count=0`
- [ ] Close GH #894 with disposition note

## References

- Linear: SMI-4765
- Closes: smith-horn/skillsmith#894
- Pattern parent: SMI-4558 / PR #840
- Scanner gate: SMI-4396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[skip-impl-check]: data/test-fixture only — see SMI-3543 carve-out for non-src changes referencing SMI numbers
