### PR TITLE
fix(ci): SMI-4852 add indexer-dispatch to deploy-edge-functions VERIFY_JWT list

### DIFF
--- a/scripts/deploy-edge-functions.sh
+++ b/scripts/deploy-edge-functions.sh
@@ -110,6 +110,7 @@ VERIFY_JWT_FUNCTIONS=(
   auth-device-preview
   expire-complimentary
   indexer
+  indexer-dispatch
   ops-report
   process-pending-subscription
   skills-outreach
@@ -152,8 +153,8 @@ if [[ -n "$FILTER_FUNCTIONS" ]]; then
   TOTAL=$((${#NO_VERIFY_JWT_FUNCTIONS[@]} + ${#VERIFY_JWT_FUNCTIONS[@]}))
   echo "Deploying $TOTAL edge function(s) to project: $PROJECT_REF"
 else
-  TOTAL=32
-  echo "Deploying all 32 edge functions to project: $PROJECT_REF"
+  TOTAL=33
+  echo "Deploying all 33 edge functions to project: $PROJECT_REF"
 fi
 
 echo "=================================================="


### PR DESCRIPTION
## Summary

Follow-up to PR #1068 — the validate-edge-functions.sh categorization fix wasn't enough. The deploy step uses a separate allowlist in `scripts/deploy-edge-functions.sh` (\`NO_VERIFY_JWT_FUNCTIONS\` + \`VERIFY_JWT_FUNCTIONS\`). \`indexer-dispatch\` was missing → "Unknown function 'indexer-dispatch' — skipping" → "NOT DEPLOYED".

Added to \`VERIFY_JWT_FUNCTIONS\` (same bucket as \`ops-report\`, \`indexer\` — JWT-verified service-role auth per supabase/config.toml). Bumped \`TOTAL=32\` → \`33\`.

## Test plan

- [ ] Auto-rerun Deploy Edge Functions on merge
- [ ] indexer-dispatch shows "Deployed" in verification step

[skip-impl-check] — shell-config-only PR.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)