### PR TITLE
fix(vscode-e2e): remove host-ready gate causing commandTimeout deadlock on diff spec (SMI-5438)

### DIFF
--- a/packages/vscode-extension/e2e/specs/diff.e2e.ts
+++ b/packages/vscode-extension/e2e/specs/diff.e2e.ts
@@ -53,21 +53,6 @@ describe('Diff skill (update advisor) — tree-context flow (SMI-5340)', () => {
   const page = new DiffSkillPage()
 
   it('diffSkill with installed arg fires get_skill + skill_diff and opens the Updates panel', async () => {
-    // Host-ready gate (SMI-5438): confirm the VS Code workbench is reachable before
-    // any command dispatch or the heavy Updates-panel interaction. On a cold/slow CI
-    // host the Extension Host can still be coming up when the spec starts; gating on
-    // getWorkbench() (the idiom in activation.e2e.ts / mcp-failure.e2e.ts) fails fast
-    // with a clear message instead of a later opaque "Remote command timeout".
-    const workbench = await browser.getWorkbench()
-    await browser.waitUntil(
-      async () => Boolean(await workbench.getActivityBar().getViewControl('Skillsmith')),
-      {
-        timeout: 30_000,
-        interval: 500,
-        timeoutMsg: 'VS Code workbench / Skillsmith activity-bar not ready before diff interaction',
-      }
-    )
-
     // autoConnect is skipped on first activation — force an explicit connection.
     await page.forceConnect()
 

--- a/packages/vscode-extension/e2e/wdio.conf.ts
+++ b/packages/vscode-extension/e2e/wdio.conf.ts
@@ -73,6 +73,9 @@ export const config: WebdriverIO.Config = {
       'wdio:vscodeOptions': {
         extensionPath: EXTENSION_PATH,
         workspacePath: WORKSPACE_PATH,
+        vscodeProxyOptions: {
+          commandTimeout: 120_000,
+        },
         userSettings: {
           'skillsmith.mcp.serverCommand': NODE_BIN,
           'skillsmith.mcp.serverArgs': [FAKE_MCP_SERVER],


### PR DESCRIPTION
## Summary

- **Root cause confirmed**: the host-ready gate added in #1639 (`getViewControl('Skillsmith')` before `forceConnect()`) creates a deadlock — Skillsmith's activity bar only renders _after_ MCP connects, which only happens _after_ `forceConnect()`. The `waitUntil(30s)` times out, then the still-pending bridge call fires at ~43s with `Remote command timeout exceeded`. With `retries:1`, both attempts fail: 2 × 43s = 86s systematic failure on every run.
- **Fix**: remove the gate entirely. The `waitUntil(MCP start)` after `forceConnect()` is the correct readiness signal — proven by the 06-22→06-26 green run which had no gate.
- **Defense-in-depth**: raise `vscodeProxyOptions.commandTimeout` from the 60s wdio-vscode-service default to 120s so any legitimately slow bridge call has more budget.

## Test plan

- [ ] CI E2E nightly (vscode-e2e.yml) passes with `diff.e2e.ts` green — dispatch `gh workflow run vscode-e2e.yml` twice post-merge and confirm ≥2 consecutive green runs
- [ ] All other specs (activation, compare, create, inventory-audit-apply, mcp-failure, tree-view) continue to pass

[skip-impl-check]
[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)