### PR TITLE
fix(release-infra): SMI-5066 register @skillsmith/billing-types in release pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,10 @@ env:
   # vscode-extension are published by other workflows or are private.
   # Parity with the inline pre-publish-check enumeration is enforced by
   # scripts/audit-standards.mjs (fails CI on drift).
-  PUBLISHABLE_PACKAGES_JSON: '["@skillsmith/core","@skillsmith/mcp-server","@skillsmith/cli","@smith-horn/enterprise"]'
+  # SMI-5066: billing-types is a types-only contract package depended on
+  # by mcp-server + enterprise. Order in this list is informational only;
+  # Turbo `--filter=` constructs an alternation, not a sequence.
+  PUBLISHABLE_PACKAGES_JSON: '["@skillsmith/core","@skillsmith/billing-types","@skillsmith/mcp-server","@skillsmith/cli","@smith-horn/enterprise"]'
 
 jobs:
   # SMI-1301: Pre-publish validation before expensive Docker build
@@ -44,6 +47,10 @@ jobs:
 
     outputs:
       core-exists: ${{ steps.version-check.outputs.core_exists }}
+      # SMI-5066: billing-types output key follows the standard
+      # <shortName>-exists convention (the mcp-server → mcp-exists drift is
+      # documented in PUBLISH_JOB_TO_OUTPUT_ALIAS in audit-standards-helpers.mjs).
+      billing-types-exists: ${{ steps.version-check.outputs.billing_types_exists }}
       mcp-exists: ${{ steps.version-check.outputs.mcp_exists }}
       cli-exists: ${{ steps.version-check.outputs.cli_exists }}
       enterprise-exists: ${{ steps.version-check.outputs.enterprise_exists }}
@@ -96,6 +103,18 @@ jobs:
           else
             echo "core_exists=false" >> $GITHUB_OUTPUT
             echo "| @skillsmith/core | $VERSION | - | 📦 Publish |" >> $GITHUB_STEP_SUMMARY
+            ANY_TO_PUBLISH=true
+          fi
+
+          # SMI-5066: Check @skillsmith/billing-types (types-only contract dep of mcp-server + enterprise)
+          VERSION=$(jq -r .version packages/billing-types/package.json)
+          PUBLISHED=$(npm view @skillsmith/billing-types@$VERSION version 2>/dev/null || echo '')
+          if [ -n "$PUBLISHED" ]; then
+            echo "billing_types_exists=true" >> $GITHUB_OUTPUT
+            echo "| @skillsmith/billing-types | $VERSION | $PUBLISHED | ⏭️ Skip |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "billing_types_exists=false" >> $GITHUB_OUTPUT
+            echo "| @skillsmith/billing-types | $VERSION | - | 📦 Publish |" >> $GITHUB_STEP_SUMMARY
             ANY_TO_PUBLISH=true
           fi
 
@@ -406,7 +425,9 @@ jobs:
         if: steps.download-docker.outcome == 'success'
         run: |
           set -e
-          for pkg in core mcp-server cli enterprise; do
+          # SMI-5066: billing-types added — its `vitest run --passWithNoTests`
+          # is a no-op today but must be invoked so future tests aren't silently skipped.
+          for pkg in core billing-types mcp-server cli enterprise; do
             echo "::group::Test @skillsmith/$pkg (packages/$pkg)"
             docker run --rm --init \
               -v ${{ github.workspace }}:/app \
@@ -571,12 +592,118 @@ jobs:
           echo "::error::@skillsmith/core@${VERSION} is not live on npm after publish — failing the job."
           exit 1
 
+  # SMI-5066: Publish @skillsmith/billing-types — types-only contract package
+  # depended on by mcp-server + enterprise. Mirrors publish-core: no `needs:`
+  # predecessor publish-* job (it has no workspace deps), so its skip-state
+  # surfaces correctly to dependents via the SMI-5060 paired-predicate pattern.
+  # Runs in parallel with publish-core (both gated on validate only).
+  publish-billing-types:
+    name: Publish @skillsmith/billing-types
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [pre-publish-check, validate]
+    # OIDC trusted-publisher must be configured on npmjs.com for this package
+    # (precondition verified before first natural release; see SMI-5066 plan §6.1).
+    permissions:
+      contents: read
+      id-token: write
+    if: |
+      (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
+      needs.pre-publish-check.outputs.billing-types-exists != 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Unlock git-crypt
+        if: ${{ env.GIT_CRYPT_KEY != '' }}
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        uses: ./.github/actions/unlock-git-crypt
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build billing-types package
+        run: npm run build -w @skillsmith/billing-types
+
+      - name: Check if version already published
+        id: version-check
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./packages/billing-types/package.json').version")
+          NPM_VERSION=$(npm view @skillsmith/billing-types version 2>/dev/null || echo 'not-found')
+          echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+          echo "npm_version=$NPM_VERSION" >> $GITHUB_OUTPUT
+          if [ "$PACKAGE_VERSION" = "$NPM_VERSION" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "::notice::@skillsmith/billing-types@$PACKAGE_VERSION already published, skipping..."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "::notice::Publishing @skillsmith/billing-types@$PACKAGE_VERSION (current npm: $NPM_VERSION)"
+          fi
+
+      # SMI-4188: mirror guard — refuses when proposed <= highest published.
+      - name: Pre-publish collision mirror guard
+        if: steps.version-check.outputs.exists != 'true'
+        run: |
+          VERSION=$(jq -r .version packages/billing-types/package.json)
+          node scripts/check-publish-collision.mjs @skillsmith/billing-types "$VERSION"
+
+      # SMI-4539: native `npm publish` OIDC needs npm >= 11.5.1; runner ships 10.9.7.
+      - name: Upgrade npm for OIDC publish (SMI-4539)
+        run: npm install -g npm@11.9.0
+
+      - name: Assert npm version (SMI-4539)
+        run: |
+          ACTUAL="$(npm --version)"
+          if [ "$ACTUAL" != "11.9.0" ]; then
+            echo "::error::Expected npm 11.9.0 for OIDC publish, got $ACTUAL"
+            exit 1
+          fi
+          echo "✓ npm $ACTUAL"
+
+      - name: Publish billing-types
+        id: publish-billing-types-oidc
+        if: steps.version-check.outputs.exists != 'true'
+        run: |
+          npm publish -w @skillsmith/billing-types --access public
+          echo "::notice::OIDC publish succeeded for @skillsmith/billing-types"
+
+      - name: Verify billing-types on npm
+        if: steps.publish-billing-types-oidc.outcome == 'success'
+        run: |
+          VERSION=$(jq -r .version packages/billing-types/package.json)
+          # Retry to absorb npm registry/CDN propagation lag right after publish.
+          for attempt in 1 2 3 4 5; do
+            LIVE=$(npm view "@skillsmith/billing-types@${VERSION}" version 2>/dev/null || echo '')
+            if [ "$LIVE" = "$VERSION" ]; then
+              echo "✓ @skillsmith/billing-types@${VERSION} verified live on npm (attempt ${attempt})"
+              exit 0
+            fi
+            echo "… @skillsmith/billing-types@${VERSION} not yet visible (attempt ${attempt}/5); waiting 6s"
+            sleep 6
+          done
+          echo "::error::@skillsmith/billing-types@${VERSION} is not live on npm after publish — failing the job."
+          exit 1
+
   # SMI-1319: Use pre-publish-check outputs to skip already-published packages
   publish-mcp-server:
     name: Publish @skillsmith/mcp-server
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [pre-publish-check, validate, publish-core]
+    # SMI-5066: publish-billing-types added — mcp-server has a runtime
+    # dependency on @skillsmith/billing-types ^0.1.0 and must not publish
+    # before billing-types is on npm.
+    needs: [pre-publish-check, validate, publish-core, publish-billing-types]
     # id-token: write enables two OIDC paths in this job:
     # - SMI-4534: `mcp-publisher login github-oidc` for the MCP Registry publish step
     # - SMI-4540: npm trusted-publisher OIDC for the npm publish step (sole npm auth
@@ -601,12 +728,18 @@ jobs:
     # Edge case retained: if `validate` is *cancelled* (not failed) and core
     # was already on npm, this job still runs. That's intentional — manual
     # cancellation is an operator action, not a soundness failure.
+    #
+    # SMI-5066: mirror the SMI-5060 paired-predicate pattern for the new
+    # publish-billing-types dependency. Audit-standards Check 48 (generalized)
+    # enforces every `*-result == 'skipped'` clause has a matching <outputKey>-exists guard.
     if: |
       !cancelled() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.mcp-exists != 'true' &&
       (needs.publish-core.result == 'success' ||
-       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true'))
+       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true')) &&
+      (needs.publish-billing-types.result == 'success' ||
+       (needs.publish-billing-types.result == 'skipped' && needs.pre-publish-check.outputs.billing-types-exists == 'true'))
 
     steps:
       - name: Checkout
@@ -900,7 +1033,9 @@ jobs:
     name: Publish @smith-horn/enterprise
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [pre-publish-check, validate, publish-core]
+    # SMI-5066: publish-billing-types added — enterprise has a runtime
+    # dependency on @skillsmith/billing-types ^0.1.0 (package.json line 47).
+    needs: [pre-publish-check, validate, publish-core, publish-billing-types]
     # SMI-4539 deliberately left this job on GITHUB_TOKEN — npm
     # trusted-publishing is npmjs.org-only; GitHub Packages is unaffected. This
     # job publishes @smith-horn/enterprise to npm.pkg.github.com via the
@@ -912,12 +1047,16 @@ jobs:
       packages: write
     # SMI-4803: see publish-mcp-server for `!cancelled()` rationale.
     # SMI-5060: see publish-mcp-server for the core-exists predicate rationale.
+    # SMI-5066: mirror predicate for publish-billing-types — enterprise also
+    # depends on @skillsmith/billing-types ^0.1.0.
     if: |
       !cancelled() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.enterprise-exists != 'true' &&
       (needs.publish-core.result == 'success' ||
-       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true'))
+       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true')) &&
+      (needs.publish-billing-types.result == 'success' ||
+       (needs.publish-billing-types.result == 'skipped' && needs.pre-publish-check.outputs.billing-types-exists == 'true'))
 
     steps:
       - name: Checkout
@@ -1037,8 +1176,10 @@ jobs:
   create-gh-release:
     name: Create GitHub Releases
     runs-on: ubuntu-latest
-    needs: [publish-core, publish-mcp-server, publish-cli, smoke-test]
-    if: always() && (needs.publish-core.result == 'success' || needs.publish-mcp-server.result == 'success' || needs.publish-cli.result == 'success')
+    # SMI-5066: publish-billing-types added so a successful billing-types
+    # publish gets a matching GitHub Release tag (@skillsmith/billing-types-vX.Y.Z).
+    needs: [publish-core, publish-billing-types, publish-mcp-server, publish-cli, smoke-test]
+    if: always() && (needs.publish-core.result == 'success' || needs.publish-billing-types.result == 'success' || needs.publish-mcp-server.result == 'success' || needs.publish-cli.result == 'success')
     timeout-minutes: 5
 
     steps:
@@ -1056,6 +1197,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CORE_RESULT: ${{ needs.publish-core.result }}
+          BILLING_TYPES_RESULT: ${{ needs.publish-billing-types.result }}
           MCP_RESULT: ${{ needs.publish-mcp-server.result }}
           CLI_RESULT: ${{ needs.publish-cli.result }}
         run: |
@@ -1101,6 +1243,8 @@ jobs:
           }
 
           create_release core packages/core @skillsmith/core "$CORE_RESULT"
+          # SMI-5066: billing-types tag matches the @skillsmith/billing-types-vX.Y.Z convention.
+          create_release billing-types packages/billing-types @skillsmith/billing-types "$BILLING_TYPES_RESULT"
           create_release mcp-server packages/mcp-server @skillsmith/mcp-server "$MCP_RESULT"
           create_release cli packages/cli @skillsmith/cli "$CLI_RESULT"
 
@@ -1108,9 +1252,11 @@ jobs:
   publish-summary:
     name: Publish Summary
     runs-on: ubuntu-latest
+    # SMI-5066: publish-billing-types added to needs + summary table.
     needs:
       [
         publish-core,
+        publish-billing-types,
         publish-mcp-server,
         publish-cli,
         publish-enterprise,
@@ -1127,6 +1273,7 @@ jobs:
           echo "| Package | Status | Smoke Test |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|--------|------------|" >> $GITHUB_STEP_SUMMARY
           echo "| @skillsmith/core | ${{ needs.publish-core.result }} | ${{ needs.smoke-test.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| @skillsmith/billing-types | ${{ needs.publish-billing-types.result }} | N/A |" >> $GITHUB_STEP_SUMMARY
           echo "| @skillsmith/mcp-server | ${{ needs.publish-mcp-server.result }} | ${{ needs.smoke-test.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| @skillsmith/cli | ${{ needs.publish-cli.result }} | ${{ needs.smoke-test.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| @smith-horn/enterprise | ${{ needs.publish-enterprise.result }} | N/A |" >> $GITHUB_STEP_SUMMARY

--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -801,3 +801,77 @@ export function parseConsumersTag(src) {
   const sorted = tokens.every((tok, i) => tok === sortedCopy[i])
   return { found: true, names: tokens, sorted }
 }
+
+/**
+ * Aliases for publish-* job names whose pre-publish-check output key uses
+ * a shorter name than the job's full shortName.
+ *
+ * SMI-5066: when generalizing Check 48 from core-only to any-package, we
+ * discovered that `publish-mcp-server`'s YAML output key is `mcp-exists`
+ * (not `mcp-server-exists`) — the bash var `mcp_exists` → key `mcp-exists`.
+ * This pre-existing convention drift is documented here rather than
+ * normalized (out of SMI-5066 scope).
+ *
+ * Audit-standards.mjs Check 48 imports this map.
+ */
+export const PUBLISH_JOB_TO_OUTPUT_ALIAS = Object.freeze({
+  'mcp-server': 'mcp',
+})
+
+/**
+ * Audit publish.yml for the SMI-5060 invariant: every
+ * `needs.publish-<pkg>.result == 'skipped'` clause MUST be paired with
+ * `pre-publish-check.outputs.<outputKey>-exists == 'true'` (where
+ * outputKey = PUBLISH_JOB_TO_OUTPUT_ALIAS[pkg] || pkg) within ±1 line.
+ *
+ * Background (SMI-5060): when `validate` fails, `publish-<pkg>` auto-skips
+ * because its `needs:` failed. GitHub Actions reports
+ * `needs.publish-<pkg>.result == 'skipped'` — indistinguishable from the
+ * legitimate "package already on npm, nothing to publish" skip. Without
+ * the paired exists predicate, downstream publish-* jobs publish broken
+ * dependents (orphan-consumer release class of bug).
+ *
+ * SMI-5066: generalized to any `publish-<pkg>` job (not just publish-core)
+ * so the same invariant covers new packages like billing-types.
+ *
+ * @param {string} content - Full publish.yml content (UTF-8).
+ * @returns {{
+ *   matches: Array<{ lineno: number, line: string, pkg: string, outputKey: string }>,
+ *   failures: Array<{ lineno: number, line: string, pkg: string, outputKey: string }>,
+ * }} matches is every skipped-clause found. failures is the subset missing
+ *    the paired guard within ±1 line.
+ */
+export function auditPublishYmlDependentGate(content) {
+  const lines = content.split('\n')
+  const skippedRegex = /needs\.publish-([a-z][a-z0-9-]*)\.result\s*==\s*'skipped'/
+
+  const matches = []
+  lines.forEach((line, idx) => {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('#')) return
+    const m = line.match(skippedRegex)
+    if (m) {
+      const pkg = m[1]
+      const outputKey = PUBLISH_JOB_TO_OUTPUT_ALIAS[pkg] || pkg
+      matches.push({ lineno: idx + 1, line: trimmed, pkg, outputKey })
+    }
+  })
+
+  const failures = []
+  for (const match of matches) {
+    const { lineno, outputKey } = match
+    // Window: lines (lineno-1) through (lineno+1) — i.e. matched line ±1.
+    // lineno is 1-based; `lines` is 0-indexed, so the slice covers idx-1..idx+1.
+    const startIdx = Math.max(0, lineno - 2)
+    const endIdx = Math.min(lines.length, lineno + 1)
+    const window = lines.slice(startIdx, endIdx).join('\n')
+    const expectedGuard = new RegExp(
+      `pre-publish-check\\.outputs\\.${outputKey}-exists\\s*==\\s*'true'`
+    )
+    if (!expectedGuard.test(window)) {
+      failures.push(match)
+    }
+  }
+
+  return { matches, failures }
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -30,6 +30,7 @@ import {
   findUnsafeSkillsRecreateMigrations,
   parseBashArray,
   parseConsumersTag,
+  auditPublishYmlDependentGate,
 } from './audit-standards-helpers.mjs'
 import { VERCEL_JSON_SHARED_FIELDS, validateVercelJsonSync } from './audit-vercel-sync-helpers.mjs'
 import { findRealpathAsymmetry } from './audit-realpath-asymmetry-helpers.mjs'
@@ -3913,17 +3914,25 @@ console.log(`\n${BOLD}47. Edge-function registration coherence (SMI-4963)${RESET
   }
 }
 
-// 48. SMI-5060 regression test: publish.yml dependents must gate `'skipped'` on core-exists.
+// 48. SMI-5060/SMI-5066 regression test: publish.yml dependents must gate
+// every `needs.publish-<pkg>.result == 'skipped'` clause on a paired
+// `pre-publish-check.outputs.<outputKey>-exists == 'true'` predicate
+// (with outputKey resolved via PUBLISH_JOB_TO_OUTPUT_ALIAS for the
+// `publish-mcp-server` → `mcp-exists` outlier).
 //
-// Background: when validate fails, `publish-core` auto-skips (its `needs:` failed),
-// and GitHub Actions reports `needs.publish-core.result == 'skipped'`. Without the
-// `core-exists == 'true'` paired predicate, the dependent publish-* jobs treated
-// failure-mode skips identically to legitimate skips ("core was already on npm"),
-// and published broken dependents (orphaned npm release on 2026-05-20, run 26186802726).
+// Background (SMI-5060): when validate fails, `publish-<pkg>` auto-skips
+// (its `needs:` failed), and GitHub Actions reports
+// `needs.publish-<pkg>.result == 'skipped'`. Without the paired exists
+// predicate, dependent publish-* jobs treated failure-mode skips identically
+// to legitimate skips ("package was already on npm"), and published broken
+// dependents (orphaned npm release on 2026-05-20, run 26186802726).
 //
-// This check guards against regression of that exact bug. Narrow on purpose:
-// broader actions-expression soundness lint would need an AST parser.
-console.log(`\n${BOLD}48. publish.yml dependent-gate soundness (SMI-5060)${RESET}`)
+// SMI-5066: generalized from publish-core-only to any publish-<pkg> via the
+// helper `auditPublishYmlDependentGate`. The alias map handles the
+// pre-existing convention drift where `publish-mcp-server`'s output key is
+// `mcp-exists`, not `mcp-server-exists`. Narrow on purpose: broader
+// actions-expression soundness lint would need an AST parser.
+console.log(`\n${BOLD}48. publish.yml dependent-gate soundness (SMI-5060/SMI-5066)${RESET}`)
 {
   const PUBLISH_YML = '.github/workflows/publish.yml'
   if (!existsSync(PUBLISH_YML)) {
@@ -3931,52 +3940,30 @@ console.log(`\n${BOLD}48. publish.yml dependent-gate soundness (SMI-5060)${RESET
   } else {
     try {
       const content = readFileSync(PUBLISH_YML, 'utf8')
-      const lines = content.split('\n')
-      // Find every line containing the `'skipped'` clause on publish-core.result,
-      // ignore comment-only lines (start with `#` after whitespace).
-      const matches = []
-      lines.forEach((line, idx) => {
-        const trimmed = line.trim()
-        if (trimmed.startsWith('#')) return
-        if (/needs\.publish-core\.result\s*==\s*'skipped'/.test(line)) {
-          matches.push({ lineno: idx + 1, line: line.trim() })
-        }
-      })
+      const { matches, failures } = auditPublishYmlDependentGate(content)
 
       if (matches.length === 0) {
         warn(
-          `Check 48: no 'publish-core.result == skipped' clauses found in ${PUBLISH_YML} — ` +
+          `Check 48: no 'publish-<pkg>.result == skipped' clauses found in ${PUBLISH_YML} — ` +
             `if this is intentional (e.g. publish.yml restructured), delete this check.`
         )
-      } else {
-        let allOk = true
-        for (const { lineno, line } of matches) {
-          // The paired predicate `pre-publish-check.outputs.core-exists == 'true'`
-          // must appear on the same line as the `'skipped'` clause OR within ±1 line
-          // (allowing for multi-line `if:` expression wrapping).
-          const startIdx = Math.max(0, lineno - 2)
-          const endIdx = Math.min(lines.length, lineno + 1)
-          const window = lines.slice(startIdx, endIdx).join('\n')
-          const hasGuard = /pre-publish-check\.outputs\.core-exists\s*==\s*'true'/.test(window)
-          if (!hasGuard) {
-            fail(
-              `Check 48: ${PUBLISH_YML}:${lineno} accepts 'publish-core.result == \\'skipped\\'' ` +
-                `without the paired 'pre-publish-check.outputs.core-exists == \\'true\\'' predicate. ` +
-                `This is the SMI-5060 regression: validate-failure skips and core-already-published ` +
-                `skips both surface as result == 'skipped' but only the latter is safe to proceed on. ` +
-                `Add the paired predicate or update the regex if publish.yml's structure changed.`,
-              `Tighten the if: clause: (needs.publish-core.result == 'success' || ` +
-                `(needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true'))`
-            )
-            allOk = false
-          }
-        }
-        if (allOk) {
-          pass(
-            `Check 48: all ${matches.length} 'publish-core.result == skipped' clause(s) in ` +
-              `${PUBLISH_YML} are paired with the core-exists predicate (SMI-5060 regression guard).`
+      } else if (failures.length > 0) {
+        for (const { lineno, pkg, outputKey } of failures) {
+          fail(
+            `Check 48: ${PUBLISH_YML}:${lineno} accepts 'publish-${pkg}.result == \\'skipped\\'' ` +
+              `without the paired 'pre-publish-check.outputs.${outputKey}-exists == \\'true\\'' predicate. ` +
+              `This is the SMI-5060 regression class: validate-failure skips and package-already-published ` +
+              `skips both surface as result == 'skipped' but only the latter is safe to proceed on. ` +
+              `Add the paired predicate or update PUBLISH_JOB_TO_OUTPUT_ALIAS in audit-standards-helpers.mjs.`,
+            `Tighten the if: clause: (needs.publish-${pkg}.result == 'success' || ` +
+              `(needs.publish-${pkg}.result == 'skipped' && needs.pre-publish-check.outputs.${outputKey}-exists == 'true'))`
           )
         }
+      } else {
+        pass(
+          `Check 48: all ${matches.length} 'publish-<pkg>.result == skipped' clause(s) in ` +
+            `${PUBLISH_YML} are paired with the <outputKey>-exists predicate (SMI-5060/SMI-5066 regression guard).`
+        )
       }
     } catch (e) {
       warn(`Could not run Check 48 (publish.yml dependent-gate soundness): ${e.message}`)

--- a/scripts/lib/version-utils.ts
+++ b/scripts/lib/version-utils.ts
@@ -62,6 +62,16 @@ export const PACKAGE_SPECS: PackageSpec[] = [
     serverJsonPath: 'packages/mcp-server/server.json',
   },
   {
+    name: '@skillsmith/billing-types',
+    shortName: 'billing-types',
+    dir: 'packages/billing-types',
+    packageJsonPath: 'packages/billing-types/package.json',
+    // SMI-5066: types-only contract package introduced by SMI-5044. No
+    // versionConstFile (no `export const VERSION` source constant) and no
+    // serverJsonPath (no MCP server.json). Receives dep-range bumps if it
+    // ever depends on another workspace package (none today).
+  },
+  {
     name: '@skillsmith/cli',
     shortName: 'cli',
     dir: 'packages/cli',

--- a/scripts/tests/audit-standards.test.ts
+++ b/scripts/tests/audit-standards.test.ts
@@ -28,6 +28,11 @@ const helpers = (await import('../audit-standards-helpers.mjs')) as {
     resolveModule: (fromFile: string, spec: string) => string | null
   ) => Set<string>
   extractSmokeTestRequiredArrays: (content: string) => { name: string; arrayIndex: number }[]
+  auditPublishYmlDependentGate: (content: string) => {
+    matches: Array<{ lineno: number; line: string; pkg: string; outputKey: string }>
+    failures: Array<{ lineno: number; line: string; pkg: string; outputKey: string }>
+  }
+  PUBLISH_JOB_TO_OUTPUT_ALIAS: Record<string, string>
 }
 
 const {
@@ -37,6 +42,8 @@ const {
   parseTsExports,
   collectTsEntryExports,
   extractSmokeTestRequiredArrays,
+  auditPublishYmlDependentGate,
+  PUBLISH_JOB_TO_OUTPUT_ALIAS,
 } = helpers
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -445,5 +452,130 @@ describe('extractSmokeTestRequiredArrays', () => {
     const entries = extractSmokeTestRequiredArrays(smokeSrc)
     const missing = entries.filter((e) => !coreExports.has(e.name))
     expect(missing.map((m) => m.name)).toEqual(['CategoryRepository'])
+  })
+})
+
+/**
+ * SMI-5066: regression tests for the generalized Check 48 helper. Background:
+ * SMI-5060 introduced the paired-predicate invariant (every
+ * `needs.publish-<pkg>.result == 'skipped'` clause must be guarded by
+ * `pre-publish-check.outputs.<outputKey>-exists == 'true'` within ±1 line).
+ * SMI-5066 generalized it from publish-core-only to any publish-<pkg>, with an
+ * alias map for the pre-existing `publish-mcp-server` → `mcp-exists` outlier.
+ *
+ * These tests guard against future regressions in either the regex or the
+ * alias-map convention.
+ */
+describe('auditPublishYmlDependentGate (SMI-5060/SMI-5066)', () => {
+  it('PUBLISH_JOB_TO_OUTPUT_ALIAS maps mcp-server to mcp', () => {
+    // The alias map exists to document and handle the convention drift
+    // between the publish-* job name and the pre-publish-check output key.
+    expect(PUBLISH_JOB_TO_OUTPUT_ALIAS['mcp-server']).toBe('mcp')
+  })
+
+  it('passes when publish-core skipped clause is paired with core-exists guard', () => {
+    const yml = [
+      'jobs:',
+      '  publish-mcp-server:',
+      '    if: |',
+      "      (needs.publish-core.result == 'success' ||",
+      "       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true'))",
+    ].join('\n')
+    const { matches, failures } = auditPublishYmlDependentGate(yml)
+    expect(matches).toHaveLength(1)
+    expect(matches[0].pkg).toBe('core')
+    expect(matches[0].outputKey).toBe('core')
+    expect(failures).toHaveLength(0)
+  })
+
+  it('passes when publish-billing-types skipped clause is paired with billing-types-exists guard', () => {
+    const yml = [
+      'jobs:',
+      '  publish-mcp-server:',
+      '    if: |',
+      "      (needs.publish-billing-types.result == 'success' ||",
+      "       (needs.publish-billing-types.result == 'skipped' && needs.pre-publish-check.outputs.billing-types-exists == 'true'))",
+    ].join('\n')
+    const { matches, failures } = auditPublishYmlDependentGate(yml)
+    expect(matches).toHaveLength(1)
+    expect(matches[0].pkg).toBe('billing-types')
+    expect(matches[0].outputKey).toBe('billing-types')
+    expect(failures).toHaveLength(0)
+  })
+
+  it('passes when publish-mcp-server skipped clause is paired with mcp-exists guard (alias map)', () => {
+    const yml = [
+      'jobs:',
+      '  publish-cli:',
+      '    if: |',
+      "      (needs.publish-mcp-server.result == 'success' ||",
+      "       (needs.publish-mcp-server.result == 'skipped' && needs.pre-publish-check.outputs.mcp-exists == 'true'))",
+    ].join('\n')
+    const { matches, failures } = auditPublishYmlDependentGate(yml)
+    expect(matches).toHaveLength(1)
+    expect(matches[0].pkg).toBe('mcp-server')
+    expect(matches[0].outputKey).toBe('mcp') // alias resolved
+    expect(failures).toHaveLength(0)
+  })
+
+  it('fails when publish-core skipped clause has no paired guard', () => {
+    const yml = [
+      'jobs:',
+      '  publish-mcp-server:',
+      '    if: |',
+      "      (needs.publish-core.result == 'success' ||",
+      "       needs.publish-core.result == 'skipped')",
+    ].join('\n')
+    const { matches, failures } = auditPublishYmlDependentGate(yml)
+    expect(matches).toHaveLength(1)
+    expect(failures).toHaveLength(1)
+    expect(failures[0].pkg).toBe('core')
+    expect(failures[0].outputKey).toBe('core')
+  })
+
+  it('fails when publish-billing-types skipped clause has no paired guard', () => {
+    const yml = [
+      'jobs:',
+      '  publish-mcp-server:',
+      '    if: |',
+      "      (needs.publish-billing-types.result == 'success' ||",
+      "       needs.publish-billing-types.result == 'skipped')",
+    ].join('\n')
+    const { matches, failures } = auditPublishYmlDependentGate(yml)
+    expect(matches).toHaveLength(1)
+    expect(failures).toHaveLength(1)
+    expect(failures[0].pkg).toBe('billing-types')
+  })
+
+  it('ignores comment-only lines containing the skipped phrase', () => {
+    const yml = [
+      'jobs:',
+      "  # Documentation: when needs.publish-core.result == 'skipped' fires,",
+      '  # the guard handles it.',
+      '  publish-mcp-server:',
+      "    if: needs.pre-publish-check.outputs.mcp-exists != 'true'",
+    ].join('\n')
+    const { matches, failures } = auditPublishYmlDependentGate(yml)
+    expect(matches).toHaveLength(0)
+    expect(failures).toHaveLength(0)
+  })
+
+  it('fails when paired guard is more than ±1 line away from the skipped clause', () => {
+    // The window is intentionally tight (±1 line) to match the canonical YAML
+    // shape produced by gh actions multi-line `if: |` blocks. A guard that
+    // drifts farther is a smell — either the YAML restructured or the guard
+    // was decoupled.
+    const yml = [
+      'jobs:',
+      '  publish-mcp-server:',
+      '    if: |',
+      "      (needs.publish-core.result == 'success' ||",
+      "       needs.publish-core.result == 'skipped') &&",
+      '      true &&',
+      '      true &&',
+      "      needs.pre-publish-check.outputs.core-exists == 'true'",
+    ].join('\n')
+    const { failures } = auditPublishYmlDependentGate(yml)
+    expect(failures).toHaveLength(1)
   })
 })

--- a/scripts/tests/prepare-release.test.ts
+++ b/scripts/tests/prepare-release.test.ts
@@ -45,13 +45,15 @@ const mockedExecFileSync = vi.mocked(execFileSync)
 const mockedWriteFileSync = vi.mocked(writeFileSync)
 
 describe('PACKAGE_SPECS configuration', () => {
-  it('should define all four packages', () => {
+  it('should define all five packages', () => {
+    // SMI-5066: billing-types added between mcp-server and cli.
     const names = PACKAGE_SPECS.map((s) => s.shortName)
     expect(names).toContain('core')
     expect(names).toContain('mcp-server')
+    expect(names).toContain('billing-types')
     expect(names).toContain('cli')
     expect(names).toContain('vscode')
-    expect(PACKAGE_SPECS).toHaveLength(4)
+    expect(PACKAGE_SPECS).toHaveLength(5)
   })
 
   it('should point to existing package.json files', () => {

--- a/scripts/tests/verify-publish-deps.test.ts
+++ b/scripts/tests/verify-publish-deps.test.ts
@@ -11,6 +11,11 @@ function makeReadJson(coreVersion: string, mcpDepRange: string) {
     if (p.endsWith('packages/core/package.json')) {
       return { name: '@skillsmith/core', version: coreVersion, dependencies: {} }
     }
+    // SMI-5066: billing-types added to PACKAGES. No deps to inspect (types-only
+    // contract). Test fixture mirrors that — empty dependencies, fixed version.
+    if (p.endsWith('packages/billing-types/package.json')) {
+      return { name: '@skillsmith/billing-types', version: '0.1.0', dependencies: {} }
+    }
     if (p.endsWith('packages/mcp-server/package.json')) {
       return {
         name: '@skillsmith/mcp-server',

--- a/scripts/verify-publish-deps.mjs
+++ b/scripts/verify-publish-deps.mjs
@@ -26,6 +26,8 @@ const ROOT = join(__dirname, '..')
 
 const PACKAGES = [
   { name: '@skillsmith/core', dir: 'packages/core' },
+  // SMI-5066: types-only contract package; mcp-server depends on it.
+  { name: '@skillsmith/billing-types', dir: 'packages/billing-types' },
   { name: '@skillsmith/mcp-server', dir: 'packages/mcp-server' },
   { name: '@skillsmith/cli', dir: 'packages/cli' },
 ]


### PR DESCRIPTION
Closes [SMI-5066](https://linear.app/smith-horn-group/issue/SMI-5066).

Adds the new @skillsmith/billing-types package (introduced by SMI-5044 / #1272) to every release-infra surface. Before this PR, the cadence flow would have silently skipped it on Sunday auto-bumps, and a manual publish would have orphaned mcp-server/enterprise consumers — the exact failure mode SMI-5060 hardened against, now extended to cover billing-types.

## Changes

1. `scripts/lib/version-utils.ts` — PACKAGE_SPECS includes `@skillsmith/billing-types` between mcp-server and cli.
2. `scripts/verify-publish-deps.mjs` — billing-types added to PACKAGES.
3. `.github/workflows/publish.yml` — seven coordinated edits:
   - `PUBLISHABLE_PACKAGES_JSON` extended (H-1 from plan-review)
   - `pre-publish-check`: `billing-types-exists` output + bash check step
   - Validate per-package test loop adds billing-types (M-3)
   - New `publish-billing-types` job — mirrors publish-core's OIDC pattern; runs in parallel with publish-core
   - `publish-mcp-server` + `publish-enterprise` `needs:` + `if:` extended with paired-predicate gate per SMI-5060 invariant (publish-cli intentionally untouched — cli does NOT depend on billing-types)
   - `create-gh-release` extended so a successful billing-types publish gets a matching GitHub Release tag (M-2)
   - `publish-summary` extended with status table row
4. `scripts/audit-standards-helpers.mjs` — new pure helper `auditPublishYmlDependentGate(content)` + `PUBLISH_JOB_TO_OUTPUT_ALIAS` export. Generalizes the SMI-5060 invariant from publish-core-only to any publish-\<pkg\> with an alias map for the pre-existing `publish-mcp-server` → `mcp-exists` output-key drift (H-2).
5. `scripts/audit-standards.mjs` — Check 48 calls into the helper; error messages reference the resolved outputKey.
6. `scripts/tests/audit-standards.test.ts` — 7 unit tests for the helper covering alias map, pass paths (core / billing-types / mcp-server alias), fail paths, comment-ignore, and out-of-window guard rejection (M-4 — not deferred).

## Plan

[docs/internal/implementation/smi-5066-billing-types-release-infra.md](https://github.com/smith-horn/skillsmith-docs/pull/222) — plan v2 folds all 9 plan-review findings (H-1, H-2, H-3, M-1 through M-4, L-1, L-2). Nothing deferred.

Docs companion PR: smith-horn/skillsmith-docs#222

## Verification

| Check | Result |
|---|---|
| `audit:standards` Check 48 (generalized) | ✅ all 5 `publish-<pkg>.result == skipped` clauses paired with `<outputKey>-exists` predicate |
| `verify-publish-deps.mjs` iterates billing-types | ✅ |
| Helper unit tests (12 inline + 7 vitest) | ✅ 12/12 inline; vitest blocked by virtiofs in worktree but logic verified directly |
| ESLint changed files | ✅ 0 errors |
| TypeScript `tsc --noEmit` | ✅ exit 0 |
| Governance retro (governance-specialist) | ✅ 0 H, 0 M findings |

## Out of scope

- Bumping billing-types' version above 0.1.0 — first natural exercise happens on the 2026-05-24 03:00 UTC cadence.
- Publishing billing-types to npm — first publish ships on cadence.
- Adding `@smith-horn/enterprise` to `verify-publish-deps.mjs` PACKAGES (pre-existing gap; documented in plan §1.3).
- Renaming `mcp-exists` to `mcp-server-exists` — separate normalization refactor outside SMI-5066. Handled via alias map.

## Precondition for first natural release

OIDC trusted-publisher must be configured on npmjs.com for `@skillsmith/billing-types` before the first natural publish. Plan §6.1 documents this as a manual verification step.

[skip-impl-check] — infra-only PR; no implementation surface to verify against.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)