### PR TITLE
fix(cli): SMI-5139 — open version-lookup DB read-only (WASM EROFS on close)

### DIFF
--- a/packages/cli/src/utils/open-database.ts
+++ b/packages/cli/src/utils/open-database.ts
@@ -29,9 +29,26 @@ import { existsSync } from 'node:fs'
  * bare `createDatabaseAsync` directly.
  *
  * @param path - Filesystem path to the SQLite database (e.g. `DEFAULT_DB_PATH`).
- * @returns A connected, schema-initialized database. Caller owns `db.close()`.
+ * @param options.readonly - SMI-5139: open read-only for pure-read consumers
+ *   (e.g. version lookups). A read-only handle CANNOT run schema DDL, so
+ *   `initializeSchema` is skipped — the caller must tolerate an absent schema
+ *   (queries on a missing table throw, which read consumers already catch).
+ *   This also prevents the WASM `SqlJsDatabaseAdapter` from persisting (writing)
+ *   on `close()`, which would throw `EROFS` on an unwritable/absent db path.
+ * @returns A connected database. Caller owns `db.close()`.
  */
-export async function openCliDatabase(path: string): Promise<DatabaseType> {
+export async function openCliDatabase(
+  path: string,
+  options?: { readonly?: boolean }
+): Promise<DatabaseType> {
+  // SMI-5139: read-only consumers open read-only and skip schema init (DDL is
+  // impossible on a read-only handle; sql.js close() then skips persist()).
+  // The open itself may throw (native better-sqlite3 read-only-opens of an
+  // absent file throw) — that is the caller's signal to degrade gracefully.
+  if (options?.readonly) {
+    return createDatabaseAsync(path, { readonly: true })
+  }
+
   let db: DatabaseType | undefined
   try {
     db = await createDatabaseAsync(path)

--- a/packages/cli/src/utils/skills-directory.ts
+++ b/packages/cli/src/utils/skills-directory.ts
@@ -76,7 +76,11 @@ export async function getSkillsFromDirectory(
   let dbConn: Database | null = null
   if (dbPath) {
     try {
-      dbConn = await openCliDatabase(dbPath)
+      // SMI-5139: this is a pure-read version lookup — open read-only so the
+      // WASM driver does not persist (write) on close() and throw EROFS when
+      // dbPath is unwritable/absent. A read-only open of an absent db throws
+      // (native driver), which the catch below degrades to hasUpdates: false.
+      dbConn = await openCliDatabase(dbPath, { readonly: true })
       versionRepo = new SkillVersionRepository(dbConn)
     } catch {
       // DB not available yet — fall back to hasUpdates: false


### PR DESCRIPTION
## Summary
- Fixes a real WASM-driver bug surfaced by `skills-directory.test.ts` (5 failures host-side; invisible in CI because Docker uses native better-sqlite3).
- `getSkillsFromDirectory()` opened the DB **read-write** (via `openCliDatabase` → `initializeSchema`) just to **read** `skill_versions`. The WASM `SqlJsDatabaseAdapter.close()` calls `persist()` → `writeFileSync(dbPath)`, throwing `EROFS` when `dbPath` is unwritable/absent (e.g. `/nonexistent.db`) — failing all of `getInstalledSkills`. WASM is exactly what real macOS / `npx` installs run.

## Fix (root cause)
- Add a `readonly` option to `openCliDatabase(path, { readonly: true })`: opens via `createDatabaseAsync(path, { readonly: true })` and **skips `initializeSchema`** (DDL can't run on a read-only handle; read consumers tolerate an absent schema). Infra already plumbs `DatabaseOptions.readonly` to both drivers — sql.js `close()` skips `persist()` when `_readonly`; native passes `readonly` to the ctor.
- `getSkillsFromDirectory` opens read-only. The existing `try/catch` already degrades to `versionRepo = null` (→ `hasUpdates: false`) when a read-only open of an absent db throws (native). No db is created as a read side-effect.

## Verification (host-side, WASM)
- `skills-directory.test.ts`: 5 failed → **5 passed**.
- **Full cli suite: 564/564 pass host-side** (these 5 were the only host failures).
- tsc / eslint / prettier clean.
- No regression for real users with an existing writable `~/.skillsmith/skills.db` — `hasUpdates` still computed.

## Notes
- Independent of the SMI-5083 telemetry batches (disjoint files). Discovered during the SMI-5129 host-side full-suite run; user requested it be fixed in-scope.
- Pushed with the documented worktree hook bypass (`core.hooksPath=/dev/null`).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)