### PR TITLE
fix(scripts): SMI-5000 remove-worktree.sh — unconditional --force + script-level dirty check

### DIFF
--- a/.claude/development/git-crypt-guide.md
+++ b/.claude/development/git-crypt-guide.md
@@ -296,17 +296,16 @@ cd worktrees/<name> && git reset --hard HEAD
 ./scripts/remove-worktree.sh .worktrees/<name> --prune
 ```
 
-Includes Docker network cleanup and per-worktree submodule working-tree
-cleanup (SMI-5000). `--force` is no longer required for routine removal
-of healthy worktrees — pre-SMI-5000, `git worktree remove` refused with
-"fatal: working trees containing submodules cannot be moved or removed"
-because every worktree initializes 4 submodules (`docs/internal` + 3
-strategy mounts). The script now `rm -rf`s each submodule working tree
-before calling `git worktree remove`. Submodule pointers and init state
-in the main repo are unaffected (the worktree's `.git` is a gitlink into
-main's `.git/worktrees/<name>/`; main's submodule config is shared but
-untouched by this directory removal). Use `--force` only when the worktree
-has uncommitted/dirty work that you want to discard.
+Includes Docker network cleanup (SMI-5000). `--force` is no longer
+required for routine removal of healthy worktrees — pre-SMI-5000,
+`git worktree remove` refused with "fatal: working trees containing
+submodules cannot be moved or removed" because every worktree initializes
+4 submodules (`docs/internal` + 3 strategy mounts). The script now passes
+`--force` unconditionally to `git worktree remove` (verified empirically:
+`--force` from outside the worktree does NOT modify main's `.git/config`
+submodule sections), and enforces a script-level dirty-tree check to
+preserve the safety that `--force` would otherwise bypass. Use `--force`
+only when the worktree has uncommitted/dirty work that you want to discard.
 
 ### Worktree `git reset` Footgun (SMI-3011)
 

--- a/.claude/development/git-crypt-guide.md
+++ b/.claude/development/git-crypt-guide.md
@@ -293,10 +293,20 @@ cd worktrees/<name> && git reset --hard HEAD
 ### Removing Worktrees
 
 ```bash
-./scripts/remove-worktree.sh --prune
+./scripts/remove-worktree.sh .worktrees/<name> --prune
 ```
 
-Includes Docker network cleanup. Use `--force` flag if smudge artifacts block removal.
+Includes Docker network cleanup and per-worktree submodule working-tree
+cleanup (SMI-5000). `--force` is no longer required for routine removal
+of healthy worktrees — pre-SMI-5000, `git worktree remove` refused with
+"fatal: working trees containing submodules cannot be moved or removed"
+because every worktree initializes 4 submodules (`docs/internal` + 3
+strategy mounts). The script now `rm -rf`s each submodule working tree
+before calling `git worktree remove`. Submodule pointers and init state
+in the main repo are unaffected (the worktree's `.git` is a gitlink into
+main's `.git/worktrees/<name>/`; main's submodule config is shared but
+untouched by this directory removal). Use `--force` only when the worktree
+has uncommitted/dirty work that you want to discard.
 
 ### Worktree `git reset` Footgun (SMI-3011)
 

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -311,13 +311,14 @@ main() {
     # level. Untracked entries (??) are excluded — they're typically
     # node_modules / build artifacts and don't represent unsaved work.
     if [[ "$force_flag" != "--force" ]]; then
-        # `grep -cv` exits 1 when zero non-?? lines match. Under
-        # `set -euo pipefail`, that exit propagates through the pipe
-        # and aborts the script on a CLEAN worktree (the common case).
-        # `|| echo 0` collapses both "no match" and "grep error" to 0;
-        # any genuine dirty lines emit their count first.
+        # `grep -v '^??'` exits 1 when zero non-?? lines match. Under
+        # `set -euo pipefail`, that exit propagates through the pipe and
+        # prevents `wc -l` from running. Wrapping in `{ ... || true; }`
+        # absorbs the no-match exit so wc -l always receives input and
+        # produces a clean single-line integer — no double-output, no
+        # spurious syntax error in the -gt comparison below.
         local dirty_count
-        dirty_count=$(cd "$worktree_path" && git status --porcelain 2>/dev/null | grep -cv '^??' || echo 0)
+        dirty_count=$(cd "$worktree_path" && git status --porcelain 2>/dev/null | { grep -v '^??' || true; } | wc -l | tr -d ' ')
         if [[ "$dirty_count" -gt 0 ]]; then
             error "Worktree has $dirty_count uncommitted change(s).
 

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -48,9 +48,11 @@ Examples:
 What this script does:
   1. Stops Docker containers associated with the worktree
   2. Removes per-worktree Docker image and node_modules volume (unless --keep-docker)
-  3. Removes the git worktree (with --force if specified)
-  4. Checks Docker network count and warns if above threshold
-  5. Optionally prunes stale Docker networks (--prune)
+  3. Refuses if the worktree has uncommitted changes, unless --force is passed (SMI-5000)
+  4. Removes the git worktree (always passes --force to git worktree remove
+     so submodule presence — post-SMI-4829 every worktree has 4 — does not block)
+  5. Checks Docker network count and warns if above threshold
+  6. Optionally prunes stale Docker networks (--prune)
 
 EOF
 }
@@ -292,12 +294,47 @@ main() {
         info "Skipping per-worktree Docker resource cleanup (--keep-docker)"
     fi
 
-    # Step 2: Remove the worktree
+    # Step 1d: SMI-5000 — script-level dirty-tree check.
+    #
+    # Post-SMI-4829, every worktree has 4 initialized submodules
+    # (docs/internal + 3 strategy mounts), and `git worktree remove`
+    # refuses without --force when submodules are present:
+    #     "fatal: working trees containing submodules cannot be moved or removed"
+    # We pass --force unconditionally in Step 2 to bypass that submodule
+    # check (verified empirically: `git worktree remove --force` from
+    # outside the worktree does NOT modify main/.git/config's submodule
+    # sections; the deinit-corruption concern only applies to
+    # `git submodule deinit --all` from inside a worktree).
+    #
+    # But --force also bypasses git's dirty-tree protection. To preserve
+    # that safety, we implement the dirty check ourselves at the script
+    # level. Untracked entries (??) are excluded — they're typically
+    # node_modules / build artifacts and don't represent unsaved work.
+    if [[ "$force_flag" != "--force" ]]; then
+        # `grep -cv` exits 1 when zero non-?? lines match. Under
+        # `set -euo pipefail`, that exit propagates through the pipe
+        # and aborts the script on a CLEAN worktree (the common case).
+        # `|| echo 0` collapses both "no match" and "grep error" to 0;
+        # any genuine dirty lines emit their count first.
+        local dirty_count
+        dirty_count=$(cd "$worktree_path" && git status --porcelain 2>/dev/null | grep -cv '^??' || echo 0)
+        if [[ "$dirty_count" -gt 0 ]]; then
+            error "Worktree has $dirty_count uncommitted change(s).
+
+Commit or discard them first, or re-run with --force to discard:
+  $(basename "$0") $worktree_path --force"
+        fi
+    fi
+
+    # Step 2: Remove the worktree (--force is now unconditional — see Step 1d
+    # rationale above). The user-visible --force flag remains for parity with
+    # `git worktree remove --force` semantics, but the script already enforced
+    # the dirty check above. SMI-5000.
     info "Removing git worktree..."
-    if git worktree remove "$worktree_path" $force_flag 2>&1; then
+    if git worktree remove "$worktree_path" --force 2>&1; then
         success "  Worktree removed"
     else
-        error "Failed to remove worktree. Try with --force flag."
+        error "Failed to remove worktree."
     fi
 
     # Step 3: Check Docker network count


### PR DESCRIPTION
## Summary

`scripts/remove-worktree.sh` Step 2 has been failing without `--force` for routine removal of healthy worktrees since the SMI-4829 cutover (every worktree now initializes 4 submodules). Git refuses with:

```text
fatal: working trees containing submodules cannot be moved or removed
```

This PR makes `--force` unconditional internally and adds a script-level dirty-tree check to preserve the safety semantic.

## Why not `git submodule deinit`?

Plan-review (H-1) caught a critical defect in the obvious fix. A worktree's `.git` is a gitlink to MAIN's `.git/worktrees/<name>`; submodule sections live in MAIN's shared `.git/config`. Running `git submodule deinit --all --force` from a worktree strips main's submodule init state.

## Why not `rm -rf` the submodule dirs?

Plan-review proposed this as a fallback. Empirically tested: `git worktree remove` also inspects the worktree's index gitlinks (`160000` entries) AND `.git/modules/<sub>/worktrees/<parent>/` per-submodule registration. After `rm -rf`-ing all 4 submodule dirs, git still refused.

## The actual fix

Pass `--force` unconditionally to `git worktree remove`. Verified empirically: `--force` from outside the worktree does NOT modify main's `.git/config` (diff before/after returns empty). To preserve the dirty-tree safety that `--force` would otherwise bypass, implement the check at the script level:

```bash
if [[ "$force_flag" != "--force" ]]; then
    dirty_count=$({ git status --porcelain 2>/dev/null | grep -v '^??' || true; } | wc -l | tr -d ' ')
    if [[ "$dirty_count" -gt 0 ]]; then
        error "Worktree has $dirty_count uncommitted change(s). ... --force to discard"
    fi
fi
git worktree remove "$worktree_path" --force
```

Untracked entries (`??`) are excluded — they're typically `node_modules` / build artifacts and don't represent unsaved work.

## Changes

- **`scripts/remove-worktree.sh`** (+44/-3): Step 1d dirty-tree check, Step 2 unconditional `--force`, `usage()` "What this script does" updated.
- **`.claude/development/git-crypt-guide.md`** (+12/-2): "Removing Worktrees" subsection updated.

## Plan-review

H-1 caught critical defect → pivot to `--force`+dirty-check (documented in plan's Changes Applied table).

## Governance

2 critical fixes amended:
- **`grep -cv ... || echo 0` double-output bug**: pipeline emitted `"0\n0"` on clean trees → `bash: [[: 0\n0: syntax error` to stderr (accidentally correct condition, but stderr noise). Fixed with `{ grep -v '^??' || true; } | wc -l | tr -d ' '`.
- **Doc-note inaccuracy**: described the rejected `rm -rf` approach. Updated to accurately reference the `--force` + dirty-check design.

## Verification (all three roundtrips pass, main `.git/config` diff empty)

| Scenario | --force? | Expected | Actual |
|----------|----------|----------|--------|
| Clean tree | no | EXIT 0, worktree removed | ✅ EXIT 0 |
| Dirty tree | no | Error + recovery hint, worktree intact | ✅ |
| Dirty tree | yes | EXIT 0, worktree removed | ✅ EXIT 0 |
| Main `.git/config` | — | Unchanged after all 3 | ✅ diff empty |
| Main `git submodule status` | — | Same init markers (` `/`+`, no `-`) | ✅ unchanged |
| Other worktrees | — | Submodules still accessible | ✅ |

audit:standards: 70 passed / 1 warn (pre-existing) / 0 failed.

## SPARC plan

`docs/internal/implementation/2026-05-19-smi-5000-remove-worktree-submodule-deinit.md` (companion docs/internal PR to follow)

## Notes

- Linear: SMI-5000
- ADR-109 trigger path: SPARC plan + plan-review completed before code
- 2 commits on branch — will squash on merge

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)