### PR TITLE
chore(smoke): SMI-4995 add coverage-report to surfaces allowlist (Check 36)

### DIFF
--- a/scripts/smoke-prod/.surfaces-allowlist.txt
+++ b/scripts/smoke-prod/.surfaces-allowlist.txt
@@ -27,6 +27,11 @@ supabase/functions/admin-grant-subscription/**
 supabase/functions/update-seat-count/**
 supabase/functions/webhook-dlq/**
 supabase/functions/quota-monitor/**
+# SMI-4995: coverage-report is the weekly cross-ecosystem coverage cron
+# (SMI-4963) — invoked only by .github/workflows/coverage-report.yml via
+# service-role auth. No user-facing HTTP surface; results land in
+# audit_logs and the GitHub Actions artifact.
+supabase/functions/coverage-report/**
 
 # SMI-4852: indexer-dispatch is invoked by repository_dispatch via the
 # indexer.yml workflow + manual ops; service-role-only, fires GitHub


### PR DESCRIPTION
Closes [SMI-4995](https://linear.app/smith-horn-group/issue/SMI-4995).

Identical recipe to the now-Done [SMI-4750](https://linear.app/smith-horn-group/issue/SMI-4750) (quota-monitor) — `audit:standards` Check 36 had been warning since `coverage-report` landed in SMI-4963:

```
⚠ 1 surface(s) not covered by surfaces.json and not allowlisted:
  supabase/functions/coverage-report/index.ts
```

`coverage-report` is the weekly cross-ecosystem coverage cron — invoked only by `.github/workflows/coverage-report.yml` via service-role auth. No user-facing HTTP surface; results land in `audit_logs` and the GHA artifact. Belongs in the cron-only allowlist, not `surfaces.json`.

Verified locally: `node scripts/audit-standards.mjs` from the worktree reports "All 90 user-facing surface(s) covered by surfaces.json or allowlist" — warning gone.

Surfaced during the PR #1223 retro (SMI-4975/4976). Filed standalone to keep that retro's scope clean.

[skip-impl-check]
[skip-smoke]