### PR TITLE
chore(release): core 0.10.0, mcp-server 0.7.0, cli 0.8.0

### DIFF
--- a/.claude/development/skill-invoke-telemetry-guide.md
+++ b/.claude/development/skill-invoke-telemetry-guide.md
@@ -284,7 +284,7 @@ needed.
 
 ## `withTelemetry` HOF
 
-Location: `packages/mcp-server/src/telemetry/with-telemetry.ts`
+Location: `packages/core/src/telemetry/wrap.ts` (exported as `@skillsmith/core/telemetry`)
 
 Key design decisions (from plan-review):
 
@@ -297,7 +297,7 @@ Key design decisions (from plan-review):
 1. Wrap the handler with `withTelemetry`:
 
    ```typescript
-   import { withTelemetry } from '../telemetry/with-telemetry.js';
+   import { withTelemetry } from '@skillsmith/core/telemetry';
 
    export const myNewTool = withTelemetry(
      async (params, context) => { /* handler */ },
@@ -352,7 +352,7 @@ Added in Wave 4 Step 4. Greps that previously lived in plan-review commentary ar
 
 - Assert `trackSkill*` event names exist in `packages/core/src/telemetry/posthog.ts` `SkillsmithEventType` union
 - Assert `ALLOWED_EVENTS` in `supabase/functions/events/index.ts` includes all three telemetry event types
-- Assert no parallel `withTelemetry` definition outside `with-telemetry.ts` (single source of truth)
+- Assert no parallel `withTelemetry` definition outside `wrap.ts` (single source of truth)
 - Assert `/tmp/skillsmith-` is not used anywhere (run files must live in `~/.skillsmith/run/`)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -34538,7 +34538,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
@@ -34569,8 +34569,8 @@
         "sklx": "dist/cli.js"
       },
       "devDependencies": {
-        "@skillsmith/core": "^0.9.0",
-        "@skillsmith/mcp-server": "^0.6.0",
+        "@skillsmith/core": "^0.10.0",
+        "@skillsmith/mcp-server": "^0.7.0",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
         "vitest": "4.1.6"
@@ -34681,7 +34681,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -34862,13 +34862,13 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-        "@skillsmith/core": "^0.9.0",
+        "@skillsmith/core": "^0.10.0",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.6.0",
+        "@skillsmith/mcp-server": "^0.7.0",
         "@smithy/config-resolver": "4.4.13",
         "@smithy/core": "3.23.12",
         "@smithy/middleware-endpoint": "4.4.27",
@@ -34883,7 +34883,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.6.0"
+        "@skillsmith/mcp-server": "^0.7.0"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -35007,11 +35007,11 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.9.0",
+        "@skillsmith/core": "^0.10.0",
         "ulid": "3.0.1",
         "zod": "3.25.76"
       },
@@ -35055,6 +35055,142 @@
       },
       "engines": {
         "node": ">=22.22.0"
+      }
+    },
+    "packages/skillsmith-cli/node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/skillsmith-cli/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/skillsmith-cli/node_modules/@skillsmith/cli": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@skillsmith/cli/-/cli-0.7.4.tgz",
+      "integrity": "sha512-3ORPXDo8RDteJNa6PRJMD2Z3i6Yu8AAKzy+lZS4GuJmsPNJx+Zk4ejdeIqrLkN3mb3DUR4zfZo5NwDCIBqwAxw==",
+      "license": "Elastic-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "7.10.1",
+        "@opentelemetry/api": "1.9.1",
+        "@opentelemetry/instrumentation-http": "0.219.0",
+        "@opentelemetry/instrumentation-runtime-node": "0.32.0",
+        "@opentelemetry/instrumentation-undici": "0.29.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-node": "0.219.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0",
+        "@opentelemetry/semantic-conventions": "1.41.1",
+        "chalk": "5.6.2",
+        "chokidar": "4.0.3",
+        "cli-table3": "0.6.5",
+        "commander": "14.0.3",
+        "fts5-sql-bundle": "1.0.2",
+        "gray-matter": "4.0.3",
+        "open": "11.0.0",
+        "ora": "9.3.0",
+        "posthog-node": "5.29.2",
+        "tree-sitter-wasms": "0.1.13",
+        "typescript": "5.9.3",
+        "web-tree-sitter": "0.25.10"
+      },
+      "bin": {
+        "skillsmith": "dist/cli.js",
+        "sklx": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.22.0"
+      },
+      "peerDependencies": {
+        "@skillsmith/enterprise": "*"
+      },
+      "peerDependenciesMeta": {
+        "@skillsmith/enterprise": {
+          "optional": true
+        }
+      }
+    },
+    "packages/skillsmith-cli/node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/skillsmith-cli/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/skillsmith-cli/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/skillsmith-cli/node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/skillsmith-cli/node_modules/ora": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
+      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.1",
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/vscode-extension": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.8.0
+
+- **Feature**: per-user inventory purge, hard-delete (SMI-5510, R0 Wave 1a) (#1684)
+- **Fix**: 0.7.4 security hotfix — interactive-search quarantine bypass (SMI-5447) (#1656)
 - **Feature**: `sklx agent install` / `uninstall` command group — installs portable agent pack (SKILL.md + shims + hooks) to detected harnesses with per-harness MCP registration (SMI-5456)
 
 ## v0.7.4

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -39,8 +39,8 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@skillsmith/core": "^0.9.0",
-    "@skillsmith/mcp-server": "^0.6.0",
+    "@skillsmith/core": "^0.10.0",
+    "@skillsmith/mcp-server": "^0.7.0",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",
     "vitest": "4.1.6"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.10.0
+
+- **Feature**: per-user inventory purge, hard-delete (SMI-5510, R0 Wave 1a) (#1684)
+- **Feature**: quarantine-hardening balance — scanner split + chmod evasion + recheck sibling re-scan (SMI-5434/5433/5437) (#1653)
 - **Feature**: telemetry marker channel for agent-mediated calls — `agent_session`/`nudge_origin`/`trigger_id` wire fields + `_meta` MCP marker extraction + harness-side attribution (SMI-5456)
 - **Feature**: change journal module — hash-chained, fsync'd records; foundation for undo (SMI-5456)
 - **Feature**: multi-target agent-pack generator emitting SKILL.md, Claude/Codex/OpenCode/Copilot shims, hooks (SMI-5456)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `@skillsmith/core` are documented here.
 - **Feature**: agent-pack installer/uninstaller with JSON-merge, manifest, path guard, per-harness reporting (SMI-5456)
 - **Feature**: paywall-triggers store for Community/Individual funnel state (SMI-5456)
 - **Feature**: extend ClientIds — add `opencode` and `hermes` skill paths (SMI-5456)
+- **Feature**: `runWithEmissionGate` — AsyncLocalStorage-scoped, per-call telemetry emission gate; `setEmissionGate` retained as a deprecated process-wide fallback (SMI-5479)
 
 ## v0.9.0
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.9.0'
+export const VERSION = '0.10.0'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1046.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-    "@skillsmith/core": "^0.9.0",
+    "@skillsmith/core": "^0.10.0",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.6.0",
+    "@skillsmith/mcp-server": "^0.7.0",
     "@smithy/config-resolver": "4.4.13",
     "@smithy/core": "3.23.12",
     "@smithy/middleware-endpoint": "4.4.27",
@@ -62,7 +62,7 @@
     "vitest": "4.1.6"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.6.0"
+    "@skillsmith/mcp-server": "^0.7.0"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.7.0
+
+- **Fix**: launcher dep-integrity preflight + zod runtime dep (SMI-5451) (#1664)
 - **Feature**: `SKILLSMITH_TOOL_PROFILE=agent` curated tool listing (~15 tools) for harness integration (SMI-5456)
 - **Feature**: `undo_apply` tool — session-scoped undo of apply_namespace_rename/apply_recommended_edit via journal (SMI-5456)
 - **Feature**: extract `_meta` marker (`agent_session`, `nudge_origin`, `trigger_id`) from MCP tool calls (SMI-5456)

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 - **Fix**: dispatch-routing for skill_inventory_audit/apply_namespace_rename/apply_recommended_edit (now callable over MCP CallTool) (SMI-5456)
 - **Feature**: inventory-audit dual-path dedup + self-exemption for agent pack (SMI-5456)
 - **Feature**: committed agent-pack assets (shims, hooks) + `generate:agent-pack` build script (SMI-5456)
+- **Feature**: consent-gated telemetry emission wired into the CallTool dispatch path for all 18 previously-never-emitting direct-dispatch tools, live-ing the agent-mediation denominator (SMI-5479)
+- **Feature**: flush-on-shutdown for buffered telemetry — bounded PostHog flush on `SIGTERM`/`SIGINT`/transport close (SMI-5479)
+- **Refactor**: extract `CallToolRequestSchema` handler from `index.ts` into `call-tool-handler.ts` to stay under the 500-LOC file-size gate (SMI-5479)
 
 ## v0.6.0
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.9.0",
+    "@skillsmith/core": "^0.10.0",
     "ulid": "3.0.1",
     "zod": "3.25.76"
   },

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.6.0",
+  "version": "0.7.0",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -106,7 +106,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.6.0'
+const PACKAGE_VERSION = '0.7.0'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 import {
   installBundledSkills,


### PR DESCRIPTION
Single release per the ratified D1 decision. Ships: **SMI-5456** Skillsmith Agent Wave 1 (portable agent pack, curated tool profile, journal + undo_apply, sklx agent install/uninstall, eval ladder), **SMI-5477** dispatch-routing fix (suggest→apply loop callable over real MCP again), **SMI-5479** consent emission gate (mediation denominator live; the day-30 window anchors on this release's sdk_version).

Also carries the SMI-5479 post-merge retro fixes (CHANGELOG entries + telemetry-guide path corrections) so prepare-release folded them into the version sections.

Note for review: **Package Validation fails by design on chore/release-* branches** (it checks deps against already-published versions; the bumps aren't published yet) — admin-merge is the documented path when it is the only red check (ci-reference § release-PR carve-out).

After merge: `gh workflow run publish.yml -f dry_run=false` (core → mcp-server → cli), post-publish smoke from a consent-ON identity, close SMI-5477 + SMI-5479 with the release version.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)