### PR TITLE
fix(scripts): SMI-4766 rebase-worktree.sh — accept --dry-run anywhere on cmdline

### DIFF
--- a/scripts/rebase-worktree.sh
+++ b/scripts/rebase-worktree.sh
@@ -381,17 +381,25 @@ step_report() {
 }
 
 main() {
+    # SMI-4766: collect positionals while still scanning for flags. The previous
+    # parser used `case ... *) break ;;` which silently dropped any flag that
+    # appeared after the first positional argument (e.g.
+    # `./scripts/rebase-worktree.sh worktrees/foo main --dry-run` ran the rebase
+    # to completion because --dry-run was never seen).
+    ARGS=()
     while [[ $# -gt 0 ]]; do
         case $1 in
             -h|--help) usage; exit 0 ;;
-            --dry-run) DRY_RUN=true; shift ;;
-            --no-submodule) SKIP_SUBMODULE=true; shift ;;
+            --dry-run) DRY_RUN=true ;;
+            --no-submodule) SKIP_SUBMODULE=true ;;
             -*) error "Unknown option: $1
 
 Run '$(basename "$0") --help' for usage information." ;;
-            *) break ;;
+            *) ARGS+=("$1") ;;
         esac
+        shift
     done
+    set -- "${ARGS[@]}"
 
     WORKTREE_PATH="${1:-}"
     TARGET_BRANCH="${2:-origin/main}"

--- a/scripts/tests/rebase-worktree.test.ts
+++ b/scripts/tests/rebase-worktree.test.ts
@@ -262,6 +262,55 @@ describe('SMI-3102: rebase-worktree.sh', () => {
     expect(headAfter).toBe(headBefore)
   })
 
+  // SMI-4766: --dry-run honored regardless of position relative to positional args.
+  // Pre-fix, `case ... *) break ;;` exited the flag loop on the first positional,
+  // silently dropping any flag that appeared after it.
+  it('honors --dry-run when passed AFTER positional args (SMI-4766)', () => {
+    const tempRoot = makeTempDir('rw-test6b')
+    tempDirs.push(tempRoot)
+    const { cloneDir, worktreeDir } = setupRepoWithWorktree(tempRoot)
+
+    git(cloneDir, 'checkout main')
+    sh(`echo "after-positional" > "${join(cloneDir, 'after.txt')}"`)
+    git(cloneDir, 'add after.txt')
+    git(cloneDir, 'commit -m "advance for SMI-4766 after-positional"')
+    git(cloneDir, 'push origin main')
+    git(cloneDir, 'checkout -')
+
+    const headBefore = git(worktreeDir, 'rev-parse HEAD')
+
+    const result = runScript(`"${worktreeDir}" origin/main --dry-run`)
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('dry-run')
+    expect(result.stdout).toContain('Dry run complete')
+
+    const headAfter = git(worktreeDir, 'rev-parse HEAD')
+    expect(headAfter).toBe(headBefore)
+  })
+
+  it('honors --dry-run when interspersed with positional args (SMI-4766)', () => {
+    const tempRoot = makeTempDir('rw-test6c')
+    tempDirs.push(tempRoot)
+    const { cloneDir, worktreeDir } = setupRepoWithWorktree(tempRoot)
+
+    git(cloneDir, 'checkout main')
+    sh(`echo "interspersed" > "${join(cloneDir, 'inter.txt')}"`)
+    git(cloneDir, 'add inter.txt')
+    git(cloneDir, 'commit -m "advance for SMI-4766 interspersed"')
+    git(cloneDir, 'push origin main')
+    git(cloneDir, 'checkout -')
+
+    const headBefore = git(worktreeDir, 'rev-parse HEAD')
+
+    const result = runScript(`"${worktreeDir}" --dry-run origin/main`)
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('dry-run')
+    expect(result.stdout).toContain('Dry run complete')
+
+    const headAfter = git(worktreeDir, 'rev-parse HEAD')
+    expect(headAfter).toBe(headBefore)
+  })
+
   // Scenario 7: --no-submodule
   it('skips submodule steps when --no-submodule is passed', () => {
     const tempRoot = makeTempDir('rw-test7')


### PR DESCRIPTION
[skip-impl-check] Shell + test-only PR (no source-code feature implementation to verify).

## Summary

- Fix `scripts/rebase-worktree.sh:383-394` arg parser bug where `case ... *) break ;;` exited the flag loop on the first positional, silently dropping any flag that appeared after it.
- The failing invocation `./scripts/rebase-worktree.sh worktrees/<n> main --dry-run` ran the rebase to completion because `--dry-run` was never seen.
- New parser collects positionals into `ARGS=()` while continuing to scan for flags; `set -- "${ARGS[@]}"` re-binds positionals afterward.

## Tests

Two regression tests in `scripts/tests/rebase-worktree.test.ts` cover:
- `--dry-run` AFTER positional args (the original failing form)
- `--dry-run` interspersed (`<wt> --dry-run main`)

Both push commits to a bare remote, capture HEAD before, run the script, assert `status==0` + `dry-run` in output + `Dry run complete` + HEAD unchanged.

Existing Scenario 6 (flag-before-positional) continues to pass. All 11 tests in the file green.

## Plan & related

- Plan: `docs/internal/implementation/smi-4767-pre-push-worktree-fixes.md` (Wave 2)
- Wave 1 (SMI-4767 pre-push Docker opt-in) merged in #984
- This PR was pushed using `SKILLSMITH_PRE_PUSH_DOCKER=1 git push` — dogfooding Wave 1's workaround

## Test plan

- [x] `bash -n scripts/rebase-worktree.sh` syntax-clean
- [x] `npx vitest run scripts/tests/rebase-worktree.test.ts` — 11/11 pass
- [x] `npm run lint && npm run typecheck` clean
- [x] `npm run audit:standards` 57/4/0 (no regression)
- [x] Governance review — no Critical/High/Medium findings; one Low (theoretical `--` separator handling) closed as won't-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)