### PR TITLE
feat(website): /account/skills Learn-more links + /docs/inventory smoke surface (SMI-5464)

### DIFF
--- a/packages/website/src/pages/account/skills.astro
+++ b/packages/website/src/pages/account/skills.astro
@@ -89,6 +89,11 @@ const supabaseConfig = getSupabaseConfig()
             your OS platform, and per-skill metadata (name, version, content hash) — never file contents
             or paths.
           </p>
+          <p class="state-body">
+            <a href="/docs/inventory" class="inline-link"
+              >Learn more about cross-machine inventory</a
+            >
+          </p>
         </div>
 
         <!-- State: opted-in-no-devices -->
@@ -105,11 +110,17 @@ const supabaseConfig = getSupabaseConfig()
             >
           </div>
           <p id="copy-status" role="status" aria-live="polite" class="copy-status"></p>
+          <p class="state-body">
+            <a href="/docs/inventory" class="inline-link"
+              >Learn more about cross-machine inventory</a
+            >
+          </p>
         </div>
 
         <!-- State: single-machine hint (shown above devices) -->
         <div id="single-machine-hint" class="inline-hint" style="display: none;">
           Push from another machine to compare your skills across machines.
+          <a href="/docs/inventory" class="inline-link">Learn more</a>
         </div>
 
         <!-- Populated device list — built client-side by skills-page-render.ts -->

--- a/scripts/smoke-prod/surfaces.json
+++ b/scripts/smoke-prod/surfaces.json
@@ -21,6 +21,16 @@
       "checks": ["check_device_page_renders"]
     },
     {
+      "id": "website-docs-inventory",
+      "owner": "website",
+      "trigger_globs": [
+        "packages/website/src/pages/docs/inventory.astro",
+        "packages/website/src/pages/account/skills.astro"
+      ],
+      "script": "scripts/smoke-prod/website.sh",
+      "checks": ["check_website_docs_inventory_renders"]
+    },
+    {
       "id": "website-homepage-canary",
       "owner": "always-on-canary",
       "trigger_globs": [],

--- a/scripts/smoke-prod/website.sh
+++ b/scripts/smoke-prod/website.sh
@@ -160,6 +160,31 @@ check_website_docs_quickstart_renders() {
   return 1
 }
 
+# ---- check_website_docs_inventory_renders ------------------------------
+# SMI-5464: /docs/inventory is the beta-tester onboarding URL for the
+# cross-machine skill inventory (SMI-5397). Fingerprint on the h1 so a
+# 200-with-error-shell page still fails.
+check_website_docs_inventory_renders() {
+  local url="${SMOKE_WEBSITE_URL}/docs/inventory"
+  local t0 t1 ms resp status body
+  t0=$(now_ms)
+  resp=$(with_retry http_body GET "$url") || true
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  status=$(printf '%s' "$resp" | head -n1)
+  body=$(printf '%s' "$resp" | tail -n +2)
+  if [ "$status" != "200" ]; then
+    report_fail "website-docs-inventory" "check_website_docs_inventory_renders" "$url" "200" "$status" "$ms"
+    return 1
+  fi
+  if ! assert_contains "$body" 'Cross-Machine Skill Inventory' "inventory-fingerprint"; then
+    report_fail "website-docs-inventory" "check_website_docs_inventory_renders" "$url" "inventory-fingerprint" "missing" "$ms"
+    return 1
+  fi
+  report_pass "website-docs-inventory" "check_website_docs_inventory_renders" "$url" "$ms"
+  return 0
+}
+
 # ---- check_website_sitemap_index --------------------------------------
 # SMI-4184 lastmod must be present for GSC crawl prioritization. Sitemap
 # regression would silently degrade Discovered-not-indexed metrics.


### PR DESCRIPTION
## Summary
PR 2 of 2 for SMI-5464 (PR 1: #1666, merged — this branch is rebased on top, so /docs/inventory ships before these links resolve).

- Three static `Learn more` anchors to `/docs/inventory` in the /account/skills empty states (consent-off, opted-in-no-devices, single-machine hint). Lib modules untouched (`inventory-view.ts` owns no HTML; `skills-page-render.ts` is populated-state only).
- New `website-docs-inventory` smoke surface: `check_website_docs_inventory_renders` (200 + h1 fingerprint), triggered by `docs/inventory.astro` + `account/skills.astro` — durable prod coverage for the beta onboarding URL, completing the SMI-5396 Wave-6 smoke pattern.

## Review & verification
- Governance review on the commit: code clean; the one High finding (merge-order coupling) is resolved by the rebase onto post-#1666 main.
- e2e-selector safety: inventory specs assert only `data-testid` content — no coupling to the empty-state copy (verified).
- `bash -n` + shellcheck clean; surfaces.json valid; audit:standards R-4 green (surface count 18→19).
- Visual suite: ran locally against the built site (12/12 green incl. /docs with the new card). Snapshots are untracked local artifacts — no baseline to commit.
- Post-merge: `workflow_dispatch` of `cross-harness-inventory-e2e.yml` (staging round-trip incl. /account/skills render) + confirm the next smoke-prod run passes `check_website_docs_inventory_renders`.

Linear: SMI-5464

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)