### PR TITLE
fix(website): SMI-4835 user-feedback pivot — auth parity, catalog reframe, positioning

### DIFF
--- a/packages/website/src/components/SignedOutOverlay.astro
+++ b/packages/website/src/components/SignedOutOverlay.astro
@@ -3,10 +3,16 @@
  * SignedOutOverlay
  *
  * SMI-4401 Wave 2 — Soft sign-in overlay for anonymous humans on /skills (spec §5.5).
+ * SMI-4837 — race fix: render hidden by default, reveal only when getSession() resolves
+ * to null AND no auth event arrives within a 250ms grace window.
  *
  * Rendering policy:
  * - SSR frontmatter in the caller MUST gate this component with
  *   `{!isCrawler && <SignedOutOverlay />}` (L7). Crawlers never receive the markup.
+ * - SMI-4837: overlay is rendered with the `hidden` attribute by default. Client script
+ *   reveals it only after confirming no live Supabase session exists. This eliminates the
+ *   cold-load race where the inline IIFE would run before the Supabase client (initialized
+ *   under astro:page-load in BaseLayout) had written the auth token to localStorage.
  * - Client-side, the overlay removes itself from DOM when a Supabase session is
  *   detected (not just hidden — DOM removal unblocks tab-nav a11y).
  * - A dismiss CTA writes `localStorage['skills_overlay_dismissed_until']` with a
@@ -34,6 +40,7 @@ import LoginButton from './auth/LoginButton.astro'
   aria-modal="false"
   aria-label="Sign in to continue"
   data-hidden-when-auth="true"
+  hidden
 >
   <div class="overlay-card">
     <h2 class="overlay-heading">Sign in to browse the full catalog</h2>
@@ -54,62 +61,124 @@ import LoginButton from './auth/LoginButton.astro'
   </div>
 </div>
 
-<script is:inline>
-  ;(function () {
-    var DISMISS_KEY = 'skills_overlay_dismissed_until'
-    var overlay = document.getElementById('signed-out-overlay')
+<script>
+  // SMI-4837: deferred module script — runs after the BaseLayout astro:page-load handler
+  // has had a chance to initialize window.__SUPABASE_CLIENT__. Subscribes to auth state
+  // and queries getSession() to decide whether to reveal the overlay. Preserves the 7-day
+  // dismiss tracking and DOM-removal-on-session behavior of the prior inline IIFE.
+  import { getSupabaseClient } from '../lib/supabase-client'
+
+  const DISMISS_KEY = 'skills_overlay_dismissed_until'
+  // Grace window: if onAuthStateChange fires within this many ms with a session, suppress
+  // the overlay even when getSession() initially resolved null. Covers cold-load timing
+  // where the singleton hydrates after the script runs.
+  const AUTH_GRACE_MS = 250
+
+  function setupOverlay() {
+    const overlay = document.getElementById('signed-out-overlay')
     if (!overlay) return
 
-    // Session-aware: if a @supabase/supabase-js v2 session exists and is not expired,
-    // remove the overlay immediately. Reads the sb-<project-ref>-auth-token localStorage
-    // key directly to avoid a full client init. Matches the JSDoc contract at :10-11.
-    try {
-      var keys = Object.keys(localStorage)
-      for (var i = 0; i < keys.length; i++) {
-        var k = keys[i]
-        if (k.indexOf('sb-') !== 0 || !/-auth-token$/.test(k)) continue
-        var raw = localStorage.getItem(k)
-        if (!raw) continue
-        var parsed = JSON.parse(raw)
-        var expiresAt = parsed && parsed.expires_at
-        if (typeof expiresAt === 'number' && expiresAt * 1000 > Date.now()) {
-          overlay.remove()
-          return
+    // Wire dismiss handler immediately — works regardless of auth state path below.
+    const dismissBtn = document.getElementById('overlay-dismiss')
+    if (dismissBtn) {
+      dismissBtn.addEventListener('click', () => {
+        try {
+          const sevenDays = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+          localStorage.setItem(DISMISS_KEY, sevenDays)
+        } catch {
+          /* no-op: dismiss still works for this session */
         }
-      }
-    } catch (_e) {
-      /* localStorage / JSON.parse failed — fall through to dismissal check */
+        overlay.remove()
+      })
     }
 
-    // On load: if a non-expired dismissal exists, remove the overlay; otherwise sweep a stale key.
+    // 7-day dismissal: if a live dismissal exists, remove overlay immediately and skip
+    // the auth check entirely. Sweep stale values on the way through.
     try {
-      var storedUntil = localStorage.getItem(DISMISS_KEY)
+      const storedUntil = localStorage.getItem(DISMISS_KEY)
       if (storedUntil) {
-        var untilMs = Date.parse(storedUntil)
+        const untilMs = Date.parse(storedUntil)
         if (!isNaN(untilMs) && untilMs > Date.now()) {
           overlay.remove()
           return
         }
         localStorage.removeItem(DISMISS_KEY)
       }
-    } catch (_e) {
-      /* localStorage unavailable (private mode, policy) — fall through to visible render */
+    } catch {
+      /* localStorage unavailable — fall through to auth check */
     }
 
-    // Dismiss handler: write 7-day expiry then remove overlay from DOM.
-    var dismissBtn = document.getElementById('overlay-dismiss')
-    if (dismissBtn) {
-      dismissBtn.addEventListener('click', function () {
-        try {
-          var sevenDays = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
-          localStorage.setItem(DISMISS_KEY, sevenDays)
-        } catch (_e) {
-          /* no-op: dismiss still works for this session */
-        }
-        overlay.remove()
-      })
+    // Subscribe BEFORE calling getSession so a token-write between subscribe-and-resolve
+    // is captured. authResolved guards against double-handling.
+    let authResolved = false
+    let supabase: ReturnType<typeof getSupabaseClient> | null = null
+    try {
+      supabase = getSupabaseClient()
+    } catch {
+      /* Config missing — fall back to anon path (overlay reveals after grace) */
     }
-  })()
+
+    const handleSignedIn = () => {
+      if (authResolved) return
+      authResolved = true
+      overlay.remove()
+    }
+
+    const handleSignedOut = () => {
+      if (authResolved) return
+      authResolved = true
+      overlay.removeAttribute('hidden')
+    }
+
+    let unsubscribe: (() => void) | null = null
+    if (supabase) {
+      const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+        if (authResolved) return
+        if (session) {
+          handleSignedIn()
+          if (unsubscribe) unsubscribe()
+        }
+      })
+      unsubscribe = () => {
+        try {
+          data.subscription.unsubscribe()
+        } catch {
+          /* no-op */
+        }
+      }
+
+      // Resolve initial state. If a session exists, hide; if not, wait AUTH_GRACE_MS
+      // for onAuthStateChange to fire (covers cold-load token-write race) before revealing.
+      supabase.auth
+        .getSession()
+        .then(({ data: sessionData }) => {
+          if (authResolved) return
+          if (sessionData?.session) {
+            handleSignedIn()
+            if (unsubscribe) unsubscribe()
+            return
+          }
+          // No session yet — give the singleton a grace window to fire onAuthStateChange.
+          window.setTimeout(() => {
+            if (authResolved) return
+            handleSignedOut()
+          }, AUTH_GRACE_MS)
+        })
+        .catch(() => {
+          if (!authResolved) handleSignedOut()
+        })
+    } else {
+      // No Supabase client available — reveal after grace so signed-in users on a
+      // misconfigured page aren't unfairly prompted instantly, and the page still
+      // surfaces the CTA for anon visitors.
+      window.setTimeout(() => {
+        if (!authResolved) handleSignedOut()
+      }, AUTH_GRACE_MS)
+    }
+  }
+
+  // Astro ClientRouter: setup on every page load (initial + transition).
+  document.addEventListener('astro:page-load', setupOverlay)
 </script>
 
 <style>

--- a/packages/website/src/data/featured-skills.json
+++ b/packages/website/src/data/featured-skills.json
@@ -1,0 +1,56 @@
+{
+  "_comment": "SMI-4838: Curated set of example skills demonstrating the Agent Skills SDK lifecycle (author -> test -> ship -> govern -> retire). All entries verified against the production indexer DB on 2026-05-09. Use 'author/name' format — `/skills/[id]` resolves either UUID or author/name.",
+  "_lifecycle_stages": ["author", "test", "ship", "govern", "secure", "review"],
+  "skills": [
+    {
+      "id": "anthropics/mcp-builder",
+      "stage": "author",
+      "rationale": "Anthropic's first-party guide to building MCP servers — the foundation any team needs when authoring agent integrations."
+    },
+    {
+      "id": "addyosmani/test-driven-development",
+      "stage": "test",
+      "rationale": "Verified TDD skill — keeps agent-authored code under test before it ships."
+    },
+    {
+      "id": "anthropics/webapp-testing",
+      "stage": "test",
+      "rationale": "Anthropic-authored web app testing skill — repeatable test scaffolding for shipped skills."
+    },
+    {
+      "id": "google-gemini/ci",
+      "stage": "ship",
+      "rationale": "Google Gemini CI skill — shows how a skill drives continuous integration for agent workflows."
+    },
+    {
+      "id": "addyosmani/ci-cd-and-automation",
+      "stage": "ship",
+      "rationale": "End-to-end CI/CD automation with verified provenance."
+    },
+    {
+      "id": "addyosmani/shipping-and-launch",
+      "stage": "ship",
+      "rationale": "Launch-readiness checks teams run before promoting a skill to prod."
+    },
+    {
+      "id": "google-gemini/code-reviewer",
+      "stage": "review",
+      "rationale": "Verified code-review skill — adds a governance gate to agent-driven changes."
+    },
+    {
+      "id": "addyosmani/security-and-hardening",
+      "stage": "secure",
+      "rationale": "Security and hardening guide for agent-managed code paths."
+    },
+    {
+      "id": "google-gemini/behavioral-evals",
+      "stage": "govern",
+      "rationale": "Behavioral evals for agent skills — the empirical layer of skill governance."
+    },
+    {
+      "id": "addyosmani/context-engineering",
+      "stage": "author",
+      "rationale": "Context-engineering skill — elevates authoring quality for teams writing their own skills."
+    }
+  ]
+}

--- a/packages/website/src/lib/pricing-data.ts
+++ b/packages/website/src/lib/pricing-data.ts
@@ -79,7 +79,8 @@ export const pricingTiers: PricingTier[] = [
     id: 'community',
     name: 'Community',
     monthlyPrice: 0,
-    description: 'Perfect for exploring Skillsmith and personal projects.',
+    // SMI-4839: free dev surface of the Agent Skills SDK
+    description: 'The free dev surface for the Agent Skills SDK and registry.',
     apiCalls: 1000,
     apiCallsFormatted: '1,000 API calls/month',
     features: [
@@ -97,7 +98,8 @@ export const pricingTiers: PricingTier[] = [
     name: 'Individual',
     monthlyPrice: 9.99,
     period: '/month',
-    description: 'For developers who want deeper insights into their skill usage.',
+    // SMI-4839: solo builders working across multiple agents/projects
+    description: 'For solo builders authoring and using skills across multiple projects.',
     apiCalls: 10000,
     apiCallsFormatted: '10,000 API calls/month',
     features: [
@@ -115,7 +117,8 @@ export const pricingTiers: PricingTier[] = [
     name: 'Team',
     monthlyPrice: 25,
     period: '/user/month',
-    description: 'Collaborate on skills with your entire team.',
+    // SMI-4839: SDK-for-teams positioning — author, version, govern, retire
+    description: 'The Agent Skills SDK for teams — author, version, govern, and retire together.',
     apiCalls: 100000,
     apiCallsFormatted: '100,000 API calls/month',
     features: [
@@ -132,7 +135,8 @@ export const pricingTiers: PricingTier[] = [
     name: 'Enterprise',
     monthlyPrice: 55,
     period: '/user/month',
-    description: 'Advanced security, compliance, and dedicated support for organizations.',
+    // SMI-4839: SDK-for-teams at org scale — governance, compliance, dedicated support
+    description: 'The SDK at org scale — governance, compliance, and dedicated support.',
     apiCalls: 'unlimited',
     apiCallsFormatted: 'Unlimited API calls',
     features: [

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -271,21 +271,18 @@ const jsonLd = {
             Create, Optimize, <br />and Secure Agent Skills.
           </h1>
 
-          <!-- Subheadline -->
+          <!-- Subheadline (SMI-4839: SDK-for-teams positioning, ≤20 words) -->
           <p
             class="text-lg sm:text-xl text-[#A1A1AA] max-w-[600px] mx-auto mb-10 opacity-0 animate-fade-up"
             style="animation-delay: 0.08s;"
           >
-            <span id="github-total" class="hidden"
-              ><span id="github-total-count">20,000+</span> skills on GitHub &mdash;
-            </span><span id="skill-count">14,000+</span> curated &amp; verified. Searchable from within
-            your project by your agent.<br />
-            From version control to replicable agent skill frameworks, Skillsmith has you covered.
+            The Agent Skills SDK for teams &mdash; author, version, govern, and retire skills across
+            your org.
           </p>
 
           <!-- CTA Buttons -->
           <div
-            class="flex flex-col sm:flex-row gap-4 justify-center mb-6 opacity-0 animate-fade-up"
+            class="flex flex-col sm:flex-row gap-4 justify-center mb-3 opacity-0 animate-fade-up"
             style="animation-delay: 0.12s;"
           >
             <a
@@ -296,12 +293,22 @@ const jsonLd = {
               Get Started Free →
             </a>
             <a
-              href="#mcp-install-block"
+              href="/docs"
               class="px-8 py-4 border border-white/10 rounded-xl font-medium text-white hover:border-white/20 transition-colors text-center focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0D0D0F] focus-visible:outline-none"
             >
-              Install MCP Server
+              Read the SDK docs
             </a>
           </div>
+          <!-- SMI-4836: email-login parity — secondary text link beneath the GitHub-default CTA -->
+          <p class="text-sm mb-6 opacity-0 animate-fade-up" style="animation-delay: 0.13s;">
+            <a
+              href="/login"
+              data-cta="email-login"
+              class="text-[#A1A1AA] hover:text-white underline-offset-4 hover:underline transition-colors focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0D0D0F] focus-visible:outline-none rounded-sm"
+            >
+              or sign in with email
+            </a>
+          </p>
 
           <!-- Social Proof -->
           <p
@@ -511,12 +518,17 @@ const jsonLd = {
         </div>
       </section>
 
-      <!-- Problem/Solution Section -->
+      <!-- Problem/Solution Section (SMI-4839: lifecycle reframe) -->
       <section class="py-24">
         <div class="max-w-[1000px] mx-auto px-6">
-          <h2 class="text-3xl sm:text-4xl font-bold text-center mb-12">
-            The skill discovery problem
+          <h2 class="text-3xl sm:text-4xl font-bold text-center mb-6">
+            The skill lifecycle problem
           </h2>
+          <p class="text-[#A1A1AA] text-center max-w-[700px] mx-auto mb-12">
+            Skills sprawl across teams: no source-of-truth, no governance, no lifecycle. Skillsmith
+            gives your org a single SDK and registry to author, distribute, govern, and retire
+            skills.
+          </p>
 
           <div class="grid md:grid-cols-2 gap-6">
             <!-- Without Skillsmith -->
@@ -527,19 +539,23 @@ const jsonLd = {
               <ul class="space-y-4">
                 <li class="flex items-start gap-3">
                   <span class="text-[#71717A] mt-0.5">✕</span>
-                  <span class="text-[#A1A1AA]">Manual searches across fragmented sources</span>
+                  <span class="text-[#A1A1AA]"
+                    >Skills scattered across forks, gists, and shared drives</span
+                  >
                 </li>
                 <li class="flex items-start gap-3">
                   <span class="text-[#71717A] mt-0.5">✕</span>
-                  <span class="text-[#A1A1AA]">No quality signals or verification</span>
+                  <span class="text-[#A1A1AA]">No source-of-truth for which version teams run</span>
                 </li>
                 <li class="flex items-start gap-3">
                   <span class="text-[#71717A] mt-0.5">✕</span>
-                  <span class="text-[#A1A1AA]">Trial and error installations</span>
+                  <span class="text-[#A1A1AA]">No governance, audit trail, or retirement path</span>
                 </li>
                 <li class="flex items-start gap-3">
                   <span class="text-[#71717A] mt-0.5">✕</span>
-                  <span class="text-[#A1A1AA]">Missing skills that would save time</span>
+                  <span class="text-[#A1A1AA]"
+                    >Authoring is ad-hoc &mdash; every team reinvents the basics</span
+                  >
                 </li>
               </ul>
             </div>
@@ -553,20 +569,27 @@ const jsonLd = {
                 <li class="flex items-start gap-3">
                   <span class="text-[#81B29A] mt-0.5">✓</span>
                   <span class="text-[#FAFAFA]"
-                    >Semantic search across <span id="skill-count-feature">14,000+</span> curated skills</span
+                    >One SDK and registry for your org &mdash; author, version, govern, retire</span
                   >
                 </li>
                 <li class="flex items-start gap-3">
                   <span class="text-[#81B29A] mt-0.5">✓</span>
-                  <span class="text-[#FAFAFA]">Quality scores you can trust</span>
+                  <span class="text-[#FAFAFA]"
+                    >Quality scores, signed publishes, audit logs you can trust</span
+                  >
                 </li>
                 <li class="flex items-start gap-3">
                   <span class="text-[#81B29A] mt-0.5">✓</span>
-                  <span class="text-[#FAFAFA]">Stack-aware recommendations</span>
+                  <span class="text-[#FAFAFA]"
+                    >MCP, CLI, and VS Code surfaces over the same registry</span
+                  >
                 </li>
                 <li class="flex items-start gap-3">
                   <span class="text-[#81B29A] mt-0.5">✓</span>
-                  <span class="text-[#FAFAFA]">Discover skills before you need them</span>
+                  <span class="text-[#FAFAFA]"
+                    >Stack-aware recommendations from <span id="skill-count-feature">14,000+</span>
+                    curated examples</span
+                  >
                 </li>
               </ul>
             </div>
@@ -716,6 +739,16 @@ const jsonLd = {
               View Pricing
             </a>
           </div>
+          <!-- SMI-4836: email-login parity — secondary text link beneath the GitHub-default CTA -->
+          <p class="text-sm mt-3">
+            <a
+              href="/login"
+              data-cta="email-login-final"
+              class="text-[#A1A1AA] hover:text-white underline-offset-4 hover:underline transition-colors focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#0D0D0F] focus-visible:outline-none rounded-sm"
+            >
+              or sign in with email
+            </a>
+          </p>
         </div>
       </section>
     </main>

--- a/packages/website/src/pages/product.astro
+++ b/packages/website/src/pages/product.astro
@@ -155,13 +155,13 @@ function cellClass(value: string): string {
   activePath="/product"
 >
   <section class="product-hero">
-    <p class="product-eyebrow">Three ways to reach the same registry</p>
+    <!-- SMI-4839: SDK-for-teams reframe — surfaces are lifecycle access points, not discovery only. -->
+    <p class="product-eyebrow">Three surfaces for your team's skill lifecycle</p>
     <h1>MCP for any agent. CLI for the terminal. VS Code for the editor.</h1>
     <p class="product-subtitle">
-      One local skill database. One API key. Three surfaces designed for different workflows. Pick
-      the one that fits where you already work — or use all three. (Throughout this page, <em
-        >MCP</em
-      >
+      One local skill database. One API key. Three surfaces over the same registry — author,
+      distribute, govern, and retire skills from wherever your team already works. (Throughout this
+      page, <em>MCP</em>
       means the Model Context Protocol — the standard agents like Claude Code, Cursor, Copilot, Codex,
       and Windsurf use to talk to external tools.)
     </p>

--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -403,7 +403,27 @@ const categoryJsonLd =
           </div>
 
           <div class="bg-dark-900 rounded-xl border border-dark-800 p-8 mb-8">
-            <h2 class="text-xl font-semibold text-white mb-4">Installation</h2>
+            <div class="flex items-start justify-between gap-4 mb-4 flex-wrap">
+              <h2 class="text-xl font-semibold text-white">Installation</h2>
+              <a
+                id="skill-source-link"
+                data-smi="4840"
+                href="#"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="View source on GitHub (opens in new tab)"
+                class="hidden inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-dark-300 hover:text-white border border-dark-700 hover:border-primary-500/50 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+              >
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"
+                  />
+                </svg>
+                <span>View source</span>
+              </a>
+            </div>
             <p class="text-dark-400 mb-4">
               Install this skill using the Skillsmith CLI or MCP server:
             </p>
@@ -724,6 +744,22 @@ const categoryJsonLd =
         const contentSection = document.getElementById('skill-content-section')
         readmeEl.textContent = skill.content
         contentSection.classList.remove('hidden')
+      }
+
+      // SMI-4840: Render "View source" link when skill.repo_url is a valid https URL.
+      // Hide gracefully when null/undefined or non-https (seed/metadata-only skills).
+      const sourceLink = document.getElementById('skill-source-link')
+      if (sourceLink) {
+        const repoUrl =
+          typeof skill.repo_url === 'string' && skill.repo_url.startsWith('https://')
+            ? skill.repo_url
+            : ''
+        if (repoUrl) {
+          sourceLink.setAttribute('href', repoUrl)
+          sourceLink.classList.remove('hidden')
+        } else {
+          sourceLink.classList.add('hidden')
+        }
       }
 
       // Show content

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -4,6 +4,12 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 // Overlay markup is never emitted to crawlers so organic skills traffic remains indexable.
 import SignedOutOverlay from '../../components/SignedOutOverlay.astro'
 import { isCrawlerUserAgent } from '../../lib/crawler-detect'
+// SMI-4838: featured-skills catalog seed — pinned author/name set verified against indexer DB.
+import featuredSkillsData from '../../data/featured-skills.json'
+
+const FEATURED_SKILL_IDS: string[] = (featuredSkillsData.skills as Array<{ id: string }>).map(
+  (s) => s.id
+)
 
 const categories = [
   { value: '', label: 'All Categories' },
@@ -127,13 +133,14 @@ const isCrawler = isCrawlerUserAgent(userAgent)
     }
     {!isCrawler && <SignedOutOverlay data-hidden-when-auth="true" />}
 
-    <!-- Header -->
+    <!-- Header (SMI-4838/4839: examples-catalog reframe) -->
     <div class="text-center mb-12">
       <h1 class="text-4xl md:text-5xl font-bold mb-4">
-        Discover <span class="gradient-text">Skills</span>
+        Examples <span class="gradient-text">catalog</span>
       </h1>
       <p class="text-dark-400 text-lg max-w-2xl mx-auto">
-        Search through our collection of verified skills to enhance your development experience.
+        Curated example skills demonstrating the Agent Skills SDK lifecycle &mdash; author, test,
+        ship, govern, and retire. Search the full registry below.
       </p>
     </div>
 
@@ -294,23 +301,22 @@ const isCrawler = isCrawlerUserAgent(userAgent)
       <p class="text-dark-500">Try adjusting your search or filters</p>
     </div>
 
-    <!-- Search Prompt State (shown when no query entered) -->
-    <div id="search-prompt-state" class="hidden text-center py-12">
-      <svg
-        class="w-16 h-16 mx-auto text-primary-500 mb-4"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
+    <!-- Featured Examples State (SMI-4838: shown when no query/filter is active). -->
+    <div id="search-prompt-state" class="hidden">
+      <div class="text-center mb-8">
+        <h2 class="text-2xl font-semibold text-white mb-2">Featured examples</h2>
+        <p class="text-dark-400 max-w-2xl mx-auto">
+          A curated walkthrough of the Agent Skills SDK lifecycle. Search above to browse the full
+          registry.
+        </p>
+      </div>
+      <div
+        id="featured-skills-grid"
+        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6"
       >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="1.5"
-          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-      </svg>
-      <h2 class="text-xl font-semibold text-dark-300 mb-2">Start Searching</h2>
-      <p class="text-dark-500 mb-4">Enter a search term or select a filter to browse skills</p>
-      <div class="flex flex-wrap justify-center gap-2 max-w-md mx-auto">
+      </div>
+      <div class="flex flex-wrap justify-center gap-2 max-w-md mx-auto mt-6">
+        <span class="text-dark-500 text-sm w-full text-center mb-1">Or jump to a topic:</span>
         <button
           class="search-suggestion px-3 py-1.5 bg-dark-800 border border-dark-700 rounded-lg text-dark-300 hover:text-white hover:border-primary-500 transition-colors text-sm"
           data-query="testing">testing</button
@@ -385,6 +391,7 @@ const isCrawler = isCrawlerUserAgent(userAgent)
     is:inline
     define:vars={{
       apiBase: `${import.meta.env.PUBLIC_API_BASE_URL || 'https://api.skillsmith.app'}/functions/v1`,
+      FEATURED_SKILL_IDS,
     }}
   >
     const API_BASE = apiBase
@@ -643,8 +650,9 @@ const isCrawler = isCrawlerUserAgent(userAgent)
         const hasFilter = category || trustTier
 
         if (!hasQuery && !hasFilter) {
+          // SMI-4838: empty query falls back to the featured-examples view, not a blank prompt.
           showState('search-prompt')
-          resultsCount.textContent = 'Enter a search term or select a filter'
+          resultsCount.textContent = 'Showing featured examples'
           allResults = []
           return
         }
@@ -916,10 +924,43 @@ const isCrawler = isCrawlerUserAgent(userAgent)
         })
       })
 
-      // SMI-2081: Initialize auth then show search prompt
-      initAuth().then(() => {
+      // SMI-4838: Featured-examples loader. Fetch each pinned skill in parallel via skills-get,
+      // render into #featured-skills-grid using the same card markup as search results. Failures
+      // are non-fatal — a missing skill is silently skipped.
+      async function loadFeaturedSkills() {
+        const grid = document.getElementById('featured-skills-grid')
+        if (!grid || !Array.isArray(FEATURED_SKILL_IDS) || FEATURED_SKILL_IDS.length === 0) return
+        try {
+          const results = await Promise.all(
+            FEATURED_SKILL_IDS.map(async (id) => {
+              try {
+                const res = await fetch(`${API_BASE}/skills-get/${encodeURIComponent(id)}`, {
+                  headers: {
+                    Authorization: `Bearer ${authToken}`,
+                    'Content-Type': 'application/json',
+                  },
+                })
+                if (!res.ok) return null
+                const body = await res.json()
+                return body?.data ?? null
+              } catch {
+                return null
+              }
+            })
+          )
+          const skills = results.filter((s) => s && s.id)
+          if (skills.length === 0) return
+          grid.innerHTML = skills.map(createSkillCard).join('')
+        } catch (e) {
+          console.debug('[Skills] featured-skills load failed:', e?.message)
+        }
+      }
+
+      // SMI-2081 + SMI-4838: Initialize auth, load featured examples, then show featured state.
+      initAuth().then(async () => {
+        await loadFeaturedSkills()
         showState('search-prompt')
-        resultsCount.textContent = 'Enter a search term or select a filter'
+        resultsCount.textContent = 'Showing featured examples'
       })
     }) // End astro:page-load handler
   </script>


### PR DESCRIPTION
## Summary

Bundle five sub-issues from the 2026-05-09 user-feedback pivot into a single PR (per the plan-reviewed implementation doc at `docs/internal/implementation/smi-4835-user-feedback-pivot.md`).

- **W1 — SMI-4836 — Email-login parity (homepage):** "or sign in with email" text link beneath both GitHub primary CTAs (hero + final CTA). Hero secondary button changed from "Install MCP Server" to "Read the SDK docs" (links to `/docs`) per the SDK reframe.
- **W2 — SMI-4837 — `/skills` SignedOutOverlay race fix:** Render hidden by default, replace `is:inline` IIFE with a deferred module script using the shared `window.__SUPABASE_CLIENT__` singleton via `getSupabaseClient()`. Subscribe to `onAuthStateChange` AND call `getSession()` on mount; reveal overlay only when `getSession()` resolves null AND no auth event arrives within a 250ms grace window. 7-day dismiss tracking (`skills_overlay_dismissed_until`) preserved verbatim.
- **W3 — SMI-4838 — `/skills` examples-catalog reframe:** Hero copy rewritten to "Examples catalog" lifecycle framing. New `featured-skills.json` (10 verified SDK lifecycle examples — anthropics, google-gemini, addyosmani; all IDs verified against the prod indexer DB on 2026-05-09). Default view (no query) renders the featured set instead of the empty "Start Searching" prompt.
- **W4 — SMI-4839 — Positioning rewrite:** Homepage subhead (15 words, ≤20-word budget); problem section retitled "The skill lifecycle problem" with author/version/govern/retire framing; `product.astro` eyebrow changed from "Three ways to reach the same registry" to "Three surfaces for your team's skill lifecycle"; `pricing-data.ts` tier descriptions reframed (Community = free dev surface; Individual = solo builders; Team = SDK for teams; Enterprise = SDK at org scale). **No tier or price changes.**
- **W5 — SMI-4840 — "View source" link on `/skills/[id]`:** Renders when `skill.repo_url` is a valid `https://` URL. `aria-label="View source on GitHub (opens in new tab)"`; `target="_blank"` + `rel="noopener noreferrer"`. Hidden gracefully for metadata-only skills.

## Surface grounding (SMI-4454 P-1, P-2)

Per the plan, every cross-surface reference was verified before edit:

| Surface | Canonical line / token | Verified |
|---|---|---|
| `/login` (email CTA target) | `packages/website/src/pages/login.astro` | exists; email auth available |
| `window.__SUPABASE_CLIENT__` | `packages/website/src/lib/supabase-client.ts:18-26`, `BaseLayout.astro:133-139` | `getSupabaseClient()` singleton |
| `sb-*-auth-token` localStorage | (replaced — now handled via SDK `getSession`) | n/a |
| `skill.repo_url` field on detail | `supabase/functions/skills-search/index.ts:204,237` and `skills-get` (`select('*')`) | DB column name confirmed; plan said `skill.repository` but actual API field is `repo_url` |
| `skills_overlay_dismissed_until` | preserved verbatim | confirmed |
| `featured-skills.json` (NEW) | 10 IDs verified via `skills-get/<author/name>` against prod (vrcnzpmndtroqxxoqkzy) — all 10 returned valid records |
| `/product` "Three ways to reach the same registry" | `product.astro:158` (eyebrow) | replaced |
| `/pricing` tier descriptions | `pricing-data.ts:80,97,115,132` (descriptions in data file, not page markup) | reframed |

**Field-name correction:** Plan referenced `skill.repository` per `packages/core/src/types.ts:80`. The detail page reads from `skills-get` which `SELECT * FROM skills`, returning the DB column `repo_url`. Used `skill.repo_url` to match the API contract; `repository` only exists on the core `Skill` type used by the CLI/MCP-server, not the website's edge-function payload.

## Featured skills seed (W3)

The 10 IDs in `featured-skills.json` cover the SDK lifecycle:

| Stage | Skill | Author | Trust |
|---|---|---|---|
| author | mcp-builder | anthropics | verified |
| author | context-engineering | addyosmani | verified |
| test | test-driven-development | addyosmani | verified |
| test | webapp-testing | anthropics | verified |
| ship | ci | google-gemini | verified |
| ship | ci-cd-and-automation | addyosmani | verified |
| ship | shipping-and-launch | addyosmani | verified |
| review | code-reviewer | google-gemini | verified |
| secure | security-and-hardening | addyosmani | verified |
| govern | behavioral-evals | google-gemini | verified |

All 10 IDs verified against `https://vrcnzpmndtroqxxoqkzy.supabase.co/functions/v1/skills-get/<author>/<name>` on 2026-05-09 — every one resolved.

## Verification

Run from the worktree (using main `skillsmith-dev-1` container with `-w` per memory; worktree node_modules has virtiofs symlink issues):

- [x] `astro check` — 0 errors / 0 warnings / 0 hints across **119 files**
- [x] `astro build` — clean (pre-existing prerender warnings on routes I did not touch)
- [x] ESLint — clean on all 6 modified files
- [x] Prettier — clean (auto-formatted via lint-staged on commit)
- [x] `audit:standards` — **100%** (64 passed, 0 warnings, 0 failed)
- [x] Pre-push (with `SKILLSMITH_PRE_PUSH_DOCKER=1` per memory SMI-4767) — security tests, npm audit, secrets scan, format, test all pass

## Test plan

- [ ] **W1:** Visit `/` logged out → hero shows GitHub `Get Started Free →` button + "or sign in with email" text link beneath. Final CTA section also shows the email link below "View Pricing".
- [ ] **W2 (regression test):** Log in via email in a fresh browser profile, then direct-navigate to `/skills` (cold load, no refresh). The `SignedOutOverlay` must NOT appear at any point during the page lifecycle. (No Playwright fixture exists for this overlay; manual repro is the verification per the plan.)
- [ ] **W2 (preserved behavior):** Log out → revisit `/skills` → overlay appears. Click "Preview anonymously" → overlay disappears, refresh → overlay still gone for 7 days.
- [ ] **W3:** Visit `/skills` with no query → "Featured examples" header renders + 10 featured skill cards loaded from `featured-skills.json` (NOT an empty search prompt).
- [ ] **W3 (search baseline):** Type "react" in search → existing search results render unchanged.
- [ ] **W4:** Visit `/`, `/product`, `/pricing` → SDK / lifecycle framing visible (subhead, problem heading, eyebrow, tier descriptions).
- [ ] **W5 (visible):** Click into a skill detail page where `repo_url` is populated (e.g., `/skills/anthropics/mcp-builder`) → "View source" link visible next to the "Installation" heading; clicking opens the GitHub repo in a new tab.
- [ ] **W5 (hidden):** Click into a metadata-only skill (no repo) → "View source" link hidden gracefully.
- [ ] **Lighthouse SEO baseline:** Capture pre-merge for `/`, `/product`, `/pricing`; after deploy, scores must stay within ±2 points (Lighthouse 100 baseline per memory).

## Linear

- Umbrella: SMI-4835 → moving to In Review post-merge.
- Sub-issues: SMI-4836, SMI-4837, SMI-4838, SMI-4839, SMI-4840 — commit SHA `27f8a04d` posted on each; will move to Done after merge.

## Out of scope (filed standalone)

- SMI-4841 — indexer: superpowers/gstack discovery (separate work, indexer team).
- SMI-4842 — indexer: awesome-claude-skills meta-list filter (separate work, indexer team).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)