### PR TITLE
fix(indexer): repo-search created:>→pushed:> + remove tokenized code-search qualifier (SMI-5176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Indexer freshness qualifier** (SMI-5176): repo-search freshness window now
+  uses `pushed:>DATE` instead of `created:>DATE` — `pushed:>` matches repos
+  with recent push activity (5–7× wider universe per topic) whereas `created:>`
+  only matched newly-created repos, permanently excluding long-lived skills.
+  GitHub code-search tokenizes date qualifiers as free-text content rather than
+  filtering by date; the broken `created:>` qualifier has been removed from both
+  `searchCodeForSkillMd` and `searchCodeForSkillMdInSubdirectory` (code search
+  is env-gated off in the production cron; removal unblocks future re-enablement
+  without misleading filtering). Added contract tests asserting the exact
+  qualifier strings emitted in fetch URLs for each search type.
+
 ### Added
 
 - **Vendor-Org Trust Tier** (2026-05-02, SMI-4651): GitHub-verified vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Indexer freshness qualifier** (SMI-5176): repo-search freshness window now
-  uses `pushed:>DATE` instead of `created:>DATE` — `pushed:>` matches repos
-  with recent push activity (5–7× wider universe per topic) whereas `created:>`
-  only matched newly-created repos, permanently excluding long-lived skills.
-  GitHub code-search tokenizes date qualifiers as free-text content rather than
-  filtering by date; the broken `created:>` qualifier has been removed from both
-  `searchCodeForSkillMd` and `searchCodeForSkillMdInSubdirectory` (code search
-  is env-gated off in the production cron; removal unblocks future re-enablement
-  without misleading filtering). Added contract tests asserting the exact
-  qualifier strings emitted in fetch URLs for each search type.
-
 ### Added
 
 - **Vendor-Org Trust Tier** (2026-05-02, SMI-4651): GitHub-verified vendor
@@ -119,6 +106,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Indexer freshness qualifier** (SMI-5176): repo-search freshness window now
+  uses `pushed:>DATE` instead of `created:>DATE` — `pushed:>` matches repos
+  with recent push activity (5–7× wider universe per topic) whereas `created:>`
+  only matched newly-created repos, permanently excluding long-lived skills.
+  GitHub code-search tokenizes date qualifiers as free-text content rather than
+  filtering by date; the broken `created:>` qualifier has been removed from both
+  `searchCodeForSkillMd` and `searchCodeForSkillMdInSubdirectory` (code search
+  is env-gated off in the production cron; removal unblocks future re-enablement
+  without misleading filtering). Added contract tests asserting the exact
+  qualifier strings emitted in fetch URLs for each search type.
 - **`skills-search` omits category + security fields** (SMI-4251): the
   `skills-search` edge function projected neither the `skill_categories` join
   nor the migration-039 security columns (`security_score`, `last_scanned_at`,

--- a/scripts/indexer/code-search.ts
+++ b/scripts/indexer/code-search.ts
@@ -76,24 +76,13 @@ const RETRY_DELAYS = [1000, 2000, 4000]
 export async function searchCodeForSkillMd(
   page: number,
   perPage = 30,
-  createdAfter: string | undefined,
   telemetry: RateLimitTelemetry
 ): Promise<{ repos: GitHubRepository[]; total: number; retries: number; error?: string }> {
-  // SMI-2576: Validate date format before URL construction
-  if (createdAfter && !/^\d{4}-\d{2}-\d{2}$/.test(createdAfter)) {
-    return {
-      repos: [],
-      total: 0,
-      retries: 0,
-      error: `Invalid date format: ${sanitizeForLog(createdAfter)}`,
-    }
-  }
-
-  // Build query: find root-level SKILL.md files
-  let queryStr = 'filename:SKILL.md path:/'
-  if (createdAfter) {
-    queryStr += ` created:>${createdAfter}`
-  }
+  // Build query: find root-level SKILL.md files.
+  // SMI-5176: date qualifiers (created:>/pushed:>) are NOT functional on GitHub
+  // code search — they are tokenized as free-text content, crushing results to
+  // files that literally contain the date string. No freshness qualifier here.
+  const queryStr = 'filename:SKILL.md path:/'
   const query = encodeURIComponent(queryStr)
   const url = `https://api.github.com/search/code?q=${query}&per_page=${perPage}&page=${page}`
 
@@ -227,7 +216,6 @@ export async function searchCodeForSkillMdInSubdirectory(
   pathPrefix: string | undefined,
   page: number,
   perPage = 30,
-  createdAfter: string | undefined,
   telemetry: RateLimitTelemetry
 ): Promise<{
   repos: GitHubRepository[]
@@ -236,17 +224,6 @@ export async function searchCodeForSkillMdInSubdirectory(
   incomplete_results: boolean
   error?: string
 }> {
-  // SMI-2576: Validate date format before URL construction
-  if (createdAfter && !/^\d{4}-\d{2}-\d{2}$/.test(createdAfter)) {
-    return {
-      repos: [],
-      total: 0,
-      retries: 0,
-      incomplete_results: false,
-      error: `Invalid date format: ${sanitizeForLog(createdAfter)}`,
-    }
-  }
-
   // Reject path prefixes with leading/trailing slashes to match DB CHECK constraint
   if (pathPrefix && (pathPrefix.startsWith('/') || pathPrefix.endsWith('/'))) {
     return {
@@ -258,11 +235,10 @@ export async function searchCodeForSkillMdInSubdirectory(
     }
   }
 
-  // Build query: broad (no path constraint) or scoped to pathPrefix
-  let queryStr = pathPrefix ? `filename:SKILL.md path:${pathPrefix}` : 'filename:SKILL.md'
-  if (createdAfter) {
-    queryStr += ` created:>${createdAfter}`
-  }
+  // Build query: broad (no path constraint) or scoped to pathPrefix.
+  // SMI-5176: date qualifiers (created:>/pushed:>) are NOT functional on GitHub
+  // code search — they are tokenized as free-text content. No freshness qualifier.
+  const queryStr = pathPrefix ? `filename:SKILL.md path:${pathPrefix}` : 'filename:SKILL.md'
   const query = encodeURIComponent(queryStr)
   const url = `https://api.github.com/search/code?q=${query}&per_page=${perPage}&page=${page}`
 

--- a/scripts/indexer/discovery-orchestrator.ts
+++ b/scripts/indexer/discovery-orchestrator.ts
@@ -119,10 +119,9 @@ export interface RunDiscoveryParams {
   discoveryPhase?: DiscoveryPhase
   /**
    * SMI-5286 Wave 1b (§#2): out-of-band backfill mode. When true the freshness
-   * window is dropped (`freshnessDate = undefined`, an un-windowed scan — a
-   * no-op qualifier the downstream `createdAfter: string | undefined` chain
-   * already accepts) and the Phase-6 stale sweep is skipped (a partial crawl
-   * must not quarantine real skills). Default false → byte-identical cron path.
+   * window is dropped (`freshnessDate = undefined`, an un-windowed scan) and
+   * the Phase-6 stale sweep is skipped (a partial crawl must not quarantine
+   * real skills). Default false → byte-identical cron path.
    */
   backfillMode?: boolean
 }
@@ -251,8 +250,11 @@ export async function runDiscovery(params: RunDiscoveryParams): Promise<IndexerR
 
   // ── Phase 2: Topic search ────────────────────────────────────────────
   // Freshness targeting on discovery runs (maintenance branch never reaches
-  // here). SMI-5286 Wave 1b (§#2): backfill mode → `undefined` (un-windowed);
-  // the `createdAfter: string | undefined` chain treats falsy as "no qualifier".
+  // here). SMI-5286 Wave 1b (§#2): backfill mode → `undefined` (un-windowed).
+  // SMI-5176: freshnessDate flows ONLY into runTopicSearchPhase → searchRepositories
+  // (repo search) where it emits a pushed:> qualifier — repo search honors it.
+  // Code search (Phase 3a/3b) receives no freshness param: GitHub code search
+  // tokenizes date qualifiers as free-text content (SMI-5176 probe verdict).
   const freshnessDate: string | undefined = backfillMode
     ? undefined
     : new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
@@ -286,13 +288,13 @@ export async function runDiscovery(params: RunDiscoveryParams): Promise<IndexerR
   result.found = highTrustSkillMap.size + topicSearchFound
 
   // ── Phase 3a: Code search for root-level SKILL.md ────────────────────
-  // SMI-4861 Wave 1 / SMI-4859: env-gated default OFF. Phase 3a has produced
-  // 0 new repos for 25+ consecutive days (RCA confirms Phase 1/2 dedup
-  // already covers every candidate). Re-enable via
-  // SKILLSMITH_ENABLE_CODE_SEARCH=true. Pattern mirrors Phase 3b at :230 —
-  // direct process.env read, NOT threaded through IndexerEnv (would be a
-  // separate refactor of parse-env.ts covering both phases).
-  // SMI-4870: only the phase-3 sub-slot (or the legacy path) runs code search.
+  // SMI-4861 / SMI-4859: env-gated default OFF. Prior "0 new repos" signal was
+  // a bug artifact — the created:> qualifier was tokenized as free-text (SMI-5176
+  // removed it). Re-enable via SKILLSMITH_ENABLE_CODE_SEARCH=true.
+  // WARNING (SMI-5296): re-enabling for INCREMENTAL runs ships with NO freshness
+  // windowing — GitHub code search has no functional date qualifier. Design the
+  // pushed_at post-filter (SMI-5296) before flipping this flag.
+  // SMI-4870: only the phase-3 sub-slot (or legacy path) runs code search.
   if (runPhase3 && process.env.SKILLSMITH_ENABLE_CODE_SEARCH === 'true') {
     try {
       const {
@@ -303,7 +305,6 @@ export async function runDiscovery(params: RunDiscoveryParams): Promise<IndexerR
         skipGateHits,
       } = await runCodeSearch(
         seenUrls,
-        freshnessDate,
         validationCache,
         validationOptions,
         codeSearchMaxPages,
@@ -338,7 +339,6 @@ export async function runDiscovery(params: RunDiscoveryParams): Promise<IndexerR
     try {
       const subdirResult = await runSubdirectorySearch(
         seenUrls,
-        freshnessDate,
         validationCache,
         validationOptions,
         codeSearchMaxPages,

--- a/scripts/indexer/indexer-runners.codesearch.ts
+++ b/scripts/indexer/indexer-runners.codesearch.ts
@@ -50,7 +50,6 @@ import type { GitHubRepository } from './topic-search.ts'
  */
 export async function runCodeSearch(
   seenUrls: Set<string>,
-  freshnessDate: string | undefined,
   validationCache: Map<string, SkillMdValidation>,
   validationOptions: { strictValidation?: boolean; minContentLength?: number },
   maxPages: number,
@@ -70,7 +69,7 @@ export async function runCodeSearch(
   let skipGateHits = 0
 
   for (let page = 1; page <= maxPages; page++) {
-    const codeResult = await searchCodeForSkillMd(page, 30, freshnessDate, telemetry)
+    const codeResult = await searchCodeForSkillMd(page, 30, telemetry)
     retries += codeResult.retries
     if (codeResult.error) {
       error = codeResult.error

--- a/scripts/indexer/phases/topic-search.ts
+++ b/scripts/indexer/phases/topic-search.ts
@@ -24,8 +24,10 @@ export interface TopicSearchPhaseParams {
   maxPages: number
   maxTopicRepos: number
   // SMI-5286 Wave 1b (§#2): `undefined` in backfill mode (un-windowed scan).
-  // `searchRepositories` accepts `createdAfter: string | undefined` and treats
-  // falsy as "no `created:>` qualifier", so this is a pass-through no-op.
+  // SMI-5176: `searchRepositories` now accepts `pushedAfter: string | undefined`
+  // and emits a `pushed:>` qualifier (not `created:>`) on repo search when set.
+  // Callers pass positionally — this field name is the orchestrator's generic
+  // `freshnessDate` variable; the rename is local to topic-search.ts.
   freshnessDate: string | undefined
   seenUrls: Set<string>
   repositories: GitHubRepository[]

--- a/scripts/indexer/subdirectory-search.ts
+++ b/scripts/indexer/subdirectory-search.ts
@@ -218,7 +218,6 @@ async function processSearchResults(
  * SMI-4852: Threads `telemetry` through to every downstream GitHub call.
  *
  * @param seenUrls - Shared deduplication set from the indexer (modified in place)
- * @param freshnessDate - ISO date string for freshness targeting (or undefined for full scan)
  * @param validationCache - Request-scoped SKILL.md validation cache
  * @param validationOptions - Strict validation and minimum content length options
  * @param maxPages - Maximum pages per query (capped by caller)
@@ -226,7 +225,6 @@ async function processSearchResults(
  */
 export async function runSubdirectorySearch(
   seenUrls: Set<string>,
-  freshnessDate: string | undefined,
   validationCache: Map<string, SkillMdValidation>,
   validationOptions: { strictValidation?: boolean; minContentLength?: number },
   maxPages: number,
@@ -262,7 +260,6 @@ export async function runSubdirectorySearch(
       undefined, // no pathPrefix → broad query
       page,
       30,
-      freshnessDate,
       telemetry
     )
 
@@ -310,13 +307,7 @@ export async function runSubdirectorySearch(
       console.log(`[BroadDiscovery] Fallback searching path:${pathPrefix}...`)
 
       for (let page = 1; page <= maxPages; page++) {
-        const result = await searchCodeForSkillMdInSubdirectory(
-          pathPrefix,
-          page,
-          30,
-          freshnessDate,
-          telemetry
-        )
+        const result = await searchCodeForSkillMdInSubdirectory(pathPrefix, page, 30, telemetry)
 
         totalRetries += result.retries
 

--- a/scripts/indexer/topic-search.ts
+++ b/scripts/indexer/topic-search.ts
@@ -118,7 +118,7 @@ export async function searchRepositories(
   topic: string,
   page: number,
   perPage = 30,
-  createdAfter: string | undefined,
+  pushedAfter: string | undefined,
   telemetry: RateLimitTelemetry
 ): Promise<{ repos: GitHubRepository[]; total: number; error?: string }> {
   try {
@@ -128,14 +128,15 @@ export async function searchRepositories(
     }
 
     // SMI-2576: Validate date format before URL construction
-    if (createdAfter && !/^\d{4}-\d{2}-\d{2}$/.test(createdAfter)) {
-      return { repos: [], total: 0, error: `Invalid date format: ${sanitizeForLog(createdAfter)}` }
+    if (pushedAfter && !/^\d{4}-\d{2}-\d{2}$/.test(pushedAfter)) {
+      return { repos: [], total: 0, error: `Invalid date format: ${sanitizeForLog(pushedAfter)}` }
     }
 
-    // Build query with optional freshness qualifier
+    // Build query with optional freshness qualifier (pushed:> matches last-push activity,
+    // not repo creation — SMI-5176 corrected created:> which only matched newly-created repos)
     let queryStr = `topic:${topic}`
-    if (createdAfter) {
-      queryStr += ` created:>${createdAfter}`
+    if (pushedAfter) {
+      queryStr += ` pushed:>${pushedAfter}`
     }
     const query = encodeURIComponent(queryStr)
     const url = `https://api.github.com/search/repositories?q=${query}&per_page=${perPage}&page=${page}&sort=stars&order=desc`

--- a/scripts/tests/indexer/community-url-fork.test.ts
+++ b/scripts/tests/indexer/community-url-fork.test.ts
@@ -134,7 +134,7 @@ describe('searchCodeForSkillMd — tree-URL and fork guard (SMI-5286 Wave 1a §#
       })
     )
 
-    const { repos } = await searchCodeForSkillMd(1, 30, undefined, noTelemetry)
+    const { repos } = await searchCodeForSkillMd(1, 30, noTelemetry)
 
     expect(repos).toHaveLength(1)
     // Root SKILL.md → skillPath '' → tree URL ends with /tree/main
@@ -156,7 +156,7 @@ describe('searchCodeForSkillMd — tree-URL and fork guard (SMI-5286 Wave 1a §#
       })
     )
 
-    const { repos } = await searchCodeForSkillMd(1, 30, undefined, noTelemetry)
+    const { repos } = await searchCodeForSkillMd(1, 30, noTelemetry)
 
     expect(repos).toHaveLength(1)
     expect(repos[0].repoName).toBe('original')
@@ -174,7 +174,7 @@ describe('searchCodeForSkillMd — tree-URL and fork guard (SMI-5286 Wave 1a §#
       })
     )
 
-    const { repos, total } = await searchCodeForSkillMd(1, 30, undefined, noTelemetry)
+    const { repos, total } = await searchCodeForSkillMd(1, 30, noTelemetry)
 
     expect(repos).toHaveLength(0)
     expect(total).toBe(2) // total_count from API is still returned
@@ -197,13 +197,7 @@ describe('searchCodeForSkillMdInSubdirectory — tree-URL and fork guard (SMI-52
       })
     )
 
-    const result = await searchCodeForSkillMdInSubdirectory(
-      '.agents/skills',
-      1,
-      30,
-      undefined,
-      noTelemetry
-    )
+    const result = await searchCodeForSkillMdInSubdirectory('.agents/skills', 1, 30, noTelemetry)
 
     expect(result.repos).toHaveLength(1)
     const repo = result.repos[0]
@@ -234,13 +228,7 @@ describe('searchCodeForSkillMdInSubdirectory — tree-URL and fork guard (SMI-52
       })
     )
 
-    const result = await searchCodeForSkillMdInSubdirectory(
-      '.agents/skills',
-      1,
-      30,
-      undefined,
-      noTelemetry
-    )
+    const result = await searchCodeForSkillMdInSubdirectory('.agents/skills', 1, 30, noTelemetry)
 
     expect(result.repos).toHaveLength(1)
     expect(result.repos[0].repoName).toBe('original')
@@ -264,7 +252,6 @@ describe('searchCodeForSkillMdInSubdirectory — tree-URL and fork guard (SMI-52
       undefined, // broad
       1,
       30,
-      undefined,
       noTelemetry
     )
 
@@ -369,5 +356,98 @@ describe('searchRepositories — tree-URL and fork guard (SMI-5286 Wave 1a §#1/
     const repoB = repos.find((r) => r.name === 'repo-b')!
     expect(repoB.url).toBe('https://github.com/acme/repo-b/tree/main')
     expect(repoB.license).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SMI-5176: Freshness qualifier contract tests (anti-false-green)
+// Asserts the EXACT qualifiers emitted in the fetch URL for each search type.
+// ---------------------------------------------------------------------------
+
+describe('SMI-5176 freshness qualifier contracts', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  // ── repo search (topic-search.ts) ────────────────────────────────────────
+
+  it('searchRepositories emits pushed:>${date} in the fetch URL when pushedAfter is supplied', async () => {
+    let capturedUrl = ''
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (url) => {
+      capturedUrl = String(url)
+      return makeFetchOk({ total_count: 0, incomplete_results: false, items: [] })
+    })
+
+    await searchRepositories('mcp', 1, 30, '2026-06-10', noTelemetry)
+
+    const decodedQ = decodeURIComponent(capturedUrl.split('q=')[1]?.split('&')[0] ?? '')
+    // POSITIVE: must contain the exact pushed:>DATE substring
+    expect(decodedQ).toContain('pushed:>2026-06-10')
+    // NEGATIVE: must NOT use the old broken qualifier
+    expect(decodedQ).not.toContain('created:>')
+  })
+
+  it('searchRepositories does NOT emit any date qualifier when pushedAfter is undefined', async () => {
+    let capturedUrl = ''
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (url) => {
+      capturedUrl = String(url)
+      return makeFetchOk({ total_count: 0, incomplete_results: false, items: [] })
+    })
+
+    await searchRepositories('mcp', 1, 30, undefined, noTelemetry)
+
+    const decodedQ = decodeURIComponent(capturedUrl.split('q=')[1]?.split('&')[0] ?? '')
+    expect(decodedQ).not.toContain('pushed:>')
+    expect(decodedQ).not.toContain('created:>')
+  })
+
+  // ── code search (code-search.ts) — neither qualifier must appear ─────────
+
+  it('searchCodeForSkillMd emits NEITHER created: NOR pushed: in the fetch URL (SMI-5176)', async () => {
+    let capturedUrl = ''
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (url) => {
+      capturedUrl = String(url)
+      return makeFetchOk({ total_count: 0, incomplete_results: false, items: [] })
+    })
+
+    await searchCodeForSkillMd(1, 30, noTelemetry)
+
+    const decodedQ = decodeURIComponent(capturedUrl.split('q=')[1]?.split('&')[0] ?? '')
+    expect(decodedQ).not.toContain('created:')
+    expect(decodedQ).not.toContain('pushed:')
+  })
+
+  it('searchCodeForSkillMdInSubdirectory (broad) emits NEITHER created: NOR pushed: in the fetch URL', async () => {
+    let capturedUrl = ''
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (url) => {
+      capturedUrl = String(url)
+      return makeFetchOk({
+        total_count: 0,
+        incomplete_results: false,
+        items: [],
+      })
+    })
+
+    await searchCodeForSkillMdInSubdirectory(undefined, 1, 30, noTelemetry)
+
+    const decodedQ = decodeURIComponent(capturedUrl.split('q=')[1]?.split('&')[0] ?? '')
+    expect(decodedQ).not.toContain('created:')
+    expect(decodedQ).not.toContain('pushed:')
+  })
+
+  it('searchCodeForSkillMdInSubdirectory (.claude/skills) emits NEITHER created: NOR pushed: in the fetch URL', async () => {
+    let capturedUrl = ''
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (url) => {
+      capturedUrl = String(url)
+      return makeFetchOk({
+        total_count: 0,
+        incomplete_results: false,
+        items: [],
+      })
+    })
+
+    await searchCodeForSkillMdInSubdirectory('.claude/skills', 1, 30, noTelemetry)
+
+    const decodedQ = decodeURIComponent(capturedUrl.split('q=')[1]?.split('&')[0] ?? '')
+    expect(decodedQ).not.toContain('created:')
+    expect(decodedQ).not.toContain('pushed:')
   })
 })

--- a/scripts/tests/indexer/subdirectory-search.perskill.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.perskill.test.ts
@@ -151,14 +151,7 @@ describe('runSubdirectorySearch — per-skill extraction (SMI-5286 Wave 1a §#1)
     const seenUrls = new Set<string>()
     const validationCache = new Map()
 
-    const result = await runSubdirectorySearch(
-      seenUrls,
-      undefined,
-      validationCache,
-      {},
-      1,
-      noTelemetry
-    )
+    const result = await runSubdirectorySearch(seenUrls, validationCache, {}, 1, noTelemetry)
 
     // Three distinct repo rows
     expect(result.repos).toHaveLength(3)
@@ -199,7 +192,7 @@ describe('runSubdirectorySearch — per-skill extraction (SMI-5286 Wave 1a §#1)
       truncatedByApi: false,
     })
 
-    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
 
     expect(result.repos).toHaveLength(3)
 
@@ -233,7 +226,7 @@ describe('runSubdirectorySearch — per-skill extraction (SMI-5286 Wave 1a §#1)
       truncatedByApi: false,
     })
 
-    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
 
     expect(result.repos).toHaveLength(2)
 
@@ -263,7 +256,6 @@ describe('runSubdirectorySearch — per-skill extraction (SMI-5286 Wave 1a §#1)
 
     const result = await runSubdirectorySearch(
       new Set(),
-      undefined,
       new Map(),
       {},
       3, // allow up to 3 pages
@@ -286,7 +278,7 @@ describe('runSubdirectorySearch — per-skill extraction (SMI-5286 Wave 1a §#1)
       truncatedByApi: true, // policy (b): emit nothing
     })
 
-    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
 
     expect(result.repos).toHaveLength(0)
   })
@@ -304,7 +296,7 @@ describe('runSubdirectorySearch — per-skill extraction (SMI-5286 Wave 1a §#1)
     // Validation fails for this skill
     mockCheckSkillMdExists.mockResolvedValue(false)
 
-    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
 
     expect(result.repos).toHaveLength(1)
     expect(result.repos[0].installable).toBe(false)
@@ -316,7 +308,7 @@ describe('runSubdirectorySearch — per-skill extraction (SMI-5286 Wave 1a §#1)
 
     mockFetchRepoLicense.mockResolvedValue({ license: null, fetchFailed: true })
 
-    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
 
     expect(result.repos).toHaveLength(0)
     expect(result.licenseFiltered).toBe(0)
@@ -331,7 +323,7 @@ describe('runSubdirectorySearch — per-skill extraction (SMI-5286 Wave 1a §#1)
 
     mockFetchRepoLicense.mockResolvedValue({ license: 'GPL-3.0', fetchFailed: false })
 
-    const result = await runSubdirectorySearch(new Set(), undefined, new Map(), {}, 1, noTelemetry)
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
 
     expect(result.repos).toHaveLength(0)
     expect(result.licenseFiltered).toBe(1)


### PR DESCRIPTION
## SMI-5176 — Freshness qualifier: repo-search `created:>`→`pushed:>` + remove the tokenized code-search qualifier

**ADR-109 gates cleared:** SPARC (`docs/internal/implementation/smi-5176-freshness-gate-pushed-probe-sparc.md`) → re-confirm `plan-review-skill` **GO** → implemented via Ruflo queen on this worktree → per-commit `/governance` **GO** (12/12 invariants).

### The probe that drove the design
GitHub `/search/code` **tokenizes** date qualifiers as free-text content — they do **not** filter:

| query | `total_count` |
|---|---|
| `filename:SKILL.md` | 245,184 |
| `filename:SKILL.md created:>2024-01-01` | **186** (tokenized — 99.92% loss) |
| `filename:SKILL.md size:<200` | 4,560 (a *real* qualifier filters fine) |

On `/search/repositories` the qualifier **is** honored, and `pushed:` ≫ `created:` at the production 7-day window: `topic:mcp` `created:>7d`=1,509 vs `pushed:>7d`=10,206 (**6.8×**); claude-code 4.7×; ai-agents 5.1×.

### Change
- **`topic-search.ts` (repo search) — SWAP** `created:>`→`pushed:>` (param `createdAfter`→`pushedAfter`, local). `created:` only matched newly-*created* repos, starving re-discovery of the long-lived-but-recently-active universe. This is the **active** fix.
- **`code-search.ts` (both fns) — REMOVE** the tokenized `created:>` (would crush 245k→~hundreds if ever applied), drop the now-dead `freshnessDate` param, and cascade the removal through `runCodeSearch` / `runSubdirectorySearch` / the `discovery-orchestrator` call sites so `freshnessDate` flows **only** to the repo-search path.
- **Re-enable guard** at the `SKILLSMITH_ENABLE_CODE_SEARCH` gate: code search now has no freshness windowing — design the `pushed_at` post-filter (**SMI-5296**, filed) before an incremental re-enable.
- **+5 anti-false-green contract tests**: repo-search emits `pushed:>${date}` exactly + no `created:>`; code-search (root/subdir/path) emits **neither** `created:` nor `pushed:` (asserts the decoded fetch URL).
- Stale-comment cleanup; `CHANGELOG` `[Unreleased]`; docs/internal pointer bumped to include the SMI-5176 SPARC revision.

### RCA correction
The inherited "code-search `created:>` is the collapse driver" was **wrong** — it's **dormant** (Phase 3a/3b are env-OFF in the prod cron; backfill runs `BACKFILL_MODE=true`→`freshnessDate=undefined`, so the qualifier fires in **no live path**). The active bug was the repo-search `created:` ratchet. Wave-3 baseline (pre-swap, recorded in the SPARC): registry **2,434 non-quarantined**; live `topic_search:*` counts were **single-digit per topic** — the ratchet on display.

### Verification (worktree Docker)
lint 0 · typecheck clean · **427/427 indexer tests** · audit:standards 0-failed/95% · prettier clean · all changed files ≤500L. Deno copy `supabase/functions/indexer/*` **untouched** (SMI-5182; not parity-guarded).

[concurrency-audit-ack]
The concurrency auditor flags 10 Pattern-3 (in-memory cache, computed key) hits — all **pre-existing on `origin/main`** and confirmed by the governance review; this diff only removes a positional `undefined` argument from call sites and introduces no new `Map()` instantiations or shared-state writes.
