### PR TITLE
feat(cli): SMI-5128 batch D — wrap audit/manage/telemetry (final CLI batch)

### DIFF
--- a/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
@@ -53,6 +53,19 @@ const CLI_DISPATCHER_MAP: Record<string, string[]> = {
   login: ['loginAction'],
   import: ['importAction'],
   create: ['createAction'],
+  // SMI-5128 batch D
+  'audit-collisions': ['collisionsAction'],
+  audit: ['advisoriesAction', 'auditAction'],
+  manage: ['listAction', 'updateAction', 'removeAction'],
+  // telemetry uses the .action.ts sibling-split (6 subcommands)
+  'telemetry.action': [
+    'telemetryEnableAction',
+    'telemetryDisableAction',
+    'telemetryStatusAction',
+    'telemetryInstallHookAction',
+    'telemetryUninstallHookAction',
+    'telemetryResetIdAction',
+  ],
 }
 
 const EXPECTED_TOTAL = Object.values(CLI_DISPATCHER_MAP).reduce((n, arr) => n + arr.length, 0)

--- a/packages/cli/src/commands/audit-collisions.ts
+++ b/packages/cli/src/commands/audit-collisions.ts
@@ -36,6 +36,7 @@ import { join } from 'node:path'
 
 import { Command } from 'commander'
 import chalk from 'chalk'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { input, select } from '@inquirer/prompts'
 
 import {
@@ -338,6 +339,36 @@ async function runAuditCollisions(options: AuditCollisionsOptions): Promise<void
  * Build the `audit collisions` subcommand. Registered as a sibling of
  * `audit advisories` in `audit.ts` (Step 0a).
  */
+// SMI-5128: extracted from inline .action() closure so withTelemetry can wrap
+// it at the export boundary (SMI-5040 coverage gate).
+async function collisionsActionImpl(opts: Record<string, boolean | undefined>): Promise<void> {
+  try {
+    await runAuditCollisions({
+      deep: opts['deep'] === true,
+      json: opts['json'] === true,
+      applyAll: opts['applyAll'] === true,
+      reportOnly: opts['reportOnly'] === true,
+      resetLedger: opts['resetLedger'] === true,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : sanitizeError(error)
+    // Confirmation rejection is not a stack-trace-worthy failure —
+    // print the canonical message and exit non-zero.
+    if (message === CONFIRMATION_REJECTED_MESSAGE) {
+      console.error(chalk.yellow(message))
+    } else {
+      console.error(chalk.red('Error:'), message)
+    }
+    process.exit(1)
+  }
+}
+
+export const collisionsAction = withTelemetry(collisionsActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'collisions',
+  extractFramework: () => 'cli',
+})
+
 export function createAuditCollisionsSubcommand(): Command {
   return new Command('collisions')
     .description(
@@ -357,27 +388,7 @@ export function createAuditCollisionsSubcommand(): Command {
       'Clear ~/.skillsmith/namespace-overrides.json (typed-confirmation gate: literal phrase `RESET LEDGER`)',
       false
     )
-    .action(async (opts: Record<string, boolean | undefined>) => {
-      try {
-        await runAuditCollisions({
-          deep: opts['deep'] === true,
-          json: opts['json'] === true,
-          applyAll: opts['applyAll'] === true,
-          reportOnly: opts['reportOnly'] === true,
-          resetLedger: opts['resetLedger'] === true,
-        })
-      } catch (error) {
-        const message = error instanceof Error ? error.message : sanitizeError(error)
-        // Confirmation rejection is not a stack-trace-worthy failure —
-        // print the canonical message and exit non-zero.
-        if (message === CONFIRMATION_REJECTED_MESSAGE) {
-          console.error(chalk.yellow(message))
-        } else {
-          console.error(chalk.red('Error:'), message)
-        }
-        process.exit(1)
-      }
-    })
+    .action(collisionsAction)
 }
 
 // Internal exports for tests.

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -20,6 +20,7 @@
 import { Command } from 'commander'
 import chalk from 'chalk'
 import { AdvisoryRepository, type SkillAdvisory } from '@skillsmith/core'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { openCliDatabase } from '../utils/open-database.js'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
@@ -160,22 +161,34 @@ async function runAdvisoriesAudit(options: AuditAdvisoriesOptions): Promise<void
  *
  * @internal exported for tests; consumers should use {@link createAuditCommand}.
  */
+// SMI-5128: extracted from inline .action() closure so withTelemetry can wrap
+// it at the export boundary (SMI-5040 coverage gate).
+async function advisoriesActionImpl(
+  opts: Record<string, string | boolean | undefined>
+): Promise<void> {
+  try {
+    await runAdvisoriesAudit({
+      db: opts['db'] as string,
+      fix: (opts['fix'] as boolean) ?? false,
+    })
+  } catch (error) {
+    console.error(chalk.red('Error:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const advisoriesAction = withTelemetry(advisoriesActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'advisories',
+  extractFramework: () => 'cli',
+})
+
 export function createAuditAdvisoriesSubcommand(): Command {
   return new Command('advisories')
     .description('Check installed skills for known security advisories (Team tier required)')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
     .option('--fix', 'Attempt to update skills with available patches')
-    .action(async (opts: Record<string, string | boolean | undefined>) => {
-      try {
-        await runAdvisoriesAudit({
-          db: opts['db'] as string,
-          fix: (opts['fix'] as boolean) ?? false,
-        })
-      } catch (error) {
-        console.error(chalk.red('Error:'), sanitizeError(error))
-        process.exit(1)
-      }
-    })
+    .action(advisoriesAction)
 }
 
 /**
@@ -216,28 +229,41 @@ export function createAuditCommand(): Command {
     .argument('[skillId]', 'Legacy positional skill-id (deprecated; use `advisories <skill-id>`)')
     .option('-d, --db <path>', 'Database file path (deprecated alias)', DEFAULT_DB_PATH)
     .option('--fix', 'Attempt to update skills with available patches (deprecated alias)')
-    .action(
-      async (skillId: string | undefined, opts: Record<string, string | boolean | undefined>) => {
-        if (skillId === undefined) {
-          // No subcommand and no positional — print parent help.
-          audit.help()
-          return
-        }
-        // Emit deprecation warning to stderr; do not pollute stdout.
-        console.error(chalk.yellow(AUDIT_FLAT_DEPRECATION_NOTICE))
-        try {
-          await runAdvisoriesAudit({
-            db: opts['db'] as string,
-            fix: (opts['fix'] as boolean) ?? false,
-          })
-        } catch (error) {
-          console.error(chalk.red('Error:'), sanitizeError(error))
-          process.exit(1)
-        }
-      }
-    )
+    .action(auditAction)
 
   return audit
 }
+
+// SMI-5128: extracted from the parent `audit` inline .action() closure so
+// withTelemetry can wrap it. `command.help()` (commander passes the Command as
+// the final action arg) replaces the closure's `audit.help()`.
+async function auditActionImpl(
+  skillId: string | undefined,
+  opts: Record<string, string | boolean | undefined>,
+  command: Command
+): Promise<void> {
+  if (skillId === undefined) {
+    // No subcommand and no positional — print parent help.
+    command.help()
+    return
+  }
+  // Emit deprecation warning to stderr; do not pollute stdout.
+  console.error(chalk.yellow(AUDIT_FLAT_DEPRECATION_NOTICE))
+  try {
+    await runAdvisoriesAudit({
+      db: opts['db'] as string,
+      fix: (opts['fix'] as boolean) ?? false,
+    })
+  } catch (error) {
+    console.error(chalk.red('Error:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const auditAction = withTelemetry(auditActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'audit',
+  extractFramework: () => 'cli',
+})
 
 export default createAuditCommand

--- a/packages/cli/src/commands/manage.ts
+++ b/packages/cli/src/commands/manage.ts
@@ -22,6 +22,7 @@ import { openCliDatabase } from '../utils/open-database.js'
 import { DEFAULT_DB_PATH, DEFAULT_SKILLS_DIR, DEFAULT_MANIFEST_PATH } from '../config.js'
 import { removeLinks } from '@skillsmith/core/install'
 import { sanitizeError } from '../utils/sanitize.js'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import { getInstalledSkills, type InstalledSkill } from '../utils/skills-directory.js'
 
 /**
@@ -312,64 +313,105 @@ async function removeSkill(skillName: string, force: boolean, dbPath: string): P
 /**
  * Create list command
  */
+// SMI-5128: handler impls extracted from inline .action() closures so
+// withTelemetry can wrap them at the export boundary (SMI-5040 coverage gate).
+async function listActionImpl(opts: Record<string, string | boolean | undefined>): Promise<void> {
+  try {
+    const dbPath = opts['db'] as string
+    const outdated = (opts['outdated'] as boolean) ?? false
+
+    const skills = await getInstalledSkills(dbPath)
+    const filtered = outdated ? skills.filter((s) => s.hasUpdates) : skills
+
+    if (outdated && filtered.length === 0) {
+      console.log(chalk.green('\nAll installed skills are up to date.\n'))
+      return
+    }
+
+    displaySkillsTable(filtered)
+  } catch (error) {
+    console.error(chalk.red('Error listing skills:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const listAction = withTelemetry(listActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'list',
+  extractFramework: () => 'cli',
+})
+
 export function createListCommand(): Command {
   return new Command('list')
     .alias('ls')
     .description('List all installed skills')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
     .option('--outdated', 'Show only skills with available updates (requires Individual tier)')
-    .action(async (opts: Record<string, string | boolean | undefined>) => {
-      try {
-        const dbPath = opts['db'] as string
-        const outdated = (opts['outdated'] as boolean) ?? false
-
-        const skills = await getInstalledSkills(dbPath)
-        const filtered = outdated ? skills.filter((s) => s.hasUpdates) : skills
-
-        if (outdated && filtered.length === 0) {
-          console.log(chalk.green('\nAll installed skills are up to date.\n'))
-          return
-        }
-
-        displaySkillsTable(filtered)
-      } catch (error) {
-        console.error(chalk.red('Error listing skills:'), sanitizeError(error))
-        process.exit(1)
-      }
-    })
+    .action(listAction)
 }
 
 /**
  * Create update command
  */
+async function updateActionImpl(
+  skillName: string | undefined,
+  opts: Record<string, string | boolean | undefined>
+): Promise<void> {
+  const dbPath = opts['db'] as string
+  const updateAll = opts['all'] as boolean | undefined
+
+  try {
+    if (updateAll || !skillName) {
+      await updateAllSkills(dbPath)
+    } else {
+      await updateSkill(skillName, dbPath)
+    }
+  } catch (error) {
+    console.error(chalk.red('Error updating skills:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const updateAction = withTelemetry(updateActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'update',
+  extractFramework: () => 'cli',
+})
+
 export function createUpdateCommand(): Command {
   return new Command('update')
     .description('Update installed skills')
     .argument('[skill]', 'Skill name to update (omit for all)')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
     .option('-a, --all', 'Update all installed skills')
-    .action(
-      async (skillName: string | undefined, opts: Record<string, string | boolean | undefined>) => {
-        const dbPath = opts['db'] as string
-        const updateAll = opts['all'] as boolean | undefined
-
-        try {
-          if (updateAll || !skillName) {
-            await updateAllSkills(dbPath)
-          } else {
-            await updateSkill(skillName, dbPath)
-          }
-        } catch (error) {
-          console.error(chalk.red('Error updating skills:'), sanitizeError(error))
-          process.exit(1)
-        }
-      }
-    )
+    .action(updateAction)
 }
 
 /**
  * Create remove command
  */
+async function removeActionImpl(
+  skillName: string,
+  opts: Record<string, string | boolean | undefined>
+): Promise<void> {
+  const force = (opts['force'] as boolean) ?? false
+  const dbPath = (opts['db'] as string) ?? DEFAULT_DB_PATH
+
+  try {
+    const success = await removeSkill(skillName, force, dbPath)
+    process.exit(success ? 0 : 1)
+  } catch (error) {
+    console.error(chalk.red('Error removing skill:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const removeAction = withTelemetry(removeActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'remove',
+  extractFramework: () => 'cli',
+})
+
 export function createRemoveCommand(): Command {
   return new Command('remove')
     .alias('rm')
@@ -378,18 +420,7 @@ export function createRemoveCommand(): Command {
     .argument('<skill>', 'Skill name to remove')
     .option('-f, --force', 'Skip confirmation prompt and force removal of modified/orphan skills')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
-    .action(async (skillName: string, opts: Record<string, string | boolean | undefined>) => {
-      const force = (opts['force'] as boolean) ?? false
-      const dbPath = (opts['db'] as string) ?? DEFAULT_DB_PATH
-
-      try {
-        const success = await removeSkill(skillName, force, dbPath)
-        process.exit(success ? 0 : 1)
-      } catch (error) {
-        console.error(chalk.red('Error removing skill:'), sanitizeError(error))
-        process.exit(1)
-      }
-    })
+    .action(removeAction)
 }
 
 export { getInstalledSkills, displaySkillsTable }

--- a/packages/cli/src/commands/telemetry.action.ts
+++ b/packages/cli/src/commands/telemetry.action.ts
@@ -1,0 +1,436 @@
+/**
+ * @fileoverview `skillsmith telemetry` action implementations + telemetry wrappers.
+ * @module @skillsmith/cli/commands/telemetry.action
+ * @see SMI-5128 batch D — sibling-split of telemetry.ts so the 6 subcommand
+ *   handlers can be wrapped with withTelemetry without exceeding the 500-LOC
+ *   gate. Mirrors the sync.action.ts / search.action.ts convention (SMI-5127):
+ *   the run* business logic + the wrapped *Action exports live here; the
+ *   commander factory stays in telemetry.ts and imports the wrapped actions.
+ *
+ * Privacy invariants (plan line 719):
+ *   - anonymousId is NEVER printed in full. Only the last 8 hex chars appear in stdout.
+ *   - The full SHA-256 hex travels only to the events endpoint in hook payloads.
+ */
+
+import { existsSync, copyFileSync, chmodSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readdirSync, unlinkSync, statSync } from 'node:fs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+import chalk from 'chalk'
+
+import {
+  loadManifest,
+  saveManifest,
+  generateAnonymousId,
+  shouldRotateAnonymousId,
+  rotateAnonymousId,
+  sweepExpiredPreviousId,
+  type TelemetryManifest,
+} from '../utils/manifest.js'
+import {
+  loadClaudeSettings,
+  addSkillHookEntries,
+  removeSkillHookEntries,
+  writeClaudeSettings,
+  TelemetryHookError,
+} from './telemetry.helpers.js'
+import { sanitizeError } from '../utils/sanitize.js'
+import { withTelemetry } from '@skillsmith/core/telemetry'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PRIVACY_URL = 'https://skillsmith.app/privacy#telemetry'
+const DEFAULT_ENDPOINT = 'https://vrcnzpmndtroqxxoqkzy.supabase.co/functions/v1/events'
+const ORPHAN_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+// All path helpers resolved at call time so test harnesses that swap HOME work.
+function hookScriptPath(): string {
+  return join(homedir(), '.skillsmith', 'hooks', 'skill-telemetry.sh')
+}
+function runDir(): string {
+  return join(homedir(), '.skillsmith', 'run')
+}
+
+// ---------------------------------------------------------------------------
+// Privacy helper — NEVER print full anonymousId
+// ---------------------------------------------------------------------------
+
+function idTail(id: string | undefined): string {
+  if (!id) return '(none)'
+  return `...${id.slice(-8)}`
+}
+
+// ---------------------------------------------------------------------------
+// Orphan GC (plan line 714)
+// ---------------------------------------------------------------------------
+
+function gcOrphanRunFiles(): void {
+  try {
+    const dir = runDir()
+    if (!existsSync(dir)) return
+    const now = Date.now()
+    for (const f of readdirSync(dir)) {
+      if (!f.startsWith('skill-')) continue
+      const fp = join(dir, f)
+      try {
+        const st = statSync(fp)
+        if (now - st.mtimeMs > ORPHAN_TTL_MS) unlinkSync(fp)
+      } catch {
+        // best-effort
+      }
+    }
+  } catch {
+    // never throw from GC
+  }
+}
+
+// ---------------------------------------------------------------------------
+// enable
+// ---------------------------------------------------------------------------
+
+async function runEnable(): Promise<void> {
+  const manifest = await loadManifest()
+  const t: TelemetryManifest = manifest.telemetry ?? { enabled: false }
+
+  if (t.enabled) {
+    console.log(chalk.green('Telemetry is already enabled.'))
+    console.log(chalk.dim(`  Anonymous ID tail: ${idTail(t.anonymousId)}`))
+    return
+  }
+
+  const now = new Date().toISOString()
+  const updated: TelemetryManifest = {
+    ...t,
+    enabled: true,
+    anonymousId: t.anonymousId ?? generateAnonymousId(),
+    anonymousIdCreatedAt: t.anonymousIdCreatedAt ?? now,
+    scope: t.scope ?? 'personal',
+    endpoint: t.endpoint ?? DEFAULT_ENDPOINT,
+  }
+
+  await saveManifest({ ...manifest, telemetry: updated })
+
+  console.log(chalk.green('Telemetry enabled.'))
+  console.log()
+  console.log(
+    'Skillsmith telemetry collects anonymous skill-invocation counts to help improve\n' +
+      'the registry and surface stale skills. No personal data, file contents, or\n' +
+      `paths are captured. Full privacy policy: ${chalk.cyan(PRIVACY_URL)}`
+  )
+  console.log()
+  console.log(chalk.dim(`  Anonymous ID tail: ${idTail(updated.anonymousId)}`))
+  console.log(chalk.dim('  Disable at any time: ') + chalk.cyan('skillsmith telemetry disable'))
+}
+
+// ---------------------------------------------------------------------------
+// disable
+// ---------------------------------------------------------------------------
+
+async function runDisable(): Promise<void> {
+  const manifest = await loadManifest()
+  const t: TelemetryManifest = manifest.telemetry ?? { enabled: false }
+
+  if (!t.enabled) {
+    console.log(chalk.dim('Telemetry is already disabled.'))
+    return
+  }
+
+  await saveManifest({ ...manifest, telemetry: { ...t, enabled: false } })
+
+  console.log(chalk.yellow('Telemetry disabled.'))
+  console.log(
+    chalk.dim(
+      '  The anonymous ID is retained in the local manifest for continuity if you re-enable.\n' +
+        '  To fully clear it: skillsmith telemetry reset-id'
+    )
+  )
+}
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+async function runStatus(): Promise<void> {
+  let manifest = await loadManifest()
+  let rotationTriggered = false
+
+  // Annual auto-rotation (plan line 706, 713)
+  if (shouldRotateAnonymousId(manifest)) {
+    const rotated = rotateAnonymousId(manifest)
+    manifest = { ...manifest, telemetry: rotated }
+    await saveManifest(manifest)
+    rotationTriggered = true
+  }
+
+  // Sweep expired previous id
+  const swept = sweepExpiredPreviousId(manifest)
+  if (swept !== manifest.telemetry) {
+    manifest = { ...manifest, telemetry: swept }
+    await saveManifest(manifest)
+  }
+
+  // GC orphan run files (plan line 714)
+  gcOrphanRunFiles()
+
+  const t: TelemetryManifest = manifest.telemetry ?? { enabled: false }
+  const endpoint = t.endpoint ?? DEFAULT_ENDPOINT
+
+  let ageDays: number | null = null
+  if (t.anonymousIdCreatedAt) {
+    ageDays = Math.floor((Date.now() - new Date(t.anonymousIdCreatedAt).getTime()) / 86_400_000)
+  }
+
+  console.log(chalk.bold('Skillsmith Telemetry Status'))
+  console.log()
+  console.log(`  Enabled:          ${t.enabled ? chalk.green('yes') : chalk.dim('no')}`)
+  console.log(`  Endpoint:         ${chalk.dim(endpoint)}`)
+  console.log(`  Anonymous ID:     ${chalk.dim(idTail(t.anonymousId))}`)
+  console.log(`  ID age (days):    ${ageDays !== null ? String(ageDays) : chalk.dim('n/a')}`)
+  console.log(`  Scope:            ${t.scope ?? chalk.dim('personal')}`)
+
+  if (t.installedAt) {
+    console.log(`  Hook installed:   ${chalk.dim(t.installedAt)}`)
+  }
+
+  if (rotationTriggered) {
+    console.log()
+    console.log(
+      chalk.yellow('  Annual rotation triggered.') +
+        chalk.dim(' New ID tail: ') +
+        chalk.cyan(idTail(t.anonymousId))
+    )
+    if (t.previousAnonymousId) {
+      console.log(
+        chalk.dim(
+          `  Previous ID retained for 7-day overlap window (retired: ${t.previousAnonymousIdRetiredAt ?? 'unknown'})`
+        )
+      )
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// install-hook
+// ---------------------------------------------------------------------------
+
+async function runInstallHook(options: {
+  scope: 'user' | 'project'
+  endpoint?: string
+}): Promise<void> {
+  // Resolve the template source — relative to this file's compiled output.
+  // src/commands/telemetry.action.ts → ../../templates/skill-telemetry.sh (via dist/commands)
+  // and one level up for the src layout during tests.
+  const templateCandidates = [
+    join(__dirname, '..', '..', 'templates', 'skill-telemetry.sh'),
+    join(__dirname, '..', 'templates', 'skill-telemetry.sh'),
+  ]
+  const templateSrc = templateCandidates.find((p) => existsSync(p))
+  if (!templateSrc) {
+    throw new Error(
+      'skill-telemetry.sh template not found. ' +
+        'Ensure the CLI package is fully built: npm run build'
+    )
+  }
+
+  // Load + validate settings.json — throws TelemetryHookError on foreign Skill matcher
+  const scope = options.scope
+  const settings = loadClaudeSettings(scope)
+  const hookPath = hookScriptPath()
+  const updated = addSkillHookEntries(settings, hookPath)
+
+  // Copy hook script to ~/.skillsmith/hooks/
+  const destPath = hookScriptPath()
+  const hooksDir = dirname(destPath)
+  mkdirSync(hooksDir, { recursive: true, mode: 0o700 })
+  copyFileSync(templateSrc, destPath)
+  try {
+    chmodSync(destPath, 0o755)
+  } catch {
+    // best-effort on Windows
+  }
+
+  // Persist settings.json atomically
+  writeClaudeSettings(scope, updated)
+
+  // Record installation timestamp in manifest
+  const manifest = await loadManifest()
+  const t: TelemetryManifest = manifest.telemetry ?? { enabled: false }
+  await saveManifest({ ...manifest, telemetry: { ...t, installedAt: new Date().toISOString() } })
+
+  // Update endpoint in manifest if provided
+  if (options.endpoint) {
+    const m2 = await loadManifest()
+    const t2 = m2.telemetry ?? { enabled: false }
+    await saveManifest({ ...m2, telemetry: { ...t2, endpoint: options.endpoint } })
+  }
+
+  const scopeLabel = scope === 'user' ? '~/.claude/settings.json' : './.claude/settings.json'
+  console.log(chalk.green('Skillsmith telemetry hook installed.'))
+  console.log(chalk.dim(`  Hook script:   ${destPath}`))
+  console.log(chalk.dim(`  Settings file: ${scopeLabel}`))
+  console.log()
+  console.log(
+    chalk.dim('Enable telemetry to start collecting: ') + chalk.cyan('skillsmith telemetry enable')
+  )
+}
+
+// ---------------------------------------------------------------------------
+// uninstall-hook
+// ---------------------------------------------------------------------------
+
+async function runUninstallHook(options: { scope: 'user' | 'project' }): Promise<void> {
+  const scope = options.scope
+  const hookPath = hookScriptPath()
+  const settings = loadClaudeSettings(scope)
+  const updated = removeSkillHookEntries(settings, hookPath)
+  writeClaudeSettings(scope, updated)
+
+  // Optionally remove the script file
+  try {
+    const scriptPath = hookScriptPath()
+    if (existsSync(scriptPath)) unlinkSync(scriptPath)
+  } catch {
+    // best-effort
+  }
+
+  const scopeLabel = scope === 'user' ? '~/.claude/settings.json' : './.claude/settings.json'
+  console.log(chalk.yellow('Skillsmith telemetry hook removed.'))
+  console.log(chalk.dim(`  Removed from: ${scopeLabel}`))
+  console.log(chalk.dim('  Foreign hooks (if any) were not touched.'))
+}
+
+// ---------------------------------------------------------------------------
+// reset-id
+// ---------------------------------------------------------------------------
+
+async function runResetId(): Promise<void> {
+  const manifest = await loadManifest()
+  const rotated = rotateAnonymousId(manifest) // unconditional rotation
+  await saveManifest({ ...manifest, telemetry: rotated })
+
+  console.log(chalk.green('Anonymous ID rotated.'))
+  console.log(chalk.dim(`  New ID tail:      ${idTail(rotated.anonymousId)}`))
+  if (rotated.previousAnonymousId) {
+    console.log(chalk.dim(`  Previous ID tail: ${idTail(rotated.previousAnonymousId)}`))
+    console.log(
+      chalk.dim(
+        `  Previous ID retirement: ${rotated.previousAnonymousIdRetiredAt ?? 'unknown'} (7-day overlap window)`
+      )
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// withTelemetry-wrapped action handlers (SMI-5128)
+// ---------------------------------------------------------------------------
+
+async function telemetryEnableActionImpl(): Promise<void> {
+  try {
+    await runEnable()
+  } catch (err) {
+    console.error(chalk.red('Error:'), sanitizeError(err))
+    process.exit(1)
+  }
+}
+
+export const telemetryEnableAction = withTelemetry(telemetryEnableActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'telemetry enable',
+  extractFramework: () => 'cli',
+})
+
+async function telemetryDisableActionImpl(): Promise<void> {
+  try {
+    await runDisable()
+  } catch (err) {
+    console.error(chalk.red('Error:'), sanitizeError(err))
+    process.exit(1)
+  }
+}
+
+export const telemetryDisableAction = withTelemetry(telemetryDisableActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'telemetry disable',
+  extractFramework: () => 'cli',
+})
+
+async function telemetryStatusActionImpl(): Promise<void> {
+  try {
+    await runStatus()
+  } catch (err) {
+    console.error(chalk.red('Error:'), sanitizeError(err))
+    process.exit(1)
+  }
+}
+
+export const telemetryStatusAction = withTelemetry(telemetryStatusActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'telemetry status',
+  extractFramework: () => 'cli',
+})
+
+async function telemetryInstallHookActionImpl(options: {
+  scope: string
+  endpoint?: string
+}): Promise<void> {
+  const scope = options.scope === 'project' ? 'project' : 'user'
+  try {
+    await runInstallHook(
+      options.endpoint !== undefined ? { scope, endpoint: options.endpoint } : { scope }
+    )
+  } catch (err) {
+    if (err instanceof TelemetryHookError) {
+      console.error(chalk.red(`Error [${err.code}]:`))
+      console.error(err.message)
+    } else {
+      console.error(chalk.red('Error:'), sanitizeError(err))
+    }
+    process.exit(1)
+  }
+}
+
+export const telemetryInstallHookAction = withTelemetry(telemetryInstallHookActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'telemetry install-hook',
+  extractFramework: () => 'cli',
+})
+
+async function telemetryUninstallHookActionImpl(options: { scope: string }): Promise<void> {
+  const scope = options.scope === 'project' ? 'project' : 'user'
+  try {
+    await runUninstallHook({ scope })
+  } catch (err) {
+    console.error(chalk.red('Error:'), sanitizeError(err))
+    process.exit(1)
+  }
+}
+
+export const telemetryUninstallHookAction = withTelemetry(telemetryUninstallHookActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'telemetry uninstall-hook',
+  extractFramework: () => 'cli',
+})
+
+async function telemetryResetIdActionImpl(): Promise<void> {
+  try {
+    await runResetId()
+  } catch (err) {
+    console.error(chalk.red('Error:'), sanitizeError(err))
+    process.exit(1)
+  }
+}
+
+export const telemetryResetIdAction = withTelemetry(telemetryResetIdActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'telemetry reset-id',
+  extractFramework: () => 'cli',
+})
+
+// Internal exports for tests (re-exported from telemetry.ts for back-compat).
+export { runEnable, runDisable, runStatus, runInstallHook, runUninstallHook, runResetId, idTail }

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -2,6 +2,10 @@
  * @fileoverview `skillsmith telemetry` command group — opt-in telemetry management.
  * @module @skillsmith/cli/commands/telemetry
  * @see SMI-5021 Wave 3 Step 2 — CLI subcommands for telemetry (plan lines 195–196, 576)
+ * @see SMI-5128 batch D — action impls + run* logic moved to telemetry.action.ts
+ *   (sibling-split convention) so the 6 subcommand handlers are withTelemetry-
+ *   wrapped without this file exceeding the 500-LOC gate. This file retains the
+ *   commander factory and re-exports the run* test helpers for back-compat.
  *
  * Subcommands:
  *   skillsmith telemetry enable
@@ -21,319 +25,16 @@
  *   - manifest read/write always via loadManifest / saveManifest (atomic rename)
  */
 
-import { existsSync, copyFileSync, chmodSync, mkdirSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { readdirSync, unlinkSync, statSync } from 'node:fs'
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
 import { Command } from 'commander'
-import chalk from 'chalk'
 
 import {
-  loadManifest,
-  saveManifest,
-  generateAnonymousId,
-  shouldRotateAnonymousId,
-  rotateAnonymousId,
-  sweepExpiredPreviousId,
-  type TelemetryManifest,
-} from '../utils/manifest.js'
-import {
-  loadClaudeSettings,
-  addSkillHookEntries,
-  removeSkillHookEntries,
-  writeClaudeSettings,
-  TelemetryHookError,
-} from './telemetry.helpers.js'
-import { sanitizeError } from '../utils/sanitize.js'
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const PRIVACY_URL = 'https://skillsmith.app/privacy#telemetry'
-const DEFAULT_ENDPOINT = 'https://vrcnzpmndtroqxxoqkzy.supabase.co/functions/v1/events'
-const ORPHAN_TTL_MS = 60 * 60 * 1000 // 1 hour
-
-// All path helpers resolved at call time so test harnesses that swap HOME work.
-function hookScriptPath(): string {
-  return join(homedir(), '.skillsmith', 'hooks', 'skill-telemetry.sh')
-}
-function runDir(): string {
-  return join(homedir(), '.skillsmith', 'run')
-}
-
-// ---------------------------------------------------------------------------
-// Privacy helper — NEVER print full anonymousId
-// ---------------------------------------------------------------------------
-
-function idTail(id: string | undefined): string {
-  if (!id) return '(none)'
-  return `...${id.slice(-8)}`
-}
-
-// ---------------------------------------------------------------------------
-// Orphan GC (plan line 714)
-// ---------------------------------------------------------------------------
-
-function gcOrphanRunFiles(): void {
-  try {
-    const dir = runDir()
-    if (!existsSync(dir)) return
-    const now = Date.now()
-    for (const f of readdirSync(dir)) {
-      if (!f.startsWith('skill-')) continue
-      const fp = join(dir, f)
-      try {
-        const st = statSync(fp)
-        if (now - st.mtimeMs > ORPHAN_TTL_MS) unlinkSync(fp)
-      } catch {
-        // best-effort
-      }
-    }
-  } catch {
-    // never throw from GC
-  }
-}
-
-// ---------------------------------------------------------------------------
-// enable
-// ---------------------------------------------------------------------------
-
-async function runEnable(): Promise<void> {
-  const manifest = await loadManifest()
-  const t: TelemetryManifest = manifest.telemetry ?? { enabled: false }
-
-  if (t.enabled) {
-    console.log(chalk.green('Telemetry is already enabled.'))
-    console.log(chalk.dim(`  Anonymous ID tail: ${idTail(t.anonymousId)}`))
-    return
-  }
-
-  const now = new Date().toISOString()
-  const updated: TelemetryManifest = {
-    ...t,
-    enabled: true,
-    anonymousId: t.anonymousId ?? generateAnonymousId(),
-    anonymousIdCreatedAt: t.anonymousIdCreatedAt ?? now,
-    scope: t.scope ?? 'personal',
-    endpoint: t.endpoint ?? DEFAULT_ENDPOINT,
-  }
-
-  await saveManifest({ ...manifest, telemetry: updated })
-
-  console.log(chalk.green('Telemetry enabled.'))
-  console.log()
-  console.log(
-    'Skillsmith telemetry collects anonymous skill-invocation counts to help improve\n' +
-      'the registry and surface stale skills. No personal data, file contents, or\n' +
-      `paths are captured. Full privacy policy: ${chalk.cyan(PRIVACY_URL)}`
-  )
-  console.log()
-  console.log(chalk.dim(`  Anonymous ID tail: ${idTail(updated.anonymousId)}`))
-  console.log(chalk.dim('  Disable at any time: ') + chalk.cyan('skillsmith telemetry disable'))
-}
-
-// ---------------------------------------------------------------------------
-// disable
-// ---------------------------------------------------------------------------
-
-async function runDisable(): Promise<void> {
-  const manifest = await loadManifest()
-  const t: TelemetryManifest = manifest.telemetry ?? { enabled: false }
-
-  if (!t.enabled) {
-    console.log(chalk.dim('Telemetry is already disabled.'))
-    return
-  }
-
-  await saveManifest({ ...manifest, telemetry: { ...t, enabled: false } })
-
-  console.log(chalk.yellow('Telemetry disabled.'))
-  console.log(
-    chalk.dim(
-      '  The anonymous ID is retained in the local manifest for continuity if you re-enable.\n' +
-        '  To fully clear it: skillsmith telemetry reset-id'
-    )
-  )
-}
-
-// ---------------------------------------------------------------------------
-// status
-// ---------------------------------------------------------------------------
-
-async function runStatus(): Promise<void> {
-  let manifest = await loadManifest()
-  let rotationTriggered = false
-
-  // Annual auto-rotation (plan line 706, 713)
-  if (shouldRotateAnonymousId(manifest)) {
-    const rotated = rotateAnonymousId(manifest)
-    manifest = { ...manifest, telemetry: rotated }
-    await saveManifest(manifest)
-    rotationTriggered = true
-  }
-
-  // Sweep expired previous id
-  const swept = sweepExpiredPreviousId(manifest)
-  if (swept !== manifest.telemetry) {
-    manifest = { ...manifest, telemetry: swept }
-    await saveManifest(manifest)
-  }
-
-  // GC orphan run files (plan line 714)
-  gcOrphanRunFiles()
-
-  const t: TelemetryManifest = manifest.telemetry ?? { enabled: false }
-  const endpoint = t.endpoint ?? DEFAULT_ENDPOINT
-
-  let ageDays: number | null = null
-  if (t.anonymousIdCreatedAt) {
-    ageDays = Math.floor((Date.now() - new Date(t.anonymousIdCreatedAt).getTime()) / 86_400_000)
-  }
-
-  console.log(chalk.bold('Skillsmith Telemetry Status'))
-  console.log()
-  console.log(`  Enabled:          ${t.enabled ? chalk.green('yes') : chalk.dim('no')}`)
-  console.log(`  Endpoint:         ${chalk.dim(endpoint)}`)
-  console.log(`  Anonymous ID:     ${chalk.dim(idTail(t.anonymousId))}`)
-  console.log(`  ID age (days):    ${ageDays !== null ? String(ageDays) : chalk.dim('n/a')}`)
-  console.log(`  Scope:            ${t.scope ?? chalk.dim('personal')}`)
-
-  if (t.installedAt) {
-    console.log(`  Hook installed:   ${chalk.dim(t.installedAt)}`)
-  }
-
-  if (rotationTriggered) {
-    console.log()
-    console.log(
-      chalk.yellow('  Annual rotation triggered.') +
-        chalk.dim(' New ID tail: ') +
-        chalk.cyan(idTail(t.anonymousId))
-    )
-    if (t.previousAnonymousId) {
-      console.log(
-        chalk.dim(
-          `  Previous ID retained for 7-day overlap window (retired: ${t.previousAnonymousIdRetiredAt ?? 'unknown'})`
-        )
-      )
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// install-hook
-// ---------------------------------------------------------------------------
-
-async function runInstallHook(options: {
-  scope: 'user' | 'project'
-  endpoint?: string
-}): Promise<void> {
-  // Resolve the template source — relative to this file's compiled output.
-  // src/commands/telemetry.ts → ../../templates/skill-telemetry.sh (via dist/commands)
-  // and one level up for the src layout during tests.
-  const templateCandidates = [
-    join(__dirname, '..', '..', 'templates', 'skill-telemetry.sh'),
-    join(__dirname, '..', 'templates', 'skill-telemetry.sh'),
-  ]
-  const templateSrc = templateCandidates.find((p) => existsSync(p))
-  if (!templateSrc) {
-    throw new Error(
-      'skill-telemetry.sh template not found. ' +
-        'Ensure the CLI package is fully built: npm run build'
-    )
-  }
-
-  // Load + validate settings.json — throws TelemetryHookError on foreign Skill matcher
-  const scope = options.scope
-  const settings = loadClaudeSettings(scope)
-  const hookPath = hookScriptPath()
-  const updated = addSkillHookEntries(settings, hookPath)
-
-  // Copy hook script to ~/.skillsmith/hooks/
-  const destPath = hookScriptPath()
-  const hooksDir = dirname(destPath)
-  mkdirSync(hooksDir, { recursive: true, mode: 0o700 })
-  copyFileSync(templateSrc, destPath)
-  try {
-    chmodSync(destPath, 0o755)
-  } catch {
-    // best-effort on Windows
-  }
-
-  // Persist settings.json atomically
-  writeClaudeSettings(scope, updated)
-
-  // Record installation timestamp in manifest
-  const manifest = await loadManifest()
-  const t: TelemetryManifest = manifest.telemetry ?? { enabled: false }
-  await saveManifest({ ...manifest, telemetry: { ...t, installedAt: new Date().toISOString() } })
-
-  // Update endpoint in manifest if provided
-  if (options.endpoint) {
-    const m2 = await loadManifest()
-    const t2 = m2.telemetry ?? { enabled: false }
-    await saveManifest({ ...m2, telemetry: { ...t2, endpoint: options.endpoint } })
-  }
-
-  const scopeLabel = scope === 'user' ? '~/.claude/settings.json' : './.claude/settings.json'
-  console.log(chalk.green('Skillsmith telemetry hook installed.'))
-  console.log(chalk.dim(`  Hook script:   ${destPath}`))
-  console.log(chalk.dim(`  Settings file: ${scopeLabel}`))
-  console.log()
-  console.log(
-    chalk.dim('Enable telemetry to start collecting: ') + chalk.cyan('skillsmith telemetry enable')
-  )
-}
-
-// ---------------------------------------------------------------------------
-// uninstall-hook
-// ---------------------------------------------------------------------------
-
-async function runUninstallHook(options: { scope: 'user' | 'project' }): Promise<void> {
-  const scope = options.scope
-  const hookPath = hookScriptPath()
-  const settings = loadClaudeSettings(scope)
-  const updated = removeSkillHookEntries(settings, hookPath)
-  writeClaudeSettings(scope, updated)
-
-  // Optionally remove the script file
-  try {
-    const scriptPath = hookScriptPath()
-    if (existsSync(scriptPath)) unlinkSync(scriptPath)
-  } catch {
-    // best-effort
-  }
-
-  const scopeLabel = scope === 'user' ? '~/.claude/settings.json' : './.claude/settings.json'
-  console.log(chalk.yellow('Skillsmith telemetry hook removed.'))
-  console.log(chalk.dim(`  Removed from: ${scopeLabel}`))
-  console.log(chalk.dim('  Foreign hooks (if any) were not touched.'))
-}
-
-// ---------------------------------------------------------------------------
-// reset-id
-// ---------------------------------------------------------------------------
-
-async function runResetId(): Promise<void> {
-  const manifest = await loadManifest()
-  const rotated = rotateAnonymousId(manifest) // unconditional rotation
-  await saveManifest({ ...manifest, telemetry: rotated })
-
-  console.log(chalk.green('Anonymous ID rotated.'))
-  console.log(chalk.dim(`  New ID tail:      ${idTail(rotated.anonymousId)}`))
-  if (rotated.previousAnonymousId) {
-    console.log(chalk.dim(`  Previous ID tail: ${idTail(rotated.previousAnonymousId)}`))
-    console.log(
-      chalk.dim(
-        `  Previous ID retirement: ${rotated.previousAnonymousIdRetiredAt ?? 'unknown'} (7-day overlap window)`
-      )
-    )
-  }
-}
+  telemetryEnableAction,
+  telemetryDisableAction,
+  telemetryStatusAction,
+  telemetryInstallHookAction,
+  telemetryUninstallHookAction,
+  telemetryResetIdAction,
+} from './telemetry.action.js'
 
 // ---------------------------------------------------------------------------
 // Command factory
@@ -347,38 +48,17 @@ export function createTelemetryCommand(): Command {
   telemetry
     .command('enable')
     .description('Opt in to anonymous skill-invocation telemetry')
-    .action(async () => {
-      try {
-        await runEnable()
-      } catch (err) {
-        console.error(chalk.red('Error:'), sanitizeError(err))
-        process.exit(1)
-      }
-    })
+    .action(telemetryEnableAction)
 
   telemetry
     .command('disable')
     .description('Opt out of telemetry (anonymous ID is retained for re-enable continuity)')
-    .action(async () => {
-      try {
-        await runDisable()
-      } catch (err) {
-        console.error(chalk.red('Error:'), sanitizeError(err))
-        process.exit(1)
-      }
-    })
+    .action(telemetryDisableAction)
 
   telemetry
     .command('status')
     .description('Show current telemetry state; triggers annual ID rotation if due')
-    .action(async () => {
-      try {
-        await runStatus()
-      } catch (err) {
-        console.error(chalk.red('Error:'), sanitizeError(err))
-        process.exit(1)
-      }
-    })
+    .action(telemetryStatusAction)
 
   telemetry
     .command('install-hook')
@@ -389,51 +69,29 @@ export function createTelemetryCommand(): Command {
       'user'
     )
     .option('--endpoint <url>', 'Override the telemetry endpoint (default: prod Supabase events)')
-    .action(async (options: { scope: string; endpoint?: string }) => {
-      const scope = options.scope === 'project' ? 'project' : 'user'
-      try {
-        await runInstallHook(
-          options.endpoint !== undefined ? { scope, endpoint: options.endpoint } : { scope }
-        )
-      } catch (err) {
-        if (err instanceof TelemetryHookError) {
-          console.error(chalk.red(`Error [${err.code}]:`))
-          console.error(err.message)
-        } else {
-          console.error(chalk.red('Error:'), sanitizeError(err))
-        }
-        process.exit(1)
-      }
-    })
+    .action(telemetryInstallHookAction)
 
   telemetry
     .command('uninstall-hook')
     .description('Remove the Skillsmith Skill hook entries from settings.json')
     .option('--scope <scope>', 'Settings scope: user or project', 'user')
-    .action(async (options: { scope: string }) => {
-      const scope = options.scope === 'project' ? 'project' : 'user'
-      try {
-        await runUninstallHook({ scope })
-      } catch (err) {
-        console.error(chalk.red('Error:'), sanitizeError(err))
-        process.exit(1)
-      }
-    })
+    .action(telemetryUninstallHookAction)
 
   telemetry
     .command('reset-id')
     .description('Immediately rotate the anonymous ID (previous ID kept for 7-day overlap window)')
-    .action(async () => {
-      try {
-        await runResetId()
-      } catch (err) {
-        console.error(chalk.red('Error:'), sanitizeError(err))
-        process.exit(1)
-      }
-    })
+    .action(telemetryResetIdAction)
 
   return telemetry
 }
 
-// Internal exports for tests
-export { runEnable, runDisable, runStatus, runInstallHook, runUninstallHook, runResetId, idTail }
+// Internal exports for tests — sourced from telemetry.action.ts (SMI-5128 split).
+export {
+  runEnable,
+  runDisable,
+  runStatus,
+  runInstallHook,
+  runUninstallHook,
+  runResetId,
+  idTail,
+} from './telemetry.action.js'


### PR DESCRIPTION
## Summary
- SMI-5083 batch 2 (SMI-5128), final batch D. Wraps the remaining 12 CLI handlers, completing CLI command telemetry coverage (24 → **36 dispatchers**).
  - `audit-collisions`: `collisions`
  - `audit`: `advisories` + `audit` (parent action now uses commander's `command.help()` — the 3rd action arg — in place of the closure's `audit.help()`)
  - `manage`: `list` + `update` + `remove`
  - `telemetry`: 6 subcommands extracted to a new **`telemetry.action.ts`** sibling (439 LOC + 6 wraps would breach the 500 gate); `telemetry.ts` keeps the factory + re-exports the `run*`/`idTail` test helpers. Mirrors the SMI-5127 `sync.action.ts` split (self-contained, no import cycle).

## Verification (host-side)
- `tsc -p packages/cli` clean; eslint clean; prettier clean.
- `telemetry-coverage.test.ts` passes — 36 dispatchers, all `isTelemetered()`.
- **`telemetry.test.ts` (19 tests) passes** — confirms the split preserved behavior and the `run*`/`idTail` re-export path.
- All files <500 LOC (audit 269, audit-collisions 408, manage 426, telemetry 97, telemetry.action 436).

## Notes
- Pure extraction (+ the `audit.help()`→`command.help()` equivalence). No `any`; explicit param types.
- Pushed with the documented worktree hook bypass (`core.hooksPath=/dev/null`): host pre-push false-fails on native-sqlite suites; CLI-only change, clean-Docker CI is the gate.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)