### PR TITLE
fix(worktree): SMI-4973 mark .mcp.json skip-worktree after auto-patch

### DIFF
--- a/.claude/development/git-crypt-guide.md
+++ b/.claude/development/git-crypt-guide.md
@@ -177,6 +177,53 @@ The script handles:
 
 **Existing worktrees**: Step 6 only runs during creation. If you have an existing worktree with a broken skillsmith MCP, apply the manual fix above. For the Step 4d / Step 7 `node_modules` symlink (SMI-4377), run `./scripts/repair-worktrees.sh` — idempotent, safe to re-run.
 
+### `.mcp.json` skip-worktree (SMI-4973)
+
+When `create-worktree.sh` finishes, the worktree's `.mcp.json` is
+**patched in place** (the `skillsmith` MCP command swaps from
+`./packages/mcp-server/dist/src/index.js` to `npx -y @skillsmith/mcp-server`
+because the worktree has no built `dist/`). The script then marks the
+file `skip-worktree` so `git status` stays clean despite the on-disk
+divergence from HEAD.
+
+**Verify your worktree is set up correctly**:
+
+```bash
+grep 'npx' .mcp.json          # working-tree content IS the npx form
+git ls-files -v .mcp.json     # lowercase 'S' = skip-worktree set
+```
+
+**Do NOT restore `.mcp.json` to HEAD.** The HEAD content (the dist path)
+does not work in a worktree — restoring it silently breaks the
+skillsmith MCP. If `git diff HEAD -- .mcp.json` shows a delta, that is
+expected and correct.
+
+**`skip-worktree`, not `assume-unchanged`**: `skip-worktree` is git's
+sanctioned mechanism for "I have intentionally modified this tracked
+file and never want it staged." `assume-unchanged` is a performance
+hint (skip the stat check) and does not guarantee the file won't be
+staged. See `git update-index --help`.
+
+**Legitimate `.mcp.json` change from a worktree** (e.g., adding a new
+MCP server):
+
+```bash
+git update-index --no-skip-worktree .mcp.json   # clear the bit
+# edit .mcp.json, git add, git commit, push
+git update-index --skip-worktree .mcp.json      # re-set the bit
+```
+
+**Pre-existing worktrees** created before SMI-4973 landed don't have
+the bit set. Run once per existing worktree:
+
+```bash
+cd .worktrees/<name>
+git update-index --skip-worktree .mcp.json
+```
+
+**If the bit is ever lost** (rare; some `git reset --hard` configs can
+clear it): re-set with `git update-index --skip-worktree .mcp.json`.
+
 **Strategy submodule init in worktrees (SMI-4829)**: `create-worktree.sh` calls `init-strategy-submodules.sh` after `git submodule update --init`. This wires sparse-checkout cones for the three strategy mount-points (`.claude/skills`, `.claude/plans`, `.claude/hive-mind`). External contributors without access to `smith-horn/skillsmith-strategy` see empty mount-points but no hard error (gate #3). To re-run manually in an existing worktree: `./scripts/init-strategy-submodules.sh` from the worktree root. Team members who skipped initial setup: `git submodule update --init .claude/skills .claude/plans .claude/hive-mind` then run the init script.
 
 **Supported worktree layouts (SMI-4654)**: Both `<repo-root>/.worktrees/<name>/` (the convention used by `create-worktree.sh`) AND nested `<repo-root>/<name>/` (worktree created directly under the repo root) are supported. `scripts/_lib.sh` computes the `node_modules` symlink depth dynamically, so either layout produces working symlinks. The `.worktrees/` convention is preferred — it keeps the repo root tidy and groups parallel work — but if you've already nested a worktree directly in the repo, you don't need to migrate it. Run `./scripts/repair-worktrees.sh` to refresh symlinks; `./scripts/verify-worktree-symlinks.sh` audits them and exits non-zero on any dangling link.

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -425,6 +425,10 @@ create_worktree() {
     # Step 6: Patch .mcp.json skillsmith entry for worktree compatibility
     info "Step 6: Patching .mcp.json (skillsmith → npx)..."
     patch_mcp_json "$worktree_path"
+    # SMI-4973: prevent the patched .mcp.json from leaking into PR commits.
+    # Per-worktree index — must run inside (cd "$worktree_path") subshell.
+    (cd "$worktree_path" && git update-index --skip-worktree .mcp.json)
+    success "  .mcp.json marked skip-worktree (SMI-4973)"
 
     echo ""
     success "Worktree created successfully!"


### PR DESCRIPTION
[skip-impl-check]

## Summary

Eliminate the recurring footgun where `create-worktree.sh`'s in-place `.mcp.json` patch (SMI-3031: skillsmith dispatch swap to `npx`) leaks into PR commits unless the contributor remembers to revert manually.

**Linear**: [SMI-4973](https://linear.app/smith-horn-group/issue/SMI-4973)
**SPARC plan**: `docs/internal/implementation/2026-05-19-smi-4973-mcp-json-skip-worktree.md`
**Code review**: `docs/internal/code_review/2026-05-19-smi-4973-mcp-skip-worktree.md`

## What changes

1. **`scripts/create-worktree.sh`** (+4 lines, after L427): Immediately after `patch_mcp_json "$worktree_path"`, run `(cd "$worktree_path" && git update-index --skip-worktree .mcp.json)` so the worktree's `.mcp.json` is patched-but-untracked. The `(cd ...)` subshell is critical — a bare call would set the bit on the *main* repo's index. Per plan-review finding E-1.

2. **`.claude/development/git-crypt-guide.md`** (+47 lines): New "skip-worktree" subsection explaining the mechanic, the "don't restore to HEAD" warning, `skip-worktree` vs `assume-unchanged` rationale, the recovery commands for legitimate modifications, and the one-time backfill for pre-existing worktrees.

## What does NOT change

- `scripts/remove-worktree.sh` is NOT modified. Per plan-review finding E-2, the per-worktree index lives in `.git/worktrees/<name>/index` and is destroyed by `git worktree remove`; adding `--no-skip-worktree` would be dead code with a misleading rationale.

## Verification (run locally before push)

Roundtrip with the modified script:

```bash
bash .worktrees/wt-smi-4973-mcp-skip/scripts/create-worktree.sh \
    .worktrees/wt-smi-4973-roundtrip test/smi-4973-roundtrip main
```

Verified:
- `.worktrees/wt-smi-4973-roundtrip/.mcp.json` contains the patched `npx` command
- `git -C .worktrees/wt-smi-4973-roundtrip status .mcp.json` — clean
- `git -C .worktrees/wt-smi-4973-roundtrip ls-files -v .mcp.json` — `S` (skip-worktree set)
- `git ls-files -v .mcp.json` (from main repo) — `H` (NOT modified; per-worktree-index confirmed)
- `bash -n scripts/create-worktree.sh` — syntax OK
- `shellcheck scripts/create-worktree.sh` — only pre-existing INFO findings; none on new lines

## Plan-review findings (resolved)

| ID | Severity | Status |
|----|----------|--------|
| E-1 | High (must-fix) | ✅ subshell wrap applied |
| E-2 | Medium (should-fix) | ✅ remove-worktree.sh left untouched (dead code rationale) |
| E-5 | Medium (should-fix) | ✅ skip-worktree vs assume-unchanged justification in doc |
| P-1 | Medium (should-fix) | ✅ doc warns against restoring to HEAD |
| E-3, E-4, P-2, C-1 | Note-only / accept-tradeoff | acknowledged in plan |

## Out-of-scope finding

`scripts/remove-worktree.sh` requires `--force` when the worktree has initialized submodules (surfaced during roundtrip verification). Filed as **SMI-5000**.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>
