### PR TITLE
feat(ci): run account-area Playwright specs on both projects (SMI-5481)

### DIFF
--- a/.github/workflows/website-account-e2e.yml
+++ b/.github/workflows/website-account-e2e.yml
@@ -1,0 +1,195 @@
+# SMI-5481 -- runs the account-area Playwright specs on every PR that touches
+# the account pages, the sidebar/nav surface, or the specs themselves.
+#
+# Why this exists: account-page-load-guards.spec.ts is the ONLY regression net
+# for the SMI-5158/4896 astro:page-load handler-leak class and the SMI-5475
+# WebKit popstate race; account-sidebar.spec.ts covers account-wide navigation
+# (SMI-5475). Both were local-only before this workflow.
+#
+# Browser matrix: the playwright invocation omits --project, so BOTH projects
+# in packages/website/playwright.config.ts run -- desktop (Chromium) and
+# mobile (iPhone 13 = WebKit). The SMI-5475 popstate race reproduces ONLY
+# under WebKit, so the runner installs webkit alongside chromium.
+#
+# Server: account pages are `export const prerender = false` (SSR via the
+# Vercel adapter) -- a static file server cannot serve them, so this uses the
+# vercel dev boot pattern from website-skills-e2e.yml (SMI-4493/4496/4508
+# lessons baked in). PLAYWRIGHT_BASE_URL pins browsers to 127.0.0.1 because
+# the account specs navigate via relative URLs (unlike skills-filter, which
+# builds absolute URLs from SKILLSMITH_WEBSITE_URL).
+#
+# Mocking: the specs self-mock Supabase client-side at https://stub.supabase.co
+# (complete-profile.helpers.ts); no staging/prod network. SSR render-time
+# PUBLIC_SUPABASE_* env comes from `vercel pull --environment=preview`.
+#
+# Docker carve-out: runs on ubuntu-latest outside the dev container --
+# Playwright needs host browsers; no native modules load on this path.
+# Precedent: website-skills-e2e.yml, device-login-roundtrip.yml, ADR-113.
+#
+# Phase 1 shadow: job-level continue-on-error keeps this non-blocking during
+# burn-in. Promote after 10 consecutive green runs: remove continue-on-error
+# and add website-account-e2e to branch-protection required checks.
+
+name: Website Account E2E
+
+on:
+  pull_request:
+    paths:
+      - 'packages/website/src/pages/account/**'
+      - 'packages/website/src/components/AccountSidebar.astro'
+      - 'packages/website/src/components/Nav.astro'
+      - 'packages/website/src/lib/account-nav.ts'
+      - 'packages/website/src/lib/supabase-config.ts'
+      - 'packages/website/src/lib/supabase-client.ts'
+      - 'packages/website/src/styles/account-profile.css'
+      - 'packages/website/src/styles/outreach-preferences.css'
+      - 'packages/website/tests/e2e/account-page-load-guards.spec.ts'
+      - 'packages/website/tests/e2e/account-sidebar.spec.ts'
+      - 'packages/website/tests/e2e/complete-profile.helpers.ts'
+      - 'packages/website/tests/e2e/astro-helpers.ts'
+      - 'packages/website/playwright.config.ts'
+      - '.github/workflows/website-account-e2e.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: website-account-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Website Account E2E
+    runs-on: ubuntu-latest
+    # 8 tests x 2 projects, workers=1 (sequential), ~30 SSR navigations per
+    # project under vercel dev. Sized against website-skills-e2e.yml's 15 min
+    # for 2 tests / 1 project; worst case (cold cache + webkit --with-deps)
+    # sums to ~16-17 min, so 25 leaves real headroom -- a timeout kill during
+    # shadow would reset the 10-green promotion streak for free.
+    timeout-minutes: 25
+    # Allow same-repo PRs and manual workflow_dispatch runs.
+    # For workflow_dispatch, github.event.pull_request is null so the
+    # head.repo.full_name check evaluates to empty-string != github.repository
+    # and the job would skip. The event_name guard permits workflow_dispatch
+    # explicitly while the PR guard blocks fork PRs (VERCEL_TOKEN unavailable).
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    continue-on-error: true # audit:allow-continue-on-error -- Phase 1 shadow; remove after 10 consecutive green runs
+    env:
+      NODE_VERSION: '22'
+      # Account specs goto() relative paths against baseURL. vercel dev binds
+      # 127.0.0.1 only; `localhost` can resolve to ::1 on the runner and hang
+      # the browser (SMI-4493/4496). Read by playwright.config.ts (SMI-5481).
+      PLAYWRIGHT_BASE_URL: 'http://127.0.0.1:4321'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Cache Vercel build cache
+        # Key is byte-identical to website-skills-e2e.yml so the two workflows
+        # share cache entries instead of doubling the cache footprint.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.vercel/cache
+          key: vercel-cache-${{ runner.os }}-${{ hashFiles('packages/website/**/*.ts', 'packages/website/**/*.tsx', 'packages/website/**/*.astro', 'packages/website/**/*.mjs', 'packages/website/**/*.json', 'packages/website/vercel.json') }}
+          restore-keys: |
+            vercel-cache-${{ runner.os }}-
+
+      - name: Install dependencies (no scripts -- host has no native module compiler chain)
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright Chromium + WebKit
+        # webkit is mandatory: the mobile project is iPhone 13 = WebKit and
+        # the SMI-5475 popstate race only reproduces there.
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: Install Vercel CLI (pinned to root devDep)
+        run: |
+          set -eu
+          PINNED=$(node -p "require('./package.json').devDependencies.vercel")
+          echo "Installing vercel@$PINNED (pinned from root package.json)"
+          npm i -g "vercel@$PINNED"
+          vercel --version
+
+      - name: Vercel pull + build website
+        working-directory: packages/website
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -eu
+          vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
+          vercel build --token "$VERCEL_TOKEN"
+
+      - name: Start vercel dev (Astro SSR account pages)
+        working-directory: packages/website
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -eu
+          mkdir -p "$GITHUB_WORKSPACE/test-results"
+          # PATH augmentation: vercel auto-detects Astro and spawns `astro dev`
+          # in a sub-shell that does not inherit npm .bin lookup -- prepend both
+          # workspace and root .bin so `astro` resolves (SMI-4493/4508).
+          export PATH="$GITHUB_WORKSPACE/packages/website/node_modules/.bin:$GITHUB_WORKSPACE/node_modules/.bin:$PATH"
+          nohup vercel dev --token "$VERCEL_TOKEN" --listen 127.0.0.1:4321 \
+            > "$GITHUB_WORKSPACE/test-results/preview.log" 2>&1 &
+          echo $! > "$GITHUB_WORKSPACE/test-results/preview.pid"
+
+      - name: Wait for preview server
+        # IPv4 to match `vercel dev --listen 127.0.0.1` (SMI-4493/4496: browsers
+        # hang on IPv6 ::1 when the server only listens on IPv4).
+        # 90s timeout -- vercel dev cold-start is ~20-30 s.
+        run: npx --yes wait-on http://127.0.0.1:4321/ -t 90000
+
+      - name: Warm SSR account routes
+        # vercel dev compiles each SSR route on first hit (multi-second). The
+        # guards spec drives ~17 navigations inside a single test; pre-compiling
+        # keeps it inside the per-test timeout and de-flakes the WebKit pass
+        # (compilation is server-side, shared across both browser projects).
+        run: |
+          set -eu
+          for p in /account /account/profile /account/cli-token/ /account/skills \
+                   /account/subscription /account/billing /account/team \
+                   /account/team/members /account/team/analytics \
+                   /account/outreach-preferences /account/telemetry; do
+            curl -sL -o /dev/null -m 60 "http://127.0.0.1:4321$p" || true
+          done
+
+      - name: Run account e2e specs (both projects -- desktop Chromium + mobile WebKit)
+        # No --project and no -g: all projects, all tests in the two files.
+        # No --reporter override: the config's [list, html(open:never)] applies,
+        # so the console gets list output AND playwright-report/ is populated
+        # for the failure-artifact upload.
+        # --timeout=90000: the guards test performs ~17 SSR navigations in one
+        # test body; the 30s default is too tight on a 2-core runner. Retries
+        # stay 0 (config default) during shadow -- a retry pass would mask the
+        # exact races these specs exist to catch.
+        run: npx playwright test --config=packages/website/playwright.config.ts --timeout=90000 packages/website/tests/e2e/account-page-load-guards.spec.ts packages/website/tests/e2e/account-sidebar.spec.ts
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: website-account-e2e-${{ github.run_id }}
+          path: |
+            packages/website/playwright-report/
+            packages/website/test-results/
+            test-results/preview.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: SIGTERM preview server
+        if: always()
+        run: |
+          if [ -f test-results/preview.pid ]; then
+            PID="$(cat test-results/preview.pid)"
+            if kill -0 "$PID" 2>/dev/null; then kill -TERM "$PID" || true; fi
+          fi

--- a/packages/website/playwright.config.ts
+++ b/packages/website/playwright.config.ts
@@ -31,7 +31,11 @@ export default defineConfig({
 
   /* Shared settings for all projects */
   use: {
-    baseURL: 'http://localhost:4321',
+    /* SMI-5481: CI boots `vercel dev --listen 127.0.0.1:4321`; on GH runners
+     * `localhost` can resolve to ::1 and browsers hang against an IPv4-only
+     * server (SMI-4493/4496). CI sets PLAYWRIGHT_BASE_URL; local default is
+     * unchanged (`||` so an empty string also falls back). */
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:4321',
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
   },


### PR DESCRIPTION
## Summary

Adds `.github/workflows/website-account-e2e.yml`: path-gated CI for `account-page-load-guards.spec.ts` + `account-sidebar.spec.ts`. The guards spec is the only regression net for the SMI-5158/4896 `astro:page-load` handler-leak class and the SMI-5475 WebKit popstate race — which only reproduces under WebKit, so the job runs BOTH Playwright projects (desktop Chromium + mobile iPhone 13/WebKit) and installs webkit on the runner.

- `vercel dev` boot pattern from `website-skills-e2e.yml` (account pages are `prerender = false` SSR — a static server cannot serve them), incl. SMI-4493/4496/4508 lessons
- Phase 1 shadow: job-level `continue-on-error` with the audit marker; promote to required after 10 consecutive green runs counted from the Playwright STEP outcome in run logs (the PR check shows green even on job failure)
- `playwright.config.ts`: `baseURL` now env-overridable via `PLAYWRIGHT_BASE_URL` (`||` fallback — local default unchanged). The account specs are the first CI consumer of relative `goto()` against `baseURL`, and `vercel dev` binds 127.0.0.1 only
- Supabase/auth fully self-mocked by the specs (`stub.supabase.co`) — no staging/prod network

## Plan & review (ADR-109)

SPARC plan: `docs/internal/implementation/smi-5481-account-e2e-ci.md` (docs repo branch `docs/smi-5481-plan`, fb40ed8; pointer bump follows post-merge). Plan-review verdict: APPROVED-WITH-CHANGES, all 7 findings applied. Governance review of the commit: clean, byte-identical to the ratified plan. Follow-up filed: SMI-5483 (extract the 4x-duplicated vercel-dev boot block).

## Verification

- Local: 16/16 tests (8 x desktop, 8 x mobile/WebKit) against a localhost-bound dev server (default path) + override smoke against a 127.0.0.1-bound server (CI path)
- `audit:standards` 0 failures; actionlint + prettier + ASCII-only clean
- This PR self-triggers the new workflow (its path filter includes the workflow file) — that run is the real-run acceptance evidence (AC-1/AC-2: expect 16 tests across both projects in the run log)

`[skip-impl-check]` — infra-only PR (workflow YAML + one config line), no `packages/*/src` changes; the implementation surface IS the CI wiring, verified by the self-triggered run above.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)