### PR TITLE
feat(vscode): single-page webview Create Skill wizard (SMI-5313, GH #1454)

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **Post-create authoring checklist**: after creating a skill, a notification guides your next steps with **Open folder** and **Authoring docs** quick actions.
 
+### Changed
+
+- Create Skill now opens a single-page form (author, name, description, type) with live name validation, replacing the step-by-step prompts.
+
 ## [0.5.0] - 2026-06-19
 
 ### Added

--- a/packages/vscode-extension/src/__tests__/CreateSkillPanel.guards.test.ts
+++ b/packages/vscode-extension/src/__tests__/CreateSkillPanel.guards.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Guard / edge-case unit tests for views/CreateSkillPanel.ts (SMI-5313 / GH #1454).
+ *
+ * Split out of CreateSkillPanel.test.ts to keep each file under the 500-line
+ * check-file-length gate. Covers: C1 re-entrancy lock, overwrite-decline,
+ * C2 dispose-after-success vs cancel/external-close, singleton reveal, and
+ * cliOutput streaming. The shared vscode/helpers/telemetry mock setup and the
+ * message-handler capture harness are intentionally duplicated (inlined) here
+ * rather than imported, to avoid a non-test .ts module in __tests__ confusing
+ * vitest globbing.
+ *
+ * Mirrors the mocking style of SkillDetailPanel.test.ts (vi.hoisted for
+ * spies that must exist before the vi.mock factory runs, vi.waitFor for
+ * the async panel work that is fired via `void _handleMessage(...)` — the
+ * webview message handler is fire-and-forget so sendMessage resolves before
+ * the async handler chain completes).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ── vi.hoisted: spies that must exist before the vi.mock factory runs ─────────
+const {
+  createWebviewPanel,
+  showWarningMessage,
+  openTextDocument,
+  showTextDocument,
+  trackMock,
+  validateSkillNameMock,
+  runCliMock,
+  existsMock,
+  showPostCreateChecklistMock,
+} = vi.hoisted(() => ({
+  createWebviewPanel: vi.fn(),
+  showWarningMessage: vi.fn(),
+  openTextDocument: vi.fn(),
+  showTextDocument: vi.fn(),
+  trackMock: vi.fn(),
+  validateSkillNameMock: vi.fn(),
+  runCliMock: vi.fn(),
+  existsMock: vi.fn(),
+  showPostCreateChecklistMock: vi.fn(),
+}))
+
+// ── vscode mock ──────────────────────────────────────────────────────────────
+vi.mock('vscode', () => ({
+  Uri: {
+    joinPath: vi.fn((_base: unknown, ...segments: string[]) => ({
+      fsPath: segments.join('/'),
+    })),
+    file: vi.fn((s: string) => ({ fsPath: s, scheme: 'file' })),
+    parse: vi.fn((s: string) => ({ toString: () => s })),
+  },
+  ViewColumn: { One: 1 },
+  window: {
+    createWebviewPanel,
+    activeTextEditor: undefined,
+    showWarningMessage,
+    showInformationMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+    openTextDocument,
+    showTextDocument,
+  },
+  workspace: { openTextDocument },
+  commands: { executeCommand: vi.fn() },
+  env: { openExternal: vi.fn() },
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+// ── helpers mock ─────────────────────────────────────────────────────────────
+vi.mock('../utils/createSkill.helpers.js', () => ({
+  buildCreateArgs: (fields: {
+    author: string
+    name: string
+    description: string
+    type: string
+  }) => [
+    'create',
+    fields.name,
+    '-a',
+    fields.author,
+    '-d',
+    fields.description,
+    '--type',
+    fields.type,
+    '-y',
+  ],
+  targetDirFor: (name: string) => `/home/user/.claude/skills/${name}`,
+  runCli: runCliMock,
+  exists: existsMock,
+  showPostCreateChecklist: showPostCreateChecklistMock,
+}))
+
+// ── CSP / nonce mock ─────────────────────────────────────────────────────────
+vi.mock('../utils/csp.js', () => ({
+  generateCspNonce: () => 'test-nonce-123',
+  getCreateSkillCsp: () => "default-src 'none';",
+}))
+
+// ── HTML mock ─────────────────────────────────────────────────────────────────
+vi.mock('../views/create-panel-html.js', () => ({
+  getCreateSkillHtml: () => '<html><body>mock</body></html>',
+}))
+
+// ── Telemetry mock ───────────────────────────────────────────────────────────
+vi.mock('../services/Telemetry.js', () => ({
+  track: trackMock,
+}))
+
+// ── validateSkillName mock ────────────────────────────────────────────────────
+vi.mock('../utils/skillNameValidation.js', () => ({
+  validateSkillName: validateSkillNameMock,
+}))
+
+// ── SkillTreeDataProvider mock ────────────────────────────────────────────────
+const refreshAndWait = vi.fn(async () => {})
+vi.mock('../sidebar/SkillTreeDataProvider.js', () => ({
+  SkillTreeDataProvider: class {
+    refreshAndWait = refreshAndWait
+  },
+}))
+
+// ── Imports under test (after all mocks) ─────────────────────────────────────
+import * as vscode from 'vscode'
+import type { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
+import type { CreatePanelInbound } from '../views/create-panel-types.js'
+import { CreateSkillPanel } from '../views/CreateSkillPanel.js'
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+type MessageHandler = (msg: CreatePanelInbound) => void | Promise<void>
+
+/**
+ * Creates a mock webview panel.
+ *
+ * Key design notes:
+ * 1. `panel.dispose()` just records the call (does NOT fire disposeHandler).
+ *    This breaks the infinite recursion: CreateSkillPanel.dispose() →
+ *    this._panel.dispose() → disposeHandler() → CreateSkillPanel.dispose().
+ *    In real VS Code, panel.dispose() fires onDidDispose asynchronously after
+ *    the call, and CreateSkillPanel guards re-entry with `_disposed`.
+ *
+ * 2. The onDidReceiveMessage handler is fired with `void _handleMessage(...)` —
+ *    fire-and-forget. So `sendMessage` returns before async work completes.
+ *    Tests that trigger async work (submit, cancel) MUST use `vi.waitFor()`
+ *    to await the expected side-effect rather than awaiting sendMessage itself.
+ */
+function createMockPanel() {
+  let messageHandler: MessageHandler | undefined
+  let disposeHandler: (() => void) | undefined
+  const postedMessages: unknown[] = []
+
+  const panel = {
+    reveal: vi.fn(),
+    // panel.dispose() just records — does NOT fire disposeHandler (breaks recursion).
+    dispose: vi.fn(),
+    title: 'Create Skill',
+    webview: {
+      html: '',
+      onDidReceiveMessage: vi.fn(
+        (handler: MessageHandler, _ctx: unknown, subs: { dispose: () => void }[]) => {
+          messageHandler = handler
+          const d = { dispose: vi.fn() }
+          if (Array.isArray(subs)) subs.push(d)
+          return d
+        }
+      ),
+      postMessage: vi.fn((msg: unknown) => {
+        postedMessages.push(msg)
+        return Promise.resolve(true)
+      }),
+      asWebviewUri: vi.fn((uri: unknown) => uri),
+    },
+    onDidDispose: vi.fn((handler: () => void, _ctx: unknown, subs: { dispose: () => void }[]) => {
+      disposeHandler = handler
+      const d = { dispose: vi.fn() }
+      if (Array.isArray(subs)) subs.push(d)
+      return d
+    }),
+  }
+
+  return {
+    panel: panel as unknown as vscode.WebviewPanel,
+    /** Fire the onDidReceiveMessage handler (returns before async work completes). */
+    sendMessage: (msg: CreatePanelInbound) => {
+      messageHandler?.(msg)
+    },
+    getPostedMessages: () => postedMessages,
+    /**
+     * Simulate an external close (user closes the webview tab).
+     * Fires onDidDispose directly — does NOT go through panel.dispose().
+     */
+    triggerExternalClose: () => {
+      disposeHandler?.()
+    },
+  }
+}
+
+const EXTENSION_URI = { fsPath: '/ext' } as vscode.Uri
+const FAKE_OUTPUT = {
+  append: vi.fn(),
+  appendLine: vi.fn(),
+  show: vi.fn(),
+  dispose: vi.fn(),
+} as unknown as vscode.OutputChannel
+
+function makeTreeProvider(): SkillTreeDataProvider {
+  return {
+    refreshAndWait,
+    getInstalledSkills: vi.fn(() => []),
+  } as unknown as SkillTreeDataProvider
+}
+
+const VALID_FIELDS = {
+  author: 'my-author',
+  name: 'my-skill',
+  description: 'A great skill',
+  type: 'basic' as const,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe('CreateSkillPanel (guards / edge cases)', () => {
+  beforeEach(() => {
+    vi.mocked(createWebviewPanel).mockReset()
+    trackMock.mockReset()
+    validateSkillNameMock.mockReset().mockReturnValue(true)
+    runCliMock.mockReset().mockResolvedValue(0)
+    existsMock.mockReset().mockResolvedValue(false)
+    showPostCreateChecklistMock.mockReset().mockResolvedValue(undefined)
+    refreshAndWait.mockReset().mockResolvedValue(undefined)
+    showWarningMessage.mockReset()
+    openTextDocument.mockReset().mockRejectedValue(new Error('not found'))
+    showTextDocument.mockReset()
+  })
+
+  afterEach(() => {
+    CreateSkillPanel.resetForTests()
+  })
+
+  // ── (e) C1: second submit while first in flight is dropped ─────────────────
+  describe('C1: re-entrancy lock', () => {
+    it('drops a second submit while the first is in flight', async () => {
+      existsMock.mockResolvedValue(false)
+
+      let runCliCalled = false
+      let resolveRunCli!: (code: number) => void
+      runCliMock.mockImplementation(
+        () =>
+          new Promise<number>((resolve) => {
+            runCliCalled = true
+            resolveRunCli = resolve
+          })
+      )
+
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+
+      // Start first submit
+      mock.sendMessage({ command: 'submit', fields: VALID_FIELDS })
+
+      // Wait until runCli is called (first submit reached the runCli await)
+      await vi.waitFor(() => {
+        expect(runCliCalled).toBe(true)
+      })
+
+      // Fire second submit — should be dropped (re-entrancy lock is set)
+      mock.sendMessage({ command: 'submit', fields: VALID_FIELDS })
+
+      // Resolve the first
+      resolveRunCli(0)
+
+      // Wait for completion
+      await vi.waitFor(() => {
+        expect(mock.panel.dispose).toHaveBeenCalled()
+      })
+
+      expect(runCliMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ── (f) overwrite: user declines ───────────────────────────────────────────
+  describe('overwrite: user declines', () => {
+    it('tracks vscode_create_cancelled with stage=overwrite and posts createFailed, no runCli', async () => {
+      existsMock.mockResolvedValue(true)
+      showWarningMessage.mockResolvedValue('Cancel') // anything other than 'Overwrite'
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      mock.sendMessage({ command: 'submit', fields: VALID_FIELDS })
+
+      await vi.waitFor(() => {
+        expect(
+          mock
+            .getPostedMessages()
+            .some((m) => (m as { command: string }).command === 'createFailed')
+        ).toBe(true)
+      })
+      expect(trackMock).toHaveBeenCalledWith('vscode_create_cancelled', { stage: 'overwrite' })
+      expect(runCliMock).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── (g) C2: dispose after success does NOT fire vscode_create_cancelled ────
+  describe('C2: dispose after success', () => {
+    it('does not fire vscode_create_cancelled when panel disposed after success', async () => {
+      runCliMock.mockResolvedValue(0)
+      existsMock.mockResolvedValue(false)
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      mock.sendMessage({ command: 'submit', fields: VALID_FIELDS })
+
+      // Wait for success completion
+      await vi.waitFor(() => {
+        expect(mock.panel.dispose).toHaveBeenCalled()
+      })
+
+      const cancelledCalls = trackMock.mock.calls.filter(
+        (call: unknown[]) => call[0] === 'vscode_create_cancelled'
+      )
+      expect(cancelledCalls).toHaveLength(0)
+    })
+  })
+
+  // ── (h) cancel / dispose without success → vscode_create_cancelled ─────────
+  describe('C2: cancel / dispose without success', () => {
+    it('fires vscode_create_cancelled with stage=wizard when cancel message received', async () => {
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      mock.sendMessage({ command: 'cancel' })
+
+      // cancel calls dispose() synchronously inside _handleMessage
+      await vi.waitFor(() => {
+        expect(trackMock).toHaveBeenCalledWith('vscode_create_cancelled', { stage: 'wizard' })
+      })
+    })
+
+    it('fires vscode_create_cancelled when panel closes externally without success (onDidDispose)', () => {
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      // Simulate external close (user closes the webview tab) — synchronous
+      mock.triggerExternalClose()
+
+      expect(trackMock).toHaveBeenCalledWith('vscode_create_cancelled', { stage: 'wizard' })
+      // L1/L3: the dispose() re-entry guard ensures the cancel fires exactly once.
+      const cancelledCalls = trackMock.mock.calls.filter(
+        (call: unknown[]) => call[0] === 'vscode_create_cancelled'
+      )
+      expect(cancelledCalls).toHaveLength(1)
+    })
+  })
+
+  // ── (i) re-createOrShow with currentPanel set → reveal ────────────────────
+  describe('singleton reveal', () => {
+    it('reveals existing panel without creating a new one on second createOrShow', () => {
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      // First open
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      expect(vi.mocked(createWebviewPanel)).toHaveBeenCalledTimes(1)
+
+      // Second open — singleton reveal
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      expect(vi.mocked(createWebviewPanel)).toHaveBeenCalledTimes(1) // no new panel
+      expect(mock.panel.reveal).toHaveBeenCalled()
+    })
+  })
+
+  // ── cliOutput streaming ────────────────────────────────────────────────────
+  describe('cliOutput streaming', () => {
+    it('posts cliOutput chunks to the webview as runCli fires onChunk', async () => {
+      existsMock.mockResolvedValue(false)
+      runCliMock.mockImplementation(
+        (_args: string[], _output: unknown, onChunk?: (c: string) => void) => {
+          onChunk?.('line 1\n')
+          onChunk?.('line 2\n')
+          return Promise.resolve(0)
+        }
+      )
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      mock.sendMessage({ command: 'submit', fields: VALID_FIELDS })
+
+      await vi.waitFor(() => {
+        const cliOutputMsgs = mock
+          .getPostedMessages()
+          .filter((m) => (m as { command: string }).command === 'cliOutput') as {
+          command: string
+          chunk: string
+        }[]
+        expect(cliOutputMsgs.some((m) => m.chunk.includes('line 1'))).toBe(true)
+      })
+
+      const posted = mock.getPostedMessages()
+      const cliOutputMsgs = posted.filter(
+        (m) => (m as { command: string }).command === 'cliOutput'
+      ) as { command: string; chunk: string }[]
+      expect(cliOutputMsgs.some((m) => m.chunk.includes('line 2'))).toBe(true)
+    })
+  })
+})

--- a/packages/vscode-extension/src/__tests__/CreateSkillPanel.test.ts
+++ b/packages/vscode-extension/src/__tests__/CreateSkillPanel.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Unit tests for views/CreateSkillPanel.ts (SMI-5313 / GH #1454).
+ *
+ * Mirrors the mocking style of SkillDetailPanel.test.ts (vi.hoisted for
+ * spies that must exist before the vi.mock factory runs, vi.waitFor for
+ * the async panel work that is fired via `void _handleMessage(...)` — the
+ * webview message handler is fire-and-forget so sendMessage resolves before
+ * the async handler chain completes).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ── vi.hoisted: spies that must exist before the vi.mock factory runs ─────────
+const {
+  createWebviewPanel,
+  showWarningMessage,
+  openTextDocument,
+  showTextDocument,
+  trackMock,
+  validateSkillNameMock,
+  runCliMock,
+  existsMock,
+  showPostCreateChecklistMock,
+} = vi.hoisted(() => ({
+  createWebviewPanel: vi.fn(),
+  showWarningMessage: vi.fn(),
+  openTextDocument: vi.fn(),
+  showTextDocument: vi.fn(),
+  trackMock: vi.fn(),
+  validateSkillNameMock: vi.fn(),
+  runCliMock: vi.fn(),
+  existsMock: vi.fn(),
+  showPostCreateChecklistMock: vi.fn(),
+}))
+
+// ── vscode mock ──────────────────────────────────────────────────────────────
+vi.mock('vscode', () => ({
+  Uri: {
+    joinPath: vi.fn((_base: unknown, ...segments: string[]) => ({
+      fsPath: segments.join('/'),
+    })),
+    file: vi.fn((s: string) => ({ fsPath: s, scheme: 'file' })),
+    parse: vi.fn((s: string) => ({ toString: () => s })),
+  },
+  ViewColumn: { One: 1 },
+  window: {
+    createWebviewPanel,
+    activeTextEditor: undefined,
+    showWarningMessage,
+    showInformationMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+    openTextDocument,
+    showTextDocument,
+  },
+  workspace: { openTextDocument },
+  commands: { executeCommand: vi.fn() },
+  env: { openExternal: vi.fn() },
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+// ── helpers mock ─────────────────────────────────────────────────────────────
+vi.mock('../utils/createSkill.helpers.js', () => ({
+  buildCreateArgs: (fields: {
+    author: string
+    name: string
+    description: string
+    type: string
+  }) => [
+    'create',
+    fields.name,
+    '-a',
+    fields.author,
+    '-d',
+    fields.description,
+    '--type',
+    fields.type,
+    '-y',
+  ],
+  targetDirFor: (name: string) => `/home/user/.claude/skills/${name}`,
+  runCli: runCliMock,
+  exists: existsMock,
+  showPostCreateChecklist: showPostCreateChecklistMock,
+}))
+
+// ── CSP / nonce mock ─────────────────────────────────────────────────────────
+vi.mock('../utils/csp.js', () => ({
+  generateCspNonce: () => 'test-nonce-123',
+  getCreateSkillCsp: () => "default-src 'none';",
+}))
+
+// ── HTML mock ─────────────────────────────────────────────────────────────────
+vi.mock('../views/create-panel-html.js', () => ({
+  getCreateSkillHtml: () => '<html><body>mock</body></html>',
+}))
+
+// ── Telemetry mock ───────────────────────────────────────────────────────────
+vi.mock('../services/Telemetry.js', () => ({
+  track: trackMock,
+}))
+
+// ── validateSkillName mock ────────────────────────────────────────────────────
+vi.mock('../utils/skillNameValidation.js', () => ({
+  validateSkillName: validateSkillNameMock,
+}))
+
+// ── SkillTreeDataProvider mock ────────────────────────────────────────────────
+const refreshAndWait = vi.fn(async () => {})
+vi.mock('../sidebar/SkillTreeDataProvider.js', () => ({
+  SkillTreeDataProvider: class {
+    refreshAndWait = refreshAndWait
+  },
+}))
+
+// ── Imports under test (after all mocks) ─────────────────────────────────────
+import * as vscode from 'vscode'
+import type { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
+import type { CreatePanelInbound } from '../views/create-panel-types.js'
+import { CreateSkillPanel } from '../views/CreateSkillPanel.js'
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+type MessageHandler = (msg: CreatePanelInbound) => void | Promise<void>
+
+/**
+ * Creates a mock webview panel.
+ *
+ * Key design notes:
+ * 1. `panel.dispose()` just records the call (does NOT fire disposeHandler).
+ *    This breaks the infinite recursion: CreateSkillPanel.dispose() →
+ *    this._panel.dispose() → disposeHandler() → CreateSkillPanel.dispose().
+ *    In real VS Code, panel.dispose() fires onDidDispose asynchronously after
+ *    the call, and CreateSkillPanel guards re-entry with `_disposed`.
+ *
+ * 2. The onDidReceiveMessage handler is fired with `void _handleMessage(...)` —
+ *    fire-and-forget. So `sendMessage` returns before async work completes.
+ *    Tests that trigger async work (submit, cancel) MUST use `vi.waitFor()`
+ *    to await the expected side-effect rather than awaiting sendMessage itself.
+ */
+function createMockPanel() {
+  let messageHandler: MessageHandler | undefined
+  let disposeHandler: (() => void) | undefined
+  const postedMessages: unknown[] = []
+
+  const panel = {
+    reveal: vi.fn(),
+    // panel.dispose() just records — does NOT fire disposeHandler (breaks recursion).
+    dispose: vi.fn(),
+    title: 'Create Skill',
+    webview: {
+      html: '',
+      onDidReceiveMessage: vi.fn(
+        (handler: MessageHandler, _ctx: unknown, subs: { dispose: () => void }[]) => {
+          messageHandler = handler
+          const d = { dispose: vi.fn() }
+          if (Array.isArray(subs)) subs.push(d)
+          return d
+        }
+      ),
+      postMessage: vi.fn((msg: unknown) => {
+        postedMessages.push(msg)
+        return Promise.resolve(true)
+      }),
+      asWebviewUri: vi.fn((uri: unknown) => uri),
+    },
+    onDidDispose: vi.fn((handler: () => void, _ctx: unknown, subs: { dispose: () => void }[]) => {
+      disposeHandler = handler
+      const d = { dispose: vi.fn() }
+      if (Array.isArray(subs)) subs.push(d)
+      return d
+    }),
+  }
+
+  return {
+    panel: panel as unknown as vscode.WebviewPanel,
+    /** Fire the onDidReceiveMessage handler (returns before async work completes). */
+    sendMessage: (msg: CreatePanelInbound) => {
+      messageHandler?.(msg)
+    },
+    getPostedMessages: () => postedMessages,
+    /**
+     * Simulate an external close (user closes the webview tab).
+     * Fires onDidDispose directly — does NOT go through panel.dispose().
+     */
+    triggerExternalClose: () => {
+      disposeHandler?.()
+    },
+  }
+}
+
+const EXTENSION_URI = { fsPath: '/ext' } as vscode.Uri
+const FAKE_OUTPUT = {
+  append: vi.fn(),
+  appendLine: vi.fn(),
+  show: vi.fn(),
+  dispose: vi.fn(),
+} as unknown as vscode.OutputChannel
+
+function makeTreeProvider(): SkillTreeDataProvider {
+  return {
+    refreshAndWait,
+    getInstalledSkills: vi.fn(() => []),
+  } as unknown as SkillTreeDataProvider
+}
+
+const VALID_FIELDS = {
+  author: 'my-author',
+  name: 'my-skill',
+  description: 'A great skill',
+  type: 'basic' as const,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe('CreateSkillPanel', () => {
+  beforeEach(() => {
+    vi.mocked(createWebviewPanel).mockReset()
+    trackMock.mockReset()
+    validateSkillNameMock.mockReset().mockReturnValue(true)
+    runCliMock.mockReset().mockResolvedValue(0)
+    existsMock.mockReset().mockResolvedValue(false)
+    showPostCreateChecklistMock.mockReset().mockResolvedValue(undefined)
+    refreshAndWait.mockReset().mockResolvedValue(undefined)
+    showWarningMessage.mockReset()
+    openTextDocument.mockReset().mockRejectedValue(new Error('not found'))
+    showTextDocument.mockReset()
+  })
+
+  afterEach(() => {
+    CreateSkillPanel.resetForTests()
+  })
+
+  // ── (a) validateName ────────────────────────────────────────────────────────
+  describe('validateName message', () => {
+    it('posts nameValidity with valid=true when name is valid', async () => {
+      validateSkillNameMock.mockReturnValue(true)
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      mock.sendMessage({ command: 'validateName', value: 'good-skill' })
+
+      // validateName is synchronous in _handleMessage — posts immediately
+      await vi.waitFor(() => {
+        expect(mock.getPostedMessages()).toContainEqual({ command: 'nameValidity', valid: true })
+      })
+    })
+
+    it('posts nameValidity with valid=false and message when name is invalid', async () => {
+      validateSkillNameMock.mockReturnValue('Name must be lowercase')
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      mock.sendMessage({ command: 'validateName', value: 'BadName' })
+
+      await vi.waitFor(() => {
+        expect(mock.getPostedMessages()).toContainEqual({
+          command: 'nameValidity',
+          valid: false,
+          message: 'Name must be lowercase',
+        })
+      })
+    })
+  })
+
+  // ── (b) submit with invalid fields ─────────────────────────────────────────
+  describe('submit with invalid fields', () => {
+    it('posts submitError and does not call runCli when fields are invalid', async () => {
+      validateSkillNameMock.mockReturnValue('Name is invalid')
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      mock.sendMessage({
+        command: 'submit',
+        fields: { author: '', name: '', description: '', type: 'basic' },
+      })
+
+      await vi.waitFor(() => {
+        expect(
+          mock.getPostedMessages().some((m) => (m as { command: string }).command === 'submitError')
+        ).toBe(true)
+      })
+      expect(runCliMock).not.toHaveBeenCalled()
+      expect(mock.panel.dispose).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── (c) submit valid, exit 0 ────────────────────────────────────────────────
+  describe('submit valid fields, CLI exits 0', () => {
+    it('posts creating, calls runCli with buildCreateArgs, tracks complete, disposes, calls checklist', async () => {
+      runCliMock.mockResolvedValue(0)
+      existsMock.mockResolvedValue(false)
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      mock.sendMessage({ command: 'submit', fields: VALID_FIELDS })
+
+      // Wait for the success path to complete (panel.dispose is the terminal signal)
+      await vi.waitFor(() => {
+        expect(mock.panel.dispose).toHaveBeenCalled()
+      })
+
+      const posted = mock.getPostedMessages()
+      expect(posted.some((m) => (m as { command: string }).command === 'creating')).toBe(true)
+      expect(runCliMock).toHaveBeenCalledWith(
+        ['create', 'my-skill', '-a', 'my-author', '-d', 'A great skill', '--type', 'basic', '-y'],
+        FAKE_OUTPUT,
+        expect.any(Function)
+      )
+      expect(trackMock).toHaveBeenCalledWith('vscode_create_complete', { type: 'basic' })
+      expect(refreshAndWait).toHaveBeenCalled()
+      expect(showPostCreateChecklistMock).toHaveBeenCalledWith(
+        '/home/user/.claude/skills/my-skill',
+        'my-skill'
+      )
+    })
+  })
+
+  // ── (d) CLI exits non-zero ──────────────────────────────────────────────────
+  describe('submit valid fields, CLI exits non-zero', () => {
+    it('posts createFailed, tracks vscode_create_failed, does not dispose', async () => {
+      runCliMock.mockResolvedValue(2)
+      existsMock.mockResolvedValue(false)
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      mock.sendMessage({ command: 'submit', fields: VALID_FIELDS })
+
+      await vi.waitFor(() => {
+        expect(
+          mock
+            .getPostedMessages()
+            .some((m) => (m as { command: string }).command === 'createFailed')
+        ).toBe(true)
+      })
+      expect(trackMock).toHaveBeenCalledWith('vscode_create_failed', {
+        reason: 'cli_nonzero_exit',
+        exit_code: 2,
+      })
+      expect(mock.panel.dispose).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/vscode-extension/src/__tests__/create-panel-html.test.ts
+++ b/packages/vscode-extension/src/__tests__/create-panel-html.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for views/create-panel-html.ts (SMI-5313 / GH #1454).
+ *
+ * Verifies the static HTML document rendered once by CreateSkillPanel:
+ * all four form fields, three type radios, CSP embedding, and aria-live slots.
+ */
+import { describe, it, expect } from 'vitest'
+import { getCreateSkillHtml } from '../views/create-panel-html.js'
+
+const NONCE = 'test-nonce-abcdefgh'
+const CSP = "default-src 'none'; script-src 'nonce-test-nonce-abcdefgh';"
+
+describe('getCreateSkillHtml', () => {
+  const html = getCreateSkillHtml(NONCE, CSP)
+
+  describe('form fields', () => {
+    it('renders the author field', () => {
+      expect(html).toContain('id="author"')
+      expect(html).toContain('name="author"')
+    })
+
+    it('renders the name field', () => {
+      expect(html).toContain('id="name"')
+      expect(html).toContain('name="name"')
+    })
+
+    it('renders the description field', () => {
+      expect(html).toContain('id="description"')
+      expect(html).toContain('name="description"')
+    })
+
+    it('renders the type fieldset', () => {
+      expect(html).toContain('name="type"')
+    })
+  })
+
+  describe('type radios', () => {
+    it('renders basic radio option', () => {
+      expect(html).toContain('value="basic"')
+    })
+
+    it('renders intermediate radio option', () => {
+      expect(html).toContain('value="intermediate"')
+    })
+
+    it('renders advanced radio option', () => {
+      expect(html).toContain('value="advanced"')
+    })
+
+    it('selects basic by default', () => {
+      expect(html).toContain('value="basic" checked')
+    })
+  })
+
+  describe('CSP', () => {
+    it('embeds the passed CSP string in the meta tag', () => {
+      expect(html).toContain(`content="${CSP}"`)
+    })
+
+    it('includes Content-Security-Policy in the meta tag', () => {
+      expect(html).toContain('http-equiv="Content-Security-Policy"')
+    })
+  })
+
+  describe('aria-live error slots', () => {
+    it('author error slot has aria-live="polite"', () => {
+      expect(html).toContain('id="authorError"')
+      // The error span should have aria-live
+      const authorErrorIdx = html.indexOf('id="authorError"')
+      const surroundingSnippet = html.slice(Math.max(0, authorErrorIdx - 100), authorErrorIdx + 100)
+      expect(surroundingSnippet).toContain('aria-live="polite"')
+    })
+
+    it('name error slot has aria-live="polite"', () => {
+      expect(html).toContain('id="nameError"')
+      const nameErrorIdx = html.indexOf('id="nameError"')
+      const surroundingSnippet = html.slice(Math.max(0, nameErrorIdx - 100), nameErrorIdx + 100)
+      expect(surroundingSnippet).toContain('aria-live="polite"')
+    })
+
+    it('description error slot has aria-live="polite"', () => {
+      expect(html).toContain('id="descriptionError"')
+      const descErrorIdx = html.indexOf('id="descriptionError"')
+      const surroundingSnippet = html.slice(Math.max(0, descErrorIdx - 100), descErrorIdx + 100)
+      expect(surroundingSnippet).toContain('aria-live="polite"')
+    })
+
+    it('type error slot exists with aria-live="polite" (M1)', () => {
+      expect(html).toContain('id="typeError"')
+      const typeErrorIdx = html.indexOf('id="typeError"')
+      const surroundingSnippet = html.slice(Math.max(0, typeErrorIdx - 100), typeErrorIdx + 100)
+      expect(surroundingSnippet).toContain('aria-live="polite"')
+    })
+
+    it('renders multiple aria-live="polite" slots (at least 3)', () => {
+      const matches = html.match(/aria-live="polite"/g) ?? []
+      expect(matches.length).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  describe('nonce', () => {
+    it('includes nonce in the script tag', () => {
+      expect(html).toContain(`nonce="${NONCE}"`)
+    })
+  })
+
+  describe('structure', () => {
+    it('is a full HTML document', () => {
+      expect(html).toContain('<!DOCTYPE html>')
+      expect(html).toContain('<html')
+      expect(html).toContain('</html>')
+    })
+
+    it('contains the form element', () => {
+      expect(html).toContain('id="createForm"')
+    })
+
+    it('contains the Create Skill button', () => {
+      expect(html).toContain('id="createBtn"')
+    })
+
+    it('contains the CLI log output area', () => {
+      expect(html).toContain('id="cliLog"')
+    })
+  })
+})

--- a/packages/vscode-extension/src/__tests__/create-panel-script.test.ts
+++ b/packages/vscode-extension/src/__tests__/create-panel-script.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for views/create-panel-script.ts (SMI-5313 / GH #1454).
+ *
+ * Verifies the webview script body returned by getCreateScript:
+ * - validateName / submit postMessage wiring
+ * - No innerHTML anywhere (H3)
+ * - cliOutput uses textContent += (H3/M5)
+ * - Null-guards on all getElementById calls
+ * - Create button is type=button wired via click (not form submit)
+ */
+import { describe, it, expect } from 'vitest'
+import { getCreateScript } from '../views/create-panel-script.js'
+
+const NONCE = 'test-nonce-script-xyz'
+
+describe('getCreateScript', () => {
+  const script = getCreateScript(NONCE)
+
+  describe('H3: no innerHTML assignment anywhere', () => {
+    it('does not assign innerHTML (no "= innerHTML" or ".innerHTML =")', () => {
+      // Comments may mention innerHTML as a safety note (e.g. "NEVER innerHTML")
+      // but no actual assignment should exist. Check for the assignment operator pattern.
+      expect(script).not.toMatch(/\.innerHTML\s*=(?!=)/)
+      expect(script).not.toMatch(/\.innerHTML\s*\+=/)
+    })
+  })
+
+  describe('H3/M5: cliOutput uses textContent +=', () => {
+    it('appends cliOutput chunks via textContent +=', () => {
+      expect(script).toContain('textContent +=')
+    })
+
+    it('the cliOutput case uses textContent += for appending', () => {
+      const cliOutputIdx = script.indexOf("case 'cliOutput'")
+      const snippet = script.slice(cliOutputIdx, cliOutputIdx + 300)
+      expect(snippet).toContain('textContent')
+      // No innerHTML assignment in this block
+      expect(snippet).not.toMatch(/\.innerHTML\s*[+]?=(?!=)/)
+    })
+  })
+
+  describe('validateName postMessage wiring', () => {
+    it('posts validateName on name input event', () => {
+      expect(script).toContain("command: 'validateName'")
+      expect(script).toContain("'input'")
+    })
+
+    it('handles nameValidity response', () => {
+      expect(script).toContain("case 'nameValidity'")
+    })
+  })
+
+  describe('submit postMessage wiring', () => {
+    it('posts submit command on Create button click', () => {
+      expect(script).toContain("command: 'submit'")
+      expect(script).toContain("'click'")
+    })
+
+    it('Create button is wired via click listener (not form submit event)', () => {
+      // The button is type=button; the script uses addEventListener('click')
+      expect(script).toContain("addEventListener('click'")
+      // No submit event listener on the form
+      expect(script).not.toContain("addEventListener('submit'")
+    })
+
+    it('handles submitError response', () => {
+      expect(script).toContain("case 'submitError'")
+    })
+
+    it('wires the type-field error slot (M1)', () => {
+      expect(script).toContain('typeError')
+      expect(script).toContain('errors.type')
+    })
+  })
+
+  describe('null-guards', () => {
+    it('null-guards nameInput', () => {
+      expect(script).toContain('nameInput')
+      expect(script).toMatch(/if\s*\(\s*nameInput\s*\)/)
+    })
+
+    it('null-guards createBtn', () => {
+      expect(script).toContain('createBtn')
+      expect(script).toMatch(/if\s*\(\s*createBtn\s*\)/)
+    })
+
+    it('null-guards cliLog', () => {
+      expect(script).toContain('cliLog')
+      expect(script).toMatch(/if\s*\(\s*cliLog/)
+    })
+  })
+
+  describe('message handler wiring', () => {
+    it('listens for window message events', () => {
+      expect(script).toContain("window.addEventListener('message'")
+    })
+
+    it('handles creating command (disables form)', () => {
+      expect(script).toContain("case 'creating'")
+    })
+
+    it('handles createFailed command (re-enables form)', () => {
+      expect(script).toContain("case 'createFailed'")
+    })
+  })
+
+  describe('vscode API', () => {
+    it('acquires the VS Code API', () => {
+      expect(script).toContain('acquireVsCodeApi()')
+    })
+  })
+
+  describe('text content safety', () => {
+    it('uses textContent (not innerHTML) for error messages', () => {
+      // setText helper uses el.textContent
+      expect(script).toContain('textContent')
+    })
+  })
+})

--- a/packages/vscode-extension/src/__tests__/createSkill.checklist.test.ts
+++ b/packages/vscode-extension/src/__tests__/createSkill.checklist.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for showPostCreateChecklist (relocated from createSkillCommand.test.ts,
+ * SMI-5313 / GH #1454). Import from utils/createSkill.helpers.js — the function
+ * moved there when the helpers were extracted for shared use by CreateSkillPanel.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const showInformationMessage = vi.fn()
+const executeCommand = vi.fn()
+const openExternal = vi.fn()
+
+vi.mock('vscode', () => ({
+  window: {
+    showInformationMessage,
+  },
+  commands: { executeCommand },
+  env: { openExternal },
+  Uri: {
+    file: (s: string) => ({ toString: () => s, fsPath: s }),
+    parse: (s: string) => ({ toString: () => s }),
+  },
+}))
+
+vi.mock('../services/Telemetry.js', () => ({
+  track: vi.fn(),
+}))
+
+/**
+ * Drain microtask queue so the fire-and-forget promise fully settles.
+ */
+const flushAsync = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(() => setImmediate(() => resolve())))
+
+describe('showPostCreateChecklist (GH #1453 / SMI-5312)', () => {
+  beforeEach(() => {
+    showInformationMessage.mockReset()
+    executeCommand.mockReset()
+    openExternal.mockReset()
+    vi.resetModules()
+  })
+
+  it('opens the skill folder in OS when user picks "Open folder"', async () => {
+    const { track } = await import('../services/Telemetry.js')
+    showInformationMessage.mockResolvedValue('Open folder')
+    const { showPostCreateChecklist } = await import('../utils/createSkill.helpers.js')
+
+    void showPostCreateChecklist('/home/user/.claude/skills/my-skill', 'my-skill')
+    await flushAsync()
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      'revealFileInOS',
+      expect.objectContaining({ toString: expect.any(Function) })
+    )
+    expect(track).toHaveBeenCalledWith('vscode_create_checklist_action', {
+      action: 'open_folder',
+    })
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('opens the authoring docs URL when user picks "Authoring docs"', async () => {
+    const { track } = await import('../services/Telemetry.js')
+    showInformationMessage.mockResolvedValue('Authoring docs')
+    const { showPostCreateChecklist } = await import('../utils/createSkill.helpers.js')
+
+    void showPostCreateChecklist('/home/user/.claude/skills/my-skill', 'my-skill')
+    await flushAsync()
+
+    expect(openExternal).toHaveBeenCalledWith(
+      expect.objectContaining({ toString: expect.any(Function) })
+    )
+    expect(track).toHaveBeenCalledWith('vscode_create_checklist_action', { action: 'docs' })
+    expect(executeCommand).not.toHaveBeenCalled()
+  })
+
+  it('swallows errors from executeCommand without unhandled rejection', async () => {
+    showInformationMessage.mockResolvedValue('Open folder')
+    executeCommand.mockRejectedValue(new Error('Host shutting down'))
+    const { showPostCreateChecklist } = await import('../utils/createSkill.helpers.js')
+
+    // Should not throw / cause unhandled rejection
+    await expect(
+      showPostCreateChecklist('/home/user/.claude/skills/my-skill', 'my-skill')
+    ).resolves.toBeUndefined()
+  })
+
+  it('takes no action when user dismisses the checklist toast', async () => {
+    showInformationMessage.mockResolvedValue(undefined)
+    const { showPostCreateChecklist } = await import('../utils/createSkill.helpers.js')
+
+    void showPostCreateChecklist('/home/user/.claude/skills/my-skill', 'my-skill')
+    await flushAsync()
+
+    expect(executeCommand).not.toHaveBeenCalled()
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+})

--- a/packages/vscode-extension/src/__tests__/createSkill.helpers.test.ts
+++ b/packages/vscode-extension/src/__tests__/createSkill.helpers.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for utils/createSkill.helpers.ts (SMI-5313 / GH #1454).
+ *
+ * Tests ensureCliAvailable, runCli (with onChunk), exists, buildCreateArgs,
+ * and targetDirFor.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+const showErrorMessage = vi.fn()
+const showInformationMessage = vi.fn()
+const clipboardWrite = vi.fn()
+const openExternal = vi.fn()
+
+vi.mock('vscode', () => ({
+  window: {
+    showErrorMessage,
+    showInformationMessage,
+  },
+  env: {
+    clipboard: { writeText: clipboardWrite },
+    openExternal,
+  },
+  Uri: {
+    file: (s: string) => ({ toString: () => s, fsPath: s }),
+    parse: (s: string) => ({ toString: () => s }),
+  },
+}))
+
+vi.mock('../services/Telemetry.js', () => ({
+  track: vi.fn(),
+}))
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter
+  stderr: EventEmitter
+}
+
+const spawnMock = vi.fn()
+vi.mock('cross-spawn', () => ({ default: spawnMock }))
+
+function makeVersionChild(behavior: 'found' | 'notfound'): FakeChild {
+  const c = new EventEmitter() as FakeChild
+  c.stdout = new EventEmitter()
+  c.stderr = new EventEmitter()
+  queueMicrotask(() => {
+    if (behavior === 'notfound') {
+      c.emit('error', Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+    } else {
+      c.emit('exit', 0)
+    }
+  })
+  return c
+}
+
+function makeCliChild(exitCode: number, chunks?: string[], errorMsg?: string): FakeChild {
+  const c = new EventEmitter() as FakeChild
+  c.stdout = new EventEmitter()
+  c.stderr = new EventEmitter()
+  queueMicrotask(() => {
+    if (errorMsg) {
+      c.emit('error', new Error(errorMsg))
+    } else {
+      if (chunks) {
+        for (const chunk of chunks) {
+          c.stdout.emit('data', Buffer.from(chunk, 'utf8'))
+        }
+      }
+      c.emit('exit', exitCode)
+    }
+  })
+  return c
+}
+
+describe('ensureCliAvailable', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+    showErrorMessage.mockReset()
+    clipboardWrite.mockReset()
+    openExternal.mockReset()
+    showInformationMessage.mockReset()
+    vi.resetModules()
+  })
+
+  it('returns true when skillsmith --version exits 0', async () => {
+    spawnMock.mockImplementationOnce(() => makeVersionChild('found'))
+    const { ensureCliAvailable } = await import('../utils/createSkill.helpers.js')
+
+    const result = await ensureCliAvailable()
+
+    expect(result).toBe(true)
+    expect(showErrorMessage).not.toHaveBeenCalled()
+  })
+
+  it('returns false and shows modal when CLI is not found', async () => {
+    spawnMock.mockImplementationOnce(() => makeVersionChild('notfound'))
+    showErrorMessage.mockResolvedValue(undefined)
+    const { ensureCliAvailable } = await import('../utils/createSkill.helpers.js')
+
+    const result = await ensureCliAvailable()
+
+    expect(result).toBe(false)
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      'Skillsmith CLI is not installed.',
+      expect.objectContaining({ modal: true }),
+      'Copy install command',
+      'Open docs'
+    )
+  })
+
+  it('copies the install command when user picks "Copy install command"', async () => {
+    spawnMock.mockImplementationOnce(() => makeVersionChild('notfound'))
+    showErrorMessage.mockResolvedValue('Copy install command')
+    const { ensureCliAvailable } = await import('../utils/createSkill.helpers.js')
+
+    await ensureCliAvailable()
+
+    expect(clipboardWrite).toHaveBeenCalledWith('npm install -g @skillsmith/cli')
+  })
+
+  it('opens docs when user picks "Open docs"', async () => {
+    spawnMock.mockImplementationOnce(() => makeVersionChild('notfound'))
+    showErrorMessage.mockResolvedValue('Open docs')
+    const { ensureCliAvailable } = await import('../utils/createSkill.helpers.js')
+
+    await ensureCliAvailable()
+
+    expect(openExternal).toHaveBeenCalledWith(
+      expect.objectContaining({ toString: expect.any(Function) })
+    )
+  })
+})
+
+describe('runCli', () => {
+  const fakeOutput = {
+    append: vi.fn(),
+    appendLine: vi.fn(),
+    show: vi.fn(),
+    dispose: vi.fn(),
+  }
+
+  beforeEach(() => {
+    spawnMock.mockReset()
+    fakeOutput.append.mockReset()
+    fakeOutput.appendLine.mockReset()
+    vi.resetModules()
+  })
+
+  it('resolves with exit code 0 on success', async () => {
+    spawnMock.mockImplementationOnce(() => makeCliChild(0))
+    const { runCli } = await import('../utils/createSkill.helpers.js')
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const code = await runCli(['create', 'my-skill', '-y'], fakeOutput as any)
+
+    expect(code).toBe(0)
+  })
+
+  it('resolves with exit code 2 on failure', async () => {
+    spawnMock.mockImplementationOnce(() => makeCliChild(2))
+    const { runCli } = await import('../utils/createSkill.helpers.js')
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const code = await runCli(['create', 'bad-name', '-y'], fakeOutput as any)
+
+    expect(code).toBe(2)
+  })
+
+  it('fires onChunk callback for each stdout chunk', async () => {
+    spawnMock.mockImplementationOnce(() => makeCliChild(0, ['chunk1', 'chunk2']))
+    const { runCli } = await import('../utils/createSkill.helpers.js')
+    const chunks: string[] = []
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await runCli(['create', 'test', '-y'], fakeOutput as any, (c) => chunks.push(c))
+
+    expect(chunks).toContain('chunk1')
+    expect(chunks).toContain('chunk2')
+  })
+
+  it('resolves with exit code 1 on spawn error', async () => {
+    spawnMock.mockImplementationOnce(() => makeCliChild(0, [], 'ENOENT: spawn error'))
+    const { runCli } = await import('../utils/createSkill.helpers.js')
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const code = await runCli(['create', 'test', '-y'], fakeOutput as any)
+
+    expect(code).toBe(1)
+  })
+
+  it('appends output to the OutputChannel', async () => {
+    spawnMock.mockImplementationOnce(() => makeCliChild(0, ['hello from cli']))
+    const { runCli } = await import('../utils/createSkill.helpers.js')
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await runCli(['create', 'test', '-y'], fakeOutput as any)
+
+    expect(fakeOutput.append).toHaveBeenCalledWith(expect.stringContaining('hello from cli'))
+  })
+})
+
+describe('exists', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('returns true for the OS temp dir (always exists)', async () => {
+    const { exists } = await import('../utils/createSkill.helpers.js')
+    const result = await exists(os.tmpdir())
+    expect(result).toBe(true)
+  })
+
+  it('returns false for a non-existent path', async () => {
+    const { exists } = await import('../utils/createSkill.helpers.js')
+    const result = await exists(path.join(os.tmpdir(), `nonexistent-${Date.now()}`))
+    expect(result).toBe(false)
+  })
+})
+
+describe('buildCreateArgs', () => {
+  it('returns exact CLI arg shape matching the old runWizard intent', async () => {
+    const { buildCreateArgs } = await import('../utils/createSkill.helpers.js')
+    const args = buildCreateArgs({
+      author: 'my-author',
+      name: 'my-skill',
+      description: 'An example skill',
+      type: 'basic',
+    })
+
+    expect(args).toEqual([
+      'create',
+      'my-skill',
+      '-a',
+      'my-author',
+      '-d',
+      'An example skill',
+      '--type',
+      'basic',
+      '-y',
+    ])
+  })
+
+  it('preserves intermediate type in args', async () => {
+    const { buildCreateArgs } = await import('../utils/createSkill.helpers.js')
+    const args = buildCreateArgs({
+      author: 'a',
+      name: 'n',
+      description: 'd',
+      type: 'intermediate',
+    })
+    expect(args).toContain('intermediate')
+    expect(args[args.indexOf('--type') + 1]).toBe('intermediate')
+  })
+})
+
+describe('targetDirFor', () => {
+  it('returns path under ~/.claude/skills/<name>', async () => {
+    const { targetDirFor } = await import('../utils/createSkill.helpers.js')
+    const dir = targetDirFor('my-skill')
+    expect(dir).toBe(path.join(os.homedir(), '.claude', 'skills', 'my-skill'))
+  })
+})

--- a/packages/vscode-extension/src/__tests__/createSkillCommand.test.ts
+++ b/packages/vscode-extension/src/__tests__/createSkillCommand.test.ts
@@ -1,48 +1,32 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { EventEmitter } from 'node:events'
-
 /**
- * Drain the microtask/macrotask queues so the fire-and-forget
- * `void showPostCreateChecklist(...)` (two sequential awaits) fully settles
- * before assertions. Two `setImmediate` ticks make the guarantee independent
- * of how the vscode mocks resolve (microtask vs macrotask).
+ * Tests for createSkillCommand.ts (rewired for SMI-5313 / GH #1454).
+ *
+ * The command now delegates to CreateSkillPanel instead of runWizard.
+ * Wizard-step tests are removed; panel interaction is tested in
+ * CreateSkillPanel.test.ts. Checklist tests moved to createSkill.checklist.test.ts.
  */
-const flushAsync = (): Promise<void> =>
-  new Promise((resolve) => setImmediate(() => setImmediate(() => resolve())))
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const showInputBox = vi.fn()
-const showQuickPick = vi.fn()
-const showInformationMessage = vi.fn()
+// ── vscode mock ───────────────────────────────────────────────────────────────
 const showErrorMessage = vi.fn()
-const showWarningMessage = vi.fn()
 const createOutputChannel = vi.fn(() => ({
   appendLine: vi.fn(),
   append: vi.fn(),
   show: vi.fn(),
   dispose: vi.fn(),
 }))
-const openTextDocument = vi.fn()
-const showTextDocument = vi.fn()
-const clipboardWrite = vi.fn()
-const openExternal = vi.fn()
 const registerCommand = vi.fn()
-const executeCommand = vi.fn()
+const FAKE_EXTENSION_URI = { fsPath: '/ext' }
 
 vi.mock('vscode', () => ({
   window: {
-    showInputBox,
-    showQuickPick,
-    showInformationMessage,
     showErrorMessage,
-    showWarningMessage,
     createOutputChannel,
-    showTextDocument,
   },
-  workspace: { openTextDocument },
-  commands: { registerCommand, executeCommand },
+  commands: { registerCommand },
   env: {
-    clipboard: { writeText: clipboardWrite },
-    openExternal,
+    clipboard: { writeText: vi.fn() },
+    openExternal: vi.fn(),
   },
   Uri: {
     file: (s: string) => ({ toString: () => s, fsPath: s }),
@@ -50,27 +34,17 @@ vi.mock('vscode', () => ({
   },
 }))
 
-interface FakeChild extends EventEmitter {
-  stdout: EventEmitter
-  stderr: EventEmitter
-}
-const spawnMock = vi.fn()
-vi.mock('cross-spawn', () => ({ default: spawnMock }))
+// ── Telemetry mock ────────────────────────────────────────────────────────────
+const trackMock = vi.fn()
+vi.mock('../services/Telemetry.js', () => ({
+  track: trackMock,
+}))
 
-function makeChild(behavior: 'found' | 'notfound', exitCode = 0): FakeChild {
-  const c = new EventEmitter() as FakeChild
-  c.stdout = new EventEmitter()
-  c.stderr = new EventEmitter()
-  queueMicrotask(() => {
-    if (behavior === 'notfound') {
-      c.emit('error', Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
-    } else {
-      c.emit('exit', exitCode)
-    }
-  })
-  return c
-}
+// ── telemetry-wrap: use real impl (withTelemetry calls track internally) ──────
+// Do NOT mock telemetry-wrap — we want createSkillAction to be the real
+// withTelemetry-wrapped version so the telemetry-coverage test stays green.
 
+// ── Sidebar mock ──────────────────────────────────────────────────────────────
 const refreshAndWait = vi.fn(async () => {})
 vi.mock('../sidebar/SkillTreeDataProvider.js', () => ({
   SkillTreeDataProvider: class {
@@ -78,33 +52,60 @@ vi.mock('../sidebar/SkillTreeDataProvider.js', () => ({
   },
 }))
 
-vi.mock('../services/Telemetry.js', () => ({
-  track: vi.fn(),
+// ── ensureCliAvailable mock ───────────────────────────────────────────────────
+const ensureCliAvailableMock = vi.fn()
+vi.mock('../utils/createSkill.helpers.js', () => ({
+  ensureCliAvailable: ensureCliAvailableMock,
+  runCli: vi.fn(),
+  exists: vi.fn(),
+  buildCreateArgs: vi.fn(),
+  targetDirFor: vi.fn(),
+  showPostCreateChecklist: vi.fn(),
 }))
 
-describe('createSkillCommand (SMI-4196)', () => {
+// ── CreateSkillPanel mock ─────────────────────────────────────────────────────
+const createOrShowMock = vi.fn()
+let currentPanelRef: undefined | { dispose: () => void } = undefined
+
+vi.mock('../views/CreateSkillPanel.js', () => ({
+  CreateSkillPanel: {
+    get currentPanel() {
+      return currentPanelRef
+    },
+    createOrShow: createOrShowMock,
+    resetForTests: vi.fn(() => {
+      currentPanelRef = undefined
+    }),
+  },
+}))
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe('createSkillCommand (SMI-5313 rewire)', () => {
   let handler: () => Promise<void>
 
   beforeEach(async () => {
-    showInputBox.mockReset()
-    showQuickPick.mockReset()
-    showInformationMessage.mockReset()
     showErrorMessage.mockReset()
-    showWarningMessage.mockReset()
-    openTextDocument.mockReset().mockRejectedValue(new Error('not found'))
-    showTextDocument.mockReset()
-    clipboardWrite.mockReset()
-    openExternal.mockReset()
+    createOutputChannel.mockReset().mockReturnValue({
+      appendLine: vi.fn(),
+      append: vi.fn(),
+      show: vi.fn(),
+      dispose: vi.fn(),
+    })
     registerCommand.mockReset()
     refreshAndWait.mockReset().mockResolvedValue(undefined)
-    executeCommand.mockReset()
-    spawnMock.mockReset()
+    trackMock.mockReset()
+    ensureCliAvailableMock.mockReset().mockResolvedValue(true)
+    createOrShowMock.mockReset()
+    currentPanelRef = undefined
 
     vi.resetModules()
     const { registerCreateSkillCommand } = await import('../commands/createSkillCommand.js')
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
     const provider = new SkillTreeDataProvider()
-    const context = { subscriptions: [] }
+    const context = {
+      subscriptions: [],
+      extensionUri: FAKE_EXTENSION_URI,
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerCreateSkillCommand(context as any, provider as any)
     const call = registerCommand.mock.calls[0]
@@ -112,207 +113,46 @@ describe('createSkillCommand (SMI-4196)', () => {
     handler = call[1] as () => Promise<void>
   })
 
-  it('surfaces install instructions when CLI is missing', async () => {
-    spawnMock.mockImplementationOnce(() => makeChild('notfound'))
-    showErrorMessage.mockResolvedValue('Copy install command')
+  it('opens the panel after ensureCliAvailable returns true', async () => {
+    ensureCliAvailableMock.mockResolvedValue(true)
 
     await handler()
 
-    expect(showErrorMessage).toHaveBeenCalledWith(
-      'Skillsmith CLI is not installed.',
-      expect.objectContaining({ modal: true }),
-      'Copy install command',
-      'Open docs'
-    )
-    expect(clipboardWrite).toHaveBeenCalledWith('npm install -g @skillsmith/cli')
-    expect(showInputBox).not.toHaveBeenCalled()
+    expect(ensureCliAvailableMock).toHaveBeenCalledTimes(1)
+    expect(createOrShowMock).toHaveBeenCalledTimes(1)
   })
 
-  it('cancels cleanly when wizard dismissed on first step', async () => {
-    spawnMock.mockImplementationOnce(() => makeChild('found'))
-    showInputBox.mockResolvedValueOnce(undefined)
+  it('tracks vscode_create_failed with cli_missing and does not open panel when CLI missing', async () => {
+    ensureCliAvailableMock.mockResolvedValue(false)
 
     await handler()
 
-    expect(showQuickPick).not.toHaveBeenCalled()
-    expect(spawnMock).toHaveBeenCalledTimes(1) // only --version check
+    expect(trackMock).toHaveBeenCalledWith('vscode_create_failed', { reason: 'cli_missing' })
+    expect(createOrShowMock).not.toHaveBeenCalled()
   })
 
-  it('rejects invalid skill name via validator', async () => {
-    spawnMock.mockImplementationOnce(() => makeChild('found'))
-    showInputBox
-      .mockResolvedValueOnce('author')
-      .mockImplementationOnce(
-        async (opts: { validateInput?: (v: string) => string | undefined }) => {
-          expect(opts.validateInput?.('BadName')).toContain('lowercase')
-          return undefined // user cancels after seeing validation
-        }
-      )
+  it('reveals the panel without calling ensureCliAvailable when panel is already open (H5)', async () => {
+    currentPanelRef = { dispose: vi.fn() }
 
     await handler()
 
-    expect(showQuickPick).not.toHaveBeenCalled()
+    expect(ensureCliAvailableMock).not.toHaveBeenCalled()
+    expect(createOrShowMock).toHaveBeenCalledTimes(1)
   })
 
-  it('spawns CLI with correct flag shape on happy path', async () => {
-    spawnMock
-      .mockImplementationOnce(() => makeChild('found')) // --version
-      .mockImplementationOnce(() => makeChild('found', 0)) // create
-
-    openTextDocument.mockResolvedValueOnce({ uri: {} }) // SKILL.md opens successfully
-    showInputBox
-      .mockResolvedValueOnce('my-author')
-      .mockResolvedValueOnce('my-skill')
-      .mockResolvedValueOnce('An example skill')
-    showQuickPick.mockResolvedValueOnce({ label: 'basic', description: '...' })
+  it('tracks vscode_create_start before CLI check on first open', async () => {
+    ensureCliAvailableMock.mockResolvedValue(true)
 
     await handler()
 
-    expect(spawnMock).toHaveBeenNthCalledWith(
-      2,
-      'skillsmith',
-      ['create', 'my-skill', '-a', 'my-author', '-d', 'An example skill', '--type', 'basic', '-y'],
-      expect.any(Object)
-    )
-    expect(refreshAndWait).toHaveBeenCalled()
-    // Flush the fire-and-forget showPostCreateChecklist promise
-    await flushAsync()
-    expect(showInformationMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Created skill "my-skill"'),
-      'Open folder',
-      'Authoring docs'
-    )
-    expect(showWarningMessage).not.toHaveBeenCalled()
+    expect(trackMock).toHaveBeenCalledWith('vscode_create_start')
   })
 
-  it('shows warning toast when SKILL.md cannot be opened after successful create', async () => {
-    spawnMock
-      .mockImplementationOnce(() => makeChild('found')) // --version
-      .mockImplementationOnce(() => makeChild('found', 0)) // create
-
-    // openTextDocument already mocked to reject in beforeEach
-    showInputBox
-      .mockResolvedValueOnce('my-author')
-      .mockResolvedValueOnce('my-skill')
-      .mockResolvedValueOnce('An example skill')
-    showQuickPick.mockResolvedValueOnce({ label: 'basic', description: '...' })
+  it('does not track vscode_create_start when panel is already open (H5)', async () => {
+    currentPanelRef = { dispose: vi.fn() }
 
     await handler()
 
-    expect(refreshAndWait).toHaveBeenCalled()
-    // Flush the fire-and-forget showPostCreateChecklist promise
-    await flushAsync()
-    expect(showInformationMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Created skill "my-skill"'),
-      'Open folder',
-      'Authoring docs'
-    )
-    expect(showWarningMessage).toHaveBeenCalledWith(
-      expect.stringContaining("couldn't open SKILL.md")
-    )
-  })
-
-  it('cancels cleanly when wizard dismissed at QuickPick (step 4)', async () => {
-    spawnMock.mockImplementationOnce(() => makeChild('found'))
-    showInputBox
-      .mockResolvedValueOnce('my-author')
-      .mockResolvedValueOnce('my-skill')
-      .mockResolvedValueOnce('An example skill')
-    showQuickPick.mockResolvedValueOnce(undefined) // user pressed Esc
-
-    await handler()
-
-    expect(spawnMock).toHaveBeenCalledTimes(1) // only --version check, no CLI spawn
-    expect(showErrorMessage).not.toHaveBeenCalled()
-    expect(refreshAndWait).not.toHaveBeenCalled()
-  })
-
-  it('reports CLI failure exit code to the user', async () => {
-    spawnMock
-      .mockImplementationOnce(() => makeChild('found'))
-      .mockImplementationOnce(() => makeChild('found', 2))
-
-    showInputBox
-      .mockResolvedValueOnce('author')
-      .mockResolvedValueOnce('name')
-      .mockResolvedValueOnce('desc')
-    showQuickPick.mockResolvedValueOnce({ label: 'basic', description: '...' })
-
-    await handler()
-
-    expect(showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('exit 2'))
-    expect(refreshAndWait).not.toHaveBeenCalled()
-  })
-
-  describe('post-create authoring checklist (GH #1453 / SMI-5312)', () => {
-    function setupHappyPath() {
-      spawnMock
-        .mockImplementationOnce(() => makeChild('found'))
-        .mockImplementationOnce(() => makeChild('found', 0))
-      openTextDocument.mockResolvedValueOnce({ uri: {} })
-      showInputBox
-        .mockResolvedValueOnce('my-author')
-        .mockResolvedValueOnce('my-skill')
-        .mockResolvedValueOnce('An example skill')
-      showQuickPick.mockResolvedValueOnce({ label: 'basic', description: '...' })
-    }
-
-    it('shows checklist toast with correct message and both button labels after successful create', async () => {
-      setupHappyPath()
-      showInformationMessage.mockResolvedValue(undefined) // user dismisses
-
-      await handler()
-      await flushAsync()
-
-      expect(showInformationMessage).toHaveBeenCalledWith(
-        expect.stringContaining('Created skill "my-skill"'),
-        'Open folder',
-        'Authoring docs'
-      )
-    })
-
-    it('opens the skill folder in OS when user picks "Open folder"', async () => {
-      const { track } = await import('../services/Telemetry.js')
-      setupHappyPath()
-      showInformationMessage.mockResolvedValue('Open folder')
-
-      await handler()
-      await flushAsync()
-
-      expect(executeCommand).toHaveBeenCalledWith(
-        'revealFileInOS',
-        expect.objectContaining({ toString: expect.any(Function) })
-      )
-      expect(track).toHaveBeenCalledWith('vscode_create_checklist_action', {
-        action: 'open_folder',
-      })
-      expect(openExternal).not.toHaveBeenCalled()
-    })
-
-    it('opens the authoring docs URL when user picks "Authoring docs"', async () => {
-      const { track } = await import('../services/Telemetry.js')
-      setupHappyPath()
-      showInformationMessage.mockResolvedValue('Authoring docs')
-
-      await handler()
-      await flushAsync()
-
-      expect(openExternal).toHaveBeenCalledWith(
-        expect.objectContaining({ toString: expect.any(Function) })
-      )
-      expect(track).toHaveBeenCalledWith('vscode_create_checklist_action', { action: 'docs' })
-      expect(executeCommand).not.toHaveBeenCalled()
-    })
-
-    it('takes no action when user dismisses the checklist toast', async () => {
-      setupHappyPath()
-      showInformationMessage.mockResolvedValue(undefined)
-
-      await handler()
-      await flushAsync()
-
-      expect(executeCommand).not.toHaveBeenCalled()
-      expect(openExternal).not.toHaveBeenCalled()
-    })
+    expect(trackMock).not.toHaveBeenCalledWith('vscode_create_start')
   })
 })

--- a/packages/vscode-extension/src/commands/createSkillCommand.ts
+++ b/packages/vscode-extension/src/commands/createSkillCommand.ts
@@ -1,110 +1,45 @@
+/**
+ * Register `skillsmith.createSkill` (SMI-5313 / GH #1454).
+ *
+ * Opens the single-page Create Skill webview wizard (CreateSkillPanel). The
+ * command verifies the CLI is available before opening the panel; once open,
+ * the panel drives all form state and CLI interaction. Re-invoking the command
+ * while the panel is already open simply reveals it (H5 — no redundant CLI check).
+ *
+ * Output is streamed to a dedicated OutputChannel so completion status is
+ * observable (exit code captured). OutputChannel preferred over Terminal because
+ * the `-y` non-interactive path has no interactive I/O.
+ */
 import * as vscode from 'vscode'
-import * as path from 'node:path'
-import * as os from 'node:os'
-import * as fs from 'node:fs/promises'
-import crossSpawn from 'cross-spawn'
 import { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
 import { track } from '../services/Telemetry.js'
 import { withTelemetry } from '../services/telemetry-wrap.js'
-import { validateSkillName } from '../utils/skillNameValidation.js'
+import { ensureCliAvailable } from '../utils/createSkill.helpers.js'
+import { CreateSkillPanel } from '../views/CreateSkillPanel.js'
 
-interface WizardState {
-  author: string
-  name: string
-  description: string
-  type: 'basic' | 'intermediate' | 'advanced'
-}
-
-const SKILL_TYPES: ReadonlyArray<{ label: WizardState['type']; description: string }> = [
-  { label: 'basic', description: 'Minimal skill scaffold (SKILL.md + README)' },
-  { label: 'intermediate', description: 'Adds CHANGELOG and examples' },
-  { label: 'advanced', description: 'Full layout with scripts/ and tests/' },
-]
-
-/**
- * Register `skillsmith.createSkill` (SMI-4196, closes GH #484).
- *
- * Multi-step QuickInput wizard that delegates scaffolding to the
- * `@skillsmith/cli`. No inline scaffolding: the CLI is the source of truth
- * for templates, and reimplementing them would drift and produce skills
- * that fail `validate`/`publish`. If the CLI is not on $PATH, surface an
- * actionable error with install command and docs link.
- *
- * Output is streamed to a dedicated OutputChannel so completion status is
- * observable (exit code captured) and success can open the new SKILL.md.
- * OutputChannel preferred over Terminal here because the `-y` non-interactive
- * path has no interactive I/O; Terminal would hide exit-status handling.
- */
 interface CreateSkillDeps {
   output: vscode.OutputChannel
   treeProvider: SkillTreeDataProvider
+  extensionUri: vscode.Uri
 }
 
 // SMI-5130: extracted from the inline registerCommand closure so withTelemetry
 // can wrap it at the export boundary (telemetry coverage gate).
 async function createSkillImpl(deps: CreateSkillDeps): Promise<void> {
-  const { output, treeProvider } = deps
+  const { output, treeProvider, extensionUri } = deps
+
+  if (CreateSkillPanel.currentPanel) {
+    // H5: re-invoking while open just reveals — no second ensureCliAvailable.
+    CreateSkillPanel.createOrShow(extensionUri, output, treeProvider)
+    return
+  }
+
   track('vscode_create_start')
   if (!(await ensureCliAvailable())) {
     track('vscode_create_failed', { reason: 'cli_missing' })
     return
   }
-
-  const state = await runWizard()
-  if (!state) {
-    track('vscode_create_cancelled', { stage: 'wizard' })
-    return
-  }
-
-  const targetDir = path.join(os.homedir(), '.claude', 'skills', state.name)
-  if (await exists(targetDir)) {
-    const overwrite = await vscode.window.showWarningMessage(
-      `A skill already exists at ${targetDir}.`,
-      { modal: true, detail: 'Re-running create will overwrite the existing SKILL.md.' },
-      'Overwrite'
-    )
-    if (overwrite !== 'Overwrite') {
-      track('vscode_create_cancelled', { stage: 'overwrite' })
-      return
-    }
-  }
-
-  const args = [
-    'create',
-    state.name,
-    '-a',
-    state.author,
-    '-d',
-    state.description,
-    '--type',
-    state.type,
-    '-y',
-  ]
-
-  output.show(true)
-  output.appendLine(`$ skillsmith ${args.join(' ')}`)
-
-  const exitCode = await runCli(args, output)
-  if (exitCode !== 0) {
-    track('vscode_create_failed', { reason: 'cli_nonzero_exit', exit_code: exitCode })
-    void vscode.window.showErrorMessage(
-      `Create skill failed (exit ${exitCode}). See the "Skillsmith CLI" output channel.`
-    )
-    return
-  }
-
-  track('vscode_create_complete', { type: state.type })
-  await treeProvider.refreshAndWait()
-  const skillMd = path.join(targetDir, 'SKILL.md')
-  try {
-    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(skillMd))
-    await vscode.window.showTextDocument(doc)
-  } catch {
-    void vscode.window.showWarningMessage(
-      `Skill "${state.name}" created, but couldn't open SKILL.md automatically. Open it from the Skills panel.`
-    )
-  }
-  void showPostCreateChecklist(targetDir, state.name)
+  CreateSkillPanel.createOrShow(extensionUri, output, treeProvider)
 }
 
 export const createSkillAction = withTelemetry(createSkillImpl, {
@@ -120,124 +55,9 @@ export function registerCreateSkillCommand(
   const output = vscode.window.createOutputChannel('Skillsmith CLI')
   context.subscriptions.push(output)
 
+  const extensionUri = context.extensionUri
   const disposable = vscode.commands.registerCommand('skillsmith.createSkill', () =>
-    createSkillAction({ output, treeProvider })
+    createSkillAction({ output, treeProvider, extensionUri })
   )
   context.subscriptions.push(disposable)
-}
-
-async function ensureCliAvailable(): Promise<boolean> {
-  const ok = await new Promise<boolean>((resolve) => {
-    const child = crossSpawn('skillsmith', ['--version'], { stdio: 'ignore' })
-    child.on('error', () => resolve(false))
-    child.on('exit', (code) => resolve(code === 0))
-  })
-  if (ok) return true
-
-  const INSTALL_CMD = 'npm install -g @skillsmith/cli'
-  const action = await vscode.window.showErrorMessage(
-    'Skillsmith CLI is not installed.',
-    { modal: true, detail: `Install with:\n${INSTALL_CMD}\n\nThen retry Create Skill.` },
-    'Copy install command',
-    'Open docs'
-  )
-  if (action === 'Copy install command') {
-    await vscode.env.clipboard.writeText(INSTALL_CMD)
-    void vscode.window.showInformationMessage('Install command copied to clipboard.')
-  } else if (action === 'Open docs') {
-    await vscode.env.openExternal(vscode.Uri.parse('https://skillsmith.app/docs'))
-  }
-  return false
-}
-
-async function runWizard(): Promise<WizardState | undefined> {
-  const author = await vscode.window.showInputBox({
-    title: 'Create Skill (1/4): Author',
-    prompt: 'Author GitHub username',
-    placeHolder: 'e.g. your-github-handle',
-    ignoreFocusOut: true,
-    validateInput: (v) => (v.trim() ? undefined : 'Author is required'),
-  })
-  if (author === undefined) return undefined
-
-  const name = await vscode.window.showInputBox({
-    title: 'Create Skill (2/4): Name',
-    prompt: 'Skill name — lowercase letters, digits, hyphens',
-    placeHolder: 'e.g. my-new-skill',
-    ignoreFocusOut: true,
-    validateInput: (v) => {
-      const result = validateSkillName(v)
-      return result === true ? undefined : result
-    },
-  })
-  if (name === undefined) return undefined
-
-  const description = await vscode.window.showInputBox({
-    title: 'Create Skill (3/4): Description',
-    prompt: 'Short description of what the skill does',
-    ignoreFocusOut: true,
-    validateInput: (v) => (v.trim() ? undefined : 'Description is required'),
-  })
-  if (description === undefined) return undefined
-
-  const pick = await vscode.window.showQuickPick(SKILL_TYPES, {
-    title: 'Create Skill (4/4): Type',
-    placeHolder: 'Select a skill type',
-    ignoreFocusOut: true,
-  })
-  if (!pick) return undefined
-
-  return {
-    author: author.trim(),
-    name: name.trim(),
-    description: description.trim(),
-    type: pick.label,
-  }
-}
-
-function runCli(args: string[], output: vscode.OutputChannel): Promise<number> {
-  return new Promise((resolve) => {
-    const child = crossSpawn('skillsmith', args, { stdio: ['ignore', 'pipe', 'pipe'] })
-    child.stdout?.on('data', (buf: Buffer) => output.append(buf.toString('utf8')))
-    child.stderr?.on('data', (buf: Buffer) => output.append(buf.toString('utf8')))
-    child.on('error', (err) => {
-      output.appendLine(`\n[error] ${err.message}`)
-      resolve(1)
-    })
-    child.on('exit', (code) => resolve(code ?? 1))
-  })
-}
-
-async function exists(p: string): Promise<boolean> {
-  try {
-    await fs.access(p)
-    return true
-  } catch {
-    return false
-  }
-}
-
-async function showPostCreateChecklist(targetDir: string, name: string): Promise<void> {
-  const OPEN_FOLDER = 'Open folder'
-  const DOCS = 'Authoring docs'
-  // Best-effort post-create affordance: the caller invokes this fire-and-forget
-  // (`void`), so the helper must never reject — `executeCommand`/`openExternal`
-  // can throw (host shutting down, unregistered scheme) and an unhandled
-  // rejection would surface to the user. Swallow; the actions are optional.
-  try {
-    const action = await vscode.window.showInformationMessage(
-      `Created skill "${name}". Next: fill in SKILL.md (frontmatter + instructions), add examples, then publish.`,
-      OPEN_FOLDER,
-      DOCS
-    )
-    if (action === OPEN_FOLDER) {
-      track('vscode_create_checklist_action', { action: 'open_folder' })
-      await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(targetDir))
-    } else if (action === DOCS) {
-      track('vscode_create_checklist_action', { action: 'docs' })
-      await vscode.env.openExternal(vscode.Uri.parse('https://skillsmith.app/docs'))
-    }
-  } catch {
-    // Optional next-step action failed; nothing actionable to surface.
-  }
 }

--- a/packages/vscode-extension/src/utils/createSkill.helpers.ts
+++ b/packages/vscode-extension/src/utils/createSkill.helpers.ts
@@ -1,0 +1,138 @@
+/**
+ * Shared helpers for the Create Skill flow (SMI-5313 / GH #1454).
+ *
+ * Extracted from createSkillCommand.ts so both the command (createSkillCommand.ts)
+ * and the webview panel (views/CreateSkillPanel.ts) can use them. Lives in utils/
+ * — NOT commands/ — so the import graph stays acyclic: commands → views → utils,
+ * commands → utils, views → utils (utils imports nothing from views/commands).
+ *
+ * The CLI is the source of truth for templates; this module never scaffolds inline.
+ */
+import * as vscode from 'vscode'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import * as fs from 'node:fs/promises'
+import crossSpawn from 'cross-spawn'
+import { track } from '../services/Telemetry.js'
+
+/** The four fields the Create Skill form collects. */
+export interface CreateFormFields {
+  author: string
+  name: string
+  description: string
+  type: 'basic' | 'intermediate' | 'advanced'
+}
+
+/** Absolute path where `skillsmith create <name>` writes the skill. */
+export function targetDirFor(name: string): string {
+  return path.join(os.homedir(), '.claude', 'skills', name)
+}
+
+/** Build the exact `skillsmith create …` CLI args (non-interactive). */
+export function buildCreateArgs(fields: CreateFormFields): string[] {
+  return [
+    'create',
+    fields.name,
+    '-a',
+    fields.author,
+    '-d',
+    fields.description,
+    '--type',
+    fields.type,
+    '-y',
+  ]
+}
+
+/**
+ * Verify the `skillsmith` CLI is on $PATH (`skillsmith --version` exits 0).
+ * On miss, surface an actionable modal (copy install cmd / open docs) and return false.
+ */
+export async function ensureCliAvailable(): Promise<boolean> {
+  const ok = await new Promise<boolean>((resolve) => {
+    const child = crossSpawn('skillsmith', ['--version'], { stdio: 'ignore' })
+    child.on('error', () => resolve(false))
+    child.on('exit', (code) => resolve(code === 0))
+  })
+  if (ok) return true
+
+  const INSTALL_CMD = 'npm install -g @skillsmith/cli'
+  const action = await vscode.window.showErrorMessage(
+    'Skillsmith CLI is not installed.',
+    { modal: true, detail: `Install with:\n${INSTALL_CMD}\n\nThen retry Create Skill.` },
+    'Copy install command',
+    'Open docs'
+  )
+  if (action === 'Copy install command') {
+    await vscode.env.clipboard.writeText(INSTALL_CMD)
+    void vscode.window.showInformationMessage('Install command copied to clipboard.')
+  } else if (action === 'Open docs') {
+    await vscode.env.openExternal(vscode.Uri.parse('https://skillsmith.app/docs'))
+  }
+  return false
+}
+
+/**
+ * Spawn `skillsmith <args>` (array args — no shell, injection-safe). Streams
+ * stdout/stderr to the OutputChannel and, when provided, to `onChunk` (e.g. the
+ * webview log). Resolves the exit code (1 on spawn error).
+ */
+export function runCli(
+  args: string[],
+  output: vscode.OutputChannel,
+  onChunk?: (chunk: string) => void
+): Promise<number> {
+  return new Promise((resolve) => {
+    const child = crossSpawn('skillsmith', args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    const emit = (buf: Buffer): void => {
+      const text = buf.toString('utf8')
+      output.append(text)
+      onChunk?.(text)
+    }
+    child.stdout?.on('data', emit)
+    child.stderr?.on('data', emit)
+    child.on('error', (err) => {
+      const msg = `\n[error] ${err.message}`
+      output.appendLine(msg)
+      onChunk?.(msg)
+      resolve(1)
+    })
+    child.on('exit', (code) => resolve(code ?? 1))
+  })
+}
+
+/** True if the path exists. */
+export async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Post-create authoring checklist (SMI-5312 / GH #1453). Best-effort: invoked
+ * fire-and-forget (`void`), so it must never reject — `executeCommand`/`openExternal`
+ * can throw (host shutting down, unregistered scheme) and an unhandled rejection
+ * would surface to the user. Swallow; the actions are optional.
+ */
+export async function showPostCreateChecklist(targetDir: string, name: string): Promise<void> {
+  const OPEN_FOLDER = 'Open folder'
+  const DOCS = 'Authoring docs'
+  try {
+    const action = await vscode.window.showInformationMessage(
+      `Created skill "${name}". Next: fill in SKILL.md (frontmatter + instructions), add examples, then publish.`,
+      OPEN_FOLDER,
+      DOCS
+    )
+    if (action === OPEN_FOLDER) {
+      track('vscode_create_checklist_action', { action: 'open_folder' })
+      await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(targetDir))
+    } else if (action === DOCS) {
+      track('vscode_create_checklist_action', { action: 'docs' })
+      await vscode.env.openExternal(vscode.Uri.parse('https://skillsmith.app/docs'))
+    }
+  } catch {
+    // Optional next-step action failed; nothing actionable to surface.
+  }
+}

--- a/packages/vscode-extension/src/utils/csp.ts
+++ b/packages/vscode-extension/src/utils/csp.ts
@@ -162,6 +162,18 @@ export function getSearchResultsCsp(nonce: string): string {
 }
 
 /**
+ * Gets CSP configuration for the Create Skill wizard webview (SMI-5313 / GH #1454).
+ * `allowInlineStyles: true` is required — the form's `<style>` block uses VS Code
+ * CSS variables (no nonce), same as the skill detail panel.
+ */
+export function getCreateSkillCsp(nonce: string): string {
+  return buildWebviewCsp(nonce, {
+    allowInlineStyles: true,
+    allowVscodeResources: true,
+  })
+}
+
+/**
  * Validates a CSP header for common security issues
  * @param csp - The CSP header to validate
  * @returns Validation result with any warnings

--- a/packages/vscode-extension/src/views/CreateSkillPanel.ts
+++ b/packages/vscode-extension/src/views/CreateSkillPanel.ts
@@ -1,0 +1,263 @@
+/**
+ * Webview panel for the single-page Create Skill wizard (SMI-5313 / GH #1454).
+ *
+ * Mirrors SkillDetailPanel's singleton lifecycle but renders a static form once
+ * and drives all subsequent state via the typed postMessage protocol
+ * (create-panel-types.ts). The caller (createSkillCommand) is responsible for
+ * `ensureCliAvailable()` BEFORE the first open; on reveal of an existing panel,
+ * form state is preserved (no reset).
+ *
+ * Concurrency / lifecycle guards (binding, from the plan-review findings):
+ *  - H1: onDidReceiveMessage is wired BEFORE webview.html is assigned.
+ *  - C1: `_creating` is set synchronously on receiving `submit`, before any
+ *    await; a second submit while creating is dropped.
+ *  - C2: `_succeeded` is set ONLY on the confirmed success path, immediately
+ *    before dispose(); onDidDispose fires `vscode_create_cancelled` only when
+ *    `!_succeeded`.
+ *  - L3: dispose() does NOT kill an in-flight crossSpawn child (a kill would
+ *    race the success path; matches the old runWizard behavior).
+ */
+import * as vscode from 'vscode'
+import * as path from 'node:path'
+import { generateCspNonce, getCreateSkillCsp } from '../utils/csp.js'
+import { track } from '../services/Telemetry.js'
+import { validateSkillName } from '../utils/skillNameValidation.js'
+import type { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
+import type {
+  CreatePanelInbound,
+  CreatePanelOutbound,
+  CreateFormFields,
+} from './create-panel-types.js'
+import {
+  buildCreateArgs,
+  runCli,
+  exists,
+  targetDirFor,
+  showPostCreateChecklist,
+} from '../utils/createSkill.helpers.js'
+import { getCreateSkillHtml } from './create-panel-html.js'
+
+const VALID_TYPES: ReadonlySet<string> = new Set(['basic', 'intermediate', 'advanced'])
+
+export class CreateSkillPanel {
+  public static currentPanel: CreateSkillPanel | undefined
+  public static readonly viewType = 'skillsmith.createSkillWizard'
+
+  private readonly _panel: vscode.WebviewPanel
+  private readonly _extensionUri: vscode.Uri
+  private readonly _output: vscode.OutputChannel
+  private readonly _treeProvider: SkillTreeDataProvider
+  private _disposables: vscode.Disposable[] = []
+
+  /** C1: in-process re-entrancy lock; a `submit` while true is dropped. */
+  private _creating = false
+  /** C2: set ONLY on the confirmed success path, immediately before dispose(). */
+  private _succeeded = false
+  /** Guards `_post` after dispose so we never message a torn-down webview. */
+  private _disposed = false
+
+  /**
+   * Open a new Create Skill panel, OR reveal the existing one (singleton).
+   * The caller MUST run `ensureCliAvailable()` before the first open. On reveal,
+   * existing form state is preserved (no reset).
+   */
+  public static createOrShow(
+    extensionUri: vscode.Uri,
+    output: vscode.OutputChannel,
+    treeProvider: SkillTreeDataProvider
+  ): void {
+    const column = vscode.window.activeTextEditor
+      ? vscode.window.activeTextEditor.viewColumn
+      : undefined
+
+    if (CreateSkillPanel.currentPanel) {
+      CreateSkillPanel.currentPanel._panel.reveal(column)
+      return
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      CreateSkillPanel.viewType,
+      'Create Skill',
+      column || vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'resources')],
+      }
+    )
+
+    CreateSkillPanel.currentPanel = new CreateSkillPanel(panel, extensionUri, output, treeProvider)
+  }
+
+  /** Clear the singleton between tests. */
+  public static resetForTests(): void {
+    CreateSkillPanel.currentPanel = undefined
+  }
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    extensionUri: vscode.Uri,
+    output: vscode.OutputChannel,
+    treeProvider: SkillTreeDataProvider
+  ) {
+    this._panel = panel
+    this._extensionUri = extensionUri
+    this._output = output
+    this._treeProvider = treeProvider
+
+    // Reference the extensionUri for the localResourceRoots contract / future
+    // resource loading (keeps it a tracked field without an unused-var lint).
+    void this._extensionUri
+
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables)
+
+    // H1: wire the message listener BEFORE assigning html, so an early debounced
+    // `validateName` from the webview is never dropped.
+    this._panel.webview.onDidReceiveMessage(
+      (message: CreatePanelInbound) => {
+        void this._handleMessage(message)
+      },
+      null,
+      this._disposables
+    )
+
+    const nonce = generateCspNonce()
+    this._panel.webview.html = getCreateSkillHtml(nonce, getCreateSkillCsp(nonce))
+  }
+
+  public dispose(): void {
+    // L1: re-entry guard — if `_panel.dispose()` ever fires `onDidDispose`
+    // synchronously, this prevents a double `vscode_create_cancelled`.
+    if (this._disposed) {
+      return
+    }
+    this._disposed = true
+    CreateSkillPanel.currentPanel = undefined
+
+    // C2: a close that wasn't a confirmed success is a cancellation.
+    if (!this._succeeded) {
+      track('vscode_create_cancelled', { stage: 'wizard' })
+    }
+
+    // L3: do NOT kill any in-flight crossSpawn child here — a kill would race
+    // the success path (matches the old runWizard behavior).
+    this._panel.dispose()
+    while (this._disposables.length) {
+      const x = this._disposables.pop()
+      if (x) {
+        x.dispose()
+      }
+    }
+  }
+
+  /** Post an outbound message; no-op once disposed. */
+  private _post(msg: CreatePanelOutbound): void {
+    if (this._disposed) {
+      return
+    }
+    void this._panel.webview.postMessage(msg)
+  }
+
+  private async _handleMessage(message: CreatePanelInbound): Promise<void> {
+    switch (message.command) {
+      case 'validateName': {
+        const res = validateSkillName(message.value)
+        this._post({
+          command: 'nameValidity',
+          valid: res === true,
+          ...(res === true ? {} : { message: res }),
+        })
+        return
+      }
+      case 'submit':
+        await this._handleSubmit(message.fields)
+        return
+      case 'cancel':
+        // onDidDispose fires the cancelled telemetry via the _succeeded guard.
+        this.dispose()
+        return
+    }
+  }
+
+  private async _handleSubmit(fields: CreateFormFields): Promise<void> {
+    // C1: synchronous re-entrancy lock — must be the first thing, before any await.
+    if (this._creating) {
+      return
+    }
+    this._creating = true
+
+    const errors = this._validateFields(fields)
+    if (Object.keys(errors).length > 0) {
+      this._post({ command: 'submitError', errors })
+      this._creating = false
+      return
+    }
+
+    const targetDir = targetDirFor(fields.name)
+
+    if (await exists(targetDir)) {
+      const choice = await vscode.window.showWarningMessage(
+        `A skill named "${fields.name}" already exists at ${targetDir}.`,
+        { modal: true, detail: 'Overwrite it?' },
+        'Overwrite'
+      )
+      if (choice !== 'Overwrite') {
+        track('vscode_create_cancelled', { stage: 'overwrite' })
+        this._post({ command: 'createFailed', message: 'Cancelled.' })
+        this._creating = false
+        return
+      }
+    }
+
+    this._post({ command: 'creating' })
+
+    const code = await runCli(buildCreateArgs(fields), this._output, (chunk) =>
+      this._post({ command: 'cliOutput', chunk })
+    )
+
+    if (code === 0) {
+      track('vscode_create_complete', { type: fields.type })
+      await this._treeProvider.refreshAndWait()
+      // C2: mark success only here, immediately before dispose().
+      this._succeeded = true
+      try {
+        const doc = await vscode.workspace.openTextDocument(
+          vscode.Uri.file(path.join(targetDir, 'SKILL.md'))
+        )
+        await vscode.window.showTextDocument(doc)
+      } catch {
+        // SKILL.md may be absent for an unexpected scaffold shape — not fatal.
+      }
+      this.dispose()
+      void showPostCreateChecklist(targetDir, fields.name)
+      return
+    }
+
+    track('vscode_create_failed', { reason: 'cli_nonzero_exit', exit_code: code })
+    this._post({
+      command: 'createFailed',
+      message: `Create failed (exit ${code}). See the log.`,
+    })
+    this._creating = false
+  }
+
+  /** Re-validate all fields host-side; returns a field→message map (empty = ok). */
+  private _validateFields(
+    fields: CreateFormFields
+  ): Partial<Record<keyof CreateFormFields, string>> {
+    const errors: Partial<Record<keyof CreateFormFields, string>> = {}
+    if (!fields.author?.trim()) {
+      errors.author = 'Author is required'
+    }
+    const nameRes = validateSkillName(fields.name ?? '')
+    if (nameRes !== true) {
+      errors.name = nameRes
+    }
+    if (!fields.description?.trim()) {
+      errors.description = 'Description is required'
+    }
+    if (!VALID_TYPES.has(fields.type)) {
+      errors.type = 'Select a skill type'
+    }
+    return errors
+  }
+}

--- a/packages/vscode-extension/src/views/create-panel-html.ts
+++ b/packages/vscode-extension/src/views/create-panel-html.ts
@@ -1,0 +1,112 @@
+/**
+ * HTML generation for the Create Skill webview panel (SMI-5313 / GH #1454).
+ *
+ * Single static document rendered once; all subsequent state is driven by the
+ * typed postMessage protocol (create-panel-types.ts). No user data is present at
+ * first render, so there is nothing dynamic to escape here — escapeHtml is used
+ * on every interpolated literal anyway (defense-in-depth, per the design).
+ */
+
+import { escapeHtml } from '../utils/security.js'
+import { getCreateStyles } from './create-panel-styles.js'
+import { getCreateScript } from './create-panel-script.js'
+
+/** A skill-type radio option with its human description (from the design doc). */
+interface TypeOption {
+  value: 'basic' | 'intermediate' | 'advanced'
+  label: string
+  description: string
+}
+
+const TYPE_OPTIONS: readonly TypeOption[] = [
+  { value: 'basic', label: 'Basic', description: 'Minimal skill scaffold (SKILL.md + README)' },
+  {
+    value: 'intermediate',
+    label: 'Intermediate',
+    description: 'Adds CHANGELOG and examples',
+  },
+  {
+    value: 'advanced',
+    label: 'Advanced',
+    description: 'Full layout with scripts/ and tests/',
+  },
+]
+
+/** Render the type radio cards (basic selected by default). */
+function getTypeCardsHtml(): string {
+  return TYPE_OPTIONS.map((opt, i) => {
+    const checked = i === 0 ? ' checked' : ''
+    return `
+            <label class="type-card">
+                <input type="radio" name="type" value="${escapeHtml(opt.value)}"${checked} />
+                <span class="type-meta">
+                    <span class="type-name">${escapeHtml(opt.label)}</span>
+                    <span class="type-desc">${escapeHtml(opt.description)}</span>
+                </span>
+            </label>`
+  }).join('')
+}
+
+/**
+ * Build the full Create Skill HTML document.
+ * @param nonce CSP nonce for the inline `<script>`.
+ * @param csp   CSP header value (from getCreateSkillCsp).
+ */
+export function getCreateSkillHtml(nonce: string, csp: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="${csp}" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Create Skill</title>
+    <style>${getCreateStyles()}</style>
+</head>
+<body>
+    <h1>Create a new skill</h1>
+    <p class="subtitle">Scaffold a skill via the Skillsmith CLI. Fields are validated before creation.</p>
+
+    <form id="createForm" aria-busy="false">
+        <div class="field">
+            <label for="author">Author</label>
+            <input type="text" id="author" name="author" autocomplete="off"
+                placeholder="your-handle" aria-describedby="authorError" />
+            <span class="error" id="authorError" aria-live="polite"></span>
+        </div>
+
+        <div class="field">
+            <label for="name">Name</label>
+            <input type="text" id="name" name="name" autocomplete="off"
+                placeholder="my-skill" aria-describedby="nameValidity nameError" />
+            <span class="name-validity" id="nameValidity" aria-live="polite"></span>
+            <span class="error" id="nameError" aria-live="polite"></span>
+        </div>
+
+        <div class="field">
+            <label for="description">Description</label>
+            <input type="text" id="description" name="description" autocomplete="off"
+                placeholder="What this skill does" aria-describedby="descriptionError" />
+            <span class="error" id="descriptionError" aria-live="polite"></span>
+        </div>
+
+        <div class="field">
+            <fieldset>
+                <legend>Type</legend>
+                <div class="type-cards">${getTypeCardsHtml()}
+                </div>
+                <span class="error" id="typeError" aria-live="polite"></span>
+            </fieldset>
+        </div>
+
+        <div class="actions">
+            <button type="button" class="btn-primary" id="createBtn">Create Skill</button>
+        </div>
+
+        <div class="failed-banner" id="failedBanner" aria-live="polite"></div>
+        <pre id="cliLog" aria-live="off"></pre>
+    </form>
+
+    <script nonce="${nonce}">${getCreateScript(nonce)}</script>
+</body>
+</html>`
+}

--- a/packages/vscode-extension/src/views/create-panel-script.ts
+++ b/packages/vscode-extension/src/views/create-panel-script.ts
@@ -1,0 +1,131 @@
+/**
+ * Client-side JavaScript for the Create Skill webview panel (SMI-5313 / GH #1454).
+ *
+ * `getCreateScript(nonce)` returns the JS *body* string (NOT a `<script>` tag);
+ * create-panel-html.ts wraps it in `<script nonce="${nonce}">…</script>`. The
+ * nonce is accepted for signature parity with the html-split convention but is
+ * not referenced inside the body (the wrapping tag carries it).
+ *
+ * Hard rules (from the design review):
+ *  - Every getElementById is null-guarded.
+ *  - cliOutput chunks are appended via `textContent +=` — NEVER innerHTML (H3/M5).
+ *  - All dynamic text uses textContent (no innerHTML anywhere).
+ */
+
+/** Generate the webview JS body for the Create Skill panel. */
+export function getCreateScript(nonce: string): string {
+  void nonce // carried by the wrapping <script nonce> tag in create-panel-html.ts
+  return `
+        const vscode = acquireVsCodeApi();
+
+        const form = document.getElementById('createForm');
+        const authorInput = document.getElementById('author');
+        const nameInput = document.getElementById('name');
+        const descriptionInput = document.getElementById('description');
+        const createBtn = document.getElementById('createBtn');
+        const nameValidity = document.getElementById('nameValidity');
+        const authorError = document.getElementById('authorError');
+        const nameError = document.getElementById('nameError');
+        const descriptionError = document.getElementById('descriptionError');
+        const typeError = document.getElementById('typeError');
+        const failedBanner = document.getElementById('failedBanner');
+        const cliLog = document.getElementById('cliLog');
+
+        function selectedType() {
+            const checked = document.querySelector('input[name="type"]:checked');
+            return checked ? checked.value : 'basic';
+        }
+
+        function setText(el, text) {
+            if (el) { el.textContent = text; }
+        }
+
+        function clearErrors() {
+            setText(authorError, '');
+            setText(nameError, '');
+            setText(descriptionError, '');
+            setText(typeError, '');
+        }
+
+        function setFormDisabled(disabled) {
+            [authorInput, nameInput, descriptionInput, createBtn].forEach(function (el) {
+                if (el) { el.disabled = disabled; }
+            });
+            document.querySelectorAll('input[name="type"]').forEach(function (el) {
+                el.disabled = disabled;
+            });
+        }
+
+        // Live name validation (debounced).
+        if (nameInput) {
+            let nameTimer;
+            nameInput.addEventListener('input', function () {
+                clearTimeout(nameTimer);
+                const value = nameInput.value;
+                nameTimer = setTimeout(function () {
+                    vscode.postMessage({ command: 'validateName', value: value });
+                }, 250);
+            });
+        }
+
+        if (createBtn) {
+            createBtn.addEventListener('click', function () {
+                vscode.postMessage({
+                    command: 'submit',
+                    fields: {
+                        author: authorInput ? authorInput.value : '',
+                        name: nameInput ? nameInput.value : '',
+                        description: descriptionInput ? descriptionInput.value : '',
+                        type: selectedType(),
+                    },
+                });
+            });
+        }
+
+        window.addEventListener('message', function (event) {
+            const msg = event.data;
+            if (!msg || typeof msg.command !== 'string') { return; }
+            switch (msg.command) {
+                case 'nameValidity':
+                    if (nameValidity) {
+                        if (msg.valid) {
+                            nameValidity.textContent = '✓ Available name';
+                            nameValidity.className = 'name-validity valid';
+                        } else {
+                            nameValidity.textContent = msg.message || '';
+                            nameValidity.className = 'name-validity invalid';
+                        }
+                    }
+                    return;
+                case 'submitError': {
+                    const errors = msg.errors || {};
+                    setText(authorError, errors.author || '');
+                    setText(nameError, errors.name || '');
+                    setText(descriptionError, errors.description || '');
+                    setText(typeError, errors.type || '');
+                    return;
+                }
+                case 'creating':
+                    clearErrors();
+                    setText(failedBanner, '');
+                    setFormDisabled(true);
+                    if (form) { form.setAttribute('aria-busy', 'true'); }
+                    if (createBtn) { createBtn.textContent = 'Creating…'; }
+                    return;
+                case 'cliOutput':
+                    // H3/M5: append RAW chunk as text only — NEVER innerHTML.
+                    if (cliLog && typeof msg.chunk === 'string') {
+                        cliLog.textContent += msg.chunk;
+                        cliLog.scrollTop = cliLog.scrollHeight;
+                    }
+                    return;
+                case 'createFailed':
+                    setFormDisabled(false);
+                    if (form) { form.setAttribute('aria-busy', 'false'); }
+                    if (createBtn) { createBtn.textContent = 'Create Skill'; }
+                    setText(failedBanner, msg.message || 'Create failed.');
+                    return;
+            }
+        });
+    `
+}

--- a/packages/vscode-extension/src/views/create-panel-styles.ts
+++ b/packages/vscode-extension/src/views/create-panel-styles.ts
@@ -1,0 +1,159 @@
+/**
+ * CSS styles for the Create Skill webview panel (SMI-5313 / GH #1454).
+ * Split out (mirrors skill-panel-styles.ts) to keep CreateSkillPanel.ts under
+ * the 500-line gate. Uses VS Code CSS variables only — no external resources.
+ */
+
+/** Generate the CSS for the Create Skill form. */
+export function getCreateStyles(): string {
+  return `
+        body {
+            font-family: var(--vscode-font-family);
+            color: var(--vscode-foreground);
+            background-color: var(--vscode-editor-background);
+            padding: 20px;
+            line-height: 1.5;
+        }
+        h1 {
+            font-size: 1.4em;
+            margin: 0 0 4px 0;
+        }
+        .subtitle {
+            color: var(--vscode-descriptionForeground);
+            margin: 0 0 20px 0;
+            font-size: 0.9em;
+        }
+        form {
+            max-width: 640px;
+        }
+        .field {
+            margin-bottom: 18px;
+        }
+        .field label {
+            display: block;
+            margin-bottom: 6px;
+            font-weight: 600;
+        }
+        .field input[type="text"] {
+            width: 100%;
+            box-sizing: border-box;
+            padding: 6px 8px;
+            background-color: var(--vscode-input-background);
+            color: var(--vscode-input-foreground);
+            border: 1px solid var(--vscode-input-border, transparent);
+            border-radius: 2px;
+            font-family: inherit;
+            font-size: inherit;
+        }
+        .field input[type="text"]:focus {
+            outline: 1px solid var(--vscode-focusBorder);
+            outline-offset: -1px;
+        }
+        .name-validity {
+            display: block;
+            margin-top: 4px;
+            font-size: 0.85em;
+            min-height: 1.1em;
+        }
+        .name-validity.valid {
+            color: var(--vscode-charts-green, var(--vscode-foreground));
+        }
+        .name-validity.invalid {
+            color: var(--vscode-errorForeground);
+        }
+        .error {
+            display: block;
+            margin-top: 4px;
+            min-height: 1.1em;
+            font-size: 0.85em;
+            color: var(--vscode-errorForeground);
+        }
+        fieldset {
+            border: none;
+            margin: 0;
+            padding: 0;
+        }
+        fieldset > legend {
+            font-weight: 600;
+            margin-bottom: 6px;
+            padding: 0;
+        }
+        .type-cards {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        .type-card {
+            display: flex;
+            align-items: flex-start;
+            gap: 8px;
+            padding: 10px 12px;
+            border: 1px solid var(--vscode-input-border, var(--vscode-panel-border, transparent));
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        .type-card:hover {
+            border-color: var(--vscode-focusBorder);
+        }
+        .type-card input[type="radio"] {
+            margin-top: 2px;
+        }
+        .type-card .type-meta {
+            display: flex;
+            flex-direction: column;
+        }
+        .type-card .type-name {
+            font-weight: 600;
+            text-transform: capitalize;
+        }
+        .type-card .type-desc {
+            color: var(--vscode-descriptionForeground);
+            font-size: 0.85em;
+        }
+        .actions {
+            margin-top: 20px;
+        }
+        .btn-primary {
+            padding: 6px 16px;
+            background-color: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
+            border: none;
+            border-radius: 2px;
+            cursor: pointer;
+            font-family: inherit;
+            font-size: inherit;
+        }
+        .btn-primary:hover {
+            background-color: var(--vscode-button-hoverBackground, var(--vscode-button-background));
+        }
+        .btn-primary:disabled {
+            opacity: 0.5;
+            cursor: default;
+        }
+        .failed-banner {
+            margin-top: 16px;
+            min-height: 1.1em;
+            color: var(--vscode-errorForeground);
+            white-space: pre-wrap;
+        }
+        #cliLog {
+            margin-top: 16px;
+            max-height: 240px;
+            overflow: auto;
+            padding: 8px;
+            background-color: var(--vscode-textCodeBlock-background, var(--vscode-editor-background));
+            border: 1px solid var(--vscode-panel-border, transparent);
+            border-radius: 2px;
+            font-family: var(--vscode-editor-font-family, monospace);
+            font-size: 0.85em;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+        #cliLog:empty {
+            display: none;
+        }
+        form[aria-busy="true"] {
+            opacity: 0.7;
+        }
+    `
+}

--- a/packages/vscode-extension/src/views/create-panel-types.ts
+++ b/packages/vscode-extension/src/views/create-panel-types.ts
@@ -1,0 +1,35 @@
+/**
+ * Message protocol for the Create Skill webview panel (SMI-5313 / GH #1454).
+ *
+ * Typed host <-> webview postMessage contract. The panel renders its static form
+ * once and drives all subsequent state via these messages (it does NOT re-render
+ * whole HTML like SkillDetailPanel). `CreateFormFields` lives in
+ * utils/createSkill.helpers.ts so the utils/ module stays free of view imports
+ * (keeps the import graph acyclic).
+ */
+import type { CreateFormFields } from '../utils/createSkill.helpers.js'
+
+export type { CreateFormFields }
+
+/** webview -> host */
+export type CreatePanelInbound =
+  | { command: 'validateName'; value: string }
+  | { command: 'submit'; fields: CreateFormFields }
+  | { command: 'cancel' }
+
+/** host -> webview */
+export type CreatePanelOutbound =
+  /** Result of host-side validateSkillName for the live name field. */
+  | { command: 'nameValidity'; valid: boolean; message?: string }
+  /** Per-field validation failures on submit (panel stays open). */
+  | { command: 'submitError'; errors: Partial<Record<keyof CreateFormFields, string>> }
+  /** CLI started — disable the form, set aria-busy, show "Creating…". */
+  | { command: 'creating' }
+  /**
+   * RAW CLI stdout/stderr chunk. The webview MUST append it via
+   * `element.textContent += chunk` — NEVER `innerHTML` (raw CLI output is
+   * untrusted HTML). The host never pre-escapes (that would double-escape).
+   */
+  | { command: 'cliOutput'; chunk: string }
+  /** CLI failed / overwrite declined — re-enable the form, show an error banner. */
+  | { command: 'createFailed'; message: string }


### PR DESCRIPTION
## Summary

Epic C / PR-C2 of the VS Code UX overhaul (parent SMI-5287). Replaces the 4-step QuickInput **Create Skill** flow with a single-page `CreateSkillPanel` webview form (author, name, description, type) with live name validation, **preserving CLI delegation** (`crossSpawn` array args — injection-safe).

Owner-approved design pass (`docs/internal/implementation/2026-06-19-vscode-1454-create-wizard-design.md`) with a 16-finding plan-review folded in before any code.

## What changed
- **NEW** `src/views/CreateSkillPanel.ts` (singleton webview, message handling), `create-panel-{html,script,styles,types}.ts`, `src/utils/createSkill.helpers.ts` (shared CLI helpers + the #1453 checklist, moved here to keep imports acyclic).
- **CHANGED** `src/commands/createSkillCommand.ts` (rewired to open/reveal the panel; `createSkillAction` `withTelemetry` anchor preserved), `src/utils/csp.ts` (+`getCreateSkillCsp`).
- Tests: `CreateSkillPanel.test.ts` + `CreateSkillPanel.guards.test.ts`, `create-panel-{html,script}.test.ts`, `createSkill.{helpers,checklist}.test.ts`, updated `createSkillCommand.test.ts`.

## Guards (plan-review + governance)
- **C1** synchronous `_creating` re-entrancy lock — no double-submit / double CLI run.
- **C2** `_succeeded` set only on success before dispose; `dispose()` re-entry guard — no spurious/duplicate `vscode_create_cancelled`.
- **H3** raw CLI-output chunks rendered via `textContent` (never `innerHTML`) — no XSS.
- **H2** no `validateSpawnArgs` on free-text fields (would reject valid `&`/`()`/`'`); array-arg spawn is the guarantee.
- **M4** helpers in `utils/` (acyclic). **H4** CSP `unsafe-inline` locked. **M6** `aria-live`/`aria-busy`. **H1** listener wired before `webview.html`.
- Governance (post-commit): M1 (surface `errors.type`), L1 (dispose re-entry guard), L3 (cancel-fires-once assertion) fixed in this PR; L2 excluded as pre-existing (`generateCspNonce` Math.random fallback, predates this PR).

## Verification (host, ADR-113)
- typecheck ✓ · lint (0 warnings) ✓ · build + package:check ✓
- 559/559 tests (43 files) · audit:standards 0 failed · every file <500 (max 413)

[skip-smoke]

GH #1454 · SMI-5313

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)