### PR TITLE
fix(retrieval): post-merge retro fixes — space-safe key parse + BSD ANSI strip (SMI-5426)

### DIFF
--- a/scripts/retrieval-autoheal.sh
+++ b/scripts/retrieval-autoheal.sh
@@ -27,7 +27,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # --- Resolve the main repo (state key + probe cwd + repair target) -----------
 # Identical derivation to autoheal-state.ts resolveMainRepoKey(): the first
 # `worktree` entry of `git worktree list --porcelain` is always the main tree.
-MAIN_REPO="$(git -C "$SCRIPT_DIR" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')"
+# Use sed (full line after the prefix), NOT `awk '{print $2}'` — awk would
+# truncate a path containing a space, diverging from the TS full-path slice and
+# silently breaking the heal + banner on such a path (round-2 retro Low-1).
+MAIN_REPO="$(git -C "$SCRIPT_DIR" worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | head -1)"
 if [ -z "${MAIN_REPO:-}" ]; then
   MAIN_REPO="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")"
 fi
@@ -194,10 +197,17 @@ acquire_lock() {
   return 1
 }
 
+# --- ANSI strip — portable across BSD (macOS) + GNU sed --------------------
+# The GNU hex-escape form for ESC is a no-op on BSD/macOS sed (it matches the
+# literal characters, not the control byte), so the prior strip silently did
+# nothing on the host target (round-2 retro Low-2). A bash $'\033' yields a real
+# ESC byte that BOTH seds match.
+strip_ansi() { sed $'s/\033\\[[0-9;]*m//g'; }
+
 # --- Reason extraction from repair output (strip ANSI; prefer the Error: line)-
 extract_reason() {
   local raw="$1" clean
-  clean="$(printf '%s' "$raw" | sed -E 's/\x1b\[[0-9;]*m//g')"
+  clean="$(printf '%s' "$raw" | strip_ansi)"
   local reason
   reason="$(printf '%s\n' "$clean" | grep -m1 -E 'Error:' | sed -E 's/^.*Error:[[:space:]]*//' | cut -c1-200)"
   if [ -z "$reason" ]; then
@@ -271,7 +281,7 @@ fi
 #    we waited. Re-probe under the lock; if healthy now, record + skip the rebuild.
 if probe_binding; then
   log "double-check: binding already healed by another instance — recording ok, skipping rebuild"
-  run_state_cli record --cwd "$SCRIPT_DIR" --result ok || true
+  run_state_cli record --cwd "$SCRIPT_DIR" --result ok --module better-sqlite3 || true
   exit 0
 fi
 
@@ -322,7 +332,7 @@ else
   log "heal: FAILED (repair rc=$REPAIR_RC): $REASON"
   {
     printf -- '--- repair output (tail) ---\n'
-    printf '%s\n' "$REPAIR_OUT" | sed -E 's/\x1b\[[0-9;]*m//g' | tail -20
+    printf '%s\n' "$REPAIR_OUT" | strip_ansi | tail -20
     printf -- '--- end repair output ---\n'
   } >> "$LOG_FILE" 2>/dev/null || true
   run_state_cli record --cwd "$SCRIPT_DIR" --result fail --reason "$REASON" --module better-sqlite3 || true

--- a/scripts/tests/retrieval-autoheal.test.ts
+++ b/scripts/tests/retrieval-autoheal.test.ts
@@ -209,6 +209,18 @@ describe('static-source assertions', () => {
     expect(src).not.toContain('disown')
   })
 
+  it('parses the worktree path with sed (space-safe), not space-truncating awk (retro Low-1)', () => {
+    expect(src).toContain("sed -n 's/^worktree //p'")
+    expect(src).not.toMatch(/worktree list[^\n]*awk '\/\^worktree \/\{print \$2/)
+  })
+
+  it('strips ANSI with a literal-ESC form portable to BSD sed, not GNU-only \\x1b (retro Low-2)', () => {
+    expect(src).toContain('strip_ansi()')
+    // No ACTIVE sed command may use the GNU-only \x1b escape (a comment may
+    // still mention it to explain why it's avoided).
+    expect(src).not.toMatch(/sed[^\n]*\\x1b/)
+  })
+
   it('real probe uses better-sqlite3', () => {
     expect(src).toContain('better-sqlite3')
   })


### PR DESCRIPTION
Post-merge governance retro on #1629 (`5826ad89`) returned a CLEAN verdict (all five audit fixes verified sound) plus three latent items, fixed here immediately per the zero-deferral rule:

- **Low-1 (silent-failure parity bug):** bash `MAIN_REPO` used `awk '{print $2}'`, truncating a worktree path at the first space while `autoheal-state.ts` uses the full path → diverging state keys on a space-containing path, silently capping out the heal AND blinding the priming banner (the SMI-5419 silent-failure class). Now `sed -n 's/^worktree //p'` (full line), matching the TS derivation.
- **Low-2:** the ANSI strip used the GNU-only hex escape — a no-op on BSD/macOS sed (the host target), leaving color codes in repair-failure reasons/log tails. New portable `strip_ansi()` (`$'\033'` literal ESC; both seds).
- **Trivial:** double-checked-lock record now passes `--module better-sqlite3` (matches the success path).
- +2 static-source regression assertions (sed key-parse; `strip_ansi`).

**Verified:** 28 tests pass in Docker (0 skips), 27+1-skip host; `shellcheck -S warning` + `bash -n` clean; eslint/prettier clean. Low-3 (test-file length, audit-exempt `.test.`) folded into SMI-5430.

> The local full typecheck/pre-push suite fails only on the documented cross-checkout stale-dist blocker (concurrent SMI-5389/5422 core exports); none of these 2 files appear there. CI builds core fresh.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

[skip-impl-check] — shell + test-only change (scripts/retrieval-autoheal.sh = 'config', the .test.ts = 'test'; no packages/*/src). The wrapped behavior is fully covered by the bash test suite (28 tests, Docker).