### PR TITLE
feat(mcp,website): surface license to consumers (SMI-5327)

### DIFF
--- a/packages/core/src/api/client.types.ts
+++ b/packages/core/src/api/client.types.ts
@@ -73,6 +73,11 @@ export interface ApiSearchResult {
   last_scanned_at?: string | null
   /** SMI-4240: Security findings array (jsonb); length drives findingsCount */
   security_findings?: unknown[] | null
+  /**
+   * SMI-5327: SPDX license identifier surfaced by skills-get / skills-search.
+   * Null means "unknown / not detected" — NOT public domain or "no restrictions".
+   */
+  license?: string | null
 }
 
 /**

--- a/packages/core/src/api/schemas.license.test.ts
+++ b/packages/core/src/api/schemas.license.test.ts
@@ -1,0 +1,54 @@
+/**
+ * SMI-5327: regression guard for the Zod strip boundary.
+ *
+ * ApiSearchResultSchema is a `z.object` (strip-by-default). `license` is surfaced
+ * by skills-get / skills-search (SMI-5320) but is silently dropped before the MCP
+ * `search` / `get_skill` tools can read it unless declared in the schema — which
+ * would make the license display a permanent "Unknown". This test fails the moment
+ * `license` is removed from the schema. Mirrors schemas.compatibility.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { ApiSearchResultSchema } from './schemas.js'
+
+describe('ApiSearchResultSchema — license passthrough (SMI-5327)', () => {
+  it('retains an SPDX license string through parse (not stripped)', () => {
+    const parsed = ApiSearchResultSchema.parse({
+      id: 'acme/skill',
+      name: 'skill',
+      description: 'desc',
+      author: 'acme',
+      quality_score: 0.9,
+      trust_tier: 'verified',
+      tags: ['testing'],
+      license: 'MIT',
+    })
+    expect(parsed.license).toBe('MIT')
+  })
+
+  it('retains an explicit null license through parse (null = unknown, not dropped)', () => {
+    const parsed = ApiSearchResultSchema.parse({
+      id: 'acme/skill',
+      name: 'skill',
+      description: 'desc',
+      author: 'acme',
+      quality_score: 0.9,
+      trust_tier: 'verified',
+      tags: ['testing'],
+      license: null,
+    })
+    expect(parsed.license).toBeNull()
+  })
+
+  it('is optional — absent license parses without error', () => {
+    const parsed = ApiSearchResultSchema.parse({
+      id: 'acme/skill',
+      name: 'skill',
+      description: null,
+      author: null,
+      quality_score: null,
+      tags: [],
+    })
+    expect(parsed.license).toBeUndefined()
+  })
+})

--- a/packages/core/src/api/schemas.ts
+++ b/packages/core/src/api/schemas.ts
@@ -59,6 +59,10 @@ export const ApiSearchResultSchema = z.object({
   last_scanned_at: z.string().nullable().optional(),
   security_findings: z.array(z.unknown()).nullable().optional(),
   quarantined: z.boolean().optional(),
+  // SMI-5327: SPDX license surfaced by skills-get / skills-search. Declared here
+  // so Zod does not strip the field before get-skill.ts / search.ts read it
+  // (same reason as compatibility above). skills-search may omit it → optional.
+  license: z.string().nullable().optional(),
 })
 
 // ============================================================================

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -104,6 +104,12 @@ export interface ApiSkill {
   security_findings?: unknown[] | null
   /** True when the skill is quarantined due to security score threshold */
   quarantined?: boolean
+  /**
+   * SMI-5327: SPDX license identifier returned by skills-get / skills-search
+   * (e.g. "MIT", "Apache-2.0"). Null means "unknown / not detected" — NOT
+   * "no restrictions" or "freely usable".
+   */
+  license?: string | null
 }
 
 // ============================================================================

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -101,6 +101,11 @@ export interface Skill {
   security?: SecuritySummary
   createdAt: string
   updatedAt: string
+  /**
+   * SMI-5327: SPDX license identifier (e.g. "MIT", "Apache-2.0"). Null means
+   * "unknown / not detected" — NOT "no restrictions" or "freely usable".
+   */
+  license?: string | null
 }
 
 /**
@@ -135,6 +140,11 @@ export interface SkillSearchResult {
   installHint?: string
   /** SMI-2760: Flat array of compatible IDE/LLM/platform slugs (e.g. ["claude-code", "cursor", "claude"]) */
   compatibility?: string[]
+  /**
+   * SMI-5327: SPDX license identifier (e.g. "MIT", "Apache-2.0"). Null means
+   * "unknown / not detected" — NOT "no restrictions" or "freely usable".
+   */
+  license?: string | null
 }
 
 /**

--- a/packages/mcp-server/src/__tests__/get-skill.test.ts
+++ b/packages/mcp-server/src/__tests__/get-skill.test.ts
@@ -421,3 +421,59 @@ describe('formatSkillDetails branch coverage', () => {
     expect(formatted).not.toContain('Tags:')
   })
 })
+
+/**
+ * SMI-5327: formatSkillDetails license display
+ * Null license must render as "unknown", not imply any permissive conclusion.
+ */
+describe('formatSkillDetails — license display (SMI-5327)', () => {
+  const baseSkill = {
+    id: 'test/skill',
+    name: 'test-skill',
+    description: 'A test skill',
+    author: 'test',
+    category: 'development' as const,
+    trustTier: 'community' as const,
+    score: 80,
+    tags: [] as string[],
+    installCommand: 'claude skill add test/skill',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  }
+  const baseResponse = (license?: string | null) => ({
+    skill: { ...baseSkill, license },
+    installCommand: 'claude skill add test/skill',
+    timing: { totalMs: 10 },
+  })
+
+  it('renders "License: MIT" verbatim for an MIT-licensed skill', () => {
+    const formatted = formatSkillDetails(baseResponse('MIT'))
+    expect(formatted).toContain('License: MIT')
+    expect(formatted).not.toContain('License: Unknown')
+  })
+
+  it('renders "License: Apache-2.0" verbatim', () => {
+    const formatted = formatSkillDetails(baseResponse('Apache-2.0'))
+    expect(formatted).toContain('License: Apache-2.0')
+  })
+
+  it('renders "License: Unknown" when license is null', () => {
+    const formatted = formatSkillDetails(baseResponse(null))
+    expect(formatted).toContain('License: Unknown')
+    // Must not imply any permissive conclusion for a null license
+    expect(formatted).not.toContain('no license')
+    expect(formatted).not.toContain('unrestricted')
+    expect(formatted).not.toContain('freely usable')
+    expect(formatted).not.toContain('public domain')
+  })
+
+  it('renders "License: Unknown" when license field is absent', () => {
+    const formatted = formatSkillDetails(baseResponse(undefined))
+    expect(formatted).toContain('License: Unknown')
+  })
+
+  it('renders "License: Unknown" when license is an empty string', () => {
+    const formatted = formatSkillDetails(baseResponse(''))
+    expect(formatted).toContain('License: Unknown')
+  })
+})

--- a/packages/mcp-server/src/__tests__/get-skill.test.ts
+++ b/packages/mcp-server/src/__tests__/get-skill.test.ts
@@ -476,4 +476,9 @@ describe('formatSkillDetails — license display (SMI-5327)', () => {
     const formatted = formatSkillDetails(baseResponse(''))
     expect(formatted).toContain('License: Unknown')
   })
+
+  it('renders "License: Unknown" when license is whitespace-only', () => {
+    const formatted = formatSkillDetails(baseResponse('   '))
+    expect(formatted).toContain('License: Unknown')
+  })
 })

--- a/packages/mcp-server/src/tools/get-skill.ts
+++ b/packages/mcp-server/src/tools/get-skill.ts
@@ -186,6 +186,8 @@ async function executeGetSkillImpl(
         // SMI-1577: Handle optional date fields with sentinel value
         createdAt: apiSkill.created_at ?? '1970-01-01T00:00:00.000Z',
         updatedAt: apiSkill.updated_at ?? '1970-01-01T00:00:00.000Z',
+        // SMI-5327: SPDX license from the API. Null means "unknown / not detected".
+        license: apiSkill.license ?? null,
       }
 
       const endTime = performance.now()
@@ -369,6 +371,9 @@ export function formatSkillDetails(response: GetSkillResponse): string {
   if (skill.repository) {
     lines.push('Repository: ' + skill.repository)
   }
+
+  // SMI-5327: License — null / whitespace-only means "unknown / not detected", NOT "no license".
+  lines.push('License: ' + (skill.license?.trim() || 'Unknown'))
 
   // Tags
   if (skill.tags && skill.tags.length > 0) {

--- a/packages/mcp-server/src/tools/search.formatter.test.ts
+++ b/packages/mcp-server/src/tools/search.formatter.test.ts
@@ -2,6 +2,8 @@
  * SMI-5178: formatter coverage for the compatibility-hidden notice.
  * Asserts the "+ N more skill(s) hidden" line appears only when
  * compatibilityHidden > 0 (the restrictive cross-tool default / explicit filter).
+ *
+ * SMI-5327: license display in search results.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -80,5 +82,79 @@ describe('formatSearchResults — discovery-only hidden notice (SMI-5178)', () =
   it('zero-result branch mentions installable_only: false as a suggestion', () => {
     const out = formatSearchResults(baseResponse({ results: [], total: 0, discoveryOnlyHidden: 0 }))
     expect(out).toContain('installable_only: false')
+  })
+})
+
+describe('formatSearchResults — license display (SMI-5327)', () => {
+  it('renders the SPDX identifier verbatim when license is "MIT"', () => {
+    const out = formatSearchResults(
+      baseResponse({
+        results: [
+          {
+            id: 'acme/skill',
+            name: 'skill',
+            description: 'a skill',
+            author: 'acme',
+            category: 'development',
+            trustTier: 'community',
+            score: 80,
+            license: 'MIT',
+          },
+        ],
+      })
+    )
+    expect(out).toContain('License: MIT')
+    expect(out).not.toContain('License: Unknown')
+  })
+
+  it('renders "License: Unknown" when license is null', () => {
+    const out = formatSearchResults(
+      baseResponse({
+        results: [
+          {
+            id: 'acme/skill',
+            name: 'skill',
+            description: 'a skill',
+            author: 'acme',
+            category: 'development',
+            trustTier: 'community',
+            score: 80,
+            license: null,
+          },
+        ],
+      })
+    )
+    expect(out).toContain('License: Unknown')
+    // Must NOT imply any permissive conclusion for a null license
+    expect(out).not.toContain('no license')
+    expect(out).not.toContain('unrestricted')
+    expect(out).not.toContain('freely usable')
+    expect(out).not.toContain('public domain')
+  })
+
+  it('renders "License: Unknown" when license field is absent', () => {
+    // baseResponse skill has no license field — same as undefined
+    const out = formatSearchResults(baseResponse())
+    expect(out).toContain('License: Unknown')
+  })
+
+  it('renders "License: Unknown" when license is an empty string', () => {
+    const out = formatSearchResults(
+      baseResponse({
+        results: [
+          {
+            id: 'acme/skill',
+            name: 'skill',
+            description: 'a skill',
+            author: 'acme',
+            category: 'development',
+            trustTier: 'community',
+            score: 80,
+            license: '',
+          },
+        ],
+      })
+    )
+    expect(out).toContain('License: Unknown')
   })
 })

--- a/packages/mcp-server/src/tools/search.formatter.test.ts
+++ b/packages/mcp-server/src/tools/search.formatter.test.ts
@@ -157,4 +157,24 @@ describe('formatSearchResults — license display (SMI-5327)', () => {
     )
     expect(out).toContain('License: Unknown')
   })
+
+  it('renders "License: Unknown" when license is whitespace-only', () => {
+    const out = formatSearchResults(
+      baseResponse({
+        results: [
+          {
+            id: 'acme/skill',
+            name: 'skill',
+            description: 'a skill',
+            author: 'acme',
+            category: 'development',
+            trustTier: 'community',
+            score: 80,
+            license: '   ',
+          },
+        ],
+      })
+    )
+    expect(out).toContain('License: Unknown')
+  })
 })

--- a/packages/mcp-server/src/tools/search.formatter.ts
+++ b/packages/mcp-server/src/tools/search.formatter.ts
@@ -67,6 +67,10 @@ export function formatSearchResults(response: SearchResponse): string {
       )
       lines.push('   ' + skill.description)
       lines.push('   ID: ' + skill.id)
+      // SMI-5327: surface license so consumers can evaluate usage terms.
+      // null / undefined / whitespace-only means the license was not detected —
+      // render "Unknown" (NOT "no license", "unrestricted", or "freely usable").
+      lines.push('   License: ' + (skill.license?.trim() || 'Unknown'))
       // SMI-4954: flag discovery-only entries so models don't try to install them
       if (skill.installable === false) {
         lines.push('   Installable: NO — discovery-only (install_skill cannot resolve this)')

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -288,6 +288,8 @@ async function executeSearchImpl(
         // ApiResponse<T> at this call site (CI typecheck confirms), so it is read
         // via a cast — the value is present at runtime.
         compatibility: (item as unknown as { compatibility?: string[] }).compatibility,
+        // SMI-5327: SPDX license from the edge function response.
+        license: item.license ?? null,
       }))
 
       // SMI-1809: Search local skills and merge with API results

--- a/packages/website/src/lib/license-label.test.ts
+++ b/packages/website/src/lib/license-label.test.ts
@@ -1,0 +1,72 @@
+/**
+ * SMI-5327: Unit tests for the licenseLabel helper.
+ *
+ * The website renders license in two places that use identical logic:
+ *   1. Skill card (createLicenseBadge in skills/index.astro inline script)
+ *   2. Skill detail page (renderSkill in skills/[id].astro inline script)
+ *
+ * Both sites are is:inline Astro scripts with no component-test harness.
+ * The label logic is extracted here so it can be covered without a browser.
+ *
+ * CONTRACT: null / undefined / empty => "Unknown" (NOT "no license",
+ * "unrestricted", "freely usable", or "public domain").
+ */
+
+import { describe, it, expect } from 'vitest'
+import { licenseLabel } from './license-label'
+
+describe('licenseLabel — known SPDX identifiers render verbatim', () => {
+  it('returns "MIT" for "MIT"', () => {
+    expect(licenseLabel('MIT')).toBe('MIT')
+  })
+
+  it('returns "Apache-2.0" for "Apache-2.0"', () => {
+    expect(licenseLabel('Apache-2.0')).toBe('Apache-2.0')
+  })
+
+  it('returns "GPL-3.0" for "GPL-3.0"', () => {
+    expect(licenseLabel('GPL-3.0')).toBe('GPL-3.0')
+  })
+
+  it('returns "CC-BY-4.0" for "CC-BY-4.0"', () => {
+    expect(licenseLabel('CC-BY-4.0')).toBe('CC-BY-4.0')
+  })
+
+  it('returns "Unlicense" for "Unlicense"', () => {
+    expect(licenseLabel('Unlicense')).toBe('Unlicense')
+  })
+})
+
+describe('licenseLabel — null / missing license renders as "Unknown"', () => {
+  it('returns "Unknown" for null', () => {
+    expect(licenseLabel(null)).toBe('Unknown')
+  })
+
+  it('returns "Unknown" for undefined', () => {
+    expect(licenseLabel(undefined)).toBe('Unknown')
+  })
+
+  it('returns "Unknown" for empty string', () => {
+    expect(licenseLabel('')).toBe('Unknown')
+  })
+
+  it('returns "Unknown" for whitespace-only string', () => {
+    expect(licenseLabel('   ')).toBe('Unknown')
+  })
+
+  it('does not return "no license" for null', () => {
+    expect(licenseLabel(null)).not.toBe('no license')
+  })
+
+  it('does not return "unrestricted" for null', () => {
+    expect(licenseLabel(null)).not.toBe('unrestricted')
+  })
+
+  it('does not return "freely usable" for null', () => {
+    expect(licenseLabel(null)).not.toBe('freely usable')
+  })
+
+  it('does not return "public domain" for null', () => {
+    expect(licenseLabel(null)).not.toBe('public domain')
+  })
+})

--- a/packages/website/src/lib/license-label.ts
+++ b/packages/website/src/lib/license-label.ts
@@ -1,0 +1,28 @@
+/**
+ * SMI-5327: License label helper for consistent rendering across surfaces.
+ *
+ * A null / undefined / empty SPDX identifier means "unknown / not detected".
+ * Consumers MUST NOT infer "no restrictions", "freely usable", or
+ * "public domain" from a null license — the database simply has no data.
+ *
+ * Real SPDX identifiers ("MIT", "Apache-2.0", "GPL-3.0", etc.) are rendered
+ * verbatim. The label is also used for the `aria-label` on the badge element.
+ */
+
+/**
+ * Return the display label for a SPDX license value.
+ *
+ * @param license - SPDX identifier from the API, or null/undefined when unknown
+ * @returns "MIT" | "Apache-2.0" | … verbatim, or "Unknown" for null/undefined/empty
+ *
+ * @example
+ * licenseLabel('MIT')       // => 'MIT'
+ * licenseLabel('Apache-2.0') // => 'Apache-2.0'
+ * licenseLabel(null)        // => 'Unknown'
+ * licenseLabel(undefined)   // => 'Unknown'
+ * licenseLabel('')          // => 'Unknown'
+ */
+export function licenseLabel(license: string | null | undefined): string {
+  const trimmed = license?.trim()
+  return trimmed ? trimmed : 'Unknown'
+}

--- a/packages/website/src/pages/skills/[id].astro
+++ b/packages/website/src/pages/skills/[id].astro
@@ -532,6 +532,10 @@ const categoryJsonLd =
                   <dt class="text-dark-500">Last Updated</dt>
                   <dd id="skill-updated" class="text-dark-300" />
                 </div>
+                <div id="license-row" class="flex justify-between hidden">
+                  <dt class="text-dark-500">License</dt>
+                  <dd id="skill-license" class="text-dark-300" />
+                </div>
               </dl>
             </div>
 
@@ -733,6 +737,11 @@ const categoryJsonLd =
         document.getElementById('updated-row').classList.remove('hidden')
         document.getElementById('skill-updated').textContent = formatDate(skill.updated_at)
       }
+      // SMI-5327: License — null / absent / whitespace-only means "unknown / not detected".
+      // NEVER render null as "no license", "unrestricted", or "freely usable".
+      // MIRRORS licenseLabel() in src/lib/license-label.ts (SMI-5327) — keep in sync; is:inline cannot import.
+      document.getElementById('license-row').classList.remove('hidden')
+      document.getElementById('skill-license').textContent = skill.license?.trim() || 'Unknown'
 
       // Tags
       const tagsContainer = document.getElementById('skill-tags')

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -575,8 +575,25 @@ const isCrawler = isCrawlerUserAgent(userAgent)
               : ''
           }
           ${createCompatibilityBadges(skill.compatibility)}
+          ${createLicenseBadge(skill.license)}
         </a>
       `
+      }
+
+      // SMI-5327: License badge. Null / absent / whitespace-only means "unknown / not detected" —
+      // render as "License: Unknown". NEVER imply "no restrictions" or "freely usable".
+      // MIRRORS licenseLabel() in src/lib/license-label.ts (SMI-5327) — keep in sync; is:inline cannot import.
+      function createLicenseBadge(license) {
+        const trimmed = license?.trim()
+        const label = trimmed ? escapeHtml(trimmed) : 'Unknown'
+        return `<div class="mt-2">
+          <span class="inline-flex items-center gap-1 text-xs text-dark-500" aria-label="License: ${label}">
+            <svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+            </svg>
+            <span>License: <span class="font-medium">${label}</span></span>
+          </span>
+        </div>`
       }
 
       // SMI-5178: display labels for compatibility slugs. MIRRORS the canonical

--- a/packages/website/src/types/index.ts
+++ b/packages/website/src/types/index.ts
@@ -50,6 +50,11 @@ export interface Skill {
   downloadCount: number
   createdAt: string
   updatedAt: string
+  /**
+   * SMI-5327: SPDX license identifier (e.g. "MIT", "Apache-2.0"). Null means
+   * "unknown / not detected" — NOT "no restrictions" or "freely usable".
+   */
+  license?: string | null
 }
 
 /**


### PR DESCRIPTION
## What

Surfaces the already-returned `license` SPDX field to consumers — the display fast-follow to **SMI-5320** (the API change shipped in #1514). Display-only; no data path changes.

## Surfaces (4 render paths)

- MCP `search` results + `get_skill` detail — `License: <SPDX>` / `License: Unknown`
- Website skill **cards** + skill **detail** page — license badge

## Null semantic (load-bearing)

`null` / empty / whitespace SPDX renders **"Unknown"** on all four paths — never "no license", "unrestricted", "freely usable", or "public domain". Canonical title-case "Unknown" is enforced; `packages/website/src/lib/license-label.ts` is the tested spec the two `is:inline` Astro mirrors follow (`license?.trim() || 'Unknown'`).

## Tests

MCP formatter + `get_skill` suites (incl. empty-string + null), website `license-label` helper (13). An independent governance review returned CHANGES-REQUIRED (casing inconsistency, whitespace handling, skeleton-flash, empty-string coverage); all findings resolved before this commit.

## Note

Every existing skill card reads "License: Unknown" until the indexer populates `skills.license` — the correct semantic (null = unknown), not "unencumbered".

> Worktree CI note: a local worktree `tsc` shows a false `license`-missing error because the worktree's shared `node_modules/@skillsmith/core` resolves to main's `packages/core`; a clean CI checkout resolves the branch's own core. Source types are correct.

Closes SMI-5327.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
