### PR TITLE
fix(ci): make /openapi.yaml post-deploy smoke errexit-safe + retry (SMI-5226)

### DIFF
--- a/.github/workflows/website-deploy-staging.yml
+++ b/.github/workflows/website-deploy-staging.yml
@@ -447,21 +447,32 @@ jobs:
       - name: Smoke - OpenAPI spec is served
         # SMI-5226: the docs/api page advertises skillsmith.app/openapi.yaml for
         # Postman/Insomnia import. Assert it serves 200 as YAML (not a 404 HTML
-        # page) with the expected contract markers.
+        # page) with the expected contract markers. Production www is served by
+        # Vercel's git-integration deploy, which can lag this workflow's CLI
+        # deploy — so retry before failing. Parse via command substitution, NOT
+        # `read < <(curl -w ...)`: curl -w emits no trailing newline, so `read`
+        # returns non-zero at EOF and trips `errexit` before any check runs.
         run: |
           set -euo pipefail
           URL=https://www.skillsmith.app/openapi.yaml
           TMP=$(mktemp)
-          read -r CODE CTYPE < <(curl -sSL -o "$TMP" -w '%{http_code} %{content_type}' --max-time 15 "$URL")
-          echo "openapi.yaml -> $CODE ($CTYPE)"
-          if [ "$CODE" != "200" ]; then
-            echo "::error::$URL returned HTTP $CODE (expected 200)"
+          ok=0
+          last="(none)"
+          for attempt in $(seq 1 6); do
+            OUT=$(curl -sSL -o "$TMP" -w '%{http_code} %{content_type}' --max-time 15 "$URL" || true)
+            CODE=${OUT%% *}
+            CTYPE=${OUT#* }
+            last="$CODE $CTYPE"
+            echo "attempt $attempt: openapi.yaml -> $last"
+            case "$CODE $CTYPE" in
+              "200 application/yaml"*|"200 text/yaml"*|"200 application/x-yaml"*|"200 text/plain"*) ok=1; break ;;
+            esac
+            sleep 20
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::$URL not served as YAML after 6 attempts (last: $last)"
             exit 1
           fi
-          case "$CTYPE" in
-            application/yaml*|text/yaml*|application/x-yaml*|text/plain*) : ;;
-            *) echo "::error::$URL served unexpected content-type '$CTYPE' (expected YAML/text, not HTML)"; exit 1 ;;
-          esac
           grep -q "openapi: 3.0" "$TMP"        || { echo "::error::spec body missing 'openapi: 3.0'"; exit 1; }
           grep -q "api.skillsmith.app" "$TMP"  || { echo "::error::spec body missing 'api.skillsmith.app' server"; exit 1; }
           PATHS=$({ grep -cE '^  /' "$TMP" || true; })


### PR DESCRIPTION
## Problem

The `/openapi.yaml` post-deploy smoke step added in #1399 **failed on every deploy** despite the spec being served correctly (live is a stable `200 application/yaml`).

Root cause: `read -r CODE CTYPE < <(curl -w '%{http_code} %{content_type}' ...)` — `curl -w` emits **no trailing newline**, so `read` returns non-zero at EOF, which trips the job shell's `errexit` (`bash -e`) **before any assertion runs**. The URL was never the issue.

Reproduced: `bash -e -c 'read -r A B < <(printf "200 x"); echo reached'` → exits 1, never prints `reached`.

## Fix

- Parse status + content-type via **command substitution + parameter expansion** (`OUT=$(curl ... || true); CODE=${OUT%% *}; CTYPE=${OUT#* }`) — errexit-safe.
- **Retry up to 6×20s**: production `www.skillsmith.app` is served by Vercel's git-integration deploy, which lags this workflow's own CLI `vercel deploy --prod`, so a single immediate probe can race propagation.

Verified locally under `bash -e` against the live URL: attempt 1 → `200 application/yaml` → PASS (exit 0).

Follow-up to #1399 (the spec itself is live and correct). Workflow-only change — no source/test surface.

`[skip-impl-check]`

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)