### PR TITLE
feat(ci): SMI-5162 static guard for out-of-order migration additions

### DIFF
--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -700,6 +700,63 @@ export const findUnsafeSkillsRecreateMigrations = (migrationsByPath, { allowList
 }
 
 /**
+ * SMI-5162: detect out-of-order added migrations.
+ *
+ * Returns a violation for every ADDED migration whose version prefix sorts
+ * (lexicographically) strictly below the maximum version prefix among the
+ * PRE-EXISTING (base) migrations. Such a migration would be silently skipped
+ * by `supabase db push` (it sorts below the applied tip), exactly the SMI-5159
+ * /account/telemetry incident.
+ *
+ * Pure: no git, no fs, no content parsing. Version = the substring before the
+ * first underscore (e.g. `20260519000005` from `20260519000005_foo.sql`, or
+ * `077` from `077_bar.sql`). Lexicographic comparison is correct across both
+ * schemes because every legacy `NNN_` prefix begins with a digit < '2' while
+ * every 14-digit timestamp begins with '2026…' (verified: 84 legacy + 14
+ * timestamp prefixes, no intermediate lengths, as of 2026-05-23).
+ *
+ * @param {string[]} addedBasenames — basenames of *.sql migrations added vs base.
+ * @param {string[]} baseBasenames — basenames of all *.sql migrations on base.
+ * @returns {{ maxBaseVersion: string|null, violations: Array<{file: string, version: string, maxBaseVersion: string}> }}
+ */
+export const findOutOfOrderMigrations = (addedBasenames, baseBasenames) => {
+  // Filter to .sql only (defensive; caller already filters).
+  const toSql = (names) => names.filter((n) => n.endsWith('.sql'))
+  const addedSql = toSql(addedBasenames)
+  const baseSql = toSql(baseBasenames)
+
+  // Extract version prefix (everything before the first underscore).
+  // Skip any basename with no underscore or an empty version token —
+  // malformed names are R-Filename's concern, not ordering's.
+  const extractVersion = (basename) => {
+    const idx = basename.indexOf('_')
+    if (idx <= 0) return null
+    return basename.slice(0, idx)
+  }
+
+  // Empty base → first-ever migration or no base context. No-op.
+  const baseVersions = baseSql.map(extractVersion).filter((v) => v !== null)
+  if (baseVersions.length === 0) {
+    return { maxBaseVersion: null, violations: [] }
+  }
+
+  // maxBaseVersion by plain string > comparison (correct across both schemes).
+  const maxBaseVersion = baseVersions.reduce((max, v) => (v > max ? v : max))
+
+  const violations = []
+  for (const basename of addedSql) {
+    const version = extractVersion(basename)
+    if (version === null) continue // malformed — skip
+    // Strict < only. Equal is allowed (duplicate-version is SMI-5163's scope).
+    if (version < maxBaseVersion) {
+      violations.push({ file: basename, version, maxBaseVersion })
+    }
+  }
+
+  return { maxBaseVersion, violations }
+}
+
+/**
  * Check pure-JS carve-out invariants on a parsed job list.
  *
  * Invariant A: every job with `needs:` containing `docker-build` must either

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -28,6 +28,7 @@ import {
   parseCiYmlJobs,
   checkCarveOutInvariants,
   findUnsafeSkillsRecreateMigrations,
+  findOutOfOrderMigrations,
   parseBashArray,
   parseConsumersTag,
   findConventionDrift,
@@ -4210,6 +4211,100 @@ console.log(`\n${BOLD}49. Convention drift backstop (SMI-5026 M5)${RESET}`)
       }
     } catch (e) {
       warn(`Could not run Check 49 (convention drift backstop): ${e.message}`)
+    }
+  }
+}
+
+// Check 50: Migration ordering guard (SMI-5162 / SMI-5159 recurrence guard)
+console.log(`\n${BOLD}50. Migration Ordering Guard (SMI-5162)${RESET}`)
+{
+  const MIG = 'supabase/migrations'
+  const baseRef = process.env.GITHUB_BASE_REF
+  let added = []
+  let baseFiles = []
+  let skipReason = null
+  try {
+    if (baseRef && baseRef.length > 0) {
+      // PR context: resolve the merge-base SHA so the BASE set reflects what
+      // this branch actually forked from, not the current tip of origin/<base>
+      // (E3: if main advanced after this branch forked, using ls-tree
+      // origin/<base> would inflate maxBaseVersion and false-fail a correctly
+      // ordered migration).
+      const mergeBase = execSync(`git merge-base origin/${baseRef} HEAD`, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim()
+      // ADDED set: --diff-filter=AR (E2) catches git-mv renames (R) in addition
+      // to plain adds (A). --name-only prints the NEW path for renames, which is
+      // the name that governs ordering. Three-dot = diff against merge-base,
+      // matching the Check 45 pattern.
+      added = execSync(`git diff --name-only --diff-filter=AR ${mergeBase}...HEAD -- ${MIG}/`, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+        .split('\n')
+        .filter(Boolean)
+      // BASE set: list the merge-base tree (not the branch tip).
+      baseFiles = execSync(`git ls-tree -r --name-only ${mergeBase} -- ${MIG}/`, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+        .split('\n')
+        .filter(Boolean)
+    } else {
+      // Local run (no PR base ref). Fall back to origin/main if present; else skip.
+      const base = execSync('git rev-parse --verify --quiet origin/main || true', {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim()
+      if (!base) {
+        skipReason = 'no origin/main ref (shallow/local)'
+      } else {
+        const mergeBase = execSync('git merge-base origin/main HEAD', {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim()
+        added = execSync(`git diff --name-only --diff-filter=AR ${mergeBase}...HEAD -- ${MIG}/`, {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
+          .split('\n')
+          .filter(Boolean)
+        baseFiles = execSync(`git ls-tree -r --name-only ${mergeBase} -- ${MIG}/`, {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
+          .split('\n')
+          .filter(Boolean)
+      }
+    }
+  } catch (e) {
+    // Shallow clone, detached HEAD, no base — must NOT false-fail. Mirror
+    // Check 45's catch-and-skip behaviour.
+    skipReason = e.message
+  }
+
+  if (skipReason) {
+    pass(`Migration ordering guard skipped (${skipReason})`)
+  } else {
+    const toBase = (p) => p.split('/').pop()
+    const addedSql = added.filter((f) => f.endsWith('.sql')).map(toBase)
+    const baseSql = baseFiles.filter((f) => f.endsWith('.sql')).map(toBase)
+    const { maxBaseVersion, violations } = findOutOfOrderMigrations(addedSql, baseSql)
+    if (addedSql.length === 0) {
+      pass('No migrations added in this diff')
+    } else if (violations.length === 0) {
+      pass(
+        `All ${addedSql.length} added migration(s) sort at/above base tip ${maxBaseVersion ?? '(none)'}`
+      )
+    } else {
+      for (const v of violations) {
+        fail(
+          `Out-of-order migration: ${v.file} (version ${v.version}) sorts BELOW base tip ${v.maxBaseVersion} — ` +
+            `would be SILENTLY SKIPPED by \`supabase db push\` (exit 0) — the SMI-5159 /account/telemetry incident.`,
+          `Rename to a version > ${v.maxBaseVersion} (e.g. \`$(date -u +%Y%m%d%H%M%S)_<name>.sql\`). SQL content unchanged.`
+        )
+      }
     }
   }
 }

--- a/scripts/tests/audit-standards-migration-ordering.test.ts
+++ b/scripts/tests/audit-standards-migration-ordering.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the SMI-5162 migration ordering guard helper.
+ *
+ * Covers `findOutOfOrderMigrations` in audit-standards-helpers.mjs.
+ *
+ * Background: a migration whose version prefix (the part before the first
+ * underscore) sorts lexicographically BELOW the maximum pre-existing migration
+ * version will be silently skipped by `supabase db push` — exactly the
+ * SMI-5159 /account/telemetry incident. This pure helper is the logic layer;
+ * Check 50 in audit-standards.mjs provides the git I/O layer.
+ */
+import { describe, expect, it } from 'vitest'
+
+const helpers = (await import('../audit-standards-helpers.mjs')) as {
+  findOutOfOrderMigrations: (
+    addedBasenames: string[],
+    baseBasenames: string[]
+  ) => {
+    maxBaseVersion: string | null
+    violations: Array<{ file: string; version: string; maxBaseVersion: string }>
+  }
+}
+
+const { findOutOfOrderMigrations } = helpers
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('findOutOfOrderMigrations (SMI-5162)', () => {
+  it('out-of-order timestamp fails: added version below base tip → 1 violation', () => {
+    const { maxBaseVersion, violations } = findOutOfOrderMigrations(
+      ['20260519000005_skill_invoke_rpcs.sql'],
+      ['20260521000001_team_member_visibility.sql']
+    )
+    expect(maxBaseVersion).toBe('20260521000001')
+    expect(violations).toHaveLength(1)
+    expect(violations[0].file).toBe('20260519000005_skill_invoke_rpcs.sql')
+    expect(violations[0].version).toBe('20260519000005')
+    expect(violations[0].maxBaseVersion).toBe('20260521000001')
+  })
+
+  it('ordered timestamp passes: added version above base tip → 0 violations', () => {
+    const { maxBaseVersion, violations } = findOutOfOrderMigrations(
+      ['20260522000001_new_feature.sql'],
+      ['20260521000001_team_member_visibility.sql']
+    )
+    expect(maxBaseVersion).toBe('20260521000001')
+    expect(violations).toHaveLength(0)
+  })
+
+  it('equal version is allowed (no false-fail): added version equals base tip → 0 violations', () => {
+    // Duplicate-version detection is SMI-5163's scope; this guard uses strict <.
+    const { maxBaseVersion, violations } = findOutOfOrderMigrations(
+      ['20260521000001_duplicate_name.sql'],
+      ['20260521000001_team_member_visibility.sql']
+    )
+    expect(maxBaseVersion).toBe('20260521000001')
+    expect(violations).toHaveLength(0)
+  })
+
+  it('cross-scheme is safe: timestamp add above legacy base tip → 0 violations', () => {
+    // Legacy prefixes start with '0', timestamps with '2' — lexicographic order is correct.
+    const { maxBaseVersion, violations } = findOutOfOrderMigrations(
+      ['20260101000001_new_ts_migration.sql'],
+      ['084_legacy_migration.sql']
+    )
+    expect(maxBaseVersion).toBe('084')
+    expect(violations).toHaveLength(0)
+  })
+
+  it('legacy add below timestamp tip fails: adding legacy NNN below 14-digit tip → 1 violation', () => {
+    const { maxBaseVersion, violations } = findOutOfOrderMigrations(
+      ['085_new_legacy.sql'],
+      ['20260521000001_team_member_visibility.sql']
+    )
+    expect(maxBaseVersion).toBe('20260521000001')
+    expect(violations).toHaveLength(1)
+    expect(violations[0].version).toBe('085')
+  })
+
+  it('empty base no-ops: first-ever migration → 0 violations, maxBaseVersion null', () => {
+    const { maxBaseVersion, violations } = findOutOfOrderMigrations(['001_initial_schema.sql'], [])
+    expect(maxBaseVersion).toBeNull()
+    expect(violations).toHaveLength(0)
+  })
+
+  it('mixed added set: one in-order + one out-of-order → exactly 1 violation, the right file', () => {
+    const { maxBaseVersion, violations } = findOutOfOrderMigrations(
+      ['20260519000005_old_invoke_rpcs.sql', '20260522000001_correct_order.sql'],
+      ['20260521000001_team_member_visibility.sql']
+    )
+    expect(maxBaseVersion).toBe('20260521000001')
+    expect(violations).toHaveLength(1)
+    expect(violations[0].file).toBe('20260519000005_old_invoke_rpcs.sql')
+  })
+
+  it('malformed basename (no underscore) is ignored: not a violation', () => {
+    const { violations } = findOutOfOrderMigrations(
+      ['no-underscore.sql'],
+      ['20260521000001_team_member_visibility.sql']
+    )
+    expect(violations).toHaveLength(0)
+  })
+
+  it('rename destination basename treated as added: if below tip → 1 violation', () => {
+    // The --diff-filter=AR wiring in Check 50 passes the destination basename
+    // to this helper. Assert that a below-tip destination correctly fails.
+    const { violations } = findOutOfOrderMigrations(
+      ['20260518000001_renamed_destination.sql'],
+      ['20260521000001_team_member_visibility.sql']
+    )
+    expect(violations).toHaveLength(1)
+    expect(violations[0].file).toBe('20260518000001_renamed_destination.sql')
+  })
+})


### PR DESCRIPTION
## What

Adds **Check 50** to `audit:standards`: on changes touching `supabase/migrations/`, fail when a newly-added migration version sorts **below** the max pre-existing version. Recurrence guard for the **SMI-5159** prod incident — `20260519000005_skill_invoke_rpcs.sql` was committed after `20260520/21000001` already existed, sorted below the applied tip, and was silently skipped by `supabase db push` (exit 0), breaking `/account/telemetry` + 3 analytics RPCs in prod.

## How

- `findOutOfOrderMigrations` — pure, filename-only helper in `scripts/audit-standards-helpers.mjs` (strict `<`; equal/duplicate-version is SMI-5163's scope).
- **Check 50** in `scripts/audit-standards.mjs` — merge-base diff (`--diff-filter=AR` catches renames; merge-base base-set avoids stale-branch false-fail), graceful-skip on shallow/no-base, mirrors the existing Check 45 `origin/<base>...HEAD` try/catch idiom. Runs in the existing `quality-checks` host job (already `fetch-depth: 0`) — no new workflow, no prod creds.
- `scripts/tests/audit-standards-migration-ordering.test.ts` — 9 cases.

## Why this design (ADR-109)

SPARC research + plan-review: `docs/internal/implementation/smi-5162-migration-ordering-guard.md`. `quality-checks` already checks out at `fetch-depth: 0` (ci.yml:999), so the merge-base diff works with zero CI changes.

## Verification

- `npm run audit:standards` → 77 passed, 0 failed (Check 50 green); only warning is the pre-existing `.claude/hive-mind` pointer (Check 21).
- New vitest: 9/9 green.
- Synthetic out-of-order fixture → Check 50 fails as designed.

## Follow-ups
- **SMI-5163**: extend to duplicate-version collisions (plan-review finding E1).
- (under SMI-5159) staging was 12 migrations behind prod — both DBs now reconciled; `scripts/apply-075-audit-logs-index.sh` references a wrong staging password var.

Refs SMI-5162 (child of SMI-5159).

[skip-smoke] — CI-only change, no prod runtime surface.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)