### PR TITLE
fix(ci): SMI-4898 pin Node 22.22.0 in Smoke Prod for npx @skillsmith/cli@latest

### DIFF
--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -75,6 +75,14 @@ jobs:
           ref: ${{ steps.sha.outputs.sha }}
           fetch-depth: 2
 
+      # SMI-4898: pin Node 22.22.0 so `npx @skillsmith/cli@latest` doesn't
+      # trip the published CLI's engines.node guard. Matches root
+      # `package.json` engines field and the canonical setup-node usage in
+      # detect-release-drift.yml / device-login-roundtrip.yml.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22.22.0'
+
       - name: Detect [skip-smoke] marker
         id: skip
         env:


### PR DESCRIPTION
## Summary

- Add `actions/setup-node@v6` with `node-version: '22.22.0'` to the `Smoke Prod` workflow's Smoke job.
- Fixes the `cli-published` surface which was failing on every main merge since 2026-05-14 06:42 UTC.

## Background

`Smoke Prod` was failing because `ubuntu-latest` ships Node v20.20.2 but `@skillsmith/cli@latest` (published) requires Node ≥22.22.0 (`engines.node` + runtime engine guard). `npx @skillsmith/cli@latest --help` and `--version` both exit 1 with `Node.js version mismatch detected.`

Other 4 smoke surfaces (website-homepage, pricing, docs/quickstart, sitemap-index) unaffected — they're plain `curl` checks.

Plan: `docs/internal/implementation/smi-4898-smoke-prod-node22.md`
Closes: SMI-4898

## Test plan

- [ ] All required CI checks green
- [ ] Post-merge: next `Smoke Prod` run on main shows all surfaces `pass` (specifically `cli-published`)
- [ ] No regression in other smoke surfaces

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)