### PR TITLE
ci(website): disable native git deploys — Vercel sever (SMI-5246 Phase 2)

### DIFF
--- a/.github/workflows/website-deploy-staging.yml
+++ b/.github/workflows/website-deploy-staging.yml
@@ -342,13 +342,13 @@ jobs:
       # Re-fire the repository_dispatch that smoke-prod.yml listens for. Once
       # native git integration is disconnected (Phase 2), Vercel stops emitting
       # the deploy webhook, so this CLI-deploy path must fire it itself.
-      # Must be a PAT (VERCEL_DEPLOY_HOOK_TOKEN) with Actions:read-write -- the
-      # default GITHUB_TOKEN will not re-trigger smoke-prod.yml (recursion guard).
+      # Must be a real PAT (GH_PAT) -- the default GITHUB_TOKEN will not
+      # re-trigger smoke-prod.yml (GitHub's workflow-recursion guard).
       - name: Re-fire post-deploy smoke dispatch
         id: smoke_dispatch
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.VERCEL_DEPLOY_HOOK_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           gh api repos/${{ github.repository }}/dispatches \
             -f event_type=vercel-prod-deployed \
@@ -360,7 +360,7 @@ jobs:
       - name: Warn if smoke dispatch failed
         if: steps.smoke_dispatch.outcome == 'failure'
         run: |
-          echo "::warning::Failed to re-fire vercel-prod-deployed dispatch; smoke-prod.yml did not auto-run. Check VERCEL_DEPLOY_HOOK_TOKEN, then trigger smoke-prod.yml manually."
+          echo "::warning::Failed to re-fire vercel-prod-deployed dispatch; smoke-prod.yml did not auto-run. Check the GH_PAT secret, then trigger smoke-prod.yml manually."
 
       - name: Generate deployment summary
         run: |

--- a/packages/website/vercel.json
+++ b/packages/website/vercel.json
@@ -3,6 +3,11 @@
   "framework": "astro",
   "installCommand": "npm install",
   "buildCommand": "npm run build",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  },
   "redirects": [
     {
       "source": "/changelog",


### PR DESCRIPTION
## ⛔ DO NOT MERGE until the Phase-1 dry-run proves the prebuilt prod path promotes the `www.skillsmith.app` alias.

Merging this disables native git production deploys on the `website` Vercel project. If the prebuilt CLI deploy (Phase 1, already on main) hasn't been confirmed to promote `www`, production stops receiving updates (it keeps serving the last git deploy — a silent freeze, not an outage). Phase 2 of SMI-5246.

## Change
- `packages/website/vercel.json` — add `git.deploymentEnabled.main: false`. The website project's git integration stops cloud-rebuilding on pushes to main; prebuilt CI (`website-deploy-staging.yml`) becomes the sole prod deploy path → metered Build CPU → ~\$0.
- The `git` key is **only** in the website config (not root `vercel.json`); it's outside the audit §39 shared-field parity set, so parity stays green (verified locally: Check 39 ✓, Failed: 0).

## Required human step at merge time (Claude cannot reach the dashboard)
Vercel → project **website** → Settings → Git → **Disconnect** the repo (or `vercel git disconnect --yes` from `packages/website`). Order: verify CLI deploy works *while connected* → merge this → Disconnect → verify CLI-only still serves.

**Verification gate after Disconnect:** push a trivial website commit; confirm **no** Vercel cloud build appears in the dashboard log AND the GHA prod deploy serves the new SHA. Also resolve the root `skillsmith` project per the plan's Pre-work §2 (disconnect if it's a live second cost source).

## Rollback
If prod misbehaves, re-run `website-deploy-staging.yml` at the prior good SHA (CLI deploy history is the rollback path now that git instant-rollback is gone). To fully revert: reconnect git in the dashboard + revert this PR.

Plan: `docs/internal/implementation/smi-5246-vercel-prebuilt-deploy.md`. Builds on Phase 1 (#1408).

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)