### PR TITLE
chore(release): @skillsmith/cli@0.7.3 (SMI-5427)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34538,7 +34538,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.7.3
+
+- **Feature**: 0.7.3 — esbuild bundle + remote-default search + skills-search safety filters (SMI-5427) (#1651)
+- **Feature**: SMI-5442 — provenance + matching fix (Local / source-identified / Pending) (#1650)
+
 ## v0.7.2
 
 - **Fix**: tolerate EISDIR when SKILL.md is a directory in skills scan (SMI-5440) (#1640)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump to publish CLI **0.7.3** to npm. Bundles the already-merged SMI-5427 (#1651: esbuild bundle + remote-default search + skills-search safety filters) and SMI-5442 provenance (#1650) — both merged to main but not yet on npm.

- cli 0.7.2 → 0.7.3; CHANGELOG updated; lockfile regenerated; npm collision guard passed.
- Prod skills-search edge fn already deployed + verified live (safe_only narrows 100→25; max_risk=999→400).
- On merge: `gh workflow run publish.yml -f dry_run=false` publishes 0.7.3.

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)

[skip-impl-check] — version-bump + CHANGELOG only; no source implementation to test (the impl shipped in #1651/#1650).