### PR TITLE
fix(audit): SMI-4829 governance P1 — sanitize Check 21 shell interpolation

### DIFF
--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -3123,6 +3123,10 @@ console.log(`\n${BOLD}Check 21: Strategy submodule pointer-on-tip${RESET}`)
     if (strategyEntries.length === 0) {
       pass('Check 21: No strategy submodules in .gitmodules — no-op (pre-cutover)')
     } else {
+      // Validate path/branch chars before shell interpolation (SMI-4829 governance retro P1).
+      // .gitmodules is version-controlled but a contributor with write access could otherwise
+      // smuggle shell metacharacters via subPath/branch into the execSync calls below.
+      const SAFE_TOKEN = /^[A-Za-z0-9._\-/]+$/
       for (const { path: subPath, branch } of strategyEntries) {
         if (!branch) {
           warn(
@@ -3131,12 +3135,21 @@ console.log(`\n${BOLD}Check 21: Strategy submodule pointer-on-tip${RESET}`)
           )
           continue
         }
+        if (!SAFE_TOKEN.test(subPath) || !SAFE_TOKEN.test(branch)) {
+          warn(
+            `Check 21: Strategy submodule '${subPath}' has unsafe characters in path or branch '${branch}' — refusing to shell out`,
+            'Verify .gitmodules manually; only [A-Za-z0-9._-/] permitted in path/branch tokens'
+          )
+          continue
+        }
         try {
           // Local pointer SHA from the parent repo's index
           const localSha = execSync(`git ls-files -s "${subPath}"`, { encoding: 'utf8' })
             .trim()
             .split(/\s+/)[1]
-          // Remote tip of the DECLARED branch (not main)
+          // Remote tip of the DECLARED branch (not main).
+          // subPath/branch validated above; .gitmodules subshell expansion is safe because
+          // the submodule URL lookup uses git's own parser, not shell metacharacters.
           const remoteSha = execSync(
             `git ls-remote "$(git config --file .gitmodules "submodule.${subPath}.url")" "${branch}"`,
             { encoding: 'utf8' }


### PR DESCRIPTION
## Summary

P1 follow-up from the post-merge governance retro on PR-1058 (cutover commit \`c89f6813\`). Adds an allowlist gate on \`subPath\` and \`branch\` parsed from \`.gitmodules\` before they're interpolated into \`execSync\` calls in Check 21.

[skip-impl-check]
[skip-smoke]

## Why

\`scripts/audit-standards.mjs:3136,3141\` interpolated the parsed values directly into shell template literals. Although \`.gitmodules\` is version-controlled, the standards-security.md \`execSync\` discipline rule applies regardless: a contributor with write access could smuggle shell metacharacters via path or branch tokens. Surface area was theoretical but real. 8-line fix.

## Test plan

- [ ] CI passes
- [ ] Local \`npm run audit:standards\` still emits the existing Check 21 output for the 3 strategy submodules

Refs: SMI-4829 governance retro, follows merge of PR-1058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)