### PR TITLE
ci(e2e): honest shadow + promotable gate shape + dependabot guards (SMI-5485)

### DIFF
--- a/.claude/development/ci-reference.md
+++ b/.claude/development/ci-reference.md
@@ -74,6 +74,8 @@ The `main` branch is protected. Config: `.github/branch-protection.json`.
 
 ### Required Checks
 
+**Drift correction (SMI-5485)**: this table and `.github/branch-protection.json` had drifted from the live `gh api repos/Smith-Horn/skillsmith/branches/main/protection` config -- the table listed a "Dependency Guard" row that is not (and was never) in `required_status_checks.contexts`, and both the table and the JSON were missing `Test (mcp-server integration)` (added when `test-mcp-server-integration` landed in `ci.yml`; never back-filled here). Reconciled below against a live `gh api` read taken the same session as this edit -- 13 required contexts, no PUT performed (catch-up only; the JSON already matches what GitHub enforces, this is a config-drift fix, not a policy change).
+
 | Check | Workflow | Purpose |
 |-------|----------|---------|
 | Secret Scan | ci.yml, docs-only.yml | Detect committed credentials |
@@ -86,13 +88,32 @@ The `main` branch is protected. Config: `.github/branch-protection.json`.
 | Markdown Lint | docs-only.yml | Documentation quality |
 | PR Validation (Node) | ci.yml | Verify PRs with SMI refs contain source changes + doc-drift (bundled — SMI-4924) |
 | PR Validation (Shell) | ci.yml | Edge function structure + smoke-prod pre-ship validation + migration SQL lint (bundled — SMI-4924) |
-| Dependency Guard | ci.yml | Block known-vulnerable dep upgrades (SMI-3985, promoted 2026-04-21) |
+| Test (root) | ci.yml | Root-scoped vitest suite (`scripts/tests`, `supabase/functions`) — SMI-4958 |
+| Test (root colocated) | ci.yml | Colocated `packages/*/src/**/*.test.ts` suite — SMI-3502 |
+| Test (mcp-server integration) | ci.yml | `packages/mcp-server` integration suite (`test-mcp-server-integration` job) |
+
+Note: `Dependency Guard` (ci.yml) runs on every PR but is NOT a required context — it is intentionally excluded from `required_status_checks.contexts`, so it does not appear above.
 
 ### How It Works
 
-- **Code PRs**: All 10 required checks must pass (the `required_status_checks.contexts` set in `.github/branch-protection.json`)
+- **Code PRs**: All 13 required checks must pass (the `required_status_checks.contexts` set in `.github/branch-protection.json`)
 - **Docs-only PRs**: Only Secret Scan + Markdown Lint (from `docs-only.yml`)
 - **Mixed PRs**: Full CI runs
+
+### Path-Filtered Workflows Cannot Be Required Checks (SMI-5485)
+
+A workflow triggered by `on.pull_request.paths` produces **no check-run at all** on a PR that doesn't touch the listed paths — not a skipped check, an *unreported* one. If that workflow's job is ever added to `required_status_checks.contexts`, every unrelated PR gets stuck on "Expected — waiting for status" forever, because GitHub has nothing to reconcile the requirement against. (Contrast a job that *runs but is conditionally skipped inside* an always-triggered workflow — e.g. a code-tier job in `ci.yml` on a docs-only PR — which GitHub correctly treats as a passed required check.)
+
+The only shape that can be promoted to a required check is **always-report gate**: the workflow triggers on every PR (no `paths` filter), a cheap first job (`changes`) detects relevant changes, a second job (`e2e`) runs conditionally on that output, and a third job (`gate`) `needs: [changes, e2e]` with `if: !cancelled()` and unconditionally reports success or failure — real result when the conditional job ran, success when it was legitimately skipped. See `.github/workflows/website-skills-e2e.yml` (`Website Skills E2E Gate`) for the canonical implementation, including the fail-closed evaluation order (fork PR → Dependabot → changes-job-failure → e2e-success → e2e-legitimately-skipped → else-red) and why the gate job uses `if: !cancelled()` rather than `if: always()` (the latter would report a spurious red during concurrency-cancellation on every force-push, polluting the promotion streak).
+
+### Dependabot Actor Guard (SMI-5485)
+
+Any PR job that depends on repository secrets must exclude `github.actor == 'dependabot[bot]'`. Dependabot PRs are same-repo branches, so they pass the ordinary fork guard (`github.event.pull_request.head.repo.full_name == github.repository`) — but Dependabot-triggered runs receive **no repository secrets**, so a `VERCEL_TOKEN`/`STAGING_SUPABASE_*`-dependent step fails under `set -eu` on every monthly `github-actions` grouped bump. Without this guard and without `continue-on-error`, that failure is a real, misleading red run; with the pre-SMI-5485 `continue-on-error: true` shadow pattern it was worse — a masked invisible-skip that inflated the promotion streak.
+
+Two guard forms, chosen by trigger surface:
+
+- **Bare form** (`github.actor != 'dependabot[bot]'`) — safe only for workflows with **no `schedule:` trigger** (e.g. `website-skills-e2e.yml`, `website-account-e2e.yml`), where the only non-`pull_request` event is `workflow_dispatch` (always a human actor).
+- **Event-scoped form** (`github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'`) — **required** for any workflow with a `schedule:` trigger (e.g. `device-login-roundtrip.yml`, `cross-harness-inventory-e2e.yml`). On a scheduled run, `github.actor` is attributed to the last person who edited the workflow file, which can legitimately be `dependabot[bot]` after a merged `github-actions` version bump — a bare actor check would then silently skip the nightly burn-in run, the exact invisible-skip failure class this convention exists to prevent.
 
 ### Emergency Bypass
 

--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -15,7 +15,8 @@
       "PR Validation (Node)",
       "PR Validation (Shell)",
       "Test (root)",
-      "Test (root colocated)"
+      "Test (root colocated)",
+      "Test (mcp-server integration)"
     ]
   },
   "enforce_admins": false,

--- a/.github/workflows/cross-harness-inventory-e2e.yml
+++ b/.github/workflows/cross-harness-inventory-e2e.yml
@@ -98,6 +98,12 @@ jobs:
     environment: e2e-staging
     permissions:
       contents: read
+    # Dependabot PRs are same-repo but receive no repository secrets (SMI-5485).
+    # Event-scoped (not a bare actor check): on `schedule`, github.actor is
+    # attributed to the last workflow editor, which can be dependabot[bot]
+    # after a merged github-actions bump -- a bare check would silently skip
+    # the nightly burn-in run. This form only excludes dependabot *PRs*.
+    if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
     continue-on-error: true # audit:allow-continue-on-error
     # H2: the marker above is REQUIRED. Device-login satisfies audit:standards
     # Check 21 via its downstream negative-control-assertion job that references

--- a/.github/workflows/device-login-roundtrip.yml
+++ b/.github/workflows/device-login-roundtrip.yml
@@ -94,6 +94,12 @@ jobs:
     environment: e2e-staging
     permissions:
       contents: read
+    # Dependabot PRs are same-repo but receive no repository secrets (SMI-5485).
+    # Event-scoped (not a bare actor check): on `schedule`, github.actor is
+    # attributed to the last workflow editor, which can be dependabot[bot]
+    # after a merged github-actions bump -- a bare check would silently skip
+    # the nightly burn-in run. This form only excludes dependabot *PRs*.
+    if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
     continue-on-error: true # Phase 1 — nightly observability mode; remove after 10 green runs
     env:
       NEGATIVE_CONTROL: ${{ github.event.inputs.negative_control || 'none' }}

--- a/.github/workflows/website-account-e2e.yml
+++ b/.github/workflows/website-account-e2e.yml
@@ -26,9 +26,33 @@
 # Playwright needs host browsers; no native modules load on this path.
 # Precedent: website-skills-e2e.yml, device-login-roundtrip.yml, ADR-113.
 #
-# Phase 1 shadow: job-level continue-on-error keeps this non-blocking during
-# burn-in. Promote after 10 consecutive green runs: remove continue-on-error
-# and add website-account-e2e to branch-protection required checks.
+# Honest-shadow semantics (SMI-5485): this workflow is shadow (non-required)
+# but honest -- there is no job-level `continue-on-error` here, so a real
+# spec failure produces a real red run conclusion. Shadow means "not in
+# required_status_checks.contexts", NOT "allowed to lie" -- a red check here
+# is informational only and does not block merges while shadow.
+#
+# Dependabot rationale: Dependabot PRs pass the same-repo fork guard (they
+# are branches on this repo) but receive NO repository secrets, so the
+# VERCEL_TOKEN-dependent steps would fail on every monthly `github-actions`
+# bump. The job `if:` below excludes `github.actor == 'dependabot[bot]'` so
+# those PRs skip the job entirely rather than surface a misleading red run.
+# No `schedule:` trigger on this workflow, so the bare actor check is safe
+# (contrast device-login-roundtrip.yml / cross-harness-inventory-e2e.yml,
+# which need the event-scoped form).
+#
+# Streak counting: gh run list --workflow=website-account-e2e.yml --limit 30
+#   --json conclusion,status,event,headSha,createdAt
+# counts toward the 10-consecutive-green promotion streak only when
+# `status == 'completed' && conclusion == 'success'`; `cancelled` runs
+# (concurrency-superseded) are excluded from the count.
+#
+# Promotion: this workflow is still `pull_request.paths`-filtered, so it
+# cannot yet join required_status_checks.contexts (an unreported check-run
+# on unrelated PRs would block merges forever). Its promotion is weeks out;
+# when it matures, restructure it to the changes/e2e/gate always-report
+# shape introduced in website-skills-e2e.yml (SMI-5485) before registering
+# it as a required check.
 
 name: Website Account E2E
 
@@ -73,8 +97,9 @@ jobs:
     # head.repo.full_name check evaluates to empty-string != github.repository
     # and the job would skip. The event_name guard permits workflow_dispatch
     # explicitly while the PR guard blocks fork PRs (VERCEL_TOKEN unavailable).
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
-    continue-on-error: true # audit:allow-continue-on-error -- Phase 1 shadow; remove after 10 consecutive green runs
+    # Dependabot PRs are same-repo (pass the guard above) but receive no
+    # repository secrets -- excluded explicitly (SMI-5485; see header).
+    if: github.actor != 'dependabot[bot]' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
     env:
       NODE_VERSION: '22'
       # Account specs goto() relative paths against baseURL. vercel dev binds

--- a/.github/workflows/website-skills-e2e.yml
+++ b/.github/workflows/website-skills-e2e.yml
@@ -1,9 +1,51 @@
-# Gates the SMI-5368 stretched-link z-index carve-out in a real Chromium on
-# every PR that touches the SkillCard renderer or the /skills page shell.
+# Gates the SMI-5368 stretched-link z-index carve-out in a real Chromium.
 #
-# Phase 1 shadow: job-level continue-on-error keeps this non-blocking during
-# burn-in. Promote after 10 consecutive green runs: remove continue-on-error
-# and add website-skills-e2e to branch-protection required checks.
+# SMI-5485 restructure -- previously `pull_request.paths`-filtered, which can
+# NEVER become a required branch-protection check: on a PR that doesn't touch
+# the listed paths, GitHub emits no check-run at all for this workflow, and a
+# required-but-unreported context blocks the merge forever ("Expected --
+# waiting for status"). This workflow now triggers on every PR and always
+# reports via the `gate` job below.
+#
+# Shape: `changes` (cheap relevance detection, every PR) -> `e2e` (runs only
+# when relevant) -> `gate` (ALWAYS reports; `Website Skills E2E Gate` is the
+# future required-check context -- see Wave 2 protocol below).
+#
+# Honest-shadow semantics: this workflow is NOT YET a required check. During
+# shadow, a red `Website Skills E2E Gate` does NOT block merge -- it is
+# informational only, surfacing real e2e health ahead of promotion. There is
+# no job-level `continue-on-error` anywhere in this file (removed by
+# SMI-5485 -- it was masking Dependabot-PR failures as green), so every run
+# conclusion is truthful and the promotion streak below is trustworthy.
+#
+# Streak counting (AC-5): a run counts toward the 10-consecutive-green
+# promotion streak only when `status == 'completed' && conclusion ==
+# 'success'`. Runs with `conclusion == 'cancelled'` (concurrency-superseded
+# by a force-push or rebase) are EXCLUDED from the count -- they neither
+# break nor extend the streak (the `gate` job's `if: !cancelled()` keeps a
+# superseded run `cancelled`, not a spurious red).
+#   gh run list --workflow=website-skills-e2e.yml --limit 30 \
+#     --json conclusion,status,event,headSha,createdAt
+#
+# Wave 2 promotion protocol (separate PR, after a real 10-consecutive-green
+# streak and explicit operator confirmation -- NOT part of this PR): add
+# `Website Skills E2E Gate` to the `contexts` array in
+# .github/branch-protection.json, apply with
+#   gh api repos/Smith-Horn/skillsmith/branches/main/protection -X PUT \
+#     --input .github/branch-protection.json
+# then run ./scripts/validate-branch-protection.sh, then remove this Phase-1
+# shadow note from the header.
+#
+# Dependabot rationale: Dependabot PRs pass the same-repo fork guard (they
+# are branches on this repo) but receive NO repository secrets, so the
+# VERCEL_TOKEN-dependent steps would fail under `set -eu` on every monthly
+# `github-actions` bump -- with continue-on-error removed that would be a
+# real, expected red run. The `e2e` job's `if:` excludes
+# `github.actor == 'dependabot[bot]'`, and the `gate` job passes Dependabot
+# PRs explicitly (a legitimate skip, not a failure). Neither this workflow
+# nor website-account-e2e.yml has a `schedule:` trigger, so the bare actor
+# check is safe here -- contrast device-login-roundtrip.yml /
+# cross-harness-inventory-e2e.yml, which need the event-scoped form.
 #
 # -g 5368 scopes the run to the 2 deterministic mocked tests (SMI-5375):
 #   - "+N more" compat toggle expands without navigating away (SMI-3529/5367/5368/5369)
@@ -16,14 +58,7 @@
 name: Website Skills E2E
 
 on:
-  pull_request:
-    paths:
-      - 'packages/website/src/components/**'
-      - 'packages/website/src/pages/skills/**'
-      - 'packages/website/src/styles/**'
-      - 'packages/website/tests/e2e/skills-filter.spec.ts'
-      - 'packages/website/playwright.config.ts'
-      - '.github/workflows/website-skills-e2e.yml'
+  pull_request: {}
   workflow_dispatch: {}
 
 concurrency:
@@ -32,19 +67,58 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    name: Detect Relevant Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - name: Detect relevant changes
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          # workflow_dispatch has no PR number (github.event.pull_request is
+          # null) -- branch BEFORE the API call so it never resolves to the
+          # malformed "pulls//files" URL (AC-4).
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "workflow_dispatch: full e2e leg, skipping changed-files API call"
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # No checkout needed -- list changed files via the pulls/files API.
+          # Fails closed: any gh/grep error aborts under set -eu, leaving
+          # `relevant` unset (never defaulted to 'false') and the job
+          # non-zero, which the gate treats as changes.result != 'success'.
+          # Include rename SOURCES (previous_filename) -- the former `paths:`
+          # filter matched a rename on both its old and new path; .filename
+          # alone would miss a file renamed OUT of a relevant path.
+          FILES="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[] | .filename, (.previous_filename // empty)')"
+          # Relevance list == the workflow's former 6 `paths` entries.
+          # Regex-anchored to the start of the repo-relative path.
+          if echo "$FILES" | grep -qE '^(packages/website/src/components/|packages/website/src/pages/skills/|packages/website/src/styles/|packages/website/tests/e2e/skills-filter\.spec\.ts$|packages/website/playwright\.config\.ts$|\.github/workflows/website-skills-e2e\.yml$)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   e2e:
-    name: Website Skills E2E
+    name: Website Skills E2E Run
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Allow same-repo PRs and manual workflow_dispatch runs.
+    # Relevant same-repo PRs and manual workflow_dispatch runs only.
     # For workflow_dispatch, github.event.pull_request is null so the
     # head.repo.full_name check evaluates to empty-string != github.repository
     # and the job would skip. The event_name guard permits workflow_dispatch
-    # explicitly while the PR guard blocks fork PRs (VERCEL_TOKEN unavailable).
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
-    continue-on-error: true # audit:allow-continue-on-error -- Phase 1 shadow; remove after 10 consecutive green runs
+    # explicitly while the PR guard blocks fork PRs (VERCEL_TOKEN
+    # unavailable). Dependabot PRs are excluded -- see header rationale.
+    if: needs.changes.outputs.relevant == 'true' && github.actor != 'dependabot[bot]' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
     env:
       NODE_VERSION: '22'
       SKILLSMITH_WEBSITE_URL: 'http://127.0.0.1:4321'
@@ -116,7 +190,10 @@ jobs:
         # No --reporter override: the config's [list, html(open:never)] applies,
         # so the console gets list output AND playwright-report/ is populated for
         # the failure-artifact upload (pr-review F-G). open:never keeps CI non-blocking.
-        run: npx playwright test --config=packages/website/playwright.config.ts packages/website/tests/e2e/skills-filter.spec.ts --project=desktop -g 5368
+        # --timeout=90000 (SMI-5485): the one genuine failure in 18 shadow runs
+        # was a 30s locator.click timeout that passed on retry; timeout-shaped
+        # fix, retries stay 0 (config default).
+        run: npx playwright test --config=packages/website/playwright.config.ts --timeout=90000 packages/website/tests/e2e/skills-filter.spec.ts --project=desktop -g 5368
 
       - name: Upload artifacts on failure
         if: failure()
@@ -137,3 +214,48 @@ jobs:
             PID="$(cat test-results/preview.pid)"
             if kill -0 "$PID" 2>/dev/null; then kill -TERM "$PID" || true; fi
           fi
+
+  gate:
+    name: Website Skills E2E Gate
+    needs: [changes, e2e]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Evaluate gate (fail-closed, fork/dependabot precedence first)
+        run: |
+          set -eu
+          # 1. Fork PR: e2e is intentionally skipped (no secrets) -- pass with
+          #    a visible warning. Guarded by event_name == 'pull_request' so a
+          #    workflow_dispatch run (github.event.pull_request is null) never
+          #    misclassifies as a fork.
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::warning::e2e skipped on fork PR (no secrets); gate passes without coverage"
+            exit 0
+          fi
+          # 2. Dependabot PR: e2e is intentionally skipped (no repository
+          #    secrets) -- legitimate skip, not a failure.
+          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+            echo "Dependabot PR: e2e skipped (no repository secrets); gate passes (legitimate skip)."
+            exit 0
+          fi
+          # 3. Fail-closed: the changes job itself errored (gh api/grep
+          #    failure) on a same-repo non-Dependabot PR.
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "::error::changes job did not succeed (result=${{ needs.changes.result }}) -- failing closed"
+            exit 1
+          fi
+          # 4. e2e ran and passed.
+          if [ "${{ needs.e2e.result }}" = "success" ]; then
+            echo "e2e passed."
+            exit 0
+          fi
+          # 5. e2e legitimately skipped (no relevant changes).
+          if [ "${{ needs.e2e.result }}" = "skipped" ] && [ "${{ needs.changes.outputs.relevant }}" = "false" ]; then
+            echo "No relevant changes; e2e legitimately skipped. Gate passes."
+            exit 0
+          fi
+          # 6. Everything else (e2e failure/cancellation, or an unreachable
+          #    relevant-but-not-success state) -- red.
+          echo "::error::e2e result=${{ needs.e2e.result }} relevant=${{ needs.changes.outputs.relevant }} -- gate fails"
+          exit 1


### PR DESCRIPTION
## Summary

The SMI-5481 retro found the shadow-mode burn-in of `website-skills-e2e.yml` broken: job-level `continue-on-error` masked 2 Dependabot-PR failures as green checks and made the "10 consecutive green" promotion streak fictional (18/18 check-green vs a real streak of 3). This PR:

- **Restructures `website-skills-e2e.yml` to an always-report gate shape** (`changes` → `e2e` → `gate`). A path-filtered workflow can never be a required check (its context doesn't report on unrelated PRs and blocks the merge as "Expected"), so the workflow now triggers on all PRs, detects relevance via the `pulls/files` API (rename-source-aware), and reports through the fail-closed `Website Skills E2E Gate` job (`if: !cancelled()`). This is the exact shape Wave 2 will promote.
- **Removes job-level `continue-on-error` from both website e2e workflows** — shadow now means non-required + honest red; the streak becomes countable from run conclusions (cancelled excluded). A red on these checks does NOT block merges during shadow.
- **Closes the Dependabot secrets hole in all four secrets-dependent e2e workflows** (Dependabot PRs are same-repo but get no repository secrets): bare actor guard on the website pair; event-scoped form on `device-login-roundtrip.yml` + `cross-harness-inventory-e2e.yml` so scheduled runs survive a merged bump attributing `github.actor` to dependabot.
- `--timeout=90000` on the skills Playwright invocation (the one genuine failure in 18 runs was a 30s click timeout; retries stay 0).
- `branch-protection.json` caught up to the live 13 required contexts; `ci-reference.md` required-checks table reconciled + both new conventions documented.

## Plan & review (ADR-109)

Plan: `docs/internal/implementation/smi-5485-skills-e2e-burn-in-repair.md` (docs branch `docs/smi-5485-plan`, 858ebe5; pointer bump follows post-merge). Plan-review: APPROVED-WITH-CHANGES, 9 findings applied (incl. event-scoped guard + `!cancelled()`). Adversarial diff review: APPROVE, one Low (rename-source relevance) fixed in-commit. Follow-ups: SMI-5488 (pre-existing Check-21 fragility on device-login), SMI-5483 (boot-block dedup, unchanged).

## Verification

- Local: actionlint, prettier, ASCII sweep, YAML parse, `audit:standards` 0 fail (75 pass)
- This PR triggers the restructured skills workflow's FULL leg (its own file is in the relevance list) — gate must report success; `website-account-e2e.yml` also runs (own file changed) proving the honest-red shape live; `device-login-roundtrip.yml` + `cross-harness-inventory-e2e.yml` will also run their staging legs (own files touched) — expected and benign
- Post-merge: one `workflow_dispatch` full-leg run from main; one scratch draft PR proving the skip leg (gate green in seconds, e2e skipped), closed unmerged
- Dependabot leg verified by expression review; confirmed live on the next monthly `github-actions` bump

`[skip-impl-check]` — infra-only PR (workflow YAML + branch-protection JSON + docs), no `packages/*/src` changes; the CI wiring itself is verified by the self-triggered runs above.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)