### PR TITLE
feat(cli): SMI-5128 batch A — wrap logout/merge/analyze/diff telemetry

### DIFF
--- a/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
@@ -38,6 +38,11 @@ const CLI_DISPATCHER_MAP: Record<string, string[]> = {
   // SMI-5127: sibling-split pilot — action impls live in *.action.ts files
   'sync.action': ['syncAction', 'syncStatusAction', 'syncHistoryAction', 'syncConfigAction'],
   'search.action': ['searchAction'],
+  // SMI-5128 batch A
+  logout: ['logoutAction'],
+  merge: ['mergeAction'],
+  analyze: ['analyzeAction'],
+  diff: ['diffAction'],
 }
 
 const EXPECTED_TOTAL = Object.values(CLI_DISPATCHER_MAP).reduce((n, arr) => n + arr.length, 0)

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -8,6 +8,7 @@
 import { Command } from 'commander'
 import chalk from 'chalk'
 import { CodebaseAnalyzer, type CodebaseContext, type FrameworkInfo } from '@skillsmith/core'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { sanitizeError } from '../utils/sanitize.js'
 
 /**
@@ -177,6 +178,40 @@ async function runAnalyze(
   }
 }
 
+// SMI-5128: extracted from inline .action() closure to a named function so
+// withTelemetry can wrap it at the export boundary (SMI-5040 coverage gate).
+async function analyzeActionImpl(
+  targetPath: string,
+  opts: Record<string, string | boolean | string[] | undefined>
+): Promise<void> {
+  try {
+    const maxFiles = parseInt(opts['max-files'] as string, 10)
+    const excludeDirs = opts['exclude'] as string[] | undefined
+    const includeDevDeps = opts['devDeps'] !== false
+    const json = (opts['json'] as boolean) === true
+
+    await runAnalyze(targetPath, {
+      maxFiles,
+      excludeDirs,
+      includeDevDeps,
+      json,
+    })
+  } catch (error) {
+    if (opts['json']) {
+      console.error(JSON.stringify({ error: sanitizeError(error) }))
+    } else {
+      console.error(chalk.red('Analysis error:'), sanitizeError(error))
+    }
+    process.exit(1)
+  }
+}
+
+export const analyzeAction = withTelemetry(analyzeActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'analyze',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create analyze command
  */
@@ -188,30 +223,7 @@ export function createAnalyzeCommand(): Command {
     .option('-e, --exclude <dirs...>', 'Directories to exclude (in addition to defaults)')
     .option('--no-dev-deps', 'Exclude dev dependencies from analysis')
     .option('-j, --json', 'Output results as JSON')
-    .action(
-      async (targetPath: string, opts: Record<string, string | boolean | string[] | undefined>) => {
-        try {
-          const maxFiles = parseInt(opts['max-files'] as string, 10)
-          const excludeDirs = opts['exclude'] as string[] | undefined
-          const includeDevDeps = opts['devDeps'] !== false
-          const json = (opts['json'] as boolean) === true
-
-          await runAnalyze(targetPath, {
-            maxFiles,
-            excludeDirs,
-            includeDevDeps,
-            json,
-          })
-        } catch (error) {
-          if (opts['json']) {
-            console.error(JSON.stringify({ error: sanitizeError(error) }))
-          } else {
-            console.error(chalk.red('Analysis error:'), sanitizeError(error))
-          }
-          process.exit(1)
-        }
-      }
-    )
+    .action(analyzeAction)
 
   return cmd
 }

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -16,6 +16,7 @@ import { readFile } from 'fs/promises'
 import { join } from 'path'
 import { classifyChange } from '@skillsmith/core'
 import { getCanonicalInstallPath } from '@skillsmith/core/install'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { requireTier } from '../utils/require-tier.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { loadManifest } from '../utils/manifest.js'
@@ -167,6 +168,61 @@ function printDiff(skillName: string, diff: SectionDiff, changeType: string): vo
 // Command factory
 // ============================================================================
 
+// SMI-5128: extracted from inline .action() closure to a named function so
+// withTelemetry can wrap it at the export boundary (SMI-5040 coverage gate).
+async function diffActionImpl(
+  skillName: string,
+  opts: { oldContent?: string; newContent?: string }
+): Promise<void> {
+  try {
+    await requireTier('individual')
+
+    // Resolve old content
+    let oldContent: string | null = null
+    if (opts.oldContent) {
+      oldContent = await readFile(opts.oldContent, 'utf-8')
+    } else {
+      oldContent = await readInstalledSkillContent(skillName)
+    }
+
+    if (!oldContent) {
+      console.error(chalk.red(`Skill "${skillName}" is not installed or SKILL.md not found.`))
+      process.exit(1)
+    }
+
+    // Resolve new content
+    let newContent: string | null = null
+    if (opts.newContent) {
+      newContent = await readFile(opts.newContent, 'utf-8')
+    } else {
+      newContent = await fetchLatestContent(skillName)
+    }
+
+    if (!newContent) {
+      console.error(
+        chalk.red(
+          `Could not fetch latest version for "${skillName}". ` +
+            `Check your network connection or provide --new-content.`
+        )
+      )
+      process.exit(1)
+    }
+
+    const diff = diffSections(oldContent, newContent)
+    const changeType = classifyChange(oldContent, newContent)
+    printDiff(skillName, diff, changeType)
+  } catch (error) {
+    console.error(chalk.red('Error:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const diffAction = withTelemetry(diffActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'diff',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create the diff command
  */
@@ -178,52 +234,5 @@ export function createDiffCommand(): Command {
     .argument('<skill>', 'Skill name to diff')
     .option('--old-content <path>', 'Path to old SKILL.md (uses installed skill if omitted)')
     .option('--new-content <path>', 'Path to new SKILL.md (fetches from registry if omitted)')
-    .action(
-      async (
-        skillName: string,
-        opts: { oldContent?: string; newContent?: string }
-      ): Promise<void> => {
-        try {
-          await requireTier('individual')
-
-          // Resolve old content
-          let oldContent: string | null = null
-          if (opts.oldContent) {
-            oldContent = await readFile(opts.oldContent, 'utf-8')
-          } else {
-            oldContent = await readInstalledSkillContent(skillName)
-          }
-
-          if (!oldContent) {
-            console.error(chalk.red(`Skill "${skillName}" is not installed or SKILL.md not found.`))
-            process.exit(1)
-          }
-
-          // Resolve new content
-          let newContent: string | null = null
-          if (opts.newContent) {
-            newContent = await readFile(opts.newContent, 'utf-8')
-          } else {
-            newContent = await fetchLatestContent(skillName)
-          }
-
-          if (!newContent) {
-            console.error(
-              chalk.red(
-                `Could not fetch latest version for "${skillName}". ` +
-                  `Check your network connection or provide --new-content.`
-              )
-            )
-            process.exit(1)
-          }
-
-          const diff = diffSections(oldContent, newContent)
-          const changeType = classifyChange(oldContent, newContent)
-          printDiff(skillName, diff, changeType)
-        } catch (error) {
-          console.error(chalk.red('Error:'), sanitizeError(error))
-          process.exit(1)
-        }
-      }
-    )
+    .action(diffAction)
 }

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -11,43 +11,54 @@ import { Command } from 'commander'
 import { confirm } from '@inquirer/prompts'
 import chalk from 'chalk'
 import { clearApiKey, getAuthStatus } from '@skillsmith/core'
+import { withTelemetry } from '@skillsmith/core/telemetry'
+
+// SMI-5128: extracted from inline .action() closure to a named function so
+// withTelemetry can wrap it at the export boundary (SMI-5040 coverage gate).
+async function logoutActionImpl(): Promise<void> {
+  // 1. Check whether there is anything to remove
+  const status = await getAuthStatus()
+  if (!status.authenticated) {
+    console.log('Not authenticated. Nothing to log out.')
+    process.exit(0)
+  }
+
+  // 2. Confirm before removing
+  const confirmed = await confirm({
+    message: 'Log out and remove stored API key?',
+    default: false,
+  })
+
+  if (!confirmed) {
+    console.log('Cancelled.')
+    process.exit(0)
+  }
+
+  // 3. Clear key from all storage locations
+  const result = await clearApiKey()
+
+  if (result.success) {
+    console.log(chalk.green(`Logged out. Key removed from ${result.source}.`))
+  } else {
+    console.log(
+      chalk.yellow(
+        `Logged out (config file cleared), but could not remove from keyring: ${result.error}`
+      )
+    )
+    console.log(chalk.dim('The key may still be stored in your OS keyring.'))
+  }
+  process.exit(0)
+}
+
+export const logoutAction = withTelemetry(logoutActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'logout',
+  extractFramework: () => 'cli',
+})
 
 /**
  * Create the `skillsmith logout` command.
  */
 export function createLogoutCommand(): Command {
-  return new Command('logout').description('Remove stored Skillsmith API key').action(async () => {
-    // 1. Check whether there is anything to remove
-    const status = await getAuthStatus()
-    if (!status.authenticated) {
-      console.log('Not authenticated. Nothing to log out.')
-      process.exit(0)
-    }
-
-    // 2. Confirm before removing
-    const confirmed = await confirm({
-      message: 'Log out and remove stored API key?',
-      default: false,
-    })
-
-    if (!confirmed) {
-      console.log('Cancelled.')
-      process.exit(0)
-    }
-
-    // 3. Clear key from all storage locations
-    const result = await clearApiKey()
-
-    if (result.success) {
-      console.log(chalk.green(`Logged out. Key removed from ${result.source}.`))
-    } else {
-      console.log(
-        chalk.yellow(
-          `Logged out (config file cleared), but could not remove from keyring: ${result.error}`
-        )
-      )
-      console.log(chalk.dim('The key may still be stored in your OS keyring.'))
-    }
-    process.exit(0)
-  })
+  return new Command('logout').description('Remove stored Skillsmith API key').action(logoutAction)
 }

--- a/packages/cli/src/commands/merge.ts
+++ b/packages/cli/src/commands/merge.ts
@@ -21,6 +21,7 @@ import {
   type MergeConflict,
   type DatabaseType,
 } from '@skillsmith/core'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { getDefaultDbPath } from '../config.js'
 
 /**
@@ -50,6 +51,147 @@ function formatMergeResult(result: {
   return lines.join('\n')
 }
 
+// SMI-5128: extracted from inline .action() closure to a named function so
+// withTelemetry can wrap it at the export boundary (SMI-5040 coverage gate).
+async function mergeActionImpl(
+  sourcePath: string,
+  targetPath: string | undefined,
+  options: {
+    strategy: string
+    dryRun: boolean
+    verbose: boolean
+    quiet: boolean
+    force: boolean
+  }
+): Promise<void> {
+  const { strategy, dryRun, verbose, quiet, force } = options
+
+  // Validate strategy
+  const validStrategies: MergeStrategy[] = [
+    'keep_target',
+    'keep_source',
+    'keep_newer',
+    'merge_fields',
+  ]
+  if (!validStrategies.includes(strategy as MergeStrategy)) {
+    console.error(`Invalid strategy: ${strategy}`)
+    console.error(`Valid strategies: ${validStrategies.join(', ')}`)
+    process.exit(1)
+  }
+
+  // Resolve paths
+  const resolvedSource = resolve(sourcePath)
+  const resolvedTarget = targetPath ? resolve(targetPath) : getDefaultDbPath()
+
+  // Check source exists
+  if (!existsSync(resolvedSource)) {
+    console.error(`Source database not found: ${resolvedSource}`)
+    process.exit(1)
+  }
+
+  // Check target exists (or will be created)
+  if (!existsSync(resolvedTarget)) {
+    console.error(`Target database not found: ${resolvedTarget}`)
+    console.error('Create a new database first with: skillsmith init')
+    process.exit(1)
+  }
+
+  if (!quiet) {
+    console.log('╔══════════════════════════════════════════════════════════════╗')
+    console.log('║              Skillsmith Database Merge                       ║')
+    console.log('╠══════════════════════════════════════════════════════════════╣')
+    console.log(`║  Source:   ${resolvedSource.slice(-48).padEnd(48)} ║`)
+    console.log(`║  Target:   ${resolvedTarget.slice(-48).padEnd(48)} ║`)
+    console.log(`║  Strategy: ${(strategy as string).padEnd(48)} ║`)
+    console.log(`║  Dry Run:  ${(dryRun ? 'Yes' : 'No').padEnd(48)} ║`)
+    console.log('╚══════════════════════════════════════════════════════════════╝')
+    console.log('')
+  }
+
+  // Open databases
+  let sourceDb: DatabaseType | null = null
+  let targetDb: DatabaseType | null = null
+
+  try {
+    sourceDb = openDatabase(resolvedSource)
+    targetDb = openDatabase(resolvedTarget)
+
+    // Check schema compatibility
+    if (!force) {
+      const sourceCompat = checkSchemaCompatibility(sourceDb)
+      const targetCompat = checkSchemaCompatibility(targetDb)
+
+      if (!sourceCompat.isCompatible) {
+        console.error(`Source database: ${sourceCompat.message}`)
+        process.exit(1)
+      }
+
+      if (!targetCompat.isCompatible) {
+        console.error(`Target database: ${targetCompat.message}`)
+        process.exit(1)
+      }
+
+      if (!quiet && sourceCompat.action !== 'none') {
+        console.log(`Source: ${sourceCompat.message}`)
+      }
+      if (!quiet && targetCompat.action !== 'none') {
+        console.log(`Target: ${targetCompat.message}`)
+      }
+    }
+
+    // Configure merge options
+    const mergeOptions: MergeOptions = {
+      strategy: strategy as MergeStrategy,
+      dryRun,
+      skipInvalid: true,
+      ...(verbose && {
+        onConflict: (conflict: MergeConflict) => {
+          console.log(`  Conflict: ${conflict.skillId} (${conflict.reason})`)
+          return strategy as MergeStrategy
+        },
+      }),
+    }
+
+    // Perform merge
+    if (!quiet) {
+      console.log('Merging databases...')
+    }
+
+    const result = mergeSkillDatabases(targetDb, sourceDb, mergeOptions)
+
+    // Display results
+    if (!quiet) {
+      console.log(formatMergeResult(result))
+
+      if (dryRun) {
+        console.log('⚠️  DRY RUN: No changes were made to the target database.')
+        console.log('   Remove --dry-run to apply these changes.')
+      } else {
+        console.log('✅ Merge complete!')
+      }
+    }
+
+    // Exit with error if there were issues
+    if (result.skillsAdded === 0 && result.skillsUpdated === 0) {
+      if (!quiet) {
+        console.log('\nNo new skills to merge.')
+      }
+    }
+  } catch (error) {
+    console.error('Merge failed:', error instanceof Error ? error.message : error)
+    process.exit(1)
+  } finally {
+    sourceDb?.close()
+    targetDb?.close()
+  }
+}
+
+export const mergeAction = withTelemetry(mergeActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'merge',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create the merge command
  */
@@ -67,128 +209,7 @@ export function createMergeCommand(): Command {
     .option('-v, --verbose', 'Show detailed conflict information', false)
     .option('-q, --quiet', 'Only output errors', false)
     .option('--force', 'Skip compatibility checks', false)
-    .action(async (sourcePath: string, targetPath: string | undefined, options) => {
-      const { strategy, dryRun, verbose, quiet, force } = options
-
-      // Validate strategy
-      const validStrategies: MergeStrategy[] = [
-        'keep_target',
-        'keep_source',
-        'keep_newer',
-        'merge_fields',
-      ]
-      if (!validStrategies.includes(strategy as MergeStrategy)) {
-        console.error(`Invalid strategy: ${strategy}`)
-        console.error(`Valid strategies: ${validStrategies.join(', ')}`)
-        process.exit(1)
-      }
-
-      // Resolve paths
-      const resolvedSource = resolve(sourcePath)
-      const resolvedTarget = targetPath ? resolve(targetPath) : getDefaultDbPath()
-
-      // Check source exists
-      if (!existsSync(resolvedSource)) {
-        console.error(`Source database not found: ${resolvedSource}`)
-        process.exit(1)
-      }
-
-      // Check target exists (or will be created)
-      if (!existsSync(resolvedTarget)) {
-        console.error(`Target database not found: ${resolvedTarget}`)
-        console.error('Create a new database first with: skillsmith init')
-        process.exit(1)
-      }
-
-      if (!quiet) {
-        console.log('╔══════════════════════════════════════════════════════════════╗')
-        console.log('║              Skillsmith Database Merge                       ║')
-        console.log('╠══════════════════════════════════════════════════════════════╣')
-        console.log(`║  Source:   ${resolvedSource.slice(-48).padEnd(48)} ║`)
-        console.log(`║  Target:   ${resolvedTarget.slice(-48).padEnd(48)} ║`)
-        console.log(`║  Strategy: ${(strategy as string).padEnd(48)} ║`)
-        console.log(`║  Dry Run:  ${(dryRun ? 'Yes' : 'No').padEnd(48)} ║`)
-        console.log('╚══════════════════════════════════════════════════════════════╝')
-        console.log('')
-      }
-
-      // Open databases
-      let sourceDb: DatabaseType | null = null
-      let targetDb: DatabaseType | null = null
-
-      try {
-        sourceDb = openDatabase(resolvedSource)
-        targetDb = openDatabase(resolvedTarget)
-
-        // Check schema compatibility
-        if (!force) {
-          const sourceCompat = checkSchemaCompatibility(sourceDb)
-          const targetCompat = checkSchemaCompatibility(targetDb)
-
-          if (!sourceCompat.isCompatible) {
-            console.error(`Source database: ${sourceCompat.message}`)
-            process.exit(1)
-          }
-
-          if (!targetCompat.isCompatible) {
-            console.error(`Target database: ${targetCompat.message}`)
-            process.exit(1)
-          }
-
-          if (!quiet && sourceCompat.action !== 'none') {
-            console.log(`Source: ${sourceCompat.message}`)
-          }
-          if (!quiet && targetCompat.action !== 'none') {
-            console.log(`Target: ${targetCompat.message}`)
-          }
-        }
-
-        // Configure merge options
-        const mergeOptions: MergeOptions = {
-          strategy: strategy as MergeStrategy,
-          dryRun,
-          skipInvalid: true,
-          ...(verbose && {
-            onConflict: (conflict: MergeConflict) => {
-              console.log(`  Conflict: ${conflict.skillId} (${conflict.reason})`)
-              return strategy as MergeStrategy
-            },
-          }),
-        }
-
-        // Perform merge
-        if (!quiet) {
-          console.log('Merging databases...')
-        }
-
-        const result = mergeSkillDatabases(targetDb, sourceDb, mergeOptions)
-
-        // Display results
-        if (!quiet) {
-          console.log(formatMergeResult(result))
-
-          if (dryRun) {
-            console.log('⚠️  DRY RUN: No changes were made to the target database.')
-            console.log('   Remove --dry-run to apply these changes.')
-          } else {
-            console.log('✅ Merge complete!')
-          }
-        }
-
-        // Exit with error if there were issues
-        if (result.skillsAdded === 0 && result.skillsUpdated === 0) {
-          if (!quiet) {
-            console.log('\nNo new skills to merge.')
-          }
-        }
-      } catch (error) {
-        console.error('Merge failed:', error instanceof Error ? error.message : error)
-        process.exit(1)
-      } finally {
-        sourceDb?.close()
-        targetDb?.close()
-      }
-    })
+    .action(mergeAction)
 
   return command
 }


### PR DESCRIPTION
## Summary
- SMI-5083 batch 2 (SMI-5128), batch A of A–D. Wraps the 4 single-handler CLI commands `logout`, `merge`, `analyze`, `diff` with the `withTelemetry` HOF, mirroring the merged SMI-5040 / SMI-5127 pattern.
- Each: inline `.action()` body → `<name>ActionImpl`; `export const <name>Action = withTelemetry(impl, {source:'cli', extractSkillId:()=>'<command>', extractFramework:()=>'cli'})`; `.action(<name>Action)`.
- Adds `logout`/`merge`/`analyze`/`diff` to `CLI_DISPATCHER_MAP` (coverage 10 → 14 dispatchers).

## Verification (host-side)
- `tsc -p packages/cli` clean; eslint clean; prettier clean.
- `telemetry-coverage.test.ts` passes (drift sentinel + `isTelemetered()` for all 4 new exports).
- All files <500 LOC (logout 64, merge 217, analyze 231, diff 238).

## Notes
- Pure extraction — no behavior changes; no `any` introduced; explicit param types on each impl.
- Pushed with the documented worktree hook bypass (`core.hooksPath=/dev/null`): host pre-push runs in host mode where native-sqlite suites false-fail; this is a CLI-only JS/TS change. Clean-Docker CI is the gate.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)