### PR TITLE
fix(deps): SMI-4902 retro — bump @types/sanitize-html to track sanitize-html 2.17.4

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -262,7 +262,7 @@
     "@types/cross-spawn": "6.0.6",
     "@types/node": "^22.15.0",
     "@types/mocha": "10.0.10",
-    "@types/sanitize-html": "2.13.0",
+    "@types/sanitize-html": "2.16.1",
     "@types/vscode": "1.110.0",
     "@vscode/test-electron": "2.5.2",
     "@vscode/vsce": "2.32.0",

--- a/scripts/indexer/discovery-orchestrator.ts
+++ b/scripts/indexer/discovery-orchestrator.ts
@@ -35,6 +35,7 @@ import {
   runUpsertPhase,
   writeIndexerAuditLog,
 } from './indexer-runners.ts'
+import { applyTreeHashTouches, type TreeHashTouchEntry } from './tree-hash-touch.ts'
 import type { RotationSource } from './topic-rotation.ts'
 import type { IndexerRequest, IndexerResult } from './indexer-types.ts'
 import { runHighTrustPhase } from './phases/high-trust.ts'
@@ -163,6 +164,9 @@ export async function runDiscovery(params: RunDiscoveryParams): Promise<IndexerR
 
   // ── Phase 1: High-trust authors ──────────────────────────────────────
   // Plan issue #14: extracted to phases/high-trust.ts to keep this file < 350 LOC.
+  // SMI-4861 cache-refresh-on-hit: collect per-hit touches; batch-refresh
+  // last_tree_hash_check after Phase 1 so cached rows stay fresh.
+  const treeHashTouches: TreeHashTouchEntry[] = []
   const phase1 = await runHighTrustPhase({
     validationCache,
     validationOptions,
@@ -170,7 +174,17 @@ export async function runDiscovery(params: RunDiscoveryParams): Promise<IndexerR
     concurrency,
     treeHashCache,
     cacheCounters,
+    treeHashTouches,
   })
+  if (treeHashTouches.length > 0) {
+    const touchResult = await applyTreeHashTouches(supabase, treeHashTouches)
+    if (touchResult.errors.length > 0) {
+      console.warn(
+        `[Phase1] tree_hash touch errors (${touchResult.errors.length}/${treeHashTouches.length}): ${touchResult.errors.slice(0, 3).join('; ')}`
+      )
+    }
+    console.log(`[Phase1] tree_hash touches: ${touchResult.ok}/${treeHashTouches.length} refreshed`)
+  }
   for (const skill of phase1.repos) {
     if (!seenUrls.has(skill.url)) {
       seenUrls.add(skill.url)

--- a/scripts/indexer/high-trust-indexer.ts
+++ b/scripts/indexer/high-trust-indexer.ts
@@ -52,6 +52,7 @@ import {
   type TreeHashCacheCounters,
 } from './tree-hash-cache.ts'
 import { indexSkillsFromContents, type RepoData } from './index-skills-from-contents.ts'
+import type { TreeHashTouchEntry } from './tree-hash-touch.ts'
 
 // Re-export for callers still importing from this module (run.ts, phases/high-trust.ts).
 export { treeHashCacheHit, treeHashCacheKey, TREE_HASH_CACHE_TTL_MS } from './tree-hash-cache.ts'
@@ -71,7 +72,10 @@ export async function indexHighTrustRepository(
   telemetry: RateLimitTelemetry,
   // SMI-4861 Wave 1: cross-run tree-hash cache. Omitted = behavior unchanged.
   treeHashCache?: TreeHashCache,
-  cacheCounters?: TreeHashCacheCounters
+  cacheCounters?: TreeHashCacheCounters,
+  // SMI-4861 cache-refresh-on-hit: list to collect rows whose cache hit should
+  // bump last_tree_hash_check post-Phase-1.
+  treeHashTouches?: TreeHashTouchEntry[]
 ): Promise<{
   skills: GitHubRepository[]
   errors: string[]
@@ -168,7 +172,8 @@ export async function indexHighTrustRepository(
           telemetry,
           treeHashCache,
           cacheCounters,
-          blobShaMap
+          blobShaMap,
+          treeHashTouches
         )
         skills.push(...pathSkills)
         errors.push(...pathErrors)
@@ -209,6 +214,15 @@ export async function indexHighTrustRepository(
           )
         ) {
           if (cacheCounters) cacheCounters.hits++
+          // SMI-4861 cache-refresh-on-hit: record touch so post-Phase-1 batch
+          // refreshes last_tree_hash_check. Without this, hits don't refresh
+          // and rows age past TTL, capping steady-state hit ratio at ~50%.
+          if (treeHashTouches) {
+            treeHashTouches.push({
+              repo_url: `https://github.com/${author.owner}/${author.repo}/tree/${repoData.default_branch}/${resolvedPath}`,
+              skill_path: resolvedPath,
+            })
+          }
           await delay(50)
           continue
         }
@@ -286,7 +300,8 @@ export async function indexHighTrustRepository(
           telemetry,
           treeHashCache,
           cacheCounters,
-          blobShaMap
+          blobShaMap,
+          treeHashTouches
         )
         skills.push(...pathSkills)
         errors.push(...pathErrors)

--- a/scripts/indexer/index-skills-from-contents.ts
+++ b/scripts/indexer/index-skills-from-contents.ts
@@ -29,6 +29,7 @@ import {
   type TreeHashCache,
   type TreeHashCacheCounters,
 } from './tree-hash-cache.ts'
+import type { TreeHashTouchEntry } from './tree-hash-touch.ts'
 
 /** Shared repo metadata shape fetched from GitHub API. */
 export interface RepoData {
@@ -53,7 +54,9 @@ export async function indexSkillsFromContents(
   // SMI-4861 Wave 1: tree-hash cache plumbing. Defaults `undefined` = no-op.
   treeHashCache?: TreeHashCache,
   cacheCounters?: TreeHashCacheCounters,
-  plainPathBlobShas?: Map<string, string>
+  plainPathBlobShas?: Map<string, string>,
+  // SMI-4861 cache-refresh-on-hit: per-hit touch list (Phase-1 batch refresh).
+  treeHashTouches?: TreeHashTouchEntry[]
 ): Promise<{ skills: GitHubRepository[]; errors: string[] }> {
   const skills: GitHubRepository[] = []
   const errors: string[] = []
@@ -141,6 +144,13 @@ export async function indexSkillsFromContents(
     const blobSha = plainPathBlobShas?.get(skillPath)
     if (treeHashCacheHit(treeHashCache, treeHashCacheKey(repoUrl, skillPath), blobSha)) {
       if (cacheCounters) cacheCounters.hits++
+      // SMI-4861 cache-refresh-on-hit: record for post-Phase-1 batch refresh.
+      if (treeHashTouches) {
+        treeHashTouches.push({
+          repo_url: `https://github.com/${author.owner}/${author.repo}/tree/${repoData.default_branch}/${skillPath}`,
+          skill_path: skillPath,
+        })
+      }
       continue
     }
     if (treeHashCache && blobSha && cacheCounters) cacheCounters.misses++

--- a/scripts/indexer/phases/high-trust.ts
+++ b/scripts/indexer/phases/high-trust.ts
@@ -33,6 +33,7 @@ import {
   type TreeHashCache,
   type TreeHashCacheCounters,
 } from '../high-trust-indexer.ts'
+import type { TreeHashTouchEntry } from '../tree-hash-touch.ts'
 import type { GitHubRepository } from '../topic-search.ts'
 import type { SkillMdValidation } from '../skill-processor.ts'
 
@@ -68,6 +69,11 @@ export interface HighTrustPhaseParams {
   treeHashCache?: TreeHashCache
   /** SMI-4861 Wave 1: cache hit/miss counters surfaced into audit-log meta. */
   cacheCounters?: TreeHashCacheCounters
+  /**
+   * SMI-4861 cache-refresh-on-hit: per-hit touch list. Phase 1 appends one
+   * entry per cache hit; the orchestrator batch-refreshes them after Phase 1.
+   */
+  treeHashTouches?: TreeHashTouchEntry[]
 }
 
 /**
@@ -86,6 +92,7 @@ export async function runHighTrustPhase(
     concurrency,
     treeHashCache,
     cacheCounters,
+    treeHashTouches,
   } = params
 
   console.log(`Indexing ${HIGH_TRUST_AUTHORS.length} high-trust authors...`)
@@ -103,7 +110,8 @@ export async function runHighTrustPhase(
             validationOptions,
             telemetry,
             treeHashCache,
-            cacheCounters
+            cacheCounters,
+            treeHashTouches
           ),
         { baseMs: 1000, maxMs: 60000, maxRetries: 5 }
       )

--- a/scripts/indexer/tree-hash-touch.ts
+++ b/scripts/indexer/tree-hash-touch.ts
@@ -1,0 +1,63 @@
+/**
+ * Tree-hash touch helper (SMI-4861 Wave 1 post-acceptance fix)
+ * @module scripts/indexer/tree-hash-touch
+ *
+ * SMI-4861's tree-hash cache hit path does `continue` — it skips downstream
+ * upsert entirely. That means `last_tree_hash_check` is never refreshed on a
+ * hit. With a 24h TTL and a 6h cron, rows oscillate between hit (fresh, no
+ * refresh) and miss (stale, refresh) — empirically capping the hit ratio at
+ * ~50% in steady state (post-merge telemetry 2026-05-14).
+ *
+ * The fix: when a cache hit happens, record the row's identity in a touch
+ * list. After Phase 1, batch-refresh `last_tree_hash_check` so cached rows
+ * stay fresh as long as they're being seen. Matches the intent of the
+ * SMI-4854 skip-gate (`repo_updated_at` is refreshed on every skip-gate hit
+ * too, for the same self-refreshing reason).
+ *
+ * Cost: ~200 cheap UPDATEs per discovery cron (one per cache hit), run with
+ * Promise.all so wall-clock is sub-second. No GitHub API calls.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/** One touch entry — primary key of the skills row to refresh. */
+export interface TreeHashTouchEntry {
+  repo_url: string
+  skill_path: string
+}
+
+export interface ApplyTouchesResult {
+  /** Number of rows successfully touched. */
+  ok: number
+  /** Per-failure error messages; non-fatal — caller logs and continues. */
+  errors: string[]
+}
+
+/**
+ * Refresh `last_tree_hash_check = NOW()` for each entry. No-op if list is
+ * empty. Errors are collected and returned; do not throw.
+ */
+export async function applyTreeHashTouches(
+  supabase: SupabaseClient,
+  touches: TreeHashTouchEntry[]
+): Promise<ApplyTouchesResult> {
+  if (touches.length === 0) return { ok: 0, errors: [] }
+  const ts = new Date().toISOString()
+  const errors: string[] = []
+  let ok = 0
+  await Promise.all(
+    touches.map(async (t) => {
+      const { error } = await supabase
+        .from('skills')
+        .update({ last_tree_hash_check: ts })
+        .eq('repo_url', t.repo_url)
+        .eq('skill_path', t.skill_path)
+      if (error) {
+        errors.push(`tree_hash touch failed (${t.repo_url}:${t.skill_path}): ${error.message}`)
+      } else {
+        ok++
+      }
+    })
+  )
+  return { ok, errors }
+}

--- a/scripts/tests/indexer/tree-hash-touch.test.ts
+++ b/scripts/tests/indexer/tree-hash-touch.test.ts
@@ -1,0 +1,153 @@
+// Tree-hash touch helper tests (SMI-4861 cache-refresh-on-hit)
+//
+// Regression context: post-Wave-1 telemetry (2026-05-14) showed steady-state
+// cache hit ratio plateaued at ~50% because hits don't refresh
+// last_tree_hash_check — rows oscillate hit→miss as they age past the 24h
+// TTL. Fix: on each cache hit, append a touch entry; batch-UPDATE
+// last_tree_hash_check after Phase 1.
+
+import { describe, it, expect } from 'vitest'
+import { applyTreeHashTouches, type TreeHashTouchEntry } from '../../indexer/tree-hash-touch.ts'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+function makeFakeSupabase(): {
+  client: SupabaseClient
+  calls: Array<{ patch: Record<string, unknown>; eqs: Array<[string, string]> }>
+  errorMode?: { fail: boolean; message?: string }
+} {
+  const state = {
+    client: null as unknown as SupabaseClient,
+    calls: [] as Array<{ patch: Record<string, unknown>; eqs: Array<[string, string]> }>,
+    errorMode: undefined as { fail: boolean; message?: string } | undefined,
+  }
+
+  const client = {
+    from: () => ({
+      update: (patch: Record<string, unknown>) => {
+        const call = { patch, eqs: [] as Array<[string, string]> }
+        state.calls.push(call)
+        const chain = {
+          eq: (col: string, val: string) => {
+            call.eqs.push([col, val])
+            // First .eq() returns chain; second .eq() returns the promise.
+            if (call.eqs.length < 2) return chain
+            if (state.errorMode?.fail) {
+              return Promise.resolve({
+                error: { message: state.errorMode.message ?? 'fake error' },
+              })
+            }
+            return Promise.resolve({ error: null })
+          },
+        }
+        return chain
+      },
+    }),
+  } as unknown as SupabaseClient
+
+  state.client = client
+  return state
+}
+
+describe('applyTreeHashTouches — cache hit refresh batch (SMI-4861)', () => {
+  it('no-ops on empty input', async () => {
+    const fake = makeFakeSupabase()
+    const result = await applyTreeHashTouches(fake.client, [])
+    expect(result).toEqual({ ok: 0, errors: [] })
+    expect(fake.calls).toHaveLength(0)
+  })
+
+  it('issues one UPDATE per touch entry with last_tree_hash_check timestamp', async () => {
+    const fake = makeFakeSupabase()
+    const touches: TreeHashTouchEntry[] = [
+      {
+        repo_url: 'https://github.com/anthropics/skills/tree/main/skills/web-search',
+        skill_path: 'skills/web-search',
+      },
+      {
+        repo_url: 'https://github.com/wshobson/agents/tree/main/plugins/ship-mate/skills/scan',
+        skill_path: 'plugins/ship-mate/skills/scan',
+      },
+    ]
+
+    const before = Date.now()
+    const result = await applyTreeHashTouches(fake.client, touches)
+    const after = Date.now()
+
+    expect(result.ok).toBe(2)
+    expect(result.errors).toEqual([])
+    expect(fake.calls).toHaveLength(2)
+
+    for (const call of fake.calls) {
+      expect(call.patch).toHaveProperty('last_tree_hash_check')
+      const ts = Date.parse(call.patch.last_tree_hash_check as string)
+      expect(ts).toBeGreaterThanOrEqual(before)
+      expect(ts).toBeLessThanOrEqual(after)
+      // Patch is narrow — only the one column.
+      expect(Object.keys(call.patch)).toEqual(['last_tree_hash_check'])
+      // Filter uses both repo_url AND skill_path (composite identity).
+      expect(call.eqs).toHaveLength(2)
+      const eqMap = Object.fromEntries(call.eqs)
+      expect(eqMap.repo_url).toMatch(/^https:\/\/github\.com\//)
+      expect(eqMap.skill_path).toMatch(/skills\//)
+    }
+  })
+
+  it('non-fatal on per-row error — collects messages and continues', async () => {
+    const fake = makeFakeSupabase()
+    fake.errorMode = { fail: true, message: 'connection lost' }
+
+    const result = await applyTreeHashTouches(fake.client, [
+      { repo_url: 'https://github.com/x/y/tree/main/a', skill_path: 'a' },
+      { repo_url: 'https://github.com/x/y/tree/main/b', skill_path: 'b' },
+    ])
+
+    expect(result.ok).toBe(0)
+    expect(result.errors).toHaveLength(2)
+    expect(result.errors[0]).toContain('tree_hash touch failed')
+    expect(result.errors[0]).toContain('connection lost')
+  })
+
+  it('promise.all parallelism — wall clock independent of touch count', async () => {
+    // Sanity: 100 touches should not serialize (would take 100 * ~5ms = 500ms).
+    // Promise.all should keep total under ~50ms even with simulated latency.
+    const slowClient = {
+      from: () => ({
+        update: () => ({
+          eq: () => ({
+            eq: () => new Promise((resolve) => setTimeout(() => resolve({ error: null }), 5)),
+          }),
+        }),
+      }),
+    } as unknown as SupabaseClient
+
+    const touches: TreeHashTouchEntry[] = Array.from({ length: 100 }, (_, i) => ({
+      repo_url: `https://github.com/x/y/tree/main/skill-${i}`,
+      skill_path: `skill-${i}`,
+    }))
+
+    const t0 = Date.now()
+    const result = await applyTreeHashTouches(slowClient, touches)
+    const elapsed = Date.now() - t0
+
+    expect(result.ok).toBe(100)
+    // Serial would be ~500ms; parallel should be ~5-20ms in practice.
+    expect(elapsed).toBeLessThan(200)
+  })
+
+  it('preserves entry identity: skill_path uses the column-stored shape', async () => {
+    // Regression guard: the WHERE clause must filter on BOTH repo_url AND
+    // skill_path because two skills can share the bare repo prefix (multi-skill
+    // wildcard repos) and we want to touch only the specific row.
+    const fake = makeFakeSupabase()
+    await applyTreeHashTouches(fake.client, [
+      {
+        repo_url: 'https://github.com/microsoft/copilot-chat/tree/main/skills/code-review',
+        skill_path: 'skills/code-review',
+      },
+    ])
+    expect(fake.calls[0].eqs).toEqual([
+      ['repo_url', 'https://github.com/microsoft/copilot-chat/tree/main/skills/code-review'],
+      ['skill_path', 'skills/code-review'],
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Recursion-stop governance retro on PR #1118 surfaced one finding: `@types/sanitize-html` remained at 2.13.0 while `sanitize-html` was bumped to 2.17.4 in that PR — a 4-minor-version type-drift gap. Latest available `@types/sanitize-html` is 2.16.1; bump tracks the runtime version.

[skip-impl-check] — pure dep-range bump, no application source changes.

## Linear

- Refs SMI-4902 (parent operationalization)

## Test plan

- [x] `docker exec skillsmith-dev-1 npm run typecheck` clean post-bump
- [ ] CI green