### PR TITLE
fix(workflow): SMI-4865 add minimal permissions block to wasm-env-snapshot.yml (CodeQL #94)

### DIFF
--- a/.github/workflows/wasm-env-snapshot.yml
+++ b/.github/workflows/wasm-env-snapshot.yml
@@ -27,6 +27,9 @@ on:
       - 'scripts/diagnostics/wasm-env-snapshot.mjs'
       - '.github/workflows/wasm-env-snapshot.yml'
 
+permissions:
+  contents: read
+
 jobs:
   wasm-env-snapshot:
     name: Capture WASM env snapshot


### PR DESCRIPTION
## Summary

- Wave 3b of the GitHub security tab triage ([canonical plan](https://github.com/smith-horn/skillsmith/blob/main/docs/internal/implementation/2026-05-11-github-security-triage.md))
- Closes CodeQL alert **#94** (`actions/missing-workflow-permissions`, warning)
- 3-line YAML insert: `permissions: { contents: read }` after the `on:` block

## Plan

[`docs/internal/implementation/smi-4865-workflow-permissions-wasm-snapshot.md`](https://github.com/smith-horn/skillsmith/blob/main/docs/internal/implementation/smi-4865-workflow-permissions-wasm-snapshot.md) — plan-reviewed (ship verdict), placement convention adopted from peer workflows.

## Why this base branch

Stacked on `fix/smi-4862-ssrf-api-proxy` (PR #1079) to clear the pre-push security-audit gate. GitHub auto-rebases to `main` once PR #1079 merges.

## Test plan

- [x] `npx js-yaml .github/workflows/wasm-env-snapshot.yml` — parse OK
- [ ] CI green
- [ ] Post-merge: `gh workflow run wasm-env-snapshot.yml` succeeds with new permissions block
- [ ] CodeQL #94 closes on rescan (~24h)

[skip-impl-check]

🤖 Generated with [Claude Code](https://claude.com/claude-code)