### PR TITLE
fix(deploy): SMI-4963 register coverage-report in edge-function deploy lists

### DIFF
--- a/scripts/deploy-edge-functions.sh
+++ b/scripts/deploy-edge-functions.sh
@@ -5,7 +5,7 @@
 #   ./scripts/deploy-edge-functions.sh --project-ref <ref> [--functions <name1,name2,...>]
 #
 # Validates the provided ref against known refs in .env before deploying.
-# When --functions is omitted, deploys all 32 functions.
+# When --functions is omitted, deploys all 34 functions.
 # When --functions is provided, deploys only the listed functions.
 
 set -euo pipefail
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
       echo "Usage: $0 --project-ref <ref> [--functions <name1,name2,...>]"
       echo ""
       echo "Deploys Supabase Edge Functions to the specified project."
-      echo "When --functions is omitted, deploys all 32 functions."
+      echo "When --functions is omitted, deploys all 34 functions."
       echo "When --functions is provided, deploys only the listed functions."
       echo ""
       echo "Options:"
@@ -108,6 +108,7 @@ VERIFY_JWT_FUNCTIONS=(
   alert-notify
   auth-device-approve
   auth-device-preview
+  coverage-report
   expire-complimentary
   indexer
   indexer-dispatch
@@ -153,8 +154,9 @@ if [[ -n "$FILTER_FUNCTIONS" ]]; then
   TOTAL=$((${#NO_VERIFY_JWT_FUNCTIONS[@]} + ${#VERIFY_JWT_FUNCTIONS[@]}))
   echo "Deploying $TOTAL edge function(s) to project: $PROJECT_REF"
 else
-  TOTAL=33
-  echo "Deploying all 33 edge functions to project: $PROJECT_REF"
+  # Dynamic count — hardcoding drifts whenever a function is added (SMI-4963).
+  TOTAL=$((${#NO_VERIFY_JWT_FUNCTIONS[@]} + ${#VERIFY_JWT_FUNCTIONS[@]}))
+  echo "Deploying all $TOTAL edge functions to project: $PROJECT_REF"
 fi
 
 echo "=================================================="

--- a/scripts/validate-edge-functions.sh
+++ b/scripts/validate-edge-functions.sh
@@ -58,6 +58,7 @@ SERVICE_ROLE_FUNCTIONS=(
   "indexer-dispatch"
   "skills-refresh-metadata"
   "ops-report"
+  "coverage-report"
   "alert-notify"
   "email-inbound"
   "process-pending-subscription"


### PR DESCRIPTION
## Summary

PR #1213 added the `coverage-report` edge function but did not register it in the deploy scripts' function lists. Since #1213 merged, the **`deploy-edge-functions` workflow has been failing on `main`** (run at `1265f304`): `deploy-edge-functions.sh` emits `WARNING: Unknown function 'coverage-report' — skipping`, then `validate-edge-functions.sh --check-deployment` hard-fails (`coverage-report: NOT DEPLOYED`). The function 404s in prod and every push to `supabase/functions/**` re-runs the red workflow.

## Changes

- **`deploy-edge-functions.sh`** — `coverage-report` added to `VERIFY_JWT_FUNCTIONS` (Service Role / default JWT verification — deployed without `--no-verify-jwt`, identical to `ops-report`). This is what makes the deploy script stop skipping it.
- **`validate-edge-functions.sh`** — `coverage-report` added to `SERVICE_ROLE_FUNCTIONS` — clears the "Not categorized" warning.
- **`deploy-edge-functions.sh`** — the deploy-all branch's `TOTAL` is now computed from the array lengths instead of a hardcoded count (it had already drifted: header/help said 32, runtime echo said 33).

## Verification

`bash -n` clean on both scripts. After merge, a manual `gh workflow run deploy-edge-functions.yml -f function_name=coverage-report` will deploy the function and the `deploy-edge-functions` workflow goes green.

Part of SMI-4963 (the registration step missed by #1213). Shell-script-only change — no TypeScript source.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)