### PR TITLE
ci(vscode): typecheck vscode-extension in CI, matrix-gated (SMI-5348)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1026,6 +1026,23 @@ jobs:
       - name: Run TypeScript type check
         run: npm run typecheck
 
+      # SMI-5348: the root `npm run typecheck` (tsc --build) covers only the
+      # packages in root tsconfig references (core/mcp-server/cli/enterprise);
+      # vscode-extension is NOT in that graph, so its `tsc --noEmit` runs
+      # nowhere in CI and type regressions merged green (SMI-5341 / McpStatusBar).
+      # vscode-extension has no @skillsmith/* workspace deps, so a standalone
+      # typecheck needs no prior Turborepo build. Gated on the affected-dirs
+      # matrix (same source as the `test` job, see `mcp-server` at the
+      # test-mcp-server-integration job) so it runs ONLY on PRs that touch the
+      # extension, and is skipped otherwise to keep this required host job green.
+      - name: Type check vscode-extension (src)
+        if: contains(fromJson(needs.classify.outputs.affected_dirs), 'vscode-extension')
+        run: npm run -w packages/vscode-extension typecheck
+
+      - name: Type check vscode-extension (e2e specs)
+        if: contains(fromJson(needs.classify.outputs.affected_dirs), 'vscode-extension')
+        run: npm run -w packages/vscode-extension typecheck:e2e
+
       - name: Run standards audit
         run: npm run audit:standards
 


### PR DESCRIPTION
## Summary

`packages/vscode-extension` was **typechecked nowhere in CI**: the root `npm run typecheck` (`tsc --build`) covers only the packages in root `tsconfig.json` references (core/mcp-server/cli/enterprise), and the vscode workflows only run esbuild (`npm run build`). A real `exactOptionalPropertyTypes` regression (SMI-5341, `McpStatusBar.ts`) merged **green** as a result, caught only later by an in-package typecheck.

This adds two **matrix-gated** typecheck steps to the already-required, host-runner `Quality Checks` job:

```yaml
- name: Type check vscode-extension (src)
  if: contains(fromJson(needs.classify.outputs.affected_dirs), 'vscode-extension')
  run: npm run -w packages/vscode-extension typecheck

- name: Type check vscode-extension (e2e specs)
  if: contains(fromJson(needs.classify.outputs.affected_dirs), 'vscode-extension')
  run: npm run -w packages/vscode-extension typecheck:e2e
```

## Why this shape (selective + immediate + safe)

- **Matrix-selective** (per request): the `if:` reuses `classify.affected_dirs` — the exact selector the `test` matrix already uses for `mcp-server` (`test-mcp-server-integration` job). Runs **only** on PRs that touch `packages/vscode-extension`; skipped on every other PR (job stays green); docs-only PRs skip `Quality Checks` entirely.
- **Immediately enforcing**: `Quality Checks` is already a required check, so no branch-protection change is needed and there's no path-filtered-required-check "stuck pending" risk.
- **Standalone**: vscode-extension has no `@skillsmith/*` workspace deps, so `tsc --noEmit` needs no prior Turborepo build.
- **Empty latent-error surface**: both `typecheck` and `typecheck:e2e` pass clean on origin/main today, so the gate enables with **no source fixes**.

## Validation

Workflow-only PR → `affected_dirs` won't contain `vscode-extension`, so the two new steps are **skipped on this PR** (expected — `ci.yml` is `ALWAYS_FULL_CI`/`code` tier but matches no `packages/` path). Confidence: (1) local triage — both typechecks exit 0 on origin/main; (2) the gate expression is the proven in-file `mcp-server` pattern; (3) the next `packages/vscode-extension/**` PR (e.g. SMI-5347) will exercise both steps green.

Plan, alternatives (root-tsconfig `composite` emit collision; separate path-filtered workflow), and plan-review findings: `docs/internal/implementation/2026-06-22-vscode-typecheck-ci-gate-smi-5348.md` (docs PR + pointer bump follow).

ADR-109: SPARC recon + plan-review completed before implementation. Governance: PASS (em-dash + npm flag-form findings fixed).

Closes SMI-5348.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)