### PR TITLE
fix(hooks): SMI-4767 SKILLSMITH_PRE_PUSH_DOCKER opt-in for macOS worktree pre-push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,8 @@ git submodule update --init                           # Init internal docs (auth
 
 **SMI-4738**: `npm install` in the main repo auto-regenerates worktree `docker-compose.override.yml` files via postinstall (macOS only, via `scripts/regen-worktree-overrides.sh`). Adding a new `packages/<pkg>/` no longer requires a manual `./scripts/repair-worktrees.sh` for existing worktrees to pick up the new bind mounts — just bounce the worktree container. Idempotency is content-compare (`cmp -s`), not marker-based, so drift caused by adding/removing/renaming a package is detected even when the prior override already had the SMI-4689 marker.
 
+**Worktree pre-push** (SMI-4767): if the pre-push host vitest fails on a macOS worktree, prepend `SKILLSMITH_PRE_PUSH_DOCKER=1` to the push to route the hook through Docker (`SKILLSMITH_PRE_PUSH_DOCKER=1 git push`). Required because SMI-4693 only landed test-fixture env scrubbing — the parent vitest process still inherits parent-worktree `GIT_*` env. Docker must be running. Tracked in SMI-4767 (workaround) + SMI-4769 (proper fix: env scrub of `pre-push-coverage-check.sh`).
+
 **Host native bindings, `IS_DOCKER` trap, outage marker + stale-instrumentation banner, macOS host fallback, SMI-4698 native-rebuild caveat**: see [git-crypt-guide.md § Host Native Bindings & SessionStart Instrumentation (SMI-4549)](.claude/development/git-crypt-guide.md#host-native-bindings--sessionstart-instrumentation-smi-4549).
 
 **Rebasing**: `./scripts/rebase-worktree.sh <worktree-path> [target-branch]` handles git-crypt filter management, submodule cross-fetching, and branch verification. Use `--dry-run` to preview. Manual fallback: [git-crypt-guide.md](.claude/development/git-crypt-guide.md#rebasing-with-git-crypt).

--- a/scripts/lib/hook-docker-detect.sh
+++ b/scripts/lib/hook-docker-detect.sh
@@ -143,23 +143,39 @@ fi
 # macOS + worktree: virtiofs cannot traverse relative symlinks (SMI-4381).
 # Always fall back here, regardless of Docker availability — running in
 # Docker would silently fail with wrong dep versions.
+#
+# SMI-4767 escape hatch: SKILLSMITH_PRE_PUSH_DOCKER=1 forces Docker even on
+# macOS worktrees, bypassing the SMI-4381 fallback. Required because SMI-4693
+# only fixed test-fixture env leak; the parent vitest process still inherits
+# parent-worktree GIT_* env. The proper fix is tracked in SMI-4769 (env scrub
+# of pre-push-coverage-check.sh).
 if [ "$IS_WORKTREE" = "1" ] && [ "$(uname)" = "Darwin" ]; then
-    NEEDS_FALLBACK=1
-    printf "${HOOK_DETECT_YELLOW}📂 Worktree on macOS — falling back to host execution (SMI-4381 / SMI-4681)${HOOK_DETECT_NC}\n"
-    printf "${HOOK_DETECT_YELLOW}   Per-package node_modules symlinks are not traversable in${HOOK_DETECT_NC}\n"
-    printf "${HOOK_DETECT_YELLOW}   Docker Desktop's virtiofs. Host resolution works correctly.${HOOK_DETECT_NC}\n"
+    if [ "${SKILLSMITH_PRE_PUSH_DOCKER:-0}" = "1" ]; then
+        if [ "$DOCKER_AVAILABLE" = "0" ]; then
+            printf "${HOOK_DETECT_RED}❌ SKILLSMITH_PRE_PUSH_DOCKER=1 set, but Docker is not running.${HOOK_DETECT_NC}\n" >&2
+            printf "${HOOK_DETECT_YELLOW}   Start the dev container: docker compose --profile dev up -d${HOOK_DETECT_NC}\n" >&2
+            printf "${HOOK_DETECT_YELLOW}   Or unset the env var to fall back to host (will hit SMI-4767 leak).${HOOK_DETECT_NC}\n" >&2
+            exit 1
+        fi
+        printf "${HOOK_DETECT_BLUE}🐳 SKILLSMITH_PRE_PUSH_DOCKER=1 — routing through Docker (SMI-4767 opt-in)${HOOK_DETECT_NC}\n"
+    else
+        NEEDS_FALLBACK=1
+        printf "${HOOK_DETECT_YELLOW}📂 Worktree on macOS — falling back to host execution (SMI-4381 / SMI-4681)${HOOK_DETECT_NC}\n"
+        printf "${HOOK_DETECT_YELLOW}   Per-package node_modules symlinks are not traversable in${HOOK_DETECT_NC}\n"
+        printf "${HOOK_DETECT_YELLOW}   Docker Desktop's virtiofs. Host resolution works correctly.${HOOK_DETECT_NC}\n"
 
-    # SMI-4681 change #15: native-binding preflight on host fallback.
-    # If host node_modules / per-package symlinks were never set up (fresh
-    # clone without `npm install --ignore-scripts` or `repair-worktrees.sh`),
-    # surface the repair path BEFORE format/coverage produces a cryptic
-    # Node module-resolution error. Symlink OR real dir both qualify;
-    # symlink target need not be eagerly resolved here.
-    if [ ! -e "node_modules" ]; then
-        printf "${HOOK_DETECT_RED}❌ Host node_modules missing in worktree.${HOOK_DETECT_NC}\n"
-        printf "${HOOK_DETECT_YELLOW}   Run: ./scripts/repair-worktrees.sh${HOOK_DETECT_NC}\n"
-        printf "${HOOK_DETECT_YELLOW}   Bypass: git push --no-verify${HOOK_DETECT_NC}\n"
-        exit 1
+        # SMI-4681 change #15: native-binding preflight on host fallback.
+        # If host node_modules / per-package symlinks were never set up (fresh
+        # clone without `npm install --ignore-scripts` or `repair-worktrees.sh`),
+        # surface the repair path BEFORE format/coverage produces a cryptic
+        # Node module-resolution error. Symlink OR real dir both qualify;
+        # symlink target need not be eagerly resolved here.
+        if [ ! -e "node_modules" ]; then
+            printf "${HOOK_DETECT_RED}❌ Host node_modules missing in worktree.${HOOK_DETECT_NC}\n"
+            printf "${HOOK_DETECT_YELLOW}   Run: ./scripts/repair-worktrees.sh${HOOK_DETECT_NC}\n"
+            printf "${HOOK_DETECT_YELLOW}   Bypass: git push --no-verify${HOOK_DETECT_NC}\n"
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
[skip-impl-check] Shell + markdown-only PR (no source-code implementation to verify).

## Summary

- Add `SKILLSMITH_PRE_PUSH_DOCKER=1` opt-in env var that routes pre-push hooks through Docker on macOS worktrees, bypassing the SMI-4381 host-fallback that triggers spurious vitest failures via parent-worktree `GIT_*` env leak.
- Document workaround in `CLAUDE.md` worktree section. Proper fix tracked in SMI-4769 (env scrub of `pre-push-coverage-check.sh` — needs own SPARC pass per ADR-109).

## Context

SMI-4693 (closed 2026-05-04) only landed Waves 1–3 (test-fixture env scrub via `git-fixture-env` helper); the parent vitest invocation in `pre-push-coverage-check.sh` still inherits parent-worktree `GIT_*` env, surfacing as spurious test failures on macOS-worktree pre-push (host fallback per SMI-4381 virtiofs limit). This workaround unblocks worktree-based PRs immediately without requiring `--no-verify` (which would skip *all* pre-push checks, not just the leaky vitest).

Verified by dogfooding: this PR was pushed using `SKILLSMITH_PRE_PUSH_DOCKER=1 git push` — pre-push format-check and test-check both ran in Docker successfully.

## Implementation

The env-var check lives inside the `IS_WORKTREE && Darwin` branch in `scripts/lib/hook-docker-detect.sh`. When the var is set:

1. If Docker isn't running → red error + `exit 1` (no opaque docker-exec failures).
2. Otherwise → skip the SMI-4381 host fallback; `USE_DOCKER` ends at 1, `RUN_PREFIX="docker exec skillsmith-dev-1"`, `CONTAINER_WD=/app/.worktrees/<name>`.

The check is placed inside the if-branch (rather than as an early-return) so the `run_cmd` function definition below (line 204) is still set for the caller.

## Plan & related

- Plan: `docs/internal/implementation/smi-4767-pre-push-worktree-fixes.md` (Wave 1)
- Wave 2 (SMI-4766 dry-run arg parser fix) ships in a separate PR off main
- SMI-4768 descoped to Low ("future work") — `git push` always originates on host
- SMI-4769 (proper env-scrub fix) filed before ExitPlanMode per ADR-109

## Test plan

- [x] `bash -n scripts/lib/hook-docker-detect.sh` syntax-clean
- [x] Manual: `SKILLSMITH_PRE_PUSH_DOCKER=1 git push` from worktree routes through Docker (this PR)
- [x] Manual: `git push` (no env var) still falls back to host as today
- [x] `docker exec ... npm run lint && npm run typecheck && npm run audit:standards` clean
- [x] `prettier --check CLAUDE.md` clean
- [x] Governance review — no Critical/High/Medium findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
