### PR TITLE
feat(cli): SMI-5128 batch C — wrap install/login/import/create telemetry

### DIFF
--- a/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
@@ -48,6 +48,11 @@ const CLI_DISPATCHER_MAP: Record<string, string[]> = {
   'import-local': ['importLocalAction'],
   pin: ['pinAction', 'unpinAction'],
   config: ['configGetAction', 'configSetAction'],
+  // SMI-5128 batch C
+  install: ['installAction'],
+  login: ['loginAction'],
+  import: ['importAction'],
+  create: ['createAction'],
 }
 
 const EXPECTED_TOTAL = Object.values(CLI_DISPATCHER_MAP).reduce((n, arr) => n + arr.length, 0)

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -21,6 +21,7 @@ import ora from 'ora'
 import { mkdir, writeFile, stat } from 'fs/promises'
 import { join } from 'path'
 import { getCanonicalInstallPath } from '@skillsmith/core/install'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 
 import { sanitizeError } from '../utils/sanitize.js'
 import { validateSkillName } from '../utils/skill-name.js'
@@ -377,6 +378,36 @@ export async function createSkill(
 // Command factory
 // ---------------------------------------------------------------------------
 
+// SMI-5128: extracted from inline .action() closure to a named function so
+// withTelemetry can wrap it at the export boundary (SMI-5040 coverage gate).
+async function createActionImpl(
+  name: string | undefined,
+  opts: Record<string, string | boolean | undefined>
+): Promise<void> {
+  try {
+    await createSkill(name, {
+      output: opts['output'] as string | undefined,
+      type: opts['type'] as string | undefined,
+      behavior: opts['behavior'] as string | undefined,
+      description: opts['description'] as string | undefined,
+      author: opts['author'] as string | undefined,
+      category: opts['category'] as string | undefined,
+      scripts: opts['scripts'] as boolean | undefined,
+      yes: opts['yes'] as boolean | undefined,
+      dryRun: opts['dryRun'] as boolean | undefined,
+    })
+  } catch (error) {
+    console.error(chalk.red('Error creating skill:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const createAction = withTelemetry(createActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'create',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create the `skillsmith create` command.
  * SMI-3083: Scaffold new agent skills without a separate skill install.
@@ -405,24 +436,5 @@ export function createCreateCommand(): Command {
     .option('--scripts', 'Include a scripts/ directory')
     .option('-y, --yes', 'Auto-confirm overwrite — always overwrites if skill directory exists')
     .option('--dry-run', 'Preview scaffold output without writing files')
-    .action(
-      async (name: string | undefined, opts: Record<string, string | boolean | undefined>) => {
-        try {
-          await createSkill(name, {
-            output: opts['output'] as string | undefined,
-            type: opts['type'] as string | undefined,
-            behavior: opts['behavior'] as string | undefined,
-            description: opts['description'] as string | undefined,
-            author: opts['author'] as string | undefined,
-            category: opts['category'] as string | undefined,
-            scripts: opts['scripts'] as boolean | undefined,
-            yes: opts['yes'] as boolean | undefined,
-            dryRun: opts['dryRun'] as boolean | undefined,
-          })
-        } catch (error) {
-          console.error(chalk.red('Error creating skill:'), sanitizeError(error))
-          process.exit(1)
-        }
-      }
-    )
+    .action(createAction)
 }

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -15,6 +15,7 @@
 
 import { Command } from 'commander'
 import { SkillRepository, type SkillCreateInput } from '@skillsmith/core'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { openCliDatabase } from '../utils/open-database.js'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
@@ -353,6 +354,33 @@ export async function importSkills(options: ImportOptions = {}): Promise<ImportR
   return result
 }
 
+// SMI-5128: extracted from inline .action() closure to a named function so
+// withTelemetry can wrap it at the export boundary (SMI-5040 coverage gate).
+async function importActionImpl(options: {
+  topic: string
+  max: string
+  db: string
+  verbose?: boolean
+}): Promise<void> {
+  try {
+    await importSkills({
+      topic: options.topic,
+      maxSkills: parseInt(options.max),
+      dbPath: options.db,
+      ...(options.verbose !== undefined && { verbose: options.verbose }),
+    })
+  } catch (error) {
+    console.error('Import failed:', sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const importAction = withTelemetry(importActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'import',
+  extractFramework: () => 'cli',
+})
+
 /**
  * SMI-4665: Build the `skillsmith import` Commander subcommand. Pulled out of
  * `index.ts` (where it was inline) so registration uses the same `addCommand`
@@ -365,19 +393,7 @@ export function createImportCommand(): Command {
     .option('-m, --max <number>', 'Maximum skills to import', '1000')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
     .option('-v, --verbose', 'Verbose output')
-    .action(async (options: { topic: string; max: string; db: string; verbose?: boolean }) => {
-      try {
-        await importSkills({
-          topic: options.topic,
-          maxSkills: parseInt(options.max),
-          dbPath: options.db,
-          ...(options.verbose !== undefined && { verbose: options.verbose }),
-        })
-      } catch (error) {
-        console.error('Import failed:', sanitizeError(error))
-        process.exit(1)
-      }
-    })
+    .action(importAction)
 }
 
 // CLI entry point — preserved so `node packages/cli/dist/src/commands/import.js`

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -18,6 +18,7 @@ import {
   type RegistryLookup,
   type RegistrySkillInfo,
 } from '@skillsmith/core'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { openCliDatabase } from '../utils/open-database.js'
 import { addLink, assertClientId, getInstallPath, type ClientId } from '@skillsmith/core/install'
 import { DEFAULT_DB_PATH, DEFAULT_MANIFEST_PATH } from '../config.js'
@@ -169,6 +170,171 @@ function displayResult(result: CoreInstallResult, quiet: boolean): void {
   }
 }
 
+// SMI-5128: extracted from inline .action() closure to a named function so
+// withTelemetry can wrap it at the export boundary (SMI-5040 coverage gate).
+async function installActionImpl(
+  skillId: string,
+  opts: {
+    force?: boolean
+    skipScan?: boolean
+    skipOptimize?: boolean
+    quiet?: boolean
+    json?: boolean
+    db?: string
+    client?: string
+    alsoLink?: string
+    symlink?: boolean
+  }
+): Promise<void> {
+  const quiet = opts.quiet ?? false
+  const jsonOutput = opts.json ?? false
+
+  try {
+    // SMI-4578: validate --client and parse --also-link before any
+    // I/O so a bad flag fails fast with a friendly hint.
+    const rawClient = opts.client ?? 'claude-code'
+    if (rawClient.includes(',')) {
+      throw new Error(
+        `--client takes a single value (got '${rawClient}'). Pass --also-link <ids> to fan-out into additional clients.`
+      )
+    }
+    assertClientId(rawClient)
+    const client: ClientId = rawClient
+    const alsoLinkClients = parseAlsoLink(opts.alsoLink, client)
+    const skillsDir = getInstallPath(client)
+
+    // Validate skill ID format
+    if (!isValidSkillId(skillId)) {
+      const errorMsg =
+        'Invalid skill ID format. Expected "author/name" or a GitHub URL.\n' +
+        '  Examples:\n' +
+        '    skillsmith install getsentry/commit\n' +
+        '    skillsmith install https://github.com/owner/repo'
+
+      if (jsonOutput) {
+        console.log(JSON.stringify({ success: false, skillId, error: errorMsg }, null, 2))
+      } else {
+        console.error(chalk.red(errorMsg))
+      }
+      process.exit(1)
+      return
+    }
+
+    const dbPath = opts.db ?? DEFAULT_DB_PATH
+    const db = await openCliDatabase(dbPath)
+
+    const spinner = jsonOutput ? null : ora('Installing skill...').start()
+
+    try {
+      const skillRepo = new SkillRepository(db)
+      const skillDependencyRepo = new SkillDependencyRepository(db)
+
+      const service = new SkillInstallationService({
+        db,
+        skillRepo,
+        skillDependencyRepo,
+        skillsDir,
+        manifestPath: DEFAULT_MANIFEST_PATH,
+        registryLookup: createDbRegistryLookup(skillRepo),
+        onProgress: (_stage: string, detail: string) => {
+          if (spinner) {
+            spinner.text = detail
+          }
+        },
+      })
+
+      // Build install options — only set defined properties (exactOptionalPropertyTypes)
+      const installOptions: import('@skillsmith/core').InstallOptions = {}
+      if (opts.force !== undefined) {
+        installOptions.force = opts.force
+      }
+      if (opts.skipScan !== undefined) {
+        installOptions.skipScan = opts.skipScan
+      }
+      if (opts.skipOptimize !== undefined) {
+        installOptions.skipOptimize = opts.skipOptimize
+      }
+
+      const installStart = Date.now()
+      const result = await service.install(skillId, installOptions)
+
+      // SMI-4182 / SMI-4795: fire-and-forget install telemetry —
+      // skipped when CLI is unauthenticated (no SKILLSMITH_API_KEY),
+      // per product decision. `trustTier` is included on every event
+      // (when known); `errorCode` is included only on failures.
+      void emitInstallEvent({
+        skillId,
+        source: 'cli',
+        success: result.success,
+        durationMs: Date.now() - installStart,
+        ...(result.trustTier !== undefined && { trustTier: result.trustTier }),
+        ...(!result.success && result.errorCode !== undefined && { errorCode: result.errorCode }),
+      })
+
+      // SMI-4578: fan-out to --also-link clients only after the
+      // primary install succeeds. Any fan-out failure is reported as
+      // a warning but does NOT mark the overall install as failed —
+      // the canonical install at `client` is already complete.
+      if (result.success && alsoLinkClients.length > 0) {
+        for (const target of alsoLinkClients) {
+          try {
+            const linked = await addLink({
+              skillId,
+              fromClient: client,
+              toClient: target,
+              preferSymlink: opts.symlink ?? false,
+              force: opts.force ?? false,
+            })
+            if (!quiet && !jsonOutput) {
+              const note = linked.fellBackToCopy ? ' (fell back to copy)' : ''
+              console.log(chalk.dim(`  Linked into ${target} as ${linked.record.kind}${note}`))
+            }
+          } catch (linkErr) {
+            if (!jsonOutput) {
+              console.warn(
+                chalk.yellow(`  Warning: could not link to ${target}: ${sanitizeError(linkErr)}`)
+              )
+            }
+          }
+        }
+      }
+
+      if (spinner) {
+        if (result.success) {
+          spinner.succeed('Skill installed')
+        } else {
+          spinner.fail('Installation failed')
+        }
+      }
+
+      if (jsonOutput) {
+        console.log(formatJsonResult(result))
+      } else {
+        displayResult(result, quiet)
+      }
+
+      if (!result.success) {
+        process.exit(1)
+      }
+    } finally {
+      db.close()
+    }
+  } catch (error) {
+    if (jsonOutput) {
+      console.log(JSON.stringify({ success: false, skillId, error: sanitizeError(error) }, null, 2))
+    } else {
+      console.error(chalk.red('Install error:'), sanitizeError(error))
+    }
+    process.exit(1)
+  }
+}
+
+export const installAction = withTelemetry(installActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'install',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create the install command
  */
@@ -193,171 +359,7 @@ export function createInstallCommand(): Command {
       'use relative symlinks instead of file copies for --also-link (POSIX only; falls back to copy on Windows EPERM)',
       false
     )
-    .action(
-      async (
-        skillId: string,
-        opts: {
-          force?: boolean
-          skipScan?: boolean
-          skipOptimize?: boolean
-          quiet?: boolean
-          json?: boolean
-          db?: string
-          client?: string
-          alsoLink?: string
-          symlink?: boolean
-        }
-      ) => {
-        const quiet = opts.quiet ?? false
-        const jsonOutput = opts.json ?? false
-
-        try {
-          // SMI-4578: validate --client and parse --also-link before any
-          // I/O so a bad flag fails fast with a friendly hint.
-          const rawClient = opts.client ?? 'claude-code'
-          if (rawClient.includes(',')) {
-            throw new Error(
-              `--client takes a single value (got '${rawClient}'). Pass --also-link <ids> to fan-out into additional clients.`
-            )
-          }
-          assertClientId(rawClient)
-          const client: ClientId = rawClient
-          const alsoLinkClients = parseAlsoLink(opts.alsoLink, client)
-          const skillsDir = getInstallPath(client)
-
-          // Validate skill ID format
-          if (!isValidSkillId(skillId)) {
-            const errorMsg =
-              'Invalid skill ID format. Expected "author/name" or a GitHub URL.\n' +
-              '  Examples:\n' +
-              '    skillsmith install getsentry/commit\n' +
-              '    skillsmith install https://github.com/owner/repo'
-
-            if (jsonOutput) {
-              console.log(JSON.stringify({ success: false, skillId, error: errorMsg }, null, 2))
-            } else {
-              console.error(chalk.red(errorMsg))
-            }
-            process.exit(1)
-            return
-          }
-
-          const dbPath = opts.db ?? DEFAULT_DB_PATH
-          const db = await openCliDatabase(dbPath)
-
-          const spinner = jsonOutput ? null : ora('Installing skill...').start()
-
-          try {
-            const skillRepo = new SkillRepository(db)
-            const skillDependencyRepo = new SkillDependencyRepository(db)
-
-            const service = new SkillInstallationService({
-              db,
-              skillRepo,
-              skillDependencyRepo,
-              skillsDir,
-              manifestPath: DEFAULT_MANIFEST_PATH,
-              registryLookup: createDbRegistryLookup(skillRepo),
-              onProgress: (_stage: string, detail: string) => {
-                if (spinner) {
-                  spinner.text = detail
-                }
-              },
-            })
-
-            // Build install options — only set defined properties (exactOptionalPropertyTypes)
-            const installOptions: import('@skillsmith/core').InstallOptions = {}
-            if (opts.force !== undefined) {
-              installOptions.force = opts.force
-            }
-            if (opts.skipScan !== undefined) {
-              installOptions.skipScan = opts.skipScan
-            }
-            if (opts.skipOptimize !== undefined) {
-              installOptions.skipOptimize = opts.skipOptimize
-            }
-
-            const installStart = Date.now()
-            const result = await service.install(skillId, installOptions)
-
-            // SMI-4182 / SMI-4795: fire-and-forget install telemetry —
-            // skipped when CLI is unauthenticated (no SKILLSMITH_API_KEY),
-            // per product decision. `trustTier` is included on every event
-            // (when known); `errorCode` is included only on failures.
-            void emitInstallEvent({
-              skillId,
-              source: 'cli',
-              success: result.success,
-              durationMs: Date.now() - installStart,
-              ...(result.trustTier !== undefined && { trustTier: result.trustTier }),
-              ...(!result.success &&
-                result.errorCode !== undefined && { errorCode: result.errorCode }),
-            })
-
-            // SMI-4578: fan-out to --also-link clients only after the
-            // primary install succeeds. Any fan-out failure is reported as
-            // a warning but does NOT mark the overall install as failed —
-            // the canonical install at `client` is already complete.
-            if (result.success && alsoLinkClients.length > 0) {
-              for (const target of alsoLinkClients) {
-                try {
-                  const linked = await addLink({
-                    skillId,
-                    fromClient: client,
-                    toClient: target,
-                    preferSymlink: opts.symlink ?? false,
-                    force: opts.force ?? false,
-                  })
-                  if (!quiet && !jsonOutput) {
-                    const note = linked.fellBackToCopy ? ' (fell back to copy)' : ''
-                    console.log(
-                      chalk.dim(`  Linked into ${target} as ${linked.record.kind}${note}`)
-                    )
-                  }
-                } catch (linkErr) {
-                  if (!jsonOutput) {
-                    console.warn(
-                      chalk.yellow(
-                        `  Warning: could not link to ${target}: ${sanitizeError(linkErr)}`
-                      )
-                    )
-                  }
-                }
-              }
-            }
-
-            if (spinner) {
-              if (result.success) {
-                spinner.succeed('Skill installed')
-              } else {
-                spinner.fail('Installation failed')
-              }
-            }
-
-            if (jsonOutput) {
-              console.log(formatJsonResult(result))
-            } else {
-              displayResult(result, quiet)
-            }
-
-            if (!result.success) {
-              process.exit(1)
-            }
-          } finally {
-            db.close()
-          }
-        } catch (error) {
-          if (jsonOutput) {
-            console.log(
-              JSON.stringify({ success: false, skillId, error: sanitizeError(error) }, null, 2)
-            )
-          } else {
-            console.error(chalk.red('Install error:'), sanitizeError(error))
-          }
-          process.exit(1)
-        }
-      }
-    )
+    .action(installAction)
 }
 
 export default createInstallCommand

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -16,6 +16,7 @@ import {
   isValidApiKeyFormat,
   type TokenCredentials,
 } from '@skillsmith/core'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { VERSION as CLI_VERSION } from '../version.js'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { openCliDatabase } from '../utils/open-database.js'
@@ -333,61 +334,74 @@ async function runPasteLegacyFlow(): Promise<void> {
   process.exit(EXIT.generic)
 }
 
+// SMI-5128: extracted from inline .action() closure to a named function so
+// withTelemetry can wrap it at the export boundary (SMI-5040 coverage gate).
+async function loginActionImpl(options: {
+  browser: boolean
+  pasteLegacy?: boolean
+}): Promise<void> {
+  // Already authenticated via JWT?
+  const existing = await loadCredentials()
+  if (existing && Date.now() < existing.expiresAt) {
+    console.log('Already authenticated. Run `skillsmith logout` to switch accounts.')
+    process.exit(EXIT.success)
+  }
+
+  // Legacy key detection: offer 3-choice menu (M10)
+  const legacyKey = detectLegacyKey()
+  if (legacyKey && !options.pasteLegacy) {
+    console.log()
+    console.log(chalk.yellow('A legacy API key is active.'))
+    console.log()
+    console.log(`  ${chalk.bold('(a)')} Keep using this key       [Enter]`)
+    console.log(`  ${chalk.bold('(d)')} Switch to device-code flow`)
+    console.log(`  ${chalk.bold('(p)')} Paste a new legacy key`)
+    console.log()
+
+    const { default: readline } = await import('readline')
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false,
+    })
+    const choice = await new Promise<string>((resolve) => {
+      process.stdout.write('Choice [a]: ')
+      rl.once('line', (line) => {
+        rl.close()
+        resolve(line.trim().toLowerCase())
+      })
+    })
+
+    if (choice === '' || choice === 'a') {
+      console.log(chalk.dim('Keeping existing key.'))
+      process.exit(EXIT.success)
+    } else if (choice === 'p') {
+      await runPasteLegacyFlow()
+      return
+    }
+    // 'd' or anything else → device flow
+    await runDeviceCodeFlow(!options.browser)
+    return
+  }
+
+  if (options.pasteLegacy) {
+    await runPasteLegacyFlow()
+    return
+  }
+
+  await runDeviceCodeFlow(!options.browser)
+}
+
+export const loginAction = withTelemetry(loginActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'login',
+  extractFramework: () => 'cli',
+})
+
 export function createLoginCommand(): Command {
   return new Command('login')
     .description('Authenticate the Skillsmith CLI')
     .option('--no-browser', 'Print URL instead of opening browser (for CI/headless)')
     .option('--paste-legacy', 'Use legacy API-key paste flow')
-    .action(async (options: { browser: boolean; pasteLegacy?: boolean }) => {
-      // Already authenticated via JWT?
-      const existing = await loadCredentials()
-      if (existing && Date.now() < existing.expiresAt) {
-        console.log('Already authenticated. Run `skillsmith logout` to switch accounts.')
-        process.exit(EXIT.success)
-      }
-
-      // Legacy key detection: offer 3-choice menu (M10)
-      const legacyKey = detectLegacyKey()
-      if (legacyKey && !options.pasteLegacy) {
-        console.log()
-        console.log(chalk.yellow('A legacy API key is active.'))
-        console.log()
-        console.log(`  ${chalk.bold('(a)')} Keep using this key       [Enter]`)
-        console.log(`  ${chalk.bold('(d)')} Switch to device-code flow`)
-        console.log(`  ${chalk.bold('(p)')} Paste a new legacy key`)
-        console.log()
-
-        const { default: readline } = await import('readline')
-        const rl = readline.createInterface({
-          input: process.stdin,
-          output: process.stdout,
-          terminal: false,
-        })
-        const choice = await new Promise<string>((resolve) => {
-          process.stdout.write('Choice [a]: ')
-          rl.once('line', (line) => {
-            rl.close()
-            resolve(line.trim().toLowerCase())
-          })
-        })
-
-        if (choice === '' || choice === 'a') {
-          console.log(chalk.dim('Keeping existing key.'))
-          process.exit(EXIT.success)
-        } else if (choice === 'p') {
-          await runPasteLegacyFlow()
-          return
-        }
-        // 'd' or anything else → device flow
-        await runDeviceCodeFlow(!options.browser)
-        return
-      }
-
-      if (options.pasteLegacy) {
-        await runPasteLegacyFlow()
-        return
-      }
-
-      await runDeviceCodeFlow(!options.browser)
-    })
+    .action(loginAction)
 }


### PR DESCRIPTION
## Summary
- SMI-5083 batch 2 (SMI-5128), batch C of A–D. Wraps 4 single-handler CLI commands `install`, `login`, `import`, `create` with `withTelemetry`.
- Each: inline `.action()` body → `<name>ActionImpl`; wrapped export `<name>Action`; `.action(<name>Action)`.
- CLI_DISPATCHER_MAP coverage 20 → 24 dispatchers.

## Verification (host-side)
- `tsc -p packages/cli` clean; eslint clean; prettier clean.
- `telemetry-coverage.test.ts` passes; all 4 new exports `isTelemetered()`.
- All files <500 LOC (install 365, login 407, import 415, create 440).

## Notes
- Pure extraction — no behavior change; no `any`; explicit param types.
- Pushed with the documented worktree hook bypass (`core.hooksPath=/dev/null`): host pre-push false-fails on native-sqlite suites; CLI-only change, clean-Docker CI is the gate.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)