### PR TITLE
fix(mcp): tighten get_skill quarantine-block message + local id fallback (SMI-5360 Wave 5 PR1 retro)

### DIFF
--- a/packages/mcp-server/src/tools/get-skill.format.ts
+++ b/packages/mcp-server/src/tools/get-skill.format.ts
@@ -49,14 +49,13 @@ export function formatSkillDetails(response: GetSkillResponse): string {
   lines.push('Category: ' + skill.category)
   // SMI-4954: surface installability so callers don't try to install a
   // discovery-only entry that install_skill cannot resolve.
-  // SMI-5360: a skill that carries a repository but is still not installable is
-  // blocked (quarantined / failed security scan), NOT discovery-only — say so
-  // rather than printing the misleading "discovery-only entry" reason.
+  // SMI-5360: installable only flips false for quarantine, so a skill that
+  // carries a repository but is still not installable is quarantine-blocked,
+  // NOT discovery-only — say so rather than printing the misleading
+  // "discovery-only entry" reason.
   if (skill.installable === false) {
     if (skill.repository) {
-      lines.push(
-        'Installable: NO — blocked (quarantined or failed security scan; install_skill will refuse this)'
-      )
+      lines.push('Installable: NO — blocked (quarantined; install_skill will refuse this)')
     } else {
       lines.push('Installable: NO — discovery-only entry (install_skill will not resolve this)')
     }

--- a/packages/mcp-server/src/tools/get-skill.ts
+++ b/packages/mcp-server/src/tools/get-skill.ts
@@ -244,7 +244,7 @@ async function executeGetSkillImpl(
   // no repoUrl is non-installable regardless) — this matches install.helpers.ts,
   // which constructs the repo only inside its repoUrl guard.
   const isLocalQuarantined = dbSkill.repoUrl
-    ? new QuarantineRepository(context.db).isQuarantined(dbSkill.id)
+    ? new QuarantineRepository(context.db).isQuarantined(dbSkill.id || skillId)
     : false
 
   // Convert database skill to MCP skill format


### PR DESCRIPTION
Two NITs from the post-merge governance retro on #1597 (verdict PASS, 0 blockers). Fixed immediately per zero-deferral.

- **Accuracy:** `formatSkillDetails` "blocked" line said "quarantined **or failed security scan**", but `installable` only flips `false` for quarantine — a failed-scan-but-not-quarantined skill stays `installable:true` and prints "Installable: yes". The "or failed security scan" cause never reaches this branch, so it's dropped.
- **Consistency:** local-DB path now calls `isQuarantined(dbSkill.id || skillId)`, matching the defensive sibling call-site (`install.helpers.ts:241`).

Cosmetic + defensive (no behavior change). 53 get-skill tests pass; eslint/prettier clean. These exact changes were vetted by the retro that surfaced them.