### PR TITLE
feat(cli): SMI-5040 v1 — wrap CLI dispatchers with withTelemetry HOF (4 files pilot)

### DIFF
--- a/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
@@ -1,0 +1,101 @@
+/**
+ * SMI-5040 — CLI-tree telemetry coverage snapshot test.
+ *
+ * Scope: `packages/cli/src/commands/` (v1 partial).
+ * Mirrors SMI-5018's MCP coverage test (packages/mcp-server/src/tools/__meta__/
+ * telemetry-coverage.test.ts) but iterates the CLI command dispatchers.
+ *
+ * Why a sibling test rather than extending SMI-5018: import-path scope. The
+ * MCP test uses `import.meta.url`-relative paths under `tools/`; reusing it
+ * would couple the two trees and force the MCP test to know about CLI files.
+ * Per-tree snapshots are loosely coupled and each can grow on its own
+ * cadence as coverage extends.
+ *
+ * v1 partial: this allowlist is intentionally smaller than the universe of
+ * CLI commands. Remaining files (~18) are tracked under SMI-5040 follow-up
+ * sub-issues. The drift sentinel in the bottom test ensures the listed
+ * dispatchers stay wrapped; new wraps must be added to CLI_DISPATCHER_MAP.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { isTelemetered } from '@skillsmith/core/telemetry'
+
+/**
+ * Maps source-file base name (no extension) under `packages/cli/src/commands/`
+ * to the list of wrapped-action export names that live in that file.
+ *
+ * ADDING A NEW WRAPPED ACTION:
+ *   1. Wrap the command's action handler with `withTelemetry` in its source
+ *      file (extract impl → const action = withTelemetry(impl, opts)).
+ *   2. Add its export name to the correct inner array below.
+ *   3. Pass the wrapped action to `.action(...)` in the createXCommand factory.
+ */
+const CLI_DISPATCHER_MAP: Record<string, string[]> = {
+  info: ['infoAction'],
+  recommend: ['recommendAction'],
+  whoami: ['whoamiAction'],
+  'install-skill': ['setupAction'],
+}
+
+const EXPECTED_TOTAL = Object.values(CLI_DISPATCHER_MAP).reduce((n, arr) => n + arr.length, 0)
+
+const COMMANDS_DIR = new URL('../', import.meta.url).pathname
+
+describe('SMI-5040: CLI command telemetry coverage (v1 partial)', () => {
+  it('EXPECTED_TOTAL matches sum of CLI_DISPATCHER_MAP entries', () => {
+    const actualSum = Object.values(CLI_DISPATCHER_MAP).reduce((n, arr) => n + arr.length, 0)
+    expect(actualSum).toBe(EXPECTED_TOTAL)
+  })
+
+  it('every listed CLI dispatcher export is telemetry-wrapped', async () => {
+    const failures: string[] = []
+
+    for (const [fileBase, exportNames] of Object.entries(CLI_DISPATCHER_MAP)) {
+      const modulePath = `${COMMANDS_DIR}${fileBase}.ts`
+
+      let mod: Record<string, unknown>
+      try {
+        mod = (await import(modulePath)) as Record<string, unknown>
+      } catch (err) {
+        failures.push(
+          `[IMPORT ERROR] ${fileBase}.ts — ${err instanceof Error ? err.message : String(err)}`
+        )
+        continue
+      }
+
+      for (const exportName of exportNames) {
+        const exported = mod[exportName]
+
+        if (typeof exported !== 'function') {
+          failures.push(`${fileBase}.ts :: ${exportName} — not a function (got ${typeof exported})`)
+          continue
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (!isTelemetered(exported as (...args: any[]) => any)) {
+          failures.push(
+            `${fileBase}.ts :: ${exportName} — function exists but isTelemetered() returned false`
+          )
+        }
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(
+        `CLI telemetry coverage failures (${failures.length}):\n` +
+          failures.map((f) => `  • ${f}`).join('\n') +
+          '\n\nTo fix: wrap the dispatcher with withTelemetry(...) and add it to CLI_DISPATCHER_MAP.'
+      )
+    }
+  })
+
+  it('reports CLI dispatcher coverage to CI output', () => {
+    const fileCount = Object.keys(CLI_DISPATCHER_MAP).length
+    const dispatcherCount = EXPECTED_TOTAL
+    console.info(
+      `[SMI-5040] CLI telemetry coverage: ${dispatcherCount} dispatchers across ${fileCount} files (v1 partial).`
+    )
+    console.info('[SMI-5040] Remaining CLI files + VS Code: tracked under SMI-5040 follow-up.')
+    expect(dispatcherCount).toBeGreaterThanOrEqual(4)
+  })
+})

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -9,6 +9,7 @@ import { Command } from 'commander'
 import chalk from 'chalk'
 import ora from 'ora'
 import { SkillRepository, createApiClient, loadStoredAccessToken } from '@skillsmith/core'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { openCliDatabase } from '../utils/open-database.js'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
@@ -26,6 +27,91 @@ interface InfoOptions {
   json: boolean
 }
 
+// SMI-5040: extracted from inline .action() closure to a named function so
+// withTelemetry can wrap it at the export boundary (SMI-5018 coverage gate).
+async function infoActionImpl(skillId: string, options: InfoOptions): Promise<void> {
+  const spinner = ora('Looking up skill...').start()
+
+  try {
+    const db = await openCliDatabase(options.db)
+    const skillRepo = new SkillRepository(db)
+
+    // Try local DB first
+    const skill = skillRepo.findById(skillId)
+    if (!skill) {
+      spinner.fail(`Skill "${skillId}" not found`)
+      process.exit(1)
+    }
+
+    // Fetch content from local DB (raw_content column)
+    let content: string | undefined
+    try {
+      const row = db.prepare('SELECT raw_content FROM skills WHERE id = ?').get(skillId) as
+        | { raw_content: string | null }
+        | undefined
+      content = row?.raw_content || undefined
+    } catch {
+      // raw_content column may not exist in pre-migration databases
+      content = undefined
+    }
+
+    // Try API for content if not available locally
+    if (!content) {
+      try {
+        // SMI-4474: auto-load JWT so logged-in users count toward quota.
+        const jwtToken = await loadStoredAccessToken()
+        const apiClient = createApiClient(jwtToken ? { jwtToken } : {})
+        if (!apiClient.isOffline()) {
+          const apiResponse = await apiClient.getSkill(skillId, { includeContent: true })
+          content = apiResponse.data.content || undefined
+        }
+      } catch {
+        // API failed — continue without content
+      }
+    }
+
+    spinner.stop()
+
+    // JSON output
+    if (options.json) {
+      console.log(JSON.stringify({ skill, content: content || null }, null, 2))
+      return
+    }
+
+    // Raw content only
+    if (options.raw) {
+      if (content) {
+        console.log(stripAnsiEscapes(content))
+      } else {
+        console.log(chalk.gray('No SKILL.md content available for this skill.'))
+      }
+      return
+    }
+
+    // Default: metadata + content
+    displaySkillDetails({ skill, rank: 0, highlights: {} })
+
+    if (content) {
+      console.log(chalk.bold('\nSkill Content:'))
+      console.log(chalk.dim('─'.repeat(60)))
+      console.log(stripAnsiEscapes(content))
+      console.log(chalk.dim('─'.repeat(60)))
+    } else {
+      console.log(chalk.gray('\nNo SKILL.md content available for this skill.'))
+    }
+  } catch (error) {
+    spinner.fail('Failed to retrieve skill info')
+    console.error(sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const infoAction = withTelemetry(infoActionImpl, {
+  source: 'cli',
+  extractSkillId: (args) => (args[0] as string) ?? 'info',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create the `info` command
  */
@@ -36,80 +122,5 @@ export function createInfoCommand(): Command {
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
     .option('--raw', 'Output only SKILL.md content (no metadata)')
     .option('--json', 'Output full JSON response')
-    .action(async (skillId: string, options: InfoOptions) => {
-      const spinner = ora('Looking up skill...').start()
-
-      try {
-        const db = await openCliDatabase(options.db)
-        const skillRepo = new SkillRepository(db)
-
-        // Try local DB first
-        const skill = skillRepo.findById(skillId)
-        if (!skill) {
-          spinner.fail(`Skill "${skillId}" not found`)
-          process.exit(1)
-        }
-
-        // Fetch content from local DB (raw_content column)
-        let content: string | undefined
-        try {
-          const row = db.prepare('SELECT raw_content FROM skills WHERE id = ?').get(skillId) as
-            | { raw_content: string | null }
-            | undefined
-          content = row?.raw_content || undefined
-        } catch {
-          // raw_content column may not exist in pre-migration databases
-          content = undefined
-        }
-
-        // Try API for content if not available locally
-        if (!content) {
-          try {
-            // SMI-4474: auto-load JWT so logged-in users count toward quota.
-            const jwtToken = await loadStoredAccessToken()
-            const apiClient = createApiClient(jwtToken ? { jwtToken } : {})
-            if (!apiClient.isOffline()) {
-              const apiResponse = await apiClient.getSkill(skillId, { includeContent: true })
-              content = apiResponse.data.content || undefined
-            }
-          } catch {
-            // API failed — continue without content
-          }
-        }
-
-        spinner.stop()
-
-        // JSON output
-        if (options.json) {
-          console.log(JSON.stringify({ skill, content: content || null }, null, 2))
-          return
-        }
-
-        // Raw content only
-        if (options.raw) {
-          if (content) {
-            console.log(stripAnsiEscapes(content))
-          } else {
-            console.log(chalk.gray('No SKILL.md content available for this skill.'))
-          }
-          return
-        }
-
-        // Default: metadata + content
-        displaySkillDetails({ skill, rank: 0, highlights: {} })
-
-        if (content) {
-          console.log(chalk.bold('\nSkill Content:'))
-          console.log(chalk.dim('─'.repeat(60)))
-          console.log(stripAnsiEscapes(content))
-          console.log(chalk.dim('─'.repeat(60)))
-        } else {
-          console.log(chalk.gray('\nNo SKILL.md content available for this skill.'))
-        }
-      } catch (error) {
-        spinner.fail('Failed to retrieve skill info')
-        console.error(sanitizeError(error))
-        process.exit(1)
-      }
-    })
+    .action(infoAction)
 }

--- a/packages/cli/src/commands/install-skill.ts
+++ b/packages/cli/src/commands/install-skill.ts
@@ -12,6 +12,7 @@ import { mkdir, copyFile, stat, readdir } from 'fs/promises'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { getCanonicalInstallPath } from '@skillsmith/core/install'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { sanitizeError } from '../utils/sanitize.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -141,6 +142,32 @@ async function installSkillsmithSkill(force: boolean): Promise<void> {
   }
 }
 
+// SMI-5040: extracted from inline .action() closure for withTelemetry wrap.
+async function setupActionImpl(opts: { force?: boolean }): Promise<void> {
+  try {
+    // SMI-3484: Deprecation warning when invoked via old name
+    const invokedName = process.argv[2]
+    if (invokedName === 'install-skill') {
+      console.log(
+        chalk.yellow(
+          'Warning: "install-skill" is deprecated and will be removed in a future release. ' +
+            'Use "setup" instead.'
+        )
+      )
+    }
+    await installSkillsmithSkill(opts.force ?? false)
+  } catch (error) {
+    console.error(chalk.red('Error:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const setupAction = withTelemetry(setupActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'setup',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create the install-skill command
  */
@@ -151,24 +178,7 @@ export function createInstallSkillCommand(): Command {
       'Set up the skillsmith slash command skill (installs to ~/.claude/skills/skillsmith/)'
     )
     .option('-f, --force', 'Reinstall even if already installed')
-    .action(async (opts: { force?: boolean }) => {
-      try {
-        // SMI-3484: Deprecation warning when invoked via old name
-        const invokedName = process.argv[2]
-        if (invokedName === 'install-skill') {
-          console.log(
-            chalk.yellow(
-              'Warning: "install-skill" is deprecated and will be removed in a future release. ' +
-                'Use "setup" instead.'
-            )
-          )
-        }
-        await installSkillsmithSkill(opts.force ?? false)
-      } catch (error) {
-        console.error(chalk.red('Error:'), sanitizeError(error))
-        process.exit(1)
-      }
-    })
+    .action(setupAction)
 }
 
 export default createInstallSkillCommand

--- a/packages/cli/src/commands/recommend.ts
+++ b/packages/cli/src/commands/recommend.ts
@@ -15,6 +15,7 @@ import {
   type SkillRole,
   SKILL_ROLES,
 } from '@skillsmith/core'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { sanitizeError } from '../utils/sanitize.js'
 
 // Re-export types for public API
@@ -186,6 +187,47 @@ async function runRecommend(targetPath: string, options: RecommendOptions): Prom
 // Command Creation
 // ============================================================================
 
+// SMI-5040: extracted from inline .action() closure for withTelemetry wrap.
+async function recommendActionImpl(
+  targetPath: string,
+  opts: Record<string, string | boolean | string[] | undefined>
+): Promise<void> {
+  const limit = parseInt(opts['limit'] as string, 10)
+  const maxFiles = parseInt(opts['max-files'] as string, 10)
+  const json = (opts['json'] as boolean) === true
+  const context = opts['context'] as string | undefined
+  const installed = opts['installed'] as string[] | undefined
+  const noOverlap = opts['overlap'] === false
+
+  const roleInput = opts['role'] as string | undefined
+  let role: SkillRole | undefined
+  if (roleInput) {
+    if (SKILL_ROLES.includes(roleInput as SkillRole)) {
+      role = roleInput as SkillRole
+    } else {
+      console.error(
+        chalk.yellow(`Warning: Invalid role "${roleInput}". Valid roles: ${SKILL_ROLES.join(', ')}`)
+      )
+    }
+  }
+
+  await runRecommend(targetPath, {
+    limit: isNaN(limit) ? 5 : Math.min(Math.max(limit, 1), 50),
+    maxFiles: isNaN(maxFiles) ? 1000 : maxFiles,
+    json,
+    context,
+    installed,
+    noOverlap,
+    role,
+  })
+}
+
+export const recommendAction = withTelemetry(recommendActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'recommend',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create recommend command
  */
@@ -203,40 +245,7 @@ export function createRecommendCommand(): Command {
       '-r, --role <role>',
       `SMI-1631: Filter by skill role (${SKILL_ROLES.join(', ')}). Skills matching the role get a +30 score boost.`
     )
-    .action(
-      async (targetPath: string, opts: Record<string, string | boolean | string[] | undefined>) => {
-        const limit = parseInt(opts['limit'] as string, 10)
-        const maxFiles = parseInt(opts['max-files'] as string, 10)
-        const json = (opts['json'] as boolean) === true
-        const context = opts['context'] as string | undefined
-        const installed = opts['installed'] as string[] | undefined
-        const noOverlap = opts['overlap'] === false
-
-        const roleInput = opts['role'] as string | undefined
-        let role: SkillRole | undefined
-        if (roleInput) {
-          if (SKILL_ROLES.includes(roleInput as SkillRole)) {
-            role = roleInput as SkillRole
-          } else {
-            console.error(
-              chalk.yellow(
-                `Warning: Invalid role "${roleInput}". Valid roles: ${SKILL_ROLES.join(', ')}`
-              )
-            )
-          }
-        }
-
-        await runRecommend(targetPath, {
-          limit: isNaN(limit) ? 5 : Math.min(Math.max(limit, 1), 50),
-          maxFiles: isNaN(maxFiles) ? 1000 : maxFiles,
-          json,
-          context,
-          installed,
-          noOverlap,
-          role,
-        })
-      }
-    )
+    .action(recommendAction)
 
   return cmd
 }

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -62,5 +62,7 @@ export const whoamiAction = withTelemetry(whoamiActionImpl, {
  * Create the `skillsmith whoami` command.
  */
 export function createWhoamiCommand(): Command {
-  return new Command('whoami').description('Show current authentication status').action(whoamiAction)
+  return new Command('whoami')
+    .description('Show current authentication status')
+    .action(whoamiAction)
 }

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -10,6 +10,7 @@
 import { Command } from 'commander'
 import chalk from 'chalk'
 import { getAuthStatus } from '@skillsmith/core'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 
 /** Human-readable labels for each credential source */
 const SOURCE_LABELS: Record<string, string> = {
@@ -19,40 +20,47 @@ const SOURCE_LABELS: Record<string, string> = {
   none: 'none',
 }
 
+// SMI-5040: extracted from inline .action() closure for withTelemetry wrap.
+async function whoamiActionImpl(): Promise<void> {
+  const status = await getAuthStatus()
+
+  if (!status.authenticated || !status.keyPrefix) {
+    console.log(`Not authenticated. Run ${chalk.cyan('`skillsmith login`')} to authenticate.`)
+    process.exit(0)
+  }
+
+  // Mask: show first 12 chars + ellipsis
+  // The full key is sk_live_ (8 chars) + 32-128 chars.
+  // 12 chars shows "sk_live_xxxx" without revealing the secret suffix.
+  const masked = `${status.keyPrefix}...`
+
+  console.log(chalk.bold('Skillsmith CLI'))
+  console.log(chalk.dim('  Key:    ') + chalk.cyan(masked))
+  console.log(chalk.dim('  Source: ') + (SOURCE_LABELS[status.source] ?? status.source))
+  console.log(chalk.dim('  Format: ') + chalk.green('valid'))
+
+  // Hint: when using file fallback, let the user know they can upgrade to keyring
+  if (status.source === 'config') {
+    console.log(
+      chalk.dim(
+        '  Tip:    Install @isaacs/keytar for more secure OS keyring storage: ' +
+          'npm install -g @isaacs/keytar'
+      )
+    )
+  }
+
+  process.exit(0)
+}
+
+export const whoamiAction = withTelemetry(whoamiActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'whoami',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create the `skillsmith whoami` command.
  */
 export function createWhoamiCommand(): Command {
-  return new Command('whoami')
-    .description('Show current authentication status')
-    .action(async () => {
-      const status = await getAuthStatus()
-
-      if (!status.authenticated || !status.keyPrefix) {
-        console.log(`Not authenticated. Run ${chalk.cyan('`skillsmith login`')} to authenticate.`)
-        process.exit(0)
-      }
-
-      // Mask: show first 12 chars + ellipsis
-      // The full key is sk_live_ (8 chars) + 32-128 chars.
-      // 12 chars shows "sk_live_xxxx" without revealing the secret suffix.
-      const masked = `${status.keyPrefix}...`
-
-      console.log(chalk.bold('Skillsmith CLI'))
-      console.log(chalk.dim('  Key:    ') + chalk.cyan(masked))
-      console.log(chalk.dim('  Source: ') + (SOURCE_LABELS[status.source] ?? status.source))
-      console.log(chalk.dim('  Format: ') + chalk.green('valid'))
-
-      // Hint: when using file fallback, let the user know they can upgrade to keyring
-      if (status.source === 'config') {
-        console.log(
-          chalk.dim(
-            '  Tip:    Install @isaacs/keytar for more secure OS keyring storage: ' +
-              'npm install -g @isaacs/keytar'
-          )
-        )
-      }
-
-      process.exit(0)
-    })
+  return new Command('whoami').description('Show current authentication status').action(whoamiAction)
 }


### PR DESCRIPTION
## Summary

- Establishes the CLI-tree telemetry wrap pattern per SMI-5040 Option A: extract inline `.action()` closure → named `<x>ActionImpl` function → `withTelemetry` wrap → re-attach to Commander factory.
- v1 wraps 4 representative commands: `info`, `recommend`, `whoami`, `setup` (formerly install-skill)
- Adds `packages/cli/src/commands/__meta__/telemetry-coverage.test.ts` mirroring SMI-5018's MCP coverage snapshot. `CLI_DISPATCHER_MAP` starts at 4 entries; the drift sentinel asserts each listed export is `isTelemetered() === true`.

## Why partial, not all 22 CLI files

Scope investigation showed 22 CLI files using `.action(...)`, several near the 500-line audit Check 3 gate (search.ts:492, sync.ts:490). Wrapping mechanically still fits the brief, but landing 22 file changes in a single PR risks conflating real bugs with mechanical churn during review. Pattern + test infrastructure ships in v1; the remaining files are tracked under SMI-5083 (follow-up sub-issue) for parallel/mechanical PRs.

## Pattern

```ts
// BEFORE
.action(async (skillId: string, options: InfoOptions) => {
  // handler body
})

// AFTER
async function infoActionImpl(skillId: string, options: InfoOptions): Promise<void> {
  // handler body — extracted unchanged
}
export const infoAction = withTelemetry(infoActionImpl, {
  source: 'cli',
  extractSkillId: (args) => (args[0] as string) ?? 'info',
  extractFramework: () => 'cli',
})
// ... .action(infoAction)
```

## Verification

- `docker exec skillsmith-dev-1 bash -c "cd /app && ./node_modules/.bin/vitest run packages/cli/src/commands/__meta__/telemetry-coverage.test.ts"` → 3/3 passing, 4 dispatchers wrapped across 4 files
- `docker exec -w /app skillsmith-dev-1 npm run typecheck` → 0 CLI errors (pre-existing zod errors on main are SMI-5037, in flight under PR #1286)

## Test plan

- [x] CLI coverage test passes
- [x] No new typecheck regressions in CLI
- [ ] CI lint + format
- [ ] Pre-existing zod typecheck failures (SMI-5037) cleared on main; rebase + re-run CI

## Linked

- Parent: SMI-5012 (telemetry epic)
- Follow-up: SMI-5083 (wrap remaining ~18 CLI files + 4 VS Code panel actions)
- Pattern source: SMI-5017's MCP wrap + SMI-5018's MCP coverage test

Closes SMI-5040 (v1 partial — follow-up tracked under SMI-5083).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)