### PR TITLE
fix(ci): SMI-4927 — migrate BuildKit cache from GHA to GHCR registry

### DIFF
--- a/.claude/development/ci-reference.md
+++ b/.claude/development/ci-reference.md
@@ -312,66 +312,116 @@ Edge functions import from Deno ESM URLs pinned at specific versions (e.g., `esm
 
 See [edge-function-patterns.md](edge-function-patterns.md) §Third-Party Library Imports for the pinning convention.
 
-## Docker BuildKit Cache Policy (SMI-3531, SMI-3539, SMI-3653)
+## Docker BuildKit Cache Policy (SMI-3531, SMI-3539, SMI-3653, SMI-4927)
 
-Three workflows build Docker images with BuildKit GHA cache. All Docker build jobs have a **20-minute timeout** to accommodate cold builds (~15 min for native module compilation).
+Three workflows build Docker images with a BuildKit registry cache hosted in
+GHCR. All Docker build jobs have a **20-minute timeout** to accommodate cold
+builds (~15 min for native module compilation).
 
-| Workflow | Scope | Mode | Timeout | Purpose |
-|----------|-------|------|---------|---------|
-| `ci.yml` | `scope=ci` | `mode=min` | 20 min | PR and push CI |
-| `e2e-tests.yml` | `scope=e2e` | `mode=min` | 20 min | End-to-end tests |
-| `publish.yml` | `scope=publish` | `mode=min` | 20 min | npm publish |
+**SMI-4927**: the BuildKit cache was migrated from `type=gha` to `type=registry`
+(GHCR). The `type=gha` backend shared the 10 GB per-repo Actions cache budget;
+its blobs accumulated without bound and LRU-evicted the useful `docker-image-*`
+tarball cache. GHCR cache lives outside that budget and is bounded by
+overwrite-in-place (each main push overwrites its tag). See
+[ci-cache-pressure-fix-v2.md](../../docs/internal/implementation/ci-cache-pressure-fix-v2.md).
 
-**Cache lifecycle** (SMI-3653):
+| Workflow | GHCR cache ref | Mode | Timeout | Purpose |
+|----------|----------------|------|---------|---------|
+| `ci.yml` | `ghcr.io/smith-horn/skillsmith-buildcache:ci` | `mode=min` | 20 min | PR and push CI |
+| `e2e-tests.yml` | `ghcr.io/smith-horn/skillsmith-buildcache:e2e` | `mode=min` | 20 min | End-to-end tests |
+| `publish.yml` | `ghcr.io/smith-horn/skillsmith-buildcache:publish` | `mode=min` | 20 min | npm publish |
+
+**Cache lifecycle** (SMI-3653, SMI-4927):
 
 | Trigger | `cache-from` (read) | `cache-to` (write) |
 |---------|---------------------|---------------------|
 | Push to main | Yes | Yes |
-| Pull request | Yes (reads main's cache) | **No** |
+| Pull request (same-repo) | Yes (reads GHCR cache) | **No** |
+| Pull request (fork) | No — GHCR login skipped, cold build | No |
 | `workflow_dispatch` from main | Yes | Yes |
 | `workflow_dispatch` from branch | Yes | No |
 
-Only main-branch pushes write BuildKit blobs. PR branches read from main's cache but do not write their own blob copies. This prevents per-PR blob accumulation that filled the 10 GB GHA cache limit (70 blobs, 7.44 GB in 24 hours — SMI-3653). Implementation uses an env-var (`CACHE_TO`) set conditionally in a prior step.
+Only main-branch pushes write the GHCR cache. PR branches read it via
+`cache-from` but never write. `cache-to` is gated main-only via an env-var
+(`CACHE_TO`) set conditionally in a prior step (SMI-3653 pattern, preserved).
 
-**Latency note**: The first PR opened after a lockfile change merges to main — but before main's post-merge CI build completes (~6 min) — may see a longer Docker build because main's cache is stale.
+**Fork PRs**: the `Log in to ghcr.io` step is guarded with
+`github.event.pull_request.head.repo.fork != true` — fork PRs run with a
+read-only `GITHUB_TOKEN` that has no `packages:` scope. With the login skipped,
+`cache-from: type=registry` against the private package is a non-fatal cache
+miss and the fork PR cold-builds.
+
+**Latency note**: the first PR opened after a lockfile change merges to main —
+but before main's post-merge CI build completes (~6 min) — may see a longer
+Docker build because the GHCR cache is stale.
 
 **Dual-layer cache architecture** (ci.yml only):
 
 ci.yml uses two cache mechanisms in sequence:
 
-1. **Mechanism 1** (`actions/cache@v5`): Keyed on `Dockerfile + package-lock.json + .dockerignore + .nvmrc`. On hit, loads a pre-built image tarball and skips Docker build entirely. On miss, falls through to mechanism 2.
-2. **Mechanism 2** (`build-push-action` with BuildKit GHA cache): Runs the full Docker build using BuildKit layer cache.
+1. **Mechanism 1** (`actions/cache@v5`): keyed on a hash of `Dockerfile`,
+   `package-lock.json`, `.dockerignore`, and `.nvmrc`. On hit, loads a pre-built
+   image tarball and skips the Docker build entirely. On miss, falls through to
+   mechanism 2. This tarball cache stays in the GHA cache budget.
+2. **Mechanism 2** (`build-push-action` with the GHCR BuildKit registry cache):
+   runs the full Docker build using the GHCR layer cache.
 
-E2E and publish workflows only use mechanism 2 (no `actions/cache` tarball layer). This means E2E PR builds rely entirely on main's BuildKit cache — if main's cache is stale, E2E gets a cold build (~6 min).
+E2E and publish workflows only use mechanism 2 (no `actions/cache` tarball
+layer). E2E PR builds therefore rely entirely on the GHCR BuildKit cache — if
+it is stale, E2E gets a cold build (~6 min).
 
 **Key decisions**:
 
-- `scope=` isolates each workflow's cache entries. Without scope, workflows evict each other's entries when the 10 GB GHA cache cap is reached.
-- All workflows use `mode=min` (final image layers only). `mode=max` was trialed for CI in PR #344 (SMI-3539) but rolled back in SMI-3547 after 72h verification showed cache pressure (10.45 GB, publish scope evicted). The marginal benefit (~3–5 min on ~1–2 lockfile-change builds/week) did not justify the cache eviction risk.
+- One GHCR package (`skillsmith-buildcache`), three tags (`ci`/`e2e`/`publish`)
+  isolate each workflow's cache. Each main push overwrites its tag, so steady
+  state is ~3 layer-sets regardless of run count — no pruning needed.
+- All workflows use `mode=min` (final image layers only). `mode=max` was
+  trialed for CI in PR #344 (SMI-3539) but rolled back in SMI-3547 after 72h
+  verification showed cache pressure. The marginal benefit (~3–5 min on ~1–2
+  lockfile-change builds/week) did not justify the eviction risk.
+- `cache-to` carries `image-manifest=true,oci-mediatypes=true` (export-side
+  only) — GHCR requires an OCI image manifest for the cache artifact.
+
+**GHCR package linking** (one-time, after the first main push): a GHCR package
+auto-created by `cache-to` is private and not linked to the repo. Open
+`github.com/orgs/smith-horn/packages/container/skillsmith-buildcache/settings`
+→ "Manage Actions access" → add `smith-horn/skillsmith` with the **Write** role.
+Until linked, every PR's `cache-from` 401s and cold-builds.
+
+**GHCR cache troubleshooting**:
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `401 Unauthorized` on `cache-from` | GHCR package not linked to the repo, or wrong visibility | Link the package (see "GHCR package linking" above) |
+| `cache-to` denied / `403` | Job missing `packages: write` permission | Add `packages: write` to the build job's `permissions:` block |
+| Fork PR always cold-builds | Expected — GHCR login is skipped on fork PRs | None; this is by design |
 
 **Monitoring commands**:
 
 ```bash
-# Total cache usage (should be under 5 GB)
+# Total GHA Actions cache usage (post-SMI-4927: BuildKit blobs no longer here)
 gh api repos/smith-horn/skillsmith/actions/cache/usage
 
-# Cache breakdown by scope
+# GHA cache breakdown — should show only docker-image-*, pkg-builds-*, npm caches
 gh api "repos/smith-horn/skillsmith/actions/caches?per_page=100" --paginate \
   --jq '[.actions_caches[] | {prefix: (.key | split("-")[0:2] | join("-")), size: .size_in_bytes}] | group_by(.prefix) | map({prefix: .[0].prefix, count: length, total_gb: ([.[].size] | add / 1073741824 * 100 | floor / 100)}) | sort_by(-.total_gb) | .[]'
 
-# Verify scope indexes (ci, e2e, publish should all be present)
-gh api "repos/smith-horn/skillsmith/actions/caches?per_page=100" --paginate \
-  --jq '.actions_caches[] | select(.key | test("index-")) | {key, last_accessed_at}'
+# GHCR BuildKit cache package — versions/tags and size
+gh api orgs/smith-horn/packages/container/skillsmith-buildcache/versions \
+  --jq '.[] | {tags: .metadata.container.tags, updated: .updated_at}'
 
-# Prune all BuildKit caches — blobs AND indexes (run when no CI is in progress)
-# IMPORTANT: Always purge indexes alongside blobs. Deleting blobs but leaving
-# indexes creates poisoned references → "blob sha256:... not found" build failures.
+# One-time GHA BuildKit purge (post-migration only — run when no CI in progress).
+# IMPORTANT: purge indexes alongside blobs — orphaned indexes create poisoned
+# references → "blob sha256:... not found" build failures.
 gh api repos/smith-horn/skillsmith/actions/caches --paginate \
   --jq '.actions_caches[] | select(.key | startswith("buildkit-blob") or startswith("index-")) | .id' \
   | xargs -I{} gh api -X DELETE repos/smith-horn/skillsmith/actions/caches/{}
 ```
 
-- **Cache-miss Step Summary** (SMI-3539): ci.yml docker-build writes cache hit/miss status to `$GITHUB_STEP_SUMMARY` so PR authors know when a cold build is expected.
+- **Cache-status Step Summary** (SMI-3539, SMI-4927): ci.yml and e2e-tests.yml
+  docker-build write cache hit/miss and GHCR login status to
+  `$GITHUB_STEP_SUMMARY` so PR authors know when a cold build is expected and
+  can diagnose a GHCR registry-pull failure.
 
 ## Artifact Retention Policy (SMI-3531)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -749,6 +749,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    # SMI-4927: packages:write for GHCR registry-cache push (cache-to on main).
+    # A job-level block fully replaces the workflow-level `contents: read`, so
+    # contents:read is re-listed here.
+    permissions:
+      contents: read
+      packages: write
+
     outputs:
       image-tag: ${{ steps.meta.outputs.tags }}
       docker-cache-hit: ${{ steps.docker-image-cache.outputs.cache-hit }}
@@ -806,6 +813,18 @@ jobs:
         if: steps.docker-image-cache.outputs.cache-hit != 'true' || steps.load-cached-image.outputs.loaded != 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
+      # SMI-4927: GHCR auth for the registry BuildKit cache. Skipped on fork PRs
+      # (read-only GITHUB_TOKEN has no packages: scope) — fork PRs then cold-build
+      # via a non-fatal cache-from miss.
+      - name: Log in to ghcr.io
+        id: ghcr-login
+        if: (steps.docker-image-cache.outputs.cache-hit != 'true' || steps.load-cached-image.outputs.loaded != 'true') && github.event.pull_request.head.repo.fork != true
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
@@ -816,13 +835,13 @@ jobs:
 
       # Cache write: main only (SMI-3653)
       # PR branches read from main's cache via cache-from but don't write blobs.
-      # This prevents per-PR blob accumulation that fills the 10 GB GHA cache limit.
-      # See docs/internal/implementation/ci-cache-pressure-fix.md
+      # SMI-4927: cache lives in GHCR (type=registry), not the 10 GB GHA budget.
+      # See docs/internal/implementation/ci-cache-pressure-fix-v2.md
       - name: Set BuildKit cache-to
         if: steps.docker-image-cache.outputs.cache-hit != 'true' || steps.load-cached-image.outputs.loaded != 'true'
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "CACHE_TO=type=gha,mode=min,scope=ci" >> $GITHUB_ENV
+            echo "CACHE_TO=type=registry,ref=ghcr.io/smith-horn/skillsmith-buildcache:ci,mode=min,image-manifest=true,oci-mediatypes=true" >> $GITHUB_ENV
           fi
 
       # SMI-2194: Only build if cache miss or load failed
@@ -834,7 +853,7 @@ jobs:
           push: false
           load: true
           tags: skillsmith-ci:${{ github.sha }}
-          cache-from: type=gha,scope=ci
+          cache-from: type=registry,ref=ghcr.io/smith-horn/skillsmith-buildcache:ci
           cache-to: ${{ env.CACHE_TO }}
           target: dev
 
@@ -881,6 +900,11 @@ jobs:
             echo "### Docker Build: Cache Miss — Full Rebuild" >> $GITHUB_STEP_SUMMARY
             echo "No cached image found. Full Docker build with native module compilation (~15 min)." >> $GITHUB_STEP_SUMMARY
             echo "This is expected after lockfile, Dockerfile, or .nvmrc changes." >> $GITHUB_STEP_SUMMARY
+            # SMI-4927: surface GHCR registry-cache login status on a rebuild.
+            # 'skipped' = fork PR (expected cold build); 'failure' = GHCR package
+            # not linked to the repo (see ci-reference.md GHCR troubleshooting).
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "GHCR registry-cache login: \`${{ steps.ghcr-login.outcome }}\` — see the build log for \`importing cache manifest from ghcr.io/...\`." >> $GITHUB_STEP_SUMMARY
           fi
 
       # SMI-708 + SMI-2193 + SMI-4646: Single extract container ("extract-all") replaces the

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,6 +40,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    # SMI-4927: packages:write for GHCR registry-cache push (cache-to on main).
+    # A job-level block fully replaces the workflow-level permissions; this job
+    # only builds and uploads artifacts (no PR comments), so it does not need
+    # the workflow-level pull-requests/issues write — only contents + packages.
+    permissions:
+      contents: read
+      packages: write
+
     outputs:
       image-tag: ${{ steps.meta.outputs.tags }}
 
@@ -60,6 +68,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
+      # SMI-4927: GHCR auth for the registry BuildKit cache. Skipped on fork PRs
+      # (read-only GITHUB_TOKEN has no packages: scope) — fork PRs then cold-build
+      # via a non-fatal cache-from miss.
+      - name: Log in to ghcr.io
+        id: ghcr-login
+        if: github.event.pull_request.head.repo.fork != true
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
@@ -70,11 +90,12 @@ jobs:
 
       # Cache write: main only (SMI-3653)
       # PR branches read from main's cache via cache-from but don't write blobs.
-      # See docs/internal/implementation/ci-cache-pressure-fix.md
+      # SMI-4927: cache lives in GHCR (type=registry), not the 10 GB GHA budget.
+      # See docs/internal/implementation/ci-cache-pressure-fix-v2.md
       - name: Set BuildKit cache-to
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "CACHE_TO=type=gha,mode=min,scope=e2e" >> $GITHUB_ENV
+            echo "CACHE_TO=type=registry,ref=ghcr.io/smith-horn/skillsmith-buildcache:e2e,mode=min,image-manifest=true,oci-mediatypes=true" >> $GITHUB_ENV
           fi
 
       - name: Build and cache Docker image
@@ -84,9 +105,18 @@ jobs:
           push: false
           load: true
           tags: skillsmith-e2e:${{ github.sha }}
-          cache-from: type=gha,scope=e2e
+          cache-from: type=registry,ref=ghcr.io/smith-horn/skillsmith-buildcache:e2e
           cache-to: ${{ env.CACHE_TO }}
           target: dev
+
+      # SMI-4927: surface GHCR registry-cache login status. 'skipped' = fork PR
+      # (expected cold build); 'failure' = GHCR package not linked to the repo
+      # (see ci-reference.md GHCR troubleshooting).
+      - name: GHCR cache status summary
+        if: always()
+        run: |
+          echo "### E2E Docker Build" >> $GITHUB_STEP_SUMMARY
+          echo "GHCR registry-cache login: \`${{ steps.ghcr-login.outcome }}\` — see the build log for \`importing cache manifest from ghcr.io/...\`." >> $GITHUB_STEP_SUMMARY
 
       # SMI-2240: Save image with current SHA tag for downstream jobs
       # SMI-4646: zstd -T0 -3 (parallel, level 3) is ~3x faster than gzip with similar ratio

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -245,6 +245,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
+      # SMI-4927: GHCR auth for the registry BuildKit cache. publish.yml runs
+      # only on release / workflow_dispatch (never fork-originated), so the
+      # login is unconditional.
+      - name: Log in to ghcr.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and cache Docker image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
@@ -252,8 +262,8 @@ jobs:
           push: false
           load: true
           tags: skillsmith-publish:${{ github.sha }}
-          cache-from: type=gha,scope=publish
-          cache-to: type=gha,mode=min,scope=publish
+          cache-from: type=registry,ref=ghcr.io/smith-horn/skillsmith-buildcache:publish
+          cache-to: type=registry,ref=ghcr.io/smith-horn/skillsmith-buildcache:publish,mode=min,image-manifest=true,oci-mediatypes=true
           target: dev
 
       - name: Save Docker image


### PR DESCRIPTION
## Summary

Migrates the CI Docker BuildKit cache from `type=gha` to a GHCR registry cache (`ghcr.io/smith-horn/skillsmith-buildcache`) across `ci.yml`, `e2e-tests.yml`, and `publish.yml`.

## Problem

The repo's GitHub Actions cache hit the 10 GB per-repo ceiling — 86 of 104 caches were `buildkit-blob-*` entries (~7 GB), all on `refs/heads/main`. The SMI-3653 fix (PR #384) made `cache-to` main-only, stopping per-PR churn, but main itself accumulates BuildKit blobs without bound. GitHub LRU-evicts at the ceiling, which evicts the useful 1.3 GB `docker-image-*` tarball cache and slows CI.

## Fix

GHCR registry cache lives **outside** the 10 GB GHA budget and is bounded by overwrite-in-place (each main push overwrites its tag → ~3 layer-sets total). The SMI-3653 main-only `cache-to` pattern is preserved via the `CACHE_TO` env var.

- GHCR login steps are **fork-PR-guarded** (`github.event.pull_request.head.repo.fork != true`) — fork PRs run with a read-only `GITHUB_TOKEN` and cold-build via a non-fatal `cache-from` miss.
- `ci.yml` / `e2e-tests.yml` `docker-build` jobs get a job-level `permissions:` block with `packages: write`; `publish.yml` already had it.
- Step Summary surfaces GHCR cache/login status.
- `ci-reference.md` cache policy section rewritten; GHCR troubleshooting table + package-linking gate documented.

## Post-merge action required (hard gate)

After the first main push creates the `skillsmith-buildcache` package, a maintainer must **link it to the repo** (package settings → Manage Actions access → add `smith-horn/skillsmith` with Write) — until then `cache-from` 401s. Then run the one-time GHA `buildkit-blob`/`index-` purge. Full steps in the SPARC doc.

## Process

ADR-109 infra change. SPARC artifact: `docs/internal/implementation/ci-cache-pressure-fix-v2.md` (companion docs PR smith-horn/skillsmith-docs#172, merged). Plan-reviewed via `plan-review-skill` — all 12 VP findings (2 Critical) applied. Supersedes `ci-cache-pressure-fix.md`.

Governance review of the diff: clean, zero findings.

## Test verification

The diff contains **only** workflow YAML + `ci-reference.md` + the docs submodule pointer — zero `.ts`/`.js`/test files. `actionlint` passes (pre-existing shellcheck info/style only). All test/build CI checks run against the actual code here.

`[skip-impl-check]` — workflow-YAML + markdown-only change, no implementation code.

Linear: SMI-4927

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)