### PR TITLE
fix(vscode-e2e): use registry-format skill id in diff spec (SMI-5438)

### DIFF
--- a/packages/vscode-extension/e2e/specs/diff.e2e.ts
+++ b/packages/vscode-extension/e2e/specs/diff.e2e.ts
@@ -29,9 +29,14 @@ import { waitForTabWithPrefix } from '../helpers/tabs.js'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 
-/** The fixture skill directory — must match the dir name used as the skill id. */
+/** Fixture skill directory (filesystem path, independent of the registry id). */
 const SKILL_DIR = path.resolve(here, '..', 'fixtures', 'skills', 'my-e2e-skill')
-const SKILL_ID = 'my-e2e-skill'
+/**
+ * Use a namespaced registry id so isLocalSkillId() returns false and
+ * diffCommandImpl takes the registry path (client.getSkill → get_skill MCP
+ * call) rather than the local-manifest path added in SMI-5412.
+ */
+const SKILL_ID = 'acme/my-e2e-skill'
 
 /** Returns true once get_skill fires for our fixture skill id. */
 const getSkillFired = (): boolean =>
@@ -68,7 +73,7 @@ describe('Diff skill (update advisor) — tree-context flow (SMI-5340)', () => {
     await page.diffSkill({
       skillData: {
         id: SKILL_ID,
-        name: SKILL_ID,
+        name: 'my-e2e-skill',
         isInstalled: true,
         path: SKILL_DIR,
       },


### PR DESCRIPTION
## Summary

- `SKILL_ID = 'my-e2e-skill'` (bare slug) is classified as a local skill by `isLocalSkillId()` (no `/`). SMI-5412 added local-skill routing to `diffCommandImpl`: bare ids go through `readManifestEntry → no source on CI → early return`, so `get_skill` was never called and the `waitUntil(getSkillFired)` timed out.
- Fix: `SKILL_ID = 'acme/my-e2e-skill'` → `isLocalSkillId()` returns `false` → registry path → `client.getSkill()` → MCP `get_skill` → fake server logs it → assertion passes.
- `SKILL_DIR` (filesystem path to fixture) and the fake MCP server are unchanged. `name` is passed separately as `'my-e2e-skill'` (slug, matching real `SkillItemData` shape).

This is the second half of SMI-5438: PR #1645 fixed the `mcpReconnect` blocking dialog; this fixes the test's skill-id format to match the routing added in SMI-5412.

## Test plan

- [x] `diff.e2e.ts` TypeScript is clean (e2e files are excluded from main tsconfig; CI validates in Docker)
- [x] Prettier clean
- [ ] Nightly E2E (`vscode-e2e.yml` → "E2E Full") ≥ 2 consecutive green runs — DoD for SMI-5438

[skip-smoke]
[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)