### PR TITLE
chore(publish): SMI-4540 retire SKILLSMITH_NPM_TOKEN — OIDC-only npm publish

### DIFF
--- a/.claude/development/publishing-guide.md
+++ b/.claude/development/publishing-guide.md
@@ -22,7 +22,7 @@ gh workflow run publish.yml -f dry_run=false
 gh run watch <run-id> --exit-status              # Monitor progress
 ```
 
-npmjs.org publishes (`@skillsmith/{core,mcp-server,cli}`) authenticate via npm trusted-publisher OIDC (SMI-4539, landed) — the `id-token: write` permission was granted in SMI-4533. The `SKILLSMITH_NPM_TOKEN` secret is retained only as an automatic in-workflow fallback: if OIDC fails, the publish job retries with the token (a loud `::warning::`, not a hard failure) so the release still ships. SMI-4540 retires the token once a real OIDC release has run clean. `@smith-horn/enterprise` publishes to GitHub Packages via `GITHUB_TOKEN` (npm trusted-publishing is npmjs.org-only). Publishes in dependency order (core → mcp-server, cli, enterprise) with validation, smoke tests, and MCP Registry publish.
+npmjs.org publishes (`@skillsmith/{core,mcp-server,cli}`) authenticate via npm trusted-publisher OIDC (SMI-4539 landed; SMI-4540 retired the token fallback on 2026-05-19 after the granular token was revoked). Trusted-publisher entries on npmjs.com for each package point at `smith-horn/skillsmith` + `publish.yml`; if OIDC fails for any reason the publish job fails loudly with no fallback. `@smith-horn/enterprise` publishes to GitHub Packages via `GITHUB_TOKEN` (npm trusted-publishing is npmjs.org-only). Publishes in dependency order (core → mcp-server, cli, enterprise) with validation, smoke tests, and MCP Registry publish.
 
 If CI fails, fix CI. Do not reach for a local publish — see [`publish-ci-recovery.md`](../../docs/internal/runbooks/publish-ci-recovery.md) for triage.
 
@@ -43,7 +43,7 @@ The previous "local fallback" recipe (`source .env && npm publish`) is **gone**.
 
 Why: every "we couldn't get CI to publish so we did it locally" commit in the changelog mapped to a regression that CI's guards would have caught. Closing this loophole forces the only path that carries our published-version history.
 
-`npm publish --ignore-scripts` skips `prepublishOnly`. The binding gate is npm trusted-publisher OIDC (SMI-4539, landed — OIDC primary, `SKILLSMITH_NPM_TOKEN` retained as an in-workflow fallback pending SMI-4540, which retires the token). The host-side guard plus token-scoped 2FA and CI-only secret access remain the layers protecting the fallback token until SMI-4540 lands.
+`npm publish --ignore-scripts` skips `prepublishOnly`. The binding gate is npm trusted-publisher OIDC (SMI-4540 — OIDC-only, no token fallback). The host-side `prepublishOnly` guard plus npmjs.com 2FA on the publisher account remain the residual layers.
 
 ## Break-Glass
 

--- a/.claude/development/vscode-publishing-guide.md
+++ b/.claude/development/vscode-publishing-guide.md
@@ -96,7 +96,7 @@ The same rule applies to all public-facing CHANGELOGs in this repo (`packages/*/
 | Dependencies | Ships `node_modules` | `--no-dependencies` (esbuild bundles) |
 | Name | Scoped (`@skillsmith/core`) | Unscoped (`skillsmith-vscode`) |
 | Registry | npmjs.com | marketplace.visualstudio.com |
-| Auth | `SKILLSMITH_NPM_TOKEN` | `VSCE_SKILLSMITH` / `VSCE_PAT` |
+| Auth | npm trusted-publisher OIDC (SMI-4540) | `VSCE_SKILLSMITH` / `VSCE_PAT` |
 | Smoke test | `scripts/smoke-test-published.ts` | `code --install-extension` |
 
 ## Troubleshooting

--- a/.env.schema
+++ b/.env.schema
@@ -81,15 +81,6 @@ GITHUB_CLIENT_SECRET=
 # @type=string @required=false @sensitive
 VSCE_SKILLSMITH=
 
-# NPM Publish Token - Fine-grained token for @skillsmith packages
-# CI-only secret. Local-publish is forbidden (SMI-4533). Token is deprecated;
-# SMI-4540 tracks deletion after OIDC stabilizes (SMI-4539).
-# Created: March 27, 2026 | Expires: June 25, 2026 (90 days)
-# Get from: npmjs.com → Access Tokens → Generate New Token → Granular Access Token
-# Scope: @skillsmith organization (read and write)
-# @type=string(startsWith=npm_) @sensitive @required=false
-SKILLSMITH_NPM_TOKEN=
-
 # Anthropic API Key - For Claude API calls
 # @type=string(startsWith=sk-ant-) @sensitive
 # ANTHROPIC_API_KEY=

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -462,12 +462,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [pre-publish-check, validate]
-    # SMI-4533/SMI-4539: id-token: write enables npm trusted-publisher OIDC.
-    # SMI-4539 landed the flip — OIDC is now the primary publish path; the
-    # SKILLSMITH_NPM_TOKEN remains wired only as an automatic in-workflow
-    # fallback for one release cycle. SMI-4540 retires the token entirely once
-    # a real OIDC release has run clean. Keeping this job-scoped (not
-    # workflow-scoped) for least privilege.
+    # SMI-4540: id-token: write enables npm trusted-publisher OIDC, which is now
+    # the sole auth path for npm publish (granular token revoked 2026-05-19).
+    # Job-scoped (not workflow-scoped) for least privilege.
     permissions:
       contents: read
       id-token: write
@@ -544,59 +541,20 @@ jobs:
           fi
           echo "✓ npm $ACTUAL"
 
-      # SMI-4539: the three steps below replace the former single `Publish core`
-      # step. They form one unit: OIDC-primary publish, token-fallback (only
-      # when OIDC fails), and a verify gate that fails the job unless the exact
-      # version is live on npm. The verify step is what prevents a green job
-      # without a real publish — the OIDC step's continue-on-error alone could
-      # otherwise let the job pass with nothing published.
-      - name: Publish core (OIDC)
+      # SMI-4540: OIDC-only publish. The token fallback (SMI-4539) was removed
+      # after the granular npm token was revoked on 2026-05-19; trusted-publisher
+      # config on npmjs.com is the sole auth path. The verify step is a
+      # post-publish visibility check — `npm publish` exiting 0 doesn't
+      # guarantee the registry CDN has the version yet.
+      - name: Publish core
         id: publish-core-oidc
         if: steps.version-check.outputs.exists != 'true'
-        # audit:allow-continue-on-error — SMI-4539: unlike the SMI-4534
-        # MCP-registry markers (where the registry publish is non-load-bearing
-        # and npm publish is the binding artifact), this OIDC step IS
-        # load-bearing. continue-on-error here exists solely so the
-        # token-fallback step below can act as its hard backstop on OIDC
-        # failure; the `Verify core on npm` step still gates job success.
-        continue-on-error: true
         run: |
           npm publish -w @skillsmith/core --access public
-          echo "::notice::OIDC publish succeeded; token-fallback step will be skipped (expected)"
-
-      - name: Publish core (token fallback — skipped when OIDC succeeds)
-        if: steps.version-check.outputs.exists != 'true' && steps.publish-core-oidc.outcome == 'failure'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.SKILLSMITH_NPM_TOKEN }}
-        run: |
-          set -uo pipefail
-          VERSION=$(jq -r .version packages/core/package.json)
-          if npm publish -w @skillsmith/core --access public --provenance; then
-            PUBLISHED_VIA_FALLBACK=true
-          else
-            # Tolerate an "already published" race ONLY if the exact intended
-            # version is confirmed live on npm; otherwise fail the job.
-            LIVE=$(npm view "@skillsmith/core@${VERSION}" version 2>/dev/null || echo '')
-            if [ "$LIVE" = "$VERSION" ]; then
-              echo "::notice::npm publish reported a conflict but @skillsmith/core@${VERSION} is already live — tolerating."
-              PUBLISHED_VIA_FALLBACK=true
-            else
-              echo "::error::Token-fallback publish failed and @skillsmith/core@${VERSION} is not live on npm."
-              exit 1
-            fi
-          fi
-          if [ "${PUBLISHED_VIA_FALLBACK:-}" = "true" ]; then
-            MSG="OIDC publish failed for @skillsmith/core@${VERSION} — release SUCCEEDED via the SKILLSMITH_NPM_TOKEN fallback. Action required before SMI-4540: investigate the npmjs.com trusted-publisher config for @skillsmith/core."
-            echo "::warning::${MSG}"
-            {
-              echo "## ⚠️ @skillsmith/core published via token fallback"
-              echo ""
-              echo "${MSG}"
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          echo "::notice::OIDC publish succeeded for @skillsmith/core"
 
       - name: Verify core on npm
-        if: steps.publish-core-oidc.outcome == 'failure' || steps.publish-core-oidc.outcome == 'success'
+        if: steps.publish-core-oidc.outcome == 'success'
         run: |
           VERSION=$(jq -r .version packages/core/package.json)
           # Retry to absorb npm registry/CDN propagation lag right after publish —
@@ -619,10 +577,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [pre-publish-check, validate, publish-core]
-    # SMI-4534: id-token: write enables `mcp-publisher login github-oidc` for the MCP
-    # Registry publish step. Job-scoped (not workflow-scoped) for least privilege —
-    # sibling publish-* jobs do not need OIDC. contents: read overrides the workflow
-    # default of contents: write since this job does not push tags or releases.
+    # id-token: write enables two OIDC paths in this job:
+    # - SMI-4534: `mcp-publisher login github-oidc` for the MCP Registry publish step
+    # - SMI-4540: npm trusted-publisher OIDC for the npm publish step (sole npm auth
+    #   path; granular token revoked 2026-05-19)
+    # Job-scoped (not workflow-scoped) for least privilege. contents: read overrides
+    # the workflow default of contents: write since this job does not push tags or releases.
     permissions:
       contents: read
       id-token: write
@@ -702,61 +662,19 @@ jobs:
           fi
           echo "✓ npm $ACTUAL"
 
-      # SMI-4539: the three steps below replace the former single
-      # `Publish mcp-server` step. They form one unit: OIDC-primary publish,
-      # token-fallback (only when OIDC fails), and a verify gate that fails the
-      # job unless the exact version is live on npm. The verify step is what
-      # prevents a green job without a real publish — the OIDC step's
-      # continue-on-error alone could otherwise let the job pass with nothing
-      # published. (The MCP-registry steps further below are unrelated — they
-      # were already OIDC since SMI-4534.)
-      - name: Publish mcp-server (OIDC)
+      # SMI-4540: OIDC-only publish. The token fallback (SMI-4539) was removed
+      # after the granular npm token was revoked on 2026-05-19; trusted-publisher
+      # config on npmjs.com is the sole auth path. (The MCP-registry steps
+      # further below are unrelated — they were already OIDC since SMI-4534.)
+      - name: Publish mcp-server
         id: publish-mcp-server-oidc
         if: steps.version-check.outputs.exists != 'true'
-        # audit:allow-continue-on-error — SMI-4539: unlike the SMI-4534
-        # MCP-registry markers (where the registry publish is non-load-bearing
-        # and npm publish is the binding artifact), this OIDC step IS
-        # load-bearing. continue-on-error here exists solely so the
-        # token-fallback step below can act as its hard backstop on OIDC
-        # failure; the `Verify mcp-server on npm` step still gates job success.
-        continue-on-error: true
         run: |
           npm publish -w @skillsmith/mcp-server --access public
-          echo "::notice::OIDC publish succeeded; token-fallback step will be skipped (expected)"
-
-      - name: Publish mcp-server (token fallback — skipped when OIDC succeeds)
-        if: steps.version-check.outputs.exists != 'true' && steps.publish-mcp-server-oidc.outcome == 'failure'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.SKILLSMITH_NPM_TOKEN }}
-        run: |
-          set -uo pipefail
-          VERSION=$(jq -r .version packages/mcp-server/package.json)
-          if npm publish -w @skillsmith/mcp-server --access public --provenance; then
-            PUBLISHED_VIA_FALLBACK=true
-          else
-            # Tolerate an "already published" race ONLY if the exact intended
-            # version is confirmed live on npm; otherwise fail the job.
-            LIVE=$(npm view "@skillsmith/mcp-server@${VERSION}" version 2>/dev/null || echo '')
-            if [ "$LIVE" = "$VERSION" ]; then
-              echo "::notice::npm publish reported a conflict but @skillsmith/mcp-server@${VERSION} is already live — tolerating."
-              PUBLISHED_VIA_FALLBACK=true
-            else
-              echo "::error::Token-fallback publish failed and @skillsmith/mcp-server@${VERSION} is not live on npm."
-              exit 1
-            fi
-          fi
-          if [ "${PUBLISHED_VIA_FALLBACK:-}" = "true" ]; then
-            MSG="OIDC publish failed for @skillsmith/mcp-server@${VERSION} — release SUCCEEDED via the SKILLSMITH_NPM_TOKEN fallback. Action required before SMI-4540: investigate the npmjs.com trusted-publisher config for @skillsmith/mcp-server."
-            echo "::warning::${MSG}"
-            {
-              echo "## ⚠️ @skillsmith/mcp-server published via token fallback"
-              echo ""
-              echo "${MSG}"
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          echo "::notice::OIDC publish succeeded for @skillsmith/mcp-server"
 
       - name: Verify mcp-server on npm
-        if: steps.publish-mcp-server-oidc.outcome == 'failure' || steps.publish-mcp-server-oidc.outcome == 'success'
+        if: steps.publish-mcp-server-oidc.outcome == 'success'
         run: |
           VERSION=$(jq -r .version packages/mcp-server/package.json)
           # Retry to absorb npm registry/CDN propagation lag right after publish —
@@ -856,11 +774,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [pre-publish-check, validate, publish-core]
-    # SMI-4533/SMI-4539: id-token: write enables npm trusted-publisher OIDC.
-    # SMI-4539 landed the flip — OIDC is now the primary publish path; the
-    # SKILLSMITH_NPM_TOKEN remains wired only as an automatic in-workflow
-    # fallback for one release cycle. SMI-4540 retires the token once a real
-    # OIDC release has run clean.
+    # SMI-4540: id-token: write enables npm trusted-publisher OIDC, which is now
+    # the sole auth path for npm publish (granular token revoked 2026-05-19).
     permissions:
       contents: read
       id-token: write
@@ -937,59 +852,18 @@ jobs:
           fi
           echo "✓ npm $ACTUAL"
 
-      # SMI-4539: the three steps below replace the former single `Publish cli`
-      # step. They form one unit: OIDC-primary publish, token-fallback (only
-      # when OIDC fails), and a verify gate that fails the job unless the exact
-      # version is live on npm. The verify step is what prevents a green job
-      # without a real publish — the OIDC step's continue-on-error alone could
-      # otherwise let the job pass with nothing published.
-      - name: Publish cli (OIDC)
+      # SMI-4540: OIDC-only publish. The token fallback (SMI-4539) was removed
+      # after the granular npm token was revoked on 2026-05-19; trusted-publisher
+      # config on npmjs.com is the sole auth path.
+      - name: Publish cli
         id: publish-cli-oidc
         if: steps.version-check.outputs.exists != 'true'
-        # audit:allow-continue-on-error — SMI-4539: unlike the SMI-4534
-        # MCP-registry markers (where the registry publish is non-load-bearing
-        # and npm publish is the binding artifact), this OIDC step IS
-        # load-bearing. continue-on-error here exists solely so the
-        # token-fallback step below can act as its hard backstop on OIDC
-        # failure; the `Verify cli on npm` step still gates job success.
-        continue-on-error: true
         run: |
           npm publish -w @skillsmith/cli --access public
-          echo "::notice::OIDC publish succeeded; token-fallback step will be skipped (expected)"
-
-      - name: Publish cli (token fallback — skipped when OIDC succeeds)
-        if: steps.version-check.outputs.exists != 'true' && steps.publish-cli-oidc.outcome == 'failure'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.SKILLSMITH_NPM_TOKEN }}
-        run: |
-          set -uo pipefail
-          VERSION=$(jq -r .version packages/cli/package.json)
-          if npm publish -w @skillsmith/cli --access public --provenance; then
-            PUBLISHED_VIA_FALLBACK=true
-          else
-            # Tolerate an "already published" race ONLY if the exact intended
-            # version is confirmed live on npm; otherwise fail the job.
-            LIVE=$(npm view "@skillsmith/cli@${VERSION}" version 2>/dev/null || echo '')
-            if [ "$LIVE" = "$VERSION" ]; then
-              echo "::notice::npm publish reported a conflict but @skillsmith/cli@${VERSION} is already live — tolerating."
-              PUBLISHED_VIA_FALLBACK=true
-            else
-              echo "::error::Token-fallback publish failed and @skillsmith/cli@${VERSION} is not live on npm."
-              exit 1
-            fi
-          fi
-          if [ "${PUBLISHED_VIA_FALLBACK:-}" = "true" ]; then
-            MSG="OIDC publish failed for @skillsmith/cli@${VERSION} — release SUCCEEDED via the SKILLSMITH_NPM_TOKEN fallback. Action required before SMI-4540: investigate the npmjs.com trusted-publisher config for @skillsmith/cli."
-            echo "::warning::${MSG}"
-            {
-              echo "## ⚠️ @skillsmith/cli published via token fallback"
-              echo ""
-              echo "${MSG}"
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          echo "::notice::OIDC publish succeeded for @skillsmith/cli"
 
       - name: Verify cli on npm
-        if: steps.publish-cli-oidc.outcome == 'failure' || steps.publish-cli-oidc.outcome == 'success'
+        if: steps.publish-cli-oidc.outcome == 'success'
         run: |
           VERSION=$(jq -r .version packages/cli/package.json)
           # Retry to absorb npm registry/CDN propagation lag right after publish —


### PR DESCRIPTION
## Summary

- Retires the `SKILLSMITH_NPM_TOKEN` token-fallback path from `publish.yml` after the granular npm token was revoked on 2026-05-19.
- Drops the `.env.schema` block + updates publishing-guide narrative to reflect OIDC-only auth (npm trusted-publisher, SMI-4539 landed).
- The fallback is now dead weight — if it ever fired, `npm publish` would 401 with a revoked token, blocking the release more loudly than necessary.

## Context

An audit triggered by a phishing email impersonating npm Security on 2026-05-19 surfaced that the `SKILLSMITH_NPM_TOKEN` had been vestigial since SMI-4539 (OIDC switch, 2026-05-17). Ryan verified OIDC trusted-publisher config on npmjs.com for all three public packages (`@skillsmith/{core,mcp-server,cli}`) pointing at `smith-horn/skillsmith` + `publish.yml`, then deleted the granular token. This PR completes the SMI-4540 cleanup that was already planned. Full audit + decision: comment on SMI-4540.

## Changes

| File | What |
|------|------|
| `.github/workflows/publish.yml` | Remove three `Publish <pkg> (token fallback)` steps + `NODE_AUTH_TOKEN: SKILLSMITH_NPM_TOKEN` env entries. Drop `continue-on-error: true` + audit:allow markers (no fallback to backstop). Simplify `Verify` conditions to gate on `outcome == 'success'`. Update job-level narrative comments. -158 lines net. |
| `.env.schema` | Drop the SKILLSMITH_NPM_TOKEN block. |
| `.claude/development/publishing-guide.md` | Rewrite OIDC + fallback narrative as OIDC-only. |
| `.claude/development/vscode-publishing-guide.md` | Update npm vs vsce auth comparison row. |

`@smith-horn/enterprise` is unaffected — it publishes to GitHub Packages via `GITHUB_TOKEN`, not npm trusted-publishing.

## Risk

If any of the three public packages has a typo in its npmjs.com trusted-publisher config, that package's next publish will fail at the OIDC step with no fallback. Mitigation: Ryan verified the config visually for all three before deleting the token (recorded on SMI-4540). Recovery: ~5 min to regenerate a granular token + re-add the fallback step (revert this PR).

## Test plan

- [x] `docker exec skillsmith-dev-1 npm run audit:standards` (65 passed, 5 unrelated warnings about strategy submodule network)
- [x] `node -e "yaml.load(...)"` confirms `publish.yml` parses cleanly (10 jobs intact)
- [x] `grep -c SKILLSMITH_NPM_TOKEN` returns 0 in all touched files
- [ ] CI green on this PR (Docker build + validate + lint + audit)
- [ ] Post-merge: `gh secret delete SKILLSMITH_NPM_TOKEN` + remove from local `.env` + close SMI-4540 (tracked separately)
- [ ] Next mcp-server / cli release: verify `OIDC publish succeeded` notice appears in run log

## Out of scope

- `docs/internal/runbooks/publish-ci-recovery.md` + `docs/internal/architecture/infrastructure-inventory.md` still reference `SKILLSMITH_NPM_TOKEN`. That submodule is currently on another active branch (`smi-4870-cron-split-plan`); will be cleaned up in a separate commit on that submodule. Historical retros/implementation plans referencing the old token are intentionally left as snapshots.
- SMI-4996 (capture inbound email auth-results) — filed separately for the phishing-classification gap that surfaced during this audit.