### PR TITLE
fix(retrieval): close W0.1 retro gaps — Check 34 shell encoder + bash symlink parity (SMI-5419)

### DIFF
--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -2358,6 +2358,14 @@ console.log(`\n${BOLD}34. encoded-project-dir resolver drift (SMI-5419)${RESET}`
     ]) {
       if (!sh.includes(fn)) problems.push(`${SHELL_MIRROR} missing function ${fn}`)
     }
+    // The shell encoder is bash parameter expansion (${1//\//-}), not a JS
+    // .replace(), so ENCODER_REGEX can't reach it. Assert the slash->dash form
+    // structurally here too — otherwise a silent shell-encoder change would only
+    // be caught by the parity test, leaving Check 34's "all 3 mirrors agree" claim
+    // unenforced for the shell side (SMI-5419 retro M1).
+    if (!/\$\{1\/\/\\\/\/-\}/.test(sh)) {
+      problems.push(`${SHELL_MIRROR} missing the canonical slash->dash encoder (\${1//\\//-})`)
+    }
   }
   const SHELL_CONSUMER = 'scripts/check-retrieval-events.sh'
   if (existsSync(SHELL_CONSUMER)) {

--- a/scripts/lib/project-dir.sh
+++ b/scripts/lib/project-dir.sh
@@ -82,7 +82,7 @@ reconcile_encoded_dir() {
   # 2. reconciled — exactly one entry equals computed under ASCII fold.
   local full=()
   for entry in "$root"/*; do
-    [ -e "$entry" ] || continue
+    [ -e "$entry" ] || [ -L "$entry" ] || continue # incl. broken symlinks (readdirSync parity)
     name="${entry##*/}"
     if [ "$(ascii_fold "$name")" = "$folded_computed" ]; then
       full+=("$name")
@@ -101,7 +101,7 @@ reconcile_encoded_dir() {
   prefix="${folded_computed}-"
   local anchors=()
   for entry in "$root"/*; do
-    [ -e "$entry" ] || continue
+    [ -e "$entry" ] || [ -L "$entry" ] || continue # incl. broken symlinks (readdirSync parity)
     name="${entry##*/}"
     folded_name="$(ascii_fold "$name")"
     case "$folded_name" in

--- a/scripts/tests/project-dir-parity.test.ts
+++ b/scripts/tests/project-dir-parity.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -268,6 +268,17 @@ describe('shell mirror parity (project-dir.sh)', () => {
       state: r.state,
       encoded: r.encoded,
     })
+  })
+
+  it('reconcile reconciled when the on-disk entry is a BROKEN symlink (SMI-5419 retro L1)', () => {
+    // readdirSync lists a broken symlink by name, so TS reports "reconciled".
+    // The bash loop must include it too — it guards with `[ -e ] || [ -L ]`, not
+    // `[ -e ]` alone (which follows the link and skips broken ones). Without that
+    // guard the shell would diverge to "miss". This case fails if the guard regresses.
+    symlinkSync('/nonexistent-parity-target', join(projectsDir, '-Users-Foo-Bar'))
+    const r = ts.reconcileEncodedDir('-users-foo-bar')
+    expect(r.state).toBe('reconciled')
+    expect(shell(['reconcile', '-users-foo-bar'])).toEqual({ state: r.state, encoded: r.encoded })
   })
 
   it('resolve-shared exact via main repo root', () => {


### PR DESCRIPTION
## Summary
Resolves the two findings from the PR #1620 post-merge governance retro (verdict was PASS_WITH_WARNINGS). Per the no-defer policy these are fixed immediately rather than left as warnings.

- **M1 (Check 34, `audit-standards.mjs`)** — Check 34 validated the shell mirror's encoder only by function-name presence; the JS `ENCODER_REGEX` can't match bash parameter expansion `${1//\//-}`, so a silent shell-encoder change would slip past Check 34 (only the parity test caught it). Adds a structural slash→dash assertion for `project-dir.sh`, so all three mirrors' encoders are now enforced — matching Check 34's stated contract.
- **L1 (`project-dir.sh` + parity test)** — the two bash reconcile loops guarded entries with `[ -e ]`, which follows symlinks and skips broken ones, while `readdirSync` (TS/mjs) lists them by name. A broken symlink under `~/.claude/projects/` would diverge (shell `miss` vs TS `reconciled`). Guards now use `[ -e ] || [ -L ]`, locked by a parity case that fails if the guard regresses.

## Verification
- `audit:standards` Check 34 ✓ (73 passed / 0 failed)
- parity test 23/23 ✓ (added the broken-symlink case)
- prettier ✓, eslint ✓, `bash -n` ✓
- post-commit governance review: PASS, 0 issues

Follow-up to #1620 (merged). Three-line-class change to `scripts/` within the already-plan-reviewed W0.1 scope (Check 34 + shell mirror were specified there), so no new ADR-109 gate.

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)