### PR TITLE
fix(website): SMI-4895/4896/4897 retro follow-up — stale comment + D-6 race guard

### DIFF
--- a/packages/website/src/pages/device.astro
+++ b/packages/website/src/pages/device.astro
@@ -1,6 +1,6 @@
 ---
 // SMI-4402: /device — RFC 8628 device-code approval page.
-// 5 states: input → approval-preview → approved (auto-close) → expired → denied.
+// 5 states: input → approval-preview → approved → expired → denied.
 // SSR: session check redirects anon→/login, incomplete-profile→/complete-profile.
 // noindex — approval page must not be crawled.
 

--- a/packages/website/tests/e2e/device.spec.ts
+++ b/packages/website/tests/e2e/device.spec.ts
@@ -193,6 +193,9 @@ test.describe('D-6 — approved state is stable, no countdown, no auto-close pro
     })
     await page.goto(DEVICE_URL)
 
+    // Wait for the auto-preview block to complete (DEVICE_URL includes user_code so init()
+    // auto-advances to preview state; clicking Approve before that resolves is a race).
+    await expect(page.locator('#state-preview')).toBeVisible()
     await page.locator('#btn-approve').click()
     await expect(page.locator('#state-approved')).toBeVisible()
 


### PR DESCRIPTION
## Summary

Governance retro on the merged PR #1109 (commit `e17818c8`) surfaced two non-blocking findings that are best fixed immediately rather than rotting:

1. **`device.astro:3`** — the 5-states comment still read `"approved (auto-close)"` after `startCountdown()` + `window.close()` were removed. Updated to `"approved"`.
2. **`device.spec.ts` D-6 re-fire test** — clicked `#btn-approve` without first awaiting `#state-preview` visible. `DEVICE_URL` carries `user_code=BCDFGHJK`, which triggers the async auto-preview block in `init()`; clicking before that resolves is a race (the button doesn't exist in the DOM until preview state shows). The first D-6 case already had this guard; the re-fire case was missing it. Added.

[skip-impl-check] — two-line typo fix + test stability guard; no application source changes worth re-validating the impl checker over.

## Linear

- [SMI-4895](https://linear.app/smith-horn-group/issue/SMI-4895)
- [SMI-4896](https://linear.app/smith-horn-group/issue/SMI-4896)
- [SMI-4897](https://linear.app/smith-horn-group/issue/SMI-4897)

## Test plan

- [x] `docker exec skillsmith-dev-1 npm run lint` clean
- [x] `docker exec skillsmith-dev-1 npm run typecheck` clean
- [x] `docker exec skillsmith-dev-1 npm run format:check` clean
- [ ] CI green

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)