### PR TITLE
feat(indexer): elapsed-time budget guard for backfill facet crawl (SMI-5448)

### DIFF
--- a/.github/workflows/indexer-backfill.yml
+++ b/.github/workflows/indexer-backfill.yml
@@ -81,6 +81,16 @@ on:
         required: false
         default: '0'
         type: string
+      max_elapsed_minutes:
+        description: 'SMI-5448: per-dispatch wall-clock budget in MINUTES (default 280, safely below the 330-min GHA timeout). The crawl checkpoints and exits at a clean boundary before the GHA kill, turning a timeout rollback into forward progress. 0 = disabled. A single in-flight page can run ~10-15 min past the trip point before the page loop breaks.'
+        required: false
+        default: '280'
+        type: string
+      accept_truncation:
+        description: 'SMI-5321/5448: when true, a saturated unbisectable leaf (>=1000 identical-byte-size files) is processed (page-1 results, recorded truncated) instead of skipped. Default false.'
+        required: false
+        default: false
+        type: boolean
       supabase_env:
         description: 'Target Supabase environment'
         required: false
@@ -212,6 +222,14 @@ jobs:
           # roughly this many skills are admitted, checkpoint, and exit so the next
           # dispatch resumes. 0 = no cap. Distinct from max_skills_per_repo.
           BACKFILL_MAX_SKILLS_PER_DISPATCH: ${{ github.event.inputs.max_skills_per_dispatch || '0' }}
+          # SMI-5448: per-dispatch wall-clock budget (minutes). The facet crawl
+          # checkpoints and exits at a clean boundary once elapsed >= this budget,
+          # turning a 330-min GHA-timeout rollback into forward progress. Default
+          # 280 leaves a 50-min margin. 0 = disabled.
+          BACKFILL_MAX_ELAPSED_MINUTES: ${{ github.event.inputs.max_elapsed_minutes || '280' }}
+          # SMI-5321: opt-in fetch-with-truncation floor for saturated unbisectable
+          # leaves. Default false = current skip-only behavior.
+          BACKFILL_ACCEPT_TRUNCATION: ${{ github.event.inputs.accept_truncation || 'false' }}
           # Raised caps for backfill mode (per SPARC section #3).
           # These override the conservative cron defaults.
           CODE_SEARCH_MAX_PAGES: '10'

--- a/scripts/indexer/parse-env.ts
+++ b/scripts/indexer/parse-env.ts
@@ -89,6 +89,14 @@ export interface IndexerEnv {
    */
   BACKFILL_MAX_SKILLS_PER_DISPATCH: number
   /**
+   * SMI-5448: per-dispatch wall-clock budget in MINUTES for the backfill facet
+   * crawl. When > 0, the crawl checkpoints and exits at a clean boundary once
+   * elapsed >= this budget, converting a GHA-timeout rollback into forward
+   * progress. Default 280 (safely below the 330-min GHA job timeout). 0 =
+   * disabled. Only consumed in BACKFILL_MODE; the cron never builds the plan.
+   */
+  BACKFILL_MAX_ELAPSED_MINUTES: number
+  /**
    * SMI-5321: opt-in fetch-with-truncation floor. When true, a saturated
    * unbisectable size-facet leaf (>=1000 identical-byte-size SKILL.md files)
    * is FETCHED (first up-to-1000 results admitted) rather than silently skipped.
@@ -248,6 +256,10 @@ export function parseEnv(env: NodeJS.ProcessEnv = process.env): IndexerEnv {
       0,
       getInt('BACKFILL_MAX_SKILLS_PER_DISPATCH', 0)
     )
+    // SMI-5448: per-dispatch wall-clock budget in minutes. Default 280 (safely
+    // below the 330-min GHA job timeout). run.ts converts >0 to ms; 0 = disabled.
+    // Only consumed in BACKFILL_MODE (the cron never builds backfillFacetPlan).
+    const BACKFILL_MAX_ELAPSED_MINUTES = getInt('BACKFILL_MAX_ELAPSED_MINUTES', 280)
     // SMI-5321: opt-in fetch-with-truncation floor for saturated unbisectable
     // leaves. Default false — absent or anything other than "true" => false.
     const BACKFILL_ACCEPT_TRUNCATION = getBool('BACKFILL_ACCEPT_TRUNCATION', false)
@@ -282,6 +294,7 @@ export function parseEnv(env: NodeJS.ProcessEnv = process.env): IndexerEnv {
       BACKFILL_MAX_RANGES,
       BACKFILL_MIN_SIZE_BYTES,
       BACKFILL_MAX_SKILLS_PER_DISPATCH,
+      BACKFILL_MAX_ELAPSED_MINUTES,
       BACKFILL_ACCEPT_TRUNCATION,
     }
   } finally {

--- a/scripts/indexer/run.ts
+++ b/scripts/indexer/run.ts
@@ -184,6 +184,9 @@ async function runDiscoveryBranch(
       maxSkillsPerDispatch: env.BACKFILL_MAX_SKILLS_PER_DISPATCH,
       // SMI-5321: opt-in fetch for saturated unbisectable leaves (default false).
       acceptTruncation: env.BACKFILL_ACCEPT_TRUNCATION,
+      // SMI-5448: per-dispatch wall-clock budget (ms). 0 = disabled.
+      maxElapsedMs:
+        env.BACKFILL_MAX_ELAPSED_MINUTES > 0 ? env.BACKFILL_MAX_ELAPSED_MINUTES * 60_000 : 0,
     }
   }
 

--- a/scripts/indexer/subdirectory-search.helpers.ts
+++ b/scripts/indexer/subdirectory-search.helpers.ts
@@ -93,6 +93,15 @@ export interface BackfillFacetPlan {
    */
   maxSkillsPerDispatch?: number
   /**
+   * SMI-5448: per-dispatch wall-clock budget (ms). When > 0, the crawl
+   * checkpoint-and-exits at a clean boundary once elapsed >= this budget,
+   * converting a GHA-timeout rollback into forward progress. Two checks:
+   * mid-range (between pages -- the cursor holds at state.lastPage, the range
+   * is NOT advanced) and range-boundary (after advance/bisect, like
+   * maxSkillsPerDispatch). 0/undefined = disabled (byte-identical to pre-5448).
+   */
+  maxElapsedMs?: number
+  /**
    * SMI-5321: opt-in fetch-with-truncation floor. When true, a saturated
    * unbisectable leaf (>=1000 identical-byte-size SKILL.md files) is processed
    * instead of skipped. The leaf is still recorded truncated=true so
@@ -158,6 +167,8 @@ export async function runBackfillFacetCrawl(
   let capSaturated = false
   let truncatedRanges = 0
   let rangesCrawled = 0
+  // SMI-5448: per-dispatch wall-clock anchor for the elapsed-budget guard.
+  const startedAt = Date.now()
 
   while (rangesCrawled < plan.maxRangesPerDispatch) {
     const range = currentFacetRange(state, facets)
@@ -166,6 +177,10 @@ export async function runBackfillFacetCrawl(
 
     let saturated = false
     let errored = false
+    // SMI-5448: write-once-true flag set only after `state.lastPage = page`
+    // (never on the saturation/error path), so a timed-out range is not
+    // advanced/bisected -- resume re-enters this facet at lastPage+1.
+    let timedOut = false
     // SMI-5321: capture page-1 repos during saturation detection so the
     // acceptTruncation floor can reuse them without a second code-search fetch.
     let saturatedPageRepos: GitHubRepository[] | null = null
@@ -204,6 +219,10 @@ export async function runBackfillFacetCrawl(
       )
       state.lastPage = page
       if (result.repos.length < plan.perPage) break // short page -> range exhausted
+      if (plan.maxElapsedMs && Date.now() - startedAt >= plan.maxElapsedMs) {
+        timedOut = true
+        break // range NOT exhausted -- hold cursor at lastPage, resume next dispatch
+      }
       await delay(6000) // 10 code-search req/min -> 6s between pages
     }
 
@@ -259,9 +278,25 @@ export async function runBackfillFacetCrawl(
         }
         advanceFacet(state)
       }
+    } else if (timedOut) {
+      // SMI-5448: elapsed budget tripped mid-range -- the range is NOT exhausted.
+      // Do NOT advance/bisect; hold the cursor at state.lastPage so the next
+      // dispatch resumes at lastPage+1 for this same facet. Outer loop breaks below.
     } else {
       // Range exhausted (short page, or page cap reached with total <= cap).
       advanceFacet(state)
+    }
+
+    // SMI-5448: mid-range elapsed break -- the facet was NOT advanced (the
+    // `else if (timedOut)` branch above left the cursor at state.lastPage), so
+    // the next dispatch resumes at lastPage+1 for this same facet. Break before
+    // the skill-cap check to avoid double-logging on the same exit.
+    if (timedOut) {
+      console.log(
+        `[Backfill] elapsed budget ${plan.maxElapsedMs}ms reached mid-range ` +
+          `(facet ${facetId(range)}, resuming at page ${state.lastPage + 1}), checkpointing and exiting`
+      )
+      break
     }
 
     // Per-dispatch skill cap: checked at the range boundary (after bisect/advance)
@@ -272,6 +307,17 @@ export async function runBackfillFacetCrawl(
     if (plan.maxSkillsPerDispatch && repos.length >= plan.maxSkillsPerDispatch) {
       console.log(
         `[Backfill] Skill cap reached: ${repos.length} skills >= cap ${plan.maxSkillsPerDispatch}, checkpointing and exiting`
+      )
+      break
+    }
+
+    // SMI-5448: range-boundary elapsed break -- the last range fully completed
+    // (advanced/bisected), so the cursor is clean. This bounds cumulative
+    // multi-range dispatches, mirroring the skill-cap check above.
+    if (plan.maxElapsedMs && Date.now() - startedAt >= plan.maxElapsedMs) {
+      console.log(
+        `[Backfill] elapsed budget ${plan.maxElapsedMs}ms reached at range boundary ` +
+          `(${rangesCrawled} ranges), checkpointing and exiting`
       )
       break
     }

--- a/scripts/indexer/subdirectory-search.helpers.ts
+++ b/scripts/indexer/subdirectory-search.helpers.ts
@@ -282,6 +282,11 @@ export async function runBackfillFacetCrawl(
       // SMI-5448: elapsed budget tripped mid-range -- the range is NOT exhausted.
       // Do NOT advance/bisect; hold the cursor at state.lastPage so the next
       // dispatch resumes at lastPage+1 for this same facet. Outer loop breaks below.
+      // Edge case (page-cap boundary): if the trip landed on the final page
+      // (state.lastPage == maxPagesPerRange), the next dispatch's page loop opens
+      // at lastPage+1 > maxPagesPerRange, its body never runs, no flags are set,
+      // and the outer `else` advances the facet -- correct: this range is treated
+      // as page-cap exhausted, identical to the pre-5448 exhaustion path.
     } else {
       // Range exhausted (short page, or page cap reached with total <= cap).
       advanceFacet(state)

--- a/scripts/tests/indexer/subdirectory-search.helpers.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.helpers.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Elapsed-time budget guard tests (SMI-5448)
+ *
+ * Verifies the `maxElapsedMs` field added to `BackfillFacetPlan` and consumed by
+ * `runBackfillFacetCrawl` (in `subdirectory-search.helpers.ts`). The guard turns a
+ * GHA-timeout whole-dispatch rollback into forward progress by checkpoint-and-
+ * exiting at a clean boundary once the per-dispatch wall clock crosses the budget.
+ * Two exit paths, both losslessly resumable via the returned cursor:
+ *   1. MID-RANGE: the budget trips between pages of a NON-exhausted range. The
+ *      range is NOT advanced/bisected -- the cursor holds at `state.lastPage`,
+ *      `facet_index` is unchanged, `done=false`. Resume re-enters at lastPage+1.
+ *   2. RANGE-BOUNDARY: several individually-fine ranges cumulatively cross the
+ *      budget. The last range fully completed (advanced), so the cursor is clean
+ *      and advanced past the crawled ranges.
+ *   3. DISABLED (`maxElapsedMs=0`): behavior byte-identical to omitting the field
+ *      (regression guard) -- the full 9-facet ladder completes to done=true.
+ *
+ * Fake-timer strategy (per the plan's review, F-3/F-4): `vi.useFakeTimers()` in
+ * `beforeEach` fakes `Date.now()` so the crawl's `Date.now() - startedAt` budget
+ * check can be driven deterministically without real waits; `vi.useRealTimers()`
+ * in `afterEach` prevents fake-timer state leaking into sibling test files. The
+ * `delay(6000)` inter-page sleep is a no-op mock (no `setTimeout`), so no timer
+ * advancement is needed to un-block the page loop -- only `Date.now()` is
+ * advanced (from inside the code-search mock, which runs once per page).
+ *
+ * Mock strategy: mirrors backfill-facet-crawl.test.ts / backfill-skill-cap.test.ts
+ * -- every I/O boundary stubbed at the module level, SUT imported after the mocks,
+ * driven through the public entry `runSubdirectorySearch(..., backfillPlan)`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+
+// ---------------------------------------------------------------------------
+// Module-level mocks -- declared before any import of the SUT
+// ---------------------------------------------------------------------------
+
+// `delay` is a no-op (no setTimeout), so fake timers only need to govern Date.now().
+vi.mock('../../indexer/_shared/rate-limit.ts', () => ({
+  GITHUB_API_DELAY: 0,
+  delay: vi.fn(async () => undefined),
+  withRateLimitTracking: vi.fn(),
+  withBackoff: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  newRateLimitTelemetry: vi.fn(() => ({})),
+}))
+
+vi.mock('../../indexer/_shared/github-auth.ts', () => ({
+  buildGitHubHeaders: vi.fn(async () => ({})),
+}))
+
+const mockSearchCode = vi.fn()
+vi.mock('../../indexer/code-search.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/code-search.ts')>()
+  return {
+    ...actual,
+    searchCodeForSkillMdInSubdirectory: (...args: unknown[]) => mockSearchCode(...args),
+  }
+})
+
+const mockFetchRepoLicense = vi.fn()
+vi.mock('../../indexer/license-filter.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/license-filter.ts')>()
+  return {
+    ...actual,
+    fetchRepoLicense: (...args: unknown[]) => mockFetchRepoLicense(...args),
+  }
+})
+
+const mockCheckSkillMdExists = vi.fn()
+vi.mock('../../indexer/skill-processor.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/skill-processor.ts')>()
+  return {
+    ...actual,
+    checkSkillMdExists: (...args: unknown[]) => mockCheckSkillMdExists(...args),
+  }
+})
+
+const mockEnumerateRepoSkillPaths = vi.fn()
+vi.mock('../../indexer/trees-enumerate.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/trees-enumerate.ts')>()
+  return {
+    ...actual,
+    enumerateRepoSkillPaths: (...args: unknown[]) => mockEnumerateRepoSkillPaths(...args),
+  }
+})
+
+// SUT imported AFTER mocks so it binds the stubs.
+import { runSubdirectorySearch, type BackfillFacetPlan } from '../../indexer/subdirectory-search.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noTelemetry: RateLimitTelemetry = {} as RateLimitTelemetry
+const LADDER_SIZE = 9
+const PER_PAGE = 100
+
+let repoCounter = 0
+function makeCodeSearchRepo(overrides: Record<string, unknown> = {}) {
+  repoCounter += 1
+  const owner = `elapsed-owner${repoCounter}`
+  return {
+    owner,
+    name: 'skills-repo',
+    fullName: `${owner}/skills-repo`,
+    description: 'test',
+    url: `https://github.com/${owner}/skills-repo/tree/main/skills/x`,
+    stars: 5,
+    forks: 0,
+    topics: ['claude-code-skill'],
+    updatedAt: new Date().toISOString(),
+    defaultBranch: 'main',
+    installable: false,
+    repoName: 'skills-repo',
+    skillPath: 'skills/x',
+    discoveryPath: 'subdirectory_search:broad',
+    ...overrides,
+  }
+}
+
+/** A FULL page (repos.length === perPage): total <= cap so no saturation/bisect,
+ *  but the page is NOT short, so the range does NOT exhaust and keeps paginating. */
+function fullPage() {
+  const repos = Array.from({ length: PER_PAGE }, () => makeCodeSearchRepo())
+  return { repos, total: 500, retries: 0, incomplete_results: false }
+}
+
+/** A single-repo short page: total under the cap, repos.length < perPage, so the
+ *  range exhausts in one page (clean advance). */
+function shortPage() {
+  return { repos: [makeCodeSearchRepo()], total: 5, retries: 0, incomplete_results: false }
+}
+
+function makePlan(overrides: Partial<BackfillFacetPlan> = {}): BackfillFacetPlan {
+  return {
+    startCursor: null,
+    pathPrefix: undefined,
+    perPage: PER_PAGE,
+    maxPagesPerRange: 20,
+    maxRangesPerDispatch: 100,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  // F-3: fake timers make Date.now() deterministic. Established at a fixed epoch
+  // so `startedAt = Date.now()` and later advances are relative to a known base.
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-07-01T00:00:00Z'))
+
+  repoCounter = 0
+  mockSearchCode.mockReset()
+  mockFetchRepoLicense.mockReset()
+  mockCheckSkillMdExists.mockReset()
+  mockEnumerateRepoSkillPaths.mockReset()
+
+  mockFetchRepoLicense.mockResolvedValue({
+    license: 'MIT',
+    defaultBranch: 'main',
+    fetchFailed: false,
+  })
+  mockCheckSkillMdExists.mockResolvedValue(true)
+  mockEnumerateRepoSkillPaths.mockResolvedValue({
+    entries: [{ path: 'skills/x', blobSha: 'sha1' }],
+    truncatedByCap: false,
+    truncatedByApi: false,
+  })
+})
+
+afterEach(() => {
+  // F-3: restore real timers so fake-timer state never leaks into sibling files.
+  vi.useRealTimers()
+})
+
+// ---------------------------------------------------------------------------
+
+describe('runSubdirectorySearch -- SMI-5448 elapsed-time budget guard', () => {
+  it('Case 1: mid-range trip -- cursor holds at lastPage, facet not advanced, done=false', async () => {
+    const budgetMs = 100
+    // Facet 0 returns FULL pages (never short-exhausts). The code-search mock
+    // advances the fake clock past the budget as page 1 is fetched, so after
+    // page 1 is processed (state.lastPage = 1) the mid-range elapsed check trips:
+    // timedOut = true, break, NO advanceFacet. Every call advances 1000ms so the
+    // budget is already crossed on the first inter-page check.
+    mockSearchCode.mockImplementation(async () => {
+      vi.advanceTimersByTime(1000) // push Date.now() well past the 100ms budget
+      return fullPage()
+    })
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100, maxElapsedMs: budgetMs })
+    )
+    const backfill = result.backfill!
+
+    // The crawl stopped mid-range on facet 0: exactly one range was entered and
+    // it did NOT complete (no advance), so ranges_crawled is 1 but facet_index 0.
+    expect(backfill.ranges_crawled).toBe(1)
+    // Not done -- the same facet must be resumed next dispatch.
+    expect(backfill.done).toBe(false)
+    // Cursor NOT advanced: still on the first facet (index 0, sentinel not 'done').
+    expect(backfill.cursor.facet_index).toBe(0)
+    expect(backfill.cursor.facet).not.toBe('done')
+    // Cursor holds at the last fully-processed page (page 1), so resume re-enters
+    // at lastPage+1 = page 2 -- no gap, no lost work.
+    expect(backfill.cursor.last_page).toBe(1)
+    // The bisection frontier is untouched (range was not bisected).
+    expect(backfill.cursor.pending_subranges).toEqual([])
+  })
+
+  it('Case 2: range-boundary trip across multiple small ranges -> clean advanced cursor', async () => {
+    const budgetMs = 100
+    // Every facet exhausts in ONE short page (clean advance). The clock advances
+    // per page so the cumulative elapsed crosses the budget at a RANGE BOUNDARY
+    // (after advanceFacet), taking the range-boundary break, not the mid-range one.
+    mockSearchCode.mockImplementation(async () => {
+      vi.advanceTimersByTime(60) // 60ms/range -> budget (100ms) crossed after range 2
+      return shortPage()
+    })
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100, maxElapsedMs: budgetMs })
+    )
+    const backfill = result.backfill!
+
+    // Stopped early (before the full 9-facet ladder) but at a clean boundary.
+    expect(backfill.ranges_crawled).toBeLessThan(LADDER_SIZE)
+    expect(backfill.ranges_crawled).toBeGreaterThanOrEqual(2)
+    expect(backfill.done).toBe(false)
+    // Cursor is ADVANCED (clean boundary): facet_index equals the number of fully
+    // completed ranges, and last_page reset to 0 for the next (un-entered) facet.
+    expect(backfill.cursor.facet_index).toBe(backfill.ranges_crawled)
+    expect(backfill.cursor.facet).not.toBe('done')
+    expect(backfill.cursor.last_page).toBe(0)
+    expect(backfill.cursor.pending_subranges).toEqual([])
+  })
+
+  it('Case 3: maxElapsedMs=0 is disabled -- byte-identical to omitting it (full ladder completes)', async () => {
+    // Even with the clock advancing aggressively per page, a 0 budget disables the
+    // guard entirely (0 is falsy), so the crawl runs the full 9-facet ladder to
+    // done -- identical to a plan with no maxElapsedMs field at all.
+    mockSearchCode.mockImplementation(async () => {
+      vi.advanceTimersByTime(10_000) // would trip any positive budget; ignored at 0
+      return shortPage()
+    })
+
+    const withZero = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100, maxElapsedMs: 0 })
+    )
+    const zeroBackfill = withZero.backfill!
+    expect(zeroBackfill.done).toBe(true)
+    expect(zeroBackfill.facets_completed).toBe(LADDER_SIZE)
+    expect(zeroBackfill.cursor.facet).toBe('done')
+
+    // Regression parity: a plan with the field OMITTED reaches the same terminal.
+    repoCounter = 0
+    mockSearchCode.mockImplementation(async () => {
+      vi.advanceTimersByTime(10_000)
+      return shortPage()
+    })
+    const withoutField = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100 }) // no maxElapsedMs at all
+    )
+    const omittedBackfill = withoutField.backfill!
+    expect(omittedBackfill.done).toBe(zeroBackfill.done)
+    expect(omittedBackfill.facets_completed).toBe(zeroBackfill.facets_completed)
+    expect(omittedBackfill.cursor.facet).toBe(zeroBackfill.cursor.facet)
+    expect(omittedBackfill.cursor.facet_index).toBe(zeroBackfill.cursor.facet_index)
+  })
+})


### PR DESCRIPTION
## SMI-5448: Backfill engine elapsed-time budget guard

### Problem
The out-of-band backfill engine (`scripts/indexer/*`, run by `indexer-backfill.yml`) has **no internal wall-clock guard**. `max_ranges` and `max_skills_per_dispatch` break only at range boundaries, so a single **non-saturated** dense leaf whose per-repo extraction alone exceeds the GHA `timeout-minutes: 330` is killed mid-extraction, **before** `writeCheckpoint` → clean whole-dispatch rollback, **zero forward progress**. Observed on prod leaf `2416-2431` (SMI-5334, run 28475690229, exactly 330 min). No dispatch parameter could cap a single range's wall time. RCA: workflow `wsbt0arj0` (file:line-traced).

### Fix
Add a per-dispatch elapsed-time budget (`BACKFILL_MAX_ELAPSED_MINUTES`, default **280**; workflow input `max_elapsed_minutes`). `runBackfillFacetCrawl` checkpoint-and-exits at two **clean** points:

- **mid-range** (between pages): holds the cursor at `state.lastPage` **without** advancing the facet → the next dispatch resumes losslessly at `lastPage+1`. Safe because `timedOut` is set *only after* `state.lastPage = page`, never on the error/saturation break paths — so it is a mutually-exclusive 4th post-page branch.
- **range-boundary** (after advance/bisect): bounds cumulative multi-range dispatches, mirroring the existing skill-cap check.

`0`/undefined = **disabled** (byte-identical to prior behavior; the cron never builds `backfillFacetPlan`). Also exposes the pre-existing `BACKFILL_ACCEPT_TRUNCATION` env as a `workflow_dispatch` input.

### Tests
`scripts/tests/indexer/subdirectory-search.helpers.test.ts` (fake timers, mocked search + `processSearchResults`): (1) mid-range no-advance resume (`facet_index` unchanged, `last_page` held), (2) range-boundary clean advance, (3) `maxElapsedMs=0` byte-identical regression guard. All pass.

### Rollout
Unblocks **SMI-5334**: once merged and the workflow input is live on `main`, the autonomous driver reverts its lossy hotfix (`max_ranges=1`, `max_skills_per_repo=10`) to full params + `-f max_elapsed_minutes=280`. First smoke at `max_elapsed_minutes=240` on the known-dense region (plan-review F-8).

### Plan / review
`docs/internal/implementation/2026-07-01-smi-5448-backfill-elapsed-time-guard.md` — SPARC + plan-review (ADR-109). The losslessness claim was verified against source in review.

### Notes
[concurrency-audit-ack]
The four `new Map()` hits the concurrency-auditor flags in `subdirectory-search.helpers.test.ts` are empty test-fixture caches passed to `runSubdirectorySearch` — the identical pattern used in every sibling backfill test (e.g. `backfill-facet-crawl.test.ts`). They are not shared production caches and carry no computed-key round-trip risk.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
