### PR TITLE
fix(docker): entrypoint npm rebuild blocked by .npmrc ignore-scripts=true (SMI-5200)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,7 @@ Project skills load from the `.claude/skills/` mount-point of the `skillsmith-st
 |---------|-----|
 | Container won't start | `docker compose --profile dev down && docker volume rm skillsmith_node_modules && docker compose --profile dev up -d` |
 | Native module errors | `docker exec skillsmith-dev-1 npm rebuild better-sqlite3 onnxruntime-node` |
+| `hnswlib-node` fails validation after rebuild (`ignore-scripts=true` in `.npmrc` blocks node-gyp) | `docker compose --profile dev down && docker volume rm skillsmith_node_modules && docker compose --profile dev up -d` — removes stale volume so Docker re-initialises from image layer (compiled without `.npmrc`). Permanent fix: SMI-5200 |
 | Platform mismatch (SIGKILL 137) | `rm -rf packages/*/node_modules/better-sqlite3 packages/*/node_modules/onnxruntime-node` then rebuild |
 | Node ABI mismatch | WASM fallback auto-activates (core ≥0.4.10). Restore native: rebuild in Docker + `./scripts/repair-host-native-deps.sh` (SMI-4549) |
 | "invalid ELF header" in Docker (SMI-4698) | [git-crypt-guide.md § Host Native Bindings](.claude/development/git-crypt-guide.md#host-native-bindings--sessionstart-instrumentation-smi-4549) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ Project skills load from the `.claude/skills/` mount-point of the `skillsmith-st
 |---------|-----|
 | Container won't start | `docker compose --profile dev down && docker volume rm skillsmith_node_modules && docker compose --profile dev up -d` |
 | Native module errors | `docker exec skillsmith-dev-1 npm rebuild better-sqlite3 onnxruntime-node` |
-| `hnswlib-node` fails validation after rebuild (`ignore-scripts=true` in `.npmrc` blocks node-gyp) | `docker compose --profile dev down && docker volume rm skillsmith_node_modules && docker compose --profile dev up -d` — removes stale volume so Docker re-initialises from image layer (compiled without `.npmrc`). Permanent fix: SMI-5200 |
+| `hnswlib-node` fails validation after rebuild (`ignore-scripts=true` in `.npmrc` blocks node-gyp — see SMI-5200) | Permanent fix ships in PR #1365. Until merged, delete the stale volume so Docker re-initialises `node_modules` from the image layer (built without `.npmrc`): `docker compose --profile dev down && docker volume rm skillsmith_node_modules && docker compose --profile dev up -d` |
 | Platform mismatch (SIGKILL 137) | `rm -rf packages/*/node_modules/better-sqlite3 packages/*/node_modules/onnxruntime-node` then rebuild |
 | Node ABI mismatch | WASM fallback auto-activates (core ≥0.4.10). Restore native: rebuild in Docker + `./scripts/repair-host-native-deps.sh` (SMI-4549) |
 | "invalid ELF header" in Docker (SMI-4698) | [git-crypt-guide.md § Host Native Bindings](.claude/development/git-crypt-guide.md#host-native-bindings--sessionstart-instrumentation-smi-4549) |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -134,7 +134,7 @@ if [ $VALIDATION_FAILED -eq 1 ]; then
 
     for module in "${NATIVE_MODULES[@]}"; do
         echo -e "${YELLOW}  Rebuilding ${module}...${NC}"
-        npm rebuild "${module}" 2>/dev/null || true
+        npm rebuild "${module}" --ignore-scripts=false
     done
 
     # Re-validate after rebuild
@@ -149,6 +149,7 @@ if [ $VALIDATION_FAILED -eq 1 ]; then
     if [ $REBUILD_FAILED -eq 1 ]; then
         echo -e "${RED}[entrypoint] Native module validation failed after rebuild.${NC}"
         echo -e "${YELLOW}Try: docker compose down && docker compose build --no-cache${NC}"
+        echo -e "${YELLOW}For verbose rebuild output (run on host): docker exec <container> npm rebuild hnswlib-node${NC}"
         exit 1
     fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -113,7 +113,8 @@ echo -e "${YELLOW}[entrypoint] Validating native modules...${NC}"
 # (SMI-4672), this loop is the only runtime rebuild path on cache miss / ABI
 # mismatch — missing a module silently fails open (mock embedding fallback per
 # ADR-009, brute-force vector search per SMI-4577, esbuild platform-binary
-# breakage). Keep this array in sync with Dockerfile:73.
+# breakage). Source-only packages (hnswlib-node) use --ignore-scripts=false so
+# node-gyp runs despite .npmrc (SMI-5200). Keep this array in sync with Dockerfile:73.
 NATIVE_MODULES=("better-sqlite3" "onnxruntime-node" "esbuild" "hnswlib-node")
 
 # Track validation status
@@ -134,22 +135,31 @@ if [ $VALIDATION_FAILED -eq 1 ]; then
 
     for module in "${NATIVE_MODULES[@]}"; do
         echo -e "${YELLOW}  Rebuilding ${module}...${NC}"
-        npm rebuild "${module}" --ignore-scripts=false || echo -e "${YELLOW}  ↳ npm rebuild exited non-zero for ${module} (see output above)${NC}"
+        # hnswlib-node ships source-only (gypfile: true); --ignore-scripts=false overrides .npmrc
+        # so node-gyp runs (SMI-5200). Prebuilt-binary packages (others) don't need this and it
+        # would re-trigger their CDN download hooks unnecessarily.
+        if [ "${module}" = "hnswlib-node" ]; then
+            npm rebuild "${module}" --ignore-scripts=false || echo -e "${YELLOW}  ↳ npm rebuild exited non-zero for ${module} (see output above)${NC}"
+        else
+            npm rebuild "${module}" || echo -e "${YELLOW}  ↳ npm rebuild exited non-zero for ${module} (see output above)${NC}"
+        fi
     done
 
     # Re-validate after rebuild
     REBUILD_FAILED=0
+    FAILED_MODULES=""
     for module in "${NATIVE_MODULES[@]}"; do
         if ! node -e "require('${module}')" 2>/dev/null; then
             echo -e "${RED}  ✗ ${module} - still failing after rebuild${NC}"
             REBUILD_FAILED=1
+            FAILED_MODULES="${FAILED_MODULES:+$FAILED_MODULES }${module}"
         fi
     done
 
     if [ $REBUILD_FAILED -eq 1 ]; then
         echo -e "${RED}[entrypoint] Native module validation failed after rebuild.${NC}"
         echo -e "${YELLOW}Try: docker compose down && docker compose build --no-cache${NC}"
-        echo -e "${YELLOW}For verbose rebuild output (run on host): docker exec <container> npm rebuild hnswlib-node${NC}"
+        echo -e "${YELLOW}For verbose rebuild output (run on host): docker exec skillsmith-dev-1 npm rebuild ${FAILED_MODULES}${NC}"
         exit 1
     fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -134,7 +134,7 @@ if [ $VALIDATION_FAILED -eq 1 ]; then
 
     for module in "${NATIVE_MODULES[@]}"; do
         echo -e "${YELLOW}  Rebuilding ${module}...${NC}"
-        npm rebuild "${module}" --ignore-scripts=false
+        npm rebuild "${module}" --ignore-scripts=false || echo -e "${YELLOW}  ↳ npm rebuild exited non-zero for ${module} (see output above)${NC}"
     done
 
     # Re-validate after rebuild


### PR DESCRIPTION
## Summary

- Root cause confirmed by Peter Lee (open source contributor, 2026-05-25): `ignore-scripts=true` in `.npmrc` is bind-mounted into the container at `/app/.npmrc`, causing `npm rebuild hnswlib-node` to skip node-gyp entirely and exit 0 with no binary produced
- `hnswlib-node@3.0.0` ships source-only (`gypfile: true`) and requires compilation; the other three native modules use prebuilt binaries and are unaffected
- Fix: add `--ignore-scripts=false` to override `.npmrc` in the rebuild loop; replace `2>/dev/null || true` with visible output + `set -e`-safe error handling

## Test plan

- [ ] `docker compose --profile dev down && docker volume rm skillsmith_node_modules && docker compose --profile dev up -d` — workaround still valid pre-merge
- [ ] After merging: start fresh container with `.npmrc` `ignore-scripts=true` present on host; all four native modules should validate ✓
- [ ] Force a rebuild failure (e.g. temporarily remove g++ in container) — error now surfaces in logs instead of being swallowed
- [ ] `docker exec skillsmith-dev-1 npm run preflight` green

## Notes

Workaround for contributors until merged:
```
docker compose --profile dev down
docker volume rm skillsmith_node_modules
docker compose --profile dev up -d
```

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)