### PR TITLE
fix(workflow): SMI-4874 Wave B — reorder publish-vscode pre-flight after npm ci

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -48,9 +48,15 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --workspace=packages/vscode-extension --include-workspace-root
+        env:
+          npm_config_engine_strict: false
+
       - name: Marketplace pre-flight (version collision check)
         id: preflight
         run: |
+          npm ls @vscode/vsce --workspace=packages/vscode-extension
           VERSION=$(node -e "console.log(require('./packages/vscode-extension/package.json').version)")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           PUBLISHED=$(npx @vscode/vsce show skillsmith.skillsmith-vscode --json 2>/dev/null | node -e "
@@ -68,11 +74,6 @@ jobs:
             exit 1
           fi
           echo "- **Next version target**: $VERSION (current published: $PUBLISHED)" >> $GITHUB_STEP_SUMMARY
-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts --workspace=packages/vscode-extension --include-workspace-root
-        env:
-          npm_config_engine_strict: false
 
       - name: Build
         run: npm run build -w packages/vscode-extension


### PR DESCRIPTION
## Summary
- Move `Marketplace pre-flight` step to run **after** `Install dependencies` in `publish-vscode.yml`.
- This makes `npx @vscode/vsce show` (line 56 pre-reorder) resolve to the lockfile-pinned `@vscode/vsce@2.32.0` instead of fetching from the registry.
- Adds `npm ls @vscode/vsce` as the first line for CI-log observability.

## Why this is a step-reorder, not a new pin

`@vscode/vsce` was **already** pinned exact (`2.32.0`) in `packages/vscode-extension/package.json` devDeps. Lines 89 and 138 already ran post-`npm ci` from inside `cd packages/vscode-extension`, so they resolve to the workspace binary. Only the pre-flight at line 56 ran *before* `npm ci`, falling back to registry-latest. Reordering closes that gap without duplicating the version string.

## Safety analysis (from plan)

- **No upstream dep**: pre-flight only reads `packages/vscode-extension/package.json` + queries marketplace. Both are independent of `npm ci` state.
- **No downstream dep**: `grep "steps.preflight" .github/workflows/publish-vscode.yml` returns **0 hits** — `steps.preflight.outputs.version` is set but never consumed. Re-ordering cannot break any consumer because there are none.
- **Cost**: a version-collision detected by pre-flight now wastes ~15-30 seconds of `npm ci` work. Acceptable for closing the unpinned `vsce show` callsite.

## Test plan
- [x] `docker exec skillsmith-dev-1 npm run audit:standards` passes
- [ ] On merge: `gh workflow run publish-vscode.yml -f dry_run=true` — pre-flight step's first line should log `@vscode/vsce@2.32.0` resolved from workspace lockfile

[skip-impl-check] — workflow YAML only, no `packages/*/src/**` changes.

Plan: `docs/internal/implementation/smi-4874-ci-pin-audit.md` (Wave B)
Linear: SMI-4874

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)