### PR TITLE
fix(website): SMI-4792 Wave 3 cross-link reference pages to lifecycle tutorials

### DIFF
--- a/packages/website/src/pages/docs/api.astro
+++ b/packages/website/src/pages/docs/api.astro
@@ -496,4 +496,18 @@ try {
       <a href="/account">account settings</a>.
     </p>
   </div>
+
+  <h2>Lifecycle Tutorials</h2>
+
+  <p>
+    The HTTP API exposes the same data the CLI and MCP server use. For end-to-end walkthroughs of
+    each lifecycle stage — including which API endpoints they exercise — see the
+    <a href="/docs/tutorials">lifecycle tutorials</a>:
+  </p>
+
+  <ul>
+    <li><a href="/docs/tutorials/discover">Discover</a> — search and recommend endpoints</li>
+    <li><a href="/docs/tutorials/evaluate">Evaluate</a> — skill detail, compare, diff endpoints</li>
+    <li><a href="/docs/tutorials/govern">Govern</a> — audit query, export, and SIEM endpoints (Enterprise)</li>
+  </ul>
 </DocsLayout>

--- a/packages/website/src/pages/docs/cli.astro
+++ b/packages/website/src/pages/docs/cli.astro
@@ -538,6 +538,23 @@ skillsmith validate ~/.claude/skills/jest-helper`}</code></pre>
     </tbody>
   </table>
 
+  <h2>Lifecycle Tutorials</h2>
+
+  <p>
+    The CLI is the universal Skillsmith surface — every lifecycle stage has a CLI path.
+    The <a href="/docs/tutorials">lifecycle tutorials</a> walk through each stage end-to-end:
+  </p>
+
+  <ul>
+    <li><a href="/docs/tutorials/discover"><strong>Discover</strong></a> — <code>skillsmith search</code>, <code>skillsmith recommend</code>, filtering by trust tier</li>
+    <li><a href="/docs/tutorials/evaluate"><strong>Evaluate</strong></a> — <code>skillsmith info</code>, <code>skillsmith diff</code>, reading trust badges</li>
+    <li><a href="/docs/tutorials/install-and-use"><strong>Install &amp; use</strong></a> — <code>skillsmith install</code> + invoking the skill in your runtime</li>
+    <li><a href="/docs/tutorials/maintain"><strong>Maintain</strong></a> — <code>skillsmith update</code>, <code>skillsmith pin</code>, <code>skillsmith audit collisions</code>, audit modes</li>
+    <li><a href="/docs/tutorials/author"><strong>Author</strong></a> — <code>skillsmith author init/validate/publish/subagent/transform/mcp-init</code></li>
+    <li><a href="/docs/tutorials/govern"><strong>Govern</strong></a> — <code>skillsmith audit advisories</code> and the audit-mode tier gates</li>
+    <li><a href="/docs/tutorials/retire"><strong>Retire</strong></a> — <code>skillsmith remove</code></li>
+  </ul>
+
   <h2>Troubleshooting</h2>
 
   <h3>Common Issues</h3>

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -499,6 +499,23 @@ Assistant: [Uses compare tool] Here's a comparison:
     </tbody>
   </table>
 
+  <h2>Lifecycle Tutorials</h2>
+
+  <p>
+    The MCP tools listed above bind to natural-language prompts in your agent runtime.
+    The <a href="/docs/tutorials">lifecycle tutorials</a> show worked examples of each stage
+    (Claude Code is the worked-example runtime; the same MCP tools work in any MCP-capable agent):
+  </p>
+
+  <ul>
+    <li><a href="/docs/tutorials/discover"><strong>Discover</strong></a> — <code>search</code>, <code>skill_recommend</code></li>
+    <li><a href="/docs/tutorials/evaluate"><strong>Evaluate</strong></a> — <code>get_skill</code>, <code>skill_compare</code>, <code>skill_diff</code></li>
+    <li><a href="/docs/tutorials/install-and-use"><strong>Install &amp; use</strong></a> — <code>install_skill</code>, <code>skill_validate</code></li>
+    <li><a href="/docs/tutorials/maintain"><strong>Maintain</strong></a> — <code>skill_updates</code>, <code>skill_outdated</code>, <code>skill_inventory_audit</code> (Team+)</li>
+    <li><a href="/docs/tutorials/govern"><strong>Govern</strong></a> — <code>skill_audit</code> (Team+), <code>audit_export</code>, <code>audit_query</code>, <code>siem_export</code> (Enterprise)</li>
+    <li><a href="/docs/tutorials/retire"><strong>Retire</strong></a> — <code>uninstall_skill</code></li>
+  </ul>
+
   <h2>Troubleshooting</h2>
 
   <h3>Server Not Starting</h3>


### PR DESCRIPTION
## Summary

Wave 3 of [SMI-4787](https://linear.app/smith-horn-group/issue/SMI-4787). Adds a "Lifecycle Tutorials" section to each reference page that lacked tutorial cross-links. Stacked on top of [PR #1027](https://github.com/smith-horn/skillsmith/pull/1027) (Wave 2 tutorials integration); will auto-retarget to `main` once #1027 merges.

## Changes

- `cli.astro`: links all 7 lifecycle stages with the matching CLI subcommand signatures
- `mcp-server.astro`: links 6 stages (omits Author since author flow is CLI-led, not MCP-tool-led) with matching MCP tool names; tier-gated tools (Team+, Enterprise) called out
- `api.astro`: links Discover, Evaluate, and Govern (the stages with API endpoint coverage)
- `vscode-extension.astro` already has comprehensive tutorial cross-links from Wave 2 — no changes needed
- Submodule pointer bump for the Wave 2 UAT internal doc (private)

## Test plan

- [x] `npm run build --workspace=@skillsmith/website` clean (verified locally)
- [x] No new `audit:standards` warnings/failures
- [x] Lint-staged passed on commit (Prettier formatted)
- [ ] CI green
- [ ] After merge: spot-check that reference pages link to tutorials and vice-versa

[skip-impl-check] — copy-only edits to existing reference pages, no new logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)