### PR TITLE
fix(ci): SMI-4969/4970/4971 alert-notify payloads + E2E usage-counter + ApiClient API-key auth

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -163,19 +163,15 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          jq -n \
-            --arg type "edge_function_deploy_failure" \
-            --arg source "github-actions" \
-            --arg workflow "deploy-edge-functions" \
-            --arg target "prod" \
-            --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --arg functions "${{ needs.detect.outputs.functions || 'all' }}" \
-            --arg commit "${{ github.sha }}" \
-            '{type: $type, source: $source, details: {workflow: $workflow, target: $target, run_url: $run_url, functions: $functions, commit: $commit}}' \
-          | curl -s -X POST "$SUPABASE_URL/functions/v1/alert-notify" \
+          BODY=$(jq -n \
+            --arg msg "Edge function deploy to prod failed for commit ${{ github.sha }} (functions: ${{ needs.detect.outputs.functions || 'all' }})." \
+            --arg rid "${{ github.run_id }}" \
+            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{type:"edge_function_deploy_failed", message:$msg, workflow:"Deploy Edge Functions", runId:$rid, runUrl:$url}')
+          curl -s -X POST "$SUPABASE_URL/functions/v1/alert-notify" \
             -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
             -H "Content-Type: application/json" \
-            -d @- || true
+            -d "$BODY" || true
 
   deploy-staging:
     name: Deploy edge functions (staging)
@@ -265,16 +261,12 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          jq -n \
-            --arg type "edge_function_deploy_failure" \
-            --arg source "github-actions" \
-            --arg workflow "deploy-edge-functions" \
-            --arg target "staging" \
-            --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --arg functions "${{ needs.detect.outputs.functions || 'all' }}" \
-            --arg commit "${{ github.sha }}" \
-            '{type: $type, source: $source, details: {workflow: $workflow, target: $target, run_url: $run_url, functions: $functions, commit: $commit}}' \
-          | curl -s -X POST "$SUPABASE_URL/functions/v1/alert-notify" \
+          BODY=$(jq -n \
+            --arg msg "Edge function deploy to staging failed for commit ${{ github.sha }} (functions: ${{ needs.detect.outputs.functions || 'all' }})." \
+            --arg rid "${{ github.run_id }}" \
+            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{type:"edge_function_deploy_failed", message:$msg, workflow:"Deploy Edge Functions", runId:$rid, runUrl:$url}')
+          curl -s -X POST "$SUPABASE_URL/functions/v1/alert-notify" \
             -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
             -H "Content-Type: application/json" \
-            -d @- || true
+            -d "$BODY" || true

--- a/.github/workflows/release-cadence-pr-staleness.yml
+++ b/.github/workflows/release-cadence-pr-staleness.yml
@@ -198,17 +198,16 @@ jobs:
             exit 0
           fi
 
-          # Format the closure list as a plain-text body. Mirrors the
-          # smoke-prod/alert.sh convention (alert-notify accepts {to, subject, body}).
+          # Format the closure list as a plain-text message body.
           STALE_LIST=$(awk -F'\t' '{ printf "  - PR #%s (%s): %s\n    %s\n", $1, $2, $3, $4 }' /tmp/stale-prs.tsv)
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BODY=$(printf 'The release-cadence PR-staleness watcher auto-closed the following stale PR(s):\n\n%s\nRunbook: docs/internal/runbooks/release-cadence-stale-pr.md\nWorkflow run: %s\n\nTo re-cut a fresh release PR: `gh workflow run release-cadence.yml -f dry_run=false`\n' "$STALE_LIST" "$RUN_URL")
 
           PAYLOAD=$(jq -nc \
-            --arg to "support@smithhorn.ca" \
-            --arg subject "[SMI-4779] release-cadence stale PR(s) auto-closed" \
-            --arg body "$BODY" \
-            '{to: $to, subject: $subject, body: $body}')
+            --arg msg "$BODY" \
+            --arg rid "${{ github.run_id }}" \
+            --arg url "$RUN_URL" \
+            '{type:"release_cadence_stale_pr_closed", message:$msg, workflow:"Release Cadence PR Staleness", runId:$rid, runUrl:$url}')
 
           curl --silent --show-error --fail \
             --max-time 15 \

--- a/packages/core/src/api/client.events.ts
+++ b/packages/core/src/api/client.events.ts
@@ -45,6 +45,16 @@ export function createBatchFlushFn(
     // edge function's validation regex `[a-zA-Z0-9_-]{1,64}`.
     const batchId = generateBatchId()
 
+    // SMI-4971: `Authorization` is set explicitly per auth-mode — API-key mode
+    // sends `X-API-Key` only (no Authorization), anonymous mode sends
+    // `Authorization: Bearer <anonKey>`. `buildRequestHeaders` no longer adds a
+    // blanket `Authorization`. (No JWT branch: `BatchPostContext` has no jwt.)
+    const authHeader: Record<string, string> = apiKey
+      ? { 'X-API-Key': apiKey }
+      : anonKey
+        ? { Authorization: `Bearer ${anonKey}` }
+        : {}
+
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), timeout)
     try {
@@ -52,7 +62,7 @@ export function createBatchFlushFn(
         method: 'POST',
         headers: {
           ...buildRequestHeaders(anonKey),
-          ...(apiKey ? { 'X-API-Key': apiKey } : {}),
+          ...authHeader,
           'X-Skillsmith-Batched': 'true',
           'X-Skillsmith-Batch-Id': batchId,
         },

--- a/packages/core/src/api/client.health.ts
+++ b/packages/core/src/api/client.health.ts
@@ -44,8 +44,14 @@ export async function checkApiHealth(
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 5000) // 5s timeout for health
 
+    // SMI-4971: health check is always an anonymous request. `Authorization`
+    // is set explicitly here because `buildRequestHeaders` no longer adds a
+    // blanket `Authorization` header.
     const response = await fetch(`${baseUrl}/health`, {
-      headers: buildRequestHeaders(anonKey),
+      headers: {
+        ...buildRequestHeaders(anonKey),
+        ...(anonKey ? { Authorization: `Bearer ${anonKey}` } : {}),
+      },
       signal: controller.signal,
     })
 

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -147,12 +147,21 @@ export class SkillsmithApiClient {
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), this.timeout)
 
-        // SMI-4402: JWT Bearer takes precedence over X-API-Key (legacy)
+        // SMI-4402: JWT Bearer takes precedence over X-API-Key (legacy).
+        // SMI-4971: `Authorization` is set explicitly per auth-mode here —
+        // `buildRequestHeaders` no longer adds a blanket `Authorization`.
+        //  - JWT mode      → Authorization: Bearer <jwtToken>
+        //  - API-key mode  → X-API-Key only, NO Authorization (a stale anon
+        //    JWT here broke downstream edge-function signature validation)
+        //  - anonymous     → Authorization: Bearer <anonKey> (restores the
+        //    header buildRequestHeaders previously added for this case)
         const authHeader: Record<string, string> = {}
         if (this.jwtToken) {
           authHeader['Authorization'] = `Bearer ${this.jwtToken}`
         } else if (this.apiKey) {
           authHeader['X-API-Key'] = this.apiKey
+        } else if (this.anonKey) {
+          authHeader['Authorization'] = `Bearer ${this.anonKey}`
         }
 
         const response = await fetch(url, {

--- a/packages/core/src/api/utils.ts
+++ b/packages/core/src/api/utils.ts
@@ -65,10 +65,21 @@ export function generateAnonymousId(): string {
 // ============================================================================
 
 /**
- * Build request headers for API calls
+ * Build request headers for API calls.
  *
- * @param anonKey - Optional Supabase anon key for authentication
- * @returns Headers object
+ * SMI-4971: This sets only the Supabase gateway `apikey` header (always the
+ * anon key) plus `Content-Type` / `x-request-id`. It deliberately does NOT set
+ * `Authorization` — that header is the caller's per-auth-mode responsibility:
+ * - JWT mode → `Authorization: Bearer <jwtToken>`
+ * - API-key mode → `X-API-Key: <apiKey>`, no `Authorization`
+ * - anonymous mode → `Authorization: Bearer <anonKey>`
+ *
+ * Previously this set `Authorization: Bearer <anonKey>` unconditionally, which
+ * left a stale cross-project anon JWT on API-key requests and broke downstream
+ * edge-function signature validation.
+ *
+ * @param anonKey - Optional Supabase anon key for the gateway `apikey` header
+ * @returns Headers object (no `Authorization` — see above)
  */
 export function buildRequestHeaders(anonKey?: string): Record<string, string> {
   const headers: Record<string, string> = {
@@ -77,7 +88,6 @@ export function buildRequestHeaders(anonKey?: string): Record<string, string> {
   }
 
   if (anonKey) {
-    headers['Authorization'] = `Bearer ${anonKey}`
     headers['apikey'] = anonKey
   }
 

--- a/packages/core/tests/api/client.auth.test.ts
+++ b/packages/core/tests/api/client.auth.test.ts
@@ -136,4 +136,66 @@ describe('SMI-1953: API Client Authentication', () => {
       expect(client.getAuthMode()).toBe('personal')
     })
   })
+
+  // SMI-4971: Verify the request-level auth headers are set explicitly per
+  // auth-mode. Previously `buildRequestHeaders` set `Authorization: Bearer
+  // <anonKey>` unconditionally, leaving a stale cross-project anon JWT on
+  // API-key requests, which broke downstream edge-function auth → 404.
+  describe('SMI-4971: per-auth-mode request headers', () => {
+    const realFetch = global.fetch
+
+    /** Captures the `headers` of the first fetch call and returns an OK JSON response. */
+    function stubFetch(): () => Record<string, string> {
+      let captured: Record<string, string> = {}
+      global.fetch = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+        captured = (init?.headers ?? {}) as Record<string, string>
+        // Shape must satisfy SearchResponseSchema: { data: ApiSearchResult[] }
+        return new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }) as unknown as typeof fetch
+      return () => captured
+    }
+
+    afterEach(() => {
+      global.fetch = realFetch
+    })
+
+    it('JWT mode sends Authorization: Bearer <jwt> and no X-API-Key', async () => {
+      const getHeaders = stubFetch()
+      const client = new SkillsmithApiClient({ jwtToken: 'jwt_token_abc' })
+
+      await client.search({ query: 'test' })
+
+      const headers = getHeaders()
+      expect(headers['Authorization']).toBe('Bearer jwt_token_abc')
+      expect(headers['X-API-Key']).toBeUndefined()
+      expect(headers['apikey']).toBeDefined()
+    })
+
+    it('API-key mode sends X-API-Key and no Authorization', async () => {
+      const getHeaders = stubFetch()
+      const client = new SkillsmithApiClient({ apiKey: 'sk_live_request_test' })
+
+      await client.search({ query: 'test' })
+
+      const headers = getHeaders()
+      expect(headers['X-API-Key']).toBe('sk_live_request_test')
+      expect(headers['Authorization']).toBeUndefined()
+      expect(headers['apikey']).toBeDefined()
+    })
+
+    it('anonymous mode sends Authorization: Bearer <anonKey> and no X-API-Key', async () => {
+      const getHeaders = stubFetch()
+      const client = new SkillsmithApiClient({ anonKey: 'anon_key_xyz' })
+
+      await client.search({ query: 'test' })
+
+      const headers = getHeaders()
+      expect(headers['Authorization']).toBe('Bearer anon_key_xyz')
+      expect(headers['X-API-Key']).toBeUndefined()
+      expect(headers['apikey']).toBe('anon_key_xyz')
+    })
+  })
 })

--- a/packages/core/tests/api/utils.test.ts
+++ b/packages/core/tests/api/utils.test.ts
@@ -143,16 +143,20 @@ describe('API Utils', () => {
       expect(headers['x-request-id']).toMatch(/^client-\d+-[a-z0-9]+$/)
     })
 
-    it('should include auth headers when anonKey provided', async () => {
+    it('should set apikey but NOT Authorization when anonKey provided (SMI-4971)', async () => {
       const { buildRequestHeaders } = await import('../../src/api/utils.js')
 
       const headers = buildRequestHeaders('test-anon-key')
 
-      expect(headers['Authorization']).toBe('Bearer test-anon-key')
+      // SMI-4971: buildRequestHeaders sets only the gateway `apikey` header.
+      // `Authorization` is the caller's per-auth-mode responsibility — emitting
+      // a blanket `Bearer <anonKey>` here left a stale cross-project token on
+      // the API-key path.
       expect(headers['apikey']).toBe('test-anon-key')
+      expect(headers['Authorization']).toBeUndefined()
     })
 
-    it('should not include auth headers when anonKey not provided', async () => {
+    it('should not include the apikey header when anonKey not provided', async () => {
       const { buildRequestHeaders } = await import('../../src/api/utils.js')
 
       const headers = buildRequestHeaders()

--- a/scripts/smoke-prod/alert.sh
+++ b/scripts/smoke-prod/alert.sh
@@ -62,10 +62,9 @@ if [ -z "${SUPABASE_URL:-}" ] || [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
 fi
 
 PAYLOAD=$(jq -nc \
-  --arg to "support@smithhorn.ca" \
-  --arg subject "$SUBJECT" \
-  --arg body "$BODY" \
-  '{to: $to, subject: $subject, body: $body}')
+  --arg msg "$BODY" \
+  --arg url "$RUN_URL" \
+  '{type:"smoke_prod_failed", message:$msg, workflow:"Smoke Prod", runUrl:$url}')
 
 curl --silent --show-error --fail \
   --max-time 15 \

--- a/tests/e2e/cli/usage-counter.e2e.test.ts
+++ b/tests/e2e/cli/usage-counter.e2e.test.ts
@@ -45,27 +45,28 @@ import {
   provisionTestUser,
   cleanupTestUser,
   getUsageRow,
+  resolveStagingSkillId,
   stagingCredentialsAbsent,
   waitForCounterIncrement,
   type ProvisionedUser,
 } from '../fixtures/usage-counter-fixture.js'
 
-// A stable, installable staging skill used to exercise the get-skill path.
-// `anthropics/web-artifacts-builder` is a verified-tier official Anthropic skill
-// with a repo_url, resolved via the author/name lookup. Staging stores skill
-// rows under UUID ids, so getSkill() returns `id` as the UUID — the assertions
-// below check that a skill resolved, not id-equality with the input string.
-// Override with SKILLSMITH_E2E_SKILL_ID if staging seed data changes (SMI-4956).
+// The staging skill used to exercise the get-skill path is resolved at runtime
+// via `resolveStagingSkillId()` (SMI-4970) — a hard-coded constant rotted twice
+// against staging seed-data drift. Staging stores skill rows under UUID ids, so
+// getSkill() returns `id` as the UUID — the assertions below check that a skill
+// resolved, not id-equality with the input string. Override with
+// SKILLSMITH_E2E_SKILL_ID to short-circuit discovery.
 const STAGING_BASE_URL = process.env['STAGING_SUPABASE_URL']?.replace(/\/$/, '') + '/functions/v1'
-const STAGING_SKILL_ID =
-  process.env['SKILLSMITH_E2E_SKILL_ID'] ?? 'anthropics/web-artifacts-builder'
 
 const skipIfNoCreds = stagingCredentialsAbsent()
 
 describe.skipIf(skipIfNoCreds)('@e2e-usage-counter CLI ApiClient → usage counter', () => {
   let user: ProvisionedUser
+  let stagingSkillId: string
 
   beforeAll(async () => {
+    stagingSkillId = await resolveStagingSkillId()
     user = await provisionTestUser({ tier: 'community' })
   }, 30_000)
 
@@ -82,7 +83,7 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter CLI ApiClient → usage count
       baseUrl: STAGING_BASE_URL,
       jwtToken: user.jwt,
     })
-    const res = await client.getSkill(STAGING_SKILL_ID)
+    const res = await client.getSkill(stagingSkillId)
     expect(res).toBeDefined()
     // Staging stores UUID ids — assert a skill resolved, not id === input.
     expect(res.data?.id).toBeTruthy()
@@ -103,13 +104,13 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter CLI ApiClient → usage count
     })
 
     // First call — populates the tier cache.
-    const r1 = await client.getSkill(STAGING_SKILL_ID)
+    const r1 = await client.getSkill(stagingSkillId)
     expect(r1.data?.id).toBeTruthy()
 
     // Second call within the cache TTL — must still increment. Pre-SMI-4461,
     // the tier-cache short-circuit returned before incrementUsageCounter was
     // ever called, silently undercounting from `2` to `1`.
-    const r2 = await client.getSkill(STAGING_SKILL_ID)
+    const r2 = await client.getSkill(stagingSkillId)
     expect(r2.data?.id).toBeTruthy()
 
     await waitForCounterIncrement(user.userId, 'get_count', before.get_count + 2)
@@ -152,7 +153,7 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter CLI ApiClient → usage count
       const client = createApiClient(
         stored ? { baseUrl: STAGING_BASE_URL, jwtToken: stored } : { baseUrl: STAGING_BASE_URL }
       )
-      const res = await client.getSkill(STAGING_SKILL_ID)
+      const res = await client.getSkill(stagingSkillId)
       expect(res.data?.id).toBeTruthy()
 
       await waitForCounterIncrement(user.userId, 'get_count', before.get_count + 1)

--- a/tests/e2e/fixtures/usage-counter-fixture.helpers.ts
+++ b/tests/e2e/fixtures/usage-counter-fixture.helpers.ts
@@ -1,0 +1,182 @@
+/** Internal helper functions and module constants for the usage-counter E2E fixture (SMI-4462). */
+
+import { createHash, randomUUID } from 'node:crypto'
+import type { ResolvedEnv, RestErrorShape, SignInResponse } from './usage-counter-fixture.types.js'
+
+export const STAGING_PROJECT_REF = 'ovhcifugwqnzoebwfuku'
+
+export function readEnv(name: string): string {
+  const v = process.env[name]
+  if (!v || v.length === 0) {
+    throw new Error(
+      `usage-counter-fixture: missing required env ${name}. ` +
+        `Run under varlock (e.g. \`varlock run -- npm run test:e2e:usage-counter\`).`
+    )
+  }
+  return v
+}
+
+export function resolveStagingEnv(): ResolvedEnv {
+  const url = readEnv('STAGING_SUPABASE_URL').replace(/\/$/, '')
+  const serviceRoleKey = readEnv('STAGING_SUPABASE_SERVICE_ROLE_KEY')
+  const anonKey = readEnv('STAGING_SUPABASE_ANON_KEY')
+
+  // Defense-in-depth: refuse to run on a non-staging URL even if a caller
+  // somehow injected prod creds via the staging-named env (CLAUDE.md memory:
+  // 2026-04-17 prod-vs-staging confusion burned ~7 minutes).
+  if (!url.includes(STAGING_PROJECT_REF)) {
+    throw new Error(
+      `usage-counter-fixture: STAGING_SUPABASE_URL must point at staging ref ${STAGING_PROJECT_REF}; got ${url}.`
+    )
+  }
+  return { url, serviceRoleKey, anonKey }
+}
+
+export async function readJsonOrText(res: Response): Promise<unknown> {
+  const text = await res.text()
+  if (!text) return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+/**
+ * Service-role wrapper around the Supabase Auth Admin API.
+ * https://supabase.com/docs/reference/api/admin-create-user
+ *
+ * Retries once on 5xx with a 2s backoff. The signup endpoint surfaces
+ * password-validation as a clean 400, but admin/users masks pre-validation
+ * failures (e.g. bcrypt's 72-char input limit) as a generic 500
+ * unexpected_failure (SMI-4525). A single retry keeps the suite resilient
+ * to genuinely transient GoTrue 5xx without papering over deterministic
+ * client-side bugs.
+ */
+export async function adminCreateUser(
+  env: ResolvedEnv,
+  body: Record<string, unknown>
+): Promise<{ id: string }> {
+  const MAX_ATTEMPTS = 2
+  let lastStatus = 0
+  let lastBody: unknown = '<no response>'
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const res = await fetch(`${env.url}/auth/v1/admin/users`, {
+      method: 'POST',
+      headers: {
+        apikey: env.serviceRoleKey,
+        Authorization: `Bearer ${env.serviceRoleKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    })
+    const data = (await readJsonOrText(res)) as { id?: string; msg?: string; error?: string }
+    if (res.ok && data && typeof data === 'object' && data.id) {
+      return { id: data.id }
+    }
+    lastStatus = res.status
+    lastBody = data ?? '<empty>'
+    const isRetriable = res.status >= 500 && res.status < 600
+    if (!isRetriable || attempt === MAX_ATTEMPTS) break
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+  }
+  throw new Error(`adminCreateUser failed (${lastStatus}): ${JSON.stringify(lastBody)}`)
+}
+
+export async function adminDeleteUser(env: ResolvedEnv, userId: string): Promise<void> {
+  const res = await fetch(`${env.url}/auth/v1/admin/users/${userId}`, {
+    method: 'DELETE',
+    headers: {
+      apikey: env.serviceRoleKey,
+      Authorization: `Bearer ${env.serviceRoleKey}`,
+    },
+  })
+  if (!res.ok && res.status !== 404) {
+    const body = await readJsonOrText(res)
+    console.warn(
+      `[cleanupTestUser] auth.admin DELETE failed (${res.status}): ${JSON.stringify(body)}`
+    )
+  }
+}
+
+export async function signInWithPassword(
+  env: ResolvedEnv,
+  email: string,
+  password: string
+): Promise<SignInResponse> {
+  const res = await fetch(`${env.url}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: {
+      apikey: env.anonKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password }),
+  })
+  const data = (await readJsonOrText(res)) as Partial<SignInResponse> & RestErrorShape
+  if (!res.ok || !data?.access_token || !data?.refresh_token) {
+    throw new Error(
+      `signInWithPassword failed (${res.status}): ${data?.message ?? JSON.stringify(data ?? '<empty>')}`
+    )
+  }
+  return { access_token: data.access_token, refresh_token: data.refresh_token }
+}
+
+/** PostgREST insert/upsert via service-role. Returns parsed JSON or throws. */
+export async function postgrestWrite(
+  env: ResolvedEnv,
+  table: string,
+  body: unknown,
+  opts: { upsertOnConflict?: string } = {}
+): Promise<void> {
+  const headers: Record<string, string> = {
+    apikey: env.serviceRoleKey,
+    Authorization: `Bearer ${env.serviceRoleKey}`,
+    'Content-Type': 'application/json',
+    Prefer: 'return=minimal',
+  }
+  if (opts.upsertOnConflict) {
+    headers['Prefer'] = 'resolution=merge-duplicates,return=minimal'
+  }
+  const url = opts.upsertOnConflict
+    ? `${env.url}/rest/v1/${table}?on_conflict=${encodeURIComponent(opts.upsertOnConflict)}`
+    : `${env.url}/rest/v1/${table}`
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const errBody = (await readJsonOrText(res)) as RestErrorShape
+    throw new Error(
+      `postgrestWrite ${table} failed (${res.status} ${errBody?.code ?? ''}): ${errBody?.message ?? JSON.stringify(errBody ?? '<empty>')}`
+    )
+  }
+}
+
+export async function postgrestDelete(
+  env: ResolvedEnv,
+  table: string,
+  filter: string
+): Promise<RestErrorShape | null> {
+  const res = await fetch(`${env.url}/rest/v1/${table}?${filter}`, {
+    method: 'DELETE',
+    headers: {
+      apikey: env.serviceRoleKey,
+      Authorization: `Bearer ${env.serviceRoleKey}`,
+      Prefer: 'return=minimal',
+    },
+  })
+  if (res.ok) return null
+  return (await readJsonOrText(res)) as RestErrorShape
+}
+
+/**
+ * Generate a sk_live_* style key. Format mirrors production
+ * (`sk_live_<48-hex>`); the value isn't pretty-printed anywhere user-visible.
+ */
+export function generateApiKey(): { plain: string; hash: string; prefix: string } {
+  const random = randomUUID().replace(/-/g, '') + randomUUID().replace(/-/g, '').slice(0, 16)
+  const plain = `sk_live_${random}`
+  const hash = createHash('sha256').update(plain).digest('hex')
+  return { plain, hash, prefix: plain.slice(0, 16) }
+}

--- a/tests/e2e/fixtures/usage-counter-fixture.ts
+++ b/tests/e2e/fixtures/usage-counter-fixture.ts
@@ -32,230 +32,29 @@
  * surface (package-lock churn was prohibitive for SMI-4462 Wave 1).
  */
 
-import { createHash, randomUUID } from 'node:crypto'
+import { randomUUID } from 'node:crypto'
+import type {
+  UserTier,
+  ProvisionedUser,
+  ProvisionOptions,
+  UsageRow,
+  CounterColumn,
+  SkillRow,
+} from './usage-counter-fixture.types.js'
+import {
+  resolveStagingEnv,
+  readEnv,
+  readJsonOrText,
+  adminCreateUser,
+  adminDeleteUser,
+  signInWithPassword,
+  postgrestWrite,
+  postgrestDelete,
+  generateApiKey,
+} from './usage-counter-fixture.helpers.js'
 
-const STAGING_PROJECT_REF = 'ovhcifugwqnzoebwfuku'
-
-export type UserTier = 'community' | 'individual' | 'team' | 'enterprise'
-
-export interface ProvisionedUser {
-  userId: string
-  email: string
-  password: string
-  /** Supabase access JWT (Bearer-style) issued by signInWithPassword. */
-  jwt: string
-  /** Supabase refresh token, written into the CLI ~/.skillsmith/config.json. */
-  refreshToken: string
-  /** Plain sk_live_* license key — write to X-API-Key / Bearer header. */
-  apiKey: string
-}
-
-export interface ProvisionOptions {
-  tier?: UserTier
-  /** Optional name for the license_keys row (defaults to 'CLI Token'). */
-  apiKeyName?: string
-}
-
-export interface UsageRow {
-  user_id: string
-  hour_bucket: string
-  search_count: number
-  get_count: number
-  recommend_count: number
-}
-
-interface ResolvedEnv {
-  url: string
-  serviceRoleKey: string
-  anonKey: string
-}
-
-function readEnv(name: string): string {
-  const v = process.env[name]
-  if (!v || v.length === 0) {
-    throw new Error(
-      `usage-counter-fixture: missing required env ${name}. ` +
-        `Run under varlock (e.g. \`varlock run -- npm run test:e2e:usage-counter\`).`
-    )
-  }
-  return v
-}
-
-function resolveStagingEnv(): ResolvedEnv {
-  const url = readEnv('STAGING_SUPABASE_URL').replace(/\/$/, '')
-  const serviceRoleKey = readEnv('STAGING_SUPABASE_SERVICE_ROLE_KEY')
-  const anonKey = readEnv('STAGING_SUPABASE_ANON_KEY')
-
-  // Defense-in-depth: refuse to run on a non-staging URL even if a caller
-  // somehow injected prod creds via the staging-named env (CLAUDE.md memory:
-  // 2026-04-17 prod-vs-staging confusion burned ~7 minutes).
-  if (!url.includes(STAGING_PROJECT_REF)) {
-    throw new Error(
-      `usage-counter-fixture: STAGING_SUPABASE_URL must point at staging ref ${STAGING_PROJECT_REF}; got ${url}.`
-    )
-  }
-  return { url, serviceRoleKey, anonKey }
-}
-
-interface RestErrorShape {
-  code?: string
-  message?: string
-  details?: string
-}
-
-async function readJsonOrText(res: Response): Promise<unknown> {
-  const text = await res.text()
-  if (!text) return undefined
-  try {
-    return JSON.parse(text)
-  } catch {
-    return text
-  }
-}
-
-/**
- * Service-role wrapper around the Supabase Auth Admin API.
- * https://supabase.com/docs/reference/api/admin-create-user
- *
- * Retries once on 5xx with a 2s backoff. The signup endpoint surfaces
- * password-validation as a clean 400, but admin/users masks pre-validation
- * failures (e.g. bcrypt's 72-char input limit) as a generic 500
- * unexpected_failure (SMI-4525). A single retry keeps the suite resilient
- * to genuinely transient GoTrue 5xx without papering over deterministic
- * client-side bugs.
- */
-async function adminCreateUser(
-  env: ResolvedEnv,
-  body: Record<string, unknown>
-): Promise<{ id: string }> {
-  const MAX_ATTEMPTS = 2
-  let lastStatus = 0
-  let lastBody: unknown = '<no response>'
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    const res = await fetch(`${env.url}/auth/v1/admin/users`, {
-      method: 'POST',
-      headers: {
-        apikey: env.serviceRoleKey,
-        Authorization: `Bearer ${env.serviceRoleKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    })
-    const data = (await readJsonOrText(res)) as { id?: string; msg?: string; error?: string }
-    if (res.ok && data && typeof data === 'object' && data.id) {
-      return { id: data.id }
-    }
-    lastStatus = res.status
-    lastBody = data ?? '<empty>'
-    const isRetriable = res.status >= 500 && res.status < 600
-    if (!isRetriable || attempt === MAX_ATTEMPTS) break
-    await new Promise((resolve) => setTimeout(resolve, 2000))
-  }
-  throw new Error(`adminCreateUser failed (${lastStatus}): ${JSON.stringify(lastBody)}`)
-}
-
-async function adminDeleteUser(env: ResolvedEnv, userId: string): Promise<void> {
-  const res = await fetch(`${env.url}/auth/v1/admin/users/${userId}`, {
-    method: 'DELETE',
-    headers: {
-      apikey: env.serviceRoleKey,
-      Authorization: `Bearer ${env.serviceRoleKey}`,
-    },
-  })
-  if (!res.ok && res.status !== 404) {
-    const body = await readJsonOrText(res)
-    console.warn(
-      `[cleanupTestUser] auth.admin DELETE failed (${res.status}): ${JSON.stringify(body)}`
-    )
-  }
-}
-
-interface SignInResponse {
-  access_token: string
-  refresh_token: string
-}
-
-async function signInWithPassword(
-  env: ResolvedEnv,
-  email: string,
-  password: string
-): Promise<SignInResponse> {
-  const res = await fetch(`${env.url}/auth/v1/token?grant_type=password`, {
-    method: 'POST',
-    headers: {
-      apikey: env.anonKey,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ email, password }),
-  })
-  const data = (await readJsonOrText(res)) as Partial<SignInResponse> & RestErrorShape
-  if (!res.ok || !data?.access_token || !data?.refresh_token) {
-    throw new Error(
-      `signInWithPassword failed (${res.status}): ${data?.message ?? JSON.stringify(data ?? '<empty>')}`
-    )
-  }
-  return { access_token: data.access_token, refresh_token: data.refresh_token }
-}
-
-/** PostgREST insert/upsert via service-role. Returns parsed JSON or throws. */
-async function postgrestWrite(
-  env: ResolvedEnv,
-  table: string,
-  body: unknown,
-  opts: { upsertOnConflict?: string } = {}
-): Promise<void> {
-  const headers: Record<string, string> = {
-    apikey: env.serviceRoleKey,
-    Authorization: `Bearer ${env.serviceRoleKey}`,
-    'Content-Type': 'application/json',
-    Prefer: 'return=minimal',
-  }
-  if (opts.upsertOnConflict) {
-    headers['Prefer'] = 'resolution=merge-duplicates,return=minimal'
-  }
-  const url = opts.upsertOnConflict
-    ? `${env.url}/rest/v1/${table}?on_conflict=${encodeURIComponent(opts.upsertOnConflict)}`
-    : `${env.url}/rest/v1/${table}`
-  const res = await fetch(url, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body),
-  })
-  if (!res.ok) {
-    const errBody = (await readJsonOrText(res)) as RestErrorShape
-    throw new Error(
-      `postgrestWrite ${table} failed (${res.status} ${errBody?.code ?? ''}): ${errBody?.message ?? JSON.stringify(errBody ?? '<empty>')}`
-    )
-  }
-}
-
-async function postgrestDelete(
-  env: ResolvedEnv,
-  table: string,
-  filter: string
-): Promise<RestErrorShape | null> {
-  const res = await fetch(`${env.url}/rest/v1/${table}?${filter}`, {
-    method: 'DELETE',
-    headers: {
-      apikey: env.serviceRoleKey,
-      Authorization: `Bearer ${env.serviceRoleKey}`,
-      Prefer: 'return=minimal',
-    },
-  })
-  if (res.ok) return null
-  return (await readJsonOrText(res)) as RestErrorShape
-}
-
-/**
- * Generate a sk_live_* style key. Format mirrors production
- * (`sk_live_<48-hex>`); the value isn't pretty-printed anywhere user-visible.
- */
-function generateApiKey(): { plain: string; hash: string; prefix: string } {
-  const random = randomUUID().replace(/-/g, '') + randomUUID().replace(/-/g, '').slice(0, 16)
-  const plain = `sk_live_${random}`
-  const hash = createHash('sha256').update(plain).digest('hex')
-  return { plain, hash, prefix: plain.slice(0, 16) }
-}
+export type { UserTier, CounterColumn } from './usage-counter-fixture.types.js'
+export type { ProvisionedUser, ProvisionOptions, UsageRow } from './usage-counter-fixture.types.js'
 
 /**
  * Provision a fresh staging user with profile + license_keys row + auth JWT.
@@ -422,6 +221,96 @@ export function stagingFunctionUrl(fn: string): string {
   return `${env.url}/functions/v1/${fn}`
 }
 
+/** Memoized resolved staging skill identifier — see resolveStagingSkillId. */
+let resolvedStagingSkillId: string | undefined
+
+const NO_VERIFIED_SKILL_ERROR = 'staging has no verified skill — cannot run the usage-counter suite'
+
+/**
+ * Resolve a staging skill identifier (`author/name`) for the usage-counter
+ * E2E suites, with runtime discovery so the suite self-heals against staging
+ * seed-data drift (SMI-4970). A hard-coded constant has rotted twice now
+ * (`anthropic/commit`, then `anthropics/web-artifacts-builder`).
+ *
+ * Resolution order:
+ *   1. `SKILLSMITH_E2E_SKILL_ID` env override — escape hatch, preserved.
+ *   2. Otherwise read the staging `skills` table directly via PostgREST.
+ *
+ * The query goes to the database (`/rest/v1/skills`) with the service-role
+ * key, NOT through the `skills-search` edge function. `skills-search` enforces
+ * an IP-scoped anonymous-trial gate (401 "Free trial exhausted") that a busy
+ * CI runner trips routinely — discovery must not depend on that quota.
+ * Service-role bypasses RLS; the read is plain and unmetered.
+ *
+ * Memoized module-scoped (including the env-override path) so the query runs
+ * at most once per suite run. The fetch has a short timeout and 1 retry,
+ * matching `adminCreateUser`'s 2s-backoff idiom.
+ *
+ * Fail-fast, with two distinct messages so triage stays honest:
+ *   - empty result          → genuinely un-runnable suite (no verified skill).
+ *   - network error / timeout / non-2xx → transient outage, not seed drift.
+ * A malformed row with a null/empty `author` or `name` also throws rather than
+ * yielding a `null/...` identifier and a misleading downstream 404.
+ */
+export async function resolveStagingSkillId(): Promise<string> {
+  if (resolvedStagingSkillId !== undefined) return resolvedStagingSkillId
+
+  const override = process.env['SKILLSMITH_E2E_SKILL_ID']
+  if (override && override.length > 0) {
+    resolvedStagingSkillId = override
+    return resolvedStagingSkillId
+  }
+
+  const env = resolveStagingEnv()
+  const url =
+    `${env.url}/rest/v1/skills` +
+    `?select=author,name&trust_tier=eq.verified&quarantined=eq.false&limit=1`
+
+  const MAX_ATTEMPTS = 2
+  let lastError: unknown
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          apikey: env.serviceRoleKey,
+          Authorization: `Bearer ${env.serviceRoleKey}`,
+        },
+        signal: AbortSignal.timeout(8_000),
+      })
+      if (!res.ok) {
+        throw new Error(`skills query returned ${res.status}`)
+      }
+      // PostgREST returns a bare JSON array of rows.
+      const rows = (await readJsonOrText(res)) as SkillRow[] | undefined
+      const results: SkillRow[] = Array.isArray(rows) ? rows : []
+      if (results.length === 0) {
+        throw new Error(NO_VERIFIED_SKILL_ERROR)
+      }
+      const first = results[0]
+      const author = first?.author
+      const name = first?.name
+      if (!author || author.length === 0 || !name || name.length === 0) {
+        throw new Error(NO_VERIFIED_SKILL_ERROR)
+      }
+      resolvedStagingSkillId = `${author}/${name}`
+      return resolvedStagingSkillId
+    } catch (err) {
+      // The empty-staging / malformed-row error is a deterministic
+      // un-runnable-suite signal — never retry it and never reclassify it.
+      if (err instanceof Error && err.message === NO_VERIFIED_SKILL_ERROR) {
+        throw err
+      }
+      lastError = err
+      if (attempt === MAX_ATTEMPTS) break
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+    }
+  }
+  throw new Error(
+    `staging skills query unreachable — transient outage, not seed drift ` +
+      `(${lastError instanceof Error ? lastError.message : String(lastError)})`
+  )
+}
+
 /** SMI-4741: Insert stale sub row (status='active', current_period_end=yesterday). */
 export async function setStaleSubscriptionRow(userId: string): Promise<void> {
   const env = resolveStagingEnv()
@@ -468,8 +357,6 @@ export function getStagingAnonKey(): string {
 export function getStagingServiceRoleKey(): string {
   return readEnv('STAGING_SUPABASE_SERVICE_ROLE_KEY')
 }
-
-type CounterColumn = 'search_count' | 'get_count' | 'recommend_count'
 
 /**
  * Polling helper — `increment_api_usage` is fire-and-forget downstream of the

--- a/tests/e2e/fixtures/usage-counter-fixture.types.ts
+++ b/tests/e2e/fixtures/usage-counter-fixture.types.ts
@@ -1,0 +1,53 @@
+/** Type declarations for the usage-counter E2E fixture (SMI-4462). */
+
+export type UserTier = 'community' | 'individual' | 'team' | 'enterprise'
+
+export interface ProvisionedUser {
+  userId: string
+  email: string
+  password: string
+  /** Supabase access JWT (Bearer-style) issued by signInWithPassword. */
+  jwt: string
+  /** Supabase refresh token, written into the CLI ~/.skillsmith/config.json. */
+  refreshToken: string
+  /** Plain sk_live_* license key — write to X-API-Key / Bearer header. */
+  apiKey: string
+}
+
+export interface ProvisionOptions {
+  tier?: UserTier
+  /** Optional name for the license_keys row (defaults to 'CLI Token'). */
+  apiKeyName?: string
+}
+
+export interface UsageRow {
+  user_id: string
+  hour_bucket: string
+  search_count: number
+  get_count: number
+  recommend_count: number
+}
+
+export interface ResolvedEnv {
+  url: string
+  serviceRoleKey: string
+  anonKey: string
+}
+
+export interface RestErrorShape {
+  code?: string
+  message?: string
+  details?: string
+}
+
+export interface SignInResponse {
+  access_token: string
+  refresh_token: string
+}
+
+export interface SkillRow {
+  author?: string | null
+  name?: string | null
+}
+
+export type CounterColumn = 'search_count' | 'get_count' | 'recommend_count'

--- a/tests/e2e/mcp/usage-counter.e2e.test.ts
+++ b/tests/e2e/mcp/usage-counter.e2e.test.ts
@@ -30,6 +30,7 @@ import {
   provisionTestUser,
   cleanupTestUser,
   getUsageRow,
+  resolveStagingSkillId,
   stagingCredentialsAbsent,
   waitForCounterIncrement,
   type ProvisionedUser,
@@ -41,9 +42,7 @@ const __dirname = dirname(__filename)
 // Built MCP server binary, relative to repo root.
 const MCP_SERVER_BIN = resolve(__dirname, '../../../packages/mcp-server/dist/src/index.js')
 
-// Stable installable staging skill — see cli/usage-counter.e2e.test.ts (SMI-4956).
-const STAGING_SKILL_ID =
-  process.env['SKILLSMITH_E2E_SKILL_ID'] ?? 'anthropics/web-artifacts-builder'
+// Staging skill resolved at runtime — see cli/usage-counter.e2e.test.ts (SMI-4970).
 const STAGING_BASE_URL =
   (process.env['STAGING_SUPABASE_URL']?.replace(/\/$/, '') ?? '') + '/functions/v1'
 
@@ -58,8 +57,10 @@ describe.skipIf(skipSuite)('@e2e-usage-counter MCP stdio → usage counter', () 
   let user: ProvisionedUser
   let client: Client
   let transport: StdioClientTransport
+  let stagingSkillId: string
 
   beforeAll(async () => {
+    stagingSkillId = await resolveStagingSkillId()
     user = await provisionTestUser({ tier: 'community' })
 
     transport = new StdioClientTransport({
@@ -101,7 +102,7 @@ describe.skipIf(skipSuite)('@e2e-usage-counter MCP stdio → usage counter', () 
 
     const response = await client.callTool({
       name: 'get_skill',
-      arguments: { skill_id: STAGING_SKILL_ID },
+      arguments: { skill_id: stagingSkillId },
     })
     expect(response).toBeDefined()
     expect(response.isError).not.toBe(true)

--- a/tests/e2e/website/account-usage.e2e.test.ts
+++ b/tests/e2e/website/account-usage.e2e.test.ts
@@ -97,9 +97,14 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter Website auth surface → usag
         Accept: 'application/json',
       },
     })
-    // Anonymous calls succeed under the trial limit; a 200 here is fine,
-    // a 429 also satisfies the negative assertion (no row mutation either way).
-    expect([200, 429]).toContain(res.status)
+    // Anonymous calls succeed under the trial limit (200). Once the shared
+    // staging anonymous-trial quota is used up, skills-search returns either
+    // 429 (rate-limited) or 401 ("Authentication required - Free trial
+    // exhausted"). All three satisfy the negative assertion below: the request
+    // is either served or rejected, and neither mutates the test user's row.
+    // 401 must be tolerated or this test goes red on any busy CI runner whose
+    // IP has burned its trial allowance (SMI-4970).
+    expect([200, 429, 401]).toContain(res.status)
 
     // Allow the same 1.5s window any successful counter increment would
     // need before sampling — gives a real bug a chance to surface.


### PR DESCRIPTION
Three CI-health fixes surfaced during SMI-4948 verification. Plan-reviewed (v1 + v2, 19 findings total, all applied).

## SMI-4969 — alert-notify callers send non-conforming payloads (commit 1)

The `alert-notify` edge function strictly requires `{type, message, workflow?, runId?, runUrl?}`. Three of 12 callers POSTed `{type, source, details}` or `{to, subject, body}` — every alert they sent 400'd silently. Rewrites all three to the canonical schema (`edge_function_deploy_failed`, `smoke_prod_failed`, `release_cadence_stale_pr_closed`), matching the `indexer.yml` idiom.

Files: `.github/workflows/deploy-edge-functions.yml`, `.github/workflows/release-cadence-pr-staleness.yml`, `scripts/smoke-prod/alert.sh`.

## SMI-4970 — E2E Usage Counter: runtime skill discovery + path #5 401 tolerance (commit 2)

Replaces the hard-coded `STAGING_SKILL_ID` (rotted twice: `anthropic/commit` → `anthropics/web-artifacts-builder`) with runtime discovery against the staging `skills` table via PostgREST + service-role (not the rate-limited `skills-search` edge function). Memoized, timeout + retry, distinct fail-fast messages for empty-result vs unreachable. `SKILLSMITH_E2E_SKILL_ID` preserved as escape hatch.

`account-usage` path #5 tolerated only `[200, 429]`; staging anonymous-trial exhaustion returns **401** — added to the accepted set with a comment.

`tests/e2e/fixtures/usage-counter-fixture.ts` grew past the 500-line limit; split into `usage-counter-fixture.{types,helpers}.ts` (behavior-preserving code movement, all public exports preserved on the main file, 4 importers unchanged).

## SMI-4971 — ApiClient sends a stale Authorization on the API-key path (commit 3)

**The actual reason the `E2E Usage Counter` workflow has been red since inception** (46 failures / 0 successes since ~2026-04-28). The SMI-4970 plan's original RCA (rotted skill ID) was incomplete — only the API-key tests fail, JWT tests pass with the same skill ID.

Root cause (verified live against staging, 3-case repro): `buildRequestHeaders` unconditionally sets `Authorization: Bearer <anonKey>`; the JWT branch overwrites it, the API-key branch leaves it stale. When the client targets a Supabase project other than the one `anonKey` belongs to (staging E2E, where `anonKey` falls back to the production anon key), that stale header is a cross-project anon JWT — `skills-get` feeds it to `createSupabaseClient(authorization)`, signature validation fails, every query errors → 404.

Fix-at-source (plan-review M1): drop `Authorization` from `buildRequestHeaders`; each caller's request site sets it explicitly per auth-mode — jwt → `Bearer <jwt>`, API-key → none (only `X-API-Key`), anonymous → `Bearer <anonKey>`. Closes the bug-class across all three header-building call sites (`client.ts`, `client.events.ts`, `client.health.ts`) rather than three scattered deletes.

Net behavior change: API-key requests stop sending `Authorization`. JWT and anonymous paths unchanged. Edge `auth-middleware` identifies API-key callers via `X-API-Key`, not `Authorization`, so this cannot break API-key identification. In production the bug was masked (anonKey matches the project); it only bit non-default Supabase targets — staging E2E, CLI/MCP users on self-hosted Supabase.

Test: `client.auth.test.ts` adds three `it()` cases (jwt / apiKey / anonymous), each with mocked `fetch` (offline) asserting the exact `Authorization`/`X-API-Key`/`apikey` headers. `utils.test.ts` updated to the new `buildRequestHeaders` contract.

## Verification

- `typecheck` / `lint` / `audit:standards` / `format:check` clean.
- `packages/core/tests/api/` — 92/92 tests pass (incl. 3 new SMI-4971 cases).
- Live E2E repro against staging: API-key `getSkill` 404 → 200 with the worktree's fixed core.
- jq-lint of all 3 rewritten alert-notify payloads — valid JSON, non-empty `type`+`message`.
- After merge: the `E2E Usage Counter` workflow goes green — its first successful run.

## Plan

`docs/internal/implementation/2026-05-19-ci-health-alert-notify-and-e2e-skill-fixes.md` (will ride along in a follow-up docs PR with the code reviews).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)