### PR TITLE
ci(publish): fix skillsmith-cli smoke - run npx outside monorepo, non-fatal (SMI-5513)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1050,20 +1050,27 @@ jobs:
             echo "::error::skillsmith-cli@${VERSION} is not live on npm after publish - failing the job."
             exit 1
           fi
-          # Smoke the REAL install path: npx pulls the wrapper + its @skillsmith/cli
-          # dep from npm and runs bin.js. Catches a broken shebang / bin delegation
-          # or an unsatisfiable @skillsmith/cli pin that `npm view` alone misses.
+          # Smoke the REAL install path, run from a fresh temp dir OUTSIDE the
+          # monorepo: npx must resolve the PUBLISHED skillsmith-cli + its
+          # @skillsmith/cli dep, not the workspace symlink. From the repo root,
+          # node_modules/@skillsmith/cli -> packages/cli (which has no built
+          # dist/ in this job), so bin.js hits MODULE_NOT_FOUND (SMI-5513 retro).
+          # Non-fatal: the publish is already verified live on npm above and
+          # cannot be un-published, so this bonus bin-delegation check warns
+          # loudly for a fix-forward rather than red-failing an irreversible
+          # success.
+          SMOKE_DIR="$(mktemp -d)"
           for attempt in 1 2 3; do
-            if npx -y "skillsmith-cli@${VERSION}" --version >/tmp/sk-smoke.out 2>&1; then
+            if (cd "$SMOKE_DIR" && npx -y "skillsmith-cli@${VERSION}" --version) >/tmp/sk-smoke.out 2>&1; then
               echo "OK npx skillsmith-cli@${VERSION} --version -> $(tail -1 /tmp/sk-smoke.out)"
               exit 0
             fi
             echo "... npx smoke not ready (attempt ${attempt}/3); waiting 8s"
             sleep 8
           done
-          echo "::error::npx skillsmith-cli@${VERSION} --version failed - wrapper bin/delegation broken."
+          echo "::warning::npx skillsmith-cli@${VERSION} --version smoke did not pass (package is published + verified live on npm regardless; check bin delegation)."
           cat /tmp/sk-smoke.out || true
-          exit 1
+          exit 0
 
   # Publish enterprise package to GitHub Packages (private)
   # SMI-1319: Use pre-publish-check outputs to skip already-published packages


### PR DESCRIPTION
## Why

`skillsmith-cli@0.5.2` published successfully via OIDC ([run 28679099754](https://github.com/smith-horn/skillsmith/actions/runs/28679099754)) and is **live + working** (`npx skillsmith-cli@0.5.2 --version` → `0.7.4` from outside the repo). But the `publish-skillsmith-cli` job's bonus `npx` smoke step **red-failed** the run: it ran `npx` from the repo root, so npx resolved `@skillsmith/cli` to the workspace symlink (`node_modules/@skillsmith/cli → packages/cli`, which has no built `dist/` in this job) → `MODULE_NOT_FOUND`. This is the known "npx resolves the local workspace binary from monorepo root" gotcha.

## Fix

- Run the smoke from a fresh `mktemp -d` **outside** the monorepo so npx resolves the **published** wrapper + its published `@skillsmith/cli` (the real user install path — verified locally: `/tmp` → `0.7.4`).
- Make the smoke **non-fatal** (`::warning::` + `exit 0`). The `npm view` live-check above already confirms the publish landed, and an npm publish is irreversible, so a bonus bin-delegation check must warn for a fix-forward, not red-fail an already-successful publish.

No effect on the already-published `0.5.2`; this hardens future wrapper publishes. `audit:standards` 0 failures; YAML validated.

[skip-impl-check]
