### PR TITLE
fix(api-proxy): Forward query-string params, fix duplicate-path crash

### DIFF
--- a/apps/api-proxy/api/proxy.ts
+++ b/apps/api-proxy/api/proxy.ts
@@ -42,7 +42,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     })
   }
 
-  const path = req.query.path as string
+  // SMI-5607: req.query.path can arrive as an array if the client's own
+  // request already had its own `?path=` (Vercel merges the rewrite-injected
+  // destination param with any client-supplied one of the same name). A raw
+  // `as string` cast let an array reach `path.startsWith(...)` below and
+  // throw an unhandled TypeError; firstHeader() already handles this shape.
+  const path = firstHeader(req.query.path)
   if (!path) {
     return res.status(400).json({ error: 'Missing path parameter' })
   }
@@ -100,6 +105,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // rejection above.
   if (resolved.origin !== baseOrigin || !pathOk) {
     return res.status(400).json({ error: 'Invalid path' })
+  }
+
+  // SMI-5606: re-attach every incoming query-string key except `path` (the
+  // destination-injected routing param from vercel.json's rewrite). Vercel's
+  // rewrite match excludes the query string, so `path` never contains one —
+  // without this, GET /skills-search and /skills-get silently lose their
+  // primary input (query, limit, category, trust_tier, min_score, id, etc.).
+  for (const [key, value] of Object.entries(req.query)) {
+    if (key === 'path') continue
+    if (Array.isArray(value)) {
+      for (const v of value) resolved.searchParams.append(key, v)
+    } else if (value !== undefined) {
+      resolved.searchParams.append(key, value)
+    }
   }
 
   const targetUrl = resolved.toString()

--- a/tests/api-proxy/proxy.test.ts
+++ b/tests/api-proxy/proxy.test.ts
@@ -14,10 +14,14 @@ import handler from '../../apps/api-proxy/api/proxy'
 const SUPABASE_URL = 'https://vrcnzpmndtroqxxoqkzy.supabase.co'
 const NULL_BYTE = String.fromCharCode(0)
 
-function makeReq(path: string | undefined, headers: Record<string, string> = {}): VercelRequest {
+function makeReq(
+  path: string | undefined,
+  headers: Record<string, string> = {},
+  extraQuery: Record<string, string | string[]> = {}
+): VercelRequest {
   return {
     method: 'GET',
-    query: path === undefined ? {} : { path },
+    query: path === undefined ? { ...extraQuery } : { path, ...extraQuery },
     headers,
     body: undefined,
   } as unknown as VercelRequest
@@ -347,5 +351,107 @@ describe('SMI-5598: api-proxy header forwarding', () => {
 
       expect(fetchHeaders(fetchSpy)['x-forwarded-for']).toBeUndefined()
     })
+  })
+})
+
+describe('SMI-5606: api-proxy query-string forwarding', () => {
+  beforeEach(() => {
+    process.env.SUPABASE_URL = SUPABASE_URL
+    vi.restoreAllMocks()
+  })
+
+  function mockUpstreamJson() {
+    return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+  }
+
+  it('re-attaches additional query-string params onto the upstream fetch URL', async () => {
+    const fetchSpy = mockUpstreamJson()
+
+    const req = makeReq('functions/v1/skills-search', {}, { query: 'test', limit: '1' })
+    const res = makeRes()
+    await handler(req, res)
+
+    const calledUrl = String(fetchSpy.mock.calls[0]?.[0] ?? '')
+    expect(calledUrl).toBe(`${SUPABASE_URL}/functions/v1/skills-search?query=test&limit=1`)
+  })
+
+  it('forwards an array-valued (repeated-key) query param as repeated keys', async () => {
+    const fetchSpy = mockUpstreamJson()
+
+    const req = makeReq('functions/v1/skills-search', {}, { category: ['dev', 'ops'] })
+    const res = makeRes()
+    await handler(req, res)
+
+    const calledUrl = String(fetchSpy.mock.calls[0]?.[0] ?? '')
+    expect(new URL(calledUrl).searchParams.getAll('category')).toEqual(['dev', 'ops'])
+  })
+
+  it('never forwards `path` itself as a query-string parameter (regression)', async () => {
+    const fetchSpy = mockUpstreamJson()
+
+    const req = makeReq('functions/v1/skills-search', {}, { query: 'test' })
+    const res = makeRes()
+    await handler(req, res)
+
+    const calledUrl = String(fetchSpy.mock.calls[0]?.[0] ?? '')
+    expect(new URL(calledUrl).searchParams.has('path')).toBe(false)
+    expect(calledUrl).toBe(`${SUPABASE_URL}/functions/v1/skills-search?query=test`)
+  })
+})
+
+describe('SMI-5607: duplicate ?path= query parameter', () => {
+  beforeEach(() => {
+    process.env.SUPABASE_URL = SUPABASE_URL
+    vi.restoreAllMocks()
+  })
+
+  function mockUpstreamJson() {
+    return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+  }
+
+  it('takes the first value and forwards successfully when path arrives duplicated (array-valued)', async () => {
+    const fetchSpy = mockUpstreamJson()
+
+    const req = {
+      method: 'GET',
+      query: { path: ['functions/v1/skills-search', 'x'] },
+      headers: {},
+      body: undefined,
+    } as unknown as VercelRequest
+    const res = makeRes()
+
+    await handler(req, res)
+
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const calledUrl = String(fetchSpy.mock.calls[0]?.[0] ?? '')
+    expect(calledUrl).toBe(`${SUPABASE_URL}/functions/v1/skills-search`)
+    expect(res._status).toBe(200)
+  })
+
+  it('returns 400 (not an unhandled crash) when the first duplicated path value is invalid', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    const req = {
+      method: 'GET',
+      query: { path: ['x', 'functions/v1/skills-search'] },
+      headers: {},
+      body: undefined,
+    } as unknown as VercelRequest
+    const res = makeRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(400)
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- **SMI-5606** (Urgent): `apps/api-proxy/api/proxy.ts` never re-attached any GET query-string parameter except the internal `path` routing param before forwarding to Supabase — silently breaking `GET /skills-search` and `GET /skills-get` (their primary input) via the default documented host `api.skillsmith.app`. Confirmed via live curl reproduction, source tracing on both `proxy.ts` and `supabase/functions/skills-search/index.ts`, and Vercel's own compiled `.vercel/output/config.json` build manifest. Fix re-attaches every `req.query` key except `path` onto the already-SSRF-validated URL's `searchParams`.
- **SMI-5607** (Low, found by an independent Opus adversarial security review of the SMI-5606 fix): a duplicate client-supplied `?path=` makes `req.query.path` an array; the old `as string` cast let it reach `.startsWith()` and throw an unhandled `TypeError` before any error handling — any anonymous caller could force an ungraceful 500. Fixed in the same commit by reusing the file's existing `firstHeader()` helper.
- **SMI-5608** filed (not fixed here, different package/concern): the website's own SSR `skills-search.ts` route silently returns `{skills:[]}`/200 on any upstream failure, masking errors independent of this fix.

## Security review
An independent Opus adversarial security review confirmed the SMI-5606 fix cannot reopen the SSRF surface this file hardens: `URLSearchParams.append()` only mutates the query component of an already-locked `URL` (origin/pathname were validated and stored as discrete components before the new loop runs), and its serializer percent-encodes every structural character (`/`, `?`, `#`, `&`, `=`, `:`, CRLF, NUL) in both keys and values — no origin/path escape, no header-injection/request-smuggling via query values. Full write-up in `docs/internal/code_review/2026-07-09-smi-5606-5607-proxy-query-string-fix.md` (private submodule).

## Test plan
- [x] `./scripts/worktree-docker.sh exec -- npx vitest run tests/api-proxy/proxy.test.ts` → 34/34 pass (5 new)
- [x] eslint, prettier, ad-hoc strict `tsc --noEmit` clean
- [x] Sibling-implementation sweep: only `proxy.ts` builds an upstream URL from `req.query`; `health.ts` unaffected
- [x] Governance pre-commit retro run in-context — report written, 0 unresolved findings
- [ ] Post-deploy smoke check (pending merge + explicit deploy go-ahead): confirm query strings now reach Supabase correctly

Refs SMI-5606, SMI-5607, SMI-5608

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)


[skip-impl-check]

The `verify-implementation` check flagged this PR as having "no source code changes" — a false positive. `scripts/ci/source-patterns.mjs`'s `SOURCE_PATTERNS` only matches `packages/`, `supabase/functions/`, `scripts/`, and a few root configs; it has no pattern for `apps/`, so `apps/api-proxy/api/proxy.ts` (the actual fix) is silently classified as `config` instead of `source`. This is the same `apps/api-proxy` blind spot already tracked as SMI-5603 (which covers `audit:standards`'s identical gap) — updating that issue now to record this second confirmed instance. Fixing `source-patterns.mjs` itself is a CI-script change requiring SPARC + plan-review per ADR-109, out of scope for this PR to do ad-hoc. User-authorized.
