### PR TITLE
fix(cli): SMI-4926 — surface an empty/unsynced local index in search

### DIFF
--- a/packages/cli/src/commands/search.helpers.ts
+++ b/packages/cli/src/commands/search.helpers.ts
@@ -16,7 +16,7 @@ import {
 import { runRegistrySync } from './run-registry-sync.js'
 
 /** Skip the auto-sync if a sync attempt started within this window. */
-const AUTO_SYNC_COOLDOWN_MS = 15 * 60_000
+export const AUTO_SYNC_COOLDOWN_MS = 15 * 60_000
 
 /**
  * Bootstrap the local registry on a first-time `search` against an empty DB.
@@ -60,4 +60,48 @@ export async function autoSyncIfEmpty(db: DatabaseType): Promise<void> {
   } catch {
     spinner.warn(chalk.yellow('Could not sync — showing local results only.'))
   }
+}
+
+/**
+ * Whether the local `skills` table has no rows.
+ *
+ * SMI-4926: a 0-result search against an empty index is meaningfully different
+ * from a genuine no-match — the registry has not been synced locally yet.
+ * Reuses the same `SkillRepository.count()` that `autoSyncIfEmpty` relies on
+ * (no raw SQL).
+ *
+ * @param db - An open, schema-initialized CLI database.
+ */
+export function isLocalIndexEmpty(db: DatabaseType): boolean {
+  return new SkillRepository(db).count() === 0
+}
+
+/**
+ * Build a sync-state-aware hint for a 0-result search against an empty index.
+ *
+ * SMI-4926: `autoSyncIfEmpty` may legitimately skip the sync (anonymous user,
+ * or a sync attempted within `AUTO_SYNC_COOLDOWN_MS`), so the hint must not
+ * unconditionally claim a sync is running. If the most recent sync attempt
+ * started within the cooldown window, the user is told to retry shortly;
+ * otherwise they are told to run `skillsmith sync`.
+ *
+ * Both messages start with a literal `ℹ ` text marker so they remain
+ * distinguishable from the yellow no-match message under `NO_COLOR`, and carry
+ * leading/trailing newlines to match `displayResults` padding.
+ *
+ * @param db - An open, schema-initialized CLI database.
+ */
+export function formatEmptyIndexHint(db: DatabaseType): string {
+  const lastAttempt = new SyncHistoryRepository(db).getHistory(1)[0]
+  if (lastAttempt) {
+    const startedMs = new Date(lastAttempt.startedAt).getTime()
+    if (!Number.isNaN(startedMs) && Date.now() - startedMs < AUTO_SYNC_COOLDOWN_MS) {
+      return chalk.yellow(
+        '\nℹ Your local skill index is still being populated — a sync is in progress. Try this search again shortly.\n'
+      )
+    }
+  }
+  return chalk.yellow(
+    '\nℹ Your local skill index is empty. Run `skillsmith sync` to populate it, then search again.\n'
+  )
 }

--- a/packages/cli/src/commands/search.test.ts
+++ b/packages/cli/src/commands/search.test.ts
@@ -1,0 +1,212 @@
+/**
+ * @fileoverview Unit tests for `skillsmith search` empty-index hinting.
+ * @see SMI-4926
+ *
+ * A 0-result search against an EMPTY local index (not yet synced) must surface
+ * an actionable, sync-state-aware hint instead of the bare "no skills found
+ * matching your criteria" message used for a genuine no-match.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { SearchService, SkillRepository, SyncHistoryRepository } from '@skillsmith/core'
+import { createTestDatabase, closeDatabase } from '@skillsmith/core/testkit'
+import type { Database as DatabaseType } from '@skillsmith/core'
+import { displayResults } from './search-formatters.js'
+import { isLocalIndexEmpty, formatEmptyIndexHint, AUTO_SYNC_COOLDOWN_MS } from './search.helpers.js'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const NO_MATCH_SUBSTRING = 'matching your criteria'
+const HINT_MARKER = 'ℹ'
+
+/** Strip ANSI color codes so newline-padding assertions are color-agnostic. */
+const ANSI_RE = new RegExp(String.fromCharCode(27) + '\\[[0-9;]*m', 'g')
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '')
+}
+
+/** Seed one skill so the local index is non-empty. */
+function seedSkill(db: DatabaseType): void {
+  new SkillRepository(db).create({
+    id: 'community/auth-helper',
+    name: 'auth-helper',
+    description: 'Authentication helper skill',
+    author: 'community',
+    trustTier: 'community',
+    tags: ['authentication'],
+  })
+}
+
+/**
+ * Record a sync attempt and force its `started_at` to a given ISO timestamp,
+ * since SyncHistoryRepository.startRun() always stamps "now".
+ */
+function seedSyncAttempt(db: DatabaseType, startedAt: string): void {
+  const id = new SyncHistoryRepository(db).startRun()
+  db.prepare('UPDATE sync_history SET started_at = ? WHERE id = ?').run(startedAt, id)
+}
+
+/** Capture console.log output produced by `fn`. */
+function captureOutput(fn: () => void): string {
+  const lines: string[] = []
+  const original = console.log
+  console.log = (...args: unknown[]): void => {
+    lines.push(args.map((a) => String(a)).join(' '))
+  }
+  try {
+    fn()
+  } finally {
+    console.log = original
+  }
+  return lines.join('\n')
+}
+
+// ============================================================================
+// Tests — search output: empty vs no-match vs match
+// ============================================================================
+
+describe('search — empty-index hinting (SMI-4926)', () => {
+  let db: DatabaseType
+
+  beforeEach(async () => {
+    db = await createTestDatabase()
+  })
+
+  afterEach(() => {
+    closeDatabase(db)
+  })
+
+  it('empty index + query → shows the hint, not the bare no-match message', () => {
+    const results = new SearchService(db).search({ query: 'anything', limit: 20 })
+    expect(results.items).toHaveLength(0)
+    expect(isLocalIndexEmpty(db)).toBe(true)
+
+    const output = captureOutput(() => {
+      if (results.items.length === 0 && isLocalIndexEmpty(db)) {
+        console.log(formatEmptyIndexHint(db))
+      } else {
+        displayResults(results.items, results.total, 0, 20)
+      }
+    })
+
+    expect(output).toContain(HINT_MARKER)
+    expect(output).not.toContain(NO_MATCH_SUBSTRING)
+  })
+
+  it('populated index + no-match query → shows the bare no-match message, not the hint', () => {
+    seedSkill(db)
+    const results = new SearchService(db).search({ query: 'zzz-nonexistent-zzz', limit: 20 })
+    expect(results.items).toHaveLength(0)
+    expect(isLocalIndexEmpty(db)).toBe(false)
+
+    const output = captureOutput(() => {
+      if (results.items.length === 0 && isLocalIndexEmpty(db)) {
+        console.log(formatEmptyIndexHint(db))
+      } else {
+        displayResults(results.items, results.total, 0, 20)
+      }
+    })
+
+    expect(output).toContain(NO_MATCH_SUBSTRING)
+    expect(output).not.toContain(HINT_MARKER)
+  })
+
+  it('populated index + matching query → renders results, no hint', () => {
+    seedSkill(db)
+    const results = new SearchService(db).search({ query: 'auth', limit: 20 })
+    expect(results.items.length).toBeGreaterThan(0)
+
+    const output = captureOutput(() => {
+      if (results.items.length === 0 && isLocalIndexEmpty(db)) {
+        console.log(formatEmptyIndexHint(db))
+      } else {
+        displayResults(results.items, results.total, 0, 20)
+      }
+    })
+
+    expect(output).toContain('auth-helper')
+    expect(output).not.toContain(HINT_MARKER)
+    expect(output).not.toContain(NO_MATCH_SUBSTRING)
+  })
+})
+
+// ============================================================================
+// Tests — isLocalIndexEmpty (pure given a db)
+// ============================================================================
+
+describe('isLocalIndexEmpty (SMI-4926)', () => {
+  let db: DatabaseType
+
+  beforeEach(async () => {
+    db = await createTestDatabase()
+  })
+
+  afterEach(() => {
+    closeDatabase(db)
+  })
+
+  it('returns true for a fresh DB with no skills', () => {
+    expect(isLocalIndexEmpty(db)).toBe(true)
+  })
+
+  it('returns false once a skill is present', () => {
+    seedSkill(db)
+    expect(isLocalIndexEmpty(db)).toBe(false)
+  })
+})
+
+// ============================================================================
+// Tests — formatEmptyIndexHint (sync-state aware)
+// ============================================================================
+
+describe('formatEmptyIndexHint (SMI-4926)', () => {
+  let db: DatabaseType
+
+  beforeEach(async () => {
+    db = await createTestDatabase()
+  })
+
+  afterEach(() => {
+    closeDatabase(db)
+  })
+
+  it('no recent sync attempt → "run `skillsmith sync`" wording with the ℹ prefix', () => {
+    const hint = formatEmptyIndexHint(db)
+    expect(hint).toContain(HINT_MARKER)
+    expect(hint).toContain('skillsmith sync')
+    expect(hint).not.toContain('in progress')
+  })
+
+  it('stale sync attempt (outside cooldown) → still "run `skillsmith sync`" wording', () => {
+    const stale = new Date(Date.now() - AUTO_SYNC_COOLDOWN_MS - 60_000).toISOString()
+    seedSyncAttempt(db, stale)
+
+    const hint = formatEmptyIndexHint(db)
+    expect(hint).toContain(HINT_MARKER)
+    expect(hint).toContain('skillsmith sync')
+    expect(hint).not.toContain('in progress')
+  })
+
+  it('recent sync attempt (within cooldown) → "in progress" wording with the ℹ prefix', () => {
+    const recent = new Date(Date.now() - 60_000).toISOString()
+    seedSyncAttempt(db, recent)
+
+    const hint = formatEmptyIndexHint(db)
+    expect(hint).toContain(HINT_MARKER)
+    expect(hint).toContain('in progress')
+    expect(hint).not.toContain('skillsmith sync')
+  })
+
+  it('both wordings carry leading and trailing newlines for displayResults padding', () => {
+    const noAttempt = stripAnsi(formatEmptyIndexHint(db))
+    expect(noAttempt.startsWith('\n')).toBe(true)
+    expect(noAttempt.endsWith('\n')).toBe(true)
+
+    seedSyncAttempt(db, new Date(Date.now() - 60_000).toISOString())
+    const recent = stripAnsi(formatEmptyIndexHint(db))
+    expect(recent.startsWith('\n')).toBe(true)
+    expect(recent.endsWith('\n')).toBe(true)
+  })
+})

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -19,7 +19,7 @@ import {
   type RegistrySkillInfo,
 } from '@skillsmith/core'
 import { openCliDatabase } from '../utils/open-database.js'
-import { autoSyncIfEmpty } from './search.helpers.js'
+import { autoSyncIfEmpty, isLocalIndexEmpty, formatEmptyIndexHint } from './search.helpers.js'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { type InteractiveSearchState, type SearchPhase, PAGE_SIZE } from './search-types.js'
@@ -137,12 +137,18 @@ async function runInteractiveSearch(dbPath: string): Promise<void> {
           )
         }
 
-        displayResults(filteredItems, results.total, state.offset, PAGE_SIZE)
-
         if (results.items.length === 0) {
+          // SMI-4926: distinguish an empty/unsynced local index from a no-match.
+          if (isLocalIndexEmpty(db)) {
+            console.log(formatEmptyIndexHint(db))
+          } else {
+            displayResults(filteredItems, results.total, state.offset, PAGE_SIZE)
+          }
           phase = 'exit'
           continue
         }
+
+        displayResults(filteredItems, results.total, state.offset, PAGE_SIZE)
 
         // Build action choices
         const choices: Array<{ name: string; value: string }> = []
@@ -309,6 +315,12 @@ async function runSearch(
     }
 
     const results = searchService.search(searchOptions)
+    // SMI-4926: an empty local index produces 0 results that look like a
+    // genuine no-match — surface a sync-state-aware hint instead.
+    if (results.items.length === 0 && isLocalIndexEmpty(db)) {
+      console.log(formatEmptyIndexHint(db))
+      return
+    }
     displayResults(results.items, results.total, 0, options.limit)
   } finally {
     db.close()


### PR DESCRIPTION
## Summary

`skillsmith search` printed the same yellow "No skills found matching your criteria" message whether the local index was a genuine no-match or simply not yet synced — misleading first-time users into thinking the registry has no matching skills. `search` now detects an empty local index and prints an actionable, sync-state-aware hint.

## Changes

- `search.helpers.ts` — new `isLocalIndexEmpty(db)` (`SkillRepository.count() === 0`, reusing the call `autoSyncIfEmpty` already uses) and `formatEmptyIndexHint(db)`. The hint inspects the most recent `sync_history` attempt: within `AUTO_SYNC_COOLDOWN_MS` → "a sync is in progress, try again shortly"; otherwise → "run `skillsmith sync`". Both variants start with a literal `ℹ ` text marker so they remain distinguishable under `NO_COLOR` (the normal empty message is also yellow). `AUTO_SYNC_COOLDOWN_MS` is now exported so helper and tests share the literal.
- `search.ts` — `runSearch` and `runInteractiveSearch` branch on `isLocalIndexEmpty(db)` for the 0-result path. `displayResults` signature unchanged. `search.ts` stays under the 500-line cap (481).
- `search.test.ts` — new; covers empty/no-match/match search output and the four `formatEmptyIndexHint` sync-state cases.

## Verification

- Typecheck (`packages/cli`): clean.
- New test: 9/9 pass.
- Lint: clean. `wc -l search.ts`: 481.

Closes SMI-4926.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)