### PR TITLE
feat(audit): local security audit engine — rug-pull + malicious-content scan (SMI-5541 Stage 1)

### DIFF
--- a/packages/cli/src/commands/audit-security.test.ts
+++ b/packages/cli/src/commands/audit-security.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview Tests for `sklx audit security` presentation (SMI-5541 Wave 2C).
+ * @module @skillsmith/cli/commands/audit-security.test
+ *
+ * The audit engine itself is unit-tested in
+ * `packages/mcp-server/src/audit/security-audit.test.ts`. Here we mock
+ * `runSecurityAudit` and cover the CLI surface: the empty-vs-findings render,
+ * the strongest-first ordering, and the `--json` passthrough.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ runSecurityAudit: vi.fn() }))
+vi.mock('@skillsmith/mcp-server/audit', () => ({ runSecurityAudit: mocks.runSecurityAudit }))
+
+import type {
+  RunSecurityAuditResult,
+  SecurityAuditFinding,
+  SecurityVerdict,
+} from '@skillsmith/mcp-server/audit'
+
+import { printFindings, runAuditSecurity } from './audit-security.js'
+
+function finding(verdict: SecurityVerdict, identifier: string): SecurityAuditFinding {
+  return {
+    kind: 'security',
+    securityId: `id-${identifier}`,
+    entry: {
+      kind: 'skill',
+      identifier,
+      source_path: `/skills/${identifier}/SKILL.md`,
+      triggerSurface: [],
+    },
+    verdict,
+    severity: verdict === 'suspicious' ? 'medium' : 'critical',
+    riskScore: 50,
+    riskDelta: verdict === 'malicious' ? null : 10,
+    newFindingCount: verdict === 'malicious' ? 0 : 1,
+    reason: `${verdict} reason for ${identifier}`,
+  }
+}
+
+function result(
+  findings: SecurityAuditFinding[],
+  summary: Partial<RunSecurityAuditResult['summary']> = {}
+): RunSecurityAuditResult {
+  return {
+    auditId: 'AUDIT1',
+    findings,
+    summary: {
+      scanned: findings.length,
+      unchanged: 0,
+      unreadable: 0,
+      hostile: findings.filter((f) => f.verdict === 'hostile').length,
+      suspicious: findings.filter((f) => f.verdict === 'suspicious').length,
+      malicious: findings.filter((f) => f.verdict === 'malicious').length,
+      durationMs: 1,
+      ...summary,
+    },
+  }
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+  mocks.runSecurityAudit.mockReset()
+})
+afterEach(() => {
+  logSpy.mockRestore()
+})
+
+const output = (): string => logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n')
+
+describe('printFindings', () => {
+  it('reports a clean bill of health when there are no findings', () => {
+    printFindings(result([], { scanned: 3 }))
+    expect(output()).toContain('No security issues found in 3')
+  })
+
+  it('warns when some skills could not be scanned (incomplete coverage)', () => {
+    printFindings(result([], { scanned: 2, unreadable: 1 }))
+    const out = output()
+    expect(out).toContain('could not be scanned')
+    expect(out).toContain('1')
+  })
+
+  it('lists findings strongest-first (hostile before suspicious)', () => {
+    printFindings(result([finding('suspicious', 'a'), finding('hostile', 'b')]))
+    const out = output()
+    expect(out).toContain('RUG-PULL')
+    expect(out).toContain('SUSPECT')
+    // hostile (RUG-PULL) must be listed before suspicious (SUSPECT).
+    expect(out.indexOf('RUG-PULL')).toBeLessThan(out.indexOf('SUSPECT'))
+  })
+
+  it('surfaces a currently-failing skill as FAILING', () => {
+    printFindings(result([finding('malicious', 'evil')]))
+    expect(output()).toContain('FAILING')
+  })
+})
+
+describe('runAuditSecurity', () => {
+  it('--json prints the raw result and skips the formatted view', async () => {
+    mocks.runSecurityAudit.mockResolvedValue(result([]))
+    await runAuditSecurity({ json: true })
+    const out = output()
+    expect(out).toContain('"auditId"')
+    expect(out).not.toContain('No security issues found')
+  })
+
+  it('default mode runs the audit and prints the formatted findings', async () => {
+    mocks.runSecurityAudit.mockResolvedValue(result([]))
+    await runAuditSecurity({ json: false })
+    expect(mocks.runSecurityAudit).toHaveBeenCalledTimes(1)
+    expect(output()).toContain('No security issues found')
+  })
+})

--- a/packages/cli/src/commands/audit-security.ts
+++ b/packages/cli/src/commands/audit-security.ts
@@ -1,0 +1,166 @@
+/**
+ * @fileoverview `sklx audit security` — local rug-pull / malicious-content scan.
+ * @module @skillsmith/cli/commands/audit-security
+ * @see SMI-5541 R0 Wave 2C (Option 1 — client-side continuous audit engine)
+ *
+ * Sibling of `sklx audit collisions` / `sklx audit advisories`. Wraps the
+ * shared `runSecurityAudit` helper from `@skillsmith/mcp-server/audit` so the
+ * scan runs where the skill content actually lives — the user's machine.
+ * Nothing leaves the device: the inventory data plane is metadata-only
+ * (ADR-124), so a server-side scan is impossible; this is the audit engine.
+ *
+ * It reads each installed skill's content, scans it with `@skillsmith/core`'s
+ * `SecurityScanner`, and — against a per-skill baseline persisted across runs
+ * — reports rug-pulls (a benign→malicious update), currently-failing skills,
+ * and material worsenings.
+ */
+
+import { Command } from 'commander'
+import chalk from 'chalk'
+import { withTelemetry } from '@skillsmith/core/telemetry'
+
+import {
+  runSecurityAudit,
+  type RunSecurityAuditResult,
+  type SecurityVerdict,
+} from '@skillsmith/mcp-server/audit'
+
+import { sanitizeError } from '../utils/sanitize.js'
+
+interface AuditSecurityOptions {
+  json: boolean
+}
+
+/** Sort key — strongest verdict first when listing findings. */
+function verdictOrder(verdict: SecurityVerdict): number {
+  switch (verdict) {
+    case 'hostile':
+      return 0
+    case 'malicious':
+      return 1
+    case 'suspicious':
+      return 2
+    default: {
+      const exhaustive: never = verdict
+      return exhaustive
+    }
+  }
+}
+
+/** Human tag per verdict (plain text — matches the `OK`/`FAIL` house style). */
+function verdictTag(verdict: SecurityVerdict): string {
+  switch (verdict) {
+    case 'hostile':
+      return chalk.red.bold('RUG-PULL')
+    case 'malicious':
+      return chalk.red('FAILING')
+    case 'suspicious':
+      return chalk.yellow('SUSPECT')
+    default: {
+      const exhaustive: never = verdict
+      return exhaustive
+    }
+  }
+}
+
+/** Warn when some skills could not be scanned — coverage was not complete. */
+function printUnreadableWarning(unreadable: number): void {
+  if (unreadable > 0) {
+    console.log(
+      chalk.yellow(
+        `WARN ${unreadable} skill(s) could not be scanned this run (unreadable content) — coverage was incomplete.`
+      )
+    )
+  }
+}
+
+function printFindings(result: RunSecurityAuditResult): void {
+  const { findings, summary } = result
+  const covered = summary.scanned + summary.unchanged
+
+  if (findings.length === 0) {
+    console.log(
+      `${chalk.green('OK')} No security issues found in ${covered} scanned skill manifest(s).`
+    )
+    printUnreadableWarning(summary.unreadable)
+    return
+  }
+
+  console.log(chalk.bold.blue('\n=== Skillsmith — Security audit ==='))
+  console.log(
+    chalk.dim(
+      `Scanned ${summary.scanned}, unchanged ${summary.unchanged}, unreadable ${summary.unreadable}.`
+    )
+  )
+  console.log(
+    `Found ${findings.length} issue(s): ` +
+      `${chalk.red.bold(String(summary.hostile))} rug-pull, ` +
+      `${chalk.red(String(summary.malicious))} failing, ` +
+      `${chalk.yellow(String(summary.suspicious))} suspicious.\n`
+  )
+
+  const sorted = [...findings].sort((a, b) => verdictOrder(a.verdict) - verdictOrder(b.verdict))
+  for (const f of sorted) {
+    console.log(
+      `${verdictTag(f.verdict)} ${chalk.bold(f.entry.identifier)} ${chalk.dim(`(${f.entry.kind})`)}`
+    )
+    console.log(`  ${f.reason}`)
+    console.log(chalk.dim(`  ${f.entry.source_path}`))
+  }
+
+  console.log(
+    chalk.dim(
+      '\nReview flagged skills before trusting them. Remove one with `sklx uninstall <skill>`, ' +
+        'or re-install it from a trusted source to reset its baseline.'
+    )
+  )
+  printUnreadableWarning(summary.unreadable)
+}
+
+async function runAuditSecurity(options: AuditSecurityOptions): Promise<void> {
+  const result = await runSecurityAudit({})
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+  printFindings(result)
+}
+
+// SMI-5128: extracted from the inline .action() closure so withTelemetry can
+// wrap it at the export boundary (SMI-5040 coverage gate).
+async function securityActionImpl(opts: Record<string, boolean | undefined>): Promise<void> {
+  try {
+    await runAuditSecurity({ json: opts['json'] === true })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : sanitizeError(error)
+    console.error(chalk.red('Error:'), message)
+    process.exit(1)
+  }
+}
+
+export const securityAction = withTelemetry(securityActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'security',
+  extractFramework: () => 'cli',
+})
+
+/**
+ * Build the `audit security` subcommand. Registered as a sibling of
+ * `audit collisions` / `audit advisories` in `audit.ts`.
+ */
+export function createAuditSecuritySubcommand(): Command {
+  return new Command('security')
+    .description(
+      "Scan each installed skill's SKILL.md for malicious content and rug-pull " +
+        'updates (runs locally, no content leaves your machine; bundled scripts ' +
+        'are not yet scanned)'
+    )
+    .option('--json', 'Emit the full result as JSON; no formatted output', false)
+    .action(securityAction)
+}
+
+// Internal exports for tests.
+export { runAuditSecurity, printFindings }
+export type { AuditSecurityOptions }
+
+export default createAuditSecuritySubcommand

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -27,6 +27,7 @@ import { sanitizeError } from '../utils/sanitize.js'
 import { requireTier } from '../utils/require-tier.js'
 import { createAuditCollisionsSubcommand } from './audit-collisions.js'
 import { createAuditSourcesSubcommand } from './audit-sources.js'
+import { createAuditSecuritySubcommand } from './audit-security.js'
 
 // ============================================================================
 // Severity display helpers
@@ -219,6 +220,8 @@ export function createAuditCommand(): Command {
   audit.addCommand(createAuditCollisionsSubcommand())
   // SMI-5407 — register `sources` sibling subcommand.
   audit.addCommand(createAuditSourcesSubcommand())
+  // SMI-5541 — register `security` sibling subcommand (local rug-pull scan).
+  audit.addCommand(createAuditSecuritySubcommand())
 
   // Deprecation alias: `sklx audit <skill-id>` → forward to `advisories`.
   // Implemented as a default-action on the parent: when Commander is invoked

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,11 @@ export { L1Cache, L2Cache, TieredCache } from './cache/index.js'
 
 // Security
 export { SecurityScanner } from './security/index.js'
+// SMI-5535 R0 Wave 2A: hostile-update (rug-pull) comparator — public API, used
+// by the client-side security audit (SMI-5541). Mirrors the SecurityScanner
+// re-export style above (a direct named re-export from the security barrel).
+export { compareScanReports, DEFAULT_RISK_THRESHOLD } from './security/index.js'
+export type { HostileUpdateVerdict } from './security/index.js'
 
 // SMI-898: Path Traversal Protection
 export {

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -18,6 +18,11 @@ export type {
   ScannerOptions,
   RiskScoreBreakdown,
 } from './scanner/index.js'
+// SMI-5535 R0 Wave 2A: the hostile-update (rug-pull) comparator is a public
+// feature; surface it (+ its default threshold + verdict type) through the
+// security barrel so it is reachable from `@skillsmith/core`.
+export { compareScanReports, DEFAULT_RISK_THRESHOLD } from './scanner/index.js'
+export type { HostileUpdateVerdict } from './scanner/index.js'
 
 // Sanitization
 export {

--- a/packages/mcp-server/src/audit/index.ts
+++ b/packages/mcp-server/src/audit/index.ts
@@ -42,6 +42,28 @@ export type {
   AuditReportWriteResult,
 } from './audit-report-writer.js'
 
+// SMI-5541 Wave 2C — local security audit (client-side rug-pull / hostile-update
+// producer that feeds the shipped 2A comparator; content is client-only per ADR-124).
+export { runSecurityAudit } from './security-audit.js'
+export type {
+  RunSecurityAuditOptions,
+  RunSecurityAuditResult,
+  SecurityAuditFinding,
+  SecurityAuditSummary,
+  SecurityVerdict,
+} from './security-audit.types.js'
+export {
+  defaultBaselinePath,
+  loadSecurityBaseline,
+  saveSecurityBaseline,
+  SECURITY_BASELINE_VERSION,
+} from './security-baseline.js'
+export type {
+  SecurityBaseline,
+  SecurityBaselineEntry,
+  StoredScanReport,
+} from './security-baseline.js'
+
 export { emitAuditCompleteEvent } from '../tools/namespace-audit/telemetry.js'
 export type {
   AuditCompleteContext,

--- a/packages/mcp-server/src/audit/security-audit.test.ts
+++ b/packages/mcp-server/src/audit/security-audit.test.ts
@@ -1,0 +1,347 @@
+/**
+ * @fileoverview Unit tests for the local security audit (SMI-5541 Wave 2C).
+ * @module @skillsmith/mcp-server/audit/security-audit.test
+ *
+ * Orchestration (baseline persistence, verdict priority, pruning, fail-safe)
+ * is tested against INJECTED `ScanReport`s so it is independent of scanner
+ * pattern churn. One integration test exercises the real `SecurityScanner`
+ * wiring on benign content (no false positive).
+ */
+
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { ScanReport, SecurityFinding } from '@skillsmith/core'
+
+import { runSecurityAudit } from './security-audit.js'
+import { loadSecurityBaseline } from './security-baseline.js'
+import type { InventoryEntry } from '../utils/local-inventory.types.js'
+
+let tmpDir: string
+let baselinePath: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sec-audit-'))
+  baselinePath = path.join(tmpDir, 'security-baseline.json')
+})
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+// --- fixtures --------------------------------------------------------------
+
+const ZERO_BREAKDOWN: ScanReport['riskBreakdown'] = {
+  jailbreak: 0,
+  socialEngineering: 0,
+  promptLeaking: 0,
+  dataExfiltration: 0,
+  privilegeEscalation: 0,
+  suspiciousCode: 0,
+  sensitivePaths: 0,
+  externalUrls: 0,
+  aiDefence: 0,
+  ssrf: 0,
+  pii: 0,
+  codeExecution: 0,
+  obfuscatedDirective: 0,
+}
+
+function report(
+  skillId: string,
+  opts: { passed: boolean; riskScore: number; findings?: SecurityFinding[] }
+): ScanReport {
+  return {
+    skillId,
+    passed: opts.passed,
+    riskScore: opts.riskScore,
+    findings: opts.findings ?? [],
+    riskBreakdown: { ...ZERO_BREAKDOWN },
+    scannedAt: new Date('2026-07-04T00:00:00.000Z'),
+    scanDurationMs: 1,
+  }
+}
+
+const CRITICAL_EXFIL: SecurityFinding = {
+  type: 'data_exfiltration',
+  severity: 'critical',
+  message: 'exfiltrate ~/.ssh/id_rsa to evil.example.com',
+  inDocumentationContext: false,
+}
+
+function entry(
+  identifier: string,
+  kind: InventoryEntry['kind'] = 'skill',
+  sourcePath?: string
+): InventoryEntry {
+  return {
+    kind,
+    identifier,
+    source_path: sourcePath ?? `/skills/${identifier}/SKILL.md`,
+    triggerSurface: [],
+  }
+}
+
+/** A `scan` stub that throws — proves the unchanged path never re-scans. */
+const scanMustNotRun = (): ScanReport => {
+  throw new Error('scan() should not be called for unchanged content')
+}
+
+// --- tests -----------------------------------------------------------------
+
+describe('runSecurityAudit', () => {
+  it('first-sight benign skill → no finding, baseline established', async () => {
+    const e = entry('foo')
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => 'benign-v1',
+      scan: () => report('foo', { passed: true, riskScore: 5 }),
+    })
+
+    expect(res.findings).toHaveLength(0)
+    expect(res.summary.scanned).toBe(1)
+    const base = loadSecurityBaseline(baselinePath)
+    expect(base.skills[e.source_path]?.report.passed).toBe(true)
+  })
+
+  it('first-sight failing skill → malicious finding (critical)', async () => {
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [entry('evil')],
+      readContent: () => 'bad',
+      scan: () => report('evil', { passed: false, riskScore: 80, findings: [CRITICAL_EXFIL] }),
+    })
+
+    expect(res.findings).toHaveLength(1)
+    expect(res.findings[0]?.verdict).toBe('malicious')
+    expect(res.findings[0]?.severity).toBe('critical')
+    expect(res.findings[0]?.riskDelta).toBeNull()
+    expect(res.summary.malicious).toBe(1)
+  })
+
+  it('benign baseline → malicious content change = hostile rug-pull', async () => {
+    const e = entry('foo')
+    // Establish a benign baseline.
+    await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => 'v1',
+      scan: () => report('foo', { passed: true, riskScore: 5 }),
+    })
+    // Content changes and now fails.
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => 'v2-malicious',
+      scan: () => report('foo', { passed: false, riskScore: 80, findings: [CRITICAL_EXFIL] }),
+    })
+
+    expect(res.findings).toHaveLength(1)
+    expect(res.findings[0]?.verdict).toBe('hostile')
+    expect(res.findings[0]?.riskDelta).toBe(75)
+    expect(res.findings[0]?.newFindingCount).toBe(1)
+    expect(res.summary.hostile).toBe(1)
+  })
+
+  it('unchanged content → skipped, no re-scan, no finding', async () => {
+    const e = entry('foo')
+    await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => 'v1',
+      scan: () => report('foo', { passed: true, riskScore: 5 }),
+    })
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => 'v1',
+      scan: scanMustNotRun,
+    })
+
+    expect(res.findings).toHaveLength(0)
+    expect(res.summary.scanned).toBe(0)
+    expect(res.summary.unchanged).toBe(1)
+  })
+
+  it('persistently-failing unchanged skill → still surfaced as malicious (no re-scan)', async () => {
+    const e = entry('evil')
+    await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => 'bad',
+      scan: () => report('evil', { passed: false, riskScore: 80, findings: [CRITICAL_EXFIL] }),
+    })
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => 'bad',
+      scan: scanMustNotRun,
+    })
+
+    expect(res.findings).toHaveLength(1)
+    expect(res.findings[0]?.verdict).toBe('malicious')
+    expect(res.summary.unchanged).toBe(1)
+  })
+
+  it('unreadable content → counted as unreadable (not unchanged), no finding, no throw', async () => {
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [entry('foo')],
+      readContent: () => null,
+      scan: () => report('foo', { passed: true, riskScore: 1 }),
+    })
+
+    expect(res.findings).toHaveLength(0)
+    expect(res.summary.unreadable).toBe(1)
+    expect(res.summary.unchanged).toBe(0)
+    expect(res.summary.scanned).toBe(0)
+  })
+
+  it('a transient unreadable run PRESERVES the baseline (rug-pull still detected next run)', async () => {
+    const e = entry('foo')
+    // Run 1: establish a benign baseline.
+    await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => 'v1',
+      scan: () => report('foo', { passed: true, riskScore: 5 }),
+    })
+    // Run 2: a transient read failure. The prior baseline must NOT be pruned.
+    await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => null,
+      scan: scanMustNotRun,
+    })
+    expect(loadSecurityBaseline(baselinePath).skills[e.source_path]).toBeDefined()
+    // Run 3: content changes to malicious → still a HOSTILE rug-pull, NOT a
+    // first-sight `malicious` (which is what a pruned baseline would produce).
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => 'v2-malicious',
+      scan: () => report('foo', { passed: false, riskScore: 80, findings: [CRITICAL_EXFIL] }),
+    })
+    expect(res.findings[0]?.verdict).toBe('hostile')
+  })
+
+  it('a scanner throw is isolated to one skill; the batch continues, baseline preserved', async () => {
+    const a = entry('a')
+    const b = entry('b')
+    // Seed a benign baseline for `a`.
+    await runSecurityAudit({
+      baselinePath,
+      inventory: [a],
+      readContent: () => 'a-v1',
+      scan: () => report('a', { passed: true, riskScore: 5 }),
+    })
+    // `a`'s scan throws (content changed → re-scan path); `b` scans fine.
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [a, b],
+      readContent: (p) => (p === a.source_path ? 'a-v2' : 'b-v1'),
+      scan: (id) => {
+        if (id === 'a') throw new Error('scanner blew up on a')
+        return report(id, { passed: true, riskScore: 2 })
+      },
+    })
+    expect(res.summary.unreadable).toBe(1) // a
+    expect(res.summary.scanned).toBe(1) // b
+    // `a`'s prior baseline survives the throw; `b` is newly baselined.
+    const base = loadSecurityBaseline(baselinePath)
+    expect(base.skills[a.source_path]).toBeDefined()
+    expect(base.skills[b.source_path]).toBeDefined()
+  })
+
+  it('a threshold change re-scans rather than trusting a verdict from a different bar', async () => {
+    const e = entry('foo')
+    await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => 'v1',
+      riskThreshold: 40,
+      scan: () => report('foo', { passed: true, riskScore: 5 }),
+    })
+    // Same content, DIFFERENT threshold → must NOT take the unchanged fast path.
+    let scanCalls = 0
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [e],
+      readContent: () => 'v1',
+      riskThreshold: 30,
+      scan: () => {
+        scanCalls += 1
+        return report('foo', { passed: true, riskScore: 5 })
+      },
+    })
+    expect(scanCalls).toBe(1)
+    expect(res.summary.scanned).toBe(1)
+    expect(res.summary.unchanged).toBe(0)
+  })
+
+  it('non-scannable kinds (claude_md_rule) are ignored', async () => {
+    const rule = entry('CLAUDE.md', 'claude_md_rule', '/home/u/.claude/CLAUDE.md')
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [rule],
+      readContent: () => 'do a thing',
+      scan: () => report('x', { passed: false, riskScore: 99, findings: [CRITICAL_EXFIL] }),
+    })
+
+    expect(res.findings).toHaveLength(0)
+    expect(res.summary.scanned).toBe(0)
+    const base = loadSecurityBaseline(baselinePath)
+    expect(base.skills[rule.source_path]).toBeUndefined()
+  })
+
+  it('prunes uninstalled skills from the baseline', async () => {
+    const a = entry('a')
+    const b = entry('b')
+    await runSecurityAudit({
+      baselinePath,
+      inventory: [a, b],
+      readContent: (p) => p,
+      scan: (id) => report(id, { passed: true, riskScore: 1 }),
+    })
+    // Re-run with only `a`, content changed so it is re-scanned.
+    await runSecurityAudit({
+      baselinePath,
+      inventory: [a],
+      readContent: (p) => `${p}-changed`,
+      scan: (id) => report(id, { passed: true, riskScore: 1 }),
+    })
+
+    const base = loadSecurityBaseline(baselinePath)
+    expect(Object.keys(base.skills)).toEqual([a.source_path])
+  })
+
+  it('corrupt baseline file → treated as empty (first-sight), no throw', async () => {
+    fs.mkdirSync(path.dirname(baselinePath), { recursive: true })
+    fs.writeFileSync(baselinePath, 'not json {{{')
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [entry('foo')],
+      readContent: () => 'x',
+      scan: () => report('foo', { passed: true, riskScore: 1 }),
+    })
+
+    expect(res.findings).toHaveLength(0)
+    expect(res.summary.scanned).toBe(1)
+  })
+
+  it('integration: the real SecurityScanner is wired and does not flag benign content', async () => {
+    const res = await runSecurityAudit({
+      baselinePath,
+      inventory: [entry('hello-world')],
+      // A plain, benign skill body — the real scanner should pass it.
+      readContent: () =>
+        '# Hello World\n\nThis skill greets the user politely. It has no code, URLs, or secrets.\n',
+      // No `scan` injected → exercises `new SecurityScanner().scan`.
+    })
+
+    expect(res.summary.scanned).toBe(1)
+    expect(res.findings).toHaveLength(0)
+  })
+})

--- a/packages/mcp-server/src/audit/security-audit.ts
+++ b/packages/mcp-server/src/audit/security-audit.ts
@@ -1,0 +1,296 @@
+/**
+ * @fileoverview Local security audit (SMI-5541 Wave 2C, Option 1).
+ * @module @skillsmith/mcp-server/audit/security-audit
+ *
+ * The PRODUCER that feeds the shipped 2A rug-pull comparator
+ * (`compareScanReports`, SMI-5535). For each installed skill it reads the
+ * on-disk SKILL.md/command/agent content, scans it with `@skillsmith/core`'s
+ * `SecurityScanner`, and — against a per-skill baseline persisted across runs
+ * (`security-baseline.ts`) — classifies the skill's current security posture:
+ *
+ *   - `hostile`    — a benign→malicious rug-pull between the last baseline and
+ *     now (the differentiated 2A signal: `compareScanReports` verdict).
+ *   - `malicious`  — the skill FAILS the scanner right now (whether first-sight
+ *     or persistently). Surfaced every run so the in-tool audit always shows
+ *     the current posture, not just deltas.
+ *   - `suspicious` — a material worsening that did not fail the scanner.
+ *
+ * One finding per skill, strongest label wins (hostile > malicious >
+ * suspicious). The baseline is rebuilt each run from the currently-present
+ * skills only (uninstalled skills are pruned → the store stays bounded), and
+ * always advances to the current scan so the NEXT run compares against the
+ * most-recent known state (a fix-then-rebreak still re-detects as hostile).
+ *
+ * Design note — content lives ONLY on the client (ADR-124 keeps the inventory
+ * data plane metadata-only, so no server-side scan is possible). This is why
+ * the continuous audit runs here, in the CLI/MCP, where the content is.
+ */
+
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+
+import { SecurityScanner, compareScanReports, DEFAULT_RISK_THRESHOLD } from '@skillsmith/core'
+import type { ScanReport } from '@skillsmith/core'
+
+import { scanLocalInventory } from '../utils/local-inventory.js'
+import type { InventoryEntry } from '../utils/local-inventory.types.js'
+import { newAuditId } from './audit-history.js'
+import {
+  defaultBaselinePath,
+  emptyBaseline,
+  loadSecurityBaseline,
+  reviveReport,
+  saveSecurityBaseline,
+  serializeReport,
+  type SecurityBaseline,
+} from './security-baseline.js'
+import type {
+  RunSecurityAuditOptions,
+  RunSecurityAuditResult,
+  SecurityAuditFinding,
+  SecurityAuditSummary,
+  SecurityVerdict,
+} from './security-audit.types.js'
+
+/**
+ * Only installed skills / commands / agents carry scannable content. The
+ * user's own `CLAUDE.md` (`claude_md_rule`) is their config, not an installed
+ * artifact — excluded so the audit never flags a user's own instructions.
+ */
+const SCANNABLE_KINDS: ReadonlySet<InventoryEntry['kind']> = new Set(['skill', 'command', 'agent'])
+
+function sha256(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex')
+}
+
+/** Bounded, never-throwing default content reader. Returns null on any failure. */
+function defaultReadContent(absPath: string): string | null {
+  try {
+    return fs.readFileSync(absPath, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+function severityFor(verdict: SecurityVerdict): 'critical' | 'medium' {
+  return verdict === 'suspicious' ? 'medium' : 'critical'
+}
+
+/** Count of high/critical findings — the actionable subset for the reason line. */
+function seriousCount(report: ScanReport): number {
+  return report.findings.filter((f) => f.severity === 'high' || f.severity === 'critical').length
+}
+
+function buildFinding(params: {
+  auditId: string
+  entry: InventoryEntry
+  verdict: SecurityVerdict
+  riskScore: number
+  riskDelta: number | null
+  newFindingCount: number
+  reason: string
+}): SecurityAuditFinding {
+  const { auditId, entry, verdict, riskScore, riskDelta, newFindingCount, reason } = params
+  return {
+    kind: 'security',
+    securityId: sha256(`${auditId}:${entry.source_path}:${verdict}`).slice(0, 16),
+    entry,
+    verdict,
+    severity: severityFor(verdict),
+    riskScore,
+    riskDelta,
+    newFindingCount,
+    reason,
+  }
+}
+
+/**
+ * INTERNAL test seams — deliberately NOT exported (and NOT part of the public
+ * `RunSecurityAuditOptions`), so the published entry point cannot accept a stub
+ * scanner / reader that would silently neuter the audit while still reporting a
+ * plausible count. The co-located test passes these via the same options bag
+ * (the parameter type below is the intersection).
+ */
+interface SecurityAuditSeams {
+  /** Override the baseline store path. */
+  baselinePath?: string
+  /** Override the content reader; returns null on failure, never throws. */
+  readContent?: (absPath: string) => string | null
+  /** Override the run's audit id (default: a fresh ULID). */
+  auditId?: string
+  /** Override the scanner with a deterministic stub. */
+  scan?: (skillId: string, content: string) => ScanReport
+}
+
+/**
+ * Run the local security audit over the current inventory. Stateless w.r.t.
+ * its own result, but it reads AND advances the per-skill baseline so
+ * rug-pulls are detected on the transition run.
+ */
+export async function runSecurityAudit(
+  opts: RunSecurityAuditOptions & SecurityAuditSeams = {}
+): Promise<RunSecurityAuditResult> {
+  const startedAt = process.hrtime.bigint()
+
+  const homeDir = opts.homeDir ?? os.homedir()
+  const auditId = opts.auditId ?? newAuditId()
+  const threshold = opts.riskThreshold ?? DEFAULT_RISK_THRESHOLD
+  const readContent = opts.readContent ?? defaultReadContent
+  const baselinePath = opts.baselinePath ?? defaultBaselinePath(homeDir)
+
+  const inventory = opts.inventory ?? (await scanLocalInventory({ homeDir })).entries
+
+  const prior = loadSecurityBaseline(baselinePath)
+  // Rebuilt from currently-present skills only → prunes GENUINELY-uninstalled
+  // skills. A skill we simply couldn't audit this run is carried forward (see
+  // `preserve`), NOT pruned.
+  const next: SecurityBaseline = emptyBaseline()
+  // One scanner instance for the whole run (its config must match `threshold`).
+  const scanner = new SecurityScanner({ riskThreshold: threshold })
+  const scan = opts.scan ?? ((skillId: string, content: string) => scanner.scan(skillId, content))
+  const nowIso = (): string => new Date().toISOString()
+
+  const findings: SecurityAuditFinding[] = []
+  let scanned = 0
+  let unchanged = 0
+  let unreadable = 0
+
+  // Couldn't audit this skill this run (unreadable content or a scanner throw):
+  // carry its prior baseline forward so a transient hiccup never masquerades as
+  // an uninstall — which would prune the baseline and downgrade a later
+  // rug-pull to a first-sight `malicious`. Count it separately so coverage is
+  // honestly reported, never folded into "unchanged".
+  const preserve = (entry: InventoryEntry): void => {
+    const priorEntry = prior.skills[entry.source_path]
+    if (priorEntry) next.skills[entry.source_path] = priorEntry
+    unreadable += 1
+  }
+
+  for (const entry of inventory) {
+    if (!SCANNABLE_KINDS.has(entry.kind)) continue
+
+    const content = readContent(entry.source_path)
+    if (content === null) {
+      preserve(entry)
+      continue
+    }
+
+    const contentHash = sha256(content)
+    const priorEntry = prior.skills[entry.source_path]
+    // "Unchanged" requires identical bytes AND the same threshold the stored
+    // verdict was computed under — a threshold change re-scans rather than
+    // trusting a verdict from a different bar (compareScanReports contract).
+    const sameThreshold = priorEntry !== undefined && priorEntry.threshold === threshold
+    const isUnchanged = sameThreshold && priorEntry.contentHash === contentHash
+
+    // Current report: reuse the stored one byte-for-byte when unchanged (no
+    // re-scan) but STILL evaluate posture (a persistently-failing skill keeps
+    // surfacing); else scan — isolating a scanner throw to THIS skill so one
+    // bad skill never aborts the whole batch.
+    let current: ScanReport
+    if (isUnchanged) {
+      current = reviveReport(priorEntry.report)
+      unchanged += 1
+    } else {
+      try {
+        current = scan(entry.identifier, content)
+      } catch {
+        preserve(entry)
+        continue
+      }
+      scanned += 1
+    }
+
+    // Rug-pull detection needs a prior produced under the SAME threshold AND an
+    // actual content change (an unchanged skill can't have transitioned).
+    let transition: SecurityVerdict | null = null
+    let riskDelta: number | null = null
+    let newFindingCount = 0
+    let transitionReason = ''
+    if (priorEntry && !isUnchanged && sameThreshold) {
+      const verdict = compareScanReports(reviveReport(priorEntry.report), current, threshold)
+      riskDelta = verdict.riskDelta
+      newFindingCount = verdict.newFindings.length
+      transitionReason = verdict.reason
+      if (verdict.verdict === 'hostile' || verdict.verdict === 'suspicious') {
+        transition = verdict.verdict
+      }
+    }
+
+    // One finding per skill; strongest label wins: hostile > malicious > suspicious.
+    if (transition === 'hostile') {
+      findings.push(
+        buildFinding({
+          auditId,
+          entry,
+          verdict: 'hostile',
+          riskScore: current.riskScore,
+          riskDelta,
+          newFindingCount,
+          reason: transitionReason,
+        })
+      )
+    } else if (!current.passed) {
+      const serious = seriousCount(current)
+      const reason = priorEntry
+        ? `Installed skill still fails the security scan (risk ${current.riskScore}, ${serious} high/critical finding(s)).`
+        : `Installed skill fails the security scan (risk ${current.riskScore}, ${serious} high/critical finding(s)); no prior baseline — establishing one now.`
+      findings.push(
+        buildFinding({
+          auditId,
+          entry,
+          verdict: 'malicious',
+          riskScore: current.riskScore,
+          riskDelta: null,
+          newFindingCount: 0,
+          reason,
+        })
+      )
+    } else if (transition === 'suspicious') {
+      findings.push(
+        buildFinding({
+          auditId,
+          entry,
+          verdict: 'suspicious',
+          riskScore: current.riskScore,
+          riskDelta,
+          newFindingCount,
+          reason: transitionReason,
+        })
+      )
+    }
+
+    // Advance the baseline: on the unchanged fast path carry the prior entry
+    // forward but refresh `updatedAt` (it WAS re-verified this run); else store
+    // the fresh scan stamped with the threshold it was produced under.
+    next.skills[entry.source_path] = isUnchanged
+      ? { ...priorEntry, updatedAt: nowIso() }
+      : {
+          contentHash,
+          threshold,
+          report: serializeReport(current),
+          updatedAt: current.scannedAt.toISOString(),
+        }
+  }
+
+  // Best-effort persist: a lost baseline simply re-establishes next run.
+  try {
+    saveSecurityBaseline(baselinePath, next)
+  } catch {
+    /* swallow — see security-baseline.ts fail-safe contract */
+  }
+
+  const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000
+  const summary: SecurityAuditSummary = {
+    scanned,
+    unchanged,
+    unreadable,
+    hostile: findings.filter((f) => f.verdict === 'hostile').length,
+    suspicious: findings.filter((f) => f.verdict === 'suspicious').length,
+    malicious: findings.filter((f) => f.verdict === 'malicious').length,
+    durationMs,
+  }
+
+  return { auditId, findings, summary }
+}

--- a/packages/mcp-server/src/audit/security-audit.types.ts
+++ b/packages/mcp-server/src/audit/security-audit.types.ts
@@ -1,0 +1,115 @@
+/**
+ * @fileoverview Type vocabulary for the local security audit (SMI-5541 Wave
+ *               2C, Option 1 — client-side continuous audit engine).
+ * @module @skillsmith/mcp-server/audit/security-audit.types
+ *
+ * The security audit is the PRODUCER that feeds the shipped 2A comparator
+ * (`compareScanReports`, SMI-5535). It scans each installed skill's on-disk
+ * content with `@skillsmith/core`'s `SecurityScanner`, compares the current
+ * `ScanReport` against a per-skill baseline persisted across runs, and emits
+ * one finding per skill whose security posture is hostile / suspicious /
+ * currently-failing. Mirrors `rot-detector.types.ts`'s shape (a finding type
+ * plus an options type) so the report writer + digest can consume it
+ * uniformly.
+ */
+
+import type { InventoryEntry } from '../utils/local-inventory.types.js'
+
+/**
+ * The three user-facing security verdicts.
+ *
+ * - `hostile`   — a previously-passing skill introduced new high/critical
+ *   findings (or crossed the risk threshold): a genuine benign→malicious
+ *   rug-pull, per `compareScanReports`.
+ * - `suspicious`— an update materially worsened the skill's risk without
+ *   meeting the hostile bar (new medium findings or a material score rise).
+ * - `malicious` — the skill FAILS the scanner right now and we have no prior
+ *   baseline to prove a transition (freshly-tracked or side-loaded skill that
+ *   never passed through the install-time quarantine gate). Not a rug-pull,
+ *   but an actively-flagged skill worth surfacing.
+ */
+export type SecurityVerdict = 'hostile' | 'suspicious' | 'malicious'
+
+/**
+ * A single security finding for one inventory entry. One finding per skill —
+ * the strongest verdict wins (hostile > suspicious; `malicious` only applies
+ * when there is no baseline to compare against).
+ */
+export interface SecurityAuditFinding {
+  kind: 'security'
+  /** Stable per-finding id — sha256(auditId:source_path:verdict).slice(0,16). */
+  securityId: string
+  /** The scanned entry (skill/command/agent). */
+  entry: InventoryEntry
+  verdict: SecurityVerdict
+  /**
+   * Digest severity, derived from the verdict: `hostile`/`malicious` →
+   * `critical`, `suspicious` → `medium`. Kept explicit so the email digest +
+   * report writer can sort/threshold without re-deriving.
+   */
+  severity: 'critical' | 'medium'
+  /** Current scan risk score (0-100). */
+  riskScore: number
+  /**
+   * `current.riskScore - previous.riskScore` for hostile/suspicious; `null`
+   * for `malicious` (no prior baseline).
+   */
+  riskDelta: number | null
+  /** How many findings are new vs the baseline (0 for `malicious`). */
+  newFindingCount: number
+  /** One concrete human-readable sentence citing the deciding signal. */
+  reason: string
+}
+
+/** Per-run counts for the summary + the email digest header. */
+export interface SecurityAuditSummary {
+  /** Entries freshly scanned this run (content new or changed since baseline). */
+  scanned: number
+  /** Entries whose content was byte-identical to the baseline (verified, not re-scanned). */
+  unchanged: number
+  /**
+   * Entries that could NOT be audited this run — content unreadable, or the
+   * scan threw. Surfaced separately (never folded into `unchanged`) so the
+   * user knows coverage was incomplete; the skill's prior baseline is
+   * preserved rather than pruned.
+   */
+  unreadable: number
+  hostile: number
+  suspicious: number
+  malicious: number
+  durationMs: number
+}
+
+/** Result returned to CLI / MCP / digest callers. */
+export interface RunSecurityAuditResult {
+  /** ULID for this run (folded into each finding's `securityId`). */
+  auditId: string
+  findings: SecurityAuditFinding[]
+  summary: SecurityAuditSummary
+}
+
+/**
+ * PUBLIC input for {@link runSecurityAudit}. All fields optional.
+ *
+ * Deliberately holds NO injectable overrides for the scanner, the content
+ * reader, or the baseline path: the production entry point must not be able to
+ * accept a stub scanner that neuters the audit. Those seams live in the
+ * non-exported `SecurityAuditSeams` type in `security-audit.ts`, reachable
+ * only by the co-located test.
+ */
+export interface RunSecurityAuditOptions {
+  /** Override `os.homedir()` — also relocates the default baseline path. */
+  homeDir?: string
+  /**
+   * Inject a pre-computed inventory (e.g. reuse `runInventoryAudit`'s scan).
+   * When omitted, `runSecurityAudit` scans the inventory itself.
+   */
+  inventory?: InventoryEntry[]
+  /**
+   * Scanner risk threshold. Recorded in each baseline entry; a skill whose
+   * baseline was produced under a DIFFERENT threshold is re-scanned rather
+   * than trusted (the `compareScanReports` caller contract). Defaults to 40 —
+   * the `SecurityScanner` + comparator default.
+   */
+  riskThreshold?: number
+}

--- a/packages/mcp-server/src/audit/security-baseline.ts
+++ b/packages/mcp-server/src/audit/security-baseline.ts
@@ -1,0 +1,149 @@
+/**
+ * @fileoverview Per-skill security baseline store (SMI-5541 Wave 2C).
+ * @module @skillsmith/mcp-server/audit/security-baseline
+ *
+ * The security audit needs the PREVIOUS `ScanReport` per skill to feed
+ * `compareScanReports(previous, current)` and detect a benign→malicious
+ * rug-pull. No cross-run store existed (`audit-history.ts` persists only
+ * whole-run collision results under a fresh ULID each run) — this module is
+ * that store: a single JSON keyed by the skill's absolute `source_path`,
+ * holding the last scan's content hash + report.
+ *
+ * Fail-safe by construction: a missing OR corrupt baseline loads as EMPTY
+ * (never throws) — the audit then treats every skill as first-sight
+ * (`malicious` if it fails now, otherwise it establishes a fresh baseline).
+ * That degrades toward showing findings, never toward silently hiding a
+ * rug-pull because a JSON blob was unreadable.
+ */
+
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import type { ScanReport, SecurityFinding } from '@skillsmith/core'
+
+// `RiskScoreBreakdown` is not re-exported from the `@skillsmith/core` root
+// barrel (only `ScanReport`/`SecurityFinding` are), so derive the breakdown
+// type from `ScanReport` itself — no dependency on the barrel exporting the
+// breakdown type by name.
+type RiskScoreBreakdown = ScanReport['riskBreakdown']
+
+/** Current on-disk schema version. Bumped only on a breaking shape change. */
+export const SECURITY_BASELINE_VERSION = 1 as const
+
+/**
+ * A `ScanReport` with `scannedAt` serialized to an ISO string (JSON has no
+ * Date). Everything else is JSON-native. `compareScanReports` reads only
+ * `passed` / `riskScore` / `findings`, so a revived report is fully valid.
+ */
+export interface StoredScanReport {
+  skillId: string
+  passed: boolean
+  findings: SecurityFinding[]
+  riskScore: number
+  riskBreakdown: RiskScoreBreakdown
+  scannedAt: string
+  scanDurationMs: number
+}
+
+/** One baseline row: the last content hash + report for a skill. */
+export interface SecurityBaselineEntry {
+  contentHash: string
+  /**
+   * Risk threshold the stored `report` (and its `passed`) was produced under.
+   * The unchanged fast path trusts the stored verdict only when the current
+   * run's threshold matches this — otherwise the skill is re-scanned, honoring
+   * the `compareScanReports` caller contract (both reports at one threshold).
+   */
+  threshold: number
+  report: StoredScanReport
+  updatedAt: string
+}
+
+/** The whole store, keyed by absolute `source_path`. */
+export interface SecurityBaseline {
+  version: typeof SECURITY_BASELINE_VERSION
+  skills: Record<string, SecurityBaselineEntry>
+}
+
+/** Absolute path to the baseline store, `~/.skillsmith/audits/security-baseline.json`. */
+export function defaultBaselinePath(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, '.skillsmith', 'audits', 'security-baseline.json')
+}
+
+/** A fresh, empty baseline. */
+export function emptyBaseline(): SecurityBaseline {
+  return { version: SECURITY_BASELINE_VERSION, skills: {} }
+}
+
+/**
+ * Load the baseline. Returns an EMPTY baseline on any failure (absent file,
+ * unreadable, invalid JSON, wrong shape, or a version we don't understand) —
+ * never throws. A version mismatch is treated as empty (safe re-baseline)
+ * rather than a hard error, so a forward-compat store can't wedge the audit.
+ */
+export function loadSecurityBaseline(baselinePath: string): SecurityBaseline {
+  let raw: string
+  try {
+    raw = fs.readFileSync(baselinePath, 'utf-8')
+  } catch {
+    return emptyBaseline()
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      (parsed as { version?: unknown }).version !== SECURITY_BASELINE_VERSION ||
+      typeof (parsed as { skills?: unknown }).skills !== 'object' ||
+      (parsed as { skills?: unknown }).skills === null
+    ) {
+      return emptyBaseline()
+    }
+    return parsed as SecurityBaseline
+  } catch {
+    return emptyBaseline()
+  }
+}
+
+/**
+ * Atomically persist the baseline (tmp write + rename, so a crash mid-write
+ * never leaves a truncated store) with owner-only perms — it embeds scan
+ * findings. Directory is created if absent. Best-effort: a write failure is
+ * swallowed by the caller's try/catch (a lost baseline just re-establishes
+ * next run); this function itself surfaces the error for tests.
+ */
+export function saveSecurityBaseline(baselinePath: string, baseline: SecurityBaseline): void {
+  const dir = path.dirname(baselinePath)
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+  // Unique tmp suffix so two concurrent audits can't clobber each other's tmp.
+  const tmp = `${baselinePath}.tmp-${process.pid}-${process.hrtime.bigint()}`
+  fs.writeFileSync(tmp, JSON.stringify(baseline, null, 2), { mode: 0o600 })
+  fs.renameSync(tmp, baselinePath)
+}
+
+/** Serialize a live `ScanReport` (Date → ISO) for storage. */
+export function serializeReport(report: ScanReport): StoredScanReport {
+  return {
+    skillId: report.skillId,
+    passed: report.passed,
+    findings: report.findings,
+    riskScore: report.riskScore,
+    riskBreakdown: report.riskBreakdown,
+    scannedAt: report.scannedAt.toISOString(),
+    scanDurationMs: report.scanDurationMs,
+  }
+}
+
+/** Revive a `StoredScanReport` (ISO → Date) into a `ScanReport` for comparison. */
+export function reviveReport(stored: StoredScanReport): ScanReport {
+  return {
+    skillId: stored.skillId,
+    passed: stored.passed,
+    findings: stored.findings,
+    riskScore: stored.riskScore,
+    riskBreakdown: stored.riskBreakdown,
+    scannedAt: new Date(stored.scannedAt),
+    scanDurationMs: stored.scanDurationMs,
+  }
+}


### PR DESCRIPTION
## R0 Wave 2C Stage 1 — local security audit engine (SMI-5541)

The continuous personal audit, **Option 1**: it runs **client-side**, where skill content actually lives. The inventory data plane is metadata-only by design (ADR-124), so a server-side scan has ~0% coverage of real inventory — the audit must run in the CLI/MCP. This PR is the **engine**; the email-notification channel (Stage 2: `audit-notify` + `audit-unsubscribe` edge fns + digest) stacks on top and is where the prod checkpoint lives. **No prod surface changes here** — pure `packages/` code.

Part of SMI-5541 (Stage 1 of 2). Does not close it.

### What it does
`runSecurityAudit` (`packages/mcp-server/src/audit/security-audit.ts`) is the missing **producer** for the shipped 2A rug-pull comparator (`compareScanReports`, SMI-5535). For each installed skill it reads the on-disk `SKILL.md`, scans it with `@skillsmith/core`'s `SecurityScanner`, and — against a per-skill baseline persisted at `~/.skillsmith/audits/security-baseline.json` — classifies the posture:
- **hostile** — a benign→malicious rug-pull between the last baseline and now (the differentiated 2A signal),
- **malicious** — the skill fails the scanner right now (first-sight or persistent; surfaced every run),
- **suspicious** — a material worsening short of failing.

One finding per skill, strongest label wins. The baseline is rebuilt each run from currently-present skills (prunes uninstalled) and advances to the current scan so a fix-then-rebreak re-detects.

`sklx audit security [--json]` (a sibling of `audit collisions`) prints findings strongest-first. Nothing leaves the machine.

### Scope (honest)
This scans each skill's **`SKILL.md`** — **bundled files (e.g. `scripts/`) are not yet scanned**. That is the biggest coverage gap and is tracked as **SMI-5543** (P2). The CLI copy states this explicitly rather than over-claiming.

### Governance (adversarial security review) — all findings resolved or tracked
Fixed in this PR: unreadable content / a scanner throw now **preserves** the skill's baseline (a transient I/O hiccup no longer prunes it and downgrades a later rug-pull to first-sight `malicious`); honest `unchanged` vs `unreadable` counters + a CLI coverage warning; each baseline entry records the **threshold** it was produced under (a threshold change re-scans, honoring the `compareScanReports` caller contract); the scanner/reader test seams are **removed from the published `RunSecurityAuditOptions`** so the production entry point can't accept a stub scanner. Tracked follow-ups: **SMI-5543** (bundle scanning), **SMI-5544** (cumulative-drift), **SMI-5545** (scanner-ruleset-version binding).

### Validation
13 engine + 6 CLI tests pass (rug-pull, first-sight/persistent malicious, unchanged-skip, pruning, corrupt-baseline fail-safe, real-scanner wiring, unreadable-preserves-baseline, scanner-throw isolation, threshold-change re-scan). Prettier + ESLint clean; all new files <500 lines. (Local cross-package `tsc` hits the known macOS worktree bind-mount stale-symlink; verified correct via a fresh-core-aliased test run — CI is authoritative.)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)