### PR TITLE
chore(release): weekly cadence bump — 2026-05-20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29713,7 +29713,7 @@
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
         "@skillsmith/core": "^0.7.2",
-        "@skillsmith/mcp-server": "^0.5.1",
+        "@skillsmith/mcp-server": "^0.5.2",
         "chalk": "5.6.2",
         "chokidar": "4.0.3",
         "cli-table3": "0.6.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29708,11 +29708,11 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@skillsmith/core": "^0.7.1",
+        "@skillsmith/core": "^0.7.2",
         "@skillsmith/mcp-server": "^0.5.1",
         "chalk": "5.6.2",
         "chokidar": "4.0.3",
@@ -29822,7 +29822,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -30020,7 +30020,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-        "@skillsmith/core": "^0.7.0",
+        "@skillsmith/core": "^0.7.2",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
@@ -30173,11 +30173,11 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.7.1",
+        "@skillsmith/core": "^0.7.2",
         "esbuild": "0.27.2",
         "ulid": "3.0.1"
       },
@@ -30227,7 +30227,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.6.2
+
+- **Chore**: SMI-5008 remove stripe SDK from @skillsmith/core dependencies (#869) (#1262)
+
 - **Chore**: SMI-5006 — bump `@skillsmith/core` dependency range to `^0.7.0` (BREAKING in core: billing moved to `@smith-horn/enterprise/billing`). No CLI surface change; CLI does not consume the billing module directly.
 - **Chore**: SMI-4539 — track `@skillsmith/core` dependency range to `^0.6.3` (synthetic patch release verifying the npm trusted-publisher OIDC publish path, PR #1171). No functional change.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.7.1",
+    "@skillsmith/core": "^0.7.2",
     "@skillsmith/mcp-server": "^0.5.1",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
     "@skillsmith/core": "^0.7.2",
-    "@skillsmith/mcp-server": "^0.5.1",
+    "@skillsmith/mcp-server": "^0.5.2",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",
     "cli-table3": "0.6.5",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.7.2
+
+- **Chore**: SMI-5008 remove stripe SDK from @skillsmith/core dependencies (#869) (#1262)
+- **Chore**: SMI-5009 promote @huggingface/transformers to optionalDependency + MCP startup capability probe (#870) (#1252)
+- **Chore**: SMI-5006 move billing module to @smith-horn/enterprise + remove core shim (#867, #868) (#1246)
+
 ## v0.7.1
 
 - **Chore**: SMI-5008 — removed direct dependency on `stripe`. Billing lives in `@smith-horn/enterprise` since v0.7.0; this release completes the dependency-graph cleanup. Consumers of `@skillsmith/core` no longer pull in the ~3MB Stripe SDK or its transitive deps. (#869)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.7.1'
+export const VERSION = '0.7.2'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-    "@skillsmith/core": "^0.7.0",
+    "@skillsmith/core": "^0.7.2",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.5.2
+
+- **Chore**: SMI-5008 remove stripe SDK from @skillsmith/core dependencies (#869) (#1262)
+
 - **Chore**: SMI-5006 — bump `@skillsmith/core` dependency range to `^0.7.0` (BREAKING in core: billing moved to `@smith-horn/enterprise/billing`). The standalone Stripe webhook endpoint no longer imports from `@skillsmith/core/billing`; it now declares a local structural type for `StripeWebhookHandler` so production wiring (and tests) can pass in the canonical `@smith-horn/enterprise/billing` class without a workspace cycle. No runtime change for downstream MCP consumers.
 - **Feature**: SMI-5009 — startup capability probe. `main()` now calls `probeEmbeddingCapability()` before connecting the stdio transport. Probe runs `EmbeddingService.checkAvailability()` inside a `Promise.race` with a hard 2 s `Symbol` timeout sentinel and a try/catch wrapper — it can neither block nor crash server boot. On success the probe is silent; when the mock fallback is engaged (`@huggingface/transformers` absent or `SKILLSMITH_USE_MOCK_EMBEDDINGS=true`), the probe emits a single structured stderr line including a remediation hint: `[skillsmith] embeddings: mock (transformers unavailable: <reason>; install @huggingface/transformers or set SKILLSMITH_USE_MOCK_EMBEDDINGS=true to silence)`. Logs are stderr-only to avoid corrupting the MCP stdio protocol frame. Companion to the `@skillsmith/core` optional-dep promotion in the same PR. (#870)
 - **Chore**: SMI-4539 — track `@skillsmith/core` dependency range to `^0.6.3` (synthetic patch release verifying the npm trusted-publisher OIDC publish path, PR #1171). No functional change.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.7.1",
+    "@skillsmith/core": "^0.7.2",
     "esbuild": "0.27.2",
     "ulid": "3.0.1"
   },

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,9 +8,13 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.5.1",
+  "version": "0.5.2",
   "_meta": {
-    "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
+    "io.skillsmith/categories": [
+      "developer-tools",
+      "ai-agents",
+      "skill-management"
+    ],
     "io.skillsmith/keywords": [
       "claude-code",
       "agent-skills",
@@ -23,7 +27,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -10,11 +10,7 @@
   },
   "version": "0.5.2",
   "_meta": {
-    "io.skillsmith/categories": [
-      "developer-tools",
-      "ai-agents",
-      "skill-management"
-    ],
+    "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
       "claude-code",
       "agent-skills",

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -73,7 +73,7 @@ import { createQuotaMiddleware } from './middleware/quota.js'
 import { resolveStartupFlag } from './cli-flags.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.5.1'
+const PACKAGE_VERSION = '0.5.2'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## v0.2.4
+
+- Version bump
+
 ## [0.2.3] - 2026-05-06
 
 - Marketplace keywords: add `agent-skills`, `cursor`, `copilot` so the extension surfaces beyond the Claude Code search.

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Discover and install agent skills directly in VS Code",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
Automated weekly release cadence PR opened by `release-cadence.yml` (SMI-4191).

## What this PR does

Runs `scripts/prepare-release.ts --all=patch` to bump all packages by one patch version and drain per-package CHANGELOG `[Unreleased]` sections into the new versions.

## What to check before merging

1. The bumped versions match what you want to ship (patch/minor/major). If minor or major is needed, close this PR, run `prepare-release.ts` with the right flags locally, and open a manual PR.
2. The CHANGELOG entries read cleanly and reference the right Linear issues.
3. CI is green.

## After merging

Trigger publish: `gh workflow run publish.yml -f dry_run=false`. The `create-gh-release` job will create matching GitHub Releases automatically.

Parent: SMI-4144. See [ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md).