### PR TITLE
test(mcp-server): harden recommend dedup test via deterministic online path (SMI-5253)

### DIFF
--- a/packages/mcp-server/src/__tests__/recommend.test.ts
+++ b/packages/mcp-server/src/__tests__/recommend.test.ts
@@ -7,7 +7,12 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi, beforeEach, afterEach } from 'vitest'
-import { executeRecommend, formatRecommendations } from '../tools/recommend.js'
+import {
+  executeRecommend,
+  formatRecommendations,
+  mergeAndDeduplicateRecommendations,
+  type SkillRecommendation,
+} from '../tools/recommend.js'
 import { createSeededTestContext, disposeTestContext, type ToolContext } from './test-utils.js'
 import * as LocalSkillSearchModule from '../tools/LocalSkillSearch.js'
 import type { LocalSkill } from '../indexer/LocalIndexer.js'
@@ -287,8 +292,31 @@ describe('Recommend Tool - Local Skill Integration (SMI-1837)', () => {
 
   describe('deduplication logic', () => {
     it('should prefer registry skills over local skills with same name', async () => {
-      expect.hasAssertions()
-      // Create a local skill with same name as registry skill
+      // SMI-5253: Route through the ONLINE path so the registry result set is deterministic.
+      // The offline path ranks DB candidates through SkillMatcher's mock-embedding similarity,
+      // whose ordering is environment-dependent — that nondeterminism previously left this
+      // assertion ungated (the sole expect() sat behind two `if` guards + expect.hasAssertions(),
+      // which failed whenever no 'commit' skill survived ranking). The online path merges
+      // apiClient.getRecommendations() with local results via mergeAndDeduplicateRecommendations
+      // (no matcher, no embeddings, no DB ordering). NOTE: the seeded DB rows are unused on this
+      // path — the registry 'commit' comes from the getRecommendations mock below, not the seed.
+      vi.spyOn(branchContext.apiClient, 'isOffline').mockReturnValue(false)
+      vi.spyOn(branchContext.apiClient, 'getRecommendations').mockResolvedValue({
+        data: [
+          {
+            id: 'anthropic/commit',
+            name: 'commit',
+            description: 'Generate semantic commit messages',
+            author: 'anthropic',
+            tags: ['git', 'commit'],
+            trust_tier: 'verified',
+            quality_score: 0.95,
+          },
+        ],
+        meta: { total: 1 },
+      })
+
+      // Local indexer returns a same-name duplicate of the registry skill
       const duplicateMockSkills: LocalSkill[] = [
         {
           id: 'local/commit',
@@ -317,31 +345,59 @@ describe('Recommend Tool - Local Skill Integration (SMI-1837)', () => {
         // Partial mock — only methods called by executeRecommend are implemented
       } as unknown as ReturnType<typeof LocalSkillSearchModule.getLocalIndexer>)
 
+      // installed_skills is passed explicitly so autoDetected=false and getInstalledSkills()
+      // (which reads the real ~/.claude/skills/) is never called — closing the last host-coupling
+      // vector. 'anthropic/review-pr' collides with neither target id, so the installed-skill
+      // filter (recommend.ts) is a no-op.
       const result = await executeRecommend(
         {
           project_context: 'git workflow',
+          installed_skills: ['anthropic/review-pr'],
           limit: 10,
         },
         branchContext
       )
 
-      // Should not have both 'anthropic/commit' and 'local/commit'
-      const commitSkills = result.recommendations.filter(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (r: any) => r.name === 'commit' || r.skill_id.includes('commit')
-      )
+      // Registry skill wins; the same-name local duplicate is deduped out — assert unconditionally.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const ids = result.recommendations.map((r: any) => r.skill_id)
+      expect(ids).toContain('anthropic/commit')
+      expect(ids).not.toContain('local/commit')
+    })
 
-      // If there's a commit skill, registry should take precedence
-      if (commitSkills.length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const hasRegistryCommit = commitSkills.some((s: any) => s.skill_id === 'anthropic/commit')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const hasLocalCommit = commitSkills.some((s: any) => s.skill_id === 'local/commit')
-        // Should not have local duplicate if registry version exists
-        if (hasRegistryCommit) {
-          expect(hasLocalCommit).toBe(false)
-        }
-      }
+    it('mergeAndDeduplicateRecommendations drops same-name local skill in favor of registry', () => {
+      // SMI-5253: Deterministic unit coverage for the same-name dedup invariant on the merge
+      // logic that BOTH the online and offline executeRecommend paths share. No context, DB, or
+      // embeddings — zero flake surface.
+      const apiResults: SkillRecommendation[] = [
+        {
+          skill_id: 'anthropic/commit',
+          name: 'commit',
+          reason: 'registry match',
+          similarity_score: 0.8,
+          trust_tier: 'verified',
+          quality_score: 95,
+          roles: [],
+        },
+      ]
+      const localResults: SkillRecommendation[] = [
+        {
+          skill_id: 'local/commit',
+          name: 'commit',
+          reason: 'local match',
+          similarity_score: 0.7,
+          trust_tier: 'local',
+          quality_score: 60,
+          roles: [],
+        },
+      ]
+
+      const merged = mergeAndDeduplicateRecommendations(apiResults, localResults, 10)
+      const ids = merged.map((r) => r.skill_id)
+
+      expect(ids).toContain('anthropic/commit')
+      expect(ids).not.toContain('local/commit') // same-name local filtered
+      expect(merged[0].skill_id).toBe('anthropic/commit') // registry ordered first
     })
   })
 


### PR DESCRIPTION
## Summary

Hardens the flaky `recommend.test.ts` › `deduplication logic` › **"should prefer registry skills over local skills with same name"** test (SMI-5253). Its sole assertion was nested behind two `if` guards plus `expect.hasAssertions()`, so it failed with *"expected any number of assertion, but got none"* whenever the **offline** `SkillMatcher` mock-embedding ranking didn't surface a `commit` skill for the `'git workflow'` query — environment-coupled (DB `ORDER BY updated_at` + embedding math), failing locally while green in CI. It blocked pre-push during SMI-5249 (PR #1414 went out with `--no-verify`).

## What changed (test-only — no production code)

`packages/mcp-server/src/__tests__/recommend.test.ts`:
- **Rewrote the test onto the deterministic ONLINE path**: mock `apiClient.isOffline()` → `false` and `apiClient.getRecommendations()` → `anthropic/commit`. The online path merges registry + local results via `mergeAndDeduplicateRecommendations` with **no matcher, no embeddings, no DB ordering**, then asserts registry-wins **unconditionally**. Reuses the established pattern from `recommend-online-path.test.ts`.
- **Passed explicit `installed_skills`** so `autoDetected=false` and `getInstalledSkills()` never reads the real `~/.claude/skills/` (closes the last host-filesystem coupling vector — plan-review High finding).
- **Added a direct unit test of `mergeAndDeduplicateRecommendations`** (pure function, zero flake surface) to retain same-name dedup coverage for the merge logic the **offline** path also uses (plan-review Medium finding — coverage backfill).

## Verification
- `recommend.test.ts`: 12/12 pass deterministically (both target tests green).
- Typecheck ✓, lint ✓ (0 problems), `audit:standards` 97% (0 failures), full root-colocated suite green except a pre-existing, unrelated item (below).
- Pre-push passed all phases without bypass.
- Plan-review (VP Product/Eng/Design) ran pre-implementation; all findings folded in. Governance on the commit: **no findings**.

## Out of scope (pre-existing, not caused by this change)
`packages/mcp-server/tests/integration/install.integration.test.ts` (UUID-install path) fails **locally** in `npm test` but is **GREEN in CI on `main`** (`Test (root colocated)` / `Test (mcp-server)` for HEAD `e4b323ab`) and fails independently of this change (different file, fails in isolation). It's a local container-state / in-file-ordering artifact and is **not** in pre-push or this PR's scope.

Linear: SMI-5253

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
