### PR TITLE
feat(indexer): per-skill collection extraction + community tree-URL builder (SMI-5286 Wave 1a)

### DIFF
--- a/scripts/indexer/code-search.ts
+++ b/scripts/indexer/code-search.ts
@@ -32,6 +32,7 @@
 import { buildGitHubHeaders } from './_shared/github-auth.ts'
 import { validateGitHubParams, sanitizeForLog } from './_shared/validation.ts'
 import { delay, withRateLimitTracking, type RateLimitTelemetry } from './_shared/rate-limit.ts'
+import { buildSkillTreeUrl } from './skill-url.ts'
 import type { GitHubRepository } from './topic-search.ts'
 
 /**
@@ -52,6 +53,8 @@ interface CodeSearchResponse {
       html_url: string
       stargazers_count: number
       forks_count: number
+      // SMI-5286 Wave 1a (§#6): light fork guard — skip forked repos.
+      fork: boolean
       topics: string[]
       default_branch: string
     }
@@ -109,6 +112,9 @@ export async function searchCodeForSkillMd(
 
         const repos: GitHubRepository[] = data.items
           .filter((item) => {
+            // SMI-5286 Wave 1a (§#6): light fork guard — forks are ~0% of the
+            // searchable population; skip them to cut noise without dedup cost.
+            if (item.repository.fork) return false
             // Deduplicate: code search can return multiple SKILL.md per repo
             const key = item.repository.full_name
             if (seen.has(key)) return false
@@ -128,7 +134,9 @@ export async function searchCodeForSkillMd(
             name: item.repository.name,
             fullName: item.repository.full_name,
             description: item.repository.description,
-            url: item.repository.html_url,
+            // SMI-5286 Wave 1a (§#1, C-1): per-skill tree URL (root SKILL.md →
+            // `${html_url}/tree/${branch}`) so rows never collide on repo_url.
+            url: buildSkillTreeUrl(item.repository.html_url, item.repository.default_branch, ''),
             stars: item.repository.stargazers_count,
             forks: item.repository.forks_count,
             topics: item.repository.topics || [],
@@ -282,6 +290,9 @@ export async function searchCodeForSkillMdInSubdirectory(
 
         const repos: GitHubRepository[] = data.items
           .filter((item) => {
+            // SMI-5286 Wave 1a (§#6): light fork guard — skip forked repos.
+            if (item.repository.fork) return false
+
             const skillPath = extractSkillPath(item.path)
 
             // Reject path traversal sequences — prevents ../ escapes from GitHub results
@@ -309,7 +320,13 @@ export async function searchCodeForSkillMdInSubdirectory(
             name: item.repository.name,
             fullName: item.repository.full_name,
             description: item.repository.description,
-            url: item.repository.html_url,
+            // SMI-5286 Wave 1a (§#1, C-1): per-skill tree URL keyed on this result's
+            // SKILL.md path so N skills in one repo yield N distinct repo_url rows.
+            url: buildSkillTreeUrl(
+              item.repository.html_url,
+              item.repository.default_branch,
+              extractSkillPath(item.path)
+            ),
             stars: item.repository.stargazers_count,
             forks: item.repository.forks_count,
             topics: item.repository.topics || [],

--- a/scripts/indexer/skill-url.ts
+++ b/scripts/indexer/skill-url.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-skill GitHub tree-URL builder (Node port)
+ * @module scripts/indexer/skill-url
+ *
+ * SMI-5286 Wave 1a (C-1): the load-bearing dedup fix. `skills.repo_url` is the
+ * ONLY unique constraint (migration 001:26) and the upsert `onConflict` target
+ * (`indexer-runners.batch.ts:153`). The community discovery emitters historically
+ * persisted the BARE repo-root `html_url` for every skill, so N SKILL.md files in
+ * one repo collided on `repo_url` → last-writer-wins → a single row.
+ *
+ * This helper constructs a DISTINCT per-skill URL of the shape
+ *   `${repoHtmlUrl}/tree/${defaultBranch}/${skillPath}`
+ * mirroring the high-trust path that already produces naturally-distinct rows at
+ * `high-trust-indexer.ts:261`. Each enumerated SKILL.md therefore yields a
+ * distinct `repo_url` and never collides.
+ *
+ * Kept tiny and dependency-free so every emitter (subdirectory-search,
+ * code-search, topic-search) can import it without a cycle.
+ */
+
+/**
+ * Build the per-skill tree URL for a SKILL.md discovered in a repository.
+ *
+ * `skillPath` is the SKILL.md's parent directory (the convention used everywhere
+ * in the indexer — `extractSkillPath`/`fetchSkillPathsFromTree` both strip the
+ * trailing `/SKILL.md`). It mirrors `high-trust-indexer.ts:261`'s `resolvedPath`.
+ *
+ * Normalization:
+ *   - strips a trailing slash from `repoHtmlUrl`
+ *   - drops a single leading slash from `skillPath`
+ *   - for a root-level skill (`skillPath === ''`) returns the bare
+ *     `${repoHtmlUrl}/tree/${defaultBranch}` (a root SKILL.md has no parent dir,
+ *     matching high-trust semantics where `resolvedPath` is the skill dir)
+ *
+ * @param repoHtmlUrl - The repository root HTML URL (e.g. `https://github.com/o/r`)
+ * @param defaultBranch - The repository default branch (e.g. `main`)
+ * @param skillPath - The SKILL.md parent directory (e.g. `.agents/skills/foo`), or `''` for root
+ * @returns A distinct per-skill tree URL
+ */
+export function buildSkillTreeUrl(
+  repoHtmlUrl: string,
+  defaultBranch: string,
+  skillPath: string
+): string {
+  const root = repoHtmlUrl.replace(/\/+$/, '')
+  const path = skillPath.replace(/^\/+/, '')
+  if (path === '') {
+    return `${root}/tree/${defaultBranch}`
+  }
+  return `${root}/tree/${defaultBranch}/${path}`
+}

--- a/scripts/indexer/subdirectory-search.ts
+++ b/scripts/indexer/subdirectory-search.ts
@@ -37,6 +37,8 @@ import { GITHUB_API_DELAY, delay, type RateLimitTelemetry } from './_shared/rate
 import { searchCodeForSkillMdInSubdirectory } from './code-search.ts'
 import { checkSkillMdExists } from './skill-processor.ts'
 import { fetchRepoLicense, isPermissiveLicense } from './license-filter.ts'
+import { enumerateRepoSkillPaths, type EnumerateTelemetry } from './trees-enumerate.ts'
+import { buildSkillTreeUrl } from './skill-url.ts'
 import type { GitHubRepository } from './topic-search.ts'
 import type { SkillMdValidation } from './skill-processor.ts'
 
@@ -74,6 +76,16 @@ export const FALLBACK_PATH_PREFIXES = [
  * SMI-4852: Threads `telemetry` to downstream `fetchRepoLicense` and
  * `checkSkillMdExists` calls so every GitHub API hit lands in the shared
  * collector.
+ *
+ * SMI-5286 Wave 1a (§#1, C-1): per-skill (collection) extraction. Each candidate
+ * repo is enumerated ONCE via the Trees API (`enumerateRepoSkillPaths`) and EVERY
+ * valid SKILL.md parent dir becomes its own `GitHubRepository`, with a DISTINCT
+ * per-skill tree URL (`buildSkillTreeUrl`) so N skills in one repo yield N distinct
+ * `repo_url` rows that never collide on `onConflict: 'repo_url'`. Each per-path row
+ * is validated independently (§#4 strict gate) before it is collected; validated
+ * rows are `installable:true` (`skill-processor.ts:440` then persists the non-null
+ * tree URL). Edit E: only the enumeration loop changed — the dedup-key /
+ * freshness-qualifier lines (`:89`) are byte-stable for the SMI-5176 rebase.
  */
 async function processSearchResults(
   resultRepos: GitHubRepository[],
@@ -82,7 +94,9 @@ async function processSearchResults(
   validationOptions: { strictValidation?: boolean; minContentLength?: number },
   repos: GitHubRepository[],
   stats: { licenseFiltered: number; licenseFetchFailed: number },
-  telemetry: RateLimitTelemetry
+  telemetry: RateLimitTelemetry,
+  enumerateTelemetry: EnumerateTelemetry,
+  enumeratedRepos: Set<string>
 ): Promise<void> {
   for (const repo of resultRepos) {
     // Deduplication key includes skillPath: one repo can have multiple skills
@@ -113,23 +127,76 @@ async function processSearchResults(
       continue
     }
 
-    // Validate SKILL.md exists and meets quality gate
-    repo.installable = await checkSkillMdExists(
+    // Mark this code-search result consumed (per-repo+skillPath identity) so the
+    // same surfaced file is not re-processed across pages/prefixes.
+    seenUrls.add(dedupKey)
+
+    // SMI-5286 Wave 1a (§#1): enumerate the repo's full tree ONCE. The broad query
+    // can surface the same repo via multiple SKILL.md hits; guard re-enumeration.
+    const repoKey = `${repo.owner}/${repo.repoName}`
+    if (enumeratedRepos.has(repoKey)) {
+      await delay(50)
+      continue
+    }
+    enumeratedRepos.add(repoKey)
+
+    const { entries, truncatedByApi, truncatedByCap } = await enumerateRepoSkillPaths(
       repo.owner,
       repo.repoName,
       repo.defaultBranch,
-      validationCache,
       telemetry,
-      repo.skillPath,
-      validationOptions
+      enumerateTelemetry
     )
 
-    // Attach license for persistence in repositoryToSkill()
-    repo.license = spdxId
+    if (truncatedByApi) {
+      // Trees API truncated — do NOT emit a partial set (deterministic skip).
+      console.log(
+        `[BroadDiscovery] Trees truncated, skipping for manual handling: ${repo.fullName}`
+      )
+      await delay(50)
+      continue
+    }
+    if (truncatedByCap) {
+      console.log(`[BroadDiscovery] Per-repo cap reached, taking first N: ${repo.fullName}`)
+    }
 
-    seenUrls.add(dedupKey)
-    repos.push(repo)
-    await delay(50)
+    // Validate each enumerated SKILL.md independently (§#4 strict gate) and emit
+    // one per-skill GitHubRepository with a distinct tree URL (C-1) per valid path.
+    for (const entry of entries) {
+      const skillPath = entry.path
+      const installable = await checkSkillMdExists(
+        repo.owner,
+        repo.repoName,
+        repo.defaultBranch,
+        validationCache,
+        telemetry,
+        skillPath,
+        validationOptions
+      )
+
+      // C-1: build the per-skill tree URL from the BARE repo html_url
+      // (reconstructed from owner/repoName), NOT from `repo.url` — by this point
+      // `repo.url` is already the code-search mapper's tree URL, so reusing it
+      // would double the `/tree/<branch>` segment. `skillUrl` already encodes
+      // `skillPath`, so it alone is the dedup key.
+      const skillUrl = buildSkillTreeUrl(
+        `https://github.com/${repo.owner}/${repo.repoName}`,
+        repo.defaultBranch,
+        skillPath
+      )
+      if (seenUrls.has(skillUrl)) continue
+      seenUrls.add(skillUrl)
+
+      repos.push({
+        ...repo,
+        url: skillUrl,
+        installable,
+        skillPath,
+        treeHash: entry.blobSha,
+        license: spdxId,
+      })
+      await delay(50)
+    }
   }
 }
 
@@ -181,6 +248,11 @@ export async function runSubdirectorySearch(
   const stats = { licenseFiltered: 0, licenseFetchFailed: 0 }
   let incompleteResults = 0
   let searchMode: 'broad' | 'prefix-fallback' = 'broad'
+  // SMI-5286 Wave 1a: run-scoped per-skill extraction state. `enumerateTelemetry`
+  // accumulates denylist/cap/truncation counters across the whole run;
+  // `enumeratedRepos` guards one Trees call per repo across pages and prefixes.
+  const enumerateTelemetry: EnumerateTelemetry = {}
+  const enumeratedRepos = new Set<string>()
 
   // ── Primary: broad query (no path constraint) ────────────────────────
   console.log('[BroadDiscovery] Running broad filename:SKILL.md query...')
@@ -217,7 +289,9 @@ export async function runSubdirectorySearch(
       validationOptions,
       repos,
       stats,
-      telemetry
+      telemetry,
+      enumerateTelemetry,
+      enumeratedRepos
     )
 
     if (result.repos.length < 30) break
@@ -269,7 +343,9 @@ export async function runSubdirectorySearch(
           validationOptions,
           repos,
           stats,
-          telemetry
+          telemetry,
+          enumerateTelemetry,
+          enumeratedRepos
         )
 
         if (result.repos.length < 30) break
@@ -285,6 +361,18 @@ export async function runSubdirectorySearch(
   console.log(
     `[BroadDiscovery] Complete (${searchMode}): ${repos.length} added, ${stats.licenseFiltered} license-filtered, ${stats.licenseFetchFailed} fetch-failed, ${incompleteResults} incomplete, ${totalRetries} retries`
   )
+  // SMI-5286 Wave 1a: per-skill extraction observability (§#1, Edit D).
+  console.log(
+    `[BroadDiscovery] Per-skill extraction: ${enumeratedRepos.size} repos enumerated, ${enumerateTelemetry.denylistSkipped ?? 0} denylist-skipped, ${enumerateTelemetry.cappedRepoCount ?? 0} capped, ${enumerateTelemetry.truncatedRepoCount ?? 0} api-truncated`
+  )
+  if (
+    enumerateTelemetry.denylistSkippedSample &&
+    enumerateTelemetry.denylistSkippedSample.length > 0
+  ) {
+    console.log(
+      `[BroadDiscovery] Denylist-skipped sample: ${enumerateTelemetry.denylistSkippedSample.join(', ')}`
+    )
+  }
 
   return {
     repos,

--- a/scripts/indexer/topic-search.ts
+++ b/scripts/indexer/topic-search.ts
@@ -16,6 +16,7 @@
 
 import { buildGitHubHeaders } from './_shared/github-auth.ts'
 import { validateGitHubParams, isValidGitHubTopic, sanitizeForLog } from './_shared/validation.ts'
+import { buildSkillTreeUrl } from './skill-url.ts'
 import {
   GITHUB_API_DELAY,
   delay,
@@ -76,6 +77,8 @@ interface GitHubSearchResponse {
     html_url: string
     stargazers_count: number
     forks_count: number
+    // SMI-5286 Wave 1a (§#6): light fork guard — skip forked repos.
+    fork: boolean
     topics: string[]
     updated_at: string
     default_branch: string
@@ -167,6 +170,8 @@ export async function searchRepositories(
     // SMI-2271: Filter out repos with invalid identifiers before processing
     const repos: GitHubRepository[] = data.items
       .filter((item) => {
+        // SMI-5286 Wave 1a (§#6): light fork guard — skip forked repos.
+        if (item.fork) return false
         try {
           validateGitHubParams(item.owner.login, item.name)
           return true
@@ -180,7 +185,12 @@ export async function searchRepositories(
         name: item.name,
         fullName: item.full_name,
         description: item.description,
-        url: item.html_url,
+        // SMI-5286 Wave 1a (§#1, C-1): topic-search knows only the repo root + a
+        // root SKILL.md. Emit the per-skill tree URL for that single known path
+        // (`${html_url}/tree/${branch}`) rather than the bare html_url so the row
+        // carries a distinct, install-correct repo_url. Repos with multiple skills
+        // are enumerated by the subdirectory path; topic-search stays root-only.
+        url: buildSkillTreeUrl(item.html_url, item.default_branch, ''),
         stars: item.stargazers_count,
         forks: item.forks_count,
         topics: item.topics || [],

--- a/scripts/indexer/trees-enumerate.ts
+++ b/scripts/indexer/trees-enumerate.ts
@@ -1,0 +1,157 @@
+/**
+ * Per-repo SKILL.md enumeration with validity/denylist/cap/truncation policy
+ * @module scripts/indexer/trees-enumerate
+ *
+ * SMI-5286 Wave 1a (§#1, §#4, §#6 support): thin wrapper over
+ * `fetchSkillPathsFromTree` (`trees-search.ts`) that turns ONE recursive Trees
+ * API call into the set of valid SKILL.md parent directories for a repo, after
+ * applying the template/example denylist (Edit D, ancestor-only), the per-repo
+ * cap (`BACKFILL_MAX_SKILLS_PER_REPO`), and the Trees-truncation policy.
+ *
+ * Extracted into its own sibling (not folded into `trees-search.ts`) to keep that
+ * file under the 500-line hard gate. Depends only on the exported
+ * `fetchSkillPathsFromTree` + `TreeSkillEntry` so there is no import cycle.
+ */
+
+import { fetchSkillPathsFromTree, type TreeSkillEntry } from './trees-search.ts'
+import type { RateLimitTelemetry } from './_shared/rate-limit.ts'
+
+/** SMI-5286 Wave 1a: max number of skipped-path samples retained per run. */
+const DENYLIST_SAMPLE_LIMIT = 20
+
+/** SMI-5286 Wave 1a: default per-repo skill cap (`BACKFILL_MAX_SKILLS_PER_REPO`). */
+const DEFAULT_MAX_SKILLS_PER_REPO = 50
+
+/**
+ * SMI-5286 Wave 1a (§#1, Edit D): template/example denylist segments. A SKILL.md
+ * is skipped only when one of these appears as a STRICT ANCESTOR directory of the
+ * skill's parent dir — never the skill's own leaf segment. Ancestor-only matching
+ * keeps legitimate skills like `.agents/skills/test-runner/SKILL.md` or
+ * `.claude/skills/examples-helper/SKILL.md` while dropping `examples/foo/SKILL.md`
+ * and `a/templates/b/SKILL.md`. `test`/`tests` are the highest-collision terms,
+ * which is exactly why a segment-anywhere match would silently kill real skills.
+ */
+export const TEMPLATE_DENYLIST_SEGMENTS = new Set([
+  'templates',
+  'examples',
+  'test',
+  'tests',
+  'fixtures',
+])
+
+/**
+ * SMI-5286 Wave 1a: mutable counters collected by `enumerateRepoSkillPaths` across
+ * many repos in a run. Caller owns the object and reads the accumulated totals
+ * (denylist skips + sample, cap saturation, API truncation) for the run summary.
+ */
+export interface EnumerateTelemetry {
+  /** Count of SKILL.md entries dropped by the ancestor-only template/example denylist. */
+  denylistSkipped?: number
+  /** Small sample of `${owner}/${repo}:${path}` strings that were denylist-skipped. */
+  denylistSkippedSample?: string[]
+  /** Count of repos whose tree exceeded the per-repo cap. */
+  cappedRepoCount?: number
+  /** Count of repos whose Trees API response was truncated (set emitted empty). */
+  truncatedRepoCount?: number
+}
+
+/**
+ * SMI-5286 Wave 1a: result of `enumerateRepoSkillPaths`.
+ */
+export interface EnumerateRepoSkillPathsResult {
+  /** Valid SKILL.md parent dirs (+ blob SHAs) after denylist + cap + truncation policy. */
+  entries: TreeSkillEntry[]
+  /** True if the per-repo cap clipped the set (first `cap` by path-sort were kept). */
+  truncatedByCap: boolean
+  /** True if the Trees API truncated; per policy (b) `entries` is empty in this case. */
+  truncatedByApi: boolean
+}
+
+/**
+ * SMI-5286 Wave 1a (§#1): true if a denylist segment is a STRICT ANCESTOR of the
+ * skill's parent directory. `skillPath` is the SKILL.md parent dir (e.g.
+ * `examples/foo` or `.agents/skills/test-runner`). The LAST segment is the skill's
+ * own leaf dir and is intentionally NOT checked, so `.../test-runner` is kept while
+ * `examples/...` / `.../templates/...` are dropped.
+ */
+function hasDenylistAncestor(skillPath: string): boolean {
+  const segments = skillPath.split('/').filter((s) => s.length > 0)
+  // Inspect every segment EXCEPT the last (the skill's own leaf dir).
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (TEMPLATE_DENYLIST_SEGMENTS.has(segments[i].toLowerCase())) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * SMI-5286 Wave 1a (§#1, §#4, §#6 support): enumerate every valid SKILL.md parent
+ * directory in a repo via ONE recursive Trees API call, applying the validity
+ * suffix gate (inherited from `fetchSkillPathsFromTree` — §#4 gate 1, strict
+ * `/SKILL.md`), the ancestor-only template/example denylist (Edit D), the
+ * per-repo cap (`BACKFILL_MAX_SKILLS_PER_REPO`), and the Trees-truncation policy
+ * (default option (b): on `truncated === true` emit ZERO entries and flag
+ * `truncatedByApi` for manual handling — per-subtree fallback is a 1c follow-up).
+ *
+ * The strict `/SKILL.md` suffix filter is NOT relaxed here: `fetchSkillPathsFromTree`
+ * already matches only `entry.path.endsWith('/SKILL.md')` (or a root `SKILL.md`),
+ * which excludes tokenized `use-skill.md` noise (SMI-5285).
+ *
+ * @param owner - GitHub repository owner
+ * @param repo - Repository name
+ * @param branch - Branch name or commit SHA to pass to fetchSkillPathsFromTree
+ * @param telemetry - Shared rate-limit telemetry collector (threaded to fetch)
+ * @param enumerateTelemetry - Run-scoped denylist/cap/truncation accumulator
+ * @param cap - Max skills per repo (default `BACKFILL_MAX_SKILLS_PER_REPO` = 50)
+ * @returns Enumerated entries plus truncation flags. On API truncation the entry
+ *   list is empty and `truncatedByApi` is true (deterministic, no silent drop).
+ */
+export async function enumerateRepoSkillPaths(
+  owner: string,
+  repo: string,
+  branch: string,
+  telemetry: RateLimitTelemetry,
+  enumerateTelemetry: EnumerateTelemetry,
+  cap: number = DEFAULT_MAX_SKILLS_PER_REPO
+): Promise<EnumerateRepoSkillPathsResult> {
+  const { entries: rawEntries, truncated } = await fetchSkillPathsFromTree(
+    owner,
+    repo,
+    branch,
+    telemetry
+  )
+
+  // Truncation policy (default option (b)): the Trees API returned a non-deterministic
+  // partial set. Do NOT emit the partial — record for manual handling and return zero.
+  if (truncated) {
+    enumerateTelemetry.truncatedRepoCount = (enumerateTelemetry.truncatedRepoCount ?? 0) + 1
+    return { entries: [], truncatedByCap: false, truncatedByApi: true }
+  }
+
+  // Validity suffix gate is already applied upstream; apply the ancestor-only
+  // template/example denylist here, collecting a small sample for observability.
+  const allowed: TreeSkillEntry[] = []
+  for (const entry of rawEntries) {
+    if (hasDenylistAncestor(entry.path)) {
+      enumerateTelemetry.denylistSkipped = (enumerateTelemetry.denylistSkipped ?? 0) + 1
+      if (!enumerateTelemetry.denylistSkippedSample) {
+        enumerateTelemetry.denylistSkippedSample = []
+      }
+      if (enumerateTelemetry.denylistSkippedSample.length < DENYLIST_SAMPLE_LIMIT) {
+        enumerateTelemetry.denylistSkippedSample.push(`${owner}/${repo}:${entry.path}`)
+      }
+      continue
+    }
+    allowed.push(entry)
+  }
+
+  // Per-repo cap: deterministic path-sort, take the first `cap`.
+  if (allowed.length > cap) {
+    allowed.sort((a, b) => a.path.localeCompare(b.path))
+    enumerateTelemetry.cappedRepoCount = (enumerateTelemetry.cappedRepoCount ?? 0) + 1
+    return { entries: allowed.slice(0, cap), truncatedByCap: true, truncatedByApi: false }
+  }
+
+  return { entries: allowed, truncatedByCap: false, truncatedByApi: false }
+}

--- a/scripts/tests/indexer/community-url-fork.test.ts
+++ b/scripts/tests/indexer/community-url-fork.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Community URL and fork-guard tests for code-search.ts and topic-search.ts
+ * (SMI-5286 Wave 1a §#1, §#6)
+ *
+ * Asserts:
+ *   (a) Result mappers emit the per-skill tree-URL (not the bare html_url).
+ *   (b) Forked repositories are filtered out before being returned.
+ *
+ * Mocks the network layer at globalThis.fetch so the production HTTP plumbing
+ * is exercised but no real requests are made. Matches the mock pattern used in
+ * skill-md-fetch.test.ts (vi.spyOn + afterEach restoreAllMocks).
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+
+// ---------------------------------------------------------------------------
+// Keep rate-limit helpers fast: mock delay + withRateLimitTracking to forward
+// the fetch call directly so we can spy on globalThis.fetch.
+// ---------------------------------------------------------------------------
+
+vi.mock('../../indexer/_shared/rate-limit.ts', () => ({
+  GITHUB_API_DELAY: 0,
+  delay: vi.fn(async () => undefined),
+  withBackoff: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  // Let withRateLimitTracking call globalThis.fetch directly (transparent).
+  withRateLimitTracking: vi.fn(async (_telemetry: unknown, url: string, opts?: RequestInit) => {
+    const init = opts ? { headers: opts.headers } : {}
+    return globalThis.fetch(url, init)
+  }),
+}))
+
+vi.mock('../../indexer/_shared/github-auth.ts', () => ({
+  buildGitHubHeaders: vi.fn(async () => ({ Authorization: 'Bearer test-token' })),
+}))
+
+// Imported AFTER mocks.
+import {
+  searchCodeForSkillMd,
+  searchCodeForSkillMdInSubdirectory,
+} from '../../indexer/code-search.ts'
+import { searchRepositories } from '../../indexer/topic-search.ts'
+
+afterEach(() => vi.restoreAllMocks())
+
+const noTelemetry: RateLimitTelemetry = {} as RateLimitTelemetry
+
+// ---------------------------------------------------------------------------
+// Helpers to build minimal GitHub API response payloads
+// ---------------------------------------------------------------------------
+
+function makeCodeSearchItem(
+  overrides: {
+    path?: string
+    full_name?: string
+    owner?: string
+    repoName?: string
+    html_url?: string
+    default_branch?: string
+    fork?: boolean
+  } = {}
+) {
+  const owner = overrides.owner ?? 'acme'
+  const repoName = overrides.repoName ?? 'my-skills'
+  return {
+    name: 'SKILL.md',
+    path: overrides.path ?? '.agents/skills/foo/SKILL.md',
+    repository: {
+      id: 1,
+      full_name: overrides.full_name ?? `${owner}/${repoName}`,
+      name: repoName,
+      owner: { login: owner },
+      description: 'A skill repo',
+      html_url: overrides.html_url ?? `https://github.com/${owner}/${repoName}`,
+      stargazers_count: 10,
+      forks_count: 2,
+      fork: overrides.fork ?? false,
+      topics: ['claude-code-skill'],
+      default_branch: overrides.default_branch ?? 'main',
+    },
+  }
+}
+
+function makeTopicSearchItem(
+  overrides: {
+    owner?: string
+    name?: string
+    html_url?: string
+    default_branch?: string
+    fork?: boolean
+  } = {}
+) {
+  const owner = overrides.owner ?? 'acme'
+  const name = overrides.name ?? 'my-skills'
+  return {
+    id: 42,
+    full_name: `${owner}/${name}`,
+    name,
+    owner: { login: owner },
+    description: 'A skill repo',
+    html_url: overrides.html_url ?? `https://github.com/${owner}/${name}`,
+    stargazers_count: 5,
+    forks_count: 1,
+    fork: overrides.fork ?? false,
+    topics: ['claude-code-skill'],
+    updated_at: '2026-01-01T00:00:00Z',
+    default_branch: overrides.default_branch ?? 'main',
+    license: { spdx_id: 'MIT' },
+  }
+}
+
+function makeFetchOk(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => body,
+  } as unknown as Response
+}
+
+// ---------------------------------------------------------------------------
+// code-search.ts — searchCodeForSkillMd (root SKILL.md)
+// ---------------------------------------------------------------------------
+
+describe('searchCodeForSkillMd — tree-URL and fork guard (SMI-5286 Wave 1a §#1/§#6)', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('emits the per-skill tree-URL (not the bare html_url) for a root SKILL.md hit', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeFetchOk({
+        total_count: 1,
+        incomplete_results: false,
+        items: [makeCodeSearchItem({ path: 'SKILL.md' })],
+      })
+    )
+
+    const { repos } = await searchCodeForSkillMd(1, 30, undefined, noTelemetry)
+
+    expect(repos).toHaveLength(1)
+    // Root SKILL.md → skillPath '' → tree URL ends with /tree/main
+    expect(repos[0].url).toBe('https://github.com/acme/my-skills/tree/main')
+    // Must NOT be bare html_url (no /tree/)
+    expect(repos[0].url).not.toBe('https://github.com/acme/my-skills')
+    expect(repos[0].skillPath).toBe('')
+  })
+
+  it('filters out forked repositories (fork===true)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeFetchOk({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          makeCodeSearchItem({ path: 'SKILL.md', fork: true, repoName: 'forked' }),
+          makeCodeSearchItem({ path: 'SKILL.md', fork: false, repoName: 'original' }),
+        ],
+      })
+    )
+
+    const { repos } = await searchCodeForSkillMd(1, 30, undefined, noTelemetry)
+
+    expect(repos).toHaveLength(1)
+    expect(repos[0].repoName).toBe('original')
+  })
+
+  it('returns an empty repos array when ALL items are forks', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeFetchOk({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          makeCodeSearchItem({ path: 'SKILL.md', fork: true, repoName: 'fork1' }),
+          makeCodeSearchItem({ path: 'SKILL.md', fork: true, repoName: 'fork2' }),
+        ],
+      })
+    )
+
+    const { repos, total } = await searchCodeForSkillMd(1, 30, undefined, noTelemetry)
+
+    expect(repos).toHaveLength(0)
+    expect(total).toBe(2) // total_count from API is still returned
+  })
+})
+
+// ---------------------------------------------------------------------------
+// code-search.ts — searchCodeForSkillMdInSubdirectory (subdirectory SKILL.md)
+// ---------------------------------------------------------------------------
+
+describe('searchCodeForSkillMdInSubdirectory — tree-URL and fork guard (SMI-5286 Wave 1a §#1/§#6)', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('emits the per-skill tree-URL for a .agents/skills/foo/SKILL.md hit', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeFetchOk({
+        total_count: 1,
+        incomplete_results: false,
+        items: [makeCodeSearchItem({ path: '.agents/skills/foo/SKILL.md' })],
+      })
+    )
+
+    const result = await searchCodeForSkillMdInSubdirectory(
+      '.agents/skills',
+      1,
+      30,
+      undefined,
+      noTelemetry
+    )
+
+    expect(result.repos).toHaveLength(1)
+    const repo = result.repos[0]
+    // URL must be the tree-URL for the skill's parent dir
+    expect(repo.url).toBe('https://github.com/acme/my-skills/tree/main/.agents/skills/foo')
+    // Not the bare html_url
+    expect(repo.url).not.toBe('https://github.com/acme/my-skills')
+    expect(repo.skillPath).toBe('.agents/skills/foo')
+  })
+
+  it('filters out forked repositories from subdirectory code search', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeFetchOk({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          makeCodeSearchItem({
+            path: '.agents/skills/foo/SKILL.md',
+            fork: true,
+            repoName: 'a-fork',
+          }),
+          makeCodeSearchItem({
+            path: '.agents/skills/bar/SKILL.md',
+            fork: false,
+            repoName: 'original',
+          }),
+        ],
+      })
+    )
+
+    const result = await searchCodeForSkillMdInSubdirectory(
+      '.agents/skills',
+      1,
+      30,
+      undefined,
+      noTelemetry
+    )
+
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0].repoName).toBe('original')
+    expect(result.repos[0].skillPath).toBe('.agents/skills/bar')
+  })
+
+  it('broad query (no pathPrefix) emits tree-URL for each distinct skill path', async () => {
+    // Two distinct SKILL.md files in the same repo — they get distinct URLs
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeFetchOk({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          makeCodeSearchItem({ path: '.agents/skills/a/SKILL.md' }),
+          makeCodeSearchItem({ path: '.agents/skills/b/SKILL.md' }),
+        ],
+      })
+    )
+
+    const result = await searchCodeForSkillMdInSubdirectory(
+      undefined, // broad
+      1,
+      30,
+      undefined,
+      noTelemetry
+    )
+
+    expect(result.repos).toHaveLength(2)
+    const urls = result.repos.map((r) => r.url)
+    expect(new Set(urls).size).toBe(2) // distinct
+    expect(urls[0]).toMatch(/\/tree\/main\/\.agents\/skills\/a/)
+    expect(urls[1]).toMatch(/\/tree\/main\/\.agents\/skills\/b/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// topic-search.ts — searchRepositories
+// ---------------------------------------------------------------------------
+
+describe('searchRepositories — tree-URL and fork guard (SMI-5286 Wave 1a §#1/§#6)', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('emits the per-skill tree-URL for a topic-search hit (root skill)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeFetchOk({
+        total_count: 1,
+        incomplete_results: false,
+        items: [makeTopicSearchItem()],
+      })
+    )
+
+    const { repos } = await searchRepositories('claude-code-skill', 1, 30, undefined, noTelemetry)
+
+    expect(repos).toHaveLength(1)
+    const repo = repos[0]
+    // Topic search always emits a root-level tree URL (skillPath='')
+    expect(repo.url).toBe('https://github.com/acme/my-skills/tree/main')
+    // Not bare html_url
+    expect(repo.url).not.toBe('https://github.com/acme/my-skills')
+    expect(repo.skillPath).toBe('')
+  })
+
+  it('filters out forked repositories from topic search results', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeFetchOk({
+        total_count: 3,
+        incomplete_results: false,
+        items: [
+          makeTopicSearchItem({ name: 'fork1', fork: true }),
+          makeTopicSearchItem({ name: 'original', fork: false }),
+          makeTopicSearchItem({ name: 'fork2', fork: true }),
+        ],
+      })
+    )
+
+    const { repos } = await searchRepositories('claude-code-skill', 1, 30, undefined, noTelemetry)
+
+    expect(repos).toHaveLength(1)
+    expect(repos[0].name).toBe('original')
+  })
+
+  it('returns empty repos array when all topic-search items are forks', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeFetchOk({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          makeTopicSearchItem({ name: 'fork1', fork: true }),
+          makeTopicSearchItem({ name: 'fork2', fork: true }),
+        ],
+      })
+    )
+
+    const { repos, total } = await searchRepositories(
+      'claude-code-skill',
+      1,
+      30,
+      undefined,
+      noTelemetry
+    )
+
+    expect(repos).toHaveLength(0)
+    expect(total).toBe(2)
+  })
+
+  it('emits distinct tree-URLs for non-fork repos and preserves SPDX license from response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      makeFetchOk({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          { ...makeTopicSearchItem({ name: 'repo-a' }), license: { spdx_id: 'Apache-2.0' } },
+          { ...makeTopicSearchItem({ name: 'repo-b' }), license: null },
+        ],
+      })
+    )
+
+    const { repos } = await searchRepositories('claude-code-skill', 1, 30, undefined, noTelemetry)
+
+    expect(repos).toHaveLength(2)
+
+    const repoA = repos.find((r) => r.name === 'repo-a')!
+    expect(repoA.url).toBe('https://github.com/acme/repo-a/tree/main')
+    expect(repoA.license).toBe('Apache-2.0')
+
+    const repoB = repos.find((r) => r.name === 'repo-b')!
+    expect(repoB.url).toBe('https://github.com/acme/repo-b/tree/main')
+    expect(repoB.license).toBeNull()
+  })
+})

--- a/scripts/tests/indexer/skill-url.test.ts
+++ b/scripts/tests/indexer/skill-url.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for Per-Skill GitHub Tree URL Builder (SMI-5286 Wave 1a C-1)
+ *
+ * The `buildSkillTreeUrl` function constructs distinct per-skill tree URLs for
+ * the upsert dedup fix. The only unique constraint is `skills.repo_url`, and the
+ * upsert target is the per-skill tree URL, not the bare repo root.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { buildSkillTreeUrl } from '../../indexer/skill-url.js'
+
+describe('SMI-5286 Wave 1a: buildSkillTreeUrl', () => {
+  describe('normal cases', () => {
+    it('should build a standard tree URL with skill path', () => {
+      const result = buildSkillTreeUrl('https://github.com/o/r', 'main', '.agents/skills/foo')
+      expect(result).toBe('https://github.com/o/r/tree/main/.agents/skills/foo')
+    })
+
+    it('should honor non-main default branch', () => {
+      const result = buildSkillTreeUrl('https://github.com/o/r', 'develop', 'x')
+      expect(result).toBe('https://github.com/o/r/tree/develop/x')
+    })
+
+    it('should handle nested skill paths', () => {
+      const result = buildSkillTreeUrl(
+        'https://github.com/foo/bar',
+        'main',
+        '.claude/skills/category/my-skill'
+      )
+      expect(result).toBe('https://github.com/foo/bar/tree/main/.claude/skills/category/my-skill')
+    })
+  })
+
+  describe('trailing slash normalization', () => {
+    it('should strip trailing slash from repo URL', () => {
+      const result = buildSkillTreeUrl('https://github.com/o/r/', 'main', 'a/b')
+      expect(result).toBe('https://github.com/o/r/tree/main/a/b')
+    })
+
+    it('should handle multiple trailing slashes on repo URL', () => {
+      const result = buildSkillTreeUrl('https://github.com/o/r///', 'main', 'path')
+      expect(result).toBe('https://github.com/o/r/tree/main/path')
+    })
+  })
+
+  describe('leading slash normalization', () => {
+    it('should drop leading slash from skillPath', () => {
+      const result = buildSkillTreeUrl('https://github.com/o/r', 'main', '/a/b')
+      expect(result).toBe('https://github.com/o/r/tree/main/a/b')
+    })
+
+    it('should handle multiple leading slashes in skillPath', () => {
+      const result = buildSkillTreeUrl('https://github.com/o/r', 'main', '///path')
+      expect(result).toBe('https://github.com/o/r/tree/main/path')
+    })
+  })
+
+  describe('root skill case (empty skillPath)', () => {
+    it('should return branch tree URL for empty skillPath', () => {
+      const result = buildSkillTreeUrl('https://github.com/o/r', 'main', '')
+      expect(result).toBe('https://github.com/o/r/tree/main')
+    })
+
+    it('should not add trailing slash for empty skillPath', () => {
+      const result = buildSkillTreeUrl('https://github.com/o/r', 'main', '')
+      expect(result).toMatch(/^https:\/\/github\.com\/o\/r\/tree\/main$/)
+      expect(result).not.toMatch(/\/$/)
+    })
+  })
+
+  describe('distinctness (C-1 guarantee)', () => {
+    it('should produce distinct URLs for different skillPaths in same repo', () => {
+      const url1 = buildSkillTreeUrl('https://github.com/o/r', 'main', 'skills/foo')
+      const url2 = buildSkillTreeUrl('https://github.com/o/r', 'main', 'skills/bar')
+      expect(url1).not.toBe(url2)
+      expect(url1).toBe('https://github.com/o/r/tree/main/skills/foo')
+      expect(url2).toBe('https://github.com/o/r/tree/main/skills/bar')
+    })
+
+    it('should produce distinct URLs for different branches', () => {
+      const url1 = buildSkillTreeUrl('https://github.com/o/r', 'main', 'skills/foo')
+      const url2 = buildSkillTreeUrl('https://github.com/o/r', 'develop', 'skills/foo')
+      expect(url1).not.toBe(url2)
+    })
+
+    it('should produce distinct URLs for different repos', () => {
+      const url1 = buildSkillTreeUrl('https://github.com/org1/r', 'main', 'skills/foo')
+      const url2 = buildSkillTreeUrl('https://github.com/org2/r', 'main', 'skills/foo')
+      expect(url1).not.toBe(url2)
+    })
+  })
+
+  describe('edge cases with both normalization rules', () => {
+    it('should strip trailing slash AND leading slash', () => {
+      const result = buildSkillTreeUrl('https://github.com/o/r/', 'main', '/a/b')
+      expect(result).toBe('https://github.com/o/r/tree/main/a/b')
+    })
+
+    it('should handle slash-only skillPath after normalization', () => {
+      const result = buildSkillTreeUrl('https://github.com/o/r', 'main', '///')
+      expect(result).toBe('https://github.com/o/r/tree/main')
+    })
+
+    it('should handle complex branch names with slashes', () => {
+      const result = buildSkillTreeUrl('https://github.com/o/r', 'release/v1.0', 'skills/my-skill')
+      expect(result).toBe('https://github.com/o/r/tree/release/v1.0/skills/my-skill')
+    })
+  })
+
+  describe('real-world high-trust emitter patterns', () => {
+    it('should match high-trust indexer URL shape (non-bare repo root)', () => {
+      // high-trust-indexer.ts:261 produces URLs like this
+      const result = buildSkillTreeUrl(
+        'https://github.com/anthropics/anthropic-sdk-python',
+        'main',
+        '.claude/skills/extract-json'
+      )
+      expect(result).toMatch(/https:\/\/github\.com\/.*\/tree\/.*\//)
+      expect(result).toContain('.claude/skills/extract-json')
+    })
+
+    it('should handle typical community discovery patterns', () => {
+      const result = buildSkillTreeUrl(
+        'https://github.com/community-user/skill-repo',
+        'main',
+        'skills'
+      )
+      expect(result).toBe('https://github.com/community-user/skill-repo/tree/main/skills')
+    })
+  })
+})

--- a/scripts/tests/indexer/subdirectory-search.perskill.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.perskill.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Per-skill extraction headline AC tests (SMI-5286 Wave 1a §#1, C-1)
+ *
+ * Drives `runSubdirectorySearch` to prove:
+ *   1. One repo with THREE valid SKILL.md files yields THREE distinct repo.url rows.
+ *   2. Each row carries the correct skillPath, treeHash, and installable===true.
+ *   3. A denylisted-ancestor path (e.g. examples/x) is excluded from the emitted rows.
+ *   4. A repo surfaced twice across code-search pages is enumerated only once
+ *      (no duplicate rows from re-enumeration).
+ *
+ * Strategy: mock every I/O boundary (code-search, license-fetch, skill-processor,
+ * trees-enumerate) at the module level; let buildSkillTreeUrl run real (pure).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — declared before any import of the SUT
+// ---------------------------------------------------------------------------
+
+// Mock delay so tests don't actually wait.
+vi.mock('../../indexer/_shared/rate-limit.ts', () => ({
+  GITHUB_API_DELAY: 0,
+  delay: vi.fn(async () => undefined),
+  withRateLimitTracking: vi.fn(),
+  withBackoff: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  newRateLimitTelemetry: vi.fn(() => ({})),
+}))
+
+vi.mock('../../indexer/_shared/github-auth.ts', () => ({
+  buildGitHubHeaders: vi.fn(async () => ({})),
+}))
+
+const mockSearchCode = vi.fn()
+vi.mock('../../indexer/code-search.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/code-search.ts')>()
+  return {
+    ...actual,
+    searchCodeForSkillMdInSubdirectory: (...args: unknown[]) => mockSearchCode(...args),
+  }
+})
+
+const mockFetchRepoLicense = vi.fn()
+vi.mock('../../indexer/license-filter.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/license-filter.ts')>()
+  return {
+    ...actual,
+    fetchRepoLicense: (...args: unknown[]) => mockFetchRepoLicense(...args),
+  }
+})
+
+const mockCheckSkillMdExists = vi.fn()
+vi.mock('../../indexer/skill-processor.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/skill-processor.ts')>()
+  return {
+    ...actual,
+    checkSkillMdExists: (...args: unknown[]) => mockCheckSkillMdExists(...args),
+  }
+})
+
+const mockEnumerateRepoSkillPaths = vi.fn()
+vi.mock('../../indexer/trees-enumerate.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/trees-enumerate.ts')>()
+  return {
+    ...actual,
+    enumerateRepoSkillPaths: (...args: unknown[]) => mockEnumerateRepoSkillPaths(...args),
+  }
+})
+
+// Imported AFTER mocks so the SUT binds the stubs.
+import { runSubdirectorySearch } from '../../indexer/subdirectory-search.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noTelemetry: RateLimitTelemetry = {} as RateLimitTelemetry
+
+/**
+ * Build a minimal GitHubRepository-shaped code-search result for a single repo.
+ * The `url` here is the BARE repo html_url (code-search mapper may transform it;
+ * subdirectory-search calls buildSkillTreeUrl internally using this as root).
+ */
+function makeCodeSearchRepo(overrides: Record<string, unknown> = {}) {
+  return {
+    owner: 'acme',
+    name: 'skills-repo',
+    fullName: 'acme/skills-repo',
+    description: 'test',
+    // Reflects production: searchCodeForSkillMdInSubdirectory already emits a
+    // per-skill tree URL here, so the consumer must rebuild from the bare
+    // html_url (owner/repoName), not re-wrap this value (governance #1).
+    url: 'https://github.com/acme/skills-repo/tree/main/.agents/skills/a',
+    stars: 5,
+    forks: 0,
+    topics: ['claude-code-skill'],
+    updatedAt: new Date().toISOString(),
+    defaultBranch: 'main',
+    installable: false,
+    repoName: 'skills-repo',
+    skillPath: '.agents/skills/a',
+    discoveryPath: 'subdirectory_search:broad',
+    ...overrides,
+  }
+}
+
+/** Make a one-page code-search result that returns without errors. */
+function makeSearchResult(repos: ReturnType<typeof makeCodeSearchRepo>[]) {
+  return {
+    repos,
+    total: repos.length,
+    retries: 0,
+    incomplete_results: false,
+  }
+}
+
+beforeEach(() => {
+  mockSearchCode.mockReset()
+  mockFetchRepoLicense.mockReset()
+  mockCheckSkillMdExists.mockReset()
+  mockEnumerateRepoSkillPaths.mockReset()
+
+  // Default: permissive license, validation always passes
+  mockFetchRepoLicense.mockResolvedValue({ license: 'MIT', fetchFailed: false })
+  mockCheckSkillMdExists.mockResolvedValue(true)
+})
+
+// ---------------------------------------------------------------------------
+// Headline AC: THREE distinct repo.url rows for ONE repo with THREE skills
+// ---------------------------------------------------------------------------
+
+describe('runSubdirectorySearch — per-skill extraction (SMI-5286 Wave 1a §#1)', () => {
+  it('emits THREE distinct url rows for one repo with three valid SKILL.md entries', async () => {
+    // Code-search returns ONE repo hit (the broad page).
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    // Second call (would paginate) returns empty → stops.
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    // Trees enumeration returns three paths for this repo.
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [
+        { path: '.agents/skills/a', blobSha: 'sha-a' },
+        { path: '.agents/skills/b', blobSha: 'sha-b' },
+        { path: '.agents/skills/c', blobSha: 'sha-c' },
+      ],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+
+    const seenUrls = new Set<string>()
+    const validationCache = new Map()
+
+    const result = await runSubdirectorySearch(
+      seenUrls,
+      undefined,
+      validationCache,
+      {},
+      1,
+      noTelemetry
+    )
+
+    // Three distinct repo rows
+    expect(result.repos).toHaveLength(3)
+
+    const urls = result.repos.map((r) => r.url)
+    // All three URLs must be distinct
+    expect(new Set(urls).size).toBe(3)
+
+    // Each URL must be a per-skill tree URL (not the bare html_url)
+    for (const url of urls) {
+      expect(url).toMatch(/\/tree\/main\//)
+    }
+
+    // Verify specific per-skill URLs
+    expect(urls).toContain('https://github.com/acme/skills-repo/tree/main/.agents/skills/a')
+    expect(urls).toContain('https://github.com/acme/skills-repo/tree/main/.agents/skills/b')
+    expect(urls).toContain('https://github.com/acme/skills-repo/tree/main/.agents/skills/c')
+
+    // Regression (governance #1): the consumer rebuilds from the bare html_url,
+    // so even though the input repo.url is already a tree URL, the emitted URLs
+    // must NOT contain a doubled `/tree/<branch>` segment.
+    for (const url of urls) {
+      expect(url).not.toMatch(/\/tree\/[^/]+\/.*\/tree\//)
+    }
+  })
+
+  it('each emitted row has the correct skillPath, treeHash, and installable===true', async () => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [
+        { path: '.agents/skills/a', blobSha: 'sha-a' },
+        { path: '.agents/skills/b', blobSha: 'sha-b' },
+        { path: '.agents/skills/c', blobSha: 'sha-c' },
+      ],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+
+    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+
+    expect(result.repos).toHaveLength(3)
+
+    const byPath = Object.fromEntries(result.repos.map((r) => [r.skillPath, r]))
+
+    expect(byPath['.agents/skills/a'].treeHash).toBe('sha-a')
+    expect(byPath['.agents/skills/a'].installable).toBe(true)
+
+    expect(byPath['.agents/skills/b'].treeHash).toBe('sha-b')
+    expect(byPath['.agents/skills/b'].installable).toBe(true)
+
+    expect(byPath['.agents/skills/c'].treeHash).toBe('sha-c')
+    expect(byPath['.agents/skills/c'].installable).toBe(true)
+  })
+
+  it('excludes the denylisted-ancestor path from the emitted rows', async () => {
+    // Repo has 3 paths; enumerateRepoSkillPaths already applies the denylist,
+    // but subdirectory-search must consume whatever enumerateRepoSkillPaths returns.
+    // Here we simulate that enumerateRepoSkillPaths correctly filtered down to 2.
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    // enumerateRepoSkillPaths returns only the non-denylisted paths
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [
+        { path: '.agents/skills/a', blobSha: 'sha-a' },
+        { path: '.agents/skills/b', blobSha: 'sha-b' },
+        // examples/x was filtered by enumerateRepoSkillPaths (denylist)
+      ],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+
+    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+
+    expect(result.repos).toHaveLength(2)
+
+    const skillPaths = result.repos.map((r) => r.skillPath)
+    expect(skillPaths).not.toContain('examples/x')
+    expect(skillPaths).toContain('.agents/skills/a')
+    expect(skillPaths).toContain('.agents/skills/b')
+  })
+
+  it('enumerates a repo only ONCE even when it appears across multiple code-search pages', async () => {
+    const repo = makeCodeSearchRepo()
+
+    // Page 1 and page 2 both surface the same repo (simulating multi-page hit)
+    mockSearchCode
+      .mockResolvedValueOnce({ ...makeSearchResult([repo]), repos: [repo] })
+      .mockResolvedValueOnce({ ...makeSearchResult([repo]), repos: [repo] })
+      .mockResolvedValue(makeSearchResult([]))
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [
+        { path: '.agents/skills/a', blobSha: 'sha-a' },
+        { path: '.agents/skills/b', blobSha: 'sha-b' },
+      ],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+
+    const result = await runSubdirectorySearch(
+      new Set(),
+      undefined,
+      new Map(),
+      {},
+      3, // allow up to 3 pages
+      noTelemetry
+    )
+
+    // enumerateRepoSkillPaths called only once (second page hit is deduped)
+    expect(mockEnumerateRepoSkillPaths).toHaveBeenCalledTimes(1)
+    // Rows are emitted only once
+    expect(result.repos).toHaveLength(2)
+  })
+
+  it('emits NO rows when enumerateRepoSkillPaths signals API truncation', async () => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [],
+      truncatedByCap: false,
+      truncatedByApi: true, // policy (b): emit nothing
+    })
+
+    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+
+    expect(result.repos).toHaveLength(0)
+  })
+
+  it('marks a skill as installable=false when checkSkillMdExists returns false', async () => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [{ path: '.agents/skills/broken', blobSha: 'sha-x' }],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+
+    // Validation fails for this skill
+    mockCheckSkillMdExists.mockResolvedValue(false)
+
+    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0].installable).toBe(false)
+  })
+
+  it('skips a repo whose license fetch failed (not counted as license-filtered)', async () => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    mockFetchRepoLicense.mockResolvedValue({ license: null, fetchFailed: true })
+
+    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+
+    expect(result.repos).toHaveLength(0)
+    expect(result.licenseFiltered).toBe(0)
+    expect(result.licenseFetchFailed).toBe(1)
+    // Trees enumeration must NOT have been called for this repo
+    expect(mockEnumerateRepoSkillPaths).not.toHaveBeenCalled()
+  })
+
+  it('excludes repos with a non-permissive license and increments licenseFiltered', async () => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    mockFetchRepoLicense.mockResolvedValue({ license: 'GPL-3.0', fetchFailed: false })
+
+    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+
+    expect(result.repos).toHaveLength(0)
+    expect(result.licenseFiltered).toBe(1)
+    expect(mockEnumerateRepoSkillPaths).not.toHaveBeenCalled()
+  })
+})

--- a/scripts/tests/indexer/trees-enumerate.test.ts
+++ b/scripts/tests/indexer/trees-enumerate.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Unit tests for trees-enumerate.ts (SMI-5286 Wave 1a)
+ *
+ * Exercises enumerateRepoSkillPaths through a stubbed fetchSkillPathsFromTree:
+ *   - Ancestor-only denylist: the key false-positive guard (Edit D)
+ *   - Per-repo cap: first N by path-sort + truncatedByCap flag
+ *   - Truncation policy (b): API-truncated tree → EMPTY entries + truncatedByApi flag
+ *   - Happy path: valid entries pass through unchanged
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+
+// ---------------------------------------------------------------------------
+// Mock fetchSkillPathsFromTree (and the rate-limit layer it uses internally)
+// ---------------------------------------------------------------------------
+
+// We need to control what fetchSkillPathsFromTree returns. Because
+// trees-enumerate.ts imports it directly, we mock the whole module.
+const mockFetchSkillPathsFromTree = vi.fn()
+
+vi.mock('../../indexer/trees-search.ts', () => ({
+  fetchSkillPathsFromTree: (...args: unknown[]) => mockFetchSkillPathsFromTree(...args),
+}))
+
+// trees-enumerate.ts does NOT call withRateLimitTracking directly (it delegates
+// to fetchSkillPathsFromTree), so no rate-limit mock is required here.
+
+// Imported AFTER mocks so the SUT binds the stub.
+import { enumerateRepoSkillPaths, type EnumerateTelemetry } from '../../indexer/trees-enumerate.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noTelemetry: RateLimitTelemetry = {} as RateLimitTelemetry
+
+function makeEntry(path: string, blobSha = 'abc123') {
+  return { path, blobSha }
+}
+
+function freshEnumerateTelemetry(): EnumerateTelemetry {
+  return {}
+}
+
+// ---------------------------------------------------------------------------
+// Ancestor-only denylist (Edit D — the key false-positive guard)
+// ---------------------------------------------------------------------------
+
+describe('enumerateRepoSkillPaths — ancestor-only denylist (SMI-5286 Edit D)', () => {
+  beforeEach(() => {
+    mockFetchSkillPathsFromTree.mockReset()
+  })
+
+  /**
+   * Tree contains:
+   *   DROPPED — denylisted word IS an ancestor:
+   *     examples/foo           ← "examples" is ancestor of "foo"
+   *     a/templates/b          ← "templates" is ancestor of "b"
+   *     x/fixtures             ← one segment and it IS the skill's own leaf? No —
+   *                              "fixtures" is the only segment (the leaf), so
+   *                              the rule says: check segments EXCEPT the last.
+   *                              Wait: x/fixtures has two segments ("x","fixtures")
+   *                              — last is "fixtures" (leaf, skipped), first is "x"
+   *                              (not in denylist) → should be KEPT.
+   *     pkg/test               ← "test" is ancestor of nothing (leaf) → KEPT
+   *
+   * Re-reading the spec carefully:
+   *   "examples/foo"         → segments ["examples","foo"] → check [0..-2] = ["examples"] → DROPPED
+   *   "a/templates/b"        → segments ["a","templates","b"] → check ["a","templates"] → DROPPED
+   *   "x/fixtures/SKILL.md" input means skillPath = "x/fixtures"
+   *                          → segments ["x","fixtures"] → check ["x"] → NOT denylist → KEPT
+   *   "pkg/test/SKILL.md"   → skillPath = "pkg/test"
+   *                          → segments ["pkg","test"] → check ["pkg"] → NOT denylist → KEPT
+   *
+   * So for paths the spec task says should be DROPPED:
+   *   examples/foo               → ancestor "examples" → DROPPED
+   *   a/templates/b              → ancestor "templates" → DROPPED
+   *   x/fixtures (one level up)  → need "fixtures" to be an ANCESTOR not the leaf
+   *     → use path "x/fixtures/real" so "fixtures" is an ancestor → DROPPED
+   *   pkg/test (one level up)    → use "test/pkg/real" so "test" is ancestor → DROPPED
+   *
+   * KEPT (denylisted word is the skill's own leaf dir, NOT an ancestor):
+   *   .agents/skills/test-runner        → leaf is "test-runner", ancestors: ".agents","skills"
+   *   .claude/skills/examples-helper    → leaf is "examples-helper", ancestors: ".claude","skills"
+   *   src/real                          → no denylist ancestors
+   */
+  it('drops entries where a denylist word is a strict ANCESTOR dir, keeps entries where it is the leaf or a non-ancestor substring', async () => {
+    // These FOUR should be dropped (denylist word appears as ancestor):
+    const dropped = [
+      makeEntry('examples/foo'), // "examples" is ancestor
+      makeEntry('a/templates/b'), // "templates" is ancestor
+      makeEntry('x/fixtures/real'), // "fixtures" is ancestor
+      makeEntry('test/pkg/real'), // "test" is ancestor
+    ]
+
+    // These THREE should be kept (denylist word is the LEAF or a non-ancestor substring):
+    const kept = [
+      makeEntry('.agents/skills/test-runner'), // leaf = "test-runner", ancestors have no denylist
+      makeEntry('.claude/skills/examples-helper'), // leaf = "examples-helper", no denylist ancestor
+      makeEntry('src/real'), // no denylist word at all
+    ]
+
+    mockFetchSkillPathsFromTree.mockResolvedValue({
+      entries: [...dropped, ...kept],
+      truncated: false,
+    })
+
+    const tel = freshEnumerateTelemetry()
+    const result = await enumerateRepoSkillPaths('owner', 'repo', 'main', noTelemetry, tel)
+
+    // All 3 kept paths survive
+    const paths = result.entries.map((e) => e.path)
+    expect(paths).toContain('.agents/skills/test-runner')
+    expect(paths).toContain('.claude/skills/examples-helper')
+    expect(paths).toContain('src/real')
+
+    // All 4 dropped paths are absent
+    expect(paths).not.toContain('examples/foo')
+    expect(paths).not.toContain('a/templates/b')
+    expect(paths).not.toContain('x/fixtures/real')
+    expect(paths).not.toContain('test/pkg/real')
+
+    expect(result.entries).toHaveLength(3)
+
+    // Telemetry: denylistSkipped = 4
+    expect(tel.denylistSkipped).toBe(4)
+    expect(tel.denylistSkippedSample).toBeDefined()
+    expect(tel.denylistSkippedSample!.length).toBe(4)
+    // Sample entries contain owner/repo:path format
+    expect(tel.denylistSkippedSample![0]).toMatch(/^owner\/repo:/)
+
+    // No cap/truncation
+    expect(result.truncatedByCap).toBe(false)
+    expect(result.truncatedByApi).toBe(false)
+  })
+
+  it('accumulates denylistSkipped across multiple calls into the same telemetry object', async () => {
+    const tel = freshEnumerateTelemetry()
+
+    mockFetchSkillPathsFromTree.mockResolvedValue({
+      entries: [makeEntry('examples/one'), makeEntry('examples/two')],
+      truncated: false,
+    })
+    await enumerateRepoSkillPaths('o', 'r1', 'main', noTelemetry, tel)
+
+    mockFetchSkillPathsFromTree.mockResolvedValue({
+      entries: [makeEntry('templates/three')],
+      truncated: false,
+    })
+    await enumerateRepoSkillPaths('o', 'r2', 'main', noTelemetry, tel)
+
+    expect(tel.denylistSkipped).toBe(3)
+    expect(tel.denylistSkippedSample!.length).toBe(3)
+  })
+
+  it('does not exceed DENYLIST_SAMPLE_LIMIT (20) in the sample even with many drops', async () => {
+    const lotsOfDropped = Array.from({ length: 30 }, (_, i) => makeEntry(`examples/skill-${i}`))
+    mockFetchSkillPathsFromTree.mockResolvedValue({
+      entries: lotsOfDropped,
+      truncated: false,
+    })
+
+    const tel = freshEnumerateTelemetry()
+    await enumerateRepoSkillPaths('o', 'r', 'main', noTelemetry, tel)
+
+    expect(tel.denylistSkipped).toBe(30)
+    // Sample is capped at 20
+    expect(tel.denylistSkippedSample!.length).toBe(20)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Per-repo cap
+// ---------------------------------------------------------------------------
+
+describe('enumerateRepoSkillPaths — per-repo cap', () => {
+  beforeEach(() => {
+    mockFetchSkillPathsFromTree.mockReset()
+  })
+
+  it('with cap=2 and 5 valid entries returns the first 2 by path-sort and sets truncatedByCap', async () => {
+    // Deliberately out of order — path-sort determines which 2 survive
+    const entries = [
+      makeEntry('z/skill'),
+      makeEntry('a/skill'),
+      makeEntry('m/skill'),
+      makeEntry('b/skill'),
+      makeEntry('c/skill'),
+    ]
+    mockFetchSkillPathsFromTree.mockResolvedValue({ entries, truncated: false })
+
+    const tel = freshEnumerateTelemetry()
+    const result = await enumerateRepoSkillPaths('o', 'r', 'main', noTelemetry, tel, 2)
+
+    expect(result.entries).toHaveLength(2)
+    // First two alphabetically
+    expect(result.entries[0].path).toBe('a/skill')
+    expect(result.entries[1].path).toBe('b/skill')
+    expect(result.truncatedByCap).toBe(true)
+    expect(result.truncatedByApi).toBe(false)
+    expect(tel.cappedRepoCount).toBe(1)
+  })
+
+  it('does NOT set truncatedByCap when entry count equals cap exactly', async () => {
+    const entries = [makeEntry('a/skill'), makeEntry('b/skill')]
+    mockFetchSkillPathsFromTree.mockResolvedValue({ entries, truncated: false })
+
+    const tel = freshEnumerateTelemetry()
+    const result = await enumerateRepoSkillPaths('o', 'r', 'main', noTelemetry, tel, 2)
+
+    expect(result.entries).toHaveLength(2)
+    expect(result.truncatedByCap).toBe(false)
+    expect(tel.cappedRepoCount).toBeUndefined()
+  })
+
+  it('uses default cap of 50 when none provided', async () => {
+    const entries = Array.from({ length: 51 }, (_, i) =>
+      makeEntry(`skill-${String(i).padStart(3, '0')}/foo`)
+    )
+    mockFetchSkillPathsFromTree.mockResolvedValue({ entries, truncated: false })
+
+    const tel = freshEnumerateTelemetry()
+    const result = await enumerateRepoSkillPaths('o', 'r', 'main', noTelemetry, tel)
+
+    expect(result.entries).toHaveLength(50)
+    expect(result.truncatedByCap).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Truncation policy (b): API-truncated → EMPTY + truncatedByApi
+// ---------------------------------------------------------------------------
+
+describe('enumerateRepoSkillPaths — truncation policy (b) (SMI-5286 §#4)', () => {
+  beforeEach(() => {
+    mockFetchSkillPathsFromTree.mockReset()
+  })
+
+  it('when Trees API is truncated: entries is EMPTY and truncatedByApi is true (no partial set)', async () => {
+    // Even if the API returned some entries (partial), policy (b) emits none.
+    mockFetchSkillPathsFromTree.mockResolvedValue({
+      entries: [makeEntry('a/skill'), makeEntry('b/skill')],
+      truncated: true,
+    })
+
+    const tel = freshEnumerateTelemetry()
+    const result = await enumerateRepoSkillPaths('o', 'r', 'main', noTelemetry, tel)
+
+    expect(result.entries).toHaveLength(0)
+    expect(result.truncatedByApi).toBe(true)
+    expect(result.truncatedByCap).toBe(false)
+    expect(tel.truncatedRepoCount).toBe(1)
+  })
+
+  it('accumulates truncatedRepoCount across calls', async () => {
+    mockFetchSkillPathsFromTree.mockResolvedValue({
+      entries: [],
+      truncated: true,
+    })
+
+    const tel = freshEnumerateTelemetry()
+    await enumerateRepoSkillPaths('o', 'r1', 'main', noTelemetry, tel)
+    await enumerateRepoSkillPaths('o', 'r2', 'main', noTelemetry, tel)
+
+    expect(tel.truncatedRepoCount).toBe(2)
+  })
+
+  it('when not truncated: truncatedByApi is false and entries are returned normally', async () => {
+    mockFetchSkillPathsFromTree.mockResolvedValue({
+      entries: [makeEntry('foo/bar')],
+      truncated: false,
+    })
+
+    const tel = freshEnumerateTelemetry()
+    const result = await enumerateRepoSkillPaths('o', 'r', 'main', noTelemetry, tel)
+
+    expect(result.truncatedByApi).toBe(false)
+    expect(result.entries).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('enumerateRepoSkillPaths — happy path', () => {
+  beforeEach(() => {
+    mockFetchSkillPathsFromTree.mockReset()
+  })
+
+  it('returns 3 distinct entries with correct path and blobSha from a clean tree', async () => {
+    const entries = [
+      { path: '.agents/skills/foo', blobSha: 'sha1' },
+      { path: '.agents/skills/bar', blobSha: 'sha2' },
+      { path: '.claude/skills/baz', blobSha: 'sha3' },
+    ]
+    mockFetchSkillPathsFromTree.mockResolvedValue({ entries, truncated: false })
+
+    const tel = freshEnumerateTelemetry()
+    const result = await enumerateRepoSkillPaths('o', 'r', 'main', noTelemetry, tel)
+
+    expect(result.entries).toHaveLength(3)
+    expect(result.entries[0]).toEqual({ path: '.agents/skills/foo', blobSha: 'sha1' })
+    expect(result.entries[1]).toEqual({ path: '.agents/skills/bar', blobSha: 'sha2' })
+    expect(result.entries[2]).toEqual({ path: '.claude/skills/baz', blobSha: 'sha3' })
+    expect(result.truncatedByCap).toBe(false)
+    expect(result.truncatedByApi).toBe(false)
+    expect(tel.denylistSkipped).toBeUndefined()
+    expect(tel.cappedRepoCount).toBeUndefined()
+    expect(tel.truncatedRepoCount).toBeUndefined()
+  })
+
+  it('passes owner, repo, branch and telemetry through to fetchSkillPathsFromTree', async () => {
+    mockFetchSkillPathsFromTree.mockResolvedValue({ entries: [], truncated: false })
+
+    const tel = freshEnumerateTelemetry()
+    await enumerateRepoSkillPaths('myorg', 'myrepo', 'develop', noTelemetry, tel)
+
+    expect(mockFetchSkillPathsFromTree).toHaveBeenCalledWith(
+      'myorg',
+      'myrepo',
+      'develop',
+      noTelemetry
+    )
+  })
+})


### PR DESCRIPTION
## SMI-5286 Wave 1a — per-skill collection extraction (the #1 volume lever for SMI-5174 >20k)

Converts the community discovery paths from per-repo 1:1 to **per-skill extraction**: a repo with N valid `*/SKILL.md` now indexes as N distinct rows. Scope is strictly 1a (§#1, §#4, §#6 of the SPARC); §#2/#3/#5 are deferred to 1b/1c.

### Load-bearing fix (C-1)
Each per-skill row carries a distinct `repo_url = ${repoHtmlUrl}/tree/${defaultBranch}/${skillPath}` (mirrors `high-trust-indexer.ts:261`) so N skills in one repo no longer collide on `onConflict:'repo_url'`. **No migration, no `skill-processor.ts:440` change** — validated subdirectory rows are `installable:true` → non-null tree URL (re-confirm finding R-1).

### Changes
- **NEW `scripts/indexer/skill-url.ts`** — pure `buildSkillTreeUrl()`.
- **NEW `scripts/indexer/trees-enumerate.ts`** — `enumerateRepoSkillPaths()`: ancestor-only template/example denylist (keeps `…/test-runner/SKILL.md`), `BACKFILL_MAX_SKILLS_PER_REPO` cap (default 50), truncation policy (b) → a truncated Trees response emits **zero** rows.
- `scripts/indexer/subdirectory-search.ts` — `processSearchResults` per-skill enumeration loop. **Edit E:** only the loop changed; the `:89` dedup/freshness lines are byte-stable for the future SMI-5176 `pushed:` rebase.
- `scripts/indexer/code-search.ts` / `topic-search.ts` — community URL mappers → tree-URL; **§#6 fork guard** (`fork` boolean + skip in all mappers).
- 4 new test files (46 tests) incl. the headline AC: **1 repo × 3 SKILL.md → 3 distinct `repo_url`**.

### Verification
typecheck clean · ESLint 0 errors · `audit:standards` 0 failed / 95% · **398 indexer tests pass** · all changed `.ts` <500 lines · Deno copy `supabase/functions/indexer/*` untouched (SMI-5182).

### Governance (read-only review) — 1 Critical + 4 found, **ALL fixed in the same commit**
- **Critical:** the per-skill URL was built from `repo.url` (already the mapper's tree-URL) → doubled `/tree/<branch>`; C-1 would silently break and the test masked it. Fixed: rebuild from the bare html_url + a no-double-`/tree/` regression assertion.
- High (masking test helper), Medium (redundant dedup key), 2 Low. Report: `docs/internal/code_review/2026-06-18-smi-5286-wave1a-perskill-extraction.md`.

### Out of scope (1b/1c)
`BACKFILL_MODE`, `per_page`→100 / facet partitioning, `indexer-backfill.yml` + checkpoint, the R-2 provenance tag column. **Sub-wave 1c (the live wide crawl) stays gated on the SMI-5176 `pushed:` probe verdict.**

SPARC: `docs/internal/implementation/smi-5286-wave1-backfill-engine-sparc.md` (re-confirm plan-reviewed, GO-FOR-1a). Linear: SMI-5286.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)