### PR TITLE
fix(scripts): SMI-4780 repair-host-native-deps.sh — fall through to build-release on root rebuild silent-failure

### DIFF
--- a/scripts/repair-host-native-deps.sh
+++ b/scripts/repair-host-native-deps.sh
@@ -142,6 +142,34 @@ if ! npm rebuild better-sqlite3 --build-from-source >"$REBUILD_LOG" 2>&1; then
 fi
 
 # Re-probe — building succeeded, but did the binding actually load?
+#
+# SMI-4780: `npm rebuild better-sqlite3 --build-from-source` reports exit 0 and
+# stdout claims a successful rebuild, but on macOS Docker Desktop the binary
+# at build/Release/better_sqlite3.node sometimes isn't actually written. The
+# v0.6.0 / v0.5.0 release session (2026-05-06) hit this and only recovered
+# by running `cd node_modules/better-sqlite3 && npm run build-release`
+# directly — same fallback the workspace-local loop already uses below.
+#
+# Apply the same fallback at the root level before erroring out: drop the
+# stale binary, run `npm run build-release` from inside the package, then
+# re-probe. Only if THAT also fails do we surface the ABI mismatch error.
+ROOT_BSQLITE_DIR="node_modules/better-sqlite3"
+if ! probe_binding; then
+  if [[ -d "$ROOT_BSQLITE_DIR" ]]; then
+    info "root npm rebuild reported success but binding still missing"
+    info "  → applying SMI-4780 fallback: build-release from inside $ROOT_BSQLITE_DIR"
+    FALLBACK_LOG="$(mktemp -t skillsmith-rebuild-root-fallback.XXXXXX)"
+    if (cd "$ROOT_BSQLITE_DIR" && rm -f build/Release/better_sqlite3.node && npm run build-release) >"$FALLBACK_LOG" 2>&1; then
+      rm -f "$FALLBACK_LOG"
+    else
+      printf '\n--- root build-release fallback output (tail) ---\n'
+      tail -20 "$FALLBACK_LOG"
+      printf '\n'
+      rm -f "$FALLBACK_LOG"
+    fi
+  fi
+fi
+
 if ! probe_binding; then
   printf '\n--- npm rebuild output (tail) ---\n'
   tail -20 "$REBUILD_LOG"


### PR DESCRIPTION
[skip-impl-check]

## Summary

Wave 2 of the v0.6.0 / v0.5.0 release-retro follow-ups. Standalone, parallel with Wave 1 (#998).

`npm rebuild better-sqlite3 --build-from-source` reports exit 0 and stdout claims a successful rebuild, but on macOS Docker Desktop (and possibly other configurations) the binary at `build/Release/better_sqlite3.node` sometimes isn't actually written. The v0.6.0 / v0.5.0 release session on 2026-05-06 hit this — 696 vitest failures cascaded after the lockfile regen because the root better-sqlite3 binding silently disappeared, and the documented `docker exec ... npm rebuild better-sqlite3` reported success but didn't restore the binary.

The actual recovery was running `cd node_modules/better-sqlite3 && rm -f build/Release/better_sqlite3.node && npm run build-release` — the same fallback the workspace-local loop already used (`scripts/repair-host-native-deps.sh:168-178`). SMI-4698 retro mentioned the workspace-local case but not the root case where `npm rebuild` silently no-ops.

## Fix

Apply the same fallback at the root level: when the post-rebuild probe fails after `npm rebuild`, drop the stale binary, run `npm run build-release` from inside the package, then re-probe. Only if THAT also fails do we surface the ABI mismatch error. The fallback uses a captured log file so its output is silent on success and shown (tail -20) on failure, matching the existing rebuild-output handling.

## Verified locally

- `bash -n scripts/repair-host-native-deps.sh` → syntax OK
- `wc -l` 205 → 233 (+28 lines)
- Idempotent: cheap healthy-path probe at line 92 still short-circuits with `[skip]` when the binding is already loaded; the new fallback only fires when `npm rebuild` succeeds AND the post-rebuild probe fails.

## Test plan

- [x] Bash syntax check.
- [ ] CI green on this PR.
- [ ] After merge: next time someone hits the silent-rebuild failure, `./scripts/repair-host-native-deps.sh` should recover automatically without the operator needing to know the workaround. (Cannot deterministically reproduce in CI — Docker Desktop / macOS specific.)

## Skip-impl-check

This PR is a single-shell-script hardening change (`scripts/repair-host-native-deps.sh`) with no implementation/test pairing. The fallback path is impossible to deterministically reproduce in CI (the silent-no-op condition only manifests on macOS Docker Desktop). `[skip-impl-check]` is appropriate here per the project's `verify-implementation-completeness.yml` carve-out for infrastructure/script-only changes.

## Refs

- SMI-4780
- SMI-4698 (workspace-local case already handled)
- Retro: docs/internal/retros/2026-05-06-smi-4590-namespace-audit-release.md (Code Review Findings table)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)