### PR TITLE
chore(release): bump cli 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34538,7 +34538,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.7.2
+
+- **Fix**: tolerate EISDIR when SKILL.md is a directory in skills scan (SMI-5440) (#1640)
+
 ## v0.7.1
 
 - **Fix**: login authenticate-only + quiet banner on machine-readable subcommands (SMI-5427) (#1628)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bumps `@skillsmith/cli` from 0.7.1 → 0.7.2
- Contains the SMI-5440 EISDIR fix from PR #1640 (merged `d04ea4c6`)
- `packages/cli/CHANGELOG.md` and `package-lock.json` updated

## Changes

- `packages/cli/package.json`: `"version": "0.7.1"` → `"0.7.2"`
- `packages/cli/CHANGELOG.md`: new `v0.7.2` entry — EISDIR toleration fix
- `package-lock.json`: version bump reflected

## Note

`Package Validation` check may fail by design on `chore/release-*` branches — the check verifies the version is already published, but this PR's purpose is to bump to an unpublished version. Admin-merge is the correct path once all other required checks are green (per ci-reference.md § Release-PR carve-out).

This is a release-only PR (version bump + CHANGELOG); the actual SMI-5440 source fix already merged in #1640. No source changes here, so the implementation-completeness check is skipped.

[skip-impl-check]
[skip-smoke]