### PR TITLE
chore(release): weekly cadence bump — 2026-06-21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3931,26 +3931,6 @@
         "@ruvector/ruvllm-win32-x64-msvc": "2.3.0"
       }
     },
-    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-arm64-gnu": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-x64-gnu": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-win32-x64-msvc": {
-      "dev": true,
-      "optional": true
-    },
     "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5668,26 +5648,6 @@
         "@ruvector/ruvllm-linux-x64-gnu": "2.3.0",
         "@ruvector/ruvllm-win32-x64-msvc": "2.3.0"
       }
-    },
-    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-arm64-gnu": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-x64-gnu": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-win32-x64-msvc": {
-      "dev": true,
-      "optional": true
     },
     "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/chalk": {
       "version": "4.1.2",
@@ -29265,12 +29225,12 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@skillsmith/core": "^0.8.0",
-        "@skillsmith/mcp-server": "^0.5.3",
+        "@skillsmith/core": "^0.8.1",
+        "@skillsmith/mcp-server": "^0.5.4",
         "chalk": "5.6.2",
         "chokidar": "4.0.3",
         "cli-table3": "0.6.5",
@@ -29301,9 +29261,6 @@
           "optional": true
         }
       }
-    },
-    "packages/cli/node_modules/@isaacs/keytar": {
-      "optional": true
     },
     "packages/cli/node_modules/cli-spinners": {
       "version": "3.4.0",
@@ -29381,7 +29338,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -29509,18 +29466,18 @@
     },
     "packages/enterprise": {
       "name": "@smith-horn/enterprise",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-        "@skillsmith/core": "^0.8.0",
+        "@skillsmith/core": "^0.8.1",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "*",
+        "@skillsmith/mcp-server": "^0.5.4",
         "@smithy/config-resolver": "4.4.13",
         "@smithy/core": "3.23.12",
         "@smithy/middleware-endpoint": "4.4.27",
@@ -29535,7 +29492,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "*"
+        "@skillsmith/mcp-server": "^0.5.4"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -29659,11 +29616,11 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.8.0",
+        "@skillsmith/core": "^0.8.1",
         "ulid": "3.0.1"
       },
       "bin": {
@@ -29712,7 +29669,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.6.4
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.6.3).
+
 ## v0.6.3
 
 - **Refactor**: SMI-5036 split oversized billing test files (#1282)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.8.0",
-    "@skillsmith/mcp-server": "^0.5.3",
+    "@skillsmith/core": "^0.8.1",
+    "@skillsmith/mcp-server": "^0.5.4",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",
     "cli-table3": "0.6.5",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.8.1
+
+- **Fix**: split search.ts under 500 + thread license through the local-DB path (SMI-5337) (#1521)
+- **Feature**: surface license to consumers (SMI-5327) (#1518)
+
 ## v0.8.0
 
 - **Feature**: SMI-5039 — new `./embeddings/probe` subpath export. Extracts the

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.8.0'
+export const VERSION = '0.8.1'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+## v0.2.1
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.2.0).
+
 ## [0.2.0] — 2026-06-02
 
 ### Added

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smith-horn/enterprise",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Enterprise features for Skillsmith including audit logging, SSO, and RBAC",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-    "@skillsmith/core": "^0.8.0",
+    "@skillsmith/core": "^0.8.1",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "*",
+    "@skillsmith/mcp-server": "^0.5.4",
     "@smithy/config-resolver": "4.4.13",
     "@smithy/core": "3.23.12",
     "@smithy/middleware-endpoint": "4.4.27",
@@ -62,7 +62,7 @@
     "vitest": "4.1.6"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "*"
+    "@skillsmith/mcp-server": "^0.5.4"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.5.4
+
+- **Fix**: split search.ts under 500 + thread license through the local-DB path (SMI-5337) (#1521)
+- **Feature**: surface license to consumers (SMI-5327) (#1518)
 - **Feature**: SMI-5178 — `search` and `skill_recommend` MCP tools now default to
   installable-only results. Discovery-only entries (no `repo_url`, cannot be resolved
   by `install_skill`) are hidden by default (~71% of the registry). Pass

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.8.0",
+    "@skillsmith/core": "^0.8.1",
     "ulid": "3.0.1"
   },
   "devDependencies": {

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.5.3",
+  "version": "0.5.4",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -92,7 +92,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.5.3'
+const PACKAGE_VERSION = '0.5.4'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## v0.6.3
+
+- **Feature**: interactive apply for inventory audit (SMI-5325) (#1515)
+- **Feature**: native "View full text diff" action for the update advisor (SMI-5323) (#1509)
+- **Feature**: SkillNotFound error code + inventory-audit deep opt-in (SMI-5322, SMI-5326) (#1508)
+- **Feature**: Audit Skill Inventory command + webview report (SMI-5318) (#1505)
+- **Feature**: security advisories + finding count in skill detail panel (SMI-5317) (#1504)
+- **Feature**: MCP-powered commands — recommend, compare, update-check (SMI-5314/5315/5316) (#1503)
+
 ## [0.6.2] - 2026-06-20
 
 ### Added

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Discover and install agent skills directly in VS Code",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
Automated weekly release cadence PR opened by `release-cadence.yml` (SMI-4191).

## What this PR does

Runs `scripts/prepare-release.ts --all=patch` to bump all packages by one patch version and drain per-package CHANGELOG `[Unreleased]` sections into the new versions.

## What to check before merging

1. The bumped versions match what you want to ship (patch/minor/major). If minor or major is needed, close this PR, run `prepare-release.ts` with the right flags locally, and open a manual PR.
2. The CHANGELOG entries read cleanly and reference the right Linear issues.
3. CI is green.

## After merging

Trigger publish: `gh workflow run publish.yml -f dry_run=false`. The `create-gh-release` job will create matching GitHub Releases automatically.

Parent: SMI-4144. See [ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md).