### PR TITLE
chore(release): SMI-4776/4777/4778 release-retro Wave 1 hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,8 @@ docker exec skillsmith-dev-1 npm run preflight         # All checks before push
 
 **Branch protection**: 13 required checks for code PRs, 2 for docs-only. Admin bypass for emergencies. Details: [ci-reference.md](.claude/development/ci-reference.md#branch-protection).
 
+**Release-PR `Package Validation` carve-out (SMI-4530, SMI-4778)**: `Package Validation` (script: `scripts/verify-publish-deps.mjs --ci`) fails by design on `chore/release-*` branches. The check verifies that every `@skillsmith/<pkg>` dep range is satisfied by an already-published npm version — but a release PR's whole purpose is to bump to a version that hasn't been published yet, so it cannot pass. **Admin-merge with `gh pr merge --admin` is the correct path** when this is the *only* failing check on a release PR and all other required checks are green. Before bypassing, search for an in-flight infra fix (`gh pr list --search "verify-publish-deps OR Package Validation"`); if one is open, rebase onto it instead. Do not admin-bypass other failing checks — that's how the SMI-4647 / SMI-4767 incidents started.
+
 ---
 
 ## Project Overview

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,8 +23,11 @@ const globalIgnores = {
     'packages/website/**',
     // TypeScript template files in .claude/templates/ should be linted
     '!.claude/templates/*.ts',
-    // Git worktrees - lint separately within each worktree context
+    // Git worktrees - lint separately within each worktree context.
+    // Both the dot-prefix `.worktrees/` (canonical, created by create-worktree.sh)
+    // and the no-dot `worktrees/` (ad-hoc parallel sessions; SMI-4777) are ignored.
     '.worktrees/**',
+    'worktrees/**',
     // Supabase edge functions use Deno runtime + are git-crypt encrypted in CI
     // Deno files have incompatible module semantics; lint them with deno lint instead
     'supabase/functions/**',

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2821,6 +2821,75 @@ console.log(`\n${BOLD}42. Workflow uses: SHA-Pin (SMI-4758)${RESET}`)
   }
 }
 
+// 43. CHANGELOG [Unreleased] Placement (SMI-4776)
+//
+// In the v0.6.0 / v0.5.0 release on 2026-05-06, two of four CHANGELOGs (mcp-server
+// + vscode-extension) had their `## [Unreleased]` block placed AFTER a `## v...`
+// version heading. The release prep ran `--no-changelog --no-commit` and hand-
+// curated the entries; the misplacement was subtle enough to slip past review.
+//
+// `[Unreleased]` MUST be the first heading after the introductory paragraph (i.e.
+// before any versioned release section). Otherwise consumers reading the file
+// top-to-bottom see a stale "current" section. Auto-generators that prepend
+// new sections also break: prepending above the (misplaced) `[Unreleased]`
+// orphans it inside an old release section.
+console.log(`\n${BOLD}43. CHANGELOG [Unreleased] Placement (SMI-4776)${RESET}`)
+{
+  const pkgDirs = existsSync('packages')
+    ? readdirSync('packages').filter((d) => existsSync(join('packages', d, 'package.json')))
+    : []
+
+  const targets = [
+    { changelogPath: 'CHANGELOG.md', label: 'root' },
+    ...pkgDirs.map((d) => ({
+      changelogPath: join('packages', d, 'CHANGELOG.md'),
+      label: `packages/${d}`,
+    })),
+  ]
+
+  let placementIssues = 0
+  for (const { changelogPath, label } of targets) {
+    if (!existsSync(changelogPath)) continue
+
+    const content = readFileSync(changelogPath, 'utf8')
+
+    // Find ALL h2 headings in order. Look for `## ` at the start of a line.
+    // Capture both `[Unreleased]` and version forms (`## vX.Y.Z`, `## [X.Y.Z]`,
+    // `## X.Y.Z`).
+    const headingRegex = /^## (.+)$/gm
+    const headings = []
+    let match
+    while ((match = headingRegex.exec(content)) !== null) {
+      const text = match[1].trim()
+      const isUnreleased = /^\[?Unreleased\]?$/i.test(text)
+      const isVersion = /^\[?v?\d+\.\d+\.\d+\]?(\s|$)/.test(text)
+      if (isUnreleased || isVersion) {
+        headings.push({ text, isUnreleased, isVersion, index: match.index })
+      }
+    }
+
+    if (headings.length === 0) continue
+
+    const firstUnreleasedIdx = headings.findIndex((h) => h.isUnreleased)
+    const firstVersionIdx = headings.findIndex((h) => h.isVersion)
+
+    if (firstUnreleasedIdx === -1 || firstVersionIdx === -1) continue
+
+    if (firstUnreleasedIdx > firstVersionIdx) {
+      placementIssues++
+      const offendingVersion = headings[firstVersionIdx].text
+      fail(
+        `${label}: '## [Unreleased]' is placed after '## ${offendingVersion}'`,
+        `Move the [Unreleased] section above the first ## v... heading in ${changelogPath}`
+      )
+    }
+  }
+
+  if (placementIssues === 0) {
+    pass('All CHANGELOGs have [Unreleased] before any versioned section')
+  }
+}
+
 // npm override drift check: @modelcontextprotocol/sdk override "." must match mcp-server range
 console.log(`\n${BOLD}Override Drift: @modelcontextprotocol/sdk${RESET}`)
 try {

--- a/vitest.config.root-tests.ts
+++ b/vitest.config.root-tests.ts
@@ -41,6 +41,9 @@ export default defineConfig({
     exclude: [
       '**/node_modules/**',
       '**/dist/**',
+      // SMI-4777: exclude git-worktree directories. Both forms (dot and no-dot).
+      '.worktrees/**',
+      'worktrees/**',
       'supabase/functions/indexer/**',
       // In locked CI checkouts, supabase/** is git-crypt ciphertext.
       // Pre-push and ci.yml matrix decrypt. Refs: SMI-4221, SMI-2672.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,13 @@ export default defineConfig({
     exclude: [
       '**/node_modules/**',
       '**/dist/**',
+      // SMI-4777: git worktrees carry their own (potentially encrypted, possibly
+      // half-rebased) test trees. They run vitest from inside the worktree, not
+      // the main repo. Both the canonical dot-prefix `.worktrees/` and the
+      // ad-hoc no-dot `worktrees/` (parallel sessions) are excluded here,
+      // mirroring the .prettierignore + ESLint fix from the same wave.
+      '.worktrees/**',
+      'worktrees/**',
       // SMI-1312: E2E and integration tests require external services (API, DB, test repos)
       // These run in dedicated workflows: e2e-tests.yml
       'tests/e2e/**',


### PR DESCRIPTION
## Summary

Three small, parallel-safe follow-ups from the v0.6.0 / v0.5.0 release governance retro on 2026-05-06 (`8a2a7352`, PR #987). Each prevents the same friction from recurring on the next release.

- **SMI-4776** — `audit:standards` Check 43: fail when a CHANGELOG has `## [Unreleased]` placed after a `## v...` heading. Two of four files in the v0.6.0 release had this drift.
- **SMI-4777** — Add `worktrees/**` (no-dot, ad-hoc parallel-session form) to `eslint.config.js`, `vitest.config.ts`, and `vitest.config.root-tests.ts` global ignores. Defense-in-depth alongside the `.prettierignore` fix from `cbbcab68`.
- **SMI-4778** — CLAUDE.md doc: explain that `Package Validation` failure on `chore/release-*` branches is fail-by-design (SMI-4530 chicken-and-egg), and `gh pr merge --admin` is the correct path when it's the only failing required check on a release PR.

## Descoped — SMI-4775

The fourth Wave 1 follow-up (`prepare-release.ts` lockfile regen, **SMI-4775**) is descoped from this PR. `scripts/prepare-release.ts` is currently 794 lines, and the pre-commit `check-file-length.mjs` hook hard-rejects any staged `.ts` file over 500 lines (no grandfathering). Adding the inline regen step pushed it to 842 and the hook blocked the commit. Per CLAUDE.md "If a hook fails, investigate and fix the underlying issue":

- Filed **SMI-4783** (`Refactor scripts/prepare-release.ts under 500 lines`) as a blocker.
- SMI-4775 stays open at High; resumes after SMI-4783 lands a refactor that extracts npm/collision/changelog/git helpers to `scripts/lib/release-*.ts`.

## Verified locally

- `docker exec skillsmith-dev-1 npm run audit:standards` → 57 pass, 5 warn, 0 fail. Check 43 added and passing.
- `docker exec skillsmith-dev-1 npm run lint` → clean.
- `docker exec skillsmith-dev-1 npm run typecheck` → clean.
- `docker exec skillsmith-dev-1 npm run format:check` → clean.

## Test plan

- [x] audit:standards exit 0 with the new Check 43 emitting a pass line.
- [x] Lint + typecheck clean.
- [ ] CI green on this PR.
- [ ] After merge: confirm Check 43 fires on a deliberate misordering in a throwaway CHANGELOG.

## Refs

- SMI-4776, SMI-4777, SMI-4778
- SMI-4775 (deferred, blocked by SMI-4783)
- Retro: docs/internal/retros/2026-05-06-smi-4590-namespace-audit-release.md
- Plan: docs/internal/implementation/2026-05-06-release-retro-followups.md

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)