### PR TITLE
feat(vscode): Audit Skill Inventory command + webview report (SMI-5318)

### DIFF
--- a/.claude/development/mcp-tools-guide.md
+++ b/.claude/development/mcp-tools-guide.md
@@ -42,7 +42,7 @@ New tools use `skill_` prefix; legacy tools (`search`, `get_skill`) lack it.
 
 ## VS Code Extension Surface
 
-The `skill_recommend`, `skill_compare`, and `skill_diff` MCP tools are surfaced in the VS Code extension as commands: **Recommend Skills**, **Compare Skills**, and **Check Skill for Updates** (the latter requires Individual plan or higher). The `skill_audit` tool is surfaced in the skill detail panel as a **Security Advisories** section (Team plan or higher).
+The `skill_recommend`, `skill_compare`, and `skill_diff` MCP tools are surfaced in the VS Code extension as commands: **Recommend Skills**, **Compare Skills**, and **Check Skill for Updates** (the latter requires Individual plan or higher). The `skill_audit` tool is surfaced in the skill detail panel as a **Security Advisories** section (Team plan or higher). The `skill_inventory_audit` tool is surfaced as the **Audit Skill Inventory** command (read-only collision report; ungated).
 
 ## CLI
 

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Compare Skills command** — side-by-side comparison of two skills in a panel (quality, trust tier, key differences, and a recommendation).
 - **Check Skill for Updates command** — compares an installed skill against the latest registry version and advises whether to update (Individual plan or higher).
 - **Security advisories** — the skill detail panel now shows published security advisories for a skill (Team plan or higher), plus a finding count on failed scans.
+- **Audit Skill Inventory** command — scans your local `~/.claude/` skills, commands, and agents for namespace collisions and shows a report with suggested renames.
 
 ### Changed
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -18,6 +18,7 @@ Discover, search, and install agent skills directly in VS Code. Works with any M
 | Recommend Skills | Contextual skill recommendations based on your installed skills, surfaced in a quick pick |
 | Compare Skills | Side-by-side comparison of two skills in a panel with quality, trust tier, key differences, and a recommendation |
 | Check for Updates | Compares an installed skill against the latest registry version and advises whether to update (Individual plan or higher) |
+| Audit Skill Inventory | Scans your local `~/.claude/` for namespace collisions and shows a report with suggested renames |
 | MCP Integration | Live data from the Skillsmith API via Model Context Protocol |
 | Offline Fallback | Works offline with cached local skill data |
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -112,6 +112,12 @@
         "title": "Check Skill for Updates (Individual+)",
         "category": "Skillsmith",
         "icon": "$(versions)"
+      },
+      {
+        "command": "skillsmith.auditInventory",
+        "title": "Audit Skill Inventory",
+        "category": "Skillsmith",
+        "icon": "$(search)"
       }
     ],
     "keybindings": [

--- a/packages/vscode-extension/src/__tests__/auditInventory.test.ts
+++ b/packages/vscode-extension/src/__tests__/auditInventory.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for auditInventoryCommand.ts (SMI-5318 / Epic D / PR-D3).
+ *
+ * Covers: not-connected guard, connected + populated, connected + clean (totalFlags:0),
+ * cancellation, and unexpected error from skillInventoryAudit.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Token ref shared by the withProgress mock and per-test overrides ──────────
+// Must be a stable object reference so the hoisted fn can read it at call time.
+const tokenRef = vi.hoisted(() => ({ isCancellationRequested: false }))
+
+// ── hoisted spies (needed inside vi.mock factories) ───────────────────────────
+const showInformationMessage = vi.hoisted(() => vi.fn())
+const showErrorMessage = vi.hoisted(() => vi.fn())
+const track = vi.hoisted(() => vi.fn())
+const mcpIsConnected = vi.hoisted(() => vi.fn(() => true))
+const mcpSkillInventoryAudit = vi.hoisted(() => vi.fn())
+const inventoryAuditCreateOrShow = vi.hoisted(() => vi.fn())
+const withProgress = vi.hoisted(() =>
+  vi.fn(async (_opts: unknown, task: (p: unknown, t: unknown) => Promise<unknown>) => {
+    return task({ report: vi.fn() }, tokenRef)
+  })
+)
+
+// ── vscode mock ───────────────────────────────────────────────────────────────
+vi.mock('vscode', () => ({
+  window: {
+    showInformationMessage,
+    showErrorMessage,
+    withProgress,
+  },
+  commands: { registerCommand: vi.fn(), executeCommand: vi.fn() },
+  workspace: {
+    getConfiguration: vi.fn(() => ({ get: () => undefined })),
+  },
+  Uri: {
+    file: (s: string) => ({ toString: () => s, fsPath: s }),
+    parse: (s: string) => ({ toString: () => s }),
+  },
+  ProgressLocation: { Window: 10 },
+  ViewColumn: { One: 1 },
+  Disposable: class {
+    dispose = vi.fn()
+  },
+  env: { openExternal: vi.fn(), isTelemetryEnabled: true },
+}))
+
+// ── Telemetry mock ────────────────────────────────────────────────────────────
+vi.mock('../services/Telemetry.js', () => ({ track }))
+
+// ── MCP Client mock ───────────────────────────────────────────────────────────
+vi.mock('../mcp/McpClient.js', () => ({
+  getMcpClient: () => ({
+    isConnected: mcpIsConnected,
+    skillInventoryAudit: mcpSkillInventoryAudit,
+  }),
+}))
+
+// ── InventoryAuditPanel mock ──────────────────────────────────────────────────
+vi.mock('../views/InventoryAuditPanel.js', () => ({
+  InventoryAuditPanel: { createOrShow: inventoryAuditCreateOrShow },
+}))
+
+// ── SUT ───────────────────────────────────────────────────────────────────────
+import { auditInventoryCommandAction } from '../commands/auditInventoryCommand.js'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const BASE_ENTRY = {
+  kind: 'skill' as const,
+  source_path: '/home/u/.claude/skills/org/foo',
+  identifier: 'org/foo',
+  triggerSurface: [],
+}
+
+function makeResponse(
+  overrides: Partial<{
+    totalFlags: number
+    errorCount: number
+    warningCount: number
+    totalEntries: number
+  }> = {}
+) {
+  const { totalFlags = 2, errorCount = 1, warningCount = 1, totalEntries = 2 } = overrides
+  return {
+    auditId: 'aud_test',
+    inventory: [BASE_ENTRY],
+    exactCollisions: [
+      {
+        kind: 'exact' as const,
+        collisionId: 'c1',
+        identifier: 'org/foo',
+        entries: [BASE_ENTRY],
+        severity: 'error' as const,
+        reason: 'duplicate identifier',
+      },
+    ],
+    semanticCollisions: [],
+    genericFlags: [],
+    renameSuggestions: [],
+    recommendedEdits: [],
+    reportPath: '/home/u/.skillsmith/audits/aud_test/report.md',
+    summary: { totalEntries, totalFlags, errorCount, warningCount, durationMs: 5 },
+  }
+}
+
+describe('auditInventoryCommand (SMI-5318)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mcpIsConnected.mockReturnValue(true)
+    // Reset the shared token so each test starts with cancellation = false.
+    tokenRef.isCancellationRequested = false
+    // Restore the default withProgress implementation after vi.clearAllMocks().
+    withProgress.mockImplementation(
+      async (_opts: unknown, task: (p: unknown, t: unknown) => Promise<unknown>) => {
+        return task({ report: vi.fn() }, tokenRef)
+      }
+    )
+  })
+
+  it('not connected: shows info message and does NOT open panel', async () => {
+    mcpIsConnected.mockReturnValue(false)
+
+    await auditInventoryCommandAction()
+
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      'Connect to the Skillsmith MCP server to audit your inventory.'
+    )
+    expect(inventoryAuditCreateOrShow).not.toHaveBeenCalled()
+  })
+
+  it('connected + populated (totalFlags>0): calls skillInventoryAudit, fires complete telemetry, opens panel', async () => {
+    const response = makeResponse({ totalFlags: 2, errorCount: 1, warningCount: 1 })
+    mcpSkillInventoryAudit.mockResolvedValue(response)
+
+    await auditInventoryCommandAction()
+
+    expect(mcpSkillInventoryAudit).toHaveBeenCalledWith({})
+    expect(track).toHaveBeenCalledWith('vscode_inventory_audit_complete', {
+      collisions: 2,
+      entries: response.summary.totalEntries,
+    })
+    expect(track).not.toHaveBeenCalledWith('vscode_inventory_audit_empty')
+    expect(inventoryAuditCreateOrShow).toHaveBeenCalledOnce()
+  })
+
+  it('connected + clean (totalFlags:0): fires empty telemetry AND still opens panel', async () => {
+    const response = makeResponse({ totalFlags: 0, errorCount: 0, warningCount: 0 })
+    mcpSkillInventoryAudit.mockResolvedValue(response)
+
+    await auditInventoryCommandAction()
+
+    expect(track).toHaveBeenCalledWith('vscode_inventory_audit_complete', {
+      collisions: 0,
+      entries: response.summary.totalEntries,
+    })
+    expect(track).toHaveBeenCalledWith('vscode_inventory_audit_empty')
+    expect(inventoryAuditCreateOrShow).toHaveBeenCalledOnce()
+  })
+
+  it('cancelled: createOrShow NOT called and complete telemetry NOT fired', async () => {
+    tokenRef.isCancellationRequested = true
+    const response = makeResponse()
+    mcpSkillInventoryAudit.mockResolvedValue(response)
+
+    await auditInventoryCommandAction()
+
+    expect(inventoryAuditCreateOrShow).not.toHaveBeenCalled()
+    expect(track).not.toHaveBeenCalledWith('vscode_inventory_audit_complete', expect.anything())
+  })
+
+  it('skillInventoryAudit throws: shows error message and does NOT unhandled-reject', async () => {
+    mcpSkillInventoryAudit.mockRejectedValue(new Error('network failure'))
+
+    await auditInventoryCommandAction()
+
+    expect(showErrorMessage).toHaveBeenCalledWith('network failure')
+    expect(inventoryAuditCreateOrShow).not.toHaveBeenCalled()
+  })
+})

--- a/packages/vscode-extension/src/__tests__/inventory-audit-panel.test.ts
+++ b/packages/vscode-extension/src/__tests__/inventory-audit-panel.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for inventory-audit-panel-html.ts and inventory-audit-sections-html.ts
+ * (SMI-5318 / Epic D / PR-D3).
+ *
+ * Pure HTML builder functions — no webview needed; just call them and assert
+ * on the returned string. No vscode import at module-load time for these modules,
+ * but we stub vscode defensively in case of transitive needs.
+ */
+import { describe, it, expect } from 'vitest'
+
+// ── vscode stub (no-op; sections/panel-html don't import vscode) ──────────────
+import { vi } from 'vitest'
+vi.mock('vscode', () => ({}))
+
+// ── SUTs ──────────────────────────────────────────────────────────────────────
+import {
+  getInventoryAuditHtml,
+  getInventoryAuditErrorHtml,
+} from '../views/inventory-audit-panel-html.js'
+import {
+  severityBadgeClass,
+  getExactCollisionsSection,
+  getSemanticSection,
+  getRenameSuggestionsSection,
+  getRecommendedEditsSection,
+} from '../views/inventory-audit-sections-html.js'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const NONCE = 'testNonce1234567890ABCD'
+
+function makeEntry(id = 'org/foo', path = '/home/u/.claude/skills/org/foo') {
+  return {
+    kind: 'skill' as const,
+    source_path: path,
+    identifier: id,
+    triggerSurface: [] as string[],
+  }
+}
+
+function makeResponse(
+  overrides: Partial<{
+    totalFlags: number
+    errorCount: number
+    warningCount: number
+    totalEntries: number
+    withCollision: boolean
+    withSemantic: boolean
+    withRename: boolean
+    withEdit: boolean
+    identifier: string
+  }> = {}
+) {
+  const {
+    totalFlags = 0,
+    errorCount = 0,
+    warningCount = 0,
+    totalEntries = 5,
+    withCollision = false,
+    withSemantic = false,
+    withRename = false,
+    withEdit = false,
+    identifier = 'org/foo',
+  } = overrides
+
+  const entryA = makeEntry(identifier)
+  const entryB = makeEntry('org/bar', '/home/u/.claude/skills/org/bar')
+
+  return {
+    auditId: 'aud_test',
+    inventory: [entryA],
+    exactCollisions: withCollision
+      ? [
+          {
+            kind: 'exact' as const,
+            collisionId: 'c1',
+            identifier,
+            entries: [entryA, entryB],
+            severity: 'error' as const,
+            reason: 'duplicate identifier found',
+          },
+        ]
+      : [],
+    semanticCollisions: withSemantic
+      ? [
+          {
+            kind: 'semantic' as const,
+            collisionId: 'c2',
+            entryA,
+            entryB,
+            cosineScore: 0.91,
+            overlappingPhrases: [
+              { phrase1: 'search files', phrase2: 'find files', similarity: 0.88 },
+            ],
+            severity: 'warning' as const,
+            reason: 'high semantic overlap',
+          },
+        ]
+      : [],
+    genericFlags: [],
+    renameSuggestions: withRename
+      ? [
+          {
+            collisionId: 'c1',
+            entry: entryA,
+            currentName: 'foo',
+            suggested: 'foo-2',
+            applyAction: 'rename_skill_dir_and_frontmatter' as const,
+            reason: 'resolves collision with org/bar',
+          },
+        ]
+      : [],
+    recommendedEdits: withEdit
+      ? [
+          {
+            collisionId: 'c1',
+            category: 'description_overlap' as const,
+            pattern: 'add_domain_qualifier' as const,
+            filePath: '/home/u/.claude/skills/org/foo/SKILL.md',
+            lineRange: { start: 1, end: 2 },
+            before: 'Searches files in the repo.',
+            after: 'Searches TypeScript files in the repo.',
+            rationale: 'Narrow scope to reduce overlap.',
+            applyAction: 'recommended_edit' as const,
+            applyMode: 'manual_review' as const,
+            otherEntry: { identifier: 'org/bar', sourcePath: '/home/u/.claude/skills/org/bar' },
+          },
+        ]
+      : [],
+    reportPath: '/home/u/.skillsmith/audits/aud_test/report.md',
+    summary: { totalEntries, totalFlags, errorCount, warningCount, durationMs: 5 },
+  }
+}
+
+// ── severityBadgeClass ────────────────────────────────────────────────────────
+describe('severityBadgeClass', () => {
+  it("maps 'error' to 'badge-error'", () => {
+    expect(severityBadgeClass('error')).toBe('badge-error')
+  })
+
+  it("maps 'warning' to 'badge-warning'", () => {
+    expect(severityBadgeClass('warning')).toBe('badge-warning')
+  })
+
+  it("maps any unknown value to 'badge-default'", () => {
+    expect(severityBadgeClass('bogus')).toBe('badge-default')
+  })
+})
+
+// ── inventory-audit HTML (SMI-5318) ───────────────────────────────────────────
+describe('inventory-audit HTML (SMI-5318)', () => {
+  it('exact-collision render: contains badge-error, escaped identifier, and section heading', () => {
+    const items = makeResponse({
+      withCollision: true,
+      totalFlags: 1,
+      errorCount: 1,
+    }).exactCollisions
+    const html = getExactCollisionsSection(items)
+
+    expect(html).toContain('badge-error')
+    expect(html).toContain('org/foo')
+    expect(html).toContain('Exact Collisions')
+  })
+
+  it('semantic render: contains badge-warning and cosine value', () => {
+    const items = makeResponse({
+      withSemantic: true,
+      totalFlags: 1,
+      warningCount: 1,
+    }).semanticCollisions
+    const html = getSemanticSection(items)
+
+    expect(html).toContain('badge-warning')
+    expect(html).toContain('0.91')
+  })
+
+  it('rename suggestion: contains currentName, suggested, and copy button with data-copy', () => {
+    const items = makeResponse({ withRename: true }).renameSuggestions
+    const html = getRenameSuggestionsSection(items)
+
+    expect(html).toContain('foo')
+    expect(html).toContain('foo-2')
+    expect(html).toContain('data-copy="foo-2"')
+  })
+
+  it('recommendedEdits: contains before/after/rationale and section heading; no Apply button', () => {
+    const items = makeResponse({ withEdit: true }).recommendedEdits
+    const html = getRecommendedEditsSection(items)
+
+    expect(html).toContain('Recommended Edits')
+    expect(html).toContain('Searches files in the repo.')
+    expect(html).toContain('Searches TypeScript files in the repo.')
+    expect(html).toContain('Narrow scope to reduce overlap.')
+    // Read-only section: no "Apply" button text inside this section
+    expect(html).not.toContain('>Apply<')
+    expect(html).not.toContain('>Apply </') // also no "Apply " prefix variant
+  })
+
+  it('XSS escape: <script> identifier is escaped, raw form absent', () => {
+    const xssId = '<script>alert(1)</script>'
+    const items = [
+      {
+        kind: 'exact' as const,
+        collisionId: 'xss1',
+        identifier: xssId,
+        entries: [makeEntry(xssId)],
+        severity: 'error' as const,
+        reason: 'dup',
+      },
+    ]
+    const html = getExactCollisionsSection(items)
+
+    expect(html).toContain('&lt;script&gt;')
+    expect(html).not.toContain('<script>alert(1)</script>')
+  })
+
+  it('clean state: contains "No namespace collisions found." and scanned-entries count', () => {
+    const response = makeResponse({ totalFlags: 0, totalEntries: 42 })
+    const html = getInventoryAuditHtml(response, NONCE)
+
+    expect(html).toContain('No namespace collisions found.')
+    expect(html).toContain('42')
+  })
+
+  it('clean state: still contains Open Full Report affordance', () => {
+    const response = makeResponse({ totalFlags: 0 })
+    const html = getInventoryAuditHtml(response, NONCE)
+
+    expect(html).toContain('Open Full Report')
+  })
+
+  it('empty section skip: exactCollisions:[] → no "Exact Collisions" heading', () => {
+    const response = makeResponse({
+      totalFlags: 1,
+      warningCount: 1,
+      withSemantic: true,
+    })
+    const html = getInventoryAuditHtml(response, NONCE)
+
+    expect(html).not.toContain('Exact Collisions')
+  })
+
+  it('error builder: getInventoryAuditErrorHtml contains message and Retry button', () => {
+    const html = getInventoryAuditErrorHtml('boom', NONCE)
+
+    expect(html).toContain('boom')
+    expect(html).toContain('Retry')
+  })
+})

--- a/packages/vscode-extension/src/__tests__/mcp/skill_inventory_audit.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/skill_inventory_audit.test.ts
@@ -1,0 +1,155 @@
+/**
+ * skill_inventory_audit is UNGATED (Community-tier) — the server never
+ * tier-denies it. The TierDenied case below only asserts that callMcpTool's
+ * classifier maps a denial-shaped isError envelope to code 'TierDenied'; the
+ * command does NOT wire handleTierDenied. (SMI-5318)
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+import { McpClient } from '../../mcp/McpClient.js'
+import { McpToolError } from '../../mcp/McpToolError.js'
+
+/** Wrap a JSON payload in the MCP tools/call success envelope. */
+function ok(payload: unknown): Record<string, unknown> {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+}
+
+/** Build an isError tools/call envelope with the given text. */
+function isErr(text: string): Record<string, unknown> {
+  return { isError: true, content: [{ type: 'text', text }] }
+}
+
+/**
+ * Returns a connected McpClient whose private `sendRequest` resolves to `raw`.
+ * Tests only — reaches into private members via an `any` cast.
+ */
+function connectedClient(raw: unknown): McpClient {
+  const client = new McpClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).status = 'connected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).sendRequest = vi.fn().mockResolvedValue(raw)
+  return client
+}
+
+const ENTRY_A = {
+  kind: 'skill' as const,
+  source_path: '/home/u/.claude/skills/org/foo',
+  identifier: 'org/foo',
+  triggerSurface: [],
+}
+
+const ENTRY_B = {
+  kind: 'skill' as const,
+  source_path: '/home/u/.claude/skills/org/bar',
+  identifier: 'org/bar',
+  triggerSurface: [],
+}
+
+const HAPPY_PAYLOAD = {
+  auditId: 'aud_1',
+  inventory: [ENTRY_A, ENTRY_B],
+  exactCollisions: [
+    {
+      kind: 'exact' as const,
+      collisionId: 'c1',
+      identifier: 'org/foo',
+      entries: [ENTRY_A, ENTRY_B],
+      severity: 'error' as const,
+      reason: 'dup',
+    },
+  ],
+  semanticCollisions: [
+    {
+      kind: 'semantic' as const,
+      collisionId: 'c2',
+      entryA: ENTRY_A,
+      entryB: ENTRY_B,
+      cosineScore: 0.91,
+      overlappingPhrases: [{ phrase1: 'a', phrase2: 'b', similarity: 0.9 }],
+      severity: 'warning' as const,
+      reason: 'overlap',
+    },
+  ],
+  genericFlags: [],
+  renameSuggestions: [
+    {
+      collisionId: 'c1',
+      entry: ENTRY_A,
+      currentName: 'foo',
+      suggested: 'foo-2',
+      applyAction: 'rename_skill_dir_and_frontmatter' as const,
+      reason: 'collision',
+    },
+  ],
+  recommendedEdits: [],
+  reportPath: '/home/u/.skillsmith/audits/aud_1/report.md',
+  summary: {
+    totalEntries: 2,
+    totalFlags: 2,
+    errorCount: 1,
+    warningCount: 1,
+    durationMs: 5,
+  },
+}
+
+describe('McpClient.skillInventoryAudit (SMI-5318)', () => {
+  it('happy path returns the typed McpInventoryAuditResponse shape', async () => {
+    const client = connectedClient(ok(HAPPY_PAYLOAD))
+
+    const result = await client.skillInventoryAudit({ deep: false })
+
+    expect(result.auditId).toBe('aud_1')
+    expect(result.exactCollisions[0]?.severity).toBe('error')
+    expect(result.semanticCollisions[0]?.cosineScore).toBe(0.91)
+    expect(result.renameSuggestions[0]?.suggested).toBe('foo-2')
+    expect(result.summary.totalFlags).toBe(2)
+    expect(result.reportPath).toMatch(/report\.md$/)
+  })
+
+  it('default args (no args) on a connected client returns the happy shape', async () => {
+    const client = connectedClient(ok(HAPPY_PAYLOAD))
+
+    // skillInventoryAudit() with no args — default param is {}
+    const result = await client.skillInventoryAudit()
+
+    expect(result.auditId).toBe('aud_1')
+    expect(result.inventory).toHaveLength(2)
+  })
+
+  it('tier-denied isError response throws McpToolError code TierDenied', async () => {
+    const client = connectedClient(
+      isErr('Inventory Audit requires Team tier. Upgrade at https://skillsmith.app/upgrade')
+    )
+    await expect(client.skillInventoryAudit()).rejects.toMatchObject({
+      name: 'McpToolError',
+      code: 'TierDenied',
+      toolName: 'skill_inventory_audit',
+    })
+  })
+
+  it('unknown-tool isError response throws McpToolError code UnknownTool', async () => {
+    const client = connectedClient(isErr('Unknown tool: skill_inventory_audit'))
+    await expect(client.skillInventoryAudit()).rejects.toMatchObject({
+      code: 'UnknownTool',
+    })
+  })
+
+  it('calling before connect throws NotConnected with the exact message', async () => {
+    const client = new McpClient()
+    await expect(client.skillInventoryAudit()).rejects.toMatchObject({
+      code: 'NotConnected',
+      message: 'MCP client not connected',
+    })
+    await expect(client.skillInventoryAudit()).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
@@ -31,6 +31,7 @@ import { createSkillAction } from '../createSkillCommand.js'
 import { recommendCommandAction } from '../recommendCommand.js'
 import { compareCommandAction } from '../compareCommand.js'
 import { diffCommandAction } from '../diffCommand.js'
+import { auditInventoryCommandAction } from '../auditInventoryCommand.js'
 import type { TelemetryEvent } from '../../services/Telemetry.js'
 
 /** Registered command id → wrapped panel action. */
@@ -44,6 +45,7 @@ const VSCODE_DISPATCHER_MAP: Record<string, (...args: never[]) => unknown> = {
   'skillsmith.recommendSkills': recommendCommandAction,
   'skillsmith.compareSkills': compareCommandAction,
   'skillsmith.diffSkill': diffCommandAction,
+  'skillsmith.auditInventory': auditInventoryCommandAction,
 }
 
 describe('SMI-5130: VS Code command telemetry coverage', () => {
@@ -71,7 +73,7 @@ describe('SMI-5130: VS Code command telemetry coverage', () => {
   it('reports VS Code dispatcher coverage to CI output', () => {
     const count = Object.keys(VSCODE_DISPATCHER_MAP).length
     console.info(`[SMI-5130] VS Code telemetry coverage: ${count} panel actions wrapped.`)
-    expect(count).toBe(9)
+    expect(count).toBe(10)
   })
 
   // SMI-5308 (M5): the detail-panel open actions are postMessage handlers, not

--- a/packages/vscode-extension/src/commands/auditInventoryCommand.ts
+++ b/packages/vscode-extension/src/commands/auditInventoryCommand.ts
@@ -1,0 +1,68 @@
+/**
+ * Audit Inventory command — audit the local `~/.claude/` inventory for
+ * namespace collisions via the ungated `skill_inventory_audit` MCP tool, then
+ * render the report in InventoryAuditPanel (SMI-5318 / Epic D / PR-D3).
+ *
+ * The tool is Community-tier and never tier-denies, so there is no
+ * `handleTierDenied` path here. Mirrors recommendCommand's command shape
+ * (track + isConnected guard + try/catch + withTelemetry export + register fn).
+ *
+ * @module commands/auditInventoryCommand
+ */
+import * as vscode from 'vscode'
+import { getMcpClient } from '../mcp/McpClient.js'
+import { withTelemetry } from '../services/telemetry-wrap.js'
+import { track } from '../services/Telemetry.js'
+import { InventoryAuditPanel } from '../views/InventoryAuditPanel.js'
+
+async function auditInventoryCommandImpl(): Promise<void> {
+  track('vscode_inventory_audit_start')
+
+  const client = getMcpClient()
+
+  if (!client.isConnected()) {
+    void vscode.window.showInformationMessage(
+      'Connect to the Skillsmith MCP server to audit your inventory.'
+    )
+    return
+  }
+
+  try {
+    await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Window, title: 'Auditing skill inventory…' },
+      async (_progress, token) => {
+        const response = await client.skillInventoryAudit({})
+        if (token.isCancellationRequested) return
+
+        const flags = response.summary.errorCount + response.summary.warningCount
+        track('vscode_inventory_audit_complete', {
+          collisions: flags,
+          entries: response.summary.totalEntries,
+        })
+        if (response.summary.totalFlags === 0) {
+          track('vscode_inventory_audit_empty')
+        }
+
+        InventoryAuditPanel.createOrShow(vscode.Uri.file(''), response)
+      }
+    )
+  } catch (err) {
+    void vscode.window.showErrorMessage(err instanceof Error ? err.message : String(err))
+  }
+}
+
+export const auditInventoryCommandAction = withTelemetry(auditInventoryCommandImpl, {
+  source: 'vscode-extension',
+  extractSkillId: () => 'inventory-audit',
+})
+
+/**
+ * Registers the Audit Inventory command (`skillsmith.auditInventory`).
+ */
+export function registerAuditInventoryCommand(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('skillsmith.auditInventory', () =>
+      auditInventoryCommandAction()
+    )
+  )
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -13,6 +13,7 @@ import { registerCreateSkillCommand } from './commands/createSkillCommand.js'
 import { registerRecommendCommand } from './commands/recommendCommand.js'
 import { registerCompareCommand } from './commands/compareCommand.js'
 import { registerDiffCommand } from './commands/diffCommand.js'
+import { registerAuditInventoryCommand } from './commands/auditInventoryCommand.js'
 import { initializeTelemetry } from './services/Telemetry.js'
 import { SkillDetailPanel } from './views/SkillDetailPanel.js'
 import { SkillService } from './services/SkillService.js'
@@ -181,6 +182,7 @@ export function activate(context: vscode.ExtensionContext): void {
   registerRecommendCommand(context)
   registerCompareCommand(context, skillService)
   registerDiffCommand(context, skillTreeDataProvider)
+  registerAuditInventoryCommand(context)
 
   // Register refresh command
   const refreshCommand = vscode.commands.registerCommand('skillsmith.refreshSkills', () => {

--- a/packages/vscode-extension/src/mcp/McpClient.ts
+++ b/packages/vscode-extension/src/mcp/McpClient.ts
@@ -17,8 +17,10 @@ import {
   type McpCompareResponse,
   type McpSkillDiffResponse,
   type McpSkillAuditResponse,
+  type McpInventoryAuditResponse,
   DEFAULT_MCP_CONFIG,
 } from './types.js'
+import type { JsonRpcRequest, JsonRpcResponse } from './jsonrpc.types.js'
 import { callMcpTool } from './callTool.js'
 
 // Re-export McpClientConfig from types for external use
@@ -26,30 +28,6 @@ export type { McpClientConfig } from './types.js'
 
 /** JSON-RPC request ID counter */
 let requestId = 0
-
-/**
- * JSON-RPC request structure
- */
-interface JsonRpcRequest {
-  jsonrpc: '2.0'
-  id: number
-  method: string
-  params: Record<string, unknown> | undefined
-}
-
-/**
- * JSON-RPC response structure
- */
-interface JsonRpcResponse {
-  jsonrpc: '2.0'
-  id: number
-  result?: unknown
-  error?: {
-    code: number
-    message: string
-    data?: unknown
-  }
-}
 
 /**
  * MCP Client for communicating with the Skillsmith MCP server
@@ -430,6 +408,22 @@ export class McpClient {
    */
   async skillAudit(args: { skillIds?: string[] } = {}): Promise<McpSkillAuditResponse> {
     return this.callTool<McpSkillAuditResponse>('skill_audit', args)
+  }
+
+  /**
+   * Audit the local `~/.claude/` inventory for namespace collisions
+   * (SMI-5318 / #1459). UNGATED — never tier-denies. `deep` (default false)
+   * gates the slower semantic-overlap pass.
+   */
+  async skillInventoryAudit(
+    args: {
+      deep?: boolean
+      homeDir?: string
+      projectDir?: string
+      applyExclusions?: boolean
+    } = {}
+  ): Promise<McpInventoryAuditResponse> {
+    return this.callTool<McpInventoryAuditResponse>('skill_inventory_audit', args)
   }
 
   /**

--- a/packages/vscode-extension/src/mcp/jsonrpc.types.ts
+++ b/packages/vscode-extension/src/mcp/jsonrpc.types.ts
@@ -1,0 +1,31 @@
+/**
+ * JSON-RPC 2.0 envelope types for the MCP stdio transport.
+ *
+ * Extracted from McpClient.ts (SMI-5318 / PR-D3) as a leaf module to keep
+ * McpClient.ts under the 500-line gate. Leaf — imports nothing from McpClient,
+ * so there is no import cycle.
+ */
+
+/**
+ * JSON-RPC request structure
+ */
+export interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  id: number
+  method: string
+  params: Record<string, unknown> | undefined
+}
+
+/**
+ * JSON-RPC response structure
+ */
+export interface JsonRpcResponse {
+  jsonrpc: '2.0'
+  id: number
+  result?: unknown
+  error?: {
+    code: number
+    message: string
+    data?: unknown
+  }
+}

--- a/packages/vscode-extension/src/mcp/types.ts
+++ b/packages/vscode-extension/src/mcp/types.ts
@@ -246,6 +246,100 @@ export interface McpSkillAuditResponse {
 }
 
 /**
+ * One entry in the local inventory scanned by skill_inventory_audit
+ * (SMI-5318 / #1459). `CollisionId`/`AuditId` are branded strings server-side;
+ * on the wire they are plain strings.
+ */
+export interface McpInventoryEntry {
+  kind: 'skill' | 'command' | 'agent' | 'claude_md_rule'
+  source_path: string
+  identifier: string
+  triggerSurface: string[]
+  mtime?: number
+  meta?: { author?: string; tags?: string[]; description?: string }
+}
+
+/** Exact identifier collision (severity always 'error'). */
+export interface McpExactCollision {
+  kind: 'exact'
+  collisionId: string
+  identifier: string
+  entries: McpInventoryEntry[]
+  severity: 'error'
+  reason: string
+}
+
+/** Semantic-overlap collision (severity always 'warning'; deep pass only). */
+export interface McpSemanticCollision {
+  kind: 'semantic'
+  collisionId: string
+  entryA: McpInventoryEntry
+  entryB: McpInventoryEntry
+  cosineScore: number
+  overlappingPhrases: Array<{ phrase1: string; phrase2: string; similarity: number }>
+  severity: 'warning'
+  reason: string
+}
+
+/** Generic-token flag (severity always 'warning'). */
+export interface McpGenericFlag {
+  kind: 'generic'
+  collisionId: string
+  identifier: string
+  entry: McpInventoryEntry
+  matchedTokens: string[]
+  severity: 'warning'
+  reason: string
+}
+
+/** A suggested rename to resolve a collision. */
+export interface McpRenameSuggestion {
+  collisionId: string
+  entry: McpInventoryEntry
+  currentName: string
+  suggested: string
+  applyAction: 'rename_command_file' | 'rename_agent_file' | 'rename_skill_dir_and_frontmatter'
+  reason: string
+}
+
+/** A suggested prose edit (rendered read-only in PR-D3; apply deferred to SMI-5325). */
+export interface McpRecommendedEdit {
+  collisionId: string
+  category: 'description_overlap' | 'claude_md_trigger_overlap'
+  pattern: 'add_domain_qualifier' | 'narrow_scope' | 'reword_trigger_verb'
+  filePath: string
+  lineRange: { start: number; end: number }
+  before: string
+  after: string
+  rationale: string
+  applyAction: 'recommended_edit'
+  applyMode: 'manual_review' | 'apply_with_confirmation'
+  otherEntry: { identifier: string; sourcePath: string }
+}
+
+/**
+ * Response from MCP skill_inventory_audit (SMI-5318 / #1459). UNGATED. The
+ * server also writes a formatted report to `reportPath`.
+ */
+export interface McpInventoryAuditResponse {
+  auditId: string
+  inventory: McpInventoryEntry[]
+  exactCollisions: McpExactCollision[]
+  genericFlags: McpGenericFlag[]
+  semanticCollisions: McpSemanticCollision[]
+  renameSuggestions: McpRenameSuggestion[]
+  recommendedEdits: McpRecommendedEdit[]
+  reportPath: string
+  summary: {
+    totalEntries: number
+    totalFlags: number
+    errorCount: number
+    warningCount: number
+    durationMs: number
+  }
+}
+
+/**
  * MCP connection status
  */
 export type McpConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error'

--- a/packages/vscode-extension/src/services/Telemetry.ts
+++ b/packages/vscode-extension/src/services/Telemetry.ts
@@ -29,6 +29,10 @@ export type TelemetryEvent =
   // SMI-5317 (Epic D / PR-D2): detail-panel security advisories (skill_audit).
   | 'vscode_advisories_shown'
   | 'vscode_advisories_tier_denied'
+  // SMI-5318 (Epic D / PR-D3): inventory audit (skill_inventory_audit).
+  | 'vscode_inventory_audit_start'
+  | 'vscode_inventory_audit_complete'
+  | 'vscode_inventory_audit_empty'
 
 // No hardcoded endpoint — telemetry is disabled by default at runtime
 // unless `skillsmith.telemetryEndpoint` is set or the production endpoint

--- a/packages/vscode-extension/src/utils/csp.ts
+++ b/packages/vscode-extension/src/utils/csp.ts
@@ -196,6 +196,17 @@ export function getSkillDiffCsp(nonce: string): string {
 }
 
 /**
+ * Gets CSP configuration for the Inventory Audit webview (SMI-5318 / GH #1459).
+ * `allowInlineStyles: true` matches the detail panel (VS Code CSS variables).
+ */
+export function getInventoryAuditCsp(nonce: string): string {
+  return buildWebviewCsp(nonce, {
+    allowInlineStyles: true,
+    allowVscodeResources: true,
+  })
+}
+
+/**
  * Validates a CSP header for common security issues
  * @param csp - The CSP header to validate
  * @returns Validation result with any warnings

--- a/packages/vscode-extension/src/views/InventoryAuditPanel.ts
+++ b/packages/vscode-extension/src/views/InventoryAuditPanel.ts
@@ -1,0 +1,165 @@
+/**
+ * Webview panel for the Skill Inventory Audit (SMI-5318 / #1459).
+ *
+ * Mirrors CompareSkillsPanel: singleton (`currentPanel`), `createOrShow`,
+ * `dispose`, `resetForTests`, CSP nonce per render, host-built HTML, the
+ * message listener wired BEFORE assigning `webview.html`. Read-only — inbound
+ * messages are `retry` (re-run the audit), `openReport` (open the formatted
+ * report file in an editor), and `copyRename` (copy a suggested name to the
+ * clipboard).
+ *
+ * The `skill_inventory_audit` MCP tool is ungated (Community tier) — there is
+ * no tier-denied handling anywhere in this panel.
+ */
+import * as vscode from 'vscode'
+import { generateCspNonce, getInventoryAuditCsp } from '../utils/csp.js'
+import { getLoadingHtml } from './skill-panel-html.js'
+import { getInventoryAuditHtml, getInventoryAuditErrorHtml } from './inventory-audit-panel-html.js'
+import { getMcpClient } from '../mcp/McpClient.js'
+import type { McpInventoryAuditResponse } from '../mcp/types.js'
+import type { InventoryAuditPanelMessage } from './inventory-audit-panel-types.js'
+
+export class InventoryAuditPanel {
+  public static currentPanel: InventoryAuditPanel | undefined
+  public static readonly viewType = 'skillsmith.inventoryAudit'
+
+  private readonly _panel: vscode.WebviewPanel
+  private _response: McpInventoryAuditResponse
+  private _disposed = false
+  private _disposables: vscode.Disposable[] = []
+
+  /** Reset the singleton between tests. */
+  public static resetForTests(): void {
+    InventoryAuditPanel.currentPanel?.dispose()
+    InventoryAuditPanel.currentPanel = undefined
+  }
+
+  public static createOrShow(_extensionUri: vscode.Uri, response: McpInventoryAuditResponse): void {
+    const column = vscode.window.activeTextEditor
+      ? vscode.window.activeTextEditor.viewColumn
+      : undefined
+
+    if (InventoryAuditPanel.currentPanel) {
+      InventoryAuditPanel.currentPanel._panel.reveal(column)
+      InventoryAuditPanel.currentPanel._response = response
+      InventoryAuditPanel.currentPanel._update()
+      return
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      InventoryAuditPanel.viewType,
+      'Skill Inventory Audit',
+      column || vscode.ViewColumn.One,
+      { enableScripts: true, retainContextWhenHidden: true }
+    )
+
+    InventoryAuditPanel.currentPanel = new InventoryAuditPanel(panel, response)
+  }
+
+  private constructor(panel: vscode.WebviewPanel, response: McpInventoryAuditResponse) {
+    this._panel = panel
+    this._response = response
+    this._panel.title = 'Skill Inventory Audit'
+
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables)
+
+    // Wire the message listener BEFORE assigning webview.html.
+    this._panel.webview.onDidReceiveMessage(
+      (message: InventoryAuditPanelMessage) => {
+        this._handleMessage(message)
+      },
+      null,
+      this._disposables
+    )
+
+    this._update()
+  }
+
+  public dispose(): void {
+    this._disposed = true
+    InventoryAuditPanel.currentPanel = undefined
+    this._panel.dispose()
+    while (this._disposables.length) {
+      const x = this._disposables.pop()
+      if (x) {
+        x.dispose()
+      }
+    }
+  }
+
+  private _handleMessage(message: InventoryAuditPanelMessage): void {
+    if (message.command === 'retry') {
+      void this._retry()
+    } else if (message.command === 'openReport') {
+      void this._openReport()
+    } else if (message.command === 'copyRename') {
+      void this._copyRename(message.text)
+    }
+  }
+
+  /**
+   * Re-run the inventory audit. Shows a loading state, then re-renders on
+   * success. The tool is ungated, so any error renders the error page (no
+   * tier-denied handling).
+   */
+  private async _retry(): Promise<void> {
+    const nonce = generateCspNonce()
+    this._panel.webview.html = getLoadingHtml(nonce, getInventoryAuditCsp(nonce))
+
+    const client = getMcpClient()
+    if (!client.isConnected()) {
+      const errNonce = generateCspNonce()
+      this._panel.webview.html = getInventoryAuditErrorHtml(
+        'Skillsmith server is not connected. Start the MCP server and try again.',
+        errNonce
+      )
+      return
+    }
+
+    try {
+      const response = await client.skillInventoryAudit({})
+      if (this._disposed) return
+      this._response = response
+      this._update()
+    } catch (err) {
+      if (this._disposed) return
+      const raw = err instanceof Error ? err.message : String(err)
+      const errNonce = generateCspNonce()
+      this._panel.webview.html = getInventoryAuditErrorHtml(
+        'Could not audit your inventory. Please try again.',
+        errNonce,
+        raw
+      )
+    }
+  }
+
+  /** Open the formatted audit report file in an editor tab. */
+  private async _openReport(): Promise<void> {
+    if (this._disposed) return
+    const reportPath = this._response.reportPath
+    if (typeof reportPath !== 'string' || reportPath.length === 0) {
+      void vscode.window.showErrorMessage('No audit report is available.')
+      return
+    }
+    try {
+      const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(reportPath))
+      if (this._disposed) return
+      await vscode.window.showTextDocument(doc)
+    } catch {
+      void vscode.window.showErrorMessage('Could not open the audit report.')
+    }
+  }
+
+  /** Copy a suggested rename to the clipboard. */
+  private async _copyRename(text: string): Promise<void> {
+    if (typeof text !== 'string') return
+    await vscode.env.clipboard.writeText(text)
+    void vscode.window.showInformationMessage('Copied: ' + text)
+  }
+
+  private _update(): void {
+    if (this._disposed) return
+    const nonce = generateCspNonce()
+    this._panel.webview.html = getInventoryAuditHtml(this._response, nonce)
+  }
+}

--- a/packages/vscode-extension/src/views/InventoryAuditPanel.ts
+++ b/packages/vscode-extension/src/views/InventoryAuditPanel.ts
@@ -103,6 +103,7 @@ export class InventoryAuditPanel {
    * tier-denied handling).
    */
   private async _retry(): Promise<void> {
+    if (this._disposed) return
     const nonce = generateCspNonce()
     this._panel.webview.html = getLoadingHtml(nonce, getInventoryAuditCsp(nonce))
 
@@ -152,9 +153,10 @@ export class InventoryAuditPanel {
 
   /** Copy a suggested rename to the clipboard. */
   private async _copyRename(text: string): Promise<void> {
+    if (this._disposed) return
     if (typeof text !== 'string') return
     await vscode.env.clipboard.writeText(text)
-    void vscode.window.showInformationMessage('Copied: ' + text)
+    void vscode.window.showInformationMessage(`Copied: ${text}`)
   }
 
   private _update(): void {

--- a/packages/vscode-extension/src/views/inventory-audit-panel-html.ts
+++ b/packages/vscode-extension/src/views/inventory-audit-panel-html.ts
@@ -1,0 +1,206 @@
+/**
+ * HTML generation for the Skill Inventory Audit panel (SMI-5318 / #1459).
+ *
+ * Host-builds all HTML, escaping every untrusted field. Reuses the compare
+ * panel's `.badge` / `.section` / `.tag` CSS vocabulary plus three severity
+ * badge classes. The per-section renderers live in
+ * `inventory-audit-sections-html.ts` to keep this file under the 500-line cap.
+ *
+ * The webview is read-only: inbound messages are `retry`, `openReport`, and
+ * `copyRename` (copy a suggested name). The inventory audit tool is ungated —
+ * there is no tier-denied path here.
+ */
+
+import { escapeHtml } from '../utils/security.js'
+import { getInventoryAuditCsp } from '../utils/csp.js'
+import type { McpInventoryAuditResponse } from '../mcp/types.js'
+import {
+  getExactCollisionsSection,
+  getGenericFlagsSection,
+  getRecommendedEditsSection,
+  getRenameSuggestionsSection,
+  getSemanticSection,
+  getSummarySection,
+} from './inventory-audit-sections-html.js'
+
+/** Styles for the inventory-audit panel — VS Code CSS variables + severity badges. */
+function getStyles(): string {
+  return `
+    body { font-family: var(--vscode-font-family); color: var(--vscode-foreground);
+      background-color: var(--vscode-editor-background); padding: 20px; line-height: 1.5; }
+    h1 { font-size: 1.4em; font-weight: 600; margin-bottom: 8px; }
+    h2 { font-size: 1.05em; font-weight: 600; margin: 24px 0 8px; }
+    section { margin-top: 8px; }
+    .summary { display: flex; gap: 16px; flex-wrap: wrap; margin: 8px 0 16px;
+      color: var(--vscode-descriptionForeground); font-size: 0.9em; }
+    .summary-error { color: #ff6b6b; font-weight: 600; }
+    .summary-warning { color: #ffb74d; font-weight: 600; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 0.8em;
+      font-weight: 600; }
+    .badge-error { background: #b71c1c; color: #fff; }
+    .badge-warning { background: #e65100; color: #fff; }
+    .badge-default { background: #455a64; color: #fff; }
+    .collision-row, .rename-row, .edit-row { border: 1px solid var(--vscode-panel-border);
+      border-radius: 6px; padding: 12px; margin-bottom: 10px; }
+    .row-header { display: flex; align-items: center; gap: 8px; }
+    .row-identifier, .rename-current, .rename-suggested, .entry-id { font-weight: 600; }
+    .row-reason { color: var(--vscode-descriptionForeground); font-size: 0.9em; margin-top: 6px; }
+    .entry-line { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 6px; }
+    .entry-path { color: var(--vscode-descriptionForeground); font-size: 0.85em;
+      font-family: var(--vscode-editor-font-family, monospace); }
+    .entry-list { margin-top: 4px; }
+    .tag { display: inline-block; padding: 1px 6px; border-radius: 3px;
+      background: var(--vscode-badge-background); color: var(--vscode-badge-foreground); font-size: 0.8em; }
+    .matched-tokens { margin-top: 6px; display: flex; gap: 4px; flex-wrap: wrap; }
+    .muted { color: var(--vscode-descriptionForeground); }
+    .semantic-entries { margin-top: 6px; }
+    .cosine-score { font-size: 0.85em; margin-top: 6px; }
+    .phrase-list { margin-top: 6px; }
+    .phrase-line { display: flex; align-items: center; gap: 8px; font-size: 0.85em; }
+    .phrase-sep, .phrase-sim { color: var(--vscode-descriptionForeground); }
+    .rename-names { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .rename-arrow, .edit-label { color: var(--vscode-descriptionForeground); }
+    .edit-diff { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 8px; }
+    .edit-before pre, .edit-after pre { white-space: pre-wrap; font-size: 12px; margin: 4px 0 0;
+      padding: 8px; border-radius: 4px; background: var(--vscode-textBlockQuote-background); }
+    .edit-file { font-family: var(--vscode-editor-font-family, monospace); font-size: 0.85em;
+      color: var(--vscode-descriptionForeground); }
+    .hero { padding: 24px; border-radius: 6px; text-align: center;
+      background: var(--vscode-textBlockQuote-background); margin: 16px 0; }
+    button { background: var(--vscode-button-background); color: var(--vscode-button-foreground);
+      border: none; padding: 8px 16px; border-radius: 4px; font-size: 13px; font-weight: 500;
+      cursor: pointer; }
+    button:hover { background-color: var(--vscode-button-hoverBackground); }
+    button:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px; }
+    .copy-btn { padding: 2px 10px; font-size: 12px; }
+    .actions { display: flex; gap: 8px; margin-top: 24px; }`
+}
+
+/** Inline script: wires Retry, Open-Report, and delegated `.copy-btn` clicks. */
+function getScript(nonce: string): string {
+  return `
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const retryBtn = document.getElementById('retryBtn');
+    if (retryBtn) {
+      retryBtn.addEventListener('click', () => {
+        vscode.postMessage({ command: 'retry' });
+      });
+    }
+    const reportBtn = document.getElementById('openReportBtn');
+    if (reportBtn) {
+      reportBtn.addEventListener('click', () => {
+        vscode.postMessage({ command: 'openReport' });
+      });
+    }
+    document.addEventListener('click', (event) => {
+      const target = event.target;
+      if (target && target.classList && target.classList.contains('copy-btn')) {
+        const text = target.dataset ? target.dataset.copy : undefined;
+        if (typeof text === 'string') {
+          vscode.postMessage({ command: 'copyRename', text: text });
+        }
+      }
+    });
+  </script>`
+}
+
+/** The "Open Full Report" + "Retry" action row, shared by clean + populated states. */
+function getActionsHtml(): string {
+  return `
+  <div class="actions">
+    <button id="openReportBtn">Open Full Report</button>
+    <button id="retryBtn">Re-run Audit</button>
+  </div>`
+}
+
+/**
+ * Build the complete Inventory Audit panel HTML. All untrusted fields are
+ * escaped (in the section renderers). When there are no flags, a clean-state
+ * hero replaces the collision sections.
+ */
+export function getInventoryAuditHtml(response: McpInventoryAuditResponse, nonce: string): string {
+  const csp = getInventoryAuditCsp(nonce)
+  const summary = response.summary
+  const totalFlags = Number.isFinite(summary?.totalFlags) ? summary.totalFlags : 0
+  const totalEntries = Number.isFinite(summary?.totalEntries) ? summary.totalEntries : 0
+
+  const bodyContent =
+    totalFlags === 0
+      ? `
+    ${getSummarySection(summary)}
+    <div class="hero">
+      <h2>No namespace collisions found.</h2>
+      <p>Scanned ${totalEntries} entries.</p>
+    </div>`
+      : `
+    ${getSummarySection(summary)}
+    ${getExactCollisionsSection(response.exactCollisions)}
+    ${getSemanticSection(response.semanticCollisions)}
+    ${getGenericFlagsSection(response.genericFlags)}
+    ${getRenameSuggestionsSection(response.renameSuggestions)}
+    ${getRecommendedEditsSection(response.recommendedEdits)}`
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="${csp}">
+  <title>Skill Inventory Audit</title>
+  <style>${getStyles()}</style>
+</head>
+<body>
+  <h1>Skill Inventory Audit</h1>
+  ${bodyContent}
+  ${getActionsHtml()}
+  ${getScript(nonce)}
+</body>
+</html>`
+}
+
+/**
+ * Build a local error page for the Inventory Audit panel. Mirrors
+ * getCompareErrorHtml: aria-live region + a Retry button wired via nonce.
+ */
+export function getInventoryAuditErrorHtml(message: string, nonce: string, raw?: string): string {
+  const csp = getInventoryAuditCsp(nonce)
+  const detailsBlock =
+    raw && raw !== message
+      ? `<details style="margin-top: 12px; color: var(--vscode-descriptionForeground);">
+        <summary>Technical details</summary>
+        <pre style="white-space: pre-wrap; font-size: 12px; margin-top: 8px;">${escapeHtml(raw)}</pre>
+       </details>`
+      : ''
+
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<style nonce="${nonce}">
+  button:hover { background-color: var(--vscode-button-hoverBackground) !important; }
+  button:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px; }
+</style>
+</head>
+<body style="font-family: var(--vscode-font-family); padding: 20px; color: var(--vscode-foreground); background-color: var(--vscode-editor-background);">
+  <div aria-live="polite">
+    <h1 style="font-size: 1.4em; font-weight: 600;">Couldn't Audit Inventory</h1>
+    <p role="alert">${escapeHtml(message)}</p>
+    ${detailsBlock}
+    <button id="retryBtn" style="background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; padding: 10px 20px; border-radius: 4px; font-size: 14px; font-weight: 500; cursor: pointer; margin-top: 16px;">
+      Retry
+    </button>
+  </div>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const btn = document.getElementById('retryBtn');
+    if (btn) {
+      btn.addEventListener('click', () => {
+        btn.disabled = true;
+        btn.textContent = 'Retrying...';
+        vscode.postMessage({ command: 'retry' });
+      });
+    }
+  </script>
+</body></html>`
+}

--- a/packages/vscode-extension/src/views/inventory-audit-panel-types.ts
+++ b/packages/vscode-extension/src/views/inventory-audit-panel-types.ts
@@ -1,0 +1,17 @@
+/**
+ * Message types for the Skill Inventory Audit panel (SMI-5318 / #1459).
+ *
+ * Split out of InventoryAuditPanel.ts / inventory-audit-panel-html.ts so each
+ * file stays under the 500-line cap. The inventory-audit webview is read-only;
+ * inbound messages are `retry` (re-run the audit), `openReport` (open the
+ * formatted report in an editor tab), and `copyRename` (copy a suggested name
+ * to the clipboard).
+ */
+
+/**
+ * Messages posted from the Inventory Audit webview back to the extension host.
+ */
+export type InventoryAuditPanelMessage =
+  | { command: 'retry' }
+  | { command: 'openReport' }
+  | { command: 'copyRename'; text: string }

--- a/packages/vscode-extension/src/views/inventory-audit-sections-html.ts
+++ b/packages/vscode-extension/src/views/inventory-audit-sections-html.ts
@@ -1,0 +1,233 @@
+/**
+ * Per-section HTML renderers for the Skill Inventory Audit panel
+ * (SMI-5318 / #1459).
+ *
+ * Each function takes the relevant array (or the summary object) and returns a
+ * host-built HTML string, returning `''` when its array is empty so empty
+ * sections never render. Split out of inventory-audit-panel-html.ts to keep
+ * both files under the 500-line cap.
+ *
+ * Security: every untrusted field is escaped via `escapeHtml`; nested arrays
+ * are iterated and escaped per-element (never `JSON.stringify`-d raw into the
+ * markup). Severity → CSS class goes through a whitelist (`severityBadgeClass`)
+ * so a malformed severity can never be interpolated into a class attribute.
+ */
+
+import { escapeHtml } from '../utils/security.js'
+import type {
+  McpExactCollision,
+  McpGenericFlag,
+  McpInventoryEntry,
+  McpRecommendedEdit,
+  McpRenameSuggestion,
+  McpSemanticCollision,
+} from '../mcp/types.js'
+
+/**
+ * Map a severity string to a whitelisted badge CSS class. Anything that is not
+ * exactly `'error'` or `'warning'` falls back to `badge-default` — the raw
+ * severity is never interpolated into the class attribute.
+ */
+export function severityBadgeClass(severity: string): string {
+  if (severity === 'error') return 'badge-error'
+  if (severity === 'warning') return 'badge-warning'
+  return 'badge-default'
+}
+
+/** Render the `kind` of an entry as a small escaped tag. */
+function renderKind(kind: string): string {
+  return `<span class="tag">${escapeHtml(kind)}</span>`
+}
+
+/** Render one inventory entry (identifier + kind + source path), all escaped. */
+function renderEntryLine(entry: McpInventoryEntry): string {
+  const identifier = typeof entry.identifier === 'string' ? entry.identifier : ''
+  const kind = typeof entry.kind === 'string' ? entry.kind : ''
+  const sourcePath = typeof entry.source_path === 'string' ? entry.source_path : ''
+  return `
+    <div class="entry-line">
+      ${renderKind(kind)}
+      <span class="entry-id">${escapeHtml(identifier)}</span>
+      <span class="entry-path">${escapeHtml(sourcePath)}</span>
+    </div>`
+}
+
+/** Render a severity badge + reason header shared by collision rows. */
+function renderRowHeader(severity: string, identifier: string, reason: string): string {
+  const badgeClass = severityBadgeClass(severity)
+  const safeSeverity = escapeHtml(severity)
+  return `
+    <div class="row-header">
+      <span class="badge ${badgeClass}">${safeSeverity}</span>
+      <span class="row-identifier">${escapeHtml(identifier)}</span>
+    </div>
+    <div class="row-reason">${escapeHtml(reason)}</div>`
+}
+
+/** Exact identifier collisions (severity always `error`). */
+export function getExactCollisionsSection(items: McpExactCollision[]): string {
+  if (!Array.isArray(items) || items.length === 0) return ''
+  const rows = items
+    .map((c) => {
+      const identifier = typeof c.identifier === 'string' ? c.identifier : ''
+      const reason = typeof c.reason === 'string' ? c.reason : ''
+      const entries = Array.isArray(c.entries) ? c.entries : []
+      const entryLines = entries.map((e) => renderEntryLine(e)).join('')
+      return `
+      <div class="collision-row">
+        ${renderRowHeader(c.severity, identifier, reason)}
+        <div class="entry-list">${entryLines}</div>
+      </div>`
+    })
+    .join('')
+  return `
+    <section aria-labelledby="exact-collisions-heading">
+      <h2 id="exact-collisions-heading">Exact Collisions</h2>
+      ${rows}
+    </section>`
+}
+
+/** Semantic-overlap collisions (severity always `warning`; deep pass only). */
+export function getSemanticSection(items: McpSemanticCollision[]): string {
+  if (!Array.isArray(items) || items.length === 0) return ''
+  const rows = items
+    .map((c) => {
+      const reason = typeof c.reason === 'string' ? c.reason : ''
+      const score = Number.isFinite(c.cosineScore) ? c.cosineScore.toFixed(2) : '—'
+      const phrases = Array.isArray(c.overlappingPhrases) ? c.overlappingPhrases : []
+      const phraseLines = phrases
+        .map((p) => {
+          const phrase1 = typeof p.phrase1 === 'string' ? p.phrase1 : ''
+          const phrase2 = typeof p.phrase2 === 'string' ? p.phrase2 : ''
+          const sim = Number.isFinite(p.similarity) ? p.similarity.toFixed(2) : '—'
+          return `
+          <div class="phrase-line">
+            <span class="phrase">${escapeHtml(phrase1)}</span>
+            <span class="phrase-sep">↔</span>
+            <span class="phrase">${escapeHtml(phrase2)}</span>
+            <span class="phrase-sim">${escapeHtml(sim)}</span>
+          </div>`
+        })
+        .join('')
+      return `
+      <div class="collision-row">
+        ${renderRowHeader(c.severity, '', reason)}
+        <div class="semantic-entries">
+          ${renderEntryLine(c.entryA)}
+          ${renderEntryLine(c.entryB)}
+        </div>
+        <div class="cosine-score">Cosine similarity: ${escapeHtml(score)}</div>
+        <div class="phrase-list">${phraseLines}</div>
+      </div>`
+    })
+    .join('')
+  return `
+    <section aria-labelledby="semantic-collisions-heading">
+      <h2 id="semantic-collisions-heading">Semantic Overlaps</h2>
+      ${rows}
+    </section>`
+}
+
+/** Generic-token flags (severity always `warning`). */
+export function getGenericFlagsSection(items: McpGenericFlag[]): string {
+  if (!Array.isArray(items) || items.length === 0) return ''
+  const rows = items
+    .map((f) => {
+      const identifier = typeof f.identifier === 'string' ? f.identifier : ''
+      const reason = typeof f.reason === 'string' ? f.reason : ''
+      const tokens = Array.isArray(f.matchedTokens) ? f.matchedTokens : []
+      const tokenTags = tokens
+        .filter((t) => typeof t === 'string')
+        .map((t) => `<span class="tag">${escapeHtml(t)}</span>`)
+        .join(' ')
+      return `
+      <div class="collision-row">
+        ${renderRowHeader(f.severity, identifier, reason)}
+        ${renderEntryLine(f.entry)}
+        <div class="matched-tokens">${tokenTags || '<span class="muted">—</span>'}</div>
+      </div>`
+    })
+    .join('')
+  return `
+    <section aria-labelledby="generic-flags-heading">
+      <h2 id="generic-flags-heading">Generic-Token Flags</h2>
+      ${rows}
+    </section>`
+}
+
+/** Suggested renames — each row carries a copy button reading `data-copy`. */
+export function getRenameSuggestionsSection(items: McpRenameSuggestion[]): string {
+  if (!Array.isArray(items) || items.length === 0) return ''
+  const rows = items
+    .map((r) => {
+      const currentName = typeof r.currentName === 'string' ? r.currentName : ''
+      const suggested = typeof r.suggested === 'string' ? r.suggested : ''
+      const reason = typeof r.reason === 'string' ? r.reason : ''
+      return `
+      <div class="rename-row">
+        <div class="rename-names">
+          <span class="rename-current">${escapeHtml(currentName)}</span>
+          <span class="rename-arrow">→</span>
+          <span class="rename-suggested">${escapeHtml(suggested)}</span>
+          <button class="copy-btn" data-copy="${escapeHtml(suggested)}">Copy</button>
+        </div>
+        ${renderEntryLine(r.entry)}
+        <div class="row-reason">${escapeHtml(reason)}</div>
+      </div>`
+    })
+    .join('')
+  return `
+    <section aria-labelledby="rename-suggestions-heading">
+      <h2 id="rename-suggestions-heading">Rename Suggestions</h2>
+      ${rows}
+    </section>`
+}
+
+/** Recommended prose edits — READ-ONLY (before → after + rationale, no apply). */
+export function getRecommendedEditsSection(items: McpRecommendedEdit[]): string {
+  if (!Array.isArray(items) || items.length === 0) return ''
+  const rows = items
+    .map((e) => {
+      const filePath = typeof e.filePath === 'string' ? e.filePath : ''
+      const before = typeof e.before === 'string' ? e.before : ''
+      const after = typeof e.after === 'string' ? e.after : ''
+      const rationale = typeof e.rationale === 'string' ? e.rationale : ''
+      return `
+      <div class="edit-row">
+        <div class="edit-file">${escapeHtml(filePath)}</div>
+        <div class="edit-diff">
+          <div class="edit-before"><span class="edit-label">Before</span><pre>${escapeHtml(before)}</pre></div>
+          <div class="edit-after"><span class="edit-label">After</span><pre>${escapeHtml(after)}</pre></div>
+        </div>
+        <div class="row-reason">${escapeHtml(rationale)}</div>
+      </div>`
+    })
+    .join('')
+  return `
+    <section aria-labelledby="recommended-edits-heading">
+      <h2 id="recommended-edits-heading">Recommended Edits (read-only)</h2>
+      ${rows}
+    </section>`
+}
+
+/** Summary type, mirrored locally to avoid importing the whole response shape. */
+export interface InventoryAuditSummary {
+  totalEntries: number
+  totalFlags: number
+  errorCount: number
+  warningCount: number
+  durationMs: number
+}
+
+/** Render the summary counts block (aria-live updates on retry). */
+export function getSummarySection(summary: InventoryAuditSummary): string {
+  const totalEntries = Number.isFinite(summary.totalEntries) ? summary.totalEntries : 0
+  const errorCount = Number.isFinite(summary.errorCount) ? summary.errorCount : 0
+  const warningCount = Number.isFinite(summary.warningCount) ? summary.warningCount : 0
+  return `
+    <div class="summary" aria-live="polite">
+      <span class="summary-stat">${totalEntries} entries scanned</span>
+      <span class="summary-stat summary-error">${errorCount} error${errorCount === 1 ? '' : 's'}</span>
+      <span class="summary-stat summary-warning">${warningCount} warning${warningCount === 1 ? '' : 's'}</span>
+    </div>`
+}


### PR DESCRIPTION
## What

PR-D3 (Epic D / GH #1459) — the last Epic-D feature PR. Adds a read-only **Audit Skill Inventory** command (`skillsmith.auditInventory`) that runs the `skill_inventory_audit` MCP tool and renders a webview report of local `~/.claude/` namespace collisions.

- Severity-badged collision sections (exact = error, semantic/generic = warning) + rename suggestions (copy-to-clipboard) + read-only recommended edits.
- **Open Full Report** link to the server-generated `report.md`.
- Clean state (`totalFlags === 0`) shows a no-collisions hero; empty sections are skipped.

## Research correction

The tool is **ungated / Community-tier** — verified `audit-tool-dispatch.ts:178` dispatches it with no `withLicenseAndQuota` wrapper and `toolFeatureMapping.ts` has no entry. So there is intentionally **no `handleTierDenied`** wiring (the original umbrella plan's "Team+" label was wrong). Interactive apply (`apply_namespace_rename` / `apply_recommended_edit`, which mutate local files) is deferred to **SMI-5325**; a `deep` opt-in setting to **SMI-5326**.

## Implementation notes

- `McpClient.ts` shed under the 500-line gate by extracting the leaf `JsonRpcRequest`/`JsonRpcResponse` interfaces to `jsonrpc.types.ts` (no import cycle, no importer churn) — then added the `skillInventoryAudit` wrapper.
- Webview mirrors `CompareSkillsPanel`: singleton, CSP nonce, `escapeHtml` on every untrusted field, severity→class whitelist, `_disposed` guards on every async path, `retainContextWhenHidden`.
- Telemetry: `vscode_inventory_audit_start/_complete/_empty`; dispatcher coverage 9 → 10.

## Verification

- typecheck / lint (zero warnings) / `package:check` clean.
- 639/639 extension tests pass (new: wrapper 4-case, command behavior, panel render incl. XSS-escape).
- `audit:standards` 0 failed (Check 28 pairing ✓, file-length ✓ — max 302 lines).
- plan-review (16 findings folded) + governance review (PASS_WITH_WARNINGS → 2 `_disposed` guards fixed in `94de2f59`).

Host-only (ADR-113). Ships unreleased → batched into **0.6.0**. Design doc + retro land in the consolidated Epic-D docs PR.

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)