### PR TITLE
fix(tests): disambiguate Test E' label in dotfile-guard e2e spec

### DIFF
--- a/packages/website/tests/e2e/cross-harness-inventory.dotfile-guard.spec.ts
+++ b/packages/website/tests/e2e/cross-harness-inventory.dotfile-guard.spec.ts
@@ -54,7 +54,7 @@ test.describe('Cross-Harness Skill Inventory — dotfile read-time guard (stagin
     )
   })
 
-  test('E: a dot-prefixed skill_id inserted directly (bypassing ingestion) never renders on /account/skills', async ({
+  test("E': a dot-prefixed skill_id inserted directly (bypassing ingestion) never renders on /account/skills", async ({
     page,
   }) => {
     test.setTimeout(120_000)
@@ -74,7 +74,7 @@ test.describe('Cross-Harness Skill Inventory — dotfile read-time guard (stagin
           password: cfg.invUserPassword,
         }),
         STAGING_CALL_TIMEOUT_MS,
-        'Test E / signInTestUser'
+        "Test E' / signInTestUser"
       )
 
       const { status: uploadStatus, body: uploadBody } = await withTimeout(
@@ -83,7 +83,7 @@ test.describe('Cross-Harness Skill Inventory — dotfile read-time guard (stagin
           skills: [{ harness: 'claude-code', skill_id: realSkillId }],
         }),
         STAGING_CALL_TIMEOUT_MS,
-        'Test E / uploadInventory (real skill)'
+        "Test E' / uploadInventory (real skill)"
       )
       expect(uploadStatus, `upload status unexpected; body: ${JSON.stringify(uploadBody)}`).toBe(
         200
@@ -98,7 +98,7 @@ test.describe('Cross-Harness Skill Inventory — dotfile read-time guard (stagin
           skillId: ghostSkillId,
         }),
         STAGING_CALL_TIMEOUT_MS,
-        'Test E / insertDeviceSkillDirect (ghost row)'
+        "Test E' / insertDeviceSkillDirect (ghost row)"
       )
 
       // ─── 3. Reload /account/skills — the read-time predicate must exclude the ghost row ───


### PR DESCRIPTION
## Summary
- Trivial follow-up from the post-merge governance retro on PR #1759 (SMI-5604).
- The new `cross-harness-inventory.dotfile-guard.spec.ts` spec's internal test label "Test E" collided with an unrelated, pre-existing "Test E" in the sibling `cross-harness-inventory.rls.spec.ts` (part of a sequential A-E scheme spanning both files). Not a functional bug — Playwright disambiguates by full file path and CI passed — but the workflow YAML's own comment already anticipated this and used a `Test E'` label to disambiguate; that label was never propagated into the spec file itself.
- Renames the test title and the three internal `withTimeout` tag strings to `Test E'` for self-consistency.

Linear: SMI-5604 (parent SMI-5382).

## Test plan
- [x] `prettier --check` clean
- [x] `npx playwright test --list` — test discovers correctly under the new title, no other references missed

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)