### PR TITLE
fix(cli): 0.7.4 security hotfix — interactive-search quarantine bypass (SMI-5447)

### DIFF
--- a/.github/workflows/packaging-test.yml
+++ b/.github/workflows/packaging-test.yml
@@ -119,6 +119,28 @@ jobs:
           node ./node_modules/@skillsmith/cli/dist/cli.js telemetry --help
           echo "telemetry --help OK"
 
+      - name: Exercise the WASM DB-open fallback (SMI-5427)
+        working-directory: /tmp/fresh-install-test/wrapper
+        env:
+          SKILLSMITH_USE_MOCK_EMBEDDINGS: 'true'
+          # Force the local branch so search opens the local DB, exercising the
+          # fts5-sql-bundle WASM fallback (better-sqlite3 is externalized + NOT
+          # declared, so it is absent here). A lazy-require MODULE_NOT_FOUND on the
+          # DB-open path would otherwise ship undetected — the --help smokes above
+          # never open a database.
+          SKILLSMITH_OFFLINE_MODE: 'true'
+        run: |
+          # Empty local DB + offline is a normal, handled state (prints a hint,
+          # exits 0). The assertion is that opening the WASM DB does not crash with
+          # a missing-module error.
+          OUT=$(node ./node_modules/@skillsmith/cli/dist/cli.js search "test" 2>&1) || true
+          echo "$OUT"
+          if echo "$OUT" | grep -qiE "Cannot find module|MODULE_NOT_FOUND|Error: No SQLite driver"; then
+            echo "::error::search 'test' failed to open the WASM DB (native/WASM fallback missing)"
+            exit 1
+          fi
+          echo "WASM DB-open fallback OK"
+
       - name: Assert --version does not trigger import
         working-directory: /tmp/fresh-install-test/wrapper
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -34538,7 +34538,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.7.4
+
+- **Security**: fix an interactive-search install path that bypassed the quarantine gate — `skillsmith search -i` → "Install this skill" no longer installs a quarantined skill (consolidated onto the quarantine-aware registry lookup shared with `install`) (SMI-5447).
+
 ## v0.7.3
 
 - **Feature**: 0.7.3 — esbuild bundle + remote-default search + skills-search safety filters (SMI-5427) (#1651)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/search.action.ts
+++ b/packages/cli/src/commands/search.action.ts
@@ -17,18 +17,16 @@ import {
   SkillRepository,
   SkillDependencyRepository,
   SkillInstallationService,
-  SkillsmithApiClient,
-  createApiClient,
-  loadStoredAccessToken,
   type SearchOptions,
   type TrustTier,
-  type RegistryLookup,
-  type RegistrySkillInfo,
 } from '@skillsmith/core'
 // SMI-5039: lazy embedding-capability probe.
 import { probeEmbeddingCapability } from '@skillsmith/core/embeddings/probe'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 import { openCliDatabase } from '../utils/open-database.js'
+// SMI-5427 hotfix: reuse the quarantine-aware registry lookup from install so the
+// interactive "Install this skill" path does NOT bypass the quarantine gate.
+import { createApiBackedRegistryLookup } from './install.js'
 import { isLocalIndexEmpty, formatEmptyIndexHint, searchRemoteOrLocal } from './search.helpers.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { type InteractiveSearchState, type SearchPhase, PAGE_SIZE } from './search-types.js'
@@ -215,9 +213,12 @@ async function runInteractiveSearch(dbPath: string): Promise<void> {
               try {
                 const skillRepo = new SkillRepository(db)
                 const skillDependencyRepo = new SkillDependencyRepository(db)
-                // SMI-5427: API-backed registry lookup — falls through to API
-                // when the skill is not in the local DB (remote-only result).
-                const registryLookup = buildRegistryLookupWithApiFallback(skillRepo)
+                // SMI-5427: quarantine-aware, API-backed registry lookup — falls
+                // through to the API for remote-only results while still honoring
+                // the local QuarantineRepository and the API's quarantined/installable
+                // flags (shared with `install`), so a quarantined skill cannot be
+                // installed from interactive search.
+                const registryLookup = await createApiBackedRegistryLookup(skillRepo, db)
                 const installService = new SkillInstallationService({
                   db,
                   skillRepo,
@@ -257,46 +258,6 @@ async function runInteractiveSearch(dbPath: string): Promise<void> {
   }
 
   console.log(chalk.dim('\nGoodbye!\n'))
-}
-
-/**
- * Build a RegistryLookup that tries local DB first, then falls back to the
- * remote API. This ensures `skillsmith install` works for skills discovered
- * via remote search even when the local DB has never been synced.
- *
- * SMI-5427: install path requires a repoUrl; remote getSkill provides it.
- */
-function buildRegistryLookupWithApiFallback(skillRepo: SkillRepository): RegistryLookup {
-  return {
-    async lookup(sid: string): Promise<RegistrySkillInfo | null> {
-      const s = skillRepo.findById(sid)
-      if (s?.repoUrl) {
-        return {
-          repoUrl: s.repoUrl,
-          name: s.name,
-          trustTier: s.trustTier,
-          quarantined: false,
-        }
-      }
-      // API fallback for remote-only results.
-      try {
-        const jwtToken = await loadStoredAccessToken()
-        const apiClient = createApiClient(jwtToken ? { jwtToken } : {})
-        if (apiClient.isOffline()) return null
-        const response = await apiClient.getSkill(sid)
-        const r = response.data
-        if (!r.repo_url) return null
-        return {
-          repoUrl: r.repo_url,
-          name: r.name,
-          trustTier: SkillsmithApiClient.toSkill(r).trustTier,
-          quarantined: false,
-        }
-      } catch {
-        return null
-      }
-    },
-  }
 }
 
 /**

--- a/scripts/verify-publish-deps.mjs
+++ b/scripts/verify-publish-deps.mjs
@@ -177,7 +177,11 @@ export function runAudit(opts = {}) {
     if (!existsSync(pkgPath)) continue
 
     const pkgJson = readJson(pkgPath)
-    const deps = { ...pkgJson.dependencies }
+    // SMI-5427: include devDependencies — the CLI moved @skillsmith/core +
+    // @skillsmith/mcp-server there (esbuild inlines them; they are stripped from
+    // the published install). Spreading only `dependencies` would silently make
+    // the CLI's workspace version-consistency check a no-op.
+    const deps = { ...pkgJson.dependencies, ...pkgJson.devDependencies }
     let siblingCount = 0
 
     for (const [depName, depRange] of Object.entries(deps)) {


### PR DESCRIPTION
## CLI 0.7.4 — security hotfix: interactive-search quarantine bypass (SMI-5447)

**Found by the post-merge governance retro of #1651.** @skillsmith/cli@0.7.3 shipped a quarantine bypass.

### The bug (Critical)
The SMI-5427 remote-default-search work added two API-backed registry lookups. The pre-merge review caught + fixed the one in `install.ts` (`createApiBackedRegistryLookup` — quarantine-aware), but missed a **parallel** `buildRegistryLookupWithApiFallback` in `search.action.ts` used by the interactive `search -i` → "Install this skill" path, which hardcoded `quarantined: false` on **both** the local and API-fallback branches. So installing a quarantined skill from interactive search bypassed the GAP-07 gate.

### Fix
- **Delete** `buildRegistryLookupWithApiFallback`; the interactive path now uses the quarantine-aware `createApiBackedRegistryLookup(skillRepo, db)` shared with `install` (local `QuarantineRepository` + API `quarantined`/`installable`). The untested duplicate is gone, so `install.test.ts`'s quarantine tests (36 tests) now cover the interactive path transitively.
- **verify-publish-deps.mjs** (LOW-4): spread `devDependencies` — the CLI's core/mcp version-consistency check became a no-op after core/mcp moved to devDeps.
- **packaging-test.yml** (LOW-5): add a real `search "test"` smoke exercising the WASM DB-open fallback (a lazy-require `MODULE_NOT_FOUND` on the DB path would otherwise ship undetected).

### Verification
59 CLI tests pass (install 36 incl. quarantine-block + search); `search.action.ts` typechecks + prettier/eslint clean.

Also in the retro, tracked separately: MEDIUM-3 (skills-search handler 543 lines) = SMI-5444.

[skip-smoke]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
