### PR TITLE
fix(core): add ./services/skill-installation-validate package export (SMI-4745 retro)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,6 +61,11 @@
       "import": "./dist/src/services/skill-installation.io.js",
       "default": "./dist/src/services/skill-installation.io.js"
     },
+    "./services/skill-installation-validate": {
+      "types": "./dist/src/services/skill-installation.validate.d.ts",
+      "import": "./dist/src/services/skill-installation.validate.js",
+      "default": "./dist/src/services/skill-installation.validate.js"
+    },
     "./config/audit-mode": {
       "types": "./dist/src/config/audit-mode.d.ts",
       "import": "./dist/src/config/audit-mode.js",


### PR DESCRIPTION
## Summary

- Post-merge governance retro on PR #1366 found `skill-installation.validate.ts` missing a package export.
- The SMI-4745 domain split added `./services/skill-installation-io` as a public entry-point for the io module but left the peer validate module without one.
- `checkDepsAgainstQuarantine`, `validateSkillMd`, `parseSkillIdInternal`, and `resolveRegistryInstall` were previously reachable via `./services/skill-installation-helpers`; adding `./services/skill-installation-validate` restores API surface parity across all three domain modules.

## Finding origin

Zero-deferral governance retro on squash `09bc6c4c` (PR #1366). Severity: Low.

## Test plan

- [x] Pre-commit typecheck + lint passed (`d3b9c035`)
- [x] Pre-push Docker test suite passed (all packages green)
- [ ] CI Build + Quality Checks pass

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)


[skip-impl-check]
