### PR TITLE
fix(vscode): replace Activity Bar stack glyph with node-graph brand mark (SMI-5349)

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Added `npm run test:vscode` for a worktree-local vscode test path; local typecheck/test now warn on stale `node_modules` instead of failing opaquely (SMI-5343/5344).
 
+### Changed
+
+- Refreshed the Activity Bar icon to the Skillsmith node-graph brand mark, replacing the previous generic stack glyph.
+
 ### Fixed
 
 - **Skill details recover after reconnecting** — the skill detail panel no longer stays stuck on "Skillsmith server unavailable" once the MCP server is back (including after you change an MCP setting, which restarts the connection). The panel now reloads on its own when the connection is restored, and Retry / reopening the skill works reliably. The connection status indicator in the status bar also stays accurate after a settings change.

--- a/packages/vscode-extension/resources/skillsmith.svg
+++ b/packages/vscode-extension/resources/skillsmith.svg
@@ -1,5 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 2L2 7l10 5 10-5-10-5z"/>
-  <path d="M2 17l10 5 10-5"/>
-  <path d="M2 12l10 5 10-5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <g transform="translate(32, 32)" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 10 -18 Q -10 -14, -10 -4 Q -10 4, 10 8 Q 10 16, -10 20"
+          stroke="currentColor" stroke-width="3" fill="none"/>
+    <circle cx="10" cy="-18" r="5" fill="currentColor"/>
+    <circle cx="-10" cy="-4" r="5" fill="currentColor"/>
+    <circle cx="10" cy="8" r="5" fill="currentColor"/>
+    <circle cx="-10" cy="20" r="5" fill="currentColor"/>
+  </g>
 </svg>


### PR DESCRIPTION
## What

Replace the VS Code extension's Activity Bar icon — the generic grey "layers" stack glyph → a monochrome `currentColor` adaptation of the Skillsmith neural-S node graph (geometry reused from `packages/website/public/logo-icon.svg`). VS Code masks Activity Bar icons to a single theme color, so it renders grey by design (which is fine — the request explicitly allowed a grey brand mark). The full-color Marketplace tile (`resources/skillsmith-icon.png`) already shows this brand mark and is unchanged.

CHANGELOG entry added under `[Unreleased]`; **no version bump** — bundles with the next 0.6.3 release.

## Verification

- SVG validated with `xmllint` and rendered grey-on-dark at icon size — reads cleanly as the node graph.
- CHANGELOG prettier-clean; `audit:standards` clean (only pre-existing unrelated warnings: migration headers, eval-cron heartbeat).

## Notes

- Rebased onto current `main` (#1537 landed concurrently and also touched the vscode package). While verifying, I found a latent vscode typecheck error (`McpStatusBar.ts` `TS2412` under `exactOptionalPropertyTypes`) that PR CI never catches — but it was already fixed by #1537 on main, so nothing for that is carried here. The underlying gap (PR CI does not typecheck `packages/vscode-extension`; only `publish-vscode.yml` does) is tracked in SMI-5350.

[skip-impl-check] — static asset + changelog only; no code-behavior change to test.
[skip-smoke] — vscode-extension only; no prod edge-function surface touched.
