### PR TITLE
feat(scripts): SMI-5145 — surface reclaimable Docker images/volumes + safe --prune

### DIFF
--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -34,7 +34,9 @@ Arguments:
 
 Options:
   --force         Force removal even if worktree has dirty files
-  --prune         Also prune stale Docker networks
+  --prune         Also prune stale Docker networks, dangling images, and build
+                  cache (aggressive image -a / volume prune stay manual — see
+                  the post-removal reclaimable report)
   --keep-docker   Preserve the per-worktree Docker image and node_modules volume
                   (default: both are removed alongside the worktree)
   -h, --help      Show this help message and exit
@@ -51,8 +53,10 @@ What this script does:
   3. Refuses if the worktree has uncommitted changes, unless --force is passed (SMI-5000)
   4. Removes the git worktree (always passes --force to git worktree remove
      so submodule presence — post-SMI-4829 every worktree has 4 — does not block)
-  5. Checks Docker network count and warns if above threshold
-  6. Optionally prunes stale Docker networks (--prune)
+  5. Checks Docker network count and reports global reclaimable Docker
+     resources (images / volumes / build cache) with manual reclaim commands
+  6. Optionally prunes stale networks + dangling images + build cache (--prune);
+     aggressive image -a / volume prune are left to the operator
 
 EOF
 }
@@ -187,6 +191,60 @@ prune_docker_networks() {
     else
         success "  No stale networks to remove"
     fi
+}
+
+#######################################
+# Report reclaimable global Docker resources (read-only)
+#
+# SMI-5145: surface the global reclaimable state — unused images, orphaned
+# volumes, and build cache — that accumulates across worktrees. Read-only;
+# never deletes. The aggressive reclaim (image -a / volume prune) is printed
+# as a MANUAL command, not run by --prune, because it can force expensive
+# native-module rebuilds (better-sqlite3 / onnxruntime, SMI-4698) in other
+# still-active worktrees.
+#
+# No GB-threshold gate (cf. NETWORK_WARN_THRESHOLD): parsing docker's
+# human-readable sizes would reintroduce a numeric-parse/errexit landmine;
+# this report is informational, so `docker system df` output is echoed raw.
+#######################################
+check_docker_reclaimable() {
+    if ! command -v docker &>/dev/null; then
+        return 0
+    fi
+
+    info "Reclaimable Docker resources (global):"
+    # Bare command, NOT inside a $(...) assignment, so under `set -euo pipefail`
+    # an unguarded non-zero exit (daemon hiccup) would abort the script before
+    # "Worktree removal complete!" — the `|| warn` keeps it tolerant.
+    docker system df 2>/dev/null || warn "  Could not read 'docker system df'"
+    echo ""
+    info "To reclaim more (manual — NOT run by --prune):"
+    echo -e "${YELLOW}  docker image prune -a   # unused tagged images${NC}"
+    echo -e "${YELLOW}  docker volume prune     # orphaned volumes (WARNING: forces native-module rebuilds in other worktrees)${NC}"
+    echo ""
+}
+
+#######################################
+# Prune the SAFE global Docker categories (dangling images + build cache)
+#
+# SMI-5145: run under --prune alongside prune_docker_networks. These do NOT
+# affect another worktree's ability to resume — named *_node_modules volumes
+# are preserved, and `image prune -f` removes only dangling/untagged images
+# (tagged images referenced by any running/stopped container are kept).
+# Aggressive `image -a` / `volume prune` stay manual (check_docker_reclaimable).
+# Each command is `|| warn`-tolerant so a transient non-zero exit doesn't abort
+# the script under `set -euo pipefail`.
+#######################################
+prune_docker_safe() {
+    if ! command -v docker &>/dev/null; then
+        warn "Docker not found, skipping safe image/cache prune"
+        return 0
+    fi
+
+    info "Pruning dangling images..."
+    docker image prune -f 2>&1 || warn "  image prune returned non-zero"
+    info "Pruning build cache..."
+    docker builder prune -f 2>&1 || warn "  builder prune returned non-zero"
 }
 
 #######################################
@@ -338,13 +396,16 @@ Commit or discard them first, or re-run with --force to discard:
         error "Failed to remove worktree."
     fi
 
-    # Step 3: Check Docker network count
+    # Step 3: Check Docker resources — network count + global reclaimable report
     echo ""
     check_docker_networks
+    check_docker_reclaimable
 
-    # Step 4: Prune networks if requested
+    # Step 4: Prune networks + SAFE global categories (dangling images + build
+    # cache) if requested. Aggressive image -a / volume prune stay manual.
     if [[ "$prune_flag" == true ]]; then
         prune_docker_networks
+        prune_docker_safe
     fi
 
     echo ""

--- a/scripts/tests/remove-worktree.test.ts
+++ b/scripts/tests/remove-worktree.test.ts
@@ -277,13 +277,81 @@ describe('SMI-4653: remove-worktree.sh per-worktree Docker cleanup', () => {
     const logPath = join(tempRoot, 'docker.log')
     const exitCodesPath = join(tempRoot, 'exit-codes')
     // Cleanup ops (compose stop, compose down, rmi, volume rm) → 1 (resources already gone).
-    // network ls (final check_docker_networks call) → 0 so the pipefail-protected pipeline
-    // doesn't blow up. Script should still succeed end-to-end.
+    // network ls (5th call, check_docker_networks) → 0 so the pipefail-protected pipeline
+    // doesn't blow up. The SMI-5145 `docker system df` (check_docker_reclaimable) is the 6th
+    // call and defaults to 0 (codes exhausted) — its bare invocation is `|| warn`-guarded so
+    // a non-zero would not abort regardless. Script should still succeed end-to-end.
     writeFileSync(exitCodesPath, '1\n1\n1\n1\n0\n')
     writeDockerShim(binDir, logPath, exitCodesPath)
 
     const result = runScriptWithDockerShim(`"${worktreeDir}" --force`, binDir, logPath, repoDir)
 
     expect(result.status).toBe(0)
+  })
+})
+
+describe('SMI-5145: reclaimable Docker report + safe --prune', () => {
+  it('reports reclaimable resources (docker system df) on a default run, without pruning', () => {
+    const tempRoot = makeTempDir('rmwt-reclaim-check')
+    tempDirs.push(tempRoot)
+    const { repoDir, worktreeDir } = setupRepoWithWorktree(tempRoot, 'wt-reclaim')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    writeDockerShim(binDir, logPath)
+
+    const result = runScriptWithDockerShim(`"${worktreeDir}" --force`, binDir, logPath, repoDir)
+
+    expect(result.status).toBe(0)
+    // Step 3 reclaimable report runs `docker system df` unconditionally.
+    expect(result.dockerCalls).toContain('system df')
+    // Without --prune, no safe prune of images / build cache / networks runs.
+    expect(result.dockerCalls.some((c) => c.startsWith('image prune'))).toBe(false)
+    expect(result.dockerCalls.some((c) => c.startsWith('builder prune'))).toBe(false)
+    expect(result.dockerCalls.some((c) => c.startsWith('network prune'))).toBe(false)
+  })
+
+  it('--prune runs network + dangling-image + build-cache prune (safe categories only)', () => {
+    const tempRoot = makeTempDir('rmwt-prune-safe')
+    tempDirs.push(tempRoot)
+    const { repoDir, worktreeDir } = setupRepoWithWorktree(tempRoot, 'wt-prunesafe')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    writeDockerShim(binDir, logPath)
+
+    const result = runScriptWithDockerShim(
+      `"${worktreeDir}" --force --prune`,
+      binDir,
+      logPath,
+      repoDir
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls).toContain('network prune -f')
+    expect(result.dockerCalls).toContain('image prune -f')
+    expect(result.dockerCalls).toContain('builder prune -f')
+    // Still reports reclaimable.
+    expect(result.dockerCalls).toContain('system df')
+    // SAFETY GUARD (non-optional): aggressive reclaim is NEVER auto-run — it can
+    // force native-module rebuilds in other active worktrees, so it stays manual.
+    expect(result.dockerCalls.some((c) => c.includes('volume prune'))).toBe(false)
+    expect(result.dockerCalls.some((c) => c.includes('image prune -a'))).toBe(false)
+  })
+
+  it('never auto-runs aggressive reclaim on a default (no --prune) run either', () => {
+    const tempRoot = makeTempDir('rmwt-no-aggressive')
+    tempDirs.push(tempRoot)
+    const { repoDir, worktreeDir } = setupRepoWithWorktree(tempRoot, 'wt-noaggr')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    writeDockerShim(binDir, logPath)
+
+    const result = runScriptWithDockerShim(`"${worktreeDir}" --force`, binDir, logPath, repoDir)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c.includes('volume prune'))).toBe(false)
+    expect(result.dockerCalls.some((c) => c.includes('image prune -a'))).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- `scripts/remove-worktree.sh` previously surfaced only Docker **networks**. This adds the global reclaimable state to worktree/session cleanup.
- **`check_docker_reclaimable()`** (read-only, Step 3, unconditional): echoes `docker system df` (images / volumes / build cache reclaimable) + prints the manual aggressive-reclaim commands with a native-rebuild caveat.
- **`prune_docker_safe()`** (under `--prune`, Step 4): runs `docker image prune -f` (dangling only) + `docker builder prune -f` (build cache).
- Aggressive `docker image prune -a` / `docker volume prune` stay **manual** — they can force expensive native-module rebuilds (SMI-4698) in other still-active worktrees.
- All new bare docker calls are `|| warn`-tolerant under `set -euo pipefail`. `usage()` updated (flag + numbered list).

## Result

- `scripts/tests/remove-worktree.test.ts`: **10/10 pass** (3 new — default reports `system df` + prunes nothing; `--prune` runs network + dangling-image + build-cache prune; safety guard asserts `volume prune` / `image prune -a` are **never** auto-run).
- `npm run audit:standards` Failed 0; `bash -n` + shellcheck clean; governance retro CLEAN.

## Process

- ADR-109 (dev-tooling Docker script): SPARC plan + plan-review complete before implementation. Plan doc bundled via the `docs/internal` pointer bump (`8cfa7d0a` → `088e27c`).
- plan-review H-1 (idempotent fixture) was bench-validated as a false alarm — fixture unchanged, all tests green.
- Closes SMI-5145.

[skip-smoke]
[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)