### PR TITLE
chore(release): bump core 0.6.1, cli 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29761,11 +29761,11 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@skillsmith/core": "^0.6.0",
+        "@skillsmith/core": "^0.6.1",
         "@skillsmith/mcp-server": "^0.5.1",
         "chalk": "5.6.2",
         "chokidar": "4.0.3",
@@ -29875,7 +29875,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@huggingface/transformers": "3.8.1",
@@ -29995,7 +29995,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-        "@skillsmith/core": "^0.6.0",
+        "@skillsmith/core": "^0.6.1",
         "jose": "^6.2.2",
         "zod": "4.2.1"
       },
@@ -30134,7 +30134,7 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.6.0",
+        "@skillsmith/core": "^0.6.1",
         "esbuild": "0.27.2",
         "ulid": "3.0.1"
       },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.6.1
+
+- **Fix**: SMI-4917 — repair first-time install (search crash, sync drops all skills, no self-config) (#1132)
+
 ## v0.6.0
 
 - **Feature**: SMI-4590 Wave 4 PR 5/6 — new `sklx audit collisions` subcommand runs the consumer namespace audit (mirrors the `skill_inventory_audit` MCP tool); new `sklx config get audit_mode` / `sklx config set audit_mode <preventative|power_user|governance|off>` for managing audit verbosity. Tier-revalidated: Free/Individual cannot select `power_user`/`governance`. (#950)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.6.0",
+    "@skillsmith/core": "^0.6.1",
     "@skillsmith/mcp-server": "^0.5.1",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.6.1
+
+- **Fix**: SMI-4917 — repair first-time install (search crash, sync drops all skills, no self-config) (#1132)
 - **Security**: SMI-4888 bump `@opentelemetry/sdk-node` 0.217 → 0.218 (resolves protobufjs transitive chain — `otlp-transformer@0.218.0` removes protobufjs entirely, PR #6629 upstream). Companion bumps: `instrumentation-http` 0.217 → 0.218, `instrumentation-runtime-node` 0.27 → 0.31, `instrumentation-undici` 0.24 → 0.28 (aligned to OTel 0.218 release wave). Closes 1 high + 6 moderate GHSAs (GHSA-q6x5-8v7m-xcrf + chain). (#1102)
 
 ## v0.6.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.6.0'
+export const VERSION = '0.6.1'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-    "@skillsmith/core": "^0.6.0",
+    "@skillsmith/core": "^0.6.1",
     "jose": "^6.2.2",
     "zod": "4.2.1"
   },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.6.0",
+    "@skillsmith/core": "^0.6.1",
     "esbuild": "0.27.2",
     "ulid": "3.0.1"
   },


### PR DESCRIPTION
## Release: @skillsmith/core 0.6.1, @skillsmith/cli 0.6.1

Out-of-cadence patch release shipping the **SMI-4917** first-time-install fixes (merged in #1132, `baef2864`) to npm. Until this publishes, `npm install -g @skillsmith/cli` still delivers the broken v0.6.0.

### Included (core 0.6.1)
- v17 migration widening the `trust_tier` CHECK to allow `'curated'` — fixes `sync` dropping all ~4,799 registry skills.

### Included (cli 0.6.1)
- `openCliDatabase()` helper — fixes `no such table: cache` crash on first `skillsmith search`.
- `postLoginSync()` + bounded `autoSyncIfEmpty()` — `login` and `search` now self-configure the local registry.

### Contents
Version bumps + CHANGELOG entries for `core`/`cli`; `@skillsmith/core` dependency range bumped in `mcp-server`/`enterprise`; regenerated `package-lock.json`. No source-code changes beyond version constants — the implementation landed and passed full CI in #1132.

After merge: `gh workflow run publish.yml -f dry_run=false` publishes core → cli.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)