### PR TITLE
fix(scripts): SMI-4774 smoke test — replace npx version-check with bin-link existence check

### DIFF
--- a/scripts/smoke-test-published.ts
+++ b/scripts/smoke-test-published.ts
@@ -10,7 +10,7 @@
  */
 
 import { execSync } from 'child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -99,13 +99,18 @@ export async function smokeTestPackage(
 
     // Package-specific tests
     if (packageName === '@skillsmith/mcp-server') {
-      // Test 2: CLI --version works
+      // Test 2: bin link is created in the locally-installed package
+      // (Re-using test 1's install instead of `npx -y` because the latter
+      // races with the npx cache on Ubuntu CI runners — confirmed flaky on
+      // 25470514891 and 25470514891 rerun. The mcp-server bin has no
+      // --version flag anyway; it just starts the MCP server, so all the
+      // old test really checked was that npx could resolve the bin.)
       tests.push(
-        await runTest('version-check', () => {
-          execSync(`npx -y ${packageName}@${version} --version`, {
-            stdio: 'pipe',
-            timeout: 30000,
-          })
+        await runTest('bin-link', () => {
+          const binPath = join(tempDir, 'node_modules', '.bin', 'skillsmith-mcp')
+          if (!existsSync(binPath)) {
+            throw new Error(`bin link not found at ${binPath}`)
+          }
         })
       )
 


### PR DESCRIPTION
## Summary

Surfaced from the governance retro of release `8a2a7352` (PR #987, v0.6.0/0.5.0/0.6.0/0.2.3 publish).

The post-publish smoke test in `.github/workflows/publish.yml` invokes `scripts/smoke-test-published.ts`, which has a `version-check` step:

```bash
npx -y @skillsmith/mcp-server@${version} --version
```

Two consecutive runs on the v0.5.0 publish (workflow `25470514891`, original + rerun) failed with `sh: 1: skillsmith-mcp: not found`. The published package is correct — `npm install @skillsmith/mcp-server@0.5.0` in a clean tempdir creates `node_modules/.bin/skillsmith-mcp` reliably both locally and on Ubuntu host.

Two compounding bugs:
1. `mcp-server`'s `skillsmith-mcp` bin has no `--version` flag — invoking it just starts the MCP server. The test was effectively only checking "did npx find the bin", not "does --version respond."
2. `npx -y` re-resolves through its own cache, racing the install path that test 1 already exercises cleanly.

## Fix

Replace `version-check` with a `bin-link` existence check that asserts `node_modules/.bin/skillsmith-mcp` exists in the tempdir set up by test 1. Tests what we actually care about, eliminates the npx-cache flake.

## Test plan

- [x] Local repro: `docker exec skillsmith-dev-1 npx tsx scripts/smoke-test-published.ts @skillsmith/mcp-server 0.5.0` → 4/4 passed in 13.4s
- [ ] CI green
- [ ] Confirm next publish-workflow smoke test passes (will validate on the next release; can also be triggered manually via `gh workflow run publish.yml -f dry_run=true`)

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)