### PR TITLE
chore(release): weekly cadence bump — 2026-06-07

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29726,12 +29726,12 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@skillsmith/core": "^0.8.0",
-        "@skillsmith/mcp-server": "^0.5.3",
+        "@skillsmith/core": "^0.8.1",
+        "@skillsmith/mcp-server": "^0.5.4",
         "chalk": "5.6.2",
         "chokidar": "4.0.3",
         "cli-table3": "0.6.5",
@@ -29840,7 +29840,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -29861,7 +29861,8 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "7.6.13",
-        "vitest": "4.1.6"
+        "vitest": "4.1.6",
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=22.22.0"
@@ -29967,18 +29968,18 @@
     },
     "packages/enterprise": {
       "name": "@smith-horn/enterprise",
-      "version": "0.1.2",
+      "version": "0.2.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-        "@skillsmith/core": "^0.7.2",
+        "@skillsmith/core": "^0.8.1",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "*",
+        "@skillsmith/mcp-server": "^0.5.4",
         "@smithy/config-resolver": "4.4.13",
         "@smithy/core": "3.23.12",
         "@smithy/middleware-endpoint": "4.4.27",
@@ -29993,7 +29994,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "*"
+        "@skillsmith/mcp-server": "^0.5.4"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -30034,37 +30035,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "packages/enterprise/node_modules/@skillsmith/core": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@skillsmith/core/-/core-0.7.2.tgz",
-      "integrity": "sha512-ESKFfrn2rK/+RldYgxzzDeZzdj/9/xW5jMZp23y27Y5p99zSAlhkB7l3r+/GerGxxydinSmZX0bx8URkaoRkqA==",
-      "license": "Elastic-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "1.9.1",
-        "@opentelemetry/instrumentation-http": "0.218.0",
-        "@opentelemetry/instrumentation-runtime-node": "0.31.0",
-        "@opentelemetry/instrumentation-undici": "0.28.0",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-node": "0.218.0",
-        "@opentelemetry/sdk-trace-base": "2.7.1",
-        "@opentelemetry/semantic-conventions": "1.41.1",
-        "fts5-sql-bundle": "1.0.2",
-        "lru-cache": "11.3.3",
-        "posthog-node": "5.29.2",
-        "tree-sitter-wasms": "0.1.13",
-        "typescript": "5.9.3",
-        "web-tree-sitter": "0.25.10",
-        "zod": "4.2.1"
-      },
-      "engines": {
-        "node": ">=22.22.0"
-      },
-      "optionalDependencies": {
-        "@huggingface/transformers": "3.8.1",
-        "better-sqlite3": "12.10.0",
-        "hnswlib-node": "^3.0.0"
       }
     },
     "packages/enterprise/node_modules/@smithy/smithy-client": {
@@ -30189,11 +30159,11 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.8.0",
+        "@skillsmith/core": "^0.8.1",
         "esbuild": "0.27.2",
         "ulid": "3.0.1"
       },
@@ -30243,7 +30213,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.6.4
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.6.3).
+
 ## v0.6.3
 
 - **Refactor**: SMI-5036 split oversized billing test files (#1282)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.8.0",
-    "@skillsmith/mcp-server": "^0.5.3",
+    "@skillsmith/core": "^0.8.1",
+    "@skillsmith/mcp-server": "^0.5.4",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",
     "cli-table3": "0.6.5",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.8.1
+
+- **Fix**: publish OpenAPI spec to production (SMI-5226) (#1399)
+- **Feature**: reconcile live API contract + register 3 audit tools (SMI-5213) (#1395)
+- **Fix**: handle AbortController timeout in RawUrlSourceAdapter SSRF test (SMI-5211)
+- **Fix**: add ./services/skill-installation-validate package export (SMI-4745 retro) (#1368)
+
 ## v0.8.0
 
 - **Feature**: SMI-5039 — new `./embeddings/probe` subpath export. Extracts the

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.8.0'
+export const VERSION = '0.8.1'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+## v0.2.1
+
+- **Fix**: add missing [Unreleased] stub to CHANGELOG post-0.2.0 release (SMI-5154 retro)
+
 ## [0.2.0] — 2026-06-02
 
 ### Added

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smith-horn/enterprise",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Enterprise features for Skillsmith including audit logging, SSO, and RBAC",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-    "@skillsmith/core": "^0.8.0",
+    "@skillsmith/core": "^0.8.1",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "*",
+    "@skillsmith/mcp-server": "^0.5.4",
     "@smithy/config-resolver": "4.4.13",
     "@smithy/core": "3.23.12",
     "@smithy/middleware-endpoint": "4.4.27",
@@ -62,7 +62,7 @@
     "vitest": "4.1.6"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "*"
+    "@skillsmith/mcp-server": "^0.5.4"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.5.4
+
+- **Fix**: make audit Check 25 spread-aware for MCP tool count (SMI-5216) (#1402)
+- **Feature**: reconcile live API contract + register 3 audit tools (SMI-5213) (#1395)
+- **Fix**: use npx -p flag to reliably resolve skillsmith-mcp binary (SMI-5208) (#1388)
+
 ## v0.5.3
 
 - **Refactor**: SMI-5036 split oversized billing test files (#1282)

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.8.0",
+    "@skillsmith/core": "^0.8.1",
     "esbuild": "0.27.2",
     "ulid": "3.0.1"
   },

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.5.3",
+  "version": "0.5.4",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -92,7 +92,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.5.3'
+const PACKAGE_VERSION = '0.5.4'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## v0.2.5
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.2.4).
+
 ## v0.2.4
 
 - Version bump

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Discover and install agent skills directly in VS Code",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
Automated weekly release cadence PR opened by `release-cadence.yml` (SMI-4191).

## What this PR does

Runs `scripts/prepare-release.ts --all=patch` to bump all packages by one patch version and drain per-package CHANGELOG `[Unreleased]` sections into the new versions.

## What to check before merging

1. The bumped versions match what you want to ship (patch/minor/major). If minor or major is needed, close this PR, run `prepare-release.ts` with the right flags locally, and open a manual PR.
2. The CHANGELOG entries read cleanly and reference the right Linear issues.
3. CI is green.

## After merging

Trigger publish: `gh workflow run publish.yml -f dry_run=false`. The `create-gh-release` job will create matching GitHub Releases automatically.

Parent: SMI-4144. See [ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md).