### PR TITLE
chore(release): core 0.8.1, mcp-server 0.5.4, cli 0.6.4 (patch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34538,12 +34538,12 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@skillsmith/core": "^0.8.0",
-        "@skillsmith/mcp-server": "^0.5.3",
+        "@skillsmith/core": "^0.8.1",
+        "@skillsmith/mcp-server": "^0.5.4",
         "chalk": "5.6.2",
         "chokidar": "4.0.3",
         "cli-table3": "0.6.5",
@@ -34651,7 +34651,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -34784,13 +34784,13 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-        "@skillsmith/core": "^0.8.0",
+        "@skillsmith/core": "^0.8.1",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "*",
+        "@skillsmith/mcp-server": "^0.5.4",
         "@smithy/config-resolver": "4.4.13",
         "@smithy/core": "3.23.12",
         "@smithy/middleware-endpoint": "4.4.27",
@@ -34805,7 +34805,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "*"
+        "@skillsmith/mcp-server": "^0.5.4"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -34929,11 +34929,11 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.8.0",
+        "@skillsmith/core": "^0.8.1",
         "ulid": "3.0.1"
       },
       "bin": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.6.4
+
+- **Feature**: recover + backfill canonical GitHub source for local skills (SMI-5407) (#1589)
+- **Feature**: CLI install block + local-search filter + 9 missing quarantine tests (SMI-5358) (#1567)
+
 ## v0.6.3
 
 - **Refactor**: SMI-5036 split oversized billing test files (#1282)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.8.0",
-    "@skillsmith/mcp-server": "^0.5.3",
+    "@skillsmith/core": "^0.8.1",
+    "@skillsmith/mcp-server": "^0.5.4",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",
     "cli-table3": "0.6.5",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.8.1
+
+- **Feature**: recover + backfill canonical GitHub source for local skills (SMI-5407) (#1589)
+- **Fix**: harden writeInstallFiles rollback against out-of-bounds delete (SMI-5359 retro) (#1586)
+- **Fix**: scan optional files before write; reject malicious config (SMI-5359 Wave 4.3, Gap-1) (#1580)
+- **Feature**: code_execution + obfuscated_directive scoring categories (SMI-5359 Wave 4.2, core) (#1582)
+- **Feature**: wire doc-context downgrade into core scanSuspiciousPatterns (SMI-5359 Wave 4.1) (#1578)
+- **Feature**: CLI install block + local-search filter + 9 missing quarantine tests (SMI-5358) (#1567)
+
 ## v0.8.0
 
 - **Feature**: SMI-5039 — new `./embeddings/probe` subpath export. Extracts the

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.8.0'
+export const VERSION = '0.8.1'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-    "@skillsmith/core": "^0.8.0",
+    "@skillsmith/core": "^0.8.1",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "*",
+    "@skillsmith/mcp-server": "^0.5.4",
     "@smithy/config-resolver": "4.4.13",
     "@smithy/core": "3.23.12",
     "@smithy/middleware-endpoint": "4.4.27",
@@ -62,7 +62,7 @@
     "vitest": "4.1.6"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "*"
+    "@skillsmith/mcp-server": "^0.5.4"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.5.4
+
+- **Feature**: recover + backfill canonical GitHub source for local skills (SMI-5407) (#1589)
+- **Fix**: scan optional files before write; reject malicious config (SMI-5359 Wave 4.3, Gap-1) (#1580)
+- **Fix**: key rescan quarantine on frontmatter name + idempotency (SMI-5358 retro) (#1569)
+- **Feature**: CLI install block + local-search filter + 9 missing quarantine tests (SMI-5358) (#1567)
 - **Feature**: SMI-5178 — `search` and `skill_recommend` MCP tools now default to
   installable-only results. Discovery-only entries (no `repo_url`, cannot be resolved
   by `install_skill`) are hidden by default (~71% of the registry). Pass

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.8.0",
+    "@skillsmith/core": "^0.8.1",
     "ulid": "3.0.1"
   },
   "devDependencies": {

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.5.3",
+  "version": "0.5.4",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -94,7 +94,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.5.3'
+const PACKAGE_VERSION = '0.5.4'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,


### PR DESCRIPTION
Patch release shipping **SMI-5407 — skill source provenance recovery** (core `provenance/` module + CLI `sklx audit sources` + read-only MCP `skill_recover_source` + skill_outdated/diff tie-ins, merged in #1589).

| Package | Current | New |
|---------|---------|-----|
| @skillsmith/core | 0.8.0 | **0.8.1** |
| @skillsmith/mcp-server | 0.5.3 | **0.5.4** |
| @skillsmith/cli | 0.6.3 | **0.6.4** |

core is included because cli + mcp-server depend on its new `provenance/` exports (publishing cli/mcp without core would leave them importing a core version that lacks provenance). enterprise's `@skillsmith/core` dep + the lockfile are updated for monorepo coherence (enterprise not published this round). `mcp-server/server.json` synced for the MCP registry.

npm collision guard passed (all proposed > highest published). Publish order on merge: core → mcp-server, cli (via `gh workflow run publish.yml -f dry_run=false`).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)