### PR TITLE
fix(website): reconcile trust-tier rendering to 5-tier ApiTrustTier (SMI-5217)

### DIFF
--- a/packages/website/src/components/Badge.astro
+++ b/packages/website/src/components/Badge.astro
@@ -11,12 +11,21 @@ interface Props {
 
 const { tier, size = 'md', showIcon = true, class: className = '' } = Astro.props
 
+// SMI-5217: 5-tier public vocabulary (ApiTrustTier). Colors mirror the canonical
+// tier page src/pages/docs/trust-tiers.astro. Keys must match terminology.ts TRUST_TIERS.
 const tierConfig = {
-  verified: {
-    label: 'Verified',
+  official: {
+    label: 'Official',
     bgColor: 'bg-green-500/10',
     textColor: 'text-green-400',
     borderColor: 'border-green-500/30',
+    icon: 'M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.196-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z',
+  },
+  verified: {
+    label: 'Verified',
+    bgColor: 'bg-blue-500/10',
+    textColor: 'text-blue-400',
+    borderColor: 'border-blue-500/30',
     icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
   },
   curated: {
@@ -28,28 +37,22 @@ const tierConfig = {
   },
   community: {
     label: 'Community',
-    bgColor: 'bg-blue-500/10',
-    textColor: 'text-blue-400',
-    borderColor: 'border-blue-500/30',
-    icon: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z',
-  },
-  experimental: {
-    label: 'Experimental',
     bgColor: 'bg-yellow-500/10',
     textColor: 'text-yellow-400',
     borderColor: 'border-yellow-500/30',
-    icon: 'M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z',
+    icon: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z',
   },
-  unknown: {
-    label: 'Unknown',
-    bgColor: 'bg-gray-500/10',
-    textColor: 'text-gray-400',
-    borderColor: 'border-gray-500/30',
+  unverified: {
+    label: 'Unverified',
+    bgColor: 'bg-red-500/10',
+    textColor: 'text-red-400',
+    borderColor: 'border-red-500/30',
     icon: 'M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
   },
 }
 
-const config = tierConfig[tier]
+// SMI-5217: degrade gracefully to the lowest-trust tier for any unexpected value.
+const config = tierConfig[tier] ?? tierConfig.unverified
 
 const sizeStyles = {
   sm: 'px-2 py-0.5 text-xs',

--- a/packages/website/src/components/SubscriptionBadge.astro
+++ b/packages/website/src/components/SubscriptionBadge.astro
@@ -5,7 +5,7 @@
  * Uses WCAG AA compliant colors
  *
  * Subscription tiers represent payment/plan levels (community, individual, team, enterprise)
- * while TrustTier badges represent skill verification status (verified, community, experimental).
+ * while TrustTier badges represent skill verification status (official, verified, curated, community, unverified).
  */
 interface Props {
   tier: 'community' | 'individual' | 'team' | 'enterprise'

--- a/packages/website/src/components/types.ts
+++ b/packages/website/src/components/types.ts
@@ -1,3 +1,5 @@
 // Shared types for website components
 
-export type TrustTier = 'verified' | 'community' | 'experimental' | 'unknown'
+// SMI-5217: alias the canonical 5-tier public vocabulary (terminology.ts) so the
+// rendering layer can't re-drift to the legacy DB tiers (experimental/unknown).
+export type { TrustTierId as TrustTier } from '../constants/terminology'

--- a/packages/website/src/constants/terminology.ts
+++ b/packages/website/src/constants/terminology.ts
@@ -9,7 +9,7 @@
  */
 
 /**
- * Trust Tiers - Four-tier system for evaluating skill safety
+ * Trust Tiers - Five-tier system for evaluating skill safety
  */
 export const TRUST_TIERS = {
   OFFICIAL: {

--- a/packages/website/src/constants/trust-tier-badges.test.ts
+++ b/packages/website/src/constants/trust-tier-badges.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { TRUST_TIERS } from './terminology'
+import {
+  TRUST_TIER_BADGE_CLASSES,
+  TRUST_TIER_PILL_CLASSES,
+  DEFAULT_TRUST_TIER,
+} from './trust-tier-badges'
+
+/**
+ * SMI-5217: guards the website rendering layer against re-drifting away from the
+ * canonical 5-tier public vocabulary. The badge maps must cover exactly the
+ * tiers declared in `TRUST_TIERS` (terminology.ts) — no more (no legacy
+ * `experimental`/`unknown`) and no fewer (no missing `official`/`unverified`).
+ */
+const CANONICAL_TIER_IDS = Object.values(TRUST_TIERS)
+  .map((t) => t.id)
+  .sort()
+
+describe('trust-tier badge maps', () => {
+  it('canonical TRUST_TIERS is the 5-tier public set', () => {
+    expect(CANONICAL_TIER_IDS).toEqual(
+      ['official', 'verified', 'curated', 'community', 'unverified'].sort()
+    )
+  })
+
+  it('full-badge map covers exactly the canonical tiers', () => {
+    expect(Object.keys(TRUST_TIER_BADGE_CLASSES).sort()).toEqual(CANONICAL_TIER_IDS)
+  })
+
+  it('compact-pill map covers exactly the canonical tiers', () => {
+    expect(Object.keys(TRUST_TIER_PILL_CLASSES).sort()).toEqual(CANONICAL_TIER_IDS)
+  })
+
+  it('carries no legacy DB-only tiers', () => {
+    for (const legacy of ['experimental', 'unknown']) {
+      expect(TRUST_TIER_BADGE_CLASSES).not.toHaveProperty(legacy)
+      expect(TRUST_TIER_PILL_CLASSES).not.toHaveProperty(legacy)
+    }
+  })
+
+  it('every tier maps to a non-empty class string', () => {
+    for (const tier of CANONICAL_TIER_IDS) {
+      expect(TRUST_TIER_BADGE_CLASSES[tier as keyof typeof TRUST_TIER_BADGE_CLASSES]).toBeTruthy()
+      expect(TRUST_TIER_PILL_CLASSES[tier as keyof typeof TRUST_TIER_PILL_CLASSES]).toBeTruthy()
+    }
+  })
+
+  it('default fallback tier is a canonical tier', () => {
+    expect(CANONICAL_TIER_IDS).toContain(DEFAULT_TRUST_TIER)
+  })
+})

--- a/packages/website/src/constants/trust-tier-badges.ts
+++ b/packages/website/src/constants/trust-tier-badges.ts
@@ -1,0 +1,41 @@
+/**
+ * Trust-tier badge class maps — single source of truth for how the 5-tier
+ * public `ApiTrustTier` renders across the site.
+ *
+ * SMI-5217: the website rendering layer had drifted to the legacy 4-tier DB
+ * vocabulary (`experimental`/`unknown`, missing `official`). The public API
+ * (`skills-search` / `skills-get`) translates internal DB tiers to the public
+ * set before serialization (SMI-5205): `experimental → community`,
+ * `unknown → unverified`. So every website surface receives exactly the five
+ * canonical tiers and never `experimental`/`unknown`.
+ *
+ * Colors mirror the canonical tier page `src/pages/docs/trust-tiers.astro`.
+ * Keys are derived from the canonical `TRUST_TIERS` constant in `terminology.ts`
+ * and pinned by `trust-tier-badges.test.ts`.
+ */
+import type { TrustTierId } from './terminology'
+
+/** Full badge (rounded pill with border) — skills browse + detail pages. */
+export const TRUST_TIER_BADGE_CLASSES: Record<TrustTierId, string> = {
+  official: 'bg-green-500/10 text-green-400 border-green-500/20',
+  verified: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  curated: 'bg-teal-500/10 text-teal-300 border-teal-500/20',
+  community: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  unverified: 'bg-red-500/10 text-red-400 border-red-500/20',
+}
+
+/** Compact pill (no border) color fragment — related-skills + homepage variant. */
+export const TRUST_TIER_PILL_CLASSES: Record<TrustTierId, string> = {
+  official: 'bg-green-500/20 text-green-400',
+  verified: 'bg-blue-500/20 text-blue-400',
+  curated: 'bg-teal-500/20 text-teal-300',
+  community: 'bg-yellow-500/20 text-yellow-400',
+  unverified: 'bg-red-500/20 text-red-400',
+}
+
+/**
+ * Lowest-trust public tier — the safe rendering fallback for any value the API
+ * doesn't return (it never returns one today, but a graceful degrade beats a
+ * blank/gray badge if the contract ever changes).
+ */
+export const DEFAULT_TRUST_TIER: TrustTierId = 'unverified'

--- a/packages/website/src/pages/index-v2.astro
+++ b/packages/website/src/pages/index-v2.astro
@@ -160,21 +160,21 @@ const supabaseConfig = getSupabaseConfig()
           >
             <span class="inline-flex items-center gap-1 mr-3">
               <span
-                class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-500/20 text-emerald-400"
+                class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-500/20 text-blue-400"
                 >verified</span
               >
               Official Anthropic skills
             </span>
             <span class="inline-flex items-center gap-1 mr-3">
               <span
-                class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-500/20 text-blue-400"
+                class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-yellow-500/20 text-yellow-400"
                 >community</span
               >
               Reviewed
             </span>
             <span class="inline-flex items-center gap-1">
-              <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-dark-700 text-dark-400"
-                >experimental</span
+              <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-500/20 text-red-400"
+                >unverified</span
               >
               New
             </span>
@@ -331,12 +331,19 @@ const supabaseConfig = getSupabaseConfig()
 
         var debounceTimer = null
 
+        // SMI-5217: 5-tier public vocabulary (ApiTrustTier), canonical colors.
+        // The API never returns experimental/unknown — any unmatched value
+        // degrades to the unverified style.
         function badgeClasses(tier) {
-          if (tier === 'verified')
-            return 'px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-500/20 text-emerald-400 flex-shrink-0'
-          if (tier === 'community')
-            return 'px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-500/20 text-blue-400 flex-shrink-0'
-          return 'px-1.5 py-0.5 rounded text-[10px] font-medium bg-dark-700 text-dark-400 flex-shrink-0'
+          const colors = {
+            official: 'bg-green-500/20 text-green-400',
+            verified: 'bg-blue-500/20 text-blue-400',
+            curated: 'bg-teal-500/20 text-teal-300',
+            community: 'bg-yellow-500/20 text-yellow-400',
+            unverified: 'bg-red-500/20 text-red-400',
+          }
+          const color = colors[tier] || colors.unverified
+          return `px-1.5 py-0.5 rounded text-[10px] font-medium ${color} flex-shrink-0`
         }
 
         function renderSkill(skill) {
@@ -351,7 +358,7 @@ const supabaseConfig = getSupabaseConfig()
           name.textContent = skill.name || skill.id || ''
           var badge = document.createElement('span')
           badge.className = badgeClasses(skill.trust_tier)
-          badge.textContent = skill.trust_tier || 'experimental'
+          badge.textContent = skill.trust_tier || 'unverified'
           top.appendChild(name)
           top.appendChild(badge)
           var desc = document.createElement('p')

--- a/packages/website/src/pages/index-v2.astro
+++ b/packages/website/src/pages/index-v2.astro
@@ -13,6 +13,8 @@ import { ClientRouter } from 'astro:transitions'
 import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
 import { getSupabaseConfig } from '../lib/supabase-config'
+// SMI-5217: single source of truth for trust-tier pill colors (canonical 5-tier).
+import { TRUST_TIER_PILL_CLASSES, DEFAULT_TRUST_TIER } from '../constants/trust-tier-badges'
 import '../styles/global.css'
 
 const supabaseConfig = getSupabaseConfig()
@@ -323,7 +325,13 @@ const supabaseConfig = getSupabaseConfig()
     </script>
 
     <!-- Inline skill search (debounced 300ms, 12 results) -->
-    <script is:inline>
+    <script
+      is:inline
+      define:vars={{
+        trustTierPillClasses: TRUST_TIER_PILL_CLASSES,
+        defaultTrustTier: DEFAULT_TRUST_TIER,
+      }}
+    >
       document.addEventListener('astro:page-load', function () {
         var input = document.getElementById('v2-search-input')
         var results = document.getElementById('v2-search-results')
@@ -331,18 +339,11 @@ const supabaseConfig = getSupabaseConfig()
 
         var debounceTimer = null
 
-        // SMI-5217: 5-tier public vocabulary (ApiTrustTier), canonical colors.
-        // The API never returns experimental/unknown — any unmatched value
-        // degrades to the unverified style.
+        // SMI-5217: 5-tier public vocabulary (ApiTrustTier). Colors come from the
+        // shared trustTierPillClasses map (define:vars). The API never returns
+        // experimental/unknown — any unmatched value degrades to the unverified style.
         function badgeClasses(tier) {
-          const colors = {
-            official: 'bg-green-500/20 text-green-400',
-            verified: 'bg-blue-500/20 text-blue-400',
-            curated: 'bg-teal-500/20 text-teal-300',
-            community: 'bg-yellow-500/20 text-yellow-400',
-            unverified: 'bg-red-500/20 text-red-400',
-          }
-          const color = colors[tier] || colors.unverified
+          const color = trustTierPillClasses[tier] || trustTierPillClasses[defaultTrustTier]
           return `px-1.5 py-0.5 rounded text-[10px] font-medium ${color} flex-shrink-0`
         }
 

--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -10,6 +10,12 @@
  * Edge cache for category pages: s-maxage=300, stale-while-revalidate=60
  */
 import BaseLayout from '../../layouts/BaseLayout.astro'
+// SMI-5217: shared 5-tier badge classes (single source of truth, canonical colors).
+import {
+  TRUST_TIER_BADGE_CLASSES,
+  TRUST_TIER_PILL_CLASSES,
+  DEFAULT_TRUST_TIER,
+} from '../../constants/trust-tier-badges'
 
 export const prerender = false
 
@@ -135,12 +141,14 @@ if (isCategory && categoryMeta) {
   Astro.response.headers.set('Cache-Control', 's-maxage=300, stale-while-revalidate=60')
 }
 
+// SMI-5217: compact related-skills pill, keyed off the shared 5-tier map.
+// categorySkills is fetched from the API (skills-search), which only returns the
+// translated public tiers, so an unmatched value degrades to the unverified style.
 function badgeClasses(tier: string): string {
-  if (tier === 'verified')
-    return 'px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-500/20 text-emerald-400 flex-shrink-0'
-  if (tier === 'community')
-    return 'px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-500/20 text-blue-400 flex-shrink-0'
-  return 'px-1.5 py-0.5 rounded text-[10px] font-medium bg-dark-700 text-dark-400 flex-shrink-0'
+  const color =
+    TRUST_TIER_PILL_CLASSES[tier as keyof typeof TRUST_TIER_PILL_CLASSES] ??
+    TRUST_TIER_PILL_CLASSES[DEFAULT_TRUST_TIER]
+  return `px-1.5 py-0.5 rounded text-[10px] font-medium ${color} flex-shrink-0`
 }
 
 // Build JSON-LD for category pages
@@ -565,6 +573,8 @@ const categoryJsonLd =
   define:vars={{
     skillId: id,
     apiBase: `${import.meta.env.PUBLIC_API_BASE_URL || 'https://api.skillsmith.app'}/functions/v1`,
+    trustBadgeClasses: TRUST_TIER_BADGE_CLASSES,
+    defaultTrustTier: DEFAULT_TRUST_TIER,
   }}
 >
   const API_BASE = apiBase
@@ -610,13 +620,8 @@ const categoryJsonLd =
       }
     }
 
-    // Trust tier badge colors
-    const trustBadgeClasses = {
-      verified: 'bg-green-500/10 text-green-400 border-green-500/20',
-      community: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
-      experimental: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
-      unknown: 'bg-dark-500/10 text-dark-400 border-dark-500/20',
-    }
+    // SMI-5217: trustBadgeClasses + defaultTrustTier injected via define:vars
+    // from the shared 5-tier map (constants/trust-tier-badges.ts).
 
     // Quality tier thresholds (matches packages/website/src/utils/quality-tiers.ts)
     const TIER_THRESHOLDS = { ELITE: 10000, HIGH_QUALITY: 500, GROWING: 50 }
@@ -687,9 +692,9 @@ const categoryJsonLd =
 
       // Trust badge
       const trustBadge = document.getElementById('skill-trust-badge')
-      const trustTier = skill.trust_tier || 'unknown'
+      const trustTier = skill.trust_tier || defaultTrustTier
       trustBadge.textContent = trustTier
-      trustBadge.className = `px-3 py-1 text-sm font-medium rounded-full border ${trustBadgeClasses[trustTier] || trustBadgeClasses.unknown}`
+      trustBadge.className = `px-3 py-1 text-sm font-medium rounded-full border ${trustBadgeClasses[trustTier] || trustBadgeClasses[defaultTrustTier]}`
 
       // Quality tier based on stars
       const stars = skill.stars ?? 0
@@ -781,7 +786,7 @@ const categoryJsonLd =
         window.gtag('event', 'skill_view', {
           skill_id: skillId,
           skill_name: skill.name || skillId,
-          trust_tier: skill.trust_tier || 'unknown',
+          trust_tier: skill.trust_tier || defaultTrustTier,
           category: skill.categories?.[0] || 'uncategorized',
         })
       }

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -6,6 +6,9 @@ import SignedOutOverlay from '../../components/SignedOutOverlay.astro'
 import { isCrawlerUserAgent } from '../../lib/crawler-detect'
 // SMI-4838: featured-skills catalog seed — pinned author/name set verified against indexer DB.
 import featuredSkillsData from '../../data/featured-skills.json'
+// SMI-5217: shared 5-tier badge classes (single source of truth, canonical colors).
+import { TRUST_TIER_BADGE_CLASSES, DEFAULT_TRUST_TIER } from '../../constants/trust-tier-badges'
+import { TRUST_TIER_ORDER } from '../../constants/terminology'
 
 const FEATURED_SKILL_IDS: string[] = (featuredSkillsData.skills as Array<{ id: string }>).map(
   (s) => s.id
@@ -22,12 +25,12 @@ const categories = [
   { value: 'security', label: 'Security' },
 ]
 
+// SMI-5217: derive filter options from the canonical 5-tier order so the values
+// stay in lock-step with the API's accepted trust_tier set (experimental/unknown
+// are rejected by skills-search; official was missing).
 const trustTiers = [
   { value: '', label: 'All Trust Tiers' },
-  { value: 'verified', label: 'Verified' },
-  { value: 'curated', label: 'Curated' },
-  { value: 'community', label: 'Community' },
-  { value: 'experimental', label: 'Experimental' },
+  ...TRUST_TIER_ORDER.map((t) => ({ value: t.id, label: t.label })),
 ]
 
 // SMI-4401 Wave 2: SSR-time crawler detection. Emits a human-only overlay while keeping
@@ -392,6 +395,8 @@ const isCrawler = isCrawlerUserAgent(userAgent)
     define:vars={{
       apiBase: `${import.meta.env.PUBLIC_API_BASE_URL || 'https://api.skillsmith.app'}/functions/v1`,
       FEATURED_SKILL_IDS,
+      trustBadgeClasses: TRUST_TIER_BADGE_CLASSES,
+      defaultTrustTier: DEFAULT_TRUST_TIER,
     }}
   >
     const API_BASE = apiBase
@@ -492,14 +497,8 @@ const isCrawler = isCrawlerUserAgent(userAgent)
       const searchPromptState = document.getElementById('search-prompt-state')
       const searchSuggestions = document.querySelectorAll('.search-suggestion')
 
-      // Trust tier badge colors
-      const trustBadgeClasses = {
-        verified: 'bg-green-500/10 text-green-400 border-green-500/20',
-        curated: 'bg-teal-500/10 text-teal-300 border-teal-500/20',
-        community: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
-        experimental: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
-        unknown: 'bg-dark-500/10 text-dark-400 border-dark-500/20',
-      }
+      // SMI-5217: trustBadgeClasses + defaultTrustTier injected via define:vars
+      // from the shared 5-tier map (constants/trust-tier-badges.ts).
 
       // Quality tier thresholds (matches packages/website/src/utils/quality-tiers.ts)
       const TIER_THRESHOLDS = { ELITE: 10000, HIGH_QUALITY: 500, GROWING: 50 }
@@ -525,7 +524,8 @@ const isCrawler = isCrawlerUserAgent(userAgent)
 
       // Create skill card HTML
       function createSkillCard(skill) {
-        const trustClass = trustBadgeClasses[skill.trust_tier] || trustBadgeClasses.unknown
+        const trustClass =
+          trustBadgeClasses[skill.trust_tier] || trustBadgeClasses[defaultTrustTier]
         const stars = skill.stars ?? 0
         const tier = getQualityTier(stars)
         const ariaLabel = `${tier.label}: ${formatNumber(stars)} stars`
@@ -540,7 +540,7 @@ const isCrawler = isCrawlerUserAgent(userAgent)
               ${orgMatchBadge}
             </div>
             <span class="ml-4 px-2.5 py-1 text-xs font-medium rounded-full border ${trustClass}">
-              ${escapeHtml(skill.trust_tier || 'unknown')}
+              ${escapeHtml(skill.trust_tier || defaultTrustTier)}
             </span>
           </div>
           <p class="text-dark-400 text-sm mb-4 line-clamp-2">${escapeHtml(skill.description || 'No description available')}</p>

--- a/packages/website/src/styles/global.css
+++ b/packages/website/src/styles/global.css
@@ -172,16 +172,25 @@
   @apply inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium;
 }
 
-@utility badge-verified {
+/* SMI-5217: 5-tier public vocabulary (ApiTrustTier), colors per docs/trust-tiers.astro. */
+@utility badge-official {
   @apply badge bg-green-100 text-green-800;
 }
 
-@utility badge-community {
+@utility badge-verified {
   @apply badge bg-blue-100 text-blue-800;
 }
 
-@utility badge-experimental {
+@utility badge-curated {
+  @apply badge bg-teal-100 text-teal-800;
+}
+
+@utility badge-community {
   @apply badge bg-yellow-100 text-yellow-800;
+}
+
+@utility badge-unverified {
+  @apply badge bg-red-100 text-red-800;
 }
 
 @layer base {

--- a/packages/website/src/types/index.ts
+++ b/packages/website/src/types/index.ts
@@ -1,6 +1,10 @@
 /**
  * Type definitions for Skillsmith website
  */
+// SMI-5217: the API (skills-search/skills-get) translates internal DB tiers to
+// the canonical 5-tier public set before serialization, so the Skill wire type
+// uses the canonical vocabulary rather than the legacy experimental/unknown DB tiers.
+import type { TrustTierId } from '../constants/terminology'
 
 /**
  * Feature in a pricing tier
@@ -39,7 +43,7 @@ export interface Skill {
   displayName: string
   description: string
   version: string
-  trustTier: 'verified' | 'curated' | 'community' | 'experimental' | 'unknown'
+  trustTier: TrustTierId
   category: SkillCategory
   tags: string[]
   qualityScore: number


### PR DESCRIPTION
## SMI-5217 — Website trust-tier rendering reconciled to canonical 5-tier

Closes SMI-5217.

### Verified RCA (code-as-truth)
The website rendering layer had drifted to the legacy 4-tier DB vocabulary (`experimental`/`unknown`, missing `official`). Confirmed against shipped edge functions:
- `supabase/functions/skills-search/index.ts:453` and `skills-get/index.ts:192` translate internal DB tiers to the public set **before serialization** (SMI-5205): `experimental → community`, `unknown → unverified`.
- All website surfaces (skills browse/detail, index-v2) are API-fed, so they only ever receive the 5-tier public set `official | verified | curated | community | unverified` — never `experimental`/`unknown`.

### Concrete bugs fixed
- **Filter sent a rejected value:** the trust-tier filter offered `experimental` (rejected by `skills-search`'s `VALID_TRUST_TIERS` → HTTP 400) and omitted `official`. Now derived from the canonical `TRUST_TIER_ORDER`.
- **Missing badge styles:** client badge maps lacked `official` + `unverified` (and `[id]` lacked `curated`); those API-returned tiers fell through to the gray "unknown" style.

### Changes
- New `constants/trust-tier-badges.ts` — single source of truth for full-badge + compact-pill class maps, canonical colors per `docs/trust-tiers.astro`, keyed off `terminology.ts` `TRUST_TIERS`; `DEFAULT_TRUST_TIER='unverified'` fallback.
- Collapsed three divergent `TrustTier` definitions onto the canonical `TrustTierId`.
- `Badge.astro` tierConfig → 5 canonical tiers + graceful fallback.
- `skills/index.astro` + `[id].astro` + `index-v2.astro` consume the shared map via `define:vars`; fallbacks point at `unverified`.
- `global.css` `badge-*` utilities reconciled.
- New `trust-tier-badges.test.ts` pins the maps to `TRUST_TIERS` (drift guard).

### Governance review
Run on `46865a87`; one finding (index-v2's duplicated inline color map) fixed in `3076e815` — index-v2 now consumes the shared constant. No new `window.__*` reads or `astro:page-load` binds (concurrency clean). Code-review report recorded here + in Linear rather than `docs/internal/code_review/` to avoid the SMI-5227 submodule pre-push staleness FAIL.

Pre-existing note (out of scope): the index-v2 legend labels a blue `verified` pill "Official Anthropic skills" — A/B variant marketing copy (SMI-3016), not a rendering-vocabulary bug.

### Verification
typecheck ✓ · root lint ✓ · 293 website tests (incl. 6 new) ✓ · `astro check` 0 errors + build ✓ · prettier ✓ · `audit:standards` 0 fail ✓

UAT: review the Vercel preview `/skills` + `/skills/<id>` badges (official=green, verified=blue, curated=teal, community=yellow, unverified=red) before merge.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)