### PR TITLE
fix(publish): SMI-5122/5123 pre-publish bootstrap fail-fast + cli→mcp-server gate

### DIFF
--- a/.claude/development/publishing-guide.md
+++ b/.claude/development/publishing-guide.md
@@ -92,6 +92,18 @@ Dependencies before consumers:
 2. `@skillsmith/mcp-server` and `@skillsmith/cli` (both depend on core)
 3. `@smith-horn/enterprise` (private, GitHub Packages)
 
+## New-package onboarding
+
+Adding a brand-new package to the publish pipeline is a multi-step setup, and **the npmjs.com registration MUST come first**. SMI-4540 made all npm publishes OIDC-only (the granular token was revoked 2026-05-19), and **OIDC trusted-publishing cannot bootstrap a package that does not already exist on npm** — the very first publish of a never-seen package dies with an opaque `E404`. SMI-5122 added a `pre-publish-check` fail-fast (`scripts/check-npm-bootstrap.mjs`) that catches this with an actionable message before the expensive Docker build, but the only real fix is to register the package by hand first.
+
+1. **Register the package + enable trusted-publisher OIDC on npmjs.com BEFORE adding it to the pipeline.** On npmjs.com: create/claim the package name, then Settings → Trusted Publisher → add repo `smith-horn/skillsmith`, workflow `publish.yml`. (GitHub Packages targets like `@smith-horn/enterprise` publish via `GITHUB_TOKEN` and *can* bootstrap a new package, so this step is npmjs.org-scoped — i.e. `@skillsmith/*`.)
+2. Add the package name to `PUBLISHABLE_PACKAGES_JSON` in `.github/workflows/publish.yml`.
+3. Add the package to `PACKAGE_SPECS` in `scripts/lib/version-utils.ts`.
+4. Run `npm run audit:standards` (Check 48 asserts the publish-job gates exist for any workspace-sibling deps the new package declares — see SMI-5123).
+5. Update the release tests (`scripts/tests/prepare-release.test.ts`, smoke-test required arrays) and add an `[Unreleased]` `CHANGELOG.md` entry so the doc-drift gate passes.
+
+If the bootstrap fail-fast trips in CI, it means step 1 was skipped — register the package on npmjs.com, then re-run. Cross-ref: SMI-4540 (OIDC-only publishes), SMI-5122 (bootstrap fail-fast).
+
 ## Critical Rules
 
 **Never** publish a consumer before its dependency. **Never** publish with an exact-pinned workspace dep (use `^` prefix). Workspace resolution masks version-pin errors locally — only fresh `npm install` from the registry reveals mismatches. See [retro: mcp-server@0.4.5](../../docs/internal/retros/2026-03-19-mcp-server-0.4.5-hotfix.md).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,6 +141,34 @@ jobs:
 
           echo "any_to_publish=$ANY_TO_PUBLISH" >> $GITHUB_OUTPUT
 
+      # SMI-5122: fail-fast for a brand-new package that was never published.
+      # The version-check step above reports `<x>_exists=false` for a package
+      # with zero versions on npm just as it does for a new VERSION of an
+      # existing package — but the former proceeds to a publish job that dies
+      # with an opaque E404, because npm OIDC trusted-publishing cannot
+      # bootstrap a package that does not already exist on npm. We surface that
+      # here with an actionable message. Only npmjs.org packages (@skillsmith/*)
+      # are gated; @smith-horn/enterprise publishes to GitHub Packages via
+      # GITHUB_TOKEN and CAN bootstrap a new package, so it is excluded.
+      # check-npm-bootstrap.mjs gracefully skips (exit 0, ::warning::) on
+      # transient network/registry errors — it never blocks on ambiguity.
+      - name: Bootstrap-publisher fail-fast (SMI-5122)
+        run: |
+          set -euo pipefail
+          FAILED=0
+          PKGS=$(echo "$PUBLISHABLE_PACKAGES_JSON" | jq -r '.[] | select(startswith("@skillsmith/"))')
+          for pkg in $PKGS; do
+            echo "::group::Bootstrap gate: $pkg"
+            if ! node scripts/check-npm-bootstrap.mjs "$pkg"; then
+              FAILED=1
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::One or more publishable packages are unregistered on npm — see annotations above."
+            exit 1
+          fi
+
       - name: Validate .npmignore files exist
         run: |
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -785,7 +813,7 @@ jobs:
     name: Publish @skillsmith/cli
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [pre-publish-check, validate, publish-core]
+    needs: [pre-publish-check, validate, publish-core, publish-mcp-server]
     # SMI-4540: id-token: write enables npm trusted-publisher OIDC, which is now
     # the sole auth path for npm publish (granular token revoked 2026-05-19).
     permissions:
@@ -793,12 +821,20 @@ jobs:
       id-token: write
     # SMI-4803: see publish-mcp-server for `!cancelled()` rationale.
     # SMI-5060: see publish-mcp-server for the core-exists predicate rationale.
+    # SMI-5123: cli's package.json depends on BOTH @skillsmith/core AND
+    # @skillsmith/mcp-server. Before this gate, publish-cli only needed/gated on
+    # core, so cli could publish while mcp-server was skipped — shipping a live
+    # dangling ref (cli@0.6.3 → mcp-server@^0.5.3 that didn't exist). Add the
+    # SMI-5060 paired predicate for mcp-server too (mcp-exists output key per
+    # PUBLISH_JOB_TO_OUTPUT_ALIAS), AND it with the existing core gate.
     if: |
       !cancelled() &&
       (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
       needs.pre-publish-check.outputs.cli-exists != 'true' &&
       (needs.publish-core.result == 'success' ||
-       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true'))
+       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true')) &&
+      (needs.publish-mcp-server.result == 'success' ||
+       (needs.publish-mcp-server.result == 'skipped' && needs.pre-publish-check.outputs.mcp-exists == 'true'))
 
     steps:
       - name: Checkout

--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -1120,3 +1120,136 @@ export function auditPublishYmlDependentGate(content) {
 
   return { matches, failures }
 }
+
+/**
+ * Map an `@scope/name` package name to its publish-job short name.
+ * `@skillsmith/mcp-server` → `mcp-server`, `@smith-horn/enterprise` →
+ * `enterprise`. Mirrors the `<scope>/<shortName>` → `publish-<shortName>`
+ * convention used throughout publish.yml.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function shortNameFromPackage(name) {
+  const slash = name.indexOf('/')
+  return slash === -1 ? name : name.slice(slash + 1)
+}
+
+/**
+ * SMI-5123: POSITIVE-COVERAGE assertion for publish.yml dependency gating.
+ *
+ * `auditPublishYmlDependentGate` only checks SOUNDNESS: any
+ * `publish-X.result == 'skipped'` clause that EXISTS must carry its paired
+ * `X-exists` predicate. It says nothing about gates that are MISSING entirely
+ * — exactly the SMI-5123 bug (publish-cli depends on @skillsmith/mcp-server in
+ * package.json but had NO gate on publish-mcp-server, so cli could publish a
+ * live dangling ref while mcp-server was skipped).
+ *
+ * This helper derives the REQUIRED gates from ground truth (each publishable
+ * package's package.json workspace-sibling deps that are themselves
+ * publishable) and asserts that the consumer's publish job both (a) `needs:`
+ * the sibling's publish job and (b) carries the SMI-5060 paired predicate
+ * (`needs.publish-<sibling>.result == 'skipped' && ...<key>-exists == 'true'`).
+ *
+ * @param {string} publishYmlContent - Full publish.yml content (UTF-8).
+ * @param {Array<{ name: string, json: any }>} pkgJsons - Publishable packages:
+ *   each `name` is the npm package name and `json` is its parsed package.json.
+ *   Only packages whose `name` appears in this list are treated as "publishable
+ *   siblings" worth gating on (so a dep on a non-published workspace lib is not
+ *   flagged).
+ * @returns {{
+ *   required: Array<{ consumer: string, sibling: string, outputKey: string }>,
+ *   failures: Array<{ consumer: string, sibling: string, outputKey: string, reason: string }>,
+ * }}
+ */
+export function auditPublishYmlRequiredGates(publishYmlContent, pkgJsons) {
+  const lines = publishYmlContent.split('\n')
+  const publishableNames = new Set(pkgJsons.map((p) => p.name))
+
+  // Locate each `publish-<short>:` job header line index (top-level job key,
+  // i.e. indented exactly 2 spaces under `jobs:`). The job body runs until the
+  // next line indented ≤ 2 spaces that is itself a key (another job) — we only
+  // need the header index and the next-job index to bound the body window.
+  const jobHeaderRegex = /^ {2}([a-z][a-z0-9-]*):\s*$/
+  const jobStarts = []
+  lines.forEach((line, idx) => {
+    const m = line.match(jobHeaderRegex)
+    if (m) jobStarts.push({ name: m[1], idx })
+  })
+
+  /** Slice the YAML body of job `jobName`, or null if absent. */
+  const jobBody = (jobName) => {
+    const pos = jobStarts.findIndex((j) => j.name === jobName)
+    if (pos === -1) return null
+    const start = jobStarts[pos].idx
+    const end = pos + 1 < jobStarts.length ? jobStarts[pos + 1].idx : lines.length
+    return lines.slice(start, end).join('\n')
+  }
+
+  const required = []
+  const failures = []
+
+  for (const { name, json } of pkgJsons) {
+    const consumerShort = shortNameFromPackage(name)
+    const consumerJob = `publish-${consumerShort}`
+    const deps = { ...(json && json.dependencies) }
+
+    for (const depName of Object.keys(deps)) {
+      if (!publishableNames.has(depName)) continue
+      if (depName === name) continue
+      const siblingShort = shortNameFromPackage(depName)
+      const outputKey = PUBLISH_JOB_TO_OUTPUT_ALIAS[siblingShort] || siblingShort
+      required.push({ consumer: consumerShort, sibling: siblingShort, outputKey })
+
+      const body = jobBody(consumerJob)
+      if (body == null) {
+        failures.push({
+          consumer: consumerShort,
+          sibling: siblingShort,
+          outputKey,
+          reason: `publish job '${consumerJob}' not found in publish.yml`,
+        })
+        continue
+      }
+
+      // (a) `needs:` must list the sibling publish job.
+      const needsRegex = new RegExp(`needs:[^\\n]*\\bpublish-${siblingShort}\\b`)
+      // A list-form `needs:` may span lines; also accept the job appearing on
+      // its own bullet/array entry anywhere in the body alongside a `needs:`.
+      const hasNeeds =
+        needsRegex.test(body) ||
+        (/\bneeds:/.test(body) && new RegExp(`\\bpublish-${siblingShort}\\b`).test(body))
+      if (!hasNeeds) {
+        failures.push({
+          consumer: consumerShort,
+          sibling: siblingShort,
+          outputKey,
+          reason: `'${consumerJob}' must list 'publish-${siblingShort}' in its needs:`,
+        })
+      }
+
+      // (b) the SMI-5060 paired predicate must be present in the job body.
+      const successClause = new RegExp(
+        `needs\\.publish-${siblingShort}\\.result\\s*==\\s*'success'`
+      )
+      const skippedPairClause = new RegExp(
+        `needs\\.publish-${siblingShort}\\.result\\s*==\\s*'skipped'\\s*&&\\s*` +
+          `needs\\.pre-publish-check\\.outputs\\.${outputKey}-exists\\s*==\\s*'true'`
+      )
+      if (!successClause.test(body) || !skippedPairClause.test(body)) {
+        failures.push({
+          consumer: consumerShort,
+          sibling: siblingShort,
+          outputKey,
+          reason:
+            `'${consumerJob}' if: must gate on publish-${siblingShort}: ` +
+            `(needs.publish-${siblingShort}.result == 'success' || ` +
+            `(needs.publish-${siblingShort}.result == 'skipped' && ` +
+            `needs.pre-publish-check.outputs.${outputKey}-exists == 'true'))`,
+        })
+      }
+    }
+  }
+
+  return { required, failures }
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -32,6 +32,7 @@ import {
   parseConsumersTag,
   findConventionDrift,
   auditPublishYmlDependentGate,
+  auditPublishYmlRequiredGates,
   parseNpmLsJson,
 } from './audit-standards-helpers.mjs'
 import { VERCEL_JSON_SHARED_FIELDS, validateVercelJsonSync } from './audit-vercel-sync-helpers.mjs'
@@ -3981,6 +3982,52 @@ console.log(`\n${BOLD}48. publish.yml dependent-gate soundness (SMI-5060/SMI-506
           `Check 48: all ${matches.length} 'publish-<pkg>.result == skipped' clause(s) in ` +
             `${PUBLISH_YML} are paired with the <outputKey>-exists predicate (SMI-5060/SMI-5066 regression guard).`
         )
+      }
+
+      // SMI-5123: POSITIVE-COVERAGE — the soundness check above only validates
+      // gates that EXIST. It says nothing about a REQUIRED gate that is missing
+      // entirely (the SMI-5123 bug: publish-cli depends on @skillsmith/mcp-server
+      // in package.json but had no gate on publish-mcp-server, so cli could
+      // publish a live dangling ref while mcp-server was skipped). Derive the
+      // required gates from ground truth — each publishable package's
+      // workspace-sibling deps that are themselves publishable — and assert the
+      // consumer's publish job both needs: the sibling and carries the paired
+      // predicate.
+      const publishableNames = JSON.parse(
+        (content.match(/PUBLISHABLE_PACKAGES_JSON:\s*'(\[[^']*\])'/) || [])[1] || '[]'
+      )
+      const pkgJsons = []
+      for (const name of publishableNames) {
+        const short = name.includes('/') ? name.slice(name.indexOf('/') + 1) : name
+        const pkgPath = `packages/${short}/package.json`
+        if (existsSync(pkgPath)) {
+          try {
+            pkgJsons.push({ name, json: JSON.parse(readFileSync(pkgPath, 'utf8')) })
+          } catch (e) {
+            warn(`Check 48 (required gates): could not parse ${pkgPath}: ${e.message}`)
+          }
+        }
+      }
+
+      if (pkgJsons.length === 0) {
+        warn('Check 48 (required gates): no publishable package.json files found — skipping')
+      } else {
+        const { required, failures: gateFailures } = auditPublishYmlRequiredGates(content, pkgJsons)
+        if (gateFailures.length > 0) {
+          for (const { consumer, sibling, reason } of gateFailures) {
+            fail(
+              `Check 48 (required gates): publish-${consumer} → publish-${sibling}: ${reason}`,
+              `${consumer}'s package.json depends on a publishable sibling; the consumer's ` +
+                `publish job must needs: the sibling job and carry the SMI-5060 paired predicate ` +
+                `so it cannot publish a dangling ref while the sibling is skipped.`
+            )
+          }
+        } else {
+          pass(
+            `Check 48 (required gates): all ${required.length} package.json workspace-sibling ` +
+              `dep(s) have the matching publish-job needs: + paired predicate in ${PUBLISH_YML} (SMI-5123).`
+          )
+        }
       }
     } catch (e) {
       warn(`Could not run Check 48 (publish.yml dependent-gate soundness): ${e.message}`)

--- a/scripts/check-npm-bootstrap.mjs
+++ b/scripts/check-npm-bootstrap.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * SMI-5122: Pre-publish fail-fast for an unregistered new npm package.
+ *
+ * The publish.yml `pre-publish-check` job's existing `Check version
+ * availability` step only asks "does <pkg>@<version> exist?". A brand-new
+ * package added to PUBLISHABLE_PACKAGES_JSON that was never published gets
+ * `<x>_exists=false` and proceeds to a publish job that dies with an opaque
+ * E404 — because npm OIDC trusted-publishing CANNOT bootstrap a package that
+ * does not already exist on npm. The package must first be registered as a
+ * trusted publisher on npmjs.com.
+ *
+ * This shim distinguishes "package has zero versions on npm" (a hard,
+ * actionable failure) from "the network/registry was unreachable" (must NOT
+ * block a publish — mirror Check 21's SMI-5080 graceful-skip approach). The
+ * network-error signal list is intentionally copied from Check 21
+ * (scripts/audit-standards.mjs, SMI-5080) plus the npm-specific E* error
+ * codes, so that a flaky registry or a CA-less Docker image degrades to a
+ * non-blocking `::warning::`, never a false `::error::`.
+ *
+ * Usage: node scripts/check-npm-bootstrap.mjs <pkg>
+ *
+ * Exit codes:
+ *   0  package exists on npm (≥1 version)            → log ok
+ *   0  existence could not be verified (network)     → ::warning::, skip gate
+ *   1  package has no versions on npm (missing/404)  → ::error::, block publish
+ *   2  usage error (missing args)
+ */
+import { execFileSync } from 'node:child_process'
+
+/**
+ * Network/registry-unreachable signals. The first group mirrors Check 21's
+ * SMI-5080 list verbatim (scripts/audit-standards.mjs); the second group adds
+ * the npm/node DNS + socket error codes that surface as `npm view` stderr.
+ */
+const NETWORK_ERROR_REGEX =
+  /unable to access|Could not resolve host|ETIMEDOUT|ECONNREFUSED|ENOTFOUND|EAI_AGAIN|network|certificate/i
+
+/** npm "package does not exist" signals. */
+const NOT_FOUND_REGEX = /E404|404 Not Found|is not in this registry/i
+
+/**
+ * Classify the result of an `npm view <pkg> version` invocation.
+ *
+ * Conservative by design: any empty-stdout case that does not clearly match a
+ * not-found signal is treated as `'network-error'` (never block on ambiguity).
+ *
+ * @param {{ stdout?: string, stderr?: string }} io
+ * @returns {'exists' | 'missing' | 'network-error'}
+ */
+export function classifyNpmExistence({ stdout = '', stderr = '' } = {}) {
+  if (String(stdout).trim()) return 'exists'
+  if (NOT_FOUND_REGEX.test(String(stderr))) return 'missing'
+  if (NETWORK_ERROR_REGEX.test(String(stderr))) return 'network-error'
+  // Empty stdout, no recognizable signal — fail open (do not block).
+  return 'network-error'
+}
+
+/**
+ * Build the actionable error message for a missing (never-published) package.
+ *
+ * @param {string} pkg
+ * @returns {string}
+ */
+export function bootstrapErrorMessage(pkg) {
+  return (
+    `${pkg} is in PUBLISHABLE_PACKAGES_JSON (.github/workflows/publish.yml) and ` +
+    `PACKAGE_SPECS (scripts/lib/version-utils.ts) but has no versions on npm. ` +
+    `OIDC trusted-publishing cannot bootstrap a new package — first register it as ` +
+    `a trusted publisher on npmjs.com (Settings -> Trusted Publisher -> repo ` +
+    `smith-horn/skillsmith, workflow publish.yml). ` +
+    `See publishing-guide.md (New-package onboarding).`
+  )
+}
+
+/**
+ * Run `npm view <pkg> version`, capturing both stdout and stderr, and classify.
+ *
+ * `npm view` exits non-zero on a 404, so the stderr is read off the thrown
+ * error's `.stderr` field in that path.
+ *
+ * @param {string} pkg
+ * @param {{ exec?: typeof execFileSync }} [deps] - injectable for tests
+ * @returns {'exists' | 'missing' | 'network-error'}
+ */
+export function checkNpmExistence(pkg, deps = {}) {
+  const exec = deps.exec || execFileSync
+  try {
+    const stdout = exec('npm', ['view', pkg, 'version'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf8',
+      env: process.env,
+      timeout: 30_000,
+    })
+    return classifyNpmExistence({ stdout, stderr: '' })
+  } catch (err) {
+    const stdout = err && err.stdout ? String(err.stdout) : ''
+    const stderr = err && err.stderr ? String(err.stderr) : String((err && err.message) || '')
+    return classifyNpmExistence({ stdout, stderr })
+  }
+}
+
+// CLI entrypoint. Only runs when invoked directly, not when imported in tests.
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('check-npm-bootstrap.mjs')
+
+if (isMain) {
+  const [, , pkg] = process.argv
+  if (!pkg) {
+    console.error('usage: check-npm-bootstrap.mjs <pkg>')
+    process.exit(2)
+  }
+
+  const verdict = checkNpmExistence(pkg)
+  if (verdict === 'exists') {
+    console.log(`✓ ${pkg} exists on npm — bootstrap gate satisfied`)
+    process.exit(0)
+  }
+  if (verdict === 'network-error') {
+    console.log(`::warning::could not verify ${pkg} existence, skipping bootstrap gate`)
+    process.exit(0)
+  }
+  // 'missing'
+  console.error(`::error::${bootstrapErrorMessage(pkg)}`)
+  process.exit(1)
+}

--- a/scripts/tests/audit-standards-publish-gate.test.ts
+++ b/scripts/tests/audit-standards-publish-gate.test.ts
@@ -1,0 +1,111 @@
+/**
+ * SMI-5123: POSITIVE-COVERAGE assertion for publish.yml dependency gating.
+ *
+ * `auditPublishYmlDependentGate` (tested in audit-standards.test.ts) only checks
+ * that gates which EXIST are sound. `auditPublishYmlRequiredGates` checks that
+ * REQUIRED gates are not MISSING — the SMI-5123 bug, where publish-cli depended
+ * on @skillsmith/mcp-server in package.json but had no gate on
+ * publish-mcp-server, so cli could publish a live dangling ref while mcp-server
+ * was skipped (cli@0.6.3 → mcp-server@^0.5.3 that didn't exist).
+ *
+ * Split into its own file (not appended to audit-standards.test.ts) because that
+ * file is already at the 500-line ceiling.
+ */
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const helpers = (await import('../audit-standards-helpers.mjs')) as {
+  auditPublishYmlRequiredGates: (
+    content: string,
+    pkgJsons: Array<{ name: string; json: { dependencies?: Record<string, string> } }>
+  ) => {
+    required: Array<{ consumer: string; sibling: string; outputKey: string }>
+    failures: Array<{ consumer: string; sibling: string; outputKey: string; reason: string }>
+  }
+}
+
+const { auditPublishYmlRequiredGates } = helpers
+
+describe('auditPublishYmlRequiredGates (SMI-5123)', () => {
+  // A correctly-gated cli job: needs: publish-mcp-server AND carries the
+  // SMI-5060 paired predicate (mcp-exists output key per the alias map).
+  const goodCliJob = [
+    'jobs:',
+    '  publish-cli:',
+    '    needs: [pre-publish-check, validate, publish-core, publish-mcp-server]',
+    '    if: |',
+    "      (needs.publish-core.result == 'success' ||",
+    "       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true')) &&",
+    "      (needs.publish-mcp-server.result == 'success' ||",
+    "       (needs.publish-mcp-server.result == 'skipped' && needs.pre-publish-check.outputs.mcp-exists == 'true'))",
+    '  publish-mcp-server:',
+    '    needs: [pre-publish-check, validate, publish-core]',
+  ].join('\n')
+
+  const cliPkgs = [
+    { name: '@skillsmith/cli', json: { dependencies: { '@skillsmith/mcp-server': '^0.5.3' } } },
+    { name: '@skillsmith/mcp-server', json: { dependencies: {} } },
+  ]
+
+  it('passes when the cli→mcp gate is present (needs: + paired predicate)', () => {
+    const { required, failures } = auditPublishYmlRequiredGates(goodCliJob, cliPkgs)
+    expect(required).toHaveLength(1)
+    expect(required[0]).toMatchObject({ consumer: 'cli', sibling: 'mcp-server', outputKey: 'mcp' })
+    expect(failures).toHaveLength(0)
+  })
+
+  it('fails when the cli→mcp gate is missing entirely', () => {
+    // publish-cli only gates on core — the SMI-5123 regression shape.
+    const missingGate = [
+      'jobs:',
+      '  publish-cli:',
+      '    needs: [pre-publish-check, validate, publish-core]',
+      '    if: |',
+      "      (needs.publish-core.result == 'success' ||",
+      "       (needs.publish-core.result == 'skipped' && needs.pre-publish-check.outputs.core-exists == 'true'))",
+      '  publish-mcp-server:',
+      '    needs: [pre-publish-check, validate, publish-core]',
+    ].join('\n')
+    const { failures } = auditPublishYmlRequiredGates(missingGate, cliPkgs)
+    // Two distinct failures: missing needs:, and missing paired predicate.
+    expect(failures.length).toBeGreaterThanOrEqual(1)
+    expect(failures.every((f) => f.consumer === 'cli' && f.sibling === 'mcp-server')).toBe(true)
+  })
+
+  it('ignores deps on non-publishable workspace packages', () => {
+    // A dep that isn't itself in the publishable set must not require a gate.
+    const pkgs = [
+      { name: '@skillsmith/cli', json: { dependencies: { '@skillsmith/internal-lib': '^1.0.0' } } },
+    ]
+    const { required, failures } = auditPublishYmlRequiredGates(goodCliJob, pkgs)
+    expect(required).toHaveLength(0)
+    expect(failures).toHaveLength(0)
+  })
+
+  it('passes against the REAL publish.yml + real publishable package.json files', () => {
+    const repoRoot = join(__dirname, '..', '..')
+    const publishYml = readFileSync(join(repoRoot, '.github/workflows/publish.yml'), 'utf8')
+
+    const publishableNames: string[] = JSON.parse(
+      (publishYml.match(/PUBLISHABLE_PACKAGES_JSON:\s*'(\[[^']*\])'/) || [])[1] || '[]'
+    )
+    expect(publishableNames.length).toBeGreaterThan(0)
+
+    const pkgJsons = publishableNames
+      .map((name) => {
+        const short = name.includes('/') ? name.slice(name.indexOf('/') + 1) : name
+        const p = join(repoRoot, `packages/${short}/package.json`)
+        return { name, json: JSON.parse(readFileSync(p, 'utf8')) }
+      })
+      .filter((x) => x.json)
+
+    const { required, failures } = auditPublishYmlRequiredGates(publishYml, pkgJsons)
+    // cli→core, cli→mcp-server, mcp-server→core, enterprise→core all required.
+    expect(required.length).toBeGreaterThanOrEqual(1)
+    expect(failures).toEqual([])
+  })
+})

--- a/scripts/tests/check-npm-bootstrap.test.ts
+++ b/scripts/tests/check-npm-bootstrap.test.ts
@@ -1,0 +1,106 @@
+/**
+ * SMI-5122: tests for the pre-publish bootstrap fail-fast helper
+ * (scripts/check-npm-bootstrap.mjs).
+ *
+ * `classifyNpmExistence` is the load-bearing pure function: it decides whether
+ * a publish should be blocked (a package that genuinely has zero versions on
+ * npm cannot be bootstrapped by OIDC trusted-publishing) or allowed to proceed
+ * (the registry was simply unreachable). Getting the second case wrong would
+ * block every release on a flaky registry, so the four branches below are the
+ * core invariant.
+ *
+ * Dynamic ESM import — same convention as audit-standards.test.ts and
+ * check-supply-chain-pins.test.ts (the module is .mjs, no .ts transpilation).
+ */
+import { describe, expect, it } from 'vitest'
+
+const mod = (await import('../check-npm-bootstrap.mjs')) as {
+  classifyNpmExistence: (io: { stdout?: string; stderr?: string }) => string
+  bootstrapErrorMessage: (pkg: string) => string
+  checkNpmExistence: (pkg: string, deps?: { exec?: (...args: unknown[]) => string }) => string
+}
+
+const { classifyNpmExistence, bootstrapErrorMessage, checkNpmExistence } = mod
+
+describe('classifyNpmExistence (SMI-5122)', () => {
+  it("returns 'exists' when stdout is a non-empty version string", () => {
+    expect(classifyNpmExistence({ stdout: '1.2.3\n', stderr: '' })).toBe('exists')
+  })
+
+  it("returns 'missing' on an E404 / not-found stderr with empty stdout", () => {
+    expect(
+      classifyNpmExistence({
+        stdout: '',
+        stderr:
+          'npm error code E404\nnpm error 404 Not Found - GET https://registry.npmjs.org/@skillsmith%2fnope',
+      })
+    ).toBe('missing')
+    // "is not in this registry" phrasing (GitHub Packages / older npm)
+    expect(classifyNpmExistence({ stdout: '', stderr: '@x/y is not in this registry.' })).toBe(
+      'missing'
+    )
+  })
+
+  it("returns 'network-error' on a transient network/registry stderr", () => {
+    expect(
+      classifyNpmExistence({
+        stdout: '',
+        stderr:
+          'npm error code EAI_AGAIN\nnpm error errno EAI_AGAIN\nrequest to https://registry.npmjs.org failed, reason: getaddrinfo EAI_AGAIN',
+      })
+    ).toBe('network-error')
+    expect(classifyNpmExistence({ stdout: '', stderr: 'unable to access the registry' })).toBe(
+      'network-error'
+    )
+    expect(classifyNpmExistence({ stdout: '', stderr: 'certificate verification failed' })).toBe(
+      'network-error'
+    )
+  })
+
+  it("returns 'network-error' (fail open) on empty stdout with no recognizable signal", () => {
+    // Conservative: never block a publish on an ambiguous/blank response.
+    expect(classifyNpmExistence({ stdout: '', stderr: '' })).toBe('network-error')
+    expect(classifyNpmExistence({ stdout: '   ', stderr: 'some unrecognized message' })).toBe(
+      'network-error'
+    )
+    expect(classifyNpmExistence({})).toBe('network-error')
+  })
+})
+
+describe('bootstrapErrorMessage (SMI-5122)', () => {
+  it('names the package and the two registries plus the npmjs.com remedy', () => {
+    const msg = bootstrapErrorMessage('@skillsmith/new-pkg')
+    expect(msg).toContain('@skillsmith/new-pkg')
+    expect(msg).toContain('PUBLISHABLE_PACKAGES_JSON')
+    expect(msg).toContain('PACKAGE_SPECS')
+    expect(msg).toContain('Trusted Publisher')
+    expect(msg).toContain('publishing-guide.md')
+  })
+})
+
+describe('checkNpmExistence (SMI-5122)', () => {
+  it("maps a successful npm view to 'exists'", () => {
+    const exec = () => '1.0.0\n'
+    expect(checkNpmExistence('@skillsmith/core', { exec: exec as never })).toBe('exists')
+  })
+
+  it("reads stderr off the thrown error for the 404 path → 'missing'", () => {
+    const exec = () => {
+      const err = new Error('Command failed') as Error & { stdout?: string; stderr?: string }
+      err.stdout = ''
+      err.stderr = 'npm error 404 Not Found'
+      throw err
+    }
+    expect(checkNpmExistence('@skillsmith/nope', { exec: exec as never })).toBe('missing')
+  })
+
+  it("reads stderr off the thrown error for the network path → 'network-error'", () => {
+    const exec = () => {
+      const err = new Error('Command failed') as Error & { stdout?: string; stderr?: string }
+      err.stdout = ''
+      err.stderr = 'getaddrinfo ENOTFOUND registry.npmjs.org'
+      throw err
+    }
+    expect(checkNpmExistence('@skillsmith/core', { exec: exec as never })).toBe('network-error')
+  })
+})


### PR DESCRIPTION
## Summary
Two publish-pipeline robustness fixes surfaced by the SMI-5119 recovery.

- **SMI-5122** — `pre-publish-check` now fails fast (with an actionable message) when a publishable npmjs package has **zero** versions on npm. OIDC trusted-publishing cannot bootstrap a brand-new package, so without this it dies mid-publish with an opaque E404 (exactly what bit the W5-W8 release). New helper `scripts/check-npm-bootstrap.mjs` mirrors Check 21's message-regex graceful-skip: transient network/registry errors warn and fall through, never block. Scoped to `@skillsmith/*` — `@smith-horn/enterprise` publishes to GitHub Packages via `GITHUB_TOKEN` and *can* bootstrap.
- **SMI-5123** — `publish-cli` is now gated on `publish-mcp-server` (added to `needs:` + the SMI-5060 paired predicate), so cli can no longer publish while its `mcp-server` dep is skipped — which previously shipped a live dangling ref (`cli@0.6.3 → mcp-server@^0.5.3` that didn't exist). `audit-standards` Check 48 gains a **positive-coverage** assertion (`auditPublishYmlRequiredGates`): every publishable package's workspace-sibling deps must have a matching `needs:` + paired predicate, so the gate can't silently disappear.

Also adds a **New-package onboarding** section to `publishing-guide.md` (register the trusted publisher on npmjs.com BEFORE adding to the pipeline).

## Test plan
- [x] `audit:standards` 0 failed (new Check 48 positive-coverage passes against the real publish.yml)
- [x] `scripts/tests/check-npm-bootstrap.test.ts` (8) + `scripts/tests/audit-standards-publish-gate.test.ts` (4) green
- [x] lint + typecheck clean; Docker pre-push tests green
- [x] CLI smoke: `check-npm-bootstrap.mjs @skillsmith/core` exits 0; nonexistent pkg exits 1 with the onboarding message

## Notes
- **ADR-109**: infra change reviewed via plan-review (VP Product/Eng/Design) before implementation.
- New tests live in a dedicated `audit-standards-publish-gate.test.ts` because `audit-standards.test.ts` is already at the 500-line ceiling.

Closes SMI-5122, SMI-5123.

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)