### PR TITLE
fix(install): harden writeInstallFiles rollback against out-of-bounds delete (SMI-5359 retro)

### DIFF
--- a/packages/core/src/services/skill-installation.io.ts
+++ b/packages/core/src/services/skill-installation.io.ts
@@ -90,6 +90,24 @@ export async function writeInstallFiles(
 ): Promise<WriteInstallResult> {
   const writtenFiles: string[] = []
   let subagentPath: string | undefined
+  // SMI-5359 (retro): lexically reject an escaping installPath BEFORE any filesystem
+  // mutation. path.resolve normalizes `..`, so an unsanitized skillName like '..'
+  // (e.g. path.basename('foo/..')) or a compromised registry skillName cannot drive
+  // installPath outside skillsDir and reach the rollback below. Thrown here, nothing
+  // has been created, so no cleanup is needed.
+  const resolvedInstall = path.resolve(installPath)
+  const resolvedSkillsDir = path.resolve(skillsDir)
+  if (
+    resolvedInstall !== resolvedSkillsDir &&
+    !resolvedInstall.startsWith(resolvedSkillsDir + path.sep)
+  ) {
+    throw new Error('Install path escapes skills directory (lexical): ' + installPath)
+  }
+  // Only set true once installPath is PROVEN inside skillsDir (both the lexical check
+  // above and the realpath check below). The recursive rollback rm keys off this so it
+  // can never force-delete an out-of-bounds path (e.g. a symlink-escape the realpath
+  // check rejects after mkdir).
+  let pathValidated = false
   try {
     await fs.mkdir(installPath, { recursive: true })
     // SMI-4692: realpath both sides — macOS /var/folders symlinks to /private/var/folders.
@@ -99,8 +117,9 @@ export async function writeInstallFiles(
       !realInstallPath.startsWith(expectedPrefix + path.sep) &&
       realInstallPath !== expectedPrefix
     ) {
-      throw new Error('Install path escapes skills directory: ' + installPath)
+      throw new Error('Install path escapes skills directory (realpath): ' + installPath)
     }
+    pathValidated = true
 
     const mainSkillPath = path.join(installPath, 'SKILL.md')
     await safeWriteFile(mainSkillPath, finalSkillContent)
@@ -125,13 +144,20 @@ export async function writeInstallFiles(
     }
   } catch (writeError) {
     // Rollback on failure. Unlink tracked files first (subagentPath lives OUTSIDE
-    // installPath, under ~/.claude/agents). Then recursively remove installPath so
-    // an untracked orphan from a mid-batch Promise.all write can't survive — the
-    // escape guard above proved installPath is inside skillsDir, so this is safe.
+    // installPath, under ~/.claude/agents).
     for (const filePath of writtenFiles) {
       await fs.unlink(filePath).catch(() => {})
     }
-    await fs.rm(installPath, { recursive: true, force: true }).catch(() => {})
+    // Only recursively remove installPath once it has been PROVEN inside skillsDir
+    // (pathValidated) — so an untracked orphan from a mid-batch Promise.all write can't
+    // survive. If mkdir or the realpath escape guard threw, installPath was never
+    // validated; fall back to a non-recursive rmdir, a safe no-op on a non-empty or
+    // out-of-bounds directory (NEVER a recursive force-delete of an unvalidated path).
+    if (pathValidated) {
+      await fs.rm(installPath, { recursive: true, force: true }).catch(() => {})
+    } else {
+      await fs.rmdir(installPath).catch(() => {})
+    }
     throw writeError
   }
   return { writtenFiles, subagentPath }

--- a/packages/core/tests/unit/services/skill-installation.io.test.ts
+++ b/packages/core/tests/unit/services/skill-installation.io.test.ts
@@ -9,7 +9,13 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { fetchAndScanOptionalFiles } from '../../../src/services/skill-installation.io.js'
+import * as fs from 'fs/promises'
+import * as os from 'os'
+import * as path from 'path'
+import {
+  fetchAndScanOptionalFiles,
+  writeInstallFiles,
+} from '../../../src/services/skill-installation.io.js'
 import type { ScannerOptions } from '../../../src/security/index.js'
 
 // SKILL.md-shaped content that saturates the scanner (riskScore >= 40).
@@ -100,5 +106,62 @@ describe('fetchAndScanOptionalFiles (SMI-5359 Gap-1)', () => {
     // No scanner -> no scan -> no rejection; README is a doc and is queued.
     expect(result.failedScans).toHaveLength(0)
     expect(result.filesToWrite.find((f) => f.filename === 'README.md')).toBeDefined()
+  })
+})
+
+/**
+ * SMI-5359 (4.3 retro): the rollback in writeInstallFiles must NEVER recursively
+ * force-delete a path that was not proven inside skillsDir. A regression guard for
+ * the data-loss bug where an escaping installPath (e.g. an unsanitized skillName
+ * resolving to a parent dir) would have nuked an out-of-bounds directory.
+ */
+describe('writeInstallFiles rollback safety (SMI-5359 retro)', () => {
+  it('does NOT delete an out-of-bounds directory when installPath escapes skillsDir', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'wif-escape-'))
+    try {
+      const skillsDir = path.join(root, 'skills')
+      await fs.mkdir(skillsDir, { recursive: true })
+      // A sibling dir OUTSIDE skillsDir with a sentinel that MUST survive.
+      const sibling = path.join(root, 'precious')
+      await fs.mkdir(sibling, { recursive: true })
+      const sentinel = path.join(sibling, 'keep.txt')
+      await fs.writeFile(sentinel, 'do not delete')
+      // installPath escapes skillsDir (skillsDir/../precious === sibling).
+      const escaping = path.join(skillsDir, '..', 'precious')
+
+      await expect(
+        writeInstallFiles(escaping, skillsDir, 'precious', '# skill', [], undefined)
+      ).rejects.toThrow(/escapes skills directory/)
+
+      // Pre-fix (recursive fs.rm in the catch) deleted the sibling + sentinel. The
+      // sentinel and sibling must be fully intact.
+      await expect(fs.access(sentinel)).resolves.toBeUndefined()
+      await expect(fs.access(sibling)).resolves.toBeUndefined()
+    } finally {
+      await fs.rm(root, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  it('writes SKILL.md for a valid in-bounds installPath', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'wif-ok-'))
+    try {
+      const skillsDir = path.join(root, 'skills')
+      await fs.mkdir(skillsDir, { recursive: true })
+      const installPath = path.join(skillsDir, 'my-skill')
+
+      const result = await writeInstallFiles(
+        installPath,
+        skillsDir,
+        'my-skill',
+        '# hello',
+        [],
+        undefined
+      )
+
+      expect(await fs.readFile(path.join(installPath, 'SKILL.md'), 'utf8')).toBe('# hello')
+      expect(result.writtenFiles.length).toBeGreaterThan(0)
+    } finally {
+      await fs.rm(root, { recursive: true, force: true }).catch(() => {})
+    }
   })
 })


### PR DESCRIPTION
Fast-follow from the **Wave 4.3 post-merge governance retro** (PR #1580). The retro found a data-loss regression introduced by 4.3's own rollback hardening.

## The bug (SHOULD-FIX / potential BLOCKER)
`writeInstallFiles`'s catch ran `fs.rm(installPath, { recursive: true, force: true })` **even when the escape guard itself threw**. If `installPath` escaped `skillsDir` (e.g. an unsanitized `skillName='..'` — `path.basename('foo/..')==='..'` — or a compromised registry `skillName` resolving to a parent dir), the rollback would **recursively force-delete an out-of-bounds directory** (worst case a `~/.claude` wipe). The prior `fs.rmdir` was a safe no-op there.

## Fix (defense in depth)
1. **Lexical `path.resolve` pre-check before any FS mutation** — rejects an escaping `installPath` before `mkdir`/`rm` (nothing created, no cleanup needed).
2. **`pathValidated` flag** — the recursive `fs.rm` runs **only** after both the lexical and realpath checks pass; otherwise it falls back to a non-recursive `fs.rmdir` (safe no-op, never a recursive force-delete of an unvalidated path). Also covers the symlink-escape case the realpath guard rejects post-mkdir.

## Test (FAILS pre-fix)
`skill-installation.io.test.ts`: an escaping `installPath` throws AND leaves an out-of-bounds sibling dir + sentinel file intact; plus a happy-path in-bounds write. 5 → 7 tests.

Verified in-container: 7 io tests pass; eslint `--max-warnings=0` / prettier / file-length clean; full `tsc --build` clean except the known worktree-only cross-package resolution artifact (resolves correctly on a fresh CI checkout). App code (no infra gate).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)