### PR TITLE
fix(core): SMI-4919 v17 migration cascade-deletes skill_categories

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: SMI-4919 — the v17 migration's `skills` table-recreate (`CREATE/INSERT/DROP/RENAME`) silently cascade-deleted every `skill_categories` row. With `foreign_keys=ON` (the driver default), `DROP TABLE skills` fires the `skill_categories.skill_id → skills(id) ON DELETE CASCADE` immediately; `SyncEngine.upsertSkills()` never repopulates `skill_categories`, so category-filtered search degraded silently after the migration. The recreate now backs `skill_categories` up into a TEMP table before the drop and restores it verbatim after the rename, inside the same transaction. The false "SQLite defers FK enforcement" header comment is corrected.
+
 ## v0.6.1
 
 - **Fix**: SMI-4917 — repair first-time install (search crash, sync drops all skills, no self-config) (#1132)

--- a/packages/core/src/db/migrations/v17-curated-trust-tier.ts
+++ b/packages/core/src/db/migrations/v17-curated-trust-tier.ts
@@ -16,12 +16,20 @@
  * set, indexes, and FTS5 triggers are copied verbatim from v16 (v17 changes only
  * the `trust_tier` CHECK list — no column added, no column dropped).
  *
- * R1 (FK inbound refs): `skill_categories`, `skill_versions`, etc. reference
- * `skills(id)`. v16 ships the identical drop/rename inside a single transaction
- * and is proven safe in production — v17 follows it exactly, with NO
- * `PRAGMA foreign_keys` toggle. SQLite defers FK enforcement to statement
- * boundaries within a transaction, so dropping and recreating `skills` in one
- * `BEGIN; ... COMMIT;` is safe even with inbound FK rows present.
+ * R1 (FK inbound refs): with `foreign_keys=ON` (the driver default), `DROP TABLE
+ * skills` fires every inbound `ON DELETE CASCADE` action *immediately* — SQLite
+ * does NOT defer cascade actions to the end of the transaction. Today
+ * `skill_categories` (`schema-sql.ts:96-100`) is the only child with a hard FK
+ * `skill_id ... REFERENCES skills(id) ON DELETE CASCADE`; its rows would be
+ * silently cascade-deleted by the recreate (SMI-4919). The recreate therefore
+ * backs `skill_categories` up into a TEMP table before `DROP TABLE skills` and
+ * restores it verbatim after the RENAME, all inside the one `BEGIN; ... COMMIT;`.
+ * (`skill_versions`, `skill_advisories`, `skill_co_installs`,
+ * `skill_dependencies`, `risk_score_history` use soft `skill_id TEXT` columns
+ * with no FK — they are unaffected.) RULE: any future `skills` table-recreate
+ * MUST back up every `ON DELETE CASCADE` child of `skills` the same way (today
+ * `skill_categories` is the only one — re-check `schema-sql.ts` before changing
+ * this dance).
  *
  * Idempotent: v17 adds no column, so the probe inspects the CHECK text itself —
  * if the `skills` DDL already contains `'curated'`, the migration is a no-op.
@@ -70,8 +78,17 @@ SELECT
   created_at, updated_at
 FROM skills;
 
+-- Back up the only ON DELETE CASCADE child of skills so DROP TABLE skills
+-- (which fires cascades immediately under foreign_keys=ON) cannot silently
+-- delete its rows. Restored verbatim after the RENAME below (SMI-4919).
+DROP TABLE IF EXISTS _skill_categories_backup;
+CREATE TEMP TABLE _skill_categories_backup AS SELECT * FROM skill_categories;
+
 DROP TABLE skills;
 ALTER TABLE skills_v17 RENAME TO skills;
+
+INSERT INTO skill_categories SELECT * FROM _skill_categories_backup;
+DROP TABLE _skill_categories_backup;
 
 CREATE INDEX IF NOT EXISTS idx_skills_author ON skills(author);
 CREATE INDEX IF NOT EXISTS idx_skills_trust_tier ON skills(trust_tier);

--- a/packages/core/tests/unit/migrations/migration-v17.test.ts
+++ b/packages/core/tests/unit/migrations/migration-v17.test.ts
@@ -8,8 +8,9 @@
  *   - A `'curated'` row inserts successfully after v17.
  *   - Idempotent re-run of v17 is a no-op.
  *   - H1: the `skills` column set is byte-identical pre/post-v17.
- *   - H3: a fixture DB carrying inbound-FK rows (skill_categories) upgrades
- *     through v17 without error.
+ *   - H3: a fixture DB carrying inbound-FK rows (skill_categories) keeps those
+ *     rows, with intact skill_id links, across the v17 skills-table recreate
+ *     (SMI-4919 — DROP TABLE fires ON DELETE CASCADE; backup/restore preserves).
  *   - H2: fresh-install convergence — v1 base → migrations → v17, no double-apply.
  */
 
@@ -270,35 +271,51 @@ describe('Migration v17: widen trust_tier CHECK to allow curated', () => {
     closeDatabase(v16)
   })
 
-  it('H3: a v16 DB carrying inbound-FK rows upgrades through v17 without error', async () => {
+  it('H3: v17 preserves skill_categories rows across the skills-table recreate', async () => {
     const v16 = await fixtureAtVersion(16)
-    // A skill row referenced by skill_categories (FK skill_categories.skill_id → skills.id).
-    v16
-      .prepare(
-        "INSERT INTO skills (id, name, trust_tier, source) VALUES ('fk-skill', 'fk', 'community', 'registry')"
-      )
-      .run()
+    // Skill rows referenced by skill_categories (FK skill_categories.skill_id → skills.id).
+    const insertSkill = v16.prepare(
+      'INSERT INTO skills (id, name, trust_tier, source) VALUES (?, ?, ?, ?)'
+    )
+    insertSkill.run('fk-skill', 'fk', 'community', 'registry')
+    insertSkill.run('fk-skill-2', 'fk2', 'verified', 'registry')
     v16.prepare("INSERT INTO categories (id, name) VALUES ('cat-1', 'testing')").run()
-    v16
-      .prepare("INSERT INTO skill_categories (skill_id, category_id) VALUES ('fk-skill', 'cat-1')")
-      .run()
+    v16.prepare("INSERT INTO categories (id, name) VALUES ('cat-2', 'devops')").run()
+    const insertLink = v16.prepare(
+      'INSERT INTO skill_categories (skill_id, category_id) VALUES (?, ?)'
+    )
+    insertLink.run('fk-skill', 'cat-1')
+    insertLink.run('fk-skill', 'cat-2')
+    insertLink.run('fk-skill-2', 'cat-1')
 
-    // The v17 recreate drops & renames `skills` inside one transaction — with
-    // inbound FK rows present this must not error (mirrors v16 exactly, no
-    // `PRAGMA foreign_keys` toggle). This is the R1/H3 regression guard.
+    // The v17 recreate drops & renames `skills` inside one transaction. Under
+    // foreign_keys=ON (driver default), `DROP TABLE skills` fires the
+    // `ON DELETE CASCADE` on skill_categories immediately — the recreate must
+    // back up & restore skill_categories so its rows survive (SMI-4919).
     expect(() => applyMigrationV17(v16)).not.toThrow()
 
-    // The skill row itself survives the recreate in the new (widened) table.
-    const skill = v16.prepare("SELECT id FROM skills WHERE id = 'fk-skill'").get() as
-      | { id: string }
-      | undefined
-    expect(skill?.id).toBe('fk-skill')
+    // The skill rows themselves survive the recreate in the new (widened) table.
+    const skills = v16.prepare('SELECT id FROM skills ORDER BY id').all() as Array<{ id: string }>
+    expect(skills.map((s) => s.id)).toEqual(['fk-skill', 'fk-skill-2'])
 
-    // Note: `skill_categories` rows are cascade-deleted by `DROP TABLE skills`
-    // because `foreign_keys` is ON (the driver default) and `skill_categories`
-    // declares `ON DELETE CASCADE`. This is pre-existing v16 behavior — v16
-    // performs the identical `DROP TABLE skills` — and is intentionally NOT a
-    // v17 regression. The CLI rebuilds category links on the next `sync`.
+    // The skill_categories rows survive with intact skill_id links — they are
+    // NOT cascade-deleted. This is the SMI-4919 regression guard.
+    const links = v16
+      .prepare('SELECT skill_id, category_id FROM skill_categories ORDER BY skill_id, category_id')
+      .all() as Array<{ skill_id: string; category_id: string }>
+    expect(links).toEqual([
+      { skill_id: 'fk-skill', category_id: 'cat-1' },
+      { skill_id: 'fk-skill', category_id: 'cat-2' },
+      { skill_id: 'fk-skill-2', category_id: 'cat-1' },
+    ])
+
+    // The TEMP backup table is dropped — no leftover artifact.
+    const backup = v16
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='_skill_categories_backup'"
+      )
+      .get() as { name: string } | undefined
+    expect(backup).toBeUndefined()
     closeDatabase(v16)
   })
 


### PR DESCRIPTION
## Summary

The v17 migration (`v17-curated-trust-tier.ts`) recreates the `skills` table inside one transaction: `CREATE skills_v17` → `INSERT…SELECT` → `DROP TABLE skills` → `RENAME`. With `foreign_keys=ON` (the driver default), `DROP TABLE skills` fires every inbound `ON DELETE CASCADE` **immediately** — SQLite does not defer cascade actions to the transaction boundary. `skill_categories` (`schema-sql.ts:96-100`) is the only child with a hard FK + `ON DELETE CASCADE`, so its rows were silently destroyed. `SyncEngine.upsertSkills()` never repopulates `skill_categories`, so category-filtered search degraded silently after the migration.

The file's header comment claiming SQLite "defers FK enforcement … so dropping and recreating `skills` is safe" was factually wrong and has been corrected.

## Fix

Inside the existing `BEGIN/COMMIT`, the recreate now backs `skill_categories` up into a `TEMP` table before `DROP TABLE skills` and restores it verbatim after the `RENAME`. A `TEMP` table lives in the connection's `temp` database and survives `DROP TABLE main.skills`; the restore runs after `skills` is recreated so the FK parent exists. The corrected header comment states the rule for future recreate migrations: back up every `ON DELETE CASCADE` child of `skills`.

v17 shipped in `core@0.6.1` hours ago with near-zero adoption, so it is fixed in place rather than superseded by a new migration.

## Changes

- `packages/core/src/db/migrations/v17-curated-trust-tier.ts` — TEMP-table backup/restore; corrected FK comment
- `packages/core/tests/unit/migrations/migration-v17.test.ts` — rewrite test H3 to assert `skill_categories` rows survive
- `packages/core/CHANGELOG.md` — `[Unreleased]` entry

## Testing

12 v17 migration tests pass (incl. the rewritten H3); core build, typecheck, lint, audit:standards green.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)