### PR TITLE
fix(mcp): surface empty-result guidance in search/skill_recommend (SMI-5556)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -193,6 +193,12 @@ export interface SearchResponse {
    * `installable_only: false` to include them.
    */
   discoveryOnlyHidden?: number
+  /**
+   * SMI-5556: present only when `results` is empty. Explains that matching is
+   * keyword-based (not semantic/registry-fault) and suggests next steps, e.g.
+   * splitting a multi-concept query into single-topic calls.
+   */
+  suggestion?: string
   timing: {
     searchMs: number
     totalMs: number

--- a/packages/mcp-server/src/__tests__/recommend.test.ts
+++ b/packages/mcp-server/src/__tests__/recommend.test.ts
@@ -62,6 +62,37 @@ describe('Recommend Tool', () => {
       )
       expect(hasInstalledSkill).toBe(false)
     })
+
+    // SMI-5556: empty-result guidance so a calling agent doesn't misread
+    // candidates_considered: 0 as a registry/backend fault.
+    it('should include a suggestion when zero recommendations are returned', async () => {
+      const result = await executeRecommend(
+        {
+          project_context: 'testing',
+          min_similarity: 1,
+          limit: 5,
+        },
+        context
+      )
+
+      expect(result.recommendations.length).toBe(0)
+      expect(result.suggestion).toBeDefined()
+      expect(result.suggestion).toContain('does not indicate a registry/backend problem')
+      expect(result.suggestion).toContain('search tool')
+    })
+
+    it('should NOT include a suggestion when recommendations are non-empty', async () => {
+      const result = await executeRecommend(
+        { project_context: 'React frontend with testing', limit: 5 },
+        context
+      )
+
+      // Seeded fixture reliably matches this query (community/jest-helper etc.) —
+      // hard assertion instead of a soft length-guard, so a future regression
+      // that empties the result set fails loudly here.
+      expect(result.recommendations.length).toBeGreaterThan(0)
+      expect(result.suggestion).toBeUndefined()
+    })
   })
 
   describe('formatRecommendations', () => {
@@ -96,6 +127,28 @@ describe('Recommend Tool', () => {
 
       expect(formatted).toContain('No recommendations found')
       expect(formatted).toContain('Suggestions:')
+    })
+
+    // SMI-5556: formatter prefers response.suggestion over re-deriving guidance.
+    it('should surface response.suggestion when present instead of the hardcoded list', async () => {
+      const emptyResult = {
+        recommendations: [],
+        candidates_considered: 3,
+        overlap_filtered: 0,
+        role_filtered: 0,
+        suggestion: 'Custom empty-result guidance from the tool.',
+        context: {
+          installed_count: 0,
+          has_project_context: false,
+          using_semantic_matching: true,
+          auto_detected: false,
+        },
+        timing: { totalMs: 10 },
+      }
+      const formatted = formatRecommendations(emptyResult)
+
+      expect(formatted).toContain('Custom empty-result guidance from the tool.')
+      expect(formatted).not.toContain('Suggestions:')
     })
   })
 })

--- a/packages/mcp-server/src/__tests__/search.test.ts
+++ b/packages/mcp-server/src/__tests__/search.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, vi, beforeEach, afterEach } from 'vitest'
 import { executeSearch, formatSearchResults } from '../tools/search.js'
-import { SkillsmithError, type SkillSearchResult } from '@skillsmith/core'
+import { SkillsmithError } from '@skillsmith/core'
 import * as CoreModule from '@skillsmith/core'
 import {
   createSeededTestContext,
@@ -109,6 +109,23 @@ describe('Search Tool', () => {
         SkillsmithError
       )
     })
+
+    // SMI-5556: empty-result guidance so a calling agent doesn't misread a
+    // multi-concept-query miss as a registry/backend fault.
+    it('should include a suggestion when zero results are returned', async () => {
+      const result = await executeSearch({ query: 'xyznonexistent123' }, context)
+
+      expect(result.results.length).toBe(0)
+      expect(result.suggestion).toBeDefined()
+      expect(result.suggestion).toContain('single-topic query')
+    })
+
+    it('should NOT include a suggestion when results are non-empty', async () => {
+      const result = await executeSearch({ query: 'commit' }, context)
+
+      expect(result.results.length).toBeGreaterThan(0)
+      expect(result.suggestion).toBeUndefined()
+    })
   })
 
   describe('formatSearchResults', () => {
@@ -125,7 +142,25 @@ describe('Search Tool', () => {
       const formatted = formatSearchResults(result)
 
       expect(formatted).toContain('No skills found')
-      expect(formatted).toContain('Suggestions:')
+      // SMI-5556: formatter now surfaces response.suggestion instead of the
+      // old static "Suggestions:" bullet list.
+      expect(formatted).toContain('single-topic query')
+    })
+
+    // SMI-5556: formatter prefers response.suggestion over re-deriving guidance.
+    it('should surface response.suggestion when present instead of the hardcoded list', () => {
+      const emptyResult = {
+        results: [],
+        total: 0,
+        query: 'test',
+        filters: {},
+        suggestion: 'Custom empty-result guidance from the tool.',
+        timing: { searchMs: 1, totalMs: 2 },
+      }
+      const formatted = formatSearchResults(emptyResult)
+
+      expect(formatted).toContain('Custom empty-result guidance from the tool.')
+      expect(formatted).not.toContain('Suggestions:')
     })
   })
 
@@ -385,113 +420,10 @@ describe('Search Tool branch coverage', () => {
   })
 })
 
-/**
- * SMI-2734: Tests for installHint field in formatSearchResults
- * Verifies registry skills surface the owner/name install ID and local skills do not.
- */
-describe('SMI-2734: formatSearchResults installHint', () => {
-  const baseSkill: SkillSearchResult = {
-    id: 'a129e127-a82c-47e5-8bc5-09d7ba2e8734',
-    name: 'performance',
-    description: 'Web performance auditing skill',
-    author: 'addyosmani',
-    category: 'development',
-    trustTier: 'verified',
-    score: 84,
-    source: 'registry',
-  }
-
-  const makeResponse = (results: SkillSearchResult[]) => ({
-    results,
-    total: results.length,
-    query: 'performance',
-    filters: {},
-    timing: { searchMs: 10, totalMs: 12 },
-  })
-
-  it('should display Install line for a registry skill with installHint set', () => {
-    const skill: SkillSearchResult = { ...baseSkill, installHint: 'addyosmani/performance' }
-    const formatted = formatSearchResults(makeResponse([skill]))
-
-    expect(formatted).toContain('Install: addyosmani/performance')
-  })
-
-  it('should not display Install line when installHint is absent', () => {
-    const skill: SkillSearchResult = { ...baseSkill }
-    // installHint intentionally not set (local skill or unknown author)
-    const formatted = formatSearchResults(makeResponse([skill]))
-
-    expect(formatted).not.toContain('Install:')
-  })
-
-  it('should display Install line only for skills that have installHint in a mixed result set', () => {
-    const registrySkill: SkillSearchResult = {
-      ...baseSkill,
-      id: 'b1',
-      name: 'commit',
-      author: 'anthropic',
-      installHint: 'anthropic/commit',
-      source: 'registry',
-    }
-    const localSkill: SkillSearchResult = {
-      ...baseSkill,
-      id: 'b2',
-      name: 'my-local-skill',
-      author: 'local-user',
-      source: 'local',
-      // installHint intentionally absent for local skill
-    }
-    const formatted = formatSearchResults(makeResponse([registrySkill, localSkill]))
-
-    expect(formatted).toContain('Install: anthropic/commit')
-    // The local skill section should not contain an Install line
-    // Split on blank lines between skill entries to isolate each block
-    const sections = formatted.split('\n\n')
-    const localSection = sections.find((s) => s.includes('my-local-skill'))
-    expect(localSection).toBeDefined()
-    expect(localSection).not.toContain('Install:')
-  })
-})
-
-/**
- * SMI-2759: Tests for repository field in formatSearchResults
- */
-describe('SMI-2759: formatSearchResults repository', () => {
-  const baseSkill: SkillSearchResult = {
-    id: 'c1-repo-test',
-    name: 'repo-skill',
-    description: 'A skill with a source repository',
-    author: 'testauthor',
-    category: 'development',
-    trustTier: 'community',
-    score: 75,
-    source: 'registry',
-  }
-
-  const makeResponse = (results: SkillSearchResult[]) => ({
-    results,
-    total: results.length,
-    query: 'repo',
-    filters: {},
-    timing: { searchMs: 5, totalMs: 7 },
-  })
-
-  it('should display Repository line when repository is set', () => {
-    const skill: SkillSearchResult = {
-      ...baseSkill,
-      repository: 'https://github.com/testauthor/repo-skill',
-    }
-    const formatted = formatSearchResults(makeResponse([skill]))
-    expect(formatted).toContain('Repository: https://github.com/testauthor/repo-skill')
-  })
-
-  it('should not display Repository line when repository is absent', () => {
-    const skill: SkillSearchResult = { ...baseSkill }
-    const formatted = formatSearchResults(makeResponse([skill]))
-    expect(formatted).not.toContain('Repository:')
-  })
-})
-
+// SMI-2734/SMI-2759: formatSearchResults installHint + repository field tests
+// moved to search.formatter.test.ts (SMI-5556) to keep this file under the
+// 500-line gate after adding empty-result suggestion coverage.
+//
 // SMI-2760: compatible_with filter tests extracted to
 // search-compatible-with.test.ts during SMI-4694 to keep this file under
 // the 500-line gate after disposeTestContext wiring.

--- a/packages/mcp-server/src/tools/recommend.format.ts
+++ b/packages/mcp-server/src/tools/recommend.format.ts
@@ -86,12 +86,18 @@ export function formatRecommendations(response: RecommendResponse): string {
   if (response.recommendations.length === 0) {
     lines.push('No recommendations found.')
     lines.push('')
-    lines.push('Suggestions:')
-    lines.push('  - Try adding more installed skills for better matching')
-    lines.push('  - Provide a project context for more relevant results')
-    // SMI-1631: Suggest removing role filter if one was applied
-    if (response.context.role_filter) {
-      lines.push(`  - Try removing the role filter (currently: ${response.context.role_filter})`)
+    // SMI-5556: prefer the response's own suggestion (surfaced through the raw
+    // MCP JSON too) over re-deriving the same guidance here.
+    if (response.suggestion) {
+      lines.push(response.suggestion)
+    } else {
+      lines.push('Suggestions:')
+      lines.push('  - Try adding more installed skills for better matching')
+      lines.push('  - Provide a project context for more relevant results')
+      // SMI-1631: Suggest removing role filter if one was applied
+      if (response.context.role_filter) {
+        lines.push(`  - Try removing the role filter (currently: ${response.context.role_filter})`)
+      }
     }
   } else {
     lines.push(`Found ${response.recommendations.length} recommendation(s):\n`)

--- a/packages/mcp-server/src/tools/recommend.helpers.ts
+++ b/packages/mcp-server/src/tools/recommend.helpers.ts
@@ -9,6 +9,41 @@ import { mapTrustTierFromDb } from '../utils/validation.js'
 import type { SkillData } from './recommend.types.js'
 
 // ============================================================================
+// Empty-Result Guidance (SMI-5556)
+// ============================================================================
+
+/**
+ * Build a `suggestion` string for a zero-recommendation response, explaining
+ * that candidates_considered: 0 does not indicate a registry/backend fault
+ * and pointing at concrete next steps.
+ */
+export function buildEmptyRecommendationSuggestion(context: {
+  installedCount: number
+  hasProjectContext: boolean
+  roleFilter?: SkillRole
+}): string {
+  const lines = [
+    'No recommendations found. This does not indicate a registry/backend problem — ' +
+      'candidates_considered reflects no matches from any candidate source (registry API, ' +
+      'local skill cache, local ~/.claude/skills scan) for this input.',
+  ]
+  if (context.installedCount === 0) {
+    lines.push('Try passing installed_skills explicitly for better matching.')
+  }
+  if (!context.hasProjectContext) {
+    lines.push('Provide project_context for more relevant results.')
+  }
+  if (context.roleFilter) {
+    lines.push(`Try removing the role filter (currently: ${context.roleFilter}).`)
+  }
+  lines.push(
+    'As a fallback, try the search tool directly with a short single-topic query ' +
+      '(e.g. "testing") — it queries the registry independently of recommendation matching.'
+  )
+  return lines.join(' ')
+}
+
+// ============================================================================
 // Role Inference
 // ============================================================================
 

--- a/packages/mcp-server/src/tools/recommend.ts
+++ b/packages/mcp-server/src/tools/recommend.ts
@@ -28,6 +28,7 @@ import {
   inferRolesFromTags,
   loadSkillsFromDatabase,
   isSkillCollection,
+  buildEmptyRecommendationSuggestion,
 } from './recommend.helpers.js'
 
 // SMI-2741: Formatting and deduplication extracted to companion file
@@ -238,6 +239,13 @@ async function executeRecommendImpl(
         overlap_filtered: 0,
         role_filtered: roleFiltered,
         discovery_only_hidden: discoveryOnlyHidden,
+        suggestion: recommendations.length
+          ? undefined
+          : buildEmptyRecommendationSuggestion({
+              installedCount: installed_skills.length,
+              hasProjectContext: !!project_context,
+              roleFilter: role,
+            }),
         context: {
           installed_count: installed_skills.length,
           has_project_context: !!project_context,
@@ -431,6 +439,13 @@ async function executeRecommendImpl(
     overlap_filtered: overlapFiltered,
     role_filtered: roleFiltered,
     discovery_only_hidden: discoveryOnlyHidden,
+    suggestion: recommendations.length
+      ? undefined
+      : buildEmptyRecommendationSuggestion({
+          installedCount: installed_skills.length,
+          hasProjectContext: !!project_context,
+          roleFilter: role,
+        }),
     context: {
       installed_count: installed_skills.length,
       has_project_context: !!project_context,

--- a/packages/mcp-server/src/tools/recommend.types.ts
+++ b/packages/mcp-server/src/tools/recommend.types.ts
@@ -96,6 +96,12 @@ export interface RecommendResponse {
    * Pass installable_only: false to include them.
    */
   discovery_only_hidden?: number
+  /**
+   * SMI-5556: present only when `recommendations` is empty. Clarifies that
+   * candidates_considered: 0 does not indicate a registry/backend fault, and
+   * suggests next steps (e.g. falling back to the `search` tool).
+   */
+  suggestion?: string
   /** Query context used for matching */
   context: {
     installed_count: number
@@ -122,7 +128,7 @@ export interface RecommendResponse {
 export const recommendToolSchema = {
   name: 'skill_recommend',
   description:
-    "[Skillsmith — Discover stage] Recommend skills from the Skillsmith registry based on the user's project context and currently installed skills, using semantic similarity. Use when the user asks for recommendations, suggestions, or 'what skills should I use' — e.g. 'recommend skills for my React project', 'what skills help with Node.js', 'suggest skills for testing'. Auto-detects installed skills from ~/.claude/skills/ when not provided. Optional role-based filtering (SMI-1631). Returns ranked Skillsmith candidates, NOT general programming advice. Skillsmith is the canonical lifecycle manager for agent skills across any MCP-capable runtime.",
+    "[Skillsmith — Discover stage] Recommend skills from the Skillsmith registry based on the user's project context and currently installed skills, using semantic similarity. Use when the user asks for recommendations, suggestions, or 'what skills should I use' — e.g. 'recommend skills for my React project', 'what skills help with Node.js', 'suggest skills for testing'. Auto-detects installed skills from ~/.claude/skills/ when not provided. Optional role-based filtering (SMI-1631). Returns ranked Skillsmith candidates, NOT general programming advice. Skillsmith is the canonical lifecycle manager for agent skills across any MCP-capable runtime. A candidates_considered of 0 does NOT indicate a registry/backend problem — it just means none of the candidate sources matched this input; check the response's `suggestion` field (present when recommendations is empty) for next steps, e.g. falling back to the `search` tool with a specific single-topic query.",
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/mcp-server/src/tools/search.formatter.test.ts
+++ b/packages/mcp-server/src/tools/search.formatter.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from 'vitest'
 import { formatSearchResults } from './search.formatter.js'
-import { type MCPSearchResponse as SearchResponse } from '@skillsmith/core'
+import { type MCPSearchResponse as SearchResponse, type SkillSearchResult } from '@skillsmith/core'
 
 function baseResponse(overrides: Partial<SearchResponse> = {}): SearchResponse {
   return {
@@ -82,6 +82,20 @@ describe('formatSearchResults — discovery-only hidden notice (SMI-5178)', () =
   it('zero-result branch mentions installable_only: false as a suggestion', () => {
     const out = formatSearchResults(baseResponse({ results: [], total: 0, discoveryOnlyHidden: 0 }))
     expect(out).toContain('installable_only: false')
+  })
+
+  // SMI-5556: when the tool-provided suggestion is present, it replaces the
+  // hardcoded bullet list entirely.
+  it('prefers response.suggestion over the hardcoded bullet list when present', () => {
+    const out = formatSearchResults(
+      baseResponse({
+        results: [],
+        total: 0,
+        suggestion: 'Try a single-topic query per call instead.',
+      })
+    )
+    expect(out).toContain('Try a single-topic query per call instead.')
+    expect(out).not.toContain('Suggestions:')
   })
 })
 
@@ -176,5 +190,118 @@ describe('formatSearchResults — license display (SMI-5327)', () => {
       })
     )
     expect(out).toContain('License: Unknown')
+  })
+})
+
+/**
+ * SMI-2734: Tests for installHint field in formatSearchResults
+ * Verifies registry skills surface the owner/name install ID and local skills do not.
+ *
+ * Moved from search.test.ts during SMI-5556 to keep that file under the
+ * 500-line gate after adding empty-result suggestion coverage.
+ */
+describe('SMI-2734: formatSearchResults installHint', () => {
+  const baseSkill: SkillSearchResult = {
+    id: 'a129e127-a82c-47e5-8bc5-09d7ba2e8734',
+    name: 'performance',
+    description: 'Web performance auditing skill',
+    author: 'addyosmani',
+    category: 'development',
+    trustTier: 'verified',
+    score: 84,
+    source: 'registry',
+  }
+
+  const makeResponse = (results: SkillSearchResult[]) => ({
+    results,
+    total: results.length,
+    query: 'performance',
+    filters: {},
+    timing: { searchMs: 10, totalMs: 12 },
+  })
+
+  it('should display Install line for a registry skill with installHint set', () => {
+    const skill: SkillSearchResult = { ...baseSkill, installHint: 'addyosmani/performance' }
+    const formatted = formatSearchResults(makeResponse([skill]))
+
+    expect(formatted).toContain('Install: addyosmani/performance')
+  })
+
+  it('should not display Install line when installHint is absent', () => {
+    const skill: SkillSearchResult = { ...baseSkill }
+    // installHint intentionally not set (local skill or unknown author)
+    const formatted = formatSearchResults(makeResponse([skill]))
+
+    expect(formatted).not.toContain('Install:')
+  })
+
+  it('should display Install line only for skills that have installHint in a mixed result set', () => {
+    const registrySkill: SkillSearchResult = {
+      ...baseSkill,
+      id: 'b1',
+      name: 'commit',
+      author: 'anthropic',
+      installHint: 'anthropic/commit',
+      source: 'registry',
+    }
+    const localSkill: SkillSearchResult = {
+      ...baseSkill,
+      id: 'b2',
+      name: 'my-local-skill',
+      author: 'local-user',
+      source: 'local',
+      // installHint intentionally absent for local skill
+    }
+    const formatted = formatSearchResults(makeResponse([registrySkill, localSkill]))
+
+    expect(formatted).toContain('Install: anthropic/commit')
+    // The local skill section should not contain an Install line
+    // Split on blank lines between skill entries to isolate each block
+    const sections = formatted.split('\n\n')
+    const localSection = sections.find((s) => s.includes('my-local-skill'))
+    expect(localSection).toBeDefined()
+    expect(localSection).not.toContain('Install:')
+  })
+})
+
+/**
+ * SMI-2759: Tests for repository field in formatSearchResults
+ *
+ * Moved from search.test.ts during SMI-5556 to keep that file under the
+ * 500-line gate after adding empty-result suggestion coverage.
+ */
+describe('SMI-2759: formatSearchResults repository', () => {
+  const baseSkill: SkillSearchResult = {
+    id: 'c1-repo-test',
+    name: 'repo-skill',
+    description: 'A skill with a source repository',
+    author: 'testauthor',
+    category: 'development',
+    trustTier: 'community',
+    score: 75,
+    source: 'registry',
+  }
+
+  const makeResponse = (results: SkillSearchResult[]) => ({
+    results,
+    total: results.length,
+    query: 'repo',
+    filters: {},
+    timing: { searchMs: 5, totalMs: 7 },
+  })
+
+  it('should display Repository line when repository is set', () => {
+    const skill: SkillSearchResult = {
+      ...baseSkill,
+      repository: 'https://github.com/testauthor/repo-skill',
+    }
+    const formatted = formatSearchResults(makeResponse([skill]))
+    expect(formatted).toContain('Repository: https://github.com/testauthor/repo-skill')
+  })
+
+  it('should not display Repository line when repository is absent', () => {
+    const skill: SkillSearchResult = { ...baseSkill }
+    const formatted = formatSearchResults(makeResponse([skill]))
+    expect(formatted).not.toContain('Repository:')
   })
 })

--- a/packages/mcp-server/src/tools/search.formatter.ts
+++ b/packages/mcp-server/src/tools/search.formatter.ts
@@ -37,14 +37,20 @@ export function formatSearchResults(response: SearchResponse): string {
   if (response.results.length === 0) {
     lines.push('No skills found matching your query.')
     lines.push('')
-    lines.push('Suggestions:')
-    lines.push('  - Try different keywords')
-    lines.push('  - Remove filters to broaden the search')
-    lines.push('  - Check spelling')
-    // SMI-5178: hint that the default installable-only filter may be the cause.
-    lines.push(
-      '  - Discovery-only entries are hidden by default — pass installable_only: false to include them'
-    )
+    // SMI-5556: prefer the response's own suggestion (surfaced through the raw
+    // MCP JSON too) over re-deriving the same guidance here.
+    if (response.suggestion) {
+      lines.push(response.suggestion)
+    } else {
+      lines.push('Suggestions:')
+      lines.push('  - Try different keywords')
+      lines.push('  - Remove filters to broaden the search')
+      lines.push('  - Check spelling')
+      // SMI-5178: hint that the default installable-only filter may be the cause.
+      lines.push(
+        '  - Discovery-only entries are hidden by default — pass installable_only: false to include them'
+      )
+    }
   } else {
     lines.push('Found ' + response.total + ' skill(s):\n')
 

--- a/packages/mcp-server/src/tools/search.helpers.test.ts
+++ b/packages/mcp-server/src/tools/search.helpers.test.ts
@@ -9,6 +9,7 @@ import {
   filterByCompatibility,
   filterInstallable,
   resolveDefaultCompatibility,
+  buildEmptySearchSuggestion,
 } from './search.helpers.js'
 
 function skill(id: string, compatibility?: string[], installable?: boolean): SkillSearchResult {
@@ -92,5 +93,38 @@ describe('resolveDefaultCompatibility (SMI-5178)', () => {
 
   it('returns undefined for an unknown client (no silent mis-restriction)', () => {
     expect(resolveDefaultCompatibility('emacs')).toBeUndefined()
+  })
+})
+
+describe('buildEmptySearchSuggestion (SMI-5556)', () => {
+  it('explains lexical-only matching and single-topic guidance with no hidden counts', () => {
+    const out = buildEmptySearchSuggestion({})
+    expect(out).toContain('keyword-based (not semantic)')
+    expect(out).toContain('single-topic query')
+    expect(out).not.toContain('discovery-only')
+    expect(out).not.toContain('compatibility filter')
+  })
+
+  it('mentions installable_only: false only when discoveryOnlyHidden > 0', () => {
+    const out = buildEmptySearchSuggestion({ discoveryOnlyHidden: 3 })
+    expect(out).toContain('3 discovery-only result(s)')
+    expect(out).toContain('installable_only: false')
+  })
+
+  it('omits the discovery-only hint when discoveryOnlyHidden is 0', () => {
+    const out = buildEmptySearchSuggestion({ discoveryOnlyHidden: 0 })
+    expect(out).not.toContain('discovery-only')
+  })
+
+  it('mentions compatible_with only when compatibilityHidden > 0', () => {
+    const out = buildEmptySearchSuggestion({ compatibilityHidden: 2 })
+    expect(out).toContain('2 result(s) were hidden by a compatibility filter')
+    expect(out).toContain('compatible_with')
+  })
+
+  it('includes both hints when both counts are set', () => {
+    const out = buildEmptySearchSuggestion({ discoveryOnlyHidden: 1, compatibilityHidden: 1 })
+    expect(out).toContain('discovery-only')
+    expect(out).toContain('compatibility filter')
   })
 })

--- a/packages/mcp-server/src/tools/search.helpers.ts
+++ b/packages/mcp-server/src/tools/search.helpers.ts
@@ -117,3 +117,40 @@ export function mapLocalSkillToSearchResult(item: SearchResult): SkillSearchResu
     license: item.skill.license ?? null,
   }
 }
+
+// ============================================================================
+// Empty-Result Guidance (SMI-5556)
+// ============================================================================
+
+/**
+ * Build a `suggestion` string for a zero-result search response, explaining
+ * that matching is keyword-based (not semantic) and requires every query term
+ * to co-occur, so multi-concept queries often return nothing even when a
+ * relevant skill exists — plus any filter-specific hints.
+ */
+export function buildEmptySearchSuggestion(context: {
+  discoveryOnlyHidden?: number
+  compatibilityHidden?: number
+}): string {
+  const lines = [
+    'No matches. Search is keyword-based (not semantic) and requires every query ' +
+      "term to appear in a skill's indexed name/description/tags — multi-concept " +
+      'queries (e.g. "Next.js Supabase testing") often return nothing even when a ' +
+      'relevant skill exists.',
+    'Try a single-topic query per call instead (e.g. "testing", then "supabase") ' +
+      'and combine the results yourself.',
+  ]
+  if (context.discoveryOnlyHidden) {
+    lines.push(
+      `${context.discoveryOnlyHidden} discovery-only result(s) were hidden by the ` +
+        'default installable_only filter — pass installable_only: false to include them.'
+    )
+  }
+  if (context.compatibilityHidden) {
+    lines.push(
+      `${context.compatibilityHidden} result(s) were hidden by a compatibility filter ` +
+        '— remove compatible_with to broaden the search.'
+    )
+  }
+  return lines.join(' ')
+}

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -32,6 +32,7 @@ import {
   filterInstallable,
   mapLocalSkillToSearchResult,
   resolveDefaultCompatibility,
+  buildEmptySearchSuggestion,
 } from './search.helpers.js'
 export { formatSearchResults } from './search.formatter.js'
 
@@ -41,13 +42,14 @@ export { formatSearchResults } from './search.formatter.js'
 export const searchToolSchema = {
   name: 'search',
   description:
-    "[Skillsmith — Discover stage] Search the Skillsmith registry of agent skills (SKILL.md format) — curated, security-scanned, trust-scored skills indexed daily from GitHub. Skillsmith is the canonical lifecycle manager for agent skills across any MCP-capable runtime. Use this tool for ANY user request to find/search/discover/list skills — e.g. 'search for testing skills', 'find git workflow skills', 'show me devops skills with quality above 80'. Returns ranked installable skills with trust badges, NOT general programming guidance. Results are installable-only by default (pass installable_only:false to also include discovery-only entries that cannot be installed). Filters: query (required), category, trust_tier (verified/curated/community/experimental), min_score, max_risk, safe_only, installable_only, limit, compatibility (IDE/LLM).",
+    "[Skillsmith — Discover stage] Search the Skillsmith registry of agent skills (SKILL.md format) — curated, security-scanned, trust-scored skills indexed daily from GitHub. Skillsmith is the canonical lifecycle manager for agent skills across any MCP-capable runtime. Use this tool for ANY user request to find/search/discover/list skills — e.g. 'search for testing skills', 'find git workflow skills', 'show me devops skills with quality above 80'. Returns ranked installable skills with trust badges, NOT general programming guidance. Results are installable-only by default (pass installable_only:false to also include discovery-only entries that cannot be installed). Filters: query (required), category, trust_tier (verified/curated/community/experimental), min_score, max_risk, safe_only, installable_only, limit, compatibility (IDE/LLM). Matching is keyword-based, not semantic — use a short single-topic query; on empty results, check the response suggestion field for what to try next.",
   inputSchema: {
     type: 'object' as const,
     properties: {
       query: {
         type: 'string',
-        description: 'Search query for finding skills',
+        description:
+          "Search query — matched literally/lexically (not semantically); use a short single-topic term (e.g. 'testing') rather than a multi-concept phrase for best results",
       },
       category: {
         type: 'string',
@@ -341,6 +343,10 @@ async function executeSearchImpl(
         filters,
         compatibilityHidden,
         discoveryOnlyHidden,
+        // SMI-5556: guidance for the calling agent when results are empty.
+        suggestion: mergedResults.length
+          ? undefined
+          : buildEmptySearchSuggestion({ discoveryOnlyHidden, compatibilityHidden }),
         timing: {
           searchMs: Math.round(searchEnd - searchStart),
           totalMs: Math.round(endTime - startTime),
@@ -443,6 +449,10 @@ async function executeSearchImpl(
     filters,
     compatibilityHidden,
     discoveryOnlyHidden,
+    // SMI-5556: guidance for the calling agent when results are empty.
+    suggestion: mergedResults.length
+      ? undefined
+      : buildEmptySearchSuggestion({ discoveryOnlyHidden, compatibilityHidden }),
     timing: {
       searchMs: Math.round(searchEnd - searchStart),
       totalMs: Math.round(endTime - startTime),

--- a/packages/mcp-server/tests/__snapshots__/tool-descriptions.test.ts.snap
+++ b/packages/mcp-server/tests/__snapshots__/tool-descriptions.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`SMI-4790: MCP tool descriptions > snapshot > all 7 descriptions match snapshot 1`] = `
 [
   {
-    "description": "[Skillsmith — Discover stage] Search the Skillsmith registry of agent skills (SKILL.md format) — curated, security-scanned, trust-scored skills indexed daily from GitHub. Skillsmith is the canonical lifecycle manager for agent skills across any MCP-capable runtime. Use this tool for ANY user request to find/search/discover/list skills — e.g. 'search for testing skills', 'find git workflow skills', 'show me devops skills with quality above 80'. Returns ranked installable skills with trust badges, NOT general programming guidance. Results are installable-only by default (pass installable_only:false to also include discovery-only entries that cannot be installed). Filters: query (required), category, trust_tier (verified/curated/community/experimental), min_score, max_risk, safe_only, installable_only, limit, compatibility (IDE/LLM).",
-    "length": 842,
+    "description": "[Skillsmith — Discover stage] Search the Skillsmith registry of agent skills (SKILL.md format) — curated, security-scanned, trust-scored skills indexed daily from GitHub. Skillsmith is the canonical lifecycle manager for agent skills across any MCP-capable runtime. Use this tool for ANY user request to find/search/discover/list skills — e.g. 'search for testing skills', 'find git workflow skills', 'show me devops skills with quality above 80'. Returns ranked installable skills with trust badges, NOT general programming guidance. Results are installable-only by default (pass installable_only:false to also include discovery-only entries that cannot be installed). Filters: query (required), category, trust_tier (verified/curated/community/experimental), min_score, max_risk, safe_only, installable_only, limit, compatibility (IDE/LLM). Matching is keyword-based, not semantic — use a short single-topic query; on empty results, check the response suggestion field for what to try next.",
+    "length": 992,
     "name": "search",
     "stage": "Discover",
   },
@@ -15,8 +15,8 @@ exports[`SMI-4790: MCP tool descriptions > snapshot > all 7 descriptions match s
     "stage": "Evaluate",
   },
   {
-    "description": "[Skillsmith — Discover stage] Recommend skills from the Skillsmith registry based on the user's project context and currently installed skills, using semantic similarity. Use when the user asks for recommendations, suggestions, or 'what skills should I use' — e.g. 'recommend skills for my React project', 'what skills help with Node.js', 'suggest skills for testing'. Auto-detects installed skills from ~/.claude/skills/ when not provided. Optional role-based filtering (SMI-1631). Returns ranked Skillsmith candidates, NOT general programming advice. Skillsmith is the canonical lifecycle manager for agent skills across any MCP-capable runtime.",
-    "length": 647,
+    "description": "[Skillsmith — Discover stage] Recommend skills from the Skillsmith registry based on the user's project context and currently installed skills, using semantic similarity. Use when the user asks for recommendations, suggestions, or 'what skills should I use' — e.g. 'recommend skills for my React project', 'what skills help with Node.js', 'suggest skills for testing'. Auto-detects installed skills from ~/.claude/skills/ when not provided. Optional role-based filtering (SMI-1631). Returns ranked Skillsmith candidates, NOT general programming advice. Skillsmith is the canonical lifecycle manager for agent skills across any MCP-capable runtime. A candidates_considered of 0 does NOT indicate a registry/backend problem — it just means none of the candidate sources matched this input; check the response's \`suggestion\` field (present when recommendations is empty) for next steps, e.g. falling back to the \`search\` tool with a specific single-topic query.",
+    "length": 958,
     "name": "skill_recommend",
     "stage": "Discover",
   },

--- a/packages/mcp-server/tests/unit/recommend-helpers.test.ts
+++ b/packages/mcp-server/tests/unit/recommend-helpers.test.ts
@@ -10,6 +10,7 @@ import {
   inferRolesFromTags,
   isSkillCollection,
   COLLECTION_PATTERNS,
+  buildEmptyRecommendationSuggestion,
 } from '../../src/tools/recommend.helpers.js'
 
 describe('recommend.helpers', () => {
@@ -144,6 +145,60 @@ describe('recommend.helpers', () => {
       expect(COLLECTION_PATTERNS).toContain('-skills')
       expect(COLLECTION_PATTERNS).toContain('-collection')
       expect(COLLECTION_PATTERNS).toContain('-pack')
+    })
+  })
+
+  describe('buildEmptyRecommendationSuggestion (SMI-5556)', () => {
+    it('always clarifies candidates_considered is not a registry/backend fault', () => {
+      const out = buildEmptyRecommendationSuggestion({
+        installedCount: 3,
+        hasProjectContext: true,
+      })
+      expect(out).toContain('does not indicate a registry/backend problem')
+      expect(out).toContain('search tool')
+    })
+
+    it('suggests passing installed_skills only when installedCount is 0', () => {
+      const withZero = buildEmptyRecommendationSuggestion({
+        installedCount: 0,
+        hasProjectContext: true,
+      })
+      expect(withZero).toContain('Try passing installed_skills explicitly')
+
+      const withSome = buildEmptyRecommendationSuggestion({
+        installedCount: 2,
+        hasProjectContext: true,
+      })
+      expect(withSome).not.toContain('Try passing installed_skills explicitly')
+    })
+
+    it('suggests providing project_context only when hasProjectContext is false', () => {
+      const without = buildEmptyRecommendationSuggestion({
+        installedCount: 1,
+        hasProjectContext: false,
+      })
+      expect(without).toContain('Provide project_context for more relevant results')
+
+      const withContext = buildEmptyRecommendationSuggestion({
+        installedCount: 1,
+        hasProjectContext: true,
+      })
+      expect(withContext).not.toContain('Provide project_context for more relevant results')
+    })
+
+    it('suggests removing the role filter only when one is set', () => {
+      const withRole = buildEmptyRecommendationSuggestion({
+        installedCount: 1,
+        hasProjectContext: true,
+        roleFilter: 'testing',
+      })
+      expect(withRole).toContain('Try removing the role filter (currently: testing)')
+
+      const withoutRole = buildEmptyRecommendationSuggestion({
+        installedCount: 1,
+        hasProjectContext: true,
+      })
+      expect(withoutRole).not.toContain('role filter')
     })
   })
 })


### PR DESCRIPTION
## Summary

- A first-time-user transcript showed the coordinating agent misreading `skill_recommend`'s `candidates_considered: 0` as a "registry/backend issue," then burning two `search` calls on broad multi-concept queries before self-correcting to narrow single-topic queries.
- Both tools already had "Suggestions:" empty-result text, but it only lived in CLI-only formatters (`recommend.format.ts`, `search.formatter.ts`) never wired into the raw MCP JSON response the calling agent actually sees (`tool-dispatch.ts` just does `JSON.stringify`).
- Adds an optional `suggestion` field (matching the existing `SkillsmithError`/`ErrorResponse` convention) to `RecommendResponse` and `SearchResponse`, populated only when results are empty, explaining why (not a registry/backend fault) and what to try next — including falling back from `skill_recommend` to `search`, and splitting multi-concept `search` queries into single-topic calls.
- Updates both tool descriptions (and `search`'s `query` param description) to proactively note lexical-only matching and single-topic query guidance up front, so the calling agent doesn't have to discover it through trial and error.
- Scoped to messaging only — no change to the underlying FTS5/`websearch_to_tsquery` matching algorithm (that would be a larger, separate effort).
- Moves the pre-existing SMI-2734/SMI-2759 `formatSearchResults` field tests from `search.test.ts` to `search.formatter.test.ts` to stay under the 500-line file gate after adding the new suggestion coverage.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Full `npm test` (793 files / 13,344 tests) — all green, run in this worktree's own Docker container
- [x] `npm run audit:standards` — 0 failed, 7 pre-existing warnings unrelated to this diff
- [x] New/updated tests cover: `suggestion` present+non-empty on zero-result/zero-candidate responses, absent on non-empty responses, and both formatters (`recommend.format.ts`, `search.formatter.ts`) surface `response.suggestion` when present instead of re-deriving the old hardcoded bullet list

**Note on `--no-verify`**: this branch's pre-push hook (`skillsmith-dev-1`-routed checks) hit three known "wrong tree" false positives when run from this worktree — stale-deps, stale-dist, and a cross-container native-SQLite probe, plus a full-suite run that failed on unrelated `@huggingface/transformers` resolution errors when executed via the main container against this worktree's directory (not this diff — confirmed by re-running the exact same failing test file, and then the full suite, directly in this worktree's own correctly-provisioned container, where everything passes clean). Per the `worktree-bringup` skill's documented protocol, I verified lint/typecheck/full-test/audit:standards all green in the correct container before pushing with `--no-verify`.

Closes SMI-5556.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)