### PR TITLE
fix(ci): docs-folder-index + openapi-spec-sync gates never fired on pointer bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,15 @@ jobs:
           # SMI-3999 Revision 2 (Stage 2 Finding M2): Intentionally DOES NOT
           # exclude `docs/internal/**` even though docs-only.yml's symmetric
           # filter does include it. Rationale: docs/internal is a git submodule,
-          # so parent-repo PRs touching it actually bump `.gitmodules` (which
-          # is NOT excluded -> code='true' -> full CI runs, which is correct —
-          # submodule bumps must validate the parent's state). If docs/internal
-          # is ever de-submoduled, this filter MUST be updated to add
+          # so a parent-repo PR touching it only ever changes the literal gitlink
+          # path `docs/internal` (no trailing slash) -- .gitmodules is NOT
+          # touched by an ordinary pointer bump (SMI-5523 correction; verified via
+          # `git diff --submodule=short docs/internal` across many real bump
+          # commits). The literal `docs/internal` path itself is not excluded by
+          # any `!...` pattern below, so it matches the `'**'` catch-all directly
+          # -> code='true' -> full CI runs, which is correct -- submodule bumps
+          # must validate the parent's state. If docs/internal is ever
+          # de-submoduled, this filter MUST be updated to add
           # `'!docs/internal/**'` or pure doc PRs touching internal docs will
           # incorrectly trigger full CI. Keep this comment load-bearing.
           filters: |

--- a/.github/workflows/docs-folder-index.yml
+++ b/.github/workflows/docs-folder-index.yml
@@ -22,6 +22,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
+      # SMI-5523: docs/internal is a git submodule, so a pointer-bump PR's only
+      # changed path is the literal gitlink 'docs/internal' (no trailing slash) —
+      # that never matches 'docs/internal/**'. This gate had 0 lifetime runs
+      # across 87 pointer-bump PRs until this literal entry was added.
+      - 'docs/internal'
       - 'docs/internal/**'
       - '.gitmodules'
 

--- a/.github/workflows/openapi-spec-sync.yml
+++ b/.github/workflows/openapi-spec-sync.yml
@@ -26,6 +26,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
+      # SMI-5523: docs/internal is a git submodule, so a pointer-bump PR's only
+      # changed path is the literal gitlink 'docs/internal' (no trailing slash) —
+      # that never matches 'docs/internal/**'. Same bug as docs-folder-index.yml
+      # (0 of this guard's 2 lifetime runs were ever from a pointer bump).
+      - 'docs/internal'
       - 'docs/internal/**'
       - '.gitmodules'
       - 'packages/website/public/openapi.yaml'


### PR DESCRIPTION
## Summary

- Two CI gates (`docs-folder-index.yml` SMI-4932, `openapi-spec-sync.yml` SMI-5226) have had **0 lifetime runs** from a `docs/internal` submodule pointer-bump PR, despite 87 historical pointer bumps — their `paths: docs/internal/**` filter can never match, because a pointer bump only ever changes the literal gitlink path `docs/internal` (no trailing content), and GitHub's glob requires a slash + more after it.
- Fix: add the literal `docs/internal` path entry to both workflows' `paths:` list.
- Also corrects a false claim in `ci.yml`'s "load-bearing" comment (pointer bumps don't touch `.gitmodules`; verified via `git diff --submodule=short` across many real bump commits) — found during this same investigation, in scope per the zero-deferral policy.

## Verification plan

Once this merges, PR #1700 (an already-open, deliberately-unmerged pointer-bump PR at the fixed docs tip) will be synchronized to confirm `Folder Reference table fresh` now runs and passes for the first time ever.

## Deferred to a follow-up (SMI-5524)

Promoting either gate to a *required* check needs the "always-report gate" restructure (per `ci-reference.md`'s `Website Skills E2E Gate` precedent) — a simple `paths`-filtered workflow can't be required as-is. Out of scope here.

Reviewed via `plan-review-skill` (VP Product/Engineering/Design panel) — VP Engineering independently found the `openapi-spec-sync.yml` duplicate bug, folded into this PR.

Plan: `docs/internal/implementation/smi-5523-docs-folder-index-gate-paths.md`

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)