### PR TITLE
fix(release): SMI-4920 release-tooling first-push CI failures

### DIFF
--- a/scripts/lib/release-changelog.ts
+++ b/scripts/lib/release-changelog.ts
@@ -33,6 +33,74 @@ export function findLastVersionBumpCommit(): string {
   }
 }
 
+/**
+ * Insert a new `## vX.Y.Z` section into a CHANGELOG body.
+ *
+ * SMI-4920 (Bug A): the previous implementation spliced the new section before
+ * the FIRST `## ` heading. When the file led with `## [Unreleased]` (the normal
+ * case), the result was `## vX.Y.Z` ABOVE `## [Unreleased]`, which trips
+ * `audit:standards` check 43 (Unreleased-before-versions ordering) and fails CI
+ * on the release PR's first push.
+ *
+ * New behaviour:
+ *  - If the first `## ` heading is `## [Unreleased]`: keep it on top (empty),
+ *    move any entry lines currently under it into the new version section, and
+ *    insert the new section directly after the (now empty) Unreleased block.
+ *  - If there is no `## [Unreleased]` heading: emit an empty `## [Unreleased]`
+ *    first, then the new version section, then the rest.
+ *
+ * Output is always conforming to check 43.
+ *
+ * @param body Raw CHANGELOG.md contents (or the synthesized default header).
+ * @param section The new `## vX.Y.Z ...` section, header line first, no
+ *   trailing newline required.
+ * @returns The rewritten CHANGELOG body.
+ */
+export function insertVersionSection(body: string, section: string): string {
+  const trimmedSection = section.trim()
+  const firstHeading = body.indexOf('\n## ')
+
+  // No `## ` heading at all — append Unreleased + section after the header.
+  if (firstHeading === -1) {
+    return `${body.trimEnd()}\n\n## [Unreleased]\n\n${trimmedSection}\n`
+  }
+
+  const before = body.slice(0, firstHeading + 1) // includes trailing newline
+  const rest = body.slice(firstHeading + 1)
+
+  // Locate the first heading line and test whether it is `## [Unreleased]`.
+  const firstLineEnd = rest.indexOf('\n')
+  const firstLine = (firstLineEnd === -1 ? rest : rest.slice(0, firstLineEnd)).trim()
+  const isUnreleased = /^## \[?Unreleased\]?$/i.test(firstLine)
+
+  if (!isUnreleased) {
+    // No leading Unreleased block — synthesize an empty one, then the section.
+    return `${before}## [Unreleased]\n\n${trimmedSection}\n\n${rest.trimEnd()}\n`
+  }
+
+  // Leading `## [Unreleased]` block: find where it ends (next `## ` heading).
+  const afterFirstHeading = firstLineEnd === -1 ? '' : rest.slice(firstLineEnd + 1)
+  const nextHeading = afterFirstHeading.indexOf('\n## ')
+
+  let unreleasedBody: string
+  let tail: string
+  if (nextHeading === -1) {
+    unreleasedBody = afterFirstHeading
+    tail = ''
+  } else {
+    unreleasedBody = afterFirstHeading.slice(0, nextHeading)
+    tail = afterFirstHeading.slice(nextHeading + 1) // strip the leading newline
+  }
+
+  // Carry forward any entry lines that were sitting under [Unreleased] (raw
+  // append; dedupe is intentionally out of scope per SMI-4920).
+  const carried = unreleasedBody.trim()
+  const sectionWithCarry = carried.length > 0 ? `${trimmedSection}\n\n${carried}` : trimmedSection
+
+  const tailBlock = tail.trim().length > 0 ? `\n\n${tail.trimEnd()}` : ''
+  return `${before}## [Unreleased]\n\n${sectionWithCarry}${tailBlock}\n`
+}
+
 export function prependToChangelog(relPath: string, section: string): void {
   const fullPath = join(ROOT_DIR, relPath)
   let content: string
@@ -42,13 +110,5 @@ export function prependToChangelog(relPath: string, section: string): void {
     content = `# Changelog\n\nAll notable changes to this package are documented here.\n`
   }
 
-  // Insert after the header (first line starting with #)
-  const headerEnd = content.indexOf('\n## ')
-  if (headerEnd !== -1) {
-    content = content.slice(0, headerEnd) + '\n' + section + '\n' + content.slice(headerEnd)
-  } else {
-    content = content.trimEnd() + '\n\n' + section + '\n'
-  }
-
-  writeFileSync(fullPath, content)
+  writeFileSync(fullPath, insertVersionSection(content, section))
 }

--- a/scripts/tests/release-changelog.test.ts
+++ b/scripts/tests/release-changelog.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import { insertVersionSection } from '../lib/release-changelog.js'
+
+/**
+ * Replicates `audit:standards` check 43 (SMI-4776): `## [Unreleased]` MUST
+ * appear before the first versioned `## v...` heading. Returns true when the
+ * CHANGELOG body is conforming.
+ */
+function isCheck43Conforming(body: string): boolean {
+  const headingRegex = /^## (.+)$/gm
+  const headings: { isUnreleased: boolean; isVersion: boolean }[] = []
+  let match: RegExpExecArray | null
+  while ((match = headingRegex.exec(body)) !== null) {
+    const text = match[1].trim()
+    const isUnreleased = /^\[?Unreleased\]?$/i.test(text)
+    const isVersion = /^\[?v?\d+\.\d+\.\d+\]?(\s|$)/.test(text)
+    if (isUnreleased || isVersion) headings.push({ isUnreleased, isVersion })
+  }
+  const firstUnreleased = headings.findIndex((h) => h.isUnreleased)
+  const firstVersion = headings.findIndex((h) => h.isVersion)
+  if (firstUnreleased === -1 || firstVersion === -1) return true
+  return firstUnreleased < firstVersion
+}
+
+const NEW_SECTION = '## v0.6.2\n\n- **Fix**: SMI-4920 release tooling'
+
+describe('insertVersionSection', () => {
+  it('leading [Unreleased] with entries: keeps Unreleased on top, carries entries into the new section', () => {
+    const body = [
+      '# Changelog',
+      '',
+      'All notable changes are documented here.',
+      '',
+      '## [Unreleased]',
+      '',
+      '- pending fix A',
+      '- pending fix B',
+      '',
+      '## v0.6.1',
+      '',
+      '- old release',
+      '',
+    ].join('\n')
+
+    const result = insertVersionSection(body, NEW_SECTION)
+
+    expect(isCheck43Conforming(result)).toBe(true)
+    // Unreleased is the first h2 heading.
+    expect(result.indexOf('## [Unreleased]')).toBeLessThan(result.indexOf('## v0.6.2'))
+    // New version section sits before the prior release.
+    expect(result.indexOf('## v0.6.2')).toBeLessThan(result.indexOf('## v0.6.1'))
+    // The carried entries moved into the new version section.
+    const v062 = result.indexOf('## v0.6.2')
+    const v061 = result.indexOf('## v0.6.1')
+    const versionBlock = result.slice(v062, v061)
+    expect(versionBlock).toContain('- pending fix A')
+    expect(versionBlock).toContain('- pending fix B')
+    // [Unreleased] is now empty (no entry lines between it and v0.6.2).
+    const unreleasedBlock = result.slice(
+      result.indexOf('## [Unreleased]'),
+      result.indexOf('## v0.6.2')
+    )
+    expect(unreleasedBlock).not.toContain('- pending')
+    // Prior release content is preserved.
+    expect(result).toContain('- old release')
+  })
+
+  it('leading [Unreleased] empty: keeps it empty, inserts new section after it', () => {
+    const body = [
+      '# Changelog',
+      '',
+      '## [Unreleased]',
+      '',
+      '## v0.6.1',
+      '',
+      '- old release',
+      '',
+    ].join('\n')
+
+    const result = insertVersionSection(body, NEW_SECTION)
+
+    expect(isCheck43Conforming(result)).toBe(true)
+    expect(result.indexOf('## [Unreleased]')).toBeLessThan(result.indexOf('## v0.6.2'))
+    expect(result.indexOf('## v0.6.2')).toBeLessThan(result.indexOf('## v0.6.1'))
+    expect(result).toContain('- old release')
+  })
+
+  it('no [Unreleased] heading: synthesizes an empty one before the new section', () => {
+    const body = [
+      '# Changelog',
+      '',
+      'All notable changes are documented here.',
+      '',
+      '## v0.6.1',
+      '',
+      '- old release',
+      '',
+    ].join('\n')
+
+    const result = insertVersionSection(body, NEW_SECTION)
+
+    expect(isCheck43Conforming(result)).toBe(true)
+    expect(result).toContain('## [Unreleased]')
+    expect(result.indexOf('## [Unreleased]')).toBeLessThan(result.indexOf('## v0.6.2'))
+    expect(result.indexOf('## v0.6.2')).toBeLessThan(result.indexOf('## v0.6.1'))
+    expect(result).toContain('- old release')
+  })
+
+  it('empty / header-only file: synthesizes [Unreleased] then the new section', () => {
+    const body = '# Changelog\n\nAll notable changes to this package are documented here.\n'
+
+    const result = insertVersionSection(body, NEW_SECTION)
+
+    expect(isCheck43Conforming(result)).toBe(true)
+    expect(result).toContain('## [Unreleased]')
+    expect(result).toContain('## v0.6.2')
+    expect(result.indexOf('## [Unreleased]')).toBeLessThan(result.indexOf('## v0.6.2'))
+    expect(result).toContain('# Changelog')
+  })
+})

--- a/scripts/tests/verify-publish-deps.test.ts
+++ b/scripts/tests/verify-publish-deps.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import { runAudit } from '../verify-publish-deps.mjs'
+
+/**
+ * Build a `readJson` stub that returns package.json shapes keyed by path
+ * suffix. `core` is the dependency; `mcp-server` declares the caret range.
+ */
+function makeReadJson(coreVersion: string, mcpDepRange: string) {
+  return (p: string) => {
+    if (p.endsWith('packages/core/package.json')) {
+      return { name: '@skillsmith/core', version: coreVersion, dependencies: {} }
+    }
+    if (p.endsWith('packages/mcp-server/package.json')) {
+      return {
+        name: '@skillsmith/mcp-server',
+        version: '0.6.2',
+        dependencies: { '@skillsmith/core': mcpDepRange },
+      }
+    }
+    if (p.endsWith('packages/cli/package.json')) {
+      return { name: '@skillsmith/cli', version: '0.6.2', dependencies: {} }
+    }
+    throw new Error(`unexpected path: ${p}`)
+  }
+}
+
+function makeLogger() {
+  const lines: string[] = []
+  return {
+    lines,
+    log: (m: string) => lines.push(m),
+    error: (m: string) => lines.push(m),
+  }
+}
+
+describe('runAudit — Check 3 in-PR version acceptance (SMI-4920)', () => {
+  it('accepts an in-PR-released version that is not yet on npm', () => {
+    const logger = makeLogger()
+    const { errors } = runAudit({
+      readJson: makeReadJson('0.6.2', '^0.6.2'),
+      npmView: () => '', // 0.6.2 not on npm yet
+      releasing: { versions: { '@skillsmith/core': '0.6.2' }, resolved: true },
+      logger,
+    })
+
+    expect(errors).toBe(0)
+    expect(logger.lines.join('\n')).toContain(
+      '@skillsmith/core@0.6.2 — not yet on npm, accepted (released in this PR)'
+    )
+  })
+
+  it('still rejects an unrelated unpublished pin (not in this PR)', () => {
+    const logger = makeLogger()
+    const { errors } = runAudit({
+      // Working tree matches base: core 0.6.2, dep declares ^0.6.2.
+      readJson: makeReadJson('0.6.2', '^0.6.2'),
+      npmView: () => '', // 0.6.2 not on npm
+      releasing: { versions: {}, resolved: true }, // non-release PR
+      logger,
+    })
+
+    expect(errors).toBe(1)
+    expect(logger.lines.join('\n')).toContain('is not published on npm')
+  })
+
+  it('base-resolution fallback: warns and falls back to npm-only Check 3', () => {
+    const logger = makeLogger()
+    const { errors } = runAudit({
+      readJson: makeReadJson('0.6.2', '^0.6.2'),
+      npmView: () => '0.6.2', // npm has it — npm-only check passes
+      releasing: { versions: {}, resolved: false }, // base could not be resolved
+      logger,
+    })
+
+    expect(errors).toBe(0)
+    expect(logger.lines.join('\n')).toContain('could not resolve PR base ref')
+  })
+
+  it('passes cleanly when the declared version is published on npm', () => {
+    const logger = makeLogger()
+    const { errors } = runAudit({
+      readJson: makeReadJson('0.6.2', '^0.6.2'),
+      npmView: () => '0.6.2',
+      releasing: { versions: {}, resolved: true },
+      logger,
+    })
+
+    expect(errors).toBe(0)
+  })
+
+  it('does not accept an in-PR map entry whose version differs from the declared range', () => {
+    const logger = makeLogger()
+    const { errors } = runAudit({
+      // dep declares ^0.6.2 (matches local), but the PR releases a different
+      // core version — Check 3 must not silently accept the 0.6.2 pin.
+      readJson: makeReadJson('0.6.2', '^0.6.2'),
+      npmView: () => '',
+      releasing: { versions: { '@skillsmith/core': '0.6.3' }, resolved: true },
+      logger,
+    })
+
+    expect(errors).toBe(1)
+    expect(logger.lines.join('\n')).toContain('is not published on npm')
+  })
+})

--- a/scripts/verify-publish-deps.mjs
+++ b/scripts/verify-publish-deps.mjs
@@ -4,6 +4,12 @@
  * Catches the exact failure mode from mcp-server@0.4.4 (SMI-3468): consumer
  * declares dep@X but code needs exports only in dep@Y (Y > X, unpublished).
  *
+ * SMI-4920 (Bug B): on a release PR, Check 2 forces dependents to declare
+ * `^<newcore>` while Check 3 requires that version already published on npm —
+ * jointly unsatisfiable (a deterministic ordering deadlock, not a race). Check 3
+ * now also accepts a version that is being released in the same PR, detected by
+ * diffing the working-tree `version` against the PR base ref.
+ *
  * Usage:
  *   node scripts/verify-publish-deps.mjs          # Check all packages
  *   node scripts/verify-publish-deps.mjs --ci     # CI mode (GitHub annotations)
@@ -13,11 +19,10 @@
 import { readFileSync, existsSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
-import { execSync } from 'child_process'
+import { execSync, execFileSync } from 'child_process'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
-const CI = process.argv.includes('--ci')
 
 const PACKAGES = [
   { name: '@skillsmith/core', dir: 'packages/core' },
@@ -25,17 +30,7 @@ const PACKAGES = [
   { name: '@skillsmith/cli', dir: 'packages/cli' },
 ]
 
-let errors = 0
 const npmCache = new Map()
-
-function log(msg) {
-  console.log(`  ${msg}`)
-}
-function warn(file, msg) {
-  errors++
-  if (CI) console.log(`::error file=${file}::${msg}`)
-  else console.error(`  ERROR: ${msg}`)
-}
 
 function npmViewCached(name, version) {
   const key = `${name}@${version}`
@@ -53,66 +48,181 @@ function npmViewCached(name, version) {
   }
 }
 
-console.log('\n  Workspace Dependency Version Audit (SMI-3471)\n')
+/**
+ * Determine which packages are being released in THIS PR by comparing the
+ * working-tree `version` field against the PR base ref. Returns a map of
+ * `{ '@skillsmith/<name>': '<newVersion>' }` for packages whose version differs.
+ *
+ * Base ref = `GITHUB_BASE_REF` when set (PR context), else `main`. The ref is
+ * fetched if not present locally — handles shallow clones / detached HEAD.
+ *
+ * Fail-soft: returns `{ versions: {}, resolved: false }` when the base ref
+ * cannot be resolved, so callers can fall back to npm-only checks.
+ *
+ * @param {{ git?: (args: string[]) => string, readJson?: (p: string) => any }} [io]
+ * @returns {{ versions: Record<string, string>, resolved: boolean }}
+ */
+export function getReleasingVersions(io = {}) {
+  const git =
+    io.git ??
+    ((args) =>
+      execFileSync('git', args, {
+        cwd: ROOT,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }))
+  const readJson = io.readJson ?? ((p) => JSON.parse(readFileSync(p, 'utf-8')))
 
-for (const pkg of PACKAGES) {
-  const pkgPath = join(ROOT, pkg.dir, 'package.json')
-  if (!existsSync(pkgPath)) continue
+  const base = process.env.GITHUB_BASE_REF || 'main'
+  const baseRef = `origin/${base}`
 
-  const pkgJson = JSON.parse(readFileSync(pkgPath, 'utf-8'))
-  const deps = { ...pkgJson.dependencies }
-  let siblingCount = 0
-
-  for (const [depName, depRange] of Object.entries(deps)) {
-    const sibling = PACKAGES.find((p) => p.name === depName)
-    if (!sibling) continue
-    siblingCount++
-
-    const siblingPkg = JSON.parse(readFileSync(join(ROOT, sibling.dir, 'package.json'), 'utf-8'))
-
-    // Check 1: Exact pin warning (no ^ or ~ or workspace:)
-    if (
-      !depRange.startsWith('^') &&
-      !depRange.startsWith('~') &&
-      !depRange.startsWith('workspace:')
-    ) {
-      warn(
-        pkgPath,
-        `${pkg.name} has exact-pinned dep ${depName}: "${depRange}". Use caret (^) for workspace deps.`
-      )
+  try {
+    // Ensure the base ref exists locally (shallow clones won't have it).
+    try {
+      git(['rev-parse', '--verify', '--quiet', baseRef])
+    } catch {
+      git(['fetch', 'origin', base])
     }
 
-    // Check 2: Version base matches local (error for ALL range types)
-    // A consumer declaring ^0.4.14 but using exports from local 0.4.16 will
-    // fail if npm resolves the minimum compatible version (0.4.14).
-    const cleanRange = depRange.replace(/^[\^~]/, '')
-    if (cleanRange !== siblingPkg.version && !depRange.startsWith('workspace:')) {
-      warn(
-        pkgPath,
-        `${pkg.name} declares ${depName}: "${depRange}" but local version is ${siblingPkg.version}. Update to "^${siblingPkg.version}" before publishing.`
-      )
-    }
+    const versions = {}
+    for (const pkg of PACKAGES) {
+      const localPath = join(ROOT, pkg.dir, 'package.json')
+      if (!existsSync(localPath)) continue
 
-    // Check 3: Verify declared version exists on npm
-    if (depRange.startsWith('^') || depRange.startsWith('~')) {
-      const baseVersion = depRange.replace(/^[\^~]/, '')
-      const published = npmViewCached(depName, baseVersion)
-      if (!published) {
-        warn(
-          pkgPath,
-          `${pkg.name} declares ${depName}@${depRange} but ${depName}@${baseVersion} is not published on npm.`
-        )
+      let localVersion
+      try {
+        localVersion = readJson(localPath).version
+      } catch {
+        continue
+      }
+
+      let baseVersion
+      try {
+        const baseJson = git(['show', `${baseRef}:${pkg.dir}/package.json`])
+        baseVersion = JSON.parse(baseJson).version
+      } catch {
+        // Package didn't exist on base, or ref unreadable — treat as a release.
+        baseVersion = undefined
+      }
+
+      if (localVersion && localVersion !== baseVersion) {
+        versions[pkg.name] = localVersion
       }
     }
+    return { versions, resolved: true }
+  } catch {
+    return { versions: {}, resolved: false }
+  }
+}
+
+/**
+ * Run the dependency audit against a set of package directories.
+ *
+ * @param {{
+ *   readJson?: (p: string) => any,
+ *   npmView?: (name: string, version: string) => string,
+ *   releasing?: { versions: Record<string, string>, resolved: boolean },
+ *   ci?: boolean,
+ *   logger?: { log: (m: string) => void, error: (m: string) => void },
+ * }} [opts]
+ * @returns {{ errors: number }}
+ */
+export function runAudit(opts = {}) {
+  const readJson = opts.readJson ?? ((p) => JSON.parse(readFileSync(p, 'utf-8')))
+  const npmView = opts.npmView ?? npmViewCached
+  const releasing = opts.releasing ?? getReleasingVersions()
+  const ci = opts.ci ?? false
+  const logger = opts.logger ?? console
+  const inPR = releasing.versions
+
+  let errors = 0
+  const log = (msg) => logger.log(`  ${msg}`)
+  const warn = (file, msg) => {
+    errors++
+    if (ci) logger.log(`::error file=${file}::${msg}`)
+    else logger.error(`  ERROR: ${msg}`)
   }
 
-  log(`${pkg.name}: checked ${siblingCount} workspace dep(s)`)
+  logger.log('\n  Workspace Dependency Version Audit (SMI-3471)\n')
+  if (!releasing.resolved) {
+    log('WARNING: could not resolve PR base ref — Check 3 falls back to npm-only verification.')
+  }
+
+  for (const pkg of PACKAGES) {
+    const pkgPath = join(ROOT, pkg.dir, 'package.json')
+    if (!existsSync(pkgPath)) continue
+
+    const pkgJson = readJson(pkgPath)
+    const deps = { ...pkgJson.dependencies }
+    let siblingCount = 0
+
+    for (const [depName, depRange] of Object.entries(deps)) {
+      const sibling = PACKAGES.find((p) => p.name === depName)
+      if (!sibling) continue
+      siblingCount++
+
+      const siblingPkg = readJson(join(ROOT, sibling.dir, 'package.json'))
+
+      // Check 1: Exact pin warning (no ^ or ~ or workspace:)
+      if (
+        !depRange.startsWith('^') &&
+        !depRange.startsWith('~') &&
+        !depRange.startsWith('workspace:')
+      ) {
+        warn(
+          pkgPath,
+          `${pkg.name} has exact-pinned dep ${depName}: "${depRange}". Use caret (^) for workspace deps.`
+        )
+      }
+
+      // Check 2: Version base matches local (error for ALL range types)
+      // A consumer declaring ^0.4.14 but using exports from local 0.4.16 will
+      // fail if npm resolves the minimum compatible version (0.4.14).
+      const cleanRange = depRange.replace(/^[\^~]/, '')
+      if (cleanRange !== siblingPkg.version && !depRange.startsWith('workspace:')) {
+        warn(
+          pkgPath,
+          `${pkg.name} declares ${depName}: "${depRange}" but local version is ${siblingPkg.version}. Update to "^${siblingPkg.version}" before publishing.`
+        )
+      }
+
+      // Check 3: Verify declared version exists on npm OR is being released in
+      // this PR (SMI-4920). On a release PR, Check 2 forces ^<newVersion>;
+      // requiring <newVersion> to already be on npm would be unsatisfiable.
+      if (depRange.startsWith('^') || depRange.startsWith('~')) {
+        const baseVersion = depRange.replace(/^[\^~]/, '')
+        const published = npmView(depName, baseVersion)
+        if (!published) {
+          if (inPR[depName] === baseVersion) {
+            log(`${depName}@${baseVersion} — not yet on npm, accepted (released in this PR)`)
+          } else {
+            warn(
+              pkgPath,
+              `${pkg.name} declares ${depName}@${depRange} but ${depName}@${baseVersion} is not published on npm.`
+            )
+          }
+        }
+      }
+    }
+
+    log(`${pkg.name}: checked ${siblingCount} workspace dep(s)`)
+  }
+
+  logger.log('')
+  if (errors > 0) {
+    logger.error(`  ${errors} error(s) found. Fix dependency versions before publishing.\n`)
+  } else {
+    log('All workspace dependency versions are consistent.\n')
+  }
+
+  return { errors }
 }
 
-console.log('')
-if (errors > 0) {
-  console.error(`  ${errors} error(s) found. Fix dependency versions before publishing.\n`)
-  process.exit(1)
-} else {
-  log('All workspace dependency versions are consistent.\n')
+function main() {
+  const ci = process.argv.includes('--ci')
+  const { errors } = runAudit({ ci })
+  process.exit(errors > 0 ? 1 : 0)
 }
+
+const isMain = import.meta.url === `file://${process.argv[1]}`
+if (isMain) main()


### PR DESCRIPTION
## Summary

The release commit produced by `prepare-release.ts` failed CI on its first push two ways. SMI-4920 fixes both.

**Bug A — changelog ordering.** `prependToChangelog()` spliced the new `## vX.Y.Z` section before the first `## ` heading. When the CHANGELOG led with `## [Unreleased]` (the normal case — confirmed by the PR #1133 CI log), the version section landed above `[Unreleased]`, tripping `audit:standards` check 43. The rewritten `insertVersionSection()` keeps `[Unreleased]` on top (empty), carries its entries into the new version section, and synthesizes an empty `[Unreleased]` when absent.

**Bug B — ordering deadlock.** `verify-publish-deps` Check 2 forces dependents to declare `^<newcore>` while Check 3 required that version already on npm — jointly unsatisfiable on a release PR (a deterministic ordering deadlock, not a race condition). New `getReleasingVersions()` diffs the working-tree version against the PR base ref (`GITHUB_BASE_REF`, fetched if absent; fail-soft to npm-only). Check 3 now also accepts a version released in the same PR, with an explicit accept log line.

## Changes

- `scripts/lib/release-changelog.ts` — rewrite `prependToChangelog()` / new `insertVersionSection()`
- `scripts/verify-publish-deps.mjs` — `getReleasingVersions()` + exported, injectable `runAudit()` + `import.meta.url` main guard
- `scripts/tests/release-changelog.test.ts`, `scripts/tests/verify-publish-deps.test.ts` — new unit tests covering both bugs

## Testing

9 new unit tests pass; typecheck, lint, audit:standards, prettier all green.

ADR-109 infra change — covered by the plan-review in `docs/internal/implementation/smi-4919-4920-4923-followups.md`.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)