### PR TITLE
fix(smoke-prod): soft-pass structured trial-exhausted 401 in skills-search check (SMI-5370)

### DIFF
--- a/scripts/smoke-prod/website.sh
+++ b/scripts/smoke-prod/website.sh
@@ -797,8 +797,15 @@ check_skills_page_renders() {
 # ---- check_skills_search_edge_fn --------------------------------------
 # SMI-5366: GET skills-search with no auth (no-verify-jwt trial tier). 200 +
 # JSON body containing "id" confirms the function is deployed and routing
-# correctly. 429 (trial rate-limit) is a soft pass — rate-limiting proves the
-# function is alive and enforcing quotas, not absent or broken.
+# correctly. Soft passes (function alive + enforcing policy, not absent/broken):
+#   - 429: trial rate-limit hit.
+#   - 401 WITH the app's structured trial/auth JSON ("signupUrl" / "trialUsed" /
+#     "Free trial"): the anonymous free-trial quota is exhausted. That structured
+#     body proves skills-search itself answered -- a missing/crashed function or a
+#     gateway reject returns 404/502/000 or a bare non-app 401. (SMI-5370: without
+#     this arm the check false-fails whenever the shared/per-IP trial is spent,
+#     paging support@ on a healthy function.)
+# A bare/gateway 401 (no app signature) is still a hard fail.
 check_skills_search_edge_fn() {
   _require_supabase_url || { report_fail "website-skills-page" "check_skills_search_edge_fn" "" "SUPABASE_URL" "unset"; return 1; }
   local url="${SMOKE_SUPABASE_URL}/functions/v1/skills-search?limit=1"
@@ -815,6 +822,16 @@ check_skills_search_edge_fn() {
       smoke_warn "check_skills_search_edge_fn: rate-limited (429) -- soft pass"
       report_pass "website-skills-page" "check_skills_search_edge_fn" "$url" "$ms"
       return 0
+      ;;
+    401)
+      # SMI-5370: a structured trial-exhausted 401 == function alive (see header).
+      if printf '%s' "$body" | grep -Eq '"signupUrl"|"trialUsed"|Free trial'; then
+        smoke_warn "check_skills_search_edge_fn: trial-exhausted 401 (structured) -- soft pass"
+        report_pass "website-skills-page" "check_skills_search_edge_fn" "$url" "$ms"
+        return 0
+      fi
+      report_fail "website-skills-page" "check_skills_search_edge_fn" "$url" "200|429|structured-401" "401-bare" "$ms"
+      return 1
       ;;
     200) ;;
     *)

--- a/scripts/smoke-prod/website.sh
+++ b/scripts/smoke-prod/website.sh
@@ -795,20 +795,30 @@ check_skills_page_renders() {
 }
 
 # ---- check_skills_search_edge_fn --------------------------------------
-# SMI-5366: GET skills-search with no auth (no-verify-jwt trial tier). 200 +
-# JSON body containing "id" confirms the function is deployed and routing
-# correctly. Soft passes (function alive + enforcing policy, not absent/broken):
+# SMI-5366 / SMI-5370: GET skills-search unauthenticated (no-verify-jwt trial
+# tier) and confirm the function is deployed + routing.
+#
+# The request MUST carry a query or a filter: skills-search validates "query OR
+# at least one filter (category/trust_tier/min_score)" *after* the auth gate and
+# returns 400 otherwise. A bare ?limit=1 therefore 400s on a fresh trial (the
+# real prod failure observed on 23b9c73f), so we send ?category=testing&limit=1
+# (mirrors the authenticated check_skills_search_usage_counter URL). 200 then
+# returns the success envelope {"data":[...],"meta":{...}}; we assert "meta"
+# rather than "id" because "id" only appears when >=1 result is present and a
+# filter can legitimately be empty.
+#
+# Soft passes (function alive + enforcing policy, not absent/broken):
 #   - 429: trial rate-limit hit.
 #   - 401 WITH the app's structured trial/auth JSON ("signupUrl" / "trialUsed" /
 #     "Free trial"): the anonymous free-trial quota is exhausted. That structured
 #     body proves skills-search itself answered -- a missing/crashed function or a
-#     gateway reject returns 404/502/000 or a bare non-app 401. (SMI-5370: without
-#     this arm the check false-fails whenever the shared/per-IP trial is spent,
-#     paging support@ on a healthy function.)
-# A bare/gateway 401 (no app signature) is still a hard fail.
+#     gateway reject returns 404/502/000 or a bare non-app 401. (Without this arm
+#     the check false-fails whenever the shared/per-IP trial is spent, paging
+#     support@ on a healthy function.)
+# A bare/gateway 401 (no app signature), a 400, or any 4xx/5xx else is a hard fail.
 check_skills_search_edge_fn() {
   _require_supabase_url || { report_fail "website-skills-page" "check_skills_search_edge_fn" "" "SUPABASE_URL" "unset"; return 1; }
-  local url="${SMOKE_SUPABASE_URL}/functions/v1/skills-search?limit=1"
+  local url="${SMOKE_SUPABASE_URL}/functions/v1/skills-search?category=testing&limit=1"
   local t0 t1 ms resp status body
   t0=$(now_ms)
   resp=$(with_retry http_body GET "$url") || true
@@ -839,8 +849,10 @@ check_skills_search_edge_fn() {
       return 1
       ;;
   esac
-  if ! assert_contains "$body" '"id"' "skills-search-json"; then
-    report_fail "website-skills-page" "check_skills_search_edge_fn" "$url" '"id" in JSON' "missing-or-empty" "$ms"
+  # On 200, assert the search success envelope (always present, result-count
+  # independent) rather than "id" (only present when >=1 result).
+  if ! assert_contains "$body" '"meta"' "skills-search-json"; then
+    report_fail "website-skills-page" "check_skills_search_edge_fn" "$url" '"meta" in JSON' "missing-or-empty" "$ms"
     return 1
   fi
   report_pass "website-skills-page" "check_skills_search_edge_fn" "$url" "$ms"


### PR DESCRIPTION
## Summary

Hotfix for a false-positive in the `website-skills-page` smoke surface added by SMI-5366 (Wave B, PR #1553). **Confirmed against the live 23b9c73f prod-smoke failure** (`check_skills_page_renders` PASS — the `/skills` page renders fine; `check_skills_search_edge_fn` FAIL, expected=200 **actual=400**).

### Root cause (two layers)
`check_skills_search_edge_fn` called prod `skills-search` with a bare `?limit=1`. But `skills-search` validates "**query OR at least one filter** (category/trust_tier/min_score)" *after* the auth gate, returning **400** when neither is present. So:
- fresh trial + no filter → **400** (the CI-runner failure)
- exhausted trial → **401** with structured trial JSON (a warm/shared CI IP, or my earlier local repro)
- fresh trial + filter → **200**

The check only soft-passed `429` and hard-failed everything else → it `report_fail`'d on the 400/401, paging `support@smithhorn.ca` on a perfectly healthy function.

### Fix
- Send `?category=testing&limit=1` (mirrors the authenticated `check_skills_search_usage_counter` URL) so a fresh trial reaches **200** instead of 400.
- On 200, assert the success envelope `"meta"` (always present) instead of `"id"` (only present when ≥1 result; a filter can legitimately be empty).
- Soft-pass `429` (rate limit) and a **structured** `401` (trial-exhausted JSON: `signupUrl`/`trialUsed`/`Free trial`) — both prove the function is alive and enforcing policy.
- `400`, a bare/gateway `401`, and any other 4xx/5xx stay **hard fails** (real contract/availability break).

Verified against `supabase/functions/skills-search/index.ts` (`:88-94` validation, `:451` `{data,meta}` envelope) and the live failure log. `bash -n` clean; assertion logic unit-checked against real 200/400 bodies.

### Scope & re-validation
- `scripts/smoke-prod/website.sh` only. `website.sh` is in no surface's `trigger_globs`, so merging this PR does not itself re-run the website surface — the next merge that touches `skill-card.ts` (PR #1556) will, and by then this fix is on `main`, clearing the alert.

## ADR-109 note
Corrective false-positive hotfix to one smoke check; CI validates on this branch PR.

Closes SMI-5370.

[skip-impl-check]