### PR TITLE
feat(retrieval): W0.1 encoded-project-dir case-fix — resolver + 3 mirrors + telemetry/memory/sessions wiring (SMI-5419)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,7 @@ Project skills load from the `.claude/skills/` mount-point of the `skillsmith-st
 
 ## Session Priming (SMI-4451)
 
-`SessionStart` hooks fire on `source=startup` for branches containing an SMI/wave token anywhere in the name (`smi-NNN` or `wave-NNN`; covers `fix/smi-…`, `chore/smi-…`, etc — SMI-4809 broadened the matcher from literal-prefix only). Deny list: `main`, `hotfix-*`, `dependabot/*`, `renovate/*`, `release/*`, `revert/*`. Two hooks: priming (`scripts/session-start-priming.sh`, requires `SKILLSMITH_PROJECT_DIR_ENCODED`, disable via `SKILLSMITH_DOC_RETRIEVAL_DISABLE_PRIMING=1`) + audit (SMI-4590 — Team/Enterprise namespace audit, 24h debounce, fail-soft, tier-gated; disable via `SKILLSMITH_SESSION_AUDIT_DISABLE=1`). Full mechanism: [ruvector-dev-tooling.md § Session Priming](.claude/development/ruvector-dev-tooling.md#session-priming-smi-4451).
+`SessionStart` hooks fire on `source=startup` for branches containing an SMI/wave token anywhere in the name (`smi-NNN` or `wave-NNN`; covers `fix/smi-…`, `chore/smi-…`, etc — SMI-4809 broadened the matcher from literal-prefix only). Deny list: `main`, `hotfix-*`, `dependabot/*`, `renovate/*`, `release/*`, `revert/*`. Two hooks: priming (`scripts/session-start-priming.sh`, disable via `SKILLSMITH_DOC_RETRIEVAL_DISABLE_PRIMING=1`) + audit (SMI-4590 — Team/Enterprise namespace audit, 24h debounce, fail-soft, tier-gated; disable via `SKILLSMITH_SESSION_AUDIT_DISABLE=1`). Full mechanism: [ruvector-dev-tooling.md § Session Priming](.claude/development/ruvector-dev-tooling.md#session-priming-smi-4451).
 
 ---
 

--- a/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.test.ts
+++ b/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.test.ts
@@ -4,6 +4,7 @@ import { tmpdir, userInfo } from 'node:os'
 import { join } from 'node:path'
 
 import { createMemoryTopicFilesAdapter, resolveMemoryDir } from './memory-topic-files.js'
+import { resetProjectDirCache } from '../retrieval-log/project-dir.js'
 import type { AdapterContext } from '../types.js'
 import type { CorpusConfig } from '../config.js'
 
@@ -82,9 +83,13 @@ beforeEach(() => {
   delete process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE
   memoryDir = join(scratch, '.claude', 'projects', ENCODED, 'memory')
   mkdirSync(memoryDir, { recursive: true })
+  // SMI-5419: resolveMemoryDir now delegates to the module-memoized shared
+  // resolver — reset between cases so a prior test's cwd can't leak through.
+  resetProjectDirCache()
 })
 
 afterEach(() => {
+  resetProjectDirCache()
   vi.mocked(homedirMock).mockReset()
   if (origMemoryOverride === undefined) delete process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE
   else process.env.SKILLSMITH_MEMORY_DIR_OVERRIDE = origMemoryOverride

--- a/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.test.ts
+++ b/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.test.ts
@@ -98,8 +98,16 @@ afterEach(() => {
 
 describe('resolveMemoryDir', () => {
   it('encodes the cwd by swapping slashes for dashes and prepending a leading dash', () => {
-    const dir = resolveMemoryDir('/Users/williamsmith/code')
-    expect(dir?.endsWith(`.claude/projects/-Users-williamsmith-code/memory`)).toBe(true)
+    // SMI-5419 M-1: use a real temp dir (no .git ancestor under /tmp) so the
+    // shared resolver's findMainRepoRoot walk falls back to the cwd encoding
+    // deterministically, independent of the host's real filesystem layout.
+    const cwd = mkdtempSync(join(tmpdir(), 'encode-cwd-'))
+    try {
+      const expected = '-' + cwd.slice(1).replace(/\//g, '-')
+      expect(resolveMemoryDir(cwd)).toBe(join(scratch, '.claude', 'projects', expected, 'memory'))
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
   })
 
   it('returns null for empty or non-absolute cwd', () => {

--- a/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.ts
+++ b/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.ts
@@ -1,9 +1,10 @@
 import { existsSync, statSync } from 'node:fs'
 import { readFile, readdir } from 'node:fs/promises'
-import { homedir, userInfo } from 'node:os'
+import { userInfo } from 'node:os'
 import { basename, join } from 'node:path'
 
 import { chunkBlocks, chunkId, estimateTokens, parseMarkdown } from '../indexer.helpers.js'
+import { resolveSharedProjectDir } from '../retrieval-log/project-dir.js'
 import type { AdapterContext, AdapterFile, ChunkMetadata, SourceAdapter } from '../types.js'
 
 /**
@@ -195,14 +196,12 @@ function isIndexable(name: string): boolean {
  *    Empty/whitespace value falls through to the derivation path so a
  *    contributor explicitly clearing the var doesn't accidentally bypass
  *    the encoded fallback.
- * 2. **Derivation path** — derive `~/.claude/projects/<encoded-cwd>/memory/`
- *    from `cwd`. Encoding per Claude Code harness: replace `/` with `-`,
- *    drop the leading `-`. Documented in SPARC §S2a L2 — if the directory
- *    derives cleanly but doesn't exist on disk, return `null` (soft skip);
- *    we do NOT throw on encoding-drift here because the adapter runs inside
- *    the indexer's per-adapter try-free loop and a throw would abort the
- *    full ingest run. The SPARC note's "throw on encoding drift" intent is
- *    preserved via the roundtrip unit test instead.
+ * 2. **Derivation path** — resolve `<shared>/memory/` via the canonical
+ *    `resolveSharedProjectDir` (SMI-5419), which keys on the MAIN repo root
+ *    (so every worktree of one project shares the memory store) and reconciles
+ *    the encoded name's casing against the on-disk `~/.claude/projects/`
+ *    entries. `listFiles` soft-skips when the dir doesn't exist (SPARC §S2a L2);
+ *    the resolver never throws, so the indexer's per-adapter loop is safe.
  */
 export function resolveMemoryDir(cwd: string): string | null {
   // SMI-4677 §S0 override path. Explicit length check (not truthiness) per
@@ -213,8 +212,8 @@ export function resolveMemoryDir(cwd: string): string | null {
     return override
   }
   if (!cwd || cwd[0] !== '/') return null
-  const encoded = '-' + cwd.slice(1).replace(/\//g, '-')
-  const home = homedir()
-  if (!home) return null
-  return join(home, '.claude', 'projects', encoded, 'memory')
+  // SMI-5419: resolve via the shared main-repo resolver so all worktrees of one
+  // project read the same curated memory store, with on-disk casing reconciled.
+  // Memory is project knowledge, not per-worktree state — same dir as telemetry.
+  return join(resolveSharedProjectDir(cwd).dir, 'memory')
 }

--- a/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.ts
+++ b/packages/doc-retrieval-mcp/src/adapters/memory-topic-files.ts
@@ -1,7 +1,7 @@
 import { existsSync, statSync } from 'node:fs'
 import { readFile, readdir } from 'node:fs/promises'
 import { userInfo } from 'node:os'
-import { basename, join } from 'node:path'
+import { basename, isAbsolute, join } from 'node:path'
 
 import { chunkBlocks, chunkId, estimateTokens, parseMarkdown } from '../indexer.helpers.js'
 import { resolveSharedProjectDir } from '../retrieval-log/project-dir.js'
@@ -215,5 +215,9 @@ export function resolveMemoryDir(cwd: string): string | null {
   // SMI-5419: resolve via the shared main-repo resolver so all worktrees of one
   // project read the same curated memory store, with on-disk casing reconciled.
   // Memory is project knowledge, not per-worktree state — same dir as telemetry.
-  return join(resolveSharedProjectDir(cwd).dir, 'memory')
+  const dir = join(resolveSharedProjectDir(cwd).dir, 'memory')
+  // Preserve the prior null-on-no-home contract (SMI-5419 L-2): if homedir()
+  // resolved empty, the shared dir would be relative — treat as unresolvable so
+  // listFiles' `dir === null` guard still fires.
+  return isAbsolute(dir) ? dir : null
 }

--- a/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.test.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.test.ts
@@ -19,7 +19,7 @@ import {
   reconcileEncodedDir,
   resetProjectDirCache,
   resolveClaudeProjectDir,
-  resolveTelemetryProjectDir,
+  resolveSharedProjectDir,
 } from './project-dir.js'
 
 let homeDir: string
@@ -111,14 +111,14 @@ describe('resolveClaudeProjectDir', () => {
   })
 })
 
-describe('resolveTelemetryProjectDir', () => {
+describe('resolveSharedProjectDir', () => {
   it('exact: resolves to the exact on-disk entry when the main repo root is present', () => {
     const repo = mkdtempSync(join(tmpdir(), 'repo-exact-'))
     mkdirSync(join(repo, '.git')) // .git as a DIRECTORY → findMainRepoRoot returns repo
     const encoded = encodeProjectSegment(repo)
     mkEntry(encoded) // create ~/.claude/projects/<encoded>
     try {
-      const r = resolveTelemetryProjectDir(repo)
+      const r = resolveSharedProjectDir(repo)
       expect(r.state).toBe('exact')
       expect(r.encoded).toBe(encoded)
     } finally {
@@ -130,7 +130,7 @@ describe('resolveTelemetryProjectDir', () => {
     const dir = mkdtempSync(join(tmpdir(), 'no-git-'))
     try {
       // No entry in projectsDir → miss state on a fresh HOME.
-      const r = resolveTelemetryProjectDir(dir)
+      const r = resolveSharedProjectDir(dir)
       expect(r.state).toBe('miss')
       expect(r.encoded).toBe(encodeProjectSegment(dir))
     } finally {
@@ -142,10 +142,10 @@ describe('resolveTelemetryProjectDir', () => {
     const dir = mkdtempSync(join(tmpdir(), 'memo-'))
     try {
       // beforeEach already called resetProjectDirCache(), so telemetryMemo is null.
-      const a = resolveTelemetryProjectDir(dir)
+      const a = resolveSharedProjectDir(dir)
       // Second call with a different arg — the arg is IGNORED because telemetryMemo
       // is already set; the very same object must be returned.
-      const b = resolveTelemetryProjectDir(dir + '/sub')
+      const b = resolveSharedProjectDir(dir + '/sub')
       expect(a).toBe(b)
     } finally {
       rmSync(dir, { recursive: true, force: true })

--- a/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.test.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.test.ts
@@ -19,6 +19,7 @@ import {
   reconcileEncodedDir,
   resetProjectDirCache,
   resolveClaudeProjectDir,
+  resolveTelemetryProjectDir,
 } from './project-dir.js'
 
 let homeDir: string
@@ -107,6 +108,48 @@ describe('resolveClaudeProjectDir', () => {
     expect(r.state).toBe('reconciled')
     expect(r.encoded).toBe('-Users-Foo-Bar')
     expect(r.dir).toBe(join(projectsDir, '-Users-Foo-Bar'))
+  })
+})
+
+describe('resolveTelemetryProjectDir', () => {
+  it('exact: resolves to the exact on-disk entry when the main repo root is present', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'repo-exact-'))
+    mkdirSync(join(repo, '.git')) // .git as a DIRECTORY → findMainRepoRoot returns repo
+    const encoded = encodeProjectSegment(repo)
+    mkEntry(encoded) // create ~/.claude/projects/<encoded>
+    try {
+      const r = resolveTelemetryProjectDir(repo)
+      expect(r.state).toBe('exact')
+      expect(r.encoded).toBe(encoded)
+    } finally {
+      rmSync(repo, { recursive: true, force: true })
+    }
+  })
+
+  it('miss fallback: falls back to cwd encoding with state miss when no .git ancestor exists', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'no-git-'))
+    try {
+      // No entry in projectsDir → miss state on a fresh HOME.
+      const r = resolveTelemetryProjectDir(dir)
+      expect(r.state).toBe('miss')
+      expect(r.encoded).toBe(encodeProjectSegment(dir))
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('memo: returns the identical object reference on repeated calls without a reset', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'memo-'))
+    try {
+      // beforeEach already called resetProjectDirCache(), so telemetryMemo is null.
+      const a = resolveTelemetryProjectDir(dir)
+      // Second call with a different arg — the arg is IGNORED because telemetryMemo
+      // is already set; the very same object must be returned.
+      const b = resolveTelemetryProjectDir(dir + '/sub')
+      expect(a).toBe(b)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.test.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.test.ts
@@ -1,0 +1,128 @@
+/**
+ * SMI-5419 W0.1 — unit tests for the encoded-project-dir resolver.
+ *
+ * Isolation: each test points `$HOME` at a fresh temp dir (os.homedir() honors
+ * $HOME on POSIX, which is where this runs — host + Docker Linux) so the
+ * reconciler reads a controlled `~/.claude/projects/` and never the real one.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  asciiFold,
+  encodeProjectSegment,
+  findMainRepoRoot,
+  reconcileEncodedDir,
+  resetProjectDirCache,
+  resolveClaudeProjectDir,
+} from './project-dir.js'
+
+let homeDir: string
+let projectsDir: string
+const origHome = process.env.HOME
+
+function mkEntry(name: string): void {
+  mkdirSync(join(projectsDir, name), { recursive: true })
+}
+
+beforeEach(() => {
+  homeDir = mkdtempSync(join(tmpdir(), 'projdir-'))
+  projectsDir = join(homeDir, '.claude', 'projects')
+  mkdirSync(projectsDir, { recursive: true })
+  process.env.HOME = homeDir
+  resetProjectDirCache()
+})
+
+afterEach(() => {
+  if (origHome === undefined) delete process.env.HOME
+  else process.env.HOME = origHome
+  rmSync(homeDir, { recursive: true, force: true })
+  resetProjectDirCache()
+})
+
+describe('encodeProjectSegment', () => {
+  it('replaces every slash with a dash, preserving case', () => {
+    expect(encodeProjectSegment('/Users/foo/Bar')).toBe('-Users-foo-Bar')
+  })
+})
+
+describe('asciiFold', () => {
+  it('lowercases only ASCII A-Z and leaves non-ASCII untouched', () => {
+    expect(asciiFold('-Users-FOO-Bar')).toBe('-users-foo-bar')
+    expect(asciiFold('-İstanbul-Æ')).toBe('-İstanbul-Æ')
+  })
+})
+
+describe('reconcileEncodedDir', () => {
+  it('returns exact when the computed name exists verbatim', () => {
+    mkEntry('-Users-foo-Bar')
+    expect(reconcileEncodedDir('-Users-foo-Bar')).toEqual({
+      encoded: '-Users-foo-Bar',
+      state: 'exact',
+    })
+  })
+
+  it('reconciles a pure casing variant to the on-disk casing', () => {
+    mkEntry('-Users-Foo-Bar')
+    const r = reconcileEncodedDir('-users-foo-bar')
+    expect(r.state).toBe('reconciled')
+    expect(r.encoded).toBe('-Users-Foo-Bar')
+  })
+
+  it('anchors casing from a descendant (worktree) entry prefix', () => {
+    mkEntry('-Users-Foo-Bar--worktrees-x')
+    const r = reconcileEncodedDir('-users-foo-bar')
+    expect(r.state).toBe('anchored')
+    expect(r.encoded).toBe('-Users-Foo-Bar')
+  })
+
+  it('does NOT match a longer sibling (substring-collision safety)', () => {
+    mkEntry('-Users-Foo-Barbaz')
+    const r = reconcileEncodedDir('-users-foo-bar')
+    expect(r.state).toBe('miss')
+    expect(r.encoded).toBe('-users-foo-bar')
+  })
+
+  it('flags ambiguous when conflicting case-variants coexist', () => {
+    mkEntry('-Users-Foo-Bar')
+    mkEntry('-Users-FOO-Bar')
+    const r = reconcileEncodedDir('-users-foo-bar')
+    expect(r.state).toBe('ambiguous')
+    expect(r.candidates).toHaveLength(2)
+  })
+
+  it('misses cleanly on a fresh projects dir', () => {
+    expect(reconcileEncodedDir('-Users-new-Project').state).toBe('miss')
+  })
+})
+
+describe('resolveClaudeProjectDir', () => {
+  it('reconciles cwd encoding and returns an absolute dir', () => {
+    mkEntry('-Users-Foo-Bar')
+    const r = resolveClaudeProjectDir('/Users/foo/bar')
+    expect(r.state).toBe('reconciled')
+    expect(r.encoded).toBe('-Users-Foo-Bar')
+    expect(r.dir).toBe(join(projectsDir, '-Users-Foo-Bar'))
+  })
+})
+
+describe('findMainRepoRoot', () => {
+  it('returns null when no .git ancestor exists', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'norepo-'))
+    expect(findMainRepoRoot(dir)).toBeNull()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns the ancestor whose .git is a directory', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'repo-'))
+    mkdirSync(join(repo, '.git'))
+    const sub = join(repo, 'a', 'b')
+    mkdirSync(sub, { recursive: true })
+    expect(findMainRepoRoot(sub)).toBe(repo)
+    rmSync(repo, { recursive: true, force: true })
+  })
+})

--- a/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts
@@ -1,0 +1,215 @@
+/**
+ * SMI-5419 W0.1 — canonical encoded-project-dir resolver with on-disk case
+ * reconciliation.
+ *
+ * Background: Claude Code stores per-project state under
+ * `~/.claude/projects/<encoded>` where `<encoded>` is the project's absolute
+ * path with every `/` replaced by `-`. Several dev-tooling sites independently
+ * re-derive this name. The encoders already AGREE on output; the defect is the
+ * INPUT path's *casing*: `process.cwd()` / a git walk-up can resolve to a
+ * lower-cased variant (e.g. `…/documents/github/…`) that does not match Claude
+ * Code's case-preserving directory. APFS case-insensitivity masks the mismatch
+ * locally; on a case-sensitive filesystem (Linux/CI) the two casings split into
+ * two different directories — which is how the retrieval-telemetry feed went
+ * silently dead for ~6 weeks.
+ *
+ * Fix: after computing the encoded name, reconcile its casing against the
+ * directories that actually exist under `~/.claude/projects/`. We never DECODE
+ * an on-disk name (a real path segment may legitimately contain `-`, so
+ * dash→slash is ambiguous); all matching is done on the ENCODED form, which is
+ * unambiguous.
+ *
+ * Two input policies, exposed as two resolvers:
+ *   - {@link resolveTelemetryProjectDir} — keyed on the MAIN repo root so all
+ *     worktrees of one project share a single `retrieval-logs.db`.
+ *   - {@link resolveClaudeProjectDir} — keyed on the raw cwd (memory / sessions
+ *     state, which Claude Code stores per actual working directory).
+ *
+ * `CLAUDE_PROJECT_DIR` is intentionally NOT used as the source: in a worktree
+ * session it is the worktree path, which would shard the deliberately-shared
+ * telemetry DB. `fs.realpathSync` is intentionally NOT used: it resolves
+ * symlinks/`..` but does not reverse on-disk casing (inert on APFS) and trips
+ * the realpath-asymmetry audit (Check 41).
+ *
+ * This module is the canonical implementation. Two mirrors exist for runtime
+ * boundaries that cannot import it: `scripts/lib/project-dir.mjs` (plain-node
+ * scripts that avoid the tsx startup cost) and a shell function in
+ * `scripts/check-retrieval-events.sh` (must survive a dead-node/dead-binding
+ * state). A cross-runtime parity test keeps all three in agreement; audit
+ * Check 34 enforces that every site references its canonical resolver.
+ */
+
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+/** Outcome of reconciling a computed encoded name against the filesystem. */
+export type ReconcileState =
+  | 'exact' // the computed name exists on disk verbatim
+  | 'reconciled' // a single case-variant existed; we adopted its casing
+  | 'anchored' // borrowed correct casing from a descendant entry's prefix
+  | 'ambiguous' // multiple conflicting case-variants — caller must surface this
+  | 'miss' // nothing on disk to reconcile against (fresh / never-opened project)
+
+export interface ResolvedProjectDir {
+  /** Encoded directory NAME (not a full path) to use under `~/.claude/projects/`. */
+  encoded: string
+  /** Absolute path `~/.claude/projects/<encoded>`. */
+  dir: string
+  state: ReconcileState
+  /** Populated only when `state === 'ambiguous'` — the conflicting on-disk names. */
+  candidates?: string[]
+}
+
+function claudeProjectsRoot(): string {
+  return join(homedir(), '.claude', 'projects')
+}
+
+/**
+ * Walk up from `start` until a directory containing `.git` as a DIRECTORY (not
+ * a file — worktrees have `.git` as a file pointing at the main gitdir). Returns
+ * the first such ancestor, or `null` before filesystem root. For a worktree
+ * under `<repo>/.worktrees/<name>/`, this returns `<repo>` so all worktrees of
+ * one project resolve to the same telemetry DB.
+ */
+export function findMainRepoRoot(start: string): string | null {
+  let current = resolve(start)
+  // Worktrees live inside the main repo, so depth is small; cap for safety.
+  for (let i = 0; i < 64; i += 1) {
+    const gitPath = join(current, '.git')
+    if (existsSync(gitPath)) {
+      try {
+        if (statSync(gitPath).isDirectory()) return current
+      } catch {
+        // unreadable — treat as missing, keep walking
+      }
+    }
+    const parent = dirname(current)
+    if (parent === current) return null
+    current = parent
+  }
+  return null
+}
+
+/**
+ * Encode an absolute path the way Claude Code names `~/.claude/projects/`
+ * entries: replace each `/` with `-`. `/Users/foo/Bar` → `-Users-foo-Bar`.
+ */
+export function encodeProjectSegment(abs: string): string {
+  return abs.replace(/\//g, '-')
+}
+
+/**
+ * ASCII-only lower-case fold. Restricted to `[A-Z]` so locale-specific rules
+ * (Turkish dotless-i, etc.) cannot make the TS and shell/mjs mirrors disagree.
+ */
+export function asciiFold(s: string): string {
+  return s.replace(/[A-Z]/g, (c) => c.toLowerCase())
+}
+
+/** List `~/.claude/projects/` entries, tolerating a fresh install (no dir). */
+function listProjectEntries(): string[] {
+  try {
+    return readdirSync(claudeProjectsRoot())
+  } catch {
+    return [] // ENOENT on a fresh install / wiped state
+  }
+}
+
+/**
+ * Reconcile a computed encoded name against the filesystem WITHOUT decoding.
+ *
+ * Resolution order (each step is unambiguous on the encoded string):
+ *   1. exact      — `<computed>` exists verbatim.
+ *   2. reconciled — exactly one entry equals `<computed>` under ASCII fold
+ *                   (a pure casing variant). Adopt its casing.
+ *   3. anchored   — no full-string variant, but one or more entries are
+ *                   `<computed>-<descendant>` under ASCII fold (e.g. a worktree
+ *                   session of the same repo). Borrow the correctly-cased
+ *                   PREFIX (length-bounded to `<computed>`), never the longer
+ *                   name — so we never select a sub-project's directory
+ *                   (guards the substring-collision trap). Ambiguous only if
+ *                   the candidate prefixes disagree on casing.
+ *   4. ambiguous  — multiple conflicting case-variants at step 2 or 3.
+ *   5. miss       — nothing to reconcile against.
+ *
+ * Returns the name to use plus the state; the caller decides how loudly to
+ * surface non-`exact`/`reconciled`/`anchored` states (warn-once, outage
+ * marker, probe non-zero exit) — this module never throws and never writes.
+ */
+export function reconcileEncodedDir(computed: string): {
+  encoded: string
+  state: ReconcileState
+  candidates?: string[]
+} {
+  if (existsSync(join(claudeProjectsRoot(), computed))) {
+    return { encoded: computed, state: 'exact' }
+  }
+  const entries = listProjectEntries()
+  const foldedComputed = asciiFold(computed)
+
+  // Step 2: full-string case-variant (exact length, not a prefix).
+  const fullMatches = entries.filter((n) => asciiFold(n) === foldedComputed)
+  if (fullMatches.length === 1) return { encoded: fullMatches[0], state: 'reconciled' }
+  if (fullMatches.length > 1)
+    return { encoded: computed, state: 'ambiguous', candidates: fullMatches }
+
+  // Step 3: prefix anchor — borrow casing from a descendant entry's prefix.
+  const prefix = `${foldedComputed}-`
+  const anchorPrefixes = new Set(
+    entries.filter((n) => asciiFold(n).startsWith(prefix)).map((n) => n.slice(0, computed.length))
+  )
+  if (anchorPrefixes.size === 1) {
+    return { encoded: [...anchorPrefixes][0], state: 'anchored' }
+  }
+  if (anchorPrefixes.size > 1) {
+    return { encoded: computed, state: 'ambiguous', candidates: [...anchorPrefixes] }
+  }
+
+  return { encoded: computed, state: 'miss' }
+}
+
+let telemetryMemo: ResolvedProjectDir | null = null
+const cwdMemo = new Map<string, ResolvedProjectDir>()
+
+/** Test-only: reset module-scope memoization between cases. */
+export function resetProjectDirCache(): void {
+  telemetryMemo = null
+  cwdMemo.clear()
+}
+
+function build(encoded: string, state: ReconcileState, candidates?: string[]): ResolvedProjectDir {
+  return {
+    encoded,
+    dir: join(claudeProjectsRoot(), encoded),
+    state,
+    ...(candidates ? { candidates } : {}),
+  }
+}
+
+/**
+ * Resolve the encoded project dir for SHARED telemetry (one DB per project,
+ * across all its worktrees). Memoized at module scope — separate from the DB
+ * handle cache, because the writer's no-op paths re-enter resolution per event.
+ */
+export function resolveTelemetryProjectDir(cwd: string = process.cwd()): ResolvedProjectDir {
+  if (telemetryMemo) return telemetryMemo
+  const root = findMainRepoRoot(cwd) ?? cwd
+  const r = reconcileEncodedDir(encodeProjectSegment(root))
+  telemetryMemo = build(r.encoded, r.state, r.candidates)
+  return telemetryMemo
+}
+
+/**
+ * Resolve the encoded project dir for PER-CWD state (memory / sessions), which
+ * Claude Code stores per actual working directory. Memoized per cwd.
+ */
+export function resolveClaudeProjectDir(cwd: string = process.cwd()): ResolvedProjectDir {
+  const key = resolve(cwd)
+  const cached = cwdMemo.get(key)
+  if (cached) return cached
+  const r = reconcileEncodedDir(encodeProjectSegment(key))
+  const resolved = build(r.encoded, r.state, r.candidates)
+  cwdMemo.set(key, resolved)
+  return resolved
+}

--- a/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts
@@ -20,10 +20,13 @@
  * unambiguous.
  *
  * Two input policies, exposed as two resolvers:
- *   - {@link resolveTelemetryProjectDir} — keyed on the MAIN repo root so all
- *     worktrees of one project share a single `retrieval-logs.db`.
- *   - {@link resolveClaudeProjectDir} — keyed on the raw cwd (memory / sessions
- *     state, which Claude Code stores per actual working directory).
+ *   - {@link resolveSharedProjectDir} — keyed on the MAIN repo root so all
+ *     worktrees of one project share a single store: the `retrieval-logs.db`
+ *     telemetry feed AND the curated `/memory` topic-file corpus (both are
+ *     project-level knowledge, not per-worktree state).
+ *   - {@link resolveClaudeProjectDir} — keyed on the raw cwd for per-working-
+ *     directory state: the session `*.jsonl` transcripts Claude Code writes
+ *     under the actual launch dir.
  *
  * `CLAUDE_PROJECT_DIR` is intentionally NOT used as the source: in a worktree
  * session it is the worktree path, which would shard the deliberately-shared
@@ -188,11 +191,14 @@ function build(encoded: string, state: ReconcileState, candidates?: string[]): R
 }
 
 /**
- * Resolve the encoded project dir for SHARED telemetry (one DB per project,
- * across all its worktrees). Memoized at module scope — separate from the DB
- * handle cache, because the writer's no-op paths re-enter resolution per event.
+ * Resolve the encoded project dir for SHARED, project-level state — keyed on the
+ * MAIN repo root so all worktrees of one project resolve to a single dir. Used by
+ * both the telemetry DB (`retrieval-logs.db`) and the curated `/memory` corpus,
+ * which are project knowledge rather than per-worktree state. Memoized at module
+ * scope — separate from the DB handle cache, because the writer's no-op paths
+ * re-enter resolution per event.
  */
-export function resolveTelemetryProjectDir(cwd: string = process.cwd()): ResolvedProjectDir {
+export function resolveSharedProjectDir(cwd: string = process.cwd()): ResolvedProjectDir {
   if (telemetryMemo) return telemetryMemo
   const root = findMainRepoRoot(cwd) ?? cwd
   const r = reconcileEncodedDir(encodeProjectSegment(root))
@@ -201,8 +207,10 @@ export function resolveTelemetryProjectDir(cwd: string = process.cwd()): Resolve
 }
 
 /**
- * Resolve the encoded project dir for PER-CWD state (memory / sessions), which
- * Claude Code stores per actual working directory. Memoized per cwd.
+ * Resolve the encoded project dir for PER-CWD state — the session `*.jsonl`
+ * transcripts Claude Code writes under the actual working directory. NOT for
+ * memory, which is shared project knowledge (see {@link resolveSharedProjectDir}).
+ * Memoized per cwd.
  */
 export function resolveClaudeProjectDir(cwd: string = process.cwd()): ResolvedProjectDir {
   const key = resolve(cwd)

--- a/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts
@@ -36,10 +36,11 @@
  *
  * This module is the canonical implementation. Two mirrors exist for runtime
  * boundaries that cannot import it: `scripts/lib/project-dir.mjs` (plain-node
- * scripts that avoid the tsx startup cost) and a shell function in
- * `scripts/check-retrieval-events.sh` (must survive a dead-node/dead-binding
- * state). A cross-runtime parity test keeps all three in agreement; audit
- * Check 34 enforces that every site references its canonical resolver.
+ * scripts that avoid the tsx startup cost) and `scripts/lib/project-dir.sh`
+ * (shell paths — e.g. check-retrieval-events.sh — that must survive a
+ * dead-node/dead-binding state). A cross-runtime parity test keeps all three in
+ * agreement; audit Check 34 enforces that every site references its canonical
+ * resolver.
  */
 
 import { existsSync, readdirSync, statSync } from 'node:fs'

--- a/packages/doc-retrieval-mcp/src/retrieval-log/schema.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/schema.ts
@@ -74,7 +74,7 @@ export interface RetrievalEvent {
  */
 export interface RetrievalLogOutageMarker {
   ts: string // ISO-8601 UTC of the failed open attempt
-  reason: 'binding_unavailable' | 'owner_mismatch'
+  reason: 'binding_unavailable' | 'owner_mismatch' | 'project_dir_ambiguous'
   error: string // truncated stringified error (≤500 chars)
   hint: string // remediation pointer surfaced in the priming banner
 }

--- a/packages/doc-retrieval-mcp/src/retrieval-log/writer.case-fix.test.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/writer.case-fix.test.ts
@@ -1,0 +1,111 @@
+/**
+ * SMI-5419 W0.1 — end-to-end case-fix round-trip.
+ *
+ * The original outage: a lower-cased cwd encoded to a project dir that did not
+ * match Claude Code's case-preserving directory, so writes split into a second
+ * dir and the read side never saw them (silent for ~6 weeks). This exercises
+ * the WHOLE native write path (not just the resolver unit): a mis-cased cwd
+ * must reconcile to the EXISTING on-disk dir so a write and a subsequent read
+ * land in the same DB — and no new mis-cased dir is created.
+ *
+ * Lives in a sibling file (not writer.test.ts) because that file is already at
+ * the 500-line soft cap; this keeps the case-fix e2e grouped and isolated.
+ */
+
+import { createRequire } from 'node:module'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type BetterSqlite3 from 'better-sqlite3'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Same native gate as writer.test.ts: require() succeeds even for a Mach-O
+// binary on Linux, so probe by actually opening an in-memory DB.
+const require = createRequire(import.meta.url)
+let Database: typeof BetterSqlite3 | null = null
+let nativeSqliteAvailable = false
+try {
+  const Ctor = require('better-sqlite3') as typeof BetterSqlite3
+  const probe = new Ctor(':memory:')
+  probe.close()
+  Database = Ctor
+  nativeSqliteAvailable = true
+} catch {
+  nativeSqliteAvailable = false
+}
+
+/** Fresh module instance so the project-dir memo + cached DB handle start null. */
+async function freshWriter(): Promise<typeof import('./writer.js')> {
+  vi.resetModules()
+  return import('./writer.js')
+}
+
+let scratch: string
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'writer-casefix-'))
+  // Delete the override so the writer exercises the real resolver path.
+  delete process.env.RETRIEVAL_LOG_DIR_OVERRIDE
+  delete process.env.IS_DOCKER
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+})
+
+afterEach(async () => {
+  const { closeRetrievalLog } = await import('./writer.js')
+  closeRetrievalLog()
+  warnSpy.mockRestore()
+  vi.unstubAllEnvs()
+  rmSync(scratch, { recursive: true, force: true })
+})
+
+describe.skipIf(!nativeSqliteAvailable)('SMI-5419 mis-cased cwd write->read round-trip', () => {
+  it('reconciles to the existing on-disk dir so write and read agree', async () => {
+    // Fake HOME with an EXISTING title-cased project dir (what Claude Code wrote).
+    const fakeHome = join(scratch, 'home')
+    const projects = join(fakeHome, '.claude', 'projects')
+    const onDisk = '-Users-Foo-Bar' // canonical casing already on disk
+    mkdirSync(join(projects, onDisk), { recursive: true })
+    vi.stubEnv('HOME', fakeHome)
+
+    // Mis-cased cwd (the bug shape). findMainRepoRoot('/users/foo/bar') => null
+    // (no .git ancestor) so the resolver keys on the cwd directly:
+    //   encode('/users/foo/bar')      = '-users-foo-bar'
+    //   asciiFold('-Users-Foo-Bar')   = '-users-foo-bar'  → single variant → reconciled
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/users/foo/bar')
+
+    try {
+      const { logRetrievalEvent } = await freshWriter()
+      logRetrievalEvent({
+        sessionId: 'mc-1',
+        ts: '2026-06-27T00:00:00Z',
+        trigger: 'session_start_priming',
+        query: 'q',
+        topKResults: '[]',
+        hookOutcome: 'primed',
+      })
+
+      // The DB lands in the reconciled (title-cased) dir...
+      const reconciledDb = join(projects, onDisk, 'retrieval-logs.db')
+      expect(existsSync(reconciledDb)).toBe(true)
+
+      // ...and NO new mis-cased dir was created (the original split bug).
+      expect(readdirSync(projects)).toEqual([onDisk])
+
+      // Read back through a fresh reader: the row is in the reconciled DB.
+      const db = new Database!(reconciledDb, { readonly: true })
+      const row = db
+        .prepare("SELECT session_id FROM retrieval_events WHERE session_id = 'mc-1'")
+        .get() as { session_id: string } | undefined
+      db.close()
+      expect(row?.session_id).toBe('mc-1')
+
+      // A single clean variant must NOT trip the ambiguity guard.
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringMatching(/ambiguous project dir/))
+    } finally {
+      cwdSpy.mockRestore()
+      vi.unstubAllEnvs()
+    }
+  })
+})

--- a/packages/doc-retrieval-mcp/src/retrieval-log/writer.case-fix.test.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/writer.case-fix.test.ts
@@ -20,6 +20,8 @@ import { join } from 'node:path'
 import type BetterSqlite3 from 'better-sqlite3'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { encodeProjectSegment } from './project-dir.js'
+
 // Same native gate as writer.test.ts: require() succeeds even for a Mach-O
 // binary on Linux, so probe by actually opening an in-memory DB.
 const require = createRequire(import.meta.url)
@@ -56,7 +58,8 @@ afterEach(async () => {
   const { closeRetrievalLog } = await import('./writer.js')
   closeRetrievalLog()
   warnSpy.mockRestore()
-  vi.unstubAllEnvs()
+  // Each test unstubs its own HOME/cwd in a finally; no afterEach unstub needed
+  // (matches writer.test.ts), and a skipped test never stubbed anything.
   rmSync(scratch, { recursive: true, force: true })
 })
 
@@ -65,15 +68,18 @@ describe.skipIf(!nativeSqliteAvailable)('SMI-5419 mis-cased cwd write->read roun
     // Fake HOME with an EXISTING title-cased project dir (what Claude Code wrote).
     const fakeHome = join(scratch, 'home')
     const projects = join(fakeHome, '.claude', 'projects')
-    const onDisk = '-Users-Foo-Bar' // canonical casing already on disk
+    // Two case-variants of the SAME repo path, both UNDER scratch so the
+    // findMainRepoRoot walk is hermetic (no real .git ancestor on any host) and
+    // the test doesn't depend on a fictional absolute path's (non-)existence.
+    const lowerCwd = join(scratch, 'work', 'myrepo') // what process.cwd() reports (the bug: lower-cased)
+    const onDisk = encodeProjectSegment(join(scratch, 'work', 'MyRepo')) // canonical casing on disk
     mkdirSync(join(projects, onDisk), { recursive: true })
     vi.stubEnv('HOME', fakeHome)
 
-    // Mis-cased cwd (the bug shape). findMainRepoRoot('/users/foo/bar') => null
-    // (no .git ancestor) so the resolver keys on the cwd directly:
-    //   encode('/users/foo/bar')      = '-users-foo-bar'
-    //   asciiFold('-Users-Foo-Bar')   = '-users-foo-bar'  → single variant → reconciled
-    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/users/foo/bar')
+    // Mis-cased cwd (the bug shape). findMainRepoRoot(lowerCwd) => null (no .git
+    // ancestor under scratch), so the resolver keys on the cwd directly and the
+    // encoding of lowerCwd ASCII-folds to onDisk's single on-disk variant → reconciled.
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(lowerCwd)
 
     try {
       const { logRetrievalEvent } = await freshWriter()

--- a/packages/doc-retrieval-mcp/src/retrieval-log/writer.test.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/writer.test.ts
@@ -430,7 +430,7 @@ describe.skipIf(!nativeSqliteAvailable)('SMI-4549 Wave 2 — outage marker', () 
 })
 
 describe('ambiguous project dir guard', () => {
-  it('no-ops when resolveTelemetryProjectDir returns ambiguous state', async () => {
+  it('no-ops when resolveSharedProjectDir returns ambiguous state', async () => {
     // The ambiguity check in openDb() fires before require('better-sqlite3'), so
     // this test does NOT need nativeSqliteAvailable — it runs in all environments.
     //

--- a/packages/doc-retrieval-mcp/src/retrieval-log/writer.test.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/writer.test.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   utimesSync,
   writeFileSync,
@@ -425,6 +426,69 @@ describe.skipIf(!nativeSqliteAvailable)('SMI-4549 Wave 2 — outage marker', () 
       topKResults: '[]',
     })
     expect(existsSync(markerPath)).toBe(false)
+  })
+})
+
+describe('ambiguous project dir guard', () => {
+  it('no-ops when resolveTelemetryProjectDir returns ambiguous state', async () => {
+    // The ambiguity check in openDb() fires before require('better-sqlite3'), so
+    // this test does NOT need nativeSqliteAvailable — it runs in all environments.
+    //
+    // The guard is only reached when RETRIEVAL_LOG_DIR_OVERRIDE is unset (the
+    // outer beforeEach sets it; we delete it here for this test).
+    delete process.env.RETRIEVAL_LOG_DIR_OVERRIDE
+
+    // Redirect HOME so we control ~/.claude/projects/ without touching the real one.
+    const fakeHome = join(scratch, 'home-ambig')
+    mkdirSync(join(fakeHome, '.claude', 'projects'), { recursive: true })
+    vi.stubEnv('HOME', fakeHome)
+
+    // Create TWO conflicting case-variant project dir entries that ASCII-fold to
+    // the same string. reconcileEncodedDir() returns 'ambiguous' when it finds
+    // more than one full-string case-variant.
+    const candidate1 = '-Users-Foo-Bar'
+    const candidate2 = '-Users-FOO-Bar'
+    mkdirSync(join(fakeHome, '.claude', 'projects', candidate1), { recursive: true })
+    mkdirSync(join(fakeHome, '.claude', 'projects', candidate2), { recursive: true })
+
+    // Spy on cwd to return a path whose encoding folds to both candidates:
+    //   encodeProjectSegment('/users/foo/bar') = '-users-foo-bar'
+    //   asciiFold('-Users-Foo-Bar') = '-users-foo-bar'  ✓
+    //   asciiFold('-Users-FOO-Bar') = '-users-foo-bar'  ✓
+    // findMainRepoRoot('/users/foo/bar') returns null (no .git ancestor) so the
+    // resolver keys on the cwd directly, producing the ambiguous encoded form.
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/users/foo/bar')
+
+    try {
+      // freshWriter() calls vi.resetModules() so the fresh project-dir.ts module
+      // has telemetryMemo = null and will call process.cwd() on the first event.
+      const { logRetrievalEvent } = await freshWriter()
+      logRetrievalEvent({
+        sessionId: 's',
+        ts: '2026-04-24T12:00:00Z',
+        trigger: 'other',
+        query: 'q',
+        topKResults: '[]',
+      })
+
+      // Must emit the one-shot ambiguity warning.
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/ambiguous project dir/))
+
+      // No DB must have been written into either candidate dir.
+      expect(
+        existsSync(join(fakeHome, '.claude', 'projects', candidate1, 'retrieval-logs.db'))
+      ).toBe(false)
+      expect(
+        existsSync(join(fakeHome, '.claude', 'projects', candidate2, 'retrieval-logs.db'))
+      ).toBe(false)
+
+      // No third (new) project dir must have been created — only the two we seeded.
+      const entries = readdirSync(join(fakeHome, '.claude', 'projects'))
+      expect(entries).toHaveLength(2)
+    } finally {
+      cwdSpy.mockRestore()
+      vi.unstubAllEnvs()
+    }
   })
 })
 

--- a/packages/doc-retrieval-mcp/src/retrieval-log/writer.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/writer.ts
@@ -20,11 +20,7 @@ import { dirname, join, resolve } from 'node:path'
 
 import type BetterSqlite3 from 'better-sqlite3'
 
-import {
-  findMainRepoRoot,
-  resetProjectDirCache,
-  resolveTelemetryProjectDir,
-} from './project-dir.js'
+import { findMainRepoRoot, resetProjectDirCache, resolveSharedProjectDir } from './project-dir.js'
 import {
   CURRENT_SCHEMA_VERSION,
   SCHEMA_SQL,
@@ -84,7 +80,7 @@ export function resolveDbPath(): { dir: string; dbPath: string } {
     const dir = resolve(override)
     return { dir, dbPath: join(dir, 'retrieval-logs.db') }
   }
-  const dir = resolveTelemetryProjectDir().dir
+  const dir = resolveSharedProjectDir().dir
   return { dir, dbPath: join(dir, 'retrieval-logs.db') }
 }
 
@@ -181,7 +177,7 @@ function openDb(): BetterSqlite3.Database | null {
     // ~/.skillsmith/logs/) lands with the W0.1 diagnostics follow-up.
     const overrideActive =
       !!process.env.RETRIEVAL_LOG_DIR_OVERRIDE && process.env.NODE_ENV !== 'production'
-    const telemetryDir = overrideActive ? null : resolveTelemetryProjectDir()
+    const telemetryDir = overrideActive ? null : resolveSharedProjectDir()
     if (telemetryDir?.state === 'ambiguous') {
       if (!ambiguousWarningEmitted) {
         console.warn(

--- a/packages/doc-retrieval-mcp/src/retrieval-log/writer.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/writer.ts
@@ -13,13 +13,18 @@
  * module" contract. Tests call `closeRetrievalLog()` between cases.
  */
 
-import { existsSync, mkdirSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { homedir, userInfo } from 'node:os'
+import { userInfo } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 
 import type BetterSqlite3 from 'better-sqlite3'
 
+import {
+  findMainRepoRoot,
+  resetProjectDirCache,
+  resolveTelemetryProjectDir,
+} from './project-dir.js'
 import {
   CURRENT_SCHEMA_VERSION,
   SCHEMA_SQL,
@@ -27,6 +32,10 @@ import {
   type RetrievalEvent,
   type RetrievalLogOutageMarker,
 } from './schema.js'
+
+// Re-exported for back-compat: callers (and the writer test) historically
+// imported `findMainRepoRoot` from this module (SMI-5419 moved it to project-dir).
+export { findMainRepoRoot }
 
 // ESM-compatible require for native module (matches search.ts pattern for
 // @ruvector/core and betterSqlite3Driver.ts in @skillsmith/core).
@@ -38,6 +47,7 @@ let cachedDb: BetterSqlite3.Database | null = null
 let rowCountWarningEmitted = false
 let dockerWarningEmitted = false
 let ownerMismatchWarningEmitted = false
+let ambiguousWarningEmitted = false
 
 /**
  * Close the cached DB handle (if any). Test-only; production code never
@@ -55,57 +65,8 @@ export function closeRetrievalLog(): void {
   rowCountWarningEmitted = false
   dockerWarningEmitted = false
   ownerMismatchWarningEmitted = false
-}
-
-/**
- * Encode an absolute filesystem path the way Claude Code does for its
- * `~/.claude/projects/` subdirectories: replace each `/` with `-`.
- *
- * `/Users/foo/bar` → `-Users-foo-bar`
- */
-function encodeProjectPath(abs: string): string {
-  return abs.replace(/\//g, '-')
-}
-
-/**
- * Walk up from `start` until a directory is found that contains `.git` as
- * a directory (not a file — worktrees have `.git` as a file pointing to
- * the main repo's gitdir). Returns the first such ancestor, or `null` if
- * none is found before filesystem root.
- *
- * Exported for unit testing; production callers use `resolveProjectDir`.
- */
-export function findMainRepoRoot(start: string): string | null {
-  let current = resolve(start)
-  // Safety cap — git worktrees live inside the main repo, so depth is small.
-  for (let i = 0; i < 64; i += 1) {
-    const gitPath = join(current, '.git')
-    if (existsSync(gitPath)) {
-      try {
-        const st = statSync(gitPath)
-        if (st.isDirectory()) return current
-      } catch {
-        // unreadable — treat as missing, keep walking
-      }
-    }
-    const parent = dirname(current)
-    if (parent === current) return null
-    current = parent
-  }
-  return null
-}
-
-/**
- * Resolve the canonical project dir for the DB path. For worktrees inside
- * `<repo>/.worktrees/<name>/`, this returns `<repo>` (the main repo) so
- * all worktrees on the same project share one `retrieval-logs.db`.
- *
- * Falls back to `process.cwd()` if no main repo ancestor is found.
- */
-function resolveProjectDir(): string {
-  const cwd = process.cwd()
-  const mainRepo = findMainRepoRoot(cwd)
-  return mainRepo ?? cwd
+  ambiguousWarningEmitted = false
+  resetProjectDirCache()
 }
 
 /**
@@ -123,9 +84,7 @@ export function resolveDbPath(): { dir: string; dbPath: string } {
     const dir = resolve(override)
     return { dir, dbPath: join(dir, 'retrieval-logs.db') }
   }
-  const project = resolveProjectDir()
-  const encoded = encodeProjectPath(project)
-  const dir = join(homedir(), '.claude', 'projects', encoded)
+  const dir = resolveTelemetryProjectDir().dir
   return { dir, dbPath: join(dir, 'retrieval-logs.db') }
 }
 
@@ -214,6 +173,26 @@ function openDb(): BetterSqlite3.Database | null {
   }
 
   try {
+    // SMI-5419: refuse to write into an ambiguous (multiple case-variant) project
+    // dir — picking one silently could split the DB. Surface it loudly instead.
+    const overrideActive =
+      !!process.env.RETRIEVAL_LOG_DIR_OVERRIDE && process.env.NODE_ENV !== 'production'
+    if (!overrideActive && resolveTelemetryProjectDir().state === 'ambiguous') {
+      const { candidates } = resolveTelemetryProjectDir()
+      if (!ambiguousWarningEmitted) {
+        console.warn(
+          `[retrieval-logs] ambiguous project dir; refusing to write: ${candidates?.join(', ')}`
+        )
+        ambiguousWarningEmitted = true
+      }
+      writeOutageMarker({
+        ts: new Date().toISOString(),
+        reason: 'project_dir_ambiguous',
+        error: `multiple case-variant ~/.claude/projects dirs: ${candidates?.join(', ')}`,
+        hint: 'consolidate the duplicate dirs (back up + merge retrieval-logs.db)',
+      })
+      return null
+    }
     const { dir, dbPath } = resolveDbPath()
 
     // mode 0700 — user-scoped, private log store (SPARC §S4).

--- a/packages/doc-retrieval-mcp/src/retrieval-log/writer.ts
+++ b/packages/doc-retrieval-mcp/src/retrieval-log/writer.ts
@@ -33,8 +33,8 @@ import {
   type RetrievalLogOutageMarker,
 } from './schema.js'
 
-// Re-exported for back-compat: callers (and the writer test) historically
-// imported `findMainRepoRoot` from this module (SMI-5419 moved it to project-dir).
+// Re-exported for back-compat: writer.test.ts imports findMainRepoRoot from this
+// module (SMI-5419 moved the implementation to project-dir.ts).
 export { findMainRepoRoot }
 
 // ESM-compatible require for native module (matches search.ts pattern for
@@ -174,23 +174,21 @@ function openDb(): BetterSqlite3.Database | null {
 
   try {
     // SMI-5419: refuse to write into an ambiguous (multiple case-variant) project
-    // dir — picking one silently could split the DB. Surface it loudly instead.
+    // dir — picking one silently could split the DB. We deliberately do NOT write
+    // an outage marker here: its dir does not yet exist, so creating it would add a
+    // THIRD case-variant dir and compound the corruption. The warn-once is the
+    // surface; richer banner surfacing (a marker under the case-independent
+    // ~/.skillsmith/logs/) lands with the W0.1 diagnostics follow-up.
     const overrideActive =
       !!process.env.RETRIEVAL_LOG_DIR_OVERRIDE && process.env.NODE_ENV !== 'production'
-    if (!overrideActive && resolveTelemetryProjectDir().state === 'ambiguous') {
-      const { candidates } = resolveTelemetryProjectDir()
+    const telemetryDir = overrideActive ? null : resolveTelemetryProjectDir()
+    if (telemetryDir?.state === 'ambiguous') {
       if (!ambiguousWarningEmitted) {
         console.warn(
-          `[retrieval-logs] ambiguous project dir; refusing to write: ${candidates?.join(', ')}`
+          `[retrieval-logs] ambiguous project dir; refusing to write: ${telemetryDir.candidates?.join(', ')}`
         )
         ambiguousWarningEmitted = true
       }
-      writeOutageMarker({
-        ts: new Date().toISOString(),
-        reason: 'project_dir_ambiguous',
-        error: `multiple case-variant ~/.claude/projects dirs: ${candidates?.join(', ')}`,
-        hint: 'consolidate the duplicate dirs (back up + merge retrieval-logs.db)',
-      })
       return null
     }
     const { dir, dbPath } = resolveDbPath()

--- a/packages/doc-retrieval-mcp/tests/probe.test.ts
+++ b/packages/doc-retrieval-mcp/tests/probe.test.ts
@@ -182,4 +182,50 @@ describe('assessInstrumentationHealth', () => {
     expect(result.stale).toBe(true)
     expect(result.reason).toBe('no_recent_rows')
   })
+
+  // --- SMI-5419 negative / boundary cases (precedence + false-positive guards) ---
+
+  it('a fresh marker takes precedence over an otherwise-healthy DB', async () => {
+    // Marker is read before the row-count path: a real outage must not be masked
+    // by recent rows that happened to land after recovery.
+    seedDb([1, 2, 3]) // would be 'healthy' on its own
+    writeMarker({
+      ts: new Date(NOW.getTime() - 60 * 60 * 1000).toISOString(),
+      reason: 'binding_unavailable',
+      error: 'native binding not found',
+      hint: 'run ./scripts/repair-host-native-deps.sh',
+    })
+    const result = await probe({ jsonlSessionCount24h: 4 })
+    expect(result.stale).toBe(true)
+    expect(result.reason).toBe('outage_marker_present')
+  })
+
+  it('does NOT flag stale at exactly 50% capture rate (no false positive)', async () => {
+    // The gate is `count < 0.5 * sessionCount` — exactly half must read healthy,
+    // so the detector does not cry wolf on the boundary.
+    seedDb([1, 2]) // 2 rows
+    const result = await probe({ jsonlSessionCount24h: 4 }) // 2 == 0.5 * 4
+    expect(result.stale).toBe(false)
+    expect(result.reason).toBe('healthy')
+  })
+
+  it('classifies 5 sessions with 0 rows as low_capture_rate, not no_recent_rows', async () => {
+    // no_recent_rows requires sessionCount > 5; the boundary value 5 falls to the
+    // capture-rate branch (0 < 0.5 * 5). Guards the off-by-one at the gate.
+    const result = await probe({ jsonlSessionCount24h: 5 }) // no DB → 0 rows
+    expect(result.stale).toBe(true)
+    expect(result.reason).toBe('low_capture_rate')
+  })
+
+  it('treats a valid-JSON marker missing a required field as absent', async () => {
+    // Distinct from the malformed-JSON case: parses cleanly but fails the field
+    // shape check, so it must fall through rather than surface a bogus banner.
+    writeFileSync(
+      outageMarkerPath,
+      JSON.stringify({ ts: new Date(NOW.getTime()).toISOString(), reason: 'x', error: 'y' }) // no `hint`
+    )
+    const result = await probe({ jsonlSessionCount24h: 0 })
+    expect(result.outageMarker).toBeNull()
+    expect(result.reason).toBe('healthy')
+  })
 })

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2300,30 +2300,33 @@ console.log(`\n${BOLD}33. PL/pgSQL RETURNS TABLE + RETURNING Ambiguity (R-3, SMI
   }
 }
 
-// 34. SMI-4451 Step 7: encoded-cwd helper drift between writer.ts and
-// session-priming-query.ts. The 4-LOC `'-' + cwd.slice(1).replace(/\//g, '-')`
-// helper is duplicated by design (plan-review #11) instead of extracted to a
-// shared utils/ module — too small to justify a new directory. This check
-// fails if either file lacks the canonical regex form, signaling drift.
-console.log(`\n${BOLD}34. encoded-cwd helper drift (SMI-4451 Step 7)${RESET}`)
+// 34. SMI-5419: encoded-project-dir resolver drift. The canonical resolver now
+// lives in project-dir.ts (the slash→dash encoder literal must exist there) and
+// writer.ts must delegate via resolveTelemetryProjectDir rather than re-deriving
+// the path. The remaining per-cwd encoder sites (session-priming-query.ts
+// memory/sessions, retrieval-log-cli.mjs, retro-frontmatter.mjs) migrate to the
+// scripts/lib .mjs mirror in the wiring step; a cross-runtime parity test then
+// guards behavioral agreement and this check tightens to "all sites import the
+// shared resolver".
+console.log(`\n${BOLD}34. encoded-project-dir resolver drift (SMI-5419)${RESET}`)
 {
-  const PAIR = [
-    'packages/doc-retrieval-mcp/src/retrieval-log/writer.ts',
-    'scripts/session-priming-query.ts',
-  ]
-  // Canonical pattern: replace forward-slashes with hyphens. Match either
-  // regex form (/\//g) or string form ('/'). Both files must match.
-  const ENCODED_CWD_REGEX = /\.replace\(\s*\/\\?\/\/?g\s*,\s*['"]-['"]\s*\)/
-  const missing = PAIR.filter((p) => {
-    if (!existsSync(p)) return true
-    return !ENCODED_CWD_REGEX.test(readFileSync(p, 'utf8'))
-  })
-  if (missing.length === 0) {
-    pass(`Both encoded-cwd duplicates present and aligned (${PAIR.length} files)`)
+  const CANONICAL = 'packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts'
+  const WRITER = 'packages/doc-retrieval-mcp/src/retrieval-log/writer.ts'
+  // Canonical slash→dash encoder; match regex form (/\//g) or string form ('/').
+  const ENCODER_REGEX = /\.replace\(\s*\/\\?\/\/?g\s*,\s*['"]-['"]\s*\)/
+  const problems = []
+  if (!existsSync(CANONICAL) || !ENCODER_REGEX.test(readFileSync(CANONICAL, 'utf8'))) {
+    problems.push(`${CANONICAL} missing the canonical slash->dash encoder`)
+  }
+  if (existsSync(WRITER) && !/resolveTelemetryProjectDir/.test(readFileSync(WRITER, 'utf8'))) {
+    problems.push(`${WRITER} must delegate to resolveTelemetryProjectDir`)
+  }
+  if (problems.length === 0) {
+    pass('encoded-project-dir resolver canonical in project-dir.ts; writer.ts delegates')
   } else {
     fail(
-      `encoded-cwd helper drift in: ${missing.join(', ')}`,
-      `Both writer.ts and session-priming-query.ts must contain \`replace(/\\//g, '-')\` (or string-form '/'). Helper is duplicated by design per smi-4450-step7-session-start-hook.md §S4 (plan-review #11) — extract to a shared module if this drift fires repeatedly.`
+      `encoded-project-dir resolver drift: ${problems.join('; ')}`,
+      `SMI-5419: keep the encoder canonical in project-dir.ts and have writer.ts (and, after wiring, every other site) resolve through it.`
     )
   }
 }

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2302,34 +2302,50 @@ console.log(`\n${BOLD}33. PL/pgSQL RETURNS TABLE + RETURNING Ambiguity (R-3, SMI
 
 // 34. SMI-5419: encoded-project-dir resolver drift. The canonical resolver lives
 // in project-dir.ts (TS) with a behavior-equivalent scripts/lib/project-dir.mjs
-// mirror (for plain-node sites that avoid tsx); a cross-runtime parity test guards
-// agreement. writer.ts + retrieval-log-cli.mjs delegate via the shared resolver.
-// Still-to-migrate per-cwd sites (session-priming-query.ts memory/sessions,
-// memory-topic-files.ts, retro-frontmatter.mjs /memory) land in the next wiring
-// step, after which this check tightens to cover them too.
+// mirror (for plain-node sites that avoid the tsx startup cost); a cross-runtime
+// parity test guards agreement. Every site that needs a `~/.claude/projects/<dir>`
+// path delegates to the shared resolver instead of re-deriving the encoding:
+//   - shared main-repo dir (resolveSharedProjectDir): writer.ts + retrieval-log-cli.mjs
+//     (telemetry DB), session-priming-query.ts (MEMORY.md), memory-topic-files.ts +
+//     retro-frontmatter.mjs (/memory corpus)
+//   - per-cwd dir (resolveClaudeProjectDir): session-priming-query.ts (session *.jsonl)
 console.log(`\n${BOLD}34. encoded-project-dir resolver drift (SMI-5419)${RESET}`)
 {
   const CANONICAL = 'packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts'
   const MJS_MIRROR = 'scripts/lib/project-dir.mjs'
-  const WRITER = 'packages/doc-retrieval-mcp/src/retrieval-log/writer.ts'
-  const CLI = 'scripts/retrieval-log-cli.mjs'
   // Canonical slash→dash encoder; match regex form (/\//g) or string form ('/').
   const ENCODER_REGEX = /\.replace\(\s*\/\\?\/\/?g\s*,\s*['"]-['"]\s*\)/
+  // Sites that MUST resolve via the shared resolver rather than re-deriving the
+  // encoded dir inline; each entry is the resolver symbol the file must reference.
+  const DELEGATES = [
+    ['packages/doc-retrieval-mcp/src/retrieval-log/writer.ts', /resolveSharedProjectDir/],
+    ['scripts/retrieval-log-cli.mjs', /resolveSharedProjectDir/],
+    ['scripts/session-priming-query.ts', /resolveSharedProjectDir/],
+    ['scripts/session-priming-query.ts', /resolveClaudeProjectDir/],
+    ['packages/doc-retrieval-mcp/src/adapters/memory-topic-files.ts', /resolveSharedProjectDir/],
+    ['scripts/lib/retro-frontmatter.mjs', /resolveSharedProjectDir/],
+  ]
+  // Plain-node consumers must IMPORT the .mjs mirror, not re-implement it.
+  const MJS_IMPORTERS = ['scripts/retrieval-log-cli.mjs', 'scripts/lib/retro-frontmatter.mjs']
   const problems = []
   for (const f of [CANONICAL, MJS_MIRROR]) {
     if (!existsSync(f) || !ENCODER_REGEX.test(readFileSync(f, 'utf8'))) {
       problems.push(`${f} missing the canonical slash->dash encoder`)
     }
   }
-  if (existsSync(WRITER) && !/resolveSharedProjectDir/.test(readFileSync(WRITER, 'utf8'))) {
-    problems.push(`${WRITER} must delegate to resolveSharedProjectDir`)
+  for (const [f, re] of DELEGATES) {
+    if (existsSync(f) && !re.test(readFileSync(f, 'utf8'))) {
+      problems.push(`${f} must resolve the encoded project dir via ${re.source}`)
+    }
   }
-  if (existsSync(CLI) && !/from '\.\/lib\/project-dir\.mjs'/.test(readFileSync(CLI, 'utf8'))) {
-    problems.push(`${CLI} must import the shared resolver from ./lib/project-dir.mjs`)
+  for (const f of MJS_IMPORTERS) {
+    if (existsSync(f) && !/from '\.\/(lib\/)?project-dir\.mjs'/.test(readFileSync(f, 'utf8'))) {
+      problems.push(`${f} must import the shared resolver from project-dir.mjs`)
+    }
   }
   if (problems.length === 0) {
     pass(
-      'encoded-project-dir resolver canonical (project-dir.ts + .mjs mirror); writer.ts + retrieval-log-cli.mjs delegate'
+      'encoded-project-dir resolver canonical (project-dir.ts + .mjs mirror); all sites delegate (memory/telemetry main-repo, sessions per-cwd)'
     )
   } else {
     fail(

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2301,13 +2301,15 @@ console.log(`\n${BOLD}33. PL/pgSQL RETURNS TABLE + RETURNING Ambiguity (R-3, SMI
 }
 
 // 34. SMI-5419: encoded-project-dir resolver drift. The canonical resolver lives
-// in project-dir.ts (TS) with a behavior-equivalent scripts/lib/project-dir.mjs
-// mirror (for plain-node sites that avoid the tsx startup cost); a cross-runtime
-// parity test guards agreement. Every site that needs a `~/.claude/projects/<dir>`
-// path delegates to the shared resolver instead of re-deriving the encoding:
+// in project-dir.ts (TS) with two behavior-equivalent mirrors — scripts/lib/
+// project-dir.mjs (plain-node sites that avoid the tsx startup cost) and scripts/
+// lib/project-dir.sh (shell paths that must survive a dead-node/dead-binding
+// state) — all three kept in lock-step by a cross-runtime parity test. Every site
+// that needs a `~/.claude/projects/<dir>` path delegates to a shared resolver
+// instead of re-deriving the encoding:
 //   - shared main-repo dir (resolveSharedProjectDir): writer.ts + retrieval-log-cli.mjs
 //     (telemetry DB), session-priming-query.ts (MEMORY.md), memory-topic-files.ts +
-//     retro-frontmatter.mjs (/memory corpus)
+//     retro-frontmatter.mjs (/memory corpus), check-retrieval-events.sh (diagnostic)
 //   - per-cwd dir (resolveClaudeProjectDir): session-priming-query.ts (session *.jsonl)
 console.log(`\n${BOLD}34. encoded-project-dir resolver drift (SMI-5419)${RESET}`)
 {
@@ -2343,9 +2345,32 @@ console.log(`\n${BOLD}34. encoded-project-dir resolver drift (SMI-5419)${RESET}`
       problems.push(`${f} must import the shared resolver from project-dir.mjs`)
     }
   }
+  // Shell mirror (must survive a dead-node/dead-binding state) + its consumer.
+  const SHELL_MIRROR = 'scripts/lib/project-dir.sh'
+  if (!existsSync(SHELL_MIRROR)) {
+    problems.push(`${SHELL_MIRROR} missing (shell mirror of the resolver)`)
+  } else {
+    const sh = readFileSync(SHELL_MIRROR, 'utf8')
+    for (const fn of [
+      'encode_project_segment',
+      'reconcile_encoded_dir',
+      'resolve_shared_project_dir',
+    ]) {
+      if (!sh.includes(fn)) problems.push(`${SHELL_MIRROR} missing function ${fn}`)
+    }
+  }
+  const SHELL_CONSUMER = 'scripts/check-retrieval-events.sh'
+  if (existsSync(SHELL_CONSUMER)) {
+    const c = readFileSync(SHELL_CONSUMER, 'utf8')
+    if (!/lib\/project-dir\.sh/.test(c) || !/resolve_shared_project_dir/.test(c)) {
+      problems.push(
+        `${SHELL_CONSUMER} must source lib/project-dir.sh and call resolve_shared_project_dir`
+      )
+    }
+  }
   if (problems.length === 0) {
     pass(
-      'encoded-project-dir resolver canonical (project-dir.ts + .mjs mirror); all sites delegate (memory/telemetry main-repo, sessions per-cwd)'
+      'encoded-project-dir resolver canonical (project-dir.ts + .mjs + .sh mirrors); all sites delegate (memory/telemetry main-repo, sessions per-cwd)'
     )
   } else {
     fail(

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2321,8 +2321,8 @@ console.log(`\n${BOLD}34. encoded-project-dir resolver drift (SMI-5419)${RESET}`
       problems.push(`${f} missing the canonical slash->dash encoder`)
     }
   }
-  if (existsSync(WRITER) && !/resolveTelemetryProjectDir/.test(readFileSync(WRITER, 'utf8'))) {
-    problems.push(`${WRITER} must delegate to resolveTelemetryProjectDir`)
+  if (existsSync(WRITER) && !/resolveSharedProjectDir/.test(readFileSync(WRITER, 'utf8'))) {
+    problems.push(`${WRITER} must delegate to resolveSharedProjectDir`)
   }
   if (existsSync(CLI) && !/from '\.\/lib\/project-dir\.mjs'/.test(readFileSync(CLI, 'utf8'))) {
     problems.push(`${CLI} must import the shared resolver from ./lib/project-dir.mjs`)

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2300,33 +2300,41 @@ console.log(`\n${BOLD}33. PL/pgSQL RETURNS TABLE + RETURNING Ambiguity (R-3, SMI
   }
 }
 
-// 34. SMI-5419: encoded-project-dir resolver drift. The canonical resolver now
-// lives in project-dir.ts (the slash→dash encoder literal must exist there) and
-// writer.ts must delegate via resolveTelemetryProjectDir rather than re-deriving
-// the path. The remaining per-cwd encoder sites (session-priming-query.ts
-// memory/sessions, retrieval-log-cli.mjs, retro-frontmatter.mjs) migrate to the
-// scripts/lib .mjs mirror in the wiring step; a cross-runtime parity test then
-// guards behavioral agreement and this check tightens to "all sites import the
-// shared resolver".
+// 34. SMI-5419: encoded-project-dir resolver drift. The canonical resolver lives
+// in project-dir.ts (TS) with a behavior-equivalent scripts/lib/project-dir.mjs
+// mirror (for plain-node sites that avoid tsx); a cross-runtime parity test guards
+// agreement. writer.ts + retrieval-log-cli.mjs delegate via the shared resolver.
+// Still-to-migrate per-cwd sites (session-priming-query.ts memory/sessions,
+// memory-topic-files.ts, retro-frontmatter.mjs /memory) land in the next wiring
+// step, after which this check tightens to cover them too.
 console.log(`\n${BOLD}34. encoded-project-dir resolver drift (SMI-5419)${RESET}`)
 {
   const CANONICAL = 'packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts'
+  const MJS_MIRROR = 'scripts/lib/project-dir.mjs'
   const WRITER = 'packages/doc-retrieval-mcp/src/retrieval-log/writer.ts'
+  const CLI = 'scripts/retrieval-log-cli.mjs'
   // Canonical slash→dash encoder; match regex form (/\//g) or string form ('/').
   const ENCODER_REGEX = /\.replace\(\s*\/\\?\/\/?g\s*,\s*['"]-['"]\s*\)/
   const problems = []
-  if (!existsSync(CANONICAL) || !ENCODER_REGEX.test(readFileSync(CANONICAL, 'utf8'))) {
-    problems.push(`${CANONICAL} missing the canonical slash->dash encoder`)
+  for (const f of [CANONICAL, MJS_MIRROR]) {
+    if (!existsSync(f) || !ENCODER_REGEX.test(readFileSync(f, 'utf8'))) {
+      problems.push(`${f} missing the canonical slash->dash encoder`)
+    }
   }
   if (existsSync(WRITER) && !/resolveTelemetryProjectDir/.test(readFileSync(WRITER, 'utf8'))) {
     problems.push(`${WRITER} must delegate to resolveTelemetryProjectDir`)
   }
+  if (existsSync(CLI) && !/from '\.\/lib\/project-dir\.mjs'/.test(readFileSync(CLI, 'utf8'))) {
+    problems.push(`${CLI} must import the shared resolver from ./lib/project-dir.mjs`)
+  }
   if (problems.length === 0) {
-    pass('encoded-project-dir resolver canonical in project-dir.ts; writer.ts delegates')
+    pass(
+      'encoded-project-dir resolver canonical (project-dir.ts + .mjs mirror); writer.ts + retrieval-log-cli.mjs delegate'
+    )
   } else {
     fail(
       `encoded-project-dir resolver drift: ${problems.join('; ')}`,
-      `SMI-5419: keep the encoder canonical in project-dir.ts and have writer.ts (and, after wiring, every other site) resolve through it.`
+      `SMI-5419: keep the encoder canonical in project-dir.ts + scripts/lib/project-dir.mjs (parity-tested) and have all sites resolve through the shared resolver.`
     )
   }
 }

--- a/scripts/check-retrieval-events.sh
+++ b/scripts/check-retrieval-events.sh
@@ -19,28 +19,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Walk up to the main repo root (worktrees: stop at the first dir whose
-# .git is a directory). Mirrors writer.ts/findMainRepoRoot.
-resolve_main_repo_root() {
-  local current parent depth
-  current="$1"
-  depth=0
-  while (( depth < 64 )); do
-    if [[ -d "$current/.git" ]]; then
-      printf '%s\n' "$current"
-      return 0
-    fi
-    parent="$(dirname "$current")"
-    if [[ "$parent" == "$current" ]]; then
-      return 1
-    fi
-    current="$parent"
-    depth=$(( depth + 1 ))
-  done
-  return 1
-}
-
-MAIN_REPO_ROOT="$(resolve_main_repo_root "$REPO_ROOT" 2>/dev/null || echo "$REPO_ROOT")"
+# SMI-5419: shared shell mirror of the encoded-project-dir resolver, parity-tested
+# against project-dir.ts / project-dir.mjs. Provides find_main_repo_root +
+# reconcile_encoded_dir + resolve_shared_project_dir so this diagnostic reads the
+# SAME dir the writer wrote to even when the cwd casing differs from the one
+# Claude Code recorded under ~/.claude/projects/.
+# shellcheck source=lib/project-dir.sh
+. "$SCRIPT_DIR/lib/project-dir.sh"
 
 if [[ -n "${IS_DOCKER:-}" ]] && [[ ! -e /.dockerenv ]]; then
   echo "stale: IS_DOCKER=$IS_DOCKER set on host but /.dockerenv absent — writer will no-op"
@@ -48,7 +33,17 @@ if [[ -n "${IS_DOCKER:-}" ]] && [[ ! -e /.dockerenv ]]; then
   exit 1
 fi
 
-ENCODED="$(echo "$MAIN_REPO_ROOT" | sed 's|^/|-|;s|/|-|g')"
+# SMI-5419: resolve + casing-reconcile against ~/.claude/projects/ so a lower-cased
+# cwd (the original bug) no longer points the probe at a different dir than the
+# writer used — which split the feed and reported a false "no DB".
+RECONCILED="$(resolve_shared_project_dir "$REPO_ROOT")"
+RECONCILE_STATE="$(printf '%s' "$RECONCILED" | cut -f1)"
+ENCODED="$(printf '%s' "$RECONCILED" | cut -f2)"
+if [[ "$RECONCILE_STATE" == "ambiguous" ]]; then
+  echo "probe-failed: ambiguous project dir — multiple case-variants under ~/.claude/projects/ fold to the same name; cannot determine the canonical DB"
+  echo "fix: remove the stale case-variant dir(s) so only the canonical one remains"
+  exit 2
+fi
 PROJECT_DIR="$HOME/.claude/projects/$ENCODED"
 DB_PATH="$PROJECT_DIR/retrieval-logs.db"
 MARKER_PATH="$PROJECT_DIR/retrieval-log.outage.json"

--- a/scripts/lib/project-dir.d.mts
+++ b/scripts/lib/project-dir.d.mts
@@ -27,5 +27,5 @@ export function reconcileEncodedDir(computed: string): {
   candidates?: string[]
 }
 export function resetProjectDirCache(): void
-export function resolveTelemetryProjectDir(cwd?: string): ResolvedProjectDir
+export function resolveSharedProjectDir(cwd?: string): ResolvedProjectDir
 export function resolveClaudeProjectDir(cwd?: string): ResolvedProjectDir

--- a/scripts/lib/project-dir.d.mts
+++ b/scripts/lib/project-dir.d.mts
@@ -1,0 +1,31 @@
+/**
+ * SMI-5419 W0.1 — type declarations for scripts/lib/project-dir.mjs.
+ *
+ * Mirrors the exports of the canonical TS resolver
+ * (packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts) so that
+ * TypeScript consumers (e.g. the cross-runtime parity test) can import
+ * project-dir.mjs cleanly under NodeNext module resolution without
+ * @ts-expect-error suppression. The .d.mts extension is the correct pairing
+ * for a .mjs module under NodeNext.
+ */
+
+export type ReconcileState = 'exact' | 'reconciled' | 'anchored' | 'ambiguous' | 'miss'
+
+export interface ResolvedProjectDir {
+  encoded: string
+  dir: string
+  state: ReconcileState
+  candidates?: string[]
+}
+
+export function findMainRepoRoot(start: string): string | null
+export function encodeProjectSegment(abs: string): string
+export function asciiFold(s: string): string
+export function reconcileEncodedDir(computed: string): {
+  encoded: string
+  state: ReconcileState
+  candidates?: string[]
+}
+export function resetProjectDirCache(): void
+export function resolveTelemetryProjectDir(cwd?: string): ResolvedProjectDir
+export function resolveClaudeProjectDir(cwd?: string): ResolvedProjectDir

--- a/scripts/lib/project-dir.mjs
+++ b/scripts/lib/project-dir.mjs
@@ -1,0 +1,128 @@
+/**
+ * SMI-5419 W0.1 — plain-Node mirror of the canonical encoded-project-dir
+ * resolver (packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts).
+ *
+ * Exists because plain-node scripts (retrieval-log-cli.mjs, retro-frontmatter.mjs)
+ * run WITHOUT tsx — to avoid its ~300ms startup cost — and so cannot import the
+ * package TS. This file MUST stay behavior-equivalent to project-dir.ts; the
+ * cross-runtime parity test (scripts/tests/project-dir-parity.test.ts) feeds both
+ * runtimes identical inputs and asserts identical output. See project-dir.ts for
+ * the full rationale: the bug is input-path CASING (not the encoding); we never
+ * decode an on-disk name; CLAUDE_PROJECT_DIR is wrong (worktree shards the shared
+ * DB) and realpathSync is inert on APFS.
+ */
+
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+function claudeProjectsRoot() {
+  return join(homedir(), '.claude', 'projects')
+}
+
+/** Walk up to the first ancestor whose `.git` is a DIRECTORY (worktrees have a file). */
+export function findMainRepoRoot(start) {
+  let current = resolve(start)
+  for (let i = 0; i < 64; i += 1) {
+    const gitPath = join(current, '.git')
+    if (existsSync(gitPath)) {
+      try {
+        if (statSync(gitPath).isDirectory()) return current
+      } catch {
+        // unreadable — treat as missing, keep walking
+      }
+    }
+    const parent = dirname(current)
+    if (parent === current) return null
+    current = parent
+  }
+  return null
+}
+
+/** Replace each `/` with `-` (Claude Code's `~/.claude/projects/` naming). */
+export function encodeProjectSegment(abs) {
+  return abs.replace(/\//g, '-')
+}
+
+/** ASCII-only lower-case fold (restricted to [A-Z] so TS/mjs/shell agree). */
+export function asciiFold(s) {
+  return s.replace(/[A-Z]/g, (c) => c.toLowerCase())
+}
+
+function listProjectEntries() {
+  try {
+    return readdirSync(claudeProjectsRoot())
+  } catch {
+    return [] // ENOENT on a fresh install / wiped state
+  }
+}
+
+/**
+ * Reconcile a computed encoded name against the filesystem WITHOUT decoding.
+ * Order: exact → full-string case-variant (reconciled) → descendant prefix
+ * (anchored, length-bounded so we never select a sub-project) → ambiguous → miss.
+ * Mirror of reconcileEncodedDir in project-dir.ts.
+ */
+export function reconcileEncodedDir(computed) {
+  if (existsSync(join(claudeProjectsRoot(), computed))) {
+    return { encoded: computed, state: 'exact' }
+  }
+  const entries = listProjectEntries()
+  const foldedComputed = asciiFold(computed)
+
+  const fullMatches = entries.filter((n) => asciiFold(n) === foldedComputed)
+  if (fullMatches.length === 1) return { encoded: fullMatches[0], state: 'reconciled' }
+  if (fullMatches.length > 1)
+    return { encoded: computed, state: 'ambiguous', candidates: fullMatches }
+
+  const prefix = `${foldedComputed}-`
+  const anchorPrefixes = new Set(
+    entries.filter((n) => asciiFold(n).startsWith(prefix)).map((n) => n.slice(0, computed.length))
+  )
+  if (anchorPrefixes.size === 1) {
+    return { encoded: [...anchorPrefixes][0], state: 'anchored' }
+  }
+  if (anchorPrefixes.size > 1) {
+    return { encoded: computed, state: 'ambiguous', candidates: [...anchorPrefixes] }
+  }
+
+  return { encoded: computed, state: 'miss' }
+}
+
+let telemetryMemo = null
+const cwdMemo = new Map()
+
+/** Test-only: reset module-scope memoization between cases. */
+export function resetProjectDirCache() {
+  telemetryMemo = null
+  cwdMemo.clear()
+}
+
+function build(encoded, state, candidates) {
+  return {
+    encoded,
+    dir: join(claudeProjectsRoot(), encoded),
+    state,
+    ...(candidates ? { candidates } : {}),
+  }
+}
+
+/** SHARED telemetry dir (one DB per project across worktrees). Memoized. */
+export function resolveTelemetryProjectDir(cwd = process.cwd()) {
+  if (telemetryMemo) return telemetryMemo
+  const root = findMainRepoRoot(cwd) ?? cwd
+  const r = reconcileEncodedDir(encodeProjectSegment(root))
+  telemetryMemo = build(r.encoded, r.state, r.candidates)
+  return telemetryMemo
+}
+
+/** PER-CWD dir (memory / sessions). Memoized per cwd. */
+export function resolveClaudeProjectDir(cwd = process.cwd()) {
+  const key = resolve(cwd)
+  const cached = cwdMemo.get(key)
+  if (cached) return cached
+  const r = reconcileEncodedDir(encodeProjectSegment(key))
+  const resolved = build(r.encoded, r.state, r.candidates)
+  cwdMemo.set(key, resolved)
+  return resolved
+}

--- a/scripts/lib/project-dir.mjs
+++ b/scripts/lib/project-dir.mjs
@@ -107,8 +107,9 @@ function build(encoded, state, candidates) {
   }
 }
 
-/** SHARED telemetry dir (one DB per project across worktrees). Memoized. */
-export function resolveTelemetryProjectDir(cwd = process.cwd()) {
+/** SHARED project-level dir (telemetry DB + /memory corpus), keyed on the main
+ * repo root so all worktrees share one. Memoized. */
+export function resolveSharedProjectDir(cwd = process.cwd()) {
   if (telemetryMemo) return telemetryMemo
   const root = findMainRepoRoot(cwd) ?? cwd
   const r = reconcileEncodedDir(encodeProjectSegment(root))
@@ -116,7 +117,8 @@ export function resolveTelemetryProjectDir(cwd = process.cwd()) {
   return telemetryMemo
 }
 
-/** PER-CWD dir (memory / sessions). Memoized per cwd. */
+/** PER-CWD dir for session *.jsonl transcripts (NOT memory — that's shared via
+ * resolveSharedProjectDir). Memoized per cwd. */
 export function resolveClaudeProjectDir(cwd = process.cwd()) {
   const key = resolve(cwd)
   const cached = cwdMemo.get(key)

--- a/scripts/lib/project-dir.sh
+++ b/scripts/lib/project-dir.sh
@@ -34,6 +34,11 @@ ascii_fold() { printf '%s' "$1" | LC_ALL=C tr 'A-Z' 'a-z'; }
 
 # Walk up for the first ancestor whose .git is a DIRECTORY (worktrees have .git
 # as a file). Echoes the path and returns 0, or returns 1 before filesystem root.
+#
+# Unlike project-dir.ts (which calls path.resolve first), this assumes an already
+# absolute, lexically-normalized input — every caller derives it via `cd && pwd`
+# or `git rev-parse --show-toplevel`, so there is no relative/`..` form to resolve.
+# We deliberately do NOT use realpath here (it resolves symlinks; see project-dir.ts).
 find_main_repo_root() {
   local current parent depth
   current="$1"

--- a/scripts/lib/project-dir.sh
+++ b/scripts/lib/project-dir.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# SMI-5419 W0.1 — shell mirror of the canonical encoded-project-dir resolver
+# (packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts).
+#
+# Why a third mirror: the diagnostic + hook shell paths must keep working in the
+# exact dead-node / dead-binding state that hid the original 6-week telemetry
+# outage, so they cannot shell out to the TS/mjs resolver. This file MUST stay
+# behaviour-equivalent to project-dir.ts and project-dir.mjs; the cross-runtime
+# parity test (scripts/tests/project-dir-parity.test.ts) feeds all three the same
+# inputs and asserts identical (state, encoded) output.
+#
+# Invariants (see project-dir.ts for the full rationale):
+#   - The bug is the INPUT path's casing, never the encoding; we never DECODE an
+#     on-disk name (dash->slash is ambiguous), only match on the encoded form.
+#   - The SHARED dir keys on the MAIN repo root so all worktrees of one project
+#     resolve to one dir (NOT CLAUDE_PROJECT_DIR, which shards it per worktree).
+#
+# Portability: bash 3.2 (stock macOS) — no associative arrays, no `mapfile`.
+#
+# Source it and call the functions, or run as a CLI (used by the parity test):
+#   bash project-dir.sh reconcile <computed-encoded-name>   -> "<state>\t<encoded>"
+#   bash project-dir.sh resolve-shared <cwd>                -> "<state>\t<encoded>"
+
+claude_projects_root() { printf '%s' "${HOME}/.claude/projects"; }
+
+# Replace every '/' with '-' (matches encodeProjectSegment in project-dir.ts).
+encode_project_segment() { printf '%s' "${1//\//-}"; }
+
+# ASCII-only lowercase fold (A-Z only), matching asciiFold(). LC_ALL=C makes tr
+# map bytes A-Z->a-z without locale rules, and no UTF-8 multibyte byte ever falls
+# in 0x41-0x5A, so non-ASCII (e.g. Turkish dotless-i, Æ) passes through unchanged
+# — exactly like the JS /[A-Z]/ replacement.
+ascii_fold() { printf '%s' "$1" | LC_ALL=C tr 'A-Z' 'a-z'; }
+
+# Walk up for the first ancestor whose .git is a DIRECTORY (worktrees have .git
+# as a file). Echoes the path and returns 0, or returns 1 before filesystem root.
+find_main_repo_root() {
+  local current parent depth
+  current="$1"
+  depth=0
+  while [ "$depth" -lt 64 ]; do
+    if [ -d "$current/.git" ]; then
+      printf '%s' "$current"
+      return 0
+    fi
+    parent="$(dirname "$current")"
+    if [ "$parent" = "$current" ]; then
+      return 1
+    fi
+    current="$parent"
+    depth=$((depth + 1))
+  done
+  return 1
+}
+
+# Reconcile a computed encoded name against the filesystem WITHOUT decoding.
+# Echoes "<state>\t<encoded>" (no trailing newline). State order mirrors
+# reconcileEncodedDir: exact -> reconciled -> anchored -> ambiguous -> miss.
+reconcile_encoded_dir() {
+  local computed root entry name folded_computed folded_name clen prefix
+  computed="$1"
+  root="$(claude_projects_root)"
+
+  # 1. exact — the computed name exists verbatim (file or dir, matches existsSync).
+  if [ -e "$root/$computed" ]; then
+    printf '%s\t%s' "exact" "$computed"
+    return 0
+  fi
+  if [ ! -d "$root" ]; then
+    printf '%s\t%s' "miss" "$computed"
+    return 0
+  fi
+
+  folded_computed="$(ascii_fold "$computed")"
+  clen=${#computed}
+
+  # 2. reconciled — exactly one entry equals computed under ASCII fold.
+  local full=()
+  for entry in "$root"/*; do
+    [ -e "$entry" ] || continue
+    name="${entry##*/}"
+    if [ "$(ascii_fold "$name")" = "$folded_computed" ]; then
+      full+=("$name")
+    fi
+  done
+  if [ "${#full[@]}" -eq 1 ]; then
+    printf '%s\t%s' "reconciled" "${full[0]}"
+    return 0
+  fi
+  if [ "${#full[@]}" -gt 1 ]; then
+    printf '%s\t%s' "ambiguous" "$computed"
+    return 0
+  fi
+
+  # 3. anchored — a descendant entry's length-bounded prefix supplies the casing.
+  prefix="${folded_computed}-"
+  local anchors=()
+  for entry in "$root"/*; do
+    [ -e "$entry" ] || continue
+    name="${entry##*/}"
+    folded_name="$(ascii_fold "$name")"
+    case "$folded_name" in
+      "$prefix"*) anchors+=("${name:0:clen}") ;;
+    esac
+  done
+  if [ "${#anchors[@]}" -gt 0 ]; then
+    # Dedupe without associative arrays (bash 3.2): sort -u into an indexed array.
+    local uniq=() line
+    while IFS= read -r line; do
+      [ -n "$line" ] && uniq+=("$line")
+    done < <(printf '%s\n' "${anchors[@]}" | sort -u)
+    if [ "${#uniq[@]}" -eq 1 ]; then
+      printf '%s\t%s' "anchored" "${uniq[0]}"
+      return 0
+    fi
+    if [ "${#uniq[@]}" -gt 1 ]; then
+      printf '%s\t%s' "ambiguous" "$computed"
+      return 0
+    fi
+  fi
+
+  printf '%s\t%s' "miss" "$computed"
+}
+
+# SHARED dir keyed on the main repo root (telemetry DB + /memory corpus).
+# Echoes "<state>\t<encoded>".
+resolve_shared_project_dir() {
+  local cwd root
+  cwd="${1:-$PWD}"
+  root="$(find_main_repo_root "$cwd" 2>/dev/null || printf '%s' "$cwd")"
+  reconcile_encoded_dir "$(encode_project_segment "$root")"
+}
+
+# CLI dispatch only when executed directly (not when sourced).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  case "${1:-}" in
+    reconcile) reconcile_encoded_dir "${2:-}" ;;
+    resolve-shared) resolve_shared_project_dir "${2:-$PWD}" ;;
+    *)
+      echo "usage: project-dir.sh {reconcile <computed>|resolve-shared <cwd>}" >&2
+      exit 2
+      ;;
+  esac
+fi

--- a/scripts/lib/retro-frontmatter.mjs
+++ b/scripts/lib/retro-frontmatter.mjs
@@ -16,10 +16,11 @@
  */
 
 import { execFileSync, spawnSync } from 'node:child_process'
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { homedir } from 'node:os'
-import { basename, dirname, join, resolve } from 'node:path'
+import { basename, join } from 'node:path'
+
+import { resolveSharedProjectDir } from './project-dir.mjs'
 
 const require = createRequire(import.meta.url)
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -250,31 +251,14 @@ function firstCommitDate(path) {
 }
 
 /**
- * Mirror writer.ts: walk up from cwd until finding a directory whose `.git`
- * is itself a directory (worktrees have `.git` as a file pointing at the
- * main repo's gitdir, so they're skipped — this resolves the worktree to
- * its main repo). Encode the result the way Claude Code encodes project
- * paths under `~/.claude/projects/`.
+ * Resolve the per-project auto-memory dir via the shared main-repo resolver
+ * (scripts/lib/project-dir.mjs). Keyed on the MAIN repo root — worktrees resolve
+ * to the same shared memory store — with the encoded name's casing reconciled
+ * against the on-disk `~/.claude/projects/` entries (SMI-5419). Memory is shared
+ * project knowledge, the same dir as the telemetry DB.
  */
 function memoryDirForCwd() {
-  let current = resolve(process.cwd())
-  for (let i = 0; i < 64; i += 1) {
-    const gitPath = join(current, '.git')
-    if (existsSync(gitPath)) {
-      try {
-        if (statSync(gitPath).isDirectory()) {
-          const encoded = current.replace(/\//g, '-')
-          return join(homedir(), '.claude', 'projects', encoded, 'memory')
-        }
-      } catch {
-        /* unreadable — keep walking */
-      }
-    }
-    const parent = dirname(current)
-    if (parent === current) break
-    current = parent
-  }
-  return null
+  return join(resolveSharedProjectDir().dir, 'memory')
 }
 
 function memoryFileExists(fileBasename) {

--- a/scripts/lib/retro-frontmatter.mjs
+++ b/scripts/lib/retro-frontmatter.mjs
@@ -262,9 +262,9 @@ function memoryDirForCwd() {
 }
 
 function memoryFileExists(fileBasename) {
-  const dir = memoryDirForCwd()
-  if (!dir) return false
-  return existsSync(join(dir, `${fileBasename}.md`))
+  // memoryDirForCwd() always returns a string (the shared resolver never returns
+  // null), so existsSync handles a non-existent dir directly (SMI-5419 L-1).
+  return existsSync(join(memoryDirForCwd(), `${fileBasename}.md`))
 }
 
 function defaultRetros() {

--- a/scripts/retrieval-log-cli.mjs
+++ b/scripts/retrieval-log-cli.mjs
@@ -25,7 +25,7 @@ import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { join } from 'node:path'
 
-import { resolveTelemetryProjectDir } from './lib/project-dir.mjs'
+import { resolveSharedProjectDir } from './lib/project-dir.mjs'
 
 const ALLOWED_OUTCOMES = ['complete', 'incomplete', 'bypassed_no_verify']
 
@@ -83,14 +83,14 @@ function main() {
  * cwd (not the MAIN repo root), so in any worktree it wrote frontmatter_lint_events
  * to a DIFFERENT DB than the writer — silently splitting the feed.
  *   1. `RETRIEVAL_LOG_DIR_OVERRIDE` (test-only; ignored in production NODE_ENV).
- *   2. `resolveTelemetryProjectDir()` — main-repo root, casing reconciled.
+ *   2. `resolveSharedProjectDir()` — main-repo root, casing reconciled.
  */
 function resolveDbPath() {
   const override = process.env.RETRIEVAL_LOG_DIR_OVERRIDE
   if (override && process.env.NODE_ENV !== 'production') {
     return join(override, 'retrieval-logs.db')
   }
-  return join(resolveTelemetryProjectDir().dir, 'retrieval-logs.db')
+  return join(resolveSharedProjectDir().dir, 'retrieval-logs.db')
 }
 
 process.exit(main())

--- a/scripts/retrieval-log-cli.mjs
+++ b/scripts/retrieval-log-cli.mjs
@@ -23,8 +23,9 @@
 
 import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
+
+import { resolveTelemetryProjectDir } from './lib/project-dir.mjs'
 
 const ALLOWED_OUTCOMES = ['complete', 'incomplete', 'bypassed_no_verify']
 
@@ -77,20 +78,19 @@ function main() {
 }
 
 /**
- * Resolve the DB path. Mirrors writer.ts:
- *   1. `RETRIEVAL_LOG_DIR_OVERRIDE` (test-only; ignored in production NODE_ENV)
- *      → use that dir verbatim.
- *   2. Encode current working directory: `~/.claude/projects/<encoded>/retrieval-logs.db`.
+ * Resolve the DB path via the shared resolver so this CLI writes to the SAME
+ * telemetry DB as writer.ts. SMI-5419 fixed a prior bug here: it encoded the raw
+ * cwd (not the MAIN repo root), so in any worktree it wrote frontmatter_lint_events
+ * to a DIFFERENT DB than the writer — silently splitting the feed.
+ *   1. `RETRIEVAL_LOG_DIR_OVERRIDE` (test-only; ignored in production NODE_ENV).
+ *   2. `resolveTelemetryProjectDir()` — main-repo root, casing reconciled.
  */
 function resolveDbPath() {
   const override = process.env.RETRIEVAL_LOG_DIR_OVERRIDE
   if (override && process.env.NODE_ENV !== 'production') {
     return join(override, 'retrieval-logs.db')
   }
-  const cwd = process.cwd()
-  if (!cwd || !cwd.startsWith('/')) return null
-  const encoded = '-' + cwd.slice(1).replace(/\//g, '-')
-  return join(homedir(), '.claude', 'projects', encoded, 'retrieval-logs.db')
+  return join(resolveTelemetryProjectDir().dir, 'retrieval-logs.db')
 }
 
 process.exit(main())

--- a/scripts/session-priming-query.ts
+++ b/scripts/session-priming-query.ts
@@ -15,14 +15,15 @@
  *     linear-api.mjs. ~25 LOC scoped to this feature.
  *   - `disabled` outcome already in RetrievalHookOutcome union (schema.ts:30)
  *     — no schema migration needed, just emit the value.
- *   - Encoded-cwd helper inlined (4 LOC) per addendum §S4 — drift caught by
- *     audit:standards Section 34.
+ *   - Encoded-cwd resolution delegates to the shared resolver in
+ *     `packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts` (SMI-5419):
+ *     MEMORY.md via the main-repo `resolveSharedProjectDir`, sessions via the
+ *     per-cwd `resolveClaudeProjectDir`. Drift caught by audit:standards §34.
  */
 
 import { execFile } from 'node:child_process'
 import { existsSync, readdirSync, statSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import { basename, join } from 'node:path'
 import { parseArgs } from 'node:util'
 import { promisify } from 'node:util'
@@ -30,6 +31,10 @@ import {
   assessInstrumentationHealth,
   type ProbeResult,
 } from '../packages/doc-retrieval-mcp/src/retrieval-log/probe.js'
+import {
+  resolveClaudeProjectDir,
+  resolveSharedProjectDir,
+} from '../packages/doc-retrieval-mcp/src/retrieval-log/project-dir.js'
 import {
   logRetrievalEvent,
   resolveRetrievalLogPaths,
@@ -77,17 +82,6 @@ interface CliArgs {
 
 export interface PrimingResult {
   additionalContext: string
-}
-
-/**
- * Local slash->dash encoder for per-cwd state (memory / sessions). Canonical form
- * is `encodeProjectSegment` in
- * `packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts`; this site is
- * migrated to the scripts/lib .mjs mirror in the SMI-5419 wiring step, after
- * which a cross-runtime parity test enforces agreement.
- */
-function encodeProjectPath(absPath: string): string {
-  return '-' + absPath.slice(1).replace(/\//g, '-')
 }
 
 function parseCliArgs(argv: string[]): CliArgs | null {
@@ -162,8 +156,10 @@ async function buildSignal2(args: CliArgs): Promise<string> {
 
 async function buildSignal3(args: CliArgs): Promise<string> {
   try {
-    const encoded = encodeProjectPath(args.cwd)
-    const memPath = join(homedir(), '.claude', 'projects', encoded, 'memory', 'MEMORY.md')
+    // SMI-5419: MEMORY.md is shared project knowledge — resolve via the main-repo
+    // resolver (casing reconciled) so a worktree session reads the same curated
+    // memory store as the main checkout, not an empty per-worktree dir.
+    const memPath = join(resolveSharedProjectDir(args.cwd).dir, 'memory', 'MEMORY.md')
     if (!existsSync(memPath)) return ''
     const text = await readFileTruncated(memPath, MEMORY_FILE_MAX_READ)
     return extractRecentBullets(text, SIGNAL_3_BULLETS)
@@ -217,11 +213,22 @@ function truncateBytes(s: string, maxBytes: number): string {
  * files modified in the last `staleHours`. The probe uses this as the
  * denominator for its capture-rate gate so the threshold is session-relative
  * rather than absolute (plan-review H3).
+ *
+ * SMI-5419: sessions are PER-CWD — Claude Code writes transcripts under the
+ * actual launch dir — so this resolves the raw cwd (casing reconciled), unlike
+ * the memory/telemetry sites which key on the shared main-repo dir.
+ *
+ * SCOPE-MISMATCH CAVEAT (flagged, not fixed here): the capture-rate ratio divides
+ * a main-repo-SHARED telemetry numerator (`retrieval_events` aggregates every
+ * worktree into one DB) by this PER-CWD sessions denominator (this launch dir
+ * only). In a worktree the denominator undercounts, so capture-rate reads high.
+ * Aligning the scopes (aggregate sessions across the main + worktree dirs, or
+ * scope telemetry per-cwd) is a probe / metrics-foundation refinement, tracked
+ * there — out of scope for the W0.1 case-fix.
  */
 function countRecentJsonlSessions(cwd: string, now: Date, staleHours: number): number {
   try {
-    const encoded = encodeProjectPath(cwd)
-    const sessionsDir = join(homedir(), '.claude', 'projects', encoded, 'sessions')
+    const sessionsDir = join(resolveClaudeProjectDir(cwd).dir, 'sessions')
     if (!existsSync(sessionsDir)) return 0
     const cutoff = now.getTime() - staleHours * 60 * 60 * 1000
     let n = 0
@@ -419,4 +426,4 @@ if (process.argv[1]?.endsWith('session-priming-query.ts')) {
   void main()
 }
 
-export { encodeProjectPath, parseCliArgs, truncateBytes }
+export { countRecentJsonlSessions, parseCliArgs, truncateBytes }

--- a/scripts/session-priming-query.ts
+++ b/scripts/session-priming-query.ts
@@ -80,9 +80,11 @@ export interface PrimingResult {
 }
 
 /**
- * Encoded-cwd helper — paired with `encodeProjectPath` in
- * `packages/doc-retrieval-mcp/src/retrieval-log/writer.ts` (line ~67).
- * Drift caught by `audit:standards` Section 34 regex.
+ * Local slash->dash encoder for per-cwd state (memory / sessions). Canonical form
+ * is `encodeProjectSegment` in
+ * `packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts`; this site is
+ * migrated to the scripts/lib .mjs mirror in the SMI-5419 wiring step, after
+ * which a cross-runtime parity test enforces agreement.
  */
 function encodeProjectPath(absPath: string): string {
   return '-' + absPath.slice(1).replace(/\//g, '-')

--- a/scripts/session-start-priming.sh
+++ b/scripts/session-start-priming.sh
@@ -46,44 +46,6 @@ emit_empty() {
   exit 0
 }
 
-# SMI-4549: Walk up from $1 until a directory is found that contains `.git`
-# as a directory (not a file — worktrees have `.git` as a file pointing to
-# the main repo's gitdir). Mirrors `findMainRepoRoot` in
-# packages/doc-retrieval-mcp/src/retrieval-log/writer.ts:75-93 so the hook's
-# .log file co-locates with the writer's retrieval-logs.db inside the same
-# encoded-project directory under ~/.claude/projects/. Without this, the
-# .log file ends up under the worktree-encoded dir while the DB lives under
-# the main-repo-encoded dir — debug hazard for SMI-4549-like investigations.
-#
-# Hardened per plan-review:
-#   - [[ ]] not [ ] for space-safe path comparisons
-#   - 64-iter max-depth cap (matches writer.ts safety cap)
-#   - explicit set +e around the loop body so unrelated probes don't trip
-#     the script's outer set -euo pipefail
-# Echoes the resolved path on stdout, exits non-zero if nothing found.
-resolve_main_repo_root() {
-  local current depth parent
-  current="$1"
-  depth=0
-  set +e
-  while (( depth < 64 )); do
-    if [[ -d "$current/.git" ]]; then
-      printf '%s\n' "$current"
-      set -e
-      return 0
-    fi
-    parent="$(dirname "$current")"
-    if [[ "$parent" == "$current" ]]; then
-      set -e
-      return 1
-    fi
-    current="$parent"
-    depth=$(( depth + 1 ))
-  done
-  set -e
-  return 1
-}
-
 SOURCE=$(json_get source unknown)
 SESSION_ID=$(json_get session_id unknown)
 CWD=$(json_get cwd "")
@@ -135,11 +97,13 @@ if [ -f "$TRANSIENT" ]; then
 fi
 
 # Gate 4: build query and search.
-# SMI-4549: encode the *main repo root* (not the worktree path) so .log file
-# co-locates with retrieval-logs.db. From a worktree, $REPO_ROOT is the
-# worktree path; resolve_main_repo_root walks up to the .git-as-directory.
-MAIN_REPO_ROOT="$(resolve_main_repo_root "$REPO_ROOT" 2>/dev/null || echo "$REPO_ROOT")"
-LOG_DIR="$HOME/.claude/projects/$(echo "$MAIN_REPO_ROOT" | sed 's|^/|-|;s|/|-|g')"
+# SMI-5419: the priming debug log lives under the case-independent
+# ~/.skillsmith/logs/ — NOT the encoded ~/.claude/projects/ dir, which is
+# case-fragile (a lower-cased cwd used to scatter the .log into a second dir)
+# and is one shared path across all worktrees. The retrieval DB itself is
+# resolved + casing-reconciled by the TS writer (resolveSharedProjectDir); this
+# hook only needs a stable place for the query's stderr.
+LOG_DIR="$HOME/.skillsmith/logs"
 mkdir -p "$LOG_DIR" 2>/dev/null || true
 LOG="$LOG_DIR/session-priming.log"
 

--- a/scripts/tests/project-dir-parity.test.ts
+++ b/scripts/tests/project-dir-parity.test.ts
@@ -1,0 +1,210 @@
+/**
+ * SMI-5419 W0.1 — cross-runtime parity test.
+ *
+ * Guards that the canonical TS resolver
+ * (packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts) and its
+ * plain-Node mirror (scripts/lib/project-dir.mjs) produce IDENTICAL output
+ * for every input scenario.
+ *
+ * Isolation: each test points $HOME at a fresh temp dir (os.homedir() honours
+ * $HOME on POSIX, which covers both host macOS and Docker Linux) so both
+ * resolvers read a controlled ~/.claude/projects/ and never the real one.
+ * Both module-scope caches are reset in beforeEach/afterEach to prevent
+ * cross-test memo leakage.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import * as ts from '../../packages/doc-retrieval-mcp/src/retrieval-log/project-dir.js'
+import * as mjs from '../lib/project-dir.mjs'
+
+// Cast the mjs namespace to the canonical TS type so every assertion is
+// fully typed and the two call sites are structurally symmetric.
+const m = mjs as typeof ts
+
+let homeDir: string
+let projectsDir: string
+const origHome = process.env.HOME
+
+/** Create a directory entry under the fake ~/.claude/projects/. */
+function mkEntry(name: string): void {
+  mkdirSync(join(projectsDir, name), { recursive: true })
+}
+
+beforeEach(() => {
+  homeDir = mkdtempSync(join(tmpdir(), 'parity-'))
+  projectsDir = join(homeDir, '.claude', 'projects')
+  mkdirSync(projectsDir, { recursive: true })
+  process.env.HOME = homeDir
+  // Reset both module-scope memos before every test.
+  ts.resetProjectDirCache()
+  m.resetProjectDirCache()
+})
+
+afterEach(() => {
+  if (origHome === undefined) delete process.env.HOME
+  else process.env.HOME = origHome
+  rmSync(homeDir, { recursive: true, force: true })
+  ts.resetProjectDirCache()
+  m.resetProjectDirCache()
+})
+
+// ---------------------------------------------------------------------------
+// encodeProjectSegment
+// ---------------------------------------------------------------------------
+
+describe('encodeProjectSegment parity', () => {
+  it('produces identical encoded string for a typical absolute path', () => {
+    const input = '/Users/foo/Bar'
+    expect(m.encodeProjectSegment(input)).toEqual(ts.encodeProjectSegment(input))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// asciiFold
+// ---------------------------------------------------------------------------
+
+describe('asciiFold parity', () => {
+  it('identical for mixed ASCII uppercase input', () => {
+    const input = '-Users-FOO-Bar'
+    expect(m.asciiFold(input)).toEqual(ts.asciiFold(input))
+  })
+
+  it('identical for a string containing non-ASCII characters (left untouched)', () => {
+    // Turkish dotless-i (İ) and Nordic Æ must survive unchanged; only A-Z fold.
+    const input = '-İstanbul-Æ-HELLO-World'
+    expect(m.asciiFold(input)).toEqual(ts.asciiFold(input))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// reconcileEncodedDir — all five ReconcileState values
+// ---------------------------------------------------------------------------
+
+describe('reconcileEncodedDir parity', () => {
+  it('exact: computed name exists verbatim on disk', () => {
+    mkEntry('-Users-foo-Bar')
+    const input = '-Users-foo-Bar'
+    expect(m.reconcileEncodedDir(input)).toEqual(ts.reconcileEncodedDir(input))
+  })
+
+  it('reconciled: a single case-variant exists → adopted casing matches', () => {
+    // On-disk entry uses title-case; computed uses all-lower.
+    mkEntry('-Users-Foo-Bar')
+    const input = '-users-foo-bar'
+    expect(m.reconcileEncodedDir(input)).toEqual(ts.reconcileEncodedDir(input))
+  })
+
+  it('anchored: correct casing borrowed from a worktree-descendant prefix', () => {
+    // Claude Code stores worktree sessions as <main-encoded>--worktrees-<name>.
+    // The reconciler must borrow the prefix casing (length-bounded) from that entry.
+    mkEntry('-Users-Foo-Bar--worktrees-x')
+    const input = '-users-foo-bar'
+    expect(m.reconcileEncodedDir(input)).toEqual(ts.reconcileEncodedDir(input))
+  })
+
+  it('ambiguous: two conflicting case-variants coexist → both returned as candidates', () => {
+    mkEntry('-Users-Foo-Bar')
+    mkEntry('-Users-FOO-Bar')
+    const input = '-users-foo-bar'
+    expect(m.reconcileEncodedDir(input)).toEqual(ts.reconcileEncodedDir(input))
+  })
+
+  it('miss: fresh projects dir with no matching entry', () => {
+    const input = '-Users-new-Project'
+    expect(m.reconcileEncodedDir(input)).toEqual(ts.reconcileEncodedDir(input))
+  })
+
+  it('miss: a LONGER sibling (substring-collision) does NOT trigger a match', () => {
+    // '-Users-Foo-Barbaz' starts with '-users-foo-bar' but is longer — the
+    // prefix anchor requires the candidate to START with '<computed>-', not just
+    // contain the computed value as a substring. So this must resolve to miss.
+    mkEntry('-Users-Foo-Barbaz')
+    const input = '-users-foo-bar'
+    expect(m.reconcileEncodedDir(input)).toEqual(ts.reconcileEncodedDir(input))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveClaudeProjectDir
+// ---------------------------------------------------------------------------
+
+describe('resolveClaudeProjectDir parity', () => {
+  it('identical state, encoded name, and absolute dir for a reconciled cwd', () => {
+    mkEntry('-Users-Foo-Bar')
+    const cwd = '/Users/foo/bar'
+    expect(m.resolveClaudeProjectDir(cwd)).toEqual(ts.resolveClaudeProjectDir(cwd))
+  })
+
+  it('identical for a cwd with no matching on-disk entry (miss)', () => {
+    const cwd = '/Users/nobody/brand-new-project'
+    expect(m.resolveClaudeProjectDir(cwd)).toEqual(ts.resolveClaudeProjectDir(cwd))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveTelemetryProjectDir
+// ---------------------------------------------------------------------------
+
+describe('resolveTelemetryProjectDir parity', () => {
+  it('exact: identical result when the main repo root has a verbatim on-disk entry', () => {
+    // Create a temp dir with .git as a DIRECTORY so findMainRepoRoot returns it.
+    const repo = mkdtempSync(join(tmpdir(), 'repo-parity-exact-'))
+    mkdirSync(join(repo, '.git'))
+    const encoded = ts.encodeProjectSegment(repo)
+    mkEntry(encoded) // place the entry in our fake ~/.claude/projects/
+    try {
+      // Call TS resolver first (after fresh reset from beforeEach), capture result.
+      const tsResult = ts.resolveTelemetryProjectDir(repo)
+
+      // Reset both caches so the mjs resolver also starts cold.
+      ts.resetProjectDirCache()
+      m.resetProjectDirCache()
+
+      const mjsResult = m.resolveTelemetryProjectDir(repo)
+      expect(mjsResult).toEqual(tsResult)
+    } finally {
+      rmSync(repo, { recursive: true, force: true })
+    }
+  })
+
+  it('miss: identical fallback to cwd encoding when no .git ancestor exists', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nogit-parity-'))
+    try {
+      const tsResult = ts.resolveTelemetryProjectDir(dir)
+
+      ts.resetProjectDirCache()
+      m.resetProjectDirCache()
+
+      const mjsResult = m.resolveTelemetryProjectDir(dir)
+      expect(mjsResult).toEqual(tsResult)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reconciled: identical result when on-disk entry has a differing case from computed', () => {
+    // Use a dir whose encoded form can be matched to an on-disk case-variant.
+    const repo = mkdtempSync(join(tmpdir(), 'repo-parity-reconcile-'))
+    mkdirSync(join(repo, '.git'))
+    // Place an upper-cased variant of the encoded name on disk.
+    const computed = ts.encodeProjectSegment(repo)
+    const variant = computed.toUpperCase()
+    mkEntry(variant)
+    try {
+      const tsResult = ts.resolveTelemetryProjectDir(repo)
+
+      ts.resetProjectDirCache()
+      m.resetProjectDirCache()
+
+      const mjsResult = m.resolveTelemetryProjectDir(repo)
+      expect(mjsResult).toEqual(tsResult)
+    } finally {
+      rmSync(repo, { recursive: true, force: true })
+    }
+  })
+})

--- a/scripts/tests/project-dir-parity.test.ts
+++ b/scripts/tests/project-dir-parity.test.ts
@@ -13,9 +13,11 @@
  * cross-test memo leakage.
  */
 
+import { execFileSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -26,6 +28,10 @@ import * as mjs from '../lib/project-dir.mjs'
 // fully typed and the two call sites are structurally symmetric.
 const m = mjs as typeof ts
 
+// Third mirror: the shell resolver (scripts/lib/project-dir.sh), run as a CLI
+// with HOME pointed at the per-test fake home. It prints "<state>\t<encoded>".
+const SHELL_MIRROR = fileURLToPath(new URL('../lib/project-dir.sh', import.meta.url))
+
 let homeDir: string
 let projectsDir: string
 const origHome = process.env.HOME
@@ -33,6 +39,16 @@ const origHome = process.env.HOME
 /** Create a directory entry under the fake ~/.claude/projects/. */
 function mkEntry(name: string): void {
   mkdirSync(join(projectsDir, name), { recursive: true })
+}
+
+/** Invoke the shell mirror CLI under the fake HOME and parse its tab output. */
+function shell(args: string[]): { state: string; encoded: string } {
+  const out = execFileSync('bash', [SHELL_MIRROR, ...args], {
+    env: { ...process.env, HOME: homeDir },
+    encoding: 'utf8',
+  })
+  const tab = out.indexOf('\t')
+  return { state: out.slice(0, tab), encoded: out.slice(tab + 1) }
 }
 
 beforeEach(() => {
@@ -205,6 +221,76 @@ describe('resolveSharedProjectDir parity', () => {
       expect(mjsResult).toEqual(tsResult)
     } finally {
       rmSync(repo, { recursive: true, force: true })
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Shell mirror parity (scripts/lib/project-dir.sh) — the third runtime.
+// candidates are not part of the shell contract, so we compare (state, encoded).
+// ---------------------------------------------------------------------------
+
+describe('shell mirror parity (project-dir.sh)', () => {
+  it('reconcile exact', () => {
+    mkEntry('-Users-foo-Bar')
+    const r = ts.reconcileEncodedDir('-Users-foo-Bar')
+    expect(shell(['reconcile', '-Users-foo-Bar'])).toEqual({ state: r.state, encoded: r.encoded })
+  })
+
+  it('reconcile reconciled (case variant)', () => {
+    mkEntry('-Users-Foo-Bar')
+    const r = ts.reconcileEncodedDir('-users-foo-bar')
+    expect(shell(['reconcile', '-users-foo-bar'])).toEqual({ state: r.state, encoded: r.encoded })
+  })
+
+  it('reconcile anchored (worktree descendant prefix)', () => {
+    mkEntry('-Users-Foo-Bar--worktrees-x')
+    const r = ts.reconcileEncodedDir('-users-foo-bar')
+    expect(shell(['reconcile', '-users-foo-bar'])).toEqual({ state: r.state, encoded: r.encoded })
+  })
+
+  it('reconcile ambiguous (conflicting variants)', () => {
+    mkEntry('-Users-Foo-Bar')
+    mkEntry('-Users-FOO-Bar')
+    const r = ts.reconcileEncodedDir('-users-foo-bar')
+    expect(shell(['reconcile', '-users-foo-bar'])).toEqual({ state: r.state, encoded: r.encoded })
+  })
+
+  it('reconcile miss (longer sibling does not match)', () => {
+    mkEntry('-Users-Foo-Barbaz')
+    const r = ts.reconcileEncodedDir('-users-foo-bar')
+    expect(shell(['reconcile', '-users-foo-bar'])).toEqual({ state: r.state, encoded: r.encoded })
+  })
+
+  it('reconcile miss (fresh projects dir)', () => {
+    const r = ts.reconcileEncodedDir('-Users-new-Project')
+    expect(shell(['reconcile', '-Users-new-Project'])).toEqual({
+      state: r.state,
+      encoded: r.encoded,
+    })
+  })
+
+  it('resolve-shared exact via main repo root', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'repo-shell-exact-'))
+    mkdirSync(join(repo, '.git'))
+    mkEntry(ts.encodeProjectSegment(repo))
+    try {
+      ts.resetProjectDirCache()
+      const r = ts.resolveSharedProjectDir(repo)
+      expect(shell(['resolve-shared', repo])).toEqual({ state: r.state, encoded: r.encoded })
+    } finally {
+      rmSync(repo, { recursive: true, force: true })
+    }
+  })
+
+  it('resolve-shared miss when no .git ancestor', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nogit-shell-'))
+    try {
+      ts.resetProjectDirCache()
+      const r = ts.resolveSharedProjectDir(dir)
+      expect(shell(['resolve-shared', dir])).toEqual({ state: r.state, encoded: r.encoded })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
     }
   })
 })

--- a/scripts/tests/project-dir-parity.test.ts
+++ b/scripts/tests/project-dir-parity.test.ts
@@ -147,10 +147,10 @@ describe('resolveClaudeProjectDir parity', () => {
 })
 
 // ---------------------------------------------------------------------------
-// resolveTelemetryProjectDir
+// resolveSharedProjectDir
 // ---------------------------------------------------------------------------
 
-describe('resolveTelemetryProjectDir parity', () => {
+describe('resolveSharedProjectDir parity', () => {
   it('exact: identical result when the main repo root has a verbatim on-disk entry', () => {
     // Create a temp dir with .git as a DIRECTORY so findMainRepoRoot returns it.
     const repo = mkdtempSync(join(tmpdir(), 'repo-parity-exact-'))
@@ -159,13 +159,13 @@ describe('resolveTelemetryProjectDir parity', () => {
     mkEntry(encoded) // place the entry in our fake ~/.claude/projects/
     try {
       // Call TS resolver first (after fresh reset from beforeEach), capture result.
-      const tsResult = ts.resolveTelemetryProjectDir(repo)
+      const tsResult = ts.resolveSharedProjectDir(repo)
 
       // Reset both caches so the mjs resolver also starts cold.
       ts.resetProjectDirCache()
       m.resetProjectDirCache()
 
-      const mjsResult = m.resolveTelemetryProjectDir(repo)
+      const mjsResult = m.resolveSharedProjectDir(repo)
       expect(mjsResult).toEqual(tsResult)
     } finally {
       rmSync(repo, { recursive: true, force: true })
@@ -175,12 +175,12 @@ describe('resolveTelemetryProjectDir parity', () => {
   it('miss: identical fallback to cwd encoding when no .git ancestor exists', () => {
     const dir = mkdtempSync(join(tmpdir(), 'nogit-parity-'))
     try {
-      const tsResult = ts.resolveTelemetryProjectDir(dir)
+      const tsResult = ts.resolveSharedProjectDir(dir)
 
       ts.resetProjectDirCache()
       m.resetProjectDirCache()
 
-      const mjsResult = m.resolveTelemetryProjectDir(dir)
+      const mjsResult = m.resolveSharedProjectDir(dir)
       expect(mjsResult).toEqual(tsResult)
     } finally {
       rmSync(dir, { recursive: true, force: true })
@@ -196,12 +196,12 @@ describe('resolveTelemetryProjectDir parity', () => {
     const variant = computed.toUpperCase()
     mkEntry(variant)
     try {
-      const tsResult = ts.resolveTelemetryProjectDir(repo)
+      const tsResult = ts.resolveSharedProjectDir(repo)
 
       ts.resetProjectDirCache()
       m.resetProjectDirCache()
 
-      const mjsResult = m.resolveTelemetryProjectDir(repo)
+      const mjsResult = m.resolveSharedProjectDir(repo)
       expect(mjsResult).toEqual(tsResult)
     } finally {
       rmSync(repo, { recursive: true, force: true })

--- a/scripts/tests/session-priming-branch-gate.test.ts
+++ b/scripts/tests/session-priming-branch-gate.test.ts
@@ -12,11 +12,12 @@
  * still don't prime.
  *
  * Detection mechanism: if the script reaches the `mkdir -p "$LOG_DIR"` line
- * (post-Gate-2, pre-Gate-4), the encoded log directory under $HOME exists
- * after the script returns. We redirect HOME to a per-test scratch dir so
- * we don't pollute the real ~/.claude/projects/. The query script is missing
- * inside the fixture's REPO_ROOT, so Gate 4 trips and exits cleanly without
- * touching the real writer DB.
+ * (post-Gate-2, pre-Gate-4), $HOME/.skillsmith/logs exists after the script
+ * returns (SMI-5419 moved LOG_DIR there from the case-fragile encoded
+ * ~/.claude/projects/ dir). We redirect HOME to a per-test scratch dir so we
+ * don't pollute the real ~/.skillsmith/. The query script is missing inside
+ * the fixture's REPO_ROOT, so Gate 4 trips and exits cleanly without touching
+ * the real writer DB.
  */
 import { describe, it, expect, afterEach } from 'vitest'
 import { execFileSync, spawnSync } from 'node:child_process'
@@ -94,10 +95,11 @@ function runHook(repo: string, branch: string, home: string): RunResult {
     timeout: 10_000,
   })
 
-  // The encoded LOG_DIR is $HOME/.claude/projects/-<repo-path-with-/-as--->
-  // matching the bash sed: 's|^/|-|;s|/|-|g' (leading / → -, all other / → -).
-  const encoded = repo.replace(/^\//, '-').replace(/\//g, '-')
-  const logDir = join(home, '.claude', 'projects', encoded)
+  // SMI-5419: LOG_DIR moved to the case-independent $HOME/.skillsmith/logs (was
+  // the case-fragile encoded ~/.claude/projects/<encoded> dir). Reaching the
+  // `mkdir -p "$LOG_DIR"` step is still the Gate-2 pass signal — every skip path
+  // calls emit_empty and exits before it.
+  const logDir = join(home, '.skillsmith', 'logs')
 
   return {
     exitCode: proc.status,
@@ -122,8 +124,9 @@ function setupFixtureRepo(branch: string): { repo: string; home: string } {
     execFileSync('git', ['checkout', '-b', branch], { cwd: repo, env, stdio: 'pipe' })
   }
 
-  // Ensure $HOME/.claude exists but NOT the encoded project dir — that's the
-  // signal we're testing for.
+  // Fresh scratch HOME: $HOME/.skillsmith/logs must NOT pre-exist — its creation
+  // by the hook is the Gate-2 pass signal we test for. ($HOME/.claude is created
+  // to mimic a realistic home; the hook no longer keys the log dir off it.)
   mkdirSync(join(home, '.claude'), { recursive: true })
 
   return { repo, home }
@@ -193,8 +196,7 @@ describe('session-start-priming.sh Gate 2 (SMI-4809)', () => {
       timeout: 10_000,
     })
 
-    const encoded = repo.replace(/^\//, '-').replace(/\//g, '-')
-    const logDir = join(home, '.claude', 'projects', encoded)
+    const logDir = join(home, '.skillsmith', 'logs')
 
     expect(proc.status).toBe(0)
     expect(existsSync(logDir)).toBe(false) // Gate 1 still rejects, doesn't reach Gate 2
@@ -229,8 +231,7 @@ describe('session-start-priming.sh Gate 2 (SMI-4809)', () => {
       timeout: 10_000,
     })
 
-    const encoded = repo.replace(/^\//, '-').replace(/\//g, '-')
-    const logDir = join(home, '.claude', 'projects', encoded)
+    const logDir = join(home, '.skillsmith', 'logs')
 
     expect(proc.status).toBe(0)
     expect(existsSync(logDir)).toBe(false) // empty branch is in deny list

--- a/scripts/tests/session-priming-branch-gate.test.ts
+++ b/scripts/tests/session-priming-branch-gate.test.ts
@@ -97,8 +97,9 @@ function runHook(repo: string, branch: string, home: string): RunResult {
 
   // SMI-5419: LOG_DIR moved to the case-independent $HOME/.skillsmith/logs (was
   // the case-fragile encoded ~/.claude/projects/<encoded> dir). Reaching the
-  // `mkdir -p "$LOG_DIR"` step is still the Gate-2 pass signal — every skip path
-  // calls emit_empty and exits before it.
+  // `mkdir -p "$LOG_DIR"` step is still the Gate-2 pass signal: deny-list/no-token
+  // skip paths emit_empty before it, and Gate 3 (idempotency) can't trigger here
+  // (random session_id → no pre-existing transient).
   const logDir = join(home, '.skillsmith', 'logs')
 
   return {

--- a/scripts/tests/session-priming-query.test.ts
+++ b/scripts/tests/session-priming-query.test.ts
@@ -37,13 +37,17 @@ vi.mock('../../packages/doc-retrieval-mcp/src/retrieval-log/writer.js', () => ({
 }))
 
 import {
-  encodeProjectPath,
+  countRecentJsonlSessions,
   extractRecentBullets,
   parseCliArgs,
   renderPrimingMarkdown,
   runQuery,
   truncateBytes,
 } from '../session-priming-query.js'
+import {
+  encodeProjectSegment,
+  resetProjectDirCache,
+} from '../../packages/doc-retrieval-mcp/src/retrieval-log/project-dir.js'
 import type { SearchHit } from '../../packages/doc-retrieval-mcp/src/types.js'
 
 let tmp: string
@@ -69,11 +73,16 @@ beforeEach(() => {
   logRetrievalEventMock.mockReset()
   delete process.env.SKILLSMITH_DOC_RETRIEVAL_DISABLE_PRIMING
   delete process.env.LINEAR_API_KEY
+  // SMI-5419: buildSignal3/countRecentJsonlSessions now resolve via the
+  // module-memoized shared/per-cwd resolvers — reset so cases don't leak.
+  resetProjectDirCache()
 })
 
 afterEach(() => {
   rmSync(tmp, { recursive: true, force: true })
   delete process.env.RETRIEVAL_LOG_DIR_OVERRIDE
+  vi.unstubAllEnvs()
+  resetProjectDirCache()
 })
 
 describe('parseCliArgs', () => {
@@ -107,16 +116,6 @@ describe('parseCliArgs', () => {
     const args = parseCliArgs(['--session-id', 'abc', '--cwd', '/x', '--out', '/y'])
     expect(args?.branch).toBe('')
     expect(args?.smi).toBe('')
-  })
-})
-
-describe('encodeProjectPath', () => {
-  it('matches writer.ts encoding contract', () => {
-    expect(encodeProjectPath('/Users/foo/Documents/Projects')).toBe('-Users-foo-Documents-Projects')
-  })
-
-  it('handles deep paths', () => {
-    expect(encodeProjectPath('/a/b/c')).toBe('-a-b-c')
   })
 })
 
@@ -244,19 +243,54 @@ describe('runQuery', () => {
     expect(queryArg).toContain('smi-4451')
   })
 
-  it('reads memory bullets when MEMORY.md is present at encoded path', async () => {
-    const encoded = encodeProjectPath(tmp)
-    const memDir = join(tmp, '.claude-fake-home', '.claude', 'projects', encoded, 'memory')
+  it('reads memory bullets from the shared main-repo dir (SMI-5419)', async () => {
+    // cwd is a git repo so findMainRepoRoot resolves it as the main root, and
+    // HOME points at a fake home so resolveSharedProjectDir's ~/.claude/projects/
+    // lookup is fully controlled. Exercises the real read path that was
+    // previously asserted only at the encoder level.
+    const repo = mkdtempSync(join(tmpdir(), 'priming-repo-'))
+    mkdirSync(join(repo, '.git'))
+    const fakeHome = mkdtempSync(join(tmpdir(), 'priming-home-'))
+    vi.stubEnv('HOME', fakeHome)
+    resetProjectDirCache()
+    const memDir = join(fakeHome, '.claude', 'projects', encodeProjectSegment(repo), 'memory')
     mkdirSync(memDir, { recursive: true })
     writeFileSync(
       join(memDir, 'MEMORY.md'),
       '# Project\n\n## Recent\n- alpha bullet\n- beta bullet\n',
       'utf8'
     )
-    // homedir() can't be re-pointed easily — test the encoder + extractor path
-    // via direct invocation; runQuery's full read-from-homedir is exercised in
-    // integration / smoke (S9). Here we verify the encoding contract holds.
-    expect(encodeProjectPath(tmp)).toBe(encoded)
+    searchMock.mockResolvedValueOnce([makeHit('h1', 0.7, 'docs/foo.md')])
+    try {
+      await runQuery({ ...baseArgs, cwd: repo })
+      const queryArg = searchMock.mock.calls[0][0].query as string
+      expect(queryArg).toContain('alpha bullet')
+      expect(queryArg).toContain('beta bullet')
+    } finally {
+      rmSync(repo, { recursive: true, force: true })
+      rmSync(fakeHome, { recursive: true, force: true })
+    }
+  })
+
+  it('countRecentJsonlSessions counts *.jsonl under the per-cwd sessions dir (SMI-5419)', () => {
+    // Sessions are PER-CWD (resolveClaudeProjectDir), not main-repo. Verify the
+    // count reads ~/.claude/projects/<encoded-cwd>/sessions/ under a fake HOME.
+    const cwd = mkdtempSync(join(tmpdir(), 'priming-sess-'))
+    const fakeHome = mkdtempSync(join(tmpdir(), 'priming-sess-home-'))
+    vi.stubEnv('HOME', fakeHome)
+    resetProjectDirCache()
+    const sessionsDir = join(fakeHome, '.claude', 'projects', encodeProjectSegment(cwd), 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    writeFileSync(join(sessionsDir, 'a.jsonl'), '{}', 'utf8')
+    writeFileSync(join(sessionsDir, 'b.jsonl'), '{}', 'utf8')
+    writeFileSync(join(sessionsDir, 'note.txt'), 'x', 'utf8') // ignored — not .jsonl
+    try {
+      // Freshly-written files have mtime ~now, so they fall inside the 24h window.
+      expect(countRecentJsonlSessions(cwd, new Date(), 24)).toBe(2)
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+      rmSync(fakeHome, { recursive: true, force: true })
+    }
   })
 
   it('passes minScore=0.35 and k=8 to search()', async () => {


### PR DESCRIPTION
## Summary

Restores the substrate for self-learning retrieval telemetry (W0.1 of the meta-harness roadmap, SMI-5418). The encoded-project-dir derivation was case-fragile: `process.cwd()` / a git walk-up can yield a lower-cased path that does not match Claude Code's case-preserving `~/.claude/projects/<encoded>` directory. On a case-sensitive filesystem (Linux/CI) this splits one project into two dirs, which is how the retrieval-telemetry feed could go silently dead; APFS case-insensitivity masks it locally.

The fix: after computing the encoded name, reconcile its casing against the directories that actually exist under `~/.claude/projects/` (never decoding an on-disk name; matching only on the unambiguous encoded form). One canonical TS resolver, two behaviour-equivalent mirrors, and a cross-runtime parity test keep all three honest.

## Key decision (memory-dir-key)

- **memory + telemetry = SHARED, main-repo-keyed** (`resolveSharedProjectDir`): one DB + one `/memory` corpus per project, shared across all its worktrees. Memory is project knowledge, not per-worktree state.
- **sessions (`*.jsonl`) = PER-CWD** (`resolveClaudeProjectDir`): Claude Code writes transcripts under the actual launch dir.

## What changed

- **Canonical resolver** `packages/doc-retrieval-mcp/src/retrieval-log/project-dir.ts` -- reconcile states exact/reconciled/anchored/ambiguous/miss; never decodes; not `CLAUDE_PROJECT_DIR` (would shard the shared DB across worktrees); not `realpathSync` (inert on APFS, trips Check 41).
- **Three mirrors, parity-tested**: TS + `scripts/lib/project-dir.mjs` (plain-node, avoids tsx startup cost) + `scripts/lib/project-dir.sh` (bash 3.2-safe; shell paths must survive a dead-node/dead-binding state). A 22-case cross-runtime parity test asserts identical output.
- **All encoded-dir sites delegate**: writer.ts + retrieval-log-cli.mjs (telemetry DB), session-priming-query.ts (MEMORY.md -> shared, sessions -> per-cwd), memory-topic-files.ts + retro-frontmatter.mjs (/memory), check-retrieval-events.sh (diagnostic).
- **`check-retrieval-events.sh`** now reconciles the DB dir (was inline `sed` encode-without-reconcile -- the shell side of the same bug). **`session-start-priming.sh`** LOG_DIR moved out of the case-fragile encoded dir to `~/.skillsmith/logs/`.
- **Writer ambiguity guard**: refuses to write (warn-once, no DB, no third dir) when multiple case-variants coexist, rather than silently picking one.
- **audit:standards Check 34** rewritten to assert the encoder is canonical in all 3 mirrors and every site delegates to the shared resolver.

## Tests

- 119 tests across the W0.1 surface (resolver units, 22-case parity incl. shell, writer, probe, memory-topic adapter, priming query/hook).
- New end-to-end **mis-cased write->read** round-trip (native better-sqlite3): a lower-cased cwd reconciles to the existing on-disk dir, the write lands there, a fresh reader reads it back, and no new mis-cased dir is created.
- New negative/boundary probe tests (marker precedence over a healthy DB; exactly-50% capture not flagged; off-by-one session-count boundary; valid-JSON-missing-field treated absent).

## Verification / value chain

Dogfooded the new shell diagnostic on the real host: it correctly reconciled to the canonical dir and surfaced the live verdict. Findings: **no case-split orphan exists on this machine** (the canonical dir holds the only DB), and the ~6-week telemetry death is the wrong-arch `better_sqlite3` binding (`dlopen ... slice is not valid mach-o`), NOT a case-split. The case-fix correctly routes the marker + DB to the canonical dir; **reviving live telemetry needs the gated W0.1 host auto-heal** (`repair-host-native-deps.sh`), which has its own SPARC + plan-review and is out of scope here.

## Notes

- Three commits (2ed98406, f4fa5438, 008ca7b5) predate this PR's working session.
- Local full `tsc --build` fails on a pre-existing cross-checkout skew (the main checkout is on a branch whose `core` src lacks a method this branch's mcp-server test uses); CI builds fresh, so it does not apply here.
- ADR-109: the `scripts/` changes are within the twice-reviewed W0.1 SPARC plan (the shell encoder + parity test were specified there).

[concurrency-audit-ack]

The module-scope memoization in project-dir.ts (telemetryMemo / cwdMemo) is intentional shared state, reviewed twice by governance: each resolver runs in a short-lived, single-repo process so the single shared-memo slot is correct in production, and tests reset it via resetProjectDirCache() in beforeEach/afterEach. There is no cross-request mutation hazard.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
