### PR TITLE
feat(vscode): post-create authoring checklist (SMI-5312, GH #1453)

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Post-create authoring checklist**: after creating a skill, a notification guides your next steps with **Open folder** and **Authoring docs** quick actions.
+
 ## [0.5.0] - 2026-06-19
 
 ### Added

--- a/packages/vscode-extension/src/__tests__/createSkillCommand.test.ts
+++ b/packages/vscode-extension/src/__tests__/createSkillCommand.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { EventEmitter } from 'node:events'
 
+/**
+ * Drain the microtask/macrotask queues so the fire-and-forget
+ * `void showPostCreateChecklist(...)` (two sequential awaits) fully settles
+ * before assertions. Two `setImmediate` ticks make the guarantee independent
+ * of how the vscode mocks resolve (microtask vs macrotask).
+ */
+const flushAsync = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(() => setImmediate(() => resolve())))
+
 const showInputBox = vi.fn()
 const showQuickPick = vi.fn()
 const showInformationMessage = vi.fn()
@@ -17,6 +26,7 @@ const showTextDocument = vi.fn()
 const clipboardWrite = vi.fn()
 const openExternal = vi.fn()
 const registerCommand = vi.fn()
+const executeCommand = vi.fn()
 
 vi.mock('vscode', () => ({
   window: {
@@ -29,13 +39,13 @@ vi.mock('vscode', () => ({
     showTextDocument,
   },
   workspace: { openTextDocument },
-  commands: { registerCommand },
+  commands: { registerCommand, executeCommand },
   env: {
     clipboard: { writeText: clipboardWrite },
     openExternal,
   },
   Uri: {
-    file: (s: string) => ({ toString: () => s }),
+    file: (s: string) => ({ toString: () => s, fsPath: s }),
     parse: (s: string) => ({ toString: () => s }),
   },
 }))
@@ -87,6 +97,7 @@ describe('createSkillCommand (SMI-4196)', () => {
     openExternal.mockReset()
     registerCommand.mockReset()
     refreshAndWait.mockReset().mockResolvedValue(undefined)
+    executeCommand.mockReset()
     spawnMock.mockReset()
 
     vi.resetModules()
@@ -164,7 +175,13 @@ describe('createSkillCommand (SMI-4196)', () => {
       expect.any(Object)
     )
     expect(refreshAndWait).toHaveBeenCalled()
-    expect(showInformationMessage).toHaveBeenCalledWith('Created skill "my-skill".')
+    // Flush the fire-and-forget showPostCreateChecklist promise
+    await flushAsync()
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Created skill "my-skill"'),
+      'Open folder',
+      'Authoring docs'
+    )
     expect(showWarningMessage).not.toHaveBeenCalled()
   })
 
@@ -183,7 +200,13 @@ describe('createSkillCommand (SMI-4196)', () => {
     await handler()
 
     expect(refreshAndWait).toHaveBeenCalled()
-    expect(showInformationMessage).toHaveBeenCalledWith('Created skill "my-skill".')
+    // Flush the fire-and-forget showPostCreateChecklist promise
+    await flushAsync()
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Created skill "my-skill"'),
+      'Open folder',
+      'Authoring docs'
+    )
     expect(showWarningMessage).toHaveBeenCalledWith(
       expect.stringContaining("couldn't open SKILL.md")
     )
@@ -219,5 +242,77 @@ describe('createSkillCommand (SMI-4196)', () => {
 
     expect(showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('exit 2'))
     expect(refreshAndWait).not.toHaveBeenCalled()
+  })
+
+  describe('post-create authoring checklist (GH #1453 / SMI-5312)', () => {
+    function setupHappyPath() {
+      spawnMock
+        .mockImplementationOnce(() => makeChild('found'))
+        .mockImplementationOnce(() => makeChild('found', 0))
+      openTextDocument.mockResolvedValueOnce({ uri: {} })
+      showInputBox
+        .mockResolvedValueOnce('my-author')
+        .mockResolvedValueOnce('my-skill')
+        .mockResolvedValueOnce('An example skill')
+      showQuickPick.mockResolvedValueOnce({ label: 'basic', description: '...' })
+    }
+
+    it('shows checklist toast with correct message and both button labels after successful create', async () => {
+      setupHappyPath()
+      showInformationMessage.mockResolvedValue(undefined) // user dismisses
+
+      await handler()
+      await flushAsync()
+
+      expect(showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Created skill "my-skill"'),
+        'Open folder',
+        'Authoring docs'
+      )
+    })
+
+    it('opens the skill folder in OS when user picks "Open folder"', async () => {
+      const { track } = await import('../services/Telemetry.js')
+      setupHappyPath()
+      showInformationMessage.mockResolvedValue('Open folder')
+
+      await handler()
+      await flushAsync()
+
+      expect(executeCommand).toHaveBeenCalledWith(
+        'revealFileInOS',
+        expect.objectContaining({ toString: expect.any(Function) })
+      )
+      expect(track).toHaveBeenCalledWith('vscode_create_checklist_action', {
+        action: 'open_folder',
+      })
+      expect(openExternal).not.toHaveBeenCalled()
+    })
+
+    it('opens the authoring docs URL when user picks "Authoring docs"', async () => {
+      const { track } = await import('../services/Telemetry.js')
+      setupHappyPath()
+      showInformationMessage.mockResolvedValue('Authoring docs')
+
+      await handler()
+      await flushAsync()
+
+      expect(openExternal).toHaveBeenCalledWith(
+        expect.objectContaining({ toString: expect.any(Function) })
+      )
+      expect(track).toHaveBeenCalledWith('vscode_create_checklist_action', { action: 'docs' })
+      expect(executeCommand).not.toHaveBeenCalled()
+    })
+
+    it('takes no action when user dismisses the checklist toast', async () => {
+      setupHappyPath()
+      showInformationMessage.mockResolvedValue(undefined)
+
+      await handler()
+      await flushAsync()
+
+      expect(executeCommand).not.toHaveBeenCalled()
+      expect(openExternal).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
@@ -77,4 +77,12 @@ describe('SMI-5130: VS Code command telemetry coverage', () => {
     expect(openIds).toHaveLength(2)
     expect(new Set(openIds).size).toBe(2)
   })
+
+  // SMI-5312: the post-create checklist action is fired inside a helper, not a
+  // registered command, so it isn't in VSCODE_DISPATCHER_MAP. Assert its
+  // type-safe id exists in the TelemetryEvent union (rename/removal breaks here).
+  it('declares the post-create checklist telemetry id', () => {
+    const checklistId: TelemetryEvent = 'vscode_create_checklist_action'
+    expect(checklistId).toBe('vscode_create_checklist_action')
+  })
 })

--- a/packages/vscode-extension/src/commands/createSkillCommand.ts
+++ b/packages/vscode-extension/src/commands/createSkillCommand.ts
@@ -104,7 +104,7 @@ async function createSkillImpl(deps: CreateSkillDeps): Promise<void> {
       `Skill "${state.name}" created, but couldn't open SKILL.md automatically. Open it from the Skills panel.`
     )
   }
-  void vscode.window.showInformationMessage(`Created skill "${state.name}".`)
+  void showPostCreateChecklist(targetDir, state.name)
 }
 
 export const createSkillAction = withTelemetry(createSkillImpl, {
@@ -214,5 +214,30 @@ async function exists(p: string): Promise<boolean> {
     return true
   } catch {
     return false
+  }
+}
+
+async function showPostCreateChecklist(targetDir: string, name: string): Promise<void> {
+  const OPEN_FOLDER = 'Open folder'
+  const DOCS = 'Authoring docs'
+  // Best-effort post-create affordance: the caller invokes this fire-and-forget
+  // (`void`), so the helper must never reject — `executeCommand`/`openExternal`
+  // can throw (host shutting down, unregistered scheme) and an unhandled
+  // rejection would surface to the user. Swallow; the actions are optional.
+  try {
+    const action = await vscode.window.showInformationMessage(
+      `Created skill "${name}". Next: fill in SKILL.md (frontmatter + instructions), add examples, then publish.`,
+      OPEN_FOLDER,
+      DOCS
+    )
+    if (action === OPEN_FOLDER) {
+      track('vscode_create_checklist_action', { action: 'open_folder' })
+      await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(targetDir))
+    } else if (action === DOCS) {
+      track('vscode_create_checklist_action', { action: 'docs' })
+      await vscode.env.openExternal(vscode.Uri.parse('https://skillsmith.app/docs'))
+    }
+  } catch {
+    // Optional next-step action failed; nothing actionable to surface.
   }
 }

--- a/packages/vscode-extension/src/services/Telemetry.ts
+++ b/packages/vscode-extension/src/services/Telemetry.ts
@@ -6,6 +6,7 @@ export type TelemetryEvent =
   | 'vscode_create_complete'
   | 'vscode_create_failed'
   | 'vscode_create_cancelled'
+  | 'vscode_create_checklist_action'
   | 'vscode_uninstall_start'
   | 'vscode_uninstall_complete'
   | 'vscode_uninstall_failed'


### PR DESCRIPTION
## Summary

Epic C / PR-C1 of the VS Code UX overhaul (parent SMI-5287). After a skill is scaffolded via **Create Skill**, the extension now shows a non-blocking post-create authoring checklist guiding the author's next steps, with two quick actions:

- **Open folder** → `revealFileInOS` on the new skill directory
- **Authoring docs** → opens https://skillsmith.app/docs

Fire-and-forget so the command resolves immediately. New `vscode_create_checklist_action` telemetry fires on each action (`{ action: 'open_folder' | 'docs' }`).

**No "Validate" button** — the `skillsmith` CLI has no `validate` subcommand, so wiring one would ship broken; MCP `skill_validate` coupling is out of scope for this small PR.

## Changes
- `src/commands/createSkillCommand.ts` — new `showPostCreateChecklist` helper (body wrapped in try/catch so the fire-and-forget caller can never see an unhandled rejection).
- `src/services/Telemetry.ts` — `vscode_create_checklist_action` added to the `TelemetryEvent` union.
- `src/__tests__/createSkillCommand.test.ts` — 4 new tests (toast shape, Open folder path, Authoring docs path, dismiss is a no-op) + a `flushAsync` two-tick helper.
- `src/commands/__meta__/telemetry-coverage.test.ts` — asserts the new type-safe event id.
- `CHANGELOG.md` — `[Unreleased]` entry (accumulates toward a single 0.6.0 release; **no interim publish**).

## Verification (host, ADR-113)
- typecheck ✓ · lint (0 warnings) ✓ · build + package:check ✓
- 497/497 tests pass (37 files) · audit:standards 0 failed · every file <500
- Governance review run; all 3 findings (2 Medium, 1 Low) fixed in this PR.

[skip-smoke]

GH #1453 · SMI-5312

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)