### PR TITLE
docs(website): SMI-4921 clarify licensing — what an enterprise pays for

### DIFF
--- a/packages/website/src/content/blog/enterprise-reference-architecture.md
+++ b/packages/website/src/content/blog/enterprise-reference-architecture.md
@@ -24,18 +24,30 @@ exist, but maturity varies. Where that matters, the text says so.
 
 ![Architecture diagram of Skillsmith showing three developer surfaces — CLI, MCP server, and VS Code extension — reading from a per-developer local SQLite database, which is synced from a hosted Supabase registry of Postgres tables and edge functions.](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/enterprise-reference-architecture/01-system-overview)
 
-## Licensing, in one paragraph
+## Licensing, and what you pay for
 
 Skillsmith is source-available under the [Elastic License 2.0](https://www.elastic.co/licensing/elastic-license).
 Every package — core, the MCP server, the CLI, the VS Code extension, and the
-enterprise package — ships under the same license. Running Skillsmith on your own
-infrastructure for your team's internal use is permitted at no charge: the
-copyright grant is royalty-free and worldwide. A paid Team or Enterprise
-subscription issues a JWT license key that unlocks the enterprise feature tier —
-it is not a license to self-host, because self-hosting for internal use is
-already granted. The one use that requires a separate commercial agreement is
-offering Skillsmith to third parties as a hosted or managed service. That is the
-whole model.
+enterprise package — ships under the same license, and running Skillsmith on your
+own infrastructure for your team's internal use is permitted at no charge: the
+copyright grant is royalty-free and worldwide. So an enterprise client pays for
+neither the software nor permission to self-host — both are already granted.
+
+What an Enterprise subscription buys is a **license key** and a **support
+commitment**. The license key — a signed JWT — unlocks the gated feature set:
+SSO/SAML, RBAC, audit logging, SIEM export, compliance reporting, the private
+registry, and advanced analytics. The support commitment is the enterprise SLA: a
+99.9% uptime target, dedicated support, custom integrations. Without the key, the
+core discovery, indexing, and installation tools still run for free; the gated
+features simply stay locked.
+
+The **API key is a separate credential** doing a different job: it authenticates
+calls to a registry — the public Skillsmith registry, or your own private
+registry — and sets their rate-limit tier. The license key decides *which
+features you have*; the API key *authenticates the calls* your deployment makes.
+The one use that needs a *separate* commercial agreement — beyond any
+subscription — is offering Skillsmith to third parties as a hosted or managed
+service. That is the whole model.
 
 ## Available today vs. designed
 


### PR DESCRIPTION
## Summary

Follow-up to SMI-4915. Rewrites the licensing section of the live enterprise reference-architecture blog post so it plainly answers "what does an enterprise client pay for?" and explains the API key — a credential the post never mentioned.

## Change

Single file: `packages/website/src/content/blog/enterprise-reference-architecture.md` — the "Licensing, in one paragraph" section becomes "Licensing, and what you pay for" (three short paragraphs):

- **Software: $0** — ELv2 grants royalty-free internal self-hosting for every package.
- **The Enterprise license key (signed JWT)** unlocks the gated feature set — SSO/SAML, RBAC, audit logging, SIEM export, compliance reporting, the private registry, advanced analytics — plus the support/SLA commitment.
- **The API key is a separate credential** — it authenticates calls to a registry (public or your own private one) and sets the rate-limit tier. License key = *which features you have*; API key = *authenticates the calls*.
- A separate commercial agreement is needed only to offer Skillsmith as a hosted service to third parties.

Model verified against the code during planning — the API key is not required to reach the public registry and is not what gates quarantine/security data; the private registry is a license-gated Enterprise feature, framed accordingly.

## Notes

- Documentation/content only — one Markdown file, no `.ts`, no diagrams, no code paths. `[skip-impl-check]` `[skip-smoke]`
- Linear: SMI-4921 (parent: SMI-4915)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)