### PR TITLE
fix(doc-retrieval): SMI-5140 make git-commits env-isolation test hermetic

### DIFF
--- a/packages/doc-retrieval-mcp/src/adapters/git-commits.test.ts
+++ b/packages/doc-retrieval-mcp/src/adapters/git-commits.test.ts
@@ -389,29 +389,66 @@ describe('git-commits adapter — read-path env isolation (SMI-5126)', () => {
       'A leaked GIT_DIR overrides the spawned git process cwd, so the adapter could read the wrong repo. stripGitDiscoveryEnv removes the discovery vars so resolution falls back to cwd-walk.'
     )
 
-    // Stage the leak vector: point GIT_DIR / GIT_INDEX_FILE at the REAL
-    // repo this test runs inside. Without the scrub, git resolves the
-    // ambient GIT_DIR and runGitLog returns the host repo's commits.
-    const realGitDir = execFileSync('git', ['rev-parse', '--git-dir'], {
-      cwd: process.cwd(),
-      encoding: 'utf8',
-    }).trim()
+    // SMI-5140: stage the leak against a self-created DECOY repo, NOT
+    // process.cwd(). Probing process.cwd() for git state is unresolvable in a
+    // worktree container (the worktree's .git pointer targets a host path absent
+    // in the container → `git rev-parse` exits 128). The decoy gives an absolute,
+    // genuinely-foreign GIT_DIR with a DISTINCT commit count (2 vs scratch's 1):
+    // if the production scrub regresses, runGitLog surfaces the decoy's 2 commits
+    // and this test fails loudly. (The prior process.cwd() setup leaked a
+    // *relative* `.git` that git re-resolved against the spawn cwd → scratch,
+    // a false-pass that never exercised the scrub.)
+    const decoy = makeFixtureTempDir('smi-5126-decoy')
     const origGitDir = process.env.GIT_DIR
     const origGitIndexFile = process.env.GIT_INDEX_FILE
-    process.env.GIT_DIR = realGitDir
-    process.env.GIT_INDEX_FILE = join(realGitDir, 'index')
-
     try {
+      git(decoy, 'init', '-q', '-b', 'main')
+      git(decoy, 'config', '--local', 'user.email', 'decoy@example.com')
+      git(decoy, 'config', '--local', 'user.name', 'Decoy Author')
+      git(decoy, 'config', '--local', 'commit.gpgsign', 'false')
+      // Two commits that BOTH survive shouldSkip (each has an SMI ref + a
+      // substantial body) so the 2-vs-1 count discriminator can't collapse.
+      // Markers SMI-9001/SMI-9002 are distinct from scratch's SMI-5126.
+      for (const [subject, body] of [
+        [
+          'feat(SMI-9001): decoy commit one — must NOT be the cwd repo',
+          'If the production scrub regresses, a leaked foreign GIT_DIR would surface this decoy commit. Its substantial body clears the minimum token threshold so shouldSkip keeps it, making the 2-vs-1 count discriminator bite.',
+        ],
+        [
+          'feat(SMI-9002): decoy commit two — second discriminator commit',
+          'Two decoy commits guarantee the leaked-GIT_DIR count (2) differs from the scratch count (1). Both carry an SMI ref and a long body so neither is dropped by shouldSkip short-subject or dependabot guards.',
+        ],
+      ] as const) {
+        execFileSync('git', ['commit', '--allow-empty', '-m', `${subject}\n\n${body}`], {
+          cwd: decoy,
+          encoding: 'utf8',
+          env: makeFixtureEnv({
+            GIT_AUTHOR_NAME: 'Decoy Author',
+            GIT_AUTHOR_EMAIL: 'decoy@example.com',
+            GIT_COMMITTER_NAME: 'Decoy Author',
+            GIT_COMMITTER_EMAIL: 'decoy@example.com',
+          }),
+        })
+      }
+      const decoyGitDir = git(decoy, 'rev-parse', '--absolute-git-dir').trim()
+      process.env.GIT_DIR = decoyGitDir
+      process.env.GIT_INDEX_FILE = join(decoyGitDir, 'index')
+
       const adapter = createGitCommitsAdapter()
       const files = await adapter.listFiles(makeCtx(scratch, 'full'))
-      // Exactly the one scratch commit — the leaked GIT_DIR did not hijack.
+      // Exactly the one scratch commit — the leaked decoy GIT_DIR did not hijack.
       expect(files.length).toBe(1)
       expect(files[0].logicalPath).toMatch(/^git:\/\/[^/]+\/commit\/[0-9a-f]{8}$/)
+      // The survivor is scratch's commit, not merely *a* single commit…
+      expect(files[0].rawContent).toContain('SMI-5126')
+      // …and no decoy commit leaked through.
+      expect(files.every((f) => !/SMI-900[12]/.test(f.rawContent))).toBe(true)
     } finally {
       if (origGitDir === undefined) delete process.env.GIT_DIR
       else process.env.GIT_DIR = origGitDir
       if (origGitIndexFile === undefined) delete process.env.GIT_INDEX_FILE
       else process.env.GIT_INDEX_FILE = origGitIndexFile
+      rmSync(decoy, { recursive: true, force: true })
     }
   })
 })


### PR DESCRIPTION
## Summary

Fixes **SMI-5140** — the worktree pre-push test gate failed on exactly one test (`git-commits.test.ts` → SMI-5126 read-path env-isolation), forcing `--no-verify` on every worktree-based PR (3× during the SMI-5119 follow-ups).

**Corrected RCA** (the issue's original env-leak RCA was empirically disproven): `docker exec` forwards no host env, so nothing is leaked into the container to strip. The real cause is a **non-hermetic test** — it staged its "leaked GIT_DIR" by probing the ambient repo via `git rev-parse --git-dir` against `process.cwd()`, which in a worktree container is `/app/.worktrees/<name>` whose `.git` pointer targets a host path absent in the container → `fatal: not a git repository` (exit 128). It was the only root-suite test with an ambient-repo git-discovery dependency.

**Fix**: stage the leak against a self-created **decoy repo** (absolute gitdir, 2 commits that both survive `shouldSkip`) instead of `process.cwd()`. This removes the ambient dependency (fixes the worktree failure) and **strengthens** the leak vector — the prior relative-`.git` setup re-resolved to the scratch fixture (a false-pass that never exercised the scrub); the foreign absolute decoy gitdir with a 2-vs-1 commit count fails loudly if the production scrub regresses.

Test-only change under `packages/*/src/**` (ADR-109 exempt). No `.husky/`/CI/Docker change (and stripping env in the hook would be a no-op — see RCA). No coverage loss.

## Validation
- 23/23 tests pass in `skillsmith-dev-1`; typecheck/lint/prettier/audit:standards clean.
- **Mutation-validated**: disabling the production scrub turns the test RED (`expected 2 to be 1`) — the decoy's 2 commits hijack `listFiles`, proving the discriminator bites end-to-end.
- Reproduced the broken-worktree-cwd condition (`git rev-parse --git-dir` exit 128) and confirmed the fixed test no longer touches it.
- Pre-push gate passed from the main repo **without `--no-verify`**.
- Plan + plan-review (3 VP perspectives, all findings applied): `docs/internal/implementation/smi-5140-worktree-prepush-gitdir.md`.

Follow-up filed: **SMI-5144** (Low) — the underlying SMI-4689-class worktree-gitdir-in-container mismatch (out of scope here).

## Test plan
- [ ] CI green (full suite).
- [ ] Verified: the test passes in a worktree dev container (the direct SMI-5140 repro).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)