### PR TITLE
refactor(core): SMI-4813 split SkillParser.ts under 500-line gate (replaces #1031)

### DIFF
--- a/packages/core/src/indexer/SkillParser.helpers.ts
+++ b/packages/core/src/indexer/SkillParser.helpers.ts
@@ -1,0 +1,101 @@
+/**
+ * SMI-4813: parseYamlFrontmatter helper, extracted from SkillParser.ts so the
+ * class file stays under the audit:standards 500-line gate.
+ *
+ * Internal to the indexer module — not re-exported from `index.ts`. Consumers
+ * import via the `SkillParser` class.
+ */
+
+/**
+ * Simple YAML frontmatter parser
+ * Parses basic YAML key-value pairs without external dependencies
+ */
+export function parseYamlFrontmatter(yaml: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  const lines = yaml.split('\n')
+  let currentKey: string | null = null
+  let arrayBuffer: string[] = []
+  let inArray = false
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+
+    // Check for array item
+    if (trimmed.startsWith('- ')) {
+      if (currentKey && inArray) {
+        const value = trimmed.slice(2).trim()
+        // Remove quotes if present
+        const unquoted = value.replace(/^["']|["']$/g, '')
+        arrayBuffer.push(unquoted)
+      }
+      continue
+    }
+
+    // Check for key-value pair
+    const colonIndex = trimmed.indexOf(':')
+    if (colonIndex > 0) {
+      // Save previous array if exists
+      if (currentKey && inArray && arrayBuffer.length > 0) {
+        result[currentKey] = arrayBuffer
+        arrayBuffer = []
+      }
+
+      const key = trimmed.slice(0, colonIndex).trim()
+      const value = trimmed.slice(colonIndex + 1).trim()
+
+      if (value === '' || value === '|' || value === '>') {
+        // This might be an array or multiline value
+        currentKey = key
+        inArray = true
+        arrayBuffer = []
+      } else {
+        // Simple key-value
+        currentKey = null
+        inArray = false
+
+        // Parse the value
+        let parsedValue: unknown = value
+
+        // Remove quotes
+        if (
+          (value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))
+        ) {
+          parsedValue = value.slice(1, -1)
+        }
+        // Parse boolean
+        else if (value === 'true') {
+          parsedValue = true
+        } else if (value === 'false') {
+          parsedValue = false
+        }
+        // Parse number
+        else if (/^-?\d+(\.\d+)?$/.test(value)) {
+          parsedValue = parseFloat(value)
+        }
+        // Parse inline array [item1, item2]
+        else if (value.startsWith('[') && value.endsWith(']')) {
+          parsedValue = value
+            .slice(1, -1)
+            .split(',')
+            .map((item) => item.trim().replace(/^["']|["']$/g, ''))
+            .filter((item) => item.length > 0)
+        }
+
+        result[key] = parsedValue
+      }
+    }
+  }
+
+  // Save final array if exists
+  if (currentKey && inArray && arrayBuffer.length > 0) {
+    result[currentKey] = arrayBuffer
+  }
+
+  return result
+}

--- a/packages/core/src/indexer/SkillParser.ts
+++ b/packages/core/src/indexer/SkillParser.ts
@@ -1,179 +1,23 @@
 /**
  * SMI-628: SkillParser - Parse SKILL.md files with YAML frontmatter.
  * Extracts metadata from the standard SKILL.md format.
+ *
+ * SMI-4813: Type surface and `parseYamlFrontmatter` helper extracted into
+ * sibling files (`SkillParser.types.ts`, `SkillParser.helpers.ts`) to keep
+ * this file under the audit:standards 500-line gate.
  */
 
 import type { TrustTier } from '../types/skill.js'
-import type { ConflictDeclaration, DependencyDeclaration } from '../types/dependencies.js'
+import type { DependencyDeclaration } from '../types/dependencies.js'
+import type {
+  SkillFrontmatter,
+  ParsedSkillMetadata,
+  ValidationResult,
+  SkillParserOptions,
+} from './SkillParser.types.js'
+import { parseYamlFrontmatter } from './SkillParser.helpers.js'
 
-/**
- * Raw metadata extracted from SKILL.md frontmatter
- */
-export interface SkillFrontmatter {
-  name: string
-  description?: string
-  author?: string
-  version?: string
-  tags?: string[]
-  /** SMI-3135: Structured dependency declaration (replaces string[]) */
-  dependencies?: DependencyDeclaration
-  category?: string
-  license?: string
-  repository?: string
-  homepage?: string
-  /** SMI-2760: Compatibility tags — IDE, LLM, and platform values */
-  compatibility?: string[]
-  /** SMI-3135: Conflict declarations */
-  conflicts?: ConflictDeclaration[]
-  /** SMI-3135: Deprecation flag */
-  deprecated?: boolean
-  /** SMI-3135: Skill that supersedes this one */
-  superseded_by?: string | null
-  /** @deprecated Use dependencies.skills instead */
-  composes?: string[]
-  [key: string]: unknown
-}
-
-/**
- * Parsed skill metadata ready for database insertion
- */
-export interface ParsedSkillMetadata {
-  name: string
-  description: string | null
-  author: string | null
-  version: string | null
-  tags: string[]
-  /** SMI-3135: Structured dependency declaration (replaces string[]) */
-  dependencies?: DependencyDeclaration
-  category: string | null
-  license: string | null
-  repository: string | null
-  rawContent: string
-  frontmatter: SkillFrontmatter
-}
-
-/**
- * Validation result for skill metadata
- */
-export interface ValidationResult {
-  valid: boolean
-  errors: string[]
-  warnings: string[]
-}
-
-/**
- * Parser options
- */
-export interface SkillParserOptions {
-  /**
-   * Whether to require a name field (default: true)
-   */
-  requireName?: boolean
-
-  /**
-   * Whether to require a description field (default: false)
-   */
-  requireDescription?: boolean
-
-  /**
-   * Custom validation function
-   */
-  customValidator?: (frontmatter: SkillFrontmatter) => ValidationResult
-}
-
-/**
- * Simple YAML frontmatter parser
- * Parses basic YAML key-value pairs without external dependencies
- */
-function parseYamlFrontmatter(yaml: string): Record<string, unknown> {
-  const result: Record<string, unknown> = {}
-  const lines = yaml.split('\n')
-  let currentKey: string | null = null
-  let arrayBuffer: string[] = []
-  let inArray = false
-
-  for (const line of lines) {
-    const trimmed = line.trim()
-
-    // Skip empty lines and comments
-    if (!trimmed || trimmed.startsWith('#')) {
-      continue
-    }
-
-    // Check for array item
-    if (trimmed.startsWith('- ')) {
-      if (currentKey && inArray) {
-        const value = trimmed.slice(2).trim()
-        // Remove quotes if present
-        const unquoted = value.replace(/^["']|["']$/g, '')
-        arrayBuffer.push(unquoted)
-      }
-      continue
-    }
-
-    // Check for key-value pair
-    const colonIndex = trimmed.indexOf(':')
-    if (colonIndex > 0) {
-      // Save previous array if exists
-      if (currentKey && inArray && arrayBuffer.length > 0) {
-        result[currentKey] = arrayBuffer
-        arrayBuffer = []
-      }
-
-      const key = trimmed.slice(0, colonIndex).trim()
-      const value = trimmed.slice(colonIndex + 1).trim()
-
-      if (value === '' || value === '|' || value === '>') {
-        // This might be an array or multiline value
-        currentKey = key
-        inArray = true
-        arrayBuffer = []
-      } else {
-        // Simple key-value
-        currentKey = null
-        inArray = false
-
-        // Parse the value
-        let parsedValue: unknown = value
-
-        // Remove quotes
-        if (
-          (value.startsWith('"') && value.endsWith('"')) ||
-          (value.startsWith("'") && value.endsWith("'"))
-        ) {
-          parsedValue = value.slice(1, -1)
-        }
-        // Parse boolean
-        else if (value === 'true') {
-          parsedValue = true
-        } else if (value === 'false') {
-          parsedValue = false
-        }
-        // Parse number
-        else if (/^-?\d+(\.\d+)?$/.test(value)) {
-          parsedValue = parseFloat(value)
-        }
-        // Parse inline array [item1, item2]
-        else if (value.startsWith('[') && value.endsWith(']')) {
-          parsedValue = value
-            .slice(1, -1)
-            .split(',')
-            .map((item) => item.trim().replace(/^["']|["']$/g, ''))
-            .filter((item) => item.length > 0)
-        }
-
-        result[key] = parsedValue
-      }
-    }
-  }
-
-  // Save final array if exists
-  if (currentKey && inArray && arrayBuffer.length > 0) {
-    result[currentKey] = arrayBuffer
-  }
-
-  return result
-}
+export type { SkillFrontmatter, ParsedSkillMetadata, ValidationResult, SkillParserOptions }
 
 /**
  * SkillParser - Parses SKILL.md files with YAML frontmatter

--- a/packages/core/src/indexer/SkillParser.types.ts
+++ b/packages/core/src/indexer/SkillParser.types.ts
@@ -1,0 +1,84 @@
+/**
+ * SMI-4813: SkillParser type surface, extracted from SkillParser.ts so the
+ * class file stays under the audit:standards 500-line gate. Public surface
+ * is preserved by re-export from `SkillParser.ts` and `indexer/index.ts`.
+ *
+ * SMI-628: Original SkillParser frontmatter / metadata types.
+ */
+
+import type { ConflictDeclaration, DependencyDeclaration } from '../types/dependencies.js'
+
+/**
+ * Raw metadata extracted from SKILL.md frontmatter
+ */
+export interface SkillFrontmatter {
+  name: string
+  description?: string
+  author?: string
+  version?: string
+  tags?: string[]
+  /** SMI-3135: Structured dependency declaration (replaces string[]) */
+  dependencies?: DependencyDeclaration
+  category?: string
+  license?: string
+  repository?: string
+  homepage?: string
+  /** SMI-2760: Compatibility tags — IDE, LLM, and platform values */
+  compatibility?: string[]
+  /** SMI-3135: Conflict declarations */
+  conflicts?: ConflictDeclaration[]
+  /** SMI-3135: Deprecation flag */
+  deprecated?: boolean
+  /** SMI-3135: Skill that supersedes this one */
+  superseded_by?: string | null
+  /** @deprecated Use dependencies.skills instead */
+  composes?: string[]
+  [key: string]: unknown
+}
+
+/**
+ * Parsed skill metadata ready for database insertion
+ */
+export interface ParsedSkillMetadata {
+  name: string
+  description: string | null
+  author: string | null
+  version: string | null
+  tags: string[]
+  /** SMI-3135: Structured dependency declaration (replaces string[]) */
+  dependencies?: DependencyDeclaration
+  category: string | null
+  license: string | null
+  repository: string | null
+  rawContent: string
+  frontmatter: SkillFrontmatter
+}
+
+/**
+ * Validation result for skill metadata
+ */
+export interface ValidationResult {
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+}
+
+/**
+ * Parser options
+ */
+export interface SkillParserOptions {
+  /**
+   * Whether to require a name field (default: true)
+   */
+  requireName?: boolean
+
+  /**
+   * Whether to require a description field (default: false)
+   */
+  requireDescription?: boolean
+
+  /**
+   * Custom validation function
+   */
+  customValidator?: (frontmatter: SkillFrontmatter) => ValidationResult
+}


### PR DESCRIPTION
## Summary

- Wave 1.1 of [SMI-4812](https://linear.app/smith-horn-group/issue/SMI-4812)
- Splits `packages/core/src/indexer/SkillParser.ts` (500 → 343 lines) into companion `SkillParser.types.ts` + `SkillParser.helpers.ts`; public surface preserved via re-export
- Bumps `docs/internal` submodule to land the [SMI-4812 audit-zero-warnings plan](https://github.com/smith-horn/skillsmith-docs/commit/5be68873)

## Why this replaces PR #1031

PR #1031 had GitHub Actions `pull_request` dispatch suppressed for the entire branch — only Vercel ran on every commit (3 SHAs). Both empty-commit nudge and close/reopen failed to recover. Hypothesis: the branch's first commit was a submodule-pointer-only change, which wedged the dispatcher. This PR bundles the submodule bump with real code changes in a single commit so there's no isolated submodule-only commit at branch root.

## Linked sub-issues under SMI-4812

| Wave | Sub-issue | PR |
|------|-----------|-----|
| 1.1 | [SMI-4813](https://linear.app/smith-horn-group/issue/SMI-4813) | **this PR** (replaces #1031) |
| 1.2 | [SMI-4814](https://linear.app/smith-horn-group/issue/SMI-4814) | #1032 |
| 2 | [SMI-4815](https://linear.app/smith-horn-group/issue/SMI-4815) | #1034 |
| 3 | [SMI-4816](https://linear.app/smith-horn-group/issue/SMI-4816) | #1035 (applied to staging + prod) |

## Audit warning delta

- Before: 4 in-scope warnings on `main`
- After this PR + #1032 + #1034 + #1035 merge: **0**

## Test plan

- [x] `docker exec skillsmith-dev-1 npx tsc --build packages/core` — green
- [x] 96/96 SkillParser-touching tests pass
- [x] `npm run audit:standards` — file-length warning resolved
- [ ] Full pre-merge CI matrix — verify dispatch fires this time
- [ ] `/governance` retro on merged diff

[skip-impl-check]

🤖 Generated with [Claude Code](https://claude.com/claude-code)