### PR TITLE
feat(team): SMI-5151 per-member cards + human-readable activity feed

### DIFF
--- a/packages/website/src/lib/team-activity-format.test.ts
+++ b/packages/website/src/lib/team-activity-format.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import { formatRelativeTime, humanizeActivity, type ActivityEvent } from './team-activity-format'
+
+const RYAN = '7cf4c4a8-e0cb-4168-9e4d-c45a56cadfcf'
+const TONY = 'a11828aa-4d3a-4820-87fc-2c9949afb9f7'
+const INVITE_UUID = 'dc352e77-393a-431e-a545-fee30f182068'
+
+const nameMap = new Map<string, string>([
+  [RYAN, 'Ryan Smith'],
+  [TONY, 'Tony Lee'],
+])
+
+function ev(partial: Partial<ActivityEvent>): ActivityEvent {
+  return {
+    event_type: null,
+    actor: null,
+    action: null,
+    resource: null,
+    timestamp: '2026-05-23T08:36:21.000Z',
+    metadata: null,
+    ...partial,
+  }
+}
+
+describe('formatRelativeTime', () => {
+  const now = new Date('2026-05-23T12:00:00.000Z')
+
+  it('renders "just now" under 45s', () => {
+    expect(formatRelativeTime('2026-05-23T11:59:30.000Z', now)).toBe('just now')
+  })
+
+  it('renders minutes', () => {
+    expect(formatRelativeTime('2026-05-23T11:55:00.000Z', now)).toBe('5 min ago')
+  })
+
+  it('renders hours', () => {
+    expect(formatRelativeTime('2026-05-23T09:00:00.000Z', now)).toBe('3 hr ago')
+  })
+
+  it('renders days with singular/plural', () => {
+    expect(formatRelativeTime('2026-05-22T12:00:00.000Z', now)).toBe('1 day ago')
+    expect(formatRelativeTime('2026-05-20T12:00:00.000Z', now)).toBe('3 days ago')
+  })
+
+  it('falls back to an absolute date past ~7 days', () => {
+    const out = formatRelativeTime('2026-05-01T12:00:00.000Z', now)
+    expect(out).not.toMatch(/ago/)
+    expect(out).toMatch(/2026/)
+  })
+
+  it('returns empty string for an invalid timestamp', () => {
+    expect(formatRelativeTime('not-a-date', now)).toBe('')
+  })
+})
+
+describe('humanizeActivity — actor resolution (three branches)', () => {
+  it('literal authenticated_user → passive voice (no actor name)', () => {
+    const out = humanizeActivity(
+      ev({ event_type: 'team_invitation:email_sent', actor: 'authenticated_user' }),
+      nameMap
+    )
+    expect(out.text).toBe('An invitation email was sent')
+  })
+
+  it('actor UUID present in nameMap → display name', () => {
+    const out = humanizeActivity(
+      ev({ event_type: 'team_invitation:revoked', actor: RYAN }),
+      nameMap
+    )
+    expect(out.text).toBe('Ryan Smith revoked an invitation')
+  })
+
+  it('actor UUID absent from nameMap (removed member) → "A team member", never passive', () => {
+    const out = humanizeActivity(
+      ev({ event_type: 'team_invitation:revoked', actor: 'unknown-uuid-xyz' }),
+      nameMap
+    )
+    expect(out.text).toBe('A team member revoked an invitation')
+  })
+})
+
+describe('humanizeActivity — sentence by event_type', () => {
+  it('created shows the role suffix from metadata', () => {
+    const out = humanizeActivity(
+      ev({
+        event_type: 'team_invitation:created',
+        actor: RYAN,
+        metadata: { role: 'member', team_id: 't1' },
+      }),
+      nameMap
+    )
+    expect(out.text).toBe('Ryan Smith created an invitation (member)')
+  })
+
+  it('accepted reads naturally without a role suffix', () => {
+    const out = humanizeActivity(
+      ev({ event_type: 'team_invitation:accepted', actor: TONY, metadata: { role: 'member' } }),
+      nameMap
+    )
+    expect(out.text).toBe('Tony Lee accepted their invitation')
+  })
+
+  it('revoked never renders an empty/undefined role parenthetical', () => {
+    const out = humanizeActivity(
+      ev({ event_type: 'team_invitation:revoked', actor: RYAN, metadata: { team_id: 't1' } }),
+      nameMap
+    )
+    expect(out.text).toBe('Ryan Smith revoked an invitation')
+    expect(out.text).not.toMatch(/\(\s*\)|undefined/)
+  })
+
+  it('removed stays generic (does not resolve the removed member)', () => {
+    const out = humanizeActivity(
+      ev({
+        event_type: 'team_member:removed',
+        actor: RYAN,
+        metadata: { team_id: 't1', removed_member_id: 'tm_tony' },
+      }),
+      nameMap
+    )
+    expect(out.text).toBe('Ryan Smith removed a member')
+    expect(out.text).not.toContain('tm_tony')
+  })
+
+  it('unknown event_type falls back to a de-snaked action verb', () => {
+    const out = humanizeActivity(
+      ev({ event_type: 'something:weird', actor: RYAN, action: 'refresh_metadata' }),
+      nameMap
+    )
+    expect(out.text).toBe('Ryan Smith refresh metadata')
+  })
+
+  it('created with an empty nameMap → passive fallback name', () => {
+    const out = humanizeActivity(
+      ev({ event_type: 'team_invitation:created', actor: RYAN, metadata: { role: 'admin' } }),
+      new Map()
+    )
+    expect(out.text).toBe('A team member created an invitation (admin)')
+  })
+})
+
+describe('humanizeActivity — never leaks raw identifiers', () => {
+  it('omits the resource UUID for every event_type', () => {
+    const eventTypes = [
+      'team_invitation:created',
+      'team_invitation:email_sent',
+      'team_invitation:accepted',
+      'team_invitation:revoked',
+      'team_member:removed',
+      'unknown:event',
+    ]
+    for (const event_type of eventTypes) {
+      const out = humanizeActivity(
+        ev({
+          event_type,
+          actor: RYAN,
+          resource: `team_invitations/${INVITE_UUID}`,
+          action: 'create',
+        }),
+        nameMap
+      )
+      expect(out.text).not.toContain(INVITE_UUID)
+      expect(out.text).not.toContain('team_invitations/')
+      expect(out.text).not.toContain(RYAN)
+    }
+  })
+})

--- a/packages/website/src/lib/team-activity-format.ts
+++ b/packages/website/src/lib/team-activity-format.ts
@@ -1,0 +1,130 @@
+/**
+ * SMI-5151: human-readable Team Dashboard activity feed.
+ *
+ * Pure formatters for the Overview "Recent Activity" panel. Maps raw `audit_logs`
+ * rows (actor UUID or the literal `authenticated_user`, snake_case action,
+ * `resource/uuid`) into plain-English sentences with relative timestamps and no
+ * raw UUIDs. Returns plain text — the caller (`index.astro`) is responsible for
+ * HTML-escaping every field before inserting into the DOM.
+ */
+
+export interface ActivityEvent {
+  event_type: string | null
+  actor: string | null
+  action: string | null
+  resource: string | null
+  timestamp: string
+  metadata: Record<string, unknown> | null
+}
+
+export interface FormattedActivity {
+  /** Plain-English line. NOT escaped — the caller must escape before DOM insertion. */
+  text: string
+  /** Absolute timestamp for the `title=` tooltip. NOT escaped. */
+  iso: string
+  /** Short relative string, e.g. "5 min ago". NOT escaped. */
+  relative: string
+}
+
+/** The literal actor edge functions write when acting on behalf of a user. */
+const LITERAL_SYSTEM_ACTOR = 'authenticated_user'
+/** Shown when an actor UUID can't be resolved (e.g. a since-removed member). */
+const FALLBACK_ACTOR = 'A team member'
+
+/**
+ * Resolve an audit actor to a display name, or `null` for the system/passive
+ * actor. Branch order is significant (plan-review #2): the `authenticated_user`
+ * literal is handled before the UUID lookup so an unknown UUID never falls into
+ * the passive branch — it resolves to {@link FALLBACK_ACTOR} instead.
+ */
+function resolveActor(actor: string | null, nameMap: Map<string, string>): string | null {
+  if (!actor || actor === LITERAL_SYSTEM_ACTOR) return null
+  return nameMap.get(actor) ?? FALLBACK_ACTOR
+}
+
+/**
+ * `" (role)"` only when the row's metadata actually carries a string `role`
+ * (plan-review #1) — `:revoked`/`:removed` carry none, so this never renders
+ * `(undefined)`/`()`.
+ */
+function roleSuffix(metadata: Record<string, unknown> | null): string {
+  const role = metadata && typeof metadata.role === 'string' ? metadata.role.trim() : ''
+  return role ? ` (${role})` : ''
+}
+
+/** De-snake an action verb for the unknown-event fallback ('send_email' → 'send email'). */
+function humanizeAction(action: string | null): string {
+  const cleaned = (action ?? '').replace(/_/g, ' ').trim()
+  return cleaned || 'updated team activity'
+}
+
+/** `"{who} {activeTail}"` when an actor is known, else the passive form. */
+function withActor(who: string | null, activeTail: string, passive: string): string {
+  return who ? `${who} ${activeTail}` : passive
+}
+
+/**
+ * Format a past timestamp as a short relative string ("just now", "5 min ago",
+ * "3 hr ago", "2 days ago"); falls back to an absolute date past ~7 days.
+ * Mirrors `team-invitations.ts:formatRelativeExpiry` but for the past direction.
+ */
+export function formatRelativeTime(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const sec = Math.floor((now.getTime() - then) / 1000)
+  if (sec < 45) return 'just now'
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min} min ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr} hr ago`
+  const days = Math.floor(hr / 24)
+  if (days <= 7) return `${days} day${days === 1 ? '' : 's'} ago`
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+/** Build the plain-English sentence for one event. Never includes the raw resource/UUID. */
+function buildSentence(ev: ActivityEvent, who: string | null): string {
+  switch (ev.event_type) {
+    case 'team_invitation:created':
+      return withActor(
+        who,
+        `created an invitation${roleSuffix(ev.metadata)}`,
+        'An invitation was created'
+      )
+    case 'team_invitation:email_sent':
+      return 'An invitation email was sent'
+    case 'team_invitation:accepted':
+      return withActor(who, 'accepted their invitation', 'An invitation was accepted')
+    case 'team_invitation:revoked':
+      return withActor(who, 'revoked an invitation', 'An invitation was revoked')
+    case 'team_member:removed':
+      return withActor(who, 'removed a member', 'A member was removed')
+    default: {
+      const verb = humanizeAction(ev.action)
+      return withActor(who, verb, `Team activity: ${verb}`)
+    }
+  }
+}
+
+/**
+ * Turn one `audit_logs` row into a human-readable activity line. Returns plain
+ * text — the caller must HTML-escape `text`, `iso`, and `relative` before
+ * inserting into the DOM.
+ */
+export function humanizeActivity(
+  ev: ActivityEvent,
+  nameMap: Map<string, string>
+): FormattedActivity {
+  const who = resolveActor(ev.actor, nameMap)
+  const parsed = new Date(ev.timestamp)
+  const iso = Number.isNaN(parsed.getTime()) ? ev.timestamp : parsed.toLocaleString()
+  return {
+    text: buildSentence(ev, who),
+    iso,
+    relative: formatRelativeTime(ev.timestamp),
+  }
+}

--- a/packages/website/src/lib/team-invite-ui.ts
+++ b/packages/website/src/lib/team-invite-ui.ts
@@ -248,7 +248,6 @@ function canRemove(viewer: Viewer, row: TeamMemberRow): boolean {
 export function renderMemberRow(row: TeamMemberRow, viewer: Viewer): string {
   const name = row.full_name || row.email?.split('@')[0] || 'Team member'
   const email = row.email ?? ''
-  const initial = (name[0] || '?').toUpperCase()
   const joined = row.joined_at
     ? new Date(row.joined_at).toLocaleDateString(undefined, {
         year: 'numeric',
@@ -263,18 +262,16 @@ export function renderMemberRow(row: TeamMemberRow, viewer: Viewer): string {
                 type="button"
                 data-action="remove-member"
                 data-member-id="${escapeHtml(row.member_id)}"
-                data-member-email="${escapeHtml(row.email ?? 'this member')}">
+                data-member-email="${escapeHtml(row.email ?? 'this member')}"
+                aria-label="Remove ${escapeHtml(name)}">
           Remove
         </button>
       </div>`
     : ''
   return `<div class="member-card" data-member-id="${escapeHtml(row.member_id)}">
-    <div class="member-info">
-      <div class="member-avatar">${escapeHtml(initial)}</div>
-      <div class="member-details">
-        <div class="member-name">${escapeHtml(name)}</div>
-        <div class="member-email">${escapeHtml(email)}</div>
-      </div>
+    <div class="member-details">
+      <div class="member-name">${escapeHtml(name)}</div>
+      <div class="member-email">${escapeHtml(email)}</div>
     </div>
     <div class="member-meta">
       <span class="role-badge role-${escapeHtml(roleLower)}">${escapeHtml(roleLabel)}</span>

--- a/packages/website/src/pages/account/team/index.astro
+++ b/packages/website/src/pages/account/team/index.astro
@@ -251,24 +251,17 @@ const supabaseConfig = getSupabaseConfig()
     border-bottom: none;
   }
 
-  .activity-user {
+  .activity-text {
     color: #fafafa;
-    font-weight: 500;
-  }
-
-  .activity-action {
-    color: #9ca3af;
-  }
-
-  .activity-target {
-    color: #b8523a;
-    font-weight: 500;
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
   .activity-time {
-    color: #6b7280;
+    color: #9ca3af;
     margin-left: auto;
     font-size: 0.8125rem;
+    white-space: nowrap;
   }
 
   .loading-state {
@@ -325,6 +318,7 @@ const supabaseConfig = getSupabaseConfig()
 <script>
   import { createClient } from '@supabase/supabase-js'
   import { checkTeamAccess, resolveGateRedirect } from '../../../lib/team-access'
+  import { humanizeActivity, type ActivityEvent } from '../../../lib/team-activity-format'
 
   const config = window.__SUPABASE_CONFIG__ || { url: '', anonKey: '' }
 
@@ -447,7 +441,31 @@ const supabaseConfig = getSupabaseConfig()
         document.getElementById('audits-run')!.textContent = String(usage.audits_run ?? 0)
       }
 
-      // 4. Recent activity — audit_logs filtered by team_id in metadata
+      // 4. Member display-name map for humanizing the activity feed. Fetched in
+      //    its own try/catch — NOT the Promise.all above, whose `throw` on any
+      //    member's RPC error (transient / forbidden) would blank the whole
+      //    dashboard. On failure the map stays empty and actors fall back to a
+      //    generic label. (SMI-5151, plan-review #10.)
+      const nameMap = new Map<string, string>()
+      try {
+        const { data: memberRows } = await supabase.rpc('list_team_members_with_profile', {
+          p_team_id: teamId,
+        })
+        for (const m of (memberRows ?? []) as Array<{
+          user_id: string
+          full_name: string | null
+          email: string | null
+        }>) {
+          if (m.user_id) {
+            nameMap.set(m.user_id, m.full_name || m.email?.split('@')[0] || 'Team member')
+          }
+        }
+      } catch {
+        // Leave nameMap empty; humanizeActivity falls back to "A team member".
+      }
+
+      // 5. Recent activity — audit_logs filtered by team_id in metadata, then
+      //    rendered as human-readable lines (no raw UUIDs). (SMI-5151)
       const { data: activity } = await supabase
         .from('audit_logs')
         .select('id, event_type, actor, resource, action, timestamp, metadata')
@@ -457,14 +475,12 @@ const supabaseConfig = getSupabaseConfig()
 
       const list = document.getElementById('activity-list')!
       if (activity && activity.length > 0) {
-        list.innerHTML = activity
-          .map((ev) => {
-            const when = new Date(ev.timestamp).toLocaleString()
+        list.innerHTML = (activity as ActivityEvent[])
+          .map((row) => {
+            const { text, iso, relative } = humanizeActivity(row, nameMap)
             return `<div class="activity-item">
-              <span class="activity-user">${escapeHtml(ev.actor ?? 'system')}</span>
-              <span class="activity-action">${escapeHtml(ev.action ?? ev.event_type)}</span>
-              <span class="activity-target">${escapeHtml(ev.resource ?? '')}</span>
-              <span class="activity-time">${escapeHtml(when)}</span>
+              <span class="activity-text">${escapeHtml(text)}</span>
+              <span class="activity-time" title="${escapeHtml(iso)}">${escapeHtml(relative)}</span>
             </div>`
           })
           .join('')

--- a/packages/website/src/pages/account/team/members.astro
+++ b/packages/website/src/pages/account/team/members.astro
@@ -189,41 +189,21 @@ const supabaseConfig = getSupabaseConfig()
   .member-list {
     display: flex;
     flex-direction: column;
-    gap: 0;
+    gap: 0.75rem;
   }
 
+  /* Each member is its own bordered card so the per-member Remove button is
+   * unambiguously scoped to that member (SMI-5151). Tokens match the page's
+   * border/radius/surface palette. */
   .member-card {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1rem 0;
-    border-bottom: 1px solid #2a2a2f;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-  }
-
-  .member-card:last-child {
-    border-bottom: none;
-  }
-
-  .member-info {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  .member-avatar {
-    width: 2.5rem;
-    height: 2.5rem;
-    border-radius: 50%;
-    background: #2a2a2f;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: 600;
-    font-size: 0.875rem;
-    color: #9ca3af;
-    flex-shrink: 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.625rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid #2a2a2f;
+    border-radius: 0.75rem;
+    background: #1a1a1f;
   }
 
   .member-name {
@@ -243,7 +223,7 @@ const supabaseConfig = getSupabaseConfig()
   }
 
   .member-actions {
-    margin-left: auto;
+    margin-top: 0.25rem;
   }
 
   .member-actions .btn {
@@ -275,7 +255,7 @@ const supabaseConfig = getSupabaseConfig()
   }
 
   .member-joined {
-    color: #6b7280;
+    color: #9ca3af;
     font-size: 0.8125rem;
   }
 

--- a/packages/website/tests/e2e/team-invitations.spec.ts
+++ b/packages/website/tests/e2e/team-invitations.spec.ts
@@ -416,6 +416,14 @@ test.describe('SMI-4294 post-smoke: members page', () => {
     await expect(tonyRow).toBeVisible({ timeout: 5000 })
     await expect(tonyRow.locator('.member-name')).toHaveText('Tony Lee')
     await expect(tonyRow.locator('.member-email')).toHaveText('hy.tony.lee@gmail.com')
+
+    // SMI-5151: per-member card — no stray avatar initial; the Remove button
+    // carries a disambiguating aria-label so the action is unambiguously scoped.
+    await expect(tonyRow.locator('.member-avatar')).toHaveCount(0)
+    await expect(tonyRow.locator('[data-action="remove-member"]')).toHaveAttribute(
+      'aria-label',
+      'Remove Tony Lee'
+    )
   })
 
   test('Bug 3 regression: owner removes member; row disappears; count decrements', async ({


### PR DESCRIPTION
## Summary
Follow-up UI polish surfaced during Ryan's SMI-4294 preview UAT. Frontend-only — no DB/RPC/migration change; invitee email stays out of audit logs (PII).

- **Members page**: each member now renders as its own bordered card (no stray "R"/"T" avatar initial; Remove button below the name with `aria-label="Remove {name}"`), so the per-member action is unambiguously scoped. `.member-joined` bumped to meet the 5:1 contrast target on the new card surface.
- **Overview activity feed**: new pure `team-activity-format` module turns `audit_logs` rows into plain-English lines ("Ryan Smith created an invitation (member)", "An invitation email was sent", relative times, **zero raw UUIDs**). Actor names resolved via `list_team_members_with_profile` fetched **outside** the throwing `Promise.all` so a `forbidden`/transient member-RPC error can't blank the dashboard.

Plan-reviewed (VP Product/Eng/Design, no Critical; all findings applied). Canonical plan + #1285 retro land via the bundled `docs/internal` pointer bump.

## Plan-review fixes baked in
- name-map RPC isolated from the throwing `Promise.all` (#10)
- `(role)` suffix gated on metadata presence — never `(undefined)` (#1)
- ordered actor resolution: `authenticated_user`→passive, UUID→name, else "A team member" (#2)
- every interpolated value escaped incl. the `title=` attribute (#3)
- role-badge/`member-joined` contrast re-checked on `#1a1a1f` (#7); Remove `aria-label` (#7)

## Test plan
- [x] Docker typecheck + lint + audit:standards
- [x] Host-website `tsc --noEmit`
- [x] Website vitest (270 pass, incl. new `team-activity-format.test.ts` — 16 cases)
- [x] All changed files <500 lines
- [ ] Ryan preview UAT: members render as cards (no initials, Remove below name, owner has no Remove); Overview activity reads as plain English with relative times and no UUIDs

Closes SMI-5151.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)