### PR TITLE
chore(core): SMI-5008 remove stripe SDK from @skillsmith/core dependencies (#869)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7208,7 +7208,6 @@
       "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.8.tgz",
       "integrity": "sha512-ZdElB7DPS7QQS8ZnFc5RPPtkg+eN11z8AmIZWAyes6pSbwXqiFB/POVevvm01begdSX1ho9Gxln/F6qlQMsuaA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -7218,7 +7217,6 @@
       "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
       "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@huggingface/jinja": "^0.5.3",
         "onnxruntime-node": "1.21.0",
@@ -18017,7 +18015,6 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -18047,7 +18044,6 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -19545,8 +19541,7 @@
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -20097,7 +20092,6 @@
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-4.1.3.tgz",
       "integrity": "sha512-KUJEViiuFT3I97t+GYMikLPJS2Lfo/S2F+DQuBWzuzaMPnvt5yyZePzArx36fBzpGTxZjIpDbXLeySLgh+k76g==",
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "globalthis": "^1.0.2",
         "matcher": "^4.0.0",
@@ -20126,7 +20120,6 @@
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -20233,8 +20226,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/h3": {
       "version": "1.15.11",
@@ -20268,7 +20260,6 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -22457,7 +22448,6 @@
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
       "integrity": "sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
       },
@@ -23964,7 +23954,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -24064,8 +24053,7 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
       "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/onnxruntime-node": {
       "version": "1.21.0",
@@ -24073,7 +24061,6 @@
       "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32",
         "darwin",
@@ -24090,7 +24077,6 @@
       "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
       "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "flatbuffers": "^25.1.24",
         "guid-typescript": "^1.0.9",
@@ -24104,8 +24090,7 @@
       "version": "1.22.0-dev.20250409-89f8206ba4",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
       "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/open": {
       "version": "11.0.0",
@@ -24855,8 +24840,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.59.1",
@@ -26235,7 +26219,6 @@
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
       "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -27875,7 +27858,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "license": "(MIT OR CC0-1.0)",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -29730,7 +29712,7 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@skillsmith/core": "^0.7.0",
+        "@skillsmith/core": "^0.7.1",
         "@skillsmith/mcp-server": "^0.5.1",
         "chalk": "5.6.2",
         "chokidar": "4.0.3",
@@ -29840,7 +29822,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -29854,7 +29836,6 @@
         "fts5-sql-bundle": "1.0.2",
         "lru-cache": "11.3.3",
         "posthog-node": "5.29.2",
-        "stripe": "20.3.0",
         "tree-sitter-wasms": "0.1.13",
         "typescript": "5.9.3",
         "web-tree-sitter": "0.25.10",
@@ -29904,23 +29885,6 @@
       },
       "engines": {
         "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-      }
-    },
-    "packages/core/node_modules/stripe": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.3.0.tgz",
-      "integrity": "sha512-DYzcmV1MfYhycr1GwjCjeQVYk9Gu8dpxyTlu7qeDCsuguug7oUTxPsUQuZeSf/OPzK7pofqobvOKVqAwlpgf/Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@types/node": ">=16"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
       }
     },
     "packages/doc-retrieval-mcp": {
@@ -30213,7 +30177,7 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.7.0",
+        "@skillsmith/core": "^0.7.1",
         "esbuild": "0.27.2",
         "ulid": "3.0.1"
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.7.0",
+    "@skillsmith/core": "^0.7.1",
     "@skillsmith/mcp-server": "^0.5.1",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.7.1
+
+- **Chore**: SMI-5008 — removed direct dependency on `stripe`. Billing lives in `@smith-horn/enterprise` since v0.7.0; this release completes the dependency-graph cleanup. Consumers of `@skillsmith/core` no longer pull in the ~3MB Stripe SDK or its transitive deps. (#869)
 - **Chore**: SMI-5009 — `@huggingface/transformers` is now an `optionalDependency` (was a regular `dependency`). Aligns the declared graph with the actual runtime contract per ADR-009: `loadTransformersModule()` already returns `null` on import failure and `EmbeddingService` already falls back to mock embeddings (`SKILLSMITH_USE_MOCK_EMBEDDINGS=true`). Consumers installing with `npm install --no-optional` (or on hosts without prebuilt ONNX binaries) now skip the ~50 MB native install and the runtime degrades gracefully to keyword-only search. To restore real embeddings, install `@huggingface/transformers` explicitly. Companion change in `@skillsmith/mcp-server`: structured stderr warning at server boot when transformers is unavailable (was previously silent). (#870)
 
 ## v0.7.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -92,7 +92,6 @@
     "fts5-sql-bundle": "1.0.2",
     "lru-cache": "11.3.3",
     "posthog-node": "5.29.2",
-    "stripe": "20.3.0",
     "tree-sitter-wasms": "0.1.13",
     "typescript": "5.9.3",
     "web-tree-sitter": "0.25.10",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.7.0'
+export const VERSION = '0.7.1'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.7.0",
+    "@skillsmith/core": "^0.7.1",
     "esbuild": "0.27.2",
     "ulid": "3.0.1"
   },


### PR DESCRIPTION
## Summary

- Removes the `stripe` package from `@skillsmith/core` direct dependencies. After SMI-5006 (W1) moved billing into `@smith-horn/enterprise`, no source file in `packages/core/src/` imports `stripe`; this completes the dependency-graph cleanup. (#869)
- Bumps `@skillsmith/core` to `0.7.1` (patch — no API surface change). Sibling consumer ranges (`@skillsmith/cli`, `@skillsmith/mcp-server`) bumped to `^0.7.1` to satisfy the workspace-version audit. Both ship with this release; SMI-5009's transformers-optional change (already merged at `186a1e84`) rides under the same `v0.7.1` CHANGELOG section.
- Synced the `VERSION` constant in `packages/core/src/index.ts` to `0.7.1` (required by `prepare-release.test.ts`).

Closes #869.
Linear: SMI-5008.

## Acceptance criteria

- [x] `stripe` is absent from `packages/core/package.json` dependencies
- [x] `stripe` is still present in `packages/enterprise/package.json` dependencies (`"stripe": "20.3.0"`)
- [x] `grep -rE "from 'stripe'|require\('stripe'\)" packages/core/src --include="*.ts"` returns empty
- [x] Preflight passes (host-side; in-container hits the known worktree git-dir limitation but Check 3 carve-out fires on host with `@skillsmith/core@0.7.1 — accepted (released in this PR)`)
- [x] Direct-deps smoke: `npm pack` tarball's `package.json` has no `stripe` in `dependencies`
- [x] Transitive smoke (plan-review H7): `npm install --omit=dev --omit=optional` into scratch dir shows no `stripe` in resolution tree
- [x] Core's version bumped to `0.7.1` (both `package.json` and `src/index.ts` VERSION constant)
- [x] CHANGELOG `v0.7.1` section added
- [x] concurrency-auditor Mode B: NA (no scannable files)
- [x] Governance retro: no findings

## Smoke output (verbatim)

Direct-deps:
```
dependencies:
{
  "@opentelemetry/api": "1.9.1",
  ... (15 deps, was 16)
}

stripe in deps: False
version: 0.7.1
```

Transitive:
```
added 5 packages [...] found 0 vulnerabilities
---
Searching transitive tree for stripe:
PASS: stripe absent from transitive resolution
```

## Test plan

- [x] `docker exec smi-5008-core-stripe-removal-dev-1 npm run preflight` — workspace-version audit (host re-run): clean
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run audit:standards` — 68 passed, 3 warnings (in-container git limitation, pre-existing), 0 failed
- [x] per-package tests: core 3566/3569, mcp-server unit 874/881, cli 560/560, enterprise 737/738 (0 failures)
- [x] mcp-server integration: 3 pre-existing failures (`@skillsmith/core/install` subpath resolution under test runner — surfaces on main; unrelated to this change)
- [x] `npx madge --circular packages/core/src` — no circular deps
- [x] direct-deps + transitive smoke (npm pack + scratch install) — both clean

## Publish gate

After merge, this requires an OIDC publish of `@skillsmith/core@0.7.1` so external consumers see the install-weight benefit. Per CLAUDE.md, publish is gated on user sign-off (`gh workflow run publish.yml -f dry_run=false`) — not triggered by this PR.

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>