### PR TITLE
fix(audit): SMI-5079 Check 11 robust npm-ls JSON parsing (stdout+stderr fallback)

### DIFF
--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -74,6 +74,44 @@ export const satisfies = (version, spec) => {
   return version === spec
 }
 
+/**
+ * SMI-5079: Parse `npm ls --json` output robustly.
+ *
+ * `npm ls` exits non-zero on tree warnings (peer-warning soup post-SMI-3984)
+ * and may interleave non-JSON prelude or warning lines into the captured
+ * output. Plain `JSON.parse(stdout)` then fails, dropping Check 11 into the
+ * pessimistic "could not inspect tree" path on overrides that ARE working.
+ *
+ * Strategy:
+ *   1. Try `JSON.parse(stdout)` directly (fast path, most common).
+ *   2. If stdout has prelude text, try parsing the substring starting at the
+ *      first `{`.
+ *   3. If both fail, try the same two strategies against `stderr` (some
+ *      npm builds split warnings/JSON across the streams).
+ *   4. Return null if nothing parses — caller falls through to pessimistic
+ *      warning, preserving the pre-SMI-3987 safe default.
+ *
+ * Returns the parsed tree object on success, or null.
+ */
+export const parseNpmLsJson = (stdout, stderr) => {
+  const tryParse = (raw) => {
+    if (!raw || typeof raw !== 'string') return null
+    try {
+      return JSON.parse(raw)
+    } catch {
+      // intentional fallthrough — try substring strategy
+    }
+    const braceIdx = raw.indexOf('{')
+    if (braceIdx < 0) return null
+    try {
+      return JSON.parse(raw.slice(braceIdx))
+    } catch {
+      return null
+    }
+  }
+  return tryParse(stdout) ?? tryParse(stderr)
+}
+
 // SMI-NNNN extraction patterns for Check 23. Subject-line refs always count
 // as completion claims. Body refs only count when prefixed by a closing
 // keyword (closes/closed/fix/fixes/fixed/resolve/resolves/resolved). The

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -32,6 +32,7 @@ import {
   parseConsumersTag,
   findConventionDrift,
   auditPublishYmlDependentGate,
+  parseNpmLsJson,
 } from './audit-standards-helpers.mjs'
 import { VERCEL_JSON_SHARED_FIELDS, validateVercelJsonSync } from './audit-vercel-sync-helpers.mjs'
 import { findRealpathAsymmetry } from './audit-realpath-asymmetry-helpers.mjs'
@@ -1377,32 +1378,23 @@ console.log(`\n${BOLD}20. Stale Doc Path References in Skills (SMI-2637)${RESET}
     // (invalid pins, peer conflicts, override inversions). The current `main`
     // post-SMI-3984 tree is in exactly that state, so every call throws.
     // **The JSON tree is still written to err.stdout** — we read it and
-    // parse it. Returning [] on every catch would fall through to the
-    // pessimistic warning path and break acceptance criterion #1
-    // (SMI-3987 plan-review E1 blocker).
-    const parseNpmLsTree = (raw) => {
-      if (!raw) return null
-      try {
-        return JSON.parse(raw)
-      } catch {
-        return null
-      }
-    }
+    // parse it. SMI-5079: some npm builds split warnings/JSON across stdout
+    // + stderr or prepend non-JSON prelude. `parseNpmLsJson` tries direct
+    // parse, brace-prefix parse, and stderr fallback before returning null.
     const getResolvedVersions = (dep) => {
-      let raw = ''
+      let stdoutRaw = ''
+      let stderrRaw = ''
       try {
-        raw = execSync(`npm ls ${dep} --all --json`, {
+        stdoutRaw = execSync(`npm ls ${dep} --all --json`, {
           encoding: 'utf-8',
           timeout: 10000,
-          stdio: ['ignore', 'pipe', 'ignore'],
+          stdio: ['ignore', 'pipe', 'pipe'],
         })
       } catch (err) {
-        // npm ls exits non-zero on ANY tree problem — stdout still contains
-        // valid JSON. Read it. If err.stdout is missing or not parseable,
-        // fall through to raw='' below → returns [] → pessimistic warning.
-        raw = (err && err.stdout && err.stdout.toString('utf-8')) || ''
+        stdoutRaw = (err && err.stdout && err.stdout.toString('utf-8')) || ''
+        stderrRaw = (err && err.stderr && err.stderr.toString('utf-8')) || ''
       }
-      const tree = parseNpmLsTree(raw)
+      const tree = parseNpmLsJson(stdoutRaw, stderrRaw)
       if (!tree) return [] // unparseable → pessimistic warning (safe default)
       // Walk the tree and collect versions of nodes whose KEY (under
       // .dependencies) matches the queried dep name. The walk must check

--- a/scripts/tests/audit-standards-npm-overrides.test.ts
+++ b/scripts/tests/audit-standards-npm-overrides.test.ts
@@ -1,0 +1,70 @@
+/**
+ * SMI-5079: Tests for `parseNpmLsJson` helper.
+ *
+ * The helper backs `getResolvedVersions` in audit-standards.mjs Check 11. It
+ * must robustly extract the npm-ls dependency tree from outputs that may
+ * include non-JSON prelude (npm warnings) or arrive on stderr instead of
+ * stdout depending on npm build/version.
+ *
+ * Pre-SMI-5079 the helper only tried plain `JSON.parse(stdout)` and dropped
+ * to "could not inspect tree" warnings for 6 working scoped overrides under
+ * the post-SMI-3984 peer-warning soup. These tests pin the new parse
+ * strategy so regressions surface in CI.
+ */
+import { describe, expect, it } from 'vitest'
+
+const helpers = (await import('../audit-standards-helpers.mjs')) as {
+  parseNpmLsJson: (stdout: string | null | undefined, stderr?: string | null) => unknown
+}
+const { parseNpmLsJson } = helpers
+
+describe('parseNpmLsJson (SMI-5079)', () => {
+  const sampleTree = {
+    version: '1.0.0',
+    name: 'skillsmith',
+    dependencies: {
+      'smol-toml': { version: '1.6.1' },
+    },
+  }
+
+  it('parses well-formed JSON on stdout', () => {
+    const out = JSON.stringify(sampleTree)
+    expect(parseNpmLsJson(out, '')).toEqual(sampleTree)
+  })
+
+  it('parses JSON when stdout has a non-JSON prelude (skips to first brace)', () => {
+    const out = `npm warn invalid: yaml-language-server@1.18.0\n${JSON.stringify(sampleTree)}`
+    expect(parseNpmLsJson(out, '')).toEqual(sampleTree)
+  })
+
+  it('parses JSON when only stderr contains the tree', () => {
+    expect(parseNpmLsJson('', JSON.stringify(sampleTree))).toEqual(sampleTree)
+  })
+
+  it('prefers stdout over stderr when both parse', () => {
+    const stdoutTree = { dependencies: { a: { version: '1.0.0' } } }
+    const stderrTree = { dependencies: { b: { version: '2.0.0' } } }
+    expect(parseNpmLsJson(JSON.stringify(stdoutTree), JSON.stringify(stderrTree))).toEqual(
+      stdoutTree
+    )
+  })
+
+  it('returns null when neither stream contains JSON', () => {
+    expect(parseNpmLsJson('npm warn deprecated foo@1.0.0\n', 'npm error code 1\n')).toBeNull()
+  })
+
+  it('returns null on empty/missing inputs', () => {
+    expect(parseNpmLsJson('', '')).toBeNull()
+    expect(parseNpmLsJson(null, undefined)).toBeNull()
+    expect(parseNpmLsJson(undefined as unknown as string, null)).toBeNull()
+  })
+
+  it('handles stderr-only path with prelude (npm warnings before JSON)', () => {
+    const stderr = `npm warn config production Use \`--omit=dev\` instead.\n${JSON.stringify(sampleTree)}`
+    expect(parseNpmLsJson('', stderr)).toEqual(sampleTree)
+  })
+
+  it('does not throw on partial JSON (returns null)', () => {
+    expect(parseNpmLsJson('{"dependencies": {', '')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Extract `parseNpmLsJson(stdout, stderr)` to `audit-standards-helpers.mjs`
- Try four parse strategies in order: stdout direct, stdout substring-from-brace, stderr direct, stderr substring-from-brace
- Caller in `audit-standards.mjs` Check 11 captures stderr now (`stdio: ['ignore', 'pipe', 'pipe']`)
- Add `scripts/tests/audit-standards-npm-overrides.test.ts` with 8 cases

## Why

Check 11 emits "could not inspect tree" warnings on overrides that ARE working when:
- `npm ls` prepends non-JSON warnings (post-SMI-3984 peer-warning soup)
- npm splits its JSON output across stdout and stderr depending on build/version

The fix is defensive: any of the four strategies yielding parseable JSON wins; null only on full failure (which preserves the pre-SMI-3987 pessimistic-warning safe default).

## Test plan

- [x] `docker exec skillsmith-dev-1 bash -c "cd /app && ./node_modules/.bin/vitest run scripts/tests/audit-standards-npm-overrides.test.ts"` → 8/8 passing
- [x] `docker exec skillsmith-dev-1 npm run audit:standards` → no regressions (71 passed / 5 warnings, all Check 21 SSL pre-existing)
- [ ] CI lint + typecheck + format
- [ ] CI audit:standards on this branch and on rebase to main

Closes SMI-5079.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)