### PR TITLE
fix(website): SMI-5055 graceful degradation when Supabase Auth is unreachable

### DIFF
--- a/packages/website/src/components/auth/LoginButton.astro
+++ b/packages/website/src/components/auth/LoginButton.astro
@@ -160,12 +160,6 @@ const buttonId = `github-login-${Math.random().toString(36).substring(2, 9)}`
 
 <script>
   import { getSupabaseClient } from '../../lib/supabase-client'
-  import { withAuthTimeout } from '../../lib/auth-timeout'
-
-  // SMI-5055: bound signInWithOAuth so a degraded GoTrue surfaces a clear error
-  // banner instead of a 30 s+ silent spinner. 10 s is generous for slow networks
-  // while still failing visibly faster than the upstream gateway timeout.
-  const OAUTH_REQUEST_TIMEOUT_MS = 10_000
 
   // UA hint for known in-app browsers that swallow OAuth redirects (SMI-2757)
   function isInAppBrowser(): boolean {
@@ -266,20 +260,20 @@ const buttonId = `github-login-${Math.random().toString(36).substring(2, 9)}`
         try {
           // Fetch OAuth URL without immediately redirecting so we can inspect it
           // and use it in the fallback banner if the redirect is swallowed (SMI-2757).
-          // Bounded with withAuthTimeout so a degraded GoTrue surfaces a real
-          // error to the user instead of a silent spinner (SMI-5055).
-          const { data, error } = await withAuthTimeout(
-            supabase.auth.signInWithOAuth({
-              provider: 'github',
-              options: {
-                redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirectTo)}`,
-                scopes: 'read:user user:email',
-                skipBrowserRedirect: true,
-              },
-            }),
-            OAUTH_REQUEST_TIMEOUT_MS,
-            'Sign-in is taking too long. Check status.supabase.com or try again in a few minutes.'
-          )
+          // SMI-5055 note: signInWithOAuth({skipBrowserRedirect}) in
+          // @supabase/supabase-js@2.105 builds the URL synchronously, so a
+          // withAuthTimeout wrapper here is dead code today. The actual
+          // GoTrue hop is the browser navigation below; if GoTrue is degraded
+          // (status.supabase.com), the user lands on an opaque Cloudflare
+          // 504 page and we have no client-side hook to intercept it.
+          const { data, error } = await supabase.auth.signInWithOAuth({
+            provider: 'github',
+            options: {
+              redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirectTo)}`,
+              scopes: 'read:user user:email',
+              skipBrowserRedirect: true,
+            },
+          })
 
           if (error) throw error
           if (!data?.url) throw new Error('No OAuth URL returned')

--- a/packages/website/src/components/auth/LoginButton.astro
+++ b/packages/website/src/components/auth/LoginButton.astro
@@ -160,6 +160,12 @@ const buttonId = `github-login-${Math.random().toString(36).substring(2, 9)}`
 
 <script>
   import { getSupabaseClient } from '../../lib/supabase-client'
+  import { withAuthTimeout } from '../../lib/auth-timeout'
+
+  // SMI-5055: bound signInWithOAuth so a degraded GoTrue surfaces a clear error
+  // banner instead of a 30 s+ silent spinner. 10 s is generous for slow networks
+  // while still failing visibly faster than the upstream gateway timeout.
+  const OAUTH_REQUEST_TIMEOUT_MS = 10_000
 
   // UA hint for known in-app browsers that swallow OAuth redirects (SMI-2757)
   function isInAppBrowser(): boolean {
@@ -259,15 +265,21 @@ const buttonId = `github-login-${Math.random().toString(36).substring(2, 9)}`
 
         try {
           // Fetch OAuth URL without immediately redirecting so we can inspect it
-          // and use it in the fallback banner if the redirect is swallowed (SMI-2757)
-          const { data, error } = await supabase.auth.signInWithOAuth({
-            provider: 'github',
-            options: {
-              redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirectTo)}`,
-              scopes: 'read:user user:email',
-              skipBrowserRedirect: true,
-            },
-          })
+          // and use it in the fallback banner if the redirect is swallowed (SMI-2757).
+          // Bounded with withAuthTimeout so a degraded GoTrue surfaces a real
+          // error to the user instead of a silent spinner (SMI-5055).
+          const { data, error } = await withAuthTimeout(
+            supabase.auth.signInWithOAuth({
+              provider: 'github',
+              options: {
+                redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirectTo)}`,
+                scopes: 'read:user user:email',
+                skipBrowserRedirect: true,
+              },
+            }),
+            OAUTH_REQUEST_TIMEOUT_MS,
+            'Sign-in is taking too long. Check status.supabase.com or try again in a few minutes.'
+          )
 
           if (error) throw error
           if (!data?.url) throw new Error('No OAuth URL returned')

--- a/packages/website/src/components/auth/UserMenu.astro
+++ b/packages/website/src/components/auth/UserMenu.astro
@@ -256,6 +256,12 @@ const { loginRedirect = '/account' } = Astro.props
 
 <script>
   import { getSupabaseClient } from '../../lib/supabase-client'
+  import { withAuthTimeout } from '../../lib/auth-timeout'
+
+  // SMI-5055: if Supabase Auth (GoTrue) is unreachable, fall back to the
+  // logged-out UI within one heartbeat rather than leaving the shimmer skeleton
+  // visible forever (status.supabase.com degradation, 2026-05-20).
+  const GET_SESSION_TIMEOUT_MS = 3000
 
   let controller: AbortController | null = null
 
@@ -273,19 +279,34 @@ const { loginRedirect = '/account' } = Astro.props
     const dropdown = document.getElementById('user-dropdown')
     const logoutBtn = document.getElementById('logout-btn')
 
+    const showLoggedOut = () => {
+      if (loadingState) loadingState.style.display = 'none'
+      if (loggedOutState) loggedOutState.style.display = 'block'
+    }
+
     const supabase = getSupabaseClient()
 
     if (!supabase) {
       // No config, show logged out state
-      if (loadingState) loadingState.style.display = 'none'
-      if (loggedOutState) loggedOutState.style.display = 'block'
+      showLoggedOut()
       return
     }
 
-    // Check auth state
-    const {
-      data: { session },
-    } = await supabase.auth.getSession()
+    // Check auth state — bounded so a degraded GoTrue can't leave the header
+    // stuck on the loading skeleton forever (SMI-5055).
+    let session: Awaited<ReturnType<typeof supabase.auth.getSession>>['data']['session'] = null
+    try {
+      const result = await withAuthTimeout(
+        supabase.auth.getSession(),
+        GET_SESSION_TIMEOUT_MS,
+        'Supabase Auth did not respond within 3 s — treating as logged out.'
+      )
+      session = result.data.session
+    } catch (err) {
+      console.warn('UserMenu: auth check failed, rendering logged-out state.', err)
+      showLoggedOut()
+      return
+    }
 
     if (loadingState) loadingState.style.display = 'none'
 

--- a/packages/website/src/lib/auth-timeout.test.ts
+++ b/packages/website/src/lib/auth-timeout.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { AuthTimeoutError, withAuthTimeout } from './auth-timeout'
+
+describe('withAuthTimeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('resolves with the inner value when the promise settles before the deadline', async () => {
+    const inner = Promise.resolve({ session: { user: { id: 'u1' } } })
+    await expect(withAuthTimeout(inner, 3000)).resolves.toEqual({ session: { user: { id: 'u1' } } })
+  })
+
+  it('throws AuthTimeoutError when the inner promise exceeds the deadline', async () => {
+    const inner = new Promise<never>(() => {
+      /* never resolves */
+    })
+    const racing = withAuthTimeout(inner, 3000, 'Sign-in service timed out')
+
+    vi.advanceTimersByTime(3000)
+    await expect(racing).rejects.toBeInstanceOf(AuthTimeoutError)
+    await expect(racing).rejects.toMatchObject({
+      isTimeout: true,
+      message: 'Sign-in service timed out',
+    })
+  })
+
+  it('propagates inner rejection without wrapping it', async () => {
+    const innerErr = new Error('network down')
+    const inner = Promise.reject(innerErr)
+    await expect(withAuthTimeout(inner, 3000)).rejects.toBe(innerErr)
+  })
+
+  it('clears the timeout once the inner promise settles (no leaked timer)', async () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const inner = Promise.resolve('ok')
+    await withAuthTimeout(inner, 3000)
+    expect(clearSpy).toHaveBeenCalled()
+    clearSpy.mockRestore()
+  })
+
+  it('uses the default timeout message when none is provided', async () => {
+    const racing = withAuthTimeout(new Promise<never>(() => {}), 100)
+    vi.advanceTimersByTime(100)
+    await expect(racing).rejects.toMatchObject({ message: 'Authentication service timed out' })
+  })
+})

--- a/packages/website/src/lib/auth-timeout.ts
+++ b/packages/website/src/lib/auth-timeout.ts
@@ -1,0 +1,36 @@
+/**
+ * Auth-call timeout helper (SMI-5055)
+ *
+ * Wraps a Supabase Auth promise (getSession, signInWithOAuth, etc.) with a
+ * deadline so the website's UI degrades gracefully when GoTrue is unreachable
+ * (e.g. the 2026-05-20 status.supabase.com "Partially Degraded Service" incident,
+ * where /auth/v1/authorize returned HTTP 504 after 30+ s).
+ *
+ * Throws AuthTimeoutError on timeout; callers can branch on `err.isTimeout`.
+ */
+
+export class AuthTimeoutError extends Error {
+  readonly isTimeout = true
+  constructor(message: string) {
+    super(message)
+    this.name = 'AuthTimeoutError'
+  }
+}
+
+export async function withAuthTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage = 'Authentication service timed out'
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new AuthTimeoutError(timeoutMessage)), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
+}

--- a/scripts/uat-smi-5055.mjs
+++ b/scripts/uat-smi-5055.mjs
@@ -1,0 +1,197 @@
+/* eslint-disable no-console */
+// SMI-5055 UAT — verifies the auth degradation fallbacks against the real
+// (still-degraded) prod Supabase project. Drops into Docker, drives Chromium
+// against the local Astro dev server (which injects the same prod
+// __SUPABASE_CONFIG__ as the deployed website).
+
+import { chromium } from 'playwright'
+
+const BASE = process.env.UAT_BASE || 'http://localhost:3001'
+const HEADERLESS_RESOLVE_BUDGET_MS = 5000 // 3s timeout + 2s slack
+const LOGIN_BANNER_BUDGET_MS = 14000 // 10s timeout + 4s slack
+
+const fail = (msg) => {
+  console.error('❌', msg)
+  process.exitCode = 1
+}
+const ok = (msg) => console.log('✅', msg)
+
+async function pricingHeaderFallsBack(page) {
+  console.log('--- TEST 1: /pricing header fallback (expect Log in / Get Started within ~3s)')
+  const navStart = Date.now()
+  await page.goto(`${BASE}/pricing`, { waitUntil: 'domcontentloaded' })
+
+  // The skeleton is the .user-menu-loading element. Once auth times out (or
+  // succeeds), it gets display:none and .user-menu-logged-out becomes visible.
+  // Wait for either the logged-out state OR the logged-in state to appear.
+  try {
+    await page.waitForFunction(
+      () => {
+        const out = document.getElementById('user-menu-logged-out')
+        const inn = document.getElementById('user-menu-logged-in')
+        const loading = document.getElementById('user-menu-loading')
+        const visible = (el) => el && el.style.display !== 'none'
+        return (visible(out) || visible(inn)) && !visible(loading)
+      },
+      { timeout: HEADERLESS_RESOLVE_BUDGET_MS }
+    )
+    const elapsed = Date.now() - navStart
+    ok(`Header resolved in ${elapsed} ms (budget ${HEADERLESS_RESOLVE_BUDGET_MS} ms)`)
+
+    const loginText = await page
+      .locator('#user-menu-logged-out a, #user-menu-logged-out button')
+      .first()
+      .textContent({ timeout: 2000 })
+      .catch(() => null)
+    if (loginText) {
+      ok(`Logged-out CTA visible: "${loginText.trim().slice(0, 40)}…"`)
+    } else {
+      fail('Logged-out CTA not visible after fallback')
+    }
+  } catch (err) {
+    fail(
+      `Header still on skeleton after ${HEADERLESS_RESOLVE_BUDGET_MS} ms — degradation fix did NOT engage`
+    )
+    const skel = await page
+      .locator('#user-menu-loading')
+      .isVisible()
+      .catch(() => false)
+    console.log('   skeleton still visible:', skel)
+    console.log('   error:', err.message)
+  }
+
+  await page.screenshot({ path: '/tmp/uat-pricing.png', fullPage: false })
+  console.log('   screenshot → /tmp/uat-pricing.png')
+}
+
+async function staleTokenTriggersTimeoutFallback(page) {
+  console.log(
+    '\n--- TEST 3: stale auth token in localStorage → getSession refresh hits degraded GoTrue → 3s timeout fallback'
+  )
+
+  // Seed a syntactically-valid but expired Supabase auth-token entry. This
+  // forces supabase-js to attempt a refresh via /auth/v1/token, which hits
+  // the degraded GoTrue and hangs — exactly the user scenario where the
+  // header skeleton would otherwise stick forever without our fix.
+  await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded' })
+  await page.evaluate(() => {
+    const fakeJwt =
+      btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' })) +
+      '.' +
+      btoa(JSON.stringify({ exp: 1, sub: 'stale-user' })) +
+      '.signature'
+    const session = {
+      access_token: `header.${fakeJwt}.sig`,
+      refresh_token: 'definitely-not-real',
+      expires_at: 1, // long expired
+      expires_in: -1,
+      token_type: 'bearer',
+      user: { id: 'stale-user', email: 'stale@example.com' },
+    }
+    localStorage.setItem('sb-vrcnzpmndtroqxxoqkzy-auth-token', JSON.stringify(session))
+  })
+
+  const navStart = Date.now()
+  await page.goto(`${BASE}/pricing`, { waitUntil: 'domcontentloaded' })
+  try {
+    await page.waitForFunction(
+      () => {
+        const out = document.getElementById('user-menu-logged-out')
+        const loading = document.getElementById('user-menu-loading')
+        const visible = (el) => el && el.style.display !== 'none'
+        return visible(out) && !visible(loading)
+      },
+      { timeout: HEADERLESS_RESOLVE_BUDGET_MS }
+    )
+    const elapsed = Date.now() - navStart
+    if (elapsed >= 2500 && elapsed <= 4500) {
+      ok(`Timeout fallback fired in ${elapsed} ms — within expected 3s window`)
+    } else if (elapsed < 2500) {
+      ok(
+        `Header resolved in ${elapsed} ms (fast path — refresh succeeded or no network call needed)`
+      )
+    } else {
+      fail(`Header took ${elapsed} ms — timeout fallback didn't engage cleanly`)
+    }
+  } catch (err) {
+    fail(`Header skeleton stuck > ${HEADERLESS_RESOLVE_BUDGET_MS} ms with stale token`)
+    console.log('   error:', err.message)
+  }
+
+  // Cleanup so subsequent tests start fresh.
+  await page.evaluate(() => localStorage.clear())
+  await page.screenshot({ path: '/tmp/uat-stale-token.png', fullPage: false })
+  console.log('   screenshot → /tmp/uat-stale-token.png')
+}
+
+async function loginButtonSmokeCheck(page) {
+  console.log('\n--- TEST 2: /login GitHub button smoke check (button renders, no JS errors)')
+  // The actual OAuth-redirect 504 happens at the browser navigation level
+  // (supabase-js v2.x with skipBrowserRedirect builds the URL synchronously,
+  // so our withAuthTimeout wrapper around signInWithOAuth is effectively a
+  // no-op for this version). The user-visible 504 page is owned by
+  // Cloudflare/Supabase — not addressable from our client. We verify the
+  // button still renders and doesn't throw before the redirect attempt.
+
+  const errors = []
+  page.on('pageerror', (e) => errors.push(e.message))
+
+  await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('.github-login-btn', { timeout: 5000 })
+
+  const btnText = (await page.locator('.github-login-btn .btn-text').textContent()) || ''
+  if (/Continue with GitHub/i.test(btnText)) {
+    ok(`Button renders with expected label: "${btnText.trim()}"`)
+  } else {
+    fail(`Button text unexpected: "${btnText.trim()}"`)
+  }
+
+  // Smoke: ensure no uncaught JS errors during init.
+  await page.waitForTimeout(500)
+  if (errors.length === 0) {
+    ok('No uncaught page errors during /login init')
+  } else {
+    fail(`Page errors detected: ${errors.join(' | ')}`)
+  }
+
+  await page.screenshot({ path: '/tmp/uat-login.png', fullPage: false })
+  console.log('   screenshot → /tmp/uat-login.png')
+  console.log(
+    '   NOTE: The OAuth-redirect 504 (user clicks → browser navigates → Cloudflare 504) is not addressable client-side without UX changes (popup/new tab). Tracked as a follow-up.'
+  )
+}
+
+;(async () => {
+  console.log(`SMI-5055 UAT against ${BASE}`)
+  console.log('Supabase Auth is currently degraded — this exercises the real fallback paths.')
+  const browser = await chromium.launch()
+  const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+  const page = await ctx.newPage()
+  page.on('console', (m) => {
+    if (['error', 'warning'].includes(m.type())) {
+      console.log(`   [browser ${m.type()}]`, m.text().slice(0, 200))
+    }
+  })
+
+  try {
+    // Warm Vite dep optimization so first real test isn't dominated by
+    // first-hit module-graph build (~5s of slack on a cold dev server).
+    console.log('--- WARMUP: priming Vite dep cache')
+    await page.goto(`${BASE}/pricing`, { waitUntil: 'load' }).catch(() => {})
+    await page.goto(`${BASE}/login`, { waitUntil: 'load' }).catch(() => {})
+    await pricingHeaderFallsBack(page)
+    await staleTokenTriggersTimeoutFallback(page)
+    await loginButtonSmokeCheck(page)
+  } finally {
+    await browser.close()
+  }
+
+  if (process.exitCode) {
+    console.log('\n❌ UAT FAILED')
+  } else {
+    console.log('\n✅ UAT PASSED — degradation fallbacks work as designed')
+  }
+})().catch((err) => {
+  console.error('UAT crashed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- **UserMenu.astro**: `supabase.auth.getSession()` now wrapped in a 3 s timeout. When Supabase Auth is degraded **and** the visitor has a stale auth token in localStorage (the only case where `getSession()` actually makes a network call), the header skeleton falls back to the "Log in" / "Get Started" CTAs instead of shimmering forever.
- **Helper**: new `packages/website/src/lib/auth-timeout.ts` (`withAuthTimeout` + `AuthTimeoutError`), 5 unit tests.
- **LoginButton.astro**: an earlier-revision wrapper around `signInWithOAuth()` was removed after UAT showed it was dead code — `@supabase/supabase-js@2.105` with `skipBrowserRedirect: true` builds the URL synchronously, so the wrapper never fires. Comment in the source documents the residual limitation (see below).

## Headless UAT against the real outage

Ran `scripts/uat-smi-5055.mjs` (Playwright + Chromium in the Docker dev container) against the local Astro dev server, which injects the same prod `__SUPABASE_CONFIG__` as the deployed website, so the auth code path hit the still-degraded prod GoTrue.

| Test | Result |
|---|---|
| 1. `/pricing` healthy header (no cached session) | ✅ 127 ms — fast path, `getSession()` returns null from localStorage |
| 3. `/pricing` with seeded stale auth-token → forces refresh against degraded GoTrue | ✅ **3102 ms — `AuthTimeoutError` fires, header falls back to Login CTA** |
| 2. `/login` smoke (button renders, no uncaught JS) | ✅ |

Test 3 is the load-bearing one: it proves the fix engages end-to-end against the real degraded service, not against a mocked one. Browser console line during Test 3:
> `UserMenu: auth check failed, rendering logged-out state. AuthTimeoutError: Supabase Auth did not respond within 3 s — treating as logged out.`

## Known limitation (not addressed by this PR)

The other user-reported symptom — "Continue with GitHub" timing out — happens at a layer this PR can't fix. With `skipBrowserRedirect: true`, `signInWithOAuth` returns the OAuth URL synchronously; the actual GoTrue hop is the **browser navigation** to `https://<ref>.supabase.co/auth/v1/authorize?...`. When GoTrue is degraded, that navigation lands users on an opaque Cloudflare 504 — outside our JS context, so no app-level banner can intercept it. A fetch-based preflight was prototyped during UAT but proved too unreliable to gate on (HEAD/cors returned 405 in 590 ms even mid-outage on 2026-05-20). Genuine fixes require a UX change (open OAuth in a popup so the original page can detect failure) — tracked as **SMI-5059** (Website: OAuth sign-in in a popup so degraded GoTrue surfaces an in-app error).

## Trigger

2026-05-20 ~17:51 UTC — user-reported. `status.supabase.com` showed "Partially Degraded Service" since 17:41 UTC; `POST /auth/v1/authorize?provider=github` returned HTTP 504. PostgREST on the same project was healthy — only GoTrue affected.

## Linear

- SMI-5055 — Website: graceful degradation when Supabase Auth (GoTrue) is unreachable

## Test plan

- [x] `docker exec -w /app/packages/website skillsmith-dev-1 npx vitest run src/lib/auth-timeout.test.ts` → 5/5 pass
- [x] `docker exec skillsmith-dev-1 npm run typecheck` / `lint` / `format:check`
- [x] `docker exec -w /app/packages/website skillsmith-dev-1 npx astro check` → 0/0/0
- [x] `docker exec -w /app/packages/website skillsmith-dev-1 npm run build` → clean
- [x] `docker exec skillsmith-dev-1 npm run audit:standards` → no new failures
- [x] **Headless E2E UAT** (`scripts/uat-smi-5055.mjs`) → all three checks pass against the real degraded GoTrue
- [ ] Post-merge: confirm prod sign-in flow once Supabase Auth has recovered

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
