### PR TITLE
feat(vscode): SMI-5143 — normalize panel-action skill_ids + wrapper emission test

### DIFF
--- a/.claude/development/skill-invoke-telemetry-guide.md
+++ b/.claude/development/skill-invoke-telemetry-guide.md
@@ -48,12 +48,22 @@ All three in-process surfaces capture skill invocations via a `withTelemetry`
 HOF that brands the wrapped handler so a per-tree coverage test can assert no
 dispatcher ships unwrapped.
 
-| Surface | Wrapper | Coverage test | Status |
-|---------|---------|---------------|--------|
-| MCP tool dispatchers | `@skillsmith/core/telemetry` `withTelemetry` | `packages/mcp-server/src/tools/__meta__/telemetry-coverage.test.ts` (SMI-5018) | Captured |
-| CLI command handlers (42 dispatchers) | `@skillsmith/core/telemetry` `withTelemetry` | `packages/cli/src/commands/__meta__/telemetry-coverage.test.ts` (SMI-5040 + SMI-5128/5129) | Captured |
-| VS Code panel actions (4) | `packages/vscode-extension/src/services/telemetry-wrap.ts` (local; emits `vscode_skill_invoke` via `services/Telemetry.ts`) | `packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts` (SMI-5130) | Captured |
-| Claude Code hook (PreToolUse/PostToolUse) | start-file + hook (not a HOF) | n/a | Captured |
+| Surface | Wrapper | `skill_id` form | Coverage test | Status |
+|---------|---------|-----------------|---------------|--------|
+| MCP tool dispatchers | `@skillsmith/core/telemetry` `withTelemetry` | bare tool name (`search`, `install_skill`) | `packages/mcp-server/src/tools/__meta__/telemetry-coverage.test.ts` (SMI-5018) | Captured |
+| CLI command handlers (42 dispatchers) | `@skillsmith/core/telemetry` `withTelemetry` | bare action name (`search`, `config set`, `author init`) | `packages/cli/src/commands/__meta__/telemetry-coverage.test.ts` (SMI-5040 + SMI-5128/5129) | Captured |
+| VS Code panel actions (4) | `packages/vscode-extension/src/services/telemetry-wrap.ts` (local; emits `vscode_skill_invoke` via `services/Telemetry.ts`) | CLI-aligned action name (`search`/`install`/`remove`/`create`) | `packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts` (SMI-5130) | Captured |
+| Claude Code hook (PreToolUse/PostToolUse) | start-file + hook (not a HOF) | registry `author/name` (`smith-horn/linear`) | n/a | Captured |
+
+### `skill_id` contract (surface-specific)
+
+`skill_id` is **not** uniformly `author/name` — it is the natural identifier for each surface (see the matrix). Only the **Claude Code hook** captures a registry skill, so only it uses `author/name`. The tool surfaces emit the tool/command being invoked:
+
+- **CLI + VS Code emit the same bare action name** (SMI-5143), so the *same* action correlates across surfaces, distinguished only by the `source` field — e.g. `{skill_id:'search', source:'cli'}` vs `{skill_id:'search', source:'vscode-extension'}`.
+- **VS Code `uninstall` → `'remove'`**: the CLI's canonical command is `remove` (`uninstall` is an alias), so `'remove'` is the shared correlation key. The MCP tool stays `uninstall_skill` (distinct — MCP tool names are not normalized).
+- Downstream analytics RPCs aggregate on `metadata.skill_name`, not `skill_id`, so this is forward-looking correlation (not a reporting dependency today).
+
+**`vscode_skill_invoke` is the canonical VS Code invocation count.** Every panel action emits it (uniform). The granular `vscode_create_*` / `vscode_uninstall_*` events are *funnel detail* for those two flows — do **not** sum `vscode_*` to count invocations (that double-counts create/uninstall); count `vscode_skill_invoke` alone.
 
 **Why VS Code uses a local wrapper (SMI-5130):** the extension is bundled
 standalone via `esbuild --bundle` for the Marketplace. Importing the core HOF
@@ -119,6 +129,8 @@ Full payload schema (all fields required unless noted):
   }
 }
 ```
+
+> The example above is a **`claude-code-hook`** payload, so its `skill_id` is the registry `author/name`. `skill_id` is **surface-specific** — see [`skill_id` contract](#skill_id-contract-surface-specific). For tool surfaces it is the tool/command name (`'search'`, `'config set'`), not `author/name`.
 
 Allowed enum values:
 

--- a/packages/vscode-extension/src/commands/createSkillCommand.ts
+++ b/packages/vscode-extension/src/commands/createSkillCommand.ts
@@ -109,7 +109,8 @@ async function createSkillImpl(deps: CreateSkillDeps): Promise<void> {
 
 export const createSkillAction = withTelemetry(createSkillImpl, {
   source: 'vscode-extension',
-  extractSkillId: () => 'skillsmith.createSkill',
+  // SMI-5143: CLI-aligned action name (shared skill_id across CLI + VS Code).
+  extractSkillId: () => 'create',
 })
 
 export function registerCreateSkillCommand(

--- a/packages/vscode-extension/src/commands/installCommand.ts
+++ b/packages/vscode-extension/src/commands/installCommand.ts
@@ -31,7 +31,8 @@ async function installCommandImpl(deps: { skillService: SkillService }): Promise
 
 export const installCommandAction = withTelemetry(installCommandImpl, {
   source: 'vscode-extension',
-  extractSkillId: () => 'skillsmith.installSkill',
+  // SMI-5143: CLI-aligned action name (shared skill_id across CLI + VS Code).
+  extractSkillId: () => 'install',
 })
 
 /**

--- a/packages/vscode-extension/src/commands/searchSkills.ts
+++ b/packages/vscode-extension/src/commands/searchSkills.ts
@@ -99,7 +99,9 @@ async function searchSkillsImpl(deps: SearchSkillsDeps): Promise<void> {
 
 export const searchSkillsAction = withTelemetry(searchSkillsImpl, {
   source: 'vscode-extension',
-  extractSkillId: () => 'skillsmith.searchSkills',
+  // SMI-5143: CLI-aligned action name so the same action shares one skill_id
+  // across CLI + VS Code, split only by `source` (cli vs vscode-extension).
+  extractSkillId: () => 'search',
 })
 
 export function registerSearchCommand(

--- a/packages/vscode-extension/src/commands/uninstallCommand.ts
+++ b/packages/vscode-extension/src/commands/uninstallCommand.ts
@@ -111,7 +111,10 @@ async function uninstallCommandImpl(
 
 export const uninstallCommandAction = withTelemetry(uninstallCommandImpl, {
   source: 'vscode-extension',
-  extractSkillId: () => 'skillsmith.uninstallSkill',
+  // SMI-5143: CLI-aligned action name. The CLI's canonical command is `remove`
+  // (`uninstall` is an alias); the MCP tool stays `uninstall_skill`. `'remove'`
+  // gives CLI↔VS Code correlation for the uninstall action.
+  extractSkillId: () => 'remove',
 })
 
 export function registerUninstallCommand(

--- a/packages/vscode-extension/src/services/telemetry-wrap.test.ts
+++ b/packages/vscode-extension/src/services/telemetry-wrap.test.ts
@@ -1,0 +1,69 @@
+/**
+ * SMI-5143 — behavioral emission tests for the VS Code-local telemetry wrapper.
+ *
+ * The per-tree coverage test (`commands/__meta__/telemetry-coverage.test.ts`) is
+ * brand-only (`isTelemetered`). The core HOF's emission is covered by
+ * `packages/core/src/telemetry/wrap.test.ts`, but the VS Code wrapper
+ * (`telemetry-wrap.ts`) is a separate impl (it can't import the core HOF — the
+ * extension esbuild-bundles standalone), so its emit-via-`track()` path needs
+ * its own behavioral coverage. Mirrors wrap.test.ts's mock-the-emitter pattern.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./Telemetry.js', () => ({ track: vi.fn() }))
+
+import { track } from './Telemetry.js'
+import { withTelemetry, isTelemetered } from './telemetry-wrap.js'
+
+const mockTrack = vi.mocked(track)
+
+beforeEach(() => {
+  mockTrack.mockReset()
+})
+
+describe('SMI-5130/5143: VS Code telemetry-wrap', () => {
+  it('emits vscode_skill_invoke with the normalized skill_id + hardcoded source', async () => {
+    async function impl(x: number): Promise<number> {
+      return x * 2
+    }
+    const wrapped = withTelemetry(impl, {
+      source: 'vscode-extension',
+      extractSkillId: () => 'search',
+    })
+
+    const result = await wrapped(3)
+
+    expect(result).toBe(6)
+    expect(mockTrack).toHaveBeenCalledOnce()
+    expect(mockTrack).toHaveBeenCalledWith('vscode_skill_invoke', {
+      skill_id: 'search',
+      source: 'vscode-extension',
+    })
+  })
+
+  it('marks the wrapped function telemetered (and the impl is not)', () => {
+    async function impl(): Promise<void> {}
+    const wrapped = withTelemetry(impl, {
+      source: 'vscode-extension',
+      extractSkillId: () => 'create',
+    })
+
+    expect(isTelemetered(wrapped)).toBe(true)
+    expect(isTelemetered(impl)).toBe(false)
+  })
+
+  it('does not break the handler when telemetry throws (fire-and-forget)', async () => {
+    mockTrack.mockImplementation(() => {
+      throw new Error('telemetry endpoint down')
+    })
+    async function impl(): Promise<string> {
+      return 'ok'
+    }
+    const wrapped = withTelemetry(impl, {
+      source: 'vscode-extension',
+      extractSkillId: () => 'install',
+    })
+
+    await expect(wrapped()).resolves.toBe('ok')
+  })
+})


### PR DESCRIPTION
## Summary
Addresses two SMI-5083 governance-retro observations (telemetry is dormant by default — `telemetryEndpoint=''`; forward-looking correctness).

- **skill_id consistency (Obs 1):** the 4 VS Code panel actions now emit CLI-aligned bare action names instead of full command ids, so the same action correlates across CLI + VS Code (split only by `source`): `search`, `install`, `remove` (CLI's canonical command; `uninstall` is an alias; MCP's `uninstall_skill` stays distinct), `create`.
- **Docs (Obs 1 + Obs 2):** `skill-invoke-telemetry-guide.md` documents `skill_id` as surface-specific (hook=`author/name`, MCP=tool name, CLI+VS Code=bare action) via a new matrix column + the `uninstall→remove` note, and marks `vscode_skill_invoke` as the canonical VS Code invocation count (granular `vscode_*` = funnel detail — don't sum).
- **Verification:** new `services/telemetry-wrap.test.ts` — behavioral emission test for the VS Code local wrapper (asserts `track('vscode_skill_invoke', {skill_id, source:'vscode-extension'})`, `isTelemetered`, fire-and-forget no-throw). Closes the brand-only gap; core HOF emission already covered by `wrap.test.ts`.

## Safety / verification
- No prod analytics groups/joins on telemetry `skill_id` (RPCs key on `metadata.skill_name`; the one `GROUP BY skill_id` is `metrics-aggregator.ts` on the distinct local SQLite surface). No core/MCP/CLI/edge-function/ALLOWED_EVENTS change.
- Plan-reviewed (sound, no Critical/High/Medium). Emission test (3) + coverage gate (2) + **full extension suite 296/296**; tsc/eslint/prettier/markdownlint clean; esbuild 728.7 KB (no posthog/OTel); `audit:standards` Failed 0 (Check 48a/48b pass).

## Notes
- Obs 3 (audit Check 48c ack) tracked separately as **SMI-5142** (ADR-109-gated).
- Submodule plan-doc inspected — its `author/name` is the hook-payload example (correct), no stale claim to fix.
- Pushed with the documented worktree hook bypass (`core.hooksPath=/dev/null`).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)