### PR TITLE
fix(website): SMI-4916 — remove internal references from published content + add CI guard

### DIFF
--- a/packages/website/src/content/blog/building-skillsmith-claude-flow.md
+++ b/packages/website/src/content/blog/building-skillsmith-claude-flow.md
@@ -104,7 +104,7 @@ Across all Skillsmith work, Launchpad generated 98 hive-mind YAML configs. Stage
 The flow is deliberate and sequential:
 
 1. **Researcher** — reads all affected files, enumerates edge cases, fetches relevant documentation
-2. **Architect** — writes a full implementation plan to `docs/internal/implementation/` covering root cause, acceptance criteria, exact code changes, and a rollback plan
+2. **Architect** — writes a full implementation plan covering root cause, acceptance criteria, exact code changes, and a rollback plan
 3. **Plan-Review** — three VP perspectives sign off before coding begins
 4. **Coder agents** — implement against the reviewed plan, not against a vague prompt
 

--- a/packages/website/src/content/blog/inside-the-local-skill-database.md
+++ b/packages/website/src/content/blog/inside-the-local-skill-database.md
@@ -70,7 +70,7 @@ The FTS5 ranking weights `name` and `tags` higher than `description` and `author
 
 A nice side effect of doing search locally: it's basically free latency-wise. Typical FTS5 query times against the full registry cache are sub-millisecond, which means the whole search-to-render cycle in your editor or chat is dominated by network calls *you didn't make* (because you're hitting your own disk).
 
-There's a small footnote: native `better-sqlite3` is the default driver, but if its prebuilt binary fails to load (Node ABI mismatch after a Node upgrade is the usual cause), Skillsmith automatically falls back to a WASM SQLite build via `fts5-sql-bundle`. The user-visible behavior is identical; the only difference is a small startup cost the first time the WASM module loads. The fallback policy is documented in [ADR-009](https://github.com/smith-horn/skillsmith/blob/main/docs/internal/adr/009-embedding-service-fallback.md).
+There's a small footnote: native `better-sqlite3` is the default driver, but if its prebuilt binary fails to load (Node ABI mismatch after a Node upgrade is the usual cause), Skillsmith automatically falls back to a WASM SQLite build via `fts5-sql-bundle`. The user-visible behavior is identical; the only difference is a small startup cost the first time the WASM module loads. The fallback policy is deterministic: real ONNX embeddings when the runtime is available, and a stable mock embedding otherwise.
 
 ## Semantic search — opt-in
 

--- a/packages/website/src/content/blog/security-quarantine-safe-installation.md
+++ b/packages/website/src/content/blog/security-quarantine-safe-installation.md
@@ -122,7 +122,7 @@ const JAILBREAK_PATTERNS = [
 
 #### 2. AI Defence Patterns (CVE-Hardened)
 
-Our newest scanner category (SMI-1532) detects sophisticated injection techniques that bypass simple pattern matching:
+Our newest scanner category detects sophisticated injection techniques that bypass simple pattern matching:
 
 ```typescript
 // 15 CVE-hardened patterns including:

--- a/packages/website/src/pages/account/team/members.astro
+++ b/packages/website/src/pages/account/team/members.astro
@@ -75,7 +75,7 @@ const supabaseConfig = getSupabaseConfig()
               id="invite-btn"
               disabled
               aria-label="Invite member (coming soon)"
-              title="Invite flow ships with SMI-4294"
+              title="Invite flow coming soon"
             >
               Invite Member (Coming soon)
             </button>
@@ -89,7 +89,7 @@ const supabaseConfig = getSupabaseConfig()
           <div class="empty-state">
             <p>Pending invites not available in this release.</p>
             <p class="text-muted">
-              Team invitation flow ships with SMI-4294. Current seats can be adjusted from the
+              Team invitation flow is coming soon. Current seats can be adjusted from the
               <a href="/account/subscription/">subscription page</a>.
             </p>
           </div>

--- a/packages/website/src/pages/docs/api.astro
+++ b/packages/website/src/pages/docs/api.astro
@@ -264,8 +264,8 @@ if (result.success) {
 
   <p>
     The following tools are available on the Enterprise tier via the MCP server.
-    They are currently <em>in preview — availability pending production migration</em>
-    (tracked in SMI-4135). Backing tables are restored in staging (SMI-4123).
+    They are currently <em>in preview — availability pending a production
+    migration</em>.
   </p>
 
   <h3>webhook_configure</h3>
@@ -312,9 +312,8 @@ if (result.success) {
   </table>
 
   <p>
-    Requires the Enterprise tier. Availability is gated on the production
-    migration tracked in SMI-4135; calls will return a feature-unavailable
-    response until then.
+    Requires the Enterprise tier. Availability is gated on a pending production
+    migration; calls will return a feature-unavailable response until then.
   </p>
 
   <h3>api_key_manage</h3>
@@ -360,9 +359,8 @@ if (result.success) {
   </table>
 
   <p>
-    Requires the Enterprise tier. Availability is gated on the production
-    migration tracked in SMI-4135; calls will return a feature-unavailable
-    response until then.
+    Requires the Enterprise tier. Availability is gated on a pending production
+    migration; calls will return a feature-unavailable response until then.
   </p>
 
   <h2>Types</h2>

--- a/packages/website/src/pages/docs/getting-started.astro
+++ b/packages/website/src/pages/docs/getting-started.astro
@@ -117,11 +117,9 @@ EOF`}</code></pre>
   <p><strong>Option 3: MCP Client Settings</strong> (MCP server only)</p>
 
   <p>
-    Skillsmith is MCP-compatible — pick the snippet for your agent. SMI-4580: every
-    snippet uses the same shape; the only differences are the config-file path and
-    (for Codex) the format. Snippets are sourced from
-    <code>@skillsmith/cli/templates/mcp-server.template.snippets.ts</code> so this
-    page can't drift from the scaffolded README.
+    Skillsmith is MCP-compatible — pick the snippet for your agent. Every
+    snippet uses the same shape; the only differences are the config-file path
+    and (for Codex) the format.
   </p>
 
   <details>

--- a/packages/website/src/pages/docs/quickstart.astro
+++ b/packages/website/src/pages/docs/quickstart.astro
@@ -258,9 +258,8 @@ curl -fsSL https://claude.ai/install.sh | sh`}</code></pre>
   <h3 id="step-a2">Step 2: Add Skillsmith MCP Server</h3>
 
   <p>
-    Pick the snippet for your MCP client. SMI-4580: snippets are sourced from
-    <code>@skillsmith/cli/templates/mcp-server.template.snippets.ts</code> so this
-    page can't drift from the scaffolded README or root README.
+    Pick the snippet for your MCP client. Every snippet uses the same shape —
+    only the config-file path (and, for Codex, the format) differs.
   </p>
 
   <details open>

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -3248,6 +3248,252 @@ console.log(`\n${BOLD}Check 23: git config --file subshell discipline${RESET}`)
   }
 }
 
+// Check 24: No internal references in rendered published website content (SMI-4916)
+//
+// Internal Linear issue IDs (SMI-NNN), ADR numbers (ADR-NNN), and private doc
+// paths (docs/internal/) are engineering jargon and must never reach end users.
+// This check scans rendered website content — .astro pages and blog markdown —
+// and fails the build if such a reference appears in user-visible text.
+//
+// Non-rendered regions are stripped before matching so legitimate internal refs
+// in frontmatter, comments, and <style>/<script> blocks stay legal:
+//   - .astro: frontmatter fence (--- … ---), <!-- … -->, {/* … */} JSX comments,
+//     and entire <style>…</style> / <script>…</script> blocks. Inside the
+//     frontmatter fence ONLY, // line comments and /* … */ block comments are
+//     also stripped. In the template body, // and /* */ are literal rendered
+//     text and are NOT stripped.
+//   - .md/.mdx: <!-- … --> only. Fenced code blocks are rendered and kept.
+// A line carrying the marker `audit:internal-ref-ok` (matched on the raw line
+// before stripping) is skipped, for the rare case a page must legitimately name
+// a reference.
+console.log(
+  `\n${BOLD}Check 24: No internal references in rendered website content (SMI-4916)${RESET}`
+)
+
+function stripAstroNonRendered(content) {
+  const rawLines = content.split('\n')
+  const out = []
+  let inFrontmatter = false
+  let frontmatterDone = false
+  let inStyleOrScript = false
+  let inOpeningTag = false // <style/<script seen, > not yet found
+  let inHtmlComment = false
+  let inJsxComment = false
+  let jsxBracePending = false // a line ended with a bare `{` — a `/*` next opens a JSX comment
+  let inBlockComment = false // /* */ inside frontmatter only
+
+  for (let i = 0; i < rawLines.length; i++) {
+    let line = rawLines[i]
+
+    // Frontmatter fence: a leading `---` on the first non-empty line opens it.
+    if (!frontmatterDone && !inFrontmatter && line.trim() === '---') {
+      inFrontmatter = true
+      out.push('')
+      continue
+    }
+    if (inFrontmatter) {
+      if (line.trim() === '---') {
+        inFrontmatter = false
+        frontmatterDone = true
+        out.push('')
+        continue
+      }
+      // Inside frontmatter: strip // line comments and /* */ block comments.
+      if (inBlockComment) {
+        const end = line.indexOf('*/')
+        if (end === -1) {
+          out.push('')
+          continue
+        }
+        line = line.slice(end + 2)
+        inBlockComment = false
+      }
+      line = line.replace(/\/\*[\s\S]*?\*\//g, '')
+      const openBlock = line.indexOf('/*')
+      if (openBlock !== -1) {
+        line = line.slice(0, openBlock)
+        inBlockComment = true
+      }
+      line = line.replace(/\/\/.*$/, '')
+      out.push(line)
+      continue
+    }
+
+    frontmatterDone = true
+
+    // Multi-line HTML comment continuation.
+    if (inHtmlComment) {
+      const end = line.indexOf('-->')
+      if (end === -1) {
+        out.push('')
+        continue
+      }
+      line = line.slice(end + 3)
+      inHtmlComment = false
+    }
+    // Multi-line JSX comment continuation.
+    if (inJsxComment) {
+      const end = line.indexOf('*/}')
+      if (end === -1) {
+        out.push('')
+        continue
+      }
+      line = line.slice(end + 3)
+      inJsxComment = false
+    }
+    // A prior line ended with a bare `{`; if this line opens with `/*` (after
+    // optional whitespace) it is a JSX comment whose opener was split.
+    if (jsxBracePending) {
+      jsxBracePending = false
+      const m = line.match(/^\s*\/\*/)
+      if (m) {
+        const end = line.indexOf('*/}')
+        if (end === -1) {
+          inJsxComment = true
+          out.push('')
+          continue
+        }
+        line = line.slice(end + 3)
+      }
+    }
+    // Multi-line opening tag continuation: <style/<script seen, > not yet found.
+    if (inOpeningTag) {
+      const gt = line.indexOf('>')
+      if (gt === -1) {
+        out.push('')
+        continue
+      }
+      line = line.slice(gt + 1)
+      inOpeningTag = false
+      inStyleOrScript = true
+    }
+    // Multi-line <style>/<script> body continuation.
+    if (inStyleOrScript) {
+      const end = line.search(/<\/(style|script)>/i)
+      if (end === -1) {
+        out.push('')
+        continue
+      }
+      line = line.slice(line.indexOf('>', end) + 1)
+      inStyleOrScript = false
+    }
+
+    // Strip single-line HTML comments, then detect an unterminated one.
+    line = line.replace(/<!--[\s\S]*?-->/g, '')
+    const openHtml = line.indexOf('<!--')
+    if (openHtml !== -1) {
+      line = line.slice(0, openHtml)
+      inHtmlComment = true
+    }
+    // Strip single-line JSX comments, then detect an unterminated one.
+    line = line.replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
+    const openJsx = line.indexOf('{/*')
+    if (openJsx !== -1) {
+      line = line.slice(0, openJsx)
+      inJsxComment = true
+    }
+    // Strip single-line <style>/<script> blocks, then detect an open one.
+    line = line.replace(/<(style|script)\b[^>]*>[\s\S]*?<\/(style|script)>/gi, '')
+    const styleScriptOpen = line.search(/<(style|script)\b/i)
+    if (styleScriptOpen !== -1) {
+      const gt = line.indexOf('>', styleScriptOpen)
+      line = line.slice(0, styleScriptOpen)
+      if (gt === -1) {
+        inOpeningTag = true // `>` is on a later line
+      } else {
+        inStyleOrScript = true
+      }
+    }
+
+    // A line whose remaining content ends with a bare `{` may open a JSX
+    // comment on the next line (Astro allows whitespace between `{` and `/*`).
+    if (/\{\s*$/.test(line)) {
+      jsxBracePending = true
+    }
+
+    out.push(line)
+  }
+  return out
+}
+
+function stripMdNonRendered(content) {
+  const rawLines = content.split('\n')
+  const out = []
+  let inHtmlComment = false
+  for (let line of rawLines) {
+    if (inHtmlComment) {
+      const end = line.indexOf('-->')
+      if (end === -1) {
+        out.push('')
+        continue
+      }
+      line = line.slice(end + 3)
+      inHtmlComment = false
+    }
+    line = line.replace(/<!--[\s\S]*?-->/g, '')
+    const openHtml = line.indexOf('<!--')
+    if (openHtml !== -1) {
+      line = line.slice(0, openHtml)
+      inHtmlComment = true
+    }
+    out.push(line)
+  }
+  return out
+}
+
+const INTERNAL_REF_PATTERN = /\bSMI-\d+\b|\bADR-\d+\b|docs\/internal\//
+const internalRefPagesDir = 'packages/website/src/pages'
+const internalRefBlogDir = 'packages/website/src/content/blog'
+
+if (!existsSync(internalRefPagesDir) && !existsSync(internalRefBlogDir)) {
+  warn('Check 24: Website pages/blog directories not found - skipping internal-ref check')
+} else {
+  const internalRefHits = []
+  const astroFilesForRefCheck = existsSync(internalRefPagesDir)
+    ? getFilesRecursive(internalRefPagesDir, ['.astro'])
+    : []
+  const mdFilesForRefCheck = existsSync(internalRefBlogDir)
+    ? getFilesRecursive(internalRefBlogDir, ['.md', '.mdx'])
+    : []
+
+  for (const file of astroFilesForRefCheck) {
+    const content = readFileSync(file, 'utf8')
+    const rawLines = content.split('\n')
+    const strippedLines = stripAstroNonRendered(content)
+    for (let i = 0; i < strippedLines.length; i++) {
+      if (rawLines[i] && rawLines[i].includes('audit:internal-ref-ok')) continue
+      const match = strippedLines[i].match(INTERNAL_REF_PATTERN)
+      if (match) {
+        internalRefHits.push({ file: relative('.', file), line: i + 1, match: match[0] })
+      }
+    }
+  }
+  for (const file of mdFilesForRefCheck) {
+    const content = readFileSync(file, 'utf8')
+    const rawLines = content.split('\n')
+    const strippedLines = stripMdNonRendered(content)
+    for (let i = 0; i < strippedLines.length; i++) {
+      if (rawLines[i] && rawLines[i].includes('audit:internal-ref-ok')) continue
+      const match = strippedLines[i].match(INTERNAL_REF_PATTERN)
+      if (match) {
+        internalRefHits.push({ file: relative('.', file), line: i + 1, match: match[0] })
+      }
+    }
+  }
+
+  if (internalRefHits.length === 0) {
+    pass('Check 24: No internal references (SMI-/ADR-/docs/internal/) in rendered website content')
+  } else {
+    fail(
+      `Check 24: ${internalRefHits.length} internal reference(s) found in rendered website content`,
+      'Reword to drop the internal ref (Linear ID, ADR number, or docs/internal/ path). For a legitimate exception, add an `audit:internal-ref-ok` marker on that line.'
+    )
+    internalRefHits.forEach(({ file, line, match }) =>
+      console.log(`    ${file}:${line} — ${match}`)
+    )
+  }
+}
+
 // Summary
 console.log('\n' + '━'.repeat(50))
 console.log(`\n${BOLD}📊 Summary${RESET}\n`)

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -3382,7 +3382,7 @@ function stripAstroNonRendered(content) {
     }
     // Multi-line <style>/<script> body continuation.
     if (inStyleOrScript) {
-      const end = line.search(/<\/(style|script)\s*>/i)
+      const end = line.search(/<\/(style|script)\b[^>]*>/i)
       if (end === -1) {
         out.push('')
         continue
@@ -3406,7 +3406,7 @@ function stripAstroNonRendered(content) {
       inJsxComment = true
     }
     // Strip single-line <style>/<script> blocks, then detect an open one.
-    line = stripUntilStable(line, /<(style|script)\b[^>]*>[\s\S]*?<\/(style|script)\s*>/gi)
+    line = stripUntilStable(line, /<(style|script)\b[^>]*>[\s\S]*?<\/(style|script)\b[^>]*>/gi)
     const styleScriptOpen = line.search(/<(style|script)\b/i)
     if (styleScriptOpen !== -1) {
       const gt = line.indexOf('>', styleScriptOpen)

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -3270,6 +3270,19 @@ console.log(
   `\n${BOLD}Check 24: No internal references in rendered website content (SMI-4916)${RESET}`
 )
 
+// Apply a stripping regex repeatedly until the text stabilizes. A single
+// .replace() pass can leave a partial delimiter behind when matches overlap
+// (e.g. `<!--<!---->`), which CodeQL flags as incomplete multi-character
+// sanitization (js/incomplete-multi-character-sanitization).
+function stripUntilStable(text, regex) {
+  let prev
+  do {
+    prev = text
+    text = text.replace(regex, '')
+  } while (text !== prev)
+  return text
+}
+
 function stripAstroNonRendered(content) {
   const rawLines = content.split('\n')
   const out = []
@@ -3369,7 +3382,7 @@ function stripAstroNonRendered(content) {
     }
     // Multi-line <style>/<script> body continuation.
     if (inStyleOrScript) {
-      const end = line.search(/<\/(style|script)>/i)
+      const end = line.search(/<\/(style|script)\s*>/i)
       if (end === -1) {
         out.push('')
         continue
@@ -3379,7 +3392,7 @@ function stripAstroNonRendered(content) {
     }
 
     // Strip single-line HTML comments, then detect an unterminated one.
-    line = line.replace(/<!--[\s\S]*?-->/g, '')
+    line = stripUntilStable(line, /<!--[\s\S]*?-->/g)
     const openHtml = line.indexOf('<!--')
     if (openHtml !== -1) {
       line = line.slice(0, openHtml)
@@ -3393,7 +3406,7 @@ function stripAstroNonRendered(content) {
       inJsxComment = true
     }
     // Strip single-line <style>/<script> blocks, then detect an open one.
-    line = line.replace(/<(style|script)\b[^>]*>[\s\S]*?<\/(style|script)>/gi, '')
+    line = stripUntilStable(line, /<(style|script)\b[^>]*>[\s\S]*?<\/(style|script)\s*>/gi)
     const styleScriptOpen = line.search(/<(style|script)\b/i)
     if (styleScriptOpen !== -1) {
       const gt = line.indexOf('>', styleScriptOpen)
@@ -3430,7 +3443,7 @@ function stripMdNonRendered(content) {
       line = line.slice(end + 3)
       inHtmlComment = false
     }
-    line = line.replace(/<!--[\s\S]*?-->/g, '')
+    line = stripUntilStable(line, /<!--[\s\S]*?-->/g)
     const openHtml = line.indexOf('<!--')
     if (openHtml !== -1) {
       line = line.slice(0, openHtml)


### PR DESCRIPTION
## Summary

Internal Linear issue IDs and other engineering-internal references were rendered in published, user-visible content on https://www.skillsmith.app — e.g. `SMI-4580` in prose on `/docs/quickstart`. There was **no CI check** guarding against this. Resolves **SMI-4916**.

## Changes

**Removed/reworded rendered internal references** (7 files):
- `docs/quickstart.astro`, `docs/getting-started.astro` — `SMI-4580` dropped; kept the user-useful "same shape" guidance
- `docs/api.astro` — `SMI-4135`/`SMI-4123` and the internal "backing tables" detail removed (3 paragraphs)
- `account/team/members.astro` — `SMI-4294` removed from a tooltip and prose ("coming soon")
- `blog/security-quarantine-safe-installation.md` — `SMI-1532` parenthetical dropped
- `blog/inside-the-local-skill-database.md` — `ADR-009` link to a private `docs/internal/adr/…` path (404s for the public) reworded
- `blog/building-skillsmith-claude-flow.md` — literal `docs/internal/implementation/` path dropped

**New CI guard** — `scripts/audit-standards.mjs` Check 24: fails the build when `SMI-\d+`, `ADR-\d+`, or `docs/internal/` appears in **rendered** website content (`pages/**/*.astro`, `content/blog/**/*.{md,mdx}`). Non-rendered regions — frontmatter, `<!-- -->`, `{/* */}`, `<style>`/`<script>` blocks — are stripped before matching, so existing code-comment references are unaffected. Exemption marker: `audit:internal-ref-ok`.

## Verification

- Check 24 **passes** after the content edits (0 rendered hits); full `audit:standards` `Failed: 0`.
- Negative tests: the check **fails** on injected `SMI-9999` / `ADR-999` / `docs/internal/` in a page body.
- Positive tests: the check does **not** fire for refs in `{/* */}`, frontmatter `//`, `<!-- -->`, or on exemption-marked lines.
- Root test suite passes locally (3628 tests). Plan-reviewed (VP Product/Engineering/Design); ADR-109 infra path (`audit-standards.mjs`).

> Pre-push reported the known SMI-4767-family host test-harness flakiness; the root suite passes on direct invocation. CI runs the real gate.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)