### PR TITLE
feat(cli): SMI-5129 — wrap author/ subcommand handlers with telemetry

### DIFF
--- a/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/cli/src/commands/__meta__/telemetry-coverage.test.ts
@@ -66,6 +66,11 @@ const CLI_DISPATCHER_MAP: Record<string, string[]> = {
     'telemetryUninstallHookAction',
     'telemetryResetIdAction',
   ],
+  // SMI-5129: author/ subcommands (init split to init.action.ts)
+  'author/init.action': ['initAction', 'validateAction', 'publishAction'],
+  'author/mcp-init': ['mcpInitAction'],
+  'author/subagent': ['subagentAction'],
+  'author/transform': ['transformAction'],
 }
 
 const EXPECTED_TOTAL = Object.values(CLI_DISPATCHER_MAP).reduce((n, arr) => n + arr.length, 0)

--- a/packages/cli/src/commands/author/index.ts
+++ b/packages/cli/src/commands/author/index.ts
@@ -10,10 +10,10 @@
  */
 
 // Re-export command creators
+// SMI-5129: the command factories moved to init.action.ts (sibling-split);
+// the logic functions + types stay in init.ts.
+export { createInitCommand, createValidateCommand, createPublishCommand } from './init.action.js'
 export {
-  createInitCommand,
-  createValidateCommand,
-  createPublishCommand,
   initSkill,
   validateSkill,
   publishSkill,

--- a/packages/cli/src/commands/author/init.action.ts
+++ b/packages/cli/src/commands/author/init.action.ts
@@ -1,0 +1,154 @@
+/**
+ * @fileoverview `skillsmith author init|validate|publish` command factories +
+ *   withTelemetry-wrapped action handlers.
+ * @module @skillsmith/cli/commands/author/init.action
+ * @see SMI-5129 — sibling-split of init.ts so the 3 author handlers can be
+ *   wrapped without init.ts exceeding the 500-LOC gate. Mirrors the
+ *   sync.action.ts / telemetry.action.ts convention (SMI-5127/SMI-5128): the
+ *   business logic (initSkill/validateSkill/publishSkill) stays in init.ts;
+ *   the commander factories + wrapped actions live here. One-way import
+ *   (init.action → init), so no import cycle.
+ */
+
+import { Command } from 'commander'
+import chalk from 'chalk'
+import { withTelemetry } from '@skillsmith/core/telemetry'
+
+import { sanitizeError } from '../../utils/sanitize.js'
+import { InitSkillError } from '../../utils/errors.js'
+import { initSkill, validateSkill, publishSkill } from './init.js'
+
+// ---------------------------------------------------------------------------
+// init
+// ---------------------------------------------------------------------------
+
+async function initActionImpl(
+  name: string | undefined,
+  opts: Record<string, string | boolean | undefined>
+): Promise<void> {
+  const targetPath = (opts['path'] as string) || '.'
+
+  try {
+    await initSkill(name, targetPath, {
+      description: opts['description'] as string | undefined,
+      author: opts['author'] as string | undefined,
+      category: opts['category'] as string | undefined,
+      yes: opts['yes'] as boolean | undefined,
+    })
+  } catch (error) {
+    // SMI-4314: typed InitSkillError → user-facing message is already
+    // composed (and chalk-styled); print it verbatim and exit with the
+    // requested code. Anything else is an unexpected bug — route
+    // through sanitizeError with the generic prefix.
+    if (error instanceof InitSkillError) {
+      console.error(error.message)
+      process.exit(error.exitCode)
+    }
+    console.error(chalk.red('Error initializing skill:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const initAction = withTelemetry(initActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'author init',
+  extractFramework: () => 'cli',
+})
+
+/**
+ * Create init command
+ * SMI-1473: Added non-interactive flags for E2E testing
+ */
+export function createInitCommand(): Command {
+  return new Command('init')
+    .description('Initialize a new skill directory')
+    .argument('[name]', 'Skill name')
+    .option('-p, --path <path>', 'Target directory', '.')
+    .option('-d, --description <description>', 'Skill description (non-interactive)')
+    .option('-a, --author <author>', 'Skill author (non-interactive)')
+    .option(
+      '-c, --category <category>',
+      'Skill category: development|productivity|communication|data|security|other (non-interactive)'
+    )
+    .option('-y, --yes', 'Auto-confirm overwrite (non-interactive)')
+    .action(initAction)
+}
+
+// ---------------------------------------------------------------------------
+// validate
+// ---------------------------------------------------------------------------
+
+async function validateActionImpl(skillPath: string): Promise<void> {
+  try {
+    const valid = await validateSkill(skillPath)
+    process.exit(valid ? 0 : 1)
+  } catch (error) {
+    console.error(chalk.red('Error validating skill:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const validateAction = withTelemetry(validateActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'author validate',
+  extractFramework: () => 'cli',
+})
+
+/**
+ * Create validate command
+ */
+export function createValidateCommand(): Command {
+  return new Command('validate')
+    .description('Validate a local SKILL.md file')
+    .argument('[path]', 'Path to SKILL.md or skill directory', '.')
+    .action(validateAction)
+}
+
+// ---------------------------------------------------------------------------
+// publish
+// ---------------------------------------------------------------------------
+
+async function publishActionImpl(
+  skillPath: string,
+  opts: Record<string, string | boolean | undefined>
+): Promise<void> {
+  try {
+    const referencePatterns = opts['referencePatterns']
+      ? String(opts['referencePatterns'])
+          .split(',')
+          .map((p) => p.trim())
+      : undefined
+    // SMI-2444: Use conditional spread to satisfy exactOptionalPropertyTypes
+    const success = await publishSkill(skillPath, {
+      ...(opts['checkReferences'] !== undefined && {
+        checkReferences: opts['checkReferences'] as boolean,
+      }),
+      ...(referencePatterns !== undefined && { referencePatterns }),
+    })
+    process.exit(success ? 0 : 1)
+  } catch (error) {
+    console.error(chalk.red('Error publishing skill:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const publishAction = withTelemetry(publishActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'author publish',
+  extractFramework: () => 'cli',
+})
+
+/**
+ * Create publish command
+ */
+export function createPublishCommand(): Command {
+  return new Command('publish')
+    .description('Prepare skill for sharing')
+    .argument('[path]', 'Path to skill directory', '.')
+    .option('--check-references', 'Scan for project-specific references before publishing')
+    .option(
+      '--reference-patterns <patterns>',
+      'Additional regex patterns to check (comma-separated)'
+    )
+    .action(publishAction)
+}

--- a/packages/cli/src/commands/author/init.ts
+++ b/packages/cli/src/commands/author/init.ts
@@ -5,7 +5,6 @@
  * Commands for creating, validating, and publishing skills.
  */
 
-import { Command } from 'commander'
 import { input, confirm, select } from '@inquirer/prompts'
 import chalk from 'chalk'
 import ora from 'ora'
@@ -394,97 +393,6 @@ export async function publishSkill(
   }
 }
 
-/**
- * Create init command
- * SMI-1473: Added non-interactive flags for E2E testing
- */
-export function createInitCommand(): Command {
-  return new Command('init')
-    .description('Initialize a new skill directory')
-    .argument('[name]', 'Skill name')
-    .option('-p, --path <path>', 'Target directory', '.')
-    .option('-d, --description <description>', 'Skill description (non-interactive)')
-    .option('-a, --author <author>', 'Skill author (non-interactive)')
-    .option(
-      '-c, --category <category>',
-      'Skill category: development|productivity|communication|data|security|other (non-interactive)'
-    )
-    .option('-y, --yes', 'Auto-confirm overwrite (non-interactive)')
-    .action(
-      async (name: string | undefined, opts: Record<string, string | boolean | undefined>) => {
-        const targetPath = (opts['path'] as string) || '.'
-
-        try {
-          await initSkill(name, targetPath, {
-            description: opts['description'] as string | undefined,
-            author: opts['author'] as string | undefined,
-            category: opts['category'] as string | undefined,
-            yes: opts['yes'] as boolean | undefined,
-          })
-        } catch (error) {
-          // SMI-4314: typed InitSkillError → user-facing message is already
-          // composed (and chalk-styled); print it verbatim and exit with the
-          // requested code. Anything else is an unexpected bug — route
-          // through sanitizeError with the generic prefix.
-          if (error instanceof InitSkillError) {
-            console.error(error.message)
-            process.exit(error.exitCode)
-          }
-          console.error(chalk.red('Error initializing skill:'), sanitizeError(error))
-          process.exit(1)
-        }
-      }
-    )
-}
-
-/**
- * Create validate command
- */
-export function createValidateCommand(): Command {
-  return new Command('validate')
-    .description('Validate a local SKILL.md file')
-    .argument('[path]', 'Path to SKILL.md or skill directory', '.')
-    .action(async (skillPath: string) => {
-      try {
-        const valid = await validateSkill(skillPath)
-        process.exit(valid ? 0 : 1)
-      } catch (error) {
-        console.error(chalk.red('Error validating skill:'), sanitizeError(error))
-        process.exit(1)
-      }
-    })
-}
-
-/**
- * Create publish command
- */
-export function createPublishCommand(): Command {
-  return new Command('publish')
-    .description('Prepare skill for sharing')
-    .argument('[path]', 'Path to skill directory', '.')
-    .option('--check-references', 'Scan for project-specific references before publishing')
-    .option(
-      '--reference-patterns <patterns>',
-      'Additional regex patterns to check (comma-separated)'
-    )
-    .action(async (skillPath: string, opts: Record<string, string | boolean | undefined>) => {
-      try {
-        const referencePatterns = opts['referencePatterns']
-          ? String(opts['referencePatterns'])
-              .split(',')
-              .map((p) => p.trim())
-          : undefined
-        // SMI-2444: Use conditional spread to satisfy exactOptionalPropertyTypes
-        const success = await publishSkill(skillPath, {
-          ...(opts['checkReferences'] !== undefined && {
-            checkReferences: opts['checkReferences'] as boolean,
-          }),
-          ...(referencePatterns !== undefined && { referencePatterns }),
-        })
-        process.exit(success ? 0 : 1)
-      } catch (error) {
-        console.error(chalk.red('Error publishing skill:'), sanitizeError(error))
-        process.exit(1)
-      }
-    })
-}
+// SMI-5129: the `init` / `validate` / `publish` command factories + their
+// withTelemetry-wrapped actions live in ./init.action.ts (sibling-split to keep
+// this file under the 500-LOC gate). They import the logic functions above.

--- a/packages/cli/src/commands/author/mcp-init.ts
+++ b/packages/cli/src/commands/author/mcp-init.ts
@@ -7,6 +7,7 @@
 import { Command } from 'commander'
 import { input, confirm } from '@inquirer/prompts'
 import chalk from 'chalk'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import ora from 'ora'
 import { mkdir, writeFile, stat } from 'fs/promises'
 import { dirname, join, resolve } from 'path'
@@ -206,6 +207,29 @@ export async function initMcpServer(
   }
 }
 
+// SMI-5129: extracted from inline .action() closure so withTelemetry can wrap it.
+async function mcpInitActionImpl(
+  name: string | undefined,
+  opts: Record<string, string | boolean | undefined>
+): Promise<void> {
+  try {
+    await initMcpServer(name, {
+      output: opts['output'] as string | undefined,
+      tools: opts['tools'] as string | undefined,
+      force: opts['force'] as boolean | undefined,
+    })
+  } catch (error) {
+    console.error(chalk.red('Error creating MCP server:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const mcpInitAction = withTelemetry(mcpInitActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'author mcp-init',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create mcp-init command
  */
@@ -216,18 +240,5 @@ export function createMcpInitCommand(): Command {
     .option('-o, --output <path>', 'Output directory')
     .option('--tools <tools>', 'Initial tools (comma-separated)')
     .option('--force', 'Overwrite existing directory')
-    .action(
-      async (name: string | undefined, opts: Record<string, string | boolean | undefined>) => {
-        try {
-          await initMcpServer(name, {
-            output: opts['output'] as string | undefined,
-            tools: opts['tools'] as string | undefined,
-            force: opts['force'] as boolean | undefined,
-          })
-        } catch (error) {
-          console.error(chalk.red('Error creating MCP server:'), sanitizeError(error))
-          process.exit(1)
-        }
-      }
-    )
+    .action(mcpInitAction)
 }

--- a/packages/cli/src/commands/author/subagent.ts
+++ b/packages/cli/src/commands/author/subagent.ts
@@ -6,6 +6,7 @@
 
 import { Command } from 'commander'
 import chalk from 'chalk'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import ora from 'ora'
 import { readFile, writeFile, stat } from 'fs/promises'
 import { basename, dirname, join, resolve } from 'path'
@@ -174,6 +175,31 @@ export async function generateSubagent(skillPath: string, options: SubagentOptio
   }
 }
 
+// SMI-5129: extracted from inline .action() closure so withTelemetry can wrap it.
+async function subagentActionImpl(
+  skillPath: string,
+  opts: Record<string, string | boolean | undefined>
+): Promise<void> {
+  try {
+    await generateSubagent(skillPath, {
+      output: opts['output'] as string | undefined,
+      tools: opts['tools'] as string | undefined,
+      model: opts['model'] as string | undefined,
+      skipClaudeMd: opts['skipClaudeMd'] as boolean | undefined,
+      force: opts['force'] as boolean | undefined,
+    })
+  } catch (error) {
+    console.error(chalk.red('Error generating subagent:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const subagentAction = withTelemetry(subagentActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'author subagent',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create subagent command
  */
@@ -186,18 +212,5 @@ export function createSubagentCommand(): Command {
     .option('--model <model>', 'Model for subagent: sonnet|opus|haiku', 'sonnet')
     .option('--skip-claude-md', 'Skip CLAUDE.md snippet generation')
     .option('--force', 'Overwrite existing subagent definition')
-    .action(async (skillPath: string, opts: Record<string, string | boolean | undefined>) => {
-      try {
-        await generateSubagent(skillPath, {
-          output: opts['output'] as string | undefined,
-          tools: opts['tools'] as string | undefined,
-          model: opts['model'] as string | undefined,
-          skipClaudeMd: opts['skipClaudeMd'] as boolean | undefined,
-          force: opts['force'] as boolean | undefined,
-        })
-      } catch (error) {
-        console.error(chalk.red('Error generating subagent:'), sanitizeError(error))
-        process.exit(1)
-      }
-    })
+    .action(subagentAction)
 }

--- a/packages/cli/src/commands/author/transform.ts
+++ b/packages/cli/src/commands/author/transform.ts
@@ -6,6 +6,7 @@
 
 import { Command } from 'commander'
 import chalk from 'chalk'
+import { withTelemetry } from '@skillsmith/core/telemetry'
 import ora from 'ora'
 import { readFile, readdir } from 'fs/promises'
 import { join, resolve } from 'path'
@@ -139,6 +140,31 @@ export async function transformSkill(skillPath: string, options: TransformOption
   }
 }
 
+// SMI-5129: extracted from inline .action() closure so withTelemetry can wrap it.
+async function transformActionImpl(
+  skillPath: string,
+  opts: Record<string, string | boolean | undefined>
+): Promise<void> {
+  try {
+    await transformSkill(skillPath, {
+      dryRun: opts['dryRun'] as boolean | undefined,
+      force: opts['force'] as boolean | undefined,
+      batch: opts['batch'] as boolean | undefined,
+      tools: opts['tools'] as string | undefined,
+      model: opts['model'] as string | undefined,
+    })
+  } catch (error) {
+    console.error(chalk.red('Error transforming skill:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const transformAction = withTelemetry(transformActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'author transform',
+  extractFramework: () => 'cli',
+})
+
 /**
  * Create transform command
  */
@@ -151,18 +177,5 @@ export function createTransformCommand(): Command {
     .option('--batch', 'Process directory of skills')
     .option('--tools <tools>', 'Override detected tools (comma-separated)')
     .option('--model <model>', 'Model for subagent: sonnet|opus|haiku', 'sonnet')
-    .action(async (skillPath: string, opts: Record<string, string | boolean | undefined>) => {
-      try {
-        await transformSkill(skillPath, {
-          dryRun: opts['dryRun'] as boolean | undefined,
-          force: opts['force'] as boolean | undefined,
-          batch: opts['batch'] as boolean | undefined,
-          tools: opts['tools'] as string | undefined,
-          model: opts['model'] as string | undefined,
-        })
-      } catch (error) {
-        console.error(chalk.red('Error transforming skill:'), sanitizeError(error))
-        process.exit(1)
-      }
-    })
+    .action(transformAction)
 }

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -371,7 +371,8 @@ describe('SMI-4314: createInitCommand wrapper maps errors to exit codes', () => 
   })
 
   it('InitSkillError → prints err.message exactly once and exits with err.exitCode', async () => {
-    const { createInitCommand } = await import('../src/commands/author/init.js')
+    // SMI-5129: createInitCommand moved to init.action.ts (sibling-split).
+    const { createInitCommand } = await import('../src/commands/author/init.action.js')
 
     const cmd = createInitCommand()
     // commander treats process.exit inside .action as a real exit; our stub


### PR DESCRIPTION
## Summary
- SMI-5083 batch 3 (SMI-5129). Wraps the 6 `author` subcommand handlers with `withTelemetry`, namespaced under the `author` parent command (`author init`, `author validate`, `author publish`, `author mcp-init`, `author subagent`, `author transform`).
- `init.ts` was 490 LOC → split: logic (`initSkill`/`validateSkill`/`publishSkill`) stays in `init.ts`; the 3 factories + wrapped actions move to a new **`author/init.action.ts`** (one-way import, no cycle). `index.ts` re-exports the factories from `init.action.js`; `init.test.ts` updated to import `createInitCommand` from the new location.
- `mcp-init`, `subagent`, `transform`: in-file wraps.
- CLI_DISPATCHER_MAP coverage 36 → **42 dispatchers**.

## Verification (host-side)
- `tsc -p packages/cli` clean; eslint clean; prettier clean.
- `telemetry-coverage.test.ts` passes (42 dispatchers, all `isTelemetered()`); `init.test.ts` (15 tests) passes — confirms the SMI-4314 `InitSkillError`→exit-code behavior survives the split.
- All files <500 (init.ts 398, init.action.ts 151, mcp-init 244, subagent 216, transform 181).
- Note: `skills-directory.test.ts` shows 5 host-side failures from the WASM/native-sqlite fallback (`native better-sqlite3 not loaded`) — pre-existing, unrelated to this diff (that suite imports nothing from `author/`). Clean-Docker CI is the gate.

## Notes
- Pure extraction; no `any`. Pushed with the documented worktree hook bypass (`core.hooksPath=/dev/null`).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)