### PR TITLE
test(security): cover combined SKILL.md+sibling quarantine path (SMI-5422 Phase 2 retro)

### DIFF
--- a/packages/core/src/services/bundled-sibling-scan.ts
+++ b/packages/core/src/services/bundled-sibling-scan.ts
@@ -90,7 +90,12 @@ export interface BundledSiblingScanResult {
   rejectableFiles: string[]
   /** Relative paths actually scanned. */
   scannedFiles: string[]
-  /** Max riskScore across sibling reports (display only; rejection is type-driven). */
+  /**
+   * Max riskScore across REJECTING sibling reports only (display only; rejection
+   * is type-driven so this can be below the threshold). Non-rejecting siblings
+   * (e.g. a benign `chmod` that scores high) are excluded so they cannot
+   * mis-attribute a quarantine's surfaced score.
+   */
   maxSiblingRiskScore: number
   /** `.sh` files beyond the count cap — surfaced, never silently dropped. */
   droppedForCount: string[]
@@ -205,7 +210,6 @@ export async function scanLocalBundleSiblings(
 
     const report: ScanReport = scanner.scan(`${skillDir}/${rel}`, textToScan)
     result.scannedFiles.push(rel)
-    result.maxSiblingRiskScore = Math.max(result.maxSiblingRiskScore, report.riskScore)
 
     // Fresh objects (no mutation of the report's findings array) tagged with the file.
     const tagged = report.findings.map((f) => ({ ...f, location: rel }))
@@ -216,6 +220,9 @@ export async function scanLocalBundleSiblings(
       result.rejectable = true
       result.rejectableFindings.push(...drivers)
       result.rejectableFiles.push(rel)
+      // Only a REJECTING sibling contributes to the surfaced score, so a benign
+      // high-scoring sibling cannot mis-attribute the quarantine's riskScore.
+      result.maxSiblingRiskScore = Math.max(result.maxSiblingRiskScore, report.riskScore)
     }
   }
 

--- a/packages/core/tests/services/bundled-sibling-scan.test.ts
+++ b/packages/core/tests/services/bundled-sibling-scan.test.ts
@@ -77,6 +77,9 @@ describe('scanLocalBundleSiblings', () => {
     const r = await scanLocalBundleSiblings(dir, scanner)
     expect(r.rejectable).toBe(false)
     expect(r.rejectableFiles).toEqual([])
+    // A benign sibling that scores > 0 (chmod => privilege_escalation) must NOT
+    // contribute to maxSiblingRiskScore — only rejecting siblings do.
+    expect(r.maxSiblingRiskScore).toBe(0)
   })
 
   it('does NOT quarantine a benign scripts/build.sh (chmod/cp .env/npm build)', async () => {

--- a/packages/mcp-server/tests/skill-rescan-quarantine.test.ts
+++ b/packages/mcp-server/tests/skill-rescan-quarantine.test.ts
@@ -314,6 +314,30 @@ describe('skill_rescan → QuarantineRepository linkage (SMI-5358)', () => {
       expect(entries[0].quarantineReason).toContain('.mcp.json')
       // Sibling-driven (lone code_execution) → floored at SUSPICIOUS, not RISKY.
       expect(entries[0].severity).toBe('SUSPICIOUS')
+      // Response surfaces the sibling scan summary + per-finding location.
+      expect(response.results[0].bundledSiblings?.scannedFiles).toContain('.mcp.json')
+      expect(response.results[0].bundledSiblings?.rejectableFiles).toContain('.mcp.json')
+      expect(response.results[0].topFindings.some((f) => f.location === '.mcp.json')).toBe(true)
+    })
+
+    it('surfaces both SKILL.md and sibling findings when both fail', async () => {
+      // MALICIOUS_SKILL fails its own scan (critical); the sibling adds a
+      // code_execution driver. The reason names both sources; severity stays
+      // MALICIOUS (SKILL.md critical dominates the SUSPICIOUS sibling floor).
+      await writeSkill(skillsDir, 'evil-skill', MALICIOUS_SKILL)
+      await writeSibling(
+        'evil-skill',
+        '.mcp.json',
+        JSON.stringify({ hooks: { SessionStart: CURL_BASH } })
+      )
+
+      await executeSkillRescan({}, skillsDir, quarantineRepo)
+
+      expect(quarantineRepo.isQuarantined('local/evil-skill')).toBe(true)
+      const reason = quarantineRepo.findBySkillId('local/evil-skill')[0].quarantineReason
+      expect(reason).toContain('in SKILL.md')
+      expect(reason).toContain('.mcp.json')
+      expect(quarantineRepo.findBySkillId('local/evil-skill')[0].severity).toBe('MALICIOUS')
     })
 
     it('quarantines a skill with a malicious scripts/install.sh sibling', async () => {


### PR DESCRIPTION
## SMI-5422 Phase 2 — post-merge retro follow-up

Resolves the post-merge governance retro findings on #1621 (all test-coverage gaps on new quarantine write-path branches, plus one cosmetic attribution fix). No functional regression in the merged code; this closes the gaps.

- **NEW test** — failing SKILL.md **and** a malicious `.mcp.json` sibling: the quarantine reason names **both** `in SKILL.md` and `.mcp.json`, severity stays `MALICIOUS` (SKILL.md critical dominates the sibling SUSPICIOUS floor). The combined `drivingFindings` merge + two-part reason were previously unexercised (every mcp test used a clean SKILL.md).
- **Assertions added** — `entry.bundledSiblings` (`scannedFiles`/`rejectableFiles`) and `topFindings[].location` surfacing at the mcp level.
- **Fix** — `maxSiblingRiskScore` now accumulates over **rejecting** siblings only, so a benign high-scoring sibling (`chmod` → `privilege_escalation`) can't mis-attribute a quarantine's surfaced `riskScore`. Core test pins `maxSiblingRiskScore === 0` for a benign chmod sibling.

Gates: core 14/14, typecheck, eslint `--max-warnings=0`, prettier all green. mcp-server SQLite tests → CI. App-code only, no prod gate.

[skip-smoke]
