### PR TITLE
feat(vscode): discovery filters + persistent search context + empty/offline states (SMI-5304/5305/5306)

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Filter Skills button** in the Skills view title bar opens a quick pick to filter discovery results by trust tier, category, and minimum score. A **Clear Skill Filters** action (shown in the title bar when filters are active) removes all active filters. Filters reset when the window reloads.
+- **Persistent status banner** in the Skills view shows what you are currently viewing — your search query and any active filters — so the context is always visible, not just a momentary toast.
+- Clearer empty and offline states: when no skills match your filters, the view says so and points you to clear them; when the Skillsmith server is unavailable the view says so directly; first-time users see a hint to start searching from the title bar or Command Palette.
+
 ## [0.4.0] - 2026-06-18
 
 ### Changed

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -18,6 +18,16 @@ Discover, search, and install agent skills directly in VS Code. Works with any M
 | MCP Integration | Live data from the Skillsmith API via Model Context Protocol |
 | Offline Fallback | Works offline with cached local skill data |
 
+### Filtering
+
+Click **Filter Skills** in the Skills view title bar to narrow discovery results by:
+
+- **Trust tier** — Official, Verified, Curated, Community, or Unverified
+- **Category** — limit results to a specific skill category
+- **Minimum score** — set a quality floor so lower-rated skills are hidden
+
+A persistent banner in the Skills view shows your active query and any filters so you always know what you're looking at. Use **Clear Skill Filters** (available in the title bar when filters are active) to reset them. Filters are cleared automatically when the window reloads.
+
 **Local-first by design.** Skillsmith caches the registry in a local SQLite database at `~/.skillsmith/skills.db`, shared across the MCP server, the CLI, and the VS Code extension. Search is FTS5 (SQLite's built-in keyword search) by default; semantic search is opt-in (`SKILLSMITH_USE_HNSW=true`) and runs over local ONNX embeddings (an open ML model format that runs on CPU — no API call). [Inside the Local Skill Database](https://skillsmith.app/blog/inside-the-local-skill-database) walks through the schema, the FTS5 / HNSW search paths, and how `sync` keeps the cache fresh.
 
 ## Getting Started

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -61,6 +61,18 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "skillsmith.filterSkills",
+        "title": "Filter Skills",
+        "category": "Skillsmith",
+        "icon": "$(filter)"
+      },
+      {
+        "command": "skillsmith.clearSkillFilters",
+        "title": "Clear Skill Filters",
+        "category": "Skillsmith",
+        "icon": "$(clear-all)"
+      },
+      {
         "command": "skillsmith.viewSkillDetails",
         "title": "View Skill Details",
         "category": "Skillsmith"
@@ -153,6 +165,16 @@
         {
           "command": "skillsmith.searchSkills",
           "when": "view == skillsmith.skillsView",
+          "group": "navigation"
+        },
+        {
+          "command": "skillsmith.filterSkills",
+          "when": "view == skillsmith.skillsView",
+          "group": "navigation"
+        },
+        {
+          "command": "skillsmith.clearSkillFilters",
+          "when": "view == skillsmith.skillsView && skillsmith.hasActiveFilters",
           "group": "navigation"
         },
         {

--- a/packages/vscode-extension/src/__tests__/SkillService.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillService.test.ts
@@ -311,6 +311,64 @@ describe('SkillService', () => {
     })
   })
 
+  describe('demo-mode filters (SMI-5304 plan-review #4)', () => {
+    it('applies trustTier filter client-side to mock results', async () => {
+      const client = createMockClient({ isConnected: () => false })
+      service = new SkillService(client, demoOn)
+
+      const unfiltered = await service.search('')
+      const filtered = await service.search('', { trustTier: 'community' })
+
+      // MOCK_SKILLS has a mix of tiers; the community filter must drop some.
+      expect(filtered.results.length).toBeLessThan(unfiltered.results.length)
+      expect(filtered.results.every((s) => s.trustTier.toLowerCase() === 'community')).toBe(true)
+    })
+
+    it('applies category filter case-insensitively (capitalized filter vs lowercase mock)', async () => {
+      const client = createMockClient({ isConnected: () => false })
+      service = new SkillService(client, demoOn)
+
+      // Filter passes 'Testing'; mock data uses lowercase 'testing'.
+      const { results } = await service.search('', { category: 'Testing' })
+      expect(results.length).toBeGreaterThan(0)
+      expect(results.every((s) => s.category.toLowerCase() === 'testing')).toBe(true)
+    })
+
+    it('applies minScore as an inclusive threshold to mock results', async () => {
+      const client = createMockClient({ isConnected: () => false })
+      service = new SkillService(client, demoOn)
+
+      const { results } = await service.search('', { minScore: 90 })
+      expect(results.length).toBeGreaterThan(0)
+      expect(results.every((s) => s.score >= 90)).toBe(true)
+    })
+
+    it('filtered vs unfiltered same query yield different mock results', async () => {
+      const client = createMockClient({ isConnected: () => false })
+      service = new SkillService(client, demoOn)
+
+      const unfiltered = await service.search('')
+      const filtered = await service.search('', { minScore: 95 })
+      expect(filtered.results.length).not.toBe(unfiltered.results.length)
+    })
+  })
+
+  describe('cache key distinctness per options', () => {
+    it('filtered + unfiltered same query are cached separately (distinct keys)', async () => {
+      const searchFn = vi.fn().mockImplementation(async () => makeMcpSearchResponse())
+      const client = createMockClient({ search: searchFn })
+      service = new SkillService(client)
+
+      await service.search('governance')
+      await service.search('governance', { trustTier: 'verified' })
+
+      // Distinct cache keys → both hit MCP (no collision).
+      expect(searchFn).toHaveBeenCalledTimes(2)
+      expect(searchFn).toHaveBeenNthCalledWith(1, 'governance', undefined)
+      expect(searchFn).toHaveBeenNthCalledWith(2, 'governance', { trustTier: 'verified' })
+    })
+  })
+
   describe('cache TTL', () => {
     it('returns cached results within TTL without re-calling MCP', async () => {
       const searchFn = vi.fn().mockResolvedValue(makeMcpSearchResponse())

--- a/packages/vscode-extension/src/__tests__/categories.test.ts
+++ b/packages/vscode-extension/src/__tests__/categories.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for the local API_CATEGORIES mirror (#1433 / SMI-5304).
+ *
+ * Mirror non-empty + drift guard: asserts the documented 6-value length so a
+ * core-side change to packages/core/src/api/types.ts API_CATEGORIES is caught
+ * here rather than silently diverging (ADR-113 — mirror, do not import).
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+// categories.ts imports `* as vscode` only for the QuickPickItem type + helper;
+// nothing is called at module load, so a bare stub is sufficient.
+vi.mock('vscode', () => ({}))
+
+import { API_CATEGORIES, getCategoryQuickPickItems } from '../sidebar/categories.js'
+
+describe('categories mirror (#1433 / SMI-5304)', () => {
+  it('mirror is non-empty', () => {
+    expect(API_CATEGORIES.length).toBeGreaterThan(0)
+  })
+
+  it('drift guard: exactly 6 categories (keep in sync with core API_CATEGORIES)', () => {
+    expect(API_CATEGORIES).toHaveLength(6)
+  })
+
+  it('contains the canonical category set', () => {
+    expect([...API_CATEGORIES]).toEqual([
+      'Development',
+      'Testing',
+      'DevOps',
+      'Documentation',
+      'Productivity',
+      'Security',
+    ])
+  })
+
+  it('getCategoryQuickPickItems returns one item per category, labelled', () => {
+    const items = getCategoryQuickPickItems()
+    expect(items).toHaveLength(API_CATEGORIES.length)
+    expect(items.map((i) => i.label)).toEqual([...API_CATEGORIES])
+  })
+})

--- a/packages/vscode-extension/src/__tests__/searchFilters.test.ts
+++ b/packages/vscode-extension/src/__tests__/searchFilters.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for the 3-step QuickPick filter collector (#1433 / SMI-5304).
+ *
+ * `collectSearchFilters` takes an injected `showQuickPick` so the three steps
+ * (trust tier → category → min score) can be driven deterministically without
+ * the extension host. Asserts: facets collected; "Any"/skip clears that facet;
+ * Escape (undefined) at any step aborts the whole flow (returns undefined).
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+// searchFilters.ts → trustTier.ts imports `* as vscode` but only touches it in
+// getTrustTierIcon (never reached here); a bare stub is sufficient.
+vi.mock('vscode', () => ({
+  window: { showQuickPick: vi.fn() },
+}))
+
+import { collectSearchFilters, type SearchFilters } from '../commands/searchFilters.js'
+import type * as vscode from 'vscode'
+
+type QPItem = vscode.QuickPickItem
+
+/**
+ * Builds an injectable showQuickPick that returns the supplied picks in order.
+ * `undefined` simulates Escape at that step.
+ */
+function scriptedQuickPick(picks: Array<QPItem | undefined>) {
+  let call = 0
+  const fn = vi.fn(async (items: readonly QPItem[], _opts: vscode.QuickPickOptions) => {
+    const choice = picks[call]
+    call++
+    if (choice === undefined) {
+      return undefined
+    }
+    // Resolve the scripted choice against the actual items by label so tests
+    // pin to the collector's real item set (catches label drift).
+    return items.find((i) => i.label === choice.label) ?? choice
+  })
+  return fn
+}
+
+/** Locate an item by a label substring among a step's offered items. */
+function pickByLabel(label: string): QPItem {
+  return { label }
+}
+
+describe('collectSearchFilters (#1433 / SMI-5304)', () => {
+  it('collects tier + category + score into a SearchFilters object', async () => {
+    const showQuickPick = scriptedQuickPick([
+      { label: '$(verified) Verified', description: 'verified' },
+      pickByLabel('Testing'),
+      pickByLabel('70+'),
+    ])
+
+    const result = await collectSearchFilters(showQuickPick)
+
+    expect(result).toEqual<SearchFilters>({
+      trustTier: 'verified',
+      category: 'Testing',
+      minScore: 70,
+    })
+    expect(showQuickPick).toHaveBeenCalledTimes(3)
+  })
+
+  it('"Any" at each step clears that facet (empty filters)', async () => {
+    const showQuickPick = scriptedQuickPick([
+      pickByLabel('Any tier'),
+      pickByLabel('Any category'),
+      pickByLabel('Any score'),
+    ])
+
+    const result = await collectSearchFilters(showQuickPick)
+
+    expect(result).toEqual<SearchFilters>({})
+  })
+
+  it('a skipped middle facet is cleared while the others are kept', async () => {
+    const showQuickPick = scriptedQuickPick([
+      { label: '$(verified-filled) Official', description: 'official' },
+      pickByLabel('Any category'),
+      pickByLabel('90+'),
+    ])
+
+    const result = await collectSearchFilters(showQuickPick)
+
+    expect(result).toEqual<SearchFilters>({ trustTier: 'official', minScore: 90 })
+    expect(result?.category).toBeUndefined()
+  })
+
+  it('Escape on step 1 aborts the whole flow (undefined)', async () => {
+    const showQuickPick = scriptedQuickPick([undefined])
+    const result = await collectSearchFilters(showQuickPick)
+    expect(result).toBeUndefined()
+    expect(showQuickPick).toHaveBeenCalledTimes(1)
+  })
+
+  it('Escape on step 2 aborts the whole flow (undefined)', async () => {
+    const showQuickPick = scriptedQuickPick([
+      { label: '$(verified) Verified', description: 'verified' },
+      undefined,
+    ])
+    const result = await collectSearchFilters(showQuickPick)
+    expect(result).toBeUndefined()
+    expect(showQuickPick).toHaveBeenCalledTimes(2)
+  })
+
+  it('Escape on step 3 aborts the whole flow (undefined)', async () => {
+    const showQuickPick = scriptedQuickPick([
+      { label: '$(verified) Verified', description: 'verified' },
+      pickByLabel('Testing'),
+      undefined,
+    ])
+    const result = await collectSearchFilters(showQuickPick)
+    expect(result).toBeUndefined()
+    expect(showQuickPick).toHaveBeenCalledTimes(3)
+  })
+
+  it('step 1 offers an Any entry plus all 5 canonical tiers', async () => {
+    let tierItems: readonly QPItem[] = []
+    const showQuickPick = vi.fn(async (items: readonly QPItem[]) => {
+      if (tierItems.length === 0) {
+        tierItems = items
+      }
+      return undefined // abort after capturing step 1
+    })
+    await collectSearchFilters(showQuickPick)
+    expect(tierItems).toHaveLength(6) // Any + 5 tiers
+    expect(tierItems[0]?.label).toBe('Any tier')
+  })
+})

--- a/packages/vscode-extension/src/__tests__/searchSkills.filters.test.ts
+++ b/packages/vscode-extension/src/__tests__/searchSkills.filters.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Tests for Wave 2a discovery: filters, persistent banner, and the
+ * `hasActiveFilters` context key (#1433 / SMI-5304, #1432 / SMI-5305,
+ * #1434-P2 / #1438-P2 / SMI-5306).
+ *
+ * Split out of searchSkills.test.ts to keep each file under the 500-line gate
+ * (scripts/check-file-length.mjs does not exempt test files). Self-contained:
+ * carries its own copy of the shared fixtures so it does not depend on the
+ * sibling file's setup.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SkillData } from '../types/skill.js'
+
+const showInputBox = vi.fn()
+const showInformationMessage = vi.fn()
+const showWarningMessage = vi.fn()
+const showErrorMessage = vi.fn()
+const executeCommand = vi.fn()
+
+/**
+ * `withProgress` invokes its task with a `progress` reporter and a cancellation
+ * `token`. Tests override `currentToken` to simulate cancellation.
+ */
+let currentToken = { isCancellationRequested: false }
+const withProgress = vi.fn(
+  async (_opts: unknown, task: (progress: unknown, token: unknown) => Promise<unknown>) => {
+    const progress = { report: vi.fn() }
+    return task(progress, currentToken)
+  }
+)
+
+vi.mock('vscode', () => ({
+  window: {
+    showInputBox,
+    showInformationMessage,
+    showWarningMessage,
+    showErrorMessage,
+    withProgress,
+  },
+  commands: { executeCommand, registerCommand: vi.fn() },
+  workspace: {
+    getConfiguration: vi.fn(() => ({ get: vi.fn(() => false) })),
+  },
+  ProgressLocation: { Notification: 15 },
+}))
+
+vi.mock('../services/Telemetry.js', () => ({ track: vi.fn() }))
+
+function makeSkill(id: string): SkillData {
+  return {
+    id,
+    name: id,
+    description: 'desc',
+    author: 'author',
+    category: 'category',
+    trustTier: 'verified',
+    score: 90,
+  }
+}
+
+/** Available group sentinel returned by the fake provider. */
+const AVAILABLE_GROUP = { id: 'group:available', itemType: 'group' as const }
+
+interface FakeProvider {
+  setSearchResults: ReturnType<typeof vi.fn>
+  clearSearchResults: ReturnType<typeof vi.fn>
+  getAvailableGroupItem: ReturnType<typeof vi.fn>
+  getFilters: ReturnType<typeof vi.fn>
+  setFilters: ReturnType<typeof vi.fn>
+  clearFilters: ReturnType<typeof vi.fn>
+  hasActiveFilters: ReturnType<typeof vi.fn>
+  getLastSearchQuery: ReturnType<typeof vi.fn>
+  describeActiveContext: ReturnType<typeof vi.fn>
+}
+
+interface ProviderState {
+  filters?: import('../commands/searchFilters.js').SearchFilters
+  lastQuery?: string
+}
+
+function makeProvider(hasAvailable: boolean, state: ProviderState = {}): FakeProvider {
+  let filters = state.filters ?? {}
+  const lastQuery = state.lastQuery ?? ''
+  return {
+    setSearchResults: vi.fn(),
+    clearSearchResults: vi.fn(),
+    getAvailableGroupItem: vi.fn(() => (hasAvailable ? AVAILABLE_GROUP : undefined)),
+    getFilters: vi.fn(() => filters),
+    setFilters: vi.fn((f) => {
+      filters = f
+    }),
+    clearFilters: vi.fn(() => {
+      filters = {}
+    }),
+    hasActiveFilters: vi.fn(
+      () =>
+        filters.trustTier !== undefined ||
+        filters.category !== undefined ||
+        filters.minScore !== undefined
+    ),
+    getLastSearchQuery: vi.fn(() => lastQuery),
+    describeActiveContext: vi.fn(() => ({ rawQuery: lastQuery, demo: false, filterParts: [] })),
+  }
+}
+
+function makeView() {
+  return {
+    reveal: vi.fn((..._args: unknown[]) => Promise.resolve()),
+    message: undefined as string | undefined,
+  }
+}
+
+function makeService(result: { results: SkillData[]; isOffline: boolean }) {
+  return { search: vi.fn(async () => result) }
+}
+
+describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    currentToken = { isCancellationRequested: false }
+  })
+
+  it('performSearch threads stored filters into skillService.search (via search command)', async () => {
+    const { searchSkillsAction } = await import('../commands/searchSkills.js')
+    showInputBox.mockResolvedValue('react')
+    const filters = { trustTier: 'verified', category: 'Testing', minScore: 70 }
+    const provider = makeProvider(true, { filters, lastQuery: 'react' })
+    const view = makeView()
+    const service = makeService({ results: [makeSkill('a')], isOffline: false })
+
+    await searchSkillsAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(service.search).toHaveBeenCalledWith('react', filters)
+  })
+
+  it('filter command collects filters, stores them, and re-runs the last query', async () => {
+    vi.resetModules()
+    vi.doMock('../commands/searchFilters.js', () => ({
+      collectSearchFilters: vi.fn(async () => ({ trustTier: 'verified' })),
+    }))
+    const { filterSkillsAction } = await import('../commands/searchSkills.js')
+    const provider = makeProvider(true, { lastQuery: 'react' })
+    const view = makeView()
+    const service = makeService({ results: [makeSkill('a')], isOffline: false })
+
+    await filterSkillsAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(provider.setFilters).toHaveBeenCalledWith({ trustTier: 'verified' })
+    expect(service.search).toHaveBeenCalledWith('react', { trustTier: 'verified' })
+    vi.doUnmock('../commands/searchFilters.js')
+    vi.resetModules()
+  })
+
+  it('filter-first (no query yet) runs browse-all with the new filters', async () => {
+    vi.resetModules()
+    vi.doMock('../commands/searchFilters.js', () => ({
+      collectSearchFilters: vi.fn(async () => ({ category: 'DevOps' })),
+    }))
+    const { filterSkillsAction } = await import('../commands/searchSkills.js')
+    const provider = makeProvider(true, { lastQuery: '' })
+    const view = makeView()
+    const service = makeService({ results: [makeSkill('a')], isOffline: false })
+
+    await filterSkillsAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(service.search).toHaveBeenCalledWith('', { category: 'DevOps' })
+    vi.doUnmock('../commands/searchFilters.js')
+    vi.resetModules()
+  })
+
+  it('filter command aborts (no setFilters / no search) when the QuickPick is cancelled', async () => {
+    vi.resetModules()
+    vi.doMock('../commands/searchFilters.js', () => ({
+      collectSearchFilters: vi.fn(async () => undefined),
+    }))
+    const { filterSkillsAction } = await import('../commands/searchSkills.js')
+    const provider = makeProvider(true, { lastQuery: 'react' })
+    const view = makeView()
+    const service = makeService({ results: [makeSkill('a')], isOffline: false })
+
+    await filterSkillsAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(provider.setFilters).not.toHaveBeenCalled()
+    expect(service.search).not.toHaveBeenCalled()
+    vi.doUnmock('../commands/searchFilters.js')
+    vi.resetModules()
+  })
+
+  it('clear command clears filters and re-runs the last query unfiltered', async () => {
+    const { clearFiltersAction } = await import('../commands/searchSkills.js')
+    const provider = makeProvider(true, {
+      filters: { trustTier: 'verified' },
+      lastQuery: 'react',
+    })
+    const view = makeView()
+    const service = makeService({ results: [makeSkill('a')], isOffline: false })
+
+    await clearFiltersAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(provider.clearFilters).toHaveBeenCalledTimes(1)
+    expect(service.search).toHaveBeenCalledWith('react', {})
+  })
+
+  it('sets the persistent context banner on results from describeActiveContext', async () => {
+    const { searchSkillsAction } = await import('../commands/searchSkills.js')
+    showInputBox.mockResolvedValue('react')
+    const provider = makeProvider(true, { lastQuery: 'react' })
+    provider.describeActiveContext.mockReturnValue({
+      rawQuery: 'react',
+      demo: false,
+      filterParts: ['Verified', 'Testing', '70+'],
+    })
+    const view = makeView()
+    const service = makeService({ results: [makeSkill('a')], isOffline: false })
+
+    await searchSkillsAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(view.message).toBe('Showing results for "react" · Verified · Testing · 70+')
+  })
+
+  it('sets a persistent banner on no-results and clears the result set', async () => {
+    const { searchSkillsAction } = await import('../commands/searchSkills.js')
+    showInputBox.mockResolvedValue('zzz')
+    const provider = makeProvider(false, { lastQuery: 'zzz' })
+    const view = makeView()
+    const service = makeService({ results: [], isOffline: false })
+
+    await searchSkillsAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(view.message).toBe('No skills found for "zzz"')
+    expect(provider.clearSearchResults).toHaveBeenCalledTimes(1)
+  })
+
+  it('filter-aware no-results copy when filters are active', async () => {
+    const { searchSkillsAction } = await import('../commands/searchSkills.js')
+    showInputBox.mockResolvedValue('react')
+    const provider = makeProvider(false, {
+      filters: { trustTier: 'verified' },
+      lastQuery: 'react',
+    })
+    const view = makeView()
+    const service = makeService({ results: [], isOffline: false })
+
+    await searchSkillsAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      'No skills match "react" with the current filters — try Clear Filters.'
+    )
+  })
+
+  it('offline + empty: persistent unavailable banner + warning + clears results', async () => {
+    const { searchSkillsAction } = await import('../commands/searchSkills.js')
+    showInputBox.mockResolvedValue('react')
+    const provider = makeProvider(false, { lastQuery: 'react' })
+    const view = makeView()
+    const service = makeService({ results: [], isOffline: true })
+
+    await searchSkillsAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(showWarningMessage).toHaveBeenCalled()
+    expect(view.message).toBe('Skillsmith server unavailable — start the MCP server and try again.')
+    expect(provider.clearSearchResults).toHaveBeenCalledTimes(1)
+  })
+
+  it('sets hasActiveFilters context key true when filters are active', async () => {
+    const { searchSkillsAction } = await import('../commands/searchSkills.js')
+    showInputBox.mockResolvedValue('react')
+    const provider = makeProvider(true, {
+      filters: { trustTier: 'verified' },
+      lastQuery: 'react',
+    })
+    const view = makeView()
+    const service = makeService({ results: [makeSkill('a')], isOffline: false })
+
+    await searchSkillsAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(executeCommand).toHaveBeenCalledWith('setContext', 'skillsmith.hasActiveFilters', true)
+  })
+
+  it('sets hasActiveFilters false on no-results (cleared via clearSearchResults path)', async () => {
+    const { searchSkillsAction } = await import('../commands/searchSkills.js')
+    showInputBox.mockResolvedValue('zzz')
+    const provider = makeProvider(false, { lastQuery: 'zzz' })
+    const view = makeView()
+    const service = makeService({ results: [], isOffline: false })
+
+    await searchSkillsAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(executeCommand).toHaveBeenCalledWith('setContext', 'skillsmith.hasActiveFilters', false)
+  })
+
+  it('sets hasActiveFilters false on offline (cleared via clearSearchResults path)', async () => {
+    const { searchSkillsAction } = await import('../commands/searchSkills.js')
+    showInputBox.mockResolvedValue('react')
+    const provider = makeProvider(false, { lastQuery: 'react' })
+    const view = makeView()
+    const service = makeService({ results: [], isOffline: true })
+
+    await searchSkillsAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    expect(executeCommand).toHaveBeenCalledWith('setContext', 'skillsmith.hasActiveFilters', false)
+  })
+
+  it('clear command sets hasActiveFilters false after clearing', async () => {
+    const { clearFiltersAction } = await import('../commands/searchSkills.js')
+    const provider = makeProvider(true, {
+      filters: { trustTier: 'verified' },
+      lastQuery: 'react',
+    })
+    const view = makeView()
+    const service = makeService({ results: [makeSkill('a')], isOffline: false })
+
+    await clearFiltersAction({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    })
+
+    // clearFilters() flips the fake provider's hasActiveFilters to false.
+    expect(executeCommand).toHaveBeenCalledWith('setContext', 'skillsmith.hasActiveFilters', false)
+  })
+
+  it('filter + clear actions are telemetry-wrapped with distinct ids', async () => {
+    const { filterSkillsAction, clearFiltersAction } = await import('../commands/searchSkills.js')
+    const { isTelemetered } = await import('../services/telemetry-wrap.js')
+    expect(isTelemetered(filterSkillsAction)).toBe(true)
+    expect(isTelemetered(clearFiltersAction)).toBe(true)
+  })
+
+  it("emits distinct telemetry skill_ids ('filter' / 'clear_filter', not 'search')", async () => {
+    vi.resetModules()
+    vi.doMock('../commands/searchFilters.js', () => ({
+      collectSearchFilters: vi.fn(async () => ({})),
+    }))
+    const { track } = await import('../services/Telemetry.js')
+    const { searchSkillsAction, filterSkillsAction, clearFiltersAction } =
+      await import('../commands/searchSkills.js')
+    const provider = makeProvider(true, { lastQuery: 'react' })
+    const view = makeView()
+    const service = makeService({ results: [makeSkill('a')], isOffline: false })
+    showInputBox.mockResolvedValue('react')
+    const deps = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      treeDataProvider: provider as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillsView: view as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      skillService: service as any,
+    }
+
+    await searchSkillsAction(deps)
+    await filterSkillsAction(deps)
+    await clearFiltersAction(deps)
+
+    const ids = vi
+      .mocked(track)
+      .mock.calls.filter((c) => c[0] === 'vscode_skill_invoke')
+      .map((c) => (c[1] as { skill_id: string }).skill_id)
+    expect(ids).toContain('search')
+    expect(ids).toContain('filter')
+    expect(ids).toContain('clear_filter')
+    vi.doUnmock('../commands/searchFilters.js')
+    vi.resetModules()
+  })
+})

--- a/packages/vscode-extension/src/__tests__/searchSkills.test.ts
+++ b/packages/vscode-extension/src/__tests__/searchSkills.test.ts
@@ -65,18 +65,49 @@ interface FakeProvider {
   setSearchResults: ReturnType<typeof vi.fn>
   clearSearchResults: ReturnType<typeof vi.fn>
   getAvailableGroupItem: ReturnType<typeof vi.fn>
+  getFilters: ReturnType<typeof vi.fn>
+  setFilters: ReturnType<typeof vi.fn>
+  clearFilters: ReturnType<typeof vi.fn>
+  hasActiveFilters: ReturnType<typeof vi.fn>
+  getLastSearchQuery: ReturnType<typeof vi.fn>
+  describeActiveContext: ReturnType<typeof vi.fn>
 }
 
-function makeProvider(hasAvailable: boolean): FakeProvider {
+interface ProviderState {
+  filters?: import('../commands/searchFilters.js').SearchFilters
+  lastQuery?: string
+}
+
+function makeProvider(hasAvailable: boolean, state: ProviderState = {}): FakeProvider {
+  let filters = state.filters ?? {}
+  const lastQuery = state.lastQuery ?? ''
   return {
     setSearchResults: vi.fn(),
     clearSearchResults: vi.fn(),
     getAvailableGroupItem: vi.fn(() => (hasAvailable ? AVAILABLE_GROUP : undefined)),
+    getFilters: vi.fn(() => filters),
+    setFilters: vi.fn((f) => {
+      filters = f
+    }),
+    clearFilters: vi.fn(() => {
+      filters = {}
+    }),
+    hasActiveFilters: vi.fn(
+      () =>
+        filters.trustTier !== undefined ||
+        filters.category !== undefined ||
+        filters.minScore !== undefined
+    ),
+    getLastSearchQuery: vi.fn(() => lastQuery),
+    describeActiveContext: vi.fn(() => ({ rawQuery: lastQuery, demo: false, filterParts: [] })),
   }
 }
 
 function makeView() {
-  return { reveal: vi.fn((..._args: unknown[]) => Promise.resolve()) }
+  return {
+    reveal: vi.fn((..._args: unknown[]) => Promise.resolve()),
+    message: undefined as string | undefined,
+  }
 }
 
 function makeService(result: { results: SkillData[]; isOffline: boolean }) {
@@ -105,7 +136,9 @@ describe('searchSkillsAction (#1431 / SMI-5298, #1434-P1)', () => {
       skillService: service as any,
     })
 
-    expect(provider.setSearchResults).toHaveBeenCalledWith(expect.any(Array), 'docker')
+    expect(provider.setSearchResults).toHaveBeenCalledWith(expect.any(Array), 'docker', {
+      demo: false,
+    })
     expect(provider.clearSearchResults).not.toHaveBeenCalled()
     // Container focused BEFORE reveal so a collapsed/hidden sidebar still surfaces.
     expect(executeCommand).toHaveBeenCalledWith('skillsmith.skillsView.focus')
@@ -178,7 +211,9 @@ describe('searchSkillsAction (#1431 / SMI-5298, #1434-P1)', () => {
     expect(provider.setSearchResults).not.toHaveBeenCalled()
     expect(showInformationMessage).toHaveBeenCalledWith('No skills found for "zzz"')
     expect(view.reveal).not.toHaveBeenCalled()
-    expect(executeCommand).not.toHaveBeenCalled()
+    // No reveal/focus on no-results; the only executeCommand is the
+    // hasActiveFilters setContext sync.
+    expect(executeCommand).not.toHaveBeenCalledWith('skillsmith.skillsView.focus')
   })
 
   it('offline + empty (not demo): shows warning, clears results, does NOT reveal', async () => {

--- a/packages/vscode-extension/src/__tests__/skillTreeDataProvider.test.ts
+++ b/packages/vscode-extension/src/__tests__/skillTreeDataProvider.test.ts
@@ -137,7 +137,7 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
     expect(provider.getLastSearchQuery()).toBe('')
   })
 
-  it('renders Available group first while searching, with the em-dash query label', async () => {
+  it('renders Available group first while searching, with the count-bearing label', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
     const provider = new SkillTreeDataProvider()
     provider.setSearchResults(sampleResults, 'docker')
@@ -147,7 +147,9 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
     // Available-first ordering.
     expect(roots[0]?.groupId).toBe('available')
     expect(roots[1]?.groupId).toBe('installed')
-    expect(roots[0]?.label).toBe('Available Skills — "docker" (2)')
+    // #1432: the group label is now the count header only (no inline query —
+    // the banner carries the query/filter context).
+    expect(roots[0]?.label).toBe('Available Skills (2)')
   })
 
   it('renders Installed group first (only) when no search is active', async () => {
@@ -262,5 +264,111 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
     } finally {
       await fs.rm(localRoot, { recursive: true, force: true })
     }
+  })
+})
+
+describe('SkillTreeDataProvider filter state + active context (#1433 / #1432)', () => {
+  const sampleResults = [
+    {
+      id: 'a/one',
+      name: 'one',
+      description: 'first',
+      author: 'a',
+      category: 'cat',
+      trustTier: 'verified',
+      score: 90,
+    },
+  ]
+
+  it('hasActiveFilters is false initially and true after setFilters', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const provider = new SkillTreeDataProvider()
+
+    expect(provider.hasActiveFilters()).toBe(false)
+    provider.setFilters({ trustTier: 'verified' })
+    expect(provider.hasActiveFilters()).toBe(true)
+    expect(provider.getFilters()).toEqual({ trustTier: 'verified' })
+  })
+
+  it('clearFilters resets to no active filters', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const provider = new SkillTreeDataProvider()
+
+    provider.setFilters({ category: 'Testing', minScore: 70 })
+    expect(provider.hasActiveFilters()).toBe(true)
+    provider.clearFilters()
+    expect(provider.hasActiveFilters()).toBe(false)
+    expect(provider.getFilters()).toEqual({})
+  })
+
+  it('setFilters stores by value (later mutation does not leak in)', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const provider = new SkillTreeDataProvider()
+
+    const input = { trustTier: 'verified' }
+    provider.setFilters(input)
+    input.trustTier = 'community'
+    expect(provider.getFilters().trustTier).toBe('verified')
+  })
+
+  it('describeActiveContext returns rawQuery + demo flag + ordered filter parts', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const provider = new SkillTreeDataProvider()
+
+    provider.setFilters({ trustTier: 'verified', category: 'Testing', minScore: 70 })
+    provider.setSearchResults(sampleResults, 'react', { demo: true })
+
+    const ctx = provider.describeActiveContext()
+    expect(ctx.rawQuery).toBe('react')
+    expect(ctx.demo).toBe(true)
+    // Ordered: tier label · category · N+.
+    expect(ctx.filterParts).toEqual(['Verified', 'Testing', '70+'])
+  })
+
+  it('describeActiveContext has no filter parts when no filters are active', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const provider = new SkillTreeDataProvider()
+
+    provider.setSearchResults(sampleResults, 'react')
+    const ctx = provider.describeActiveContext()
+    expect(ctx.filterParts).toEqual([])
+    expect(ctx.demo).toBe(false)
+  })
+
+  it('getLastSearchQuery returns the raw query, not the display label', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const provider = new SkillTreeDataProvider()
+
+    provider.setSearchResults(sampleResults, 'react', { demo: true })
+    // Raw query is stored separately from the demo annotation.
+    expect(provider.getLastSearchQuery()).toBe('react')
+  })
+
+  it('group:available id is stable across filter/query changes (reveal guard)', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const provider = new SkillTreeDataProvider()
+
+    provider.setSearchResults(sampleResults, 'react')
+    const before = provider.getAvailableGroupItem()
+    expect(before?.id).toBe('group:available')
+
+    provider.setFilters({ trustTier: 'verified', category: 'Testing', minScore: 90 })
+    provider.setSearchResults(sampleResults, 'docker', { demo: true })
+    const after = provider.getAvailableGroupItem()
+    // Label may change with filters/query; the reveal id must NOT.
+    expect(after?.id).toBe('group:available')
+  })
+
+  it('clearSearchResults clears the query but preserves active filters', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const provider = new SkillTreeDataProvider()
+
+    provider.setFilters({ trustTier: 'verified' })
+    provider.setSearchResults(sampleResults, 'react')
+    provider.clearSearchResults()
+
+    expect(provider.getLastSearchQuery()).toBe('')
+    // No-results / offline must not silently drop the user's filter selection.
+    expect(provider.hasActiveFilters()).toBe(true)
   })
 })

--- a/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
@@ -24,7 +24,7 @@ vi.mock('vscode', () => ({
 }))
 
 import { isTelemetered } from '../../services/telemetry-wrap.js'
-import { searchSkillsAction } from '../searchSkills.js'
+import { searchSkillsAction, filterSkillsAction, clearFiltersAction } from '../searchSkills.js'
 import { installCommandAction } from '../installCommand.js'
 import { uninstallCommandAction } from '../uninstallCommand.js'
 import { createSkillAction } from '../createSkillCommand.js'
@@ -32,6 +32,8 @@ import { createSkillAction } from '../createSkillCommand.js'
 /** Registered command id → wrapped panel action. */
 const VSCODE_DISPATCHER_MAP: Record<string, (...args: never[]) => unknown> = {
   'skillsmith.searchSkills': searchSkillsAction,
+  'skillsmith.filterSkills': filterSkillsAction,
+  'skillsmith.clearSkillFilters': clearFiltersAction,
   'skillsmith.installSkill': installCommandAction,
   'skillsmith.uninstallSkill': uninstallCommandAction,
   'skillsmith.createSkill': createSkillAction,
@@ -62,6 +64,6 @@ describe('SMI-5130: VS Code command telemetry coverage', () => {
   it('reports VS Code dispatcher coverage to CI output', () => {
     const count = Object.keys(VSCODE_DISPATCHER_MAP).length
     console.info(`[SMI-5130] VS Code telemetry coverage: ${count} panel actions wrapped.`)
-    expect(count).toBe(4)
+    expect(count).toBe(6)
   })
 })

--- a/packages/vscode-extension/src/commands/searchFilters.ts
+++ b/packages/vscode-extension/src/commands/searchFilters.ts
@@ -1,0 +1,125 @@
+/**
+ * #1433 (SMI-5304) — the 3-step skippable QuickPick collector for discovery
+ * filters (trust tier → category → min score).
+ *
+ * Extracted into its own module (plan-review #6) so `searchSkills.ts` stays
+ * well under the 500-line gate and the collector is unit-testable in isolation.
+ *
+ * Each step offers an "Any" entry that CLEARS that facet; selecting it (or
+ * leaving the step) drops the facet from the returned object. Pressing Escape
+ * at any step ABORTS the whole flow and returns `undefined` so the caller can
+ * leave existing filters untouched (vs. an explicit "clear all" which returns
+ * `{}`).
+ *
+ * `showQuickPick` is injected (defaulting to `vscode.window.showQuickPick`) so
+ * tests can drive the three steps deterministically without the extension host.
+ */
+import * as vscode from 'vscode'
+import {
+  type ExtensionTrustTier,
+  getTrustTierCodicon,
+  getTrustTierLabel,
+} from '../sidebar/trustTier.js'
+import { getCategoryQuickPickItems } from '../sidebar/categories.js'
+
+/**
+ * Discovery filter facets. An absent key means that facet is unset (no
+ * filtering on it). This is the single shape stored on the provider and passed
+ * to `SkillService.search` options.
+ */
+export interface SearchFilters {
+  category?: string
+  trustTier?: string
+  minScore?: number
+}
+
+/** Minimum-score presets offered in step 3. */
+const MIN_SCORE_PRESETS: ReadonlyArray<{ label: string; value: number }> = [
+  { label: '50+', value: 50 },
+  { label: '70+', value: 70 },
+  { label: '90+', value: 90 },
+]
+
+/** Trust tiers offered in step 1, in canonical (highest-trust-first) order. */
+const FILTER_TIERS: readonly ExtensionTrustTier[] = [
+  'official',
+  'verified',
+  'curated',
+  'community',
+  'unverified',
+]
+
+/** The `vscode.window.showQuickPick` overload the collector relies on. */
+type ShowQuickPick = (
+  items: readonly vscode.QuickPickItem[],
+  options: vscode.QuickPickOptions
+) => Thenable<vscode.QuickPickItem | undefined>
+
+/** Sentinel "Any" labels — selecting one clears that facet. */
+const ANY_TIER = 'Any tier'
+const ANY_CATEGORY = 'Any category'
+const ANY_SCORE = 'Any score'
+
+/**
+ * Runs the 3-step QuickPick. Returns the collected `SearchFilters`, or
+ * `undefined` if the user cancelled (Escape) at any step.
+ */
+export async function collectSearchFilters(
+  showQuickPick: ShowQuickPick = vscode.window.showQuickPick.bind(vscode.window)
+): Promise<SearchFilters | undefined> {
+  const filters: SearchFilters = {}
+
+  // Step 1/3 — trust tier.
+  const tierItems: vscode.QuickPickItem[] = [
+    { label: ANY_TIER },
+    ...FILTER_TIERS.map((tier) => ({
+      label: `${getTrustTierCodicon(tier)} ${getTrustTierLabel(tier)}`,
+      description: tier,
+    })),
+  ]
+  const tierPick = await showQuickPick(tierItems, {
+    title: 'Filter Skills (1/3) — Trust tier',
+    placeHolder: 'Select a trust tier (or Any to skip)',
+  })
+  if (tierPick === undefined) {
+    return undefined
+  }
+  if (tierPick.label !== ANY_TIER && tierPick.description) {
+    filters.trustTier = tierPick.description
+  }
+
+  // Step 2/3 — category.
+  const categoryItems: vscode.QuickPickItem[] = [
+    { label: ANY_CATEGORY },
+    ...getCategoryQuickPickItems(),
+  ]
+  const categoryPick = await showQuickPick(categoryItems, {
+    title: 'Filter Skills (2/3) — Category',
+    placeHolder: 'Select a category (or Any to skip)',
+  })
+  if (categoryPick === undefined) {
+    return undefined
+  }
+  if (categoryPick.label !== ANY_CATEGORY) {
+    filters.category = categoryPick.label
+  }
+
+  // Step 3/3 — minimum score.
+  const scoreItems: vscode.QuickPickItem[] = [
+    { label: ANY_SCORE },
+    ...MIN_SCORE_PRESETS.map((preset) => ({ label: preset.label })),
+  ]
+  const scorePick = await showQuickPick(scoreItems, {
+    title: 'Filter Skills (3/3) — Minimum score',
+    placeHolder: 'Select a minimum score (or Any to skip)',
+  })
+  if (scorePick === undefined) {
+    return undefined
+  }
+  const preset = MIN_SCORE_PRESETS.find((p) => p.label === scorePick.label)
+  if (preset) {
+    filters.minScore = preset.value
+  }
+
+  return filters
+}

--- a/packages/vscode-extension/src/commands/searchSkills.ts
+++ b/packages/vscode-extension/src/commands/searchSkills.ts
@@ -6,12 +6,19 @@
  * (the single `skillsmith.skillsView` tree), not the retired `searchView`.
  * Results land in the provider's "Available Skills" group, which is then
  * revealed via the retained `TreeView` handle.
+ *
+ * Wave 2a (#1433 SMI-5304 / #1432 SMI-5305 / #1434-P2 SMI-5306): a shared
+ * `performSearch` helper threads active filters into the search, sets the
+ * persistent `TreeView.message` context banner, maintains the
+ * `skillsmith.hasActiveFilters` context key, and renders filter-aware
+ * empty/offline copy. Filters are collected via `searchFilters.ts`.
  */
 import * as vscode from 'vscode'
 import type { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
 import type { SkillTreeItem } from '../sidebar/SkillTreeItem.js'
 import type { SkillService } from '../services/SkillService.js'
 import { withTelemetry } from '../services/telemetry-wrap.js'
+import { collectSearchFilters, type SearchFilters } from './searchFilters.js'
 
 interface SearchSkillsDeps {
   treeDataProvider: SkillTreeDataProvider
@@ -22,6 +29,31 @@ interface SearchSkillsDeps {
 /** SMI-5288: whether explicit demo mode is enabled. */
 function isDemoModeEnabled(): boolean {
   return vscode.workspace.getConfiguration('skillsmith').get<boolean>('demoMode', false)
+}
+
+/**
+ * Composes the persistent context banner (#1432) from the provider's single
+ * `describeActiveContext()` formatter, so the banner and the group label can
+ * never drift. The banner owns the query + filter parts; the group label owns
+ * the count header.
+ */
+function formatContextBanner(deps: SearchSkillsDeps): string {
+  const { rawQuery, demo, filterParts } = deps.treeDataProvider.describeActiveContext()
+  const head = rawQuery ? `Showing results for "${rawQuery}"` : 'Showing all skills'
+  const parts = [head, ...filterParts]
+  if (demo) {
+    parts.push('Demo')
+  }
+  return parts.join(' · ')
+}
+
+/** Reflects the provider's filter state into the `hasActiveFilters` context key. */
+async function syncActiveFiltersContext(deps: SearchSkillsDeps): Promise<void> {
+  await vscode.commands.executeCommand(
+    'setContext',
+    'skillsmith.hasActiveFilters',
+    deps.treeDataProvider.hasActiveFilters()
+  )
 }
 
 /**
@@ -43,28 +75,28 @@ async function revealAvailableGroup(deps: SearchSkillsDeps): Promise<void> {
   }
 }
 
-// SMI-5130: extracted from the inline registerCommand closure so withTelemetry
-// can wrap it at the export boundary (telemetry coverage gate). Deps that the
-// closure captured are threaded in explicitly. The reveal call MUST stay inside
-// this function (never module scope) so telemetry-coverage.test.ts can import
-// `searchSkillsAction` as a value without invoking vscode APIs at load.
-async function searchSkillsImpl(deps: SearchSkillsDeps): Promise<void> {
+/**
+ * Shared search core (#1433): runs the query with the supplied filters, routes
+ * results into the provider, maintains the context banner + `hasActiveFilters`
+ * key, and reveals the Available group. Used by the search command and both the
+ * filter/clear-filter commands so they share one code path.
+ *
+ * The reveal + banner + setContext calls MUST stay inside this function (never
+ * module scope) so telemetry-coverage.test.ts can import the wrapped actions as
+ * values without invoking vscode APIs at load.
+ */
+async function performSearch(
+  deps: SearchSkillsDeps,
+  query: string,
+  filters: SearchFilters
+): Promise<void> {
   const { treeDataProvider, skillService } = deps
-  // Show search input (query is optional - empty searches return all skills)
-  const query = await vscode.window.showInputBox({
-    prompt: 'Search for agent skills',
-    placeHolder: 'Search for skills (or press Enter to browse all)',
-    title: 'Skillsmith Search',
-  })
-
-  // User cancelled (pressed Escape)
-  if (query === undefined) {
-    return
-  }
-
   const trimmedQuery = query.trim()
+  const hasFilters =
+    filters.trustTier !== undefined ||
+    filters.category !== undefined ||
+    filters.minScore !== undefined
 
-  // Show cancellable progress with timed messages
   await vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
@@ -91,7 +123,7 @@ async function searchSkillsImpl(deps: SearchSkillsDeps): Promise<void> {
           return
         }
 
-        const { results, isOffline } = await skillService.search(trimmedQuery)
+        const { results, isOffline } = await skillService.search(trimmedQuery, filters)
 
         if (token.isCancellationRequested) {
           return
@@ -103,26 +135,34 @@ async function searchSkillsImpl(deps: SearchSkillsDeps): Promise<void> {
 
         if (results.length === 0) {
           // SMI-5288: offline + empty + not demo means the server is
-          // unavailable — be honest instead of showing a fake catalog.
+          // unavailable — be honest instead of showing a fake catalog. Render
+          // a persistent in-tree banner (#1438-P2) in addition to the warning.
           if (isOffline && !demoMode) {
             vscode.window.showWarningMessage(
               'Skillsmith server unavailable — start the Skillsmith MCP server and try again.'
             )
             treeDataProvider.clearSearchResults()
+            deps.skillsView.message =
+              'Skillsmith server unavailable — start the MCP server and try again.'
+            await syncActiveFiltersContext(deps)
             return
           }
-          const noResultsMsg = trimmedQuery
-            ? `No skills found for "${trimmedQuery}"`
-            : 'No skills found'
+          // #1434-P2: filter-aware no-results copy.
+          const noResultsMsg = buildNoResultsMessage(trimmedQuery, hasFilters)
           vscode.window.showInformationMessage(noResultsMsg)
           treeDataProvider.clearSearchResults()
+          deps.skillsView.message = noResultsMsg
+          await syncActiveFiltersContext(deps)
           return
         }
 
-        const label = trimmedQuery || 'all skills'
         // SMI-5288: non-empty offline results only happen in demo mode now.
-        const displayLabel = isOffline && demoMode ? `${label} (Demo)` : label
-        treeDataProvider.setSearchResults(results, displayLabel)
+        const isDemoResults = isOffline && demoMode
+        treeDataProvider.setSearchResults(results, trimmedQuery, { demo: isDemoResults })
+
+        // #1432: persistent context banner derived from the single formatter.
+        deps.skillsView.message = formatContextBanner(deps)
+        await syncActiveFiltersContext(deps)
 
         // SMI-5298 (#1431): surface the Available group in the unified view.
         // #1434-P1: the "Found N skills" success toast is intentionally removed —
@@ -139,11 +179,73 @@ async function searchSkillsImpl(deps: SearchSkillsDeps): Promise<void> {
   )
 }
 
+/** Builds the no-results copy, filter-aware (#1434-P2). */
+function buildNoResultsMessage(trimmedQuery: string, hasFilters: boolean): string {
+  if (hasFilters) {
+    return trimmedQuery
+      ? `No skills match "${trimmedQuery}" with the current filters — try Clear Filters.`
+      : 'No skills match the current filters — try Clear Filters.'
+  }
+  return trimmedQuery ? `No skills found for "${trimmedQuery}"` : 'No skills found'
+}
+
+// SMI-5130: extracted from the inline registerCommand closure so withTelemetry
+// can wrap it at the export boundary (telemetry coverage gate). Deps that the
+// closure captured are threaded in explicitly.
+async function searchSkillsImpl(deps: SearchSkillsDeps): Promise<void> {
+  // Show search input (query is optional - empty searches return all skills)
+  const query = await vscode.window.showInputBox({
+    prompt: 'Search for agent skills',
+    placeHolder: 'Search for skills (or press Enter to browse all)',
+    title: 'Skillsmith Search',
+  })
+
+  // User cancelled (pressed Escape)
+  if (query === undefined) {
+    return
+  }
+
+  await performSearch(deps, query, deps.treeDataProvider.getFilters())
+}
+
+/**
+ * #1433: collect filters via the 3-step QuickPick, store them on the provider
+ * (single source of truth), then re-run the LAST query with them. A filter-
+ * first flow (no query yet) runs browse-all (`''`). Escape aborts and leaves
+ * the existing filters untouched.
+ */
+async function applyFiltersImpl(deps: SearchSkillsDeps): Promise<void> {
+  const filters = await collectSearchFilters()
+  if (filters === undefined) {
+    return
+  }
+  deps.treeDataProvider.setFilters(filters)
+  await performSearch(deps, deps.treeDataProvider.getLastSearchQuery(), filters)
+}
+
+/** #1433: clear all filters and re-run the last query unfiltered. */
+async function clearFiltersImpl(deps: SearchSkillsDeps): Promise<void> {
+  deps.treeDataProvider.clearFilters()
+  await performSearch(deps, deps.treeDataProvider.getLastSearchQuery(), {})
+}
+
 export const searchSkillsAction = withTelemetry(searchSkillsImpl, {
   source: 'vscode-extension',
   // SMI-5143: CLI-aligned action name so the same action shares one skill_id
   // across CLI + VS Code, split only by `source` (cli vs vscode-extension).
   extractSkillId: () => 'search',
+})
+
+export const filterSkillsAction = withTelemetry(applyFiltersImpl, {
+  source: 'vscode-extension',
+  // Plan-review #5: distinct id so filter adoption is measurable (not 'search').
+  extractSkillId: () => 'filter',
+})
+
+export const clearFiltersAction = withTelemetry(clearFiltersImpl, {
+  source: 'vscode-extension',
+  // Plan-review #5: distinct id so clear-filter usage is measurable.
+  extractSkillId: () => 'clear_filter',
 })
 
 export function registerSearchCommand(
@@ -152,8 +254,10 @@ export function registerSearchCommand(
   skillsView: vscode.TreeView<SkillTreeItem>,
   skillService: SkillService
 ): void {
-  const searchCommand = vscode.commands.registerCommand('skillsmith.searchSkills', () =>
-    searchSkillsAction({ treeDataProvider, skillsView, skillService })
+  const deps: SearchSkillsDeps = { treeDataProvider, skillsView, skillService }
+  context.subscriptions.push(
+    vscode.commands.registerCommand('skillsmith.searchSkills', () => searchSkillsAction(deps)),
+    vscode.commands.registerCommand('skillsmith.filterSkills', () => filterSkillsAction(deps)),
+    vscode.commands.registerCommand('skillsmith.clearSkillFilters', () => clearFiltersAction(deps))
   )
-  context.subscriptions.push(searchCommand)
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -114,6 +114,16 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(skillsView)
 
+  // #1438-P2 (SMI-5306): first-run / pre-search hint. `viewsWelcome` renders
+  // ONLY for an empty tree, so an installed-but-never-searched user never sees
+  // it (plan-review #2). Surface the affordance as a persistent
+  // `TreeView.message` hint shown until the first search runs; `performSearch`
+  // overwrites it with the context banner once results land. Per-platform chord
+  // copy mirrors Wave 1's welcome message.
+  const isMac = process.platform === 'darwin'
+  const searchChord = isMac ? '⌘K ⌘Y' : 'Ctrl+K Ctrl+Y'
+  skillsView.message = `Press the search icon or ${searchChord} to discover skills.`
+
   // Register intellisense providers
   const skillMdSelector = getSkillMdSelector()
 

--- a/packages/vscode-extension/src/services/SkillService.ts
+++ b/packages/vscode-extension/src/services/SkillService.ts
@@ -83,8 +83,12 @@ export class SkillService {
 
     // Server unavailable (or transport error). Mock is demo-only now.
     if (this.demoMode()) {
-      // Demo mode: empty query returns all mock skills (browse-all mode)
-      const results = query ? searchMockSkills(query) : [...MOCK_SKILLS]
+      // Demo mode: empty query returns all mock skills (browse-all mode).
+      // SMI-5304 demo-mode honesty (plan-review #4): apply filters client-side
+      // so a demo user who sets filters never sees unfiltered results while the
+      // banner claims filtering happened.
+      const base = query ? searchMockSkills(query) : [...MOCK_SKILLS]
+      const results = applyMockFilters(base, options)
       return { results, isOffline: true }
     }
     return { results: [], isOffline: true }
@@ -144,6 +148,41 @@ export class SkillService {
   clearCache(): void {
     this.searchCache.clear()
   }
+}
+
+/**
+ * Applies discovery filters to demo-mode mock results (SMI-5304 plan-review #4).
+ *
+ * Mirrors the server-side `search` facet semantics so demo mode is honest:
+ * - `category`: exact match, case-insensitive (mock data uses lowercase
+ *   categories, e.g. `development`, while the filter passes `Development`).
+ * - `trustTier`: exact match, case-insensitive.
+ * - `minScore`: inclusive threshold (`score >= minScore`).
+ *
+ * Returns a new array; never mutates the input.
+ */
+export function applyMockFilters(
+  skills: SkillData[],
+  options?: { category?: string; trustTier?: string; minScore?: number }
+): SkillData[] {
+  if (!options) {
+    return skills
+  }
+  const category = options.category?.toLowerCase()
+  const trustTier = options.trustTier?.toLowerCase()
+  const { minScore } = options
+  return skills.filter((skill) => {
+    if (category !== undefined && skill.category.toLowerCase() !== category) {
+      return false
+    }
+    if (trustTier !== undefined && skill.trustTier.toLowerCase() !== trustTier) {
+      return false
+    }
+    if (minScore !== undefined && skill.score < minScore) {
+      return false
+    }
+    return true
+  })
 }
 
 /** Map MCP search result to SkillData */

--- a/packages/vscode-extension/src/sidebar/SkillTreeDataProvider.ts
+++ b/packages/vscode-extension/src/sidebar/SkillTreeDataProvider.ts
@@ -9,11 +9,30 @@ import * as fs from 'fs/promises'
 import * as path from 'path'
 import * as os from 'os'
 import { SkillTreeItem, type SkillItemData } from './SkillTreeItem.js'
-import { type ExtensionTrustTier, normalizeTrustTier } from './trustTier.js'
+import { type ExtensionTrustTier, normalizeTrustTier, getTrustTierLabel } from './trustTier.js'
 import { type SkillData } from '../types/skill.js'
+import { type SearchFilters } from '../commands/searchFilters.js'
 
 /** Maximum length for skill descriptions */
 const MAX_DESCRIPTION_LENGTH = 100
+
+/**
+ * Structured description of the active discovery context (#1432 / SMI-5305).
+ *
+ * The SINGLE source of truth (plan-review #1) from which BOTH the Available
+ * group label and the persistent `TreeView.message` banner are composed, so the
+ * two surfaces can never drift. Each surface picks the parts it owns:
+ *   - banner = `rawQuery` + `filterParts` (the "Showing results for…" sentence)
+ *   - group label = the count header (`Available Skills (N)`)
+ */
+export interface ActiveContext {
+  /** The true search query (distinct from any `(Demo)`/`all skills` display label). */
+  rawQuery: string
+  /** Whether the results came from demo-mode mock data. */
+  demo: boolean
+  /** Ordered, human-readable active-filter labels (tier, category, `N+`). */
+  filterParts: string[]
+}
 
 /**
  * SkillTreeDataProvider implements TreeDataProvider for the skill sidebar
@@ -26,7 +45,12 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
   private installedSkills: SkillItemData[] = []
   private availableSkills: SkillItemData[] = []
   private loadingPromise: Promise<void> | undefined
-  private lastSearchQuery = ''
+  /** The TRUE raw search query — distinct from any display label (#1432). */
+  private rawQuery = ''
+  /** Whether the current results came from demo-mode mock data. */
+  private demo = false
+  /** Active discovery filters — single source of truth (#1433). Ephemeral. */
+  private filters: SearchFilters = {}
 
   constructor() {
     // Load installed skills on initialization
@@ -41,13 +65,22 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
   }
 
   /**
-   * Sets search results as available skills
+   * Sets search results as available skills.
+   *
+   * The raw query is stored SEPARATELY from any display suffix (#1432 / #1433):
+   * earlier code conflated the query with the `(Demo)`/`all skills` display
+   * label, so the context formatter could not recover the true query. Callers
+   * now pass the true `rawQuery` plus an optional `demo` flag; the demo
+   * annotation is composed at render time from `demo`, never baked into the
+   * stored query.
    *
    * @param results - Search results to display
-   * @param query - The search query used
+   * @param rawQuery - The true search query ('' for browse-all)
+   * @param meta.demo - Whether the results are demo-mode mock data
    */
-  setSearchResults(results: SkillData[], query: string): void {
-    this.lastSearchQuery = query
+  setSearchResults(results: SkillData[], rawQuery: string, meta: { demo?: boolean } = {}): void {
+    this.rawQuery = rawQuery
+    this.demo = meta.demo ?? false
     this.availableSkills = results.map((skill) => {
       const tier = normalizeTrustTier(skill.trustTier)
       const item: SkillItemData = {
@@ -68,19 +101,72 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
   }
 
   /**
-   * Clears search results
+   * Clears search results. Does NOT clear the active filters — clearing
+   * results (e.g. a no-results or offline run) must leave the user's filter
+   * selection intact so the Clear Filters action still reflects reality.
    */
   clearSearchResults(): void {
     this.availableSkills = []
-    this.lastSearchQuery = ''
+    this.rawQuery = ''
+    this.demo = false
     this._onDidChangeTreeData.fire()
   }
 
   /**
-   * Gets the search query that was last used
+   * Gets the true search query last used ('' for browse-all / no search).
    */
   getLastSearchQuery(): string {
-    return this.lastSearchQuery
+    return this.rawQuery
+  }
+
+  /** Returns the active discovery filters (single source of truth, #1433). */
+  getFilters(): SearchFilters {
+    return this.filters
+  }
+
+  /**
+   * Replaces the active filters. Stored by value (shallow copy) so a later
+   * mutation of the caller's object cannot retroactively change provider state.
+   */
+  setFilters(filters: SearchFilters): void {
+    this.filters = { ...filters }
+    this._onDidChangeTreeData.fire()
+  }
+
+  /** Clears all active filters. */
+  clearFilters(): void {
+    this.filters = {}
+    this._onDidChangeTreeData.fire()
+  }
+
+  /** Whether any discovery filter is currently active. */
+  hasActiveFilters(): boolean {
+    return (
+      this.filters.trustTier !== undefined ||
+      this.filters.category !== undefined ||
+      this.filters.minScore !== undefined
+    )
+  }
+
+  /**
+   * The SINGLE formatter (plan-review #1) describing the active discovery
+   * context. Both the Available group label and the #1432 banner derive from
+   * this, so they can never diverge. Returns the raw query, the demo flag, and
+   * the ordered filter-facet labels (tier · category · `N+`).
+   */
+  describeActiveContext(): ActiveContext {
+    const filterParts: string[] = []
+    if (this.filters.trustTier !== undefined) {
+      const label = getTrustTierLabel(this.filters.trustTier)
+      filterParts.push(label || this.filters.trustTier)
+    }
+    if (this.filters.category !== undefined) {
+      filterParts.push(this.filters.category)
+    }
+    if (this.filters.minScore !== undefined) {
+      filterParts.push(`${this.filters.minScore}+`)
+    }
+    return { rawQuery: this.rawQuery, demo: this.demo, filterParts }
   }
 
   /**
@@ -209,12 +295,21 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
    * Builds the Available group header. Single source of truth shared by
    * `getRootGroups()`, `getAvailableGroupItem()`, and `getParent()` so the
    * stable id (`group:available`) matches across all reveal/parent lookups.
+   *
+   * The label is now the COUNT-BEARING header only (#1432 plan-review #8): the
+   * query + filter context lives in the persistent `TreeView.message` banner,
+   * so the two surfaces are complementary, not duplicate. `createGroup` appends
+   * the `(N)` count; the stable `group:available` id is decoupled from the
+   * label (set from `groupId` in `SkillTreeItem.setupGroupItem`), so changing
+   * the label never regresses the reveal contract (#1431 / SMI-5298).
    */
   private buildAvailableGroupItem(): SkillTreeItem {
-    const label = this.lastSearchQuery
-      ? `Available Skills — "${this.lastSearchQuery}"`
-      : 'Available Skills'
-    return SkillTreeItem.createGroup(label, 'available', this.availableSkills.length, true)
+    return SkillTreeItem.createGroup(
+      'Available Skills',
+      'available',
+      this.availableSkills.length,
+      true
+    )
   }
 
   /**

--- a/packages/vscode-extension/src/sidebar/categories.ts
+++ b/packages/vscode-extension/src/sidebar/categories.ts
@@ -1,0 +1,36 @@
+/**
+ * Local mirror of the canonical 6-value category enum
+ * (packages/core/src/api/types.ts API_CATEGORIES). ADR-113 forbids importing
+ * @skillsmith/core into the extension; keep this in sync with
+ * packages/core/src/api/types.ts API_CATEGORIES.
+ *
+ * Used by the #1433 filter QuickPick (src/commands/searchFilters.ts). A drift
+ * guard (src/__tests__/categories.test.ts) asserts the documented length so a
+ * core-side change is caught at CI rather than silently diverging.
+ */
+import * as vscode from 'vscode'
+
+/**
+ * The canonical 6 category filter values, mirroring API_CATEGORIES from
+ * packages/core/src/api/types.ts. Order matches core (insertion order).
+ */
+export const API_CATEGORIES = [
+  'Development',
+  'Testing',
+  'DevOps',
+  'Documentation',
+  'Productivity',
+  'Security',
+] as const
+
+/** A single category value. */
+export type ApiCategory = (typeof API_CATEGORIES)[number]
+
+/**
+ * Builds QuickPick items for the category filter step. The returned list is
+ * just the 6 categories — the "Any" (clear) entry is composed by the collector
+ * (src/commands/searchFilters.ts) so the clear semantics live in one place.
+ */
+export function getCategoryQuickPickItems(): vscode.QuickPickItem[] {
+  return API_CATEGORIES.map((category) => ({ label: category }))
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2024,6 +2024,8 @@ console.log(`\n${BOLD}28. VS Code Command ↔ Test Pairing (SMI-4194)${RESET}`)
         'skillsmith.mcpReconnect', // integration-tested via McpStatusBar
         'skillsmith.searchSkills', // exercised through SkillService tests
         'skillsmith.installSkill', // exercised through SkillService tests
+        'skillsmith.filterSkills', // SMI-5304: collector in searchFilters.test.ts, action in searchSkills.test.ts
+        'skillsmith.clearSkillFilters', // SMI-5304: action exercised in searchSkills.test.ts
       ])
       const testFiles = readdirSync(testDir).filter((f) => f.endsWith('.test.ts'))
       const missing = []


### PR DESCRIPTION
## Summary

Wave 2a of the VS Code extension UX epics — the **discovery** slice, building on the Wave 1 (0.4.0) unified tree. One functional PR; no version bump (0.5.0 is batched after Wave 2b).

- **#1433 filter UI (SMI-5304)** — a "Filter Skills" title-bar button opens a 3-step skippable QuickPick (trust tier → category → minimum score). Filters live on `SkillTreeDataProvider` (ephemeral — reset on reload), surfaced via a single `describeActiveContext()` formatter, with a context-key-gated "Clear Skill Filters" action. The filter data path already existed end-to-end (`SkillService.search(query, {category,trustTier,minScore})`); this adds the collection surface. `trust_tier` is exact-match (single-tier select). Demo mode filters mock results client-side so it never claims filtering that didn't happen. Distinct `filter`/`clear_filter` telemetry ids.
- **#1432 persistent search context (SMI-5305)** — a persistent `TreeView.message` banner ("Showing results for …") reflecting the active query + filters, complementary to the count-only group label (both derive from the one formatter). VS Code tree views have no native editable inline field; this delivers the intent (persistent context).
- **#1434-P2 / #1438-P2 empty & offline states (SMI-5306)** — filter-aware no-results copy, persistent offline state (preserves SMI-5288 honesty — no fake catalog), and a first-run pre-search hint (`TreeView.message`, not `viewsWelcome`, which only renders for an empty tree).

## New files
- `src/sidebar/categories.ts` — mirror of core's 6-value `API_CATEGORIES` (ADR-113: mirror, not import), with a drift guard.
- `src/commands/searchFilters.ts` — the 3-step QuickPick collector (testable in isolation).

## Process
- Design pass (`#1433`) owner-approved; plan-reviewed (APPROVE WITH EDITS — all 10 findings folded in).
- Governance review on the committed diff: **ship**, zero findings.

## Verification (host, ADR-113)
- `npm run typecheck && lint && build && package:check` — all green
- **435/435 tests** pass across 33 files (+ new `categories.test.ts`, `searchFilters.test.ts`, `searchSkills.filters.test.ts`; extended provider/service/search tests)
- `audit:standards`: 76 passed, 0 failed, 3 pre-existing warnings; every file < 500 lines

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)