### PR TITLE
fix(scripts): SMI-4776 audit:standards Check 43 — include line numbers in failure message

### DIFF
--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2878,8 +2878,12 @@ console.log(`\n${BOLD}43. CHANGELOG [Unreleased] Placement (SMI-4776)${RESET}`)
     if (firstUnreleasedIdx > firstVersionIdx) {
       placementIssues++
       const offendingVersion = headings[firstVersionIdx].text
+      // Convert char offsets to 1-indexed line numbers so operators can jump
+      // straight to the misordered headings (SMI-4776 acceptance criterion).
+      const versionLine = content.slice(0, headings[firstVersionIdx].index).split('\n').length
+      const unreleasedLine = content.slice(0, headings[firstUnreleasedIdx].index).split('\n').length
       fail(
-        `${label}: '## [Unreleased]' is placed after '## ${offendingVersion}'`,
+        `${label}: '## [Unreleased]' (${changelogPath}:${unreleasedLine}) is placed after '## ${offendingVersion}' (${changelogPath}:${versionLine})`,
         `Move the [Unreleased] section above the first ## v... heading in ${changelogPath}`
       )
     }


### PR DESCRIPTION
[skip-impl-check]

## Summary

Governance retro on PR #998 (commit `3826f353`) flagged that the SMI-4776 acceptance criterion ("Reports per-file violations with line numbers") was not fully implemented in the original Check 43. The `fail()` message named the offending version heading but didn't surface line numbers — even though the regex match `index` (char offset) was already being captured.

## Fix

Convert the captured char offset to a 1-indexed line number for both the `[Unreleased]` block and the offending version heading. Operators can now jump straight to the misordered headings via the standard `<file>:<line>` form that editors recognize.

```text
Before: packages/mcp-server: '## [Unreleased]' is placed after '## v0.5.0'
After:  packages/mcp-server: '## [Unreleased]' (packages/mcp-server/CHANGELOG.md:42) is placed after '## v0.5.0' (packages/mcp-server/CHANGELOG.md:18)
```

## Verified locally

- `docker exec skillsmith-dev-1 npx node scripts/audit-standards.mjs` → Check 43 still passes against the current state of all CHANGELOGs (none misordered).
- 5-line diff, no new dependencies.

## Test plan

- [x] Audit passes locally.
- [ ] CI green.

## Refs

- SMI-4776 (acceptance criterion gap caught in retro)
- Built on PR #998 (merged `3826f353`).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)