### PR TITLE
chore(smoke): remove stale inventory-upload allowlist carve-out (SMI-5453)

### DIFF
--- a/scripts/smoke-prod/.surfaces-allowlist.txt
+++ b/scripts/smoke-prod/.surfaces-allowlist.txt
@@ -113,11 +113,3 @@ packages/website/src/pages/invite/[token].astro
 # Smoke verification requires a real OAuth email-change event which the
 # harness cannot synthesize. Gateway-verified (no --no-verify-jwt).
 supabase/functions/sync-oauth-email/**
-
-# SMI-5389: inventory-upload is NOT deployed to prod yet (Wave 6 / SMI-5396
-# gates the prod apply behind the demand gate). Gateway-verified; smoke
-# verification needs a real authenticated session + consent ON, which the
-# harness cannot synthesize without persisting test data. Wave 6 moves this
-# into surfaces.json with the unauth-401 + consent-off-no-op checks from the
-# plan's "Smoke vs CI" table.
-supabase/functions/inventory-upload/**


### PR DESCRIPTION
## Summary
Removes the stale `supabase/functions/inventory-upload/**` block from `scripts/smoke-prod/.surfaces-allowlist.txt`.

The Wave-6 plan review (SMI-5396 item M4) called for removing this block once the `edge-fn-inventory-upload` surface landed in `surfaces.json` — it did (`scripts/smoke-prod/inventory.sh`, unauth-401 + anon-RPC-denial checks). The block's comment claims inventory-upload is not deployed to prod, which has been false since 2026-06-27 (PR #1574 merge auto-deploy).

## Verification
- `npm run audit:standards` R-4: all 98 user-facing surfaces covered by surfaces.json or allowlist, 0 failed
- Governance review: only consumer of the allowlist is audit Check 36 (warning-only); no orphan entries remain
- Linear: SMI-5453 (project: Cross-Harness Skill Inventory)

[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)