### PR TITLE
fix(mcp,core): split search.ts under 500 + thread license through local-DB path (SMI-5337)

### DIFF
--- a/packages/core/src/services/SearchService.helpers.ts
+++ b/packages/core/src/services/SearchService.helpers.ts
@@ -88,6 +88,8 @@ export function rowToSkill(row: FTSRow): Skill {
       row.compatibility && row.compatibility !== '[]'
         ? (JSON.parse(row.compatibility) as string[])
         : undefined,
+    // SMI-5327: SPDX license (null = unknown / not detected)
+    license: row.license ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }

--- a/packages/core/src/services/SearchService.types.ts
+++ b/packages/core/src/services/SearchService.types.ts
@@ -27,6 +27,8 @@ export interface FTSRow {
   security_passed: number | null // SQLite uses 0/1 for boolean
   // SMI-2760: Compatibility JSON array
   compatibility: string | null
+  // SMI-5327: SPDX license identifier (null = unknown / not detected)
+  license: string | null
   created_at: string
   updated_at: string
   rank: number

--- a/packages/core/src/types/skill.ts
+++ b/packages/core/src/types/skill.ts
@@ -82,6 +82,11 @@ export interface Skill {
    * `SkillRepository.rowToSkill()` always populates it from the DB.
    */
   source?: SkillSource
+  /**
+   * SMI-5327: SPDX license identifier (e.g. "MIT", "Apache-2.0"). Null means
+   * "unknown / not detected" — NOT "no restrictions" or "freely usable".
+   */
+  license?: string | null
   createdAt: string
   updatedAt: string
   // SMI-skill-version-tracking Wave 1: version tracking fields

--- a/packages/mcp-server/src/tools/search.helpers.ts
+++ b/packages/mcp-server/src/tools/search.helpers.ts
@@ -12,7 +12,9 @@ import {
   type SkillSearchResult,
   type CompatibilityFilter,
   CLIENT_TO_COMPATIBILITY_SLUG,
+  type SearchResult,
 } from '@skillsmith/core'
+import { extractCategoryFromTags, mapTrustTierFromDb } from '../utils/validation.js'
 
 /**
  * SMI-2760: Filter search results by compatibility tags.
@@ -69,4 +71,49 @@ export function resolveDefaultCompatibility(
   const slug = CLIENT_TO_COMPATIBILITY_SLUG[client]
   if (!slug) return undefined
   return { ides: [slug] }
+}
+
+/**
+ * SMI-5337 retro: Map a local SearchService result item to the SkillSearchResult
+ * wire format used by the MCP search tool.
+ *
+ * Extracted from search.ts to keep that file under the 500-line governance limit.
+ * Mirrors the API-path mapping in executeSearchImpl with parity on all fields
+ * including the SMI-5327 license field.
+ *
+ * SMI-1491: repository field for installation source transparency.
+ * SMI-825:  security summary.
+ * SMI-2734: installHint guarded on real registry owner (not 'unknown').
+ * SMI-2760: compatibility tags.
+ * SMI-5327: SPDX license parity with the API path.
+ */
+export function mapLocalSkillToSearchResult(item: SearchResult): SkillSearchResult {
+  return {
+    id: item.skill.id,
+    name: item.skill.name,
+    description: item.skill.description || '',
+    author: item.skill.author || 'unknown',
+    category: extractCategoryFromTags(item.skill.tags),
+    trustTier: mapTrustTierFromDb(item.skill.trustTier),
+    score: Math.round((item.skill.qualityScore ?? 0) * 100), // Convert 0-1 to 0-100
+    repository: item.skill.repoUrl || undefined,
+    // SMI-4954: installable when the local DB row carries a repoUrl
+    installable: Boolean(item.skill.repoUrl),
+    // SMI-2734: Only set installHint when author is a real registry owner (not 'unknown')
+    installHint:
+      item.skill.author && item.skill.author !== 'unknown'
+        ? item.skill.author + '/' + item.skill.name
+        : undefined,
+    // SMI-825: Security summary
+    security: {
+      passed: item.skill.securityPassed,
+      riskScore: item.skill.riskScore,
+      findingsCount: item.skill.securityFindingsCount,
+      scannedAt: item.skill.securityScannedAt,
+    },
+    // SMI-2760: Compatibility tags
+    compatibility: item.skill.compatibility,
+    // SMI-5327: SPDX license — parity with API path's `item.license ?? null`
+    license: item.skill.license ?? null,
+  }
 }

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -29,6 +29,7 @@ import { searchLocalSkills } from './LocalSkillSearch.js'
 import {
   filterByCompatibility,
   filterInstallable,
+  mapLocalSkillToSearchResult,
   resolveDefaultCompatibility,
 } from './search.helpers.js'
 export { formatSearchResults } from './search.formatter.js'
@@ -390,38 +391,10 @@ async function executeSearchImpl(
 
   const searchEnd = performance.now()
 
-  // Convert SearchResult to SkillSearchResult format
-  // SMI-1491: Added repository field for transparency
-  // SMI-825: Added security summary
-  // SMI-2734: installHint intentionally omitted — local DB results are registry skills fetched
-  // via the local cache. However the local DB also holds skills without a routable registry
-  // owner (e.g. seed data with author='unknown'). Guard on author being a real value.
-  const results: SkillSearchResult[] = searchResults.items.map((item) => ({
-    id: item.skill.id,
-    name: item.skill.name,
-    description: item.skill.description || '',
-    author: item.skill.author || 'unknown',
-    category: extractCategoryFromTags(item.skill.tags),
-    trustTier: mapTrustTierFromDb(item.skill.trustTier),
-    score: Math.round((item.skill.qualityScore ?? 0) * 100), // Convert 0-1 to 0-100
-    repository: item.skill.repoUrl || undefined,
-    // SMI-4954: installable when the local DB row carries a repoUrl
-    installable: Boolean(item.skill.repoUrl),
-    // SMI-2734: Only set installHint when author is a real registry owner (not 'unknown')
-    installHint:
-      item.skill.author && item.skill.author !== 'unknown'
-        ? item.skill.author + '/' + item.skill.name
-        : undefined,
-    // SMI-825: Security summary
-    security: {
-      passed: item.skill.securityPassed,
-      riskScore: item.skill.riskScore,
-      findingsCount: item.skill.securityFindingsCount,
-      scannedAt: item.skill.securityScannedAt,
-    },
-    // SMI-2760: Compatibility tags
-    compatibility: item.skill.compatibility,
-  }))
+  // Convert SearchResult to SkillSearchResult format.
+  // SMI-5337 retro: mapping extracted to mapLocalSkillToSearchResult in search.helpers.ts
+  // to keep search.ts under the 500-line governance limit and to add SMI-5327 license parity.
+  const results: SkillSearchResult[] = searchResults.items.map(mapLocalSkillToSearchResult)
 
   // SMI-1809: Search local skills and merge with local DB results
   // Skip local search if trust_tier filter excludes local skills

--- a/packages/website/src/lib/license-label.parity.test.ts
+++ b/packages/website/src/lib/license-label.parity.test.ts
@@ -1,0 +1,48 @@
+/**
+ * SMI-5337 retro: Parity guard for the licenseLabel() helper vs the two
+ * is:inline Astro badge sites that cannot import it at runtime.
+ *
+ * Both inline sites mirror the same logic:
+ *   skills/index.astro   — createLicenseBadge(license)
+ *   skills/[id].astro    — skill.license?.trim() || 'Unknown'
+ *
+ * This test exists to catch any drift between the extracted helper and the
+ * inline duplicates. When a badge site changes its null-handling, this test
+ * must be updated FIRST so the helper stays the authoritative source.
+ *
+ * CONTRACT (all three implementations agree):
+ *   licenseLabel('MIT')   === 'MIT'
+ *   licenseLabel(null)    === 'Unknown'
+ *   licenseLabel(undefined) === 'Unknown'
+ *   licenseLabel('')      === 'Unknown'
+ *   licenseLabel('   ')   === 'Unknown'
+ */
+
+import { describe, it, expect } from 'vitest'
+import { licenseLabel } from './license-label'
+
+describe('licenseLabel — parity with is:inline Astro badge sites (SMI-5337)', () => {
+  // skills/index.astro createLicenseBadge: `const label = trimmed ? escapeHtml(trimmed) : 'Unknown'`
+  // skills/[id].astro renderSkill:         `skill.license?.trim() || 'Unknown'`
+  // licenseLabel():                        `const trimmed = license?.trim(); return trimmed ? trimmed : 'Unknown'`
+
+  it('MIT renders as "MIT" (non-null verbatim passthrough)', () => {
+    expect(licenseLabel('MIT')).toBe('MIT')
+  })
+
+  it('null → "Unknown" (missing license, not "freely usable")', () => {
+    expect(licenseLabel(null)).toBe('Unknown')
+  })
+
+  it('undefined → "Unknown" (absent license field)', () => {
+    expect(licenseLabel(undefined)).toBe('Unknown')
+  })
+
+  it('"" → "Unknown" (empty string, same as null semantics)', () => {
+    expect(licenseLabel('')).toBe('Unknown')
+  })
+
+  it('"   " → "Unknown" (whitespace-only, [id].astro .trim() || "Unknown" path)', () => {
+    expect(licenseLabel('   ')).toBe('Unknown')
+  })
+})


### PR DESCRIPTION
Post-merge governance retro follow-ups for SMI-5327 (#1518).

- **HIGH** — `search.ts` was 501 lines (1 over the hard gate); extracted the local-skill→result mapping into `search.helpers.ts` `mapLocalSkillToSearchResult()` → **474**.
- **MED** — threaded `license` through the local-DB path: `core/src/types/skill.ts` `Skill`, `SearchService` `FTSRow` + `rowToSkill`, and the extracted mapping (`license: item.skill.license ?? null`) — the offline/fallback path now matches the API path.
- **LOW** — `license-label.parity.test.ts` guards the two `is:inline` Astro badge MIRRORS against `licenseLabel()`.

Verified locally: `@skillsmith/core` builds standalone clean; both files <500; website tests pass. Closes SMI-5337.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)