### PR TITLE
chore(release): bump core 0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29765,7 +29765,7 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@skillsmith/core": "^0.6.1",
+        "@skillsmith/core": "^0.6.2",
         "@skillsmith/mcp-server": "^0.5.1",
         "chalk": "5.6.2",
         "chokidar": "4.0.3",
@@ -29875,7 +29875,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@huggingface/transformers": "3.8.1",
@@ -29995,7 +29995,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-        "@skillsmith/core": "^0.6.1",
+        "@skillsmith/core": "^0.6.2",
         "jose": "^6.2.2",
         "zod": "4.2.1"
       },
@@ -30134,7 +30134,7 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.6.1",
+        "@skillsmith/core": "^0.6.2",
         "esbuild": "0.27.2",
         "ulid": "3.0.1"
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.6.1",
+    "@skillsmith/core": "^0.6.2",
     "@skillsmith/mcp-server": "^0.5.1",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
-- **Fix**: SMI-4919 — the v17 migration's `skills` table-recreate (`CREATE/INSERT/DROP/RENAME`) silently cascade-deleted every `skill_categories` row. With `foreign_keys=ON` (the driver default), `DROP TABLE skills` fires the `skill_categories.skill_id → skills(id) ON DELETE CASCADE` immediately; `SyncEngine.upsertSkills()` never repopulates `skill_categories`, so category-filtered search degraded silently after the migration. The recreate now backs `skill_categories` up into a TEMP table before the drop and restores it verbatim after the rename, inside the same transaction. The false "SQLite defers FK enforcement" header comment is corrected.
+## v0.6.2
+
+- **Fix**: SMI-4919 — the v17 migration's `skills` table-recreate (`CREATE/INSERT/DROP/RENAME`) silently cascade-deleted every `skill_categories` row. With `foreign_keys=ON` (the driver default), `DROP TABLE skills` fires the `skill_categories.skill_id → skills(id) ON DELETE CASCADE` immediately; `SyncEngine.upsertSkills()` never repopulates `skill_categories`, so category-filtered search degraded silently after the migration. The recreate now backs `skill_categories` up into a TEMP table before the drop and restores it verbatim after the rename, inside the same transaction. The false "SQLite defers FK enforcement" header comment is corrected. (#1140)
 
 ## v0.6.1
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.6.1'
+export const VERSION = '0.6.2'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-    "@skillsmith/core": "^0.6.1",
+    "@skillsmith/core": "^0.6.2",
     "jose": "^6.2.2",
     "zod": "4.2.1"
   },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.6.1",
+    "@skillsmith/core": "^0.6.2",
     "esbuild": "0.27.2",
     "ulid": "3.0.1"
   },


### PR DESCRIPTION
## Release: @skillsmith/core 0.6.1 → 0.6.2

Ships **SMI-4919** — the v17 migration now preserves `skill_categories` rows across the `skills`-table recreate (PR #1140, on `main`).

### Changes
- `@skillsmith/core` version 0.6.1 → 0.6.2
- `@skillsmith/core` VERSION constant + dependent ranges (`cli`, `mcp-server`, `enterprise`) bumped to `^0.6.2`
- `packages/core/CHANGELOG.md` — new `## v0.6.2` section (consolidated to a single SMI-4919 entry; the carry-forward duplicate from `prepare-release` was removed by hand)
- `package-lock.json` regenerated

### First release through the SMI-4920 tooling fix
This is the first release commit produced after PR #1139 (SMI-4920) landed. It validates that fix end-to-end:
- **CHANGELOG ordering** — `## [Unreleased]` stays on top, `## v0.6.2` is inserted below it → `audit:standards` check 43 passes on first push.
- **verify-publish-deps** — `core@0.6.2` is not yet on npm, but Check 3 now accepts it as a version released in this same PR.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)