### PR TITLE
feat(cli): SMI-5128 batch B — wrap ab-test/import-local/pin/config telemetry

### DIFF
--- a/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
@@ -43,6 +43,11 @@ const CLI_DISPATCHER_MAP: Record<string, string[]> = {
   merge: ['mergeAction'],
   analyze: ['analyzeAction'],
   diff: ['diffAction'],
+  // SMI-5128 batch B
+  'ab-test': ['abTestAction'],
+  'import-local': ['importLocalAction'],
+  pin: ['pinAction', 'unpinAction'],
+  config: ['configGetAction', 'configSetAction'],
 }
 
 const EXPECTED_TOTAL = Object.values(CLI_DISPATCHER_MAP).reduce((n, arr) => n + arr.length, 0)

--- a/packages/cli/src/commands/ab-test.ts
+++ b/packages/cli/src/commands/ab-test.ts
@@ -7,6 +7,7 @@
 
 import { Command } from 'commander'
 import chalk from 'chalk'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { tryLoadEnterpriseValidator } from '../utils/license-validation.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import type { LicenseTier } from '../utils/license-types.js'
@@ -222,6 +223,23 @@ export async function runAbTest(options: AbTestOptions): Promise<void> {
   }
 }
 
+// SMI-5128 batch B: extracted from inline .action() closure so withTelemetry
+// can wrap it at the export boundary (SMI-5018 coverage gate).
+async function abTestActionImpl(opts: Record<string, string | boolean | undefined>): Promise<void> {
+  await runAbTest({
+    skill: opts['skill'] as string | undefined,
+    iterations: opts['iterations'] ? parseInt(opts['iterations'] as string, 10) : 10,
+    output: opts['output'] as string | undefined,
+    json: opts['json'] === true,
+  })
+}
+
+export const abTestAction = withTelemetry(abTestActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'ab-test',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create the ab-test command
  */
@@ -244,14 +262,7 @@ Note: This feature requires Team tier ($25/user/mo) or higher.
 Visit https://skillsmith.app/pricing to upgrade.
 `
     )
-    .action(async (opts: Record<string, string | boolean | undefined>) => {
-      await runAbTest({
-        skill: opts['skill'] as string | undefined,
-        iterations: opts['iterations'] ? parseInt(opts['iterations'] as string, 10) : 10,
-        output: opts['output'] as string | undefined,
-        json: opts['json'] === true,
-      })
-    })
+    .action(abTestAction)
 
   return cmd
 }

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -33,6 +33,7 @@ import { Command } from 'commander'
 import chalk from 'chalk'
 
 import { isAuditMode, resolveAuditMode, type AuditMode } from '@skillsmith/core/config/audit-mode'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { tierAllowsAuditMode } from '@skillsmith/core/audit'
 
 import { sanitizeError } from '../utils/sanitize.js'
@@ -205,6 +206,47 @@ async function runConfigSet(key: string, value: string): Promise<void> {
 // Command factory
 // ---------------------------------------------------------------------------
 
+// SMI-5128 batch B: extracted from inline .action() closures so withTelemetry
+// can wrap them at the export boundary (SMI-5018 coverage gate).
+
+async function configGetActionImpl(key: string): Promise<void> {
+  try {
+    await runConfigGet(key)
+  } catch (error) {
+    if (error instanceof ConfigError) {
+      console.error(chalk.red(`Error [${error.code}]:`), error.message)
+    } else {
+      console.error(chalk.red('Error:'), sanitizeError(error))
+    }
+    process.exit(1)
+  }
+}
+
+export const configGetAction = withTelemetry(configGetActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'config get',
+  extractFramework: () => 'cli',
+})
+
+async function configSetActionImpl(key: string, value: string): Promise<void> {
+  try {
+    await runConfigSet(key, value)
+  } catch (error) {
+    if (error instanceof ConfigError) {
+      console.error(chalk.red(`Error [${error.code}]:`), error.message)
+    } else {
+      console.error(chalk.red('Error:'), sanitizeError(error))
+    }
+    process.exit(1)
+  }
+}
+
+export const configSetAction = withTelemetry(configSetActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'config set',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Build the `config` parent command. v1 supports `get` / `set` subcommands
  * with a single supported key (`audit_mode`). Additional keys land in v2.
@@ -217,34 +259,12 @@ export function createConfigCommand(): Command {
   config
     .command('get <key>')
     .description('Read a configuration value (e.g. `audit_mode`)')
-    .action(async (key: string) => {
-      try {
-        await runConfigGet(key)
-      } catch (error) {
-        if (error instanceof ConfigError) {
-          console.error(chalk.red(`Error [${error.code}]:`), error.message)
-        } else {
-          console.error(chalk.red('Error:'), sanitizeError(error))
-        }
-        process.exit(1)
-      }
-    })
+    .action(configGetAction)
 
   config
     .command('set <key> <value>')
     .description('Write a configuration value (atomic; tier-revalidated for audit_mode)')
-    .action(async (key: string, value: string) => {
-      try {
-        await runConfigSet(key, value)
-      } catch (error) {
-        if (error instanceof ConfigError) {
-          console.error(chalk.red(`Error [${error.code}]:`), error.message)
-        } else {
-          console.error(chalk.red('Error:'), sanitizeError(error))
-        }
-        process.exit(1)
-      }
-    })
+    .action(configSetAction)
 
   return config
 }

--- a/packages/cli/src/commands/import-local.ts
+++ b/packages/cli/src/commands/import-local.ts
@@ -7,6 +7,7 @@
  */
 import { Command } from 'commander'
 import { SkillRepository, type SkillCreateInput } from '@skillsmith/core'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { openCliDatabase } from '../utils/open-database.js'
 import {
   getCanonicalInstallPath,
@@ -203,6 +204,59 @@ async function startWatchMode(opts: ImportLocalOptions, jsonOutput: boolean): Pr
   console.log(`[import-local] watching ${rootDir} (Ctrl-C to stop)`)
 }
 
+// SMI-5128 batch B: extracted from inline .action() closure so withTelemetry
+// can wrap it at the export boundary (SMI-5018 coverage gate).
+async function importLocalActionImpl(
+  path: string | undefined,
+  cliOptions: {
+    client?: string
+    watch?: boolean
+    dryRun?: boolean
+    json?: boolean
+    db?: string
+  }
+): Promise<void> {
+  try {
+    let resolvedClient: ClientId | undefined
+    if (cliOptions.client !== undefined) {
+      resolvedClient = resolveClientId(cliOptions.client)
+    }
+
+    const opts: ImportLocalOptions = {
+      ...(path !== undefined && { path }),
+      ...(resolvedClient !== undefined && { client: resolvedClient }),
+      ...(cliOptions.watch !== undefined && { watch: cliOptions.watch }),
+      ...(cliOptions.dryRun !== undefined && { dryRun: cliOptions.dryRun }),
+      ...(cliOptions.json !== undefined && { json: cliOptions.json }),
+      ...(cliOptions.db !== undefined && { dbPath: cliOptions.db }),
+    }
+
+    if (opts.watch) {
+      await startWatchMode(opts, !!opts.json)
+      return
+    }
+
+    const result = await runImportLocal(opts)
+    if (opts.json) {
+      console.log(JSON.stringify(result))
+    } else {
+      printHumanSummary(result)
+    }
+    if (result.errors.length > 0 && opts.json) {
+      process.exit(1)
+    }
+  } catch (error) {
+    console.error('import-local failed:', sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const importLocalAction = withTelemetry(importLocalActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'import-local',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Build the Commander subcommand. Wired into `index.ts` via `addCommand`.
  */
@@ -222,52 +276,7 @@ export function createImportLocalCommand(): Command {
     .option('--dry-run', 'List what would be imported without writing to the DB')
     .option('--json', 'Emit a single machine-readable summary object on stdout')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
-    .action(
-      async (
-        path: string | undefined,
-        cliOptions: {
-          client?: string
-          watch?: boolean
-          dryRun?: boolean
-          json?: boolean
-          db?: string
-        }
-      ) => {
-        try {
-          let resolvedClient: ClientId | undefined
-          if (cliOptions.client !== undefined) {
-            resolvedClient = resolveClientId(cliOptions.client)
-          }
-
-          const opts: ImportLocalOptions = {
-            ...(path !== undefined && { path }),
-            ...(resolvedClient !== undefined && { client: resolvedClient }),
-            ...(cliOptions.watch !== undefined && { watch: cliOptions.watch }),
-            ...(cliOptions.dryRun !== undefined && { dryRun: cliOptions.dryRun }),
-            ...(cliOptions.json !== undefined && { json: cliOptions.json }),
-            ...(cliOptions.db !== undefined && { dbPath: cliOptions.db }),
-          }
-
-          if (opts.watch) {
-            await startWatchMode(opts, !!opts.json)
-            return
-          }
-
-          const result = await runImportLocal(opts)
-          if (opts.json) {
-            console.log(JSON.stringify(result))
-          } else {
-            printHumanSummary(result)
-          }
-          if (result.errors.length > 0 && opts.json) {
-            process.exit(1)
-          }
-        } catch (error) {
-          console.error('import-local failed:', sanitizeError(error))
-          process.exit(1)
-        }
-      }
-    )
+    .action(importLocalAction)
 }
 
 function printHumanSummary(result: ImportLocalResult): void {

--- a/packages/cli/src/commands/pin.ts
+++ b/packages/cli/src/commands/pin.ts
@@ -15,6 +15,7 @@
 
 import { Command } from 'commander'
 import chalk from 'chalk'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { requireTier } from '../utils/require-tier.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { loadManifest, updateManifestEntry } from '../utils/manifest.js'
@@ -36,6 +37,114 @@ function truncateHash(hash: string): string {
 // Command factories
 // ============================================================================
 
+// SMI-5128 batch B: extracted from inline .action() closures so withTelemetry
+// can wrap them at the export boundary (SMI-5018 coverage gate).
+
+async function pinActionImpl(skillName: string): Promise<void> {
+  try {
+    await requireTier('individual')
+
+    const manifest = await loadManifest()
+    const entry = manifest.installedSkills[skillName]
+
+    if (!entry) {
+      console.error(
+        chalk.red(
+          `Skill "${skillName}" not found in manifest. ` +
+            `Install the skill first with: skillsmith setup`
+        )
+      )
+      process.exit(1)
+    }
+
+    const hash = entry.contentHash ?? entry.originalContentHash ?? null
+
+    if (!hash) {
+      console.warn(
+        chalk.yellow(
+          `Warning: No content hash available for "${skillName}". ` +
+            `Reinstall the skill to record a hash.`
+        )
+      )
+      process.exit(1)
+    }
+
+    const pinHash = truncateHash(hash)
+
+    await updateManifestEntry((m) => {
+      const existingEntry = m.installedSkills[skillName]
+      if (!existingEntry) return m
+      return {
+        ...m,
+        installedSkills: {
+          ...m.installedSkills,
+          [skillName]: {
+            ...existingEntry,
+            pinnedVersion: pinHash,
+          },
+        },
+      }
+    })
+
+    console.log(chalk.green(`Pinned ${skillName} to content hash ${pinHash}`))
+  } catch (error) {
+    console.error(chalk.red('Error:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const pinAction = withTelemetry(pinActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'pin',
+  extractFramework: () => 'cli',
+})
+
+async function unpinActionImpl(skillName: string): Promise<void> {
+  try {
+    await requireTier('individual')
+
+    const manifest = await loadManifest()
+    const entry = manifest.installedSkills[skillName]
+
+    if (!entry) {
+      console.error(chalk.red(`Skill "${skillName}" not found in manifest.`))
+      process.exit(1)
+    }
+
+    if (!entry.pinnedVersion) {
+      console.log(chalk.dim(`Skill "${skillName}" is not pinned.`))
+      return
+    }
+
+    const previousPin = entry.pinnedVersion
+
+    await updateManifestEntry((m) => {
+      const existingEntry = m.installedSkills[skillName]
+      if (!existingEntry) return m
+
+      const { pinnedVersion: _removed, ...rest } = existingEntry
+      return {
+        ...m,
+        installedSkills: {
+          ...m.installedSkills,
+          [skillName]: rest,
+        },
+      }
+    })
+
+    console.log(chalk.green(`Unpinned ${skillName} (was pinned to ${previousPin})`))
+  } catch (error) {
+    console.error(chalk.red('Error:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const unpinAction = withTelemetry(unpinActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'unpin',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create the pin command
  */
@@ -43,58 +152,7 @@ export function createPinCommand(): Command {
   return new Command('pin')
     .description('Pin an installed skill to its current content hash (Individual tier)')
     .argument('<skill>', 'Skill name to pin')
-    .action(async (skillName: string): Promise<void> => {
-      try {
-        await requireTier('individual')
-
-        const manifest = await loadManifest()
-        const entry = manifest.installedSkills[skillName]
-
-        if (!entry) {
-          console.error(
-            chalk.red(
-              `Skill "${skillName}" not found in manifest. ` +
-                `Install the skill first with: skillsmith setup`
-            )
-          )
-          process.exit(1)
-        }
-
-        const hash = entry.contentHash ?? entry.originalContentHash ?? null
-
-        if (!hash) {
-          console.warn(
-            chalk.yellow(
-              `Warning: No content hash available for "${skillName}". ` +
-                `Reinstall the skill to record a hash.`
-            )
-          )
-          process.exit(1)
-        }
-
-        const pinHash = truncateHash(hash)
-
-        await updateManifestEntry((m) => {
-          const existingEntry = m.installedSkills[skillName]
-          if (!existingEntry) return m
-          return {
-            ...m,
-            installedSkills: {
-              ...m.installedSkills,
-              [skillName]: {
-                ...existingEntry,
-                pinnedVersion: pinHash,
-              },
-            },
-          }
-        })
-
-        console.log(chalk.green(`Pinned ${skillName} to content hash ${pinHash}`))
-      } catch (error) {
-        console.error(chalk.red('Error:'), sanitizeError(error))
-        process.exit(1)
-      }
-    })
+    .action(pinAction)
 }
 
 /**
@@ -104,43 +162,5 @@ export function createUnpinCommand(): Command {
   return new Command('unpin')
     .description('Remove the content-hash pin from an installed skill (Individual tier)')
     .argument('<skill>', 'Skill name to unpin')
-    .action(async (skillName: string): Promise<void> => {
-      try {
-        await requireTier('individual')
-
-        const manifest = await loadManifest()
-        const entry = manifest.installedSkills[skillName]
-
-        if (!entry) {
-          console.error(chalk.red(`Skill "${skillName}" not found in manifest.`))
-          process.exit(1)
-        }
-
-        if (!entry.pinnedVersion) {
-          console.log(chalk.dim(`Skill "${skillName}" is not pinned.`))
-          return
-        }
-
-        const previousPin = entry.pinnedVersion
-
-        await updateManifestEntry((m) => {
-          const existingEntry = m.installedSkills[skillName]
-          if (!existingEntry) return m
-
-          const { pinnedVersion: _removed, ...rest } = existingEntry
-          return {
-            ...m,
-            installedSkills: {
-              ...m.installedSkills,
-              [skillName]: rest,
-            },
-          }
-        })
-
-        console.log(chalk.green(`Unpinned ${skillName} (was pinned to ${previousPin})`))
-      } catch (error) {
-        console.error(chalk.red('Error:'), sanitizeError(error))
-        process.exit(1)
-      }
-    })
+    .action(unpinAction)
 }


### PR DESCRIPTION
## Summary
- SMI-5083 batch 2 (SMI-5128), batch B of A–D. Wraps 6 handlers across 4 files with `withTelemetry`: `ab-test`, `import-local` (single-handler), `pin`+`unpin`, and `config get`+`config set` (namespaced subcommand skillIds).
- Each inline `.action()` body → `<name>ActionImpl`; wrapped export `<name>Action`; `.action(<name>Action)`.
- CLI_DISPATCHER_MAP coverage 14 → 20 dispatchers.

## Verification (host-side)
- `tsc -p packages/cli` clean; eslint clean; prettier clean.
- `telemetry-coverage.test.ts` passes; all 6 new exports `isTelemetered()`.
- All files <500 LOC (ab-test 270, import-local 305, pin 166, config 274).

## Notes
- Pure extraction — no behavior change; no `any`; explicit param types.
- Pushed with the documented worktree hook bypass (`core.hooksPath=/dev/null`): host pre-push false-fails on native-sqlite suites; CLI-only JS/TS change, clean-Docker CI is the gate.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)