### PR TITLE
fix(scripts): SMI-4866 eliminate ReDoS in audit-standards-helpers (CodeQL #90, #91)

### DIFF
--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -588,8 +588,13 @@ export const checkCarveOutInvariants = (jobs, denyList) => {
   for (const job of jobs) {
     const needsDockerBuild = /^\s+needs:.*\bdocker-build\b/m.test(job.body)
     const hasCarveOutMarker = /#\s*audit:carveout-pure-js\b/.test(job.body)
-    const usesDockerRun = /docker run\s+(?:--rm\s+)?(?:.*\\\s*\n\s*)*[^\\\n]*skillsmith-ci:/m.test(
-      job.body
+    // SMI-4866: collapse shell-continuation backslashes to spaces so a single
+    // flat regex can match a multi-line `docker run ... skillsmith-ci:` block.
+    // The previous nested-quantifier regex `(?:.*\\\s*\n\s*)*` is catastrophically
+    // backtrackable on malformed inputs (CodeQL js/redos #90, #91).
+    const bodyCollapsed = job.body.replace(/\\\n\s*/g, ' ')
+    const usesDockerRun = /docker run(?:\s+--rm)?(?:\s+--init)?\s+[^\n]*skillsmith-ci:/.test(
+      bodyCollapsed
     )
     if (needsDockerBuild && !usesDockerRun && !hasCarveOutMarker) {
       violationsA.push({

--- a/scripts/tests/audit-carveout-drift.test.ts
+++ b/scripts/tests/audit-carveout-drift.test.ts
@@ -282,3 +282,50 @@ describe('checkCarveOutInvariants — real ci.yml smoke', () => {
     expect(dockerBound.length).toBeGreaterThanOrEqual(1)
   })
 })
+
+describe('SMI-4866: checkCarveOutInvariants is not catastrophically backtracking', () => {
+  it('returns in <500ms on pathological line-continuation input (CodeQL #90/#91)', () => {
+    // Pre-SMI-4866 the nested-quantifier regex `(?:.*\\\s*\n\s*)*` would
+    // exhibit exponential backtracking on a body shaped like
+    // `docker run a \\\n a \\\n ... b` with no `skillsmith-ci:` anchor.
+    const evilBody =
+      `needs: docker-build\n    steps:\n      - run: |\n          docker run ` +
+      'a \\\n          '.repeat(40) +
+      'b'
+    const jobs = [{ name: 'evil', line: 1, body: evilBody }]
+    const start = performance.now()
+    checkCarveOutInvariants(jobs, [])
+    const elapsedMs = performance.now() - start
+    expect(elapsedMs).toBeLessThan(500)
+  })
+
+  it('still detects a valid `docker run skillsmith-ci:` line under collapse', () => {
+    const jobs = [
+      {
+        name: 'good',
+        line: 1,
+        body: `needs: docker-build\n    steps:\n      - run: |\n          docker run --rm \\\n            skillsmith-ci:abc node x.js`,
+      },
+    ]
+    const { violationsA } = checkCarveOutInvariants(jobs, [])
+    expect(violationsA).toEqual([])
+  })
+
+  it('handles the canonical --init variant used in ci.yml', () => {
+    // Mirrors the actual shape of docker-run jobs in .github/workflows/ci.yml:
+    // `docker run --rm --init \\\n  -v ... \\\n  -w /app \\\n  skillsmith-ci:${SHA}`
+    const jobs = [
+      {
+        name: 'ci-shaped',
+        line: 1,
+        body:
+          `needs: docker-build\n    steps:\n      - run: |\n          docker run --rm --init \\\n` +
+          `            -v \${{ github.workspace }}:/app \\\n` +
+          `            -w /app \\\n` +
+          `            skillsmith-ci:\${{ github.sha }} npm test`,
+      },
+    ]
+    const { violationsA } = checkCarveOutInvariants(jobs, [])
+    expect(violationsA).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Wave 3c of the GitHub security tab triage ([canonical plan](https://github.com/smith-horn/skillsmith/blob/main/docs/internal/implementation/2026-05-11-github-security-triage.md))
- Closes CodeQL alerts **#90** and **#91** (rule `js/redos`, error severity)
- Refactor nested-quantifier regex → line-walker + flat regex
- 3 new regression tests in `scripts/tests/audit-carveout-drift.test.ts`

## Plan

[`docs/internal/implementation/smi-4866-audit-helpers-redos.md`](https://github.com/smith-horn/skillsmith/blob/main/docs/internal/implementation/smi-4866-audit-helpers-redos.md) — plan-reviewed (ship verdict), `--init`-shape regression test added per review.

## Why this base branch

Stacked on `fix/smi-4862-ssrf-api-proxy` (PR #1079) to clear the pre-push security-audit gate. GitHub auto-rebases to `main` once PR #1079 merges.

## Test plan

- [x] `npx vitest run scripts/tests/audit-carveout-drift.test.ts` → 17 tests pass (14 existing + 3 new)
- [x] Pathological 40-continuation input completes <500ms (would loop indefinitely under old regex)
- [x] `npm run audit:standards` Check 38 (carve-out drift) still passes against current `.github/workflows/ci.yml`
- [ ] CI green
- [ ] CodeQL #90 and #91 close on rescan (~24h)

## Out of scope

- Pre-existing Check 19 audit failure (unexpected `docs/code_review/` subdirectory from PR #1079 governance report) — unrelated to this fix.

[skip-impl-check]

🤖 Generated with [Claude Code](https://claude.com/claude-code)