### PR TITLE
fix(ci): SMI-4803 publish.yml — add !cancelled() to publish-* if: gates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -535,7 +535,12 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    # SMI-4803: `!cancelled() &&` overrides GitHub Actions' implicit `success()`
+    # check on `needs:`. Without it, when `publish-core` skips (because core is
+    # already published), this job is auto-skipped before its `if:` is evaluated
+    # — making the explicit `result == 'skipped'` clause below dead code.
     if: |
+      !cancelled() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.mcp-exists != 'true' &&
       (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')
@@ -683,7 +688,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    # SMI-4803: see publish-mcp-server for `!cancelled()` rationale.
     if: |
+      !cancelled() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.cli-exists != 'true' &&
       (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')
@@ -758,7 +765,9 @@ jobs:
       contents: read
       id-token: write
       packages: write
+    # SMI-4803: see publish-mcp-server for `!cancelled()` rationale.
     if: |
+      !cancelled() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.enterprise-exists != 'true' &&
       (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')


### PR DESCRIPTION
## Summary

- 3-line fix: prepend `!cancelled() &&` to the `if:` blocks of `publish-mcp-server`, `publish-cli`, and `publish-enterprise` in `.github/workflows/publish.yml`.
- Unblocks the SMI-4790 release: `@skillsmith/mcp-server@0.5.1` is currently published as a GitHub Release + tag but absent from npm because all 4 publish.yml triggers (runs 25522926751, 25523833585, 25524504407, 25525137514) skipped the publish jobs.
- Plan: [docs/internal/implementation/smi-4803-publish-yml-skipped-needs-gating.md](https://github.com/smith-horn/skillsmith/blob/fix/smi-4803-publish-needs-gating/docs/internal/implementation/smi-4803-publish-yml-skipped-needs-gating.md) (committed in this branch via the docs/internal submodule).

## Root cause

GitHub Actions applies an implicit `success()` check on `needs:` before evaluating the explicit `if:` expression. When `publish-core` is skipped (because core is already published — its own `if:` evaluates false), the implicit check **auto-skips** every job that lists `publish-core` in `needs:` *before* the explicit `if:` runs. The existing `(needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')` clause is dead code — it's never reached.

`smoke-test` and `create-gh-release` already use `if: always() && ...` for this reason; the publish-\* jobs whose only skip-path is `publish-core` were missed.

## Fix

`!cancelled() &&` overrides the implicit success() check while still honoring cancellation. Preferred over `always()` (too broad — would run on cancellation) and `!failure()` (less self-documenting).

## Verification matrix

After merge, re-trigger publish via the existing `@skillsmith/mcp-server-v0.5.1` release tag (or workflow_dispatch with `dry_run=false`):

| Job | Expected | Why |
|---|---|---|
| publish-core | skipped | `core_exists=true` (0.6.0 already on npm) |
| publish-mcp-server | **runs and publishes** | `mcp_exists=false` (0.5.1 not on npm); core skipped, not failed |
| publish-cli | skipped | `cli_exists=true` (0.6.0 already on npm) |
| publish-enterprise | runs/skips per current state | gated by GitHub Packages check |

Smoke after publish: `npm view @skillsmith/mcp-server@0.5.1 version` → `0.5.1`; mcp-publisher registry publish succeeds.

## Plan-review

Approved by plan-review-specialist (VP Engineering / VP Product / Risk lenses) with one S1 docs clarification (applied): `!cancelled()` overrides the implicit-skip path only — a *failed* upstream job (e.g., `validate`) still triggers the failure gate, so `publish-*` won't run on a broken validate. SMI-4802 (separate `prepare-release.ts` bug) remains out of scope per VP Product call.

## Test plan

- [ ] CI green on this branch (TypeScript, lint, audit:standards, etc. — workflow files don't affect application tests but full matrix should pass)
- [ ] After merge: re-trigger publish.yml; observe publish-mcp-server runs (not skipped)
- [ ] `npm view @skillsmith/mcp-server@0.5.1 version` returns `0.5.1`
- [ ] MCP Registry shows 0.5.1
- [ ] Bare-prompt smoke ("Search for testing skills" with NO Skillsmith anchor) triggers `mcp__skillsmith__search` after MCP client picks up new tool descriptions

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>