### PR TITLE
fix(deps): SMI-4539 resync package-lock.json for npm 11 strict npm ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4376,6 +4376,26 @@
         "@ruvector/ruvllm-win32-x64-msvc": "2.3.0"
       }
     },
+    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-arm64-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-x64-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-win32-x64-msvc": {
+      "dev": true,
+      "optional": true
+    },
     "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4619,18 +4639,6 @@
         "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
-      }
-    },
-    "node_modules/@claude-flow/cli/node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@claude-flow/cli/node_modules/require-in-the-middle": {
@@ -6105,6 +6113,26 @@
         "@ruvector/ruvllm-linux-x64-gnu": "2.3.0",
         "@ruvector/ruvllm-win32-x64-msvc": "2.3.0"
       }
+    },
+    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-arm64-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-x64-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-win32-x64-msvc": {
+      "dev": true,
+      "optional": true
     },
     "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/chalk": {
       "version": "4.1.2",
@@ -9130,9 +9158,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
-      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -9223,18 +9251,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.218.0.tgz",
@@ -9254,18 +9270,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
@@ -9425,14 +9429,31 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
-      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
+      "integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/api-logs": "0.218.0",
         "import-in-the-middle": "^3.0.0",
         "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-aws-sdk": {
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.73.0.tgz",
+      "integrity": "sha512-0INPkHbR6o4J3psE+ncwWaE7qtDpb2p+i+qfV82cfwYLCXavYCGosBZ/S4pOErDVJYIyQVIsNAHhaUgaL313SQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.218.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9459,35 +9480,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
-      "integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-runtime-node": {
       "version": "0.31.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.31.0.tgz",
@@ -9497,35 +9489,6 @@
         "@opentelemetry/api-logs": "^0.218.0",
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.218.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-runtime-node/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-runtime-node/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
-      "integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9549,35 +9512,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.7.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-undici/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-undici/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
-      "integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
@@ -9632,18 +9566,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
@@ -9710,18 +9632,6 @@
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
@@ -9775,35 +9685,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
-      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
-      "integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
@@ -29746,6 +29627,9 @@
         }
       }
     },
+    "packages/cli/node_modules/@isaacs/keytar": {
+      "optional": true
+    },
     "packages/cli/node_modules/cli-spinners": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
@@ -29983,23 +29867,6 @@
         "@skillsmith/mcp-server": {
           "optional": true
         }
-      }
-    },
-    "packages/enterprise/node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.69.0.tgz",
-      "integrity": "sha512-JfSp3anFL5Lx/ysQSa4MnKxvSsXSnYpgQ831Y+yNs5wJZcJC4tB+YpnKH+bU5oFdKEF59FpI6Gn5Wg2vjVpR2A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.214.0",
-        "@opentelemetry/semantic-conventions": "^1.34.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
       }
     },
     "packages/enterprise/node_modules/@smithy/smithy-client": {
@@ -30295,13 +30162,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "packages/website/node_modules/web-vitals": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
-      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
-      "dev": true,
-      "license": "Apache-2.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

SMI-4539's publish-core job upgrades npm to **11.9.0** for native trusted-publisher OIDC. npm 11's `npm ci` is stricter than npm 10's and rejected `main`'s lockfile in publish run [26011319795](https://github.com/smith-horn/skillsmith/actions/runs/26011319795):

- hoisted `@opentelemetry/instrumentation` / `@opentelemetry/api-logs` pinned at `0.214.0` while `@skillsmith/core` requires the `0.218.0` line — **latent drift since the SMI-4888 OTel bump**; npm 10's `npm ci` silently tolerated it (this is why regular CI stayed green).
- `@ruvector/ruvllm-*` platform optionals + `@isaacs/keytar` missing from the lockfile.

No publish occurred — the failure is in `Install dependencies`, before `Publish core (OIDC)`.

## Fix

Regenerated with `npx npm@11.9.0 install --package-lock-only`:
- stale `0.214.0` hoists dropped
- missing optional platform packages added
- redundant nested OTel copies dedupe to the `0.218.0` top-level

No production dependency downgrades — version shifts are transitive re-resolution within already-satisfied ranges. Nested `jose@5.10.0` / `web-vitals@5.2.0` drops are the known lock-regen dedup behavior (SMI-4784); top-level versions retained. Diff: +64 / -204 (mostly nested-entry consolidation).

## Test plan

- Regular CI `npm ci` (Docker, npm 10) accepts a fully-consistent npm-11-generated lockfile.
- Post-merge: `publish.yml -f dry_run=false` — publish-core's npm 11.9.0 `npm ci` now passes, exercising the OIDC publish path.

[skip-impl-check] — lockfile-only change, no source files.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)