### PR TITLE
fix: SMI-4902 retro — virtual-block lint coverage + skills markers + sanitize-html bump

### DIFF
--- a/.github/workflows/concurrency-audit-pr.yml
+++ b/.github/workflows/concurrency-audit-pr.yml
@@ -56,16 +56,37 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout PR (full history + submodules)
+      - name: Checkout PR (no submodules yet)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-          submodules: recursive
-          # The strategy submodule (.claude/skills) requires a PAT to clone.
-          # If unavailable, the checkout silently skips the submodule and the
-          # script-not-found branch below will short-circuit the audit.
-          token: ${{ secrets.STRATEGY_SUBMODULE_PAT || github.token }}
+          # SMI-4902 retro: submodules: false here. The strategy submodule
+          # (.claude/skills) and docs/internal are private repos requiring a
+          # PAT. actions/checkout treats submodule-fetch failure as fatal —
+          # external contributors and PRs without STRATEGY_SUBMODULE_PAT secret
+          # would hard-fail at this step instead of degrading to the "scripts
+          # not found, skip" branch below. We fetch the submodules in a
+          # separate continue-on-error step so the audit no-ops gracefully
+          # when the PAT is absent.
+
+      - name: Fetch submodules (best-effort)
+        # SMI-4902 retro: keep going on submodule-clone failure so the
+        # "Verify scanner scripts present" step can short-circuit cleanly.
+        # External-contributor PRs lacking STRATEGY_SUBMODULE_PAT land here.
+        # audit:allow-continue-on-error — see step comment.
+        continue-on-error: true
+        env:
+          STRATEGY_SUBMODULE_PAT: ${{ secrets.STRATEGY_SUBMODULE_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -n "${STRATEGY_SUBMODULE_PAT:-}" ]; then
+            # Use the PAT to clone the private submodules. Rewrite the github.com URL
+            # for the duration of this step only.
+            git config --global url."https://x-access-token:${STRATEGY_SUBMODULE_PAT}@github.com/".insteadOf "https://github.com/"
+          fi
+          git submodule update --init --recursive .claude/skills docs/internal || \
+            echo "::warning::submodule fetch failed; subsequent audit will short-circuit"
 
       - name: Unlock git-crypt
         # Required so that any encrypted plan content (none today, but future-

--- a/package-lock.json
+++ b/package-lock.json
@@ -18163,9 +18163,9 @@
       "license": "MIT"
     },
     "node_modules/devalue": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
-      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -29612,18 +29612,6 @@
       "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
       "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "license": "MIT"
-    },
-    "node_modules/yaml-language-server/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17901,6 +17901,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -18469,7 +18475,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -20603,6 +20608,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
       "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -20622,6 +20628,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -21870,6 +21877,15 @@
       "optional": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
       }
     },
     "node_modules/leven": {
@@ -26212,20 +26228,6 @@
         "sbx": "bin/sandbox.mjs"
       }
     },
-    "node_modules/sanitize-html": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.14.0.tgz",
-      "integrity": "sha512-CafX+IUPxZshXqqRaG9ZClSlfPVjSxI0td7n07hk8QO2oO+9JDnlcL8iM8TWeOXOIBFgIOx6zioTzM53AOMn3g==",
-      "license": "MIT",
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^8.0.0",
-        "is-plain-object": "^5.0.0",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.3.11"
-      }
-    },
     "node_modules/sass-formatter": {
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
@@ -30250,7 +30252,7 @@
       "dependencies": {
         "cross-spawn": "7.0.6",
         "marked": "15.0.7",
-        "sanitize-html": "2.14.0"
+        "sanitize-html": "2.17.4"
       },
       "devDependencies": {
         "@types/cross-spawn": "6.0.6",
@@ -30268,6 +30270,25 @@
         "vscode": "^1.110.0"
       }
     },
+    "packages/vscode-extension/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "packages/vscode-extension/node_modules/marked": {
       "version": "15.0.7",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.7.tgz",
@@ -30278,6 +30299,21 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "packages/vscode-extension/node_modules/sanitize-html": {
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
       }
     },
     "packages/website": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -256,7 +256,7 @@
   "dependencies": {
     "cross-spawn": "7.0.6",
     "marked": "15.0.7",
-    "sanitize-html": "2.14.0"
+    "sanitize-html": "2.17.4"
   },
   "devDependencies": {
     "@types/cross-spawn": "6.0.6",

--- a/packages/website/eslint.config.js
+++ b/packages/website/eslint.config.js
@@ -94,21 +94,46 @@ export default [
     },
   },
   // Virtual JS files from <script is:inline> blocks
+  // SMI-4904: include skillsmith-local plugin so no-raw-window-global fires
+  // on virtual *.astro/*.js files (is:inline scripts are parsed as JS blocks,
+  // not as *.astro directly; without explicit plugin registration the rule is
+  // silently absent for this virtual-file namespace).
   {
     files: ['**/*.astro/*.js'],
+    plugins: {
+      'skillsmith-local': skillsmithLocal,
+    },
     rules: {
       'prefer-rest-params': 'off',
       'no-unused-vars': 'off',
       'no-empty': 'off',
+      'skillsmith-local/no-raw-window-global': 'error',
     },
   },
   // Virtual TS files from <script> blocks
+  // SMI-4904: same plugin registration required — virtual *.astro/*.ts files
+  // are a separate flat-config namespace from *.astro and *.ts.
+  // SMI-4902 retro: override parserOptions.project = null. Virtual files live
+  // outside tsconfig.json's include, so the TS parser bails with "file not in
+  // project" and the rule never runs. The rule is syntax-only (AST visitor on
+  // MemberExpression) and does not need TS type info — disabling project
+  // lookups lets the parser succeed and the rule fire.
   {
     files: ['**/*.astro/*.ts'],
+    plugins: {
+      'skillsmith-local': skillsmithLocal,
+    },
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: null,
+      },
+    },
     rules: {
       '@typescript-eslint/no-unused-vars': 'off',
       'no-unused-vars': 'off',
       'no-empty': 'off',
+      'skillsmith-local/no-raw-window-global': 'error',
     },
   },
 ]

--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -584,7 +584,12 @@ const categoryJsonLd =
 
     async function initAuth() {
       try {
-        // Use shared singleton from window.__SUPABASE_CLIENT__ (SMI-3595)
+        // Use shared singleton from window.__SUPABASE_CLIENT__ (SMI-3595).
+        // is:inline + define:vars prevents ES import of getSupabaseClient(),
+        // so this consumer cannot use the canonical lazy helper. The null-check
+        // below degrades gracefully if BaseLayout hasn't populated the global
+        // yet. SMI-4907 tracks migrating this script to a bundled <script>.
+        // eslint-disable-next-line skillsmith-local/no-raw-window-global
         const supabase = window.__SUPABASE_CLIENT__
         if (!supabase) {
           console.debug('[Skills] No Supabase client, using anon key')

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -421,7 +421,12 @@ const isCrawler = isCrawlerUserAgent(userAgent)
 
       async function initAuth() {
         try {
-          // Use shared singleton from window.__SUPABASE_CLIENT__ (SMI-3595)
+          // Use shared singleton from window.__SUPABASE_CLIENT__ (SMI-3595).
+          // is:inline + define:vars prevents ES import of getSupabaseClient(),
+          // so this consumer cannot use the canonical lazy helper. The null-check
+          // below degrades gracefully if BaseLayout hasn't populated the global
+          // yet. SMI-4907 tracks migrating this script to a bundled <script>.
+          // eslint-disable-next-line skillsmith-local/no-raw-window-global
           const supabase = window.__SUPABASE_CLIENT__
           if (!supabase) {
             console.debug('[Skills] No Supabase client, using anon key')


### PR DESCRIPTION
## Summary

Four fixes from /governance retro on the merged SMI-4902 cascade (PRs #1112/1113/1114):

1. **ESLint rule now fires on Astro `<script>` virtual blocks** — `parserOptions.project: null` override on the `**/*.astro/*.ts` block. The W2 plugin registration alone wasn't enough; the TS parser bailed on virtual files outside tsconfig.json. Smoke test confirms the rule fires on a known violation.

2. **Real violations caught**: `skills/index.astro:425` and `skills/[id].astro:588` read `window.__SUPABASE_CLIENT__` directly. Both are inside `is:inline` scripts using `define:vars`, so ES import of `getSupabaseClient()` isn't possible. Added inline-disable markers with rationale comments referencing **SMI-4907** for the proper migration (convert `is:inline` → bundled).

3. **`sanitize-html` 2.14.0 → 2.17.4** in vscode-extension. Fixes critical CVE [GHSA-rpr9-rxv7-x643](https://github.com/advisories/GHSA-rpr9-rxv7-x643). `npm audit --omit=dev` post-bump: 0 vulnerabilities.

4. **`docs/internal` pointer bumped to `399d8c1`** (post-#160 index sync + #161 marker fix).

[skip-impl-check] — retro fixes; surrounding cascade ships the underlying initiative.

## Linear

- Refs SMI-4902 (parent operationalization)
- References SMI-4907 (open, `is:inline` script migration)

## Test plan

- [x] `docker exec skillsmith-dev-1 npx eslint src/pages/skills/index.astro src/pages/skills/[id].astro` clean
- [x] `npm audit --omit=dev` reports 0 vulnerabilities
- [x] `npm run preflight` clean
- [ ] CI green

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)