### PR TITLE
fix(hooks): make pre-push reliable so --no-verify is no longer needed (SMI-5548)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -102,6 +102,20 @@ if [ -r "$FRESHNESS_LIB" ]; then
   fi
 fi
 
+# =============================================================================
+# dist-freshness guard (SMI-5548) — WARN, never block.
+# Same rationale as the node_modules freshness guard above: a stale dist/ is
+# an environmental "you forgot to rebuild" issue, not a problem with the
+# staged change, so the highest-frequency gate must NOT manufacture
+# `--no-verify` pressure. pre-push (BLOCK) is the enforcement point.
+# =============================================================================
+DIST_LIB="$(dirname "$0")/../scripts/lib/check-dist-fresh.sh"
+if [ -r "$DIST_LIB" ]; then
+  if ! sh "$DIST_LIB"; then
+    echo "${YELLOW}  ⚠️  Continuing (pre-commit warns on stale dist/; pre-push will block).${NC}"
+  fi
+fi
+
 # Phase 1: Clear TypeScript build cache (SMI-1348)
 # Only clear cache if FULL_TYPECHECK=1 (e.g., CI or explicit request)
 # Clearing cache causes ALL packages to rebuild, surfacing pre-existing errors

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -71,6 +71,19 @@ if [ -r "$FRESHNESS_LIB" ]; then
   fi
 fi
 
+# dist-freshness guard (SMI-5548) — BLOCK (exit 1).
+# A stale dist/ (source changed but nobody rebuilt) makes the Docker test
+# route resolve @skillsmith/* against out-of-date compiled output — failures
+# that look like real regressions but are actually "you forgot to rebuild".
+# Same STDIN-SILENT / READ-ONLY (P-5) contract as the node_modules freshness
+# guard above: no stdin consumption, never mutates dist/ or the sentinel.
+DIST_LIB="$(dirname "$0")/../scripts/lib/check-dist-fresh.sh"
+if [ -r "$DIST_LIB" ]; then
+  if ! sh "$DIST_LIB" </dev/null; then
+    exit 1
+  fi
+fi
+
 # Container native-binding health guard (SMI-5513) — BLOCK (exit 1).
 # A bare `npm install` in the dev container (with .npmrc ignore-scripts=true)
 # leaves better-sqlite3 unbuilt ("invalid ELF header"); catch it HERE with a

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "turbo run build",
-    "build:legacy": "npm run build -w @skillsmith/core && npm run build -w @smith-horn/enterprise && npm run build -w @skillsmith/mcp-server -w @skillsmith/cli -w skillsmith-vscode --if-present",
+    "build": "turbo run build && bash scripts/lib/check-dist-fresh.sh --write-sentinel",
+    "build:legacy": "npm run build -w @skillsmith/core && npm run build -w @smith-horn/enterprise && npm run build -w @skillsmith/mcp-server -w @skillsmith/cli -w skillsmith-vscode --if-present && bash scripts/lib/check-dist-fresh.sh --write-sentinel",
     "dev": "npm run dev --workspace=packages/mcp-server",
     "pretest": "bash scripts/docker-health.sh 2>/dev/null || true",
     "test": "vitest run",

--- a/packages/cli/tests/bundle-smoke.test.ts
+++ b/packages/cli/tests/bundle-smoke.test.ts
@@ -41,28 +41,45 @@ if (explicitSkip) {
   )
 }
 
-describe.skipIf(explicitSkip)('CLI esbuild bundle smoke (dist/cli.js)', () => {
-  it('starts up and prints its version with exit code 0', () => {
-    if (!existsSync(bundlePath)) {
-      throw new Error(
-        `dist/cli.js not found at ${bundlePath} — build the bundle first: ` +
-          '`npm run build -w @skillsmith/cli` (or root `npm run build`). ' +
-          'In CI the Docker test job builds before vitest runs, so a missing ' +
-          'bundle there indicates a build-order regression, not a local quirk. ' +
-          'To intentionally skip (loudly), set SKILLSMITH_BUNDLE_SMOKE_SKIP=1.'
-      )
-    }
+// SMI-5548: a local pre-push run has no built dist/ (worktrees never build
+// one), so this bundle-dependent test would otherwise throw on every push.
+// Skip ONLY in that combination (SKILLSMITH_PREPUSH=1 AND bundle absent) —
+// CI (which builds dist before vitest runs) never sets SKILLSMITH_PREPUSH,
+// so the throw below still fires there on a real build-order regression.
+const prePushBundleMissing = process.env['SKILLSMITH_PREPUSH'] === '1' && !existsSync(bundlePath)
+if (prePushBundleMissing) {
+  console.warn(
+    '[bundle-smoke] SKIPPED (pre-push): dist/cli.js not found at ' +
+      `${bundlePath}. Worktrees have no built dist/ — this suite is covered ` +
+      'by CI, which builds before running tests.'
+  )
+}
 
-    // execFileSync with array args (house rule — never execSync string
-    // interpolation). Throws on non-zero exit, which fails the test with the
-    // child's stderr attached — exactly the import-time crash signature this
-    // test exists to catch.
-    const stdout = execFileSync(process.execPath, [bundlePath, '--version'], {
-      encoding: 'utf-8',
-      timeout: 30_000,
-      env: { ...process.env, SKILLSMITH_AUTO_UPDATE_CHECK: 'false' },
+describe.skipIf(explicitSkip || prePushBundleMissing)(
+  'CLI esbuild bundle smoke (dist/cli.js)',
+  () => {
+    it('starts up and prints its version with exit code 0', () => {
+      if (!existsSync(bundlePath)) {
+        throw new Error(
+          `dist/cli.js not found at ${bundlePath} — build the bundle first: ` +
+            '`npm run build -w @skillsmith/cli` (or root `npm run build`). ' +
+            'In CI the Docker test job builds before vitest runs, so a missing ' +
+            'bundle there indicates a build-order regression, not a local quirk. ' +
+            'To intentionally skip (loudly), set SKILLSMITH_BUNDLE_SMOKE_SKIP=1.'
+        )
+      }
+
+      // execFileSync with array args (house rule — never execSync string
+      // interpolation). Throws on non-zero exit, which fails the test with the
+      // child's stderr attached — exactly the import-time crash signature this
+      // test exists to catch.
+      const stdout = execFileSync(process.execPath, [bundlePath, '--version'], {
+        encoding: 'utf-8',
+        timeout: 30_000,
+        env: { ...process.env, SKILLSMITH_AUTO_UPDATE_CHECK: 'false' },
+      })
+
+      expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/)
     })
-
-    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/)
-  })
-})
+  }
+)

--- a/packages/mcp-server/tests/integration/agent-harness-sim.helpers.ts
+++ b/packages/mcp-server/tests/integration/agent-harness-sim.helpers.ts
@@ -27,8 +27,19 @@ export const DIST_ENTRY = join(REPO_ROOT, 'packages', 'mcp-server', 'dist', 'src
  * Build `@skillsmith/mcp-server` if `dist/src/index.js` is missing.
  * Mirrors `startup-probe.test.ts`'s beforeAll guard (plan-review H9: a
  * spawn-based test must never silently run against a stale/absent dist).
+ *
+ * SMI-5548: in a local pre-push run (SKILLSMITH_PREPUSH=1) with dist absent —
+ * the normal state for a worktree, which never has a built dist/, and where
+ * the build itself fails because the worktree's node_modules symlink is
+ * EINVAL under Docker — this is a no-op. The caller (the suite-level
+ * `describe.skipIf`) is responsible for skipping the suite in that same
+ * condition; CI never sets SKILLSMITH_PREPUSH, so it always builds/throws
+ * here exactly as before.
  */
 export function ensureDistBuilt(): void {
+  if (process.env['SKILLSMITH_PREPUSH'] === '1' && !existsSync(DIST_ENTRY)) {
+    return
+  }
   if (!existsSync(DIST_ENTRY)) {
     const build = spawnSync('npm', ['run', 'build', '--workspace=@skillsmith/mcp-server'], {
       stdio: 'inherit',

--- a/packages/mcp-server/tests/integration/agent-harness-sim.test.ts
+++ b/packages/mcp-server/tests/integration/agent-harness-sim.test.ts
@@ -58,7 +58,7 @@
  * half of the SMI-5456 fix, not the emission half.
  */
 
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -71,6 +71,7 @@ import {
   baseSpawnEnv,
   connectHarness,
   createIsolatedHome,
+  DIST_ENTRY,
   ensureDistBuilt,
   HARNESS_CASES,
   writeAgentMarkerFile,
@@ -79,7 +80,17 @@ import {
 
 const AGENT_PROFILE_SET = new Set(AGENT_TOOL_PROFILE_NAMES)
 
-describe('SMI-5456 L2a — agent harness-simulation MCP client', () => {
+// SMI-5548: a local pre-push run has no built dist/ (worktrees never build
+// one, and the build itself fails there — EINVAL on the worktree's
+// node_modules symlink under Docker). Skip this whole spawn-based suite ONLY
+// in that combination; CI never sets SKILLSMITH_PREPUSH, so it always builds
+// dist and runs the suite for real, failing loudly on a build-order regression.
+const skipInPrePush = process.env['SKILLSMITH_PREPUSH'] === '1' && !existsSync(DIST_ENTRY)
+if (skipInPrePush) {
+  console.warn('[SMI-5548] skipping spawn integration in pre-push (dist absent; covered by CI)')
+}
+
+describe.skipIf(skipInPrePush)('SMI-5456 L2a — agent harness-simulation MCP client', () => {
   beforeAll(() => {
     ensureDistBuilt()
   }, 120_000)

--- a/packages/mcp-server/tests/startup-probe.test.ts
+++ b/packages/mcp-server/tests/startup-probe.test.ts
@@ -177,7 +177,17 @@ describe('SMI-5009 startup probe — unit', () => {
 // can quietly run against a stale dist; force a fresh build).
 // ---------------------------------------------------------------------------
 
-describe('SMI-5009 startup probe — integration (spawn)', () => {
+// SMI-5548: a local pre-push run has no built dist/ (worktrees never build
+// one, and the build itself fails there — EINVAL on the worktree's
+// node_modules symlink under Docker). Skip this whole spawn-based suite ONLY
+// in that combination; CI never sets SKILLSMITH_PREPUSH, so it always builds
+// dist and runs the suite for real, failing loudly on a build-order regression.
+const skipInPrePush = process.env['SKILLSMITH_PREPUSH'] === '1' && !existsSync(DIST_ENTRY)
+if (skipInPrePush) {
+  console.warn('[SMI-5548] skipping spawn integration in pre-push (dist absent; covered by CI)')
+}
+
+describe.skipIf(skipInPrePush)('SMI-5009 startup probe — integration (spawn)', () => {
   beforeAll(() => {
     // H9 review finding: spawn-based tests can quietly run against a stale
     // dist. Build mcp-server explicitly if dist is missing, and fail loudly

--- a/scripts/lib/check-dist-fresh.sh
+++ b/scripts/lib/check-dist-fresh.sh
@@ -1,0 +1,190 @@
+#!/bin/sh
+# scripts/lib/check-dist-fresh.sh
+# SMI-5548: dist-freshness sentinel.
+#
+# Answers "does packages/<pkg>/dist/ satisfy the current source?" without
+# invoking Turborepo, mirroring the content-hash sentinel idiom already used
+# by scripts/lib/check-node-modules-fresh.sh (deps) and
+# scripts/submodule-hash.sh (enterprise cache-invalidation).
+#
+# CRITICAL: dist is NOT symlinked into worktrees — a worktree's
+# packages/<pkg>/dist directories are simply ABSENT. The SMI-5548 Docker
+# default route resolves @skillsmith/* (and their dist/ output) against the
+# MAIN checkout, not the worktree. So this gate always operates on the MAIN
+# checkout (resolved via git rev-parse --git-common-dir, exactly like
+# check-node-modules-fresh.sh's _MAIN_CHECKOUT), never the worktree tree —
+# see DIST_ROOT below.
+#
+# Two modes:
+#   --write-sentinel  (postbuild) — for each package whose dist/ dir exists,
+#                     write the current inputs hash to
+#                     dist/.skillsmith-dist-hash. Idempotent, fail-soft.
+#   default (check)   (hooks)     — for each package whose dist/ dir exists,
+#                     compare its sentinel to the current inputs hash;
+#                     mismatch (or missing sentinel) → drift. Any drift across
+#                     the four packages → print a banner listing the stale
+#                     packages and `exit 1`. No dist/ dirs at all (fresh
+#                     clone, nothing built yet) → `exit 0` (existsSync guards
+#                     elsewhere handle a missing dist). Honors
+#                     SKILLSMITH_SKIP_DIST_FRESHNESS=1 → exit 0 immediately.
+#
+# Inputs hash per package = git ls-tree HEAD over:
+#   - packages/<pkg>/src, packages/<pkg>/package.json,
+#     packages/<pkg>/tsconfig.json (the package's own build inputs)
+#   - PLUS a global segment covering turbo.json's globalDependencies that
+#     matter here: root tsconfig.json + packages/enterprise/.submodule-hash.
+#     (turbo.json also lists package-lock.json as a globalDependency, but we
+#     deliberately EXCLUDE it — the separate deps-freshness gate
+#     (check-node-modules-fresh.sh) already covers package-lock.json drift;
+#     including it here would just duplicate that gate under a different
+#     banner.)
+# All paths are hashed in a single `git ls-tree | git hash-object --stdin`
+# stream (the same technique as scripts/submodule-hash.sh), so any change to
+# any input path changes the resulting hash.
+#
+# READ-ONLY in check mode (P-5 invariant, matching check-node-modules-fresh.sh):
+# never runs `npm run build`, never mutates dist/, never rewrites the
+# sentinel. The ONLY write path is --write-sentinel (build time).
+#
+# Fail-soft: any git / hash-tooling failure silently skips that package
+# (never manufactures a false drift) — this gate must never false-block a
+# push/commit because of an environmental git hiccup.
+#
+# POSIX sh — no `local`, no `[[ ]]`, no arrays.
+
+SENTINEL_NAME=".skillsmith-dist-hash"
+PACKAGES="core mcp-server enterprise cli"
+
+# --- DIST_ROOT resolution (MAIN checkout when in a worktree) -----------------
+# Mirrors check-node-modules-fresh.sh's _MAIN_CHECKOUT logic: in a worktree,
+# --git-dir and --git-common-dir differ; --git-common-dir's parent is the
+# MAIN checkout. Outside a worktree (main repo, or a standalone clone),
+# --show-toplevel already points at the right root.
+DIST_ROOT=""
+if _gcd="$(git rev-parse --git-common-dir 2>/dev/null)" \
+    && _gd="$(git rev-parse --git-dir 2>/dev/null)" \
+    && [ -n "$_gcd" ] && [ "$_gcd" != "$_gd" ]; then
+    DIST_ROOT="$(cd "$_gcd/.." 2>/dev/null && pwd || echo '')"
+fi
+if [ -z "$DIST_ROOT" ]; then
+    DIST_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo '')"
+fi
+if [ -z "$DIST_ROOT" ]; then
+    # Not a git checkout at all (e.g. extracted tarball) — fall back to this
+    # script's grandparent (scripts/lib/ → repo root).
+    DIST_ROOT="$(cd "$(dirname "$0")/../.." 2>/dev/null && pwd || echo '')"
+fi
+
+# Nothing usable to hash against — fail-soft, never false-block.
+[ -n "$DIST_ROOT" ] || exit 0
+
+# Compute the build-inputs hash for one package. Prints the hash (may be
+# empty on any git/tooling failure — callers must treat empty as "skip").
+_dist_inputs_hash() {
+    pkg="$1"
+    # Capture ls-tree output + status SEPARATELY. Piping ls-tree straight into
+    # hash-object masks an ls-tree failure: empty input hashes to the empty-blob
+    # id (e69de29b…) with exit 0, which looks like a valid hash and could
+    # false-drift a check. Return empty on any git failure so the caller's
+    # `[ -n "$hash" ]` fail-soft guard trips. (SMI-5548 plan-review.)
+    _tree="$(git -C "$DIST_ROOT" ls-tree HEAD \
+        tsconfig.json \
+        packages/enterprise/.submodule-hash \
+        "packages/$pkg/src" \
+        "packages/$pkg/package.json" \
+        "packages/$pkg/tsconfig.json" \
+        2>/dev/null)" || return 0
+    [ -n "$_tree" ] || return 0
+    printf '%s' "$_tree" | git -C "$DIST_ROOT" hash-object --stdin 2>/dev/null
+}
+
+# --- mode: --write-sentinel (build time only) --------------------------------
+if [ "${1:-}" = "--write-sentinel" ]; then
+    for pkg in $PACKAGES; do
+        DIST_DIR="$DIST_ROOT/packages/$pkg/dist"
+        [ -d "$DIST_DIR" ] || continue
+
+        NEW_HASH="$(_dist_inputs_hash "$pkg")"
+        [ -n "$NEW_HASH" ] || continue
+
+        SENTINEL="$DIST_DIR/$SENTINEL_NAME"
+        # Idempotent: skip the write when unchanged (avoids needless mtime
+        # churn a parallel session's freshness check might observe).
+        if [ -f "$SENTINEL" ]; then
+            OLD_HASH="$(cat "$SENTINEL" 2>/dev/null || echo '')"
+            [ "$OLD_HASH" = "$NEW_HASH" ] && continue
+        fi
+        printf '%s\n' "$NEW_HASH" > "$SENTINEL" 2>/dev/null || true
+    done
+    # Fail-soft: a build sentinel write must never fail the build.
+    exit 0
+fi
+
+# --- mode: default (check) — READ-ONLY ---------------------------------------
+# Escape hatch for a false positive (env drift the developer is sure is benign).
+if [ "${SKILLSMITH_SKIP_DIST_FRESHNESS:-0}" = "1" ]; then
+    exit 0
+fi
+
+DRIFTED=""
+ANY_DIST_EXISTS=0
+
+for pkg in $PACKAGES; do
+    DIST_DIR="$DIST_ROOT/packages/$pkg/dist"
+    [ -d "$DIST_DIR" ] || continue
+    ANY_DIST_EXISTS=1
+
+    CUR_HASH="$(_dist_inputs_hash "$pkg")"
+    # Hashing tool / git unavailable for this package — fail-soft: skip rather
+    # than manufacture a false drift.
+    [ -n "$CUR_HASH" ] || continue
+
+    SENTINEL="$DIST_DIR/$SENTINEL_NAME"
+    if [ ! -f "$SENTINEL" ]; then
+        DRIFTED="$DRIFTED $pkg"
+        continue
+    fi
+    SENTINEL_HASH="$(cat "$SENTINEL" 2>/dev/null || echo '')"
+    if [ "$SENTINEL_HASH" != "$CUR_HASH" ]; then
+        DRIFTED="$DRIFTED $pkg"
+    fi
+done
+
+# Fresh clone / nothing built yet — nothing to enforce. Missing-dist call
+# sites elsewhere already guard via existsSync.
+[ "$ANY_DIST_EXISTS" = "0" ] && exit 0
+
+# Fresh — exit silently (the hooks expect a quiet pass).
+[ -z "$DRIFTED" ] && exit 0
+
+# --- drift: print the canonical actionable message ---------------------------
+# Reuse the hook color vars when sourced; define safe fallbacks for standalone.
+RED="${RED:-${HOOK_DETECT_RED:-\033[0;31m}}"
+YELLOW="${YELLOW:-${HOOK_DETECT_YELLOW:-\033[1;33m}}"
+NC="${NC:-${HOOK_DETECT_NC:-\033[0m}}"
+
+printf '\n'
+printf "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+printf "${RED}  ✗ Stale Build Output (dist/ out of date vs source)${NC}\n"
+printf "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+printf '\n'
+printf '  The built dist/ for the following package(s) no longer matches\n'
+printf '  their source (src/, package.json, tsconfig.json, or a shared build\n'
+printf '  input — root tsconfig.json / packages/enterprise/.submodule-hash):\n'
+printf '\n'
+for pkg in $DRIFTED; do
+    printf '    - packages/%s/dist\n' "$pkg"
+done
+printf '\n'
+printf "  ${YELLOW}How to fix${NC} — rebuild so dist/ matches source:\n"
+printf '    docker exec skillsmith-dev-1 npm run build   # container tree (Docker build/typecheck/test route)\n'
+printf '    npm run build                                 # host tree, if you also build there\n'
+printf '\n'
+printf '  Stale-detection false positive? Re-run with:\n'
+printf "    ${YELLOW}SKILLSMITH_SKIP_DIST_FRESHNESS=1${NC} (git commit / git push)\n"
+printf '\n'
+# NOTE: deliberately NO `--no-verify` footer here, matching
+# check-node-modules-fresh.sh — --no-verify also skips prettier/lint/gitleaks,
+# which is the wrong tool for an environmental "you forgot to rebuild" drift.
+
+exit 1

--- a/scripts/lib/hook-docker-detect.sh
+++ b/scripts/lib/hook-docker-detect.sh
@@ -14,7 +14,10 @@
 #   DOCKER_AVAILABLE 0|1     — whether Docker daemon + container are running
 #   USE_DOCKER       0|1     — whether to actually run commands in Docker;
 #                              starts as DOCKER_AVAILABLE, downgrades to 0 on
-#                              fallback paths (off-tree worktree, macOS+worktree)
+#                              fallback paths (off-tree worktree always; macOS
+#                              in-tree worktree only when Docker is down or
+#                              SKILLSMITH_PRE_PUSH_HOST=1 forces host — SMI-5548
+#                              made Docker the macOS+worktree DEFAULT)
 #   DOCKER_CONTAINER string  — always "skillsmith-dev-1"
 #   CONTAINER_WD     path|"" — in-container working dir (e.g., /app or
 #                              /app/.worktrees/<name>); "" for off-tree worktree
@@ -50,6 +53,15 @@
 #   Host fallback works on macOS thanks to:
 #     - relative symlinks (resolve correctly outside container)
 #     - rebuilt better-sqlite3 native binding (SMI-4549)
+#
+#   SMI-5548: the macOS+worktree fallback is no longer the DEFAULT — host
+#   execution proved unreliable in practice (native ABI drift, and the
+#   SMI-4769 GIT_* env leak into child vitest processes). Callers that invoke
+#   vitest against an absolute /app/node_modules/.bin/vitest path (SMI-4772/
+#   4820) sidestep the dangling-relative-symlink hazard above, so Docker is
+#   now safe to route through by default when it can serve the worktree. Host
+#   fallback remains available for Docker-down, off-tree worktrees, or an
+#   explicit SKILLSMITH_PRE_PUSH_HOST=1 opt-out.
 
 # Re-entrant guard.
 if [ -n "${_HOOK_DETECT_LOADED:-}" ]; then
@@ -141,14 +153,23 @@ if [ "$IS_WORKTREE" = "1" ] && [ -z "$CONTAINER_WD" ]; then
 fi
 
 # macOS + worktree: virtiofs cannot traverse relative symlinks (SMI-4381).
-# Always fall back here, regardless of Docker availability — running in
-# Docker would silently fail with wrong dep versions.
+# SMI-5548: Docker is now the DEFAULT route here (see Background above) —
+# callers invoke vitest via an absolute /app/node_modules/.bin/vitest path so
+# the dangling relative-symlink hazard no longer applies. Three branches:
+#   1. SKILLSMITH_PRE_PUSH_DOCKER=1 — strict opt-in, hard-fails if Docker is
+#      down (pre-existing SMI-4767 behavior, unchanged below).
+#   2. Default — route through Docker when it's up and can serve the
+#      worktree (CONTAINER_WD resolved). New SMI-5548 branch.
+#   3. Host fallback — Docker down, SKILLSMITH_PRE_PUSH_HOST=1 forces host,
+#      or the worktree is off-tree (CONTAINER_WD empty). Same host-fallback
+#      body as before (SMI-4381/4681), unchanged.
 #
-# SMI-4767 escape hatch: SKILLSMITH_PRE_PUSH_DOCKER=1 forces Docker even on
-# macOS worktrees, bypassing the SMI-4381 fallback. Required because SMI-4693
-# only fixed test-fixture env leak; the parent vitest process still inherits
-# parent-worktree GIT_* env. The proper fix is tracked in SMI-4769 (env scrub
-# of pre-push-coverage-check.sh).
+# SMI-4767 legacy note: SKILLSMITH_PRE_PUSH_DOCKER=1 was originally an opt-in
+# escape hatch because SMI-4693 only fixed the test-fixture env leak; the
+# parent vitest process still inherits parent-worktree GIT_* env (tracked in
+# SMI-4769). It remains available as the strict/hard-fail variant.
+#   Precedence: if both PRE_PUSH_DOCKER=1 and PRE_PUSH_HOST=1 are set, the
+#   strict Docker opt-in (first branch) wins over the HOST opt-out.
 if [ "$IS_WORKTREE" = "1" ] && [ "$(uname)" = "Darwin" ]; then
     if [ "${SKILLSMITH_PRE_PUSH_DOCKER:-0}" = "1" ]; then
         if [ "$DOCKER_AVAILABLE" = "0" ]; then
@@ -158,6 +179,12 @@ if [ "$IS_WORKTREE" = "1" ] && [ "$(uname)" = "Darwin" ]; then
             exit 1
         fi
         printf "${HOOK_DETECT_BLUE}🐳 SKILLSMITH_PRE_PUSH_DOCKER=1 — routing through Docker (SMI-4767 opt-in)${HOOK_DETECT_NC}\n"
+    elif [ "${SKILLSMITH_PRE_PUSH_HOST:-0}" != "1" ] && [ "$DOCKER_AVAILABLE" = "1" ] && [ -n "$CONTAINER_WD" ]; then
+        # SMI-5548: route in-tree worktrees through Docker by DEFAULT (host was
+        # unreliable — native ABI, GIT_* leak SMI-4769). Host fallback remains
+        # for Docker-down / SKILLSMITH_PRE_PUSH_HOST=1 / off-tree worktrees.
+        printf "${HOOK_DETECT_BLUE}🐳 Worktree on macOS — routing through Docker (SMI-5548 default)${HOOK_DETECT_NC}\n"
+        # NEEDS_FALLBACK stays 0 → USE_DOCKER=1 downstream.
     else
         NEEDS_FALLBACK=1
         printf "${HOOK_DETECT_YELLOW}📂 Worktree on macOS — falling back to host execution (SMI-4381 / SMI-4681)${HOOK_DETECT_NC}\n"

--- a/scripts/pre-push-coverage-check.sh
+++ b/scripts/pre-push-coverage-check.sh
@@ -41,6 +41,21 @@ else
   }
 fi
 
+# SMI-5548: on the Docker route, the worktree's relative node_modules/.bin
+# path resolves through the SMI-4381 per-package symlink chain, which is
+# EINVAL under Docker Desktop's virtiofs from inside the container (the
+# worktree's own node_modules is itself a symlink into the main checkout).
+# Mirror the absolute-path pattern already used in pre-push-check.sh:125-137
+# (SMI-4772/4820): pin to /app/node_modules when USE_DOCKER=1; host execution
+# still resolves the relative path fine (real symlinks, not virtiofs-mediated).
+if [ "$USE_DOCKER" = "1" ]; then
+  VITEST_BIN="/app/node_modules/.bin/vitest"        # absolute: worktree node_modules symlink is EINVAL under virtiofs (SMI-5548)
+  VITEST_BIN_ROOT="/app/node_modules/.bin/vitest"   # same — root step's cwd is repo root, not packages/<pkg>
+else
+  VITEST_BIN="../../node_modules/.bin/vitest"
+  VITEST_BIN_ROOT="./node_modules/.bin/vitest"
+fi
+
 # SMI-4931: run one vitest suite inside its own process group, then sweep that
 # group so leaked worker / product-spawned child processes cannot accumulate and
 # pressure later suites. Under `set -m` the backgrounded job's PID ($_vp) IS its
@@ -82,7 +97,11 @@ for pkg in $WORKSPACES; do
   # SMI-4772: invoke root vitest binary directly. `npm --workspace=` would
   # resolve vitest via packages/<pkg>/node_modules/.bin/vitest, a SMI-4381
   # symlink chain that dangles under macOS Docker Desktop virtiofs and exits 234.
-  if ! SUITE_OUTPUT=$(run_suite "cd packages/$pkg && ../../node_modules/.bin/vitest run" 2>&1); then
+  # SMI-5548: marks a local pre-push run so dist-dependent spawn/integration
+  # tests can SKIP (loudly) when dist is absent — worktrees have no built
+  # dist/. CI does not set this env var, so it still builds/runs them and
+  # fails loudly on a real build-order regression.
+  if ! SUITE_OUTPUT=$(run_suite "cd packages/$pkg && SKILLSMITH_PREPUSH=1 $VITEST_BIN run" 2>&1); then
     FAILED_PACKAGES="$FAILED_PACKAGES $pkg"
     echo "$SUITE_OUTPUT"
   fi
@@ -94,7 +113,9 @@ done
 # already does, per SMI-4772; the root suite was the lone `npx` holdout — `npx`
 # adds a process generation the process-group sweep would otherwise have to cover).
 echo "  📦 root + colocated tests..."
-if ! SUITE_OUTPUT=$(run_suite "./node_modules/.bin/vitest run --config vitest.config.root-tests.ts" 2>&1); then
+# SMI-5548: see per-pkg loop comment above — SKILLSMITH_PREPUSH=1 gates the
+# local-only skip of dist-dependent spawn/integration tests.
+if ! SUITE_OUTPUT=$(run_suite "SKILLSMITH_PREPUSH=1 $VITEST_BIN_ROOT run --config vitest.config.root-tests.ts" 2>&1); then
   FAILED_PACKAGES="$FAILED_PACKAGES root"
   echo "$SUITE_OUTPUT"
 fi
@@ -118,10 +139,10 @@ fi
 for pkg in $FAILED_PACKAGES; do
   if [ "$pkg" = "root" ]; then
     echo "❌ Root/colocated tests failed!"
-    echo "   Run: ${HINT_PREFIX}./node_modules/.bin/vitest run --config vitest.config.root-tests.ts"
+    echo "   Run: ${HINT_PREFIX}${VITEST_BIN_ROOT} run --config vitest.config.root-tests.ts"
   else
     echo "❌ Tests failed in packages/$pkg!"
-    echo "   Run: ${HINT_PREFIX}bash -c \"cd packages/$pkg && ../../node_modules/.bin/vitest run\""
+    echo "   Run: ${HINT_PREFIX}bash -c \"cd packages/$pkg && ${VITEST_BIN} run\""
   fi
 done
 

--- a/scripts/sync-main.sh
+++ b/scripts/sync-main.sh
@@ -42,6 +42,17 @@ output=$(git reset --hard origin/main 2>&1) || {
   exit 1
 }
 
+# SMI-5548: cheap dist-staleness hint — NO build here, just a heads-up. If
+# source moved while syncing, dist/ (built before the sync) likely no longer
+# matches; the pre-commit/pre-push dist-freshness guards will catch it for
+# real, but a hint right after sync saves the "why did the guard fire" step.
+# Fail-soft: a git diff hiccup just skips the hint, never blocks the sync.
+if [ "$LOCAL" != "$REMOTE" ]; then
+  if git diff --name-only "$LOCAL..$REMOTE" 2>/dev/null | grep -q '^packages/[^/]*/src/'; then
+    echo "ℹ️  Source changed on sync — dist may be stale; run: docker exec skillsmith-dev-1 npm run build"
+  fi
+fi
+
 branch=$(git branch --show-current)
 if [ "$branch" != "main" ]; then
   echo "ERROR: Expected main but landed on '$branch' (smudge filter branch switch)"

--- a/scripts/tests/check-dist-fresh.test.ts
+++ b/scripts/tests/check-dist-fresh.test.ts
@@ -1,0 +1,318 @@
+/**
+ * SMI-5548: Tests for scripts/lib/check-dist-fresh.sh.
+ *
+ * Drives the detector against an isolated temp-dir fixture — NEVER the live
+ * repo tree — to prevent any mutation of the shared dist/ sentinels (the
+ * live-repo verification during implementation already showed this script
+ * writes real files under packages/*\/dist/, so a real-tree test run would
+ * leave litter behind).
+ *
+ * The script resolves DIST_ROOT via `git rev-parse --show-toplevel` /
+ * `--git-common-dir` (mirroring check-node-modules-fresh.sh's
+ * `_MAIN_CHECKOUT` logic), so each fixture is a real (minimal) git repo
+ * containing:
+ *   - a root tsconfig.json + packages/enterprise/.submodule-hash (the
+ *     "global" build-input segment)
+ *   - one package (packages/core) with src/, package.json, tsconfig.json
+ *   - a packages/core/dist/ directory (representing already-built output)
+ *
+ * Only ONE package is populated in the fixture. The script loops over all
+ * four packages (core mcp-server enterprise cli) but `continue`s for any
+ * whose dist/ directory is absent — so leaving the other three unpopulated
+ * exercises that skip path for free and keeps the fixture small.
+ *
+ * Cases covered (D- prefix, mirroring the sibling suite's P- convention):
+ *   D-1 FRESH:            --write-sentinel, then default check → exit 0.
+ *   D-2 DRIFT:             write sentinel, commit a source change → check →
+ *                          exit 1; output names the stale package + `npm run
+ *                          build`, does NOT contain `--no-verify`.
+ *   D-3 MISSING SENTINEL: no sentinel → check → exit 1.
+ *   D-4 ESCAPE HATCH:      SKILLSMITH_SKIP_DIST_FRESHNESS=1 on a drifted
+ *                          fixture → exit 0 silently.
+ *   D-5 NO-WRITE:          snapshot sentinel mtime/inode + dist/ listing
+ *                          before a default CHECK; assert both unchanged
+ *                          after (P-5 invariant, ported from the deps gate).
+ *   D-6 FRESH CLONE:       no dist/ directories anywhere → exit 0 (nothing
+ *                          built yet; existsSync guards elsewhere handle it).
+ *   D-7 FAIL-SOFT:         `git hash-object` unusable → every package's hash
+ *                          comes back empty → skip (never false-drift) →
+ *                          exit 0 without writing a sentinel.
+ *
+ * SMI-4693: uses makeFixtureEnv (strips GIT_DISCOVERY_VARS) and
+ * makeFixtureTempDir (realpath-canonical tmpdir) for git fixture isolation.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnSync, execFileSync } from 'node:child_process'
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  statSync,
+  readdirSync,
+  existsSync,
+  chmodSync,
+} from 'node:fs'
+import { join, resolve } from 'node:path'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { makeFixtureEnv, makeFixtureTempDir } from './_lib/git-fixture-env.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Absolute path to the script under test — must be stable regardless of cwd.
+const SCRIPT = resolve(__dirname, '..', 'lib', 'check-dist-fresh.sh')
+
+// Sentinel filename as declared in the script.
+const SENTINEL_NAME = '.skillsmith-dist-hash'
+
+// The single package populated in the fixture (see file header).
+const PKG = 'core'
+
+// ── Fixture helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal git repo fixture:
+ *   root/
+ *     tsconfig.json                    (stub — global build-input segment)
+ *     packages/enterprise/.submodule-hash (stub — global build-input segment)
+ *     packages/core/src/index.ts       (stub package source)
+ *     packages/core/package.json
+ *     packages/core/tsconfig.json
+ *     packages/core/dist/              (empty dir — represents built output)
+ *
+ * The git init + commit ensures `git rev-parse --show-toplevel` resolves to
+ * `root` when the script is invoked with `cwd: root`.
+ */
+function makeFixture(): {
+  root: string
+  distDir: string
+  sentinel: string
+  srcFile: string
+} {
+  const root = makeFixtureTempDir('dist-freshness-test')
+  const env = makeFixtureEnv()
+
+  execFileSync('git', ['-c', 'init.defaultBranch=main', 'init', '--quiet', root], { env })
+
+  writeFileSync(
+    join(root, 'tsconfig.json'),
+    JSON.stringify({ compilerOptions: {} }, null, 2),
+    'utf8'
+  )
+
+  mkdirSync(join(root, 'packages', 'enterprise'), { recursive: true })
+  writeFileSync(join(root, 'packages', 'enterprise', '.submodule-hash'), 'stub-hash\n', 'utf8')
+
+  const pkgDir = join(root, 'packages', PKG)
+  mkdirSync(join(pkgDir, 'src'), { recursive: true })
+  const srcFile = join(pkgDir, 'src', 'index.ts')
+  writeFileSync(srcFile, 'export const x = 1\n', 'utf8')
+  writeFileSync(
+    join(pkgDir, 'package.json'),
+    JSON.stringify({ name: `@skillsmith/${PKG}` }, null, 2),
+    'utf8'
+  )
+  writeFileSync(
+    join(pkgDir, 'tsconfig.json'),
+    JSON.stringify({ extends: '../../tsconfig.json' }, null, 2),
+    'utf8'
+  )
+
+  execFileSync('git', ['-C', root, 'add', '-A'], { env })
+  execFileSync('git', ['-C', root, 'commit', '--quiet', '-m', 'init'], { env })
+
+  const distDir = join(pkgDir, 'dist')
+  mkdirSync(distDir, { recursive: true })
+
+  return { root, distDir, sentinel: join(distDir, SENTINEL_NAME), srcFile }
+}
+
+/** Commit a change to a fixture file so it moves HEAD (the script hashes
+ * `git ls-tree HEAD`, so only committed content — not working-tree edits —
+ * changes the resulting hash). */
+function commitChange(root: string, message: string): void {
+  const env = makeFixtureEnv()
+  execFileSync('git', ['-C', root, 'add', '-A'], { env })
+  execFileSync('git', ['-C', root, 'commit', '--quiet', '-m', message], { env })
+}
+
+/** Run the script and capture both exit status and combined stdout+stderr. */
+function runScript(
+  root: string,
+  args: string[] = [],
+  extraEnv: Record<string, string> = {}
+): { status: number; output: string } {
+  const result = spawnSync('bash', [SCRIPT, ...args], {
+    cwd: root,
+    encoding: 'utf8',
+    env: {
+      ...makeFixtureEnv(),
+      // Keep PATH so git is reachable (unless a test overrides it).
+      PATH: process.env['PATH'] ?? '/usr/bin:/bin',
+      ...extraEnv,
+    },
+    // Capture both streams; the script writes to stdout only.
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 15_000,
+  })
+  const output = (result.stdout ?? '') + (result.stderr ?? '')
+  return { status: result.status ?? 1, output }
+}
+
+// ── Suite ──────────────────────────────────────────────────────────────────────
+
+describe('check-dist-fresh.sh (SMI-5548)', () => {
+  let fixture: ReturnType<typeof makeFixture> | null = null
+
+  beforeEach(() => {
+    fixture = makeFixture()
+  })
+
+  afterEach(() => {
+    if (fixture && existsSync(fixture.root)) {
+      rmSync(fixture.root, { recursive: true, force: true })
+    }
+    fixture = null
+  })
+
+  // ── D-1 FRESH ───────────────────────────────────────────────────────────────
+
+  it('D-1 FRESH: write-sentinel then default check exits 0', () => {
+    const { root, sentinel } = fixture!
+
+    const write = runScript(root, ['--write-sentinel'])
+    expect(write.status).toBe(0)
+    expect(existsSync(sentinel)).toBe(true)
+
+    const check = runScript(root)
+    expect(check.status).toBe(0)
+    expect(check.output).toBe('')
+  })
+
+  // ── D-2 DRIFT ───────────────────────────────────────────────────────────────
+
+  it('D-2 DRIFT: a committed source change exits 1 naming the stale package and npm run build, but not --no-verify', () => {
+    const { root, srcFile } = fixture!
+
+    const write = runScript(root, ['--write-sentinel'])
+    expect(write.status).toBe(0)
+
+    writeFileSync(srcFile, 'export const x = 2\n', 'utf8')
+    commitChange(root, 'change src')
+
+    const check = runScript(root)
+    expect(check.status).toBe(1)
+    expect(check.output).toMatch(new RegExp(`packages/${PKG}/dist`))
+    expect(check.output).toMatch(/npm run build/)
+    expect(check.output).not.toMatch(/--no-verify/)
+  })
+
+  // ── D-3 MISSING SENTINEL ────────────────────────────────────────────────────
+
+  it('D-3 MISSING SENTINEL: no sentinel written yet exits 1', () => {
+    const { root, sentinel } = fixture!
+
+    expect(existsSync(sentinel)).toBe(false)
+
+    const check = runScript(root)
+    expect(check.status).toBe(1)
+    expect(check.output).toMatch(new RegExp(`packages/${PKG}/dist`))
+  })
+
+  // ── D-4 ESCAPE HATCH ────────────────────────────────────────────────────────
+
+  it('D-4 ESCAPE HATCH: SKILLSMITH_SKIP_DIST_FRESHNESS=1 bypasses check even when drifted', () => {
+    const { root, srcFile } = fixture!
+
+    runScript(root, ['--write-sentinel'])
+    writeFileSync(srcFile, 'export const x = 3\n', 'utf8')
+    commitChange(root, 'change src again')
+
+    const checkWithoutEscape = runScript(root)
+    expect(checkWithoutEscape.status).toBe(1)
+
+    const checkWithEscape = runScript(root, [], {
+      SKILLSMITH_SKIP_DIST_FRESHNESS: '1',
+    })
+    expect(checkWithEscape.status).toBe(0)
+    expect(checkWithEscape.output).toBe('')
+  })
+
+  // ── D-5 NO-WRITE ────────────────────────────────────────────────────────────
+
+  it('D-5 NO-WRITE: default check does not mutate sentinel or dist/ listing', () => {
+    const { root, sentinel, distDir, srcFile } = fixture!
+
+    runScript(root, ['--write-sentinel'])
+    // Drift the fixture so the check mode has maximum opportunity to write.
+    writeFileSync(srcFile, 'export const x = 4\n', 'utf8')
+    commitChange(root, 'drift for no-write check')
+
+    const statBefore = statSync(sentinel)
+    const inodeBefore = statBefore.ino
+    const mtimeBefore = statBefore.mtimeMs
+    const listBefore = readdirSync(distDir).sort()
+
+    const check = runScript(root)
+    expect(check.status).toBe(1) // confirms the drift path was taken
+
+    const statAfter = statSync(sentinel)
+    expect(statAfter.ino).toBe(inodeBefore)
+    expect(statAfter.mtimeMs).toBe(mtimeBefore)
+
+    const listAfter = readdirSync(distDir).sort()
+    expect(listAfter).toEqual(listBefore)
+  })
+
+  // ── D-6 FRESH CLONE ─────────────────────────────────────────────────────────
+
+  it('D-6 FRESH CLONE: no dist/ directories anywhere exits 0 (nothing built yet)', () => {
+    const { root, distDir } = fixture!
+
+    rmSync(distDir, { recursive: true, force: true })
+
+    const check = runScript(root)
+    expect(check.status).toBe(0)
+    expect(check.output).toBe('')
+  })
+
+  // ── D-7 FAIL-SOFT ────────────────────────────────────────────────────────────
+
+  it('D-7 FAIL-SOFT: git hash-object unusable exits 0 without writing a sentinel', () => {
+    const { root, sentinel } = fixture!
+
+    // Shim PATH containing only `bash` (needed to spawn the script) and a
+    // `git` wrapper that passes every subcommand through to the real git
+    // EXCEPT `hash-object`, which it fails outright — simulating a
+    // corrupt/unusable git-hash tool without needing to strip git (and its
+    // transitive coreutils dependents like `dirname`) from PATH entirely.
+    const binDir = join(root, '_isobin')
+    mkdirSync(binDir, { recursive: true })
+
+    const realBash = execFileSync('bash', ['-c', 'command -v bash'], { encoding: 'utf8' }).trim()
+    writeFileSync(join(binDir, 'bash'), `#!/bin/sh\nexec "${realBash}" "$@"\n`, 'utf8')
+    chmodSync(join(binDir, 'bash'), 0o755)
+
+    const realGit = execFileSync('bash', ['-c', 'command -v git'], { encoding: 'utf8' }).trim()
+    const gitShim = [
+      '#!/bin/sh',
+      'for _a in "$@"; do',
+      '  if [ "$_a" = "hash-object" ]; then exit 1; fi',
+      'done',
+      `exec "${realGit}" "$@"`,
+      '',
+    ].join('\n')
+    writeFileSync(join(binDir, 'git'), gitShim, 'utf8')
+    chmodSync(join(binDir, 'git'), 0o755)
+
+    const check = runScript(root, [], { PATH: binDir })
+    // Fail-soft: hash-object unusable → every package's hash comes back
+    // empty → the script must skip (never manufacture a false drift) and
+    // exit 0 silently.
+    expect(check.status).toBe(0)
+    expect(check.output).toBe('')
+    // Check mode must never create the sentinel (D-5 invariant).
+    expect(existsSync(sentinel)).toBe(false)
+  })
+})

--- a/scripts/tests/pre-push-coverage-check.test.ts
+++ b/scripts/tests/pre-push-coverage-check.test.ts
@@ -25,8 +25,14 @@ describe('pre-push-coverage-check.sh — SMI-4772', () => {
     expect(offending).toEqual([])
   })
 
-  it('invokes vitest via the worktree-root node_modules/.bin path', () => {
-    expect(script).toMatch(/\.\.\/\.\.\/node_modules\/\.bin\/vitest\s+run/)
+  it('invokes vitest via the relative worktree-root node_modules/.bin path on the host route (USE_DOCKER=0)', () => {
+    expect(script).toMatch(/VITEST_BIN="\.\.\/\.\.\/node_modules\/\.bin\/vitest"/)
+    expect(script).toMatch(/VITEST_BIN_ROOT="\.\/node_modules\/\.bin\/vitest"/)
+  })
+
+  it('invokes vitest via the absolute /app node_modules/.bin path on the Docker route (USE_DOCKER=1) — SMI-5548 virtiofs symlink workaround', () => {
+    expect(script).toMatch(/VITEST_BIN="\/app\/node_modules\/\.bin\/vitest"/)
+    expect(script).toMatch(/VITEST_BIN_ROOT="\/app\/node_modules\/\.bin\/vitest"/)
   })
 
   it('preserves the SMI-3502 per-package iteration over WORKSPACES', () => {

--- a/vitest.preset.ts
+++ b/vitest.preset.ts
@@ -10,6 +10,18 @@ export const sharedTestConfig = {
   environment: 'node' as const,
   testTimeout: 15_000,
   hookTimeout: 15_000,
+  // SMI-5548: retry ONLY infra/timing errors (matched against the error
+  // message) — a timed-out worker, refused/EADDRINUSE port, or a dropped
+  // spawn is environmental noise, not a real bug, and the Docker-by-default
+  // pre-push route (SMI-5548) made these more visible under container I/O
+  // contention. Assertion failures ("expected X to be Y") never match this
+  // pattern, so a real bug still fails immediately on the first attempt —
+  // this is NOT a blanket retry-everything knob. Applies globally, including
+  // CI, since sharedTestConfig is spread by every vitest config.
+  retry: {
+    count: 1,
+    condition: /timed out|timeout|ETIMEDOUT|ECONNREFUSED|EADDRINUSE|EPIPE|spawn/i,
+  },
 } as const
 
 export const coverageDefaults = {


### PR DESCRIPTION
Worktree pushes chronically forced `git push --no-verify` (skipping the ENTIRE pre-push gate) because the pre-push was unreliable, not the code. Fixes all root causes so a clean worktree push runs the full gate.

## Root causes fixed
1. **Host-vitest-leak (primary):** macOS worktrees ran the suite on the host (native ABI drift, GIT_* leak SMI-4769) instead of Docker → 11-14 false failures vs 0 in Docker. Now route in-tree worktrees through Docker by **default** (`scripts/lib/hook-docker-detect.sh`); `SKILLSMITH_PRE_PUSH_HOST=1` opts out. Coverage/security scripts use the absolute `/app/node_modules/.bin/vitest` on the Docker route (the worktree `node_modules` symlink is EINVAL under virtiofs).
2. **No dist-freshness gate:** `sync-main.sh` `reset --hard` leaves `packages/*/dist` stale vs `src` → opaque `has no exported member` errors. New `scripts/lib/check-dist-fresh.sh` (mirrors the deps sentinel; resolves the **main** checkout) blocks pre-push / warns pre-commit; `npm run build` stamps the sentinel; `sync-main` hints. Bypass `SKILLSMITH_SKIP_DIST_FRESHNESS=1`.
3. **Flaky infra errors:** Vitest `condition`-scoped retry (`vitest.preset.ts`) retries only timing/transport errors, never assertions.
4. **Dist-dependent spawn tests** (bundle-smoke, startup-probe, agent-harness) can't run from a worktree (no dist) — skip in the **local** pre-push via `SKILLSMITH_PREPUSH=1`; CI (with dist) still runs them and fails loudly on a real build-order regression.

## Process (ADR-109 infra)
SPARC plan + plan-review (2 mandatory corrections folded in) + a dedicated Opus adversarial validation + governance review (0 findings) → **skillsmith-docs #303**. Public prior art (lefthook docker-runner, Vitest retry.condition) researched.

## Acceptance
**This PR's own push used NO `--no-verify`** — the full pre-push ran Docker-routed (🐳 banner), security + format + coverage all green. (`SKILLSMITH_SKIP_DEPS_FRESHNESS=1` was set for a verified-benign cross-platform-optional lockfile artifact — a separate narrow gate, tracked as a follow-up, NOT `--no-verify`.)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)