### PR TITLE
docs(git-crypt-guide): SMI-4767 add SKILLSMITH_PRE_PUSH_DOCKER escape-hatch note

### DIFF
--- a/.claude/development/git-crypt-guide.md
+++ b/.claude/development/git-crypt-guide.md
@@ -337,4 +337,13 @@ The repair script is idempotent — sub-second `[skip]` exit when the binding al
 
 …it is **expected** and the hook is doing the right thing. If the message is followed by `❌ Host node_modules missing in worktree.`, run `./scripts/repair-worktrees.sh` to backfill the symlinks + native bindings.
 
+**Escape hatch — `SKILLSMITH_PRE_PUSH_DOCKER=1` (SMI-4767)**: the host fallback above is correct for `pre-commit` (lint/format) but breaks `pre-push` test runs because the parent vitest invocation in `scripts/pre-push-coverage-check.sh` still inherits parent-worktree `GIT_*` env. SMI-4693 only landed Waves 1–3 (test-fixture env scrub via `git-fixture-env`); the parent-vitest leak is deferred to SMI-4769. Workaround: prepend `SKILLSMITH_PRE_PUSH_DOCKER=1` to the push to force Docker even on macOS worktrees, bypassing this fallback for pre-push only:
+
+```bash
+SKILLSMITH_PRE_PUSH_DOCKER=1 git push        # per-invocation (preferred)
+export SKILLSMITH_PRE_PUSH_DOCKER=1          # session-wide if pushing repeatedly
+```
+
+Docker must be running — the hook prints a red error + `exit 1` if `SKILLSMITH_PRE_PUSH_DOCKER=1` is set but the dev container is down. Do NOT use `git push --no-verify` as the default; that bypasses *all* pre-push checks (security scan, format check, etc.), not just the leaky vitest. The env-var workaround is targeted.
+
 **Caveat (SMI-4698)**: the **native-rebuild step** of `./scripts/repair-worktrees.sh` aborts if a `skillsmith*-dev-N` container is running — it would otherwise overwrite the container's ELF native bindings via the symlinked `node_modules`. Symlink-repair steps run safely regardless. Stop the container first (`docker compose --profile dev down`), or pass `--force-with-active-docker` and run `docker exec -w /app skillsmith-dev-1 npm rebuild better-sqlite3 onnxruntime-node` afterward to restore the container's bindings.


### PR DESCRIPTION
[skip-impl-check] Docs-only — adds 9 lines to one .md file.

## Summary

- Post-merge governance retro on PR #984 flagged that `.claude/development/git-crypt-guide.md` (the canonical deep-dive doc CLAUDE.md links to via "macOS host fallback") didn't mention the new `SKILLSMITH_PRE_PUSH_DOCKER=1` opt-in.
- A user hitting the SMI-4767 vitest leak who follows the CLAUDE.md link to the deep dive lands in the "this is expected" section and misses the workaround.
- Add an "Escape hatch — `SKILLSMITH_PRE_PUSH_DOCKER=1` (SMI-4767)" subsection right after the host-fallback fenced block, with usage examples and an explicit warning against falling back to `git push --no-verify`.

## Context

Wave 1 (SMI-4767, PR #984) added the env-var workaround in `scripts/lib/hook-docker-detect.sh` and a one-paragraph note in `CLAUDE.md`. CLAUDE.md follows progressive-disclosure: it links to `.claude/development/git-crypt-guide.md` for deep-dive details. The deep-dive section was the missing link.

## Test plan

- [x] `prettier --check` clean
- [x] No code changes; doc-only
- [x] CLAUDE.md (line 134) already references SMI-4767; this adds the canonical reference doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)