### PR TITLE
docs(core): SMI-4539 retro — correct v0.6.3 CHANGELOG source-delta claim

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## v0.6.3
 
-- **Chore**: SMI-4539 — synthetic patch release to verify the npm trusted-publisher OIDC publish path end-to-end (PR #1171). No functional or API change; `@skillsmith/core` source is identical to v0.6.2.
+- **Chore**: SMI-4539 — synthetic patch release to verify the npm trusted-publisher OIDC publish path end-to-end (PR #1171). No functional or API change; the only source delta from v0.6.2 is the `VERSION` constant bump in `src/index.ts` (PR #1174). Published via OIDC in run 26012688904 with SLSA build provenance.
 
 ## v0.6.2
 


### PR DESCRIPTION
## Summary

Governance retrospective finding on the merged SMI-4539 OIDC-verification PRs (#1172, #1174, #1176).

`packages/core/CHANGELOG.md`'s v0.6.3 entry — written in PR #1172 — claimed the release was "source is identical to v0.6.2". PR #1174 subsequently bumped the `VERSION` constant in `packages/core/src/index.ts`, so the published `0.6.3` tarball is **not** source-identical to 0.6.2. The wording is corrected to name the `VERSION`-constant delta and record the OIDC publish run (26012688904, SLSA build provenance).

Low-severity doc-accuracy fix; no code change.

[skip-impl-check] [skip-smoke] — CHANGELOG-only.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)