### PR TITLE
fix(scripts): SMI-4928 — dedupe carried-forward changelog entries

### DIFF
--- a/scripts/lib/release-changelog.ts
+++ b/scripts/lib/release-changelog.ts
@@ -34,6 +34,70 @@ export function findLastVersionBumpCommit(): string {
 }
 
 /**
+ * Extract identity tokens from a single changelog entry line.
+ *
+ * SMI-4928: tokens are used to decide whether a carried-forward `[Unreleased]`
+ * entry already covers an auto-generated terse entry (so the terse one can be
+ * suppressed). Tokens are every `SMI-\d+` reference and every `(#\d+)` PR-ref
+ * in the line. A line with no recognizable token returns `[]` — the caller
+ * fails safe by keeping such auto-generated lines.
+ *
+ * @param line A changelog entry line (typically starting with `- `).
+ * @returns The list of identity tokens found (uppercased SMI refs + `#NN`).
+ */
+export function extractChangeTokens(line: string): string[] {
+  const tokens: string[] = []
+  for (const m of line.matchAll(/SMI-\d+/gi)) {
+    tokens.push(m[0].toUpperCase())
+  }
+  for (const m of line.matchAll(/\(#(\d+)\)/g)) {
+    tokens.push(`#${m[1]}`)
+  }
+  return tokens
+}
+
+/**
+ * Combine the auto-generated terse `## vX.Y.Z` section with the carried-forward
+ * `[Unreleased]` entry lines, suppressing auto-generated entries that a carried
+ * line already covers (SMI-4928). Caller guarantees `carried` is non-empty.
+ *
+ * @param trimmedSection Auto-generated section: `## v...` header then `- ` lines.
+ * @param carried Trimmed carried-forward `[Unreleased]` entry block.
+ * @returns The combined section body (header + kept auto lines + carried).
+ */
+function dedupeAutoSection(trimmedSection: string, carried: string): string {
+  const sectionLines = trimmedSection.split('\n')
+  // Header is everything up to (and excluding) the first `- ` entry line.
+  const firstEntryIdx = sectionLines.findIndex((l) => l.startsWith('- '))
+  if (firstEntryIdx === -1) {
+    // No auto-generated entry lines — nothing to dedupe.
+    return `${trimmedSection}\n\n${carried}`
+  }
+  const headerLines = sectionLines.slice(0, firstEntryIdx)
+  const autoEntryLines = sectionLines.slice(firstEntryIdx).filter((l) => l.startsWith('- '))
+
+  // Union token set of every carried entry line.
+  const carriedTokens = new Set<string>()
+  for (const line of carried.split('\n')) {
+    if (!line.startsWith('- ')) continue
+    for (const token of extractChangeTokens(line)) {
+      carriedTokens.add(token)
+    }
+  }
+
+  // Drop an auto-generated entry IFF its tokens intersect the carried set.
+  // Keep entries with no recognizable token (cannot prove duplicate).
+  const keptAutoLines = autoEntryLines.filter((line) => {
+    const tokens = extractChangeTokens(line)
+    if (tokens.length === 0) return true
+    return !tokens.some((t) => carriedTokens.has(t))
+  })
+
+  const header = headerLines.join('\n')
+  return `${header}\n${keptAutoLines.join('\n')}\n\n${carried}`.replace(/\n{3,}/g, '\n\n')
+}
+
+/**
  * Insert a new `## vX.Y.Z` section into a CHANGELOG body.
  *
  * SMI-4920 (Bug A): the previous implementation spliced the new section before
@@ -92,10 +156,20 @@ export function insertVersionSection(body: string, section: string): string {
     tail = afterFirstHeading.slice(nextHeading + 1) // strip the leading newline
   }
 
-  // Carry forward any entry lines that were sitting under [Unreleased] (raw
-  // append; dedupe is intentionally out of scope per SMI-4920).
+  // Carry forward any entry lines that were sitting under [Unreleased].
+  //
+  // SMI-4928: when a merged PR already wrote a detailed `[Unreleased]` entry
+  // for a change, the auto-generated terse section also contains a terse entry
+  // for the same change — producing two lines for one change in the new
+  // version section. Token-based dedupe (below) suppresses the auto-generated
+  // terse line when a carried line already covers it by identity token
+  // (`SMI-\d+` / `(#\d+)`). Auto-generated lines with no recognizable token are
+  // kept (fail safe — cannot prove a duplicate). When `carried` is empty no
+  // token logic runs and the output is byte-identical to the pre-SMI-4928
+  // behaviour.
   const carried = unreleasedBody.trim()
-  const sectionWithCarry = carried.length > 0 ? `${trimmedSection}\n\n${carried}` : trimmedSection
+  const sectionWithCarry =
+    carried.length > 0 ? dedupeAutoSection(trimmedSection, carried) : trimmedSection
 
   const tailBlock = tail.trim().length > 0 ? `\n\n${tail.trimEnd()}` : ''
   return `${before}## [Unreleased]\n\n${sectionWithCarry}${tailBlock}\n`

--- a/scripts/tests/release-changelog.test.ts
+++ b/scripts/tests/release-changelog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { insertVersionSection } from '../lib/release-changelog.js'
+import { extractChangeTokens, insertVersionSection } from '../lib/release-changelog.js'
 
 /**
  * Replicates `audit:standards` check 43 (SMI-4776): `## [Unreleased]` MUST
@@ -117,5 +117,206 @@ describe('insertVersionSection', () => {
     expect(result).toContain('## v0.6.2')
     expect(result.indexOf('## [Unreleased]')).toBeLessThan(result.indexOf('## v0.6.2'))
     expect(result).toContain('# Changelog')
+  })
+})
+
+/**
+ * Count occurrences of an `SMI-NNNN` token within the freshly generated
+ * `## vX.Y.Z` version section (between its heading and the next `## ` heading).
+ */
+function countTokenInVersionSection(body: string, versionHeading: string, token: string): number {
+  const start = body.indexOf(versionHeading)
+  if (start === -1) return 0
+  const afterHeading = body.slice(start + versionHeading.length)
+  const nextHeading = afterHeading.indexOf('\n## ')
+  const section = nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading)
+  return section.split(token).length - 1
+}
+
+describe('insertVersionSection — SMI-4928 carried-forward dedupe', () => {
+  it('suppresses the auto-generated terse entry when a carried [Unreleased] entry covers the same SMI', () => {
+    const body = [
+      '# Changelog',
+      '',
+      '## [Unreleased]',
+      '',
+      '- **Fix**: SMI-4919 — long detailed description of the preserved behaviour (#1140)',
+      '',
+      '## v0.6.1',
+      '',
+      '- old release',
+      '',
+    ].join('\n')
+    const autoSection = '## v0.6.2\n\n- **Fix**: SMI-4919 preserve attribution (#1140)'
+
+    const result = insertVersionSection(body, autoSection)
+
+    // SMI-4919 appears exactly once in the new version section.
+    expect(countTokenInVersionSection(result, '## v0.6.2', 'SMI-4919')).toBe(1)
+    // The detailed/carried line is the one kept; the terse line is dropped.
+    expect(result).toContain('- **Fix**: SMI-4919 — long detailed description')
+    expect(result).not.toContain('- **Fix**: SMI-4919 preserve attribution')
+  })
+
+  it('does not over-suppress: an unrelated auto entry survives alongside the carried one', () => {
+    const body = [
+      '# Changelog',
+      '',
+      '## [Unreleased]',
+      '',
+      '- **Fix**: SMI-4919 — long detailed description (#1140)',
+      '',
+      '## v0.6.1',
+      '',
+      '- old release',
+      '',
+    ].join('\n')
+    const autoSection = [
+      '## v0.6.2',
+      '',
+      '- **Fix**: SMI-4919 preserve attribution (#1140)',
+      '- **Feature**: SMI-4923 new unrelated capability (#1145)',
+    ].join('\n')
+
+    const result = insertVersionSection(body, autoSection)
+
+    expect(countTokenInVersionSection(result, '## v0.6.2', 'SMI-4919')).toBe(1)
+    expect(countTokenInVersionSection(result, '## v0.6.2', 'SMI-4923')).toBe(1)
+    expect(result).toContain('- **Feature**: SMI-4923 new unrelated capability')
+    expect(result).not.toContain('- **Fix**: SMI-4919 preserve attribution')
+  })
+
+  it('empty [Unreleased]: the auto-generated section is byte-identical to pre-fix output', () => {
+    const bodyEmptyUnreleased = [
+      '# Changelog',
+      '',
+      '## [Unreleased]',
+      '',
+      '## v0.6.1',
+      '',
+      '- old release',
+      '',
+    ].join('\n')
+    const autoSection = [
+      '## v0.6.2',
+      '',
+      '- **Fix**: SMI-4919 preserve attribution (#1140)',
+      '- **Feature**: SMI-4923 new capability (#1145)',
+    ].join('\n')
+
+    const result = insertVersionSection(bodyEmptyUnreleased, autoSection)
+
+    // No carried entries → no token logic; the auto section is appended verbatim.
+    expect(result).toContain(autoSection.trim())
+  })
+
+  it('keeps an auto-generated entry that carries no SMI/PR token even when [Unreleased] is non-empty', () => {
+    const body = [
+      '# Changelog',
+      '',
+      '## [Unreleased]',
+      '',
+      '- **Fix**: SMI-4919 — long detailed description (#1140)',
+      '',
+      '## v0.6.1',
+      '',
+      '- old release',
+      '',
+    ].join('\n')
+    const autoSection = [
+      '## v0.6.2',
+      '',
+      '- **Fix**: SMI-4919 preserve attribution (#1140)',
+      '- **Chore**: tidy up internal helper naming',
+    ].join('\n')
+
+    const result = insertVersionSection(body, autoSection)
+
+    // Tokenless auto entry cannot be proven a duplicate → kept.
+    expect(result).toContain('- **Chore**: tidy up internal helper naming')
+    expect(countTokenInVersionSection(result, '## v0.6.2', 'SMI-4919')).toBe(1)
+  })
+
+  it('invariant: no SMI token appears twice in a freshly generated version section', () => {
+    const body = [
+      '# Changelog',
+      '',
+      '## [Unreleased]',
+      '',
+      '- **Fix**: SMI-4919 — detailed (#1140)',
+      '- **Feature**: SMI-4923 — detailed (#1145)',
+      '',
+      '## v0.6.1',
+      '',
+      '- old release',
+      '',
+    ].join('\n')
+    const autoSection = [
+      '## v0.6.2',
+      '',
+      '- **Fix**: SMI-4919 terse (#1140)',
+      '- **Feature**: SMI-4923 terse (#1145)',
+      '- **Perf**: SMI-4930 terse (#1150)',
+    ].join('\n')
+
+    const result = insertVersionSection(body, autoSection)
+
+    const start = result.indexOf('## v0.6.2')
+    const section = result.slice(start, result.indexOf('## v0.6.1'))
+    for (const token of new Set(section.match(/SMI-\d+/g) ?? [])) {
+      expect(section.split(token).length - 1).toBe(1)
+    }
+  })
+
+  it('all auto entries suppressed: header still emitted, body is the carried block', () => {
+    const body = [
+      '# Changelog',
+      '',
+      '## [Unreleased]',
+      '',
+      '- **Fix**: SMI-4919 — detailed (#1140)',
+      '',
+      '## v0.6.1',
+      '',
+      '- old release',
+      '',
+    ].join('\n')
+    const autoSection = '## v0.6.2\n\n- **Fix**: SMI-4919 terse (#1140)'
+
+    const result = insertVersionSection(body, autoSection)
+
+    expect(result).toContain('## v0.6.2')
+    expect(countTokenInVersionSection(result, '## v0.6.2', 'SMI-4919')).toBe(1)
+    expect(result).toContain('- **Fix**: SMI-4919 — detailed (#1140)')
+    expect(result).not.toContain('- **Fix**: SMI-4919 terse')
+  })
+})
+
+describe('extractChangeTokens', () => {
+  it('extracts an SMI ref and a PR ref from one entry line', () => {
+    expect(extractChangeTokens('- **Fix**: SMI-4919 preserve attribution (#1140)')).toEqual([
+      'SMI-4919',
+      '#1140',
+    ])
+  })
+
+  it('extracts multiple SMI refs in a single line', () => {
+    expect(extractChangeTokens('- **Fix**: SMI-4919 and SMI-4923 combined (#1140)')).toEqual([
+      'SMI-4919',
+      'SMI-4923',
+      '#1140',
+    ])
+  })
+
+  it('uppercases lowercase SMI refs', () => {
+    expect(extractChangeTokens('- fix smi-4919 thing')).toEqual(['SMI-4919'])
+  })
+
+  it('returns an empty array for a line with no recognizable token', () => {
+    expect(extractChangeTokens('- **Chore**: tidy up internal helper naming')).toEqual([])
+  })
+
+  it('does not treat a bare #NN (without parentheses) as a PR token', () => {
+    expect(extractChangeTokens('- note about issue #1140 inline')).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

`prepare-release` produced duplicate changelog entries: when a merged PR already wrote an `[Unreleased]` entry for a change, the new `## vX.Y.Z` section ended up with both the auto-generated terse entry and the carried-forward detailed entry for that one change (observed on `core@0.6.2`, PR #1141, hand-cleaned). `insertVersionSection()` now dedupes by identity token.

## Changes

- `scripts/lib/release-changelog.ts` — new pure exported `extractChangeTokens(line)` (returns `SMI-\d+` refs + `(#\d+)` PR-refs) and a `dedupeAutoSection()` helper. When `[Unreleased]` carry-forward is non-empty, any auto-generated entry whose token set intersects the carried entries' tokens is dropped (the detailed/carried line wins). Entries with no recognizable token are kept (fail-safe). If all auto entries are suppressed, the `## v...` header is still emitted. When carry-forward is empty, output is byte-identical to pre-fix behaviour.
- `scripts/tests/release-changelog.test.ts` — extended; 6 new dedupe cases + 5 `extractChangeTokens` unit tests + a regression guard. Asserts the issue's acceptance criterion (no `SMI-\d+` token appears twice in a generated section).

## Verification

- Test: 15/15 pass (4 pre-existing + 11 new).
- Typecheck + lint: clean.

Closes SMI-4928.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)