### PR TITLE
docs(submodule) + fix(infra): SMI-4829 plan + SMI-4820 pre-push security vitest fix

### DIFF
--- a/scripts/pre-push-check.sh
+++ b/scripts/pre-push-check.sh
@@ -121,11 +121,21 @@ fi
 # =============================================================================
 # CHECK 1: Security Test Suite (Optimized - single run)
 # SMI-1366: Uses run_cmd for Docker/local fallback
+# SMI-4820: From worktree-cwd inside Docker, `npm test` (and the worktree-local
+# `./node_modules/.bin/vitest`) fail at module resolution because virtiofs
+# cannot traverse the relative symlink chain SMI-4381 puts in worktree
+# node_modules. Mirroring the SMI-4772 fix in pre-push-coverage-check.sh:
+# invoke vitest binary directly. In Docker, pin to /app/node_modules (always
+# absolute). On host, ./node_modules works (host resolves symlinks fine).
 # =============================================================================
 echo "📋 Running security test suite..."
 
 # Run tests once, capture both output and exit code
-TEST_OUTPUT=$(run_cmd npm test -- packages/core/tests/security/ 2>&1) || TEST_STATUS=$?
+if [ "$USE_DOCKER" = "1" ]; then
+  TEST_OUTPUT=$(docker exec -w "$CONTAINER_WD" "$DOCKER_CONTAINER" /app/node_modules/.bin/vitest run packages/core/tests/security/ 2>&1) || TEST_STATUS=$?
+else
+  TEST_OUTPUT=$(run_cmd ./node_modules/.bin/vitest run packages/core/tests/security/ 2>&1) || TEST_STATUS=$?
+fi
 TEST_STATUS=${TEST_STATUS:-0}
 
 # Display relevant output (filter for test results)


### PR DESCRIPTION
## Summary

- **SMI-4829 implementation plan** (docs/internal pointer bump). Strategic-IP extraction from git-crypt → private submodule under mount-point shape (b). Authored under ADR-109 SPARC + plan-review (Opus 4.7 → VP Product/Eng/Design → 10 edits applied).
- **SMI-4820 pre-push hook fix**. Security tests fail silently from worktree-cwd inside Docker because virtiofs can't traverse the relative `node_modules` symlink chain. Mirrors the SMI-4772 fix in `pre-push-coverage-check.sh`: invoke vitest binary directly, pin to `/app/node_modules` in Docker.

## Two commits

1. `cc3d0de7` — `docs(submodule): SMI-4829 bump docs/internal — strategy-submodule extraction plan` — submodule pointer to plan + plan-review edits (smith-horn/skillsmith-docs#147)
2. `09404505` — `fix(infra): SMI-4820 pre-push security tests fail silently from worktree-cwd Docker` — 12-line targeted fix to `scripts/pre-push-check.sh` CHECK 1

## Why bundled

The hook fix was discovered while pushing this PR; without it every docs-only push from a macOS worktree blocks on the silent vitest failure. Bundled because the fix is what made this very PR pushable. Easy to review (12 LOC change, mirrors existing SMI-4772 pattern).

## Plan PR

Plan content lives in `smith-horn/skillsmith-docs#147`. This PR only bumps the pointer.

## Test plan

- [x] Pre-push hook now succeeds from worktree-cwd Docker (verified locally, 268/268 security tests pass)
- [ ] Reviewer reads plan in PR-147; flags blockers before Wave 1
- [ ] Reviewer accepts mount-point shape (b) + 30-day rollback threshold + gold-set Decision B
- [ ] Stage 5 (`smith-horn/skillsmith-strategy --private` provisioning) gated on this PR + PR-147 approval

[skip-impl-check] — pure-shell + submodule-pointer change; no production source files modified, so the implementation-completeness verification does not apply.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)