### PR TITLE
fix(billing-types): SMI-5044 break mcp-server↔enterprise type-import cycle

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,6 +57,7 @@ const tsConfig = tseslint.config(
       parserOptions: {
         // Exclude website - it uses Astro's tsconfig which requires Astro installed
         project: [
+          './packages/billing-types/tsconfig.json',
           './packages/core/tsconfig.json',
           './packages/mcp-server/tsconfig.json',
           './packages/cli/tsconfig.json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11983,6 +11983,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@skillsmith/billing-types": {
+      "resolved": "packages/billing-types",
+      "link": true
+    },
     "node_modules/@skillsmith/cli": {
       "resolved": "packages/cli",
       "link": true
@@ -29706,6 +29710,17 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "packages/billing-types": {
+      "name": "@skillsmith/billing-types",
+      "version": "0.1.0",
+      "license": "Elastic-2.0",
+      "devDependencies": {
+        "vitest": "4.1.6"
+      },
+      "engines": {
+        "node": ">=22.22.0"
+      }
+    },
     "packages/cli": {
       "name": "@skillsmith/cli",
       "version": "0.6.2",
@@ -30020,6 +30035,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
+        "@skillsmith/billing-types": "^0.1.0",
         "@skillsmith/core": "^0.7.2",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
@@ -30177,6 +30193,7 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@skillsmith/billing-types": "^0.1.0",
         "@skillsmith/core": "^0.7.2",
         "esbuild": "0.27.2",
         "ulid": "3.0.1"

--- a/packages/billing-types/CHANGELOG.md
+++ b/packages/billing-types/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to `@skillsmith/billing-types` are documented here.
+
+## [Unreleased]
+
+## 0.1.0
+
+- **Initial release**: SMI-5044 — types-only contract package created to
+  resolve the `@skillsmith/mcp-server` ↔ `@smith-horn/enterprise` workspace
+  cycle. Exports `StripeWebhookHandler` interface + `StripeWebhookResult`
+  result shape. No runtime code. Public on npmjs.com under Elastic-2.0.

--- a/packages/billing-types/README.md
+++ b/packages/billing-types/README.md
@@ -1,0 +1,10 @@
+# @skillsmith/billing-types
+
+Types-only contract shared between [`@skillsmith/mcp-server`](https://www.npmjs.com/package/@skillsmith/mcp-server) and `@smith-horn/enterprise`. Introduced in SMI-5044 to break a workspace cycle: the standalone Stripe webhook HTTP endpoint in mcp-server needs the handler's structural shape, but the canonical runtime class lives in the enterprise package, which transitively depends on mcp-server. By depending on this types-only package instead, both consumers stay decoupled.
+
+No runtime code. Exports:
+
+- `StripeWebhookHandler` — the structural interface implemented by `@smith-horn/enterprise/billing`'s canonical class.
+- `StripeWebhookResult` — the return shape of `handleWebhook()`.
+
+License: Elastic-2.0.

--- a/packages/billing-types/package.json
+++ b/packages/billing-types/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@skillsmith/billing-types",
+  "version": "0.1.0",
+  "description": "Types-only contract shared between @skillsmith/mcp-server and @smith-horn/enterprise for the Stripe webhook surface. No runtime code.",
+  "type": "module",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "default": "./dist/src/index.js"
+    }
+  },
+  "scripts": {
+    "prepublishOnly": "node ../../scripts/lib/forbid-local-publish.mjs && npm run build",
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "license": "Elastic-2.0",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/smith-horn/skillsmith.git",
+    "directory": "packages/billing-types"
+  },
+  "homepage": "https://github.com/smith-horn/skillsmith#readme",
+  "bugs": {
+    "url": "https://github.com/smith-horn/skillsmith/issues"
+  },
+  "keywords": [
+    "skillsmith",
+    "stripe",
+    "billing",
+    "types",
+    "webhook"
+  ],
+  "devDependencies": {
+    "vitest": "4.1.6"
+  },
+  "engines": {
+    "node": ">=22.22.0"
+  }
+}

--- a/packages/billing-types/src/index.ts
+++ b/packages/billing-types/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @skillsmith/billing-types
+ *
+ * Types-only contract shared between `@skillsmith/mcp-server` (public, on
+ * npmjs.com) and `@smith-horn/enterprise` (restricted, on npm.pkg.github.com).
+ *
+ * SMI-5044: introduced to break the previous workspace cycle.
+ *
+ * - The canonical runtime class lives at `@smith-horn/enterprise/billing`
+ *   (`StripeWebhookHandler`). It `implements` the interface below so that
+ *   assignability is enforced at the source-of-truth.
+ * - The webhook HTTP endpoint at
+ *   `@skillsmith/mcp-server/webhooks/stripe-webhook-endpoint` consumes only
+ *   this interface — no runtime import of enterprise.
+ *
+ * No runtime code lives here. Adding runtime code to this package would
+ * defeat the cycle-resolution purpose (the public mcp-server pulls this in;
+ * it must remain Elastic-2.0 types-only).
+ */
+
+/**
+ * Result of processing a single Stripe webhook event.
+ *
+ * Kept as a structural type using `eventId: string` rather than the branded
+ * `StripeEventId` from `@smith-horn/enterprise/billing`. A branded string is
+ * still structurally a string, so the canonical handler's
+ * `Promise<WebhookProcessResult>` remains assignable to
+ * `Promise<StripeWebhookResult>` from this package.
+ */
+export interface StripeWebhookResult {
+  success: boolean
+  message: string
+  eventId: string
+  processed: boolean
+  error?: string
+}
+
+/**
+ * Structural contract for a Stripe webhook handler.
+ *
+ * Consumers (e.g. the standalone webhook HTTP endpoint in mcp-server) only
+ * need to invoke `handleWebhook(payload, signature)`. The canonical
+ * implementation in `@smith-horn/enterprise/billing` does signature
+ * verification, idempotency, routing, and license-key callbacks; none of
+ * that machinery is exposed here.
+ */
+export interface StripeWebhookHandler {
+  handleWebhook(payload: string, signature: string): Promise<StripeWebhookResult>
+}

--- a/packages/billing-types/tsconfig.json
+++ b/packages/billing-types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,5 +4,14 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+- **Chore**: SMI-5044 — `StripeWebhookHandler` class now `implements
+  StripeWebhookHandlerContract` from the new types-only
+  `@skillsmith/billing-types` package, providing a compile-time assignability
+  guarantee between the canonical runtime class here and the structural
+  surface consumed by `@skillsmith/mcp-server`. Adds
+  `@skillsmith/billing-types@^0.1.0` as a runtime dep. Belt-and-suspenders:
+  `tests/billing/StripeWebhookHandler.assignability.test.ts` asserts the same
+  at the test layer. Resolves the workspace cycle previously documented in
+  the inline interface at `packages/mcp-server/src/webhooks/stripe-webhook-endpoint.ts`.
 - **Feature**: SMI-5006 — billing module relocated from `@skillsmith/core/billing`. New subpath export `@smith-horn/enterprise/billing` ships `StripeClient`, `BillingService`, `StripeWebhookHandler`, `GDPRComplianceService`, `StripeReconciliationJob`, plus the associated types. `stripe@20.3.0` added as a runtime dep. Migration: change imports from `@skillsmith/core/billing` to `@smith-horn/enterprise/billing`. Companion CHANGELOG note in `@skillsmith/core` 0.7.0 (BREAKING — the subpath shim was not shipped, so consumers must update imports at the same time as the core bump). Three pre-existing strict-mode errors are suppressed via `exactOptionalPropertyTypes: false` / `noUncheckedIndexedAccess: false` / `noPropertyAccessFromIndexSignature: false` in `tsconfig.json`; restoration is tracked as a follow-up issue. `@skillsmith/core` dep range tightened to `^0.7.0` (consumes the new `createLogger` / `Logger` re-export).
 - **Bump**: `@skillsmith/core` dep range to `^0.5.8` — pulls in SMI-4563 native SQLite driver auto-install via `optionalDependencies`. Enterprise package's own version unchanged; downstream installs will now resolve `core@0.5.8` with native better-sqlite3 by default instead of WASM fallback.

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
+    "@skillsmith/billing-types": "^0.1.0",
     "@skillsmith/core": "^0.7.2",
     "jose": "^6.2.2",
     "stripe": "20.3.0",

--- a/packages/enterprise/src/billing/StripeWebhookHandler.ts
+++ b/packages/enterprise/src/billing/StripeWebhookHandler.ts
@@ -16,6 +16,7 @@
 import type Stripe from 'stripe'
 import type { Database as DatabaseType } from '@skillsmith/core'
 import { createLogger } from '@skillsmith/core'
+import type { StripeWebhookHandler as StripeWebhookHandlerContract } from '@skillsmith/billing-types'
 import type { StripeClient } from './StripeClient.js'
 import type { BillingService } from './BillingService.js'
 import type { StripeEventId, WebhookProcessResult } from './types.js'
@@ -57,7 +58,7 @@ const logger = createLogger('StripeWebhookHandler')
  * const result = await handler.handleWebhook(payload, signature);
  * ```
  */
-export class StripeWebhookHandler {
+export class StripeWebhookHandler implements StripeWebhookHandlerContract {
   private readonly stripe: StripeClient
   private readonly billing: BillingService
   private readonly db: DatabaseType

--- a/packages/enterprise/tests/billing/StripeWebhookHandler.assignability.test.ts
+++ b/packages/enterprise/tests/billing/StripeWebhookHandler.assignability.test.ts
@@ -1,0 +1,62 @@
+/**
+ * SMI-5044: StripeWebhookHandler assignability test
+ *
+ * Belt-and-suspenders alongside the `implements StripeWebhookHandlerContract`
+ * declaration on the canonical class. If the contract in
+ * `@skillsmith/billing-types` drifts from the runtime class — for example,
+ * if someone adds a new method to the contract or changes the
+ * `handleWebhook` signature — both this test and the source-level
+ * `implements` clause will fail.
+ *
+ * Tests the REAL wire, not a mock: constructs a real `StripeWebhookHandler`
+ * with shaped-but-mock collaborators, then asserts (via a `satisfies`-style
+ * runtime cast plus an actual invocation) that the instance is structurally
+ * assignable to the public contract.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type Stripe from 'stripe'
+import type {
+  StripeWebhookHandler as StripeWebhookHandlerContract,
+  StripeWebhookResult,
+} from '@skillsmith/billing-types'
+import { StripeWebhookHandler } from '../../src/billing/StripeWebhookHandler.js'
+import type { StripeClient } from '../../src/billing/StripeClient.js'
+import type { BillingService } from '../../src/billing/BillingService.js'
+import type { Database } from '@skillsmith/core'
+
+describe('StripeWebhookHandler ↔ @skillsmith/billing-types contract', () => {
+  it('is structurally assignable to StripeWebhookHandlerContract', async () => {
+    const mockStripe = {
+      verifyWebhookSignature: vi.fn(
+        () => ({ id: 'evt_assignability', type: 'unknown.event' }) as unknown as Stripe.Event
+      ),
+    } as unknown as StripeClient
+    const mockBilling = {
+      isEventProcessed: vi.fn().mockReturnValue(false),
+      recordWebhookEvent: vi.fn(),
+    } as unknown as BillingService
+    const mockDb = {} as Database
+
+    const real = new StripeWebhookHandler({
+      stripeClient: mockStripe,
+      billingService: mockBilling,
+      db: mockDb,
+    })
+
+    // Compile-time assignability: assigning to a typed binding without `as`
+    // would reject any structural drift.
+    const contract: StripeWebhookHandlerContract = real
+    expect(typeof contract.handleWebhook).toBe('function')
+
+    // Runtime assignability: invoke through the contract type and verify the
+    // shape of the result against StripeWebhookResult.
+    const result: StripeWebhookResult = await contract.handleWebhook('payload', 'sig')
+    expect(result).toMatchObject({
+      success: expect.any(Boolean),
+      message: expect.any(String),
+      eventId: expect.any(String),
+      processed: expect.any(Boolean),
+    })
+  })
+})

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Chore**: SMI-5044 — `StripeWebhookHandler` structural interface in
+  `src/webhooks/stripe-webhook-endpoint.ts` is now re-exported from the new
+  `@skillsmith/billing-types` package instead of being declared inline. This
+  resolves the workspace cycle with `@smith-horn/enterprise`. No runtime
+  change; consumers continue to `import type { StripeWebhookHandler } from
+  '@skillsmith/mcp-server'` (the re-export is preserved). Adds
+  `@skillsmith/billing-types@^0.1.0` as a runtime dep.
+
 ## v0.5.2
 
 - **Chore**: SMI-5008 remove stripe SDK from @skillsmith/core dependencies (#869) (#1262)

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@skillsmith/billing-types": "^0.1.0",
     "@skillsmith/core": "^0.7.2",
     "esbuild": "0.27.2",
     "ulid": "3.0.1"

--- a/packages/mcp-server/src/webhooks/stripe-webhook-endpoint.ts
+++ b/packages/mcp-server/src/webhooks/stripe-webhook-endpoint.ts
@@ -19,27 +19,17 @@ import {
   getClientIp,
 } from './webhook-endpoint.js'
 import type { RateLimiterState, WebhookServerConfig } from './webhook-endpoint.js'
+import type { StripeWebhookHandler } from '@skillsmith/billing-types'
+
 /**
- * SMI-5006: Structural type for the webhook handler — duck-typed to avoid a
- * workspace cycle with `@smith-horn/enterprise` (which already has an optional
- * runtime dependency on `@skillsmith/mcp-server/audit`). The canonical class
- * lives at `@smith-horn/enterprise/billing` — that package's `StripeWebhookHandler`
- * is structurally assignable to this interface. Callers (production wiring,
- * tests) construct the real class and pass it in; this surface only consumes
- * the `handleWebhook` method.
+ * SMI-5044: the structural `StripeWebhookHandler` interface previously declared
+ * inline here was promoted to the types-only `@skillsmith/billing-types`
+ * package to resolve the workspace cycle with `@smith-horn/enterprise`. The
+ * canonical class still lives at `@smith-horn/enterprise/billing` and
+ * `implements` the shared interface (assignability test:
+ * `packages/enterprise/tests/billing/StripeWebhookHandler.assignability.test.ts`).
  */
-export interface StripeWebhookHandler {
-  handleWebhook(
-    payload: string,
-    signature: string
-  ): Promise<{
-    success: boolean
-    message: string
-    eventId: string
-    processed: boolean
-    error?: string
-  }>
-}
+export type { StripeWebhookHandler }
 
 // ============================================================================
 // Configuration

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -20,5 +20,5 @@
   },
   "include": ["src/**/*", "tests/**/*"],
   "exclude": ["node_modules", "dist"],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../core" }, { "path": "../billing-types" }]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "tsBuildInfoFile": ".tsbuildinfo"
   },
   "references": [
+    { "path": "./packages/billing-types" },
     { "path": "./packages/core" },
     { "path": "./packages/mcp-server" },
     { "path": "./packages/cli" }


### PR DESCRIPTION
## Summary

W5 of the Enterprise Package Split follow-on cleanup. Resolves the mcp-server↔enterprise type-import workspace cycle introduced as a known workaround in SMI-5006.

- New types-only package \`@skillsmith/billing-types@0.1.0\` (ESM, Elastic-2.0, public on npmjs.com)
- mcp-server's inline structural \`StripeWebhookHandler\` interface (formerly at \`packages/mcp-server/src/webhooks/stripe-webhook-endpoint.ts:31-42\`) deleted; both enterprise (canonical class) and mcp-server (consumer) now import from \`@skillsmith/billing-types\`
- Assignability test at \`packages/enterprise/tests/billing/StripeWebhookHandler.assignability.test.ts\` guards the contract
- Plan promoted to \`docs/internal/implementation/smi-5035-5036-5039-5044-enterprise-backlog-cleanup.md\` (submodule pointer bumped in this PR)

## ADR-109

Satisfied by the plan-review pass on \`docs/internal/implementation/smi-5035-5036-5039-5044-enterprise-backlog-cleanup.md\`. New-package scaffold only; no workflow/hook/Dockerfile changes.

## Madge cycle check

\`\`\`
$ docker exec smi-5044-billing-types-cycle-dev-1 npx --yes madge --circular --extensions ts \\
    --exclude '(dist|node_modules)' \\
    packages/core/src packages/enterprise/src packages/mcp-server/src packages/billing-types/src
Processed 655 files (2.2s)
✖ Found 15 circular dependencies!
\`\`\`

Zero cross-package cycles involving \`core / enterprise / mcp-server / billing-types\`. All 15 are pre-existing intra-package cycles (e.g. \`core/src/api/cache.ts ↔ core/src/api/client.ts\`) — out of scope for this PR.

## Pre-push parity proof (\`--no-verify\` justification)

Pre-push hook fails with the documented \`better-sqlite3\` host bind-mount flake in \`StripeReconciliation.test.ts\` (memory \`feedback_smi_4693_host_vitest_fixture_leak.md\`, also W1/W4 in SMI-5006/5009).

| Context | cwd | Result |
|---|---|---|
| Docker \`skillsmith-dev-1\` (main repo) | \`/app\` | **15/15 PASS** |
| Docker \`skillsmith-dev-1\` (worktree, W5 HEAD) | \`/app/.worktrees/wt-smi-5044\` | **15/15 FAIL** \`db.close(undefined)\` |
| Docker \`skillsmith-dev-1\` (worktree, clean HEAD pre-commit) | \`/app/.worktrees/wt-smi-5044\` | **15/15 FAIL identical** |

Worktree-specific virtiofs bind-mount issue, unrelated to W5 changes. Even \`SKILLSMITH_PRE_PUSH_DOCKER=1\` doesn't help when the routing into \`skillsmith-dev-1\` re-uses worktree cwd. \`--no-verify\` push authorized per W5 dispatch guardrails.

## Test plan

- [ ] Required CI checks pass (10 for code changes)
- [ ] \`packages/billing-types/\` published as a public ESM package on npmjs.com under Elastic-2.0 (publish gated; deferred to consolidated run after W5-W8)
- [ ] Assignability test exercises the real \`StripeWebhookHandler\` class (not a mock)
- [ ] mcp-server inline interface deleted (verified: \`grep -n 'interface StripeWebhookHandler' packages/mcp-server/src\` returns nothing)

## Linear

SMI-5044 → In Progress on push; moves to Done on merge.

Related: SMI-5006 (parent — Wave 1 of Enterprise Package Split), SMI-5039 (next wave W6), SMI-5035 (W7), SMI-5036 (W8).