### PR TITLE
test(e2e): SMI-4956 fix stale STAGING_SKILL_ID default in usage-counter e2e

### DIFF
--- a/tests/e2e/cli/usage-counter.e2e.test.ts
+++ b/tests/e2e/cli/usage-counter.e2e.test.ts
@@ -50,11 +50,15 @@ import {
   type ProvisionedUser,
 } from '../fixtures/usage-counter-fixture.js'
 
-// Skill the staging registry is guaranteed to have. Falls back to env override
-// if the seed data ever rotates. `anthropic/commit` is verified-tier and has
-// been present since the initial registry seed.
+// A stable, installable staging skill used to exercise the get-skill path.
+// `anthropics/web-artifacts-builder` is a verified-tier official Anthropic skill
+// with a repo_url, resolved via the author/name lookup. Staging stores skill
+// rows under UUID ids, so getSkill() returns `id` as the UUID — the assertions
+// below check that a skill resolved, not id-equality with the input string.
+// Override with SKILLSMITH_E2E_SKILL_ID if staging seed data changes (SMI-4956).
 const STAGING_BASE_URL = process.env['STAGING_SUPABASE_URL']?.replace(/\/$/, '') + '/functions/v1'
-const STAGING_SKILL_ID = process.env['SKILLSMITH_E2E_SKILL_ID'] ?? 'anthropic/commit'
+const STAGING_SKILL_ID =
+  process.env['SKILLSMITH_E2E_SKILL_ID'] ?? 'anthropics/web-artifacts-builder'
 
 const skipIfNoCreds = stagingCredentialsAbsent()
 
@@ -80,7 +84,8 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter CLI ApiClient → usage count
     })
     const res = await client.getSkill(STAGING_SKILL_ID)
     expect(res).toBeDefined()
-    expect(res.data?.id).toBe(STAGING_SKILL_ID)
+    // Staging stores UUID ids — assert a skill resolved, not id === input.
+    expect(res.data?.id).toBeTruthy()
 
     // Counter increment lands asynchronously after the response — give the
     // RPC up to ~2s to commit before reading user_api_usage.
@@ -99,13 +104,13 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter CLI ApiClient → usage count
 
     // First call — populates the tier cache.
     const r1 = await client.getSkill(STAGING_SKILL_ID)
-    expect(r1.data?.id).toBe(STAGING_SKILL_ID)
+    expect(r1.data?.id).toBeTruthy()
 
     // Second call within the cache TTL — must still increment. Pre-SMI-4461,
     // the tier-cache short-circuit returned before incrementUsageCounter was
     // ever called, silently undercounting from `2` to `1`.
     const r2 = await client.getSkill(STAGING_SKILL_ID)
-    expect(r2.data?.id).toBe(STAGING_SKILL_ID)
+    expect(r2.data?.id).toBeTruthy()
 
     await waitForCounterIncrement(user.userId, 'get_count', before.get_count + 2)
     const after = await getUsageRow(user.userId)
@@ -148,7 +153,7 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter CLI ApiClient → usage count
         stored ? { baseUrl: STAGING_BASE_URL, jwtToken: stored } : { baseUrl: STAGING_BASE_URL }
       )
       const res = await client.getSkill(STAGING_SKILL_ID)
-      expect(res.data?.id).toBe(STAGING_SKILL_ID)
+      expect(res.data?.id).toBeTruthy()
 
       await waitForCounterIncrement(user.userId, 'get_count', before.get_count + 1)
       const after = await getUsageRow(user.userId)

--- a/tests/e2e/mcp/usage-counter.e2e.test.ts
+++ b/tests/e2e/mcp/usage-counter.e2e.test.ts
@@ -41,7 +41,9 @@ const __dirname = dirname(__filename)
 // Built MCP server binary, relative to repo root.
 const MCP_SERVER_BIN = resolve(__dirname, '../../../packages/mcp-server/dist/src/index.js')
 
-const STAGING_SKILL_ID = process.env['SKILLSMITH_E2E_SKILL_ID'] ?? 'anthropic/commit'
+// Stable installable staging skill — see cli/usage-counter.e2e.test.ts (SMI-4956).
+const STAGING_SKILL_ID =
+  process.env['SKILLSMITH_E2E_SKILL_ID'] ?? 'anthropics/web-artifacts-builder'
 const STAGING_BASE_URL =
   (process.env['STAGING_SUPABASE_URL']?.replace(/\/$/, '') ?? '') + '/functions/v1'
 


### PR DESCRIPTION
## Summary

The `usage-counter` e2e tests defaulted `STAGING_SKILL_ID` to `'anthropic/commit'` — staging (`ovhcifugwqnzoebwfuku`) has no skill named `commit` and no author `anthropic`. An in-code comment falsely claimed the skill was "guaranteed present since the initial seed." Follow-up to SMI-4950.

## Changes

- A staging pooler query confirmed the installable verified-tier skills are under author `anthropics` (plural) with UUID `id`s. Default is now `'anthropics/web-artifacts-builder'` — verified-tier, `quality_score` 0.95, non-null `repo_url`, not quarantined — resolved via the `skills-get` author/name lookup.
- Staging stores skill rows under UUID `id`s, so `getSkill('author/name')` returns `id` as the UUID, never the input string. The CLI test's four `expect(res.data?.id).toBe(STAGING_SKILL_ID)` assertions were therefore latent failures; relaxed to `.toBeTruthy()` (assert a skill resolved — the meaningful guard before the counter assertion).
- Corrected the false "guaranteed since initial seed" comment.

## Verification

`typecheck`, `lint`, `format:check` all pass. The e2e suite runs in its dedicated staging workflow (`describe.skipIf(stagingCredentialsAbsent())`) and will exercise the new default against staging on the next run.

Governance review: 0 findings (`docs/internal/code_review/2026-05-18-smi-4956-staging-skill-id.md`).

Closes SMI-4956.

[skip-impl-check] — test-only change, no `packages/*/src` modification.
[skip-smoke] — no production behavior change.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)