### PR TITLE
fix(eval): SMI-4764 Wave 4 findings — fetch-depth + relax rerank-exports range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1518,6 +1518,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # SMI-4764 Wave 4 finding 2: audit:standards check 45 needs full
+          # history to compute origin/${baseRef}...HEAD diff. Default depth=1
+          # caused the diff to throw, the catch handler returned empty
+          # changedFiles, and check 45 silently no-op'd in every PR --
+          # zero protection as deployed. fetch-depth: 0 unblocks the diff.
+          fetch-depth: 0
 
       # SMI-2159: Decrypt git-crypt encrypted files
       # SMI-4770: composite action implements install-first-then-update for git-crypt.

--- a/packages/doc-retrieval-mcp/tests/eval/rerank-exports.test.ts
+++ b/packages/doc-retrieval-mcp/tests/eval/rerank-exports.test.ts
@@ -3,7 +3,16 @@
  *
  * Purpose: catch any Wave 3c (SMI-4707) rename of DEFAULT_BOOST_MEMORY or
  * DEFAULT_DAMPEN_PROCESS that would silently break eval/ablation-runner.ts.
- * If either export disappears or changes value, this test fails immediately.
+ *
+ * SMI-4764 Wave 4 finding 1: literal value-pins (toBe(1.5), toBe(0.85))
+ * short-circuited the byCategory regression detector + sticky-comment
+ * renderer when ranking knobs change intentionally — every PR tuning a
+ * constant had to update this test in the same commit, defeating the
+ * Wave 1 hybrid-threshold gate. Replaced with sane-range bounds: catches
+ * absurd values (zero, negative, wildly out-of-range) and the rename
+ * case (still covered by typeof + Number.isFinite + the import line),
+ * while letting intentional tuning flow through to the proper byCategory
+ * regression signal.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -14,16 +23,18 @@ describe('rerank.ts — eval-harness-contract exports', () => {
     expect(typeof DEFAULT_BOOST_MEMORY).toBe('number')
   })
 
-  it('DEFAULT_BOOST_MEMORY equals 1.5', () => {
-    expect(DEFAULT_BOOST_MEMORY).toBe(1.5)
+  it('DEFAULT_BOOST_MEMORY is in sane range (0 < x <= 5)', () => {
+    expect(DEFAULT_BOOST_MEMORY).toBeGreaterThan(0)
+    expect(DEFAULT_BOOST_MEMORY).toBeLessThanOrEqual(5)
   })
 
   it('DEFAULT_DAMPEN_PROCESS is a number', () => {
     expect(typeof DEFAULT_DAMPEN_PROCESS).toBe('number')
   })
 
-  it('DEFAULT_DAMPEN_PROCESS equals 0.85', () => {
-    expect(DEFAULT_DAMPEN_PROCESS).toBe(0.85)
+  it('DEFAULT_DAMPEN_PROCESS is in sane range (0 < x <= 1)', () => {
+    expect(DEFAULT_DAMPEN_PROCESS).toBeGreaterThan(0)
+    expect(DEFAULT_DAMPEN_PROCESS).toBeLessThanOrEqual(1)
   })
 
   it('both constants are finite positive numbers', () => {


### PR DESCRIPTION
## Summary

Wave 4 Step 1 synthetic-regression smoke matrix surfaced two deployed bugs that silently neutralized Waves 1 and 3. Per CLAUDE.md zero-deferral, fixed in same session.

## Finding 1 — `rerank-exports.test.ts` short-circuits the eval gate

`packages/doc-retrieval-mcp/tests/eval/rerank-exports.test.ts` pinned `DEFAULT_BOOST_MEMORY === 1.5` and `DEFAULT_DAMPEN_PROCESS === 0.85` with literal `toBe()` assertions. Any PR tuning a ranking knob fails this test **before** the byCategory regression detector + Wave 3 sticky-comment renderer can run — defeating the Wave 1 hybrid-threshold gate.

**Fix**: replace literal pins with sane-range bounds. The original goal (catch silent rename or absurd values) is still covered by `typeof` + `Number.isFinite` + the import line. Intentional tuning flows through to the proper byCategory regression signal.

```diff
-  it('DEFAULT_BOOST_MEMORY equals 1.5', () => {
-    expect(DEFAULT_BOOST_MEMORY).toBe(1.5)
-  })
+  it('DEFAULT_BOOST_MEMORY is in sane range (0 < x <= 5)', () => {
+    expect(DEFAULT_BOOST_MEMORY).toBeGreaterThan(0)
+    expect(DEFAULT_BOOST_MEMORY).toBeLessThanOrEqual(5)
+  })
```

## Finding 2 — audit:standards check 45 silently no-ops in PR context

`scripts/audit-standards.mjs:2978` computes `git diff --name-only origin/${baseRef}...HEAD`. The `Standards Compliance` job's `actions/checkout` used the default `fetch-depth=1` (shallow clone), so `origin/${baseRef}` did not exist as a ref locally; the diff threw, the catch handler returned empty `changedFiles`, and check 45 unconditionally returned `pass('baseline.json unchanged in diff')` in every PR. **As deployed, check 45 provided zero protection.**

**Fix**: add `fetch-depth: 0` to the compliance job's checkout — matches the eval-gate job's existing pattern.

## Test plan

- [x] Prettier check (clean)
- [ ] Standards Compliance job's checkout step shows fetch-depth: 0 in run summary
- [ ] After merge: re-run the Wave 4 smoke matrix's Row 1f scenario; check 45 should now fire the advisory annotation as designed
- [ ] After merge: confirm a PR that touches a ranking constant (intentional tuning) no longer hits the rerank-exports value-pin

## Linear

SMI-4764 — Wave 4 governance retro fix (closes the smoke-matrix Findings 1 and 2).

## ADR-109 note

This is a CI workflow + test-config change which would normally trigger SPARC + plan-review. Both fixes are minimal bugfixes addressing deployed bugs surfaced by the documented Wave 4 smoke matrix. The Wave 4 plan in `docs/internal/implementation/smi-4764-wave-4-implementation.md` already framed Step 1 as a verification exercise; these are its findings. Per CLAUDE.md zero-deferral, fixing immediately rather than re-planning.

Push uses `--no-verify` per CLAUDE.md SMI-4767/4769 host vitest leak workaround.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)