### PR TITLE
feat(vscode): security advisories + finding count in skill detail panel (SMI-5317)

### DIFF
--- a/.claude/development/mcp-tools-guide.md
+++ b/.claude/development/mcp-tools-guide.md
@@ -42,7 +42,7 @@ New tools use `skill_` prefix; legacy tools (`search`, `get_skill`) lack it.
 
 ## VS Code Extension Surface
 
-The `skill_recommend`, `skill_compare`, and `skill_diff` MCP tools are surfaced in the VS Code extension as commands: **Recommend Skills**, **Compare Skills**, and **Check Skill for Updates** (the latter requires Individual plan or higher).
+The `skill_recommend`, `skill_compare`, and `skill_diff` MCP tools are surfaced in the VS Code extension as commands: **Recommend Skills**, **Compare Skills**, and **Check Skill for Updates** (the latter requires Individual plan or higher). The `skill_audit` tool is surfaced in the skill detail panel as a **Security Advisories** section (Team plan or higher).
 
 ## CLI
 

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Recommend Skills command** — contextual skill recommendations based on your installed skills, surfaced in a quick pick.
 - **Compare Skills command** — side-by-side comparison of two skills in a panel (quality, trust tier, key differences, and a recommendation).
 - **Check Skill for Updates command** — compares an installed skill against the latest registry version and advises whether to update (Individual plan or higher).
+- **Security advisories** — the skill detail panel now shows published security advisories for a skill (Team plan or higher), plus a finding count on failed scans.
 
 ### Changed
 

--- a/packages/vscode-extension/src/__tests__/SkillDetailPanel.advisories.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillDetailPanel.advisories.test.ts
@@ -1,0 +1,199 @@
+/**
+ * SMI-5317: lazy Security Advisories auto-load in SkillDetailPanel.
+ * Split into its own file (self-contained mock scaffolding) to keep
+ * SkillDetailPanel.test.ts under the 500-line gate.
+ *
+ * Covers: happy-path render + telemetry (H3), stale-skill guard (C1),
+ * dispose guard (C2), and session-cached tier denial (M1).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Uri: {
+    joinPath: vi.fn((_base: unknown, ...segments: string[]) => ({ fsPath: segments.join('/') })),
+    parse: vi.fn((s: string) => ({ toString: () => s })),
+    file: vi.fn((s: string) => ({ fsPath: s, scheme: 'file' })),
+  },
+  ViewColumn: { One: 1 },
+  window: {
+    createWebviewPanel: vi.fn(),
+    activeTextEditor: undefined,
+    showWarningMessage: vi.fn(),
+    showInformationMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+  },
+  commands: { executeCommand: vi.fn() },
+  env: { openExternal: vi.fn() },
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+vi.mock('../commands/uninstallCommand.js', () => ({ uninstallByTarget: vi.fn() }))
+
+const { track } = vi.hoisted(() => ({ track: vi.fn() }))
+vi.mock('../services/Telemetry.js', () => ({ track }))
+
+// The panel branches on `instanceof McpToolError`, so that stays the real class.
+const { skillAudit, isConnected } = vi.hoisted(() => ({
+  skillAudit: vi.fn(),
+  isConnected: vi.fn(() => true),
+}))
+vi.mock('../mcp/McpClient.js', () => ({
+  getMcpClient: () => ({ skillAudit, isConnected }),
+}))
+
+import * as vscode from 'vscode'
+import { SkillDetailPanel } from '../views/SkillDetailPanel.js'
+import { McpToolError } from '../mcp/McpToolError.js'
+import type { SkillService } from '../services/SkillService.js'
+
+function createMockPanel() {
+  const htmlValues: string[] = []
+  const panel = {
+    reveal: vi.fn(),
+    dispose: vi.fn(),
+    title: '',
+    webview: {
+      get html() {
+        return htmlValues[htmlValues.length - 1] ?? ''
+      },
+      set html(value: string) {
+        htmlValues.push(value)
+      },
+      onDidReceiveMessage: vi.fn((_h: unknown, _c: unknown, subs: unknown[]) => {
+        const d = { dispose: vi.fn() }
+        if (Array.isArray(subs)) subs.push(d)
+        return d
+      }),
+      asWebviewUri: vi.fn((uri: { fsPath: string }) => uri),
+    },
+    onDidDispose: vi.fn((_h: () => void, _c: unknown, subs: unknown[]) => {
+      const d = { dispose: vi.fn() }
+      if (Array.isArray(subs)) subs.push(d)
+      return d
+    }),
+  }
+  return { panel: panel as unknown as vscode.WebviewPanel, getHtmlHistory: () => htmlValues }
+}
+
+function createMockSkillService(): SkillService {
+  return {
+    getRichSkill: vi.fn().mockResolvedValue({
+      skill: {
+        id: 'test/skill',
+        name: 'Test Skill',
+        description: 'A test skill',
+        author: 'tester',
+        category: 'testing',
+        trustTier: 'verified',
+        score: 85,
+      },
+      isOffline: false,
+    }),
+    isConnected: () => true,
+  } as unknown as SkillService
+}
+
+const EXTENSION_URI = { fsPath: '/test/extension' } as vscode.Uri
+const ADV = {
+  skillName: 'test/skill',
+  severity: 'high' as const,
+  title: 'A published advisory',
+  id: 'SKADV-1',
+  fixAvailable: true,
+}
+const deferred = () => {
+  let resolve: (v: unknown) => void = () => {}
+  const promise = new Promise((res) => (resolve = res))
+  return { promise, resolve }
+}
+const tick = () => new Promise((r) => setTimeout(r, 0))
+
+async function showPanel(id = 'test/skill'): Promise<ReturnType<typeof createMockPanel>> {
+  const mock = createMockPanel()
+  vi.mocked(vscode.window.createWebviewPanel).mockReturnValue(mock.panel)
+  SkillDetailPanel.createOrShow(EXTENSION_URI, id)
+  await vi.waitFor(() => expect(mock.getHtmlHistory().at(-1) ?? '').toContain('Test Skill'))
+  return mock
+}
+
+describe('SkillDetailPanel lazy advisories (SMI-5317)', () => {
+  beforeEach(() => {
+    SkillDetailPanel.currentPanel = undefined
+    vi.mocked(vscode.window.createWebviewPanel).mockReset()
+    track.mockReset()
+    skillAudit.mockReset()
+    skillAudit.mockResolvedValue({ advisoriesAvailable: false, advisories: [] })
+    isConnected.mockReset()
+    isConnected.mockReturnValue(true)
+    SkillDetailPanel.resetForTests()
+    SkillDetailPanel.setTreeProvider(undefined)
+  })
+
+  afterEach(() => {
+    SkillDetailPanel.resetForTests()
+  })
+
+  it('renders advisories after skillAudit resolves and fires telemetry (H3)', async () => {
+    SkillDetailPanel.setSkillService(createMockSkillService())
+    skillAudit.mockResolvedValue({ advisoriesAvailable: true, advisories: [ADV] })
+    const mock = await showPanel()
+    await vi.waitFor(() =>
+      expect(mock.getHtmlHistory().at(-1) ?? '').toContain('Security Advisories')
+    )
+    expect(mock.getHtmlHistory().at(-1) ?? '').toContain('A published advisory')
+    expect(track).toHaveBeenCalledWith('vscode_advisories_shown', {
+      count: 1,
+      surface: 'detail-panel',
+    })
+  })
+
+  it('does NOT apply advisories for a stale skillId (C1)', async () => {
+    const first = deferred()
+    skillAudit
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValue({ advisoriesAvailable: true, advisories: [] })
+    const service = createMockSkillService()
+    SkillDetailPanel.setSkillService(service)
+    const mock = await showPanel()
+    SkillDetailPanel.createOrShow(EXTENSION_URI, 'other/skill')
+    await vi.waitFor(() => expect(vi.mocked(service.getRichSkill)).toHaveBeenCalledTimes(2))
+    first.resolve({ advisoriesAvailable: true, advisories: [ADV] })
+    await tick()
+    expect(mock.getHtmlHistory().at(-1) ?? '').not.toContain('A published advisory')
+    expect(track).not.toHaveBeenCalledWith('vscode_advisories_shown', expect.anything())
+  })
+
+  it('does not re-render when disposed before skillAudit resolves (C2)', async () => {
+    const d = deferred()
+    skillAudit.mockReturnValue(d.promise)
+    SkillDetailPanel.setSkillService(createMockSkillService())
+    const mock = await showPanel()
+    SkillDetailPanel.currentPanel?.dispose()
+    const count = mock.getHtmlHistory().length
+    d.resolve({ advisoriesAvailable: true, advisories: [ADV] })
+    await tick()
+    expect(mock.getHtmlHistory().length).toBe(count)
+  })
+
+  it('caches the tier denial and skips the call on the next panel (M1)', async () => {
+    SkillDetailPanel.setSkillService(createMockSkillService())
+    skillAudit.mockRejectedValue(
+      new McpToolError('skill_audit', 'TierDenied', 'Team plan required')
+    )
+    const mock = await showPanel()
+    await vi.waitFor(() => expect(mock.getHtmlHistory().at(-1) ?? '').toContain('advisory-upsell'))
+    expect(track).toHaveBeenCalledWith('vscode_advisories_tier_denied', { surface: 'detail-panel' })
+    expect(skillAudit).toHaveBeenCalledTimes(1)
+
+    SkillDetailPanel.currentPanel?.dispose()
+    skillAudit.mockClear()
+    await showPanel()
+    await tick()
+    expect(skillAudit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/vscode-extension/src/__tests__/SkillDetailPanel.advisories.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillDetailPanel.advisories.test.ts
@@ -186,7 +186,9 @@ describe('SkillDetailPanel lazy advisories (SMI-5317)', () => {
       new McpToolError('skill_audit', 'TierDenied', 'Team plan required')
     )
     const mock = await showPanel()
-    await vi.waitFor(() => expect(mock.getHtmlHistory().at(-1) ?? '').toContain('advisory-upsell'))
+    await vi.waitFor(() =>
+      expect(mock.getHtmlHistory().at(-1) ?? '').toContain('available on the Team plan')
+    )
     expect(track).toHaveBeenCalledWith('vscode_advisories_tier_denied', { surface: 'detail-panel' })
     expect(skillAudit).toHaveBeenCalledTimes(1)
 
@@ -195,5 +197,50 @@ describe('SkillDetailPanel lazy advisories (SMI-5317)', () => {
     await showPanel()
     await tick()
     expect(skillAudit).not.toHaveBeenCalled()
+  })
+
+  it('still shows the upsell on a later panel without re-calling (M2)', async () => {
+    SkillDetailPanel.setSkillService(createMockSkillService())
+    skillAudit.mockRejectedValue(
+      new McpToolError('skill_audit', 'TierDenied', 'Team plan required')
+    )
+    const first = await showPanel()
+    await vi.waitFor(() =>
+      expect(first.getHtmlHistory().at(-1) ?? '').toContain('available on the Team plan')
+    )
+
+    SkillDetailPanel.currentPanel?.dispose()
+    skillAudit.mockClear()
+    const second = await showPanel()
+    await tick()
+    // The session flag skips the gated call, but the upsell still renders.
+    expect(skillAudit).not.toHaveBeenCalled()
+    expect(second.getHtmlHistory().at(-1) ?? '').toContain('available on the Team plan')
+  })
+
+  it('drops an advisory with a malformed skillName without throwing (H1)', async () => {
+    SkillDetailPanel.setSkillService(createMockSkillService())
+    skillAudit.mockResolvedValue({
+      advisoriesAvailable: true,
+      // first row has a non-string skillName (untrusted JSON-RPC data) and must
+      // be filtered out without throwing; the valid row still renders.
+      advisories: [{ ...ADV, skillName: undefined }, ADV],
+    })
+    const mock = await showPanel()
+    await vi.waitFor(() =>
+      expect(mock.getHtmlHistory().at(-1) ?? '').toContain('Security Advisories')
+    )
+    expect(mock.getHtmlHistory().at(-1) ?? '').toContain('A published advisory')
+  })
+
+  it('silently ignores a non-TierDenied skillAudit error (L3)', async () => {
+    SkillDetailPanel.setSkillService(createMockSkillService())
+    skillAudit.mockRejectedValue(new McpToolError('skill_audit', 'Unknown', 'boom'))
+    const mock = await showPanel()
+    await tick()
+    const html = mock.getHtmlHistory().at(-1) ?? ''
+    expect(html).not.toContain('available on the Team plan')
+    expect(html).not.toContain('Security Advisories')
+    expect(track).not.toHaveBeenCalledWith('vscode_advisories_tier_denied', expect.anything())
   })
 })

--- a/packages/vscode-extension/src/__tests__/SkillDetailPanel.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillDetailPanel.test.ts
@@ -45,6 +45,17 @@ vi.mock('../services/Telemetry.js', () => ({
   track: vi.fn(),
 }))
 
+// SMI-5317: the panel lazily auto-loads advisories via getMcpClient().skillAudit
+// after a successful render. Stub it inert here so these error/action tests stay
+// focused; the advisory behaviour itself is covered in
+// SkillDetailPanel.advisories.test.ts.
+vi.mock('../mcp/McpClient.js', () => ({
+  getMcpClient: () => ({
+    skillAudit: vi.fn().mockResolvedValue({ advisoriesAvailable: false, advisories: [] }),
+    isConnected: () => true,
+  }),
+}))
+
 import * as vscode from 'vscode'
 import { SkillDetailPanel } from '../views/SkillDetailPanel.js'
 import type { SkillService } from '../services/SkillService.js'

--- a/packages/vscode-extension/src/__tests__/SkillService.security.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillService.security.test.ts
@@ -1,0 +1,41 @@
+/**
+ * SMI-5317: securityFindingsCount mapping in mapSkillDetailsToExtendedSkillData.
+ * Split out of SkillService.test.ts to stay under the 500-line file gate.
+ */
+import { describe, it, expect } from 'vitest'
+import { mapSkillDetailsToExtendedSkillData } from '../services/SkillService.js'
+import type { McpGetSkillResponse, McpSkillDetails } from '../mcp/types.js'
+
+/** Minimal valid get_skill response; pass a `security` override to exercise mapping. */
+function makeResponse(security?: McpSkillDetails['security']): McpGetSkillResponse {
+  const skill: McpSkillDetails = {
+    id: 'org/foo',
+    name: 'Foo',
+    description: 'd',
+    author: 'org',
+    category: 'development',
+    trustTier: 'verified',
+    score: 90,
+    ...(security ? { security } : {}),
+  }
+  return { skill, installCommand: 'skillsmith install org/foo', timing: { totalMs: 1 } }
+}
+
+describe('SkillService securityFindingsCount mapping (SMI-5317)', () => {
+  it('maps securityFindingsCount from security.findingsCount when present', () => {
+    const result = mapSkillDetailsToExtendedSkillData(
+      makeResponse({
+        passed: false,
+        riskScore: 40,
+        findingsCount: 3,
+        scannedAt: '2026-01-01T00:00:00Z',
+      })
+    )
+    expect(result.securityFindingsCount).toBe(3)
+  })
+
+  it('maps securityFindingsCount to null when security is undefined', () => {
+    const result = mapSkillDetailsToExtendedSkillData(makeResponse())
+    expect(result.securityFindingsCount).toBeNull()
+  })
+})

--- a/packages/vscode-extension/src/__tests__/mcp/skill_audit.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/skill_audit.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+import { McpClient } from '../../mcp/McpClient.js'
+import { McpToolError } from '../../mcp/McpToolError.js'
+
+/** Wrap a JSON payload in the MCP tools/call success envelope. */
+function ok(payload: unknown): Record<string, unknown> {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+}
+
+/** Build an isError tools/call envelope with the given text. */
+function isErr(text: string): Record<string, unknown> {
+  return { isError: true, content: [{ type: 'text', text }] }
+}
+
+/**
+ * Returns a connected McpClient whose private `sendRequest` resolves to `raw`.
+ * Tests only — reaches into private members via an `any` cast.
+ */
+function connectedClient(raw: unknown): McpClient {
+  const client = new McpClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).status = 'connected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).sendRequest = vi.fn().mockResolvedValue(raw)
+  return client
+}
+
+const HAPPY_PAYLOAD = {
+  advisoriesAvailable: true,
+  summary: { critical: 1, high: 0, medium: 0, low: 0, total: 1 },
+  advisories: [
+    {
+      skillName: 'org/foo',
+      severity: 'critical',
+      title: 'X',
+      id: 'SSA-2026-001',
+      fixAvailable: true,
+    },
+  ],
+}
+
+describe('McpClient.skillAudit (SMI-5317)', () => {
+  it('happy path returns the typed McpSkillAuditResponse shape', async () => {
+    const client = connectedClient(ok(HAPPY_PAYLOAD))
+
+    const result = await client.skillAudit({ skillIds: ['org/foo'] })
+
+    expect(result.advisoriesAvailable).toBe(true)
+    expect(result.advisories?.[0]?.id).toBe('SSA-2026-001')
+    expect(result.summary?.critical).toBe(1)
+    expect(result.summary?.total).toBe(1)
+  })
+
+  it('default args (no skillIds) on a connected client returns the happy shape', async () => {
+    const client = connectedClient(ok(HAPPY_PAYLOAD))
+
+    // skillAudit() with no args — default param is {}
+    const result = await client.skillAudit()
+
+    expect(result.advisoriesAvailable).toBe(true)
+    expect(result.advisories?.[0]?.id).toBe('SSA-2026-001')
+  })
+
+  it('tier-denied isError response throws McpToolError code TierDenied', async () => {
+    const client = connectedClient(
+      isErr('Security Audit requires Team tier. Upgrade at https://skillsmith.app/upgrade')
+    )
+    await expect(client.skillAudit({ skillIds: ['org/foo'] })).rejects.toMatchObject({
+      name: 'McpToolError',
+      code: 'TierDenied',
+      toolName: 'skill_audit',
+    })
+  })
+
+  it('unknown-tool isError response throws McpToolError code UnknownTool', async () => {
+    const client = connectedClient(isErr('Unknown tool: skill_audit'))
+    await expect(client.skillAudit({ skillIds: ['org/foo'] })).rejects.toMatchObject({
+      code: 'UnknownTool',
+    })
+  })
+
+  it('calling before connect throws NotConnected with the exact message', async () => {
+    const client = new McpClient()
+    await expect(client.skillAudit({ skillIds: ['org/foo'] })).rejects.toMatchObject({
+      code: 'NotConnected',
+      message: 'MCP client not connected',
+    })
+    await expect(client.skillAudit({ skillIds: ['org/foo'] })).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/__tests__/skill-panel-advisories.test.ts
+++ b/packages/vscode-extension/src/__tests__/skill-panel-advisories.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for getAdvisoriesHtml in skill-panel-html.ts (SMI-5317).
+ * Split into its own file to keep skill-panel-html.test.ts under the 500-line
+ * gate — same precedent as skill-panel-security.test.ts (SMI-4240).
+ *
+ * Covers: advisory section render + escaping (L1), severity whitelist (L1),
+ * fix marker, aria-live (L2), tier-denied upsell line, and the empty case.
+ */
+import { describe, it, expect } from 'vitest'
+import { getAdvisoriesHtml, getSkillDetailHtml } from '../views/skill-panel-html.js'
+import type { McpAdvisory } from '../mcp/types.js'
+import type { ExtendedSkillData } from '../types/skill.js'
+
+const NONCE = 'test-nonce-123'
+const CSP = "default-src 'none';"
+
+const adv = (o: Partial<McpAdvisory> = {}): McpAdvisory => ({
+  skillName: 'tester/test-skill',
+  severity: 'high',
+  title: 'Prompt injection in tool description',
+  id: 'SKADV-2026-001',
+  fixAvailable: true,
+  ...o,
+})
+
+function makeSkill(overrides: Partial<ExtendedSkillData> = {}): ExtendedSkillData {
+  return {
+    id: 'test-skill',
+    name: 'Test Skill',
+    description: 'A test skill description',
+    author: 'tester',
+    category: 'testing',
+    trustTier: 'verified',
+    score: 85,
+    version: undefined,
+    tags: undefined,
+    installCommand: undefined,
+    scoreBreakdown: undefined,
+    ...overrides,
+  }
+}
+
+describe('getAdvisoriesHtml (SMI-5317)', () => {
+  it('renders the section with an escaped title, severity badge, and aria-live', () => {
+    const html = getAdvisoriesHtml([adv()], false)
+    expect(html).toContain('Security Advisories')
+    expect(html).toContain('aria-live="polite"')
+    expect(html).toContain('badge-sev-high')
+    expect(html).toContain('HIGH')
+    expect(html).toContain('Prompt injection in tool description')
+    expect(html).toContain('fix available')
+  })
+
+  it('escapes script tags and quotes in the title (L1)', () => {
+    const html = getAdvisoriesHtml([adv({ title: '<script>alert("xss")</script>' })], false)
+    expect(html).toContain('&lt;script&gt;')
+    expect(html).not.toContain('<script>alert')
+  })
+
+  it('maps an out-of-whitelist severity to the low badge class (L1)', () => {
+    const html = getAdvisoriesHtml(
+      [adv({ severity: 'evil' as unknown as McpAdvisory['severity'] })],
+      false
+    )
+    expect(html).toContain('badge-sev-low')
+    expect(html).not.toContain('badge-sev-evil')
+  })
+
+  it('omits the fix marker when fixAvailable is false', () => {
+    expect(getAdvisoriesHtml([adv({ fixAvailable: false })], false)).not.toContain('fix available')
+  })
+
+  it('renders the quiet upsell line (no link) when tierDenied and no advisories', () => {
+    const html = getAdvisoriesHtml(null, true)
+    expect(html).toContain('advisory-upsell')
+    expect(html).toContain('Security advisories are available on the Team plan.')
+    expect(html).not.toContain('<a ')
+  })
+
+  it('returns empty string when neither advisories nor tierDenied', () => {
+    expect(getAdvisoriesHtml(null, false)).toBe('')
+    expect(getAdvisoriesHtml([], false)).toBe('')
+  })
+
+  it('integrates into the full panel via getSkillDetailHtml', () => {
+    const html = getSkillDetailHtml(
+      makeSkill(),
+      NONCE,
+      CSP,
+      false,
+      { installed: false },
+      {
+        advisories: [adv()],
+        tierDenied: false,
+      }
+    )
+    expect(html).toContain('Security Advisories')
+  })
+})

--- a/packages/vscode-extension/src/__tests__/skill-panel-html.test.ts
+++ b/packages/vscode-extension/src/__tests__/skill-panel-html.test.ts
@@ -364,6 +364,8 @@ describe('getTrustBadgeText', () => {
 })
 
 // Security scan tests live in skill-panel-security.test.ts (SMI-4240 file-size split).
+// Advisory-section tests (getAdvisoriesHtml, SMI-5317) live in
+// skill-panel-advisories.test.ts — same 500-line-gate split precedent.
 
 describe('getLoadingHtml', () => {
   it('returns loading spinner HTML with CSP', () => {

--- a/packages/vscode-extension/src/__tests__/skill-panel-security.test.ts
+++ b/packages/vscode-extension/src/__tests__/skill-panel-security.test.ts
@@ -110,3 +110,55 @@ describe('security scan rendering (SMI-3857/3858)', () => {
     expect(html).not.toContain('<span class="scan-date">')
   })
 })
+
+describe('findingsCount rendering (SMI-5317 / H1)', () => {
+  it('appends a pluralized count on FAIL with findingsCount > 1', () => {
+    const html = getSkillDetailHtml(
+      makeSkill({ securityPassed: false, securityFindingsCount: 3 }),
+      NONCE,
+      CSP
+    )
+    expect(html).toContain('3 findings')
+  })
+
+  it('uses the singular "finding" on FAIL with findingsCount === 1', () => {
+    const html = getSkillDetailHtml(
+      makeSkill({ securityPassed: false, securityFindingsCount: 1 }),
+      NONCE,
+      CSP
+    )
+    expect(html).toContain('1 finding')
+    expect(html).not.toContain('1 findings')
+  })
+
+  it('shows no count on FAIL when findingsCount is 0', () => {
+    const html = getSkillDetailHtml(
+      makeSkill({ securityPassed: false, securityFindingsCount: 0 }),
+      NONCE,
+      CSP
+    )
+    expect(html).toContain('scan-fail')
+    expect(html).not.toContain('finding')
+  })
+
+  it('shows no count on PASS even when findingsCount is present', () => {
+    const html = getSkillDetailHtml(
+      makeSkill({ securityPassed: true, securityFindingsCount: 5 }),
+      NONCE,
+      CSP
+    )
+    expect(html).toContain('scan-pass')
+    expect(html).not.toContain('5 finding')
+    expect(html).not.toContain('finding')
+  })
+
+  it('shows no count when Pending (securityPassed null)', () => {
+    const html = getSkillDetailHtml(
+      makeSkill({ securityPassed: null, securityFindingsCount: 4 }),
+      NONCE,
+      CSP
+    )
+    expect(html).toContain('scan-none')
+    expect(html).not.toContain('finding')
+  })
+})

--- a/packages/vscode-extension/src/mcp/McpClient.ts
+++ b/packages/vscode-extension/src/mcp/McpClient.ts
@@ -16,6 +16,7 @@ import {
   type McpRecommendResponse,
   type McpCompareResponse,
   type McpSkillDiffResponse,
+  type McpSkillAuditResponse,
   DEFAULT_MCP_CONFIG,
 } from './types.js'
 import { callMcpTool } from './callTool.js'
@@ -420,6 +421,15 @@ export class McpClient {
     trustTier?: 'verified' | 'community' | 'experimental'
   }): Promise<McpSkillDiffResponse> {
     return this.callTool<McpSkillDiffResponse>('skill_diff', args)
+  }
+
+  /**
+   * Published security advisories for skills (SMI-5317 / #1458). Tier-gated to
+   * Team+ (`skill_security_audit`); a denial surfaces as `McpToolError` code
+   * `TierDenied`. Omit `skillIds` to audit all skills with active advisories.
+   */
+  async skillAudit(args: { skillIds?: string[] } = {}): Promise<McpSkillAuditResponse> {
+    return this.callTool<McpSkillAuditResponse>('skill_audit', args)
   }
 
   /**

--- a/packages/vscode-extension/src/mcp/types.ts
+++ b/packages/vscode-extension/src/mcp/types.ts
@@ -222,6 +222,30 @@ export interface McpSkillDiffResponse {
 }
 
 /**
+ * A published security advisory for a skill (SMI-5317 / #1458). CVE-style — note
+ * there is no per-finding `message`/`line` (that shape lives on the install
+ * response's McpSecurityReport, not on skill_audit).
+ */
+export interface McpAdvisory {
+  skillName: string
+  severity: 'critical' | 'high' | 'medium' | 'low'
+  title: string
+  id: string
+  fixAvailable: boolean
+}
+
+/**
+ * Response from the MCP skill_audit tool (SMI-5317 / #1458). Team+ gated.
+ * `summary`/`advisories` are present only when `advisoriesAvailable` is true.
+ */
+export interface McpSkillAuditResponse {
+  advisoriesAvailable: boolean
+  message?: string
+  summary?: { critical: number; high: number; medium: number; low: number; total: number }
+  advisories?: McpAdvisory[]
+}
+
+/**
  * MCP connection status
  */
 export type McpConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error'

--- a/packages/vscode-extension/src/services/SkillService.ts
+++ b/packages/vscode-extension/src/services/SkillService.ts
@@ -226,6 +226,8 @@ export function mapSkillDetailsToExtendedSkillData(
     securityPassed: s.security?.passed ?? null,
     securityRiskScore: s.security?.riskScore ?? null,
     securityScannedAt: s.security?.scannedAt ?? null,
+    // SMI-5317: thread the finding count (dropped before); null when no security info.
+    securityFindingsCount: s.security?.findingsCount ?? null,
   }
   if (s.repository !== undefined) {
     result.repository = s.repository

--- a/packages/vscode-extension/src/services/Telemetry.ts
+++ b/packages/vscode-extension/src/services/Telemetry.ts
@@ -26,6 +26,9 @@ export type TelemetryEvent =
   | 'vscode_compare_complete'
   | 'vscode_diff_start'
   | 'vscode_diff_complete'
+  // SMI-5317 (Epic D / PR-D2): detail-panel security advisories (skill_audit).
+  | 'vscode_advisories_shown'
+  | 'vscode_advisories_tier_denied'
 
 // No hardcoded endpoint — telemetry is disabled by default at runtime
 // unless `skillsmith.telemetryEndpoint` is set or the production endpoint

--- a/packages/vscode-extension/src/types/skill.ts
+++ b/packages/vscode-extension/src/types/skill.ts
@@ -38,4 +38,6 @@ export interface ExtendedSkillData extends SkillData {
   securityRiskScore?: number | null | undefined
   /** SMI-3858: When the skill was last scanned */
   securityScannedAt?: string | null | undefined
+  /** SMI-5317: Scan finding count (null = no security info). Count only — the findings list is not on get_skill (see SMI-5324). */
+  securityFindingsCount?: number | null | undefined
 }

--- a/packages/vscode-extension/src/views/SkillDetailPanel.ts
+++ b/packages/vscode-extension/src/views/SkillDetailPanel.ts
@@ -264,9 +264,11 @@ export class SkillDetailPanel {
     const loadingNonce = this._getNonce()
     this._panel.webview.html = getLoadingHtml(loadingNonce, getSkillDetailCsp(loadingNonce))
     this._showFullContent = false
-    // SMI-5317: clear stale advisory state before the new load (C1).
+    // SMI-5317: clear stale advisory state before the new load (C1). Reflect a
+    // prior session tier-denial immediately (M2) so the upsell line persists on
+    // every gated panel without re-calling the Team-gated tool.
     this._advisories = null
-    this._advisoryTierDenied = false
+    this._advisoryTierDenied = SkillDetailPanel._advisoryTierDeniedSession
 
     if (!SkillDetailPanel._skillService) {
       const nonce = this._getNonce()
@@ -333,19 +335,28 @@ export class SkillDetailPanel {
         return
       }
       // M3: defensive normalized filter (the server already filters by skillIds).
+      // H1: skillName is untrusted JSON-RPC data — guard the shape before
+      // skillComparisonKey() (which calls .split) so a malformed row can't throw.
       const key = skillComparisonKey(skillId)
-      const list = (r.advisories ?? []).filter((a) => skillComparisonKey(a.skillName) === key)
+      const list = (r.advisories ?? []).filter(
+        (a) => typeof a.skillName === 'string' && skillComparisonKey(a.skillName) === key
+      )
       this._advisories = list
       if (list.length > 0) {
         track('vscode_advisories_shown', { count: list.length, surface: 'detail-panel' })
       }
       this._update()
     } catch (err) {
+      const denied = err instanceof McpToolError && err.code === 'TierDenied'
+      // M1: tier denial is account-global — record it even if we've navigated
+      // away, so the next panel skips the wasted gated call.
+      if (denied) {
+        SkillDetailPanel._advisoryTierDeniedSession = true
+      }
       if (this._disposed || this._skillId !== skillId) {
         return
       }
-      if (err instanceof McpToolError && err.code === 'TierDenied') {
-        SkillDetailPanel._advisoryTierDeniedSession = true
+      if (denied) {
         this._advisoryTierDenied = true
         track('vscode_advisories_tier_denied', { surface: 'detail-panel' })
         this._update()

--- a/packages/vscode-extension/src/views/SkillDetailPanel.ts
+++ b/packages/vscode-extension/src/views/SkillDetailPanel.ts
@@ -15,6 +15,9 @@ import type {
 import { skillComparisonKey } from '../utils/skillId.js'
 import { uninstallByTarget } from '../commands/uninstallCommand.js'
 import { track } from '../services/Telemetry.js'
+import { getMcpClient } from '../mcp/McpClient.js'
+import { McpToolError } from '../mcp/McpToolError.js'
+import type { McpAdvisory } from '../mcp/types.js'
 import {
   getLoadingHtml,
   getSkillDetailHtml,
@@ -47,6 +50,18 @@ export class SkillDetailPanel {
   private _skillPath: string | undefined
   private _hasSkillMd = false
 
+  /**
+   * SMI-5317: lazily-loaded Team-gated security advisories. `_advisories` is the
+   * filtered list once `skill_audit` resolves; `_advisoryTierDenied` flips when
+   * a free/Individual user hits the Team gate (drives the quiet inline upsell).
+   * `_disposed` guards against writes after the panel is closed (C2). The static
+   * session flag (M1) skips the wasted Team-gated call after the first denial.
+   */
+  private _advisories: McpAdvisory[] | null = null
+  private _advisoryTierDenied = false
+  private _disposed = false
+  private static _advisoryTierDeniedSession = false
+
   /** Set the shared SkillService instance (called once at activation) */
   public static setSkillService(service: SkillService): void {
     SkillDetailPanel._skillService = service
@@ -66,6 +81,7 @@ export class SkillDetailPanel {
   public static resetForTests(): void {
     SkillDetailPanel._skillService = undefined as unknown as SkillService
     SkillDetailPanel._treeProvider = undefined
+    SkillDetailPanel._advisoryTierDeniedSession = false
   }
 
   public static createOrShow(extensionUri: vscode.Uri, skillId: string) {
@@ -123,6 +139,7 @@ export class SkillDetailPanel {
 
   public dispose() {
     SkillDetailPanel.currentPanel = undefined
+    this._disposed = true
 
     this._panel.dispose()
 
@@ -247,6 +264,9 @@ export class SkillDetailPanel {
     const loadingNonce = this._getNonce()
     this._panel.webview.html = getLoadingHtml(loadingNonce, getSkillDetailCsp(loadingNonce))
     this._showFullContent = false
+    // SMI-5317: clear stale advisory state before the new load (C1).
+    this._advisories = null
+    this._advisoryTierDenied = false
 
     if (!SkillDetailPanel._skillService) {
       const nonce = this._getNonce()
@@ -263,6 +283,9 @@ export class SkillDetailPanel {
       this._skillData = skill
       this._resolveInstalledState()
       this._update()
+      // SMI-5317: lazily auto-load Team-gated advisories; never block the base
+      // panel render on the gated call (it throws TierDenied for free users).
+      void this._loadAdvisories(this._skillId)
     } catch (error) {
       const rawMessage = error instanceof Error ? error.message : String(error)
       const userMessage = mapErrorToUserMessage(rawMessage)
@@ -288,7 +311,54 @@ export class SkillDetailPanel {
     this._hasSkillMd = local?.hasSkillMd ?? false
   }
 
+  /**
+   * SMI-5317: lazily fetch Team-gated security advisories for the viewed skill
+   * and re-render. Passive and non-modal — a free user sees a single quiet
+   * upsell line, never a billing modal. Guards (C1/C2): the captured `skillId`
+   * must still match `this._skillId` and the panel must not be disposed before
+   * any state mutation. M1: skip entirely once the session has seen a denial.
+   */
+  private async _loadAdvisories(skillId: string): Promise<void> {
+    if (SkillDetailPanel._advisoryTierDeniedSession) {
+      return
+    }
+    const client = getMcpClient()
+    if (!client.isConnected()) {
+      return
+    }
+    try {
+      const r = await client.skillAudit({ skillIds: [skillId] })
+      // C1 (stale-skill) + C2 (dispose): bail before mutating if context moved on.
+      if (this._disposed || this._skillId !== skillId) {
+        return
+      }
+      // M3: defensive normalized filter (the server already filters by skillIds).
+      const key = skillComparisonKey(skillId)
+      const list = (r.advisories ?? []).filter((a) => skillComparisonKey(a.skillName) === key)
+      this._advisories = list
+      if (list.length > 0) {
+        track('vscode_advisories_shown', { count: list.length, surface: 'detail-panel' })
+      }
+      this._update()
+    } catch (err) {
+      if (this._disposed || this._skillId !== skillId) {
+        return
+      }
+      if (err instanceof McpToolError && err.code === 'TierDenied') {
+        SkillDetailPanel._advisoryTierDeniedSession = true
+        this._advisoryTierDenied = true
+        track('vscode_advisories_tier_denied', { surface: 'detail-panel' })
+        this._update()
+      }
+      // Other errors: silently leave _advisories null (no modal — passive load).
+    }
+  }
+
   private _update() {
+    // C2: never touch the webview after the panel is disposed.
+    if (this._disposed) {
+      return
+    }
     if (!this._skillData) {
       return
     }
@@ -337,6 +407,9 @@ export class SkillDetailPanel {
       hasSkillMd: this._hasSkillMd,
       ...(this._skillPath !== undefined ? { skillPath: this._skillPath } : {}),
     }
-    return getSkillDetailHtml(skill, nonce, csp, this._showFullContent, actionCtx)
+    return getSkillDetailHtml(skill, nonce, csp, this._showFullContent, actionCtx, {
+      advisories: this._advisories,
+      tierDenied: this._advisoryTierDenied,
+    })
   }
 }

--- a/packages/vscode-extension/src/views/skill-panel-html.ts
+++ b/packages/vscode-extension/src/views/skill-panel-html.ts
@@ -146,22 +146,13 @@ export function getAdvisoriesHtml(advisories: McpAdvisory[] | null, tierDenied: 
       .join('')
     return `
     <div class="section" aria-live="polite">
-        <style>
-            .advisory-row { display: flex; align-items: center; gap: 8px; padding: 4px 0; flex-wrap: wrap; }
-            .advisory-id { color: var(--vscode-descriptionForeground); font-size: 12px; }
-            .advisory-fix { color: var(--vscode-charts-green, #28a745); font-size: 12px; }
-            .badge-sev-critical { background-color: #d32f2f; color: white; }
-            .badge-sev-high { background-color: #e65100; color: white; }
-            .badge-sev-medium { background-color: #b8960a; color: white; }
-            .badge-sev-low { background-color: #6c757d; color: white; }
-        </style>
         <h2>Security Advisories</h2>${rows}
     </div>
     `
   }
   if (tierDenied) {
     return `
-    <div class="section">
+    <div class="section" aria-live="polite">
         <p class="advisory-upsell">${escapeHtml('Security advisories are available on the Team plan.')}</p>
     </div>
     `

--- a/packages/vscode-extension/src/views/skill-panel-html.ts
+++ b/packages/vscode-extension/src/views/skill-panel-html.ts
@@ -87,6 +87,12 @@ function getSecurityScanHtml(skill: ExtendedSkillData): string {
     statusClass = 'scan-pass'
   } else if (passed === false) {
     statusText = risk != null ? `FAIL (risk: ${risk}/100)` : 'FAIL'
+    // SMI-5317: append the finding count only on FAIL with >0 findings (count
+    // only — the findings list is not on get_skill, see SMI-5324).
+    const n = skill.securityFindingsCount
+    if (typeof n === 'number' && n > 0) {
+      statusText += ` · ${n} finding${n === 1 ? '' : 's'}`
+    }
     statusClass = 'scan-fail'
   } else {
     // passed === null || undefined: no scan result available.

--- a/packages/vscode-extension/src/views/skill-panel-html.ts
+++ b/packages/vscode-extension/src/views/skill-panel-html.ts
@@ -4,6 +4,7 @@
 
 import { escapeHtml } from '../utils/security.js'
 import { getSkillDetailCsp } from '../utils/csp.js'
+import type { McpAdvisory } from '../mcp/types.js'
 import type { ExtendedSkillData, ScoreBreakdown, SkillActionContext } from './skill-panel-types.js'
 import { getContentHtml, renderMarkdown } from './skill-panel-content.js'
 import { inferRepositoryUrl } from './skill-panel-helpers.js'
@@ -113,6 +114,61 @@ function getSecurityScanHtml(skill: ExtendedSkillData): string {
             </div>`
 }
 
+/** Severity values that map to a known `.badge-sev-*` class (L1 whitelist). */
+const ADVISORY_SEVERITIES = ['critical', 'high', 'medium', 'low'] as const
+
+/**
+ * SMI-5317: Generate the lazily-loaded "Security Advisories" section from
+ * Team-gated `skill_audit` advisories. Returns `''` when there is nothing to
+ * show so the caller can place it unconditionally (M4).
+ *
+ * Security (L1): every untrusted field is escaped via `escapeHtml`, and the
+ * severity is mapped to a CSS class through a whitelist — never interpolated
+ * raw. The section is `aria-live="polite"` (L2) since it arrives after the
+ * base panel render, and severity is rendered as visible text (not color-only).
+ */
+export function getAdvisoriesHtml(advisories: McpAdvisory[] | null, tierDenied: boolean): string {
+  if (advisories && advisories.length > 0) {
+    const rows = advisories
+      .map((a) => {
+        const sev = ADVISORY_SEVERITIES.includes(a.severity) ? a.severity : 'low'
+        const sevLabel = escapeHtml(sev.toUpperCase())
+        const title = escapeHtml(a.title)
+        const id = escapeHtml(a.id)
+        const fixMarker = a.fixAvailable ? ' <span class="advisory-fix">fix available</span>' : ''
+        return `
+            <div class="advisory-row">
+                <span class="badge badge-sev-${sev}">${sevLabel}</span>
+                <span class="advisory-title">${title}</span>
+                <span class="advisory-id">${id}</span>${fixMarker}
+            </div>`
+      })
+      .join('')
+    return `
+    <div class="section" aria-live="polite">
+        <style>
+            .advisory-row { display: flex; align-items: center; gap: 8px; padding: 4px 0; flex-wrap: wrap; }
+            .advisory-id { color: var(--vscode-descriptionForeground); font-size: 12px; }
+            .advisory-fix { color: var(--vscode-charts-green, #28a745); font-size: 12px; }
+            .badge-sev-critical { background-color: #d32f2f; color: white; }
+            .badge-sev-high { background-color: #e65100; color: white; }
+            .badge-sev-medium { background-color: #b8960a; color: white; }
+            .badge-sev-low { background-color: #6c757d; color: white; }
+        </style>
+        <h2>Security Advisories</h2>${rows}
+    </div>
+    `
+  }
+  if (tierDenied) {
+    return `
+    <div class="section">
+        <p class="advisory-upsell">${escapeHtml('Security advisories are available on the Team plan.')}</p>
+    </div>
+    `
+  }
+  return ''
+}
+
 /**
  * Generate the score breakdown section HTML
  */
@@ -159,7 +215,11 @@ export function getSkillDetailHtml(
   nonce: string,
   csp: string,
   showFullContent = false,
-  actionCtx: SkillActionContext = { installed: false }
+  actionCtx: SkillActionContext = { installed: false },
+  advisoryCtx: { advisories: McpAdvisory[] | null; tierDenied: boolean } = {
+    advisories: null,
+    tierDenied: false,
+  }
 ): string {
   // Escape all user-controlled content to prevent XSS
   const safeName = escapeHtml(skill.name)
@@ -238,6 +298,8 @@ export function getSkillDetailHtml(
             ${getSecurityScanHtml(skill)}
         </div>
     </div>
+
+    ${getAdvisoriesHtml(advisoryCtx.advisories, advisoryCtx.tierDenied)}
 
     ${scoreBreakdown ? getScoreBreakdownHtml(scoreBreakdown) : ''}
 

--- a/packages/vscode-extension/src/views/skill-panel-styles.ts
+++ b/packages/vscode-extension/src/views/skill-panel-styles.ts
@@ -191,6 +191,15 @@ export function getStyles(): string {
             color: var(--vscode-descriptionForeground);
             margin-left: 8px;
         }
+        /* SMI-5317: security advisories section */
+        .advisory-row { display: flex; align-items: center; gap: 8px; padding: 4px 0; flex-wrap: wrap; }
+        .advisory-id { color: var(--vscode-descriptionForeground); font-size: 12px; }
+        .advisory-fix { color: var(--vscode-charts-green, #28a745); font-size: 12px; }
+        .advisory-upsell { color: var(--vscode-descriptionForeground); font-size: 13px; }
+        .badge-sev-critical { background-color: #d32f2f; color: white; }
+        .badge-sev-high { background-color: #e65100; color: white; }
+        .badge-sev-medium { background-color: #b8960a; color: white; }
+        .badge-sev-low { background-color: #6c757d; color: white; }
         ${getContentStyles()}
     `
 }


### PR DESCRIPTION
Epic D / PR-D2 of the VS Code UX overhaul (parent SMI-5287). Host-only (ADR-113). Ships **unreleased** → batches into **0.6.0** at the end of Epic D.

## What this adds (#1458)
A standalone design pass found the original "rich per-file scan findings (severity/message/line)" data is **not reachable** from the detail panel (it lives only on the install response, not `get_skill` or `skill_audit`). Owner chose to ship what *is* reachable:

- **Finding count** in the security cell — threads `get_skill`'s `findingsCount` through (was dropped); shows "FAIL · N findings" (count only).
- **Security Advisories section** (Team+) — lazily auto-loads `skill_audit` on panel open (non-blocking, non-modal). Renders published advisories (severity badge, title, fix-available); a subtle one-line upsell on tier denial.

## Design + safety
- Lazy load with stale-skill + dispose guards (no write-after-dispose, no cross-skill bleed); account-global tier-denial cached per session (no repeated wasted Team calls); normalized + shape-guarded advisory filter.
- All advisory fields `escapeHtml`'d; severity→CSS via whitelist; `aria-live` section; styles in `getStyles()` (no per-render inline `<style>`).
- Telemetry: `vscode_advisories_shown` (only when advisories render) + `vscode_advisories_tier_denied`.

## Deferred (filed)
- Per-file scan findings in the panel needs a `get_skill` server change → **SMI-5324**.

## Verification
typecheck ✓ · lint (0 warnings) ✓ · **617 tests pass** · `package:check` ✓ · `audit:standards` 0-failed. Standalone design pass + plan-review (2 Crit + 3 High folded pre-code); `/governance` clean (H1/M1/M2/L1/L3 fixed in-PR). Every file <500.

[skip-smoke]