### PR TITLE
chore(release): bump mcp-server 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29055,7 +29055,7 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 All notable changes to `@skillsmith/mcp-server` are documented here.
 
+## [Unreleased]
+
 ## v0.5.1
 
 - **Feature**: SMI-4790 lifecycle-tagged tool descriptions + skill auto-install (#1022)
 - **Fix**: SMI-4795 thread errorCode + trustTier through install telemetry (#1014)
-
-## [Unreleased]
 
 ## v0.5.0
 

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@skillsmith/mcp-server` are documented here.
 
+## v0.5.1
+
+- **Feature**: SMI-4790 lifecycle-tagged tool descriptions + skill auto-install (#1022)
+- **Fix**: SMI-4795 thread errorCode + trustTier through install telemetry (#1014)
+
 ## [Unreleased]
 
 ## v0.5.0

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.5.0",
+  "version": "0.5.1",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -71,7 +71,7 @@ import { createLicenseMiddleware } from './middleware/license.js'
 import { createQuotaMiddleware } from './middleware/quota.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.5.0'
+const PACKAGE_VERSION = '0.5.1'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,


### PR DESCRIPTION
## Summary

Wave 1 release of [SMI-4787](https://linear.app/smith-horn-group/issue/SMI-4787) (Skillsmith Master Skill Discoverability).

`@skillsmith/mcp-server`: **0.5.0 → 0.5.1**

## Changes shipping

- Lifecycle-tagged MCP tool descriptions ([SMI-4790](https://linear.app/smith-horn-group/issue/SMI-4790), #1022)
- Bundled skill auto-install on every non-first-run MCP startup (SMI-4790)
- Fix install telemetry threading errorCode + trustTier ([SMI-4795](https://linear.app/smith-horn-group/issue/SMI-4795), #1014)

## Test plan

- [ ] CI green on this PR
- [ ] Admin-merge per CLAUDE.md SMI-4530 carve-out (`Package Validation` fails by design on release branches)
- [ ] After merge: `gh workflow run publish.yml -f dry_run=false`
- [ ] Verify `npm view @skillsmith/mcp-server version` returns 0.5.1
- [ ] Verify MCP Registry shows 0.5.1
- [ ] Smoke: clean shell `npx -y @skillsmith/mcp-server@0.5.1`, verify `[skillsmith] Installed bundled skill: skillsmith` on stderr; bare prompt "Search for testing skills" (no Skillsmith anchor) triggers `mcp__skillsmith__search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>