### PR TITLE
feat(vscode): native "View full text diff" action for the update advisor (SMI-5323)

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 
 - **Deep inventory audit** — a new setting `skillsmith.inventoryAudit.deep` (off by default) runs the slower semantic-overlap pass when you Audit Skill Inventory, surfacing near-duplicate skills beyond exact namespace clashes.
+- **View full text diff** — the update advisor (Check Skill for Updates) now has a "View full text diff" button that opens your installed `SKILL.md` against the registry's latest version in VS Code's native side-by-side diff editor, alongside the structured summary.
 
 ### Fixed
 

--- a/packages/vscode-extension/src/__tests__/SkillDiffPanel.textdiff.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillDiffPanel.textdiff.test.ts
@@ -33,7 +33,13 @@ vi.mock('../utils/csp.js', () => ({
   generateCspNonce: () => 'nonce',
   getSkillDiffCsp: () => "default-src 'none';",
 }))
-vi.mock('../mcp/McpClient.js', () => ({ getMcpClient: () => ({ isConnected: () => true }) }))
+vi.mock('../mcp/McpClient.js', () => ({
+  getMcpClient: () => ({
+    isConnected: () => true,
+    // Present so the retry path resolves cleanly (no unhandled rejection).
+    skillDiff: vi.fn().mockResolvedValue({ changeType: 'minor' }),
+  }),
+}))
 vi.mock('../mcp/tierDenied.js', () => ({ handleTierDenied: vi.fn() }))
 
 import * as vscode from 'vscode'
@@ -103,6 +109,33 @@ describe('SkillDiffPanel — viewTextDiff (SMI-5323)', () => {
     expect(oldUri.toString()).toBe('skillsmith-diff:smith-horn%2Fdocker/installed.md')
     expect(newUri.toString()).toBe('skillsmith-diff:smith-horn%2Fdocker/latest.md')
     expect(title).toBe('docker: installed ↔ latest')
+  })
+
+  it('uses the refreshed args after the singleton panel is reused for another skill', () => {
+    const mock = createMockPanel()
+    createWebviewPanel.mockReturnValue(mock.panel)
+
+    SkillDiffPanel.createOrShow({} as vscode.Uri, 'docker', RESPONSE, ARGS)
+    // Reuse the open panel for a different skill (no new webview created).
+    const argsB: SkillDiffArgs = {
+      skillId: 'community/kubectl',
+      oldContent: 'K8S OLD',
+      newContent: 'K8S NEW',
+    }
+    SkillDiffPanel.createOrShow({} as vscode.Uri, 'kubectl', RESPONSE, argsB)
+    expect(createWebviewPanel).toHaveBeenCalledTimes(1)
+
+    mock.send({ command: 'viewTextDiff' })
+
+    const [, oldUri, newUri, title] = executeCommand.mock.calls[0] as [
+      string,
+      vscode.Uri,
+      vscode.Uri,
+      string,
+    ]
+    expect(oldUri.toString()).toBe('skillsmith-diff:community%2Fkubectl/installed.md')
+    expect(newUri.toString()).toBe('skillsmith-diff:community%2Fkubectl/latest.md')
+    expect(title).toBe('kubectl: installed ↔ latest')
   })
 
   it('does not open a diff for an unrelated message', () => {

--- a/packages/vscode-extension/src/__tests__/SkillDiffPanel.textdiff.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillDiffPanel.textdiff.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for SkillDiffPanel's native text-diff action (SMI-5323).
+ *
+ * Drives the webview `viewTextDiff` message and asserts the panel opens VS
+ * Code's built-in diff editor (`vscode.diff`) with the two `skillsmith-diff:`
+ * URIs that the (real) content provider serves. Mirrors the createWebviewPanel
+ * mock style of CreateSkillPanel.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const executeCommand = vi.hoisted(() => vi.fn())
+const createWebviewPanel = vi.hoisted(() => vi.fn())
+
+vi.mock('vscode', () => ({
+  Uri: { parse: (s: string) => ({ toString: () => s }) },
+  ViewColumn: { One: 1 },
+  window: { createWebviewPanel, activeTextEditor: undefined },
+  commands: { executeCommand },
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+vi.mock('../views/diff-panel-html.js', () => ({
+  getDiffHtml: () => '<html><body>diff</body></html>',
+  getDiffErrorHtml: () => '<html><body>error</body></html>',
+}))
+vi.mock('../views/skill-panel-html.js', () => ({ getLoadingHtml: () => '<html>loading</html>' }))
+vi.mock('../utils/csp.js', () => ({
+  generateCspNonce: () => 'nonce',
+  getSkillDiffCsp: () => "default-src 'none';",
+}))
+vi.mock('../mcp/McpClient.js', () => ({ getMcpClient: () => ({ isConnected: () => true }) }))
+vi.mock('../mcp/tierDenied.js', () => ({ handleTierDenied: vi.fn() }))
+
+import * as vscode from 'vscode'
+import { SkillDiffPanel } from '../views/SkillDiffPanel.js'
+import type { McpSkillDiffResponse } from '../mcp/types.js'
+import type { SkillDiffArgs } from '../views/diff-panel-types.js'
+
+type MessageHandler = (msg: { command: string }) => void
+
+function createMockPanel() {
+  let messageHandler: MessageHandler | undefined
+  const panel = {
+    reveal: vi.fn(),
+    dispose: vi.fn(),
+    title: '',
+    webview: {
+      html: '',
+      onDidReceiveMessage: vi.fn(
+        (handler: MessageHandler, _ctx: unknown, subs: { dispose: () => void }[]) => {
+          messageHandler = handler
+          const d = { dispose: vi.fn() }
+          if (Array.isArray(subs)) subs.push(d)
+          return d
+        }
+      ),
+    },
+    onDidDispose: vi.fn((_h: () => void, _ctx: unknown, subs: { dispose: () => void }[]) => {
+      const d = { dispose: vi.fn() }
+      if (Array.isArray(subs)) subs.push(d)
+      return d
+    }),
+  }
+  return {
+    panel: panel as unknown as vscode.WebviewPanel,
+    send: (msg: { command: string }) => messageHandler?.(msg),
+  }
+}
+
+const RESPONSE = { changeType: 'minor' } as McpSkillDiffResponse
+const ARGS: SkillDiffArgs = {
+  skillId: 'smith-horn/docker',
+  oldContent: 'OLD CONTENT',
+  newContent: 'NEW CONTENT',
+}
+
+describe('SkillDiffPanel — viewTextDiff (SMI-5323)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    SkillDiffPanel.resetForTests()
+  })
+
+  it('opens vscode.diff with installed + latest skillsmith-diff URIs and a titled label', () => {
+    const mock = createMockPanel()
+    createWebviewPanel.mockReturnValue(mock.panel)
+
+    SkillDiffPanel.createOrShow({} as vscode.Uri, 'docker', RESPONSE, ARGS)
+    mock.send({ command: 'viewTextDiff' })
+
+    expect(executeCommand).toHaveBeenCalledTimes(1)
+    const [command, oldUri, newUri, title] = executeCommand.mock.calls[0] as [
+      string,
+      vscode.Uri,
+      vscode.Uri,
+      string,
+    ]
+    expect(command).toBe('vscode.diff')
+    expect(oldUri.toString()).toBe('skillsmith-diff:smith-horn%2Fdocker/installed.md')
+    expect(newUri.toString()).toBe('skillsmith-diff:smith-horn%2Fdocker/latest.md')
+    expect(title).toBe('docker: installed ↔ latest')
+  })
+
+  it('does not open a diff for an unrelated message', () => {
+    const mock = createMockPanel()
+    createWebviewPanel.mockReturnValue(mock.panel)
+
+    SkillDiffPanel.createOrShow({} as vscode.Uri, 'docker', RESPONSE, ARGS)
+    mock.send({ command: 'retry' })
+
+    expect(executeCommand).not.toHaveBeenCalled()
+  })
+})

--- a/packages/vscode-extension/src/__tests__/diff-panel-html.test.ts
+++ b/packages/vscode-extension/src/__tests__/diff-panel-html.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for the "View full text diff" affordance in diff-panel-html.ts
+ * (SMI-5323). Pure HTML builder — no webview needed.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({}))
+
+import { getDiffHtml } from '../views/diff-panel-html.js'
+import type { McpSkillDiffResponse } from '../mcp/types.js'
+
+const NONCE = 'testNonce1234567890'
+
+function makeResponse(overrides: Partial<McpSkillDiffResponse> = {}): McpSkillDiffResponse {
+  return {
+    changeType: 'minor',
+    recommendation: 'review-then-update',
+    sectionsAdded: [],
+    sectionsRemoved: [],
+    sectionsModified: [],
+    riskScoreDelta: null,
+    changelog: null,
+    ...overrides,
+  } as McpSkillDiffResponse
+}
+
+describe('getDiffHtml — View full text diff (SMI-5323)', () => {
+  it('renders the View full text diff button', () => {
+    const html = getDiffHtml('docker', makeResponse(), NONCE)
+    expect(html).toContain('id="textDiffBtn"')
+    expect(html).toContain('View full text diff')
+  })
+
+  it('wires the button to post viewTextDiff under the supplied nonce', () => {
+    const html = getDiffHtml('docker', makeResponse(), NONCE)
+    expect(html).toContain(`<script nonce="${NONCE}">`)
+    expect(html).toContain("command: 'viewTextDiff'")
+    expect(html).toContain('acquireVsCodeApi()')
+  })
+
+  it('escapes the skill name (no raw markup injection)', () => {
+    const html = getDiffHtml('<script>alert(1)</script>', makeResponse(), NONCE)
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(html).not.toContain('<script>alert(1)</script>')
+  })
+})

--- a/packages/vscode-extension/src/__tests__/skillDiffContentProvider.test.ts
+++ b/packages/vscode-extension/src/__tests__/skillDiffContentProvider.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for views/skillDiffContentProvider.ts (SMI-5323).
+ *
+ * The provider is a tiny in-memory store keyed by URI; we mock `vscode.Uri.parse`
+ * to a stable identity so `setContent` and `provideTextDocumentContent` round-trip.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Uri: {
+    parse: (s: string) => ({ toString: () => s }),
+  },
+}))
+
+import * as vscode from 'vscode'
+import { SkillDiffContentProvider } from '../views/skillDiffContentProvider.js'
+
+describe('SkillDiffContentProvider (SMI-5323)', () => {
+  it('exposes the skillsmith-diff scheme', () => {
+    expect(SkillDiffContentProvider.scheme).toBe('skillsmith-diff')
+  })
+
+  it('setContent returns a skillsmith-diff URI and serves the stored text', () => {
+    const provider = new SkillDiffContentProvider()
+    const uri = provider.setContent('org%2Ffoo/installed.md', 'old text')
+
+    expect(uri.toString()).toBe('skillsmith-diff:org%2Ffoo/installed.md')
+    expect(provider.provideTextDocumentContent(uri)).toBe('old text')
+  })
+
+  it('returns an empty string for an unknown URI', () => {
+    const provider = new SkillDiffContentProvider()
+    const unknown = vscode.Uri.parse('skillsmith-diff:never/set.md')
+
+    expect(provider.provideTextDocumentContent(unknown)).toBe('')
+  })
+
+  it('overwrites content for the same path so the map cannot grow unbounded', () => {
+    const provider = new SkillDiffContentProvider()
+    const first = provider.setContent('k/latest.md', 'v1')
+    const second = provider.setContent('k/latest.md', 'v2')
+
+    expect(first.toString()).toBe(second.toString())
+    expect(provider.provideTextDocumentContent(second)).toBe('v2')
+  })
+})

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -14,6 +14,10 @@ import { registerRecommendCommand } from './commands/recommendCommand.js'
 import { registerCompareCommand } from './commands/compareCommand.js'
 import { registerDiffCommand } from './commands/diffCommand.js'
 import { registerAuditInventoryCommand } from './commands/auditInventoryCommand.js'
+import {
+  SkillDiffContentProvider,
+  skillDiffContentProvider,
+} from './views/skillDiffContentProvider.js'
 import { initializeTelemetry } from './services/Telemetry.js'
 import { SkillDetailPanel } from './views/SkillDetailPanel.js'
 import { SkillService } from './services/SkillService.js'
@@ -183,6 +187,15 @@ export function activate(context: vscode.ExtensionContext): void {
   registerCompareCommand(context, skillService)
   registerDiffCommand(context, skillTreeDataProvider)
   registerAuditInventoryCommand(context)
+
+  // SMI-5323: serve installed vs registry-latest SKILL.md to the native diff
+  // editor opened from the update advisor's "View full text diff" action.
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(
+      SkillDiffContentProvider.scheme,
+      skillDiffContentProvider
+    )
+  )
 
   // Register refresh command
   const refreshCommand = vscode.commands.registerCommand('skillsmith.refreshSkills', () => {

--- a/packages/vscode-extension/src/views/SkillDiffPanel.ts
+++ b/packages/vscode-extension/src/views/SkillDiffPanel.ts
@@ -16,6 +16,7 @@ import { getDiffHtml, getDiffErrorHtml } from './diff-panel-html.js'
 import { getMcpClient } from '../mcp/McpClient.js'
 import { McpToolError } from '../mcp/McpToolError.js'
 import { handleTierDenied } from '../mcp/tierDenied.js'
+import { skillDiffContentProvider } from './skillDiffContentProvider.js'
 import type { McpSkillDiffResponse } from '../mcp/types.js'
 import type { DiffPanelMessage, SkillDiffArgs } from './diff-panel-types.js'
 
@@ -102,7 +103,27 @@ export class SkillDiffPanel {
   private _handleMessage(message: DiffPanelMessage): void {
     if (message.command === 'retry') {
       void this._retry()
+    } else if (message.command === 'viewTextDiff') {
+      this._openTextDiff()
     }
+  }
+
+  /**
+   * SMI-5323: open the installed vs registry-latest SKILL.md in VS Code's native
+   * diff editor. Both texts are already on `_args`; the content provider serves
+   * them under the read-only `skillsmith-diff:` scheme. The `.md` suffixes give
+   * the diff editor Markdown highlighting and readable tab labels.
+   */
+  private _openTextDiff(): void {
+    const key = encodeURIComponent(this._args.skillId)
+    const oldUri = skillDiffContentProvider.setContent(`${key}/installed.md`, this._args.oldContent)
+    const newUri = skillDiffContentProvider.setContent(`${key}/latest.md`, this._args.newContent)
+    void vscode.commands.executeCommand(
+      'vscode.diff',
+      oldUri,
+      newUri,
+      `${this._skillName}: installed ↔ latest`
+    )
   }
 
   /**

--- a/packages/vscode-extension/src/views/SkillDiffPanel.ts
+++ b/packages/vscode-extension/src/views/SkillDiffPanel.ts
@@ -27,7 +27,7 @@ export class SkillDiffPanel {
   private readonly _panel: vscode.WebviewPanel
   private _skillName: string
   private _response: McpSkillDiffResponse
-  private readonly _args: SkillDiffArgs
+  private _args: SkillDiffArgs
   private _disposables: vscode.Disposable[] = []
 
   /** Reset the singleton between tests. */
@@ -50,6 +50,9 @@ export class SkillDiffPanel {
       SkillDiffPanel.currentPanel._panel.reveal(column)
       SkillDiffPanel.currentPanel._skillName = skillName
       SkillDiffPanel.currentPanel._response = response
+      // Refresh _args too — a stale value would make "View full text diff" and
+      // retry operate on the previously-opened skill's content (SMI-5323).
+      SkillDiffPanel.currentPanel._args = args
       SkillDiffPanel.currentPanel._update()
       return
     }

--- a/packages/vscode-extension/src/views/diff-panel-html.ts
+++ b/packages/vscode-extension/src/views/diff-panel-html.ts
@@ -84,7 +84,12 @@ function getDiffStyles(): string {
     .meta-label { font-size: 0.85em; color: var(--vscode-descriptionForeground); }
     .changelog { white-space: pre-wrap; background: var(--vscode-textCodeBlock-background);
       padding: 12px; border-radius: 6px; font-size: 0.9em; }
-    .no-changes { margin-top: 20px; color: var(--vscode-descriptionForeground); }`
+    .no-changes { margin-top: 20px; color: var(--vscode-descriptionForeground); }
+    .text-diff-btn { margin-top: 8px; background: var(--vscode-button-secondaryBackground);
+      color: var(--vscode-button-secondaryForeground); border: none; padding: 8px 16px;
+      border-radius: 4px; font-size: 13px; font-weight: 500; cursor: pointer; }
+    .text-diff-btn:hover { background: var(--vscode-button-secondaryHoverBackground); }
+    .text-diff-btn:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px; }`
 }
 
 /** Render the risk-score-delta row when present. */
@@ -154,6 +159,10 @@ export function getDiffHtml(
     </div>
   </div>
 
+  <div class="meta-row">
+    <button id="textDiffBtn" class="text-diff-btn">View full text diff</button>
+  </div>
+
   ${added}
   ${removed}
   ${modified}
@@ -161,6 +170,16 @@ export function getDiffHtml(
 
   ${getRiskDeltaHtml(response.riskScoreDelta)}
   ${getChangelogHtml(response.changelog)}
+
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const textDiffBtn = document.getElementById('textDiffBtn');
+    if (textDiffBtn) {
+      textDiffBtn.addEventListener('click', () => {
+        vscode.postMessage({ command: 'viewTextDiff' });
+      });
+    }
+  </script>
 </body>
 </html>`
 }

--- a/packages/vscode-extension/src/views/diff-panel-types.ts
+++ b/packages/vscode-extension/src/views/diff-panel-types.ts
@@ -8,12 +8,11 @@
 
 /**
  * Messages posted from the Diff webview back to the extension host.
- * The diff panel is read-only, so the only inbound message is `retry`
- * (re-run the check after a transient `McpToolError`).
+ * - `retry`: re-run the check after a transient `McpToolError`.
+ * - `viewTextDiff` (SMI-5323): open the installed vs registry-latest SKILL.md
+ *   side-by-side in VS Code's native diff editor.
  */
-export interface DiffPanelMessage {
-  command: 'retry'
-}
+export type DiffPanelMessage = { command: 'retry' } | { command: 'viewTextDiff' }
 
 /**
  * Arguments for an MCP `skill_diff` call. Stored on the panel so a `retry`

--- a/packages/vscode-extension/src/views/skillDiffContentProvider.ts
+++ b/packages/vscode-extension/src/views/skillDiffContentProvider.ts
@@ -1,0 +1,41 @@
+/**
+ * Read-only content provider backing the native "View full text diff" action
+ * (SMI-5323). The structured update advisor (`SkillDiffPanel`) already holds the
+ * installed SKILL.md and the registry-latest SKILL.md; this provider serves
+ * those two texts to VS Code's built-in diff editor (`vscode.diff`) under the
+ * `skillsmith-diff:` scheme.
+ *
+ * Content lives in memory only and is overwritten on each invocation (keyed by
+ * URI), so the map holds at most two entries per skill the user inspects.
+ *
+ * @module views/skillDiffContentProvider
+ */
+import * as vscode from 'vscode'
+
+export class SkillDiffContentProvider implements vscode.TextDocumentContentProvider {
+  public static readonly scheme = 'skillsmith-diff'
+
+  private readonly _contents = new Map<string, string>()
+
+  /** VS Code calls this to populate each side of the diff editor. */
+  public provideTextDocumentContent(uri: vscode.Uri): string {
+    return this._contents.get(uri.toString()) ?? ''
+  }
+
+  /**
+   * Store `content` under `path` and return the `skillsmith-diff:` URI that
+   * serves it. Pass a `path` ending in `.md` so the diff editor highlights the
+   * content as Markdown and shows a readable tab label.
+   */
+  public setContent(path: string, content: string): vscode.Uri {
+    const uri = vscode.Uri.parse(`${SkillDiffContentProvider.scheme}:${path}`)
+    this._contents.set(uri.toString(), content)
+    return uri
+  }
+}
+
+/**
+ * Module singleton — registered once in `extension.ts` and shared by
+ * `SkillDiffPanel`, which writes content immediately before opening the diff.
+ */
+export const skillDiffContentProvider = new SkillDiffContentProvider()


### PR DESCRIPTION
## Summary

Group B of the Epic-D backlog follow-ups (child of SMI-5287) — adds a native text-diff action to the update advisor. Accumulates toward the 0.6.1 patch (not published here).

The Check-Skill-for-Updates advisor (`SkillDiffPanel`) ships a structured semantic summary. This adds a **"View full text diff"** button that opens your installed `SKILL.md` against the registry-latest version in VS Code's native side-by-side diff editor — *alongside* the structured view, not replacing it.

### How it works
- New `skillsmith-diff:` `TextDocumentContentProvider` (`skillDiffContentProvider.ts`) serves the two SKILL.md texts the panel already holds on its args. Registered once in `extension.ts`; content is in-memory and overwritten per skill/side.
- The button posts a `viewTextDiff` message; `SkillDiffPanel._openTextDiff` writes both sides to the provider and calls `vscode.diff(oldUri, newUri, title)`.
- Governance fix folded in: `createOrShow`'s singleton-reuse path now refreshes `_args` (previously only `_skillName`/`_response`), so reusing the open advisor for another skill no longer diffs stale content.

## Tests
- `skillDiffContentProvider.test.ts` — store/serve round-trip, unknown-URI empty, overwrite semantics.
- `diff-panel-html.test.ts` — button + nonce script presence, skill-name escaping.
- `SkillDiffPanel.textdiff.test.ts` — `viewTextDiff` invokes `vscode.diff` with the right URIs/title; the reuse-refresh path; the non-viewTextDiff message path.

## Verification
Host green: typecheck, lint, build, **659 tests**, `package:check` (VSIX), `audit:standards` 0-failed (3 pre-existing warnings); all files <500. Pre-merge governance run; MAJOR (stale `_args`) + MINOR fixed in-PR.

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)