### PR TITLE
chore(indexer): SMI-4861 Wave 1 retro — surface cache counters in RunSummary stdout

### DIFF
--- a/scripts/indexer/discovery-orchestrator.ts
+++ b/scripts/indexer/discovery-orchestrator.ts
@@ -400,5 +400,8 @@ export async function runDiscovery(params: RunDiscoveryParams): Promise<IndexerR
   }
 
   result.repositories_found = repositories.length
+  // SMI-4861 Wave 1 post-merge retro: also surface cache counters in stdout
+  // RunSummary so cron logs show the hit ratio without a DB query.
+  result.tree_hash_cache = { hits: cacheCounters.hits, misses: cacheCounters.misses }
   return result
 }

--- a/scripts/indexer/indexer-types.ts
+++ b/scripts/indexer/indexer-types.ts
@@ -71,6 +71,11 @@ export interface IndexerResult {
     trees_api_calls: number
     truncated_responses: number
   }
+  /** SMI-4861 Wave 1: tree-hash TTL cache hit/miss counters. Surfaces in stdout RunSummary so cron logs show ratio without DB query. */
+  tree_hash_cache?: {
+    hits: number
+    misses: number
+  }
   errors: string[]
   dryRun: boolean
   /** SMI-4376: Populated by `runDiscovery`; equals `repositories.length` at end of Phase 3. */

--- a/scripts/indexer/run.ts
+++ b/scripts/indexer/run.ts
@@ -55,6 +55,9 @@ interface RunSummary {
     topics: string[]
     cron_slot: number | null
     rotation_source: RotationSource | 'maintenance'
+    // SMI-4861 Wave 1 post-merge retro: surface cache counters in cron log line.
+    tree_hash_cache_hits: number
+    tree_hash_cache_misses: number
   }
 }
 
@@ -258,6 +261,8 @@ async function main(): Promise<void> {
       topics,
       cron_slot: env.CRON_SLOT,
       rotation_source: rotationSource,
+      tree_hash_cache_hits: result.tree_hash_cache?.hits ?? 0,
+      tree_hash_cache_misses: result.tree_hash_cache?.misses ?? 0,
       ...summarizeRateLimitTelemetry(telemetry),
     },
   }


### PR DESCRIPTION
## Summary

Post-merge governance retro on PR #1089 (SMI-4861 Wave 1) surfaced one IMPORTANT finding: the tree-hash cache hit/miss counters were being persisted to `audit_logs.metadata.meta` but NOT emitted to the stdout `RunSummary` line. The GHA workflow log only shows `RunSummary`, so the cache hit ratio was only queryable via Supabase — defeating the operator-visibility goal of the Wave 1 3-cron acceptance window.

## Change

- `IndexerResult` gains optional `tree_hash_cache: { hits, misses }`
- `discovery-orchestrator.ts:404` populates from local `cacheCounters`
- `run.ts` `RunSummary.meta` gains `tree_hash_cache_hits` + `_misses` (defaults `0` for maintenance runs)

## Why now

The acceptance criterion for SMI-4861 Wave 1 is **three consecutive discovery crons** at 06/12/18 UTC showing:
- Cron 2: hits ratio ≥ 0.8
- Cron 3: hits ratio ≥ 0.8 AND `rate_limit_remaining_min ≥ 200` AND `secondary_rate_limit_hits == 0`

Without surfacing the counters in stdout, the cron operator must run a Supabase query after each run to compute the ratio. Surfacing in `RunSummary` makes the GHA workflow log self-sufficient for the acceptance check.

## Test plan
- [x] 82/82 indexer tests pass
- [x] Lint + typecheck + prettier clean
- [x] No public API surface changed (audit-log path unchanged; this only adds to the existing `meta` envelope)

`[skip-impl-check]`

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)