### PR TITLE
fix(release): SMI-5064 emit descriptive cadence-only changelog default

### DIFF
--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -368,10 +368,17 @@ async function main(): Promise<void> {
         prependToChangelog(join(plan.spec.dir, 'CHANGELOG.md'), section)
         console.log(`  ✓ Changelog: ${plan.spec.shortName} (${entries.length} entries)`)
       } else {
-        // Create minimal entry
-        const section = `## v${plan.newVersion}\n\n- Version bump`
+        // SMI-5064: emit a descriptive cadence-only default instead of the
+        // bare "- Version bump" placeholder. The `**Cadence**:` bold prefix
+        // matches the `- **Fix**: …` / `- **Feature**: …` convention emitted
+        // by formatChangelogSection (version-utils.ts:280-288) for visual
+        // consistency. Referencing the prior version lets a reader run
+        // `git log v<prior>..v<new> -- <pkg-dir>` to verify zero commits.
+        const section = `## v${plan.newVersion}\n\n- **Cadence**: Mechanical cadence alignment (no changes since v${plan.currentVersion}).`
         prependToChangelog(join(plan.spec.dir, 'CHANGELOG.md'), section)
-        console.log(`  ✓ Changelog: ${plan.spec.shortName} (version bump only)`)
+        console.log(
+          `  ✓ Changelog: ${plan.spec.shortName} (cadence-only bump from v${plan.currentVersion})`
+        )
       }
     }
   }

--- a/scripts/tests/release-changelog.test.ts
+++ b/scripts/tests/release-changelog.test.ts
@@ -359,3 +359,68 @@ describe('extractChangeTokens', () => {
     expect(extractChangeTokens('- note about issue #1140 inline')).toEqual([])
   })
 })
+
+/**
+ * SMI-5064: regression test for the cadence-only changelog default.
+ *
+ * Background: `prepare-release.ts:370-376` emits a section body when a
+ * package has zero commits since the last bump AND no carried [Unreleased]
+ * content. The pre-SMI-5064 body was the bare `- Version bump` — uninformative
+ * and visually inconsistent with the `- **Fix**: …` / `- **Feature**: …`
+ * convention used elsewhere. SMI-5064 swaps it for
+ * `- **Cadence**: Mechanical cadence alignment (no changes since v${prior}).`
+ *
+ * This test exercises insertVersionSection (the pure function that places
+ * the section into the CHANGELOG body) with the new bullet shape and
+ * verifies it lands cleanly: bullet preserved verbatim, no spurious
+ * duplication, correct position relative to `## [Unreleased]`.
+ */
+describe('insertVersionSection — SMI-5064 cadence-only default bullet', () => {
+  it('inserts the cadence bullet exactly once between [Unreleased] and prior version', () => {
+    const body = '# Changelog\n\n## [Unreleased]\n\n## v0.2.3\n\n- **Fix**: prior work (#100)\n'
+    const section =
+      '## v0.2.4\n\n- **Cadence**: Mechanical cadence alignment (no changes since v0.2.3).'
+
+    const result = insertVersionSection(body, section)
+
+    // Bullet preserved verbatim.
+    expect(result).toContain(
+      '- **Cadence**: Mechanical cadence alignment (no changes since v0.2.3).'
+    )
+    // No spurious duplicate.
+    expect(result.match(/Mechanical cadence alignment/g)).toHaveLength(1)
+    // Order: ## [Unreleased] before ## v0.2.4 before ## v0.2.3 (audit Check 43 invariant).
+    const unreleasedIdx = result.indexOf('## [Unreleased]')
+    const newVersionIdx = result.indexOf('## v0.2.4')
+    const oldVersionIdx = result.indexOf('## v0.2.3')
+    expect(unreleasedIdx).toBeGreaterThanOrEqual(0)
+    expect(unreleasedIdx).toBeLessThan(newVersionIdx)
+    expect(newVersionIdx).toBeLessThan(oldVersionIdx)
+  })
+
+  it('inserts the cadence bullet correctly when CHANGELOG has no prior versions', () => {
+    // First-time-after-init case — only the synthesized header exists.
+    const body = '# Changelog\n\nAll notable changes to this package are documented here.\n'
+    const section =
+      '## v0.1.0\n\n- **Cadence**: Mechanical cadence alignment (no changes since v0.0.1).'
+
+    const result = insertVersionSection(body, section)
+
+    expect(result).toContain('## [Unreleased]')
+    expect(result).toContain(
+      '- **Cadence**: Mechanical cadence alignment (no changes since v0.0.1).'
+    )
+    expect(result.match(/Mechanical cadence alignment/g)).toHaveLength(1)
+
+    // Governance-fold: assert the cadence bullet lands UNDER `## v0.1.0`, not
+    // under `## [Unreleased]`. Catches a regression where the cadence text
+    // gets placed in the wrong section (would still satisfy the .toContain
+    // assertions but break the Check 43 ordering invariant in spirit).
+    const unreleasedIdx = result.indexOf('## [Unreleased]')
+    const v010Idx = result.indexOf('## v0.1.0')
+    const cadenceIdx = result.indexOf('- **Cadence**: Mechanical cadence alignment')
+    expect(unreleasedIdx).toBeGreaterThanOrEqual(0)
+    expect(v010Idx).toBeGreaterThan(unreleasedIdx)
+    expect(cadenceIdx).toBeGreaterThan(v010Idx)
+  })
+})


### PR DESCRIPTION
Closes [SMI-5064](https://linear.app/smith-horn-group/issue/SMI-5064).

When `scripts/prepare-release.ts` encounters a package with zero commits since the last bump AND no carried `[Unreleased]` content, it previously emitted a bare `- Version bump` placeholder bullet. This PR swaps it for a descriptive default with a back-reference to the prior version.

## Before / After

```diff
 ## v0.2.4

-- Version bump
+- **Cadence**: Mechanical cadence alignment (no changes since v0.2.3).
```

## Why `**Cadence**:` (bold prefix)

Matches the existing `- **Fix**: …` / `- **Feature**: …` convention emitted by `formatChangelogSection` (`version-utils.ts:280-288`) for visual consistency across mixed cadence-only and content-bearing versions.

## Why include the prior version

Reader can run `git log v0.2.3..v0.2.4 -- packages/vscode-extension` to confirm zero commits — self-verifying entry.

## Tests

Two new tests in `scripts/tests/release-changelog.test.ts` covering:
- Cadence bullet inserted between `## [Unreleased]` and prior version with correct ordering (Check 43 invariant).
- First-time case (CHANGELOG has no prior versions) — bullet lands under `## v0.1.0`, not `## [Unreleased]` (positional assertion added per governance retro M-1).

Both validated locally via `tsx --eval` against `insertVersionSection`.

## Plan

[docs/internal/implementation/smi-5064-vscode-changelog-placeholder.md](https://github.com/smith-horn/skillsmith-docs/pull/224) — v2, folds plan-review M-1, L-1, L-2; governance retro M-1 also folded (positional assertion in Test 2).

## Out of scope

- Backfilling historical `- Version bump` entries in vscode-extension's CHANGELOG (out per Linear acceptance criteria).

[skip-impl-check] — single-bullet output change, no implementation surface to verify against.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)