### PR TITLE
fix(test): repair install.integration UUID mock seam + un-break integration config (SMI-5261)

### DIFF
--- a/packages/mcp-server/tests/integration/install.integration.test.ts
+++ b/packages/mcp-server/tests/integration/install.integration.test.ts
@@ -27,13 +27,35 @@ vi.mock('../../src/tools/install.helpers.js', async (importActual) => {
   }
 })
 
-// SMI-3483: Core service now owns fetchFromGitHub — mock it there too so
-// SkillInstallationService uses the test double instead of real GitHub fetch.
-vi.mock('@skillsmith/core/services/skill-installation-helpers', async (importActual) => {
+// SMI-5260: SkillInstallationService imports `fetchFromGitHub` +
+// `fetchOptionalInstallFiles` DIRECTLY from `skill-installation.io` — NOT from the
+// `-helpers` re-export the prior mock targeted (which is why the UUID install test
+// silently 404'd against the real network). Mock the `.io` module so the service
+// uses the test doubles. `fetchOptionalInstallFiles` must also be mocked: its
+// internal `fetchFromGitHub` call is a lexical module-local reference (not the
+// mocked export), so the un-mocked real version would still hit the network for
+// README/examples/config.json. `writeInstallFiles` is intentionally left REAL so the
+// install actually writes SKILL.md to the per-test temp skillsDir (asserted below).
+vi.mock('@skillsmith/core/services/skill-installation-io', async (importActual) => {
   const actual = await importActual<Record<string, unknown>>()
   return {
     ...actual,
     fetchFromGitHub: vi.fn(),
+    fetchOptionalInstallFiles: vi.fn(),
+  }
+})
+
+// SMI-5260: redirect the install target away from the real `~/.claude/skills`.
+// `resolveClientPath`/`getInstallPath` derive from `CLIENT_NATIVE_PATHS`, which is
+// frozen at module load (`homedir()`), so a runtime HOME swap cannot redirect them —
+// mock the resolvers and point them at the per-test temp skillsDir in beforeEach.
+// `addLink` and the rest are preserved via importActual.
+vi.mock('@skillsmith/core/install', async (importActual) => {
+  const actual = await importActual<Record<string, unknown>>()
+  return {
+    ...actual,
+    resolveClientPath: vi.fn(),
+    getInstallPath: vi.fn(),
   }
 })
 
@@ -788,6 +810,11 @@ Use this skill by mentioning it in Claude Code.
     let fetchFromGitHub: ReturnType<typeof vi.fn>
 
     let coreFetchFromGitHub: ReturnType<typeof vi.fn>
+    // SMI-5260: core `.io` optional-files double + the install-path resolvers,
+    // redirected per-test to the temp skillsDir.
+    let coreFetchOptionalInstallFiles: ReturnType<typeof vi.fn>
+    let resolveClientPath: ReturnType<typeof vi.fn>
+    let getInstallPath: ReturnType<typeof vi.fn>
 
     beforeAll(async () => {
       // Dynamic import after vi.mock() has been hoisted — module is already mocked
@@ -801,15 +828,35 @@ Use this skill by mentioning it in Claude Code.
       lookupSkillFromRegistry = vi.mocked(helpersModule.lookupSkillFromRegistry)
       fetchFromGitHub = vi.mocked(helpersModule.fetchFromGitHub)
 
-      // SMI-3483: Core service owns fetchFromGitHub — get its mock handle too
-      const coreHelpersModule = await import('@skillsmith/core/services/skill-installation-helpers')
+      // SMI-5260: core service fetches via `skill-installation.io` — grab the
+      // GitHub-fetch and optional-files mock handles from there. Also grab the
+      // install-path resolvers so each test can redirect writes to its temp dir.
+      const coreIoModule = await import('@skillsmith/core/services/skill-installation-io')
       coreFetchFromGitHub = vi.mocked(
-        coreHelpersModule.fetchFromGitHub as (...args: unknown[]) => unknown
+        coreIoModule.fetchFromGitHub as (...args: unknown[]) => unknown
+      )
+      coreFetchOptionalInstallFiles = vi.mocked(
+        coreIoModule.fetchOptionalInstallFiles as (...args: unknown[]) => unknown
+      )
+      const coreInstallModule = await import('@skillsmith/core/install')
+      resolveClientPath = vi.mocked(
+        coreInstallModule.resolveClientPath as (...args: unknown[]) => unknown
+      )
+      getInstallPath = vi.mocked(
+        coreInstallModule.getInstallPath as (...args: unknown[]) => unknown
       )
     })
 
     beforeEach(() => {
       vi.clearAllMocks()
+      // SMI-5260: redirect every install in this block to the per-test temp
+      // skillsDir (created by the outer describe's beforeEach) so writes never
+      // touch the real ~/.claude/skills. Optional-files fetch is a no-op by
+      // default so the suite stays fully offline; the happy-path test sets the
+      // SKILL.md fetch return explicitly.
+      resolveClientPath.mockReturnValue(fsContext.skillsDir)
+      getInstallPath.mockReturnValue(fsContext.skillsDir)
+      coreFetchOptionalInstallFiles.mockResolvedValue([])
     })
 
     it('UUID with valid repo_url resolves and installs the skill', async () => {
@@ -820,7 +867,7 @@ Use this skill by mentioning it in Claude Code.
         trustTier: 'community',
         quarantined: false,
       })
-      // SKILL.md fetch succeeds (mock both mcp-server and core paths)
+      // SKILL.md fetch succeeds (mock both the mcp-server seam and the core .io seam)
       fetchFromGitHub.mockResolvedValue(VALID_SKILL_MD)
       coreFetchFromGitHub.mockResolvedValue(VALID_SKILL_MD)
 
@@ -831,6 +878,13 @@ Use this skill by mentioning it in Claude Code.
       expect(result.success).toBe(true)
       expect(result.skillId).toBe(TEST_UUID)
       expect(lookupSkillFromRegistry).toHaveBeenCalledWith(TEST_UUID, expect.anything())
+      // SMI-5260 anti-false-green guards: the core .io fetch double was actually
+      // exercised (proving the mock intercepts the service's direct import, not a
+      // real network fetch), and the install wrote SKILL.md into the temp skillsDir.
+      // A regression back to a real-fetch / real-path install fails loudly here.
+      expect(coreFetchFromGitHub).toHaveBeenCalled()
+      expect(result.installPath.startsWith(fsContext.skillsDir)).toBe(true)
+      expect(await fileExists(path.join(result.installPath, 'SKILL.md'))).toBe(true)
     })
 
     it('UUID with null registry result returns "indexed for discovery only" error', async () => {

--- a/packages/mcp-server/vitest.config.integration.ts
+++ b/packages/mcp-server/vitest.config.integration.ts
@@ -3,25 +3,29 @@
  */
 
 import { defineConfig } from 'vitest/config'
-import { resolve } from 'path'
 import { sharedTestConfig } from '../../vitest.preset'
 
+// SMI-5260: no `resolve.alias` for `@skillsmith/core`. The alias pointed at
+// `../core/src/index.ts`, which (a) broke collection (`npm run test:integration`
+// errored treating the `.ts` as a directory) and (b) split the service and its
+// mocked `.io`/install subpaths into two module instances, so `vi.mock` never
+// intercepted the service's direct imports. Core resolves through
+// `node_modules/@skillsmith/core` → built dist, the same instance the service
+// loads, so subpath mocks intercept correctly. Mirrors the working unit
+// `vitest.config.ts`, which has no such alias.
 export default defineConfig({
-  resolve: {
-    alias: {
-      '@skillsmith/core': resolve(__dirname, '../core/src/index.ts'),
-    },
-  },
   test: {
     ...sharedTestConfig,
     include: ['tests/integration/**/*.integration.test.ts'],
     testTimeout: 30000, // 30s timeout for integration tests (overrides preset 15s)
     hookTimeout: 30000, // 30s timeout for setup/teardown
     pool: 'forks', // Use forks for better isolation
-    poolOptions: {
-      forks: {
-        singleFork: true, // Run tests sequentially to avoid DB conflicts
-      },
-    },
+    // SMI-5260: Vitest 4 removed `test.poolOptions`. `maxWorkers: 1` is the
+    // migration analog of the prior `poolOptions.forks.singleFork: true` — a
+    // single fork runs the suite sequentially, avoiding the in-memory-DB
+    // conflicts these integration tests rely on. (Under Vitest 4 the old
+    // `singleFork` key was silently ignored, so this restores the intended
+    // serialization, not just clears the deprecation warning.)
+    maxWorkers: 1,
   },
 })

--- a/scripts/check-file-length.ignore
+++ b/scripts/check-file-length.ignore
@@ -29,3 +29,7 @@
 
 # SMI-5211 split follow-up
 packages/core/tests/RawUrlSourceAdapter.security.test.ts
+
+# SMI-5263 split follow-up (pre-existing over-limit; grew during the SMI-5261
+# mock-seam fix — split into 3 concern-scoped siblings tracked in SMI-5263)
+packages/mcp-server/tests/integration/install.integration.test.ts


### PR DESCRIPTION
## Summary

Wave 1 of SMI-5260 (app/test). Fixes the deterministically-failing `install.integration.test.ts` UUID-install test and un-breaks the whole `mcp-server` integration suite.

**Root cause (confirmed, not flaky):** the test mocked `@skillsmith/core/services/skill-installation-helpers` — a module that only *re-exports* `fetchFromGitHub` — but `SkillInstallationService` imports `fetchFromGitHub` **directly** from `./skill-installation.io.js`. The mock never intercepted, so the real fetch of the fake `owner/test-skill` 404'd → `success:false`. A `resolve.alias` in the integration config compounded it: it broke `npm run test:integration` collection (the "0-test" files) and would split service-vs-mock into two module instances.

## Changes

- **`vitest.config.integration.ts`**: delete the `resolve.alias` block so `@skillsmith/core` resolves through `node_modules` → built **dist** (the same instance the service loads), making subpath mocks interceptable. Migrate the Vitest-4-removed `poolOptions.forks.singleFork` to `maxWorkers: 1` (the old key was silently ignored under Vitest 4 — this restores the intended sequential execution and clears the deprecation warning).
- **`install.integration.test.ts`**: mock `@skillsmith/core/services/skill-installation-io` (`fetchFromGitHub` + `fetchOptionalInstallFiles` — the latter makes real network calls via its lexical `fetchFromGitHub`) and `@skillsmith/core/install` (`resolveClientPath`/`getInstallPath` → per-test temp `skillsDir`, since those paths are frozen at module load and can't be redirected by a HOME swap). `writeInstallFiles` is kept **real** so the install actually writes. Permanent anti-false-green assertions: `coreFetchFromGitHub` was called, `result.installPath` is under the temp dir, and `SKILL.md` was written.
- **`scripts/check-file-length.ignore`**: grandfather `install.integration.test.ts` (pre-existing 894-line over-limit file; grew to 949 here) with split follow-up **SMI-5263**.

## Test results

```
docker exec skillsmith-dev-1 npm run test:integration -w packages/mcp-server
Test Files  10 passed (10)
     Tests  174 passed | 6 skipped (180)
```

`github-api.integration.test.ts` self-skips its 6 network tests via `GITHUB_API_TESTS` (default-skip). Full offline run — no `GITHUB_*` env set. Typecheck, eslint (`--max-warnings=0`), prettier, and `audit:standards` (77 pass / 0 fail) all green.

## Notes

- **No production source changed** — test + package-local config + hook ignore-list only. Not an ADR-109 infra change (package-local test config; plan-reviewed).
- The mcp-server integration suite still runs in **no CI job** — that gap is closed in Wave 2 (**SMI-5262**, ADR-109 infra), which depends on this PR.
- Residual: the now-active happy-path install writes a manifest to the container's ephemeral `~/.skillsmith` (no mock seam without a production change); the load-bearing target (skillsDir) is isolated. Noted on SMI-5263.

Closes SMI-5261. Part of SMI-5260.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
