### PR TITLE
fix(eval): SMI-4764 Wave 3 — paginate listComments in sticky PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,10 +434,15 @@ jobs:
             const fs = require('fs');
             const body = fs.readFileSync('/tmp/eval-comment.md', 'utf8');
             const marker = '<!-- skillsmith:eval-baseline-comment -->';
-            const { data: comments } = await github.rest.issues.listComments({
+            // Paginate: PRs can accumulate >30 comments (default page size),
+            // and a non-paginated listComments would miss an existing sticky
+            // marker on a later page and create a duplicate. SMI-4764 Wave 3
+            // governance retro fix.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
             const existing = comments.find(c => c.body && c.body.startsWith(marker));
             if (existing) {


### PR DESCRIPTION
## Summary

Governance retro of PR #1013 (Wave 3 squash `749e0219`) surfaced one
Medium-severity finding: the new sticky PR comment step in the
`retrieval-eval-gate` job uses `github.rest.issues.listComments` without
pagination. GitHub's REST API defaults to 30 comments per page; PRs that
accumulate >30 comments would miss an existing sticky marker on a later
page and create duplicate comments on each push.

## Fix

Replaced single-page `listComments` with `github.paginate(...)` and
`per_page: 100`, the canonical octokit pagination pattern.

## Files changed

- `.github/workflows/ci.yml` — paginate sticky-comment lookup
- `docs/internal` submodule bump — adds Wave 3 code-review report at
  `code_review/2026-05-07-smi-4764-wave-3.md` and updates the index

## Test plan

- [x] Prettier check on `.github/workflows/ci.yml` (clean)
- [x] YAML parse via `js-yaml` (valid)
- [ ] Sticky-comment test fires on this PR itself once CI runs (this PR
      touches `.github/workflows/ci.yml` which is in the eval-gate
      `paths-filter` only via `**/eval/**`, so the renderer step will
      not run on this PR — gating is intentional)

## Linear

SMI-4764 — Wave 3 governance retro fix (separate from Wave 4 backlog).

Push uses `--no-verify` per CLAUDE.md SMI-4767/4769 host vitest leak
workaround.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)