### PR TITLE
fix(docker): entrypoint self-heals all native modules under ignore-scripts (SMI-5351)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,11 +270,11 @@ Project skills load from the `.claude/skills/` mount-point of the `skillsmith-st
 | Problem | Fix |
 |---------|-----|
 | Container won't start | `docker compose --profile dev down && docker volume rm skillsmith_node_modules && docker compose --profile dev up -d` |
-| Native module errors | `docker exec skillsmith-dev-1 npm rebuild better-sqlite3 onnxruntime-node` |
-| `hnswlib-node` fails validation after rebuild (`ignore-scripts=true` in `.npmrc` blocks node-gyp — see SMI-5200) | Permanent fix ships in PR #1365. Until merged, delete the stale volume so Docker re-initialises `node_modules` from the image layer (built without `.npmrc`): `docker compose --profile dev down && docker volume rm skillsmith_node_modules && docker compose --profile dev up -d` |
+| Native module errors | `docker compose restart dev` (entrypoint self-heals better-sqlite3 / onnxruntime-node / hnswlib-node on restart, SMI-5351; first run may re-download a prebuilt) or per-module `docker exec skillsmith-dev-1 npm rebuild <module> --ignore-scripts=false`. esbuild's binary loads lazily, so a corrupt esbuild binary isn't auto-detected — SMI-5352. |
+| `hnswlib-node` fails validation after rebuild (`ignore-scripts=true` in `.npmrc` blocks node-gyp — see SMI-5200) | The entrypoint now self-heals on restart (`docker compose restart dev`, SMI-5351 extended `--ignore-scripts=false` to all native modules). `docker volume rm skillsmith_node_modules` is a last resort only. |
 | Platform mismatch (SIGKILL 137) | `rm -rf packages/*/node_modules/better-sqlite3 packages/*/node_modules/onnxruntime-node` then rebuild |
 | Node ABI mismatch | WASM fallback auto-activates (core ≥0.4.10). Restore native: rebuild in Docker + `./scripts/repair-host-native-deps.sh` (SMI-4549) |
-| "invalid ELF header" in Docker (SMI-4698) | [git-crypt-guide.md § Host Native Bindings](.claude/development/git-crypt-guide.md#host-native-bindings--sessionstart-instrumentation-smi-4549) |
+| "invalid ELF header" in Docker (SMI-4698) | Try `docker compose restart dev` (self-heals) or `docker exec skillsmith-dev-1 npm rebuild <module> --ignore-scripts=false` first; for persistent host-binding leaks, see [git-crypt-guide.md § Host Native Bindings](.claude/development/git-crypt-guide.md#host-native-bindings--sessionstart-instrumentation-smi-4549) |
 | Worktree `npm run build` fails (SMI-4689) | SMI-4738 postinstall auto-regenerates override; bounce worktree container. Drift: `./scripts/repair-worktrees.sh` from main repo. macOS only. [Details](.claude/development/git-crypt-guide.md#worktree-docker-bind-mounts-smi-4689) |
 | Docker DNS failure | `docker network prune -f` then restart |
 | Stale CJS artifacts | `docker exec skillsmith-dev-1 bash -c 'find /app/packages -path "*/src/*.js" -not -path "*/node_modules/*" -not -path "*/dist/*" -type f -delete'` |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -109,12 +109,19 @@ fi
 echo -e "${YELLOW}[entrypoint] Validating native modules...${NC}"
 
 # List of native modules to validate.
-# Must match Dockerfile:73 `npm rebuild` list. With .npmrc ignore-scripts=true
-# (SMI-4672), this loop is the only runtime rebuild path on cache miss / ABI
-# mismatch — missing a module silently fails open (mock embedding fallback per
-# ADR-009, brute-force vector search per SMI-4577, esbuild platform-binary
-# breakage). Source-only packages (hnswlib-node) use --ignore-scripts=false so
-# node-gyp runs despite .npmrc (SMI-5200). Keep this array in sync with Dockerfile:73.
+# Must match the `RUN npm rebuild …` line in the Dockerfile (the NATIVE_MODULES
+# array is the canonical source; keep both in sync). With .npmrc ignore-scripts=true
+# (SMI-4672), plain `npm rebuild` is a verified no-op — it exits 0 but leaves
+# the binary byte-identical (SMI-5351 ground-truth investigation). ALL four
+# modules therefore require --ignore-scripts=false in the rebuild loop, not just
+# hnswlib-node. This includes prebuilt-binary packages (better-sqlite3,
+# onnxruntime-node, esbuild): their CDN download hooks (prebuild-install) ARE
+# install scripts and are blocked by ignore-scripts=true exactly as node-gyp is.
+# On the already-failed path, re-downloading the prebuilt IS the intended
+# self-heal. Source-only packages (hnswlib-node) have always needed the override
+# so node-gyp runs (SMI-5200); this change extends that to all four modules.
+# The override is scoped to the rebuild loop only (inside the
+# VALIDATION_FAILED guard) so healthy restarts pay nothing.
 NATIVE_MODULES=("better-sqlite3" "onnxruntime-node" "esbuild" "hnswlib-node")
 
 # Track validation status
@@ -134,15 +141,17 @@ if [ $VALIDATION_FAILED -eq 1 ]; then
     echo -e "${YELLOW}[entrypoint] Native module mismatch detected. Attempting rebuild...${NC}"
 
     for module in "${NATIVE_MODULES[@]}"; do
-        echo -e "${YELLOW}  Rebuilding ${module}...${NC}"
-        # hnswlib-node ships source-only (gypfile: true); --ignore-scripts=false overrides .npmrc
-        # so node-gyp runs (SMI-5200). Prebuilt-binary packages (others) don't need this and it
-        # would re-trigger their CDN download hooks unnecessarily.
-        if [ "${module}" = "hnswlib-node" ]; then
-            npm rebuild "${module}" --ignore-scripts=false || echo -e "${YELLOW}  ↳ npm rebuild exited non-zero for ${module} (see output above)${NC}"
-        else
-            npm rebuild "${module}" || echo -e "${YELLOW}  ↳ npm rebuild exited non-zero for ${module} (see output above)${NC}"
-        fi
+        # All four modules require --ignore-scripts=false: plain `npm rebuild` is a
+        # no-op under .npmrc ignore-scripts=true, verified SMI-5351 (exits 0 but
+        # leaves the binary byte-identical). This applies to prebuilt-binary packages
+        # (better-sqlite3, onnxruntime-node, esbuild) just as much as to the
+        # source-only package (hnswlib-node, SMI-5200) — CDN download hooks
+        # (prebuild-install) are install scripts and are blocked by ignore-scripts=true.
+        # Re-downloading a prebuilt only happens on this already-failed path and IS
+        # the intended self-heal. The --ignore-scripts=false override is scoped here,
+        # inside the VALIDATION_FAILED guard, so healthy restarts pay nothing.
+        echo -e "${YELLOW}  Rebuilding ${module} (first run may fetch a prebuilt)...${NC}"
+        npm rebuild "${module}" --ignore-scripts=false || echo -e "${YELLOW}  ↳ npm rebuild exited non-zero for ${module} (see output above)${NC}"
     done
 
     # Re-validate after rebuild
@@ -158,8 +167,14 @@ if [ $VALIDATION_FAILED -eq 1 ]; then
 
     if [ $REBUILD_FAILED -eq 1 ]; then
         echo -e "${RED}[entrypoint] Native module validation failed after rebuild.${NC}"
-        echo -e "${YELLOW}Try: docker compose down && docker compose build --no-cache${NC}"
-        echo -e "${YELLOW}For verbose rebuild output (run on host): docker exec skillsmith-dev-1 npm rebuild ${FAILED_MODULES}${NC}"
+        echo -e "${YELLOW}For verbose rebuild output (run on host): docker exec skillsmith-dev-1 npm rebuild ${FAILED_MODULES} --ignore-scripts=false${NC}"
+        # Probe CDN reachability before recommending a network-dependent recovery path.
+        # --max-time 5 is mandatory: a CDN hang must not stall container start (M11/F2).
+        if curl -fsS --max-time 5 https://registry.npmjs.org/ >/dev/null 2>&1; then
+            echo -e "${YELLOW}Try: docker compose down && docker compose build --no-cache${NC}"
+        else
+            echo -e "${YELLOW}Network unreachable — reconnect to the internet, then: docker compose restart dev${NC}"
+        fi
         exit 1
     fi
 

--- a/scripts/tests/docker-entrypoint-native-rebuild.test.ts
+++ b/scripts/tests/docker-entrypoint-native-rebuild.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Static-assertion tests for the native-module rebuild loop in docker-entrypoint.sh.
+ *
+ * These tests assert structural properties of the shell script without running
+ * it, mirroring the convention from scripts/tests/audit-standards-parse-bash-array.test.ts.
+ *
+ * Assertions:
+ *   C1 — Scoped to the VALIDATION_FAILED guard region only; within that region:
+ *        (a) every NATIVE_MODULES entry is rebuilt with --ignore-scripts=false
+ *        (b) no `npm rebuild` appears without --ignore-scripts=false
+ *        (c) no `if [ "${module}" = ` carve-out remains
+ *   C2 — NATIVE_MODULES (bash array) equals the Dockerfile `RUN npm rebuild …` list
+ *   #5 — The verbose-hint line carries --ignore-scripts=false
+ *   L15 — The rebuild loop is nested inside the VALIDATION_FAILED -eq 1 guard
+ *
+ * SMI-5351: all four native modules must use --ignore-scripts=false in the
+ * rebuild loop; plain `npm rebuild` is a no-op under .npmrc ignore-scripts=true.
+ */
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { describe, expect, it, beforeAll } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// File resolution — locate from the test file's directory, then walk up to
+// the repo root (same pattern as sibling audit-standards-*.test.ts files
+// which use readFileSync with relative paths from process.cwd()).
+// ---------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// Repo root is two levels up from scripts/tests/
+const REPO_ROOT = resolve(__dirname, '..', '..')
+
+const ENTRYPOINT_PATH = resolve(REPO_ROOT, 'docker-entrypoint.sh')
+const DOCKERFILE_PATH = resolve(REPO_ROOT, 'Dockerfile')
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reuse the parseBashArray convention from audit-standards-helpers.mjs:
+ * parse a Bash array declaration `NAME=(\n  entry1\n  entry2\n)\n` and
+ * return the set of string entries (stripping quotes and inline comments).
+ *
+ * Returns null if the named array is not present in `src` or has no multiline
+ * body (e.g. inline empty `NAME=()`).
+ */
+function parseBashArray(src: string, arrayName: string): Set<string> | null {
+  // Match `NAME=( ... )` capturing the body between the parens. Handles BOTH
+  // single-line `NAME=("a" "b" "c")` (the form NATIVE_MODULES uses) and
+  // multi-line array declarations.
+  const re = new RegExp(`(?:^|\\n)[\\t ]*${arrayName}=\\(([\\s\\S]*?)\\)`)
+  const m = src.match(re)
+  if (!m) return null
+  // Strip full-line comments, then extract quoted strings and barewords.
+  const body = m[1].replace(/#.*$/gm, '')
+  const entries = new Set<string>()
+  for (const raw of body.match(/"[^"]*"|'[^']*'|[^\s()]+/g) ?? []) {
+    const tok = raw.replace(/^["']|["']$/g, '').trim()
+    if (/^[a-z0-9@][a-z0-9_./-]*$/i.test(tok)) entries.add(tok)
+  }
+  return entries.size > 0 ? entries : null
+}
+
+/**
+ * Parse the space-separated module list from the Dockerfile `RUN npm rebuild …`
+ * line. This is a DIFFERENT shape from a bash array — tokens are space-separated
+ * on a single line, terminated by `||` or end-of-line — so parseBashArray
+ * cannot be reused here (C2/L18).
+ *
+ * Matches: `RUN npm rebuild better-sqlite3 onnxruntime-node esbuild hnswlib-node || true`
+ * Returns a Set of the module token strings, or null if no such line is found.
+ */
+function parseDockerfileRebuildLine(src: string): Set<string> | null {
+  // Capture everything between `npm rebuild` and `||` or end-of-line
+  const m = src.match(/^RUN\s+npm\s+rebuild\s+([\w@/.-]+(?:\s+[\w@/.-]+)*)\s*(?:\|\|.*)?$/m)
+  if (!m) return null
+  const tokens = m[1]
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+  return new Set(tokens)
+}
+
+/**
+ * Extract the VALIDATION_FAILED -eq 1 guard region from docker-entrypoint.sh.
+ *
+ * The region is the text from the opening `if [ $VALIDATION_FAILED -eq 1 ]`
+ * line through its matching `fi` line (inclusive). We use a stateful bracket
+ * counter so nested if/fi pairs are handled correctly without ambiguity.
+ *
+ * Returns null if the guard is not found.
+ */
+function extractValidationFailedRegion(src: string): string | null {
+  const lines = src.split('\n')
+
+  let startIdx = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (/if\s+\[\s+\$VALIDATION_FAILED\s+-eq\s+1\s+\]/.test(lines[i])) {
+      startIdx = i
+      break
+    }
+  }
+  if (startIdx === -1) return null
+
+  // Walk forward, tracking if/fi nesting depth
+  let depth = 0
+  let endIdx = -1
+  for (let i = startIdx; i < lines.length; i++) {
+    const line = lines[i]
+    // Count `if` keywords (word-boundary match to avoid false positives)
+    if (/\bif\b/.test(line)) depth++
+    if (/\bfi\b/.test(line)) {
+      depth--
+      if (depth === 0) {
+        endIdx = i
+        break
+      }
+    }
+  }
+  if (endIdx === -1) return null
+
+  return lines.slice(startIdx, endIdx + 1).join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Load files once
+// ---------------------------------------------------------------------------
+
+let entrypointSrc: string
+let dockerfileSrc: string
+
+beforeAll(() => {
+  entrypointSrc = readFileSync(ENTRYPOINT_PATH, 'utf8')
+  dockerfileSrc = readFileSync(DOCKERFILE_PATH, 'utf8')
+})
+
+// ---------------------------------------------------------------------------
+// L15: The rebuild loop is nested inside the VALIDATION_FAILED -eq 1 guard
+// ---------------------------------------------------------------------------
+
+describe('L15: rebuild loop nesting', () => {
+  it('the VALIDATION_FAILED -eq 1 guard exists in docker-entrypoint.sh', () => {
+    expect(entrypointSrc).toMatch(/if\s+\[\s+\$VALIDATION_FAILED\s+-eq\s+1\s+\]/)
+  })
+
+  it('the rebuild loop (for module in "${NATIVE_MODULES[@]}") is inside the VALIDATION_FAILED guard', () => {
+    const region = extractValidationFailedRegion(entrypointSrc)
+    expect(region).not.toBeNull()
+    // The rebuild for loop must appear within the region
+    expect(region).toMatch(/for\s+module\s+in\s+"\$\{NATIVE_MODULES\[@\]\}"/)
+  })
+
+  it('npm rebuild calls do NOT appear outside the VALIDATION_FAILED guard', () => {
+    const region = extractValidationFailedRegion(entrypointSrc)
+    expect(region).not.toBeNull()
+
+    // Remove the region from the full file and verify no `npm rebuild` COMMAND
+    // remains. Pure-comment lines legitimately discuss `npm rebuild` (the header
+    // + the explanatory block above NATIVE_MODULES), so strip them first — only
+    // actual command lines count (same comment-skip rule as C1(b) below).
+    const regionText = region as string
+    const outsideCommands = entrypointSrc
+      .replace(regionText, '')
+      .split('\n')
+      .filter((l) => !/^\s*#/.test(l))
+      .join('\n')
+    expect(outsideCommands).not.toMatch(/\bnpm\s+rebuild\b/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// C1: Within the VALIDATION_FAILED guard, assert the rebuild loop properties
+// ---------------------------------------------------------------------------
+
+describe('C1: rebuild loop assertions (scoped to VALIDATION_FAILED region)', () => {
+  it('(a) every NATIVE_MODULES entry is rebuilt with --ignore-scripts=false', () => {
+    const region = extractValidationFailedRegion(entrypointSrc)
+    expect(region).not.toBeNull()
+
+    const nativeModules = parseBashArray(entrypointSrc, 'NATIVE_MODULES')
+    expect(nativeModules).not.toBeNull()
+    expect(nativeModules!.size).toBeGreaterThan(0)
+
+    // Every module that is in NATIVE_MODULES must appear in an
+    // `npm rebuild "${module}" --ignore-scripts=false` invocation within the region.
+    // Because the loop iterates over the array variable (not each module by name),
+    // we assert the canonical single rebuild command form is present.
+    expect(region).toMatch(/npm\s+rebuild\s+"\$\{module\}"\s+--ignore-scripts=false/)
+  })
+
+  it('(b) no `npm rebuild` appears in the region without --ignore-scripts=false', () => {
+    const region = extractValidationFailedRegion(entrypointSrc)
+    expect(region).not.toBeNull()
+
+    // Find all lines that contain `npm rebuild` in the region
+    const lines = region!.split('\n')
+    const rebuildLines = lines.filter((l) => /\bnpm\s+rebuild\b/.test(l))
+
+    // Every rebuild line must include --ignore-scripts=false
+    for (const line of rebuildLines) {
+      // Skip lines that are pure comments
+      const stripped = line.replace(/^\s*#.*$/, '').trim()
+      if (!stripped) continue
+      if (stripped.startsWith('#')) continue
+      // Any npm rebuild invocation must carry the flag
+      if (/\bnpm\s+rebuild\b/.test(stripped)) {
+        expect(
+          stripped,
+          `Line contains 'npm rebuild' without --ignore-scripts=false: ${stripped}`
+        ).toMatch(/--ignore-scripts=false/)
+      }
+    }
+  })
+
+  it('(c) no `if [ "${module}" = ` carve-out remains in the region', () => {
+    const region = extractValidationFailedRegion(entrypointSrc)
+    expect(region).not.toBeNull()
+    // The original hnswlib-node carve-out was `if [ "${module}" = "hnswlib-node" ]`
+    expect(region).not.toMatch(/if\s+\[\s+"\$\{module\}"\s+=\s+/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// C2: NATIVE_MODULES array equals Dockerfile `RUN npm rebuild …` list
+// ---------------------------------------------------------------------------
+
+describe('C2: NATIVE_MODULES sync with Dockerfile', () => {
+  it('NATIVE_MODULES is present and non-empty in docker-entrypoint.sh', () => {
+    const modules = parseBashArray(entrypointSrc, 'NATIVE_MODULES')
+    expect(modules).not.toBeNull()
+    expect(modules!.size).toBeGreaterThan(0)
+  })
+
+  it('Dockerfile contains a `RUN npm rebuild …` line that is parseable', () => {
+    const dockerModules = parseDockerfileRebuildLine(dockerfileSrc)
+    expect(dockerModules).not.toBeNull()
+    expect(dockerModules!.size).toBeGreaterThan(0)
+  })
+
+  it('NATIVE_MODULES entries equal the Dockerfile `RUN npm rebuild` modules (set equality)', () => {
+    const nativeModules = parseBashArray(entrypointSrc, 'NATIVE_MODULES')
+    const dockerModules = parseDockerfileRebuildLine(dockerfileSrc)
+
+    expect(nativeModules).not.toBeNull()
+    expect(dockerModules).not.toBeNull()
+
+    const nativeArr = [...nativeModules!].sort()
+    const dockerArr = [...dockerModules!].sort()
+
+    expect(
+      nativeArr,
+      `NATIVE_MODULES in entrypoint [${nativeArr.join(', ')}] must equal Dockerfile rebuild list [${dockerArr.join(', ')}]`
+    ).toEqual(dockerArr)
+  })
+
+  it('known modules (better-sqlite3, onnxruntime-node, esbuild, hnswlib-node) are present in both', () => {
+    const nativeModules = parseBashArray(entrypointSrc, 'NATIVE_MODULES')
+    const dockerModules = parseDockerfileRebuildLine(dockerfileSrc)
+
+    expect(nativeModules).not.toBeNull()
+    expect(dockerModules).not.toBeNull()
+
+    const expected = ['better-sqlite3', 'onnxruntime-node', 'esbuild', 'hnswlib-node']
+    for (const mod of expected) {
+      expect(nativeModules!.has(mod), `NATIVE_MODULES missing: ${mod}`).toBe(true)
+      expect(dockerModules!.has(mod), `Dockerfile rebuild list missing: ${mod}`).toBe(true)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #5: The verbose-hint line carries --ignore-scripts=false
+// ---------------------------------------------------------------------------
+
+describe('#5: verbose-hint contains --ignore-scripts=false', () => {
+  it('the failure-path verbose hint line includes --ignore-scripts=false', () => {
+    // The hint is the `docker exec … npm rebuild ${FAILED_MODULES}` line
+    // in the REBUILD_FAILED block. Find it and assert it carries the flag.
+    const lines = entrypointSrc.split('\n')
+    const hintLines = lines.filter(
+      (l) => /docker\s+exec/.test(l) && /npm\s+rebuild/.test(l) && /FAILED_MODULES/.test(l)
+    )
+
+    expect(
+      hintLines.length,
+      'Expected exactly one verbose-hint line (docker exec … npm rebuild ${FAILED_MODULES} …)'
+    ).toBeGreaterThan(0)
+
+    for (const hint of hintLines) {
+      expect(hint, `Verbose-hint line is missing --ignore-scripts=false:\n  ${hint}`).toMatch(
+        /--ignore-scripts=false/
+      )
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Parsers sanity-check (unit tests for the helpers above)
+// ---------------------------------------------------------------------------
+
+describe('parseBashArray (local helper)', () => {
+  it('parses double-quoted entries from a canonical multiline array', () => {
+    const src = `NATIVE_MODULES=(\n  "better-sqlite3"\n  "onnxruntime-node"\n)\n`
+    const result = parseBashArray(src, 'NATIVE_MODULES')
+    expect(result).not.toBeNull()
+    expect([...result!].sort()).toEqual(['better-sqlite3', 'onnxruntime-node'])
+  })
+
+  it('returns null when the array is missing', () => {
+    expect(parseBashArray('OTHER=(\n  foo\n)\n', 'NATIVE_MODULES')).toBeNull()
+  })
+
+  it('returns null for inline-empty array', () => {
+    expect(parseBashArray('NATIVE_MODULES=()\n', 'NATIVE_MODULES')).toBeNull()
+  })
+})
+
+describe('parseDockerfileRebuildLine (local helper)', () => {
+  it('parses a space-separated RUN npm rebuild line with || suffix', () => {
+    const src = `RUN npm rebuild better-sqlite3 onnxruntime-node esbuild hnswlib-node || true\n`
+    const result = parseDockerfileRebuildLine(src)
+    expect(result).not.toBeNull()
+    expect([...result!].sort()).toEqual([
+      'better-sqlite3',
+      'esbuild',
+      'hnswlib-node',
+      'onnxruntime-node',
+    ])
+  })
+
+  it('returns null when no RUN npm rebuild line is present', () => {
+    const src = `FROM node:22-slim\nRUN apt-get update\n`
+    expect(parseDockerfileRebuildLine(src)).toBeNull()
+  })
+
+  it('does not include the `|| true` token as a module name', () => {
+    const src = `RUN npm rebuild foo bar || true\n`
+    const result = parseDockerfileRebuildLine(src)
+    expect(result).not.toBeNull()
+    expect(result!.has('||')).toBe(false)
+    expect(result!.has('true')).toBe(false)
+    expect([...result!].sort()).toEqual(['bar', 'foo'])
+  })
+})


### PR DESCRIPTION
## What & why (SMI-5351, ADR-109 infra)

The `docker-entrypoint.sh` native-module rebuild loop passed `--ignore-scripts=false` only for `hnswlib-node`; `better-sqlite3` / `onnxruntime-node` / `esbuild` used plain `npm rebuild`, which is a **verified no-op under `.npmrc ignore-scripts=true`** (exits 0, leaves the binary byte-identical). So a `docker compose restart` could not repair 3 of 4 native modules after a host-arch binary leaked into the named `node_modules` volume (SMI-4698 class) — forcing a `docker volume rm` wipe or `--no-verify`.

## Changes
- **docker-entrypoint.sh**: rebuild every native module with `--ignore-scripts=false` (inside the `VALIDATION_FAILED` guard — healthy restarts pay nothing); fix the verbose recovery hint to carry the flag; offline-aware recovery (`curl --max-time 5` CDN probe) + per-module progress notice; comments use content anchors not line numbers.
- **scripts/tests/docker-entrypoint-native-rebuild.test.ts** (new, 17/17): static assertions — every module rebuilt with the flag, none without it, NATIVE_MODULES ↔ Dockerfile `npm rebuild` list set-equality, hint carries the flag, loop nested in the guard. Negative-checked: correctly fails against the old `origin/main` entrypoint.
- **CLAUDE.md** troubleshooting: cheap `docker compose restart` / per-module rebuild recovery; dropped the stale "#1365 until merged" note (merged 2026-05-26); honest that esbuild's binary loads lazily so a corrupt esbuild binary isn't auto-detected (→ SMI-5352).
- **docs/internal** pointer → ADR-109 plan + index reconcile (399→400).

## Process
- Plan: `docs/internal/implementation/2026-06-22-smi-5351-container-native-self-heal.md`. **Plan-reviewed (18 findings, all applied).**
- Cause-B leak investigated: a container `npm install` under `ignore-scripts=true` copies host darwin artifacts into the named volume (proof: `@esbuild/darwin-arm64` byte-identical in a linux-arm64 volume). The Wave-1 fix self-corrects on every restart → no further code; the residual esbuild **detection** gap is split to **SMI-5352**.
- Container restored live this session WITHOUT a volume wipe (`npm rebuild --ignore-scripts=false` on all 4 modules).

## Verification
- `bash -n` + `shellcheck` clean; new test 17/17, eslint/prettier clean, typecheck OK (ES2022/NodeNext).
- The full corrupt-binary-then-`docker compose restart` container cycle is the documented reviewer/CI gate (skipped locally to avoid re-corrupting the shared dev container used by a parallel session).

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)


[skip-impl-check] — infra change: shell entrypoint + static test + docs; no packages/*/src.
