### PR TITLE
chore(docker): SMI-4998 harden entrypoint pre-check (GH#1108)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,8 +44,8 @@ MCP_DIST_ENTRY="/app/packages/mcp-server/dist/src/index.js"
 echo -e "${YELLOW}[entrypoint] Checking dist/ outputs...${NC}"
 
 # Pre-check: node_modules must be initialised before build can succeed
-if [ ! -f "/app/node_modules/.package-lock.json" ]; then
-    echo -e "${RED}  ✗ node_modules not initialised — run: npm install inside this container${NC}"
+if [ ! -f "/app/node_modules/.package-lock.json" ] || [ ! -x "/app/node_modules/.bin/turbo" ]; then
+    echo -e "${RED}  ✗ node_modules not initialised (or partial install) — run: npm install inside this container${NC}"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Tightens `docker-entrypoint.sh:47` pre-check to also assert `/app/node_modules/.bin/turbo` is executable. Replaces the cryptic mid-build `sh: 1: turbo: not found` with the existing fail-fast message (annotated for the partial-install case).
- Happy-path first-start is unaffected: named volume `node_modules:/app/node_modules` (`docker-compose.yml:12`) is seeded from image-layer `npm ci --include=dev` (`Dockerfile:64`), so turbo is always present.
- Closes [GH#1108](https://github.com/smith-horn/skillsmith/issues/1108). Linked to [SMI-4998](https://linear.app/smith-horn-group/issue/SMI-4998). Plan: `docs/internal/implementation/smi-4998-issue-1108-entrypoint-hardening.md`.

## Diff

```diff
-if [ ! -f "/app/node_modules/.package-lock.json" ]; then
-    echo -e "${RED}  ✗ node_modules not initialised — run: npm install inside this container${NC}"
+if [ ! -f "/app/node_modules/.package-lock.json" ] || [ ! -x "/app/node_modules/.bin/turbo" ]; then
+    echo -e "${RED}  ✗ node_modules not initialised (or partial install) — run: npm install inside this container${NC}"
     exit 1
 fi
```

## Verification transcripts

### Phase 1 — Fresh-start happy path

```
$ DEV_PORT=3381 docker compose --profile dev down -v
$ docker compose --profile dev build --no-cache dev
$ DEV_PORT=3381 docker compose --profile dev up -d
$ docker logs smi-4998-issue-1108-entrypoint-precheck-dev-1
[entrypoint] Checking dist/ outputs...
  ✗ dist/ not found (first container start) — building packages...
  ✓ Build complete.
[entrypoint] dist/ outputs ready.
[entrypoint] Validating native modules...
  ✓ better-sqlite3
  ✓ onnxruntime-node
  ✓ esbuild
  ✓ hnswlib-node
[entrypoint] All native modules validated.

$ docker exec ... ls -la /app/node_modules/.bin/turbo
lrwxrwxrwx 1 root root 18 May 19 23:48 /app/node_modules/.bin/turbo -> ../turbo/bin/turbo
$ docker exec ... node -e "require('/app/packages/mcp-server/dist/src/index.js'); console.log('ok')"
ok
Skillsmith MCP server running
```

### Phase 2 — Partial-install repro (PRE-fix, current main behavior)

```
$ docker exec ... rm -f /app/node_modules/.bin/turbo
$ docker compose --profile dev restart dev
[entrypoint] Checking dist/ outputs...
  ✗ dist/ not found (first container start) — building packages...

> skillsmith@0.1.2 build
> turbo run build --filter=!@skillsmith/website

sh: 1: turbo: not found
  ✗ Build failed — run npm run build inside this container to see details.
```

This is the exact symptom GH#1108 reported.

### Phase 3 — Same scenario POST-fix (this PR)

```
$ docker compose --profile dev restart dev
[entrypoint] Checking dist/ outputs...
  ✗ node_modules not initialised (or partial install) — run: npm install inside this container
```

Clean fail-fast with a diagnosable message — no cryptic mid-build error.

### Phase 4 — Post-fix happy path still works

```
$ # restore turbo symlink, then restart
$ docker compose --profile dev start dev
[entrypoint] Checking dist/ outputs...
  ✗ dist/ not found (first container start) — building packages...
 Tasks:    6 successful, 6 total
Cached:    6 cached, 6 total
  Time:    3.273s >>> FULL TURBO
  ✓ Build complete.
[entrypoint] dist/ outputs ready.
[entrypoint] Validating native modules...
  ✓ better-sqlite3 / onnxruntime-node / esbuild / hnswlib-node
[entrypoint] All native modules validated.
```

## Test plan

- [x] Phase 1 — Worktree fresh start (`down -v`, `build --no-cache`, `up -d`) shows `✓ Build complete` + four native modules pass
- [x] Phase 2 — Partial-install repro (rm turbo) PRE-fix emits `sh: 1: turbo: not found`
- [x] Phase 3 — Same scenario POST-fix emits the new clear `partial install` message
- [x] Phase 4 — POST-fix happy path still completes `✓ Build complete`
- [x] `docker exec ... npm run preflight` clean
- [x] `docker exec ... npm run audit:standards` — 66 passed, 4 pre-existing warnings (unrelated)
- [x] `/concurrency-auditor` Mode B — no scannable hits (shell out of scope per skill surface)
- [x] `/governance` post-commit — clean
- [x] Pre-push hook (Docker mode via `SKILLSMITH_PRE_PUSH_DOCKER=1`, per SMI-4767 memory) — all test suites pass

## Out of scope

- Reporter's `npm install --prefix /app` injection — would mask future image-layer drift and re-run dependency resolution on every cold start.
- Generalising the pre-check to a list of expected binaries — defer until same class of bug appears for another binary.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)


[skip-impl-check]

This PR modifies a shell script (`docker-entrypoint.sh`) with no corresponding TypeScript implementation. The verify-implementation check requires this marker for non-`.ts`/`.tsx` source-only changes.
