### PR TITLE
fix(doc-retrieval-mcp): SMI-4763 recompute corpus stats and fix index-state path resolution

### DIFF
--- a/packages/doc-retrieval-mcp/eval/eval-runner.ts
+++ b/packages/doc-retrieval-mcp/eval/eval-runner.ts
@@ -23,10 +23,65 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { GoldEntry, RunResult, MetricsReport } from './metrics.js'
 import { computeMetrics } from './metrics.js'
+import { resolveRepoPath } from '../src/config.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const GOLD_SET_PATH = join(__dirname, 'gold-set.json')
 const BASELINE_PATH = join(__dirname, 'baseline.json')
+
+// ---------------------------------------------------------------------------
+// Index-state helpers (SMI-4763)
+//
+// `resolveIndexStateFile` mirrors src/config.ts repoRoot()/resolveRepoPath()
+// so the GAP 1 startup check and the corpus-stats refresh both consult the
+// SAME path the indexer writes to: `$SKILLSMITH_REPO_ROOT/.ruvector/.index-state.json`
+// (or `$CWD/.ruvector/.index-state.json` when the env var is unset).
+//
+// The previous `join(__dirname, '..', '.ruvector', '.index-state.json')` resolved
+// inside the package (`packages/doc-retrieval-mcp/.ruvector/...`), which never
+// exists in practice — the GAP 1 check silently passed and `updateBaseline()`
+// carried forward stale corpus stats forever. See SMI-4763 issue body.
+// ---------------------------------------------------------------------------
+
+export function resolveIndexStateFile(): string {
+  return resolveRepoPath('.ruvector/.index-state.json')
+}
+
+/**
+ * Read corpus stats (filesScanned, chunksUpserted) from the indexer's
+ * `.index-state.json`. Fails soft: missing or malformed files return zeros
+ * and emit a warning to stderr — a degraded baseline is preferable to a
+ * failed baseline write, since baseline.json is the only durable record of
+ * the metric run that just completed.
+ */
+export function readCorpusStatsFromIndex(stateFile: string): {
+  filesScanned: number
+  chunksUpserted: number
+} {
+  if (!existsSync(stateFile)) {
+    process.stderr.write(
+      `Warning: index-state file not found at ${stateFile}; baseline corpus stats will be 0/0.\n`
+    )
+    return { filesScanned: 0, chunksUpserted: 0 }
+  }
+  let chunkCountByFile: Record<string, number>
+  try {
+    const raw = readFileSync(stateFile, 'utf8')
+    const parsed = JSON.parse(raw) as { chunkCountByFile?: Record<string, number> }
+    chunkCountByFile = parsed.chunkCountByFile ?? {}
+  } catch (err: unknown) {
+    process.stderr.write(
+      `Warning: failed to parse index-state file at ${stateFile} (${String(err)}); baseline corpus stats will be 0/0.\n`
+    )
+    return { filesScanned: 0, chunksUpserted: 0 }
+  }
+  const filesScanned = Object.keys(chunkCountByFile).length
+  const chunksUpserted = Object.values(chunkCountByFile).reduce(
+    (sum, n) => sum + (typeof n === 'number' ? n : 0),
+    0
+  )
+  return { filesScanned, chunksUpserted }
+}
 
 // ---------------------------------------------------------------------------
 // CLI flag parsing
@@ -87,7 +142,10 @@ function buildMockResults(entries: GoldEntry[]): RunResult[] {
 
 async function buildRealResults(entries: GoldEntry[]): Promise<RunResult[]> {
   // GAP 1 startup check: verify memory-topic-files adapter is indexed.
-  const stateFile = join(__dirname, '..', '.ruvector', '.index-state.json')
+  // SMI-4763: resolve via repoRoot() so we consult the real .index-state.json
+  // the indexer writes to (`$REPO_ROOT/.ruvector/...`), not the
+  // package-local stub path that never exists in practice.
+  const stateFile = resolveIndexStateFile()
   if (existsSync(stateFile)) {
     const stateRaw = readFileSync(stateFile, 'utf8')
     const state = JSON.parse(stateRaw) as { chunkCountByFile?: Record<string, number> }
@@ -139,7 +197,7 @@ async function buildRealResults(entries: GoldEntry[]): Promise<RunResult[]> {
 // check-baseline-drift.ts. `prior` and `current` are recall@5 scalars; the
 // full metric set lives under `metrics`. Promotion: each real-mode run
 // promotes existing.current → prior and writes the new recall@5 as current.
-interface BaselineFile {
+export interface BaselineFile {
   prior: number | null
   current: number | null
   generated: string
@@ -166,23 +224,31 @@ function readKnobsFromEnv(): BaselineFile['knobs'] {
   }
 }
 
-function updateBaseline(report: MetricsReport): void {
+export function updateBaseline(
+  report: MetricsReport,
+  opts: { baselinePath?: string; stateFile?: string } = {}
+): void {
+  const baselinePath = opts.baselinePath ?? BASELINE_PATH
+  const stateFile = opts.stateFile ?? resolveIndexStateFile()
   let existingCurrent: number | null = null
-  let existingCorpus: BaselineFile['corpus'] = { filesScanned: 0, chunksUpserted: 0 }
-  if (existsSync(BASELINE_PATH)) {
+  if (existsSync(baselinePath)) {
     try {
-      const existing = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as Partial<BaselineFile>
+      const existing = JSON.parse(readFileSync(baselinePath, 'utf8')) as Partial<BaselineFile>
       if (typeof existing.current === 'number') existingCurrent = existing.current
-      if (existing.corpus) existingCorpus = existing.corpus
     } catch {
       // malformed baseline — start fresh
     }
   }
+  // SMI-4763: recompute corpus stats from the live index-state file on every
+  // run. The previous implementation carried `existingCorpus` forward from the
+  // prior baseline.json, so once the value was wrong it stayed wrong even as
+  // the index grew (e.g., 1325 files → 1500 files would still report 1325).
+  const freshCorpus = readCorpusStatsFromIndex(stateFile)
   const updated: BaselineFile = {
     prior: existingCurrent,
     current: report.overall.recallAt5,
     generated: new Date().toISOString().split('T')[0],
-    corpus: existingCorpus,
+    corpus: freshCorpus,
     knobs: readKnobsFromEnv(),
     metrics: {
       recallAt5: report.overall.recallAt5,
@@ -191,7 +257,7 @@ function updateBaseline(report: MetricsReport): void {
       ndcgAt10: report.overall.ndcgAt10,
     },
   }
-  writeFileSync(BASELINE_PATH, JSON.stringify(updated, null, 2) + '\n', 'utf8')
+  writeFileSync(baselinePath, JSON.stringify(updated, null, 2) + '\n', 'utf8')
 }
 
 // ---------------------------------------------------------------------------
@@ -323,7 +389,17 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err: unknown) => {
-  process.stderr.write(`eval-runner error: ${String(err)}\n`)
-  process.exit(1)
-})
+// Only run as CLI entry point — do not execute when imported by tests.
+// SMI-4763: corpus-stats.test.ts imports updateBaseline / readCorpusStatsFromIndex
+// from this module; without this guard, every test import would run a full
+// mock-mode eval pass and pollute stdout. Mirrors check-baseline-drift.ts.
+const isEntryPoint =
+  process.argv[1] !== undefined &&
+  (process.argv[1].endsWith('eval-runner.ts') || process.argv[1].endsWith('eval-runner.js'))
+
+if (isEntryPoint) {
+  main().catch((err: unknown) => {
+    process.stderr.write(`eval-runner error: ${String(err)}\n`)
+    process.exit(1)
+  })
+}

--- a/packages/doc-retrieval-mcp/tests/eval/corpus-stats.test.ts
+++ b/packages/doc-retrieval-mcp/tests/eval/corpus-stats.test.ts
@@ -1,0 +1,188 @@
+/**
+ * SMI-4763 — Unit tests for corpus-stats helpers in eval-runner.ts.
+ *
+ * Two latent bugs surfaced during the SMI-4762 baseline bootstrap:
+ *
+ *   Bug 1: `updateBaseline()` carried `existingCorpus` forward unchanged from
+ *          the previous baseline.json. If the index grew (e.g. 1325 → 1500
+ *          files), baseline.json kept claiming the stale count forever.
+ *
+ *   Bug 2: The GAP 1 startup check resolved `.index-state.json` against the
+ *          package directory (`packages/doc-retrieval-mcp/.ruvector/...`)
+ *          instead of `$REPO_ROOT/.ruvector/...`. The file never existed at
+ *          the wrong path, so the check silently passed.
+ *
+ * Test 5 is the regression guard for Bug 1: it verifies that `updateBaseline`
+ * always reflects the live index state, never the previous baseline.json.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  readCorpusStatsFromIndex,
+  resolveIndexStateFile,
+  updateBaseline,
+  type BaselineFile,
+} from '../../eval/eval-runner.js'
+import type { MetricsReport } from '../../eval/metrics.js'
+
+// ---------------------------------------------------------------------------
+// Fixtures and helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'smi-4763-corpus-stats-'))
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function writeStateFile(chunkCountByFile: Record<string, number>): string {
+  const path = join(tmpDir, '.index-state.json')
+  writeFileSync(path, JSON.stringify({ chunkCountByFile }, null, 2), 'utf8')
+  return path
+}
+
+function makeReport(recallAt5: number): MetricsReport {
+  return {
+    overall: { count: 10, recallAt5, recallAt10: recallAt5 + 0.05, mrr: 0.7, ndcgAt10: 0.75 },
+    byCategory: {},
+    byDifficulty: {},
+  }
+}
+
+// ---------------------------------------------------------------------------
+// readCorpusStatsFromIndex — Tests 1-4
+// ---------------------------------------------------------------------------
+
+describe('readCorpusStatsFromIndex', () => {
+  it('Test 1: returns correct counts for a 3-file / 10-chunk fixture', () => {
+    const stateFile = writeStateFile({
+      'memory://feedback_a.md': 4,
+      'memory://feedback_b.md': 3,
+      'docs/internal/architecture/standards.md': 3,
+    })
+    const stats = readCorpusStatsFromIndex(stateFile)
+    expect(stats.filesScanned).toBe(3)
+    expect(stats.chunksUpserted).toBe(10)
+  })
+
+  it('Test 2: missing file returns 0/0 without throwing', () => {
+    const missing = join(tmpDir, 'does-not-exist.json')
+    expect(() => readCorpusStatsFromIndex(missing)).not.toThrow()
+    const stats = readCorpusStatsFromIndex(missing)
+    expect(stats).toEqual({ filesScanned: 0, chunksUpserted: 0 })
+  })
+
+  it('Test 3: malformed JSON returns 0/0 without throwing', () => {
+    const path = join(tmpDir, '.index-state.json')
+    writeFileSync(path, '{not valid json', 'utf8')
+    expect(() => readCorpusStatsFromIndex(path)).not.toThrow()
+    const stats = readCorpusStatsFromIndex(path)
+    expect(stats).toEqual({ filesScanned: 0, chunksUpserted: 0 })
+  })
+
+  it('Test 4: empty chunkCountByFile returns 0/0', () => {
+    const stateFile = writeStateFile({})
+    const stats = readCorpusStatsFromIndex(stateFile)
+    expect(stats).toEqual({ filesScanned: 0, chunksUpserted: 0 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updateBaseline regression — Test 5 (Bug 1 guard)
+// ---------------------------------------------------------------------------
+
+describe('updateBaseline (SMI-4763 regression guard)', () => {
+  it('Test 5: writes corpus stats from the live index, NOT the prior baseline.json', () => {
+    const baselinePath = join(tmpDir, 'baseline.json')
+
+    // Run 1: index has 1325 files / 28432 chunks
+    const stateRun1 = writeStateFile({
+      ...Object.fromEntries(
+        Array.from({ length: 1325 }, (_, i) => [`memory://file_${i}.md`, 21] as const)
+      ),
+    })
+    // 1325 * 21 = 27825 — not 28432 — but Test 5 only requires the post-update
+    // value reflects the live index. Use clean math:
+    // 1325 files with 21 chunks each = 27825 chunks.
+    updateBaseline(makeReport(0.5), { baselinePath, stateFile: stateRun1 })
+    const after1 = JSON.parse(readFileSync(baselinePath, 'utf8')) as BaselineFile
+    expect(after1.corpus.filesScanned).toBe(1325)
+    expect(after1.corpus.chunksUpserted).toBe(27825)
+
+    // Run 2: index grew to 1500 files / 31500 chunks (1500 * 21).
+    // Critical: baseline.json from Run 1 still says 1325/27825. The bug being
+    // guarded against is the carry-forward of those stale stats.
+    const stateRun2 = writeStateFile({
+      ...Object.fromEntries(
+        Array.from({ length: 1500 }, (_, i) => [`memory://file_${i}.md`, 21] as const)
+      ),
+    })
+    updateBaseline(makeReport(0.6), { baselinePath, stateFile: stateRun2 })
+    const after2 = JSON.parse(readFileSync(baselinePath, 'utf8')) as BaselineFile
+
+    // The load-bearing assertion: stats reflect the LIVE index (1500/31500),
+    // not the previous baseline.json's stats (1325/27825).
+    expect(after2.corpus.filesScanned).toBe(1500)
+    expect(after2.corpus.chunksUpserted).toBe(31500)
+
+    // Sanity: prior promotion still works correctly.
+    expect(after2.prior).toBe(0.5)
+    expect(after2.current).toBe(0.6)
+  })
+
+  it('Test 5b: degraded baseline (missing state file) writes 0/0 not throws', () => {
+    const baselinePath = join(tmpDir, 'baseline.json')
+    const missingState = join(tmpDir, 'never-existed.json')
+    expect(() =>
+      updateBaseline(makeReport(0.5), { baselinePath, stateFile: missingState })
+    ).not.toThrow()
+    expect(existsSync(baselinePath)).toBe(true)
+    const written = JSON.parse(readFileSync(baselinePath, 'utf8')) as BaselineFile
+    expect(written.corpus).toEqual({ filesScanned: 0, chunksUpserted: 0 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveIndexStateFile — Tests 6-8 (Bug 2 guard)
+// ---------------------------------------------------------------------------
+
+describe('resolveIndexStateFile', () => {
+  let originalRepoRoot: string | undefined
+
+  beforeEach(() => {
+    originalRepoRoot = process.env.SKILLSMITH_REPO_ROOT
+  })
+
+  afterEach(() => {
+    if (originalRepoRoot === undefined) {
+      delete process.env.SKILLSMITH_REPO_ROOT
+    } else {
+      process.env.SKILLSMITH_REPO_ROOT = originalRepoRoot
+    }
+  })
+
+  it('Test 6: respects SKILLSMITH_REPO_ROOT env when set', () => {
+    process.env.SKILLSMITH_REPO_ROOT = '/tmp/synthetic-repo-root'
+    const resolved = resolveIndexStateFile()
+    expect(resolved).toBe('/tmp/synthetic-repo-root/.ruvector/.index-state.json')
+  })
+
+  it('Test 7: falls back to process.cwd() when SKILLSMITH_REPO_ROOT is unset', () => {
+    delete process.env.SKILLSMITH_REPO_ROOT
+    const resolved = resolveIndexStateFile()
+    expect(resolved).toBe(join(process.cwd(), '.ruvector', '.index-state.json'))
+  })
+
+  it('Test 8: produces an absolute path', () => {
+    process.env.SKILLSMITH_REPO_ROOT = '/tmp/abs-check'
+    const resolved = resolveIndexStateFile()
+    expect(resolved.startsWith('/')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- **Bug 1**: `updateBaseline()` carried `existingCorpus` forward unchanged from the previous baseline.json, so once the count was right (1325/28432 from SMI-4762 bootstrap) it stayed there forever even as the index grew. Now recomputes from the live `.index-state.json` on every run via a new `readCorpusStatsFromIndex()` helper.
- **Bug 2**: GAP 1 startup check resolved `.index-state.json` against `packages/doc-retrieval-mcp/.ruvector/...` (package-local) instead of `$REPO_ROOT/.ruvector/...` (where the indexer actually writes). The file never existed at the wrong path so the check silently passed for everyone. Both call sites now use a shared `resolveIndexStateFile()` that mirrors `repoRoot()` from `src/config.ts` (via `resolveRepoPath`).
- **Tests**: 9 new unit tests in `tests/eval/corpus-stats.test.ts` — 4 helper tests (correct counts, missing file, malformed JSON, empty map), 1 load-bearing regression guard for the carry-forward bug (Test 5: index grows 1325→1500 between runs, asserts the second baseline reflects 1500 not the carried-forward 1325), 1 degraded-baseline soft-fail, 3 path-resolution tests (env override, cwd fallback, absolute path). All 133 doc-retrieval-mcp tests pass.

## Files changed

| File | Lines |
|------|-------|
| `packages/doc-retrieval-mcp/eval/eval-runner.ts` | +89 / -13 |
| `packages/doc-retrieval-mcp/tests/eval/corpus-stats.test.ts` | +201 (new) |

Adjacent to PR #983 (SMI-4764 Wave 0) but does not overlap — #983 modifies the signature emission tail of `updateBaseline()`; this PR modifies the corpus-stats branch and the GAP 1 check at the top of `buildRealResults()`.

## Self-test (in worktree Docker container)

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run format:check` — all files formatted
- `npm run audit:standards` — 57 passed / 4 warnings / 0 failed
- `npx vitest run` (full doc-retrieval-mcp suite) — 133 passed / 0 failed
- Pre-push test phase failed on host with `better-sqlite3 invalid ELF header` (SMI-4698 host native binding cascade in core/cli/mcp-server tests). Per memory `feedback_main_branch_claims_via_ci.md`, host-side test failures from native ABI mismatch are not regressions; CI is authoritative.

## Bonus end-to-end

Ran `RETRIEVAL_EVAL_REAL=1 npx tsx eval/eval-runner.ts` inside the worktree container. The container has no host `.ruvector/` mount, so `readCorpusStatsFromIndex` correctly emitted the missing-file warning and wrote `{ filesScanned: 0, chunksUpserted: 0 }` instead of carrying forward the prior 1325/28432 — exactly the behavior change Bug 1 fix is designed to produce. baseline.json was reverted before staging per spec.

## Test plan

- [x] All 9 new tests pass
- [x] All 133 doc-retrieval-mcp tests pass
- [x] Lint / typecheck / format / audit clean
- [x] No baseline.json change committed
- [x] No drift into PR #983 territory (lines 201 / 209-261)

`Closes SMI-4763`

[skip-impl-check]

🤖 Generated with [Claude Code](https://claude.com/claude-code)