### PR TITLE
fix(mcp-server): use npx -p flag to reliably resolve skillsmith-mcp binary (SMI-5208)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -44,9 +44,9 @@ so this README and the website docs cannot drift.
 ```json
 {
   "mcpServers": {
-    "@skillsmith/mcp-server": {
+    "skillsmith": {
       "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
+      "args": ["-y", "-p", "@skillsmith/mcp-server", "skillsmith-mcp"],
       "env": {
         "SKILLSMITH_API_KEY": "sk_live_..."
       }
@@ -59,15 +59,18 @@ Restart Claude Code after editing settings.json.
 
 </details>
 
+<!-- SMI-5208: contributor-only warning — do not remove or move inside template snippets -->
+> **Skillsmith contributors:** If you're working inside the skillsmith monorepo, do NOT add the above global `~/.claude/settings.json` entry. The project's `.mcp.json` already configures the `skillsmith` MCP server via `scripts/mcp-skillsmith-launcher.sh`. Adding a global entry causes Claude Code to attempt a second connection that also announces as `skillsmith-mcp`, resulting in "Failed to reconnect to skillsmith" errors. Remove the global entry; the project entry takes precedence.
+
 <details>
 <summary><strong>Cursor</strong> — <code>~/.cursor/mcp.json</code></summary>
 
 ```json
 {
   "mcpServers": {
-    "@skillsmith/mcp-server": {
+    "skillsmith": {
       "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
+      "args": ["-y", "-p", "@skillsmith/mcp-server", "skillsmith-mcp"],
       "env": {
         "SKILLSMITH_API_KEY": "sk_live_..."
       }
@@ -86,9 +89,9 @@ Cursor 2.4+ required. Reload the window after saving.
 ```json
 {
   "mcpServers": {
-    "@skillsmith/mcp-server": {
+    "skillsmith": {
       "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
+      "args": ["-y", "-p", "@skillsmith/mcp-server", "skillsmith-mcp"],
       "env": {
         "SKILLSMITH_API_KEY": "sk_live_..."
       }
@@ -107,9 +110,9 @@ VS Code 1.108+ required. Workspace-scoped (commit to repo if team-shared, or use
 ```json
 {
   "mcpServers": {
-    "@skillsmith/mcp-server": {
+    "skillsmith": {
       "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
+      "args": ["-y", "-p", "@skillsmith/mcp-server", "skillsmith-mcp"],
       "env": {
         "SKILLSMITH_API_KEY": "${env:SKILLSMITH_API_KEY}"
       }
@@ -126,11 +129,11 @@ Supports `${env:VAR}` interpolation; export `SKILLSMITH_API_KEY` in your shell i
 <summary><strong>Codex CLI</strong> — <code>~/.codex/config.toml</code> (TOML, not JSON)</summary>
 
 ```toml
-[mcp_servers.@skillsmith/mcp-server]
+[mcp_servers.skillsmith]
 command = "npx"
-args = ["-y", "@skillsmith/mcp-server"]
+args = ["-y", "-p", "@skillsmith/mcp-server", "skillsmith-mcp"]
 
-[mcp_servers.@skillsmith/mcp-server.env]
+[mcp_servers.skillsmith.env]
 SKILLSMITH_API_KEY = "sk_live_..."
 ```
 
@@ -144,9 +147,9 @@ Codex reads `~/.agents/skills`. When installing via Skillsmith CLI, pass `--clie
 ```json
 {
   "mcpServers": {
-    "@skillsmith/mcp-server": {
+    "skillsmith": {
       "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
+      "args": ["-y", "-p", "@skillsmith/mcp-server", "skillsmith-mcp"],
       "env": {
         "SKILLSMITH_API_KEY": "sk_live_..."
       }
@@ -204,7 +207,7 @@ Without an API key, you're limited to **10 total requests** (trial mode). With a
   "mcpServers": {
     "skillsmith": {
       "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
+      "args": ["-y", "-p", "@skillsmith/mcp-server", "skillsmith-mcp"],
       "env": {
         "SKILLSMITH_API_KEY": "sk_live_your_key_here"
       }
@@ -457,7 +460,7 @@ Distribute that value through the same secure channel used for `SUPABASE_SERVICE
   "mcpServers": {
     "skillsmith": {
       "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
+      "args": ["-y", "-p", "@skillsmith/mcp-server", "skillsmith-mcp"],
       "env": {
         "SKILLSMITH_API_KEY": "sk_live_your_personal_key",
         "SKILLSMITH_LICENSE_KEY": "sklic_your_team_license",

--- a/packages/mcp-server/src/cli-flags.ts
+++ b/packages/mcp-server/src/cli-flags.ts
@@ -2,7 +2,7 @@
  * SMI-4805: startup CLI-flag handling for the MCP server.
  *
  * `@skillsmith/mcp-server` is a stdio-driven MCP server — when invoked directly
- * (`npx -y @skillsmith/mcp-server --version`) the MCP SDK otherwise swallows
+ * (`npx -y -p @skillsmith/mcp-server skillsmith-mcp --version`) the MCP SDK otherwise swallows
  * argv and the process starts the server instead of printing the version.
  *
  * `resolveStartupFlag` is a pure function so it can be unit-tested without

--- a/scripts/smoke-prod/mcp-server.sh
+++ b/scripts/smoke-prod/mcp-server.sh
@@ -76,7 +76,7 @@ check_mcp_server_version_exits_zero() {
   t0=$(now_ms)
   tmp=$(mktemp -d)
   set +e
-  out=$(cd "$tmp" && timeout "$SMOKE_MCP_TIMEOUT" npx -y "${SMOKE_MCP_PKG}@latest" --version 2>&1)
+  out=$(cd "$tmp" && timeout "$SMOKE_MCP_TIMEOUT" npx -y -p "${SMOKE_MCP_PKG}@latest" skillsmith-mcp --version 2>&1)
   rc=$?
   set -e
   rm -rf "$tmp"
@@ -85,14 +85,14 @@ check_mcp_server_version_exits_zero() {
 
   if [ "$rc" -ne 0 ]; then
     local snippet="${out:0:200}"
-    report_fail "mcp-server-published" "check_mcp_server_version_exits_zero" "npx ${SMOKE_MCP_PKG}@latest --version" "exit 0" "exit $rc: $snippet" "$ms"
+    report_fail "mcp-server-published" "check_mcp_server_version_exits_zero" "npx -p ${SMOKE_MCP_PKG}@latest skillsmith-mcp --version" "exit 0" "exit $rc: $snippet" "$ms"
     return 1
   fi
   if ! printf '%s' "$out" | grep -qE '[0-9]+\.[0-9]+\.[0-9]+'; then
-    report_fail "mcp-server-published" "check_mcp_server_version_exits_zero" "npx ${SMOKE_MCP_PKG}@latest --version" "semver" "${out:0:80}" "$ms"
+    report_fail "mcp-server-published" "check_mcp_server_version_exits_zero" "npx -p ${SMOKE_MCP_PKG}@latest skillsmith-mcp --version" "semver" "${out:0:80}" "$ms"
     return 1
   fi
-  report_pass "mcp-server-published" "check_mcp_server_version_exits_zero" "npx ${SMOKE_MCP_PKG}@latest --version" "$ms"
+  report_pass "mcp-server-published" "check_mcp_server_version_exits_zero" "npx -p ${SMOKE_MCP_PKG}@latest skillsmith-mcp --version" "$ms"
   return 0
 }
 


### PR DESCRIPTION
## Summary

- Replaces all documented `npx -y @skillsmith/mcp-server` invocations (8 config blocks) with the explicit `-p` form: `npx -y -p @skillsmith/mcp-server skillsmith-mcp`
- Adds a contributor warning in README explaining the global vs project `.mcp.json` conflict
- Fixes `scripts/smoke-prod/mcp-server.sh` `check_mcp_server_version_exits_zero` which was testing the broken invocation path since SMI-4774
- Updates `cli-flags.ts` JSDoc comment to reference the correct invocation

**Root cause**: `npx @skillsmith/mcp-server` strips the `@skillsmith/` scope and looks for a binary named `mcp-server`, which doesn't exist. Some npm 10 + `/bin/sh` environments fail without the single-binary fallback. This is the same failure the smoke harness hit in SMI-4774 — the harness was fixed at the time but the underlying cause was left unresolved. Fixes GitHub issue #1384 (peter604).

**Why not a `"mcp-server"` bin alias**: generic name reserved-looking in the MCP ecosystem; would collide with other vendors' bins under `npx`/global installs.

## Test plan

- [x] Pre-push: all packages pass, format clean, security checks clean
- [x] audit:standards: 76/76 passed (3 pre-existing warnings, none in this diff)
- [x] Lint + TypeScript: clean
- [x] `check_mcp_server_version_exits_zero` now exercises `npx -y -p @skillsmith/mcp-server@latest skillsmith-mcp --version` — will validate on next prod smoke run post-merge
- [x] README: confirmed 0 remaining `"-y", "@skillsmith/mcp-server"` occurrences; all 8 blocks updated

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)