### PR TITLE
fix(api-proxy): Forward X-API-Key and a trusted client IP to Supabase

### DIFF
--- a/apps/api-proxy/api/proxy.ts
+++ b/apps/api-proxy/api/proxy.ts
@@ -1,5 +1,29 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 
+const IP_RE = /^(?:\d{1,3}(?:\.\d{1,3}){3}|[0-9a-fA-F:]+)$/
+
+function firstHeader(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v
+}
+
+// SMI-5598: resolve ONE trusted client IP. Prefers Cloudflare's un-spoofable
+// cf-connecting-ip (both api.skillsmith.app and the Supabase origin are
+// Cloudflare-fronted — verified via dig); falls back to Vercel's own
+// overwritten x-real-ip/x-forwarded-for (also un-spoofable, Vercel scrubs
+// external values). Never trusts a raw client-asserted value beyond these.
+function resolveClientIp(req: VercelRequest): string | undefined {
+  const candidates = [
+    firstHeader(req.headers['cf-connecting-ip']),
+    firstHeader(req.headers['x-real-ip']),
+    firstHeader(req.headers['x-forwarded-for']),
+  ]
+  for (const c of candidates) {
+    const ip = c?.split(',')[0]?.trim()
+    if (ip && IP_RE.test(ip)) return ip
+  }
+  return undefined
+}
+
 /**
  * Dynamic proxy to Supabase
  * Reads SUPABASE_URL from environment to avoid hardcoding project URLs
@@ -85,12 +109,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const headers: Record<string, string> = {}
 
     // Forward relevant headers
-    const forwardHeaders = ['authorization', 'apikey', 'content-type', 'x-request-id']
+    const forwardHeaders = ['authorization', 'apikey', 'content-type', 'x-request-id', 'x-api-key']
     for (const header of forwardHeaders) {
       const value = req.headers[header]
       if (value && typeof value === 'string') {
         headers[header] = value
       }
+    }
+
+    // SMI-5598: forward ONE trusted client IP as the sole X-Forwarded-For value
+    // (see resolveClientIp() above for the full trust-model rationale — do NOT
+    // relay raw client-supplied IP headers verbatim).
+    const clientIp = resolveClientIp(req)
+    if (clientIp) {
+      headers['x-forwarded-for'] = clientIp
     }
 
     const response = await fetch(targetUrl, {
@@ -100,7 +132,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     })
 
     // Forward response headers
-    const responseHeaders = ['content-type', 'x-ratelimit-limit', 'x-ratelimit-remaining']
+    const responseHeaders = [
+      'content-type',
+      'x-ratelimit-limit',
+      'x-ratelimit-remaining',
+      'x-ratelimit-reset',
+      'x-request-id',
+    ]
     for (const header of responseHeaders) {
       const value = response.headers.get(header)
       if (value) {

--- a/apps/api-proxy/vercel.json
+++ b/apps/api-proxy/vercel.json
@@ -20,7 +20,10 @@
       "headers": [
         { "key": "Access-Control-Allow-Origin", "value": "*" },
         { "key": "Access-Control-Allow-Methods", "value": "GET, POST, OPTIONS" },
-        { "key": "Access-Control-Allow-Headers", "value": "Content-Type, Authorization, apikey" }
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "Content-Type, Authorization, apikey, X-API-Key"
+        }
       ]
     }
   ]

--- a/tests/api-proxy/proxy.test.ts
+++ b/tests/api-proxy/proxy.test.ts
@@ -7,16 +7,18 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import handler from '../../apps/api-proxy/api/proxy'
 
 const SUPABASE_URL = 'https://vrcnzpmndtroqxxoqkzy.supabase.co'
 const NULL_BYTE = String.fromCharCode(0)
 
-function makeReq(path: string | undefined): VercelRequest {
+function makeReq(path: string | undefined, headers: Record<string, string> = {}): VercelRequest {
   return {
     method: 'GET',
     query: path === undefined ? {} : { path },
-    headers: {},
+    headers,
     body: undefined,
   } as unknown as VercelRequest
 }
@@ -183,6 +185,167 @@ describe('SMI-4862: api-proxy SSRF hardening', () => {
       await handler(req, res)
 
       expect(res._status).toBe(204)
+    })
+  })
+})
+
+describe('SMI-5598: api-proxy header forwarding', () => {
+  beforeEach(() => {
+    process.env.SUPABASE_URL = SUPABASE_URL
+    vi.restoreAllMocks()
+  })
+
+  function mockUpstreamJson(headers: Record<string, string> = {}) {
+    return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json', ...headers },
+      })
+    )
+  }
+
+  function fetchHeaders(fetchSpy: { mock: { calls: unknown[][] } }): Record<string, string> {
+    const init = fetchSpy.mock.calls[0]?.[1] as { headers?: Record<string, string> } | undefined
+    return init?.headers ?? {}
+  }
+
+  describe('request header forwarding', () => {
+    it('forwards x-api-key to the upstream fetch call', async () => {
+      const fetchSpy = mockUpstreamJson()
+
+      const req = makeReq('functions/v1/stats', { 'x-api-key': 'sk_live_test123' })
+      const res = makeRes()
+      await handler(req, res)
+
+      expect(fetchHeaders(fetchSpy)['x-api-key']).toBe('sk_live_test123')
+    })
+
+    it('still forwards the existing allow-listed headers (regression)', async () => {
+      const fetchSpy = mockUpstreamJson()
+
+      const req = makeReq('functions/v1/stats', {
+        authorization: 'Bearer abc123',
+        apikey: 'anon-key',
+        'content-type': 'application/json',
+        'x-request-id': 'req-123',
+      })
+      const res = makeRes()
+      await handler(req, res)
+
+      const calledHeaders = fetchHeaders(fetchSpy)
+      expect(calledHeaders.authorization).toBe('Bearer abc123')
+      expect(calledHeaders.apikey).toBe('anon-key')
+      expect(calledHeaders['content-type']).toBe('application/json')
+      expect(calledHeaders['x-request-id']).toBe('req-123')
+    })
+
+    it('does not forward non-allow-listed headers', async () => {
+      const fetchSpy = mockUpstreamJson()
+
+      const req = makeReq('functions/v1/stats', {
+        cookie: 'session=abc123',
+        'x-forwarded-host': 'evil.example.com',
+      })
+      const res = makeRes()
+      await handler(req, res)
+
+      const calledHeaders = fetchHeaders(fetchSpy)
+      expect(calledHeaders.cookie).toBeUndefined()
+      expect(calledHeaders['x-forwarded-host']).toBeUndefined()
+    })
+  })
+
+  describe('response header forwarding', () => {
+    it('forwards x-ratelimit-reset and x-request-id from the upstream response back to the client', async () => {
+      mockUpstreamJson({ 'x-ratelimit-reset': '1700000000', 'x-request-id': 'resp-req-1' })
+
+      const req = makeReq('functions/v1/stats')
+      const res = makeRes()
+      await handler(req, res)
+
+      expect(res.setHeader).toHaveBeenCalledWith('x-ratelimit-reset', '1700000000')
+      expect(res.setHeader).toHaveBeenCalledWith('x-request-id', 'resp-req-1')
+    })
+  })
+
+  describe('CORS allow-list parity (vercel.json)', () => {
+    it('Access-Control-Allow-Headers includes X-API-Key', () => {
+      const vercelJsonPath = resolve(__dirname, '../../apps/api-proxy/vercel.json')
+      const vercelConfig = JSON.parse(readFileSync(vercelJsonPath, 'utf-8')) as {
+        headers: Array<{ headers: Array<{ key: string; value: string }> }>
+      }
+      const allowHeadersEntry = vercelConfig.headers[0]?.headers.find(
+        (h) => h.key === 'Access-Control-Allow-Headers'
+      )
+
+      expect(allowHeadersEntry?.value).toContain('X-API-Key')
+    })
+  })
+
+  describe('resolveClientIp', () => {
+    it('prefers cf-connecting-ip over x-real-ip and forwards it as the sole x-forwarded-for value', async () => {
+      const fetchSpy = mockUpstreamJson()
+
+      const req = makeReq('functions/v1/stats', {
+        'cf-connecting-ip': '203.0.113.7',
+        // Deliberately different/bogus value to prove cf-connecting-ip wins.
+        'x-real-ip': '198.51.100.99',
+      })
+      const res = makeRes()
+      await handler(req, res)
+
+      const forwarded = fetchHeaders(fetchSpy)['x-forwarded-for']
+      expect(forwarded).toBe('203.0.113.7')
+      expect(forwarded).not.toContain(',')
+    })
+
+    it('falls back to x-real-ip when cf-connecting-ip is absent', async () => {
+      const fetchSpy = mockUpstreamJson()
+
+      const req = makeReq('functions/v1/stats', { 'x-real-ip': '198.51.100.42' })
+      const res = makeRes()
+      await handler(req, res)
+
+      expect(fetchHeaders(fetchSpy)['x-forwarded-for']).toBe('198.51.100.42')
+    })
+
+    it('does not relay a raw multi-entry client-supplied x-forwarded-for verbatim', async () => {
+      const fetchSpy = mockUpstreamJson()
+
+      const req = makeReq('functions/v1/stats', { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' })
+      const res = makeRes()
+      await handler(req, res)
+
+      const forwarded = fetchHeaders(fetchSpy)['x-forwarded-for']
+      // resolveClientIp() takes only the first, validated entry — never the
+      // literal client-supplied chain.
+      expect(forwarded).toBe('1.2.3.4')
+      expect(forwarded).not.toBe('1.2.3.4, 5.6.7.8')
+    })
+
+    it('drops a malformed cf-connecting-ip and falls back to the next candidate', async () => {
+      const fetchSpy = mockUpstreamJson()
+
+      const req = makeReq('functions/v1/stats', {
+        'cf-connecting-ip': 'not-an-ip',
+        'x-real-ip': '198.51.100.5',
+      })
+      const res = makeRes()
+      await handler(req, res)
+
+      expect(fetchHeaders(fetchSpy)['x-forwarded-for']).toBe('198.51.100.5')
+    })
+
+    it('omits x-forwarded-for entirely when a CRLF-injection payload is the only candidate', async () => {
+      const fetchSpy = mockUpstreamJson()
+
+      const req = makeReq('functions/v1/stats', {
+        'cf-connecting-ip': '1.2.3.4\r\nX-Injected: evil',
+      })
+      const res = makeRes()
+      await handler(req, res)
+
+      expect(fetchHeaders(fetchSpy)['x-forwarded-for']).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
## Summary

- Fixes **SMI-5598**: `apps/api-proxy/api/proxy.ts`'s `forwardHeaders` allow-list has been missing `x-api-key` since 2026-01-23 (`fd1ffcc5`), silently stripping API-key auth from every request through the documented/default host `api.skillsmith.app`. Authenticated paid-tier traffic was falling back to unauthenticated/trial handling (a 10-request lifetime cap).
- Adds a `resolveClientIp()` helper forwarding a single trusted client IP (Cloudflare's `cf-connecting-ip`, falling back to Vercel's own `x-real-ip`/`x-forwarded-for`) as `X-Forwarded-For` — restores per-caller trial-bucket attribution. This design was corrected mid-implementation after an adversarial Opus security review found the original plan (raw IP-header passthrough) both non-functional (Vercel already overwrites those headers to prevent spoofing) and a latent spoof vector via `cf-connecting-ip`. See `docs/internal/implementation/api-proxy-auth-header-fix-and-docs-accuracy.md` for the full trust-model analysis (independently DNS-verified: both `api.skillsmith.app` and the Supabase origin are Cloudflare-fronted).
- Widens the response-header allow-list (`x-ratelimit-reset`, `x-request-id` — both promised as always-present in the public API docs but previously stripped).
- Adds `X-API-Key` to the CORS `Access-Control-Allow-Headers` in `vercel.json`.

## Test plan

- [x] 29/29 tests passing in `tests/api-proxy/proxy.test.ts` (10 new — header forwarding, non-allow-listed rejection, response-header passthrough, CORS parity, `resolveClientIp` precedence/validation/injection-rejection)
- [x] ESLint, Prettier, ad-hoc strict `tsc --noEmit` clean (no project `tsconfig.json` exists for this app — tracked as SMI-5603)
- [x] Governance code review: `docs/internal/code_review/2026-07-08-smi-5598-5599-api-proxy-auth-fix-and-docs-accuracy.md` — 0 unresolved findings
- [ ] **Manual, post-merge**: deploy via `cd apps/api-proxy && vercel --prod` (no CI/CD auto-deploy for this app), then run the post-deploy smoke check (single authenticated request, confirm `X-RateLimit-Limit` reflects the caller's tier, not the anonymous fallback)

Refs SMI-5598, SMI-5600, SMI-5601, SMI-5602, SMI-5603

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>