### PR TITLE
chore(release): cli 0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34538,7 +34538,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.7.1
+
+- **Fix**: login authenticate-only + quiet banner on machine-readable subcommands (SMI-5427) (#1628)
+
 ## v0.7.0
 
 - **Feature**: Wave 3 — local CLI/MCP push agent (SMI-5390/5391/5392) (#1579)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## chore(release): cli 0.7.1

Release the CLI 0.7.1 first-run fixes merged in #1628 (SMI-5427):
- **Instant login** — drops the postLoginSync 20-minute WASM registry sync.
- **Quiet banner** on inventory push/status and non-TTY/scripted use.

cli-only bump (no core/mcp-server change). npm collision guard passed (0.7.1 > published 0.7.0). After merge: gh workflow run publish.yml -f dry_run=false.

[skip-impl-check] — version-bump + changelog only (no source changes); the implementation + its tests landed in #1628.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)