### PR TITLE
fix(test): SMI-4975/4976 E2E usage-counter — bypass client cache + canonical 'id' arg

### DIFF
--- a/tests/e2e/cli/usage-counter.e2e.test.ts
+++ b/tests/e2e/cli/usage-counter.e2e.test.ts
@@ -103,14 +103,23 @@ describe.skipIf(skipIfNoCreds)('@e2e-usage-counter CLI ApiClient → usage count
       apiKey: user.apiKey,
     })
 
-    // First call — populates the tier cache.
-    const r1 = await client.getSkill(stagingSkillId)
+    // SMI-4975: bypass the client-side responseCache so both calls actually
+    // hit the wire. `DEFAULT_TTL.getSkill = 24h` (packages/core/src/api/cache.ts:71)
+    // means a second `getSkill(sameId)` is served from in-process memory in
+    // 0ms without reaching the edge function — the test would silently pass
+    // its r2 data-shape assertion while never exercising the server's
+    // tier-cache hit path or the counter increment we're trying to validate.
+    // Per-call `{ cache: 'no-store' }` (CallCacheOptions, packages/core/src/api/client.cache.ts:17)
+    // is the public override.
+    //
+    // First call — populates the SERVER tier cache.
+    const r1 = await client.getSkill(stagingSkillId, { cache: 'no-store' })
     expect(r1.data?.id).toBeTruthy()
 
     // Second call within the cache TTL — must still increment. Pre-SMI-4461,
     // the tier-cache short-circuit returned before incrementUsageCounter was
     // ever called, silently undercounting from `2` to `1`.
-    const r2 = await client.getSkill(stagingSkillId)
+    const r2 = await client.getSkill(stagingSkillId, { cache: 'no-store' })
     expect(r2.data?.id).toBeTruthy()
 
     await waitForCounterIncrement(user.userId, 'get_count', before.get_count + 2)

--- a/tests/e2e/mcp/usage-counter.e2e.test.ts
+++ b/tests/e2e/mcp/usage-counter.e2e.test.ts
@@ -102,7 +102,12 @@ describe.skipIf(skipSuite)('@e2e-usage-counter MCP stdio → usage counter', () 
 
     const response = await client.callTool({
       name: 'get_skill',
-      arguments: { skill_id: stagingSkillId },
+      // SMI-4976: the tool input schema declares `id` (see
+      // packages/mcp-server/src/tools/get-skill.ts:46-69 — `getSkillInputSchema`).
+      // Sending `skill_id` here results in Zod dropping the unknown key and
+      // the required-field guard firing with 'Skill ID is required' — the
+      // call never reaches the API.
+      arguments: { id: stagingSkillId },
     })
     expect(response).toBeDefined()
     expect(response.isError).not.toBe(true)


### PR DESCRIPTION
## Summary

Two test-only fixes that make the `E2E Usage Counter` workflow green for the **first time** since its inception (~2026-04-28, 46 consecutive failures).

Closes [SMI-4975](https://linear.app/smith-horn-group/issue/SMI-4975) and [SMI-4976](https://linear.app/smith-horn-group/issue/SMI-4976).

## Background

After SMI-4969/4970/4971 (PR #1219) landed, the workflow was still red. The prior session's continuation-prompt RCAs ("SMI-2144 cache-hit counter regression resurfaced" + "MCP wrapper returning isError on API-key auth") were both **wrong** — re-investigated empirically via diagnostic repros against staging.

### SMI-4975 — client-side responseCache masked the cache-hit test

`tests/e2e/cli/usage-counter.e2e.test.ts` "API-key cache hit" failed `expected 2 to be 3`. Diagnostic trace:

```
r1: data.id=361201ab-…  elapsed=836ms   (cold round-trip — real)
r2: data.id=361201ab-…  elapsed=0ms     (zero — never hit wire)
counter: +1 (only r1 incremented)
```

`elapsed=0ms` is the smoking gun. `@skillsmith/core`'s SkillsmithApiClient (`packages/core/src/api/client.ts:69-95`) caches `getSkill` responses for 24h (`packages/core/src/api/cache.ts:71`). The server-side counter wiring (`supabase/functions/skills-get/index.ts:189` + tier-cache hit returning userId at `_shared/api-key-auth.ts:127-135`) was **clean throughout** — the test invariant was violated inside the client.

**Fix**: pass per-call `{ cache: 'no-store' }` (the documented `CallCacheOptions` surface at `packages/core/src/api/client.cache.ts:17`) to both `getSkill` calls. JWT and auto-load tests use fresh `createApiClient` instances, so the 24h TTL doesn't bite them.

### SMI-4976 — test sent `skill_id` but schema expects `id`

`tests/e2e/mcp/usage-counter.e2e.test.ts` failed `expected true not to be true` (i.e. `response.isError === true`). Response body:

```json
{ "content": [{ "text": "Error: Skill ID is required" }], "isError": true }
```

The MCP server's stderr showed **no HTTP activity** — boot lines only. The Zod schema at `packages/mcp-server/src/tools/get-skill.ts:46-69` declares the field as **`id`**, not `skill_id`. Sending `skill_id` makes Zod drop the unknown key, then the required-field guard fires with the literal text `'Skill ID is required'`.

**Fix**: change `arguments: { skill_id: stagingSkillId }` → `arguments: { id: stagingSkillId }`.

## Verification

All 13 tests in the E2E Usage Counter suite pass against staging from the worktree:

```
varlock run -- npm run test:e2e:usage-counter -- --reporter=verbose
✓ JWT path (+1)                                                    1913ms
✓ API-key cache hit (+2)                  — SMI-4975 target        2241ms
✓ SMI-4474 auto-load (+1)                                          1583ms
✓ get_skill via MCP stdio (+1)            — SMI-4976 target        1368ms
✓ Website authed Bearer JWT (+1)                                   1525ms
✓ Website anon SSR proxy (+0)                                      2106ms
✓ Stale billing period fallback                                     204ms
✓ 5× license-key generation tests
✓ Direct X-API-Key cache-hit (+2)                                  2103ms

Test Files  5 passed (5)
     Tests  13 passed (13)
  Duration  33.33s
```

Governance review on the commit: **0 findings**.

## Scope

Test-only. No `supabase/functions/` changes, no schema changes, no workflow changes. **No ADR-109 trigger.** Implementation plan + RCA write-up in [docs/internal #195+1 follow-up].

## Risks

- **R1 (low)**: After bypassing client cache, the server's tier-cache might not actually produce "+1 on every call" — would suggest a separate server bug we hadn't seen. **Mitigation realised**: empirical staging run shows +2 (both calls increment), confirming server-side wiring is correct.
- **R2 (very low)**: `cache: 'no-store'` doesn't behave as documented. **Mitigation realised**: same staging run proves r1 + r2 are real round-trips (836ms + 1.4s respectively in the diagnostic trace).

## Acceptance

Post-merge: `gh workflow run e2e-usage-counter.yml --ref main` should complete with conclusion `success` for the first time in the workflow's history.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)