### PR TITLE
fix(ci): make audit Check 25 spread-aware for MCP tool count (SMI-5216)

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -149,11 +149,11 @@ const toolDefinitions = [
   complianceReportToolSchema,
   // SMI-5213: skill_inventory_audit, apply_namespace_rename, and (gated)
   // apply_recommended_edit. Spread so apply_recommended_edit is omitted
-  // when APPLY_TEMPLATE_REGISTRY is empty. NOTE: audit:standards Check 25
-  // line-counts this array and can't see spread/conditional entries, so it
-  // emits a non-blocking tool-count warn (37 vs 39 README rows). The real
-  // registration invariant is covered by the ListTools-registry test;
-  // SMI-5216 tracks making Check 25 spread-aware (ADR-109 infra path).
+  // when APPLY_TEMPLATE_REGISTRY is empty. audit:standards Check 25 resolves
+  // this spread to its MAX *ToolSchema set (SMI-5216), so the README must
+  // document every tool that CAN register (the max set, incl. the gated one).
+  // Runtime may register fewer; that correctness is covered by the
+  // ListTools-registry test, not Check 25.
   ...newAuditToolDefinitions(),
 ]
 

--- a/scripts/audit-mcp-tool-count-helpers.mjs
+++ b/scripts/audit-mcp-tool-count-helpers.mjs
@@ -1,0 +1,151 @@
+/**
+ * Helper for audit:standards Check 25 (MCP Tool Count parity, SMI-3886 / SMI-5216).
+ *
+ * Counts the tools in `packages/mcp-server/src/index.ts`'s `toolDefinitions`
+ * array, resolving spread builders (`...builder()`) to the number of `*ToolSchema`
+ * identifiers they can contribute.
+ *
+ * IMPORTANT — counts the MAXIMUM tool set: every tool a spread builder CAN
+ * contribute, conditional `.push()` included. The runtime may register fewer
+ * (e.g. `apply_recommended_edit` is gated on `APPLY_TEMPLATE_REGISTRY.size`);
+ * runtime-registration correctness is covered by the ListTools-registry test in
+ * `packages/mcp-server`, NOT by this counter. The invariant this enables is:
+ * "the README documents every tool that CAN register." (SMI-5216)
+ *
+ * Pure / side-effect-free: no I/O of its own (the caller injects
+ * `resolveModuleSource`) so it can be unit-tested without running the full audit
+ * (audit-standards.mjs executes every check on import).
+ */
+
+/** A tool schema is any identifier matching `<word>ToolSchema`. */
+const SCHEMA_IDENTIFIER = /\b\w+ToolSchema\b/g
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Find the import specifier (module path) that `name` is imported from in `source`.
+ * Handles single- and multi-line `import { … } from '<spec>'` (incl. `import type`).
+ * @returns {string | null} the specifier (e.g. './audit-tool-dispatch.js') or null.
+ */
+export function findImportSpecifier(name, source) {
+  const importRe = /import\s+(?:type\s+)?\{([\s\S]*?)\}\s*from\s*['"]([^'"]+)['"]/g
+  const nameRe = new RegExp(`(^|[\\s,{])${escapeRegExp(name)}(\\s|,|}|$)`)
+  let m
+  while ((m = importRe.exec(source)) !== null) {
+    if (nameRe.test(m[1])) return m[2]
+  }
+  return null
+}
+
+/**
+ * Extract a builder's block body by walking balanced braces from the body-opening
+ * `{` (the first `{` encountered at paren-depth 0 after the declaration anchor, so
+ * parameter-destructuring braces are skipped). Supports `function NAME(...)` and
+ * `const|let|var NAME = (...) =>` / `= function (...)` forms.
+ * @returns {string | null} the body text, or null if the declaration/body isn't
+ *   found or the braces can't balance (caller treats null as count-as-1 + warn).
+ */
+export function extractBuilderBody(name, source) {
+  const anchor = new RegExp(
+    `(?:export\\s+)?(?:async\\s+)?function\\s+${escapeRegExp(name)}\\b|` +
+      `(?:export\\s+)?(?:const|let|var)\\s+${escapeRegExp(name)}\\s*=`
+  )
+  const am = anchor.exec(source)
+  if (!am) return null
+
+  // Find the body-opening brace at paren-depth 0 (skip param-list / destructuring braces).
+  let parenDepth = 0
+  let braceStart = -1
+  for (let i = am.index + am[0].length; i < source.length; i++) {
+    const ch = source[i]
+    if (ch === '(') parenDepth++
+    else if (ch === ')') parenDepth = Math.max(0, parenDepth - 1)
+    else if (ch === '{' && parenDepth === 0) {
+      braceStart = i
+      break
+    }
+  }
+  if (braceStart === -1) return null
+
+  // Walk balanced braces to the matching close.
+  let depth = 0
+  for (let i = braceStart; i < source.length; i++) {
+    const ch = source[i]
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return source.slice(braceStart + 1, i)
+    }
+  }
+  return null // unbalanced
+}
+
+/**
+ * Resolve a spread builder to the count of distinct `*ToolSchema` identifiers in
+ * its body (the max set). Returns null on ANY failure — import specifier not found,
+ * `resolveModuleSource` returns null/throws, body can't be isolated, or 0 schemas
+ * found — so the caller can count-as-1 and warn rather than silently undercount.
+ */
+function resolveBuilderToolCount(builderName, indexContent, resolveModuleSource) {
+  const spec = findImportSpecifier(builderName, indexContent)
+  if (!spec) return null
+
+  let moduleSource
+  try {
+    moduleSource = resolveModuleSource(spec)
+  } catch {
+    return null
+  }
+  if (!moduleSource) return null
+
+  const body = extractBuilderBody(builderName, moduleSource)
+  if (body === null) return null
+
+  const matches = body.match(SCHEMA_IDENTIFIER)
+  if (!matches || matches.length === 0) return null
+  return new Set(matches).size
+}
+
+/**
+ * Count the maximum tools registered via `toolDefinitions` in `indexContent`.
+ *
+ * @param {object} opts
+ * @param {string} opts.indexContent - source text of mcp-server/src/index.ts.
+ * @param {(spec: string) => string | null} opts.resolveModuleSource - maps an import
+ *   specifier (e.g. './audit-tool-dispatch.js') to that module's source text, or null.
+ * @returns {{ count: number, unresolvedSpreads: string[] }} - `count` is the static
+ *   maximum tool count; `unresolvedSpreads` lists builder names that could not be
+ *   resolved (each counted as 1) so the caller can emit a warn.
+ */
+export function countToolDefinitions({ indexContent, resolveModuleSource }) {
+  const unresolvedSpreads = []
+  const defMatch = indexContent.match(/const toolDefinitions\s*=\s*\[([\s\S]*?)\]/)
+  if (!defMatch) return { count: 0, unresolvedSpreads }
+
+  let count = 0
+  for (const rawLine of defMatch[1].split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('//')) continue
+
+    const spread = line.match(/^\.\.\.\s*([A-Za-z0-9_$]+)\s*\(/)
+    if (!spread) {
+      // A plain entry (identifier or inline object) — counts as one tool
+      // regardless of whether it matches *ToolSchema (e.g. installTool/uninstallTool).
+      count += 1
+      continue
+    }
+
+    const builderName = spread[1]
+    const resolved = resolveBuilderToolCount(builderName, indexContent, resolveModuleSource)
+    if (resolved === null) {
+      unresolvedSpreads.push(builderName)
+      count += 1
+    } else {
+      count += resolved
+    }
+  }
+
+  return { count, unresolvedSpreads }
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -40,6 +40,7 @@ import {
 import { VERCEL_JSON_SHARED_FIELDS, validateVercelJsonSync } from './audit-vercel-sync-helpers.mjs'
 import { findRealpathAsymmetry } from './audit-realpath-asymmetry-helpers.mjs'
 import { findUnpinnedActionUses } from './audit-workflow-sha-pin-helpers.mjs'
+import { countToolDefinitions } from './audit-mcp-tool-count-helpers.mjs'
 
 const RED = '\x1b[31m'
 const GREEN = '\x1b[32m'
@@ -1881,11 +1882,28 @@ console.log(`\n${BOLD}25. MCP Tool Count (SMI-3886)${RESET}`)
   } else {
     try {
       const indexContent = readFileSync(mcpIndexPath, 'utf8')
-      // Extract toolDefinitions array and count entries (lines with Schema or Tool suffix)
-      const defMatch = indexContent.match(/const toolDefinitions\s*=\s*\[([\s\S]*?)\]/)
-      const toolCount = defMatch
-        ? defMatch[1].split('\n').filter((l) => l.trim() && !l.trim().startsWith('//')).length
-        : 0
+      // SMI-5216: spread-aware count. Plain entries count as 1; a `...builder()`
+      // spread is resolved to the MAX *ToolSchema set the builder can contribute
+      // (conditional pushes included). Invariant: the README documents every tool
+      // that CAN register. Runtime may register fewer (e.g. apply_recommended_edit
+      // is gated on APPLY_TEMPLATE_REGISTRY) — that's covered by the
+      // ListTools-registry test, not this counter.
+      const mcpSrcDir = dirname(mcpIndexPath)
+      const { count: toolCount, unresolvedSpreads } = countToolDefinitions({
+        indexContent,
+        // Map an import specifier (e.g. './audit-tool-dispatch.js') to its .ts source.
+        resolveModuleSource: (spec) => {
+          if (!spec.startsWith('.')) return null
+          const tsPath = resolvePath(mcpSrcDir, spec.replace(/\.js$/, '.ts'))
+          return existsSync(tsPath) ? readFileSync(tsPath, 'utf8') : null
+        },
+      })
+      if (unresolvedSpreads.length > 0) {
+        warn(
+          `Check 25: could not resolve spread builder(s) in toolDefinitions: ${unresolvedSpreads.join(', ')}`,
+          'Each unresolved spread was counted as a single tool — the README parity count may be low'
+        )
+      }
 
       const readme = readFileSync(mcpReadmePath, 'utf8')
       // Extract "Available Tools" section up to next heading, then count tool rows

--- a/scripts/tests/audit-mcp-tool-count.test.ts
+++ b/scripts/tests/audit-mcp-tool-count.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest'
+import {
+  countToolDefinitions,
+  findImportSpecifier,
+  extractBuilderBody,
+} from '../audit-mcp-tool-count-helpers.mjs'
+
+/**
+ * SMI-5216: Check 25 (MCP Tool Count parity) must resolve the `...newAuditToolDefinitions()`
+ * spread to the MAXIMUM tool set instead of line-counting it as a single entry.
+ * The failure-mode cases below are the load-bearing safety net — any resolution
+ * failure must degrade to count-as-1 + a named entry in `unresolvedSpreads`.
+ */
+
+// A faithful miniature of mcp-server/src/index.ts: a few plain entries (one of which
+// is NOT *ToolSchema), then a spread builder import + use.
+const INDEX_WITH_SPREAD = `
+import { searchToolSchema } from './tools/search.js'
+import { newAuditToolDefinitions } from './audit-tool-dispatch.js'
+
+const installTool = makeInstallTool()
+
+const toolDefinitions = [
+  searchToolSchema,
+  installTool,
+  // a comment line that must be ignored
+  ...newAuditToolDefinitions(),
+]
+`
+
+// The real builder shape: 2 always + 1 conditional push = 3 max.
+const DISPATCH_SOURCE = `
+import { skillInventoryAuditToolSchema } from './tools/skill-inventory-audit.js'
+import { applyNamespaceRenameToolSchema } from './tools/apply-namespace-rename.js'
+import { applyRecommendedEditToolSchema } from './tools/apply-recommended-edit.js'
+
+export function newAuditToolDefinitions() {
+  const defs = [skillInventoryAuditToolSchema, applyNamespaceRenameToolSchema]
+  if (APPLY_TEMPLATE_REGISTRY.size > 0) {
+    defs.push(applyRecommendedEditToolSchema)
+  }
+  return defs
+}
+`
+
+const resolveTo = (source: string) => () => source
+const resolveNull = () => null
+
+describe('countToolDefinitions — counting semantics', () => {
+  it('resolves a spread builder to its max *ToolSchema set (2 literals + 1 spread→3 = 3 total here)', () => {
+    const { count, unresolvedSpreads } = countToolDefinitions({
+      indexContent: INDEX_WITH_SPREAD,
+      resolveModuleSource: resolveTo(DISPATCH_SOURCE),
+    })
+    // 2 plain entries (searchToolSchema, installTool) + 3 from the builder = 5
+    expect(count).toBe(5)
+    expect(unresolvedSpreads).toEqual([])
+  })
+
+  it('counts a non-*ToolSchema literal entry (installTool) as one tool', () => {
+    const idx = `
+const toolDefinitions = [
+  searchToolSchema,
+  installTool,
+  uninstallTool,
+]
+`
+    const { count, unresolvedSpreads } = countToolDefinitions({
+      indexContent: idx,
+      resolveModuleSource: resolveNull,
+    })
+    expect(count).toBe(3)
+    expect(unresolvedSpreads).toEqual([])
+  })
+
+  it('counts a builder with only array entries (no conditional push)', () => {
+    const idx = `
+import { b } from './b.js'
+const toolDefinitions = [
+  aToolSchema,
+  ...b(),
+]
+`
+    const builder = `export function b() { return [xToolSchema, yToolSchema] }`
+    const { count } = countToolDefinitions({
+      indexContent: idx,
+      resolveModuleSource: resolveTo(builder),
+    })
+    expect(count).toBe(3) // aToolSchema + (xToolSchema, yToolSchema)
+  })
+
+  it('counts a schema pushed under an `if` (max set, conditional included)', () => {
+    const idx = `
+import { b } from './b.js'
+const toolDefinitions = [
+  ...b(),
+]
+`
+    const builder = `export function b() {
+      const defs = [oneToolSchema]
+      if (flag) defs.push(twoToolSchema)
+      return defs
+    }`
+    const { count } = countToolDefinitions({
+      indexContent: idx,
+      resolveModuleSource: resolveTo(builder),
+    })
+    expect(count).toBe(2)
+  })
+
+  it('resolves an arrow-function builder via the widened anchor', () => {
+    const idx = `
+import { b } from './b.js'
+const toolDefinitions = [
+  ...b(),
+]
+`
+    const builder = `export const b = () => { return [oneToolSchema, twoToolSchema, threeToolSchema] }`
+    const { count, unresolvedSpreads } = countToolDefinitions({
+      indexContent: idx,
+      resolveModuleSource: resolveTo(builder),
+    })
+    expect(count).toBe(3)
+    expect(unresolvedSpreads).toEqual([])
+  })
+
+  it('equals the literal count when there is no spread (back-compat)', () => {
+    const idx = `const toolDefinitions = [
+  aToolSchema,
+  bToolSchema,
+  cToolSchema,
+]`
+    const { count, unresolvedSpreads } = countToolDefinitions({
+      indexContent: idx,
+      resolveModuleSource: resolveNull,
+    })
+    expect(count).toBe(3)
+    expect(unresolvedSpreads).toEqual([])
+  })
+
+  it('returns 0 when toolDefinitions is absent', () => {
+    const { count } = countToolDefinitions({
+      indexContent: 'const other = []',
+      resolveModuleSource: resolveNull,
+    })
+    expect(count).toBe(0)
+  })
+})
+
+describe('countToolDefinitions — resolution-failure modes (count-as-1 + named warn)', () => {
+  const idxWithSpread = `
+import { b } from './b.js'
+const toolDefinitions = [
+  aToolSchema,
+  ...b(),
+]
+`
+
+  it('(a) builder import specifier absent from index → count-as-1, name in unresolvedSpreads', () => {
+    const idxNoImport = `const toolDefinitions = [
+  aToolSchema,
+  ...b(),
+]`
+    const { count, unresolvedSpreads } = countToolDefinitions({
+      indexContent: idxNoImport,
+      resolveModuleSource: resolveTo('whatever'),
+    })
+    expect(count).toBe(2) // aToolSchema + spread-as-1
+    expect(unresolvedSpreads).toEqual(['b'])
+  })
+
+  it('(b) resolveModuleSource returns null → count-as-1, name in unresolvedSpreads', () => {
+    const { count, unresolvedSpreads } = countToolDefinitions({
+      indexContent: idxWithSpread,
+      resolveModuleSource: resolveNull,
+    })
+    expect(count).toBe(2)
+    expect(unresolvedSpreads).toEqual(['b'])
+  })
+
+  it('(b′) resolveModuleSource throws → count-as-1, name in unresolvedSpreads', () => {
+    const { count, unresolvedSpreads } = countToolDefinitions({
+      indexContent: idxWithSpread,
+      resolveModuleSource: () => {
+        throw new Error('read failed')
+      },
+    })
+    expect(count).toBe(2)
+    expect(unresolvedSpreads).toEqual(['b'])
+  })
+
+  it('(c) builder body braces cannot balance → count-as-1, name in unresolvedSpreads', () => {
+    const truncated = `export function b() { const defs = [oneToolSchema]` // no closing brace
+    const { count, unresolvedSpreads } = countToolDefinitions({
+      indexContent: idxWithSpread,
+      resolveModuleSource: resolveTo(truncated),
+    })
+    expect(count).toBe(2)
+    expect(unresolvedSpreads).toEqual(['b'])
+  })
+
+  it('(d) builder body resolves but has 0 *ToolSchema → count-as-1, name in unresolvedSpreads', () => {
+    const empty = `export function b() { return [] }`
+    const { count, unresolvedSpreads } = countToolDefinitions({
+      indexContent: idxWithSpread,
+      resolveModuleSource: resolveTo(empty),
+    })
+    expect(count).toBe(2)
+    expect(unresolvedSpreads).toEqual(['b'])
+  })
+})
+
+describe('findImportSpecifier', () => {
+  it('finds a single-line import', () => {
+    expect(findImportSpecifier('foo', `import { foo } from './bar.js'`)).toBe('./bar.js')
+  })
+  it('finds a name in a multi-line / multi-name import', () => {
+    const src = `import {\n  a,\n  foo,\n  b,\n} from './multi.js'`
+    expect(findImportSpecifier('foo', src)).toBe('./multi.js')
+  })
+  it('does not match a substring (bar vs barBaz)', () => {
+    expect(findImportSpecifier('bar', `import { barBaz } from './x.js'`)).toBeNull()
+  })
+  it('returns null when the name is not imported', () => {
+    expect(findImportSpecifier('foo', `import { other } from './x.js'`)).toBeNull()
+  })
+})
+
+describe('extractBuilderBody', () => {
+  it('extracts a function-declaration body', () => {
+    const body = extractBuilderBody('b', `export function b(): T[] { return [xToolSchema] }`)
+    expect(body).toContain('xToolSchema')
+  })
+  it('skips parameter-destructuring braces', () => {
+    const body = extractBuilderBody('b', `const b = ({ a } = {}) => { return [yToolSchema] }`)
+    expect(body).toContain('yToolSchema')
+    expect(body).not.toContain('= {}')
+  })
+  it('returns null on unbalanced braces', () => {
+    expect(extractBuilderBody('b', `function b() { return [`)).toBeNull()
+  })
+  it('returns null when the builder is not found', () => {
+    expect(extractBuilderBody('missing', `function other() {}`)).toBeNull()
+  })
+})


### PR DESCRIPTION
## SMI-5216 — Check 25 (MCP Tool Count) can't count spread/conditional registration

Closes SMI-5216. **ADR-109 infra** (`scripts/audit-standards.mjs`) — SPARC plan + plan-review completed.

### Problem
Check 25 line-counted `const toolDefinitions = [...]` in `mcp-server/src/index.ts` and couldn't see through the single-line `...newAuditToolDefinitions()` spread (returns 2–3 `*ToolSchema`, one gated on `APPLY_TEMPLATE_REGISTRY`), producing a standing non-blocking warn `37 in toolDefinitions vs 39 in README`.

### Fix
New pure helper `scripts/audit-mcp-tool-count-helpers.mjs` resolves each `...builder()` spread: locate the builder's import → read its source module → count distinct `*ToolSchema` identifiers in its body (the static **maximum** set, conditional `.push()` included). `36 literals + 3 = 39 == README`. Plain entries (incl. non-`*ToolSchema` `installTool`/`uninstallTool`) count as 1. **Any** resolution failure (import/file/brace/0-schemas) degrades to count-as-1 and surfaces via `unresolvedSpreads` → a named `warn`, so a future un-analyzable builder is loud, not silent.

### Invariant (documented in helper + reworded `index.ts` comment)
The README documents every tool that **can** register (max set); runtime may register fewer — that correctness stays covered by the ListTools-registry test, not Check 25.

### Plan-review (sound, no Critical/High; 2 Medium edits folded in)
- Hardened the test matrix to cover **each** resolution-failure mode explicitly.
- Added the "counts MAX set" invariant comment to prevent a future maintainer reintroducing the 38-vs-39 oscillation.
- Verified: `installTool`/`uninstallTool` are the only non-`*ToolSchema` literals (handled); `audit-tool-dispatch.ts` is not git-crypt'd (host-readable); extracted-helper+test matches in-repo precedent (`audit-vercel-sync-helpers.mjs`).
- Plan: `docs/internal/implementation/smi-5216-audit-check25-spread-aware.md` (submodule).

### Verification
- Check 25 → `✓ MCP tool count matches: 39 tools in code and README`
- `audit:standards` 0 fail (77 pass / 2 warn — the tool-count warn is gone)
- 20 new unit tests (incl. each failure mode), lint + typecheck clean
- Helper imports under plain `node` — satisfies the non-Docker `quality-checks` job

### Governance
Clean — no findings. No new shared state; pure side-effect-free helper. Review recorded here + in Linear (not `docs/internal/code_review/`, to avoid the SMI-5227 submodule pre-push staleness FAIL).

### Unrelated note
`packages/mcp-server/tests/integration/install.integration.test.ts` fails in **local Docker** but is **green in CI** at base SHA `e2940e59` (reproduced with this PR's changes stashed) — a local-env artifact, **not** introduced here.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)