### PR TITLE
docs(edge): SMI-4963 PR C — auth-matrix canonical helper + scan-all-of-X + implausible-count guard

### DIFF
--- a/.claude/development/edge-function-patterns.md
+++ b/.claude/development/edge-function-patterns.md
@@ -221,6 +221,41 @@ if (!secret) {
 
 ---
 
+## External-fetch parsers: the implausible-count guard
+
+When an edge function parses HTML, CSV, or other markup fetched from an
+external service (anything you don't control end-to-end), assert that the
+parsed row/record count falls within a plausible band BEFORE acting on it.
+A markup change that silently drops your selector returns `parseCount = 0`
+(or `1`, or `N << expected`), and the downstream "scan everything we got"
+loop quietly does nothing.
+
+Caught twice in one week: SMI-4961 (`leaderboard-coverage.test.ts` skill-list
+parser) and SMI-4963 (`coverage-report` weekly leaderboard fetch) — both
+would have shipped silent no-ops to prod without the guard.
+
+```typescript
+const PLAUSIBLE_MIN = 100   // raise the floor; this is a sanity check, not a target
+const PLAUSIBLE_MAX = 2000  // ceiling; raise as the population grows
+
+const rows = parseLeaderboard(html)
+if (rows.length < PLAUSIBLE_MIN || rows.length > PLAUSIBLE_MAX) {
+  console.warn(
+    `[parser] Implausible row count ${rows.length} ` +
+      `(expected ${PLAUSIBLE_MIN}-${PLAUSIBLE_MAX}) — treating as parse failure`
+  )
+  return { rows: [], fetchFailed: true }
+}
+```
+
+Pair with a unit test that feeds the parser HTML with a deliberately-broken
+selector and asserts the implausible-count branch fires (`leaderboard-fetch.
+test.ts` has the canonical pattern). The guard is an active asset, not a
+defensive nicety — leave it on, raise the floor over time, and treat any
+"implausible" warning in prod logs as an incident, not noise.
+
+---
+
 ## Testing Edge Functions with Vitest
 
 ### The Module-Load-Time Problem
@@ -332,7 +367,9 @@ Authoritative auth/JWT-verification table for every edge function. CLAUDE.md kee
 | `auth-device-preview` | Authenticated (User JWT, gateway-verified) | No |
 | `indexer-dispatch` | Service Role (explicit bearer check + `verify_jwt=true`); invoked from cron/manual operator curl. Mints GitHub App installation token and POSTs `repository_dispatch` to GHA `indexer.yml`. (SMI-4852) | No |
 
-**Adding anonymous functions** (CI validates): Add to `supabase/config.toml` with `verify_jwt = false`, add to `NO_VERIFY_JWT_FUNCTIONS` in `scripts/audit-standards.mjs`, and add deploy command to `CLAUDE.md` (the deploy block is CI-pinned via `audit-standards.mjs:472` + `validate-anonymous-functions.ts`).
+**Adding anonymous functions** (CI validates): Add to `supabase/config.toml` with `verify_jwt = false`, add to `NO_VERIFY_JWT_FUNCTIONS` in `scripts/audit-standards.mjs`, and add deploy command to `CLAUDE.md` (the deploy block is CI-pinned via `audit-standards.mjs:472` + `validate-anonymous-functions.ts`). `audit:standards` Check 47 (SMI-4963) additionally enforces that every function appears in EXACTLY ONE of `deploy-edge-functions.sh`'s `NO_VERIFY_JWT_FUNCTIONS` / `VERIFY_JWT_FUNCTIONS` AND EXACTLY ONE of `validate-edge-functions.sh`'s `ANONYMOUS_FUNCTIONS` / `AUTHENTICATED_FUNCTIONS` / `SERVICE_ROLE_FUNCTIONS`, AND that `NO_VERIFY_JWT_FUNCTIONS` members carry a matching `[functions.<name>] verify_jwt = false` in `config.toml`.
+
+**In-handler bearer checks**: use the canonical `isServiceRoleCaller` helper from `supabase/functions/_shared/auth.ts` (reads the gateway-verified bearer's `role` claim). Never raw-string-compare against `` `Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')}` `` — the GHA-secret value and the platform-injected edge-function env value are both service-role JWTs but need not be byte-identical (different signing rounds, independent rotation), so a string-equality check can 401 a legitimate caller. The SMI-4963 dry-run smoke surfaced exactly this: a raw compare 401'd the coverage-report workflow caller because the two values diverged by one byte.
 
 ## Project Refs (Prod vs Staging)
 
@@ -348,6 +385,38 @@ When verifying a prod edge function via `curl`, always use `$SUPABASE_URL` (unde
 ## Auto-deploy
 
 Edge functions are automatically deployed to **both** prod (`vrcnzpmndtroqxxoqkzy`) and staging (`ovhcifugwqnzoebwfuku`) when changes to `supabase/functions/**` are merged to main. The `deploy-edge-functions.yml` workflow detects changed functions and runs `deploy-prod` and `deploy-staging` jobs in parallel; failure of one does not block the other. `_shared/` changes trigger a full deploy of all 32 functions to both refs. Manual full deploy: `gh workflow run deploy-edge-functions.yml -f deploy_all=true`. (SMI-4528)
+
+## Scan-all-of-X: edge function vs GHA-runner
+
+Supabase edge functions cap at a **150-second wall clock** (`IDLE_TIMEOUT`).
+Any "scan all of X" pattern — every repo, every skill, every license probe,
+every leaderboard row — eventually crosses that wall as the population grows.
+When it crosses, the function times out, the cron silently produces no data,
+and the next iteration starts from the same too-large work-set.
+
+Lineage of this lesson in Skillsmith:
+
+| SMI | Symptom | Fix |
+|-----|---------|-----|
+| SMI-4843 | Indexer started missing repos at scale | Investigated — capacity bounded |
+| SMI-4846 | Edge-function `indexer` hit 150s ceiling at ~7k skills | Diagnostic dry-run + page caps |
+| SMI-4852 | `indexer-dispatch` shim → moves `indexer` to GHA-runner (no wall clock) | Tier-2 GHA workflow + repository_dispatch |
+| SMI-4963 | `coverage-report` 150s wall (license-probe storm × 27 repos) | Soften + instrument; concurrency cap |
+| SMI-4997 | Same wall as 4963 persists post-mitigation | Pending: license-probe retry storm vs `repo_url` index vs GHA-runner |
+
+Decision checklist BEFORE picking edge-function for a scan-all workload:
+
+1. **Does N × per-item cost plausibly exceed 30s today?** (Budget: 30s gives 5× headroom against the 150s ceiling for tail variance + retries.)
+2. **Will N grow?** (Skills, repos, users, ecosystems — count anything that's been added monotonically for >6 months.)
+3. **Does the per-item op require external HTTP / retries?** (Per-item retry storms eat seconds fast; observed in SMI-4963: 3 retries × 270ms × 27 repos = 22s just for retries.)
+
+**Two or more "yes" answers** → choose the GHA-runner path from the start
+(repository_dispatch + GHA workflow + `indexer-dispatch`-style trigger
+shim). Retrofitting an edge function to a GHA runner is feasible but
+costly (3 fully-merged PRs minimum: trigger shim, GHA workflow, deploy
+plumbing); building it as GHA from day one is one PR.
+
+For Tier-2 GHA-runner pattern reference see `supabase/functions/indexer-dispatch/index.ts` + `.github/workflows/indexer.yml`.
 
 ## Related Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ Vitest only runs tests matching these patterns. Tests elsewhere are **silently i
 
 When verifying a prod edge function via `curl`, always use `$SUPABASE_URL` (under `varlock run --`) or the literal `https://vrcnzpmndtroqxxoqkzy.supabase.co`. Function-auth matrix (21 rows) and auto-deploy mechanics: see [edge-function-patterns.md § Function Auth Matrix](.claude/development/edge-function-patterns.md#function-auth-matrix).
 
-**Adding anonymous functions** (CI validates): add to `supabase/config.toml` with `verify_jwt = false`, to `NO_VERIFY_JWT_FUNCTIONS` in `scripts/audit-standards.mjs`, and to the deploy block below. **Deploy commands** (`--no-verify-jwt` required — CI scans CLAUDE.md for these):
+**Adding anonymous functions** (CI validates): add to `supabase/config.toml` with `verify_jwt = false`, to `NO_VERIFY_JWT_FUNCTIONS` in `scripts/audit-standards.mjs`, and to the deploy block below; `npm run audit:standards` Check 47 (SMI-4963) enforces deploy-script + validate-script + `config.toml` registration coherence. **Deploy commands** (`--no-verify-jwt` required — CI scans CLAUDE.md for these):
 
 ```bash
 npx supabase functions deploy early-access-signup --no-verify-jwt


### PR DESCRIPTION
## Summary
Three retro-action documentation additions to `.claude/development/edge-function-patterns.md` plus a `CLAUDE.md` one-liner pointing at audit:standards Check 47. Closes the SMI-4963 retro four-lesson action set:

- **PR A** (#1231) — `_shared/auth.ts` canonical helper for Lesson 2.
- **PR B** (#1232) — `audit:standards` Check 47 for Lesson 1.
- **PR C** (this) — Lessons 3 + 4 + auth-matrix note + CLAUDE.md pointer.

## Doc changes

### `.claude/development/edge-function-patterns.md`

| Anchor | Addition | Lesson |
|---|---|---|
| Function Auth Matrix (~L335) | Note added: Check 47 enforces deploy-script + validate-script + config.toml; in-handler bearer checks MUST use `_shared/auth.ts` canonical helper (never raw-string-compare against `SUPABASE_SERVICE_ROLE_KEY`) | 1 + 2 |
| Between Common Issues (~L194) and Testing Edge Functions with Vitest (~L222) | NEW section: **External-fetch parsers: the implausible-count guard** — guard template + testing pattern reference. Caught two distinct silent-no-op failures in one week (SMI-4961 + SMI-4963). | 3 |
| Between Auto-deploy (~L348) and Related Documentation (~L352) | NEW section: **Scan-all-of-X: edge function vs GHA-runner** — SMI lineage table (SMI-4843 → 4846 → 4852 → 4963 → 4997) + three-question design-time decision checklist | 4 |

### `CLAUDE.md` (~L187)
One-line addendum to the existing "Adding anonymous functions" sentence referencing Check 47.

## Why doc-only for Lessons 3 + 4
Per the plan: Lesson 1 is an enforceable invariant (Check 47); Lesson 2 is a canonical helper (`_shared/auth.ts`); Lessons 3 + 4 are **design-decision documentation, not invariants**. There's no static check that meaningfully distinguishes "scan-all-of-X scaled past 30s" from "scan-all-of-X under 30s and likely to stay there" without knowing the per-item cost and the future population growth — that's a design call. Similarly, the implausible-count guard's PLAUSIBLE_MIN/MAX bands are application-specific and chosen by the author.

## Verification
- Visual review: 3 doc additions land at the right anchors, internal links resolve to existing in-repo files (`_shared/auth.ts` from PR A, `audit:standards` Check 47 from PR B).
- `npm run audit:standards` — clean.
- `npm run lint` — clean.

## Depends on
PR A (#1231) merged at e870fc4d (auth-matrix note references `_shared/auth.ts`).

## Plan
`docs/internal/implementation/smi-4963-retro-action-four-lessons.md`

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)