### PR TITLE
chore(docs): SMI-4932 generator + CI guard for index.md Folder Reference table

### DIFF
--- a/.github/workflows/docs-folder-index.yml
+++ b/.github/workflows/docs-folder-index.yml
@@ -1,0 +1,77 @@
+name: Docs Folder Index Guard
+
+# SMI-4932: fail a PR when the "Folder Reference" table in docs/internal/index.md
+# is stale relative to the actual folder contents.
+#
+# docs/internal is the private submodule smith-horn/skillsmith-docs; index.md
+# lives inside it and the submodule has no CI of its own. This guard runs in the
+# main repo and triggers on PRs that touch docs/internal/** (i.e. bump the
+# submodule pointer) or .gitmodules. It detects drift retroactively on the
+# pointer-bump PR — it does not prevent submodule-internal commits from drifting
+# the table (limitation R3; rationale in the plan below).
+#
+# # audit:carveout-pure-js — see docs/internal/implementation/smi-4932-folder-index-generator.md
+# Runs `node` on the host runner: scripts/gen-docs-folder-index.mjs has zero
+# dependencies and no native modules, so no Docker dev container / npm ci is
+# needed. SMI-4647 carveout applies.
+#
+# Plan: docs/internal/implementation/smi-4932-folder-index-generator.md
+# Parent: SMI-4932.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'docs/internal/**'
+      - '.gitmodules'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-folder-index-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Folder Reference table fresh
+    # audit:carveout-pure-js — host node, zero-dep script, no Docker needed
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout PR (no submodules yet)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch docs/internal submodule (best-effort)
+        # docs/internal is a private repo requiring STRATEGY_SUBMODULE_PAT.
+        # actions/checkout treats submodule-fetch failure as fatal, so we fetch
+        # in a separate continue-on-error step — external-contributor PRs
+        # lacking the PAT degrade to the "skip" branch instead of hard-failing.
+        # audit:allow-continue-on-error — see step comment.
+        continue-on-error: true
+        env:
+          STRATEGY_SUBMODULE_PAT: ${{ secrets.STRATEGY_SUBMODULE_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -n "${STRATEGY_SUBMODULE_PAT:-}" ]; then
+            git config --global url."https://x-access-token:${STRATEGY_SUBMODULE_PAT}@github.com/".insteadOf "https://github.com/"
+          fi
+          git submodule update --init docs/internal || \
+            echo "::warning::docs/internal submodule fetch failed; the folder-index check will short-circuit"
+
+      - name: Verify docs/internal present
+        id: verify
+        run: |
+          set -euo pipefail
+          if [ -f docs/internal/index.md ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::docs/internal not checked out (external contributors lack PAT access). Skipping folder-index check."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check Folder Reference table
+        if: steps.verify.outputs.present == 'true'
+        run: node scripts/gen-docs-folder-index.mjs --check

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "typecheck:watch": "tsc --build --watch",
     "audit:standards": "node scripts/audit-standards.mjs",
     "audit:drift": "node scripts/audit-linear-drift.mjs",
+    "docs:folder-index": "node scripts/gen-docs-folder-index.mjs --write",
+    "docs:folder-index:check": "node scripts/gen-docs-folder-index.mjs --check",
     "validate:skills": "node scripts/validate-local-skills.mjs",
     "validate:anon-functions": "npx tsx scripts/validate-anonymous-functions.ts",
     "ci:local": "npm run lint && npm run typecheck && npm run test:coverage",

--- a/scripts/gen-docs-folder-index.mjs
+++ b/scripts/gen-docs-folder-index.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// SMI-4932: regenerate the "Folder Reference" table in docs/internal/index.md.
+//
+// The table is one row per direct subdirectory of docs/internal/, columns
+// `Folder | Files | Has Index`. It is hand-maintained and perpetually drifts
+// (a doc PR adding a file anywhere under docs/internal/ silently staleness it).
+// This script regenerates it from the filesystem so the drift class is closed.
+//
+// Counting rule (reverse-engineered from rows still correct as of 2026-05-18 —
+// adr 50=50, architecture 39=39, archive 8=8, analysis 10=10, backups 0):
+//   count = number of *.md files among a folder's DIRECT children
+//           (non-recursive), INCLUDING index.md itself.
+//   Has Index = ✓ iff <folder>/index.md exists.
+//   Folder set = direct subdirectories of docs/internal/, no dot-dirs, sorted.
+//
+// Scope: ONLY the `## Folder Reference` block is regenerated. The ~7 curated
+// aggregate tables (Quick Access / Engineering / etc.) are editorial subsets and
+// are NOT touched — see docs/internal/implementation/smi-4932-folder-index-generator.md
+// and SMI-4946.
+//
+// Anchor contract: the table is wrapped in a <details> block —
+//   ## Folder Reference -> <details> -> <summary> -> blank -> header+separator
+//   -> data rows -> blank -> </details>. spliceBlock anchors on the
+//   `| Folder | Files | Has Index |` header + separator and replaces ONLY the
+//   contiguous `| ... |` data rows. The <details>/<summary>/</details> tags and
+//   the trailing `**Last updated**:` stamp are outside the region and untouched.
+//   If the anchors are absent the script exits 1 — it never writes a malformed
+//   file (fail-closed).
+//
+// Usage:
+//   node scripts/gen-docs-folder-index.mjs            # --write (rewrite in place)
+//   node scripts/gen-docs-folder-index.mjs --write
+//   node scripts/gen-docs-folder-index.mjs --check    # exit 1 + diff if stale
+//   node scripts/gen-docs-folder-index.mjs --root <path>   # default docs/internal
+//   node scripts/gen-docs-folder-index.mjs --help
+//
+// Exit codes:
+//   0 — success (--write done, or --check found the table fresh)
+//   1 — --check found drift, or a fatal error (anchors absent, root missing)
+
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, '..')
+
+const HEADER = '| Folder | Files | Has Index |'
+
+/** Direct subdirectories of `root`, excluding dot-dirs, sorted alphabetically. */
+export function listFolders(root) {
+  return readdirSync(root, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !e.name.startsWith('.'))
+    .map((e) => e.name)
+    .sort()
+}
+
+/** Count of `*.md` files among `dir`'s direct children (non-recursive). */
+export function countMd(dir) {
+  return readdirSync(dir, { withFileTypes: true }).filter(
+    (e) => e.isFile() && e.name.endsWith('.md')
+  ).length
+}
+
+/** True iff `<dir>/index.md` exists. */
+export function hasIndex(dir) {
+  return existsSync(join(dir, 'index.md'))
+}
+
+/** One markdown table row per folder under `root`, in folder order. */
+export function buildRows(root) {
+  return listFolders(root).map((name) => {
+    const dir = join(root, name)
+    return `| ${name} | ${countMd(dir)} | ${hasIndex(dir) ? '✓ ' : ''}|`
+  })
+}
+
+/** Map a list of `| name | count | mark |` rows to { name: rowText }. */
+function indexRows(rows) {
+  const map = new Map()
+  for (const r of rows) {
+    const name = r.split('|')[1]?.trim()
+    if (name) map.set(name, r)
+  }
+  return map
+}
+
+/** Human-readable per-folder diff between committed and expected rows. */
+export function diffRows(committed, expected) {
+  const before = indexRows(committed)
+  const after = indexRows(expected)
+  const lines = []
+  for (const [name, row] of after) {
+    if (!before.has(name)) lines.push(`  + ${row}   (new folder)`)
+    else if (before.get(name) !== row) lines.push(`  - ${before.get(name)}\n  + ${row}`)
+  }
+  for (const [name, row] of before) {
+    if (!after.has(name)) lines.push(`  - ${row}   (folder removed)`)
+  }
+  return lines
+}
+
+/** Folder Reference data rows currently committed in `text` (between anchors). */
+function committedRows(text) {
+  const lines = text.split('\n')
+  const h = lines.findIndex((l) => l.trim() === HEADER)
+  if (h === -1) return []
+  let end = h + 2
+  while (end < lines.length && lines[end].startsWith('|')) end++
+  return lines.slice(h + 2, end)
+}
+
+/**
+ * Replace the Folder Reference data rows in `text` with `rows`.
+ * Anchors on the `| Folder | Files | Has Index |` header + separator line;
+ * replaces the contiguous run of `| ... |` rows that follows. Throws if the
+ * anchors are absent — never returns a malformed document.
+ */
+export function spliceBlock(text, rows) {
+  const lines = text.split('\n')
+  const h = lines.findIndex((l) => l.trim() === HEADER)
+  if (h === -1) {
+    throw new Error(`Anchor not found: "${HEADER}" header missing from index.md`)
+  }
+  const sep = lines[h + 1]
+  if (!sep || !/^\s*\|[-\s|]+\|\s*$/.test(sep)) {
+    throw new Error(`Anchor not found: separator row missing after the table header`)
+  }
+  let end = h + 2
+  while (end < lines.length && lines[end].startsWith('|')) end++
+  return [...lines.slice(0, h + 2), ...rows, ...lines.slice(end)].join('\n')
+}
+
+/** Read index.md, returns { path, text }. Exits 1 if root or file is absent. */
+function loadIndex(root) {
+  if (!existsSync(root)) {
+    console.error(`✖ root not found: ${root}`)
+    process.exit(1)
+  }
+  const path = join(root, 'index.md')
+  if (!existsSync(path)) {
+    console.error(`✖ index.md not found: ${path}`)
+    process.exit(1)
+  }
+  return { path, text: readFileSync(path, 'utf8') }
+}
+
+function main(argv) {
+  if (argv.includes('--help')) {
+    console.log(
+      [
+        'gen-docs-folder-index.mjs — regenerate the Folder Reference table in index.md',
+        '',
+        'Usage:',
+        '  node scripts/gen-docs-folder-index.mjs            rewrite in place (--write)',
+        '  node scripts/gen-docs-folder-index.mjs --check    exit 1 + diff if stale',
+        '  node scripts/gen-docs-folder-index.mjs --root <p> root dir (default docs/internal)',
+        '  node scripts/gen-docs-folder-index.mjs --help     this message',
+      ].join('\n')
+    )
+    return 0
+  }
+  const rootIdx = argv.indexOf('--root')
+  const rootArg = rootIdx !== -1 ? argv[rootIdx + 1] : 'docs/internal'
+  const root = join(REPO_ROOT, rootArg)
+  const check = argv.includes('--check')
+
+  const { path, text } = loadIndex(root)
+  const rows = buildRows(root)
+  const updated = spliceBlock(text, rows)
+
+  if (check) {
+    if (updated === text) {
+      console.log('✓ Folder Reference table is up to date')
+      return 0
+    }
+    console.error('✖ Folder Reference table is stale. Run: npm run docs:folder-index')
+    for (const line of diffRows(committedRows(text), rows)) console.error(line)
+    return 1
+  }
+
+  if (updated === text) {
+    console.log('✓ Folder Reference table already up to date — no change')
+    return 0
+  }
+  writeFileSync(path, updated)
+  console.log(`✓ Regenerated Folder Reference table in ${path}`)
+  return 0
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(main(process.argv.slice(2)))
+}

--- a/scripts/gen-docs-folder-index.mjs
+++ b/scripts/gen-docs-folder-index.mjs
@@ -161,6 +161,10 @@ function main(argv) {
     return 0
   }
   const rootIdx = argv.indexOf('--root')
+  if (rootIdx !== -1 && !argv[rootIdx + 1]) {
+    console.error('✖ --root requires a path argument')
+    return 1
+  }
   const rootArg = rootIdx !== -1 ? argv[rootIdx + 1] : 'docs/internal'
   const root = join(REPO_ROOT, rootArg)
   const check = argv.includes('--check')

--- a/scripts/tests/gen-docs-folder-index.test.ts
+++ b/scripts/tests/gen-docs-folder-index.test.ts
@@ -1,0 +1,155 @@
+/**
+ * SMI-4932: Tests for gen-docs-folder-index.mjs.
+ *
+ * Pure-function tests against temp-dir fixtures — never the live docs/internal/.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// @ts-expect-error -- plain ESM module, no .d.ts
+import {
+  listFolders,
+  countMd,
+  hasIndex,
+  buildRows,
+  spliceBlock,
+  diffRows,
+} from '../gen-docs-folder-index.mjs'
+
+let root: string
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'gen-docs-folder-index-'))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+/** Create `<root>/<name>/` and populate it with the given file names. */
+function folder(name: string, files: string[]): string {
+  const dir = join(root, name)
+  mkdirSync(dir, { recursive: true })
+  for (const f of files) writeFileSync(join(dir, f), '')
+  return dir
+}
+
+describe('countMd', () => {
+  it('counts only direct-child *.md files, including index.md', () => {
+    const dir = folder('adr', ['index.md', '001.md', '002.md', 'notes.txt'])
+    expect(countMd(dir)).toBe(3)
+  })
+
+  it('returns 0 for a folder with no *.md files', () => {
+    const dir = folder('backups', ['dump.sql', 'image.png'])
+    expect(countMd(dir)).toBe(0)
+  })
+
+  it('does not recurse into nested subdirectories', () => {
+    const dir = folder('parent', ['a.md'])
+    mkdirSync(join(dir, 'nested'))
+    writeFileSync(join(dir, 'nested', 'b.md'), '')
+    expect(countMd(dir)).toBe(1)
+  })
+})
+
+describe('hasIndex', () => {
+  it('is true when index.md exists', () => {
+    expect(hasIndex(folder('withindex', ['index.md', 'x.md']))).toBe(true)
+  })
+
+  it('is false when index.md is absent', () => {
+    expect(hasIndex(folder('noindex', ['x.md']))).toBe(false)
+  })
+})
+
+describe('listFolders', () => {
+  it('returns direct subdirectories sorted, excluding dot-dirs', () => {
+    folder('zeta', [])
+    folder('alpha', [])
+    folder('.hidden', [])
+    writeFileSync(join(root, 'loose.md'), '')
+    expect(listFolders(root)).toEqual(['alpha', 'zeta'])
+  })
+})
+
+describe('buildRows', () => {
+  it('emits one row per folder, with the ✓ marker only when index.md exists', () => {
+    folder('adr', ['index.md', '001.md'])
+    folder('bugs', ['report.md'])
+    expect(buildRows(root)).toEqual(['| adr | 2 | ✓ |', '| bugs | 1 | |'])
+  })
+
+  it('row count equals listFolders count (the <summary>All folders</summary> claim)', () => {
+    folder('a', ['x.md'])
+    folder('b', [])
+    folder('c', ['index.md'])
+    expect(buildRows(root)).toHaveLength(listFolders(root).length)
+  })
+})
+
+const SAMPLE = `# Docs
+
+## Folder Reference
+
+<details>
+<summary>All folders (click to expand)</summary>
+
+| Folder | Files | Has Index |
+|--------|-------|-----------|
+| adr | 5 | ✓ |
+| old | 2 | |
+
+</details>
+
+---
+
+**Last updated**: 2026-01-01
+`
+
+describe('spliceBlock', () => {
+  it('replaces only the data rows, preserving the wrapper and stamp', () => {
+    const out = spliceBlock(SAMPLE, ['| adr | 9 | ✓ |'])
+    expect(out).toContain('| adr | 9 | ✓ |')
+    expect(out).not.toContain('| old | 2 | |')
+    expect(out).toContain('<details>')
+    expect(out).toContain('<summary>All folders (click to expand)</summary>')
+    expect(out).toContain('</details>')
+    expect(out).toContain('**Last updated**: 2026-01-01')
+  })
+
+  it('is idempotent — splicing the same rows twice yields identical text', () => {
+    const rows = ['| adr | 5 | ✓ |', '| old | 2 | |']
+    const once = spliceBlock(SAMPLE, rows)
+    expect(spliceBlock(once, rows)).toBe(once)
+  })
+
+  it('throws (fail-closed) when the table header anchor is absent', () => {
+    expect(() => spliceBlock('# Docs\n\nno table here\n', [])).toThrow(/Anchor not found/)
+  })
+
+  it('throws (fail-closed) when the separator row is missing', () => {
+    const noSep = '# Docs\n\n| Folder | Files | Has Index |\n| adr | 5 | ✓ |\n'
+    expect(() => spliceBlock(noSep, [])).toThrow(/Anchor not found/)
+  })
+})
+
+describe('diffRows', () => {
+  it('reports added, removed, and changed folders', () => {
+    const before = ['| adr | 5 | ✓ |', '| old | 2 | |']
+    const after = ['| adr | 9 | ✓ |', '| new | 1 | |']
+    const lines = diffRows(before, after).join('\n')
+    expect(lines).toContain('+ | new | 1 | |')
+    expect(lines).toContain('| old | 2 | |')
+    expect(lines).toContain('- | adr | 5 | ✓ |')
+    expect(lines).toContain('+ | adr | 9 | ✓ |')
+  })
+
+  it('returns no lines when committed and expected match', () => {
+    const rows = ['| adr | 5 | ✓ |']
+    expect(diffRows(rows, rows)).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `scripts/gen-docs-folder-index.mjs` — a zero-dependency Node generator that regenerates the `## Folder Reference` table in `docs/internal/index.md` from the filesystem (`--write`) or verifies it (`--check`). The table was hand-maintained and perpetually drifting.
- Adds the `Docs Folder Index Guard` workflow (`.github/workflows/docs-folder-index.yml`) — fails a PR that touches `docs/internal/**` when the committed table is stale. Mirrors `concurrency-audit-pr.yml`'s private-submodule PAT-checkout pattern.
- Adds `docs:folder-index` / `docs:folder-index:check` npm aliases and a 14-test unit suite.

ADR-109 infra change: SPARC artifact (`docs/internal/implementation/smi-4932-folder-index-generator.md`) + plan-review preceded implementation. Governance review ran clean (1 Low finding fixed in `a6602daf`).

## Scope + a known temporary inconsistency

This PR ships the generator + guard + tests. It does **not** regenerate `docs/internal/index.md` itself — that lands inside the `skillsmith-docs` submodule, currently held by a parallel session; the regeneration + submodule pointer bump follow on a separate PR.

The generator regenerates **only** the Folder Reference table. `index.md` has ~7 other *curated* count-bearing tables (Quick Access / Engineering / etc.). They currently *agree* with the Folder Reference rows; once the table is regenerated they will *disagree* (e.g. `research 45` in Folder Reference vs `39` in the curated Product table) until **SMI-4946** lands. SMI-4946 is the durable fix for that curated-table drift, filed as a direct consequence of this work.

## Test plan

- [x] `lint`, `typecheck`, `format:check` clean
- [x] `audit:standards` — 0 failed
- [x] 14/14 unit tests pass (`scripts/tests/gen-docs-folder-index.test.ts`)
- [x] `actionlint` on the new workflow clean
- [x] `--check` against the live `docs/internal/` correctly detects drift and exits 1
- [ ] On the first PR that bumps the `docs/internal` pointer, confirm `Docs Folder Index Guard` runs green

[skip-impl-check] — no `packages/*/src` change; the generator is a `scripts/` tool shipped with its own test suite.
[skip-smoke] — build/CI tooling, no production runtime surface.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)