### PR TITLE
fix(quarantine): key rescan quarantine on frontmatter name + idempotency (SMI-5358 retro)

### DIFF
--- a/packages/mcp-server/src/tools/skill-rescan.ts
+++ b/packages/mcp-server/src/tools/skill-rescan.ts
@@ -15,6 +15,7 @@ import { join } from 'path'
 import { SecurityScanner, QuarantineRepository, type QuarantineSeverity } from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 import { resolveClientPath } from '@skillsmith/core/install'
+import { parseFrontmatter } from '../indexer/FrontmatterParser.js'
 
 // ============================================================================
 // Input / Output types
@@ -300,27 +301,41 @@ async function executeSkillRescanImpl(
     // SMI-5358: advisory → quarantine linkage.
     // Persist a quarantine entry when the rescan finds over-threshold advisories
     // so that local search (searchLocalSkills) hides the threat and the quarantine
-    // dashboard surfaces it. The key MUST match the LocalIndexer id scheme
-    // (`local/{name}`) so QuarantineRepository.isQuarantined() lines up on the
-    // search side — a bare name would never match and the filter would no-op.
+    // dashboard surfaces it.
+    //
+    // KEY PARITY (SMI-5358 retro): the key MUST equal the LocalIndexer id that
+    // searchLocalSkills filters on, which is `local/${frontmatter.name || dirName}`
+    // (LocalIndexer is top-level-only; indexLocalSkill derives name the same way).
+    // discoverInstalledSkills yields the DIRECTORY name, so a SKILL.md whose
+    // `name:` differs from its directory would be quarantined under the wrong key
+    // and silently evade the filter. Derive the canonical name from frontmatter
+    // first, mirroring LocalIndexer, then fall back to the directory name.
     if (!report.passed && quarantineRepo) {
-      const hasCritical = severityCounts.critical > 0
-      const hasHigh = severityCounts.high > 0
-      const quarantineSeverity = findingsToQuarantineSeverity(hasCritical, hasHigh)
-      const detectedPatterns = sortedFindings.slice(0, MAX_FINDINGS_PER_SKILL).map((f) => f.type)
-      quarantineRepo.create({
-        skillId: `local/${skill.name}`,
-        source: 'rescan',
-        quarantineReason:
-          `Security rescan detected ${report.findings.length} finding(s) ` +
-          `(riskScore=${report.riskScore}): ` +
-          sortedFindings
-            .slice(0, 2)
-            .map((f) => f.message.slice(0, 80))
-            .join('; '),
-        severity: quarantineSeverity,
-        detectedPatterns,
-      })
+      const canonicalName = parseFrontmatter(content).name || skill.name
+      const skillKey = `local/${canonicalName}`
+      // Idempotent: a persistently-failing skill rescanned repeatedly must not
+      // accumulate duplicate pending rows (the quarantine table has no
+      // UNIQUE(skill_id, source)). Skip if already quarantined; a previously
+      // APPROVED entry (isQuarantined === false) still re-quarantines as intended.
+      if (!quarantineRepo.isQuarantined(skillKey)) {
+        const hasCritical = severityCounts.critical > 0
+        const hasHigh = severityCounts.high > 0
+        const quarantineSeverity = findingsToQuarantineSeverity(hasCritical, hasHigh)
+        const detectedPatterns = sortedFindings.slice(0, MAX_FINDINGS_PER_SKILL).map((f) => f.type)
+        quarantineRepo.create({
+          skillId: skillKey,
+          source: 'rescan',
+          quarantineReason:
+            `Security rescan detected ${report.findings.length} finding(s) ` +
+            `(riskScore=${report.riskScore}): ` +
+            sortedFindings
+              .slice(0, 2)
+              .map((f) => f.message.slice(0, 80))
+              .join('; '),
+          severity: quarantineSeverity,
+          detectedPatterns,
+        })
+      }
     }
   }
 

--- a/packages/mcp-server/tests/skill-rescan-quarantine.test.ts
+++ b/packages/mcp-server/tests/skill-rescan-quarantine.test.ts
@@ -254,4 +254,34 @@ describe('skill_rescan → QuarantineRepository linkage (SMI-5358)', () => {
     expect(entries.length).toBeGreaterThan(0)
     expect(entries[0].reviewStatus).toBe('pending')
   })
+
+  // --------------------------------------------------------------------------
+  // SMI-5358 retro: key parity + idempotency
+  // --------------------------------------------------------------------------
+
+  it('keys the quarantine entry on frontmatter name, not the directory name', async () => {
+    // MALICIOUS_SKILL has `name: evil-skill` in its frontmatter but is installed
+    // in a directory named `misnamed-dir`. LocalIndexer (and therefore
+    // searchLocalSkills) ids it `local/evil-skill` (frontmatter.name wins), so the
+    // quarantine entry MUST also key on `local/evil-skill` — keying on the
+    // directory name (`local/misnamed-dir`) would let it evade the search filter.
+    await writeSkill(skillsDir, 'misnamed-dir', MALICIOUS_SKILL)
+
+    await executeSkillRescan({}, skillsDir, quarantineRepo)
+
+    expect(quarantineRepo.findBySkillId('local/evil-skill')).toHaveLength(1)
+    expect(quarantineRepo.isQuarantined('local/evil-skill')).toBe(true)
+    // Directory-name key must NOT be used.
+    expect(quarantineRepo.findBySkillId('local/misnamed-dir')).toHaveLength(0)
+  })
+
+  it('does not create duplicate entries when the same failing skill is rescanned twice', async () => {
+    await writeSkill(skillsDir, 'evil-skill', MALICIOUS_SKILL)
+
+    await executeSkillRescan({}, skillsDir, quarantineRepo)
+    await executeSkillRescan({}, skillsDir, quarantineRepo)
+
+    // Idempotent: the second rescan must not accumulate a second pending row.
+    expect(quarantineRepo.findBySkillId('local/evil-skill')).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
Post-merge governance retro on #1567 (SMI-5358) surfaced two should-fixes in the new advisory->quarantine linkage. Both fixed here.

### Fixes
- **Key parity (security):** `skill_rescan` keyed quarantine entries on the **directory** name, but `searchLocalSkills` filters on LocalIndexer's id `local/${frontmatter.name || dirName}` (LocalIndexer is top-level-only). A `SKILL.md` whose `name:` differed from its directory would be quarantined under the wrong key and **silently evade the local-search filter**. Now derives the canonical name from frontmatter first (mirroring `indexLocalSkill`), falling back to the directory name.
- **Idempotency (data quality):** repeated rescans of a persistently-failing skill accumulated duplicate pending rows (no `UNIQUE(skill_id, source)`). `create()` is now guarded on `isQuarantined()`; a previously **approved** entry still re-quarantines.

### Tests
- mismatched frontmatter-name keying: a malicious skill in dir `misnamed-dir` with `name: evil-skill` is quarantined as `local/evil-skill` (not `local/misnamed-dir`).
- double-rescan idempotency: exactly one entry after two rescans.

### Verification
typecheck/prettier/eslint clean; rescan + round-trip + install suites green via direct vitest (57 passed). App-code + tests only; no infra/migration.

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)