### PR TITLE
feat(ci): SMI-5005 chronic-red-monitor cross-run alert dedup via GHA artifact

### DIFF
--- a/.github/workflows/chronic-red-monitor.yml
+++ b/.github/workflows/chronic-red-monitor.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Restore previous chronic-red state
         run: |
           mkdir -p "$STATE_DIR"
-          artifact_id=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts" --paginate \
+          artifact_id=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts" \
             --jq '[.artifacts[] | select(.name=="chronic-red-state" and .expired==false)]
                   | sort_by(.created_at) | reverse | .[0].id // empty')
           if [ -n "$artifact_id" ]; then
@@ -43,7 +43,7 @@ jobs:
             unzip -o /tmp/state.zip -d "$STATE_DIR/"
             echo "Restored chronic-red-state from artifact $artifact_id"
             echo "::group::Restored state.json contents"
-            cat "$STATE_DIR/state.json" 2>/dev/null | jq . || echo "(no state.json in artifact)"
+            jq . "$STATE_DIR/state.json" 2>/dev/null || echo "(no state.json in artifact)"
             echo "::endgroup::"
           else
             echo "::notice::No prior chronic-red-state artifact — treating all chronic-red workflows as new"

--- a/.github/workflows/chronic-red-monitor.yml
+++ b/.github/workflows/chronic-red-monitor.yml
@@ -1,6 +1,7 @@
 # SMI-4974: detect workflows that have rotted into chronic-red.
 # Inverts the burden: instead of every contributor checking every workflow's
 # badge, we hear about regressions on a 24h cadence.
+# SMI-5005: cross-run alert dedup via GHA artifact-backed state file.
 name: Chronic-Red Workflow Monitor
 
 on:
@@ -21,8 +22,46 @@ jobs:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       THRESHOLD: '3'
+      STATE_DIR: /tmp/chronic-red-state
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # SMI-5005: cross-run artifact fetch. `actions/download-artifact@v8`
+      # only fetches within the SAME workflow run; for the previous run's
+      # state we use `gh api` to find and download the most recent
+      # non-expired `chronic-red-state` artifact. continue-on-error
+      # isn't needed because the gh api calls handle missing-artifact
+      # silently (artifact_id is empty → skip download).
+      - name: Restore previous chronic-red state
+        run: |
+          mkdir -p "$STATE_DIR"
+          artifact_id=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts" --paginate \
+            --jq '[.artifacts[] | select(.name=="chronic-red-state" and .expired==false)]
+                  | sort_by(.created_at) | reverse | .[0].id // empty')
+          if [ -n "$artifact_id" ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/$artifact_id/zip" > /tmp/state.zip
+            unzip -o /tmp/state.zip -d "$STATE_DIR/"
+            echo "Restored chronic-red-state from artifact $artifact_id"
+            echo "::group::Restored state.json contents"
+            cat "$STATE_DIR/state.json" 2>/dev/null | jq . || echo "(no state.json in artifact)"
+            echo "::endgroup::"
+          else
+            echo "::notice::No prior chronic-red-state artifact — treating all chronic-red workflows as new"
+          fi
+
       - name: Run chronic-red monitor
         run: bash scripts/chronic-red-monitor.sh
+
+      # SMI-5005: upload the (possibly-updated) state for the next run.
+      # `if: always()` so a script failure mid-loop still persists the
+      # state for entries that were updated before the failure.
+      # `continue-on-error: true` (H-3) so concurrent dispatch + cron
+      # race on the upload doesn't fail the job.
+      - name: Upload chronic-red state for next run
+        if: always()
+        continue-on-error: true # audit:allow-continue-on-error — concurrent dispatch+cron race; one duplicate alert acceptable (P-5 in SPARC plan)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: chronic-red-state
+          path: /tmp/chronic-red-state/state.json
+          retention-days: 30

--- a/scripts/chronic-red-monitor.sh
+++ b/scripts/chronic-red-monitor.sh
@@ -2,6 +2,17 @@
 # SMI-4974: detect workflows that have failed THRESHOLD consecutive runs
 # on main AND are NOT in the explicit required-backing allowlist below.
 # Post one alert-notify per chronic-red workflow.
+#
+# SMI-5005: cross-run alert dedup via GHA artifact-backed state file.
+# At workflow start, the chronic-red-monitor.yml workflow restores the
+# most-recent non-expired `chronic-red-state` artifact via `gh api`
+# (cross-run fetch — `actions/download-artifact` can only fetch within
+# the same run). The state file maps workflow file names to the SHA of
+# the last failure we alerted on. If the current failing SHA matches the
+# stored SHA, we skip the alert. Otherwise we alert AND update the
+# stored SHA — BUT only if alert-notify returned 2xx (M-2 fix: a
+# transient Supabase outage must NOT permanently suppress future
+# alerts).
 set -euo pipefail
 
 : "${THRESHOLD:=3}"
@@ -9,6 +20,26 @@ set -euo pipefail
 : "${SUPABASE_SERVICE_ROLE_KEY:?required}"
 
 REPO="${GITHUB_REPOSITORY:-smith-horn/skillsmith}"
+
+# SMI-5005: state-file path. The workflow restores the prior run's
+# artifact into $STATE_DIR before invoking this script. Defaults to
+# /tmp for ad-hoc local testing.
+STATE_DIR="${STATE_DIR:-/tmp}"
+STATE_FILE="$STATE_DIR/state.json"
+mkdir -p "$STATE_DIR"
+[ -f "$STATE_FILE" ] || echo '{}' > "$STATE_FILE"
+
+stored_sha_for() {
+  # `// ""` (clearer than `// empty` under set -euo pipefail).
+  jq -r --arg w "$1" '.[$w] // ""' "$STATE_FILE"
+}
+
+update_stored_sha() {
+  local w="$1" sha="$2" tmp
+  tmp=$(mktemp)
+  jq --arg w "$w" --arg sha "$sha" '. + {($w): $sha}' "$STATE_FILE" > "$tmp"
+  mv "$tmp" "$STATE_FILE"
+}
 
 # Required-backing workflow files — i.e., workflows whose jobs ARE in
 # branch-protection.json's required_status_checks.contexts. Maintained
@@ -41,6 +72,7 @@ printf '  %s\n' "${REQUIRED_BACKING_FILES[@]}"
 echo "::endgroup::"
 
 alerts=0
+skipped_dup=0
 while IFS= read -r workflow; do
   [ -z "$workflow" ] && continue
   if is_required_backing "$workflow"; then
@@ -53,6 +85,21 @@ while IFS= read -r workflow; do
   count=$(echo "$conclusions" | grep -cv '^$' || true)
   fails=$(echo "$conclusions" | grep -c '^failure$' || true)
   if [ "$count" -eq "$THRESHOLD" ] && [ "$fails" -eq "$THRESHOLD" ]; then
+    # SMI-5005: dedup check — fetch the current failing run's headSha
+    # and compare with the stored SHA for this workflow.
+    current_sha=$(gh run list --workflow "$workflow" --branch main --limit 1 \
+      --json headSha -q '.[0].headSha' 2>/dev/null || true)
+    stored=$(stored_sha_for "$workflow")
+
+    if [ -z "$current_sha" ]; then
+      # M-1: emit warning when dedup is bypassed (API blip / no main runs)
+      echo "::warning::$workflow: could not fetch headSha, alerting without dedup"
+    elif [ "$current_sha" = "$stored" ]; then
+      echo "::notice::$workflow still failing at SHA $current_sha (already alerted) — skipping"
+      skipped_dup=$((skipped_dup + 1))
+      continue
+    fi
+
     # Most recent failing run for the alert URL.
     run_info=$(gh run list --workflow "$workflow" --branch main --limit 1 --json databaseId,url -q '.[0]')
     run_id=$(echo "$run_info" | jq -r .databaseId)
@@ -65,13 +112,24 @@ while IFS= read -r workflow; do
       --arg url "$run_url" \
       '{type:"chronic_red", message:$msg, workflow:$wf, runId:$rid, runUrl:$url}')
     echo "::warning::$msg ($run_url)"
-    curl -s -X POST \
+
+    # SMI-5005 M-2: capture HTTP status; only update state on 2xx so a
+    # transient Supabase outage doesn't permanently suppress alerts.
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
       -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
       -H "Content-Type: application/json" \
       -d "$body" \
-      "$SUPABASE_URL/functions/v1/alert-notify" || true
-    alerts=$((alerts + 1))
+      "$SUPABASE_URL/functions/v1/alert-notify" || echo "000")
+
+    if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+      alerts=$((alerts + 1))
+      if [ -n "$current_sha" ]; then
+        update_stored_sha "$workflow" "$current_sha"
+      fi
+    else
+      echo "::warning::alert-notify returned HTTP $http_code for $workflow — state not updated; will retry next run"
+    fi
   fi
 done <<< "$all_workflows"
 
-echo "Chronic-red monitor finished: $alerts alert(s) posted"
+echo "Chronic-red monitor finished: $alerts alert(s) posted, $skipped_dup dedup skip(s)"

--- a/scripts/chronic-red-monitor.sh
+++ b/scripts/chronic-red-monitor.sh
@@ -85,14 +85,15 @@ while IFS= read -r workflow; do
   count=$(echo "$conclusions" | grep -cv '^$' || true)
   fails=$(echo "$conclusions" | grep -c '^failure$' || true)
   if [ "$count" -eq "$THRESHOLD" ] && [ "$fails" -eq "$THRESHOLD" ]; then
-    # SMI-5005: dedup check — fetch the current failing run's headSha
-    # and compare with the stored SHA for this workflow.
-    current_sha=$(gh run list --workflow "$workflow" --branch main --limit 1 \
-      --json headSha -q '.[0].headSha' 2>/dev/null || true)
+    # SMI-5005: dedup check — fetch the current failing run's headSha,
+    # databaseId, and url in one call, then compare headSha with stored.
+    run_info=$(gh run list --workflow "$workflow" --branch main --limit 1 \
+      --json headSha,databaseId,url -q '.[0]' 2>/dev/null || true)
+    current_sha=$(echo "$run_info" | jq -r '.headSha // ""')
     stored=$(stored_sha_for "$workflow")
 
     if [ -z "$current_sha" ]; then
-      # M-1: emit warning when dedup is bypassed (API blip / no main runs)
+      # M-1: emit warning when dedup is bypassed (gh run list API failure / empty response)
       echo "::warning::$workflow: could not fetch headSha, alerting without dedup"
     elif [ "$current_sha" = "$stored" ]; then
       echo "::notice::$workflow still failing at SHA $current_sha (already alerted) — skipping"
@@ -100,10 +101,8 @@ while IFS= read -r workflow; do
       continue
     fi
 
-    # Most recent failing run for the alert URL.
-    run_info=$(gh run list --workflow "$workflow" --branch main --limit 1 --json databaseId,url -q '.[0]')
-    run_id=$(echo "$run_info" | jq -r .databaseId)
-    run_url=$(echo "$run_info" | jq -r .url)
+    run_id=$(echo "$run_info" | jq -r '.databaseId // ""')
+    run_url=$(echo "$run_info" | jq -r '.url // ""')
     msg="\"$workflow\" has failed $THRESHOLD consecutive runs on main"
     body=$(jq -n \
       --arg msg "$msg" \


### PR DESCRIPTION
## Summary

SMI-4974's chronic-red monitor re-alerts every 14:00 UTC for any still-red workflow. For a workflow that stays red 30 days, that's 30 identical alert emails — alert fatigue masks real signal (SMI-4640 lesson).

This PR persists last-alerted-SHA per workflow across cron runs via a GHA artifact-backed JSON map: `{ "<workflow.yml>": "<head-sha>", ... }`. Same SHA → skip alert. Different SHA → alert AND update state.

## Why `gh api` instead of `actions/download-artifact`?

Plan-review (E-2) caught a critical structural defect. `actions/download-artifact@v8` only fetches within the SAME workflow run (verified: every existing repo usage of download-artifact is intra-run, e.g., `ci.yml` downloads `docker-image` uploaded earlier in the same run). The original "download the prior run's artifact" design would have silently no-opped (download finds nothing → `continue-on-error` masks it → state never loads → every run alerts unconditionally, defeating the entire feature).

The fix: cross-run fetch via `gh api repos/{owner}/{repo}/actions/artifacts`, sort by `created_at` desc, take the most recent non-expired one, download via `gh api .../zip`. No new permissions required (verified: `ci.yml` uploads artifacts with `permissions: contents: read` only).

## Why HTTP-status-gated state update?

Plan-review M-2 caught a data-correctness issue. If alert-notify returns non-2xx (transient Supabase outage), the original design would still update `stored_sha[workflow]` and the next run would suppress the alert permanently (until a NEW failing commit). The fix: capture `%{http_code}` from curl; only call `update_stored_sha` on 2xx. On 4xx/5xx, emit `::warning::HTTP NNN — state not updated; will retry next run`.

## Changes

- **`scripts/chronic-red-monitor.sh`** (+62/-4): `STATE_DIR` + `stored_sha_for` / `update_stored_sha` jq helpers, dedup check (current `headSha` vs stored), HTTP-status-gated `update_stored_sha`, dedup-skip counter.
- **`.github/workflows/chronic-red-monitor.yml`** (+39): `Restore previous chronic-red state` step (gh api cross-run fetch), `Upload chronic-red state for next run` step with `audit:allow-continue-on-error` marker (concurrent dispatch+cron race acceptable per SPARC P-5).

## Plan-review

7 findings. **Critical pivots accepted**: E-1 (overwrite v4+ incompatibility — dropped `overwrite: true`, SHA-pinned `upload-artifact@v7`), E-2 (cross-run requires `gh api`). **Rejected with empirical evidence**: H-2 (reviewer claimed `actions: write` needed for upload — `ci.yml` proves `contents: read` is sufficient). **Applied**: H-1 (explicit `--branch main`), H-3 (`continue-on-error` on upload), M-1 (warning log on empty SHA), M-2 (HTTP-status-gated state update), M-3 (no-prior-artifact notice), L-1 (`// ""`), L-2 (verification step).

## Governance

4 inline fixes amended (commit `4bc4b2fa`):
- **G-1**: collapsed two `gh run list` calls into one (eliminated TOCTOU + a network round-trip)
- **G-2**: removed `--paginate` on artifact listing (per-page jq filter risk for >30 artifacts)
- **G-3**: removed UUOC (`cat | jq` → `jq <file>`)
- **G-4**: M-1 comment accuracy (the "no main runs" case can't reach dedup; corrected to "API failure / empty response"); added `// ""` fallbacks on `.databaseId`/`.url` extractions

## Verification (post-merge, in CI)

- First run with no prior artifact: `::notice::No prior chronic-red-state artifact …`; monitor runs; upload step succeeds; artifact attached.
- Second run with same SHA: `::notice::… already alerted at SHA X — skipping`; zero new alerts.
- Different SHA after a new failing commit: alert fires; state updated.
- alert-notify 4xx response: `::warning::… HTTP NNN — state not updated`; next run with valid response alerts.

`audit:standards`: 0 failures (1 warn pre-existing). Check 21 (SMI-3217 continue-on-error) satisfied via `# audit:allow-continue-on-error` marker on the upload step.

## SPARC plan

`docs/internal/implementation/2026-05-19-smi-5005-chronic-red-dedup.md` (companion PR to follow)

## Notes

- Linear: SMI-5005
- ADR-109 trigger path: SPARC + plan-review completed before code
- 2 commits → squash on merge

[skip-impl-check]
[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)