### PR TITLE
feat(vscode): close Epics B + C — proactive MCP-offline sidebar + post-create checklist (SMI-5345, SMI-5346)

### DIFF
--- a/packages/vscode-extension/e2e/specs/activation.e2e.ts
+++ b/packages/vscode-extension/e2e/specs/activation.e2e.ts
@@ -9,7 +9,7 @@ import { browser, expect } from '@wdio/globals'
 
 const EXTENSION_ID = 'skillsmith.skillsmith-vscode'
 
-// The 15 commands contributed in package.json `contributes.commands`.
+// The 17 commands contributed in package.json `contributes.commands`.
 const EXPECTED_COMMANDS = [
   'skillsmith.searchSkills',
   'skillsmith.installSkill',
@@ -26,6 +26,8 @@ const EXPECTED_COMMANDS = [
   'skillsmith.compareWithSelected',
   'skillsmith.diffSkill',
   'skillsmith.auditInventory',
+  'skillsmith.runValidate',
+  'skillsmith.dismissNextSteps',
 ]
 
 describe('Skillsmith extension activation', () => {
@@ -45,7 +47,7 @@ describe('Skillsmith extension activation', () => {
     expect(isActive).toBe(true)
   })
 
-  it('registers all 15 contributed commands', async () => {
+  it('registers all 17 contributed commands', async () => {
     const registered: string[] = await browser.executeWorkbench((vscode) =>
       vscode.commands.getCommands(true)
     )

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -130,6 +130,18 @@
         "title": "Audit Skill Inventory",
         "category": "Skillsmith",
         "icon": "$(search)"
+      },
+      {
+        "command": "skillsmith.runValidate",
+        "title": "Validate Skill",
+        "category": "Skillsmith",
+        "icon": "$(check)"
+      },
+      {
+        "command": "skillsmith.dismissNextSteps",
+        "title": "Dismiss",
+        "category": "Skillsmith",
+        "icon": "$(close)"
       }
     ],
     "keybindings": [
@@ -221,6 +233,11 @@
       ],
       "view/item/context": [
         {
+          "command": "skillsmith.dismissNextSteps",
+          "when": "view == skillsmith.skillsView && viewItem == nextStepsGroup",
+          "group": "inline"
+        },
+        {
           "command": "skillsmith.installSkill",
           "when": "view == skillsmith.skillsView && viewItem == skill",
           "group": "inline"
@@ -266,6 +283,10 @@
         },
         {
           "command": "skillsmith.compareWithSelected",
+          "when": "false"
+        },
+        {
+          "command": "skillsmith.dismissNextSteps",
           "when": "false"
         }
       ]

--- a/packages/vscode-extension/src/__tests__/CreateSkillPanel.guards.test.ts
+++ b/packages/vscode-extension/src/__tests__/CreateSkillPanel.guards.test.ts
@@ -27,7 +27,7 @@ const {
   validateSkillNameMock,
   runCliMock,
   existsMock,
-  showPostCreateChecklistMock,
+  showNextStepsMock,
 } = vi.hoisted(() => ({
   createWebviewPanel: vi.fn(),
   showWarningMessage: vi.fn(),
@@ -37,7 +37,7 @@ const {
   validateSkillNameMock: vi.fn(),
   runCliMock: vi.fn(),
   existsMock: vi.fn(),
-  showPostCreateChecklistMock: vi.fn(),
+  showNextStepsMock: vi.fn(),
 }))
 
 // ── vscode mock ──────────────────────────────────────────────────────────────
@@ -91,7 +91,7 @@ vi.mock('../utils/createSkill.helpers.js', () => ({
   targetDirFor: (name: string) => `/home/user/.claude/skills/${name}`,
   runCli: runCliMock,
   exists: existsMock,
-  showPostCreateChecklist: showPostCreateChecklistMock,
+  runValidate: vi.fn(),
 }))
 
 // ── CSP / nonce mock ─────────────────────────────────────────────────────────
@@ -120,6 +120,7 @@ const refreshAndWait = vi.fn(async () => {})
 vi.mock('../sidebar/SkillTreeDataProvider.js', () => ({
   SkillTreeDataProvider: class {
     refreshAndWait = refreshAndWait
+    showNextSteps = showNextStepsMock
   },
 }))
 
@@ -209,6 +210,7 @@ const FAKE_OUTPUT = {
 function makeTreeProvider(): SkillTreeDataProvider {
   return {
     refreshAndWait,
+    showNextSteps: showNextStepsMock,
     getInstalledSkills: vi.fn(() => []),
   } as unknown as SkillTreeDataProvider
 }
@@ -228,7 +230,7 @@ describe('CreateSkillPanel (guards / edge cases)', () => {
     validateSkillNameMock.mockReset().mockReturnValue(true)
     runCliMock.mockReset().mockResolvedValue(0)
     existsMock.mockReset().mockResolvedValue(false)
-    showPostCreateChecklistMock.mockReset().mockResolvedValue(undefined)
+    showNextStepsMock.mockReset()
     refreshAndWait.mockReset().mockResolvedValue(undefined)
     showWarningMessage.mockReset()
     openTextDocument.mockReset().mockRejectedValue(new Error('not found'))
@@ -324,6 +326,24 @@ describe('CreateSkillPanel (guards / edge cases)', () => {
         (call: unknown[]) => call[0] === 'vscode_create_cancelled'
       )
       expect(cancelledCalls).toHaveLength(0)
+    })
+
+    // SMI-5346: on success, showNextSteps is called instead of the old toast.
+    it('calls showNextSteps on the tree provider after a successful create', async () => {
+      runCliMock.mockResolvedValue(0)
+      existsMock.mockResolvedValue(false)
+      const mock = createMockPanel()
+      vi.mocked(createWebviewPanel).mockReturnValue(mock.panel)
+
+      CreateSkillPanel.createOrShow(EXTENSION_URI, FAKE_OUTPUT, makeTreeProvider())
+      mock.sendMessage({ command: 'submit', fields: VALID_FIELDS })
+
+      await vi.waitFor(() => {
+        expect(showNextStepsMock).toHaveBeenCalledWith(
+          VALID_FIELDS.name,
+          `/home/user/.claude/skills/${VALID_FIELDS.name}`
+        )
+      })
     })
   })
 

--- a/packages/vscode-extension/src/__tests__/CreateSkillPanel.test.ts
+++ b/packages/vscode-extension/src/__tests__/CreateSkillPanel.test.ts
@@ -19,7 +19,6 @@ const {
   validateSkillNameMock,
   runCliMock,
   existsMock,
-  showPostCreateChecklistMock,
 } = vi.hoisted(() => ({
   createWebviewPanel: vi.fn(),
   showWarningMessage: vi.fn(),
@@ -29,7 +28,6 @@ const {
   validateSkillNameMock: vi.fn(),
   runCliMock: vi.fn(),
   existsMock: vi.fn(),
-  showPostCreateChecklistMock: vi.fn(),
 }))
 
 // ── vscode mock ──────────────────────────────────────────────────────────────
@@ -83,7 +81,6 @@ vi.mock('../utils/createSkill.helpers.js', () => ({
   targetDirFor: (name: string) => `/home/user/.claude/skills/${name}`,
   runCli: runCliMock,
   exists: existsMock,
-  showPostCreateChecklist: showPostCreateChecklistMock,
 }))
 
 // ── CSP / nonce mock ─────────────────────────────────────────────────────────
@@ -225,7 +222,6 @@ describe('CreateSkillPanel', () => {
     validateSkillNameMock.mockReset().mockReturnValue(true)
     runCliMock.mockReset().mockResolvedValue(0)
     existsMock.mockReset().mockResolvedValue(false)
-    showPostCreateChecklistMock.mockReset().mockResolvedValue(undefined)
     showNextStepsMock.mockReset()
     refreshAndWait.mockReset().mockResolvedValue(undefined)
     showWarningMessage.mockReset()

--- a/packages/vscode-extension/src/__tests__/CreateSkillPanel.test.ts
+++ b/packages/vscode-extension/src/__tests__/CreateSkillPanel.test.ts
@@ -109,9 +109,13 @@ vi.mock('../utils/skillNameValidation.js', () => ({
 
 // ── SkillTreeDataProvider mock ────────────────────────────────────────────────
 const refreshAndWait = vi.fn(async () => {})
+// SMI-5346: the post-create toast was replaced by the sidebar "Next steps"
+// section — the panel now calls `treeProvider.showNextSteps(name, targetDir)`.
+const showNextStepsMock = vi.fn()
 vi.mock('../sidebar/SkillTreeDataProvider.js', () => ({
   SkillTreeDataProvider: class {
     refreshAndWait = refreshAndWait
+    showNextSteps = showNextStepsMock
   },
 }))
 
@@ -202,6 +206,7 @@ function makeTreeProvider(): SkillTreeDataProvider {
   return {
     refreshAndWait,
     getInstalledSkills: vi.fn(() => []),
+    showNextSteps: showNextStepsMock,
   } as unknown as SkillTreeDataProvider
 }
 
@@ -221,6 +226,7 @@ describe('CreateSkillPanel', () => {
     runCliMock.mockReset().mockResolvedValue(0)
     existsMock.mockReset().mockResolvedValue(false)
     showPostCreateChecklistMock.mockReset().mockResolvedValue(undefined)
+    showNextStepsMock.mockReset()
     refreshAndWait.mockReset().mockResolvedValue(undefined)
     showWarningMessage.mockReset()
     openTextDocument.mockReset().mockRejectedValue(new Error('not found'))
@@ -313,9 +319,9 @@ describe('CreateSkillPanel', () => {
       )
       expect(trackMock).toHaveBeenCalledWith('vscode_create_complete', { type: 'basic' })
       expect(refreshAndWait).toHaveBeenCalled()
-      expect(showPostCreateChecklistMock).toHaveBeenCalledWith(
-        '/home/user/.claude/skills/my-skill',
-        'my-skill'
+      expect(showNextStepsMock).toHaveBeenCalledWith(
+        'my-skill',
+        '/home/user/.claude/skills/my-skill'
       )
     })
   })

--- a/packages/vscode-extension/src/__tests__/createSkill.checklist.test.ts
+++ b/packages/vscode-extension/src/__tests__/createSkill.checklist.test.ts
@@ -1,96 +1,137 @@
 /**
- * Tests for showPostCreateChecklist (relocated from createSkillCommand.test.ts,
- * SMI-5313 / GH #1454). Import from utils/createSkill.helpers.js — the function
- * moved there when the helpers were extracted for shared use by CreateSkillPanel.
+ * Tests for the post-create sidebar section (SMI-5346) and runValidate helper.
+ *
+ * Replaces the old toast-based showPostCreateChecklist assertions:
+ *  - runValidate calls output.show + spawns ['validate'] + writes completion line
+ *  - showNextSteps is called on create success (tested via guards test + here)
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'node:events'
 
-const showInformationMessage = vi.fn()
-const executeCommand = vi.fn()
-const openExternal = vi.fn()
+// ── cross-spawn mock (top level — hoisted) ───────────────────────────────────
+const spawnMock = vi.fn()
+vi.mock('cross-spawn', () => ({ default: spawnMock }))
 
+// ── vscode mock ───────────────────────────────────────────────────────────────
 vi.mock('vscode', () => ({
   window: {
-    showInformationMessage,
+    showInformationMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
   },
-  commands: { executeCommand },
-  env: { openExternal },
+  env: {
+    clipboard: { writeText: vi.fn() },
+    openExternal: vi.fn(),
+  },
   Uri: {
     file: (s: string) => ({ toString: () => s, fsPath: s }),
     parse: (s: string) => ({ toString: () => s }),
   },
 }))
 
+// ── Telemetry mock ────────────────────────────────────────────────────────────
 vi.mock('../services/Telemetry.js', () => ({
   track: vi.fn(),
 }))
 
-/**
- * Drain microtask queue so the fire-and-forget promise fully settles.
- */
-const flushAsync = (): Promise<void> =>
-  new Promise((resolve) => setImmediate(() => setImmediate(() => resolve())))
+// ─────────────────────────────────────────────────────────────────────────────
 
-describe('showPostCreateChecklist (GH #1453 / SMI-5312)', () => {
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter
+  stderr: EventEmitter
+  kill: () => void
+}
+
+function makeCliChild(exitCode: number, chunks?: string[], errorMsg?: string): FakeChild {
+  const c = new EventEmitter() as FakeChild
+  c.stdout = new EventEmitter()
+  c.stderr = new EventEmitter()
+  c.kill = vi.fn()
+  queueMicrotask(() => {
+    if (errorMsg) {
+      c.emit('error', new Error(errorMsg))
+    } else {
+      if (chunks) {
+        for (const chunk of chunks) {
+          c.stdout.emit('data', Buffer.from(chunk, 'utf8'))
+        }
+      }
+      c.emit('exit', exitCode)
+    }
+  })
+  return c
+}
+
+describe('runValidate (SMI-5346)', () => {
+  const fakeOutput = {
+    append: vi.fn(),
+    appendLine: vi.fn(),
+    show: vi.fn(),
+    dispose: vi.fn(),
+  }
+
   beforeEach(() => {
-    showInformationMessage.mockReset()
-    executeCommand.mockReset()
-    openExternal.mockReset()
+    spawnMock.mockReset()
+    fakeOutput.append.mockReset()
+    fakeOutput.appendLine.mockReset()
+    fakeOutput.show.mockReset()
     vi.resetModules()
   })
 
-  it('opens the skill folder in OS when user picks "Open folder"', async () => {
-    const { track } = await import('../services/Telemetry.js')
-    showInformationMessage.mockResolvedValue('Open folder')
-    const { showPostCreateChecklist } = await import('../utils/createSkill.helpers.js')
+  it('calls output.show(true) before spawning', async () => {
+    spawnMock.mockImplementationOnce(() => makeCliChild(0))
+    const { runValidate } = await import('../utils/createSkill.helpers.js')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await runValidate(fakeOutput as any)
+    expect(fakeOutput.show).toHaveBeenCalledWith(true)
+  })
 
-    void showPostCreateChecklist('/home/user/.claude/skills/my-skill', 'my-skill')
-    await flushAsync()
-
-    expect(executeCommand).toHaveBeenCalledWith(
-      'revealFileInOS',
-      expect.objectContaining({ toString: expect.any(Function) })
+  it('spawns skillsmith with ["validate"] args (array, injection-safe)', async () => {
+    spawnMock.mockImplementationOnce(() => makeCliChild(0))
+    const { runValidate } = await import('../utils/createSkill.helpers.js')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await runValidate(fakeOutput as any)
+    expect(spawnMock).toHaveBeenCalledWith(
+      'skillsmith',
+      ['validate'],
+      expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
     )
-    expect(track).toHaveBeenCalledWith('vscode_create_checklist_action', {
-      action: 'open_folder',
-    })
-    expect(openExternal).not.toHaveBeenCalled()
   })
 
-  it('opens the authoring docs URL when user picks "Authoring docs"', async () => {
-    const { track } = await import('../services/Telemetry.js')
-    showInformationMessage.mockResolvedValue('Authoring docs')
-    const { showPostCreateChecklist } = await import('../utils/createSkill.helpers.js')
-
-    void showPostCreateChecklist('/home/user/.claude/skills/my-skill', 'my-skill')
-    await flushAsync()
-
-    expect(openExternal).toHaveBeenCalledWith(
-      expect.objectContaining({ toString: expect.any(Function) })
+  it('writes a success line on exit 0', async () => {
+    spawnMock.mockImplementationOnce(() => makeCliChild(0))
+    const { runValidate } = await import('../utils/createSkill.helpers.js')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await runValidate(fakeOutput as any)
+    expect(fakeOutput.appendLine).toHaveBeenCalledWith(
+      expect.stringContaining('completed successfully')
     )
-    expect(track).toHaveBeenCalledWith('vscode_create_checklist_action', { action: 'docs' })
-    expect(executeCommand).not.toHaveBeenCalled()
   })
 
-  it('swallows errors from executeCommand without unhandled rejection', async () => {
-    showInformationMessage.mockResolvedValue('Open folder')
-    executeCommand.mockRejectedValue(new Error('Host shutting down'))
-    const { showPostCreateChecklist } = await import('../utils/createSkill.helpers.js')
-
-    // Should not throw / cause unhandled rejection
-    await expect(
-      showPostCreateChecklist('/home/user/.claude/skills/my-skill', 'my-skill')
-    ).resolves.toBeUndefined()
+  it('writes a failure line + hint on non-zero exit', async () => {
+    spawnMock.mockImplementationOnce(() => makeCliChild(1))
+    const { runValidate } = await import('../utils/createSkill.helpers.js')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await runValidate(fakeOutput as any)
+    const calls = fakeOutput.appendLine.mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(calls.some((line) => line.includes('exited with code'))).toBe(true)
   })
 
-  it('takes no action when user dismisses the checklist toast', async () => {
-    showInformationMessage.mockResolvedValue(undefined)
-    const { showPostCreateChecklist } = await import('../utils/createSkill.helpers.js')
+  it('writes an error line on spawn error', async () => {
+    spawnMock.mockImplementationOnce(() => makeCliChild(0, [], 'ENOENT: spawn failed'))
+    const { runValidate } = await import('../utils/createSkill.helpers.js')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await runValidate(fakeOutput as any)
+    const calls = fakeOutput.appendLine.mock.calls.map((c: unknown[]) => String(c[0]))
+    expect(calls.some((line) => line.includes('[error]'))).toBe(true)
+  })
 
-    void showPostCreateChecklist('/home/user/.claude/skills/my-skill', 'my-skill')
-    await flushAsync()
-
-    expect(executeCommand).not.toHaveBeenCalled()
-    expect(openExternal).not.toHaveBeenCalled()
+  it('streams stdout chunks to the output channel', async () => {
+    spawnMock.mockImplementationOnce(() => makeCliChild(0, ['validation output line\n']))
+    const { runValidate } = await import('../utils/createSkill.helpers.js')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await runValidate(fakeOutput as any)
+    expect(fakeOutput.append).toHaveBeenCalledWith(
+      expect.stringContaining('validation output line')
+    )
   })
 })

--- a/packages/vscode-extension/src/__tests__/createSkill.checklist.test.ts
+++ b/packages/vscode-extension/src/__tests__/createSkill.checklist.test.ts
@@ -134,4 +134,34 @@ describe('runValidate (SMI-5346)', () => {
       expect.stringContaining('validation output line')
     )
   })
+
+  it('on timeout: kills the child and writes ONLY the timeout line (post-kill exit is suppressed)', async () => {
+    const { runValidate } = await import('../utils/createSkill.helpers.js')
+    vi.useFakeTimers()
+    try {
+      // A child that never exits on its own — the 30s timeout must fire first.
+      const child = new EventEmitter() as FakeChild
+      child.stdout = new EventEmitter()
+      child.stderr = new EventEmitter()
+      child.kill = vi.fn()
+      spawnMock.mockImplementationOnce(() => child)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pending = runValidate(fakeOutput as any)
+      // Fire the 30s timeout: kill + timeout line + resolve.
+      await vi.advanceTimersByTimeAsync(30_000)
+      // kill() triggers `exit` on a real process — simulate it. The `settled`
+      // guard must suppress a second completion line.
+      child.emit('exit', null)
+      await pending
+
+      expect(child.kill).toHaveBeenCalled()
+      const lines = fakeOutput.appendLine.mock.calls.map((c: unknown[]) => String(c[0]))
+      expect(lines.some((l) => l.includes('timed out'))).toBe(true)
+      expect(lines.some((l) => l.includes('exited with code'))).toBe(false)
+      expect(lines.some((l) => l.includes('completed successfully'))).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/packages/vscode-extension/src/__tests__/createSkillCommand.test.ts
+++ b/packages/vscode-extension/src/__tests__/createSkillCommand.test.ts
@@ -49,6 +49,7 @@ const refreshAndWait = vi.fn(async () => {})
 vi.mock('../sidebar/SkillTreeDataProvider.js', () => ({
   SkillTreeDataProvider: class {
     refreshAndWait = refreshAndWait
+    showNextSteps = vi.fn()
   },
 }))
 
@@ -60,7 +61,7 @@ vi.mock('../utils/createSkill.helpers.js', () => ({
   exists: vi.fn(),
   buildCreateArgs: vi.fn(),
   targetDirFor: vi.fn(),
-  showPostCreateChecklist: vi.fn(),
+  runValidate: vi.fn(),
 }))
 
 // ── CreateSkillPanel mock ─────────────────────────────────────────────────────
@@ -101,11 +102,18 @@ describe('createSkillCommand (SMI-5313 rewire)', () => {
     vi.resetModules()
     const { registerCreateSkillCommand } = await import('../commands/createSkillCommand.js')
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
     const context = {
       subscriptions: [],
       extensionUri: FAKE_EXTENSION_URI,
+      globalState: {
+        get: vi.fn(),
+        update: vi.fn(async () => {}),
+        keys: vi.fn(() => []),
+        setKeysForSync: vi.fn(),
+      },
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const provider = new SkillTreeDataProvider(context as any)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerCreateSkillCommand(context as any, provider as any)
     const call = registerCommand.mock.calls[0]

--- a/packages/vscode-extension/src/__tests__/searchSkills.filters.test.ts
+++ b/packages/vscode-extension/src/__tests__/searchSkills.filters.test.ts
@@ -114,10 +114,23 @@ function makeService(result: { results: SkillData[]; isOffline: boolean }) {
   return { search: vi.fn(async () => result) }
 }
 
+/**
+ * SMI-5345: `performSearch` routes the persistent banner / no-results / offline
+ * copy through the `SidebarMessageState` machine (the single owner of
+ * `view.message`) instead of writing `view.message` directly. Tests assert on
+ * `setSearchBanner` and pass this mock as the (now required) dep.
+ */
+function makeMessageState() {
+  return { setFirstRunHint: vi.fn(), setSearchBanner: vi.fn(), setOffline: vi.fn() }
+}
+
+let messageState = makeMessageState()
+
 describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     currentToken = { isCancellationRequested: false }
+    messageState = makeMessageState()
   })
 
   it('performSearch threads stored filters into skillService.search (via search command)', async () => {
@@ -135,6 +148,7 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
     expect(service.search).toHaveBeenCalledWith('react', filters)
@@ -157,6 +171,7 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
     expect(provider.setFilters).toHaveBeenCalledWith({ trustTier: 'verified' })
@@ -182,6 +197,7 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
     expect(service.search).toHaveBeenCalledWith('', { category: 'DevOps' })
@@ -206,6 +222,7 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
     expect(provider.setFilters).not.toHaveBeenCalled()
@@ -230,6 +247,7 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
     expect(provider.clearFilters).toHaveBeenCalledTimes(1)
@@ -255,9 +273,12 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
-    expect(view.message).toBe('Showing results for "react" · Verified · Testing · 70+')
+    expect(messageState.setSearchBanner).toHaveBeenCalledWith(
+      'Showing results for "react" · Verified · Testing · 70+'
+    )
   })
 
   it('sets a persistent banner on no-results and clears the result set', async () => {
@@ -274,9 +295,10 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
-    expect(view.message).toBe('No skills found for "zzz"')
+    expect(messageState.setSearchBanner).toHaveBeenCalledWith('No skills found for "zzz"')
     expect(provider.clearSearchResults).toHaveBeenCalledTimes(1)
   })
 
@@ -297,6 +319,7 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
     expect(showInformationMessage).toHaveBeenCalledWith(
@@ -318,10 +341,13 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
     expect(showWarningMessage).toHaveBeenCalled()
-    expect(view.message).toBe('Skillsmith server unavailable — start the MCP server and try again.')
+    expect(messageState.setSearchBanner).toHaveBeenCalledWith(
+      'Skillsmith server unavailable — start the MCP server and try again.'
+    )
     expect(provider.clearSearchResults).toHaveBeenCalledTimes(1)
   })
 
@@ -342,6 +368,7 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
     expect(executeCommand).toHaveBeenCalledWith('setContext', 'skillsmith.hasActiveFilters', true)
@@ -361,6 +388,7 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
     expect(executeCommand).toHaveBeenCalledWith('setContext', 'skillsmith.hasActiveFilters', false)
@@ -380,6 +408,7 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
     expect(executeCommand).toHaveBeenCalledWith('setContext', 'skillsmith.hasActiveFilters', false)
@@ -401,6 +430,7 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     })
 
     // clearFilters() flips the fake provider's hasActiveFilters to false.
@@ -433,6 +463,7 @@ describe('filter + banner + context-key (#1433 / #1432 / #1434-P2)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState,
     }
 
     await searchSkillsAction(deps)

--- a/packages/vscode-extension/src/__tests__/searchSkills.test.ts
+++ b/packages/vscode-extension/src/__tests__/searchSkills.test.ts
@@ -114,6 +114,15 @@ function makeService(result: { results: SkillData[]; isOffline: boolean }) {
   return { search: vi.fn(async () => result) }
 }
 
+/**
+ * SMI-5345: `performSearch` now routes banner/offline copy through the
+ * `SidebarMessageState` machine instead of writing `view.message` directly.
+ * Tests pass a mock so the (now required) dep is satisfied.
+ */
+function makeMessageState() {
+  return { setFirstRunHint: vi.fn(), setSearchBanner: vi.fn(), setOffline: vi.fn() }
+}
+
 describe('searchSkillsAction (#1431 / SMI-5298, #1434-P1)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -134,6 +143,7 @@ describe('searchSkillsAction (#1431 / SMI-5298, #1434-P1)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState: makeMessageState(),
     })
 
     expect(provider.setSearchResults).toHaveBeenCalledWith(expect.any(Array), 'docker', {
@@ -161,6 +171,7 @@ describe('searchSkillsAction (#1431 / SMI-5298, #1434-P1)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState: makeMessageState(),
     })
 
     const revealArg = view.reveal.mock.calls[0]?.[0]
@@ -185,6 +196,7 @@ describe('searchSkillsAction (#1431 / SMI-5298, #1434-P1)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState: makeMessageState(),
     })
 
     expect(executeCommand).toHaveBeenCalledWith('skillsmith.skillsView.focus')
@@ -205,6 +217,7 @@ describe('searchSkillsAction (#1431 / SMI-5298, #1434-P1)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState: makeMessageState(),
     })
 
     expect(provider.clearSearchResults).toHaveBeenCalledTimes(1)
@@ -230,6 +243,7 @@ describe('searchSkillsAction (#1431 / SMI-5298, #1434-P1)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState: makeMessageState(),
     })
 
     expect(showWarningMessage).toHaveBeenCalledWith(
@@ -255,6 +269,7 @@ describe('searchSkillsAction (#1431 / SMI-5298, #1434-P1)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState: makeMessageState(),
     })
 
     expect(service.search).not.toHaveBeenCalled()
@@ -278,6 +293,7 @@ describe('searchSkillsAction (#1431 / SMI-5298, #1434-P1)', () => {
       skillsView: view as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       skillService: service as any,
+      messageState: makeMessageState(),
     })
 
     expect(service.search).not.toHaveBeenCalled()

--- a/packages/vscode-extension/src/__tests__/skillTreeDataProvider.crossref.test.ts
+++ b/packages/vscode-extension/src/__tests__/skillTreeDataProvider.crossref.test.ts
@@ -58,9 +58,30 @@ vi.mock('vscode', () => {
     ThemeColor: class {
       constructor(public id: string) {}
     },
-    Uri: { parse: (s: string) => ({ toString: () => s }) },
+    Uri: {
+      file: (s: string) => ({ toString: () => s, fsPath: s }),
+      parse: (s: string) => ({ toString: () => s }),
+    },
   }
 })
+
+vi.mock('../services/Telemetry.js', () => ({
+  track: vi.fn(),
+}))
+
+function makeContext(): import('vscode').ExtensionContext {
+  const store = new Map<string, unknown>()
+  return {
+    globalState: {
+      get: <T>(key: string) => store.get(key) as T | undefined,
+      update: async (key: string, value: unknown) => {
+        store.set(key, value)
+      },
+      keys: () => [...store.keys()],
+      setKeysForSync: vi.fn(),
+    },
+  } as unknown as import('vscode').ExtensionContext
+}
 
 describe('SkillTreeDataProvider installedElsewhere cross-reference (#1436 / SMI-5307)', () => {
   // C2: normalized id cross-reference — registry id `smith-horn/my-skill` must
@@ -78,7 +99,7 @@ describe('SkillTreeDataProvider installedElsewhere cross-reference (#1436 / SMI-
       } as any)
 
       const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-      const provider = new SkillTreeDataProvider()
+      const provider = new SkillTreeDataProvider(makeContext())
       await provider.refreshAndWait()
 
       provider.setSearchResults(
@@ -142,7 +163,7 @@ describe('SkillTreeDataProvider installedElsewhere cross-reference (#1436 / SMI-
       } as any)
 
       const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-      const provider = new SkillTreeDataProvider()
+      const provider = new SkillTreeDataProvider(makeContext())
 
       // Set search results immediately (before the constructor-fired load settles).
       provider.setSearchResults(
@@ -190,7 +211,7 @@ describe('SkillTreeDataProvider installedElsewhere cross-reference (#1436 / SMI-
       } as any)
 
       const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-      const provider = new SkillTreeDataProvider()
+      const provider = new SkillTreeDataProvider(makeContext())
       await provider.refreshAndWait()
 
       // Search arrives after load has settled.
@@ -237,7 +258,7 @@ describe('SkillTreeDataProvider installedElsewhere cross-reference (#1436 / SMI-
       } as any)
 
       const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-      const provider = new SkillTreeDataProvider()
+      const provider = new SkillTreeDataProvider(makeContext())
       await provider.refreshAndWait()
 
       provider.setSearchResults(
@@ -294,7 +315,7 @@ describe('SkillTreeDataProvider hasSkillMd (#1436 / SMI-5307)', () => {
       } as any)
 
       const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-      const provider = new SkillTreeDataProvider()
+      const provider = new SkillTreeDataProvider(makeContext())
       await provider.refreshAndWait()
 
       const installed = provider.getInstalledSkills()
@@ -319,7 +340,7 @@ describe('SkillTreeDataProvider hasSkillMd (#1436 / SMI-5307)', () => {
       } as any)
 
       const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-      const provider = new SkillTreeDataProvider()
+      const provider = new SkillTreeDataProvider(makeContext())
       await provider.refreshAndWait()
 
       const installed = provider.getInstalledSkills()

--- a/packages/vscode-extension/src/__tests__/skillTreeDataProvider.nextSteps.test.ts
+++ b/packages/vscode-extension/src/__tests__/skillTreeDataProvider.nextSteps.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Unit tests for SkillTreeDataProvider next-steps and MCP-offline features
+ * (SMI-5345 / SMI-5346).
+ *
+ * Covers:
+ *  - showNextSteps adds the 'Next steps' group with 4 rows
+ *  - dismissNextSteps (and the dismissed flag) hides it
+ *  - a fresh showNextSteps after dismiss RE-shows (per-create reset)
+ *  - setMcpOffline(true) prepends the reconnect row; false removes it
+ *  - showNextSteps emits 'vscode_create_checklist_view' EXACTLY ONCE even across
+ *    multiple getChildren calls (mock track)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── vscode mock ───────────────────────────────────────────────────────────────
+const trackMock = vi.fn()
+
+vi.mock('vscode', () => {
+  class TreeItem {
+    constructor(
+      public label: string,
+      public collapsibleState?: number
+    ) {}
+    iconPath?: unknown
+    description?: string
+    tooltip?: unknown
+    contextValue?: string
+    command?: unknown
+    id?: string
+  }
+  return {
+    EventEmitter: class {
+      event = vi.fn()
+      fire = vi.fn()
+    },
+    workspace: {
+      getConfiguration: vi.fn(() => ({ get: vi.fn(() => undefined) })),
+    },
+    TreeItem,
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    MarkdownString: class {
+      value = ''
+      isTrusted = true
+      appendMarkdown(s: string) {
+        this.value += s
+        return this
+      }
+      appendText(s: string) {
+        this.value += s
+        return this
+      }
+      appendCodeblock() {
+        return this
+      }
+    },
+    ThemeIcon: class {
+      constructor(
+        public id: string,
+        public color?: unknown
+      ) {}
+    },
+    ThemeColor: class {
+      constructor(public id: string) {}
+    },
+    Uri: {
+      file: (s: string) => ({ toString: () => s, fsPath: s }),
+      parse: (s: string) => ({ toString: () => s }),
+    },
+  }
+})
+
+vi.mock('../services/Telemetry.js', () => ({
+  track: trackMock,
+}))
+
+// ── In-memory globalState mock ────────────────────────────────────────────────
+function makeContext(): import('vscode').ExtensionContext {
+  const store = new Map<string, unknown>()
+  return {
+    globalState: {
+      get: <T>(key: string) => store.get(key) as T | undefined,
+      update: async (key: string, value: unknown) => {
+        store.set(key, value)
+      },
+      keys: () => [...store.keys()],
+      setKeysForSync: vi.fn(),
+    },
+  } as unknown as import('vscode').ExtensionContext
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('SkillTreeDataProvider — next-steps section (SMI-5346)', () => {
+  beforeEach(() => {
+    trackMock.mockReset()
+    vi.resetModules()
+  })
+
+  it('showNextSteps adds a "nextSteps" group with 4 child rows', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const ctx = makeContext()
+    const provider = new SkillTreeDataProvider(ctx)
+
+    provider.showNextSteps('my-skill', '/home/user/.claude/skills/my-skill')
+
+    const roots = provider.getChildren()
+    const nextStepsGroup = roots.find((g) => g.groupId === 'nextSteps')
+    expect(nextStepsGroup).toBeDefined()
+    expect(nextStepsGroup?.contextValue).toBe('nextStepsGroup')
+
+    if (!nextStepsGroup) throw new Error('nextSteps group missing')
+    const rows = provider.getChildren(nextStepsGroup)
+    expect(rows).toHaveLength(4)
+    const labels = rows.map((r) => r.label)
+    expect(labels).toContain('Open skill folder')
+    expect(labels).toContain('Open SKILL.md to add triggers')
+    expect(labels).toContain('Run skillsmith validate')
+    expect(labels).toContain('Authoring docs')
+  })
+
+  it('each checklist row has a command', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const ctx = makeContext()
+    const provider = new SkillTreeDataProvider(ctx)
+    provider.showNextSteps('my-skill', '/home/user/.claude/skills/my-skill')
+
+    const roots = provider.getChildren()
+    const nextStepsGroup = roots.find((g) => g.groupId === 'nextSteps')
+    if (!nextStepsGroup) throw new Error('nextSteps group missing')
+    const rows = provider.getChildren(nextStepsGroup)
+    for (const row of rows) {
+      expect(row.command).toBeDefined()
+      expect(typeof (row.command as { command: string }).command).toBe('string')
+    }
+  })
+
+  it('dismissNextSteps hides the section', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const ctx = makeContext()
+    const provider = new SkillTreeDataProvider(ctx)
+
+    provider.showNextSteps('my-skill', '/home/user/.claude/skills/my-skill')
+    expect(provider.getChildren().some((g) => g.groupId === 'nextSteps')).toBe(true)
+
+    provider.dismissNextSteps()
+    expect(provider.getChildren().some((g) => g.groupId === 'nextSteps')).toBe(false)
+  })
+
+  it('a fresh showNextSteps after dismiss RE-shows the section (per-create reset)', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const ctx = makeContext()
+    const provider = new SkillTreeDataProvider(ctx)
+
+    provider.showNextSteps('skill-1', '/home/user/.claude/skills/skill-1')
+    provider.dismissNextSteps()
+    // Section hidden after first dismiss.
+    expect(provider.getChildren().some((g) => g.groupId === 'nextSteps')).toBe(false)
+
+    // A new create resets the dismissed flag.
+    provider.showNextSteps('skill-2', '/home/user/.claude/skills/skill-2')
+    expect(provider.getChildren().some((g) => g.groupId === 'nextSteps')).toBe(true)
+  })
+
+  it('showNextSteps emits vscode_create_checklist_view exactly once, not on subsequent getChildren', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const ctx = makeContext()
+    const provider = new SkillTreeDataProvider(ctx)
+
+    provider.showNextSteps('my-skill', '/home/user/.claude/skills/my-skill')
+    // Multiple getChildren calls must NOT trigger additional track calls.
+    provider.getChildren()
+    provider.getChildren()
+    provider.getChildren()
+
+    const viewCalls = trackMock.mock.calls.filter(
+      (call: unknown[]) => call[0] === 'vscode_create_checklist_view'
+    )
+    expect(viewCalls).toHaveLength(1)
+  })
+
+  it('getParent returns the nextSteps group for a checklist row', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const ctx = makeContext()
+    const provider = new SkillTreeDataProvider(ctx)
+
+    provider.showNextSteps('my-skill', '/home/user/.claude/skills/my-skill')
+    const roots = provider.getChildren()
+    const nextStepsGroup = roots.find((g) => g.groupId === 'nextSteps')
+    if (!nextStepsGroup) throw new Error('nextSteps group missing')
+    const rows = provider.getChildren(nextStepsGroup)
+    const firstRow = rows[0]
+    if (!firstRow) throw new Error('expected at least one row')
+
+    const parent = provider.getParent(firstRow)
+    expect(parent).toBeDefined()
+    expect(parent?.groupId).toBe('nextSteps')
+  })
+
+  it('nextSteps group is inserted AFTER the offline row and BEFORE Installed', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const ctx = makeContext()
+    const provider = new SkillTreeDataProvider(ctx)
+
+    provider.setMcpOffline(true)
+    provider.showNextSteps('my-skill', '/home/user/.claude/skills/my-skill')
+
+    const roots = provider.getChildren()
+    const labels = roots.map((r) => r.label)
+    const offlineIdx = roots.findIndex((r) => r.contextValue === 'mcpOffline')
+    const nextStepsIdx = roots.findIndex((r) => r.groupId === 'nextSteps')
+    const installedIdx = roots.findIndex((r) => r.groupId === 'installed')
+
+    expect(offlineIdx).toBeGreaterThanOrEqual(0)
+    expect(nextStepsIdx).toBeGreaterThan(offlineIdx)
+    expect(installedIdx).toBeGreaterThan(nextStepsIdx)
+    // suppress unused variable lint for labels
+    expect(labels.length).toBeGreaterThan(0)
+  })
+})
+
+describe('SkillTreeDataProvider — MCP-offline reconnect row (SMI-5345)', () => {
+  beforeEach(() => {
+    trackMock.mockReset()
+    vi.resetModules()
+  })
+
+  it('setMcpOffline(true) prepends the reconnect row to root groups', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const ctx = makeContext()
+    const provider = new SkillTreeDataProvider(ctx)
+
+    provider.setMcpOffline(true)
+
+    const roots = provider.getChildren()
+    const offlineRow = roots[0]
+    expect(offlineRow).toBeDefined()
+    expect(offlineRow?.contextValue).toBe('mcpOffline')
+    expect(offlineRow?.label).toContain('Reconnect')
+    expect((offlineRow?.command as { command: string } | undefined)?.command).toBe(
+      'skillsmith.mcpReconnect'
+    )
+  })
+
+  it('setMcpOffline(false) removes the reconnect row', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const ctx = makeContext()
+    const provider = new SkillTreeDataProvider(ctx)
+
+    provider.setMcpOffline(true)
+    expect(provider.getChildren().some((r) => r.contextValue === 'mcpOffline')).toBe(true)
+
+    provider.setMcpOffline(false)
+    expect(provider.getChildren().some((r) => r.contextValue === 'mcpOffline')).toBe(false)
+  })
+
+  it('offline row is first (before Installed group) when no next-steps are shown', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const ctx = makeContext()
+    const provider = new SkillTreeDataProvider(ctx)
+
+    provider.setMcpOffline(true)
+
+    const roots = provider.getChildren()
+    expect(roots[0]?.contextValue).toBe('mcpOffline')
+    expect(roots[roots.length - 1]?.groupId).toBe('installed')
+  })
+
+  it('no offline row when setMcpOffline was never called (default false)', async () => {
+    const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
+    const ctx = makeContext()
+    const provider = new SkillTreeDataProvider(ctx)
+
+    const roots = provider.getChildren()
+    expect(roots.some((r) => r.contextValue === 'mcpOffline')).toBe(false)
+  })
+})

--- a/packages/vscode-extension/src/__tests__/skillTreeDataProvider.test.ts
+++ b/packages/vscode-extension/src/__tests__/skillTreeDataProvider.test.ts
@@ -49,9 +49,31 @@ vi.mock('vscode', () => {
     ThemeColor: class {
       constructor(public id: string) {}
     },
-    Uri: { parse: (s: string) => ({ toString: () => s }) },
+    Uri: {
+      file: (s: string) => ({ toString: () => s, fsPath: s }),
+      parse: (s: string) => ({ toString: () => s }),
+    },
   }
 })
+
+vi.mock('../services/Telemetry.js', () => ({
+  track: vi.fn(),
+}))
+
+/** In-memory ExtensionContext for tests. */
+function makeContext(): import('vscode').ExtensionContext {
+  const store = new Map<string, unknown>()
+  return {
+    globalState: {
+      get: <T>(key: string) => store.get(key) as T | undefined,
+      update: async (key: string, value: unknown) => {
+        store.set(key, value)
+      },
+      keys: () => [...store.keys()],
+      setKeysForSync: vi.fn(),
+    },
+  } as unknown as import('vscode').ExtensionContext
+}
 
 describe('SkillTreeDataProvider installed-skills API (SMI-4194)', () => {
   let tempRoot: string
@@ -66,7 +88,7 @@ describe('SkillTreeDataProvider installed-skills API (SMI-4194)', () => {
 
   it('getInstalledSkills returns empty array before any refresh', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
     expect(provider.getInstalledSkills()).toEqual([])
   })
 
@@ -86,7 +108,7 @@ describe('SkillTreeDataProvider installed-skills API (SMI-4194)', () => {
 
     // Mock must be set BEFORE constructor fires loadInstalledSkills.
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
     // The constructor-fired load shares its in-flight promise with refreshAndWait,
     // so awaiting refreshAndWait guarantees the initial load has settled.
     await provider.refreshAndWait()
@@ -126,7 +148,7 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
 
   it('setSearchResults populates the Available group; clearSearchResults empties it', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
 
     provider.setSearchResults(sampleResults, 'docker')
     expect(provider.getAvailableSkills()).toHaveLength(2)
@@ -139,7 +161,7 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
 
   it('renders Available group first while searching, with the count-bearing label', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
     provider.setSearchResults(sampleResults, 'docker')
 
     const roots = provider.getChildren()
@@ -154,7 +176,7 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
 
   it('renders Installed group first (only) when no search is active', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
 
     const roots = provider.getChildren()
     expect(roots).toHaveLength(1)
@@ -163,7 +185,7 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
 
   it('getChildren on the available group returns the search-result skill items', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
     provider.setSearchResults(sampleResults, 'docker')
 
     const roots = provider.getChildren()
@@ -176,7 +198,7 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
 
   it('getAvailableGroupItem returns the group when results exist, undefined otherwise', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
 
     expect(provider.getAvailableGroupItem()).toBeUndefined()
 
@@ -193,7 +215,7 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
 
   it('group ids are stable across calls (so TreeView.reveal can match)', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
     provider.setSearchResults(sampleResults, 'docker')
 
     const first = provider.getAvailableGroupItem()
@@ -207,7 +229,7 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
 
   it('getParent: group items resolve to undefined (root)', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
     provider.setSearchResults(sampleResults, 'docker')
 
     const roots = provider.getChildren()
@@ -218,7 +240,7 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
 
   it('getParent: an available (skill) item resolves to the Available group', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
     provider.setSearchResults(sampleResults, 'docker')
 
     const availableGroup = provider.getChildren().find((g) => g.groupId === 'available')
@@ -249,7 +271,7 @@ describe('SkillTreeDataProvider unified search surface (#1431 / SMI-5298)', () =
       } as any)
 
       const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-      const provider = new SkillTreeDataProvider()
+      const provider = new SkillTreeDataProvider(makeContext())
       await provider.refreshAndWait()
 
       const installedGroup = provider.getChildren().find((g) => g.groupId === 'installed')
@@ -282,7 +304,7 @@ describe('SkillTreeDataProvider filter state + active context (#1433 / #1432)', 
 
   it('hasActiveFilters is false initially and true after setFilters', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
 
     expect(provider.hasActiveFilters()).toBe(false)
     provider.setFilters({ trustTier: 'verified' })
@@ -292,7 +314,7 @@ describe('SkillTreeDataProvider filter state + active context (#1433 / #1432)', 
 
   it('clearFilters resets to no active filters', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
 
     provider.setFilters({ category: 'Testing', minScore: 70 })
     expect(provider.hasActiveFilters()).toBe(true)
@@ -303,7 +325,7 @@ describe('SkillTreeDataProvider filter state + active context (#1433 / #1432)', 
 
   it('setFilters stores by value (later mutation does not leak in)', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
 
     const input = { trustTier: 'verified' }
     provider.setFilters(input)
@@ -313,7 +335,7 @@ describe('SkillTreeDataProvider filter state + active context (#1433 / #1432)', 
 
   it('describeActiveContext returns rawQuery + demo flag + ordered filter parts', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
 
     provider.setFilters({ trustTier: 'verified', category: 'Testing', minScore: 70 })
     provider.setSearchResults(sampleResults, 'react', { demo: true })
@@ -327,7 +349,7 @@ describe('SkillTreeDataProvider filter state + active context (#1433 / #1432)', 
 
   it('describeActiveContext has no filter parts when no filters are active', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
 
     provider.setSearchResults(sampleResults, 'react')
     const ctx = provider.describeActiveContext()
@@ -337,7 +359,7 @@ describe('SkillTreeDataProvider filter state + active context (#1433 / #1432)', 
 
   it('getLastSearchQuery returns the raw query, not the display label', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
 
     provider.setSearchResults(sampleResults, 'react', { demo: true })
     // Raw query is stored separately from the demo annotation.
@@ -346,7 +368,7 @@ describe('SkillTreeDataProvider filter state + active context (#1433 / #1432)', 
 
   it('group:available id is stable across filter/query changes (reveal guard)', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
 
     provider.setSearchResults(sampleResults, 'react')
     const before = provider.getAvailableGroupItem()
@@ -361,7 +383,7 @@ describe('SkillTreeDataProvider filter state + active context (#1433 / #1432)', 
 
   it('clearSearchResults clears the query but preserves active filters', async () => {
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
+    const provider = new SkillTreeDataProvider(makeContext())
 
     provider.setFilters({ trustTier: 'verified' })
     provider.setSearchResults(sampleResults, 'react')

--- a/packages/vscode-extension/src/__tests__/uninstallCommand.test.ts
+++ b/packages/vscode-extension/src/__tests__/uninstallCommand.test.ts
@@ -15,7 +15,10 @@ vi.mock('vscode', () => {
     window: { showWarningMessage, showErrorMessage, showInformationMessage, showQuickPick },
     commands: { registerCommand },
     env: { openExternal: vi.fn() },
-    Uri: { parse: (s: string) => ({ toString: () => s }) },
+    Uri: {
+      file: (s: string) => ({ toString: () => s, fsPath: s }),
+      parse: (s: string) => ({ toString: () => s }),
+    },
     workspace: {
       getConfiguration: vi.fn(() => ({ get: vi.fn(() => undefined) })),
     },
@@ -43,6 +46,7 @@ vi.mock('../sidebar/SkillTreeDataProvider.js', () => ({
   SkillTreeDataProvider: class {
     refreshAndWait = refreshAndWait
     getInstalledSkills = getInstalledSkills
+    showNextSteps = vi.fn()
   },
 }))
 
@@ -95,8 +99,17 @@ describe('uninstallCommand (SMI-4195)', () => {
     vi.resetModules()
     const { registerUninstallCommand } = await import('../commands/uninstallCommand.js')
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    const provider = new SkillTreeDataProvider()
     context = { subscriptions: [] }
+    const fakeCtx = {
+      globalState: {
+        get: vi.fn(),
+        update: vi.fn(async () => {}),
+        keys: vi.fn(() => []),
+        setKeysForSync: vi.fn(),
+      },
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const provider = new SkillTreeDataProvider(fakeCtx as any)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerUninstallCommand(context as any, provider as any)
     const call = registerCommand.mock.calls[0]
@@ -262,7 +275,16 @@ describe('uninstallByTarget core (SMI-5308 / detail-panel)', () => {
     const mod = await import('../commands/uninstallCommand.js')
     uninstallByTarget = mod.uninstallByTarget
     const { SkillTreeDataProvider } = await import('../sidebar/SkillTreeDataProvider.js')
-    provider = new SkillTreeDataProvider()
+    const fakeContext = {
+      globalState: {
+        get: vi.fn(),
+        update: vi.fn(async () => {}),
+        keys: vi.fn(() => []),
+        setKeysForSync: vi.fn(),
+      },
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    provider = new SkillTreeDataProvider(fakeContext as any)
   })
 
   afterEach(async () => {

--- a/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
+++ b/packages/vscode-extension/src/commands/__meta__/telemetry-coverage.test.ts
@@ -92,11 +92,14 @@ describe('SMI-5130: VS Code command telemetry coverage', () => {
     expect(new Set(openIds).size).toBe(2)
   })
 
-  // SMI-5312: the post-create checklist action is fired inside a helper, not a
-  // registered command, so it isn't in VSCODE_DISPATCHER_MAP. Assert its
-  // type-safe id exists in the TelemetryEvent union (rename/removal breaks here).
+  // SMI-5346: the post-create checklist is now a dismissible sidebar section
+  // that emits `vscode_create_checklist_view` once when shown (fired in
+  // NextStepsManager, not a registered command, so not in VSCODE_DISPATCHER_MAP).
+  // Assert its type-safe id exists in the TelemetryEvent union (rename/removal
+  // breaks here). The prior `vscode_create_checklist_action` toast event was
+  // removed with the toast.
   it('declares the post-create checklist telemetry id', () => {
-    const checklistId: TelemetryEvent = 'vscode_create_checklist_action'
-    expect(checklistId).toBe('vscode_create_checklist_action')
+    const checklistId: TelemetryEvent = 'vscode_create_checklist_view'
+    expect(checklistId).toBe('vscode_create_checklist_view')
   })
 })

--- a/packages/vscode-extension/src/commands/searchSkills.ts
+++ b/packages/vscode-extension/src/commands/searchSkills.ts
@@ -17,6 +17,7 @@ import * as vscode from 'vscode'
 import type { SkillTreeDataProvider } from '../sidebar/SkillTreeDataProvider.js'
 import type { SkillTreeItem } from '../sidebar/SkillTreeItem.js'
 import type { SkillService } from '../services/SkillService.js'
+import type { SidebarMessageState } from '../sidebar/message-state.js'
 import { withTelemetry } from '../services/telemetry-wrap.js'
 import { collectSearchFilters, type SearchFilters } from './searchFilters.js'
 
@@ -24,6 +25,11 @@ interface SearchSkillsDeps {
   treeDataProvider: SkillTreeDataProvider
   skillsView: vscode.TreeView<SkillTreeItem>
   skillService: SkillService
+  // SMI-5345 (#1438): the single owner of `skillsView.message`. `performSearch`
+  // routes its context banner / no-results / offline copy through this state
+  // machine instead of writing `skillsView.message` directly, which resolves
+  // the multi-writer race with the first-run hint and the MCP-offline observer.
+  messageState: SidebarMessageState
 }
 
 /** SMI-5288: whether explicit demo mode is enabled. */
@@ -142,8 +148,9 @@ async function performSearch(
               'Skillsmith server unavailable — start the Skillsmith MCP server and try again.'
             )
             treeDataProvider.clearSearchResults()
-            deps.skillsView.message =
+            deps.messageState.setSearchBanner(
               'Skillsmith server unavailable — start the MCP server and try again.'
+            )
             await syncActiveFiltersContext(deps)
             return
           }
@@ -151,7 +158,7 @@ async function performSearch(
           const noResultsMsg = buildNoResultsMessage(trimmedQuery, hasFilters)
           vscode.window.showInformationMessage(noResultsMsg)
           treeDataProvider.clearSearchResults()
-          deps.skillsView.message = noResultsMsg
+          deps.messageState.setSearchBanner(noResultsMsg)
           await syncActiveFiltersContext(deps)
           return
         }
@@ -161,7 +168,7 @@ async function performSearch(
         treeDataProvider.setSearchResults(results, trimmedQuery, { demo: isDemoResults })
 
         // #1432: persistent context banner derived from the single formatter.
-        deps.skillsView.message = formatContextBanner(deps)
+        deps.messageState.setSearchBanner(formatContextBanner(deps))
         await syncActiveFiltersContext(deps)
 
         // SMI-5298 (#1431): surface the Available group in the unified view.
@@ -252,9 +259,10 @@ export function registerSearchCommand(
   context: vscode.ExtensionContext,
   treeDataProvider: SkillTreeDataProvider,
   skillsView: vscode.TreeView<SkillTreeItem>,
-  skillService: SkillService
+  skillService: SkillService,
+  messageState: SidebarMessageState
 ): void {
-  const deps: SearchSkillsDeps = { treeDataProvider, skillsView, skillService }
+  const deps: SearchSkillsDeps = { treeDataProvider, skillsView, skillService, messageState }
   context.subscriptions.push(
     vscode.commands.registerCommand('skillsmith.searchSkills', () => searchSkillsAction(deps)),
     vscode.commands.registerCommand('skillsmith.filterSkills', () => filterSkillsAction(deps)),

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -6,10 +6,13 @@
  */
 import * as vscode from 'vscode'
 import { SkillTreeDataProvider } from './sidebar/SkillTreeDataProvider.js'
+import { createSidebarMessageState } from './sidebar/message-state.js'
+import { registerMcpSidebarObserver } from './sidebar/mcp-status-observer.js'
 import { registerSearchCommand } from './commands/searchSkills.js'
 import { registerQuickInstallCommand } from './commands/installCommand.js'
 import { registerUninstallCommand } from './commands/uninstallCommand.js'
 import { registerCreateSkillCommand } from './commands/createSkillCommand.js'
+import { runValidate } from './utils/createSkill.helpers.js'
 import { registerRecommendCommand } from './commands/recommendCommand.js'
 import { registerCompareCommand } from './commands/compareCommand.js'
 import { registerDiffCommand } from './commands/diffCommand.js'
@@ -63,8 +66,9 @@ export function activate(context: vscode.ExtensionContext): void {
   )
   SkillDetailPanel.setSkillService(skillService)
 
-  // Initialize providers
-  skillTreeDataProvider = new SkillTreeDataProvider()
+  // Initialize providers. SMI-5346: the provider takes `context` so the
+  // post-create checklist section can persist its dismiss flag in globalState.
+  skillTreeDataProvider = new SkillTreeDataProvider(context)
 
   // Inject the tree provider into the detail panel so it can resolve installed
   // state (#1437 / SMI-5308). Always set before the only live createOrShow path.
@@ -108,10 +112,14 @@ export function activate(context: vscode.ExtensionContext): void {
         clipboardWrite: (text) => vscode.env.clipboard.writeText(text),
       })
     })
-    context.subscriptions.push(versionCheckSub)
   }
 
   registerVersionCheck()
+  // SMI-5345 (plan-review C3): push ONE stable disposable that always disposes
+  // the *current* versionCheckSub, instead of re-pushing inside
+  // registerVersionCheck() on every config-swap rebind — which grew
+  // context.subscriptions unboundedly across settings changes.
+  context.subscriptions.push({ dispose: () => versionCheckSub?.dispose() })
 
   // Register MCP commands
   registerMcpCommands(context)
@@ -126,6 +134,12 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(skillsView)
 
+  // SMI-5345 (#1438): a single owner for `skillsView.message`. The first-run
+  // hint, the search context banner, and the MCP-offline notice all route
+  // through this state machine (precedence: offline > search banner > hint),
+  // resolving the multi-writer clobber + reconnect-during-search race.
+  const messageState = createSidebarMessageState(skillsView)
+
   // #1438-P2 (SMI-5306): first-run / pre-search hint. `viewsWelcome` renders
   // ONLY for an empty tree, so an installed-but-never-searched user never sees
   // it (plan-review #2). Surface the affordance as a persistent
@@ -134,7 +148,17 @@ export function activate(context: vscode.ExtensionContext): void {
   // copy mirrors Wave 1's welcome message.
   const isMac = process.platform === 'darwin'
   const searchChord = isMac ? '⌘K ⌘Y' : 'Ctrl+K Ctrl+Y'
-  skillsView.message = `Press the search icon or ${searchChord} to discover skills.`
+  messageState.setFirstRunHint(`Press the search icon or ${searchChord} to discover skills.`)
+
+  // SMI-5345 (#1438): proactively mirror MCP connection drops into the sidebar
+  // (offline `.message` + a pinned Reconnect row) even when the drop happens
+  // outside of a search. Rebinds on the config-driven client swap below.
+  const mcpSidebarObserver = registerMcpSidebarObserver({
+    getClient: getMcpClient,
+    messageState,
+    offlineRow: skillTreeDataProvider,
+  })
+  context.subscriptions.push(mcpSidebarObserver)
 
   // Register intellisense providers
   const skillMdSelector = getSkillMdSelector()
@@ -179,7 +203,7 @@ export function activate(context: vscode.ExtensionContext): void {
   }
 
   // Register commands — pass skillService to consumers
-  registerSearchCommand(context, skillTreeDataProvider, skillsView, skillService)
+  registerSearchCommand(context, skillTreeDataProvider, skillsView, skillService, messageState)
   registerQuickInstallCommand(context, skillService)
   registerUninstallCommand(context, skillTreeDataProvider)
   registerCreateSkillCommand(context, skillTreeDataProvider)
@@ -214,6 +238,19 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(refreshCommand, viewDetailsCommand)
 
+  // SMI-5346 (#1453): post-create checklist actions. Registered inline and
+  // unwrapped (like refreshSkills / viewSkillDetails) — they are not panel
+  // telemetry dispatchers, so they stay out of VSCODE_DISPATCHER_MAP.
+  const validateOutput = vscode.window.createOutputChannel('Skillsmith Validate')
+  const runValidateCommand = vscode.commands.registerCommand('skillsmith.runValidate', () => {
+    void runValidate(validateOutput)
+  })
+  const dismissNextStepsCommand = vscode.commands.registerCommand(
+    'skillsmith.dismissNextSteps',
+    () => skillTreeDataProvider.dismissNextSteps()
+  )
+  context.subscriptions.push(validateOutput, runValidateCommand, dismissNextStepsCommand)
+
   // Listen for configuration changes
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
@@ -221,6 +258,7 @@ export function activate(context: vscode.ExtensionContext): void {
         initializeMcpClientFromSettings()
         registerVersionCheck()
         mcpStatusBar?.rebind()
+        mcpSidebarObserver.rebind()
         void connectWithProgress()
       }
     })

--- a/packages/vscode-extension/src/mcp/McpStatusBar.ts
+++ b/packages/vscode-extension/src/mcp/McpStatusBar.ts
@@ -11,7 +11,7 @@ import { getMcpClient } from './McpClient.js'
 export class McpStatusBar {
   private statusBarItem: vscode.StatusBarItem
   private disposables: vscode.Disposable[] = []
-  private statusSub?: vscode.Disposable
+  private statusSub: vscode.Disposable | undefined
 
   constructor() {
     this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100)

--- a/packages/vscode-extension/src/services/Telemetry.ts
+++ b/packages/vscode-extension/src/services/Telemetry.ts
@@ -6,7 +6,6 @@ export type TelemetryEvent =
   | 'vscode_create_complete'
   | 'vscode_create_failed'
   | 'vscode_create_cancelled'
-  | 'vscode_create_checklist_action'
   | 'vscode_uninstall_start'
   | 'vscode_uninstall_complete'
   | 'vscode_uninstall_failed'

--- a/packages/vscode-extension/src/services/Telemetry.ts
+++ b/packages/vscode-extension/src/services/Telemetry.ts
@@ -39,6 +39,8 @@ export type TelemetryEvent =
   | 'vscode_inventory_apply_applied'
   | 'vscode_inventory_apply_failed'
   | 'vscode_inventory_apply_cancelled'
+  // SMI-5346: next-steps checklist view (sidebar section).
+  | 'vscode_create_checklist_view'
 
 // No hardcoded endpoint — telemetry is disabled by default at runtime
 // unless `skillsmith.telemetryEndpoint` is set or the production endpoint

--- a/packages/vscode-extension/src/sidebar/SkillTreeDataProvider.nextSteps.ts
+++ b/packages/vscode-extension/src/sidebar/SkillTreeDataProvider.nextSteps.ts
@@ -1,0 +1,108 @@
+/**
+ * Next-steps checklist logic for SkillTreeDataProvider (SMI-5346).
+ *
+ * Extracted to keep SkillTreeDataProvider.ts under 500 lines.
+ * The provider delegates all next-steps state and row-building here.
+ */
+import * as vscode from 'vscode'
+import * as path from 'node:path'
+import { SkillTreeItem } from './SkillTreeItem.js'
+import { track } from '../services/Telemetry.js'
+
+/** Per-create next-steps state. */
+export interface NextStepsState {
+  name: string
+  targetDir: string
+}
+
+const DISMISSED_KEY = 'skillsmith.createChecklistDismissed'
+
+/**
+ * Manages next-steps section state and delegates from SkillTreeDataProvider.
+ * The provider stores one instance and calls these methods.
+ */
+export class NextStepsManager {
+  private state: NextStepsState | undefined = undefined
+
+  constructor(private readonly context: vscode.ExtensionContext) {}
+
+  /**
+   * Show the next-steps section for a newly-created skill.
+   *
+   * - Resets the per-create dismissed flag (so the section always appears after
+   *   a fresh create, even if it was previously dismissed for an earlier create).
+   * - Tracks 'vscode_create_checklist_view' EXACTLY ONCE here, synchronously,
+   *   BEFORE the caller fires _onDidChangeTreeData. Never tracked in render paths.
+   */
+  show(name: string, targetDir: string, onChanged: () => void): void {
+    void this.context.globalState.update(DISMISSED_KEY, false)
+    this.state = { name, targetDir }
+    track('vscode_create_checklist_view')
+    onChanged()
+  }
+
+  /**
+   * Dismiss the next-steps section. Persists across reloads via globalState.
+   */
+  dismiss(onChanged: () => void): void {
+    void this.context.globalState.update(DISMISSED_KEY, true)
+    this.state = undefined
+    onChanged()
+  }
+
+  /**
+   * Whether the section should currently be visible.
+   */
+  isVisible(): boolean {
+    if (!this.state) {
+      return false
+    }
+    return this.context.globalState.get<boolean>(DISMISSED_KEY) !== true
+  }
+
+  /**
+   * Returns the current state (name + targetDir), or undefined if not set.
+   */
+  getState(): NextStepsState | undefined {
+    return this.state
+  }
+
+  /**
+   * Builds the 'Next steps' group header item.
+   */
+  buildGroupItem(): SkillTreeItem {
+    return SkillTreeItem.createNextStepsGroup()
+  }
+
+  /**
+   * Builds the four action rows for the 'Next steps' group.
+   */
+  buildRows(): SkillTreeItem[] {
+    const s = this.state
+    if (!s) {
+      return []
+    }
+    const { targetDir } = s
+    return [
+      SkillTreeItem.createChecklistRow('Open skill folder', {
+        command: 'revealFileInOS',
+        title: 'Open skill folder',
+        arguments: [vscode.Uri.file(targetDir)],
+      }),
+      SkillTreeItem.createChecklistRow('Open SKILL.md to add triggers', {
+        command: 'vscode.open',
+        title: 'Open SKILL.md',
+        arguments: [vscode.Uri.file(path.join(targetDir, 'SKILL.md'))],
+      }),
+      SkillTreeItem.createChecklistRow('Run skillsmith validate', {
+        command: 'skillsmith.runValidate',
+        title: 'Run skillsmith validate',
+      }),
+      SkillTreeItem.createChecklistRow('Authoring docs', {
+        command: 'vscode.open',
+        title: 'Authoring docs',
+        arguments: [vscode.Uri.parse('https://skillsmith.app/docs')],
+      }),
+    ]
+  }
+}

--- a/packages/vscode-extension/src/sidebar/SkillTreeDataProvider.ts
+++ b/packages/vscode-extension/src/sidebar/SkillTreeDataProvider.ts
@@ -13,6 +13,7 @@ import { type ExtensionTrustTier, normalizeTrustTier, getTrustTierLabel } from '
 import { type SkillData } from '../types/skill.js'
 import { type SearchFilters } from '../commands/searchFilters.js'
 import { buildInstalledKeySet, skillComparisonKey } from '../utils/skillId.js'
+import { NextStepsManager } from './SkillTreeDataProvider.nextSteps.js'
 
 /** Maximum length for skill descriptions */
 const MAX_DESCRIPTION_LENGTH = 100
@@ -52,8 +53,13 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
   private demo = false
   /** Active discovery filters — single source of truth (#1433). Ephemeral. */
   private filters: SearchFilters = {}
+  /** Whether the MCP server is currently offline (SMI-5345). */
+  private mcpOffline = false
+  /** Next-steps checklist manager (SMI-5346). */
+  private readonly nextStepsManager: NextStepsManager
 
-  constructor() {
+  constructor(context: vscode.ExtensionContext) {
+    this.nextStepsManager = new NextStepsManager(context)
     // Load installed skills on initialization
     void this.loadInstalledSkills()
   }
@@ -66,28 +72,49 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
   }
 
   /**
+   * Sets the MCP-offline state (SMI-5345).
+   * When offline, a pinned reconnect row is prepended to the root groups.
+   */
+  setMcpOffline(isOffline: boolean): void {
+    this.mcpOffline = isOffline
+    this._onDidChangeTreeData.fire()
+  }
+
+  /**
+   * Shows the next-steps checklist section for a newly-created skill (SMI-5346).
+   *
+   * - Resets the per-create dismissed flag (per-create reset).
+   * - Tracks 'vscode_create_checklist_view' exactly once, synchronously.
+   * - Fires _onDidChangeTreeData.
+   */
+  showNextSteps(name: string, targetDir: string): void {
+    this.nextStepsManager.show(name, targetDir, () => {
+      this._onDidChangeTreeData.fire()
+    })
+  }
+
+  /**
+   * Dismisses the next-steps section (SMI-5346).
+   * Persists dismissal in globalState so it survives reloads.
+   */
+  dismissNextSteps(): void {
+    this.nextStepsManager.dismiss(() => {
+      this._onDidChangeTreeData.fire()
+    })
+  }
+
+  /**
    * Sets search results as available skills.
-   *
-   * The raw query is stored SEPARATELY from any display suffix (#1432 / #1433):
-   * earlier code conflated the query with the `(Demo)`/`all skills` display
-   * label, so the context formatter could not recover the true query. Callers
-   * now pass the true `rawQuery` plus an optional `demo` flag; the demo
-   * annotation is composed at render time from `demo`, never baked into the
-   * stored query.
-   *
-   * @param results - Search results to display
+   * Raw query stored separately from display suffix (#1432 / #1433).
    * @param rawQuery - The true search query ('' for browse-all)
-   * @param meta.demo - Whether the results are demo-mode mock data
+   * @param meta.demo - Whether results are demo-mode mock data
    */
   setSearchResults(results: SkillData[], rawQuery: string, meta: { demo?: boolean } = {}): void {
     this.rawQuery = rawQuery
     this.demo = meta.demo ?? false
-    // `isInstalled` is intentionally false for all search results stored here.
-    // Whether a registry hit is ALSO installed locally is determined at render
-    // time in `getGroupChildren` via the normalized id cross-reference (H4).
-    // `installedElsewhere` (set there) is the authoritative "also installed"
-    // signal for the Available surface — it must never be baked into the stored
-    // item because the installed set can change between renders.
+    // `isInstalled` stays false here; `installedElsewhere` is computed at
+    // render time via cross-reference so getParent routes Available items
+    // correctly (#1431 / SMI-5298, H4 / C2).
     this.availableSkills = results.map((skill) => {
       const tier = normalizeTrustTier(skill.trustTier)
       const item: SkillItemData = {
@@ -107,11 +134,7 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
     this._onDidChangeTreeData.fire()
   }
 
-  /**
-   * Clears search results. Does NOT clear the active filters — clearing
-   * results (e.g. a no-results or offline run) must leave the user's filter
-   * selection intact so the Clear Filters action still reflects reality.
-   */
+  /** Clears search results without clearing active filters. */
   clearSearchResults(): void {
     this.availableSkills = []
     this.rawQuery = ''
@@ -210,18 +233,18 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
   }
 
   /**
-   * Returns the parent of the given element.
-   *
-   * Required by `vscode.TreeView.reveal` (#1431 / SMI-5298). Implemented as a
-   * PURE DERIVATION rather than a mutable membership map: a skill can appear in
-   * BOTH the Installed and Available groups (installed AND a search hit), so any
-   * cached single-parent map would be wrong. Parentage is derived solely from
-   * the element's type and `contextValue`/`isInstalled`:
-   *   - group items → `undefined` (root)
-   *   - installed skill (`contextValue === 'installedSkill'`) → Installed group
-   *   - available skill (`contextValue === 'skill'`) → Available group
+   * Returns the parent of the given element (required by TreeView.reveal,
+   * #1431 / SMI-5298). Pure derivation — no cached map, since a skill can
+   * appear in both Installed and Available groups simultaneously.
    */
   getParent(element: SkillTreeItem): SkillTreeItem | undefined {
+    // Next-steps row items belong to the nextSteps group (must be checked BEFORE
+    // the general group guard, because checklist rows use itemType='group').
+    if (element.contextValue === 'nextStepsRow') {
+      return this.nextStepsManager.buildGroupItem()
+    }
+
+    // Group items (nextSteps group, offline row, installed, available) are root items.
     if (element.itemType === 'group') {
       return undefined
     }
@@ -235,11 +258,7 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
     return this.getAvailableGroupItem()
   }
 
-  /**
-   * Returns the Available group `SkillTreeItem` when search results exist, else
-   * `undefined` (so `reveal` no-ops). Shares the single group-builder with
-   * `getRootGroups()` so the id matches and `TreeView.reveal` can resolve it.
-   */
+  /** Returns the Available group item when search results exist, else undefined. */
   getAvailableGroupItem(): SkillTreeItem | undefined {
     if (this.availableSkills.length === 0) {
       return undefined
@@ -247,21 +266,12 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
     return this.buildAvailableGroupItem()
   }
 
-  /**
-   * Returns installed skills in a form suitable for quickPick consumers
-   * (e.g., uninstall/create commands) without requiring a tree selection.
-   * Data is refreshed via `refresh()`; callers awaiting fresh state should
-   * call `await provider.refreshAndWait()` first.
-   */
+  /** Returns installed skills for quickPick consumers (uninstall/create). */
   getInstalledSkills(): readonly SkillItemData[] {
     return this.installedSkills
   }
 
-  /**
-   * Triggers a reload and resolves when the installed-skills list is current.
-   * Preferred over `refresh()` when callers need to observe the post-refresh
-   * state (e.g., a command that enumerates after uninstalling).
-   */
+  /** Triggers a reload and resolves when the installed-skills list is current. */
   async refreshAndWait(): Promise<void> {
     await this.loadInstalledSkills()
   }
@@ -269,20 +279,34 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
   /**
    * Gets the root level groups.
    *
-   * Ordering (#1431 / SMI-5298): when a search is active (`availableSkills`
-   * populated) the Available group renders FIRST so just-searched results lead;
-   * with no active search, Installed-first (the default browse layout).
+   * Ordering (#1431 / SMI-5298 / SMI-5345 / SMI-5346):
+   *   1. Pinned MCP-offline reconnect row (if offline)
+   *   2. Next steps group (if visible)
+   *   3. Available Skills (if search active) or Installed Skills (default)
+   *   4. Installed Skills (always present)
    */
   private getRootGroups(): SkillTreeItem[] {
-    const installedGroup = this.buildInstalledGroupItem()
+    const groups: SkillTreeItem[] = []
 
-    // Show available skills group only when there are search results.
-    if (this.availableSkills.length > 0) {
-      // Available-first while searching.
-      return [this.buildAvailableGroupItem(), installedGroup]
+    // (1) Pinned offline reconnect row (SMI-5345)
+    if (this.mcpOffline) {
+      groups.push(SkillTreeItem.createMcpOfflineRow())
     }
 
-    return [installedGroup]
+    // (2) Next-steps section (SMI-5346)
+    if (this.nextStepsManager.isVisible()) {
+      groups.push(this.nextStepsManager.buildGroupItem())
+    }
+
+    // (3+4) Available-first while searching; otherwise Installed only.
+    const installedGroup = this.buildInstalledGroupItem()
+    if (this.availableSkills.length > 0) {
+      groups.push(this.buildAvailableGroupItem(), installedGroup)
+    } else {
+      groups.push(installedGroup)
+    }
+
+    return groups
   }
 
   /**
@@ -299,16 +323,9 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
   }
 
   /**
-   * Builds the Available group header. Single source of truth shared by
-   * `getRootGroups()`, `getAvailableGroupItem()`, and `getParent()` so the
-   * stable id (`group:available`) matches across all reveal/parent lookups.
-   *
-   * The label is now the COUNT-BEARING header only (#1432 plan-review #8): the
-   * query + filter context lives in the persistent `TreeView.message` banner,
-   * so the two surfaces are complementary, not duplicate. `createGroup` appends
-   * the `(N)` count; the stable `group:available` id is decoupled from the
-   * label (set from `groupId` in `SkillTreeItem.setupGroupItem`), so changing
-   * the label never regresses the reveal contract (#1431 / SMI-5298).
+   * Builds the Available group header (single source of truth for label/id).
+   * Label is count-bearing only (#1432); stable `group:available` id decoupled
+   * from label so TreeView.reveal never regresses (#1431 / SMI-5298).
    */
   private buildAvailableGroupItem(): SkillTreeItem {
     return SkillTreeItem.createGroup(
@@ -320,14 +337,8 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
   }
 
   /**
-   * Gets children for a specific group.
-   *
-   * For the `available` branch the installed-key set is computed once per
-   * render call and used to mark each registry hit with `installedElsewhere`
-   * when its normalized slug matches a locally-installed skill. This is a
-   * render-time annotation — the stored `availableSkills` items are never
-   * mutated and `isInstalled` is left false so `getParent` continues routing
-   * Available items to the Available group (#1431 / SMI-5298, H4 / C2).
+   * Gets children for a specific group. Available branch computes the
+   * installedElsewhere marker at render time (H4 / #1431 / SMI-5298).
    */
   private getGroupChildren(groupId?: string): SkillTreeItem[] {
     switch (groupId) {
@@ -343,6 +354,8 @@ export class SkillTreeDataProvider implements vscode.TreeDataProvider<SkillTreeI
           return SkillTreeItem.createSkill(skill)
         })
       }
+      case 'nextSteps':
+        return this.nextStepsManager.buildRows()
       default:
         return []
     }

--- a/packages/vscode-extension/src/sidebar/SkillTreeItem.ts
+++ b/packages/vscode-extension/src/sidebar/SkillTreeItem.ts
@@ -212,6 +212,8 @@ export class SkillTreeItem extends vscode.TreeItem {
         return new vscode.ThemeIcon('folder-library')
       case 'available':
         return new vscode.ThemeIcon('cloud')
+      case 'nextSteps':
+        return new vscode.ThemeIcon('checklist')
       default:
         return new vscode.ThemeIcon('symbol-misc')
     }
@@ -252,5 +254,60 @@ export class SkillTreeItem extends vscode.TreeItem {
       data,
       undefined
     )
+  }
+
+  /**
+   * Creates the 'Next steps' group header item (SMI-5346).
+   * contextValue is 'nextStepsGroup' so package.json can target a dismiss menu.
+   */
+  static createNextStepsGroup(): SkillTreeItem {
+    const item = new SkillTreeItem(
+      'Next steps',
+      vscode.TreeItemCollapsibleState.Expanded,
+      'group',
+      undefined,
+      'nextSteps'
+    )
+    item.contextValue = 'nextStepsGroup'
+    return item
+  }
+
+  /**
+   * Creates a pinned MCP-offline reconnect row (SMI-5345).
+   */
+  static createMcpOfflineRow(): SkillTreeItem {
+    const item = new SkillTreeItem(
+      'Skillsmith server unavailable — Reconnect',
+      vscode.TreeItemCollapsibleState.None,
+      'group',
+      undefined,
+      undefined
+    )
+    item.iconPath = new vscode.ThemeIcon('debug-disconnect')
+    item.contextValue = 'mcpOffline'
+    item.command = {
+      command: 'skillsmith.mcpReconnect',
+      title: 'Reconnect',
+    }
+    return item
+  }
+
+  /**
+   * Creates a checklist action row for the 'Next steps' section (SMI-5346).
+   *
+   * @param label - Display label
+   * @param command - VS Code command to execute when the row is clicked
+   */
+  static createChecklistRow(label: string, command: vscode.Command): SkillTreeItem {
+    const item = new SkillTreeItem(
+      label,
+      vscode.TreeItemCollapsibleState.None,
+      'group',
+      undefined,
+      undefined
+    )
+    item.command = command
+    item.contextValue = 'nextStepsRow'
+    return item
   }
 }

--- a/packages/vscode-extension/src/sidebar/mcp-status-observer.test.ts
+++ b/packages/vscode-extension/src/sidebar/mcp-status-observer.test.ts
@@ -258,6 +258,29 @@ describe('registerMcpSidebarObserver — rebind / dispose', () => {
     observer.dispose()
   })
 
+  it('rebind cancels a pending offline debounce timer (no offline on the new client)', async () => {
+    const fake = makeFakeClient()
+    const { state, setOffline } = makeMessageState()
+    const { row, setMcpOffline } = makeOfflineRow()
+    const observer = registerMcpSidebarObserver({
+      getClient: () => fake.client,
+      messageState: state,
+      offlineRow: row,
+      debounceMs: 0,
+    })
+
+    // Old client drops; a config swap rebinds before the debounce timer fires.
+    fake.fire('disconnected')
+    observer.rebind()
+    await flush()
+
+    // The stale timer must NOT stamp offline onto the freshly-swapped client.
+    expect(setOffline).not.toHaveBeenCalled()
+    expect(setMcpOffline).not.toHaveBeenCalled()
+
+    observer.dispose()
+  })
+
   it('dispose tears down the subscription and clears a pending timer', async () => {
     const fake = makeFakeClient()
     const { state, setOffline } = makeMessageState()

--- a/packages/vscode-extension/src/sidebar/mcp-status-observer.test.ts
+++ b/packages/vscode-extension/src/sidebar/mcp-status-observer.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for the proactive MCP-offline observer (SMI-5345 / #1438).
+ *
+ * A fake client exposes a manually-fireable `onStatusChange` so status
+ * transitions are driven deterministically. `debounceMs: 0` collapses the
+ * debounce, but the timer is still asynchronous (a 0ms `setTimeout`), so the
+ * tests await a macrotask flush before asserting offline side effects.
+ *
+ * Covers: drop→(debounce)→offline; reconnect-after-offline→online; initial
+ * connect with no prior offline = zero calls (must not erase the first-run
+ * hint); 'connecting' no-op; debounce cancelled when a reconnect arrives first;
+ * rebind disposes the old sub without double-subscribing; dispose cleans up.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { SidebarMessageState } from './message-state.js'
+import { registerMcpSidebarObserver, type OfflineRowController } from './mcp-status-observer.js'
+
+/** Flush pending 0ms timers (the debounce fires on a macrotask). */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+interface FakeDisposable {
+  dispose: () => void
+  disposed: boolean
+}
+
+/**
+ * A manually-driven MCP client. `fire(status)` invokes every live listener;
+ * each `onStatusChange` returns a disposable whose `dispose()` removes the
+ * listener and flips `disposed` so tests can assert teardown.
+ */
+function makeFakeClient(): {
+  client: { onStatusChange: (l: (s: string) => void) => FakeDisposable; getStatus: () => string }
+  fire: (status: string) => void
+  liveListenerCount: () => number
+  disposables: FakeDisposable[]
+} {
+  const listeners = new Set<(s: string) => void>()
+  const disposables: FakeDisposable[] = []
+  let status = 'connected'
+
+  const client = {
+    onStatusChange(listener: (s: string) => void): FakeDisposable {
+      listeners.add(listener)
+      const disposable: FakeDisposable = {
+        disposed: false,
+        dispose(): void {
+          listeners.delete(listener)
+          disposable.disposed = true
+        },
+      }
+      disposables.push(disposable)
+      return disposable
+    },
+    getStatus(): string {
+      return status
+    },
+  }
+
+  return {
+    client,
+    fire(next: string): void {
+      status = next
+      listeners.forEach((l) => l(next))
+    },
+    liveListenerCount: () => listeners.size,
+    disposables,
+  }
+}
+
+function makeMessageState(): { state: SidebarMessageState; setOffline: ReturnType<typeof vi.fn> } {
+  const setOffline = vi.fn()
+  const state: SidebarMessageState = {
+    setFirstRunHint: vi.fn(),
+    setSearchBanner: vi.fn(),
+    setOffline,
+  }
+  return { state, setOffline }
+}
+
+function makeOfflineRow(): { row: OfflineRowController; setMcpOffline: ReturnType<typeof vi.fn> } {
+  const setMcpOffline = vi.fn()
+  return { row: { setMcpOffline }, setMcpOffline }
+}
+
+describe('registerMcpSidebarObserver — offline surfacing', () => {
+  it('a drop surfaces offline (message + row) after the debounce', async () => {
+    const fake = makeFakeClient()
+    const { state, setOffline } = makeMessageState()
+    const { row, setMcpOffline } = makeOfflineRow()
+    const observer = registerMcpSidebarObserver({
+      getClient: () => fake.client,
+      messageState: state,
+      offlineRow: row,
+      debounceMs: 0,
+    })
+
+    fake.fire('disconnected')
+    // Side effects are deferred to the (0ms) timer.
+    expect(setOffline).not.toHaveBeenCalled()
+    await flush()
+    expect(setOffline).toHaveBeenCalledWith(true)
+    expect(setMcpOffline).toHaveBeenCalledWith(true)
+
+    observer.dispose()
+  })
+
+  it("'error' also surfaces offline", async () => {
+    const fake = makeFakeClient()
+    const { state, setOffline } = makeMessageState()
+    const { row, setMcpOffline } = makeOfflineRow()
+    const observer = registerMcpSidebarObserver({
+      getClient: () => fake.client,
+      messageState: state,
+      offlineRow: row,
+      debounceMs: 0,
+    })
+
+    fake.fire('error')
+    await flush()
+    expect(setOffline).toHaveBeenCalledWith(true)
+    expect(setMcpOffline).toHaveBeenCalledWith(true)
+
+    observer.dispose()
+  })
+})
+
+describe('registerMcpSidebarObserver — reconnect / clear', () => {
+  it('connected after an offline clears both message and row', async () => {
+    const fake = makeFakeClient()
+    const { state, setOffline } = makeMessageState()
+    const { row, setMcpOffline } = makeOfflineRow()
+    const observer = registerMcpSidebarObserver({
+      getClient: () => fake.client,
+      messageState: state,
+      offlineRow: row,
+      debounceMs: 0,
+    })
+
+    fake.fire('disconnected')
+    await flush()
+    setOffline.mockClear()
+    setMcpOffline.mockClear()
+
+    fake.fire('connected')
+    expect(setOffline).toHaveBeenCalledWith(false)
+    expect(setMcpOffline).toHaveBeenCalledWith(false)
+
+    observer.dispose()
+  })
+
+  it('initial connected with NO prior offline does nothing (preserves the hint)', () => {
+    const fake = makeFakeClient()
+    const { state, setOffline } = makeMessageState()
+    const { row, setMcpOffline } = makeOfflineRow()
+    const observer = registerMcpSidebarObserver({
+      getClient: () => fake.client,
+      messageState: state,
+      offlineRow: row,
+      debounceMs: 0,
+    })
+
+    fake.fire('connected')
+    expect(setOffline).not.toHaveBeenCalled()
+    expect(setMcpOffline).not.toHaveBeenCalled()
+
+    observer.dispose()
+  })
+
+  it("'connecting' is a no-op", () => {
+    const fake = makeFakeClient()
+    const { state, setOffline } = makeMessageState()
+    const { row, setMcpOffline } = makeOfflineRow()
+    const observer = registerMcpSidebarObserver({
+      getClient: () => fake.client,
+      messageState: state,
+      offlineRow: row,
+      debounceMs: 0,
+    })
+
+    fake.fire('connecting')
+    expect(setOffline).not.toHaveBeenCalled()
+    expect(setMcpOffline).not.toHaveBeenCalled()
+
+    observer.dispose()
+  })
+
+  it('a reconnect arriving before the debounce fires cancels the offline', async () => {
+    const fake = makeFakeClient()
+    const { state, setOffline } = makeMessageState()
+    const { row, setMcpOffline } = makeOfflineRow()
+    const observer = registerMcpSidebarObserver({
+      getClient: () => fake.client,
+      messageState: state,
+      offlineRow: row,
+      debounceMs: 0,
+    })
+
+    fake.fire('disconnected')
+    // Reconnect before the (0ms) debounce timer has run.
+    fake.fire('connected')
+    await flush()
+
+    // No offline was ever surfaced, and the connect did not clear (no prior
+    // offline) — zero calls in either direction.
+    expect(setOffline).not.toHaveBeenCalled()
+    expect(setMcpOffline).not.toHaveBeenCalled()
+
+    observer.dispose()
+  })
+})
+
+describe('registerMcpSidebarObserver — rebind / dispose', () => {
+  it('rebind disposes the old subscription without double-subscribing', () => {
+    const fake = makeFakeClient()
+    const { state } = makeMessageState()
+    const { row } = makeOfflineRow()
+    const observer = registerMcpSidebarObserver({
+      getClient: () => fake.client,
+      messageState: state,
+      offlineRow: row,
+      debounceMs: 0,
+    })
+
+    expect(fake.liveListenerCount()).toBe(1)
+    observer.rebind()
+    // Old listener gone, exactly one live (no leak / double-sub).
+    expect(fake.liveListenerCount()).toBe(1)
+    expect(fake.disposables[0]?.disposed).toBe(true)
+    expect(fake.disposables.length).toBe(2)
+
+    observer.dispose()
+  })
+
+  it('rebind preserves wasOffline so a later reconnect still clears', async () => {
+    const fake = makeFakeClient()
+    const { state, setOffline } = makeMessageState()
+    const { row, setMcpOffline } = makeOfflineRow()
+    const observer = registerMcpSidebarObserver({
+      getClient: () => fake.client,
+      messageState: state,
+      offlineRow: row,
+      debounceMs: 0,
+    })
+
+    fake.fire('disconnected')
+    await flush()
+    expect(setOffline).toHaveBeenCalledWith(true)
+    setOffline.mockClear()
+    setMcpOffline.mockClear()
+
+    observer.rebind()
+    fake.fire('connected')
+    expect(setOffline).toHaveBeenCalledWith(false)
+    expect(setMcpOffline).toHaveBeenCalledWith(false)
+
+    observer.dispose()
+  })
+
+  it('dispose tears down the subscription and clears a pending timer', async () => {
+    const fake = makeFakeClient()
+    const { state, setOffline } = makeMessageState()
+    const { row } = makeOfflineRow()
+    const observer = registerMcpSidebarObserver({
+      getClient: () => fake.client,
+      messageState: state,
+      offlineRow: row,
+      debounceMs: 0,
+    })
+
+    fake.fire('disconnected')
+    // Dispose before the debounce timer fires — it must be cancelled.
+    observer.dispose()
+    await flush()
+    expect(setOffline).not.toHaveBeenCalled()
+    expect(fake.liveListenerCount()).toBe(0)
+    expect(fake.disposables[0]?.disposed).toBe(true)
+  })
+})

--- a/packages/vscode-extension/src/sidebar/mcp-status-observer.ts
+++ b/packages/vscode-extension/src/sidebar/mcp-status-observer.ts
@@ -1,0 +1,133 @@
+/**
+ * Proactive MCP-offline observer (SMI-5345 / #1438).
+ *
+ * Subscribes to the MCP client's `onStatusChange` and drives both the sidebar
+ * message (via the single-owner {@link SidebarMessageState}) and the offline
+ * row controller when the server drops out of band. A short debounce avoids
+ * flickering the offline copy during the client's own transient reconnect
+ * churn (`disconnected` → `connecting` → `connected`).
+ *
+ * The observer NEVER acts on the initial `connected` (when `wasOffline` is
+ * false) — doing so would erase the first-run hint before the user has even
+ * searched. It only clears offline state after a prior offline was shown.
+ */
+import type * as vscode from 'vscode'
+import type { SidebarMessageState } from './message-state.js'
+
+/** Default debounce before surfacing offline copy on a drop (ms). */
+const DEFAULT_DEBOUNCE_MS = 1500
+
+/**
+ * The offline-row side of the sidebar (the tree's "MCP offline" affordance).
+ * Kept minimal so the observer depends only on what it drives — the concrete
+ * `SkillTreeDataProvider` implements this.
+ */
+export interface OfflineRowController {
+  setMcpOffline(isOffline: boolean): void
+}
+
+/** A minimal view of the MCP client the observer needs. */
+interface ObservableClient {
+  onStatusChange(listener: (status: string) => void): vscode.Disposable
+  getStatus(): string
+}
+
+interface McpSidebarObserverDeps {
+  /** Resolves the (possibly hot-swapped) singleton MCP client. */
+  getClient: () => ObservableClient
+  /** The single owner of `TreeView.message`. */
+  messageState: SidebarMessageState
+  /** The offline-row affordance on the tree. */
+  offlineRow: OfflineRowController
+  /** Debounce before surfacing offline copy (default 1500ms; pass 0 in tests). */
+  debounceMs?: number
+}
+
+/** Handle for rebinding (after a singleton swap) and disposing the observer. */
+export interface McpSidebarObserver {
+  /** Dispose the prior subscription and re-subscribe to the current singleton. */
+  rebind(): void
+  /** Dispose the subscription and clear any pending debounce timer. */
+  dispose(): void
+}
+
+/**
+ * Registers the proactive MCP-offline observer. Returns a handle whose
+ * `rebind()` must be called whenever the MCP client singleton is swapped (e.g.
+ * on a config change), and whose `dispose()` tears down the subscription + timer.
+ */
+export function registerMcpSidebarObserver(deps: McpSidebarObserverDeps): McpSidebarObserver {
+  const { getClient, messageState, offlineRow } = deps
+  const debounceMs = deps.debounceMs ?? DEFAULT_DEBOUNCE_MS
+
+  let subscription: vscode.Disposable | undefined
+  let pendingTimer: ReturnType<typeof setTimeout> | undefined
+  // Survives rebind so a reconnect after a singleton swap still clears offline.
+  let wasOffline = false
+
+  function clearPendingTimer(): void {
+    if (pendingTimer !== undefined) {
+      clearTimeout(pendingTimer)
+      pendingTimer = undefined
+    }
+  }
+
+  function goOffline(): void {
+    wasOffline = true
+    messageState.setOffline(true)
+    offlineRow.setMcpOffline(true)
+  }
+
+  function goOnline(): void {
+    wasOffline = false
+    messageState.setOffline(false)
+    offlineRow.setMcpOffline(false)
+  }
+
+  function handleStatus(status: string): void {
+    if (status === 'disconnected' || status === 'error') {
+      // Debounce: a transient drop the client itself recovers from should not
+      // flash the offline copy. A later status cancels this timer first.
+      clearPendingTimer()
+      pendingTimer = setTimeout(() => {
+        pendingTimer = undefined
+        goOffline()
+      }, debounceMs)
+      return
+    }
+
+    if (status === 'connected') {
+      // Cancel a pending offline regardless — the drop self-healed.
+      clearPendingTimer()
+      // Only act if we previously surfaced offline. The initial connect must
+      // NOT clear offline (it would erase the first-run hint).
+      if (wasOffline) {
+        goOnline()
+      }
+      return
+    }
+
+    // 'connecting' (and any unknown status): no-op.
+  }
+
+  function subscribe(): void {
+    subscription = getClient().onStatusChange(handleStatus)
+  }
+
+  subscribe()
+
+  return {
+    rebind(): void {
+      subscription?.dispose()
+      subscription = undefined
+      // Preserve wasOffline across the swap; a reconnect on the new singleton
+      // must still be able to clear a previously-shown offline state.
+      subscribe()
+    },
+    dispose(): void {
+      clearPendingTimer()
+      subscription?.dispose()
+      subscription = undefined
+    },
+  }
+}

--- a/packages/vscode-extension/src/sidebar/mcp-status-observer.ts
+++ b/packages/vscode-extension/src/sidebar/mcp-status-observer.ts
@@ -118,6 +118,10 @@ export function registerMcpSidebarObserver(deps: McpSidebarObserverDeps): McpSid
 
   return {
     rebind(): void {
+      // Cancel any in-flight offline debounce from the OLD client — otherwise a
+      // stale timer could fire goOffline() onto the freshly-swapped client even
+      // after it has already connected (governance, plan-review follow-up).
+      clearPendingTimer()
       subscription?.dispose()
       subscription = undefined
       // Preserve wasOffline across the swap; a reconnect on the new singleton

--- a/packages/vscode-extension/src/sidebar/message-state.test.ts
+++ b/packages/vscode-extension/src/sidebar/message-state.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the single-owner sidebar message state machine (SMI-5345 / #1438).
+ *
+ * Asserts the precedence matrix (offline > banner > hint > undefined) and the
+ * race-resolving invariants: a banner set while offline stays masked by the
+ * offline copy; clearing offline restores whichever lower-precedence input is
+ * still set; and a reconnect arriving after a search shows the banner, not
+ * `undefined` (the old multi-writer clobber).
+ *
+ * The TreeView is mocked as a plain `{ message: undefined }` object cast to the
+ * type; assertions read `.message` directly.
+ */
+import { describe, it, expect } from 'vitest'
+import type * as vscode from 'vscode'
+import {
+  createSidebarMessageState,
+  OFFLINE_MESSAGE,
+  type SidebarMessageState,
+} from './message-state.js'
+
+/** A minimal TreeView stand-in — only `.message` is exercised. */
+function makeTreeView(): { view: vscode.TreeView<unknown>; raw: { message: string | undefined } } {
+  const raw: { message: string | undefined } = { message: undefined }
+  return { view: raw as unknown as vscode.TreeView<unknown>, raw }
+}
+
+function setup(): { state: SidebarMessageState; raw: { message: string | undefined } } {
+  const { view, raw } = makeTreeView()
+  return { state: createSidebarMessageState(view), raw }
+}
+
+describe('createSidebarMessageState — precedence matrix', () => {
+  it('starts with no message', () => {
+    const { raw } = setup()
+    expect(raw.message).toBeUndefined()
+  })
+
+  it('shows the first-run hint when only the hint is set', () => {
+    const { state, raw } = setup()
+    state.setFirstRunHint('hint')
+    expect(raw.message).toBe('hint')
+  })
+
+  it('search banner outranks the first-run hint', () => {
+    const { state, raw } = setup()
+    state.setFirstRunHint('hint')
+    state.setSearchBanner('banner')
+    expect(raw.message).toBe('banner')
+  })
+
+  it('offline copy outranks the search banner', () => {
+    const { state, raw } = setup()
+    state.setSearchBanner('banner')
+    state.setOffline(true)
+    expect(raw.message).toBe(OFFLINE_MESSAGE)
+  })
+
+  it('offline copy outranks the first-run hint', () => {
+    const { state, raw } = setup()
+    state.setFirstRunHint('hint')
+    state.setOffline(true)
+    expect(raw.message).toBe(OFFLINE_MESSAGE)
+  })
+})
+
+describe('createSidebarMessageState — clearing', () => {
+  it('clearing the banner falls back to the first-run hint', () => {
+    const { state, raw } = setup()
+    state.setFirstRunHint('hint')
+    state.setSearchBanner('banner')
+    state.setSearchBanner(undefined)
+    expect(raw.message).toBe('hint')
+  })
+
+  it('clearing the banner with no hint falls back to undefined', () => {
+    const { state, raw } = setup()
+    state.setSearchBanner('banner')
+    state.setSearchBanner(undefined)
+    expect(raw.message).toBeUndefined()
+  })
+
+  it('clearing the hint with no banner falls back to undefined', () => {
+    const { state, raw } = setup()
+    state.setFirstRunHint('hint')
+    state.setFirstRunHint(undefined)
+    expect(raw.message).toBeUndefined()
+  })
+})
+
+describe('createSidebarMessageState — offline/banner race invariants', () => {
+  it('a banner set WHILE offline stays masked by the offline copy', () => {
+    const { state, raw } = setup()
+    state.setOffline(true)
+    state.setSearchBanner('banner')
+    expect(raw.message).toBe(OFFLINE_MESSAGE)
+  })
+
+  it('clearing offline restores the banner that was set while offline', () => {
+    const { state, raw } = setup()
+    state.setOffline(true)
+    state.setSearchBanner('banner')
+    state.setOffline(false)
+    expect(raw.message).toBe('banner')
+  })
+
+  it('clearing offline restores the hint when no banner is set', () => {
+    const { state, raw } = setup()
+    state.setFirstRunHint('hint')
+    state.setOffline(true)
+    state.setOffline(false)
+    expect(raw.message).toBe('hint')
+  })
+
+  it('reconnect AFTER a search shows the banner, not undefined (no clobber)', () => {
+    const { state, raw } = setup()
+    // A search lands a banner...
+    state.setSearchBanner('Showing results for "foo"')
+    // ...then the client drops and reconnects mid-session.
+    state.setOffline(true)
+    state.setOffline(false)
+    // The banner must survive — the old multi-writer bug erased it.
+    expect(raw.message).toBe('Showing results for "foo"')
+  })
+})

--- a/packages/vscode-extension/src/sidebar/message-state.ts
+++ b/packages/vscode-extension/src/sidebar/message-state.ts
@@ -1,0 +1,82 @@
+/**
+ * Single-owner state machine for `TreeView.message` (SMI-5345 / #1438).
+ *
+ * Before this, three sites wrote `skillsView.message` directly — the first-run
+ * hint (extension.ts), the search/no-results/offline banners (searchSkills.ts),
+ * and (newly) the proactive MCP-offline copy. Concurrent writers raced: a
+ * reconnect firing mid-search could clobber a banner, and an out-of-band drop
+ * could erase the first-run hint. This module is the ONLY writer of
+ * `treeView.message`. Each input is held in closure state; every setter
+ * recomputes the message by a fixed precedence so the surface can never drift:
+ *
+ *   offline-copy (if offline) > searchBanner (if set) > firstRunHint (if set) > undefined
+ */
+import type * as vscode from 'vscode'
+
+/** The proactive MCP-offline sidebar copy (SMI-5345). */
+export const OFFLINE_MESSAGE =
+  'Skillsmith server unavailable — start the MCP server, then Reconnect from the status bar.'
+
+/**
+ * The single writer of `TreeView.message`. Each setter mutates one closure
+ * input and re-derives the visible message by precedence.
+ */
+export interface SidebarMessageState {
+  /** The persistent first-run / pre-search hint (lowest precedence). */
+  setFirstRunHint(text: string | undefined): void
+  /** The active search / no-results context banner (middle precedence). */
+  setSearchBanner(text: string | undefined): void
+  /** Whether the MCP server is offline (highest precedence when true). */
+  setOffline(isOffline: boolean): void
+}
+
+/**
+ * Creates the single-owner message state machine bound to a TreeView. Holds the
+ * first-run hint, search banner, and offline flag in closure state; recomputes
+ * `treeView.message` on every setter.
+ */
+export function createSidebarMessageState(treeView: vscode.TreeView<unknown>): SidebarMessageState {
+  let firstRunHint: string | undefined
+  let searchBanner: string | undefined
+  let isOffline = false
+
+  function resolve(): string | undefined {
+    if (isOffline) {
+      return OFFLINE_MESSAGE
+    }
+    if (searchBanner !== undefined) {
+      return searchBanner
+    }
+    if (firstRunHint !== undefined) {
+      return firstRunHint
+    }
+    return undefined
+  }
+
+  function recompute(): void {
+    const next = resolve()
+    // `TreeView.message` is `message?: string`; under exactOptionalPropertyTypes
+    // a direct `= undefined` is rejected. Set the string when present, otherwise
+    // `delete` to clear the banner (the documented way to remove the message).
+    if (next === undefined) {
+      delete treeView.message
+    } else {
+      treeView.message = next
+    }
+  }
+
+  return {
+    setFirstRunHint(text: string | undefined): void {
+      firstRunHint = text
+      recompute()
+    },
+    setSearchBanner(text: string | undefined): void {
+      searchBanner = text
+      recompute()
+    },
+    setOffline(offline: boolean): void {
+      isOffline = offline
+      recompute()
+    },
+  }
+}

--- a/packages/vscode-extension/src/utils/createSkill.helpers.ts
+++ b/packages/vscode-extension/src/utils/createSkill.helpers.ts
@@ -9,11 +9,10 @@
  * The CLI is the source of truth for templates; this module never scaffolds inline.
  */
 import * as vscode from 'vscode'
-import * as path from 'node:path'
 import * as os from 'node:os'
+import * as path from 'node:path'
 import * as fs from 'node:fs/promises'
 import crossSpawn from 'cross-spawn'
-import { track } from '../services/Telemetry.js'
 
 /** The four fields the Create Skill form collects. */
 export interface CreateFormFields {
@@ -111,28 +110,55 @@ export async function exists(p: string): Promise<boolean> {
 }
 
 /**
- * Post-create authoring checklist (SMI-5312 / GH #1453). Best-effort: invoked
- * fire-and-forget (`void`), so it must never reject — `executeCommand`/`openExternal`
- * can throw (host shutting down, unregistered scheme) and an unhandled rejection
- * would surface to the user. Swallow; the actions are optional.
+ * Run `skillsmith validate` against the current skill (SMI-5346).
+ *
+ * Injection-safe: args are passed as an array to cross-spawn, never via shell.
+ * The command is intended to be registered as 'skillsmith.runValidate' and
+ * wrapped with withTelemetry by the queen (extension.ts).
+ *
+ * Races a 30-second timeout that kills the child and writes a timeout line to
+ * the output channel. On exit-0 writes a success line; on non-zero writes a
+ * failure line + hint.
  */
-export async function showPostCreateChecklist(targetDir: string, name: string): Promise<void> {
-  const OPEN_FOLDER = 'Open folder'
-  const DOCS = 'Authoring docs'
-  try {
-    const action = await vscode.window.showInformationMessage(
-      `Created skill "${name}". Next: fill in SKILL.md (frontmatter + instructions), add examples, then publish.`,
-      OPEN_FOLDER,
-      DOCS
-    )
-    if (action === OPEN_FOLDER) {
-      track('vscode_create_checklist_action', { action: 'open_folder' })
-      await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(targetDir))
-    } else if (action === DOCS) {
-      track('vscode_create_checklist_action', { action: 'docs' })
-      await vscode.env.openExternal(vscode.Uri.parse('https://skillsmith.app/docs'))
+export async function runValidate(output: vscode.OutputChannel): Promise<void> {
+  output.show(true)
+  output.appendLine('Running skillsmith validate…')
+
+  const TIMEOUT_MS = 30_000
+
+  await new Promise<void>((resolve) => {
+    const child = crossSpawn('skillsmith', ['validate'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    const timer = setTimeout(() => {
+      child.kill()
+      output.appendLine('[error] skillsmith validate timed out after 30 s.')
+      resolve()
+    }, TIMEOUT_MS)
+
+    const emit = (buf: Buffer): void => {
+      output.append(buf.toString('utf8'))
     }
-  } catch {
-    // Optional next-step action failed; nothing actionable to surface.
-  }
+    child.stdout?.on('data', emit)
+    child.stderr?.on('data', emit)
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      output.appendLine(`[error] ${err.message}`)
+      resolve()
+    })
+
+    child.on('exit', (code) => {
+      clearTimeout(timer)
+      if (code === 0) {
+        output.appendLine('skillsmith validate completed successfully.')
+      } else {
+        output.appendLine(
+          `skillsmith validate exited with code ${String(code)}. Check the output above for details.`
+        )
+      }
+      resolve()
+    })
+  })
 }

--- a/packages/vscode-extension/src/utils/createSkill.helpers.ts
+++ b/packages/vscode-extension/src/utils/createSkill.helpers.ts
@@ -127,11 +127,27 @@ export async function runValidate(output: vscode.OutputChannel): Promise<void> {
   const TIMEOUT_MS = 30_000
 
   await new Promise<void>((resolve) => {
+    // Exactly one terminal path (timeout / error / exit) may report + resolve.
+    // `kill()` on timeout still fires `exit`, so without this guard the channel
+    // would get a spurious "exited with code null" line after the timeout
+    // message (governance follow-up).
+    let settled = false
+    const settle = (): boolean => {
+      if (settled) {
+        return false
+      }
+      settled = true
+      return true
+    }
+
     const child = crossSpawn('skillsmith', ['validate'], {
       stdio: ['ignore', 'pipe', 'pipe'],
     })
 
     const timer = setTimeout(() => {
+      if (!settle()) {
+        return
+      }
       child.kill()
       output.appendLine('[error] skillsmith validate timed out after 30 s.')
       resolve()
@@ -145,12 +161,18 @@ export async function runValidate(output: vscode.OutputChannel): Promise<void> {
 
     child.on('error', (err) => {
       clearTimeout(timer)
+      if (!settle()) {
+        return
+      }
       output.appendLine(`[error] ${err.message}`)
       resolve()
     })
 
     child.on('exit', (code) => {
       clearTimeout(timer)
+      if (!settle()) {
+        return
+      }
       if (code === 0) {
         output.appendLine('skillsmith validate completed successfully.')
       } else {

--- a/packages/vscode-extension/src/views/CreateSkillPanel.ts
+++ b/packages/vscode-extension/src/views/CreateSkillPanel.ts
@@ -28,13 +28,7 @@ import type {
   CreatePanelOutbound,
   CreateFormFields,
 } from './create-panel-types.js'
-import {
-  buildCreateArgs,
-  runCli,
-  exists,
-  targetDirFor,
-  showPostCreateChecklist,
-} from '../utils/createSkill.helpers.js'
+import { buildCreateArgs, runCli, exists, targetDirFor } from '../utils/createSkill.helpers.js'
 import { getCreateSkillHtml } from './create-panel-html.js'
 
 const VALID_TYPES: ReadonlySet<string> = new Set(['basic', 'intermediate', 'advanced'])
@@ -228,7 +222,7 @@ export class CreateSkillPanel {
         // SKILL.md may be absent for an unexpected scaffold shape — not fatal.
       }
       this.dispose()
-      void showPostCreateChecklist(targetDir, fields.name)
+      this._treeProvider.showNextSteps(fields.name, targetDir)
       return
     }
 

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2028,6 +2028,8 @@ console.log(`\n${BOLD}28. VS Code Command ↔ Test Pairing (SMI-4194)${RESET}`)
         'skillsmith.selectForCompare', // SMI-5340: tree-context compare; action tested in compareSkills.test.ts + compare-source.test.ts
         'skillsmith.compareWithSelected', // SMI-5340: tree-context compare; action tested in compareSkills.test.ts
         'skillsmith.clearSkillFilters', // SMI-5304: action exercised in searchSkills.test.ts
+        'skillsmith.runValidate', // SMI-5346: validate helper tested in createSkill.checklist.test.ts
+        'skillsmith.dismissNextSteps', // SMI-5346: dismiss tested in skillTreeDataProvider.nextSteps.test.ts
       ])
       const testFiles = readdirSync(testDir).filter((f) => f.endsWith('.test.ts'))
       const missing = []


### PR DESCRIPTION
Closes the last two children of the VS Code UX overhaul (SMI-5287): Epic B and Epic C. After this + the E2E follow-up land, SMI-5287 is complete.

Closes #1438
Closes #1453

## SMI-5345 (#1438) — proactive MCP-offline sidebar
- New single-owner `message-state.ts` machine for `skillsView.message` (precedence **offline > search banner > first-run hint**) — eliminates the multi-writer clobber + reconnect-during-search race.
- New `mcp-status-observer.ts`: on an out-of-band MCP drop (not just during a search) it surfaces an offline notice **and a pinned Reconnect tree row** (visible even to users with installed skills — `viewsWelcome` is hidden once the tree is non-empty). Debounced 1.5s; never erases the first-run hint on the initial connect; rebinds + cancels stale timers on the config-driven client swap.
- Fixed a `registerVersionCheck` subscription-accumulation leak (plan-review C3).

## SMI-5346 (#1453) — post-create checklist sidebar section
- Replaced the transient post-create toast with a dismissible **"Next steps"** sidebar section (new `group:nextSteps` root group) with CLI-command rows, incl. a new `skillsmith.runValidate` command (`output.show` + 30s timeout + completion line).
- Per-create `globalState` dismiss (`skillsmith.dismissNextSteps`); emits `vscode_create_checklist_view` once.

## Also
- Fixed a latent `exactOptionalPropertyTypes` regression in `McpStatusBar.ts` (introduced by SMI-5341) that merged green because **the vscode-extension package is not typechecked in CI** (root `tsc --build` excludes it; the vscode workflows only esbuild). Follow-up filed.

## Verification (host-only, ADR-113 — no Docker)
- `npm run typecheck` / `npm run lint` / `npm run audit:standards` clean (17 commands paired, all files <500 lines).
- **756 unit tests green.**
- Plan-review (4 Critical / 12 High folded) + governance review (5 findings, **all resolved**: observer rebind timer, runValidate double-resolve, dead telemetry event, dead test mock + 2 new regression tests).

E2E `create` + `tree-view` specs land separately (SMI-5339 Phase 2b). The plan doc + `docs/internal` pointer bump land via a docs PR.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
