### PR TITLE
fix(ci): SMI-4938 — add failure alerting to scheduled workflows

### DIFF
--- a/.github/workflows/device-login-roundtrip-cleanup.yml
+++ b/.github/workflows/device-login-roundtrip-cleanup.yml
@@ -66,3 +66,22 @@ jobs:
             -v ON_ERROR_STOP=1 \
             -P pager=off \
             -c "DELETE FROM audit_logs WHERE event_type = 'auth:device_code:consumed' AND metadata->>'user_id' = '${E2E_TEST_USER_ID}' AND created_at < now() - interval '7 days';"
+
+      # SMI-4938: email alert on scheduled failure. Before this, the job had
+      # no failure signal at all and a 0/4 failure streak went unnoticed.
+      - name: Send alert on failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          curl -s -X POST "$SUPABASE_URL/functions/v1/alert-notify" \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "type": "device_login_cleanup_failed",
+              "message": "The weekly device-login audit_logs cleanup workflow failed. Check GitHub Actions for details.",
+              "workflow": "Device Login Round-Trip audit_logs cleanup",
+              "runId": "${{ github.run_id }}",
+              "runUrl": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }' || echo "Alert notification failed (non-fatal)"

--- a/.github/workflows/release-cadence.yml
+++ b/.github/workflows/release-cadence.yml
@@ -132,3 +132,22 @@ jobs:
           )" \
             --base main \
             --head "${{ steps.branch.outputs.branch }}"
+
+      # SMI-4938: email alert on scheduled failure. Before this, release-cadence
+      # had no failure signal and its "Open PR" step failed silently for weeks.
+      - name: Send alert on failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          curl -s -X POST "$SUPABASE_URL/functions/v1/alert-notify" \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "type": "release_cadence_failed",
+              "message": "The weekly release-cadence workflow failed. Check GitHub Actions for details.",
+              "workflow": "Release Cadence",
+              "runId": "${{ github.run_id }}",
+              "runUrl": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }' || echo "Alert notification failed (non-fatal)"

--- a/.github/workflows/weekly-security-scan.yml
+++ b/.github/workflows/weekly-security-scan.yml
@@ -304,3 +304,22 @@ jobs:
 
           This issue was auto-created by SMI-3335 (parity ported via SMI-4392). Close when resolved."
           fi
+
+      # SMI-4938: email alert on scheduled failure, parallel to the GH-issue
+      # alert above (SMI-3335), so failures also reach the support inbox.
+      - name: Send email alert on failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          curl -s -X POST "$SUPABASE_URL/functions/v1/alert-notify" \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "type": "security_scan_failed",
+              "message": "The weekly security scan workflow failed. Check GitHub Actions for details.",
+              "workflow": "Weekly Security Scan",
+              "runId": "${{ github.run_id }}",
+              "runUrl": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }' || echo "Alert notification failed (non-fatal)"


### PR DESCRIPTION
## Summary

Follow-up to PR #1163 (SMI-4934/4935/4937). Part of why those scheduled-workflow failures sat unnoticed for weeks: most scheduled workflows had no failure alerting. This adds an `alert-notify` failure step (POST to the prod `alert-notify` edge function → `support@smithhorn.ca` via Resend) to three of them, using the canonical `type`/`message`/`workflow`/`runId`/`runUrl` payload from `refresh-metadata.yml`.

| Workflow | Before | Change |
|---|---|---|
| `weekly-security-scan.yml` | GH-issue alert only (SMI-3335) | + email alert, alongside the existing GH-issue alert |
| `release-cadence.yml` | **no failure signal** | + email alert |
| `device-login-roundtrip-cleanup.yml` | **no failure signal** | + email alert |

Each step is gated `failure() && github.event_name == 'schedule'` so manual `workflow_dispatch` runs don't generate alert noise. Repo-level `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` secrets are used (same as `indexer.yml` / `refresh-metadata.yml` / `batch-transform.yml`).

## Scope note

The original SMI-4938 framing said "3 of 4 workflows have no alerting" — on inspection, `weekly-security-scan.yml` already alerts via GH-issue creation (that is how issue #1060 was filed). The accurate gap was 2 workflows with *zero* signal; the third gets a parallel email channel for consistency, per maintainer decision.

## Verification

- All 3 files: `prettier --check` clean, valid YAML, `audit:standards` 0 failed.
- Alert steps only fire on scheduled failures; no behaviour change to successful runs.
- Live alerting is exercised the next time any of these workflows fails on schedule.

[skip-impl-check] — workflow-YAML-only change, no application source.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)