### PR TITLE
fix(audit): SMI-5142 — Check 48c honors audit:check-48-ack suppression marker

### DIFF
--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -954,6 +954,45 @@ export function findFunctionDefinitions(srcByPath, symbol) {
 }
 
 /**
+ * Returns `true` if the definition at `line` (1-indexed) in `src` is opted out
+ * of Check 48c via an `audit:check-48-ack` marker — either on the definition
+ * line itself or anywhere in the contiguous comment block immediately preceding
+ * it. The upward walk stops at the first blank OR non-comment line, so a distant
+ * comment carrying the token cannot reach an unrelated definition.
+ *
+ * Why preceding-comment-aware (not same-line only, like 48d): a `withTelemetry`
+ * signature is frequently multi-line (generics + params), so a trailing same-line
+ * marker would fight the formatter. The one legitimate parallel definition
+ * (the esbuild-bundled VS Code extension's local wrapper, which cannot import the
+ * canonical core HOF) carries its ack on the comment block above the def.
+ *
+ * A comment line is one whose trimmed form starts with `//`, `*`, or `/*`.
+ * Detection is substring (`String.prototype.includes`), matching 48d's existing
+ * tradeoff: a def line containing the literal token inside an unrelated string
+ * would be falsely suppressed — narrow, and the audit script excludes itself
+ * from the survey.
+ *
+ * @param {string} src - full file contents
+ * @param {number} line - 1-indexed definition line
+ * @returns {boolean}
+ */
+export function defHasCheck48Ack(src, line) {
+  const lines = src.split('\n')
+  const defIdx = line - 1
+  if (defIdx < 0 || defIdx >= lines.length) return false
+  if (lines[defIdx].includes('audit:check-48-ack')) return true
+  for (let i = defIdx - 1; i >= 0; i--) {
+    const trimmed = lines[i].trim()
+    if (trimmed === '') break
+    const isComment =
+      trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')
+    if (!isComment) break
+    if (lines[i].includes('audit:check-48-ack')) return true
+  }
+  return false
+}
+
+/**
  * Find literal `/tmp/skillsmith-` references in production source. Excludes
  * test files (matching `*.test.*`, `*.spec.*`, `__tests__/`, `tests/`,
  * `_tests_/`, `/e2e/`, `fixtures/`) — those legitimately use the prefix as
@@ -999,7 +1038,10 @@ export function findTmpSkillsmithRefs(srcByPath) {
  * declared sources of truth (no false-positive surface — drift IS the bug).
  * 48c/48d are grep-based heuristics that might over-flag in legitimate
  * edge cases — `warn()` keeps them visible without blocking PRs, matching
- * the false-positive-fatigue guidance in CLAUDE.md governance retros.
+ * the false-positive-fatigue guidance in CLAUDE.md governance retros. Both
+ * honor an `audit:check-48-ack` opt-out marker: 48d per-line (same line as the
+ * reference), 48c on the def line or the comment block immediately above the
+ * parallel definition (see defHasCheck48Ack).
  *
  * @param {object} input
  * @param {string} input.posthogSrc - contents of packages/core/src/telemetry/posthog.ts
@@ -1031,8 +1073,16 @@ export function findConventionDrift(input) {
   const allowedEventsMissing = allowed ? expectedNewEvents.filter((e) => !allowed.has(e)) : []
 
   // 48c: exactly one withTelemetry definition (in canonicalWithTelemetryPath).
+  // A parallel definition can opt out via an `audit:check-48-ack` marker on the
+  // def line or in the comment block immediately above it (genuinely-justified
+  // surfaces, e.g. the esbuild-bundled VS Code extension that cannot import the
+  // core HOF). See defHasCheck48Ack.
   const allDefs = findFunctionDefinitions(surveySrcByPath, 'withTelemetry')
-  const parallelWithTelemetryDefs = allDefs.filter((d) => d.file !== canonicalWithTelemetryPath)
+  const parallelWithTelemetryDefs = allDefs.filter(
+    (d) =>
+      d.file !== canonicalWithTelemetryPath &&
+      !defHasCheck48Ack(surveySrcByPath[d.file] ?? '', d.line)
+  )
 
   // 48d: /tmp/skillsmith- must not appear in production source.
   const tmpSkillsmithRefs = findTmpSkillsmithRefs(surveySrcByPath)

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -4058,10 +4058,11 @@ console.log(`\n${BOLD}48. publish.yml dependent-gate soundness (SMI-5060/SMI-506
 //   48d (warn): /tmp/skillsmith-* not used in production source (M8 — runtime
 //               state lives in ~/.skillsmith/run/, /tmp doesn't survive reboot)
 //
-// Exemption: a per-line comment containing `audit:check-48-ack` opts that
-// line out of 48d (the only sub-check with grep-heuristic false-positive
-// surface). 48a/48b are exact-string set membership against declared sources
-// of truth — there is no legitimate exemption.
+// Exemption: a comment containing `audit:check-48-ack` opts out of the
+// grep-heuristic warns — 48d per-line (same line as the reference) and 48c on
+// the def line or the comment block immediately above the parallel definition.
+// 48a/48b are exact-string set membership against declared sources of truth —
+// there is no legitimate exemption.
 //
 // Severity: 48c/48d are `warn()` for v1 to avoid false-positive fatigue
 // blocking unrelated PRs (CLAUDE.md governance retro guidance). Promote to
@@ -4186,8 +4187,9 @@ console.log(`\n${BOLD}49. Convention drift backstop (SMI-5026 M5)${RESET}`)
           `Check 48c: parallel withTelemetry definition(s) detected — ` +
             `single-source-of-truth violation per SMI-5016 H1:\n${sites}`,
           `The canonical definition is in ${CANONICAL_WRAP_PATH}. Re-export ` +
-            `from there instead of redefining. Suppress a known-false-positive ` +
-            `with \`// audit:check-48-ack\` on the same line (with rationale).`
+            `from there instead of redefining. Suppress a genuinely-justified ` +
+            `parallel definition with \`// audit:check-48-ack <reason>\` on the ` +
+            `definition line or in the comment block immediately above it.`
         )
       }
 

--- a/scripts/tests/audit-standards-convention-drift.test.ts
+++ b/scripts/tests/audit-standards-convention-drift.test.ts
@@ -33,6 +33,7 @@ const helpers = (await import('../audit-standards-helpers.mjs')) as {
     srcByPath: Record<string, string>,
     symbol: string
   ) => { file: string; line: number; snippet: string }[]
+  defHasCheck48Ack: (src: string, line: number) => boolean
   findTmpSkillsmithRefs: (
     srcByPath: Record<string, string>
   ) => { file: string; line: number; snippet: string }[]
@@ -49,6 +50,7 @@ const {
   parseStringUnionType,
   parseTsLiteralArray,
   findFunctionDefinitions,
+  defHasCheck48Ack,
   findTmpSkillsmithRefs,
   findConventionDrift,
 } = helpers
@@ -197,6 +199,71 @@ describe('findFunctionDefinitions', () => {
 })
 
 // ---------------------------------------------------------------------------
+// defHasCheck48Ack (48c opt-out)
+// ---------------------------------------------------------------------------
+
+describe('defHasCheck48Ack', () => {
+  it('honors a marker on the definition line itself', () => {
+    const src = 'export function withTelemetry(fn) { return fn } // audit:check-48-ack inline'
+    expect(defHasCheck48Ack(src, 1)).toBe(true)
+  })
+
+  it('honors a marker in the contiguous // comment block above the def', () => {
+    // Mirrors the real packages/vscode-extension/.../telemetry-wrap.ts shape:
+    // a multi-line // block carrying the token, immediately above the def.
+    const src = [
+      '// audit:check-48-ack — intentional parallel definition: the extension',
+      '// bundles standalone and cannot import the canonical core HOF.',
+      'export function withTelemetry<F>(fn: F): F {',
+    ].join('\n')
+    expect(defHasCheck48Ack(src, 3)).toBe(true)
+  })
+
+  it('honors a marker on a * block-comment continuation line above the def', () => {
+    const src = [
+      '/**',
+      ' * audit:check-48-ack rationale here',
+      ' */',
+      'const withTelemetry = (fn) => fn',
+    ].join('\n')
+    expect(defHasCheck48Ack(src, 4)).toBe(true)
+  })
+
+  it('does NOT honor a marker separated from the def by a blank line', () => {
+    const src = [
+      '// audit:check-48-ack stale',
+      '',
+      'export function withTelemetry(fn) { return fn }',
+    ].join('\n')
+    expect(defHasCheck48Ack(src, 3)).toBe(false)
+  })
+
+  it('does NOT honor a marker separated from the def by a code line (walk stops at non-comment)', () => {
+    const src = [
+      '// audit:check-48-ack from an unrelated symbol',
+      'const unrelated = 1',
+      'export function withTelemetry(fn) { return fn }',
+    ].join('\n')
+    expect(defHasCheck48Ack(src, 3)).toBe(false)
+  })
+
+  it('does NOT honor a marker on an unrelated distant line', () => {
+    const src = [
+      '// audit:check-48-ack',
+      'const a = 1',
+      'const b = 2',
+      'function withTelemetry() {}',
+    ].join('\n')
+    expect(defHasCheck48Ack(src, 4)).toBe(false)
+  })
+
+  it('returns false for an out-of-range line', () => {
+    expect(defHasCheck48Ack('const x = 1', 99)).toBe(false)
+    expect(defHasCheck48Ack('const x = 1', 0)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // findTmpSkillsmithRefs
 // ---------------------------------------------------------------------------
 
@@ -299,6 +366,56 @@ export interface Foo {}`
   })
 
   it('flags a parallel withTelemetry definition (48c warn surface)', () => {
+    const r = findConventionDrift({
+      posthogSrc: CANONICAL_POSTHOG,
+      eventsSrc: CANONICAL_EVENTS,
+      surveySrcByPath: {
+        [CANONICAL_WRAP]: 'export function withTelemetry<F>(fn: F): F { return fn }',
+        'packages/website/src/shim.ts': 'export const withTelemetry = (fn: any) => fn',
+      },
+      expectedNewEvents: EXPECTED,
+      canonicalWithTelemetryPath: CANONICAL_WRAP,
+    })
+    expect(r.parallelWithTelemetryDefs).toHaveLength(1)
+    expect(r.parallelWithTelemetryDefs[0].file).toBe('packages/website/src/shim.ts')
+  })
+
+  it('does NOT flag a parallel def acked on the same line (48c opt-out)', () => {
+    const r = findConventionDrift({
+      posthogSrc: CANONICAL_POSTHOG,
+      eventsSrc: CANONICAL_EVENTS,
+      surveySrcByPath: {
+        [CANONICAL_WRAP]: 'export function withTelemetry<F>(fn: F): F { return fn }',
+        'packages/vscode-extension/src/services/telemetry-wrap.ts':
+          'export function withTelemetry(fn) { return fn } // audit:check-48-ack bundled extension',
+      },
+      expectedNewEvents: EXPECTED,
+      canonicalWithTelemetryPath: CANONICAL_WRAP,
+    })
+    expect(r.parallelWithTelemetryDefs).toEqual([])
+  })
+
+  it('does NOT flag a parallel def acked in the comment block above (real telemetry-wrap.ts shape)', () => {
+    const r = findConventionDrift({
+      posthogSrc: CANONICAL_POSTHOG,
+      eventsSrc: CANONICAL_EVENTS,
+      surveySrcByPath: {
+        [CANONICAL_WRAP]: 'export function withTelemetry<F>(fn: F): F { return fn }',
+        'packages/vscode-extension/src/services/telemetry-wrap.ts': [
+          '// audit:check-48-ack — intentional parallel definition: the extension',
+          '// bundles standalone (esbuild) and cannot import the canonical core HOF.',
+          'export function withTelemetry<A, R>(fn: (...a: A[]) => R): (...a: A[]) => R {',
+          '  return fn',
+          '}',
+        ].join('\n'),
+      },
+      expectedNewEvents: EXPECTED,
+      canonicalWithTelemetryPath: CANONICAL_WRAP,
+    })
+    expect(r.parallelWithTelemetryDefs).toEqual([])
+  })
+
+  it('still flags a parallel def with NO ack (regression guard)', () => {
     const r = findConventionDrift({
       posthogSrc: CANONICAL_POSTHOG,
       eventsSrc: CANONICAL_EVENTS,


### PR DESCRIPTION
## Summary

- Check 48c (parallel `withTelemetry` definition detector) advertised a `// audit:check-48-ack` opt-out in its WARN text but **never honored it** — only 48d did. This adds `defHasCheck48Ack(src, line)` and filters `parallelWithTelemetryDefs` by it in `findConventionDrift`.
- **Contract**: the marker is honored on the **definition line** OR anywhere in the **contiguous comment block immediately above** it (upward walk stops at the first blank or non-comment line). A multi-line generic signature can't carry a clean trailing marker, and the one legitimate parallel def — the esbuild-bundled VS Code extension wrapper (`packages/vscode-extension/src/services/telemetry-wrap.ts`, which can't import the canonical core HOF) — already places its ack on the comment block above the def.
- Corrects the 48c WARN remediation text and the section comment that wrongly claimed only 48d honored the marker.

## Result

- `npm run audit:standards`: **Check 48c now PASSES** (the acked vscode def is suppressed). Failed 0; the lone remaining warning is the pre-existing Check 21 `.claude/hive-mind` submodule-pointer drift (unrelated).
- `scripts/tests/audit-standards-convention-drift.test.ts`: **36 pass** (new `defHasCheck48Ack` unit cases + 48c honor/regression-guard integration cases).

## Process

- ADR-109 (CI-script change): SPARC plan + `plan-review-skill` (5 refinements applied) + post-commit `/governance` (clean — no Critical/High/Medium) all completed.
- Closes SMI-5142.

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)