### PR TITLE
fix(release): SMI-5057 clean cadence-PR hygiene in prepare-release.ts

### DIFF
--- a/scripts/lib/release-changelog.ts
+++ b/scripts/lib/release-changelog.ts
@@ -94,7 +94,18 @@ function dedupeAutoSection(trimmedSection: string, carried: string): string {
   })
 
   const header = headerLines.join('\n')
-  return `${header}\n${keptAutoLines.join('\n')}\n\n${carried}`.replace(/\n{3,}/g, '\n\n')
+  // SMI-5057: join kept-auto and carried with a single newline. The
+  // previous `\n\n${carried}` inserted a spurious blank line between
+  // bullets of the same version section (e.g. PR #1268 cli/mcp-server
+  // CHANGELOGs had a blank line between drained SMI-5008 and carried
+  // SMI-5006 entries). The `\n{3,}` cleanup is preserved because the
+  // empty-keptAutoLines path still produces `\n\n` between header and
+  // carried, which is correct.
+  //
+  // Caller precondition: dedupeAutoSection is only invoked when
+  // carried.length > 0 (release-changelog.ts:172). No need to guard
+  // against an empty carried producing a trailing newline.
+  return `${header}\n${keptAutoLines.join('\n')}\n${carried}`.replace(/\n{3,}/g, '\n\n')
 }
 
 /**

--- a/scripts/lib/version-utils.ts
+++ b/scripts/lib/version-utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFileSync } from 'child_process'
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 
@@ -22,6 +22,12 @@ export interface PackageSpec {
   versionConstPattern?: RegExp
   versionConstReplacement?: (v: string) => string
   serverJsonPath?: string
+  /**
+   * SMI-5057: When true, this package's package.json dep ranges are NOT
+   * touched by updateWorkspaceDependencies. Used for packages on a separate
+   * publish cadence (skillsmith-vscode → publish-vscode.yml).
+   */
+  skipDepRangeUpdate?: boolean
 }
 
 export interface ChangelogEntry {
@@ -66,15 +72,85 @@ export const PACKAGE_SPECS: PackageSpec[] = [
     shortName: 'vscode',
     dir: 'packages/vscode-extension',
     packageJsonPath: 'packages/vscode-extension/package.json',
+    // SMI-5057: vscode-extension is published on a separate cadence
+    // (publish-vscode.yml). prepare-release.ts must NOT bump its
+    // workspace dep ranges (vscode has no @skillsmith/* deps today,
+    // but a future contributor might add one for shared types).
+    skipDepRangeUpdate: true,
   },
 ]
 
-// Packages that depend on @skillsmith/core (dep gets updated when core bumps)
+/**
+ * Packages that depend on @skillsmith/core.
+ *
+ * Historical role (pre-SMI-5057): canonical input to `updateCoreDependency`.
+ * SMI-5057 superseded that function with `updateWorkspaceDependencies`,
+ * which derives its targets from `PACKAGE_SPECS` + `skipDepRangeUpdate`.
+ *
+ * Retained as exported const because `scripts/tests/prepare-release.test.ts`
+ * asserts its contents (Wave 4 SMI-4191 fixture). The single source of
+ * truth for the deps-traversal is now PACKAGE_SPECS.
+ */
 export const CORE_DEPENDENTS = [
   'packages/mcp-server/package.json',
   'packages/cli/package.json',
   'packages/enterprise/package.json',
 ]
+
+/**
+ * SMI-5057: walk every PACKAGE_SPECS target (minus skipDepRangeUpdate ones)
+ * and update any workspace dep range whose key matches a freshly-bumped
+ * package. Returns the list of files actually modified.
+ *
+ * Replaces the older core-only `updateCoreDependency`. The natural
+ * predicate "skip if dep key is not in the bump map" correctly handles
+ * peerDependencies with `"*"` (e.g. cli → @skillsmith/enterprise: "*"
+ * where enterprise is not in PACKAGE_SPECS today, so it's never in the
+ * bump map and is naturally skipped).
+ */
+export function updateWorkspaceDependencies(
+  plans: Array<{ spec: PackageSpec; newVersion: string }>
+): { updated: string[] } {
+  const bumpMap = new Map<string, string>()
+  for (const plan of plans) {
+    bumpMap.set(plan.spec.name, plan.newVersion)
+  }
+
+  const updated: string[] = []
+  const DEP_KINDS = ['dependencies', 'devDependencies', 'peerDependencies'] as const
+
+  for (const target of PACKAGE_SPECS) {
+    if (target.skipDepRangeUpdate) continue
+    const fullPath = join(ROOT_DIR, target.packageJsonPath)
+    // SMI-5057 M-7: the enterprise submodule may be uninitialized on
+    // external clones. Graceful skip — never throw.
+    if (!existsSync(fullPath)) continue
+
+    const pkg = JSON.parse(readFileSync(fullPath, 'utf-8'))
+    let changed = false
+
+    for (const depKind of DEP_KINDS) {
+      const deps = pkg[depKind] as Record<string, string> | undefined
+      if (!deps) continue
+      for (const [depName, currentRange] of Object.entries(deps)) {
+        const newVersion = bumpMap.get(depName)
+        if (!newVersion) continue
+        const newRange = `^${newVersion}`
+        if (currentRange !== newRange) {
+          deps[depName] = newRange
+          changed = true
+        }
+      }
+    }
+
+    if (changed) {
+      writeFileSync(fullPath, JSON.stringify(pkg, null, 2) + '\n')
+      updated.push(target.packageJsonPath)
+    }
+  }
+
+  return { updated }
+}
 
 // --- Version Arithmetic ---
 

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -15,12 +15,12 @@
  * to keep this orchestrator under the 500-line file-length budget.
  */
 
-import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { execFileSync } from 'child_process'
+import { readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
 import {
   PACKAGE_SPECS,
-  CORE_DEPENDENTS,
   ROOT_DIR,
   incrementVersion,
   isValidSemver,
@@ -29,6 +29,7 @@ import {
   readVersionConstant,
   getCommitsSince,
   formatChangelogSection,
+  updateWorkspaceDependencies,
   type PackageSpec,
 } from './lib/version-utils.js'
 import {
@@ -234,19 +235,21 @@ function updateServerJson(relPath: string, newVersion: string): void {
     server.packages[0].version = newVersion
   }
   writeFileSync(fullPath, JSON.stringify(server, null, 2) + '\n')
+  // SMI-5057: re-format with prettier to collapse short arrays (e.g.
+  // 3-element `categories`) onto one line per repo prettier config.
+  // Without this, `npm run format:check` fails on every cadence PR.
+  // `npx prettier` resolves via node_modules/.bin/prettier — present
+  // because release-cadence.yml runs `npm ci --ignore-scripts` before
+  // calling prepare-release.ts (--ignore-scripts skips lifecycle scripts
+  // but NOT the install itself, so devDependencies including prettier
+  // land in node_modules).
+  execFileSync('npx', ['prettier', '--write', fullPath], { stdio: 'inherit' })
 }
 
-function updateCoreDependency(newCoreVersion: string): void {
-  for (const relPath of CORE_DEPENDENTS) {
-    const fullPath = join(ROOT_DIR, relPath)
-    if (!existsSync(fullPath)) continue
-    const pkg = JSON.parse(readFileSync(fullPath, 'utf-8'))
-    if (pkg.dependencies?.['@skillsmith/core']) {
-      pkg.dependencies['@skillsmith/core'] = `^${newCoreVersion}`
-      writeFileSync(fullPath, JSON.stringify(pkg, null, 2) + '\n')
-    }
-  }
-}
+// SMI-5057: `updateCoreDependency` removed — superseded by
+// `updateWorkspaceDependencies` (in version-utils.ts), which walks every
+// PACKAGE_SPECS target and updates any dep range matching a bumped package.
+// This fixes the missing @skillsmith/mcp-server dep bump in @skillsmith/cli.
 
 // --- Main ---
 
@@ -329,11 +332,17 @@ async function main(): Promise<void> {
     console.log(`  ✓ ${plan.spec.name}@${plan.newVersion}`)
   }
 
-  // Step 6: Update @skillsmith/core dep in dependents
-  const corePlan = plans.find((p) => p.spec.shortName === 'core')
-  if (corePlan) {
-    updateCoreDependency(corePlan.newVersion)
-    console.log(`  ✓ Updated @skillsmith/core dep in dependents`)
+  // Step 6: Update workspace dep ranges in all sibling packages.
+  //
+  // SMI-5057: Replaces the older core-only updateCoreDependency. Walks every
+  // PACKAGE_SPECS target (minus skipDepRangeUpdate ones) and updates any dep
+  // range whose key matches a freshly-bumped package. Catches the
+  // @skillsmith/mcp-server stale-range bug in @skillsmith/cli that bit
+  // PR #1268.
+  const { updated: updatedDepFiles } = updateWorkspaceDependencies(plans)
+  if (updatedDepFiles.length > 0) {
+    console.log(`  ✓ Updated workspace dep ranges in ${updatedDepFiles.length} package(s):`)
+    for (const path of updatedDepFiles) console.log(`    - ${path}`)
   }
 
   // Step 6.5: Regenerate package-lock.json so the lockfile matches the bumped

--- a/scripts/tests/prepare-release.test.ts
+++ b/scripts/tests/prepare-release.test.ts
@@ -27,6 +27,8 @@ import {
   isValidSemver,
   incrementVersion,
   compareSemver,
+  updateWorkspaceDependencies,
+  type PackageSpec,
 } from '../lib/version-utils'
 
 import {
@@ -535,5 +537,108 @@ describe('SMI-4188: shared npm-view fixtures parity', () => {
     mockedExecFileSync.mockReturnValue(fixture as never)
     const latest = await fetchNpmLatest('@skillsmith/core')
     expect(latest).toBe('2.1.2')
+  })
+})
+
+describe('updateWorkspaceDependencies (SMI-5057)', () => {
+  beforeEach(() => {
+    mockedWriteFileSync.mockClear()
+    // Critical: prevent the spy from calling through to the real
+    // writeFileSync. updateWorkspaceDependencies writes to live
+    // packages/*/package.json; without this no-op, the test mutates
+    // the working tree (writeFileSync was wrapped via
+    // `vi.fn(actual.writeFileSync)` which calls through by default).
+    mockedWriteFileSync.mockImplementation(() => {})
+  })
+
+  it('updates @skillsmith/mcp-server dep range in @skillsmith/cli when mcp-server bumps', () => {
+    const corePlan = {
+      spec: PACKAGE_SPECS.find((s) => s.shortName === 'core')!,
+      newVersion: '0.7.3',
+    }
+    const mcpPlan = {
+      spec: PACKAGE_SPECS.find((s) => s.shortName === 'mcp-server')!,
+      newVersion: '0.5.3',
+    }
+
+    const { updated } = updateWorkspaceDependencies([corePlan, mcpPlan])
+
+    // cli/package.json depends on both core and mcp-server → updated.
+    expect(updated).toContain('packages/cli/package.json')
+    // mcp-server/package.json depends only on core → updated (core dep range changed).
+    expect(updated).toContain('packages/mcp-server/package.json')
+
+    // Inspect the writes: cli's mcp-server dep range should be ^0.5.3.
+    const cliWrite = mockedWriteFileSync.mock.calls.find((c) =>
+      String(c[0]).endsWith('packages/cli/package.json')
+    )
+    expect(cliWrite).toBeDefined()
+    const cliPkg = JSON.parse(String(cliWrite![1]))
+    expect(cliPkg.dependencies['@skillsmith/mcp-server']).toBe('^0.5.3')
+    expect(cliPkg.dependencies['@skillsmith/core']).toBe('^0.7.3')
+  })
+
+  it('skips skillsmith-vscode (skipDepRangeUpdate=true) even if a future contributor adds @skillsmith/* deps', () => {
+    // Simulate the vscode entry having a hypothetical core dep.
+    const vscodeSpec = PACKAGE_SPECS.find((s) => s.shortName === 'vscode')!
+    expect(vscodeSpec.skipDepRangeUpdate).toBe(true)
+
+    const corePlan = {
+      spec: PACKAGE_SPECS.find((s) => s.shortName === 'core')!,
+      newVersion: '0.7.3',
+    }
+
+    const { updated } = updateWorkspaceDependencies([corePlan])
+
+    // vscode package.json must never appear in updated list — the
+    // skipDepRangeUpdate guard short-circuits before reading the file.
+    expect(updated).not.toContain('packages/vscode-extension/package.json')
+  })
+
+  it('treats peerDependencies with non-bumped key as a no-op (SMI-5057 M-5)', () => {
+    // @skillsmith/enterprise: "*" in cli's peerDependencies is NOT in
+    // PACKAGE_SPECS, so it never lands in the bump map and is naturally
+    // skipped. No `*`-string heuristic needed.
+    const corePlan = {
+      spec: PACKAGE_SPECS.find((s) => s.shortName === 'core')!,
+      newVersion: '0.7.3',
+    }
+
+    updateWorkspaceDependencies([corePlan])
+
+    // If we wrote cli/package.json, verify the peerDependencies entry was
+    // preserved as "*" (not converted to a versioned range).
+    const cliWrite = mockedWriteFileSync.mock.calls.find((c) =>
+      String(c[0]).endsWith('packages/cli/package.json')
+    )
+    if (cliWrite) {
+      const cliPkg = JSON.parse(String(cliWrite![1]))
+      if (cliPkg.peerDependencies?.['@skillsmith/enterprise']) {
+        expect(cliPkg.peerDependencies['@skillsmith/enterprise']).toBe('*')
+      }
+    }
+  })
+
+  it('is a no-op when nothing in the bump map matches existing deps', () => {
+    // Bump a non-existent fake package — nothing should be updated.
+    const fakeSpec: PackageSpec = {
+      name: '@nonexistent/package',
+      shortName: 'fake',
+      dir: 'packages/fake',
+      packageJsonPath: 'packages/fake/package.json',
+    }
+    const fakePlan = { spec: fakeSpec, newVersion: '1.0.0' }
+
+    const { updated } = updateWorkspaceDependencies([fakePlan])
+
+    expect(updated).toHaveLength(0)
+  })
+
+  it('CORE_DEPENDENTS const is retained and matches the historical fixture (regression guard)', () => {
+    // SMI-5057: const kept exported for backcompat with this test fixture.
+    // If a future refactor removes it, this test fails loud.
+    expect(CORE_DEPENDENTS).toContain('packages/mcp-server/package.json')
+    expect(CORE_DEPENDENTS).toContain('packages/cli/package.json')
+    expect(CORE_DEPENDENTS).toContain('packages/enterprise/package.json')
   })
 })

--- a/scripts/tests/release-changelog.test.ts
+++ b/scripts/tests/release-changelog.test.ts
@@ -290,6 +290,45 @@ describe('insertVersionSection — SMI-4928 carried-forward dedupe', () => {
     expect(result).toContain('- **Fix**: SMI-4919 — detailed (#1140)')
     expect(result).not.toContain('- **Fix**: SMI-4919 terse')
   })
+
+  // SMI-5057: regression test for spurious blank line between kept auto
+  // entries and carried [Unreleased] entries. PR #1268 cli/mcp-server
+  // CHANGELOGs surfaced the bug after the SMI-4928 fix landed.
+  it('SMI-5057: kept auto + carried entries join with single newline (no blank line in middle)', () => {
+    const body = [
+      '# Changelog',
+      '',
+      '## [Unreleased]',
+      '',
+      '- **Chore**: SMI-5006 — bump core dep range (#869)',
+      '- **Chore**: SMI-4539 — track core dep range (#1171)',
+      '',
+      '## v0.5.1',
+      '',
+      '- old release',
+      '',
+    ].join('\n')
+    // Auto-generated has a different token (SMI-5008) so dedupe keeps it.
+    const autoSection = '## v0.5.2\n\n- **Chore**: SMI-5008 remove stripe SDK (#1262)'
+
+    const result = insertVersionSection(body, autoSection)
+
+    // Extract the v0.5.2 section.
+    const start = result.indexOf('## v0.5.2')
+    const end = result.indexOf('## v0.5.1')
+    const section = result.slice(start, end)
+
+    // Bullets must be contiguous — no blank line between SMI-5008 and SMI-5006.
+    expect(section).toContain('- **Chore**: SMI-5008 remove stripe SDK (#1262)')
+    expect(section).toContain('- **Chore**: SMI-5006 — bump core dep range (#869)')
+    // The exact join: SMI-5008 line, single newline, SMI-5006 line (no blank between).
+    const bulletPattern =
+      /- \*\*Chore\*\*: SMI-5008 remove stripe SDK \(#1262\)\n- \*\*Chore\*\*: SMI-5006/
+    expect(section).toMatch(bulletPattern)
+    // Pre-SMI-5057 produced `SMI-5008 (#1262)\n\n- **Chore**: SMI-5006` —
+    // the regex below is the regression marker. Must NOT appear post-fix.
+    expect(section).not.toMatch(/- \*\*Chore\*\*: SMI-5008[^\n]*\n\n- \*\*Chore\*\*: SMI-5006/)
+  })
 })
 
 describe('extractChangeTokens', () => {


### PR DESCRIPTION
Fixes 3 bugs that forced manual patchup on every weekly cadence PR.

## Bugs fixed

| # | Bug | File | Verification |
|---|---|---|---|
| 1 | Workspace dep ranges not bumped on sibling version bump (cli @skillsmith/mcp-server stayed at ^0.5.1 when mcp bumped to 0.5.2) | `scripts/lib/version-utils.ts` + `scripts/prepare-release.ts` | Integration test on test branch: cli mcp-server dep ^0.5.2 → ^0.5.3 ✓ |
| 2 | server.json non-canonical multiline formatting (categories array as multiline) | `scripts/prepare-release.ts` (`updateServerJson`) | Integration test: categories on one line + format:check passes ✓ |
| 3 | Spurious blank line between drained auto-entry and carried [Unreleased] entries | `scripts/lib/release-changelog.ts` (`dedupeAutoSection`) | Test added; integration test mcp-server CHANGELOG v0.5.3 contiguous bullets ✓ |

## Plan + plan-review

| Artifact | Link |
|---|---|
| Plan | [docs/internal/implementation/smi-5057-prepare-release-cadence-hygiene.md](https://github.com/smith-horn/skillsmith-docs/pull/219) |
| Plan-review | plan-review-specialist 2026-05-20 — **3H/4M/3L all folded** before implementation |
| Linear | [SMI-5057](https://linear.app/smith-horn-group/issue/SMI-5057) |

## Tests

- `scripts/tests/release-changelog.test.ts`: 16 pass (1 new SMI-5057 regression case for the blank-line bug)
- `scripts/tests/prepare-release.test.ts`: 47 pass (5 new for `updateWorkspaceDependencies`)
- `npm run audit:standards`: 67 pass / 5 warn / 0 fail
- End-to-end on `test/smi-5057-dryrun`: all 3 fixes verified live; branch torn down

## Why now

Next scheduled cadence dispatch: 2026-05-24 03:00 UTC (Sunday). Without this fix, every Sunday's prepare-release.ts run produces a PR that fails Package Validation + Quality Checks until a human patches it (5 min × ∞ Sundays).

## Out of scope

- Bug 4 (vscode bare "Version bump" placeholder when no [Unreleased] content). Different codepath + design decision. Filing as SMI-5064.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)