### PR TITLE
fix(website): restructure quickstart MCP client flow + fix snippet drift (SMI-5554)

### DIFF
--- a/packages/website/src/components/DocsSidebar.astro
+++ b/packages/website/src/components/DocsSidebar.astro
@@ -74,7 +74,7 @@ function isActive(href: string): boolean {
 
 <aside class="w-64 shrink-0 border-r border-dark-800 bg-dark-900/50">
   <nav
-    class="sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto p-6"
+    class="docs-nav sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto p-6"
     aria-label="Documentation navigation"
   >
     {
@@ -276,5 +276,30 @@ function isActive(href: string): boolean {
     aside {
       display: none;
     }
+  }
+
+  /* Nav list content can exceed the viewport height, so it scrolls internally
+     (overflow-y-auto above) — style that scrollbar thin/subtle instead of the
+     default OS-native bar, which reads as a stray gray column next to the sidebar. */
+  .docs-nav {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 163, 184, 0.3) transparent;
+  }
+
+  .docs-nav::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .docs-nav::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .docs-nav::-webkit-scrollbar-thumb {
+    background-color: rgba(148, 163, 184, 0.3);
+    border-radius: 9999px;
+  }
+
+  .docs-nav::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(148, 163, 184, 0.5);
   }
 </style>

--- a/packages/website/src/lib/mcp-client-snippets.parity.test.ts
+++ b/packages/website/src/lib/mcp-client-snippets.parity.test.ts
@@ -1,0 +1,142 @@
+/**
+ * SMI-5554 parity guard: MCP_CLIENT_SNIPPETS in mcp-client-snippets.ts must stay
+ * in sync with the canonical CLIENT_SNIPPETS matrix in @skillsmith/cli.
+ *
+ * Source of truth: packages/cli/src/templates/mcp-server.template.snippets.ts
+ * (CLIENT_SNIPPETS + SNIPPET_DISPLAY_ORDER). The website client bundle CANNOT
+ * import @skillsmith/cli at runtime (same constraint as skill-card.parity.test.ts
+ * re: @skillsmith/core), so mcp-client-snippets.ts is a hand-maintained mirror,
+ * and this test is the enforcement boundary.
+ *
+ * Unlike skill-card.parity.test.ts (which only guards a label map), this test
+ * also asserts BODY content, not just id/label/configPath/format metadata —
+ * the bodies are the actual copy-pasteable content that drifted last time (2 of
+ * 8 canonical clients were missing entirely from both website pages, and no
+ * test caught it).
+ *
+ * When the canonical CLI matrix changes, update MCP_CLIENT_SNIPPETS and the
+ * EXPECTED constant below in lockstep.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { MCP_CLIENT_SNIPPETS, withApiKey } from './mcp-client-snippets'
+
+// Hardcoded canonical contract — derived from
+// packages/cli/src/templates/mcp-server.template.snippets.ts (SNIPPET_DISPLAY_ORDER).
+// Do NOT derive this from MCP_CLIENT_SNIPPETS itself; that would make the test circular.
+const EXPECTED: ReadonlyArray<{
+  id: string
+  label: string
+  configPath: string
+  format: 'json' | 'toml' | 'yaml'
+}> = [
+  {
+    id: 'claude-code',
+    label: 'Claude Code',
+    configPath: '~/.claude/settings.json',
+    format: 'json',
+  },
+  { id: 'cursor', label: 'Cursor', configPath: '~/.cursor/mcp.json', format: 'json' },
+  {
+    id: 'copilot',
+    label: 'GitHub Copilot (VS Code)',
+    configPath: '.vscode/mcp.json (workspace)',
+    format: 'json',
+  },
+  {
+    id: 'windsurf',
+    label: 'Windsurf',
+    configPath: '~/.codeium/windsurf/mcp_config.json',
+    format: 'json',
+  },
+  { id: 'codex', label: 'Codex CLI', configPath: '~/.codex/config.toml', format: 'toml' },
+  {
+    id: 'agents',
+    label: 'Cross-agent (open standard)',
+    configPath: '~/.agents/mcp.json',
+    format: 'json',
+  },
+  {
+    id: 'opencode',
+    label: 'OpenCode',
+    configPath: '~/.config/opencode/opencode.json',
+    format: 'json',
+  },
+  {
+    id: 'hermes',
+    label: 'Hermes (Nous Research)',
+    configPath: '~/.hermes/config.yaml',
+    format: 'yaml',
+  },
+]
+
+describe('MCP_CLIENT_SNIPPETS — parity with CLI CLIENT_SNIPPETS (SMI-5554)', () => {
+  it('has exactly the 8-entry canonical id/label/configPath/format contract, in SNIPPET_DISPLAY_ORDER', () => {
+    const actual = MCP_CLIENT_SNIPPETS.map(({ id, label, configPath, format }) => ({
+      id,
+      label,
+      configPath,
+      format,
+    }))
+    expect(actual).toEqual(EXPECTED)
+  })
+
+  it('every body contains the expected npx launch shape for its client', () => {
+    for (const snippet of MCP_CLIENT_SNIPPETS) {
+      if (snippet.format === 'json') {
+        const parsed = JSON.parse(snippet.body) as Record<string, unknown>
+        if (snippet.id === 'opencode') {
+          const mcp = parsed.mcp as Record<string, { command: unknown }>
+          expect(mcp['@skillsmith/mcp-server'].command).toEqual([
+            'npx',
+            '-y',
+            '@skillsmith/mcp-server',
+          ])
+        } else {
+          const mcpServers = parsed.mcpServers as Record<
+            string,
+            { command: unknown; args: unknown }
+          >
+          const entry = mcpServers['@skillsmith/mcp-server']
+          expect(entry.command).toBe('npx')
+          expect(entry.args).toEqual(['-y', '@skillsmith/mcp-server'])
+        }
+      } else if (snippet.format === 'toml') {
+        expect(snippet.body).toContain('command = "npx"')
+        expect(snippet.body).toContain('args = ["-y", "@skillsmith/mcp-server"]')
+      } else {
+        // yaml (hermes)
+        expect(snippet.body).toContain('command: "npx"')
+        expect(snippet.body).toContain('args: ["-y", "@skillsmith/mcp-server"]')
+      }
+    }
+  })
+
+  it('withApiKey() injects a valid env block for every format without disturbing the launch shape', () => {
+    for (const snippet of MCP_CLIENT_SNIPPETS) {
+      const withKey = withApiKey(snippet.body, snippet.format, snippet.id)
+      // Windsurf documents `${env:VAR}` interpolation, so its example sources
+      // the key from the shell rather than inlining a literal placeholder.
+      const expectedValue =
+        snippet.id === 'windsurf' ? '${env:SKILLSMITH_API_KEY}' : 'sk_live_your_key_here'
+      if (snippet.format === 'json') {
+        const parsed = JSON.parse(withKey) as Record<string, unknown>
+        if (snippet.id === 'opencode') {
+          const mcp = parsed.mcp as Record<string, { environment?: Record<string, string> }>
+          expect(mcp['@skillsmith/mcp-server'].environment).toEqual({
+            SKILLSMITH_API_KEY: expectedValue,
+          })
+        } else {
+          const mcpServers = parsed.mcpServers as Record<string, { env?: Record<string, string> }>
+          expect(mcpServers['@skillsmith/mcp-server'].env).toEqual({
+            SKILLSMITH_API_KEY: expectedValue,
+          })
+        }
+      } else if (snippet.format === 'toml') {
+        expect(withKey).toContain(`SKILLSMITH_API_KEY = "${expectedValue}"`)
+      } else {
+        expect(withKey).toContain(`SKILLSMITH_API_KEY: "${expectedValue}"`)
+      }
+    }
+  })
+})

--- a/packages/website/src/lib/mcp-client-snippets.ts
+++ b/packages/website/src/lib/mcp-client-snippets.ts
@@ -1,0 +1,202 @@
+/**
+ * SMI-5554: Shared per-client MCP config snippet data for the website docs.
+ *
+ * Mirrors (does NOT import) the canonical per-client snippet matrix in
+ * packages/cli/src/templates/mcp-server.template.snippets.ts — the website
+ * client bundle cannot import @skillsmith/cli or @skillsmith/core at runtime
+ * (same constraint documented in packages/website/src/lib/skill-card.parity.test.ts),
+ * so this is a hand-maintained mirror, kept in lockstep by
+ * mcp-client-snippets.parity.test.ts. When the canonical CLI matrix changes,
+ * update MCP_CLIENT_SNIPPETS and that test's EXPECTED constant together.
+ *
+ * Consumed by:
+ *   - packages/website/src/pages/docs/quickstart.astro (Step 2, Option C — uses `.body`)
+ *   - packages/website/src/pages/docs/getting-started.astro (Option 3 — uses
+ *     `withApiKey(snippet.body, snippet.format)`)
+ *
+ * Order matches SNIPPET_DISPLAY_ORDER in the CLI package's canonical file.
+ *
+ * @module lib/mcp-client-snippets
+ */
+
+export type McpClientId =
+  | 'claude-code'
+  | 'cursor'
+  | 'copilot'
+  | 'windsurf'
+  | 'codex'
+  | 'agents'
+  | 'opencode'
+  | 'hermes'
+
+export interface McpClientSnippet {
+  /** Canonical client id — matches SnippetClientId in the CLI package */
+  id: McpClientId
+  /** Display label for the `<summary>` header */
+  label: string
+  /** Path to the config file the user edits */
+  configPath: string
+  /** File format hint for the syntax highlighter and the withApiKey() branch */
+  format: 'json' | 'toml' | 'yaml'
+  /** Snippet body with NO API key — the quickstart.astro (Option C) variant */
+  body: string
+  /**
+   * Notes shown beneath the snippet. May contain literal HTML (e.g. `<code>`)
+   * — render with `set:html`, not plain `{}` interpolation, or the markup
+   * gets escaped into visible text.
+   */
+  notes?: string
+  /** True only for claude-code — renders its <details> open by default */
+  openByDefault?: boolean
+}
+
+// The 5 "standard" JSON clients (claude-code, cursor, copilot, windsurf,
+// agents) share an identical body: they all key on the published package
+// name, not a client-specific name, so this is reused rather than
+// hand-duplicated 5 times (see Review Summary #2 in the SMI-5554 plan).
+const STANDARD_JSON_BODY = `{
+  "mcpServers": {
+    "@skillsmith/mcp-server": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"]
+    }
+  }
+}`
+
+/** Per-client snippet matrix, in SNIPPET_DISPLAY_ORDER. */
+export const MCP_CLIENT_SNIPPETS: ReadonlyArray<McpClientSnippet> = [
+  {
+    id: 'claude-code',
+    label: 'Claude Code',
+    configPath: '~/.claude/settings.json',
+    format: 'json',
+    body: STANDARD_JSON_BODY,
+    openByDefault: true,
+  },
+  {
+    id: 'cursor',
+    label: 'Cursor',
+    configPath: '~/.cursor/mcp.json',
+    format: 'json',
+    body: STANDARD_JSON_BODY,
+    notes: 'Cursor 2.4+ required. Reload the window after saving.',
+  },
+  {
+    id: 'copilot',
+    label: 'GitHub Copilot (VS Code)',
+    configPath: '.vscode/mcp.json (workspace)',
+    format: 'json',
+    body: STANDARD_JSON_BODY,
+    notes:
+      'VS Code 1.108+ required. Workspace-scoped (commit to repo if team-shared, or use user settings.json instead).',
+  },
+  {
+    id: 'windsurf',
+    label: 'Windsurf',
+    configPath: '~/.codeium/windsurf/mcp_config.json',
+    format: 'json',
+    body: STANDARD_JSON_BODY,
+    notes: 'Supports <code>${env:VAR}</code> interpolation for secrets in this config.',
+  },
+  {
+    id: 'codex',
+    label: 'Codex CLI',
+    configPath: '~/.codex/config.toml',
+    format: 'toml',
+    body: `[mcp_servers.@skillsmith/mcp-server]
+command = "npx"
+args = ["-y", "@skillsmith/mcp-server"]`,
+    notes:
+      'Codex reads <code>~/.agents/skills</code>. When installing via Skillsmith CLI, pass <code>--client agents</code>.',
+  },
+  {
+    id: 'agents',
+    label: 'Cross-agent (open standard)',
+    configPath: '~/.agents/mcp.json',
+    format: 'json',
+    body: STANDARD_JSON_BODY,
+  },
+  {
+    id: 'opencode',
+    label: 'OpenCode',
+    configPath: '~/.config/opencode/opencode.json',
+    format: 'json',
+    // OpenCode's entry schema differs from the other 5 JSON clients:
+    // `command` is an array and the env-var field is named `environment`,
+    // not `env` (verified opencode.ai/docs/mcp-servers/).
+    body: `{
+  "mcp": {
+    "@skillsmith/mcp-server": {
+      "type": "local",
+      "command": ["npx", "-y", "@skillsmith/mcp-server"],
+      "enabled": true
+    }
+  }
+}`,
+    notes:
+      'OpenCode also reads <code>.claude/skills</code> and <code>.agents/skills</code> for skill discovery. Note the OpenCode-specific entry shape: <code>command</code> is an array and the env-var field is named <code>environment</code>, not <code>env</code>.',
+  },
+  {
+    id: 'hermes',
+    label: 'Hermes (Nous Research)',
+    configPath: '~/.hermes/config.yaml',
+    format: 'yaml',
+    body: `mcp_servers:
+  @skillsmith/mcp-server:
+    command: "npx"
+    args: ["-y", "@skillsmith/mcp-server"]`,
+    notes:
+      'Hermes config is YAML. Hermes has no <code>SessionStart</code> hook equivalent — nudge/attribution is unsupported on this harness.',
+  },
+]
+
+const STANDARD_ARGS_LINE = /(\n {6}"args": \[[^\n]*\])\n( {4}\}\n)/
+const OPENCODE_ENABLED_LINE = /(\n {6}"enabled": true)\n( {4}\}\n)/
+
+function withApiKeyJson(body: string, id?: McpClientId): string {
+  // OpenCode's shape is keyed differently (`mcp` + `environment`, not
+  // `mcpServers` + `env`) — special-cased here rather than folded into the
+  // standard branch below, so the 5 standard JSON clients stay simple.
+  if (body.includes('"mcp": {')) {
+    return body.replace(
+      OPENCODE_ENABLED_LINE,
+      '$1,\n      "environment": {\n        "SKILLSMITH_API_KEY": "sk_live_your_key_here"\n      }\n$2'
+    )
+  }
+  // Windsurf documents `${env:VAR}` interpolation, so its example shows the
+  // key sourced from the shell instead of inlined as a literal placeholder
+  // (see the `notes` field on the windsurf entry above).
+  const value = id === 'windsurf' ? '${env:SKILLSMITH_API_KEY}' : 'sk_live_your_key_here'
+  return body.replace(
+    STANDARD_ARGS_LINE,
+    `$1,\n      "env": {\n        "SKILLSMITH_API_KEY": "${value}"\n      }\n$2`
+  )
+}
+
+function withApiKeyToml(body: string): string {
+  const match = body.match(/^\[mcp_servers\.(.+)\]/)
+  const table = match ? match[1] : '@skillsmith/mcp-server'
+  return `${body}\n\n[mcp_servers.${table}.env]\nSKILLSMITH_API_KEY = "sk_live_your_key_here"`
+}
+
+function withApiKeyYaml(body: string): string {
+  return `${body}\n    env:\n      SKILLSMITH_API_KEY: "sk_live_your_key_here"`
+}
+
+/**
+ * Derives the API-key variant of a snippet body from its no-API-key `body`,
+ * instead of hand-authoring a second template string per client. Used by
+ * getting-started.astro; quickstart.astro renders `.body` as-is.
+ *
+ * `id` is optional but should be passed whenever available — it's only used
+ * to special-case Windsurf's `${env:VAR}` interpolation example.
+ */
+export function withApiKey(
+  body: string,
+  format: 'json' | 'toml' | 'yaml',
+  id?: McpClientId
+): string {
+  if (format === 'toml') return withApiKeyToml(body)
+  if (format === 'yaml') return withApiKeyYaml(body)
+  return withApiKeyJson(body, id)
+}

--- a/packages/website/src/pages/docs/getting-started.astro
+++ b/packages/website/src/pages/docs/getting-started.astro
@@ -1,5 +1,6 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
+import { MCP_CLIENT_SNIPPETS, withApiKey } from '../../lib/mcp-client-snippets';
 ---
 
 <DocsLayout title="Configuration Guide" description="Set up API keys, verify your installation, configure advanced options, and troubleshoot Skillsmith">
@@ -119,99 +120,16 @@ EOF`}</code></pre>
   <p>
     Skillsmith is MCP-compatible — pick the snippet for your agent. Every
     snippet uses the same shape; the only differences are the config-file path
-    and (for Codex) the format.
+    and (for Codex/Hermes) the format.
   </p>
 
-  <details>
-    <summary><strong>Claude Code</strong> — <code>~/.claude/settings.json</code></summary>
-    <pre><code>{`{
-  "mcpServers": {
-    "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
-      "env": {
-        "SKILLSMITH_API_KEY": "sk_live_your_key_here"
-      }
-    }
-  }
-}`}</code></pre>
-    <p>Restart Claude Code after editing settings.json.</p>
-  </details>
-
-  <details>
-    <summary><strong>Cursor</strong> — <code>~/.cursor/mcp.json</code></summary>
-    <pre><code>{`{
-  "mcpServers": {
-    "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
-      "env": {
-        "SKILLSMITH_API_KEY": "sk_live_your_key_here"
-      }
-    }
-  }
-}`}</code></pre>
-    <p>Cursor 2.4+ required. Reload the window after saving.</p>
-  </details>
-
-  <details>
-    <summary><strong>GitHub Copilot (VS Code)</strong> — <code>.vscode/mcp.json</code> (workspace)</summary>
-    <pre><code>{`{
-  "mcpServers": {
-    "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
-      "env": {
-        "SKILLSMITH_API_KEY": "sk_live_your_key_here"
-      }
-    }
-  }
-}`}</code></pre>
-    <p>VS Code 1.108+ required. Workspace-scoped (commit to repo if team-shared, or use user settings.json).</p>
-  </details>
-
-  <details>
-    <summary><strong>Windsurf</strong> — <code>~/.codeium/windsurf/mcp_config.json</code></summary>
-    <pre><code>{`{
-  "mcpServers": {
-    "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
-      "env": {
-        "SKILLSMITH_API_KEY": "\${env:SKILLSMITH_API_KEY}"
-      }
-    }
-  }
-}`}</code></pre>
-    <p>Supports <code>${`\${env:VAR}`}</code> interpolation; export <code>SKILLSMITH_API_KEY</code> in your shell.</p>
-  </details>
-
-  <details>
-    <summary><strong>Codex CLI</strong> — <code>~/.codex/config.toml</code> (TOML, not JSON)</summary>
-    <pre><code>{`[mcp_servers.@skillsmith/mcp-server]
-command = "npx"
-args = ["-y", "@skillsmith/mcp-server"]
-
-[mcp_servers.@skillsmith/mcp-server.env]
-SKILLSMITH_API_KEY = "sk_live_your_key_here"`}</code></pre>
-    <p>Codex reads <code>~/.agents/skills</code>. When installing via Skillsmith CLI, pass <code>--client agents</code>.</p>
-  </details>
-
-  <details>
-    <summary><strong>Cross-agent (open standard)</strong> — <code>~/.agents/mcp.json</code></summary>
-    <pre><code>{`{
-  "mcpServers": {
-    "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
-      "env": {
-        "SKILLSMITH_API_KEY": "sk_live_your_key_here"
-      }
-    }
-  }
-}`}</code></pre>
-    <p>Read by any agent honouring the cross-agent skill convention.</p>
-  </details>
+  {MCP_CLIENT_SNIPPETS.map((client) => (
+    <details open={client.openByDefault}>
+      <summary><strong>{client.label}</strong> — <code>{client.configPath}</code>{client.format !== 'json' ? ` (${client.format.toUpperCase()})` : ''}</summary>
+      <pre><code>{withApiKey(client.body, client.format, client.id)}</code></pre>
+      {client.notes && <p set:html={client.notes} />}
+    </details>
+  ))}
 
   <div class="callout warning">
     <p class="callout-heading">Shell Exports Don't Work</p>

--- a/packages/website/src/pages/docs/quickstart.astro
+++ b/packages/website/src/pages/docs/quickstart.astro
@@ -6,6 +6,7 @@
  * 2. Alternative: Direct CLI usage
  */
 import DocsLayout from '../../layouts/DocsLayout.astro';
+import { MCP_CLIENT_SNIPPETS } from '../../lib/mcp-client-snippets';
 ---
 
 <DocsLayout title="5-Minute Setup" description="Get started with Skillsmith in 5 minutes. Two ways to discover and install skills for your development environment.">
@@ -37,20 +38,20 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
           {
             "@type": "HowToStep",
             "position": 1,
-            "name": "Install an MCP Client",
-            "text": "Install an MCP-compatible client such as Claude Code: npm install -g @anthropic-ai/claude-code"
+            "name": "Open Your Project, Then Open Your AI Agent",
+            "text": "Navigate to your project directory, then open your AI coding agent (Claude Code, Cursor, GitHub Copilot, Windsurf, Codex CLI, or another MCP client) from inside it."
           },
           {
             "@type": "HowToStep",
             "position": 2,
-            "name": "Configure Skillsmith MCP Server",
-            "text": "Add the configuration snippet to your MCP client settings.json. Then restart your MCP client to load the server."
+            "name": "Add the Skillsmith MCP Server",
+            "text": "Add the Skillsmith MCP server using Claude Code's built-in 'claude mcp add' command, by asking your agent in chat, or by editing your MCP client's config file directly. Then restart your agent to load Skillsmith."
           },
           {
             "@type": "HowToStep",
             "position": 3,
-            "name": "Discover Skills",
-            "text": "Navigate to your project directory, start your MCP client, and ask: 'What skills would be helpful for this project?'"
+            "name": "Discover Skills for Your Project",
+            "text": "Ask your agent: 'What skills would be helpful for this project?'"
           }
         ]
       },
@@ -217,11 +218,34 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
   <div class="callout">
     <p class="callout-heading">What is MCP?</p>
     <p>
-      MCP (Model Context Protocol) lets AI assistants like Claude Code connect to external tool servers. Skillsmith provides an MCP server that gives your assistant the ability to search and install skills for you.
+      MCP (Model Context Protocol) lets AI coding agents — Claude Code, Cursor, GitHub Copilot, Windsurf, Codex CLI, and others — connect to external tool servers. An "MCP client" is just your agent's name for this capability. Skillsmith provides an MCP server that gives your agent the ability to search and install skills for you.
     </p>
   </div>
 
-  <h3 id="step-a1">Step 1: Install an MCP Client</h3>
+  <h3 id="step-a1">Step 1: Open Your Project, Then Open Your AI Agent</h3>
+
+  <p>
+    Skillsmith reads your project's <code>package.json</code> and file structure to
+    recommend relevant skills, so open your AI agent from inside the project you
+    want skills for.
+  </p>
+
+  <pre><code>{`cd /path/to/your/project`}</code></pre>
+
+  <p>
+    "MCP client" just means your AI coding agent — Claude Code, Cursor, GitHub
+    Copilot, Windsurf, and Codex CLI all work the same way here. Already have one
+    open in this project? <a href="#step-a2">Skip to Step 2</a>.
+  </p>
+
+  <div class="callout">
+    <p>
+      <strong>Don't have an agent yet?</strong> Claude Code is a fast-to-install
+      default — any agent above works the same way.
+    </p>
+  </div>
+
+  <p><strong>Installing Claude Code</strong> (skip this if you already have an agent open):</p>
 
   <div class="quickstart-tabs-container">
     <div class="quickstart-tabs">
@@ -255,109 +279,79 @@ curl -fsSL https://claude.ai/install.sh | sh`}</code></pre>
     </div>
   </div>
 
-  <h3 id="step-a2">Step 2: Add Skillsmith MCP Server</h3>
+  <h3 id="step-a2">Step 2: Add the Skillsmith MCP Server</h3>
 
   <p>
-    Pick the snippet for your MCP client. Every snippet uses the same shape —
-    only the config-file path (and, for Codex, the format) differs.
+    Using Claude Code? Start with Option A. Using any other agent? Skip to Option B.
   </p>
 
-  <details open>
-    <summary><strong>Claude Code</strong> — <code>~/.claude/settings.json</code></summary>
-    <pre><code>{`{
-  "mcpServers": {
-    "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"]
-    }
-  }
-}`}</code></pre>
-  </details>
+  <h4>Option A — Claude Code's built-in command (fastest)</h4>
 
-  <details>
-    <summary><strong>Cursor</strong> — <code>~/.cursor/mcp.json</code></summary>
-    <pre><code>{`{
-  "mcpServers": {
-    "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"]
-    }
-  }
-}`}</code></pre>
-    <p>Cursor 2.4+ required.</p>
-  </details>
-
-  <details>
-    <summary><strong>GitHub Copilot (VS Code)</strong> — <code>.vscode/mcp.json</code> (workspace)</summary>
-    <pre><code>{`{
-  "mcpServers": {
-    "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"]
-    }
-  }
-}`}</code></pre>
-    <p>VS Code 1.108+ required.</p>
-  </details>
-
-  <details>
-    <summary><strong>Windsurf</strong> — <code>~/.codeium/windsurf/mcp_config.json</code></summary>
-    <pre><code>{`{
-  "mcpServers": {
-    "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"]
-    }
-  }
-}`}</code></pre>
-  </details>
-
-  <details>
-    <summary><strong>Codex CLI</strong> — <code>~/.codex/config.toml</code> (TOML, not JSON)</summary>
-    <pre><code>{`[mcp_servers.@skillsmith/mcp-server]
-command = "npx"
-args = ["-y", "@skillsmith/mcp-server"]`}</code></pre>
-    <p>
-      Codex reads <code>~/.agents/skills</code>. When installing via Skillsmith CLI, pass
-      <code>--client agents</code>.
-    </p>
-  </details>
-
-  <details>
-    <summary><strong>Cross-agent (open standard)</strong> — <code>~/.agents/mcp.json</code></summary>
-    <pre><code>{`{
-  "mcpServers": {
-    "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"]
-    }
-  }
-}`}</code></pre>
-  </details>
-
-  <div class="callout">
-    <p class="callout-heading">Tip</p>
-    <p>
-      You can also paste any snippet directly into your AI assistant's chat, and it can
-      update the relevant config file for you.
-    </p>
-  </div>
+  <pre><code>{`claude mcp add skillsmith -- npx -y @skillsmith/mcp-server`}</code></pre>
 
   <p>
-    After updating your settings, restart your MCP client to load Skillsmith.
+    The <code>--</code> separates Claude Code's own flags from the command it should
+    run. This adds the server at the default <code>--scope local</code> (this
+    project only); pass <code>--scope user</code> to make it available in every
+    project instead, or <code>--scope project</code> to share it via a checked-in
+    config. Verify with <code>claude mcp list</code>; remove it with
+    <code>claude mcp remove skillsmith</code>.
+  </p>
+
+  <p>
+    <em>Note: <code>skillsmith</code> here is just a local name you're choosing for
+    this install — it doesn't need to match the <code>@skillsmith/mcp-server</code>
+    package name used in Option B/C's config files.</em>
+  </p>
+
+  <h4>Option B — Ask your agent in chat (works with any agent)</h4>
+
+  <p>
+    This is a normal file-edit request, not a special "auto-config" feature — your
+    agent will edit a config file for you, and you should expect the usual
+    permission prompt the first time it writes to a new file. Paste this into your
+    agent's chat:
+  </p>
+
+  <pre><code>{`Please add the Skillsmith MCP server to my MCP client configuration.
+Create the config file if it doesn't exist yet, and show me the diff
+before you save. Use this entry:
+
+{
+  "mcpServers": {
+    "@skillsmith/mcp-server": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"]
+    }
+  }
+}
+
+Tell me which file you changed when you're done.`}</code></pre>
+
+  <h4>Option C — Edit the config file yourself</h4>
+
+  <p>
+    Pick the snippet for your MCP client and add it to the matching config file.
+    Every snippet uses the same shape — only the config-file path (and, for
+    Codex/Hermes, the format) differs.
+  </p>
+
+  {MCP_CLIENT_SNIPPETS.map((client) => (
+    <details open={client.openByDefault}>
+      <summary><strong>{client.label}</strong> — <code>{client.configPath}</code>{client.format !== 'json' ? ` (${client.format.toUpperCase()})` : ''}</summary>
+      <pre><code>{client.body}</code></pre>
+      {client.notes && <p set:html={client.notes} />}
+    </details>
+  ))}
+
+  <p>
+    After any of the three options above, restart your agent to load Skillsmith.
   </p>
 
   <h3 id="step-a3">Step 3: Discover Skills for Your Project</h3>
 
   <p>
-    Navigate to your project directory and start your MCP client:
-  </p>
-
-  <pre><code>{`cd /path/to/your/project
-claude`}</code></pre>
-
-  <p>
-    Now just ask your assistant to find skills for your project:
+    You're already in your project with your agent open from Step 1 — just ask:
   </p>
 
   <div class="quickstart-conversation">

--- a/packages/website/src/pages/docs/quickstart.astro
+++ b/packages/website/src/pages/docs/quickstart.astro
@@ -174,7 +174,6 @@ import { MCP_CLIENT_SNIPPETS } from '../../lib/mcp-client-snippets';
           </svg>
         </div>
         <div>
-          <span class="quickstart-badge quickstart-badge-primary">Recommended</span>
           <h3 class="quickstart-card-title">MCP Client Setup</h3>
         </div>
       </div>
@@ -197,7 +196,6 @@ import { MCP_CLIENT_SNIPPETS } from '../../lib/mcp-client-snippets';
           </svg>
         </div>
         <div>
-          <span class="quickstart-badge quickstart-badge-secondary">Alternative</span>
           <h3 class="quickstart-card-title">Direct CLI</h3>
         </div>
       </div>
@@ -213,7 +211,7 @@ import { MCP_CLIENT_SNIPPETS } from '../../lib/mcp-client-snippets';
   </div>
 
   <!-- PATH A: MCP Client -->
-  <h2 id="path-claude-code">Using an MCP Client (Recommended)</h2>
+  <h2 id="path-claude-code">Using an MCP Client</h2>
 
   <div class="callout">
     <p class="callout-heading">What is MCP?</p>
@@ -719,18 +717,6 @@ skillsmith info jest-helper`}</code></pre>
     }
     .quickstart-icon-muted {
       color: #9ca3af;
-    }
-    .quickstart-badge {
-      font-size: 0.625rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-    }
-    .quickstart-badge-primary {
-      color: #38bdf8;
-    }
-    .quickstart-badge-secondary {
-      color: #6b7280;
     }
     .quickstart-card-title {
       font-size: 1.125rem !important;


### PR DESCRIPTION
## Summary

- Restructures Path A ("Using an MCP Client") of `/docs/quickstart`: Step 1 now opens the project + agent first (Claude Code framed as one option among several, not the only path), Step 2 offers three tiered ways to add the MCP server (Claude Code's `claude mcp add` CLI command, an ask-your-agent-in-chat prompt, or manual config editing), Step 3 drops the now-redundant navigation.
- Fixes a real drift bug found during research: `quickstart.astro` and `getting-started.astro` each hardcoded their own 6-client MCP snippet set, missing 2 of the 8 canonical clients (`opencode`, `hermes`) documented in `packages/cli/src/templates/mcp-server.template.snippets.ts`, with no test guarding it.
- Extracts a shared `packages/website/src/lib/mcp-client-snippets.ts` (8 clients + a `withApiKey()` helper) consumed by both pages, plus `mcp-client-snippets.parity.test.ts` (modeled on `skill-card.parity.test.ts`) that checks snippet bodies, not just metadata.
- Plan reviewed via `/plan-review-skill` (VP Product/Engineering/Design, 7 findings incorporated) before implementation; governance review after implementation found and fixed 2 more regressions (Windsurf's `${env:VAR}` interpolation example and Cursor/Copilot's fuller getting-started notes were silently dropped by the initial generic refactor — restored).

Linear: SMI-5554 (this change), SMI-5555 (follow-up — an unrelated npx-in-worktree infra bug found and worked around along the way).

## Test plan

- [x] `npm run build` (astro check + astro build) — clean
- [x] `npm test` — 458/458 tests pass, including new parity test
- [x] `npm run lint` — zero warnings/errors on touched files
- [x] `npm run audit:standards` — 0 failures (7 pre-existing warnings, all unrelated to this diff)
- [x] Manual dev-server check of both `/docs/quickstart` and `/docs/getting-started` — all 8 clients render, JSON-LD validates, HTML entities in notes render correctly
- [ ] Manual: paste the Step 2 Option B prompt into a real agent against a scratch project to confirm it produces a correct, permission-gated config edit (can't be scripted/CI'd)

Code review report: `docs/internal/code_review/2026-07-06-smi-5554-quickstart-mcp-flow.md`

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)