### PR TITLE
chore(docs,scripts): SMI-5006 bump docs/internal pointer for PR #1246 + grandfather-list correction

### DIFF
--- a/scripts/check-file-length.ignore
+++ b/scripts/check-file-length.ignore
@@ -18,9 +18,10 @@
 #
 # Do not add new files here without a corresponding split follow-up issue.
 
-# SMI-5036 split follow-up — three billing test files relocated by SMI-5006 from
+# SMI-5036 split follow-up — two billing test files relocated by SMI-5006 from
 # packages/core/tests/billing/ to packages/enterprise/tests/billing/. Pre-existed
 # over-limit on main; the rename surfaces the hook for the first time.
+# (GDPRCompliance.test.ts removed during SMI-5006 retro 2026-05-20 — actual line
+#  count 486 is under the 500-line gate, so it should never have been listed.)
 packages/enterprise/tests/billing/StripeClient.test.ts
 packages/enterprise/tests/billing/webhook-handlers.test.ts
-packages/enterprise/tests/billing/GDPRCompliance.test.ts


### PR DESCRIPTION
## Summary

Post-merge follow-up for [SMI-5006](https://linear.app/smith-horn-group/issue/SMI-5006/) (Wave 1 of Enterprise Package Split, PR #1246).

- **docs/internal** pointer bumped to include:
  - 4 wave implementation plans (smi-5006/5007/5008/5009)
  - SMI-5006 W1 retro (`2026-05-20-smi-5006-w1-billing-move-retro.md`)
  - `retros/index.md` updated

- **scripts/check-file-length.ignore**: removed `GDPRCompliance.test.ts`. SMI-5006 retro audit found the queen-coordinator miscounted this file as 532 lines; actual is 486 (under the 500-line gate). SMI-5036 description corrected to reference only the 2 actually-over-limit files.

## Linear hygiene done in retro

- **SMI-5006** → Done
- **SMI-5007** (already Canceled) → audit-trail comment added explaining collapse into SMI-5006
- **SMI-5008**: blockedBy rebased from canceled SMI-5007 to SMI-5006 directly
- **SMI-5036**: title + description corrected (2 files, not 3)
- **SMI-5044** filed — track the mcp-server↔enterprise type-import workspace cycle resolution (the inline structural interface in `stripe-webhook-endpoint.ts:31-42` is documented but not the long-term solution)

## Test plan

- [x] `git diff --cached scripts/check-file-length.ignore` confirms only the GDPRCompliance.test.ts line removed (the file's wc -l is 486, under the gate)
- [x] `git diff --cached docs/internal` shows submodule pointer advance c3c49680..109ea434
- [ ] CI passes (this is config-only + submodule pointer; no source changes)

## Notes

- `[skip-impl-check]` because this is config/docs-only.

[skip-impl-check]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>