### PR TITLE
fix(scanner): placeholder/low-entropy gate for PII credential findings (SMI-5420)

### DIFF
--- a/packages/core/src/security/scanner/SecurityScanner.scanners.ts
+++ b/packages/core/src/security/scanner/SecurityScanner.scanners.ts
@@ -212,6 +212,67 @@ export function scanPrivilegeEscalation(
   return findings
 }
 
+/**
+ * SMI-5420: credential PII pattern indices (api/secret/access key, provider
+ * tokens, password) whose matched VALUE can be a documentation placeholder.
+ * Excludes email (7), SSN (8), and the private-key marker (9) — those have no
+ * placeholder-secret failure mode.
+ */
+const CREDENTIAL_PII_INDICES = new Set([0, 1, 2, 3, 4, 5, 6, 10])
+
+/**
+ * SMI-5420: named-placeholder markers that indicate an example, not a real
+ * secret. Intentionally NO `X{4,}` rule — it would test the raw match string and
+ * short-circuit before the entropy check, downgrading a REAL high-entropy secret
+ * that coincidentally contains `xxxx` (governance FN). An all-repeated-char value
+ * (e.g. `xxxx…`) is caught by the `/^(.)\1+$/` check in looksLikePlaceholderSecret
+ * instead, and partial-repeat low-variety values by the entropy floor.
+ */
+const PLACEHOLDER_SECRET_RE =
+  /EXAMPLE|YOUR[_-]?|PLACEHOLDER|CHANGE[_-]?ME|DUMMY|FAKE|SAMPLE|REDACTED|INSERT[_-]|\.\.\.|<[^>]+>/i
+
+/** SMI-5420: minimum Shannon entropy (bits/char) for a value to read as a real secret. */
+const SECRET_ENTROPY_FLOOR = 3.0
+
+/** SMI-5420: Shannon entropy (bits per character) of a string. */
+export function shannonEntropy(s: string): number {
+  if (!s) return 0
+  const freq = new Map<string, number>()
+  for (const ch of s) freq.set(ch, (freq.get(ch) ?? 0) + 1)
+  let h = 0
+  for (const c of freq.values()) {
+    const p = c / s.length
+    h -= p * Math.log2(p)
+  }
+  return h
+}
+
+/**
+ * SMI-5420: extract the secret token from a credential match by stripping a
+ * leading `<key>:`/`<key>=` assignment prefix and surrounding quotes.
+ */
+function extractSecretValue(match: string): string {
+  return match
+    .replace(/^[^:=]*[:=]\s*/, '')
+    .replace(/^['"]|['"]$/g, '')
+    .trim()
+}
+
+/**
+ * SMI-5420: a credential match is a documentation placeholder (not a real leaked
+ * secret) when it carries a named placeholder marker, is a single repeated
+ * character, or its value has sub-secret Shannon entropy. Such matches must NOT
+ * emit critical/high severity — the batch trust-scorer (trust-scorer.ts) and the
+ * install gate quarantine on severity, so an example secret would falsely flag.
+ */
+export function looksLikePlaceholderSecret(match: string): boolean {
+  if (PLACEHOLDER_SECRET_RE.test(match)) return true
+  const value = extractSecretValue(match)
+  if (value.length === 0) return false
+  if (/^(.)\1+$/.test(value)) return true
+  return shannonEntropy(value) < SECRET_ENTROPY_FLOOR
+}
+
 /** SMI-3864: Detect PII patterns. Email in YAML frontmatter gets low severity. */
 export function scanPiiPatterns(content: string, lineContexts?: LineContext[]): SecurityFinding[] {
   const findings: SecurityFinding[] = []
@@ -244,7 +305,15 @@ export function scanPiiPatterns(content: string, lineContexts?: LineContext[]): 
         else if (inDocContext) severity = 'medium'
         else if (pi <= 2 || pi === 9) severity = 'critical'
         else severity = 'high'
-        const confidence: FindingConfidence = inDocContext || inEmailSafeContext ? 'low' : 'high'
+        let confidence: FindingConfidence = inDocContext || inEmailSafeContext ? 'low' : 'high'
+        // SMI-5420: a credential match that reads as a documentation placeholder
+        // (named placeholder, repeated char, or low entropy) must not emit
+        // critical/high — the batch trust-scorer quarantines on severity, so an
+        // example secret like `api_key: "YOUR_API_KEY_HERE"` would falsely flag.
+        if (CREDENTIAL_PII_INDICES.has(pi) && looksLikePlaceholderSecret(match[0])) {
+          severity = 'low'
+          confidence = 'low'
+        }
         findings.push({
           type: 'pii',
           severity,

--- a/packages/core/tests/security/pii-detection.test.ts
+++ b/packages/core/tests/security/pii-detection.test.ts
@@ -6,6 +6,19 @@
 
 import { describe, it, expect } from 'vitest'
 import { SecurityScanner } from '../../src/security/scanner/index.js'
+import {
+  looksLikePlaceholderSecret,
+  shannonEntropy,
+} from '../../src/security/scanner/SecurityScanner.scanners.js'
+
+// Assemble provider-shaped fixtures at runtime so the literal source never
+// contains a contiguous provider-secret pattern (defeats GitHub push protection).
+// These are synthetic test values, not real credentials.
+const cat = (...parts: string[]): string => parts.join('')
+const STRIPE_REAL = cat('sk', '_live_', 'aB3xK9mQ7zP2wL5nR8tY1vC4')
+const STRIPE_PLACEHOLDER = cat('sk', '_live_', 'EXAMPLEKEYPLACEHOLDER1234')
+const GHP_PLACEHOLDER = cat('ghp', '_', 'EXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLE12')
+const AWS_REAL = cat('AKIA', 'JQ7TX9R2K4M6N8P0')
 
 describe('PII Detection (SMI-3864)', () => {
   const scanner = new SecurityScanner()
@@ -15,12 +28,16 @@ describe('PII Detection (SMI-3864)', () => {
       const report = scanner.scan('test', 'api_key = "secret_key_XXXXXXXXXXXXXXXXXXX"')
       const pii = report.findings.filter((f) => f.type === 'pii')
       expect(pii.length).toBeGreaterThan(0)
+      // SMI-5420: this fixture is a repeated-X placeholder -> gated to low.
+      expect(pii[0].severity).toBe('low')
     })
 
     it('should detect secret key assignments', () => {
       const report = scanner.scan('test', 'secret_key = "YYYYYYYYYYYYYYYYYYYYY1234567890"')
       const pii = report.findings.filter((f) => f.type === 'pii')
       expect(pii.length).toBeGreaterThan(0)
+      // SMI-5420: low-entropy repeated-Y placeholder -> gated to low.
+      expect(pii[0].severity).toBe('low')
     })
 
     it('should detect GitHub PATs', () => {
@@ -103,6 +120,111 @@ describe('PII Detection (SMI-3864)', () => {
       const report = scanner.scan('test', 'api_key = "secret_key_XXXXXXXXXXXXXXXXXXX"')
       expect(report.riskBreakdown).toHaveProperty('pii')
       expect(report.riskBreakdown.pii).toBeGreaterThan(0)
+    })
+  })
+
+  // SMI-5420: a credential match that reads as a documentation placeholder must
+  // not emit critical/high severity (the batch trust-scorer quarantines on
+  // severity), while a real high-entropy secret must still flag.
+  describe('SMI-5420 placeholder credential false-positive gate', () => {
+    const placeholders = [
+      'api_key = "YOUR_API_KEY_HERE_xxxxxxxx"',
+      'secret_key = "EXAMPLE1234567890ABCDEF"',
+      'access_token = "REPLACE_WITH_YOUR_TOKEN_HERE"',
+      'api_key = "xxxxxxxxxxxxxxxxxxxxxxxx"',
+      'aws_key: AKIAIOSFODNN7EXAMPLE',
+    ]
+    for (const content of placeholders) {
+      it(`downgrades placeholder credential to low: ${content.slice(0, 28)}`, () => {
+        const report = scanner.scan('test', content)
+        const pii = report.findings.filter((f) => f.type === 'pii')
+        expect(pii.length).toBeGreaterThan(0) // still detected...
+        // ...but low severity, so the batch trust-scorer cannot quarantine it.
+        expect(pii.every((f) => f.severity === 'low')).toBe(true)
+        expect(report.riskScore).toBeLessThan(40)
+      })
+    }
+
+    it('keeps a real high-entropy api key at critical (no FN regression)', () => {
+      const pii = scanner
+        .scan('test', 'api_key = "aB3xK9mQ7zP2wL5nR8tY1vC4"')
+        .findings.filter((f) => f.type === 'pii')
+      expect(pii.length).toBeGreaterThan(0)
+      expect(pii[0].severity).toBe('critical')
+    })
+
+    it('keeps a real secret that coincidentally contains "xxxx" at critical (Finding-1 FN guard)', () => {
+      const pii = scanner
+        .scan('test', 'api_key = "k7xxxx1abc2efgh3ijkl"')
+        .findings.filter((f) => f.type === 'pii')
+      expect(pii.length).toBeGreaterThan(0)
+      expect(pii[0].severity).toBe('critical')
+    })
+
+    it('keeps a real high-entropy password at high (no FN regression)', () => {
+      const pii = scanner
+        .scan('test', 'password = "Tr0ub4dor3xKq9Zp"')
+        .findings.filter((f) => f.type === 'pii')
+      expect(pii.length).toBeGreaterThan(0)
+      expect(pii[0].severity).toBe('high')
+    })
+
+    it('downgrades a placeholder password to low', () => {
+      const pii = scanner
+        .scan('test', 'password = "changeme"')
+        .findings.filter((f) => f.type === 'pii')
+      expect(pii.length).toBeGreaterThan(0)
+      expect(pii[0].severity).toBe('low')
+    })
+
+    it('downgrades provider-token placeholders to low (Stripe, GitHub)', () => {
+      const stripe = scanner
+        .scan('test', `key: ${STRIPE_PLACEHOLDER}`)
+        .findings.filter((f) => f.type === 'pii')
+      expect(stripe[0]?.severity).toBe('low')
+      const gh = scanner
+        .scan('test', `token: ${GHP_PLACEHOLDER}`)
+        .findings.filter((f) => f.type === 'pii')
+      expect(gh[0]?.severity).toBe('low')
+    })
+
+    it('keeps a real provider token at full severity (no FN regression)', () => {
+      const stripe = scanner
+        .scan('test', `key: ${STRIPE_REAL}`)
+        .findings.filter((f) => f.type === 'pii')
+      expect(stripe.length).toBeGreaterThan(0)
+      expect(stripe[0].severity).toBe('high')
+    })
+
+    it('keeps a real AWS access key at high (no FN regression)', () => {
+      const pii = scanner
+        .scan('test', `aws_key: ${AWS_REAL}`)
+        .findings.filter((f) => f.type === 'pii')
+      expect(pii.length).toBeGreaterThan(0)
+      expect(pii[0].severity).toBe('high')
+    })
+
+    it('does not downgrade non-credential PII (SSN keeps full severity)', () => {
+      const pii = scanner.scan('test', 'SSN: 123-45-6789').findings.filter((f) => f.type === 'pii')
+      expect(pii.length).toBeGreaterThan(0)
+      expect(pii[0].severity).not.toBe('low')
+    })
+
+    it('shannonEntropy: 0 for empty/repeated, high for random', () => {
+      expect(shannonEntropy('')).toBe(0)
+      expect(shannonEntropy('aaaaaaaa')).toBe(0)
+      expect(shannonEntropy('aB3xK9mQ7zP2wL5nR8tY1vC4')).toBeGreaterThan(3)
+    })
+
+    it('looksLikePlaceholderSecret: true for placeholders, false for real', () => {
+      expect(looksLikePlaceholderSecret('api_key = "YOUR_API_KEY_HERE"')).toBe(true)
+      expect(looksLikePlaceholderSecret('AKIAIOSFODNN7EXAMPLE')).toBe(true)
+      expect(looksLikePlaceholderSecret('api_key = "xxxxxxxxxxxx"')).toBe(true)
+      expect(looksLikePlaceholderSecret(STRIPE_PLACEHOLDER)).toBe(true)
+      // real secrets — including one with a coincidental "xxxx" run + a provider token
+      expect(looksLikePlaceholderSecret('api_key = "aB3xK9mQ7zP2wL5nR8tY1vC4"')).toBe(false)
+      expect(looksLikePlaceholderSecret('api_key = "k7xxxx1abc2efgh3ijkl"')).toBe(false)
+      expect(looksLikePlaceholderSecret(STRIPE_REAL)).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## SMI-5420: PII placeholder / low-entropy false-positive gate (Wave 4.5)

The core `SecurityScanner` PII scan emits **critical/high** severity for credential matches (api/secret/access key, provider tokens, password) in non-doc context. The batch trust-scorer + install gate quarantine on **severity** (not score), so a SKILL.md containing a PLACEHOLDER credential — `api_key: "YOUR_API_KEY_HERE"`, the AWS canonical `AKIAIOSFODNN7EXAMPLE`, `api_key: "xxxx…"`, `password: "changeme"` — was **falsely quarantined**, even though it is documentation, not a real leaked secret.

### Fix
Gate the matched secret VALUE before it can emit critical/high (`looksLikePlaceholderSecret`): a named-placeholder marker (EXAMPLE / YOUR_ / PLACEHOLDER / CHANGEME / DUMMY / FAKE / SAMPLE / REDACTED / `<…>` / ellipsis), a single repeated char, or sub-secret Shannon entropy (< 3.0 bits/char) → downgrade to low severity + low confidence. Scoped to credential pattern indices {0,1,2,3,4,5,6,10}; **email, SSN, and the private-key marker are untouched**. Core-only (the edge scanner has no `pii` category) → no edge/staging gate; ships in the next core release.

### Scope of impact
This is the **local install / rescan / skill-scanner** path (CLI + MCP `install_skill` + batch trust-scorer) — NOT the prod registry indexer (which uses the edge scanner). It reduces false-positive quarantines of documentation example credentials.

### Rigor
- Adversarial governance (opus) caught a HIGH false-negative: an early `X{4,}` denylist rule tested the raw match and short-circuited before the entropy check, so a real high-entropy secret containing `xxxx` would wrongly downgrade. **Fixed** — removed `X{4,}` (the all-repeated-char + entropy checks cover genuine placeholders) + added an explicit FN-guard test. Also fixed `\bFAKE\b`→`FAKE` consistency + added provider/password FN-regression tests.
- 27 PII tests (placeholders → low + sub-40; real high-entropy api/AWS/Stripe/password stay critical/high; SSN unchanged; helper unit tests). Full typecheck / eslint / prettier / file-length clean; regression-guard + scoring suites green.
- Provider-shaped test fixtures are assembled at runtime so the source never contains a contiguous provider-secret (GitHub push protection).
