### PR TITLE
chore(deps): SMI-4875 risk-accept otel sdk-node devDep vuln via Dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,6 +95,20 @@ updates:
       # tree-sitter 0.26.x. Re-evaluate when tree-sitter-wasms ≥ 0.2 ships.
       - dependency-name: 'web-tree-sitter'
         versions: ['>=0.26.0']
+      # SMI-4875: @opentelemetry/sdk-node <0.217.0 (GHSA-q7rr-3cgh-j5r3,
+      # Prometheus exporter process crash) is reachable ONLY via the
+      # ruflo → @claude-flow/cli → agentdb@3.0.0-alpha.11 devDependency path.
+      # ruflo is dev-only tooling (hive-mind / agent-spawning), not shipped at
+      # runtime: `npm audit --omit=dev` is clean and the CI Security Audit job
+      # already omits devDeps. agentdb pulls sdk-node transitively (it declares
+      # no direct sdk-node dep) so a Dependabot version-update PR cannot reach
+      # it; this entry is forward-defensive. Risk-accepted disposition.
+      # The version scope keeps alerts LIVE for the prod-tracked
+      # @skillsmith/core dependency (currently @opentelemetry/sdk-node@0.218.0,
+      # i.e. ≥0.217.0 — already patched). Drop this entry once @claude-flow/cli
+      # bumps agentdb's otel chain past 0.217.0.
+      - dependency-name: '@opentelemetry/sdk-node'
+        versions: ['<0.217.0']
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
## Summary

Closes the SMI-4875 disposition: **risk-accept** the `@opentelemetry/sdk-node` Prometheus-exporter advisory (GHSA-q7rr-3cgh-j5r3) and record it with a scoped Dependabot `ignore` entry.

## Why risk-accept

- The vuln (`@opentelemetry/sdk-node <0.217.0`) is reachable **only** via `ruflo → @claude-flow/cli → agentdb@3.0.0-alpha.11` — a **devDependency** path (hive-mind / agent-spawning tooling, not shipped at runtime).
- `npm audit --omit=dev` is clean; the CI **Security Audit** job already omits devDeps and is unaffected.
- `agentdb` pulls `sdk-node` transitively (declares no direct dep), so a Dependabot version-update PR cannot reach it regardless.
- `agentdb@3.0.0-alpha.11` is a pre-release — the cleanest real fix is an upstream `@claude-flow/cli` bump.

Disposition options 1 (wait upstream) and 2 (npm override) were considered: option 2 would jump agentdb's otel `0.52 → 0.218` across many breaking changes with real ruflo-breakage risk, for a devDep-only finding. Option 3 (risk-accept) chosen.

## Change

One scoped `ignore` entry in `.github/dependabot.yml`:

```yaml
- dependency-name: '@opentelemetry/sdk-node'
  versions: ['<0.217.0']
```

The version scope suppresses **exactly** the vulnerable old range (only the `agentdb` devDep resolves it) while keeping alerts **live** for the prod-tracked `@skillsmith/core` dependency at `0.218.0` (≥0.217.0, already patched). The entry should be dropped once `@claude-flow/cli` bumps agentdb's otel chain past 0.217.0.

## Verification

- `npm audit --omit=dev` → 0 vulnerabilities (prod scope clean).
- 0 open Dependabot alerts on the repo.
- YAML validated; pre-commit lint+format passed.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)