### PR TITLE
fix(scanner): guard short PII placeholder markers against coincidental substrings (SMI-5423)

### DIFF
--- a/packages/core/src/security/scanner/SecurityScanner.scanners.ts
+++ b/packages/core/src/security/scanner/SecurityScanner.scanners.ts
@@ -227,9 +227,23 @@ const CREDENTIAL_PII_INDICES = new Set([0, 1, 2, 3, 4, 5, 6, 10])
  * that coincidentally contains `xxxx` (governance FN). An all-repeated-char value
  * (e.g. `xxxx…`) is caught by the `/^(.)\1+$/` check in looksLikePlaceholderSecret
  * instead, and partial-repeat low-variety values by the entropy floor.
+ *
+ * SMI-5423: the SHORT markers (FAKE/DUMMY/SAMPLE/YOUR, ≤6 chars) are guarded with
+ * a negative lookbehind `(?<![A-Za-z0-9])` so they only match as a delimited token
+ * (`FAKE_KEY`, `<FAKE>`, value-start) — NOT mid-random-string (`k7FAKE1abc`), which
+ * is the same raw-match short-circuit FN class as the removed `X{4,}`. Longer
+ * markers (EXAMPLE/PLACEHOLDER/CHANGEME/REDACTED, 7+ chars) stay unbounded: their
+ * coincidence probability is negligible AND `AKIA…7EXAMPLE` needs EXAMPLE to match
+ * mid-token.
+ *
+ * Accepted tradeoff (SMI-5423 governance): a digit-immediately-prefixed token like
+ * `1FAKE_KEY` fails the lookbehind and scores critical rather than low. This is the
+ * FP-SAFE direction (over-flag a rare contrived placeholder) — strictly preferable
+ * in a security scanner to the FN it replaces (a real secret downgraded); and a
+ * longer such value falls under the entropy floor anyway.
  */
 const PLACEHOLDER_SECRET_RE =
-  /EXAMPLE|YOUR[_-]?|PLACEHOLDER|CHANGE[_-]?ME|DUMMY|FAKE|SAMPLE|REDACTED|INSERT[_-]|\.\.\.|<[^>]+>/i
+  /EXAMPLE|(?<![A-Za-z0-9])YOUR[_-]?|PLACEHOLDER|CHANGE[_-]?ME|(?<![A-Za-z0-9])DUMMY|(?<![A-Za-z0-9])FAKE|(?<![A-Za-z0-9])SAMPLE|REDACTED|INSERT[_-]|\.\.\.|<[^>]+>/i
 
 /** SMI-5420: minimum Shannon entropy (bits/char) for a value to read as a real secret. */
 const SECRET_ENTROPY_FLOOR = 3.0

--- a/packages/core/tests/security/pii-detection.test.ts
+++ b/packages/core/tests/security/pii-detection.test.ts
@@ -161,6 +161,28 @@ describe('PII Detection (SMI-3864)', () => {
       expect(pii[0].severity).toBe('critical')
     })
 
+    it('keeps real secrets that coincidentally contain a short marker word at critical (SMI-5423)', () => {
+      // FAKE/DUMMY/SAMPLE/YOUR embedded mid-random-string must NOT downgrade (lookbehind guard).
+      for (const v of [
+        'api_key = "k7FAKE1abc2efgh3ijkl"',
+        'api_key = "k7DUMMY1abc2efgh3ijk"',
+        'api_key = "k7SAMPLE1abc2efgh3ij"',
+        'api_key = "k7YOUR1abc2efgh3ijkl"',
+      ]) {
+        const pii = scanner.scan('test', v).findings.filter((f) => f.type === 'pii')
+        expect(pii.length).toBeGreaterThan(0)
+        expect(pii[0].severity).toBe('critical')
+      }
+    })
+
+    it('still downgrades a delimited-token short-marker placeholder to low (SMI-5423)', () => {
+      const pii = scanner
+        .scan('test', 'api_key = "FAKE_API_KEY_1234567890"')
+        .findings.filter((f) => f.type === 'pii')
+      expect(pii.length).toBeGreaterThan(0)
+      expect(pii[0].severity).toBe('low')
+    })
+
     it('keeps a real high-entropy password at high (no FN regression)', () => {
       const pii = scanner
         .scan('test', 'password = "Tr0ub4dor3xKq9Zp"')
@@ -225,6 +247,10 @@ describe('PII Detection (SMI-3864)', () => {
       expect(looksLikePlaceholderSecret('api_key = "aB3xK9mQ7zP2wL5nR8tY1vC4"')).toBe(false)
       expect(looksLikePlaceholderSecret('api_key = "k7xxxx1abc2efgh3ijkl"')).toBe(false)
       expect(looksLikePlaceholderSecret(STRIPE_REAL)).toBe(false)
+      // SMI-5423: short marker word embedded mid-random-string is NOT a placeholder,
+      // but a delimited-token short marker still is.
+      expect(looksLikePlaceholderSecret('api_key = "k7FAKE1abc2efgh3ijkl"')).toBe(false)
+      expect(looksLikePlaceholderSecret('api_key = "FAKE_API_KEY_1234567890"')).toBe(true)
     })
   })
 })


### PR DESCRIPTION
Fast-follow hardening from the SMI-5420 post-merge retro (adversarial governance). The named-placeholder denylist tested the raw match, so a real high-entropy credential value coincidentally containing a SHORT marker word (FAKE/DUMMY/SAMPLE/YOUR, ≤6 chars) short-circuited to placeholder before the entropy check (`api_key="k7FAKE1abc2efgh3ijkl"` → wrongly low) — the same FN class as the removed `X{4,}`.

Fix: negative lookbehind `(?<![A-Za-z0-9])` on the short markers so they only match as delimited tokens, not mid-random-string. Longer markers (EXAMPLE/PLACEHOLDER/CHANGEME/REDACTED) stay unbounded (negligible coincidence + `AKIA…7EXAMPLE` needs mid-token EXAMPLE).

Governance PASS_WITH_WARNINGS: the digit-prefixed `1FAKE_KEY` edge case now scores critical — documented as the FP-SAFE direction (over-flag a rare placeholder, vs the dangerous FN it replaces). 29 PII tests incl. FN guards for all 4 short markers (k7FAKE/k7DUMMY/k7SAMPLE/k7YOUR → critical) + delimited placeholder still low. Core-only; ships in next core release. Closes SMI-5423.