### PR TITLE
fix(mcp): get_skill installable:false for quarantined skills + run the SSRF e2e suite in CI (SMI-5360 Wave 5 PR1)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -330,6 +330,91 @@ jobs:
             test-results/mcp-*.json
           retention-days: 7
 
+  # SMI-5360: Security E2E lane. Runs the SSRF / DNS-rebinding suite
+  # (packages/core/tests/e2e/security/security.e2e.test.ts) that the CLI/MCP
+  # runners never reach. Fully offline: no network, no secrets. Reuses the
+  # pre-built Docker image + node_modules from docker-build, like the CLI lane.
+  security-e2e-tests:
+    name: Security E2E Tests
+    runs-on: ubuntu-latest
+    needs: docker-build
+    if: github.event.inputs.test_scope != 'cli' && github.event.inputs.test_scope != 'mcp'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      # No git-crypt unlock and no `npm run build`: this lane runs one offline
+      # test that imports @skillsmith/core via relative src paths (vitest
+      # transpiles on the fly) and touches no encrypted supabase/** files. The
+      # extracted node_modules already carry the prebuilt better-sqlite3 binary.
+      - name: Download Docker image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: docker-image-e2e
+          path: /tmp
+
+      - name: Download node_modules
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: node-modules-e2e
+          path: /tmp
+
+      # SMI-2240: re-tag if the loaded tag differs from the expected SHA.
+      - name: Load Docker image
+        run: |
+          zstd -d --stdout /tmp/skillsmith-e2e.tar.zst | docker load
+          LOADED_TAG=$(docker images skillsmith-e2e --format '{{.Tag}}' | head -1)
+          if [ -n "$LOADED_TAG" ] && [ "$LOADED_TAG" != "${{ github.sha }}" ]; then
+            echo "Re-tagging: $LOADED_TAG -> ${{ github.sha }}"
+            if ! docker tag skillsmith-e2e:$LOADED_TAG skillsmith-e2e:${{ github.sha }}; then
+              echo "::error::Failed to re-tag Docker image"
+              exit 1
+            fi
+          fi
+
+      - name: Extract node_modules
+        run: zstd -d --stdout /tmp/node_modules.tar.zst | tar -xf - -C ${{ github.workspace }}
+
+      - name: Run Security E2E tests in Docker
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/app \
+            -w /app \
+            -e SKILLSMITH_E2E=true \
+            skillsmith-e2e:${{ github.sha }} \
+            npm run test:e2e:security -- --reporter=default --reporter=json --outputFile.json=test-results/security-results.json
+
+      # SMI-5360 AC#2: vitest exits non-zero on zero matched files, but assert
+      # the executed count explicitly so an inert lane (wrong glob/positional)
+      # can never read as a pass.
+      - name: Assert the security suite actually executed
+        run: |
+          COUNT=$(docker run --rm \
+            -v ${{ github.workspace }}:/app \
+            -w /app \
+            skillsmith-e2e:${{ github.sha }} \
+            node -p "require('./test-results/security-results.json').numTotalTests")
+          echo "Security E2E numTotalTests=$COUNT"
+          case "$COUNT" in
+            '' | *[!0-9]*)
+              echo "::error::Security E2E test count is not a positive integer ($COUNT) - the lane is inert or broken"
+              exit 1
+              ;;
+          esac
+          if [ "$COUNT" -lt 1 ]; then
+            echo "::error::Security E2E suite matched 0 tests - the CI lane is inert"
+            exit 1
+          fi
+
+      - name: Upload security test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: security-e2e-results
+          path: test-results/security-results.json
+          retention-days: 7
+
   # Generate reports and create Linear issues for failures
   # SMI-969: Uses pre-built Docker image and node_modules from docker-build job
   report-results:

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "test:e2e:create-issues": "npx tsx scripts/e2e/create-linear-issues.ts",
     "test:e2e:baseline": "npx tsx scripts/e2e/generate-report.ts --baseline",
     "test:e2e:usage-counter": "vitest run --config vitest.e2e.config.ts",
+    "test:e2e:security": "vitest run --config vitest-e2e.config.ts packages/core/tests/e2e/security",
     "skillsmith": "node packages/cli/dist/src/index.js",
     "cleanup:orphans": "./scripts/cleanup-orphans.sh",
     "transform:batch": "npx tsx scripts/batch-transform-skills.ts",

--- a/packages/mcp-server/src/__tests__/get-skill.api-path.test.ts
+++ b/packages/mcp-server/src/__tests__/get-skill.api-path.test.ts
@@ -222,4 +222,61 @@ describe('executeGetSkill (API path)', () => {
       expect(result.skill.repository).toBeUndefined()
     })
   })
+
+  // SMI-5360: a quarantined skill must report installable:false even though it
+  // carries a repo_url. install_skill already refuses quarantined skills
+  // (validate.ts:149); returning installable:true here would contradict the
+  // accompanying security warning.
+  describe('installability gate (SMI-5360)', () => {
+    it('reports installable=false for a quarantined skill that has a repo_url', async () => {
+      context = await createApiMockContext({
+        apiSkill: {
+          id: 'evil/exfil',
+          name: 'exfil',
+          trust_tier: 'community',
+          repo_url: 'https://github.com/evil/exfil',
+          last_scanned_at: '2026-06-01T00:00:00.000Z',
+          security_score: 85,
+          security_findings: [{ rule: 'data-exfiltration' }],
+          quarantined: true,
+        },
+      })
+
+      const result = await executeGetSkill({ id: 'evil/exfil' }, context)
+      expect(result.skill.installable).toBe(false)
+    })
+
+    it('reports installable=true for a clean skill that has a repo_url', async () => {
+      context = await createApiMockContext({
+        apiSkill: {
+          id: 'good/clean',
+          name: 'clean',
+          trust_tier: 'verified',
+          repo_url: 'https://github.com/good/clean',
+          last_scanned_at: '2026-06-01T00:00:00.000Z',
+          security_score: 0,
+          security_findings: [],
+          quarantined: false,
+        },
+      })
+
+      const result = await executeGetSkill({ id: 'good/clean' }, context)
+      expect(result.skill.installable).toBe(true)
+    })
+
+    it('still reports installable=false for a discovery-only entry (no repo_url)', async () => {
+      context = await createApiMockContext({
+        apiSkill: {
+          id: 'disc/only',
+          name: 'only',
+          trust_tier: 'community',
+          repo_url: null,
+          quarantined: false,
+        },
+      })
+
+      const result = await executeGetSkill({ id: 'disc/only' }, context)
+      expect(result.skill.installable).toBe(false)
+    })
+  })
 })

--- a/packages/mcp-server/src/__tests__/get-skill.test.ts
+++ b/packages/mcp-server/src/__tests__/get-skill.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { executeGetSkill, formatSkillDetails } from '../tools/get-skill.js'
-import { SkillsmithError, ErrorCodes } from '@skillsmith/core'
+import { SkillsmithError, ErrorCodes, QuarantineRepository } from '@skillsmith/core'
 import { createSeededTestContext, disposeTestContext, type ToolContext } from './test-utils.js'
 
 let context: ToolContext
@@ -480,5 +480,94 @@ describe('formatSkillDetails — license display (SMI-5327)', () => {
   it('renders "License: Unknown" when license is whitespace-only', () => {
     const formatted = formatSkillDetails(baseResponse('   '))
     expect(formatted).toContain('License: Unknown')
+  })
+})
+
+/**
+ * SMI-5360: formatSkillDetails installability line. A skill that carries a
+ * repository but is not installable is blocked (quarantined / failed scan), NOT
+ * discovery-only — the reason text must distinguish the two.
+ */
+describe('formatSkillDetails — installability (SMI-5360)', () => {
+  const baseSkill = {
+    id: 'test/skill',
+    name: 'test-skill',
+    description: 'A test skill',
+    author: 'test',
+    category: 'development' as const,
+    trustTier: 'community' as const,
+    score: 80,
+    tags: [] as string[],
+    installCommand: 'claude skill add test/skill',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  }
+  const responseWith = (overrides: { installable?: boolean; repository?: string }) => ({
+    skill: { ...baseSkill, ...overrides },
+    installCommand: 'claude skill add test/skill',
+    timing: { totalMs: 10 },
+  })
+
+  it('prints "Installable: yes" when installable', () => {
+    const formatted = formatSkillDetails(
+      responseWith({ installable: true, repository: 'https://github.com/test/skill' })
+    )
+    expect(formatted).toContain('Installable: yes')
+  })
+
+  it('labels a non-installable skill that has a repository as blocked, not discovery-only', () => {
+    const formatted = formatSkillDetails(
+      responseWith({ installable: false, repository: 'https://github.com/test/skill' })
+    )
+    expect(formatted).toContain('Installable: NO')
+    expect(formatted).toContain('blocked')
+    expect(formatted).not.toContain('discovery-only')
+  })
+
+  it('labels a non-installable skill with no repository as discovery-only', () => {
+    const formatted = formatSkillDetails(responseWith({ installable: false }))
+    expect(formatted).toContain('Installable: NO')
+    expect(formatted).toContain('discovery-only')
+    expect(formatted).not.toContain('blocked')
+  })
+})
+
+/**
+ * SMI-5360: end-to-end local-DB path. Local quarantine lives in
+ * QuarantineRepository (a separate table), not on the skill row, so the offline
+ * get_skill fallback must consult it before reporting installability.
+ */
+describe('Get Skill Tool — local-DB quarantine gate (SMI-5360)', () => {
+  it('reports installable=false and labels it blocked for a quarantined seeded skill', async () => {
+    const ctx = await createSeededTestContext()
+    try {
+      const quarantineRepo = new QuarantineRepository(ctx.db)
+      quarantineRepo.create({
+        skillId: 'anthropic/commit',
+        source: 'security-scanner',
+        quarantineReason: 'test: simulated malicious finding',
+        severity: 'MALICIOUS',
+      })
+
+      const result = await executeGetSkill({ id: 'anthropic/commit' }, ctx)
+      expect(result.skill.installable).toBe(false)
+
+      const formatted = formatSkillDetails(result)
+      expect(formatted).toContain('Installable: NO')
+      expect(formatted).toContain('blocked')
+    } finally {
+      await disposeTestContext(ctx)
+    }
+  })
+
+  it('keeps installable=true for a non-quarantined seeded skill (regression guard)', async () => {
+    const ctx = await createSeededTestContext()
+    try {
+      const result = await executeGetSkill({ id: 'anthropic/commit' }, ctx)
+      expect(result.skill.installable).toBe(true)
+      expect(formatSkillDetails(result)).toContain('Installable: yes')
+    } finally {
+      await disposeTestContext(ctx)
+    }
   })
 })

--- a/packages/mcp-server/src/tools/get-skill.format.ts
+++ b/packages/mcp-server/src/tools/get-skill.format.ts
@@ -1,0 +1,201 @@
+/**
+ * @fileoverview Terminal/CLI formatting helpers for get_skill responses.
+ * @module @skillsmith/mcp-server/tools/get-skill.format
+ *
+ * SMI-5360: split out of get-skill.ts to keep that file under the 500-line
+ * limit. These are pure presentation helpers — no I/O, no ToolContext.
+ */
+
+import {
+  type GetSkillResponse,
+  type MCPTrustTier as TrustTier,
+  TrustTierDescriptions,
+} from '@skillsmith/core'
+
+/**
+ * Format skill details for terminal/CLI display.
+ *
+ * Produces a comprehensive human-readable string including:
+ * - Basic info (ID, author, version, category)
+ * - Full description
+ * - Trust tier with explanation
+ * - Visual score breakdown bars
+ * - Repository and tags
+ * - Installation command
+ *
+ * @param response - Get skill response from executeGetSkill
+ * @returns Formatted string suitable for terminal output
+ *
+ * @example
+ * const response = await executeGetSkill({ id: 'getsentry/commit' });
+ * console.log(formatSkillDetails(response));
+ * // Output:
+ * // === commit ===
+ * // ID: getsentry/commit
+ * // Author: getsentry
+ * // Version: 1.2.0
+ * // ...
+ */
+export function formatSkillDetails(response: GetSkillResponse): string {
+  const skill = response.skill
+  const lines: string[] = []
+
+  lines.push('\n=== ' + skill.name + ' ===\n')
+
+  // Basic info
+  lines.push('ID: ' + skill.id)
+  lines.push('Author: ' + skill.author)
+  lines.push('Version: ' + (skill.version || 'N/A'))
+  lines.push('Category: ' + skill.category)
+  // SMI-4954: surface installability so callers don't try to install a
+  // discovery-only entry that install_skill cannot resolve.
+  // SMI-5360: a skill that carries a repository but is still not installable is
+  // blocked (quarantined / failed security scan), NOT discovery-only — say so
+  // rather than printing the misleading "discovery-only entry" reason.
+  if (skill.installable === false) {
+    if (skill.repository) {
+      lines.push(
+        'Installable: NO — blocked (quarantined or failed security scan; install_skill will refuse this)'
+      )
+    } else {
+      lines.push('Installable: NO — discovery-only entry (install_skill will not resolve this)')
+    }
+  } else if (skill.installable === true) {
+    lines.push('Installable: yes')
+  }
+  lines.push('')
+
+  // Description
+  lines.push('Description:')
+  lines.push('  ' + skill.description)
+  lines.push('')
+
+  // Trust tier with explanation
+  lines.push('Trust Tier: ' + formatTrustTier(skill.trustTier))
+  lines.push('  ' + TrustTierDescriptions[skill.trustTier])
+  lines.push('')
+
+  // Score breakdown
+  lines.push('Overall Score: ' + skill.score + '/100')
+  if (skill.scoreBreakdown) {
+    lines.push('Score Breakdown:')
+    lines.push('  Quality:       ' + formatScoreBar(skill.scoreBreakdown.quality))
+    lines.push('  Popularity:    ' + formatScoreBar(skill.scoreBreakdown.popularity))
+    lines.push('  Maintenance:   ' + formatScoreBar(skill.scoreBreakdown.maintenance))
+    lines.push('  Security:      ' + formatScoreBar(skill.scoreBreakdown.security))
+    lines.push('  Documentation: ' + formatScoreBar(skill.scoreBreakdown.documentation))
+  }
+  lines.push('')
+
+  // Repository
+  if (skill.repository) {
+    lines.push('Repository: ' + skill.repository)
+  }
+
+  // SMI-5327: License — null / whitespace-only means "unknown / not detected", NOT "no license".
+  lines.push('License: ' + (skill.license?.trim() || 'Unknown'))
+
+  // Tags
+  if (skill.tags && skill.tags.length > 0) {
+    lines.push('Tags: ' + skill.tags.join(', '))
+  }
+  lines.push('')
+
+  // SMI-825: Security information
+  lines.push('--- Security ---')
+  if (skill.security) {
+    if (skill.security.passed === null) {
+      lines.push('  Status: Not scanned')
+    } else if (skill.security.passed) {
+      lines.push('  Status: PASSED')
+      lines.push('  Risk Score: ' + (skill.security.riskScore ?? 0) + '/100')
+      lines.push('  Findings: ' + (skill.security.findingsCount ?? 0))
+    } else {
+      lines.push('  Status: FAILED')
+      lines.push('  Risk Score: ' + (skill.security.riskScore ?? 0) + '/100 (HIGH)')
+      lines.push('  Findings: ' + (skill.security.findingsCount ?? 0))
+      lines.push('  WARNING: This skill has security issues. Review carefully before use.')
+    }
+    if (skill.security.scannedAt) {
+      lines.push('  Scanned: ' + skill.security.scannedAt)
+    }
+  } else {
+    lines.push('  Status: Not scanned')
+  }
+  lines.push('')
+
+  // SMI-3137: Dependency intelligence
+  if (response.dependencies && response.dependencies.length > 0) {
+    lines.push('--- Dependencies ---')
+    for (const dep of response.dependencies) {
+      const version = dep.dep_version ? '@' + dep.dep_version : ''
+      const source = dep.dep_source === 'declared' ? '' : ' (inferred)'
+      lines.push('  [' + dep.dep_type + '] ' + dep.dep_target + version + source)
+    }
+    lines.push('')
+  }
+
+  // SMI-2761: Co-install recommendations
+  if (response.also_installed && response.also_installed.length > 0) {
+    lines.push('--- Users Also Installed ---')
+    for (const co of response.also_installed) {
+      lines.push('  ' + co.skillId + (co.description ? ' — ' + co.description : ''))
+    }
+    lines.push('')
+  }
+
+  // SMI-3672: Skill content (SKILL.md)
+  if (response.content) {
+    lines.push('--- Skill Content ---')
+    lines.push(response.content)
+    lines.push('')
+  }
+
+  // Installation
+  lines.push('--- Installation ---')
+  lines.push('  ' + response.installCommand)
+  lines.push('')
+
+  // Timing
+  lines.push('---')
+  lines.push('Retrieved in ' + response.timing.totalMs + 'ms')
+
+  return lines.join('\n')
+}
+
+/**
+ * Format trust tier with visual indicator
+ * SMI-1809: Added 'local' tier
+ * SMI-2381 / SMI-4520: Added 'curated' tier
+ * SMI-5205: Added 'official' and 'unverified' tiers
+ */
+function formatTrustTier(tier: TrustTier): string {
+  switch (tier) {
+    case 'official':
+      return '[!] OFFICIAL' // SMI-5205: Platform/partner with full security review
+    case 'verified':
+      return '[*] VERIFIED'
+    case 'community':
+      return '[+] COMMUNITY'
+    case 'curated':
+      return '[#] CURATED' // SMI-2381: Third-party publisher
+    case 'local':
+      return '[@] LOCAL' // SMI-1809: Local skills from ~/.claude/skills/
+    case 'experimental':
+      return '[~] EXPERIMENTAL'
+    case 'unknown':
+      return '[?] UNKNOWN'
+    case 'unverified':
+      return '[?] UNVERIFIED' // SMI-5205: Public alias for unknown
+  }
+}
+
+/**
+ * Format score as a visual bar
+ */
+function formatScoreBar(score: number): string {
+  const filled = Math.round(score / 10)
+  const empty = 10 - filled
+  const bar = '='.repeat(filled) + '-'.repeat(empty)
+  return '[' + bar + '] ' + score + '/100'
+}

--- a/packages/mcp-server/src/tools/get-skill.ts
+++ b/packages/mcp-server/src/tools/get-skill.ts
@@ -27,12 +27,11 @@ import {
   type MCPSkill as Skill,
   type GetSkillResponse,
   type AlsoInstalledSkill,
-  type MCPTrustTier as TrustTier,
   type SecuritySummary,
-  TrustTierDescriptions,
   SkillsmithError,
   ErrorCodes,
   trackSkillView,
+  QuarantineRepository,
 } from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 import type { ToolContext } from '../context.js'
@@ -168,7 +167,10 @@ async function executeGetSkillImpl(
         repository: apiSkill.repo_url || undefined,
         // SMI-4954: installable when the registry row carries a repo_url —
         // discovery-only entries (repo_url null, SMI-2723) cannot be installed.
-        installable: Boolean(apiSkill.repo_url),
+        // SMI-5360: a quarantined skill is never installable — install_skill
+        // refuses it (validate.ts:149), so reporting installable:true here would
+        // be a self-contradictory response next to the security warning.
+        installable: Boolean(apiSkill.repo_url) && apiSkill.quarantined !== true,
         version: undefined,
         // SMI-4240: Prefer the category joined from skill_categories by the API
         // (populated by the indexer's classifier) over tag-based inference.
@@ -236,6 +238,15 @@ async function executeGetSkillImpl(
     })
   }
 
+  // SMI-5360: mirror the API-path quarantine gate on the local DB fallback.
+  // Local quarantine lives in a separate table (QuarantineRepository), not on
+  // the skill row. Only consult it when the skill has a repoUrl (a skill with
+  // no repoUrl is non-installable regardless) — this matches install.helpers.ts,
+  // which constructs the repo only inside its repoUrl guard.
+  const isLocalQuarantined = dbSkill.repoUrl
+    ? new QuarantineRepository(context.db).isQuarantined(dbSkill.id)
+    : false
+
   // Convert database skill to MCP skill format
   const skill: Skill = {
     id: dbSkill.id,
@@ -244,7 +255,8 @@ async function executeGetSkillImpl(
     author: dbSkill.author || 'unknown',
     repository: dbSkill.repoUrl || undefined,
     // SMI-4954: installable when the local DB row carries a repoUrl
-    installable: Boolean(dbSkill.repoUrl),
+    // SMI-5360: ...and the skill is not locally quarantined.
+    installable: Boolean(dbSkill.repoUrl) && !isLocalQuarantined,
     version: undefined, // Version not stored in current schema
     category: extractCategoryFromTags(dbSkill.tags),
     trustTier: mapTrustTierFromDb(dbSkill.trustTier as import('@skillsmith/core').TrustTier),
@@ -301,184 +313,10 @@ async function executeGetSkillImpl(
   }
 }
 
-/**
- * Format skill details for terminal/CLI display.
- *
- * Produces a comprehensive human-readable string including:
- * - Basic info (ID, author, version, category)
- * - Full description
- * - Trust tier with explanation
- * - Visual score breakdown bars
- * - Repository and tags
- * - Installation command
- *
- * @param response - Get skill response from executeGetSkill
- * @returns Formatted string suitable for terminal output
- *
- * @example
- * const response = await executeGetSkill({ id: 'getsentry/commit' });
- * console.log(formatSkillDetails(response));
- * // Output:
- * // === commit ===
- * // ID: getsentry/commit
- * // Author: getsentry
- * // Version: 1.2.0
- * // ...
- */
-export function formatSkillDetails(response: GetSkillResponse): string {
-  const skill = response.skill
-  const lines: string[] = []
-
-  lines.push('\n=== ' + skill.name + ' ===\n')
-
-  // Basic info
-  lines.push('ID: ' + skill.id)
-  lines.push('Author: ' + skill.author)
-  lines.push('Version: ' + (skill.version || 'N/A'))
-  lines.push('Category: ' + skill.category)
-  // SMI-4954: surface installability so callers don't try to install a
-  // discovery-only entry that install_skill cannot resolve.
-  if (skill.installable === false) {
-    lines.push('Installable: NO — discovery-only entry (install_skill will not resolve this)')
-  } else if (skill.installable === true) {
-    lines.push('Installable: yes')
-  }
-  lines.push('')
-
-  // Description
-  lines.push('Description:')
-  lines.push('  ' + skill.description)
-  lines.push('')
-
-  // Trust tier with explanation
-  lines.push('Trust Tier: ' + formatTrustTier(skill.trustTier))
-  lines.push('  ' + TrustTierDescriptions[skill.trustTier])
-  lines.push('')
-
-  // Score breakdown
-  lines.push('Overall Score: ' + skill.score + '/100')
-  if (skill.scoreBreakdown) {
-    lines.push('Score Breakdown:')
-    lines.push('  Quality:       ' + formatScoreBar(skill.scoreBreakdown.quality))
-    lines.push('  Popularity:    ' + formatScoreBar(skill.scoreBreakdown.popularity))
-    lines.push('  Maintenance:   ' + formatScoreBar(skill.scoreBreakdown.maintenance))
-    lines.push('  Security:      ' + formatScoreBar(skill.scoreBreakdown.security))
-    lines.push('  Documentation: ' + formatScoreBar(skill.scoreBreakdown.documentation))
-  }
-  lines.push('')
-
-  // Repository
-  if (skill.repository) {
-    lines.push('Repository: ' + skill.repository)
-  }
-
-  // SMI-5327: License — null / whitespace-only means "unknown / not detected", NOT "no license".
-  lines.push('License: ' + (skill.license?.trim() || 'Unknown'))
-
-  // Tags
-  if (skill.tags && skill.tags.length > 0) {
-    lines.push('Tags: ' + skill.tags.join(', '))
-  }
-  lines.push('')
-
-  // SMI-825: Security information
-  lines.push('--- Security ---')
-  if (skill.security) {
-    if (skill.security.passed === null) {
-      lines.push('  Status: Not scanned')
-    } else if (skill.security.passed) {
-      lines.push('  Status: PASSED')
-      lines.push('  Risk Score: ' + (skill.security.riskScore ?? 0) + '/100')
-      lines.push('  Findings: ' + (skill.security.findingsCount ?? 0))
-    } else {
-      lines.push('  Status: FAILED')
-      lines.push('  Risk Score: ' + (skill.security.riskScore ?? 0) + '/100 (HIGH)')
-      lines.push('  Findings: ' + (skill.security.findingsCount ?? 0))
-      lines.push('  WARNING: This skill has security issues. Review carefully before use.')
-    }
-    if (skill.security.scannedAt) {
-      lines.push('  Scanned: ' + skill.security.scannedAt)
-    }
-  } else {
-    lines.push('  Status: Not scanned')
-  }
-  lines.push('')
-
-  // SMI-3137: Dependency intelligence
-  if (response.dependencies && response.dependencies.length > 0) {
-    lines.push('--- Dependencies ---')
-    for (const dep of response.dependencies) {
-      const version = dep.dep_version ? '@' + dep.dep_version : ''
-      const source = dep.dep_source === 'declared' ? '' : ' (inferred)'
-      lines.push('  [' + dep.dep_type + '] ' + dep.dep_target + version + source)
-    }
-    lines.push('')
-  }
-
-  // SMI-2761: Co-install recommendations
-  if (response.also_installed && response.also_installed.length > 0) {
-    lines.push('--- Users Also Installed ---')
-    for (const co of response.also_installed) {
-      lines.push('  ' + co.skillId + (co.description ? ' — ' + co.description : ''))
-    }
-    lines.push('')
-  }
-
-  // SMI-3672: Skill content (SKILL.md)
-  if (response.content) {
-    lines.push('--- Skill Content ---')
-    lines.push(response.content)
-    lines.push('')
-  }
-
-  // Installation
-  lines.push('--- Installation ---')
-  lines.push('  ' + response.installCommand)
-  lines.push('')
-
-  // Timing
-  lines.push('---')
-  lines.push('Retrieved in ' + response.timing.totalMs + 'ms')
-
-  return lines.join('\n')
-}
-
-/**
- * Format trust tier with visual indicator
- * SMI-1809: Added 'local' tier
- * SMI-2381 / SMI-4520: Added 'curated' tier
- * SMI-5205: Added 'official' and 'unverified' tiers
- */
-function formatTrustTier(tier: TrustTier): string {
-  switch (tier) {
-    case 'official':
-      return '[!] OFFICIAL' // SMI-5205: Platform/partner with full security review
-    case 'verified':
-      return '[*] VERIFIED'
-    case 'community':
-      return '[+] COMMUNITY'
-    case 'curated':
-      return '[#] CURATED' // SMI-2381: Third-party publisher
-    case 'local':
-      return '[@] LOCAL' // SMI-1809: Local skills from ~/.claude/skills/
-    case 'experimental':
-      return '[~] EXPERIMENTAL'
-    case 'unknown':
-      return '[?] UNKNOWN'
-    case 'unverified':
-      return '[?] UNVERIFIED' // SMI-5205: Public alias for unknown
-  }
-}
-
-/**
- * Format score as a visual bar
- */
-function formatScoreBar(score: number): string {
-  const filled = Math.round(score / 10)
-  const empty = 10 - filled
-  const bar = '='.repeat(filled) + '-'.repeat(empty)
-  return '[' + bar + '] ' + score + '/100'
-}
+// SMI-5360: formatSkillDetails (+ its trust-tier / score-bar helpers) lives in
+// get-skill.format.ts to keep this file under the 500-line limit. Re-exported
+// here so existing imports from '../tools/get-skill.js' keep working.
+export { formatSkillDetails } from './get-skill.format.js'
 
 // SMI-5017 W2.S2: wrap at export boundary
 export const executeGetSkill = withTelemetry(executeGetSkillImpl, {

--- a/vitest-e2e.config.ts
+++ b/vitest-e2e.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
       // MCP server E2E tests
       'packages/mcp-server/tests/e2e/**/*.test.ts',
       'packages/mcp-server/tests/e2e/**/*.e2e.test.ts',
+      // SMI-5360: core E2E security suite (SSRF / DNS-rebinding). Run only by the
+      // `test:e2e:security` script, which scopes via a positional path. The CLI/
+      // MCP runners pass their own dir positional (CLI_TESTS_DIR / MCP_TESTS_DIR),
+      // so this entry never widens their runs.
+      'packages/core/tests/e2e/**/*.e2e.test.ts',
     ],
     exclude: ['**/node_modules/**', '**/dist/**'],
     testTimeout: 60000, // 60s for E2E (overrides preset 15s)


### PR DESCRIPTION
## SMI-5360 Wave 5 — PR 1 of 2 (the safe, non-prod half)

Residual hardening after Wave 4 (SMI-5359) shipped the quarantine detectors to prod. Two independent items, both API-contract correctness — **not** a new security hole (the canonical install path already refuses quarantined skills via `skill-installation.validate.ts:149`).

### Part A — `get_skill` reports `installable:false` for quarantined skills (MCP, app code)
`executeGetSkill` recomputed `installable` from `repo_url` alone on **both** branches, so a quarantined skill came back `installable:true` next to its own "blocked" security warning — a self-contradictory response.

- **API path** (`get-skill.ts`): `installable = Boolean(repo_url) && quarantined !== true`.
- **Local-DB fallback**: consult `QuarantineRepository.isQuarantined(id)` (local quarantine lives in a separate table, not on the skill row) — mirrors the install path (`install.helpers.ts:240-241`), guarded behind the `repoUrl` check so discovery-only skills do no extra work.
- **Formatter**: `formatSkillDetails` now distinguishes a quarantine block (has repo, not installable → "blocked") from a genuine discovery-only entry (no repo), instead of always printing the misleading "discovery-only entry" reason.
- `formatSkillDetails` + its trust-tier/score-bar helpers moved to `get-skill.format.ts` (re-exported) to keep `get-skill.ts` under the 500-line limit (510 → 325).

Regression check: nothing relies on `installable:true` for a quarantined skill (core API client defaults `?? false`, website has zero consumers, install path blocks independently). Flipping `true → false` is strictly more restrictive.

### Part B — run the SSRF / DNS-rebinding e2e suite in CI (infra)
`packages/core/tests/e2e/security/security.e2e.test.ts` (offline) ran **nowhere** — excluded from the main run and absent from both e2e configs.

- New `test:e2e:security` script (`vitest --config vitest-e2e.config.ts <positional>`).
- Added the core e2e glob to that shared config's `include`. Safe for the CLI/MCP runners: they pass their own dir positional (`CLI_TESTS_DIR` / `MCP_TESTS_DIR`), which never intersects the core path.
- New `security-e2e-tests` job in `e2e-tests.yml` (offline; no git-crypt, no build, no secrets) with an explicit `numTotalTests > 0` assertion so an inert lane (wrong glob) cannot read as a pass.

### Validation
- 53 get-skill unit tests + the 22-test security suite pass in-container; the lane provably executes (`numTotalTests=22`).
- eslint (0 warnings), prettier, file-length (`get-skill.ts` 325, `get-skill.format.ts` 201) all clean.
- Governance (opus, adversarial): **PASS_WITH_WARNINGS**, 0 blockers; the 1 SHOULD-FIX + 2 NITs are folded in.
- Typecheck note: `tsc --build` in this worktree reports one error (`fetchAndScanOptionalFiles` missing on the core **dist**) — a known worktree cross-package false-negative (the worktree resolves `@skillsmith/core` to the main checkout's stale dist on a different branch; the worktree source has the export). CI rebuilds core fresh.
- ADR-109: plan-reviewed (`docs/internal/implementation/smi-5360-wave5-skillsget-ssrf-lane.md`).

### Not in this PR
The edge `skills-get` half ships as **PR 2** — prod-affecting (auto-deploys on merge), gated on a staging deploy + curl validation with a reconvene before the prod merge.
