### PR TITLE
fix(indexer): SMI-4861 — paginate prefetch past PostgREST max-rows cap

### DIFF
--- a/scripts/indexer/prefetch-existing-skills.ts
+++ b/scripts/indexer/prefetch-existing-skills.ts
@@ -1,0 +1,99 @@
+/**
+ * Paginated prefetch of existing skill rows — skip-gate + tree-hash cache seed.
+ * @module scripts/indexer/prefetch-existing-skills
+ *
+ * SMI-4861: a single unbounded `.select()` is silently capped by PostgREST's
+ * `max-rows` (1000). The indexer prefetch feeds two maps from one query — the
+ * SMI-4854 `repo_updated_at` skip-gate and the SMI-4861 tree-hash cache — so
+ * the cap meant both only ever saw the first 1000 of ~8400 eligible rows,
+ * structurally pinning the tree-hash cache hit ratio near ~30% regardless of
+ * TTL. This walks the table in `max-rows`-sized pages instead.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  treeHashCacheKey,
+  type TreeHashCache,
+  type TreeHashCacheEntry,
+} from './high-trust-indexer.ts'
+
+/** PostgREST `max-rows` cap — also the page size for the paginated walk. */
+export const PREFETCH_PAGE_SIZE = 1000
+/** Safety bound: ~8400 eligible rows today; 1000 pages = 1M-row headroom. */
+const MAX_PREFETCH_PAGES = 1000
+
+interface SkillPrefetchRow {
+  repo_url: string
+  repo_updated_at: string | null
+  skill_path: string | null
+  tree_hash: string | null
+  last_tree_hash_check: string | null
+}
+
+export interface PrefetchResult {
+  /** repo_url → repo_updated_at, consumed by the SMI-4854 skip-gate. */
+  existingRepoUpdatedAt: Map<string, string | null>
+  /** (bareRepoUrl, skill_path) → tree-hash entry, consumed by Phase 1. */
+  treeHashCache: TreeHashCache
+  /** Rows scanned across all pages — surfaced for telemetry. */
+  rowsScanned: number
+}
+
+/**
+ * Load every skill row with a non-null `repo_url`, paging past PostgREST's
+ * `max-rows` cap. Ordered by `repo_url` (the upsert conflict key, so unique
+ * for non-null rows) to keep `.range()` page boundaries stable.
+ *
+ * Prefetch failure is non-fatal: a partial result just means fewer skip-gate
+ * and cache hits this run — correctness is preserved by the downstream fetch.
+ */
+export async function prefetchExistingSkills(
+  supabase: SupabaseClient,
+  requestId: string
+): Promise<PrefetchResult> {
+  const existingRepoUpdatedAt = new Map<string, string | null>()
+  const treeHashCache: TreeHashCache = new Map<string, TreeHashCacheEntry>()
+  let rowsScanned = 0
+
+  for (let page = 0; page < MAX_PREFETCH_PAGES; page++) {
+    const from = page * PREFETCH_PAGE_SIZE
+    const { data, error } = await supabase
+      .from('skills')
+      .select('repo_url, repo_updated_at, skill_path, tree_hash, last_tree_hash_check')
+      .not('repo_url', 'is', null)
+      .order('repo_url', { ascending: true })
+      .range(from, from + PREFETCH_PAGE_SIZE - 1)
+
+    if (error) {
+      console.error(
+        JSON.stringify({
+          event: 'repo_updated_at_prefetch_failed',
+          error: error.message,
+          request_id: requestId,
+          page,
+        })
+      )
+      break
+    }
+
+    const rows = (data ?? []) as SkillPrefetchRow[]
+    for (const row of rows) {
+      if (!row.repo_url) continue
+      existingRepoUpdatedAt.set(row.repo_url, row.repo_updated_at ?? null)
+      if (row.tree_hash) {
+        // skills.repo_url stores the per-skill URL `…/tree/<branch>/<skillPath>`
+        // for multi-skill repos; Phase 1 lookups key on the bare repo URL +
+        // skill_path tuple, so strip the suffix here for round-trip parity.
+        const bareRepoUrl = row.repo_url.split('/tree/')[0]
+        treeHashCache.set(treeHashCacheKey(bareRepoUrl, row.skill_path ?? ''), {
+          tree_hash: row.tree_hash,
+          last_tree_hash_check: row.last_tree_hash_check,
+        })
+      }
+    }
+    rowsScanned += rows.length
+    if (rows.length < PREFETCH_PAGE_SIZE) break
+  }
+
+  return { existingRepoUpdatedAt, treeHashCache, rowsScanned }
+}

--- a/scripts/indexer/run.ts
+++ b/scripts/indexer/run.ts
@@ -36,11 +36,7 @@ import { runDiscovery } from './discovery-orchestrator.ts'
 import { runMaintenanceReconciliation } from './maintenance-helpers.ts'
 import type { IndexerRequest, IndexerResult } from './indexer-types.ts'
 import type { SkillMdValidation } from './skill-processor.ts'
-import {
-  treeHashCacheKey,
-  type TreeHashCache,
-  type TreeHashCacheEntry,
-} from './high-trust-indexer.ts'
+import { prefetchExistingSkills } from './prefetch-existing-skills.ts'
 
 interface RunSummary {
   data: unknown
@@ -96,47 +92,18 @@ async function runDiscoveryBranch(
   const searchApiTokenBucket = createTokenBucket(0.5, 1)
   const codeSearchTokenBucket = createTokenBucket(1 / 6, 1)
 
-  // SMI-4854 + SMI-4861 Wave 1: Prefetch repo_updated_at + tree_hash maps in
-  // a single query. tree_hash + last_tree_hash_check are read into a separate
-  // `(repo_url, skill_path) → {tree_hash, last_tree_hash_check}` map so Phase 1
-  // can short-circuit the per-skill raw.* fetch when blob SHA + freshness match.
-  const existingRepoUpdatedAt = new Map<string, string | null>()
-  const treeHashCache: TreeHashCache = new Map<string, TreeHashCacheEntry>()
-  const { data: existingRows, error: prefetchError } = await supabase
-    .from('skills')
-    .select('repo_url, repo_updated_at, skill_path, tree_hash, last_tree_hash_check')
-    .not('repo_url', 'is', null)
-  if (prefetchError) {
-    console.error(
-      JSON.stringify({
-        event: 'repo_updated_at_prefetch_failed',
-        error: prefetchError.message,
-        request_id: requestId,
-      })
-    )
-    // Non-fatal — empty maps mean no skip-gate hits this run; correctness preserved.
-  } else {
-    for (const row of (existingRows ?? []) as Array<{
-      repo_url: string
-      repo_updated_at: string | null
-      skill_path: string | null
-      tree_hash: string | null
-      last_tree_hash_check: string | null
-    }>) {
-      if (!row.repo_url) continue
-      existingRepoUpdatedAt.set(row.repo_url, row.repo_updated_at ?? null)
-      if (row.tree_hash) {
-        // skills.repo_url stores the per-skill URL `…/tree/<branch>/<skillPath>` for
-        // multi-skill repos (skill-processor.ts:473). Phase 1 lookups key on the bare
-        // repo URL + skill_path tuple, so strip the suffix here for round-trip parity.
-        const bareRepoUrl = row.repo_url.split('/tree/')[0]
-        treeHashCache.set(treeHashCacheKey(bareRepoUrl, row.skill_path ?? ''), {
-          tree_hash: row.tree_hash,
-          last_tree_hash_check: row.last_tree_hash_check,
-        })
-      }
-    }
-  }
+  // SMI-4854 + SMI-4861 Wave 1: Prefetch repo_updated_at + tree_hash maps so
+  // Phase 1 can short-circuit the per-skill raw.* fetch when blob SHA +
+  // freshness match. Paginated — an unbounded `.select()` is silently capped
+  // by PostgREST's `max-rows` (1000), which previously starved both maps to
+  // the first ~1000 of the ~8400-row corpus. See prefetch-existing-skills.ts.
+  const { existingRepoUpdatedAt, treeHashCache, rowsScanned } = await prefetchExistingSkills(
+    supabase,
+    requestId
+  )
+  console.log(
+    `[Prefetch] ${rowsScanned} skill rows scanned; tree-hash cache seeded with ${treeHashCache.size} entries`
+  )
 
   const result = await runDiscovery({
     supabase,

--- a/scripts/tests/indexer/prefetch-existing-skills.test.ts
+++ b/scripts/tests/indexer/prefetch-existing-skills.test.ts
@@ -1,0 +1,118 @@
+// Paginated prefetch tests (SMI-4861 — PostgREST max-rows cap fix)
+//
+// Regression context: post-Wave-1 telemetry showed the tree-hash cache hit
+// ratio pinned near ~30%. RCA: the prefetch did one unbounded `.select()`,
+// which PostgREST silently caps at `max-rows` (1000). With ~8400 eligible
+// rows, the cache + skip-gate only ever saw the first 1000. Fix: walk the
+// table in `max-rows`-sized pages via `.range()`.
+
+import { describe, it, expect } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  prefetchExistingSkills,
+  PREFETCH_PAGE_SIZE,
+} from '../../indexer/prefetch-existing-skills.ts'
+
+interface Row {
+  repo_url: string
+  repo_updated_at: string | null
+  skill_path: string | null
+  tree_hash: string | null
+  last_tree_hash_check: string | null
+}
+
+/**
+ * Mock the supabase chain `.from().select().not().order().range(from,to)`.
+ * `.range()` slices `dataset`, emulating PostgREST: a request never returns
+ * more than `PREFETCH_PAGE_SIZE` rows even if the window is wider.
+ */
+function makeFakeSupabase(
+  dataset: Row[],
+  opts: { failOnPage?: number } = {}
+): { client: SupabaseClient; rangeCalls: Array<[number, number]> } {
+  const rangeCalls: Array<[number, number]> = []
+  const client = {
+    from: () => ({
+      select: () => ({
+        not: () => ({
+          order: () => ({
+            range: (from: number, to: number) => {
+              rangeCalls.push([from, to])
+              const page = rangeCalls.length - 1
+              if (opts.failOnPage === page) {
+                return Promise.resolve({ data: null, error: { message: 'pooler timeout' } })
+              }
+              // PostgREST max-rows: cap the slice at PREFETCH_PAGE_SIZE.
+              const width = Math.min(to - from + 1, PREFETCH_PAGE_SIZE)
+              return Promise.resolve({ data: dataset.slice(from, from + width), error: null })
+            },
+          }),
+        }),
+      }),
+    }),
+  } as unknown as SupabaseClient
+  return { client, rangeCalls }
+}
+
+function makeRows(count: number, withHashEvery = 0): Row[] {
+  return Array.from({ length: count }, (_, i) => ({
+    repo_url: `https://github.com/owner/repo${String(i).padStart(6, '0')}/tree/main/skills/s${i}`,
+    repo_updated_at: `2026-05-15T00:00:${String(i % 60).padStart(2, '0')}Z`,
+    skill_path: `skills/s${i}`,
+    tree_hash: withHashEvery && i % withHashEvery === 0 ? `blob${i}` : null,
+    last_tree_hash_check: withHashEvery && i % withHashEvery === 0 ? '2026-05-15T16:00:00Z' : null,
+  }))
+}
+
+describe('prefetchExistingSkills — paginated prefetch (SMI-4861)', () => {
+  it('single page: loads all rows when corpus < page size', async () => {
+    const { client, rangeCalls } = makeFakeSupabase(makeRows(250))
+    const { existingRepoUpdatedAt, rowsScanned } = await prefetchExistingSkills(client, 'req-1')
+    expect(rowsScanned).toBe(250)
+    expect(existingRepoUpdatedAt.size).toBe(250)
+    // One full request; loop stops because the page came back short.
+    expect(rangeCalls).toHaveLength(1)
+    expect(rangeCalls[0]).toEqual([0, PREFETCH_PAGE_SIZE - 1])
+  })
+
+  it('REGRESSION: walks past the 1000-row PostgREST cap', async () => {
+    // 8400 rows ≈ the production corpus. A single .select() would yield 1000.
+    const { client, rangeCalls } = makeFakeSupabase(makeRows(8400))
+    const { existingRepoUpdatedAt, rowsScanned } = await prefetchExistingSkills(client, 'req-2')
+    expect(rowsScanned).toBe(8400)
+    expect(existingRepoUpdatedAt.size).toBe(8400)
+    // 9 pages: 8 full (8000) + 1 partial (400).
+    expect(rangeCalls).toHaveLength(9)
+    expect(rangeCalls[8]).toEqual([8000, 8000 + PREFETCH_PAGE_SIZE - 1])
+  })
+
+  it('terminates on an exactly-divisible corpus (extra empty page)', async () => {
+    const { client, rangeCalls } = makeFakeSupabase(makeRows(2 * PREFETCH_PAGE_SIZE))
+    const { rowsScanned } = await prefetchExistingSkills(client, 'req-3')
+    expect(rowsScanned).toBe(2 * PREFETCH_PAGE_SIZE)
+    // 2 full pages return exactly PREFETCH_PAGE_SIZE → loop probes a 3rd.
+    expect(rangeCalls).toHaveLength(3)
+  })
+
+  it('seeds treeHashCache with the bare-repo-URL + skill_path key', async () => {
+    // Every 3rd row carries a tree_hash; spans 2 pages to prove cache rows
+    // beyond the first 1000 are seeded too.
+    const { client } = makeFakeSupabase(makeRows(1500, 3))
+    const { treeHashCache } = await prefetchExistingSkills(client, 'req-4')
+    expect(treeHashCache.size).toBe(Math.ceil(1500 / 3))
+    // repo_url suffix `/tree/main/skills/sN` must be stripped for the key.
+    const entry = treeHashCache.get('https://github.com/owner/repo000000:skills/s0')
+    expect(entry).toEqual({ tree_hash: 'blob0', last_tree_hash_check: '2026-05-15T16:00:00Z' })
+    // A row that appears only on page 2 (index 1002) is present.
+    expect(treeHashCache.has('https://github.com/owner/repo001002:skills/s1002')).toBe(true)
+  })
+
+  it('non-fatal on a mid-walk error: returns the pages collected so far', async () => {
+    const { client, rangeCalls } = makeFakeSupabase(makeRows(3000), { failOnPage: 1 })
+    const { existingRepoUpdatedAt, rowsScanned } = await prefetchExistingSkills(client, 'req-5')
+    // Page 0 loaded (1000), page 1 errored → break. Partial result, no throw.
+    expect(rowsScanned).toBe(PREFETCH_PAGE_SIZE)
+    expect(existingRepoUpdatedAt.size).toBe(PREFETCH_PAGE_SIZE)
+    expect(rangeCalls).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Summary

Wave 1 acceptance RCA. The tree-hash cache hit ratio plateaued near ~30% (target 80%) and the cache-refresh-on-hit fix (`a8a07eb8`) did **not** move it — the cause is upstream of TTL staleness.

The indexer prefetch issued a single unbounded `.select()` on `skills WHERE repo_url IS NOT NULL`. PostgREST silently caps an unbounded select at `max-rows` (1000). With ~8400 eligible rows, the prefetch only ever loaded the first 1000 — ~126 of the 407 hash-bearing rows. So the tree-hash cache could structurally hold at most ~126/407, and the SMI-4854 `repo_updated_at` skip-gate (fed by the same query) was equally starved.

- **Empirically confirmed:** the exact pre-fix query returns exactly 1000 rows (126 with `tree_hash`).
- **Fix:** `prefetchExistingSkills()` walks the table in `max-rows`-sized pages via `.range()`, ordered by `repo_url` (the upsert conflict key — unique for non-null rows — so page boundaries are stable).
- **Verified against prod:** paginated walk returns **8396 rows across 9 pages, all 407 `tree_hash` rows**.

`run.ts` now logs `[Prefetch] N skill rows scanned; tree-hash cache seeded with M entries` per cron.

## Test plan

- [x] +5 tests in `prefetch-existing-skills.test.ts` — single page, 8400-row past-cap regression guard, exact-divisible termination, bare-URL cache-key seeding across pages, non-fatal mid-walk error
- [x] 98/98 indexer tests pass
- [x] Typecheck + lint + prettier clean
- [x] Governance review — 0 findings (`docs/internal/code_review/2026-05-15-smi-4861-prefetch-pagination.md`)
- [ ] Post-merge: next discovery cron `[Prefetch]` line shows ~8396 scanned; cron-after hit ratio climbs past 80%

Deno twin not updated — the Edge Function indexer is dormant post-Tier-2 migration (SMI-4852). Kill switch `INDEXER_CONCURRENCY_KILL_SWITCH=1` stays ON until Wave 3.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)