### PR TITLE
fix(website): drop leftover JSON-LD (Recommended) suffix on quickstart (SMI-5554)

### DIFF
--- a/packages/website/src/pages/docs/quickstart.astro
+++ b/packages/website/src/pages/docs/quickstart.astro
@@ -17,7 +17,7 @@ import { MCP_CLIENT_SNIPPETS } from '../../lib/mcp-client-snippets';
     "@graph": [
       {
         "@type": "HowTo",
-        "name": "How to Set Up Skillsmith with an MCP Client (Recommended)",
+        "name": "How to Set Up Skillsmith with an MCP Client",
         "description": "Install Skillsmith MCP server to discover and install skills using natural language",
         "totalTime": "PT5M",
         "tool": [


### PR DESCRIPTION
## Summary

Small follow-up to #1732 (already merged). That PR removed the visible "Recommended"/"Alternative" badges from the quickstart workflow-choice cards (per user feedback: MCP vs CLI is a workflow choice, not a quality ranking), but missed the same wording in the page's JSON-LD `HowTo` schema `name` field — fixes that one-line inconsistency.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] Full `npm test` (root + colocated + website) — all green

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)