### PR TITLE
docs(migration-safety): fix stale staging DB password var name (SMI-5532)

### DIFF
--- a/.claude/development/supabase-migration-safety.md
+++ b/.claude/development/supabase-migration-safety.md
@@ -238,7 +238,7 @@ Document the output of each query in the Linear ticket comment before running `s
 ```bash
 # Staging
 varlock run -- sh -c 'npx supabase db push \
-  --db-url "postgresql://postgres.ovhcifugwqnzoebwfuku:$SUPABASE_DB_PASSWORD_STAGING@aws-1-us-east-1.pooler.supabase.com:5432/postgres"'
+  --db-url "postgresql://postgres.ovhcifugwqnzoebwfuku:$STAGING_SUPABASE_DB_PASSWORD@aws-1-us-east-1.pooler.supabase.com:5432/postgres"'
 
 # Prod (only after 24h staging soak)
 varlock run -- sh -c 'npx supabase db push \


### PR DESCRIPTION
One-line fix to `.claude/development/supabase-migration-safety.md` § Apply command.

The staging `db push` example referenced `$SUPABASE_DB_PASSWORD_STAGING`, which is **unset** in the local varlock env and appears **nowhere else in the repo**. The canonical var (`.env.schema:255`, `scripts/validate-staging.sh`, `docs/internal/runbooks/staging-migration-drift-repair.md`) is `STAGING_SUPABASE_DB_PASSWORD`. As written, the staging apply command would fail locally on an empty password.

Found during the SMI-5532 out-of-band prod apply (the guide is the supabase-migration-reviewer skill's knowledge base). Docs-only, no code.

`[skip-impl-check]` — documentation-only change, no TypeScript source.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)