### PR TITLE
chore(config): SMI-5132 enable ruflo MCP swarm coordination + fix enabledMcpjsonServers drift

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,11 +60,7 @@
       "mcp__ruflo__transfer_ipfs-resolve",
       "mcp__ruflo__hooks_intelligence_pattern-store",
       "mcp__ruflo__hooks_intelligence_pattern-search",
-      "mcp__ruflo__memory_store",
-      "mcp__ruflo__memory_search",
-      "mcp__ruflo__memory_search_unified",
       "mcp__ruflo__memory_migrate",
-      "mcp__ruflo__swarm_init",
       "mcp__ruflo__claims_handoff",
       "mcp__ruflo__claims_accept-handoff",
       "mcp__ruflo__hooks_post-task",
@@ -186,7 +182,7 @@
     ]
   },
   "includeCoAuthoredBy": true,
-  "enabledMcpjsonServers": ["claude-flow", "ruv-swarm"],
+  "enabledMcpjsonServers": ["skillsmith", "skillsmith-doc-retrieval", "ruflo"],
   "statusLine": {
     "type": "command",
     "command": "npx @claude-flow/cli@latest hooks statusline || node .claude/helpers/statusline.cjs || echo Claude Flow V3"


### PR DESCRIPTION
## Summary

Enables the documented ruflo **swarm-coordination** layer at the MCP level and fixes stale config drift. Changes `.claude/settings.json` only (1 insertion / 5 deletions).

Investigation question (SMI-5132): is the ruflo queen-coordinator's inability to dispatch executing workers intended, or a misconfiguration? **Intended** — ruflo is a stdio MCP coordinator (`CLAUDE_FLOW_REMOTE_EXECUTION=true`); execution runs via Claude Code's Task tool. This PR keeps that model but turns on the swarm topology + shared-memory coordination so workers can coordinate through ruflo.

## Changes

- **Un-deny 4 ruflo coordination tools** from `permissions.deny`: `swarm_init`, `memory_store`, `memory_search`, `memory_search_unified`. Local-state SQLite coordination only — no external calls, no LLM execution.
  - **Kept denied** (autonomous-execution boundary preserved): `memory_migrate`, all `hive-mind_*`, all `agentdb_*`, all `transfer_*`, `claims_handoff`/`claims_accept-handoff`, `hooks_post-task`, `hooks_model-outcome`.
- **Fix `enabledMcpjsonServers` drift**: `["claude-flow","ruv-swarm"]` (stale, non-gating) → real `.mcp.json` keys `["skillsmith","skillsmith-doc-retrieval","ruflo"]`.

## Out of scope

Autonomous/headless execution (ruflo hive-mind/swarm CLI spawning `claude -p`) remains denied. This does **not** enable in-MCP LLM execution.

## ADR-109

`.claude/settings.json` is not an ADR-109 trigger path and the `hooks` block is untouched, so no SPARC required. The version-alignment follow-up (SMI-5133) does touch hooks → routed through SPARC there.

## Follow-ups

- **SMI-5133** — align claude-flow/ruflo package versions across `.mcp.json` / settings hooks / statusline (ADR-109).
- **SMI-5134** — `claude-flow-guide.md` ruflo tool-prefix migration + document the MCP-coordinates/Task-executes model.

## Verification (post-merge, requires session reload)

1. `swarm_init({topology:"hierarchical",maxAgents:2})` returns a swarm id (was denied).
2. `memory_store` / `memory_search` round-trip.
3. `swarm_init → agent_spawn ×2 → swarm_status → task_orchestrate` at the coordination layer.
4. `skillsmith` + `skillsmith-doc-retrieval` MCP tools still respond after the rename.

Closes SMI-5132.

[skip-impl-check] — config-only change (`.claude/settings.json`); no source or test files modified.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)