### PR TITLE
ci(website): prebuilt Vercel deploys + PR previews (SMI-5246 Phase 1)

### DIFF
--- a/.github/workflows/website-deploy-staging.yml
+++ b/.github/workflows/website-deploy-staging.yml
@@ -345,6 +345,7 @@ jobs:
       # Must be a PAT (VERCEL_DEPLOY_HOOK_TOKEN) with Actions:read-write -- the
       # default GITHUB_TOKEN will not re-trigger smoke-prod.yml (recursion guard).
       - name: Re-fire post-deploy smoke dispatch
+        id: smoke_dispatch
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.VERCEL_DEPLOY_HOOK_TOKEN }}
@@ -352,6 +353,14 @@ jobs:
           gh api repos/${{ github.repository }}/dispatches \
             -f event_type=vercel-prod-deployed \
             -f 'client_payload[sha]=${{ github.sha }}'
+
+      # Surface a failed dispatch (e.g. missing/expired PAT) without failing the
+      # already-successful production deploy. smoke-prod.yml can still be run via
+      # workflow_dispatch if this annotation appears.
+      - name: Warn if smoke dispatch failed
+        if: steps.smoke_dispatch.outcome == 'failure'
+        run: |
+          echo "::warning::Failed to re-fire vercel-prod-deployed dispatch; smoke-prod.yml did not auto-run. Check VERCEL_DEPLOY_HOOK_TOKEN, then trigger smoke-prod.yml manually."
 
       - name: Generate deployment summary
         run: |

--- a/.github/workflows/website-deploy-staging.yml
+++ b/.github/workflows/website-deploy-staging.yml
@@ -58,12 +58,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE_VERSION }}-
 
+      - name: Cache Vercel build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.vercel/cache
+          key: vercel-cache-${{ runner.os }}-${{ hashFiles('packages/website/**/*.ts', 'packages/website/**/*.tsx', 'packages/website/**/*.astro', 'packages/website/**/*.mjs', 'packages/website/**/*.json', 'packages/website/vercel.json') }}
+          restore-keys: |
+            vercel-cache-${{ runner.os }}-
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
-
-      - name: Build website
-        working-directory: packages/website
-        run: npm run build
 
       - name: Install Vercel CLI (pinned to root devDep)
         run: |
@@ -72,7 +76,18 @@ jobs:
           npm i -g "vercel@$PINNED"
           vercel --version
 
-      - name: Deploy to Vercel (Staging)
+      - name: Vercel pull + build (preview, prebuilt)
+        working-directory: packages/website
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -eu
+          vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
+          vercel build --token "$VERCEL_TOKEN"
+
+      - name: Deploy prebuilt to Vercel (Staging)
         id: deploy
         working-directory: packages/website
         env:
@@ -80,9 +95,9 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
-          # Deploy to staging (no --prod flag)
+          # Deploy the prebuilt Build Output (no cloud rebuild)
           # Redirect stderr to stdout, then filter for URL only to avoid leaking logs
-          DEPLOYMENT_URL=$(vercel deploy --yes --token="$VERCEL_TOKEN" 2>/dev/null | grep -E '^https://' | tail -1)
+          DEPLOYMENT_URL=$(vercel deploy --prebuilt --yes --token="$VERCEL_TOKEN" 2>/dev/null | grep -E '^https://' | tail -1)
 
           if [ -z "$DEPLOYMENT_URL" ]; then
             echo "::error::Failed to capture deployment URL. Check Vercel configuration."
@@ -275,12 +290,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE_VERSION }}-
 
+      - name: Cache Vercel build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.vercel/cache
+          key: vercel-cache-${{ runner.os }}-${{ hashFiles('packages/website/**/*.ts', 'packages/website/**/*.tsx', 'packages/website/**/*.astro', 'packages/website/**/*.mjs', 'packages/website/**/*.json', 'packages/website/vercel.json') }}
+          restore-keys: |
+            vercel-cache-${{ runner.os }}-
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
-
-      - name: Build website
-        working-directory: packages/website
-        run: npm run build
 
       - name: Install Vercel CLI (pinned to root devDep)
         run: |
@@ -289,7 +308,18 @@ jobs:
           npm i -g "vercel@$PINNED"
           vercel --version
 
-      - name: Deploy to Vercel (Production)
+      - name: Vercel pull + build (production, prebuilt)
+        working-directory: packages/website
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -eu
+          vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
+          vercel build --prod --token "$VERCEL_TOKEN"
+
+      - name: Deploy prebuilt to Vercel (Production)
         id: deploy
         working-directory: packages/website
         env:
@@ -297,9 +327,9 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
-          # Deploy to production (with --prod flag)
+          # Deploy the prebuilt Build Output to production (no cloud rebuild)
           # Redirect stderr to stdout, then filter for URL only to avoid leaking logs
-          DEPLOYMENT_URL=$(vercel deploy --prod --yes --token="$VERCEL_TOKEN" 2>/dev/null | grep -E '^https://' | tail -1)
+          DEPLOYMENT_URL=$(vercel deploy --prebuilt --prod --yes --token="$VERCEL_TOKEN" 2>/dev/null | grep -E '^https://' | tail -1)
 
           if [ -z "$DEPLOYMENT_URL" ]; then
             echo "::error::Failed to capture deployment URL. Check Vercel configuration."
@@ -308,6 +338,20 @@ jobs:
 
           echo "deployment-url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
           echo "Deployed to production: $DEPLOYMENT_URL"
+
+      # Re-fire the repository_dispatch that smoke-prod.yml listens for. Once
+      # native git integration is disconnected (Phase 2), Vercel stops emitting
+      # the deploy webhook, so this CLI-deploy path must fire it itself.
+      # Must be a PAT (VERCEL_DEPLOY_HOOK_TOKEN) with Actions:read-write -- the
+      # default GITHUB_TOKEN will not re-trigger smoke-prod.yml (recursion guard).
+      - name: Re-fire post-deploy smoke dispatch
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.VERCEL_DEPLOY_HOOK_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/dispatches \
+            -f event_type=vercel-prod-deployed \
+            -f 'client_payload[sha]=${{ github.sha }}'
 
       - name: Generate deployment summary
         run: |

--- a/.github/workflows/website-preview-pr.yml
+++ b/.github/workflows/website-preview-pr.yml
@@ -1,0 +1,138 @@
+name: Website Preview (PR)
+
+# Replaces the automatic per-PR preview deploys that Vercel git integration
+# provided before Phase 2 disconnected native git integration (SMI-5246).
+# Runs a prebuilt deploy on every push to a PR so UAT always has a fresh URL.
+# Full rationale: docs/internal/implementation/smi-5246-vercel-prebuilt-deploy.md
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'packages/website/**'
+
+concurrency:
+  group: website-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '22'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Deploy Preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Fork PRs do not have access to VERCEL_TOKEN -- skip cleanly rather than fail.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Cache npm dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.NODE_VERSION }}-
+
+      - name: Cache Vercel build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.vercel/cache
+          key: vercel-cache-${{ runner.os }}-${{ hashFiles('packages/website/**/*.ts', 'packages/website/**/*.tsx', 'packages/website/**/*.astro', 'packages/website/**/*.mjs', 'packages/website/**/*.json', 'packages/website/vercel.json') }}
+          restore-keys: |
+            vercel-cache-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Vercel CLI (pinned to root devDep)
+        run: |
+          PINNED=$(node -p "require('./package.json').devDependencies.vercel")
+          echo "Installing vercel@$PINNED (pinned from root package.json)"
+          npm i -g "vercel@$PINNED"
+          vercel --version
+
+      - name: Deploy preview (prebuilt)
+        id: deploy
+        working-directory: packages/website
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -eu
+          vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
+          vercel build --token "$VERCEL_TOKEN"
+          URL=$(vercel deploy --prebuilt --yes --token "$VERCEL_TOKEN" 2>/dev/null | grep -E '^https://' | tail -1)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL on PR
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const MARKER = '<!-- website-preview -->';
+            const previewUrl = '${{ steps.deploy.outputs.url }}';
+            const sha = '${{ github.event.pull_request.head.sha }}';
+            const shortSha = sha.slice(0, 7);
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+
+            let body;
+            if (previewUrl) {
+              body = [
+                MARKER,
+                '### Website Preview',
+                '',
+                `| | |`,
+                `|---|---|`,
+                `| **Preview URL** | ${previewUrl} |`,
+                `| **Commit** | \`${shortSha}\` |`,
+                `| **Actions run** | [View logs](${runUrl}) |`,
+              ].join('\n');
+            } else {
+              body = [
+                MARKER,
+                '### Website Preview',
+                '',
+                '**Deploy failed.** No preview URL was captured.',
+                '',
+                `[View logs](${runUrl}) for details.`,
+              ].join('\n');
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## What & why

The `website` Vercel project (www.skillsmith.app) is ~95% of the Vercel bill (~\$272/mo) — almost all "Build CPU Minutes." Both deploy jobs in `website-deploy-staging.yml` run `vercel deploy` **without** `--prebuilt`, so Vercel rebuilds in the cloud (metered) after the runner already built. This PR (Phase 1) converts them to ship the prebuilt Build Output instead.

Closes part of SMI-5246. Full plan: `docs/internal/implementation/smi-5246-vercel-prebuilt-deploy.md`.

## Changes

- **`website-deploy-staging.yml`** — both deploy jobs now `vercel pull` + `vercel build` + `vercel deploy --prebuilt` (staging `--environment=preview`; production `--prod`). Dropped the redundant `npm run build` (`vercel build` runs it), added a `~/.vercel/cache` step. After the prod deploy, re-fire the `vercel-prod-deployed` `repository_dispatch` (continue-on-error, via the existing `VERCEL_DEPLOY_HOOK_TOKEN` PAT) so `smoke-prod.yml` keeps firing once native git is disconnected in Phase 2.
- **`website-preview-pr.yml`** (new) — prebuilt PR previews (synchronize-triggered, sticky comment with built SHA, fork-gated, `pull-requests: write`) to replace native-git previews removed in Phase 2.

## Safety / sequencing

- **Native git integration stays connected in this PR.** The prebuilt CLI deploy runs in parallel with the existing git deploy, so a problem can't freeze prod. Phase 2 (`git.deploymentEnabled: false` + dashboard Disconnect) is a **separate PR**, gated on a real prod prebuilt deploy promoting the `www` alias.
- The `deployment-url` output name is unchanged, so Lighthouse/link-check/smoke jobs are unaffected.

## Process

- ADR-109 infra change: SPARC + plan-review complete (VP Product/Eng/Design); findings folded into the plan doc. `/governance` review clean.
- Validated: YAML parse, ASCII-only, no `pipefail` on URL capture, PAT (not GITHUB_TOKEN) on the dispatch.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)