### PR TITLE
fix(eval-cron): run retrieval-eval in an isolated checkout, never the dev's live tree (SMI-5353)

### DIFF
--- a/.claude/development/eval-cron-setup.md
+++ b/.claude/development/eval-cron-setup.md
@@ -6,7 +6,9 @@ Plan: [docs/internal/implementation/smi-4764-eval-baseline-automation.md](../../
 
 ## What this does
 
-A weekly local cron that runs `RETRIEVAL_EVAL_REAL=1` against `docs/internal` + the memory adapter, opens an auto-PR if `baseline.json` drifts, and writes a heartbeat row to `packages/doc-retrieval-mcp/eval/.cron-heartbeat`. The heartbeat is read by `audit:standards` (check 44, advisory) — stale heartbeat (>14 days) emits a warning prompting the replacement protocol.
+A weekly local cron that runs `RETRIEVAL_EVAL_REAL=1` against the corpus (`docs/internal` + `.claude/skills` + the memory adapter), opens an auto-PR if `baseline.json` drifts, and writes a heartbeat row to `packages/doc-retrieval-mcp/eval/.cron-heartbeat`. The heartbeat is read by `audit:standards` (check 44, advisory) — stale heartbeat (>14 days) emits a warning prompting the replacement protocol.
+
+**SMI-5353 — runs in an isolated checkout, never your live tree.** The eval runs against a dedicated clone at `~/.skillsmith/eval-checkout`, pinned to `origin/main`, inside its own ephemeral container (`skillsmith-eval-cron-1`). Your primary working tree and `skillsmith-dev-1` container are never reset, stashed, or guarded. After each run the heartbeat is **copied back** into your primary tree so `audit:standards` Check 44 stays fresh. This replaced the old design that ran in your live tree and refused (silently skipping the weekly run) whenever you had uncommitted `docs/internal` / `.claude/skills` work — which was effectively always.
 
 ## Why local, not CI
 
@@ -15,10 +17,27 @@ A weekly local cron that runs `RETRIEVAL_EVAL_REAL=1` against `docs/internal` + 
 ## Prerequisites
 
 - Repo cloned at a stable path (cron resolves it from the LaunchAgent / systemd unit)
-- Docker Desktop running with `skillsmith-dev-1` reachable
+- Docker Desktop running (the cron brings up its own `skillsmith-eval-cron-1` container; the daemon must be reachable)
 - `gh` CLI authenticated with PR-create permissions
 - `varlock` set up if the dev container needs env injection
-- `git submodule update --init docs/internal` succeeds (you have access to the private docs submodule)
+- Private-submodule access: `git submodule update --init docs/internal .claude/skills` succeeds (the eval corpus reads both)
+- `SKILLSMITH_PROJECT_DIR_ENCODED` exported in the cron's environment (login shell / launchd `EnvironmentVariables` / systemd unit) so the eval container's `/skillsmith-memory` bind-mount resolves — the cron refuses to run a memory-less corpus
+- **≥ 3 GB free** at `$HOME` (isolated clone ~100 MB + `node_modules` ~500 MB + `.ruvector` ~200 MB)
+
+### One-time isolated-checkout setup (SMI-5353)
+
+Before first run (and on any replacement hand-off), create the dedicated clone the cron runs in. Do this **after** the SMI-5353 change is on `origin/main` (the clone needs `docker-compose.eval-cron.yml`):
+
+```bash
+git clone https://github.com/smith-horn/skillsmith.git ~/.skillsmith/eval-checkout
+cd ~/.skillsmith/eval-checkout
+git submodule update --init --force docs/internal .claude/skills   # private — needs your creds
+# Validate the wiring without running the ~1h40m eval:
+cd /path/to/your/primary/repo
+./scripts/eval-baseline-cron.sh --dry-run
+```
+
+The cron auto-clones on first run if the directory is absent, but doing it manually lets you confirm submodule access + disk up front. `--dry-run` validates: clone present, `origin/main` reachable, submodules initialized, the eval container starts, `tsx` resolves, `/skillsmith-memory` is populated, and the two heartbeat paths are distinct. It does **not** run the eval or exercise copy-back.
 
 ## macOS setup (primary)
 
@@ -36,7 +55,7 @@ launchctl load   ~/Library/LaunchAgents/app.skillsmith.eval-baseline-cron.plist
 launchctl list | grep skillsmith
 mkdir -p ~/.skillsmith/logs    # for first-run log path
 
-# 4. Optional: dry-run the script to confirm guards pass
+# 4. Optional: dry-run the script to confirm the isolated checkout is wired (SMI-5353)
 ./scripts/eval-baseline-cron.sh --dry-run
 
 # 5. Optional: trigger manually for first-run smoke
@@ -65,22 +84,26 @@ systemctl --user list-timers | grep skillsmith
 journalctl --user -u skillsmith-eval-baseline-cron --since '1 day ago'
 ```
 
-## Heartbeat lifecycle
+## Heartbeat lifecycle (SMI-5353)
 
-The cron always writes a heartbeat row to `packages/doc-retrieval-mcp/eval/.cron-heartbeat`:
+The cron writes a heartbeat row in the **isolated clone**, then **copies it back** into your primary tree at `packages/doc-retrieval-mcp/eval/.cron-heartbeat`:
 
 ```text
-<ISO-timestamp>\t<git-HEAD-sha>\tOK
+<ISO-timestamp>\t<git-HEAD-sha>\t<OK|FAIL|WARN-PARTIAL>
 ```
 
-(Failed runs write `FAIL` instead of `OK`.)
+- `OK` — eval succeeded, full corpus.
+- `FAIL` — the eval errored (or copy-back failed; the copy-back failure path forces `FAIL` so the signal can't go silently stale).
+- `WARN-PARTIAL` — `.claude/skills` couldn't be pinned (e.g. expired PAT); the eval still ran against `docs/internal` + memory, but the corpus was partial.
 
-| Cron run outcome | What gets committed | When |
+`audit:standards` Check 44 reads the **working-tree** copy in your primary tree, so the copy-back is the entire local freshness mechanism. **There is no manual weekly push** — the old "no-drift weeks need a manual heartbeat-only commit" step (and its forgotten-push failure mode) is gone.
+
+| Cron run outcome | What lands in your primary tree | What gets committed to `main` |
 |---|---|---|
-| Drift detected | `baseline.json` + `.cron-heartbeat` together via auto-PR | Automatic (cron opens PR with `eval-baseline-cron` label) |
-| No drift | `.cron-heartbeat` only | **Manual** — canonical dev pushes a heartbeat-only commit weekly |
+| Drift detected | Fresh heartbeat (copy-back) | `baseline.json` + `.cron-heartbeat` via auto-PR (`eval-baseline-cron` label), opened from the clone |
+| No drift | Fresh heartbeat (copy-back) | Nothing — copy-back alone keeps Check 44 fresh |
 
-**Why manual heartbeat-only push**: the cron deliberately does NOT auto-commit when there's no drift, to avoid spamming `main` with no-op commits. Canonical dev's weekly hygiene includes a `git add packages/doc-retrieval-mcp/eval/.cron-heartbeat && git commit -m 'chore(eval): cron heartbeat'` push when no drift PR fires. Forgetting this surfaces as the >14d audit warning.
+The copied-back heartbeat sits **untracked** in your primary tree; that's expected and harmless (Check 44 reads the working-tree file, and the cron no longer runs in your tree so it can't be tripped by it).
 
 ## Replacement protocol
 
@@ -88,10 +111,10 @@ If the canonical dev becomes unavailable for >2 weeks:
 
 1. **Verify staleness**: `audit:standards` warning will be live. Manually inspect `.cron-heartbeat` last timestamp.
 2. **Designate replacement**: file a Linear issue under SMI-4764 (or a successor parent). Tag `area:eval-baseline`. The replacement dev:
-   - Has access to `docs/internal` submodule (private)
+   - Has access to the `docs/internal` + `.claude/skills` submodules (private)
    - Has Docker + `gh` set up
-   - Commits to running the cron + manual weekly heartbeat-only pushes
-3. **Hand off the canonical role**: the new dev installs the cron locally per the macOS / Linux setup above. The old dev disables their cron:
+   - Commits to running the cron (no manual weekly push — the cron copies the heartbeat back automatically; SMI-5353)
+3. **Hand off the canonical role**: the new dev performs the **one-time isolated-checkout setup** (see Prerequisites → "One-time isolated-checkout setup") and then installs the cron locally per the macOS / Linux setup above. The old dev disables their cron and tears down their isolated checkout:
 
    ```bash
    # macOS
@@ -99,6 +122,11 @@ If the canonical dev becomes unavailable for >2 weeks:
    rm ~/Library/LaunchAgents/app.skillsmith.eval-baseline-cron.plist
    # Linux
    systemctl --user disable --now skillsmith-eval-baseline-cron.timer
+   # Both: remove the isolated checkout + its container/volume (SMI-5353)
+   docker compose --project-name skillsmith-eval-cron \
+     -f ~/.skillsmith/eval-checkout/docker-compose.yml \
+     -f ~/.skillsmith/eval-checkout/docker-compose.eval-cron.yml down -v 2>/dev/null
+   rm -rf ~/.skillsmith/eval-checkout
    ```
 
 4. **Document the hand-off**: comment on SMI-4764 (or successor) noting the date and new canonical dev.
@@ -117,16 +145,27 @@ systemctl --user stop --now skillsmith-eval-baseline-cron.timer
 
 The `audit:standards` warning will fire after 14 days of pause — that's intentional, it's the exact signal the system is supposed to surface.
 
+If a run is **in progress** when you unload (SMI-5353), the ephemeral eval container keeps going until the run finishes. To kill it immediately:
+
+```bash
+docker compose --project-name skillsmith-eval-cron \
+  -f ~/.skillsmith/eval-checkout/docker-compose.yml \
+  -f ~/.skillsmith/eval-checkout/docker-compose.eval-cron.yml down
+```
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `cron must run from 'main' (current: '<branch>')` | Canonical dev left feature branch checked out at scheduled time | Switch to main before the next scheduled run, or expect to skip a week |
-| `cron requires clean working tree` | Uncommitted local edits | Commit / stash; cron will retry next week |
-| `Docker container 'skillsmith-dev-1' is not running` | Docker Desktop not launched at scheduled time | Start container; verify launch-agent / timer is set to fire when machine wakes |
-| `eval invocation failed with exit N` | Eval-runner errored (network, OOM, indexer state) | Inspect `~/.skillsmith/logs/eval-cron-<date>.log`; .cron-heartbeat will record `FAIL` so the audit can distinguish `not running` vs `running but failing` |
-| Auto-PR not opened despite drift | `gh` not authenticated, or branch already exists | Check `gh auth status`; remove stale `chore/eval-baseline-cron-<date>` branch with `git branch -D` + `git push --delete origin <branch>` |
-| `audit:standards` heartbeat stale warning despite cron running | Forgetting the manual heartbeat-only push when there's no drift | Run `git add packages/doc-retrieval-mcp/eval/.cron-heartbeat && git commit -m 'chore(eval): cron heartbeat' && git push` |
+| `Docker daemon not reachable` | Docker Desktop not launched at scheduled time | Start Docker; verify the launch-agent / timer is set to fire when the machine wakes |
+| `isolated clone missing at ~/.skillsmith/eval-checkout` (dry-run) | One-time setup not done, or the clone was deleted | Run the one-time isolated-checkout setup (see Prerequisites). A real (non-dry-run) run auto-clones |
+| `docs/internal not initialized in the clone (missing index.md sentinel)` / `docs/internal submodule update failed` | Lost private-submodule access (PAT/SSH) in the clone | Restore creds; `git -C ~/.skillsmith/eval-checkout submodule update --init --force docs/internal`. `docs/internal` is required — the cron aborts without it |
+| Heartbeat shows `WARN-PARTIAL` | `.claude/skills` submodule couldn't be pinned (e.g. expired PAT); eval ran on a partial corpus | Restore strategy-submodule access; next run pins it and returns to `OK`. Baseline from a `WARN-PARTIAL` run may differ slightly — don't treat its drift as authoritative |
+| Eval container fails to start (`up --wait` times out) | Stale `skillsmith-eval-cron-1` / image build / native-module health | `docker compose --project-name skillsmith-eval-cron -f ~/.skillsmith/eval-checkout/docker-compose.yml -f ~/.skillsmith/eval-checkout/docker-compose.eval-cron.yml down -v` then re-run; inspect `~/.skillsmith/logs/eval-cron-<date>.log` |
+| `/skillsmith-memory is empty in the eval container` | `SKILLSMITH_PROJECT_DIR_ENCODED` unset at `compose up` → empty memory bind-mount | Export `SKILLSMITH_PROJECT_DIR_ENCODED` in the cron's environment (login shell / launchd `EnvironmentVariables` / systemd unit) |
+| `heartbeat copy-back to the dev tree failed` | Primary-tree path not writable / disk full | Check disk + permissions on `<primary-repo>/packages/doc-retrieval-mcp/eval/`; the cron forces `FAIL` in this case so Check 44 reflects the gap |
+| `eval invocation failed with exit N` | Eval-runner errored (network, OOM, indexer state) | Inspect `~/.skillsmith/logs/eval-cron-<date>.log`; `.cron-heartbeat` records `FAIL` so the audit distinguishes `not running` vs `running but failing` |
+| Auto-PR not opened despite drift | `gh` not authenticated, or branch already exists | Check `gh auth status`; the branch suffix is now minute-resolution (`-YYYYMMDDTHHMM`) so same-day collisions are unlikely. Remove a stale `chore/eval-baseline-cron-*` branch with `git branch -D` + `git push --delete origin <branch>` |
 
 ## What this does NOT cover
 

--- a/.claude/development/eval-cron-setup.md
+++ b/.claude/development/eval-cron-setup.md
@@ -93,10 +93,12 @@ The cron writes a heartbeat row in the **isolated clone**, then **copies it back
 ```
 
 - `OK` — eval succeeded, full corpus.
-- `FAIL` — the eval errored (or copy-back failed; the copy-back failure path forces `FAIL` so the signal can't go silently stale).
+- `FAIL` — the eval errored.
 - `WARN-PARTIAL` — `.claude/skills` couldn't be pinned (e.g. expired PAT); the eval still ran against `docs/internal` + memory, but the corpus was partial.
 
-`audit:standards` Check 44 reads the **working-tree** copy in your primary tree, so the copy-back is the entire local freshness mechanism. **There is no manual weekly push** — the old "no-drift weeks need a manual heartbeat-only commit" step (and its forgotten-push failure mode) is gone.
+The cron writes the run's true status directly to **both** the clone's heartbeat and your primary tree's (no `cp` indirection), so the dev-tree file always carries the real status — never a silently-retained stale line. `audit:standards` Check 44 reads the **working-tree** copy in your primary tree, so this write-back is the entire local freshness mechanism. **There is no manual weekly push** — the old "no-drift weeks need a manual heartbeat-only commit" step (and its forgotten-push failure mode) is gone.
+
+If the dev-tree write itself fails (path not writable / disk full), the cron logs an `ERROR` to `~/.skillsmith/logs/eval-cron-<date>.log`; Check 44 then keeps reading the prior line and won't flag the run until the normal 14-day staleness window expires. The log is the authoritative signal in that (rare) case.
 
 | Cron run outcome | What lands in your primary tree | What gets committed to `main` |
 |---|---|---|
@@ -163,7 +165,7 @@ docker compose --project-name skillsmith-eval-cron \
 | Heartbeat shows `WARN-PARTIAL` | `.claude/skills` submodule couldn't be pinned (e.g. expired PAT); eval ran on a partial corpus | Restore strategy-submodule access; next run pins it and returns to `OK`. Baseline from a `WARN-PARTIAL` run may differ slightly — don't treat its drift as authoritative |
 | Eval container fails to start (`up --wait` times out) | Stale `skillsmith-eval-cron-1` / image build / native-module health | `docker compose --project-name skillsmith-eval-cron -f ~/.skillsmith/eval-checkout/docker-compose.yml -f ~/.skillsmith/eval-checkout/docker-compose.eval-cron.yml down -v` then re-run; inspect `~/.skillsmith/logs/eval-cron-<date>.log` |
 | `/skillsmith-memory is empty in the eval container` | `SKILLSMITH_PROJECT_DIR_ENCODED` unset at `compose up` → empty memory bind-mount | Export `SKILLSMITH_PROJECT_DIR_ENCODED` in the cron's environment (login shell / launchd `EnvironmentVariables` / systemd unit) |
-| `heartbeat copy-back to the dev tree failed` | Primary-tree path not writable / disk full | Check disk + permissions on `<primary-repo>/packages/doc-retrieval-mcp/eval/`; the cron forces `FAIL` in this case so Check 44 reflects the gap |
+| `could not write heartbeat to the dev tree` | Primary-tree path not writable / disk full | Check disk + permissions on `<primary-repo>/packages/doc-retrieval-mcp/eval/`. Check 44 keeps reading the prior line until the 14-day window expires; the log line is the authoritative signal for that run |
 | `eval invocation failed with exit N` | Eval-runner errored (network, OOM, indexer state) | Inspect `~/.skillsmith/logs/eval-cron-<date>.log`; `.cron-heartbeat` records `FAIL` so the audit distinguishes `not running` vs `running but failing` |
 | Auto-PR not opened despite drift | `gh` not authenticated, or branch already exists | Check `gh auth status`; the branch suffix is now minute-resolution (`-YYYYMMDDTHHMM`) so same-day collisions are unlikely. Remove a stale `chore/eval-baseline-cron-*` branch with `git branch -D` + `git push --delete origin <branch>` |
 

--- a/docker-compose.eval-cron.yml
+++ b/docker-compose.eval-cron.yml
@@ -1,0 +1,35 @@
+# docker-compose.eval-cron.yml — SMI-5353
+#
+# Override layer for the retrieval-eval cron's ISOLATED container. Used ONLY by
+# scripts/eval-baseline-cron.sh against the ~/.skillsmith/eval-checkout clone —
+# never by the dev's normal `docker compose --profile dev up`.
+#
+# Why this exists: docker-compose.yml hardcodes `container_name: skillsmith-dev-1`
+# and publishes host port 3001. A second container (for the eval clone) would
+# collide on BOTH. This override renames the container and DROPS the host port
+# entirely (the eval is driven via `docker exec`, so it needs no published port).
+#
+# `ports: !reset []` — Compose merges sequences by APPENDING, so a plain
+# `ports:` override would keep the base 3001 mapping and still collide. The
+# `!reset` tag (Compose Spec >= 2.24; bundled docker compose is far newer)
+# clears the inherited list instead. Verified: the merged config has no
+# published ports.
+#
+# NOT auto-loaded: Compose only auto-merges `docker-compose.override.yml`. This
+# file must be passed explicitly via `-f docker-compose.yml -f docker-compose.eval-cron.yml`
+# (the cron does this), so it is inert for every other workflow.
+#
+# Volume scoping: the cron runs Compose with `--project-name skillsmith-eval-cron`,
+# so the `node_modules` named volume resolves to `skillsmith-eval-cron_node_modules`
+# — distinct from the dev's `skillsmith_node_modules`. Tear down with `down`
+# (NOT `down -v`) to preserve that volume across weekly runs.
+services:
+  dev:
+    container_name: skillsmith-eval-cron-1
+    # Ephemeral: the cron brings this up for the run and tears it down on EXIT.
+    # Must NOT auto-restart like the canonical dev container (base sets
+    # `restart: unless-stopped`).
+    restart: 'no'
+    # Drop the inherited 3001 host-port mapping — eval is exec-driven, no port
+    # needed, and keeping 3001 would collide with the canonical dev container.
+    ports: !reset []

--- a/scripts/eval-baseline-cron.sh
+++ b/scripts/eval-baseline-cron.sh
@@ -89,6 +89,16 @@ log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG_FILE" >&2
 }
 
+# Portable SHA-256: macOS ships `shasum`; most Linux distros ship `sha256sum`
+# and may NOT ship `shasum` (it's a separate Perl package). Prefer sha256sum.
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
 # `docker compose` wrapper: dedicated project + base file + eval override.
 compose() {
   docker compose --project-name "$EVAL_PROJECT" \
@@ -97,9 +107,18 @@ compose() {
     "$@"
 }
 
+# Regenerate the index fresh each run — wipe the clone's .ruvector. Defined here
+# (before any early-exit point) so the EXIT trap can call it even when the script
+# aborts before reaching the eval. Idempotent + safe if the clone is absent.
+# shellcheck disable=SC2329  # invoked indirectly via teardown / trap
+cleanup_index() {
+  rm -rf "$EVAL_CLONE/.ruvector" 2>/dev/null || true
+}
+
 # EXIT trap: always tear the ephemeral eval container down (NOT `down -v` — keep
-# the project-scoped node_modules volume warm for next week). Preserves the
-# triggering exit code.
+# the project-scoped node_modules volume warm for next week) AND wipe the clone's
+# index (so a failed/aborted run can't leave a stale index for next week).
+# Preserves the triggering exit code.
 # shellcheck disable=SC2329  # invoked indirectly via `trap teardown EXIT`
 teardown() {
   local code=$?
@@ -107,6 +126,7 @@ teardown() {
     log "Tearing down eval container (${EVAL_CONTAINER})..."
     compose down >>"$LOG_FILE" 2>&1 || log "WARNING: eval container teardown failed — inspect 'docker ps'."
   fi
+  cleanup_index
   exit "$code"
 }
 trap teardown EXIT
@@ -204,8 +224,11 @@ fi
 # ---------------------------------------------------------------------------
 
 log "Bringing up eval container (${EVAL_CONTAINER}) on project ${EVAL_PROJECT}..."
-compose --profile dev up -d --wait --wait-timeout 300 >>"$LOG_FILE" 2>&1
+# Mark up BEFORE the call: a timed-out/failed `up` aborts under set -e, and a
+# half-created container must still be torn down by the EXIT trap — otherwise it
+# orphans and the next run collides on container_name (governance High).
 CONTAINER_UP=1
+compose --profile dev up -d --wait --wait-timeout 300 >>"$LOG_FILE" 2>&1
 
 # Install deps (always — guarantees tsx + runtime deps; ~30-60s warm). M7.
 log "Installing dependencies in the eval container (npm ci)..."
@@ -242,7 +265,7 @@ fi
 # Capture baseline.json hash before the eval (drift detection)
 # ---------------------------------------------------------------------------
 
-PRE_HASH="$(shasum -a 256 "$BASELINE_FILE" | awk '{print $1}')"
+PRE_HASH="$(sha256_file "$BASELINE_FILE")"
 log "Pre-eval baseline.json sha256: $PRE_HASH"
 
 # ---------------------------------------------------------------------------
@@ -263,20 +286,18 @@ docker exec -w /app "$EVAL_CONTAINER" sh -c \
 # Status: FAIL (eval errored) | WARN-PARTIAL (.claude/skills not pinned) | OK.
 
 write_heartbeat() {
-  local status="$1"
-  printf '%s\t%s\t%s\n' \
+  local status="$1" line
+  # Write the SAME real status directly to BOTH files (no `cp` — the dev-tree
+  # write must carry the run's true status, not silently keep a stale prior line
+  # if a copy fails). Check 44 reads the dev-tree file.
+  line="$(printf '%s\t%s\t%s' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     "$(git -C "$EVAL_CLONE" rev-parse HEAD)" \
-    "$status" \
-    > "$ISOLATED_HEARTBEAT_FILE"
+    "$status")"
+  printf '%s\n' "$line" > "$ISOLATED_HEARTBEAT_FILE"
   mkdir -p "$(dirname "$DEV_TREE_HEARTBEAT_FILE")"
-  if ! cp "$ISOLATED_HEARTBEAT_FILE" "$DEV_TREE_HEARTBEAT_FILE"; then
-    log "ERROR: heartbeat copy-back to the dev tree failed — Check 44 will stale despite a completed run."
-    # Propagate FAIL into the clone's heartbeat so the signal is not silently OK.
-    printf '%s\t%s\tFAIL\n' \
-      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-      "$(git -C "$EVAL_CLONE" rev-parse HEAD)" \
-      > "$ISOLATED_HEARTBEAT_FILE"
+  if ! printf '%s\n' "$line" > "$DEV_TREE_HEARTBEAT_FILE" 2>/dev/null; then
+    log "ERROR: could not write heartbeat to the dev tree ($DEV_TREE_HEARTBEAT_FILE). Check 44 may not reflect this run until the 14-day staleness window expires."
   fi
 }
 
@@ -298,18 +319,12 @@ fi
 # Drift detection
 # ---------------------------------------------------------------------------
 
-POST_HASH="$(shasum -a 256 "$BASELINE_FILE" | awk '{print $1}')"
+POST_HASH="$(sha256_file "$BASELINE_FILE")"
 log "Post-eval baseline.json sha256: $POST_HASH"
 
-cleanup_index() {
-  # L1: regenerate the index fresh each run — wipe the clone's .ruvector.
-  rm -rf "$EVAL_CLONE/.ruvector" 2>/dev/null || true
-}
-
 if [ "$PRE_HASH" = "$POST_HASH" ]; then
-  log "No drift — baseline.json unchanged. Heartbeat copied back to the dev tree (no commit needed)."
-  cleanup_index
-  exit 0
+  log "No drift — baseline.json unchanged. Heartbeat written to the dev tree (no commit needed)."
+  exit 0  # EXIT trap tears down the container + wipes the index.
 fi
 
 log "Drift detected — opening auto-PR from the isolated clone..."
@@ -359,6 +374,7 @@ else
 fi
 
 git -C "$EVAL_CLONE" checkout main >>"$LOG_FILE" 2>&1 || log "WARNING: could not return clone to main."
-cleanup_index
+# Delete the per-run local branch so they don't accumulate in the clone (Low).
+git -C "$EVAL_CLONE" branch -D "$BRANCH" >>"$LOG_FILE" 2>&1 || true
 
-exit 0
+exit 0  # EXIT trap tears down the container + wipes the index.

--- a/scripts/eval-baseline-cron.sh
+++ b/scripts/eval-baseline-cron.sh
@@ -1,33 +1,46 @@
 #!/bin/bash
-# audit:host-npm-required — see SMI-4814 (npm runs inside a multi-line `docker exec -w /app sh -c '...'` block the per-line audit scanner cannot see; verify line ~141)
-# scripts/eval-baseline-cron.sh — SMI-4764 Wave 2
+# audit:host-npm-required — see SMI-4814 (npm runs inside a multi-line `docker exec -w /app sh -c '...'` block the per-line audit scanner cannot see)
+# scripts/eval-baseline-cron.sh — SMI-4764 Wave 2; SMI-5353 decoupled-checkout rewrite
 #
 # Canonical-developer cron entry point for the retrieval-eval baseline.
-# Runs `RETRIEVAL_EVAL_REAL=1` weekly against the canonical dev's local
-# corpus (docs/internal + memory adapter), opens an auto-PR via `gh` if
-# the resulting baseline.json drifts from origin/main, and always writes
-# a heartbeat row to packages/doc-retrieval-mcp/eval/.cron-heartbeat.
 #
-# Plan reference: docs/internal/implementation/smi-4764-eval-baseline-automation.md §Wave 2
+# SMI-5353: the eval runs against an ISOLATED clone (~/.skillsmith/eval-checkout)
+# pinned to origin/main, inside a DEDICATED ephemeral container — NEVER the dev's
+# live working tree. This decouples the weekly eval from the canonical dev's
+# perpetual WIP (submodule pointer drift on docs/internal + .claude/skills, plus
+# the cron's own untracked heartbeat), which used to trip the old clean-tree
+# guard and silently skip the run every week (last clean run before the rewrite:
+# 2026-06-07). A clean checkout pinned to origin/main is also the *intended*
+# corpus, so this is more faithful than the old in-place `git reset --hard`.
 #
-# Hard guards (refuse to run otherwise — addresses plan-review v2 #3):
-#   1. Current branch == main (no feature-branch contamination)
-#   2. Working tree clean (no half-staged developer edits)
-#   3. Docker container running (skillsmith-dev-1)
+# Plan reference: docs/internal/implementation/smi-5353-eval-cron-decoupled-checkout.md
 #
-# Heartbeat lifecycle:
-#   - Always written on each invocation (even on no-drift runs).
-#   - Committed by canonical dev as part of the auto-PR (drift case)
-#     or via a manual weekly heartbeat-only push (no-drift case).
-#   - Stale heartbeat (>14d) triggers `audit:standards` warning (Wave 2 Step 4)
-#     prompting designated-replacement protocol.
+# Flow:
+#   1. Guard: Docker daemon reachable.
+#   2. Preflight: distinct heartbeat paths, dev-tree heartbeat dir writable, disk.
+#   3. Ensure the isolated clone exists (clone origin once).
+#   4. Bring up the ephemeral eval container (compose + eval-cron override); trap teardown.
+#   5. Sync the clone to origin/main + pin ALL corpus submodules (docs/internal + .claude/skills).
+#   6. npm ci inside the eval container.
+#   7. Memory bind-mount preflight (corpus REQUIRES the memory adapter).
+#   8. Run RETRIEVAL_EVAL_REAL=1 eval in the eval container.
+#   9. Write heartbeat (OK / FAIL / WARN-PARTIAL) in the clone; copy it back to the dev tree.
+#  10. Drift detection -> auto-PR opened from the clone.
+#  11. Cleanup: wipe the clone's .ruvector; container torn down by the EXIT trap.
+#
+# The old branch==main + clean-working-tree guards on the dev's live tree are
+# GONE — the isolated clone is clean + pinned by construction.
+#
+# Heartbeat lifecycle (SMI-5353): copy-back to the dev tree every run keeps
+# `audit:standards` Check 44 fresh locally WITHOUT the old fragile manual-weekly
+# heartbeat push. On drift, the auto-PR still commits the tracked heartbeat +
+# baseline.json to main.
 #
 # Usage:
 #   ./scripts/eval-baseline-cron.sh             # Real run
-#   ./scripts/eval-baseline-cron.sh --dry-run   # Validate guards only, no eval
+#   ./scripts/eval-baseline-cron.sh --dry-run   # Validate setup only, no eval
 #
-# Logs: ~/.skillsmith/logs/eval-cron-<YYYY-MM-DD>.log (30-day rotation
-# managed externally — keep recent runs only).
+# Logs: ~/.skillsmith/logs/eval-cron-<YYYY-MM-DD>.log (30-day rotation external).
 
 set -euo pipefail
 
@@ -52,116 +65,234 @@ done
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-HEARTBEAT_FILE="packages/doc-retrieval-mcp/eval/.cron-heartbeat"
-BASELINE_FILE="packages/doc-retrieval-mcp/eval/baseline.json"
-DOCKER_CONTAINER="skillsmith-dev-1"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"          # the canonical dev's PRIMARY tree
+
+# Isolated, cron-owned clone (OUTSIDE the repo — never the dev's live tree).
+EVAL_CLONE="${SKILLSMITH_EVAL_CLONE:-${HOME}/.skillsmith/eval-checkout}"
+EVAL_PROJECT="skillsmith-eval-cron"                # Compose project (scopes the node_modules volume)
+EVAL_CONTAINER="skillsmith-eval-cron-1"            # set by docker-compose.eval-cron.yml override
+
+REL_BASELINE="packages/doc-retrieval-mcp/eval/baseline.json"
+REL_HEARTBEAT="packages/doc-retrieval-mcp/eval/.cron-heartbeat"
+BASELINE_FILE="$EVAL_CLONE/$REL_BASELINE"
+ISOLATED_HEARTBEAT_FILE="$EVAL_CLONE/$REL_HEARTBEAT"
+DEV_TREE_HEARTBEAT_FILE="$REPO_ROOT/$REL_HEARTBEAT"
+
+MIN_DISK_GB=3
+CONTAINER_UP=0
+
 LOG_DIR="${HOME}/.skillsmith/logs"
 LOG_FILE="${LOG_DIR}/eval-cron-$(date -u +%Y-%m-%d).log"
 mkdir -p "$LOG_DIR"
-
-cd "$REPO_ROOT"
 
 log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG_FILE" >&2
 }
 
+# `docker compose` wrapper: dedicated project + base file + eval override.
+compose() {
+  docker compose --project-name "$EVAL_PROJECT" \
+    -f "$EVAL_CLONE/docker-compose.yml" \
+    -f "$EVAL_CLONE/docker-compose.eval-cron.yml" \
+    "$@"
+}
+
+# EXIT trap: always tear the ephemeral eval container down (NOT `down -v` — keep
+# the project-scoped node_modules volume warm for next week). Preserves the
+# triggering exit code.
+# shellcheck disable=SC2329  # invoked indirectly via `trap teardown EXIT`
+teardown() {
+  local code=$?
+  if [ "$CONTAINER_UP" = "1" ]; then
+    log "Tearing down eval container (${EVAL_CONTAINER})..."
+    compose down >>"$LOG_FILE" 2>&1 || log "WARNING: eval container teardown failed — inspect 'docker ps'."
+  fi
+  exit "$code"
+}
+trap teardown EXIT
+
 # ---------------------------------------------------------------------------
-# Guard 1: must run from main
+# Guard: Docker daemon reachable
 # ---------------------------------------------------------------------------
 
-CURRENT_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo "")"
-if [ "$CURRENT_BRANCH" != "main" ]; then
-  log "ERROR: cron must run from 'main' (current: '$CURRENT_BRANCH')"
-  log "Refusing to run — switch to main and re-invoke."
+if ! docker info >/dev/null 2>&1; then
+  log "ERROR: Docker daemon not reachable. Start Docker Desktop and retry."
   exit 1
 fi
 
 # ---------------------------------------------------------------------------
-# Guard 2: clean working tree
+# Preflight: distinct heartbeat paths + writable dev-tree target + disk
+# ---------------------------------------------------------------------------
+
+# H8: the isolated and dev-tree heartbeats MUST be different files, else the
+# copy-back is a no-op and Check 44 reads a stale (or self-overwritten) file.
+if [ "$ISOLATED_HEARTBEAT_FILE" = "$DEV_TREE_HEARTBEAT_FILE" ]; then
+  log "ERROR: isolated and dev-tree heartbeat paths are identical ($ISOLATED_HEARTBEAT_FILE)."
+  log "  EVAL_CLONE must differ from REPO_ROOT. Refusing to run."
+  exit 1
+fi
+if [ "$EVAL_CLONE" = "$REPO_ROOT" ]; then
+  log "ERROR: EVAL_CLONE equals REPO_ROOT ($REPO_ROOT). The eval must run in a separate clone."
+  exit 1
+fi
+
+# M8: disk space. `df -Pk` is POSIX (macOS + Linux); convert KB available -> GB.
+AVAIL_GB="$(df -Pk "$HOME" | awk 'NR==2 {print int($4/1048576)}')"
+if [ "${AVAIL_GB:-0}" -lt "$MIN_DISK_GB" ]; then
+  log "ERROR: only ${AVAIL_GB}GB free at \$HOME; need >= ${MIN_DISK_GB}GB (clone + node_modules + .ruvector). Refusing to run."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Ensure the isolated clone exists
+# ---------------------------------------------------------------------------
+
+if [ ! -d "$EVAL_CLONE/.git" ]; then
+  if [ "$DRY_RUN" = "1" ]; then
+    log "ERROR (dry-run): isolated clone missing at $EVAL_CLONE."
+    log "  Run the one-time setup first (see .claude/development/eval-cron-setup.md)."
+    exit 1
+  fi
+  ORIGIN_URL="$(git -C "$REPO_ROOT" remote get-url origin)"
+  log "Cloning $ORIGIN_URL into $EVAL_CLONE (one-time)..."
+  mkdir -p "$(dirname "$EVAL_CLONE")"
+  git clone "$ORIGIN_URL" "$EVAL_CLONE" >>"$LOG_FILE" 2>&1
+fi
+
+# Sanity: the eval override must be present in the clone (it ships on origin/main).
+if [ ! -f "$EVAL_CLONE/docker-compose.eval-cron.yml" ]; then
+  log "ERROR: $EVAL_CLONE/docker-compose.eval-cron.yml missing."
+  log "  The clone predates SMI-5353 on origin/main — 'git -C $EVAL_CLONE fetch && git -C $EVAL_CLONE reset --hard origin/main' or re-clone."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Sync the clone to origin/main
+# ---------------------------------------------------------------------------
+
+log "Fetching origin/main in the isolated clone..."
+git -C "$EVAL_CLONE" fetch origin main >>"$LOG_FILE" 2>&1
+
+if [ "$DRY_RUN" = "0" ]; then
+  git -C "$EVAL_CLONE" checkout main >>"$LOG_FILE" 2>&1
+  git -C "$EVAL_CLONE" reset --hard origin/main >>"$LOG_FILE" 2>&1
+fi
+
+# Pin corpus submodules. docs/internal is REQUIRED (requireSubmodule); fail-fast.
+# .claude/skills is in the corpus globs too but non-fatal — warn-and-continue (M2).
+PARTIAL=0
+if [ "$DRY_RUN" = "0" ]; then
+  if ! git -C "$EVAL_CLONE" submodule update --init --force docs/internal >>"$LOG_FILE" 2>&1; then
+    log "ERROR: docs/internal submodule update failed — corpus REQUIRES it. Aborting."
+    exit 1
+  fi
+  if ! git -C "$EVAL_CLONE" submodule update --init --force .claude/skills >>"$LOG_FILE" 2>&1; then
+    log "WARNING: .claude/skills submodule update failed; continuing with prior checkout (PARTIAL corpus)."
+    PARTIAL=1
+  fi
+fi
+
+# Dry-run: corpus submodule sentinels must already be present.
+if [ ! -f "$EVAL_CLONE/docs/internal/index.md" ]; then
+  log "ERROR: docs/internal not initialized in the clone (missing index.md sentinel)."
+  log "  Run 'git -C $EVAL_CLONE submodule update --init --force docs/internal' (needs private-submodule access)."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Bring up the ephemeral eval container
+# ---------------------------------------------------------------------------
+
+log "Bringing up eval container (${EVAL_CONTAINER}) on project ${EVAL_PROJECT}..."
+compose --profile dev up -d --wait --wait-timeout 300 >>"$LOG_FILE" 2>&1
+CONTAINER_UP=1
+
+# Install deps (always — guarantees tsx + runtime deps; ~30-60s warm). M7.
+log "Installing dependencies in the eval container (npm ci)..."
+docker exec -w /app "$EVAL_CONTAINER" npm ci >>"$LOG_FILE" 2>&1
+
+# tsx must resolve — the eval runner is `tsx eval/eval-runner.ts`.
+if ! docker exec -w /app "$EVAL_CONTAINER" sh -c 'npm ls tsx >/dev/null 2>&1 || npx --no-install tsx --version >/dev/null 2>&1'; then
+  log "ERROR: tsx not resolvable in the eval container after npm ci."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Memory bind-mount preflight (H1)
 # ---------------------------------------------------------------------------
 #
-# `git status --porcelain` lists modified, staged, untracked, and conflicted
-# entries. We tolerate:
-#   - Untracked files in worktrees/ (created by parallel create-worktree.sh)
-#   - Submodule dirty content (untracked + modified files INSIDE the submodule),
-#     because docs/internal often carries parallel-session WIP files. The
-#     parent's submodule POINTER (the SHA the parent commit references) is
-#     still validated — `--ignore-submodules=dirty` ignores dirty content
-#     but NOT pointer changes, so an unstaged SHA bump still flags `M`.
+# The memory-topic-files adapter reads /skillsmith-memory (bind-mounted from
+# ${HOME}/.claude/projects/${SKILLSMITH_PROJECT_DIR_ENCODED}/memory). If that env
+# var was empty at `compose up`, the mount is an empty dir and the eval's GAP 1
+# check would `process.exit(1)` mid-run with a cryptic message. Surface it here.
 
-PORCELAIN="$(git -c submodule.recurse=false status --porcelain --ignore-submodules=dirty | grep -vE '^\?\? worktrees/' || true)"
-if [ -n "$PORCELAIN" ]; then
-  log "ERROR: cron requires clean working tree. Found:"
-  echo "$PORCELAIN" | tee -a "$LOG_FILE" >&2
-  log "Refusing to run — commit or stash changes and re-invoke."
+if ! docker exec "$EVAL_CONTAINER" sh -c '[ -n "$(ls -A /skillsmith-memory 2>/dev/null)" ]'; then
+  log "ERROR: /skillsmith-memory is empty in the eval container."
+  log "  Export SKILLSMITH_PROJECT_DIR_ENCODED before launch (see eval-cron-setup.md) so the"
+  log "  memory bind-mount resolves. Refusing to run a degraded (memory-less) corpus."
   exit 1
 fi
-
-# ---------------------------------------------------------------------------
-# Guard 3: Docker container running
-# ---------------------------------------------------------------------------
-
-if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${DOCKER_CONTAINER}\$"; then
-  log "ERROR: Docker container '${DOCKER_CONTAINER}' is not running."
-  log "Start it: docker compose --profile dev up -d"
-  exit 1
-fi
-
-log "Guards passed: branch=main, tree=clean, container=${DOCKER_CONTAINER}"
 
 if [ "$DRY_RUN" = "1" ]; then
-  log "Dry-run mode — exiting before eval invocation."
+  log "Dry-run OK: clone present, origin reachable, submodules initialized, container up, tsx resolvable, memory mount populated, heartbeat paths distinct. Exiting before eval."
   exit 0
 fi
 
 # ---------------------------------------------------------------------------
-# Sync main + submodule before run
-# ---------------------------------------------------------------------------
-
-log "Syncing main from origin..."
-git fetch origin main >>"$LOG_FILE" 2>&1
-git reset --hard origin/main >>"$LOG_FILE" 2>&1
-git submodule update --init docs/internal >>"$LOG_FILE" 2>&1
-
-# ---------------------------------------------------------------------------
-# Capture baseline.json hash before the eval (for drift detection)
+# Capture baseline.json hash before the eval (drift detection)
 # ---------------------------------------------------------------------------
 
 PRE_HASH="$(shasum -a 256 "$BASELINE_FILE" | awk '{print $1}')"
 log "Pre-eval baseline.json sha256: $PRE_HASH"
 
 # ---------------------------------------------------------------------------
-# Run eval in canonical mode inside Docker
+# Run the eval in canonical mode inside the eval container
 # ---------------------------------------------------------------------------
 
 log "Running canonical real-mode eval..."
 EVAL_EXIT=0
-docker exec -w /app "$DOCKER_CONTAINER" sh -c \
+docker exec -w /app "$EVAL_CONTAINER" sh -c \
   'SKILLSMITH_REPO_ROOT=/app SKILLSMITH_EVAL_CANONICAL=true RETRIEVAL_EVAL_REAL=1 \
    npm run eval:retrieval --workspace=packages/doc-retrieval-mcp' \
   >>"$LOG_FILE" 2>&1 || EVAL_EXIT=$?
 
+# ---------------------------------------------------------------------------
+# Heartbeat: write in the clone, copy back to the dev tree (H4)
+# ---------------------------------------------------------------------------
+#
+# Status: FAIL (eval errored) | WARN-PARTIAL (.claude/skills not pinned) | OK.
+
+write_heartbeat() {
+  local status="$1"
+  printf '%s\t%s\t%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "$(git -C "$EVAL_CLONE" rev-parse HEAD)" \
+    "$status" \
+    > "$ISOLATED_HEARTBEAT_FILE"
+  mkdir -p "$(dirname "$DEV_TREE_HEARTBEAT_FILE")"
+  if ! cp "$ISOLATED_HEARTBEAT_FILE" "$DEV_TREE_HEARTBEAT_FILE"; then
+    log "ERROR: heartbeat copy-back to the dev tree failed — Check 44 will stale despite a completed run."
+    # Propagate FAIL into the clone's heartbeat so the signal is not silently OK.
+    printf '%s\t%s\tFAIL\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      "$(git -C "$EVAL_CLONE" rev-parse HEAD)" \
+      > "$ISOLATED_HEARTBEAT_FILE"
+  fi
+}
+
 if [ "$EVAL_EXIT" != "0" ]; then
   log "ERROR: eval invocation failed with exit $EVAL_EXIT — see $LOG_FILE"
-  # Still write heartbeat so the freshness check can distinguish "cron
-  # ran but eval failed" from "cron not running at all". Append a marker.
-  printf '%s\t%s\tFAIL\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    "$(git rev-parse HEAD)" \
-    > "$HEARTBEAT_FILE"
+  write_heartbeat "FAIL"
   exit "$EVAL_EXIT"
 fi
 
-# ---------------------------------------------------------------------------
-# Always write heartbeat (success path)
-# ---------------------------------------------------------------------------
-
-printf '%s\t%s\tOK\n' \
-  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  "$(git rev-parse HEAD)" \
-  > "$HEARTBEAT_FILE"
-log "Heartbeat written: $HEARTBEAT_FILE"
+if [ "$PARTIAL" = "1" ]; then
+  write_heartbeat "WARN-PARTIAL"
+  log "Heartbeat written (WARN-PARTIAL): $DEV_TREE_HEARTBEAT_FILE"
+else
+  write_heartbeat "OK"
+  log "Heartbeat written (OK): $DEV_TREE_HEARTBEAT_FILE"
+fi
 
 # ---------------------------------------------------------------------------
 # Drift detection
@@ -170,50 +301,64 @@ log "Heartbeat written: $HEARTBEAT_FILE"
 POST_HASH="$(shasum -a 256 "$BASELINE_FILE" | awk '{print $1}')"
 log "Post-eval baseline.json sha256: $POST_HASH"
 
+cleanup_index() {
+  # L1: regenerate the index fresh each run — wipe the clone's .ruvector.
+  rm -rf "$EVAL_CLONE/.ruvector" 2>/dev/null || true
+}
+
 if [ "$PRE_HASH" = "$POST_HASH" ]; then
-  log "No drift — baseline.json unchanged. Heartbeat-only commit deferred to manual weekly push."
+  log "No drift — baseline.json unchanged. Heartbeat copied back to the dev tree (no commit needed)."
+  cleanup_index
   exit 0
 fi
 
-log "Drift detected — opening auto-PR..."
+log "Drift detected — opening auto-PR from the isolated clone..."
 
 # ---------------------------------------------------------------------------
-# Open auto-PR via gh CLI
+# Open auto-PR via gh CLI (from the clone)
 # ---------------------------------------------------------------------------
 #
-# Pattern mirrors `release-cadence.yml` (plan §7 / Surface Grounding).
-# Branch name embeds the date so consecutive cron runs don't collide.
+# Minute-resolution branch suffix (M1) so a scheduled + manual run on the same
+# day cannot collide. PR/push failures are non-fatal: the heartbeat is already
+# fresh, and the drift can be re-PR'd next run.
 
-BRANCH="chore/eval-baseline-cron-$(date -u +%Y%m%d)"
-git checkout -b "$BRANCH" >>"$LOG_FILE" 2>&1
-git add "$BASELINE_FILE" "$HEARTBEAT_FILE"
-# baseline.md is regenerated by hand by the canonical dev when shape changes;
-# cron-driven drifts are typically corpus-only so the prose copy stays valid.
-git commit -m "chore(eval): cron-detected baseline drift ($(date -u +%Y-%m-%d))
+BRANCH="chore/eval-baseline-cron-$(date -u +%Y%m%dT%H%M)"
+PR_OK=1
+{
+  git -C "$EVAL_CLONE" checkout -b "$BRANCH" &&
+  git -C "$EVAL_CLONE" add "$REL_BASELINE" "$REL_HEARTBEAT" &&
+  git -C "$EVAL_CLONE" commit -m "chore(eval): cron-detected baseline drift ($(date -u +%Y-%m-%d))
 
-Auto-generated by scripts/eval-baseline-cron.sh on canonical dev's machine.
-baseline.json sha256 changed: ${PRE_HASH:0:12} → ${POST_HASH:0:12}
+Auto-generated by scripts/eval-baseline-cron.sh in the isolated eval checkout.
+baseline.json sha256 changed: ${PRE_HASH:0:12} -> ${POST_HASH:0:12}
 
 CI Retrieval Eval Gate exercises the hybrid threshold against this diff;
 review the per-category breakdown in the gate output before merging.
 
-[skip-impl-check]" >>"$LOG_FILE" 2>&1
+[skip-impl-check]" &&
+  git -C "$EVAL_CLONE" push -u origin "$BRANCH" --no-verify
+} >>"$LOG_FILE" 2>&1 || PR_OK=0
 
-git push -u origin "$BRANCH" --no-verify >>"$LOG_FILE" 2>&1
+if [ "$PR_OK" = "1" ]; then
+  ( cd "$EVAL_CLONE" && gh pr create \
+    --base main \
+    --head "$BRANCH" \
+    --title "chore(eval): cron-detected baseline drift ($(date -u +%Y-%m-%d))" \
+    --label "eval-baseline-cron" \
+    --body "Auto-generated by \`scripts/eval-baseline-cron.sh\` in the isolated eval checkout. Review the Retrieval Eval Gate per-category breakdown before merging.
 
-gh pr create \
-  --base main \
-  --head "$BRANCH" \
-  --title "chore(eval): cron-detected baseline drift ($(date -u +%Y-%m-%d))" \
-  --label "eval-baseline-cron" \
-  --body "Auto-generated by \`scripts/eval-baseline-cron.sh\` on the canonical dev's machine. Review the Retrieval Eval Gate per-category breakdown before merging.
+baseline.json sha256: \`${PRE_HASH:0:12}\` -> \`${POST_HASH:0:12}\`
 
-baseline.json sha256: \`${PRE_HASH:0:12}\` → \`${POST_HASH:0:12}\`
+[skip-impl-check]" ) >>"$LOG_FILE" 2>&1 || PR_OK=0
+fi
 
-[skip-impl-check]" \
-  >>"$LOG_FILE" 2>&1
+if [ "$PR_OK" = "1" ]; then
+  log "Auto-PR opened on branch ${BRANCH}"
+else
+  log "WARNING: auto-PR creation failed (gh auth / existing branch?). Drift recorded; will retry next run. See $LOG_FILE."
+fi
 
-log "Auto-PR opened on branch ${BRANCH}"
-git checkout main >>"$LOG_FILE" 2>&1
+git -C "$EVAL_CLONE" checkout main >>"$LOG_FILE" 2>&1 || log "WARNING: could not return clone to main."
+cleanup_index
 
 exit 0

--- a/scripts/eval-baseline-launchd.plist.template
+++ b/scripts/eval-baseline-launchd.plist.template
@@ -27,6 +27,14 @@
       script itself writes detailed logs to ~/.skillsmith/logs/).
     - RunAtLoad=false: do NOT fire on `launchctl load`. Schedule-only.
     - StartCalendarInterval is the launchd equivalent of cron expressions.
+    - SMI-5353: launchd has no per-invocation timeout key equivalent to
+      systemd's TimeoutStartSec. If a run wedges (hung `docker compose up`
+      or stuck eval), kill it manually:
+        launchctl list | grep skillsmith         # find the PID
+        launchctl kill TERM gui/$(id -u)/app.skillsmith.eval-baseline-cron
+      The script's EXIT trap still tears the ephemeral eval container down on
+      kill. As a backstop, `launchctl remove app.skillsmith.eval-baseline-cron`
+      unloads the agent entirely.
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/scripts/eval-baseline-systemd.service.template
+++ b/scripts/eval-baseline-systemd.service.template
@@ -34,6 +34,12 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 WorkingDirectory=__REPO_PATH__
+# SMI-5353: cap total run time. The real eval is ~1h40m; the isolated-checkout
+# bring-up + npm ci adds a few minutes. 7200s (2h) leaves headroom while still
+# killing a hung `docker compose up` / wedged eval rather than blocking the
+# systemd slot indefinitely. The script's own EXIT trap still tears the
+# ephemeral eval container down on timeout-kill.
+TimeoutStartSec=7200
 # Login shell so PATH includes docker/gh/varlock per canonical dev's profile.
 ExecStart=/bin/bash -lc 'cd __REPO_PATH__ && ./scripts/eval-baseline-cron.sh'
 StandardOutput=append:%h/.skillsmith/logs/eval-cron-systemd-stdout.log


### PR DESCRIPTION
## Summary

The weekly retrieval-eval cron (SMI-4764 W2) has **silently skipped since 2026-06-07**. It ran in the canonical dev's live working tree and refused at its clean-tree guard whenever `docs/internal` / `.claude/skills` carried uncommitted WIP — which is effectively always. The guard refusing was *correct* (it protected WIP from the cron's own `git reset --hard`), so the durable fix is to **decouple the eval from the live tree entirely**.

Closes the diagnosis + fix for **SMI-5353** (re-scoped from the original "cron not firing" mis-diagnosis — it fires every Sunday; it was refusing).

## What changed (Option A — plan-reviewed)

- The eval now runs in a **dedicated clone at `~/.skillsmith/eval-checkout`**, pinned to `origin/main`, inside its **own ephemeral container** (`skillsmith-eval-cron-1`). The dev's primary tree + `skillsmith-dev-1` container are **never** reset, stashed, or guarded.
- New non-auto-loaded `docker-compose.eval-cron.yml` override renames the container + drops the host port (`ports: !reset []`) so it can't collide with the hardcoded `skillsmith-dev-1` / port 3001.
- Heartbeat is written **directly to the dev tree** each run (replacing the fragile "manual weekly push", whose forgotten-push failure mode caused the stale-heartbeat warnings).
- **All** corpus submodules pinned (`docs/internal` + `.claude/skills`) — closes a latent fidelity gap (the old cron synced only `docs/internal`, but `.claude/skills/**/SKILL.md` is in the corpus globs).
- Adds disk + memory-bind-mount preflights, `WARN-PARTIAL` status, minute-resolution auto-PR branch, EXIT-trap container teardown + index wipe, portable `sha256` (Linux `sha256sum`), and a documented `--dry-run` contract.

## Process (ADR-109 infra change)

- **Plan**: `docs/internal/implementation/smi-5353-eval-cron-decoupled-checkout.md`.
- **Plan-review**: 6 Critical / 9 High / 8 Medium / 4 Low — all resolved. Option C (worktree) rejected for 5 structural blockers (`git worktree add main` is fatal; post-PR `checkout main` fails in a worktree; node_modules symlink ambiguity; `.git` index-lock contention with the live session; git-crypt smudge-dirty after reset).
- **Governance** (post-commit, on `a4d76817`): 6 findings (2 High / 2 Med / 2 Low) — all fixed in `d7fd69ad` (orphan-safe teardown, portable sha256, direct heartbeat write, index cleanup on all exit paths, branch pruning, doc accuracy).

## Validation

- `shellcheck` clean (default severity), `audit:standards` pass (76/0), `prettier` clean, compose merge verified (renamed container, 0 published ports, base `skillsmith-dev-1` untouched).
- ⚠️ **Functional smoke is a manual canonical-dev gate**: the real `RETRIEVAL_EVAL_REAL=1` run is ~1h40m and needs the one-time clone setup on the canonical dev's machine. **SMI-5353 stays In Review until that smoke is logged.** CI cannot run this — `docs/internal` is excluded from CI and `assertNotInCi()` hard-blocks the eval in CI.

## Notes

- No `.ts` source / test changes — config + shell + Markdown only.
- One-time setup, replacement protocol (+ teardown), and troubleshooting rewritten in `.claude/development/eval-cron-setup.md`.

[skip-impl-check]
[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
