### PR TITLE
fix(gitignore): SMI-5124 match worktree per-package node_modules symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
-node_modules/
+# No trailing slash: also match worktree per-package node_modules symlinks (SMI-5124)
+node_modules
 .pnpm-store/
 
 # Ruflo AgentDB runtime persistence (hive-mind state)

--- a/packages/website/.gitignore
+++ b/packages/website/.gitignore
@@ -4,7 +4,8 @@ dist-worker/
 .astro/
 
 # Dependencies
-node_modules/
+# No trailing slash: also match worktree per-package node_modules symlinks (SMI-5124)
+node_modules
 
 # Environment variables
 .env


### PR DESCRIPTION
## Summary
Drop the trailing slash on the `node_modules` ignore in the root `.gitignore` and `packages/website/.gitignore`. A trailing-slash pattern (`node_modules/`) matches directories but **not symlinks**, so worktree per-package `node_modules` symlinks (e.g. `packages/core/node_modules -> ...`) showed as untracked and could be staged by `git add -A` — a foot-gun caught manually during the SMI-5119 recovery.

## Changes
- `.gitignore`: `node_modules/` → `node_modules`
- `packages/website/.gitignore`: `node_modules/` → `node_modules`

## Verification
- `git check-ignore packages/core/node_modules packages/website/node_modules node_modules` → all three ignored (symlinks + real dirs).
- `git ls-files | grep -c node_modules` → 0 (nothing previously tracked becomes ignored).
- `packages/website` is the only nested package `.gitignore` referencing node_modules.

Closes SMI-5124.

[skip-impl-check]
[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)