### PR TITLE
feat(scripts): SMI-4925 — guard against unsafe skills-recreate migrations

### DIFF
--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -568,6 +568,99 @@ export const parseCiYmlJobs = (ciYmlContent) => {
   return jobs
 }
 
+// ============================================================================
+// SMI-4925: skills-recreate migration FK-cascade guard
+// ============================================================================
+//
+// SQLite fires ON DELETE CASCADE actions *immediately* when foreign_keys=ON,
+// not deferred to end of transaction. The skills-recreate pattern (DROP TABLE
+// skills + RENAME) therefore silently deletes all child rows in any table with
+// a hard `skill_id ... REFERENCES skills(id) ON DELETE CASCADE` column.
+//
+// SMI-4919 fixed this in v17 by backing `skill_categories` (the only such
+// child as of that migration) into a TEMP table before DROP TABLE skills and
+// restoring it after the RENAME — all inside one BEGIN/COMMIT.
+//
+// This helper detects any future migration that recreates the skills table
+// WITHOUT that backup/restore pair, preventing the bug from being reintroduced.
+//
+// If a new ON DELETE CASCADE child of `skills` is added to schema-sql.ts,
+// the conforming backup/restore pattern must be extended to include it, and
+// the regex below updated accordingly (the helper would still catch the
+// absence of the _skill_categories_backup pattern, which is a useful signal).
+
+/**
+ * Detect skills-table recreation migrations that do NOT include the
+ * `_skill_categories_backup` TEMP-table backup/restore pair required to
+ * preserve ON DELETE CASCADE child rows (SMI-4919 / SMI-4925).
+ *
+ * @param {Record<string, string>} migrationsByPath — map of file path →
+ *   file contents for every migration to check.
+ * @param {{ allowList: string[] }} options — basenames to skip without
+ *   flagging (e.g. `['v16-skill-source.ts']` for fix-forward allowlisting).
+ * @returns {Array<{file: string, reason: string}>}
+ */
+export const findUnsafeSkillsRecreateMigrations = (migrationsByPath, { allowList = [] } = {}) => {
+  // Matches DROP TABLE [IF EXISTS] skills — word-boundary after `skills` so
+  // `DROP TABLE skills_v17` and `DROP TABLE _skill_categories_backup` do NOT
+  // match. Case-insensitive, tolerant of extra whitespace.
+  const DROP_SKILLS_RE = /DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?skills\b/i
+
+  // Both halves of the backup/restore pair must be present.
+  // Half A: CREATE TEMP TABLE _skill_categories_backup (followed by AS SELECT
+  //         ... FROM skill_categories — we only require the CREATE TEMP TABLE
+  //         prefix; the AS SELECT part is optional in the regex for robustness).
+  const BACKUP_CREATE_RE = /CREATE\s+TEMP\s+TABLE\s+_skill_categories_backup\b/i
+
+  // Half B: INSERT INTO skill_categories SELECT * FROM _skill_categories_backup
+  const BACKUP_RESTORE_RE =
+    /INSERT\s+INTO\s+skill_categories\s+SELECT\s+.*FROM\s+_skill_categories_backup\b/i
+
+  const violations = []
+
+  for (const [filePath, content] of Object.entries(migrationsByPath)) {
+    const basename = filePath.split('/').pop() ?? filePath
+
+    // Check if this migration recreates the skills table.
+    if (!DROP_SKILLS_RE.test(content)) continue
+
+    // Allow-listed files are skipped without flagging (fix-forward).
+    if (allowList.includes(basename)) continue
+
+    // A safe recreate must include BOTH halves of the backup/restore pair.
+    const hasBackupCreate = BACKUP_CREATE_RE.test(content)
+    const hasBackupRestore = BACKUP_RESTORE_RE.test(content)
+
+    if (hasBackupCreate && hasBackupRestore) continue
+
+    // Determine which halves are missing for the reason string.
+    if (!hasBackupCreate && !hasBackupRestore) {
+      violations.push({
+        file: filePath,
+        reason:
+          'recreates `skills` table (DROP TABLE skills) but is missing both halves of the ' +
+          '_skill_categories_backup TEMP-table guard (CREATE TEMP TABLE + INSERT INTO ... SELECT)',
+      })
+    } else if (!hasBackupCreate) {
+      violations.push({
+        file: filePath,
+        reason:
+          'recreates `skills` table but is missing the backup half: ' +
+          '`CREATE TEMP TABLE _skill_categories_backup AS SELECT * FROM skill_categories`',
+      })
+    } else {
+      violations.push({
+        file: filePath,
+        reason:
+          'recreates `skills` table but is missing the restore half: ' +
+          '`INSERT INTO skill_categories SELECT * FROM _skill_categories_backup`',
+      })
+    }
+  }
+
+  return violations
+}
+
 /**
  * Check pure-JS carve-out invariants on a parsed job list.
  *

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -27,6 +27,7 @@ import {
   findUncoveredSurfacePaths,
   parseCiYmlJobs,
   checkCarveOutInvariants,
+  findUnsafeSkillsRecreateMigrations,
 } from './audit-standards-helpers.mjs'
 import { VERCEL_JSON_SHARED_FIELDS, validateVercelJsonSync } from './audit-vercel-sync-helpers.mjs'
 import { findRealpathAsymmetry } from './audit-realpath-asymmetry-helpers.mjs'
@@ -3504,6 +3505,76 @@ if (!existsSync(internalRefPagesDir) && !existsSync(internalRefBlogDir)) {
     internalRefHits.forEach(({ file, line, match }) =>
       console.log(`    ${file}:${line} — ${match}`)
     )
+  }
+}
+
+// 46. Skills-recreate migration FK-cascade guard (SMI-4925)
+//
+// Background: SQLite fires ON DELETE CASCADE actions immediately when
+// `foreign_keys = ON` (the driver default). Any migration that recreates the
+// `skills` table via DROP TABLE + RENAME therefore silently deletes all rows
+// in every child table that holds a hard `skill_id REFERENCES skills(id)
+// ON DELETE CASCADE`. As of schema-sql.ts, `skill_categories` is the ONLY
+// such child; `skill_versions`, `skill_advisories`, `skill_co_installs`,
+// `skill_dependencies`, and `risk_score_history` all use soft `skill_id TEXT`
+// columns with no FK and are unaffected.
+//
+// SMI-4919 introduced the conforming pattern in v17: back `skill_categories`
+// up into `_skill_categories_backup` (TEMP table) BEFORE `DROP TABLE skills`,
+// then restore it AFTER the RENAME — all inside one BEGIN/COMMIT.
+//
+// v16 performed the same recreate WITHOUT the guard; it is allow-listed here
+// because fixing it retroactively (fix-forward) is intentional — re-applying
+// v16 on an existing DB would still trigger the cascade on the old schema where
+// `skill_categories` may be empty, and the migration is already deployed.
+//
+// EXTEND THIS CHECK if a new ON DELETE CASCADE child of `skills` is added to
+// schema-sql.ts: update the helper regex in audit-standards-helpers.mjs to
+// require backup/restore pairs for the new child table as well.
+console.log(`\n${BOLD}46. Skills-recreate migration FK-cascade guard (SMI-4925)${RESET}`)
+{
+  const coreMigrationsDir = 'packages/core/src/db/migrations'
+  if (!existsSync(coreMigrationsDir)) {
+    pass('No core migrations dir — skipping skills-recreate FK-cascade guard')
+  } else {
+    try {
+      const migrationFiles = readdirSync(coreMigrationsDir)
+        .filter((f) => f.endsWith('.ts'))
+        .map((f) => join(coreMigrationsDir, f))
+      const migrationsByPath = {}
+      for (const f of migrationFiles) migrationsByPath[f] = readFileSync(f, 'utf8')
+      const violations = findUnsafeSkillsRecreateMigrations(migrationsByPath, {
+        // v16 recreates skills without the guard; allow-listed as fix-forward
+        // (the migration is already deployed and retroactive patching is not
+        // needed — v17 introduced the conforming backup/restore pattern).
+        allowList: ['v16-skill-source.ts'],
+      })
+      const recreateCount = Object.entries(migrationsByPath).filter(([, src]) =>
+        /DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?skills\b/i.test(src)
+      ).length
+      if (violations.length === 0) {
+        pass(
+          `Skills-recreate FK-cascade guard: ${recreateCount} recreate migration(s) scanned — all safe or allow-listed`
+        )
+      } else {
+        for (const v of violations) {
+          fail(
+            `Skills-recreate FK-cascade guard: ${v.file} — ${v.reason}`,
+            'Follow the v17 RECREATE_TABLE_SQL pattern in ' +
+              'packages/core/src/db/migrations/v17-curated-trust-tier.ts: ' +
+              'add `DROP TABLE IF EXISTS _skill_categories_backup; ' +
+              'CREATE TEMP TABLE _skill_categories_backup AS SELECT * FROM skill_categories;` ' +
+              'BEFORE `DROP TABLE skills`, and ' +
+              '`INSERT INTO skill_categories SELECT * FROM _skill_categories_backup; ' +
+              'DROP TABLE _skill_categories_backup;` AFTER the RENAME. ' +
+              '`skill_categories` is the only ON DELETE CASCADE child of `skills` ' +
+              'per packages/core/src/db/schema-sql.ts — re-check that file if a new cascade child is added.'
+          )
+        }
+      }
+    } catch (e) {
+      warn(`Could not check skills-recreate FK-cascade guard: ${e.message}`)
+    }
   }
 }
 

--- a/scripts/tests/audit-standards-skills-recreate.test.ts
+++ b/scripts/tests/audit-standards-skills-recreate.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the SMI-4925 skills-recreate FK-cascade guard helper.
+ *
+ * Covers `findUnsafeSkillsRecreateMigrations` in audit-standards-helpers.mjs.
+ *
+ * Background: any migration that drops and recreates the `skills` table must
+ * back up `skill_categories` (the only ON DELETE CASCADE child as of
+ * schema-sql.ts) into a TEMP table before the DROP and restore it after the
+ * RENAME — otherwise SQLite's immediate-cascade behaviour silently deletes all
+ * child rows (SMI-4919). v17 is the conforming reference; v16 is allow-listed.
+ */
+import { describe, expect, it } from 'vitest'
+
+const helpers = (await import('../audit-standards-helpers.mjs')) as {
+  findUnsafeSkillsRecreateMigrations: (
+    migrationsByPath: Record<string, string>,
+    options?: { allowList?: string[] }
+  ) => Array<{ file: string; reason: string }>
+}
+
+const { findUnsafeSkillsRecreateMigrations } = helpers
+
+// ---------------------------------------------------------------------------
+// Fixture SQL snippets
+// ---------------------------------------------------------------------------
+
+/** Conforming v17-shaped SQL: contains both halves of the backup/restore pair. */
+const V17_SAFE_SQL = `
+BEGIN;
+CREATE TABLE skills_v17 (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+INSERT INTO skills_v17 SELECT id, name FROM skills;
+DROP TABLE IF EXISTS _skill_categories_backup;
+CREATE TEMP TABLE _skill_categories_backup AS SELECT * FROM skill_categories;
+DROP TABLE skills;
+ALTER TABLE skills_v17 RENAME TO skills;
+INSERT INTO skill_categories SELECT * FROM _skill_categories_backup;
+DROP TABLE _skill_categories_backup;
+COMMIT;
+`
+
+/** v16-shaped SQL: recreates skills but has NO backup/restore pair. */
+const V16_UNSAFE_SQL = `
+BEGIN;
+CREATE TABLE skills_v16 (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+INSERT INTO skills_v16 SELECT id, name FROM skills;
+DROP TABLE skills;
+ALTER TABLE skills_v16 RENAME TO skills;
+COMMIT;
+`
+
+/** A migration that does not recreate skills at all. */
+const NON_RECREATE_SQL = `
+ALTER TABLE skills ADD COLUMN foo TEXT;
+CREATE INDEX IF NOT EXISTS idx_skills_foo ON skills(foo);
+`
+
+/** Has the CREATE TEMP TABLE backup half but NOT the INSERT restore half. */
+const HALF_BACKUP_ONLY_SQL = `
+BEGIN;
+CREATE TABLE skills_v18 (id TEXT PRIMARY KEY);
+INSERT INTO skills_v18 SELECT id FROM skills;
+CREATE TEMP TABLE _skill_categories_backup AS SELECT * FROM skill_categories;
+DROP TABLE skills;
+ALTER TABLE skills_v18 RENAME TO skills;
+COMMIT;
+`
+
+/** Has DROP TABLE skills_v17 but NOT DROP TABLE skills — must NOT trigger. */
+const DROP_VERSIONED_TABLE_SQL = `
+BEGIN;
+CREATE TABLE skills_v17 (id TEXT PRIMARY KEY);
+DROP TABLE skills_v17;
+ALTER TABLE skills_new RENAME TO skills_v17;
+COMMIT;
+`
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('findUnsafeSkillsRecreateMigrations (SMI-4925)', () => {
+  it('v17-shaped SQL with backup/restore pair — no violation', () => {
+    const violations = findUnsafeSkillsRecreateMigrations({
+      'packages/core/src/db/migrations/v17-curated-trust-tier.ts': V17_SAFE_SQL,
+    })
+    expect(violations).toHaveLength(0)
+  })
+
+  it('recreate dropping skills with NO backup pair — violation', () => {
+    const violations = findUnsafeSkillsRecreateMigrations({
+      'packages/core/src/db/migrations/v99-hypothetical.ts': V16_UNSAFE_SQL,
+    })
+    expect(violations).toHaveLength(1)
+    expect(violations[0].file).toBe('packages/core/src/db/migrations/v99-hypothetical.ts')
+    expect(violations[0].reason).toMatch(/_skill_categories_backup/)
+  })
+
+  it('v16-shaped SQL with basename in allowList — no violation', () => {
+    const violations = findUnsafeSkillsRecreateMigrations(
+      { 'packages/core/src/db/migrations/v16-skill-source.ts': V16_UNSAFE_SQL },
+      { allowList: ['v16-skill-source.ts'] }
+    )
+    expect(violations).toHaveLength(0)
+  })
+
+  it('non-recreate migration (ALTER TABLE ADD COLUMN) — no violation', () => {
+    const violations = findUnsafeSkillsRecreateMigrations({
+      'packages/core/src/db/migrations/v10-add-column.ts': NON_RECREATE_SQL,
+    })
+    expect(violations).toHaveLength(0)
+  })
+
+  it('recreate with ONLY the CREATE TEMP TABLE half (no restore INSERT) — violation', () => {
+    const violations = findUnsafeSkillsRecreateMigrations({
+      'packages/core/src/db/migrations/v20-missing-restore.ts': HALF_BACKUP_ONLY_SQL,
+    })
+    expect(violations).toHaveLength(1)
+    expect(violations[0].reason).toMatch(/restore half/)
+  })
+
+  it('DROP TABLE skills_v17 present but NOT DROP TABLE skills — no violation (word-boundary check)', () => {
+    const violations = findUnsafeSkillsRecreateMigrations({
+      'packages/core/src/db/migrations/v17-curated-trust-tier.ts': DROP_VERSIONED_TABLE_SQL,
+    })
+    expect(violations).toHaveLength(0)
+  })
+
+  it('multiple migrations — only unsafe non-allowlisted ones are flagged', () => {
+    const violations = findUnsafeSkillsRecreateMigrations(
+      {
+        'packages/core/src/db/migrations/v16-skill-source.ts': V16_UNSAFE_SQL,
+        'packages/core/src/db/migrations/v17-curated-trust-tier.ts': V17_SAFE_SQL,
+        'packages/core/src/db/migrations/v18-some-other.ts': V16_UNSAFE_SQL,
+        'packages/core/src/db/migrations/v10-add-column.ts': NON_RECREATE_SQL,
+      },
+      { allowList: ['v16-skill-source.ts'] }
+    )
+    // v16 is allow-listed, v17 is safe, v10 is not a recreate → only v18 flagged
+    expect(violations).toHaveLength(1)
+    expect(violations[0].file).toBe('packages/core/src/db/migrations/v18-some-other.ts')
+  })
+
+  it('defaults to empty allowList when options are omitted', () => {
+    const violations = findUnsafeSkillsRecreateMigrations({
+      'packages/core/src/db/migrations/v16-skill-source.ts': V16_UNSAFE_SQL,
+    })
+    // No allowList → v16 is flagged
+    expect(violations).toHaveLength(1)
+  })
+
+  it('DROP TABLE IF EXISTS skills (with IF EXISTS) also triggers the guard', () => {
+    const sqlWithIfExists = `
+BEGIN;
+CREATE TABLE skills_v99 (id TEXT PRIMARY KEY);
+INSERT INTO skills_v99 SELECT id FROM skills;
+DROP TABLE IF EXISTS skills;
+ALTER TABLE skills_v99 RENAME TO skills;
+COMMIT;
+`
+    const violations = findUnsafeSkillsRecreateMigrations({
+      'packages/core/src/db/migrations/v99-if-exists.ts': sqlWithIfExists,
+    })
+    expect(violations).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

Adds an `audit:standards` check (Check 46) that **fails** when a SQLite migration recreates the `skills` table (`DROP TABLE skills`) without preserving its `ON DELETE CASCADE` child `skill_categories` via the TEMP-table backup/restore pair. This is a structural tripwire against reintroducing the v17 cascade-delete bug fixed in SMI-4919 (#1140).

## Changes

- `scripts/audit-standards-helpers.mjs` — new pure `findUnsafeSkillsRecreateMigrations(migrationsByPath, { allowList })`. Word-boundary `DROP TABLE [IF EXISTS] skills` match (won't false-match `skills_v17`); requires both `CREATE TEMP TABLE _skill_categories_backup` and `INSERT INTO skill_categories SELECT * FROM _skill_categories_backup` for a recreate to be considered safe.
- `scripts/audit-standards.mjs` — Check 46 wiring; `v16-skill-source.ts` allow-listed (intentionally unchanged, fix-forward only).
- `scripts/tests/audit-standards-skills-recreate.test.ts` — 9 cases (conforming v17, non-conforming, allow-listed v16, non-recreate, half-pair, word-boundary, multi-migration).

## Verification

- New test: 9/9 pass.
- Full `audit:standards`: Check 46 passes (2 recreate migrations scanned — v17 safe, v16 allow-listed); overall 66 pass / 0 fail.

Closes SMI-4925.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)