### PR TITLE
fix(website): SMI-4835 follow-up — guard persistent astro:page-load listeners against cross-page firing

### DIFF
--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -655,10 +655,14 @@ const categoryJsonLd =
 
     // Show error state
     function showError(message) {
-      loadingState.classList.add('hidden')
-      skillContent.classList.add('hidden')
-      errorState.classList.remove('hidden')
-      errorMessage.textContent = message
+      // Defensive: refs are normally captured at lines 630-634 against markup
+      // that always renders for !isCategory pages. Guard anyway — a failure here
+      // (e.g. async fetchSkill catch firing after a ClientRouter detach) should
+      // not throw a confusing null-deref over the underlying error message.
+      if (loadingState) loadingState.classList.add('hidden')
+      if (skillContent) skillContent.classList.add('hidden')
+      if (errorState) errorState.classList.remove('hidden')
+      if (errorMessage) errorMessage.textContent = message
     }
 
     // Render skill details

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -400,6 +400,13 @@ const isCrawler = isCrawlerUserAgent(userAgent)
 
     // Use astro:page-load for View Transitions compatibility (fires on both initial load and client-side navigation)
     document.addEventListener('astro:page-load', () => {
+      // Document-level listeners persist across ClientRouter navigations. When the user
+      // navigates /skills → /skills/[id] (or any non-/skills page), this handler still
+      // fires but the elements it expects (search-input, etc.) don't exist on the new
+      // page. Bail early to avoid `null.addEventListener` deref on line ~893+.
+      // Mirrors the same defensive guard at packages/website/src/pages/skills/[id].astro:575.
+      if (!document.getElementById('search-input')) return
+
       // Get Supabase config for API authentication
       const config = window.__SUPABASE_CONFIG__ || { url: '', anonKey: '' }
       const supabaseAnonKey = config.anonKey


### PR DESCRIPTION
## Summary

User-reported during manual W5 verification of #1051 — two console errors on `/skills/[id]` detail pages:

1. **`Cannot read properties of null (reading 'addEventListener')`** at `skills/index.astro:893` (compiled). Root cause: that file registers a `document.addEventListener('astro:page-load', …)` with **no guard** for "am I on /skills?". `document` listeners persist across Astro ClientRouter navigations, so on `/skills → /skills/[id]` the listener still fires and tries `searchInput.addEventListener(…)` where `searchInput` is null on the detail page. Pre-existing from 2026-01-29 (`e5304a3a3`); surfaced by the W3 catalog reframe in #1051 pulling more users through the search → detail navigation path. Mirrors the existing guard at `[id].astro:575`.

2. **`Cannot read properties of null (reading 'classList')`** in `showError` ← `fetchSkill` at `[id].astro:658`. Root cause harder to pin down (`curl` confirms `loading-state` / `error-state` / `error-message` / `skill-content` IDs all render in markup). Adding belt-and-suspenders null guards in `showError` so a failure here surfaces as a console.error from the underlying fetch error rather than an opaque null deref over stale closures.

Both are technically pre-existing — but #1051's catalog reframe made the `/skills → /skills/[id]` path more prominent, surfacing the listener-bleed.

## Changes

- `packages/website/src/pages/skills/index.astro:402-409` — early-return guard `if (!document.getElementById('search-input')) return`. Comment cross-references the existing guard in `[id].astro:575`.
- `packages/website/src/pages/skills/[id].astro:657-666` — defensive null guards in `showError` so the underlying error message is logged rather than a null deref masking it.

## Test plan

- [x] `npx prettier --check` clean on both files
- [x] Lint-staged + pre-commit hooks pass
- [ ] User retests on Vercel preview after merge — confirm both console errors are gone on cold-load `/skills` → click into a featured skill (e.g. `anthropics/mcp-builder`)
- [ ] Confirm `/skills` search still works (typing "react" returns results) — guard is a pure no-op when on /skills with `search-input` present

## Out of scope

- Refactoring the persistent-listener pattern more broadly. Other Astro pages have the same anti-pattern (`DocsLayout.astro:115`, `BlogLayout.astro:250`, etc.), but each has its own context. Apply the guard here, file a broader cleanup if it recurs elsewhere.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)