### PR TITLE
chore(deps): bump undici 7.25.0 → 7.28.0 (HIGH security GHSA-vmh5-mc38-953g)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27576,9 +27576,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -29712,7 +29712,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",


### PR DESCRIPTION
## Bump `undici` 7.25.0 → 7.28.0 — HIGH security (GHSA-vmh5-mc38-953g)

A newly-published HIGH advisory affects `undici` ≤7.27.2:
- **GHSA-vmh5-mc38-953g** — TLS certificate validation bypass via dropped `requestTls` in SOCKS5 `ProxyAgent`
- **GHSA-pr7r-676h-xcf6** — cross-user information disclosure via shared-cache whitespace bypass

**Repo-wide, not a single PR's regression:** `origin/main`'s lockfile also pinned `undici@7.25.0`, so the `Security Audit` job (`npm audit --audit-level=high --omit=dev`) now fails on **every** code PR. PR #1477 (merged 16:42 UTC) passed before the advisory was published; the next code PR (#1482) hit the new failure.

### Fix
- Lockfile-only: `7.28.0` is within the existing root override (`undici: "^7.18.0"`), so **no `package.json` change**.
- Regenerated with the **pinned `npm@11.9.0`** (`npx update undici --package-lock-only --ignore-scripts`), not local npm 10.9.7 (which prunes cross-platform optionals, SMI-5272).
- Verified: `jose@5.10.0` anchor intact; ruvllm/keytar platform optionals preserved; `npm audit --audit-level=high --omit=dev` exits **0**.
- Incidental: the lockfile's `packages/vscode-extension` workspace version syncs `0.2.4 → 0.3.0` to match its already-committed `package.json` on main (lockfile was left stale by that version bump) — harmless re-sync.

Unblocks #1482 (SMI-5176) and any other in-flight code PR.

[skip-impl-check]
Dependency/security lockfile bump — no implementation surface.
