### PR TITLE
test(core): SMI-5121 — skipIf native better-sqlite3 in import-to-database suite

### DIFF
--- a/packages/core/tests/scripts/import-to-database.test.ts
+++ b/packages/core/tests/scripts/import-to-database.test.ts
@@ -16,6 +16,7 @@ import { importToDatabase, saveReport } from '../../src/scripts/import-to-databa
 import { createDatabase, openDatabase } from '../../src/db/schema.js'
 import { SkillRepository } from '../../src/repositories/SkillRepository.js'
 import { SearchService } from '../../src/services/SearchService.js'
+import { isBetterSqlite3Available } from '../../src/db/drivers/betterSqlite3Driver.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const TEST_DIR = join(__dirname, '..', 'fixtures', 'import-test')
@@ -77,7 +78,12 @@ const sampleValidatedSkills = {
   ],
 }
 
-describe('SMI-866: import-to-database', () => {
+// SMI-5121: this suite drives the native-only sync path (importToDatabase →
+// createDatabase → createDatabaseSync), which throws when better-sqlite3 can't
+// load — unlike sibling DB tests that use the WASM fallback. Skip (don't fail)
+// where native is unavailable (macOS host, worktree virtiofs) so the pre-push
+// coverage check passes everywhere; CI runs in clean Docker where native loads.
+describe.skipIf(!isBetterSqlite3Available())('SMI-866: import-to-database', () => {
   beforeEach(() => {
     // Create test directory
     if (!existsSync(TEST_DIR)) {


### PR DESCRIPTION
## Summary
- Gates the SMI-866 `import-to-database` suite with `describe.skipIf(!isBetterSqlite3Available())` so it **skips** (rather than throwing) where native better-sqlite3 can't load.
- This suite drives the native-only sync path (`importToDatabase → createDatabase → createDatabaseSync`), unlike sibling DB tests that use the WASM fallback — so it was the test that hard-failed the pre-push **Phase 4 coverage check** on macOS host and in worktrees (virtiofs), forcing ~7 bypassed pushes during the SMI-5012 aftershock.
- CI runs in clean Docker where native loads → `skipIf(false)` → all 20 tests run. **No native-path coverage lost.**

## Verification
- Host-side (native absent): suite now **skips cleanly** (20 skipped, 0 errors) instead of throwing.
- `tsc --noEmit` ✓, `eslint` ✓ (0), `prettier --check` ✓ on the changed file.
- Probe `isBetterSqlite3Available()` is the exact predicate `createDatabaseSync` checks before throwing (`createDatabase.ts:115`).

## Note on remaining worktree false-negatives (out of scope — SMI-5082 family)
With import-to-database fixed, the worktree/host pre-push surfaced **10 unrelated host-only failures** in `packages/doc-retrieval-mcp/src/adapters/` (git/fs-state-sensitive adapters, e.g. `git-commits.test.ts`). **All 94 adapter tests pass in clean Docker** (verified) — these are environmental worktree false-negatives, a different root cause from this PR (worktree git/fs state, not the native-sqlite sync path). Tracked under SMI-5082. This push therefore used the documented `command git -c core.hooksPath=/dev/null` bypass; clean-Docker CI is the real gate.

Linear: SMI-5121

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)