### PR TITLE
fix(cli): SMI-4482 — actionable auth guidance when sync hits the trial limit

### DIFF
--- a/packages/cli/src/commands/sync.helpers.ts
+++ b/packages/cli/src/commands/sync.helpers.ts
@@ -7,8 +7,48 @@
  */
 
 import chalk from 'chalk'
-import { createLocalFilesystemAdapter, type AdapterError } from '@skillsmith/core'
+import { createLocalFilesystemAdapter, type AdapterError, type SyncResult } from '@skillsmith/core'
 import { DEFAULT_SKILLS_DIR } from '../config.js'
+
+/**
+ * SMI-4482: Detect whether a failed sync was caused by exhausted/absent
+ * credentials rather than a transient network or server error.
+ *
+ * Root cause: on a fresh install (`skillsmith sync` before `skillsmith login`,
+ * no `SKILLSMITH_API_KEY`) the API client correctly falls back to the public
+ * Supabase anon key and reaches the anonymous IP-trial path. Once the per-IP
+ * free-trial limit is exhausted the `skills-search` edge function returns
+ * HTTP 401 with body `{"error":"Authentication required", ...}`. `SyncEngine`
+ * surfaces that raw string in `SyncResult.errors`, so the CLI used to print a
+ * bare `Authentication required` with `Σ Total: 0` and no next step.
+ *
+ * This matches the 401 auth signal so `sync.ts` can replace the bare error
+ * with actionable guidance.
+ *
+ * @param result - The `SyncResult` returned by the sync engine.
+ * @returns `true` when the sync failed solely because no usable credentials
+ *   were available (anonymous trial exhausted or auth rejected).
+ */
+export function isAuthFailure(result: SyncResult): boolean {
+  if (result.success || result.totalProcessed > 0) {
+    return false
+  }
+  return result.errors.some((error) => /authentication required|unauthorized/i.test(error))
+}
+
+/**
+ * SMI-4482: Actionable, multi-line guidance shown when `sync` fails because
+ * no credentials are available. Replaces the previous bare
+ * `Error: Authentication required` so the user always has a clear next step.
+ *
+ * @returns Lines to print to stderr, in order.
+ */
+export function formatAuthGuidance(): string[] {
+  return [
+    chalk.yellow('Sync requires authentication. Run: ') + chalk.cyan('skillsmith login'),
+    chalk.dim('Or set SKILLSMITH_API_KEY for headless/CI use.'),
+  ]
+}
 
 /**
  * Scan `~/.claude/skills` for non-fatal adapter warnings.

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -28,7 +28,12 @@ import { runRegistrySync } from './run-registry-sync.js'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { formatDuration, formatDate, formatTimeUntil } from '../utils/formatters.js'
-import { scanLocalSkillsForWarnings, formatAdapterWarnings } from './sync.helpers.js'
+import {
+  scanLocalSkillsForWarnings,
+  formatAdapterWarnings,
+  isAuthFailure,
+  formatAuthGuidance,
+} from './sync.helpers.js'
 
 /**
  * Run sync operation
@@ -76,6 +81,26 @@ async function runSync(options: {
       if (options.json) {
         spinner.stop()
         console.log(JSON.stringify(result, null, 2))
+        // SMI-4482: signal auth failure via exit code so `--json` scripts can
+        // detect "needs login" without parsing the payload.
+        if (isAuthFailure(result)) {
+          process.exitCode = 1
+        }
+        return
+      }
+
+      // SMI-4482: When sync failed because no credentials were available
+      // (anonymous IP-trial exhausted, or auth rejected), replace the bare
+      // `Authentication required` error with actionable guidance and exit
+      // non-zero — instead of printing `Σ Total: 0` with no next step.
+      if (isAuthFailure(result)) {
+        spinner.fail(chalk.yellow('Sync requires authentication'))
+        console.log()
+        for (const line of formatAuthGuidance()) {
+          console.error(line)
+        }
+        // db.close() runs in the `finally` block below before process.exit.
+        process.exitCode = 1
         return
       }
 

--- a/packages/cli/tests/sync.auth-ux.test.ts
+++ b/packages/cli/tests/sync.auth-ux.test.ts
@@ -1,0 +1,189 @@
+/**
+ * SMI-4482: CLI `sync` command — actionable auth UX.
+ *
+ * Covers the fresh-install scenario where `skillsmith sync` runs before
+ * `skillsmith login`: the API client reaches the anonymous IP-trial path, the
+ * per-IP trial limit is exhausted server-side, and the `skills-search` edge
+ * function returns HTTP 401 `{"error":"Authentication required"}`. Previously
+ * the CLI printed a bare `Authentication required` with `Σ Total: 0`; it must
+ * now print actionable next steps and exit non-zero.
+ *
+ * Network is fully mocked — no production API calls.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { SyncResult } from '@skillsmith/core'
+import { isAuthFailure, formatAuthGuidance } from '../src/commands/sync.helpers.js'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeResult(overrides: Partial<SyncResult> = {}): SyncResult {
+  return {
+    success: false,
+    skillsAdded: 0,
+    skillsUpdated: 0,
+    skillsUnchanged: 0,
+    totalProcessed: 0,
+    errors: [],
+    durationMs: 5,
+    dryRun: false,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure-helper tests
+// ---------------------------------------------------------------------------
+
+describe('SMI-4482: isAuthFailure', () => {
+  it('detects the server "Authentication required" 401 signal', () => {
+    expect(isAuthFailure(makeResult({ errors: ['Authentication required'] }))).toBe(true)
+  })
+
+  it('detects an "Unauthorized" variant', () => {
+    expect(isAuthFailure(makeResult({ errors: ['Fetch error at offset 0: Unauthorized'] }))).toBe(
+      true
+    )
+  })
+
+  it('is case-insensitive', () => {
+    expect(isAuthFailure(makeResult({ errors: ['authentication required'] }))).toBe(true)
+  })
+
+  it('returns false for a transient network error (no auth signal)', () => {
+    expect(isAuthFailure(makeResult({ errors: ['fetch failed'] }))).toBe(false)
+  })
+
+  it('returns false for a successful sync', () => {
+    expect(isAuthFailure(makeResult({ success: true, totalProcessed: 12, skillsAdded: 12 }))).toBe(
+      false
+    )
+  })
+
+  it('returns false when partial results were returned even if an auth error is present', () => {
+    // A creds-present run that hit a 401 on one page but still synced skills
+    // is NOT a "needs login" situation — the user already has access.
+    expect(
+      isAuthFailure(makeResult({ totalProcessed: 5, errors: ['Authentication required'] }))
+    ).toBe(false)
+  })
+
+  it('returns false when there are no errors', () => {
+    expect(isAuthFailure(makeResult({ errors: [] }))).toBe(false)
+  })
+})
+
+describe('SMI-4482: formatAuthGuidance', () => {
+  it('includes the login command and the headless/CI hint', () => {
+    const text = formatAuthGuidance().join('\n')
+    expect(text).toContain('skillsmith login')
+    expect(text).toContain('Sync requires authentication')
+    expect(text).toContain('SKILLSMITH_API_KEY')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Command-level tests
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  runRegistrySync: vi.fn(),
+  dbClose: vi.fn(),
+  spinner: {
+    start: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+    text: '',
+  },
+}))
+
+vi.mock('../src/commands/run-registry-sync.js', () => ({
+  runRegistrySync: (...args: unknown[]) => mocks.runRegistrySync(...args),
+}))
+
+vi.mock('../src/utils/open-database.js', () => ({
+  openCliDatabase: () => Promise.resolve({ close: mocks.dbClose }),
+}))
+
+vi.mock('ora', () => ({ default: () => mocks.spinner }))
+
+const originalConsoleLog = console.log
+const originalConsoleError = console.error
+const mockConsoleLog = vi.fn()
+const mockConsoleError = vi.fn()
+
+describe('SMI-4482: sync command — no-credentials UX', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    console.log = mockConsoleLog
+    console.error = mockConsoleError
+    process.exitCode = undefined
+  })
+
+  afterEach(() => {
+    console.log = originalConsoleLog
+    console.error = originalConsoleError
+    process.exitCode = undefined
+  })
+
+  it('prints actionable login guidance (not a bare error) and exits non-zero', async () => {
+    mocks.runRegistrySync.mockResolvedValue(makeResult({ errors: ['Authentication required'] }))
+
+    const { createSyncCommand } = await import('../src/commands/sync.js')
+    await createSyncCommand().parseAsync(['node', 'test'])
+
+    const stderr = mockConsoleError.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(stderr).toContain('Sync requires authentication')
+    expect(stderr).toContain('skillsmith login')
+    expect(stderr).toContain('SKILLSMITH_API_KEY')
+    expect(process.exitCode).toBe(1)
+
+    // The bad UX must NOT appear: no bare "Σ Total: 0" results block.
+    const stdout = mockConsoleLog.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(stdout).not.toContain('Total:')
+    expect(mocks.dbClose).toHaveBeenCalled()
+  })
+
+  it('emits machine-readable JSON and exit code 1 with --json on auth failure', async () => {
+    mocks.runRegistrySync.mockResolvedValue(makeResult({ errors: ['Authentication required'] }))
+
+    const { createSyncCommand } = await import('../src/commands/sync.js')
+    await createSyncCommand().parseAsync(['node', 'test', '--json'])
+
+    const stdout = mockConsoleLog.mock.calls.map((c) => String(c[0])).join('\n')
+    const parsed = JSON.parse(stdout)
+    expect(parsed.errors).toContain('Authentication required')
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('does NOT trigger the guard for a successful (creds-present) sync', async () => {
+    mocks.runRegistrySync.mockResolvedValue(
+      makeResult({ success: true, totalProcessed: 8, skillsAdded: 8 })
+    )
+
+    const { createSyncCommand } = await import('../src/commands/sync.js')
+    await createSyncCommand().parseAsync(['node', 'test'])
+
+    expect(mocks.spinner.succeed).toHaveBeenCalled()
+    const stdout = mockConsoleLog.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(stdout).toContain('Total:')
+    const stderr = mockConsoleError.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(stderr).not.toContain('Sync requires authentication')
+    expect(process.exitCode).toBeUndefined()
+  })
+
+  it('does NOT trigger the guard for a non-auth transient failure', async () => {
+    mocks.runRegistrySync.mockResolvedValue(makeResult({ errors: ['fetch failed'] }))
+
+    const { createSyncCommand } = await import('../src/commands/sync.js')
+    await createSyncCommand().parseAsync(['node', 'test'])
+
+    expect(mocks.spinner.warn).toHaveBeenCalled()
+    const stderr = mockConsoleError.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(stderr).not.toContain('Sync requires authentication')
+  })
+})


### PR DESCRIPTION
## Summary

`skillsmith sync` on a fresh install (before `skillsmith login`) printed `Σ Total: 0` and a bare `Authentication required` with no next step.

## Root cause

Investigated with a direct `curl` against the prod `skills-search` edge function:
- no credentials → **HTTP 401** `{"error":"Authentication required", ...}`
- with the Supabase anon key → **HTTP 200**

The anonymous trial path is **not** broken and `createApiClient` is **not** erroring early — `SkillsmithApiClient` correctly falls back to the public anon key. The real cause: once the **per-IP free-trial limit is exhausted**, `skills-search` returns 401; `SyncEngine` surfaces the raw string in `SyncResult.errors` and the CLI rendered it as a bare error. Not a regression — the pre-0.5.10 "partial results" behaviour was just the trial not yet exhausted.

This is the UX-guard branch of the issue's two-branch proposal.

## Change

- `sync.helpers.ts` — `isAuthFailure(result)` (matches the 401 auth signal **only when `totalProcessed === 0`**, so a creds-present partial run is never flagged) + `formatAuthGuidance()`.
- `sync.ts` — before the results block, an auth-only failure now prints actionable guidance and sets `process.exitCode = 1` (so `finally`'s `db.close()` still runs); `--json` callers get the payload plus exit 1.

User-facing message (replaces the bare error):
```
✖ Sync requires authentication

Sync requires authentication. Run: skillsmith login
Or set SKILLSMITH_API_KEY for headless/CI use.
```

## Testing

`packages/cli/tests/sync.auth-ux.test.ts` — 12 tests, network mocked: no-creds → actionable message + exit 1; creds-present partial run → not flagged; `--json` exit code. `tsc`/`eslint` clean; files under 500 lines.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)