### PR TITLE
feat(ci): SMI-5120 source-vs-version drift detector

### DIFF
--- a/.github/workflows/version-drift-check.yml
+++ b/.github/workflows/version-drift-check.yml
@@ -26,6 +26,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # SMI-5120: the source-version drift detector walks git history + tags
+          # (baseline resolution + release-cycle count). The default depth-1
+          # clone would blind it and silently no-op the guard.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -43,25 +48,55 @@ jobs:
           cat /tmp/drift.json
           exit 0
 
+      # SMI-5120: source-vs-version drift (published artifact frozen while src changed).
+      - name: Run source-version drift check
+        id: source_drift
+        continue-on-error: true
+        run: |
+          set +e
+          node scripts/check-source-version-drift.mjs > /tmp/source-drift.json
+          CODE=$?
+          echo "exit_code=$CODE" >> $GITHUB_OUTPUT
+          cat /tmp/source-drift.json
+          exit 0
+
+      - name: Merge drift reports
+        id: merge
+        run: |
+          # Guard against a missing/empty source-drift.json (the step above is
+          # continue-on-error): a detector crash must never break the working
+          # behind-npm upsert. Default the missing side to empty arrays.
+          if [ ! -s /tmp/source-drift.json ]; then
+            echo '{"sourceDrifted":[],"clean":[],"errors":[]}' > /tmp/source-drift.json
+          fi
+          jq -s '{
+            drifted: (.[0].drifted // []),
+            sourceDrifted: (.[1].sourceDrifted // []),
+            errors: ((.[0].errors // []) + (.[1].errors // []))
+          }' /tmp/drift.json /tmp/source-drift.json > /tmp/combined.json
+          cat /tmp/combined.json
+
       - name: Parse drift report
         id: parse
         run: |
-          DRIFT_COUNT=$(jq -r '.drifted | length' /tmp/drift.json)
-          ERROR_COUNT=$(jq -r '.errors | length' /tmp/drift.json)
+          DRIFT_COUNT=$(jq -r '.drifted | length' /tmp/combined.json)
+          SOURCE_DRIFT_COUNT=$(jq -r '.sourceDrifted | length' /tmp/combined.json)
+          ERROR_COUNT=$(jq -r '.errors | length' /tmp/combined.json)
           echo "drift_count=$DRIFT_COUNT" >> $GITHUB_OUTPUT
+          echo "source_drift_count=$SOURCE_DRIFT_COUNT" >> $GITHUB_OUTPUT
           echo "error_count=$ERROR_COUNT" >> $GITHUB_OUTPUT
 
       - name: Upsert Linear issue on drift
-        if: steps.parse.outputs.drift_count != '0' || steps.parse.outputs.error_count != '0'
+        if: steps.parse.outputs.drift_count != '0' || steps.parse.outputs.source_drift_count != '0' || steps.parse.outputs.error_count != '0'
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          node scripts/linear-upsert-drift-issue.mjs /tmp/drift.json
+          node scripts/linear-upsert-drift-issue.mjs /tmp/combined.json
 
       - name: Fail job if drift or error
-        if: steps.drift.outputs.exit_code != '0'
+        if: steps.drift.outputs.exit_code != '0' || steps.source_drift.outputs.exit_code != '0'
         run: |
           echo "::error::Drift or npm failure detected. See Linear issue."
           exit 1

--- a/scripts/check-source-version-drift.mjs
+++ b/scripts/check-source-version-drift.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+/**
+ * SMI-5120 AC #3: source-vs-version drift detector.
+ *
+ * Flags a publishable package whose package.json version has been static
+ * across >= RELEASES_THRESHOLD release cycles while its src/ kept changing —
+ * i.e. a published artifact that has silently frozen on its registry. This is
+ * the @smith-horn/enterprise failure mode: published 0.1.2 on 2026-01-13, never
+ * bumped, ~5 months of billing src landed since, all invisible to consumers.
+ *
+ * Companion to (not a replacement for) the orthogonal weekly checks:
+ *   - check-version-drift.mjs  — local version BEHIND npm latest
+ *   - detect-release-drift.mjs — npm-published version missing a GH Release
+ * This one catches local src AHEAD of a static published version.
+ *
+ * Pure ESM with injected I/O (mirrors detect-release-drift.mjs) so the gate
+ * logic is unit-testable without any network or git. Emits a JSON report:
+ *   { sourceDrifted: [...], clean: [...], errors: [...] }
+ * Exits 0 iff sourceDrifted.length === 0 AND errors.length === 0.
+ *
+ * Invoked from .github/workflows/version-drift-check.yml (its output is merged
+ * into the shared version-drift Linear issue via linear-upsert-drift-issue.mjs).
+ * Requires a full-history checkout (fetch-depth: 0) — baseline resolution and
+ * the release-cycle count both walk git history/tags.
+ */
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const REPO_ROOT = join(__dirname, '..')
+
+/** A package must be static across this many release cycles to be flagged. */
+export const RELEASES_THRESHOLD = 3
+
+/**
+ * Publishable packages, grounded to PUBLISHABLE_PACKAGES_JSON in
+ * .github/workflows/publish.yml (a unit test asserts the names stay in sync).
+ * `registry` mirrors PACKAGE_SPECS in scripts/lib/version-utils.ts; `tagPrefix`
+ * mirrors TRACKED_PACKAGES in detect-release-drift.mjs. @smith-horn/enterprise
+ * publishes to GitHub Packages and has NO git tags, so it relies on the
+ * version-string baseline fallback.
+ */
+export const PUBLISHABLE_SPECS = [
+  { name: '@skillsmith/core', dir: 'core', tagPrefix: '@skillsmith/core-v' },
+  { name: '@skillsmith/mcp-server', dir: 'mcp-server', tagPrefix: '@skillsmith/mcp-server-v' },
+  { name: '@skillsmith/cli', dir: 'cli', tagPrefix: '@skillsmith/cli-v' },
+  { name: '@smith-horn/enterprise', dir: 'enterprise', registry: 'https://npm.pkg.github.com' },
+]
+
+/**
+ * Parse a 3-segment semver into [major, minor, patch]. Pre-release/build
+ * suffixes are stripped. Returns null for anything that isn't X.Y.Z.
+ */
+export function parseSemver(s) {
+  if (typeof s !== 'string') return null
+  const core = s.split(/[-+]/, 1)[0]
+  const parts = core.split('.').map((n) => Number.parseInt(n, 10))
+  if (parts.length !== 3 || parts.some((n) => !Number.isFinite(n))) return null
+  return parts
+}
+
+/** True iff semver a > b. Invalid inputs return false (treated as equal). */
+export function semverGt(a, b) {
+  const pa = parseSemver(a)
+  const pb = parseSemver(b)
+  if (!pa || !pb) return false
+  for (let i = 0; i < 3; i += 1) {
+    if (pa[i] > pb[i]) return true
+    if (pa[i] < pb[i]) return false
+  }
+  return false
+}
+
+/**
+ * True iff a commit subject is a release-version-bump commit, using the same
+ * 3-pattern matcher as findLastVersionBumpCommit in lib/release-changelog.ts.
+ * Used only by the countReleasesSince fallback (when no publishable tags are
+ * reachable after the baseline).
+ */
+export function isReleaseBumpSubject(subject) {
+  if (typeof subject !== 'string') return false
+  return (
+    subject.startsWith('chore(release):') ||
+    subject.startsWith('chore: bump version') ||
+    /^chore:.*bump.*\d+\.\d+\.\d+/.test(subject)
+  )
+}
+
+function git(args) {
+  return execFileSync('git', args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+}
+
+/**
+ * Default I/O using execFileSync (git/npm) + fs. Tests inject stubs.
+ * @typedef {{
+ *   readVersion: (dir: string) => string,
+ *   resolveBaselineRef: (spec: object, version: string) => string | null,
+ *   countReleasesSince: (baseline: string) => number,
+ *   srcChangedSince: (baseline: string, dir: string) => boolean,
+ *   publishedLatest: (name: string, registry?: string) => string | null | 'unverified',
+ * }} IO
+ */
+
+/** @returns {IO} */
+export function defaultIO() {
+  return {
+    readVersion: (dir) => {
+      const pj = JSON.parse(readFileSync(join(REPO_ROOT, 'packages', dir, 'package.json'), 'utf-8'))
+      return pj.version
+    },
+
+    resolveBaselineRef: (spec, version) => {
+      // Prefer the release tag (npmjs packages). The current version may be
+      // ahead of the latest tag (a bump landed but isn't tagged yet) — then the
+      // tag won't exist and we fall through to the version-string commit.
+      if (spec.tagPrefix) {
+        const tag = `${spec.tagPrefix}${version}`
+        try {
+          git(['rev-parse', '--verify', '--quiet', `${tag}^{commit}`])
+          return tag
+        } catch {
+          // tag absent — fall through
+        }
+      }
+      // Newest commit that introduced the current version into package.json
+      // (pickaxe). Survives revert/reintroduce + squash relocation; the search
+      // string is the prettier-canonical 2-space form.
+      try {
+        const out = git([
+          'log',
+          `-S"version": "${version}"`,
+          '--format=%H',
+          '--',
+          `packages/${spec.dir}/package.json`,
+        ]).trim()
+        const newest = out.split('\n')[0]?.trim()
+        return newest || null
+      } catch {
+        return null
+      }
+    },
+
+    countReleasesSince: (baseline) => {
+      // Primary: distinct commits targeted by a publishable version tag that are
+      // reachable from HEAD but not from the baseline (one weekly release cuts
+      // several package tags on one commit → dedup by SHA = one cycle).
+      let tags = []
+      try {
+        const out = git([
+          'tag',
+          '--merged',
+          'HEAD',
+          '--no-merged',
+          baseline,
+          '--list',
+          '@skillsmith/*-v*',
+        ]).trim()
+        tags = out
+          ? out
+              .split('\n')
+              .map((t) => t.trim())
+              .filter(Boolean)
+          : []
+      } catch {
+        tags = []
+      }
+      if (tags.length > 0) {
+        const shas = new Set()
+        for (const tag of tags) {
+          try {
+            shas.add(git(['rev-list', '-n', '1', tag]).trim())
+          } catch {
+            // unreadable tag — ignore
+          }
+        }
+        return shas.size
+      }
+      // Fallback: count release-bump commits in baseline..HEAD.
+      try {
+        const out = git(['log', `${baseline}..HEAD`, '--format=%s']).trim()
+        if (!out) return 0
+        return out.split('\n').filter(isReleaseBumpSubject).length
+      } catch {
+        return 0
+      }
+    },
+
+    srcChangedSince: (baseline, dir) => {
+      try {
+        const out = git([
+          'log',
+          `${baseline}..HEAD`,
+          '--format=%H',
+          '--',
+          `packages/${dir}/src`,
+        ]).trim()
+        return out.length > 0
+      } catch {
+        return false
+      }
+    },
+
+    publishedLatest: (name, registry) => {
+      const args = ['view', name, 'version']
+      if (registry) args.push(`--registry=${registry}`)
+      try {
+        const out = execFileSync('npm', args, {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 30_000,
+        }).trim()
+        return out || null
+      } catch (err) {
+        const stderr = (err.stderr || '').toString()
+        const message = err.message || ''
+        if (/E404|404 Not Found|not in this registry/i.test(stderr)) return null
+        const isAuth =
+          /E401|E403|Unauthorized|ENEEDAUTH|need(?:s)? auth|authentication/i.test(stderr) ||
+          /E401|E403|Unauthorized|ENEEDAUTH/i.test(message)
+        // A registry-targeted lookup (GitHub Packages) needs auth; CI runs it
+        // without a token. Degrade gracefully — never fail-close a GH-Packages
+        // lookup — and let the git signal decide. Anonymous npmjs auth errors
+        // are real, so fail-close those.
+        if (registry && isAuth) return 'unverified'
+        throw new Error(`npm view ${name} failed: ${message}${stderr ? '\n' + stderr : ''}`)
+      }
+    },
+  }
+}
+
+/**
+ * Evaluate one package. Pure given an IO. Returns a tagged result:
+ *   { kind: 'drift' | 'clean', ... }
+ */
+export function evaluatePackage(spec, io) {
+  const version = io.readVersion(spec.dir)
+  const baseline = io.resolveBaselineRef(spec, version)
+  if (!baseline) {
+    return { kind: 'clean', pkg: spec.name, version, note: 'no_baseline' }
+  }
+
+  const releasesElapsed = io.countReleasesSince(baseline)
+  const srcChanged = io.srcChangedSince(baseline, spec.dir)
+  const published = io.publishedLatest(spec.name, spec.registry)
+
+  if (published === null) {
+    // Never published — that's detect-release-drift's / a never-released
+    // concern, not a stale-published-artifact one.
+    return { kind: 'clean', pkg: spec.name, version, note: 'not_published', releasesElapsed }
+  }
+  if (published !== 'unverified') {
+    if (semverGt(published, version)) {
+      return { kind: 'clean', pkg: spec.name, version, note: 'behind_npm', published }
+    }
+    if (semverGt(version, published)) {
+      return { kind: 'clean', pkg: spec.name, version, note: 'pending_publish', published }
+    }
+    // version === published → frozen candidate
+  }
+
+  const registryUnverified = published === 'unverified'
+  if (releasesElapsed >= RELEASES_THRESHOLD && srcChanged) {
+    return { kind: 'drift', pkg: spec.name, version, releasesElapsed, baseline, registryUnverified }
+  }
+  return {
+    kind: 'clean',
+    pkg: spec.name,
+    version,
+    note: srcChanged ? 'within_threshold' : 'src_unchanged',
+    releasesElapsed,
+  }
+}
+
+/** Run the check across specs. The only side effects are inside `io`. */
+export function runSourceDriftCheck(specs, io) {
+  const report = { sourceDrifted: [], clean: [], errors: [] }
+  for (const spec of specs) {
+    try {
+      const result = evaluatePackage(spec, io)
+      const { kind, ...rest } = result
+      if (kind === 'drift') report.sourceDrifted.push(rest)
+      else report.clean.push(rest)
+    } catch (err) {
+      report.errors.push({ pkg: spec.name, error: String(err.message || err) })
+    }
+  }
+  return report
+}
+
+function main() {
+  const report = runSourceDriftCheck(PUBLISHABLE_SPECS, defaultIO())
+  console.log(JSON.stringify(report, null, 2))
+  const ok = report.sourceDrifted.length === 0 && report.errors.length === 0
+  process.exit(ok ? 0 : 1)
+}
+
+// Only execute when run directly, not when imported by tests.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/scripts/linear-upsert-drift-issue.mjs
+++ b/scripts/linear-upsert-drift-issue.mjs
@@ -222,7 +222,7 @@ export function buildDescription(report, dateIso = new Date().toISOString().slic
   const lines = []
   lines.push(`## Version Drift Detected - ${dateIso}`)
   lines.push('')
-  if (report.drifted.length > 0) {
+  if ((report.drifted || []).length > 0) {
     lines.push('### Drifted packages')
     lines.push('')
     lines.push('| Package | Local | npm latest |')
@@ -232,7 +232,23 @@ export function buildDescription(report, dateIso = new Date().toISOString().slic
     }
     lines.push('')
   }
-  if (report.errors.length > 0) {
+  if ((report.sourceDrifted || []).length > 0) {
+    // SMI-5120: published artifact frozen while src kept changing.
+    lines.push('### Source-vs-version drift (stale published artifact)')
+    lines.push('')
+    lines.push(
+      '_"Repo releases since baseline" is a repo-wide release-cycle count, not the package\'s own version bumps._'
+    )
+    lines.push('')
+    lines.push('| Package | Version | Repo releases since baseline | Registry |')
+    lines.push('|---------|---------|------------------------------|----------|')
+    for (const s of report.sourceDrifted) {
+      const registry = s.registryUnverified ? 'unverified' : 'verified'
+      lines.push(`| ${s.pkg} | ${s.version} | ${s.releasesElapsed} | ${registry} |`)
+    }
+    lines.push('')
+  }
+  if ((report.errors || []).length > 0) {
     lines.push('### npm lookup errors')
     lines.push('')
     lines.push('| Package | Error |')
@@ -327,7 +343,10 @@ async function main() {
     )
     process.exit(2)
   }
-  const hasDrift = (report.drifted || []).length > 0 || (report.errors || []).length > 0
+  const hasDrift =
+    (report.drifted || []).length > 0 ||
+    (report.sourceDrifted || []).length > 0 ||
+    (report.errors || []).length > 0
   if (!hasDrift) {
     console.log('No drift or errors — nothing to upsert.')
     return

--- a/scripts/tests/check-source-version-drift.test.ts
+++ b/scripts/tests/check-source-version-drift.test.ts
@@ -1,0 +1,161 @@
+/**
+ * SMI-5120 AC #3: tests for check-source-version-drift.mjs.
+ *
+ * All git/npm I/O is injected, so the gate logic is exercised with zero network
+ * or git. The "frozen" case is the bench-validation plant: it flags; removing
+ * ANY one gate (releases below threshold, src unchanged, version not equal to
+ * published) drops it out — proving the guard catches the remedy, not just the
+ * diagnosis.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  evaluatePackage,
+  runSourceDriftCheck,
+  semverGt,
+  isReleaseBumpSubject,
+  PUBLISHABLE_SPECS,
+  RELEASES_THRESHOLD,
+} from '../check-source-version-drift.mjs'
+
+const ENTERPRISE = {
+  name: '@smith-horn/enterprise',
+  dir: 'enterprise',
+  registry: 'https://npm.pkg.github.com',
+}
+
+/** A frozen-artifact IO: high release count, src changed, version == published. */
+function frozenIO(overrides = {}) {
+  return {
+    readVersion: () => '0.1.2',
+    resolveBaselineRef: () => 'baseline-sha',
+    countReleasesSince: () => RELEASES_THRESHOLD + 2,
+    srcChangedSince: () => true,
+    publishedLatest: () => '0.1.2',
+    ...overrides,
+  }
+}
+
+describe('evaluatePackage', () => {
+  it('flags a frozen published artifact (all gates satisfied)', () => {
+    const r = evaluatePackage(ENTERPRISE, frozenIO())
+    expect(r.kind).toBe('drift')
+    expect(r.pkg).toBe('@smith-horn/enterprise')
+    expect(r.version).toBe('0.1.2')
+    expect(r.releasesElapsed).toBe(RELEASES_THRESHOLD + 2)
+    expect(r.registryUnverified).toBe(false)
+  })
+
+  it('does NOT flag when release count is below threshold (recently bumped)', () => {
+    const r = evaluatePackage(
+      ENTERPRISE,
+      frozenIO({ countReleasesSince: () => RELEASES_THRESHOLD - 1 })
+    )
+    expect(r.kind).toBe('clean')
+    expect(r.note).toBe('within_threshold')
+  })
+
+  it('does NOT flag when src is unchanged since the baseline', () => {
+    const r = evaluatePackage(ENTERPRISE, frozenIO({ srcChangedSince: () => false }))
+    expect(r.kind).toBe('clean')
+    expect(r.note).toBe('src_unchanged')
+  })
+
+  it('does NOT flag when the local version is ahead of published (pending publish)', () => {
+    const r = evaluatePackage(ENTERPRISE, frozenIO({ publishedLatest: () => '0.1.1' }))
+    expect(r.kind).toBe('clean')
+    expect(r.note).toBe('pending_publish')
+  })
+
+  it('does NOT flag when the local version is behind published (check-version-drift territory)', () => {
+    const r = evaluatePackage(ENTERPRISE, frozenIO({ publishedLatest: () => '0.2.0' }))
+    expect(r.kind).toBe('clean')
+    expect(r.note).toBe('behind_npm')
+  })
+
+  it('flags on the git signal when the registry is unverifiable (GitHub Packages, no token)', () => {
+    const r = evaluatePackage(ENTERPRISE, frozenIO({ publishedLatest: () => 'unverified' }))
+    expect(r.kind).toBe('drift')
+    expect(r.registryUnverified).toBe(true)
+  })
+
+  it('does NOT flag a never-published package', () => {
+    const r = evaluatePackage(ENTERPRISE, frozenIO({ publishedLatest: () => null }))
+    expect(r.kind).toBe('clean')
+    expect(r.note).toBe('not_published')
+  })
+
+  it('does NOT flag when no baseline can be resolved', () => {
+    const r = evaluatePackage(ENTERPRISE, frozenIO({ resolveBaselineRef: () => null }))
+    expect(r.kind).toBe('clean')
+    expect(r.note).toBe('no_baseline')
+  })
+})
+
+describe('runSourceDriftCheck', () => {
+  it('partitions results into sourceDrifted / clean and surfaces thrown IO as errors', () => {
+    const specs = [
+      { name: '@frozen/pkg', dir: 'frozen' },
+      { name: '@healthy/pkg', dir: 'healthy' },
+      { name: '@broken/pkg', dir: 'broken' },
+    ]
+    const io = {
+      readVersion: (dir) => {
+        if (dir === 'broken') throw new Error('boom')
+        return '1.0.0'
+      },
+      resolveBaselineRef: () => 'baseline',
+      countReleasesSince: (baseline) => (baseline === 'baseline' ? RELEASES_THRESHOLD + 1 : 0),
+      srcChangedSince: (_baseline, dir) => dir === 'frozen',
+      publishedLatest: () => '1.0.0',
+    }
+    const report = runSourceDriftCheck(specs, io)
+    expect(report.sourceDrifted.map((d) => d.pkg)).toEqual(['@frozen/pkg'])
+    expect(report.clean.map((c) => c.pkg)).toEqual(['@healthy/pkg'])
+    expect(report.errors.map((e) => e.pkg)).toEqual(['@broken/pkg'])
+    // The drift entry carries no internal `kind` tag.
+    expect(report.sourceDrifted[0]).not.toHaveProperty('kind')
+  })
+})
+
+describe('semverGt', () => {
+  it('compares 3-segment semvers and treats invalid input as not-greater', () => {
+    expect(semverGt('0.2.0', '0.1.9')).toBe(true)
+    expect(semverGt('0.1.2', '0.1.2')).toBe(false)
+    expect(semverGt('0.1.1', '0.1.2')).toBe(false)
+    expect(semverGt('not-a-version', '0.1.0')).toBe(false)
+  })
+})
+
+describe('isReleaseBumpSubject (countReleasesSince fallback matcher)', () => {
+  it('matches the canonical 3 release-bump commit forms', () => {
+    expect(isReleaseBumpSubject('chore(release): publish 0.8.0')).toBe(true)
+    expect(isReleaseBumpSubject('chore: bump version to 0.8.0')).toBe(true)
+    expect(isReleaseBumpSubject('chore: bump @skillsmith/core 0.8.0')).toBe(true)
+  })
+
+  it('does not match ordinary feature/fix commits', () => {
+    expect(isReleaseBumpSubject('feat(core): add widget')).toBe(false)
+    expect(isReleaseBumpSubject('fix: handle null')).toBe(false)
+  })
+})
+
+describe('PUBLISHABLE_SPECS drift guard', () => {
+  it('stays in sync with PUBLISHABLE_PACKAGES_JSON in publish.yml', () => {
+    const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+    const publishYml = readFileSync(join(repoRoot, '.github/workflows/publish.yml'), 'utf8')
+    const match = publishYml.match(/PUBLISHABLE_PACKAGES_JSON:\s*'(\[[^']*\])'/)
+    expect(match, 'PUBLISHABLE_PACKAGES_JSON not found in publish.yml').toBeTruthy()
+    const declared = JSON.parse(match[1])
+    expect(PUBLISHABLE_SPECS.map((s) => s.name).sort()).toEqual([...declared].sort())
+  })
+
+  it('marks only @smith-horn/enterprise with a non-default registry', () => {
+    const withRegistry = PUBLISHABLE_SPECS.filter((s) => s.registry)
+    expect(withRegistry.map((s) => s.name)).toEqual(['@smith-horn/enterprise'])
+    expect(withRegistry[0].registry).toBe('https://npm.pkg.github.com')
+  })
+})

--- a/scripts/tests/linear-upsert-drift-issue.test.ts
+++ b/scripts/tests/linear-upsert-drift-issue.test.ts
@@ -81,6 +81,69 @@ describe('buildDescription', () => {
     expect(desc).toContain('### npm lookup errors')
     expect(desc).toContain('| @skillsmith/foo | getaddrinfo ENOTFOUND |')
   })
+
+  // SMI-5120: source-vs-version drift section.
+  it('renders the source-drift section with legend and a verified row', () => {
+    const desc = buildDescription(
+      {
+        drifted: [],
+        clean: [],
+        errors: [],
+        sourceDrifted: [
+          {
+            pkg: '@skillsmith/core',
+            version: '0.8.0',
+            releasesElapsed: 4,
+            registryUnverified: false,
+          },
+        ],
+      },
+      '2026-04-20'
+    )
+    expect(desc).toContain('### Source-vs-version drift (stale published artifact)')
+    expect(desc).toContain('Repo releases since baseline')
+    expect(desc).toContain('not the package')
+    expect(desc).toContain('| @skillsmith/core | 0.8.0 | 4 | verified |')
+  })
+
+  it('marks an unverified registry (GitHub Packages without auth)', () => {
+    const desc = buildDescription(
+      {
+        drifted: [],
+        clean: [],
+        errors: [],
+        sourceDrifted: [
+          {
+            pkg: '@smith-horn/enterprise',
+            version: '0.1.2',
+            releasesElapsed: 20,
+            registryUnverified: true,
+          },
+        ],
+      },
+      '2026-04-20'
+    )
+    expect(desc).toContain('| @smith-horn/enterprise | 0.1.2 | 20 | unverified |')
+  })
+
+  it('tolerates a report carrying only sourceDrifted (no drifted/errors keys)', () => {
+    const desc = buildDescription(
+      {
+        sourceDrifted: [
+          {
+            pkg: '@smith-horn/enterprise',
+            version: '0.1.2',
+            releasesElapsed: 20,
+            registryUnverified: true,
+          },
+        ],
+      },
+      '2026-04-20'
+    )
+    expect(desc).toContain('### Source-vs-version drift (stale published artifact)')
+    expect(desc).not.toContain('### Drifted packages')
+    expect(desc).not.toContain('### npm lookup errors')
+  })
 })
 
 describe('withRetry', () => {


### PR DESCRIPTION
## Summary

Closes **SMI-5120 AC #3** — the source-vs-version drift detector. Adds a weekly CI backstop that flags a publishable package whose `package.json` version has been static across ≥3 release cycles while its `src/` kept changing (a published artifact silently frozen on its registry — the `@smith-horn/enterprise` 0.1.2 failure mode that prompted SMI-5120).

- **`scripts/check-source-version-drift.mjs`** (new) — pure-ESM detector with injected I/O (mirrors `detect-release-drift.mjs`), unit-testable with zero network/git. Triple-gate: `releasesElapsed ≥ 3` AND `src/` changed since the version's baseline AND the version is not ahead of what's published. Registry-aware: graceful `unverified` for GitHub Packages without a token.
- **`scripts/linear-upsert-drift-issue.mjs`** — `buildDescription` renders a `sourceDrifted` section + legend; `hasDrift` includes it.
- **`.github/workflows/version-drift-check.yml`** — `fetch-depth: 0` (history + tags), the detector step, a guarded `jq -s` merge of both reports, and a fail gate that ORs both step exits. One weekly job, one shared Linear issue.

## ADR-109

Plan reviewed (VP Product/Eng/Design) — 2 Critical + 2 High + 4 Med/Low, all applied. The two Criticals (missing `fetch-depth: 0`; authoring as `.mjs` not `.ts` since the workflow runs no `npm ci`) would each have silently no-op'd the guard.

## Verification

- eslint 0, `tsc --build` clean, `audit:standards` 0 failures, vitest 25/25 (new), prettier clean.
- **Live functional bench-validation** against real git + registries: `@smith-horn/enterprise` flagged (releasesElapsed 22, registryUnverified) while core/mcp/cli stay clean (within_threshold) — no false positives.
- `jq -s` merge + missing/empty-source guard dry-runs verified.

## Test plan

- [ ] CI green (Docker).
- [ ] Post-merge **smoke**: `gh workflow run version-drift-check.yml` on `main` flags the live-frozen enterprise (fetch-depth + jq + upsert wiring proven against real CI). SMI-5120 → Done only after this.

## Notes

- `[skip-impl-check]` — CI-tooling + tests, no `packages/*/src` change.
- Implementation plan, code-review report, and retro land in a follow-up `chore(docs)` pointer-bump PR (per the docs/internal submodule workflow).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)