### PR TITLE
chore(deps-dev): SMI-4868 bump vercel to exact 52.2.0 (Dependabot #101)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "typescript": "5.9.3",
         "typescript-eslint": "8.59.1",
         "varlock": "0.1.4",
-        "vercel": "50.38.1",
+        "vercel": "52.2.0",
         "vitest": "4.1.2"
       },
       "engines": {
@@ -7169,6 +7169,238 @@
         }
       }
     },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.2.0.tgz",
+      "integrity": "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.2.0",
+        "@napi-rs/keyring-darwin-x64": "1.2.0",
+        "@napi-rs/keyring-freebsd-x64": "1.2.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.2.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.2.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.2.0.tgz",
+      "integrity": "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.2.0.tgz",
+      "integrity": "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.2.0.tgz",
+      "integrity": "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -12321,16 +12553,18 @@
       }
     },
     "node_modules/@vercel/backends": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.0.54.tgz",
-      "integrity": "sha512-VXI/5GimPtu+Av7Uvv0cJ13nG1OZzreG52C/6fZh1kyWtHzH0w87ak+3p1upLJIFZR7Rv8TYQ+wZQwsuJsBnXg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.2.0.tgz",
+      "integrity": "sha512-7J0nJCd7h29CXG0jeejS8DnI4qAF96Fo6qibAPG7nbbJ5v0ZpWZhzeL8XwvvT3du6S50bRGcQCPJQNcShw6pEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/build-utils": "13.12.1",
+        "@vercel/build-utils": "13.20.0",
         "@vercel/nft": "1.5.0",
+        "@yarnpkg/parsers": "^3.0.0",
         "execa": "3.2.0",
         "fs-extra": "11.1.0",
+        "js-yaml": "^3.13.1",
         "oxc-transform": "0.111.0",
         "path-to-regexp": "8.3.0",
         "resolve.exports": "2.0.3",
@@ -12341,6 +12575,16 @@
       },
       "peerDependencies": {
         "typescript": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@vercel/backends/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/@vercel/backends/node_modules/execa": {
@@ -12419,6 +12663,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@vercel/backends/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@vercel/backends/node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -12454,6 +12712,13 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vercel/backends/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@vercel/backends/node_modules/strip-final-newline": {
       "version": "2.0.0",
@@ -12493,9 +12758,9 @@
       }
     },
     "node_modules/@vercel/build-utils": {
-      "version": "13.12.1",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.12.1.tgz",
-      "integrity": "sha512-etbYYV0RqKBZKgGK/BACqvSlD+vHMJjB+WBRF5NFLp9AVrAyhw8fTKDrvNCVHX8jZqCXrv+uWpb7acO9H4TCmA==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.20.0.tgz",
+      "integrity": "sha512-Jd29k42KSCRKOs+oSSVthw4xSjZBK3pUDG6AZl95/TsvIDNwRkjI2Nvs1ZcYDJdeLR346PQdWReFJGqkf/tb6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12519,13 +12784,13 @@
       "license": "MIT"
     },
     "node_modules/@vercel/cervel": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.0.41.tgz",
-      "integrity": "sha512-N/KlpuMHwYiYPHqrf1bx4r9FVUkZXXXVH7OSJFDgF5VyNK2T2dBrsHv0pHN/+5AFtL2E6QazjvOYoOkNNoSY9g==",
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.0.55.tgz",
+      "integrity": "sha512-uRisWx/d5goDEKx9eVpDjT4LA65FsOmDRw65ZMqkFZJbeX496ss37g1+/yiVBrQ0+35RcTYB9K1i8JAMFqv57w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.0.54"
+        "@vercel/backends": "0.2.0"
       },
       "bin": {
         "cervel": "bin/cervel.mjs"
@@ -12534,10 +12799,100 @@
         "typescript": "^4.0.0 || ^5.0.0"
       }
     },
+    "node_modules/@vercel/cli-auth": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-auth/-/cli-auth-0.1.0.tgz",
+      "integrity": "sha512-6H2b6c83auVjrKnFtiSkqz+JA5hNXYAJv/TKggxw1eJ7CQiXh6ZkWPdPi4G9sUVRJh61iTEu+FXiNsWH2xAr9Q==",
+      "dev": true,
+      "dependencies": {
+        "@napi-rs/keyring": "1.2.0",
+        "async-listen": "3.0.0",
+        "open": "8.4.0",
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-auth/node_modules/async-listen": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.0.tgz",
+      "integrity": "sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@vercel/cli-auth/node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@vercel/cli-auth/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vercel/cli-auth/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@vercel/cli-auth/node_modules/open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vercel/cli-auth/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@vercel/detect-agent": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vercel/detect-agent/-/detect-agent-1.2.1.tgz",
-      "integrity": "sha512-U/BJCltQSTFTHwaiCQQTQG3GonTbRoEewjV+OU2mMjcHLAoPOh6CP1SXA2XNmqiqI3c82nkRNJ7piZ14RqmTXw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@vercel/detect-agent/-/detect-agent-1.2.3.tgz",
+      "integrity": "sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -12545,13 +12900,13 @@
       }
     },
     "node_modules/@vercel/elysia": {
-      "version": "0.1.56",
-      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.56.tgz",
-      "integrity": "sha512-2I+W0oiuQBDZJ0BDUeviOiBU+WMwKnoH4WPalFGG6imamaTyhqqwjol22k9zRBnacqRd7k1bLnrOsefL8q0KFg==",
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.71.tgz",
+      "integrity": "sha512-YTEIX6hfpgg71D/45QyYGLj/wXUjnvfbbNWOgbnmWs9B2yWeZzWFysp6umVg99bvvyxgaPfes9I0MQbqNMvIgA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.6.23",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0"
       }
     },
@@ -12563,15 +12918,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/express": {
-      "version": "0.1.66",
-      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.66.tgz",
-      "integrity": "sha512-USGFkW2Y3QuB2JZyKZ+PSK3byRVg2yrou04Cp8EArkqLzRPjtltO/6Qy0ZnfwGLJktUkHpQn6g2slLMrMnuZpg==",
+      "version": "0.1.81",
+      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.81.tgz",
+      "integrity": "sha512-Y7J5L7jdiJ/3ojo0SO2OVINCN4+CzST0kW9SXLCB75oNajwZ0wFsUSp/x5PqjDtJ2WU9QDIXO7qBhjrRkaEK4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/cervel": "0.0.41",
+        "@vercel/cervel": "0.0.55",
         "@vercel/nft": "1.5.0",
-        "@vercel/node": "5.6.23",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
@@ -12605,13 +12960,13 @@
       }
     },
     "node_modules/@vercel/fastify": {
-      "version": "0.1.59",
-      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.59.tgz",
-      "integrity": "sha512-P+VX15cvNsi6J3zfoccDhqK53OgfTJx6W05IgXRwZewsXTQSnKHBM8lt8IGeeUzp1lgiXz7reXXLqAaoapvlMw==",
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.74.tgz",
+      "integrity": "sha512-CjjuHKysQs41MJOWHVGXyiZvhLQBzAe5KRamXgs4Tn0lNztQh/tY0TlB8Qtty8+R2c5I4l0EnNCSxQ3a/Nayxg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.6.23",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0"
       }
     },
@@ -12772,14 +13127,14 @@
       }
     },
     "node_modules/@vercel/gatsby-plugin-vercel-builder": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.1.7.tgz",
-      "integrity": "sha512-gtdHUCNSebH3NqvoBmS0AO9T/Wv0jYPzGBlMv3N8mFiHytiAdL8rNjVQiIYC9hvDXMkra4k3Yz2P1nijMth0UQ==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.1.21.tgz",
+      "integrity": "sha512-QHsoUoiLaUBq6px9oNUtTh2M/Ba1lNa3fVvEU70gY3PkzVlEf20tS/g04lEnBhtqMCSMJgziO8/Ql058pcppFA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sinclair/typebox": "0.25.24",
-        "@vercel/build-utils": "13.12.1",
+        "@vercel/build-utils": "13.20.0",
         "esbuild": "0.27.0",
         "etag": "1.8.1",
         "fs-extra": "11.1.0"
@@ -12801,32 +13156,32 @@
       }
     },
     "node_modules/@vercel/go": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.4.7.tgz",
-      "integrity": "sha512-BPFHPiOeq8QSt87R0KXE+V2b5K7vlKna/NRrEggAin4qtf2XHc2R5Iq/rrIZtj8sUF5LJegCbACGBB+PFjmnzQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.5.0.tgz",
+      "integrity": "sha512-xMHQLqQiEfK+YJlC5eJ4S/1E4fBEUAf1u2DwQYsZlS3rLlHVqTOcZ973Z+wZV5pr4/d3vvpgB4/GQ0eqdig0jw==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/h3": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.65.tgz",
-      "integrity": "sha512-YIFF4CGwhnFEJLabCLCV0LoeyQUzn302W2mgb3FaDFbqmcKeK7zZlkBv7oLKqMl4sdk3Z98FzhgxQr7kKVbg/A==",
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.80.tgz",
+      "integrity": "sha512-Vu+l1qXjD9P8P5rnLKGRaSbKkbBnxc2in+zHN7tD0vWxLcpecrPKnAgbVozT37LDvpT5I38aXQIFMKokjCQfAw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.6.23",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0"
       }
     },
     "node_modules/@vercel/hono": {
-      "version": "0.2.59",
-      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.59.tgz",
-      "integrity": "sha512-aiRIz53VTg4aXeKocqdGWuBNr9pnMM263EMU2WnYwNG6d9PSBGP/aH3Md18FD9JilVUlli+kPkt82ExOEWUi6g==",
+      "version": "0.2.74",
+      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.74.tgz",
+      "integrity": "sha512-NWOEeb3Vg8d9Y5/wnjajdPzXrrImGoSds/PkqQK802mzR9/8svdFhe1qnqSxzM6e3Y2iID0DJxhnZjVjowkOcQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/nft": "1.5.0",
-        "@vercel/node": "5.6.23",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
@@ -12871,31 +13226,31 @@
       }
     },
     "node_modules/@vercel/koa": {
-      "version": "0.1.39",
-      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.39.tgz",
-      "integrity": "sha512-T+N1SluAufkyvDAnfzJm1LQo4RG6L/5qLiri37zdzuUCDNykrmCY70bc51YffaWyL4INjwYf+OLHt3xcFmzMvQ==",
+      "version": "0.1.54",
+      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.54.tgz",
+      "integrity": "sha512-fUNQ6Wwp8gGT2KnoUH5Xv74eatFjza0cWwj60vY7zdymoNbuVNDBRLxFGiMUHl/wItzYuQIhPoaEeGiiYcuMDw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.6.23",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0"
       }
     },
     "node_modules/@vercel/nestjs": {
-      "version": "0.2.60",
-      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.60.tgz",
-      "integrity": "sha512-/kLwhh/eazwEOiZ3pFKoRHkkEIVICrud7gECumZaMc+APX6b77B7vN87kryaAty9Vz9bhhFHHp68FLox6Le+9A==",
+      "version": "0.2.75",
+      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.75.tgz",
+      "integrity": "sha512-0wTm/Yp15Z3tvu8OFEvzQjXyC7R/77mGQ3vKn61LNxxxGztL2m0N+F2oIciEiIaHYszct3TbEkA6bUbUFBGDLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.6.23",
+        "@vercel/node": "5.7.13",
         "@vercel/static-config": "3.2.0"
       }
     },
     "node_modules/@vercel/next": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.16.4.tgz",
-      "integrity": "sha512-XZgB1uqwww/P1uXNjabYpgNNdqh+faXGoDbl1vrwWHytrJJq1ZbJRsRl9LaZNsxA4RAIhdLMUD670/WwHjNZvQ==",
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.16.8.tgz",
+      "integrity": "sha512-buiiOH7t8afdBHcF9vdIZ9z4LwA5hcTS9AUq6UlSY7qbKeeRUIgSVdz8QrYNvHhKMj/CAaTB92C/k25u9U9Muw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12961,9 +13316,9 @@
       }
     },
     "node_modules/@vercel/node": {
-      "version": "5.6.23",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.6.23.tgz",
-      "integrity": "sha512-hBQ9k0s2QcCqYNfjIDtgAo/bcJuwaZE3zFSJfiSeyegwNFjizgADrKMRPsedhIj675MpuaXJPqadeZQA7cgSNg==",
+      "version": "5.7.13",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.7.13.tgz",
+      "integrity": "sha512-IbGplZ0lAvk6D4scBENKRLOjVbLa3knA3nDJL/1tmcy32UeWRdumo/YpoNMYo3Eg6y6uLtI1ajwpnQJsfzUtjg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12971,7 +13326,7 @@
         "@edge-runtime/primitives": "4.1.0",
         "@edge-runtime/vm": "3.2.0",
         "@types/node": "20.11.0",
-        "@vercel/build-utils": "13.12.1",
+        "@vercel/build-utils": "13.20.0",
         "@vercel/error-utils": "2.0.3",
         "@vercel/nft": "1.5.0",
         "@vercel/static-config": "3.2.0",
@@ -13093,9 +13448,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/python": {
-      "version": "6.29.0",
-      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.29.0.tgz",
-      "integrity": "sha512-B5nnIJrMjsT2bawrsNmgwjDRarSm2PGr6o2yUFvYlfUyggR0cqt8L9GvPJPijUt2biebukWE18rAzf41JDfkUA==",
+      "version": "6.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.36.0.tgz",
+      "integrity": "sha512-GLCX2JV2zfjGoSaANWi6gfL1z1IO02ulFhDOGYlOwBmVb1qQFLLssTnbN5uDO5heWm5Owi2/eqBG+l2E7TXiVQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13202,9 +13557,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/rust": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@vercel/rust/-/rust-1.0.6.tgz",
-      "integrity": "sha512-rhIzbFYg6B8SyRHsYhTi/iLu48LKAUC4tsp1xygS1nizEKCtnJ+O2CSJxuBMMeMdlFfxydWZV+d5nOgSZYeKNA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@vercel/rust/-/rust-1.1.1.tgz",
+      "integrity": "sha512-y6GYEQ8ltRRD8JNmSt0kWars7IMKjm1Nv26rFgl9wWVFqe5UeAvAHohiTX7D6W0Yowx6v+BnR3czeoVHwQvEMg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13318,15 +13673,65 @@
         "node": ">=6"
       }
     },
+    "node_modules/@vercel/sandbox": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-1.9.0.tgz",
+      "integrity": "sha512-zgr1ad0tkT1xZn/8Vxo60wOUOLqMAVGo4WqJQ8/UDcUtWynNJsBjI2tiMdWZrAo9EKH1MIqEzJNkcclF0UT1EQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0",
+        "async-retry": "1.3.3",
+        "jsonlines": "0.1.1",
+        "ms": "2.1.3",
+        "picocolors": "^1.1.1",
+        "tar-stream": "3.1.7",
+        "undici": "^7.16.0",
+        "xdg-app-paths": "5.1.0",
+        "zod": "3.24.4"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/zod": {
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@vercel/static-build": {
-      "version": "2.9.7",
-      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.9.7.tgz",
-      "integrity": "sha512-cfRL+vVeKrXtYZh0CACCLyaVcc0i1nLQux+FCfiVpkval/2agMdVkWpwnn9+rix+glY4aDy6B4irNjCrNZKM9A==",
+      "version": "2.9.21",
+      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.9.21.tgz",
+      "integrity": "sha512-LnaroK/z97iAwg0vNHECQHAm2oaFLSWiKqCZIETnv5RpIqDXgj/URBD8v+DNNSXWGXsYOk7ezLRuQnlpq3Jx5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/gatsby-plugin-vercel-analytics": "1.0.11",
-        "@vercel/gatsby-plugin-vercel-builder": "2.1.7",
+        "@vercel/gatsby-plugin-vercel-builder": "2.1.21",
         "@vercel/static-config": "3.2.0",
         "ts-morph": "12.0.0"
       }
@@ -14197,6 +14602,51 @@
         "streamx": "^2.15.0"
       }
     },
+    "node_modules/@yarnpkg/parsers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.3.tgz",
+      "integrity": "sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "js-yaml": "^3.10.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@yarnpkg/parsers/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@yarnpkg/parsers/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/abbrev": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
@@ -14793,7 +15243,6 @@
       "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -14828,7 +15277,6 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -17314,7 +17762,6 @@
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.7.0"
       }
@@ -17493,8 +17940,7 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -19817,6 +20263,13 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jsonlines": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsonlines/-/jsonlines-0.1.1.tgz",
+      "integrity": "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -24440,6 +24893,22 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sandbox": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/sandbox/-/sandbox-2.5.6.tgz",
+      "integrity": "sha512-tnFr7nyiuEhsAGb+xy60SDbij0790X+FgDljh3J/2HaRM6yQgNJkQKHbDH8ld7mR+PozXGgEfJ2Dc/5OyFnwsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/sandbox": "1.9.0",
+        "debug": "^4.4.1",
+        "zod": "^4.1.1"
+      },
+      "bin": {
+        "sandbox": "bin/sandbox.mjs",
+        "sbx": "bin/sandbox.mjs"
+      }
+    },
     "node_modules/sanitize-html": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.14.0.tgz",
@@ -25382,7 +25851,6 @@
       "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
@@ -25789,7 +26257,6 @@
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "b4a": "^1.6.4"
       }
@@ -26803,41 +27270,44 @@
       }
     },
     "node_modules/vercel": {
-      "version": "50.38.1",
-      "resolved": "https://registry.npmjs.org/vercel/-/vercel-50.38.1.tgz",
-      "integrity": "sha512-FO2v4nvBfjd5dn1ZdRQTEqt/gUe4hXYFj3Va4jO9USHiJeSIkWwH68vpSMU75ARegFIpsm0usYPzPPWvtCLkMQ==",
+      "version": "52.2.0",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-52.2.0.tgz",
+      "integrity": "sha512-iwFQ7kMudNlu8/LTAFnxRgyaAHeEcK2AEo9TBGSudGugjcz0PoqVRlaoj2B5SGefE87nNSi0ky+T6yGMuYKcOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.0.54",
+        "@vercel/backends": "0.2.0",
         "@vercel/blob": "2.3.0",
-        "@vercel/build-utils": "13.12.1",
-        "@vercel/detect-agent": "1.2.1",
-        "@vercel/elysia": "0.1.56",
-        "@vercel/express": "0.1.66",
-        "@vercel/fastify": "0.1.59",
+        "@vercel/build-utils": "13.20.0",
+        "@vercel/cli-auth": "0.1.0",
+        "@vercel/detect-agent": "1.2.3",
+        "@vercel/elysia": "0.1.71",
+        "@vercel/express": "0.1.81",
+        "@vercel/fastify": "0.1.74",
         "@vercel/fun": "1.3.0",
-        "@vercel/go": "3.4.7",
-        "@vercel/h3": "0.1.65",
-        "@vercel/hono": "0.2.59",
+        "@vercel/go": "3.5.0",
+        "@vercel/h3": "0.1.80",
+        "@vercel/hono": "0.2.74",
         "@vercel/hydrogen": "1.3.6",
-        "@vercel/koa": "0.1.39",
-        "@vercel/nestjs": "0.2.60",
-        "@vercel/next": "4.16.4",
-        "@vercel/node": "5.6.23",
+        "@vercel/koa": "0.1.54",
+        "@vercel/nestjs": "0.2.75",
+        "@vercel/next": "4.16.8",
+        "@vercel/node": "5.7.13",
         "@vercel/prepare-flags-definitions": "0.2.1",
-        "@vercel/python": "6.29.0",
+        "@vercel/python": "6.36.0",
         "@vercel/redwood": "2.4.12",
         "@vercel/remix-builder": "5.7.2",
         "@vercel/ruby": "2.3.2",
-        "@vercel/rust": "1.0.6",
-        "@vercel/static-build": "2.9.7",
+        "@vercel/rust": "1.1.1",
+        "@vercel/static-build": "2.9.21",
         "chokidar": "4.0.0",
         "esbuild": "0.27.0",
         "form-data": "^4.0.0",
         "jose": "5.9.6",
         "luxon": "^3.4.0",
-        "proxy-agent": "6.4.0"
+        "proxy-agent": "6.4.0",
+        "sandbox": "2.5.6",
+        "smol-toml": "1.5.2"
       },
       "bin": {
         "vc": "dist/vc.js",
@@ -26871,6 +27341,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/vercel/node_modules/smol-toml": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
+      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.59.1",
     "varlock": "0.1.4",
-    "vercel": "50.38.1",
+    "vercel": "52.2.0",
     "vitest": "4.1.2"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Wave 4 of the GitHub security tab triage ([docs/internal/implementation/2026-05-11-github-security-triage.md](https://github.com/smith-horn/skillsmith/blob/main/docs/internal/implementation/2026-05-11-github-security-triage.md))
- Closes Dependabot alert **#101** (`vercel`, moderate): _"Vercel: Non-interactive mode includes CLI arguments in suggested command output"_
- Root devDep: `vercel` 50.38.1 → 52.2.0 (exact pin, no caret)
- Supersedes Dependabot PR #992 (same target version, more recent rebase)

## Why 52.2.0 and not 52.0.1

GHSA lists `52.0.1` as the patched version but **vercel never published 52.0.1 to npm** — the registry has `52.0.0`, then jumps to `52.2.0` / `52.2.1`. Taking 52.2.0 (smallest available patched version) to keep the bump minimal.

## Why this base branch

Stacked on `fix/smi-4862-ssrf-api-proxy` (PR #1079) to clear the pre-push security-audit gate that catches the otel CVEs already being fixed there. **If rebased to `main` before #1079 merges, the pre-push audit gate re-surfaces those otel CVEs.** GitHub will auto-rebase this PR's base to `main` once PR #1079 merges. No file overlap with PR #1079.

## Test plan

- [x] `npm audit --audit-level=high --omit=dev` → `found 0 vulnerabilities` (with #1079 base)
- [x] Governance review (governance-specialist agent) — `PASS_WITH_WARNINGS, ship`. Lockfile diff scoped to vercel/`@vercel/*`/`@napi-rs/keyring` transitive — zero unrelated top-level entries.
- [x] Long-form CLI flags used in `.github/workflows/website-deploy-staging.yml` and `device-login-roundtrip.yml` are stable across the 50→52 jump.
- [ ] CI Type Check, Security Audit, Dependency Guard all green
- [ ] After merge: Dependabot #101 auto-closes on rescan (~24h)

## Out of scope (Linear follow-ups filed)

- `website-deploy-staging.yml` line 69 installs `vercel@latest` globally rather than consuming the pinned devDep; the lockfile pin therefore provides no runtime guarantee for deployments. Separate hardening issue filed under Skillsmith: CI Health.

[skip-impl-check]

🤖 Generated with [Claude Code](https://claude.com/claude-code)