### PR TITLE
feat(scripts): SMI-4775 prepare-release — regenerate package-lock.json after dep bumps

### DIFF
--- a/scripts/lib/release-git.ts
+++ b/scripts/lib/release-git.ts
@@ -54,7 +54,20 @@ export function getCurrentBranch(): string {
   }).trim()
 }
 
-export function createCommit(plans: BumpPlan[]): void {
+/**
+ * SMI-4775: regenerate package-lock.json after dep-range bumps so the published
+ * release ships a lockfile that matches the bumped `^X.Y.Z` ranges in
+ * package.json. `--ignore-scripts` skips native postinstall (better-sqlite3,
+ * onnxruntime-node) which the host doesn't need rebuilt for a lockfile-only pass.
+ */
+export function regenerateLockfile(): void {
+  execFileSync('npm', ['install', '--package-lock-only', '--ignore-scripts'], {
+    cwd: ROOT_DIR,
+    stdio: 'inherit',
+  })
+}
+
+export function createCommit(plans: BumpPlan[], includeLockfile = false): void {
   const filesToAdd: string[] = []
 
   for (const plan of plans) {
@@ -71,6 +84,11 @@ export function createCommit(plans: BumpPlan[]): void {
         filesToAdd.push(dep)
       }
     }
+  }
+
+  // SMI-4775: include regenerated package-lock.json when caller opts in.
+  if (includeLockfile) {
+    filesToAdd.push('package-lock.json')
   }
 
   const existing = filesToAdd.filter((f) => existsSync(join(ROOT_DIR, f)))

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -43,7 +43,12 @@ import {
   type NpmLookup,
 } from './lib/release-collision.js'
 import { findLastVersionBumpCommit, prependToChangelog } from './lib/release-changelog.js'
-import { validatePostWrite, getCurrentBranch, createCommit } from './lib/release-git.js'
+import {
+  validatePostWrite,
+  getCurrentBranch,
+  createCommit,
+  regenerateLockfile,
+} from './lib/release-git.js'
 
 // Re-export the helper surface so existing test imports continue to resolve
 // against `../prepare-release` (SMI-4783 keeps the public surface stable).
@@ -64,6 +69,7 @@ interface Options {
   dryRun: boolean
   noChangelog: boolean
   noCommit: boolean
+  noLockfileRegen: boolean
   allowDowngrade: boolean
   check: boolean
 }
@@ -76,6 +82,7 @@ function parseArgs(): Options {
   let dryRun = false
   let noChangelog = false
   let noCommit = false
+  let noLockfileRegen = false
   let allowDowngrade = false
   let check = false
 
@@ -86,6 +93,8 @@ function parseArgs(): Options {
       noChangelog = true
     } else if (arg === '--no-commit') {
       noCommit = true
+    } else if (arg === '--no-lockfile-regen') {
+      noLockfileRegen = true
     } else if (arg === '--allow-downgrade') {
       allowDowngrade = true
     } else if (arg === '--check') {
@@ -126,7 +135,7 @@ function parseArgs(): Options {
     }
   }
 
-  return { bumps, dryRun, noChangelog, noCommit, allowDowngrade, check }
+  return { bumps, dryRun, noChangelog, noCommit, noLockfileRegen, allowDowngrade, check }
 }
 
 function printUsage(): void {
@@ -144,6 +153,7 @@ Options:
   --dry-run             Preview changes without writing
   --no-changelog        Skip changelog generation
   --no-commit           Write files but don't create git commit
+  --no-lockfile-regen   Skip 'npm install --package-lock-only' after dep-range bumps (SMI-4775)
   --check               Audit-only: run npm collision check, no writes, exit non-zero on conflict
   --allow-downgrade     Permit bumping to a semver <= highest published (rare; never overrides equals-published)
   --help                Show this help
@@ -242,7 +252,7 @@ function updateCoreDependency(newCoreVersion: string): void {
 
 async function main(): Promise<void> {
   const options = parseArgs()
-  const { bumps, dryRun, noChangelog, noCommit, allowDowngrade, check } = options
+  const { bumps, dryRun, noChangelog, noCommit, noLockfileRegen, allowDowngrade, check } = options
 
   // Step 0: Branch guard (skip in --check mode — audit is safe on any branch)
   if (!check) {
@@ -326,6 +336,19 @@ async function main(): Promise<void> {
     console.log(`  ✓ Updated @skillsmith/core dep in dependents`)
   }
 
+  // Step 6.5: Regenerate package-lock.json so the lockfile matches the bumped
+  // dep ranges (SMI-4775). Without this, the publish workflow ships a
+  // lockfile pinned to the previous core version while package.json declares
+  // the new one — `npm ci` then either fails or silently resolves stale
+  // transitive deps. Opt out with --no-lockfile-regen for emergency releases.
+  if (!noLockfileRegen) {
+    console.log('  Regenerating package-lock.json (SMI-4775)...')
+    regenerateLockfile()
+    console.log('  ✓ Lockfile regenerated')
+  } else {
+    console.log('  ⚠ Skipping lockfile regen (--no-lockfile-regen)')
+  }
+
   // Step 7-8: Generate and prepend changelogs
   if (!noChangelog) {
     const since = findLastVersionBumpCommit()
@@ -369,9 +392,9 @@ async function main(): Promise<void> {
     process.exit(0)
   }
 
-  // Step 11: Commit
+  // Step 11: Commit (include package-lock.json when regen ran)
   const preBranch = getCurrentBranch()
-  createCommit(plans)
+  createCommit(plans, !noLockfileRegen)
 
   // Step 12: Post-commit branch verification
   const postBranch = getCurrentBranch()

--- a/scripts/tests/release-git.test.ts
+++ b/scripts/tests/release-git.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for scripts/lib/release-git.ts — SMI-4775 lockfile regen + createCommit lockfile inclusion.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { execFileSync } from 'child_process'
+
+// ESM-safe module mocks (must be declared before importing SUT).
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process')
+  return { ...actual, execFileSync: vi.fn(actual.execFileSync) }
+})
+
+import { regenerateLockfile, createCommit } from '../lib/release-git'
+import { PACKAGE_SPECS, ROOT_DIR } from '../lib/version-utils'
+import type { BumpPlan } from '../lib/release-collision'
+
+const mockedExecFileSync = vi.mocked(execFileSync)
+
+const corePlan: BumpPlan = {
+  spec: PACKAGE_SPECS.find((s) => s.shortName === 'core')!,
+  currentVersion: '0.5.8',
+  newVersion: '0.6.0',
+}
+
+describe('regenerateLockfile (SMI-4775)', () => {
+  beforeEach(() => {
+    mockedExecFileSync.mockReset()
+    mockedExecFileSync.mockReturnValue('' as never)
+  })
+
+  it("calls 'npm install --package-lock-only --ignore-scripts' from ROOT_DIR", () => {
+    regenerateLockfile()
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1)
+    const [cmd, args, opts] = mockedExecFileSync.mock.calls[0]!
+    expect(cmd).toBe('npm')
+    expect(args).toEqual(['install', '--package-lock-only', '--ignore-scripts'])
+    expect(opts).toMatchObject({ cwd: ROOT_DIR, stdio: 'inherit' })
+  })
+})
+
+describe('createCommit lockfile inclusion (SMI-4775)', () => {
+  beforeEach(() => {
+    mockedExecFileSync.mockReset()
+    mockedExecFileSync.mockReturnValue('' as never)
+  })
+
+  it("does NOT add 'package-lock.json' to git add when includeLockfile is omitted (back-compat default)", () => {
+    createCommit([corePlan])
+    const addCall = mockedExecFileSync.mock.calls.find(
+      (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1][0] === 'add'
+    )
+    expect(addCall).toBeDefined()
+    const addArgs = addCall![1] as string[]
+    expect(addArgs).not.toContain('package-lock.json')
+  })
+
+  it("adds 'package-lock.json' to git add when includeLockfile=true", () => {
+    createCommit([corePlan], true)
+    const addCall = mockedExecFileSync.mock.calls.find(
+      (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1][0] === 'add'
+    )
+    expect(addCall).toBeDefined()
+    const addArgs = addCall![1] as string[]
+    expect(addArgs).toContain('package-lock.json')
+  })
+
+  it("does NOT add 'package-lock.json' when includeLockfile=false (--no-lockfile-regen path)", () => {
+    createCommit([corePlan], false)
+    const addCall = mockedExecFileSync.mock.calls.find(
+      (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1][0] === 'add'
+    )
+    const addArgs = addCall![1] as string[]
+    expect(addArgs).not.toContain('package-lock.json')
+  })
+})


### PR DESCRIPTION
## Summary

Adds `regenerateLockfile()` step between dep-update (step 6) and changelog (step 7) of `prepare-release.ts`. Runs `npm install --package-lock-only --ignore-scripts` from `ROOT_DIR` and includes the regenerated `package-lock.json` in the release commit so the publish workflow ships a lockfile matching the bumped `@skillsmith/core ^X.Y.Z` ranges in `package.json`.

Without this, releases ship a lockfile pinned to the previous core version while `package.json` declares the new one — `npm ci` then either fails or silently resolves stale transitive deps. This was the root of the SMI-4781 batch dropping `jose@5.10.0` / `web-vitals@5.2.0` from the lockfile.

## What changed

- `scripts/lib/release-git.ts` — new `regenerateLockfile()`; `createCommit(plans, includeLockfile?)` now optionally adds `package-lock.json` to `git add`.
- `scripts/prepare-release.ts` — new `--no-lockfile-regen` opt-out flag, threaded through `parseArgs`/`Options`/`main`. New step 6.5 between dep-update and changelog.
- `scripts/tests/release-git.test.ts` — 4 new tests:
  - `regenerateLockfile()` invokes `npm install --package-lock-only --ignore-scripts` from `ROOT_DIR`
  - `createCommit(plans)` (no flag) does NOT add `package-lock.json` (back-compat)
  - `createCommit(plans, true)` adds `package-lock.json`
  - `createCommit(plans, false)` does NOT add `package-lock.json` (`--no-lockfile-regen` path)

## Verification

- `wc -l scripts/prepare-release.ts` → **426** (under 500-line budget; SMI-4783 left ~75 lines of headroom)
- `docker exec skillsmith-dev-1 npm run typecheck` → green
- `docker exec skillsmith-dev-1 npm run lint` → green
- `docker exec skillsmith-dev-1 npm run audit:standards` → green
- `docker exec skillsmith-dev-1 npx vitest run scripts/tests/prepare-release.test.ts scripts/tests/release-git.test.ts` → 46/46 pass

Unblocked by SMI-4783 (release helper extraction, merged at `3a2fd6c5`).

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] All 42 prepare-release tests + 4 new release-git tests pass
- [x] audit:standards green
- [x] File-length pre-commit hook passes (no `--no-verify` bypass)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)