### PR TITLE
fix: SMI-4397 grandfather ignore-list for check-file-length pre-commit hook

### DIFF
--- a/scripts/check-file-length.ignore
+++ b/scripts/check-file-length.ignore
@@ -1,0 +1,32 @@
+# check-file-length.ignore — grandfather list for the pre-commit length hook (SMI-4397)
+#
+# Purpose:
+#   scripts/check-file-length.mjs hard-fails any staged .ts file over 500
+#   lines. The paths below are pre-existing over-limit files exempted from
+#   that hard-fail so they can still be committed without `git commit
+#   --no-verify`. The exemption is conditional: it applies ONLY while the
+#   file remains over 500 lines. Once a listed file is split below the
+#   limit it re-enters normal enforcement and the hook prints an
+#   "eligible to de-list" notice — remove its entry here at that point.
+#
+# Format:
+#   - One repo-relative path per line (forward slashes).
+#   - Blank lines and lines starting with `#` are ignored.
+#   - Trailing whitespace and CRLF line endings are tolerated.
+#   - Each grandfathered path is preceded by a `# SMI-XXXX split follow-up`
+#     comment naming the Linear issue that will split the file.
+#
+# Do not add new files here without a corresponding split follow-up issue.
+
+# SMI-4948 split follow-up
+supabase/functions/indexer/index.test.ts
+# SMI-4948 split follow-up
+supabase/functions/_shared/ops-report-templates.ts
+# SMI-4948 split follow-up
+supabase/functions/_shared/security-scanner-edge.test.ts
+# SMI-4948 split follow-up
+supabase/functions/indexer/index.subdirectory.test.ts
+# SMI-4948 split follow-up
+supabase/functions/skills-refresh-metadata/index.ts
+# SMI-4948 split follow-up
+supabase/functions/ops-report/usage-aggregators.ts

--- a/scripts/check-file-length.mjs
+++ b/scripts/check-file-length.mjs
@@ -6,32 +6,171 @@
  *
  * Usage: node scripts/check-file-length.mjs <file1> [file2] ...
  * Exit 0 = all files OK, Exit 1 = one or more files exceed limit.
+ *
+ * Grandfather ignore-list (SMI-4397): six pre-existing over-limit
+ * git-crypt edge-function files cannot be committed without --no-verify.
+ * `scripts/check-file-length.ignore` lists repo-relative paths whose
+ * hard-fail is suppressed WHILE they remain over-limit. lint-staged v16
+ * passes absolute paths, so both sides are normalized to repo-relative
+ * before matching. A grandfathered file split below the limit re-enters
+ * enforcement and prints an "eligible to de-list" notice.
  */
 
-import { readFileSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const MAX_LINES = 500
-const files = process.argv.slice(2)
 
-if (files.length === 0) {
+/**
+ * Resolve a path to its canonical, symlink-free absolute form.
+ * Both the repo root and each staged file are canonicalized so a
+ * symlinked path component (e.g. macOS `/tmp` → `/private/tmp`, or a
+ * worktree's symlinked node_modules) cannot make `path.relative` emit a
+ * spurious `../../` prefix that would defeat ignore-list matching.
+ * Falls back to a plain `resolve` when the path does not yet exist.
+ *
+ * @param {string} p - a path to canonicalize
+ * @returns {string} canonical absolute path
+ */
+function canonicalize(p) {
+  const abs = resolve(p)
+  try {
+    return realpathSync(abs)
+  } catch {
+    return abs
+  }
+}
+
+/** Canonical absolute path to the repo root (this script lives in scripts/). */
+export function getRepoRoot() {
+  return canonicalize(resolve(dirname(fileURLToPath(import.meta.url)), '..'))
+}
+
+/**
+ * Parse the ignore-list file contents into a Set of trimmed,
+ * repo-relative paths. Comment (`#`) and blank lines are skipped;
+ * trailing whitespace and CRLF line endings are tolerated.
+ *
+ * @param {string} contents - raw ignore-file text
+ * @returns {Set<string>} repo-relative paths to grandfather
+ */
+export function parseIgnoreList(contents) {
+  const entries = new Set()
+  for (const rawLine of contents.split('\n')) {
+    const line = rawLine.replace(/\r$/, '').trim()
+    if (line.length === 0 || line.startsWith('#')) {
+      continue
+    }
+    entries.add(line)
+  }
+  return entries
+}
+
+/**
+ * Load and parse the sibling check-file-length.ignore file.
+ * Returns an empty Set if the file is absent (graceful default).
+ *
+ * @param {string} ignorePath - absolute path to the ignore file
+ * @returns {Set<string>} grandfathered repo-relative paths
+ */
+export function loadIgnoreList(ignorePath) {
+  try {
+    return parseIgnoreList(readFileSync(ignorePath, 'utf8'))
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return new Set()
+    }
+    throw err
+  }
+}
+
+/**
+ * Evaluate staged files against the line limit and ignore-list.
+ *
+ * lint-staged v16 passes absolute paths; the ignore-list stores
+ * repo-relative paths — both are normalized to repo-relative before
+ * an exact comparison (SMI-4397 C1). A grandfathered path is only
+ * exempt WHILE still over-limit (SMI-4397 H1).
+ *
+ * @param {string[]} files - staged file paths (absolute or relative)
+ * @param {Set<string>} ignoreList - grandfathered repo-relative paths
+ * @param {string} repoRoot - absolute repo root
+ * @returns {{violations: {relPath: string, lineCount: number}[],
+ *            skipped: {relPath: string, lineCount: number}[],
+ *            delistable: {relPath: string, lineCount: number}[]}}
+ */
+export function checkFiles(files, ignoreList, repoRoot) {
+  const violations = []
+  const skipped = []
+  const delistable = []
+  // Canonicalize the root too so both sides of `relative` share a
+  // symlink-free base (the caller may pass an un-canonicalized path).
+  const canonicalRoot = canonicalize(repoRoot)
+
+  for (const filePath of files) {
+    // lint-staged v16 passes absolute paths; older invocations may pass
+    // CWD-relative ones. Canonicalize before computing the repo-relative
+    // form so symlinked path components cannot defeat ignore matching.
+    const relPath = relative(canonicalRoot, canonicalize(filePath))
+    const content = readFileSync(filePath, 'utf8')
+    const lineCount = content.split('\n').length
+    const grandfathered = ignoreList.has(relPath)
+
+    if (lineCount > MAX_LINES) {
+      if (grandfathered) {
+        skipped.push({ relPath, lineCount })
+      } else {
+        violations.push({ relPath, lineCount })
+      }
+    } else if (grandfathered) {
+      // Shrunk below the limit — exemption is now stale.
+      delistable.push({ relPath, lineCount })
+    }
+  }
+
+  return { violations, skipped, delistable }
+}
+
+/** CLI entrypoint — only runs when invoked directly, not on import. */
+function main() {
+  const files = process.argv.slice(2)
+  if (files.length === 0) {
+    process.exit(0)
+  }
+
+  const repoRoot = getRepoRoot()
+  const ignoreList = loadIgnoreList(join(repoRoot, 'scripts', 'check-file-length.ignore'))
+  const { violations, skipped, delistable } = checkFiles(files, ignoreList, repoRoot)
+
+  for (const { relPath } of skipped) {
+    console.log(`  ${relPath}: skipped (grandfathered — SMI-4948 split pending)`)
+  }
+
+  for (const { relPath, lineCount } of delistable) {
+    console.log(
+      `  ${relPath}: ${lineCount} lines — now under ${MAX_LINES}, eligible to de-list from scripts/check-file-length.ignore`
+    )
+  }
+
+  if (violations.length > 0) {
+    console.error(`\nFile length check failed (max ${MAX_LINES} lines):\n`)
+    for (const { relPath, lineCount } of violations) {
+      console.error(`  ${relPath}: ${lineCount} lines`)
+    }
+    console.error(
+      '\nSplit large files before committing. See CI Health Requirements in CLAUDE.md.\n'
+    )
+    process.exit(1)
+  }
+
   process.exit(0)
 }
 
-const violations = []
-
-for (const filePath of files) {
-  const content = readFileSync(filePath, 'utf8')
-  const lineCount = content.split('\n').length
-  if (lineCount > MAX_LINES) {
-    violations.push({ filePath, lineCount })
-  }
-}
-
-if (violations.length > 0) {
-  console.error(`\nFile length check failed (max ${MAX_LINES} lines):\n`)
-  for (const { filePath, lineCount } of violations) {
-    console.error(`  ${filePath}: ${lineCount} lines`)
-  }
-  console.error('\nSplit large files before committing. See CI Health Requirements in CLAUDE.md.\n')
-  process.exit(1)
+// Canonicalize both sides so a symlinked invocation path (e.g. macOS
+// `/tmp` → `/private/tmp`) still recognizes a direct run.
+const invokedDirectly =
+  canonicalize(fileURLToPath(import.meta.url)) === canonicalize(process.argv[1] ?? '')
+if (invokedDirectly) {
+  main()
 }

--- a/scripts/tests/check-file-length.test.ts
+++ b/scripts/tests/check-file-length.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the pre-commit file-length hook and its grandfather
+ * ignore-list (SMI-4397).
+ *
+ * The hook has had zero tests until now. Coverage targets every case the
+ * SMI-4397 plan enumerates:
+ *   - over-limit file fails (enforcement intact)
+ *   - under-limit file passes
+ *   - ignore-listed over-limit path is skipped
+ *   - an ABSOLUTE-path argument matches a repo-relative ignore entry
+ *     (the plan-review C1 failure mode — fails a naive string-equality impl)
+ *   - comment / blank / trailing-whitespace / CRLF lines tolerated
+ *   - a grandfathered file now UNDER 500 lines re-enters enforcement (H1)
+ *   - absent ignore-list degrades gracefully (all files checked)
+ *
+ * Fixtures use temp directories (Date.now() + random suffix), never real
+ * repo files.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, cpSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+// @ts-expect-error - .mjs script has no typings
+import { parseIgnoreList, checkFiles, loadIgnoreList } from '../check-file-length.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SCRIPT_PATH = resolve(__dirname, '..', 'check-file-length.mjs')
+
+/** Create a unique temp directory for a fixture repo. */
+function makeTempDir(): string {
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  return mkdtempSync(join(tmpdir(), `check-file-length-${suffix}-`))
+}
+
+/** Build a .ts file with exactly `lines` lines under `root`. */
+function writeTsFile(root: string, relPath: string, lines: number): string {
+  const abs = join(root, relPath)
+  mkdirSync(dirname(abs), { recursive: true })
+  // `lines` lines == `lines - 1` newline characters via split('\n').length.
+  const body = Array.from({ length: lines }, (_, i) => `const x${i} = ${i}`).join('\n')
+  writeFileSync(abs, body, 'utf8')
+  return abs
+}
+
+describe('parseIgnoreList', () => {
+  it('tolerates comments, blank lines, trailing whitespace, and CRLF', () => {
+    const raw = [
+      '# header comment',
+      '',
+      '   ',
+      '# SMI-4948 split follow-up',
+      'supabase/functions/indexer/index.test.ts   ', // trailing whitespace
+      'supabase/functions/_shared/ops-report-templates.ts\r', // CRLF
+      '#trailing comment',
+    ].join('\n')
+
+    const entries = parseIgnoreList(raw)
+
+    expect(entries.has('supabase/functions/indexer/index.test.ts')).toBe(true)
+    expect(entries.has('supabase/functions/_shared/ops-report-templates.ts')).toBe(true)
+    expect(entries.has('# header comment')).toBe(false)
+    expect(entries.size).toBe(2)
+  })
+
+  it('returns an empty set for empty input', () => {
+    expect(parseIgnoreList('').size).toBe(0)
+  })
+})
+
+describe('loadIgnoreList', () => {
+  it('returns an empty set when the ignore file is absent', () => {
+    const dir = makeTempDir()
+    try {
+      const entries = loadIgnoreList(join(dir, 'does-not-exist.ignore'))
+      expect(entries.size).toBe(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('checkFiles', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = makeTempDir()
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('flags an over-limit file as a violation', () => {
+    const abs = writeTsFile(root, 'src/big.ts', 600)
+    const { violations, skipped } = checkFiles([abs], new Set(), root)
+    expect(violations).toHaveLength(1)
+    expect(violations[0].relPath).toBe('src/big.ts')
+    expect(violations[0].lineCount).toBe(600)
+    expect(skipped).toHaveLength(0)
+  })
+
+  it('passes an under-limit file with no violations', () => {
+    const abs = writeTsFile(root, 'src/small.ts', 300)
+    const { violations, skipped, delistable } = checkFiles([abs], new Set(), root)
+    expect(violations).toHaveLength(0)
+    expect(skipped).toHaveLength(0)
+    expect(delistable).toHaveLength(0)
+  })
+
+  it('skips an ignore-listed over-limit path instead of failing', () => {
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
+    const ignoreList = new Set(['supabase/functions/indexer/index.test.ts'])
+    const { violations, skipped } = checkFiles([abs], ignoreList, root)
+    expect(violations).toHaveLength(0)
+    expect(skipped).toHaveLength(1)
+    expect(skipped[0].relPath).toBe('supabase/functions/indexer/index.test.ts')
+  })
+
+  it('matches an ABSOLUTE-path argument against a repo-relative ignore entry (C1)', () => {
+    // lint-staged v16 passes absolute paths; the ignore file stores
+    // repo-relative. A naive string-equality impl would treat the
+    // absolute path as unmatched and fail the commit.
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
+    expect(resolve(abs)).toBe(abs) // sanity: abs really is absolute
+    const ignoreList = new Set(['supabase/functions/indexer/index.test.ts'])
+    const { violations, skipped } = checkFiles([abs], ignoreList, root)
+    expect(violations).toHaveLength(0)
+    expect(skipped).toHaveLength(1)
+  })
+
+  it('re-enforces a grandfathered file once it drops below the limit (H1)', () => {
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 420)
+    const ignoreList = new Set(['supabase/functions/indexer/index.test.ts'])
+    const { violations, skipped, delistable } = checkFiles([abs], ignoreList, root)
+    expect(violations).toHaveLength(0)
+    expect(skipped).toHaveLength(0)
+    expect(delistable).toHaveLength(1)
+    expect(delistable[0].relPath).toBe('supabase/functions/indexer/index.test.ts')
+    expect(delistable[0].lineCount).toBe(420)
+  })
+
+  it('checks every file when the ignore-list is empty', () => {
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
+    const { violations } = checkFiles([abs], new Set(), root)
+    expect(violations).toHaveLength(1)
+  })
+})
+
+/**
+ * End-to-end exercise of the script as lint-staged invokes it: spawn the
+ * real .mjs against a temp repo whose scripts/check-file-length.ignore is
+ * a fixture. The script resolves repoRoot from its own location, so the
+ * script copy must live inside the fixture repo.
+ */
+describe('check-file-length.mjs (end-to-end)', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = makeTempDir()
+    mkdirSync(join(root, 'scripts'), { recursive: true })
+    cpSync(SCRIPT_PATH, join(root, 'scripts', 'check-file-length.mjs'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function runHook(args: string[]): { status: number; stdout: string; stderr: string } {
+    try {
+      const stdout = execFileSync(
+        'node',
+        [join(root, 'scripts', 'check-file-length.mjs'), ...args],
+        {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }
+      )
+      return { status: 0, stdout, stderr: '' }
+    } catch (err) {
+      const e = err as { status?: number; stdout?: string; stderr?: string }
+      return { status: e.status ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' }
+    }
+  }
+
+  it('exits 0 with no arguments', () => {
+    expect(runHook([]).status).toBe(0)
+  })
+
+  it('exits 1 for a non-grandfathered over-limit file', () => {
+    const abs = writeTsFile(root, 'packages/core/src/foo.ts', 600)
+    const { status, stderr } = runHook([abs])
+    expect(status).toBe(1)
+    expect(stderr).toContain('packages/core/src/foo.ts')
+    expect(stderr).toContain('600 lines')
+  })
+
+  it('exits 0 and prints a skip notice for a grandfathered over-limit file (absolute path)', () => {
+    writeFileSync(
+      join(root, 'scripts', 'check-file-length.ignore'),
+      '# SMI-4948 split follow-up\nsupabase/functions/indexer/index.test.ts\n',
+      'utf8'
+    )
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
+    const { status, stdout } = runHook([abs])
+    expect(status).toBe(0)
+    expect(stdout).toContain('supabase/functions/indexer/index.test.ts: skipped (grandfathered')
+  })
+
+  it('exits 0 and prints an eligible-to-de-list notice once a grandfathered file is under the limit (H1)', () => {
+    writeFileSync(
+      join(root, 'scripts', 'check-file-length.ignore'),
+      '# SMI-4948 split follow-up\nsupabase/functions/indexer/index.test.ts\n',
+      'utf8'
+    )
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 410)
+    const { status, stdout } = runHook([abs])
+    expect(status).toBe(0)
+    expect(stdout).toContain('eligible to de-list')
+  })
+
+  it('still fails an over-limit file when the ignore-list file is absent', () => {
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
+    const { status } = runHook([abs])
+    expect(status).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

The lint-staged pre-commit hook `scripts/check-file-length.mjs` hard-fails any staged `.ts` file over 500 lines. Six pre-existing over-limit git-crypt edge-function files therefore cannot be committed without `git commit --no-verify` — which CLAUDE.md discourages without authorization. This adds an explicit grandfather mechanism.

Implements the plan-reviewed doc at `docs/internal/implementation/smi-4397-check-file-length-grandfather-list.md`.

## Changes

- **`scripts/check-file-length.ignore`** (new) — newline-delimited repo-relative paths with a header comment block (purpose + format). Seeded with the six over-limit files, each preceded by a `# SMI-4948 split follow-up` comment. SMI-4948 is the umbrella tracking the splits.
- **`scripts/check-file-length.mjs`** — loads the sibling `.ignore` file (graceful empty default if absent). lint-staged v16 passes **absolute** paths while the `.ignore` stores **repo-relative** — both sides are canonicalized (realpath, symlink-safe) and compared as repo-relative (**plan-review C1**). A grandfathered path is exempt **only while still over-limit**; once split below 500 lines it re-enters enforcement and prints an `eligible to de-list` notice (**plan-review H1**). Active exemptions print `<path>: skipped (grandfathered — SMI-4948 split pending)`. No git-crypt detection — path membership only.
- **`scripts/tests/check-file-length.test.ts`** (new — the script had zero tests) — 14 cases: over/under-limit, ignore-listed skip, the C1 absolute-vs-relative match (fails a naive string-equality impl), `.ignore` comment/blank/trailing-whitespace/CRLF tolerance, the H1 re-enforcement, absent-`.ignore` graceful default.
- **`docs/internal`** submodule pointer bumped to include the plan-reviewed implementation doc.

## Verification

- `npm run lint` (scripts/tests) — clean
- `audit:standards` — 0 failures (2 pre-existing unrelated warnings)
- New test suite — 14/14 pass
- Manual: hook skips the 977-line grandfathered `supabase/functions/indexer/index.test.ts` (exit 0); a non-grandfathered 600-line file still hard-fails (exit 1)

Beyond the C1 plan-review item, the implementation also canonicalizes the `import.meta.url` vs `process.argv[1]` direct-invocation guard and the repo-root resolution — without this, a symlinked invocation path (e.g. macOS `/tmp` → `/private/tmp`, or a worktree's symlinked `node_modules`) makes `path.relative` emit a spurious `../../` prefix that defeats ignore-list matching. Caught by the end-to-end tests.

[skip-impl-check]

ADR-109: this is a `scripts/` hook change — the implementation plan + plan-review satisfy the infra-change requirement.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)