### PR TITLE
chore(release): core 0.8.2 / mcp-server 0.5.5 / cli 0.6.5 / vscode 0.6.3 (provenance value chain)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34538,12 +34538,12 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
-        "@skillsmith/core": "^0.8.1",
-        "@skillsmith/mcp-server": "^0.5.4",
+        "@skillsmith/core": "^0.8.2",
+        "@skillsmith/mcp-server": "^0.5.5",
         "chalk": "5.6.2",
         "chokidar": "4.0.3",
         "cli-table3": "0.6.5",
@@ -34651,7 +34651,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -34784,13 +34784,13 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-        "@skillsmith/core": "^0.8.1",
+        "@skillsmith/core": "^0.8.2",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.5.4",
+        "@skillsmith/mcp-server": "^0.5.5",
         "@smithy/config-resolver": "4.4.13",
         "@smithy/core": "3.23.12",
         "@smithy/middleware-endpoint": "4.4.27",
@@ -34805,7 +34805,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.5.4"
+        "@skillsmith/mcp-server": "^0.5.5"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -34929,11 +34929,11 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.8.1",
+        "@skillsmith/core": "^0.8.2",
         "ulid": "3.0.1"
       },
       "bin": {
@@ -34982,7 +34982,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.6.5
+
+- **Fix**: View-Changes accepts install's `github:owner/repo` source + main->master fallback (SMI-5408) (#1602)
+- **Feature**: enrich git/plugin-recovered skills with the registry UUID (SMI-5411) (#1600)
+- **Feature**: affix-tolerant registry-name matching for source recovery (SMI-5413) (#1592)
+
 ## v0.6.4
 
 - **Feature**: recover + backfill canonical GitHub source for local skills (SMI-5407) (#1589)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
-    "@skillsmith/core": "^0.8.1",
-    "@skillsmith/mcp-server": "^0.5.4",
+    "@skillsmith/core": "^0.8.2",
+    "@skillsmith/mcp-server": "^0.5.5",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",
     "cli-table3": "0.6.5",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.8.2
+
+- **Feature**: enrich git/plugin-recovered skills with the registry UUID (SMI-5411) (#1600)
+- **Feature**: affix-tolerant registry-name matching for source recovery (SMI-5413) (#1592)
+
 ## v0.8.1
 
 - **Feature**: recover + backfill canonical GitHub source for local skills (SMI-5407) (#1589)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.8.1'
+export const VERSION = '0.8.2'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-    "@skillsmith/core": "^0.8.1",
+    "@skillsmith/core": "^0.8.2",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.5.4",
+    "@skillsmith/mcp-server": "^0.5.5",
     "@smithy/config-resolver": "4.4.13",
     "@smithy/core": "3.23.12",
     "@smithy/middleware-endpoint": "4.4.27",
@@ -62,7 +62,7 @@
     "vitest": "4.1.6"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.5.4"
+    "@skillsmith/mcp-server": "^0.5.5"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.5.5
+
+- **Feature**: enrich git/plugin-recovered skills with the registry UUID (SMI-5411) (#1600)
+- **Fix**: tighten get_skill quarantine-block message + local id fallback (SMI-5360 Wave 5 PR1 retro) (#1598)
+- **Fix**: get_skill installable:false for quarantined skills + run the SSRF e2e suite in CI (SMI-5360 Wave 5 PR1) (#1597)
+- **Feature**: affix-tolerant registry-name matching for source recovery (SMI-5413) (#1592)
+
 ## v0.5.4
 
 - **Feature**: recover + backfill canonical GitHub source for local skills (SMI-5407) (#1589)

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.8.1",
+    "@skillsmith/core": "^0.8.2",
     "ulid": "3.0.1"
   },
   "devDependencies": {

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.5.4",
+  "version": "0.5.5",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -94,7 +94,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.5.4'
+const PACKAGE_VERSION = '0.5.5'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## v0.6.3
 
 - **Feature**: View Changes uses the recovered manifest source for local skills (SMI-5412) (#1599)
+- **Docs**: Marketplace README de-Claude-Code-specific — the audit/install copy now reflects multi-harness support; the skills directory is configurable (default `~/.claude/skills`) (SMI-5416)
 ### Added
 
 - Added `npm run test:vscode` for a worktree-local vscode test path; local typecheck/test now warn on stale `node_modules` instead of failing opaquely (SMI-5343/5344).

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## v0.6.3
+
+- **Feature**: View Changes uses the recovered manifest source for local skills (SMI-5412) (#1599)
 ### Added
 
 - Added `npm run test:vscode` for a worktree-local vscode test path; local typecheck/test now warn on stale `node_modules` instead of failing opaquely (SMI-5343/5344).

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -6,7 +6,7 @@ Discover, search, and install agent skills directly in VS Code. Works with any M
 
 - **Browse the Skillsmith skill registry** from your VS Code sidebar
 - **View skill details** with rendered SKILL.md documentation
-- **One-click install** skills to `~/.claude/skills`
+- **One-click install** skills to your configured skills directory (default `~/.claude/skills`)
 
 ## Features
 
@@ -18,7 +18,7 @@ Discover, search, and install agent skills directly in VS Code. Works with any M
 | Recommend Skills | Contextual skill recommendations based on your installed skills, surfaced in a quick pick |
 | Compare Skills | Side-by-side comparison of two skills in a panel with quality, trust tier, key differences, and a recommendation |
 | Check for Updates | Compares an installed skill against the latest registry version and advises whether to update (Individual plan or higher) |
-| Audit Skill Inventory | Scans your local `~/.claude/` for namespace collisions and shows a report with suggested renames |
+| Audit Skill Inventory | Scans your local skill inventory for namespace collisions and shows a report with suggested renames |
 | MCP Integration | Live data from the Skillsmith API via Model Context Protocol |
 | Offline Fallback | Works offline with cached local skill data |
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Discover and install agent skills directly in VS Code",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
## Patch release — skill source provenance value chain

Ships the SMI-5407 follow-through end-to-end so recovered skill sources actually drive View-Changes + Check-for-updates.

| Package | From | To |
|---------|------|-----|
| @skillsmith/core | 0.8.1 | **0.8.2** |
| @skillsmith/mcp-server | 0.5.4 | **0.5.5** |
| @skillsmith/cli | 0.6.4 | **0.6.5** |
| skillsmith-vscode | 0.6.2 | **0.6.3** |

Included:
- **SMI-5408** (cli): View-Changes accepts install's `github:owner/repo` source + main→master fallback
- **SMI-5411** (core/mcp/cli): git/plugin-recovered skills get the registry UUID → `skill_outdated` resolves
- **SMI-5412** (vscode): View Changes reads the recovered manifest source + diffs against GitHub raw
- **SMI-5413** (core): affix-tolerant registry-name matching (first release)

`enterprise` unchanged (0.2.0) except cross-package dep bumps. `core`/`mcp` `src` VERSION constants + lockfile updated. Collision guard passed (all proposed > published).

After merge: `gh workflow run publish.yml -f dry_run=false` (core → mcp-server, cli) + trigger the VS Code publish workflow.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)