### PR TITLE
fix(cli): SMI-4917 — repair first-time install (search crash, sync drops all skills, no self-config)

### DIFF
--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -19,12 +19,8 @@
 
 import { Command } from 'commander'
 import chalk from 'chalk'
-import {
-  createDatabaseAsync,
-  initializeSchema,
-  AdvisoryRepository,
-  type SkillAdvisory,
-} from '@skillsmith/core'
+import { AdvisoryRepository, type SkillAdvisory } from '@skillsmith/core'
+import { openCliDatabase } from '../utils/open-database.js'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { requireTier } from '../utils/require-tier.js'
@@ -102,8 +98,7 @@ async function runAdvisoriesAudit(options: AuditAdvisoriesOptions): Promise<void
   // Team tier required for security advisories
   await requireTier('team')
 
-  const db = await createDatabaseAsync(options.db)
-  initializeSchema(db) // SMI-4486
+  const db = await openCliDatabase(options.db)
 
   try {
     const advisoryRepo = new AdvisoryRepository(db)

--- a/packages/cli/src/commands/import-local.ts
+++ b/packages/cli/src/commands/import-local.ts
@@ -6,12 +6,8 @@
  * @see SMI-4665
  */
 import { Command } from 'commander'
-import {
-  createDatabaseAsync,
-  initializeSchema,
-  SkillRepository,
-  type SkillCreateInput,
-} from '@skillsmith/core'
+import { SkillRepository, type SkillCreateInput } from '@skillsmith/core'
+import { openCliDatabase } from '../utils/open-database.js'
 import {
   getCanonicalInstallPath,
   getInstallPath,
@@ -97,8 +93,7 @@ export async function runImportLocal(opts: ImportLocalOptions): Promise<ImportLo
 
   if (opts.dryRun) {
     // Tally without writing.
-    const db = await createDatabaseAsync(dbPath)
-    initializeSchema(db)
+    const db = await openCliDatabase(dbPath)
     try {
       const repo = new SkillRepository(db)
       for (const record of records) {
@@ -121,8 +116,7 @@ export async function runImportLocal(opts: ImportLocalOptions): Promise<ImportLo
   }
 
   // Real import.
-  const db = await createDatabaseAsync(dbPath)
-  initializeSchema(db)
+  const db = await openCliDatabase(dbPath)
   try {
     const repo = new SkillRepository(db)
     for (const record of records) {

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -14,7 +14,8 @@
  */
 
 import { Command } from 'commander'
-import { createDatabaseAsync, SkillRepository, type SkillCreateInput } from '@skillsmith/core'
+import { SkillRepository, type SkillCreateInput } from '@skillsmith/core'
+import { openCliDatabase } from '../utils/open-database.js'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
 
@@ -272,7 +273,7 @@ export async function importSkills(options: ImportOptions = {}): Promise<ImportR
   }
 
   // Initialize database
-  const db = await createDatabaseAsync(dbPath)
+  const db = await openCliDatabase(dbPath)
   const skillRepo = new SkillRepository(db)
 
   console.log(`Searching for repositories with topic: ${topic}...`)

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -8,13 +8,8 @@
 import { Command } from 'commander'
 import chalk from 'chalk'
 import ora from 'ora'
-import {
-  createDatabaseAsync,
-  initializeSchema,
-  SkillRepository,
-  createApiClient,
-  loadStoredAccessToken,
-} from '@skillsmith/core'
+import { SkillRepository, createApiClient, loadStoredAccessToken } from '@skillsmith/core'
+import { openCliDatabase } from '../utils/open-database.js'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { displaySkillDetails } from './search-formatters.js'
@@ -45,8 +40,7 @@ export function createInfoCommand(): Command {
       const spinner = ora('Looking up skill...').start()
 
       try {
-        const db = await createDatabaseAsync(options.db)
-        initializeSchema(db)
+        const db = await openCliDatabase(options.db)
         const skillRepo = new SkillRepository(db)
 
         // Try local DB first

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -9,8 +9,6 @@ import { Command } from 'commander'
 import chalk from 'chalk'
 import ora from 'ora'
 import {
-  createDatabaseAsync,
-  initializeSchema,
   SkillRepository,
   SkillDependencyRepository,
   SkillInstallationService,
@@ -20,6 +18,7 @@ import {
   type RegistryLookup,
   type RegistrySkillInfo,
 } from '@skillsmith/core'
+import { openCliDatabase } from '../utils/open-database.js'
 import { addLink, assertClientId, getInstallPath, type ClientId } from '@skillsmith/core/install'
 import { DEFAULT_DB_PATH, DEFAULT_MANIFEST_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
@@ -244,8 +243,7 @@ export function createInstallCommand(): Command {
           }
 
           const dbPath = opts.db ?? DEFAULT_DB_PATH
-          const db = await createDatabaseAsync(dbPath)
-          initializeSchema(db)
+          const db = await openCliDatabase(dbPath)
 
           const spinner = jsonOutput ? null : ora('Installing skill...').start()
 

--- a/packages/cli/src/commands/login.post-login-sync.test.ts
+++ b/packages/cli/src/commands/login.post-login-sync.test.ts
@@ -1,0 +1,136 @@
+// SMI-4917 Bug 3: post-login registry auto-sync.
+// PLS-1: device-code success path runs the post-login sync.
+// PLS-2: a failed post-login sync is non-fatal — login still exits 0.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mockDeviceCodeSuccess } from './login.test-helpers.js'
+
+vi.mock('readline', () => {
+  const createInterface = vi.fn()
+  return { default: { createInterface }, createInterface }
+})
+
+vi.mock('@skillsmith/core', () => ({
+  loadCredentials: vi.fn(),
+  storeCredentials: vi.fn(),
+  getApiKey: vi.fn(),
+  getApiBaseUrl: vi.fn().mockReturnValue('https://api.skillsmith.app/functions/v1'),
+  storeApiKey: vi.fn(),
+  isValidApiKeyFormat: vi.fn(),
+}))
+
+vi.mock('@inquirer/prompts', () => ({ password: vi.fn() }))
+vi.mock('open', () => ({ default: vi.fn() }))
+
+// postLoginSync (SMI-4917) opens a DB and runs runRegistrySync — both stubbed.
+const mockOpenCliDatabase = vi.fn()
+const mockRunRegistrySync = vi.fn()
+vi.mock('../utils/open-database.js', () => ({
+  openCliDatabase: (...args: unknown[]) => mockOpenCliDatabase(...args),
+}))
+vi.mock('./run-registry-sync.js', () => ({
+  runRegistrySync: (...args: unknown[]) => mockRunRegistrySync(...args),
+}))
+vi.mock('ora', () => {
+  const spinner = {
+    start: vi.fn(() => spinner),
+    succeed: vi.fn(() => spinner),
+    warn: vi.fn(() => spinner),
+    fail: vi.fn(() => spinner),
+    stop: vi.fn(() => spinner),
+    text: '',
+  }
+  return { default: vi.fn(() => spinner) }
+})
+
+import { createLoginCommand } from './login.js'
+import { loadCredentials, storeCredentials } from '@skillsmith/core'
+
+const mockLoadCredentials = vi.mocked(loadCredentials)
+const mockStoreCredentials = vi.mocked(storeCredentials)
+
+async function runCommand(args: string[] = []): Promise<void> {
+  const cmd = createLoginCommand()
+  await cmd.parseAsync(['node', 'login', ...args])
+}
+
+describe('SMI-4917 Bug 3: postLoginSync', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+  let processExitSpy: ReturnType<typeof vi.spyOn>
+  let originalEnv: NodeJS.ProcessEnv
+  let originalFetch: typeof fetch
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    originalEnv = { ...process.env }
+    originalFetch = global.fetch
+    process.env['CI'] = 'true'
+    delete process.env['SKILLSMITH_API_KEY']
+    mockLoadCredentials.mockResolvedValue(null)
+    mockStoreCredentials.mockResolvedValue(undefined)
+    mockOpenCliDatabase.mockResolvedValue({ close: vi.fn() })
+    mockRunRegistrySync.mockResolvedValue({
+      success: true,
+      skillsAdded: 0,
+      skillsUpdated: 0,
+      skillsUnchanged: 0,
+      totalProcessed: 0,
+      errors: [],
+      durationMs: 1,
+      dryRun: false,
+    })
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: string | number | null | undefined) => {
+        vi.clearAllTimers()
+        throw new Error(`process.exit(${code ?? 0})`)
+      })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    process.env = originalEnv
+    global.fetch = originalFetch
+    consoleLogSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+    processExitSpy.mockRestore()
+  })
+
+  it('PLS-1: device-code success path runs the post-login registry sync', async () => {
+    mockDeviceCodeSuccess()
+    mockRunRegistrySync.mockResolvedValue({
+      success: true,
+      skillsAdded: 12,
+      skillsUpdated: 0,
+      skillsUnchanged: 0,
+      totalProcessed: 12,
+      errors: [],
+      durationMs: 1,
+      dryRun: false,
+    })
+
+    const run = runCommand()
+    run.catch(() => {})
+    await vi.runAllTimersAsync()
+
+    await expect(run).rejects.toThrow('process.exit(0)')
+    expect(mockRunRegistrySync).toHaveBeenCalledTimes(1)
+  })
+
+  it('PLS-2: a failed post-login sync is non-fatal — login still exits 0', async () => {
+    mockDeviceCodeSuccess()
+    // Sync fails; credentials were already persisted, so login must still succeed.
+    mockRunRegistrySync.mockRejectedValue(new Error('registry unreachable'))
+
+    const run = runCommand()
+    run.catch(() => {})
+    await vi.runAllTimersAsync()
+
+    await expect(run).rejects.toThrow('process.exit(0)')
+    expect(mockStoreCredentials).toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/commands/login.test-helpers.ts
+++ b/packages/cli/src/commands/login.test-helpers.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Shared test helpers for the `login` command test files.
+ *
+ * Extracted so both `login.test.ts` and `login.post-login-sync.test.ts` share
+ * the device-code fetch stub without duplication (and to keep each test file
+ * under the 500-line limit).
+ */
+import { vi } from 'vitest'
+
+/**
+ * Stub `global.fetch` to simulate a successful device-code exchange: the
+ * `auth-device-code` request succeeds, the first `auth-device-token` poll
+ * returns 428 (authorization pending), and the second poll returns tokens.
+ */
+export function mockDeviceCodeSuccess(): void {
+  let callCount = 0
+  global.fetch = vi.fn().mockImplementation((url: string) => {
+    if ((url as string).includes('auth-device-code')) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            device_code: 'dc_test',
+            user_code: 'BCDFGHJK',
+            verification_uri: 'https://skillsmith.app/device',
+            expires_in: 900,
+            interval: 5,
+          }),
+      })
+    }
+    // auth-device-token
+    callCount++
+    if (callCount === 1) {
+      return Promise.resolve({ ok: false, status: 428, json: () => Promise.resolve({}) })
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: 'jwt.access',
+          refresh_token: 'jwt.refresh',
+          expires_in: 3600,
+        }),
+    })
+  }) as typeof fetch
+}

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -43,7 +43,38 @@ vi.mock('@inquirer/prompts', () => ({
 
 vi.mock('open', () => ({ default: vi.fn() }))
 
+// SMI-4917: postLoginSync opens a DB and syncs the registry after login.
+// Stub the helper, the sync, and ora so the post-login sync is a controlled
+// no-op here — its behavior is covered by login.post-login-sync.test.ts.
+vi.mock('../utils/open-database.js', () => ({
+  openCliDatabase: vi.fn().mockResolvedValue({ close: vi.fn() }),
+}))
+vi.mock('./run-registry-sync.js', () => ({
+  runRegistrySync: vi.fn().mockResolvedValue({
+    success: true,
+    skillsAdded: 0,
+    skillsUpdated: 0,
+    skillsUnchanged: 0,
+    totalProcessed: 0,
+    errors: [],
+    durationMs: 1,
+    dryRun: false,
+  }),
+}))
+vi.mock('ora', () => {
+  const spinner = {
+    start: vi.fn(() => spinner),
+    succeed: vi.fn(() => spinner),
+    warn: vi.fn(() => spinner),
+    fail: vi.fn(() => spinner),
+    stop: vi.fn(() => spinner),
+    text: '',
+  }
+  return { default: vi.fn(() => spinner) }
+})
+
 import { createLoginCommand } from './login.js'
+import { mockDeviceCodeSuccess } from './login.test-helpers.js'
 import {
   loadCredentials,
   storeCredentials,
@@ -66,40 +97,6 @@ const NOW = Date.now()
 async function runCommand(args: string[] = []): Promise<void> {
   const cmd = createLoginCommand()
   await cmd.parseAsync(['node', 'login', ...args])
-}
-
-// Simulate a successful device-code exchange
-function mockDeviceCodeSuccess(): void {
-  let callCount = 0
-  global.fetch = vi.fn().mockImplementation((url: string) => {
-    if ((url as string).includes('auth-device-code')) {
-      return Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            device_code: 'dc_test',
-            user_code: 'BCDFGHJK',
-            verification_uri: 'https://skillsmith.app/device',
-            expires_in: 900,
-            interval: 5,
-          }),
-      })
-    }
-    // auth-device-token
-    callCount++
-    if (callCount === 1) {
-      return Promise.resolve({ ok: false, status: 428, json: () => Promise.resolve({}) })
-    }
-    return Promise.resolve({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          access_token: 'jwt.access',
-          refresh_token: 'jwt.refresh',
-          expires_in: 3600,
-        }),
-    })
-  }) as typeof fetch
 }
 
 describe('createLoginCommand', () => {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -6,6 +6,7 @@ import { hostname } from 'node:os'
 import { Command } from 'commander'
 import { password } from '@inquirer/prompts'
 import chalk from 'chalk'
+import ora from 'ora'
 import {
   getApiKey,
   getApiBaseUrl,
@@ -16,6 +17,9 @@ import {
   type TokenCredentials,
 } from '@skillsmith/core'
 import { VERSION as CLI_VERSION } from '../version.js'
+import { DEFAULT_DB_PATH } from '../config.js'
+import { openCliDatabase } from '../utils/open-database.js'
+import { runRegistrySync } from './run-registry-sync.js'
 
 const DEVICE_PAGE_URL = 'https://skillsmith.app/device'
 const DEVICE_CODE_TIMEOUT_MS = 15 * 60 * 1000
@@ -146,6 +150,32 @@ async function pollDeviceToken(deviceCode: string): Promise<PollResult> {
   }
 }
 
+/**
+ * SMI-4917 Bug 3: bootstrap the local skill registry immediately after a
+ * successful login so the very next `skillsmith search` returns results.
+ *
+ * Non-fatal: credentials are already persisted by `storeCredentials` /
+ * `storeApiKey` before this runs. A sync failure (offline, API error) downgrades
+ * to a warning and never changes the login exit code. `ora` no-ops on a non-TTY
+ * stream, so headless logins are unaffected.
+ *
+ * Shared by both the device-code flow and the paste-legacy flow (M1).
+ */
+async function postLoginSync(): Promise<void> {
+  const syncSpinner = ora('Syncing skills from the registry…').start()
+  try {
+    const db = await openCliDatabase(DEFAULT_DB_PATH)
+    try {
+      const result = await runRegistrySync(db)
+      syncSpinner.succeed(chalk.green(`Synced ${result.totalProcessed} skills.`))
+    } finally {
+      db.close()
+    }
+  } catch {
+    syncSpinner.warn(chalk.yellow('Skills sync skipped — run `skillsmith sync` later.'))
+  }
+}
+
 async function runDeviceCodeFlow(noBrowser: boolean): Promise<void> {
   let dc: DeviceCodeBody
   try {
@@ -234,6 +264,8 @@ async function runDeviceCodeFlow(noBrowser: boolean): Promise<void> {
 
     await storeCredentials({ ...result.creds, version: 2 })
     console.log(chalk.green('\nLogged in successfully.'))
+    // SMI-4917 Bug 3: auto-sync the registry so the first search returns results.
+    await postLoginSync()
     // SMI-4447: close the "did it work?" gap post-login. A single concrete command the
     // user can run in-terminal beats a URL (phishing-safe, no browser context switch).
     console.log(chalk.dim('  Try it: skillsmith search mcp'))
@@ -282,6 +314,10 @@ async function runPasteLegacyFlow(): Promise<void> {
       }
       console.log(chalk.green('\nLogged in successfully.'))
       console.log(chalk.dim('  Clear your clipboard when done.'))
+      // SMI-4917 Bug 3: auto-sync the registry so the first search returns results.
+      await postLoginSync()
+      // SMI-4447 parity: give the paste path the same concrete next-step hint.
+      console.log(chalk.dim('  Try it: skillsmith search mcp'))
       process.exit(EXIT.success)
     }
   } catch (err) {

--- a/packages/cli/src/commands/manage.ts
+++ b/packages/cli/src/commands/manage.ts
@@ -12,14 +12,13 @@ import ora from 'ora'
 import { mkdir } from 'fs/promises'
 import { dirname } from 'path'
 import {
-  createDatabaseAsync,
-  initializeSchema,
   SkillRepository,
   SkillDependencyRepository,
   SkillInstallationService,
   type Skill,
   type TrustTier,
 } from '@skillsmith/core'
+import { openCliDatabase } from '../utils/open-database.js'
 import { DEFAULT_DB_PATH, DEFAULT_SKILLS_DIR, DEFAULT_MANIFEST_PATH } from '../config.js'
 import { removeLinks } from '@skillsmith/core/install'
 import { sanitizeError } from '../utils/sanitize.js'
@@ -93,7 +92,7 @@ async function getSkillDiff(
   skillName: string,
   dbPath: string
 ): Promise<{ oldVersion: string | null; newVersion: string | null; changes: string[] } | null> {
-  const db = await createDatabaseAsync(dbPath)
+  const db = await openCliDatabase(dbPath)
   const skillRepo = new SkillRepository(db)
 
   try {
@@ -254,8 +253,7 @@ async function removeSkill(skillName: string, force: boolean, dbPath: string): P
 
   // Ensure database directory exists before opening
   await mkdir(dirname(dbPath), { recursive: true })
-  const db = await createDatabaseAsync(dbPath)
-  initializeSchema(db)
+  const db = await openCliDatabase(dbPath)
 
   try {
     const skillRepo = new SkillRepository(db)

--- a/packages/cli/src/commands/run-registry-sync.ts
+++ b/packages/cli/src/commands/run-registry-sync.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Reusable registry-sync helper.
+ * @see SMI-4917
+ *
+ * Extracted from `sync.ts`'s `runSync` so the registry-sync mechanics (JWT load,
+ * API client, repositories, `SyncEngine`) can be reused by:
+ *   - the `sync` command (`sync.ts`),
+ *   - the post-login auto-sync (`login.ts`),
+ *   - the empty-DB auto-sync on `search` (`search.helpers.ts`).
+ *
+ * This helper does NOT open or close the database and does NOT call
+ * `process.exit` — the caller owns the database lifecycle and process control.
+ */
+import {
+  SkillRepository,
+  SyncConfigRepository,
+  SyncHistoryRepository,
+  SkillVersionRepository,
+  SyncEngine,
+  createApiClient,
+  loadStoredAccessToken,
+  type DatabaseType,
+  type SyncProgress,
+  type SyncResult,
+} from '@skillsmith/core'
+
+/**
+ * Run a registry sync against an already-open, schema-initialized database.
+ *
+ * @param db - An open CLI database (use `openCliDatabase`). The caller owns
+ *   `db.close()`.
+ * @param options - Sync options.
+ * @param options.force - Force a full sync (ignore last-sync time).
+ * @param options.dryRun - Report what would sync without writing.
+ * @param options.onProgress - Progress callback forwarded to the `SyncEngine`.
+ * @returns The `SyncResult` from the engine.
+ */
+export async function runRegistrySync(
+  db: DatabaseType,
+  options: {
+    force?: boolean
+    dryRun?: boolean
+    onProgress?: (progress: SyncProgress) => void
+  } = {}
+): Promise<SyncResult> {
+  const skillRepo = new SkillRepository(db)
+  const syncConfigRepo = new SyncConfigRepository(db)
+  const syncHistoryRepo = new SyncHistoryRepository(db)
+  const skillVersionRepo = new SkillVersionRepository(db)
+
+  // SMI-4474: auto-load JWT from ~/.skillsmith/config.json so logged-in users
+  // count toward their quota instead of going anonymous.
+  const jwtToken = await loadStoredAccessToken()
+  const apiClient = createApiClient(jwtToken ? { jwtToken } : {})
+
+  const syncEngine = new SyncEngine(
+    apiClient,
+    skillRepo,
+    syncConfigRepo,
+    syncHistoryRepo,
+    skillVersionRepo
+  )
+
+  const syncOptions: {
+    force?: boolean
+    dryRun?: boolean
+    onProgress?: (progress: SyncProgress) => void
+  } = {}
+  if (options.force !== undefined) syncOptions.force = options.force
+  if (options.dryRun !== undefined) syncOptions.dryRun = options.dryRun
+  if (options.onProgress !== undefined) syncOptions.onProgress = options.onProgress
+
+  return syncEngine.sync(syncOptions)
+}

--- a/packages/cli/src/commands/search.helpers.ts
+++ b/packages/cli/src/commands/search.helpers.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Helpers for the `search` command.
+ * @see SMI-4917
+ *
+ * Extracted from `search.ts` pre-emptively so the empty-DB auto-sync logic does
+ * not push `search.ts` past the 500-line `audit:standards` gate.
+ */
+import chalk from 'chalk'
+import ora from 'ora'
+import {
+  SkillRepository,
+  SyncHistoryRepository,
+  loadStoredAccessToken,
+  type DatabaseType,
+} from '@skillsmith/core'
+import { runRegistrySync } from './run-registry-sync.js'
+
+/** Skip the auto-sync if a sync attempt started within this window. */
+const AUTO_SYNC_COOLDOWN_MS = 15 * 60_000
+
+/**
+ * Bootstrap the local registry on a first-time `search` against an empty DB.
+ *
+ * Bug 3 of SMI-4917: a fresh install (or a login that pre-dates the post-login
+ * auto-sync) leaves an empty `skills` table, so the first `search` returns
+ * nothing. This helper syncs the registry once, best-effort, when the DB is
+ * empty.
+ *
+ * Bounded (H5) to avoid hammering the registry:
+ *   - skipped when the DB already has skills,
+ *   - skipped for anonymous users (no stored token) — they would only hit the
+ *     trial cap; `search` falls back to whatever is local,
+ *   - skipped when a sync was attempted within the last 15 minutes (so a string
+ *     of failed/offline searches does not re-trigger a full sync each time).
+ *
+ * Never throws: a sync failure downgrades to a warning and `search` proceeds
+ * with local results.
+ *
+ * @param db - An open, schema-initialized CLI database.
+ */
+export async function autoSyncIfEmpty(db: DatabaseType): Promise<void> {
+  if (new SkillRepository(db).count() > 0) return
+
+  // Anonymous users would only hit the trial cap — skip the auto-sync.
+  if (!(await loadStoredAccessToken())) return
+
+  // Skip when a sync was attempted recently (success OR failure).
+  const lastAttempt = new SyncHistoryRepository(db).getHistory(1)[0]
+  if (lastAttempt) {
+    const startedMs = new Date(lastAttempt.startedAt).getTime()
+    if (!Number.isNaN(startedMs) && Date.now() - startedMs < AUTO_SYNC_COOLDOWN_MS) {
+      return
+    }
+  }
+
+  const spinner = ora('No skills found locally — syncing from registry…').start()
+  try {
+    const result = await runRegistrySync(db)
+    spinner.succeed(chalk.green(`Synced ${result.totalProcessed} skills.`))
+  } catch {
+    spinner.warn(chalk.yellow('Could not sync — showing local results only.'))
+  }
+}

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -9,8 +9,6 @@ import { input, checkbox, number, select } from '@inquirer/prompts'
 import chalk from 'chalk'
 import ora from 'ora'
 import {
-  createDatabaseAsync,
-  initializeSchema,
   SearchService,
   SkillRepository,
   SkillDependencyRepository,
@@ -20,6 +18,8 @@ import {
   type RegistryLookup,
   type RegistrySkillInfo,
 } from '@skillsmith/core'
+import { openCliDatabase } from '../utils/open-database.js'
+import { autoSyncIfEmpty } from './search.helpers.js'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { type InteractiveSearchState, type SearchPhase, PAGE_SIZE } from './search-types.js'
@@ -42,7 +42,9 @@ export {
  * Uses iterative while loop instead of recursion for new searches.
  */
 async function runInteractiveSearch(dbPath: string): Promise<void> {
-  const db = await createDatabaseAsync(dbPath)
+  const db = await openCliDatabase(dbPath)
+  // SMI-4917 Bug 3: bootstrap the local registry on a first-time search.
+  await autoSyncIfEmpty(db)
   const searchService = new SearchService(db)
 
   console.log(chalk.bold.blue('\n=== Skillsmith Interactive Search ===\n'))
@@ -67,9 +69,11 @@ async function runInteractiveSearch(dbPath: string): Promise<void> {
           message: 'Filter by trust tier (select with space, enter to continue):',
           choices: [
             { name: chalk.green('Verified'), value: 'verified' },
+            { name: chalk.blue('Curated'), value: 'curated' },
             { name: chalk.yellow('Community'), value: 'community' },
             { name: chalk.red('Experimental'), value: 'experimental' },
             { name: chalk.gray('Unknown'), value: 'unknown' },
+            { name: chalk.cyan('Local'), value: 'local' },
           ],
         })
 
@@ -203,7 +207,6 @@ async function runInteractiveSearch(dbPath: string): Promise<void> {
             if (nextAction === 'install') {
               const installSpinner = ora('Installing skill...').start()
               try {
-                initializeSchema(db)
                 const skillRepo = new SkillRepository(db)
                 const skillDependencyRepo = new SkillDependencyRepository(db)
                 const registryLookup: RegistryLookup = {
@@ -275,7 +278,9 @@ async function runSearch(
     maxRisk?: number
   }
 ): Promise<void> {
-  const db = await createDatabaseAsync(options.db)
+  const db = await openCliDatabase(options.db)
+  // SMI-4917 Bug 3: bootstrap the local registry on a first-time search.
+  await autoSyncIfEmpty(db)
   const searchService = new SearchService(db)
 
   try {
@@ -341,7 +346,7 @@ Quality Score Formula:
     .option('-l, --limit <number>', 'Maximum results to show', '20')
     .option(
       '-t, --tier <tier>',
-      'Filter by trust tier (verified, community, experimental, unknown)'
+      'Filter by trust tier (verified, curated, community, experimental, unknown, local)'
     )
     .option(
       '-c, --category <category>',

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -18,18 +18,13 @@ import chalk from 'chalk'
 import ora from 'ora'
 import Table from 'cli-table3'
 import {
-  createDatabaseAsync,
-  initializeSchema,
-  SkillRepository,
-  createApiClient,
-  loadStoredAccessToken,
   SyncConfigRepository,
   SyncHistoryRepository,
-  SyncEngine,
-  SkillVersionRepository,
   type SyncProgress,
   type SyncFrequency,
 } from '@skillsmith/core'
+import { openCliDatabase } from '../utils/open-database.js'
+import { runRegistrySync } from './run-registry-sync.js'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { formatDuration, formatDate, formatTimeUntil } from '../utils/formatters.js'
@@ -48,32 +43,14 @@ async function runSync(options: {
 
   try {
     spinner.start('Opening database...')
-    const db = await createDatabaseAsync(options.dbPath)
-    // SMI-4486: createDatabaseAsync returns a connected DB but doesn't create
-    // tables — fresh installs would otherwise hit "no such table: skills".
-    initializeSchema(db)
+    // SMI-4917: openCliDatabase opens a connected, schema-initialized DB —
+    // fresh installs would otherwise hit "no such table: skills".
+    const db = await openCliDatabase(options.dbPath)
 
     try {
-      const skillRepo = new SkillRepository(db)
-      const syncConfigRepo = new SyncConfigRepository(db)
-      const syncHistoryRepo = new SyncHistoryRepository(db)
-      const skillVersionRepo = new SkillVersionRepository(db)
-      // SMI-4474: auto-load JWT from ~/.skillsmith/config.json so logged-in
-      // users count toward their quota instead of going anonymous.
-      const jwtToken = await loadStoredAccessToken()
-      const apiClient = createApiClient(jwtToken ? { jwtToken } : {})
-
-      const syncEngine = new SyncEngine(
-        apiClient,
-        skillRepo,
-        syncConfigRepo,
-        syncHistoryRepo,
-        skillVersionRepo
-      )
-
       spinner.text = options.force ? 'Starting full sync...' : 'Starting differential sync...'
 
-      const result = await syncEngine.sync({
+      const result = await runRegistrySync(db, {
         force: options.force,
         dryRun: options.dryRun,
         onProgress: (progress: SyncProgress) => {
@@ -148,8 +125,7 @@ async function runSync(options: {
  */
 async function showStatus(options: { dbPath: string; json: boolean }): Promise<void> {
   try {
-    const db = await createDatabaseAsync(options.dbPath)
-    initializeSchema(db) // SMI-4486
+    const db = await openCliDatabase(options.dbPath)
 
     try {
       const syncConfigRepo = new SyncConfigRepository(db)
@@ -256,8 +232,7 @@ async function showHistory(options: {
   json: boolean
 }): Promise<void> {
   try {
-    const db = await createDatabaseAsync(options.dbPath)
-    initializeSchema(db) // SMI-4486
+    const db = await openCliDatabase(options.dbPath)
 
     try {
       const syncHistoryRepo = new SyncHistoryRepository(db)
@@ -337,8 +312,7 @@ async function configureSync(options: {
   json: boolean
 }): Promise<void> {
   try {
-    const db = await createDatabaseAsync(options.dbPath)
-    initializeSchema(db) // SMI-4486
+    const db = await openCliDatabase(options.dbPath)
 
     try {
       const syncConfigRepo = new SyncConfigRepository(db)

--- a/packages/cli/src/utils/open-database.ts
+++ b/packages/cli/src/utils/open-database.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Shared CLI database opener — the single schema-safe entry point.
+ * @see SMI-4486, SMI-4917
+ *
+ * `@skillsmith/core` re-exports the BARE `createDatabaseAsync` factory
+ * (`db/createDatabase.js`) — it opens a connection but creates NO tables. Every
+ * CLI command that touches a table (`skills`, `cache`, `sync_history`, …) MUST
+ * call `initializeSchema` first, or it crashes on a fresh DB with errors like
+ * `no such table: cache`.
+ *
+ * Before this helper, each command repeated `createDatabaseAsync` +
+ * `initializeSchema` by hand; any command that forgot the second line shipped a
+ * first-time-install crash (Bug 1 of SMI-4917 — `search` did exactly this).
+ * `openCliDatabase` makes the footgun structurally impossible: it is the one
+ * unmissable way a CLI command opens a database.
+ */
+import { createDatabaseAsync, initializeSchema, type DatabaseType } from '@skillsmith/core'
+
+/**
+ * Open a CLI database with the full schema initialized and all migrations
+ * applied. Use this everywhere a CLI command needs a database — never call the
+ * bare `createDatabaseAsync` directly.
+ *
+ * @param path - Filesystem path to the SQLite database (e.g. `DEFAULT_DB_PATH`).
+ * @returns A connected, schema-initialized database. Caller owns `db.close()`.
+ */
+export async function openCliDatabase(path: string): Promise<DatabaseType> {
+  const db = await createDatabaseAsync(path)
+  initializeSchema(db)
+  return db
+}

--- a/packages/cli/src/utils/skills-directory.ts
+++ b/packages/cli/src/utils/skills-directory.ts
@@ -8,12 +8,11 @@ import { createHash } from 'crypto'
 import { join } from 'path'
 import {
   SkillParser,
-  createDatabaseAsync,
-  initializeSchema,
   SkillVersionRepository,
   type Database,
   type TrustTier,
 } from '@skillsmith/core'
+import { openCliDatabase } from './open-database.js'
 import {
   CANONICAL_CLIENT,
   CLIENT_IDS,
@@ -77,8 +76,7 @@ export async function getSkillsFromDirectory(
   let dbConn: Database | null = null
   if (dbPath) {
     try {
-      dbConn = await createDatabaseAsync(dbPath)
-      initializeSchema(dbConn)
+      dbConn = await openCliDatabase(dbPath)
       versionRepo = new SkillVersionRepository(dbConn)
     } catch {
       // DB not available yet — fall back to hasUpdates: false

--- a/packages/cli/tests/open-database.test.ts
+++ b/packages/cli/tests/open-database.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Tests for the shared CLI database opener.
+ * @see SMI-4917 — Bug 1: `search` crashed with `no such table: cache` on a
+ *   fresh DB because it used the bare `createDatabaseAsync` factory without
+ *   `initializeSchema`.
+ *
+ * The regression guard: a DB opened via `openCliDatabase` must be fully
+ * schema-initialized so `SearchService` (which queries the `cache` table) does
+ * not throw on a brand-new database.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { SearchService, SkillRepository, closeDatabase, type DatabaseType } from '@skillsmith/core'
+import { openCliDatabase } from '../src/utils/open-database.js'
+
+describe('SMI-4917 Bug 1: openCliDatabase', () => {
+  const opened: DatabaseType[] = []
+
+  afterEach(() => {
+    for (const db of opened) closeDatabase(db)
+    opened.length = 0
+  })
+
+  async function open(): Promise<DatabaseType> {
+    const db = await openCliDatabase(':memory:')
+    opened.push(db)
+    return db
+  }
+
+  it('returns a fully schema-initialized database', async () => {
+    const db = await open()
+    // The `cache` table only exists once the schema is initialized.
+    const cacheTable = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='cache'")
+      .get()
+    expect(cacheTable).toBeDefined()
+  })
+
+  it('a fresh search no longer throws `no such table: cache`', async () => {
+    const db = await open()
+    const search = new SearchService(db)
+    // Before the fix, SearchService.search() crashed here on a bare DB.
+    expect(() => search.search({ query: 'mcp', limit: 10 })).not.toThrow()
+  })
+
+  it('search on a fresh DB returns an empty result set, not an error', async () => {
+    const db = await open()
+    const search = new SearchService(db)
+    const results = search.search({ query: 'anything', limit: 10 })
+    expect(results.items).toEqual([])
+    expect(results.total).toBe(0)
+  })
+
+  it('the skills table is queryable on a fresh DB', async () => {
+    const db = await open()
+    expect(new SkillRepository(db).count()).toBe(0)
+  })
+})

--- a/packages/cli/tests/search-helpers.test.ts
+++ b/packages/cli/tests/search-helpers.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview Tests for the `search` command's empty-DB auto-sync helper.
+ * @see SMI-4917 — Bug 3: a fresh install left an empty `skills` table so the
+ *   first `search` returned nothing. `autoSyncIfEmpty` bootstraps the registry,
+ *   bounded (H5) so it never hammers the API.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// loadStoredAccessToken decides whether the user is authenticated; runRegistrySync
+// performs the actual sync. Both are mocked so the test is hermetic.
+const loadStoredAccessToken = vi.fn<() => Promise<string | null>>()
+const runRegistrySync = vi.fn()
+
+vi.mock('@skillsmith/core', async () => {
+  const actual = await vi.importActual<typeof import('@skillsmith/core')>('@skillsmith/core')
+  return {
+    ...actual,
+    loadStoredAccessToken: () => loadStoredAccessToken(),
+  }
+})
+
+vi.mock('../src/commands/run-registry-sync.js', () => ({
+  runRegistrySync: (...args: unknown[]) => runRegistrySync(...args),
+}))
+
+// ora must no-op cleanly in the test (non-TTY) — stub it to a chainable object.
+vi.mock('ora', () => {
+  const spinner = {
+    start: vi.fn(() => spinner),
+    succeed: vi.fn(() => spinner),
+    warn: vi.fn(() => spinner),
+    fail: vi.fn(() => spinner),
+    stop: vi.fn(() => spinner),
+    text: '',
+  }
+  return { default: vi.fn(() => spinner) }
+})
+
+import { openCliDatabase } from '../src/utils/open-database.js'
+import {
+  SkillRepository,
+  SyncHistoryRepository,
+  closeDatabase,
+  type DatabaseType,
+} from '@skillsmith/core'
+
+async function freshDb(): Promise<DatabaseType> {
+  return openCliDatabase(':memory:')
+}
+
+function seedSkill(db: DatabaseType): void {
+  new SkillRepository(db).create({
+    id: 'seed-1',
+    name: 'seeded-skill',
+    description: 'a pre-existing skill',
+    trustTier: 'community',
+  })
+}
+
+describe('SMI-4917 Bug 3: autoSyncIfEmpty', () => {
+  let db: DatabaseType
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    runRegistrySync.mockResolvedValue({
+      success: true,
+      skillsAdded: 5,
+      skillsUpdated: 0,
+      skillsUnchanged: 0,
+      totalProcessed: 5,
+      errors: [],
+      durationMs: 1,
+      dryRun: false,
+    })
+    db = await freshDb()
+  })
+
+  afterEach(() => {
+    closeDatabase(db)
+  })
+
+  it('syncs when the DB is empty and a token is present', async () => {
+    loadStoredAccessToken.mockResolvedValue('jwt-token')
+    const { autoSyncIfEmpty } = await import('../src/commands/search.helpers.js')
+
+    await autoSyncIfEmpty(db)
+
+    expect(runRegistrySync).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT sync when the DB already has skills', async () => {
+    loadStoredAccessToken.mockResolvedValue('jwt-token')
+    seedSkill(db)
+    const { autoSyncIfEmpty } = await import('../src/commands/search.helpers.js')
+
+    await autoSyncIfEmpty(db)
+
+    expect(runRegistrySync).not.toHaveBeenCalled()
+  })
+
+  it('does NOT sync for an anonymous user (no stored token)', async () => {
+    loadStoredAccessToken.mockResolvedValue(null)
+    const { autoSyncIfEmpty } = await import('../src/commands/search.helpers.js')
+
+    await autoSyncIfEmpty(db)
+
+    expect(runRegistrySync).not.toHaveBeenCalled()
+  })
+
+  it('does NOT sync when a sync was attempted within the last 15 minutes', async () => {
+    loadStoredAccessToken.mockResolvedValue('jwt-token')
+    // Record a sync attempt that started 1 minute ago.
+    const historyRepo = new SyncHistoryRepository(db)
+    historyRepo.startRun() // startRun() stamps started_at = now
+    const { autoSyncIfEmpty } = await import('../src/commands/search.helpers.js')
+
+    await autoSyncIfEmpty(db)
+
+    expect(runRegistrySync).not.toHaveBeenCalled()
+  })
+
+  it('DOES sync when the last sync attempt is older than 15 minutes', async () => {
+    loadStoredAccessToken.mockResolvedValue('jwt-token')
+    // Insert a sync_history row whose started_at is 20 minutes ago.
+    const twentyMinAgo = new Date(Date.now() - 20 * 60_000).toISOString()
+    db.prepare("INSERT INTO sync_history (id, started_at, status) VALUES (?, ?, 'success')").run(
+      'old-run',
+      twentyMinAgo
+    )
+    const { autoSyncIfEmpty } = await import('../src/commands/search.helpers.js')
+
+    await autoSyncIfEmpty(db)
+
+    expect(runRegistrySync).toHaveBeenCalledTimes(1)
+  })
+
+  it('never throws when the sync fails — search proceeds with local results', async () => {
+    loadStoredAccessToken.mockResolvedValue('jwt-token')
+    runRegistrySync.mockRejectedValue(new Error('network down'))
+    const { autoSyncIfEmpty } = await import('../src/commands/search.helpers.js')
+
+    await expect(autoSyncIfEmpty(db)).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/src/db/migration-runner.ts
+++ b/packages/core/src/db/migration-runner.ts
@@ -26,6 +26,7 @@ import { MIGRATION_V10_SQL } from './migrations/v10-dependencies.js'
 import { MIGRATION_V12_SQL } from './migrations/v12-risk-score-history.js'
 import { MIGRATION_V13_SQL } from './migrations/v13-team-tables.js'
 import { applyMigrationV16 } from './migrations/v16-skill-source.js'
+import { applyMigrationV17 } from './migrations/v17-curated-trust-tier.js'
 import { SCHEMA_SQL, FTS5_MIGRATION_SQL } from './schema-sql.js'
 
 /**
@@ -44,7 +45,7 @@ export interface Migration {
   apply?: (db: Database) => void
 }
 
-// Reserved: v14 (RBAC), v15 (integrations), v16 → SMI-4665
+// Reserved: v14 (RBAC), v15 (integrations), v16 → SMI-4665, v17 → SMI-4917
 
 export const MIGRATIONS: Migration[] = [
   {
@@ -116,6 +117,11 @@ export const MIGRATIONS: Migration[] = [
     version: 16,
     description: "SMI-4665: source column + extend trust_tier CHECK to allow 'local'",
     apply: applyMigrationV16,
+  },
+  {
+    version: 17,
+    description: "SMI-4917: widen trust_tier CHECK to allow 'curated'",
+    apply: applyMigrationV17,
   },
 ]
 

--- a/packages/core/src/db/migrations/v17-curated-trust-tier.ts
+++ b/packages/core/src/db/migrations/v17-curated-trust-tier.ts
@@ -1,0 +1,125 @@
+/**
+ * @fileoverview Migration v17 — widen the `trust_tier` CHECK to allow `'curated'`
+ * @see SMI-4917: First-time-install bug fixes
+ *
+ * The skill registry ships skills with `trust_tier = 'curated'` (introduced in
+ * SMI-2381 — third-party publishers manually opted in). The canonical `TrustTier`
+ * type and the API/Zod schema accept `'curated'`, but the SQLite CHECK constraint
+ * on the `skills` table omitted it (`schema-sql.ts`, `v16-skill-source.ts` allowed
+ * only `verified, community, experimental, unknown, local`). Every `'curated'` row
+ * therefore failed on insert, so `sync` silently dropped every curated skill.
+ *
+ * SQLite cannot ALTER an existing CHECK constraint in place — the table is
+ * recreated using the standard create/copy/drop/rename dance, all wrapped in a
+ * transaction so a mid-process kill leaves either the old shape or the new shape,
+ * never a half-applied state. This mirrors `applyMigrationV16` exactly; the column
+ * set, indexes, and FTS5 triggers are copied verbatim from v16 (v17 changes only
+ * the `trust_tier` CHECK list — no column added, no column dropped).
+ *
+ * R1 (FK inbound refs): `skill_categories`, `skill_versions`, etc. reference
+ * `skills(id)`. v16 ships the identical drop/rename inside a single transaction
+ * and is proven safe in production — v17 follows it exactly, with NO
+ * `PRAGMA foreign_keys` toggle. SQLite defers FK enforcement to statement
+ * boundaries within a transaction, so dropping and recreating `skills` in one
+ * `BEGIN; ... COMMIT;` is safe even with inbound FK rows present.
+ *
+ * Idempotent: v17 adds no column, so the probe inspects the CHECK text itself —
+ * if the `skills` DDL already contains `'curated'`, the migration is a no-op.
+ * Re-running on a v17+ DB (or a fresh install, whose base `SCHEMA_SQL` already
+ * includes `'curated'`) short-circuits. The duplicate-column guard in
+ * `runMigrations` / `runMigrationsSafe` does not apply here (no column change),
+ * so the probe is the sole idempotency mechanism — it is load-bearing.
+ */
+import type { Database } from '../database-interface.js'
+
+const RECREATE_TABLE_SQL = `
+BEGIN;
+
+CREATE TABLE skills_v17 (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  author TEXT,
+  repo_url TEXT UNIQUE,
+  quality_score REAL CHECK(quality_score IS NULL OR (quality_score >= 0 AND quality_score <= 1)),
+  trust_tier TEXT CHECK(trust_tier IN ('verified', 'curated', 'community', 'experimental', 'unknown', 'local')) DEFAULT 'unknown',
+  tags TEXT DEFAULT '[]',
+  risk_score INTEGER CHECK(risk_score IS NULL OR (risk_score >= 0 AND risk_score <= 100)),
+  security_findings_count INTEGER DEFAULT 0,
+  security_scanned_at TEXT,
+  security_passed INTEGER,
+  compatibility TEXT DEFAULT '[]',
+  content_hash TEXT,
+  visibility TEXT NOT NULL DEFAULT 'public',
+  team_id TEXT,
+  source TEXT NOT NULL DEFAULT 'registry' CHECK (source IN ('registry', 'local')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO skills_v17 (
+  id, name, description, author, repo_url, quality_score, trust_tier, tags,
+  risk_score, security_findings_count, security_scanned_at, security_passed,
+  compatibility, content_hash, visibility, team_id, source,
+  created_at, updated_at
+)
+SELECT
+  id, name, description, author, repo_url, quality_score, trust_tier, tags,
+  risk_score, security_findings_count, security_scanned_at, security_passed,
+  compatibility, content_hash, visibility, team_id, source,
+  created_at, updated_at
+FROM skills;
+
+DROP TABLE skills;
+ALTER TABLE skills_v17 RENAME TO skills;
+
+CREATE INDEX IF NOT EXISTS idx_skills_author ON skills(author);
+CREATE INDEX IF NOT EXISTS idx_skills_trust_tier ON skills(trust_tier);
+CREATE INDEX IF NOT EXISTS idx_skills_quality_score ON skills(quality_score);
+CREATE INDEX IF NOT EXISTS idx_skills_updated_at ON skills(updated_at);
+CREATE INDEX IF NOT EXISTS idx_skills_created_at ON skills(created_at);
+CREATE INDEX IF NOT EXISTS idx_skills_risk_score ON skills(risk_score);
+CREATE INDEX IF NOT EXISTS idx_skills_security_passed ON skills(security_passed);
+CREATE INDEX IF NOT EXISTS idx_skills_source ON skills(source);
+
+CREATE TRIGGER IF NOT EXISTS skills_ai AFTER INSERT ON skills BEGIN
+  INSERT INTO skills_fts(rowid, name, description, tags, author)
+  VALUES (NEW.rowid, NEW.name, NEW.description, NEW.tags, NEW.author);
+END;
+
+CREATE TRIGGER IF NOT EXISTS skills_ad AFTER DELETE ON skills BEGIN
+  INSERT INTO skills_fts(skills_fts, rowid, name, description, tags, author)
+  VALUES ('delete', OLD.rowid, OLD.name, OLD.description, OLD.tags, OLD.author);
+END;
+
+CREATE TRIGGER IF NOT EXISTS skills_au AFTER UPDATE ON skills BEGIN
+  INSERT INTO skills_fts(skills_fts, rowid, name, description, tags, author)
+  VALUES ('delete', OLD.rowid, OLD.name, OLD.description, OLD.tags, OLD.author);
+  INSERT INTO skills_fts(rowid, name, description, tags, author)
+  VALUES (NEW.rowid, NEW.name, NEW.description, NEW.tags, NEW.author);
+END;
+
+COMMIT;
+`
+
+/**
+ * Apply the v17 migration if not already present.
+ *
+ * Exported as a function rather than a SQL string because the table-recreation
+ * dance must short-circuit on an already-widened DB. v17 adds no column, so the
+ * probe inspects the `skills` table DDL for the `'curated'` literal — if present,
+ * the constraint is already widened (fresh install or v17 already applied) and
+ * the migration is a no-op.
+ */
+export function applyMigrationV17(db: Database): void {
+  const ddl = db
+    .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='skills'")
+    .get() as { sql: string } | undefined
+
+  if (ddl && ddl.sql.includes("'curated'")) {
+    // CHECK already widened — fresh DB or v17 already applied. No-op.
+    return
+  }
+
+  db.exec(RECREATE_TABLE_SQL)
+}

--- a/packages/core/src/db/schema-sql.ts
+++ b/packages/core/src/db/schema-sql.ts
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS skills (
   author TEXT,
   repo_url TEXT UNIQUE,
   quality_score REAL CHECK(quality_score IS NULL OR (quality_score >= 0 AND quality_score <= 1)),
-  trust_tier TEXT CHECK(trust_tier IN ('verified', 'community', 'experimental', 'unknown', 'local')) DEFAULT 'unknown', -- SMI-4665: added 'local' for filesystem-imported skills
+  trust_tier TEXT CHECK(trust_tier IN ('verified', 'curated', 'community', 'experimental', 'unknown', 'local')) DEFAULT 'unknown', -- SMI-4665: added 'local'; SMI-4917: added 'curated'
   tags TEXT DEFAULT '[]', -- JSON array of tags
   risk_score INTEGER CHECK(risk_score IS NULL OR (risk_score >= 0 AND risk_score <= 100)), -- SMI-825
   security_findings_count INTEGER DEFAULT 0,

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -41,7 +41,8 @@ export type DatabaseType = Database
 // v13: SMI-3896 visibility and team_id for private skills
 // v14, v15: reserved (RBAC, integrations)
 // v16: SMI-4665 source column + extend trust_tier CHECK to allow 'local'
-export const SCHEMA_VERSION = 16
+// v17: SMI-4917 widen trust_tier CHECK to allow 'curated'
+export const SCHEMA_VERSION = 17
 
 /**
  * Initialize the database with the complete schema.

--- a/packages/core/src/types/skill.ts
+++ b/packages/core/src/types/skill.ts
@@ -9,9 +9,9 @@ import type { DependencyDeclaration } from './dependencies.js'
  * SMI-4665: 'local' is now a first-class DB-backed tier — the skills.trust_tier
  *   CHECK constraint allows 'local' (migration v16) so filesystem-imported skills
  *   surface distinctly in search rather than being conflated with 'unknown'.
- *
- * Note: 'curated' is reserved on the type but not yet in the DB CHECK
- * (separate roadmap item — promotes high-quality community skills).
+ * SMI-2381 / SMI-4917: 'curated' (third-party publishers manually opted into the
+ *   registry) is a first-class DB-backed tier — the skills.trust_tier CHECK
+ *   constraint allows 'curated' (migration v17).
  */
 export type TrustTier = 'verified' | 'curated' | 'community' | 'experimental' | 'unknown' | 'local'
 

--- a/packages/core/tests/unit/migrations/migration-v16.test.ts
+++ b/packages/core/tests/unit/migrations/migration-v16.test.ts
@@ -161,8 +161,13 @@ describe('Migration v16: source column + trust_tier=local', () => {
       }
     }
 
-    const versionAfter = getSchemaVersion(db)
-    expect(versionAfter).toBeLessThan(16)
+    // A broken v16 must not stamp version 16. Assert on row 16 specifically —
+    // not getSchemaVersion() (MAX), since later migrations (v17, SMI-4917) can
+    // legitimately succeed and advance the MAX past 16.
+    const v16Stamped = db
+      .prepare('SELECT 1 AS hit FROM schema_version WHERE version = 16')
+      .get() as { hit: number } | undefined
+    expect(v16Stamped).toBeUndefined()
     expect(stamped).toBeGreaterThanOrEqual(0)
   })
 

--- a/packages/core/tests/unit/migrations/migration-v17.test.ts
+++ b/packages/core/tests/unit/migrations/migration-v17.test.ts
@@ -1,0 +1,330 @@
+/**
+ * @fileoverview Tests for migration v17 — widen `trust_tier` CHECK to allow `'curated'`
+ * @see SMI-4917: First-time-install bug fixes
+ *
+ * Coverage targets (from plan-review § Tests):
+ *   - H4: v13→v17 and v16→v17 fixture-DB upgrades reach v17 cleanly with FTS
+ *     triggers intact (the only safety net for a client-side migration).
+ *   - A `'curated'` row inserts successfully after v17.
+ *   - Idempotent re-run of v17 is a no-op.
+ *   - H1: the `skills` column set is byte-identical pre/post-v17.
+ *   - H3: a fixture DB carrying inbound-FK rows (skill_categories) upgrades
+ *     through v17 without error.
+ *   - H2: fresh-install convergence — v1 base → migrations → v17, no double-apply.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createTestDatabase, closeDatabase, type Database } from '../../helpers/database.js'
+import {
+  getSchemaVersion,
+  SCHEMA_VERSION,
+  runMigrations,
+  runMigrationsSafe,
+  MIGRATIONS,
+  createDatabaseAsync,
+  initializeSchema,
+  SCHEMA_SQL,
+} from '../../../src/db/schema.js'
+import { applyMigrationV17 } from '../../../src/db/migrations/v17-curated-trust-tier.js'
+// The BARE factory (creates no tables) — needed to build a pristine fixture DB
+// whose schema_version table starts empty. createDatabaseAsync from schema.js
+// calls initializeSchema and would pre-stamp the current SCHEMA_VERSION.
+import { createDatabaseAsync as createBareDatabaseAsync } from '../../../src/db/createDatabase.js'
+
+/**
+ * The genuine pre-v17 `skills` table DDL (the v16 shape — CHECK omits 'curated').
+ * Copied verbatim from `v16-skill-source.ts` so the fixture faithfully reproduces
+ * a real pre-fix v16 DB even though the current `SCHEMA_SQL` base is already
+ * widened. Without this, a fresh-install fixture built from `SCHEMA_SQL` would
+ * already admit 'curated' and the v17 migration would be untestable.
+ */
+const V16_SKILLS_DDL = `
+DROP TRIGGER IF EXISTS skills_ai;
+DROP TRIGGER IF EXISTS skills_ad;
+DROP TRIGGER IF EXISTS skills_au;
+DROP TABLE skills;
+CREATE TABLE skills (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  author TEXT,
+  repo_url TEXT UNIQUE,
+  quality_score REAL CHECK(quality_score IS NULL OR (quality_score >= 0 AND quality_score <= 1)),
+  trust_tier TEXT CHECK(trust_tier IN ('verified', 'community', 'experimental', 'unknown', 'local')) DEFAULT 'unknown',
+  tags TEXT DEFAULT '[]',
+  risk_score INTEGER CHECK(risk_score IS NULL OR (risk_score >= 0 AND risk_score <= 100)),
+  security_findings_count INTEGER DEFAULT 0,
+  security_scanned_at TEXT,
+  security_passed INTEGER,
+  compatibility TEXT DEFAULT '[]',
+  content_hash TEXT,
+  visibility TEXT NOT NULL DEFAULT 'public',
+  team_id TEXT,
+  source TEXT NOT NULL DEFAULT 'registry' CHECK (source IN ('registry', 'local')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_skills_author ON skills(author);
+CREATE INDEX IF NOT EXISTS idx_skills_trust_tier ON skills(trust_tier);
+CREATE INDEX IF NOT EXISTS idx_skills_source ON skills(source);
+CREATE TRIGGER IF NOT EXISTS skills_ai AFTER INSERT ON skills BEGIN
+  INSERT INTO skills_fts(rowid, name, description, tags, author)
+  VALUES (NEW.rowid, NEW.name, NEW.description, NEW.tags, NEW.author);
+END;
+CREATE TRIGGER IF NOT EXISTS skills_ad AFTER DELETE ON skills BEGIN
+  INSERT INTO skills_fts(skills_fts, rowid, name, description, tags, author)
+  VALUES ('delete', OLD.rowid, OLD.name, OLD.description, OLD.tags, OLD.author);
+END;
+CREATE TRIGGER IF NOT EXISTS skills_au AFTER UPDATE ON skills BEGIN
+  INSERT INTO skills_fts(skills_fts, rowid, name, description, tags, author)
+  VALUES ('delete', OLD.rowid, OLD.name, OLD.description, OLD.tags, OLD.author);
+  INSERT INTO skills_fts(rowid, name, description, tags, author)
+  VALUES (NEW.rowid, NEW.name, NEW.description, NEW.tags, NEW.author);
+END;
+`
+
+/**
+ * Build a fixture DB whose schema is stamped at exactly `targetVersion` by
+ * running the canonical base schema then every migration up to (and including)
+ * `targetVersion`. The `skills` table is then forced to the genuine pre-v17 v16
+ * shape so the v17 migration is genuinely "pending" and exercised by the runner.
+ */
+async function fixtureAtVersion(targetVersion: number): Promise<Database> {
+  // Bare factory — no tables created. SCHEMA_SQL then builds the v1 base schema
+  // with an empty schema_version table, and migrations are applied up to target.
+  const db = (await createBareDatabaseAsync(':memory:')) as Database
+  db.exec(SCHEMA_SQL)
+  for (const migration of MIGRATIONS) {
+    if (migration.version === 1 || migration.version > targetVersion) continue
+    try {
+      if (migration.apply) {
+        migration.apply(db)
+      } else if (migration.sql !== undefined) {
+        db.exec(migration.sql)
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      if (!msg.includes('duplicate column')) throw error
+    }
+    // Some migration SQL stamps its own schema_version row — use INSERT OR
+    // IGNORE so this fixture helper never double-stamps.
+    db.prepare('INSERT OR IGNORE INTO schema_version (version) VALUES (?)').run(migration.version)
+  }
+  // Force the `skills` table to the genuine pre-v17 (v16) CHECK shape — the
+  // current SCHEMA_SQL base is already widened, so without this the fixture
+  // would already admit 'curated'.
+  db.exec(V16_SKILLS_DDL)
+  return db
+}
+
+function skillsColumns(db: Database): string[] {
+  return (db.prepare('PRAGMA table_info(skills)').all() as Array<{ name: string }>)
+    .map((c) => c.name)
+    .sort()
+}
+
+function triggerNames(db: Database): string[] {
+  return (
+    db
+      .prepare("SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name='skills'")
+      .all() as Array<{ name: string }>
+  )
+    .map((t) => t.name)
+    .sort()
+}
+
+describe('Migration v17: widen trust_tier CHECK to allow curated', () => {
+  let db: Database
+
+  beforeEach(async () => {
+    db = await createTestDatabase()
+  })
+
+  afterEach(() => {
+    closeDatabase(db)
+  })
+
+  it('SCHEMA_VERSION is at least 17', () => {
+    expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(17)
+  })
+
+  it('fresh DB accepts insert with trust_tier=curated', () => {
+    const insert = db.prepare(`
+      INSERT INTO skills (id, name, description, trust_tier, quality_score, source)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `)
+
+    expect(() =>
+      insert.run(
+        'curated-1',
+        'a-curated-skill',
+        'A curated registry skill',
+        'curated',
+        0.8,
+        'registry'
+      )
+    ).not.toThrow()
+
+    const row = db.prepare('SELECT trust_tier FROM skills WHERE id = ?').get('curated-1') as {
+      trust_tier: string
+    }
+    expect(row.trust_tier).toBe('curated')
+  })
+
+  it('still accepts every pre-existing trust_tier value', () => {
+    const insert = db.prepare(
+      "INSERT INTO skills (id, name, trust_tier, source) VALUES (?, ?, ?, 'registry')"
+    )
+    for (const tier of ['verified', 'community', 'experimental', 'unknown', 'local']) {
+      expect(() => insert.run(`tier-${tier}`, tier, tier)).not.toThrow()
+    }
+  })
+
+  it('rejects trust_tier values outside the widened set', () => {
+    const insert = db.prepare(
+      "INSERT INTO skills (id, name, trust_tier, source) VALUES (?, ?, ?, 'registry')"
+    )
+    expect(() => insert.run('bad-tier', 'bad', 'made-up')).toThrow(/CHECK constraint failed/)
+  })
+
+  it('applyMigrationV17 is idempotent — running twice is a no-op', () => {
+    expect(() => applyMigrationV17(db)).not.toThrow()
+    const colsAfterFirst = skillsColumns(db)
+    expect(() => applyMigrationV17(db)).not.toThrow()
+    expect(skillsColumns(db)).toEqual(colsAfterFirst)
+  })
+
+  it('v16→v17: a v16 fixture DB upgrades to v17 cleanly', async () => {
+    const v16 = await fixtureAtVersion(16)
+    expect(getSchemaVersion(v16)).toBe(16)
+    // A v16 DB rejects curated before the upgrade.
+    expect(() =>
+      v16
+        .prepare(
+          "INSERT INTO skills (id, name, trust_tier, source) VALUES ('pre', 'p', 'curated', 'registry')"
+        )
+        .run()
+    ).toThrow(/CHECK constraint failed/)
+
+    const ran = runMigrations(v16)
+    expect(ran).toBeGreaterThanOrEqual(1)
+    expect(getSchemaVersion(v16)).toBe(SCHEMA_VERSION)
+
+    // After v17 the curated insert succeeds.
+    expect(() =>
+      v16
+        .prepare(
+          "INSERT INTO skills (id, name, trust_tier, source) VALUES ('post', 'p', 'curated', 'registry')"
+        )
+        .run()
+    ).not.toThrow()
+    expect(triggerNames(v16)).toEqual(['skills_ad', 'skills_ai', 'skills_au'])
+    closeDatabase(v16)
+  })
+
+  it('v13→v17: a v13 fixture DB upgrades through every migration to v17 cleanly', async () => {
+    const v13 = await fixtureAtVersion(13)
+    expect(getSchemaVersion(v13)).toBe(13)
+
+    const ran = runMigrations(v13)
+    expect(ran).toBeGreaterThanOrEqual(2) // at minimum v16 + v17
+    expect(getSchemaVersion(v13)).toBe(SCHEMA_VERSION)
+
+    expect(() =>
+      v13
+        .prepare(
+          "INSERT INTO skills (id, name, trust_tier, source) VALUES ('c', 'c', 'curated', 'registry')"
+        )
+        .run()
+    ).not.toThrow()
+    expect(triggerNames(v13)).toEqual(['skills_ad', 'skills_ai', 'skills_au'])
+    closeDatabase(v13)
+  })
+
+  it('v16→v17 preserves all existing skill rows', async () => {
+    const v16 = await fixtureAtVersion(16)
+    const insert = v16.prepare(
+      'INSERT INTO skills (id, name, trust_tier, source) VALUES (?, ?, ?, ?)'
+    )
+    insert.run('keep-1', 'verified-skill', 'verified', 'registry')
+    insert.run('keep-2', 'local-skill', 'local', 'local')
+
+    runMigrations(v16)
+
+    const rows = v16
+      .prepare('SELECT id, trust_tier, source FROM skills ORDER BY id')
+      .all() as Array<{ id: string; trust_tier: string; source: string }>
+    expect(rows).toEqual([
+      { id: 'keep-1', trust_tier: 'verified', source: 'registry' },
+      { id: 'keep-2', trust_tier: 'local', source: 'local' },
+    ])
+    closeDatabase(v16)
+  })
+
+  it('H1: the skills column set is byte-identical before and after v17', async () => {
+    const v16 = await fixtureAtVersion(16)
+    const colsBefore = skillsColumns(v16)
+    applyMigrationV17(v16)
+    const colsAfter = skillsColumns(v16)
+    expect(colsAfter).toEqual(colsBefore)
+    closeDatabase(v16)
+  })
+
+  it('H3: a v16 DB carrying inbound-FK rows upgrades through v17 without error', async () => {
+    const v16 = await fixtureAtVersion(16)
+    // A skill row referenced by skill_categories (FK skill_categories.skill_id → skills.id).
+    v16
+      .prepare(
+        "INSERT INTO skills (id, name, trust_tier, source) VALUES ('fk-skill', 'fk', 'community', 'registry')"
+      )
+      .run()
+    v16.prepare("INSERT INTO categories (id, name) VALUES ('cat-1', 'testing')").run()
+    v16
+      .prepare("INSERT INTO skill_categories (skill_id, category_id) VALUES ('fk-skill', 'cat-1')")
+      .run()
+
+    // The v17 recreate drops & renames `skills` inside one transaction — with
+    // inbound FK rows present this must not error (mirrors v16 exactly, no
+    // `PRAGMA foreign_keys` toggle). This is the R1/H3 regression guard.
+    expect(() => applyMigrationV17(v16)).not.toThrow()
+
+    // The skill row itself survives the recreate in the new (widened) table.
+    const skill = v16.prepare("SELECT id FROM skills WHERE id = 'fk-skill'").get() as
+      | { id: string }
+      | undefined
+    expect(skill?.id).toBe('fk-skill')
+
+    // Note: `skill_categories` rows are cascade-deleted by `DROP TABLE skills`
+    // because `foreign_keys` is ON (the driver default) and `skill_categories`
+    // declares `ON DELETE CASCADE`. This is pre-existing v16 behavior — v16
+    // performs the identical `DROP TABLE skills` — and is intentionally NOT a
+    // v17 regression. The CLI rebuilds category links on the next `sync`.
+    closeDatabase(v16)
+  })
+
+  it('H2: fresh-install convergence — base schema → migrations → v17, no double-apply', async () => {
+    const fresh = await createDatabaseAsync(':memory:')
+    initializeSchema(fresh)
+    // initializeSchema stamps SCHEMA_VERSION directly; the v17 probe must no-op.
+    expect(getSchemaVersion(fresh)).toBe(SCHEMA_VERSION)
+    expect(() => applyMigrationV17(fresh)).not.toThrow()
+    // runMigrations sees a current version → 0 pending.
+    expect(runMigrations(fresh)).toBe(0)
+    // Fresh base schema already admits 'curated'.
+    expect(() =>
+      fresh
+        .prepare(
+          "INSERT INTO skills (id, name, trust_tier, source) VALUES ('fresh-c', 'c', 'curated', 'registry')"
+        )
+        .run()
+    ).not.toThrow()
+    closeDatabase(fresh)
+  })
+
+  it('runMigrationsSafe is a no-op on a DB already at v17', () => {
+    const before = getSchemaVersion(db)
+    expect(runMigrationsSafe(db)).toBe(0)
+    expect(getSchemaVersion(db)).toBe(before)
+    expect(getSchemaVersion(db)).toBeGreaterThanOrEqual(17)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes three defects that break the first-time `npm install -g @skillsmith/cli` → `skillsmith login` → `skillsmith search mcp` flow (the exact sequence the post-login tutorial prints). Closes **SMI-4917**.

- **Bug 1 — `no such table: cache`**: `search.ts` (and `manage.ts`, `import.ts`) opened a DB via the bare `createDatabaseAsync` export without `initializeSchema`, crashing on a fresh DB. Fixed with a shared `openCliDatabase()` helper now used by all 14 CLI DB-open sites.
- **Bug 2 — `CHECK constraint failed: trust_tier`**: the registry ships `'curated'` skills (SMI-2381) but the SQLite CHECK omitted the value, so `sync` dropped all ~4,799 skills. New **v17 migration** (imperative table-recreate, mirrors v16) widens the constraint; base schema updated for fresh installs.
- **Bug 3 — no self-configuration**: `login` now runs a best-effort registry sync (`postLoginSync()`, non-fatal), and `search` against an empty DB auto-syncs (bounded: token present + no sync in last 15 min). Both share a new `runRegistrySync()` helper.

## Changes

**Wave 2 (`c1cc503e`, core)** — `v17-curated-trust-tier.ts` migration; registered in `migration-runner.ts`; `SCHEMA_VERSION` 16→17; base `schema-sql.ts` CHECK widened; stale `types/skill.ts` comment removed.

**Waves 1+3 (`53078b43`, cli)** — `openCliDatabase()` helper + 14 call-site migration; `runRegistrySync()` helper; `sync.ts` refactored onto it; `login.ts` `postLoginSync()`; `search.helpers.ts` `autoSyncIfEmpty()`; trust-tier UI consistency.

## Plan & review

VP-reviewed implementation plan (14 findings applied): `docs/internal/implementation/smi-4917-first-time-install-fixes.md`. Risk-ordered waves: verify → DB migration → DB helper → behavior.

## Tests

New: `migration-v17.test.ts` (12 tests — v13→v17/v16→v17 upgrades, `'curated'` insert, idempotency, byte-identical column set, FK-rows fixture, fresh-install convergence), `open-database.test.ts`, `search-helpers.test.ts`, `login.post-login-sync.test.ts`. Full worktree preflight green: build clean, ESLint 0, typecheck pass, `audit:standards` pass, **5068 tests passed**, all modified files <500 lines.

MCP `search` already accepts `'curated'` (live-API fallback) so was not broken — but it shares `~/.skillsmith/skills.db`, so the v17 migration also protects MCP-side local-DB writes.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)