### PR TITLE
ci(smoke-prod): harden alert step so a smoke failure can never go silent (SMI-5373)

### DIFF
--- a/.github/workflows/smoke-prod.yml
+++ b/.github/workflows/smoke-prod.yml
@@ -196,17 +196,36 @@ jobs:
           set -euo pipefail
           REPORT="$RUNNER_TEMP/smoke-report.json"
           if [ ! -f "$REPORT" ]; then
-            echo "::error::report missing — cannot alert"
+            echo "::error::report missing - cannot alert"
             exit 1
           fi
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
           SHORT_SHA="${SHA:0:8}"
 
-          # Idempotency: one issue per merge SHA. Adopts the
-          # post-merge-verify.yml lines 70-95 pattern (find-existing,
-          # comment-or-create) so workflow re-runs don't fan-out duplicate
-          # issues. See SMI-4459 plan § Wave 4 idempotency.
+          # (1) EMAIL FIRST (SMI-5373) - the only channel that reaches a human. Runs
+          # before the GitHub-issue ops so a failure there can never suppress it.
+          # Non-fatal here; if it fails we record it and fail the job at the very end
+          # (step 4). Only REPORT/RUN_URL/SHORT_SHA are needed - nothing but pure
+          # variable assignment precedes it, so "email first" is airtight.
+          EMAIL_OK=1
+          ./scripts/smoke-prod/alert.sh \
+            --report "$REPORT" \
+            --run-url "$RUN_URL" \
+            --sha "$SHORT_SHA" || EMAIL_OK=0
+          if [ "$EMAIL_OK" -eq 0 ]; then
+            echo "::error::alert.sh email failed - the human-reaching channel did not fire"
+          fi
+
+          # (2) Self-healing labels - a future label deletion or a fork without them
+          # cannot re-break issue create. --force updates in place (exit 0 if present);
+          # || true keeps a missing labels:write permission from aborting the step.
+          gh label create smoke-failure --color b60205 --force >/dev/null 2>&1 || true
+          gh label create ci-failure --color d73a4a --force >/dev/null 2>&1 || true
+
+          # TITLE/BODY are consumed only by the issue ops below, so compute them here
+          # (after the email). Idempotency: one issue per merge SHA (comment-or-create)
+          # so workflow re-runs don't fan-out duplicate issues. See SMI-4459 Wave 4.
           TITLE="Smoke-prod failure on $SHORT_SHA"
           BODY="$(cat <<EOF
           Smoke-prod failed on \`$SHORT_SHA\`.
@@ -218,25 +237,30 @@ jobs:
           See \`.claude/development/smoke-prod-guide.md\` for triage steps.
           EOF
           )"
+
+          # (3) Non-fatal issue ops - a tracking hiccup degrades to a warning; the
+          # email (the channel that matters) has already been attempted above.
           EXISTING=$(gh issue list \
             --label smoke-failure \
             --state open \
             --search "$TITLE in:title" \
             --json number \
-            --jq '.[0].number // empty')
+            --jq '.[0].number // empty') || EXISTING=""
           if [ -n "$EXISTING" ]; then
             echo "Commenting on existing issue #$EXISTING"
-            gh issue comment "$EXISTING" --body "$BODY"
+            gh issue comment "$EXISTING" --body "$BODY" \
+              || echo "::warning::issue tracking failed; email already attempted"
           else
             echo "Filing new auto-issue"
             gh issue create \
               --title "$TITLE ($RUN_URL)" \
               --body "$BODY" \
-              --label ci-failure,smoke-failure
+              --label ci-failure,smoke-failure \
+              || echo "::warning::issue tracking failed; email already attempted"
           fi
 
-          # Email via alert-notify (uses service-role key, scoped to this job).
-          ./scripts/smoke-prod/alert.sh \
-            --report "$REPORT" \
-            --run-url "$RUN_URL" \
-            --sha "$SHORT_SHA" || echo "::warning::alert.sh failed; issue still filed"
+          # (4) If the email failed, fail the job so the run goes red - issue-op
+          # hiccups above stay non-fatal, but a missed email must never be green.
+          if [ "$EMAIL_OK" -eq 0 ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## SMI-5373 — harden smoke-prod alert ordering (ADR-109)

[skip-impl-check]

Hardens the "Alert on Failure" step in `.github/workflows/smoke-prod.yml` so a real post-deploy smoke failure can never go silent.

### Problem
The alert step ran `gh issue list/comment/create` BEFORE the email (`./scripts/smoke-prod/alert.sh`) under `set -euo pipefail`. Any gh-issue failure (missing label, rate-limit, perms, transient API error) aborted the step before the email fired — on run `23b9c73f` a real smoke failure produced **no issue AND no email**. Layer 1 (the missing `smoke-failure` label) was already fixed by creating the label; this PR is Layer 2 (the structural ordering coupling).

### Fix (three coordinated edits, plan-reviewed)
1. **Email-first** — `alert.sh` runs first (only pure variable assignment precedes it). Capture `EMAIL_OK`; `exit 1` at the end if the email (the only human-reaching channel) failed, so a missed email is never a green run.
2. **Self-healing labels** — `gh label create smoke-failure/ci-failure --force ... || true` before the issue ops, so a deleted label or a fork can't re-break issue create.
3. **Non-fatal issue ops** — `gh issue list ... || EXISTING=""` plus `|| echo "::warning::..."` on the comment/create branches; a tracking hiccup degrades to a warning now that the email already fired.

Report-missing still `exit 1`s (alert.sh structurally needs the report; the smoke job is itself red) — documented accepted residual.

### ADR-109 + validation
Infra change → SPARC plan + `plan-review-skill` done (APPROVED-WITH-EDITS; all 8 findings folded in). Plan: `docs/internal/implementation/smi-5373-smoke-prod-alert-ordering-hardening.md` (lands in the docs-submodule PR). Validated: `bash -n` OK, `shellcheck -s bash` clean, `actionlint` no findings, alert step fully ASCII, `audit:standards` 75 passed / 0 failed. The job runs only on `failure() && needs.smoke.result == 'failure'`, so there is no success-path behavior change.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
