### PR TITLE
feat(governance): structural out-of-scope tier in drift audit (SMI-5275 Track 2)

### DIFF
--- a/.github/workflows/linear-drift-audit.yml
+++ b/.github/workflows/linear-drift-audit.yml
@@ -55,8 +55,10 @@ jobs:
           fi
           DRIFT_COUNT=$(jq -r '.drift | length' /tmp/drift-results.json)
           MENTION_COUNT=$(jq -r '.mentionOnly | length' /tmp/drift-results.json 2>/dev/null || echo "0")
+          OOS_COUNT=$(jq -r '.outOfScope | length' /tmp/drift-results.json 2>/dev/null || echo "0")
           echo "drift_count=$DRIFT_COUNT" >> $GITHUB_OUTPUT
           echo "mention_count=$MENTION_COUNT" >> $GITHUB_OUTPUT
+          echo "oos_count=$OOS_COUNT" >> $GITHUB_OUTPUT
 
       - name: Ensure governance label exists
         if: steps.check.outputs.drift_count != '0'
@@ -72,19 +74,33 @@ jobs:
         run: |
           DRIFT_COUNT=${{ steps.check.outputs.drift_count }}
           MENTION_COUNT=${{ steps.check.outputs.mention_count }}
+          OOS_COUNT=${{ steps.check.outputs.oos_count }}
           DATE=$(date -u +%Y-%m-%d)
 
           # Build issue body
-          BODY="## Linear Drift Audit — $DATE
+          BODY="## Linear Drift Audit - $DATE
 
           **$DRIFT_COUNT issue(s)** marked Done without any source code commits.
           **$MENTION_COUNT issue(s)** have commits but no source glob match (informational).
+          **$OOS_COUNT issue(s)** structurally excluded (external initiative/curriculum - no allowlist entry needed).
 
           ### Drift Details
           "
 
           # Append each drifted issue with reason
           BODY+=$(jq -r '.drift[] | "- **\(.id)**: \(.title) (reason: \(.reason))"' /tmp/drift-results.json)
+
+          # Best-effort: list the structurally-excluded set so a maintainer can
+          # audit WHAT was excluded (canonical surface is the step summary).
+          if [ "$OOS_COUNT" != "0" ]; then
+            OOS_LIST=$(jq -r '.outOfScope[] | "- **\(.id)**: \(.title) (\(.reason))"' /tmp/drift-results.json)
+            BODY+="
+
+          <details><summary>Out-of-scope ($OOS_COUNT auto-excluded)</summary>
+
+          $OOS_LIST
+          </details>"
+          fi
 
           BODY+="
 
@@ -122,13 +138,24 @@ jobs:
             MENTION=$(jq -r '.mentionOnly | length' /tmp/drift-results.json 2>/dev/null || echo "0")
             DRIFT=$(jq -r '.drift | length' /tmp/drift-results.json 2>/dev/null || echo "?")
             ALLOWLISTED=$(jq -r '.allowlisted' /tmp/drift-results.json 2>/dev/null || echo "?")
+            OOS=$(jq -r '.outOfScope | length' /tmp/drift-results.json 2>/dev/null || echo "0")
             echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
             echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
             echo "| Total completed | $TOTAL |" >> $GITHUB_STEP_SUMMARY
             echo "| Verified | $VERIFIED |" >> $GITHUB_STEP_SUMMARY
             echo "| Mention-only | $MENTION |" >> $GITHUB_STEP_SUMMARY
             echo "| Allowlisted | $ALLOWLISTED |" >> $GITHUB_STEP_SUMMARY
+            echo "| Out-of-scope | $OOS |" >> $GITHUB_STEP_SUMMARY
             echo "| **Drift** | **$DRIFT** |" >> $GITHUB_STEP_SUMMARY
+            # Canonical (always-rendered) out-of-scope audit trail: id + title + reason.
+            if [ "$OOS" != "0" ]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "<details><summary>Out-of-scope ($OOS auto-excluded: external initiative/curriculum)</summary>" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              jq -r '.outOfScope[] | "- \(.id): \(.title) (\(.reason))"' /tmp/drift-results.json >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "</details>" >> $GITHUB_STEP_SUMMARY
+            fi
           else
             echo "Audit did not produce results. Check logs." >> $GITHUB_STEP_SUMMARY
           fi

--- a/scripts/audit-linear-drift.mjs
+++ b/scripts/audit-linear-drift.mjs
@@ -45,6 +45,26 @@ const SOURCE_GLOBS = [
 const RETRY_DELAYS = [1000, 2000, 4000]
 const ALLOWLIST_PATH = '.linear-drift-allowlist'
 
+// SMI-5275: Structural out-of-scope tier. The SMI Linear team spans multiple
+// initiatives; non-Skillsmith ones (021 School Platform, MiniMax Gateway, …)
+// ship their code in other repos and would always "drift" here. Classify them
+// structurally rather than via manual allowlist entries.
+//
+// SOURCE OF TRUTH: copied verbatim from scripts/triage-linear-drift.mjs
+// (SKILLSMITH_PROJECT_PATTERNS, ~lines 221-226). Keep the two in lock-step —
+// several Skillsmith projects live under names that don't start with
+// "Skillsmith", so the initiative check needs this project-name escape hatch.
+const SKILLSMITH_PROJECT_PATTERNS = [
+  /^Skillsmith/i,
+  /Dependabot Vulnerability Fixes/i,
+  /Stub-to-Real|Tier Feature Gap/i,
+  /^Backfill Infrastructure/i,
+]
+// LIVE Smith Horn Group label set — confirmed external-curriculum markers ONLY
+// (verified 2026-06-14). Do NOT add generic Docs/Content/documentation labels
+// here: those mark genuine Skillsmith repo docs and would suppress real drift.
+const EXTERNAL_CURRICULUM_LABELS = ['Track_A', 'Track_B', 'Track_C', 'Track_Z', 'Cohort_4']
+
 // --- Argument Parsing ---
 
 function parseArgs() {
@@ -121,6 +141,8 @@ async function fetchDoneIssues(since) {
           title
           completedAt
           state { name }
+          project { name initiatives { nodes { name } } }
+          labels(first: 50) { nodes { name } }
         }
         pageInfo { hasNextPage endCursor }
       }
@@ -146,8 +168,11 @@ async function fetchDoneIssues(since) {
 
     const data = await res.json()
     if (data.errors) {
-      console.error('Linear API error:', JSON.stringify(data.errors))
-      process.exit(1)
+      // Distinct from the drift `exit 1` gate: a Linear query rejection (e.g.
+      // a complexity error or schema drift) must never be mistaken for drift.
+      // exit 2 = audit could not run; exit 1 = audit ran and found drift.
+      console.error('Drift audit: Linear query failed:', JSON.stringify(data.errors))
+      process.exit(2)
     }
 
     const { nodes, pageInfo } = data.data.issues
@@ -246,6 +271,49 @@ function verifyIssue(issueId, verbose) {
   return { status: 'unverified', reason: 'no-commit-found' }
 }
 
+// --- Structural Out-of-Scope (SMI-5275) ---
+
+/**
+ * Classify an issue as structurally out-of-scope for THIS repo's drift audit.
+ *
+ * Returns `{ outOfScope: true, reason }` ONLY when:
+ *   - (primary) the issue's project has a non-empty initiatives list, NONE of
+ *     which is Skillsmith (full-list `.some()`, never nodes[0] — guards
+ *     multi-initiative issues), AND the project name matches no known
+ *     Skillsmith project pattern → reason `external-initiative:<name>`; OR
+ *   - (secondary) the issue carries an external-curriculum label (catches
+ *     orphan issues with no project/initiative) → reason
+ *     `external-curriculum-label:<label>`.
+ *
+ * Otherwise returns `{ outOfScope: false }`. FAIL SAFE: a missing/blank
+ * initiative with no curriculum label keeps the issue IN scope (it falls
+ * through to verifyIssue and can still be flagged as drift) — the heuristic
+ * never silently excludes.
+ */
+function isOutOfScope(issue) {
+  // Primary: project initiative ∉ Skillsmith AND project not a Skillsmith project.
+  const initiativeNodes = issue.project?.initiatives?.nodes
+  if (Array.isArray(initiativeNodes) && initiativeNodes.length > 0) {
+    const hasSkillsmith = initiativeNodes.some((n) => /^Skillsmith$/i.test(n?.name ?? ''))
+    const projectName = issue.project?.name ?? ''
+    const isSkillsmithProject = SKILLSMITH_PROJECT_PATTERNS.some((p) => p.test(projectName))
+    if (!hasSkillsmith && !isSkillsmithProject) {
+      // Report a representative non-Skillsmith initiative name for the reason.
+      const externalName = initiativeNodes.find((n) => n?.name)?.name ?? 'unknown'
+      return { outOfScope: true, reason: `external-initiative:${externalName}` }
+    }
+  }
+
+  // Secondary: external-curriculum label on an orphan issue (no project/initiative).
+  const labels = issue.labels?.nodes?.map((n) => n?.name).filter(Boolean) ?? []
+  const curriculumLabel = labels.find((l) => EXTERNAL_CURRICULUM_LABELS.includes(l))
+  if (curriculumLabel) {
+    return { outOfScope: true, reason: `external-curriculum-label:${curriculumLabel}` }
+  }
+
+  return { outOfScope: false }
+}
+
 // --- Main ---
 
 async function main() {
@@ -266,10 +334,20 @@ async function main() {
   const verifiedIssues = []
   const mentionOnlyIssues = []
   const allowlistedIssues = []
+  const outOfScopeIssues = []
 
   for (const issue of issues) {
     if (allowlist.has(issue.identifier)) {
       allowlistedIssues.push(issue)
+      continue
+    }
+
+    // SMI-5275: structural exclusion BEFORE verifyIssue. External-initiative /
+    // external-curriculum issues ship their code in other repos and would
+    // always drift here; exclude them from the `exit 1` gate.
+    const scope = isOutOfScope(issue)
+    if (scope.outOfScope) {
+      outOfScopeIssues.push({ ...issue, reason: scope.reason })
       continue
     }
 
@@ -303,6 +381,16 @@ async function main() {
             completedAt: i.completedAt,
             reason: i.reason,
           })),
+          // SMI-5275: out-of-scope is a per-item array (so maintainers can audit
+          // WHAT was excluded), while `allowlisted` stays a bare count. The
+          // asymmetry is intentional — do not "fix" it: the allowlist is a
+          // manual override that needs no per-item audit trail here.
+          outOfScope: outOfScopeIssues.map((i) => ({
+            id: i.identifier,
+            title: i.title,
+            completedAt: i.completedAt,
+            reason: i.reason,
+          })),
           allowlisted: allowlistedIssues.length,
         },
         null,
@@ -313,7 +401,17 @@ async function main() {
     console.log(`Verified: ${verifiedIssues.length}`)
     console.log(`Mention-only (commit exists, no source glob match): ${mentionOnlyIssues.length}`)
     console.log(`Allowlisted: ${allowlistedIssues.length}`)
+    console.log(
+      `Out-of-scope (external initiative/curriculum — auto-excluded): ${outOfScopeIssues.length}`
+    )
     console.log(`Drift detected: ${driftIssues.length}`)
+
+    if (outOfScopeIssues.length > 0) {
+      console.log('\n--- Issues structurally excluded (external initiative/curriculum) ---\n')
+      for (const issue of outOfScopeIssues) {
+        console.log(`  ${issue.identifier}: ${issue.title} (${issue.reason})`)
+      }
+    }
 
     if (mentionOnlyIssues.length > 0) {
       console.log('\n--- Issues with commits but no source glob match (informational) ---\n')
@@ -357,4 +455,5 @@ export {
   hasMergedPr,
   hasAnyGitCommit,
   verifyIssue,
+  isOutOfScope,
 }

--- a/scripts/tests/audit-linear-drift.test.ts
+++ b/scripts/tests/audit-linear-drift.test.ts
@@ -254,4 +254,110 @@ describe('SMI-3542: Linear Drift Audit', () => {
       expect(result.since).toBe('2026-03-01')
     })
   })
+
+  // SMI-5275: structural out-of-scope tier. isOutOfScope is pure (no CLI mocks),
+  // operating on the in-memory issue object returned by the GraphQL query.
+  describe('isOutOfScope', () => {
+    it('(a) flags an issue under a non-Skillsmith initiative as out-of-scope', async () => {
+      const { isOutOfScope } = await importModule()
+      const issue = {
+        identifier: 'SMI-9001',
+        project: {
+          name: 'Module 4',
+          initiatives: { nodes: [{ name: '021 School Platform' }] },
+        },
+        labels: { nodes: [] },
+      }
+      const result = isOutOfScope(issue)
+      expect(result.outOfScope).toBe(true)
+      expect(result.reason.startsWith('external-initiative')).toBe(true)
+      expect(result.reason).toBe('external-initiative:021 School Platform')
+    })
+
+    it('(b) flags an orphan issue (no project) carrying an external-curriculum label', async () => {
+      const { isOutOfScope } = await importModule()
+      const issue = {
+        identifier: 'SMI-9002',
+        project: null,
+        labels: { nodes: [{ name: 'Track_A' }] },
+      }
+      const result = isOutOfScope(issue)
+      expect(result.outOfScope).toBe(true)
+      expect(result.reason.startsWith('external-curriculum-label')).toBe(true)
+      expect(result.reason).toBe('external-curriculum-label:Track_A')
+    })
+
+    it('(c) keeps a Skillsmith-initiative issue in scope (stays drift)', async () => {
+      const { isOutOfScope } = await importModule()
+      const issue = {
+        identifier: 'SMI-9003',
+        project: {
+          name: 'Core Repositories',
+          initiatives: { nodes: [{ name: 'Skillsmith' }] },
+        },
+        labels: { nodes: [] },
+      }
+      expect(isOutOfScope(issue).outOfScope).toBe(false)
+    })
+
+    it('(d) does NOT exclude a Skillsmith issue labeled generic Docs (guards rejected alt A)', async () => {
+      const { isOutOfScope } = await importModule()
+      const issue = {
+        identifier: 'SMI-9004',
+        project: {
+          name: 'Core Repositories',
+          initiatives: { nodes: [{ name: 'Skillsmith' }] },
+        },
+        labels: { nodes: [{ name: 'Docs' }] },
+      }
+      expect(isOutOfScope(issue).outOfScope).toBe(false)
+    })
+
+    it('(e) keeps a multi-initiative issue in scope when Skillsmith is among them (.some guard)', async () => {
+      const { isOutOfScope } = await importModule()
+      const issue = {
+        identifier: 'SMI-9005',
+        project: {
+          name: 'Shared Project',
+          initiatives: { nodes: [{ name: '021 School Platform' }, { name: 'Skillsmith' }] },
+        },
+        labels: { nodes: [] },
+      }
+      expect(isOutOfScope(issue).outOfScope).toBe(false)
+    })
+
+    it('keeps an issue in scope when the project name matches a Skillsmith project pattern', async () => {
+      const { isOutOfScope } = await importModule()
+      const issue = {
+        identifier: 'SMI-9006',
+        project: {
+          name: 'Dependabot Vulnerability Fixes',
+          // Non-Skillsmith initiative, but project carve-out wins.
+          initiatives: { nodes: [{ name: 'MiniMax Gateway' }] },
+        },
+        labels: { nodes: [] },
+      }
+      expect(isOutOfScope(issue).outOfScope).toBe(false)
+    })
+
+    it('keeps an issue with no project and no curriculum label in scope (fail-safe)', async () => {
+      const { isOutOfScope } = await importModule()
+      const issue = {
+        identifier: 'SMI-9007',
+        project: null,
+        labels: { nodes: [{ name: 'bug' }] },
+      }
+      expect(isOutOfScope(issue).outOfScope).toBe(false)
+    })
+
+    it('keeps an issue with an empty initiatives list in scope (fail-safe)', async () => {
+      const { isOutOfScope } = await importModule()
+      const issue = {
+        identifier: 'SMI-9008',
+        project: { name: 'Some Project', initiatives: { nodes: [] } },
+        labels: { nodes: [] },
+      }
+      expect(isOutOfScope(issue).outOfScope).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## What

Track 2 of SMI-5275. Teaches the **Linear Drift Audit** (`scripts/audit-linear-drift.mjs`) to exclude non-Skillsmith-initiative and external-curriculum issues **structurally** at audit time — so they stop false-positiving as "drift" and no longer need a manual `.linear-drift-allowlist` entry each month. Reuses the initiative discriminator already proven in `triage-linear-drift.mjs`.

Companion to #1427 (Track 1, the one-time allowlist clearance of the current 71).

## How

- **GraphQL** (`fetchDoneIssues`): + `project { name initiatives { nodes { name } } }` and bounded `labels(first: 50)`. The extended `first:100` query was empirically verified accepted by live Linear (no complexity rejection).
- **`isOutOfScope(issue)`**: primary signal = no initiative node matches `/^Skillsmith$/i` **and** project isn't a Skillsmith project (`.some()` over the **full** initiatives list — multi-initiative safe, never `nodes[0]`); secondary = `Track_A/B/C/Z` / `Cohort_4` label (catches orphan issues with no project). **Fail-safe**: missing initiative + no curriculum label → stays *in* scope.
- **Query error ≠ drift**: a Linear query rejection now `exit 2` (was `exit 1`) so it can't masquerade as drift; the drift gate stays `exit 1`.
- **Visibility**: JSON gains a per-item `outOfScope[]` (id/title/reason); the workflow renders it in the always-visible GH **step summary** (`<details>`) + best-effort issue-body line.

## ADR-109 gate

Infra change (CI-invoked script + workflow) → SPARC + plan-review completed. Design doc + the **19-issue / 6-High plan-review** (all High findings fixed: multi-initiative `.some()`, GraphQL-error exit split, smoke allowlist-shadow handling, per-item audit trail, drift=0 visibility, live-name fixtures) at `docs/internal/implementation/smi-5275-drift-audit-out-of-scope-tier.md`.

> Note: that design doc currently lives **untracked** in the `docs/internal` submodule, which has pre-existing pointer drift (SMI-5272/5266 commits ahead of main's recorded pointer) from in-flight work. It was intentionally **not** bundled into this code PR to avoid entangling that drift — see PR discussion for submodule reconciliation.

## Tests

`scripts/tests/audit-linear-drift.test.ts` — **30 passed** (8 new `isOutOfScope` cases incl. multi-initiative guard, `Docs`-label-stays-in-scope regression guard, project-pattern carve-out, fail-safe). `lint` / `typecheck` / `audit:standards` (78/0, lone pre-existing migration-header warning) clean. `audit-linear-drift.mjs` is 459 lines (< 500 gate).

Follow-up: **SMI-5277** (prune now-redundant allowlist entries once this is green in CI).

Related: SMI-5275, SMI-5277, #1074, #1427