### PR TITLE
fix(test): SMI-4972 vitest E2E alias for worktree @skillsmith/* imports

### DIFF
--- a/.claude/development/git-crypt-guide.md
+++ b/.claude/development/git-crypt-guide.md
@@ -230,6 +230,49 @@ clear it): re-set with `git update-index --skip-worktree .mcp.json`.
 
 **Pre-commit hook behavior in worktrees (SMI-4377 + SMI-4381)**: The Docker `.:/app` bind-mount DOES cover `.worktrees/` (visible at `/app/.worktrees/<name>/` inside the container) — the original SMI-4377 diagnosis ("worktrees live outside `/app`") was wrong. `compute_container_wd` translates the host worktree path to its in-container equivalent. On macOS Docker Desktop, virtiofs cannot traverse the relative per-package `node_modules` symlinks, so worktree commits fall back to host execution (visible as `📂 Worktree on macOS — falling back to host execution (SMI-4381)`). The host fallback works correctly because `scripts/_lib.sh link_worktree_package_node_modules` symlinks each `packages/<pkg>/node_modules` so workspace-pinned deps (e.g. `zod@3.25.76` in `mcp-server`) resolve correctly. Linux Docker hosts use the in-container path. Off-tree worktrees (created outside `<repo-root>/.worktrees/`) also fall back to host. See `docs/internal/retros/2026-04-29-smi-4381-original-diagnosis-wrong.md` for the full RCA.
 
+### E2E imports of `@skillsmith/*` from worktrees (SMI-4972)
+
+A worktree's `node_modules` is a symlink to the main repo's `node_modules`
+(SMI-4377/SMI-4381 — saves 5-10 GB per worktree). Inside, each
+`@skillsmith/<pkg>` entry symlinks to the main repo's `packages/<pkg>/`.
+Any E2E code that does `import '@skillsmith/<pkg>'` would, by default,
+resolve to **main's** `packages/<pkg>/dist`, NOT the worktree's.
+
+Unit tests are not affected — vitest's `vitest.config.ts` source-transforms
+TypeScript directly and tests use relative imports (`../../src/...`).
+
+E2E tests, however, run from `vitest.e2e.config.ts` and import via the
+package name (e.g., `tests/e2e/cli/usage-counter.e2e.test.ts` imports
+from `@skillsmith/core`). To prevent silent main-vs-worktree skew,
+`vitest.e2e.config.ts` defines an explicit alias map that routes
+`@skillsmith/core`, `@skillsmith/mcp-server`, and `@skillsmith/enterprise`
+to the worktree's `packages/<pkg>/dist/src/index.js`.
+
+**Precondition**: you must build the relevant package(s) before running
+E2E from a worktree:
+
+```bash
+docker exec skillsmith-dev-1 npm run build
+# OR for a single package:
+docker exec skillsmith-dev-1 npm run build --workspace=@skillsmith/core
+```
+
+**If you forget**, the test will fail with a clear `MODULE_NOT_FOUND`
+pointing at the worktree's missing dist:
+
+```text
+Error: Cannot find module '/path/to/.worktrees/<name>/packages/core/dist/src/index.js'
+```
+
+This loud failure is by design — pre-SMI-4972, the missing-build state
+silently fell through to main's dist, masking what the worktree was
+actually testing.
+
+**Subpath imports caveat**: `import { x } from '@skillsmith/core/errors'`
+does NOT match the alias key `@skillsmith/core` and falls through to
+the node_modules symlink (i.e., main's dist). No such imports exist in
+`tests/e2e/` as of 2026-05-19; if you add one, extend the alias map.
+
 ### Manual Method
 
 ```bash

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -8,8 +8,13 @@
  * GitHub Actions job — can run the suite explicitly.
  */
 
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 import { sharedTestConfig } from './vitest.preset'
+
+// SMI-4972: project is "type": "module" (ESM); __dirname is not native.
+const here = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   test: {
@@ -28,5 +33,30 @@ export default defineConfig({
     // Each spec provisions its own user; sequential keeps staging tidy and
     // avoids racing the auth.users insert quota.
     fileParallelism: false,
+  },
+  // SMI-4972: route @skillsmith/<pkg> imports to the WORKTREE's built dist,
+  // not main's via the node_modules symlink (SMI-4377). Without this, E2E
+  // from a worktree silently exercises main's package code while claiming
+  // to verify worktree edits. dist/ not src/ because consumers import the
+  // built artifact; alias short-circuits vitest's transform pipeline so
+  // src/ access would require a relative import.
+  //
+  // Explicit per-package map (NOT regex + $1 — plan-review E-1):
+  // Rollup/Vite alias's string `replacement` does not interpolate regex
+  // capture groups. Only the three packages with `main: ./dist/src/index.js`
+  // need aliasing. cli/website/vscode-extension/doc-retrieval-mcp are NOT
+  // imported as `@skillsmith/<pkg>` by any E2E test (confirmed by
+  // `grep -rn "from '@skillsmith/" tests/e2e/`).
+  //
+  // Subpath exports (`@skillsmith/core/errors`) do NOT match these keys
+  // and fall through to node_modules resolution — i.e., to main's dist.
+  // Today zero such imports exist in tests/e2e/ (plan-review E-4). If
+  // future E2E tests add them, this map must be extended.
+  resolve: {
+    alias: {
+      '@skillsmith/core': path.resolve(here, 'packages/core/dist/src/index.js'),
+      '@skillsmith/mcp-server': path.resolve(here, 'packages/mcp-server/dist/src/index.js'),
+      '@skillsmith/enterprise': path.resolve(here, 'packages/enterprise/dist/src/index.js'),
+    },
   },
 })


### PR DESCRIPTION
[skip-impl-check]

## Summary

Add explicit per-package `resolve.alias` to `vitest.e2e.config.ts` so worktree-local E2E tests exercise the **worktree's** built `dist`, not main's (via the `node_modules` symlink chain established by SMI-4377/SMI-4381).

**Linear**: [SMI-4972](https://linear.app/smith-horn-group/issue/SMI-4972)
**SPARC plan**: `docs/internal/implementation/2026-05-19-smi-4972-vitest-e2e-alias.md`
**Code review**: `docs/internal/code_review/2026-05-19-smi-4972-vitest-e2e-alias.md`

## Root cause

A worktree's `node_modules` symlinks to the main repo's `node_modules` (SMI-4377 design, saves 5-10 GB per worktree). Inside, `@skillsmith/<pkg>` symlinks back to the main repo's `packages/<pkg>/`. So `import '@skillsmith/core'` from a worktree's E2E test silently resolves to **main's** `packages/core/dist`, NOT the worktree's. This cost ~10 min during SMI-4971 verification (Fix 4 required an absolute-path repro because the E2E suite was importing main's pre-fix core).

## What changes

### `vitest.e2e.config.ts` (+30 lines)

- New imports: `path` from `node:path`, `fileURLToPath` from `node:url`.
- ESM `__dirname` shim: `const here = path.dirname(fileURLToPath(import.meta.url))` (project is `"type": "module"`).
- New `resolve.alias` block with **explicit per-package map** (per plan-review finding E-1 — Rollup/Vite alias's string `replacement` does NOT interpolate regex `$1` capture groups):
  ```ts
  resolve: {
    alias: {
      '@skillsmith/core': path.resolve(here, 'packages/core/dist/src/index.js'),
      '@skillsmith/mcp-server': path.resolve(here, 'packages/mcp-server/dist/src/index.js'),
      '@skillsmith/enterprise': path.resolve(here, 'packages/enterprise/dist/src/index.js'),
    },
  },
  ```

Only the three workspace packages with `main: ./dist/src/index.js`. `cli`, `website`, `vscode-extension`, `doc-retrieval-mcp` are NOT imported via package name in any E2E test (verified by `grep -rn "from '@skillsmith/" tests/e2e/` — zero hits for those names).

### `.claude/development/git-crypt-guide.md` (+43 lines)

New subsection under "Worktree Setup": "E2E imports of `@skillsmith/*` from worktrees (SMI-4972)". Covers:
- The `node_modules` symlink chain rationale (SMI-4377).
- Why unit tests are not affected (source-transform pipeline).
- Why E2E tests ARE affected (package-name import).
- The alias as the fix; the build precondition.
- The exact `MODULE_NOT_FOUND` message a contributor will see if they forget to build (per plan-review E-3).
- Subpath-imports caveat: `@skillsmith/core/errors` does NOT match the alias key (per plan-review E-4); zero such imports in `tests/e2e/` today.

## What does NOT change

- `vitest.config.ts` (unit-test config) — deliberately untouched. Adding an alias would short-circuit vitest's source-transform pipeline.
- `package.json` test scripts — no `build && vitest` chaining. Pre-existing DX gap shared with `test:e2e:mcp` binary path; SMI-4972 does not regress it (per plan-review P-1).

## Plan-review findings (resolved before implementation)

| ID | Severity | Resolution |
|----|----------|------------|
| E-1 | High (must-fix) | ✅ Explicit per-package map, NOT regex with `$1` |
| E-3 | Medium (should-fix) | ✅ Doc quotes exact `MODULE_NOT_FOUND` path |
| E-4 | Medium (should-fix) | ✅ Subpath-imports caveat documented |
| E-2/E-5/E-6 | Low / note-only | Acknowledged |
| P-1 | Accept-tradeoff | No build-chaining in test scripts; loud failure is desired |

## Verification

- ✅ `npm run audit:standards` passes (clean).
- ✅ Type-check passes against the modified file (only unrelated `vitest.preset` resolution warning from running `tsc` from wrong CWD).
- ✅ Diff confirmed clean (worker reverted the throwaway probe before commit; only the alias + doc remain).
- ⚠️ Runtime probe was attempted but blocked by virtiofs symlink limitation when invoking turbo/tsc from inside a macOS Docker worktree (SMI-4377/4549/4698 territory). CI will exercise the alias on the next E2E run.

## Out-of-scope findings (filed)

- SMI-5002 (filed) — `patch_mcp_json` output not prettier-formatted, surfaced by SMI-4973's skip-worktree (causes pre-push format failures from worktrees).
- SMI-5000 (filed during SMI-4973) — `remove-worktree.sh` requires `--force` with submodules.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)