### PR TITLE
docs(dev-guides): public-docs table reconciliation + dormant smoke-trigger annotation (SMI-5464 retro)

### DIFF
--- a/.claude/development/deployment-guide.md
+++ b/.claude/development/deployment-guide.md
@@ -151,10 +151,15 @@ Public docs at [skillsmith.app/docs](https://skillsmith.app/docs):
 | Quickstart | `/docs/quickstart` |
 | CLI Reference | `/docs/cli` |
 | MCP Server | `/docs/mcp-server` |
+| VS Code Extension | `/docs/vscode-extension` |
 | API Reference | `/docs/api` |
 | Security | `/docs/security` |
 | Quarantine | `/docs/quarantine` |
 | Trust Tiers | `/docs/trust-tiers` |
+| Dependencies | `/docs/dependencies` |
+| Cross-machine Inventory | `/docs/inventory` |
+| FAQ | `/docs/faq` |
+| Tutorials (index + discover, evaluate, install-and-use, maintain, author, govern, retire) | `/docs/tutorials`, `/docs/tutorials/<name>` |
 
 Contact form at `/contact` supports `?topic=` param. `/verify` redirects to `/contact?topic=verification`.
 

--- a/.claude/development/vercel-deploy-hook.md
+++ b/.claude/development/vercel-deploy-hook.md
@@ -1,5 +1,13 @@
 # Vercel deploy hook → smoke-prod trigger
 
+> **Status: dormant backup path (verified 2026-07-01, SMI-5464 PR #1666 retro).**
+> Since the SMI-5246/5247 cutover to git-disconnected prebuilt-CI deploys, smoke-prod
+> fires via `workflow_run` on CI completion — the `vercel-prod-deployed`
+> `repository_dispatch` trigger has not fired in 40+ consecutive smoke runs and is
+> retained only as a manual/backup entry point. If smoke "never fires", check the
+> `workflow_run` chain (CI conclusion + concurrency-group cancellation) FIRST — do
+> not start with the PAT-rotation table below; that applies only to this dormant path.
+
 The smoke-prod workflow (`.github/workflows/smoke-prod.yml`) needs to fire
 after Vercel finishes deploying the website. Vercel's webhook surface does
 not natively trigger GitHub workflows, so we route through GitHub's


### PR DESCRIPTION
PR #1666 governance-retro findings (1 Med, 1 Low), both doc-drift:

- **deployment-guide.md**: the "Public docs" table listed 9 of 21 live pages — added /docs/inventory (new), /docs/vscode-extension, /docs/dependencies, /docs/faq, and the tutorials family.
- **vercel-deploy-hook.md**: status banner marking the `repository_dispatch` smoke trigger as a dormant backup (0 firings in 40+ runs; `workflow_run` is the real path post-SMI-5246/5247) so the PAT-rotation failure-mode table doesn't misdirect an operator.

Docs-only; no runtime surface.

[skip-impl-check]

Linear: SMI-5464

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)