### PR TITLE
feat(website): extract typed SkillCard renderer into skill-card.ts (SMI-5366, closes #1377)

### DIFF
--- a/packages/website/src/lib/license-label.parity.test.ts
+++ b/packages/website/src/lib/license-label.parity.test.ts
@@ -1,14 +1,17 @@
 /**
- * SMI-5337 retro: Parity guard for the licenseLabel() helper vs the two
- * is:inline Astro badge sites that cannot import it at runtime.
+ * SMI-5337 retro: Parity guard for the licenseLabel() helper vs the badge
+ * sites that render a license label.
  *
- * Both inline sites mirror the same logic:
- *   skills/index.astro   — createLicenseBadge(license)
- *   skills/[id].astro    — skill.license?.trim() || 'Unknown'
+ * Sites:
+ *   lib/skill-card.ts    — renderLicenseBadge() now calls licenseLabel() directly
+ *                          (SMI-5366 extracted it from skills/index.astro; bundled,
+ *                          so it imports the helper rather than mirroring it).
+ *   skills/[id].astro    — still is:inline, mirrors `skill.license?.trim() || 'Unknown'`
+ *                          (SMI-4907 tracks migrating that page to a bundled <script>).
  *
- * This test exists to catch any drift between the extracted helper and the
- * inline duplicates. When a badge site changes its null-handling, this test
- * must be updated FIRST so the helper stays the authoritative source.
+ * This test exists to catch any drift between the helper and the remaining
+ * inline mirror ([id].astro). When a badge site changes its null-handling, this
+ * test must be updated FIRST so the helper stays the authoritative source.
  *
  * CONTRACT (all three implementations agree):
  *   licenseLabel('MIT')   === 'MIT'
@@ -22,9 +25,9 @@ import { describe, it, expect } from 'vitest'
 import { licenseLabel } from './license-label'
 
 describe('licenseLabel — parity with is:inline Astro badge sites (SMI-5337)', () => {
-  // skills/index.astro createLicenseBadge: `const label = trimmed ? escapeHtml(trimmed) : 'Unknown'`
-  // skills/[id].astro renderSkill:         `skill.license?.trim() || 'Unknown'`
-  // licenseLabel():                        `const trimmed = license?.trim(); return trimmed ? trimmed : 'Unknown'`
+  // lib/skill-card.ts renderLicenseBadge: `escapeHtml(licenseLabel(license))` (calls the helper)
+  // skills/[id].astro renderSkill:        `skill.license?.trim() || 'Unknown'` (inline mirror)
+  // licenseLabel():                       `const trimmed = license?.trim(); return trimmed ? trimmed : 'Unknown'`
 
   it('MIT renders as "MIT" (non-null verbatim passthrough)', () => {
     expect(licenseLabel('MIT')).toBe('MIT')

--- a/packages/website/src/lib/license-label.test.ts
+++ b/packages/website/src/lib/license-label.test.ts
@@ -1,11 +1,12 @@
 /**
  * SMI-5327: Unit tests for the licenseLabel helper.
  *
- * The website renders license in two places that use identical logic:
- *   1. Skill card (createLicenseBadge in skills/index.astro inline script)
- *   2. Skill detail page (renderSkill in skills/[id].astro inline script)
+ * The website renders license in two places:
+ *   1. Skill card (renderLicenseBadge in lib/skill-card.ts — calls licenseLabel();
+ *      extracted from skills/index.astro in SMI-5366)
+ *   2. Skill detail page (renderSkill in skills/[id].astro is:inline script — still
+ *      mirrors the logic; SMI-4907 tracks bundling that page)
  *
- * Both sites are is:inline Astro scripts with no component-test harness.
  * The label logic is extracted here so it can be covered without a browser.
  *
  * CONTRACT: null / undefined / empty => "Unknown" (NOT "no license",

--- a/packages/website/src/lib/skill-card.parity.test.ts
+++ b/packages/website/src/lib/skill-card.parity.test.ts
@@ -1,0 +1,36 @@
+/**
+ * SMI-5178 / SMI-5366 parity guard: COMPAT_LABELS in skill-card.ts must stay in
+ * sync with the canonical COMPATIBILITY_LABELS map in @skillsmith/core.
+ *
+ * Source of truth: packages/core/src/compatibility/slugs.ts (COMPATIBILITY_LABELS).
+ * The website client bundle CANNOT import @skillsmith/core at runtime, so this map
+ * is duplicated in skill-card.ts and this test is the enforcement boundary.
+ *
+ * The source-of-truth guard for core's own map lives at:
+ *   scripts/tests/indexer/compatibility-slug-parity.test.ts
+ *
+ * Pattern: follows the precedent of license-label.parity.test.ts (SMI-5337 retro).
+ * When the canonical core map changes, update COMPAT_LABELS in skill-card.ts and
+ * the EXPECTED constant below in lockstep.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { COMPAT_LABELS } from './skill-card'
+
+// Hardcoded canonical contract — derived from packages/core/src/compatibility/slugs.ts.
+// Do NOT derive this from COMPAT_LABELS itself; that would make the test circular.
+const EXPECTED: Record<string, string> = {
+  'claude-code': 'Claude Code',
+  cursor: 'Cursor',
+  copilot: 'GitHub Copilot',
+  windsurf: 'Windsurf',
+  antigravity: 'Antigravity',
+  codex: 'Codex',
+  gemini: 'Gemini',
+}
+
+describe('COMPAT_LABELS — parity with core COMPATIBILITY_LABELS (SMI-5178)', () => {
+  it('deep-equals the 7-entry canonical contract from packages/core/src/compatibility/slugs.ts', () => {
+    expect(COMPAT_LABELS).toEqual(EXPECTED)
+  })
+})

--- a/packages/website/src/lib/skill-card.test.ts
+++ b/packages/website/src/lib/skill-card.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Inline snapshot gate + assertion set for renderSkillCard (SMI-5366).
+ *
+ * Snapshot:    regenerate with `npx vitest run -u src/lib/skill-card.test.ts`
+ *              (or the Docker equivalent below). Review the diff before committing.
+ * Parity companion: skill-card.parity.test.ts pins COMPAT_LABELS vs the core contract.
+ *
+ * Docker:
+ *   docker exec smi-5365-skills-index-bundled-migration-dev-1 \
+ *     sh -c 'cd packages/website && npx vitest run -u src/lib/skill-card.test.ts'
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { WireSkill } from '../types/skills'
+import { renderSkillCard } from './skill-card'
+import { formatNumber, getQualityTier } from './skills-utils'
+import { TRUST_TIER_BADGE_CLASSES, DEFAULT_TRUST_TIER } from '../constants/trust-tier-badges'
+
+/**
+ * Representative fully-populated skill for the inline snapshot and many assertion
+ * blocks below.  compatibility has 5 entries (> MAX_VISIBLE=4) so the "+N more"
+ * expand path is exercised in the snapshot and several assertion tests.
+ */
+const FULL_SKILL: WireSkill = {
+  id: 'acme/test-runner',
+  name: 'Test Runner',
+  author: 'acme',
+  description: 'Runs your tests automatically',
+  trust_tier: 'verified',
+  stars: 1234,
+  categories: ['testing'],
+  version: '1.2.0',
+  repo_url: 'https://github.com/x/y',
+  compatibility: ['claude-code', 'cursor', 'copilot', 'windsurf', 'codex'],
+  license: 'MIT',
+  _orgMatch: 'acme',
+}
+const FULL_HREF = '/skills/acme%2Ftest-runner'
+
+describe('renderSkillCard', () => {
+  // ─── inline snapshot ──────────────────────────────────────────────────────────
+  // Anti-drift gate: any structural change to the renderer's markup breaks this.
+  // Regenerate by running vitest with the -u flag (see file header).
+  // Review the generated diff before committing — reject garbage output.
+  it('renders a fully-populated skill card (inline snapshot)', () => {
+    const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+    expect(html).toMatchInlineSnapshot(`
+      "
+              <a href="/skills/acme%2Ftest-runner" class="card-hover block bg-dark-900 rounded-xl border border-dark-800 p-6 hover:border-primary-500/50">
+                <div class="flex items-start justify-between mb-4">
+                  <div class="flex-1 min-w-0">
+                    <h3 class="text-lg font-semibold text-white truncate">Test Runner</h3>
+                    <p class="text-dark-500 text-sm">acme</p>
+                    <span class="inline-flex items-center gap-1 px-2 py-0.5 mt-2 rounded-full text-xs font-medium bg-primary-500/10 text-primary-300 border border-primary-500/30" aria-label="Matches your org: acme">
+          <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M10 2a6 6 0 100 12 6 6 0 000-12zm0 2a4 4 0 110 8 4 4 0 010-8z"/></svg>
+          Matches your org: acme
+        </span>
+                  </div>
+                  <span class="ml-4 px-2.5 py-1 text-xs font-medium rounded-full border bg-blue-500/10 text-blue-400 border-blue-500/20">
+                    verified
+                  </span>
+                </div>
+                <p class="text-dark-400 text-sm mb-4 line-clamp-2">Runs your tests automatically</p>
+                <div class="flex items-center justify-between text-sm">
+                  <div class="flex items-center space-x-4">
+                    
+                      <span class="text-dark-500">
+                        <svg class="w-4 h-4 inline-block mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+                        </svg>
+                        testing
+                      </span>
+                    
+                    <span class="text-dark-500">v1.2.0</span>
+                  </div>
+                  <span class="text-green-400 text-lg" role="img" aria-label="High Quality: 1,234 stars" title="High Quality: 1,234 stars">●<span class="sr-only">High Quality: 1,234 stars</span></span>
+                </div>
+                <div class="mt-3 pt-3 border-t border-dark-800">
+                    <span class="inline-flex items-center gap-1 text-xs text-dark-500">
+                      <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+                      </svg>
+                      View source
+                    </span>
+                  </div>
+                <div class="mt-3 pt-3 border-t border-dark-800 flex flex-wrap gap-1 items-center">
+          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">Claude Code</span><span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">Cursor</span><span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">GitHub Copilot</span><span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">Windsurf</span>
+          <span id="compat-extra-1" style="display:none"><span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">Codex</span></span>
+          <button
+            type="button"
+            class="px-1.5 py-0.5 rounded text-xs text-dark-400 hover:text-primary-400 transition-colors focus:outline-none focus:ring-1 focus:ring-primary-500"
+            aria-label="Show 1 more compatibility tags"
+            aria-expanded="false"
+            aria-controls="compat-extra-1"
+            onclick="event.preventDefault(); event.stopPropagation(); document.getElementById('compat-extra-1').style.display='contents'; this.setAttribute('aria-expanded','true'); this.style.display='none';"
+          >+1 more</button>
+        </div>
+                <div class="mt-2">
+          <span class="inline-flex items-center gap-1 text-xs text-dark-500" aria-label="License: MIT">
+            <svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+            </svg>
+            <span>License: <span class="font-medium">MIT</span></span>
+          </span>
+        </div>
+              </a>
+            "
+    `)
+  })
+
+  // ─── trust badge ──────────────────────────────────────────────────────────────
+  describe('trust badge', () => {
+    it('verified tier renders the verified badge class and "verified" text', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(html).toContain(TRUST_TIER_BADGE_CLASSES.verified)
+      expect(html).toMatch(/rounded-full border [^>]+>\s*verified\s*<\/span>/)
+    })
+
+    it('absent trust_tier falls back to DEFAULT_TRUST_TIER class and "unverified" text', () => {
+      // Minimal WireSkill with no trust_tier property — exactOptionalPropertyTypes
+      // requires omission rather than setting to undefined.
+      const html = renderSkillCard({
+        skill: { id: 'test', name: 'No Tier Skill' },
+        href: '/skills/test',
+      })
+      expect(html).toContain(TRUST_TIER_BADGE_CLASSES[DEFAULT_TRUST_TIER])
+      expect(html).toMatch(/rounded-full border [^>]+>\s*unverified\s*<\/span>/)
+    })
+
+    it('runtime-unknown trust_tier falls back to default class, shows raw slug, no "undefined" in any class attr', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- deliberate any-cast: simulates a runtime-unknown trust tier value that cannot exist in the type system
+      const skill: WireSkill = { id: 'test', name: 'Test', trust_tier: 'ultra-mega-tier' as any }
+      const html = renderSkillCard({ skill, href: '/skills/test' })
+      expect(html).toContain(TRUST_TIER_BADGE_CLASSES[DEFAULT_TRUST_TIER])
+      expect(html).toContain('ultra-mega-tier')
+      expect(html).not.toMatch(/class="[^"]*undefined[^"]*"/)
+    })
+  })
+
+  // ─── quality dot ──────────────────────────────────────────────────────────────
+  describe('quality dot', () => {
+    // Compute expected values the same way the renderer does — locale-independent.
+    const tier = getQualityTier(1234)
+    const expectedLabel = `${tier.label}: ${formatNumber(1234)} stars`
+
+    it('has role="img"', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(html).toContain('role="img"')
+    })
+
+    it('has aria-label with locale-grouped star count (regex tolerant of separator)', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      // Tolerates comma, period, narrow-no-break-space (U+202F), or thin-space
+      // separators across different Node.js locale/ICU configurations.
+      expect(html).toMatch(/aria-label="High Quality: 1[,.\s]?234 stars"/)
+    })
+
+    it('has sr-only span with same text as aria-label, and title= equal to aria-label', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(html).toContain(`aria-label="${expectedLabel}"`)
+      expect(html).toContain(`title="${expectedLabel}"`)
+      expect(html).toContain(`<span class="sr-only">${expectedLabel}</span>`)
+    })
+
+    it('has tier.color class text-green-400 for 1234 stars (High Quality tier)', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(tier.color).toBe('text-green-400')
+      expect(html).toContain(tier.color)
+    })
+  })
+
+  // ─── org badge ────────────────────────────────────────────────────────────────
+  describe('org badge', () => {
+    it('contributes empty string when _orgMatch is absent', () => {
+      const html = renderSkillCard({
+        skill: { id: 'test', name: 'Test' },
+        href: '/skills/test',
+      })
+      expect(html).not.toContain('Matches your org')
+    })
+
+    it('renders aria-label, visible text, and badge classes when _orgMatch is set', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(html).toContain('aria-label="Matches your org: acme"')
+      expect(html).toContain('Matches your org: acme')
+      expect(html).toContain('bg-primary-500/10 text-primary-300')
+    })
+  })
+
+  // ─── compatibility ────────────────────────────────────────────────────────────
+  describe('compatibility', () => {
+    it('known slugs render display labels not raw slugs', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(html).toContain('Claude Code')
+      expect(html).toContain('GitHub Copilot')
+      expect(html).not.toMatch(/>claude-code</)
+      expect(html).not.toMatch(/>copilot</)
+    })
+
+    it('unknown slug renders its raw escaped value', () => {
+      const skill: WireSkill = {
+        id: 'test',
+        name: 'Test',
+        compatibility: ['claude-code', 'cursor', 'copilot', 'windsurf', 'neovim'],
+      }
+      const html = renderSkillCard({ skill, href: '/skills/test' })
+      expect(html).toContain('>neovim<')
+    })
+
+    it('with >4 items, +N more button aria-controls matches the hidden span id', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      const ariaControlsMatch = html.match(/aria-controls="(compat-extra-\d+)"/)
+      expect(ariaControlsMatch).not.toBeNull()
+      const extraId = ariaControlsMatch?.[1] ?? ''
+      expect(extraId).toMatch(/^compat-extra-\d+$/)
+      expect(html).toContain(`id="${extraId}"`)
+    })
+
+    it('with >4 items, +N more button has aria-expanded="false" and correct aria-label', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(html).toContain('aria-expanded="false"')
+      expect(html).toContain('aria-label="Show 1 more compatibility tags"')
+    })
+
+    it('onclick contains event.preventDefault() and event.stopPropagation() (SMI-3529 nested-button-in-anchor guard)', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(html).toContain('event.preventDefault()')
+      expect(html).toContain('event.stopPropagation()')
+    })
+
+    it('max 4 badges are visible before the hidden extra span', () => {
+      const skill: WireSkill = {
+        id: 'test',
+        name: 'Test',
+        compatibility: ['claude-code', 'cursor', 'copilot', 'windsurf', 'codex'],
+      }
+      const html = renderSkillCard({ skill, href: '/skills/test' })
+      const hiddenIdx = html.indexOf('style="display:none"')
+      expect(hiddenIdx).toBeGreaterThan(0)
+      // Everything before the hidden span — only the 4 visible badge spans land here.
+      // The +N more button (also has px-1.5 py-0.5 classes) comes after the hidden span.
+      const visibleSection = html.slice(0, hiddenIdx)
+      const visibleBadgeMatches = visibleSection.match(/px-1\.5 py-0\.5 rounded text-xs/g)
+      expect(visibleBadgeMatches).toHaveLength(4)
+    })
+
+    it('empty compatibility array renders no compat badge row', () => {
+      const html = renderSkillCard({
+        skill: { id: 'test', name: 'Test', compatibility: [] },
+        href: '/skills/test',
+      })
+      expect(html).not.toContain('text-primary-400 border border-primary-500/20')
+    })
+
+    it('absent compatibility renders no compat badge row', () => {
+      const html = renderSkillCard({
+        skill: { id: 'test', name: 'Test' },
+        href: '/skills/test',
+      })
+      expect(html).not.toContain('text-primary-400 border border-primary-500/20')
+    })
+
+    it('two successive calls with >4 compat tags emit distinct monotonically-increasing compat-extra-N ids', () => {
+      const skill: WireSkill = {
+        id: 'test',
+        name: 'Test',
+        compatibility: ['claude-code', 'cursor', 'copilot', 'windsurf', 'codex'],
+      }
+      const html1 = renderSkillCard({ skill, href: '/skills/test' })
+      const html2 = renderSkillCard({ skill, href: '/skills/test' })
+
+      const m1 = html1.match(/id="compat-extra-(\d+)"/)
+      const m2 = html2.match(/id="compat-extra-(\d+)"/)
+      expect(m1).not.toBeNull()
+      expect(m2).not.toBeNull()
+
+      // Use optional-chain + fallback so TypeScript doesn't require non-null assertion.
+      // If m1 / m2 are null the above expect() already fails the test.
+      const n1 = parseInt(m1?.[1] ?? '0', 10)
+      const n2 = parseInt(m2?.[1] ?? '0', 10)
+      expect(n1).toBeGreaterThan(0) // sanity: both resolved to valid ids
+      expect(n2).toBeGreaterThan(n1) // monotonically increasing, never resetting
+    })
+  })
+
+  // ─── license ──────────────────────────────────────────────────────────────────
+  describe('license', () => {
+    it('MIT renders as aria-label="License: MIT" and visible License: MIT', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(html).toContain('aria-label="License: MIT"')
+      expect(html).toContain('License: <span class="font-medium">MIT</span>')
+    })
+
+    it('null license renders as License: Unknown', () => {
+      const html = renderSkillCard({
+        skill: { id: 'test', name: 'Test', license: null },
+        href: '/skills/test',
+      })
+      expect(html).toContain('aria-label="License: Unknown"')
+      expect(html).toContain('License: <span class="font-medium">Unknown</span>')
+    })
+
+    it('absent license renders as License: Unknown', () => {
+      const html = renderSkillCard({
+        skill: { id: 'test', name: 'Test' },
+        href: '/skills/test',
+      })
+      expect(html).toContain('aria-label="License: Unknown"')
+    })
+
+    it('whitespace-only license renders as License: Unknown', () => {
+      const html = renderSkillCard({
+        skill: { id: 'test', name: 'Test', license: '   ' },
+        href: '/skills/test',
+      })
+      expect(html).toContain('aria-label="License: Unknown"')
+    })
+
+    it('output never contains "freely usable" or "no restrictions" (SMI-5327)', () => {
+      const htmlNull = renderSkillCard({
+        skill: { id: 'test', name: 'Test', license: null },
+        href: '/skills/test',
+      })
+      const htmlAbsent = renderSkillCard({
+        skill: { id: 'test', name: 'Test' },
+        href: '/skills/test',
+      })
+      for (const html of [htmlNull, htmlAbsent]) {
+        expect(html).not.toContain('freely usable')
+        expect(html).not.toContain('no restrictions')
+      }
+    })
+  })
+
+  // ─── repo_url ─────────────────────────────────────────────────────────────────
+  describe('repo_url', () => {
+    it('View source row appears for https:// URL', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(html).toContain('View source')
+    })
+
+    it('View source row absent for http:// URL', () => {
+      const skill: WireSkill = { ...FULL_SKILL, repo_url: 'http://github.com/x/y' }
+      const html = renderSkillCard({ skill, href: FULL_HREF })
+      expect(html).not.toContain('View source')
+    })
+
+    it('View source row absent for git@ URL', () => {
+      const skill: WireSkill = { ...FULL_SKILL, repo_url: 'git@github.com:x/y.git' }
+      const html = renderSkillCard({ skill, href: FULL_HREF })
+      expect(html).not.toContain('View source')
+    })
+
+    it('View source row absent when repo_url is not provided', () => {
+      const html = renderSkillCard({
+        skill: { id: 'test', name: 'Test' },
+        href: '/skills/test',
+      })
+      expect(html).not.toContain('View source')
+    })
+  })
+
+  // ─── conditionals ─────────────────────────────────────────────────────────────
+  describe('conditionals', () => {
+    it('categories[0] is rendered when present', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(html).toContain('testing')
+    })
+
+    it('categories[0] is absent when categories array is empty', () => {
+      const skill: WireSkill = { ...FULL_SKILL, categories: [] }
+      const html = renderSkillCard({ skill, href: FULL_HREF })
+      // The category icon SVG path only appears when categories[0] is truthy
+      expect(html).not.toContain('M7 7h.01M7 3h5c')
+    })
+
+    it('version renders as vN.N.N when version is present', () => {
+      const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+      expect(html).toContain('v1.2.0')
+    })
+
+    it('version is absent when version is not provided', () => {
+      const html = renderSkillCard({
+        skill: { id: 'test', name: 'Test' },
+        href: '/skills/test',
+      })
+      expect(html).not.toContain('v1.2.0')
+    })
+  })
+
+  // ─── href + XSS ───────────────────────────────────────────────────────────────
+  describe('href and XSS', () => {
+    it('href is used verbatim — URL-encoded chars are preserved', () => {
+      const href = '/skills/' + encodeURIComponent('a/b c')
+      const html = renderSkillCard({ skill: { id: 'a/b c', name: 'Test' }, href })
+      expect(html).toContain(`href="${href}"`)
+    })
+
+    it('dangerous chars in name and author are HTML-escaped', () => {
+      const skill: WireSkill = {
+        id: 'test',
+        name: '<img src=x onerror=alert(1)>',
+        author: '"></a>',
+      }
+      const html = renderSkillCard({ skill, href: '/skills/test' })
+      // name: raw < must not appear; escaped &lt; must appear in its place
+      expect(html).not.toContain('<img src=x')
+      expect(html).toContain('&lt;img src=x')
+      // author: raw " must not appear as an attribute breakout sequence
+      expect(html).not.toContain('"></a>')
+    })
+  })
+})

--- a/packages/website/src/lib/skill-card.ts
+++ b/packages/website/src/lib/skill-card.ts
@@ -1,0 +1,172 @@
+/**
+ * Typed renderer for the skill card HTML fragment (SMI-5366 / GH #1377).
+ *
+ * Extracted verbatim from the inline createSkillCard() / createOrgMatchBadge() /
+ * createCompatibilityBadges() / createLicenseBadge() closures that lived in the
+ * skills/index.astro <script> block. Now bundler-visible and unit-tested
+ * (skill-card.test.ts pins the markup via an inline snapshot + assertion set;
+ * skill-card.parity.test.ts pins COMPAT_LABELS against the core contract).
+ *
+ * Browser/SSR-safe: escapeHtml is pure-string (no `document`). The caller builds
+ * `href` so the renderer stays URL-policy-agnostic.
+ */
+
+import type { WireSkill } from '../types/skills.js'
+import { getQualityTier, escapeHtml, formatNumber } from './skills-utils.js'
+import { licenseLabel } from './license-label.js'
+import { TRUST_TIER_BADGE_CLASSES, DEFAULT_TRUST_TIER } from '../constants/trust-tier-badges.js'
+
+export interface SkillCardProps {
+  skill: WireSkill
+  href: string
+}
+
+// SMI-5178: display labels for compatibility slugs. MIRRORS the canonical map in
+// @skillsmith/core (COMPATIBILITY_LABELS, compatibility/slugs.ts) — the website
+// client bundle cannot import core, so skill-card.parity.test.ts asserts these
+// stay in sync. Unknown slugs fall back to the raw (escaped) value.
+export const COMPAT_LABELS: Record<string, string> = {
+  'claude-code': 'Claude Code',
+  cursor: 'Cursor',
+  copilot: 'GitHub Copilot',
+  windsurf: 'Windsurf',
+  antigravity: 'Antigravity',
+  codex: 'Codex',
+  gemini: 'Gemini',
+}
+
+const MAX_VISIBLE = 4
+
+// SMI-5178: module-scope id sequence for "+N more" aria-controls wiring. The
+// module evaluates once, so the counter is monotonic across both grids and
+// across ClientRouter navigations — ids never collide or reset.
+let compatBadgeSeq = 0
+
+// SMI-4401 Wave 2 A-M9-2: render a "Matches your org" badge when signal-boost applies.
+function renderOrgMatchBadge(orgName: string | undefined): string {
+  if (!orgName) return ''
+  return `<span class="inline-flex items-center gap-1 px-2 py-0.5 mt-2 rounded-full text-xs font-medium bg-primary-500/10 text-primary-300 border border-primary-500/30" aria-label="Matches your org: ${escapeHtml(orgName)}">
+    <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M10 2a6 6 0 100 12 6 6 0 000-12zm0 2a4 4 0 110 8 4 4 0 010-8z"/></svg>
+    Matches your org: ${escapeHtml(orgName)}
+  </span>`
+}
+
+// SMI-5327: License badge. Null / absent / whitespace-only means "unknown / not
+// detected" — render as "License: Unknown". NEVER imply "no restrictions" or
+// "freely usable". Uses the canonical licenseLabel() (single source of truth).
+function renderLicenseBadge(license: string | null | undefined): string {
+  const label = escapeHtml(licenseLabel(license))
+  return `<div class="mt-2">
+    <span class="inline-flex items-center gap-1 text-xs text-dark-500" aria-label="License: ${label}">
+      <svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+      </svg>
+      <span>License: <span class="font-medium">${label}</span></span>
+    </span>
+  </div>`
+}
+
+// SMI-2760 / SMI-5178: compatibility badge row (max 4 visible; +N more expands,
+// keyboard-operable with aria-expanded/aria-controls). Renders display labels,
+// not raw slugs. `[]`/absent compatibility = no badges.
+function renderCompatibilityBadges(compatibility: string[] | undefined): string {
+  if (!Array.isArray(compatibility) || compatibility.length === 0) return ''
+
+  const visible = compatibility.slice(0, MAX_VISIBLE)
+  const extra = compatibility.slice(MAX_VISIBLE)
+
+  const badge = (tag: string): string => {
+    const label = COMPAT_LABELS[tag] || tag
+    return `<span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">${escapeHtml(label)}</span>`
+  }
+
+  const visibleHtml = visible.map(badge).join('')
+
+  if (extra.length === 0) {
+    return `<div class="mt-3 pt-3 border-t border-dark-800 flex flex-wrap gap-1">${visibleHtml}</div>`
+  }
+
+  const hiddenHtml = extra.map(badge).join('')
+  const extraId = `compat-extra-${++compatBadgeSeq}`
+
+  // Expand-only: on reveal, show the hidden badges, mark aria-expanded, and hide
+  // the toggle (no collapse) so aria-expanded never desyncs. The inline onclick
+  // keeps event.preventDefault()+stopPropagation() so the click never bubbles to
+  // the card <a> and navigates (SMI-3529 nested-interactive guard).
+  return `<div class="mt-3 pt-3 border-t border-dark-800 flex flex-wrap gap-1 items-center">
+    ${visibleHtml}
+    <span id="${extraId}" style="display:none">${hiddenHtml}</span>
+    <button
+      type="button"
+      class="px-1.5 py-0.5 rounded text-xs text-dark-400 hover:text-primary-400 transition-colors focus:outline-none focus:ring-1 focus:ring-primary-500"
+      aria-label="Show ${extra.length} more compatibility tags"
+      aria-expanded="false"
+      aria-controls="${extraId}"
+      onclick="event.preventDefault(); event.stopPropagation(); document.getElementById('${extraId}').style.display='contents'; this.setAttribute('aria-expanded','true'); this.style.display='none';"
+    >+${extra.length} more</button>
+  </div>`
+}
+
+/**
+ * Render the full skill card HTML fragment. `href` is supplied by the caller
+ * (e.g. `/skills/${encodeURIComponent(skill.id)}`).
+ */
+export function renderSkillCard({ skill, href }: SkillCardProps): string {
+  // SMI-5365: preserve the original runtime fallback — an absent OR runtime-unknown
+  // trust_tier degrades to the default tier's class, never an undefined fragment.
+  const trustClass =
+    TRUST_TIER_BADGE_CLASSES[skill.trust_tier ?? DEFAULT_TRUST_TIER] ??
+    TRUST_TIER_BADGE_CLASSES[DEFAULT_TRUST_TIER]
+  const stars = skill.stars ?? 0
+  const tier = getQualityTier(stars)
+  const ariaLabel = `${tier.label}: ${formatNumber(stars)} stars`
+  const orgMatchBadge = renderOrgMatchBadge(skill._orgMatch)
+
+  return `
+        <a href="${href}" class="card-hover block bg-dark-900 rounded-xl border border-dark-800 p-6 hover:border-primary-500/50">
+          <div class="flex items-start justify-between mb-4">
+            <div class="flex-1 min-w-0">
+              <h3 class="text-lg font-semibold text-white truncate">${escapeHtml(skill.name)}</h3>
+              <p class="text-dark-500 text-sm">${escapeHtml(skill.author || 'Unknown author')}</p>
+              ${orgMatchBadge}
+            </div>
+            <span class="ml-4 px-2.5 py-1 text-xs font-medium rounded-full border ${trustClass}">
+              ${escapeHtml(skill.trust_tier || DEFAULT_TRUST_TIER)}
+            </span>
+          </div>
+          <p class="text-dark-400 text-sm mb-4 line-clamp-2">${escapeHtml(skill.description || 'No description available')}</p>
+          <div class="flex items-center justify-between text-sm">
+            <div class="flex items-center space-x-4">
+              ${
+                skill.categories?.[0]
+                  ? `
+                <span class="text-dark-500">
+                  <svg class="w-4 h-4 inline-block mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+                  </svg>
+                  ${escapeHtml(skill.categories[0])}
+                </span>
+              `
+                  : ''
+              }
+              ${skill.version ? `<span class="text-dark-500">v${escapeHtml(skill.version)}</span>` : ''}
+            </div>
+            <span class="${tier.color} text-lg" role="img" aria-label="${ariaLabel}" title="${ariaLabel}">●<span class="sr-only">${ariaLabel}</span></span>
+          </div>
+          ${
+            skill.repo_url && skill.repo_url.startsWith('https://')
+              ? `<div class="mt-3 pt-3 border-t border-dark-800">
+              <span class="inline-flex items-center gap-1 text-xs text-dark-500">
+                <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+                </svg>
+                View source
+              </span>
+            </div>`
+              : ''
+          }
+          ${renderCompatibilityBadges(skill.compatibility)}
+          ${renderLicenseBadge(skill.license)}
+        </a>
+      `
+}

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -398,12 +398,10 @@ const isCrawler = isCrawlerUserAgent(userAgent)
     // helpers. Data that used to arrive via define:vars now comes from direct imports
     // + import.meta.env (Vite-substituted at build) + the #featured-skills-grid
     // data-attribute. SMI-4907 tracked this migration for index.astro.
-    import {
-      TRUST_TIER_BADGE_CLASSES as trustBadgeClasses,
-      DEFAULT_TRUST_TIER as defaultTrustTier,
-    } from '../../constants/trust-tier-badges'
     import { getSupabaseClient } from '../../lib/supabase-client'
-    import { getQualityTier, escapeHtml, formatNumber } from '../../lib/skills-utils.js'
+    // SMI-5366: the card renderer + its helpers now live in the bundler-visible,
+    // unit-tested skill-card.ts module (GH #1377). The page just supplies the href.
+    import { renderSkillCard } from '../../lib/skill-card.js'
     import type { WireSkill } from '../../types/skills.js'
 
     // SMI-5365: reconstruct the edge-function base in-script. import.meta.env
@@ -516,155 +514,6 @@ const isCrawler = isCrawlerUserAgent(userAgent)
       const retryButton = document.getElementById('retry-button') as HTMLButtonElement
       const searchPromptState = document.getElementById('search-prompt-state') as HTMLElement
       const searchSuggestions = document.querySelectorAll<HTMLButtonElement>('.search-suggestion')
-
-      // SMI-5217 / SMI-5365: trustBadgeClasses + defaultTrustTier imported above
-      // from the shared 5-tier map (constants/trust-tier-badges.ts).
-      // getQualityTier, escapeHtml, formatNumber imported from lib/skills-utils.js (SMI-5366).
-
-      // SMI-4401 Wave 2 A-M9-2: render a "Matches your org" badge when signal-boost applies.
-      function createOrgMatchBadge(orgName: string | undefined) {
-        if (!orgName) return ''
-        return `<span class="inline-flex items-center gap-1 px-2 py-0.5 mt-2 rounded-full text-xs font-medium bg-primary-500/10 text-primary-300 border border-primary-500/30" aria-label="Matches your org: ${escapeHtml(orgName)}">
-          <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M10 2a6 6 0 100 12 6 6 0 000-12zm0 2a4 4 0 110 8 4 4 0 010-8z"/></svg>
-          Matches your org: ${escapeHtml(orgName)}
-        </span>`
-      }
-
-      // Create skill card HTML
-      function createSkillCard(skill: WireSkill) {
-        // SMI-5365: preserve the original runtime fallback — an absent OR
-        // runtime-unknown trust_tier (legacy experimental/unknown the API
-        // shouldn't emit, but defend anyway) degrades to the default tier's
-        // class rather than rendering an `undefined` class fragment.
-        const trustClass =
-          trustBadgeClasses[skill.trust_tier ?? defaultTrustTier] ??
-          trustBadgeClasses[defaultTrustTier]
-        const stars = skill.stars ?? 0
-        const tier = getQualityTier(stars)
-        const ariaLabel = `${tier.label}: ${formatNumber(stars)} stars`
-        const orgMatchBadge = createOrgMatchBadge(skill._orgMatch)
-
-        return `
-        <a href="/skills/${encodeURIComponent(skill.id)}" class="card-hover block bg-dark-900 rounded-xl border border-dark-800 p-6 hover:border-primary-500/50">
-          <div class="flex items-start justify-between mb-4">
-            <div class="flex-1 min-w-0">
-              <h3 class="text-lg font-semibold text-white truncate">${escapeHtml(skill.name)}</h3>
-              <p class="text-dark-500 text-sm">${escapeHtml(skill.author || 'Unknown author')}</p>
-              ${orgMatchBadge}
-            </div>
-            <span class="ml-4 px-2.5 py-1 text-xs font-medium rounded-full border ${trustClass}">
-              ${escapeHtml(skill.trust_tier || defaultTrustTier)}
-            </span>
-          </div>
-          <p class="text-dark-400 text-sm mb-4 line-clamp-2">${escapeHtml(skill.description || 'No description available')}</p>
-          <div class="flex items-center justify-between text-sm">
-            <div class="flex items-center space-x-4">
-              ${
-                skill.categories?.[0]
-                  ? `
-                <span class="text-dark-500">
-                  <svg class="w-4 h-4 inline-block mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-                  </svg>
-                  ${escapeHtml(skill.categories[0])}
-                </span>
-              `
-                  : ''
-              }
-              ${skill.version ? `<span class="text-dark-500">v${escapeHtml(skill.version)}</span>` : ''}
-            </div>
-            <span class="${tier.color} text-lg" role="img" aria-label="${ariaLabel}" title="${ariaLabel}">●<span class="sr-only">${ariaLabel}</span></span>
-          </div>
-          ${
-            skill.repo_url && skill.repo_url.startsWith('https://')
-              ? `<div class="mt-3 pt-3 border-t border-dark-800">
-              <span class="inline-flex items-center gap-1 text-xs text-dark-500">
-                <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-                </svg>
-                View source
-              </span>
-            </div>`
-              : ''
-          }
-          ${createCompatibilityBadges(skill.compatibility)}
-          ${createLicenseBadge(skill.license)}
-        </a>
-      `
-      }
-
-      // SMI-5327: License badge. Null / absent / whitespace-only means "unknown / not detected" —
-      // render as "License: Unknown". NEVER imply "no restrictions" or "freely usable".
-      // MIRRORS licenseLabel() in src/lib/license-label.ts (SMI-5327) — keep in sync.
-      function createLicenseBadge(license: string | null | undefined) {
-        const trimmed = license?.trim()
-        const label = trimmed ? escapeHtml(trimmed) : 'Unknown'
-        return `<div class="mt-2">
-          <span class="inline-flex items-center gap-1 text-xs text-dark-500" aria-label="License: ${label}">
-            <svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-            </svg>
-            <span>License: <span class="font-medium">${label}</span></span>
-          </span>
-        </div>`
-      }
-
-      // SMI-5178: display labels for compatibility slugs. MIRRORS the canonical
-      // map in @skillsmith/core (COMPATIBILITY_LABELS, compatibility/slugs.ts) —
-      // the website client bundle cannot import core, so a parity test asserts
-      // these stay in sync. Unknown slugs fall back to the raw (escaped) value.
-      const COMPAT_LABELS: Record<string, string> = {
-        'claude-code': 'Claude Code',
-        cursor: 'Cursor',
-        copilot: 'GitHub Copilot',
-        windsurf: 'Windsurf',
-        antigravity: 'Antigravity',
-        codex: 'Codex',
-        gemini: 'Gemini',
-      }
-
-      // SMI-5178: unique id sequence for "+N more" aria-controls wiring.
-      let compatBadgeSeq = 0
-
-      // SMI-2760 / SMI-5178: compatibility badge row (max 4 visible; +N more
-      // expands, keyboard-operable with aria-expanded/aria-controls). Renders
-      // display labels, not raw slugs. `[]`/absent compatibility = no badges.
-      function createCompatibilityBadges(compatibility: string[] | undefined) {
-        if (!Array.isArray(compatibility) || compatibility.length === 0) return ''
-
-        const MAX_VISIBLE = 4
-        const visible = compatibility.slice(0, MAX_VISIBLE)
-        const extra = compatibility.slice(MAX_VISIBLE)
-
-        const badge = (tag: string) => {
-          const label = COMPAT_LABELS[tag] || tag
-          return `<span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">${escapeHtml(label)}</span>`
-        }
-
-        const visibleHtml = visible.map(badge).join('')
-
-        if (extra.length === 0) {
-          return `<div class="mt-3 pt-3 border-t border-dark-800 flex flex-wrap gap-1">${visibleHtml}</div>`
-        }
-
-        const hiddenHtml = extra.map(badge).join('')
-        const extraId = `compat-extra-${++compatBadgeSeq}`
-
-        // Expand-only: on reveal, show the hidden badges, mark aria-expanded, and
-        // hide the toggle (no collapse) so aria-expanded never desyncs.
-        return `<div class="mt-3 pt-3 border-t border-dark-800 flex flex-wrap gap-1 items-center">
-          ${visibleHtml}
-          <span id="${extraId}" style="display:none">${hiddenHtml}</span>
-          <button
-            type="button"
-            class="px-1.5 py-0.5 rounded text-xs text-dark-400 hover:text-primary-400 transition-colors focus:outline-none focus:ring-1 focus:ring-primary-500"
-            aria-label="Show ${extra.length} more compatibility tags"
-            aria-expanded="false"
-            aria-controls="${extraId}"
-            onclick="event.preventDefault(); event.stopPropagation(); document.getElementById('${extraId}').style.display='contents'; this.setAttribute('aria-expanded','true'); this.style.display='none';"
-          >+${extra.length} more</button>
-        </div>`
-      }
 
       // Show/hide states
       function showState(state: 'loading' | 'empty' | 'error' | 'results' | 'search-prompt') {
@@ -928,7 +777,9 @@ const isCrawler = isCrawlerUserAgent(userAgent)
         const endIdx = startIdx + ITEMS_PER_PAGE
         const pageResults = allResults.slice(startIdx, endIdx)
 
-        resultsGrid.innerHTML = pageResults.map(createSkillCard).join('')
+        resultsGrid.innerHTML = pageResults
+          .map((s) => renderSkillCard({ skill: s, href: `/skills/${encodeURIComponent(s.id)}` }))
+          .join('')
         resultsCount.textContent = `Showing ${startIdx + 1}-${Math.min(endIdx, allResults.length)} of ${allResults.length} skills`
 
         // Update pagination
@@ -1017,7 +868,9 @@ const isCrawler = isCrawlerUserAgent(userAgent)
           )
           const skills = results.filter((s) => s && s.id)
           if (skills.length === 0) return
-          grid.innerHTML = skills.map(createSkillCard).join('')
+          grid.innerHTML = skills
+            .map((s) => renderSkillCard({ skill: s, href: `/skills/${encodeURIComponent(s.id)}` }))
+            .join('')
         } catch (e) {
           console.debug('[Skills] featured-skills load failed:', (e as Error)?.message)
         }

--- a/packages/website/tests/e2e/skills-filter.spec.ts
+++ b/packages/website/tests/e2e/skills-filter.spec.ts
@@ -284,4 +284,43 @@ test.describe('Skills Filter-Only Browsing (SMI-1658)', () => {
       await verifyResultsDisplayed(page)
     })
   })
+
+  // SMI-5366 (GH #1377): the card markup now comes from the extracted
+  // renderSkillCard() module. These assert the rendered output in a real
+  // browser (the unit tests pin the string; these prove it mounts + behaves).
+  test.describe('SkillCard renderer (SMI-5366)', () => {
+    test('rendered cards expose the quality dot and license row', async ({ page }) => {
+      await page.locator('#category-filter').selectOption('development')
+      await waitForResults(page)
+
+      const firstCard = page.locator('#results-grid a').first()
+      await expect(firstCard).toBeVisible()
+      // renderSkillCard always emits a quality dot (role="img") and a license row.
+      await expect(firstCard.locator('[role="img"]')).toBeVisible()
+      await expect(firstCard.getByText('License:')).toBeVisible()
+    })
+
+    test('"+N more" compatibility toggle expands without navigating away (SMI-3529)', async ({
+      page,
+    }) => {
+      await page.locator('#category-filter').selectOption('development')
+      await waitForResults(page)
+
+      // The toggle only appears for skills with >4 compatibility tags; skip if
+      // none are on this page rather than flake on data shape.
+      const moreBtn = page.locator('#results-grid button', { hasText: /\+\d+ more/ }).first()
+      test.skip((await moreBtn.count()) === 0, 'no card with >4 compatibility tags on this page')
+
+      const urlBefore = page.url()
+      const controls = await moreBtn.getAttribute('aria-controls')
+      await moreBtn.click()
+
+      // The click must NOT bubble to the card <a> and navigate to the detail page.
+      await expect(page).toHaveURL(urlBefore)
+      await expect(moreBtn).toHaveAttribute('aria-expanded', 'true')
+      if (controls) {
+        await expect(page.locator(`#${controls}`)).toBeVisible()
+      }
+    })
+  })
 })

--- a/scripts/smoke-prod/surfaces.json
+++ b/scripts/smoke-prod/surfaces.json
@@ -163,6 +163,17 @@
         "check_website_docs_vscode_extension_renders",
         "check_website_docs_authoring_redirect"
       ]
+    },
+    {
+      "id": "website-skills-page",
+      "owner": "website",
+      "trigger_globs": [
+        "packages/website/src/pages/skills/index.astro",
+        "packages/website/src/lib/skill-card.ts",
+        "packages/website/src/lib/skills-utils.ts"
+      ],
+      "script": "scripts/smoke-prod/website.sh",
+      "checks": ["check_skills_page_renders", "check_skills_search_edge_fn"]
     }
   ]
 }

--- a/scripts/smoke-prod/website.sh
+++ b/scripts/smoke-prod/website.sh
@@ -763,3 +763,69 @@ check_website_docs_authoring_redirect() {
   report_fail "website-docs-tutorials" "check_website_docs_authoring_redirect" "$url" "3xx-redirect" "$status" "$ms"
   return 1
 }
+
+# ---- check_skills_page_renders ----------------------------------------
+# SMI-5366: Verifies /skills renders the SSR shell with the search input and
+# featured-skills grid markup. The card grid is client-rendered so we assert
+# only the server-rendered structural IDs, not card content.
+check_skills_page_renders() {
+  local url="${SMOKE_WEBSITE_URL}/skills"
+  local t0 t1 ms resp status body
+  t0=$(now_ms)
+  resp=$(with_retry http_body GET "$url") || true
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  status=$(printf '%s' "$resp" | head -n1)
+  body=$(printf '%s' "$resp" | tail -n +2)
+
+  if [ "$status" != "200" ]; then
+    report_fail "website-skills-page" "check_skills_page_renders" "$url" "200" "$status" "$ms"
+    return 1
+  fi
+  if ! assert_contains "$body" 'id="featured-skills-grid"' "skills-page-grid"; then
+    report_fail "website-skills-page" "check_skills_page_renders" "$url" 'id="featured-skills-grid"' "missing-fingerprint" "$ms"
+    return 1
+  fi
+  if ! assert_contains "$body" 'id="search-input"' "skills-page-search"; then
+    report_fail "website-skills-page" "check_skills_page_renders" "$url" 'id="search-input"' "missing-fingerprint" "$ms"
+    return 1
+  fi
+  report_pass "website-skills-page" "check_skills_page_renders" "$url" "$ms"
+  return 0
+}
+
+# ---- check_skills_search_edge_fn --------------------------------------
+# SMI-5366: GET skills-search with no auth (no-verify-jwt trial tier). 200 +
+# JSON body containing "id" confirms the function is deployed and routing
+# correctly. 429 (trial rate-limit) is a soft pass — rate-limiting proves the
+# function is alive and enforcing quotas, not absent or broken.
+check_skills_search_edge_fn() {
+  _require_supabase_url || { report_fail "website-skills-page" "check_skills_search_edge_fn" "" "SUPABASE_URL" "unset"; return 1; }
+  local url="${SMOKE_SUPABASE_URL}/functions/v1/skills-search?limit=1"
+  local t0 t1 ms resp status body
+  t0=$(now_ms)
+  resp=$(with_retry http_body GET "$url") || true
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  status=$(printf '%s' "$resp" | head -n1)
+  body=$(printf '%s' "$resp" | tail -n +2)
+
+  case "$status" in
+    429)
+      smoke_warn "check_skills_search_edge_fn: rate-limited (429) -- soft pass"
+      report_pass "website-skills-page" "check_skills_search_edge_fn" "$url" "$ms"
+      return 0
+      ;;
+    200) ;;
+    *)
+      report_fail "website-skills-page" "check_skills_search_edge_fn" "$url" "200" "$status" "$ms"
+      return 1
+      ;;
+  esac
+  if ! assert_contains "$body" '"id"' "skills-search-json"; then
+    report_fail "website-skills-page" "check_skills_search_edge_fn" "$url" '"id" in JSON' "missing-or-empty" "$ms"
+    return 1
+  fi
+  report_pass "website-skills-page" "check_skills_search_edge_fn" "$url" "$ms"
+  return 0
+}

--- a/scripts/tests/indexer/compatibility-slug-parity.test.ts
+++ b/scripts/tests/indexer/compatibility-slug-parity.test.ts
@@ -4,8 +4,8 @@
  * Three surfaces must agree on the slug set:
  *  1. the indexer matrix (scripts/indexer/compatibility-map.ts) — derives slugs from skill_path
  *  2. @skillsmith/core (compatibility/slugs.ts) — the canonical filterable list + labels (MCP)
- *  3. the website badge renderer (skills/index.astro) — mirrors the labels (client bundle
- *     cannot import core)
+ *  3. the website badge renderer (lib/skill-card.ts) — mirrors the labels (client bundle
+ *     cannot import core; extracted from skills/index.astro in SMI-5366)
  *
  * This test fails if a slug is added to the matrix but not the canonical list, or if the
  * website label map drifts from core.
@@ -40,14 +40,16 @@ describe('compatibility slug parity (SMI-5178)', () => {
   })
 
   it('the website badge renderer mirrors every core slug + label', () => {
-    const astro = readFileSync(
-      resolve(repoRoot, 'packages/website/src/pages/skills/index.astro'),
+    // SMI-5366: COMPAT_LABELS was extracted from skills/index.astro into the
+    // typed renderer module lib/skill-card.ts.
+    const renderer = readFileSync(
+      resolve(repoRoot, 'packages/website/src/lib/skill-card.ts'),
       'utf8'
     )
     for (const slug of COMPATIBILITY_SLUGS) {
-      expect(astro, `website COMPAT_LABELS missing slug "${slug}"`).toContain(slug)
+      expect(renderer, `website COMPAT_LABELS missing slug "${slug}"`).toContain(slug)
       expect(
-        astro,
+        renderer,
         `website COMPAT_LABELS missing label "${COMPATIBILITY_LABELS[slug]}"`
       ).toContain(COMPATIBILITY_LABELS[slug])
     }


### PR DESCRIPTION
## Summary

Wave B of the SkillCard renderer extraction — **Closes #1377**. Lifts the 4 inline card closures out of `skills/index.astro` into a bundler-visible, unit-tested `lib/skill-card.ts` renderer module.

**Stacked on Wave A (#1552 / SMI-5365).** Base of this PR is `fix/smi-5365-skills-index-bundled-migration`; per SMI-2597, Wave A merges first (then this retargets to `main`). Linear: **SMI-5366**.

## What changed

- **`lib/skill-card.ts`** — `renderSkillCard({ skill, href }): string`, `COMPAT_LABELS`, `SkillCardProps`, with private `renderOrgMatchBadge` / `renderCompatibilityBadges` / `renderLicenseBadge`. The caller supplies `href`, so the renderer is URL-policy-agnostic.
  - **Re-adds the SMI-5327 license badge** (via the canonical `licenseLabel()`) that the stale PR #1406 omitted — porting #1406 as-is would have regressed it.
  - Keeps the `+N more` inline `onclick` with `event.preventDefault()` + `event.stopPropagation()` verbatim (SMI-3529 nested-button-in-anchor no-navigate guard).
- **`index.astro`** imports `renderSkillCard`, deletes the 4 closures + `COMPAT_LABELS` + `compatBadgeSeq`, rewires both grids' call sites (`href = /skills/${encodeURIComponent(id)}`).
- **Tests (the real gate, node env):** `skill-card.test.ts` (34 — inline snapshot + trust-badge fallback, quality dot, org badge, compat display-labels/max-4/`+N more` ARIA + preventDefault/stopPropagation + monotonic non-resetting ids, license `Unknown`/never-"freely usable", repo_url https gate, href encoding, XSS); `skill-card.parity.test.ts` (COMPAT_LABELS vs the documented core contract — website can't import `@skillsmith/core` at runtime). Repoints the existing `compatibility-slug-parity.test.ts` at the new location.
- **Prod gate:** registers a `website-skills-page` smoke surface (`/skills` renders + `skills-search` edge fn, 429 trial soft-pass).
- **Staging E2E:** extends `skills-filter.spec.ts` with renderer assertions including the `+N more` **expands-without-navigating** test.

## Verification

- `astro check` **0/0/0**; **362 website tests** + root parity tests pass
- `concurrency-auditor` Mode B clean; `audit:standards` 0 failures; prettier/lint clean
- `index.astro` shrinks by ~150 lines (closures removed)

## Notes

- `skills/[id].astro` deliberately stays inline (SMI-4907 remains open for it).
- Three a11y/CSP follow-ups (expand-only focus, `<button>`-in-`<a>` validity, inline-onclick vs strict CSP) are filed as separate Linear issues — out of scope for a faithful refactor.

Plan: `docs/internal/implementation/website-skill-card-renderer-extraction.md` (docs PR smith-horn/skillsmith-docs#266).
