### PR TITLE
docs(architecture): reconcile Dec-2025 design docs to as-built (SMI-5215)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ Project skills load from the `.claude/skills/` mount-point of the `skillsmith-st
 
 ## Key References
 
-- **Architecture**: [System Overview](docs/internal/architecture/system-design/system-overview.md), [Skill Dependencies](docs/internal/architecture/system-design/skill-dependencies.md), [Index](docs/internal/architecture/index.md)
+- **Architecture**: [API Architecture (as-built)](docs/internal/architecture/system-design/api-architecture.md), [Skill Dependencies](docs/internal/architecture/system-design/skill-dependencies.md), [Index](docs/internal/architecture/index.md). Historical (Dec-2025 design, superseded): [System Overview](docs/internal/architecture/system-design/system-overview.md)
 - **Standards**: [Engineering](docs/internal/architecture/standards.md), [DB](docs/internal/architecture/standards-database.md), [Astro](docs/internal/architecture/standards-astro.md), [Security](docs/internal/architecture/standards-security.md)
 - **Process**: [Context Compaction](docs/internal/process/context-compaction.md), [Linear Hygiene](docs/internal/process/linear-hygiene-guide.md), [Wave Checklist](docs/internal/process/wave-completion-checklist.md)
 - **Testing**: [Stripe](.claude/development/stripe-testing.md), [Neural](.claude/development/neural-testing.md), [Benchmarks](.claude/development/benchmarks.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,9 +168,9 @@ Vitest only runs tests matching these patterns. Tests elsewhere are **silently i
 | `get_skill` | Get skill details by `author/name` ID |
 | `install_skill` | Install skill to `~/.claude/skills` |
 | `uninstall_skill` | Remove installed skill |
-| `recommend` | Contextual skill recommendations |
-| `validate` | Validate skill structure |
-| `compare` | Compare 2-5 skills side-by-side |
+| `skill_recommend` | Contextual skill recommendations |
+| `skill_validate` | Validate skill structure |
+| `skill_compare` | Compare 2-5 skills side-by-side |
 | `skill_diff` | Diff two installed skill versions side-by-side |
 | `skill_audit` | Audit skill for security advisories (Team+) |
 | `skill_inventory_audit` | Audit local `~/.claude/` inventory for namespace collisions; returns rename + edit suggestions (SMI-4590) |

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -305,7 +305,7 @@ Search for skills matching a query.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `query` | string | Yes | Search term (min 2 characters) |
+| `query` | string | Conditional | Search term (min 3 characters); required unless a filter (`category`/`trust_tier`/`min_score`) is provided |
 | `category` | string | No | Filter by category (development, testing, devops, etc.) |
 | `trust_tier` | string | No | Filter by trust level (verified, community, experimental) |
 | `min_score` | number | No | Minimum quality score (0-100) |

--- a/packages/website/src/pages/docs/api.astro
+++ b/packages/website/src/pages/docs/api.astro
@@ -81,8 +81,8 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
       <tr>
         <td><code>query</code></td>
         <td><code>string</code></td>
-        <td>Yes</td>
-        <td>Search query (minimum 2 characters)</td>
+        <td>Conditional</td>
+        <td>Search query (minimum 3 characters). Required unless at least one filter (<code>category</code>, <code>trust_tier</code>, <code>min_score</code>) is provided.</td>
       </tr>
       <tr>
         <td><code>category</code></td>
@@ -363,8 +363,8 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
   </p>
 
   <pre><code>{`{
-  "error": "Query parameter required (minimum 2 characters)",
-  "details": { "parameter": "query", "received": "a" }
+  "error": "Query must be at least 3 characters",
+  "details": { "parameter": "query", "received": "ab" }
 }`}</code></pre>
 
   <table>


### PR DESCRIPTION
Wave 3 (final) of **SMI-5212**. Reconciles the internal Dec-2025 "Design (No Implementation)" docs — which described a never-shipped 3-server "Claude Discovery Hub" (`~/.claude-discovery/`) — to the as-built single `skillsmith` MCP server.

Closes SMI-5215.

## What changed (docs/internal submodule → `c155193`)
- **Archived** `system-design/backend-api.md` + `execution/artifacts/api-contracts.md` → `archive/` with superseded banners.
- **Banner-marked (in place)** 7 stale siblings — `system-overview.md` (the nominal "source of truth"), `integrations.md`, `data.md`, `infrastructure.md`, `mcp-tool-specs.md`, `data-schema.md`, `error-codes.md` — each pointing at the new as-built doc.
- **New** `architecture/system-design/api-architecture.md` (As-Built, 2026-06-05): single `skillsmith` server (stdio), the real tool set (incl. the SMI-5213 audit tools), real `@skillsmith/core` services/repositories, real storage (`~/.skillsmith/`, `~/.claude/skills/`), and the 12-endpoint HTTP surface (Elastic License, `api.skillsmith.app`). **Every claim verified against code** by governance review — zero unevidenced claims.
- **Redirected** 8 inbound links (incl. broken `/docs/architecture/...` absolute forms) to the archive path or the new doc.
- **Indexes**: `archive/` count 8→10, system-design + architecture indexes, CLAUDE.md Key References → as-built doc (system-overview relabeled historical).

## Verification
Governance review (Opus): as-built doc factually verified (37 tools match `toolDefinitions`, storage paths real, 12 endpoints match `openapi.yaml`, services/repos confirmed); 30 PR-added/redirected links all resolve (0 broken); 9 banners correct; index counts fixed. No fiction asserted as fact (all `claude-discovery`/`discovery-core` mentions are explicit negations).

Docs-only change.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)