### PR TITLE
test(vscode): create-skill happy-path E2E + CLI shim (SMI-5347)

### DIFF
--- a/.github/workflows/vscode-e2e.yml
+++ b/.github/workflows/vscode-e2e.yml
@@ -133,6 +133,17 @@ jobs:
           path: packages/vscode-extension/.wdio-vscode-service
           key: wdio-vscode-${{ runner.os }}-${{ env.VSCODE_E2E_VERSION }}
 
+      # SMI-5347: the create-skill spec shells out to a `skillsmith` binary
+      # (createSkill.helpers.ts). Put the deterministic e2e shim on PATH so the
+      # extension host resolves it. $GITHUB_PATH is shell-level and propagates to
+      # every later step's process tree (npm -> wdio -> VS Code extension host),
+      # which is the reliable way to make crossSpawn('skillsmith', ...) resolve.
+      # full job only; the per-PR smoke specs do not exercise create.
+      - name: Provision skillsmith CLI shim on PATH
+        run: |
+          chmod +x packages/vscode-extension/e2e/bin/skillsmith
+          echo "${{ github.workspace }}/packages/vscode-extension/e2e/bin" >> "$GITHUB_PATH"
+
       # test:e2e runs test:e2e:setup itself, then wdio against the full glob.
       - name: Run E2E full suite (headless)
         working-directory: packages/vscode-extension

--- a/packages/vscode-extension/e2e/bin/skillsmith
+++ b/packages/vscode-extension/e2e/bin/skillsmith
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Deterministic `skillsmith` CLI shim for the VS Code E2E suite (SMI-5347).
+ *
+ * The real `@skillsmith/cli create` still interactively prompts for `category`
+ * and `behavior` when those flags are absent — and the extension's
+ * `buildCreateArgs` never passes them — so the real CLI would hang headless.
+ * This shim implements the minimum contract the create + Next-steps flow needs,
+ * deterministically and without building the CLI dependency chain. It is a TEST
+ * FIXTURE under e2e/, not shipped code; CI puts e2e/bin on PATH for the nightly
+ * `full` job only (see .github/workflows/vscode-e2e.yml).
+ *
+ * CommonJS (require, not import): the nearest package.json
+ * (packages/vscode-extension/package.json) has no top-level "type", so Node
+ * scopes this extension-less file to CommonJS regardless of the ESM root.
+ *
+ * Contract (driven by createSkill.helpers.ts):
+ *   - `--version` / `-v`      -> print a version line, exit 0 (ensureCliAvailable)
+ *   - `create <name> [flags]` -> scaffold ~/.claude/skills/<name>/ (SKILL.md +
+ *                                README/CHANGELOG/.gitignore + resources/), exit 0
+ *   - `validate`              -> print OK, exit 0 (the "Run skillsmith validate" row)
+ *   - anything else           -> exit 0
+ *
+ * Mirrors the real CLI's default install path (core getCanonicalInstallPath:
+ * ~/.claude/skills) so the extension's targetDirFor(name) and the scaffold agree.
+ */
+'use strict'
+
+const { mkdirSync, writeFileSync } = require('node:fs')
+const { homedir } = require('node:os')
+const { join } = require('node:path')
+
+const VERSION = '0.0.0-e2e-shim'
+const argv = process.argv.slice(2)
+
+function flagValue(names) {
+  for (let i = 0; i < argv.length; i += 1) {
+    if (names.includes(argv[i])) {
+      return argv[i + 1]
+    }
+  }
+  return undefined
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`)
+  process.exit(1)
+}
+
+if (argv.includes('--version') || argv.includes('-v')) {
+  process.stdout.write(`${VERSION}\n`)
+  process.exit(0)
+}
+
+const command = argv[0]
+
+if (command === 'validate') {
+  // The Next-steps "Run skillsmith validate" row invokes this; always succeed.
+  process.stdout.write('skillsmith validate (e2e shim): OK\n')
+  process.exit(0)
+}
+
+if (command === 'create') {
+  // First positional after `create` is the skill name (flags start with `-`).
+  const name = argv.slice(1).find((a) => !a.startsWith('-'))
+  if (!name) {
+    fail('e2e shim: create requires a <name>')
+  }
+  // Refuse path separators / leading dot so a name can never escape the target
+  // dir (defence-in-depth; the spec always passes a plain kebab-case literal).
+  if (/[/\\]/.test(name) || name.startsWith('.')) {
+    fail('e2e shim: skill name must be a plain identifier (no path separators or leading dot)')
+  }
+  const author = flagValue(['-a', '--author']) || 'e2e'
+  const description = flagValue(['-d', '--description']) || 'created by the e2e shim'
+  const type = flagValue(['--type', '-t']) || 'basic'
+  const baseDir = flagValue(['-o', '--output']) || join(homedir(), '.claude', 'skills')
+  const dir = join(baseDir, name)
+
+  mkdirSync(join(dir, 'resources'), { recursive: true })
+  writeFileSync(
+    join(dir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${description}\nauthor: ${author}\ntype: ${type}\n---\n\n# ${name}\n\nScaffolded by the e2e shim. Add your skill instructions and triggers here.\n`
+  )
+  writeFileSync(join(dir, 'README.md'), `# ${name}\n\n${description}\n`)
+  writeFileSync(join(dir, 'CHANGELOG.md'), '# Changelog\n\n## 0.1.0\n\n- Initial scaffold.\n')
+  writeFileSync(join(dir, '.gitignore'), 'node_modules/\n')
+
+  process.stdout.write(`Created skill "${name}" at ${dir}\n`)
+  process.exit(0)
+}
+
+// Unknown command: succeed quietly so the shim never blocks the suite.
+process.exit(0)

--- a/packages/vscode-extension/e2e/pageobjects/create-skill.page.ts
+++ b/packages/vscode-extension/e2e/pageobjects/create-skill.page.ts
@@ -1,0 +1,77 @@
+/**
+ * Page object for the Create Skill webview wizard (SMI-5347 / SMI-5313).
+ *
+ * Encapsulates opening the wizard, entering its webview iframe, filling the
+ * four-field form, submitting, and returning the wdio context to the top frame.
+ *
+ * The success path (`CreateSkillPanel._handleSubmit`) runs the `skillsmith`
+ * CLI, then `dispose()`s the panel (tearing down the iframe) and finally calls
+ * `treeProvider.showNextSteps(name, targetDir)`. Because the panel auto-disposes,
+ * we exit the iframe via `browser.switchToFrame(null)` (reset to the top-level
+ * browsing context) rather than `webview.close()`, which would operate on the
+ * now-detached iframe.
+ */
+import { browser, $ } from '@wdio/globals'
+import { type WebView } from 'wdio-vscode-service'
+
+/** Panel title set by CreateSkillPanel (`createWebviewPanel(..., 'Create Skill', ...)`). */
+const PANEL_TITLE = 'Create Skill'
+
+export interface CreateFormInput {
+  author: string
+  name: string
+  description: string
+  type: 'basic' | 'intermediate' | 'advanced'
+}
+
+export class CreateSkillPage {
+  /**
+   * Open the Create Skill wizard and switch the wdio context INTO its webview
+   * iframe. Retries the command until the panel appears; re-invoking
+   * `skillsmith.createSkill` while the panel is already open just reveals it
+   * (no second CLI check — CreateSkillPanel singleton), so the retry is safe.
+   */
+  async openCreatePanel(): Promise<void> {
+    const workbench = await browser.getWorkbench()
+    const webview = (await browser.waitUntil(
+      async () => {
+        await browser.executeWorkbench((vscode) =>
+          vscode.commands.executeCommand('skillsmith.createSkill')
+        )
+        try {
+          return await workbench.getWebviewByTitle(PANEL_TITLE)
+        } catch {
+          return false
+        }
+      },
+      {
+        timeout: 40_000,
+        interval: 3_000,
+        timeoutMsg: `create panel "${PANEL_TITLE}" did not open`,
+      }
+    )) as WebView
+    await webview.open()
+  }
+
+  /**
+   * Inside the iframe: fill the four fields, submit, then reset to the top
+   * frame. Must be called after `openCreatePanel()` (which leaves the wdio
+   * context inside the iframe). The name is a valid kebab-case slug, so host-side
+   * validation passes and no `submitError` is posted.
+   */
+  async fillAndSubmit(fields: CreateFormInput): Promise<void> {
+    await (await $('#author')).setValue(fields.author)
+    await (await $('#name')).setValue(fields.name)
+    await (await $('#description')).setValue(fields.description)
+    await (await $(`input[name="type"][value="${fields.type}"]`)).click()
+
+    const submit = await $('#createBtn')
+    await submit.waitForClickable({ timeout: 15_000 })
+    await submit.click()
+
+    // The success path disposes the panel (iframe detaches) before the next
+    // assertion reads the tree, so reset to the top-level browsing context.
+    // switchToFrame(null) is safe whether or not the iframe still exists.
+    await browser.switchToFrame(null)
+  }
+}

--- a/packages/vscode-extension/e2e/specs/create.e2e.ts
+++ b/packages/vscode-extension/e2e/specs/create.e2e.ts
@@ -1,0 +1,126 @@
+/**
+ * Create-skill happy-path E2E spec (SMI-5347).
+ *
+ * Exercises the create flow end-to-end: open the Create Skill wizard → fill +
+ * submit → the `skillsmith` CLI scaffolds the skill → the panel disposes and
+ * the SMI-5346 "Next steps" sidebar section renders with its checklist rows →
+ * dismiss hides it.
+ *
+ * The create flow shells out to a real `skillsmith` binary (`createSkill.helpers`
+ * `ensureCliAvailable`/`runCli`) and is pure-CLI — no MCP. CI provisions a
+ * deterministic `skillsmith` shim (`e2e/bin/skillsmith`) on PATH for the nightly
+ * `full` job; the shim writes to `~/.claude/skills/<name>` (matching the
+ * extension's hardcoded `targetDirFor`, which ignores `skillsmith.skillsDirectory`).
+ * The new skill therefore does NOT appear in the Installed-Skills group (which
+ * scans the fixture dir) — so this spec asserts on the Next-steps group, which
+ * `showNextSteps(name, targetDir)` renders independently of the skills dir.
+ *
+ * This spec runs in the nightly `full` tier only (it is not in the per-PR smoke
+ * `--spec` list).
+ */
+import { execFileSync } from 'node:child_process'
+import { rmSync } from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import { browser, expect } from '@wdio/globals'
+import { CreateSkillPage } from '../pageobjects/create-skill.page.js'
+import { SkillsTreePage } from '../pageobjects/skills-tree.page.js'
+
+const TEST_SKILL_NAME = 'e2e-create-skill'
+const TARGET_DIR = path.join(homedir(), '.claude', 'skills', TEST_SKILL_NAME)
+
+/** True when a `skillsmith` executable resolves on PATH and exits 0 on `--version`. */
+function skillsmithOnPath(): boolean {
+  try {
+    execFileSync('skillsmith', ['--version'], { stdio: 'ignore', timeout: 5_000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('Create skill — happy path + Next-steps (SMI-5347)', () => {
+  const createPage = new CreateSkillPage()
+  const treePage = new SkillsTreePage()
+
+  before(function () {
+    // The skip-guard runs BEFORE any openCreatePanel(): if `skillsmith` is not
+    // on PATH, ensureCliAvailable() shows an un-drivable {modal:true} dialog
+    // (hangs the wdio bridge headless). CI puts the e2e/bin shim on PATH for the
+    // `full` job; local runs without the shim skip cleanly here instead of
+    // hanging.
+    if (!skillsmithOnPath()) {
+      this.skip()
+    }
+    // Remove any prior scaffold so the overwrite-confirm {modal:true} (the only
+    // modal reachable in the success path) never fires for a fresh create.
+    rmSync(TARGET_DIR, { recursive: true, force: true })
+  })
+
+  after(() => {
+    rmSync(TARGET_DIR, { recursive: true, force: true })
+  })
+
+  it('creates a skill via the wizard and renders the Next-steps checklist', async () => {
+    await createPage.openCreatePanel()
+    await createPage.fillAndSubmit({
+      author: 'e2e',
+      name: TEST_SKILL_NAME,
+      description: 'created by e2e',
+      type: 'basic',
+    })
+
+    // Success-path ordering (CreateSkillPanel._handleSubmit): runCli →
+    // refreshAndWait() (re-renders the tree WITHOUT the group) → dispose() →
+    // showNextSteps() (re-renders WITH the group). So the group appears only
+    // after the CLI round-trip; poll until both the group header and the
+    // validate row are visible. The group is created Expanded, so its child rows
+    // are returned by the section's flattened getVisibleItems().
+    let labels: string[] = []
+    await browser.waitUntil(
+      async () => {
+        labels = await treePage.getVisibleTreeLabels()
+        return (
+          labels.includes('Next steps') && labels.some((l) => l.includes('Run skillsmith validate'))
+        )
+      },
+      {
+        timeout: 30_000,
+        interval: 1_500,
+        timeoutMsg:
+          'Next-steps group + "Run skillsmith validate" row did not appear within 30s.\n' +
+          `Last observed labels: [${labels.map((l) => `"${l}"`).join(', ')}]`,
+      }
+    )
+
+    expect(labels.includes('Next steps')).toBe(true)
+    expect(labels.some((l) => l.includes('Run skillsmith validate'))).toBe(true)
+  })
+
+  it('dismiss hides the Next-steps section', async () => {
+    await browser.executeWorkbench((vscode) =>
+      vscode.commands.executeCommand('skillsmith.dismissNextSteps')
+    )
+    // Refresh to force a re-render; the dismissed flag (globalState) survives it.
+    await browser.executeWorkbench((vscode) =>
+      vscode.commands.executeCommand('skillsmith.refreshSkills')
+    )
+
+    let labels: string[] = []
+    await browser.waitUntil(
+      async () => {
+        labels = await treePage.getVisibleTreeLabels()
+        return !labels.includes('Next steps')
+      },
+      {
+        timeout: 15_000,
+        interval: 1_500,
+        timeoutMsg:
+          'Next-steps group still visible 15s after dismiss.\n' +
+          `Last observed labels: [${labels.map((l) => `"${l}"`).join(', ')}]`,
+      }
+    )
+
+    expect(labels.includes('Next steps')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

The SMI-5346 post-create **"Next steps"** sidebar section shipped with unit coverage only; the create flow was dropped from SMI-5339 Phase 2b because it shells out to a real `skillsmith` binary (not on PATH in CI) and the CLI-missing path shows an un-drivable `{modal:true}` dialog.

This adds the **happy-path E2E** (nightly `full` tier only):

- **`e2e/bin/skillsmith`** — a deterministic CommonJS shim. The real `skillsmith create` still interactively prompts for `category`/`behavior` (the extension never passes those flags), so it would hang headless. The shim handles `--version`, `create <name> … -y` (scaffolds `SKILL.md` + README/CHANGELOG/.gitignore at `~/.claude/skills/<name>`, matching the extension's hardcoded `targetDirFor`), and `validate`. Name guard rejects path separators.
- **`e2e/pageobjects/create-skill.page.ts`** — drives the `'Create Skill'` webview (`#author`/`#name`/`#description`/`input[name=type]`/`#createBtn`); exits the iframe via `switchToFrame(null)` because the success path disposes the panel.
- **`e2e/specs/create.e2e.ts`** — open wizard → submit → assert the **Next-steps** group + **"Run skillsmith validate"** row render; then dismiss hides it. A `before()` skip-guard (`skillsmith --version`) keeps local runs without the shim from hanging on the modal. Asserts on Next-steps (not Installed) because the create writes to `~/.claude/skills`, not the fixture `skillsDirectory`.
- **`vscode-e2e.yml` `full` job** — puts `e2e/bin` on PATH via `$GITHUB_PATH` (shell-level, propagates to the `npm → wdio → extension-host` tree). **Smoke job untouched** (new spec auto-joins the full glob only).

## Scope

**Happy-path only** (user decision): the CLI-missing modal stays unit-covered (un-drivable headless, SMI-5325/5339).

## Validation

- Local: `typecheck` + `typecheck:e2e` (both SMI-5348 gate steps run on this PR since it touches `packages/vscode-extension`) exit 0; `format:check` + `audit:standards` + `actionlint` clean; shim functionally tested.
- **Real VS Code**: the `full` E2E job is **dispatched on this branch** (run [28003082508](https://github.com/smith-horn/skillsmith/actions/runs/28003082508)) to validate the create spec on a real Extension Development Host before merge — the per-PR smoke does not run new specs.

Plan + plan-review (B2 iframe teardown, C1 prettier, B1 timeout bench-rejected) + governance fixes (shim path-traversal guard, `execFileSync` timeout): `docs/internal/implementation/2026-06-22-vscode-create-happy-path-e2e-smi-5347.md` (docs PR + pointer bump follow).

ADR-109: SPARC recon + plan-review completed before implementation.

Closes SMI-5347.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)