### PR TITLE
fix(cli): tolerate EISDIR when SKILL.md is a directory in skills scan (SMI-5440)

### DIFF
--- a/packages/cli/src/utils/skills-directory.ts
+++ b/packages/cli/src/utils/skills-directory.ts
@@ -140,10 +140,12 @@ export async function getSkillsFromDirectory(
             installedVia,
           })
         } catch (error) {
-          // Only treat ENOENT (file not found) as "no SKILL.md"
-          // Re-throw permission errors and other unexpected errors
+          // ENOENT: SKILL.md absent — treat as unknown skill.
+          // EISDIR: SKILL.md is itself a directory (e.g. .backups/SKILL.md created
+          // by apply_recommended_edit — SMI-5440). Treat the same as absent.
+          // Re-throw permission errors and other unexpected errors.
           const errno = (error as NodeJS.ErrnoException).code
-          if (errno !== 'ENOENT') {
+          if (errno !== 'ENOENT' && errno !== 'EISDIR') {
             throw error
           }
 

--- a/packages/cli/tests/skills-directory.test.ts
+++ b/packages/cli/tests/skills-directory.test.ts
@@ -112,4 +112,17 @@ describe('getInstalledSkills (SMI-4578)', () => {
     expect(winners).toHaveLength(1)
     expect(winners[0]?.installedVia).toBe('claude-code')
   })
+
+  it('does not crash when a subdirectory contains a SKILL.md that is itself a directory (SMI-5440)', async () => {
+    // Reproduces the .backups/SKILL.md layout created by apply_recommended_edit
+    const claudeDir = path.join(homeDir, '.claude', 'skills')
+    await plantSkill(claudeDir, 'real-skill')
+    // .backups has a SKILL.md dir (not file) — the backup store
+    await mkdir(path.join(claudeDir, '.backups', 'SKILL.md'), { recursive: true })
+
+    const { getInstalledSkills } = await import('../src/utils/skills-directory.js')
+    // Must not throw EISDIR; real-skill must still be returned
+    const skills = await getInstalledSkills('/nonexistent.db')
+    expect(skills.some((s) => s.name === 'real-skill')).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary

- `apply_recommended_edit` (SMI-4590) creates `~/.claude/skills/.backups/SKILL.md/` as a **directory** (the backup store), not a file
- `getSkillsFromDirectory` called `stat(SKILL.md)` (succeeds on directories) then `readFile(SKILL.md)` which throws `EISDIR`
- Only `ENOENT` was in the tolerated error set, so `inventory status` / `inventory push` crashed entirely

**Fix:** adds `EISDIR` to the tolerated codes in the catch block; the directory entry is treated as a missing SKILL.md (listed as an unknown skill, scan continues).

**Regression test:** reproduces the `.backups/SKILL.md/` directory layout and asserts the scan doesn't throw and returns the real skill.

## Test plan

- [x] `skills-directory.test.ts` 6/6 green in Docker (including the new SMI-5440 case)
- [x] Full pre-push suite passed in Docker

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)