### PR TITLE
SMI-4830 retro: index.md drift fixes (root + submodule)

### DIFF
--- a/.claude/templates/index.md
+++ b/.claude/templates/index.md
@@ -14,6 +14,7 @@ Reusable templates for common documentation and development tasks.
 | [implementation-plan.md](implementation-plan.md) | Implementation plan structure for `docs/internal/implementation/` |
 | [migration-review-checklist.md](migration-review-checklist.md) | Migration code review checklist |
 | [beta-invite-email.md](beta-invite-email.md) | Beta invite email template (Resend HTML) |
+| [history-rewrite-notification.md](history-rewrite-notification.md) | Notification template for git history rewrites (re-clone instructions) |
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Post-merge governance retro on SMI-4830 (#1049) surfaced 8 issues. This PR resolves the structural ones in one pass:

- **M1** — `docs/internal/index.md` had 12 folder-count drifts. Submodule PR smith-horn/skillsmith-docs#145 (squash-merged at `fb6c7316`) fixes them all. This PR bumps the submodule pointer.
- **M2** — `.claude/development/index.md` was missing `eval-cron-setup.md`. Added.
- **M3** — `.claude/templates/index.md` was missing `history-rewrite-notification.md`. Added.
- **M4 + L1** — Plan amendments on `smi-4830-skillsmith-harness-coexistence.md` (template carve-out note + "Execution prerequisites" → "Execution log" with checkmarks) — included in submodule PR.
- **H1** — Linear labels were already fixed via MCP round-trip on SMI-4830/4831/4832/4833/4834 (no PR needed).
- **L3** — Local plan-mode artifact cleanup will follow this PR's merge.

## Linear

[SMI-4830](https://linear.app/smith-horn-group/issue/SMI-4830) (Done) — retro follow-ups bundled here per CLAUDE.md "fix all governance findings in same PR cycle, no deferral."

## Test plan

- [x] Verified `ls <folder>/*.md | wc -l` matches updated counts in submodule index.md
- [x] Verified `eval-cron-setup.md` and `history-rewrite-notification.md` exist as files
- [x] Pre-push hook green via `SKILLSMITH_PRE_PUSH_DOCKER=1` (host rollup native-binding gap unchanged from #1049)
- [ ] Required CI checks green

## CI markers

`[skip-impl-check]` — docs-only PR (3 index.md files + submodule pointer bump). No source changes.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)