### PR TITLE
fix(release): SMI-4923 smoke test fails for multi-bin packages

### DIFF
--- a/scripts/smoke-test-published.ts
+++ b/scripts/smoke-test-published.ts
@@ -45,6 +45,16 @@ function formatError(e: unknown): string {
   return parts.join('\n')
 }
 
+/**
+ * Build the npx command for a CLI bin smoke test.
+ * Uses `-p <pkg>@<version> <bin>` so npx resolves a specific package and
+ * invokes an explicit bin — the correct form for multi-bin packages where
+ * the bin name does not match the package-name segment.
+ */
+export function buildCliSmokeCommand(pkg: string, version: string, bin: string): string {
+  return `npx -y -p ${pkg}@${version} ${bin} --help`
+}
+
 async function runTest(name: string, fn: () => void | Promise<void>): Promise<TestResult> {
   const start = Date.now()
   try {
@@ -221,10 +231,20 @@ export async function smokeTestPackage(
     }
 
     if (packageName === '@skillsmith/cli') {
-      // Test 2: CLI --help works
+      // Test 2: skillsmith bin --help works (SMI-4923: use -p + explicit bin for multi-bin packages)
       tests.push(
-        await runTest('cli-help', () => {
-          execSync(`npx -y ${packageName}@${version} --help`, {
+        await runTest('cli-help-skillsmith', () => {
+          execSync(buildCliSmokeCommand(packageName, version, 'skillsmith'), {
+            stdio: 'pipe',
+            timeout: 30000,
+          })
+        })
+      )
+
+      // Test 3: sklx alias bin --help works
+      tests.push(
+        await runTest('cli-help-sklx', () => {
+          execSync(buildCliSmokeCommand(packageName, version, 'sklx'), {
             stdio: 'pipe',
             timeout: 30000,
           })

--- a/scripts/tests/smoke-test-published.test.ts
+++ b/scripts/tests/smoke-test-published.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Unit tests for smoke-test-published helper functions.
+ * SMI-4923: verify buildCliSmokeCommand produces the correct npx form for
+ * multi-bin packages (explicit -p <pkg>@<version> <bin> instead of bare
+ * `npx -y <pkg>@<version>` which fails when no bin matches the package-name
+ * segment).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { buildCliSmokeCommand } from '../smoke-test-published'
+
+describe('buildCliSmokeCommand', () => {
+  it('returns correct npx command for the skillsmith bin', () => {
+    expect(buildCliSmokeCommand('@skillsmith/cli', '1.2.3', 'skillsmith')).toBe(
+      'npx -y -p @skillsmith/cli@1.2.3 skillsmith --help'
+    )
+  })
+
+  it('returns correct npx command for the sklx bin', () => {
+    expect(buildCliSmokeCommand('@skillsmith/cli', '1.2.3', 'sklx')).toBe(
+      'npx -y -p @skillsmith/cli@1.2.3 sklx --help'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes the `@skillsmith/cli` smoke test that fails with `sh: 1: skillsmith: not found` on CI because `npx -y <pkg>@<version>` cannot select a bin when no bin name matches the package-name segment (`cli`)
- Replaces the broken single `cli-help` test with two explicit tests — `cli-help-skillsmith` and `cli-help-sklx` — using the correct `npx -y -p <pkg>@<version> <bin>` form
- Extracts `buildCliSmokeCommand(pkg, version, bin)` as an exported pure helper so it is independently unit-testable

## Bug

`@skillsmith/cli` declares two bins (`skillsmith` and `sklx`). When `npx -y @skillsmith/cli@<version>` runs, npx attempts to resolve a bin by the package-name segment (`cli`) — finds nothing — and exits with `sh: 1: skillsmith: not found`. The published package is correct; only the smoke script's invocation form was wrong.

## Changes

- `scripts/smoke-test-published.ts`: add `buildCliSmokeCommand` export; replace `cli-help` single test with `cli-help-skillsmith` + `cli-help-sklx` pair
- `scripts/tests/smoke-test-published.test.ts` (new): unit tests asserting exact output of `buildCliSmokeCommand` for both bins

## Infrastructure change coverage

This change touches `scripts/smoke-test-published.ts` (a CI/hook-adjacent script). The ADR-109 SPARC + plan-review requirement is satisfied: the implementation plan is at `docs/internal/implementation/smi-4919-4920-4923-followups.md`.

## Test plan

- [x] `buildCliSmokeCommand` unit tests pass (2/2)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 warnings)
- [x] `npm run audit:standards` passes (exit 0)
- [x] Prettier check passes
- [x] `wc -l scripts/smoke-test-published.ts` = 334 (well under 500-line gate)

Closes SMI-4923