### PR TITLE
feat(vscode): UX Wave 2b — richer rows + detail product page (#1436/#1437, SMI-5307/5308)

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -8,9 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+<!-- Wave 2a -->
 - **Filter Skills button** in the Skills view title bar opens a quick pick to filter discovery results by trust tier, category, and minimum score. A **Clear Skill Filters** action (shown in the title bar when filters are active) removes all active filters. Filters reset when the window reloads.
 - **Persistent status banner** in the Skills view shows what you are currently viewing — your search query and any active filters — so the context is always visible, not just a momentary toast.
 - Clearer empty and offline states: when no skills match your filters, the view says so and points you to clear them; when the Skillsmith server is unavailable the view says so directly; first-time users see a hint to start searching from the title bar or Command Palette.
+<!-- /Wave 2a -->
+
+<!-- Wave 2b -->
+- **Richer sidebar rows** — each available skill shows metadata inline: `by {author} · {category} · {score}/100 · ✓ Installed` (when also installed locally). Evaluate skills at a glance without opening every detail panel.
+- **Detail panel product page** — sticky header with Install/Uninstall action stays visible while scrolling; installed skills show **Open SKILL.md** and **Open folder** shortcuts for quick navigation.
+<!-- /Wave 2b -->
 
 ## [0.4.0] - 2026-06-18
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -28,6 +28,10 @@ Click **Filter Skills** in the Skills view title bar to narrow discovery results
 
 A persistent banner in the Skills view shows your active query and any filters so you always know what you're looking at. Use **Clear Skill Filters** (available in the title bar when filters are active) to reset them. Filters are cleared automatically when the window reloads.
 
+### Browsing and Detail View
+
+The sidebar displays skills with rich metadata on each row: author, category, score, and an installed indicator when the skill is also available locally. Click a skill to open the detail panel, where a sticky header keeps the Install or Uninstall button visible while you scroll through documentation. For installed skills, the detail panel offers quick shortcuts to open the skill's `SKILL.md` file or reveal its folder in the operating system.
+
 **Local-first by design.** Skillsmith caches the registry in a local SQLite database at `~/.skillsmith/skills.db`, shared across the MCP server, the CLI, and the VS Code extension. Search is FTS5 (SQLite's built-in keyword search) by default; semantic search is opt-in (`SKILLSMITH_USE_HNSW=true`) and runs over local ONNX embeddings (an open ML model format that runs on CPU — no API call). [Inside the Local Skill Database](https://skillsmith.app/blog/inside-the-local-skill-database) walks through the schema, the FTS5 / HNSW search paths, and how `sync` keeps the cache fresh.
 
 ## Getting Started

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -194,6 +194,11 @@
           "when": "viewItem == skill"
         },
         {
+          "command": "skillsmith.viewSkillDetails",
+          "when": "view == skillsmith.skillsView && viewItem == installedSkill",
+          "group": "navigation"
+        },
+        {
           "command": "skillsmith.uninstallSkill",
           "when": "view == skillsmith.skillsView && viewItem == installedSkill",
           "group": "inline"

--- a/packages/vscode-extension/src/__tests__/SkillDetailPanel.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillDetailPanel.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for SkillDetailPanel error handling
  * Tests the error flow, retry mechanism, and missing-service fallback.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // Mock vscode module before any imports that depend on it
 vi.mock('vscode', () => ({
@@ -11,12 +11,15 @@ vi.mock('vscode', () => ({
       fsPath: segments.join('/'),
     })),
     parse: vi.fn((s: string) => ({ toString: () => s })),
+    file: vi.fn((s: string) => ({ fsPath: s, scheme: 'file' })),
   },
   ViewColumn: { One: 1 },
   window: {
     createWebviewPanel: vi.fn(),
     activeTextEditor: undefined,
     showWarningMessage: vi.fn(),
+    showInformationMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
   },
   commands: {
     executeCommand: vi.fn(),
@@ -32,9 +35,20 @@ vi.mock('vscode', () => ({
   },
 }))
 
+// vi.hoisted so the spy exists before the hoisted vi.mock factory runs.
+const { uninstallByTarget } = vi.hoisted(() => ({ uninstallByTarget: vi.fn() }))
+vi.mock('../commands/uninstallCommand.js', () => ({
+  uninstallByTarget,
+}))
+
+vi.mock('../services/Telemetry.js', () => ({
+  track: vi.fn(),
+}))
+
 import * as vscode from 'vscode'
 import { SkillDetailPanel } from '../views/SkillDetailPanel.js'
 import type { SkillService } from '../services/SkillService.js'
+import type { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
 
 /** Creates a mock webview panel with spyable html setter */
 function createMockPanel() {
@@ -100,6 +114,22 @@ function createMockSkillService(
   } as unknown as SkillService
 }
 
+interface InstalledFixture {
+  id: string
+  name: string
+  path?: string
+  hasSkillMd?: boolean
+  isInstalled: boolean
+}
+
+/** Creates a mock SkillTreeDataProvider exposing installed fixtures. */
+function createMockTreeProvider(installed: InstalledFixture[]): SkillTreeDataProvider {
+  return {
+    getInstalledSkills: vi.fn(() => installed),
+    refreshAndWait: vi.fn(async () => {}),
+  } as unknown as SkillTreeDataProvider
+}
+
 const EXTENSION_URI = { fsPath: '/test/extension' } as vscode.Uri
 
 describe('SkillDetailPanel', () => {
@@ -107,6 +137,14 @@ describe('SkillDetailPanel', () => {
     // Reset singleton
     SkillDetailPanel.currentPanel = undefined
     vi.mocked(vscode.window.createWebviewPanel).mockReset()
+    vi.mocked(vscode.commands.executeCommand).mockReset()
+    uninstallByTarget.mockReset()
+    SkillDetailPanel.setTreeProvider(undefined)
+  })
+
+  afterEach(() => {
+    // M1: clear both injected statics so they don't leak across files/tests.
+    SkillDetailPanel.resetForTests()
   })
 
   describe('error HTML on service failure', () => {
@@ -218,6 +256,169 @@ describe('SkillDetailPanel', () => {
       await vi.waitFor(() => {
         expect(getRichSkill).toHaveBeenCalledTimes(2)
       })
+    })
+  })
+
+  describe('conditional action set (SMI-5308)', () => {
+    async function showPanel(): Promise<ReturnType<typeof createMockPanel>> {
+      const mock = createMockPanel()
+      vi.mocked(vscode.window.createWebviewPanel).mockReturnValue(mock.panel)
+      SkillDetailPanel.createOrShow(EXTENSION_URI, 'test/skill')
+      await vi.waitFor(() => {
+        const lastHtml = mock.getHtmlHistory().at(-1) ?? ''
+        expect(lastHtml).toContain('Test Skill')
+      })
+      return mock
+    }
+
+    it('renders the installed action set when the skill is installed', async () => {
+      SkillDetailPanel.setSkillService(createMockSkillService())
+      SkillDetailPanel.setTreeProvider(
+        createMockTreeProvider([
+          { id: 'skill', name: 'Test Skill', path: '/skills/skill', hasSkillMd: true, isInstalled: true },
+        ])
+      )
+
+      const mock = await showPanel()
+      const html = mock.getHtmlHistory().at(-1) ?? ''
+      expect(html).toContain('id="uninstallBtn"')
+      expect(html).toContain('id="openFolderBtn"')
+      expect(html).toContain('id="openSkillFileBtn"')
+      expect(html).not.toContain('id="installBtn"')
+    })
+
+    it('renders Install only when the skill is not installed', async () => {
+      SkillDetailPanel.setSkillService(createMockSkillService())
+      SkillDetailPanel.setTreeProvider(createMockTreeProvider([]))
+
+      const mock = await showPanel()
+      const html = mock.getHtmlHistory().at(-1) ?? ''
+      expect(html).toContain('id="installBtn"')
+      expect(html).not.toContain('id="uninstallBtn"')
+    })
+
+    it('treats the skill as available when no provider is injected (C3)', async () => {
+      SkillDetailPanel.setSkillService(createMockSkillService())
+      // No setTreeProvider — covers tests + the dead revive path.
+
+      const mock = await showPanel()
+      const html = mock.getHtmlHistory().at(-1) ?? ''
+      expect(html).toContain('id="installBtn"')
+      expect(html).not.toContain('id="uninstallBtn"')
+    })
+
+    it('omits Open SKILL.md when the installed skill has no SKILL.md', async () => {
+      SkillDetailPanel.setSkillService(createMockSkillService())
+      SkillDetailPanel.setTreeProvider(
+        createMockTreeProvider([
+          { id: 'skill', name: 'Test Skill', path: '/skills/skill', hasSkillMd: false, isInstalled: true },
+        ])
+      )
+
+      const mock = await showPanel()
+      const html = mock.getHtmlHistory().at(-1) ?? ''
+      expect(html).toContain('id="uninstallBtn"')
+      expect(html).not.toContain('id="openSkillFileBtn"')
+    })
+  })
+
+  describe('action message handlers (SMI-5308)', () => {
+    async function showInstalledPanel(
+      hasSkillMd: boolean
+    ): Promise<ReturnType<typeof createMockPanel>> {
+      SkillDetailPanel.setSkillService(createMockSkillService())
+      SkillDetailPanel.setTreeProvider(
+        createMockTreeProvider([
+          { id: 'skill', name: 'Test Skill', path: '/skills/skill', hasSkillMd, isInstalled: true },
+        ])
+      )
+      const mock = createMockPanel()
+      vi.mocked(vscode.window.createWebviewPanel).mockReturnValue(mock.panel)
+      SkillDetailPanel.createOrShow(EXTENSION_URI, 'test/skill')
+      await vi.waitFor(() => {
+        expect(mock.getHtmlHistory().at(-1) ?? '').toContain('id="uninstallBtn"')
+      })
+      return mock
+    }
+
+    it('opens SKILL.md via vscode.open when hasSkillMd', async () => {
+      const mock = await showInstalledPanel(true)
+      mock.sendMessage({ command: 'openSkillFile' })
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'vscode.open',
+        expect.objectContaining({ fsPath: '/skills/skill/SKILL.md' })
+      )
+    })
+
+    it('does not open SKILL.md when hasSkillMd is false', async () => {
+      const mock = await showInstalledPanel(false)
+      mock.sendMessage({ command: 'openSkillFile' })
+      expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith(
+        'vscode.open',
+        expect.anything()
+      )
+    })
+
+    it('reveals the folder via revealFileInOS', async () => {
+      const mock = await showInstalledPanel(true)
+      mock.sendMessage({ command: 'openFolder' })
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'revealFileInOS',
+        expect.objectContaining({ fsPath: '/skills/skill' })
+      )
+    })
+
+    it('disposes the panel after a successful in-panel uninstall (H9)', async () => {
+      uninstallByTarget.mockResolvedValue(true)
+      const mock = await showInstalledPanel(true)
+      mock.sendMessage({ command: 'uninstall' })
+      await vi.waitFor(() => {
+        expect(uninstallByTarget).toHaveBeenCalledWith(
+          { skillId: 'test/skill', skillPath: '/skills/skill' },
+          expect.anything(),
+          'detail-panel'
+        )
+      })
+      await vi.waitFor(() => {
+        expect(mock.panel.dispose).toHaveBeenCalled()
+      })
+    })
+
+    it('does not dispose the panel when uninstall returns false', async () => {
+      uninstallByTarget.mockResolvedValue(false)
+      const mock = await showInstalledPanel(true)
+      mock.sendMessage({ command: 'uninstall' })
+      await vi.waitFor(() => {
+        expect(uninstallByTarget).toHaveBeenCalled()
+      })
+      expect(mock.panel.dispose).not.toHaveBeenCalled()
+    })
+
+    it('aborts with a notice when the skill is gone at click time (M2)', async () => {
+      SkillDetailPanel.setSkillService(createMockSkillService())
+      // Provider reports the skill installed at load, but empty at click time.
+      const provider = createMockTreeProvider([
+        { id: 'skill', name: 'Test Skill', path: '/skills/skill', hasSkillMd: true, isInstalled: true },
+      ])
+      SkillDetailPanel.setTreeProvider(provider)
+
+      const mock = createMockPanel()
+      vi.mocked(vscode.window.createWebviewPanel).mockReturnValue(mock.panel)
+      SkillDetailPanel.createOrShow(EXTENSION_URI, 'test/skill')
+      await vi.waitFor(() => {
+        expect(mock.getHtmlHistory().at(-1) ?? '').toContain('id="uninstallBtn"')
+      })
+
+      // The skill vanished in another window.
+      vi.mocked(provider.getInstalledSkills).mockReturnValue([])
+      mock.sendMessage({ command: 'uninstall' })
+
+      await vi.waitFor(() => {
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+          'Skill no longer installed — refresh the tree'
+        )
+      })
+      expect(uninstallByTarget).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/vscode-extension/src/__tests__/SkillDetailPanel.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillDetailPanel.test.ts
@@ -394,6 +394,18 @@ describe('SkillDetailPanel', () => {
       expect(mock.panel.dispose).not.toHaveBeenCalled()
     })
 
+    it('surfaces a generic error and does not dispose when the core throws (H3)', async () => {
+      uninstallByTarget.mockRejectedValue(new Error('Unexpected fs error'))
+      const mock = await showInstalledPanel(true)
+      mock.sendMessage({ command: 'uninstall' })
+      await vi.waitFor(() => {
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to uninstall')
+        )
+      })
+      expect(mock.panel.dispose).not.toHaveBeenCalled()
+    })
+
     it('aborts with a notice when the skill is gone at click time (M2)', async () => {
       SkillDetailPanel.setSkillService(createMockSkillService())
       // Provider reports the skill installed at load, but empty at click time.

--- a/packages/vscode-extension/src/__tests__/SkillDetailPanel.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillDetailPanel.test.ts
@@ -275,7 +275,13 @@ describe('SkillDetailPanel', () => {
       SkillDetailPanel.setSkillService(createMockSkillService())
       SkillDetailPanel.setTreeProvider(
         createMockTreeProvider([
-          { id: 'skill', name: 'Test Skill', path: '/skills/skill', hasSkillMd: true, isInstalled: true },
+          {
+            id: 'skill',
+            name: 'Test Skill',
+            path: '/skills/skill',
+            hasSkillMd: true,
+            isInstalled: true,
+          },
         ])
       )
 
@@ -311,7 +317,13 @@ describe('SkillDetailPanel', () => {
       SkillDetailPanel.setSkillService(createMockSkillService())
       SkillDetailPanel.setTreeProvider(
         createMockTreeProvider([
-          { id: 'skill', name: 'Test Skill', path: '/skills/skill', hasSkillMd: false, isInstalled: true },
+          {
+            id: 'skill',
+            name: 'Test Skill',
+            path: '/skills/skill',
+            hasSkillMd: false,
+            isInstalled: true,
+          },
         ])
       )
 
@@ -410,7 +422,13 @@ describe('SkillDetailPanel', () => {
       SkillDetailPanel.setSkillService(createMockSkillService())
       // Provider reports the skill installed at load, but empty at click time.
       const provider = createMockTreeProvider([
-        { id: 'skill', name: 'Test Skill', path: '/skills/skill', hasSkillMd: true, isInstalled: true },
+        {
+          id: 'skill',
+          name: 'Test Skill',
+          path: '/skills/skill',
+          hasSkillMd: true,
+          isInstalled: true,
+        },
       ])
       SkillDetailPanel.setTreeProvider(provider)
 

--- a/packages/vscode-extension/src/__tests__/SkillTreeItem.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillTreeItem.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for SkillTreeItem.formatDescription (#1436 / SMI-5307)
+ *
+ * All assertions go through the public `SkillTreeItem.createSkill(data)`
+ * factory so that the description format is tested as callers observe it —
+ * no access to the private `formatDescription` method.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => {
+  class TreeItem {
+    constructor(
+      public label: string,
+      public collapsibleState?: number
+    ) {}
+    iconPath?: unknown
+    description?: string
+    tooltip?: unknown
+    contextValue?: string
+    command?: unknown
+    id?: string
+  }
+  return {
+    TreeItem,
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    MarkdownString: class {
+      value = ''
+      isTrusted = true
+      appendMarkdown(s: string) {
+        this.value += s
+        return this
+      }
+      appendText(s: string) {
+        this.value += s
+        return this
+      }
+      appendCodeblock() {
+        return this
+      }
+    },
+    ThemeIcon: class {
+      constructor(
+        public id: string,
+        public color?: unknown
+      ) {}
+    },
+    ThemeColor: class {
+      constructor(public id: string) {}
+    },
+    Uri: { parse: (s: string) => ({ toString: () => s }) },
+  }
+})
+
+import { SkillTreeItem } from '../sidebar/SkillTreeItem.js'
+import type { SkillItemData } from '../sidebar/SkillTreeItem.js'
+
+/** Minimal base data — override per test */
+const base: SkillItemData = {
+  id: 'test/skill',
+  name: 'Test Skill',
+  description: undefined,
+  isInstalled: false,
+}
+
+describe('SkillTreeItem.formatDescription (#1436 / SMI-5307)', () => {
+  it('all four segments present → joined with U+00B7 middle dot', () => {
+    const item = SkillTreeItem.createSkill({
+      ...base,
+      author: 'Alice',
+      category: 'testing',
+      score: 90,
+      installedElsewhere: true,
+    })
+    expect(item.description).toBe('by Alice · testing · 90/100 · ✓ Installed')
+  })
+
+  it('author only → "by {author}"', () => {
+    const item = SkillTreeItem.createSkill({ ...base, author: 'Alice' })
+    expect(item.description).toBe('by Alice')
+  })
+
+  it('score 0 → included as "0/100" (zero is not omitted)', () => {
+    const item = SkillTreeItem.createSkill({ ...base, score: 0 })
+    expect(item.description).toContain('0/100')
+  })
+
+  it('score undefined → no score segment', () => {
+    const item = SkillTreeItem.createSkill({ ...base, author: 'Alice', category: 'cat' })
+    expect(item.description).not.toContain('/100')
+    expect(item.description).toBe('by Alice · cat')
+  })
+
+  it('no fields at all → empty string', () => {
+    const item = SkillTreeItem.createSkill({ ...base })
+    expect(item.description).toBe('')
+  })
+
+  it('installedElsewhere true → description ends with "✓ Installed"', () => {
+    const item = SkillTreeItem.createSkill({ ...base, installedElsewhere: true })
+    expect(item.description).toBe('✓ Installed')
+  })
+
+  it('installedElsewhere absent (undefined) → no "✓ Installed" marker', () => {
+    const item = SkillTreeItem.createSkill({ ...base, author: 'Bob' })
+    expect(item.description).not.toContain('✓ Installed')
+  })
+
+  it('category and score without author → correct order, no "by" prefix', () => {
+    const item = SkillTreeItem.createSkill({ ...base, category: 'devops', score: 75 })
+    expect(item.description).toBe('devops · 75/100')
+  })
+
+  // Regression guard — H4: installedElsewhere must NOT leak into contextValue.
+  // An available item with installedElsewhere:true must stay contextValue='skill'
+  // so getParent() routes it to the Available group, not the Installed group.
+  it('regression guard: installedElsewhere:true + isInstalled:false → contextValue "skill"', () => {
+    const item = SkillTreeItem.createSkill({
+      ...base,
+      isInstalled: false,
+      installedElsewhere: true,
+    })
+    expect(item.contextValue).toBe('skill')
+  })
+
+  it('regression guard: isInstalled:true → contextValue "installedSkill"', () => {
+    const item = SkillTreeItem.createSkill({
+      ...base,
+      isInstalled: true,
+    })
+    expect(item.contextValue).toBe('installedSkill')
+  })
+
+  it('trust-tier label is NOT present in description (redundant with icon)', () => {
+    const item = SkillTreeItem.createSkill({
+      ...base,
+      author: 'Alice',
+      trustTier: 'verified',
+    })
+    // Trust tier labels like "Verified" must not appear in the description line.
+    expect(item.description).not.toMatch(/verified/i)
+    expect(item.description).toBe('by Alice')
+  })
+})

--- a/packages/vscode-extension/src/__tests__/skill-panel-actions.test.ts
+++ b/packages/vscode-extension/src/__tests__/skill-panel-actions.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for skill-panel-actions.ts (SMI-5308).
+ * Covers the conditional action block: Install (available) vs
+ * Uninstall + Open Folder + Open SKILL.md (installed), aria-labels, and the
+ * SKILL.md gate.
+ */
+import { describe, it, expect } from 'vitest'
+import { getActionBlock } from '../views/skill-panel-actions.js'
+
+const REPO = 'https://github.com/tester/test-skill'
+
+describe('getActionBlock', () => {
+  describe('available state (not installed)', () => {
+    it('renders the Install button only when there is no repository', () => {
+      const html = getActionBlock({ installed: false }, '')
+      expect(html).toContain('id="installBtn"')
+      expect(html).toContain('Install Skill')
+      expect(html).not.toContain('id="repoBtn"')
+      expect(html).not.toContain('id="uninstallBtn"')
+      expect(html).not.toContain('id="openFolderBtn"')
+    })
+
+    it('adds the View Repository button when a repository is present', () => {
+      const html = getActionBlock({ installed: false }, REPO)
+      expect(html).toContain('id="installBtn"')
+      expect(html).toContain('id="repoBtn"')
+      expect(html).toContain('View Repository')
+      expect(html).toContain(`data-url="${REPO}"`)
+    })
+  })
+
+  describe('installed state', () => {
+    it('renders Uninstall + Open Folder + Open SKILL.md when hasSkillMd', () => {
+      const html = getActionBlock(
+        { installed: true, skillPath: '/skills/test-skill', hasSkillMd: true },
+        ''
+      )
+      expect(html).toContain('id="uninstallBtn"')
+      expect(html).toContain('btn-destructive')
+      expect(html).toContain('id="openFolderBtn"')
+      expect(html).toContain('id="openSkillFileBtn"')
+      expect(html).toContain('Open SKILL.md')
+      expect(html).not.toContain('id="installBtn"')
+    })
+
+    it('omits Open SKILL.md when hasSkillMd is false', () => {
+      const html = getActionBlock(
+        { installed: true, skillPath: '/skills/test-skill', hasSkillMd: false },
+        ''
+      )
+      expect(html).toContain('id="uninstallBtn"')
+      expect(html).toContain('id="openFolderBtn"')
+      expect(html).not.toContain('id="openSkillFileBtn"')
+    })
+
+    it('omits Open SKILL.md when hasSkillMd is undefined', () => {
+      const html = getActionBlock({ installed: true, skillPath: '/skills/test-skill' }, '')
+      expect(html).not.toContain('id="openSkillFileBtn"')
+    })
+
+    it('keeps the repo button alongside the installed actions when present', () => {
+      const html = getActionBlock(
+        { installed: true, skillPath: '/skills/test-skill', hasSkillMd: true },
+        REPO
+      )
+      expect(html).toContain('id="repoBtn"')
+      expect(html).toContain('id="uninstallBtn"')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('gives every available-state action an explicit aria-label', () => {
+      const html = getActionBlock({ installed: false }, REPO)
+      expect(html).toContain('aria-label="Install this skill"')
+      expect(html).toContain('aria-label="View the source repository"')
+    })
+
+    it('gives every installed-state action an explicit aria-label', () => {
+      const html = getActionBlock(
+        { installed: true, skillPath: '/skills/test-skill', hasSkillMd: true },
+        ''
+      )
+      expect(html).toContain('aria-label="Uninstall this skill"')
+      expect(html).toContain('aria-label="Open the skill folder"')
+      expect(html).toContain('aria-label="Open SKILL.md"')
+    })
+  })
+
+  describe('security', () => {
+    it('escapes a repository URL with HTML metacharacters', () => {
+      const html = getActionBlock({ installed: false }, 'https://x.test/"><script>')
+      expect(html).not.toContain('<script>')
+      expect(html).toContain('&lt;script&gt;')
+    })
+  })
+})

--- a/packages/vscode-extension/src/__tests__/skill-panel-actions.test.ts
+++ b/packages/vscode-extension/src/__tests__/skill-panel-actions.test.ts
@@ -86,9 +86,20 @@ describe('getActionBlock', () => {
     })
   })
 
-  describe('security', () => {
-    it('escapes a repository URL with HTML metacharacters', () => {
-      const html = getActionBlock({ installed: false }, 'https://x.test/"><script>')
+  describe('repository URL handling', () => {
+    it('interpolates an already-escaped URL without double-encoding (&amp; stays &amp;)', () => {
+      // The caller (getSkillDetailHtml) pre-escapes the URL. getActionBlock must
+      // NOT re-escape, or `&` in a query string becomes `&amp;amp;` and the
+      // webview opens the wrong URL.
+      const safe = 'https://x.test/repo?a=1&amp;b=2'
+      const html = getActionBlock({ installed: false }, safe)
+      expect(html).toContain('data-url="https://x.test/repo?a=1&amp;b=2"')
+      expect(html).not.toContain('&amp;amp;')
+    })
+
+    it('emits no raw script tag for a properly pre-escaped URL', () => {
+      const safe = 'https://x.test/&quot;&gt;&lt;script&gt;'
+      const html = getActionBlock({ installed: false }, safe)
       expect(html).not.toContain('<script>')
       expect(html).toContain('&lt;script&gt;')
     })

--- a/packages/vscode-extension/src/__tests__/skill-panel-html.test.ts
+++ b/packages/vscode-extension/src/__tests__/skill-panel-html.test.ts
@@ -103,20 +103,9 @@ describe('getSkillDetailHtml', () => {
       expect(html).not.toContain('inferred from skill ID')
     })
 
-    it('shows View Repository button for explicit repository', () => {
-      const html = getSkillDetailHtml(
-        makeSkill({ repository: 'https://github.com/tester/test-skill' }),
-        NONCE,
-        CSP
-      )
-      expect(html).toContain('View Repository')
-    })
-
-    it('suppresses View Repository button for inferred repository', () => {
-      const html = getSkillDetailHtml(makeSkill({ id: 'tester/test-skill' }), NONCE, CSP)
-      expect(html).toContain('inferred from skill ID')
-      expect(html).not.toContain('View Repository')
-    })
+    // Action-block assertions (Install / View Repository buttons) live in
+    // skill-panel-actions.test.ts after the SMI-5308 split — getActionBlock owns
+    // that markup now.
   })
 
   describe('description markdown rendering', () => {
@@ -258,6 +247,42 @@ describe('getSkillDetailHtml', () => {
     it('omits skill content section when content is absent', () => {
       const html = getSkillDetailHtml(makeSkill(), NONCE, CSP)
       expect(html).not.toContain('Skill Content')
+    })
+  })
+
+  describe('sticky header restructure (SMI-5308)', () => {
+    it('wraps the title + badge in a header-titles container with the action block', () => {
+      const html = getSkillDetailHtml(makeSkill(), NONCE, CSP)
+      expect(html).toContain('class="header-titles"')
+      // The action block renders inside the header (sticky CTA), not as a
+      // trailing bottom block.
+      const header = html.split('class="header"')[1]?.split('class="description"')[0] ?? ''
+      expect(header).toContain('class="actions"')
+    })
+
+    it('does not render the root-level aria-live wrapper (H6)', () => {
+      const html = getSkillDetailHtml(makeSkill(), NONCE, CSP)
+      // The whole-body aria-live wrapper was removed so reloads don't announce
+      // the entire panel. The detail body must contain no aria-live region.
+      const body = html.split('<body>')[1] ?? ''
+      expect(body).not.toContain('aria-live')
+    })
+
+    it('renders Install action for available (default) skills', () => {
+      const html = getSkillDetailHtml(makeSkill(), NONCE, CSP)
+      expect(html).toContain('id="installBtn"')
+      expect(html).not.toContain('id="uninstallBtn"')
+    })
+
+    it('renders the installed action set when actionCtx.installed', () => {
+      const html = getSkillDetailHtml(makeSkill(), NONCE, CSP, false, {
+        installed: true,
+        skillPath: '/skills/test-skill',
+        hasSkillMd: true,
+      })
+      expect(html).toContain('id="uninstallBtn"')
+      expect(html).toContain('id="openFolderBtn"')
+      expect(html).not.toContain('id="installBtn"')
     })
   })
 })

--- a/packages/vscode-extension/src/__tests__/skill-panel-script.test.ts
+++ b/packages/vscode-extension/src/__tests__/skill-panel-script.test.ts
@@ -28,6 +28,32 @@ describe('getScript', () => {
     expect(html).toContain("command: 'install'")
   })
 
+  it('null-guards the install button (C1)', () => {
+    // The install button is absent on the installed-skill view; an unguarded
+    // getElementById('installBtn').addEventListener would throw and kill every
+    // listener wired after it.
+    expect(html).toContain('const installBtn = ')
+    expect(html).toContain('if (installBtn) {')
+  })
+
+  it('wires the uninstall button to the uninstall command', () => {
+    expect(html).toContain("getElementById('uninstallBtn')")
+    expect(html).toContain("command: 'uninstall'")
+    expect(html).toContain('if (uninstallBtn) {')
+  })
+
+  it('wires the Open SKILL.md button', () => {
+    expect(html).toContain("getElementById('openSkillFileBtn')")
+    expect(html).toContain("command: 'openSkillFile'")
+    expect(html).toContain('if (openSkillFileBtn) {')
+  })
+
+  it('wires the Open Folder button', () => {
+    expect(html).toContain("getElementById('openFolderBtn')")
+    expect(html).toContain("command: 'openFolder'")
+    expect(html).toContain('if (openFolderBtn) {')
+  })
+
   it('includes repository button listener', () => {
     expect(html).toContain("getElementById('repoBtn')")
     expect(html).toContain("command: 'openRepository'")

--- a/packages/vscode-extension/src/__tests__/skill-panel-styles.test.ts
+++ b/packages/vscode-extension/src/__tests__/skill-panel-styles.test.ts
@@ -59,6 +59,19 @@ describe('getStyles', () => {
     expect(css).toContain('.btn-secondary')
   })
 
+  it('makes the header sticky with an opaque background (SMI-5308)', () => {
+    expect(css).toContain('position: sticky')
+    expect(css).toContain('top: 0')
+    expect(css).toContain('background-color: var(--vscode-editor-background)')
+    expect(css).toContain('justify-content: space-between')
+  })
+
+  it('defines a destructive button style using VS Code error tokens', () => {
+    expect(css).toContain('.btn-destructive')
+    expect(css).toContain('var(--vscode-inputValidation-errorBackground)')
+    expect(css).toContain('var(--vscode-errorForeground)')
+  })
+
   it('contains repository link styles with focus indicator', () => {
     expect(css).toContain('.repository-link')
     expect(css).toContain('.repository-link:focus')

--- a/packages/vscode-extension/src/__tests__/skillTreeDataProvider.crossref.test.ts
+++ b/packages/vscode-extension/src/__tests__/skillTreeDataProvider.crossref.test.ts
@@ -1,0 +1,332 @@
+/**
+ * SkillTreeDataProvider — installedElsewhere cross-reference + hasSkillMd
+ * (#1436 / SMI-5307)
+ *
+ * Split from skillTreeDataProvider.test.ts to stay under the 500-line limit.
+ * These tests exercise the render-time `installedElsewhere` annotation (C2 /
+ * H4) and the `hasSkillMd` flag set in `doLoadInstalledSkills`.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+vi.mock('vscode', () => {
+  class TreeItem {
+    constructor(
+      public label: string,
+      public collapsibleState?: number
+    ) {}
+    iconPath?: unknown
+    description?: string
+    tooltip?: unknown
+    contextValue?: string
+    command?: unknown
+    id?: string
+  }
+  return {
+    EventEmitter: class {
+      event = vi.fn()
+      fire = vi.fn()
+    },
+    workspace: {
+      getConfiguration: vi.fn(() => ({ get: vi.fn(() => undefined) })),
+    },
+    TreeItem,
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    MarkdownString: class {
+      value = ''
+      isTrusted = true
+      appendMarkdown(s: string) {
+        this.value += s
+        return this
+      }
+      appendText(s: string) {
+        this.value += s
+        return this
+      }
+      appendCodeblock() {
+        return this
+      }
+    },
+    ThemeIcon: class {
+      constructor(
+        public id: string,
+        public color?: unknown
+      ) {}
+    },
+    ThemeColor: class {
+      constructor(public id: string) {}
+    },
+    Uri: { parse: (s: string) => ({ toString: () => s }) },
+  }
+})
+
+describe('SkillTreeDataProvider installedElsewhere cross-reference (#1436 / SMI-5307)', () => {
+  // C2: normalized id cross-reference — registry id `smith-horn/my-skill` must
+  // match installed slug `my-skill`; unrelated `smith-horn/other` must not.
+  it('C2: Available child for a registry hit matching an installed slug gets installedElsewhere', async () => {
+    const localRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'skillsmith-c2-'))
+    try {
+      const skillDir = path.join(localRoot, 'my-skill')
+      await fs.mkdir(skillDir)
+
+      const vscode = await import('vscode')
+      vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+        get: vi.fn(() => localRoot),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+
+      const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+      const provider = new SkillTreeDataProvider()
+      await provider.refreshAndWait()
+
+      provider.setSearchResults(
+        [
+          {
+            id: 'smith-horn/my-skill',
+            name: 'My Skill',
+            description: 'desc',
+            author: 'smith-horn',
+            category: 'cat',
+            trustTier: 'verified',
+            score: 80,
+          },
+          {
+            id: 'smith-horn/other',
+            name: 'Other',
+            description: 'desc2',
+            author: 'smith-horn',
+            category: 'cat',
+            trustTier: 'community',
+            score: 60,
+          },
+        ],
+        'test'
+      )
+
+      const availableGroup = provider.getChildren().find((g) => g.groupId === 'available')
+      if (!availableGroup) throw new Error('expected an available group')
+      const children = provider.getChildren(availableGroup)
+
+      const mySkillItem = children.find((c) => c.skillData?.id === 'smith-horn/my-skill')
+      const otherItem = children.find((c) => c.skillData?.id === 'smith-horn/other')
+
+      if (!mySkillItem) throw new Error('expected smith-horn/my-skill in available children')
+      if (!otherItem) throw new Error('expected smith-horn/other in available children')
+
+      // The matching hit must carry the installedElsewhere marker.
+      expect(mySkillItem.skillData?.installedElsewhere).toBe(true)
+      expect(String(mySkillItem.description)).toContain('✓ Installed')
+
+      // The non-matching hit must not.
+      expect(otherItem.skillData?.installedElsewhere).toBeFalsy()
+      expect(String(otherItem.description)).not.toContain('✓ Installed')
+    } finally {
+      await fs.rm(localRoot, { recursive: true, force: true })
+    }
+  })
+
+  // Async ordering (a): search results arrive BEFORE installed scan completes;
+  // after scan, re-rendering getGroupChildren must apply the marker.
+  it('async ordering (a): setSearchResults before installed load — marker present after load', async () => {
+    const localRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'skillsmith-async-a-'))
+    try {
+      const skillDir = path.join(localRoot, 'my-skill')
+      await fs.mkdir(skillDir)
+
+      const vscode = await import('vscode')
+      vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+        get: vi.fn(() => localRoot),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+
+      const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+      const provider = new SkillTreeDataProvider()
+
+      // Set search results immediately (before the constructor-fired load settles).
+      provider.setSearchResults(
+        [
+          {
+            id: 'smith-horn/my-skill',
+            name: 'My Skill',
+            description: 'd',
+            author: 'a',
+            category: 'cat',
+            trustTier: 'verified',
+            score: 80,
+          },
+        ],
+        'test'
+      )
+
+      // Wait for the installed load to complete; getGroupChildren re-evaluates
+      // against the now-populated installedSkills on the next getChildren call.
+      await provider.refreshAndWait()
+
+      const availableGroup = provider.getChildren().find((g) => g.groupId === 'available')
+      if (!availableGroup) throw new Error('expected an available group')
+      const children = provider.getChildren(availableGroup)
+      const item = children.find((c) => c.skillData?.id === 'smith-horn/my-skill')
+      if (!item) throw new Error('expected smith-horn/my-skill')
+
+      expect(item.skillData?.installedElsewhere).toBe(true)
+    } finally {
+      await fs.rm(localRoot, { recursive: true, force: true })
+    }
+  })
+
+  // Async ordering (b): installed scan completes first, then search arrives.
+  it('async ordering (b): installed load first, then setSearchResults — marker present', async () => {
+    const localRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'skillsmith-async-b-'))
+    try {
+      const skillDir = path.join(localRoot, 'my-skill')
+      await fs.mkdir(skillDir)
+
+      const vscode = await import('vscode')
+      vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+        get: vi.fn(() => localRoot),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+
+      const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+      const provider = new SkillTreeDataProvider()
+      await provider.refreshAndWait()
+
+      // Search arrives after load has settled.
+      provider.setSearchResults(
+        [
+          {
+            id: 'smith-horn/my-skill',
+            name: 'My Skill',
+            description: 'd',
+            author: 'a',
+            category: 'cat',
+            trustTier: 'verified',
+            score: 80,
+          },
+        ],
+        'test'
+      )
+
+      const availableGroup = provider.getChildren().find((g) => g.groupId === 'available')
+      if (!availableGroup) throw new Error('expected an available group')
+      const children = provider.getChildren(availableGroup)
+      const item = children.find((c) => c.skillData?.id === 'smith-horn/my-skill')
+      if (!item) throw new Error('expected smith-horn/my-skill')
+
+      expect(item.skillData?.installedElsewhere).toBe(true)
+    } finally {
+      await fs.rm(localRoot, { recursive: true, force: true })
+    }
+  })
+
+  // H4 / reveal-contract guard: a search hit that is also installed still
+  // parents to the Available group, never to the Installed group.
+  // `getAvailableGroupItem().id === 'group:available'` must be unchanged.
+  it('reveal-contract guard: installedElsewhere item still parents to Available group', async () => {
+    const localRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'skillsmith-reveal-'))
+    try {
+      const skillDir = path.join(localRoot, 'my-skill')
+      await fs.mkdir(skillDir)
+
+      const vscode = await import('vscode')
+      vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+        get: vi.fn(() => localRoot),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+
+      const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+      const provider = new SkillTreeDataProvider()
+      await provider.refreshAndWait()
+
+      provider.setSearchResults(
+        [
+          {
+            id: 'smith-horn/my-skill',
+            name: 'My Skill',
+            description: 'd',
+            author: 'a',
+            category: 'cat',
+            trustTier: 'verified',
+            score: 80,
+          },
+        ],
+        'test'
+      )
+
+      const availableGroup = provider.getChildren().find((g) => g.groupId === 'available')
+      if (!availableGroup) throw new Error('expected an available group')
+      const children = provider.getChildren(availableGroup)
+      const item = children.find((c) => c.skillData?.id === 'smith-horn/my-skill')
+      if (!item) throw new Error('expected smith-horn/my-skill')
+
+      // installedElsewhere is set, but isInstalled stays false and contextValue
+      // stays 'skill' — getParent must route to Available, not Installed.
+      expect(item.skillData?.installedElsewhere).toBe(true)
+      expect(item.skillData?.isInstalled).toBe(false)
+      expect(item.contextValue).toBe('skill')
+
+      const parent = provider.getParent(item)
+      expect(parent?.groupId).toBe('available')
+      expect(parent?.id).toBe('group:available')
+
+      // Stable Available group id is unaffected by the cross-reference.
+      expect(provider.getAvailableGroupItem()?.id).toBe('group:available')
+    } finally {
+      await fs.rm(localRoot, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('SkillTreeDataProvider hasSkillMd (#1436 / SMI-5307)', () => {
+  it('installed skill with SKILL.md present → hasSkillMd true', async () => {
+    const localRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'skillsmith-skillmd-'))
+    try {
+      const skillDir = path.join(localRoot, 'has-skill-md')
+      await fs.mkdir(skillDir)
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '---\nname: has-skill-md\n---\nDesc')
+
+      const vscode = await import('vscode')
+      vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+        get: vi.fn(() => localRoot),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+
+      const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+      const provider = new SkillTreeDataProvider()
+      await provider.refreshAndWait()
+
+      const installed = provider.getInstalledSkills()
+      expect(installed).toHaveLength(1)
+      expect(installed[0]?.hasSkillMd).toBe(true)
+    } finally {
+      await fs.rm(localRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('installed skill without SKILL.md → hasSkillMd falsy (undefined)', async () => {
+    const localRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'skillsmith-noskillmd-'))
+    try {
+      const skillDir = path.join(localRoot, 'no-skill-md')
+      await fs.mkdir(skillDir)
+      // No SKILL.md written — readFile throws, hasSkillMd stays false/undefined.
+
+      const vscode = await import('vscode')
+      vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+        get: vi.fn(() => localRoot),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+
+      const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+      const provider = new SkillTreeDataProvider()
+      await provider.refreshAndWait()
+
+      const installed = provider.getInstalledSkills()
+      expect(installed).toHaveLength(1)
+      expect(installed[0]?.hasSkillMd).toBeFalsy()
+    } finally {
+      await fs.rm(localRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/vscode-extension/src/__tests__/uninstallCommand.test.ts
+++ b/packages/vscode-extension/src/__tests__/uninstallCommand.test.ts
@@ -50,8 +50,9 @@ vi.mock('../services/installUtils.js', () => ({
   getSkillsDirectory: vi.fn(() => globalThis.__TEMP_ROOT__ as string),
 }))
 
+const track = vi.fn()
 vi.mock('../services/Telemetry.js', () => ({
-  track: vi.fn(),
+  track,
 }))
 
 declare global {
@@ -78,6 +79,7 @@ describe('uninstallCommand (SMI-4195)', () => {
     registerCommand.mockReset()
     mcpConnected.mockReset().mockReturnValue(true)
     mcpUninstall.mockReset()
+    track.mockReset()
     refreshAndWait.mockReset().mockResolvedValue(undefined)
     getInstalledSkills.mockReset().mockReturnValue([
       {
@@ -232,5 +234,129 @@ describe('uninstallCommand (SMI-4195)', () => {
 
     await expect(fs.access(skillPath)).rejects.toThrow()
     expect(showInformationMessage).toHaveBeenCalledWith('Uninstalled "example-skill".')
+  })
+})
+
+describe('uninstallByTarget core (SMI-5308 / detail-panel)', () => {
+  let tempRoot: string
+  let skillPath: string
+  let uninstallByTarget: typeof import('../commands/uninstallCommand.js')['uninstallByTarget']
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let provider: any
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'uninstall-core-'))
+    globalThis.__TEMP_ROOT__ = tempRoot
+    skillPath = path.join(tempRoot, 'example-skill')
+    await fs.mkdir(skillPath)
+
+    showWarningMessage.mockReset()
+    showErrorMessage.mockReset()
+    showInformationMessage.mockReset()
+    mcpConnected.mockReset().mockReturnValue(true)
+    mcpUninstall.mockReset()
+    track.mockReset()
+    refreshAndWait.mockReset().mockResolvedValue(undefined)
+
+    vi.resetModules()
+    const mod = await import('../commands/uninstallCommand.js')
+    uninstallByTarget = mod.uninstallByTarget
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    provider = new SkillTreeDataProvider()
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true })
+  })
+
+  it('returns true and emits detail-panel telemetry on MCP success', async () => {
+    showWarningMessage.mockResolvedValue('Uninstall')
+    mcpUninstall.mockResolvedValue({ success: true, skillId: 'example-skill' })
+
+    const ok = await uninstallByTarget(
+      { skillId: 'example-skill', skillPath },
+      { treeProvider: provider },
+      'detail-panel'
+    )
+
+    expect(ok).toBe(true)
+    expect(mcpUninstall).toHaveBeenCalledWith('example-skill')
+    expect(track).toHaveBeenCalledWith('vscode_uninstall_start', { via: 'detail-panel' })
+    expect(track).toHaveBeenCalledWith('vscode_uninstall_complete', { via: 'detail-panel' })
+    expect(showInformationMessage).toHaveBeenCalledWith('Uninstalled "example-skill".')
+  })
+
+  it('returns false on confirm cancel', async () => {
+    showWarningMessage.mockResolvedValue(undefined)
+
+    const ok = await uninstallByTarget(
+      { skillId: 'example-skill', skillPath },
+      { treeProvider: provider },
+      'detail-panel'
+    )
+
+    expect(ok).toBe(false)
+    expect(mcpUninstall).not.toHaveBeenCalled()
+    expect(track).toHaveBeenCalledWith('vscode_uninstall_cancelled', {
+      via: 'detail-panel',
+      stage: 'confirm',
+    })
+  })
+
+  it('returns false and refuses when the path is outside the root', async () => {
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'uninstall-core-outside-'))
+    try {
+      const evilLink = path.join(tempRoot, 'evil')
+      await fs.symlink(outside, evilLink)
+      showWarningMessage.mockResolvedValue('Uninstall')
+
+      const ok = await uninstallByTarget(
+        { skillId: 'evil', skillPath: evilLink },
+        { treeProvider: provider },
+        'detail-panel'
+      )
+
+      expect(ok).toBe(false)
+      expect(mcpUninstall).not.toHaveBeenCalled()
+      expect(track).toHaveBeenCalledWith('vscode_uninstall_failed', {
+        via: 'detail-panel',
+        reason: 'path_outside_root',
+      })
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true })
+    }
+  })
+
+  it('routes TierDenied to the upgrade UX and returns false', async () => {
+    showWarningMessage.mockResolvedValueOnce('Uninstall').mockResolvedValueOnce(undefined)
+    mcpUninstall.mockResolvedValue({ success: false, error: 'TierDenied: requires the Team plan' })
+
+    const ok = await uninstallByTarget(
+      { skillId: 'example-skill', skillPath },
+      { treeProvider: provider },
+      'detail-panel'
+    )
+
+    expect(ok).toBe(false)
+    expect(track).toHaveBeenCalledWith('vscode_uninstall_failed', {
+      via: 'detail-panel',
+      reason: 'tier_denied',
+    })
+    await expect(fs.access(skillPath)).resolves.toBeUndefined()
+  })
+
+  it('falls back to fs.rm on transport throw and returns true', async () => {
+    showWarningMessage.mockResolvedValue('Uninstall')
+    mcpUninstall.mockRejectedValue(new Error('ECONNRESET'))
+
+    const ok = await uninstallByTarget(
+      { skillId: 'example-skill', skillPath },
+      { treeProvider: provider },
+      'detail-panel'
+    )
+
+    expect(ok).toBe(true)
+    await expect(fs.access(skillPath)).rejects.toThrow()
+    expect(track).toHaveBeenCalledWith('vscode_uninstall_complete', { via: 'detail-panel' })
   })
 })

--- a/packages/vscode-extension/src/__tests__/uninstallCommand.test.ts
+++ b/packages/vscode-extension/src/__tests__/uninstallCommand.test.ts
@@ -240,7 +240,7 @@ describe('uninstallCommand (SMI-4195)', () => {
 describe('uninstallByTarget core (SMI-5308 / detail-panel)', () => {
   let tempRoot: string
   let skillPath: string
-  let uninstallByTarget: typeof import('../commands/uninstallCommand.js')['uninstallByTarget']
+  let uninstallByTarget: (typeof import('../commands/uninstallCommand.js'))['uninstallByTarget']
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let provider: any
 

--- a/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
@@ -28,6 +28,7 @@ import { searchSkillsAction, filterSkillsAction, clearFiltersAction } from '../s
 import { installCommandAction } from '../installCommand.js'
 import { uninstallCommandAction } from '../uninstallCommand.js'
 import { createSkillAction } from '../createSkillCommand.js'
+import type { TelemetryEvent } from '../../services/Telemetry.js'
 
 /** Registered command id → wrapped panel action. */
 const VSCODE_DISPATCHER_MAP: Record<string, (...args: never[]) => unknown> = {
@@ -65,5 +66,15 @@ describe('SMI-5130: VS Code command telemetry coverage', () => {
     const count = Object.keys(VSCODE_DISPATCHER_MAP).length
     console.info(`[SMI-5130] VS Code telemetry coverage: ${count} panel actions wrapped.`)
     expect(count).toBe(6)
+  })
+
+  // SMI-5308 (M5): the detail-panel open actions are postMessage handlers, not
+  // registered commands, so they don't appear in VSCODE_DISPATCHER_MAP. Assert
+  // their distinct, type-safe ids exist in the TelemetryEvent union (a removal
+  // or rename breaks compilation here).
+  it('declares distinct telemetry ids for the detail-panel open actions', () => {
+    const openIds: TelemetryEvent[] = ['vscode_open_skill_file', 'vscode_open_folder']
+    expect(openIds).toHaveLength(2)
+    expect(new Set(openIds).size).toBe(2)
   })
 })

--- a/packages/vscode-extension/src/commands/uninstallCommand.ts
+++ b/packages/vscode-extension/src/commands/uninstallCommand.ts
@@ -30,44 +30,52 @@ interface UninstallCommandDeps {
  * check → MCP uninstall_skill → refresh tree. Falls back to `fs.rm` when MCP
  * is disconnected (same containment guard).
  */
-// SMI-5130: extracted from the inline registerCommand closure so withTelemetry
-// can wrap it at the export boundary (telemetry coverage gate).
-async function uninstallCommandImpl(
+/** Where the uninstall was initiated from (drives the `via` telemetry dimension). */
+type UninstallVia = 'context-menu' | 'palette' | 'detail-panel'
+
+/**
+ * Shared uninstall core (SMI-5308 / L3). Runs the confirm → containment guard →
+ * MCP-first → `fs.rm` fallback → tierDenied → refresh → success-toast → telemetry
+ * sequence for ALL entry paths (command palette, tree context menu, detail
+ * panel). Keeping the `track()` calls here guarantees every caller emits the
+ * full start/complete/failed/cancelled envelope.
+ *
+ * `via` is an explicit parameter (NOT derived from the target) so each caller
+ * declares its own surface.
+ *
+ * @returns `true` on a successful uninstall, `false` on cancel/refusal/failure.
+ */
+export async function uninstallByTarget(
+  target: { skillId: string; skillPath: string },
   deps: UninstallCommandDeps,
-  arg?: SkillTreeItem
-): Promise<void> {
+  via: UninstallVia
+): Promise<boolean> {
   const { treeProvider } = deps
-  const via = arg?.skillData?.isInstalled ? 'context-menu' : 'palette'
   track('vscode_uninstall_start', { via })
-  const pick = await resolveTarget(arg, treeProvider)
-  if (!pick) {
-    track('vscode_uninstall_cancelled', { via, stage: 'resolve' })
-    return
-  }
 
   const confirm = await vscode.window.showWarningMessage(
-    `Uninstall skill "${pick.skillId}"?`,
+    `Uninstall skill "${target.skillId}"?`,
     {
       modal: true,
-      detail: `This will permanently delete:\n${pick.skillPath}\n\nThis action cannot be undone.`,
+      detail: `This will permanently delete:\n${target.skillPath}\n\nThis action cannot be undone.`,
     },
     'Uninstall'
   )
   if (confirm !== 'Uninstall') {
     track('vscode_uninstall_cancelled', { via, stage: 'confirm' })
-    return
+    return false
   }
 
   const skillsRoot = getSkillsDirectory()
   try {
-    await assertInsideRoot(pick.skillPath, skillsRoot)
+    await assertInsideRoot(target.skillPath, skillsRoot)
   } catch (err) {
     if (err instanceof PathOutsideRoot) {
       track('vscode_uninstall_failed', { via, reason: 'path_outside_root' })
       void vscode.window.showErrorMessage(
-        `Refusing to uninstall: "${pick.skillPath}" resolves outside the configured skills directory.`
+        `Refusing to uninstall: "${target.skillPath}" resolves outside the configured skills directory.`
       )
-      return
+      return false
     }
     throw err
   }
@@ -77,7 +85,7 @@ async function uninstallCommandImpl(
 
   if (client.isConnected()) {
     try {
-      const result = await client.uninstallSkill(pick.skillId)
+      const result = await client.uninstallSkill(target.skillId)
       if (!result.success) {
         // MCP is reachable and deliberately refused — surface this, do NOT fall back to
         // fs.rm. Falling back would bypass server-side enforcement (e.g. tier-gated ops).
@@ -89,12 +97,12 @@ async function uninstallCommandImpl(
             'skillsmith.uninstallSkill',
             new McpToolError('uninstall_skill', 'TierDenied', result.error!)
           )
-          return
+          return false
         }
         const reason = result.error ?? 'MCP server refused the uninstall request'
         track('vscode_uninstall_failed', { via, reason: 'mcp_refused' })
-        void vscode.window.showErrorMessage(`Failed to uninstall "${pick.skillId}": ${reason}`)
-        return
+        void vscode.window.showErrorMessage(`Failed to uninstall "${target.skillId}": ${reason}`)
+        return false
       }
       uninstalled = true
     } catch (err) {
@@ -106,19 +114,40 @@ async function uninstallCommandImpl(
 
   if (!uninstalled) {
     try {
-      await fs.rm(pick.skillPath, { recursive: true, force: true })
+      await fs.rm(target.skillPath, { recursive: true, force: true })
       uninstalled = true
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       track('vscode_uninstall_failed', { via, reason: 'fs_rm_error' })
-      void vscode.window.showErrorMessage(`Failed to uninstall "${pick.skillId}": ${msg}`)
-      return
+      void vscode.window.showErrorMessage(`Failed to uninstall "${target.skillId}": ${msg}`)
+      return false
     }
   }
 
   await treeProvider.refreshAndWait()
   track('vscode_uninstall_complete', { via })
-  void vscode.window.showInformationMessage(`Uninstalled "${pick.skillId}".`)
+  void vscode.window.showInformationMessage(`Uninstalled "${target.skillId}".`)
+  return true
+}
+
+// SMI-5130: extracted from the inline registerCommand closure so withTelemetry
+// can wrap it at the export boundary (telemetry coverage gate).
+async function uninstallCommandImpl(
+  deps: UninstallCommandDeps,
+  arg?: SkillTreeItem
+): Promise<void> {
+  const { treeProvider } = deps
+  const via: UninstallVia = arg?.skillData?.isInstalled ? 'context-menu' : 'palette'
+  const pick = await resolveTarget(arg, treeProvider)
+  if (!pick) {
+    // The resolve-stage cancel fires before the core's `start`, so emit `start`
+    // here too to keep the start→cancelled envelope intact for this path.
+    track('vscode_uninstall_start', { via })
+    track('vscode_uninstall_cancelled', { via, stage: 'resolve' })
+    return
+  }
+
+  await uninstallByTarget(pick, deps, via)
 }
 
 export const uninstallCommandAction = withTelemetry(uninstallCommandImpl, {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -58,6 +58,10 @@ export function activate(context: vscode.ExtensionContext): void {
   // Initialize providers
   skillTreeDataProvider = new SkillTreeDataProvider()
 
+  // Inject the tree provider into the detail panel so it can resolve installed
+  // state (#1437 / SMI-5308). Always set before the only live createOrShow path.
+  SkillDetailPanel.setTreeProvider(skillTreeDataProvider)
+
   // Initialize intellisense providers
   const skillCompletionProvider = new SkillCompletionProvider()
   const skillHoverProvider = new SkillHoverProvider()

--- a/packages/vscode-extension/src/services/Telemetry.ts
+++ b/packages/vscode-extension/src/services/Telemetry.ts
@@ -13,6 +13,10 @@ export type TelemetryEvent =
   | 'vscode_tier_denied'
   // SMI-5130: generic panel-action invocation (skill-invocation telemetry, SMI-5012).
   | 'vscode_skill_invoke'
+  // SMI-5308: detail-panel open actions (distinct type-safe ids vs the generic
+  // invoke discriminator, M5).
+  | 'vscode_open_skill_file'
+  | 'vscode_open_folder'
 
 // No hardcoded endpoint — telemetry is disabled by default at runtime
 // unless `skillsmith.telemetryEndpoint` is set or the production endpoint

--- a/packages/vscode-extension/src/sidebar/SkillTreeDataProvider.ts
+++ b/packages/vscode-extension/src/sidebar/SkillTreeDataProvider.ts
@@ -12,6 +12,7 @@ import { SkillTreeItem, type SkillItemData } from './SkillTreeItem.js'
 import { type ExtensionTrustTier, normalizeTrustTier, getTrustTierLabel } from './trustTier.js'
 import { type SkillData } from '../types/skill.js'
 import { type SearchFilters } from '../commands/searchFilters.js'
+import { buildInstalledKeySet, skillComparisonKey } from '../utils/skillId.js'
 
 /** Maximum length for skill descriptions */
 const MAX_DESCRIPTION_LENGTH = 100
@@ -81,6 +82,12 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
   setSearchResults(results: SkillData[], rawQuery: string, meta: { demo?: boolean } = {}): void {
     this.rawQuery = rawQuery
     this.demo = meta.demo ?? false
+    // `isInstalled` is intentionally false for all search results stored here.
+    // Whether a registry hit is ALSO installed locally is determined at render
+    // time in `getGroupChildren` via the normalized id cross-reference (H4).
+    // `installedElsewhere` (set there) is the authoritative "also installed"
+    // signal for the Available surface — it must never be baked into the stored
+    // item because the installed set can change between renders.
     this.availableSkills = results.map((skill) => {
       const tier = normalizeTrustTier(skill.trustTier)
       const item: SkillItemData = {
@@ -313,14 +320,29 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
   }
 
   /**
-   * Gets children for a specific group
+   * Gets children for a specific group.
+   *
+   * For the `available` branch the installed-key set is computed once per
+   * render call and used to mark each registry hit with `installedElsewhere`
+   * when its normalized slug matches a locally-installed skill. This is a
+   * render-time annotation — the stored `availableSkills` items are never
+   * mutated and `isInstalled` is left false so `getParent` continues routing
+   * Available items to the Available group (#1431 / SMI-5298, H4 / C2).
    */
   private getGroupChildren(groupId?: string): SkillTreeItem[] {
     switch (groupId) {
       case 'installed':
         return this.installedSkills.map((skill) => SkillTreeItem.createSkill(skill))
-      case 'available':
-        return this.availableSkills.map((skill) => SkillTreeItem.createSkill(skill))
+      case 'available': {
+        const installedKeys = buildInstalledKeySet(this.installedSkills.map((s) => s.id))
+        return this.availableSkills.map((skill) => {
+          const installedElsewhere = installedKeys.has(skillComparisonKey(skill.id))
+          if (installedElsewhere) {
+            return SkillTreeItem.createSkill({ ...skill, installedElsewhere: true })
+          }
+          return SkillTreeItem.createSkill(skill)
+        })
+      }
       default:
         return []
     }
@@ -374,14 +396,16 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
 
           let description: string | undefined
           let trustTier: ExtensionTrustTier | undefined = undefined
+          let hasSkillMd = false
 
           // Try to read description and trust tier from SKILL.md
           try {
             const content = await fs.readFile(skillMdPath, 'utf-8')
+            hasSkillMd = true
             description = this.extractDescription(content)
             trustTier = this.extractTrustTier(content)
           } catch {
-            // Ignore read errors - file may not exist
+            // Ignore read errors - file may not exist or be unreadable
           }
 
           const item: SkillItemData = {
@@ -393,6 +417,9 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
           }
           if (trustTier !== undefined) {
             item.trustTier = trustTier
+          }
+          if (hasSkillMd) {
+            item.hasSkillMd = true
           }
           return item
         })

--- a/packages/vscode-extension/src/sidebar/SkillTreeItem.ts
+++ b/packages/vscode-extension/src/sidebar/SkillTreeItem.ts
@@ -31,6 +31,21 @@ export interface SkillItemData {
   score?: number
   path?: string
   isInstalled: boolean
+  /**
+   * Render-only marker: this Available-group (registry) hit is ALSO installed
+   * locally. Drives the `✓ Installed` description suffix ONLY — it must NEVER be
+   * mirrored into `isInstalled`/`contextValue`, or `getParent` would route a
+   * search hit to the Installed group and break the #1431/SMI-5298 reveal
+   * contract (`group:available` stable id). Set at render time in
+   * `getGroupChildren` via the normalized id cross-reference. (#1436 / SMI-5307)
+   */
+  installedElsewhere?: boolean
+  /**
+   * Whether a `SKILL.md` file was found on disk for an installed skill. Gates
+   * the detail panel's "Open SKILL.md" action (#1437 / SMI-5308). Set in
+   * `doLoadInstalledSkills`; undefined for registry results.
+   */
+  hasSkillMd?: boolean
 }
 
 /**
@@ -111,7 +126,11 @@ export class SkillTreeItem extends vscode.TreeItem {
   }
 
   /**
-   * Formats the description line for a skill item
+   * Formats the description line for a skill item.
+   *
+   * Format (U+00B7 middle dot separator): `by {author} · {category} · {score}/100 · ✓ Installed`
+   * Each segment is conditional; all-missing → `''`. Trust-tier label is
+   * intentionally excluded — it is redundant with the row icon and the tooltip.
    */
   private formatDescription(data: SkillItemData): string {
     const parts: string[] = []
@@ -120,12 +139,19 @@ export class SkillTreeItem extends vscode.TreeItem {
       parts.push(`by ${data.author}`)
     }
 
-    const label = getTrustTierLabel(data.trustTier)
-    if (label) {
-      parts.push(label)
+    if (data.category) {
+      parts.push(data.category)
     }
 
-    return parts.join(' | ')
+    if (data.score !== undefined) {
+      parts.push(`${data.score}/100`)
+    }
+
+    if (data.installedElsewhere) {
+      parts.push('✓ Installed')
+    }
+
+    return parts.join(' · ')
   }
 
   /**

--- a/packages/vscode-extension/src/utils/__tests__/skillId.test.ts
+++ b/packages/vscode-extension/src/utils/__tests__/skillId.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for skill-ID normalization helpers (#1436 / #1437 cross-reference, C2).
+ */
+import { describe, it, expect } from 'vitest'
+import { skillComparisonKey, buildInstalledKeySet } from '../skillId.js'
+
+describe('skillComparisonKey', () => {
+  it('strips an author/ prefix and lowercases', () => {
+    expect(skillComparisonKey('smith-horn/My-Skill')).toBe('my-skill')
+  })
+
+  it('passes a bare slug through (lowercased)', () => {
+    expect(skillComparisonKey('My-Skill')).toBe('my-skill')
+  })
+
+  it('keeps only the trailing segment for nested ids', () => {
+    expect(skillComparisonKey('org/group/the-skill')).toBe('the-skill')
+  })
+
+  it('handles an empty string without throwing', () => {
+    expect(skillComparisonKey('')).toBe('')
+  })
+})
+
+describe('buildInstalledKeySet', () => {
+  it('normalizes installed dir slugs into a lookup set', () => {
+    const set = buildInstalledKeySet(['my-skill', 'Other-Skill'])
+    expect(set.has('my-skill')).toBe(true)
+    expect(set.has('other-skill')).toBe(true)
+  })
+
+  it('matches a registry author/name hit against an installed dir slug (C2)', () => {
+    const set = buildInstalledKeySet(['my-skill'])
+    // registry id is `author/name`; installed id is the bare dir slug
+    expect(set.has(skillComparisonKey('smith-horn/my-skill'))).toBe(true)
+    expect(set.has(skillComparisonKey('smith-horn/not-installed'))).toBe(false)
+  })
+})

--- a/packages/vscode-extension/src/utils/skillId.ts
+++ b/packages/vscode-extension/src/utils/skillId.ts
@@ -1,0 +1,40 @@
+/**
+ * Skill-ID normalization helpers shared by the sidebar (#1436) and the detail
+ * panel (#1437).
+ *
+ * Installed skills are keyed by their on-disk directory slug (e.g. `my-skill`),
+ * while registry/search results carry a fully-qualified `author/name` id
+ * (e.g. `smith-horn/my-skill`). To cross-reference "is this registry hit also
+ * installed?" both forms must be reduced to a common comparison key.
+ *
+ * @module utils/skillId
+ */
+
+/**
+ * Reduce any skill id to a case-insensitive comparison key by stripping an
+ * optional `author/` prefix and lowercasing.
+ *
+ * - `smith-horn/My-Skill` → `my-skill`
+ * - `my-skill`           → `my-skill`
+ *
+ * Note: slugs can collide across different authors, so a match is a best-effort
+ * "also installed" hint, not an identity proof. Callers using this for a UI
+ * marker accept the residual false-positive risk.
+ *
+ * @param id - A skill id in either `author/name` or bare-slug form
+ * @returns The lowercased trailing slug segment
+ */
+export function skillComparisonKey(id: string): string {
+  return (id.split('/').pop() ?? id).toLowerCase()
+}
+
+/**
+ * Build a Set of comparison keys from a list of installed-skill ids, for O(1)
+ * "also installed" lookups against registry results.
+ *
+ * @param installedIds - Installed skill ids (typically on-disk dir slugs)
+ * @returns A Set of normalized comparison keys
+ */
+export function buildInstalledKeySet(installedIds: readonly string[]): Set<string> {
+  return new Set(installedIds.map(skillComparisonKey))
+}

--- a/packages/vscode-extension/src/views/SkillDetailPanel.ts
+++ b/packages/vscode-extension/src/views/SkillDetailPanel.ts
@@ -7,7 +7,11 @@ import * as path from 'node:path'
 import { generateCspNonce, getSkillDetailCsp } from '../utils/csp.js'
 import type { SkillService } from '../services/SkillService.js'
 import type { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
-import type { ExtendedSkillData, SkillPanelMessage, SkillActionContext } from './skill-panel-types.js'
+import type {
+  ExtendedSkillData,
+  SkillPanelMessage,
+  SkillActionContext,
+} from './skill-panel-types.js'
 import { skillComparisonKey } from '../utils/skillId.js'
 import { uninstallByTarget } from '../commands/uninstallCommand.js'
 import { track } from '../services/Telemetry.js'
@@ -167,10 +171,7 @@ export class SkillDetailPanel {
         return
       case 'openFolder':
         if (this._skillPath) {
-          void vscode.commands.executeCommand(
-            'revealFileInOS',
-            vscode.Uri.file(this._skillPath)
-          )
+          void vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(this._skillPath))
           track('vscode_open_folder', { surface: 'detail-panel' })
         }
         return
@@ -194,9 +195,7 @@ export class SkillDetailPanel {
     const key = skillComparisonKey(this._skillId)
     const local = provider.getInstalledSkills().find((s) => skillComparisonKey(s.id) === key)
     if (!local || !local.path) {
-      void vscode.window.showInformationMessage(
-        'Skill no longer installed — refresh the tree'
-      )
+      void vscode.window.showInformationMessage('Skill no longer installed — refresh the tree')
       return
     }
 

--- a/packages/vscode-extension/src/views/SkillDetailPanel.ts
+++ b/packages/vscode-extension/src/views/SkillDetailPanel.ts
@@ -3,9 +3,14 @@
  * Uses SkillService for centralized MCP-first + mock fallback.
  */
 import * as vscode from 'vscode'
+import * as path from 'node:path'
 import { generateCspNonce, getSkillDetailCsp } from '../utils/csp.js'
 import type { SkillService } from '../services/SkillService.js'
-import type { ExtendedSkillData, SkillPanelMessage } from './skill-panel-types.js'
+import type { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
+import type { ExtendedSkillData, SkillPanelMessage, SkillActionContext } from './skill-panel-types.js'
+import { skillComparisonKey } from '../utils/skillId.js'
+import { uninstallByTarget } from '../commands/uninstallCommand.js'
+import { track } from '../services/Telemetry.js'
 import {
   getLoadingHtml,
   getSkillDetailHtml,
@@ -24,6 +29,7 @@ export class SkillDetailPanel {
   private static readonly TRUSTED_DOMAINS = ['github.com', 'gitlab.com', 'skillsmith.app']
 
   private static _skillService: SkillService
+  private static _treeProvider: SkillTreeDataProvider | undefined
 
   private readonly _panel: vscode.WebviewPanel
   private readonly _extensionUri: vscode.Uri
@@ -32,9 +38,30 @@ export class SkillDetailPanel {
   private _showFullContent = false
   private _disposables: vscode.Disposable[] = []
 
+  /** Installed-state resolved at load time (drives the conditional action set). */
+  private _installed = false
+  private _skillPath: string | undefined
+  private _hasSkillMd = false
+
   /** Set the shared SkillService instance (called once at activation) */
   public static setSkillService(service: SkillService): void {
     SkillDetailPanel._skillService = service
+  }
+
+  /**
+   * Inject the tree provider (called once at activation). Used to look up
+   * whether the viewed skill is installed locally and where on disk. When unset
+   * (tests / the dead `revive` path), the panel treats the skill as
+   * available-only (C3).
+   */
+  public static setTreeProvider(provider: SkillTreeDataProvider | undefined): void {
+    SkillDetailPanel._treeProvider = provider
+  }
+
+  /** Clear both injected statics between tests (M1). */
+  public static resetForTests(): void {
+    SkillDetailPanel._skillService = undefined as unknown as SkillService
+    SkillDetailPanel._treeProvider = undefined
   }
 
   public static createOrShow(extensionUri: vscode.Uri, skillId: string) {
@@ -126,6 +153,68 @@ export class SkillDetailPanel {
       case 'retry':
         void this._loadAndUpdate()
         return
+      case 'uninstall':
+        void this._handleUninstall()
+        return
+      case 'openSkillFile':
+        if (this._skillPath && this._hasSkillMd) {
+          void vscode.commands.executeCommand(
+            'vscode.open',
+            vscode.Uri.file(path.join(this._skillPath, 'SKILL.md'))
+          )
+          track('vscode_open_skill_file', { surface: 'detail-panel' })
+        }
+        return
+      case 'openFolder':
+        if (this._skillPath) {
+          void vscode.commands.executeCommand(
+            'revealFileInOS',
+            vscode.Uri.file(this._skillPath)
+          )
+          track('vscode_open_folder', { surface: 'detail-panel' })
+        }
+        return
+    }
+  }
+
+  /**
+   * Handle an in-panel uninstall request. Re-resolves the installed entry at
+   * click time (multi-window safety, M2); if it's gone, notifies and aborts.
+   * Delegates to the shared `uninstallByTarget` core (which shows the success
+   * toast + emits telemetry), then disposes the panel on success (H9) so the
+   * dead local-only skill is never re-fetched into an error page.
+   */
+  private async _handleUninstall(): Promise<void> {
+    const provider = SkillDetailPanel._treeProvider
+    if (!this._skillPath || !provider) {
+      return
+    }
+
+    // Re-find at click time — the skill may have been removed in another window.
+    const key = skillComparisonKey(this._skillId)
+    const local = provider.getInstalledSkills().find((s) => skillComparisonKey(s.id) === key)
+    if (!local || !local.path) {
+      void vscode.window.showInformationMessage(
+        'Skill no longer installed — refresh the tree'
+      )
+      return
+    }
+
+    try {
+      const ok = await uninstallByTarget(
+        { skillId: this._skillId, skillPath: local.path },
+        { treeProvider: provider },
+        'detail-panel'
+      )
+      if (ok) {
+        this.dispose()
+      }
+    } catch (err) {
+      // H3: never let an uninstall throw escape the handler — the core already
+      // emits `vscode_uninstall_failed` for known failure shapes; surface the
+      // rest as a generic error rather than a silent drop.
+      const msg = err instanceof Error ? err.message : String(err)
+      void vscode.window.showErrorMessage(`Failed to uninstall "${this._skillId}": ${msg}`)
     }
   }
 
@@ -173,6 +262,7 @@ export class SkillDetailPanel {
     try {
       const { skill } = await SkillDetailPanel._skillService.getRichSkill(this._skillId)
       this._skillData = skill
+      this._resolveInstalledState()
       this._update()
     } catch (error) {
       const rawMessage = error instanceof Error ? error.message : String(error)
@@ -181,6 +271,22 @@ export class SkillDetailPanel {
       this._panel.title = `Error: ${this._skillId}`
       this._panel.webview.html = getErrorHtml(userMessage, this._skillId, nonce, rawMessage)
     }
+  }
+
+  /**
+   * Cross-reference the viewed skill against the installed list to populate the
+   * `_installed` / `_skillPath` / `_hasSkillMd` fields that drive the action set.
+   * Null-guards the provider: when unset (tests / dead `revive` path), the skill
+   * is treated as available-only (C3).
+   */
+  private _resolveInstalledState(): void {
+    const key = skillComparisonKey(this._skillId)
+    const local = SkillDetailPanel._treeProvider
+      ?.getInstalledSkills()
+      .find((s) => skillComparisonKey(s.id) === key)
+    this._installed = !!local
+    this._skillPath = local?.path
+    this._hasSkillMd = local?.hasSkillMd ?? false
   }
 
   private _update() {
@@ -225,6 +331,13 @@ export class SkillDetailPanel {
     // Ensure extensionUri is used (for future resource loading)
     void this._getResourceUri
 
-    return getSkillDetailHtml(skill, nonce, csp, this._showFullContent)
+    // Build the action context conditionally: under exactOptionalPropertyTypes
+    // an optional `skillPath?: string` must be omitted (not set to undefined).
+    const actionCtx: SkillActionContext = {
+      installed: this._installed,
+      hasSkillMd: this._hasSkillMd,
+      ...(this._skillPath !== undefined ? { skillPath: this._skillPath } : {}),
+    }
+    return getSkillDetailHtml(skill, nonce, csp, this._showFullContent, actionCtx)
   }
 }

--- a/packages/vscode-extension/src/views/skill-panel-actions.ts
+++ b/packages/vscode-extension/src/views/skill-panel-actions.ts
@@ -7,22 +7,21 @@
  * explicit `aria-label` (H7) because the header-first DOM order places actions
  * ahead of the body content.
  */
-import { escapeHtml } from '../utils/security.js'
 import type { SkillActionContext } from './skill-panel-types.js'
 
 /**
  * Build the header action buttons for the detail panel.
  *
  * @param ctx - Installed-state context resolved at load time
- * @param safeRepository - An already-`escapeHtml`'d repository URL, or `''`
+ * @param safeRepository - An already-`escapeHtml`'d repository URL, or `''`.
+ *   It is interpolated as-is — re-escaping here would double-encode `&` in
+ *   query strings and corrupt the `data-url` the webview opens (matches the
+ *   body `.repository-link` span, which also consumes the pre-escaped value).
  * @returns The buttons HTML fragment
  */
 export function getActionBlock(ctx: SkillActionContext, safeRepository: string): string {
-  // Defense-in-depth: ctx carries no raw user strings into the markup today, but
-  // re-escape the repository URL so this builder stays safe if callers change.
-  const repoUrl = escapeHtml(safeRepository)
   const repoButton = safeRepository
-    ? `<button class="btn-secondary" id="repoBtn" data-url="${repoUrl}" aria-label="View the source repository">View Repository</button>`
+    ? `<button class="btn-secondary" id="repoBtn" data-url="${safeRepository}" aria-label="View the source repository">View Repository</button>`
     : ''
 
   if (!ctx.installed) {

--- a/packages/vscode-extension/src/views/skill-panel-actions.ts
+++ b/packages/vscode-extension/src/views/skill-panel-actions.ts
@@ -1,0 +1,45 @@
+/**
+ * Action-block builder for SkillDetailPanel (#1437 / SMI-5308).
+ *
+ * Extracted from skill-panel-html.ts so that module stays under the 500-line
+ * gate. Renders the sticky-header CTA cluster: Install (available) vs
+ * Uninstall + Open Folder + Open SKILL.md (installed). Every button carries an
+ * explicit `aria-label` (H7) because the header-first DOM order places actions
+ * ahead of the body content.
+ */
+import { escapeHtml } from '../utils/security.js'
+import type { SkillActionContext } from './skill-panel-types.js'
+
+/**
+ * Build the header action buttons for the detail panel.
+ *
+ * @param ctx - Installed-state context resolved at load time
+ * @param safeRepository - An already-`escapeHtml`'d repository URL, or `''`
+ * @returns The buttons HTML fragment
+ */
+export function getActionBlock(ctx: SkillActionContext, safeRepository: string): string {
+  // Defense-in-depth: ctx carries no raw user strings into the markup today, but
+  // re-escape the repository URL so this builder stays safe if callers change.
+  const repoUrl = escapeHtml(safeRepository)
+  const repoButton = safeRepository
+    ? `<button class="btn-secondary" id="repoBtn" data-url="${repoUrl}" aria-label="View the source repository">View Repository</button>`
+    : ''
+
+  if (!ctx.installed) {
+    return `<div class="actions">
+        <button class="btn-primary" id="installBtn" aria-label="Install this skill">Install Skill</button>
+        ${repoButton}
+    </div>`
+  }
+
+  const openSkillFileButton = ctx.hasSkillMd
+    ? `<button class="btn-secondary" id="openSkillFileBtn" aria-label="Open SKILL.md">Open SKILL.md</button>`
+    : ''
+
+  return `<div class="actions">
+        <button class="btn-destructive" id="uninstallBtn" aria-label="Uninstall this skill">Uninstall</button>
+        <button class="btn-secondary" id="openFolderBtn" aria-label="Open the skill folder">Open Folder</button>
+        ${openSkillFileButton}
+        ${repoButton}
+    </div>`
+}

--- a/packages/vscode-extension/src/views/skill-panel-html.ts
+++ b/packages/vscode-extension/src/views/skill-panel-html.ts
@@ -4,11 +4,12 @@
 
 import { escapeHtml } from '../utils/security.js'
 import { getSkillDetailCsp } from '../utils/csp.js'
-import type { ExtendedSkillData, ScoreBreakdown } from './skill-panel-types.js'
+import type { ExtendedSkillData, ScoreBreakdown, SkillActionContext } from './skill-panel-types.js'
 import { getContentHtml, renderMarkdown } from './skill-panel-content.js'
 import { inferRepositoryUrl } from './skill-panel-helpers.js'
 import { getStyles } from './skill-panel-styles.js'
 import { getScript } from './skill-panel-script.js'
+import { getActionBlock } from './skill-panel-actions.js'
 
 // Re-export for testing
 export { getContentHtml } from './skill-panel-content.js'
@@ -181,7 +182,8 @@ export function getSkillDetailHtml(
   skill: ExtendedSkillData,
   nonce: string,
   csp: string,
-  showFullContent = false
+  showFullContent = false,
+  actionCtx: SkillActionContext = { installed: false }
 ): string {
   // Escape all user-controlled content to prevent XSS
   const safeName = escapeHtml(skill.name)
@@ -213,10 +215,12 @@ export function getSkillDetailHtml(
     <style>${getStyles()}</style>
 </head>
 <body>
-    <div aria-live="polite">
     <div class="header">
-        <h1>${safeName}</h1>
-        <span class="badge badge-${trustBadgeColor}">${trustBadgeText}</span>
+        <div class="header-titles">
+            <h1>${safeName}</h1>
+            <span class="badge badge-${trustBadgeColor}">${trustBadgeText}</span>
+        </div>
+        ${getActionBlock(actionCtx, safeRepository)}
     </div>
 
     <div class="description">${safeDescription}</div>
@@ -296,13 +300,6 @@ export function getSkillDetailHtml(
             // cross-ecosystem discovery-only skills, the section simply doesn't appear.
             ''
     }
-
-    <div class="actions">
-        <button class="btn-primary" id="installBtn">Install Skill</button>
-        ${safeRepository ? `<button class="btn-secondary" id="repoBtn" data-url="${safeRepository}">View Repository</button>` : ''}
-    </div>
-
-    </div>
 
     ${getScript(nonce)}
 </body>

--- a/packages/vscode-extension/src/views/skill-panel-script.ts
+++ b/packages/vscode-extension/src/views/skill-panel-script.ts
@@ -13,9 +13,36 @@ export function getScript(nonce: string): string {
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
 
-        document.getElementById('installBtn').addEventListener('click', function() {
-            vscode.postMessage({ command: 'install' });
-        });
+        // C1: null-guard every getElementById. The Install button is absent on
+        // the installed-skill view; an unguarded lookup throws and kills every
+        // listener wired after it (uninstall/open would be dead).
+        const installBtn = document.getElementById('installBtn');
+        if (installBtn) {
+            installBtn.addEventListener('click', function() {
+                vscode.postMessage({ command: 'install' });
+            });
+        }
+
+        const uninstallBtn = document.getElementById('uninstallBtn');
+        if (uninstallBtn) {
+            uninstallBtn.addEventListener('click', function() {
+                vscode.postMessage({ command: 'uninstall' });
+            });
+        }
+
+        const openSkillFileBtn = document.getElementById('openSkillFileBtn');
+        if (openSkillFileBtn) {
+            openSkillFileBtn.addEventListener('click', function() {
+                vscode.postMessage({ command: 'openSkillFile' });
+            });
+        }
+
+        const openFolderBtn = document.getElementById('openFolderBtn');
+        if (openFolderBtn) {
+            openFolderBtn.addEventListener('click', function() {
+                vscode.postMessage({ command: 'openFolder' });
+            });
+        }
 
         const repoBtn = document.getElementById('repoBtn');
         if (repoBtn) {

--- a/packages/vscode-extension/src/views/skill-panel-styles.ts
+++ b/packages/vscode-extension/src/views/skill-panel-styles.ts
@@ -24,10 +24,30 @@ export function getStyles(): string {
             margin-bottom: 24px;
             padding-bottom: 16px;
             border-bottom: 1px solid var(--vscode-panel-border);
+            position: sticky;
+            top: 0;
+            z-index: 10;
+            background-color: var(--vscode-editor-background);
+            justify-content: space-between;
+            flex-wrap: nowrap;
+        }
+        .header-titles {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            min-width: 0;
         }
         .header h1 {
             margin: 0;
             font-size: 24px;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            flex-shrink: 1;
+        }
+        .header .actions {
+            flex-shrink: 0;
         }
         .badge {
             display: inline-block;
@@ -86,7 +106,7 @@ export function getStyles(): string {
             background-color: var(--vscode-progressBar-foreground);
             border-radius: 4px;
         }
-        .actions { display: flex; gap: 12px; margin-top: 24px; }
+        .header .actions { display: flex; gap: 12px; }
         button {
             padding: 10px 20px;
             border: none;
@@ -105,6 +125,15 @@ export function getStyles(): string {
             color: var(--vscode-button-secondaryForeground);
         }
         .btn-secondary:hover { background-color: var(--vscode-button-secondaryHoverBackground); }
+        .btn-destructive {
+            background-color: var(--vscode-inputValidation-errorBackground);
+            color: var(--vscode-errorForeground);
+            border: 1px solid var(--vscode-inputValidation-errorBorder);
+        }
+        .btn-destructive:hover {
+            background-color: var(--vscode-inputValidation-errorBorder);
+            color: var(--vscode-editor-background);
+        }
         .repository-link {
             color: var(--vscode-textLink-foreground);
             text-decoration: none;

--- a/packages/vscode-extension/src/views/skill-panel-types.ts
+++ b/packages/vscode-extension/src/views/skill-panel-types.ts
@@ -10,6 +10,28 @@ export type { ScoreBreakdown, ExtendedSkillData } from '../types/skill.js'
  * Message types received from the webview
  */
 export interface SkillPanelMessage {
-  command: 'install' | 'openRepository' | 'openExternal' | 'expandContent' | 'retry'
+  command:
+    | 'install'
+    | 'openRepository'
+    | 'openExternal'
+    | 'expandContent'
+    | 'retry'
+    | 'uninstall'
+    | 'openSkillFile'
+    | 'openFolder'
   url?: string
+}
+
+/**
+ * Drives the panel's conditional action block (#1437 / SMI-5308).
+ *
+ * Resolved at load time from the installed-skill cross-reference: when the skill
+ * being viewed is also installed locally, `installed` is true and `skillPath`
+ * points at the on-disk directory. `hasSkillMd` gates the "Open SKILL.md" action
+ * so it never targets an absent file.
+ */
+export interface SkillActionContext {
+  installed: boolean
+  skillPath?: string
+  hasSkillMd?: boolean
 }


### PR DESCRIPTION
## Summary

VS Code extension UX **Wave 2b** (Epic B browse & detail polish), bundled into one PR per owner decision. Host-only (ADR-113). Children of **SMI-5287**.

### #1436 — Richer sidebar rows (SMI-5307)
Row description goes from `by {author} | {tier}` to `by {author} · {category} · {score}/100 · ✓ Installed`. The installed indicator on registry hits is computed render-time via a normalized id cross-reference (new `src/utils/skillId.ts` strips the `author/` prefix so registry `author/name` ids match installed dir slugs — a raw match never fired). Uses a render-only `installedElsewhere` field that never touches `isInstalled`/`contextValue`, preserving the #1431/SMI-5298 `getParent` reveal contract.

### #1437 — Detail-panel product page (SMI-5308)
- **Sticky header** carries title + trust badge + primary CTA (stays visible on scroll).
- **Conditional action set** — Install (available) vs **Uninstall** (destructive) + **Open folder** + **Open SKILL.md** (installed, gated on `hasSkillMd`).
- **In-panel Uninstall** reuses the existing flow via an extracted shared `uninstallByTarget` core (confirm + containment guard + MCP-first + `fs.rm` fallback + tierDenied + tree refresh + telemetry); panel disposes after the success toast.
- `SkillDetailPanel.setTreeProvider` DI supplies installed-state + on-disk path.

## Quality
- **Plan-review** (VP Product/Eng/Design): 4 Critical + 10 High + 10 Medium + 4 Low — all folded in before coding. Criticals: unguarded `getElementById` (would kill all installed-skill buttons), id-form mismatch (installed badge would never fire), dead `revive` (documented non-persistence), message-union extension.
- **Governance** (post-commit): 1 Medium (repo-URL double-escape) + 1 Low (untested throw path) — both fixed in `e5cc91b5`.
- typecheck ✓ · eslint 0 warnings ✓ · **493 tests pass** · build + package:check ✓ · `audit:standards` 76/0/3 ✓ · every file <500 lines.

## Follow-up (not in this PR)
- **0.5.0 release** publishes right after merge (bundles Wave 2a + 2b; CHANGELOG `[Unreleased]` already staged).
- Design doc + retro land via the docs-submodule PR.
- SMI-5309 tracks splitting `McpClient.ts` (490/500) on its next change.

Commits: `b95a0ae1` (#1436) · `2af30713` (#1437) · `e5cc91b5` (governance fixes).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)