### PR TITLE
feat(vscode): MCP-powered commands — recommend, compare, update-check (SMI-5314/5315/5316)

### DIFF
--- a/.claude/development/mcp-tools-guide.md
+++ b/.claude/development/mcp-tools-guide.md
@@ -40,6 +40,10 @@ New tools use `skill_` prefix; legacy tools (`search`, `get_skill`) lack it.
 
 **Team-scoped tools** (`team_workspace`, `share_skill`, `private_registry_*`) additionally require `SKILLSMITH_LICENSE_KEY` to resolve the caller's team AND `SUPABASE_SERVICE_ROLE_KEY` on the MCP host for downstream CRUD (SMI-4312 / ADR-116 — the MCP subprocess has no user JWT, so anon-key RLS policies deny). Resolution path: `SKILLSMITH_LICENSE_KEY` env → SHA-256 → `license_keys.key_hash` → `subscriptions` → `teams.subscription_id`, via the `resolve_team_from_license` RPC (migration 071, SECURITY DEFINER, invoked via anon client). Missing/invalid keys return a typed error (not stub data) when Supabase is configured; missing service-role key surfaces `Team workspace operations require SUPABASE_SERVICE_ROLE_KEY`.
 
+## VS Code Extension Surface
+
+The `skill_recommend`, `skill_compare`, and `skill_diff` MCP tools are surfaced in the VS Code extension as commands: **Recommend Skills**, **Compare Skills**, and **Check Skill for Updates** (the latter requires Individual plan or higher).
+
 ## CLI
 
 `skillsmith` or `sklx` — `author subagent/transform/mcp-init`, `sync/status/config`. See [ADR-018](../../docs/internal/adr/018-registry-sync-system.md). New in SMI-4590: `sklx audit collisions` (namespace audit, opposite of legacy `sklx audit advisories` security-advisory checker), `sklx config get audit_mode` / `sklx config set audit_mode <preventative|power_user|governance|off>` (tier-revalidated; Free/Individual cannot select `power_user`/`governance`).

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 
 - **Post-create authoring checklist**: after creating a skill, a notification guides your next steps with **Open folder** and **Authoring docs** quick actions.
+- **Recommend Skills command** — contextual skill recommendations based on your installed skills, surfaced in a quick pick.
+- **Compare Skills command** — side-by-side comparison of two skills in a panel (quality, trust tier, key differences, and a recommendation).
+- **Check Skill for Updates command** — compares an installed skill against the latest registry version and advises whether to update (Individual plan or higher).
 
 ### Changed
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -15,6 +15,9 @@ Discover, search, and install agent skills directly in VS Code. Works with any M
 | Sidebar Skill Tree | Browse skills grouped into Installed and Available sections, with a trust-tier badge shown per skill |
 | Skill Search | Search the registry by keyword — trust-tier badges are shown on each result |
 | Detail Panel | Rich skill detail view with rendered SKILL.md content, score breakdown, and metadata |
+| Recommend Skills | Contextual skill recommendations based on your installed skills, surfaced in a quick pick |
+| Compare Skills | Side-by-side comparison of two skills in a panel with quality, trust tier, key differences, and a recommendation |
+| Check for Updates | Compares an installed skill against the latest registry version and advises whether to update (Individual plan or higher) |
 | MCP Integration | Live data from the Skillsmith API via Model Context Protocol |
 | Offline Fallback | Works offline with cached local skill data |
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -94,6 +94,24 @@
         "title": "Uninstall Skill",
         "category": "Skillsmith",
         "icon": "$(trash)"
+      },
+      {
+        "command": "skillsmith.recommendSkills",
+        "title": "Recommend Skills",
+        "category": "Skillsmith",
+        "icon": "$(lightbulb)"
+      },
+      {
+        "command": "skillsmith.compareSkills",
+        "title": "Compare Skills",
+        "category": "Skillsmith",
+        "icon": "$(diff)"
+      },
+      {
+        "command": "skillsmith.diffSkill",
+        "title": "Check Skill for Updates (Individual+)",
+        "category": "Skillsmith",
+        "icon": "$(versions)"
       }
     ],
     "keybindings": [

--- a/packages/vscode-extension/src/__tests__/compareSkills.test.ts
+++ b/packages/vscode-extension/src/__tests__/compareSkills.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for compareCommand.ts (SMI-5315 / #1456).
+ *
+ * Covers: happy path (two picks → skillCompare → panel), first-pick cancelled,
+ * TierDenied from skillCompare.
+ *
+ * createQuickPick is driven by capturing the onDidAccept / onDidHide handlers
+ * and calling them synchronously after a small tick.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── hoisted spies ─────────────────────────────────────────────────────────────
+const showInformationMessage = vi.hoisted(() => vi.fn())
+const showErrorMessage = vi.hoisted(() => vi.fn())
+const showWarningMessage = vi.hoisted(() => vi.fn())
+const createQuickPickFn = vi.hoisted(() => vi.fn())
+
+// ── vscode mock ───────────────────────────────────────────────────────────────
+vi.mock('vscode', () => ({
+  window: {
+    showInformationMessage,
+    showErrorMessage,
+    showWarningMessage,
+    createQuickPick: createQuickPickFn,
+    showQuickPick: vi.fn(),
+  },
+  commands: { registerCommand: vi.fn(), executeCommand: vi.fn() },
+  workspace: {
+    workspaceFolders: undefined,
+    getConfiguration: vi.fn(() => ({ get: vi.fn(() => undefined) })),
+  },
+  Uri: {
+    file: (s: string) => ({ toString: () => s, fsPath: s }),
+    parse: (s: string) => ({ toString: () => s }),
+  },
+  ViewColumn: { One: 1 },
+  Disposable: class {
+    dispose = vi.fn()
+  },
+  env: { openExternal: vi.fn(), isTelemetryEnabled: true },
+}))
+
+// ── Telemetry mock ────────────────────────────────────────────────────────────
+vi.mock('../services/Telemetry.js', () => ({ track: vi.fn() }))
+
+// ── trustTier mock ────────────────────────────────────────────────────────────
+vi.mock('../sidebar/trustTier.js', () => ({
+  getTrustTierCodicon: () => '$(verified)',
+  getTrustTierLabel: () => 'Verified',
+}))
+
+// ── MCP Client mock ───────────────────────────────────────────────────────────
+const mcpIsConnected = vi.hoisted(() => vi.fn(() => true))
+const mcpSkillCompare = vi.hoisted(() => vi.fn())
+
+vi.mock('../mcp/McpClient.js', () => ({
+  getMcpClient: () => ({
+    isConnected: mcpIsConnected,
+    skillCompare: mcpSkillCompare,
+  }),
+}))
+
+// ── tierDenied mock ───────────────────────────────────────────────────────────
+const handleTierDenied = vi.hoisted(() => vi.fn())
+vi.mock('../mcp/tierDenied.js', () => ({ handleTierDenied }))
+
+// ── CompareSkillsPanel mock ───────────────────────────────────────────────────
+const compareCreateOrShow = vi.hoisted(() => vi.fn())
+vi.mock('../views/CompareSkillsPanel.js', () => ({
+  CompareSkillsPanel: { createOrShow: compareCreateOrShow },
+}))
+
+// ── McpToolError: real class so instanceof works ──────────────────────────────
+import { McpToolError } from '../mcp/McpToolError.js'
+
+// ── SUT ───────────────────────────────────────────────────────────────────────
+import { compareCommandAction } from '../commands/compareCommand.js'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const SKILL_A = {
+  id: 'org/skill-a',
+  name: 'Skill A',
+  author: 'org',
+  description: 'first',
+  trustTier: 'verified',
+  version: '1.0.0',
+}
+const SKILL_B = {
+  id: 'org/skill-b',
+  name: 'Skill B',
+  author: 'org',
+  description: 'second',
+  trustTier: 'community',
+  version: '2.0.0',
+}
+
+const FAKE_COMPARE_RESPONSE = { skill_a: SKILL_A.id, skill_b: SKILL_B.id, comparison: 'diff text' }
+
+/**
+ * Build a minimal fake QuickPick that immediately resolves with the given skill
+ * on `.show()`, simulating the user accepting the first item in the list.
+ * Pass `skill: null` to simulate the user dismissing the picker (onDidHide).
+ */
+function makeQuickPickStub(skill: typeof SKILL_A | null) {
+  let acceptHandler: (() => void) | undefined
+  let hideHandler: (() => void) | undefined
+
+  const qp = {
+    title: '',
+    placeholder: '',
+    matchOnDescription: false,
+    matchOnDetail: false,
+    busy: false,
+    items: [] as { skill: typeof SKILL_A | null }[],
+    selectedItems: [] as { skill: typeof SKILL_A | null }[],
+    value: '',
+    onDidChangeValue: vi.fn((_cb: (v: string) => void) => ({ dispose: vi.fn() })),
+    onDidAccept: vi.fn((cb: () => void) => {
+      acceptHandler = cb
+      return { dispose: vi.fn() }
+    }),
+    onDidHide: vi.fn((cb: () => void) => {
+      hideHandler = cb
+      return { dispose: vi.fn() }
+    }),
+    show: vi.fn(() => {
+      if (skill) {
+        qp.selectedItems = [{ skill }]
+        acceptHandler?.()
+      } else {
+        hideHandler?.()
+      }
+    }),
+    hide: vi.fn(() => {
+      hideHandler?.()
+    }),
+    dispose: vi.fn(),
+  }
+  return qp
+}
+
+const FAKE_SKILL_SERVICE = {
+  search: vi.fn().mockResolvedValue({ results: [SKILL_A, SKILL_B], isOffline: false }),
+}
+
+const FAKE_CONTEXT = {
+  subscriptions: [],
+  extensionUri: { toString: () => '/ext', fsPath: '/ext' },
+}
+
+describe('compareCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mcpIsConnected.mockReturnValue(true)
+    mcpSkillCompare.mockResolvedValue(FAKE_COMPARE_RESPONSE)
+    FAKE_SKILL_SERVICE.search.mockResolvedValue({ results: [SKILL_A, SKILL_B], isOffline: false })
+  })
+
+  it('calls skillCompare and opens CompareSkillsPanel on two distinct picks', async () => {
+    // Return first stub for SKILL_A pick, second for SKILL_B pick.
+    createQuickPickFn
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_B))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await compareCommandAction({
+      skillService: FAKE_SKILL_SERVICE as any,
+      context: FAKE_CONTEXT as any,
+    })
+
+    expect(mcpSkillCompare).toHaveBeenCalledWith({ skill_a: SKILL_A.id, skill_b: SKILL_B.id })
+    expect(compareCreateOrShow).toHaveBeenCalledWith(
+      FAKE_CONTEXT.extensionUri,
+      FAKE_COMPARE_RESPONSE
+    )
+  })
+
+  it('returns early without calling skillCompare when first pick is cancelled', async () => {
+    // First pick dismisses (null = hide without accept).
+    createQuickPickFn.mockReturnValueOnce(makeQuickPickStub(null))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await compareCommandAction({
+      skillService: FAKE_SKILL_SERVICE as any,
+      context: FAKE_CONTEXT as any,
+    })
+
+    expect(mcpSkillCompare).not.toHaveBeenCalled()
+    expect(compareCreateOrShow).not.toHaveBeenCalled()
+  })
+
+  it('returns early without calling skillCompare when second pick is cancelled', async () => {
+    createQuickPickFn
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
+      .mockReturnValueOnce(makeQuickPickStub(null))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await compareCommandAction({
+      skillService: FAKE_SKILL_SERVICE as any,
+      context: FAKE_CONTEXT as any,
+    })
+
+    expect(mcpSkillCompare).not.toHaveBeenCalled()
+    expect(compareCreateOrShow).not.toHaveBeenCalled()
+  })
+
+  it('shows info message and skips skillCompare when MCP is not connected', async () => {
+    mcpIsConnected.mockReturnValue(false)
+    createQuickPickFn
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_B))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await compareCommandAction({
+      skillService: FAKE_SKILL_SERVICE as any,
+      context: FAKE_CONTEXT as any,
+    })
+
+    expect(mcpSkillCompare).not.toHaveBeenCalled()
+    expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining('not connected'))
+  })
+
+  it('calls handleTierDenied and does NOT open panel when skillCompare throws TierDenied', async () => {
+    const tierErr = new McpToolError('skill_compare', 'TierDenied', 'requires the Team plan')
+    mcpSkillCompare.mockRejectedValue(tierErr)
+
+    createQuickPickFn
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_B))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await compareCommandAction({
+      skillService: FAKE_SKILL_SERVICE as any,
+      context: FAKE_CONTEXT as any,
+    })
+
+    expect(handleTierDenied).toHaveBeenCalledWith('skillsmith.compareSkills', tierErr)
+    expect(compareCreateOrShow).not.toHaveBeenCalled()
+  })
+
+  it('shows generic error message on non-TierDenied McpToolError', async () => {
+    const err = new McpToolError('skill_compare', 'Unknown', 'something went wrong')
+    mcpSkillCompare.mockRejectedValue(err)
+
+    createQuickPickFn
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_B))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await compareCommandAction({
+      skillService: FAKE_SKILL_SERVICE as any,
+      context: FAKE_CONTEXT as any,
+    })
+
+    expect(showErrorMessage).toHaveBeenCalledWith('something went wrong')
+    expect(compareCreateOrShow).not.toHaveBeenCalled()
+  })
+})

--- a/packages/vscode-extension/src/__tests__/compareSkills.test.ts
+++ b/packages/vscode-extension/src/__tests__/compareSkills.test.ts
@@ -72,9 +72,17 @@ vi.mock('../views/CompareSkillsPanel.js', () => ({
 
 // ── McpToolError: real class so instanceof works ──────────────────────────────
 import { McpToolError } from '../mcp/McpToolError.js'
+import type * as vscode from 'vscode'
+import type { SkillService } from '../services/SkillService.js'
 
 // ── SUT ───────────────────────────────────────────────────────────────────────
 import { compareCommandAction } from '../commands/compareCommand.js'
+
+/** Cast the partial mocks to the action's param types without `any`. */
+const asDeps = (): { skillService: SkillService; context: vscode.ExtensionContext } => ({
+  skillService: FAKE_SKILL_SERVICE as unknown as SkillService,
+  context: FAKE_CONTEXT as unknown as vscode.ExtensionContext,
+})
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 const SKILL_A = {
@@ -162,16 +170,14 @@ describe('compareCommand', () => {
       .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
       .mockReturnValueOnce(makeQuickPickStub(SKILL_B))
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await compareCommandAction({
-      skillService: FAKE_SKILL_SERVICE as any,
-      context: FAKE_CONTEXT as any,
-    })
+    await compareCommandAction(asDeps())
 
     expect(mcpSkillCompare).toHaveBeenCalledWith({ skill_a: SKILL_A.id, skill_b: SKILL_B.id })
     expect(compareCreateOrShow).toHaveBeenCalledWith(
       FAKE_CONTEXT.extensionUri,
-      FAKE_COMPARE_RESPONSE
+      FAKE_COMPARE_RESPONSE,
+      SKILL_A.id,
+      SKILL_B.id
     )
   })
 
@@ -179,11 +185,7 @@ describe('compareCommand', () => {
     // First pick dismisses (null = hide without accept).
     createQuickPickFn.mockReturnValueOnce(makeQuickPickStub(null))
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await compareCommandAction({
-      skillService: FAKE_SKILL_SERVICE as any,
-      context: FAKE_CONTEXT as any,
-    })
+    await compareCommandAction(asDeps())
 
     expect(mcpSkillCompare).not.toHaveBeenCalled()
     expect(compareCreateOrShow).not.toHaveBeenCalled()
@@ -194,11 +196,7 @@ describe('compareCommand', () => {
       .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
       .mockReturnValueOnce(makeQuickPickStub(null))
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await compareCommandAction({
-      skillService: FAKE_SKILL_SERVICE as any,
-      context: FAKE_CONTEXT as any,
-    })
+    await compareCommandAction(asDeps())
 
     expect(mcpSkillCompare).not.toHaveBeenCalled()
     expect(compareCreateOrShow).not.toHaveBeenCalled()
@@ -210,11 +208,7 @@ describe('compareCommand', () => {
       .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
       .mockReturnValueOnce(makeQuickPickStub(SKILL_B))
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await compareCommandAction({
-      skillService: FAKE_SKILL_SERVICE as any,
-      context: FAKE_CONTEXT as any,
-    })
+    await compareCommandAction(asDeps())
 
     expect(mcpSkillCompare).not.toHaveBeenCalled()
     expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining('not connected'))
@@ -228,11 +222,7 @@ describe('compareCommand', () => {
       .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
       .mockReturnValueOnce(makeQuickPickStub(SKILL_B))
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await compareCommandAction({
-      skillService: FAKE_SKILL_SERVICE as any,
-      context: FAKE_CONTEXT as any,
-    })
+    await compareCommandAction(asDeps())
 
     expect(handleTierDenied).toHaveBeenCalledWith('skillsmith.compareSkills', tierErr)
     expect(compareCreateOrShow).not.toHaveBeenCalled()
@@ -246,11 +236,7 @@ describe('compareCommand', () => {
       .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
       .mockReturnValueOnce(makeQuickPickStub(SKILL_B))
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await compareCommandAction({
-      skillService: FAKE_SKILL_SERVICE as any,
-      context: FAKE_CONTEXT as any,
-    })
+    await compareCommandAction(asDeps())
 
     expect(showErrorMessage).toHaveBeenCalledWith('something went wrong')
     expect(compareCreateOrShow).not.toHaveBeenCalled()

--- a/packages/vscode-extension/src/__tests__/diffCommand.test.ts
+++ b/packages/vscode-extension/src/__tests__/diffCommand.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for diffCommand.ts (SMI-5316 / #1457).
+ *
+ * Covers: happy path, empty local SKILL.md abort, missing registry content abort,
+ * TierDenied before panel open, no installed skills guard.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── hoisted spies ─────────────────────────────────────────────────────────────
+const showInformationMessage = vi.hoisted(() => vi.fn())
+const showErrorMessage = vi.hoisted(() => vi.fn())
+const showQuickPick = vi.hoisted(() => vi.fn())
+
+// ── vscode mock ───────────────────────────────────────────────────────────────
+vi.mock('vscode', () => ({
+  window: {
+    showInformationMessage,
+    showErrorMessage,
+    showWarningMessage: vi.fn(),
+    showQuickPick,
+  },
+  commands: { registerCommand: vi.fn(), executeCommand: vi.fn() },
+  workspace: {
+    workspaceFolders: undefined,
+    getConfiguration: vi.fn(() => ({ get: vi.fn(() => undefined) })),
+  },
+  Uri: {
+    file: (s: string) => ({ toString: () => s, fsPath: s }),
+    parse: (s: string) => ({ toString: () => s }),
+  },
+  ViewColumn: { One: 1 },
+  Disposable: class {
+    dispose = vi.fn()
+  },
+  env: { openExternal: vi.fn(), isTelemetryEnabled: true },
+}))
+
+// ── Telemetry mock ────────────────────────────────────────────────────────────
+vi.mock('../services/Telemetry.js', () => ({ track: vi.fn() }))
+
+// ── trustTier mock ────────────────────────────────────────────────────────────
+vi.mock('../sidebar/trustTier.js', () => ({
+  getTrustTierCodicon: () => '$(verified)',
+}))
+
+// ── fs/promises mock ──────────────────────────────────────────────────────────
+const readFile = vi.hoisted(() => vi.fn())
+vi.mock('node:fs/promises', () => ({ readFile }))
+
+// ── MCP Client mock ───────────────────────────────────────────────────────────
+const mcpIsConnected = vi.hoisted(() => vi.fn(() => true))
+const mcpGetSkill = vi.hoisted(() => vi.fn())
+const mcpSkillDiff = vi.hoisted(() => vi.fn())
+
+vi.mock('../mcp/McpClient.js', () => ({
+  getMcpClient: () => ({
+    isConnected: mcpIsConnected,
+    getSkill: mcpGetSkill,
+    skillDiff: mcpSkillDiff,
+  }),
+}))
+
+// ── tierDenied mock ───────────────────────────────────────────────────────────
+const handleTierDenied = vi.hoisted(() => vi.fn())
+vi.mock('../mcp/tierDenied.js', () => ({ handleTierDenied }))
+
+// ── SkillDiffPanel mock ───────────────────────────────────────────────────────
+const diffCreateOrShow = vi.hoisted(() => vi.fn())
+vi.mock('../views/SkillDiffPanel.js', () => ({
+  SkillDiffPanel: { createOrShow: diffCreateOrShow },
+}))
+
+// ── McpToolError: real class so instanceof works ──────────────────────────────
+import { McpToolError } from '../mcp/McpToolError.js'
+
+// ── SUT ───────────────────────────────────────────────────────────────────────
+import { diffCommandAction } from '../commands/diffCommand.js'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const INSTALLED_SKILL = {
+  id: 'org/my-skill',
+  name: 'My Skill',
+  path: '/home/user/.claude/skills/my-skill',
+  trustTier: 'verified' as const,
+  hasSkillMd: true,
+}
+
+const LOCAL_CONTENT = '# My Skill\n\nThis is the installed version.'
+const REGISTRY_CONTENT = '# My Skill\n\nThis is the latest registry version with improvements.'
+const DIFF_RESPONSE = { changeType: 'minor', verdict: 'update_recommended', diff: '+ improvements' }
+
+/** Stub treeProvider with one installed skill by default. */
+function makeTreeProvider(skills: (typeof INSTALLED_SKILL)[] = [INSTALLED_SKILL]) {
+  return {
+    getInstalledSkills: vi.fn(() => skills),
+  }
+}
+
+const FAKE_CONTEXT = {
+  subscriptions: [],
+  extensionUri: { toString: () => '/ext', fsPath: '/ext' },
+}
+
+describe('diffCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mcpIsConnected.mockReturnValue(true)
+    readFile.mockResolvedValue(LOCAL_CONTENT)
+    mcpGetSkill.mockResolvedValue({ content: REGISTRY_CONTENT })
+    mcpSkillDiff.mockResolvedValue(DIFF_RESPONSE)
+    showQuickPick.mockResolvedValue({ item: INSTALLED_SKILL })
+  })
+
+  it('reads local SKILL.md, fetches registry content, calls skillDiff, and opens SkillDiffPanel', async () => {
+    const treeProvider = makeTreeProvider()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await diffCommandAction({ treeProvider: treeProvider as any, context: FAKE_CONTEXT as any })
+
+    expect(readFile).toHaveBeenCalledWith(expect.stringContaining('SKILL.md'), 'utf8')
+    expect(mcpGetSkill).toHaveBeenCalledWith(INSTALLED_SKILL.id)
+    expect(mcpSkillDiff).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skillId: INSTALLED_SKILL.id,
+        oldContent: LOCAL_CONTENT,
+        newContent: REGISTRY_CONTENT,
+      })
+    )
+    expect(diffCreateOrShow).toHaveBeenCalledWith(
+      FAKE_CONTEXT.extensionUri,
+      INSTALLED_SKILL.name,
+      DIFF_RESPONSE,
+      expect.objectContaining({ skillId: INSTALLED_SKILL.id })
+    )
+    expect(handleTierDenied).not.toHaveBeenCalled()
+  })
+
+  it('shows info message and aborts when local SKILL.md is empty', async () => {
+    readFile.mockResolvedValue('')
+
+    const treeProvider = makeTreeProvider()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await diffCommandAction({ treeProvider: treeProvider as any, context: FAKE_CONTEXT as any })
+
+    expect(mcpSkillDiff).not.toHaveBeenCalled()
+    expect(diffCreateOrShow).not.toHaveBeenCalled()
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining(INSTALLED_SKILL.name)
+    )
+  })
+
+  it('shows info message and aborts when registry content is missing (undefined)', async () => {
+    mcpGetSkill.mockResolvedValue({ content: undefined })
+
+    const treeProvider = makeTreeProvider()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await diffCommandAction({ treeProvider: treeProvider as any, context: FAKE_CONTEXT as any })
+
+    expect(mcpSkillDiff).not.toHaveBeenCalled()
+    expect(diffCreateOrShow).not.toHaveBeenCalled()
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("isn't in the registry")
+    )
+  })
+
+  it('shows info message and aborts when registry content is empty string', async () => {
+    mcpGetSkill.mockResolvedValue({ content: '' })
+
+    const treeProvider = makeTreeProvider()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await diffCommandAction({ treeProvider: treeProvider as any, context: FAKE_CONTEXT as any })
+
+    expect(mcpSkillDiff).not.toHaveBeenCalled()
+    expect(diffCreateOrShow).not.toHaveBeenCalled()
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("isn't in the registry")
+    )
+  })
+
+  it('calls handleTierDenied and does NOT open SkillDiffPanel when skillDiff throws TierDenied', async () => {
+    const tierErr = new McpToolError('skill_diff', 'TierDenied', 'requires the Individual plan')
+    mcpSkillDiff.mockRejectedValue(tierErr)
+
+    const treeProvider = makeTreeProvider()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await diffCommandAction({ treeProvider: treeProvider as any, context: FAKE_CONTEXT as any })
+
+    expect(handleTierDenied).toHaveBeenCalledWith('skillsmith.diffSkill', tierErr)
+    expect(diffCreateOrShow).not.toHaveBeenCalled()
+  })
+
+  it('shows info message when there are no installed skills', async () => {
+    const treeProvider = makeTreeProvider([])
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await diffCommandAction({ treeProvider: treeProvider as any, context: FAKE_CONTEXT as any })
+
+    expect(showQuickPick).not.toHaveBeenCalled()
+    expect(mcpSkillDiff).not.toHaveBeenCalled()
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('No installed skills')
+    )
+  })
+
+  it('returns early without calling skillDiff when QuickPick is dismissed', async () => {
+    showQuickPick.mockResolvedValue(undefined)
+
+    const treeProvider = makeTreeProvider()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await diffCommandAction({ treeProvider: treeProvider as any, context: FAKE_CONTEXT as any })
+
+    expect(mcpSkillDiff).not.toHaveBeenCalled()
+    expect(diffCreateOrShow).not.toHaveBeenCalled()
+  })
+
+  it('shows info message and aborts when readFile fails', async () => {
+    readFile.mockRejectedValue(new Error('ENOENT'))
+
+    const treeProvider = makeTreeProvider()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await diffCommandAction({ treeProvider: treeProvider as any, context: FAKE_CONTEXT as any })
+
+    expect(mcpSkillDiff).not.toHaveBeenCalled()
+    expect(diffCreateOrShow).not.toHaveBeenCalled()
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("Couldn't read SKILL.md")
+    )
+  })
+})

--- a/packages/vscode-extension/src/__tests__/mcp/skill_compare.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/skill_compare.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+import { McpClient } from '../../mcp/McpClient.js'
+import { McpToolError } from '../../mcp/McpToolError.js'
+
+/** Wrap a JSON payload in the MCP tools/call success envelope. */
+function ok(payload: unknown): Record<string, unknown> {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+}
+
+/** Build an isError tools/call envelope with the given text. */
+function isErr(text: string): Record<string, unknown> {
+  return { isError: true, content: [{ type: 'text', text }] }
+}
+
+/**
+ * Returns a connected McpClient whose private `sendRequest` resolves to `raw`.
+ * Tests only — reaches into private members via an `any` cast.
+ */
+function connectedClient(raw: unknown): McpClient {
+  const client = new McpClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).status = 'connected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).sendRequest = vi.fn().mockResolvedValue(raw)
+  return client
+}
+
+describe('McpClient.skillCompare (SMI-5315)', () => {
+  it('happy path returns the typed McpCompareResponse shape', async () => {
+    const response = {
+      comparison: {
+        a: {
+          id: 'smith-horn/docker',
+          name: 'docker',
+          description: 'Container-based development',
+          author: 'smith-horn',
+          quality_score: 92,
+          score_breakdown: null,
+          trust_tier: 'verified',
+          category: 'development',
+          tags: ['docker', 'containers'],
+          version: null,
+          dependencies: [],
+        },
+        b: {
+          id: 'community/docker-compose',
+          name: 'docker-compose',
+          description: 'Docker Compose orchestration',
+          author: 'community',
+          quality_score: 78,
+          score_breakdown: null,
+          trust_tier: 'community',
+          category: 'development',
+          tags: ['docker', 'compose'],
+          version: null,
+          dependencies: [],
+        },
+      },
+      differences: [
+        {
+          field: 'quality_score',
+          a_value: 92,
+          b_value: 78,
+          winner: 'a',
+        },
+        {
+          field: 'trust_tier',
+          a_value: 'verified',
+          b_value: 'community',
+          winner: 'a',
+        },
+      ],
+      recommendation: 'smith-horn/docker is the stronger choice based on quality and trust tier.',
+      winner: 'a',
+      timing: { totalMs: 88 },
+    }
+    const client = connectedClient(ok(response))
+
+    const result = await client.skillCompare({
+      skill_a: 'smith-horn/docker',
+      skill_b: 'community/docker-compose',
+    })
+
+    expect(result.comparison.a.id).toBe('smith-horn/docker')
+    expect(result.comparison.b.id).toBe('community/docker-compose')
+    expect(result.winner).toBe('a')
+    expect(result.differences[0]?.field).toBe('quality_score')
+  })
+
+  it('tier-denied isError response throws McpToolError code TierDenied', async () => {
+    const client = connectedClient(
+      isErr('TierDenied: skill_compare requires the Individual plan ($9.99/mo)')
+    )
+    await expect(
+      client.skillCompare({ skill_a: 'smith-horn/docker', skill_b: 'community/docker-compose' })
+    ).rejects.toMatchObject({
+      name: 'McpToolError',
+      code: 'TierDenied',
+      toolName: 'skill_compare',
+    })
+  })
+
+  it('unknown-tool isError response throws McpToolError code UnknownTool', async () => {
+    const client = connectedClient(isErr('Unknown tool: skill_compare'))
+    await expect(
+      client.skillCompare({ skill_a: 'smith-horn/docker', skill_b: 'community/docker-compose' })
+    ).rejects.toMatchObject({ code: 'UnknownTool' })
+  })
+
+  it('calling before connect throws NotConnected with the exact message', async () => {
+    const client = new McpClient()
+    await expect(
+      client.skillCompare({ skill_a: 'smith-horn/docker', skill_b: 'community/docker-compose' })
+    ).rejects.toMatchObject({
+      code: 'NotConnected',
+      message: 'MCP client not connected',
+    })
+    await expect(
+      client.skillCompare({ skill_a: 'smith-horn/docker', skill_b: 'community/docker-compose' })
+    ).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/__tests__/mcp/skill_diff.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/skill_diff.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+import { McpClient } from '../../mcp/McpClient.js'
+import { McpToolError } from '../../mcp/McpToolError.js'
+
+/** Wrap a JSON payload in the MCP tools/call success envelope. */
+function ok(payload: unknown): Record<string, unknown> {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+}
+
+/** Build an isError tools/call envelope with the given text. */
+function isErr(text: string): Record<string, unknown> {
+  return { isError: true, content: [{ type: 'text', text }] }
+}
+
+/**
+ * Returns a connected McpClient whose private `sendRequest` resolves to `raw`.
+ * Tests only — reaches into private members via an `any` cast.
+ */
+function connectedClient(raw: unknown): McpClient {
+  const client = new McpClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).status = 'connected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).sendRequest = vi.fn().mockResolvedValue(raw)
+  return client
+}
+
+const OLD_CONTENT = `# docker\nRun npm commands in Docker containers.\n\n## Usage\nUse for npm install.\n`
+const NEW_CONTENT = `# docker\nRun commands in Docker containers with native module support.\n\n## Usage\nUse for npm install, build steps.\n\n## Advanced\nSupports glibc-requiring modules.\n`
+
+describe('McpClient.skillDiff (SMI-5316)', () => {
+  it('happy path returns the typed McpSkillDiffResponse shape', async () => {
+    const response = {
+      skill: 'smith-horn/docker',
+      changeType: 'minor',
+      sectionsAdded: ['Advanced'],
+      sectionsRemoved: [],
+      sectionsModified: ['Usage'],
+      riskScoreDelta: -2,
+      changelog: '- Expanded usage examples\n- Added Advanced section for native modules',
+      recommendation: 'review-then-update',
+    }
+    const client = connectedClient(ok(response))
+
+    const result = await client.skillDiff({
+      skillId: 'smith-horn/docker',
+      oldContent: OLD_CONTENT,
+      newContent: NEW_CONTENT,
+      oldRiskScore: 10,
+      newRiskScore: 8,
+      hasLocalModifications: false,
+      trustTier: 'verified',
+    })
+
+    expect(result.changeType).toBe('minor')
+    expect(result.recommendation).toBe('review-then-update')
+    expect(result.sectionsAdded).toContain('Advanced')
+    expect(result.riskScoreDelta).toBe(-2)
+  })
+
+  it('tier-denied isError response throws McpToolError code TierDenied', async () => {
+    const client = connectedClient(
+      isErr(
+        'Version Tracking requires Individual tier ($9.99/mo). Upgrade at https://skillsmith.app/upgrade'
+      )
+    )
+    await expect(
+      client.skillDiff({
+        skillId: 'smith-horn/docker',
+        oldContent: OLD_CONTENT,
+        newContent: NEW_CONTENT,
+      })
+    ).rejects.toMatchObject({
+      name: 'McpToolError',
+      code: 'TierDenied',
+      toolName: 'skill_diff',
+    })
+  })
+
+  it('unknown-tool isError response throws McpToolError code UnknownTool', async () => {
+    const client = connectedClient(isErr('Unknown tool: skill_diff'))
+    await expect(
+      client.skillDiff({
+        skillId: 'smith-horn/docker',
+        oldContent: OLD_CONTENT,
+        newContent: NEW_CONTENT,
+      })
+    ).rejects.toMatchObject({ code: 'UnknownTool' })
+  })
+
+  it('calling before connect throws NotConnected with the exact message', async () => {
+    const client = new McpClient()
+    await expect(
+      client.skillDiff({
+        skillId: 'smith-horn/docker',
+        oldContent: OLD_CONTENT,
+        newContent: NEW_CONTENT,
+      })
+    ).rejects.toMatchObject({
+      code: 'NotConnected',
+      message: 'MCP client not connected',
+    })
+    await expect(
+      client.skillDiff({
+        skillId: 'smith-horn/docker',
+        oldContent: OLD_CONTENT,
+        newContent: NEW_CONTENT,
+      })
+    ).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/__tests__/mcp/skill_recommend.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/skill_recommend.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+import { McpClient } from '../../mcp/McpClient.js'
+import { McpToolError } from '../../mcp/McpToolError.js'
+
+/** Wrap a JSON payload in the MCP tools/call success envelope. */
+function ok(payload: unknown): Record<string, unknown> {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+}
+
+/** Build an isError tools/call envelope with the given text. */
+function isErr(text: string): Record<string, unknown> {
+  return { isError: true, content: [{ type: 'text', text }] }
+}
+
+/**
+ * Returns a connected McpClient whose private `sendRequest` resolves to `raw`.
+ * Tests only — reaches into private members via an `any` cast.
+ */
+function connectedClient(raw: unknown): McpClient {
+  const client = new McpClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).status = 'connected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).sendRequest = vi.fn().mockResolvedValue(raw)
+  return client
+}
+
+describe('McpClient.skillRecommend (SMI-5314)', () => {
+  it('happy path returns the typed McpRecommendResponse shape', async () => {
+    const response = {
+      recommendations: [
+        {
+          skill_id: 'smith-horn/docker',
+          name: 'docker',
+          reason: 'Matches your container-based development workflow',
+          similarity_score: 0.87,
+          trust_tier: 'verified',
+          quality_score: 92,
+          roles: ['developer'],
+          installable: true,
+        },
+      ],
+      candidates_considered: 50,
+      overlap_filtered: 3,
+      role_filtered: 0,
+      discovery_only_hidden: 2,
+      context: {
+        installed_count: 5,
+        has_project_context: true,
+        using_semantic_matching: true,
+        auto_detected: false,
+        role_filter: 'developer',
+      },
+      timing: { totalMs: 142 },
+    }
+    const client = connectedClient(ok(response))
+
+    const result = await client.skillRecommend({ limit: 10, project_context: 'my-app' })
+
+    expect(result.recommendations[0]?.skill_id).toBe('smith-horn/docker')
+    expect(result.recommendations[0]?.similarity_score).toBe(0.87)
+    expect(result.recommendations[0]?.quality_score).toBe(92)
+    expect(result.candidates_considered).toBe(50)
+    expect(result.context.has_project_context).toBe(true)
+  })
+
+  it('tier-denied isError response throws McpToolError code TierDenied', async () => {
+    const client = connectedClient(
+      isErr('TierDenied: skill_recommend requires the Team plan ($25/user/mo)')
+    )
+    await expect(client.skillRecommend({ limit: 10 })).rejects.toMatchObject({
+      name: 'McpToolError',
+      code: 'TierDenied',
+      toolName: 'skill_recommend',
+    })
+  })
+
+  it('unknown-tool isError response throws McpToolError code UnknownTool', async () => {
+    const client = connectedClient(isErr('Unknown tool: skill_recommend'))
+    await expect(client.skillRecommend({ limit: 10 })).rejects.toMatchObject({
+      code: 'UnknownTool',
+    })
+  })
+
+  it('calling before connect throws NotConnected with the exact message', async () => {
+    const client = new McpClient()
+    await expect(client.skillRecommend({ limit: 10 })).rejects.toMatchObject({
+      code: 'NotConnected',
+      message: 'MCP client not connected',
+    })
+    await expect(client.skillRecommend({ limit: 10 })).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/__tests__/recommendSkills.test.ts
+++ b/packages/vscode-extension/src/__tests__/recommendSkills.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for recommendCommand.ts (SMI-5314 / Epic D / PR-D1).
+ *
+ * Covers: happy path, empty recommendations, not-connected guard, TierDenied.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── hoisted spies (needed inside vi.mock factories) ───────────────────────────
+const showInformationMessage = vi.hoisted(() => vi.fn())
+const showErrorMessage = vi.hoisted(() => vi.fn())
+const showQuickPick = vi.hoisted(() => vi.fn())
+const executeCommand = vi.hoisted(() => vi.fn())
+
+// ── vscode mock ───────────────────────────────────────────────────────────────
+vi.mock('vscode', () => ({
+  window: {
+    showInformationMessage,
+    showErrorMessage,
+    showQuickPick,
+    showWarningMessage: vi.fn(),
+  },
+  commands: { registerCommand: vi.fn(), executeCommand },
+  workspace: {
+    workspaceFolders: undefined,
+    getConfiguration: vi.fn(() => ({ get: vi.fn(() => undefined) })),
+  },
+  Uri: {
+    file: (s: string) => ({ toString: () => s, fsPath: s }),
+    parse: (s: string) => ({ toString: () => s }),
+  },
+  ViewColumn: { One: 1 },
+  Disposable: class {
+    dispose = vi.fn()
+  },
+  env: { openExternal: vi.fn(), isTelemetryEnabled: true },
+}))
+
+// ── Telemetry mock ────────────────────────────────────────────────────────────
+vi.mock('../services/Telemetry.js', () => ({ track: vi.fn() }))
+
+// ── trustTier mock ────────────────────────────────────────────────────────────
+vi.mock('../sidebar/trustTier.js', () => ({
+  getTrustTierCodicon: () => '$(verified)',
+}))
+
+// ── MCP Client mock ───────────────────────────────────────────────────────────
+const mcpIsConnected = vi.hoisted(() => vi.fn(() => true))
+const mcpSkillRecommend = vi.hoisted(() => vi.fn())
+
+vi.mock('../mcp/McpClient.js', () => ({
+  getMcpClient: () => ({
+    isConnected: mcpIsConnected,
+    skillRecommend: mcpSkillRecommend,
+  }),
+}))
+
+// ── tierDenied mock ───────────────────────────────────────────────────────────
+const handleTierDenied = vi.hoisted(() => vi.fn())
+vi.mock('../mcp/tierDenied.js', () => ({ handleTierDenied }))
+
+// ── McpToolError: import real class so instanceof works ───────────────────────
+import { McpToolError } from '../mcp/McpToolError.js'
+
+// ── SUT ───────────────────────────────────────────────────────────────────────
+import { recommendCommandAction } from '../commands/recommendCommand.js'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const FAKE_RECOMMENDATION = {
+  skill_id: 'test-org/my-skill',
+  name: 'My Skill',
+  reason: 'Useful for TypeScript projects',
+  similarity_score: 0.92,
+  trust_tier: 'verified',
+  quality_score: 88,
+}
+
+describe('recommendCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mcpIsConnected.mockReturnValue(true)
+  })
+
+  it('shows QuickPick with items and navigates to skill details on pick', async () => {
+    mcpSkillRecommend.mockResolvedValue({ recommendations: [FAKE_RECOMMENDATION] })
+    showQuickPick.mockResolvedValue({ skillId: FAKE_RECOMMENDATION.skill_id })
+
+    await recommendCommandAction()
+
+    expect(mcpSkillRecommend).toHaveBeenCalledWith(expect.objectContaining({ limit: 10 }))
+    expect(showQuickPick).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ skillId: FAKE_RECOMMENDATION.skill_id })]),
+      expect.objectContaining({ title: 'Recommended Skills' })
+    )
+    expect(executeCommand).toHaveBeenCalledWith(
+      'skillsmith.viewSkillDetails',
+      FAKE_RECOMMENDATION.skill_id
+    )
+  })
+
+  it('shows info message and does NOT show QuickPick on empty recommendations', async () => {
+    mcpSkillRecommend.mockResolvedValue({ recommendations: [] })
+
+    await recommendCommandAction()
+
+    expect(showQuickPick).not.toHaveBeenCalled()
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('No skill recommendations'),
+      expect.any(String)
+    )
+  })
+
+  it('shows info message and does NOT call skillRecommend when not connected', async () => {
+    mcpIsConnected.mockReturnValue(false)
+
+    await recommendCommandAction()
+
+    expect(mcpSkillRecommend).not.toHaveBeenCalled()
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Connect to the Skillsmith MCP server')
+    )
+  })
+
+  it('calls handleTierDenied and does NOT show error message when skillRecommend throws TierDenied', async () => {
+    const tierErr = new McpToolError('skill_recommend', 'TierDenied', 'requires the Team plan')
+    mcpSkillRecommend.mockRejectedValue(tierErr)
+
+    await recommendCommandAction()
+
+    expect(handleTierDenied).toHaveBeenCalledWith('skillsmith.recommendSkills', tierErr)
+    expect(showErrorMessage).not.toHaveBeenCalled()
+  })
+
+  it('does NOT call executeCommand when QuickPick is dismissed without selection', async () => {
+    mcpSkillRecommend.mockResolvedValue({ recommendations: [FAKE_RECOMMENDATION] })
+    showQuickPick.mockResolvedValue(undefined)
+
+    await recommendCommandAction()
+
+    expect(executeCommand).not.toHaveBeenCalled()
+  })
+
+  it('shows error message on unexpected error', async () => {
+    mcpSkillRecommend.mockRejectedValue(new Error('network failure'))
+
+    await recommendCommandAction()
+
+    expect(showErrorMessage).toHaveBeenCalledWith('network failure')
+    expect(handleTierDenied).not.toHaveBeenCalled()
+  })
+})

--- a/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
@@ -28,6 +28,9 @@ import { searchSkillsAction, filterSkillsAction, clearFiltersAction } from '../s
 import { installCommandAction } from '../installCommand.js'
 import { uninstallCommandAction } from '../uninstallCommand.js'
 import { createSkillAction } from '../createSkillCommand.js'
+import { recommendCommandAction } from '../recommendCommand.js'
+import { compareCommandAction } from '../compareCommand.js'
+import { diffCommandAction } from '../diffCommand.js'
 import type { TelemetryEvent } from '../../services/Telemetry.js'
 
 /** Registered command id → wrapped panel action. */
@@ -38,6 +41,9 @@ const VSCODE_DISPATCHER_MAP: Record<string, (...args: never[]) => unknown> = {
   'skillsmith.installSkill': installCommandAction,
   'skillsmith.uninstallSkill': uninstallCommandAction,
   'skillsmith.createSkill': createSkillAction,
+  'skillsmith.recommendSkills': recommendCommandAction,
+  'skillsmith.compareSkills': compareCommandAction,
+  'skillsmith.diffSkill': diffCommandAction,
 }
 
 describe('SMI-5130: VS Code command telemetry coverage', () => {
@@ -65,7 +71,7 @@ describe('SMI-5130: VS Code command telemetry coverage', () => {
   it('reports VS Code dispatcher coverage to CI output', () => {
     const count = Object.keys(VSCODE_DISPATCHER_MAP).length
     console.info(`[SMI-5130] VS Code telemetry coverage: ${count} panel actions wrapped.`)
-    expect(count).toBe(6)
+    expect(count).toBe(9)
   })
 
   // SMI-5308 (M5): the detail-panel open actions are postMessage handlers, not

--- a/packages/vscode-extension/src/commands/compareCommand.ts
+++ b/packages/vscode-extension/src/commands/compareCommand.ts
@@ -1,0 +1,197 @@
+/**
+ * Compare Skills command (SMI-5315 / #1456).
+ *
+ * Two sequential debounced QuickPick searches pick exactly two skills, then
+ * `skill_compare` runs and the result opens in CompareSkillsPanel. Mirrors
+ * installCommand's debounced `createQuickPick` search pattern + the
+ * withTelemetry export/register shape.
+ *
+ * @module commands/compareCommand
+ */
+import * as vscode from 'vscode'
+import type { SkillData } from '../types/skill.js'
+import type { SkillService } from '../services/SkillService.js'
+import { getTrustTierCodicon, getTrustTierLabel } from '../sidebar/trustTier.js'
+import { getMcpClient } from '../mcp/McpClient.js'
+import { McpToolError } from '../mcp/McpToolError.js'
+import { handleTierDenied } from '../mcp/tierDenied.js'
+import { withTelemetry } from '../services/telemetry-wrap.js'
+import { track } from '../services/Telemetry.js'
+import { CompareSkillsPanel } from '../views/CompareSkillsPanel.js'
+
+/** Debounce delay for search input (matches installCommand). */
+const SEARCH_DEBOUNCE_MS = 300
+
+interface SkillQuickPickItem extends vscode.QuickPickItem {
+  skill: SkillData | null
+}
+
+function createQuickPickItem(skill: SkillData): SkillQuickPickItem {
+  const trustIcon = getTrustTierCodicon(skill.trustTier)
+  const tierLabel = getTrustTierLabel(skill.trustTier)
+  return {
+    label: `${trustIcon} ${skill.name}`,
+    description: tierLabel ? `by ${skill.author} | ${tierLabel}` : `by ${skill.author}`,
+    detail: skill.description,
+    skill,
+  }
+}
+
+/**
+ * Shows one debounced skill-search QuickPick and resolves with the picked
+ * skill, or `undefined` when the user dismisses it (silent cancel).
+ */
+function pickSkill(skillService: SkillService, title: string): Promise<SkillData | undefined> {
+  return new Promise<SkillData | undefined>((resolve) => {
+    const quickPick = vscode.window.createQuickPick<SkillQuickPickItem>()
+    quickPick.title = title
+    quickPick.placeholder = 'Search for a skill to compare'
+    quickPick.matchOnDescription = true
+    quickPick.matchOnDetail = true
+
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined
+    let accepted = false
+
+    quickPick.onDidChangeValue((value: string) => {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer)
+      }
+      const query = value.trim()
+      quickPick.busy = true
+      debounceTimer = setTimeout(async () => {
+        try {
+          const { results } = await skillService.search(query)
+          if (results.length === 0) {
+            quickPick.items = [
+              {
+                label: '$(info) No skills found',
+                description: query ? `No results for "${query}"` : 'Type to search',
+                alwaysShow: true,
+                skill: null,
+              },
+            ]
+          } else {
+            quickPick.items = results.map((skill) => createQuickPickItem(skill))
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error'
+          quickPick.items = [
+            {
+              label: '$(error) Search failed',
+              description: message,
+              alwaysShow: true,
+              skill: null,
+            },
+          ]
+        } finally {
+          quickPick.busy = false
+        }
+      }, SEARCH_DEBOUNCE_MS)
+    })
+
+    quickPick.onDidAccept(() => {
+      const selected = quickPick.selectedItems[0]
+      if (!selected || !selected.skill) {
+        return
+      }
+      accepted = true
+      const picked = selected.skill
+      quickPick.hide()
+      resolve(picked)
+    })
+
+    quickPick.onDidHide(() => {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer)
+      }
+      quickPick.dispose()
+      if (!accepted) {
+        resolve(undefined)
+      }
+    })
+
+    quickPick.show()
+  })
+}
+
+/**
+ * Picks the second skill, re-opening the picker if the user selects the same
+ * skill as the first (self-compare guard).
+ */
+async function pickSecondSkill(
+  skillService: SkillService,
+  first: SkillData
+): Promise<SkillData | undefined> {
+  const title = `Compare skills (2 of 2) — compare with "${first.name}"`
+  for (;;) {
+    const second = await pickSkill(skillService, title)
+    if (!second) {
+      return undefined
+    }
+    if (second.id === first.id) {
+      void vscode.window.showWarningMessage('Pick two different skills to compare.')
+      continue
+    }
+    return second
+  }
+}
+
+async function compareCommandImpl(deps: {
+  skillService: SkillService
+  context: vscode.ExtensionContext
+}): Promise<void> {
+  track('vscode_compare_start')
+
+  const first = await pickSkill(deps.skillService, 'Compare skills (1 of 2)')
+  if (!first) {
+    return
+  }
+
+  const second = await pickSecondSkill(deps.skillService, first)
+  if (!second) {
+    return
+  }
+
+  const client = getMcpClient()
+  if (!client.isConnected()) {
+    void vscode.window.showInformationMessage(
+      'Skillsmith server is not connected. Start the MCP server and try again.'
+    )
+    return
+  }
+
+  try {
+    const response = await client.skillCompare({ skill_a: first.id, skill_b: second.id })
+    CompareSkillsPanel.createOrShow(deps.context.extensionUri, response)
+    track('vscode_compare_complete')
+  } catch (err) {
+    if (err instanceof McpToolError) {
+      if (err.code === 'TierDenied') {
+        await handleTierDenied('skillsmith.compareSkills', err)
+        return
+      }
+      void vscode.window.showErrorMessage(err.message)
+      return
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    void vscode.window.showErrorMessage(`Could not compare skills: ${message}`)
+  }
+}
+
+export const compareCommandAction = withTelemetry(compareCommandImpl, {
+  source: 'vscode-extension',
+  extractSkillId: () => 'compare',
+})
+
+/**
+ * Registers the Compare Skills command (`skillsmith.compareSkills`).
+ */
+export function registerCompareCommand(
+  context: vscode.ExtensionContext,
+  skillService: SkillService
+): void {
+  const command = vscode.commands.registerCommand('skillsmith.compareSkills', () =>
+    compareCommandAction({ skillService, context })
+  )
+  context.subscriptions.push(command)
+}

--- a/packages/vscode-extension/src/commands/compareCommand.ts
+++ b/packages/vscode-extension/src/commands/compareCommand.ts
@@ -162,7 +162,7 @@ async function compareCommandImpl(deps: {
 
   try {
     const response = await client.skillCompare({ skill_a: first.id, skill_b: second.id })
-    CompareSkillsPanel.createOrShow(deps.context.extensionUri, response)
+    CompareSkillsPanel.createOrShow(deps.context.extensionUri, response, first.id, second.id)
     track('vscode_compare_complete')
   } catch (err) {
     if (err instanceof McpToolError) {

--- a/packages/vscode-extension/src/commands/diffCommand.ts
+++ b/packages/vscode-extension/src/commands/diffCommand.ts
@@ -1,0 +1,147 @@
+/**
+ * Check Skill for Updates command (SMI-5316 / #1457).
+ *
+ * Product framing (owner decision D-B): an UPDATE ADVISOR. Pick an installed
+ * skill, read its local SKILL.md, fetch the registry's latest version, and run
+ * `skill_diff` to advise whether to update. The result opens in SkillDiffPanel,
+ * which leads with the recommendation verdict. `skill_diff` is tier-gated to
+ * Individual+ — a denial routes to the upgrade UX BEFORE any panel opens.
+ *
+ * @module commands/diffCommand
+ */
+import * as vscode from 'vscode'
+import { readFile } from 'node:fs/promises'
+import * as path from 'node:path'
+import type { SkillItemData } from '../sidebar/SkillTreeItem.js'
+import type { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
+import { getTrustTierCodicon } from '../sidebar/trustTier.js'
+import { getMcpClient } from '../mcp/McpClient.js'
+import { McpToolError } from '../mcp/McpToolError.js'
+import { handleTierDenied } from '../mcp/tierDenied.js'
+import { withTelemetry } from '../services/telemetry-wrap.js'
+import { track } from '../services/Telemetry.js'
+import { SkillDiffPanel } from '../views/SkillDiffPanel.js'
+import type { SkillDiffArgs } from '../views/diff-panel-types.js'
+
+interface InstalledPickItem extends vscode.QuickPickItem {
+  item: SkillItemData
+}
+
+/** Map the extension's 5-tier trust model to skill_diff's narrower input. */
+function toDiffTrustTier(tier: SkillItemData['trustTier']): 'verified' | 'community' {
+  return tier === 'verified' ? 'verified' : 'community'
+}
+
+/** Show the installed-skill picker; resolve with the pick or undefined (cancel). */
+async function pickInstalledSkill(
+  treeProvider: SkillTreeDataProvider
+): Promise<SkillItemData | undefined> {
+  const installed = treeProvider.getInstalledSkills().filter((s) => s.path)
+  if (installed.length === 0) {
+    void vscode.window.showInformationMessage('No installed skills to check for updates.')
+    return undefined
+  }
+
+  const items: InstalledPickItem[] = installed.map((s) => ({
+    label: `${getTrustTierCodicon(s.trustTier)} ${s.name}`,
+    description: s.id,
+    item: s,
+  }))
+
+  const picked = await vscode.window.showQuickPick(items, {
+    title: 'Check Skill for Updates',
+    placeHolder: 'Select an installed skill to compare with the latest version',
+    matchOnDescription: true,
+  })
+  return picked?.item
+}
+
+async function diffCommandImpl(deps: {
+  treeProvider: SkillTreeDataProvider
+  context: vscode.ExtensionContext
+}): Promise<void> {
+  track('vscode_diff_start')
+
+  const skill = await pickInstalledSkill(deps.treeProvider)
+  if (!skill || !skill.path) {
+    return
+  }
+
+  // Read the locally-installed SKILL.md (oldContent).
+  let oldContent: string
+  try {
+    oldContent = await readFile(path.join(skill.path, 'SKILL.md'), 'utf8')
+  } catch {
+    void vscode.window.showInformationMessage(
+      `Couldn't read SKILL.md for "${skill.name}" — nothing to compare.`
+    )
+    return
+  }
+  if (!oldContent.trim()) {
+    void vscode.window.showInformationMessage(`"${skill.name}" has no SKILL.md content to compare.`)
+    return
+  }
+
+  const client = getMcpClient()
+  if (!client.isConnected()) {
+    void vscode.window.showInformationMessage(
+      'Skillsmith server is not connected. Start the MCP server and try again.'
+    )
+    return
+  }
+
+  try {
+    // Registry-latest content (newContent).
+    const detail = await client.getSkill(skill.id)
+    const newContent = detail.content
+    if (!newContent || !newContent.trim()) {
+      void vscode.window.showInformationMessage(
+        `"${skill.name}" isn't in the registry, so there's no newer version to compare against.`
+      )
+      return
+    }
+
+    const args: SkillDiffArgs = {
+      skillId: skill.id,
+      oldContent,
+      newContent,
+      trustTier: toDiffTrustTier(skill.trustTier),
+    }
+
+    const response = await client.skillDiff(args)
+    SkillDiffPanel.createOrShow(deps.context.extensionUri, skill.name, response, args)
+    track('vscode_diff_complete', { changeType: response.changeType })
+  } catch (err) {
+    if (err instanceof McpToolError) {
+      // Route a tier denial to the upgrade UX before any panel opens. The
+      // defensive message check covers a denial that arrives without the
+      // TierDenied code (e.g. a differently-shaped middleware message).
+      if (err.code === 'TierDenied' || /requires .*tier|upgrade/i.test(err.message)) {
+        await handleTierDenied('skillsmith.diffSkill', err)
+        return
+      }
+      void vscode.window.showErrorMessage(err.message)
+      return
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    void vscode.window.showErrorMessage(`Could not check for updates: ${message}`)
+  }
+}
+
+export const diffCommandAction = withTelemetry(diffCommandImpl, {
+  source: 'vscode-extension',
+  extractSkillId: () => 'diff',
+})
+
+/**
+ * Registers the Check Skill for Updates command (`skillsmith.diffSkill`).
+ */
+export function registerDiffCommand(
+  context: vscode.ExtensionContext,
+  treeProvider: SkillTreeDataProvider
+): void {
+  const command = vscode.commands.registerCommand('skillsmith.diffSkill', () =>
+    diffCommandAction({ treeProvider, context })
+  )
+  context.subscriptions.push(command)
+}

--- a/packages/vscode-extension/src/commands/diffCommand.ts
+++ b/packages/vscode-extension/src/commands/diffCommand.ts
@@ -115,8 +115,10 @@ async function diffCommandImpl(deps: {
     if (err instanceof McpToolError) {
       // Route a tier denial to the upgrade UX before any panel opens. The
       // defensive message check covers a denial that arrives without the
-      // TierDenied code (e.g. a differently-shaped middleware message).
-      if (err.code === 'TierDenied' || /requires .*tier|upgrade/i.test(err.message)) {
+      // TierDenied code (e.g. a differently-shaped middleware message). Kept
+      // narrow — grouped to "requires … (tier|plan)" so a bare "upgrade"
+      // substring in an unrelated error can't misroute (M1).
+      if (err.code === 'TierDenied' || /requires .*(tier|plan)/i.test(err.message)) {
         await handleTierDenied('skillsmith.diffSkill', err)
         return
       }

--- a/packages/vscode-extension/src/commands/recommendCommand.ts
+++ b/packages/vscode-extension/src/commands/recommendCommand.ts
@@ -1,0 +1,87 @@
+/**
+ * Recommend Command — surface contextual skill recommendations via MCP
+ * (SMI-5314 / Epic D / PR-D1).
+ *
+ * @module commands/recommendCommand
+ */
+import * as vscode from 'vscode'
+import { getMcpClient } from '../mcp/McpClient.js'
+import { McpToolError } from '../mcp/McpToolError.js'
+import { handleTierDenied } from '../mcp/tierDenied.js'
+import { getTrustTierCodicon } from '../sidebar/trustTier.js'
+import { withTelemetry } from '../services/telemetry-wrap.js'
+import { track } from '../services/Telemetry.js'
+
+/** QuickPick item that carries the resolved skill_id for downstream navigation. */
+interface RecommendQuickPickItem extends vscode.QuickPickItem {
+  skillId: string
+}
+
+async function recommendCommandImpl(): Promise<void> {
+  track('vscode_recommend_start')
+
+  const client = getMcpClient()
+
+  if (!client.isConnected()) {
+    vscode.window.showInformationMessage(
+      'Connect to the Skillsmith MCP server to get recommendations.'
+    )
+    return
+  }
+
+  try {
+    const workspaceName = vscode.workspace.workspaceFolders?.[0]?.name
+    const extraArgs = workspaceName ? { project_context: workspaceName } : {}
+
+    const response = await client.skillRecommend({ limit: 10, ...extraArgs })
+    const { recommendations } = response
+
+    if (recommendations.length === 0) {
+      track('vscode_recommend_empty')
+      const action = await vscode.window.showInformationMessage(
+        'No skill recommendations found for this workspace.',
+        'Search skills'
+      )
+      if (action === 'Search skills') {
+        await vscode.commands.executeCommand('skillsmith.searchSkills')
+      }
+      return
+    }
+
+    const items: RecommendQuickPickItem[] = recommendations.map((r) => ({
+      label: `${getTrustTierCodicon(r.trust_tier)} ${r.name}`,
+      description: r.reason,
+      detail: `similarity ${Math.round(r.similarity_score * 100)}% · quality ${r.quality_score}/100`,
+      skillId: r.skill_id,
+    }))
+
+    track('vscode_recommend_complete', { count: recommendations.length })
+
+    const picked = await vscode.window.showQuickPick(items, {
+      title: 'Recommended Skills',
+      matchOnDescription: true,
+      matchOnDetail: true,
+    })
+
+    if (picked) {
+      await vscode.commands.executeCommand('skillsmith.viewSkillDetails', picked.skillId)
+    }
+  } catch (err) {
+    if (err instanceof McpToolError && err.code === 'TierDenied') {
+      await handleTierDenied('skillsmith.recommendSkills', err)
+      return
+    }
+    vscode.window.showErrorMessage(err instanceof Error ? err.message : String(err))
+  }
+}
+
+export const recommendCommandAction = withTelemetry(recommendCommandImpl, {
+  source: 'vscode-extension',
+  extractSkillId: () => 'recommend',
+})
+
+export function registerRecommendCommand(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('skillsmith.recommendSkills', () => recommendCommandAction())
+  )
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -10,6 +10,9 @@ import { registerSearchCommand } from './commands/searchSkills.js'
 import { registerQuickInstallCommand } from './commands/installCommand.js'
 import { registerUninstallCommand } from './commands/uninstallCommand.js'
 import { registerCreateSkillCommand } from './commands/createSkillCommand.js'
+import { registerRecommendCommand } from './commands/recommendCommand.js'
+import { registerCompareCommand } from './commands/compareCommand.js'
+import { registerDiffCommand } from './commands/diffCommand.js'
 import { initializeTelemetry } from './services/Telemetry.js'
 import { SkillDetailPanel } from './views/SkillDetailPanel.js'
 import { SkillService } from './services/SkillService.js'
@@ -175,6 +178,9 @@ export function activate(context: vscode.ExtensionContext): void {
   registerQuickInstallCommand(context, skillService)
   registerUninstallCommand(context, skillTreeDataProvider)
   registerCreateSkillCommand(context, skillTreeDataProvider)
+  registerRecommendCommand(context)
+  registerCompareCommand(context, skillService)
+  registerDiffCommand(context, skillTreeDataProvider)
 
   // Register refresh command
   const refreshCommand = vscode.commands.registerCommand('skillsmith.refreshSkills', () => {

--- a/packages/vscode-extension/src/mcp/McpClient.ts
+++ b/packages/vscode-extension/src/mcp/McpClient.ts
@@ -13,9 +13,12 @@ import {
   type McpGetSkillResponse,
   type McpInstallResponse,
   type McpUninstallResponse,
+  type McpRecommendResponse,
+  type McpCompareResponse,
+  type McpSkillDiffResponse,
   DEFAULT_MCP_CONFIG,
 } from './types.js'
-import { McpToolError, type McpToolErrorCode } from './McpToolError.js'
+import { callMcpTool } from './callTool.js'
 
 // Re-export McpClientConfig from types for external use
 export type { McpClientConfig } from './types.js'
@@ -45,21 +48,6 @@ interface JsonRpcResponse {
     message: string
     data?: unknown
   }
-}
-
-/**
- * SMI-5288: Classify the text of an `isError` MCP tool response into an
- * `McpToolErrorCode`. Tier/plan denials and unknown-tool errors get specific
- * codes so command handlers can branch without string-matching messages.
- */
-function classifyIsErrorText(errorText: string): McpToolErrorCode {
-  if (/tier|plan|denied|forbidden|upgrade/i.test(errorText)) {
-    return 'TierDenied'
-  }
-  if (/unknown tool|not found|no such tool/i.test(errorText)) {
-    return 'UnknownTool'
-  }
-  return 'Unknown'
 }
 
 /**
@@ -334,55 +322,16 @@ export class McpClient {
   }
 
   /**
-   * Call an MCP tool with defensive response parsing
+   * Call an MCP tool. Delegates parsing + error classification to `callMcpTool`
+   * (SMI-5309). Reads `this.status` / `this.sendRequest` at call time so the
+   * test seam (set private `status='connected'`, stub private `sendRequest`) is
+   * preserved unchanged.
    */
   private async callTool<T>(name: string, args: Record<string, unknown>): Promise<T> {
-    if (this.status !== 'connected') {
-      throw new McpToolError(name, 'NotConnected', 'MCP client not connected')
-    }
-
-    const raw = await this.sendRequest('tools/call', {
-      name,
-      arguments: args,
+    return callMcpTool<T>(name, args, {
+      connected: this.status === 'connected',
+      send: (method, params) => this.sendRequest(method, params),
     })
-
-    const result = raw as Record<string, unknown> | null | undefined
-    if (!result || typeof result !== 'object') {
-      throw new McpToolError(
-        name,
-        'InvalidResponse',
-        `Invalid MCP response: expected object, got ${typeof raw}`
-      )
-    }
-
-    const content = result['content']
-    if (!Array.isArray(content) || content.length === 0) {
-      throw new McpToolError(
-        name,
-        'InvalidResponse',
-        'Invalid MCP response: missing or empty content array'
-      )
-    }
-
-    if (result['isError']) {
-      const errorText = (content[0] as { text?: string })?.text || 'Unknown error'
-      throw new McpToolError(name, classifyIsErrorText(errorText), errorText)
-    }
-
-    const text = (content[0] as { text?: string })?.text
-    if (!text) {
-      throw new McpToolError(name, 'InvalidResponse', 'Empty response from MCP server')
-    }
-
-    try {
-      return JSON.parse(text) as T
-    } catch (parseError) {
-      throw new McpToolError(
-        name,
-        'InvalidResponse',
-        `Failed to parse MCP response as JSON: ${parseError instanceof Error ? parseError.message : 'unknown error'}`
-      )
-    }
   }
 
   /**
@@ -430,6 +379,47 @@ export class McpClient {
    */
   async uninstallSkill(skillId: string): Promise<McpUninstallResponse> {
     return this.callTool<McpUninstallResponse>('uninstall_skill', { skillId })
+  }
+
+  /**
+   * Contextual skill recommendations (SMI-5314 / #1455). Ungated; the server
+   * auto-detects installed skills from `~/.claude/skills/` when
+   * `installed_skills` is omitted. Keys are snake_case per the tool schema.
+   */
+  async skillRecommend(args: {
+    installed_skills?: string[]
+    project_context?: string
+    limit?: number
+    role?: string
+    installable_only?: boolean
+  }): Promise<McpRecommendResponse> {
+    return this.callTool<McpRecommendResponse>('skill_recommend', args)
+  }
+
+  /**
+   * Side-by-side comparison of exactly two skills (SMI-5315 / #1456). Ungated.
+   * Each id is `author/name` or a UUID.
+   */
+  async skillCompare(args: { skill_a: string; skill_b: string }): Promise<McpCompareResponse> {
+    return this.callTool<McpCompareResponse>('skill_compare', args)
+  }
+
+  /**
+   * Structured semantic diff between two SKILL.md contents (SMI-5316 / #1457).
+   * Tier-gated to Individual+ (`version_tracking`); a denial surfaces as an
+   * `McpToolError` with code `TierDenied`. `oldContent`/`newContent` must be
+   * non-empty (server enforces `min(1)`).
+   */
+  async skillDiff(args: {
+    skillId: string
+    oldContent: string
+    newContent: string
+    oldRiskScore?: number
+    newRiskScore?: number
+    hasLocalModifications?: boolean
+    trustTier?: 'verified' | 'community' | 'experimental'
+  }): Promise<McpSkillDiffResponse> {
+    return this.callTool<McpSkillDiffResponse>('skill_diff', args)
   }
 
   /**

--- a/packages/vscode-extension/src/mcp/callTool.ts
+++ b/packages/vscode-extension/src/mcp/callTool.ts
@@ -1,0 +1,91 @@
+/**
+ * MCP tool-call parsing + error classification (SMI-5309).
+ *
+ * Extracted from McpClient.ts to keep that file under the 500-line hard gate
+ * before Epic D adds wrappers. `McpClient.callTool<T>` is now a thin delegate to
+ * `callMcpTool<T>` here, passing its connection status + a `send` closure so the
+ * exact test seam (set private `status='connected'`, stub private `sendRequest`)
+ * is preserved.
+ */
+import { McpToolError, type McpToolErrorCode } from './McpToolError.js'
+
+/**
+ * SMI-5288: Classify the text of an `isError` MCP tool response into an
+ * `McpToolErrorCode`. Tier/plan denials and unknown-tool errors get specific
+ * codes so command handlers can branch without string-matching messages.
+ *
+ * NOTE (SMI-5322): `not found` currently maps to `UnknownTool` — this is a
+ * tested contract (`__tests__/mcp/uninstall_skill.test.ts`). A precise
+ * `SkillNotFound` code is tracked separately; do not change this here.
+ */
+export function classifyIsErrorText(errorText: string): McpToolErrorCode {
+  if (/tier|plan|denied|forbidden|upgrade/i.test(errorText)) {
+    return 'TierDenied'
+  }
+  if (/unknown tool|not found|no such tool/i.test(errorText)) {
+    return 'UnknownTool'
+  }
+  return 'Unknown'
+}
+
+/**
+ * Call an MCP tool with defensive response parsing. Throws `McpToolError` on any
+ * non-success response (not connected, invalid envelope, isError, unparseable).
+ *
+ * @param name  MCP tool name (e.g. `skill_compare`)
+ * @param args  tool arguments object
+ * @param opts.connected  whether the client is currently connected
+ * @param opts.send  sends a JSON-RPC request and resolves with `result`
+ */
+export async function callMcpTool<T>(
+  name: string,
+  args: Record<string, unknown>,
+  opts: {
+    connected: boolean
+    send: (method: string, params?: Record<string, unknown>) => Promise<unknown>
+  }
+): Promise<T> {
+  if (!opts.connected) {
+    throw new McpToolError(name, 'NotConnected', 'MCP client not connected')
+  }
+
+  const raw = await opts.send('tools/call', { name, arguments: args })
+
+  const result = raw as Record<string, unknown> | null | undefined
+  if (!result || typeof result !== 'object') {
+    throw new McpToolError(
+      name,
+      'InvalidResponse',
+      `Invalid MCP response: expected object, got ${typeof raw}`
+    )
+  }
+
+  const content = result['content']
+  if (!Array.isArray(content) || content.length === 0) {
+    throw new McpToolError(
+      name,
+      'InvalidResponse',
+      'Invalid MCP response: missing or empty content array'
+    )
+  }
+
+  if (result['isError']) {
+    const errorText = (content[0] as { text?: string })?.text || 'Unknown error'
+    throw new McpToolError(name, classifyIsErrorText(errorText), errorText)
+  }
+
+  const text = (content[0] as { text?: string })?.text
+  if (!text) {
+    throw new McpToolError(name, 'InvalidResponse', 'Empty response from MCP server')
+  }
+
+  try {
+    return JSON.parse(text) as T
+  } catch (parseError) {
+    throw new McpToolError(
+      name,
+      'InvalidResponse',
+      `Failed to parse MCP response as JSON: ${parseError instanceof Error ? parseError.message : 'unknown error'}`
+    )
+  }
+}

--- a/packages/vscode-extension/src/mcp/types.ts
+++ b/packages/vscode-extension/src/mcp/types.ts
@@ -131,6 +131,97 @@ export interface McpUninstallResponse {
 }
 
 /**
+ * A single contextual recommendation from MCP skill_recommend (SMI-5314).
+ */
+export interface McpRecommendation {
+  skill_id: string
+  name: string
+  reason: string
+  /** Semantic similarity, 0–1. */
+  similarity_score: number
+  trust_tier: string
+  /** Quality score, 0–100. */
+  quality_score: number
+  roles?: string[]
+  installable?: boolean
+}
+
+/**
+ * Response from MCP skill_recommend tool (SMI-5314 / #1455).
+ */
+export interface McpRecommendResponse {
+  recommendations: McpRecommendation[]
+  candidates_considered: number
+  overlap_filtered: number
+  role_filtered: number
+  discovery_only_hidden?: number
+  context: {
+    installed_count: number
+    has_project_context: boolean
+    using_semantic_matching: boolean
+    auto_detected: boolean
+    role_filter?: string
+  }
+  timing: { totalMs: number }
+}
+
+/**
+ * Per-skill summary inside a compare result. Note: `score_breakdown` and
+ * `version` are currently always null, and `dependencies` always empty,
+ * server-side — render must omit rather than print "null" (SMI-5315).
+ */
+export interface McpCompareSummary {
+  id: string
+  name: string
+  description: string
+  author: string
+  /** Quality score, 0–100. */
+  quality_score: number
+  score_breakdown: McpScoreBreakdown | null
+  trust_tier: string
+  category: string
+  tags: string[]
+  version: string | null
+  dependencies: string[]
+}
+
+/**
+ * A single field-level difference between two compared skills.
+ */
+export interface McpSkillDifference {
+  field: string
+  a_value: unknown
+  b_value: unknown
+  winner?: 'a' | 'b' | 'tie'
+}
+
+/**
+ * Response from MCP skill_compare tool (SMI-5315 / #1456). Exactly two skills.
+ */
+export interface McpCompareResponse {
+  comparison: { a: McpCompareSummary; b: McpCompareSummary }
+  differences: McpSkillDifference[]
+  recommendation: string
+  winner: 'a' | 'b' | 'tie'
+  timing: { totalMs: number }
+}
+
+/**
+ * Response from MCP skill_diff tool (SMI-5316 / #1457). Structured semantic
+ * diff between two SKILL.md contents — this is the McpClient.patterns.md example.
+ */
+export interface McpSkillDiffResponse {
+  skill: string
+  changeType: 'major' | 'minor' | 'patch' | 'unknown'
+  sectionsAdded: string[]
+  sectionsRemoved: string[]
+  sectionsModified: string[]
+  riskScoreDelta: number | null
+  changelog: string | null
+  recommendation: 'auto-update' | 'review-then-update' | 'manual-review-required'
+}
+
+/**
  * MCP connection status
  */
 export type McpConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error'

--- a/packages/vscode-extension/src/services/Telemetry.ts
+++ b/packages/vscode-extension/src/services/Telemetry.ts
@@ -18,6 +18,14 @@ export type TelemetryEvent =
   // invoke discriminator, M5).
   | 'vscode_open_skill_file'
   | 'vscode_open_folder'
+  // SMI-5314/5315/5316 (Epic D / PR-D1): MCP-powered command surfaces.
+  | 'vscode_recommend_start'
+  | 'vscode_recommend_complete'
+  | 'vscode_recommend_empty'
+  | 'vscode_compare_start'
+  | 'vscode_compare_complete'
+  | 'vscode_diff_start'
+  | 'vscode_diff_complete'
 
 // No hardcoded endpoint — telemetry is disabled by default at runtime
 // unless `skillsmith.telemetryEndpoint` is set or the production endpoint

--- a/packages/vscode-extension/src/utils/csp.ts
+++ b/packages/vscode-extension/src/utils/csp.ts
@@ -174,6 +174,28 @@ export function getCreateSkillCsp(nonce: string): string {
 }
 
 /**
+ * Gets CSP configuration for the Compare Skills webview (SMI-5315 / GH #1456).
+ * `allowInlineStyles: true` matches the detail panel (VS Code CSS variables).
+ */
+export function getCompareCsp(nonce: string): string {
+  return buildWebviewCsp(nonce, {
+    allowInlineStyles: true,
+    allowVscodeResources: true,
+  })
+}
+
+/**
+ * Gets CSP configuration for the Skill Diff / update-advisor webview
+ * (SMI-5316 / GH #1457). `allowInlineStyles: true` matches the detail panel.
+ */
+export function getSkillDiffCsp(nonce: string): string {
+  return buildWebviewCsp(nonce, {
+    allowInlineStyles: true,
+    allowVscodeResources: true,
+  })
+}
+
+/**
  * Validates a CSP header for common security issues
  * @param csp - The CSP header to validate
  * @returns Validation result with any warnings

--- a/packages/vscode-extension/src/views/CompareSkillsPanel.ts
+++ b/packages/vscode-extension/src/views/CompareSkillsPanel.ts
@@ -1,0 +1,138 @@
+/**
+ * Webview panel for comparing exactly two skills side-by-side (SMI-5315 / #1456).
+ *
+ * Mirrors SkillDetailPanel: singleton (`currentPanel`), `createOrShow`,
+ * `dispose`, `resetForTests`, CSP nonce per render, host-built HTML, the message
+ * listener wired BEFORE assigning `webview.html`. Read-only — the only inbound
+ * message is `retry`, which re-runs the comparison via the MCP client.
+ */
+import * as vscode from 'vscode'
+import { generateCspNonce, getCompareCsp } from '../utils/csp.js'
+import { getLoadingHtml } from './skill-panel-html.js'
+import { getCompareHtml, getCompareErrorHtml } from './compare-panel-html.js'
+import { getMcpClient } from '../mcp/McpClient.js'
+import { McpToolError } from '../mcp/McpToolError.js'
+import { handleTierDenied } from '../mcp/tierDenied.js'
+import type { McpCompareResponse } from '../mcp/types.js'
+import type { ComparePanelMessage } from './compare-panel-types.js'
+
+export class CompareSkillsPanel {
+  public static currentPanel: CompareSkillsPanel | undefined
+  public static readonly viewType = 'skillsmith.compareSkills'
+
+  private readonly _panel: vscode.WebviewPanel
+  private _response: McpCompareResponse
+  private _disposables: vscode.Disposable[] = []
+
+  /** Reset the singleton between tests. */
+  public static resetForTests(): void {
+    CompareSkillsPanel.currentPanel?.dispose()
+    CompareSkillsPanel.currentPanel = undefined
+  }
+
+  public static createOrShow(_extensionUri: vscode.Uri, response: McpCompareResponse): void {
+    const column = vscode.window.activeTextEditor
+      ? vscode.window.activeTextEditor.viewColumn
+      : undefined
+
+    if (CompareSkillsPanel.currentPanel) {
+      CompareSkillsPanel.currentPanel._panel.reveal(column)
+      CompareSkillsPanel.currentPanel._response = response
+      CompareSkillsPanel.currentPanel._update()
+      return
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      CompareSkillsPanel.viewType,
+      'Compare Skills',
+      column || vscode.ViewColumn.One,
+      { enableScripts: true }
+    )
+
+    CompareSkillsPanel.currentPanel = new CompareSkillsPanel(panel, response)
+  }
+
+  private constructor(panel: vscode.WebviewPanel, response: McpCompareResponse) {
+    this._panel = panel
+    this._response = response
+
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables)
+
+    // Wire the message listener BEFORE assigning webview.html.
+    this._panel.webview.onDidReceiveMessage(
+      (message: ComparePanelMessage) => {
+        this._handleMessage(message)
+      },
+      null,
+      this._disposables
+    )
+
+    this._update()
+  }
+
+  public dispose(): void {
+    CompareSkillsPanel.currentPanel = undefined
+    this._panel.dispose()
+    while (this._disposables.length) {
+      const x = this._disposables.pop()
+      if (x) {
+        x.dispose()
+      }
+    }
+  }
+
+  private _handleMessage(message: ComparePanelMessage): void {
+    if (message.command === 'retry') {
+      void this._retry()
+    }
+  }
+
+  /**
+   * Re-run the comparison for the same two skills. Shows a loading state, then
+   * re-renders on success. TierDenied routes to the upgrade UX; other errors
+   * re-render the error page.
+   */
+  private async _retry(): Promise<void> {
+    const nonce = generateCspNonce()
+    this._panel.webview.html = getLoadingHtml(nonce, getCompareCsp(nonce))
+
+    const client = getMcpClient()
+    if (!client.isConnected()) {
+      const errNonce = generateCspNonce()
+      this._panel.webview.html = getCompareErrorHtml(
+        'Skillsmith server is not connected. Start the MCP server and try again.',
+        errNonce
+      )
+      return
+    }
+
+    try {
+      const response = await client.skillCompare({
+        skill_a: this._response.comparison.a.id,
+        skill_b: this._response.comparison.b.id,
+      })
+      this._response = response
+      this._update()
+    } catch (err) {
+      if (err instanceof McpToolError && err.code === 'TierDenied') {
+        await handleTierDenied('skillsmith.compareSkills', err)
+        return
+      }
+      const raw = err instanceof Error ? err.message : String(err)
+      const errNonce = generateCspNonce()
+      this._panel.webview.html = getCompareErrorHtml(
+        'Could not compare these skills. Please try again.',
+        errNonce,
+        raw
+      )
+    }
+  }
+
+  private _update(): void {
+    const a = this._response.comparison.a.name
+    const b = this._response.comparison.b.name
+    this._panel.title = `Compare: ${a} vs ${b}`
+    const nonce = generateCspNonce()
+    this._panel.webview.html = getCompareHtml(this._response, nonce)
+  }
+}

--- a/packages/vscode-extension/src/views/CompareSkillsPanel.ts
+++ b/packages/vscode-extension/src/views/CompareSkillsPanel.ts
@@ -22,6 +22,9 @@ export class CompareSkillsPanel {
 
   private readonly _panel: vscode.WebviewPanel
   private _response: McpCompareResponse
+  /** Original picked ids — retry re-runs against these, not the response echo (L3). */
+  private _skillAId: string
+  private _skillBId: string
   private _disposables: vscode.Disposable[] = []
 
   /** Reset the singleton between tests. */
@@ -30,7 +33,12 @@ export class CompareSkillsPanel {
     CompareSkillsPanel.currentPanel = undefined
   }
 
-  public static createOrShow(_extensionUri: vscode.Uri, response: McpCompareResponse): void {
+  public static createOrShow(
+    _extensionUri: vscode.Uri,
+    response: McpCompareResponse,
+    skillAId: string,
+    skillBId: string
+  ): void {
     const column = vscode.window.activeTextEditor
       ? vscode.window.activeTextEditor.viewColumn
       : undefined
@@ -38,6 +46,8 @@ export class CompareSkillsPanel {
     if (CompareSkillsPanel.currentPanel) {
       CompareSkillsPanel.currentPanel._panel.reveal(column)
       CompareSkillsPanel.currentPanel._response = response
+      CompareSkillsPanel.currentPanel._skillAId = skillAId
+      CompareSkillsPanel.currentPanel._skillBId = skillBId
       CompareSkillsPanel.currentPanel._update()
       return
     }
@@ -49,12 +59,19 @@ export class CompareSkillsPanel {
       { enableScripts: true }
     )
 
-    CompareSkillsPanel.currentPanel = new CompareSkillsPanel(panel, response)
+    CompareSkillsPanel.currentPanel = new CompareSkillsPanel(panel, response, skillAId, skillBId)
   }
 
-  private constructor(panel: vscode.WebviewPanel, response: McpCompareResponse) {
+  private constructor(
+    panel: vscode.WebviewPanel,
+    response: McpCompareResponse,
+    skillAId: string,
+    skillBId: string
+  ) {
     this._panel = panel
     this._response = response
+    this._skillAId = skillAId
+    this._skillBId = skillBId
 
     this._panel.onDidDispose(() => this.dispose(), null, this._disposables)
 
@@ -108,8 +125,8 @@ export class CompareSkillsPanel {
 
     try {
       const response = await client.skillCompare({
-        skill_a: this._response.comparison.a.id,
-        skill_b: this._response.comparison.b.id,
+        skill_a: this._skillAId,
+        skill_b: this._skillBId,
       })
       this._response = response
       this._update()

--- a/packages/vscode-extension/src/views/SkillDiffPanel.ts
+++ b/packages/vscode-extension/src/views/SkillDiffPanel.ts
@@ -1,0 +1,151 @@
+/**
+ * Webview panel for the Skill Diff / update-advisor (SMI-5316 / #1457).
+ *
+ * Mirrors SkillDetailPanel / CompareSkillsPanel: singleton (`currentPanel`),
+ * `createOrShow`, `dispose`, `resetForTests`, CSP nonce per render, host-built
+ * HTML, the message listener wired BEFORE assigning `webview.html`. The command
+ * routes a tier denial to the upgrade UX before this panel ever opens, so the
+ * panel opens only on a successful diff. Read-only — the only inbound message is
+ * `retry`, which re-runs `skill_diff` with the stored args (covers a transient
+ * disconnect between the initial check and a manual retry).
+ */
+import * as vscode from 'vscode'
+import { generateCspNonce, getSkillDiffCsp } from '../utils/csp.js'
+import { getLoadingHtml } from './skill-panel-html.js'
+import { getDiffHtml, getDiffErrorHtml } from './diff-panel-html.js'
+import { getMcpClient } from '../mcp/McpClient.js'
+import { McpToolError } from '../mcp/McpToolError.js'
+import { handleTierDenied } from '../mcp/tierDenied.js'
+import type { McpSkillDiffResponse } from '../mcp/types.js'
+import type { DiffPanelMessage, SkillDiffArgs } from './diff-panel-types.js'
+
+export class SkillDiffPanel {
+  public static currentPanel: SkillDiffPanel | undefined
+  public static readonly viewType = 'skillsmith.skillDiff'
+
+  private readonly _panel: vscode.WebviewPanel
+  private _skillName: string
+  private _response: McpSkillDiffResponse
+  private readonly _args: SkillDiffArgs
+  private _disposables: vscode.Disposable[] = []
+
+  /** Reset the singleton between tests. */
+  public static resetForTests(): void {
+    SkillDiffPanel.currentPanel?.dispose()
+    SkillDiffPanel.currentPanel = undefined
+  }
+
+  public static createOrShow(
+    _extensionUri: vscode.Uri,
+    skillName: string,
+    response: McpSkillDiffResponse,
+    args: SkillDiffArgs
+  ): void {
+    const column = vscode.window.activeTextEditor
+      ? vscode.window.activeTextEditor.viewColumn
+      : undefined
+
+    if (SkillDiffPanel.currentPanel) {
+      SkillDiffPanel.currentPanel._panel.reveal(column)
+      SkillDiffPanel.currentPanel._skillName = skillName
+      SkillDiffPanel.currentPanel._response = response
+      SkillDiffPanel.currentPanel._update()
+      return
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      SkillDiffPanel.viewType,
+      'Check for Updates',
+      column || vscode.ViewColumn.One,
+      { enableScripts: true }
+    )
+
+    SkillDiffPanel.currentPanel = new SkillDiffPanel(panel, skillName, response, args)
+  }
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    skillName: string,
+    response: McpSkillDiffResponse,
+    args: SkillDiffArgs
+  ) {
+    this._panel = panel
+    this._skillName = skillName
+    this._response = response
+    this._args = args
+
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables)
+
+    // Wire the message listener BEFORE assigning webview.html.
+    this._panel.webview.onDidReceiveMessage(
+      (message: DiffPanelMessage) => {
+        this._handleMessage(message)
+      },
+      null,
+      this._disposables
+    )
+
+    this._update()
+  }
+
+  public dispose(): void {
+    SkillDiffPanel.currentPanel = undefined
+    this._panel.dispose()
+    while (this._disposables.length) {
+      const x = this._disposables.pop()
+      if (x) {
+        x.dispose()
+      }
+    }
+  }
+
+  private _handleMessage(message: DiffPanelMessage): void {
+    if (message.command === 'retry') {
+      void this._retry()
+    }
+  }
+
+  /**
+   * Re-run the update check with the stored args. Shows a loading state, then
+   * re-renders on success. TierDenied routes to the upgrade UX; other errors
+   * re-render the error page.
+   */
+  private async _retry(): Promise<void> {
+    const nonce = generateCspNonce()
+    this._panel.webview.html = getLoadingHtml(nonce, getSkillDiffCsp(nonce))
+
+    const client = getMcpClient()
+    if (!client.isConnected()) {
+      const errNonce = generateCspNonce()
+      this._panel.webview.html = getDiffErrorHtml(
+        'Skillsmith server is not connected. Start the MCP server and try again.',
+        errNonce
+      )
+      return
+    }
+
+    try {
+      const response = await client.skillDiff(this._args)
+      this._response = response
+      this._update()
+    } catch (err) {
+      if (err instanceof McpToolError && err.code === 'TierDenied') {
+        await handleTierDenied('skillsmith.diffSkill', err)
+        return
+      }
+      const raw = err instanceof Error ? err.message : String(err)
+      const errNonce = generateCspNonce()
+      this._panel.webview.html = getDiffErrorHtml(
+        'Could not check this skill for updates. Please try again.',
+        errNonce,
+        raw
+      )
+    }
+  }
+
+  private _update(): void {
+    this._panel.title = `Updates: ${this._skillName}`
+    const nonce = generateCspNonce()
+    this._panel.webview.html = getDiffHtml(this._skillName, this._response, nonce)
+  }
+}

--- a/packages/vscode-extension/src/views/compare-panel-html.ts
+++ b/packages/vscode-extension/src/views/compare-panel-html.ts
@@ -8,7 +8,7 @@
  */
 
 import { escapeHtml } from '../utils/security.js'
-import { getSkillDiffCsp, getCompareCsp } from '../utils/csp.js'
+import { getCompareCsp } from '../utils/csp.js'
 import { getTrustBadgeColor, getTrustBadgeText } from './trust-badge.js'
 import type { McpCompareResponse, McpCompareSummary, McpSkillDifference } from '../mcp/types.js'
 
@@ -58,11 +58,23 @@ function getTagsRowHtml(a: McpCompareSummary, b: McpCompareSummary): string {
     </tr>`
 }
 
+/**
+ * Format an untrusted, `unknown`-typed difference value for display. Avoids the
+ * literal "null"/"undefined"/"[object Object]" that bare `String()` would emit
+ * (L1) — null/undefined render as an em dash, objects as compact JSON. The
+ * result is still escaped by the caller.
+ */
+function formatDiffValue(value: unknown): string {
+  if (value === null || value === undefined) return '—'
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
 /** Render one differences row, highlighting the winner cell. */
 function getDifferenceRowHtml(diff: McpSkillDifference): string {
   const safeField = escapeHtml(String(diff.field))
-  const safeA = escapeHtml(String(diff.a_value))
-  const safeB = escapeHtml(String(diff.b_value))
+  const safeA = escapeHtml(formatDiffValue(diff.a_value))
+  const safeB = escapeHtml(formatDiffValue(diff.b_value))
   const aWin = diff.winner === 'a' ? ' diff-winner' : ''
   const bWin = diff.winner === 'b' ? ' diff-winner' : ''
   return `
@@ -168,14 +180,10 @@ export function getCompareHtml(response: McpCompareResponse, nonce: string): str
 }
 
 /**
- * Build a local error page for the Compare panel (CSP from getSkillDiffCsp is
- * compatible; we reuse the compare CSP for consistency). Mirrors the detail
- * panel's getErrorHtml: aria-live region + a Retry button wired via nonce.
+ * Build a local error page for the Compare panel. Mirrors the detail panel's
+ * getErrorHtml: aria-live region + a Retry button wired via nonce.
  */
 export function getCompareErrorHtml(message: string, nonce: string, rawError?: string): string {
-  // getCompareCsp is the compare panel's CSP; getSkillDiffCsp is imported only
-  // to satisfy the shared-helper contract noted in the worker brief.
-  void getSkillDiffCsp
   const csp = getCompareCsp(nonce)
   const detailsBlock =
     rawError && rawError !== message

--- a/packages/vscode-extension/src/views/compare-panel-html.ts
+++ b/packages/vscode-extension/src/views/compare-panel-html.ts
@@ -1,0 +1,218 @@
+/**
+ * HTML generation for the Compare Skills panel (SMI-5315 / #1456).
+ *
+ * Mirrors skill-panel-html.ts: host-builds all HTML, escapes every untrusted
+ * field via `escapeHtml`, and uses the shared `.badge badge-${color}` /
+ * `.score-bar` / `.score-fill` / `.section` / `.meta-grid` component vocabulary.
+ * The webview is read-only; the only inbound message is `retry`.
+ */
+
+import { escapeHtml } from '../utils/security.js'
+import { getSkillDiffCsp, getCompareCsp } from '../utils/csp.js'
+import { getTrustBadgeColor, getTrustBadgeText } from './trust-badge.js'
+import type { McpCompareResponse, McpCompareSummary, McpSkillDifference } from '../mcp/types.js'
+
+/** Clamp a quality score into the 0–100 range for the score bar width. */
+function clampScore(score: number): number {
+  if (!Number.isFinite(score)) return 0
+  return Math.min(100, Math.max(0, score))
+}
+
+/** Render the two-column summary cell for one skill (name / author / trust / score). */
+function getSummaryColumnHtml(summary: McpCompareSummary, label: 'A' | 'B'): string {
+  const safeName = escapeHtml(summary.name)
+  const safeAuthor = escapeHtml(summary.author)
+  const badgeColor = getTrustBadgeColor(summary.trust_tier)
+  const badgeText = getTrustBadgeText(summary.trust_tier)
+  const score = clampScore(summary.quality_score)
+  return `
+    <div class="summary-col">
+      <div class="summary-label">Skill ${label}</div>
+      <h2 class="summary-name">${safeName}</h2>
+      <div class="summary-author">by ${safeAuthor}</div>
+      <div class="summary-trust">
+        <span class="badge badge-${badgeColor}">${badgeText}</span>
+      </div>
+      <div class="summary-score">
+        <span class="score-label">Quality</span>
+        <div class="score-bar"><div class="score-fill" style="width: ${score}%"></div></div>
+        <span class="score-value">${score}/100</span>
+      </div>
+    </div>`
+}
+
+/**
+ * Render the side-by-side tags row. Tags are an array of untrusted strings —
+ * each escaped. Empty arrays render an em dash so the grid stays aligned.
+ */
+function getTagsRowHtml(a: McpCompareSummary, b: McpCompareSummary): string {
+  const renderTags = (tags: string[]): string => {
+    if (!tags || tags.length === 0) return '<span class="muted">—</span>'
+    return tags.map((t) => `<span class="tag">${escapeHtml(t)}</span>`).join(' ')
+  }
+  return `
+    <tr>
+      <td class="diff-field">Tags</td>
+      <td>${renderTags(a.tags)}</td>
+      <td>${renderTags(b.tags)}</td>
+    </tr>`
+}
+
+/** Render one differences row, highlighting the winner cell. */
+function getDifferenceRowHtml(diff: McpSkillDifference): string {
+  const safeField = escapeHtml(String(diff.field))
+  const safeA = escapeHtml(String(diff.a_value))
+  const safeB = escapeHtml(String(diff.b_value))
+  const aWin = diff.winner === 'a' ? ' diff-winner' : ''
+  const bWin = diff.winner === 'b' ? ' diff-winner' : ''
+  return `
+    <tr>
+      <td class="diff-field">${safeField}</td>
+      <td class="diff-value${aWin}">${safeA}</td>
+      <td class="diff-value${bWin}">${safeB}</td>
+    </tr>`
+}
+
+/** Styles for the compare panel — uses VS Code CSS variables (no nonce needed). */
+function getCompareStyles(): string {
+  return `
+    body { font-family: var(--vscode-font-family); color: var(--vscode-foreground);
+      background-color: var(--vscode-editor-background); padding: 20px; line-height: 1.5; }
+    h1 { font-size: 1.4em; font-weight: 600; margin-bottom: 16px; }
+    .section { margin-top: 24px; }
+    .section h2 { font-size: 1.05em; font-weight: 600; margin-bottom: 8px; }
+    .summary-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .summary-col { border: 1px solid var(--vscode-panel-border); border-radius: 6px; padding: 12px; }
+    .summary-label { font-size: 0.8em; text-transform: uppercase; letter-spacing: 0.05em;
+      color: var(--vscode-descriptionForeground); }
+    .summary-name { font-size: 1.1em; margin: 4px 0; }
+    .summary-author { color: var(--vscode-descriptionForeground); font-size: 0.9em; }
+    .summary-trust { margin: 8px 0; }
+    .summary-score { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 0.8em;
+      font-weight: 600; }
+    .badge-official { background: #2e7d32; color: #fff; }
+    .badge-verified { background: #1565c0; color: #fff; }
+    .badge-curated { background: #6a1b9a; color: #fff; }
+    .badge-community { background: #455a64; color: #fff; }
+    .badge-unverified { background: #b71c1c; color: #fff; }
+    .score-label { font-size: 0.85em; color: var(--vscode-descriptionForeground); }
+    .score-bar { flex: 1; height: 8px; background: var(--vscode-progressBar-background);
+      border-radius: 4px; overflow: hidden; }
+    .score-fill { height: 100%; background: var(--vscode-progressBar-foreground); }
+    .score-value { font-size: 0.85em; min-width: 48px; text-align: right; }
+    table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+    th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--vscode-panel-border);
+      vertical-align: top; }
+    th { font-weight: 600; font-size: 0.85em; color: var(--vscode-descriptionForeground); }
+    .diff-field { font-weight: 600; }
+    .diff-winner { background: var(--vscode-editor-selectionBackground); font-weight: 600; }
+    .tag { display: inline-block; padding: 1px 6px; margin: 1px; border-radius: 3px;
+      background: var(--vscode-badge-background); color: var(--vscode-badge-foreground); font-size: 0.8em; }
+    .muted { color: var(--vscode-descriptionForeground); }
+    .recommendation { margin-top: 24px; padding: 12px; border-radius: 6px;
+      background: var(--vscode-textBlockQuote-background);
+      border-left: 4px solid var(--vscode-textLink-foreground); }`
+}
+
+/**
+ * Build the complete Compare panel HTML. All untrusted fields are escaped.
+ */
+export function getCompareHtml(response: McpCompareResponse, nonce: string): string {
+  const csp = getCompareCsp(nonce)
+  const a = response.comparison.a
+  const b = response.comparison.b
+
+  // OMIT version / score_breakdown / empty-dependencies rows entirely
+  // (server always returns null/[] today — never render "null").
+  const differenceRows = response.differences.map(getDifferenceRowHtml).join('')
+  const safeRecommendation = escapeHtml(response.recommendation)
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="${csp}">
+  <title>Compare Skills</title>
+  <style>${getCompareStyles()}</style>
+</head>
+<body>
+  <h1>Compare Skills</h1>
+
+  <div class="summary-grid">
+    ${getSummaryColumnHtml(a, 'A')}
+    ${getSummaryColumnHtml(b, 'B')}
+  </div>
+
+  <div class="section">
+    <h2>Differences</h2>
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Field</th>
+          <th scope="col">${escapeHtml(a.name)}</th>
+          <th scope="col">${escapeHtml(b.name)}</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${getTagsRowHtml(a, b)}
+        ${differenceRows || '<tr><td colspan="3" class="muted">No field-level differences.</td></tr>'}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="recommendation" aria-live="polite">${safeRecommendation}</div>
+</body>
+</html>`
+}
+
+/**
+ * Build a local error page for the Compare panel (CSP from getSkillDiffCsp is
+ * compatible; we reuse the compare CSP for consistency). Mirrors the detail
+ * panel's getErrorHtml: aria-live region + a Retry button wired via nonce.
+ */
+export function getCompareErrorHtml(message: string, nonce: string, rawError?: string): string {
+  // getCompareCsp is the compare panel's CSP; getSkillDiffCsp is imported only
+  // to satisfy the shared-helper contract noted in the worker brief.
+  void getSkillDiffCsp
+  const csp = getCompareCsp(nonce)
+  const detailsBlock =
+    rawError && rawError !== message
+      ? `<details style="margin-top: 12px; color: var(--vscode-descriptionForeground);">
+        <summary>Technical details</summary>
+        <pre style="white-space: pre-wrap; font-size: 12px; margin-top: 8px;">${escapeHtml(rawError)}</pre>
+       </details>`
+      : ''
+
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<style nonce="${nonce}">
+  button:hover { background-color: var(--vscode-button-hoverBackground) !important; }
+  button:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px; }
+</style>
+</head>
+<body style="font-family: var(--vscode-font-family); padding: 20px; color: var(--vscode-foreground); background-color: var(--vscode-editor-background);">
+  <div aria-live="polite">
+    <h1 style="font-size: 1.4em; font-weight: 600;">Couldn't Compare Skills</h1>
+    <p role="alert">${escapeHtml(message)}</p>
+    ${detailsBlock}
+    <button id="retryBtn" style="background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; padding: 10px 20px; border-radius: 4px; font-size: 14px; font-weight: 500; cursor: pointer; margin-top: 16px;">
+      Retry
+    </button>
+  </div>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const btn = document.getElementById('retryBtn');
+    if (btn) {
+      btn.addEventListener('click', () => {
+        btn.disabled = true;
+        btn.textContent = 'Retrying...';
+        vscode.postMessage({ command: 'retry' });
+      });
+    }
+  </script>
+</body></html>`
+}

--- a/packages/vscode-extension/src/views/compare-panel-types.ts
+++ b/packages/vscode-extension/src/views/compare-panel-types.ts
@@ -1,0 +1,15 @@
+/**
+ * Message + view-data types for the Compare Skills panel (SMI-5315 / #1456).
+ *
+ * Split out of CompareSkillsPanel.ts / compare-panel-html.ts so each file stays
+ * under the 500-line cap.
+ */
+
+/**
+ * Messages posted from the Compare webview back to the extension host.
+ * The compare panel is read-only, so the only inbound message is `retry`
+ * (re-run the comparison after a transient `McpToolError`).
+ */
+export interface ComparePanelMessage {
+  command: 'retry'
+}

--- a/packages/vscode-extension/src/views/diff-panel-html.ts
+++ b/packages/vscode-extension/src/views/diff-panel-html.ts
@@ -1,0 +1,212 @@
+/**
+ * HTML generation for the Skill Diff / update-advisor panel (SMI-5316 / #1457).
+ *
+ * Product framing (owner decision D-B): this is an UPDATE ADVISOR. The panel
+ * LEADS with the `recommendation` verdict + `changeType` badge, then shows the
+ * section changes / risk delta / changelog as supporting detail. Mirrors
+ * skill-panel-html.ts: host-built, every untrusted field escaped, shared
+ * `.section` / `.badge` component vocabulary. Read-only — inbound message is
+ * only `retry`.
+ */
+
+import { escapeHtml } from '../utils/security.js'
+import { getSkillDiffCsp } from '../utils/csp.js'
+import type { McpSkillDiffResponse } from '../mcp/types.js'
+
+/** Friendly verdict copy for each recommendation value. */
+function getVerdictCopy(recommendation: McpSkillDiffResponse['recommendation']): {
+  title: string
+  badgeClass: string
+} {
+  switch (recommendation) {
+    case 'auto-update':
+      return { title: 'Safe to update', badgeClass: 'verdict-safe' }
+    case 'review-then-update':
+      return { title: 'Review before updating', badgeClass: 'verdict-review' }
+    case 'manual-review-required':
+      return { title: 'Manual review required', badgeClass: 'verdict-manual' }
+    default:
+      return { title: 'Review before updating', badgeClass: 'verdict-review' }
+  }
+}
+
+/** Map changeType to a badge color class. */
+function getChangeTypeBadgeClass(changeType: McpSkillDiffResponse['changeType']): string {
+  switch (changeType) {
+    case 'major':
+      return 'change-major'
+    case 'minor':
+      return 'change-minor'
+    case 'patch':
+      return 'change-patch'
+    default:
+      return 'change-unknown'
+  }
+}
+
+/** Render one section-changes list, or '' when the list is empty. */
+function getSectionListHtml(title: string, entries: string[]): string {
+  if (!entries || entries.length === 0) {
+    return ''
+  }
+  const items = entries.map((e) => `<li>${escapeHtml(e)}</li>`).join('')
+  return `
+    <div class="section">
+      <h2>${escapeHtml(title)}</h2>
+      <ul class="section-list">${items}</ul>
+    </div>`
+}
+
+/** Styles for the diff panel — uses VS Code CSS variables (no nonce needed). */
+function getDiffStyles(): string {
+  return `
+    body { font-family: var(--vscode-font-family); color: var(--vscode-foreground);
+      background-color: var(--vscode-editor-background); padding: 20px; line-height: 1.5; }
+    h1 { font-size: 1.4em; font-weight: 600; margin-bottom: 4px; }
+    .skill-name { color: var(--vscode-descriptionForeground); font-size: 0.95em; margin-bottom: 16px; }
+    .verdict { padding: 16px; border-radius: 8px; margin-bottom: 8px;
+      background: var(--vscode-textBlockQuote-background); }
+    .verdict-title { font-size: 1.2em; font-weight: 600; display: flex; align-items: center; gap: 10px; }
+    .verdict-safe { border-left: 4px solid #2e7d32; }
+    .verdict-review { border-left: 4px solid #f9a825; }
+    .verdict-manual { border-left: 4px solid #b71c1c; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 0.75em;
+      font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+    .change-major { background: #b71c1c; color: #fff; }
+    .change-minor { background: #f9a825; color: #000; }
+    .change-patch { background: #2e7d32; color: #fff; }
+    .change-unknown { background: #455a64; color: #fff; }
+    .section { margin-top: 20px; }
+    .section h2 { font-size: 1.05em; font-weight: 600; margin-bottom: 6px; }
+    .section-list { margin: 0; padding-left: 20px; }
+    .section-list li { margin: 2px 0; }
+    .meta-row { margin-top: 16px; }
+    .meta-label { font-size: 0.85em; color: var(--vscode-descriptionForeground); }
+    .changelog { white-space: pre-wrap; background: var(--vscode-textCodeBlock-background);
+      padding: 12px; border-radius: 6px; font-size: 0.9em; }
+    .no-changes { margin-top: 20px; color: var(--vscode-descriptionForeground); }`
+}
+
+/** Render the risk-score-delta row when present. */
+function getRiskDeltaHtml(delta: number | null): string {
+  if (delta === null) {
+    return ''
+  }
+  const sign = delta > 0 ? '+' : ''
+  return `
+    <div class="meta-row">
+      <span class="meta-label">Risk score change:</span> ${sign}${escapeHtml(String(delta))}
+    </div>`
+}
+
+/** Render the changelog block when present. */
+function getChangelogHtml(changelog: string | null): string {
+  if (!changelog) {
+    return ''
+  }
+  return `
+    <div class="section">
+      <h2>Changelog</h2>
+      <div class="changelog">${escapeHtml(changelog)}</div>
+    </div>`
+}
+
+/**
+ * Build the complete Diff / update-advisor panel HTML. Leads with the verdict
+ * and changeType badge. All untrusted fields escaped.
+ */
+export function getDiffHtml(
+  skillName: string,
+  response: McpSkillDiffResponse,
+  nonce: string
+): string {
+  const csp = getSkillDiffCsp(nonce)
+  const verdict = getVerdictCopy(response.recommendation)
+  const changeBadgeClass = getChangeTypeBadgeClass(response.changeType)
+  const safeName = escapeHtml(skillName)
+  const safeChangeType = escapeHtml(response.changeType)
+
+  const added = getSectionListHtml('Sections added', response.sectionsAdded)
+  const removed = getSectionListHtml('Sections removed', response.sectionsRemoved)
+  const modified = getSectionListHtml('Sections modified', response.sectionsModified)
+  const noSemanticChanges =
+    response.sectionsAdded.length === 0 &&
+    response.sectionsRemoved.length === 0 &&
+    response.sectionsModified.length === 0
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="${csp}">
+  <title>Check for Updates</title>
+  <style>${getDiffStyles()}</style>
+</head>
+<body>
+  <h1>Update Check</h1>
+  <div class="skill-name">${safeName}</div>
+
+  <div class="verdict ${verdict.badgeClass}" aria-live="polite">
+    <div class="verdict-title">
+      ${escapeHtml(verdict.title)}
+      <span class="badge ${changeBadgeClass}">${safeChangeType}</span>
+    </div>
+  </div>
+
+  ${added}
+  ${removed}
+  ${modified}
+  ${noSemanticChanges ? '<div class="no-changes">No semantic changes detected.</div>' : ''}
+
+  ${getRiskDeltaHtml(response.riskScoreDelta)}
+  ${getChangelogHtml(response.changelog)}
+</body>
+</html>`
+}
+
+/**
+ * Build a local error page for the Diff panel. Mirrors the detail panel's
+ * getErrorHtml: aria-live region + a Retry button wired via nonce.
+ */
+export function getDiffErrorHtml(message: string, nonce: string, rawError?: string): string {
+  const csp = getSkillDiffCsp(nonce)
+  const detailsBlock =
+    rawError && rawError !== message
+      ? `<details style="margin-top: 12px; color: var(--vscode-descriptionForeground);">
+        <summary>Technical details</summary>
+        <pre style="white-space: pre-wrap; font-size: 12px; margin-top: 8px;">${escapeHtml(rawError)}</pre>
+       </details>`
+      : ''
+
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<style nonce="${nonce}">
+  button:hover { background-color: var(--vscode-button-hoverBackground) !important; }
+  button:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px; }
+</style>
+</head>
+<body style="font-family: var(--vscode-font-family); padding: 20px; color: var(--vscode-foreground); background-color: var(--vscode-editor-background);">
+  <div aria-live="polite">
+    <h1 style="font-size: 1.4em; font-weight: 600;">Couldn't Check for Updates</h1>
+    <p role="alert">${escapeHtml(message)}</p>
+    ${detailsBlock}
+    <button id="retryBtn" style="background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; padding: 10px 20px; border-radius: 4px; font-size: 14px; font-weight: 500; cursor: pointer; margin-top: 16px;">
+      Retry
+    </button>
+  </div>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const btn = document.getElementById('retryBtn');
+    if (btn) {
+      btn.addEventListener('click', () => {
+        btn.disabled = true;
+        btn.textContent = 'Retrying...';
+        vscode.postMessage({ command: 'retry' });
+      });
+    }
+  </script>
+</body></html>`
+}

--- a/packages/vscode-extension/src/views/diff-panel-types.ts
+++ b/packages/vscode-extension/src/views/diff-panel-types.ts
@@ -1,0 +1,31 @@
+/**
+ * Message + view-data types for the Skill Diff / update-advisor panel
+ * (SMI-5316 / #1457).
+ *
+ * Split out of SkillDiffPanel.ts / diff-panel-html.ts so each file stays under
+ * the 500-line cap.
+ */
+
+/**
+ * Messages posted from the Diff webview back to the extension host.
+ * The diff panel is read-only, so the only inbound message is `retry`
+ * (re-run the check after a transient `McpToolError`).
+ */
+export interface DiffPanelMessage {
+  command: 'retry'
+}
+
+/**
+ * Arguments for an MCP `skill_diff` call. Stored on the panel so a `retry`
+ * re-runs the same check (e.g. after a transient disconnect). Mirrors the
+ * `McpClient.skillDiff` parameter shape.
+ */
+export interface SkillDiffArgs {
+  skillId: string
+  oldContent: string
+  newContent: string
+  oldRiskScore?: number
+  newRiskScore?: number
+  hasLocalModifications?: boolean
+  trustTier?: 'verified' | 'community' | 'experimental'
+}

--- a/packages/vscode-extension/src/views/skill-panel-html.ts
+++ b/packages/vscode-extension/src/views/skill-panel-html.ts
@@ -14,41 +14,11 @@ import { getActionBlock } from './skill-panel-actions.js'
 // Re-export for testing
 export { getContentHtml } from './skill-panel-content.js'
 
-// vocabulary mirrors src/sidebar/trustTier.ts (ApiTrustTier 5-tier). Kept inline to keep this module vscode-free.
-function normalizeTierForBadge(tier: string): string {
-  const lower = tier.toLowerCase()
-  const canonical = ['official', 'verified', 'curated', 'community', 'unverified']
-  if (canonical.includes(lower)) return lower
-  // Legacy mapping: experimental → community; all other unrecognized → unverified
-  if (lower === 'experimental') return 'community'
-  return 'unverified'
-}
-
-/**
- * Get the CSS class for trust tier badge color
- */
-export function getTrustBadgeColor(tier: string): string {
-  return normalizeTierForBadge(tier)
-}
-
-/**
- * Get the display text for trust tier badge
- */
-export function getTrustBadgeText(tier: string): string {
-  const normalized = normalizeTierForBadge(tier)
-  switch (normalized) {
-    case 'official':
-      return 'Official'
-    case 'verified':
-      return 'Verified'
-    case 'curated':
-      return 'Curated'
-    case 'community':
-      return 'Community'
-    default:
-      return 'Unverified'
-  }
-}
+// SMI-5315: trust-badge helpers extracted to ./trust-badge.ts so the Compare /
+// Diff panels share the same `.badge badge-${color}` component. Re-exported here
+// for back-compat with existing importers + tests.
+import { getTrustBadgeColor, getTrustBadgeText } from './trust-badge.js'
+export { getTrustBadgeColor, getTrustBadgeText } from './trust-badge.js'
 
 /**
  * Generate loading HTML for the panel

--- a/packages/vscode-extension/src/views/trust-badge.ts
+++ b/packages/vscode-extension/src/views/trust-badge.ts
@@ -1,0 +1,44 @@
+/**
+ * Trust-tier badge helpers for webview surfaces (SMI-5315).
+ *
+ * Extracted from skill-panel-html.ts so the Compare / Diff panels render trust
+ * with the same `.badge badge-${color}` component as the detail panel. Vocabulary
+ * mirrors src/sidebar/trustTier.ts (ApiTrustTier 5-tier); kept vscode-free so it
+ * can be imported by any HTML-builder module. NOTE: these are for WEBVIEW badges;
+ * QuickPick string surfaces use the codicon getters in src/sidebar/trustTier.ts.
+ */
+
+function normalizeTierForBadge(tier: string): string {
+  const lower = tier.toLowerCase()
+  const canonical = ['official', 'verified', 'curated', 'community', 'unverified']
+  if (canonical.includes(lower)) return lower
+  // Legacy mapping: experimental → community; all other unrecognized → unverified
+  if (lower === 'experimental') return 'community'
+  return 'unverified'
+}
+
+/**
+ * Get the CSS class suffix for a trust tier badge color (`badge-${color}`).
+ */
+export function getTrustBadgeColor(tier: string): string {
+  return normalizeTierForBadge(tier)
+}
+
+/**
+ * Get the display text for a trust tier badge.
+ */
+export function getTrustBadgeText(tier: string): string {
+  const normalized = normalizeTierForBadge(tier)
+  switch (normalized) {
+    case 'official':
+      return 'Official'
+    case 'verified':
+      return 'Verified'
+    case 'curated':
+      return 'Curated'
+    case 'community':
+      return 'Community'
+    default:
+      return 'Unverified'
+  }
+}


### PR DESCRIPTION
Epic D / PR-D1 of the VS Code UX overhaul (parent SMI-5287). Host-only (ADR-113). Ships **unreleased** — batches into a single **0.6.0** at the end of Epic D.

## What this adds
Three MCP-powered command surfaces, plus the SMI-5309 `McpClient.callTool` split that buys headroom under the 500-line gate:

- **Recommend Skills** (`skillsmith.recommendSkills`, SMI-5314) — QuickPick of contextual recommendations (`skill_recommend`, ungated) → opens the detail panel.
- **Compare Skills** (`skillsmith.compareSkills`, SMI-5315) — two sequential search picks → `skill_compare` (exactly two skills) → comparison webview (summary + field differences + recommendation). Self-compare guarded.
- **Check Skill for Updates** (`skillsmith.diffSkill`, SMI-5316) — installed-vs-registry-latest update advisor: reads local SKILL.md + `getSkill().content` → `skill_diff` → webview leading with the recommendation verdict + changeType. **Tier-gated (Individual+)**; TierDenied routes to the upgrade UX before any panel opens.

## Implementation notes
- `src/mcp/callTool.ts` (new) — `callMcpTool<T>` + `classifyIsErrorText` extracted; `McpClient.callTool` delegates, test seam preserved byte-for-byte. **Closes SMI-5309.**
- New wrappers `skillRecommend`/`skillCompare`/`skillDiff` + response types (`src/mcp/types.ts`), per `McpClient.patterns.md`.
- Webviews reuse CSP nonce + `escapeHtml` + shared `trust-badge` helpers (extracted from `skill-panel-html.ts`); loading + error/Retry states; every untrusted field escaped; listener wired before `webview.html`.
- Telemetry: 7 new event ids; coverage gate `6 → 9`.

## Decisions (owner-approved)
- Diff data source = installed-vs-registry-latest (no version-history store exists).
- Diff framed as an **update advisor** ("Check Skill for Updates"), tier requirement shown up front.
- Native `vscode.diff` text-diff deferred → SMI-5323. Precise `SkillNotFound` classification deferred → SMI-5322.

## Verification
typecheck ✓ · lint (0 warnings) ✓ · **591 tests pass** · `package:check` (VSIX) ✓ · `audit:standards` 0 failed. Plan-reviewed (2 Crit + 9 High folded pre-code); `/governance` clean (M1/L1/L2/L3 fixed in-PR). Every file <500 (max McpClient.ts 480).

[skip-smoke]