### PR TITLE
feat(vscode): tree-context compare + diff entry points with nightly E2E (SMI-5340)

### DIFF
--- a/packages/vscode-extension/e2e/fixtures/fake-mcp-server.mjs
+++ b/packages/vscode-extension/e2e/fixtures/fake-mcp-server.mjs
@@ -54,6 +54,103 @@ function send(obj) {
 }
 
 // --- canned domain payloads (shapes mirror src/mcp/types.ts) ----------------
+
+// search — McpSearchResponse
+const searchResponse = () => ({
+  results: [
+    {
+      id: 'acme/skill-alpha',
+      name: 'skill-alpha',
+      description: 'Alpha skill for E2E compare',
+      author: 'acme',
+      category: 'development',
+      trustTier: 'verified',
+      score: 88,
+    },
+    {
+      id: 'acme/skill-beta',
+      name: 'skill-beta',
+      description: 'Beta skill for E2E compare',
+      author: 'acme',
+      category: 'development',
+      trustTier: 'community',
+      score: 72,
+    },
+  ],
+  total: 2,
+  query: '',
+  filters: {},
+  timing: { searchMs: 1, totalMs: 2 },
+})
+
+// get_skill — McpGetSkillResponse (CRITICAL: top-level `content` must be non-empty)
+const getSkillResponse = (id) => ({
+  skill: {
+    id: id || 'acme/skill-alpha',
+    name: id ? id.split('/').pop() : 'skill-alpha',
+    description: 'E2E fake skill',
+    author: 'acme',
+    category: 'development',
+    trustTier: 'verified',
+    score: 88,
+  },
+  installCommand: `npx skillsmith install ${id || 'acme/skill-alpha'}`,
+  // diffCommand reads detail.content — must be a non-empty markdown string
+  content: '# E2E Fake Skill\n\nRegistry content for E2E diff fixture.\n',
+  timing: { totalMs: 1 },
+})
+
+// skill_compare — McpCompareResponse
+const skillCompareResponse = (skill_a, skill_b) => ({
+  comparison: {
+    a: {
+      id: skill_a || 'acme/skill-alpha',
+      name: skill_a ? skill_a.split('/').pop() : 'skill-alpha',
+      description: 'Alpha skill',
+      author: 'acme',
+      quality_score: 88,
+      score_breakdown: null,
+      trust_tier: 'verified',
+      category: 'development',
+      tags: [],
+      version: null,
+      dependencies: [],
+    },
+    b: {
+      id: skill_b || 'acme/skill-beta',
+      name: skill_b ? skill_b.split('/').pop() : 'skill-beta',
+      description: 'Beta skill',
+      author: 'acme',
+      quality_score: 72,
+      score_breakdown: null,
+      trust_tier: 'community',
+      category: 'development',
+      tags: [],
+      version: null,
+      dependencies: [],
+    },
+  },
+  differences: [
+    { field: 'quality_score', a_value: 88, b_value: 72, winner: 'a' },
+    { field: 'trust_tier', a_value: 'verified', b_value: 'community', winner: 'a' },
+  ],
+  recommendation: 'skill-alpha has a higher quality score and verified trust tier.',
+  winner: 'a',
+  timing: { totalMs: 5 },
+})
+
+// skill_diff — McpSkillDiffResponse
+const skillDiffResponse = (skillId) => ({
+  skill: skillId || 'my-e2e-skill',
+  changeType: 'minor',
+  sectionsAdded: ['## New Section'],
+  sectionsRemoved: [],
+  sectionsModified: ['## Usage'],
+  riskScoreDelta: null,
+  changelog: null,
+  recommendation: 'review-then-update',
+})
+
 const RENAME_SUGGESTION = {
   collisionId: 'col-e2e-1',
   currentName: 'my-skill',
@@ -101,6 +198,18 @@ function toolResult(params) {
   }
 
   switch (name) {
+    case 'search':
+      return { content: [{ type: 'text', text: JSON.stringify(searchResponse()) }] }
+    case 'get_skill':
+      return { content: [{ type: 'text', text: JSON.stringify(getSkillResponse(args.id)) }] }
+    case 'skill_compare':
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify(skillCompareResponse(args.skill_a, args.skill_b)) },
+        ],
+      }
+    case 'skill_diff':
+      return { content: [{ type: 'text', text: JSON.stringify(skillDiffResponse(args.skillId)) }] }
     case 'skill_inventory_audit': {
       inventoryAuditCalls += 1
       const payload = inventoryAuditCalls === 1 ? auditWithCollision() : auditClean()

--- a/packages/vscode-extension/e2e/fixtures/skills/my-e2e-skill/SKILL.md
+++ b/packages/vscode-extension/e2e/fixtures/skills/my-e2e-skill/SKILL.md
@@ -1,0 +1,11 @@
+# my-e2e-skill
+
+A minimal installed skill fixture for the SMI-5340 E2E diff spec.
+
+## Usage
+
+Use when you need an E2E test fixture for the diff command.
+
+## Triggers
+
+- "e2e diff test"

--- a/packages/vscode-extension/e2e/helpers/tabs.ts
+++ b/packages/vscode-extension/e2e/helpers/tabs.ts
@@ -1,0 +1,46 @@
+/**
+ * Tab-polling helpers for the SMI-5340 E2E specs.
+ *
+ * CompareSkillsPanel and SkillDiffPanel set dynamic titles in `_update()`:
+ *   - `Compare: <name-a> vs <name-b>`   (CompareSkillsPanel.ts:151)
+ *   - `Updates: <skill-name>`            (SkillDiffPanel.ts:171)
+ *
+ * `getWebviewByTitle` requires an EXACT title, but the fake MCP responses
+ * determine the names at run-time. Polling `vscode.window.tabGroups` for
+ * a prefix match is more robust and avoids the 40s openAuditPanel retry loop.
+ */
+import { browser } from '@wdio/globals'
+
+/**
+ * Wait until at least one open editor tab has a label that starts with
+ * `prefix`, then return that label.  Polls the extension host via
+ * `executeWorkbench` so it runs inside the VS Code process.
+ */
+export async function waitForTabWithPrefix(prefix: string, timeout = 30_000): Promise<string> {
+  let found = ''
+  await browser.waitUntil(
+    async () => {
+      const label = (await browser.executeWorkbench((vscode, p) => {
+        for (const group of vscode.window.tabGroups.all) {
+          for (const tab of group.tabs) {
+            if (tab.label.startsWith(p)) {
+              return tab.label
+            }
+          }
+        }
+        return ''
+      }, prefix)) as string
+      if (label) {
+        found = label
+        return true
+      }
+      return false
+    },
+    {
+      timeout,
+      interval: 500,
+      timeoutMsg: `No tab with prefix "${prefix}" appeared within ${timeout}ms`,
+    }
+  )
+  return found
+}

--- a/packages/vscode-extension/e2e/pageobjects/compare-skills.page.ts
+++ b/packages/vscode-extension/e2e/pageobjects/compare-skills.page.ts
@@ -1,0 +1,61 @@
+/**
+ * Page object for the two-step tree-context compare flow (SMI-5340).
+ *
+ * Both commands accept an optional `SkillTreeItem` arg; when provided, they
+ * skip the QuickPick entirely. We pass a duck-typed plain object (no `new
+ * SkillTreeItem(...)` — the class lives in src/ and is unavailable to the wdio
+ * runner) via executeWorkbench's extra-arg channel, which JSON-serialises the
+ * value across the extension-host bridge. The command handlers only access
+ * `.skillData.*` so a plain object satisfies all checks.
+ *
+ * compareWithSelectedImpl also re-validates the compare-source skill via
+ * `deps.skillService.getSkill(sourceId)` → `client.getSkill()` → MCP
+ * `get_skill`. The fake server handles `get_skill` so this round-trip succeeds.
+ */
+import { browser } from '@wdio/globals'
+
+export interface SyntheticSkillArg {
+  skillData: {
+    id: string
+    name: string
+    isInstalled?: boolean
+    path?: string
+  }
+}
+
+export class CompareSkillsPage {
+  /**
+   * Force an MCP connection (identical to InventoryAuditPage.forceConnect).
+   * The extension only auto-connects on non-first activations; tests must
+   * trigger one explicitly.
+   */
+  async forceConnect(): Promise<void> {
+    await browser.executeWorkbench((vscode) =>
+      vscode.commands.executeCommand('skillsmith.mcpReconnect')
+    )
+  }
+
+  /**
+   * Execute `skillsmith.selectForCompare` with a synthetic SkillTreeItem arg.
+   * Sets the compare source (stored in compare-source.ts) without showing the
+   * QuickPick.
+   */
+  async selectForCompare(arg: SyntheticSkillArg): Promise<void> {
+    await browser.executeWorkbench(
+      (vscode, a) => vscode.commands.executeCommand('skillsmith.selectForCompare', a),
+      arg
+    )
+  }
+
+  /**
+   * Execute `skillsmith.compareWithSelected` with a synthetic SkillTreeItem arg
+   * as the B skill.  The handler re-validates the source skill (MCP `get_skill`)
+   * then calls `skill_compare` and opens CompareSkillsPanel.
+   */
+  async compareWithSelected(arg: SyntheticSkillArg): Promise<void> {
+    await browser.executeWorkbench(
+      (vscode, a) => vscode.commands.executeCommand('skillsmith.compareWithSelected', a),
+      arg
+    )
+  }
+}

--- a/packages/vscode-extension/e2e/pageobjects/diff-skill.page.ts
+++ b/packages/vscode-extension/e2e/pageobjects/diff-skill.page.ts
@@ -1,0 +1,48 @@
+/**
+ * Page object for the skillsmith.diffSkill tree-context command (SMI-5340).
+ *
+ * When `preselected.skillData.isInstalled && preselected.skillData.path` is
+ * truthy, diffCommandImpl skips the QuickPick and reads SKILL.md from the
+ * provided `path`.  We pass a duck-typed plain object via executeWorkbench's
+ * extra-arg channel — the handler only checks `.skillData.*` properties.
+ *
+ * After reading SKILL.md, the command calls:
+ *   1. `client.getSkill(skill.id)` → MCP `get_skill` (registry content)
+ *   2. `client.skillDiff(args)` → MCP `skill_diff`
+ * Both are handled by the fake server; `get_skill` returns a non-empty
+ * `content` field so the "no registry content" early-return is not hit.
+ */
+import { browser } from '@wdio/globals'
+
+export interface SyntheticInstalledSkillArg {
+  skillData: {
+    id: string
+    name: string
+    isInstalled: true
+    /** Absolute path to the directory containing SKILL.md. */
+    path: string
+    trustTier?: string
+  }
+}
+
+export class DiffSkillPage {
+  /**
+   * Force an MCP connection (identical to InventoryAuditPage.forceConnect).
+   */
+  async forceConnect(): Promise<void> {
+    await browser.executeWorkbench((vscode) =>
+      vscode.commands.executeCommand('skillsmith.mcpReconnect')
+    )
+  }
+
+  /**
+   * Execute `skillsmith.diffSkill` with a synthetic installed SkillTreeItem arg.
+   * Skips the installed-skill QuickPick and goes straight to the MCP calls.
+   */
+  async diffSkill(arg: SyntheticInstalledSkillArg): Promise<void> {
+    await browser.executeWorkbench(
+      (vscode, a) => vscode.commands.executeCommand('skillsmith.diffSkill', a),
+      arg
+    )
+  }
+}

--- a/packages/vscode-extension/e2e/specs/activation.e2e.ts
+++ b/packages/vscode-extension/e2e/specs/activation.e2e.ts
@@ -9,7 +9,7 @@ import { browser, expect } from '@wdio/globals'
 
 const EXTENSION_ID = 'skillsmith.skillsmith-vscode'
 
-// The 13 commands contributed in package.json `contributes.commands`.
+// The 15 commands contributed in package.json `contributes.commands`.
 const EXPECTED_COMMANDS = [
   'skillsmith.searchSkills',
   'skillsmith.installSkill',
@@ -22,6 +22,8 @@ const EXPECTED_COMMANDS = [
   'skillsmith.uninstallSkill',
   'skillsmith.recommendSkills',
   'skillsmith.compareSkills',
+  'skillsmith.selectForCompare',
+  'skillsmith.compareWithSelected',
   'skillsmith.diffSkill',
   'skillsmith.auditInventory',
 ]
@@ -43,7 +45,7 @@ describe('Skillsmith extension activation', () => {
     expect(isActive).toBe(true)
   })
 
-  it('registers all 13 contributed commands', async () => {
+  it('registers all 15 contributed commands', async () => {
     const registered: string[] = await browser.executeWorkbench((vscode) =>
       vscode.commands.getCommands(true)
     )

--- a/packages/vscode-extension/e2e/specs/compare.e2e.ts
+++ b/packages/vscode-extension/e2e/specs/compare.e2e.ts
@@ -1,0 +1,77 @@
+/**
+ * Tree-context compare flow E2E spec (SMI-5340 Wave 2).
+ *
+ * Drives `skillsmith.selectForCompare` (A) → `skillsmith.compareWithSelected`
+ * (B) with synthetic duck-typed SkillTreeItem args (no QuickPick interaction).
+ * Asserts:
+ *   (a) `skill_compare` fired with the expected {skill_a, skill_b} in the MCP
+ *       call log (fake-mcp-server.mjs).
+ *   (b) A tab whose label starts with "Compare: " appeared in the workbench
+ *       (CompareSkillsPanel._update sets `panel.title = \`Compare: ${a} vs ${b}\``).
+ *
+ * compareWithSelectedImpl also calls `get_skill` to re-validate the compare
+ * source; the fake server handles both `get_skill` and `skill_compare`.
+ *
+ * Note: the first `skillsmith.mcpReconnect` on a fresh activation may open the
+ * "Reconnect / Disconnect" picker when the client is already connected; the page
+ * object guard relies on the fact that first-run auto-connect is skipped and
+ * the test's `forceConnect()` is the triggering call.
+ */
+import { browser, expect } from '@wdio/globals'
+import { CompareSkillsPage } from '../pageobjects/compare-skills.page.js'
+import { readFakeMcpLog } from '../fixtures/fake-mcp-log.js'
+import { waitForTabWithPrefix } from '../helpers/tabs.js'
+
+const SKILL_A_ID = 'acme/skill-alpha'
+const SKILL_B_ID = 'acme/skill-beta'
+
+/** Returns true once skill_compare fires with the expected ids. */
+const compareToolFired = (): boolean =>
+  readFakeMcpLog().some((e) => {
+    if (e['t'] !== 'tools/call' || e['name'] !== 'skill_compare') return false
+    const args = e['args'] as { skill_a?: string; skill_b?: string } | undefined
+    return args?.skill_a === SKILL_A_ID && args?.skill_b === SKILL_B_ID
+  })
+
+describe('Compare skills — tree-context two-step flow (SMI-5340)', () => {
+  const page = new CompareSkillsPage()
+
+  it('selectForCompare + compareWithSelected open the Compare panel', async () => {
+    // autoConnect is skipped on first activation — force an explicit connection.
+    await page.forceConnect()
+
+    // Wait for the MCP server to be ready (the start marker appears in the log
+    // after the fake server truncates and writes it on spawn).
+    await browser.waitUntil(() => readFakeMcpLog().some((e) => e['t'] === 'start'), {
+      timeout: 20_000,
+      interval: 500,
+      timeoutMsg: 'fake MCP server never started (no {t:"start"} marker in log)',
+    })
+
+    // Step 1: select skill A as the compare source.
+    await page.selectForCompare({ skillData: { id: SKILL_A_ID, name: 'skill-alpha' } })
+    // Pause briefly so the information toast resolves before the second command.
+    await browser.pause(500)
+
+    // Step 2: compare with skill B. compareWithSelectedImpl:
+    //   - reads the compare source (SKILL_A_ID)
+    //   - re-validates it via skillService.getSkill() → MCP get_skill
+    //   - calls client.skillCompare({skill_a, skill_b}) → MCP skill_compare
+    //   - opens CompareSkillsPanel
+    await page.compareWithSelected({ skillData: { id: SKILL_B_ID, name: 'skill-beta' } })
+
+    // Assert (a): skill_compare fired with the correct ids.
+    await browser.waitUntil(compareToolFired, {
+      timeout: 20_000,
+      interval: 500,
+      timeoutMsg: `skill_compare {skill_a:"${SKILL_A_ID}", skill_b:"${SKILL_B_ID}"} never reached the fake MCP server`,
+    })
+
+    // Assert (b): a tab whose label starts with "Compare: " is open.
+    // The exact label is "Compare: skill-alpha vs skill-beta" (from the fake
+    // server's comparison.a.name / comparison.b.name), but we match on the
+    // prefix so the assertion doesn't depend on fake-data field names.
+    const tabLabel = await waitForTabWithPrefix('Compare: ')
+    expect(tabLabel).toContain('Compare: ')
+  })
+})

--- a/packages/vscode-extension/e2e/specs/diff.e2e.ts
+++ b/packages/vscode-extension/e2e/specs/diff.e2e.ts
@@ -1,0 +1,96 @@
+/**
+ * Diff skill (update advisor) tree-context E2E spec (SMI-5340 Wave 2).
+ *
+ * Drives `skillsmith.diffSkill` with a synthetic installed SkillTreeItem arg
+ * that points at the `e2e/fixtures/skills/my-e2e-skill/` fixture directory
+ * (which contains a real SKILL.md). The arg satisfies the
+ * `preselected?.skillData?.isInstalled && preselected.skillData.path` guard in
+ * diffCommandImpl so the QuickPick is skipped entirely.
+ *
+ * diffCommandImpl sequence:
+ *   1. Reads SKILL.md from `skill.path` → `oldContent`
+ *   2. Calls `client.getSkill(skill.id)` → MCP `get_skill` → `detail.content`
+ *      (top-level `content` on McpGetSkillResponse — non-empty markdown)
+ *   3. Calls `client.skillDiff(args)` → MCP `skill_diff`
+ *   4. Opens SkillDiffPanel (title: `Updates: <skillName>`)
+ *
+ * Asserts:
+ *   (a) `get_skill` fired for the fixture skill id.
+ *   (b) `skill_diff` fired for the fixture skill id.
+ *   (c) A tab whose label starts with "Updates: " appeared in the workbench
+ *       (SkillDiffPanel._update sets `panel.title = \`Updates: ${this._skillName}\``).
+ */
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { browser, expect } from '@wdio/globals'
+import { DiffSkillPage } from '../pageobjects/diff-skill.page.js'
+import { readFakeMcpLog } from '../fixtures/fake-mcp-log.js'
+import { waitForTabWithPrefix } from '../helpers/tabs.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+/** The fixture skill directory — must match the dir name used as the skill id. */
+const SKILL_DIR = path.resolve(here, '..', 'fixtures', 'skills', 'my-e2e-skill')
+const SKILL_ID = 'my-e2e-skill'
+
+/** Returns true once get_skill fires for our fixture skill id. */
+const getSkillFired = (): boolean =>
+  readFakeMcpLog().some((e) => {
+    if (e['t'] !== 'tools/call' || e['name'] !== 'get_skill') return false
+    const args = e['args'] as { id?: string } | undefined
+    return args?.id === SKILL_ID
+  })
+
+/** Returns true once skill_diff fires for our fixture skill id. */
+const skillDiffFired = (): boolean =>
+  readFakeMcpLog().some((e) => {
+    if (e['t'] !== 'tools/call' || e['name'] !== 'skill_diff') return false
+    const args = e['args'] as { skillId?: string } | undefined
+    return args?.skillId === SKILL_ID
+  })
+
+describe('Diff skill (update advisor) — tree-context flow (SMI-5340)', () => {
+  const page = new DiffSkillPage()
+
+  it('diffSkill with installed arg fires get_skill + skill_diff and opens the Updates panel', async () => {
+    // autoConnect is skipped on first activation — force an explicit connection.
+    await page.forceConnect()
+
+    // Wait for the MCP server to be ready.
+    await browser.waitUntil(() => readFakeMcpLog().some((e) => e['t'] === 'start'), {
+      timeout: 20_000,
+      interval: 500,
+      timeoutMsg: 'fake MCP server never started (no {t:"start"} marker in log)',
+    })
+
+    // Invoke diffSkill with a synthetic installed arg. The handler reads SKILL.md
+    // from SKILL_DIR (the e2e fixture), then calls get_skill + skill_diff.
+    await page.diffSkill({
+      skillData: {
+        id: SKILL_ID,
+        name: SKILL_ID,
+        isInstalled: true,
+        path: SKILL_DIR,
+      },
+    })
+
+    // Assert (a): get_skill fired with the fixture skill id.
+    await browser.waitUntil(getSkillFired, {
+      timeout: 20_000,
+      interval: 500,
+      timeoutMsg: `get_skill for "${SKILL_ID}" never reached the fake MCP server`,
+    })
+
+    // Assert (b): skill_diff fired with the fixture skill id.
+    await browser.waitUntil(skillDiffFired, {
+      timeout: 20_000,
+      interval: 500,
+      timeoutMsg: `skill_diff for "${SKILL_ID}" never reached the fake MCP server`,
+    })
+
+    // Assert (c): a tab whose label starts with "Updates: " is open.
+    // The exact label is "Updates: my-e2e-skill" (SkillDiffPanel._update).
+    const tabLabel = await waitForTabWithPrefix('Updates: ')
+    expect(tabLabel).toContain('Updates: ')
+  })
+})

--- a/packages/vscode-extension/e2e/wdio.conf.ts
+++ b/packages/vscode-extension/e2e/wdio.conf.ts
@@ -21,6 +21,15 @@ const EXTENSION_PATH = path.resolve(here, '..')
 const WORKSPACE_PATH = path.resolve(here, 'fixtures', 'workspace')
 /** The fake stdio MCP server the extension spawns instead of `npx @skillsmith/mcp-server`. */
 const FAKE_MCP_SERVER = path.resolve(here, 'fixtures', 'fake-mcp-server.mjs')
+/**
+ * Fake installed-skills directory for the SMI-5340 diff E2E spec. Points the
+ * extension's `skillsmith.skillsDirectory` at our fixture tree so
+ * `doLoadInstalledSkills` finds `my-e2e-skill/SKILL.md` without touching
+ * `~/.claude/skills`. The diff command reads SKILL.md via the synthetic arg's
+ * `path` field (not from this directory), so this is informational only —
+ * it prevents the tree-view from emitting file-not-found warnings on CI.
+ */
+const FIXTURE_SKILLS_DIR = path.resolve(here, 'fixtures', 'skills')
 
 // Absolute node binary. The extension host (Electron, launched by wdio without a
 // login shell) has no guaranteed `node` on PATH, so a bare 'node' serverCommand
@@ -71,6 +80,10 @@ export const config: WebdriverIO.Config = {
           // Keep the e2e run quiet / deterministic.
           'skillsmith.telemetry.enabled': false,
           'skillsmith.demoMode': false,
+          // Point the installed-skills tree at our fixture dir (SMI-5340) so
+          // the extension finds `my-e2e-skill/SKILL.md` without scanning
+          // `~/.claude/skills` on the CI runner.
+          'skillsmith.skillsDirectory': FIXTURE_SKILLS_DIR,
           // Render modal dialogs (showWarningMessage({modal:true})) as the in-DOM
           // .monaco-dialog-box widget instead of an OS-native dialog. Native is the
           // default on macOS/Windows and is invisible to WebDriver; 'custom' makes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -114,6 +114,18 @@
         "icon": "$(versions)"
       },
       {
+        "command": "skillsmith.selectForCompare",
+        "title": "Select for Compare",
+        "category": "Skillsmith",
+        "icon": "$(compare-changes)"
+      },
+      {
+        "command": "skillsmith.compareWithSelected",
+        "title": "Compare with Selected",
+        "category": "Skillsmith",
+        "icon": "$(diff)"
+      },
+      {
         "command": "skillsmith.auditInventory",
         "title": "Audit Skill Inventory",
         "category": "Skillsmith",
@@ -230,6 +242,31 @@
         {
           "command": "skillsmith.uninstallSkill",
           "when": "view == skillsmith.skillsView && viewItem == installedSkill"
+        },
+        {
+          "command": "skillsmith.selectForCompare",
+          "when": "view == skillsmith.skillsView && viewItem =~ /^(skill|installedSkill)$/",
+          "group": "skillsmith_compare@1"
+        },
+        {
+          "command": "skillsmith.compareWithSelected",
+          "when": "view == skillsmith.skillsView && viewItem =~ /^(skill|installedSkill)$/ && skillsmith.compareSourceSet",
+          "group": "skillsmith_compare@2"
+        },
+        {
+          "command": "skillsmith.diffSkill",
+          "when": "view == skillsmith.skillsView && viewItem == installedSkill",
+          "group": "skillsmith_diff@1"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "skillsmith.selectForCompare",
+          "when": "false"
+        },
+        {
+          "command": "skillsmith.compareWithSelected",
+          "when": "false"
         }
       ]
     },

--- a/packages/vscode-extension/src/__tests__/SkillDetailPanel.test.ts
+++ b/packages/vscode-extension/src/__tests__/SkillDetailPanel.test.ts
@@ -429,6 +429,38 @@ describe('SkillDetailPanel', () => {
       expect(mock.panel.dispose).not.toHaveBeenCalled()
     })
 
+    it('dispatches skillsmith.diffSkill with a duck-typed installed arg when diffSkill message received', async () => {
+      const mock = await showInstalledPanel(true)
+      mock.sendMessage({ command: 'diffSkill' })
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'skillsmith.diffSkill',
+        expect.objectContaining({
+          skillData: expect.objectContaining({
+            id: 'test/skill',
+            isInstalled: true,
+            path: '/skills/skill',
+          }),
+        })
+      )
+    })
+
+    it('does not dispatch skillsmith.diffSkill when the skill is not installed', async () => {
+      SkillDetailPanel.setSkillService(createMockSkillService())
+      SkillDetailPanel.setTreeProvider(createMockTreeProvider([]))
+      const mock = createMockPanel()
+      vi.mocked(vscode.window.createWebviewPanel).mockReturnValue(mock.panel)
+      SkillDetailPanel.createOrShow(EXTENSION_URI, 'test/skill')
+      await vi.waitFor(() => {
+        expect(mock.getHtmlHistory().at(-1) ?? '').toContain('id="installBtn"')
+      })
+
+      mock.sendMessage({ command: 'diffSkill' })
+      expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith(
+        'skillsmith.diffSkill',
+        expect.anything()
+      )
+    })
+
     it('aborts with a notice when the skill is gone at click time (M2)', async () => {
       SkillDetailPanel.setSkillService(createMockSkillService())
       // Provider reports the skill installed at load, but empty at click time.

--- a/packages/vscode-extension/src/__tests__/compare-source.test.ts
+++ b/packages/vscode-extension/src/__tests__/compare-source.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for compare-source.ts (SMI-5340).
+ *
+ * Covers: set/get/clear lifecycle + the `setContext` calls that drive the
+ * `skillsmith.compareSourceSet` VS Code context key.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── hoisted spies ─────────────────────────────────────────────────────────────
+const executeCommand = vi.hoisted(() => vi.fn())
+
+// ── vscode mock ───────────────────────────────────────────────────────────────
+// compare-source.ts only uses `vscode.commands.executeCommand` — a minimal stub
+// is sufficient. No module-scope call touches it (see file header), so the mock
+// does not need to handle import-time invocations.
+vi.mock('vscode', () => ({
+  commands: { executeCommand },
+  window: {},
+  workspace: { getConfiguration: () => ({ get: () => undefined }) },
+  env: {},
+  Uri: {},
+}))
+
+// ── SUT ───────────────────────────────────────────────────────────────────────
+import {
+  getCompareSource,
+  setCompareSource,
+  clearCompareSource,
+} from '../commands/compare-source.js'
+
+const CONTEXT_KEY = 'skillsmith.compareSourceSet'
+
+describe('compare-source (SMI-5340)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset module state: clear any source left over from a previous test.
+    clearCompareSource()
+    // clearCompareSource will have called executeCommand — reset after the cleanup.
+    vi.clearAllMocks()
+  })
+
+  it('getCompareSource returns undefined when nothing has been set', () => {
+    expect(getCompareSource()).toBeUndefined()
+  })
+
+  it('setCompareSource stores the id and returns it via getCompareSource', () => {
+    setCompareSource('org/my-skill')
+    expect(getCompareSource()).toBe('org/my-skill')
+  })
+
+  it('setCompareSource calls setContext with key and true', () => {
+    setCompareSource('org/my-skill')
+    expect(executeCommand).toHaveBeenCalledWith('setContext', CONTEXT_KEY, true)
+  })
+
+  it('clearCompareSource removes the stored id', () => {
+    setCompareSource('org/my-skill')
+    clearCompareSource()
+    expect(getCompareSource()).toBeUndefined()
+  })
+
+  it('clearCompareSource calls setContext with key and false', () => {
+    setCompareSource('org/my-skill')
+    vi.clearAllMocks() // reset call record so only clearCompareSource shows
+    clearCompareSource()
+    expect(executeCommand).toHaveBeenCalledWith('setContext', CONTEXT_KEY, false)
+    expect(executeCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it('setCompareSource overwrites a previously-set id', () => {
+    setCompareSource('org/skill-a')
+    setCompareSource('org/skill-b')
+    expect(getCompareSource()).toBe('org/skill-b')
+    // setContext called twice — both with true
+    expect(executeCommand).toHaveBeenCalledTimes(2)
+    expect(executeCommand).toHaveBeenNthCalledWith(1, 'setContext', CONTEXT_KEY, true)
+    expect(executeCommand).toHaveBeenNthCalledWith(2, 'setContext', CONTEXT_KEY, true)
+  })
+
+  it('setContext key is exactly "skillsmith.compareSourceSet"', () => {
+    setCompareSource('org/x')
+    const [, key] = executeCommand.mock.calls[0] as [string, string, boolean]
+    expect(key).toBe('skillsmith.compareSourceSet')
+  })
+})

--- a/packages/vscode-extension/src/__tests__/compareSkills.test.ts
+++ b/packages/vscode-extension/src/__tests__/compareSkills.test.ts
@@ -14,6 +14,7 @@ const showInformationMessage = vi.hoisted(() => vi.fn())
 const showErrorMessage = vi.hoisted(() => vi.fn())
 const showWarningMessage = vi.hoisted(() => vi.fn())
 const createQuickPickFn = vi.hoisted(() => vi.fn())
+const executeCommand = vi.hoisted(() => vi.fn())
 
 // ── vscode mock ───────────────────────────────────────────────────────────────
 vi.mock('vscode', () => ({
@@ -24,7 +25,7 @@ vi.mock('vscode', () => ({
     createQuickPick: createQuickPickFn,
     showQuickPick: vi.fn(),
   },
-  commands: { registerCommand: vi.fn(), executeCommand: vi.fn() },
+  commands: { registerCommand: vi.fn(), executeCommand },
   workspace: {
     workspaceFolders: undefined,
     getConfiguration: vi.fn(() => ({ get: vi.fn(() => undefined) })),
@@ -76,7 +77,14 @@ import type * as vscode from 'vscode'
 import type { SkillService } from '../services/SkillService.js'
 
 // ── SUT ───────────────────────────────────────────────────────────────────────
-import { compareCommandAction } from '../commands/compareCommand.js'
+// compare-source.ts uses the vscode mock above (commands.executeCommand) — no
+// separate mock needed; the real module runs under the vscode stub.
+import {
+  compareCommandAction,
+  selectForCompareAction,
+  compareWithSelectedAction,
+} from '../commands/compareCommand.js'
+import { getCompareSource, clearCompareSource } from '../commands/compare-source.js'
 
 /** Cast the partial mocks to the action's param types without `any`. */
 const asDeps = (): { skillService: SkillService; context: vscode.ExtensionContext } => ({
@@ -260,5 +268,193 @@ describe('compareCommand', () => {
     expect(showErrorMessage).not.toHaveBeenCalled()
     expect(handleTierDenied).not.toHaveBeenCalled()
     expect(compareCreateOrShow).not.toHaveBeenCalled()
+  })
+})
+
+// ── Helpers for tree-context tests ────────────────────────────────────────────
+
+/**
+ * Build a minimal SkillTreeItem-shaped object for the tree-context commands.
+ * We only need `skillData` — the rest of the TreeItem surface is irrelevant.
+ */
+function makeTreeItem(skill: { id: string; name: string; isInstalled?: boolean }): {
+  skillData: { id: string; name: string; isInstalled: boolean; description: undefined }
+} {
+  return {
+    skillData: {
+      id: skill.id,
+      name: skill.name,
+      isInstalled: skill.isInstalled ?? true,
+      description: undefined,
+    },
+  }
+}
+
+// ── FAKE_SKILL_SERVICE extended with getSkill ─────────────────────────────────
+const getSkillMock = vi.fn()
+const FAKE_SKILL_SERVICE_EXTENDED = {
+  search: vi.fn().mockResolvedValue({ results: [SKILL_A, SKILL_B], isOffline: false }),
+  getSkill: getSkillMock,
+}
+
+const asDepsExtended = () => ({
+  skillService: FAKE_SKILL_SERVICE_EXTENDED as unknown as SkillService,
+  context: FAKE_CONTEXT as unknown as import('vscode').ExtensionContext,
+})
+
+// ── selectForCompare ──────────────────────────────────────────────────────────
+
+describe('selectForCompare (SMI-5340)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearCompareSource()
+    mcpIsConnected.mockReturnValue(true)
+  })
+
+  it('sets the compare source and shows an info toast', async () => {
+    const item = makeTreeItem(SKILL_A)
+
+    await selectForCompareAction(asDepsExtended(), item as never)
+
+    expect(getCompareSource()).toBe(SKILL_A.id)
+    // setContext called with key + true
+    expect(executeCommand).toHaveBeenCalledWith('setContext', 'skillsmith.compareSourceSet', true)
+    expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining(SKILL_A.name))
+  })
+
+  it('no-ops when arg is undefined', async () => {
+    await selectForCompareAction(asDepsExtended(), undefined as never)
+
+    expect(getCompareSource()).toBeUndefined()
+    expect(showInformationMessage).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when arg has no skillData', async () => {
+    await selectForCompareAction(asDepsExtended(), {} as never)
+
+    expect(getCompareSource()).toBeUndefined()
+  })
+})
+
+// ── compareWithSelected ───────────────────────────────────────────────────────
+
+describe('compareWithSelected (SMI-5340)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearCompareSource()
+    mcpIsConnected.mockReturnValue(true)
+    mcpSkillCompare.mockResolvedValue(FAKE_COMPARE_RESPONSE)
+    getSkillMock.mockResolvedValue(SKILL_A)
+  })
+
+  it('calls skillCompare + opens panel + clears source when source and target differ', async () => {
+    // Set source to SKILL_A
+    const sourceItem = makeTreeItem(SKILL_A)
+    await selectForCompareAction(asDepsExtended(), sourceItem as never)
+    expect(getCompareSource()).toBe(SKILL_A.id)
+
+    // Now compare with SKILL_B
+    const targetItem = makeTreeItem(SKILL_B)
+    await compareWithSelectedAction(asDepsExtended(), targetItem as never)
+
+    expect(mcpSkillCompare).toHaveBeenCalledWith({ skill_a: SKILL_A.id, skill_b: SKILL_B.id })
+    expect(compareCreateOrShow).toHaveBeenCalledWith(
+      FAKE_CONTEXT.extensionUri,
+      FAKE_COMPARE_RESPONSE,
+      SKILL_A.id,
+      SKILL_B.id
+    )
+    // Source cleared after successful comparison
+    expect(getCompareSource()).toBeUndefined()
+    expect(executeCommand).toHaveBeenCalledWith('setContext', 'skillsmith.compareSourceSet', false)
+  })
+
+  it('warns and no-ops when no source is set', async () => {
+    const targetItem = makeTreeItem(SKILL_B)
+    await compareWithSelectedAction(asDepsExtended(), targetItem as never)
+
+    expect(showWarningMessage).toHaveBeenCalledWith(expect.stringContaining('No skill selected'))
+    expect(mcpSkillCompare).not.toHaveBeenCalled()
+  })
+
+  it('warns and no-ops when source equals target', async () => {
+    const item = makeTreeItem(SKILL_A)
+    await selectForCompareAction(asDepsExtended(), item as never)
+
+    await compareWithSelectedAction(asDepsExtended(), item as never)
+
+    expect(showWarningMessage).toHaveBeenCalledWith(expect.stringContaining('two different skills'))
+    expect(mcpSkillCompare).not.toHaveBeenCalled()
+  })
+
+  it('warns + clears source + sets context false when source skill is stale (getSkill throws)', async () => {
+    const sourceItem = makeTreeItem(SKILL_A)
+    await selectForCompareAction(asDepsExtended(), sourceItem as never)
+
+    // Simulate stale source — getSkill rejects
+    getSkillMock.mockRejectedValue(new Error('NotFound'))
+
+    const targetItem = makeTreeItem(SKILL_B)
+    await compareWithSelectedAction(asDepsExtended(), targetItem as never)
+
+    expect(showWarningMessage).toHaveBeenCalledWith(expect.stringContaining('no longer available'))
+    expect(mcpSkillCompare).not.toHaveBeenCalled()
+    expect(getCompareSource()).toBeUndefined()
+    expect(executeCommand).toHaveBeenCalledWith('setContext', 'skillsmith.compareSourceSet', false)
+  })
+
+  it('preserves the selected source when the comparison fails (MCP disconnected)', async () => {
+    const sourceItem = makeTreeItem(SKILL_A)
+    await selectForCompareAction(asDepsExtended(), sourceItem as never)
+    expect(getCompareSource()).toBe(SKILL_A.id)
+
+    // Source re-validates fine, but the comparison itself fails (server down) —
+    // the source must survive so the retry is a single click (governance #1).
+    mcpIsConnected.mockReturnValue(false)
+
+    const targetItem = makeTreeItem(SKILL_B)
+    await compareWithSelectedAction(asDepsExtended(), targetItem as never)
+
+    expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining('not connected'))
+    expect(mcpSkillCompare).not.toHaveBeenCalled()
+    expect(getCompareSource()).toBe(SKILL_A.id)
+  })
+
+  it('no-ops when arg is undefined', async () => {
+    // Set a source first so it's not a "no source" error
+    const sourceItem = makeTreeItem(SKILL_A)
+    await selectForCompareAction(asDepsExtended(), sourceItem as never)
+
+    await compareWithSelectedAction(asDepsExtended(), undefined as never)
+
+    expect(mcpSkillCompare).not.toHaveBeenCalled()
+  })
+})
+
+// ── existing palette compareSkills still works (regression guard) ─────────────
+
+describe('compareSkills palette (SMI-5340 regression)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearCompareSource()
+    mcpIsConnected.mockReturnValue(true)
+    mcpSkillCompare.mockResolvedValue(FAKE_COMPARE_RESPONSE)
+    FAKE_SKILL_SERVICE.search.mockResolvedValue({ results: [SKILL_A, SKILL_B], isOffline: false })
+  })
+
+  it('palette flow still calls skillCompare and opens panel unchanged', async () => {
+    createQuickPickFn
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_A))
+      .mockReturnValueOnce(makeQuickPickStub(SKILL_B))
+
+    await compareCommandAction(asDeps())
+
+    expect(mcpSkillCompare).toHaveBeenCalledWith({ skill_a: SKILL_A.id, skill_b: SKILL_B.id })
+    expect(compareCreateOrShow).toHaveBeenCalledWith(
+      FAKE_CONTEXT.extensionUri,
+      FAKE_COMPARE_RESPONSE,
+      SKILL_A.id,
+      SKILL_B.id
+    )
   })
 })

--- a/packages/vscode-extension/src/__tests__/diffCommand.test.ts
+++ b/packages/vscode-extension/src/__tests__/diffCommand.test.ts
@@ -235,6 +235,35 @@ describe('diffCommand', () => {
     expect(diffCreateOrShow).not.toHaveBeenCalled()
   })
 
+  it('skips the picker and diffs the preselected skill when arg has isInstalled + path', async () => {
+    const treeProvider = makeTreeProvider()
+    const preselected = {
+      skillData: { ...INSTALLED_SKILL, isInstalled: true },
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const deps = { treeProvider, context: FAKE_CONTEXT, preselected } as any
+    await diffCommandAction(deps)
+
+    expect(showQuickPick).not.toHaveBeenCalled()
+    expect(readFile).toHaveBeenCalledWith(expect.stringContaining('SKILL.md'), 'utf8')
+    expect(mcpGetSkill).toHaveBeenCalledWith(INSTALLED_SKILL.id)
+    expect(diffCreateOrShow).toHaveBeenCalled()
+  })
+
+  it('falls back to the picker when preselected arg is installed but has no path', async () => {
+    const treeProvider = makeTreeProvider()
+    const preselected = {
+      skillData: { ...INSTALLED_SKILL, isInstalled: true, path: undefined },
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const deps = { treeProvider, context: FAKE_CONTEXT, preselected } as any
+    await diffCommandAction(deps)
+
+    expect(showQuickPick).toHaveBeenCalled()
+  })
+
   it('shows info message and aborts when readFile fails', async () => {
     readFile.mockRejectedValue(new Error('ENOENT'))
 

--- a/packages/vscode-extension/src/__tests__/skill-panel-actions.test.ts
+++ b/packages/vscode-extension/src/__tests__/skill-panel-actions.test.ts
@@ -18,6 +18,7 @@ describe('getActionBlock', () => {
       expect(html).not.toContain('id="repoBtn"')
       expect(html).not.toContain('id="uninstallBtn"')
       expect(html).not.toContain('id="openFolderBtn"')
+      expect(html).not.toContain('id="diffBtn"')
     })
 
     it('adds the View Repository button when a repository is present', () => {
@@ -41,6 +42,25 @@ describe('getActionBlock', () => {
       expect(html).toContain('id="openSkillFileBtn"')
       expect(html).toContain('Open SKILL.md')
       expect(html).not.toContain('id="installBtn"')
+    })
+
+    it('renders diffBtn with btn-secondary and correct aria-label in installed state', () => {
+      const html = getActionBlock(
+        { installed: true, skillPath: '/skills/test-skill', hasSkillMd: true },
+        ''
+      )
+      expect(html).toContain('id="diffBtn"')
+      expect(html).toContain('btn-secondary')
+      expect(html).toContain('aria-label="View changes for this skill"')
+      expect(html).toContain('View changes')
+    })
+
+    it('renders diffBtn even when hasSkillMd is false', () => {
+      const html = getActionBlock(
+        { installed: true, skillPath: '/skills/test-skill', hasSkillMd: false },
+        ''
+      )
+      expect(html).toContain('id="diffBtn"')
     })
 
     it('omits Open SKILL.md when hasSkillMd is false', () => {

--- a/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
@@ -29,7 +29,11 @@ import { installCommandAction } from '../installCommand.js'
 import { uninstallCommandAction } from '../uninstallCommand.js'
 import { createSkillAction } from '../createSkillCommand.js'
 import { recommendCommandAction } from '../recommendCommand.js'
-import { compareCommandAction } from '../compareCommand.js'
+import {
+  compareCommandAction,
+  selectForCompareAction,
+  compareWithSelectedAction,
+} from '../compareCommand.js'
 import { diffCommandAction } from '../diffCommand.js'
 import { auditInventoryCommandAction } from '../auditInventoryCommand.js'
 import type { TelemetryEvent } from '../../services/Telemetry.js'
@@ -44,6 +48,8 @@ const VSCODE_DISPATCHER_MAP: Record<string, (...args: never[]) => unknown> = {
   'skillsmith.createSkill': createSkillAction,
   'skillsmith.recommendSkills': recommendCommandAction,
   'skillsmith.compareSkills': compareCommandAction,
+  'skillsmith.selectForCompare': selectForCompareAction,
+  'skillsmith.compareWithSelected': compareWithSelectedAction,
   'skillsmith.diffSkill': diffCommandAction,
   'skillsmith.auditInventory': auditInventoryCommandAction,
 }
@@ -73,7 +79,7 @@ describe('SMI-5130: VS Code command telemetry coverage', () => {
   it('reports VS Code dispatcher coverage to CI output', () => {
     const count = Object.keys(VSCODE_DISPATCHER_MAP).length
     console.info(`[SMI-5130] VS Code telemetry coverage: ${count} panel actions wrapped.`)
-    expect(count).toBe(10)
+    expect(count).toBe(12)
   })
 
   // SMI-5308 (M5): the detail-panel open actions are postMessage handlers, not

--- a/packages/vscode-extension/src/commands/compare-source.ts
+++ b/packages/vscode-extension/src/commands/compare-source.ts
@@ -1,0 +1,48 @@
+/**
+ * Compare-source session state (SMI-5340).
+ *
+ * Holds the skill id that was "Selected for Compare" so that a subsequent
+ * "Compare with Selected" tree-context invocation can skip the first QuickPick.
+ * The state lives only for the lifetime of the VS Code window (module-level
+ * variable) and is cleared after a successful comparison or when it becomes
+ * stale.
+ *
+ * `setContext` calls are ONLY made inside the exported functions — never at
+ * module scope — so that the telemetry-coverage test (which vi.mocks vscode as
+ * `{ commands: {} }`) can safely import this module without hitting a
+ * `commands.executeCommand is not a function` error at import time.
+ *
+ * @module commands/compare-source
+ */
+import * as vscode from 'vscode'
+
+/** The VS Code context key that controls `compareWithSelected` menu visibility. */
+const CONTEXT_KEY = 'skillsmith.compareSourceSet'
+
+let compareSource: string | undefined
+
+/**
+ * Returns the currently-selected compare source skill id, or `undefined` if
+ * none has been set.
+ */
+export function getCompareSource(): string | undefined {
+  return compareSource
+}
+
+/**
+ * Records `id` as the compare-source and sets the `skillsmith.compareSourceSet`
+ * VS Code context key to `true`, enabling the "Compare with Selected" menu entry.
+ */
+export function setCompareSource(id: string): void {
+  compareSource = id
+  void vscode.commands.executeCommand('setContext', CONTEXT_KEY, true)
+}
+
+/**
+ * Clears the compare-source and sets the `skillsmith.compareSourceSet` VS Code
+ * context key to `false`, hiding the "Compare with Selected" menu entry.
+ */
+export function clearCompareSource(): void {
+  compareSource = undefined
+  void vscode.commands.executeCommand('setContext', CONTEXT_KEY, false)
+}

--- a/packages/vscode-extension/src/commands/compareCommand.ts
+++ b/packages/vscode-extension/src/commands/compareCommand.ts
@@ -6,11 +6,16 @@
  * installCommand's debounced `createQuickPick` search pattern + the
  * withTelemetry export/register shape.
  *
+ * SMI-5340 adds two tree-context commands:
+ *   - `skillsmith.selectForCompare`   — sets the compare source on a SkillTreeItem
+ *   - `skillsmith.compareWithSelected` — completes the comparison against the source
+ *
  * @module commands/compareCommand
  */
 import * as vscode from 'vscode'
 import type { SkillData } from '../types/skill.js'
 import type { SkillService } from '../services/SkillService.js'
+import { SkillTreeItem } from '../sidebar/SkillTreeItem.js'
 import { getTrustTierCodicon, getTrustTierLabel } from '../sidebar/trustTier.js'
 import { getMcpClient } from '../mcp/McpClient.js'
 import { McpToolError } from '../mcp/McpToolError.js'
@@ -18,6 +23,7 @@ import { handleTierDenied } from '../mcp/tierDenied.js'
 import { withTelemetry } from '../services/telemetry-wrap.js'
 import { track } from '../services/Telemetry.js'
 import { CompareSkillsPanel } from '../views/CompareSkillsPanel.js'
+import { getCompareSource, setCompareSource, clearCompareSource } from './compare-source.js'
 
 /** Debounce delay for search input (matches installCommand). */
 const SEARCH_DEBOUNCE_MS = 300
@@ -136,10 +142,62 @@ async function pickSecondSkill(
   }
 }
 
-async function compareCommandImpl(deps: {
+/** Shared deps passed to `runComparison`. */
+interface ComparisonDeps {
   skillService: SkillService
   context: vscode.ExtensionContext
-}): Promise<void> {
+}
+
+/**
+ * Core compare logic: calls `skill_compare` on the MCP client and opens
+ * `CompareSkillsPanel`. Extracted so both the QuickPick palette flow and the
+ * tree-context "Compare with Selected" flow share a single implementation.
+ *
+ * Handles: not-connected, TierDenied, SkillNotFound, and generic errors.
+ * Emits `vscode_compare_complete` on success only; callers emit
+ * `vscode_compare_start`. Returns `true` on success, `false` on any handled
+ * failure (so callers can decide whether to preserve a selected source).
+ */
+export async function runComparison(
+  skillAId: string,
+  skillBId: string,
+  deps: ComparisonDeps
+): Promise<boolean> {
+  const client = getMcpClient()
+  if (!client.isConnected()) {
+    void vscode.window.showInformationMessage(
+      'Skillsmith server is not connected. Start the MCP server and try again.'
+    )
+    return false
+  }
+
+  try {
+    const response = await client.skillCompare({ skill_a: skillAId, skill_b: skillBId })
+    CompareSkillsPanel.createOrShow(deps.context.extensionUri, response, skillAId, skillBId)
+    track('vscode_compare_complete')
+    return true
+  } catch (err) {
+    if (err instanceof McpToolError) {
+      if (err.code === 'TierDenied') {
+        await handleTierDenied('skillsmith.compareSkills', err)
+        return false
+      }
+      if (err.code === 'SkillNotFound') {
+        void vscode.window.showWarningMessage(
+          'One or both skills could not be found. Check the skill IDs and try again.'
+        )
+        return false
+      }
+      void vscode.window.showErrorMessage(err.message)
+      return false
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    void vscode.window.showErrorMessage(`Could not compare skills: ${message}`)
+    return false
+  }
+}
+
+async function compareCommandImpl(deps: ComparisonDeps): Promise<void> {
   track('vscode_compare_start')
 
   const first = await pickSkill(deps.skillService, 'Compare skills (1 of 2)')
@@ -152,35 +210,60 @@ async function compareCommandImpl(deps: {
     return
   }
 
-  const client = getMcpClient()
-  if (!client.isConnected()) {
-    void vscode.window.showInformationMessage(
-      'Skillsmith server is not connected. Start the MCP server and try again.'
+  await runComparison(first.id, second.id, deps)
+}
+
+// ── Tree-context: Select for Compare (SMI-5340) ───────────────────────────────
+
+async function selectForCompareImpl(_deps: ComparisonDeps, arg?: SkillTreeItem): Promise<void> {
+  if (!arg?.skillData) {
+    return
+  }
+  setCompareSource(arg.skillData.id)
+  void vscode.window.showInformationMessage(
+    `Selected "${arg.skillData.name}" for compare — pick a second skill.`
+  )
+}
+
+// ── Tree-context: Compare with Selected (SMI-5340) ───────────────────────────
+
+async function compareWithSelectedImpl(deps: ComparisonDeps, arg?: SkillTreeItem): Promise<void> {
+  if (!arg?.skillData) {
+    return
+  }
+
+  const sourceId = getCompareSource()
+  if (!sourceId) {
+    void vscode.window.showWarningMessage(
+      'No skill selected for compare. Right-click a skill and choose "Select for Compare" first.'
     )
     return
   }
 
+  const targetId = arg.skillData.id
+  if (sourceId === targetId) {
+    void vscode.window.showWarningMessage('Pick two different skills to compare.')
+    return
+  }
+
+  // Re-validate the source is still resolvable in the registry (compare is a
+  // registry operation; a source that 404s there can't be compared).
   try {
-    const response = await client.skillCompare({ skill_a: first.id, skill_b: second.id })
-    CompareSkillsPanel.createOrShow(deps.context.extensionUri, response, first.id, second.id)
-    track('vscode_compare_complete')
-  } catch (err) {
-    if (err instanceof McpToolError) {
-      if (err.code === 'TierDenied') {
-        await handleTierDenied('skillsmith.compareSkills', err)
-        return
-      }
-      if (err.code === 'SkillNotFound') {
-        void vscode.window.showWarningMessage(
-          'One or both skills could not be found. Check the skill IDs and try again.'
-        )
-        return
-      }
-      void vscode.window.showErrorMessage(err.message)
-      return
-    }
-    const message = err instanceof Error ? err.message : 'Unknown error'
-    void vscode.window.showErrorMessage(`Could not compare skills: ${message}`)
+    await deps.skillService.getSkill(sourceId)
+  } catch {
+    void vscode.window.showWarningMessage(
+      'The first skill is no longer available. Please select it again.'
+    )
+    clearCompareSource()
+    return
+  }
+
+  track('vscode_compare_start')
+  const succeeded = await runComparison(sourceId, targetId, deps)
+  // Drop the selected source only on success — on a transient failure (e.g. MCP
+  // disconnected) keep it so the retry is a single click.
+  if (succeeded) {
+    clearCompareSource()
   }
 }
 
@@ -189,15 +272,39 @@ export const compareCommandAction = withTelemetry(compareCommandImpl, {
   extractSkillId: () => 'compare',
 })
 
+export const selectForCompareAction = withTelemetry(
+  (deps: ComparisonDeps, arg?: SkillTreeItem) => selectForCompareImpl(deps, arg),
+  {
+    source: 'vscode-extension',
+    extractSkillId: () => 'selectForCompare',
+  }
+)
+
+export const compareWithSelectedAction = withTelemetry(
+  (deps: ComparisonDeps, arg?: SkillTreeItem) => compareWithSelectedImpl(deps, arg),
+  {
+    source: 'vscode-extension',
+    extractSkillId: () => 'compareWithSelected',
+  }
+)
+
 /**
- * Registers the Compare Skills command (`skillsmith.compareSkills`).
+ * Registers the Compare Skills command (`skillsmith.compareSkills`) and the two
+ * tree-context compare commands added by SMI-5340.
  */
 export function registerCompareCommand(
   context: vscode.ExtensionContext,
   skillService: SkillService
 ): void {
-  const command = vscode.commands.registerCommand('skillsmith.compareSkills', () =>
-    compareCommandAction({ skillService, context })
+  const deps: ComparisonDeps = { skillService, context }
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('skillsmith.compareSkills', () => compareCommandAction(deps)),
+    vscode.commands.registerCommand('skillsmith.selectForCompare', (arg?: SkillTreeItem) =>
+      selectForCompareAction(deps, arg)
+    ),
+    vscode.commands.registerCommand('skillsmith.compareWithSelected', (arg?: SkillTreeItem) =>
+      compareWithSelectedAction(deps, arg)
+    )
   )
-  context.subscriptions.push(command)
 }

--- a/packages/vscode-extension/src/commands/diffCommand.ts
+++ b/packages/vscode-extension/src/commands/diffCommand.ts
@@ -12,7 +12,7 @@
 import * as vscode from 'vscode'
 import { readFile } from 'node:fs/promises'
 import * as path from 'node:path'
-import type { SkillItemData } from '../sidebar/SkillTreeItem.js'
+import type { SkillItemData, SkillTreeItem } from '../sidebar/SkillTreeItem.js'
 import type { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
 import { getTrustTierCodicon } from '../sidebar/trustTier.js'
 import { getMcpClient } from '../mcp/McpClient.js'
@@ -59,10 +59,16 @@ async function pickInstalledSkill(
 async function diffCommandImpl(deps: {
   treeProvider: SkillTreeDataProvider
   context: vscode.ExtensionContext
+  preselected?: SkillTreeItem | undefined
 }): Promise<void> {
   track('vscode_diff_start')
 
-  const skill = await pickInstalledSkill(deps.treeProvider)
+  let skill: SkillItemData | undefined
+  if (deps.preselected?.skillData?.isInstalled && deps.preselected.skillData.path) {
+    skill = deps.preselected.skillData
+  } else {
+    skill = await pickInstalledSkill(deps.treeProvider)
+  }
   if (!skill || !skill.path) {
     return
   }
@@ -148,8 +154,8 @@ export function registerDiffCommand(
   context: vscode.ExtensionContext,
   treeProvider: SkillTreeDataProvider
 ): void {
-  const command = vscode.commands.registerCommand('skillsmith.diffSkill', () =>
-    diffCommandAction({ treeProvider, context })
+  const command = vscode.commands.registerCommand('skillsmith.diffSkill', (arg?: SkillTreeItem) =>
+    diffCommandAction({ treeProvider, context, preselected: arg })
   )
   context.subscriptions.push(command)
 }

--- a/packages/vscode-extension/src/views/SkillDetailPanel.ts
+++ b/packages/vscode-extension/src/views/SkillDetailPanel.ts
@@ -192,6 +192,18 @@ export class SkillDetailPanel {
           track('vscode_open_folder', { surface: 'detail-panel' })
         }
         return
+      case 'diffSkill':
+        if (this._installed && this._skillPath) {
+          void vscode.commands.executeCommand('skillsmith.diffSkill', {
+            skillData: {
+              id: this._skillId,
+              name: this._skillData?.name ?? this._skillId,
+              isInstalled: true,
+              path: this._skillPath,
+            },
+          })
+        }
+        return
     }
   }
 

--- a/packages/vscode-extension/src/views/skill-panel-actions.ts
+++ b/packages/vscode-extension/src/views/skill-panel-actions.ts
@@ -39,6 +39,7 @@ export function getActionBlock(ctx: SkillActionContext, safeRepository: string):
         <button class="btn-destructive" id="uninstallBtn" aria-label="Uninstall this skill">Uninstall</button>
         <button class="btn-secondary" id="openFolderBtn" aria-label="Open the skill folder">Open Folder</button>
         ${openSkillFileButton}
+        <button class="btn-secondary" id="diffBtn" aria-label="View changes for this skill">View changes</button>
         ${repoButton}
     </div>`
 }

--- a/packages/vscode-extension/src/views/skill-panel-script.ts
+++ b/packages/vscode-extension/src/views/skill-panel-script.ts
@@ -44,6 +44,13 @@ export function getScript(nonce: string): string {
             });
         }
 
+        const diffBtn = document.getElementById('diffBtn');
+        if (diffBtn) {
+            diffBtn.addEventListener('click', function() {
+                vscode.postMessage({ command: 'diffSkill' });
+            });
+        }
+
         const repoBtn = document.getElementById('repoBtn');
         if (repoBtn) {
             repoBtn.addEventListener('click', function() {

--- a/packages/vscode-extension/src/views/skill-panel-types.ts
+++ b/packages/vscode-extension/src/views/skill-panel-types.ts
@@ -19,6 +19,7 @@ export interface SkillPanelMessage {
     | 'uninstall'
     | 'openSkillFile'
     | 'openFolder'
+    | 'diffSkill'
   url?: string
 }
 

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2025,6 +2025,8 @@ console.log(`\n${BOLD}28. VS Code Command ↔ Test Pairing (SMI-4194)${RESET}`)
         'skillsmith.searchSkills', // exercised through SkillService tests
         'skillsmith.installSkill', // exercised through SkillService tests
         'skillsmith.filterSkills', // SMI-5304: collector in searchFilters.test.ts, action in searchSkills.test.ts
+        'skillsmith.selectForCompare', // SMI-5340: tree-context compare; action tested in compareSkills.test.ts + compare-source.test.ts
+        'skillsmith.compareWithSelected', // SMI-5340: tree-context compare; action tested in compareSkills.test.ts
         'skillsmith.clearSkillFilters', // SMI-5304: action exercised in searchSkills.test.ts
       ])
       const testFiles = readdirSync(testDir).filter((f) => f.endsWith('.test.ts'))


### PR DESCRIPTION
## What

Wires the two missing entry points for the already-shipped compare (#1456) and diff (#1457) features in the VS Code extension, plus nightly E2E coverage. Closes the AC gaps held open in the 2026-06-21 triage sweep (SMI-5287).

## Changes

**#1456 — compare from the tree** (Select for Compare / Compare with Selected — VS Code's native two-step)
- New `selectForCompare` + `compareWithSelected` commands, backed by a session compare-source + `skillsmith.compareSourceSet` context key (`compare-source.ts`). Palette `compareSkills` (two QuickPicks) unchanged.

**#1457 — diff entry points**
- `diffSkill` accepts a pre-selected installed skill (skips the picker; guards on `.path`), wired from an installed-skill tree context menu **and** a detail-panel "View changes" button.

**Wiring + meta**
- `package.json`: 2 commands + 3 `view/item/context` menus + `commandPalette` suppression.
- telemetry-coverage map + count (10→12); `activation.e2e.ts` command count (13→15).

**Nightly E2E (SMI-5339 Phase 2b)**
- `compare.e2e.ts` + `diff.e2e.ts` drive the **real** commands via synthetic `SkillTreeItem` args (no test-only seam), asserting via `readFakeMcpLog` + `vscode.window.tabGroups`. The `full`-job glob auto-picks them — no `vscode-e2e.yml` edit; they are not in the per-PR smoke `--spec` list (verify via the nightly/dispatch full job).

## Verification
- typecheck + eslint (0 warnings); **68 unit tests**; **5/5 E2E pass on real VS Code** (2 new + 3 existing, no regression).
- Plan review (SHIP-WITH-FIXES — all folded) + governance review (SHIP-WITH-FIXES — clear-source-on-failure fixed + test added).

Plan: `docs/internal/implementation/2026-06-22-vscode-compare-diff-entrypoints-e2e.md`.

Closes #1456, closes #1457. SMI-5340.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)