### PR TITLE
test+ci(indexer): assert admit-volume counters + surface in backfill summary (SMI-5319 retro)

### DIFF
--- a/.github/workflows/indexer-backfill.yml
+++ b/.github/workflows/indexer-backfill.yml
@@ -261,6 +261,19 @@ jobs:
           CURRENT_FACET=$(printf '%s' "$RESPONSE" | jq -r '.data.backfill.current_facet // "unknown"')
           PENDING_SUBRANGES=$(printf '%s' "$RESPONSE" | jq -r '.data.backfill.pending_subrange_count // 0')
 
+          # SMI-5319: Phase-3b admit-volume counters from .data.subdirectory_search.
+          # With the license gate removed, license_filtered is ~0, so the meaningful
+          # health signals are how many skills were ADMITTED, the null-license rate,
+          # and how many repos were SKIPPED for an unresolvable default branch.
+          # no_default_branch is the leading regression indicator for the W5 branch
+          # fix: a rising value means GET /repos is failing to resolve branches again
+          # (the original 404-every-repo failure). These are independent dimensions,
+          # not a partition; admitted is the authoritative admit count.
+          ADMITTED=$(printf '%s' "$RESPONSE" | jq -r '.data.subdirectory_search.admitted // 0')
+          LICENSE_NULL=$(printf '%s' "$RESPONSE" | jq -r '.data.subdirectory_search.license_null // 0')
+          NO_DEFAULT_BRANCH=$(printf '%s' "$RESPONSE" | jq -r '.data.subdirectory_search.no_default_branch // 0')
+          LICENSE_FETCH_FAILED=$(printf '%s' "$RESPONSE" | jq -r '.data.subdirectory_search.license_fetch_failed // 0')
+
           # CRITICAL: token_source must be exactly "pat" on every backfill dispatch.
           # An "app" value means the App env entries leaked in (consuming the cron's
           # rate bucket); "unknown" means the indexer never emitted the field (e.g. it
@@ -288,6 +301,10 @@ jobs:
             echo "| Checkpoint ID | $CHECKPOINT_ID |"
             echo "| Cap Saturated | $CAP_SATURATED |"
             echo "| Truncated Repo Count | $TRUNCATED_REPO_COUNT |"
+            echo "| Skills Admitted | $ADMITTED |"
+            echo "| Null License (of admitted) | $LICENSE_NULL |"
+            echo "| No Default Branch (skipped) | $NO_DEFAULT_BRANCH |"
+            echo "| License Fetch Failed | $LICENSE_FETCH_FAILED |"
             echo "| Token Source | $TOKEN_SOURCE |"
             echo ""
             # current_facet == 'done' is authoritative: it is set only when the

--- a/scripts/tests/indexer/subdirectory-search.license-branch.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.license-branch.test.ts
@@ -312,6 +312,11 @@ describe('runSubdirectorySearch — license-as-metadata + Trees default branch (
     expect(result.repos).toHaveLength(1)
     expect(result.repos[0].license).toBe(spdx)
     expect(result.licenseFiltered).toBe(0)
+    // SMI-5319 retro: pin the two NEW observability counters (admit volume +
+    // null-license rate) so a regression that stops/double-counts them can't
+    // silently corrupt the dispatch-summary monitoring.
+    expect(result.admitted).toBe(1)
+    expect(result.licenseNull).toBe(spdx === null ? 1 : 0)
   })
 
   // SMI-5319: license resolution is ONCE-per-repo (after the validity gate).
@@ -342,6 +347,9 @@ describe('runSubdirectorySearch — license-as-metadata + Trees default branch (
     for (const r of result.repos) expect(r.license).toBe('MIT')
     // Exactly ONE license fetch for the whole repo.
     expect(mockFetchRepoLicense).toHaveBeenCalledTimes(1)
+    // SMI-5319 retro: all three skills admit; none is null-license (MIT resolved once).
+    expect(result.admitted).toBe(3)
+    expect(result.licenseNull).toBe(0)
   })
 
   // SMI-5319: the repoMetaCache is reused across two code-search pages of the same


### PR DESCRIPTION
## What

Resolves the two findings from the **governance retro** on the merged SMI-5319 engine fix (PR #1511, squash `cda03285`). Both were LOW severity and adversarially verified (5-dimension review → per-finding skeptic pass).

### 1. Test coverage gap (`subdirectory-search.license-branch.test.ts`)
The net-new `admitted` (admit volume) and `licenseNull` (null-license rate) counters — the indexer's primary observability signals after the license gate was removed — had **zero test assertions**. A regression that stopped/double-counted them would silently corrupt dispatch-summary monitoring. Pinned in two existing tests (no new fixtures):
- the `it.each` all-license-types case: `admitted === 1`, `licenseNull === (null ? 1 : 0)`
- the N-skill once-per-repo case: `admitted === 3`, `licenseNull === 0`

### 2. Operator observability gap (`indexer-backfill.yml`)
The Phase-3b admit-volume counters (`admitted` / `license_null` / `no_default_branch` / `license_fetch_failed`) reached the JSON + raw GHA log but **not** the operator-facing step-summary table. `no_default_branch` is the **leading regression indicator for the W5 branch-resolution fix** (a rising value means `GET /repos` is failing to resolve branches again — the original 404-every-repo failure). Surfaced all four as additional table rows (additive, ASCII-only).

## Verification
- `subdirectory-search.license-branch.test.ts`: 14/14 pass in Docker (incl. the new assertions).
- `prettier --check` + `eslint` clean on both files.
- Workflow YAML: ASCII-only, parses.

## Notes
- **ADR-109**: the workflow change is additive observability only (jq reads + summary rows) — no trigger/job/permission/concurrency change — and is the remedy a governance retro prescribed + verified. Pushed via local git (the `gh` OAuth token lacks `workflow` scope).
- `[skip-impl-check]` — test + CI-observability change only; no new source behavior.

Closes the SMI-5319 governance retro.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
