### PR TITLE
docs: SMI-5012 aftershock — Phase 1 retro + plan + CLAUDE.md Linear Hygiene

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,23 @@ Git-crypt smudge filters can silently switch branches during stash/pop (includin
 
 ---
 
+## Linear Hygiene (per-commit + per-PR)
+
+**Keep Linear in lock-step with the code. Every commit and every merge updates Linear before moving on — no batching, no end-of-session catch-up.**
+
+**After EVERY commit** (immediately, before the next task):
+1. **Comment** on the relevant `SMI-xxx` issue with the commit SHA + a one-line summary of what changed.
+2. **Advance status** if the commit completes the work (`In Progress` → `In Review`/`Done`). A commit that only partially advances the issue stays `In Progress` with a progress comment.
+3. If **no issue exists** for the work, create one under the correct project *before* committing (never commit orphaned work). Project assignment is mandatory (see [Linear hygiene guide](docs/internal/process/linear-hygiene-guide.md)).
+
+**After EVERY PR merges**:
+1. Move the issue to `Done` with the squash-merge SHA in a closing comment.
+2. Post a **project update** on the Linear project when a wave/PR-cluster lands or a blocker changes state — keep stakeholders current without them having to read the issue feed.
+
+**Tooling**: MCP Linear tools when connected; fallback `varlock run -- node scripts/linear-api.mjs` (never `npm run linear:done` — broken). Team: **Smith Horn Group**. Always set `project` + a detailed description + labels on issue creation. Full conventions: [linear-hygiene-guide.md](docs/internal/process/linear-hygiene-guide.md).
+
+---
+
 ## Varlock Security
 
 **All secrets via Varlock. Never expose API keys in terminal output.** Commit `.env.schema` (defines `@sensitive`) and `.env.example` (placeholders); **never** `.env`. Run with secrets: `varlock run -- npm test`. Validate: `varlock load` (masked). **Never** `echo $SECRET` or `cat .env`. Never ask users to paste secrets in chat. See [AI Agent Secret Handling](docs/internal/architecture/standards-security.md#411-ai-agent-secret-handling-smi-1956).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,11 +118,13 @@ Git-crypt smudge filters can silently switch branches during stash/pop (includin
 **Keep Linear in lock-step with the code. Every commit and every merge updates Linear before moving on — no batching, no end-of-session catch-up.**
 
 **After EVERY commit** (immediately, before the next task):
+
 1. **Comment** on the relevant `SMI-xxx` issue with the commit SHA + a one-line summary of what changed.
 2. **Advance status** if the commit completes the work (`In Progress` → `In Review`/`Done`). A commit that only partially advances the issue stays `In Progress` with a progress comment.
 3. If **no issue exists** for the work, create one under the correct project *before* committing (never commit orphaned work). Project assignment is mandatory (see [Linear hygiene guide](docs/internal/process/linear-hygiene-guide.md)).
 
 **After EVERY PR merges**:
+
 1. Move the issue to `Done` with the squash-merge SHA in a closing comment.
 2. Post a **project update** on the Linear project when a wave/PR-cluster lands or a blocker changes state — keep stakeholders current without them having to read the issue feed.
 


### PR DESCRIPTION
## Summary
- Bumps `docs/internal` pointer to `1880b85` — adds the SMI-5012 aftershock **Phase 1 retro** (`retros/2026-05-22-...`) and the **aftershock plan** (`implementation/2026-05-21-...`) + retros index entry.
- Adds a dedicated **"Linear Hygiene (per-commit + per-PR)"** section to `CLAUDE.md`, elevating the per-commit issue-update + per-PR project-update cadence out of the footer reminders (per user request this session).

## Context
Phase 1 of the SMI-5012 aftershock landed 5 PRs (#1286/#1289/#1292/#1293/#1294 — SMI-5037/5062/5079/5080/5040), all merged with clean CI. Governance retro: zero findings. Full detail in the retro doc.

[skip-smoke] docs-only; no prod surface touched.

## Test plan
- [x] docs/internal submodule commit pushed (`1880b85` on skillsmith-docs main)
- [x] CLAUDE.md edit re-applied (lost earlier to a parallel-session branch switch)
- [ ] Docs-tier CI (Detect Doc Changes + Markdown Lint) green

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)