### PR TITLE
feat(api): reconcile live API contract + register 3 audit tools (SMI-5213)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -90,7 +90,7 @@ skillsmith search --interactive
 
 **Options:**
 - `-c, --category <category>` - Filter by category
-- `-t, --trust <tier>` - Filter by trust tier (verified, community, experimental)
+- `-t, --trust <tier>` - Filter by trust tier (official, verified, curated, community, unverified)
 - `-l, --limit <n>` - Maximum results (default: 10)
 - `-i, --interactive` - Interactive selection mode
 
@@ -185,7 +185,7 @@ skillsmith create my-skill --dry-run
 - `--behavior <behavior>` - Behavioral classification: `autonomous`, `guided`, `interactive`, `configurable`
 - `-d, --description <description>` - Skill description (skips prompt)
 - `-a, --author <author>` - Author GitHub username (skips prompt)
-- `-c, --category <category>` - Category: `development`, `productivity`, `communication`, `data`, `security`, `other`
+- `-c, --category <category>` - Category: `Development`, `Testing`, `DevOps`, `Documentation`, `Productivity`, `Security`
 - `--scripts` - Include a `scripts/` directory
 - `-y, --yes` - Auto-confirm overwrite if skill directory exists
 - `--dry-run` - Preview scaffold output without writing files

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -90,7 +90,7 @@ skillsmith search --interactive
 
 **Options:**
 - `-c, --category <category>` - Filter by category
-- `-t, --trust <tier>` - Filter by trust tier (official, verified, curated, community, unverified)
+- `-t, --trust <tier>` - Filter by trust tier (verified, community, experimental)
 - `-l, --limit <n>` - Maximum results (default: 10)
 - `-i, --interactive` - Interactive selection mode
 
@@ -185,7 +185,7 @@ skillsmith create my-skill --dry-run
 - `--behavior <behavior>` - Behavioral classification: `autonomous`, `guided`, `interactive`, `configurable`
 - `-d, --description <description>` - Skill description (skips prompt)
 - `-a, --author <author>` - Author GitHub username (skips prompt)
-- `-c, --category <category>` - Category: `Development`, `Testing`, `DevOps`, `Documentation`, `Productivity`, `Security`
+- `-c, --category <category>` - Category: `development`, `productivity`, `communication`, `data`, `security`, `other`
 - `--scripts` - Include a `scripts/` directory
 - `-y, --yes` - Auto-confirm overwrite if skill directory exists
 - `--dry-run` - Preview scaffold output without writing files

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -124,7 +124,8 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.13",
-    "vitest": "4.1.6"
+    "vitest": "4.1.6",
+    "yaml": "^2.8.3"
   },
   "files": [
     "dist",

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -49,6 +49,8 @@ export {
 // API Types (OpenAPI-aligned)
 // ============================================================================
 
+export { API_TRUST_TIERS, API_CATEGORIES } from './types.js'
+
 export type {
   // Trust tier and enums
   ApiTrustTier,

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -2,7 +2,7 @@
  * API Types matching OpenAPI specification
  * @module api/types
  *
- * These types are aligned with docs/api/openapi.yaml for type-safe API interactions.
+ * These types are aligned with docs/internal/api/openapi.yaml for type-safe API interactions.
  * Uses snake_case for API wire format compatibility.
  */
 
@@ -14,7 +14,14 @@
  * Trust tier levels from API
  */
 // SMI-5205: 5-tier public model; experimental/unknown are internal only (translated at response layer)
-export type ApiTrustTier = 'official' | 'verified' | 'curated' | 'community' | 'unverified'
+export const API_TRUST_TIERS = [
+  'official',
+  'verified',
+  'curated',
+  'community',
+  'unverified',
+] as const
+export type ApiTrustTier = (typeof API_TRUST_TIERS)[number]
 
 // ============================================================================
 // Category (matches OpenAPI category enum)
@@ -23,13 +30,15 @@ export type ApiTrustTier = 'official' | 'verified' | 'curated' | 'community' | '
 /**
  * Skill category filter values
  */
-export type ApiCategory =
-  | 'Development'
-  | 'Testing'
-  | 'DevOps'
-  | 'Documentation'
-  | 'Productivity'
-  | 'Security'
+export const API_CATEGORIES = [
+  'Development',
+  'Testing',
+  'DevOps',
+  'Documentation',
+  'Productivity',
+  'Security',
+] as const
+export type ApiCategory = (typeof API_CATEGORIES)[number]
 
 // ============================================================================
 // Project Type (matches OpenAPI project_type enum)

--- a/packages/core/src/exports/types.ts
+++ b/packages/core/src/exports/types.ts
@@ -110,6 +110,8 @@ export type { ErrorCategory, ErrorCode, ErrorResponse } from '../errors.js'
 // API Types (SMI-1244, SMI-1245, SMI-1300)
 // ============================================================================
 
+export { API_TRUST_TIERS, API_CATEGORIES } from '../api/index.js'
+
 export type {
   ApiClientConfig,
   ApiResponse,

--- a/packages/core/tests/integration/openapi-contract.test.ts
+++ b/packages/core/tests/integration/openapi-contract.test.ts
@@ -1,0 +1,285 @@
+/**
+ * SMI-5213 / Wave 1 BARRIER: OpenAPI contract enforcement test.
+ *
+ * Guards the three-way consistency between:
+ *   1. docs/internal/api/openapi.yaml  (source of truth)
+ *   2. packages/core/src/api/types.ts  (API_TRUST_TIERS, API_CATEGORIES)
+ *   3. supabase/config.toml            (verify_jwt = false function registrations)
+ *
+ * Skip-gated: the entire suite is skipped when docs/internal/api/openapi.yaml
+ * is absent (external contributors / CI without the docs/internal submodule).
+ *
+ * verify_jwt=false (21 fns) ⊋ documented-public (12 paths).
+ * The allowlist below is the positive source of truth for the public surface.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { parse } from 'yaml'
+import { API_TRUST_TIERS, API_CATEGORIES } from '../../src/api/types.js'
+
+// ---------------------------------------------------------------------------
+// Locate files relative to this test file
+// ---------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// packages/core/tests/integration/ → up 4 dirs to repo root
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..')
+const OPENAPI_PATH = path.join(REPO_ROOT, 'docs', 'internal', 'api', 'openapi.yaml')
+const SUPABASE_CONFIG_PATH = path.join(REPO_ROOT, 'supabase', 'config.toml')
+
+// ---------------------------------------------------------------------------
+// Allowlist of the 12 documented public endpoints (positive source of truth)
+// ---------------------------------------------------------------------------
+
+const DOCUMENTED_ENDPOINTS = [
+  '/skills-search',
+  '/skills-get',
+  '/skills-recommend',
+  '/events',
+  '/health',
+  '/stats',
+  '/early-access-signup',
+  '/contact-submit',
+  '/checkout',
+  '/stripe-webhook',
+  '/auth-device-code',
+  '/auth-device-token',
+] as const
+
+// Gateway-verified functions (deploy WITHOUT --no-verify-jwt); they appear in
+// config.toml with verify_jwt = true and are NOT in the allowlist above but
+// may be reachable via other surfaces.
+const GATEWAY_VERIFIED_EXCEPTIONS = new Set([
+  'webhook-dlq',
+  'auth-device-approve',
+  'auth-device-preview',
+  'indexer-dispatch',
+  'team-invite-send',
+  'sync-stripe-email',
+  'sync-oauth-email',
+])
+
+// ---------------------------------------------------------------------------
+// Recursive walker: collect every { fieldName, enum } pair in any YAML object
+// Handles both parameter-style (object has `name` + `schema.enum`) and
+// schema-property style (object has property key == fieldName with `.enum`).
+// ---------------------------------------------------------------------------
+
+type YamlNode = Record<string, unknown> | unknown[] | unknown
+
+interface EnumOccurrence {
+  fieldName: string
+  enumValues: string[]
+  /** Human-readable breadcrumb for assertion messages */
+  location: string
+}
+
+function collectEnums(node: YamlNode, breadcrumb: string): EnumOccurrence[] {
+  if (!node || typeof node !== 'object') return []
+
+  const results: EnumOccurrence[] = []
+
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) {
+      results.push(...collectEnums(node[i] as YamlNode, `${breadcrumb}[${i}]`))
+    }
+    return results
+  }
+
+  const obj = node as Record<string, unknown>
+
+  // Parameter-style: { name: 'trust_tier', schema: { enum: [...] } }
+  if (
+    typeof obj['name'] === 'string' &&
+    obj['schema'] &&
+    typeof obj['schema'] === 'object' &&
+    !Array.isArray(obj['schema'])
+  ) {
+    const schema = obj['schema'] as Record<string, unknown>
+    if (Array.isArray(schema['enum'])) {
+      results.push({
+        fieldName: obj['name'] as string,
+        enumValues: schema['enum'] as string[],
+        location: `${breadcrumb}(param:${obj['name']}).schema.enum`,
+      })
+    }
+  }
+
+  // Schema-property style: { properties: { trust_tier: { enum: [...] } } }
+  if (
+    obj['properties'] &&
+    typeof obj['properties'] === 'object' &&
+    !Array.isArray(obj['properties'])
+  ) {
+    const props = obj['properties'] as Record<string, unknown>
+    for (const [propName, propVal] of Object.entries(props)) {
+      if (
+        propVal &&
+        typeof propVal === 'object' &&
+        !Array.isArray(propVal) &&
+        Array.isArray((propVal as Record<string, unknown>)['enum'])
+      ) {
+        results.push({
+          fieldName: propName,
+          enumValues: (propVal as Record<string, unknown>)['enum'] as string[],
+          location: `${breadcrumb}.properties.${propName}.enum`,
+        })
+      }
+      // Recurse into the property value
+      results.push(...collectEnums(propVal as YamlNode, `${breadcrumb}.properties.${propName}`))
+    }
+  }
+
+  // Recurse into all other keys (skipping 'properties' already handled and 'schema'
+  // only if we didn't already collect from it above — but recurse always to find nested)
+  for (const [key, val] of Object.entries(obj)) {
+    if (key === 'properties') continue // already handled above
+    results.push(...collectEnums(val as YamlNode, `${breadcrumb}.${key}`))
+  }
+
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// Deduplicate by (fieldName, location) to avoid double-counting from recursion
+// ---------------------------------------------------------------------------
+
+function deduplicateEnums(occurrences: EnumOccurrence[]): EnumOccurrence[] {
+  const seen = new Set<string>()
+  return occurrences.filter((o) => {
+    const key = `${o.fieldName}::${o.location}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Parse config.toml: collect function names with verify_jwt = false
+// ---------------------------------------------------------------------------
+
+function collectNoJwtFunctions(tomlContent: string): Set<string> {
+  const result = new Set<string>()
+  // Match [functions.<name>] blocks followed by verify_jwt = false
+  const blockRegex = /\[functions\.([^\]]+)\][^[]*verify_jwt\s*=\s*false/g
+  let match: RegExpExecArray | null
+  while ((match = blockRegex.exec(tomlContent)) !== null) {
+    result.add(match[1].trim())
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Conditionally skip when submodule is absent
+// ---------------------------------------------------------------------------
+
+const specExists = existsSync(OPENAPI_PATH)
+
+describe.skipIf(!specExists)('SMI-5213: OpenAPI contract', () => {
+  // Parse once per suite
+  const specContent = specExists ? readFileSync(OPENAPI_PATH, 'utf-8') : ''
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const spec = specExists ? (parse(specContent) as any) : null
+
+  // -------------------------------------------------------------------------
+  // Top-level metadata assertions
+  // -------------------------------------------------------------------------
+
+  it('license is Elastic License 2.0', () => {
+    expect(spec.info.license.name).toBe('Elastic License 2.0')
+  })
+
+  it('production server URL is https://api.skillsmith.app', () => {
+    const servers: Array<{ url: string; description?: string }> = spec.servers ?? []
+    const prodServer = servers.find((s) => s.description?.toLowerCase().includes('production'))
+    expect(prodServer, 'No production server entry found').toBeDefined()
+    expect(prodServer!.url).toBe('https://api.skillsmith.app')
+  })
+
+  it('contact.url includes smith-horn', () => {
+    expect(spec.info.contact.url).toContain('smith-horn')
+  })
+
+  // -------------------------------------------------------------------------
+  // Enum consistency: trust_tier
+  // -------------------------------------------------------------------------
+
+  it('all trust_tier enum occurrences match API_TRUST_TIERS', () => {
+    const all = deduplicateEnums(collectEnums(spec, 'spec'))
+    const trustTierOccurrences = all.filter((o) => o.fieldName === 'trust_tier')
+
+    expect(
+      trustTierOccurrences.length,
+      `Expected ≥2 trust_tier enum occurrences, found ${trustTierOccurrences.length}: ${trustTierOccurrences.map((o) => o.location).join(', ')}`
+    ).toBeGreaterThanOrEqual(2)
+
+    for (const occurrence of trustTierOccurrences) {
+      expect(occurrence.enumValues, `trust_tier enum mismatch at ${occurrence.location}`).toEqual([
+        ...API_TRUST_TIERS,
+      ])
+    }
+  })
+
+  it('all category enum occurrences match API_CATEGORIES', () => {
+    const all = deduplicateEnums(collectEnums(spec, 'spec'))
+    const categoryOccurrences = all.filter((o) => o.fieldName === 'category')
+
+    expect(
+      categoryOccurrences.length,
+      `Expected ≥1 category enum occurrence, found ${categoryOccurrences.length}: ${categoryOccurrences.map((o) => o.location).join(', ')}`
+    ).toBeGreaterThanOrEqual(1)
+
+    for (const occurrence of categoryOccurrences) {
+      expect(occurrence.enumValues, `category enum mismatch at ${occurrence.location}`).toEqual([
+        ...API_CATEGORIES,
+      ])
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // Documented paths
+  // -------------------------------------------------------------------------
+
+  it('spec documents all 12 allowlisted paths', () => {
+    const specPaths: string[] = Object.keys(spec.paths ?? {})
+    for (const endpoint of DOCUMENTED_ENDPOINTS) {
+      expect(specPaths, `Spec is missing documented endpoint: ${endpoint}`).toContain(endpoint)
+    }
+  })
+
+  it('spec contains no undocumented paths beyond the allowlist', () => {
+    const specPaths: string[] = Object.keys(spec.paths ?? {})
+    const allowSet = new Set<string>(DOCUMENTED_ENDPOINTS)
+    const extras = specPaths.filter((p) => !allowSet.has(p))
+    expect(
+      extras,
+      `Spec contains paths not in the documented allowlist: ${extras.join(', ')}`
+    ).toHaveLength(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // config.toml surface alignment
+  // -------------------------------------------------------------------------
+
+  it("each documented endpoint's function name is registered as verify_jwt=false (or is a gateway-verified exception)", () => {
+    expect(existsSync(SUPABASE_CONFIG_PATH), 'supabase/config.toml not found').toBe(true)
+    const toml = readFileSync(SUPABASE_CONFIG_PATH, 'utf-8')
+    const noJwtFunctions = collectNoJwtFunctions(toml)
+
+    for (const endpoint of DOCUMENTED_ENDPOINTS) {
+      // Strip leading slash to get function name
+      const fnName = endpoint.replace(/^\//, '')
+      const isNoJwt = noJwtFunctions.has(fnName)
+      const isException = GATEWAY_VERIFIED_EXCEPTIONS.has(fnName)
+      expect(
+        isNoJwt || isException,
+        `${endpoint} (fn: ${fnName}) is neither in verify_jwt=false list nor in GATEWAY_VERIFIED_EXCEPTIONS`
+      ).toBe(true)
+    }
+  })
+})

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -272,6 +272,9 @@ All tiers include:
 | `skill_diff` | Section-level diff between skill versions | Individual+ |
 | `skill_pack_audit` | Audit all skills in a directory | Individual+ |
 | `skill_audit` | Check skills for security advisories | Team+ |
+| `skill_inventory_audit` | Audit local `~/.claude/` inventory for namespace collisions; returns rename + edit suggestions | Team+ |
+| `apply_namespace_rename` | Apply a rename suggestion from an inventory audit (`apply`/`custom`/`skip`) | Team+ |
+| `apply_recommended_edit` | Apply a recommended prose edit from an inventory audit (gated on APPLY_TEMPLATE_REGISTRY) | Team+ |
 | `team_workspace` | Manage team workspaces (create, list, get, delete) | Team+ |
 | `share_skill` | Add, remove, or list skills in a team workspace | Team+ |
 | `publish_private` | Mark a skill as private to your team | Team+ |

--- a/packages/mcp-server/src/audit-tool-dispatch.ts
+++ b/packages/mcp-server/src/audit-tool-dispatch.ts
@@ -30,9 +30,18 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import type { ToolContext } from './context.js'
 import { skillAuditInputSchema, executeSkillAudit } from './tools/skill-audit.js'
 import { skillPackAuditInputSchema, executeSkillPackAudit } from './tools/skill-pack-audit.js'
-import { skillInventoryAudit } from './tools/skill-inventory-audit.js'
-import { applyNamespaceRename } from './tools/apply-namespace-rename.js'
-import { applyRecommendedEditTool } from './tools/apply-recommended-edit.js'
+import {
+  skillInventoryAudit,
+  skillInventoryAuditToolSchema,
+} from './tools/skill-inventory-audit.js'
+import {
+  applyNamespaceRename,
+  applyNamespaceRenameToolSchema,
+} from './tools/apply-namespace-rename.js'
+import {
+  applyRecommendedEditTool,
+  applyRecommendedEditToolSchema,
+} from './tools/apply-recommended-edit.js'
 import { APPLY_TEMPLATE_REGISTRY } from './audit/edit-applier.js'
 import { withLicenseAndQuota } from './middleware/license.js'
 import type { LicenseMiddleware } from './middleware/license.js'
@@ -76,6 +85,42 @@ function buildAuditToolNames(): string[] {
  */
 export function isAuditToolName(name: string): boolean {
   return AUDIT_TOOL_NAMES.has(name)
+}
+
+/**
+ * SMI-5213: ListTools definitions for the THREE NEW audit-family tools
+ * (`skill_inventory_audit`, `apply_namespace_rename`, and — gated —
+ * `apply_recommended_edit`). `index.ts` spreads this into `toolDefinitions`
+ * so the tools become client-discoverable.
+ *
+ * Deliberately EXCLUDES `skill_audit` / `skill_pack_audit`: those are
+ * already registered in `index.ts`'s static array; re-listing them here
+ * would double-list them in ListTools.
+ *
+ * `apply_recommended_edit` is included iff `APPLY_TEMPLATE_REGISTRY.size > 0`
+ * — the SAME registration gate `buildAuditToolNames` uses for
+ * `AUDIT_TOOL_NAMES`, so the discoverable surface and the dispatchable
+ * surface stay in lock-step.
+ */
+export interface NewAuditToolDefinition {
+  name: string
+  description: string
+  inputSchema: {
+    type: 'object'
+    properties: Record<string, unknown>
+    required: string[]
+  }
+}
+
+export function newAuditToolDefinitions(): NewAuditToolDefinition[] {
+  const defs: NewAuditToolDefinition[] = [
+    skillInventoryAuditToolSchema,
+    applyNamespaceRenameToolSchema,
+  ]
+  if (APPLY_TEMPLATE_REGISTRY.size > 0) {
+    defs.push(applyRecommendedEditToolSchema)
+  }
+  return defs
 }
 
 /**

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -60,6 +60,10 @@ import {
 import { webhookConfigureToolSchema, apiKeyManageToolSchema } from './tools/integration-tools.js'
 import { complianceReportToolSchema } from './tools/compliance-tools.js'
 import { dispatchToolCall } from './tool-dispatch.js'
+// SMI-5213: make the three audit-family tools client-discoverable. The
+// builder gates `apply_recommended_edit` on APPLY_TEMPLATE_REGISTRY and
+// omits the already-registered `skill_audit` / `skill_pack_audit`.
+import { newAuditToolDefinitions } from './audit-tool-dispatch.js'
 import {
   isFirstRun,
   markFirstRunComplete,
@@ -143,6 +147,14 @@ const toolDefinitions = [
   webhookConfigureToolSchema,
   apiKeyManageToolSchema,
   complianceReportToolSchema,
+  // SMI-5213: skill_inventory_audit, apply_namespace_rename, and (gated)
+  // apply_recommended_edit. Spread so apply_recommended_edit is omitted
+  // when APPLY_TEMPLATE_REGISTRY is empty. NOTE: audit:standards Check 25
+  // line-counts this array and can't see spread/conditional entries, so it
+  // emits a non-blocking tool-count warn (37 vs 39 README rows). The real
+  // registration invariant is covered by the ListTools-registry test;
+  // SMI-5216 tracks making Check 25 spread-aware (ADR-109 infra path).
+  ...newAuditToolDefinitions(),
 ]
 
 // Create server

--- a/packages/mcp-server/src/tools/apply-namespace-rename.ts
+++ b/packages/mcp-server/src/tools/apply-namespace-rename.ts
@@ -41,6 +41,11 @@ import type { ApplyNamespaceRenameResponse } from './apply-namespace-rename.type
  * iff `action === 'custom'`; `customName` is forbidden otherwise (rejects
  * payloads that pass an unused field on apply / skip — keeps the surface
  * clean and helps catch caller-side bugs).
+ *
+ * SMI-5213: `confirmed` (default false) gates the file mutation. When
+ * `confirmed !== true` (and `action !== 'skip'`), the tool returns a
+ * non-mutating preview envelope describing the rename; the caller must
+ * re-invoke with `confirmed: true` to actually rename the file.
  */
 export const applyNamespaceRenameInputSchema = z
   .object({
@@ -48,6 +53,7 @@ export const applyNamespaceRenameInputSchema = z
     collisionId: z.string().min(1),
     action: z.enum(['apply', 'custom', 'skip']),
     customName: z.string().min(1).optional(),
+    confirmed: z.boolean().optional(),
   })
   .strict()
   .superRefine((value, ctx) => {
@@ -66,6 +72,47 @@ export const applyNamespaceRenameInputSchema = z
       })
     }
   })
+
+/**
+ * MCP tool schema for `apply_namespace_rename` (SMI-5213). Hand-written
+ * JSON Schema mirroring {@link applyNamespaceRenameInputSchema} so the
+ * tool is client-discoverable via ListTools. Keep in sync with the Zod
+ * schema.
+ */
+export const applyNamespaceRenameToolSchema = {
+  name: 'apply_namespace_rename',
+  description:
+    "[Skillsmith — Maintain stage] Apply a rename suggestion from a prior `skill_inventory_audit`. MUTATES `~/.claude` (renames a skill/command/agent file) — but ONLY when `confirmed: true`. Without `confirmed`, returns a non-mutating preview ({ preview: true, before, after, applied: false }) so the agent can show the change before committing. `action: 'apply'` uses the suggested name; `'custom'` uses `customName`; `'skip'` records a no-op.",
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      auditId: {
+        type: 'string',
+        description: 'auditId from a prior skill_inventory_audit response.',
+      },
+      collisionId: {
+        type: 'string',
+        description: 'collisionId of the RenameSuggestion to apply.',
+      },
+      action: {
+        type: 'string',
+        description:
+          "'apply' uses the suggested name; 'custom' uses customName; 'skip' is a no-op.",
+        enum: ['apply', 'custom', 'skip'],
+      },
+      customName: {
+        type: 'string',
+        description: "Required when action === 'custom'; forbidden otherwise.",
+      },
+      confirmed: {
+        type: 'boolean',
+        description:
+          'When true, performs the file rename. When omitted/false, returns a non-mutating preview. Defaults to false.',
+      },
+    },
+    required: ['auditId', 'collisionId', 'action'],
+  },
+}
 
 /**
  * Execute the `apply_namespace_rename` tool.
@@ -121,6 +168,23 @@ async function applyNamespaceRenameImpl(input: unknown): Promise<ApplyNamespaceR
       collisionId: validInput.collisionId as ApplyNamespaceRenameResponse['collisionId'],
       errorCode: 'namespace.audit.collision_not_found',
       error: `Collision ${validInput.collisionId} not found in audit ${validInput.auditId}.`,
+    }
+  }
+
+  // SMI-5213: confirmation gate. Without `confirmed: true`, return a
+  // non-mutating preview describing the rename. The agent surfaces this
+  // to the user and re-invokes with `confirmed: true` to apply.
+  const targetName = validInput.action === 'custom' ? validInput.customName! : suggestion.suggested
+  if (validInput.confirmed !== true) {
+    return {
+      success: true,
+      preview: true,
+      collisionId: suggestion.collisionId,
+      action: suggestion.applyAction,
+      target: suggestion.entry.source_path,
+      before: suggestion.currentName,
+      after: targetName,
+      applied: false,
     }
   }
 

--- a/packages/mcp-server/src/tools/apply-namespace-rename.types.ts
+++ b/packages/mcp-server/src/tools/apply-namespace-rename.types.ts
@@ -49,4 +49,19 @@ export interface ApplyNamespaceRenameResponse {
     | 'namespace.rename.subcall_failed'
   /** Human-readable error message. */
   error?: string
+  // SMI-5213: confirmation-gate preview fields. Present (with
+  // `applied: false`) when the tool was called without `confirmed: true`
+  // on a non-skip action — nothing on disk changed.
+  /** True when this is a non-mutating preview of the rename. */
+  preview?: boolean
+  /** Mutation strategy that *would* run on confirm. */
+  action?: string
+  /** Absolute path of the file that *would* be renamed. */
+  target?: string
+  /** Current identifier (pre-rename). */
+  before?: string
+  /** Proposed identifier (post-rename: suggested or custom name). */
+  after?: string
+  /** Always `false` on a preview; absent on a real apply. */
+  applied?: boolean
 }

--- a/packages/mcp-server/src/tools/apply-recommended-edit.ts
+++ b/packages/mcp-server/src/tools/apply-recommended-edit.ts
@@ -37,13 +37,51 @@ import type { ApplyRecommendedEditResponse } from './apply-recommended-edit.type
 /**
  * Zod input schema. `auditId` + `collisionId` are FKs into
  * `~/.skillsmith/audits/<auditId>/suggestions.json`.
+ *
+ * SMI-5213: `confirmed` (default false) gates the file mutation. When
+ * `confirmed !== true`, the tool returns a non-mutating preview envelope
+ * describing the prose edit; the caller must re-invoke with
+ * `confirmed: true` to actually rewrite the file.
  */
 export const applyRecommendedEditInputSchema = z
   .object({
     auditId: z.string().min(1),
     collisionId: z.string().min(1),
+    confirmed: z.boolean().optional(),
   })
   .strict()
+
+/**
+ * MCP tool schema for `apply_recommended_edit` (SMI-5213). Hand-written
+ * JSON Schema mirroring {@link applyRecommendedEditInputSchema} so the
+ * tool is client-discoverable via ListTools. Registration is gated on
+ * `APPLY_TEMPLATE_REGISTRY.size > 0` — see `newAuditToolDefinitions` in
+ * `audit-tool-dispatch.ts`. Keep in sync with the Zod schema.
+ */
+export const applyRecommendedEditToolSchema = {
+  name: 'apply_recommended_edit',
+  description:
+    '[Skillsmith — Maintain stage] Apply a recommended prose edit from a prior `skill_inventory_audit`. MUTATES `~/.claude` (rewrites a SKILL.md / CLAUDE.md snippet) — but ONLY when `confirmed: true`. Without `confirmed`, returns a non-mutating preview ({ preview: true, before, after, applied: false }). Gated on APPLY_TEMPLATE_REGISTRY: only registered when at least one apply-eligible template is enabled.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      auditId: {
+        type: 'string',
+        description: 'auditId from a prior skill_inventory_audit response.',
+      },
+      collisionId: {
+        type: 'string',
+        description: 'collisionId of the RecommendedEdit to apply.',
+      },
+      confirmed: {
+        type: 'boolean',
+        description:
+          'When true, performs the prose edit. When omitted/false, returns a non-mutating preview. Defaults to false.',
+      },
+    },
+    required: ['auditId', 'collisionId'],
+  },
+}
 
 /**
  * Execute the `apply_recommended_edit` tool. Returns the response
@@ -85,6 +123,22 @@ async function applyRecommendedEditToolImpl(input: unknown): Promise<ApplyRecomm
       collisionId: validInput.collisionId as ApplyRecommendedEditResponse['collisionId'],
       errorCode: 'namespace.audit.collision_not_found',
       error: `Collision ${validInput.collisionId} not found in audit ${validInput.auditId}.`,
+    }
+  }
+
+  // SMI-5213: confirmation gate. Without `confirmed: true`, return a
+  // non-mutating preview describing the prose edit. The agent surfaces
+  // the before/after to the user and re-invokes with `confirmed: true`.
+  if (validInput.confirmed !== true) {
+    return {
+      success: true,
+      preview: true,
+      collisionId: edit.collisionId,
+      action: edit.pattern,
+      target: edit.filePath,
+      before: edit.before,
+      after: edit.after,
+      applied: false,
     }
   }
 

--- a/packages/mcp-server/src/tools/apply-recommended-edit.types.ts
+++ b/packages/mcp-server/src/tools/apply-recommended-edit.types.ts
@@ -53,4 +53,19 @@ export interface ApplyRecommendedEditResponse {
     | 'edit.subcall_failed'
   /** Human-readable error message. */
   error?: string
+  // SMI-5213: confirmation-gate preview fields. Present (with
+  // `applied: false`) when the tool was called without `confirmed: true`
+  // — nothing on disk changed.
+  /** True when this is a non-mutating preview of the prose edit. */
+  preview?: boolean
+  /** Template pattern that *would* be applied on confirm. */
+  action?: string
+  /** Absolute path of the file that *would* be rewritten. */
+  target?: string
+  /** Current snippet at the edit's line range (pre-edit). */
+  before?: string
+  /** Proposed snippet (post-edit). */
+  after?: string
+  /** Always `false` on a preview; absent on a real apply. */
+  applied?: boolean
 }

--- a/packages/mcp-server/src/tools/skill-inventory-audit.ts
+++ b/packages/mcp-server/src/tools/skill-inventory-audit.ts
@@ -59,6 +59,40 @@ export const skillInventoryAuditInputSchema = z
 export type SkillInventoryAuditValidatedInput = z.infer<typeof skillInventoryAuditInputSchema>
 
 /**
+ * MCP tool schema for `skill_inventory_audit` (SMI-5213). Hand-written
+ * JSON Schema mirroring {@link skillInventoryAuditInputSchema} so the tool
+ * is client-discoverable via ListTools. Keep in sync with the Zod schema.
+ */
+export const skillInventoryAuditToolSchema = {
+  name: 'skill_inventory_audit',
+  description:
+    '[Skillsmith — Maintain stage] Audit the local `~/.claude/` inventory (skills, commands, agents, CLAUDE.md rules) for namespace collisions. Returns rename + prose-edit suggestions keyed by a fresh `auditId`. Read-only — performs no file mutations. Feed the returned suggestions into `apply_namespace_rename` / `apply_recommended_edit`.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      deep: {
+        type: 'boolean',
+        description: 'Run the deep (semantic) collision pass. Defaults to false.',
+      },
+      homeDir: {
+        type: 'string',
+        description:
+          'Override the inventory root. Must resolve under os.homedir() or os.tmpdir(); arbitrary paths are rejected.',
+      },
+      projectDir: {
+        type: 'string',
+        description: 'Project directory whose CLAUDE.md rules are included in the scan.',
+      },
+      applyExclusions: {
+        type: 'boolean',
+        description: 'Apply the configured exclusion list to the scan. Defaults to true.',
+      },
+    },
+    required: [],
+  },
+}
+
+/**
  * Execute the `skill_inventory_audit` tool. Validates input via Zod and
  * returns either the success response OR a structured validation-error
  * envelope (matches `install.ts:buildValidationError` pattern).

--- a/packages/mcp-server/tests/integration/audit-roundtrip.test.ts
+++ b/packages/mcp-server/tests/integration/audit-roundtrip.test.ts
@@ -168,6 +168,7 @@ describe('audit round-trip — inventory → rename → idempotent re-apply', ()
         auditId: audit.auditId,
         collisionId: suggestion.collisionId,
         action: 'apply',
+        confirmed: true,
       },
       fakeContext(),
       fakeLicense(),
@@ -190,6 +191,7 @@ describe('audit round-trip — inventory → rename → idempotent re-apply', ()
         auditId: audit.auditId,
         collisionId: suggestion.collisionId,
         action: 'apply',
+        confirmed: true,
       },
       fakeContext(),
       fakeLicense(),
@@ -252,7 +254,7 @@ describe('audit round-trip — apply_recommended_edit via dispatcher', () => {
 
     const editApply = await dispatchAuditTool(
       'apply_recommended_edit',
-      { auditId, collisionId },
+      { auditId, collisionId, confirmed: true },
       fakeContext(),
       fakeLicense(),
       fakeQuota()
@@ -263,6 +265,94 @@ describe('audit round-trip — apply_recommended_edit via dispatcher', () => {
     expect(fs.readFileSync(filePath, 'utf-8')).toContain(
       'description: deploy code to production for deployment tasks'
     )
+  })
+})
+
+describe('audit round-trip — confirmation gate via dispatcher (SMI-5213)', () => {
+  it('apply_namespace_rename returns a preview (no mutation) when confirmed is omitted', async () => {
+    plantSkill(TEST_HOME, 'ship')
+    const cmdPath = plantCommand(TEST_HOME, 'ship')
+    const future = new Date(Date.now() + 60_000)
+    fs.utimesSync(cmdPath, future, future)
+
+    const auditCall = await dispatchAuditTool(
+      'skill_inventory_audit',
+      { homeDir: TEST_HOME },
+      fakeContext(),
+      fakeLicense(),
+      fakeQuota()
+    )
+    const audit = decodeBody<SkillInventoryAuditResponse>(auditCall)
+    const suggestion = audit.renameSuggestions[0]!
+
+    const previewCall = await dispatchAuditTool(
+      'apply_namespace_rename',
+      { auditId: audit.auditId, collisionId: suggestion.collisionId, action: 'apply' },
+      fakeContext(),
+      fakeLicense(),
+      fakeQuota()
+    )
+    const preview = decodeBody<ApplyNamespaceRenameResponse>(previewCall)
+    expect(preview.success).toBe(true)
+    expect(preview.preview).toBe(true)
+    expect(preview.applied).toBe(false)
+    // File untouched — preview did not mutate.
+    expect(fs.existsSync(cmdPath)).toBe(true)
+  })
+
+  it('apply_recommended_edit returns a preview (no mutation) when confirmed is omitted', async () => {
+    const description = 'deploy code to production'
+    const filePath = plantSkill(TEST_HOME, 'roundtrip-preview', description)
+    const auditId = '01J6Z3M0CK4N0R3MPREVIEW0001' as AuditId
+    const collisionId = 'roundtripPreviewFixture' as CollisionId
+    const lines = fs.readFileSync(filePath, 'utf-8').split('\n')
+    const lineIdx = lines.findIndex((l) => l === `description: ${description}`)
+    const edit: RecommendedEdit = {
+      collisionId,
+      category: 'description_overlap',
+      pattern: 'add_domain_qualifier',
+      filePath,
+      lineRange: { start: lineIdx + 1, end: lineIdx + 1 },
+      before: `description: ${description}`,
+      after: `description: ${description} for deployment tasks`,
+      rationale: 'preview fixture',
+      applyAction: 'recommended_edit',
+      applyMode: 'apply_with_confirmation',
+      otherEntry: { identifier: 'partner-skill', sourcePath: '/tmp/partner.md' },
+    }
+    await writeAuditHistory({
+      auditId,
+      inventory: [],
+      exactCollisions: [],
+      genericFlags: [],
+      semanticCollisions: [],
+      summary: {
+        totalEntries: 0,
+        totalFlags: 0,
+        errorCount: 0,
+        warningCount: 0,
+        durationMs: 0,
+        passDurations: { exact: 0, generic: 0, semantic: 0 },
+      },
+    })
+    await writeAuditSuggestions(auditId, [], [edit])
+    const before = fs.readFileSync(filePath, 'utf-8')
+
+    const previewCall = await dispatchAuditTool(
+      'apply_recommended_edit',
+      { auditId, collisionId },
+      fakeContext(),
+      fakeLicense(),
+      fakeQuota()
+    )
+    const preview = decodeBody<ApplyRecommendedEditResponse>(previewCall)
+    expect(preview.success).toBe(true)
+    expect(preview.preview).toBe(true)
+    expect(preview.applied).toBe(false)
+    expect(preview.before).toBe(edit.before)
+    expect(preview.after).toBe(edit.after)
+    // File untouched.
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(before)
   })
 })
 

--- a/packages/mcp-server/tests/unit/apply-namespace-rename.test.ts
+++ b/packages/mcp-server/tests/unit/apply-namespace-rename.test.ts
@@ -124,6 +124,7 @@ describe('apply_namespace_rename — action: apply', () => {
       auditId: audit.auditId,
       collisionId: suggestion.collisionId,
       action: 'apply',
+      confirmed: true,
     })
     expect(response.success).toBe(true)
     expect(response.result).toBeDefined()
@@ -131,6 +132,64 @@ describe('apply_namespace_rename — action: apply', () => {
     // Source path no longer exists; target does.
     expect(fs.existsSync(cmdPath)).toBe(false)
     expect(fs.existsSync(response.result!.toPath)).toBe(true)
+  })
+})
+
+describe('apply_namespace_rename — confirmation gate (SMI-5213)', () => {
+  it('returns a non-mutating preview when confirmed is omitted', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+    const cmdPath = path.join(TEST_HOME, '.claude', 'commands', 'ship.md')
+    const before = fs.readFileSync(cmdPath, 'utf-8')
+
+    const response = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'apply',
+    })
+    expect(response.success).toBe(true)
+    expect(response.preview).toBe(true)
+    expect(response.applied).toBe(false)
+    expect(response.result).toBeUndefined()
+    expect(response.action).toBe(suggestion.applyAction)
+    expect(response.before).toBe(suggestion.currentName)
+    expect(response.after).toBe(suggestion.suggested)
+    // File untouched.
+    expect(fs.existsSync(cmdPath)).toBe(true)
+    expect(fs.readFileSync(cmdPath, 'utf-8')).toBe(before)
+  })
+
+  it('returns a non-mutating preview when confirmed is explicitly false', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+    const cmdPath = path.join(TEST_HOME, '.claude', 'commands', 'ship.md')
+
+    const response = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'apply',
+      confirmed: false,
+    })
+    expect(response.success).toBe(true)
+    expect(response.preview).toBe(true)
+    expect(response.applied).toBe(false)
+    expect(fs.existsSync(cmdPath)).toBe(true)
+  })
+
+  it('previews the custom name when action is custom and confirmed is omitted', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+
+    const response = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'custom',
+      customName: 'ship-preview-custom',
+    })
+    expect(response.success).toBe(true)
+    expect(response.preview).toBe(true)
+    expect(response.after).toBe('ship-preview-custom')
+    expect(response.result).toBeUndefined()
   })
 })
 
@@ -144,6 +203,7 @@ describe('apply_namespace_rename — action: custom', () => {
       collisionId: suggestion.collisionId,
       action: 'custom',
       customName: 'ship-custom-explicit',
+      confirmed: true,
     })
     expect(response.success).toBe(true)
     expect(response.result?.success).toBe(true)
@@ -212,6 +272,7 @@ describe('apply_namespace_rename — idempotent re-apply', () => {
       auditId: audit.auditId,
       collisionId: suggestion.collisionId,
       action: 'apply',
+      confirmed: true,
     })
     expect(first.success).toBe(true)
     expect(first.result?.success).toBe(true)
@@ -220,6 +281,7 @@ describe('apply_namespace_rename — idempotent re-apply', () => {
       auditId: audit.auditId,
       collisionId: suggestion.collisionId,
       action: 'apply',
+      confirmed: true,
     })
     expect(second.success).toBe(true)
     expect(second.result?.success).toBe(true)

--- a/packages/mcp-server/tests/unit/apply-recommended-edit.test.ts
+++ b/packages/mcp-server/tests/unit/apply-recommended-edit.test.ts
@@ -142,12 +142,60 @@ describe('apply_recommended_edit — happy path', () => {
     const filePath = plantSkillForEdit(TEST_HOME, 'fixture', description)
     const { auditId, collisionId } = await seedAuditWithEdit(filePath, description)
 
-    const response = await applyRecommendedEditTool({ auditId, collisionId })
+    const response = await applyRecommendedEditTool({ auditId, collisionId, confirmed: true })
     expect(response.success).toBe(true)
     expect(response.result?.success).toBe(true)
     // File mutated: original line replaced with the templated version.
     const fileBody = fs.readFileSync(filePath, 'utf-8')
     expect(fileBody).toContain('description: deploy code to production (qualified)')
+  })
+})
+
+describe('apply_recommended_edit — confirmation gate (SMI-5213)', () => {
+  it('returns a non-mutating preview when confirmed is omitted', async () => {
+    const description = 'deploy code to production'
+    const filePath = plantSkillForEdit(TEST_HOME, 'fixture-preview', description)
+    const { auditId, collisionId, edit } = await seedAuditWithEdit(filePath, description)
+    const before = fs.readFileSync(filePath, 'utf-8')
+
+    const response = await applyRecommendedEditTool({ auditId, collisionId })
+    expect(response.success).toBe(true)
+    expect(response.preview).toBe(true)
+    expect(response.applied).toBe(false)
+    expect(response.result).toBeUndefined()
+    expect(response.action).toBe(edit.pattern)
+    expect(response.target).toBe(filePath)
+    expect(response.before).toBe(edit.before)
+    expect(response.after).toBe(edit.after)
+    // File untouched.
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(before)
+  })
+
+  it('returns a non-mutating preview when confirmed is explicitly false', async () => {
+    const description = 'deploy code to production'
+    const filePath = plantSkillForEdit(TEST_HOME, 'fixture-preview-false', description)
+    const { auditId, collisionId } = await seedAuditWithEdit(filePath, description)
+    const before = fs.readFileSync(filePath, 'utf-8')
+
+    const response = await applyRecommendedEditTool({ auditId, collisionId, confirmed: false })
+    expect(response.success).toBe(true)
+    expect(response.preview).toBe(true)
+    expect(response.applied).toBe(false)
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(before)
+  })
+
+  it('mutates the file only when confirmed is true', async () => {
+    const description = 'deploy code to production'
+    const filePath = plantSkillForEdit(TEST_HOME, 'fixture-confirmed', description)
+    const { auditId, collisionId } = await seedAuditWithEdit(filePath, description)
+
+    const response = await applyRecommendedEditTool({ auditId, collisionId, confirmed: true })
+    expect(response.success).toBe(true)
+    expect(response.preview).toBeUndefined()
+    expect(response.result?.success).toBe(true)
+    expect(fs.readFileSync(filePath, 'utf-8')).toContain(
+      'description: deploy code to production (qualified)'
+    )
   })
 })
 
@@ -158,7 +206,10 @@ describe('apply_recommended_edit — registry guard', () => {
     const { auditId, collisionId } = await seedAuditWithEdit(filePath, description, 'narrow_scope')
     const before = fs.readFileSync(filePath, 'utf-8')
 
-    const response = await applyRecommendedEditTool({ auditId, collisionId })
+    // SMI-5213: registry guard fires only on the actual apply path, so
+    // confirm to reach it (an unconfirmed call would short-circuit to a
+    // preview).
+    const response = await applyRecommendedEditTool({ auditId, collisionId, confirmed: true })
     expect(response.success).toBe(false)
     expect(response.errorCode).toBe('edit.template_not_in_apply_registry')
     // File untouched — registry guard rejects before any mutation.
@@ -200,7 +251,7 @@ describe('apply_recommended_edit — failure modes', () => {
       'utf-8'
     )
 
-    const response = await applyRecommendedEditTool({ auditId, collisionId })
+    const response = await applyRecommendedEditTool({ auditId, collisionId, confirmed: true })
     expect(response.success).toBe(false)
     expect(response.errorCode).toBe('edit.subcall_failed')
     expect(response.error).toContain('edit.stale_before')
@@ -229,6 +280,41 @@ describe('audit-tool-dispatch — apply_recommended_edit conditional registratio
     const dispatch = await import('../../src/audit-tool-dispatch.js')
     expect(dispatch.AUDIT_TOOL_NAMES.has('apply_recommended_edit')).toBe(true)
     expect(dispatch.isAuditToolName('apply_recommended_edit')).toBe(true)
+  })
+
+  // SMI-5213: newAuditToolDefinitions feeds index.ts's toolDefinitions so
+  // the three tools are client-discoverable via ListTools.
+  it('newAuditToolDefinitions returns the 3 new tools (live registry) and excludes skill_audit', async () => {
+    const dispatch = await import('../../src/audit-tool-dispatch.js')
+    const names = dispatch.newAuditToolDefinitions().map((d) => d.name)
+    expect(names).toEqual([
+      'skill_inventory_audit',
+      'apply_namespace_rename',
+      'apply_recommended_edit',
+    ])
+    // Must NOT re-list the already-registered audit tools.
+    expect(names).not.toContain('skill_audit')
+    expect(names).not.toContain('skill_pack_audit')
+  })
+
+  it('newAuditToolDefinitions omits apply_recommended_edit when the registry is empty', async () => {
+    vi.resetModules()
+    vi.doMock('../../src/audit/edit-applier.js', async (importOriginal) => {
+      const actual = (await importOriginal()) as Record<string, unknown>
+      return {
+        ...actual,
+        APPLY_TEMPLATE_REGISTRY: new Set<EditTemplatePattern>(),
+      }
+    })
+    try {
+      const dispatch = await import('../../src/audit-tool-dispatch.js')
+      const names = dispatch.newAuditToolDefinitions().map((d) => d.name)
+      expect(names).toEqual(['skill_inventory_audit', 'apply_namespace_rename'])
+      expect(names).not.toContain('apply_recommended_edit')
+    } finally {
+      vi.doUnmock('../../src/audit/edit-applier.js')
+      vi.resetModules()
+    }
   })
 
   it('omits apply_recommended_edit when APPLY_TEMPLATE_REGISTRY is empty', async () => {


### PR DESCRIPTION
Wave 1 of **SMI-5212** (API contract documentation drift reconciliation). Source-of-truth PR — Waves 2 (website) and 3 (design docs) build on this.

Closes SMI-5213.

## What changed

**OpenAPI spec** (`docs/internal` submodule → `smith-horn/skillsmith-docs@23e5b7d`, pointer bumped here):
- license MIT → **Elastic License 2.0**; contact → `github.com/smith-horn/skillsmith`
- prod server `api.skillsmith.dev` → **`api.skillsmith.app`** (Vercel proxy); direct Supabase origin noted
- `X-API-Key` securityScheme declared (not globally required)
- both `trust_tier` enums → 5-tier `ApiTrustTier`; `category` → 6 Titlecase `ApiCategory`
- **+8 public endpoints** (health, stats, early-access-signup, contact-submit, checkout, stripe-webhook, auth-device-code, auth-device-token) documented from real `supabase/functions/*/index.ts`. 12 paths total.

**MCP tool registration + safety:**
- Register `skill_inventory_audit`, `apply_namespace_rename`, `apply_recommended_edit` (gated) via shared `newAuditToolDefinitions()` — they were dispatchable but invisible to clients.
- **`confirmed` preview gate** on the two `~/.claude`-mutating apply tools: returns a non-mutating `{preview:true,…}` envelope unless `confirmed===true`. Adversarially verified (Zod rejects non-boolean; `!== true` is the gate).

**Type contract:** `types.ts` `API_TRUST_TIERS`/`API_CATEGORIES` const arrays + derived unions + value re-exports through both barrels; fixed wrong spec-path comment.

**Drift guard:** `yaml@^2.8.3` devDep + `openapi-contract.test.ts` (8/8) — asserts license/server/contact, every `trust_tier`/`category` enum === const arrays, endpoint allowlist ⊆ `verify_jwt=false`; skip-gates when the submodule spec is absent. (Single committed spec — `public/openapi.yaml` is build-generated.)

**Docs:** mcp-server README +3 tool rows; CLI README trust-tier/category vocab fix.

## Verification
typecheck ✓ · lint ✓ · 3 changed packages build ✓ (FULL TURBO) · drift test 8/8 ✓ · mcp-server 2028 pass / 1 **pre-existing** fail (`install.integration` UUID path — fails identically on pristine main, network-dependent) · audit:standards 0 failed / 6 warns.

Governance review (Opus, adversarial on the preview gate): **clean, zero findings**.

## Known items
- audit:standards Check 25 emits a **non-blocking** tool-count warn — spread/conditional registration isn't line-countable. Real invariant covered by the new ListTools-registry test. Heuristic fix tracked in **SMI-5216** (ADR-109 infra).

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)