### PR TITLE
ci: SMI-4539 run npm ci on npm 10, defer npm@11.9.0 to publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -496,20 +496,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
-      # SMI-4539: native `npm publish` OIDC needs npm >= 11.5.1; the runner
-      # ships 10.9.7. Pin to a fixed version so the assertion below is exact.
-      - name: Upgrade npm for OIDC publish (SMI-4539)
-        run: npm install -g npm@11.9.0
-
-      - name: Assert npm version (SMI-4539)
-        run: |
-          ACTUAL="$(npm --version)"
-          if [ "$ACTUAL" != "11.9.0" ]; then
-            echo "::error::Expected npm 11.9.0 for OIDC publish, got $ACTUAL"
-            exit 1
-          fi
-          echo "✓ npm $ACTUAL"
-
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
@@ -540,6 +526,23 @@ jobs:
         run: |
           VERSION=$(jq -r .version packages/core/package.json)
           node scripts/check-publish-collision.mjs @skillsmith/core "$VERSION"
+
+      # SMI-4539: native `npm publish` OIDC needs npm >= 11.5.1; the runner
+      # ships 10.9.7. The upgrade runs HERE — after `npm ci` and the build —
+      # because npm 11's `npm ci` is stricter than npm 10's and rejects the
+      # repo-standard (npm 10) lockfile. Install, build and version-check run
+      # on npm 10; only `npm publish` below runs on npm 11.9.0.
+      - name: Upgrade npm for OIDC publish (SMI-4539)
+        run: npm install -g npm@11.9.0
+
+      - name: Assert npm version (SMI-4539)
+        run: |
+          ACTUAL="$(npm --version)"
+          if [ "$ACTUAL" != "11.9.0" ]; then
+            echo "::error::Expected npm 11.9.0 for OIDC publish, got $ACTUAL"
+            exit 1
+          fi
+          echo "✓ npm $ACTUAL"
 
       # SMI-4539: the three steps below replace the former single `Publish core`
       # step. They form one unit: OIDC-primary publish, token-fallback (only
@@ -654,20 +657,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
-      # SMI-4539: native `npm publish` OIDC needs npm >= 11.5.1; the runner
-      # ships 10.9.7. Pin to a fixed version so the assertion below is exact.
-      - name: Upgrade npm for OIDC publish (SMI-4539)
-        run: npm install -g npm@11.9.0
-
-      - name: Assert npm version (SMI-4539)
-        run: |
-          ACTUAL="$(npm --version)"
-          if [ "$ACTUAL" != "11.9.0" ]; then
-            echo "::error::Expected npm 11.9.0 for OIDC publish, got $ACTUAL"
-            exit 1
-          fi
-          echo "✓ npm $ACTUAL"
-
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
@@ -695,6 +684,23 @@ jobs:
         run: |
           VERSION=$(jq -r .version packages/mcp-server/package.json)
           node scripts/check-publish-collision.mjs @skillsmith/mcp-server "$VERSION"
+
+      # SMI-4539: native `npm publish` OIDC needs npm >= 11.5.1; the runner
+      # ships 10.9.7. The upgrade runs HERE — after `npm ci` and the build —
+      # because npm 11's `npm ci` is stricter than npm 10's and rejects the
+      # repo-standard (npm 10) lockfile. Install, build and version-check run
+      # on npm 10; only `npm publish` below runs on npm 11.9.0.
+      - name: Upgrade npm for OIDC publish (SMI-4539)
+        run: npm install -g npm@11.9.0
+
+      - name: Assert npm version (SMI-4539)
+        run: |
+          ACTUAL="$(npm --version)"
+          if [ "$ACTUAL" != "11.9.0" ]; then
+            echo "::error::Expected npm 11.9.0 for OIDC publish, got $ACTUAL"
+            exit 1
+          fi
+          echo "✓ npm $ACTUAL"
 
       # SMI-4539: the three steps below replace the former single
       # `Publish mcp-server` step. They form one unit: OIDC-primary publish,
@@ -886,20 +892,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
-      # SMI-4539: native `npm publish` OIDC needs npm >= 11.5.1; the runner
-      # ships 10.9.7. Pin to a fixed version so the assertion below is exact.
-      - name: Upgrade npm for OIDC publish (SMI-4539)
-        run: npm install -g npm@11.9.0
-
-      - name: Assert npm version (SMI-4539)
-        run: |
-          ACTUAL="$(npm --version)"
-          if [ "$ACTUAL" != "11.9.0" ]; then
-            echo "::error::Expected npm 11.9.0 for OIDC publish, got $ACTUAL"
-            exit 1
-          fi
-          echo "✓ npm $ACTUAL"
-
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
@@ -927,6 +919,23 @@ jobs:
         run: |
           VERSION=$(jq -r .version packages/cli/package.json)
           node scripts/check-publish-collision.mjs @skillsmith/cli "$VERSION"
+
+      # SMI-4539: native `npm publish` OIDC needs npm >= 11.5.1; the runner
+      # ships 10.9.7. The upgrade runs HERE — after `npm ci` and the build —
+      # because npm 11's `npm ci` is stricter than npm 10's and rejects the
+      # repo-standard (npm 10) lockfile. Install, build and version-check run
+      # on npm 10; only `npm publish` below runs on npm 11.9.0.
+      - name: Upgrade npm for OIDC publish (SMI-4539)
+        run: npm install -g npm@11.9.0
+
+      - name: Assert npm version (SMI-4539)
+        run: |
+          ACTUAL="$(npm --version)"
+          if [ "$ACTUAL" != "11.9.0" ]; then
+            echo "::error::Expected npm 11.9.0 for OIDC publish, got $ACTUAL"
+            exit 1
+          fi
+          echo "✓ npm $ACTUAL"
 
       # SMI-4539: the three steps below replace the former single `Publish cli`
       # step. They form one unit: OIDC-primary publish, token-fallback (only


### PR DESCRIPTION
## Summary

Corrective fix to the merged SMI-4539 OIDC publish flip (PR #1171), found during the plan's prescribed post-merge verification.

PR #1171 added `npm install -g npm@11.9.0` **before** `npm ci` in `publish-core`/`publish-mcp-server`/`publish-cli`. npm 11's `npm ci` is materially stricter than npm 10's about lockfile↔`package.json` consistency and rejected the repo-standard (npm 10) `package-lock.json` outright — publish run [26011319795](https://github.com/smith-horn/skillsmith/actions/runs/26011319795) failed `Install dependencies` with `EUSAGE` (stale `@opentelemetry/instrumentation` hoist since the SMI-4888 OTel bump, missing `@ruvector/ruvllm-*` optional platform packages).

Regenerating the lockfile with npm 11 is **not** viable: npm 10's `npm ci` (every other CI job + the Docker build) then rejects the npm-11 lockfile shape (`Missing: jose@5.10.0 / web-vitals@5.2.0`) — the two npm majors produce mutually-incompatible lockfiles.

## Fix

In each of the 3 npmjs.org publish jobs, move the `Upgrade npm for OIDC publish` + `Assert npm version` steps from **before `Install dependencies`** to **immediately after `Pre-publish collision mirror guard`**, before `Publish <pkg> (OIDC)`.

`npm ci`, the build, the version-check and the collision guard now run on the repo-standard **npm 10**; only `npm publish` — the only step that needs npm ≥ 11.5.1 for native trusted-publisher OIDC — runs on **npm 11.9.0**. No lockfile change, no repo-wide npm-major bump.

## ADR-109

`publish.yml` is an ADR-109 trigger path. This is a defect correction within the already-plan-reviewed SMI-4539 scope (the OIDC mechanism, token fallback and verify gate are unchanged — only the npm-upgrade step's position moves). The implementation doc `smi-4539-oidc-publish-flip.md` is updated to record the defect + corrected ordering (skillsmith-docs#179, folded in via the submodule pointer bump).

## Test plan

- Post-merge: `publish.yml -f dry_run=false` — `Install dependencies` passes on npm 10; `Publish core (OIDC)` runs on npm 11.9.0; verify `Verify core on npm` passes and the Provenance badge appears.

[skip-impl-check] — workflow + submodule-pointer change, no source files.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)