### PR TITLE
fix(core,mcp-server): align scanner thresholds for official/unverified tiers (SMI-5205 retro)

### DIFF
--- a/packages/core/src/services/skill-installation.types.ts
+++ b/packages/core/src/services/skill-installation.types.ts
@@ -261,7 +261,7 @@ export const TRUST_TIER_SCANNER_OPTIONS: Record<TrustTier, ScannerOptions> = {
     maxContentLength: 2_000_000,
   },
   unverified: {
-    riskThreshold: 15,
+    riskThreshold: 20, // Same as unknown — unverified is the public alias for unknown
     maxContentLength: 250_000,
   },
 }

--- a/packages/mcp-server/src/tools/install.types.ts
+++ b/packages/mcp-server/src/tools/install.types.ts
@@ -67,8 +67,8 @@ export function validateTrustTier(value: string | null | undefined): TrustTier {
  */
 export const TRUST_TIER_SCANNER_OPTIONS: Record<TrustTier, ScannerOptions> = {
   official: {
-    // SMI-5205: Platform/partner skills with full security review — same tolerance as verified
-    riskThreshold: 70, // Higher threshold - more tolerant
+    // SMI-5205: Platform/partner skills with full security review — more permissive than verified
+    riskThreshold: 80, // Higher than verified (70); official tier has full Skillsmith security audit
     maxContentLength: 2_000_000, // Allow larger skills
   },
   verified: {


### PR DESCRIPTION
## Summary

Post-merge governance retro finding from SMI-5205. Two `TRUST_TIER_SCANNER_OPTIONS` objects in different packages had inconsistent `riskThreshold` values for the new tiers added in SMI-5205.

- `official`: `packages/mcp-server/src/tools/install.types.ts` used 70 (same as verified). Corrected to 80 — `official` ranks above `verified` (tier 5 vs 4) and carries a full Skillsmith security audit.
- `unverified`: `packages/core/src/services/skill-installation.types.ts` used 15 (stricter than unknown). Corrected to 20 — `unverified` is the public alias for `unknown` and should use the same threshold.

Also includes the SMI-5205 governance retro report in `docs/internal/retros/`.

## Test plan

- [ ] `npm run typecheck` — passes (no type changes, threshold values are `number`)
- [ ] `npm run lint` — passes
- [ ] No behaviour change in test suite (scanner thresholds are not tested directly; functional correctness unchanged)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)