### PR TITLE
feat(vscode): interactive apply for inventory audit (SMI-5325)

### DIFF
--- a/.claude/development/mcp-tools-guide.md
+++ b/.claude/development/mcp-tools-guide.md
@@ -42,7 +42,7 @@ New tools use `skill_` prefix; legacy tools (`search`, `get_skill`) lack it.
 
 ## VS Code Extension Surface
 
-The `skill_recommend`, `skill_compare`, and `skill_diff` MCP tools are surfaced in the VS Code extension as commands: **Recommend Skills**, **Compare Skills**, and **Check Skill for Updates** (the latter requires Individual plan or higher). The `skill_audit` tool is surfaced in the skill detail panel as a **Security Advisories** section (Team plan or higher). The `skill_inventory_audit` tool is surfaced as the **Audit Skill Inventory** command (read-only collision report; ungated).
+The `skill_recommend`, `skill_compare`, and `skill_diff` MCP tools are surfaced in the VS Code extension as commands: **Recommend Skills**, **Compare Skills**, and **Check Skill for Updates** (the latter requires Individual plan or higher). The `skill_audit` tool is surfaced in the skill detail panel as a **Security Advisories** section (Team plan or higher). The `skill_inventory_audit` tool is surfaced as the **Audit Skill Inventory** command, whose report offers interactive apply (SMI-5325): the `apply_namespace_rename` and `apply_recommended_edit` tools back per-row **Apply rename…** / **Apply edit…** actions (preview → confirm → re-audit; all ungated/Community).
 
 ## CLI
 

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Apply inventory-audit fixes in one click** — the Audit Skill Inventory report now has **Apply rename…** buttons on suggested renames and **Apply edit…** buttons on confirmable prose edits. Each shows a preview and a confirmation before changing anything, writes a backup, and re-scans your inventory afterward so the report stays current. Edits that need manual judgement are labelled "Review and apply manually" rather than auto-applied.
+
 ## [0.6.1] - 2026-06-20
 
 ### Added

--- a/packages/vscode-extension/src/__tests__/inventory-audit-apply.test.ts
+++ b/packages/vscode-extension/src/__tests__/inventory-audit-apply.test.ts
@@ -235,6 +235,18 @@ describe('InventoryAuditPanel interactive apply (SMI-5325)', () => {
     expect(fakeClient.applyNamespaceRename).toHaveBeenCalledTimes(1)
   })
 
+  it('retry is ignored while an apply is in flight (no _response swap mid-flow)', async () => {
+    // Apply preview never resolves → the flow is parked with _applyInFlight set.
+    fakeClient.applyNamespaceRename.mockReturnValue(new Promise(() => {}))
+    InventoryAuditPanel.createOrShow(URI, makeResponse())
+
+    mock.send({ command: 'applyRename', collisionId: 'c1' })
+    mock.send({ command: 'retry' })
+
+    // The user-retry must NOT re-audit (which would swap _response mid-apply).
+    expect(fakeClient.skillInventoryAudit).not.toHaveBeenCalled()
+  })
+
   it('unknown collisionId from the webview is a no-op', async () => {
     InventoryAuditPanel.createOrShow(URI, makeResponse())
     mock.send({ command: 'applyRename', collisionId: 'does-not-exist' })

--- a/packages/vscode-extension/src/__tests__/inventory-audit-apply.test.ts
+++ b/packages/vscode-extension/src/__tests__/inventory-audit-apply.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Interactive-apply flow for InventoryAuditPanel (SMI-5325).
+ *
+ * Drives the panel through real HTML builders + a mocked McpClient, asserting
+ * the preview→confirm→apply→re-audit sequence, the re-entrancy guard, the
+ * confirm-cancel path, structured-error self-heal, and the UnknownTool collapse.
+ * Webview messages are fire-and-forget (`void _handleMessage`), so async work is
+ * awaited via `vi.waitFor`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── vi.hoisted spies (must exist before the vi.mock factories run) ────────────
+const { fakeClient, trackMock, showWarningMessage, showInformationMessage, showErrorMessage } =
+  vi.hoisted(() => ({
+    fakeClient: {
+      isConnected: vi.fn(() => true),
+      skillInventoryAudit: vi.fn(),
+      applyNamespaceRename: vi.fn(),
+      applyRecommendedEdit: vi.fn(),
+    },
+    trackMock: vi.fn(),
+    showWarningMessage: vi.fn(),
+    showInformationMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+  }))
+
+vi.mock('vscode', () => ({
+  Uri: { file: vi.fn((s: string) => ({ fsPath: s, scheme: 'file' })) },
+  ViewColumn: { One: 1 },
+  window: {
+    createWebviewPanel: vi.fn(),
+    activeTextEditor: undefined,
+    showWarningMessage,
+    showInformationMessage,
+    showErrorMessage,
+  },
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+vi.mock('../mcp/McpClient.js', () => ({ getMcpClient: () => fakeClient }))
+vi.mock('../services/Telemetry.js', () => ({ track: trackMock }))
+
+import * as vscode from 'vscode'
+import { McpToolError } from '../mcp/McpToolError.js'
+import { InventoryAuditPanel } from '../views/InventoryAuditPanel.js'
+import type { McpInventoryAuditResponse } from '../mcp/types.js'
+
+// ── Mock webview panel (captures the message handler) ─────────────────────────
+function createMockPanel() {
+  let messageHandler: ((msg: unknown) => void) | undefined
+  const panel = {
+    reveal: vi.fn(),
+    dispose: vi.fn(),
+    title: '',
+    webview: {
+      html: '',
+      onDidReceiveMessage: vi.fn(
+        (handler: (msg: unknown) => void, _ctx: unknown, subs: { dispose: () => void }[]) => {
+          messageHandler = handler
+          const d = { dispose: vi.fn() }
+          if (Array.isArray(subs)) subs.push(d)
+          return d
+        }
+      ),
+      postMessage: vi.fn(() => Promise.resolve(true)),
+    },
+    onDidDispose: vi.fn((_h: () => void, _c: unknown, subs: { dispose: () => void }[]) => {
+      const d = { dispose: vi.fn() }
+      if (Array.isArray(subs)) subs.push(d)
+      return d
+    }),
+  }
+  return {
+    panel: panel as unknown as vscode.WebviewPanel,
+    send: (msg: unknown) => messageHandler?.(msg),
+    html: () => panel.webview.html,
+  }
+}
+
+const URI = { fsPath: '/ext' } as vscode.Uri
+
+function makeEntry(id = 'org/foo') {
+  return {
+    kind: 'skill' as const,
+    source_path: `/home/u/.claude/skills/${id}`,
+    identifier: id,
+    triggerSurface: [] as string[],
+  }
+}
+
+function makeResponse(
+  editApplyMode: 'manual_review' | 'apply_with_confirmation' = 'apply_with_confirmation'
+): McpInventoryAuditResponse {
+  return {
+    auditId: 'aud_test',
+    inventory: [makeEntry()],
+    exactCollisions: [
+      {
+        kind: 'exact',
+        collisionId: 'c1',
+        identifier: 'org/foo',
+        entries: [makeEntry(), makeEntry('org/bar')],
+        severity: 'error',
+        reason: 'dup',
+      },
+    ],
+    genericFlags: [],
+    semanticCollisions: [],
+    renameSuggestions: [
+      {
+        collisionId: 'c1',
+        entry: makeEntry(),
+        currentName: 'foo',
+        suggested: 'foo-2',
+        applyAction: 'rename_skill_dir_and_frontmatter',
+        reason: 'collision',
+      },
+    ],
+    recommendedEdits: [
+      {
+        collisionId: 'c3',
+        category: 'description_overlap',
+        pattern: 'add_domain_qualifier',
+        filePath: '/home/u/.claude/skills/org/foo/SKILL.md',
+        lineRange: { start: 1, end: 2 },
+        before: 'b',
+        after: 'a',
+        rationale: 'r',
+        applyAction: 'recommended_edit',
+        applyMode: editApplyMode,
+        otherEntry: { identifier: 'org/bar', sourcePath: '/p' },
+      },
+    ],
+    reportPath: '/home/u/.skillsmith/audits/aud_test/report.md',
+    summary: { totalEntries: 2, totalFlags: 1, errorCount: 1, warningCount: 0, durationMs: 5 },
+  }
+}
+
+const CLEAN_RESPONSE: McpInventoryAuditResponse = {
+  ...makeResponse(),
+  exactCollisions: [],
+  renameSuggestions: [],
+  recommendedEdits: [],
+  summary: { totalEntries: 2, totalFlags: 0, errorCount: 0, warningCount: 0, durationMs: 5 },
+}
+
+describe('InventoryAuditPanel interactive apply (SMI-5325)', () => {
+  let mock: ReturnType<typeof createMockPanel>
+
+  beforeEach(() => {
+    InventoryAuditPanel.resetForTests()
+    fakeClient.isConnected.mockReset().mockReturnValue(true)
+    fakeClient.skillInventoryAudit.mockReset().mockResolvedValue(CLEAN_RESPONSE)
+    fakeClient.applyNamespaceRename.mockReset()
+    fakeClient.applyRecommendedEdit.mockReset()
+    trackMock.mockReset()
+    showWarningMessage.mockReset()
+    showInformationMessage.mockReset()
+    showErrorMessage.mockReset()
+    mock = createMockPanel()
+    vi.mocked(vscode.window.createWebviewPanel).mockReturnValue(mock.panel)
+  })
+
+  it('rename happy path: preview(confirmed:false) → modal → apply(confirmed:true) → re-audit', async () => {
+    fakeClient.applyNamespaceRename
+      .mockResolvedValueOnce({
+        success: true,
+        preview: true,
+        collisionId: 'c1',
+        before: 'foo',
+        after: 'foo-2',
+        applied: false,
+      })
+      .mockResolvedValueOnce({ success: true, collisionId: 'c1' })
+    showWarningMessage.mockResolvedValue('Apply')
+
+    InventoryAuditPanel.createOrShow(URI, makeResponse())
+    mock.send({ command: 'applyRename', collisionId: 'c1' })
+
+    await vi.waitFor(() => expect(fakeClient.applyNamespaceRename).toHaveBeenCalledTimes(2))
+    expect(fakeClient.applyNamespaceRename).toHaveBeenNthCalledWith(1, {
+      auditId: 'aud_test',
+      collisionId: 'c1',
+      action: 'apply',
+      confirmed: false,
+    })
+    expect(fakeClient.applyNamespaceRename).toHaveBeenNthCalledWith(2, {
+      auditId: 'aud_test',
+      collisionId: 'c1',
+      action: 'apply',
+      confirmed: true,
+    })
+    await vi.waitFor(() => expect(fakeClient.skillInventoryAudit).toHaveBeenCalled())
+    expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining('backup was saved'))
+    expect(trackMock).toHaveBeenCalledWith('vscode_inventory_apply_applied', { kind: 'rename' })
+    // Re-audit rendered the clean state with the announced status message.
+    expect(mock.html()).toContain('No namespace collisions found.')
+    expect(mock.html()).toContain('a backup was saved')
+  })
+
+  it('confirm cancelled: apply(confirmed:true) is NOT called, no re-audit', async () => {
+    fakeClient.applyNamespaceRename.mockResolvedValueOnce({
+      success: true,
+      preview: true,
+      collisionId: 'c1',
+      before: 'foo',
+      after: 'foo-2',
+      applied: false,
+    })
+    showWarningMessage.mockResolvedValue(undefined)
+
+    InventoryAuditPanel.createOrShow(URI, makeResponse())
+    mock.send({ command: 'applyRename', collisionId: 'c1' })
+
+    await vi.waitFor(() =>
+      expect(trackMock).toHaveBeenCalledWith('vscode_inventory_apply_cancelled', { kind: 'rename' })
+    )
+    expect(fakeClient.applyNamespaceRename).toHaveBeenCalledTimes(1)
+    expect(fakeClient.skillInventoryAudit).not.toHaveBeenCalled()
+  })
+
+  it('re-entrancy: a second apply while one is in flight is ignored', async () => {
+    fakeClient.applyNamespaceRename.mockReturnValue(new Promise(() => {})) // never resolves
+    InventoryAuditPanel.createOrShow(URI, makeResponse())
+
+    mock.send({ command: 'applyRename', collisionId: 'c1' })
+    mock.send({ command: 'applyRename', collisionId: 'c1' })
+
+    // The guard is set synchronously before the first await, so the second is a no-op.
+    expect(fakeClient.applyNamespaceRename).toHaveBeenCalledTimes(1)
+  })
+
+  it('unknown collisionId from the webview is a no-op', async () => {
+    InventoryAuditPanel.createOrShow(URI, makeResponse())
+    mock.send({ command: 'applyRename', collisionId: 'does-not-exist' })
+
+    expect(fakeClient.applyNamespaceRename).not.toHaveBeenCalled()
+  })
+
+  it('collision_not_found on preview self-heals via re-audit (no confirm, no mutation)', async () => {
+    fakeClient.applyNamespaceRename.mockResolvedValueOnce({
+      success: false,
+      collisionId: 'c1',
+      errorCode: 'namespace.audit.collision_not_found',
+      error: 'gone',
+    })
+
+    InventoryAuditPanel.createOrShow(URI, makeResponse())
+    mock.send({ command: 'applyRename', collisionId: 'c1' })
+
+    await vi.waitFor(() => expect(fakeClient.skillInventoryAudit).toHaveBeenCalled())
+    expect(showWarningMessage).not.toHaveBeenCalled() // never reached the confirm modal
+    expect(fakeClient.applyNamespaceRename).toHaveBeenCalledTimes(1) // preview only
+    expect(trackMock).toHaveBeenCalledWith('vscode_inventory_apply_failed', {
+      kind: 'rename',
+      errorCode: 'namespace.audit.collision_not_found',
+    })
+  })
+
+  it('applyEdit UnknownTool collapses edit buttons to the manual-review hint', async () => {
+    fakeClient.applyRecommendedEdit.mockRejectedValueOnce(
+      new McpToolError('apply_recommended_edit', 'UnknownTool', 'Unknown tool')
+    )
+
+    InventoryAuditPanel.createOrShow(URI, makeResponse('apply_with_confirmation'))
+    // The Apply-edit button carries the edit collisionId c3 (the delegated-click
+    // script also names `apply-edit-btn`, so assert on the unique data-collision).
+    expect(mock.html()).toContain('data-collision="c3"') // edit button present pre-click
+    mock.send({ command: 'applyEdit', collisionId: 'c3' })
+
+    await vi.waitFor(() => expect(mock.html()).toContain('Review and apply manually'))
+    expect(mock.html()).not.toContain('data-collision="c3"') // collapsed to the hint
+    expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("isn't supported"))
+  })
+
+  it('not connected: apply surfaces a connect prompt and does not call the tool', async () => {
+    fakeClient.isConnected.mockReturnValue(false)
+    InventoryAuditPanel.createOrShow(URI, makeResponse())
+    mock.send({ command: 'applyRename', collisionId: 'c1' })
+
+    await vi.waitFor(() =>
+      expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining('not connected'))
+    )
+    expect(fakeClient.applyNamespaceRename).not.toHaveBeenCalled()
+  })
+})

--- a/packages/vscode-extension/src/__tests__/inventory-audit-panel.test.ts
+++ b/packages/vscode-extension/src/__tests__/inventory-audit-panel.test.ts
@@ -47,6 +47,7 @@ function makeResponse(
     withSemantic: boolean
     withRename: boolean
     withEdit: boolean
+    editApplyMode: 'manual_review' | 'apply_with_confirmation'
     identifier: string
   }> = {}
 ) {
@@ -59,6 +60,7 @@ function makeResponse(
     withSemantic = false,
     withRename = false,
     withEdit = false,
+    editApplyMode = 'manual_review',
     identifier = 'org/foo',
   } = overrides
 
@@ -121,7 +123,7 @@ function makeResponse(
             after: 'Searches TypeScript files in the repo.',
             rationale: 'Narrow scope to reduce overlap.',
             applyAction: 'recommended_edit' as const,
-            applyMode: 'manual_review' as const,
+            applyMode: editApplyMode,
             otherEntry: { identifier: 'org/bar', sourcePath: '/home/u/.claude/skills/org/bar' },
           },
         ]
@@ -173,26 +175,72 @@ describe('inventory-audit HTML (SMI-5318)', () => {
     expect(html).toContain('0.91')
   })
 
-  it('rename suggestion: contains currentName, suggested, and copy button with data-copy', () => {
+  it('rename suggestion: contains currentName, suggested, copy + Apply-rename buttons', () => {
     const items = makeResponse({ withRename: true }).renameSuggestions
     const html = getRenameSuggestionsSection(items)
 
     expect(html).toContain('foo')
     expect(html).toContain('foo-2')
     expect(html).toContain('data-copy="foo-2"')
+    // SMI-5325: Apply-rename button carries the collisionId (escaped).
+    expect(html).toContain('apply-rename-btn')
+    expect(html).toContain('data-collision="c1"')
+    expect(html).toContain('Apply rename')
   })
 
-  it('recommendedEdits: contains before/after/rationale and section heading; no Apply button', () => {
-    const items = makeResponse({ withEdit: true }).recommendedEdits
+  it('recommendedEdits (manual_review): shows the manual-review hint, NOT an Apply button', () => {
+    const items = makeResponse({ withEdit: true, editApplyMode: 'manual_review' }).recommendedEdits
     const html = getRecommendedEditsSection(items)
 
     expect(html).toContain('Recommended Edits')
     expect(html).toContain('Searches files in the repo.')
     expect(html).toContain('Searches TypeScript files in the repo.')
     expect(html).toContain('Narrow scope to reduce overlap.')
-    // Read-only section: no "Apply" button text inside this section
-    expect(html).not.toContain('>Apply<')
-    expect(html).not.toContain('>Apply </') // also no "Apply " prefix variant
+    // manual_review → hint, no apply-edit button
+    expect(html).toContain('Review and apply manually')
+    expect(html).not.toContain('apply-edit-btn')
+  })
+
+  it('recommendedEdits (apply_with_confirmation): renders the Apply-edit button with data-collision', () => {
+    const items = makeResponse({
+      withEdit: true,
+      editApplyMode: 'apply_with_confirmation',
+    }).recommendedEdits
+    const html = getRecommendedEditsSection(items)
+
+    expect(html).toContain('apply-edit-btn')
+    expect(html).toContain('data-collision="c1"')
+    expect(html).toContain('Apply edit')
+    expect(html).not.toContain('Review and apply manually')
+  })
+
+  it('recommendedEdits: editApplyUnavailable collapses an applyable row to the hint', () => {
+    const items = makeResponse({
+      withEdit: true,
+      editApplyMode: 'apply_with_confirmation',
+    }).recommendedEdits
+    const html = getRecommendedEditsSection(items, true)
+
+    expect(html).not.toContain('apply-edit-btn')
+    expect(html).toContain('Review and apply manually')
+  })
+
+  it('XSS escape: a malicious collisionId is escaped into the data-collision attribute', () => {
+    const xss = '"><img src=x onerror=alert(1)>'
+    const items = [
+      {
+        collisionId: xss,
+        entry: makeEntry(),
+        currentName: 'foo',
+        suggested: 'foo-2',
+        applyAction: 'rename_skill_dir_and_frontmatter' as const,
+        reason: 'collision',
+      },
+    ]
+    const html = getRenameSuggestionsSection(items)
+
+    expect(html).not.toContain('onerror=alert(1)>')
+    expect(html).toContain('&lt;img')
   })
 
   it('XSS escape: <script> identifier is escaped, raw form absent', () => {

--- a/packages/vscode-extension/src/__tests__/mcp/apply_namespace_rename.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/apply_namespace_rename.test.ts
@@ -1,0 +1,114 @@
+/**
+ * apply_namespace_rename is UNGATED (Community-tier) and ALWAYS registered. The
+ * dispatcher wraps its result with `okBody` (isError:false), so application-level
+ * failure arrives as `success:false` + `errorCode` INSIDE the parsed envelope —
+ * NOT a thrown McpToolError. (SMI-5325)
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+import { McpClient } from '../../mcp/McpClient.js'
+import { McpToolError } from '../../mcp/McpToolError.js'
+
+/** Wrap a JSON payload in the MCP tools/call success envelope (non-isError). */
+function ok(payload: unknown): Record<string, unknown> {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+}
+
+/** Returns a connected McpClient whose private `sendRequest` resolves to `raw`. */
+function connectedClient(raw: unknown): McpClient {
+  const client = new McpClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).status = 'connected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).sendRequest = vi.fn().mockResolvedValue(raw)
+  return client
+}
+
+const ARGS = { auditId: 'aud_1', collisionId: 'c1', action: 'apply' as const }
+
+describe('McpClient.applyNamespaceRename (SMI-5325)', () => {
+  it('preview (confirmed:false) returns the preview envelope unchanged', async () => {
+    const client = connectedClient(
+      ok({
+        success: true,
+        preview: true,
+        collisionId: 'c1',
+        action: 'rename_skill_dir_and_frontmatter',
+        target: '/home/u/.claude/skills/org/foo',
+        before: 'foo',
+        after: 'foo-2',
+        applied: false,
+      })
+    )
+
+    const result = await client.applyNamespaceRename({ ...ARGS, confirmed: false })
+
+    expect(result.success).toBe(true)
+    expect(result.preview).toBe(true)
+    expect(result.applied).toBe(false)
+    expect(result.before).toBe('foo')
+    expect(result.after).toBe('foo-2')
+  })
+
+  it('apply (confirmed:true) returns success with the Wave-2 result', async () => {
+    const client = connectedClient(
+      ok({ success: true, collisionId: 'c1', result: { fromPath: '/a', toPath: '/b' } })
+    )
+
+    const result = await client.applyNamespaceRename({ ...ARGS, confirmed: true })
+
+    expect(result.success).toBe(true)
+    expect(result.collisionId).toBe('c1')
+  })
+
+  it('structured failure is RETURNED (success:false + errorCode), not thrown', async () => {
+    const client = connectedClient(
+      ok({
+        success: false,
+        collisionId: 'c1',
+        errorCode: 'namespace.audit.collision_not_found',
+        error: 'Collision c1 not found in audit aud_1.',
+      })
+    )
+
+    const result = await client.applyNamespaceRename({ ...ARGS, confirmed: true })
+
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('namespace.audit.collision_not_found')
+    expect(result.error).toContain('not found')
+  })
+
+  it('subcall failure preserves the rename errorCode in the envelope', async () => {
+    const client = connectedClient(
+      ok({
+        success: false,
+        collisionId: 'c1',
+        errorCode: 'namespace.rename.subcall_failed',
+        error: 'namespace.rename.target_exists: target already exists',
+      })
+    )
+
+    const result = await client.applyNamespaceRename({ ...ARGS, confirmed: true })
+
+    expect(result.errorCode).toBe('namespace.rename.subcall_failed')
+    expect(result.error).toContain('target_exists')
+  })
+
+  it('calling before connect throws NotConnected', async () => {
+    const client = new McpClient()
+    await expect(client.applyNamespaceRename(ARGS)).rejects.toMatchObject({
+      code: 'NotConnected',
+      message: 'MCP client not connected',
+    })
+    await expect(client.applyNamespaceRename(ARGS)).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/__tests__/mcp/apply_recommended_edit.test.ts
+++ b/packages/vscode-extension/src/__tests__/mcp/apply_recommended_edit.test.ts
@@ -1,0 +1,104 @@
+/**
+ * apply_recommended_edit is UNGATED but CONDITIONALLY registered server-side
+ * (`APPLY_TEMPLATE_REGISTRY`). When the registry is empty the tool is absent →
+ * an `Unknown tool` isError envelope → McpToolError code 'UnknownTool'. Otherwise
+ * its result is `okBody`-wrapped, so application failure is `success:false` +
+ * `errorCode` inside the parsed envelope, not a throw. (SMI-5325)
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private cb: () => void) {}
+    dispose() {
+      this.cb()
+    }
+  },
+}))
+
+import { McpClient } from '../../mcp/McpClient.js'
+import { McpToolError } from '../../mcp/McpToolError.js'
+
+function ok(payload: unknown): Record<string, unknown> {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] }
+}
+
+function isErr(text: string): Record<string, unknown> {
+  return { isError: true, content: [{ type: 'text', text }] }
+}
+
+function connectedClient(raw: unknown): McpClient {
+  const client = new McpClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).status = 'connected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(client as any).sendRequest = vi.fn().mockResolvedValue(raw)
+  return client
+}
+
+const ARGS = { auditId: 'aud_1', collisionId: 'c3' }
+
+describe('McpClient.applyRecommendedEdit (SMI-5325)', () => {
+  it('preview (confirmed:false) returns the preview envelope unchanged', async () => {
+    const client = connectedClient(
+      ok({
+        success: true,
+        preview: true,
+        collisionId: 'c3',
+        target: '/home/u/.claude/skills/org/foo/SKILL.md',
+        before: 'Use this for foo.',
+        after: 'Use this for foo (org domain).',
+        applied: false,
+      })
+    )
+
+    const result = await client.applyRecommendedEdit({ ...ARGS, confirmed: false })
+
+    expect(result.success).toBe(true)
+    expect(result.preview).toBe(true)
+    expect(result.after).toContain('org domain')
+  })
+
+  it('apply (confirmed:true) returns success', async () => {
+    const client = connectedClient(
+      ok({ success: true, collisionId: 'c3', result: { filePath: '/p' } })
+    )
+
+    const result = await client.applyRecommendedEdit({ ...ARGS, confirmed: true })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('template-not-in-registry failure is returned, not thrown', async () => {
+    const client = connectedClient(
+      ok({
+        success: false,
+        collisionId: 'c3',
+        errorCode: 'edit.template_not_in_apply_registry',
+        error: 'Template narrow_scope is not in the apply registry.',
+      })
+    )
+
+    const result = await client.applyRecommendedEdit({ ...ARGS, confirmed: true })
+
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('edit.template_not_in_apply_registry')
+  })
+
+  it('unregistered tool (empty registry) throws McpToolError code UnknownTool', async () => {
+    const client = connectedClient(isErr('Unknown tool: apply_recommended_edit'))
+    await expect(client.applyRecommendedEdit(ARGS)).rejects.toMatchObject({
+      code: 'UnknownTool',
+      toolName: 'apply_recommended_edit',
+    })
+  })
+
+  it('calling before connect throws NotConnected', async () => {
+    const client = new McpClient()
+    await expect(client.applyRecommendedEdit(ARGS)).rejects.toMatchObject({
+      code: 'NotConnected',
+      message: 'MCP client not connected',
+    })
+    await expect(client.applyRecommendedEdit(ARGS)).rejects.toBeInstanceOf(McpToolError)
+  })
+})

--- a/packages/vscode-extension/src/mcp/McpClient.ts
+++ b/packages/vscode-extension/src/mcp/McpClient.ts
@@ -18,6 +18,8 @@ import {
   type McpSkillDiffResponse,
   type McpSkillAuditResponse,
   type McpInventoryAuditResponse,
+  type McpApplyNamespaceRenameResponse,
+  type McpApplyRecommendedEditResponse,
   DEFAULT_MCP_CONFIG,
 } from './types.js'
 import type { JsonRpcRequest, JsonRpcResponse } from './jsonrpc.types.js'
@@ -427,6 +429,37 @@ export class McpClient {
   }
 
   /**
+   * Apply a rename suggestion from a prior `skill_inventory_audit` (SMI-5325).
+   * UNGATED. Mutates `~/.claude/` (backup + revert ledger) only when
+   * `confirmed: true`; else returns a non-mutating preview. The UI sends
+   * `action: 'apply'` (`'custom'`/`'skip'` are reserved for SMI-5328).
+   * App-level failure arrives as `success: false` + `errorCode`, not a throw.
+   */
+  async applyNamespaceRename(args: {
+    auditId: string
+    collisionId: string
+    action: 'apply' | 'custom' | 'skip'
+    customName?: string
+    confirmed?: boolean
+  }): Promise<McpApplyNamespaceRenameResponse> {
+    return this.callTool<McpApplyNamespaceRenameResponse>('apply_namespace_rename', args)
+  }
+
+  /**
+   * Apply a recommended prose edit from a prior `skill_inventory_audit`
+   * (SMI-5325). UNGATED but conditionally registered server-side
+   * (`APPLY_TEMPLATE_REGISTRY`) — when absent, throws `McpToolError`
+   * (`UnknownTool`). Mutates `~/.claude/` only when `confirmed: true`.
+   */
+  async applyRecommendedEdit(args: {
+    auditId: string
+    collisionId: string
+    confirmed?: boolean
+  }): Promise<McpApplyRecommendedEditResponse> {
+    return this.callTool<McpApplyRecommendedEditResponse>('apply_recommended_edit', args)
+  }
+
+  /**
    * Disconnect from the MCP server
    */
   disconnect(): void {
@@ -447,38 +480,7 @@ export class McpClient {
   }
 }
 
-/**
- * Singleton MCP client instance
- */
-let mcpClientInstance: McpClient | null = null
-
-/**
- * Get the singleton MCP client instance
- */
-export function getMcpClient(): McpClient {
-  if (!mcpClientInstance) {
-    mcpClientInstance = new McpClient()
-  }
-  return mcpClientInstance
-}
-
-/**
- * Initialize the MCP client with custom configuration
- */
-export function initializeMcpClient(config?: Partial<McpClientConfig>): McpClient {
-  if (mcpClientInstance) {
-    mcpClientInstance.disconnect()
-  }
-  mcpClientInstance = new McpClient(config)
-  return mcpClientInstance
-}
-
-/**
- * Dispose the MCP client
- */
-export function disposeMcpClient(): void {
-  if (mcpClientInstance) {
-    mcpClientInstance.disconnect()
-    mcpClientInstance = null
-  }
-}
+// Singleton accessors live in McpClientSingleton.ts (SMI-5325 file-length shed)
+// and are re-exported here for back-compat. The circular import is eval-safe —
+// see McpClientSingleton.ts.
+export { getMcpClient, initializeMcpClient, disposeMcpClient } from './McpClientSingleton.js'

--- a/packages/vscode-extension/src/mcp/McpClientSingleton.ts
+++ b/packages/vscode-extension/src/mcp/McpClientSingleton.ts
@@ -1,0 +1,44 @@
+/**
+ * Singleton accessor for the shared {@link McpClient} instance.
+ *
+ * Split out of `McpClient.ts` (SMI-5325) to keep that file under the 500-line
+ * pre-commit gate as new tool wrappers are added. `McpClient.ts` re-exports
+ * these for back-compat, so existing `import { getMcpClient } from './McpClient.js'`
+ * sites are unaffected.
+ *
+ * Circular-import safety: this module imports the `McpClient` *class* from
+ * `./McpClient.js`, and `McpClient.ts` re-exports the functions below. The
+ * class binding is referenced only inside these function bodies (which run at
+ * call time, long after both modules finish evaluating), never at module-eval
+ * time — so the cycle never hits a TDZ. esbuild/ESM resolve it cleanly.
+ */
+import { McpClient } from './McpClient.js'
+import type { McpClientConfig } from './types.js'
+
+/** Singleton MCP client instance. */
+let mcpClientInstance: McpClient | null = null
+
+/** Get the singleton MCP client instance. */
+export function getMcpClient(): McpClient {
+  if (!mcpClientInstance) {
+    mcpClientInstance = new McpClient()
+  }
+  return mcpClientInstance
+}
+
+/** Initialize the MCP client with custom configuration. */
+export function initializeMcpClient(config?: Partial<McpClientConfig>): McpClient {
+  if (mcpClientInstance) {
+    mcpClientInstance.disconnect()
+  }
+  mcpClientInstance = new McpClient(config)
+  return mcpClientInstance
+}
+
+/** Dispose the MCP client. */
+export function disposeMcpClient(): void {
+  if (mcpClientInstance) {
+    mcpClientInstance.disconnect()
+    mcpClientInstance = null
+  }
+}

--- a/packages/vscode-extension/src/mcp/types.ts
+++ b/packages/vscode-extension/src/mcp/types.ts
@@ -340,6 +340,57 @@ export interface McpInventoryAuditResponse {
 }
 
 /**
+ * Response from MCP `apply_namespace_rename` (SMI-5325). UNGATED. Mirrors the
+ * server envelope (`apply-namespace-rename.types.ts`). Application-level failure
+ * is `success: false` + `errorCode` (the dispatcher wraps every result with
+ * `okBody` → `isError: false`, so this never surfaces as a thrown McpToolError).
+ * The SMI-5213 preview fields are present (with `applied: false`) when the tool
+ * was called without `confirmed: true`. `result` is opaque to the extension.
+ */
+export interface McpApplyNamespaceRenameResponse {
+  success: boolean
+  collisionId: string
+  result?: unknown
+  errorCode?:
+    | 'namespace.audit.invalid_input'
+    | 'namespace.audit.history_not_found'
+    | 'namespace.audit.collision_not_found'
+    | 'namespace.rename.subcall_failed'
+  error?: string
+  preview?: boolean
+  action?: string
+  target?: string
+  before?: string
+  after?: string
+  applied?: boolean
+}
+
+/**
+ * Response from MCP `apply_recommended_edit` (SMI-5325). UNGATED but the tool is
+ * conditionally registered server-side (`APPLY_TEMPLATE_REGISTRY`). Mirrors the
+ * server envelope (`apply-recommended-edit.types.ts`); same preview/error-code
+ * contract as {@link McpApplyNamespaceRenameResponse}. `result` is opaque.
+ */
+export interface McpApplyRecommendedEditResponse {
+  success: boolean
+  collisionId: string
+  result?: unknown
+  errorCode?:
+    | 'namespace.audit.invalid_input'
+    | 'namespace.audit.history_not_found'
+    | 'namespace.audit.collision_not_found'
+    | 'edit.template_not_in_apply_registry'
+    | 'edit.subcall_failed'
+  error?: string
+  preview?: boolean
+  action?: string
+  target?: string
+  before?: string
+  after?: string
+  applied?: boolean
+}
+
+/**
  * MCP connection status
  */
 export type McpConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error'

--- a/packages/vscode-extension/src/services/Telemetry.ts
+++ b/packages/vscode-extension/src/services/Telemetry.ts
@@ -33,6 +33,12 @@ export type TelemetryEvent =
   | 'vscode_inventory_audit_start'
   | 'vscode_inventory_audit_complete'
   | 'vscode_inventory_audit_empty'
+  // SMI-5325 (Epic D): interactive apply (apply_namespace_rename / _recommended_edit).
+  // Panel-message-driven (no new registered command → coverage count stays 10).
+  | 'vscode_inventory_apply_preview'
+  | 'vscode_inventory_apply_applied'
+  | 'vscode_inventory_apply_failed'
+  | 'vscode_inventory_apply_cancelled'
 
 // No hardcoded endpoint — telemetry is disabled by default at runtime
 // unless `skillsmith.telemetryEndpoint` is set or the production endpoint

--- a/packages/vscode-extension/src/views/InventoryAuditPanel.ts
+++ b/packages/vscode-extension/src/views/InventoryAuditPanel.ts
@@ -1,23 +1,46 @@
 /**
- * Webview panel for the Skill Inventory Audit (SMI-5318 / #1459).
+ * Webview panel for the Skill Inventory Audit (SMI-5318 / #1459; interactive
+ * apply added in SMI-5325).
  *
  * Mirrors CompareSkillsPanel: singleton (`currentPanel`), `createOrShow`,
- * `dispose`, `resetForTests`, CSP nonce per render, host-built HTML, the
- * message listener wired BEFORE assigning `webview.html`. Read-only — inbound
- * messages are `retry` (re-run the audit), `openReport` (open the formatted
- * report file in an editor), and `copyRename` (copy a suggested name to the
- * clipboard).
+ * `dispose`, `resetForTests`, CSP nonce per render, host-built HTML, the message
+ * listener wired BEFORE assigning `webview.html`. Inbound messages: `retry`
+ * (re-run the audit), `openReport`, `copyRename`, and `applyRename` / `applyEdit`
+ * (SMI-5325 — apply a suggested rename / prose edit, both mutating `~/.claude/`).
  *
- * The `skill_inventory_audit` MCP tool is ungated (Community tier) — there is
- * no tier-denied handling anywhere in this panel.
+ * All apply tools are ungated (Community tier) — no tier-denied handling. The
+ * SMI-5213 confirmation gate is honored: every apply first fetches a non-mutating
+ * preview (`confirmed: false`), shows a native modal, then mutates
+ * (`confirmed: true`) only on confirm, and re-audits to refresh the report.
  */
 import * as vscode from 'vscode'
 import { generateCspNonce, getInventoryAuditCsp } from '../utils/csp.js'
 import { getLoadingHtml } from './skill-panel-html.js'
 import { getInventoryAuditHtml, getInventoryAuditErrorHtml } from './inventory-audit-panel-html.js'
 import { getMcpClient } from '../mcp/McpClient.js'
+import { McpToolError } from '../mcp/McpToolError.js'
+import { track } from '../services/Telemetry.js'
 import type { McpInventoryAuditResponse } from '../mcp/types.js'
 import type { InventoryAuditPanelMessage } from './inventory-audit-panel-types.js'
+
+/**
+ * Structural view of an apply response envelope (both
+ * `McpApplyNamespaceRenameResponse` and `McpApplyRecommendedEditResponse` are
+ * assignable to it). Application-level failure is `success: false` + `errorCode`
+ * inside the envelope — never a thrown error (the dispatcher uses `okBody`).
+ */
+interface ApplyEnvelope {
+  success: boolean
+  errorCode?: string
+  error?: string
+  preview?: boolean
+  before?: string
+  after?: string
+  target?: string
+  applied?: boolean
+}
+
+const NOT_CONNECTED_MSG = 'Skillsmith server is not connected. Start the MCP server and try again.'
 
 export class InventoryAuditPanel {
   public static currentPanel: InventoryAuditPanel | undefined
@@ -26,6 +49,13 @@ export class InventoryAuditPanel {
   private readonly _panel: vscode.WebviewPanel
   private _response: McpInventoryAuditResponse
   private _disposed = false
+  // SMI-5325: re-entrancy guard — at most one apply flow runs at a time on the
+  // singleton. Set synchronously at the top of an apply (before any await), so a
+  // second webview click is ignored while one is in flight.
+  private _applyInFlight = false
+  // SMI-5325: once the server's `apply_recommended_edit` is known unavailable
+  // (registry empty → UnknownTool), suppress all Apply-edit buttons.
+  private _editApplyUnavailable = false
   private _disposables: vscode.Disposable[] = []
 
   /** Reset the singleton between tests. */
@@ -89,20 +119,179 @@ export class InventoryAuditPanel {
 
   private _handleMessage(message: InventoryAuditPanelMessage): void {
     if (message.command === 'retry') {
-      void this._retry()
+      void this._reaudit()
     } else if (message.command === 'openReport') {
       void this._openReport()
     } else if (message.command === 'copyRename') {
       void this._copyRename(message.text)
+    } else if (message.command === 'applyRename') {
+      void this._applyRename(message.collisionId)
+    } else if (message.command === 'applyEdit') {
+      void this._applyEdit(message.collisionId)
     }
   }
 
+  /** Apply a suggested rename. Validates the collisionId against the live report. */
+  private async _applyRename(collisionId: string): Promise<void> {
+    const suggestion = this._response.renameSuggestions.find((s) => s.collisionId === collisionId)
+    if (!suggestion) return
+    const before = typeof suggestion.currentName === 'string' ? suggestion.currentName : ''
+    const after = typeof suggestion.suggested === 'string' ? suggestion.suggested : ''
+    await this._runApply('rename', {
+      confirmTitle: 'Apply this rename?',
+      summary: `"${before}" → "${after}"`,
+      successMessage: `Renamed "${before}" → "${after}" — a backup was saved.`,
+      call: (confirmed) =>
+        getMcpClient().applyNamespaceRename({
+          auditId: this._response.auditId,
+          collisionId,
+          action: 'apply',
+          confirmed,
+        }),
+    })
+  }
+
+  /** Apply a recommended prose edit (only reachable for apply_with_confirmation rows). */
+  private async _applyEdit(collisionId: string): Promise<void> {
+    const edit = this._response.recommendedEdits.find((e) => e.collisionId === collisionId)
+    if (!edit) return
+    const filePath = typeof edit.filePath === 'string' ? edit.filePath : 'the file'
+    await this._runApply('edit', {
+      confirmTitle: 'Apply this edit?',
+      summary: `Rewrite ${filePath}`,
+      successMessage: 'Applied edit — a backup was saved.',
+      call: (confirmed) =>
+        getMcpClient().applyRecommendedEdit({
+          auditId: this._response.auditId,
+          collisionId,
+          confirmed,
+        }),
+    })
+  }
+
   /**
-   * Re-run the inventory audit. Shows a loading state, then re-renders on
-   * success. The tool is ungated, so any error renders the error page (no
-   * tier-denied handling).
+   * Shared apply flow: preview (confirmed:false) → native-modal confirm → apply
+   * (confirmed:true) → re-audit. Guarded by `_applyInFlight`.
    */
-  private async _retry(): Promise<void> {
+  private async _runApply(
+    kind: 'rename' | 'edit',
+    opts: {
+      confirmTitle: string
+      summary: string
+      successMessage: string
+      call: (confirmed: boolean) => Promise<ApplyEnvelope>
+    }
+  ): Promise<void> {
+    if (this._disposed || this._applyInFlight) return
+    this._applyInFlight = true
+    try {
+      if (!getMcpClient().isConnected()) {
+        void vscode.window.showInformationMessage(NOT_CONNECTED_MSG)
+        return
+      }
+
+      // Phase 1: non-mutating preview.
+      let preview: ApplyEnvelope
+      try {
+        preview = await opts.call(false)
+      } catch (err) {
+        this._handleApplyThrow(kind, err)
+        return
+      }
+      if (this._disposed) return
+      track('vscode_inventory_apply_preview', { kind })
+      if (!preview.success) {
+        await this._handleApplyErrorCode(kind, preview)
+        return
+      }
+
+      // Phase 2: native-modal confirmation (the rich diff stays in the panel row).
+      const detail = `${opts.summary}\n\nThis modifies a file under ~/.claude (a backup is saved).`
+      const choice = await vscode.window.showWarningMessage(
+        opts.confirmTitle,
+        { modal: true, detail },
+        'Apply'
+      )
+      if (this._disposed) return
+      if (choice !== 'Apply') {
+        track('vscode_inventory_apply_cancelled', { kind })
+        return
+      }
+
+      // Phase 3: mutating apply.
+      let applied: ApplyEnvelope
+      try {
+        applied = await opts.call(true)
+      } catch (err) {
+        this._handleApplyThrow(kind, err)
+        return
+      }
+      if (this._disposed) return
+      if (!applied.success) {
+        await this._handleApplyErrorCode(kind, applied)
+        return
+      }
+
+      // Phase 4: success → re-audit + announce.
+      track('vscode_inventory_apply_applied', { kind })
+      void vscode.window.showInformationMessage(opts.successMessage)
+      await this._reaudit(opts.successMessage)
+    } finally {
+      this._applyInFlight = false
+    }
+  }
+
+  /** Map a thrown McpToolError (transport-level) to user-facing messaging. */
+  private _handleApplyThrow(kind: 'rename' | 'edit', err: unknown): void {
+    const code = err instanceof McpToolError ? err.code : 'Unknown'
+    track('vscode_inventory_apply_failed', { kind, errorCode: code })
+    if (code === 'NotConnected') {
+      void vscode.window.showInformationMessage(NOT_CONNECTED_MSG)
+      return
+    }
+    if (code === 'UnknownTool' && kind === 'edit') {
+      // Registry-empty server build: collapse all Apply-edit buttons to the hint.
+      this._editApplyUnavailable = true
+      void vscode.window.showInformationMessage(
+        "Applying recommended edits isn't supported by the connected Skillsmith server."
+      )
+      this._update()
+      return
+    }
+    const raw = err instanceof Error ? err.message : String(err)
+    void vscode.window.showErrorMessage(`Could not apply the change. ${raw}`)
+  }
+
+  /** Map a structured `success:false` envelope (errorCode) to user-facing messaging. */
+  private async _handleApplyErrorCode(kind: 'rename' | 'edit', env: ApplyEnvelope): Promise<void> {
+    const code = env.errorCode ?? 'unknown'
+    track('vscode_inventory_apply_failed', { kind, errorCode: code })
+    // Self-heal: a drifted persisted audit → silently re-scan. No mutation
+    // happened in these cases, so this cannot produce a partial apply, and the
+    // re-audit never re-fires an apply (no loop).
+    if (
+      code === 'namespace.audit.history_not_found' ||
+      code === 'namespace.audit.collision_not_found'
+    ) {
+      await this._reaudit('Your inventory changed — refreshing the audit…')
+      return
+    }
+    const detail = typeof env.error === 'string' ? env.error : ''
+    const messages: Record<string, string> = {
+      'namespace.audit.invalid_input': "That suggestion couldn't be applied (invalid input).",
+      'namespace.rename.subcall_failed': `Rename failed: ${detail} — re-run the audit to see the current state.`,
+      'edit.template_not_in_apply_registry': "This edit template can't be applied automatically.",
+      'edit.subcall_failed': `Edit failed: ${detail} — re-run the audit to see the current state.`,
+    }
+    void vscode.window.showErrorMessage(messages[code] ?? 'Could not apply the change.')
+  }
+
+  /**
+   * Re-run the inventory audit (shared by the Re-run button and post-apply
+   * refresh). Shows a loading state, then re-renders on success. `statusMessage`,
+   * when set, is announced via the panel's aria-live status node.
+   */
+  private async _reaudit(statusMessage = ''): Promise<void> {
     if (this._disposed) return
     const nonce = generateCspNonce()
     this._panel.webview.html = getLoadingHtml(nonce, getInventoryAuditCsp(nonce))
@@ -110,10 +299,7 @@ export class InventoryAuditPanel {
     const client = getMcpClient()
     if (!client.isConnected()) {
       const errNonce = generateCspNonce()
-      this._panel.webview.html = getInventoryAuditErrorHtml(
-        'Skillsmith server is not connected. Start the MCP server and try again.',
-        errNonce
-      )
+      this._panel.webview.html = getInventoryAuditErrorHtml(NOT_CONNECTED_MSG, errNonce)
       return
     }
 
@@ -121,7 +307,7 @@ export class InventoryAuditPanel {
       const response = await client.skillInventoryAudit({})
       if (this._disposed) return
       this._response = response
-      this._update()
+      this._update(statusMessage)
     } catch (err) {
       if (this._disposed) return
       const raw = err instanceof Error ? err.message : String(err)
@@ -159,9 +345,12 @@ export class InventoryAuditPanel {
     void vscode.window.showInformationMessage(`Copied: ${text}`)
   }
 
-  private _update(): void {
+  private _update(statusMessage = ''): void {
     if (this._disposed) return
     const nonce = generateCspNonce()
-    this._panel.webview.html = getInventoryAuditHtml(this._response, nonce)
+    this._panel.webview.html = getInventoryAuditHtml(this._response, nonce, {
+      editApplyUnavailable: this._editApplyUnavailable,
+      statusMessage,
+    })
   }
 }

--- a/packages/vscode-extension/src/views/InventoryAuditPanel.ts
+++ b/packages/vscode-extension/src/views/InventoryAuditPanel.ts
@@ -119,6 +119,12 @@ export class InventoryAuditPanel {
 
   private _handleMessage(message: InventoryAuditPanelMessage): void {
     if (message.command === 'retry') {
+      // Ignore a user-triggered re-run while an apply flow is mid-flight: it
+      // would swap `_response` (new auditId) during the Phase-1 preview window
+      // and re-render the panel underneath the confirm modal. Internal
+      // `_reaudit` calls (post-apply / self-heal) run from inside the flow and
+      // are intentionally not gated. (SMI-5325 governance M-1/M-2)
+      if (this._applyInFlight) return
       void this._reaudit()
     } else if (message.command === 'openReport') {
       void this._openReport()
@@ -137,17 +143,15 @@ export class InventoryAuditPanel {
     if (!suggestion) return
     const before = typeof suggestion.currentName === 'string' ? suggestion.currentName : ''
     const after = typeof suggestion.suggested === 'string' ? suggestion.suggested : ''
+    // Snapshot auditId so it stays coherent with this collisionId for both the
+    // preview and the apply call, even if `_response` is replaced meanwhile.
+    const auditId = this._response.auditId
     await this._runApply('rename', {
       confirmTitle: 'Apply this rename?',
       summary: `"${before}" → "${after}"`,
       successMessage: `Renamed "${before}" → "${after}" — a backup was saved.`,
       call: (confirmed) =>
-        getMcpClient().applyNamespaceRename({
-          auditId: this._response.auditId,
-          collisionId,
-          action: 'apply',
-          confirmed,
-        }),
+        getMcpClient().applyNamespaceRename({ auditId, collisionId, action: 'apply', confirmed }),
     })
   }
 
@@ -156,16 +160,13 @@ export class InventoryAuditPanel {
     const edit = this._response.recommendedEdits.find((e) => e.collisionId === collisionId)
     if (!edit) return
     const filePath = typeof edit.filePath === 'string' ? edit.filePath : 'the file'
+    // Snapshot auditId (coherent with this collisionId across preview + apply).
+    const auditId = this._response.auditId
     await this._runApply('edit', {
       confirmTitle: 'Apply this edit?',
       summary: `Rewrite ${filePath}`,
       successMessage: 'Applied edit — a backup was saved.',
-      call: (confirmed) =>
-        getMcpClient().applyRecommendedEdit({
-          auditId: this._response.auditId,
-          collisionId,
-          confirmed,
-        }),
+      call: (confirmed) => getMcpClient().applyRecommendedEdit({ auditId, collisionId, confirmed }),
     })
   }
 

--- a/packages/vscode-extension/src/views/inventory-audit-panel-html.ts
+++ b/packages/vscode-extension/src/views/inventory-audit-panel-html.ts
@@ -73,10 +73,23 @@ function getStyles(): string {
     button:hover { background-color: var(--vscode-button-hoverBackground); }
     button:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px; }
     .copy-btn { padding: 2px 10px; font-size: 12px; }
+    /* SMI-5325: apply buttons use the secondary treatment so the consequential
+       (file-mutating) action is visually distinct from the benign Copy. */
+    .apply-btn { padding: 2px 10px; font-size: 12px;
+      background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); }
+    .apply-btn:hover { background-color: var(--vscode-button-secondaryHoverBackground); }
+    .edit-actions { margin-top: 8px; }
+    .edit-hint { color: var(--vscode-descriptionForeground); font-size: 0.85em; font-style: italic; }
+    .status-node { color: var(--vscode-descriptionForeground); font-size: 0.9em; margin: 4px 0; min-height: 1.2em; }
+    .status-node:empty { margin: 0; min-height: 0; }
     .actions { display: flex; gap: 8px; margin-top: 24px; }`
 }
 
-/** Inline script: wires Retry, Open-Report, and delegated `.copy-btn` clicks. */
+/**
+ * Inline script: wires Retry, Open-Report, delegated `.copy-btn` / `.apply-btn`
+ * clicks, and — SMI-5325 — moves focus to the status node after a re-render so a
+ * screen-reader user is re-oriented and hears the apply result.
+ */
 function getScript(nonce: string): string {
   return `
   <script nonce="${nonce}">
@@ -95,13 +108,20 @@ function getScript(nonce: string): string {
     }
     document.addEventListener('click', (event) => {
       const target = event.target;
-      if (target && target.classList && target.classList.contains('copy-btn')) {
-        const text = target.dataset ? target.dataset.copy : undefined;
-        if (typeof text === 'string') {
-          vscode.postMessage({ command: 'copyRename', text: text });
-        }
+      if (!target || !target.classList) return;
+      const data = target.dataset || {};
+      if (target.classList.contains('copy-btn') && typeof data.copy === 'string') {
+        vscode.postMessage({ command: 'copyRename', text: data.copy });
+      } else if (target.classList.contains('apply-rename-btn') && typeof data.collision === 'string') {
+        vscode.postMessage({ command: 'applyRename', collisionId: data.collision });
+      } else if (target.classList.contains('apply-edit-btn') && typeof data.collision === 'string') {
+        vscode.postMessage({ command: 'applyEdit', collisionId: data.collision });
       }
     });
+    const statusNode = document.getElementById('statusNode');
+    if (statusNode && statusNode.textContent && statusNode.textContent.trim().length > 0) {
+      statusNode.focus();
+    }
   </script>`
 }
 
@@ -118,12 +138,22 @@ function getActionsHtml(): string {
  * Build the complete Inventory Audit panel HTML. All untrusted fields are
  * escaped (in the section renderers). When there are no flags, a clean-state
  * hero replaces the collision sections.
+ *
+ * SMI-5325 options: `editApplyUnavailable` collapses all Apply-edit buttons to
+ * the manual-review hint (server's `apply_recommended_edit` is unregistered);
+ * `statusMessage` is announced via an `aria-live` status node that the inline
+ * script focuses on load (re-orients a screen-reader user after an apply).
  */
-export function getInventoryAuditHtml(response: McpInventoryAuditResponse, nonce: string): string {
+export function getInventoryAuditHtml(
+  response: McpInventoryAuditResponse,
+  nonce: string,
+  opts: { editApplyUnavailable?: boolean; statusMessage?: string } = {}
+): string {
   const csp = getInventoryAuditCsp(nonce)
   const summary = response.summary
   const totalFlags = Number.isFinite(summary?.totalFlags) ? summary.totalFlags : 0
   const totalEntries = Number.isFinite(summary?.totalEntries) ? summary.totalEntries : 0
+  const statusMessage = typeof opts.statusMessage === 'string' ? opts.statusMessage : ''
 
   const bodyContent =
     totalFlags === 0
@@ -139,7 +169,7 @@ export function getInventoryAuditHtml(response: McpInventoryAuditResponse, nonce
     ${getSemanticSection(response.semanticCollisions)}
     ${getGenericFlagsSection(response.genericFlags)}
     ${getRenameSuggestionsSection(response.renameSuggestions)}
-    ${getRecommendedEditsSection(response.recommendedEdits)}`
+    ${getRecommendedEditsSection(response.recommendedEdits, opts.editApplyUnavailable === true)}`
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -152,6 +182,7 @@ export function getInventoryAuditHtml(response: McpInventoryAuditResponse, nonce
 </head>
 <body>
   <h1>Skill Inventory Audit</h1>
+  <div id="statusNode" class="status-node" role="status" aria-live="polite" tabindex="-1">${escapeHtml(statusMessage)}</div>
   ${bodyContent}
   ${getActionsHtml()}
   ${getScript(nonce)}

--- a/packages/vscode-extension/src/views/inventory-audit-panel-types.ts
+++ b/packages/vscode-extension/src/views/inventory-audit-panel-types.ts
@@ -2,10 +2,10 @@
  * Message types for the Skill Inventory Audit panel (SMI-5318 / #1459).
  *
  * Split out of InventoryAuditPanel.ts / inventory-audit-panel-html.ts so each
- * file stays under the 500-line cap. The inventory-audit webview is read-only;
- * inbound messages are `retry` (re-run the audit), `openReport` (open the
- * formatted report in an editor tab), and `copyRename` (copy a suggested name
- * to the clipboard).
+ * file stays under the 500-line cap. Inbound messages are `retry` (re-run the
+ * audit), `openReport` (open the formatted report in an editor tab), `copyRename`
+ * (copy a suggested name to the clipboard), and — SMI-5325 — `applyRename` /
+ * `applyEdit` (apply a suggested rename / prose edit by `collisionId`).
  */
 
 /**
@@ -15,3 +15,5 @@ export type InventoryAuditPanelMessage =
   | { command: 'retry' }
   | { command: 'openReport' }
   | { command: 'copyRename'; text: string }
+  | { command: 'applyRename'; collisionId: string }
+  | { command: 'applyEdit'; collisionId: string }

--- a/packages/vscode-extension/src/views/inventory-audit-sections-html.ts
+++ b/packages/vscode-extension/src/views/inventory-audit-sections-html.ts
@@ -155,7 +155,12 @@ export function getGenericFlagsSection(items: McpGenericFlag[]): string {
     </section>`
 }
 
-/** Suggested renames — each row carries a copy button reading `data-copy`. */
+/**
+ * Suggested renames — each row carries a Copy button (`data-copy`) and an
+ * "Apply rename…" button (`data-collision`, SMI-5325). The host validates the
+ * `collisionId` against the live response before any apply, and always sends
+ * `action: 'apply'` (the suggested name); custom-name is deferred (SMI-5328).
+ */
 export function getRenameSuggestionsSection(items: McpRenameSuggestion[]): string {
   if (!Array.isArray(items) || items.length === 0) return ''
   const rows = items
@@ -163,6 +168,7 @@ export function getRenameSuggestionsSection(items: McpRenameSuggestion[]): strin
       const currentName = typeof r.currentName === 'string' ? r.currentName : ''
       const suggested = typeof r.suggested === 'string' ? r.suggested : ''
       const reason = typeof r.reason === 'string' ? r.reason : ''
+      const collisionId = typeof r.collisionId === 'string' ? r.collisionId : ''
       return `
       <div class="rename-row">
         <div class="rename-names">
@@ -170,6 +176,7 @@ export function getRenameSuggestionsSection(items: McpRenameSuggestion[]): strin
           <span class="rename-arrow">→</span>
           <span class="rename-suggested">${escapeHtml(suggested)}</span>
           <button class="copy-btn" data-copy="${escapeHtml(suggested)}">Copy</button>
+          <button class="apply-btn apply-rename-btn" data-collision="${escapeHtml(collisionId)}">Apply rename…</button>
         </div>
         ${renderEntryLine(r.entry)}
         <div class="row-reason">${escapeHtml(reason)}</div>
@@ -183,8 +190,18 @@ export function getRenameSuggestionsSection(items: McpRenameSuggestion[]): strin
     </section>`
 }
 
-/** Recommended prose edits — READ-ONLY (before → after + rationale, no apply). */
-export function getRecommendedEditsSection(items: McpRecommendedEdit[]): string {
+/**
+ * Recommended prose edits (SMI-5325). Rows whose `applyMode` is
+ * `'apply_with_confirmation'` carry an "Apply edit…" button (`data-collision`);
+ * `'manual_review'` rows show a muted "Review and apply manually" hint instead,
+ * so the absent button reads as intentional. When `editApplyUnavailable` is true
+ * (the server's `apply_recommended_edit` is unregistered), ALL rows collapse to
+ * the hint.
+ */
+export function getRecommendedEditsSection(
+  items: McpRecommendedEdit[],
+  editApplyUnavailable = false
+): string {
   if (!Array.isArray(items) || items.length === 0) return ''
   const rows = items
     .map((e) => {
@@ -192,6 +209,11 @@ export function getRecommendedEditsSection(items: McpRecommendedEdit[]): string 
       const before = typeof e.before === 'string' ? e.before : ''
       const after = typeof e.after === 'string' ? e.after : ''
       const rationale = typeof e.rationale === 'string' ? e.rationale : ''
+      const collisionId = typeof e.collisionId === 'string' ? e.collisionId : ''
+      const applyable = !editApplyUnavailable && e.applyMode === 'apply_with_confirmation'
+      const action = applyable
+        ? `<button class="apply-btn apply-edit-btn" data-collision="${escapeHtml(collisionId)}">Apply edit…</button>`
+        : `<span class="edit-hint">Review and apply manually</span>`
       return `
       <div class="edit-row">
         <div class="edit-file">${escapeHtml(filePath)}</div>
@@ -200,12 +222,13 @@ export function getRecommendedEditsSection(items: McpRecommendedEdit[]): string 
           <div class="edit-after"><span class="edit-label">After</span><pre>${escapeHtml(after)}</pre></div>
         </div>
         <div class="row-reason">${escapeHtml(rationale)}</div>
+        <div class="edit-actions">${action}</div>
       </div>`
     })
     .join('')
   return `
     <section aria-labelledby="recommended-edits-heading">
-      <h2 id="recommended-edits-heading">Recommended Edits (read-only)</h2>
+      <h2 id="recommended-edits-heading">Recommended Edits</h2>
       ${rows}
     </section>`
 }


### PR DESCRIPTION
## What

Adds interactive **Apply rename…** / **Apply edit…** actions to the (previously read-only) Skill Inventory Audit panel, backed by the ungated `apply_namespace_rename` / `apply_recommended_edit` MCP tools. Closes the deferred apply dimension from PR-D3 (SMI-5318). Host-only (ADR-113).

## Flow (SMI-5213 confirmation gate)

preview (`confirmed:false`) → **native modal confirm** → apply (`confirmed:true`) → re-audit → refresh. The rich before→after diff stays in the panel row; the modal is the deliberate yes/no. Success toast states a backup was saved; an `aria-live` status node announces the result + restores focus after re-render.

## Design

`docs/internal/implementation/2026-06-20-vscode-smi-5325-inventory-apply-design.md` (plan-reviewed by VP Product/Eng/Design — 15 findings folded; owner picked native-modal hybrid).

## Notable decisions

- **Two-layer error model**: the dispatcher wraps results with `okBody`, so `success:false` + `errorCode` arrive *inside* the parsed envelope (handled per-code, incl. self-heal re-audit on `history_/collision_not_found`); only `NotConnected` / registry-empty `UnknownTool` throw `McpToolError`.
- **No tier-denied path** — both apply tools are ungated/Community (verified).
- Edit Apply gated on `applyMode==='apply_with_confirmation'`; `manual_review` rows show a "Review and apply manually" hint. Registry-empty edit tool → `UnknownTool` collapses all edit buttons to the hint.
- `_applyInFlight` re-entrancy guard; user-retry gated during an in-flight apply; `auditId` snapshotted coherently with `collisionId` (governance M-1/M-2).
- `McpClient` singleton helpers shed to `McpClientSingleton.ts` (eval-safe re-export) to stay under the 500-line gate.
- 4 new telemetry ids; coverage count unchanged at 10 (no new registered command).

## Verification

typecheck clean · eslint zero-warnings · **680/680 tests pass** (2 new mcp wrapper suites + a panel-interaction suite) · `package:check` VSIX ok · `audit:standards` 0 failed · every changed file <500.

## Governance

Post-commit review found one Major (retry/apply `_response` race) — fixed in `9d0edd2f` with a regression test. Re-verified clean.

## Deferred follow-ups (filed)

SMI-5328 (custom-name rename), SMI-5329 (MCP-exposed revert + GUI undo — cross-package), SMI-5330 (widen telemetry allowlist).

Ships in **0.6.2**. Linear: SMI-5325.

[skip-smoke]