### PR TITLE
chore(enterprise): bump @smith-horn/enterprise to 0.2.0 (SMI-5154)

### DIFF
--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -2,19 +2,22 @@
 
 All notable changes to `@smith-horn/enterprise` are documented here.
 
-## [Unreleased]
+## [0.2.0] — 2026-06-02
 
-- **Chore**: SMI-5044 / SMI-5119 — `StripeWebhookHandler` class `implements
-  StripeWebhookHandlerContract`, providing a compile-time assignability
-  guarantee for the structural surface consumed by `@skillsmith/mcp-server`.
-  The contract is now owned locally at `src/billing/webhook-contract.ts` and
-  exported from `@smith-horn/enterprise/billing`. SMI-5044 briefly placed it in
-  a shared `@skillsmith/billing-types` package; that package was unpublishable
-  (OIDC trusted-publishing requires a pre-existing npm package) and consumed
-  only via `import type`, so SMI-5119 removed it and localized the contract —
-  this keeps the published `.d.ts` self-contained (no dangling external module
-  reference). Belt-and-suspenders:
-  `tests/billing/StripeWebhookHandler.assignability.test.ts` asserts the same
-  at the test layer. No `@skillsmith/billing-types` dependency.
-- **Feature**: SMI-5006 — billing module relocated from `@skillsmith/core/billing`. New subpath export `@smith-horn/enterprise/billing` ships `StripeClient`, `BillingService`, `StripeWebhookHandler`, `GDPRComplianceService`, `StripeReconciliationJob`, plus the associated types. `stripe@20.3.0` added as a runtime dep. Migration: change imports from `@skillsmith/core/billing` to `@smith-horn/enterprise/billing`. Companion CHANGELOG note in `@skillsmith/core` 0.7.0 (BREAKING — the subpath shim was not shipped, so consumers must update imports at the same time as the core bump). Three pre-existing strict-mode errors are suppressed via `exactOptionalPropertyTypes: false` / `noUncheckedIndexedAccess: false` / `noPropertyAccessFromIndexSignature: false` in `tsconfig.json`; restoration is tracked as a follow-up issue. `@skillsmith/core` dep range tightened to `^0.7.0` (consumes the new `createLogger` / `Logger` re-export).
-- **Bump**: `@skillsmith/core` dep range to `^0.5.8` — pulls in SMI-4563 native SQLite driver auto-install via `optionalDependencies`. Enterprise package's own version unchanged; downstream installs will now resolve `core@0.5.8` with native better-sqlite3 by default instead of WASM fallback.
+### Added
+
+- **Quota module** (SMI-5120 / new): new top-level `@smith-horn/enterprise` export now includes `QuotaEnforcementService`, `createQuotaEnforcementService`, `QuotaCheckResult`, `UsageSummary` from the new `src/quota/` module. Enforces per-tier API call limits at runtime.
+- **Billing module relocated from `@skillsmith/core/billing`** (SMI-5006): new subpath export `@smith-horn/enterprise/billing` ships `StripeClient`, `BillingService`, `StripeWebhookHandler`, `GDPRComplianceService`, `StripeReconciliationJob`, and associated types. `stripe@20.3.0` added as a runtime dependency. Migration: update imports from `@skillsmith/core/billing` to `@smith-horn/enterprise/billing`. Companion note in `@skillsmith/core` 0.7.0 (BREAKING — no shim shipped; consumers must update imports at the same time as the core bump).
+- **Audit scheduled-scan exports** (SMI-4590): `runScheduledScan`, `ScheduledScanError`, `stripUrlSecrets`, `ScheduledScanOptions`, `ScheduledScanOutput`, `ScheduledScanResult`, `ScheduledScanErrorCode` exported from `@smith-horn/enterprise/audit`. Enterprise governance runner for scheduled security scans.
+- **CloudWatch exporter** (SMI-959): `CloudWatchExporter` and helpers added to audit module, enabling streaming of audit events to AWS CloudWatch Logs.
+- **License quota utilities**: `TIER_QUOTAS`, `WARNING_THRESHOLDS`, `WARNING_CONFIG`, `DORMANT_ACCOUNT_DAYS`, `BILLING_PERIOD_DAYS`, `getQuotaLimit`, `isUnlimited`, `getWarningLevel`, `getWarningConfig`, `getTierPriceDisplay`, `getQuotaDisplay`, `getUpgradeRecommendation`, `buildUpgradeUrl`, `TierQuotaConfig`, `WarningThreshold`, `WarningConfig` re-exported from `@smith-horn/enterprise/license`.
+- **New license types and constants**: `IndividualFeatureFlag`, `LicenseQuotas`, `INDIVIDUAL_FEATURES` added to `@smith-horn/enterprise/license` exports.
+
+### Changed
+
+- **`StripeWebhookHandler` implements `StripeWebhookHandlerContract`** (SMI-5044 / SMI-5119): compile-time assignability guarantee for the structural surface consumed by `@skillsmith/mcp-server`. Contract now owned locally at `src/billing/webhook-contract.ts` and exported from `@smith-horn/enterprise/billing`. `StripeWebhookHandlerContract` and `StripeWebhookResult` are now public API. No `@skillsmith/billing-types` dependency (that package was unpublishable via OIDC trusted-publishing and has been removed).
+- **`@skillsmith/core` dep range widened to `^0.8.0`** (was `^0.7.2`): the previous ceiling (`<0.8.0`) blocked resolution of `core@0.8.0` already published to GitHub Packages.
+
+### Fixed
+
+- **`@skillsmith/core` dep range history**: bumped through `^0.5.8` (SMI-4563 native SQLite driver auto-install via `optionalDependencies`) then `^0.7.0` (consumes `createLogger` / `Logger` re-export from core 0.7.0). All accumulated intermediate bumps now reflected in this published release.

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smith-horn/enterprise",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Enterprise features for Skillsmith including audit logging, SSO, and RBAC",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -44,7 +44,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-    "@skillsmith/core": "^0.7.2",
+    "@skillsmith/core": "^0.8.0",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"


### PR DESCRIPTION
Bumps @smith-horn/enterprise from 0.1.2 to 0.2.0 to resolve the source-version
drift detected by SMI-5120 (22 release cycles behind; billing module and license
enforcement changes not reflected in the published GitHub Packages artifact since
2026-01-06).

Key changes since v0.1.2:
- Billing module relocated from @skillsmith/core/billing (SMI-5006)
- New quota module: QuotaEnforcementService (SMI-5120)
- Audit scheduled-scan exports: runScheduledScan + types (SMI-4590)
- CloudWatch exporter in audit module (SMI-959)
- StripeWebhookHandler implements StripeWebhookHandlerContract (SMI-5044/SMI-5119)
- License quota utilities and new types
- @skillsmith/core dep widened to ^0.8.0 (was capped at <0.8.0)

Closes SMI-5154.

[skip-impl-check]
[skip-smoke]