### PR TITLE
docs(inventory): document skillsmith inventory purge (SMI-5527)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -147,7 +147,7 @@ skillsmith update author/skill-name
 
 Cross-machine skill inventory for viewing which agent skills are installed across your machines and harnesses. Requires `skillsmith login` and opt-in via the [Cross-machine skill inventory toggle](https://www.skillsmith.app/account/telemetry) at skillsmith.app/account/telemetry (off by default). Once enabled, view your inventory at [skillsmith.app/account/skills](https://www.skillsmith.app/account/skills).
 
-**Privacy:** Only skill IDs, versions, content hashes, declared SKILL.md front-matter fields (author, license, repository), and device platform metadata are uploaded. File contents, paths, and your raw hostname are never transmitted. Set `SKILLSMITH_INVENTORY_DISABLE=1` to hard-disable.
+**Privacy:** Only skill IDs, versions, content hashes, declared SKILL.md front-matter fields (author, license, repository), and device platform metadata are uploaded. File contents, paths, and your raw hostname are never transmitted. Set `SKILLSMITH_INVENTORY_DISABLE=1` to hard-disable, or run `skillsmith inventory purge` to delete everything already stored.
 
 #### inventory push
 
@@ -182,6 +182,18 @@ Clear the local device registration; the next push creates a fresh device ID and
 ```bash
 skillsmith inventory forget-device
 ```
+
+#### inventory purge
+
+Permanently delete this account's entire stored cross-machine inventory from Skillsmith's servers (all devices and their skill rows). Irreversible. Prompts for confirmation unless `--yes` is passed.
+
+```bash
+skillsmith inventory purge
+skillsmith inventory purge --yes
+```
+
+**Options:**
+- `-y, --yes` - Skip the confirmation prompt (for scripts)
 
 See [Cross-machine skill inventory](https://www.skillsmith.app/docs/inventory) for details.
 

--- a/packages/website/src/pages/docs/inventory.astro
+++ b/packages/website/src/pages/docs/inventory.astro
@@ -117,12 +117,12 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
     <li>File contents, file paths, or skill source code</li>
   </ul>
 
-  <div class="callout warning">
-    <p class="callout-heading">No purge control yet</p>
+  <div class="callout">
+    <p class="callout-heading">Purging your stored inventory</p>
     <p>
       Turning inventory sync off stops future uploads immediately — this is enforced server-side,
-      not just by the CLI. A control to purge your already-stored inventory is planned but not
-      available yet.
+      not just by the CLI. To permanently delete everything already stored, run
+      <code>skillsmith inventory purge</code> (see <a href="#commands">Commands</a> below).
     </p>
   </div>
 
@@ -199,6 +199,17 @@ skillsmith inventory status --verbose`}</code></pre>
   </p>
 
   <pre><code>{`skillsmith inventory forget-device`}</code></pre>
+
+  <h3>skillsmith inventory purge</h3>
+
+  <p>
+    Permanently deletes this account's entire stored cross-machine inventory from Skillsmith's
+    servers — every device row and its skill rows. This is irreversible. Prompts for confirmation
+    unless <code>--yes</code> is passed (for scripts).
+  </p>
+
+  <pre><code>{`skillsmith inventory purge
+skillsmith inventory purge --yes`}</code></pre>
 
   <div class="callout">
     <p class="callout-heading">Using Claude Code?</p>


### PR DESCRIPTION
## Summary
- The public docs page (`/docs/inventory`) and the CLI README both still said a purge control wasn't available yet, but `skillsmith inventory purge` shipped 2 days ago (SMI-5510, #1684).
- Replaces the stale "No purge control yet" callout with a description of `skillsmith inventory purge`, and adds a `purge` command subsection to both the website docs and the CLI README (matching the existing push/status/forget-device pattern).

This is a prerequisite for a follow-up public GitHub issue recruiting UAT design partners for cross-machine skill inventory (SMI-5397's beta→GA recruitment gate) — testers shouldn't be pointed at docs that say a shipped command doesn't exist.

Docs-only change; no source/test files touched.

## Test plan
- [x] `npx prettier --check` on both files
- [ ] Preview `/docs/inventory` after merge/deploy — confirm the purge section renders and the callout is accurate
- [ ] Confirm CLI README renders correctly on npm

SMI-5527

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>