### PR TITLE
ci: SMI-4908 bundle pure-JS quality trio into single quality-checks job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,7 @@ jobs:
           fi
           echo "gold-set.json: $COUNT entries"
       # Note: TypeScript type-check of eval/ is already performed by the
-      # `Type Check` job (pure-JS carve-out runs root `npm run typecheck` which
+      # `Quality Checks` job (pure-JS carve-out runs root `npm run typecheck` which
       # builds workspace deps via Turborepo). Re-running tsc here without
       # building @skillsmith/core would fail on unrelated src/ imports.
       - name: Run eval unit tests (metrics, ablation, drift check)
@@ -462,7 +462,7 @@ jobs:
             }
 
   # SMI-3985: Supply-chain pin drift guard for the three Wave 1 hardening
-  # surfaces that are NOT covered by `Standards Compliance` (audit-standards
+  # surfaces that are NOT covered by `Quality Checks` (audit-standards
   # Check 12, packages/*/package.json only) or `Security Audit` (npm audit):
   #   A. GitHub-native license + OpenSSF scorecard review (pull_request only)
   #   B. Deterministic drift guard: .mcp.json @latest, esm.sh semver pins,
@@ -518,10 +518,11 @@ jobs:
           comment-summary-in-pr: on-failure
 
       # B. Drift guard for the three Wave 1 hardened surfaces NOT covered by
-      #    `Standards Compliance` / `Security Audit`: esm.sh CDN imports,
+      #    `Quality Checks` / `Security Audit`: esm.sh CDN imports,
       #    .mcp.json @latest tags, third-party GH Actions SHA pins.
-      #    audit-standards.mjs Check 12 already runs in the `Standards
-      #    Compliance` job (ci.yml:1276) — do NOT call it again here.
+      #    audit-standards.mjs Check 12 already runs in the `Quality Checks`
+      #    job (the bundled lint+typecheck+audit:standards step) — do NOT
+      #    call it again here.
       - name: Supply-chain drift guard
         run: node scripts/ci/check-supply-chain-pins.mjs
 
@@ -983,21 +984,35 @@ jobs:
       # for future runs, not uploaded as artifact. The cache provides cross-run benefits
       # without the per-run upload overhead (~30-60s).
 
-  # Parallel quality checks using Docker container
-  # SMI-708: All jobs now use pre-extracted node_modules instead of npm ci
-  lint:
-    name: Lint
+  # SMI-4908: Bundle pure-JS quality trio (lint + typecheck + compliance) into a
+  # single host job. Saves ~3 min of duplicated setup (checkout + git-crypt
+  # unlock + setup-node + npm ci) per PR. Plan:
+  # docs/internal/implementation/ci-bundle-pure-js-quality-trio.md
+  #
+  # `if:` is the broader of the three pre-bundle conditions
+  # (code == 'true' only, dropping the lint/typecheck `skip_tests != 'true'`
+  # extra gate). Trade-off: Dependabot batch + release-cadence PRs now run all
+  # four steps where they previously skipped lint/typecheck. ~135s/PR added on
+  # that low-frequency path; accepted as a consistency win — full lint+typecheck
+  # on dep bumps is arguably correct anyway.
+  quality-checks:
+    name: Quality Checks
     # audit:carveout-pure-js — see docs/internal/implementation/smi-4647-pure-js-carveout-and-drift-check.md
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [classify, detect-changes]
-    if: |
-      needs.detect-changes.outputs.code == 'true' &&
-      needs.classify.outputs.skip_tests != 'true'
+    if: needs.detect-changes.outputs.code == 'true'
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # SMI-4764 Wave 4 finding 2: audit:standards check 45 needs full
+          # history to compute origin/${baseRef}...HEAD diff. Default depth=1
+          # caused the diff to throw, the catch handler returned empty
+          # changedFiles, and check 45 silently no-op'd in every PR --
+          # zero protection as deployed. fetch-depth: 0 unblocks the diff.
+          fetch-depth: 0
 
       # SMI-2159: Decrypt git-crypt encrypted files
       # SMI-4770: composite action implements install-first-then-update for git-crypt.
@@ -1024,41 +1039,11 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
-  typecheck:
-    name: Type Check
-    # audit:carveout-pure-js — see docs/internal/implementation/smi-4647-pure-js-carveout-and-drift-check.md
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: [classify, detect-changes]
-    if: |
-      needs.detect-changes.outputs.code == 'true' &&
-      needs.classify.outputs.skip_tests != 'true'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      # SMI-2159: Decrypt git-crypt encrypted files
-      # SMI-4770: composite action implements install-first-then-update for git-crypt.
-      - name: Unlock git-crypt
-        if: ${{ env.GIT_CRYPT_KEY != '' }}
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
-        uses: ./.github/actions/unlock-git-crypt
-        with:
-          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
-
       - name: Run TypeScript type check
         run: npm run typecheck
+
+      - name: Run standards audit
+        run: npm run audit:standards
 
   # SMI-2192: Matrix-based test execution for affected packages
   # Runs tests in parallel per package, only for packages affected by changes
@@ -1507,46 +1492,8 @@ jobs:
       # SMI-1250: Removed coverage step - global thresholds don't apply to subset tests
       # Security tests run above without coverage; full coverage in main test job
 
-  compliance:
-    name: Standards Compliance
-    # audit:carveout-pure-js — see docs/internal/implementation/smi-4647-pure-js-carveout-and-drift-check.md
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.code == 'true'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          # SMI-4764 Wave 4 finding 2: audit:standards check 45 needs full
-          # history to compute origin/${baseRef}...HEAD diff. Default depth=1
-          # caused the diff to throw, the catch handler returned empty
-          # changedFiles, and check 45 silently no-op'd in every PR --
-          # zero protection as deployed. fetch-depth: 0 unblocks the diff.
-          fetch-depth: 0
-
-      # SMI-2159: Decrypt git-crypt encrypted files
-      # SMI-4770: composite action implements install-first-then-update for git-crypt.
-      - name: Unlock git-crypt
-        if: ${{ env.GIT_CRYPT_KEY != '' }}
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
-        uses: ./.github/actions/unlock-git-crypt
-        with:
-          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Run standards audit
-        run: npm run audit:standards
+  # SMI-4908: `compliance` job folded into `quality-checks` above (lint +
+  # typecheck + audit:standards bundled to share one setup pass).
 
   # SMI-2116: Website Build Verification
   # Ensures website builds successfully when website files change
@@ -1683,7 +1630,7 @@ jobs:
     # audit:carveout-pure-js — see docs/internal/implementation/smi-4647-pure-js-carveout-and-drift-check.md
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [lint, test, classify]
+    needs: [quality-checks, test, classify]
     # audit:allow-continue-on-error — non-blocking initially while we stabilize
     continue-on-error: true
     # Only run for code changes - skip for docs/config
@@ -1741,7 +1688,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [lint, typecheck, test, security, compliance, detect-changes]
+    needs: [quality-checks, test, security, detect-changes]
     # SMI-3999: Explicit detect-changes gate. The lint/typecheck/security/compliance
     # chain-skip already covers this, but explicit gate makes the required-check
     # contract unambiguous to future readers. The `(test.result == 'skipped')` clause
@@ -1755,11 +1702,9 @@ jobs:
     if: |
       !cancelled() &&
       needs.detect-changes.outputs.code == 'true' &&
-      needs.lint.result == 'success' &&
-      needs.typecheck.result == 'success' &&
+      needs.quality-checks.result == 'success' &&
       (needs.test.result == 'success' || needs.test.result == 'skipped') &&
-      needs.security.result == 'success' &&
-      needs.compliance.result == 'success'
+      needs.security.result == 'success'
 
     steps:
       - name: Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -13525,16 +13525,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@types/sanitize-html": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.13.0.tgz",
-      "integrity": "sha512-X31WxbvW9TjIhZZNyNBZ/p5ax4ti7qsNDBDEnH4zAgmEh35YnFD1UiS6z9Cd34kKm0LslFW0KPmTQzu/oGtsqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "htmlparser2": "^8.0.0"
-      }
-    },
     "node_modules/@types/sax": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
@@ -20602,39 +20592,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-assert": {
@@ -30246,7 +30203,7 @@
         "@types/cross-spawn": "6.0.6",
         "@types/mocha": "10.0.10",
         "@types/node": "^22.15.0",
-        "@types/sanitize-html": "2.13.0",
+        "@types/sanitize-html": "2.16.1",
         "@types/vscode": "1.110.0",
         "@vscode/test-electron": "2.5.2",
         "@vscode/vsce": "2.32.0",
@@ -30256,6 +30213,16 @@
       },
       "engines": {
         "vscode": "^1.110.0"
+      }
+    },
+    "packages/vscode-extension/node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
       }
     },
     "packages/vscode-extension/node_modules/htmlparser2": {

--- a/scripts/measure-ci-minutes.sh
+++ b/scripts/measure-ci-minutes.sh
@@ -36,6 +36,11 @@ SHA="$1"
 command -v gh >/dev/null || { echo "missing: gh CLI" >&2; exit 2; }
 command -v jq >/dev/null || { echo "missing: jq" >&2; exit 2; }
 
+# Process-scoped scratch dir — avoids predictable /tmp paths (symlink attack
+# surface) and collisions between concurrent runs.
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
 # Fetch the merge commit's date as the pivot point.
 PIVOT_ISO=$(gh api "repos/$REPO/commits/$SHA" --jq .commit.committer.date) || {
   echo "could not resolve commit $SHA in $REPO" >&2
@@ -93,14 +98,14 @@ sum_minutes() {
   echo "$label: $valid valid samples, total ${total_ms} ms ($(awk "BEGIN{printf \"%.1f\", $total_ms/60000}") min)"
   echo ""
   # Stash for delta calculation.
-  echo "$valid:$total_ms" > "/tmp/ci-minutes-$label.txt"
+  echo "$valid:$total_ms" > "$SCRATCH/$label.txt"
 }
 
 sum_minutes "before" "${before[@]}"
 sum_minutes "after"  "${after[@]}"
 
-before_data=$(cat /tmp/ci-minutes-before.txt)
-after_data=$(cat /tmp/ci-minutes-after.txt)
+before_data=$(cat "$SCRATCH/before.txt")
+after_data=$(cat "$SCRATCH/after.txt")
 before_valid="${before_data%%:*}"
 before_ms="${before_data##*:}"
 after_valid="${after_data%%:*}"

--- a/scripts/measure-ci-minutes.sh
+++ b/scripts/measure-ci-minutes.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SMI-4908: measure CI-minute delta around a merge SHA.
+#
+# Usage:
+#   ./scripts/measure-ci-minutes.sh <merge-sha> [n=10]
+#
+# Args:
+#   merge-sha  the commit SHA on main where the change merged
+#   n          number of merged PRs before/after to sample (default 10)
+#
+# Output (stdout):
+#   markdown table — PR | sha | total_billable_ms | jobs_count
+#   plus before/after sums and delta in CI-minutes.
+#
+# Exit codes:
+#   0   success
+#   1   fewer than 5 timing samples on either side (insufficient signal)
+#   2   missing prerequisites (gh, jq) or bad args
+#
+# Failure modes:
+#   - GHA timing API has retention limits (typically 90 days for billable
+#     breakdown). Individual run lookups that 404 print a warning to stderr
+#     and skip that PR; full failure only if < 5 valid samples per side.
+
+set -euo pipefail
+
+REPO="${REPO:-Smith-Horn/skillsmith}"
+N="${2:-10}"
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <merge-sha> [n=10]" >&2
+  exit 2
+fi
+SHA="$1"
+
+command -v gh >/dev/null || { echo "missing: gh CLI" >&2; exit 2; }
+command -v jq >/dev/null || { echo "missing: jq" >&2; exit 2; }
+
+# Fetch the merge commit's date as the pivot point.
+PIVOT_ISO=$(gh api "repos/$REPO/commits/$SHA" --jq .commit.committer.date) || {
+  echo "could not resolve commit $SHA in $REPO" >&2
+  exit 2
+}
+
+# List merged PRs on main, partition before/after by mergedAt.
+mapfile -t PR_LINES < <(
+  gh pr list --repo "$REPO" --state merged --base main \
+    --limit $((N * 5)) \
+    --json number,mergeCommit,mergedAt \
+    --jq '.[] | [.number, (.mergeCommit.oid // ""), .mergedAt] | @tsv'
+)
+
+before=()
+after=()
+for line in "${PR_LINES[@]}"; do
+  IFS=$'\t' read -r pr_num pr_sha pr_merged <<<"$line"
+  [ -z "$pr_sha" ] && continue
+  [ "$pr_sha" = "$SHA" ] && continue
+  if [[ "$pr_merged" < "$PIVOT_ISO" ]]; then
+    [ ${#before[@]} -lt "$N" ] && before+=("$pr_num:$pr_sha")
+  else
+    [ ${#after[@]} -lt "$N" ] && after+=("$pr_num:$pr_sha")
+  fi
+done
+
+sum_minutes() {
+  local label="$1"; shift
+  local total_ms=0 valid=0
+  echo "## $label"
+  printf "| PR | sha | billable_ms | jobs |\n|---|---|---|---|\n"
+  for entry in "$@"; do
+    pr_num="${entry%%:*}"
+    pr_sha="${entry##*:}"
+    # Find the most recent ci.yml run for this SHA.
+    run_id=$(gh api "repos/$REPO/actions/runs?head_sha=$pr_sha&per_page=20" \
+      --jq '.workflow_runs[] | select(.path == ".github/workflows/ci.yml") | .id' \
+      | head -1)
+    if [ -z "$run_id" ]; then
+      echo "warn: PR #$pr_num sha=$pr_sha — no ci.yml run found, skipping" >&2
+      continue
+    fi
+    timing=$(gh api "repos/$REPO/actions/runs/$run_id/timing" 2>/dev/null) || {
+      echo "warn: PR #$pr_num run=$run_id — timing unavailable, skipping" >&2
+      continue
+    }
+    ms=$(jq -r '.run_duration_ms // 0' <<<"$timing")
+    jobs=$(gh api "repos/$REPO/actions/runs/$run_id/jobs" --jq '.jobs | length' 2>/dev/null || echo 0)
+    total_ms=$((total_ms + ms))
+    valid=$((valid + 1))
+    printf "| #%s | %s | %s | %s |\n" "$pr_num" "${pr_sha:0:8}" "$ms" "$jobs"
+  done
+  echo ""
+  echo "$label: $valid valid samples, total ${total_ms} ms ($(awk "BEGIN{printf \"%.1f\", $total_ms/60000}") min)"
+  echo ""
+  # Stash for delta calculation.
+  echo "$valid:$total_ms" > "/tmp/ci-minutes-$label.txt"
+}
+
+sum_minutes "before" "${before[@]}"
+sum_minutes "after"  "${after[@]}"
+
+before_data=$(cat /tmp/ci-minutes-before.txt)
+after_data=$(cat /tmp/ci-minutes-after.txt)
+before_valid="${before_data%%:*}"
+before_ms="${before_data##*:}"
+after_valid="${after_data%%:*}"
+after_ms="${after_data##*:}"
+
+if [ "$before_valid" -lt 5 ] || [ "$after_valid" -lt 5 ]; then
+  echo "insufficient samples: before=$before_valid, after=$after_valid (need >=5 each)" >&2
+  exit 1
+fi
+
+before_avg_min=$(awk "BEGIN{printf \"%.2f\", $before_ms/60000/$before_valid}")
+after_avg_min=$(awk "BEGIN{printf \"%.2f\", $after_ms/60000/$after_valid}")
+delta_min=$(awk "BEGIN{printf \"%.2f\", $before_avg_min - $after_avg_min}")
+
+echo "## Summary"
+echo ""
+echo "| Window | PRs | Avg CI-min/PR |"
+echo "|---|---|---|"
+echo "| before $SHA | $before_valid | $before_avg_min |"
+echo "| after  $SHA | $after_valid | $after_avg_min |"
+echo "| **delta** | | **$delta_min min/PR saved** |"


### PR DESCRIPTION
## Summary

- Merge `lint`, `typecheck`, `compliance` host jobs in `ci.yml` into one `quality-checks` job that shares one setup pass (checkout + git-crypt unlock + setup-node + `npm ci --ignore-scripts`).
- Save **~3 min CI minutes/PR** (~46% trio reduction) at a +1 min wall-clock cost — explicit user choice (cost over wall-clock).
- Add `scripts/measure-ci-minutes.sh` to measure the delta post-merge.

## Critical preservation

- **SMI-4647 Docker-First Carve-Out** preserved — bundled job keeps `# audit:carveout-pure-js` marker. Check 38 (`audit-standards-helpers.mjs:585-618`) is marker-based, not allow-list-based, so the new job inherits the carve-out automatically (no helper edit needed).
- **SMI-4764** `fetch-depth: 0` retained for `audit:standards` check 45.
- **`build` job `if:` block** at `ci.yml:1755-1762` collapsed: three `needs.{lint,typecheck,compliance}.result` references → single `needs.quality-checks.result`. **Without this, `build` would never run post-merge** (Critical bug caught in plan-review round 1).
- Inline doc-pointer comments at the prior `Type Check` / `Standards Compliance` references (`ci.yml:397, 465, 521, 524`) updated to `Quality Checks`.

## Trade-off

Drops the `skip_tests != 'true'` gate that `lint`/`typecheck` had. Dependabot batch + release-cadence PRs now run all four steps; ~135s/PR added on that low-frequency path. Accepted as a consistency win — full lint+typecheck on dep bumps is arguably correct anyway.

## NOT in this PR (follow-up after canary verifies)

Branch protection update is sequenced as Step 5 of the plan to avoid an admin-bypass window. After this merges:
1. Open canary PRs (one docs-only, one code) to confirm `Quality Checks` appears in GitHub's status-check catalog and `build` runs.
2. Open follow-up PR updating `.github/branch-protection.json` (swap 3 names → `Quality Checks`), `.claude/development/ci-reference.md` (table, line 130/140/197/411 carve-out body, Mermaid graph at lines 159-182, "All 13 checks" → "10 checks" at line 95), and `CLAUDE.md` ("13 checks" → "10 checks").
3. Apply: `gh api repos/Smith-Horn/skillsmith/branches/main/protection -X PUT --input .github/branch-protection.json`.
4. Verify with `./scripts/validate-branch-protection.sh` (zero drift).

## Plan & review

- Plan: `docs/internal/implementation/ci-bundle-pure-js-quality-trio.md` (ADR-109 SPARC artifact, plan-reviewed twice — 15 patches applied across rounds 1+2; round 1 caught 2 Criticals, round 2 caught 2 Highs).
- Linear: [SMI-4908](https://linear.app/smith-horn-group/issue/SMI-4908) under Skillsmith: CI Health.

## Test plan

- [ ] CI green on this PR — `Quality Checks` appears once; `build` and `code-review` start when it completes.
- [ ] Inject deliberate ESLint error (separate test PR) → fails at `Run ESLint` step, later steps skipped.
- [ ] Inject deliberate TypeScript error → fails at `Run TypeScript type check` step.
- [ ] Inject deliberate `audit:standards` violation (e.g., 600-line file) → fails at `Run standards audit` step.
- [ ] Open docs-only PR → `Quality Checks` skipped; only `Secret Scan` + `Markdown Lint` required.
- [ ] After merge: canary PRs (one docs, one code) confirm required-check counts.
- [ ] After follow-up branch-protection PR: `./scripts/validate-branch-protection.sh` reports zero drift.
- [ ] Run `scripts/measure-ci-minutes.sh <merge-sha>` after 10 post-merge PRs land — confirm delta ≥ 1.5 saved CI-min/PR (vs 3.0 projected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)