### PR TITLE
fix(ci): allowlist D1DX/secret-capture-skill — sensitive_path .env false positive (SMI-5206)

### DIFF
--- a/data/skills-security-allowlist.json
+++ b/data/skills-security-allowlist.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-21T18:30:00.000Z",
+  "generatedAt": "2026-06-02T00:00:00.000Z",
   "allowlist": [
     {
       "skillId": "github/kcmadden/claude-code-1password-skill",
@@ -65,6 +65,15 @@
       "reviewedBy": "ryansmith108",
       "reviewedAt": "2026-05-17",
       "expiresAt": "2026-08-15"
+    },
+    {
+      "skillId": "github/D1DX/secret-capture-skill",
+      "findingType": "sensitive_path",
+      "messagePattern": "\\.env",
+      "reason": "Secret-routing utility (analogous to Varlock) that captures credentials via a hidden-input dialog and routes them to vaults/stores without the value appearing in any tool result, log, or transcript. The env-file adapter writes to a local .env (0600) as one of eight routing destinations; the bare-keyword sensitive_path regex fires on the repo description's mention of '.env file' as a destination. Same false-positive class as github/RobinGase/skill-protocol-rs and github/dokind/qpay-skills. Triaged 2026-05-31 under SMI-5206 — Wave 2 sensitive_path tightening (require assignment/path context) will eliminate this class of false positive. Closes GH #1343.",
+      "reviewedBy": "ryansmith108",
+      "reviewedAt": "2026-05-31",
+      "expiresAt": "2026-08-29"
     }
   ]
 }

--- a/packages/core/tests/skill-scanner/allowlist.test.ts
+++ b/packages/core/tests/skill-scanner/allowlist.test.ts
@@ -391,10 +391,11 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
     const filePath = path.resolve(__dirname, '../../../../data/skills-security-allowlist.json')
     const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
     const parsed = parseAllowlistFile(raw)
-    expect(parsed.allowlist.length).toBe(7)
+    expect(parsed.allowlist.length).toBe(8)
     const ids = parsed.allowlist.map((e) => e.skillId).sort()
     expect(ids).toEqual(
       [
+        'github/D1DX/secret-capture-skill',
         'github/RENJI04/prompt-injection-auditor',
         'github/RobinGase/skill-protocol-rs',
         'github/StrategicPromptArchitect-AI/MalPromptSentinel-CC-Skill',

--- a/packages/core/tests/skill-scanner/allowlist.test.ts
+++ b/packages/core/tests/skill-scanner/allowlist.test.ts
@@ -387,6 +387,10 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
   // SMI-4934 (2026-05-17): qpay-skills added — QPay payment-integration skill
   // whose subject matter is .env credential setup; bare-keyword sensitive_path
   // regex false-positives until Wave 2 tightens.
+  // SMI-5206 (2026-05-31): D1DX/secret-capture-skill added — secret-routing
+  // utility whose repo description mentions '.env file' as one of eight routing
+  // destinations; bare-keyword sensitive_path regex false-positives until
+  // Wave 2 tightens.
   it('is parseable and every entry expires 90 days after review', () => {
     const filePath = path.resolve(__dirname, '../../../../data/skills-security-allowlist.json')
     const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))


### PR DESCRIPTION
## Summary

- `github/D1DX/secret-capture-skill` quarantined post-allowlist on 2026-05-31 weekly scan ([run #26701581790](https://github.com/smith-horn/skillsmith/actions/runs/26701581790)) for a HIGH `sensitive_path: \.env` finding
- Triaged: **false positive** — same class as `skill-protocol-rs` and `qpay-skills`. The skill is a secret-routing utility (analogous to Varlock); `.env` appears in the repo description as a documented routing destination, not a leak vector
- Adds allowlist entry + updates ship-it sanity test (count 7→8, adds skill ID to sorted array)
- Closes GH #1343

## Test plan

- [x] `packages/core/tests/skill-scanner/allowlist.test.ts` — 24/24 pass locally
- [x] `npm run audit:standards` — 0 failures
- [x] Pre-push: typecheck ✓, security tests ✓, full test suite ✓
- [ ] After merge: trigger `gh workflow run weekly-security-scan.yml` and confirm "Fail if post-allowlist quarantine is non-empty" exits 0

Linear: [SMI-5206](https://linear.app/smith-horn-group/issue/SMI-5206)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)