### PR TITLE
fix(mcp-server): SMI-4864 escape backslash in tool-descriptions test regex (CodeQL #95)

### DIFF
--- a/packages/mcp-server/tests/tool-descriptions.test.ts
+++ b/packages/mcp-server/tests/tool-descriptions.test.ts
@@ -41,7 +41,7 @@ describe('SMI-4790: MCP tool descriptions', () => {
       ({ tool, stage }) => {
         const expectedPrefix = `[Skillsmith — ${stage} stage]`
         expect(tool.description).toMatch(
-          new RegExp(`^${expectedPrefix.replace(/[—[\]]/g, '\\$&')}`)
+          new RegExp(`^${expectedPrefix.replace(/[\\[\]—]/g, '\\$&')}`)
         )
       }
     )


### PR DESCRIPTION
## Summary

- Wave 3a of the GitHub security tab triage ([docs/internal/implementation/2026-05-11-github-security-triage.md](https://github.com/smith-horn/skillsmith/blob/main/docs/internal/implementation/2026-05-11-github-security-triage.md))
- Closes CodeQL alert **#95** (`js/incomplete-sanitization`, high)
- 1-line change: `/[—[\]]/g` → `/[\\[\]—]/g` so a hypothetical backslash in the prefix string would also be escaped before being inserted into `new RegExp(...)`

## Why this base branch

Stacked on `fix/smi-4862-ssrf-api-proxy` (PR #1079) to clear the pre-push security-audit gate that catches the otel CVEs already being fixed there. **GitHub will auto-rebase this PR's base to `main` once PR #1079 merges.** No file overlap with PR #1079.

## Test plan

- [x] `npx vitest run packages/mcp-server/tests/tool-descriptions.test.ts` — 22 tests pass
- [x] `npx eslint packages/mcp-server/tests/tool-descriptions.test.ts` — clean
- [x] Governance review (governance-specialist agent) — `PASS, ship as-is`
- [ ] CI Type Check, Test (mcp-server), CodeQL all green
- [ ] After merge: `gh api repos/smith-horn/skillsmith/code-scanning/alerts -q '[.[] | select(.number==95 and .state=="open")] | length'` returns `0` after CodeQL rescan

## Out of scope (Linear follow-ups filed)

- Swap the hand-rolled character-class escape for `escape-string-regexp` across any future `new RegExp(untrusted)` sites — governance recommendation, not blocking.
- Local pre-push hook fails on pre-existing zod3/zod4 workspace hoisting collision (typecheck on `validation.ts`/`tool-dispatch.ts`/`license.gate.ts` and root-tests UUID validation on `team-workspace.test.ts`); **CI on origin/main is green for both Type Check and Test (mcp-server)**, so this is a worktree-env-only issue.

[skip-impl-check]

🤖 Generated with [Claude Code](https://claude.com/claude-code)