### PR TITLE
fix(website): correct non-conforming callout colors on docs pages

### DIFF
--- a/packages/website/src/pages/docs/getting-started.astro
+++ b/packages/website/src/pages/docs/getting-started.astro
@@ -215,7 +215,7 @@ SKILLSMITH_API_KEY = "sk_live_your_key_here"`}</code></pre>
     <p>Read by any agent honouring the cross-agent skill convention.</p>
   </details>
 
-  <div class="callout callout-warning">
+  <div class="callout warning">
     <p class="callout-heading">Shell Exports Don't Work</p>
     <p>
       Running <code>export SKILLSMITH_API_KEY=...</code> in your terminal does NOT pass the variable

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -109,7 +109,7 @@ EOF`}</code></pre>
     </p>
   </div>
 
-  <div class="callout callout-warning">
+  <div class="callout warning">
     <p class="callout-heading">Shell Exports Don't Work</p>
     <p>
       Running <code>export SKILLSMITH_API_KEY=...</code> in your terminal does NOT pass the variable

--- a/packages/website/src/pages/docs/quickstart.astro
+++ b/packages/website/src/pages/docs/quickstart.astro
@@ -135,8 +135,8 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
     Get Skillsmith running in 5 minutes. Choose your preferred workflow below.
   </p>
 
-  <div class="quickstart-prereqs" style="background: var(--color-warning-bg, #fff8e1); border: 1px solid var(--color-warning-border, #ffe082); border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 1.5rem;">
-    <p style="margin: 0;"><strong>Note:</strong> The bare <code>skillsmith</code> package on npm is not this project. Use <code>@skillsmith/cli</code> for the CLI or <code>@skillsmith/mcp-server</code> for MCP. Alternatively, <code>npm install -g skillsmith-cli</code> also works.</p>
+  <div class="callout warning">
+    <p><strong>Note:</strong> The bare <code>skillsmith</code> package on npm is not this project. Use <code>@skillsmith/cli</code> for the CLI or <code>@skillsmith/mcp-server</code> for MCP. Alternatively, <code>npm install -g skillsmith-cli</code> also works.</p>
   </div>
 
   <!-- Prerequisites -->
@@ -406,8 +406,8 @@ claude`}</code></pre>
     </p>
   </div>
 
-  <div class="callout" style="background: #f0f7ff; border-left: 4px solid #3b82f6; padding: 1rem; margin: 1.5rem 0; border-radius: 0 0.5rem 0.5rem 0;">
-    <p style="margin: 0;">
+  <div class="callout">
+    <p>
       <strong>Built-in security scanning</strong> — Every skill is automatically scanned for security issues before installation.
       Skills with critical findings are blocked; high-severity findings require your confirmation.
       <a href="/docs/security">Learn more about security →</a>
@@ -417,7 +417,7 @@ claude`}</code></pre>
   <!-- PATH B: Direct CLI -->
   <h2 id="path-cli">Using the CLI Directly</h2>
 
-  <div class="callout callout-warning">
+  <div class="callout warning">
     <p class="callout-heading">When to use this</p>
     <p>
       Use the CLI if you prefer traditional command-line tools, want to script skill management, or are not using an MCP client.

--- a/packages/website/src/pages/docs/tutorials/govern.astro
+++ b/packages/website/src/pages/docs/tutorials/govern.astro
@@ -88,7 +88,7 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
     </tbody>
   </table>
 
-  <div class="callout callout-warning">
+  <div class="callout warning">
     <p class="callout-heading">Tier gating is enforced</p>
     <p>
       Governance tools require a Team or Enterprise license. Free and Individual tiers see typed


### PR DESCRIPTION
## Summary

Fixes non-conforming background/font colors on docs callouts — reported on `/docs/quickstart`. Resolves **SMI-4914**.

The docs site is dark-themed only (`#0d0d0f` bg, near-white text). Two callouts on `/docs/quickstart` set **light backgrounds via inline `style` attributes** without overriding the inherited near-white text — producing near-white text on light backgrounds, a WCAG AA contrast failure:

- **"Note:" callout** — `style="background: var(--color-warning-bg, #fff8e1)"`; the CSS vars are undefined in `src/`, so it fell back to light-yellow.
- **"Built-in security scanning" callout** — inline light-blue `#f0f7ff` background.

A repo-wide grep also found a related bug: `class="callout callout-warning"` matches no CSS rule (canonical is `.callout.warning`), so warning callouts silently rendered as plain cyan info callouts — on **4 pages**.

## Changes

8 lines across 4 `.astro` files, all reusing the existing canonical dark `.callout` / `.callout warning` component (`DocsLayout.astro:261–287`) — no new CSS:

- `quickstart.astro` — "Note:" → `callout warning` (drop inline light-yellow style); "Built-in security scanning" → drop inline light-blue style; "When to use this" → `callout warning`.
- `mcp-server.astro`, `getting-started.astro`, `tutorials/govern.astro` — `callout-warning` → `callout warning`.

## Verification

- Website build: 0 errors.
- `grep -rn "callout-warning" packages/website/src` → 0 results.
- `audit:standards` → 0 failures.
- Plan-reviewed (VP Product/Engineering/Design); plan: `docs/internal/implementation/docs-callout-contrast-conformance.md`.
- Pre-merge visual contrast check on the Vercel preview deployment.

> Note: local pre-push reported failures in `packages/core`/`packages/mcp-server` performance tests — the pre-existing `better-sqlite3` native-module env issue (SMI-4698 family), in packages untouched by this `.astro`-only change. CI runs in a clean Docker build.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)