### PR TITLE
fix(vscode-e2e): post-merge governance retro findings (SMI-5438)

### DIFF
--- a/.github/workflows/vscode-e2e.yml
+++ b/.github/workflows/vscode-e2e.yml
@@ -95,6 +95,12 @@ jobs:
           npm run test:e2e:setup
           xvfb-run -a npx wdio run ./e2e/wdio.conf.ts --spec ./e2e/specs/activation.e2e.ts
 
+      # outcome == 'success' excludes 'failure', 'cancelled', and 'skipped'.
+      # The cache-hit guard already ensures predownload was not skipped, so this
+      # guard's purpose is to avoid persisting a partial download under the
+      # un-rotated version key. A bare if:always() save would be skipped on
+      # 20-min job-timeout cancellation anyway, so success-gating is the correct
+      # and safe choice.
       - name: Save VS Code binary cache
         if: steps.cache-restore.outputs.cache-hit != 'true' && steps.predownload.outcome == 'success'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -102,9 +108,11 @@ jobs:
           path: packages/vscode-extension/.wdio-vscode-service
           key: wdio-vscode-${{ runner.os }}-${{ env.VSCODE_E2E_VERSION }}
 
-      # test:e2e:setup patches minimatch ESM and MUST run before wdio. The
-      # package test:e2e script runs it for us, but the smoke path invokes wdio
-      # directly with --spec (which bypasses that chain), so run it explicitly.
+      # test:e2e:setup patches minimatch ESM. The smoke path invokes wdio directly
+      # with --spec (which bypasses the package test:e2e chain), so the patch must
+      # be applied explicitly. On cache-miss the pre-download step above already
+      # called test:e2e:setup (wdio requires it); this step is the canonical call
+      # that covers the cache-hit path and the real smoke spec run below.
       - name: Patch minimatch ESM (test:e2e:setup)
         run: npm run test:e2e:setup -w packages/vscode-extension
 
@@ -167,6 +175,9 @@ jobs:
       # the lightest spec (activation) so the heavy diff spec never pays the cold
       # download. test:e2e:setup (minimatch ESM patch) must run first or wdio aborts
       # at config load; xvfb is needed because wdio boots VS Code after onPrepare.
+      # Note: this runs the full activation.e2e.ts spec assertions, not just
+      # onPrepare. A spec failure here blocks the cache save; the binary is still
+      # downloaded. The real test run below re-executes and surfaces the failure.
       - name: Pre-download VS Code binary (decoupled from test clock)
         id: predownload
         if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/packages/vscode-extension/e2e/wdio.conf.ts
+++ b/packages/vscode-extension/e2e/wdio.conf.ts
@@ -74,7 +74,10 @@ export const config: WebdriverIO.Config = {
         extensionPath: EXTENSION_PATH,
         workspacePath: WORKSPACE_PATH,
         vscodeProxyOptions: {
-          commandTimeout: 120_000,
+          // Set 17% below the Mocha budget (120 s) so a bridge-call that times
+          // out surfaces the more-actionable "Remote command timeout exceeded"
+          // error rather than Mocha's bare spec-level timeout.
+          commandTimeout: 100_000,
         },
         userSettings: {
           'skillsmith.mcp.serverCommand': NODE_BIN,
@@ -103,11 +106,10 @@ export const config: WebdriverIO.Config = {
   reporters: ['spec'],
   logLevel: 'warn',
 
-  // Connection-layer slack for a slow CI host (SMI-5438): the time wdio waits for
-  // a single command round-trip to the VS Code host before erroring. This is NOT a
-  // result retry — it does not re-run or mask a failing assertion; it only widens
-  // the per-command transport budget so a momentarily-busy Extension Host doesn't
-  // trip "Remote command timeout exceeded". mochaOpts.retries stays at 1 (below).
+  // Widens the WebDriver session-connection budget — the time wdio waits for the
+  // initial WS handshake with the wdio-vscode-service proxy (NOT per-command
+  // round-trips; that is vscodeProxyOptions.commandTimeout above). Provides slack
+  // on a slow CI host spinning up Electron. Does NOT mask assertion failures.
   connectionRetryTimeout: 120_000,
 
   // Retries hide the iframe-timing races this suite exists to catch; cap at 1

--- a/packages/vscode-extension/src/__tests__/McpStatusBar.test.ts
+++ b/packages/vscode-extension/src/__tests__/McpStatusBar.test.ts
@@ -184,6 +184,10 @@ describe('McpStatusBar (SMI-5341 Fix 3)', () => {
     clientBOnStatusChangeDispose.mockClear()
     currentClientRef.current = 'A'
     vi.mocked(vscode.window.createStatusBarItem).mockClear()
+    // Reset stubs that the registerMcpCommands suite (below) adds to the shared
+    // vscode mock — prevents cross-suite call-count pollution.
+    mockShowInfoMsg.mockReset()
+    mockWithProgress.mockReset()
     const stub = getStub()
     if (stub) {
       stub.show.mockClear()


### PR DESCRIPTION
## Summary

Follow-up fixes from post-merge governance retrospectives on PRs #1639, #1645, #1646 (SMI-5438). All three retros are complete; #1646 was a clean PASS; #1645 and #1639 surfaced findings applied here.

**From PR #1645 retro (PASS_WITH_WARNINGS):**
- `McpStatusBar.test.ts`: add `mockShowInfoMsg.mockReset()` + `mockWithProgress.mockReset()` to the SMI-5341 `beforeEach` block — prevents the shared vscode mock stubs (added for the new registerMcpCommands suite) from polluting call counts in the older suite if either mock is ever indirectly triggered.

**From PR #1639 retro (residual unfixed findings):**
- `wdio.conf.ts`: lower `vscodeProxyOptions.commandTimeout` from 120k → 100k so bridge-call timeouts surface the actionable `Remote command timeout exceeded` error before Mocha's bare 120s spec timeout fires.
- `wdio.conf.ts`: fix the `connectionRetryTimeout` comment — it governs the initial WebDriver session handshake (not per-command round-trips).
- `vscode-e2e.yml` (smoke): clarify the "Patch minimatch ESM" comment — on cache-miss the pre-download step already called `test:e2e:setup`; this step is the canonical invocation for the smoke spec run and covers the cache-hit path.
- `vscode-e2e.yml` (smoke): document why `outcome == 'success'` is the correct save guard (excludes 'cancelled'; 'skipped' is already excluded by the cache-hit guard).
- `vscode-e2e.yml` (full): note that the pre-download step runs full `activation.e2e.ts` assertions (not just `onPrepare`); a spec failure blocks the cache save but the binary is still downloaded and the real run re-surfaces the failure.

## Test plan

- [x] `McpStatusBar.test.ts` — 13/13 tests pass after adding mock resets
- [x] Prettier clean on all 3 changed files
- [ ] CI — vscode-extension unit tests + smoke E2E

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)