### PR TITLE
chore(scripts): SMI-4999 — pooler-psql-session.sh + CLAUDE.md pooler choice guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Git-crypt smudge filters can silently switch branches during stash/pop (includin
 
 **All secrets via Varlock. Never expose API keys in terminal output.** Commit `.env.schema` (defines `@sensitive`) and `.env.example` (placeholders); **never** `.env`. Run with secrets: `varlock run -- npm test`. Validate: `varlock load` (masked). **Never** `echo $SECRET` or `cat .env`. Never ask users to paste secrets in chat. See [AI Agent Secret Handling](docs/internal/architecture/standards-security.md#411-ai-agent-secret-handling-smi-1956).
 
-**Supabase pooler access**: `SUPABASE_POOLER_URL` has a literal `[YOUR-PASSWORD]` placeholder. Use the canonical helper: `varlock run -- ./scripts/pooler-psql.sh`. Routes through transaction pooler (port 6543), avoiding PostgREST's 8s `statement_timeout`. Requires Docker container running. Full rationale: script header.
+**Supabase pooler access**: `SUPABASE_POOLER_URL` has a literal `[YOUR-PASSWORD]` placeholder. Two canonical helpers, both via `varlock run --` (host tool — not inside the container): `./scripts/pooler-psql.sh` (transaction pooler, port 6543) for ad-hoc queries, single-statement DDL, short writes — bypasses PostgREST's 8s `statement_timeout`. `./scripts/pooler-psql-session.sh` (session pooler, port 5432) for long-running maintenance — `VACUUM`, `REINDEX CONCURRENTLY`, stored procedures with `COMMIT` between batches, anything where the transaction pooler returns `ECHECKOUTTIMEOUT` (SMI-4968 retro / SMI-4999). Requires Docker container running. Full rationale: script headers.
 
 ---
 

--- a/scripts/pooler-psql-session.sh
+++ b/scripts/pooler-psql-session.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# pooler-psql-session.sh — canonical entry point for psql against the Supabase
+# SESSION pooler (port 5432). Sibling of pooler-psql.sh. SMI-4999.
+#
+# When to use this vs pooler-psql.sh:
+#   ./scripts/pooler-psql.sh         (port 6543, transaction pooler)
+#     — ad-hoc queries, single-statement DDL, short writes. Each statement
+#       is its own transaction at the pooler level.
+#   ./scripts/pooler-psql-session.sh (port 5432, session pooler)         <-- here
+#     — long-running maintenance. Use when ANY of:
+#         * VACUUM, REINDEX CONCURRENTLY (or any operation past a few seconds)
+#         * Stored procedure with COMMIT between batches (CREATE PROCEDURE
+#           ... LANGUAGE plpgsql AS $$ ... LOOP ... COMMIT; ... END LOOP $$;
+#           called via CALL — transaction-pooler mode rejects COMMIT inside
+#           a CALL because each transaction may swap server connections)
+#         * The transaction pooler returns FATAL: (ECHECKOUTTIMEOUT) — i.e.
+#           its server-connection budget is exhausted by your workload
+#         * You need a multi-statement session bound to one server connection
+#
+# Why the choice exists at all: the transaction pooler is sized for short
+# statements and aggressively reuses server connections per transaction; the
+# session pooler holds a dedicated server connection for the client's whole
+# session, which is what long-running maintenance needs.
+#
+# Both poolers route through aws-1-us-east-1.pooler.supabase.com. PostgREST
+# also runs at this hostname and aborts long queries at statement_timeout=8s
+# (error 57014); both poolers bypass that. The choice between ports is purely
+# transaction-mode vs session-mode (PgBouncer / Supavisor mode).
+#
+# Provenance: SMI-4968 prod runbook — a 6M-row search:metrics purge from
+# audit_logs and a follow-up REINDEX CONCURRENTLY repeatedly hit
+# ECHECKOUTTIMEOUT on the transaction pooler. The same workload ran cleanly
+# as a procedure with `SET statement_timeout = 0` and COMMIT per batch via
+# this session pooler. See docs/internal/implementation/smi-4968-supabase-disk-io.md
+# for the full retro and exact statement shapes.
+#
+# Usage:
+#   varlock run -- ./scripts/pooler-psql-session.sh -c 'CALL my_proc();'
+#   varlock run -- ./scripts/pooler-psql-session.sh -f maintenance.sql
+#   echo 'VACUUM (ANALYZE) my_table;' | varlock run -- ./scripts/pooler-psql-session.sh
+#   varlock run -- ./scripts/pooler-psql-session.sh --help
+#
+# Requires:
+#   - Docker container skillsmith-dev-1 running (provides psql 15+)
+#   - `varlock run --` prefix to supply SUPABASE_PROJECT_REF +
+#     SUPABASE_DB_PASSWORD without leaking them to the terminal
+
+set -eu
+
+: "${SUPABASE_PROJECT_REF:?must be set — run via 'varlock run -- ./scripts/pooler-psql-session.sh ...'}"
+: "${SUPABASE_DB_PASSWORD:?must be set — run via 'varlock run -- ./scripts/pooler-psql-session.sh ...'}"
+
+if ! docker inspect skillsmith-dev-1 --format '{{.State.Running}}' 2>/dev/null | grep -q '^true$'; then
+  echo "error: skillsmith-dev-1 container is not running. Start it with:" >&2
+  echo "  docker compose --profile dev up -d" >&2
+  exit 1
+fi
+
+exec docker exec -i \
+  -e PGHOST="aws-1-us-east-1.pooler.supabase.com" \
+  -e PGPORT="5432" \
+  -e PGUSER="postgres.${SUPABASE_PROJECT_REF}" \
+  -e PGPASSWORD="${SUPABASE_DB_PASSWORD}" \
+  -e PGDATABASE="postgres" \
+  skillsmith-dev-1 psql "$@"

--- a/scripts/pooler-psql.sh
+++ b/scripts/pooler-psql.sh
@@ -13,6 +13,13 @@
 # audit_logs LIKE queries at statement_timeout 8s (error 57014). Transaction
 # pooler bypasses that. Do not regress away from this.
 #
+# See also: pooler-psql-session.sh — session pooler (port 5432) sibling for
+# long-running maintenance (VACUUM, REINDEX CONCURRENTLY, procedures with
+# COMMIT between batches). The transaction pooler can return FATAL:
+# (ECHECKOUTTIMEOUT) when its server-connection budget is exhausted by such
+# workloads; the session pooler holds a dedicated server connection for the
+# duration. SMI-4968 retro / SMI-4999.
+#
 # Usage:
 #   varlock run -- ./scripts/pooler-psql.sh -c 'SELECT version();'
 #   echo 'SELECT 1;' | varlock run -- ./scripts/pooler-psql.sh


### PR DESCRIPTION
## Context

SMI-4968 prod-runbook follow-up. Two operational learnings worth capturing on forward-looking surfaces:

**1. Pooler choice for long-running maintenance.** The transaction pooler (`aws-1-us-east-1.pooler.supabase.com:6543`) repeatedly returned `FATAL: (ECHECKOUTTIMEOUT)` during a 6M-row purge + VACUUM. The session pooler (same host, port **5432**) ran the same workload cleanly — `VACUUM`, `REINDEX CONCURRENTLY`, and a `CALL` to a procedure with `COMMIT` between batches. Root cause: transaction pooler is sized for short statements; long-held server connections and procedures-with-`COMMIT` exceed its budget.

**2. `varlock` is a host tool.** The SMI-4968 runbook had `docker exec skillsmith-dev-1 varlock run -- ./scripts/pooler-psql.sh …` — varlock isn't in the container's PATH. Correct: `varlock run -- ./scripts/pooler-psql.sh …`. The canonical `pooler-psql.sh` header already says so; the runbook doc was inconsistent.

## Changes

1. **New** `scripts/pooler-psql-session.sh` — sibling of `pooler-psql.sh` on port 5432. Header documents *when* to reach for each pooler (with the ECHECKOUTTIMEOUT failure mode and procedure-with-COMMIT example) and cites the SMI-4968 retro.
2. `scripts/pooler-psql.sh` **header** — "See also" line cross-referencing the session variant.
3. **CLAUDE.md "Varlock Security" section** — one-paragraph rewrite pointing to both helpers with brief when-to-use-each.

## Skipped (deliberately)

Editing `docs/internal/implementation/smi-4968-supabase-disk-io.md` — it's a historical retrospective. Future maintenance authors should find the canonical scripts via CLAUDE.md / `grep scripts/pooler*`, not copy from old retros. The durable knowledge belongs on forward-looking surfaces.

## Verification

Live-tested the new script against prod:

```
$ varlock run -- ./scripts/pooler-psql-session.sh -c "SELECT inet_server_port(), current_setting('server_version');"
 inet_server_port | current_setting
------------------+-----------------
             5432 | 17.6
```

Linear: SMI-4999

[skip-impl-check]