### PR TITLE
ci(publish): OIDC publish job for the unscoped skillsmith-cli wrapper (SMI-5513)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -930,6 +930,141 @@ jobs:
           echo "::error::@skillsmith/cli@${VERSION} is not live on npm after publish — failing the job."
           exit 1
 
+  # SMI-5513: Standalone OIDC publish job for the UNSCOPED skillsmith-cli wrapper
+  # (the npm name-disambiguation redirect from SMI-3561; delegates to
+  # @skillsmith/cli). Deliberately NOT added to PUBLISHABLE_PACKAGES_JSON:
+  #  - audit-standards Check 26's registration-parity regex is scoped-only
+  #    (@skillsmith|smith-horn), so an unscoped entry would fail unfixably;
+  #  - the wrapper's @skillsmith/cli dep is a floating ^range independent of the
+  #    in-repo cli version, so Check 48's required-gate would be semantically wrong.
+  # Self-contained: the inline version-check gates the publish, mirroring
+  # publish-core's internal guard. Because it is not in pre-publish-check, it
+  # forfeits the SMI-1319 coarse whole-job skip (accepted: pays checkout+npm-ci
+  # on every release run regardless of whether its version changed).
+  publish-skillsmith-cli:
+    name: Publish skillsmith-cli
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [pre-publish-check, publish-cli]
+    # SMI-4540: id-token: write enables npm trusted-publisher OIDC (sole npm auth
+    # path; granular token revoked 2026-05-19). Job-scoped, least privilege.
+    permissions:
+      contents: read
+      id-token: write
+    # SMI-5123: the wrapper's runtime dep is @skillsmith/cli, so it MUST publish
+    # after publish-cli, never in parallel (job-definition order does not order
+    # execution; only needs: does). Otherwise a same-release cli bump could ship
+    # a wrapper pinning a cli version not yet on npm. Mirror the SMI-4803
+    # !cancelled() + SMI-5060 paired-predicate shape from publish-cli.
+    # NOTE: dry_run is `type: boolean`, so `inputs.dry_run` is boolean and
+    # `false == 'false'` coerces via ToNumber to NaN (never fires). Use the
+    # string-typed `github.event.inputs.dry_run` exactly as the sibling jobs do.
+    if: |
+      !cancelled() &&
+      (github.event_name == 'release' || github.event.inputs.dry_run == 'false') &&
+      (needs.publish-cli.result == 'success' ||
+       (needs.publish-cli.result == 'skipped' && needs.pre-publish-check.outputs.cli-exists == 'true'))
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      # No `Unlock git-crypt` step: the wrapper has no encrypted deps and no
+      # build; `npm ci --ignore-scripts` never reads supabase/functions|migrations
+      # (they are not npm workspaces). Omitted for least privilege.
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # No build step: skillsmith-cli is a thin wrapper (files: [bin.js]); nothing
+      # to compile. @skillsmith/cli resolves from npm on the end-user machine.
+
+      - name: Check if version already published
+        id: version-check
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./packages/skillsmith-cli/package.json').version")
+          NPM_VERSION=$(npm view skillsmith-cli version 2>/dev/null || echo 'not-found')
+          echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+          echo "npm_version=$NPM_VERSION" >> $GITHUB_OUTPUT
+          if [ "$PACKAGE_VERSION" = "$NPM_VERSION" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "::notice::skillsmith-cli@$PACKAGE_VERSION already published, skipping..."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "::notice::Publishing skillsmith-cli@$PACKAGE_VERSION (current npm: $NPM_VERSION)"
+          fi
+
+      # SMI-4188: mirror guard - see publish-core job for rationale.
+      - name: Pre-publish collision mirror guard
+        if: steps.version-check.outputs.exists != 'true'
+        run: |
+          VERSION=$(jq -r .version packages/skillsmith-cli/package.json)
+          node scripts/check-publish-collision.mjs skillsmith-cli "$VERSION"
+
+      # SMI-4539: native npm publish OIDC needs npm >= 11.5.1; runner ships 10.9.7.
+      # Upgrade AFTER npm ci (npm 11's ci rejects the repo-standard npm-10 lockfile).
+      - name: Upgrade npm for OIDC publish (SMI-4539)
+        run: npm install -g npm@11.9.0
+
+      - name: Assert npm version (SMI-4539)
+        run: |
+          ACTUAL="$(npm --version)"
+          if [ "$ACTUAL" != "11.9.0" ]; then
+            echo "::error::Expected npm 11.9.0 for OIDC publish, got $ACTUAL"
+            exit 1
+          fi
+          echo "OK npm $ACTUAL"
+
+      # SMI-4540: OIDC-only publish (npmjs.com Trusted Publisher: smith-horn/
+      # skillsmith + publish.yml). --access public is a harmless no-op on an
+      # unscoped package (kept for step-shape consistency).
+      - name: Publish skillsmith-cli
+        id: publish-skillsmith-cli-oidc
+        if: steps.version-check.outputs.exists != 'true'
+        run: |
+          npm publish -w skillsmith-cli --access public
+          echo "::notice::OIDC publish succeeded for skillsmith-cli"
+
+      - name: Verify skillsmith-cli on npm + smoke the wrapper
+        if: steps.publish-skillsmith-cli-oidc.outcome == 'success'
+        run: |
+          VERSION=$(jq -r .version packages/skillsmith-cli/package.json)
+          # Retry to absorb npm registry/CDN propagation lag right after publish.
+          LIVE=''
+          for attempt in 1 2 3 4 5; do
+            LIVE=$(npm view "skillsmith-cli@${VERSION}" version 2>/dev/null || echo '')
+            if [ "$LIVE" = "$VERSION" ]; then
+              echo "OK skillsmith-cli@${VERSION} verified live on npm (attempt ${attempt})"
+              break
+            fi
+            echo "... skillsmith-cli@${VERSION} not yet visible (attempt ${attempt}/5); waiting 6s"
+            sleep 6
+          done
+          if [ "$LIVE" != "$VERSION" ]; then
+            echo "::error::skillsmith-cli@${VERSION} is not live on npm after publish - failing the job."
+            exit 1
+          fi
+          # Smoke the REAL install path: npx pulls the wrapper + its @skillsmith/cli
+          # dep from npm and runs bin.js. Catches a broken shebang / bin delegation
+          # or an unsatisfiable @skillsmith/cli pin that `npm view` alone misses.
+          for attempt in 1 2 3; do
+            if npx -y "skillsmith-cli@${VERSION}" --version >/tmp/sk-smoke.out 2>&1; then
+              echo "OK npx skillsmith-cli@${VERSION} --version -> $(tail -1 /tmp/sk-smoke.out)"
+              exit 0
+            fi
+            echo "... npx smoke not ready (attempt ${attempt}/3); waiting 8s"
+            sleep 8
+          done
+          echo "::error::npx skillsmith-cli@${VERSION} --version failed - wrapper bin/delegation broken."
+          cat /tmp/sk-smoke.out || true
+          exit 1
+
   # Publish enterprise package to GitHub Packages (private)
   # SMI-1319: Use pre-publish-check outputs to skip already-published packages
   publish-enterprise:

--- a/packages/skillsmith-cli/package.json
+++ b/packages/skillsmith-cli/package.json
@@ -7,6 +7,7 @@
     "skillsmith-cli": "./bin.js"
   },
   "scripts": {
+    "prepublishOnly": "node ../../scripts/lib/forbid-local-publish.mjs",
     "test": "echo 'No tests — thin wrapper package'"
   },
   "dependencies": {


### PR DESCRIPTION
## Why

The unscoped **`skillsmith-cli`** wrapper (npm name-disambiguation redirect, SMI-3561) was never onboarded to the OIDC trusted-publisher pipeline — the four scoped `@skillsmith/*` packages publish via `publish.yml`, but the wrapper had no CI publish path, so its pending `0.5.2` (pin/bin fix) couldn't ship token-free. Closes **SMI-5513**; unblocks the **SMI-5512** `0.5.2` republish.

## Changes

- **`.github/workflows/publish.yml`** — standalone `publish-skillsmith-cli` job. Deliberately **NOT** in `PUBLISHABLE_PACKAGES_JSON`: an unscoped name breaks `audit-standards` Check 26's scoped-only registration regex, and the wrapper's floating `@skillsmith/cli: ^0.7.0` dep makes the Check 48 required-gate semantically wrong. Mirrors `publish-cli`; **no build, no git-crypt unlock** (no encrypted deps — least privilege). Inline version-check self-skips when already published; collision guard; npm 11.9.0 for OIDC; verify-on-npm + an `npx skillsmith-cli@<v> --version` smoke of the real install path.
- **`packages/skillsmith-cli/package.json`** — add the SMI-4533 `prepublishOnly` forbid-local-publish guard (the only `publish.yml` package missing it; an unscoped *public* package is the most important to guard against a rogue local publish).

## Plan-review (ADR-109) — 2 correctness bugs caught & fixed

1. **Critical:** original `needs: [pre-publish-check]` would run **in parallel** with `publish-cli` (job-definition order ≠ execution order) — SMI-5123 class. Fixed: `needs: [pre-publish-check, publish-cli]` + the SMI-5060 paired predicate (`publish-cli.result == 'success' || (skipped && cli-exists)`).
2. **Critical:** `inputs.dry_run == 'false'` silently never fires — `dry_run` is `type: boolean`, so `false == 'false'` coerces to NaN. Fixed: the string-typed `github.event.inputs.dry_run == 'false'` (verbatim from the sibling jobs).

**Deferred (follow-up on SMI-5513):** adding the wrapper to `verify-publish-deps.mjs` — it cascades into a `PACKAGE_SPECS` lockstep obligation that would break every cli-only release; the post-publish `npx` smoke already catches an unsatisfiable pin at publish time.

## Validation

- `audit:standards` **0 failures** — Check 48 explicitly confirms the new job's paired `publish-cli` predicate (SMI-5060/5123 guard).
- Workflow YAML parses; job `needs: [pre-publish-check, publish-cli]`.
- `prepublishOnly` guard verified: **refuses off-CI** (exit 1, SMI-4533 message), **passes in-CI**.
- Prereq **done**: npmjs.com Trusted Publisher configured on the `skillsmith-cli` package (`smith-horn/skillsmith` + `publish.yml`).

## After merge

`gh workflow run publish.yml -f dry_run=false` → `publish-skillsmith-cli` publishes `0.5.2` via OIDC (version-check sees `0.5.2 != 0.5.1`) → verify + `npx` smoke. Confirm `npm view skillsmith-cli version` → `0.5.2`.

[skip-impl-check]
