### PR TITLE
fix(dx): SMI-4910 silence docker compose env-var warnings + ship .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Skillsmith environment template — copy to .env: `cp .env.example .env`
+#
+# SCOPE: this file is the "docker compose onboarding minimum" — just enough to
+# start the dev container without Compose interpolation warnings. It is NOT a
+# complete environment. The authoritative, full variable set (70+ vars: Supabase,
+# Stripe, Vercel, etc.) and their types/@required/@sensitive metadata live in
+# `.env.schema`, which Varlock validates. Maintainers needing a Varlock-complete
+# `.env` should populate from `.env.schema`, not from this file.
+#
+# `.env` is gitignored — never commit it.
+#
+# The three keys below are interpolated by docker-compose.yml. Defining them
+# (even empty) keeps `docker compose up` warning-free; fill in real values only
+# if you need the corresponding feature.
+
+# GitHub PAT — optional. Empty = unauthenticated GitHub API (low rate limit);
+# only skill-indexing work needs a real gh* token.
+GITHUB_TOKEN=
+
+# Linear API key — maintainers only; used solely by the `orchestrator` profile.
+# Contributors leave this empty. See `.env.schema` for the format.
+LINEAR_API_KEY=
+
+# Encoded host project path for the doc-retrieval memory bind (SMI-4677).
+# External contributors: leave empty. Smith Horn team members: generate the
+# real value via the one-liner documented in `.env.schema`.
+SKILLSMITH_PROJECT_DIR_ENCODED=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,15 +40,30 @@ Not sure if your contribution fits? Open a [GitHub Discussion](https://github.co
 git clone https://github.com/smith-horn/skillsmith.git
 cd skillsmith
 
-# 2. Start Docker container
+# 2. Create your local environment file
+cp .env.example .env
+
+# 3. Start Docker container
 docker compose --profile dev up -d
 
-# 3. Install dependencies
+# 4. Install dependencies
 docker exec skillsmith-dev-1 npm install
 
-# 4. Run tests to verify setup
+# 5. Run tests to verify setup
 docker exec skillsmith-dev-1 npm test
 ```
+
+`.env.example` is the docker-compose onboarding minimum — it defines just the three variables
+`docker-compose.yml` interpolates, so step 2 alone keeps `docker compose up` warning-free. It is
+not a complete environment; the authoritative, full variable set (types, `@required`,
+`@sensitive`) lives in `.env.schema`. `.env` is gitignored — never commit it.
+
+### Maintainer setup (Smith Horn org members)
+
+Smith Horn team members should additionally populate `SKILLSMITH_PROJECT_DIR_ENCODED` in `.env` so
+the doc-retrieval memory bind (SMI-4677) resolves to the real host path. The generation one-liner
+is documented in `.env.schema` next to the variable definition. External contributors can leave
+the placeholder untouched — the dev container starts either way.
 
 ### Host-side install (SMI-4672)
 

--- a/README.md
+++ b/README.md
@@ -280,13 +280,16 @@ Skillsmith uses **Docker-first development**. All commands run inside Docker to 
 git clone https://github.com/smith-horn/skillsmith.git
 cd skillsmith
 
-# 2. Start the development container
+# 2. Create your local environment file
+cp .env.example .env
+
+# 3. Start the development container
 docker compose --profile dev up -d
 
-# 3. Install dependencies (first time only)
+# 4. Install dependencies (first time only)
 docker exec skillsmith-dev-1 npm install
 
-# 4. Build and test
+# 5. Build and test
 docker exec skillsmith-dev-1 npm run build
 docker exec skillsmith-dev-1 npm test
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,16 @@ services:
       # doc-retrieval-mcp memory-topic-files adapter. Source path uses
       # ${HOME} (resolved host-side at compose-parse time) +
       # ${SKILLSMITH_PROJECT_DIR_ENCODED} (per-contributor; see .env.schema).
+      # The `:-` empty-default is intentional (SMI-4910): contributors without
+      # a .env get a silent (warning-free) blank rather than a Compose WARN.
       # Bind always succeeds; if the source dir doesn't exist, Docker creates
       # an empty mount and the adapter's existsSync guard skips it gracefully.
       # Test profile and orchestrator omit this bind by design (CI runners
       # have no host memory dir; orchestrator does not index).
-      - ${HOME}/.claude/projects/${SKILLSMITH_PROJECT_DIR_ENCODED}/memory:/skillsmith-memory:ro
+      - ${HOME}/.claude/projects/${SKILLSMITH_PROJECT_DIR_ENCODED:-}/memory:/skillsmith-memory:ro
     environment:
       - NODE_ENV=development
-      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
       # SMI-4677: tells doc-retrieval-mcp memory-topic-files adapter to
       # bypass its homedir()-derived path resolution and read from the
       # bind-mounted dir above instead.
@@ -71,7 +73,7 @@ services:
       - node_modules:/app/node_modules
     environment:
       - NODE_ENV=development
-      - LINEAR_API_KEY=${LINEAR_API_KEY}
+      - LINEAR_API_KEY=${LINEAR_API_KEY:-}
       - SKILLSMITH_PATH=/app
     working_dir: /app
     entrypoint: ['/app/docker-entrypoint.sh']


### PR DESCRIPTION
## Summary

Contributors running `docker compose --profile dev up -d` saw three Docker Compose interpolation warnings (`SKILLSMITH_PROJECT_DIR_ENCODED`, `GITHUB_TOKEN`, `LINEAR_API_KEY` "variable is not set"). The container still started, but the warnings alarm new contributors and signal a real onboarding gap.

**Root cause:** Compose interpolates the whole file at parse time and warns on any `${VAR}` absent from both the shell env and a `.env` file. The repo shipped no `.env` / `.env.example` and no env-setup onboarding step — even though `.gitignore` already anticipates a committed `.env.example` (`!.env.example`).

## Changes

- **`docker-compose.yml`** — `${VAR:-}` empty-defaults on the three interpolated vars (matches the existing `${DEV_PORT:-3001}` pattern at line 9). `:-` only suppresses the warning; resolved values are unchanged.
- **`.env.example`** — new committed template defining the three docker-compose-interpolated vars (empty values — defined-but-empty silences the warnings). Scoped explicitly as the "docker-compose onboarding minimum"; `.env.schema` (70+ vars) stays authoritative for a Varlock-complete env.
- **`CONTRIBUTING.md` / `README.md`** — add a `cp .env.example .env` step; maintainer-only `SKILLSMITH_PROJECT_DIR_ENCODED` setup moved to its own CONTRIBUTING.md subsection.
- **`docs/internal`** — submodule pointer bumped to the ADR-109 implementation plan (smith-horn/skillsmith-docs#163).

## Process

ADR-109 infra change (`docker-compose.yml`) — routed through SPARC + plan-review (10 issues applied; C1 reconciled after verification showed `.env.schema` has 70 vars).

## Verification

- `docker compose config` → **zero warnings** with and without a `.env`
- H2 mount diff → memory-bind source path byte-identical before/after the `:-` change
- `docker compose --env-file .env.example config` → zero warnings
- Prettier + markdownlint clean on all changed files

No prod surface — local verification only. `[skip-smoke]`

Resolves: SMI-4910

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

[skip-impl-check] — config + docs change (docker-compose.yml, .env.example, CONTRIBUTING.md, README.md, submodule pointer); no packages/*/src code.
