### PR TITLE
fix(website): deflake skills-filter e2e — suppress SignedOutOverlay via its dismissal key (SMI-5504)

### DIFF
--- a/packages/website/tests/e2e/skills-filter.spec.ts
+++ b/packages/website/tests/e2e/skills-filter.spec.ts
@@ -51,6 +51,25 @@ async function verifyResultsDisplayed(page: Page): Promise<number> {
 
 test.describe('Skills Filter-Only Browsing (SMI-1658)', () => {
   test.beforeEach(async ({ page }) => {
+    // SMI-5504 deflake: suppress SignedOutOverlay (SMI-4401/4837) deterministically.
+    // Anonymous contexts have no Supabase session, so the overlay's deferred script
+    // reveals a full-viewport pointer-blocking backdrop ~250ms+ after astro:page-load,
+    // racing every click in this suite (~7% loss in CI). Both historical failures'
+    // error-context artifacts (run 28305673909; run 28626331405 attempt 1 -- after a
+    // rerun the red evidence survives only in the run's ARTIFACTS, not its logs) name
+    // "signed-out-overlay ... intercepts pointer events". Seeding the component's own
+    // dismissal key (+24h here; the component's real TTL is 7 days) makes
+    // setupOverlay() remove the overlay before it can reveal.
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem(
+          'skills_overlay_dismissed_until',
+          new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+        )
+      } catch {
+        /* localStorage unavailable — overlay suppression falls back to the race */
+      }
+    })
     await page.goto(`${BASE_URL}/skills`)
     // Wait for the page to be fully loaded
     await expect(page.locator('#category-filter')).toBeVisible()


### PR DESCRIPTION
## Summary

Deflakes the skills-filter e2e carve-out (the suite backing the required `Website Skills E2E Gate` check). Both historical CI failures were NOT click slowness: the `SignedOutOverlay` (SMI-4401/4837) reveals a full-viewport pointer-blocking backdrop ~250ms+ after `getSession()` resolves null for the (always anonymous) CI context, occasionally landing mid-click-retry and blocking the hit-target check until timeout. The Wave-1 `--timeout=90000` bump never touched the cause.

## Evidence

- Error-context artifacts of BOTH failures (run 28305673909 and run 28626331405 attempt 1) name `signed-out-overlay ... intercepts pointer events` — Playwright's own hit-target diagnostic, twice each.
- Note for future archaeology: after a `--failed` rerun, the red evidence survives only in the run's **artifacts**, not its logs (run 28626331405's logs show the green attempt 2).

## Fix

Seed the component's own documented dismissal key (`localStorage['skills_overlay_dismissed_until']`) via `page.addInitScript` in the suite-level `beforeEach` — `setupOverlay()` then removes the overlay on entry through its real dismissal path, on every navigation, before the reveal timer can arm. Test-only change; 16 lines + comment.

## Verification

- 20/20 local repeats green with the fix (10 × both carve-out tests).
- Control run without the fix passes locally too — prod-speed assets always win the race; the failure requires CI's slow vite-dev module chain. RCA rests on the artifact evidence above, not repro.
- This PR touches the spec (in the gate's relevance list) → the full e2e leg runs on this PR.
- Opus adversarial review: APPROVE (findings actioned: SMI-5507 overlay pointer-events modality parity; SMI-5508 dormant complete-profile overlay coverage). Governance review findings (evidence-citation durability, TTL wording) fixed in-commit.

## Acceptance (post-merge, per SMI-5504)

20 consecutive green main dispatches with no click-timeout, then SMI-5504 → Done.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)
