### PR TITLE
fix(indexer): SMI-4941 repair HIGH_TRUST_AUTHORS Node/Deno parity test

### DIFF
--- a/scripts/tests/indexer/parity.test.ts
+++ b/scripts/tests/indexer/parity.test.ts
@@ -15,9 +15,10 @@
  * differences from formatter disagreement are not.
  */
 
-import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
-import { resolve, dirname } from 'node:path'
+import { describe, it, expect, afterAll } from 'vitest'
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { resolve, dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 
 /**
@@ -102,14 +103,28 @@ function normalizeWs(s: string): string {
  * declaration. Returns the substring between the matching `[` and `]` brackets.
  * Skips bracket characters inside string literals so commented-out brackets or
  * brackets-in-strings don't confuse depth tracking.
+ *
+ * SMI-4941: The array literal's opening `[` is located by first finding the
+ * declaration's `=`, then searching for `[` AFTER it. This is required because
+ * a type annotation such as `: HighTrustAuthor[]` places a `[` before the `=`;
+ * a naive `indexOf('[', declIdx)` matches that annotation bracket, walks the
+ * immediately-following `]`, and returns the empty string — a silent always-pass.
+ * Assumption enforced here: the `=` precedes the array literal's `[`. The
+ * `openIdx < eqIdx` guard hardens against future generic-default declarations
+ * like `export const X: Record<K, V[]> = [...]` where a bracket also follows
+ * the `=` in name only — if no real array `[` follows the `=`, we throw rather
+ * than mis-extract.
  */
 function extractArrayBody(filePath: string, constName: string): string {
   const source = readFileSync(filePath, 'utf-8')
   const declIdx = source.indexOf(`export const ${constName}`)
   if (declIdx < 0) throw new Error(`const ${constName} not found in ${filePath}`)
 
-  const openIdx = source.indexOf('[', declIdx)
-  if (openIdx < 0) throw new Error(`opening [ for ${constName} not found in ${filePath}`)
+  const eqIdx = source.indexOf('=', declIdx)
+  if (eqIdx < 0) throw new Error(`'=' for ${constName} not found in ${filePath}`)
+  const openIdx = source.indexOf('[', eqIdx)
+  if (openIdx < 0 || openIdx < eqIdx)
+    throw new Error(`array literal '[' for ${constName} not found after '=' in ${filePath}`)
 
   let depth = 1
   let i = openIdx + 1
@@ -189,8 +204,23 @@ const __dirname = dirname(__filename)
 const REPO_ROOT = resolve(__dirname, '..', '..', '..')
 const DENO_HELPERS = resolve(REPO_ROOT, 'supabase/functions/indexer/skill-processor.helpers.ts')
 const NODE_HELPERS = resolve(REPO_ROOT, 'scripts/indexer/skill-processor.helpers.ts')
-const DENO_AUTHORS = resolve(REPO_ROOT, 'supabase/functions/indexer/high-trust-authors.ts')
-const NODE_AUTHORS = resolve(REPO_ROOT, 'scripts/indexer/high-trust-authors.ts')
+// SMI-4941: after the SMI-4843 Phase 5b split, `high-trust-authors.ts` is just
+// `[...CORE_HIGH_TRUST_AUTHORS, ...LEADERBOARD_HIGH_TRUST_AUTHORS]` — spread
+// references, not data. The real author tables live in the `.core.ts` /
+// `.leaderboard.ts` twins, so the parity assertions target those directly.
+const DENO_AUTHORS_CORE = resolve(
+  REPO_ROOT,
+  'supabase/functions/indexer/high-trust-authors.core.ts'
+)
+const NODE_AUTHORS_CORE = resolve(REPO_ROOT, 'scripts/indexer/high-trust-authors.core.ts')
+const DENO_AUTHORS_LEADERBOARD = resolve(
+  REPO_ROOT,
+  'supabase/functions/indexer/high-trust-authors.leaderboard.ts'
+)
+const NODE_AUTHORS_LEADERBOARD = resolve(
+  REPO_ROOT,
+  'scripts/indexer/high-trust-authors.leaderboard.ts'
+)
 const DENO_META_LIST = resolve(REPO_ROOT, 'supabase/functions/indexer/meta-list-filter.ts')
 const NODE_META_LIST = resolve(REPO_ROOT, 'scripts/indexer/meta-list-filter.ts')
 const DENO_AUDIT_LOG = resolve(REPO_ROOT, 'supabase/functions/indexer/indexer-audit-log.ts')
@@ -276,15 +306,38 @@ describe('Deno <-> Node helper parity', () => {
   })
 })
 
-describe('Deno <-> Node HIGH_TRUST_AUTHORS parity (SMI-4843 Phase 5)', () => {
-  const denoEncrypted = isGitCryptEncrypted(DENO_AUTHORS)
+describe('Deno <-> Node HIGH_TRUST_AUTHORS parity (SMI-4843 Phase 5 / SMI-4941)', () => {
+  // SMI-4941: each assertion computes its own git-crypt skip-guard against its
+  // own Deno path — post-merge-verify.yml runs without the git-crypt key, so a
+  // single shared guard would not correctly skip both twins independently.
+  const coreEncrypted = isGitCryptEncrypted(DENO_AUTHORS_CORE)
+  const leaderboardEncrypted = isGitCryptEncrypted(DENO_AUTHORS_LEADERBOARD)
 
-  it.skipIf(denoEncrypted)(
-    'HIGH_TRUST_AUTHORS array body is byte-identical (normalized whitespace)',
+  it.skipIf(coreEncrypted)(
+    'CORE_HIGH_TRUST_AUTHORS array body is byte-identical (normalized whitespace)',
     () => {
-      const deno = normalizeWs(extractArrayBody(DENO_AUTHORS, 'HIGH_TRUST_AUTHORS'))
-      const node = normalizeWs(extractArrayBody(NODE_AUTHORS, 'HIGH_TRUST_AUTHORS'))
-      expect(node).toBe(deno)
+      const deno = normalizeWs(extractArrayBody(DENO_AUTHORS_CORE, 'CORE_HIGH_TRUST_AUTHORS'))
+      const node = normalizeWs(extractArrayBody(NODE_AUTHORS_CORE, 'CORE_HIGH_TRUST_AUTHORS'))
+      expect(
+        node,
+        'CORE_HIGH_TRUST_AUTHORS drift between scripts/indexer/ and supabase/functions/indexer/ twins'
+      ).toBe(deno)
+    }
+  )
+
+  it.skipIf(leaderboardEncrypted)(
+    'LEADERBOARD_HIGH_TRUST_AUTHORS array body is byte-identical (normalized whitespace)',
+    () => {
+      const deno = normalizeWs(
+        extractArrayBody(DENO_AUTHORS_LEADERBOARD, 'LEADERBOARD_HIGH_TRUST_AUTHORS')
+      )
+      const node = normalizeWs(
+        extractArrayBody(NODE_AUTHORS_LEADERBOARD, 'LEADERBOARD_HIGH_TRUST_AUTHORS')
+      )
+      expect(
+        node,
+        'LEADERBOARD_HIGH_TRUST_AUTHORS drift between scripts/indexer/ and supabase/functions/indexer/ twins'
+      ).toBe(deno)
     }
   )
 })
@@ -322,4 +375,53 @@ describe('Deno <-> Node AuditLogMeta interface parity (SMI-4879)', () => {
       expect(node).toBe(deno)
     }
   )
+})
+
+/**
+ * SMI-4941: Negative regression test for `extractArrayBody`. The original
+ * defect was a SILENT always-pass — `extractArrayBody` matched the `[` inside a
+ * `: SomeType[]` type annotation, walked the immediately-following `]`, and
+ * returned `''`, so the parity assertion degenerated to `'' === ''`. A positive
+ * parity test cannot catch that (identical twins also produce `'' === ''`), so
+ * the fix can only be pinned by a test that proves divergent fixtures yield
+ * DIFFERENT non-empty bodies and that an annotation-bearing declaration yields
+ * the real array content rather than `''`.
+ */
+describe('extractArrayBody divergence regression (SMI-4941)', () => {
+  const fixtureDir = mkdtempSync(join(tmpdir(), 'smi-4941-parity-'))
+
+  afterAll(() => {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  })
+
+  it('returns the real array body for an annotated declaration (not the empty string)', () => {
+    // The `: AuthorEntry[]` annotation places a `[` before the `=`. Bug 1 made
+    // the extractor match THAT bracket; the fix searches after `=` instead.
+    const annotated = join(fixtureDir, 'annotated.ts')
+    writeFileSync(
+      annotated,
+      "export const SAMPLE_AUTHORS: AuthorEntry[] = [\n  { name: 'alpha' },\n  { name: 'beta' },\n]\n"
+    )
+    const body = extractArrayBody(annotated, 'SAMPLE_AUTHORS')
+    expect(body).not.toBe('')
+    expect(normalizeWs(body)).toContain("name: 'alpha'")
+    expect(normalizeWs(body)).toContain("name: 'beta'")
+  })
+
+  it('reports DIFFERENT bodies for divergent fixtures (proves drift is caught)', () => {
+    const aPath = join(fixtureDir, 'twin-a.ts')
+    const bPath = join(fixtureDir, 'twin-b.ts')
+    // twin-a carries a `: AuthorEntry[]` annotation; twin-b does not — both must
+    // still extract the real array content, and the two must differ.
+    writeFileSync(
+      aPath,
+      "export const TWIN: AuthorEntry[] = [\n  { name: 'alpha' },\n  { name: 'beta' },\n]\n"
+    )
+    writeFileSync(bPath, "export const TWIN = [\n  { name: 'alpha' },\n  { name: 'gamma' },\n]\n")
+    const a = normalizeWs(extractArrayBody(aPath, 'TWIN'))
+    const b = normalizeWs(extractArrayBody(bPath, 'TWIN'))
+    expect(a).not.toBe('')
+    expect(b).not.toBe('')
+    expect(a).not.toBe(b)
+  })
 })


### PR DESCRIPTION
## Summary

The `Deno <-> Node HIGH_TRUST_AUTHORS parity` test in `scripts/tests/indexer/parity.test.ts` was a silent no-op — it always passed by comparing `'' === ''`. Two compounding defects:

- **Bug 1 — type-annotation bracket.** `extractArrayBody` located the array literal with `source.indexOf('[', declIdx)`. For `export const HIGH_TRUST_AUTHORS: HighTrustAuthor[] = [`, that matched the `[` inside the annotation `HighTrustAuthor[]`, not the array literal — the depth walk hit the annotation's `]` and returned `''`. Fixed by finding the declaration's `=` first, then searching for `[` after it, with an `openIdx < eqIdx` guard against future generic-default declarations.
- **Bug 2 — stale post-split target.** After the SMI-4843 Phase 5b split, `high-trust-authors.ts` holds `[...CORE_HIGH_TRUST_AUTHORS, ...LEADERBOARD_HIGH_TRUST_AUTHORS]` — spread refs, not data. Re-pointed the parity block at the real `.core.ts` / `.leaderboard.ts` data twins, split into two `it.skipIf` assertions (one per const), each with its own git-crypt skip-guard and a drift-naming failure message.

Added a negative divergent-fixture regression test (tmpdir fixtures, incl. a `: SomeType[]`-annotated fixture) that pins Bug 1 and proves divergence is caught.

Pure test-infra change — no production behavior. This is Wave 1 of the SMI-4962 stacked plan; it must merge before the SMI-4962 author-expansion PR opens so that PR's CI runs the repaired parity guard.

Linear: SMI-4941

## Test plan

- [x] `parity.test.ts` — 14 tests pass, 4 new HIGH_TRUST_AUTHORS/regression tests run live (none skipped)
- [x] Divergence sanity-check: temporarily diverged a Deno `.core.ts` entry → `CORE_HIGH_TRUST_AUTHORS` test failed with the custom drift message → reverted, green
- [x] lint / typecheck / audit:standards clean

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)