### PR TITLE
fix(scripts): SMI-5002 prettier-write .mcp.json inside create-worktree.sh

### DIFF
--- a/.claude/development/git-crypt-guide.md
+++ b/.claude/development/git-crypt-guide.md
@@ -198,6 +198,18 @@ does not work in a worktree — restoring it silently breaks the
 skillsmith MCP. If `git diff HEAD -- .mcp.json` shows a delta, that is
 expected and correct.
 
+**Prettier-formatting (SMI-5002)**: `create-worktree.sh` Step 6 also runs
+`prettier --write .mcp.json` inside the Docker container immediately after
+the jq patch, so the on-disk content matches the project's prettier style
+(`printWidth: 100` collapses jq's multi-line short args arrays back to
+single-line). Without this step, `format:check` fails on every worktree
+push (hard exit — no `continue-on-error`), forcing operators to bypass
+pre-push via `SKILLSMITH_PRE_PUSH_DOCKER=1 git push --no-verify`. If the
+container is down at create time, the prettier step warns and continues;
+the worktree remains usable but `format:check` will fail until you run
+`docker exec skillsmith-dev-1 sh -c 'cd /app/<wt-rel-path> && npx
+prettier --write .mcp.json'` manually.
+
 **`skip-worktree`, not `assume-unchanged`**: `skip-worktree` is git's
 sanctioned mechanism for "I have intentionally modified this tracked
 file and never want it staged." `assume-unchanged` is a performance

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -295,6 +295,7 @@ patch_mcp_json() {
     fi
 
     local tmp_file
+    local container_rel
     tmp_file=$(mktemp)
     trap 'rm -f "$tmp_file"' EXIT  # clean up on SIGINT/SIGTERM/EXIT
 
@@ -305,6 +306,26 @@ patch_mcp_json() {
         cat "$tmp_file" > "$mcp_json"
         rm -f "$tmp_file"
         trap - EXIT
+        # SMI-5002: normalize jq's multi-line output to single-line short arrays
+        # so the project's prettier config (printWidth: 100) is satisfied.
+        # Worktree push otherwise needs --no-verify to bypass format:check
+        # (skip-worktree from SMI-4973 hides the diff from `git status` but
+        # not from prettier's content-style check). validate_args (L209-224)
+        # normalizes worktree_path to an absolute path under REPO_ROOT for
+        # relative invocations; strip the REPO_ROOT/ prefix to compute the
+        # container-relative path. The container only has REPO_ROOT mounted
+        # at /app, so out-of-tree worktrees cannot be reached via docker exec
+        # — warn-skip in that case.
+        container_rel="${worktree_path#"$REPO_ROOT/"}"
+        if [[ "$container_rel" == "$worktree_path" ]]; then
+            warn "  Prettier skip: worktree not under REPO_ROOT — manual prettier-write may be needed"
+        elif docker exec skillsmith-dev-1 sh -c \
+            "cd \"/app/$container_rel\" && npx --no-install prettier --write .mcp.json" \
+            >/dev/null; then
+            success "  Prettier-formatted .mcp.json (SMI-5002)"
+        else
+            warn "  Prettier unavailable (container down or prettier missing?); .mcp.json may fail format:check until run manually"
+        fi
         success "  Patched .mcp.json: skillsmith → npx (worktrees have no local dist)"
     else
         rm -f "$tmp_file"


### PR DESCRIPTION
## Summary

`patch_mcp_json` in `scripts/create-worktree.sh` uses `jq` to rewrite the worktree's `.mcp.json` so the skillsmith MCP server uses `npx -y @skillsmith/mcp-server` (worktrees have no built dist). `jq` emits multi-line short args arrays; project prettier config (`printWidth: 100`) prefers single-line. Result: every worktree push has needed `SKILLSMITH_PRE_PUSH_DOCKER=1 git push --no-verify` since SMI-4973 landed, degrading the pre-push safety net (security-scan and Linear-sync phases also skipped).

This PR runs `prettier --write .mcp.json` inside `skillsmith-dev-1` immediately after the `jq` patch (after `trap - EXIT` at L307), so the on-disk content matches prettier style and `format:check` passes without a bypass.

## Changes

- **`scripts/create-worktree.sh`** (+21 lines): prettier-write block in `patch_mcp_json()`. Container path computed via `${worktree_path#"$REPO_ROOT/"}` (NOT `basename`) so non-`.worktrees/` invocations behave correctly. Out-of-tree placements warn-skip (container only has `/app` mounted as `REPO_ROOT`). Container-down / prettier-missing also warns and continues — worktree remains usable, operator gets a clear next step.
- **`.claude/development/git-crypt-guide.md`** (+12 lines): one-paragraph addition inside the existing SMI-4973 `.mcp.json skip-worktree` subsection.

## Plan-review

8 findings. **Accepted**: E-1 (path-stripping correctness), E-3 (anchor explicit after `trap - EXIT`), M-1 (broader warn message), M-2 (non-`.worktrees/` verification), M-3 (jq -c rationale), L-1 (local declaration grouping), L-2 (container name clarity). **Rejected with empirical evidence**: E-2 — reviewer claimed `npx --no-install` was removed in npm 7+; empirically `npx --no-install prettier --version` returns `3.8.3` in the npm 10.9.7 container (flag still works); reviewer's recommended `--no` actually breaks (swallows `prettier` as positional). Kept `--no-install`.

## Governance

Inline review caught 2 issues, both amended into the commit:
- **Major**: doc note said "reports a warning" — corrected to "fails on every worktree push (hard exit — no `continue-on-error`)" since `format:check` in `ci.yml` is bare `npm run format:check`.
- **Minor**: `sh -c "cd /app/$container_rel && ..."` would fail on paths with spaces; quoted as `"cd \"/app/$container_rel\" && ..."`.

## Verification

- `npm run audit:standards`: 68 passed / 3 warnings (pre-existing) / 0 failed
- Roundtrip from main repo CWD: `Step 6: ... ✓ Prettier-formatted .mcp.json (SMI-5002)`
- Host `npx prettier --check` on new worktree's `.mcp.json`: exit 0
- Skip-worktree bit still set (`S .mcp.json`); `git status` clean
- Patch content verified live (skillsmith uses `npx -y @skillsmith/mcp-server`)

## SPARC plan

`docs/internal/implementation/2026-05-19-smi-5002-prettier-mcp-json.md` (companion docs/internal PR to follow)

## Notes

- Linear: SMI-5002
- ADR-109 trigger path: SPARC plan + plan-review completed before code
- After this lands, future worktree pushes should not need `--no-verify` for the `.mcp.json` prettier issue (pre-push vitest leak SMI-4767 is a separate concern)

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)