### PR TITLE
chore(vercel): SMI-5062 filter turbo build to @skillsmith/website only

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "astro",
   "installCommand": "npm install",
-  "buildCommand": "npm run build && rm -rf .vercel/output && mkdir -p .vercel && cp -r packages/website/.vercel/output .vercel/output",
+  "buildCommand": "npx turbo run build --filter=@skillsmith/website && rm -rf .vercel/output && mkdir -p .vercel && cp -r packages/website/.vercel/output .vercel/output",
   "redirects": [
     {
       "source": "/:path*",


### PR DESCRIPTION
## Summary

- Filter Vercel's `buildCommand` to `turbo run build --filter=@skillsmith/website` so only the website (no workspace deps) builds for deploys
- Decouples Vercel deploys from mcp-server / cli / vscode-extension / enterprise typecheck health — these will no longer surface as Vercel deploy errors against unrelated PRs
- Verified via `turbo run build --filter=@skillsmith/website --dry-run=json`: resolved `"packages": ["@skillsmith/website"]` only

## Why

SMI-5012 telemetry stack hit this exact failure mode on 2026-05-20: an mcp-server HOF generic issue cascaded to ~600 TS18046 errors, which Vercel reported as deployment failures against PR-2/3/4 even though the website was healthy.

Closes SMI-5062.

## Test plan

- [ ] CI green
- [ ] Vercel preview build runs only `@skillsmith/website#build` task (no mcp-server / cli / vscode-extension tasks in turbo run plan)
- [ ] Deliberate mcp-server tsc break on a follow-up branch does NOT block Vercel preview deploy
- [ ] `[skip-impl-check]` since this is config-only

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)