### PR TITLE
fix(ci): SMI-5047 swap GITHUB_TOKEN to RELEASE_PAT in release-cadence.yml

### DIFF
--- a/.github/workflows/release-cadence.yml
+++ b/.github/workflows/release-cadence.yml
@@ -106,7 +106,14 @@ jobs:
       - name: Open PR
         if: steps.check.outputs.count != '0' && github.event.inputs.dry_run != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # SMI-5047: GITHUB_TOKEN cannot create PRs because the repo-level
+          # "Allow GitHub Actions to create and approve pull requests" setting
+          # is disabled (failure mode introduced ~2026-04-26; 4 missed Sunday
+          # windows). Use a dedicated RELEASE_PAT (least-privilege: only
+          # pull-requests:write + contents:write on smith-horn/skillsmith)
+          # rather than reusing GH_PAT, which would broaden batch-transform
+          # and indexer-dispatch blast radius.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           gh pr create \
             --title "chore(release): weekly cadence bump — ${{ steps.branch.outputs.date }}" \


### PR DESCRIPTION
Fixes SMI-5047 — `release-cadence.yml` has failed every Sunday since 2026-04-26 with:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

## Root cause

The workflow's `permissions:` block declares `pull-requests: write` (correct), but the **repo-level setting** "Allow GitHub Actions to create and approve pull requests" gates `createPullRequest` regardless of workflow-scoped permissions. That setting was disabled around 2026-04-26 (likely org-level policy change tracked under SMI-5045 parent investigation).

**Impact**: 4 missed Sunday release windows (2026-04-26, 2026-05-03, 2026-05-10, 2026-05-17). No automated patch-bump PRs landed during this period.

## Fix

Swap `GH_TOKEN` in the `Open PR` step from `secrets.GITHUB_TOKEN` to `secrets.RELEASE_PAT` — a dedicated fine-grained PAT scoped to `smith-horn/skillsmith` only, with `pull-requests: write` + `contents: write`. Least-privilege; does not broaden the existing `GH_PAT` (used by `batch-transform.yml` + `indexer-dispatch`) by adding PR-create capability.

## Plan-review

0 BLOCKER, 1 HIGH, 3 MEDIUM, 2 LOW — all folded into the persisted plan: `docs/internal/implementation/smi-5047-release-cadence-pat-swap.md` (landed via PR #1264).

## Verification (post-merge)

1. Dry-run parse check: `gh workflow run release-cadence.yml -f dry_run=true` (sanity-only; doesn't exercise the new binding).
2. **Real dispatch** (the actual integration test): `gh workflow run release-cadence.yml -f dry_run=false`. Should open a cadence PR within ~60s; with 4 weeks of accumulated `[Unreleased]` entries, the threshold gate will trigger.
3. Next scheduled fire 2026-05-24 03:00 UTC should turn the chronic-red-monitor (SMI-5005) green for this workflow.

## Operational caveat (already in plan)

`release-cadence-pr-staleness.yml` auto-closes PRs older than 24h. The Sunday cadence PR must be merged same-day to survive. If not, file SMI-5049 to bump `max_hours` to 72.

## Related

- Plan: `docs/internal/implementation/smi-5047-release-cadence-pat-swap.md`
- Linear: SMI-5047 (P2-High)
- Parent investigation: SMI-5045
- Surfaced by: SMI-5005 chronic-red-monitor first-fire (2026-05-20)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)