### PR TITLE
release(core): SMI-4539 — @skillsmith/core v0.6.3 synthetic patch for OIDC verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29712,7 +29712,7 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@skillsmith/core": "^0.6.2",
+        "@skillsmith/core": "^0.6.3",
         "@skillsmith/mcp-server": "^0.5.1",
         "chalk": "5.6.2",
         "chokidar": "4.0.3",
@@ -30096,7 +30096,7 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.6.2",
+        "@skillsmith/core": "^0.6.3",
         "esbuild": "0.27.2",
         "ulid": "3.0.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26941,12 +26941,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/sql.js": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
@@ -29828,7 +29822,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "@huggingface/transformers": "3.8.1",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Chore**: SMI-4539 — track `@skillsmith/core` dependency range to `^0.6.3` (synthetic patch release verifying the npm trusted-publisher OIDC publish path, PR #1171). No functional change.
+
 ## v0.6.1
 
 - **Fix**: SMI-4917 — repair first-time install (search crash, sync drops all skills, no self-config) (#1132)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.6.2",
+    "@skillsmith/core": "^0.6.3",
     "@skillsmith/mcp-server": "^0.5.1",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.6.3
+
+- **Chore**: SMI-4539 — synthetic patch release to verify the npm trusted-publisher OIDC publish path end-to-end (PR #1171). No functional or API change; `@skillsmith/core` source is identical to v0.6.2.
+
 ## v0.6.2
 
 - **Fix**: SMI-4919 — the v17 migration's `skills` table-recreate (`CREATE/INSERT/DROP/RENAME`) silently cascade-deleted every `skill_categories` row. With `foreign_keys=ON` (the driver default), `DROP TABLE skills` fires the `skill_categories.skill_id → skills(id) ON DELETE CASCADE` immediately; `SyncEngine.upsertSkills()` never repopulates `skill_categories`, so category-filtered search degraded silently after the migration. The recreate now backs `skill_categories` up into a TEMP table before the drop and restores it verbatim after the rename, inside the same transaction. The false "SQLite defers FK enforcement" header comment is corrected. (#1140)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Chore**: SMI-4539 — track `@skillsmith/core` dependency range to `^0.6.3` (synthetic patch release verifying the npm trusted-publisher OIDC publish path, PR #1171). No functional change.
+
 ## v0.5.1
 
 - **Feature**: SMI-4790 lifecycle-tagged tool descriptions + skill auto-install (#1022)

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.6.2",
+    "@skillsmith/core": "^0.6.3",
     "esbuild": "0.27.2",
     "ulid": "3.0.1"
   },


### PR DESCRIPTION
## Summary

Synthetic patch release of `@skillsmith/core` (0.6.2 → 0.6.3) to verify the npm trusted-publisher **OIDC** publish path landed in PR #1171 (SMI-4539).

**No functional or API change** — core source is byte-identical to v0.6.2. The version bump exists solely so a real `publish.yml` run executes `Publish core (OIDC)` against npmjs.org and proves the trusted-publisher config end-to-end.

## After merge

`gh workflow run publish.yml -f dry_run=false` → expect: `Publish core (OIDC)` succeeds, `Publish core (token fallback)` skipped, `Verify core on npm` passes, the published `@skillsmith/core@0.6.3` shows the npm **Provenance** badge. Recorded against SMI-4539.

[skip-impl-check] — version + changelog + lockfile only; no source or tests.
[skip-smoke] — no runtime behavior change.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)