### PR TITLE
feat(website): docs-style left sidebar for the account area (SMI-5475)

### DIFF
--- a/packages/website/src/components/AccountSidebar.astro
+++ b/packages/website/src/components/AccountSidebar.astro
@@ -178,6 +178,10 @@ const { currentPath } = Astro.props
     mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpolyline points='4 17 10 11 4 5'/%3E%3Cline x1='12' y1='19' x2='20' y2='19'/%3E%3C/svg%3E");
   }
 
+  .nav-icon[data-icon='grid']::before {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Crect x='3' y='3' width='7' height='7'/%3E%3Crect x='14' y='3' width='7' height='7'/%3E%3Crect x='14' y='14' width='7' height='7'/%3E%3Crect x='3' y='14' width='7' height='7'/%3E%3C/svg%3E");
+  }
+
   .nav-icon[data-icon='repeat']::before {
     mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpolyline points='17 1 21 5 17 9'/%3E%3Cpath d='M3 11V9a4 4 0 0 1 4-4h14'/%3E%3Cpolyline points='7 23 3 19 7 15'/%3E%3Cpath d='M21 13v2a4 4 0 0 1-4 4H3'/%3E%3C/svg%3E");
   }

--- a/packages/website/src/components/AccountSidebar.astro
+++ b/packages/website/src/components/AccountSidebar.astro
@@ -1,0 +1,214 @@
+---
+/**
+ * AccountSidebar — persistent left navigation for /account pages (SMI-5475).
+ *
+ * Visual parity with DocsSidebar.astro, but in plain scoped CSS: account
+ * pages hand-roll their documents and do not load global.css/Tailwind
+ * (precedent: TeamNav.astro). Zero client JS — active state is computed
+ * server-side per navigation, so the SMI-4896/5158 astro:page-load
+ * handler-leak class cannot occur. No transition:persist for the same
+ * reason. Hidden below 1024px, matching the docs sidebar (product
+ * decision, SMI-5475).
+ *
+ * Usage:
+ *   <div class="account-shell">
+ *     <AccountSidebar currentPath={Astro.url.pathname} />
+ *     <main class="...">...</main>
+ *   </div>
+ */
+
+import { ACCOUNT_NAV_SECTIONS, isActiveAccountNav } from '../lib/account-nav'
+
+interface Props {
+  currentPath: string
+}
+
+const { currentPath } = Astro.props
+---
+
+<aside class="account-sidebar">
+  <nav aria-label="Account navigation">
+    {
+      ACCOUNT_NAV_SECTIONS.map((section) => (
+        <div class="sidebar-section">
+          <h3>{section.heading}</h3>
+          <ul>
+            {section.items.map((item) => (
+              <li>
+                <a
+                  href={item.href}
+                  class:list={[
+                    'account-nav-link',
+                    { active: isActiveAccountNav(item.href, currentPath) },
+                  ]}
+                  aria-current={isActiveAccountNav(item.href, currentPath) ? 'page' : undefined}
+                >
+                  <span class="nav-icon" data-icon={item.icon} />
+                  <span>{item.label}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))
+    }
+  </nav>
+</aside>
+
+<!-- The .account-shell wrapper lives in each page template, out of scoped-style
+     reach; one shared global definition here beats 11 drifting per-page copies.
+     The component only mounts on account pages, so the leak surface is nil. -->
+<style is:global>
+  .account-shell {
+    display: flex;
+    align-items: stretch;
+    width: 100%;
+    flex: 1;
+    min-height: calc(100vh - 4rem);
+  }
+
+  /* Supplies flex/min-width where page container CSS lacks it (cli-token,
+     telemetry). Astro compiles page-scoped styles with :where() (0-1-0),
+     so this 0-1-1 selector wins without !important. */
+  .account-shell > main {
+    flex: 1;
+    min-width: 0;
+  }
+
+  @media (max-width: 1024px) {
+    .account-shell {
+      display: block;
+      min-height: 0;
+    }
+  }
+</style>
+
+<style>
+  .account-sidebar {
+    width: 16rem;
+    flex-shrink: 0;
+    border-right: 1px solid #1f1f23; /* dark-800 */
+    background: rgba(18, 18, 20, 0.5); /* dark-900/50 */
+  }
+
+  .account-sidebar > nav {
+    position: sticky;
+    top: 4rem; /* below the 4rem top Nav */
+    height: calc(100vh - 4rem);
+    overflow-y: auto;
+    padding: 1.5rem;
+  }
+
+  .sidebar-section {
+    margin-bottom: 1.5rem;
+  }
+
+  .sidebar-section h3 {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #94a3b8; /* dark-400 */
+    margin: 0 0 0.75rem;
+    padding: 0 0.75rem;
+  }
+
+  .sidebar-section ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .account-nav-link {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #cbd5e1; /* dark-300 */
+    text-decoration: none;
+    transition:
+      color 0.15s,
+      background-color 0.15s;
+  }
+
+  .account-nav-link:hover {
+    background: #1f1f23; /* dark-800 */
+    color: #ffffff;
+  }
+
+  .account-nav-link.active {
+    background: rgba(224, 122, 95, 0.1); /* primary-500/10 */
+    color: #ec8b73; /* primary-400 */
+  }
+
+  .nav-icon {
+    width: 1.125rem;
+    height: 1.125rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.7;
+  }
+
+  .nav-icon::before {
+    content: '';
+    width: 1rem;
+    height: 1rem;
+    background: currentColor;
+    mask-size: contain;
+    mask-repeat: no-repeat;
+    mask-position: center;
+  }
+
+  .nav-icon[data-icon='home']::before {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpath d='M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z'/%3E%3Cpolyline points='9 22 9 12 15 12 15 22'/%3E%3C/svg%3E");
+  }
+
+  .nav-icon[data-icon='mail']::before {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpath d='M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z'/%3E%3Cpolyline points='22,6 12,13 2,6'/%3E%3C/svg%3E");
+  }
+
+  .nav-icon[data-icon='terminal']::before {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpolyline points='4 17 10 11 4 5'/%3E%3Cline x1='12' y1='19' x2='20' y2='19'/%3E%3C/svg%3E");
+  }
+
+  .nav-icon[data-icon='repeat']::before {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpolyline points='17 1 21 5 17 9'/%3E%3Cpath d='M3 11V9a4 4 0 0 1 4-4h14'/%3E%3Cpolyline points='7 23 3 19 7 15'/%3E%3Cpath d='M21 13v2a4 4 0 0 1-4 4H3'/%3E%3C/svg%3E");
+  }
+
+  .nav-icon[data-icon='credit-card']::before {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Crect x='1' y='4' width='22' height='16' rx='2' ry='2'/%3E%3Cline x1='1' y1='10' x2='23' y2='10'/%3E%3C/svg%3E");
+  }
+
+  .nav-icon[data-icon='users']::before {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpath d='M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2'/%3E%3Ccircle cx='9' cy='7' r='4'/%3E%3Cpath d='M23 21v-2a4 4 0 0 0-3-3.87'/%3E%3Cpath d='M16 3.13a4 4 0 0 1 0 7.75'/%3E%3C/svg%3E");
+  }
+
+  .nav-icon[data-icon='bell']::before {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpath d='M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9'/%3E%3Cpath d='M13.73 21a2 2 0 0 1-3.46 0'/%3E%3C/svg%3E");
+  }
+
+  .nav-icon[data-icon='activity']::before {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpolyline points='22 12 18 12 15 21 9 3 6 12 2 12'/%3E%3C/svg%3E");
+  }
+
+  .nav-icon[data-icon='play-circle']::before {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpolygon points='10 8 16 12 10 16 10 8'/%3E%3C/svg%3E");
+  }
+
+  .nav-icon[data-icon='code']::before {
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpolyline points='16 18 22 12 16 6'/%3E%3Cpolyline points='8 6 2 12 8 18'/%3E%3C/svg%3E");
+  }
+
+  @media (max-width: 1024px) {
+    .account-sidebar {
+      display: none;
+    }
+  }
+</style>

--- a/packages/website/src/lib/account-nav.test.ts
+++ b/packages/website/src/lib/account-nav.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for account sidebar nav data + active-link logic (SMI-5475).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { ACCOUNT_NAV_SECTIONS, isActiveAccountNav } from './account-nav'
+
+describe('isActiveAccountNav', () => {
+  it('matches the dashboard exactly, with and without trailing slash', () => {
+    expect(isActiveAccountNav('/account', '/account')).toBe(true)
+    expect(isActiveAccountNav('/account', '/account/')).toBe(true)
+  })
+
+  it('does not light the dashboard on subpages', () => {
+    expect(isActiveAccountNav('/account', '/account/subscription')).toBe(false)
+    expect(isActiveAccountNav('/account', '/account/team/members')).toBe(false)
+  })
+
+  it('matches exact subpages regardless of trailing slash on either side', () => {
+    expect(isActiveAccountNav('/account/cli-token/', '/account/cli-token')).toBe(true)
+    expect(isActiveAccountNav('/account/cli-token/', '/account/cli-token/')).toBe(true)
+    expect(isActiveAccountNav('/account/billing', '/account/billing/')).toBe(true)
+  })
+
+  it('keeps Team lit across the team sub-tabs', () => {
+    expect(isActiveAccountNav('/account/team', '/account/team')).toBe(true)
+    expect(isActiveAccountNav('/account/team', '/account/team/')).toBe(true)
+    expect(isActiveAccountNav('/account/team', '/account/team/members')).toBe(true)
+    expect(isActiveAccountNav('/account/team', '/account/team/workspaces')).toBe(true)
+    expect(isActiveAccountNav('/account/team', '/account/team/analytics')).toBe(true)
+  })
+
+  it('does not false-positive on sibling paths sharing the team prefix', () => {
+    expect(isActiveAccountNav('/account/team', '/account/teammates')).toBe(false)
+  })
+
+  it('never activates docs links on account paths', () => {
+    for (const path of ['/account', '/account/billing', '/account/team/members']) {
+      expect(isActiveAccountNav('/docs/quickstart', path)).toBe(false)
+      expect(isActiveAccountNav('/docs/api', path)).toBe(false)
+    }
+  })
+
+  it('activates exactly one item per account page', () => {
+    const allItems = ACCOUNT_NAV_SECTIONS.flatMap((s) => s.items)
+    const accountPaths = [
+      '/account',
+      '/account/profile',
+      '/account/cli-token/',
+      '/account/subscription',
+      '/account/billing',
+      '/account/team',
+      '/account/team/members',
+      '/account/outreach-preferences',
+      '/account/telemetry',
+    ]
+    for (const path of accountPaths) {
+      const active = allItems.filter((i) => isActiveAccountNav(i.href, path))
+      expect(active, `path ${path}`).toHaveLength(1)
+    }
+  })
+})
+
+describe('ACCOUNT_NAV_SECTIONS', () => {
+  it('has unique hrefs', () => {
+    const hrefs = ACCOUNT_NAV_SECTIONS.flatMap((s) => s.items.map((i) => i.href))
+    expect(new Set(hrefs).size).toBe(hrefs.length)
+  })
+
+  it('has an icon and label on every item', () => {
+    for (const item of ACCOUNT_NAV_SECTIONS.flatMap((s) => s.items)) {
+      expect(item.icon).toBeTruthy()
+      expect(item.label).toBeTruthy()
+    }
+  })
+})

--- a/packages/website/src/lib/account-nav.test.ts
+++ b/packages/website/src/lib/account-nav.test.ts
@@ -47,6 +47,7 @@ describe('isActiveAccountNav', () => {
       '/account',
       '/account/profile',
       '/account/cli-token/',
+      '/account/skills',
       '/account/subscription',
       '/account/billing',
       '/account/team',

--- a/packages/website/src/lib/account-nav.ts
+++ b/packages/website/src/lib/account-nav.ts
@@ -25,6 +25,7 @@ export const ACCOUNT_NAV_SECTIONS: AccountNavSection[] = [
       { href: '/account/profile', label: 'Email Address', icon: 'mail' },
       // Trailing slash matches the page's own path guard, which accepts both forms.
       { href: '/account/cli-token/', label: 'CLI Token', icon: 'terminal' },
+      { href: '/account/skills', label: 'Skill Inventory', icon: 'grid' },
     ],
   },
   {

--- a/packages/website/src/lib/account-nav.ts
+++ b/packages/website/src/lib/account-nav.ts
@@ -1,0 +1,77 @@
+/**
+ * Account-area sidebar navigation data + active-link logic (SMI-5475).
+ *
+ * Pure module so `isActiveAccountNav` is unit-testable outside Astro
+ * (same pattern as other extracted utils in src/lib/). Consumed by
+ * src/components/AccountSidebar.astro.
+ */
+
+export interface AccountNavItem {
+  href: string
+  label: string
+  icon: string
+}
+
+export interface AccountNavSection {
+  heading: string
+  items: AccountNavItem[]
+}
+
+export const ACCOUNT_NAV_SECTIONS: AccountNavSection[] = [
+  {
+    heading: 'Account',
+    items: [
+      { href: '/account', label: 'Dashboard', icon: 'home' },
+      { href: '/account/profile', label: 'Email Address', icon: 'mail' },
+      // Trailing slash matches the page's own path guard, which accepts both forms.
+      { href: '/account/cli-token/', label: 'CLI Token', icon: 'terminal' },
+    ],
+  },
+  {
+    heading: 'Billing',
+    items: [
+      { href: '/account/subscription', label: 'Subscription', icon: 'repeat' },
+      { href: '/account/billing', label: 'Billing History', icon: 'credit-card' },
+    ],
+  },
+  {
+    heading: 'Team',
+    items: [{ href: '/account/team', label: 'Team', icon: 'users' }],
+  },
+  {
+    heading: 'Preferences',
+    items: [
+      { href: '/account/outreach-preferences', label: 'Outreach', icon: 'bell' },
+      { href: '/account/telemetry', label: 'Telemetry', icon: 'activity' },
+    ],
+  },
+  {
+    heading: 'Resources',
+    items: [
+      { href: '/docs/quickstart', label: 'Getting Started', icon: 'play-circle' },
+      { href: '/docs/api', label: 'API Docs', icon: 'code' },
+    ],
+  },
+]
+
+function stripTrailingSlash(path: string): string {
+  return path.length > 1 ? path.replace(/\/+$/, '') : path
+}
+
+/**
+ * Whether a sidebar item should render as active for the current path.
+ *
+ * `/account/team` is a section root: its sub-tabs (/members, /workspaces,
+ * /analytics — navigated via TeamNav) keep the Team item lit. Everything
+ * else is an exact match after trailing-slash normalization, so
+ * `/account/cli-token/` matches both slash forms and `/account` never
+ * lights up on subpages.
+ */
+export function isActiveAccountNav(href: string, currentPath: string): boolean {
+  const current = stripTrailingSlash(currentPath)
+  const target = stripTrailingSlash(href)
+  if (target === '/account/team') {
+    return current === target || current.startsWith(`${target}/`)
+  }
+  return current === target
+}

--- a/packages/website/src/pages/account/billing.astro
+++ b/packages/website/src/pages/account/billing.astro
@@ -16,6 +16,7 @@
 export const prerender = false
 
 import { ClientRouter } from 'astro:transitions'
+import AccountSidebar from '../../components/AccountSidebar.astro'
 import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import { getSupabaseConfig } from '../../lib/supabase-config'
@@ -48,113 +49,117 @@ const supabaseConfig = getSupabaseConfig()
   <body>
     <Nav activePath="/account/billing" />
 
-    <main class="billing-container">
-      <!-- Loading State -->
-      <div id="loading-state" class="loading-state">
-        <div class="spinner-container">
-          <svg class="spinner" viewBox="0 0 24 24">
-            <circle
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              stroke-width="4"
-              fill="none"
-              opacity="0.25"></circle>
-            <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
-            ></path>
-          </svg>
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
+
+      <main class="billing-container">
+        <!-- Loading State -->
+        <div id="loading-state" class="loading-state">
+          <div class="spinner-container">
+            <svg class="spinner" viewBox="0 0 24 24">
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+                fill="none"
+                opacity="0.25"></circle>
+              <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
+              ></path>
+            </svg>
+          </div>
+          <p>Loading billing history...</p>
         </div>
-        <p>Loading billing history...</p>
-      </div>
 
-      <!-- Error State -->
-      <div id="error-state" class="error-state" style="display: none;">
-        <div class="error-content">
-          <svg class="error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1.5"
-              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-            ></path>
-          </svg>
-          <h3>Failed to load billing data</h3>
-          <p id="error-message">Something went wrong</p>
-          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
+        <!-- Error State -->
+        <div id="error-state" class="error-state" style="display: none;">
+          <div class="error-content">
+            <svg class="error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              ></path>
+            </svg>
+            <h3>Failed to load billing data</h3>
+            <p id="error-message">Something went wrong</p>
+            <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
+          </div>
         </div>
-      </div>
 
-      <!-- Content -->
-      <div id="billing-content" style="display: none;">
-        <h1>Billing History</h1>
+        <!-- Content -->
+        <div id="billing-content" style="display: none;">
+          <h1>Billing History</h1>
 
-        <!-- Current Subscription Summary -->
-        <section class="section">
-          <h2>Current Subscription</h2>
-          <div class="subscription-summary" id="subscription-summary">
-            <div class="summary-item">
-              <span class="label">Plan</span>
-              <span class="value" id="current-plan">Community</span>
+          <!-- Current Subscription Summary -->
+          <section class="section">
+            <h2>Current Subscription</h2>
+            <div class="subscription-summary" id="subscription-summary">
+              <div class="summary-item">
+                <span class="label">Plan</span>
+                <span class="value" id="current-plan">Community</span>
+              </div>
+              <div class="summary-item">
+                <span class="label">Status</span>
+                <span class="status-badge" id="subscription-status">Active</span>
+              </div>
+              <div class="summary-item">
+                <span class="label">Next Payment</span>
+                <span class="value" id="next-payment">-</span>
+              </div>
+              <div class="summary-item">
+                <span class="label">Amount</span>
+                <span class="value" id="payment-amount">Free</span>
+              </div>
             </div>
-            <div class="summary-item">
-              <span class="label">Status</span>
-              <span class="status-badge" id="subscription-status">Active</span>
-            </div>
-            <div class="summary-item">
-              <span class="label">Next Payment</span>
-              <span class="value" id="next-payment">-</span>
-            </div>
-            <div class="summary-item">
-              <span class="label">Amount</span>
-              <span class="value" id="payment-amount">Free</span>
-            </div>
-          </div>
-        </section>
+          </section>
 
-        <!-- Payment Method -->
-        <section class="section">
-          <div class="section-header">
-            <h2>Payment Method</h2>
-            <button class="btn btn-secondary btn-sm" id="manage-payment-btn">Manage</button>
-          </div>
-          <div class="payment-method" id="payment-method">
-            <div class="no-payment">
-              <p>No payment method on file</p>
-              <p class="text-muted">Add a payment method to upgrade to a paid plan.</p>
+          <!-- Payment Method -->
+          <section class="section">
+            <div class="section-header">
+              <h2>Payment Method</h2>
+              <button class="btn btn-secondary btn-sm" id="manage-payment-btn">Manage</button>
             </div>
-          </div>
-        </section>
-
-        <!-- Invoice History -->
-        <section class="section">
-          <h2>Invoice History</h2>
-          <div class="invoices-list" id="invoices-list">
-            <div class="empty-state">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-                <line x1="16" y1="2" x2="16" y2="6"></line>
-                <line x1="8" y1="2" x2="8" y2="6"></line>
-                <line x1="3" y1="10" x2="21" y2="10"></line>
-              </svg>
-              <p>No invoices yet</p>
-              <p class="text-muted">
-                Invoices will appear here once you have an active subscription.
-              </p>
+            <div class="payment-method" id="payment-method">
+              <div class="no-payment">
+                <p>No payment method on file</p>
+                <p class="text-muted">Add a payment method to upgrade to a paid plan.</p>
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
 
-        <!-- Billing Contact -->
-        <section class="section">
-          <h2>Billing Contact</h2>
-          <div class="billing-contact" id="billing-contact">
-            <p class="text-muted">Invoices are sent to your account email.</p>
-            <p id="billing-email">-</p>
-          </div>
-        </section>
-      </div>
-    </main>
+          <!-- Invoice History -->
+          <section class="section">
+            <h2>Invoice History</h2>
+            <div class="invoices-list" id="invoices-list">
+              <div class="empty-state">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                  <line x1="16" y1="2" x2="16" y2="6"></line>
+                  <line x1="8" y1="2" x2="8" y2="6"></line>
+                  <line x1="3" y1="10" x2="21" y2="10"></line>
+                </svg>
+                <p>No invoices yet</p>
+                <p class="text-muted">
+                  Invoices will appear here once you have an active subscription.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <!-- Billing Contact -->
+          <section class="section">
+            <h2>Billing Contact</h2>
+            <div class="billing-contact" id="billing-contact">
+              <p class="text-muted">Invoices are sent to your account email.</p>
+              <p id="billing-email">-</p>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
 
     <Footer compact />
   </body>

--- a/packages/website/src/pages/account/cli-token.astro
+++ b/packages/website/src/pages/account/cli-token.astro
@@ -17,6 +17,7 @@ export const prerender = false
 
 import { ClientRouter } from 'astro:transitions'
 import { getSupabaseConfig } from '../../lib/supabase-config'
+import AccountSidebar from '../../components/AccountSidebar.astro'
 import Nav from '../../components/Nav.astro'
 
 const supabaseConfig = getSupabaseConfig()
@@ -59,98 +60,103 @@ const supabaseConfig = getSupabaseConfig()
   <body>
     <Nav activePath="/account" />
 
-    <main class="page-container">
-      <!-- Loading State -->
-      <div id="loading-state" class="loading-state">
-        <div class="spinner-container">
-          <svg class="spinner" viewBox="0 0 24 24" aria-hidden="true">
-            <circle
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              stroke-width="4"
-              fill="none"
-              opacity="0.25"></circle>
-            <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
-            ></path>
-          </svg>
-        </div>
-        <p>Loading...</p>
-      </div>
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <!-- Error State -->
-      <div id="error-state" class="error-state" style="display: none;">
-        <div class="error-content">
-          <h2>Something went wrong</h2>
-          <p id="error-message">Please try again.</p>
-          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
-        </div>
-      </div>
-
-      <!-- Page Content (hidden until authenticated) -->
-      <div id="page-content" style="display: none;">
-        <div class="page-header">
-          <a href="/account" class="back-link">← Account</a>
-          <h1>CLI Token</h1>
-          <p class="page-description">
-            Generate an API key to authenticate the <code>skillsmith login</code> command.
-          </p>
+      <main class="page-container">
+        <!-- Loading State -->
+        <div id="loading-state" class="loading-state">
+          <div class="spinner-container">
+            <svg class="spinner" viewBox="0 0 24 24" aria-hidden="true">
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+                fill="none"
+                opacity="0.25"></circle>
+              <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
+              ></path>
+            </svg>
+          </div>
+          <p>Loading...</p>
         </div>
 
-        <!-- Instructions -->
-        <div class="instructions-card">
-          <h2>How to use</h2>
-          <ol class="steps">
-            <li>Run <code>skillsmith login</code> in your terminal</li>
-            <li>Click <strong>Generate CLI Token</strong> below</li>
-            <li>Click <strong>Copy</strong> to copy the key</li>
-            <li>Return to your terminal and paste the key when prompted</li>
-          </ol>
+        <!-- Error State -->
+        <div id="error-state" class="error-state" style="display: none;">
+          <div class="error-content">
+            <h2>Something went wrong</h2>
+            <p id="error-message">Please try again.</p>
+            <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
+          </div>
         </div>
 
-        <!-- Key Generation Section -->
-        <div class="token-card">
-          <!-- Initial state: generate button -->
-          <div id="generate-section">
-            <p class="token-hint">
-              Each key is shown <strong>once only</strong> — copy it immediately.
+        <!-- Page Content (hidden until authenticated) -->
+        <div id="page-content" style="display: none;">
+          <div class="page-header">
+            <a href="/account" class="back-link">← Account</a>
+            <h1>CLI Token</h1>
+            <p class="page-description">
+              Generate an API key to authenticate the <code>skillsmith login</code> command.
             </p>
-            <button id="generate-btn" class="btn btn-primary"> Generate CLI Token </button>
-            <p id="generate-error" class="error-text" style="display: none;"></p>
           </div>
 
-          <!-- Key display state (hidden until generated) -->
-          <div id="key-section" style="display: none;">
-            <div id="key-container" aria-live="polite" aria-atomic="true" class="key-container">
-              <p class="key-label">Your CLI API key:</p>
-              <div class="key-display-row">
-                <code id="key-value" class="key-value">sk_live_...</code>
-                <button
-                  id="copy-btn"
-                  class="btn btn-secondary btn-sm"
-                  aria-label="Copy API key to clipboard"
-                >
-                  Copy
-                </button>
-              </div>
-              <p class="key-warning">
-                <strong>Save this key now.</strong> It will not be shown again after you close this page.
+          <!-- Instructions -->
+          <div class="instructions-card">
+            <h2>How to use</h2>
+            <ol class="steps">
+              <li>Run <code>skillsmith login</code> in your terminal</li>
+              <li>Click <strong>Generate CLI Token</strong> below</li>
+              <li>Click <strong>Copy</strong> to copy the key</li>
+              <li>Return to your terminal and paste the key when prompted</li>
+            </ol>
+          </div>
+
+          <!-- Key Generation Section -->
+          <div class="token-card">
+            <!-- Initial state: generate button -->
+            <div id="generate-section">
+              <p class="token-hint">
+                Each key is shown <strong>once only</strong> — copy it immediately.
               </p>
+              <button id="generate-btn" class="btn btn-primary"> Generate CLI Token </button>
+              <p id="generate-error" class="error-text" style="display: none;"></p>
             </div>
 
-            <p class="return-hint">Return to your terminal and paste the key when prompted.</p>
+            <!-- Key display state (hidden until generated) -->
+            <div id="key-section" style="display: none;">
+              <div id="key-container" aria-live="polite" aria-atomic="true" class="key-container">
+                <p class="key-label">Your CLI API key:</p>
+                <div class="key-display-row">
+                  <code id="key-value" class="key-value">sk_live_...</code>
+                  <button
+                    id="copy-btn"
+                    class="btn btn-secondary btn-sm"
+                    aria-label="Copy API key to clipboard"
+                  >
+                    Copy
+                  </button>
+                </div>
+                <p class="key-warning">
+                  <strong>Save this key now.</strong> It will not be shown again after you close this
+                  page.
+                </p>
+              </div>
 
-            <button id="done-btn" class="btn btn-primary" aria-label="Close">
-              I've copied it — close
-            </button>
+              <p class="return-hint">Return to your terminal and paste the key when prompted.</p>
+
+              <button id="done-btn" class="btn btn-primary" aria-label="Close">
+                I've copied it — close
+              </button>
+            </div>
           </div>
-        </div>
 
-        <!-- Tier info -->
-        <p class="tier-note" id="tier-note" style="display: none;"></p>
-      </div>
-    </main>
+          <!-- Tier info -->
+          <p class="tier-note" id="tier-note" style="display: none;"></p>
+        </div>
+      </main>
+    </div>
 
     <script>
       import { createClient } from '@supabase/supabase-js'

--- a/packages/website/src/pages/account/index.astro
+++ b/packages/website/src/pages/account/index.astro
@@ -13,6 +13,7 @@ export const prerender = false
 
 import { ClientRouter } from 'astro:transitions'
 import { getSupabaseConfig } from '../../lib/supabase-config'
+import AccountSidebar from '../../components/AccountSidebar.astro'
 import Footer from '../../components/Footer.astro'
 import Nav from '../../components/Nav.astro'
 
@@ -47,227 +48,155 @@ const supabaseConfig = getSupabaseConfig()
   <body>
     <Nav activePath="/account" />
 
-    <main class="dashboard-container">
-      <!-- SMI-4463: Quota banner — populated client-side after the
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
+      <main class="dashboard-container">
+        <!-- SMI-4463: Quota banner — populated client-side after the
            tier-aware billing-period RPC resolves. Hidden until then.
            Placed above the page heading per WCAG landmark conventions. -->
-      <div id="quota-banner-container" aria-live="polite" style="display: none;"></div>
+        <div id="quota-banner-container" aria-live="polite" style="display: none;"></div>
 
-      <!-- Loading State -->
-      <div id="loading-state" class="loading-state">
-        <div class="spinner-container">
-          <svg class="spinner" viewBox="0 0 24 24">
-            <circle
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              stroke-width="4"
-              fill="none"
-              opacity="0.25"></circle>
-            <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
-            ></path>
-          </svg>
-        </div>
-        <p>Loading your account...</p>
-      </div>
-
-      <!-- Error State -->
-      <div id="error-state" class="error-state" style="display: none;">
-        <div class="error-content">
-          <svg class="error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1.5"
-              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-            ></path>
-          </svg>
-          <h3>Failed to load account data</h3>
-          <p id="error-message">Something went wrong</p>
-          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
-        </div>
-      </div>
-
-      <!-- Dashboard Content (hidden until loaded) -->
-      <div id="dashboard-content" style="display: none;">
-        <!-- Welcome Section -->
-        <div class="welcome-section">
-          <h1>Welcome back, <span id="user-name">User</span></h1>
-          <p class="user-email" id="user-email">user@example.com</p>
-          <p class="github-username" id="github-username" style="display: none;">
-            <svg class="github-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"
+        <!-- Loading State -->
+        <div id="loading-state" class="loading-state">
+          <div class="spinner-container">
+            <svg class="spinner" viewBox="0 0 24 24">
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+                fill="none"
+                opacity="0.25"></circle>
+              <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
               ></path>
             </svg>
-            <a
-              id="github-link"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="GitHub profile">GitHub</a
-            >
-          </p>
+          </div>
+          <p>Loading your account...</p>
         </div>
 
-        <!-- Stats Cards -->
-        <div class="stats-grid">
-          <div class="stat-card">
-            <div class="stat-label">Current Plan</div>
-            <div class="stat-value" id="current-tier">Community</div>
-          </div>
-
-          <div class="stat-card">
-            <div class="stat-label">API Usage</div>
-            <div class="stat-value" id="api-usage">0 / 1,000</div>
-            <span class="stat-subtext">total API calls</span>
-          </div>
-
-          <div class="stat-card">
-            <div class="stat-label">License Keys</div>
-            <div class="stat-value" id="key-count">0 / 1</div>
-            <span class="stat-subtext">active keys</span>
+        <!-- Error State -->
+        <div id="error-state" class="error-state" style="display: none;">
+          <div class="error-content">
+            <svg class="error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              ></path>
+            </svg>
+            <h3>Failed to load account data</h3>
+            <p id="error-message">Something went wrong</p>
+            <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
           </div>
         </div>
 
-        <!-- Subscription Section -->
-        <section class="dashboard-section">
-          <div class="section-header">
-            <h2>Subscription</h2>
-            <a href="/account/subscription/" class="btn btn-secondary btn-sm">Manage</a>
-          </div>
-
-          <div class="subscription-card" id="subscription-card">
-            <div class="subscription-info">
-              <div class="subscription-tier">
-                <span class="tier-badge community" id="tier-badge">Community</span>
-                <span class="tier-price" id="tier-price">Free</span>
-              </div>
-              <div class="subscription-details" id="subscription-details">
-                <p>Free forever with 1,000 API calls per month</p>
-              </div>
-            </div>
-            <div class="subscription-actions" id="subscription-actions">
-              <a href="/pricing" class="btn btn-primary">Upgrade Plan</a>
-            </div>
-          </div>
-        </section>
-
-        <!-- License Keys Section -->
-        <section class="dashboard-section">
-          <div class="section-header">
-            <h2>License Keys</h2>
-            <button id="generate-key-btn" class="btn btn-primary btn-sm">Generate New Key</button>
-          </div>
-
-          <div id="keys-list" class="keys-list">
-            <div class="empty-state">
-              <p>No license keys yet.</p>
-              <p class="text-muted">Generate a key to authenticate your CLI or MCP server.</p>
-            </div>
-          </div>
-
-          <!-- New Key Modal -->
-          <div id="new-key-modal" class="modal" style="display: none;">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h3>New License Key Generated</h3>
-                <button class="modal-close" id="close-modal">&times;</button>
-              </div>
-              <div class="modal-body">
-                <p class="warning-text">
-                  <strong>Important:</strong> Copy this key now. It will not be shown again.
-                </p>
-                <div class="key-display">
-                  <code id="new-key-value">sk_live_...</code>
-                  <button id="copy-key-btn" class="btn btn-secondary btn-sm">Copy</button>
-                </div>
-              </div>
-              <div class="modal-footer">
-                <button id="done-btn" class="btn btn-primary">Done</button>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <!-- Quick Links Section -->
-        <section class="dashboard-section">
-          <h2>Quick Links</h2>
-          <div class="quick-links">
-            <a href="/docs/quickstart" class="quick-link">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path>
-              </svg>
-              <span>Getting Started</span>
-            </a>
-            <a href="/docs/api" class="quick-link">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-                <polyline points="14 2 14 8 20 8"></polyline>
-                <line x1="16" y1="13" x2="8" y2="13"></line>
-                <line x1="16" y1="17" x2="8" y2="17"></line>
-              </svg>
-              <span>API Documentation</span>
-            </a>
-            <a href="/account/team" class="quick-link">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
-                <circle cx="9" cy="7" r="4"></circle>
-                <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
-                <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
-              </svg>
-              <span>Team</span>
-            </a>
-            <a href="/account/billing" class="quick-link">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <rect x="1" y="4" width="22" height="16" rx="2" ry="2"></rect>
-                <line x1="1" y1="10" x2="23" y2="10"></line>
-              </svg>
-              <span>Billing History</span>
-            </a>
-            <a href="/account/cli-token/" class="quick-link">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="4 17 10 11 4 5"></polyline>
-                <line x1="12" y1="19" x2="20" y2="19"></line>
-              </svg>
-              <span>CLI Token</span>
-            </a>
-            <a href="/account/profile" class="quick-link">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <rect x="2" y="4" width="20" height="16" rx="2"></rect>
-                <path d="M22 7l-10 6L2 7"></path>
-              </svg>
-              <span>Email Address</span>
-            </a>
-            <a href="/account/outreach-preferences" class="quick-link">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <!-- Dashboard Content (hidden until loaded) -->
+        <div id="dashboard-content" style="display: none;">
+          <!-- Welcome Section -->
+          <div class="welcome-section">
+            <h1>Welcome back, <span id="user-name">User</span></h1>
+            <p class="user-email" id="user-email">user@example.com</p>
+            <p class="github-username" id="github-username" style="display: none;">
+              <svg class="github-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                 <path
-                  d="M18.364 18.364A9 9 0 0 0 5.636 5.636m12.728 12.728A9 9 0 0 1 5.636 5.636m12.728 12.728L5.636 5.636"
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"
                 ></path>
               </svg>
-              <span>Outreach Preferences</span>
-            </a>
-            <a href="/account/telemetry" class="quick-link">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M3 12h4l3-9 4 18 3-9h4"></path>
-              </svg>
-              <span>Telemetry Preferences</span>
-            </a>
-            <a href="/account/skills" class="quick-link">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <rect x="3" y="3" width="7" height="7"></rect>
-                <rect x="14" y="3" width="7" height="7"></rect>
-                <rect x="14" y="14" width="7" height="7"></rect>
-                <rect x="3" y="14" width="7" height="7"></rect>
-              </svg>
-              <span>Skill Inventory</span>
-            </a>
+              <a
+                id="github-link"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="GitHub profile">GitHub</a
+              >
+            </p>
           </div>
-        </section>
-      </div>
-    </main>
+
+          <!-- Stats Cards -->
+          <div class="stats-grid">
+            <div class="stat-card">
+              <div class="stat-label">Current Plan</div>
+              <div class="stat-value" id="current-tier">Community</div>
+            </div>
+
+            <div class="stat-card">
+              <div class="stat-label">API Usage</div>
+              <div class="stat-value" id="api-usage">0 / 1,000</div>
+              <span class="stat-subtext">total API calls</span>
+            </div>
+
+            <div class="stat-card">
+              <div class="stat-label">License Keys</div>
+              <div class="stat-value" id="key-count">0 / 1</div>
+              <span class="stat-subtext">active keys</span>
+            </div>
+          </div>
+
+          <!-- Subscription Section -->
+          <section class="dashboard-section">
+            <div class="section-header">
+              <h2>Subscription</h2>
+              <a href="/account/subscription/" class="btn btn-secondary btn-sm">Manage</a>
+            </div>
+
+            <div class="subscription-card" id="subscription-card">
+              <div class="subscription-info">
+                <div class="subscription-tier">
+                  <span class="tier-badge community" id="tier-badge">Community</span>
+                  <span class="tier-price" id="tier-price">Free</span>
+                </div>
+                <div class="subscription-details" id="subscription-details">
+                  <p>Free forever with 1,000 API calls per month</p>
+                </div>
+              </div>
+              <div class="subscription-actions" id="subscription-actions">
+                <a href="/pricing" class="btn btn-primary">Upgrade Plan</a>
+              </div>
+            </div>
+          </section>
+
+          <!-- License Keys Section -->
+          <section class="dashboard-section">
+            <div class="section-header">
+              <h2>License Keys</h2>
+              <button id="generate-key-btn" class="btn btn-primary btn-sm">Generate New Key</button>
+            </div>
+
+            <div id="keys-list" class="keys-list">
+              <div class="empty-state">
+                <p>No license keys yet.</p>
+                <p class="text-muted">Generate a key to authenticate your CLI or MCP server.</p>
+              </div>
+            </div>
+
+            <!-- New Key Modal -->
+            <div id="new-key-modal" class="modal" style="display: none;">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h3>New License Key Generated</h3>
+                  <button class="modal-close" id="close-modal">&times;</button>
+                </div>
+                <div class="modal-body">
+                  <p class="warning-text">
+                    <strong>Important:</strong> Copy this key now. It will not be shown again.
+                  </p>
+                  <div class="key-display">
+                    <code id="new-key-value">sk_live_...</code>
+                    <button id="copy-key-btn" class="btn btn-secondary btn-sm">Copy</button>
+                  </div>
+                </div>
+                <div class="modal-footer">
+                  <button id="done-btn" class="btn btn-primary">Done</button>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
 
     <Footer compact />
   </body>
@@ -614,36 +543,6 @@ const supabaseConfig = getSupabaseConfig()
     font-size: 0.875rem;
   }
 
-  /* Quick Links */
-  .quick-links {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 1rem;
-    margin-top: 1rem;
-  }
-
-  .quick-link {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 1rem;
-    background: #1a1a1f;
-    border-radius: 0.5rem;
-    text-decoration: none;
-    color: #fafafa;
-    transition: background 0.2s;
-  }
-
-  .quick-link:hover {
-    background: #2a2a2f;
-  }
-
-  .quick-link svg {
-    width: 1.25rem;
-    height: 1.25rem;
-    color: #e07a5f;
-  }
-
   /* Buttons */
   .btn {
     display: inline-flex;
@@ -833,6 +732,27 @@ const supabaseConfig = getSupabaseConfig()
     const doneBtn = document.getElementById('done-btn') as HTMLButtonElement
     const copyKeyBtn = document.getElementById('copy-key-btn') as HTMLButtonElement
     const newKeyValue = document.getElementById('new-key-value') as HTMLElement
+
+    // On popstate-driven ClientRouter transitions (WebKit especially) the
+    // pathname can already read /account while the swapped-in DOM still
+    // belongs to the previous page, so the guard above passes against a
+    // foreign DOM and the lookups return null. Bail out; the transition's
+    // own astro:page-load re-fires this handler once the real dashboard
+    // DOM is in place. Caught by account-page-load-guards.spec.ts (SMI-5475).
+    if (
+      !loadingState ||
+      !dashboardContent ||
+      !errorState ||
+      !errorMessage ||
+      !generateKeyBtn ||
+      !newKeyModal ||
+      !closeModalBtn ||
+      !doneBtn ||
+      !copyKeyBtn ||
+      !newKeyValue
+    ) {
+      return
+    }
 
     // State management function for consistent UI transitions
     function showState(state: 'loading' | 'content' | 'error') {

--- a/packages/website/src/pages/account/outreach-preferences.astro
+++ b/packages/website/src/pages/account/outreach-preferences.astro
@@ -8,7 +8,9 @@ export const prerender = false
 
 import { ClientRouter } from 'astro:transitions'
 import { getSupabaseConfig } from '../../lib/supabase-config'
+import AccountSidebar from '../../components/AccountSidebar.astro'
 import Footer from '../../components/Footer.astro'
+import Nav from '../../components/Nav.astro'
 import '../../styles/outreach-preferences.css'
 
 const supabaseConfig = getSupabaseConfig()
@@ -37,101 +39,106 @@ const supabaseConfig = getSupabaseConfig()
     <ClientRouter />
   </head>
   <body>
-    <main class="container">
-      <div id="loading-state" class="center-state">
-        <svg class="spinner" viewBox="0 0 24 24">
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            stroke-width="4"
-            fill="none"
-            opacity="0.25"></circle>
-          <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
-          ></path>
-        </svg>
-        <p>Loading...</p>
-      </div>
+    <Nav activePath="/account" />
 
-      <div id="error-state" class="center-state" style="display:none;">
-        <p id="error-message" class="error-text">Something went wrong</p>
-        <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
-      </div>
-
-      <div id="page-content" style="display:none;">
-        <div class="page-header">
-          <a href="/account" class="back-link">&larr; Account</a>
-          <h1>Outreach Preferences</h1>
-          <p class="subtitle">
-            Control which repositories receive Skillsmith quality-report issues.
-          </p>
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
+      <main class="container">
+        <div id="loading-state" class="center-state">
+          <svg class="spinner" viewBox="0 0 24 24">
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+              fill="none"
+              opacity="0.25"></circle>
+            <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
+            ></path>
+          </svg>
+          <p>Loading...</p>
         </div>
 
-        <div id="no-github-state" class="card center-card" style="display:none;">
-          <h2>GitHub Account Required</h2>
-          <p>Connect your GitHub account to manage outreach preferences.</p>
-          <button id="connect-github-btn" class="btn btn-primary">Connect GitHub</button>
+        <div id="error-state" class="center-state" style="display:none;">
+          <p id="error-message" class="error-text">Something went wrong</p>
+          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
         </div>
 
-        <div id="prefs-content" style="display:none;">
-          <div
-            id="pre-save-notice"
-            role="status"
-            aria-live="polite"
-            class="notice"
-            style="display:none;"
-          >
-            <strong>Before you save:</strong> Opting out will immediately create a suppression record.
-            Any open quality-report issues will be auto-closed within 24 hours. To re-enable outreach
-            for a repo, toggle it back on this page.
+        <div id="page-content" style="display:none;">
+          <div class="page-header">
+            <a href="/account" class="back-link">&larr; Account</a>
+            <h1>Outreach Preferences</h1>
+            <p class="subtitle">
+              Control which repositories receive Skillsmith quality-report issues.
+            </p>
           </div>
 
-          <div class="toolbar">
-            <input
-              id="filter-input"
-              type="text"
-              class="filter-input"
-              placeholder="Filter repositories..."
-              aria-label="Filter repositories"
-            />
-            <button id="select-all-btn" class="btn btn-secondary btn-sm">Select All</button>
-            <button id="deselect-all-btn" class="btn btn-secondary btn-sm">Deselect All</button>
+          <div id="no-github-state" class="card center-card" style="display:none;">
+            <h2>GitHub Account Required</h2>
+            <p>Connect your GitHub account to manage outreach preferences.</p>
+            <button id="connect-github-btn" class="btn btn-primary">Connect GitHub</button>
           </div>
 
-          <div id="repo-list" class="repo-list" aria-label="Repository list"></div>
-          <p id="empty-state" class="empty-text" style="display:none;">
-            No indexed repos found. Skillsmith has not yet indexed any repositories under your
-            GitHub account or your GitHub organizations. Skills are indexed daily.
-          </p>
-
-          <div class="save-row">
-            <button id="save-btn" class="btn btn-primary" disabled aria-disabled="true"
-              >Save Preferences</button
-            >
-            <svg
-              id="save-spinner"
-              class="spinner spinner-sm"
-              viewBox="0 0 24 24"
+          <div id="prefs-content" style="display:none;">
+            <div
+              id="pre-save-notice"
+              role="status"
+              aria-live="polite"
+              class="notice"
               style="display:none;"
-              aria-hidden="true"
             >
-              <circle
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                stroke-width="4"
-                fill="none"
-                opacity="0.25"></circle>
-              <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
-              ></path>
-            </svg>
+              <strong>Before you save:</strong> Opting out will immediately create a suppression record.
+              Any open quality-report issues will be auto-closed within 24 hours. To re-enable outreach
+              for a repo, toggle it back on this page.
+            </div>
+
+            <div class="toolbar">
+              <input
+                id="filter-input"
+                type="text"
+                class="filter-input"
+                placeholder="Filter repositories..."
+                aria-label="Filter repositories"
+              />
+              <button id="select-all-btn" class="btn btn-secondary btn-sm">Select All</button>
+              <button id="deselect-all-btn" class="btn btn-secondary btn-sm">Deselect All</button>
+            </div>
+
+            <div id="repo-list" class="repo-list" aria-label="Repository list"></div>
+            <p id="empty-state" class="empty-text" style="display:none;">
+              No indexed repos found. Skillsmith has not yet indexed any repositories under your
+              GitHub account or your GitHub organizations. Skills are indexed daily.
+            </p>
+
+            <div class="save-row">
+              <button id="save-btn" class="btn btn-primary" disabled aria-disabled="true"
+                >Save Preferences</button
+              >
+              <svg
+                id="save-spinner"
+                class="spinner spinner-sm"
+                viewBox="0 0 24 24"
+                style="display:none;"
+                aria-hidden="true"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                  fill="none"
+                  opacity="0.25"></circle>
+                <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
+                ></path>
+              </svg>
+            </div>
+            <p id="save-result" style="display:none;font-size:.875rem;"></p>
           </div>
-          <p id="save-result" style="display:none;font-size:.875rem;"></p>
         </div>
-      </div>
-    </main>
+      </main>
+    </div>
 
     <Footer compact />
   </body>

--- a/packages/website/src/pages/account/profile.astro
+++ b/packages/website/src/pages/account/profile.astro
@@ -14,7 +14,9 @@ export const prerender = false
 
 import { ClientRouter } from 'astro:transitions'
 import { getSupabaseConfig } from '../../lib/supabase-config'
+import AccountSidebar from '../../components/AccountSidebar.astro'
 import Footer from '../../components/Footer.astro'
+import Nav from '../../components/Nav.astro'
 import '../../styles/account-profile.css'
 
 const supabaseConfig = getSupabaseConfig()
@@ -40,185 +42,192 @@ const supabaseConfig = getSupabaseConfig()
     <ClientRouter />
   </head>
   <body>
-    <main class="container">
-      <div id="loading-state" class="center-state">
-        <svg class="spinner" viewBox="0 0 24 24">
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            stroke-width="4"
-            fill="none"
-            opacity="0.25"></circle>
-          <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
-          ></path>
-        </svg>
-        <p>Loading...</p>
-      </div>
+    <Nav activePath="/account" />
 
-      <div id="error-state" class="center-state" style="display:none;">
-        <p id="error-message" class="error-text">Something went wrong</p>
-        <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
-      </div>
-
-      <div id="page-content" style="display:none;">
-        <div class="page-header">
-          <a href="/account" class="back-link">&larr; Account</a>
-          <h1>Email Address</h1>
-          <p class="subtitle">Change the email address associated with your Skillsmith account.</p>
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
+      <main class="container">
+        <div id="loading-state" class="center-state">
+          <svg class="spinner" viewBox="0 0 24 24">
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+              fill="none"
+              opacity="0.25"></circle>
+            <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
+            ></path>
+          </svg>
+          <p>Loading...</p>
         </div>
 
-        <div class="card">
-          <p class="field-label">Current email</p>
-          <p id="current-email" class="current-email">&nbsp;</p>
+        <div id="error-state" class="center-state" style="display:none;">
+          <p id="error-message" class="error-text">Something went wrong</p>
+          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
         </div>
 
-        <!-- Pending change banner (a change is awaiting inbox confirmation) -->
-        <div
-          id="pending-banner"
-          class="card notice"
-          role="status"
-          aria-live="polite"
-          style="display:none;"
-        >
-          <strong>Email change pending.</strong>
-          <span id="pending-text"></span>
-          Your account email won't change until both inboxes are confirmed.
-        </div>
+        <div id="page-content" style="display:none;">
+          <div class="page-header">
+            <a href="/account" class="back-link">&larr; Account</a>
+            <h1>Email Address</h1>
+            <p class="subtitle">
+              Change the email address associated with your Skillsmith account.
+            </p>
+          </div>
 
-        <!-- Password-account form -->
-        <form id="password-form" class="card" style="display:none;" novalidate>
-          <div class="form-field">
-            <label for="new-email">New email address</label>
-            <input
-              id="new-email"
-              name="new-email"
-              type="email"
-              autocomplete="email"
-              aria-describedby="email-error"
-              required
-            />
+          <div class="card">
+            <p class="field-label">Current email</p>
+            <p id="current-email" class="current-email">&nbsp;</p>
           </div>
-          <div class="form-field">
-            <label for="confirm-email">Confirm new email address</label>
-            <input
-              id="confirm-email"
-              name="confirm-email"
-              type="email"
-              autocomplete="email"
-              aria-describedby="email-error"
-              required
-            />
-            <p id="email-error" class="field-error" role="alert" style="display:none;"></p>
+
+          <!-- Pending change banner (a change is awaiting inbox confirmation) -->
+          <div
+            id="pending-banner"
+            class="card notice"
+            role="status"
+            aria-live="polite"
+            style="display:none;"
+          >
+            <strong>Email change pending.</strong>
+            <span id="pending-text"></span>
+            Your account email won't change until both inboxes are confirmed.
           </div>
-          <div class="form-field">
-            <label for="current-password">Current password</label>
-            <input
-              id="current-password"
-              name="current-password"
-              type="password"
-              autocomplete="current-password"
-              aria-describedby="password-error"
-              required
-            />
-            <p id="password-error" class="field-error" role="alert" style="display:none;"></p>
+
+          <!-- Password-account form -->
+          <form id="password-form" class="card" style="display:none;" novalidate>
+            <div class="form-field">
+              <label for="new-email">New email address</label>
+              <input
+                id="new-email"
+                name="new-email"
+                type="email"
+                autocomplete="email"
+                aria-describedby="email-error"
+                required
+              />
+            </div>
+            <div class="form-field">
+              <label for="confirm-email">Confirm new email address</label>
+              <input
+                id="confirm-email"
+                name="confirm-email"
+                type="email"
+                autocomplete="email"
+                aria-describedby="email-error"
+                required
+              />
+              <p id="email-error" class="field-error" role="alert" style="display:none;"></p>
+            </div>
+            <div class="form-field">
+              <label for="current-password">Current password</label>
+              <input
+                id="current-password"
+                name="current-password"
+                type="password"
+                autocomplete="current-password"
+                aria-describedby="password-error"
+                required
+              />
+              <p id="password-error" class="field-error" role="alert" style="display:none;"></p>
+            </div>
+            <div class="save-row">
+              <button id="submit-btn" type="submit" class="btn btn-primary"
+                >Send confirmation links</button
+              >
+              <svg
+                id="submit-spinner"
+                class="spinner spinner-sm"
+                viewBox="0 0 24 24"
+                style="display:none;"
+                aria-hidden="true"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                  fill="none"
+                  opacity="0.25"></circle>
+                <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
+                ></path>
+              </svg>
+            </div>
+            <p class="hint">
+              We'll email a confirmation link to <strong>both</strong> your current and new address. Your
+              email changes only after you confirm both.
+            </p>
+          </form>
+
+          <!-- Sent confirmation (after a successful request) -->
+          <div
+            id="sent-state"
+            class="card success-card"
+            role="status"
+            aria-live="polite"
+            style="display:none;"
+          >
+            <h2>Check both inboxes</h2>
+            <p id="sent-text"></p>
+            <p class="hint">
+              Didn't get an email? Check the address you entered and try again — for security, you
+              can request another change in up to an hour.
+            </p>
           </div>
-          <div class="save-row">
-            <button id="submit-btn" type="submit" class="btn btn-primary"
-              >Send confirmation links</button
-            >
-            <svg
-              id="submit-spinner"
-              class="spinner spinner-sm"
-              viewBox="0 0 24 24"
-              style="display:none;"
-              aria-hidden="true"
-            >
-              <circle
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                stroke-width="4"
-                fill="none"
-                opacity="0.25"></circle>
-              <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
-              ></path>
-            </svg>
+
+          <!-- OAuth-account guidance -->
+          <div id="oauth-guidance" class="card" style="display:none;">
+            <h2 id="oauth-heading">Your email comes from your sign-in provider</h2>
+            <p id="oauth-body"></p>
+            <ol class="steps">
+              <li id="oauth-step1"></li>
+              <li id="oauth-step2"></li>
+              <li id="oauth-step3"></li>
+            </ol>
+            <div class="save-row">
+              <button id="oauth-sync-btn" type="button" class="btn btn-primary"
+                >Update my email</button
+              >
+              <svg
+                id="oauth-sync-spinner"
+                class="spinner spinner-sm"
+                viewBox="0 0 24 24"
+                style="display:none;"
+                aria-hidden="true"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                  fill="none"
+                  opacity="0.25"></circle>
+                <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
+                ></path>
+              </svg>
+            </div>
+            <p id="oauth-sync-hint" class="hint"></p>
+            <p id="oauth-sync-result" role="status" aria-live="polite" style="display:none;"></p>
+            <p class="hint">
+              Can't access your old provider email?
+              <a href="mailto:support@smithhorn.ca?subject=Change%20account%20email"
+                >Contact support</a
+              >
+              to verify your identity.
+            </p>
           </div>
-          <p class="hint">
-            We'll email a confirmation link to <strong>both</strong> your current and new address. Your
-            email changes only after you confirm both.
+
+          <!-- Applies to both paths -->
+          <p class="hint footnote">
+            Note: pending team invitations sent to your old address won't transfer automatically —
+            ask the team owner to re-invite your new address.
           </p>
-        </form>
-
-        <!-- Sent confirmation (after a successful request) -->
-        <div
-          id="sent-state"
-          class="card success-card"
-          role="status"
-          aria-live="polite"
-          style="display:none;"
-        >
-          <h2>Check both inboxes</h2>
-          <p id="sent-text"></p>
-          <p class="hint">
-            Didn't get an email? Check the address you entered and try again — for security, you can
-            request another change in up to an hour.
-          </p>
         </div>
-
-        <!-- OAuth-account guidance -->
-        <div id="oauth-guidance" class="card" style="display:none;">
-          <h2 id="oauth-heading">Your email comes from your sign-in provider</h2>
-          <p id="oauth-body"></p>
-          <ol class="steps">
-            <li id="oauth-step1"></li>
-            <li id="oauth-step2"></li>
-            <li id="oauth-step3"></li>
-          </ol>
-          <div class="save-row">
-            <button id="oauth-sync-btn" type="button" class="btn btn-primary"
-              >Update my email</button
-            >
-            <svg
-              id="oauth-sync-spinner"
-              class="spinner spinner-sm"
-              viewBox="0 0 24 24"
-              style="display:none;"
-              aria-hidden="true"
-            >
-              <circle
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                stroke-width="4"
-                fill="none"
-                opacity="0.25"></circle>
-              <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
-              ></path>
-            </svg>
-          </div>
-          <p id="oauth-sync-hint" class="hint"></p>
-          <p id="oauth-sync-result" role="status" aria-live="polite" style="display:none;"></p>
-          <p class="hint">
-            Can't access your old provider email?
-            <a href="mailto:support@smithhorn.ca?subject=Change%20account%20email"
-              >Contact support</a
-            >
-            to verify your identity.
-          </p>
-        </div>
-
-        <!-- Applies to both paths -->
-        <p class="hint footnote">
-          Note: pending team invitations sent to your old address won't transfer automatically — ask
-          the team owner to re-invite your new address.
-        </p>
-      </div>
-    </main>
+      </main>
+    </div>
 
     <Footer compact />
   </body>

--- a/packages/website/src/pages/account/skills.astro
+++ b/packages/website/src/pages/account/skills.astro
@@ -17,6 +17,7 @@ export const prerender = false
 import { ClientRouter } from 'astro:transitions'
 import { getSupabaseConfig } from '../../lib/supabase-config'
 import Footer from '../../components/Footer.astro'
+import AccountSidebar from '../../components/AccountSidebar.astro'
 import Nav from '../../components/Nav.astro'
 
 const supabaseConfig = getSupabaseConfig()
@@ -47,98 +48,102 @@ const supabaseConfig = getSupabaseConfig()
   <body>
     <Nav activePath="/account" />
 
-    <main class="page-container">
-      <div id="loading-state" class="state-block">
-        <svg class="spinner" viewBox="0 0 24 24" aria-hidden="true">
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            stroke-width="4"
-            fill="none"
-            opacity="0.25"></circle>
-          <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
-          ></path>
-        </svg>
-        <p>Loading inventory...</p>
-      </div>
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <div id="error-state" class="state-block" style="display: none;">
-        <p id="error-message" class="error-text">Something went wrong.</p>
-        <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
-      </div>
-
-      <div id="page-content" style="display: none;">
-        <div class="page-header">
-          <a href="/account" class="back-link">&larr; Account</a>
-          <h1>Skill Inventory</h1>
-          <p class="page-description">
-            A read-only view of the skills installed across your machines. Push from each machine
-            with <code>skillsmith inventory push</code>.
-          </p>
+      <main class="page-container">
+        <div id="loading-state" class="state-block">
+          <svg class="spinner" viewBox="0 0 24 24" aria-hidden="true">
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+              fill="none"
+              opacity="0.25"></circle>
+            <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
+            ></path>
+          </svg>
+          <p>Loading inventory...</p>
         </div>
 
-        <!-- State: consent-off -->
-        <div id="state-consent-off" class="card" style="display: none;">
-          <h2>Cross-machine inventory is off.</h2>
-          <p class="state-body">
-            Enable inventory sync on the
-            <a href="/account/telemetry" class="inline-link">Telemetry Preferences</a> page to see your
-            skills across machines. When enabled, Skillsmith uploads a one-way hash of your hostname,
-            your OS platform, and per-skill metadata (name, version, content hash) — never file contents
-            or paths.
-          </p>
-          <p class="state-body">
-            <a href="/docs/inventory" class="inline-link"
-              >Learn more about cross-machine inventory</a
-            >
-          </p>
+        <div id="error-state" class="state-block" style="display: none;">
+          <p id="error-message" class="error-text">Something went wrong.</p>
+          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
         </div>
 
-        <!-- State: opted-in-no-devices -->
-        <div id="state-opted-in-no-devices" class="card" style="display: none;">
-          <h2>Inventory sync is on.</h2>
-          <p class="state-body">Run this on each machine to push your installed skills:</p>
-          <div class="command-block">
-            <code class="command-code">skillsmith inventory push</code>
-            <button
-              id="copy-command-btn"
-              type="button"
-              class="btn btn-secondary btn-sm"
-              aria-label="Copy command to clipboard">Copy</button
-            >
+        <div id="page-content" style="display: none;">
+          <div class="page-header">
+            <a href="/account" class="back-link">&larr; Account</a>
+            <h1>Skill Inventory</h1>
+            <p class="page-description">
+              A read-only view of the skills installed across your machines. Push from each machine
+              with <code>skillsmith inventory push</code>.
+            </p>
           </div>
-          <p id="copy-status" role="status" aria-live="polite" class="copy-status"></p>
-          <p class="state-body">
-            <a href="/docs/inventory" class="inline-link"
-              >Learn more about cross-machine inventory</a
-            >
-          </p>
-        </div>
 
-        <!-- State: single-machine hint (shown above devices) -->
-        <div id="single-machine-hint" class="inline-hint" style="display: none;">
-          Push from another machine to compare your skills across machines.
-          <a href="/docs/inventory" class="inline-link">Learn more</a>
-        </div>
+          <!-- State: consent-off -->
+          <div id="state-consent-off" class="card" style="display: none;">
+            <h2>Cross-machine inventory is off.</h2>
+            <p class="state-body">
+              Enable inventory sync on the
+              <a href="/account/telemetry" class="inline-link">Telemetry Preferences</a> page to see your
+              skills across machines. When enabled, Skillsmith uploads a one-way hash of your hostname,
+              your OS platform, and per-skill metadata (name, version, content hash) — never file contents
+              or paths.
+            </p>
+            <p class="state-body">
+              <a href="/docs/inventory" class="inline-link"
+                >Learn more about cross-machine inventory</a
+              >
+            </p>
+          </div>
 
-        <!-- Populated device list — built client-side by skills-page-render.ts -->
-        <h2 id="devices-heading" class="devices-heading" style="display: none;">Your machines</h2>
-        <div id="devices-container"></div>
+          <!-- State: opted-in-no-devices -->
+          <div id="state-opted-in-no-devices" class="card" style="display: none;">
+            <h2>Inventory sync is on.</h2>
+            <p class="state-body">Run this on each machine to push your installed skills:</p>
+            <div class="command-block">
+              <code class="command-code">skillsmith inventory push</code>
+              <button
+                id="copy-command-btn"
+                type="button"
+                class="btn btn-secondary btn-sm"
+                aria-label="Copy command to clipboard">Copy</button
+              >
+            </div>
+            <p id="copy-status" role="status" aria-live="polite" class="copy-status"></p>
+            <p class="state-body">
+              <a href="/docs/inventory" class="inline-link"
+                >Learn more about cross-machine inventory</a
+              >
+            </p>
+          </div>
 
-        <!-- Always visible inside content: reload affordance -->
-        <div class="reload-row">
-          <button type="button" data-action="reload" class="btn btn-secondary">
-            Reload this view
-          </button>
-          <p class="reload-description">
-            This reloads what your machines last reported — there is no way to push changes back to
-            a machine from here.
-          </p>
+          <!-- State: single-machine hint (shown above devices) -->
+          <div id="single-machine-hint" class="inline-hint" style="display: none;">
+            Push from another machine to compare your skills across machines.
+            <a href="/docs/inventory" class="inline-link">Learn more</a>
+          </div>
+
+          <!-- Populated device list — built client-side by skills-page-render.ts -->
+          <h2 id="devices-heading" class="devices-heading" style="display: none;">Your machines</h2>
+          <div id="devices-container"></div>
+
+          <!-- Always visible inside content: reload affordance -->
+          <div class="reload-row">
+            <button type="button" data-action="reload" class="btn btn-secondary">
+              Reload this view
+            </button>
+            <p class="reload-description">
+              This reloads what your machines last reported — there is no way to push changes back
+              to a machine from here.
+            </p>
+          </div>
         </div>
-      </div>
-    </main>
+      </main>
+    </div>
 
     <Footer compact />
   </body>

--- a/packages/website/src/pages/account/subscription.astro
+++ b/packages/website/src/pages/account/subscription.astro
@@ -19,6 +19,7 @@ import { ClientRouter } from 'astro:transitions'
 import { getSupabaseConfig } from '../../lib/supabase-config'
 import { pricingTiers } from '../../lib/pricing-data'
 import Footer from '../../components/Footer.astro'
+import AccountSidebar from '../../components/AccountSidebar.astro'
 import Nav from '../../components/Nav.astro'
 
 // Read env vars at SSR time to inject into client script
@@ -62,200 +63,204 @@ const tierLookup = Object.fromEntries(
   <body>
     <Nav activePath="/account/subscription" />
 
-    <main class="subscription-container">
-      <!-- Team tier-gate notice (SMI-4321) — shown when the user was redirected
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
+
+      <main class="subscription-container">
+        <!-- Team tier-gate notice (SMI-4321) — shown when the user was redirected
            here from /account/team/** because their tier or subscription no longer
            qualifies for Team access. Populated client-side from ?gated=<reason>. -->
-      <div
-        id="team-gated-notice"
-        class="gated-notice"
-        style="display: none;"
-        role="status"
-        aria-live="polite"
-      >
-        <p id="team-gated-notice-text"></p>
-      </div>
-
-      <!-- Loading State -->
-      <div id="loading-state" class="loading-state">
-        <div class="spinner-container">
-          <svg class="spinner" viewBox="0 0 24 24">
-            <circle
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              stroke-width="4"
-              fill="none"
-              opacity="0.25"></circle>
-            <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
-            ></path>
-          </svg>
+        <div
+          id="team-gated-notice"
+          class="gated-notice"
+          style="display: none;"
+          role="status"
+          aria-live="polite"
+        >
+          <p id="team-gated-notice-text"></p>
         </div>
-        <p>Loading subscription details...</p>
-      </div>
 
-      <!-- Error State -->
-      <div id="error-state" class="error-state" style="display: none;">
-        <div class="error-content">
-          <svg class="error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1.5"
-              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-            ></path>
-          </svg>
-          <h3>Failed to load subscription data</h3>
-          <p id="error-message">Something went wrong</p>
-          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
+        <!-- Loading State -->
+        <div id="loading-state" class="loading-state">
+          <div class="spinner-container">
+            <svg class="spinner" viewBox="0 0 24 24">
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+                fill="none"
+                opacity="0.25"></circle>
+              <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
+              ></path>
+            </svg>
+          </div>
+          <p>Loading subscription details...</p>
         </div>
-      </div>
 
-      <!-- Content -->
-      <div id="subscription-content" style="display: none;">
-        <h1>Manage Subscription</h1>
-
-        <!-- Current Plan Section -->
-        <section class="section">
-          <h2>Current Plan</h2>
-          <div class="current-plan-card">
-            <div class="plan-info">
-              <span class="tier-badge" id="current-tier-badge">Community</span>
-              <div class="plan-details">
-                <div class="plan-name" id="plan-name">Community Plan</div>
-                <div class="plan-price" id="plan-price">Free</div>
-              </div>
-            </div>
-            <div class="plan-meta" id="plan-meta">
-              <p>1,000 API calls per month</p>
-            </div>
+        <!-- Error State -->
+        <div id="error-state" class="error-state" style="display: none;">
+          <div class="error-content">
+            <svg class="error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              ></path>
+            </svg>
+            <h3>Failed to load subscription data</h3>
+            <p id="error-message">Something went wrong</p>
+            <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
           </div>
+        </div>
 
-          <!-- Subscription Details (for paid tiers) -->
-          <div id="subscription-details" style="display: none;">
-            <div class="detail-row">
-              <span>Billing Period</span>
-              <span id="billing-period">Monthly</span>
-            </div>
-            <div class="detail-row">
-              <span>Next Billing Date</span>
-              <span id="next-billing">-</span>
-            </div>
-            <div class="detail-row" id="seat-count-row" style="display: none;">
-              <span>Team Seats</span>
-              <span id="seat-count">1</span>
-            </div>
-            <div class="detail-row">
-              <span>Status</span>
-              <span id="subscription-status" class="status-badge">Active</span>
-            </div>
-          </div>
-        </section>
+        <!-- Content -->
+        <div id="subscription-content" style="display: none;">
+          <h1>Manage Subscription</h1>
 
-        <!-- Seat Management Section (for team/enterprise) -->
-        <section class="section" id="seat-management-section" style="display: none;">
-          <h2>Team Seats</h2>
-          <div class="seat-management">
-            <div class="seat-info">
-              <p>Current seats: <strong id="current-seats">1</strong></p>
-              <p class="text-muted">Each additional seat is billed at your plan rate.</p>
-            </div>
-            <div class="seat-controls">
-              <button class="btn btn-secondary" id="decrease-seats">-</button>
-              <input type="number" id="new-seat-count" min="1" max="1000" value="1" />
-              <button class="btn btn-secondary" id="increase-seats">+</button>
-            </div>
-            <button class="btn btn-primary" id="update-seats-btn" disabled>Update Seats</button>
-            <p
-              id="seat-unavailable-note"
-              class="text-muted"
-              role="note"
-              aria-live="polite"
-              style="display: none;"
-            >
-            </p>
-          </div>
-        </section>
-
-        <!-- Upgrade/Downgrade Section -->
-        <section class="section">
-          <h2>Change Plan</h2>
-          <div class="plans-grid">
-            <div class="plan-option" data-tier="individual">
-              <div class="plan-header">
-                <span class="plan-tier">Individual</span>
-                <div class="plan-pricing">
-                  <span class="price">$9.99</span>
-                  <span class="period">/month</span>
+          <!-- Current Plan Section -->
+          <section class="section">
+            <h2>Current Plan</h2>
+            <div class="current-plan-card">
+              <div class="plan-info">
+                <span class="tier-badge" id="current-tier-badge">Community</span>
+                <div class="plan-details">
+                  <div class="plan-name" id="plan-name">Community Plan</div>
+                  <div class="plan-price" id="plan-price">Free</div>
                 </div>
               </div>
-              <ul class="plan-features">
-                <li>10,000 API calls/month</li>
-                <li>3 license keys</li>
-                <li>Email support</li>
-              </ul>
-              <button class="btn btn-primary btn-full select-plan-btn" data-tier="individual">
-                Select Individual
-              </button>
-            </div>
-
-            <div class="plan-option featured" data-tier="team">
-              <div class="featured-badge">Most Popular</div>
-              <div class="plan-header">
-                <span class="plan-tier">Team</span>
-                <div class="plan-pricing">
-                  <span class="price">$25</span>
-                  <span class="period">/user/month</span>
-                </div>
+              <div class="plan-meta" id="plan-meta">
+                <p>1,000 API calls per month</p>
               </div>
-              <ul class="plan-features">
-                <li>100,000 API calls/month</li>
-                <li>10 license keys</li>
-                <li>Priority support</li>
-              </ul>
-              <button class="btn btn-primary btn-full select-plan-btn" data-tier="team">
-                Select Team
-              </button>
             </div>
 
-            <div class="plan-option" data-tier="enterprise">
-              <div class="plan-header">
-                <span class="plan-tier">Enterprise</span>
-                <div class="plan-pricing">
-                  <span class="price">$55</span>
-                  <span class="period">/user/month</span>
-                </div>
+            <!-- Subscription Details (for paid tiers) -->
+            <div id="subscription-details" style="display: none;">
+              <div class="detail-row">
+                <span>Billing Period</span>
+                <span id="billing-period">Monthly</span>
               </div>
-              <ul class="plan-features">
-                <li>Unlimited API calls</li>
-                <li>50 license keys</li>
-                <li>99.9% SLA guarantee</li>
-                <li>Dedicated support</li>
-              </ul>
-              <button class="btn btn-primary btn-full select-plan-btn" data-tier="enterprise">
-                Select Enterprise
-              </button>
+              <div class="detail-row">
+                <span>Next Billing Date</span>
+                <span id="next-billing">-</span>
+              </div>
+              <div class="detail-row" id="seat-count-row" style="display: none;">
+                <span>Team Seats</span>
+                <span id="seat-count">1</span>
+              </div>
+              <div class="detail-row">
+                <span>Status</span>
+                <span id="subscription-status" class="status-badge">Active</span>
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
 
-        <!-- Cancel Section -->
-        <section class="section" id="cancel-section" style="display: none;">
-          <h2>Cancel Subscription</h2>
-          <div class="cancel-info">
-            <p>
-              If you cancel, your subscription will remain active until the end of your current
-              billing period.
-            </p>
-            <p class="text-muted">
-              After cancellation, you'll be downgraded to the free Community plan.
-            </p>
-            <button class="btn btn-danger" id="cancel-btn">Cancel Subscription</button>
-          </div>
-        </section>
-      </div>
-    </main>
+          <!-- Seat Management Section (for team/enterprise) -->
+          <section class="section" id="seat-management-section" style="display: none;">
+            <h2>Team Seats</h2>
+            <div class="seat-management">
+              <div class="seat-info">
+                <p>Current seats: <strong id="current-seats">1</strong></p>
+                <p class="text-muted">Each additional seat is billed at your plan rate.</p>
+              </div>
+              <div class="seat-controls">
+                <button class="btn btn-secondary" id="decrease-seats">-</button>
+                <input type="number" id="new-seat-count" min="1" max="1000" value="1" />
+                <button class="btn btn-secondary" id="increase-seats">+</button>
+              </div>
+              <button class="btn btn-primary" id="update-seats-btn" disabled>Update Seats</button>
+              <p
+                id="seat-unavailable-note"
+                class="text-muted"
+                role="note"
+                aria-live="polite"
+                style="display: none;"
+              >
+              </p>
+            </div>
+          </section>
+
+          <!-- Upgrade/Downgrade Section -->
+          <section class="section">
+            <h2>Change Plan</h2>
+            <div class="plans-grid">
+              <div class="plan-option" data-tier="individual">
+                <div class="plan-header">
+                  <span class="plan-tier">Individual</span>
+                  <div class="plan-pricing">
+                    <span class="price">$9.99</span>
+                    <span class="period">/month</span>
+                  </div>
+                </div>
+                <ul class="plan-features">
+                  <li>10,000 API calls/month</li>
+                  <li>3 license keys</li>
+                  <li>Email support</li>
+                </ul>
+                <button class="btn btn-primary btn-full select-plan-btn" data-tier="individual">
+                  Select Individual
+                </button>
+              </div>
+
+              <div class="plan-option featured" data-tier="team">
+                <div class="featured-badge">Most Popular</div>
+                <div class="plan-header">
+                  <span class="plan-tier">Team</span>
+                  <div class="plan-pricing">
+                    <span class="price">$25</span>
+                    <span class="period">/user/month</span>
+                  </div>
+                </div>
+                <ul class="plan-features">
+                  <li>100,000 API calls/month</li>
+                  <li>10 license keys</li>
+                  <li>Priority support</li>
+                </ul>
+                <button class="btn btn-primary btn-full select-plan-btn" data-tier="team">
+                  Select Team
+                </button>
+              </div>
+
+              <div class="plan-option" data-tier="enterprise">
+                <div class="plan-header">
+                  <span class="plan-tier">Enterprise</span>
+                  <div class="plan-pricing">
+                    <span class="price">$55</span>
+                    <span class="period">/user/month</span>
+                  </div>
+                </div>
+                <ul class="plan-features">
+                  <li>Unlimited API calls</li>
+                  <li>50 license keys</li>
+                  <li>99.9% SLA guarantee</li>
+                  <li>Dedicated support</li>
+                </ul>
+                <button class="btn btn-primary btn-full select-plan-btn" data-tier="enterprise">
+                  Select Enterprise
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <!-- Cancel Section -->
+          <section class="section" id="cancel-section" style="display: none;">
+            <h2>Cancel Subscription</h2>
+            <div class="cancel-info">
+              <p>
+                If you cancel, your subscription will remain active until the end of your current
+                billing period.
+              </p>
+              <p class="text-muted">
+                After cancellation, you'll be downgraded to the free Community plan.
+              </p>
+              <button class="btn btn-danger" id="cancel-btn">Cancel Subscription</button>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
 
     <Footer compact />
   </body>

--- a/packages/website/src/pages/account/team/analytics.astro
+++ b/packages/website/src/pages/account/team/analytics.astro
@@ -14,6 +14,7 @@ export const prerender = false
 
 import { ClientRouter } from 'astro:transitions'
 import Footer from '../../../components/Footer.astro'
+import AccountSidebar from '../../../components/AccountSidebar.astro'
 import Nav from '../../../components/Nav.astro'
 import TeamNav from '../../../components/TeamNav.astro'
 import { getSupabaseConfig } from '../../../lib/supabase-config'
@@ -43,37 +44,41 @@ const supabaseConfig = getSupabaseConfig()
   <body>
     <Nav activePath="/account/team" />
 
-    <main class="analytics-container">
-      <h1>Team Analytics</h1>
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <TeamNav activePath="/account/team/analytics" />
+      <main class="analytics-container">
+        <h1>Team Analytics</h1>
 
-      <div id="loading-state" class="loading-state">
-        <p>Loading analytics...</p>
-      </div>
+        <TeamNav activePath="/account/team/analytics" />
 
-      <div
-        id="error-state"
-        class="error-state"
-        style="display: none;"
-        role="alert"
-        aria-live="polite"
-      >
-        <h3>Failed to load analytics</h3>
-        <p id="error-message">Something went wrong.</p>
-        <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
-      </div>
+        <div id="loading-state" class="loading-state">
+          <p>Loading analytics...</p>
+        </div>
 
-      <div id="content" style="display: none;">
-        <section class="section">
-          <h2>Coming soon</h2>
-          <p class="muted">
-            Team analytics dashboards ship in a follow-on release. Your team passes the access check
-            — this page is the stub the tier-gate protects.
-          </p>
-        </section>
-      </div>
-    </main>
+        <div
+          id="error-state"
+          class="error-state"
+          style="display: none;"
+          role="alert"
+          aria-live="polite"
+        >
+          <h3>Failed to load analytics</h3>
+          <p id="error-message">Something went wrong.</p>
+          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
+        </div>
+
+        <div id="content" style="display: none;">
+          <section class="section">
+            <h2>Coming soon</h2>
+            <p class="muted">
+              Team analytics dashboards ship in a follow-on release. Your team passes the access
+              check — this page is the stub the tier-gate protects.
+            </p>
+          </section>
+        </div>
+      </main>
+    </div>
 
     <Footer compact />
   </body>

--- a/packages/website/src/pages/account/team/index.astro
+++ b/packages/website/src/pages/account/team/index.astro
@@ -14,6 +14,7 @@ export const prerender = false
 
 import { ClientRouter } from 'astro:transitions'
 import Footer from '../../../components/Footer.astro'
+import AccountSidebar from '../../../components/AccountSidebar.astro'
 import Nav from '../../../components/Nav.astro'
 import TeamNav from '../../../components/TeamNav.astro'
 import { getSupabaseConfig } from '../../../lib/supabase-config'
@@ -43,83 +44,87 @@ const supabaseConfig = getSupabaseConfig()
   <body>
     <Nav activePath="/account/team" />
 
-    <main class="dashboard-container">
-      <h1>Team Dashboard</h1>
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <TeamNav activePath="/account/team" />
+      <main class="dashboard-container">
+        <h1>Team Dashboard</h1>
 
-      <!-- Loading skeleton -->
-      <div id="loading-state" class="loading-state">
-        <p>Loading team data...</p>
-      </div>
+        <TeamNav activePath="/account/team" />
 
-      <!-- Error alert -->
-      <div
-        id="error-state"
-        class="error-state"
-        style="display: none;"
-        role="alert"
-        aria-live="polite"
-      >
-        <h3>Failed to load team</h3>
-        <p id="error-message">Something went wrong.</p>
-        <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
-      </div>
+        <!-- Loading skeleton -->
+        <div id="loading-state" class="loading-state">
+          <p>Loading team data...</p>
+        </div>
 
-      <!-- Content -->
-      <div id="team-content" style="display: none;">
-        <section class="section">
-          <h2>Team Overview</h2>
-          <div class="stats-grid">
-            <div class="stat-card">
-              <div class="stat-value" id="team-name">—</div>
-              <div class="stat-label">Team Name</div>
-            </div>
-            <div class="stat-card">
-              <div class="stat-value" id="member-count">—</div>
-              <div class="stat-label">Members</div>
-            </div>
-            <div class="stat-card">
-              <div class="stat-value" id="workspace-count">—</div>
-              <div class="stat-label">Workspaces</div>
-            </div>
-            <div class="stat-card">
-              <div class="stat-value" id="skill-count">—</div>
-              <div class="stat-label">Shared Skills</div>
-            </div>
-          </div>
-        </section>
+        <!-- Error alert -->
+        <div
+          id="error-state"
+          class="error-state"
+          style="display: none;"
+          role="alert"
+          aria-live="polite"
+        >
+          <h3>Failed to load team</h3>
+          <p id="error-message">Something went wrong.</p>
+          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
+        </div>
 
-        <section class="section">
-          <h2>Usage Summary (Last 30 Days)</h2>
-          <div class="usage-grid" id="usage-grid">
-            <div class="usage-row">
-              <span class="usage-label">Total Events</span>
-              <span class="usage-value" id="total-events">—</span>
+        <!-- Content -->
+        <div id="team-content" style="display: none;">
+          <section class="section">
+            <h2>Team Overview</h2>
+            <div class="stats-grid">
+              <div class="stat-card">
+                <div class="stat-value" id="team-name">—</div>
+                <div class="stat-label">Team Name</div>
+              </div>
+              <div class="stat-card">
+                <div class="stat-value" id="member-count">—</div>
+                <div class="stat-label">Members</div>
+              </div>
+              <div class="stat-card">
+                <div class="stat-value" id="workspace-count">—</div>
+                <div class="stat-label">Workspaces</div>
+              </div>
+              <div class="stat-card">
+                <div class="stat-value" id="skill-count">—</div>
+                <div class="stat-label">Shared Skills</div>
+              </div>
             </div>
-            <div class="usage-row">
-              <span class="usage-label">API Calls</span>
-              <span class="usage-value" id="api-calls">—</span>
-            </div>
-            <div class="usage-row">
-              <span class="usage-label">Skills Installed</span>
-              <span class="usage-value" id="skills-installed">—</span>
-            </div>
-            <div class="usage-row">
-              <span class="usage-label">Security Audits</span>
-              <span class="usage-value" id="audits-run">—</span>
-            </div>
-          </div>
-        </section>
+          </section>
 
-        <section class="section">
-          <h2>Recent Activity</h2>
-          <div class="activity-list" id="activity-list">
-            <p class="empty-text">No recent activity.</p>
-          </div>
-        </section>
-      </div>
-    </main>
+          <section class="section">
+            <h2>Usage Summary (Last 30 Days)</h2>
+            <div class="usage-grid" id="usage-grid">
+              <div class="usage-row">
+                <span class="usage-label">Total Events</span>
+                <span class="usage-value" id="total-events">—</span>
+              </div>
+              <div class="usage-row">
+                <span class="usage-label">API Calls</span>
+                <span class="usage-value" id="api-calls">—</span>
+              </div>
+              <div class="usage-row">
+                <span class="usage-label">Skills Installed</span>
+                <span class="usage-value" id="skills-installed">—</span>
+              </div>
+              <div class="usage-row">
+                <span class="usage-label">Security Audits</span>
+                <span class="usage-value" id="audits-run">—</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="section">
+            <h2>Recent Activity</h2>
+            <div class="activity-list" id="activity-list">
+              <p class="empty-text">No recent activity.</p>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
 
     <Footer compact />
   </body>

--- a/packages/website/src/pages/account/team/members.astro
+++ b/packages/website/src/pages/account/team/members.astro
@@ -11,6 +11,7 @@ export const prerender = false
 
 import { ClientRouter } from 'astro:transitions'
 import Footer from '../../../components/Footer.astro'
+import AccountSidebar from '../../../components/AccountSidebar.astro'
 import Nav from '../../../components/Nav.astro'
 import TeamInviteModal from '../../../components/TeamInviteModal.astro'
 import TeamNav from '../../../components/TeamNav.astro'
@@ -41,54 +42,58 @@ const supabaseConfig = getSupabaseConfig()
   <body>
     <Nav activePath="/account/team" />
 
-    <main class="members-container">
-      <h1>Team Members</h1>
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <TeamNav activePath="/account/team/members" />
+      <main class="members-container">
+        <h1>Team Members</h1>
 
-      <!-- Loading skeleton -->
-      <div id="loading-state" class="loading-state">
-        <p>Loading members...</p>
-      </div>
+        <TeamNav activePath="/account/team/members" />
 
-      <!-- Error alert -->
-      <div
-        id="error-state"
-        class="error-state"
-        style="display: none;"
-        role="alert"
-        aria-live="polite"
-      >
-        <h3>Failed to load members</h3>
-        <p id="error-message">Something went wrong.</p>
-        <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
-      </div>
+        <!-- Loading skeleton -->
+        <div id="loading-state" class="loading-state">
+          <p>Loading members...</p>
+        </div>
 
-      <div id="content" style="display: none;">
-        <section class="section">
-          <div class="section-header">
-            <h2 id="members-heading">Members</h2>
-            <button
-              class="btn btn-primary"
-              id="invite-btn"
-              type="button"
-              data-action="open-invite-modal"
-              aria-haspopup="dialog"
-              aria-controls="team-invite-modal"
-            >
-              Invite Member
-            </button>
-          </div>
+        <!-- Error alert -->
+        <div
+          id="error-state"
+          class="error-state"
+          style="display: none;"
+          role="alert"
+          aria-live="polite"
+        >
+          <h3>Failed to load members</h3>
+          <p id="error-message">Something went wrong.</p>
+          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
+        </div>
 
-          <div class="member-list" id="member-list"></div>
-        </section>
+        <div id="content" style="display: none;">
+          <section class="section">
+            <div class="section-header">
+              <h2 id="members-heading">Members</h2>
+              <button
+                class="btn btn-primary"
+                id="invite-btn"
+                type="button"
+                data-action="open-invite-modal"
+                aria-haspopup="dialog"
+                aria-controls="team-invite-modal"
+              >
+                Invite Member
+              </button>
+            </div>
 
-        <section class="section">
-          <h2>Pending Invites</h2>
-          <div id="pending-list" class="pending-list" aria-live="polite"></div>
-        </section>
-      </div>
-    </main>
+            <div class="member-list" id="member-list"></div>
+          </section>
+
+          <section class="section">
+            <h2>Pending Invites</h2>
+            <div id="pending-list" class="pending-list" aria-live="polite"></div>
+          </section>
+        </div>
+      </main>
+    </div>
 
     <TeamInviteModal />
 

--- a/packages/website/src/pages/account/team/workspaces.astro
+++ b/packages/website/src/pages/account/team/workspaces.astro
@@ -10,6 +10,7 @@ export const prerender = false
 
 import { ClientRouter } from 'astro:transitions'
 import Footer from '../../../components/Footer.astro'
+import AccountSidebar from '../../../components/AccountSidebar.astro'
 import Nav from '../../../components/Nav.astro'
 import TeamNav from '../../../components/TeamNav.astro'
 import { getSupabaseConfig } from '../../../lib/supabase-config'
@@ -39,89 +40,97 @@ const supabaseConfig = getSupabaseConfig()
   <body>
     <Nav activePath="/account/team" />
 
-    <main class="workspaces-container">
-      <h1>Team Workspaces</h1>
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <TeamNav activePath="/account/team/workspaces" />
+      <main class="workspaces-container">
+        <h1>Team Workspaces</h1>
 
-      <!-- Loading skeleton -->
-      <div id="loading-state" class="loading-state">
-        <p>Loading workspaces...</p>
-      </div>
+        <TeamNav activePath="/account/team/workspaces" />
 
-      <!-- Error alert -->
-      <div
-        id="error-state"
-        class="error-state"
-        style="display: none;"
-        role="alert"
-        aria-live="polite"
-      >
-        <h3>Failed to load workspaces</h3>
-        <p id="error-message">Something went wrong.</p>
-        <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
-      </div>
+        <!-- Loading skeleton -->
+        <div id="loading-state" class="loading-state">
+          <p>Loading workspaces...</p>
+        </div>
 
-      <div id="content" style="display: none;">
-        <section class="section">
-          <div class="section-header">
-            <h2 id="ws-heading">Workspaces</h2>
-            <button class="btn btn-primary" id="create-workspace-btn" aria-label="Create workspace">
-              Create Workspace
-            </button>
-          </div>
+        <!-- Error alert -->
+        <div
+          id="error-state"
+          class="error-state"
+          style="display: none;"
+          role="alert"
+          aria-live="polite"
+        >
+          <h3>Failed to load workspaces</h3>
+          <p id="error-message">Something went wrong.</p>
+          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
+        </div>
 
-          <div class="workspace-grid" id="ws-grid"></div>
+        <div id="content" style="display: none;">
+          <section class="section">
+            <div class="section-header">
+              <h2 id="ws-heading">Workspaces</h2>
+              <button
+                class="btn btn-primary"
+                id="create-workspace-btn"
+                aria-label="Create workspace"
+              >
+                Create Workspace
+              </button>
+            </div>
 
-          <div class="empty-state" id="empty-state" style="display: none;">
-            <h3>No workspaces yet</h3>
-            <p>Create a workspace to start sharing skills with your team.</p>
-          </div>
-        </section>
-      </div>
+            <div class="workspace-grid" id="ws-grid"></div>
 
-      <!-- Create dialog -->
-      <div
-        id="create-modal"
-        class="modal"
-        style="display: none;"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="create-modal-title"
-      >
-        <div class="modal-content">
-          <div class="modal-header">
-            <h3 id="create-modal-title">New Workspace</h3>
-            <button class="modal-close" id="close-modal" aria-label="Close">&times;</button>
-          </div>
-          <div class="modal-body">
-            <label class="field">
-              <span class="field-label">Name</span>
-              <input
-                type="text"
-                id="ws-name"
-                placeholder="Backend Tools"
-                maxlength="100"
-                required
-              />
-            </label>
-            <label class="field">
-              <span class="field-label">Description (optional)</span>
-              <textarea
-                id="ws-description"
-                placeholder="Shared skills for the backend team"
-                maxlength="500"
-                rows="3"></textarea>
-            </label>
-            <p id="create-error" class="error-inline" style="display: none;"></p>
-          </div>
-          <div class="modal-footer">
-            <button id="cancel-create" class="btn btn-secondary">Cancel</button>
-            <button id="submit-create" class="btn btn-primary">Create</button>
+            <div class="empty-state" id="empty-state" style="display: none;">
+              <h3>No workspaces yet</h3>
+              <p>Create a workspace to start sharing skills with your team.</p>
+            </div>
+          </section>
+        </div>
+
+        <!-- Create dialog -->
+        <div
+          id="create-modal"
+          class="modal"
+          style="display: none;"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="create-modal-title"
+        >
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 id="create-modal-title">New Workspace</h3>
+              <button class="modal-close" id="close-modal" aria-label="Close">&times;</button>
+            </div>
+            <div class="modal-body">
+              <label class="field">
+                <span class="field-label">Name</span>
+                <input
+                  type="text"
+                  id="ws-name"
+                  placeholder="Backend Tools"
+                  maxlength="100"
+                  required
+                />
+              </label>
+              <label class="field">
+                <span class="field-label">Description (optional)</span>
+                <textarea
+                  id="ws-description"
+                  placeholder="Shared skills for the backend team"
+                  maxlength="500"
+                  rows="3"></textarea>
+              </label>
+              <p id="create-error" class="error-inline" style="display: none;"></p>
+            </div>
+            <div class="modal-footer">
+              <button id="cancel-create" class="btn btn-secondary">Cancel</button>
+              <button id="submit-create" class="btn btn-primary">Create</button>
+            </div>
           </div>
         </div>
-      </div>
-    </main>
+      </main>
+    </div>
 
     <Footer compact />
   </body>

--- a/packages/website/src/pages/account/telemetry.astro
+++ b/packages/website/src/pages/account/telemetry.astro
@@ -17,6 +17,7 @@ export const prerender = false
 import { ClientRouter } from 'astro:transitions'
 import { getSupabaseConfig } from '../../lib/supabase-config'
 import Footer from '../../components/Footer.astro'
+import AccountSidebar from '../../components/AccountSidebar.astro'
 import Nav from '../../components/Nav.astro'
 
 const supabaseConfig = getSupabaseConfig()
@@ -47,146 +48,152 @@ const supabaseConfig = getSupabaseConfig()
   <body>
     <Nav activePath="/account" />
 
-    <main class="page-container">
-      <div id="loading-state" class="state-block">
-        <svg class="spinner" viewBox="0 0 24 24" aria-hidden="true">
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            stroke-width="4"
-            fill="none"
-            opacity="0.25"></circle>
-          <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
-          ></path>
-        </svg>
-        <p>Loading...</p>
-      </div>
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <div id="error-state" class="state-block" style="display: none;">
-        <p id="error-message" class="error-text">Something went wrong.</p>
-        <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
-      </div>
-
-      <div id="page-content" style="display: none;">
-        <div class="page-header">
-          <a href="/account" class="back-link">&larr; Account</a>
-          <h1>Telemetry Preferences</h1>
-          <p class="page-description">
-            Skillsmith can collect anonymous data about which skills you invoke (skill name,
-            duration, success/failure). This helps us improve recommendations and surface broken or
-            stale skills. Telemetry is <strong>off by default</strong>.
-          </p>
+      <main class="page-container">
+        <div id="loading-state" class="state-block">
+          <svg class="spinner" viewBox="0 0 24 24" aria-hidden="true">
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+              fill="none"
+              opacity="0.25"></circle>
+            <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="4" fill="none"
+            ></path>
+          </svg>
+          <p>Loading...</p>
         </div>
 
-        <section class="card">
-          <div class="toggle-row">
-            <div class="toggle-text">
-              <h2>Skill-invocation telemetry</h2>
-              <p id="state-summary" class="state-summary">Off</p>
-            </div>
-            <label class="switch" for="telemetry-toggle">
-              <input id="telemetry-toggle" type="checkbox" aria-describedby="state-summary" />
-              <span class="switch-slider" aria-hidden="true"></span>
-            </label>
+        <div id="error-state" class="state-block" style="display: none;">
+          <p id="error-message" class="error-text">Something went wrong.</p>
+          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
+        </div>
+
+        <div id="page-content" style="display: none;">
+          <div class="page-header">
+            <a href="/account" class="back-link">&larr; Account</a>
+            <h1>Telemetry Preferences</h1>
+            <p class="page-description">
+              Skillsmith can collect anonymous data about which skills you invoke (skill name,
+              duration, success/failure). This helps us improve recommendations and surface broken
+              or stale skills. Telemetry is <strong>off by default</strong>.
+            </p>
           </div>
 
-          <dl class="meta-grid">
-            <div>
-              <dt>Anonymous ID</dt>
-              <dd id="anon-id-display">Not set</dd>
+          <section class="card">
+            <div class="toggle-row">
+              <div class="toggle-text">
+                <h2>Skill-invocation telemetry</h2>
+                <p id="state-summary" class="state-summary">Off</p>
+              </div>
+              <label class="switch" for="telemetry-toggle">
+                <input id="telemetry-toggle" type="checkbox" aria-describedby="state-summary" />
+                <span class="switch-slider" aria-hidden="true"></span>
+              </label>
             </div>
-            <div>
-              <dt>ID rotated</dt>
-              <dd id="anon-id-rotated">Never</dd>
+
+            <dl class="meta-grid">
+              <div>
+                <dt>Anonymous ID</dt>
+                <dd id="anon-id-display">Not set</dd>
+              </div>
+              <div>
+                <dt>ID rotated</dt>
+                <dd id="anon-id-rotated">Never</dd>
+              </div>
+              <div>
+                <dt>Last updated</dt>
+                <dd id="updated-at-display">Never</dd>
+              </div>
+            </dl>
+
+            <div class="actions-row">
+              <button id="save-btn" class="btn btn-primary" disabled aria-disabled="true">
+                Save
+              </button>
+              <button id="rotate-btn" class="btn btn-secondary" type="button">
+                Rotate anonymous ID
+              </button>
             </div>
-            <div>
-              <dt>Last updated</dt>
-              <dd id="updated-at-display">Never</dd>
+            <p id="save-result" class="save-result" role="status" aria-live="polite"></p>
+          </section>
+
+          <section class="card info-card">
+            <h2>What we collect when telemetry is on</h2>
+            <ul>
+              <li>Skill name (e.g. <code>linear</code>, <code>cloudinary</code>)</li>
+              <li>Invocation source (CLI / MCP tool / VS Code)</li>
+              <li>Duration and success/failure outcome</li>
+              <li>Framework string (e.g. <code>claude-code</code>, <code>cursor</code>)</li>
+            </ul>
+            <h2>What we never collect</h2>
+            <ul>
+              <li>Arguments you pass to a skill</li>
+              <li>File paths, file contents, or environment variables</li>
+              <li>
+                Anything linking the anonymous ID to your real identity outside this dashboard
+              </li>
+            </ul>
+          </section>
+
+          <section class="card">
+            <div class="toggle-row">
+              <div class="toggle-text">
+                <h2>Cross-machine skill inventory</h2>
+                <p id="inventory-state-summary" class="state-summary">Off</p>
+              </div>
+              <label class="switch" for="inventory-toggle">
+                <input
+                  id="inventory-toggle"
+                  type="checkbox"
+                  aria-describedby="inventory-state-summary"
+                />
+                <span class="switch-slider" aria-hidden="true"></span>
+              </label>
             </div>
-          </dl>
-
-          <div class="actions-row">
-            <button id="save-btn" class="btn btn-primary" disabled aria-disabled="true">
-              Save
-            </button>
-            <button id="rotate-btn" class="btn btn-secondary" type="button">
-              Rotate anonymous ID
-            </button>
-          </div>
-          <p id="save-result" class="save-result" role="status" aria-live="polite"></p>
-        </section>
-
-        <section class="card info-card">
-          <h2>What we collect when telemetry is on</h2>
-          <ul>
-            <li>Skill name (e.g. <code>linear</code>, <code>cloudinary</code>)</li>
-            <li>Invocation source (CLI / MCP tool / VS Code)</li>
-            <li>Duration and success/failure outcome</li>
-            <li>Framework string (e.g. <code>claude-code</code>, <code>cursor</code>)</li>
-          </ul>
-          <h2>What we never collect</h2>
-          <ul>
-            <li>Arguments you pass to a skill</li>
-            <li>File paths, file contents, or environment variables</li>
-            <li>Anything linking the anonymous ID to your real identity outside this dashboard</li>
-          </ul>
-        </section>
-
-        <section class="card">
-          <div class="toggle-row">
-            <div class="toggle-text">
-              <h2>Cross-machine skill inventory</h2>
-              <p id="inventory-state-summary" class="state-summary">Off</p>
+            <p class="toggle-description">
+              Push your installed-skill inventory to Skillsmith so you can see it across machines at
+              <a href="/account/skills" class="inline-link">www.skillsmith.app/account/skills</a>.
+              Inventory sync is <strong>off by default</strong>.
+            </p>
+            <div class="actions-row">
+              <button id="inventory-save-btn" class="btn btn-primary" disabled aria-disabled="true">
+                Save
+              </button>
             </div>
-            <label class="switch" for="inventory-toggle">
-              <input
-                id="inventory-toggle"
-                type="checkbox"
-                aria-describedby="inventory-state-summary"
-              />
-              <span class="switch-slider" aria-hidden="true"></span>
-            </label>
-          </div>
-          <p class="toggle-description">
-            Push your installed-skill inventory to Skillsmith so you can see it across machines at
-            <a href="/account/skills" class="inline-link">www.skillsmith.app/account/skills</a>.
-            Inventory sync is <strong>off by default</strong>.
-          </p>
-          <div class="actions-row">
-            <button id="inventory-save-btn" class="btn btn-primary" disabled aria-disabled="true">
-              Save
-            </button>
-          </div>
-          <p id="inventory-save-result" class="save-result" role="status" aria-live="polite"></p>
-        </section>
+            <p id="inventory-save-result" class="save-result" role="status" aria-live="polite"></p>
+          </section>
 
-        <section class="card info-card">
-          <h2>What's shared when cross-machine inventory is on</h2>
-          <ul>
-            <li>A random device ID (generated locally; never linked to your name)</li>
-            <li>An optional device label you set (e.g. <code>work-laptop</code>)</li>
-            <li>OS platform and architecture (e.g. <code>darwin/arm64</code>)</li>
-            <li>CLI version</li>
-            <li>A one-way hash of your hostname — the raw hostname is never uploaded</li>
-            <li>
-              Per installed skill: harness, skill ID, version, content hash, source, pinned version,
-              and update policy
-            </li>
-          </ul>
-          <h2>What we never upload</h2>
-          <ul>
-            <li>Your raw hostname or any identifying system information</li>
-            <li>File contents, file paths, or skill source code</li>
-          </ul>
-          <p class="info-note">
-            Turning inventory sync off stops future uploads immediately (enforced server-side). A
-            future control on this page will let you purge your stored inventory.
-          </p>
-        </section>
-      </div>
-    </main>
+          <section class="card info-card">
+            <h2>What's shared when cross-machine inventory is on</h2>
+            <ul>
+              <li>A random device ID (generated locally; never linked to your name)</li>
+              <li>An optional device label you set (e.g. <code>work-laptop</code>)</li>
+              <li>OS platform and architecture (e.g. <code>darwin/arm64</code>)</li>
+              <li>CLI version</li>
+              <li>A one-way hash of your hostname — the raw hostname is never uploaded</li>
+              <li>
+                Per installed skill: harness, skill ID, version, content hash, source, pinned
+                version, and update policy
+              </li>
+            </ul>
+            <h2>What we never upload</h2>
+            <ul>
+              <li>Your raw hostname or any identifying system information</li>
+              <li>File contents, file paths, or skill source code</li>
+            </ul>
+            <p class="info-note">
+              Turning inventory sync off stops future uploads immediately (enforced server-side). A
+              future control on this page will let you purge your stored inventory.
+            </p>
+          </section>
+        </div>
+      </main>
+    </div>
 
     <Footer compact />
 

--- a/packages/website/tests/e2e/account-page-load-guards.spec.ts
+++ b/packages/website/tests/e2e/account-page-load-guards.spec.ts
@@ -25,17 +25,36 @@ import { refireAstroPageLoad } from './astro-helpers'
 // The bug surfaces as a null property access, phrased differently per engine.
 const NULL_DEREF = /Cannot read properties of null|null is not an object|reading 'style'/
 
-// Quick-link siblings reachable via a real `<a>` on the /account dashboard, so
-// ClientRouter (not a full reload) performs the transition that re-fires
-// `astro:page-load` on the previously-visited page's leaked listener.
+// Sibling pages reachable via a real `<a>` in the account sidebar (SMI-5475 —
+// replaced the Quick Links grid), so ClientRouter (not a full reload) performs
+// the transition that re-fires `astro:page-load` on the previously-visited
+// page's leaked listener.
 const SIBLINGS = [
   { href: '/account/team', url: '/account/team' },
   { href: '/account/billing', url: '/account/billing' },
+  { href: '/account/subscription', url: '/account/subscription' },
+  { href: '/account/profile', url: '/account/profile' },
   { href: '/account/cli-token/', url: '/account/cli-token' },
   { href: '/account/outreach-preferences', url: '/account/outreach-preferences' },
   { href: '/account/telemetry', url: '/account/telemetry' },
   { href: '/account/skills', url: '/account/skills' },
 ]
+
+/**
+ * Click a sidebar link through ClientRouter. Below 1024px the sidebar is
+ * CSS-hidden (matches /docs — SMI-5475 product decision), so on the mobile
+ * project we dispatch a programmatic click: it still bubbles to ClientRouter's
+ * document-level listener and drives a real SPA navigation, preserving the
+ * leaked-listener regression net at both viewports.
+ */
+async function clickAccountNav(page: Page, href: string): Promise<void> {
+  const link = page.locator(`.account-sidebar a[href="${href}"]`)
+  if (await link.isVisible()) {
+    await link.click()
+  } else {
+    await link.evaluate((el) => (el as HTMLElement).click())
+  }
+}
 
 function collectNullDerefs(page: Page): string[] {
   const hits: string[] = []
@@ -68,7 +87,7 @@ test.describe('account pages — astro:page-load path guards (SMI-5158)', () => 
       // Forward: ClientRouter SPA-nav. The /account (index) listener — and every
       // sibling listener registered on a prior iteration — re-fires here on the
       // foreign DOM. Pre-fix the index handler throws the null-deref.
-      await page.click(`.quick-links a[href="${sibling.href}"]`)
+      await clickAccountNav(page, sibling.href)
       await expect(page).toHaveURL(new RegExp(`${sibling.url}/?$`))
 
       // Back to /account via history (ClientRouter intercepts popstate): the
@@ -84,9 +103,9 @@ test.describe('account pages — astro:page-load path guards (SMI-5158)', () => 
     expect(hits, hits.join('\n')).toEqual([])
   })
 
-  test('the new Team quick-link navigates to /account/team', async ({ page }) => {
+  test('the Team sidebar link navigates to /account/team', async ({ page }) => {
     await page.goto('/account')
-    await page.click('.quick-links a[href="/account/team"]')
+    await clickAccountNav(page, '/account/team')
     await expect(page).toHaveURL(/\/account\/team\/?$/)
   })
 })

--- a/packages/website/tests/e2e/account-sidebar.spec.ts
+++ b/packages/website/tests/e2e/account-sidebar.spec.ts
@@ -80,6 +80,20 @@ test.describe('account sidebar (SMI-5475)', () => {
     }
   })
 
+  test('formerly Nav-less pages now render top Nav + sidebar', async ({ page }) => {
+    // profile and outreach-preferences shipped without <Nav> until SMI-5475.
+    for (const { path, href } of [
+      { path: '/account/profile', href: '/account/profile' },
+      { path: '/account/outreach-preferences', href: '/account/outreach-preferences' },
+    ]) {
+      await page.goto(path)
+      await expect(page.locator('nav.nav-container')).toHaveCount(1)
+      const active = page.locator('.account-sidebar a[aria-current="page"]')
+      await expect(active).toHaveCount(1)
+      await expect(active).toHaveAttribute('href', href)
+    }
+  })
+
   test('visibility follows the docs breakpoint (hidden below 1024px)', async ({ page }) => {
     await page.goto('/account')
 

--- a/packages/website/tests/e2e/account-sidebar.spec.ts
+++ b/packages/website/tests/e2e/account-sidebar.spec.ts
@@ -71,6 +71,15 @@ test.describe('account sidebar (SMI-5475)', () => {
     await expect(active).toHaveAttribute('href', '/account/skills')
   })
 
+  test('keeps Team active across the TeamNav sub-tabs (prefix match)', async ({ page }) => {
+    for (const path of ['/account/team', '/account/team/members', '/account/team/analytics']) {
+      await page.goto(path)
+      const active = page.locator('.account-sidebar a[aria-current="page"]')
+      await expect(active).toHaveCount(1)
+      await expect(active).toHaveAttribute('href', '/account/team')
+    }
+  })
+
   test('visibility follows the docs breakpoint (hidden below 1024px)', async ({ page }) => {
     await page.goto('/account')
 

--- a/packages/website/tests/e2e/account-sidebar.spec.ts
+++ b/packages/website/tests/e2e/account-sidebar.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * account-sidebar.spec.ts
+ *
+ * SMI-5475 — the account area's Quick Links grid was replaced by a persistent
+ * docs-style left sidebar (AccountSidebar.astro). These tests assert:
+ *   - the sidebar renders with exactly one active item per page (aria-current),
+ *   - the Quick Links grid is gone,
+ *   - visibility follows the docs breakpoint (hidden < 1024px — product
+ *     decision: mobile matches /docs, no fallback nav).
+ *
+ * Active-state assertions use attached-DOM checks (toHaveCount / attribute),
+ * so they hold on the mobile project too, where the sidebar is CSS-hidden.
+ * Auth + Supabase are mocked via complete-profile.helpers.ts (no network).
+ */
+
+import { test, expect } from '@playwright/test'
+import { buildSessionToken, injectSupabaseStub, mockSupabase } from './complete-profile.helpers'
+
+test.describe('account sidebar (SMI-5475)', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
+    await mockSupabase(page, {})
+  })
+
+  test('replaces Quick Links on /account and marks Dashboard active', async ({ page }) => {
+    await page.goto('/account')
+
+    await expect(page.locator('.quick-links')).toHaveCount(0)
+
+    const active = page.locator('.account-sidebar a[aria-current="page"]')
+    await expect(active).toHaveCount(1)
+    await expect(active).toHaveAttribute('href', '/account')
+  })
+
+  test('renders every account destination the Quick Links grid used to offer', async ({ page }) => {
+    await page.goto('/account')
+
+    for (const href of [
+      '/account',
+      '/account/profile',
+      '/account/cli-token/',
+      '/account/skills',
+      '/account/subscription',
+      '/account/billing',
+      '/account/team',
+      '/account/outreach-preferences',
+      '/account/telemetry',
+      '/docs/quickstart',
+      '/docs/api',
+    ]) {
+      await expect(page.locator(`.account-sidebar nav a[href="${href}"]`)).toHaveCount(1)
+    }
+    await expect(page.locator('.account-sidebar nav a')).toHaveCount(11)
+  })
+
+  test('visibility follows the docs breakpoint (hidden below 1024px)', async ({ page }) => {
+    await page.goto('/account')
+
+    const sidebar = page.locator('.account-sidebar')
+    const width = page.viewportSize()?.width ?? 0
+    if (width > 1024) {
+      await expect(sidebar).toBeVisible()
+    } else {
+      await expect(sidebar).toBeHidden()
+    }
+  })
+})

--- a/packages/website/tests/e2e/account-sidebar.spec.ts
+++ b/packages/website/tests/e2e/account-sidebar.spec.ts
@@ -53,6 +53,24 @@ test.describe('account sidebar (SMI-5475)', () => {
     await expect(page.locator('.account-sidebar nav a')).toHaveCount(11)
   })
 
+  test('marks exactly one matching item active on subpages', async ({ page }) => {
+    await page.goto('/account/billing')
+    let active = page.locator('.account-sidebar a[aria-current="page"]')
+    await expect(active).toHaveCount(1)
+    await expect(active).toHaveAttribute('href', '/account/billing')
+
+    // Trailing-slash normalization: the nav href is /account/cli-token/.
+    await page.goto('/account/cli-token/')
+    active = page.locator('.account-sidebar a[aria-current="page"]')
+    await expect(active).toHaveCount(1)
+    await expect(active).toHaveAttribute('href', '/account/cli-token/')
+
+    await page.goto('/account/skills')
+    active = page.locator('.account-sidebar a[aria-current="page"]')
+    await expect(active).toHaveCount(1)
+    await expect(active).toHaveAttribute('href', '/account/skills')
+  })
+
   test('visibility follows the docs breakpoint (hidden below 1024px)', async ({ page }) => {
     await page.goto('/account')
 


### PR DESCRIPTION
## Summary

Replaces the `/account` dashboard's Quick Links grid with a persistent docs-style left sidebar across all 11 account render pages (SMI-5475). Navigation previously existed only on the dashboard; subpages had no way to move around the account area except browser back — and two pages (`profile`, `outreach-preferences`) shipped with no top nav at all.

- New `src/lib/account-nav.ts`: nav sections + `isActiveAccountNav` (exact match after trailing-slash normalization; `/account/team` prefix rule keeps Team lit across TeamNav sub-tabs). 9 unit tests.
- New `src/components/AccountSidebar.astro`: visual parity with `DocsSidebar.astro` in plain scoped CSS (account pages do not load global.css/Tailwind; precedent `TeamNav.astro`). Zero client JS, no `transition:persist` — the SMI-4896/5158 handler-leak class cannot occur. Includes a namespaced `is:global` block for the `.account-shell` flex wrapper each page uses.
- All account pages wrap `<main>` in `.account-shell` with the sidebar; TeamNav stays as secondary tabs on team pages; `profile` + `outreach-preferences` also gain `<Nav>`.
- Mobile (<1024px): sidebar hidden, matching `/docs` exactly (product decision confirmed with Ryan; accepted UX tradeoff).
- Quick Links section + CSS deleted; the two docs links live on as a Resources sidebar section; `/account/skills` (landed on main mid-flight) is included.

## Bug fixed en route

Extending the guards spec's navigation set exposed a latent SMI-5158-class race on WebKit: `index.astro`'s `astro:page-load` handler can enter with `pathname === /account` while the swapped-in DOM still belongs to the previous page (popstate transitions), so the path guard passes against a foreign DOM and `getElementById('dashboard-content')` returns null -> `null is not an object (evaluating 'dashboardContent.style')`. Pre-existing on main. Fixed with an element-presence bail; the guards spec failed pre-fix and is 3x consecutive green post-fix on both projects.

## Tests

- `account-nav.test.ts`: 9 unit tests (dashboard exact match, team prefix, trailing-slash normalization, single-active invariant, href uniqueness).
- `account-page-load-guards.spec.ts`: migrated from `.quick-links` to sidebar selectors; JS-click fallback preserves the mobile leak-regression net (sidebar is CSS-hidden there); siblings extended with `/account/subscription` + `/account/profile`.
- New `account-sidebar.spec.ts`: active-state per page, Quick Links gone, link inventory (11), breakpoint visibility, Nav+sidebar regression for the formerly Nav-less pages.
- Full run: 443/443 website unit tests, 16/16 e2e (desktop + mobile, 3x consecutive), `astro check` 0 errors, `astro build` clean, eslint + prettier clean. Screenshot-verified at 1440px and 375px against `/docs`.

Note: the two account e2e specs are local-only (no CI workflow runs them today).

Code review report: `docs/internal/code_review/2026-07-01-smi-5475-account-sidebar.md` (1 High fixed in-branch, 0 open).

Linear: SMI-5475

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
