### PR TITLE
feat(vscode): McpToolError + tier-denied UX + remove silent mock fallback (SMI-5288)

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -238,6 +238,11 @@
           "type": "string",
           "default": "",
           "description": "Telemetry endpoint URL (leave empty to disable network calls). Events POST here as {event, anonymous_id, metadata}."
+        },
+        "skillsmith.demoMode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show sample/demo skills when the Skillsmith server is unavailable. Off by default; intended for demos and screenshots only."
         }
       }
     }

--- a/packages/vscode-extension/src/__tests__/McpToolError.test.ts
+++ b/packages/vscode-extension/src/__tests__/McpToolError.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { McpToolError } from '../mcp/McpToolError.js'
+
+describe('McpToolError (SMI-5288)', () => {
+  it('sets name, code, and toolName', () => {
+    const err = new McpToolError('search', 'TierDenied', 'requires the Team plan')
+    expect(err.name).toBe('McpToolError')
+    expect(err.code).toBe('TierDenied')
+    expect(err.toolName).toBe('search')
+    expect(err.message).toBe('requires the Team plan')
+  })
+
+  it('is an instance of Error', () => {
+    const err = new McpToolError('get_skill', 'NotConnected', 'MCP client not connected')
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/__tests__/SkillService.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillService.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../services/SkillService.js'
 import type { McpClient } from '../mcp/McpClient.js'
 import type { McpSearchResponse, McpGetSkillResponse } from '../mcp/types.js'
+import { McpToolError } from '../mcp/McpToolError.js'
 import { MOCK_SKILLS } from '../data/mockSkills.js'
 
 /** Create a mock McpClient with optional overrides */
@@ -23,6 +24,9 @@ function createMockClient(
     ...overrides,
   } as unknown as McpClient
 }
+
+/** Demo-mode-on resolver (SMI-5288). */
+const demoOn = () => true
 
 /** Fixture: MCP search response */
 function makeMcpSearchResponse(partial?: Partial<McpSearchResponse>): McpSearchResponse {
@@ -135,37 +139,102 @@ describe('SkillService', () => {
     })
   })
 
-  // --- Fallback behavior ---
+  // --- SMI-5288: demo-only mock + TierDenied rethrow ---
 
-  describe('fallback on disconnect', () => {
-    it('returns mock data + isOffline: true when MCP disconnected', async () => {
+  describe('TierDenied propagation (never mocked)', () => {
+    it('search rethrows McpToolError TierDenied instead of returning mock', async () => {
+      const searchFn = vi
+        .fn()
+        .mockRejectedValue(new McpToolError('search', 'TierDenied', 'requires the Team plan'))
+      const client = createMockClient({ search: searchFn })
+      // demo mode ON to prove TierDenied still wins over the mock branch
+      service = new SkillService(client, demoOn)
+
+      await expect(service.search('governance')).rejects.toMatchObject({
+        code: 'TierDenied',
+      })
+    })
+
+    it('getRichSkill rethrows McpToolError TierDenied instead of returning mock', async () => {
+      const getSkillFn = vi
+        .fn()
+        .mockRejectedValue(new McpToolError('get_skill', 'TierDenied', 'requires the Team plan'))
+      const client = createMockClient({ getSkill: getSkillFn })
+      service = new SkillService(client, demoOn)
+
+      await expect(service.getRichSkill('governance')).rejects.toMatchObject({
+        code: 'TierDenied',
+      })
+    })
+  })
+
+  describe('offline + demo mode OFF (default)', () => {
+    it('search returns empty results + isOffline true when MCP disconnected', async () => {
       const client = createMockClient({ isConnected: () => false })
+      service = new SkillService(client) // demoMode defaults to off
+
+      const { results, isOffline } = await service.search('governance')
+
+      expect(isOffline).toBe(true)
+      expect(results).toEqual([])
+    })
+
+    it('search returns empty on transport error (no mock leak)', async () => {
+      const searchFn = vi.fn().mockRejectedValue(new Error('ECONNRESET'))
+      const client = createMockClient({ search: searchFn })
       service = new SkillService(client)
 
       const { results, isOffline } = await service.search('governance')
 
       expect(isOffline).toBe(true)
+      expect(results).toEqual([])
+    })
+
+    it('getRichSkill throws McpToolError NotConnected when MCP disconnected', async () => {
+      const client = createMockClient({ isConnected: () => false })
+      service = new SkillService(client)
+
+      await expect(service.getRichSkill('governance')).rejects.toMatchObject({
+        code: 'NotConnected',
+        message: 'Skillsmith server unavailable',
+      })
+    })
+
+    it('getRichSkill throws NotConnected on transport error', async () => {
+      const getSkillFn = vi.fn().mockRejectedValue(new Error('network error'))
+      const client = createMockClient({ getSkill: getSkillFn })
+      service = new SkillService(client)
+
+      await expect(service.getRichSkill('governance')).rejects.toBeInstanceOf(McpToolError)
+    })
+  })
+
+  describe('offline + demo mode ON', () => {
+    it('search returns mock data + isOffline true when MCP disconnected', async () => {
+      const client = createMockClient({ isConnected: () => false })
+      service = new SkillService(client, demoOn)
+
+      const { results, isOffline } = await service.search('governance')
+
+      expect(isOffline).toBe(true)
       expect(results.length).toBeGreaterThan(0)
-      // Results come from searchMockSkills
       expect(results.some((s) => s.id === 'governance')).toBe(true)
     })
 
-    it('empty-query fallback returns all MOCK_SKILLS (not empty)', async () => {
+    it('empty-query returns all MOCK_SKILLS in demo mode', async () => {
       const client = createMockClient({ isConnected: () => false })
-      service = new SkillService(client)
+      service = new SkillService(client, demoOn)
 
       const { results, isOffline } = await service.search('')
 
       expect(isOffline).toBe(true)
       expect(results).toHaveLength(MOCK_SKILLS.length)
     })
-  })
 
-  describe('getRichSkill fallback on MCP error', () => {
-    it('returns mock data + isOffline: true when MCP errors', async () => {
+    it('getRichSkill returns mock data + isOffline true in demo mode', async () => {
       const getSkillFn = vi.fn().mockRejectedValue(new Error('network error'))
       const client = createMockClient({ getSkill: getSkillFn })
-      service = new SkillService(client)
+      service = new SkillService(client, demoOn)
 
       const { skill, isOffline } = await service.getRichSkill('governance')
 
@@ -173,35 +242,16 @@ describe('SkillService', () => {
       expect(skill.id).toBe('governance')
       expect(skill.version).toBeUndefined()
     })
-  })
 
-  describe('unknown skill ID fallback', () => {
-    it('returns fallback object with score 0 and unverified tier', async () => {
+    it('getSkill returns fallback (score 0, unverified) for unknown id in demo mode', async () => {
       const client = createMockClient({ isConnected: () => false })
-      service = new SkillService(client)
+      service = new SkillService(client, demoOn)
 
       const skill = await service.getSkill('nonexistent-skill-xyz')
 
       expect(skill.id).toBe('nonexistent-skill-xyz')
       expect(skill.trustTier).toBe('unverified')
       expect(skill.score).toBe(0)
-    })
-  })
-
-  // --- Edge cases ---
-
-  describe('malformed MCP response', () => {
-    it('falls back gracefully without crashing', async () => {
-      const searchFn = vi
-        .fn()
-        .mockRejectedValue(new TypeError('Cannot read properties of undefined'))
-      const client = createMockClient({ search: searchFn })
-      service = new SkillService(client)
-
-      const { results, isOffline } = await service.search('test')
-
-      expect(isOffline).toBe(true)
-      expect(Array.isArray(results)).toBe(true)
     })
   })
 
@@ -238,10 +288,21 @@ describe('SkillService', () => {
   })
 
   describe('connection state transition mid-call', () => {
-    it('falls back gracefully when connection drops during search', async () => {
+    it('returns empty offline result when connection drops during search (demo off)', async () => {
       const searchFn = vi.fn().mockRejectedValue(new Error('MCP server disconnected'))
       const client = createMockClient({ search: searchFn })
       service = new SkillService(client)
+
+      const { results, isOffline } = await service.search('governance')
+
+      expect(isOffline).toBe(true)
+      expect(results).toEqual([])
+    })
+
+    it('falls back to mock when connection drops mid-call in demo mode', async () => {
+      const searchFn = vi.fn().mockRejectedValue(new Error('MCP server disconnected'))
+      const client = createMockClient({ search: searchFn })
+      service = new SkillService(client, demoOn)
 
       const { results, isOffline } = await service.search('governance')
 

--- a/packages/vscode-extension/src/__tests__/mcp/get_skill.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/get_skill.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+import { McpClient } from '../../mcp/McpClient.js'
+import { McpToolError } from '../../mcp/McpToolError.js'
+
+function ok(payload: unknown): Record<string, unknown> {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+}
+
+function isErr(text: string): Record<string, unknown> {
+  return { isError: true, content: [{ type: 'text', text }] }
+}
+
+function connectedClient(raw: unknown): McpClient {
+  const client = new McpClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).status = 'connected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).sendRequest = vi.fn().mockResolvedValue(raw)
+  return client
+}
+
+describe('McpClient.getSkill (SMI-5288)', () => {
+  it('happy path returns the typed McpGetSkillResponse shape', async () => {
+    const response = {
+      skill: {
+        id: 'a/b',
+        name: 'B',
+        description: 'd',
+        author: 'a',
+        category: 'c',
+        trustTier: 'verified',
+        score: 90,
+      },
+      installCommand: 'npx @skillsmith/cli install a/b',
+      timing: { totalMs: 5 },
+    }
+    const client = connectedClient(ok(response))
+
+    const result = await client.getSkill('a/b')
+
+    expect(result.skill.id).toBe('a/b')
+    expect(result.installCommand).toBe('npx @skillsmith/cli install a/b')
+  })
+
+  it('tier-denied isError response throws McpToolError code TierDenied', async () => {
+    const client = connectedClient(isErr('Upgrade required to view this skill'))
+    await expect(client.getSkill('a/b')).rejects.toMatchObject({
+      code: 'TierDenied',
+      toolName: 'get_skill',
+    })
+  })
+
+  it('unknown-tool isError response throws McpToolError code UnknownTool', async () => {
+    const client = connectedClient(isErr('No such tool: get_skill'))
+    await expect(client.getSkill('a/b')).rejects.toMatchObject({ code: 'UnknownTool' })
+  })
+
+  it('calling before connect throws NotConnected with the exact message', async () => {
+    const client = new McpClient()
+    await expect(client.getSkill('a/b')).rejects.toMatchObject({
+      code: 'NotConnected',
+      message: 'MCP client not connected',
+    })
+    await expect(client.getSkill('a/b')).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/__tests__/mcp/install_skill.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/install_skill.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+import { McpClient } from '../../mcp/McpClient.js'
+import { McpToolError } from '../../mcp/McpToolError.js'
+
+function ok(payload: unknown): Record<string, unknown> {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+}
+
+function isErr(text: string): Record<string, unknown> {
+  return { isError: true, content: [{ type: 'text', text }] }
+}
+
+function connectedClient(raw: unknown): McpClient {
+  const client = new McpClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).status = 'connected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).sendRequest = vi.fn().mockResolvedValue(raw)
+  return client
+}
+
+describe('McpClient.installSkill (SMI-5288)', () => {
+  it('happy path returns the typed McpInstallResponse shape', async () => {
+    const response = {
+      success: true,
+      skillId: 'a/b',
+      installPath: '~/.claude/skills/a/b',
+    }
+    const client = connectedClient(ok(response))
+
+    const result = await client.installSkill('a/b')
+
+    expect(result.success).toBe(true)
+    expect(result.installPath).toBe('~/.claude/skills/a/b')
+  })
+
+  it('tier-denied isError response throws McpToolError code TierDenied', async () => {
+    const client = connectedClient(isErr('This action is forbidden on your plan'))
+    await expect(client.installSkill('a/b')).rejects.toMatchObject({
+      code: 'TierDenied',
+      toolName: 'install_skill',
+    })
+  })
+
+  it('unknown-tool isError response throws McpToolError code UnknownTool', async () => {
+    const client = connectedClient(isErr('Unknown tool: install_skill'))
+    await expect(client.installSkill('a/b')).rejects.toMatchObject({ code: 'UnknownTool' })
+  })
+
+  it('calling before connect throws NotConnected with the exact message', async () => {
+    const client = new McpClient()
+    await expect(client.installSkill('a/b')).rejects.toMatchObject({
+      code: 'NotConnected',
+      message: 'MCP client not connected',
+    })
+    await expect(client.installSkill('a/b')).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/__tests__/mcp/search.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/search.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+import { McpClient } from '../../mcp/McpClient.js'
+import { McpToolError } from '../../mcp/McpToolError.js'
+
+/** Wrap a JSON payload in the MCP tools/call success envelope. */
+function ok(payload: unknown): Record<string, unknown> {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+}
+
+/** Build an isError tools/call envelope with the given text. */
+function isErr(text: string): Record<string, unknown> {
+  return { isError: true, content: [{ type: 'text', text }] }
+}
+
+/**
+ * Returns a connected McpClient whose private `sendRequest` resolves to `raw`.
+ * Tests only — reaches into private members via an `any` cast.
+ */
+function connectedClient(raw: unknown): McpClient {
+  const client = new McpClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).status = 'connected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).sendRequest = vi.fn().mockResolvedValue(raw)
+  return client
+}
+
+describe('McpClient.search (SMI-5288)', () => {
+  it('happy path returns the typed McpSearchResponse shape', async () => {
+    const response = {
+      results: [
+        {
+          id: 'a/b',
+          name: 'B',
+          description: 'd',
+          author: 'a',
+          category: 'c',
+          trustTier: 'verified',
+          score: 90,
+        },
+      ],
+      total: 1,
+      query: 'b',
+      filters: {},
+      timing: { searchMs: 1, totalMs: 2 },
+    }
+    const client = connectedClient(ok(response))
+
+    const result = await client.search('b')
+
+    expect(result.total).toBe(1)
+    expect(result.results[0]?.id).toBe('a/b')
+  })
+
+  it('tier-denied isError response throws McpToolError code TierDenied', async () => {
+    const client = connectedClient(isErr('TierDenied: requires the Team plan'))
+    await expect(client.search('b')).rejects.toMatchObject({
+      name: 'McpToolError',
+      code: 'TierDenied',
+      toolName: 'search',
+    })
+  })
+
+  it('unknown-tool isError response throws McpToolError code UnknownTool', async () => {
+    const client = connectedClient(isErr('Unknown tool: search'))
+    await expect(client.search('b')).rejects.toMatchObject({ code: 'UnknownTool' })
+  })
+
+  it('calling before connect throws NotConnected with the exact message', async () => {
+    const client = new McpClient()
+    await expect(client.search('b')).rejects.toMatchObject({
+      code: 'NotConnected',
+      message: 'MCP client not connected',
+    })
+    await expect(client.search('b')).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/__tests__/mcp/uninstall_skill.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/uninstall_skill.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+import { McpClient } from '../../mcp/McpClient.js'
+import { McpToolError } from '../../mcp/McpToolError.js'
+
+function ok(payload: unknown): Record<string, unknown> {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+}
+
+function isErr(text: string): Record<string, unknown> {
+  return { isError: true, content: [{ type: 'text', text }] }
+}
+
+function connectedClient(raw: unknown): McpClient {
+  const client = new McpClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).status = 'connected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).sendRequest = vi.fn().mockResolvedValue(raw)
+  return client
+}
+
+describe('McpClient.uninstallSkill (SMI-5288)', () => {
+  it('happy path returns the typed McpUninstallResponse shape', async () => {
+    const response = { success: true, skillId: 'a/b' }
+    const client = connectedClient(ok(response))
+
+    const result = await client.uninstallSkill('a/b')
+
+    expect(result.success).toBe(true)
+    expect(result.skillId).toBe('a/b')
+  })
+
+  it('tier-denied isError response throws McpToolError code TierDenied', async () => {
+    const client = connectedClient(isErr('denied: requires the Team plan'))
+    await expect(client.uninstallSkill('a/b')).rejects.toMatchObject({
+      code: 'TierDenied',
+      toolName: 'uninstall_skill',
+    })
+  })
+
+  it('unknown-tool isError response throws McpToolError code UnknownTool', async () => {
+    const client = connectedClient(isErr('tool not found'))
+    await expect(client.uninstallSkill('a/b')).rejects.toMatchObject({ code: 'UnknownTool' })
+  })
+
+  it('calling before connect throws NotConnected with the exact message', async () => {
+    const client = new McpClient()
+    await expect(client.uninstallSkill('a/b')).rejects.toMatchObject({
+      code: 'NotConnected',
+      message: 'MCP client not connected',
+    })
+    await expect(client.uninstallSkill('a/b')).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/__tests__/tierDenied.test.ts
+++ b/packages/vscode-extension/src/__tests__/tierDenied.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { showWarningMessage, openExternal, track } = vi.hoisted(() => ({
+  showWarningMessage: vi.fn(),
+  openExternal: vi.fn(),
+  track: vi.fn(),
+}))
+
+vi.mock('vscode', () => ({
+  window: { showWarningMessage },
+  env: { openExternal },
+  Uri: { parse: (s: string) => ({ toString: () => s, __raw: s }) },
+}))
+
+vi.mock('../services/Telemetry.js', () => ({
+  track: (...args: unknown[]) => track(...args),
+}))
+
+import { handleTierDenied, parseRequiredTier } from '../mcp/tierDenied.js'
+import { McpToolError } from '../mcp/McpToolError.js'
+
+describe('parseRequiredTier (SMI-5288)', () => {
+  it('extracts tier name from "requires the Team plan"', () => {
+    expect(parseRequiredTier('TierDenied: requires the Team plan')).toBe('Team')
+  })
+  it('extracts tier name from "requires Enterprise tier"', () => {
+    expect(parseRequiredTier('requires Enterprise tier')).toBe('Enterprise')
+  })
+  it('returns undefined when no tier token present', () => {
+    expect(parseRequiredTier('access denied')).toBeUndefined()
+    expect(parseRequiredTier(undefined)).toBeUndefined()
+  })
+})
+
+describe('handleTierDenied (SMI-5288)', () => {
+  beforeEach(() => {
+    showWarningMessage.mockReset()
+    openExternal.mockReset()
+    track.mockReset()
+  })
+
+  it('emits vscode_tier_denied telemetry with cmd + required_tier', async () => {
+    showWarningMessage.mockResolvedValue(undefined)
+    const err = new McpToolError('install_skill', 'TierDenied', 'requires the Team plan')
+
+    await handleTierDenied('skillsmith.installSkill', err)
+
+    expect(track).toHaveBeenCalledWith('vscode_tier_denied', {
+      cmd: 'skillsmith.installSkill',
+      required_tier: 'Team',
+    })
+  })
+
+  it('shows a warning with Open Billing and Learn more actions', async () => {
+    showWarningMessage.mockResolvedValue(undefined)
+    const err = new McpToolError('install_skill', 'TierDenied', 'requires the Team plan')
+
+    await handleTierDenied('skillsmith.installSkill', err)
+
+    expect(showWarningMessage).toHaveBeenCalledWith(
+      'requires the Team plan',
+      'Open Billing',
+      'Learn more'
+    )
+  })
+
+  it('opens billing URL with ?src=vscode&cmd=<command> on Open Billing', async () => {
+    showWarningMessage.mockResolvedValue('Open Billing')
+    const err = new McpToolError('uninstall_skill', 'TierDenied', 'requires the Team plan')
+
+    await handleTierDenied('skillsmith.uninstallSkill', err)
+
+    expect(openExternal).toHaveBeenCalledTimes(1)
+    const arg = openExternal.mock.calls[0]?.[0] as { toString: () => string }
+    const url = arg.toString()
+    expect(url).toContain('https://skillsmith.app/billing')
+    expect(url).toContain('?src=vscode&cmd=skillsmith.uninstallSkill')
+  })
+
+  it('opens the pricing page on Learn more', async () => {
+    showWarningMessage.mockResolvedValue('Learn more')
+    const err = new McpToolError('search', 'TierDenied', 'requires the Team plan')
+
+    await handleTierDenied('skillsmith.searchSkills', err)
+
+    const arg = openExternal.mock.calls[0]?.[0] as { toString: () => string }
+    expect(arg.toString()).toBe('https://skillsmith.app/pricing')
+  })
+
+  it('does not open anything when the warning is dismissed', async () => {
+    showWarningMessage.mockResolvedValue(undefined)
+    const err = new McpToolError('search', 'TierDenied', 'requires the Team plan')
+
+    await handleTierDenied('skillsmith.searchSkills', err)
+
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a generic message when err.message is empty', async () => {
+    showWarningMessage.mockResolvedValue(undefined)
+    const err = new McpToolError('search', 'TierDenied', '')
+
+    await handleTierDenied('skillsmith.searchSkills', err)
+
+    expect(showWarningMessage).toHaveBeenCalledWith(
+      'This feature requires a higher plan.',
+      'Open Billing',
+      'Learn more'
+    )
+    expect(track).toHaveBeenCalledWith('vscode_tier_denied', {
+      cmd: 'skillsmith.searchSkills',
+      required_tier: undefined,
+    })
+  })
+})

--- a/packages/vscode-extension/src/__tests__/uninstallCommand.test.ts
+++ b/packages/vscode-extension/src/__tests__/uninstallCommand.test.ts
@@ -14,6 +14,8 @@ vi.mock('vscode', () => {
   return {
     window: { showWarningMessage, showErrorMessage, showInformationMessage, showQuickPick },
     commands: { registerCommand },
+    env: { openExternal: vi.fn() },
+    Uri: { parse: (s: string) => ({ toString: () => s }) },
     workspace: {
       getConfiguration: vi.fn(() => ({ get: vi.fn(() => undefined) })),
     },
@@ -180,17 +182,40 @@ describe('uninstallCommand (SMI-4195)', () => {
   })
 
   it('surfaces MCP refusal and does NOT fall back to fs.rm', async () => {
-    // MCP is connected but deliberately refuses (e.g. TierDenied, server-side validation).
+    // MCP is connected but deliberately refuses (server-side validation).
     // The extension must NOT bypass this by deleting via fs.rm.
     showQuickPick.mockResolvedValue({ skillId: 'example-skill', skillPath })
     showWarningMessage.mockResolvedValue('Uninstall')
-    mcpUninstall.mockResolvedValue({ success: false, error: 'TierDenied: requires Team plan' })
+    mcpUninstall.mockResolvedValue({ success: false, error: 'Skill is locked by policy' })
 
     await handler()
 
     expect(showErrorMessage).toHaveBeenCalledWith(
-      expect.stringContaining('TierDenied: requires Team plan')
+      expect.stringContaining('Skill is locked by policy')
     )
+    // Skill directory must still exist — fs.rm was NOT called.
+    await expect(fs.access(skillPath)).resolves.toBeUndefined()
+    expect(showInformationMessage).not.toHaveBeenCalledWith(expect.stringContaining('Uninstalled'))
+  })
+
+  it('routes a TierDenied refusal to the upgrade UX and does NOT fall back to fs.rm', async () => {
+    // SMI-5288: a TierDenied {success:false} payload must show the tier-denied
+    // warning (not the generic error) and must not delete via fs.rm.
+    showQuickPick.mockResolvedValue({ skillId: 'example-skill', skillPath })
+    // First showWarningMessage call = the confirm dialog; second = tierDenied warning.
+    showWarningMessage.mockResolvedValueOnce('Uninstall').mockResolvedValueOnce(undefined)
+    mcpUninstall.mockResolvedValue({ success: false, error: 'TierDenied: requires the Team plan' })
+
+    await handler()
+
+    // The tier-denied warning was shown with the upgrade actions.
+    expect(showWarningMessage).toHaveBeenCalledWith(
+      'TierDenied: requires the Team plan',
+      'Open Billing',
+      'Learn more'
+    )
+    // Generic refusal error must NOT be shown.
+    expect(showErrorMessage).not.toHaveBeenCalled()
     // Skill directory must still exist — fs.rm was NOT called.
     await expect(fs.access(skillPath)).resolves.toBeUndefined()
     expect(showInformationMessage).not.toHaveBeenCalledWith(expect.stringContaining('Uninstalled'))

--- a/packages/vscode-extension/src/commands/installCommand.ts
+++ b/packages/vscode-extension/src/commands/installCommand.ts
@@ -12,10 +12,17 @@ import type { SkillService } from '../services/SkillService.js'
 import { getSkillPath, installSkillLocally } from '../services/installUtils.js'
 import { getTrustTierCodicon, getTrustTierLabel } from '../sidebar/trustTier.js'
 import { getMcpClient } from '../mcp/McpClient.js'
+import { McpToolError } from '../mcp/McpToolError.js'
+import { handleTierDenied } from '../mcp/tierDenied.js'
 import { withTelemetry } from '../services/telemetry-wrap.js'
 
 /** Debounce delay for search input */
 const SEARCH_DEBOUNCE_MS = 300
+
+/** SMI-5288: whether explicit demo mode is enabled. */
+function isDemoModeEnabled(): boolean {
+  return vscode.workspace.getConfiguration('skillsmith').get<boolean>('demoMode', false)
+}
 
 /**
  * Quick pick item with skill data
@@ -79,11 +86,13 @@ async function showQuickInstallPicker(skillService: SkillService): Promise<void>
         const { results, isOffline } = await skillService.search(query)
 
         if (results.length === 0) {
-          if (isOffline) {
+          if (isOffline && !isDemoModeEnabled()) {
+            // SMI-5288: server unavailable and demo mode off — be honest, do
+            // not offer mock/placeholder skills.
             quickPick.items = [
               {
-                label: '$(cloud-offline) No offline results',
-                description: 'Connect to Skillsmith for full search',
+                label: '$(cloud-offline) Skillsmith server unavailable',
+                description: 'Start the Skillsmith MCP server and try again.',
                 alwaysShow: true,
                 skill: null,
               },
@@ -194,6 +203,12 @@ async function installSkillWithProgress(skill: SkillData): Promise<void> {
 
         progress.report({ increment: 100, message: 'Complete!' })
 
+        if (result.tierDeniedHandled) {
+          // SMI-5288: the server refused on tier grounds; the tier-denied UX
+          // (billing/pricing prompt) has already been shown. Do not error.
+          return
+        }
+
         if (result.success) {
           await showInstallSuccess(skill, result)
         } else {
@@ -213,6 +228,8 @@ interface InstallResult {
   installPath: string
   tips: string[] | undefined
   error: string | undefined
+  /** SMI-5288: server refused on tier grounds; tier-denied UX already shown. */
+  tierDeniedHandled?: boolean
 }
 
 /**
@@ -234,13 +251,30 @@ async function performInstall(skill: SkillData): Promise<InstallResult> {
           tips: result.tips,
           error: undefined,
         }
-      } else {
+      }
+
+      // SMI-5288: install_skill returns a structured {success:false} payload
+      // (not an isError response), so callTool never throws for a tier denial.
+      // Detect it here and route to the upgrade UX instead of a generic error.
+      if (/^TierDenied/i.test(result.error ?? '')) {
+        await handleTierDenied(
+          'skillsmith.installSkill',
+          new McpToolError('install_skill', 'TierDenied', result.error!)
+        )
         return {
           success: false,
-          installPath: result.installPath || '',
+          installPath: '',
           tips: undefined,
           error: result.error,
+          tierDeniedHandled: true,
         }
+      }
+
+      return {
+        success: false,
+        installPath: result.installPath || '',
+        tips: undefined,
+        error: result.error,
       }
     } catch (error) {
       console.warn('[Skillsmith] MCP install failed, falling back to local:', error)

--- a/packages/vscode-extension/src/commands/searchSkills.ts
+++ b/packages/vscode-extension/src/commands/searchSkills.ts
@@ -12,6 +12,11 @@ interface SearchSkillsDeps {
   skillService: SkillService
 }
 
+/** SMI-5288: whether explicit demo mode is enabled. */
+function isDemoModeEnabled(): boolean {
+  return vscode.workspace.getConfiguration('skillsmith').get<boolean>('demoMode', false)
+}
+
 // SMI-5130: extracted from the inline registerCommand closure so withTelemetry
 // can wrap it at the export boundary (telemetry coverage gate). Deps that the
 // closure captured are threaded in explicitly.
@@ -66,7 +71,18 @@ async function searchSkillsImpl(deps: SearchSkillsDeps): Promise<void> {
 
         progress.report({ increment: 100 })
 
+        const demoMode = isDemoModeEnabled()
+
         if (results.length === 0) {
+          // SMI-5288: offline + empty + not demo means the server is
+          // unavailable — be honest instead of showing a fake catalog.
+          if (isOffline && !demoMode) {
+            vscode.window.showWarningMessage(
+              'Skillsmith server unavailable — start the Skillsmith MCP server and try again.'
+            )
+            searchProvider.clearResults()
+            return
+          }
           const noResultsMsg = trimmedQuery
             ? `No skills found for "${trimmedQuery}"`
             : 'No skills found'
@@ -76,7 +92,8 @@ async function searchSkillsImpl(deps: SearchSkillsDeps): Promise<void> {
         }
 
         const label = trimmedQuery || 'all skills'
-        const displayLabel = isOffline ? `${label} (Offline)` : label
+        // SMI-5288: non-empty offline results only happen in demo mode now.
+        const displayLabel = isOffline && demoMode ? `${label} (Demo)` : label
         searchProvider.setResults(results, displayLabel)
 
         // Focus on search results view

--- a/packages/vscode-extension/src/commands/uninstallCommand.ts
+++ b/packages/vscode-extension/src/commands/uninstallCommand.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode'
 import * as fs from 'node:fs/promises'
 import { getMcpClient } from '../mcp/McpClient.js'
+import { McpToolError } from '../mcp/McpToolError.js'
+import { handleTierDenied } from '../mcp/tierDenied.js'
 import { getSkillsDirectory } from '../services/installUtils.js'
 import { track } from '../services/Telemetry.js'
 import { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
@@ -79,6 +81,16 @@ async function uninstallCommandImpl(
       if (!result.success) {
         // MCP is reachable and deliberately refused — surface this, do NOT fall back to
         // fs.rm. Falling back would bypass server-side enforcement (e.g. tier-gated ops).
+        // SMI-5288: a TierDenied refusal arrives as a structured {success:false}
+        // payload (not an isError throw), so route it to the upgrade UX.
+        if (/^TierDenied/i.test(result.error ?? '')) {
+          track('vscode_uninstall_failed', { via, reason: 'tier_denied' })
+          await handleTierDenied(
+            'skillsmith.uninstallSkill',
+            new McpToolError('uninstall_skill', 'TierDenied', result.error!)
+          )
+          return
+        }
         const reason = result.error ?? 'MCP server refused the uninstall request'
         track('vscode_uninstall_failed', { via, reason: 'mcp_refused' })
         void vscode.window.showErrorMessage(`Failed to uninstall "${pick.skillId}": ${reason}`)

--- a/packages/vscode-extension/src/data/mockSkills.ts
+++ b/packages/vscode-extension/src/data/mockSkills.ts
@@ -1,7 +1,8 @@
 /**
- * Fallback skill data for offline/disconnected mode
+ * Sample skill data for demo/training mode only (gated by skillsmith.demoMode).
  * Primary data comes from the Skillsmith API via SkillService + McpClient.
- * This module provides fallback data when the MCP server is unavailable.
+ * SMI-5288: this is NOT a silent offline fallback — it is returned only when
+ * explicit demo mode is enabled, for demos and screenshots.
  *
  * The SkillData interface is defined in types/skill.ts and re-exported here
  * for backwards compatibility.
@@ -50,7 +51,7 @@ export const MOCK_SKILLS: SkillData[] = [
     description: 'Automatically generates unit tests for your code using AI.',
     author: 'skillsmith',
     category: 'testing',
-    trustTier: 'standard',
+    trustTier: 'curated',
     score: 85,
     repository: 'https://github.com/skillsmith/test-generator-skill',
   },

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -49,8 +49,12 @@ export function activate(context: vscode.ExtensionContext): void {
   // Initialize MCP client with configuration from settings
   initializeMcpClientFromSettings()
 
-  // Create centralized SkillService
-  const skillService = new SkillService(getMcpClient())
+  // Create centralized SkillService. SMI-5288: mock data is demo-only — the
+  // demoMode resolver gates whether sample skills are shown when the server is
+  // unavailable.
+  const skillService = new SkillService(getMcpClient(), () =>
+    vscode.workspace.getConfiguration('skillsmith').get<boolean>('demoMode', false)
+  )
   SkillDetailPanel.setSkillService(skillService)
 
   // Initialize providers

--- a/packages/vscode-extension/src/mcp/McpClient.ts
+++ b/packages/vscode-extension/src/mcp/McpClient.ts
@@ -15,6 +15,7 @@ import {
   type McpUninstallResponse,
   DEFAULT_MCP_CONFIG,
 } from './types.js'
+import { McpToolError, type McpToolErrorCode } from './McpToolError.js'
 
 // Re-export McpClientConfig from types for external use
 export type { McpClientConfig } from './types.js'
@@ -44,6 +45,21 @@ interface JsonRpcResponse {
     message: string
     data?: unknown
   }
+}
+
+/**
+ * SMI-5288: Classify the text of an `isError` MCP tool response into an
+ * `McpToolErrorCode`. Tier/plan denials and unknown-tool errors get specific
+ * codes so command handlers can branch without string-matching messages.
+ */
+function classifyIsErrorText(errorText: string): McpToolErrorCode {
+  if (/tier|plan|denied|forbidden|upgrade/i.test(errorText)) {
+    return 'TierDenied'
+  }
+  if (/unknown tool|not found|no such tool/i.test(errorText)) {
+    return 'UnknownTool'
+  }
+  return 'Unknown'
 }
 
 /**
@@ -322,7 +338,7 @@ export class McpClient {
    */
   private async callTool<T>(name: string, args: Record<string, unknown>): Promise<T> {
     if (this.status !== 'connected') {
-      throw new Error('MCP client not connected')
+      throw new McpToolError(name, 'NotConnected', 'MCP client not connected')
     }
 
     const raw = await this.sendRequest('tools/call', {
@@ -332,28 +348,38 @@ export class McpClient {
 
     const result = raw as Record<string, unknown> | null | undefined
     if (!result || typeof result !== 'object') {
-      throw new Error(`Invalid MCP response: expected object, got ${typeof raw}`)
+      throw new McpToolError(
+        name,
+        'InvalidResponse',
+        `Invalid MCP response: expected object, got ${typeof raw}`
+      )
     }
 
     const content = result['content']
     if (!Array.isArray(content) || content.length === 0) {
-      throw new Error('Invalid MCP response: missing or empty content array')
+      throw new McpToolError(
+        name,
+        'InvalidResponse',
+        'Invalid MCP response: missing or empty content array'
+      )
     }
 
     if (result['isError']) {
       const errorText = (content[0] as { text?: string })?.text || 'Unknown error'
-      throw new Error(errorText)
+      throw new McpToolError(name, classifyIsErrorText(errorText), errorText)
     }
 
     const text = (content[0] as { text?: string })?.text
     if (!text) {
-      throw new Error('Empty response from MCP server')
+      throw new McpToolError(name, 'InvalidResponse', 'Empty response from MCP server')
     }
 
     try {
       return JSON.parse(text) as T
     } catch (parseError) {
-      throw new Error(
+      throw new McpToolError(
+        name,
+        'InvalidResponse',
         `Failed to parse MCP response as JSON: ${parseError instanceof Error ? parseError.message : 'unknown error'}`
       )
     }

--- a/packages/vscode-extension/src/mcp/McpToolError.ts
+++ b/packages/vscode-extension/src/mcp/McpToolError.ts
@@ -1,0 +1,22 @@
+/**
+ * Structured error thrown by `McpClient.callTool` on any non-success MCP
+ * response (SMI-5288). Command-level handlers branch on `.code` instead of
+ * string-matching `.message` — see McpClient.patterns.md § 3.
+ */
+export type McpToolErrorCode =
+  | 'TierDenied'
+  | 'UnknownTool'
+  | 'NotConnected'
+  | 'InvalidResponse'
+  | 'Unknown'
+
+export class McpToolError extends Error {
+  constructor(
+    public readonly toolName: string,
+    public readonly code: McpToolErrorCode,
+    message: string
+  ) {
+    super(message)
+    this.name = 'McpToolError'
+  }
+}

--- a/packages/vscode-extension/src/mcp/tierDenied.ts
+++ b/packages/vscode-extension/src/mcp/tierDenied.ts
@@ -1,0 +1,46 @@
+/**
+ * Tier-denied UX handler (SMI-5288) implementing vscode-mcp-parity Design
+ * Principle 3: when an MCP tool refuses an action because the caller's plan is
+ * too low, surface a warning with a path to upgrade rather than silently
+ * failing or falling back to mock data.
+ */
+import * as vscode from 'vscode'
+import type { McpToolError } from './McpToolError.js'
+import { track } from '../services/Telemetry.js'
+
+/**
+ * Parse a tier name out of a tier-denied error message, e.g.
+ * "requires the Team plan" → "Team". Returns `undefined` when no tier token is
+ * present.
+ */
+export function parseRequiredTier(message: string | undefined): string | undefined {
+  if (!message) return undefined
+  const match = /requires (?:the )?(\w+) (?:plan|tier)/i.exec(message)
+  return match ? match[1] : undefined
+}
+
+/**
+ * Show the tier-denied warning and route the user to billing or pricing.
+ * Always emits the `vscode_tier_denied` telemetry event.
+ */
+export async function handleTierDenied(command: string, err: McpToolError): Promise<void> {
+  const requiredTier = parseRequiredTier(err.message)
+  track('vscode_tier_denied', { cmd: command, required_tier: requiredTier })
+
+  const choice = await vscode.window.showWarningMessage(
+    err.message || 'This feature requires a higher plan.',
+    'Open Billing',
+    'Learn more'
+  )
+
+  if (choice === 'Open Billing') {
+    await vscode.env.openExternal(
+      vscode.Uri.parse(
+        'https://skillsmith.app/billing?src=vscode&cmd=' + encodeURIComponent(command)
+      )
+    )
+  } else if (choice === 'Learn more') {
+    // `packages/website/src/pages/pricing.astro` exists → use /pricing.
+    await vscode.env.openExternal(vscode.Uri.parse('https://skillsmith.app/pricing'))
+  }
+}

--- a/packages/vscode-extension/src/services/SkillService.ts
+++ b/packages/vscode-extension/src/services/SkillService.ts
@@ -1,9 +1,18 @@
 /**
- * Centralized skill data service with MCP-first + mock fallback
+ * Centralized skill data service (SMI-5288).
+ *
+ * MCP-first. Mock data is no longer a silent offline fallback in the live
+ * product — it is returned ONLY when explicit demo mode is enabled
+ * (`skillsmith.demoMode`, resolved via the injected `demoMode` callback). When
+ * the server is unavailable and demo mode is off, search returns empty results
+ * and `getRichSkill` throws so the UI can show an honest "server unavailable"
+ * state. Tier-denied errors always propagate (never mocked).
+ *
  * Accepts McpClient via constructor injection for testability.
  */
 import type { McpClient } from '../mcp/McpClient.js'
 import type { McpSkillSearchResult, McpGetSkillResponse } from '../mcp/types.js'
+import { McpToolError } from '../mcp/McpToolError.js'
 import {
   MOCK_SKILLS,
   getSkillById as getMockSkillById,
@@ -33,11 +42,18 @@ export class SkillService {
   private searchCache = new Map<string, CacheEntry>()
   private static readonly CACHE_TTL_MS = 60_000
 
-  constructor(private readonly client: McpClient) {}
+  constructor(
+    private readonly client: McpClient,
+    // SMI-5288: resolves whether explicit demo mode is on. Defaults to off so
+    // mock data never leaks into the live product unless the caller opts in.
+    private readonly demoMode: () => boolean = () => false
+  ) {}
 
   /**
-   * Search for skills. MCP-first with mock fallback.
-   * Empty query returns all mock skills in fallback mode.
+   * Search for skills. MCP-first. Mock data is returned only in demo mode.
+   * - TierDenied errors propagate (never mocked).
+   * - Other errors / not-connected: demo mode returns mock (empty query → all
+   *   MOCK_SKILLS, browse-all); otherwise returns an empty offline result.
    */
   async search(
     query: string,
@@ -56,17 +72,30 @@ export class SkillService {
         this.searchCache.set(cacheKey, { results, timestamp: Date.now() })
         return { results, isOffline: false }
       } catch (error) {
-        console.warn('[Skillsmith] MCP search failed, using fallback:', error)
+        // Tier denial must never be masked by mock data — let the command
+        // surface the upgrade UX.
+        if (error instanceof McpToolError && error.code === 'TierDenied') {
+          throw error
+        }
+        console.warn('[Skillsmith] MCP search failed:', error)
       }
     }
 
-    // Fallback: empty query returns all mock skills (browse-all mode)
-    const results = query ? searchMockSkills(query) : [...MOCK_SKILLS]
-    return { results, isOffline: true }
+    // Server unavailable (or transport error). Mock is demo-only now.
+    if (this.demoMode()) {
+      // Demo mode: empty query returns all mock skills (browse-all mode)
+      const results = query ? searchMockSkills(query) : [...MOCK_SKILLS]
+      return { results, isOffline: true }
+    }
+    return { results: [], isOffline: true }
   }
 
   /**
-   * Get rich skill details (ExtendedSkillData) with MCP-first fallback.
+   * Get rich skill details (ExtendedSkillData). MCP-first.
+   * - TierDenied errors propagate (never mocked).
+   * - Other errors / not-connected: demo mode returns mock; otherwise throws
+   *   `McpToolError(NotConnected)` since `skill` is non-nullable and an empty
+   *   skill is not representable.
    */
   async getRichSkill(skillId: string): Promise<RichSkillResult> {
     if (this.client.isConnected()) {
@@ -74,21 +103,28 @@ export class SkillService {
         const response = await this.client.getSkill(skillId)
         return { skill: mapSkillDetailsToExtendedSkillData(response), isOffline: false }
       } catch (error) {
-        console.warn('[Skillsmith] MCP get_skill failed, using fallback:', error)
+        if (error instanceof McpToolError && error.code === 'TierDenied') {
+          throw error
+        }
+        console.warn('[Skillsmith] MCP get_skill failed:', error)
       }
     }
 
-    const mock = getMockSkillById(skillId)
-    return {
-      skill: {
-        ...mock,
-        version: undefined,
-        tags: undefined,
-        installCommand: undefined,
-        scoreBreakdown: undefined,
-      },
-      isOffline: true,
+    // Mock is demo-only now.
+    if (this.demoMode()) {
+      const mock = getMockSkillById(skillId)
+      return {
+        skill: {
+          ...mock,
+          version: undefined,
+          tags: undefined,
+          installCommand: undefined,
+          scoreBreakdown: undefined,
+        },
+        isOffline: true,
+      }
     }
+    throw new McpToolError('get_skill', 'NotConnected', 'Skillsmith server unavailable')
   }
 
   /**


### PR DESCRIPTION
> **Stacked on #1475** (`vscode/smi-5289-5290-provider-cleanup`) — shares `installCommand.ts`. Base will be retargeted to `main` after #1475 merges. Review the [compare view](https://github.com/smith-horn/skillsmith/compare/vscode/smi-5289-5290-provider-cleanup...vscode/smi-5288-mcp-error-infra) for this PR's own diff.

## What & why

Two things, both flagged in the VS Code UX assessment (Gaps §1) / SMI-5287:

**1. Error infrastructure (Epic D prerequisite — Blocker).** No Epic D MCP wrapper can ship correctly without it.
- `McpToolError {toolName, code, message}` (codes: `TierDenied | UnknownTool | NotConnected | InvalidResponse | Unknown`).
- `callTool` throws `McpToolError` at every site (`classifyIsErrorText` maps `isError` text → code); `'MCP client not connected'` preserved verbatim.
- `tierDenied.ts` `handleTierDenied()` — Design Principle 3: **Open Billing** (`billing?src=vscode&cmd=<cmd>`) / **Learn more** (`/pricing`) + emits the previously-declared-but-unused `vscode_tier_denied` telemetry (`cmd` + `required_tier`).
- install/uninstall classify the **structured** `{success:false, error:'TierDenied…'}` payload (which `callTool` returns as *success*) and route to the upgrade UX; uninstall keeps its no-`fs.rm`-on-refusal guarantee.
- Seeds the `src/__tests__/mcp/<tool>.test.ts` convention + `McpToolError`/`tierDenied` unit tests.

**2. Remove the silent mock-data fallback** (owner decision — no mock in a live product unless demo/training).
- New `skillsmith.demoMode` setting (default **off**); `MOCK_SKILLS` is now demo-only.
- `SkillService` rethrows `TierDenied` (never mocks it); offline + demo-off → `search` returns empty, `getRichSkill` throws `NotConnected`.
- Honest "Skillsmith server unavailable" empty-state in search + install picker; detail panel shows the unavailable error instead of a fake skill page.
- `mockSkills.ts`: demo-only header; fixed bogus `trustTier:'standard'` data → `'curated'` (deferred here from #1475).

## Verification

29 test files / **380 tests** green; `tsc`/`eslint`/`build`/`audit:standards` clean. All files <500 (McpClient.ts 490 — watch). Review: `docs/internal/code_review/2026-06-17-vscode-mcptoolerror-mock-removal.md`. Canonical telemetry/UX refs in ADR-121 + `vscode-mcp-parity.md`.

SMI-5288