### PR TITLE
fix(indexer): make the 1c backfill actually index skills — license gate + partition + Trees-branch (SMI-5319)

### DIFF
--- a/.github/workflows/indexer-backfill.yml
+++ b/.github/workflows/indexer-backfill.yml
@@ -71,6 +71,11 @@ on:
         required: false
         default: '50'
         type: string
+      min_size_bytes:
+        description: 'Skip size facets below this byte size on a FRESH crawl (e.g. 1024 to skip the 0-1023B noise band; ignored on resume). Default 0 = all facets.'
+        required: false
+        default: '0'
+        type: string
       supabase_env:
         description: 'Target Supabase environment'
         required: false
@@ -190,10 +195,14 @@ jobs:
           # finalize each dispatch — topic/high-trust are the cron's job, so this
           # keeps every backfill dispatch focused and resumable on the facet cursor.
           DISCOVERY_PHASE: '3'
-          # SMI-5286 1c: per-dispatch (sub)range budget — the facet driver writes a
+          # SMI-5286 1c: per-dispatch (sub)range budget -- the facet driver writes a
           # checkpoint after this many ranges so the run fits the GHA cap; re-dispatch
           # with resume_from=latest until facets_remaining=0.
           BACKFILL_MAX_RANGES: ${{ github.event.inputs.max_ranges || '50' }}
+          # SMI-5319 W4: fresh-start facet skip -- skip noise-band facets below this
+          # byte size on a cold-start dispatch; ignored on resume (cursor carries its
+          # own facet_index). Default 0 = all facets.
+          BACKFILL_MIN_SIZE_BYTES: ${{ github.event.inputs.min_size_bytes || '0' }}
           # Raised caps for backfill mode (per SPARC section #3).
           # These override the conservative cron defaults.
           CODE_SEARCH_MAX_PAGES: '10'

--- a/.github/workflows/indexer-backfill.yml
+++ b/.github/workflows/indexer-backfill.yml
@@ -76,6 +76,11 @@ on:
         required: false
         default: '0'
         type: string
+      max_skills_per_dispatch:
+        description: 'Stop the dispatch after roughly this many skills are admitted (checkpoints + exits; resume continues). 0 = no cap. Distinct from max_skills_per_repo.'
+        required: false
+        default: '0'
+        type: string
       supabase_env:
         description: 'Target Supabase environment'
         required: false
@@ -203,6 +208,10 @@ jobs:
           # byte size on a cold-start dispatch; ignored on resume (cursor carries its
           # own facet_index). Default 0 = all facets.
           BACKFILL_MIN_SIZE_BYTES: ${{ github.event.inputs.min_size_bytes || '0' }}
+          # Per-dispatch skill cap: stop the crawl at a clean range boundary once
+          # roughly this many skills are admitted, checkpoint, and exit so the next
+          # dispatch resumes. 0 = no cap. Distinct from max_skills_per_repo.
+          BACKFILL_MAX_SKILLS_PER_DISPATCH: ${{ github.event.inputs.max_skills_per_dispatch || '0' }}
           # Raised caps for backfill mode (per SPARC section #3).
           # These override the conservative cron defaults.
           CODE_SEARCH_MAX_PAGES: '10'

--- a/.github/workflows/indexer-backfill.yml
+++ b/.github/workflows/indexer-backfill.yml
@@ -192,7 +192,7 @@ jobs:
           BACKFILL_MAX_SKILLS_PER_REPO: ${{ github.event.inputs.max_skills_per_repo || '50' }}
           BACKFILL_PATH_PREFIX: ${{ github.event.inputs.path_prefix || '' }}
           # SMI-5286 1c: run ONLY Phase 3 (the size-faceted subdirectory crawl) +
-          # finalize each dispatch — topic/high-trust are the cron's job, so this
+          # finalize each dispatch -- topic/high-trust are the cron's job, so this
           # keeps every backfill dispatch focused and resumable on the facet cursor.
           DISCOVERY_PHASE: '3'
           # SMI-5286 1c: per-dispatch (sub)range budget -- the facet driver writes a

--- a/scripts/indexer/backfill-checkpoint.ts
+++ b/scripts/indexer/backfill-checkpoint.ts
@@ -372,13 +372,14 @@ export async function readLatestCheckpoint(
     }
 
     if (excludeDryRun) {
-      // Exclude rows where metadata.dry_run is the boolean true.
-      // PostgREST's `.not('metadata->>dry_run', 'eq', 'true')` emits:
-      //   metadata->>'dry_run' != 'true' OR metadata->>'dry_run' IS NULL
-      // The IS NULL branch means legacy rows with no dry_run field are
-      // INCLUDED — they are treated as live, which is the safe default
-      // (an operator pre-flight cleans untagged dry-run rows; see SMI-5319).
-      query = query.not('metadata->>dry_run', 'eq', 'true')
+      // Exclude rows where metadata.dry_run is the boolean true, but KEEP rows
+      // where it is absent/null (legacy pre-SMI-5319 checkpoints — treated as
+      // live, the safe default). NULL-safety is explicit here: `.not(...,'eq',
+      // 'true')` would emit `NOT (col = 'true')`, which is NULL (→ row dropped)
+      // when col IS NULL — silently cold-starting on legacy live checkpoints.
+      // The `.or(neq.true | is.null)` form emits the intended
+      // `col <> 'true' OR col IS NULL` (i.e. col IS DISTINCT FROM 'true').
+      query = query.or('metadata->>dry_run.neq.true,metadata->>dry_run.is.null')
     }
 
     const { data, error } = await query

--- a/scripts/indexer/backfill-checkpoint.ts
+++ b/scripts/indexer/backfill-checkpoint.ts
@@ -195,6 +195,16 @@ export interface BackfillCrawlOutcome {
 /**
  * Checkpoint payload persisted under `audit_logs.metadata`. `run_id` lets a
  * resume scope to a single dispatch lineage; the rest is operator observability.
+ *
+ * `dry_run` tags whether the writing dispatch was a dry run. Used by
+ * {@link readLatestCheckpoint} with `excludeDryRun: true` so a LIVE
+ * `resume_from=latest` does not accidentally resume from a DRY_RUN cursor.
+ *
+ * Legacy rows written before this field was added have `dry_run` absent
+ * (null in JSONB). {@link readLatestCheckpoint} treats those as LIVE rows
+ * (not excluded) — the operator is responsible for cleaning up any pre-existing
+ * dry-run checkpoints during pre-flight before the first tagged live run
+ * (SMI-5319 plan).
  */
 export interface BackfillCheckpointPayload {
   run_id: string
@@ -205,6 +215,12 @@ export interface BackfillCheckpointPayload {
   cap_saturated: boolean
   /** Repos skipped because their Trees response truncated (cap or API). */
   truncated_repo_count: number
+  /**
+   * Whether this checkpoint was written by a DRY_RUN dispatch. Tagged so live
+   * resumes can skip dry-run checkpoints via {@link readLatestCheckpoint}
+   * `excludeDryRun: true`.
+   */
+  dry_run: boolean
 }
 
 /**
@@ -212,8 +228,13 @@ export interface BackfillCheckpointPayload {
  * checkpoint failure cannot abort an in-flight backfill mid-facet (the operator
  * loop tolerates a missed checkpoint by re-running the same facet idempotently).
  *
+ * DRY_RUN dispatches intentionally write checkpoints so the operator can verify
+ * the resume loop end-to-end before flipping to live writes. The `dry_run` field
+ * in `metadata` lets a subsequent live `resume_from=latest` skip these rows when
+ * {@link readLatestCheckpoint} is called with `excludeDryRun: true`.
+ *
  * @param supabase - Supabase admin client.
- * @param payload - The checkpoint cursor + progress counters.
+ * @param payload - The checkpoint cursor + progress counters, including `dry_run`.
  * @returns true on a clean insert, false if the write was rejected/threw.
  */
 export async function writeCheckpoint(
@@ -233,6 +254,7 @@ export async function writeCheckpoint(
         facets_total: payload.facets_total,
         cap_saturated: payload.cap_saturated,
         truncated_repo_count: payload.truncated_repo_count,
+        dry_run: payload.dry_run,
       },
     })
     if (error) {
@@ -296,6 +318,31 @@ export function resolveTokenSource(env: NodeJS.ProcessEnv = process.env): 'app' 
 }
 
 /**
+ * Options for {@link readLatestCheckpoint}.
+ */
+export interface ReadLatestCheckpointOptions {
+  /**
+   * When true, excludes rows whose `metadata.dry_run` is exactly `'true'`
+   * (PostgREST text-cast of the JSONB boolean). Rows where `dry_run` is absent
+   * (null — legacy rows written before SMI-5319) are NOT excluded, preserving
+   * backward compatibility with untagged live checkpoints.
+   *
+   * Use `excludeDryRun: true` on a LIVE `resume_from=latest` call so it never
+   * resumes from a DRY_RUN cursor. DRY_RUN dispatches should pass `false` (the
+   * default) so they can verify the resume loop against the latest checkpoint
+   * regardless of whether it was written by a dry run or a live run.
+   *
+   * NOTE: legacy DRY_RUN checkpoints written before this field was added cannot
+   * be distinguished from live ones and are NOT excluded. The operator must clean
+   * up any pre-existing untagged dry-run checkpoints during pre-flight before the
+   * first tagged live run (SMI-5319 plan).
+   *
+   * @default false
+   */
+  excludeDryRun?: boolean
+}
+
+/**
  * Read the most recent checkpoint, optionally scoped to a single `run_id`.
  * Returns null when no checkpoint exists (cold start) or on read failure — the
  * caller treats null as "start from the beginning".
@@ -304,12 +351,15 @@ export function resolveTokenSource(env: NodeJS.ProcessEnv = process.env): 'app' 
  * @param runId - Optional dispatch lineage to scope the resume to. Omit (or pass
  *   undefined) to read the latest checkpoint across all runs (the `latest`
  *   default the workflow's `resume_from` input maps to).
+ * @param options - Additional query options (see {@link ReadLatestCheckpointOptions}).
  * @returns The latest matching checkpoint payload, or null.
  */
 export async function readLatestCheckpoint(
   supabase: SupabaseClient,
-  runId?: string
+  runId?: string,
+  options: ReadLatestCheckpointOptions = {}
 ): Promise<BackfillCheckpointPayload | null> {
+  const { excludeDryRun = false } = options
   try {
     let query = supabase
       .from('audit_logs')
@@ -319,6 +369,16 @@ export async function readLatestCheckpoint(
     if (runId !== undefined && runId !== '' && runId !== 'latest') {
       // `metadata->>'run_id'` text-extract filter (PostgREST JSON operator).
       query = query.eq('metadata->>run_id', runId)
+    }
+
+    if (excludeDryRun) {
+      // Exclude rows where metadata.dry_run is the boolean true.
+      // PostgREST's `.not('metadata->>dry_run', 'eq', 'true')` emits:
+      //   metadata->>'dry_run' != 'true' OR metadata->>'dry_run' IS NULL
+      // The IS NULL branch means legacy rows with no dry_run field are
+      // INCLUDED — they are treated as live, which is the safe default
+      // (an operator pre-flight cleans untagged dry-run rows; see SMI-5319).
+      query = query.not('metadata->>dry_run', 'eq', 'true')
     }
 
     const { data, error } = await query

--- a/scripts/indexer/code-search.facets.ts
+++ b/scripts/indexer/code-search.facets.ts
@@ -100,6 +100,35 @@ export function facetToQualifier(facet: SizeFacet): string {
 const OPEN_ENDED_BISECT_CEILING = 4 * 1024 * 1024
 
 /**
+ * Return the index of the first facet in the canonical {@link buildSizeFacets}
+ * ladder whose `hi >= minSizeBytes`. Used by the backfill crawl to skip the
+ * low-byte noise band (0-1023B facets) on a FRESH START when the operator
+ * knows real skills are always >=1024B (SMI-5319 W4).
+ *
+ * Contract:
+ * - Returns 0 when `minSizeBytes <= 0` (no skip — all facets included).
+ * - Returns the index of the FIRST facet whose `hi >= minSizeBytes`.
+ *   For the 9-bucket ladder: 1024 → 4, 2048 → 5, 4096 → 6, etc.
+ * - Clamps to the last valid index (never exceeds `facets.length - 1`) so a
+ *   huge `minSizeBytes` starts at the open-ended tail rather than going OOB.
+ * - RESUMES are NOT affected — this function is ONLY called on the fresh-start
+ *   path; resumed crawls carry their own `facet_index` from the checkpoint
+ *   cursor and never consult `min_size_bytes`.
+ *
+ * @param minSizeBytes - Minimum file size in bytes. Values <= 0 return 0.
+ * @returns Zero-based index into the static 9-bucket size ladder.
+ */
+export function firstFacetIndexForMinSize(minSizeBytes: number): number {
+  if (minSizeBytes <= 0) return 0
+  const facets = buildSizeFacets()
+  for (let i = 0; i < facets.length; i++) {
+    if (facets[i].hi >= minSizeBytes) return i
+  }
+  // minSizeBytes exceeds every finite hi: clamp to last index.
+  return facets.length - 1
+}
+
+/**
  * Split a facet into two disjoint, contiguous, inclusive halves that together
  * cover the SAME range (used when a facet saturates the 1000-result cap).
  * Finite: mid = lo + floor((hi - lo) / 2) → [{lo, hi: mid}, {lo: mid+1, hi}].

--- a/scripts/indexer/indexer-types.ts
+++ b/scripts/indexer/indexer-types.ts
@@ -60,10 +60,14 @@ export interface IndexerResult {
     repos_found: number
     total_found: number
     retries: number
-    /** Repos excluded because license is confirmed non-permissive */
+    /** SMI-5319: ~0 by default; only the SKILLSMITH_INDEXER_LICENSE_GATE kill-switch excludes repos */
     license_filtered: number
-    /** Repos skipped because the license API call failed — will retry next run */
+    /** Repos whose license API call failed — admitted with license:null (SMI-5319), counted for observability */
     license_fetch_failed: number
+    /** SMI-5319: skills admitted (indexed) this run */
+    admitted?: number
+    /** SMI-5319: admitted skills whose resolved SPDX is null (the null-license rate) */
+    license_null?: number
     /** Number of pages where GitHub returned incomplete_results (query timeout) */
     incomplete_results?: number
     /** Which search strategy was used: 'broad' (single query) or 'prefix-fallback' (3 scoped queries) */

--- a/scripts/indexer/indexer-types.ts
+++ b/scripts/indexer/indexer-types.ts
@@ -62,12 +62,14 @@ export interface IndexerResult {
     retries: number
     /** SMI-5319: ~0 by default; only the SKILLSMITH_INDEXER_LICENSE_GATE kill-switch excludes repos */
     license_filtered: number
-    /** Repos whose license API call failed — admitted with license:null (SMI-5319), counted for observability */
+    /** Repos whose repo-metadata API call failed — skipped (no resolvable branch), retried next run (SMI-5319) */
     license_fetch_failed: number
     /** SMI-5319: skills admitted (indexed) this run */
     admitted?: number
     /** SMI-5319: admitted skills whose resolved SPDX is null (the null-license rate) */
     license_null?: number
+    /** SMI-5319: repos skipped because no default branch could be resolved (code search omits it); retried next run */
+    no_default_branch?: number
     /** Number of pages where GitHub returned incomplete_results (query timeout) */
     incomplete_results?: number
     /** Which search strategy was used: 'broad' (single query) or 'prefix-fallback' (3 scoped queries) */

--- a/scripts/indexer/license-filter.ts
+++ b/scripts/indexer/license-filter.ts
@@ -61,42 +61,66 @@ export function isPermissiveLicense(spdxId: string | null | undefined): boolean 
 }
 
 /**
- * Result of a license fetch operation.
+ * Result of a repo-metadata fetch (license + default branch).
  * Distinguishes between a confirmed non-permissive license and a fetch failure,
  * which produce different outcomes in the caller (licenseFiltered vs licenseFetchFailed).
+ *
+ * SMI-5319: `defaultBranch` is fetched ALONGSIDE the license from the SAME
+ * `GET /repos/{owner}/{repo}` call. The GitHub /search/code API does NOT return
+ * `default_branch` (it surfaces as null in the code-search mapper), so the Trees
+ * enumeration (`enumerateRepoSkillPaths`) and the emitted skill tree URL must use
+ * THIS branch — not `repo.defaultBranch` from the code-search result — to avoid
+ * `GET /git/trees/null` → 404 for every repo.
  */
 export interface FetchLicenseResult {
   /** SPDX license identifier, or null if the repo has no detected license. */
   license: string | null
   /**
-   * True when the license could not be fetched due to a rate limit or network
+   * SMI-5319: the repository's default branch (e.g. 'main'), or null if it could
+   * not be resolved (fetch failed, or the field was absent from the response).
+   * Callers MUST NOT enumerate a repo whose `defaultBranch` is null.
+   */
+  defaultBranch: string | null
+  /**
+   * True when the metadata could not be fetched due to a rate limit or network
    * error (after retries). The repo is excluded from this run but should not
    * be counted as license-filtered — it may succeed on the next indexer run.
+   * When true, `defaultBranch` is null.
    */
   fetchFailed: boolean
 }
 
 /**
- * GitHub repository license response shape
+ * GitHub repository metadata response shape.
+ * SMI-5319: `default_branch` is read alongside the license SPDX id.
  */
 interface RepoLicenseResponse {
   license: {
     spdx_id: string
   } | null
+  default_branch?: string | null
 }
 
 /** Retry delays for exponential backoff on rate-limit responses (ms) */
 const LICENSE_RETRY_DELAYS = [1000, 2000, 4000]
 
 /**
- * Fetch the SPDX license identifier for a GitHub repository.
+ * Fetch the SPDX license identifier AND the default branch for a GitHub repo
+ * via a single `GET /repos/{owner}/{repo}` call.
  *
- * Used for code search results which do not include license data in the
- * search response. Topic search results include license in the GitHub Search
- * API response and do not need this function.
+ * Used for code search results which do not include license data — NOR the
+ * default branch (`default_branch` is null on the /search/code API) — in the
+ * search response. Topic search results include both in the GitHub Search API
+ * response and do not need this function.
  *
- * Returns `{ license: null, fetchFailed: false }` for repos with no license.
- * Returns `{ license: null, fetchFailed: true }` for rate-limit/network errors.
+ * Returns `{ license: null, defaultBranch: <branch>, fetchFailed: false }` for
+ * repos with no detected license. Returns
+ * `{ license: null, defaultBranch: null, fetchFailed: true }` for
+ * rate-limit/network errors (after retries).
+ *
+ * SMI-5319: the default branch is read from `data.default_branch` on the SAME
+ * response, so the Trees enumeration and the emitted skill tree URL can use the
+ * REAL branch instead of the null `default_branch` from the code-search mapper.
  *
  * SMI-4852: Builds headers internally (matching Deno parent), threads
  * `telemetry`, routes through `withRateLimitTracking` (Hard Rule 1).
@@ -119,7 +143,7 @@ export async function fetchRepoLicense(
     validateGitHubParams(owner, repo)
   } catch {
     console.log(`[LicenseFilter] Skipping invalid repo: ${sanitizeForLog(`${owner}/${repo}`)}`)
-    return { license: null, fetchFailed: false }
+    return { license: null, defaultBranch: null, fetchFailed: false }
   }
 
   const url = `https://api.github.com/repos/${owner}/${repo}`
@@ -133,7 +157,11 @@ export async function fetchRepoLicense(
 
       if (response.ok) {
         const data = (await response.json()) as RepoLicenseResponse
-        return { license: data.license?.spdx_id ?? null, fetchFailed: false }
+        return {
+          license: data.license?.spdx_id ?? null,
+          defaultBranch: data.default_branch ?? null,
+          fetchFailed: false,
+        }
       }
 
       // Rate limit — retry with backoff
@@ -150,14 +178,14 @@ export async function fetchRepoLicense(
         console.log(
           `[LicenseFilter] Rate limit exhausted for ${sanitizeForLog(`${owner}/${repo}`)}. Remaining: ${remaining}`
         )
-        return { license: null, fetchFailed: true }
+        return { license: null, defaultBranch: null, fetchFailed: true }
       }
 
       // Non-retryable HTTP error (404, 5xx, etc.)
       console.log(
         `[LicenseFilter] HTTP ${response.status} for ${sanitizeForLog(`${owner}/${repo}`)}`
       )
-      return { license: null, fetchFailed: response.status >= 500 }
+      return { license: null, defaultBranch: null, fetchFailed: response.status >= 500 }
     } catch (error) {
       if (attempt < LICENSE_RETRY_DELAYS.length) {
         const delayMs = LICENSE_RETRY_DELAYS[attempt]
@@ -170,9 +198,9 @@ export async function fetchRepoLicense(
       console.log(
         `[LicenseFilter] Network error exhausted retries for ${sanitizeForLog(`${owner}/${repo}`)}: ${error instanceof Error ? error.message : 'Unknown'}`
       )
-      return { license: null, fetchFailed: true }
+      return { license: null, defaultBranch: null, fetchFailed: true }
     }
   }
 
-  return { license: null, fetchFailed: true }
+  return { license: null, defaultBranch: null, fetchFailed: true }
 }

--- a/scripts/indexer/parse-env.ts
+++ b/scripts/indexer/parse-env.ts
@@ -170,7 +170,12 @@ export function parseEnv(env: NodeJS.ProcessEnv = process.env): IndexerEnv {
     // Per-dispatch skill cap: stop the crawl at a clean range boundary once
     // roughly this many skills are admitted, checkpoint, and exit. Default 0 = no
     // cap. Distinct from the per-repo cap BACKFILL_MAX_SKILLS_PER_REPO.
-    const BACKFILL_MAX_SKILLS_PER_DISPATCH = getInt('BACKFILL_MAX_SKILLS_PER_DISPATCH', 0)
+    // Clamp to >= 0: a negative value would be truthy in the cap guard and trip
+    // the per-dispatch break immediately (exit after the first range, 0 skills).
+    const BACKFILL_MAX_SKILLS_PER_DISPATCH = Math.max(
+      0,
+      getInt('BACKFILL_MAX_SKILLS_PER_DISPATCH', 0)
+    )
 
     // Concurrency: kill-switch (env=1) forces 1, else CONCURRENCY env or D-3 default of 2.
     const kill_switch_engaged = getBool('CONCURRENCY_KILL_SWITCH', false)

--- a/scripts/indexer/parse-env.ts
+++ b/scripts/indexer/parse-env.ts
@@ -50,6 +50,15 @@ export interface IndexerEnv {
    * and the operator re-dispatches with `resume_from=latest`.
    */
   BACKFILL_MAX_RANGES: number
+  /**
+   * SMI-5319 W4: minimum file size (bytes) for the backfill crawl's FRESH START.
+   * When > 0, the facet driver begins at the first facet whose `hi >=
+   * BACKFILL_MIN_SIZE_BYTES` instead of facet 0, skipping the low-byte noise band
+   * (0-1023B facets are GitHub-tokenized stubs that admit zero real skills).
+   * Default 0 = all facets. Only applied on a fresh start — RESUMES carry their
+   * own facet_index from the checkpoint cursor and are unaffected.
+   */
+  BACKFILL_MIN_SIZE_BYTES: number
 }
 
 function getRequired(name: string): string {
@@ -146,6 +155,11 @@ export function parseEnv(env: NodeJS.ProcessEnv = process.env): IndexerEnv {
         ? undefined
         : backfillPathPrefixRaw
     const BACKFILL_MAX_RANGES = getInt('BACKFILL_MAX_RANGES', 150)
+    // SMI-5319 W4: fresh-start facet skip — skip the 0-1023B noise band on a
+    // cold-start dispatch. Default 0 = all facets (no skip). Only applied on the
+    // fresh-start path; RESUMES carry their own facet_index from the checkpoint
+    // cursor and are unaffected.
+    const BACKFILL_MIN_SIZE_BYTES = getInt('BACKFILL_MIN_SIZE_BYTES', 0)
 
     // Concurrency: kill-switch (env=1) forces 1, else CONCURRENCY env or D-3 default of 2.
     const kill_switch_engaged = getBool('CONCURRENCY_KILL_SWITCH', false)
@@ -172,6 +186,7 @@ export function parseEnv(env: NodeJS.ProcessEnv = process.env): IndexerEnv {
       BACKFILL_MODE,
       BACKFILL_PATH_PREFIX,
       BACKFILL_MAX_RANGES,
+      BACKFILL_MIN_SIZE_BYTES,
     }
   } finally {
     process.env = prev

--- a/scripts/indexer/parse-env.ts
+++ b/scripts/indexer/parse-env.ts
@@ -59,6 +59,13 @@ export interface IndexerEnv {
    * own facet_index from the checkpoint cursor and are unaffected.
    */
   BACKFILL_MIN_SIZE_BYTES: number
+  /**
+   * Per-dispatch skill cap: the facet driver stops at a clean range boundary once
+   * roughly this many skills are admitted, checkpoints, and exits so the next
+   * dispatch resumes. Default 0 = no cap. Distinct from the per-repo cap
+   * BACKFILL_MAX_SKILLS_PER_REPO.
+   */
+  BACKFILL_MAX_SKILLS_PER_DISPATCH: number
 }
 
 function getRequired(name: string): string {
@@ -160,6 +167,10 @@ export function parseEnv(env: NodeJS.ProcessEnv = process.env): IndexerEnv {
     // fresh-start path; RESUMES carry their own facet_index from the checkpoint
     // cursor and are unaffected.
     const BACKFILL_MIN_SIZE_BYTES = getInt('BACKFILL_MIN_SIZE_BYTES', 0)
+    // Per-dispatch skill cap: stop the crawl at a clean range boundary once
+    // roughly this many skills are admitted, checkpoint, and exit. Default 0 = no
+    // cap. Distinct from the per-repo cap BACKFILL_MAX_SKILLS_PER_REPO.
+    const BACKFILL_MAX_SKILLS_PER_DISPATCH = getInt('BACKFILL_MAX_SKILLS_PER_DISPATCH', 0)
 
     // Concurrency: kill-switch (env=1) forces 1, else CONCURRENCY env or D-3 default of 2.
     const kill_switch_engaged = getBool('CONCURRENCY_KILL_SWITCH', false)
@@ -187,6 +198,7 @@ export function parseEnv(env: NodeJS.ProcessEnv = process.env): IndexerEnv {
       BACKFILL_PATH_PREFIX,
       BACKFILL_MAX_RANGES,
       BACKFILL_MIN_SIZE_BYTES,
+      BACKFILL_MAX_SKILLS_PER_DISPATCH,
     }
   } finally {
     process.env = prev

--- a/scripts/indexer/run.ts
+++ b/scripts/indexer/run.ts
@@ -171,6 +171,9 @@ async function runDiscoveryBranch(
       perPage: 100,
       maxPagesPerRange: env.CODE_SEARCH_MAX_PAGES,
       maxRangesPerDispatch: env.BACKFILL_MAX_RANGES,
+      // SMI-5319 W4: only applied on a fresh start (null cursor); resumes
+      // carry their own facet_index from the checkpoint and are unaffected.
+      minSizeBytes: env.BACKFILL_MIN_SIZE_BYTES,
     }
   }
 

--- a/scripts/indexer/run.ts
+++ b/scripts/indexer/run.ts
@@ -174,6 +174,8 @@ async function runDiscoveryBranch(
       // SMI-5319 W4: only applied on a fresh start (null cursor); resumes
       // carry their own facet_index from the checkpoint and are unaffected.
       minSizeBytes: env.BACKFILL_MIN_SIZE_BYTES,
+      // Per-dispatch skill cap (0 = no cap). Distinct from per-repo cap.
+      maxSkillsPerDispatch: env.BACKFILL_MAX_SKILLS_PER_DISPATCH,
     }
   }
 

--- a/scripts/indexer/run.ts
+++ b/scripts/indexer/run.ts
@@ -142,12 +142,19 @@ async function runDiscoveryBranch(
   // advanced cursor returns on `result.backfill_crawl` and is checkpointed below.
   // `RESUME_FROM` ('latest' or a specific run_id) maps to the workflow's
   // `resume_from` input; the NEW checkpoint is keyed on GITHUB_RUN_ID.
+  //
+  // SMI-5319 (W3): a LIVE run passes excludeDryRun: true so it cannot
+  // accidentally resume from a DRY_RUN checkpoint cursor. A DRY_RUN dispatch
+  // passes false (the default) — it should still resume from the latest
+  // checkpoint (dry-run or live) to verify the resume loop end-to-end.
   let checkpointId: string | null = null
   let backfillFacetPlan: BackfillFacetPlan | undefined
   const backfillRunId = process.env.GITHUB_RUN_ID ?? requestId
   if (env.BACKFILL_MODE) {
     const resumeFrom = process.env.RESUME_FROM
-    const checkpoint = await readLatestCheckpoint(supabase, resumeFrom)
+    const checkpoint = await readLatestCheckpoint(supabase, resumeFrom, {
+      excludeDryRun: !env.DRY_RUN,
+    })
     if (checkpoint) {
       const { path, facet, last_page } = checkpoint.cursor
       console.log(
@@ -201,6 +208,8 @@ async function runDiscoveryBranch(
   // (resume_from=latest) continues mid-facet. Written even in DRY_RUN so the
   // operator can verify the resume loop before flipping to a live write
   // (audit_logs is append-only telemetry, not the skills registry).
+  // SMI-5319 (W3): stamp dry_run so a subsequent live resume_from=latest can
+  // skip these rows via readLatestCheckpoint's excludeDryRun: true option.
   if (env.BACKFILL_MODE && result.backfill_crawl) {
     const bc = result.backfill_crawl
     const wrote = await writeCheckpoint(supabase, {
@@ -210,6 +219,7 @@ async function runDiscoveryBranch(
       facets_total: bc.facets_total,
       cap_saturated: bc.cap_saturated,
       truncated_repo_count: bc.truncated_repo_count,
+      dry_run: env.DRY_RUN,
     })
     if (wrote) checkpointId = backfillRunId
     console.log(

--- a/scripts/indexer/subdirectory-search.helpers.ts
+++ b/scripts/indexer/subdirectory-search.helpers.ts
@@ -237,8 +237,11 @@ export async function processSearchResults(
 
     // SMI-5319: without a resolvable default branch we CANNOT enumerate the repo
     // (`GET /git/trees/null` → 404 for every path) and MUST NOT emit a row with a
-    // null branch. Skip and retry on the next run. NOT added to seenUrls so the
-    // skill paths remain re-discoverable.
+    // null branch. Skip. Retry happens on the NEXT indexer run: `seenUrls` and
+    // `enumeratedRepos` are run-scoped (allocated fresh per `runSubdirectorySearch`),
+    // so a later run with a resolvable branch re-discovers and re-enumerates this
+    // repo. (Within THIS run it is not retried — the `enumeratedRepos` once-guard
+    // already holds `repoKey`, and this hit's `dedupKey` is already in `seenUrls`.)
     if (branch === null) {
       console.log(`[BroadDiscovery] No default branch, skipping (retry next run): ${repo.fullName}`)
       stats.noDefaultBranch++

--- a/scripts/indexer/subdirectory-search.helpers.ts
+++ b/scripts/indexer/subdirectory-search.helpers.ts
@@ -45,14 +45,51 @@ import type { SkillMdValidation } from './skill-processor.ts'
  * SMI-5319: The single shared derivation of a per-run repo cache key.
  *
  * Used as the key for BOTH the `enumeratedRepos` once-guard AND the
- * `licenseCache` map so the write-key (when a license is resolved + cached) and
- * the read-key (when a cached license is consumed) are provably identical — a
+ * `repoMetaCache` map so the write-key (when repo metadata is resolved + cached)
+ * and the read-key (when cached metadata is consumed) are provably identical — a
  * concurrency-auditor Pattern-3 (cache key-shape mismatch, SMI-4861) invariant.
  * Centralizing it here removes the inline `${owner}/${repoName}` that previously
  * lived at two call sites.
  */
 export function repoCacheKey(owner: string, repoName: string): string {
   return `${owner}/${repoName}`
+}
+
+/**
+ * SMI-5319: per-run cached repo metadata resolved once via the SAME
+ * `GET /repos/{owner}/{repo}` call (`fetchRepoLicense`). The code-search API does
+ * not return `default_branch`, so the REAL branch from this metadata — not
+ * `repo.defaultBranch` (null) — drives both the Trees enumeration and the emitted
+ * skill tree URL. A `defaultBranch` of null means the repo cannot be enumerated
+ * this run (fetch failed or the field was absent) and must be skipped.
+ */
+export interface RepoMeta {
+  /** Resolved SPDX license id (surfaced metadata), or null. */
+  license: string | null
+  /** Resolved default branch, or null when it could not be resolved. */
+  defaultBranch: string | null
+}
+
+/**
+ * Mutable per-run counters accumulated across every `processSearchResults` call.
+ * Shared by the broad/fallback loop and the backfill crawl so the shape stays in
+ * lock-step at all three threading sites.
+ */
+export interface SubdirSearchStats {
+  /** Repos dropped by the legacy kill-switch license gate (~0 by default). */
+  licenseFiltered: number
+  /** Metadata-fetch failures (rate-limit / network, after retries). */
+  licenseFetchFailed: number
+  /** Skills admitted (indexed) this run. */
+  admitted: number
+  /** Admitted skills whose resolved SPDX is null. */
+  licenseNull: number
+  /**
+   * SMI-5319: repos skipped because no default branch could be resolved (the
+   * code-search API omits `default_branch` and the `GET /repos` fallback failed
+   * or returned no branch). Skipped repos are retried on the next run.
+   */
+  noDefaultBranch: number
 }
 
 /**
@@ -63,12 +100,20 @@ export function repoCacheKey(owner: string, repoName: string): string {
  * ALL valid skills regardless of license and records the resolved SPDX id as
  * surfaced metadata (the consumer decides). The ONLY admission filter is the
  * existing strict validity path (`enumerateRepoSkillPaths` +
- * `checkSkillMdExists`). License resolution is now once-per-repo, AFTER the
- * `enumeratedRepos` once-guard, cached in `licenseCache` keyed by
- * {@link repoCacheKey} (the same derivation as the once-guard, so write-key ===
- * read-key), and NEVER drops a skill — a fetch failure records `license: null`
- * and proceeds. A kill-switch (`SKILLSMITH_INDEXER_LICENSE_GATE === 'true'`)
- * restores the legacy exclude-non-permissive behavior without a deploy.
+ * `checkSkillMdExists`). Repo metadata (license + default branch) is resolved
+ * once-per-repo, AFTER the `enumeratedRepos` once-guard but BEFORE the Trees
+ * enumeration, cached in `repoMetaCache` keyed by {@link repoCacheKey} (the same
+ * derivation as the once-guard, so write-key === read-key). A license-fetch
+ * failure records `license: null` and never drops a skill. A kill-switch
+ * (`SKILLSMITH_INDEXER_LICENSE_GATE === 'true'`) restores the legacy
+ * exclude-non-permissive behavior without a deploy.
+ *
+ * SMI-5319 (Trees default-branch fix): the code-search API does NOT return
+ * `default_branch`, so `repo.defaultBranch` is null. The REAL branch comes from
+ * the same `GET /repos` metadata call and is passed to `enumerateRepoSkillPaths`
+ * AND `buildSkillTreeUrl`. A repo whose default branch cannot be resolved is
+ * skipped (NOT enumerated with a null branch, which 404s every Trees call) and
+ * retried on the next run.
  *
  * SMI-4852: Threads `telemetry` to downstream `fetchRepoLicense` and
  * `checkSkillMdExists` calls so every GitHub API hit lands in the shared
@@ -89,16 +134,11 @@ export async function processSearchResults(
   validationCache: Map<string, SkillMdValidation>,
   validationOptions: { strictValidation?: boolean; minContentLength?: number },
   repos: GitHubRepository[],
-  stats: {
-    licenseFiltered: number
-    licenseFetchFailed: number
-    admitted: number
-    licenseNull: number
-  },
+  stats: SubdirSearchStats,
   telemetry: RateLimitTelemetry,
   enumerateTelemetry: EnumerateTelemetry,
   enumeratedRepos: Set<string>,
-  licenseCache: Map<string, string | null>
+  repoMetaCache: Map<string, RepoMeta>
 ): Promise<void> {
   // SMI-5319 kill-switch: when set to the literal string 'true', restore the
   // legacy pre-validity license ADMISSION gate (exclude non-permissive repos)
@@ -112,25 +152,26 @@ export async function processSearchResults(
     if (seenUrls.has(dedupKey)) continue
 
     // SMI-5319: keyed via the shared `repoCacheKey` derivation so the once-guard
-    // key (enumeratedRepos) and the licenseCache key are provably identical
+    // key (enumeratedRepos) and the repoMetaCache key are provably identical
     // (concurrency-auditor Pattern-3 invariant).
     const repoKey = repoCacheKey(repo.owner, repo.repoName)
 
     // SMI-5319 kill-switch (legacy path only): the OLD pre-validity admission gate.
-    // Fetch SPDX from the GitHub API and drop the repo if the license could not be
-    // fetched (retry next run) or is confirmed non-permissive. Disabled by default
-    // — the new behavior resolves license once-per-repo AFTER the validity gate and
-    // never drops a skill. When the gate admits a repo, the just-fetched SPDX is
-    // seeded into `licenseCache` so the post-validity resolution below reuses it
-    // (no second fetch there). NOTE: this break-glass loop runs before the
-    // `enumeratedRepos` once-guard, so a repo surfacing via multiple skillPaths is
-    // re-fetched here per hit — acceptable on the default-off legacy path.
+    // Fetch repo metadata from the GitHub API and drop the repo if it could not be
+    // fetched (retry next run) or the license is confirmed non-permissive. Disabled
+    // by default — the new behavior resolves metadata once-per-repo AFTER the
+    // once-guard and never drops a skill. When the gate admits a repo, the
+    // just-fetched metadata is seeded into `repoMetaCache` so the post-once-guard
+    // resolution below reuses it (no second fetch there). NOTE: this break-glass
+    // loop runs before the `enumeratedRepos` once-guard, so a repo surfacing via
+    // multiple skillPaths is re-fetched here per hit — acceptable on the
+    // default-off legacy path.
     if (legacyLicenseGate) {
-      const { license: spdxId, fetchFailed } = await fetchRepoLicense(
-        repo.owner,
-        repo.repoName,
-        telemetry
-      )
+      const {
+        license: spdxId,
+        defaultBranch,
+        fetchFailed,
+      } = await fetchRepoLicense(repo.owner, repo.repoName, telemetry)
 
       if (fetchFailed) {
         // API failure — skip this run but don't count as license-filtered.
@@ -149,8 +190,10 @@ export async function processSearchResults(
         continue
       }
 
-      // Admitted by the legacy gate: reuse this SPDX for the metadata resolution.
-      if (!licenseCache.has(repoKey)) licenseCache.set(repoKey, spdxId)
+      // Admitted by the legacy gate: reuse this metadata for the resolution below.
+      if (!repoMetaCache.has(repoKey)) {
+        repoMetaCache.set(repoKey, { license: spdxId, defaultBranch })
+      }
     }
 
     // Mark this code-search result consumed (per-repo+skillPath identity) so the
@@ -165,10 +208,48 @@ export async function processSearchResults(
     }
     enumeratedRepos.add(repoKey)
 
+    // SMI-5319: resolve repo metadata (license + default branch) ONCE per repo,
+    // AFTER the once-guard but BEFORE enumeration, cached on `repoKey` (the SAME
+    // key as the once-guard above, so write-key === read-key). The code-search API
+    // does NOT return `default_branch` (`repo.defaultBranch` is null), so the REAL
+    // branch comes from this `GET /repos` call. A metadata-fetch failure records
+    // `license: null` + `defaultBranch: null`. The repo is enumerated once per run,
+    // so a cache miss here means exactly one fetch.
+    let meta: RepoMeta
+    if (repoMetaCache.has(repoKey)) {
+      meta = repoMetaCache.get(repoKey) ?? { license: null, defaultBranch: null }
+    } else {
+      const { license, defaultBranch, fetchFailed } = await fetchRepoLicense(
+        repo.owner,
+        repo.repoName,
+        telemetry
+      )
+      // Ignore fetchFailed for license: record null and proceed (never drop, never
+      // retry-storm). A failed fetch also leaves `defaultBranch` null → the repo is
+      // skipped below and retried next run.
+      meta = { license: fetchFailed ? null : license, defaultBranch }
+      if (fetchFailed) stats.licenseFetchFailed++
+      repoMetaCache.set(repoKey, meta)
+    }
+    const spdx = meta.license
+    const branch = meta.defaultBranch
+    if (spdx === null) stats.licenseNull++
+
+    // SMI-5319: without a resolvable default branch we CANNOT enumerate the repo
+    // (`GET /git/trees/null` → 404 for every path) and MUST NOT emit a row with a
+    // null branch. Skip and retry on the next run. NOT added to seenUrls so the
+    // skill paths remain re-discoverable.
+    if (branch === null) {
+      console.log(`[BroadDiscovery] No default branch, skipping (retry next run): ${repo.fullName}`)
+      stats.noDefaultBranch++
+      await delay(50)
+      continue
+    }
+
     const { entries, truncatedByApi, truncatedByCap } = await enumerateRepoSkillPaths(
       repo.owner,
       repo.repoName,
-      repo.defaultBranch,
+      branch,
       telemetry,
       enumerateTelemetry
     )
@@ -185,23 +266,6 @@ export async function processSearchResults(
       console.log(`[BroadDiscovery] Per-repo cap reached, taking first N: ${repo.fullName}`)
     }
 
-    // SMI-5319: resolve the license ONCE per repo, AFTER the validity gate
-    // (enumeration succeeded), cached on `repoKey` (the SAME key as the
-    // once-guard above). A fetch failure records `license: null` and PROCEEDS —
-    // the license is surfaced metadata only, never an admission filter. The repo
-    // is enumerated once per run, so a cache miss here means exactly one fetch.
-    let spdx: string | null
-    if (licenseCache.has(repoKey)) {
-      spdx = licenseCache.get(repoKey) ?? null
-    } else {
-      const { license, fetchFailed } = await fetchRepoLicense(repo.owner, repo.repoName, telemetry)
-      // Ignore fetchFailed: record null and proceed (never drop, never retry-storm).
-      spdx = fetchFailed ? null : license
-      if (fetchFailed) stats.licenseFetchFailed++
-      licenseCache.set(repoKey, spdx)
-    }
-    if (spdx === null) stats.licenseNull++
-
     // Validate each enumerated SKILL.md independently (§#4 strict gate) and emit
     // one per-skill GitHubRepository with a distinct tree URL (C-1) per valid path.
     for (const entry of entries) {
@@ -209,7 +273,7 @@ export async function processSearchResults(
       const installable = await checkSkillMdExists(
         repo.owner,
         repo.repoName,
-        repo.defaultBranch,
+        branch,
         validationCache,
         telemetry,
         skillPath,
@@ -220,10 +284,11 @@ export async function processSearchResults(
       // (reconstructed from owner/repoName), NOT from `repo.url` — by this point
       // `repo.url` is already the code-search mapper's tree URL, so reusing it
       // would double the `/tree/<branch>` segment. `skillUrl` already encodes
-      // `skillPath`, so it alone is the dedup key.
+      // `skillPath`, so it alone is the dedup key. SMI-5319: built with the FETCHED
+      // `branch` (not `repo.defaultBranch`, which is null from code search).
       const skillUrl = buildSkillTreeUrl(
         `https://github.com/${repo.owner}/${repo.repoName}`,
-        repo.defaultBranch,
+        branch,
         skillPath
       )
       if (seenUrls.has(skillUrl)) continue
@@ -301,16 +366,11 @@ export async function runBackfillFacetCrawl(
   validationCache: Map<string, SkillMdValidation>,
   validationOptions: { strictValidation?: boolean; minContentLength?: number },
   repos: GitHubRepository[],
-  stats: {
-    licenseFiltered: number
-    licenseFetchFailed: number
-    admitted: number
-    licenseNull: number
-  },
+  stats: SubdirSearchStats,
   telemetry: RateLimitTelemetry,
   enumerateTelemetry: EnumerateTelemetry,
   enumeratedRepos: Set<string>,
-  licenseCache: Map<string, string | null>,
+  repoMetaCache: Map<string, RepoMeta>,
   errors: string[]
 ): Promise<BackfillCrawlOutcome> {
   const facets = buildSizeFacets()
@@ -375,7 +435,7 @@ export async function runBackfillFacetCrawl(
         telemetry,
         enumerateTelemetry,
         enumeratedRepos,
-        licenseCache
+        repoMetaCache
       )
       state.lastPage = page
       if (result.repos.length < plan.perPage) break // short page → range exhausted

--- a/scripts/indexer/subdirectory-search.helpers.ts
+++ b/scripts/indexer/subdirectory-search.helpers.ts
@@ -22,7 +22,12 @@ import { checkSkillMdExists } from './skill-processor.ts'
 import { fetchRepoLicense, isPermissiveLicense } from './license-filter.ts'
 import { enumerateRepoSkillPaths, type EnumerateTelemetry } from './trees-enumerate.ts'
 import { buildSkillTreeUrl } from './skill-url.ts'
-import { buildSizeFacets, facetId, facetToQualifier } from './code-search.facets.ts'
+import {
+  buildSizeFacets,
+  facetId,
+  facetToQualifier,
+  firstFacetIndexForMinSize,
+} from './code-search.facets.ts'
 import {
   type BackfillCursor,
   type BackfillCrawlOutcome,
@@ -262,6 +267,16 @@ export interface BackfillFacetPlan {
   maxPagesPerRange: number
   /** Dispatch budget: stop after this many (sub)ranges so the run fits the GHA cap. */
   maxRangesPerDispatch: number
+  /**
+   * SMI-5319 W4: minimum file size (bytes) for the FRESH-START facet index.
+   * On a cold start (no resume cursor), the crawl begins at the first facet in
+   * the static 9-bucket ladder whose `hi >= minSizeBytes`, skipping the
+   * low-byte noise band. Default (undefined/0) = start at facet 0 (all facets).
+   *
+   * RESUMES are unaffected: when `startCursor` is non-null the cursor's own
+   * `facet_index` is used as-is and `minSizeBytes` is ignored.
+   */
+  minSizeBytes?: number
 }
 
 /** GitHub code-search retrievable-results ceiling per query (any query caps here). */
@@ -300,6 +315,24 @@ export async function runBackfillFacetCrawl(
 ): Promise<BackfillCrawlOutcome> {
   const facets = buildSizeFacets()
   const state = cursorToFacetState(plan.startCursor)
+
+  // SMI-5319 W4: on a FRESH START (null startCursor), advance the facet index
+  // to skip the low-byte noise band. A resume (non-null startCursor) carries
+  // its own facet_index from the checkpoint cursor and must NOT be overridden —
+  // `cursorToFacetState` already restored it above, so we only act when there
+  // was no prior cursor to restore from.
+  if (plan.startCursor == null && (plan.minSizeBytes ?? 0) > 0) {
+    const skipToIndex = firstFacetIndexForMinSize(plan.minSizeBytes ?? 0)
+    if (skipToIndex > 0) {
+      console.log(
+        `[Backfill] min_size_bytes=${plan.minSizeBytes} -> starting at facet ${skipToIndex} ` +
+          `(${facets[skipToIndex].lo}-${Number.isFinite(facets[skipToIndex].hi) ? facets[skipToIndex].hi : String(facets[skipToIndex].hi)}), ` +
+          `skipping facets 0-${skipToIndex - 1}`
+      )
+      state.facetIndex = skipToIndex
+    }
+  }
+
   const pathLabel = plan.pathPrefix ?? 'broad'
   let capSaturated = false
   let truncatedRanges = 0

--- a/scripts/indexer/subdirectory-search.helpers.ts
+++ b/scripts/indexer/subdirectory-search.helpers.ts
@@ -19,6 +19,20 @@ import { searchCodeForSkillMdInSubdirectory } from './code-search.ts'
 import { checkSkillMdExists } from './skill-processor.ts'
 import { fetchRepoLicense, isPermissiveLicense } from './license-filter.ts'
 import { enumerateRepoSkillPaths, type EnumerateTelemetry } from './trees-enumerate.ts'
+
+/**
+ * SMI-5319: The single shared derivation of a per-run repo cache key.
+ *
+ * Used as the key for BOTH the `enumeratedRepos` once-guard AND the
+ * `licenseCache` map so the write-key (when a license is resolved + cached) and
+ * the read-key (when a cached license is consumed) are provably identical — a
+ * concurrency-auditor Pattern-3 (cache key-shape mismatch, SMI-4861) invariant.
+ * Centralizing it here removes the inline `${owner}/${repoName}` that previously
+ * lived at two call sites.
+ */
+export function repoCacheKey(owner: string, repoName: string): string {
+  return `${owner}/${repoName}`
+}
 import { buildSkillTreeUrl } from './skill-url.ts'
 import { buildSizeFacets, facetId, facetToQualifier } from './code-search.facets.ts'
 import {
@@ -35,8 +49,19 @@ import type { GitHubRepository } from './topic-search.ts'
 import type { SkillMdValidation } from './skill-processor.ts'
 
 /**
- * Process code search results: deduplicate, license-gate, validate, and collect repos.
+ * Process code search results: deduplicate, validate, resolve license, and collect repos.
  * Shared by both broad and fallback search paths.
+ *
+ * SMI-5319: the license ADMISSION gate has been removed. The indexer now indexes
+ * ALL valid skills regardless of license and records the resolved SPDX id as
+ * surfaced metadata (the consumer decides). The ONLY admission filter is the
+ * existing strict validity path (`enumerateRepoSkillPaths` +
+ * `checkSkillMdExists`). License resolution is now once-per-repo, AFTER the
+ * `enumeratedRepos` once-guard, cached in `licenseCache` keyed by
+ * {@link repoCacheKey} (the same derivation as the once-guard, so write-key ===
+ * read-key), and NEVER drops a skill — a fetch failure records `license: null`
+ * and proceeds. A kill-switch (`SKILLSMITH_INDEXER_LICENSE_GATE === 'true'`)
+ * restores the legacy exclude-non-permissive behavior without a deploy.
  *
  * SMI-4852: Threads `telemetry` to downstream `fetchRepoLicense` and
  * `checkSkillMdExists` calls so every GitHub API hit lands in the shared
@@ -49,8 +74,7 @@ import type { SkillMdValidation } from './skill-processor.ts'
  * `repo_url` rows that never collide on `onConflict: 'repo_url'`. Each per-path row
  * is validated independently (§#4 strict gate) before it is collected; validated
  * rows are `installable:true` (`skill-processor.ts:440` then persists the non-null
- * tree URL). Edit E: only the enumeration loop changed — the dedup-key /
- * freshness-qualifier lines (`:89`) are byte-stable for the SMI-5176 rebase.
+ * tree URL).
  */
 export async function processSearchResults(
   resultRepos: GitHubRepository[],
@@ -58,38 +82,66 @@ export async function processSearchResults(
   validationCache: Map<string, SkillMdValidation>,
   validationOptions: { strictValidation?: boolean; minContentLength?: number },
   repos: GitHubRepository[],
-  stats: { licenseFiltered: number; licenseFetchFailed: number },
+  stats: {
+    licenseFiltered: number
+    licenseFetchFailed: number
+    admitted: number
+    licenseNull: number
+  },
   telemetry: RateLimitTelemetry,
   enumerateTelemetry: EnumerateTelemetry,
-  enumeratedRepos: Set<string>
+  enumeratedRepos: Set<string>,
+  licenseCache: Map<string, string | null>
 ): Promise<void> {
+  // SMI-5319 kill-switch: when set to the literal string 'true', restore the
+  // legacy pre-validity license ADMISSION gate (exclude non-permissive repos)
+  // so ops can re-enable the old behavior without a deploy. Default (unset /
+  // anything else) = OFF = the new no-gate behavior.
+  const legacyLicenseGate = process.env.SKILLSMITH_INDEXER_LICENSE_GATE === 'true'
+
   for (const repo of resultRepos) {
     // Deduplication key includes skillPath: one repo can have multiple skills
     const dedupKey = repo.skillPath ? `${repo.url}/${repo.skillPath}` : repo.url
     if (seenUrls.has(dedupKey)) continue
 
-    // License gate: fetch SPDX from GitHub API (not included in code search response)
-    const { license: spdxId, fetchFailed } = await fetchRepoLicense(
-      repo.owner,
-      repo.repoName,
-      telemetry
-    )
+    // SMI-5319: keyed via the shared `repoCacheKey` derivation so the once-guard
+    // key (enumeratedRepos) and the licenseCache key are provably identical
+    // (concurrency-auditor Pattern-3 invariant).
+    const repoKey = repoCacheKey(repo.owner, repo.repoName)
 
-    if (fetchFailed) {
-      // API failure — skip this run but don't count as license-filtered.
-      // NOT added to seenUrls so the repo is retried on the next indexer run.
-      console.log(`[BroadDiscovery] License fetch failed (will retry next run): ${repo.fullName}`)
-      stats.licenseFetchFailed++
-      await delay(200)
-      continue
-    }
+    // SMI-5319 kill-switch (legacy path only): the OLD pre-validity admission gate.
+    // Fetch SPDX from the GitHub API and drop the repo if the license could not be
+    // fetched (retry next run) or is confirmed non-permissive. Disabled by default
+    // — the new behavior resolves license once-per-repo AFTER the validity gate and
+    // never drops a skill. When the gate admits a repo, the just-fetched SPDX is
+    // seeded into `licenseCache` so the once-per-repo resolution below reuses it
+    // (no redundant second fetch in legacy mode).
+    if (legacyLicenseGate) {
+      const { license: spdxId, fetchFailed } = await fetchRepoLicense(
+        repo.owner,
+        repo.repoName,
+        telemetry
+      )
 
-    if (!isPermissiveLicense(spdxId)) {
-      // Confirmed non-permissive license — permanently excluded.
-      console.log(`[BroadDiscovery] License excluded: ${repo.fullName} spdx=${spdxId ?? 'null'}`)
-      stats.licenseFiltered++
-      await delay(200)
-      continue
+      if (fetchFailed) {
+        // API failure — skip this run but don't count as license-filtered.
+        // NOT added to seenUrls so the repo is retried on the next indexer run.
+        console.log(`[BroadDiscovery] License fetch failed (will retry next run): ${repo.fullName}`)
+        stats.licenseFetchFailed++
+        await delay(200)
+        continue
+      }
+
+      if (!isPermissiveLicense(spdxId)) {
+        // Confirmed non-permissive license — permanently excluded.
+        console.log(`[BroadDiscovery] License excluded: ${repo.fullName} spdx=${spdxId ?? 'null'}`)
+        stats.licenseFiltered++
+        await delay(200)
+        continue
+      }
+
+      // Admitted by the legacy gate: reuse this SPDX for the metadata resolution.
+      if (!licenseCache.has(repoKey)) licenseCache.set(repoKey, spdxId)
     }
 
     // Mark this code-search result consumed (per-repo+skillPath identity) so the
@@ -98,7 +150,6 @@ export async function processSearchResults(
 
     // SMI-5286 Wave 1a (§#1): enumerate the repo's full tree ONCE. The broad query
     // can surface the same repo via multiple SKILL.md hits; guard re-enumeration.
-    const repoKey = `${repo.owner}/${repo.repoName}`
     if (enumeratedRepos.has(repoKey)) {
       await delay(50)
       continue
@@ -124,6 +175,23 @@ export async function processSearchResults(
     if (truncatedByCap) {
       console.log(`[BroadDiscovery] Per-repo cap reached, taking first N: ${repo.fullName}`)
     }
+
+    // SMI-5319: resolve the license ONCE per repo, AFTER the validity gate
+    // (enumeration succeeded), cached on `repoKey` (the SAME key as the
+    // once-guard above). A fetch failure records `license: null` and PROCEEDS —
+    // the license is surfaced metadata only, never an admission filter. The repo
+    // is enumerated once per run, so a cache miss here means exactly one fetch.
+    let spdx: string | null
+    if (licenseCache.has(repoKey)) {
+      spdx = licenseCache.get(repoKey) ?? null
+    } else {
+      const { license, fetchFailed } = await fetchRepoLicense(repo.owner, repo.repoName, telemetry)
+      // Ignore fetchFailed: record null and proceed (never drop, never retry-storm).
+      spdx = fetchFailed ? null : license
+      if (fetchFailed) stats.licenseFetchFailed++
+      licenseCache.set(repoKey, spdx)
+    }
+    if (spdx === null) stats.licenseNull++
 
     // Validate each enumerated SKILL.md independently (§#4 strict gate) and emit
     // one per-skill GitHubRepository with a distinct tree URL (C-1) per valid path.
@@ -152,14 +220,17 @@ export async function processSearchResults(
       if (seenUrls.has(skillUrl)) continue
       seenUrls.add(skillUrl)
 
+      // SMI-5319: emit with the cached license as surfaced metadata (possibly
+      // null). Admission was already governed by the strict validity gate above.
       repos.push({
         ...repo,
         url: skillUrl,
         installable,
         skillPath,
         treeHash: entry.blobSha,
-        license: spdxId,
+        license: spdx,
       })
+      stats.admitted++
       await delay(50)
     }
   }
@@ -201,8 +272,9 @@ const CODE_SEARCH_RESULT_CAP = 1000
  * almost always denylist-caught boilerplate) is recorded as truncated, logged,
  * and skipped (never silently dropped). The frontier (facet index + bisection
  * stack + page) is fully captured by the returned cursor so a dispatch boundary
- * mid-bisection resumes losslessly. Reuses {@link processSearchResults} (license
- * gate + Trees per-skill enumeration + per-path validation) unchanged.
+ * mid-bisection resumes losslessly. Reuses {@link processSearchResults} (Trees
+ * per-skill enumeration + per-path validation + once-per-repo license metadata
+ * resolution) unchanged.
  */
 export async function runBackfillFacetCrawl(
   plan: BackfillFacetPlan,
@@ -210,10 +282,16 @@ export async function runBackfillFacetCrawl(
   validationCache: Map<string, SkillMdValidation>,
   validationOptions: { strictValidation?: boolean; minContentLength?: number },
   repos: GitHubRepository[],
-  stats: { licenseFiltered: number; licenseFetchFailed: number },
+  stats: {
+    licenseFiltered: number
+    licenseFetchFailed: number
+    admitted: number
+    licenseNull: number
+  },
   telemetry: RateLimitTelemetry,
   enumerateTelemetry: EnumerateTelemetry,
   enumeratedRepos: Set<string>,
+  licenseCache: Map<string, string | null>,
   errors: string[]
 ): Promise<BackfillCrawlOutcome> {
   const facets = buildSizeFacets()
@@ -259,7 +337,8 @@ export async function runBackfillFacetCrawl(
         stats,
         telemetry,
         enumerateTelemetry,
-        enumeratedRepos
+        enumeratedRepos,
+        licenseCache
       )
       state.lastPage = page
       if (result.repos.length < plan.perPage) break // short page → range exhausted

--- a/scripts/indexer/subdirectory-search.helpers.ts
+++ b/scripts/indexer/subdirectory-search.helpers.ts
@@ -1,13 +1,14 @@
 /**
- * Subdirectory-search helpers: shared per-skill result processor + the SMI-5286
- * 1c size-faceted backfill crawl.
+ * Subdirectory-search helpers: BackfillFacetPlan + runBackfillFacetCrawl.
  * @module scripts/indexer/subdirectory-search.helpers
  *
  * Extracted from `subdirectory-search.ts` to keep that entrypoint under the
- * 500-line CI gate (SMI-5286 1c). `processSearchResults` is shared by the legacy
- * broad/fallback loop AND the backfill crawl; `runBackfillFacetCrawl` is the
- * size-faceted depth-first driver. The dependency is one-way
- * (`subdirectory-search.ts` → this file) — this file never imports the entrypoint.
+ * 500-line CI gate (SMI-5286 1c). The per-skill result processor and shared
+ * types live in `subdirectory-search.process.ts` (split out when the SMI-5319
+ * per-dispatch skill cap pushed this file over 500 lines). Re-exports everything
+ * from the process module so callers that import from this path continue to work
+ * unchanged. The dependency is one-way
+ * (`subdirectory-search.ts` -> this file -> subdirectory-search.process.ts).
  *
  * NOT parity-guarded (`parity.test.ts` exempts the subdirectory surface, C-2),
  * so divergence from the Deno copy is safe and intended (the backfill engine is
@@ -16,12 +17,6 @@
 
 import { delay, type RateLimitTelemetry } from './_shared/rate-limit.ts'
 import { searchCodeForSkillMdInSubdirectory } from './code-search.ts'
-import { checkSkillMdExists } from './skill-processor.ts'
-// `isPermissiveLicense` is consumed ONLY by the SMI-5319 kill-switch (the legacy
-// license gate); the default path resolves license as surfaced metadata only.
-import { fetchRepoLicense, isPermissiveLicense } from './license-filter.ts'
-import { enumerateRepoSkillPaths, type EnumerateTelemetry } from './trees-enumerate.ts'
-import { buildSkillTreeUrl } from './skill-url.ts'
 import {
   buildSizeFacets,
   facetId,
@@ -40,278 +35,21 @@ import {
 } from './backfill-checkpoint.ts'
 import type { GitHubRepository } from './topic-search.ts'
 import type { SkillMdValidation } from './skill-processor.ts'
+import type { EnumerateTelemetry } from './trees-enumerate.ts'
 
-/**
- * SMI-5319: The single shared derivation of a per-run repo cache key.
- *
- * Used as the key for BOTH the `enumeratedRepos` once-guard AND the
- * `repoMetaCache` map so the write-key (when repo metadata is resolved + cached)
- * and the read-key (when cached metadata is consumed) are provably identical — a
- * concurrency-auditor Pattern-3 (cache key-shape mismatch, SMI-4861) invariant.
- * Centralizing it here removes the inline `${owner}/${repoName}` that previously
- * lived at two call sites.
- */
-export function repoCacheKey(owner: string, repoName: string): string {
-  return `${owner}/${repoName}`
-}
-
-/**
- * SMI-5319: per-run cached repo metadata resolved once via the SAME
- * `GET /repos/{owner}/{repo}` call (`fetchRepoLicense`). The code-search API does
- * not return `default_branch`, so the REAL branch from this metadata — not
- * `repo.defaultBranch` (null) — drives both the Trees enumeration and the emitted
- * skill tree URL. A `defaultBranch` of null means the repo cannot be enumerated
- * this run (fetch failed or the field was absent) and must be skipped.
- */
-export interface RepoMeta {
-  /** Resolved SPDX license id (surfaced metadata), or null. */
-  license: string | null
-  /** Resolved default branch, or null when it could not be resolved. */
-  defaultBranch: string | null
-}
-
-/**
- * Mutable per-run counters accumulated across every `processSearchResults` call.
- * Shared by the broad/fallback loop and the backfill crawl so the shape stays in
- * lock-step at all three threading sites.
- */
-export interface SubdirSearchStats {
-  /** Repos dropped by the legacy kill-switch license gate (~0 by default). */
-  licenseFiltered: number
-  /** Metadata-fetch failures (rate-limit / network, after retries). */
-  licenseFetchFailed: number
-  /** Skills admitted (indexed) this run. */
-  admitted: number
-  /** Admitted skills whose resolved SPDX is null. */
-  licenseNull: number
-  /**
-   * SMI-5319: repos skipped because no default branch could be resolved (the
-   * code-search API omits `default_branch` and the `GET /repos` fallback failed
-   * or returned no branch). Skipped repos are retried on the next run.
-   */
-  noDefaultBranch: number
-}
-
-/**
- * Process code search results: deduplicate, validate, resolve license, and collect repos.
- * Shared by both broad and fallback search paths.
- *
- * SMI-5319: the license ADMISSION gate has been removed. The indexer now indexes
- * ALL valid skills regardless of license and records the resolved SPDX id as
- * surfaced metadata (the consumer decides). The ONLY admission filter is the
- * existing strict validity path (`enumerateRepoSkillPaths` +
- * `checkSkillMdExists`). Repo metadata (license + default branch) is resolved
- * once-per-repo, AFTER the `enumeratedRepos` once-guard but BEFORE the Trees
- * enumeration, cached in `repoMetaCache` keyed by {@link repoCacheKey} (the same
- * derivation as the once-guard, so write-key === read-key). A license-fetch
- * failure records `license: null` and never drops a skill. A kill-switch
- * (`SKILLSMITH_INDEXER_LICENSE_GATE === 'true'`) restores the legacy
- * exclude-non-permissive behavior without a deploy.
- *
- * SMI-5319 (Trees default-branch fix): the code-search API does NOT return
- * `default_branch`, so `repo.defaultBranch` is null. The REAL branch comes from
- * the same `GET /repos` metadata call and is passed to `enumerateRepoSkillPaths`
- * AND `buildSkillTreeUrl`. A repo whose default branch cannot be resolved is
- * skipped (NOT enumerated with a null branch, which 404s every Trees call) and
- * retried on the next run.
- *
- * SMI-4852: Threads `telemetry` to downstream `fetchRepoLicense` and
- * `checkSkillMdExists` calls so every GitHub API hit lands in the shared
- * collector.
- *
- * SMI-5286 Wave 1a (§#1, C-1): per-skill (collection) extraction. Each candidate
- * repo is enumerated ONCE via the Trees API (`enumerateRepoSkillPaths`) and EVERY
- * valid SKILL.md parent dir becomes its own `GitHubRepository`, with a DISTINCT
- * per-skill tree URL (`buildSkillTreeUrl`) so N skills in one repo yield N distinct
- * `repo_url` rows that never collide on `onConflict: 'repo_url'`. Each per-path row
- * is validated independently (§#4 strict gate) before it is collected; validated
- * rows are `installable:true` (`skill-processor.ts:440` then persists the non-null
- * tree URL).
- */
-export async function processSearchResults(
-  resultRepos: GitHubRepository[],
-  seenUrls: Set<string>,
-  validationCache: Map<string, SkillMdValidation>,
-  validationOptions: { strictValidation?: boolean; minContentLength?: number },
-  repos: GitHubRepository[],
-  stats: SubdirSearchStats,
-  telemetry: RateLimitTelemetry,
-  enumerateTelemetry: EnumerateTelemetry,
-  enumeratedRepos: Set<string>,
-  repoMetaCache: Map<string, RepoMeta>
-): Promise<void> {
-  // SMI-5319 kill-switch: when set to the literal string 'true', restore the
-  // legacy pre-validity license ADMISSION gate (exclude non-permissive repos)
-  // so ops can re-enable the old behavior without a deploy. Default (unset /
-  // anything else) = OFF = the new no-gate behavior.
-  const legacyLicenseGate = process.env.SKILLSMITH_INDEXER_LICENSE_GATE === 'true'
-
-  for (const repo of resultRepos) {
-    // Deduplication key includes skillPath: one repo can have multiple skills
-    const dedupKey = repo.skillPath ? `${repo.url}/${repo.skillPath}` : repo.url
-    if (seenUrls.has(dedupKey)) continue
-
-    // SMI-5319: keyed via the shared `repoCacheKey` derivation so the once-guard
-    // key (enumeratedRepos) and the repoMetaCache key are provably identical
-    // (concurrency-auditor Pattern-3 invariant).
-    const repoKey = repoCacheKey(repo.owner, repo.repoName)
-
-    // SMI-5319 kill-switch (legacy path only): the OLD pre-validity admission gate.
-    // Fetch repo metadata from the GitHub API and drop the repo if it could not be
-    // fetched (retry next run) or the license is confirmed non-permissive. Disabled
-    // by default — the new behavior resolves metadata once-per-repo AFTER the
-    // once-guard and never drops a skill. When the gate admits a repo, the
-    // just-fetched metadata is seeded into `repoMetaCache` so the post-once-guard
-    // resolution below reuses it (no second fetch there). NOTE: this break-glass
-    // loop runs before the `enumeratedRepos` once-guard, so a repo surfacing via
-    // multiple skillPaths is re-fetched here per hit — acceptable on the
-    // default-off legacy path.
-    if (legacyLicenseGate) {
-      const {
-        license: spdxId,
-        defaultBranch,
-        fetchFailed,
-      } = await fetchRepoLicense(repo.owner, repo.repoName, telemetry)
-
-      if (fetchFailed) {
-        // API failure — skip this run but don't count as license-filtered.
-        // NOT added to seenUrls so the repo is retried on the next indexer run.
-        console.log(`[BroadDiscovery] License fetch failed (will retry next run): ${repo.fullName}`)
-        stats.licenseFetchFailed++
-        await delay(200)
-        continue
-      }
-
-      if (!isPermissiveLicense(spdxId)) {
-        // Confirmed non-permissive license — permanently excluded.
-        console.log(`[BroadDiscovery] License excluded: ${repo.fullName} spdx=${spdxId ?? 'null'}`)
-        stats.licenseFiltered++
-        await delay(200)
-        continue
-      }
-
-      // Admitted by the legacy gate: reuse this metadata for the resolution below.
-      if (!repoMetaCache.has(repoKey)) {
-        repoMetaCache.set(repoKey, { license: spdxId, defaultBranch })
-      }
-    }
-
-    // Mark this code-search result consumed (per-repo+skillPath identity) so the
-    // same surfaced file is not re-processed across pages/prefixes.
-    seenUrls.add(dedupKey)
-
-    // SMI-5286 Wave 1a (§#1): enumerate the repo's full tree ONCE. The broad query
-    // can surface the same repo via multiple SKILL.md hits; guard re-enumeration.
-    if (enumeratedRepos.has(repoKey)) {
-      await delay(50)
-      continue
-    }
-    enumeratedRepos.add(repoKey)
-
-    // SMI-5319: resolve repo metadata (license + default branch) ONCE per repo,
-    // AFTER the once-guard but BEFORE enumeration, cached on `repoKey` (the SAME
-    // key as the once-guard above, so write-key === read-key). The code-search API
-    // does NOT return `default_branch` (`repo.defaultBranch` is null), so the REAL
-    // branch comes from this `GET /repos` call. A metadata-fetch failure records
-    // `license: null` + `defaultBranch: null`. The repo is enumerated once per run,
-    // so a cache miss here means exactly one fetch.
-    let meta: RepoMeta
-    if (repoMetaCache.has(repoKey)) {
-      meta = repoMetaCache.get(repoKey) ?? { license: null, defaultBranch: null }
-    } else {
-      const { license, defaultBranch, fetchFailed } = await fetchRepoLicense(
-        repo.owner,
-        repo.repoName,
-        telemetry
-      )
-      // Ignore fetchFailed for license: record null and proceed (never drop, never
-      // retry-storm). A failed fetch also leaves `defaultBranch` null → the repo is
-      // skipped below and retried next run.
-      meta = { license: fetchFailed ? null : license, defaultBranch }
-      if (fetchFailed) stats.licenseFetchFailed++
-      repoMetaCache.set(repoKey, meta)
-    }
-    const spdx = meta.license
-    const branch = meta.defaultBranch
-    if (spdx === null) stats.licenseNull++
-
-    // SMI-5319: without a resolvable default branch we CANNOT enumerate the repo
-    // (`GET /git/trees/null` → 404 for every path) and MUST NOT emit a row with a
-    // null branch. Skip. Retry happens on the NEXT indexer run: `seenUrls` and
-    // `enumeratedRepos` are run-scoped (allocated fresh per `runSubdirectorySearch`),
-    // so a later run with a resolvable branch re-discovers and re-enumerates this
-    // repo. (Within THIS run it is not retried — the `enumeratedRepos` once-guard
-    // already holds `repoKey`, and this hit's `dedupKey` is already in `seenUrls`.)
-    if (branch === null) {
-      console.log(`[BroadDiscovery] No default branch, skipping (retry next run): ${repo.fullName}`)
-      stats.noDefaultBranch++
-      await delay(50)
-      continue
-    }
-
-    const { entries, truncatedByApi, truncatedByCap } = await enumerateRepoSkillPaths(
-      repo.owner,
-      repo.repoName,
-      branch,
-      telemetry,
-      enumerateTelemetry
-    )
-
-    if (truncatedByApi) {
-      // Trees API truncated — do NOT emit a partial set (deterministic skip).
-      console.log(
-        `[BroadDiscovery] Trees truncated, skipping for manual handling: ${repo.fullName}`
-      )
-      await delay(50)
-      continue
-    }
-    if (truncatedByCap) {
-      console.log(`[BroadDiscovery] Per-repo cap reached, taking first N: ${repo.fullName}`)
-    }
-
-    // Validate each enumerated SKILL.md independently (§#4 strict gate) and emit
-    // one per-skill GitHubRepository with a distinct tree URL (C-1) per valid path.
-    for (const entry of entries) {
-      const skillPath = entry.path
-      const installable = await checkSkillMdExists(
-        repo.owner,
-        repo.repoName,
-        branch,
-        validationCache,
-        telemetry,
-        skillPath,
-        validationOptions
-      )
-
-      // C-1: build the per-skill tree URL from the BARE repo html_url
-      // (reconstructed from owner/repoName), NOT from `repo.url` — by this point
-      // `repo.url` is already the code-search mapper's tree URL, so reusing it
-      // would double the `/tree/<branch>` segment. `skillUrl` already encodes
-      // `skillPath`, so it alone is the dedup key. SMI-5319: built with the FETCHED
-      // `branch` (not `repo.defaultBranch`, which is null from code search).
-      const skillUrl = buildSkillTreeUrl(
-        `https://github.com/${repo.owner}/${repo.repoName}`,
-        branch,
-        skillPath
-      )
-      if (seenUrls.has(skillUrl)) continue
-      seenUrls.add(skillUrl)
-
-      // SMI-5319: emit with the cached license as surfaced metadata (possibly
-      // null). Admission was already governed by the strict validity gate above.
-      repos.push({
-        ...repo,
-        url: skillUrl,
-        installable,
-        skillPath,
-        treeHash: entry.blobSha,
-        license: spdx,
-      })
-      stats.admitted++
-      await delay(50)
-    }
-  }
-}
+// Types and the result-processor used internally by runBackfillFacetCrawl.
+// Also re-exported so callers that import from this path continue to work.
+import {
+  processSearchResults,
+  type RepoMeta,
+  type SubdirSearchStats,
+} from './subdirectory-search.process.ts'
+export {
+  repoCacheKey,
+  processSearchResults,
+  type RepoMeta,
+  type SubdirSearchStats,
+} from './subdirectory-search.process.ts'
 
 /**
  * SMI-5286 1c: a single dispatch's facet-crawl plan. The driver in `run.ts`
@@ -331,7 +69,7 @@ export interface BackfillFacetPlan {
   pathPrefix: string | undefined
   /** Results per code-search page (GitHub max 100). */
   perPage: number
-  /** Pages to crawl per (sub)range before treating it as exhausted (≈ ceil(1000 / perPage)). */
+  /** Pages to crawl per (sub)range before treating it as exhausted (approx ceil(1000 / perPage)). */
   maxPagesPerRange: number
   /** Dispatch budget: stop after this many (sub)ranges so the run fits the GHA cap. */
   maxRangesPerDispatch: number
@@ -345,6 +83,15 @@ export interface BackfillFacetPlan {
    * `facet_index` is used as-is and `minSizeBytes` is ignored.
    */
   minSizeBytes?: number
+  /**
+   * Per-dispatch skill cap: stop the crawl at a clean range boundary once
+   * `repos.length >= maxSkillsPerDispatch`, checkpoint, and exit so the next
+   * dispatch resumes. The overshoot by at most the last range's contribution is
+   * intentional -- the break occurs AFTER the full range completes (bisect or
+   * advance), so the cursor is always clean. Default 0 (or undefined) = no cap.
+   * Distinct from the per-repo cap `BACKFILL_MAX_SKILLS_PER_REPO`.
+   */
+  maxSkillsPerDispatch?: number
 }
 
 /** GitHub code-search retrievable-results ceiling per query (any query caps here). */
@@ -355,7 +102,7 @@ const CODE_SEARCH_RESULT_CAP = 1000
  * query (or a single `path:` prefix). Pages each size (sub)range to the 1000-cap;
  * a range whose `total_count` exceeds the cap is BISECTED (its halves crawled
  * before the next top-level facet) so every file is reachable. A range that
- * saturates but cannot subdivide further (≥1000 identical-byte-size files —
+ * saturates but cannot subdivide further (>=1000 identical-byte-size files --
  * almost always denylist-caught boilerplate) is recorded as truncated, logged,
  * and skipped (never silently dropped). The frontier (facet index + bisection
  * stack + page) is fully captured by the returned cursor so a dispatch boundary
@@ -381,7 +128,7 @@ export async function runBackfillFacetCrawl(
 
   // SMI-5319 W4: on a FRESH START (null startCursor), advance the facet index
   // to skip the low-byte noise band. A resume (non-null startCursor) carries
-  // its own facet_index from the checkpoint cursor and must NOT be overridden —
+  // its own facet_index from the checkpoint cursor and must NOT be overridden --
   // `cursorToFacetState` already restored it above, so we only act when there
   // was no prior cursor to restore from.
   if (plan.startCursor == null && (plan.minSizeBytes ?? 0) > 0) {
@@ -422,7 +169,7 @@ export async function runBackfillFacetCrawl(
         break
       }
       // The 1000-cap is detected from total_count on the first page: rather than
-      // waste pages on the unreachable tail, bisect immediately — the sub-ranges
+      // waste pages on the unreachable tail, bisect immediately -- the sub-ranges
       // (each < cap, or bisected further) cover the same files.
       if (page === 1 && result.total > CODE_SEARCH_RESULT_CAP) {
         saturated = true
@@ -441,37 +188,49 @@ export async function runBackfillFacetCrawl(
         repoMetaCache
       )
       state.lastPage = page
-      if (result.repos.length < plan.perPage) break // short page → range exhausted
-      await delay(6000) // 10 code-search req/min → 6s between pages
+      if (result.repos.length < plan.perPage) break // short page -> range exhausted
+      await delay(6000) // 10 code-search req/min -> 6s between pages
     }
 
     rangesCrawled++
 
     if (errored) {
       // M-1: a page error (rate-limiter already retried transient 403/429, so a
-      // returned error is exceptional) — count it as truncated so it surfaces in
+      // returned error is exceptional) -- count it as truncated so it surfaces in
       // the dispatch summary + errors[], then advance past the range rather than
       // re-crawl it forever this dispatch. The operator can re-run the facet under
-      // a narrower BACKFILL_PATH_PREFIX once the cause is cleared (SPARC §#3).
+      // a narrower BACKFILL_PATH_PREFIX once the cause is cleared (SPARC sec#3).
       truncatedRanges++
       console.warn(
-        `[Backfill] facet ${facetId(range)} (${pathLabel}) errored — recorded as truncated, advancing`
+        `[Backfill] facet ${facetId(range)} (${pathLabel}) errored -- recorded as truncated, advancing`
       )
       advanceFacet(state)
     } else if (saturated) {
       capSaturated = true
       if (!bisectCurrentFacet(state, range)) {
         // Saturated AND unbisectable: record + skip (never silent). The operator
-        // can re-run this facet under a narrower BACKFILL_PATH_PREFIX (SPARC §#3).
+        // can re-run this facet under a narrower BACKFILL_PATH_PREFIX (SPARC sec#3).
         truncatedRanges++
         console.warn(
-          `[Backfill] facet ${facetId(range)} (${pathLabel}) saturated at the 1000-cap and cannot subdivide — recorded as truncated, skipping`
+          `[Backfill] facet ${facetId(range)} (${pathLabel}) saturated at the 1000-cap and cannot subdivide -- recorded as truncated, skipping`
         )
         advanceFacet(state)
       }
     } else {
       // Range exhausted (short page, or page cap reached with total <= cap).
       advanceFacet(state)
+    }
+
+    // Per-dispatch skill cap: checked at the range boundary (after bisect/advance)
+    // so the cursor is always clean and `done` is computed normally below. The
+    // overshoot by at most the last range's contribution is intentional. The crawl
+    // is NOT done -- there is more to do; the next dispatch resumes from the
+    // checkpoint cursor written by the caller.
+    if (plan.maxSkillsPerDispatch && repos.length >= plan.maxSkillsPerDispatch) {
+      console.log(
+        `[Backfill] Skill cap reached: ${repos.length} skills >= cap ${plan.maxSkillsPerDispatch}, checkpointing and exiting`
+      )
+      break
     }
   }
 

--- a/scripts/indexer/subdirectory-search.helpers.ts
+++ b/scripts/indexer/subdirectory-search.helpers.ts
@@ -17,22 +17,10 @@
 import { delay, type RateLimitTelemetry } from './_shared/rate-limit.ts'
 import { searchCodeForSkillMdInSubdirectory } from './code-search.ts'
 import { checkSkillMdExists } from './skill-processor.ts'
+// `isPermissiveLicense` is consumed ONLY by the SMI-5319 kill-switch (the legacy
+// license gate); the default path resolves license as surfaced metadata only.
 import { fetchRepoLicense, isPermissiveLicense } from './license-filter.ts'
 import { enumerateRepoSkillPaths, type EnumerateTelemetry } from './trees-enumerate.ts'
-
-/**
- * SMI-5319: The single shared derivation of a per-run repo cache key.
- *
- * Used as the key for BOTH the `enumeratedRepos` once-guard AND the
- * `licenseCache` map so the write-key (when a license is resolved + cached) and
- * the read-key (when a cached license is consumed) are provably identical — a
- * concurrency-auditor Pattern-3 (cache key-shape mismatch, SMI-4861) invariant.
- * Centralizing it here removes the inline `${owner}/${repoName}` that previously
- * lived at two call sites.
- */
-export function repoCacheKey(owner: string, repoName: string): string {
-  return `${owner}/${repoName}`
-}
 import { buildSkillTreeUrl } from './skill-url.ts'
 import { buildSizeFacets, facetId, facetToQualifier } from './code-search.facets.ts'
 import {
@@ -47,6 +35,20 @@ import {
 } from './backfill-checkpoint.ts'
 import type { GitHubRepository } from './topic-search.ts'
 import type { SkillMdValidation } from './skill-processor.ts'
+
+/**
+ * SMI-5319: The single shared derivation of a per-run repo cache key.
+ *
+ * Used as the key for BOTH the `enumeratedRepos` once-guard AND the
+ * `licenseCache` map so the write-key (when a license is resolved + cached) and
+ * the read-key (when a cached license is consumed) are provably identical — a
+ * concurrency-auditor Pattern-3 (cache key-shape mismatch, SMI-4861) invariant.
+ * Centralizing it here removes the inline `${owner}/${repoName}` that previously
+ * lived at two call sites.
+ */
+export function repoCacheKey(owner: string, repoName: string): string {
+  return `${owner}/${repoName}`
+}
 
 /**
  * Process code search results: deduplicate, validate, resolve license, and collect repos.
@@ -114,8 +116,10 @@ export async function processSearchResults(
     // fetched (retry next run) or is confirmed non-permissive. Disabled by default
     // — the new behavior resolves license once-per-repo AFTER the validity gate and
     // never drops a skill. When the gate admits a repo, the just-fetched SPDX is
-    // seeded into `licenseCache` so the once-per-repo resolution below reuses it
-    // (no redundant second fetch in legacy mode).
+    // seeded into `licenseCache` so the post-validity resolution below reuses it
+    // (no second fetch there). NOTE: this break-glass loop runs before the
+    // `enumeratedRepos` once-guard, so a repo surfacing via multiple skillPaths is
+    // re-fetched here per hit — acceptable on the default-off legacy path.
     if (legacyLicenseGate) {
       const { license: spdxId, fetchFailed } = await fetchRepoLicense(
         repo.owner,

--- a/scripts/indexer/subdirectory-search.process.ts
+++ b/scripts/indexer/subdirectory-search.process.ts
@@ -1,0 +1,296 @@
+/**
+ * Per-skill result processor: `processSearchResults` + shared types.
+ * @module scripts/indexer/subdirectory-search.process
+ *
+ * Extracted from `subdirectory-search.helpers.ts` to keep that module under
+ * the 500-line pre-commit gate after the SMI-5319 per-dispatch skill cap was
+ * added. The dependency graph is strictly one-way:
+ *   subdirectory-search.ts
+ *     -> subdirectory-search.helpers.ts  (re-exports everything from here)
+ *       -> subdirectory-search.process.ts  (this file; no upward imports)
+ *
+ * NOT parity-guarded (`parity.test.ts` exempts the subdirectory surface, C-2),
+ * so divergence from the Deno copy is safe and intended.
+ */
+
+import { delay, type RateLimitTelemetry } from './_shared/rate-limit.ts'
+import { checkSkillMdExists } from './skill-processor.ts'
+// `isPermissiveLicense` is consumed ONLY by the SMI-5319 kill-switch (the legacy
+// license gate); the default path resolves license as surfaced metadata only.
+import { fetchRepoLicense, isPermissiveLicense } from './license-filter.ts'
+import { enumerateRepoSkillPaths, type EnumerateTelemetry } from './trees-enumerate.ts'
+import { buildSkillTreeUrl } from './skill-url.ts'
+import type { GitHubRepository } from './topic-search.ts'
+import type { SkillMdValidation } from './skill-processor.ts'
+
+/**
+ * SMI-5319: The single shared derivation of a per-run repo cache key.
+ *
+ * Used as the key for BOTH the `enumeratedRepos` once-guard AND the
+ * `repoMetaCache` map so the write-key (when repo metadata is resolved + cached)
+ * and the read-key (when cached metadata is consumed) are provably identical -- a
+ * concurrency-auditor Pattern-3 (cache key-shape mismatch, SMI-4861) invariant.
+ * Centralizing it here removes the inline `${owner}/${repoName}` that previously
+ * lived at two call sites.
+ */
+export function repoCacheKey(owner: string, repoName: string): string {
+  return `${owner}/${repoName}`
+}
+
+/**
+ * SMI-5319: per-run cached repo metadata resolved once via the SAME
+ * `GET /repos/{owner}/{repo}` call (`fetchRepoLicense`). The code-search API does
+ * not return `default_branch`, so the REAL branch from this metadata -- not
+ * `repo.defaultBranch` (null) -- drives both the Trees enumeration and the emitted
+ * skill tree URL. A `defaultBranch` of null means the repo cannot be enumerated
+ * this run (fetch failed or the field was absent) and must be skipped.
+ */
+export interface RepoMeta {
+  /** Resolved SPDX license id (surfaced metadata), or null. */
+  license: string | null
+  /** Resolved default branch, or null when it could not be resolved. */
+  defaultBranch: string | null
+}
+
+/**
+ * Mutable per-run counters accumulated across every `processSearchResults` call.
+ * Shared by the broad/fallback loop and the backfill crawl so the shape stays in
+ * lock-step at all three threading sites.
+ */
+export interface SubdirSearchStats {
+  /** Repos dropped by the legacy kill-switch license gate (~0 by default). */
+  licenseFiltered: number
+  /** Metadata-fetch failures (rate-limit / network, after retries). */
+  licenseFetchFailed: number
+  /** Skills admitted (indexed) this run. */
+  admitted: number
+  /** Admitted skills whose resolved SPDX is null. */
+  licenseNull: number
+  /**
+   * SMI-5319: repos skipped because no default branch could be resolved (the
+   * code-search API omits `default_branch` and the `GET /repos` fallback failed
+   * or returned no branch). Skipped repos are retried on the next run.
+   */
+  noDefaultBranch: number
+}
+
+/**
+ * Process code search results: deduplicate, validate, resolve license, and collect repos.
+ * Shared by both broad and fallback search paths.
+ *
+ * SMI-5319: the license ADMISSION gate has been removed. The indexer now indexes
+ * ALL valid skills regardless of license and records the resolved SPDX id as
+ * surfaced metadata (the consumer decides). The ONLY admission filter is the
+ * existing strict validity path (`enumerateRepoSkillPaths` +
+ * `checkSkillMdExists`). Repo metadata (license + default branch) is resolved
+ * once-per-repo, AFTER the `enumeratedRepos` once-guard but BEFORE the Trees
+ * enumeration, cached in `repoMetaCache` keyed by {@link repoCacheKey} (the same
+ * derivation as the once-guard, so write-key === read-key). A license-fetch
+ * failure records `license: null` and never drops a skill. A kill-switch
+ * (`SKILLSMITH_INDEXER_LICENSE_GATE === 'true'`) restores the legacy
+ * exclude-non-permissive behavior without a deploy.
+ *
+ * SMI-5319 (Trees default-branch fix): the code-search API does NOT return
+ * `default_branch`, so `repo.defaultBranch` is null. The REAL branch comes from
+ * the same `GET /repos` metadata call and is passed to `enumerateRepoSkillPaths`
+ * AND `buildSkillTreeUrl`. A repo whose default branch cannot be resolved is
+ * skipped (NOT enumerated with a null branch, which 404s every Trees call) and
+ * retried on the next run.
+ *
+ * SMI-4852: Threads `telemetry` to downstream `fetchRepoLicense` and
+ * `checkSkillMdExists` calls so every GitHub API hit lands in the shared
+ * collector.
+ *
+ * SMI-5286 Wave 1a (sec#1, C-1): per-skill (collection) extraction. Each candidate
+ * repo is enumerated ONCE via the Trees API (`enumerateRepoSkillPaths`) and EVERY
+ * valid SKILL.md parent dir becomes its own `GitHubRepository`, with a DISTINCT
+ * per-skill tree URL (`buildSkillTreeUrl`) so N skills in one repo yield N distinct
+ * `repo_url` rows that never collide on `onConflict: 'repo_url'`. Each per-path row
+ * is validated independently (sec#4 strict gate) before it is collected; validated
+ * rows are `installable:true` (`skill-processor.ts:440` then persists the non-null
+ * tree URL).
+ */
+export async function processSearchResults(
+  resultRepos: GitHubRepository[],
+  seenUrls: Set<string>,
+  validationCache: Map<string, SkillMdValidation>,
+  validationOptions: { strictValidation?: boolean; minContentLength?: number },
+  repos: GitHubRepository[],
+  stats: SubdirSearchStats,
+  telemetry: RateLimitTelemetry,
+  enumerateTelemetry: EnumerateTelemetry,
+  enumeratedRepos: Set<string>,
+  repoMetaCache: Map<string, RepoMeta>
+): Promise<void> {
+  // SMI-5319 kill-switch: when set to the literal string 'true', restore the
+  // legacy pre-validity license ADMISSION gate (exclude non-permissive repos)
+  // so ops can re-enable the old behavior without a deploy. Default (unset /
+  // anything else) = OFF = the new no-gate behavior.
+  const legacyLicenseGate = process.env.SKILLSMITH_INDEXER_LICENSE_GATE === 'true'
+
+  for (const repo of resultRepos) {
+    // Deduplication key includes skillPath: one repo can have multiple skills
+    const dedupKey = repo.skillPath ? `${repo.url}/${repo.skillPath}` : repo.url
+    if (seenUrls.has(dedupKey)) continue
+
+    // SMI-5319: keyed via the shared `repoCacheKey` derivation so the once-guard
+    // key (enumeratedRepos) and the repoMetaCache key are provably identical
+    // (concurrency-auditor Pattern-3 invariant).
+    const repoKey = repoCacheKey(repo.owner, repo.repoName)
+
+    // SMI-5319 kill-switch (legacy path only): the OLD pre-validity admission gate.
+    // Fetch repo metadata from the GitHub API and drop the repo if it could not be
+    // fetched (retry next run) or the license is confirmed non-permissive. Disabled
+    // by default -- the new behavior resolves metadata once-per-repo AFTER the
+    // once-guard and never drops a skill. When the gate admits a repo, the
+    // just-fetched metadata is seeded into `repoMetaCache` so the post-once-guard
+    // resolution below reuses it (no second fetch there). NOTE: this break-glass
+    // loop runs before the `enumeratedRepos` once-guard, so a repo surfacing via
+    // multiple skillPaths is re-fetched here per hit -- acceptable on the
+    // default-off legacy path.
+    if (legacyLicenseGate) {
+      const {
+        license: spdxId,
+        defaultBranch,
+        fetchFailed,
+      } = await fetchRepoLicense(repo.owner, repo.repoName, telemetry)
+
+      if (fetchFailed) {
+        // API failure -- skip this run but don't count as license-filtered.
+        // NOT added to seenUrls so the repo is retried on the next indexer run.
+        console.log(`[BroadDiscovery] License fetch failed (will retry next run): ${repo.fullName}`)
+        stats.licenseFetchFailed++
+        await delay(200)
+        continue
+      }
+
+      if (!isPermissiveLicense(spdxId)) {
+        // Confirmed non-permissive license -- permanently excluded.
+        console.log(`[BroadDiscovery] License excluded: ${repo.fullName} spdx=${spdxId ?? 'null'}`)
+        stats.licenseFiltered++
+        await delay(200)
+        continue
+      }
+
+      // Admitted by the legacy gate: reuse this metadata for the resolution below.
+      if (!repoMetaCache.has(repoKey)) {
+        repoMetaCache.set(repoKey, { license: spdxId, defaultBranch })
+      }
+    }
+
+    // Mark this code-search result consumed (per-repo+skillPath identity) so the
+    // same surfaced file is not re-processed across pages/prefixes.
+    seenUrls.add(dedupKey)
+
+    // SMI-5286 Wave 1a (sec#1): enumerate the repo's full tree ONCE. The broad query
+    // can surface the same repo via multiple SKILL.md hits; guard re-enumeration.
+    if (enumeratedRepos.has(repoKey)) {
+      await delay(50)
+      continue
+    }
+    enumeratedRepos.add(repoKey)
+
+    // SMI-5319: resolve repo metadata (license + default branch) ONCE per repo,
+    // AFTER the once-guard but BEFORE enumeration, cached on `repoKey` (the SAME
+    // key as the once-guard above, so write-key === read-key). The code-search API
+    // does NOT return `default_branch` (`repo.defaultBranch` is null), so the REAL
+    // branch comes from this `GET /repos` call. A metadata-fetch failure records
+    // `license: null` + `defaultBranch: null`. The repo is enumerated once per run,
+    // so a cache miss here means exactly one fetch.
+    let meta: RepoMeta
+    if (repoMetaCache.has(repoKey)) {
+      meta = repoMetaCache.get(repoKey) ?? { license: null, defaultBranch: null }
+    } else {
+      const { license, defaultBranch, fetchFailed } = await fetchRepoLicense(
+        repo.owner,
+        repo.repoName,
+        telemetry
+      )
+      // Ignore fetchFailed for license: record null and proceed (never drop, never
+      // retry-storm). A failed fetch also leaves `defaultBranch` null -> the repo is
+      // skipped below and retried next run.
+      meta = { license: fetchFailed ? null : license, defaultBranch }
+      if (fetchFailed) stats.licenseFetchFailed++
+      repoMetaCache.set(repoKey, meta)
+    }
+    const spdx = meta.license
+    const branch = meta.defaultBranch
+    if (spdx === null) stats.licenseNull++
+
+    // SMI-5319: without a resolvable default branch we CANNOT enumerate the repo
+    // (`GET /git/trees/null` -> 404 for every path) and MUST NOT emit a row with a
+    // null branch. Skip. Retry happens on the NEXT indexer run: `seenUrls` and
+    // `enumeratedRepos` are run-scoped (allocated fresh per `runSubdirectorySearch`),
+    // so a later run with a resolvable branch re-discovers and re-enumerates this
+    // repo. (Within THIS run it is not retried -- the `enumeratedRepos` once-guard
+    // already holds `repoKey`, and this hit's `dedupKey` is already in `seenUrls`.)
+    if (branch === null) {
+      console.log(`[BroadDiscovery] No default branch, skipping (retry next run): ${repo.fullName}`)
+      stats.noDefaultBranch++
+      await delay(50)
+      continue
+    }
+
+    const { entries, truncatedByApi, truncatedByCap } = await enumerateRepoSkillPaths(
+      repo.owner,
+      repo.repoName,
+      branch,
+      telemetry,
+      enumerateTelemetry
+    )
+
+    if (truncatedByApi) {
+      // Trees API truncated -- do NOT emit a partial set (deterministic skip).
+      console.log(
+        `[BroadDiscovery] Trees truncated, skipping for manual handling: ${repo.fullName}`
+      )
+      await delay(50)
+      continue
+    }
+    if (truncatedByCap) {
+      console.log(`[BroadDiscovery] Per-repo cap reached, taking first N: ${repo.fullName}`)
+    }
+
+    // Validate each enumerated SKILL.md independently (sec#4 strict gate) and emit
+    // one per-skill GitHubRepository with a distinct tree URL (C-1) per valid path.
+    for (const entry of entries) {
+      const skillPath = entry.path
+      const installable = await checkSkillMdExists(
+        repo.owner,
+        repo.repoName,
+        branch,
+        validationCache,
+        telemetry,
+        skillPath,
+        validationOptions
+      )
+
+      // C-1: build the per-skill tree URL from the BARE repo html_url
+      // (reconstructed from owner/repoName), NOT from `repo.url` -- by this point
+      // `repo.url` is already the code-search mapper's tree URL, so reusing it
+      // would double the `/tree/<branch>` segment. `skillUrl` already encodes
+      // `skillPath`, so it alone is the dedup key. SMI-5319: built with the FETCHED
+      // `branch` (not `repo.defaultBranch`, which is null from code search).
+      const skillUrl = buildSkillTreeUrl(
+        `https://github.com/${repo.owner}/${repo.repoName}`,
+        branch,
+        skillPath
+      )
+      if (seenUrls.has(skillUrl)) continue
+      seenUrls.add(skillUrl)
+
+      // SMI-5319: emit with the cached license as surfaced metadata (possibly
+      // null). Admission was already governed by the strict validity gate above.
+      repos.push({
+        ...repo,
+        url: skillUrl,
+        installable,
+        skillPath,
+        treeHash: entry.blobSha,
+        license: spdx,
+      })
+      stats.admitted++
+      await delay(50)
+    }
+  }
+}

--- a/scripts/indexer/subdirectory-search.ts
+++ b/scripts/indexer/subdirectory-search.ts
@@ -97,10 +97,11 @@ export const FALLBACK_PATH_PREFIXES = [
  * Deduplicates results against the shared seenUrls set from earlier phases
  * so repos discovered via topic search are not re-validated.
  *
- * License gate: repos without a permissive license (MIT, Apache-2.0, etc.) are
- * excluded and counted in licenseFiltered. Repos where the license fetch failed
- * (rate limit / network error) are counted separately in licenseFetchFailed and
- * are NOT added to seenUrls — they will be retried on the next indexer run.
+ * SMI-5319: license is NOT an admission filter. Every valid skill is indexed with
+ * its resolved SPDX as surfaced metadata (the consumer decides). `licenseFiltered`
+ * is ~0 unless `SKILLSMITH_INDEXER_LICENSE_GATE=true` restores the legacy gate; a
+ * license-fetch failure records `license: null` and STILL admits the skill.
+ * `admitted` / `licenseNull` report admit volume and the null-license rate.
  *
  * SMI-4852: Threads `telemetry` through to every downstream GitHub call.
  *
@@ -126,6 +127,10 @@ export async function runSubdirectorySearch(
   retries: number
   licenseFiltered: number
   licenseFetchFailed: number
+  /** SMI-5319: skills admitted (indexed) this run. */
+  admitted: number
+  /** SMI-5319: admitted skills whose resolved SPDX is null. */
+  licenseNull: number
   incompleteResults: number
   searchMode: 'broad' | 'prefix-fallback'
   errors: string[]
@@ -178,6 +183,8 @@ export async function runSubdirectorySearch(
       retries: totalRetries,
       licenseFiltered: stats.licenseFiltered,
       licenseFetchFailed: stats.licenseFetchFailed,
+      admitted: stats.admitted,
+      licenseNull: stats.licenseNull,
       incompleteResults,
       searchMode,
       errors,
@@ -316,6 +323,8 @@ export async function runSubdirectorySearch(
     retries: totalRetries,
     licenseFiltered: stats.licenseFiltered,
     licenseFetchFailed: stats.licenseFetchFailed,
+    admitted: stats.admitted,
+    licenseNull: stats.licenseNull,
     incompleteResults,
     searchMode: primaryMode,
     errors,
@@ -359,6 +368,8 @@ export async function runSubdirectorySearchPhase(args: {
       retries: subdirResult.retries,
       license_filtered: subdirResult.licenseFiltered,
       license_fetch_failed: subdirResult.licenseFetchFailed,
+      admitted: subdirResult.admitted,
+      license_null: subdirResult.licenseNull,
       incomplete_results: subdirResult.incompleteResults,
       search_mode: subdirResult.searchMode,
     }
@@ -373,6 +384,8 @@ export async function runSubdirectorySearchPhase(args: {
       retries: 0,
       license_filtered: 0,
       license_fetch_failed: 0,
+      admitted: 0,
+      license_null: 0,
       error: 'phase_failed',
     }
   }

--- a/scripts/indexer/subdirectory-search.ts
+++ b/scripts/indexer/subdirectory-search.ts
@@ -45,6 +45,7 @@ import {
   processSearchResults,
   runBackfillFacetCrawl,
   type BackfillFacetPlan,
+  type RepoMeta,
 } from './subdirectory-search.helpers.ts'
 import type { BackfillCrawlOutcome } from './backfill-checkpoint.ts'
 import type { GitHubRepository } from './topic-search.ts'
@@ -131,6 +132,8 @@ export async function runSubdirectorySearch(
   admitted: number
   /** SMI-5319: admitted skills whose resolved SPDX is null. */
   licenseNull: number
+  /** SMI-5319: repos skipped for an unresolvable default branch (retried next run). */
+  noDefaultBranch: number
   incompleteResults: number
   searchMode: 'broad' | 'prefix-fallback'
   errors: string[]
@@ -142,18 +145,26 @@ export async function runSubdirectorySearch(
   let totalFound = 0
   let totalRetries = 0
   // SMI-5319: `licenseFiltered` is ~0 now (only the kill-switch path increments
-  // it). `admitted` + `licenseNull` give admit volume + null-license rate.
-  const stats = { licenseFiltered: 0, licenseFetchFailed: 0, admitted: 0, licenseNull: 0 }
+  // it). `admitted` + `licenseNull` give admit volume + null-license rate;
+  // `noDefaultBranch` counts repos skipped for an unresolvable default branch.
+  const stats = {
+    licenseFiltered: 0,
+    licenseFetchFailed: 0,
+    admitted: 0,
+    licenseNull: 0,
+    noDefaultBranch: 0,
+  }
   let incompleteResults = 0
   const searchMode: 'broad' | 'prefix-fallback' = 'broad'
   // SMI-5286 Wave 1a: run-scoped per-skill extraction state. `enumerateTelemetry`
   // accumulates denylist/cap/truncation counters across the whole run;
   // `enumeratedRepos` guards one Trees call per repo across pages and prefixes.
-  // SMI-5319: `licenseCache` resolves each repo's license at most once per run;
-  // it is keyed by `repoCacheKey` — the SAME derivation as `enumeratedRepos`.
+  // SMI-5319: `repoMetaCache` resolves each repo's metadata (license + default
+  // branch) at most once per run; it is keyed by `repoCacheKey` — the SAME
+  // derivation as `enumeratedRepos`.
   const enumerateTelemetry: EnumerateTelemetry = {}
   const enumeratedRepos = new Set<string>()
-  const licenseCache = new Map<string, string | null>()
+  const repoMetaCache = new Map<string, RepoMeta>()
 
   // ── SMI-5286 1c: size-faceted backfill crawl (replaces the legacy loop) ──
   if (backfillPlan) {
@@ -167,12 +178,12 @@ export async function runSubdirectorySearch(
       telemetry,
       enumerateTelemetry,
       enumeratedRepos,
-      licenseCache,
+      repoMetaCache,
       errors
     )
     console.log(
       `[Backfill] Facet crawl: ${repos.length} skills added, ${backfill.facets_completed}/${backfill.facets_total} facets, ${backfill.ranges_crawled} ranges this dispatch, ` +
-        `admitted=${stats.admitted}, licenseNull=${stats.licenseNull}, ${stats.licenseFiltered} license-filtered, cap_saturated=${backfill.cap_saturated}, truncated=${backfill.truncated_repo_count}, done=${backfill.done}`
+        `admitted=${stats.admitted}, licenseNull=${stats.licenseNull}, noDefaultBranch=${stats.noDefaultBranch}, ${stats.licenseFiltered} license-filtered, cap_saturated=${backfill.cap_saturated}, truncated=${backfill.truncated_repo_count}, done=${backfill.done}`
     )
     console.log(
       `[Backfill] Per-skill extraction: ${enumeratedRepos.size} repos enumerated, ${enumerateTelemetry.denylistSkipped ?? 0} denylist-skipped, ${enumerateTelemetry.cappedRepoCount ?? 0} capped, ${enumerateTelemetry.truncatedRepoCount ?? 0} api-truncated`
@@ -185,6 +196,7 @@ export async function runSubdirectorySearch(
       licenseFetchFailed: stats.licenseFetchFailed,
       admitted: stats.admitted,
       licenseNull: stats.licenseNull,
+      noDefaultBranch: stats.noDefaultBranch,
       incompleteResults,
       searchMode,
       errors,
@@ -230,7 +242,7 @@ export async function runSubdirectorySearch(
       telemetry,
       enumerateTelemetry,
       enumeratedRepos,
-      licenseCache
+      repoMetaCache
     )
 
     if (result.repos.length < BROAD_QUERY_PER_PAGE) break
@@ -284,7 +296,7 @@ export async function runSubdirectorySearch(
           telemetry,
           enumerateTelemetry,
           enumeratedRepos,
-          licenseCache
+          repoMetaCache
         )
 
         if (result.repos.length < BROAD_QUERY_PER_PAGE) break
@@ -302,7 +314,7 @@ export async function runSubdirectorySearch(
   // `licenseFiltered` is ~0 unless the SKILLSMITH_INDEXER_LICENSE_GATE kill-switch
   // is on. Existing fields kept for shape stability.
   console.log(
-    `[BroadDiscovery] Complete (${primaryMode}): ${repos.length} added, admitted=${stats.admitted}, licenseNull=${stats.licenseNull}, ${stats.licenseFiltered} license-filtered, ${stats.licenseFetchFailed} fetch-failed, ${incompleteResults} incomplete, ${totalRetries} retries`
+    `[BroadDiscovery] Complete (${primaryMode}): ${repos.length} added, admitted=${stats.admitted}, licenseNull=${stats.licenseNull}, noDefaultBranch=${stats.noDefaultBranch}, ${stats.licenseFiltered} license-filtered, ${stats.licenseFetchFailed} fetch-failed, ${incompleteResults} incomplete, ${totalRetries} retries`
   )
   // SMI-5286 Wave 1a: per-skill extraction observability (§#1, Edit D).
   console.log(
@@ -325,6 +337,7 @@ export async function runSubdirectorySearch(
     licenseFetchFailed: stats.licenseFetchFailed,
     admitted: stats.admitted,
     licenseNull: stats.licenseNull,
+    noDefaultBranch: stats.noDefaultBranch,
     incompleteResults,
     searchMode: primaryMode,
     errors,
@@ -370,6 +383,7 @@ export async function runSubdirectorySearchPhase(args: {
       license_fetch_failed: subdirResult.licenseFetchFailed,
       admitted: subdirResult.admitted,
       license_null: subdirResult.licenseNull,
+      no_default_branch: subdirResult.noDefaultBranch,
       incomplete_results: subdirResult.incompleteResults,
       search_mode: subdirResult.searchMode,
     }
@@ -386,6 +400,7 @@ export async function runSubdirectorySearchPhase(args: {
       license_fetch_failed: 0,
       admitted: 0,
       license_null: 0,
+      no_default_branch: 0,
       error: 'phase_failed',
     }
   }

--- a/scripts/indexer/subdirectory-search.ts
+++ b/scripts/indexer/subdirectory-search.ts
@@ -136,14 +136,19 @@ export async function runSubdirectorySearch(
   const errors: string[] = []
   let totalFound = 0
   let totalRetries = 0
-  const stats = { licenseFiltered: 0, licenseFetchFailed: 0 }
+  // SMI-5319: `licenseFiltered` is ~0 now (only the kill-switch path increments
+  // it). `admitted` + `licenseNull` give admit volume + null-license rate.
+  const stats = { licenseFiltered: 0, licenseFetchFailed: 0, admitted: 0, licenseNull: 0 }
   let incompleteResults = 0
   const searchMode: 'broad' | 'prefix-fallback' = 'broad'
   // SMI-5286 Wave 1a: run-scoped per-skill extraction state. `enumerateTelemetry`
   // accumulates denylist/cap/truncation counters across the whole run;
   // `enumeratedRepos` guards one Trees call per repo across pages and prefixes.
+  // SMI-5319: `licenseCache` resolves each repo's license at most once per run;
+  // it is keyed by `repoCacheKey` — the SAME derivation as `enumeratedRepos`.
   const enumerateTelemetry: EnumerateTelemetry = {}
   const enumeratedRepos = new Set<string>()
+  const licenseCache = new Map<string, string | null>()
 
   // ── SMI-5286 1c: size-faceted backfill crawl (replaces the legacy loop) ──
   if (backfillPlan) {
@@ -157,11 +162,12 @@ export async function runSubdirectorySearch(
       telemetry,
       enumerateTelemetry,
       enumeratedRepos,
+      licenseCache,
       errors
     )
     console.log(
       `[Backfill] Facet crawl: ${repos.length} skills added, ${backfill.facets_completed}/${backfill.facets_total} facets, ${backfill.ranges_crawled} ranges this dispatch, ` +
-        `${stats.licenseFiltered} license-filtered, cap_saturated=${backfill.cap_saturated}, truncated=${backfill.truncated_repo_count}, done=${backfill.done}`
+        `admitted=${stats.admitted}, licenseNull=${stats.licenseNull}, ${stats.licenseFiltered} license-filtered, cap_saturated=${backfill.cap_saturated}, truncated=${backfill.truncated_repo_count}, done=${backfill.done}`
     )
     console.log(
       `[Backfill] Per-skill extraction: ${enumeratedRepos.size} repos enumerated, ${enumerateTelemetry.denylistSkipped ?? 0} denylist-skipped, ${enumerateTelemetry.cappedRepoCount ?? 0} capped, ${enumerateTelemetry.truncatedRepoCount ?? 0} api-truncated`
@@ -216,7 +222,8 @@ export async function runSubdirectorySearch(
       stats,
       telemetry,
       enumerateTelemetry,
-      enumeratedRepos
+      enumeratedRepos,
+      licenseCache
     )
 
     if (result.repos.length < BROAD_QUERY_PER_PAGE) break
@@ -269,7 +276,8 @@ export async function runSubdirectorySearch(
           stats,
           telemetry,
           enumerateTelemetry,
-          enumeratedRepos
+          enumeratedRepos,
+          licenseCache
         )
 
         if (result.repos.length < BROAD_QUERY_PER_PAGE) break
@@ -282,8 +290,12 @@ export async function runSubdirectorySearch(
     }
   }
 
+  // SMI-5319: `admitted` = volume passing the strict validity gate; `licenseNull`
+  // = how many had no detectable license (now surfaced, not dropped).
+  // `licenseFiltered` is ~0 unless the SKILLSMITH_INDEXER_LICENSE_GATE kill-switch
+  // is on. Existing fields kept for shape stability.
   console.log(
-    `[BroadDiscovery] Complete (${primaryMode}): ${repos.length} added, ${stats.licenseFiltered} license-filtered, ${stats.licenseFetchFailed} fetch-failed, ${incompleteResults} incomplete, ${totalRetries} retries`
+    `[BroadDiscovery] Complete (${primaryMode}): ${repos.length} added, admitted=${stats.admitted}, licenseNull=${stats.licenseNull}, ${stats.licenseFiltered} license-filtered, ${stats.licenseFetchFailed} fetch-failed, ${incompleteResults} incomplete, ${totalRetries} retries`
   )
   // SMI-5286 Wave 1a: per-skill extraction observability (§#1, Edit D).
   console.log(

--- a/scripts/indexer/subdirectory-search.ts
+++ b/scripts/indexer/subdirectory-search.ts
@@ -32,10 +32,13 @@
  * Gated by SKILLSMITH_ENABLE_SUBDIRECTORY_SEARCH=true env var to prevent
  * accidental budget exhaustion when not needed.
  *
- * License gate: code search does not return license data. Each unique repo found
- * here requires a separate fetchRepoLicense() call before indexing. This means
- * N subdirectory repos = N additional /repos/{owner}/{repo} API calls (main API,
- * 5000 req/hr authenticated — budget is generous but must be monitored).
+ * Repo metadata (SMI-5319): code search returns neither license NOR
+ * default_branch. Each unique repo found here requires a separate
+ * fetchRepoLicense() call (GET /repos/{owner}/{repo}) that resolves BOTH the
+ * surfaced license AND the real default branch (the branch drives the Trees
+ * enumeration + the emitted skill URL; a repo with no resolvable branch is
+ * skipped). This means N subdirectory repos = N additional /repos API calls
+ * (main API, 5000 req/hr authenticated — budget is generous but must be monitored).
  */
 
 import { GITHUB_API_DELAY, delay, type RateLimitTelemetry } from './_shared/rate-limit.ts'

--- a/scripts/tests/indexer/backfill-checkpoint.dry-run.test.ts
+++ b/scripts/tests/indexer/backfill-checkpoint.dry-run.test.ts
@@ -69,8 +69,8 @@ type ReadQueryState = {
   row: { metadata: BackfillCheckpointPayload } | null
   error: { message: string } | null
   eqFilters: Record<string, string>
-  /** Captures .not(column, operator, value) calls for assertion. */
-  notFilters: Array<{ column: string; operator: string; value: string }>
+  /** Captures .or(filterString) calls for assertion. */
+  orFilters: string[]
 }
 
 function makeReadMock(state: ReadQueryState): SupabaseClient {
@@ -79,8 +79,8 @@ function makeReadMock(state: ReadQueryState): SupabaseClient {
       state.eqFilters[key] = value
       return chain
     },
-    not: (column: string, operator: string, value: string) => {
-      state.notFilters.push({ column, operator, value })
+    or: (filter: string) => {
+      state.orFilters.push(filter)
       return chain
     },
     order: () => chain,
@@ -129,52 +129,48 @@ describe('writeCheckpoint — dry_run tag (SMI-5319 W3)', () => {
 // ---------------------------------------------------------------------------
 
 describe('readLatestCheckpoint — excludeDryRun (SMI-5319 W3)', () => {
-  it('does NOT apply a not() filter when excludeDryRun is false (default)', async () => {
+  it('does NOT apply an or() filter when excludeDryRun is false (default)', async () => {
     const state: ReadQueryState = {
       row: { metadata: makePayload() },
       error: null,
       eqFilters: {},
-      notFilters: [],
+      orFilters: [],
     }
     const supabase = makeReadMock(state)
 
     await readLatestCheckpoint(supabase, undefined, { excludeDryRun: false })
 
-    expect(state.notFilters).toHaveLength(0)
+    expect(state.orFilters).toHaveLength(0)
   })
 
-  it('does NOT apply a not() filter when options is omitted entirely', async () => {
+  it('does NOT apply an or() filter when options is omitted entirely', async () => {
     const state: ReadQueryState = {
       row: { metadata: makePayload() },
       error: null,
       eqFilters: {},
-      notFilters: [],
+      orFilters: [],
     }
     const supabase = makeReadMock(state)
 
     // No options arg — default behaviour must be back-compat (no filter).
     await readLatestCheckpoint(supabase)
 
-    expect(state.notFilters).toHaveLength(0)
+    expect(state.orFilters).toHaveLength(0)
   })
 
-  it('applies .not("metadata->>dry_run", "eq", "true") when excludeDryRun is true', async () => {
+  it('applies a NULL-safe .or() (dry_run neq true OR is null) when excludeDryRun is true', async () => {
     const state: ReadQueryState = {
       row: { metadata: makePayload({ dry_run: false }) },
       error: null,
       eqFilters: {},
-      notFilters: [],
+      orFilters: [],
     }
     const supabase = makeReadMock(state)
 
     await readLatestCheckpoint(supabase, undefined, { excludeDryRun: true })
 
-    expect(state.notFilters).toHaveLength(1)
-    expect(state.notFilters[0]).toEqual({
-      column: 'metadata->>dry_run',
-      operator: 'eq',
-      value: 'true',
-    })
+    expect(state.orFilters).toHaveLength(1)
+    expect(state.orFilters[0]).toBe('metadata->>dry_run.neq.true,metadata->>dry_run.is.null')
   })
 
   it('excludeDryRun: true — filter applied; mock returns the live (non-dry-run) row', async () => {
@@ -185,13 +181,13 @@ describe('readLatestCheckpoint — excludeDryRun (SMI-5319 W3)', () => {
       row: { metadata: livePayload },
       error: null,
       eqFilters: {},
-      notFilters: [],
+      orFilters: [],
     }
     const supabase = makeReadMock(state)
 
     const result = await readLatestCheckpoint(supabase, undefined, { excludeDryRun: true })
 
-    expect(state.notFilters).toHaveLength(1)
+    expect(state.orFilters).toHaveLength(1)
     expect(result).not.toBeNull()
     expect(result?.run_id).toBe('live-run')
     expect(result?.dry_run).toBe(false)
@@ -205,26 +201,28 @@ describe('readLatestCheckpoint — excludeDryRun (SMI-5319 W3)', () => {
       row: { metadata: dryRunPayload },
       error: null,
       eqFilters: {},
-      notFilters: [],
+      orFilters: [],
     }
     const supabase = makeReadMock(state)
 
     const result = await readLatestCheckpoint(supabase, undefined, { excludeDryRun: false })
 
-    // No not() filter applied.
-    expect(state.notFilters).toHaveLength(0)
+    // No or() filter applied.
+    expect(state.orFilters).toHaveLength(0)
     expect(result?.run_id).toBe('dry-run')
     expect(result?.dry_run).toBe(true)
   })
 
   it('legacy row WITHOUT dry_run field is returned when excludeDryRun is true (NULL-safe)', async () => {
     // A legacy checkpoint row has no dry_run key in metadata (JSONB value is null).
-    // PostgREST .not('metadata->>dry_run', 'eq', 'true') generates:
-    //   metadata->>'dry_run' <> 'true' OR metadata->>'dry_run' IS NULL
-    // The IS NULL branch includes the legacy row — it is NOT silently excluded.
-    // This test verifies the mock simulates that behaviour: the legacy row is returned
-    // even though excludeDryRun is true, proving no silent loss of legacy live checkpoints.
-    // (Pre-SMI-5319 dry-run checkpoints must be cleaned up by the operator pre-flight.)
+    // The query uses `.or('metadata->>dry_run.neq.true,metadata->>dry_run.is.null')`,
+    // which emits `metadata->>'dry_run' <> 'true' OR metadata->>'dry_run' IS NULL`.
+    // The IS NULL branch includes legacy rows — they are NOT silently excluded.
+    // A unit test can't exercise the DB predicate (the mock returns the row), so this
+    // proves null-safety at the query-construction level: the .or() string carries the
+    // explicit `is.null` branch (asserted below). DB-level behaviour is covered by the
+    // live-dispatch verification (SMI-5319). Pre-SMI-5319 dry-run rows must still be
+    // cleaned up by the operator pre-flight.
     const legacyPayload = makePayload({ run_id: 'legacy-live-run' })
     // Delete dry_run to simulate a pre-SMI-5319 row.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -233,14 +231,16 @@ describe('readLatestCheckpoint — excludeDryRun (SMI-5319 W3)', () => {
       row: { metadata: legacyWithoutDryRun as BackfillCheckpointPayload },
       error: null,
       eqFilters: {},
-      notFilters: [],
+      orFilters: [],
     }
     const supabase = makeReadMock(state)
 
     const result = await readLatestCheckpoint(supabase, undefined, { excludeDryRun: true })
 
-    // The not() filter was applied (DB includes the row because dry_run IS NULL).
-    expect(state.notFilters).toHaveLength(1)
+    // The NULL-safe .or() filter was applied — its `is.null` branch is what keeps
+    // legacy rows; assert the exact null-inclusive form (proof, not a tautology).
+    expect(state.orFilters).toHaveLength(1)
+    expect(state.orFilters[0]).toContain('metadata->>dry_run.is.null')
     // The legacy checkpoint is returned — not dropped.
     expect(result).not.toBeNull()
     expect(result?.run_id).toBe('legacy-live-run')

--- a/scripts/tests/indexer/backfill-checkpoint.dry-run.test.ts
+++ b/scripts/tests/indexer/backfill-checkpoint.dry-run.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Backfill checkpoint dry-run hygiene tests (SMI-5319 W3)
+ * @module scripts/tests/indexer/backfill-checkpoint.dry-run
+ *
+ * Covers the W3 additions to backfill-checkpoint.ts:
+ *  - writeCheckpoint stamps dry_run: true/false into audit_logs.metadata
+ *  - readLatestCheckpoint excludeDryRun: true applies the PostgREST .not() filter
+ *  - excludeDryRun is NULL-safe: legacy rows with no dry_run field are NOT excluded
+ *  - excludeDryRun: false (default) — dry-run rows are still returned
+ *
+ * Split from backfill-checkpoint.test.ts to stay under the 500-line CI gate.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  writeCheckpoint,
+  readLatestCheckpoint,
+  type BackfillCheckpointPayload,
+} from '../../indexer/backfill-checkpoint.ts'
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+function makePayload(
+  overrides: Partial<BackfillCheckpointPayload> = {}
+): BackfillCheckpointPayload {
+  return {
+    run_id: 'run-dry-run-test',
+    cursor: { path: 'test/path', facet: '2026-06-19', last_page: 1 },
+    facets_completed: 2,
+    facets_total: 8,
+    cap_saturated: false,
+    truncated_repo_count: 0,
+    dry_run: false,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Insert mock (mirrors the shape in backfill-checkpoint.test.ts)
+// ---------------------------------------------------------------------------
+
+interface CapturedInsert {
+  table: string
+  payload: Record<string, unknown>
+}
+
+function makeInsertMock(
+  captured: CapturedInsert[],
+  error: { message: string } | null = null
+): SupabaseClient {
+  return {
+    from: (table: string) => ({
+      insert: (payload: Record<string, unknown>) => {
+        captured.push({ table, payload })
+        return Promise.resolve({ data: null, error })
+      },
+    }),
+  } as unknown as SupabaseClient
+}
+
+// ---------------------------------------------------------------------------
+// Read mock with not() filter capture
+// ---------------------------------------------------------------------------
+
+type ReadQueryState = {
+  row: { metadata: BackfillCheckpointPayload } | null
+  error: { message: string } | null
+  eqFilters: Record<string, string>
+  /** Captures .not(column, operator, value) calls for assertion. */
+  notFilters: Array<{ column: string; operator: string; value: string }>
+}
+
+function makeReadMock(state: ReadQueryState): SupabaseClient {
+  const chain = {
+    eq: (key: string, value: string) => {
+      state.eqFilters[key] = value
+      return chain
+    },
+    not: (column: string, operator: string, value: string) => {
+      state.notFilters.push({ column, operator, value })
+      return chain
+    },
+    order: () => chain,
+    limit: () => chain,
+    maybeSingle: () =>
+      Promise.resolve({
+        data: state.row,
+        error: state.error,
+      }),
+  }
+  return {
+    from: () => ({
+      select: () => chain,
+    }),
+  } as unknown as SupabaseClient
+}
+
+// ---------------------------------------------------------------------------
+// writeCheckpoint: dry_run tag (SMI-5319 W3)
+// ---------------------------------------------------------------------------
+
+describe('writeCheckpoint — dry_run tag (SMI-5319 W3)', () => {
+  it('stamps dry_run: true into audit_logs.metadata when payload.dry_run is true', async () => {
+    const captured: CapturedInsert[] = []
+    const supabase = makeInsertMock(captured)
+
+    await writeCheckpoint(supabase, makePayload({ dry_run: true }))
+
+    const metadata = captured[0].payload.metadata as Record<string, unknown>
+    expect(metadata.dry_run).toBe(true)
+  })
+
+  it('stamps dry_run: false into audit_logs.metadata when payload.dry_run is false', async () => {
+    const captured: CapturedInsert[] = []
+    const supabase = makeInsertMock(captured)
+
+    await writeCheckpoint(supabase, makePayload({ dry_run: false }))
+
+    const metadata = captured[0].payload.metadata as Record<string, unknown>
+    expect(metadata.dry_run).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// readLatestCheckpoint: excludeDryRun filter (SMI-5319 W3)
+// ---------------------------------------------------------------------------
+
+describe('readLatestCheckpoint — excludeDryRun (SMI-5319 W3)', () => {
+  it('does NOT apply a not() filter when excludeDryRun is false (default)', async () => {
+    const state: ReadQueryState = {
+      row: { metadata: makePayload() },
+      error: null,
+      eqFilters: {},
+      notFilters: [],
+    }
+    const supabase = makeReadMock(state)
+
+    await readLatestCheckpoint(supabase, undefined, { excludeDryRun: false })
+
+    expect(state.notFilters).toHaveLength(0)
+  })
+
+  it('does NOT apply a not() filter when options is omitted entirely', async () => {
+    const state: ReadQueryState = {
+      row: { metadata: makePayload() },
+      error: null,
+      eqFilters: {},
+      notFilters: [],
+    }
+    const supabase = makeReadMock(state)
+
+    // No options arg — default behaviour must be back-compat (no filter).
+    await readLatestCheckpoint(supabase)
+
+    expect(state.notFilters).toHaveLength(0)
+  })
+
+  it('applies .not("metadata->>dry_run", "eq", "true") when excludeDryRun is true', async () => {
+    const state: ReadQueryState = {
+      row: { metadata: makePayload({ dry_run: false }) },
+      error: null,
+      eqFilters: {},
+      notFilters: [],
+    }
+    const supabase = makeReadMock(state)
+
+    await readLatestCheckpoint(supabase, undefined, { excludeDryRun: true })
+
+    expect(state.notFilters).toHaveLength(1)
+    expect(state.notFilters[0]).toEqual({
+      column: 'metadata->>dry_run',
+      operator: 'eq',
+      value: 'true',
+    })
+  })
+
+  it('excludeDryRun: true — filter applied; mock returns the live (non-dry-run) row', async () => {
+    // The DB has two rows: most recent is dry_run:true, prior is dry_run:false.
+    // With the filter applied, the DB returns only the live row (mock simulates this).
+    const livePayload = makePayload({ run_id: 'live-run', dry_run: false })
+    const state: ReadQueryState = {
+      row: { metadata: livePayload },
+      error: null,
+      eqFilters: {},
+      notFilters: [],
+    }
+    const supabase = makeReadMock(state)
+
+    const result = await readLatestCheckpoint(supabase, undefined, { excludeDryRun: true })
+
+    expect(state.notFilters).toHaveLength(1)
+    expect(result).not.toBeNull()
+    expect(result?.run_id).toBe('live-run')
+    expect(result?.dry_run).toBe(false)
+  })
+
+  it('excludeDryRun: false — returns a dry-run row when it is the latest', async () => {
+    // A DRY_RUN dispatch resuming from the latest checkpoint should still
+    // see dry-run checkpoints (to verify the resume loop end-to-end).
+    const dryRunPayload = makePayload({ run_id: 'dry-run', dry_run: true })
+    const state: ReadQueryState = {
+      row: { metadata: dryRunPayload },
+      error: null,
+      eqFilters: {},
+      notFilters: [],
+    }
+    const supabase = makeReadMock(state)
+
+    const result = await readLatestCheckpoint(supabase, undefined, { excludeDryRun: false })
+
+    // No not() filter applied.
+    expect(state.notFilters).toHaveLength(0)
+    expect(result?.run_id).toBe('dry-run')
+    expect(result?.dry_run).toBe(true)
+  })
+
+  it('legacy row WITHOUT dry_run field is returned when excludeDryRun is true (NULL-safe)', async () => {
+    // A legacy checkpoint row has no dry_run key in metadata (JSONB value is null).
+    // PostgREST .not('metadata->>dry_run', 'eq', 'true') generates:
+    //   metadata->>'dry_run' <> 'true' OR metadata->>'dry_run' IS NULL
+    // The IS NULL branch includes the legacy row — it is NOT silently excluded.
+    // This test verifies the mock simulates that behaviour: the legacy row is returned
+    // even though excludeDryRun is true, proving no silent loss of legacy live checkpoints.
+    // (Pre-SMI-5319 dry-run checkpoints must be cleaned up by the operator pre-flight.)
+    const legacyPayload = makePayload({ run_id: 'legacy-live-run' })
+    // Delete dry_run to simulate a pre-SMI-5319 row.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { dry_run, ...legacyWithoutDryRun } = legacyPayload
+    const state: ReadQueryState = {
+      row: { metadata: legacyWithoutDryRun as BackfillCheckpointPayload },
+      error: null,
+      eqFilters: {},
+      notFilters: [],
+    }
+    const supabase = makeReadMock(state)
+
+    const result = await readLatestCheckpoint(supabase, undefined, { excludeDryRun: true })
+
+    // The not() filter was applied (DB includes the row because dry_run IS NULL).
+    expect(state.notFilters).toHaveLength(1)
+    // The legacy checkpoint is returned — not dropped.
+    expect(result).not.toBeNull()
+    expect(result?.run_id).toBe('legacy-live-run')
+    // dry_run is absent on legacy rows (undefined after the cast-back).
+    expect((result as Record<string, unknown>)['dry_run']).toBeUndefined()
+  })
+})

--- a/scripts/tests/indexer/backfill-checkpoint.test.ts
+++ b/scripts/tests/indexer/backfill-checkpoint.test.ts
@@ -1,11 +1,12 @@
 /**
- * Backfill checkpoint read/write tests (SMI-5286 Wave 1b §#5)
+ * Backfill checkpoint read/write tests (SMI-5286 Wave 1b §#5 + SMI-5319 W3)
  * @module scripts/tests/indexer/backfill-checkpoint
  *
  * Covers:
  *  - resolveTokenSource: app/pat detection from env vars
- *  - writeCheckpoint: insert shape, fail-soft on error/throw
- *  - readLatestCheckpoint: payload parsing, runId filter, null on no row/error
+ *  - writeCheckpoint: insert shape, fail-soft on error/throw, dry_run tag
+ *  - readLatestCheckpoint: payload parsing, runId filter, null on no row/error,
+ *    excludeDryRun filter (SMI-5319 W3)
  *  - Round-trip: write then read back preserves cursor (path, facet, last_page)
  */
 
@@ -33,6 +34,7 @@ function makePayload(
     facets_total: 10,
     cap_saturated: false,
     truncated_repo_count: 2,
+    dry_run: false,
     ...overrides,
   }
 }
@@ -203,6 +205,7 @@ describe('writeCheckpoint', () => {
       facets_total: 15,
       cap_saturated: true,
       truncated_repo_count: 5,
+      dry_run: false,
     })
 
     await writeCheckpoint(supabase, payload)
@@ -214,6 +217,7 @@ describe('writeCheckpoint', () => {
     expect(metadata.facets_total).toBe(15)
     expect(metadata.cap_saturated).toBe(true)
     expect(metadata.truncated_repo_count).toBe(5)
+    expect(metadata.dry_run).toBe(false)
   })
 
   it('returns false (fail-soft) when supabase returns an error response', async () => {
@@ -248,8 +252,10 @@ type ReadQueryState = {
 }
 
 /**
- * Builds a Supabase mock whose `from('audit_logs').select().eq().order().limit().maybeSingle()`
+ * Builds a Supabase mock whose `from('audit_logs').select().eq().not().order().limit().maybeSingle()`
  * chain returns the configured row/error pair and records eq() calls.
+ * The `.not()` call is a no-op here — excludeDryRun filter behaviour is
+ * covered in backfill-checkpoint.dry-run.test.ts (SMI-5319 W3 split).
  */
 function makeReadMock(state: ReadQueryState): SupabaseClient {
   const chain = {
@@ -257,6 +263,7 @@ function makeReadMock(state: ReadQueryState): SupabaseClient {
       state.eqFilters[key] = value
       return chain
     },
+    not: () => chain,
     order: () => chain,
     limit: () => chain,
     maybeSingle: () =>
@@ -318,7 +325,11 @@ describe('readLatestCheckpoint', () => {
 
   it('applies run_id filter when a specific runId is given', async () => {
     const payload = makePayload({ run_id: 'specific-run' })
-    const state: ReadQueryState = { row: { metadata: payload }, error: null, eqFilters: {} }
+    const state: ReadQueryState = {
+      row: { metadata: payload },
+      error: null,
+      eqFilters: {},
+    }
     const supabase = makeReadMock(state)
 
     await readLatestCheckpoint(supabase, 'specific-run')
@@ -408,6 +419,7 @@ describe('backfill checkpoint round-trip (SPARC AC §#5)', () => {
       facets_total: 20,
       cap_saturated: true,
       truncated_repo_count: 3,
+      dry_run: false,
     }
 
     const writeOk = await writeCheckpoint(writeSupabase, originalPayload)
@@ -434,5 +446,7 @@ describe('backfill checkpoint round-trip (SPARC AC §#5)', () => {
     expect(readBack?.cap_saturated).toBe(true)
     expect(readBack?.truncated_repo_count).toBe(3)
     expect(readBack?.run_id).toBe('roundtrip-run-001')
+    // SMI-5319 W3: dry_run tag survives the round-trip
+    expect(readBack?.dry_run).toBe(false)
   })
 })

--- a/scripts/tests/indexer/backfill-facet-crawl.test.ts
+++ b/scripts/tests/indexer/backfill-facet-crawl.test.ts
@@ -161,8 +161,15 @@ beforeEach(() => {
   mockCheckSkillMdExists.mockReset()
   mockEnumerateRepoSkillPaths.mockReset()
 
-  // Default I/O behaviour: permissive license, validation passes, one skill per repo.
-  mockFetchRepoLicense.mockResolvedValue({ license: 'MIT', fetchFailed: false })
+  // Default I/O behaviour: permissive license + resolvable default branch,
+  // validation passes, one skill per repo. SMI-5319: fetchRepoLicense now also
+  // returns `defaultBranch` (the code-search API omits it) — the crawl skips a
+  // repo whose `defaultBranch` is null, so it must be present for repos to emit.
+  mockFetchRepoLicense.mockResolvedValue({
+    license: 'MIT',
+    defaultBranch: 'main',
+    fetchFailed: false,
+  })
   mockCheckSkillMdExists.mockResolvedValue(true)
   mockEnumerateRepoSkillPaths.mockResolvedValue({
     entries: [{ path: 'skills/x', blobSha: 'sha1' }],

--- a/scripts/tests/indexer/backfill-min-size.test.ts
+++ b/scripts/tests/indexer/backfill-min-size.test.ts
@@ -124,7 +124,14 @@ beforeEach(() => {
   mockCheckSkillMdExists.mockReset()
   mockEnumerateRepoSkillPaths.mockReset()
 
-  mockFetchRepoLicense.mockResolvedValue({ license: 'MIT', fetchFailed: false })
+  // SMI-5319: fetchRepoLicense now also returns `defaultBranch` (the code-search
+  // API omits it) — a repo with a null `defaultBranch` is skipped, so a real
+  // branch must be present for repos to emit.
+  mockFetchRepoLicense.mockResolvedValue({
+    license: 'MIT',
+    defaultBranch: 'main',
+    fetchFailed: false,
+  })
   mockCheckSkillMdExists.mockResolvedValue(true)
   mockEnumerateRepoSkillPaths.mockResolvedValue({
     entries: [{ path: 'skills/x', blobSha: 'sha1' }],

--- a/scripts/tests/indexer/backfill-min-size.test.ts
+++ b/scripts/tests/indexer/backfill-min-size.test.ts
@@ -1,0 +1,269 @@
+/**
+ * SMI-5319 W4: min_size_bytes fresh-start facet skip tests
+ *
+ * Verifies that `minSizeBytes` in `BackfillFacetPlan` skips low-byte noise-band
+ * facets on a FRESH START and is IGNORED on a RESUME (the cursor's own
+ * `facet_index` takes precedence). The 9-facet ladder is unchanged -- min_size
+ * only adjusts the initial `facetIndex` on the cold-start path.
+ *
+ * Mock strategy mirrors `backfill-facet-crawl.test.ts` exactly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+
+// ---------------------------------------------------------------------------
+// Module-level mocks -- declared before any import of the SUT
+// ---------------------------------------------------------------------------
+
+vi.mock('../../indexer/_shared/rate-limit.ts', () => ({
+  GITHUB_API_DELAY: 0,
+  delay: vi.fn(async () => undefined),
+  withRateLimitTracking: vi.fn(),
+  withBackoff: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  newRateLimitTelemetry: vi.fn(() => ({})),
+}))
+
+vi.mock('../../indexer/_shared/github-auth.ts', () => ({
+  buildGitHubHeaders: vi.fn(async () => ({})),
+}))
+
+const mockSearchCode = vi.fn()
+vi.mock('../../indexer/code-search.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/code-search.ts')>()
+  return {
+    ...actual,
+    searchCodeForSkillMdInSubdirectory: (...args: unknown[]) => mockSearchCode(...args),
+  }
+})
+
+const mockFetchRepoLicense = vi.fn()
+vi.mock('../../indexer/license-filter.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/license-filter.ts')>()
+  return {
+    ...actual,
+    fetchRepoLicense: (...args: unknown[]) => mockFetchRepoLicense(...args),
+  }
+})
+
+const mockCheckSkillMdExists = vi.fn()
+vi.mock('../../indexer/skill-processor.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/skill-processor.ts')>()
+  return {
+    ...actual,
+    checkSkillMdExists: (...args: unknown[]) => mockCheckSkillMdExists(...args),
+  }
+})
+
+const mockEnumerateRepoSkillPaths = vi.fn()
+vi.mock('../../indexer/trees-enumerate.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/trees-enumerate.ts')>()
+  return {
+    ...actual,
+    enumerateRepoSkillPaths: (...args: unknown[]) => mockEnumerateRepoSkillPaths(...args),
+  }
+})
+
+// Imported AFTER mocks so the SUT binds the stubs.
+import { runSubdirectorySearch, type BackfillFacetPlan } from '../../indexer/subdirectory-search.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noTelemetry: RateLimitTelemetry = {} as RateLimitTelemetry
+
+/** Static ladder length -- kept literal to assert against the SUT, not derive from it. */
+const LADDER_SIZE = 9
+
+let repoCounter = 0
+function makeCodeSearchRepo(overrides: Record<string, unknown> = {}) {
+  repoCounter += 1
+  const owner = `owner${repoCounter}`
+  return {
+    owner,
+    name: 'skills-repo',
+    fullName: `${owner}/skills-repo`,
+    description: 'test',
+    url: `https://github.com/${owner}/skills-repo/tree/main/skills/x`,
+    stars: 5,
+    forks: 0,
+    topics: ['claude-code-skill'],
+    updatedAt: new Date().toISOString(),
+    defaultBranch: 'main',
+    installable: false,
+    repoName: 'skills-repo',
+    skillPath: 'skills/x',
+    discoveryPath: 'subdirectory_search:broad',
+    ...overrides,
+  }
+}
+
+function nonSaturatingPage(page: number) {
+  if (page === 1) {
+    return { repos: [makeCodeSearchRepo()], total: 5, retries: 0, incomplete_results: false }
+  }
+  return { repos: [], total: 5, retries: 0, incomplete_results: false }
+}
+
+function makePlan(overrides: Partial<BackfillFacetPlan> = {}): BackfillFacetPlan {
+  return {
+    startCursor: null,
+    pathPrefix: undefined,
+    perPage: 100,
+    maxPagesPerRange: 20,
+    maxRangesPerDispatch: 100,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  repoCounter = 0
+  mockSearchCode.mockReset()
+  mockFetchRepoLicense.mockReset()
+  mockCheckSkillMdExists.mockReset()
+  mockEnumerateRepoSkillPaths.mockReset()
+
+  mockFetchRepoLicense.mockResolvedValue({ license: 'MIT', fetchFailed: false })
+  mockCheckSkillMdExists.mockResolvedValue(true)
+  mockEnumerateRepoSkillPaths.mockResolvedValue({
+    entries: [{ path: 'skills/x', blobSha: 'sha1' }],
+    truncatedByCap: false,
+    truncatedByApi: false,
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('SMI-5319 W4: runSubdirectorySearch -- minSizeBytes fresh-start facet skip', () => {
+  it('W4-A: fresh start with minSizeBytes=1024 starts at facet 4 (size:1024..2047), skipping facets 0-3', async () => {
+    // Collect the size qualifiers passed to every code-search call.
+    const observedQualifiers: string[] = []
+    mockSearchCode.mockImplementation(
+      async (
+        _pathPrefix: unknown,
+        page: number,
+        _perPage: unknown,
+        _tel: unknown,
+        sizeQualifier: string
+      ) => {
+        observedQualifiers.push(sizeQualifier)
+        return nonSaturatingPage(page)
+      }
+    )
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      // minSizeBytes=1024 on a fresh start (startCursor=null) must skip facets 0-3.
+      makePlan({ minSizeBytes: 1024, maxRangesPerDispatch: 100 })
+    )
+
+    const backfill = result.backfill!
+    // Done: the crawl ran facets 4-8 and exhausted the full ladder.
+    expect(backfill.done).toBe(true)
+    // facetIndex advanced past LADDER_SIZE (all 9 entries of the static array).
+    expect(backfill.facets_completed).toBe(LADDER_SIZE)
+    expect(backfill.cursor.facet_index).toBe(LADDER_SIZE)
+
+    // The first code-search call must have used 'size:1024..2047' (facet 4).
+    expect(observedQualifiers.length).toBeGreaterThan(0)
+    expect(observedQualifiers[0]).toBe('size:1024..2047')
+
+    // Facets 0-3 were never crawled: their qualifiers must be absent.
+    const noiseBandQualifiers = ['size:0..127', 'size:128..255', 'size:256..511', 'size:512..1023']
+    for (const q of noiseBandQualifiers) {
+      expect(observedQualifiers).not.toContain(q)
+    }
+  })
+
+  it('W4-B: fresh start with minSizeBytes=0 starts at facet 0 (size:0..127, no skip)', async () => {
+    const observedQualifiers: string[] = []
+    mockSearchCode.mockImplementation(
+      async (
+        _pathPrefix: unknown,
+        page: number,
+        _perPage: unknown,
+        _tel: unknown,
+        sizeQualifier: string
+      ) => {
+        observedQualifiers.push(sizeQualifier)
+        return nonSaturatingPage(page)
+      }
+    )
+
+    await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ minSizeBytes: 0, maxRangesPerDispatch: 1 })
+    )
+
+    // First call must be the first facet (size:0..127) -- no skip applied.
+    expect(observedQualifiers.length).toBeGreaterThan(0)
+    expect(observedQualifiers[0]).toBe('size:0..127')
+  })
+
+  it('W4-C: a RESUME from a checkpoint cursor at facet_index=6 ignores minSizeBytes and resumes at facet 6', async () => {
+    // Simulate: the crawl already completed facets 0-5 (facet_index=6 in cursor).
+    // Even with minSizeBytes=1024 (which would normally skip to facet 4 on a fresh
+    // start), the resume must honor the cursor's own facet_index=6.
+    //
+    // This is the load-bearing resume-invariant: cursorToFacetState() restores
+    // facetIndex from the checkpoint cursor BEFORE the min_size code runs; the
+    // min_size branch is guarded by `plan.startCursor == null` so it is NEVER
+    // executed on a resume path.
+    const observedQualifiers: string[] = []
+    mockSearchCode.mockImplementation(
+      async (
+        _pathPrefix: unknown,
+        page: number,
+        _perPage: unknown,
+        _tel: unknown,
+        sizeQualifier: string
+      ) => {
+        observedQualifiers.push(sizeQualifier)
+        return nonSaturatingPage(page)
+      }
+    )
+
+    // Build a checkpoint cursor placing the crawl at facet_index=6.
+    // facets[6] = { lo: 4096, hi: 8191 } -> qualifier 'size:4096..8191'.
+    const resumeCursor = {
+      path: '',
+      facet: '4096-8191',
+      last_page: 0,
+      facet_index: 6,
+      pending_subranges: [],
+    }
+
+    await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({
+        startCursor: resumeCursor,
+        minSizeBytes: 1024, // would skip to facet 4 on fresh start -- MUST be ignored here
+        maxRangesPerDispatch: 1,
+      })
+    )
+
+    // The first call must be at facet 6 (size:4096..8191), NOT at facet 4
+    // (size:1024..2047). This proves the resume path ignores minSizeBytes.
+    expect(observedQualifiers.length).toBeGreaterThan(0)
+    expect(observedQualifiers[0]).toBe('size:4096..8191')
+
+    // Facets below index 6 must not appear (they were already completed in the
+    // prior dispatch that wrote the checkpoint cursor).
+    expect(observedQualifiers).not.toContain('size:0..127')
+    expect(observedQualifiers).not.toContain('size:1024..2047')
+    expect(observedQualifiers).not.toContain('size:2048..4095')
+  })
+})

--- a/scripts/tests/indexer/backfill-min-size.test.ts
+++ b/scripts/tests/indexer/backfill-min-size.test.ts
@@ -165,7 +165,8 @@ describe('SMI-5319 W4: runSubdirectorySearch -- minSizeBytes fresh-start facet s
     const backfill = result.backfill!
     // Done: the crawl ran facets 4-8 and exhausted the full ladder.
     expect(backfill.done).toBe(true)
-    // facetIndex advanced past LADDER_SIZE (all 9 entries of the static array).
+    // Only facets 4-8 were crawled (min_size skipped 0-3); facets_completed is a
+    // ladder-position counter that reads LADDER_SIZE once the ladder is exhausted.
     expect(backfill.facets_completed).toBe(LADDER_SIZE)
     expect(backfill.cursor.facet_index).toBe(LADDER_SIZE)
 

--- a/scripts/tests/indexer/backfill-skill-cap.test.ts
+++ b/scripts/tests/indexer/backfill-skill-cap.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Per-dispatch skill cap tests (SMI-5319)
+ *
+ * Verifies the `maxSkillsPerDispatch` field added to `BackfillFacetPlan`:
+ *   1. A crawl with a cap stops EARLY (before exhausting maxRangesPerDispatch),
+ *      returns done=false, and produces a resumable cursor (range boundary).
+ *   2. cap=0 (or unset) is a no-op -- the full ladder completes.
+ *   3. Resuming from the capped cursor (with no cap) eventually reaches done=true.
+ *
+ * Mock strategy: identical to backfill-facet-crawl.test.ts -- module-level mocks
+ * declared before the SUT import, all I/O boundaries stubbed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+
+// ---------------------------------------------------------------------------
+// Module-level mocks -- declared before any import of the SUT
+// ---------------------------------------------------------------------------
+
+vi.mock('../../indexer/_shared/rate-limit.ts', () => ({
+  GITHUB_API_DELAY: 0,
+  delay: vi.fn(async () => undefined),
+  withRateLimitTracking: vi.fn(),
+  withBackoff: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  newRateLimitTelemetry: vi.fn(() => ({})),
+}))
+
+vi.mock('../../indexer/_shared/github-auth.ts', () => ({
+  buildGitHubHeaders: vi.fn(async () => ({})),
+}))
+
+const mockSearchCode = vi.fn()
+vi.mock('../../indexer/code-search.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/code-search.ts')>()
+  return {
+    ...actual,
+    searchCodeForSkillMdInSubdirectory: (...args: unknown[]) => mockSearchCode(...args),
+  }
+})
+
+const mockFetchRepoLicense = vi.fn()
+vi.mock('../../indexer/license-filter.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/license-filter.ts')>()
+  return {
+    ...actual,
+    fetchRepoLicense: (...args: unknown[]) => mockFetchRepoLicense(...args),
+  }
+})
+
+const mockCheckSkillMdExists = vi.fn()
+vi.mock('../../indexer/skill-processor.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/skill-processor.ts')>()
+  return {
+    ...actual,
+    checkSkillMdExists: (...args: unknown[]) => mockCheckSkillMdExists(...args),
+  }
+})
+
+const mockEnumerateRepoSkillPaths = vi.fn()
+vi.mock('../../indexer/trees-enumerate.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/trees-enumerate.ts')>()
+  return {
+    ...actual,
+    enumerateRepoSkillPaths: (...args: unknown[]) => mockEnumerateRepoSkillPaths(...args),
+  }
+})
+
+// SUT imported AFTER mocks.
+import { runSubdirectorySearch, type BackfillFacetPlan } from '../../indexer/subdirectory-search.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noTelemetry: RateLimitTelemetry = {} as RateLimitTelemetry
+const LADDER_SIZE = 9
+
+let repoCounter = 0
+function makeCodeSearchRepo(overrides: Record<string, unknown> = {}) {
+  repoCounter += 1
+  const owner = `cap-owner${repoCounter}`
+  return {
+    owner,
+    name: 'skills-repo',
+    fullName: `${owner}/skills-repo`,
+    description: 'test',
+    url: `https://github.com/${owner}/skills-repo/tree/main/skills/x`,
+    stars: 5,
+    forks: 0,
+    topics: ['claude-code-skill'],
+    updatedAt: new Date().toISOString(),
+    defaultBranch: 'main',
+    installable: false,
+    repoName: 'skills-repo',
+    skillPath: 'skills/x',
+    discoveryPath: 'subdirectory_search:broad',
+    ...overrides,
+  }
+}
+
+function nonSaturatingPage(page: number) {
+  if (page === 1) {
+    return { repos: [makeCodeSearchRepo()], total: 5, retries: 0, incomplete_results: false }
+  }
+  return { repos: [], total: 5, retries: 0, incomplete_results: false }
+}
+
+function makePlan(overrides: Partial<BackfillFacetPlan> = {}): BackfillFacetPlan {
+  return {
+    startCursor: null,
+    pathPrefix: undefined,
+    perPage: 100,
+    maxPagesPerRange: 20,
+    maxRangesPerDispatch: 100,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  repoCounter = 0
+  mockSearchCode.mockReset()
+  mockFetchRepoLicense.mockReset()
+  mockCheckSkillMdExists.mockReset()
+  mockEnumerateRepoSkillPaths.mockReset()
+
+  mockFetchRepoLicense.mockResolvedValue({
+    license: 'MIT',
+    defaultBranch: 'main',
+    fetchFailed: false,
+  })
+  mockCheckSkillMdExists.mockResolvedValue(true)
+  mockEnumerateRepoSkillPaths.mockResolvedValue({
+    entries: [{ path: 'skills/x', blobSha: 'sha1' }],
+    truncatedByCap: false,
+    truncatedByApi: false,
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('runSubdirectorySearch -- maxSkillsPerDispatch skill cap (SMI-5319)', () => {
+  it('stops early at a range boundary and returns done=false with a resumable cursor', async () => {
+    // Each range yields 1 skill. With a cap of 2 the loop stops after 2 ranges.
+    mockSearchCode.mockImplementation(async (_pathPrefix: unknown, page: number) =>
+      nonSaturatingPage(page)
+    )
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100, maxSkillsPerDispatch: 2 })
+    )
+    const backfill = result.backfill!
+    // Crawl stopped early -- fewer than all 9 ranges.
+    expect(backfill.ranges_crawled).toBeLessThan(LADDER_SIZE)
+    // done must be false (more ranges remain after the cap).
+    expect(backfill.done).toBe(false)
+    // Cursor must be resumable (not 'done').
+    expect(backfill.cursor.facet).not.toBe('done')
+    // At least 2 skills admitted (cap was reached or slightly exceeded).
+    expect(result.repos.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('cap=0 is a no-op -- the full 9-facet ladder completes', async () => {
+    mockSearchCode.mockImplementation(async (_pathPrefix: unknown, page: number) =>
+      nonSaturatingPage(page)
+    )
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100, maxSkillsPerDispatch: 0 })
+    )
+    const backfill = result.backfill!
+    expect(backfill.done).toBe(true)
+    expect(backfill.facets_completed).toBe(LADDER_SIZE)
+    expect(backfill.cursor.facet).toBe('done')
+  })
+
+  it('resuming from the capped cursor (without cap) eventually reaches done=true', async () => {
+    mockSearchCode.mockImplementation(async (_pathPrefix: unknown, page: number) =>
+      nonSaturatingPage(page)
+    )
+
+    // Dispatch 1: cap at 2 skills.
+    const first = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100, maxSkillsPerDispatch: 2 })
+    )
+    expect(first.backfill!.done).toBe(false)
+
+    // Drain to completion from the returned cursor with no cap.
+    let cursor = first.backfill!.cursor
+    let done = first.backfill!.done
+    let guard = 0
+    while (!done) {
+      if (guard++ > 20) throw new Error('resume loop did not converge')
+      const next = await runSubdirectorySearch(
+        new Set<string>(),
+        new Map(),
+        {},
+        1,
+        noTelemetry,
+        makePlan({ startCursor: cursor, maxRangesPerDispatch: 100 })
+      )
+      cursor = next.backfill!.cursor
+      done = next.backfill!.done
+    }
+    expect(cursor.facet).toBe('done')
+  })
+})

--- a/scripts/tests/indexer/code-search.facets.test.ts
+++ b/scripts/tests/indexer/code-search.facets.test.ts
@@ -15,6 +15,7 @@ import {
   facetId,
   facetToQualifier,
   bisectFacet,
+  firstFacetIndexForMinSize,
   type SizeFacet,
 } from '../../indexer/code-search.facets.ts'
 
@@ -80,6 +81,39 @@ describe('SMI-5286 Wave 1c: facetId', () => {
 
   it('labels the open-ended bucket as `${lo}+`', () => {
     expect(facetId({ lo: 16384, hi: Number.POSITIVE_INFINITY })).toBe('16384+')
+  })
+})
+
+describe('SMI-5319 W4: firstFacetIndexForMinSize', () => {
+  it('returns 0 for minSizeBytes <= 0 (no skip, all facets)', () => {
+    expect(firstFacetIndexForMinSize(0)).toBe(0)
+    expect(firstFacetIndexForMinSize(-1)).toBe(0)
+    expect(firstFacetIndexForMinSize(-1000)).toBe(0)
+  })
+
+  it('returns 0 for minSizeBytes = 1 (first facet hi=127 >= 1)', () => {
+    expect(firstFacetIndexForMinSize(1)).toBe(0)
+  })
+
+  it('returns 4 for minSizeBytes = 1024 (facet index 4 has lo=1024, hi=2047)', () => {
+    // The 9-bucket ladder: [0-127, 128-255, 256-511, 512-1023, 1024-2047, ...]
+    // facets[4].hi = 2047 >= 1024 and facets[3].hi = 1023 < 1024.
+    expect(firstFacetIndexForMinSize(1024)).toBe(4)
+  })
+
+  it('returns 4 for minSizeBytes = 1500 (facet 4 hi=2047 >= 1500)', () => {
+    expect(firstFacetIndexForMinSize(1500)).toBe(4)
+  })
+
+  it('returns 5 for minSizeBytes = 2048 (facet 5 lo=2048, hi=4095)', () => {
+    expect(firstFacetIndexForMinSize(2048)).toBe(5)
+  })
+
+  it('returns the last index (8) for a huge minSizeBytes (clamps to open-ended tail)', () => {
+    const facets = buildSizeFacets()
+    const lastIndex = facets.length - 1
+    expect(firstFacetIndexForMinSize(999_999_999)).toBe(lastIndex)
+    expect(firstFacetIndexForMinSize(Number.MAX_SAFE_INTEGER)).toBe(lastIndex)
   })
 })
 

--- a/scripts/tests/indexer/parse-env.backfill.test.ts
+++ b/scripts/tests/indexer/parse-env.backfill.test.ts
@@ -220,6 +220,11 @@ describe('parseEnv -- BACKFILL_MAX_SKILLS_PER_DISPATCH', () => {
     expect(parseEnv().BACKFILL_MAX_SKILLS_PER_DISPATCH).toBe(0)
   })
 
+  it('clamps a negative BACKFILL_MAX_SKILLS_PER_DISPATCH to 0 (no cap, not an immediate exit)', () => {
+    process.env.BACKFILL_MAX_SKILLS_PER_DISPATCH = '-1'
+    expect(parseEnv().BACKFILL_MAX_SKILLS_PER_DISPATCH).toBe(0)
+  })
+
   it('BACKFILL_MAX_SKILLS_PER_DISPATCH is present in the returned IndexerEnv shape', () => {
     const env = parseEnv()
     expect('BACKFILL_MAX_SKILLS_PER_DISPATCH' in env).toBe(true)

--- a/scripts/tests/indexer/parse-env.backfill.test.ts
+++ b/scripts/tests/indexer/parse-env.backfill.test.ts
@@ -143,3 +143,44 @@ describe('parseEnv — SMI-5286 1c backfill levers', () => {
     expect(env.MAX_PAGES).toBe(7)
   })
 })
+
+describe('parseEnv -- SMI-5319 W4: BACKFILL_MIN_SIZE_BYTES', () => {
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    originalEnv = { ...process.env }
+    for (const k of Object.keys(process.env)) {
+      delete process.env[k]
+    }
+    Object.assign(process.env, BASE_ENV)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('defaults BACKFILL_MIN_SIZE_BYTES to 0 when the var is absent', () => {
+    delete process.env.BACKFILL_MIN_SIZE_BYTES
+    expect(parseEnv().BACKFILL_MIN_SIZE_BYTES).toBe(0)
+  })
+
+  it('defaults BACKFILL_MIN_SIZE_BYTES to 0 when the var is an empty string', () => {
+    process.env.BACKFILL_MIN_SIZE_BYTES = ''
+    expect(parseEnv().BACKFILL_MIN_SIZE_BYTES).toBe(0)
+  })
+
+  it('parses BACKFILL_MIN_SIZE_BYTES="1024" as 1024', () => {
+    process.env.BACKFILL_MIN_SIZE_BYTES = '1024'
+    expect(parseEnv().BACKFILL_MIN_SIZE_BYTES).toBe(1024)
+  })
+
+  it('parses BACKFILL_MIN_SIZE_BYTES="0" as 0', () => {
+    process.env.BACKFILL_MIN_SIZE_BYTES = '0'
+    expect(parseEnv().BACKFILL_MIN_SIZE_BYTES).toBe(0)
+  })
+
+  it('BACKFILL_MIN_SIZE_BYTES is present in the returned IndexerEnv shape (not undefined)', () => {
+    const env = parseEnv()
+    expect('BACKFILL_MIN_SIZE_BYTES' in env).toBe(true)
+  })
+})

--- a/scripts/tests/indexer/parse-env.backfill.test.ts
+++ b/scripts/tests/indexer/parse-env.backfill.test.ts
@@ -184,3 +184,44 @@ describe('parseEnv -- SMI-5319 W4: BACKFILL_MIN_SIZE_BYTES', () => {
     expect('BACKFILL_MIN_SIZE_BYTES' in env).toBe(true)
   })
 })
+
+describe('parseEnv -- BACKFILL_MAX_SKILLS_PER_DISPATCH', () => {
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    originalEnv = { ...process.env }
+    for (const k of Object.keys(process.env)) {
+      delete process.env[k]
+    }
+    Object.assign(process.env, BASE_ENV)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('defaults BACKFILL_MAX_SKILLS_PER_DISPATCH to 0 when the var is absent', () => {
+    delete process.env.BACKFILL_MAX_SKILLS_PER_DISPATCH
+    expect(parseEnv().BACKFILL_MAX_SKILLS_PER_DISPATCH).toBe(0)
+  })
+
+  it('defaults BACKFILL_MAX_SKILLS_PER_DISPATCH to 0 when the var is an empty string', () => {
+    process.env.BACKFILL_MAX_SKILLS_PER_DISPATCH = ''
+    expect(parseEnv().BACKFILL_MAX_SKILLS_PER_DISPATCH).toBe(0)
+  })
+
+  it('parses BACKFILL_MAX_SKILLS_PER_DISPATCH="500" as 500', () => {
+    process.env.BACKFILL_MAX_SKILLS_PER_DISPATCH = '500'
+    expect(parseEnv().BACKFILL_MAX_SKILLS_PER_DISPATCH).toBe(500)
+  })
+
+  it('parses BACKFILL_MAX_SKILLS_PER_DISPATCH="0" as 0 (no cap)', () => {
+    process.env.BACKFILL_MAX_SKILLS_PER_DISPATCH = '0'
+    expect(parseEnv().BACKFILL_MAX_SKILLS_PER_DISPATCH).toBe(0)
+  })
+
+  it('BACKFILL_MAX_SKILLS_PER_DISPATCH is present in the returned IndexerEnv shape', () => {
+    const env = parseEnv()
+    expect('BACKFILL_MAX_SKILLS_PER_DISPATCH' in env).toBe(true)
+  })
+})

--- a/scripts/tests/indexer/subdirectory-search.license-branch.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.license-branch.test.ts
@@ -1,0 +1,437 @@
+/**
+ * License-as-metadata + Trees default-branch AC tests (SMI-5319)
+ *
+ * Split out of `subdirectory-search.perskill.test.ts` to keep both files under
+ * the 500-line CI gate. Drives `runSubdirectorySearch` to prove the SMI-5319
+ * behavior:
+ *   1. The license ADMISSION gate is gone — ALL licenses
+ *      (null/CC0/MIT/Apache-2.0/GPL-3.0) ADMIT with the surfaced SPDX.
+ *   2. Repo metadata (license + default branch) resolution is once-per-repo
+ *      (N-skill repo → ONE fetchRepoLicense), cached across pages of the same repo.
+ *   3. `repoCacheKey` is the single shared key derivation (equality / round-trip).
+ *   4. The SKILLSMITH_INDEXER_LICENSE_GATE kill-switch restores legacy exclusion.
+ *
+ * SMI-5319 (Trees default-branch fix): the code-search API does NOT return
+ * default_branch, so the real branch is fetched alongside the license (one
+ * `GET /repos` call) BEFORE enumeration. These tests also prove:
+ *   5. A repo with a valid FETCHED branch EMITS skills — enumeration + skillUrl
+ *      use the FETCHED branch, not the null `repo.defaultBranch`.
+ *   6. A repo whose metadata resolves a null default branch is SKIPPED (not
+ *      enumerated with a null branch, not a crash), and retried next run.
+ *
+ * Strategy: mock every I/O boundary (code-search, license-fetch, skill-processor,
+ * trees-enumerate) at the module level; let buildSkillTreeUrl run real (pure).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — declared before any import of the SUT
+// ---------------------------------------------------------------------------
+
+// Mock delay so tests don't actually wait.
+vi.mock('../../indexer/_shared/rate-limit.ts', () => ({
+  GITHUB_API_DELAY: 0,
+  delay: vi.fn(async () => undefined),
+  withRateLimitTracking: vi.fn(),
+  withBackoff: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  newRateLimitTelemetry: vi.fn(() => ({})),
+}))
+
+vi.mock('../../indexer/_shared/github-auth.ts', () => ({
+  buildGitHubHeaders: vi.fn(async () => ({})),
+}))
+
+const mockSearchCode = vi.fn()
+vi.mock('../../indexer/code-search.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/code-search.ts')>()
+  return {
+    ...actual,
+    searchCodeForSkillMdInSubdirectory: (...args: unknown[]) => mockSearchCode(...args),
+  }
+})
+
+const mockFetchRepoLicense = vi.fn()
+vi.mock('../../indexer/license-filter.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/license-filter.ts')>()
+  return {
+    ...actual,
+    fetchRepoLicense: (...args: unknown[]) => mockFetchRepoLicense(...args),
+  }
+})
+
+const mockCheckSkillMdExists = vi.fn()
+vi.mock('../../indexer/skill-processor.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/skill-processor.ts')>()
+  return {
+    ...actual,
+    checkSkillMdExists: (...args: unknown[]) => mockCheckSkillMdExists(...args),
+  }
+})
+
+const mockEnumerateRepoSkillPaths = vi.fn()
+vi.mock('../../indexer/trees-enumerate.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/trees-enumerate.ts')>()
+  return {
+    ...actual,
+    enumerateRepoSkillPaths: (...args: unknown[]) => mockEnumerateRepoSkillPaths(...args),
+  }
+})
+
+// Imported AFTER mocks so the SUT binds the stubs.
+import { runSubdirectorySearch } from '../../indexer/subdirectory-search.ts'
+// repoCacheKey is a pure helper (no I/O) — imported real for the key-shape test.
+import { repoCacheKey } from '../../indexer/subdirectory-search.helpers.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noTelemetry: RateLimitTelemetry = {} as RateLimitTelemetry
+
+/**
+ * Build a minimal GitHubRepository-shaped code-search result for a single repo.
+ * The `url` here is the BARE repo html_url (code-search mapper may transform it;
+ * subdirectory-search calls buildSkillTreeUrl internally using this as root).
+ */
+function makeCodeSearchRepo(overrides: Record<string, unknown> = {}) {
+  return {
+    owner: 'acme',
+    name: 'skills-repo',
+    fullName: 'acme/skills-repo',
+    description: 'test',
+    // Reflects production: searchCodeForSkillMdInSubdirectory already emits a
+    // per-skill tree URL here, so the consumer must rebuild from the bare
+    // html_url (owner/repoName), not re-wrap this value (governance #1).
+    url: 'https://github.com/acme/skills-repo/tree/main/.agents/skills/a',
+    stars: 5,
+    forks: 0,
+    topics: ['claude-code-skill'],
+    updatedAt: new Date().toISOString(),
+    defaultBranch: 'main',
+    installable: false,
+    repoName: 'skills-repo',
+    skillPath: '.agents/skills/a',
+    discoveryPath: 'subdirectory_search:broad',
+    ...overrides,
+  }
+}
+
+/** Make a one-page code-search result that returns without errors. */
+function makeSearchResult(repos: ReturnType<typeof makeCodeSearchRepo>[]) {
+  return {
+    repos,
+    total: repos.length,
+    retries: 0,
+    incomplete_results: false,
+  }
+}
+
+beforeEach(() => {
+  mockSearchCode.mockReset()
+  mockFetchRepoLicense.mockReset()
+  mockCheckSkillMdExists.mockReset()
+  mockEnumerateRepoSkillPaths.mockReset()
+
+  // Default: permissive license + resolvable default branch, validation passes.
+  // SMI-5319: fetchRepoLicense now returns `defaultBranch` alongside the license
+  // (the code-search API omits `default_branch`) — a repo whose `defaultBranch`
+  // is null is SKIPPED (not enumerated with a null branch), so the default mock
+  // must carry a real branch for repos to emit.
+  mockFetchRepoLicense.mockResolvedValue({
+    license: 'MIT',
+    defaultBranch: 'main',
+    fetchFailed: false,
+  })
+  mockCheckSkillMdExists.mockResolvedValue(true)
+})
+
+// ---------------------------------------------------------------------------
+
+describe('runSubdirectorySearch — license-as-metadata + Trees default branch (SMI-5319)', () => {
+  // SMI-5319 (Trees default-branch fix): a failed metadata fetch yields a null
+  // default branch, so the repo CANNOT be enumerated (`GET /git/trees/null` would
+  // 404). It is SKIPPED (not emitted with a null branch) and retried next run —
+  // it is NOT a license-admission filter (`licenseFiltered` stays 0).
+  it('skips a repo whose metadata fetch failed (null default branch) — not a crash, not emitted', async () => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    // A real-looking tree exists, but the metadata fetch failing means we never
+    // reach enumeration (branch resolves to null first).
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+    mockFetchRepoLicense.mockResolvedValue({
+      license: null,
+      defaultBranch: null,
+      fetchFailed: true,
+    })
+
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+    // Skipped: no row emitted, no crash.
+    expect(result.repos).toHaveLength(0)
+    // A null branch with no skill is never an admission filter.
+    expect(result.licenseFiltered).toBe(0)
+    expect(result.licenseFetchFailed).toBe(1)
+    expect(result.noDefaultBranch).toBe(1)
+    // Enumeration is NOT reached without a resolvable branch.
+    expect(mockEnumerateRepoSkillPaths).not.toHaveBeenCalled()
+  })
+
+  // SMI-5319 (Trees default-branch fix): a SUCCESSFUL metadata fetch that returns
+  // a genuinely-absent default branch (e.g. a permissions-stripped response) also
+  // skips the repo — null branch is unenumerable regardless of why.
+  it('skips a repo whose metadata fetch succeeded but returned a null default branch', async () => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+    // Fetch succeeded (not a failure) but no branch in the response.
+    mockFetchRepoLicense.mockResolvedValue({
+      license: 'MIT',
+      defaultBranch: null,
+      fetchFailed: false,
+    })
+
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+    expect(result.repos).toHaveLength(0)
+    expect(result.noDefaultBranch).toBe(1)
+    // Not a fetch failure → licenseFetchFailed stays 0.
+    expect(result.licenseFetchFailed).toBe(0)
+    expect(mockEnumerateRepoSkillPaths).not.toHaveBeenCalled()
+  })
+
+  // SMI-5319 (Trees default-branch fix): the HEADLINE case. A repo with a valid
+  // FETCHED default branch + tree entries now EMITS skills — enumeration is called
+  // with the FETCHED branch (NOT `repo.defaultBranch`), and the emitted skillUrl
+  // uses the fetched branch. This is the behavior the bug masked (every repo 404'd
+  // on `GET /git/trees/null` because `repo.defaultBranch` was null from code search).
+  it('emits skills using the FETCHED default branch, not repo.defaultBranch', async () => {
+    // The code-search hit carries a null defaultBranch (matches production: the
+    // /search/code API does not return default_branch).
+    mockSearchCode.mockResolvedValueOnce(
+      makeSearchResult([makeCodeSearchRepo({ defaultBranch: null })])
+    )
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+    // The metadata call resolves the REAL branch ('trunk', deliberately not 'main'
+    // so the assertion can't accidentally pass off repo.defaultBranch).
+    mockFetchRepoLicense.mockResolvedValue({
+      license: 'MIT',
+      defaultBranch: 'trunk',
+      fetchFailed: false,
+    })
+
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0].installable).toBe(true)
+    expect(result.noDefaultBranch).toBe(0)
+
+    // enumerateRepoSkillPaths was called with the FETCHED branch ('trunk'), the
+    // 3rd positional arg — NOT the null repo.defaultBranch.
+    expect(mockEnumerateRepoSkillPaths).toHaveBeenCalledTimes(1)
+    const enumerateBranchArg = mockEnumerateRepoSkillPaths.mock.calls[0][2]
+    expect(enumerateBranchArg).toBe('trunk')
+
+    // The emitted skillUrl uses the fetched branch ('trunk'), never 'null'.
+    expect(result.repos[0].url).toBe(
+      'https://github.com/acme/skills-repo/tree/trunk/.agents/skills/a'
+    )
+    expect(result.repos[0].url).not.toContain('/tree/null/')
+
+    // checkSkillMdExists was also called with the fetched branch (3rd positional arg).
+    const checkBranchArg = mockCheckSkillMdExists.mock.calls[0][2]
+    expect(checkBranchArg).toBe('trunk')
+  })
+
+  // SMI-5319: INVERTED. A non-permissive license is no longer an admission filter
+  // — the skill ADMITS and the SPDX is surfaced; licenseFiltered stays 0.
+  it('admits a repo with a non-permissive license and surfaces its SPDX', async () => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+    mockFetchRepoLicense.mockResolvedValue({
+      license: 'GPL-3.0',
+      defaultBranch: 'main',
+      fetchFailed: false,
+    })
+
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0].license).toBe('GPL-3.0')
+    expect(result.licenseFiltered).toBe(0)
+    expect(mockEnumerateRepoSkillPaths).toHaveBeenCalledTimes(1)
+  })
+
+  // SMI-5319: every license value ADMITS with the correct surfaced SPDX.
+  it.each([
+    ['null (no detected license)', null],
+    ['CC0-1.0 (public-domain dedication)', 'CC0-1.0'],
+    ['MIT (permissive)', 'MIT'],
+    ['Apache-2.0 (permissive)', 'Apache-2.0'],
+    ['GPL-3.0 (copyleft)', 'GPL-3.0'],
+  ])('admits and surfaces license for %s', async (_label, spdx) => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+    mockFetchRepoLicense.mockResolvedValue({
+      license: spdx,
+      defaultBranch: 'main',
+      fetchFailed: false,
+    })
+
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0].license).toBe(spdx)
+    expect(result.licenseFiltered).toBe(0)
+  })
+
+  // SMI-5319: license resolution is ONCE-per-repo (after the validity gate).
+  it('fetches the license exactly ONCE for an N-skill repo', async () => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    // One repo, three valid SKILL.md paths.
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [
+        { path: '.agents/skills/a', blobSha: 'sha-a' },
+        { path: '.agents/skills/b', blobSha: 'sha-b' },
+        { path: '.agents/skills/c', blobSha: 'sha-c' },
+      ],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+    mockFetchRepoLicense.mockResolvedValue({
+      license: 'MIT',
+      defaultBranch: 'main',
+      fetchFailed: false,
+    })
+
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+    // Three emitted skills, all sharing the one resolved license.
+    expect(result.repos).toHaveLength(3)
+    for (const r of result.repos) expect(r.license).toBe('MIT')
+    // Exactly ONE license fetch for the whole repo.
+    expect(mockFetchRepoLicense).toHaveBeenCalledTimes(1)
+  })
+
+  // SMI-5319: the repoMetaCache is reused across two code-search pages of the same
+  // repo — still exactly ONE fetch total (write-key === read-key via repoCacheKey).
+  it('reuses the cached license across two pages of the same repo (one fetch total)', async () => {
+    const repo = makeCodeSearchRepo()
+
+    mockSearchCode
+      .mockResolvedValueOnce({ ...makeSearchResult([repo]), repos: [repo] })
+      .mockResolvedValueOnce({ ...makeSearchResult([repo]), repos: [repo] })
+      .mockResolvedValue(makeSearchResult([]))
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+    mockFetchRepoLicense.mockResolvedValue({
+      license: 'Apache-2.0',
+      defaultBranch: 'main',
+      fetchFailed: false,
+    })
+
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 3, noTelemetry)
+
+    // The repo is enumerated once (once-guard) and the license fetched once.
+    expect(mockEnumerateRepoSkillPaths).toHaveBeenCalledTimes(1)
+    expect(mockFetchRepoLicense).toHaveBeenCalledTimes(1)
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0].license).toBe('Apache-2.0')
+  })
+
+  // SMI-5319 (Pattern-3 invariant): repoCacheKey is the single key derivation, so
+  // the once-guard write-key and the repoMetaCache read-key are provably identical.
+  it('repoCacheKey is a stable, deterministic owner/repo derivation', () => {
+    expect(repoCacheKey('acme', 'skills-repo')).toBe('acme/skills-repo')
+    // Deterministic / idempotent.
+    expect(repoCacheKey('acme', 'skills-repo')).toBe(repoCacheKey('acme', 'skills-repo'))
+    // Distinct owners or repos do not collide.
+    expect(repoCacheKey('acme', 'a')).not.toBe(repoCacheKey('acme', 'b'))
+    expect(repoCacheKey('a', 'repo')).not.toBe(repoCacheKey('b', 'repo'))
+  })
+
+  // SMI-5319 kill-switch: SKILLSMITH_INDEXER_LICENSE_GATE=true restores the legacy
+  // pre-validity exclusion (drop non-permissive, count as license-filtered).
+  describe('SKILLSMITH_INDEXER_LICENSE_GATE kill-switch (legacy behavior)', () => {
+    afterEach(() => {
+      delete process.env.SKILLSMITH_INDEXER_LICENSE_GATE
+    })
+
+    it('restores legacy exclusion of non-permissive licenses when =true', async () => {
+      process.env.SKILLSMITH_INDEXER_LICENSE_GATE = 'true'
+
+      mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+      mockSearchCode.mockResolvedValue(makeSearchResult([]))
+      mockFetchRepoLicense.mockResolvedValue({
+        license: 'GPL-3.0',
+        defaultBranch: 'main',
+        fetchFailed: false,
+      })
+
+      const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+      // Legacy: dropped before the validity gate, counted as license-filtered.
+      expect(result.repos).toHaveLength(0)
+      expect(result.licenseFiltered).toBe(1)
+      expect(mockEnumerateRepoSkillPaths).not.toHaveBeenCalled()
+    })
+
+    it('admits permissive licenses under the legacy gate', async () => {
+      process.env.SKILLSMITH_INDEXER_LICENSE_GATE = 'true'
+
+      mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+      mockSearchCode.mockResolvedValue(makeSearchResult([]))
+      mockEnumerateRepoSkillPaths.mockResolvedValue({
+        entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+        truncatedByCap: false,
+        truncatedByApi: false,
+      })
+      mockFetchRepoLicense.mockResolvedValue({
+        license: 'MIT',
+        defaultBranch: 'main',
+        fetchFailed: false,
+      })
+
+      const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+      expect(result.repos).toHaveLength(1)
+      expect(result.repos[0].license).toBe('MIT')
+      expect(result.licenseFiltered).toBe(0)
+    })
+  })
+})

--- a/scripts/tests/indexer/subdirectory-search.perskill.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.perskill.test.ts
@@ -8,11 +8,19 @@
  *   4. A repo surfaced twice across code-search pages is enumerated only once
  *      (no duplicate rows from re-enumeration).
  *
+ * SMI-5319: the license ADMISSION gate has been removed. These tests also prove:
+ *   5. ALL licenses (null/CC0/MIT/Apache-2.0/GPL-3.0) ADMIT with the surfaced SPDX.
+ *   6. A failed license fetch ADMITS the skill with `license: null` (never drops).
+ *   7. License resolution is once-per-repo (N-skill repo → ONE fetchRepoLicense),
+ *      cached across pages of the same repo.
+ *   8. `repoCacheKey` is the single shared key derivation (equality / round-trip).
+ *   9. The SKILLSMITH_INDEXER_LICENSE_GATE kill-switch restores legacy exclusion.
+ *
  * Strategy: mock every I/O boundary (code-search, license-fetch, skill-processor,
  * trees-enumerate) at the module level; let buildSkillTreeUrl run real (pure).
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
 
 // ---------------------------------------------------------------------------
@@ -70,6 +78,8 @@ vi.mock('../../indexer/trees-enumerate.ts', async (importOriginal) => {
 
 // Imported AFTER mocks so the SUT binds the stubs.
 import { runSubdirectorySearch } from '../../indexer/subdirectory-search.ts'
+// repoCacheKey is a pure helper (no I/O) — imported real for the key-shape test.
+import { repoCacheKey } from '../../indexer/subdirectory-search.helpers.ts'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -302,31 +312,178 @@ describe('runSubdirectorySearch — per-skill extraction (SMI-5286 Wave 1a §#1)
     expect(result.repos[0].installable).toBe(false)
   })
 
-  it('skips a repo whose license fetch failed (not counted as license-filtered)', async () => {
+  // SMI-5319: INVERTED. A failed license fetch no longer drops the skill — it
+  // ADMITS with `license: null`, and the (post-validity) enumeration IS called.
+  it('admits a repo whose license fetch failed, surfacing license: null', async () => {
     mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
     mockSearchCode.mockResolvedValue(makeSearchResult([]))
 
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
     mockFetchRepoLicense.mockResolvedValue({ license: null, fetchFailed: true })
 
     const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
 
-    expect(result.repos).toHaveLength(0)
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0].license).toBeNull()
+    // Not an admission filter → never counted as license-filtered.
     expect(result.licenseFiltered).toBe(0)
     expect(result.licenseFetchFailed).toBe(1)
-    // Trees enumeration must NOT have been called for this repo
-    expect(mockEnumerateRepoSkillPaths).not.toHaveBeenCalled()
+    // Enumeration (the strict validity gate) IS exercised now.
+    expect(mockEnumerateRepoSkillPaths).toHaveBeenCalledTimes(1)
   })
 
-  it('excludes repos with a non-permissive license and increments licenseFiltered', async () => {
+  // SMI-5319: INVERTED. A non-permissive license is no longer an admission filter
+  // — the skill ADMITS and the SPDX is surfaced; licenseFiltered stays 0.
+  it('admits a repo with a non-permissive license and surfaces its SPDX', async () => {
     mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
     mockSearchCode.mockResolvedValue(makeSearchResult([]))
 
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
     mockFetchRepoLicense.mockResolvedValue({ license: 'GPL-3.0', fetchFailed: false })
 
     const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
 
-    expect(result.repos).toHaveLength(0)
-    expect(result.licenseFiltered).toBe(1)
-    expect(mockEnumerateRepoSkillPaths).not.toHaveBeenCalled()
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0].license).toBe('GPL-3.0')
+    expect(result.licenseFiltered).toBe(0)
+    expect(mockEnumerateRepoSkillPaths).toHaveBeenCalledTimes(1)
+  })
+
+  // SMI-5319: every license value ADMITS with the correct surfaced SPDX.
+  it.each([
+    ['null (no detected license)', null],
+    ['CC0-1.0 (public-domain dedication)', 'CC0-1.0'],
+    ['MIT (permissive)', 'MIT'],
+    ['Apache-2.0 (permissive)', 'Apache-2.0'],
+    ['GPL-3.0 (copyleft)', 'GPL-3.0'],
+  ])('admits and surfaces license for %s', async (_label, spdx) => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+    mockFetchRepoLicense.mockResolvedValue({ license: spdx, fetchFailed: false })
+
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0].license).toBe(spdx)
+    expect(result.licenseFiltered).toBe(0)
+  })
+
+  // SMI-5319: license resolution is ONCE-per-repo (after the validity gate).
+  it('fetches the license exactly ONCE for an N-skill repo', async () => {
+    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+    mockSearchCode.mockResolvedValue(makeSearchResult([]))
+
+    // One repo, three valid SKILL.md paths.
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [
+        { path: '.agents/skills/a', blobSha: 'sha-a' },
+        { path: '.agents/skills/b', blobSha: 'sha-b' },
+        { path: '.agents/skills/c', blobSha: 'sha-c' },
+      ],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+    mockFetchRepoLicense.mockResolvedValue({ license: 'MIT', fetchFailed: false })
+
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+    // Three emitted skills, all sharing the one resolved license.
+    expect(result.repos).toHaveLength(3)
+    for (const r of result.repos) expect(r.license).toBe('MIT')
+    // Exactly ONE license fetch for the whole repo.
+    expect(mockFetchRepoLicense).toHaveBeenCalledTimes(1)
+  })
+
+  // SMI-5319: the licenseCache is reused across two code-search pages of the same
+  // repo — still exactly ONE fetch total (write-key === read-key via repoCacheKey).
+  it('reuses the cached license across two pages of the same repo (one fetch total)', async () => {
+    const repo = makeCodeSearchRepo()
+
+    mockSearchCode
+      .mockResolvedValueOnce({ ...makeSearchResult([repo]), repos: [repo] })
+      .mockResolvedValueOnce({ ...makeSearchResult([repo]), repos: [repo] })
+      .mockResolvedValue(makeSearchResult([]))
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+    mockFetchRepoLicense.mockResolvedValue({ license: 'Apache-2.0', fetchFailed: false })
+
+    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 3, noTelemetry)
+
+    // The repo is enumerated once (once-guard) and the license fetched once.
+    expect(mockEnumerateRepoSkillPaths).toHaveBeenCalledTimes(1)
+    expect(mockFetchRepoLicense).toHaveBeenCalledTimes(1)
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0].license).toBe('Apache-2.0')
+  })
+
+  // SMI-5319 (Pattern-3 invariant): repoCacheKey is the single key derivation, so
+  // the once-guard write-key and the licenseCache read-key are provably identical.
+  it('repoCacheKey is a stable, deterministic owner/repo derivation', () => {
+    expect(repoCacheKey('acme', 'skills-repo')).toBe('acme/skills-repo')
+    // Deterministic / idempotent.
+    expect(repoCacheKey('acme', 'skills-repo')).toBe(repoCacheKey('acme', 'skills-repo'))
+    // Distinct owners or repos do not collide.
+    expect(repoCacheKey('acme', 'a')).not.toBe(repoCacheKey('acme', 'b'))
+    expect(repoCacheKey('a', 'repo')).not.toBe(repoCacheKey('b', 'repo'))
+  })
+
+  // SMI-5319 kill-switch: SKILLSMITH_INDEXER_LICENSE_GATE=true restores the legacy
+  // pre-validity exclusion (drop non-permissive, count as license-filtered).
+  describe('SKILLSMITH_INDEXER_LICENSE_GATE kill-switch (legacy behavior)', () => {
+    afterEach(() => {
+      delete process.env.SKILLSMITH_INDEXER_LICENSE_GATE
+    })
+
+    it('restores legacy exclusion of non-permissive licenses when =true', async () => {
+      process.env.SKILLSMITH_INDEXER_LICENSE_GATE = 'true'
+
+      mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+      mockSearchCode.mockResolvedValue(makeSearchResult([]))
+      mockFetchRepoLicense.mockResolvedValue({ license: 'GPL-3.0', fetchFailed: false })
+
+      const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+      // Legacy: dropped before the validity gate, counted as license-filtered.
+      expect(result.repos).toHaveLength(0)
+      expect(result.licenseFiltered).toBe(1)
+      expect(mockEnumerateRepoSkillPaths).not.toHaveBeenCalled()
+    })
+
+    it('admits permissive licenses under the legacy gate', async () => {
+      process.env.SKILLSMITH_INDEXER_LICENSE_GATE = 'true'
+
+      mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
+      mockSearchCode.mockResolvedValue(makeSearchResult([]))
+      mockEnumerateRepoSkillPaths.mockResolvedValue({
+        entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
+        truncatedByCap: false,
+        truncatedByApi: false,
+      })
+      mockFetchRepoLicense.mockResolvedValue({ license: 'MIT', fetchFailed: false })
+
+      const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
+
+      expect(result.repos).toHaveLength(1)
+      expect(result.repos[0].license).toBe('MIT')
+      expect(result.licenseFiltered).toBe(0)
+    })
   })
 })

--- a/scripts/tests/indexer/subdirectory-search.perskill.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.perskill.test.ts
@@ -8,19 +8,17 @@
  *   4. A repo surfaced twice across code-search pages is enumerated only once
  *      (no duplicate rows from re-enumeration).
  *
- * SMI-5319: the license ADMISSION gate has been removed. These tests also prove:
- *   5. ALL licenses (null/CC0/MIT/Apache-2.0/GPL-3.0) ADMIT with the surfaced SPDX.
- *   6. A failed license fetch ADMITS the skill with `license: null` (never drops).
- *   7. License resolution is once-per-repo (N-skill repo → ONE fetchRepoLicense),
- *      cached across pages of the same repo.
- *   8. `repoCacheKey` is the single shared key derivation (equality / round-trip).
- *   9. The SKILLSMITH_INDEXER_LICENSE_GATE kill-switch restores legacy exclusion.
+ * SMI-5319: the default mock now returns `defaultBranch` alongside the license
+ * (the code-search API omits it) so repos emit. The license-as-metadata + Trees
+ * default-branch assertions live in the sibling
+ * `subdirectory-search.license-branch.test.ts` (split out to keep both files
+ * under the 500-line CI gate).
  *
  * Strategy: mock every I/O boundary (code-search, license-fetch, skill-processor,
  * trees-enumerate) at the module level; let buildSkillTreeUrl run real (pure).
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
 
 // ---------------------------------------------------------------------------
@@ -78,8 +76,6 @@ vi.mock('../../indexer/trees-enumerate.ts', async (importOriginal) => {
 
 // Imported AFTER mocks so the SUT binds the stubs.
 import { runSubdirectorySearch } from '../../indexer/subdirectory-search.ts'
-// repoCacheKey is a pure helper (no I/O) — imported real for the key-shape test.
-import { repoCacheKey } from '../../indexer/subdirectory-search.helpers.ts'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -131,8 +127,16 @@ beforeEach(() => {
   mockCheckSkillMdExists.mockReset()
   mockEnumerateRepoSkillPaths.mockReset()
 
-  // Default: permissive license, validation always passes
-  mockFetchRepoLicense.mockResolvedValue({ license: 'MIT', fetchFailed: false })
+  // Default: permissive license + resolvable default branch, validation passes.
+  // SMI-5319: fetchRepoLicense now returns `defaultBranch` alongside the license
+  // (the code-search API omits `default_branch`) — a repo whose `defaultBranch`
+  // is null is SKIPPED (not enumerated with a null branch), so the default mock
+  // must carry a real branch for repos to emit.
+  mockFetchRepoLicense.mockResolvedValue({
+    license: 'MIT',
+    defaultBranch: 'main',
+    fetchFailed: false,
+  })
   mockCheckSkillMdExists.mockResolvedValue(true)
 })
 
@@ -310,180 +314,5 @@ describe('runSubdirectorySearch — per-skill extraction (SMI-5286 Wave 1a §#1)
 
     expect(result.repos).toHaveLength(1)
     expect(result.repos[0].installable).toBe(false)
-  })
-
-  // SMI-5319: INVERTED. A failed license fetch no longer drops the skill — it
-  // ADMITS with `license: null`, and the (post-validity) enumeration IS called.
-  it('admits a repo whose license fetch failed, surfacing license: null', async () => {
-    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
-    mockSearchCode.mockResolvedValue(makeSearchResult([]))
-
-    mockEnumerateRepoSkillPaths.mockResolvedValue({
-      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
-      truncatedByCap: false,
-      truncatedByApi: false,
-    })
-    mockFetchRepoLicense.mockResolvedValue({ license: null, fetchFailed: true })
-
-    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
-
-    expect(result.repos).toHaveLength(1)
-    expect(result.repos[0].license).toBeNull()
-    // Not an admission filter → never counted as license-filtered.
-    expect(result.licenseFiltered).toBe(0)
-    expect(result.licenseFetchFailed).toBe(1)
-    // Enumeration (the strict validity gate) IS exercised now.
-    expect(mockEnumerateRepoSkillPaths).toHaveBeenCalledTimes(1)
-  })
-
-  // SMI-5319: INVERTED. A non-permissive license is no longer an admission filter
-  // — the skill ADMITS and the SPDX is surfaced; licenseFiltered stays 0.
-  it('admits a repo with a non-permissive license and surfaces its SPDX', async () => {
-    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
-    mockSearchCode.mockResolvedValue(makeSearchResult([]))
-
-    mockEnumerateRepoSkillPaths.mockResolvedValue({
-      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
-      truncatedByCap: false,
-      truncatedByApi: false,
-    })
-    mockFetchRepoLicense.mockResolvedValue({ license: 'GPL-3.0', fetchFailed: false })
-
-    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
-
-    expect(result.repos).toHaveLength(1)
-    expect(result.repos[0].license).toBe('GPL-3.0')
-    expect(result.licenseFiltered).toBe(0)
-    expect(mockEnumerateRepoSkillPaths).toHaveBeenCalledTimes(1)
-  })
-
-  // SMI-5319: every license value ADMITS with the correct surfaced SPDX.
-  it.each([
-    ['null (no detected license)', null],
-    ['CC0-1.0 (public-domain dedication)', 'CC0-1.0'],
-    ['MIT (permissive)', 'MIT'],
-    ['Apache-2.0 (permissive)', 'Apache-2.0'],
-    ['GPL-3.0 (copyleft)', 'GPL-3.0'],
-  ])('admits and surfaces license for %s', async (_label, spdx) => {
-    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
-    mockSearchCode.mockResolvedValue(makeSearchResult([]))
-
-    mockEnumerateRepoSkillPaths.mockResolvedValue({
-      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
-      truncatedByCap: false,
-      truncatedByApi: false,
-    })
-    mockFetchRepoLicense.mockResolvedValue({ license: spdx, fetchFailed: false })
-
-    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
-
-    expect(result.repos).toHaveLength(1)
-    expect(result.repos[0].license).toBe(spdx)
-    expect(result.licenseFiltered).toBe(0)
-  })
-
-  // SMI-5319: license resolution is ONCE-per-repo (after the validity gate).
-  it('fetches the license exactly ONCE for an N-skill repo', async () => {
-    mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
-    mockSearchCode.mockResolvedValue(makeSearchResult([]))
-
-    // One repo, three valid SKILL.md paths.
-    mockEnumerateRepoSkillPaths.mockResolvedValue({
-      entries: [
-        { path: '.agents/skills/a', blobSha: 'sha-a' },
-        { path: '.agents/skills/b', blobSha: 'sha-b' },
-        { path: '.agents/skills/c', blobSha: 'sha-c' },
-      ],
-      truncatedByCap: false,
-      truncatedByApi: false,
-    })
-    mockFetchRepoLicense.mockResolvedValue({ license: 'MIT', fetchFailed: false })
-
-    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
-
-    // Three emitted skills, all sharing the one resolved license.
-    expect(result.repos).toHaveLength(3)
-    for (const r of result.repos) expect(r.license).toBe('MIT')
-    // Exactly ONE license fetch for the whole repo.
-    expect(mockFetchRepoLicense).toHaveBeenCalledTimes(1)
-  })
-
-  // SMI-5319: the licenseCache is reused across two code-search pages of the same
-  // repo — still exactly ONE fetch total (write-key === read-key via repoCacheKey).
-  it('reuses the cached license across two pages of the same repo (one fetch total)', async () => {
-    const repo = makeCodeSearchRepo()
-
-    mockSearchCode
-      .mockResolvedValueOnce({ ...makeSearchResult([repo]), repos: [repo] })
-      .mockResolvedValueOnce({ ...makeSearchResult([repo]), repos: [repo] })
-      .mockResolvedValue(makeSearchResult([]))
-
-    mockEnumerateRepoSkillPaths.mockResolvedValue({
-      entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
-      truncatedByCap: false,
-      truncatedByApi: false,
-    })
-    mockFetchRepoLicense.mockResolvedValue({ license: 'Apache-2.0', fetchFailed: false })
-
-    const result = await runSubdirectorySearch(new Set(), new Map(), {}, 3, noTelemetry)
-
-    // The repo is enumerated once (once-guard) and the license fetched once.
-    expect(mockEnumerateRepoSkillPaths).toHaveBeenCalledTimes(1)
-    expect(mockFetchRepoLicense).toHaveBeenCalledTimes(1)
-    expect(result.repos).toHaveLength(1)
-    expect(result.repos[0].license).toBe('Apache-2.0')
-  })
-
-  // SMI-5319 (Pattern-3 invariant): repoCacheKey is the single key derivation, so
-  // the once-guard write-key and the licenseCache read-key are provably identical.
-  it('repoCacheKey is a stable, deterministic owner/repo derivation', () => {
-    expect(repoCacheKey('acme', 'skills-repo')).toBe('acme/skills-repo')
-    // Deterministic / idempotent.
-    expect(repoCacheKey('acme', 'skills-repo')).toBe(repoCacheKey('acme', 'skills-repo'))
-    // Distinct owners or repos do not collide.
-    expect(repoCacheKey('acme', 'a')).not.toBe(repoCacheKey('acme', 'b'))
-    expect(repoCacheKey('a', 'repo')).not.toBe(repoCacheKey('b', 'repo'))
-  })
-
-  // SMI-5319 kill-switch: SKILLSMITH_INDEXER_LICENSE_GATE=true restores the legacy
-  // pre-validity exclusion (drop non-permissive, count as license-filtered).
-  describe('SKILLSMITH_INDEXER_LICENSE_GATE kill-switch (legacy behavior)', () => {
-    afterEach(() => {
-      delete process.env.SKILLSMITH_INDEXER_LICENSE_GATE
-    })
-
-    it('restores legacy exclusion of non-permissive licenses when =true', async () => {
-      process.env.SKILLSMITH_INDEXER_LICENSE_GATE = 'true'
-
-      mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
-      mockSearchCode.mockResolvedValue(makeSearchResult([]))
-      mockFetchRepoLicense.mockResolvedValue({ license: 'GPL-3.0', fetchFailed: false })
-
-      const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
-
-      // Legacy: dropped before the validity gate, counted as license-filtered.
-      expect(result.repos).toHaveLength(0)
-      expect(result.licenseFiltered).toBe(1)
-      expect(mockEnumerateRepoSkillPaths).not.toHaveBeenCalled()
-    })
-
-    it('admits permissive licenses under the legacy gate', async () => {
-      process.env.SKILLSMITH_INDEXER_LICENSE_GATE = 'true'
-
-      mockSearchCode.mockResolvedValueOnce(makeSearchResult([makeCodeSearchRepo()]))
-      mockSearchCode.mockResolvedValue(makeSearchResult([]))
-      mockEnumerateRepoSkillPaths.mockResolvedValue({
-        entries: [{ path: '.agents/skills/a', blobSha: 'sha-a' }],
-        truncatedByCap: false,
-        truncatedByApi: false,
-      })
-      mockFetchRepoLicense.mockResolvedValue({ license: 'MIT', fetchFailed: false })
-
-      const result = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry)
-
-      expect(result.repos).toHaveLength(1)
-      expect(result.repos[0].license).toBe('MIT')
-      expect(result.licenseFiltered).toBe(0)
-    })
   })
 })


### PR DESCRIPTION
## Problem (SMI-5319)
The 1c backfill (`indexer-backfill.yml`) indexed **0 skills** — every dispatch was consumed without producing a single skill. Investigation found **three layered root causes**, each masking the next (the subdirectory/backfill code-search path had never run end-to-end in prod — it was always gated to 0):

1. **License admission gate** — `processSearchResults` hard-dropped any repo without a permissive license. The broad long tail is ~94% null-license, so 5,091 found → 0 admitted. Contradicts the ratified SMI-5178 "index broad, surface narrow" decision.
2. **Size-faceting wasted the dispatch budget** on the 0–1023-byte noise band (GitHub-tokenized matches + tiny stubs that the validity gate correctly rejects) before reaching real skills (≥1024 bytes).
3. **Trees API 404 for every repo** — GitHub's `/search/code` API does not return `default_branch`, so `repo.defaultBranch` was null and `GET /git/trees/null` 404'd for every repo → 0 enumerated.

## Fix
| Wave | Change |
|---|---|
| **W1** | Remove the license admission gate; index all valid skills; record license as surfaced metadata (consumer decides); license resolved once-per-repo, cached, never drops on fetch failure; `SKILLSMITH_INDEXER_LICENSE_GATE` kill-switch (default off). |
| **W3** | Checkpoint `dry_run` tagging + NULL-safe `.or()` filter so a LIVE `resume_from=latest` never resumes from a dry-run cursor (and legacy untagged rows survive). |
| **W4** | `BACKFILL_MIN_SIZE_BYTES` — start a fresh crawl above the noise band (resumes unaffected; ladder unchanged). |
| **W5** | Fetch the real `default_branch` (+ license) via `GET /repos` once-per-repo **before** enumeration; use the real branch for the Trees call AND the emitted skill URL; skip repos with no resolvable branch (`no_default_branch` counter). |
| **cap** | `BACKFILL_MAX_SKILLS_PER_DISPATCH` — per-dispatch skill cap (range-granular) for controlled writes + safe operator-loop rollout. |

Also threads `admitted`/`license_null`/`no_default_branch` into `IndexerResult.subdirectory_search` for `audit_logs` observability.

## Proof (prod)
- **DRY_RUN** (`.claude/skills`, `min_size_bytes=1024`): **36,641 admitted**, `license_filtered=0`, `no_default_branch=0`, core bucket healthy (was: 5091 filtered, core drained to 0, 1438 secondary-rate-limit hits).
- **LIVE** (capped): **8,928 skills written**, registry **8,056 → 16,984**; 0 `/tree/null/` URLs; every row has a real branch + `skill_path`; licenses recorded; lock released cleanly; `token_source=pat`.

## Gates
Every commit passed full `tsc --build` + ESLint(0) + prettier. Per-commit concurrency-auditor (clean — `repoMetaCache`/`licenseCache` write-key===read-key invariant pinned + tested) + governance (caught + fixed a Critical W3 NULL-safety bug and two footguns). Indexer test suite (500+ tests) passes.

## Scope / notes
- Engine is `scripts/indexer/*` (authoritative; Node GHA runner). The Deno mirror `supabase/functions/indexer/*` still has the Trees-branch bug but is parity-exempt + Phase-3b-disabled in the cron — tracked on **SMI-5182** (decommission), not patched here.
- Touches `.github/workflows/indexer-backfill.yml` (additive inputs only; within the plan-reviewed SMI-5319 effort, ADR-109 satisfied).
- Follow-ups: SMI-5320 (surface license on the skills-search read path), the full-volume rollout (held for planned staging — ~250K skill universe).

Plan: `docs/internal/implementation/smi-5319-backfill-license-gate-removal.md`.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)