### PR TITLE
fix(ci): free BuildKit cache + pipefail before docker save (SMI-5441)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -118,12 +118,25 @@ jobs:
           echo "### E2E Docker Build" >> $GITHUB_STEP_SUMMARY
           echo "GHCR registry-cache login: \`${{ steps.ghcr-login.outcome }}\` — see the build log for \`importing cache manifest from ghcr.io/...\`." >> $GITHUB_STEP_SUMMARY
 
+      # SMI-5441: Free BuildKit intermediate cache before save so the runner
+      # does not run out of disk space mid-write (docker save pipes to zstd;
+      # without pipefail a partial write still exits 0 and uploads a corrupt
+      # archive). The built image layers are kept; only unreferenced cache
+      # blobs are removed.
+      - name: Free BuildKit cache before image save
+        run: docker builder prune -f
+
       # SMI-2240: Save image with current SHA tag for downstream jobs
       # SMI-4646: zstd -T0 -3 (parallel, level 3) is ~3x faster than gzip with similar ratio
+      # SMI-5441: set -o pipefail so a daemon disk-full error in `docker save`
+      # propagates through the pipe and fails this step (preventing upload of a
+      # corrupt archive that would silently break every downstream load).
       - name: Save Docker image
         run: |
+          set -o pipefail
           docker save skillsmith-e2e:${{ github.sha }} | zstd -T0 -3 > /tmp/skillsmith-e2e.tar.zst
-          echo "✓ Saved image with tag: ${{ github.sha }}"
+          SAVED_BYTES=$(stat -c%s /tmp/skillsmith-e2e.tar.zst 2>/dev/null || stat -f%z /tmp/skillsmith-e2e.tar.zst)
+          echo "✓ Saved image with tag: ${{ github.sha }} (${SAVED_BYTES} bytes)"
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Summary

- **Root cause**: BuildKit registry cache fills the runner's `/var/lib/docker` during the build phase (4–8 GB for a cold GHCR cache import), leaving no temp space for `docker save`. The `docker save | zstd` pipe lacked `set -o pipefail`, so the daemon's disk-full error didn't propagate — the step exited 0 and uploaded a corrupt `.tar.zst`.
- **Symptom**: All three downstream E2E jobs (`CLI E2E Tests`, `Security E2E Tests`, `Generate Reports`) fail with `open .../repositories: no such file or directory` on `docker load`.
- **Fix 1**: New `Free BuildKit cache before image save` step runs `docker builder prune -f` — frees intermediate/dangling build cache only; the tagged `skillsmith-e2e:$SHA` image is in the Docker image store and is not removed.
- **Fix 2**: `set -o pipefail` in `Save Docker image` — secondary guard so any non-zero `docker save` exit propagates through the pipe and fails the step rather than uploading a corrupt archive.

## Test plan

- [ ] `CLI E2E Tests` / `Security E2E Tests` / `Generate Reports` pass on this PR's CI run
- [ ] `Build Docker Image` job's `Save Docker image` step shows `(N bytes)` in the log — confirms stat line executed and archive is non-zero
- [ ] `Build Docker Image` job's `Free BuildKit cache before image save` step shows "Total reclaimed space" in Docker output

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)