### PR TITLE
docs(ci): SMI-4927 — correct GHCR package-linking note (auto-linked)

### DIFF
--- a/.claude/development/ci-reference.md
+++ b/.claude/development/ci-reference.md
@@ -382,11 +382,15 @@ it is stale, E2E gets a cold build (~6 min).
 - `cache-to` carries `image-manifest=true,oci-mediatypes=true` (export-side
   only) — GHCR requires an OCI image manifest for the cache artifact.
 
-**GHCR package linking** (one-time, after the first main push): a GHCR package
-auto-created by `cache-to` is private and not linked to the repo. Open
+**GHCR package linking**: a package created by a workflow's `GITHUB_TOKEN` (as
+`cache-to` does on the first main push) is **auto-linked** to the source repo —
+GitHub sets the package's `repository` to `smith-horn/skillsmith` and the repo's
+Actions inherit access, so same-repo PR `cache-from` resolves with no manual
+step. The package is private; that is expected and fine for same-repo CI.
+Verified for `skillsmith-buildcache` on 2026-05-16 (SMI-4927). Manual linking is
+only a **fallback**: if `cache-from` ever 401s, open
 `github.com/orgs/smith-horn/packages/container/skillsmith-buildcache/settings`
 → "Manage Actions access" → add `smith-horn/skillsmith` with the **Write** role.
-Until linked, every PR's `cache-from` 401s and cold-builds.
 
 **GHCR cache troubleshooting**:
 


### PR DESCRIPTION
## Summary

Corrects the **GHCR package linking** paragraph in `ci-reference.md`. The SMI-4927 migration doc stated manual linking was *required* after the first main push. Post-merge verification proved otherwise.

## Verification (2026-05-16)

After PR #1146 merged, the post-merge `E2E Tests` run's `cache-to` created the `skillsmith-buildcache` GHCR package. Inspecting it:

```
name:        skillsmith-buildcache
visibility:  private
repository:  smith-horn/skillsmith   ← auto-linked
versions:    1 — tag "e2e"
```

A package created by a workflow's `GITHUB_TOKEN` is **auto-linked** to the source repo (the `repository` field is populated and the repo's Actions inherit access). No manual "Manage Actions access" step is needed for same-repo `cache-from`.

## Change

The paragraph now states the package is auto-linked, and frames manual linking as a **fallback** only (for the `401` case) — consistent with the existing GHCR troubleshooting table. One file, prose-only.

`[skip-impl-check]` — markdown-only, no implementation code.

Linear: SMI-4927

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)