### PR TITLE
fix(ci): SMI-5060 publish.yml — gate dependents on real core publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -590,11 +590,23 @@ jobs:
     # check on `needs:`. Without it, when `publish-core` skips (because core is
     # already published), this job is auto-skipped before its `if:` is evaluated
     # — making the explicit `result == 'skipped'` clause below dead code.
+    #
+    # SMI-5060: gate the 'skipped' branch on the core-exists predicate. Without
+    # it, when validate fails and publish-core auto-skips because its `needs:`
+    # failed, GitHub Actions still reports `publish-core.result == 'skipped'`
+    # — letting this dependent publish despite core having neither been built
+    # nor published. `core-exists == 'true'` discriminates the legitimate skip
+    # (core was already on npm) from the failure-mode skip.
+    #
+    # Edge case retained: if `validate` is *cancelled* (not failed) and core
+    # was already on npm, this job still runs. That's intentional — manual
+    # cancellation is an operator action, not a soundness failure.
     if: |
       !cancelled() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.mcp-exists != 'true' &&
-      (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')
+      (needs.publish-core.result == 'success' ||
+       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true'))
 
     steps:
       - name: Checkout
@@ -780,11 +792,13 @@ jobs:
       contents: read
       id-token: write
     # SMI-4803: see publish-mcp-server for `!cancelled()` rationale.
+    # SMI-5060: see publish-mcp-server for the core-exists predicate rationale.
     if: |
       !cancelled() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.cli-exists != 'true' &&
-      (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')
+      (needs.publish-core.result == 'success' ||
+       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true'))
 
     steps:
       - name: Checkout
@@ -897,11 +911,13 @@ jobs:
       id-token: write
       packages: write
     # SMI-4803: see publish-mcp-server for `!cancelled()` rationale.
+    # SMI-5060: see publish-mcp-server for the core-exists predicate rationale.
     if: |
       !cancelled() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.enterprise-exists != 'true' &&
-      (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')
+      (needs.publish-core.result == 'success' ||
+       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true'))
 
     steps:
       - name: Checkout

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -3913,6 +3913,77 @@ console.log(`\n${BOLD}47. Edge-function registration coherence (SMI-4963)${RESET
   }
 }
 
+// 48. SMI-5060 regression test: publish.yml dependents must gate `'skipped'` on core-exists.
+//
+// Background: when validate fails, `publish-core` auto-skips (its `needs:` failed),
+// and GitHub Actions reports `needs.publish-core.result == 'skipped'`. Without the
+// `core-exists == 'true'` paired predicate, the dependent publish-* jobs treated
+// failure-mode skips identically to legitimate skips ("core was already on npm"),
+// and published broken dependents (orphaned npm release on 2026-05-20, run 26186802726).
+//
+// This check guards against regression of that exact bug. Narrow on purpose:
+// broader actions-expression soundness lint would need an AST parser.
+console.log(`\n${BOLD}48. publish.yml dependent-gate soundness (SMI-5060)${RESET}`)
+{
+  const PUBLISH_YML = '.github/workflows/publish.yml'
+  if (!existsSync(PUBLISH_YML)) {
+    warn(`Check 48: ${PUBLISH_YML} not found — skipping`)
+  } else {
+    try {
+      const content = readFileSync(PUBLISH_YML, 'utf8')
+      const lines = content.split('\n')
+      // Find every line containing the `'skipped'` clause on publish-core.result,
+      // ignore comment-only lines (start with `#` after whitespace).
+      const matches = []
+      lines.forEach((line, idx) => {
+        const trimmed = line.trim()
+        if (trimmed.startsWith('#')) return
+        if (/needs\.publish-core\.result\s*==\s*'skipped'/.test(line)) {
+          matches.push({ lineno: idx + 1, line: line.trim() })
+        }
+      })
+
+      if (matches.length === 0) {
+        warn(
+          `Check 48: no 'publish-core.result == skipped' clauses found in ${PUBLISH_YML} — ` +
+            `if this is intentional (e.g. publish.yml restructured), delete this check.`
+        )
+      } else {
+        let allOk = true
+        for (const { lineno, line } of matches) {
+          // The paired predicate `pre-publish-check.outputs.core-exists == 'true'`
+          // must appear on the same line as the `'skipped'` clause OR within ±1 line
+          // (allowing for multi-line `if:` expression wrapping).
+          const startIdx = Math.max(0, lineno - 2)
+          const endIdx = Math.min(lines.length, lineno + 1)
+          const window = lines.slice(startIdx, endIdx).join('\n')
+          const hasGuard = /pre-publish-check\.outputs\.core-exists\s*==\s*'true'/.test(window)
+          if (!hasGuard) {
+            fail(
+              `Check 48: ${PUBLISH_YML}:${lineno} accepts 'publish-core.result == \\'skipped\\'' ` +
+                `without the paired 'pre-publish-check.outputs.core-exists == \\'true\\'' predicate. ` +
+                `This is the SMI-5060 regression: validate-failure skips and core-already-published ` +
+                `skips both surface as result == 'skipped' but only the latter is safe to proceed on. ` +
+                `Add the paired predicate or update the regex if publish.yml's structure changed.`,
+              `Tighten the if: clause: (needs.publish-core.result == 'success' || ` +
+                `(needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true'))`
+            )
+            allOk = false
+          }
+        }
+        if (allOk) {
+          pass(
+            `Check 48: all ${matches.length} 'publish-core.result == skipped' clause(s) in ` +
+              `${PUBLISH_YML} are paired with the core-exists predicate (SMI-5060 regression guard).`
+          )
+        }
+      }
+    } catch (e) {
+      warn(`Could not run Check 48 (publish.yml dependent-gate soundness): ${e.message}`)
+    }
+  }
+}
+
 // Summary
 console.log('\n' + '━'.repeat(50))
 console.log(`\n${BOLD}📊 Summary${RESET}\n`)


### PR DESCRIPTION
## Summary

Fixes a soundness bug in `.github/workflows/publish.yml` that allowed `@skillsmith/mcp-server` and `@skillsmith/cli` to publish to npm with broken `@skillsmith/core` deps when validate failed. Surfaced 2026-05-20 (run [26186802726](https://github.com/smith-horn/skillsmith/actions/runs/26186802726)).

## Root cause

Three dependent jobs (`publish-mcp-server`, `publish-cli`, `publish-enterprise`) accepted `needs.publish-core.result == 'skipped'` as success-equivalent. GitHub Actions returns `'skipped'` for **both** legitimate (core already on npm) **and** failure-mode (validate failed → publish-core auto-skipped because needs failed) skips.

## Fix

Add `needs.pre-publish-check.outputs.core-exists == 'true'` as the discriminator. Now the dependent jobs only proceed on skipped when core is genuinely already on npm.

```yaml
# Before
(needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')

# After
(needs.publish-core.result == 'success' ||
 (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true'))
```

Three sites: publish.yml:609, :801, :920.

## Regression guard (in-PR, not deferred per CLAUDE.md)

Adds **Check 48** to `scripts/audit-standards.mjs`:
- Scans publish.yml for every `'publish-core.result == \'skipped\''` clause
- Fails if the paired `core-exists == 'true'` predicate is absent
- Verified to catch the exact pre-fix shape on all 3 sites

## ADR-109 trail

| Artifact | Link |
|---|---|
| Plan | [docs/internal/implementation/smi-5060-publish-soundness.md](https://github.com/smith-horn/skillsmith-docs/pull/217) |
| Plan-review | plan-review-specialist 2026-05-20 — 2H/3M/2L all folded |
| Linear | [SMI-5060](https://linear.app/smith-horn-group/issue/SMI-5060) |

## Verification

- [x] `npm run audit:standards` — passed (Check 48 active)
- [x] Check 48 regression-tested by temporarily reverting all 3 sites — flagged all 3
- [x] YAML parse via `js-yaml`
- [ ] Post-merge: simulation branch test (path in plan; bumps core to `99.99.99-smi5060-test` + forced-fail test in valid vitest path; expects all publish-* to skip)

## Why now

Next scheduled cadence dispatch is 2026-05-24 03:00 UTC (Sunday). This fix should land before then so the next release runs under the correct gate.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)