### PR TITLE
fix(ci): SMI-4852 post-merge hotfixes

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -126,6 +126,15 @@ regexes = [
   '''HierarchicalNSWConstruct''',
   '''resetCachedHnswCtorForTe''',
 
+  # False positive (SMI-4856): the literal string `pr-123-validation` appears
+  # in `.claude/skills/github-workflow-automation/integration.md:138` (now
+  # migrated to the smith-horn/skillsmith-strategy submodule per SMI-4829,
+  # but historical commits 8506a0e5 + 62e2093405 still contain the path and
+  # gitleaks-action scans commit history). It is a workflow-name example
+  # identifier, not an API key — entropy 3.7 matches the broad
+  # generic-api-key regex by coincidence.
+  '''pr-123-validation''',
+
 ]
 
 # Allow specific files that contain examples or tests

--- a/scripts/tests/indexer/parity.test.ts
+++ b/scripts/tests/indexer/parity.test.ts
@@ -104,16 +104,40 @@ const REPO_ROOT = resolve(__dirname, '..', '..', '..')
 const DENO_HELPERS = resolve(REPO_ROOT, 'supabase/functions/indexer/skill-processor.helpers.ts')
 const NODE_HELPERS = resolve(REPO_ROOT, 'scripts/indexer/skill-processor.helpers.ts')
 
-describe('Deno <-> Node helper parity', () => {
-  it('repoUpdatedAtKey body is byte-identical (normalized whitespace)', () => {
-    const deno = normalizeWs(extractBody(DENO_HELPERS, 'repoUpdatedAtKey'))
-    const node = normalizeWs(extractBody(NODE_HELPERS, 'repoUpdatedAtKey'))
-    expect(node).toBe(deno)
-  })
+/**
+ * SMI-4852: Skip the parity assertions when the Deno helpers are git-crypt-
+ * encrypted (e.g. post-merge-verify.yml runs without unlocking the key).
+ * The encrypted file begins with the literal magic `\x00GITCRYPT\x00`. When
+ * we observe that, the test exits clean — the parity invariant is enforced
+ * in unlocked contexts (PR matrix, local Docker) where every diff lands.
+ */
+function isGitCryptEncrypted(filePath: string): boolean {
+  try {
+    const head = readFileSync(filePath).subarray(0, 10)
+    return head[0] === 0 && head.toString('utf-8', 1, 9) === 'GITCRYPT\x00'.slice(0, 8)
+  } catch {
+    return false
+  }
+}
 
-  it('minimalSkillPayload body is byte-identical (normalized whitespace)', () => {
-    const deno = normalizeWs(extractBody(DENO_HELPERS, 'minimalSkillPayload'))
-    const node = normalizeWs(extractBody(NODE_HELPERS, 'minimalSkillPayload'))
-    expect(node).toBe(deno)
-  })
+describe('Deno <-> Node helper parity', () => {
+  const denoEncrypted = isGitCryptEncrypted(DENO_HELPERS)
+
+  it.skipIf(denoEncrypted)(
+    'repoUpdatedAtKey body is byte-identical (normalized whitespace)',
+    () => {
+      const deno = normalizeWs(extractBody(DENO_HELPERS, 'repoUpdatedAtKey'))
+      const node = normalizeWs(extractBody(NODE_HELPERS, 'repoUpdatedAtKey'))
+      expect(node).toBe(deno)
+    }
+  )
+
+  it.skipIf(denoEncrypted)(
+    'minimalSkillPayload body is byte-identical (normalized whitespace)',
+    () => {
+      const deno = normalizeWs(extractBody(DENO_HELPERS, 'minimalSkillPayload'))
+      const node = normalizeWs(extractBody(NODE_HELPERS, 'minimalSkillPayload'))
+      expect(node).toBe(deno)
+    }
+  )
 })

--- a/scripts/validate-edge-functions.sh
+++ b/scripts/validate-edge-functions.sh
@@ -55,6 +55,7 @@ AUTHENTICATED_FUNCTIONS=(
 # Service role functions (scheduled jobs, internal)
 SERVICE_ROLE_FUNCTIONS=(
   "indexer"
+  "indexer-dispatch"
   "skills-refresh-metadata"
   "ops-report"
   "alert-notify"


### PR DESCRIPTION
## Summary

Three independent CI failures observed on main after PR #1067 merged:

1. **Deploy Edge Functions** — `indexer-dispatch` not in `SERVICE_ROLE_FUNCTIONS` array in `scripts/validate-edge-functions.sh`. Categorization gate blocked deploy. Added.
2. **Post-Merge Verify** — parity test reads encrypted file in unlocked-CI context, throws. Added `it.skipIf(isGitCryptEncrypted(...))` guard.
3. **CI + Docs CI** — gitleaks false-positive on `pr-123-validation` (SMI-4856; in historical commits 8506a0e5, 62e2093405). Added to `.gitleaks.toml` allowlist with rationale.

## Test plan

- [x] Local lint clean
- [x] Local parity test passes (no skip on unlocked working tree; skip path verified via git-crypt magic detection)
- [ ] CI green
- [ ] Deploy Edge Functions re-runs successfully → `indexer-dispatch` deploys
- [ ] Post-Merge Verify passes
- [ ] gitleaks Secret Scan passes

[skip-impl-check] — shell/config/test-only PR (no production source code changes).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)