### PR TITLE
fix(core): SMI-4539 sync VERSION constant to 0.6.3

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.6.2'
+export const VERSION = '0.6.3'
 
 // ============================================================================
 // Grouped Exports from Barrel Files


### PR DESCRIPTION
## Summary

PR #1172 bumped `packages/core/package.json` to `0.6.3` (synthetic patch release for npm trusted-publisher OIDC verification, SMI-4539) but missed the matching `export const VERSION = '0.6.2'` in `packages/core/src/index.ts`.

`prepare-release.ts` normally bumps both via `versionConstReplacement`; the manual synthetic-release bump only touched `package.json`. The publish run [26010304411](https://github.com/smith-horn/skillsmith/actions/runs/26010304411) failed at the **Validate** gate — `prepare-release.test.ts` "Version sync validation" asserted `'0.6.2' to be '0.6.3'`. The gate fired **before any publish job ran**, so no partial publish occurred.

This one-line fix syncs the constant. Once merged, re-trigger `publish.yml -f dry_run=false` to exercise the OIDC publish path.

## Test plan

- `prepare-release.test.ts` version-sync check now passes (`0.6.3 == 0.6.3`).
- Post-merge: publish run confirms `Publish core (OIDC)` succeeded / `(token fallback)` skipped / `Verify core on npm` passed.

[skip-impl-check] — single string-literal change, no new feature surface.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)