### PR TITLE
chore(retro): SMI-4835 cleanup — dead #skill-count / #github-total refs after hero subhead rewrite

### DIFF
--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -806,14 +806,12 @@ const jsonLd = {
       }
 
       /* Reserve space for dynamic content to prevent CLS */
-      #skill-count,
       #skill-count-feature,
       #skill-count-install {
         display: inline-block;
         min-width: 6ch;
       }
 
-      #github-total-count,
       #github-total-count-install {
         display: inline-block;
         min-width: 8ch;
@@ -1008,12 +1006,10 @@ const jsonLd = {
         }
 
         function updateCount(count) {
-          const el = document.getElementById('skill-count')
           const elFeature = document.getElementById('skill-count-feature')
           const elInstall = document.getElementById('skill-count-install')
           if (count > 0) {
             var formattedCount = formatNumber(count) + '+'
-            if (el) el.textContent = formattedCount
             if (elFeature) elFeature.textContent = formattedCount
             if (elInstall) elInstall.textContent = formattedCount
           }
@@ -1022,14 +1018,10 @@ const jsonLd = {
         function updateGithubTotal(total, skillCount) {
           if (total > 0 && total > skillCount) {
             var formatted = formatNumber(total) + '+'
-            ;['github-total-count', 'github-total-count-install'].forEach(function (id) {
-              var el = document.getElementById(id)
-              if (el) el.textContent = formatted
-            })
-            ;['github-total', 'github-total-install'].forEach(function (id) {
-              var el = document.getElementById(id)
-              if (el) el.classList.remove('hidden')
-            })
+            var elInstallCount = document.getElementById('github-total-count-install')
+            if (elInstallCount) elInstallCount.textContent = formatted
+            var elInstall = document.getElementById('github-total-install')
+            if (elInstall) elInstall.classList.remove('hidden')
           }
         }
 


### PR DESCRIPTION
## Summary

Post-merge governance retro on PR #1051 (squash `30b2791b`) found dead-id references in `packages/website/src/pages/index.astro` left behind by the W4 hero subhead rewrite.

- The hero subhead removed `<span id="skill-count">` and `<span id="github-total">` (replaced with the SDK-for-teams ≤20-word subhead).
- CSS rule at L809–820 and JS update path at L1011/1025–1032 still referenced those IDs.
- JS was null-guarded → no runtime error shipped.
- Cleanup: removed dead CSS rule entries; collapsed the now-redundant `['…', '…-install']` loops to direct `-install` lookups.

## Test plan

- [x] `docker exec skillsmith-dev-1 npm run lint` — clean
- [x] `docker exec skillsmith-dev-1 npx prettier --check packages/website/src/pages/index.astro` — clean
- [x] Verified surviving consumers: `#skill-count-feature`, `#skill-count-install`, `#github-total-install`, `#github-total-count-install` — all referenced in template, all still wired in JS update functions.
- [x] No callers of removed IDs in `packages/website/src/pages/account/team/index.astro` (it has its own scoped `#skill-count` element + script — different page, different scope).

## Out of scope (notes)

- **Retro doc + implementation plan** are written to `docs/internal/retros/2026-05-09-smi-4835-user-feedback-pivot.md` and `docs/internal/implementation/smi-4835-user-feedback-pivot.md` but **untracked in the docs submodule** — the submodule is currently on `smi-4764-wave-4-plan` with another in-flight session. Will commit those in a clean submodule sync once that WIP is resolved (don't want to contaminate the active branch).
- **Pre-existing 500-line violations** carried forward by PR #1051: `index.astro` 1056→1089, `skills/index.astro` 954→995, `skills/[id].astro` 868→904. All were over the standard pre-PR; tracked alongside the SMI-4796 series (audit:standards warn-vs-fail gap).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)