### PR TITLE
fix(install): SMI-4795 thread errorCode + trustTier through install telemetry

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -282,13 +282,18 @@ export function createInstallCommand(): Command {
             const installStart = Date.now()
             const result = await service.install(skillId, installOptions)
 
-            // SMI-4182: fire-and-forget install telemetry — skipped when CLI
-            // is unauthenticated (no SKILLSMITH_API_KEY), per product decision.
+            // SMI-4182 / SMI-4795: fire-and-forget install telemetry —
+            // skipped when CLI is unauthenticated (no SKILLSMITH_API_KEY),
+            // per product decision. `trustTier` is included on every event
+            // (when known); `errorCode` is included only on failures.
             void emitInstallEvent({
               skillId,
               source: 'cli',
               success: result.success,
               durationMs: Date.now() - installStart,
+              ...(result.trustTier !== undefined && { trustTier: result.trustTier }),
+              ...(!result.success &&
+                result.errorCode !== undefined && { errorCode: result.errorCode }),
             })
 
             // SMI-4578: fan-out to --also-link clients only after the

--- a/packages/cli/tests/unit/commands/install.test.ts
+++ b/packages/cli/tests/unit/commands/install.test.ts
@@ -24,6 +24,8 @@ const mocks = vi.hoisted(() => ({
   createDatabaseAsync: vi.fn(),
   initializeSchema: vi.fn(),
   dbClose: vi.fn(),
+  // SMI-4795: hoisted so tests can assert install-telemetry payloads.
+  emitInstallEvent: vi.fn(async () => undefined),
 }))
 
 vi.mock('ora', () => ({
@@ -50,7 +52,7 @@ vi.mock('@skillsmith/core', () => ({
     }
   }),
   isGitHubUrl: vi.fn((url: string) => url.startsWith('https://github.com/')),
-  emitInstallEvent: vi.fn(async () => undefined),
+  emitInstallEvent: (...args: unknown[]) => mocks.emitInstallEvent(...args),
 }))
 
 // Mock console and process.exit
@@ -526,6 +528,78 @@ describe('SMI-3484: CLI Install Command', () => {
       await cmd.parseAsync(['node', 'test', 'community/jest-helper'])
 
       expect(mocks.dbClose).toHaveBeenCalled()
+    })
+  })
+
+  // ==========================================================================
+  // SMI-4795: install telemetry must thread errorCode + trustTier
+  //
+  // CLI emit site previously forwarded only {skillId, source, success,
+  // durationMs}. After SMI-4795 trustTier is included on every event (when
+  // the service surfaces it) and errorCode is included only on failures.
+  // ==========================================================================
+
+  describe('SMI-4795: emitInstallEvent receives errorCode + trustTier', () => {
+    it('forwards trustTier and errorCode on a failed install', async () => {
+      mocks.installFn.mockResolvedValueOnce({
+        success: false,
+        skillId: 'community/jest-helper',
+        installPath: '/tmp/.claude/skills/jest-helper',
+        errorCode: 'SCAN_REJECTED',
+        trustTier: 'community',
+        error: 'Security scan failed',
+      })
+
+      const { createInstallCommand } = await import('../../../src/commands/install.js')
+      const cmd = createInstallCommand()
+      await cmd.parseAsync(['node', 'test', 'community/jest-helper'])
+
+      expect(mocks.emitInstallEvent).toHaveBeenCalledTimes(1)
+      const payload = mocks.emitInstallEvent.mock.calls[0]?.[0] as Record<string, unknown>
+      expect(payload).toMatchObject({
+        skillId: 'community/jest-helper',
+        source: 'cli',
+        success: false,
+        errorCode: 'SCAN_REJECTED',
+        trustTier: 'community',
+      })
+      expect(typeof payload.durationMs).toBe('number')
+    })
+
+    it('forwards trustTier on success but omits errorCode', async () => {
+      // Default beforeEach already returns success+trustTier:'community'.
+      const { createInstallCommand } = await import('../../../src/commands/install.js')
+      const cmd = createInstallCommand()
+      await cmd.parseAsync(['node', 'test', 'community/jest-helper'])
+
+      expect(mocks.emitInstallEvent).toHaveBeenCalledTimes(1)
+      const payload = mocks.emitInstallEvent.mock.calls[0]?.[0] as Record<string, unknown>
+      expect(payload).toMatchObject({
+        skillId: 'community/jest-helper',
+        source: 'cli',
+        success: true,
+        trustTier: 'community',
+      })
+      expect(payload.errorCode).toBeUndefined()
+    })
+
+    it('omits both fields when service result lacks them', async () => {
+      mocks.installFn.mockResolvedValueOnce({
+        success: false,
+        skillId: 'community/jest-helper',
+        installPath: '',
+        error: 'legacy failure',
+      })
+
+      const { createInstallCommand } = await import('../../../src/commands/install.js')
+      const cmd = createInstallCommand()
+      await cmd.parseAsync(['node', 'test', 'community/jest-helper'])
+
+      expect(mocks.emitInstallEvent).toHaveBeenCalledTimes(1)
+      const payload = mocks.emitInstallEvent.mock.calls[0]?.[0] as Record<string, unknown>
+      expect(payload.errorCode).toBeUndefined()
+      expect(payload.trustTier).toBeUndefined()
+      expect(payload.success).toBe(false)
     })
   })
 })

--- a/packages/cli/tests/unit/commands/install.test.ts
+++ b/packages/cli/tests/unit/commands/install.test.ts
@@ -25,7 +25,7 @@ const mocks = vi.hoisted(() => ({
   initializeSchema: vi.fn(),
   dbClose: vi.fn(),
   // SMI-4795: hoisted so tests can assert install-telemetry payloads.
-  emitInstallEvent: vi.fn(async () => undefined),
+  emitInstallEvent: vi.fn(async (_payload: unknown) => undefined),
 }))
 
 vi.mock('ora', () => ({
@@ -52,7 +52,7 @@ vi.mock('@skillsmith/core', () => ({
     }
   }),
   isGitHubUrl: vi.fn((url: string) => url.startsWith('https://github.com/')),
-  emitInstallEvent: (...args: unknown[]) => mocks.emitInstallEvent(...args),
+  emitInstallEvent: (payload: unknown) => mocks.emitInstallEvent(payload),
 }))
 
 // Mock console and process.exit
@@ -540,6 +540,25 @@ describe('SMI-3484: CLI Install Command', () => {
   // ==========================================================================
 
   describe('SMI-4795: emitInstallEvent receives errorCode + trustTier', () => {
+    interface TelemetryPayload {
+      skillId: string
+      source: string
+      success: boolean
+      durationMs?: number
+      trustTier?: string
+      errorCode?: string
+    }
+
+    function getEmittedPayload(): TelemetryPayload {
+      const calls = mocks.emitInstallEvent.mock.calls as unknown as Array<[unknown]>
+      expect(calls.length).toBeGreaterThan(0)
+      const firstCall = calls[0]
+      expect(firstCall).toBeDefined()
+      const payload = (firstCall as [unknown])[0] as TelemetryPayload
+      expect(payload).toBeDefined()
+      return payload
+    }
+
     it('forwards trustTier and errorCode on a failed install', async () => {
       mocks.installFn.mockResolvedValueOnce({
         success: false,
@@ -555,7 +574,7 @@ describe('SMI-3484: CLI Install Command', () => {
       await cmd.parseAsync(['node', 'test', 'community/jest-helper'])
 
       expect(mocks.emitInstallEvent).toHaveBeenCalledTimes(1)
-      const payload = mocks.emitInstallEvent.mock.calls[0]?.[0] as Record<string, unknown>
+      const payload = getEmittedPayload()
       expect(payload).toMatchObject({
         skillId: 'community/jest-helper',
         source: 'cli',
@@ -573,7 +592,7 @@ describe('SMI-3484: CLI Install Command', () => {
       await cmd.parseAsync(['node', 'test', 'community/jest-helper'])
 
       expect(mocks.emitInstallEvent).toHaveBeenCalledTimes(1)
-      const payload = mocks.emitInstallEvent.mock.calls[0]?.[0] as Record<string, unknown>
+      const payload = getEmittedPayload()
       expect(payload).toMatchObject({
         skillId: 'community/jest-helper',
         source: 'cli',
@@ -596,7 +615,7 @@ describe('SMI-3484: CLI Install Command', () => {
       await cmd.parseAsync(['node', 'test', 'community/jest-helper'])
 
       expect(mocks.emitInstallEvent).toHaveBeenCalledTimes(1)
-      const payload = mocks.emitInstallEvent.mock.calls[0]?.[0] as Record<string, unknown>
+      const payload = getEmittedPayload()
       expect(payload.errorCode).toBeUndefined()
       expect(payload.trustTier).toBeUndefined()
       expect(payload.success).toBe(false)

--- a/packages/core/src/exports/services.ts
+++ b/packages/core/src/exports/services.ts
@@ -382,6 +382,7 @@ export {
   type ProgressCallback,
   type InstallOptions,
   type InstallResult as CoreInstallResult,
+  type InstallErrorCode,
   type UninstallOptions,
   type UninstallResult as CoreUninstallResult,
   type SkillManifest,

--- a/packages/core/src/services/skill-installation.errors.ts
+++ b/packages/core/src/services/skill-installation.errors.ts
@@ -1,0 +1,92 @@
+/**
+ * @fileoverview Failure-result builders for SkillInstallationService.
+ * @module @skillsmith/core/services/skill-installation.errors
+ * @see SMI-4795: install telemetry — populate `errorCode` at every failure
+ *
+ * Centralizes the `success: false` `InstallResult` shape so the main service
+ * file stays under the 500-line gate (audit:standards Check 1) while every
+ * failure path threads its taxonomy code into install telemetry.
+ *
+ * Importers should never destructure these results — always return the
+ * builder's output verbatim so the caller's emitInstallEvent() observes the
+ * canonical `errorCode` + `trustTier` pair.
+ */
+
+import type { ScanReport } from '../security/index.js'
+import type { TrustTier } from '../types/skill.js'
+import type { InstallErrorCode, InstallResult } from './skill-installation.types.js'
+
+/** Common arguments for every failure-result builder */
+export interface InstallFailureArgs {
+  /** Original skillId from the caller (echoed back into the result) */
+  skillId: string
+  /** Path the install would have written to; '' when unresolvable */
+  installPath: string
+  /** Trust tier resolved at the failure point (defaults to 'unknown') */
+  trustTier?: TrustTier
+  /** Sanitized human-readable error message */
+  error: string
+  /** Optional remediation tips surfaced to UI */
+  tips?: string[]
+  /** Optional scan report when failure originated from the security scanner */
+  securityReport?: ScanReport
+}
+
+/**
+ * Build a `success: false` InstallResult with the given `errorCode`.
+ *
+ * Why a builder instead of inline literals: every failure path must populate
+ * `errorCode` for SMI-4795 telemetry; pulling the construction out of the
+ * service prevents drift where a future failure return forgets the code.
+ */
+export function buildInstallFailure(
+  errorCode: InstallErrorCode,
+  args: InstallFailureArgs
+): InstallResult {
+  const result: InstallResult = {
+    success: false,
+    skillId: args.skillId,
+    installPath: args.installPath,
+    errorCode,
+    error: args.error,
+  }
+  if (args.trustTier !== undefined) {
+    result.trustTier = args.trustTier
+  }
+  if (args.tips !== undefined) {
+    result.tips = args.tips
+  }
+  if (args.securityReport !== undefined) {
+    result.securityReport = args.securityReport
+  }
+  return result
+}
+
+/**
+ * Build a CONFIRMATION_REQUIRED failure — distinct from buildInstallFailure
+ * because it carries `requiresConfirmation: true` + `confirmationReason`
+ * fields the UI uses to render the prompt.
+ */
+export function buildConfirmationRequired(args: {
+  skillId: string
+  installPath: string
+  trustTier: TrustTier
+  securityReport?: ScanReport
+  confirmationReason: string
+  tips: string[]
+}): InstallResult {
+  const result: InstallResult = {
+    success: false,
+    skillId: args.skillId,
+    installPath: args.installPath,
+    errorCode: 'CONFIRMATION_REQUIRED',
+    trustTier: args.trustTier,
+    requiresConfirmation: true,
+    confirmationReason: args.confirmationReason,
+    tips: args.tips,
+  }
+  if (args.securityReport !== undefined) {
+    result.securityReport = args.securityReport
+  }
+  return result
+}

--- a/packages/core/src/services/skill-installation.errors.ts
+++ b/packages/core/src/services/skill-installation.errors.ts
@@ -73,7 +73,7 @@ export function buildConfirmationRequired(args: {
   trustTier: TrustTier
   securityReport?: ScanReport
   confirmationReason: string
-  tips: string[]
+  tips?: string[]
 }): InstallResult {
   const result: InstallResult = {
     success: false,
@@ -83,7 +83,9 @@ export function buildConfirmationRequired(args: {
     trustTier: args.trustTier,
     requiresConfirmation: true,
     confirmationReason: args.confirmationReason,
-    tips: args.tips,
+  }
+  if (args.tips !== undefined) {
+    result.tips = args.tips
   }
   if (args.securityReport !== undefined) {
     result.securityReport = args.securityReport

--- a/packages/core/src/services/skill-installation.service.ts
+++ b/packages/core/src/services/skill-installation.service.ts
@@ -38,6 +38,7 @@ import {
   validateOptionalConfig,
   checkDepsAgainstQuarantine,
 } from './skill-installation.helpers.js'
+import { buildInstallFailure, buildConfirmationRequired } from './skill-installation.errors.js'
 const DEFAULT_SKILLS_DIR = path.join(os.homedir(), '.claude', 'skills')
 const DEFAULT_MANIFEST_PATH = path.join(os.homedir(), '.skillsmith', 'manifest.json')
 export interface SkillInstallationServiceParams {
@@ -95,21 +96,18 @@ export class SkillInstallationService {
       let indexedContentHash: string | undefined
       if (parsed.isRegistryId) {
         if (!this.registryLookup) {
-          return {
-            success: false,
+          return buildInstallFailure('REGISTRY_LOOKUP_UNAVAILABLE', {
             skillId,
             installPath: '',
             error:
               'Registry lookup not available. ' +
               'Use a full GitHub URL: install { skillId: "https://github.com/owner/repo" }',
-          }
+          })
         }
-
         this.onProgress('lookup', 'Looking up skill in registry')
         const registrySkill = await this.registryLookup.lookup(skillId)
         if (!registrySkill) {
-          return {
-            success: false,
+          return buildInstallFailure('REGISTRY_SKILL_NOT_FOUND', {
             skillId,
             installPath: '',
             error:
@@ -123,13 +121,13 @@ export class SkillInstallationService {
               'Search for installable skills using the search tool',
               'Many indexed skills are metadata-only and cannot be installed directly',
             ],
-          }
+          })
         }
         if (registrySkill.quarantined) {
-          return {
-            success: false,
+          return buildInstallFailure('QUARANTINED', {
             skillId,
             installPath: '',
+            trustTier: registrySkill.trustTier,
             error:
               'Skill "' +
               skillId +
@@ -140,7 +138,7 @@ export class SkillInstallationService {
               'If you believe this is a false positive, contact support via https://skillsmith.app/contact?topic=security',
               'Contact the skill author or visit the quarantine documentation for more information',
             ],
-          }
+          })
         }
 
         const repoInfo = parseRepoUrl(registrySkill.repoUrl)
@@ -163,12 +161,12 @@ export class SkillInstallationService {
       this.onProgress('manifest', 'Checking manifest')
       const manifest = await this.manifest.load()
       if (manifest.installedSkills[skillName] && !options.force) {
-        return {
-          success: false,
+        return buildInstallFailure('ALREADY_INSTALLED', {
           skillId,
           installPath,
+          trustTier,
           error: 'Skill "' + skillName + '" is already installed. Use force=true to reinstall.',
-        }
+        })
       }
       this.onProgress('fetch', 'Fetching SKILL.md from GitHub')
       const skillMdPath = basePath + 'SKILL.md'
@@ -177,10 +175,10 @@ export class SkillInstallationService {
         skillMdContent = await fetchFromGitHub(owner, repo, skillMdPath, branch)
       } catch {
         const repoUrl = 'https://github.com/' + owner + '/' + repo
-        return {
-          success: false,
+        return buildInstallFailure('FETCH_FAILED', {
           skillId,
           installPath,
+          trustTier,
           error: fromRegistry
             ? 'This skill is indexed in the Skillsmith registry but its installation source appears broken (SKILL.md not found at ' +
               (basePath || 'repository root') +
@@ -199,31 +197,31 @@ export class SkillInstallationService {
                 'This skill may be browse-only (no SKILL.md at expected location)',
                 'Verify the repository exists: ' + repoUrl,
               ],
-        }
+        })
       }
       this.onProgress('validate', 'Validating SKILL.md')
       const validation = validateSkillMd(skillMdContent)
       if (!validation.valid) {
-        return {
-          success: false,
+        return buildInstallFailure('VALIDATION_FAILED', {
           skillId,
           installPath,
+          trustTier,
           error: 'Invalid SKILL.md: ' + validation.errors.join(', '),
           tips: [
             'SKILL.md must have YAML frontmatter with name and description fields',
             'Content must be at least 100 characters',
           ],
-        }
+        })
       }
 
       const contentHashMismatch = // SMI-3510
         indexedContentHash != null ? hashContent(skillMdContent) !== indexedContentHash : false
       // Security scan — GAP-06: Restrict skipScan to trusted tiers only
       if (options.skipScan && (trustTier === 'experimental' || trustTier === 'unknown')) {
-        return {
-          success: false,
+        return buildInstallFailure('SKIP_SCAN_FORBIDDEN', {
           skillId,
           installPath: '',
+          trustTier,
           error:
             'Cannot skip security scan for ' +
             trustTier +
@@ -233,7 +231,7 @@ export class SkillInstallationService {
             'Trust tier "' + trustTier + '" requires a security scan before installation',
             'If you believe this skill is safe, request a trust tier upgrade from the author',
           ],
-        }
+        })
       }
       let securityReport: InstallResult['securityReport']
       if (!options.skipScan) {
@@ -259,12 +257,11 @@ export class SkillInstallationService {
                 ? ' (Experimental skill - aggressive scanning applied)'
                 : ''
 
-          return {
-            success: false,
+          return buildInstallFailure('SCAN_REJECTED', {
             skillId,
             installPath,
-            securityReport,
             trustTier,
+            securityReport,
             error:
               'Security scan failed with ' +
               criticalFindings.length +
@@ -277,7 +274,7 @@ export class SkillInstallationService {
               'Trust tier: ' + trustTier + ' (threshold: ' + scannerOptions.riskThreshold + ')',
               'Risk score: ' + securityReport.riskScore,
             ],
-          }
+          })
         }
       }
 
@@ -292,13 +289,11 @@ export class SkillInstallationService {
             ? trustTier + ' tier skills have not been reviewed.'
             : 'Security scan detected issues.'
           : 'No security scan was performed.'
-        return {
-          success: false,
+        return buildConfirmationRequired({
           skillId,
           installPath,
-          securityReport,
           trustTier,
-          requiresConfirmation: true,
+          securityReport,
           confirmationReason:
             'This is an ' +
             trustTier +
@@ -306,7 +301,7 @@ export class SkillInstallationService {
             scanNote +
             ' Re-run with confirmed=true to proceed.',
           tips: ['Trust tier: ' + trustTier, 'Use confirmed=true to proceed with installation'],
-        }
+        })
       }
       this.onProgress('optimize', 'Applying optimization')
       const optimizeResult = options.skipOptimize
@@ -479,12 +474,12 @@ export class SkillInstallationService {
         tips,
       }
     } catch (error) {
-      return {
-        success: false,
+      return buildInstallFailure('UNKNOWN', {
         skillId,
         installPath: '',
+        trustTier,
         error: sanitizeInstallError(error),
-      }
+      })
     }
   }
 

--- a/packages/core/src/services/skill-installation.types.ts
+++ b/packages/core/src/services/skill-installation.types.ts
@@ -69,6 +69,27 @@ export interface OptimizationInfo {
   optimizedLines?: number
 }
 
+/**
+ * SMI-4795: Coarse error-code taxonomy for failed install events.
+ *
+ * Each code maps to a specific `success: false` return path inside
+ * SkillInstallationService.install(). The taxonomy is intentionally narrow —
+ * it should be cardinality-bounded enough for telemetry funnel analysis and
+ * stable across releases. Adding a new code requires (a) a real new failure
+ * return path and (b) updating downstream funnel queries.
+ */
+export type InstallErrorCode =
+  | 'REGISTRY_LOOKUP_UNAVAILABLE' // Registry ID supplied but no registry-lookup adapter configured
+  | 'REGISTRY_SKILL_NOT_FOUND' // Registry lookup returned null (no installable repo_url)
+  | 'QUARANTINED' // Skill is quarantined per registry metadata
+  | 'ALREADY_INSTALLED' // Skill present in manifest and force=false
+  | 'FETCH_FAILED' // SKILL.md fetch from GitHub failed
+  | 'VALIDATION_FAILED' // SKILL.md missing required frontmatter / too short
+  | 'SKIP_SCAN_FORBIDDEN' // skipScan requested but trust tier disallows it
+  | 'SCAN_REJECTED' // Security scan returned non-passing report
+  | 'CONFIRMATION_REQUIRED' // Experimental/unknown registry skill needs confirmed=true
+  | 'UNKNOWN' // Unhandled exception caught by outer try/catch
+
 /** Result of an install operation */
 export interface InstallResult {
   success: boolean
@@ -77,6 +98,12 @@ export interface InstallResult {
   securityReport?: ScanReport
   tips?: string[]
   error?: string
+  /**
+   * SMI-4795: Coarse machine-readable failure code, populated at every
+   * `success: false` return path. Always undefined when `success: true`.
+   * Used by install-telemetry funnel; see {@link InstallErrorCode}.
+   */
+  errorCode?: InstallErrorCode
   /** Trust tier used for security scanning */
   trustTier?: TrustTier
   /** Optimization info (Skillsmith Optimization Layer) */

--- a/packages/core/tests/unit/services/skill-installation.service.test.ts
+++ b/packages/core/tests/unit/services/skill-installation.service.test.ts
@@ -437,4 +437,139 @@ describe('SMI-3483: SkillInstallationService', () => {
       expect(forceResult.warning).toContain('not in the manifest')
     })
   })
+
+  // ==========================================================================
+  // SMI-4795: errorCode taxonomy on install failures
+  //
+  // Each failing return path inside install() must populate `errorCode` with
+  // a code from InstallErrorCode. Telemetry (emitInstallEvent) reads this
+  // field; without it the install funnel cannot classify failures.
+  // ==========================================================================
+
+  describe('SMI-4795: install failures populate errorCode', () => {
+    beforeEach(() => {
+      vi.stubGlobal('fetch', vi.fn())
+    })
+
+    it('REGISTRY_LOOKUP_UNAVAILABLE when registry id supplied without lookup adapter', async () => {
+      const service = createService(db) // no registryLookup
+      const result = await service.install('author/some-skill')
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('REGISTRY_LOOKUP_UNAVAILABLE')
+    })
+
+    it('REGISTRY_SKILL_NOT_FOUND when registry returns null', async () => {
+      const service = createService(db, {
+        registryLookup: createMockRegistryLookup({}), // empty registry
+      })
+      const result = await service.install('author/missing-skill')
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('REGISTRY_SKILL_NOT_FOUND')
+    })
+
+    it('QUARANTINED when registry flags the skill', async () => {
+      const service = createService(db, {
+        registryLookup: createMockRegistryLookup({
+          'author/quarantined-skill': {
+            repoUrl: 'https://github.com/author/quarantined-skill',
+            name: 'quarantined-skill',
+            quarantined: true,
+            trustTier: 'community',
+          },
+        }),
+      })
+      const result = await service.install('author/quarantined-skill')
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('QUARANTINED')
+      expect(result.trustTier).toBe('community')
+    })
+
+    it('FETCH_FAILED when SKILL.md is unreachable', async () => {
+      const mockFetch = vi.mocked(fetch)
+      mockFetch.mockResolvedValue(new Response('Not found', { status: 404 }))
+
+      const service = createService(db)
+      const result = await service.install('https://github.com/owner/missing-repo')
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('FETCH_FAILED')
+    })
+
+    it('VALIDATION_FAILED when SKILL.md is malformed/short', async () => {
+      const mockFetch = vi.mocked(fetch)
+      mockFetch.mockImplementation(async (url) => {
+        const urlStr = typeof url === 'string' ? url : url.toString()
+        if (urlStr.includes('SKILL.md')) {
+          return new Response(SHORT_SKILL_MD, { status: 200 })
+        }
+        return new Response('Not found', { status: 404 })
+      })
+
+      const service = createService(db)
+      const result = await service.install('https://github.com/owner/short-repo')
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('VALIDATION_FAILED')
+    })
+
+    it('ALREADY_INSTALLED on repeat install without force', async () => {
+      const mockFetch = vi.mocked(fetch)
+      mockFetch.mockImplementation(async (url) => {
+        const urlStr = typeof url === 'string' ? url : url.toString()
+        if (urlStr.includes('SKILL.md')) {
+          return new Response(VALID_SKILL_MD, { status: 200 })
+        }
+        return new Response('Not found', { status: 404 })
+      })
+
+      const service = createService(db)
+      const first = await service.install('https://github.com/owner/dup-repo')
+      expect(first.success).toBe(true)
+
+      const second = await service.install('https://github.com/owner/dup-repo')
+      expect(second.success).toBe(false)
+      expect(second.errorCode).toBe('ALREADY_INSTALLED')
+    })
+
+    it('SKIP_SCAN_FORBIDDEN when skipScan requested on unknown tier', async () => {
+      const mockFetch = vi.mocked(fetch)
+      mockFetch.mockImplementation(async (url) => {
+        const urlStr = typeof url === 'string' ? url : url.toString()
+        if (urlStr.includes('SKILL.md')) {
+          return new Response(VALID_SKILL_MD, { status: 200 })
+        }
+        return new Response('Not found', { status: 404 })
+      })
+
+      // Direct GitHub URL → trust tier defaults to 'unknown', skipScan disallowed
+      const service = createService(db)
+      const result = await service.install('https://github.com/owner/skip-repo', {
+        skipScan: true,
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('SKIP_SCAN_FORBIDDEN')
+      expect(result.trustTier).toBe('unknown')
+    })
+
+    it('successful install does NOT carry errorCode', async () => {
+      const mockFetch = vi.mocked(fetch)
+      mockFetch.mockImplementation(async (url) => {
+        const urlStr = typeof url === 'string' ? url : url.toString()
+        if (urlStr.includes('SKILL.md')) {
+          return new Response(VALID_SKILL_MD, { status: 200 })
+        }
+        return new Response('Not found', { status: 404 })
+      })
+
+      const service = createService(db)
+      const result = await service.install('https://github.com/owner/ok-repo')
+
+      expect(result.success).toBe(true)
+      expect(result.errorCode).toBeUndefined()
+    })
+  })
 })

--- a/packages/mcp-server/src/tools/install.test.ts
+++ b/packages/mcp-server/src/tools/install.test.ts
@@ -358,4 +358,79 @@ describe('installSkill() Zod boundary guard (SMI-4288 / #599)', () => {
       expect(mockInstall).not.toHaveBeenCalled()
     })
   })
+
+  // ==========================================================================
+  // SMI-4795: install telemetry must thread errorCode + trustTier
+  //
+  // Prior to SMI-4795, the MCP emit site only forwarded {skillId, source,
+  // success, durationMs}. This left every failed install in the funnel as
+  // `error_code: NULL`, blocking root-cause classification. These tests
+  // assert the four metadata fields are now propagated to emitInstallEvent.
+  // ==========================================================================
+
+  describe('SMI-4795: emitInstallEvent receives errorCode + trustTier', () => {
+    it('forwards trustTier and errorCode on a failed install', async () => {
+      mockInstall.mockResolvedValueOnce({
+        success: false,
+        skillId: 'owner/repo/scan-rejected',
+        installPath: '',
+        errorCode: 'SCAN_REJECTED',
+        trustTier: 'community',
+        error: 'Security scan failed',
+      })
+
+      await installSkill({ skillId: 'owner/repo/scan-rejected' })
+
+      expect(mockEmitInstallEvent).toHaveBeenCalledTimes(1)
+      const payload = mockEmitInstallEvent.mock.calls[0]?.[0]
+      expect(payload).toMatchObject({
+        skillId: 'owner/repo/scan-rejected',
+        source: 'mcp',
+        success: false,
+        errorCode: 'SCAN_REJECTED',
+        trustTier: 'community',
+      })
+      expect(typeof payload.durationMs).toBe('number')
+    })
+
+    it('forwards trustTier on a successful install but omits errorCode', async () => {
+      mockInstall.mockResolvedValueOnce({
+        success: true,
+        skillId: 'owner/repo/ok-skill',
+        installPath: '/tmp/mock/ok-skill',
+        trustTier: 'verified',
+      })
+
+      await installSkill({ skillId: 'owner/repo/ok-skill' })
+
+      expect(mockEmitInstallEvent).toHaveBeenCalledTimes(1)
+      const payload = mockEmitInstallEvent.mock.calls[0]?.[0]
+      expect(payload).toMatchObject({
+        skillId: 'owner/repo/ok-skill',
+        source: 'mcp',
+        success: true,
+        trustTier: 'verified',
+      })
+      expect(payload.errorCode).toBeUndefined()
+    })
+
+    it('omits both errorCode and trustTier when neither is set', async () => {
+      // Service returned a failure result that pre-dates SMI-4795 (no fields).
+      // Emit-site must not invent values — payload omits both keys cleanly.
+      mockInstall.mockResolvedValueOnce({
+        success: false,
+        skillId: 'owner/repo/legacy-failure',
+        installPath: '',
+        error: 'something went wrong',
+      })
+
+      await installSkill({ skillId: 'owner/repo/legacy-failure' })
+
+      expect(mockEmitInstallEvent).toHaveBeenCalledTimes(1)
+      const payload = mockEmitInstallEvent.mock.calls[0]?.[0]
+      expect(payload.errorCode).toBeUndefined()
+      expect(payload.trustTier).toBeUndefined()
+      expect(payload.success).toBe(false)
+    })
+  })
 })

--- a/packages/mcp-server/src/tools/install.ts
+++ b/packages/mcp-server/src/tools/install.ts
@@ -218,12 +218,17 @@ export async function installSkill(input: unknown, _context?: ToolContext): Prom
     confirmed: validInput.confirmed,
   })
 
-  // SMI-4182: fire-and-forget install telemetry for usage report funnel
+  // SMI-4182 / SMI-4795: fire-and-forget install telemetry for usage report
+  // funnel. `trustTier` is included on every event (when known) and
+  // `errorCode` is included only on failures so the wire payload stays
+  // minimal for successful installs.
   void emitInstallEvent({
     skillId: validInput.skillId,
     source: 'mcp',
     success: result.success,
     durationMs: Date.now() - installStart,
+    ...(result.trustTier !== undefined && { trustTier: result.trustTier }),
+    ...(!result.success && result.errorCode !== undefined && { errorCode: result.errorCode }),
   })
 
   // SMI-4578: fan-out to additional clients after primary install. Failures


### PR DESCRIPTION
## Summary

- Adds 10-code `InstallErrorCode` taxonomy and threads `errorCode` + `trustTier` through every `success: false` return inside `SkillInstallationService.install()`.
- Updates both MCP and CLI emit sites (`emitInstallEvent`) to forward the new fields.
- 14 new tests across core service, MCP boundary, and CLI boundary.

## Why

Parent SMI-4782 fixed the events sanitizer to accept `error_code` and `trust_tier` server-side. But the client-side emitters never populated either field — every install-failure row in prod (4 confirmed on 2026-05-07 from one user installing anthropic/* skills via MCP) lands with NULL classifications. Funnel triage cannot distinguish auth failure from registry miss from scan rejection until both fields flow.

## Definition of done

- [x] `InstallResult.errorCode` added; populated at every `success: false` return path
- [x] Both emit sites pass `trustTier` (always when known) and `errorCode` (failures only)
- [x] Unit + integration tests cover new fields on failure paths
- [x] /governance retro clean (F-2 + F-5 fixed in 47d756bc)
- [ ] CI green
- [ ] Merge

## Taxonomy

| Code | Trigger |
|---|---|
| `REGISTRY_LOOKUP_UNAVAILABLE` | Registry id, no adapter |
| `REGISTRY_SKILL_NOT_FOUND` | Registry returned null |
| `QUARANTINED` | Skill flagged in registry |
| `ALREADY_INSTALLED` | Manifest hit, no force |
| `FETCH_FAILED` | SKILL.md fetch failed |
| `VALIDATION_FAILED` | Bad frontmatter / too short |
| `SKIP_SCAN_FORBIDDEN` | skipScan disallowed for tier |
| `SCAN_REJECTED` | Security scan failed |
| `CONFIRMATION_REQUIRED` | Experimental/unknown needs confirmed=true |
| `UNKNOWN` | Outer try/catch |

Each code maps 1:1 to a real `success: false` return — no speculative codes.

## Files

- `packages/core/src/services/skill-installation.types.ts` — `InstallErrorCode` union + `errorCode?` field
- `packages/core/src/services/skill-installation.errors.ts` — NEW (92 lines) failure-result builders to keep `service.ts` under 500-line gate
- `packages/core/src/services/skill-installation.service.ts` — refactored 9 failure returns to use builders (502 → 496 lines)
- `packages/core/src/exports/services.ts` — re-export `InstallErrorCode`
- `packages/mcp-server/src/tools/install.ts` — emit site forwards `trustTier` + `errorCode`
- `packages/cli/src/commands/install.ts` — emit site forwards `trustTier` + `errorCode`
- 3 test files: 8 core + 3 MCP + 3 CLI new tests (76 install tests total, all green)

Wire format (`supabase/functions/_shared/audit-log.ts` + events sanitizer) already accepts both keys per SMI-4782 — this PR fills the client-side gap only.

## Test plan

- [x] `npm run typecheck --workspace @skillsmith/core` clean
- [x] `npm run typecheck --workspace @skillsmith/mcp-server` clean
- [x] `npm run typecheck --workspace @skillsmith/cli` clean
- [x] `npx vitest run` for service / MCP / CLI install tests — 76/76 pass
- [x] `npm run lint` + `npm run format:check` clean
- [x] `npm run audit:standards` 92% (5 pre-existing warnings, none introduced)
- [ ] CI matrix green
- [ ] Post-merge: re-query `audit_logs WHERE event_type='telemetry:skill_install'` for new rows → confirm `error_code` + `trust_tier` populated. Note: telemetry rows arrive only after CLI/MCP-server packages are republished and end-users upgrade — this PR is necessary but not sufficient for prod observability. SMI-4794 tracks the post-rollout funnel verification.

Linear: https://linear.app/smith-horn-group/issue/SMI-4795
Parent: SMI-4782 (events sanitizer)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)