### PR TITLE
fix(core): SMI-4484/4807 — self-heal corrupt SQLite DBs + soften WASM-fallback messaging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29904,7 +29904,7 @@
         "node": ">=22.22.0"
       },
       "optionalDependencies": {
-        "better-sqlite3": "11.10.0",
+        "better-sqlite3": "12.10.0",
         "hnswlib-node": "^3.0.0"
       }
     },
@@ -29924,6 +29924,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "packages/core/node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "packages/core/node_modules/stripe": {

--- a/packages/cli/src/utils/open-database.ts
+++ b/packages/cli/src/utils/open-database.ts
@@ -14,7 +14,14 @@
  * `openCliDatabase` makes the footgun structurally impossible: it is the one
  * unmissable way a CLI command opens a database.
  */
-import { createDatabaseAsync, initializeSchema, type DatabaseType } from '@skillsmith/core'
+import {
+  createDatabaseAsync,
+  initializeSchema,
+  isCorruptionError,
+  backupCorruptDbFile,
+  type DatabaseType,
+} from '@skillsmith/core'
+import { existsSync } from 'node:fs'
 
 /**
  * Open a CLI database with the full schema initialized and all migrations
@@ -25,7 +32,25 @@ import { createDatabaseAsync, initializeSchema, type DatabaseType } from '@skill
  * @returns A connected, schema-initialized database. Caller owns `db.close()`.
  */
 export async function openCliDatabase(path: string): Promise<DatabaseType> {
-  const db = await createDatabaseAsync(path)
-  initializeSchema(db)
-  return db
+  try {
+    const db = await createDatabaseAsync(path)
+    initializeSchema(db)
+    return db
+  } catch (err) {
+    // SMI-4484: backstop for corruption that surfaces during schema init (e.g.
+    // a corrupt page only read once the schema queries run). The sql.js driver
+    // self-heals on open, but a corrupt file opened by the native driver can
+    // still fail here. Back up the bad file and retry once on a fresh DB.
+    if (!isCorruptionError(err) || path === ':memory:' || !existsSync(path)) {
+      throw err
+    }
+    const backupPath = backupCorruptDbFile(path)
+    console.warn(
+      `[Skillsmith] The local database at ${path} was corrupt and could not be opened. ` +
+        `It has been backed up to ${backupPath} and will be rebuilt on the next sync.`
+    )
+    const db = await createDatabaseAsync(path)
+    initializeSchema(db)
+    return db
+  }
 }

--- a/packages/cli/src/utils/open-database.ts
+++ b/packages/cli/src/utils/open-database.ts
@@ -32,8 +32,9 @@ import { existsSync } from 'node:fs'
  * @returns A connected, schema-initialized database. Caller owns `db.close()`.
  */
 export async function openCliDatabase(path: string): Promise<DatabaseType> {
+  let db: DatabaseType | undefined
   try {
-    const db = await createDatabaseAsync(path)
+    db = await createDatabaseAsync(path)
     initializeSchema(db)
     return db
   } catch (err) {
@@ -44,13 +45,22 @@ export async function openCliDatabase(path: string): Promise<DatabaseType> {
     if (!isCorruptionError(err) || path === ':memory:' || !existsSync(path)) {
       throw err
     }
+    // Close the handle opened before initializeSchema failed so it is not
+    // leaked before we rebuild.
+    if (db) {
+      try {
+        db.close()
+      } catch {
+        // handle already unusable — nothing more to free
+      }
+    }
     const backupPath = backupCorruptDbFile(path)
     console.warn(
       `[Skillsmith] The local database at ${path} was corrupt and could not be opened. ` +
         `It has been backed up to ${backupPath} and will be rebuilt on the next sync.`
     )
-    const db = await createDatabaseAsync(path)
-    initializeSchema(db)
-    return db
+    const fresh = await createDatabaseAsync(path)
+    initializeSchema(fresh)
+    return fresh
   }
 }

--- a/packages/cli/tests/open-database.test.ts
+++ b/packages/cli/tests/open-database.test.ts
@@ -9,6 +9,9 @@
  * not throw on a brand-new database.
  */
 import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, existsSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { SearchService, SkillRepository, closeDatabase, type DatabaseType } from '@skillsmith/core'
 import { openCliDatabase } from '../src/utils/open-database.js'
 
@@ -53,5 +56,34 @@ describe('SMI-4917 Bug 1: openCliDatabase', () => {
   it('the skills table is queryable on a fresh DB', async () => {
     const db = await open()
     expect(new SkillRepository(db).count()).toBe(0)
+  })
+})
+
+describe('SMI-4484: openCliDatabase corrupt-DB self-heal', () => {
+  let tempDir: string
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('recovers from a corrupt on-disk database by backing it up and rebuilding', async () => {
+    tempDir = mkdtempSync(
+      join(tmpdir(), `smi4484-cli-${Date.now()}-${Math.random().toString(36).slice(2)}-`)
+    )
+    const dbPath = join(tempDir, 'skills.db')
+    // A corrupt file the WASM driver cannot read.
+    writeFileSync(dbPath, Buffer.from('not a sqlite database — corrupt on-disk file'))
+
+    const db = await openCliDatabase(dbPath)
+    closeDatabase(db)
+
+    // The corrupt file was backed up out of the way.
+    const backups = readdirSync(tempDir).filter((f) => f.includes('.corrupt-'))
+    expect(backups.length).toBe(1)
+
+    // A fresh, schema-initialized DB was opened in its place.
+    const reopened = await openCliDatabase(dbPath)
+    expect(new SkillRepository(reopened).count()).toBe(0)
+    closeDatabase(reopened)
   })
 })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
     "zod": "4.2.1"
   },
   "optionalDependencies": {
-    "better-sqlite3": "11.10.0",
+    "better-sqlite3": "12.10.0",
     "hnswlib-node": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/core/src/db/createDatabase.ts
+++ b/packages/core/src/db/createDatabase.ts
@@ -21,8 +21,15 @@ import type { Database, DatabaseOptions } from './database-interface.js'
 import {
   createBetterSqlite3Database,
   isBetterSqlite3Available,
+  getBetterSqlite3FailureReason,
 } from './drivers/betterSqlite3Driver.js'
 import { createSqlJsDatabase, isSqlJsAvailable } from './drivers/sqljsDriver.js'
+
+/**
+ * SMI-4807: guard so the WASM-fallback notice is emitted at most once per
+ * process, no matter how many database connections are opened.
+ */
+let wasmFallbackNoticeEmitted = false
 
 /**
  * Driver type used for database connections
@@ -165,7 +172,19 @@ export async function createDatabaseAsync(
 
   // Fall back to sql.js WASM
   if (isSqlJsAvailable()) {
-    console.warn('[Skillsmith] Native SQLite unavailable, using WASM driver')
+    if (!wasmFallbackNoticeEmitted) {
+      wasmFallbackNoticeEmitted = true
+      let message =
+        '[Skillsmith] Using WASM SQLite driver ' +
+        '(native better-sqlite3 not loaded — expected on direct macOS/npx installs).'
+      if (process.env.SKILLSMITH_DEBUG) {
+        const reason = getBetterSqlite3FailureReason()
+        if (reason) {
+          message += ` Reason: ${reason}`
+        }
+      }
+      console.warn(message)
+    }
     return await createSqlJsDatabase(path, options)
   }
 

--- a/packages/core/src/db/drivers/betterSqlite3Driver.ts
+++ b/packages/core/src/db/drivers/betterSqlite3Driver.ts
@@ -145,6 +145,25 @@ export function createBetterSqlite3Database(
 }
 
 /**
+ * Captured reason the native driver last failed to load.
+ *
+ * SMI-4807: `better-sqlite3` is an optionalDependency whose install/dlopen
+ * failures were previously swallowed by a bare `catch {}`. We now retain the
+ * error message so the WASM-fallback path can surface it under `SKILLSMITH_DEBUG`.
+ */
+let betterSqlite3FailureReason: string | undefined
+
+/**
+ * Get the reason the native better-sqlite3 module last failed to load.
+ *
+ * @returns The failure message, or `undefined` if the native module loaded
+ *   successfully or has not been checked yet.
+ */
+export function getBetterSqlite3FailureReason(): string | undefined {
+  return betterSqlite3FailureReason
+}
+
+/**
  * Check if better-sqlite3 native module is available
  * @returns true if the native module can be loaded
  */
@@ -155,8 +174,11 @@ export function isBetterSqlite3Available(): boolean {
     // Catches ABI mismatch (Node upgrade) and platform mismatch (Linux binary on macOS).
     const testDb = new Database(':memory:')
     testDb.close()
+    betterSqlite3FailureReason = undefined
     return true
-  } catch {
+  } catch (err) {
+    // SMI-4807: capture the failure reason instead of silently discarding it.
+    betterSqlite3FailureReason = err instanceof Error ? err.message : String(err)
     return false
   }
 }

--- a/packages/core/src/db/drivers/corruption.ts
+++ b/packages/core/src/db/drivers/corruption.ts
@@ -1,0 +1,64 @@
+/**
+ * SMI-4484: SQLite corruption detection + self-heal helpers
+ *
+ * On fresh macOS installs, the native better-sqlite3 driver writes WAL-mode
+ * journal files that the WASM driver (sql.js) cannot read. The result is a
+ * `database disk image is malformed` error on the next sync.
+ *
+ * These helpers let both the sql.js driver and the CLI database opener
+ * recognise a corruption-class error and recover by backing up the bad file
+ * and rebuilding an empty database — instead of crashing the user's command.
+ */
+
+import { existsSync, renameSync } from 'node:fs'
+
+/**
+ * Substrings that identify a SQLite corruption-class error.
+ * Matched case-insensitively against the error message.
+ */
+const CORRUPTION_MARKERS = [
+  'sqlite_corrupt',
+  'malformed',
+  'not a database',
+  'file is encrypted',
+  'disk image is malformed',
+]
+
+/**
+ * Determine whether an error indicates a corrupt / unreadable SQLite file.
+ *
+ * @param err - The thrown value (Error, string, or anything).
+ * @returns true if the error message matches a known corruption marker.
+ */
+export function isCorruptionError(err: unknown): boolean {
+  const message = (
+    err instanceof Error ? err.message : typeof err === 'string' ? err : String(err)
+  ).toLowerCase()
+
+  return CORRUPTION_MARKERS.some((marker) => message.includes(marker))
+}
+
+/**
+ * Back up a corrupt SQLite file by renaming it out of the way.
+ *
+ * The backup path is `${path}.corrupt-<timestamp>` where the timestamp is an
+ * ISO string with `:` and `.` replaced by `-` so it is filesystem-safe.
+ *
+ * @param path - Path to the corrupt database file. Must be a real file path
+ *   (not `:memory:`) and must exist on disk.
+ * @returns The path the corrupt file was moved to.
+ * @throws Error if `path` is `:memory:` or the file does not exist.
+ */
+export function backupCorruptDbFile(path: string): string {
+  if (path === ':memory:') {
+    throw new Error('[Skillsmith] backupCorruptDbFile: cannot back up an in-memory database')
+  }
+  if (!existsSync(path)) {
+    throw new Error(`[Skillsmith] backupCorruptDbFile: file does not exist: ${path}`)
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const backupPath = `${path}.corrupt-${timestamp}`
+  renameSync(path, backupPath)
+  return backupPath
+}

--- a/packages/core/src/db/drivers/sqljsDriver.ts
+++ b/packages/core/src/db/drivers/sqljsDriver.ts
@@ -18,6 +18,7 @@
 import { createRequire } from 'node:module'
 import type { Database, Statement, RunResult, DatabaseOptions } from '../database-interface.js'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { isCorruptionError, backupCorruptDbFile } from './corruption.js'
 
 // ESM-compatible require for dynamic module loading
 const require = createRequire(import.meta.url)
@@ -382,14 +383,42 @@ export async function createSqlJsDatabase(
     throw new Error(`SQLITE_CANTOPEN: unable to open database file: ${path}`)
   }
 
-  const db = new SQL.Database(data)
-
-  // Set default pragmas for consistency
-  // Note: WAL mode is intentionally NOT set for sql.js because:
-  // 1. sql.js operates fully in-memory with manual file persistence
-  // 2. Journal modes are meaningless without filesystem integration
-  // 3. Setting WAL would create false parity expectations with better-sqlite3
-  db.run('PRAGMA foreign_keys = ON')
+  // Open the database. If the on-disk file is corrupt (e.g. WAL-mode files
+  // written by the native driver that sql.js cannot read — SMI-4484), back it
+  // up and rebuild an empty database so the next sync repopulates it, instead
+  // of crashing the user's command with `database disk image is malformed`.
+  //
+  // sql.js validates the file lazily — `new SQL.Database(data)` and a no-op
+  // PRAGMA can both succeed on garbage bytes; corruption only surfaces on the
+  // first read of a page. We therefore probe `sqlite_master` inside the
+  // try-block so corruption is detected here rather than at an arbitrary later
+  // query the caller cannot recover from.
+  let db: SqlJsDatabase
+  try {
+    db = new SQL.Database(data)
+    // Set default pragmas for consistency.
+    // Note: WAL mode is intentionally NOT set for sql.js because:
+    // 1. sql.js operates fully in-memory with manual file persistence
+    // 2. Journal modes are meaningless without filesystem integration
+    // 3. Setting WAL would create false parity expectations with better-sqlite3
+    db.run('PRAGMA foreign_keys = ON')
+    // Integrity probe: forces sql.js to read the schema page. Skipped for a
+    // brand-new empty database (no `data`) where there is nothing to validate.
+    if (data !== undefined) {
+      db.run('SELECT name FROM sqlite_master LIMIT 1')
+    }
+  } catch (error) {
+    if (!isCorruptionError(error) || path === ':memory:' || !existsSync(path)) {
+      throw error
+    }
+    const backupPath = backupCorruptDbFile(path)
+    console.warn(
+      `[Skillsmith] The local database at ${path} was corrupt and could not be opened. ` +
+        `It has been backed up to ${backupPath} and will be rebuilt on the next sync.`
+    )
+    db = new SQL.Database()
+    db.run('PRAGMA foreign_keys = ON')
+  }
 
   return new SqlJsDatabaseAdapter(db, path, options)
 }

--- a/packages/core/src/db/drivers/sqljsDriver.ts
+++ b/packages/core/src/db/drivers/sqljsDriver.ts
@@ -394,8 +394,10 @@ export async function createSqlJsDatabase(
   // try-block so corruption is detected here rather than at an arbitrary later
   // query the caller cannot recover from.
   let db: SqlJsDatabase
+  let partialDb: SqlJsDatabase | undefined
   try {
-    db = new SQL.Database(data)
+    partialDb = new SQL.Database(data)
+    db = partialDb
     // Set default pragmas for consistency.
     // Note: WAL mode is intentionally NOT set for sql.js because:
     // 1. sql.js operates fully in-memory with manual file persistence
@@ -408,6 +410,15 @@ export async function createSqlJsDatabase(
       db.run('SELECT name FROM sqlite_master LIMIT 1')
     }
   } catch (error) {
+    // Free the partially-opened handle's WASM heap memory before we rebuild or
+    // rethrow — otherwise it leaks for the process lifetime (SMI-4484).
+    if (partialDb) {
+      try {
+        partialDb.close()
+      } catch {
+        // handle already unusable — nothing more to free
+      }
+    }
     if (!isCorruptionError(error) || path === ':memory:' || !existsSync(path)) {
       throw error
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,10 @@ export * from './exports/repositories.js'
 // SMI-2721 (L1): Export createDatabaseAsync for CLI + enterprise async migration
 export { createDatabaseSync, createDatabaseAsync } from './db/createDatabase.js'
 export type { Database } from './db/database-interface.js'
+// SMI-4484: corruption detection + self-heal helpers, reused by the CLI opener.
+export { isCorruptionError, backupCorruptDbFile } from './db/drivers/corruption.js'
+// SMI-4807: native-driver failure reason getter.
+export { getBetterSqlite3FailureReason } from './db/drivers/betterSqlite3Driver.js'
 
 // Types - All type definitions
 export * from './exports/types.js'

--- a/packages/core/tests/db/corruption.test.ts
+++ b/packages/core/tests/db/corruption.test.ts
@@ -1,0 +1,135 @@
+/**
+ * SMI-4484 / SMI-4807: SQLite corruption self-heal + native-driver failure capture
+ *
+ * Covers:
+ * - isCorruptionError predicate (true for corruption-class messages, false otherwise)
+ * - backupCorruptDbFile renames the bad file out of the way
+ * - createSqlJsDatabase self-heals when handed a corrupt on-disk file
+ * - getBetterSqlite3FailureReason returns a string after a forced failure
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, existsSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { isCorruptionError, backupCorruptDbFile } from '../../src/db/drivers/corruption.js'
+import { createSqlJsDatabase } from '../../src/db/drivers/sqljsDriver.js'
+import {
+  isBetterSqlite3Available,
+  getBetterSqlite3FailureReason,
+} from '../../src/db/drivers/betterSqlite3Driver.js'
+
+/** Create a unique temp directory for filesystem-touching tests. */
+function makeTempDir(): string {
+  return mkdtempSync(
+    join(tmpdir(), `smi4484-${Date.now()}-${Math.random().toString(36).slice(2)}-`)
+  )
+}
+
+describe('isCorruptionError', () => {
+  it('returns true for "database disk image is malformed"', () => {
+    expect(isCorruptionError(new Error('database disk image is malformed'))).toBe(true)
+  })
+
+  it('returns true for "file is not a database"', () => {
+    expect(isCorruptionError(new Error('file is not a database'))).toBe(true)
+  })
+
+  it('returns true for an SQLITE_CORRUPT error', () => {
+    expect(isCorruptionError(new Error('SQLITE_CORRUPT: database is corrupt'))).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isCorruptionError(new Error('DATABASE DISK IMAGE IS MALFORMED'))).toBe(true)
+  })
+
+  it('accepts a plain string', () => {
+    expect(isCorruptionError('file is not a database')).toBe(true)
+  })
+
+  it('returns false for unrelated errors', () => {
+    expect(isCorruptionError(new Error('no such table: cache'))).toBe(false)
+    expect(isCorruptionError(new Error('ENOENT: no such file or directory'))).toBe(false)
+    expect(isCorruptionError(new Error('connection timed out'))).toBe(false)
+  })
+
+  it('returns false for non-error values', () => {
+    expect(isCorruptionError(undefined)).toBe(false)
+    expect(isCorruptionError(null)).toBe(false)
+    expect(isCorruptionError(42)).toBe(false)
+  })
+})
+
+describe('backupCorruptDbFile', () => {
+  let tempDir: string
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('renames the corrupt file to a timestamped .corrupt-* path', () => {
+    tempDir = makeTempDir()
+    const dbPath = join(tempDir, 'skills.db')
+    writeFileSync(dbPath, 'garbage')
+
+    const backupPath = backupCorruptDbFile(dbPath)
+
+    expect(backupPath).toMatch(/skills\.db\.corrupt-/)
+    expect(existsSync(dbPath)).toBe(false)
+    expect(existsSync(backupPath)).toBe(true)
+  })
+
+  it('throws for an in-memory path', () => {
+    expect(() => backupCorruptDbFile(':memory:')).toThrow(/in-memory/)
+  })
+
+  it('throws when the file does not exist', () => {
+    tempDir = makeTempDir()
+    expect(() => backupCorruptDbFile(join(tempDir, 'missing.db'))).toThrow(/does not exist/)
+  })
+})
+
+describe('createSqlJsDatabase — corrupt-DB self-heal (SMI-4484)', () => {
+  let tempDir: string
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('does not throw on a corrupt file, backs it up, and returns a usable empty DB', async () => {
+    tempDir = makeTempDir()
+    const dbPath = join(tempDir, 'skills.db')
+    // Write garbage bytes — not a valid SQLite file.
+    writeFileSync(dbPath, Buffer.from('this is definitely not a sqlite database file'))
+
+    const db = await createSqlJsDatabase(dbPath)
+
+    // A backup file should now exist alongside the (rebuilt) database.
+    const backups = readdirSync(tempDir).filter((f) => f.includes('.corrupt-'))
+    expect(backups.length).toBe(1)
+
+    // The returned database is usable and empty.
+    db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)')
+    db.prepare('INSERT INTO t (name) VALUES (?)').run('hello')
+    const row = db.prepare<{ name: string }>('SELECT name FROM t WHERE id = 1').get()
+    expect(row?.name).toBe('hello')
+
+    db.close()
+  })
+})
+
+describe('getBetterSqlite3FailureReason — SMI-4807', () => {
+  it('returns undefined or a string consistent with native availability', () => {
+    const available = isBetterSqlite3Available()
+    const reason = getBetterSqlite3FailureReason()
+
+    if (available) {
+      // Native loaded — no failure reason retained.
+      expect(reason).toBeUndefined()
+    } else {
+      // Native unavailable — a human-readable reason must be captured.
+      expect(typeof reason).toBe('string')
+      expect((reason ?? '').length).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the macOS first-install failure surface (Phase A Sprint 2):

- **SMI-4484** — CLI sync failed with `database disk image is malformed`. Root cause: the native `better-sqlite3` driver writes WAL-mode files that the WASM driver (`sql.js`) cannot read; on a driver switch the WASM driver hits `SQLITE_CORRUPT`. There was no recovery.
- **SMI-4807** — the WASM-fallback message fired on every macOS install and read like a regression.

## Changes

- **Corruption self-heal** (`packages/core/src/db/drivers/corruption.ts`, new): `isCorruptionError()` predicate + `backupCorruptDbFile()`. `createSqlJsDatabase` now probes `sqlite_master` on open (sql.js validates lazily), and on a corruption-class error backs the file up to `<db>.corrupt-<ts>`, rebuilds empty, and warns — instead of crashing. `openCliDatabase` applies the same guard around `initializeSchema`.
- **Native-driver diagnostics**: `isBetterSqlite3Available()` no longer swallows the failure reason — `getBetterSqlite3FailureReason()` exposes it; surfaced under `SKILLSMITH_DEBUG`.
- **Softened message**: the WASM-fallback notice is now an expected-state line, emitted at most once per process.
- **`better-sqlite3` 11.10.0 → 12.10.0**: kept as `optionalDependency` (never hard-fails an install); 12.x declares `node 20.x–26.x` with current prebuilt coverage, so native loads for more macOS users.
- **ADR-101** updated (skillsmith-docs#176, submodule pointer bumped) to document the driver-fallback chain & corruption recovery.

## Decision (recorded on SMI-4807)

WASM is an adequate steady state for this small local cache — perf is sub-perceptible at this scale. The self-heal is the load-bearing fix (makes driver-switching safe regardless); the better-sqlite3 bump is dependency hygiene, not a perf play.

## Testing

- `packages/core/tests/db/corruption.test.ts` (new, 12 tests) — `isCorruptionError`, `backupCorruptDbFile`, `createSqlJsDatabase` self-heal, `getBetterSqlite3FailureReason`.
- `packages/cli/tests/open-database.test.ts` — corrupt-DB backstop test.
- Governance review found and fixed a leaked DB handle on the corruption-recovery path (commit `aa6f26a3`).
- core `tsc`/`eslint` clean; corruption suite 12/12.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)