### PR TITLE
fix(scripts): SMI-4772 pre-push hook — invoke root vitest binary directly

### DIFF
--- a/scripts/pre-push-coverage-check.sh
+++ b/scripts/pre-push-coverage-check.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Pre-push Phase 4: Per-workspace test validation
-# Issues: SMI-1602, SMI-2166, SMI-3502, SMI-4681
+# Issues: SMI-1602, SMI-2166, SMI-3502, SMI-4681, SMI-4772
 #
 # Runs tests per workspace to avoid aggregate I/O contention (SMI-3502).
-# Matches CI behavior (npm test --workspace=packages/X).
+# Invokes the root vitest binary directly (SMI-4772) instead of `npm --workspace=`,
+# which resolves vitest via SMI-4381 per-package symlinks that dangle under
+# macOS Docker Desktop virtiofs (vitest exits 234).
 # Previously ran all 254 test files in a single Vitest process with V8 coverage.
 #
 # SMI-4681: source shared detection so macOS+worktree falls back to host
@@ -44,7 +46,10 @@ for pkg in $WORKSPACES; do
   [ -z "$pkg" ] && continue
 
   echo "  📦 packages/$pkg..."
-  LAST_OUTPUT=$(run_cmd npm test --workspace=packages/"$pkg" 2>&1)
+  # SMI-4772: invoke root vitest binary directly. `npm --workspace=` would
+  # resolve vitest via packages/<pkg>/node_modules/.bin/vitest, a SMI-4381
+  # symlink chain that dangles under macOS Docker Desktop virtiofs and exits 234.
+  LAST_OUTPUT=$(run_cmd bash -c "cd packages/$pkg && ../../node_modules/.bin/vitest run" 2>&1)
   if [ $? -ne 0 ]; then
     FAILED_PACKAGES="$FAILED_PACKAGES $pkg"
   fi
@@ -77,7 +82,7 @@ for pkg in $FAILED_PACKAGES; do
     echo "   Run: ${HINT_PREFIX}npx vitest run --config vitest.config.root-tests.ts"
   else
     echo "❌ Tests failed in packages/$pkg!"
-    echo "   Run: ${HINT_PREFIX}npm test --workspace=packages/$pkg"
+    echo "   Run: ${HINT_PREFIX}bash -c \"cd packages/$pkg && ../../node_modules/.bin/vitest run\""
   fi
 done
 

--- a/scripts/tests/pre-push-coverage-check.test.ts
+++ b/scripts/tests/pre-push-coverage-check.test.ts
@@ -1,0 +1,36 @@
+/**
+ * SMI-4772: pre-push hook must invoke vitest via root-level binary path,
+ * not `npm --workspace=`. The latter resolves vitest through
+ * packages/<pkg>/node_modules/.bin, a SMI-4381 symlink chain that dangles
+ * under macOS Docker Desktop virtiofs and exits 234.
+ */
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SCRIPT_PATH = join(__dirname, '..', 'pre-push-coverage-check.sh')
+
+describe('pre-push-coverage-check.sh — SMI-4772', () => {
+  const script = readFileSync(SCRIPT_PATH, 'utf8')
+
+  it('does not reintroduce `npm test --workspace=` for the per-pkg step', () => {
+    const lines = script.split('\n')
+    const offending = lines.filter(
+      (line) =>
+        /run_cmd\s+npm\s+test\s+--workspace=/.test(line) ||
+        /\$\(run_cmd\s+npm\s+test\s+--workspace=/.test(line)
+    )
+    expect(offending).toEqual([])
+  })
+
+  it('invokes vitest via the worktree-root node_modules/.bin path', () => {
+    expect(script).toMatch(/\.\.\/\.\.\/node_modules\/\.bin\/vitest\s+run/)
+  })
+
+  it('preserves the SMI-3502 per-package iteration over WORKSPACES', () => {
+    expect(script).toMatch(/WORKSPACES="core cli mcp-server enterprise"/)
+    expect(script).toMatch(/for pkg in \$WORKSPACES/)
+  })
+})


### PR DESCRIPTION
## Summary

- The per-workspace test step in `scripts/pre-push-coverage-check.sh` invoked `npm test --workspace=packages/<pkg>`, which resolves vitest via `packages/<pkg>/node_modules/.bin/vitest` — a SMI-4381 per-package symlink chain that dangles under macOS Docker Desktop virtiofs when the hook is routed through the main container via SMI-4767's `SKILLSMITH_PRE_PUSH_DOCKER=1` escape hatch. Tests pass when invoked directly but the npm-workspace entry path exits 234, forcing `--no-verify` on every worktree push (hit during PR #990 / SMI-4770).
- Switch to `bash -c "cd packages/<pkg> && ../../node_modules/.bin/vitest run"`. The explicit relative path resolves the root-level vitest binary (a real file). CWD inside the package preserves per-package `vitest.config.ts` semantics — including mcp-server's integration/e2e excludes.
- Adds `scripts/tests/pre-push-coverage-check.test.ts` as a regression guard against reintroducing the npm-workspace form.

## Verification

Test counts match across all four packages pre/post fix (verified locally in `skillsmith-dev-1`):

| pkg          | files | tests |
| ------------ | ----- | ----- |
| core         | 165/166 | 3702/3705 |
| cli          | 24/24 | 534/534 |
| mcp-server   | 44/44 | 834/841 (7 todo) |
| enterprise   | 17/17 | 567/567 |

Per-package excludes preserved (mcp-server tests/integration/**/*.integration.test.ts and tests/e2e/** still excluded by per-package config).

## Test plan

- [x] All 4 packages run identical test sets pre/post (counts above)
- [x] Pre-push hook passes from main repo (./scripts/pre-push-coverage-check.sh)
- [x] audit:standards clean (Score 92%, 0 failures)
- [x] Regression test asserts the safe pattern is in place
- [ ] CI matrix validates Linux Docker path (no symlink issue, must remain green)

Closes SMI-4772.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

[skip-impl-check]
