### PR TITLE
feat(cli): Implement real skillsmith update command (SMI-5593)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -133,15 +133,28 @@ skillsmith remove author/skill-name --force
 
 ### update
 
-Update installed skills.
+Update installed skills. Requires an explicit selector — a skill name, several
+names, or `--all` — bare `skillsmith update` with none of those prints usage
+guidance instead of updating anything.
 
 ```bash
 # Update all skills
-skillsmith update
+skillsmith update --all
 
-# Update specific skill
-skillsmith update author/skill-name
+# Update one skill
+skillsmith update skill-name
+
+# Update a specific set of skills
+skillsmith update skill-name another-skill
+
+# Preview changes without applying them
+skillsmith update skill-name --dry-run
 ```
+
+**Options:**
+- `-a, --all` - Update all installed skills
+- `-n, --dry-run` - Show what would update without installing
+- `-d, --db <path>` - Database file path
 
 ### inventory
 
@@ -770,7 +783,7 @@ npm run dev
 
 ```bash
 # Update all installed skills
-skillsmith update
+skillsmith update --all
 
 # Remove a skill
 skillsmith remove community/old-skill

--- a/packages/cli/src/commands/manage.action.ts
+++ b/packages/cli/src/commands/manage.action.ts
@@ -1,0 +1,284 @@
+/**
+ * SMI-745: Skill Management Commands — action implementations.
+ *
+ * SMI-5593: split out of manage.ts (which had grown past the 500-line
+ * standard once the real `skillsmith update` implementation replaced the
+ * stub) following the <command>.action.ts convention established by
+ * SMI-5040/SMI-5127. The update diff/apply logic lives in manage.update.ts
+ * (a second sibling split — this file was still over 500 lines with it
+ * inline). manage.ts keeps only the commander factory functions.
+ */
+
+import { confirm } from '@inquirer/prompts'
+import chalk from 'chalk'
+import Table from 'cli-table3'
+import ora from 'ora'
+import { mkdir } from 'fs/promises'
+import { dirname } from 'path'
+import {
+  SkillRepository,
+  SkillDependencyRepository,
+  SkillInstallationService,
+  type TrustTier,
+} from '@skillsmith/core'
+import { openCliDatabase } from '../utils/open-database.js'
+import { DEFAULT_DB_PATH, DEFAULT_SKILLS_DIR, DEFAULT_MANIFEST_PATH } from '../config.js'
+import { removeLinks } from '@skillsmith/core/install'
+import { sanitizeError } from '../utils/sanitize.js'
+import { withTelemetry } from '@skillsmith/core/telemetry'
+import { getInstalledSkills, type InstalledSkill } from '../utils/skills-directory.js'
+import { getSkillDiff, updateSkill, updateSkills } from './manage.update.js'
+
+/**
+ * SMI-1809: Added 'local' tier color for local skills
+ * SMI-5205: Added 'official' and 'unverified' tier colors
+ */
+const TRUST_TIER_COLORS: Record<TrustTier, (text: string) => string> = {
+  official: chalk.magenta, // SMI-5205: Platform/partner — magenta to stand out from verified
+  verified: chalk.green,
+  curated: chalk.blue,
+  community: chalk.yellow,
+  local: chalk.cyan, // SMI-1809: Cyan for local skills
+  experimental: chalk.red,
+  unknown: chalk.gray,
+  unverified: chalk.gray, // SMI-5205: Public alias for unknown — same color as unknown
+}
+
+/**
+ * Display skills in a table format
+ */
+function displaySkillsTable(skills: InstalledSkill[]): void {
+  if (skills.length === 0) {
+    console.log(chalk.yellow('\nNo skills installed.\n'))
+    console.log(chalk.dim('Install skills with: skillsmith install <author/skill-name>\n'))
+    return
+  }
+
+  const table = new Table({
+    head: [
+      chalk.bold('Name'),
+      chalk.bold('Version'),
+      chalk.bold('Trust Tier'),
+      chalk.bold('Install Date'),
+      chalk.bold('Updates'),
+    ],
+    colWidths: [30, 15, 15, 15, 12],
+  })
+
+  for (const skill of skills) {
+    const colorFn = TRUST_TIER_COLORS[skill.trustTier]
+    table.push([
+      colorFn(skill.name),
+      skill.version || chalk.dim('N/A'),
+      colorFn(skill.trustTier),
+      skill.installDate,
+      skill.hasUpdates ? chalk.green('Available') : chalk.dim('Up to date'),
+    ])
+  }
+
+  console.log('\n' + chalk.bold.blue('Installed Skills') + '\n')
+  console.log(table.toString())
+  console.log(
+    chalk.dim(
+      `\n${skills.length} skill(s) found (global: ~/.claude/skills, local: ./.claude/skills)\n`
+    )
+  )
+}
+
+/**
+ * Remove a skill using SkillInstallationService for manifest-aware removal.
+ * Falls back to direct removal for orphan skills (on disk but not in manifest).
+ */
+async function removeSkill(skillName: string, force: boolean, dbPath: string): Promise<boolean> {
+  // Show skill info and confirm before proceeding (unless --force)
+  if (!force) {
+    const installed = await getInstalledSkills()
+    const skill = installed.find((s) => s.name.toLowerCase() === skillName.toLowerCase())
+
+    if (!skill) {
+      console.log(chalk.red(`Skill "${skillName}" is not installed`))
+      return false
+    }
+
+    console.log(chalk.bold(`\nSkill to remove:`))
+    console.log(`  Name: ${skill.name}`)
+    console.log(`  Version: ${skill.version || 'N/A'}`)
+    console.log(`  Path: ${skill.path}`)
+    console.log()
+
+    const proceed = await confirm({
+      message: `Are you sure you want to remove ${skill.name}?`,
+      default: false,
+    })
+
+    if (!proceed) {
+      console.log(chalk.yellow('Removal cancelled'))
+      return false
+    }
+  }
+
+  const spinner = ora(`Removing ${skillName}...`).start()
+
+  // Ensure database directory exists before opening
+  await mkdir(dirname(dbPath), { recursive: true })
+  const db = await openCliDatabase(dbPath)
+
+  try {
+    const skillRepo = new SkillRepository(db)
+    const skillDependencyRepo = new SkillDependencyRepository(db)
+
+    const service = new SkillInstallationService({
+      db,
+      skillRepo,
+      skillDependencyRepo,
+      skillsDir: DEFAULT_SKILLS_DIR,
+      manifestPath: DEFAULT_MANIFEST_PATH,
+      onProgress: (_stage: string, detail: string) => {
+        spinner.text = detail
+      },
+    })
+
+    const result = await service.uninstall(skillName, { force })
+
+    if (result.success) {
+      // SMI-4578: tear down any --also-link fan-out destinations recorded
+      // for this skill. Best-effort — uninstall must succeed even if the
+      // manifest is missing or a destination was already cleaned up.
+      try {
+        const linkCount = await removeLinks(skillName)
+        if (linkCount > 0) {
+          spinner.text = `Removed ${linkCount} cross-client link${linkCount > 1 ? 's' : ''}`
+        }
+      } catch (linkErr) {
+        console.log(
+          chalk.yellow(
+            `  Warning: could not clean up cross-client links: ${sanitizeError(linkErr)}`
+          )
+        )
+      }
+
+      spinner.succeed(`Successfully removed ${skillName}`)
+      if (result.warning) {
+        console.log(chalk.yellow(`  Warning: ${result.warning}`))
+      }
+      return true
+    } else {
+      spinner.fail(result.message)
+      if (result.warning) {
+        console.log(chalk.yellow(`  ${result.warning}`))
+      }
+      return false
+    }
+  } catch (error) {
+    spinner.fail(`Failed to remove ${skillName}: ${sanitizeError(error)}`)
+    return false
+  } finally {
+    db.close()
+  }
+}
+
+/**
+ * List action
+ */
+// SMI-5128: handler impls extracted from inline .action() closures so
+// withTelemetry can wrap them at the export boundary (SMI-5040 coverage gate).
+async function listActionImpl(opts: Record<string, string | boolean | undefined>): Promise<void> {
+  try {
+    const dbPath = opts['db'] as string
+    const outdated = (opts['outdated'] as boolean) ?? false
+
+    const skills = await getInstalledSkills(dbPath)
+    const filtered = outdated ? skills.filter((s) => s.hasUpdates) : skills
+
+    if (outdated && filtered.length === 0) {
+      console.log(chalk.green('\nAll installed skills are up to date.\n'))
+      return
+    }
+
+    displaySkillsTable(filtered)
+  } catch (error) {
+    console.error(chalk.red('Error listing skills:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const listAction = withTelemetry(listActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'list',
+  extractFramework: () => 'cli',
+})
+
+/**
+ * Update action
+ *
+ * SMI-5593: user control over one skill, a set of skills, or all skills.
+ * Bare `skillsmith update` (no names, no --all) prints usage guidance
+ * instead of silently updating everything — a behavior change from the
+ * prior implicit "no args = update all" (see docs updated alongside this).
+ */
+async function updateActionImpl(
+  skillNames: string[],
+  opts: Record<string, string | boolean | undefined>
+): Promise<void> {
+  const dbPath = (opts['db'] as string) ?? DEFAULT_DB_PATH
+  const updateAll = (opts['all'] as boolean) ?? false
+  const dryRun = (opts['dryRun'] as boolean) ?? false
+
+  try {
+    if (updateAll) {
+      if (skillNames.length > 0) {
+        console.error(chalk.red('Cannot combine --all with specific skill names.'))
+        process.exit(1)
+        return
+      }
+      await updateSkills(undefined, dbPath, dryRun)
+    } else if (skillNames.length > 0) {
+      await updateSkills(skillNames, dbPath, dryRun)
+    } else {
+      console.log(
+        chalk.yellow('Specify one or more skills to update, or pass --all for everything.')
+      )
+      console.log(chalk.dim('  skillsmith update <skill>'))
+      console.log(chalk.dim('  skillsmith update <skill1> <skill2> ...'))
+      console.log(chalk.dim('  skillsmith update --all'))
+      console.log(chalk.dim('  skillsmith update <skill> --dry-run'))
+      process.exit(1)
+    }
+  } catch (error) {
+    console.error(chalk.red('Error updating skills:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const updateAction = withTelemetry(updateActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'update',
+  extractFramework: () => 'cli',
+})
+
+/**
+ * Remove action
+ */
+async function removeActionImpl(
+  skillName: string,
+  opts: Record<string, string | boolean | undefined>
+): Promise<void> {
+  const force = (opts['force'] as boolean) ?? false
+  const dbPath = (opts['db'] as string) ?? DEFAULT_DB_PATH
+
+  try {
+    const success = await removeSkill(skillName, force, dbPath)
+    process.exit(success ? 0 : 1)
+  } catch (error) {
+    console.error(chalk.red('Error removing skill:'), sanitizeError(error))
+    process.exit(1)
+  }
+}
+
+export const removeAction = withTelemetry(removeActionImpl, {
+  source: 'cli',
+  extractSkillId: () => 'remove',
+  extractFramework: () => 'cli',
+})
+
+export { getInstalledSkills, displaySkillsTable, getSkillDiff, updateSkill, updateSkills }

--- a/packages/cli/src/commands/manage.ts
+++ b/packages/cli/src/commands/manage.ts
@@ -2,348 +2,30 @@
  * SMI-745: Skill Management Commands
  *
  * Provides CLI commands for listing, updating, and removing installed skills.
+ *
+ * SMI-5593: action implementations moved to manage.action.ts (500-line
+ * standard). This file retains only the commander factory functions and
+ * re-exports.
  */
 
 import { Command } from 'commander'
-import { confirm } from '@inquirer/prompts'
-import chalk from 'chalk'
-import Table from 'cli-table3'
-import ora from 'ora'
-import { mkdir } from 'fs/promises'
-import { dirname } from 'path'
-import {
-  SkillRepository,
-  SkillDependencyRepository,
-  SkillInstallationService,
-  type Skill,
-  type TrustTier,
-} from '@skillsmith/core'
-import { openCliDatabase } from '../utils/open-database.js'
-import { DEFAULT_DB_PATH, DEFAULT_SKILLS_DIR, DEFAULT_MANIFEST_PATH } from '../config.js'
-import { removeLinks } from '@skillsmith/core/install'
-import { sanitizeError } from '../utils/sanitize.js'
-import { withTelemetry } from '@skillsmith/core/telemetry'
-import { getInstalledSkills, type InstalledSkill } from '../utils/skills-directory.js'
+import { DEFAULT_DB_PATH } from '../config.js'
+import { listAction, updateAction, removeAction } from './manage.action.js'
 
-/**
- * SMI-1809: Added 'local' tier color for local skills
- * SMI-5205: Added 'official' and 'unverified' tier colors
- */
-const TRUST_TIER_COLORS: Record<TrustTier, (text: string) => string> = {
-  official: chalk.magenta, // SMI-5205: Platform/partner — magenta to stand out from verified
-  verified: chalk.green,
-  curated: chalk.blue,
-  community: chalk.yellow,
-  local: chalk.cyan, // SMI-1809: Cyan for local skills
-  experimental: chalk.red,
-  unknown: chalk.gray,
-  unverified: chalk.gray, // SMI-5205: Public alias for unknown — same color as unknown
-}
-
-/**
- * Extended Skill type with optional version field.
- * Used for type-safe version comparisons in getSkillDiff.
- */
-interface SkillWithVersion extends Skill {
-  version?: string
-}
-
-/**
- * Display skills in a table format
- */
-function displaySkillsTable(skills: InstalledSkill[]): void {
-  if (skills.length === 0) {
-    console.log(chalk.yellow('\nNo skills installed.\n'))
-    console.log(chalk.dim('Install skills with: skillsmith install <author/skill-name>\n'))
-    return
-  }
-
-  const table = new Table({
-    head: [
-      chalk.bold('Name'),
-      chalk.bold('Version'),
-      chalk.bold('Trust Tier'),
-      chalk.bold('Install Date'),
-      chalk.bold('Updates'),
-    ],
-    colWidths: [30, 15, 15, 15, 12],
-  })
-
-  for (const skill of skills) {
-    const colorFn = TRUST_TIER_COLORS[skill.trustTier]
-    table.push([
-      colorFn(skill.name),
-      skill.version || chalk.dim('N/A'),
-      colorFn(skill.trustTier),
-      skill.installDate,
-      skill.hasUpdates ? chalk.green('Available') : chalk.dim('Up to date'),
-    ])
-  }
-
-  console.log('\n' + chalk.bold.blue('Installed Skills') + '\n')
-  console.log(table.toString())
-  console.log(
-    chalk.dim(
-      `\n${skills.length} skill(s) found (global: ~/.claude/skills, local: ./.claude/skills)\n`
-    )
-  )
-}
-
-/**
- * Get skill diff from database
- */
-async function getSkillDiff(
-  skillName: string,
-  dbPath: string
-): Promise<{ oldVersion: string | null; newVersion: string | null; changes: string[] } | null> {
-  const db = await openCliDatabase(dbPath)
-  const skillRepo = new SkillRepository(db)
-
-  try {
-    // Find skill in database by name (case-insensitive search)
-    const allSkills = skillRepo.findAll(1000, 0)
-    const skill = allSkills.items.find(
-      (s: Skill) => s.name.toLowerCase() === skillName.toLowerCase()
-    )
-
-    if (!skill) {
-      return null
-    }
-
-    // Get installed version
-    const installed = (await getInstalledSkills()).find(
-      (s) => s.name.toLowerCase() === skillName.toLowerCase()
-    )
-
-    const changes: string[] = []
-
-    const skillWithVersion = skill as SkillWithVersion
-
-    if (installed?.version !== skillWithVersion.version) {
-      changes.push(
-        `Version: ${installed?.version || 'N/A'} -> ${skillWithVersion.version || 'N/A'}`
-      )
-    }
-
-    if (installed?.trustTier !== skill.trustTier) {
-      changes.push(`Trust Tier: ${installed?.trustTier || 'unknown'} -> ${skill.trustTier}`)
-    }
-
-    return {
-      oldVersion: installed?.version || null,
-      newVersion: skillWithVersion.version || null,
-      changes,
-    }
-  } finally {
-    db.close()
-  }
-}
-
-/**
- * Update a single skill
- */
-async function updateSkill(skillName: string, dbPath: string): Promise<boolean> {
-  const spinner = ora(`Checking updates for ${skillName}...`).start()
-
-  try {
-    const diff = await getSkillDiff(skillName, dbPath)
-
-    if (!diff) {
-      spinner.fail(`Skill "${skillName}" not found in registry`)
-      return false
-    }
-
-    if (diff.changes.length === 0) {
-      spinner.succeed(`${skillName} is already up to date`)
-      return true
-    }
-
-    spinner.stop()
-
-    console.log(chalk.bold(`\nChanges for ${skillName}:`))
-    for (const change of diff.changes) {
-      console.log(chalk.cyan(`  - ${change}`))
-    }
-    console.log()
-
-    const proceed = await confirm({
-      message: `Update ${skillName}?`,
-      default: true,
-    })
-
-    if (!proceed) {
-      console.log(chalk.yellow('Update cancelled'))
-      return false
-    }
-
-    const updateSpinner = ora(`Updating ${skillName}...`).start()
-    updateSpinner.stop()
-
-    // SMI-skill-version-tracking Wave 1: updateSkill not yet implemented
-    // Wave 2 will wire this to the install tool with conflict resolution.
-    throw new Error('updateSkill not yet implemented')
-  } catch (error) {
-    spinner.fail(`Failed to update ${skillName}: ${sanitizeError(error)}`)
-    return false
-  }
-}
-
-/**
- * Update all installed skills
- */
-async function updateAllSkills(dbPath: string): Promise<void> {
-  const skills = await getInstalledSkills()
-
-  if (skills.length === 0) {
-    console.log(chalk.yellow('No skills installed'))
-    return
-  }
-
-  console.log(chalk.bold(`\nChecking updates for ${skills.length} skill(s)...\n`))
-
-  let updated = 0
-  let failed = 0
-
-  for (const skill of skills) {
-    const success = await updateSkill(skill.name, dbPath)
-    if (success) {
-      updated++
-    } else {
-      failed++
-    }
-  }
-
-  console.log(chalk.bold('\nUpdate Summary:'))
-  console.log(chalk.green(`  Updated: ${updated}`))
-  if (failed > 0) {
-    console.log(chalk.red(`  Failed: ${failed}`))
-  }
-  console.log()
-}
-
-/**
- * Remove a skill using SkillInstallationService for manifest-aware removal.
- * Falls back to direct removal for orphan skills (on disk but not in manifest).
- */
-async function removeSkill(skillName: string, force: boolean, dbPath: string): Promise<boolean> {
-  // Show skill info and confirm before proceeding (unless --force)
-  if (!force) {
-    const installed = await getInstalledSkills()
-    const skill = installed.find((s) => s.name.toLowerCase() === skillName.toLowerCase())
-
-    if (!skill) {
-      console.log(chalk.red(`Skill "${skillName}" is not installed`))
-      return false
-    }
-
-    console.log(chalk.bold(`\nSkill to remove:`))
-    console.log(`  Name: ${skill.name}`)
-    console.log(`  Version: ${skill.version || 'N/A'}`)
-    console.log(`  Path: ${skill.path}`)
-    console.log()
-
-    const proceed = await confirm({
-      message: `Are you sure you want to remove ${skill.name}?`,
-      default: false,
-    })
-
-    if (!proceed) {
-      console.log(chalk.yellow('Removal cancelled'))
-      return false
-    }
-  }
-
-  const spinner = ora(`Removing ${skillName}...`).start()
-
-  // Ensure database directory exists before opening
-  await mkdir(dirname(dbPath), { recursive: true })
-  const db = await openCliDatabase(dbPath)
-
-  try {
-    const skillRepo = new SkillRepository(db)
-    const skillDependencyRepo = new SkillDependencyRepository(db)
-
-    const service = new SkillInstallationService({
-      db,
-      skillRepo,
-      skillDependencyRepo,
-      skillsDir: DEFAULT_SKILLS_DIR,
-      manifestPath: DEFAULT_MANIFEST_PATH,
-      onProgress: (_stage: string, detail: string) => {
-        spinner.text = detail
-      },
-    })
-
-    const result = await service.uninstall(skillName, { force })
-
-    if (result.success) {
-      // SMI-4578: tear down any --also-link fan-out destinations recorded
-      // for this skill. Best-effort — uninstall must succeed even if the
-      // manifest is missing or a destination was already cleaned up.
-      try {
-        const linkCount = await removeLinks(skillName)
-        if (linkCount > 0) {
-          spinner.text = `Removed ${linkCount} cross-client link${linkCount > 1 ? 's' : ''}`
-        }
-      } catch (linkErr) {
-        console.log(
-          chalk.yellow(
-            `  Warning: could not clean up cross-client links: ${sanitizeError(linkErr)}`
-          )
-        )
-      }
-
-      spinner.succeed(`Successfully removed ${skillName}`)
-      if (result.warning) {
-        console.log(chalk.yellow(`  Warning: ${result.warning}`))
-      }
-      return true
-    } else {
-      spinner.fail(result.message)
-      if (result.warning) {
-        console.log(chalk.yellow(`  ${result.warning}`))
-      }
-      return false
-    }
-  } catch (error) {
-    spinner.fail(`Failed to remove ${skillName}: ${sanitizeError(error)}`)
-    return false
-  } finally {
-    db.close()
-  }
-}
+export {
+  getInstalledSkills,
+  displaySkillsTable,
+  getSkillDiff,
+  updateSkill,
+  updateSkills,
+  listAction,
+  updateAction,
+  removeAction,
+} from './manage.action.js'
 
 /**
  * Create list command
  */
-// SMI-5128: handler impls extracted from inline .action() closures so
-// withTelemetry can wrap them at the export boundary (SMI-5040 coverage gate).
-async function listActionImpl(opts: Record<string, string | boolean | undefined>): Promise<void> {
-  try {
-    const dbPath = opts['db'] as string
-    const outdated = (opts['outdated'] as boolean) ?? false
-
-    const skills = await getInstalledSkills(dbPath)
-    const filtered = outdated ? skills.filter((s) => s.hasUpdates) : skills
-
-    if (outdated && filtered.length === 0) {
-      console.log(chalk.green('\nAll installed skills are up to date.\n'))
-      return
-    }
-
-    displaySkillsTable(filtered)
-  } catch (error) {
-    console.error(chalk.red('Error listing skills:'), sanitizeError(error))
-    process.exit(1)
-  }
-}
-
-export const listAction = withTelemetry(listActionImpl, {
-  source: 'cli',
-  extractSkillId: () => 'list',
-  extractFramework: () => 'cli',
-})
-
 export function createListCommand(): Command {
   return new Command('list')
     .alias('ls')
@@ -355,66 +37,24 @@ export function createListCommand(): Command {
 
 /**
  * Create update command
+ *
+ * SMI-5593: user control over one skill, a set of skills, or all skills —
+ * `skillsmith update <skill>`, `skillsmith update <skill1> <skill2> ...`,
+ * or `skillsmith update --all`.
  */
-async function updateActionImpl(
-  skillName: string | undefined,
-  opts: Record<string, string | boolean | undefined>
-): Promise<void> {
-  const dbPath = opts['db'] as string
-  const updateAll = opts['all'] as boolean | undefined
-
-  try {
-    if (updateAll || !skillName) {
-      await updateAllSkills(dbPath)
-    } else {
-      await updateSkill(skillName, dbPath)
-    }
-  } catch (error) {
-    console.error(chalk.red('Error updating skills:'), sanitizeError(error))
-    process.exit(1)
-  }
-}
-
-export const updateAction = withTelemetry(updateActionImpl, {
-  source: 'cli',
-  extractSkillId: () => 'update',
-  extractFramework: () => 'cli',
-})
-
 export function createUpdateCommand(): Command {
   return new Command('update')
     .description('Update installed skills')
-    .argument('[skill]', 'Skill name to update (omit for all)')
+    .argument('[skills...]', 'Skill name(s) to update (omit for all, or pass --all explicitly)')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
     .option('-a, --all', 'Update all installed skills')
+    .option('-n, --dry-run', 'Show what would update without installing')
     .action(updateAction)
 }
 
 /**
  * Create remove command
  */
-async function removeActionImpl(
-  skillName: string,
-  opts: Record<string, string | boolean | undefined>
-): Promise<void> {
-  const force = (opts['force'] as boolean) ?? false
-  const dbPath = (opts['db'] as string) ?? DEFAULT_DB_PATH
-
-  try {
-    const success = await removeSkill(skillName, force, dbPath)
-    process.exit(success ? 0 : 1)
-  } catch (error) {
-    console.error(chalk.red('Error removing skill:'), sanitizeError(error))
-    process.exit(1)
-  }
-}
-
-export const removeAction = withTelemetry(removeActionImpl, {
-  source: 'cli',
-  extractSkillId: () => 'remove',
-  extractFramework: () => 'cli',
-})
-
 export function createRemoveCommand(): Command {
   return new Command('remove')
     .alias('rm')
@@ -425,5 +65,3 @@ export function createRemoveCommand(): Command {
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
     .action(removeAction)
 }
-
-export { getInstalledSkills, displaySkillsTable }

--- a/packages/cli/src/commands/manage.update.ts
+++ b/packages/cli/src/commands/manage.update.ts
@@ -1,0 +1,282 @@
+/**
+ * SMI-5593: `skillsmith update` diff/apply logic.
+ *
+ * Split out of manage.action.ts (which had grown past the 500-line standard)
+ * following the <command>.action.ts / <command>.<concern>.ts sibling
+ * convention established by SMI-5040/SMI-5127.
+ */
+
+import { confirm } from '@inquirer/prompts'
+import chalk from 'chalk'
+import ora from 'ora'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+import {
+  SkillRepository,
+  SkillDependencyRepository,
+  SkillInstallationService,
+  SkillParser,
+  type Skill,
+} from '@skillsmith/core'
+import { openCliDatabase } from '../utils/open-database.js'
+import { DEFAULT_SKILLS_DIR, DEFAULT_MANIFEST_PATH } from '../config.js'
+import { sanitizeError } from '../utils/sanitize.js'
+import { getInstalledSkills, type InstalledSkill } from '../utils/skills-directory.js'
+import { createApiBackedRegistryLookup } from './install.js'
+
+/**
+ * Extended Skill type with optional version field.
+ * Used for type-safe version comparisons in getSkillDiff.
+ */
+interface SkillWithVersion extends Skill {
+  version?: string
+}
+
+/**
+ * SMI-5593: read an installed skill's own SKILL.md front-matter `id` field
+ * (conventionally `author/name`, stamped at install time — see SMI-5442
+ * provenance capture). This is the fallback source of truth for resolving a
+ * bare skill name to a full registry ID when the local SQLite cache doesn't
+ * have the skill (the common case per SMI-5427 remote-default search).
+ * Returns null when SKILL.md is unreadable or has no `author/name`-shaped id.
+ */
+async function resolveInstalledSkillId(installed: InstalledSkill): Promise<string | null> {
+  try {
+    const content = await readFile(join(installed.path, 'SKILL.md'), 'utf-8')
+    const parsed = new SkillParser().parse(content) as unknown as Record<string, unknown> | null
+    const id = parsed?.['id']
+    return typeof id === 'string' && id.includes('/') ? id : null
+  } catch {
+    return null
+  }
+}
+
+/** Resolved diff/update target for a single installed skill. */
+interface SkillDiff {
+  /** Full `author/name` registry ID to pass to SkillInstallationService.install(). */
+  skillId: string
+  oldVersion: string | null
+  newVersion: string | null
+  changes: string[]
+}
+
+/**
+ * Get skill diff for an installed skill, checking the local registry cache
+ * first and falling back to the remote registry when the cache doesn't have
+ * it (SMI-5427: the local SQLite cache is commonly empty in the
+ * remote-default world — the local-only lookup this replaced would report
+ * "not found in registry" for most real installs).
+ *
+ * Returns `'not-installed'` when the skill isn't installed at all, or
+ * `'unresolvable'` when it's installed but has no recorded registry ID
+ * (locally or in its own SKILL.md front-matter) to update against.
+ */
+async function getSkillDiff(
+  skillName: string,
+  dbPath: string
+): Promise<SkillDiff | 'not-installed' | 'unresolvable'> {
+  const installed = (await getInstalledSkills(dbPath)).find(
+    (s) => s.name.toLowerCase() === skillName.toLowerCase()
+  )
+  if (!installed) {
+    return 'not-installed'
+  }
+
+  const db = await openCliDatabase(dbPath)
+  const skillRepo = new SkillRepository(db)
+
+  try {
+    // Find skill in the local registry cache by name (case-insensitive search).
+    const allSkills = skillRepo.findAll(1000, 0)
+    const skill = allSkills.items.find(
+      (s: Skill) => s.name.toLowerCase() === skillName.toLowerCase()
+    )
+
+    if (skill) {
+      const changes: string[] = []
+      const skillWithVersion = skill as SkillWithVersion
+
+      if (installed.version !== skillWithVersion.version) {
+        changes.push(
+          `Version: ${installed.version || 'N/A'} -> ${skillWithVersion.version || 'N/A'}`
+        )
+      }
+
+      if (installed.trustTier !== skill.trustTier) {
+        changes.push(`Trust Tier: ${installed.trustTier || 'unknown'} -> ${skill.trustTier}`)
+      }
+
+      return {
+        skillId: skill.id,
+        oldVersion: installed.version,
+        newVersion: skillWithVersion.version || null,
+        changes,
+      }
+    }
+
+    // Not in the local cache — resolve via the skill's own recorded id and
+    // confirm it against the remote registry (same fallback shape as
+    // install.ts's createApiBackedRegistryLookup, SMI-5427).
+    const resolvedId = await resolveInstalledSkillId(installed)
+    if (!resolvedId) {
+      return 'unresolvable'
+    }
+
+    const registryLookup = await createApiBackedRegistryLookup(skillRepo, db)
+    const remote = await registryLookup.lookup(resolvedId)
+    if (!remote) {
+      return 'unresolvable'
+    }
+
+    // The registry API doesn't expose a comparable version string, so we
+    // can't render a version diff here — confirm the source and let the
+    // force-install fetch + overwrite with the latest content.
+    return {
+      skillId: resolvedId,
+      oldVersion: installed.version,
+      newVersion: null,
+      changes: [
+        `Registry source confirmed at ${remote.repoUrl} — no cached version to diff; will fetch and overwrite with the latest content.`,
+      ],
+    }
+  } finally {
+    db.close()
+  }
+}
+
+/**
+ * Update a single skill. With `dryRun`, shows the same diff preview without
+ * prompting or installing.
+ */
+async function updateSkill(skillName: string, dbPath: string, dryRun = false): Promise<boolean> {
+  const spinner = ora(`Checking updates for ${skillName}...`).start()
+
+  try {
+    const diff = await getSkillDiff(skillName, dbPath)
+
+    if (diff === 'not-installed') {
+      spinner.fail(
+        `"${skillName}" is not installed — use "skillsmith install <author>/${skillName}" instead`
+      )
+      return false
+    }
+
+    if (diff === 'unresolvable') {
+      spinner.fail(
+        `"${skillName}" has no recorded registry source — try "skillsmith install <author>/${skillName} --force" with the full ID`
+      )
+      return false
+    }
+
+    if (diff.changes.length === 0) {
+      spinner.succeed(`${skillName} is already up to date`)
+      return true
+    }
+
+    spinner.stop()
+
+    console.log(chalk.bold(`\nChanges for ${skillName}:`))
+    for (const change of diff.changes) {
+      console.log(chalk.cyan(`  - ${change}`))
+    }
+    console.log()
+
+    if (dryRun) {
+      console.log(chalk.dim(`(dry run — ${skillName} was not updated)\n`))
+      return true
+    }
+
+    const proceed = await confirm({
+      message: `Update ${skillName}?`,
+      default: true,
+    })
+
+    if (!proceed) {
+      console.log(chalk.yellow('Update cancelled'))
+      return false
+    }
+
+    const updateSpinner = ora(`Updating ${skillName}...`).start()
+
+    const db = await openCliDatabase(dbPath)
+    try {
+      const skillRepo = new SkillRepository(db)
+      const skillDependencyRepo = new SkillDependencyRepository(db)
+      const registryLookup = await createApiBackedRegistryLookup(skillRepo, db)
+
+      const service = new SkillInstallationService({
+        db,
+        skillRepo,
+        skillDependencyRepo,
+        skillsDir: DEFAULT_SKILLS_DIR,
+        manifestPath: DEFAULT_MANIFEST_PATH,
+        registryLookup,
+        onProgress: (_stage: string, detail: string) => {
+          updateSpinner.text = detail
+        },
+      })
+
+      const result = await service.install(diff.skillId, { force: true })
+
+      if (result.success) {
+        updateSpinner.succeed(`Updated ${skillName}`)
+        return true
+      }
+
+      updateSpinner.fail(`Failed to update ${skillName}: ${result.error}`)
+      return false
+    } finally {
+      db.close()
+    }
+  } catch (error) {
+    spinner.fail(`Failed to update ${skillName}: ${sanitizeError(error)}`)
+    return false
+  }
+}
+
+/**
+ * Update a set of skills by name, or every installed skill when `names` is
+ * omitted (the `--all` path). Shared by the explicit-list and `--all`
+ * commander paths so both print the same per-skill progress + summary.
+ */
+async function updateSkills(
+  names: string[] | undefined,
+  dbPath: string,
+  dryRun: boolean
+): Promise<void> {
+  const targetNames = names ?? (await getInstalledSkills(dbPath)).map((s) => s.name)
+
+  if (targetNames.length === 0) {
+    console.log(chalk.yellow('No skills installed'))
+    return
+  }
+
+  console.log(chalk.bold(`\nChecking updates for ${targetNames.length} skill(s)...\n`))
+
+  let updated = 0
+  let failed = 0
+
+  for (const name of targetNames) {
+    const success = await updateSkill(name, dbPath, dryRun)
+    if (success) {
+      updated++
+    } else {
+      failed++
+    }
+  }
+
+  console.log(chalk.bold('\nUpdate Summary:'))
+  console.log(chalk.green(`  Updated: ${updated}`))
+  if (failed > 0) {
+    console.log(chalk.red(`  Failed: ${failed}`))
+  }
+  console.log()
+
+  if (!dryRun && updated > 0) {
+    console.log(
+      chalk.dim('Run "skillsmith inventory push" to sync this to skillsmith.app/account/skills.\n')
+    )
+  }
+}
+
+export { getSkillDiff, updateSkill, updateSkills }

--- a/packages/cli/tests/e2e/manage.e2e.test.ts
+++ b/packages/cli/tests/e2e/manage.e2e.test.ts
@@ -278,6 +278,40 @@ describe('E2E: skillsmith update', () => {
 
       assertNoHardcoded(result, 'skillsmith update -a', 'update: all', __filename)
     })
+
+    // SMI-5593: bare `skillsmith update` no longer implicitly means "update
+    // all" — it requires an explicit selector (a name, several names, or
+    // --all) and exits non-zero with usage guidance otherwise.
+    it('should require an explicit selector instead of defaulting to --all', async () => {
+      installMockSkill('selector-required-test')
+
+      const result = await runCommand(['update'])
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stdout.toLowerCase()).toContain('--all')
+
+      assertNoHardcoded(result, 'skillsmith update', 'update: no selector', __filename)
+    })
+
+    it('should accept multiple skill names in one invocation', async () => {
+      installMockSkill('multi-a')
+      installMockSkill('multi-b')
+
+      const result = await runCommand(['update', 'multi-a', 'multi-b'])
+
+      recordTiming('update:multi', 'skillsmith update multi-a multi-b', result.durationMs)
+
+      // May fail if skills aren't in the registry, but should not crash or expose paths.
+      assertNoHardcoded(result, 'skillsmith update multi-a multi-b', 'update: multiple', __filename)
+    })
+
+    it('should support --dry-run without prompting or crashing', async () => {
+      installMockSkill('dry-run-test')
+
+      const result = await runCommand(['update', 'dry-run-test', '--dry-run'])
+
+      assertNoHardcoded(result, 'skillsmith update --dry-run', 'update: dry run', __filename)
+    })
   })
 })
 

--- a/packages/cli/tests/manage.skills-directory.test.ts
+++ b/packages/cli/tests/manage.skills-directory.test.ts
@@ -1,0 +1,376 @@
+/**
+ * SMI-1630: Search both global and local skill directories.
+ *
+ * Split out of manage.test.ts (a pre-existing over-500-line file, unrelated
+ * to SMI-5593) to satisfy the pre-commit file-length gate while manage.test.ts
+ * is being touched anyway.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { join } from 'path'
+import { homedir } from 'os'
+
+// Mock file system
+vi.mock('fs/promises', () => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  rm: vi.fn(),
+  stat: vi.fn(),
+}))
+
+// Mock core - use class implementations to avoid vitest warning
+vi.mock('@skillsmith/core', () => ({
+  createDatabase: vi.fn(() => ({ close: vi.fn() })),
+  createDatabaseAsync: vi.fn(),
+  initializeSchema: vi.fn(),
+  SkillRepository: vi.fn().mockImplementation(function () {
+    return {
+      findAll: vi.fn(() => ({ items: [], total: 0, limit: 1000, offset: 0, hasMore: false })),
+    }
+  }),
+  SkillDependencyRepository: vi.fn().mockImplementation(function () {
+    return { clearAll: vi.fn() }
+  }),
+  SkillInstallationService: vi.fn().mockImplementation(function () {
+    return { uninstall: vi.fn() }
+  }),
+  SkillParser: vi.fn().mockImplementation(function () {
+    return {
+      parse: vi.fn(),
+      inferTrustTier: vi.fn(() => 'unknown'),
+    }
+  }),
+}))
+
+describe('SMI-1630: Search both global and local skill directories', () => {
+  const GLOBAL_SKILLS_DIR = join(homedir(), '.claude', 'skills')
+  const LOCAL_SKILLS_DIR = join(process.cwd(), '.claude', 'skills')
+
+  const mockSkillMd = (name: string, version: string) => `---
+name: ${name}
+version: ${version}
+---
+# ${name}
+
+A test skill.
+`
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    // Reset module cache to ensure fresh imports with mocked fs
+    vi.resetModules()
+  })
+
+  it('should search both global and local skill directories', async () => {
+    const { readdir, readFile, stat } = await import('fs/promises')
+    const readdirMock = vi.mocked(readdir)
+    const readFileMock = vi.mocked(readFile)
+    const statMock = vi.mocked(stat)
+
+    // Mock global directory with one skill
+    readdirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === GLOBAL_SKILLS_DIR) {
+        return [{ name: 'global-skill', isDirectory: () => true }] as unknown as ReturnType<
+          typeof readdir
+        >
+      }
+      if (dirPath === LOCAL_SKILLS_DIR) {
+        return [{ name: 'local-skill', isDirectory: () => true }] as unknown as ReturnType<
+          typeof readdir
+        >
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    statMock.mockResolvedValue({
+      mtime: new Date('2024-01-15'),
+    } as unknown as Awaited<ReturnType<typeof stat>>)
+
+    readFileMock.mockImplementation(async (filePath) => {
+      if (String(filePath).includes('global-skill')) {
+        return mockSkillMd('global-skill', '1.0.0')
+      }
+      if (String(filePath).includes('local-skill')) {
+        return mockSkillMd('local-skill', '2.0.0')
+      }
+      throw new Error('File not found')
+    })
+
+    const { getInstalledSkills } = await import('../src/commands/manage.js')
+    const skills = await getInstalledSkills()
+
+    // Should have searched both directories
+    expect(readdirMock).toHaveBeenCalledWith(GLOBAL_SKILLS_DIR, { withFileTypes: true })
+    expect(readdirMock).toHaveBeenCalledWith(LOCAL_SKILLS_DIR, { withFileTypes: true })
+
+    // Should return skills from both directories
+    const skillNames = skills.map((s) => s.name)
+    expect(skillNames).toContain('global-skill')
+    expect(skillNames).toContain('local-skill')
+    expect(skills).toHaveLength(2)
+  })
+
+  it('should merge skills from both directories', async () => {
+    const { readdir, readFile, stat } = await import('fs/promises')
+    const readdirMock = vi.mocked(readdir)
+    const readFileMock = vi.mocked(readFile)
+    const statMock = vi.mocked(stat)
+
+    // Both directories have different skills
+    readdirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === GLOBAL_SKILLS_DIR) {
+        return [
+          { name: 'skill-a', isDirectory: () => true },
+          { name: 'skill-b', isDirectory: () => true },
+        ] as unknown as ReturnType<typeof readdir>
+      }
+      if (dirPath === LOCAL_SKILLS_DIR) {
+        return [
+          { name: 'skill-c', isDirectory: () => true },
+          { name: 'skill-d', isDirectory: () => true },
+        ] as unknown as ReturnType<typeof readdir>
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    statMock.mockResolvedValue({
+      mtime: new Date('2024-01-15'),
+    } as unknown as Awaited<ReturnType<typeof stat>>)
+
+    readFileMock.mockImplementation(async (filePath) => {
+      const path = String(filePath)
+      if (path.includes('skill-a')) return mockSkillMd('skill-a', '1.0.0')
+      if (path.includes('skill-b')) return mockSkillMd('skill-b', '1.0.0')
+      if (path.includes('skill-c')) return mockSkillMd('skill-c', '1.0.0')
+      if (path.includes('skill-d')) return mockSkillMd('skill-d', '1.0.0')
+      throw new Error('File not found')
+    })
+
+    const { getInstalledSkills } = await import('../src/commands/manage.js')
+    const skills = await getInstalledSkills()
+
+    // Should have all 4 skills merged
+    expect(skills).toHaveLength(4)
+    const skillNames = skills.map((s) => s.name)
+    expect(skillNames).toContain('skill-a')
+    expect(skillNames).toContain('skill-b')
+    expect(skillNames).toContain('skill-c')
+    expect(skillNames).toContain('skill-d')
+  })
+
+  it('should give local skills precedence over global skills with the same name', async () => {
+    const { readdir, readFile, stat } = await import('fs/promises')
+    const readdirMock = vi.mocked(readdir)
+    const readFileMock = vi.mocked(readFile)
+    const statMock = vi.mocked(stat)
+
+    // Both directories have a skill with the same name
+    readdirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === GLOBAL_SKILLS_DIR) {
+        return [{ name: 'shared-skill', isDirectory: () => true }] as unknown as ReturnType<
+          typeof readdir
+        >
+      }
+      if (dirPath === LOCAL_SKILLS_DIR) {
+        return [{ name: 'shared-skill', isDirectory: () => true }] as unknown as ReturnType<
+          typeof readdir
+        >
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    statMock.mockResolvedValue({
+      mtime: new Date('2024-01-15'),
+    } as unknown as Awaited<ReturnType<typeof stat>>)
+
+    readFileMock.mockImplementation(async (filePath) => {
+      const path = String(filePath)
+      if (path.includes('shared-skill')) {
+        return mockSkillMd('shared-skill', '1.0.0')
+      }
+      throw new Error('File not found')
+    })
+
+    const { getInstalledSkills } = await import('../src/commands/manage.js')
+    const skills = await getInstalledSkills()
+
+    // Should only have one skill (deduplicated)
+    expect(skills).toHaveLength(1)
+
+    // The local skill should take precedence (verified by path)
+    const sharedSkill = skills.find((s) => s.name === 'shared-skill')
+    expect(sharedSkill).toBeDefined()
+    // Key assertion: local path takes precedence over global
+    expect(sharedSkill?.path).toContain(LOCAL_SKILLS_DIR)
+    expect(sharedSkill?.path).not.toContain(GLOBAL_SKILLS_DIR)
+  })
+
+  it('should handle missing local skills directory gracefully', async () => {
+    const { readdir, readFile, stat } = await import('fs/promises')
+    const readdirMock = vi.mocked(readdir)
+    const readFileMock = vi.mocked(readFile)
+    const statMock = vi.mocked(stat)
+
+    // Global exists, local does not
+    readdirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === GLOBAL_SKILLS_DIR) {
+        return [{ name: 'global-only', isDirectory: () => true }] as unknown as ReturnType<
+          typeof readdir
+        >
+      }
+      // Local directory doesn't exist
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    statMock.mockResolvedValue({
+      mtime: new Date('2024-01-15'),
+    } as unknown as Awaited<ReturnType<typeof stat>>)
+
+    readFileMock.mockImplementation(async (filePath) => {
+      if (String(filePath).includes('global-only')) {
+        return mockSkillMd('global-only', '1.0.0')
+      }
+      throw new Error('File not found')
+    })
+
+    const { getInstalledSkills } = await import('../src/commands/manage.js')
+    const skills = await getInstalledSkills()
+
+    // Should still return skills from global directory
+    expect(skills).toHaveLength(1)
+    expect(skills[0]?.name).toBe('global-only')
+  })
+
+  it('should handle missing global skills directory gracefully', async () => {
+    const { readdir, readFile, stat } = await import('fs/promises')
+    const readdirMock = vi.mocked(readdir)
+    const readFileMock = vi.mocked(readFile)
+    const statMock = vi.mocked(stat)
+
+    // Local exists, global does not
+    readdirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === LOCAL_SKILLS_DIR) {
+        return [{ name: 'local-only', isDirectory: () => true }] as unknown as ReturnType<
+          typeof readdir
+        >
+      }
+      // Global directory doesn't exist
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    statMock.mockResolvedValue({
+      mtime: new Date('2024-01-15'),
+    } as unknown as Awaited<ReturnType<typeof stat>>)
+
+    readFileMock.mockImplementation(async (filePath) => {
+      if (String(filePath).includes('local-only')) {
+        return mockSkillMd('local-only', '1.0.0')
+      }
+      throw new Error('File not found')
+    })
+
+    const { getInstalledSkills } = await import('../src/commands/manage.js')
+    const skills = await getInstalledSkills()
+
+    // Should return skills from local directory only
+    expect(skills).toHaveLength(1)
+    expect(skills[0]?.name).toBe('local-only')
+  })
+
+  it('should include source location indicator for each skill', async () => {
+    const { readdir, readFile, stat } = await import('fs/promises')
+    const readdirMock = vi.mocked(readdir)
+    const readFileMock = vi.mocked(readFile)
+    const statMock = vi.mocked(stat)
+
+    readdirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === GLOBAL_SKILLS_DIR) {
+        return [{ name: 'global-skill', isDirectory: () => true }] as unknown as ReturnType<
+          typeof readdir
+        >
+      }
+      if (dirPath === LOCAL_SKILLS_DIR) {
+        return [{ name: 'local-skill', isDirectory: () => true }] as unknown as ReturnType<
+          typeof readdir
+        >
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    statMock.mockResolvedValue({
+      mtime: new Date('2024-01-15'),
+    } as unknown as Awaited<ReturnType<typeof stat>>)
+
+    readFileMock.mockImplementation(async (filePath) => {
+      const path = String(filePath)
+      if (path.includes('global-skill')) return mockSkillMd('global-skill', '1.0.0')
+      if (path.includes('local-skill')) return mockSkillMd('local-skill', '1.0.0')
+      throw new Error('File not found')
+    })
+
+    const { getInstalledSkills } = await import('../src/commands/manage.js')
+    const skills = await getInstalledSkills()
+
+    // Skills should indicate their source (global vs local)
+    const globalSkill = skills.find((s) => s.name === 'global-skill')
+    const localSkill = skills.find((s) => s.name === 'local-skill')
+
+    expect(globalSkill?.path).toContain(GLOBAL_SKILLS_DIR)
+    expect(localSkill?.path).toContain(LOCAL_SKILLS_DIR)
+  })
+
+  it('should return empty array when both directories are missing', async () => {
+    const { readdir } = await import('fs/promises')
+    const readdirMock = vi.mocked(readdir)
+
+    // Neither directory exists
+    readdirMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+
+    const { getInstalledSkills } = await import('../src/commands/manage.js')
+    const skills = await getInstalledSkills()
+
+    expect(skills).toEqual([])
+  })
+
+  it('should throw permission errors instead of silently ignoring them', async () => {
+    const { readdir } = await import('fs/promises')
+    const readdirMock = vi.mocked(readdir)
+
+    // Simulate permission denied error
+    readdirMock.mockRejectedValue(Object.assign(new Error('Permission denied'), { code: 'EACCES' }))
+
+    const { getInstalledSkills } = await import('../src/commands/manage.js')
+
+    await expect(getInstalledSkills()).rejects.toThrow('Permission denied')
+  })
+
+  it('should throw when SKILL.md has permission error', async () => {
+    const { readdir, readFile, stat } = await import('fs/promises')
+    const readdirMock = vi.mocked(readdir)
+    const readFileMock = vi.mocked(readFile)
+    const statMock = vi.mocked(stat)
+
+    readdirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === GLOBAL_SKILLS_DIR) {
+        return [{ name: 'protected-skill', isDirectory: () => true }] as unknown as ReturnType<
+          typeof readdir
+        >
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    // stat succeeds for SKILL.md path
+    statMock.mockResolvedValue({
+      mtime: new Date('2024-01-15'),
+    } as unknown as Awaited<ReturnType<typeof stat>>)
+
+    // But reading the file fails with permission error
+    readFileMock.mockRejectedValue(
+      Object.assign(new Error('Permission denied'), { code: 'EACCES' })
+    )
+
+    const { getInstalledSkills } = await import('../src/commands/manage.js')
+
+    await expect(getInstalledSkills()).rejects.toThrow('Permission denied')
+  })
+})

--- a/packages/cli/tests/manage.test.ts
+++ b/packages/cli/tests/manage.test.ts
@@ -135,14 +135,29 @@ describe('SMI-745: Skill Management Commands', () => {
       expect(allOpt?.long).toBe('--all')
     })
 
-    it('accepts optional skill name argument', async () => {
+    it('accepts a variadic, optional skills argument (SMI-5593: one/set/all)', async () => {
       const { createUpdateCommand } = await import('../src/commands/manage.js')
       const cmd = createUpdateCommand()
 
-      // Has one optional argument
-      expect(cmd.registeredArguments.length).toBeGreaterThanOrEqual(0)
+      expect(cmd.registeredArguments.length).toBe(1)
+      expect(cmd.registeredArguments[0]?.required).toBe(false)
+      expect(cmd.registeredArguments[0]?.variadic).toBe(true)
+    })
+
+    it('has --dry-run option (SMI-5593)', async () => {
+      const { createUpdateCommand } = await import('../src/commands/manage.js')
+      const cmd = createUpdateCommand()
+
+      const dryRunOpt = cmd.options.find((o) => o.long === '--dry-run')
+      expect(dryRunOpt).toBeDefined()
+      expect(dryRunOpt?.short).toBe('-n')
     })
   })
+
+  // SMI-5593: skillsmith update's real-implementation tests (registry
+  // fallback, one/set/all selector, --dry-run, edge cases) live in the
+  // sibling manage.update.test.ts — split out to stay under the 500-line
+  // pre-commit file-length gate.
 
   describe('createRemoveCommand', () => {
     it('creates a command with correct name', async () => {
@@ -201,340 +216,9 @@ describe('SMI-745: Skill Management Commands', () => {
    *
    * Local skills should take precedence over global skills with the same name.
    */
-  describe('SMI-1630: Search both global and local skill directories', () => {
-    const GLOBAL_SKILLS_DIR = join(homedir(), '.claude', 'skills')
-    const LOCAL_SKILLS_DIR = join(process.cwd(), '.claude', 'skills')
-
-    const mockSkillMd = (name: string, version: string) => `---
-name: ${name}
-version: ${version}
----
-# ${name}
-
-A test skill.
-`
-
-    beforeEach(async () => {
-      vi.clearAllMocks()
-      // Reset module cache to ensure fresh imports with mocked fs
-      vi.resetModules()
-    })
-
-    it('should search both global and local skill directories', async () => {
-      const { readdir, readFile, stat } = await import('fs/promises')
-      const readdirMock = vi.mocked(readdir)
-      const readFileMock = vi.mocked(readFile)
-      const statMock = vi.mocked(stat)
-
-      // Mock global directory with one skill
-      readdirMock.mockImplementation(async (dirPath) => {
-        if (dirPath === GLOBAL_SKILLS_DIR) {
-          return [{ name: 'global-skill', isDirectory: () => true }] as unknown as ReturnType<
-            typeof readdir
-          >
-        }
-        if (dirPath === LOCAL_SKILLS_DIR) {
-          return [{ name: 'local-skill', isDirectory: () => true }] as unknown as ReturnType<
-            typeof readdir
-          >
-        }
-        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
-      })
-
-      statMock.mockResolvedValue({
-        mtime: new Date('2024-01-15'),
-      } as unknown as Awaited<ReturnType<typeof stat>>)
-
-      readFileMock.mockImplementation(async (filePath) => {
-        if (String(filePath).includes('global-skill')) {
-          return mockSkillMd('global-skill', '1.0.0')
-        }
-        if (String(filePath).includes('local-skill')) {
-          return mockSkillMd('local-skill', '2.0.0')
-        }
-        throw new Error('File not found')
-      })
-
-      const { getInstalledSkills } = await import('../src/commands/manage.js')
-      const skills = await getInstalledSkills()
-
-      // Should have searched both directories
-      expect(readdirMock).toHaveBeenCalledWith(GLOBAL_SKILLS_DIR, { withFileTypes: true })
-      expect(readdirMock).toHaveBeenCalledWith(LOCAL_SKILLS_DIR, { withFileTypes: true })
-
-      // Should return skills from both directories
-      const skillNames = skills.map((s) => s.name)
-      expect(skillNames).toContain('global-skill')
-      expect(skillNames).toContain('local-skill')
-      expect(skills).toHaveLength(2)
-    })
-
-    it('should merge skills from both directories', async () => {
-      const { readdir, readFile, stat } = await import('fs/promises')
-      const readdirMock = vi.mocked(readdir)
-      const readFileMock = vi.mocked(readFile)
-      const statMock = vi.mocked(stat)
-
-      // Both directories have different skills
-      readdirMock.mockImplementation(async (dirPath) => {
-        if (dirPath === GLOBAL_SKILLS_DIR) {
-          return [
-            { name: 'skill-a', isDirectory: () => true },
-            { name: 'skill-b', isDirectory: () => true },
-          ] as unknown as ReturnType<typeof readdir>
-        }
-        if (dirPath === LOCAL_SKILLS_DIR) {
-          return [
-            { name: 'skill-c', isDirectory: () => true },
-            { name: 'skill-d', isDirectory: () => true },
-          ] as unknown as ReturnType<typeof readdir>
-        }
-        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
-      })
-
-      statMock.mockResolvedValue({
-        mtime: new Date('2024-01-15'),
-      } as unknown as Awaited<ReturnType<typeof stat>>)
-
-      readFileMock.mockImplementation(async (filePath) => {
-        const path = String(filePath)
-        if (path.includes('skill-a')) return mockSkillMd('skill-a', '1.0.0')
-        if (path.includes('skill-b')) return mockSkillMd('skill-b', '1.0.0')
-        if (path.includes('skill-c')) return mockSkillMd('skill-c', '1.0.0')
-        if (path.includes('skill-d')) return mockSkillMd('skill-d', '1.0.0')
-        throw new Error('File not found')
-      })
-
-      const { getInstalledSkills } = await import('../src/commands/manage.js')
-      const skills = await getInstalledSkills()
-
-      // Should have all 4 skills merged
-      expect(skills).toHaveLength(4)
-      const skillNames = skills.map((s) => s.name)
-      expect(skillNames).toContain('skill-a')
-      expect(skillNames).toContain('skill-b')
-      expect(skillNames).toContain('skill-c')
-      expect(skillNames).toContain('skill-d')
-    })
-
-    it('should give local skills precedence over global skills with the same name', async () => {
-      const { readdir, readFile, stat } = await import('fs/promises')
-      const readdirMock = vi.mocked(readdir)
-      const readFileMock = vi.mocked(readFile)
-      const statMock = vi.mocked(stat)
-
-      // Both directories have a skill with the same name
-      readdirMock.mockImplementation(async (dirPath) => {
-        if (dirPath === GLOBAL_SKILLS_DIR) {
-          return [{ name: 'shared-skill', isDirectory: () => true }] as unknown as ReturnType<
-            typeof readdir
-          >
-        }
-        if (dirPath === LOCAL_SKILLS_DIR) {
-          return [{ name: 'shared-skill', isDirectory: () => true }] as unknown as ReturnType<
-            typeof readdir
-          >
-        }
-        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
-      })
-
-      statMock.mockResolvedValue({
-        mtime: new Date('2024-01-15'),
-      } as unknown as Awaited<ReturnType<typeof stat>>)
-
-      readFileMock.mockImplementation(async (filePath) => {
-        const path = String(filePath)
-        if (path.includes('shared-skill')) {
-          return mockSkillMd('shared-skill', '1.0.0')
-        }
-        throw new Error('File not found')
-      })
-
-      const { getInstalledSkills } = await import('../src/commands/manage.js')
-      const skills = await getInstalledSkills()
-
-      // Should only have one skill (deduplicated)
-      expect(skills).toHaveLength(1)
-
-      // The local skill should take precedence (verified by path)
-      const sharedSkill = skills.find((s) => s.name === 'shared-skill')
-      expect(sharedSkill).toBeDefined()
-      // Key assertion: local path takes precedence over global
-      expect(sharedSkill?.path).toContain(LOCAL_SKILLS_DIR)
-      expect(sharedSkill?.path).not.toContain(GLOBAL_SKILLS_DIR)
-    })
-
-    it('should handle missing local skills directory gracefully', async () => {
-      const { readdir, readFile, stat } = await import('fs/promises')
-      const readdirMock = vi.mocked(readdir)
-      const readFileMock = vi.mocked(readFile)
-      const statMock = vi.mocked(stat)
-
-      // Global exists, local does not
-      readdirMock.mockImplementation(async (dirPath) => {
-        if (dirPath === GLOBAL_SKILLS_DIR) {
-          return [{ name: 'global-only', isDirectory: () => true }] as unknown as ReturnType<
-            typeof readdir
-          >
-        }
-        // Local directory doesn't exist
-        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
-      })
-
-      statMock.mockResolvedValue({
-        mtime: new Date('2024-01-15'),
-      } as unknown as Awaited<ReturnType<typeof stat>>)
-
-      readFileMock.mockImplementation(async (filePath) => {
-        if (String(filePath).includes('global-only')) {
-          return mockSkillMd('global-only', '1.0.0')
-        }
-        throw new Error('File not found')
-      })
-
-      const { getInstalledSkills } = await import('../src/commands/manage.js')
-      const skills = await getInstalledSkills()
-
-      // Should still return skills from global directory
-      expect(skills).toHaveLength(1)
-      expect(skills[0]?.name).toBe('global-only')
-    })
-
-    it('should handle missing global skills directory gracefully', async () => {
-      const { readdir, readFile, stat } = await import('fs/promises')
-      const readdirMock = vi.mocked(readdir)
-      const readFileMock = vi.mocked(readFile)
-      const statMock = vi.mocked(stat)
-
-      // Local exists, global does not
-      readdirMock.mockImplementation(async (dirPath) => {
-        if (dirPath === LOCAL_SKILLS_DIR) {
-          return [{ name: 'local-only', isDirectory: () => true }] as unknown as ReturnType<
-            typeof readdir
-          >
-        }
-        // Global directory doesn't exist
-        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
-      })
-
-      statMock.mockResolvedValue({
-        mtime: new Date('2024-01-15'),
-      } as unknown as Awaited<ReturnType<typeof stat>>)
-
-      readFileMock.mockImplementation(async (filePath) => {
-        if (String(filePath).includes('local-only')) {
-          return mockSkillMd('local-only', '1.0.0')
-        }
-        throw new Error('File not found')
-      })
-
-      const { getInstalledSkills } = await import('../src/commands/manage.js')
-      const skills = await getInstalledSkills()
-
-      // Should return skills from local directory only
-      expect(skills).toHaveLength(1)
-      expect(skills[0]?.name).toBe('local-only')
-    })
-
-    it('should include source location indicator for each skill', async () => {
-      const { readdir, readFile, stat } = await import('fs/promises')
-      const readdirMock = vi.mocked(readdir)
-      const readFileMock = vi.mocked(readFile)
-      const statMock = vi.mocked(stat)
-
-      readdirMock.mockImplementation(async (dirPath) => {
-        if (dirPath === GLOBAL_SKILLS_DIR) {
-          return [{ name: 'global-skill', isDirectory: () => true }] as unknown as ReturnType<
-            typeof readdir
-          >
-        }
-        if (dirPath === LOCAL_SKILLS_DIR) {
-          return [{ name: 'local-skill', isDirectory: () => true }] as unknown as ReturnType<
-            typeof readdir
-          >
-        }
-        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
-      })
-
-      statMock.mockResolvedValue({
-        mtime: new Date('2024-01-15'),
-      } as unknown as Awaited<ReturnType<typeof stat>>)
-
-      readFileMock.mockImplementation(async (filePath) => {
-        const path = String(filePath)
-        if (path.includes('global-skill')) return mockSkillMd('global-skill', '1.0.0')
-        if (path.includes('local-skill')) return mockSkillMd('local-skill', '1.0.0')
-        throw new Error('File not found')
-      })
-
-      const { getInstalledSkills } = await import('../src/commands/manage.js')
-      const skills = await getInstalledSkills()
-
-      // Skills should indicate their source (global vs local)
-      const globalSkill = skills.find((s) => s.name === 'global-skill')
-      const localSkill = skills.find((s) => s.name === 'local-skill')
-
-      expect(globalSkill?.path).toContain(GLOBAL_SKILLS_DIR)
-      expect(localSkill?.path).toContain(LOCAL_SKILLS_DIR)
-    })
-
-    it('should return empty array when both directories are missing', async () => {
-      const { readdir } = await import('fs/promises')
-      const readdirMock = vi.mocked(readdir)
-
-      // Neither directory exists
-      readdirMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
-
-      const { getInstalledSkills } = await import('../src/commands/manage.js')
-      const skills = await getInstalledSkills()
-
-      expect(skills).toEqual([])
-    })
-
-    it('should throw permission errors instead of silently ignoring them', async () => {
-      const { readdir } = await import('fs/promises')
-      const readdirMock = vi.mocked(readdir)
-
-      // Simulate permission denied error
-      readdirMock.mockRejectedValue(
-        Object.assign(new Error('Permission denied'), { code: 'EACCES' })
-      )
-
-      const { getInstalledSkills } = await import('../src/commands/manage.js')
-
-      await expect(getInstalledSkills()).rejects.toThrow('Permission denied')
-    })
-
-    it('should throw when SKILL.md has permission error', async () => {
-      const { readdir, readFile, stat } = await import('fs/promises')
-      const readdirMock = vi.mocked(readdir)
-      const readFileMock = vi.mocked(readFile)
-      const statMock = vi.mocked(stat)
-
-      readdirMock.mockImplementation(async (dirPath) => {
-        if (dirPath === GLOBAL_SKILLS_DIR) {
-          return [{ name: 'protected-skill', isDirectory: () => true }] as unknown as ReturnType<
-            typeof readdir
-          >
-        }
-        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
-      })
-
-      // stat succeeds for SKILL.md path
-      statMock.mockResolvedValue({
-        mtime: new Date('2024-01-15'),
-      } as unknown as Awaited<ReturnType<typeof stat>>)
-
-      // But reading the file fails with permission error
-      readFileMock.mockRejectedValue(
-        Object.assign(new Error('Permission denied'), { code: 'EACCES' })
-      )
-
-      const { getInstalledSkills } = await import('../src/commands/manage.js')
-
-      await expect(getInstalledSkills()).rejects.toThrow('Permission denied')
-    })
-  })
+  // SMI-1630 directory-scanning tests (unrelated to SMI-5593) live in the
+  // sibling manage.skills-directory.test.ts — split out because this file
+  // was already over the 500-line pre-commit gate before this change.
 
   describe('displaySkillsTable', () => {
     it('is exported from module', async () => {

--- a/packages/cli/tests/manage.update.test.ts
+++ b/packages/cli/tests/manage.update.test.ts
@@ -350,7 +350,8 @@ describe('SMI-5593: skillsmith update — real update path', () => {
   })
 
   describe('updateSkills (multi-skill / --all)', () => {
-    it('updates a specific set of named skills and reports a summary', async () => {
+    /** Two installed skills (astro, ci-doctor), both resolvable via the local cache. */
+    async function mockTwoInstalledSkills(): Promise<void> {
       const { readdir, stat } = await import('fs/promises')
       vi.mocked(readdir).mockImplementation(async (dirPath) => {
         if (dirPath === SKILLS_DIR) {
@@ -371,6 +372,10 @@ describe('SMI-5593: skillsmith update — real update path', () => {
       ])
       const { confirm } = await import('@inquirer/prompts')
       vi.mocked(confirm).mockResolvedValue(true)
+    }
+
+    it('updates a specific set of named skills and reports a summary', async () => {
+      await mockTwoInstalledSkills()
 
       const { updateSkills } = await import('../src/commands/manage.js')
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -380,6 +385,27 @@ describe('SMI-5593: skillsmith update — real update path', () => {
       expect(mocks.installFn).toHaveBeenCalledTimes(2)
       const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
       expect(output).toContain('Updated: 2')
+
+      logSpy.mockRestore()
+    })
+
+    it('continues past a per-skill failure and reports a partial-failure summary', async () => {
+      await mockTwoInstalledSkills()
+      mocks.installFn.mockImplementation(async (skillId: unknown) =>
+        skillId === 'a/astro'
+          ? { success: true, skillId: 'a/astro', installPath: join(homedir(), 'astro') }
+          : { success: false, error: 'ALREADY_INSTALLED: local modifications detected' }
+      )
+
+      const { updateSkills } = await import('../src/commands/manage.js')
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await updateSkills(['astro', 'ci-doctor'], '/fake/db.sqlite', false)
+
+      expect(mocks.installFn).toHaveBeenCalledTimes(2)
+      const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(output).toContain('Updated: 1')
+      expect(output).toContain('Failed: 1')
 
       logSpy.mockRestore()
     })

--- a/packages/cli/tests/manage.update.test.ts
+++ b/packages/cli/tests/manage.update.test.ts
@@ -1,0 +1,457 @@
+/**
+ * SMI-5593: `skillsmith update` real implementation tests.
+ *
+ * Split out of manage.test.ts (which had grown past the 500-line pre-commit
+ * file-length gate) mirroring the manage.ts/manage.action.ts/manage.update.ts
+ * source split.
+ *
+ * skillsmith update was a stub (`throw new Error('updateSkill not yet
+ * implemented')`). These tests cover the real implementation: registry
+ * fallback when the local SQLite cache is empty (SMI-5427), the
+ * one/set/all selector, --dry-run, and the not-installed/unresolvable edge
+ * cases.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'path'
+import { homedir } from 'os'
+
+// Mock file system
+vi.mock('fs/promises', () => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  rm: vi.fn(),
+  stat: vi.fn(),
+}))
+
+// Mock inquirer
+vi.mock('@inquirer/prompts', () => ({
+  confirm: vi.fn(),
+}))
+
+// Mock ora
+vi.mock('ora', () => ({
+  default: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    text: '',
+  })),
+}))
+
+/** Loose shape for a mocked local-registry-cache row (SkillRepository.findAll items). */
+interface MockCachedSkill {
+  id: string
+  name: string
+  version: string
+  trustTier: string
+}
+
+/** Loose shape for mocked parsed SKILL.md front-matter (SkillParser.parse output). */
+interface MockParsedSkill {
+  name?: string
+  version?: string | null
+  id?: string | undefined
+}
+
+// Hoisted mock state for SkillInstallationService and the update path
+const mocks = vi.hoisted(() => ({
+  uninstallFn: vi.fn(),
+  installFn: vi.fn(),
+  dbClose: vi.fn(),
+  createDatabaseAsync: vi.fn(),
+  initializeSchema: vi.fn(),
+  findAllFn: vi.fn(
+    (): {
+      items: MockCachedSkill[]
+      total: number
+      limit: number
+      offset: number
+      hasMore: boolean
+    } => ({
+      items: [],
+      total: 0,
+      limit: 1000,
+      offset: 0,
+      hasMore: false,
+    })
+  ),
+  findByIdFn: vi.fn((): MockCachedSkill | null => null),
+  // Shared across every `new SkillParser()` instance so a test can drive what
+  // parsed SKILL.md front-matter (name/version/id) the update path sees.
+  parseFn: vi.fn((): MockParsedSkill | undefined => undefined),
+  // Mutable per-test API client stub returned by createApiClient() (install.js,
+  // not @skillsmith/core — but reached transitively via createApiBackedRegistryLookup).
+  apiClient: {
+    isOffline: (): boolean => true,
+    getSkill: vi.fn(),
+  },
+}))
+
+// Mock core - use class implementations to avoid vitest warning
+vi.mock('@skillsmith/core', () => ({
+  createDatabase: vi.fn(() => ({
+    close: vi.fn(),
+  })),
+  createDatabaseAsync: (...args: unknown[]) => mocks.createDatabaseAsync(...args),
+  initializeSchema: (...args: unknown[]) => mocks.initializeSchema(...args),
+  SkillRepository: vi.fn().mockImplementation(function () {
+    return {
+      findAll: mocks.findAllFn,
+      findById: mocks.findByIdFn,
+    }
+  }),
+  SkillDependencyRepository: vi.fn().mockImplementation(function () {
+    return {
+      clearAll: vi.fn(),
+    }
+  }),
+  SkillInstallationService: vi.fn().mockImplementation(function () {
+    return {
+      uninstall: mocks.uninstallFn,
+      install: mocks.installFn,
+    }
+  }),
+  SkillParser: vi.fn().mockImplementation(function () {
+    return {
+      parse: mocks.parseFn,
+      inferTrustTier: vi.fn(() => 'unknown'),
+    }
+  }),
+  // Reached only via install.js's createApiBackedRegistryLookup(), which
+  // updateSkill() now calls on every update — not the update path's main
+  // logic, but must resolve without throwing.
+  QuarantineRepository: vi.fn().mockImplementation(function () {
+    return { isQuarantined: vi.fn(() => false) }
+  }),
+  SkillsmithApiClient: {
+    toSkill: vi.fn(() => ({ trustTier: 'community' })),
+  },
+  emitInstallEvent: vi.fn(),
+  isGitHubUrl: vi.fn(() => false),
+  createApiClient: vi.fn(() => mocks.apiClient),
+  loadStoredAccessToken: vi.fn(async () => null),
+}))
+
+describe('SMI-5593: skillsmith update — real update path', () => {
+  const SKILLS_DIR = join(homedir(), '.claude', 'skills')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    const mockDb = { close: mocks.dbClose }
+    mocks.createDatabaseAsync.mockResolvedValue(mockDb)
+    mocks.uninstallFn.mockResolvedValue({ success: true })
+
+    // vi.clearAllMocks() only clears call history, not implementations set
+    // via mockReturnValue/mockResolvedValue, so a persistent override from
+    // one test would otherwise leak into the next.
+    mocks.installFn.mockResolvedValue({
+      success: true,
+      skillId: 'author/test-skill',
+      installPath: join(homedir(), '.claude', 'skills', 'test-skill'),
+    })
+    mocks.findAllFn.mockReturnValue({ items: [], total: 0, limit: 1000, offset: 0, hasMore: false })
+    mocks.findByIdFn.mockReturnValue(null)
+    mocks.parseFn.mockReturnValue(undefined)
+    mocks.apiClient.isOffline = () => true
+    mocks.apiClient.getSkill = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  /** Mock a single installed skill directory with the given SKILL.md front-matter. */
+  async function mockInstalledSkill(
+    name: string,
+    opts: { version?: string; id?: string } = {}
+  ): Promise<void> {
+    const { readdir, stat } = await import('fs/promises')
+    vi.mocked(readdir).mockImplementation(async (dirPath) => {
+      if (dirPath === SKILLS_DIR) {
+        return [{ name, isDirectory: () => true }] as unknown as ReturnType<typeof readdir>
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+    vi.mocked(stat).mockResolvedValue({
+      mtime: new Date('2026-01-01'),
+    } as unknown as Awaited<ReturnType<typeof stat>>)
+    mocks.parseFn.mockReturnValue({ name, version: opts.version ?? null, id: opts.id })
+  }
+
+  async function mockNoInstalledSkills(): Promise<void> {
+    const { readdir } = await import('fs/promises')
+    vi.mocked(readdir).mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+  }
+
+  /** Drive SkillRepository.findAll()'s mocked local-registry-cache page. */
+  function mockCache(items: MockCachedSkill[]): void {
+    mocks.findAllFn.mockReturnValue({
+      items,
+      total: items.length,
+      limit: 1000,
+      offset: 0,
+      hasMore: false,
+    })
+  }
+
+  describe('getSkillDiff', () => {
+    it('returns "not-installed" when the skill is not on disk', async () => {
+      await mockNoInstalledSkills()
+      const { getSkillDiff } = await import('../src/commands/manage.js')
+
+      const result = await getSkillDiff('ghost-skill', '/fake/db.sqlite')
+      expect(result).toBe('not-installed')
+    })
+
+    it('diffs against the local registry cache when the skill is indexed there', async () => {
+      await mockInstalledSkill('astro', { version: '1.0.0' })
+      mockCache([
+        { id: 'wrsmith108/astro', name: 'astro', version: '2.0.0', trustTier: 'community' },
+      ])
+
+      const { getSkillDiff } = await import('../src/commands/manage.js')
+      const result = await getSkillDiff('astro', '/fake/db.sqlite')
+
+      expect(result).not.toBe('not-installed')
+      expect(result).not.toBe('unresolvable')
+      if (typeof result === 'object') {
+        expect(result.skillId).toBe('wrsmith108/astro')
+        expect(result.changes.some((c) => c.includes('1.0.0 -> 2.0.0'))).toBe(true)
+      }
+    })
+
+    it('falls back to the remote registry when the local cache is empty (SMI-5427)', async () => {
+      await mockInstalledSkill('astro', { version: '1.0.0', id: 'wrsmith108/astro' })
+      mockCache([])
+      mocks.apiClient.isOffline = () => false
+      mocks.apiClient.getSkill = vi.fn().mockResolvedValue({
+        data: {
+          repo_url: 'https://github.com/wrsmith108/astro',
+          name: 'astro',
+          trust_tier: 'community',
+        },
+      })
+
+      const { getSkillDiff } = await import('../src/commands/manage.js')
+      const result = await getSkillDiff('astro', '/fake/db.sqlite')
+
+      expect(result).not.toBe('not-installed')
+      expect(result).not.toBe('unresolvable')
+      if (typeof result === 'object') {
+        expect(result.skillId).toBe('wrsmith108/astro')
+      }
+    })
+
+    it('returns "unresolvable" when installed but no registry id can be found', async () => {
+      // No `id:` front-matter and empty local cache and offline registry.
+      await mockInstalledSkill('mystery-skill', { version: '1.0.0' })
+      mockCache([])
+
+      const { getSkillDiff } = await import('../src/commands/manage.js')
+      const result = await getSkillDiff('mystery-skill', '/fake/db.sqlite')
+
+      expect(result).toBe('unresolvable')
+    })
+  })
+
+  describe('updateSkill', () => {
+    it('fails clearly without prompting or installing when not installed', async () => {
+      await mockNoInstalledSkills()
+      const { confirm } = await import('@inquirer/prompts')
+
+      const { updateSkill } = await import('../src/commands/manage.js')
+      const success = await updateSkill('ghost-skill', '/fake/db.sqlite')
+
+      expect(success).toBe(false)
+      expect(confirm).not.toHaveBeenCalled()
+      expect(mocks.installFn).not.toHaveBeenCalled()
+    })
+
+    it('reports already up to date without prompting when there is no diff', async () => {
+      await mockInstalledSkill('astro', { version: '2.0.0' })
+      // trustTier must match getInstalledSkills()'s mocked inferTrustTier()
+      // (always 'unknown' in this file's SkillParser mock) for a true no-op diff.
+      mockCache([{ id: 'wrsmith108/astro', name: 'astro', version: '2.0.0', trustTier: 'unknown' }])
+      const { confirm } = await import('@inquirer/prompts')
+
+      const { updateSkill } = await import('../src/commands/manage.js')
+      const success = await updateSkill('astro', '/fake/db.sqlite')
+
+      expect(success).toBe(true)
+      expect(confirm).not.toHaveBeenCalled()
+      expect(mocks.installFn).not.toHaveBeenCalled()
+    })
+
+    it('--dry-run shows the diff without prompting or installing', async () => {
+      await mockInstalledSkill('astro', { version: '1.0.0' })
+      mockCache([
+        { id: 'wrsmith108/astro', name: 'astro', version: '2.0.0', trustTier: 'community' },
+      ])
+      const { confirm } = await import('@inquirer/prompts')
+
+      const { updateSkill } = await import('../src/commands/manage.js')
+      const success = await updateSkill('astro', '/fake/db.sqlite', true)
+
+      expect(success).toBe(true)
+      expect(confirm).not.toHaveBeenCalled()
+      expect(mocks.installFn).not.toHaveBeenCalled()
+    })
+
+    it('force-installs the resolved skill id on confirmation', async () => {
+      await mockInstalledSkill('astro', { version: '1.0.0' })
+      mockCache([
+        { id: 'wrsmith108/astro', name: 'astro', version: '2.0.0', trustTier: 'community' },
+      ])
+      const { confirm } = await import('@inquirer/prompts')
+      vi.mocked(confirm).mockResolvedValue(true)
+
+      const { updateSkill } = await import('../src/commands/manage.js')
+      const success = await updateSkill('astro', '/fake/db.sqlite')
+
+      expect(success).toBe(true)
+      expect(mocks.installFn).toHaveBeenCalledWith('wrsmith108/astro', { force: true })
+    })
+
+    it('cancels without installing when the user declines the prompt', async () => {
+      await mockInstalledSkill('astro', { version: '1.0.0' })
+      mockCache([
+        { id: 'wrsmith108/astro', name: 'astro', version: '2.0.0', trustTier: 'community' },
+      ])
+      const { confirm } = await import('@inquirer/prompts')
+      vi.mocked(confirm).mockResolvedValue(false)
+
+      const { updateSkill } = await import('../src/commands/manage.js')
+      const success = await updateSkill('astro', '/fake/db.sqlite')
+
+      expect(success).toBe(false)
+      expect(mocks.installFn).not.toHaveBeenCalled()
+    })
+
+    it('reports install failure (e.g. a conflict) without throwing', async () => {
+      await mockInstalledSkill('astro', { version: '1.0.0' })
+      mockCache([
+        { id: 'wrsmith108/astro', name: 'astro', version: '2.0.0', trustTier: 'community' },
+      ])
+      const { confirm } = await import('@inquirer/prompts')
+      vi.mocked(confirm).mockResolvedValue(true)
+      mocks.installFn.mockResolvedValue({
+        success: false,
+        error: 'ALREADY_INSTALLED: local modifications detected',
+      })
+
+      const { updateSkill } = await import('../src/commands/manage.js')
+      const success = await updateSkill('astro', '/fake/db.sqlite')
+
+      expect(success).toBe(false)
+    })
+  })
+
+  describe('updateSkills (multi-skill / --all)', () => {
+    it('updates a specific set of named skills and reports a summary', async () => {
+      const { readdir, stat } = await import('fs/promises')
+      vi.mocked(readdir).mockImplementation(async (dirPath) => {
+        if (dirPath === SKILLS_DIR) {
+          return [
+            { name: 'astro', isDirectory: () => true },
+            { name: 'ci-doctor', isDirectory: () => true },
+          ] as unknown as ReturnType<typeof readdir>
+        }
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      })
+      vi.mocked(stat).mockResolvedValue({
+        mtime: new Date('2026-01-01'),
+      } as unknown as Awaited<ReturnType<typeof stat>>)
+      mocks.parseFn.mockImplementation(() => ({ version: '1.0.0' }))
+      mockCache([
+        { id: 'a/astro', name: 'astro', version: '2.0.0', trustTier: 'community' },
+        { id: 'b/ci-doctor', name: 'ci-doctor', version: '2.0.0', trustTier: 'community' },
+      ])
+      const { confirm } = await import('@inquirer/prompts')
+      vi.mocked(confirm).mockResolvedValue(true)
+
+      const { updateSkills } = await import('../src/commands/manage.js')
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await updateSkills(['astro', 'ci-doctor'], '/fake/db.sqlite', false)
+
+      expect(mocks.installFn).toHaveBeenCalledTimes(2)
+      const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(output).toContain('Updated: 2')
+
+      logSpy.mockRestore()
+    })
+
+    it('updates every installed skill when names is omitted (--all)', async () => {
+      const { readdir, stat } = await import('fs/promises')
+      vi.mocked(readdir).mockImplementation(async (dirPath) => {
+        if (dirPath === SKILLS_DIR) {
+          return [{ name: 'astro', isDirectory: () => true }] as unknown as ReturnType<
+            typeof readdir
+          >
+        }
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      })
+      vi.mocked(stat).mockResolvedValue({
+        mtime: new Date('2026-01-01'),
+      } as unknown as Awaited<ReturnType<typeof stat>>)
+      mocks.parseFn.mockReturnValue({ version: '1.0.0' })
+      mockCache([{ id: 'a/astro', name: 'astro', version: '2.0.0', trustTier: 'community' }])
+      const { confirm } = await import('@inquirer/prompts')
+      vi.mocked(confirm).mockResolvedValue(true)
+
+      const { updateSkills } = await import('../src/commands/manage.js')
+      await updateSkills(undefined, '/fake/db.sqlite', false)
+
+      expect(mocks.installFn).toHaveBeenCalledWith('a/astro', { force: true })
+    })
+
+    it('prints "No skills installed" and does nothing when there is nothing to update', async () => {
+      await mockNoInstalledSkills()
+      const { updateSkills } = await import('../src/commands/manage.js')
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await updateSkills(undefined, '/fake/db.sqlite', false)
+
+      expect(mocks.installFn).not.toHaveBeenCalled()
+      const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(output).toContain('No skills installed')
+
+      logSpy.mockRestore()
+    })
+  })
+
+  describe('updateActionImpl (via updateAction) — explicit selector required', () => {
+    it('prints usage guidance and exits non-zero with no names and no --all', async () => {
+      const { updateAction } = await import('../src/commands/manage.js')
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+
+      await updateAction([], { db: '/fake/db.sqlite' })
+
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(mocks.installFn).not.toHaveBeenCalled()
+      const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(output).toContain('skillsmith update --all')
+
+      logSpy.mockRestore()
+      exitSpy.mockRestore()
+    })
+
+    it('rejects combining --all with explicit skill names', async () => {
+      const { updateAction } = await import('../src/commands/manage.js')
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+
+      await updateAction(['astro'], { db: '/fake/db.sqlite', all: true })
+
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(mocks.installFn).not.toHaveBeenCalled()
+
+      errorSpy.mockRestore()
+      exitSpy.mockRestore()
+    })
+  })
+})

--- a/packages/website/src/pages/docs/tutorials/maintain.astro
+++ b/packages/website/src/pages/docs/tutorials/maintain.astro
@@ -77,7 +77,7 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
       <tr>
         <td>CLI</td>
         <td><code>skillsmith update</code></td>
-        <td>Update one or all installed skills</td>
+        <td>Update one skill, a set of skills, or all of them (<code>--all</code>)</td>
         <td>All</td>
       </tr>
       <tr>
@@ -131,9 +131,15 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
 
   <p>Run this in your terminal:</p>
 
-  <pre><code>{`skillsmith update                       # Update all installed skills
-skillsmith update community/jest-helper # Update one skill
-skillsmith update --dry-run             # See what would change without applying`}</code></pre>
+  <pre><code>{`skillsmith update --all                   # Update all installed skills
+skillsmith update jest-helper             # Update one skill
+skillsmith update jest-helper commit-lint # Update a specific set of skills
+skillsmith update jest-helper --dry-run   # See what would change without applying`}</code></pre>
+
+  <p>
+    <code>skillsmith update</code> with no skill names and no <code>--all</code> prints usage
+    guidance instead of updating anything — pick one of the forms above.
+  </p>
 
   <p>
     Before a major-version update, run a


### PR DESCRIPTION
## Summary

- Replaces the `skillsmith update` CLI stub (`throw new Error('updateSkill not yet implemented')`) with a real implementation wired to `SkillInstallationService.install(force: true)` — the same machinery already used by `sklx install --force` and the MCP `install_skill` tool. The `/account/skills` website page's docs already told users to run this command for "Update available" items; it never worked.
- Fixes `getSkillDiff()`, which only checked the local SQLite registry cache and reported "not found in registry" for most real installs since that cache is commonly empty in the remote-default world (SMI-5427). It now falls back to the skill's own recorded SKILL.md id plus the remote registry.
- Gives users full control over update scope: a single skill, an explicit set of skills, or `--all` (previously only single-skill or `--all`). Adds `--dry-run`.
- **Breaking change**: bare `skillsmith update` with no names and no `--all` now prints usage guidance instead of silently updating everything. Documented in `maintain.astro` and `cli/README.md`.
- `manage.ts` had grown past the 500-line standard once the stub was replaced with real logic; split into `manage.ts` (commander factories), `manage.action.ts` (list/update/remove action wrappers), and `manage.update.ts` (diff/apply logic).

**Scope boundary**: this gives the *human operator* one/set/all update control via the CLI only. It does not add a batched MCP tool — `install_skill` (MCP) remains single-skill/force-based, and `skill_updates`/`skill_outdated` remain read-only. A batch-aware MCP update tool for agent-driven bulk updates is a reasonable follow-on but is intentionally out of scope here (per `docs/internal/implementation/inventory-update-action-and-backups-cleanup.md` Section 1).

## Test plan

- [x] `npx tsc --build` (full monorepo) — clean
- [x] `npx vitest run` (full monorepo) — 803/804 files, 13484/13504 tests passing
- [x] e2e: `packages/cli/tests/e2e/manage.e2e.test.ts` (18 tests, incl. 3 new for the selector-required/multi-name/--dry-run behavior)
- [x] Manual: `skillsmith update <skill>` against a real skill with an empty local SQLite cache, confirmed the registry-fallback fix
- [x] Governance code-review report: 0 Critical/High/Medium findings

Refs SMI-5593

Co-Authored-By: Claude <noreply@anthropic.com>
