### PR TITLE
build(mcp-server): Add standalone Dockerfile for Docker MCP registry

### DIFF
--- a/.claude/development/mcp-registry.md
+++ b/.claude/development/mcp-registry.md
@@ -3,6 +3,8 @@
 **Linear Issue**: [SMI-2158](https://linear.app/smith-horn-group/issue/SMI-2158/register-skillsmith-on-mcp-registry-and-claude-connector-directory)
 **Last Updated**: February 1, 2026
 
+> This page covers the **official MCP registry** only. Skillsmith is also listed on a second, independently-mechanized channel — see [Docker MCP Registry](#docker-mcp-registry) below.
+
 ## Overview
 
 Skillsmith is published to the official MCP Registry, enabling discovery by:
@@ -212,3 +214,79 @@ curl -s "https://registry.modelcontextprotocol.io/v0.1/servers?search=skillsmith
 - [MCP Registry Quickstart](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx)
 - [server.json Schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json)
 - [Claude Connector Directory](https://claude.com/connectors)
+
+---
+
+## Docker MCP Registry
+
+**Linear Issue**: SMI-5609 · **Plan**: `docs/internal/implementation/docker-mcp-registry-publish.md`
+
+Docker maintains a second, separately-curated MCP registry — `github.com/docker/mcp-registry` — that feeds Docker Hub's `mcp/` namespace and Docker Desktop's MCP Toolkit UI. This is an independent distribution channel from the official `registry.modelcontextprotocol.io` registry documented above: different repo, different maintainers, different submission and build mechanism.
+
+### Registry Details
+
+| Field | Value |
+|-------|-------|
+| Registry repo | <https://github.com/docker/mcp-registry> |
+| Docker Hub image | `mcp/skillsmith` |
+| Entry files | `servers/skillsmith/server.yaml` + `servers/skillsmith/tools.json`, in a **fork of `docker/mcp-registry`** — not this repository |
+| Build context (`source.directory`) | `packages/mcp-server` |
+| Dockerfile | `packages/mcp-server/Dockerfile` |
+
+### The `source.directory` monorepo mechanism
+
+For a monorepo submission, Docker's registry builds the image using `server.yaml`'s `source.directory` field as **both** the Dockerfile location and the entire build context — the build has no access to anything outside that directory: no repo root, no sibling packages, no root `package-lock.json` or `.npmrc`. Skillsmith's entry sets `directory: packages/mcp-server`, so `packages/mcp-server/Dockerfile` is written to be fully self-sufficient from that directory alone. It resolves `@skillsmith/core` as a real published npm dependency (not a workspace link), so a plain `npm install` works with zero workspace context.
+
+### License compatibility (resolved)
+
+Skillsmith is licensed under Elastic License 2.0 (ELv2) — source-available, not OSI-approved (ADR-119). Docker's `CONTRIBUTING.md` states in prose: *"Make sure the license of your MCP Server allows people to consume it (MIT or Apache 2 are great, GPL is not)."* Taken literally, this could read as excluding ELv2. It's more restrictive than Docker's actual automated gate.
+
+`internal/licenses/check.go` in `docker/mcp-registry` only rejects a GitHub-detected SPDX license key prefixed `gpl`, `agpl`, or `npl`:
+
+```go
+func IsValid(license *github.License) bool {
+	if license != nil && (strings.HasPrefix(license.GetKey(), "gpl") || strings.HasPrefix(license.GetKey(), "agpl") || strings.HasPrefix(license.GetKey(), "npl")) {
+		return false
+	}
+	return true
+}
+```
+
+`gh api repos/smith-horn/skillsmith --jq '.license'` returns `{"key":"other","name":"Other","spdx_id":"NOASSERTION"}`. This isn't a defect in our `LICENSE` file — it's the canonical, unmodified Elastic License 2.0 text — GitHub's `licensee`/`choosealicense.com` catalog simply has no entry for Elastic-2.0 at all, even for the canonical text, so *any* ELv2 repo resolves to `"other"`. `"other"` never matches the `gpl`/`agpl`/`npl` prefixes, so **the automated gate passes cleanly and reliably, not just as a one-time result**. A discretionary human "Docker team review" step still sits on top of the automated gate (residual risk: small). See the plan doc for the reputational-risk contingency and registry precedent (`elasticsearch`, `grafana`, `cockroachdb` are all listed despite non-permissive core licenses, via a separately-licensed MCP wrapper repo in most of those cases).
+
+### Nightly automated bump-PRs
+
+Once a submission is merged, Docker runs an automated nightly GitHub Action that opens commit-bump PRs against `docker/mcp-registry` to keep the pinned `source.commit` current (per Docker's `docs/configuration.md`: *"Once an initial revision is accepted into the registry, an automated nightly GitHub Action will drive PRs to perform updates"*). There is no fixed-cadence maintenance obligation — review opportunistically when GitHub notifies of a new bump PR. Ownership: the SMI-5609 assignee, or its Wave 2 follow-up issue's assignee once Wave 1 (in-repo, closed on merge) and Wave 2 (external submission, unbounded timeline) are split into separate Linear issues per this repo's convention of not letting external/unbounded-timeline follow-up work block an in-repo issue from closing.
+
+### Accepted risk — no lockfile in the Docker build context
+
+`packages/mcp-server/Dockerfile`'s build context has no `package-lock.json` — neither `packages/core/` nor `packages/mcp-server/` has its own lockfile; only the repo root does, which is out of scope for this build context. Both manual rebuilds and Docker's nightly bump-PR automation therefore resolve dependencies fresh (`npm install`, not `npm ci`) on every build. This is a deliberate accepted risk, not a gap to fix — revisit only if it causes a real break.
+
+### Accepted risk — semver drift between npm-published and Docker-published server
+
+**Verified live, not just theoretical (Wave 1 Step 5 local validation)**: building the image from current `main` HEAD's `dist/` while installing `@skillsmith/core` from the public npm registry (`0.10.0`) crashes the server at startup — `packages/mcp-server/src/index.ts`'s static import graph reaches `DEFAULT_RISK_THRESHOLD` from `@skillsmith/core`, which the published `0.10.0` tarball doesn't export (confirmed by downloading and grepping it directly; the export exists in local `packages/core/src/index.ts` but postdates the last publish, and `packages/core/CHANGELOG.md`'s `[Unreleased]` section is empty despite that — a version-bump gap upstream of this doc). **Not currently affecting real users**: the published `@skillsmith/mcp-server@0.7.0` tarball predates this export and doesn't reference it. It only bites the specific combination this Dockerfile uses (fresh HEAD `dist/` + npm-installed `core`) — confirmed by patch-testing with a correct local `core/dist` overlaid into the built image, after which `initialize`, the no-auth trial path, and the volume-mount write-through all worked correctly.
+
+**Concrete rule for pinning `source.commit`** (Wave 2 Step 1): never pin to "current `main` tip" by default. Pin only to a commit at or before the last `@skillsmith/mcp-server` npm publish (so the built `dist/` only references already-published `@skillsmith/core` exports), or wait for `@skillsmith/core` to publish a version containing whatever HEAD-ahead exports exist before pinning past that point. This is a scheduling constraint on which commit to submit, not a code fix — follow the normal publish cadence (`publishing-guide.md`), don't force an out-of-cycle release for this.
+
+### Three parallel self-descriptions
+
+The Docker listing's `about.description` (in `server.yaml`), the npm `package.json` description, and the official-registry `server.json` description (documented above) are three separate, surface-appropriate pitches maintained independently — not one shared string kept in sync across all three. This is intentional; a future editor should not assume divergence between them is drift to fix.
+
+### Naming across registries
+
+The same server has three different identifiers across the three channels — expected, not a bug:
+
+| Channel | Identifier |
+|---------|-----------|
+| npm | `@skillsmith/mcp-server` |
+| Official MCP registry | `io.github.smith-horn/skillsmith` |
+| Docker MCP registry | `mcp/skillsmith` |
+
+No action needed — noted here only so a future support conversation isn't confused by the divergence.
+
+### References
+
+- [docker/mcp-registry](https://github.com/docker/mcp-registry)
+- [Configuration docs (`docs/configuration.md`)](https://github.com/docker/mcp-registry/blob/main/docs/configuration.md)
+- [Contributing guide](https://github.com/docker/mcp-registry/blob/main/CONTRIBUTING.md)
+- `docs/internal/implementation/docker-mcp-registry-publish.md` — full investigation, including the reputational-risk contingency owner and the license-check verification trail

--- a/.claude/development/mcp-registry.md
+++ b/.claude/development/mcp-registry.md
@@ -245,10 +245,10 @@ Skillsmith is licensed under Elastic License 2.0 (ELv2) — source-available, no
 
 ```go
 func IsValid(license *github.License) bool {
-	if license != nil && (strings.HasPrefix(license.GetKey(), "gpl") || strings.HasPrefix(license.GetKey(), "agpl") || strings.HasPrefix(license.GetKey(), "npl")) {
-		return false
-	}
-	return true
+    if license != nil && (strings.HasPrefix(license.GetKey(), "gpl") || strings.HasPrefix(license.GetKey(), "agpl") || strings.HasPrefix(license.GetKey(), "npl")) {
+        return false
+    }
+    return true
 }
 ```
 

--- a/.github/workflows/packaging-test.yml
+++ b/.github/workflows/packaging-test.yml
@@ -205,3 +205,59 @@ jobs:
           else
             gh issue create --repo "${{ github.repository }}" --title "CI: Packaging Test failed ($(date -u +%Y-%m-%d))" --label "ci-alert" --body "Workflow: Packaging Test Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} Branch: ${{ github.ref_name }} This issue was auto-created by SMI-3335. Close when resolved."
           fi
+
+  # SMI-5609: lightweight backstop for packages/mcp-server/Dockerfile (Docker MCP
+  # registry submission, docker/mcp-registry `source.directory: packages/mcp-server`).
+  # A successful `docker build` alone is the target here — catches dependency
+  # resolution / native-module build breaks cheaply. Full functional smoke
+  # (MCP initialize, no-auth trial, volume-mount write) is deliberately out of
+  # scope for this CI job; see docs/internal/implementation/docker-mcp-registry-publish.md.
+  docker-build-test:
+    name: Docker Build Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build mcp-server (with inlined workspace deps)
+        # turbo builds core -> mcp-server in dependency order, producing
+        # packages/mcp-server/dist/ which the Dockerfile's `COPY dist/` step needs.
+        run: npx turbo build --filter=@skillsmith/mcp-server
+
+      - name: Build mcp-server Docker image
+        run: docker build -t skillsmith-mcp-ci-check packages/mcp-server
+
+      - name: Generate test report
+        if: always()
+        run: |
+          echo "## Docker Build Test Results (SMI-5609)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| mcp-server dist/ built | checked |" >> $GITHUB_STEP_SUMMARY
+          echo "| packages/mcp-server/Dockerfile builds standalone | checked |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Run triggered: $(date -u)" >> $GITHUB_STEP_SUMMARY
+
+      # SMI-3335: Alert on scheduled workflow failure
+      - name: Alert on failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list --repo "${{ github.repository }}" --label "ci-alert" --search "Docker Build Test failed" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "${{ github.repository }}" --body "Still failing: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          else
+            gh issue create --repo "${{ github.repository }}" --title "CI: Docker Build Test failed ($(date -u +%Y-%m-%d))" --label "ci-alert" --body "Workflow: Packaging Test (Docker Build Test job) Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} Branch: ${{ github.ref_name }} This issue was auto-created by SMI-5609. Close when resolved."
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -192,10 +192,10 @@ USER nodejs
 # Health check for production container
 # Verifies the MCP server can start and respond
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD node -e "require('./packages/mcp-server/dist/index.js')" || exit 1
+    CMD node -e "require('./packages/mcp-server/dist/src/index.js')" || exit 1
 
 # Expose MCP server port (if applicable)
 EXPOSE 3001
 
 # Start the MCP server
-CMD ["node", "packages/mcp-server/dist/index.js"]
+CMD ["node", "packages/mcp-server/dist/src/index.js"]

--- a/packages/mcp-server/.dockerignore
+++ b/packages/mcp-server/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+src
+tests
+*.test.ts
+*.spec.ts
+.env
+.env.*
+*.log

--- a/packages/mcp-server/Dockerfile
+++ b/packages/mcp-server/Dockerfile
@@ -1,0 +1,52 @@
+# Standalone build context for the Docker MCP registry (docker/mcp-registry,
+# source.directory: packages/mcp-server) — separate from the repo-root Dockerfile.
+# `dist/` must be pre-built (repo-root `npm run build`) before `docker build` runs;
+# see docs/internal/implementation/docker-mcp-registry-publish.md item 1 (open question).
+
+# -----------------------------------------------------------------------------
+# Stage 1: deps - install dependencies with native-module build tools present
+# -----------------------------------------------------------------------------
+FROM node:22-slim AS deps
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+WORKDIR /app
+
+COPY package.json ./
+
+# --ignore-scripts denies arbitrary postinstall scripts from the full transitive
+# tree (no lockfile in this build context, so resolution is unpinned) — matches
+# the root Dockerfile's own pattern (Dockerfile:64) rather than letting a
+# compromised transitive dep auto-execute as root on Docker's signed-build infra.
+RUN npm install --omit=dev --ignore-scripts
+
+# Explicit rebuild of the native optionalDependencies that --ignore-scripts skipped
+# (better-sqlite3, onnxruntime-node, hnswlib-node), matching Dockerfile:73.
+RUN npm rebuild better-sqlite3 onnxruntime-node hnswlib-node || true
+
+COPY dist/ ./dist/
+
+# -----------------------------------------------------------------------------
+# Stage 2: runtime - lean image, no build tools, non-root user
+# -----------------------------------------------------------------------------
+FROM node:22-slim AS runtime
+
+WORKDIR /app
+
+RUN groupadd --gid 1001 nodejs \
+    && useradd --uid 1001 --gid nodejs --shell /bin/bash --create-home nodejs
+
+COPY --from=deps --chown=nodejs:nodejs /app/node_modules ./node_modules
+COPY --from=deps --chown=nodejs:nodejs /app/dist ./dist
+COPY --chown=nodejs:nodejs package.json ./
+
+USER nodejs
+
+ENV NODE_ENV=production
+
+CMD ["node", "dist/src/index.js"]


### PR DESCRIPTION
## Summary
- Adds `packages/mcp-server/Dockerfile` — a standalone, 2-stage build that compiles in isolation from that directory alone. Required because Docker's MCP registry (`docker/mcp-registry`) builds monorepo submissions using a `source.directory` field as both Dockerfile location and build context, with no access to the workspace root.
- Fixes a pre-existing bug in the root `Dockerfile`'s `prod` stage: HEALTHCHECK/CMD referenced `packages/mcp-server/dist/index.js`, which has never existed (real path is `dist/src/index.js`). That target wasn't wired into `docker-compose.yml` or any CI workflow, so it shipped broken until this investigation surfaced it.
- Adds a `docker-build-test` job to `packaging-test.yml` so a future break in the new Dockerfile is caught in CI rather than only at Docker's own review.
- Documents the new distribution channel in `.claude/development/mcp-registry.md`, including the license-compatibility finding (Elastic License 2.0 passes Docker's automated gate via GitHub's `licensee` `"other"` fallback — verified against Docker's actual `internal/licenses/check.go`, not just their prose `CONTRIBUTING.md`).

## Process
- ADR-109 gate (Dockerfile changes = infra change): full VP Product/Engineering/Design `plan-review-skill` pass before implementation — 22 findings, all applied. Plan: `docs/internal/implementation/docker-mcp-registry-publish.md`.
- Adversarial Opus security review of the resulting Dockerfile — 3 findings (unrestricted install scripts running as root, `RUN chown` image bloat, missing `.dockerignore`), all fixed in this commit.
- Local validation surfaced a real, currently-live version-alignment gap between `main` HEAD's `mcp-server` code and the published `@skillsmith/core@0.10.0` (missing export, crashes server startup when built from HEAD + npm-installed core) — **not** affecting today's published `@skillsmith/mcp-server@0.7.0` npm users, but a hard constraint on which commit the follow-up external Docker submission (Wave 2, separate, not part of this PR) may pin. Documented in both the plan doc and `mcp-registry.md`.
- Governance/code-review report: `docs/internal/code_review/2026-07-08-smi-5609-docker-mcp-registry-dockerfile.md` — zero findings requiring fixes (everything caught upstream by the two reviews above).

## Out of scope (explicitly)
Opening a PR to the external `docker/mcp-registry` repo (Wave 2) is separate work, gated on explicit human confirmation before opening any PR to that third-party repo. Not part of this change.

Refs SMI-5609

## Test plan
- [x] `docker build packages/mcp-server` succeeds standalone (context scoped to that directory alone, no repo-root access)
- [x] MCP `initialize` smoke test passes (with a version-aligned `@skillsmith/core`; documented crash mode with the currently-published npm version, see above)
- [x] No-auth trial path works inside the container
- [x] Volume-mounted config path (`/home/nodejs/.skillsmith`) persists real files to the host
- [x] `docker build --target prod .` (root Dockerfile) builds clean; fixed path resolves and runs inside the built image
- [x] `npm run audit:standards` — 0 failures (8 pre-existing, unrelated warnings)
- [x] `npx prettier --check` on touched docs/CI files