### PR TITLE
feat(vscode): SkillNotFound error code + inventory-audit deep opt-in (SMI-5322, SMI-5326)

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Deep inventory audit** — a new setting `skillsmith.inventoryAudit.deep` (off by default) runs the slower semantic-overlap pass when you Audit Skill Inventory, surfacing near-duplicate skills beyond exact namespace clashes.
+
+### Fixed
+
+- Clearer "skill not found" messaging — when a skill you compare or check for updates no longer exists in the registry (or its ID is invalid), the extension now says so directly instead of showing a generic error.
+
 ## [0.6.0] - 2026-06-19
 
 ### Added

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -295,6 +295,11 @@
           "type": "boolean",
           "default": false,
           "description": "Show sample/demo skills when the Skillsmith server is unavailable. Off by default; intended for demos and screenshots only."
+        },
+        "skillsmith.inventoryAudit.deep": {
+          "type": "boolean",
+          "default": false,
+          "description": "Run the deep semantic-overlap pass when auditing your skill inventory (Audit Skill Inventory). Detects semantic collisions beyond exact namespace clashes, but is slower. Off by default."
         }
       }
     }

--- a/packages/vscode-extension/src/__tests__/auditInventory.test.ts
+++ b/packages/vscode-extension/src/__tests__/auditInventory.test.ts
@@ -17,6 +17,8 @@ const track = vi.hoisted(() => vi.fn())
 const mcpIsConnected = vi.hoisted(() => vi.fn(() => true))
 const mcpSkillInventoryAudit = vi.hoisted(() => vi.fn())
 const inventoryAuditCreateOrShow = vi.hoisted(() => vi.fn())
+// SMI-5326: configurable `skillsmith.inventoryAudit.deep` read.
+const configGet = vi.hoisted(() => vi.fn((_key: string, fallback?: unknown) => fallback))
 const withProgress = vi.hoisted(() =>
   vi.fn(async (_opts: unknown, task: (p: unknown, t: unknown) => Promise<unknown>) => {
     return task({ report: vi.fn() }, tokenRef)
@@ -32,7 +34,7 @@ vi.mock('vscode', () => ({
   },
   commands: { registerCommand: vi.fn(), executeCommand: vi.fn() },
   workspace: {
-    getConfiguration: vi.fn(() => ({ get: () => undefined })),
+    getConfiguration: vi.fn(() => ({ get: configGet })),
   },
   Uri: {
     file: (s: string) => ({ toString: () => s, fsPath: s }),
@@ -108,6 +110,9 @@ describe('auditInventoryCommand (SMI-5318)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mcpIsConnected.mockReturnValue(true)
+    // Restore the default config read (returns the fallback) — a per-test
+    // mockReturnValue override survives vi.clearAllMocks(), so re-establish it.
+    configGet.mockImplementation((_key: string, fallback?: unknown) => fallback)
     // Reset the shared token so each test starts with cancellation = false.
     tokenRef.isCancellationRequested = false
     // Restore the default withProgress implementation after vi.clearAllMocks().
@@ -142,6 +147,16 @@ describe('auditInventoryCommand (SMI-5318)', () => {
     })
     expect(track).not.toHaveBeenCalledWith('vscode_inventory_audit_empty')
     expect(inventoryAuditCreateOrShow).toHaveBeenCalledOnce()
+  })
+
+  it('deep setting enabled: passes { deep: true } to skillInventoryAudit (SMI-5326)', async () => {
+    configGet.mockReturnValue(true)
+    mcpSkillInventoryAudit.mockResolvedValue(makeResponse())
+
+    await auditInventoryCommandAction()
+
+    expect(configGet).toHaveBeenCalledWith('inventoryAudit.deep', false)
+    expect(mcpSkillInventoryAudit).toHaveBeenCalledWith({ deep: true })
   })
 
   it('connected + clean (totalFlags:0): fires empty telemetry AND still opens panel', async () => {

--- a/packages/vscode-extension/src/__tests__/compareSkills.test.ts
+++ b/packages/vscode-extension/src/__tests__/compareSkills.test.ts
@@ -241,4 +241,24 @@ describe('compareCommand', () => {
     expect(showErrorMessage).toHaveBeenCalledWith('something went wrong')
     expect(compareCreateOrShow).not.toHaveBeenCalled()
   })
+
+  it('shows a friendly warning and does NOT open panel on SkillNotFound (SMI-5322)', async () => {
+    const err = new McpToolError(
+      'skill_compare',
+      'SkillNotFound',
+      'Skill "community/foo" not found'
+    )
+    mcpSkillCompare.mockRejectedValue(err)
+
+    createQuickPickFn
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_B))
+
+    await compareCommandAction(asDeps())
+
+    expect(showWarningMessage).toHaveBeenCalledWith(expect.stringContaining('could not be found'))
+    expect(showErrorMessage).not.toHaveBeenCalled()
+    expect(handleTierDenied).not.toHaveBeenCalled()
+    expect(compareCreateOrShow).not.toHaveBeenCalled()
+  })
 })

--- a/packages/vscode-extension/src/__tests__/diffCommand.test.ts
+++ b/packages/vscode-extension/src/__tests__/diffCommand.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // ── hoisted spies ─────────────────────────────────────────────────────────────
 const showInformationMessage = vi.hoisted(() => vi.fn())
 const showErrorMessage = vi.hoisted(() => vi.fn())
+const showWarningMessage = vi.hoisted(() => vi.fn())
 const showQuickPick = vi.hoisted(() => vi.fn())
 
 // ── vscode mock ───────────────────────────────────────────────────────────────
@@ -16,7 +17,7 @@ vi.mock('vscode', () => ({
   window: {
     showInformationMessage,
     showErrorMessage,
-    showWarningMessage: vi.fn(),
+    showWarningMessage,
     showQuickPick,
   },
   commands: { registerCommand: vi.fn(), executeCommand: vi.fn() },
@@ -190,6 +191,22 @@ describe('diffCommand', () => {
     await diffCommandAction({ treeProvider: treeProvider as any, context: FAKE_CONTEXT as any })
 
     expect(handleTierDenied).toHaveBeenCalledWith('skillsmith.diffSkill', tierErr)
+    expect(diffCreateOrShow).not.toHaveBeenCalled()
+  })
+
+  it('shows a friendly warning and does NOT open SkillDiffPanel on SkillNotFound (SMI-5322)', async () => {
+    mcpSkillDiff.mockRejectedValue(
+      new McpToolError('skill_diff', 'SkillNotFound', 'Skill "smith-horn/docker" not found')
+    )
+
+    const treeProvider = makeTreeProvider()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await diffCommandAction({ treeProvider: treeProvider as any, context: FAKE_CONTEXT as any })
+
+    expect(showWarningMessage).toHaveBeenCalledWith(expect.stringContaining('could not be found'))
+    expect(handleTierDenied).not.toHaveBeenCalled()
+    expect(showErrorMessage).not.toHaveBeenCalled()
     expect(diffCreateOrShow).not.toHaveBeenCalled()
   })
 

--- a/packages/vscode-extension/src/__tests__/mcp/classifyIsErrorText.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/classifyIsErrorText.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for `classifyIsErrorText` (SMI-5322).
+ *
+ * Pins the precedence that lets a skill-level not-found map to `SkillNotFound`
+ * while the generic tool-not-found contract (`tool not found -> UnknownTool`,
+ * uninstall_skill.test.ts) stays intact.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { classifyIsErrorText } from '../../mcp/callTool.js'
+
+describe('classifyIsErrorText (SMI-5322)', () => {
+  it('tier/plan/denied/forbidden/upgrade text -> TierDenied', () => {
+    expect(classifyIsErrorText('TierDenied: requires the Individual plan')).toBe('TierDenied')
+    expect(classifyIsErrorText('This feature is not available in your current tier')).toBe(
+      'TierDenied'
+    )
+    expect(classifyIsErrorText('Please upgrade to continue')).toBe('TierDenied')
+  })
+
+  it('server SKILL_NOT_FOUND message -> SkillNotFound', () => {
+    expect(classifyIsErrorText('Error: Skill "smith-horn/docker" not found')).toBe('SkillNotFound')
+    // Case-insensitive + extra text between "skill" and "not found".
+    expect(classifyIsErrorText('skill foo/bar was not found in the registry')).toBe('SkillNotFound')
+  })
+
+  it('server SKILL_INVALID_ID message -> SkillNotFound', () => {
+    expect(classifyIsErrorText('Error: Invalid skill ID format: "@@@"')).toBe('SkillNotFound')
+  })
+
+  it('generic tool-not-found stays UnknownTool (preserves the tested contract)', () => {
+    expect(classifyIsErrorText('tool not found')).toBe('UnknownTool')
+    expect(classifyIsErrorText('Unknown tool: skill_compare')).toBe('UnknownTool')
+    expect(classifyIsErrorText('no such tool')).toBe('UnknownTool')
+  })
+
+  it('unrelated errors fall through to Unknown', () => {
+    expect(classifyIsErrorText('network timeout')).toBe('Unknown')
+    expect(classifyIsErrorText('Unknown error')).toBe('Unknown')
+  })
+})

--- a/packages/vscode-extension/src/__tests__/mcp/classifyIsErrorText.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/classifyIsErrorText.test.ts
@@ -28,6 +28,17 @@ describe('classifyIsErrorText (SMI-5322)', () => {
     expect(classifyIsErrorText('Error: Invalid skill ID format: "@@@"')).toBe('SkillNotFound')
   })
 
+  it('skill name containing a tier keyword still classifies SkillNotFound, not TierDenied', () => {
+    // The SkillNotFound rule runs before TierDenied so a skill named e.g.
+    // "plan-review" / "tier-manager" / "upgrade-kit" does not misroute to the
+    // upgrade upsell.
+    expect(classifyIsErrorText('Error: Skill "smith-horn/plan-review" not found')).toBe(
+      'SkillNotFound'
+    )
+    expect(classifyIsErrorText('Error: Skill "tier-manager" not found')).toBe('SkillNotFound')
+    expect(classifyIsErrorText('Error: Skill "upgrade-kit" not found')).toBe('SkillNotFound')
+  })
+
   it('generic tool-not-found stays UnknownTool (preserves the tested contract)', () => {
     expect(classifyIsErrorText('tool not found')).toBe('UnknownTool')
     expect(classifyIsErrorText('Unknown tool: skill_compare')).toBe('UnknownTool')

--- a/packages/vscode-extension/src/__tests__/mcp/skill_compare.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/skill_compare.test.ts
@@ -117,6 +117,13 @@ describe('McpClient.skillCompare (SMI-5315)', () => {
     ).rejects.toMatchObject({ code: 'UnknownTool' })
   })
 
+  it('skill-not-found isError response throws McpToolError code SkillNotFound (SMI-5322)', async () => {
+    const client = connectedClient(isErr('Error: Skill "community/docker-compose" not found'))
+    await expect(
+      client.skillCompare({ skill_a: 'smith-horn/docker', skill_b: 'community/docker-compose' })
+    ).rejects.toMatchObject({ code: 'SkillNotFound', toolName: 'skill_compare' })
+  })
+
   it('calling before connect throws NotConnected with the exact message', async () => {
     const client = new McpClient()
     await expect(

--- a/packages/vscode-extension/src/commands/auditInventoryCommand.ts
+++ b/packages/vscode-extension/src/commands/auditInventoryCommand.ts
@@ -27,11 +27,18 @@ async function auditInventoryCommandImpl(): Promise<void> {
     return
   }
 
+  // SMI-5326: opt into the slower semantic-overlap pass via setting. Pass `deep`
+  // only when true — exactOptionalPropertyTypes forbids `{ deep: undefined }`,
+  // and `{}` preserves the existing fast-path default.
+  const deep = vscode.workspace
+    .getConfiguration('skillsmith')
+    .get<boolean>('inventoryAudit.deep', false)
+
   try {
     await vscode.window.withProgress(
       { location: vscode.ProgressLocation.Window, title: 'Auditing skill inventory…' },
       async (_progress, token) => {
-        const response = await client.skillInventoryAudit({})
+        const response = await client.skillInventoryAudit(deep ? { deep: true } : {})
         if (token.isCancellationRequested) return
 
         const flags = response.summary.errorCount + response.summary.warningCount

--- a/packages/vscode-extension/src/commands/compareCommand.ts
+++ b/packages/vscode-extension/src/commands/compareCommand.ts
@@ -170,6 +170,12 @@ async function compareCommandImpl(deps: {
         await handleTierDenied('skillsmith.compareSkills', err)
         return
       }
+      if (err.code === 'SkillNotFound') {
+        void vscode.window.showWarningMessage(
+          'One or both skills could not be found. Check the skill IDs and try again.'
+        )
+        return
+      }
       void vscode.window.showErrorMessage(err.message)
       return
     }

--- a/packages/vscode-extension/src/commands/diffCommand.ts
+++ b/packages/vscode-extension/src/commands/diffCommand.ts
@@ -122,6 +122,12 @@ async function diffCommandImpl(deps: {
         await handleTierDenied('skillsmith.diffSkill', err)
         return
       }
+      if (err.code === 'SkillNotFound') {
+        void vscode.window.showWarningMessage(
+          'This skill could not be found in the registry. It may have been removed or renamed.'
+        )
+        return
+      }
       void vscode.window.showErrorMessage(err.message)
       return
     }

--- a/packages/vscode-extension/src/mcp/McpClient.patterns.md
+++ b/packages/vscode-extension/src/mcp/McpClient.patterns.md
@@ -40,7 +40,7 @@ async skillDiff(args: { skillId: string; from: string; to: string }): Promise<Mc
 export class McpToolError extends Error {
   constructor(
     public readonly toolName: string,
-    public readonly code: string, // e.g. 'TierDenied', 'SkillNotFound'
+    public readonly code: McpToolErrorCode,
     message: string,
   ) {
     super(message)
@@ -48,6 +48,13 @@ export class McpToolError extends Error {
   }
 }
 ```
+
+`McpToolErrorCode` is a 6-value union (`McpToolError.ts`):
+`TierDenied | UnknownTool | SkillNotFound | NotConnected | InvalidResponse |
+Unknown`. `SkillNotFound` (SMI-5322) is classified from the server's plain-text
+`Skill "x" not found` / `Invalid skill ID format` messages — see
+`classifyIsErrorText` in `callTool.ts`, which keeps the generic `tool not found
+-> UnknownTool` contract by requiring the word "skill".
 
 Command-level handlers catch `McpToolError` and branch on `.code`. No
 string-matching against `.message`.

--- a/packages/vscode-extension/src/mcp/McpToolError.ts
+++ b/packages/vscode-extension/src/mcp/McpToolError.ts
@@ -6,6 +6,7 @@
 export type McpToolErrorCode =
   | 'TierDenied'
   | 'UnknownTool'
+  | 'SkillNotFound'
   | 'NotConnected'
   | 'InvalidResponse'
   | 'Unknown'

--- a/packages/vscode-extension/src/mcp/callTool.ts
+++ b/packages/vscode-extension/src/mcp/callTool.ts
@@ -14,13 +14,21 @@ import { McpToolError, type McpToolErrorCode } from './McpToolError.js'
  * `McpToolErrorCode`. Tier/plan denials and unknown-tool errors get specific
  * codes so command handlers can branch without string-matching messages.
  *
- * NOTE (SMI-5322): `not found` currently maps to `UnknownTool` — this is a
- * tested contract (`__tests__/mcp/uninstall_skill.test.ts`). A precise
- * `SkillNotFound` code is tracked separately; do not change this here.
+ * SMI-5322: A skill-level not-found (`SKILL_NOT_FOUND`) or invalid-id
+ * (`SKILL_INVALID_ID`) must classify as `SkillNotFound`, NOT `UnknownTool`. The
+ * server surfaces these as plain text — `Error: Skill "x" not found` /
+ * `Error: Invalid skill ID format: "x"` — because `index.ts` emits only
+ * `error.message`, not the structured `SkillsmithError.code`. So we match the
+ * message text. Requiring the word "skill" keeps the generic `tool not found ->
+ * UnknownTool` contract intact (`__tests__/mcp/uninstall_skill.test.ts`): a bare
+ * "tool not found" has no "skill" token and falls through to the rule below.
  */
 export function classifyIsErrorText(errorText: string): McpToolErrorCode {
   if (/tier|plan|denied|forbidden|upgrade/i.test(errorText)) {
     return 'TierDenied'
+  }
+  if (/\bskill\b.*\bnot found\b/i.test(errorText) || /invalid skill id/i.test(errorText)) {
+    return 'SkillNotFound'
   }
   if (/unknown tool|not found|no such tool/i.test(errorText)) {
     return 'UnknownTool'

--- a/packages/vscode-extension/src/mcp/callTool.ts
+++ b/packages/vscode-extension/src/mcp/callTool.ts
@@ -21,14 +21,21 @@ import { McpToolError, type McpToolErrorCode } from './McpToolError.js'
  * `error.message`, not the structured `SkillsmithError.code`. So we match the
  * message text. Requiring the word "skill" keeps the generic `tool not found ->
  * UnknownTool` contract intact (`__tests__/mcp/uninstall_skill.test.ts`): a bare
- * "tool not found" has no "skill" token and falls through to the rule below.
+ * "tool not found" has no "skill" token and falls through to the unknown-tool
+ * rule.
+ *
+ * The `SkillNotFound` rule is checked BEFORE `TierDenied` on purpose: a skill
+ * whose name contains a tier keyword (e.g. `Skill "plan-review" not found`)
+ * would otherwise misroute to the upgrade upsell. A real tier-denial message
+ * never contains `skill … not found` / `invalid skill id`, so this ordering is
+ * safe.
  */
 export function classifyIsErrorText(errorText: string): McpToolErrorCode {
-  if (/tier|plan|denied|forbidden|upgrade/i.test(errorText)) {
-    return 'TierDenied'
-  }
   if (/\bskill\b.*\bnot found\b/i.test(errorText) || /invalid skill id/i.test(errorText)) {
     return 'SkillNotFound'
+  }
+  if (/tier|plan|denied|forbidden|upgrade/i.test(errorText)) {
+    return 'TierDenied'
   }
   if (/unknown tool|not found|no such tool/i.test(errorText)) {
     return 'UnknownTool'

--- a/packages/vscode-extension/src/views/CompareSkillsPanel.ts
+++ b/packages/vscode-extension/src/views/CompareSkillsPanel.ts
@@ -137,11 +137,11 @@ export class CompareSkillsPanel {
       }
       const raw = err instanceof Error ? err.message : String(err)
       const errNonce = generateCspNonce()
-      this._panel.webview.html = getCompareErrorHtml(
-        'Could not compare these skills. Please try again.',
-        errNonce,
-        raw
-      )
+      const headline =
+        err instanceof McpToolError && err.code === 'SkillNotFound'
+          ? 'One or both skills could not be found. Check the skill IDs and try again.'
+          : 'Could not compare these skills. Please try again.'
+      this._panel.webview.html = getCompareErrorHtml(headline, errNonce, raw)
     }
   }
 

--- a/packages/vscode-extension/src/views/SkillDiffPanel.ts
+++ b/packages/vscode-extension/src/views/SkillDiffPanel.ts
@@ -135,11 +135,11 @@ export class SkillDiffPanel {
       }
       const raw = err instanceof Error ? err.message : String(err)
       const errNonce = generateCspNonce()
-      this._panel.webview.html = getDiffErrorHtml(
-        'Could not check this skill for updates. Please try again.',
-        errNonce,
-        raw
-      )
+      const headline =
+        err instanceof McpToolError && err.code === 'SkillNotFound'
+          ? 'This skill could not be found in the registry. It may have been removed or renamed.'
+          : 'Could not check this skill for updates. Please try again.'
+      this._panel.webview.html = getDiffErrorHtml(headline, errNonce, raw)
     }
   }
 


### PR DESCRIPTION
## Summary

Group A of the Epic-D backlog follow-ups — two small, host-only VS Code extension changes (children of SMI-5287). Accumulates toward a 0.6.1 patch (not published here).

### SMI-5322 — precise `SkillNotFound` error code
- Adds `SkillNotFound` to the `McpToolErrorCode` union (now 6 values).
- `classifyIsErrorText` now maps the server's plain-text `Skill "x" not found` / `Invalid skill ID format` messages (`SKILL_NOT_FOUND` / `SKILL_INVALID_ID`) to `SkillNotFound`. The server's top-level catch emits only `error.message` (not the structured code), so classification is text-based; requiring the word **skill** preserves the tested `tool not found -> UnknownTool` contract.
- The `SkillNotFound` rule is ordered **before** `TierDenied` so a skill whose name contains a tier keyword (e.g. `plan-review`, `tier-manager`) does not misroute to the upgrade upsell (governance-caught).
- Routed to friendly messaging in `compareCommand`, `diffCommand`, and the Compare/Diff panel retry paths.

### SMI-5326 — inventory-audit `deep` opt-in
- New setting `skillsmith.inventoryAudit.deep` (default **false**). When enabled, the Audit Skill Inventory command passes `{ deep: true }` (exactOptionalPropertyTypes-safe — `{}` otherwise) to run the slower semantic-overlap pass.

## Tests
- New `classifyIsErrorText` unit test (incl. the tier-keyword-skill-name edge case + preserved contract).
- New `SkillNotFound` cases: client-layer (`skill_compare.test.ts`) + command-level routing (`compareSkills.test.ts`, `diffCommand.test.ts`).
- `auditInventory.test.ts`: deep-enabled assertion.

## Verification
Host green: typecheck, lint, build, **649 tests**, `package:check` (VSIX), `audit:standards` 0-failed (3 pre-existing warnings); all files <500 lines. Pre-merge governance review run; CRITICAL + MAJOR findings fixed in-PR.

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)