### PR TITLE
fix(website): pluralize +N more aria-label + harden compat snapshot id (SMI-5371)

### DIFF
--- a/packages/website/src/lib/skill-card.test.ts
+++ b/packages/website/src/lib/skill-card.test.ts
@@ -43,7 +43,14 @@ describe('renderSkillCard', () => {
   // Regenerate by running vitest with the -u flag (see file header).
   // Review the generated diff before committing — reject garbage output.
   it('renders a fully-populated skill card (inline snapshot)', () => {
-    const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
+    // SMI-5371: normalize the compat-extra-N id so this snapshot is independent
+    // of the module-scope compatBadgeSeq counter (no test-ordering fragility).
+    // The real id wiring (aria-controls === hidden-span id, monotonic increment)
+    // is covered by the aria-controls + monotonic-id tests further down.
+    const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF }).replace(
+      /compat-extra-\d+/g,
+      'compat-extra-N'
+    )
     expect(html).toMatchInlineSnapshot(`
       "
               <a href="/skills/acme%2Ftest-runner" class="card-hover block bg-dark-900 rounded-xl border border-dark-800 p-6 hover:border-primary-500/50">
@@ -85,14 +92,14 @@ describe('renderSkillCard', () => {
                   </div>
                 <div class="mt-3 pt-3 border-t border-dark-800 flex flex-wrap gap-1 items-center">
           <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">Claude Code</span><span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">Cursor</span><span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">GitHub Copilot</span><span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">Windsurf</span>
-          <span id="compat-extra-1" style="display:none"><span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">Codex</span></span>
+          <span id="compat-extra-N" style="display:none"><span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-primary-500/10 text-primary-400 border border-primary-500/20">Codex</span></span>
           <button
             type="button"
             class="px-1.5 py-0.5 rounded text-xs text-dark-400 hover:text-primary-400 transition-colors focus:outline-none focus:ring-1 focus:ring-primary-500"
-            aria-label="Show 1 more compatibility tags"
+            aria-label="Show 1 more compatibility tag"
             aria-expanded="false"
-            aria-controls="compat-extra-1"
-            onclick="event.preventDefault(); event.stopPropagation(); document.getElementById('compat-extra-1').style.display='contents'; this.setAttribute('aria-expanded','true'); this.style.display='none';"
+            aria-controls="compat-extra-N"
+            onclick="event.preventDefault(); event.stopPropagation(); document.getElementById('compat-extra-N').style.display='contents'; this.setAttribute('aria-expanded','true'); this.style.display='none';"
           >+1 more</button>
         </div>
                 <div class="mt-2">
@@ -216,10 +223,22 @@ describe('renderSkillCard', () => {
       expect(html).toContain(`id="${extraId}"`)
     })
 
-    it('with >4 items, +N more button has aria-expanded="false" and correct aria-label', () => {
+    it('with exactly one hidden item, +N more uses aria-expanded="false" and a singular aria-label', () => {
+      // FULL_SKILL has 5 compat tags -> 1 hidden -> singular "tag" (SMI-5371).
       const html = renderSkillCard({ skill: FULL_SKILL, href: FULL_HREF })
       expect(html).toContain('aria-expanded="false"')
-      expect(html).toContain('aria-label="Show 1 more compatibility tags"')
+      expect(html).toContain('aria-label="Show 1 more compatibility tag"')
+      expect(html).not.toContain('Show 1 more compatibility tags')
+    })
+
+    it('pluralizes the +N more aria-label when more than one item is hidden (SMI-5371)', () => {
+      const skill: WireSkill = {
+        ...FULL_SKILL,
+        compatibility: ['claude-code', 'cursor', 'copilot', 'windsurf', 'codex', 'gemini'],
+      }
+      const html = renderSkillCard({ skill, href: FULL_HREF })
+      // 6 tags -> 2 hidden -> plural "tags".
+      expect(html).toContain('aria-label="Show 2 more compatibility tags"')
     })
 
     it('onclick contains event.preventDefault() and event.stopPropagation() (SMI-3529 nested-button-in-anchor guard)', () => {

--- a/packages/website/src/lib/skill-card.ts
+++ b/packages/website/src/lib/skill-card.ts
@@ -99,7 +99,7 @@ function renderCompatibilityBadges(compatibility: string[] | undefined): string 
     <button
       type="button"
       class="px-1.5 py-0.5 rounded text-xs text-dark-400 hover:text-primary-400 transition-colors focus:outline-none focus:ring-1 focus:ring-primary-500"
-      aria-label="Show ${extra.length} more compatibility tags"
+      aria-label="Show ${extra.length} more compatibility tag${extra.length === 1 ? '' : 's'}"
       aria-expanded="false"
       aria-controls="${extraId}"
       onclick="event.preventDefault(); event.stopPropagation(); document.getElementById('${extraId}').style.display='contents'; this.setAttribute('aria-expanded','true'); this.style.display='none';"


### PR DESCRIPTION
## Summary

Resolves the two Low findings from the post-merge governance retro on Wave B (SMI-5366, GH #1377). All Wave B critical invariants (XSS, SMI-3529 nested-button guard, trust-tier fallback, COMPAT_LABELS parity, P-5 concurrency, license badge) passed — these are the remaining polish items.

### Low-1 — a11y (real correctness bug)
`renderCompatibilityBadges` emitted `aria-label="Show ${extra.length} more compatibility tags"` unconditionally, so a screen reader announced the grammatically wrong **"Show 1 more compatibility tags"** when exactly one tag is hidden. Now pluralizes the noun: `tag${extra.length === 1 ? '' : 's'}`.

### Low-2 — test robustness
The inline snapshot hardcoded `compat-extra-1`, stable only because the snapshot test happened to run first (before the module-scope `compatBadgeSeq` counter incremented). Adding any >4-compat render above it would silently break the snapshot. Now normalizes `compat-extra-\d+` → `compat-extra-N` in the snapshot's html before `toMatchInlineSnapshot`. The real id wiring (aria-controls === hidden-span id, monotonic increment) stays covered by separate assertions, so no coverage is lost.

## Tests
- New plural-case regression test (6 tags → 2 hidden → "tags"); the singular test now also asserts the wrong-plural form is absent.
- Snapshot regenerated via `vitest -u`.
- `astro check` 0/0/0; **363** website tests pass; prettier clean.

## Note on CI
Local pre-push surfaced an **unrelated** flake in `packages/enterprise/tests/audit/scheduled-scan.test.ts` (passes in isolation, fails only under full-suite parallel load) — filed as **SMI-5372**, not caused by this `packages/website` diff.

Closes SMI-5371.