### PR TITLE
ci: SMI-4933 — weekly prune of untagged GHCR buildcache orphans

### DIFF
--- a/.claude/development/ci-reference.md
+++ b/.claude/development/ci-reference.md
@@ -321,9 +321,12 @@ builds (~15 min for native module compilation).
 **SMI-4927**: the BuildKit cache was migrated from `type=gha` to `type=registry`
 (GHCR). The `type=gha` backend shared the 10 GB per-repo Actions cache budget;
 its blobs accumulated without bound and LRU-evicted the useful `docker-image-*`
-tarball cache. GHCR cache lives outside that budget and is bounded by
-overwrite-in-place (each main push overwrites its tag). See
-[ci-cache-pressure-fix-v2.md](../../docs/internal/implementation/ci-cache-pressure-fix-v2.md).
+tarball cache. GHCR cache lives outside that budget. Its **tagged** versions are
+bounded by overwrite-in-place (each main push moves the tag to a fresh version);
+the prior version is left **untagged, not deleted**, so untagged orphans
+accumulate and are pruned weekly by `ghcr-cache-prune.yml` (SMI-4933). See
+[ci-cache-pressure-fix-v2.md](../../docs/internal/implementation/ci-cache-pressure-fix-v2.md)
+and [ghcr-cache-retention.md](../../docs/internal/implementation/ghcr-cache-retention.md).
 
 | Workflow | GHCR cache ref | Mode | Timeout | Purpose |
 |----------|----------------|------|---------|---------|
@@ -373,8 +376,10 @@ it is stale, E2E gets a cold build (~6 min).
 **Key decisions**:
 
 - One GHCR package (`skillsmith-buildcache`), three tags (`ci`/`e2e`/`publish`)
-  isolate each workflow's cache. Each main push overwrites its tag, so steady
-  state is ~3 layer-sets regardless of run count — no pruning needed.
+  isolate each workflow's cache. Each main push moves its tag to a fresh
+  version, so the **tagged** set stays at ~3 layer-sets regardless of run count.
+  The prior version is left untagged (not deleted), so untagged orphans
+  accumulate — `ghcr-cache-prune.yml` (SMI-4933) prunes them weekly.
 - All workflows use `mode=min` (final image layers only). `mode=max` was
   trialed for CI in PR #344 (SMI-3539) but rolled back in SMI-3547 after 72h
   verification showed cache pressure. The marginal benefit (~3–5 min on ~1–2
@@ -399,6 +404,7 @@ only a **fallback**: if `cache-from` ever 401s, open
 | `401 Unauthorized` on `cache-from` | GHCR package not linked to the repo, or wrong visibility | Link the package (see "GHCR package linking" above) |
 | `cache-to` denied / `403` | Job missing `packages: write` permission | Add `packages: write` to the build job's `permissions:` block |
 | Fork PR always cold-builds | Expected — GHCR login is skipped on fork PRs | None; this is by design |
+| Untagged version count growing past ~3 | Weekly prune disabled, never ran, or 403 on missing Admin role | Check `ghcr-cache-prune.yml` Actions history; confirm the package's "Manage Actions access" grants `smith-horn/skillsmith` the Admin role; re-run via `workflow_dispatch` |
 
 **Monitoring commands**:
 
@@ -413,6 +419,11 @@ gh api "repos/smith-horn/skillsmith/actions/caches?per_page=100" --paginate \
 # GHCR BuildKit cache package — versions/tags and size
 gh api orgs/smith-horn/packages/container/skillsmith-buildcache/versions \
   --jq '.[] | {tags: .metadata.container.tags, updated: .updated_at}'
+
+# Untagged-orphan count — should stay bounded (ghcr-cache-prune.yml, SMI-4933).
+# A count growing past min-versions-to-keep means the weekly prune is not running.
+gh api orgs/smith-horn/packages/container/skillsmith-buildcache/versions --paginate \
+  --jq '[.[] | select(.metadata.container.tags == [])] | length'
 
 # One-time GHA BuildKit purge (post-migration only — run when no CI in progress).
 # IMPORTANT: purge indexes alongside blobs — orphaned indexes create poisoned

--- a/.github/workflows/ghcr-cache-prune.yml
+++ b/.github/workflows/ghcr-cache-prune.yml
@@ -1,0 +1,48 @@
+# SMI-4933: Weekly prune of untagged GHCR buildcache orphans.
+#
+# SMI-4927 migrated the CI Docker BuildKit cache to a GHCR registry cache
+# (ghcr.io/smith-horn/skillsmith-buildcache, tags ci/e2e/publish). A BuildKit
+# `cache-to` export with mode=min does not mutate an image in place; it pushes
+# a NEW package version and moves the tag to it, leaving the prior version
+# untagged but NOT deleted. Untagged orphans therefore accumulate without bound;
+# GitHub offers no native retention policy for GHCR container versions.
+#
+# This workflow deletes ONLY untagged versions (delete-only-untagged-versions),
+# so the live ci/e2e/publish tags are never candidates. min-versions-to-keep: 3
+# is a redundant safety floor; orphans are inherently safe to delete because an
+# in-flight build's `cache-from` always resolves a TAG, never an orphaned digest.
+#
+# Failure visibility: no email/Linear alert (low-stakes cache hygiene). A failed
+# run shows as a red weekly run in the Actions tab; a missed prune is harmless.
+#
+# Prerequisite: the smith-horn/skillsmith repo must hold the Admin role in the
+# package's "Manage Actions access" for GITHUB_TOKEN to delete container
+# versions. See docs/internal/implementation/ghcr-cache-retention.md.
+
+name: GHCR Cache Prune
+
+on:
+  schedule:
+    # Sunday 04:00 UTC, 1h after the weekly publish window (Sun 03:00 UTC),
+    # so a release run's fresh `publish` version is already tagged.
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prune-untagged:
+    name: Prune untagged buildcache versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      packages: write
+    steps:
+      - name: Delete untagged skillsmith-buildcache versions
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
+        with:
+          package-name: skillsmith-buildcache
+          package-type: container
+          delete-only-untagged-versions: 'true'
+          min-versions-to-keep: 3


### PR DESCRIPTION
## Summary

SMI-4927 migrated the CI BuildKit cache to a GHCR registry cache. Each `cache-to` export pushes a **new** package version and moves the tag to it, leaving the prior version **untagged but not deleted** — so untagged orphans accumulate without bound. GitHub has no native retention policy for GHCR container versions.

This PR adds a scheduled prune workflow and corrects the SMI-4927 docs that wrongly claimed the cache needs no pruning.

## Changes

- **`.github/workflows/ghcr-cache-prune.yml`** (new) — weekly (Sun 04:00 UTC, 1h after the publish window) + `workflow_dispatch`. Runs `actions/delete-package-versions` (SHA-pinned `@e5bc658` # v5) with `delete-only-untagged-versions: 'true'`, so the live `ci`/`e2e`/`publish` tags are never deletion candidates. `min-versions-to-keep: 3` is a defensive floor.
- **`.claude/development/ci-reference.md`** — corrects the "bounded by overwrite-in-place" / "no pruning needed" claims (true only of the tagged set); adds a troubleshooting row + an orphan-count monitoring command.
- **`docs/internal`** pointer — bump for the ADR-109 SPARC artifact `ghcr-cache-retention.md` and the v2-doc corrections ([skillsmith-docs#175](https://github.com/smith-horn/skillsmith-docs/pull/175), merged).

## Process

- ADR-109: SPARC artifact `docs/internal/implementation/ghcr-cache-retention.md`, plan-reviewed (VP Product / Engineering / Design — 8 findings, all applied).
- `/governance` on the commit: 1 finding (non-ASCII em dashes in workflow comments) found and fixed before push.
- Pre-push test phase fails environmentally (worktree/Docker native-binary mismatch, SMI-4820/4767); diff is workflow YAML + markdown + submodule pointer only — zero code/test files — so `--no-verify` push was authorized. CI runs the real suite in a clean container.

## Manual prerequisite (before the first scheduled run)

A maintainer must raise `smith-horn/skillsmith` to the **Admin** role in the `skillsmith-buildcache` package's "Manage Actions access" — `GITHUB_TOKEN` needs Admin to delete container package versions. Until then the prune run 403s (harmless: orphans persist one more week).

## Verification

- Post-merge: `workflow_dispatch`-trigger `ghcr-cache-prune.yml`; confirm it reports deleted/kept counts and all `ci`/`e2e`/`publish` tags survive.
- Soak: after 2 weekly runs, untagged version count stays bounded.

[skip-impl-check]

Related: SMI-4933 · parent SMI-4927

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)