### PR TITLE
feat(website): surface suggested-action copy on /account/skills badges

### DIFF
--- a/packages/website/src/lib/inventory-view.suggested-action.test.ts
+++ b/packages/website/src/lib/inventory-view.suggested-action.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for the SMI-5595 additions to inventory-view.ts: SKILL_STATE_META's
+ * `suggestedAction` field and the device-wide `computeDeviceBatchTip` helper.
+ *
+ * Split out of inventory-view.test.ts to keep both files under the
+ * project's 500-line-per-file standard.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  computeDeviceBatchTip,
+  DEVICE_BATCH_UPDATE_TIP,
+  SKILL_STATE_META,
+  type SkillState,
+  type SkillView,
+} from './inventory-view'
+
+/**
+ * Build a complete SkillView with sensible defaults. Override only the
+ * fields each test cares about.
+ */
+function makeSkillView(partial: Partial<SkillView>): SkillView {
+  return {
+    harness: 'claude-code',
+    skillId: 'skill-default',
+    version: '1.0.0',
+    present: true,
+    pinned: false,
+    state: 'current',
+    author: null,
+    repository: null,
+    license: null,
+    ...partial,
+  }
+}
+
+describe('SKILL_STATE_META — suggestedAction (SMI-5595)', () => {
+  const allStates: SkillState[] = [
+    'current',
+    'drifted',
+    'missing',
+    'pinned',
+    'unknown',
+    'local',
+    'source-identified',
+    'pending',
+  ]
+
+  it('every entry has a suggestedAction field of the correct type', () => {
+    for (const state of allStates) {
+      const meta = SKILL_STATE_META[state]
+      expect(meta).toHaveProperty('suggestedAction')
+      expect(meta.suggestedAction === null || typeof meta.suggestedAction === 'string').toBe(true)
+    }
+  })
+
+  it('suggestedAction copy matches the exact reviewed spec strings', () => {
+    expect(SKILL_STATE_META.current.suggestedAction).toBe('No action needed.')
+    expect(SKILL_STATE_META.drifted.suggestedAction).toBe(
+      'Run `skillsmith update <skill>` on that machine.'
+    )
+    expect(SKILL_STATE_META.missing.suggestedAction).toBe(
+      'Confirm the skill is still installed, then re-run `skillsmith inventory push` from that machine — or reinstall it if it was removed intentionally.'
+    )
+    expect(SKILL_STATE_META.pinned.suggestedAction).toBe(
+      'No action needed. Run `skillsmith unpin <skill>` if you want drift checks again.'
+    )
+    expect(SKILL_STATE_META.unknown.suggestedAction).toBe(
+      'No action needed — expected for skills you wrote yourself or installed outside the registry.'
+    )
+    expect(SKILL_STATE_META.local.suggestedAction).toBe(
+      "No action needed. Add `author`, `repository`, and `license` front-matter to the skill's `SKILL.md` if you'd like it to show as Claimed source instead."
+    )
+    expect(SKILL_STATE_META['source-identified'].suggestedAction).toBe(
+      "No action needed — the author/repository shown is self-reported and hasn't been verified by the registry. It would show as a verified source if the skill is published to the registry (`skillsmith publish`)."
+    )
+    expect(SKILL_STATE_META.pending.suggestedAction).toBe(
+      'None — this is a transient state. Refresh the page in a few seconds.'
+    )
+  })
+
+  it('drifted and pinned suggestedAction contain the <skill> placeholder inside a backtick span', () => {
+    expect(SKILL_STATE_META.drifted.suggestedAction).toContain('`skillsmith update <skill>`')
+    expect(SKILL_STATE_META.pinned.suggestedAction).toContain('`skillsmith unpin <skill>`')
+  })
+
+  it('current and unknown suggestedAction contain no backticks or <skill> placeholder', () => {
+    expect(SKILL_STATE_META.current.suggestedAction).not.toContain('`')
+    expect(SKILL_STATE_META.current.suggestedAction).not.toContain('<skill>')
+    expect(SKILL_STATE_META.unknown.suggestedAction).not.toContain('`')
+    expect(SKILL_STATE_META.unknown.suggestedAction).not.toContain('<skill>')
+  })
+
+  it('no state other than drifted/pinned contains the <skill> placeholder', () => {
+    for (const state of allStates) {
+      if (state === 'drifted' || state === 'pinned') continue
+      expect(SKILL_STATE_META[state].suggestedAction).not.toContain('<skill>')
+    }
+  })
+})
+
+describe('computeDeviceBatchTip', () => {
+  it('returns null for an empty skills array', () => {
+    expect(computeDeviceBatchTip([])).toBeNull()
+  })
+
+  it('returns null for 0 drifted skills', () => {
+    const skills = [
+      makeSkillView({ skillId: 'a', state: 'current' }),
+      makeSkillView({ skillId: 'b', state: 'missing' }),
+    ]
+    expect(computeDeviceBatchTip(skills)).toBeNull()
+  })
+
+  it('returns null for exactly 1 drifted skill', () => {
+    const skills = [
+      makeSkillView({ skillId: 'a', state: 'drifted' }),
+      makeSkillView({ skillId: 'b', state: 'current' }),
+    ]
+    expect(computeDeviceBatchTip(skills)).toBeNull()
+  })
+
+  it('returns the tip string for exactly 2 drifted skills', () => {
+    const skills = [
+      makeSkillView({ skillId: 'a', state: 'drifted' }),
+      makeSkillView({ skillId: 'b', state: 'drifted' }),
+    ]
+    expect(computeDeviceBatchTip(skills)).toBe(DEVICE_BATCH_UPDATE_TIP)
+  })
+
+  it('returns the tip string for 3+ drifted skills', () => {
+    const skills = [
+      makeSkillView({ skillId: 'a', state: 'drifted' }),
+      makeSkillView({ skillId: 'b', state: 'drifted' }),
+      makeSkillView({ skillId: 'c', state: 'drifted' }),
+    ]
+    expect(computeDeviceBatchTip(skills)).toBe(DEVICE_BATCH_UPDATE_TIP)
+  })
+
+  it('fires when the 2 drifted skills are on two DIFFERENT harnesses (device-wide, not per-harness)', () => {
+    const skills = [
+      makeSkillView({ skillId: 'a', harness: 'claude-code', state: 'drifted' }),
+      makeSkillView({ skillId: 'b', harness: 'cursor', state: 'drifted' }),
+    ]
+    expect(computeDeviceBatchTip(skills)).toBe(DEVICE_BATCH_UPDATE_TIP)
+  })
+
+  it('pinned skills never count toward the drifted threshold, regardless of count', () => {
+    const skills = [
+      makeSkillView({ skillId: 'a', state: 'pinned' }),
+      makeSkillView({ skillId: 'b', state: 'pinned' }),
+      makeSkillView({ skillId: 'c', state: 'pinned' }),
+    ]
+    expect(computeDeviceBatchTip(skills)).toBeNull()
+  })
+})

--- a/packages/website/src/lib/inventory-view.test.ts
+++ b/packages/website/src/lib/inventory-view.test.ts
@@ -369,6 +369,10 @@ describe('SKILL_STATE_META', () => {
   })
 })
 
+// suggestedAction coverage (SKILL_STATE_META) and computeDeviceBatchTip are in
+// inventory-view.suggested-action.test.ts (SMI-5595) — split out to stay under
+// the project's 500-line-per-file standard.
+
 // ─── STALE_AFTER_HOURS ────────────────────────────────────────────────────────
 
 describe('STALE_AFTER_HOURS', () => {

--- a/packages/website/src/lib/inventory-view.ts
+++ b/packages/website/src/lib/inventory-view.ts
@@ -121,42 +121,65 @@ export type EmptyState = 'consent-off' | 'opted-in-no-devices' | 'single-machine
 export const STALE_AFTER_HOURS = 24
 
 /**
- * Human-readable label and one-line tooltip for each {@link SkillState}.
- * The `.astro` component maps each state to an icon/shape; this module owns
- * only the text.
+ * Human-readable label, one-line tooltip, and suggested next action for each
+ * {@link SkillState}. The `.astro` component maps each state to an
+ * icon/shape; this module owns only the text.
+ *
+ * `suggestedAction` may contain inline-code spans delimited by backtick
+ * pairs (`` ` ``...`` ` ``), which the renderer converts to `<code>` tags.
+ * The literal placeholder token `<skill>` (inside a backtick span) appears
+ * only in the `drifted` and `pinned` entries and is substituted by the
+ * renderer with the real skill ID. `suggestedAction` is `null` when a state
+ * has no actionable next step.
  */
-export const SKILL_STATE_META: Record<SkillState, { label: string; description: string }> = {
+export const SKILL_STATE_META: Record<
+  SkillState,
+  { label: string; description: string; suggestedAction: string | null }
+> = {
   current: {
     label: 'Up to date',
     description: 'Up to date with the registry',
+    suggestedAction: 'No action needed.',
   },
   drifted: {
     label: 'Update available',
     description: 'A newer version is available in the registry',
+    suggestedAction: 'Run `skillsmith update <skill>` on that machine.',
   },
   missing: {
     label: 'Missing',
     description: 'Installed before but not seen in the latest sync',
+    suggestedAction:
+      'Confirm the skill is still installed, then re-run `skillsmith inventory push` from that machine — or reinstall it if it was removed intentionally.',
   },
   pinned: {
     label: 'Pinned',
     description: 'Pinned to a version; drift checks suppressed',
+    suggestedAction:
+      'No action needed. Run `skillsmith unpin <skill>` if you want drift checks again.',
   },
   unknown: {
     label: 'Unknown',
     description: 'Not matched to a registry skill (local or custom)',
+    suggestedAction:
+      'No action needed — expected for skills you wrote yourself or installed outside the registry.',
   },
   local: {
     label: 'Local',
     description: 'Installed locally; no registry or declared source',
+    suggestedAction:
+      "No action needed. Add `author`, `repository`, and `license` front-matter to the skill's `SKILL.md` if you'd like it to show as Claimed source instead.",
   },
   'source-identified': {
     label: 'Claimed source',
     description: "Source declared in the skill's own metadata (not registry-verified)",
+    suggestedAction:
+      "No action needed — the author/repository shown is self-reported and hasn't been verified by the registry. It would show as a verified source if the skill is published to the registry (`skillsmith publish`).",
   },
   pending: {
     label: 'Checking…',
     description: 'Resolving source — check back shortly',
+    suggestedAction: 'None — this is a transient state. Refresh the page in a few seconds.',
   },
 }
 
@@ -222,6 +245,38 @@ export function buildInventoryView(rows: InventoryRow[]): DeviceView[] {
   }
 
   return Array.from(byDevice.values())
+}
+
+// ─── Device-wide batch tips ───────────────────────────────────────────────────
+
+/**
+ * Copy shown when a device has multiple drifted skills, suggesting a single
+ * batch-update command instead of updating each skill individually.
+ */
+export const DEVICE_BATCH_UPDATE_TIP =
+  'Multiple skills on this machine have updates — run `skillsmith update --all` to update everything at once.'
+
+/**
+ * Decide whether to show the {@link DEVICE_BATCH_UPDATE_TIP} for a device.
+ *
+ * Threshold is evaluated **device-wide, across all harnesses** — not
+ * per-harness. A device with one `drifted` skill under `claude-code` and one
+ * `drifted` skill under `cursor` still crosses the threshold, because
+ * `skillsmith update --all` operates on the whole machine, not a single
+ * harness. Callers must pass the full flat list of a device's skills
+ * (i.e. call this *before* any per-harness grouping) — grouping first and
+ * calling this per-harness-group would undercount and suppress the tip.
+ *
+ * @param skills - All skills for a single device, across every harness.
+ * @returns {@link DEVICE_BATCH_UPDATE_TIP} when 2 or more skills are
+ *   `drifted`; otherwise `null`.
+ *
+ * @example
+ * computeDeviceBatchTip(device.skills) // => tip string or null
+ */
+export function computeDeviceBatchTip(skills: SkillView[]): string | null {
+  const driftedCount = skills.filter((s) => s.state === 'drifted').length
+  return driftedCount >= 2 ? DEVICE_BATCH_UPDATE_TIP : null
 }
 
 // ─── Formatting helpers ───────────────────────────────────────────────────────

--- a/packages/website/src/lib/skills-page-render.suggested-action.test.ts
+++ b/packages/website/src/lib/skills-page-render.suggested-action.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for the SMI-5595 suggested-action rendering in skills-page-render.ts
+ * (per-skill `.skill-action` span and the device-wide `.device-batch-tip`).
+ *
+ * Split out of skills-page-render.test.ts to keep both files under the
+ * project's 500-line-per-file standard.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { buildDeviceCardHtml } from './skills-page-render'
+import { SKILL_STATE_META, type DeviceView, type SkillView } from './inventory-view'
+
+describe('buildDeviceCardHtml — suggested action / device batch tip (SMI-5595)', () => {
+  it('drifted: renders a .skill-action span with the skill id substituted into a <code> command, unescaped for benign chars', () => {
+    const device: DeviceView = {
+      deviceId: 'abcdef12-3456-4789-8abc-def012345678',
+      label: 'my-box',
+      hostnameDisplay: null,
+      platform: 'darwin',
+      lastSeen: '2026-06-26T00:00:00.000Z',
+      deviceState: 'fresh',
+      neverSynced: false,
+      skills: [
+        {
+          harness: 'zed',
+          skillId: 'acme/widget',
+          version: '1.0.0',
+          present: true,
+          pinned: false,
+          state: 'drifted',
+          author: null,
+          repository: null,
+          license: null,
+        },
+      ],
+    }
+    const html = buildDeviceCardHtml(device)
+    expect(html).toContain('<span class="skill-action">')
+    // '/' is not HTML-significant — escapeHtml leaves it unchanged.
+    expect(html).toContain('<code>skillsmith update acme/widget</code>')
+  })
+
+  it('drifted: escapes a skill id containing < and & inside the rendered <code> span (XSS-safety regression)', () => {
+    const device: DeviceView = {
+      deviceId: 'abcdef12-3456-4789-8abc-def012345678',
+      label: 'my-box',
+      hostnameDisplay: null,
+      platform: 'darwin',
+      lastSeen: '2026-06-26T00:00:00.000Z',
+      deviceState: 'fresh',
+      neverSynced: false,
+      skills: [
+        {
+          harness: 'zed',
+          skillId: 'evil/<script>&x',
+          version: '1.0.0',
+          present: true,
+          pinned: false,
+          state: 'drifted',
+          author: null,
+          repository: null,
+          license: null,
+        },
+      ],
+    }
+    const html = buildDeviceCardHtml(device)
+    expect(html).not.toContain('<script>&x')
+    expect(html).toContain('<code>skillsmith update evil/&lt;script&gt;&amp;x</code>')
+  })
+
+  it('drifted: a backtick in the skill id does not shift code-span parity (regression for the split-then-substitute order)', () => {
+    const device: DeviceView = {
+      deviceId: 'abcdef12-3456-4789-8abc-def012345678',
+      label: 'my-box',
+      hostnameDisplay: null,
+      platform: 'darwin',
+      lastSeen: '2026-06-26T00:00:00.000Z',
+      deviceState: 'fresh',
+      neverSynced: false,
+      skills: [
+        {
+          harness: 'zed',
+          skillId: 'acme/wid`get',
+          version: '1.0.0',
+          present: true,
+          pinned: false,
+          state: 'drifted',
+          author: null,
+          repository: null,
+          license: null,
+        },
+      ],
+    }
+    const html = buildDeviceCardHtml(device)
+    // Splitting on the (trusted) template first, then substituting <skill> only
+    // inside the already-identified code segment, means a backtick carried in
+    // by the skill id can't shift which parts of the surrounding sentence get
+    // treated as code — the whole command stays inside one <code> span.
+    expect(html).toContain('<code>skillsmith update acme/wid`get</code>')
+    const actionMatch = html.match(/<span class="skill-action">(.*?)<\/span>/)
+    expect(actionMatch).not.toBeNull()
+    expect(actionMatch![1]).toBe('Run <code>skillsmith update acme/wid`get</code> on that machine.')
+  })
+
+  it('current: renders a .skill-action span with plain text and no <code> child for a no-command state', () => {
+    const device: DeviceView = {
+      deviceId: 'abcdef12-3456-4789-8abc-def012345678',
+      label: 'my-box',
+      hostnameDisplay: null,
+      platform: 'darwin',
+      lastSeen: '2026-06-26T00:00:00.000Z',
+      deviceState: 'fresh',
+      neverSynced: false,
+      skills: [
+        {
+          harness: 'zed',
+          skillId: 'acme/widget',
+          version: '1.0.0',
+          present: true,
+          pinned: false,
+          state: 'current',
+          author: null,
+          repository: null,
+          license: null,
+        },
+      ],
+    }
+    const html = buildDeviceCardHtml(device)
+    const actionMatch = html.match(/<span class="skill-action">(.*?)<\/span>/)
+    expect(actionMatch).not.toBeNull()
+    expect(actionMatch![1]).toBe(SKILL_STATE_META.current.suggestedAction)
+    expect(actionMatch![1]).not.toContain('<code>')
+  })
+
+  it('a11y: the .skill-action span for a skill is nested inside that skill\'s own <li class="skill-item"> (not a sibling or unattached element)', () => {
+    const device: DeviceView = {
+      deviceId: 'abcdef12-3456-4789-8abc-def012345678',
+      label: 'my-box',
+      hostnameDisplay: null,
+      platform: 'darwin',
+      lastSeen: '2026-06-26T00:00:00.000Z',
+      deviceState: 'fresh',
+      neverSynced: false,
+      skills: [
+        {
+          harness: 'zed',
+          skillId: 'acme/widget',
+          version: '1.0.0',
+          present: true,
+          pinned: false,
+          state: 'drifted',
+          author: null,
+          repository: null,
+          license: null,
+        },
+      ],
+    }
+    const html = buildDeviceCardHtml(device)
+    const liMatch = html.match(/<li class="skill-item">.*?<\/li>/s)
+    expect(liMatch).not.toBeNull()
+    const liHtml = liMatch![0]
+    expect(liHtml).toContain('acme/widget')
+    expect(liHtml).toContain('<span class="skill-action">')
+    expect(liHtml).toContain('<code>skillsmith update acme/widget</code>')
+  })
+
+  describe('device batch tip (computeDeviceBatchTip integration)', () => {
+    function skill(overrides: Partial<SkillView>): SkillView {
+      return {
+        harness: 'zed',
+        skillId: 'acme/widget',
+        version: '1.0.0',
+        present: true,
+        pinned: false,
+        state: 'current',
+        author: null,
+        repository: null,
+        license: null,
+        ...overrides,
+      }
+    }
+
+    it('renders exactly one .device-batch-tip when 2+ skills are drifted across different harnesses', () => {
+      const device: DeviceView = {
+        deviceId: 'abcdef12-3456-4789-8abc-def012345678',
+        label: 'my-box',
+        hostnameDisplay: null,
+        platform: 'darwin',
+        lastSeen: '2026-06-26T00:00:00.000Z',
+        deviceState: 'fresh',
+        neverSynced: false,
+        skills: [
+          skill({ harness: 'zed', skillId: 'acme/one', state: 'drifted' }),
+          skill({ harness: 'cursor', skillId: 'acme/two', state: 'drifted' }),
+        ],
+      }
+      const html = buildDeviceCardHtml(device)
+      const matches = html.match(/class="device-batch-tip"/g) ?? []
+      expect(matches).toHaveLength(1)
+      expect(html).toContain('<code>skillsmith update --all</code>')
+    })
+
+    it('renders no .device-batch-tip when 0 or 1 skill is drifted', () => {
+      const zeroDrifted: DeviceView = {
+        deviceId: 'abcdef12-3456-4789-8abc-def012345678',
+        label: 'my-box',
+        hostnameDisplay: null,
+        platform: 'darwin',
+        lastSeen: '2026-06-26T00:00:00.000Z',
+        deviceState: 'fresh',
+        neverSynced: false,
+        skills: [skill({ state: 'current' }), skill({ skillId: 'acme/two', state: 'local' })],
+      }
+      expect(buildDeviceCardHtml(zeroDrifted)).not.toContain('device-batch-tip')
+
+      const oneDrifted: DeviceView = {
+        ...zeroDrifted,
+        skills: [skill({ state: 'drifted' }), skill({ skillId: 'acme/two', state: 'current' })],
+      }
+      expect(buildDeviceCardHtml(oneDrifted)).not.toContain('device-batch-tip')
+    })
+
+    it('renders no .device-batch-tip for a neverSynced device', () => {
+      const device: DeviceView = {
+        deviceId: 'abcdef12-3456-4789-8abc-def012345678',
+        label: 'my-box',
+        hostnameDisplay: null,
+        platform: 'darwin',
+        lastSeen: '2026-06-26T00:00:00.000Z',
+        deviceState: 'fresh',
+        neverSynced: true,
+        skills: [],
+      }
+      expect(buildDeviceCardHtml(device)).not.toContain('device-batch-tip')
+    })
+
+    it('the .device-batch-tip is a sibling of the harness lists, never nested inside a <ul>/<li>', () => {
+      const device: DeviceView = {
+        deviceId: 'abcdef12-3456-4789-8abc-def012345678',
+        label: 'my-box',
+        hostnameDisplay: null,
+        platform: 'darwin',
+        lastSeen: '2026-06-26T00:00:00.000Z',
+        deviceState: 'fresh',
+        neverSynced: false,
+        skills: [
+          skill({ harness: 'zed', skillId: 'acme/one', state: 'drifted' }),
+          skill({ harness: 'cursor', skillId: 'acme/two', state: 'drifted' }),
+        ],
+      }
+      const html = buildDeviceCardHtml(device)
+      const tipIndex = html.indexOf('class="device-batch-tip"')
+      const firstUlIndex = html.indexOf('<ul')
+      expect(tipIndex).toBeGreaterThan(-1)
+      expect(firstUlIndex).toBeGreaterThan(-1)
+      // The tip must appear before the first harness <ul> — i.e. it's a direct
+      // child of <section>, not nested inside the harness-grouped skill list.
+      expect(tipIndex).toBeLessThan(firstUlIndex)
+
+      const liMatches = html.match(/<li class="skill-item">.*?<\/li>/gs) ?? []
+      expect(liMatches.length).toBeGreaterThan(0)
+      for (const li of liMatches) {
+        expect(li).not.toContain('device-batch-tip')
+      }
+    })
+  })
+})

--- a/packages/website/src/lib/skills-page-render.ts
+++ b/packages/website/src/lib/skills-page-render.ts
@@ -7,7 +7,12 @@
  * `injectSkillsPageStyles()`.
  */
 
-import { SKILL_STATE_META, formatRelativeTime, formatAbsoluteTime } from './inventory-view'
+import {
+  SKILL_STATE_META,
+  formatRelativeTime,
+  formatAbsoluteTime,
+  computeDeviceBatchTip,
+} from './inventory-view'
 import type { SkillState, DeviceView, SkillView } from './inventory-view'
 
 // ─── Badge config (mirrors InventoryStateBadge.astro) ─────────────────────────
@@ -150,6 +155,27 @@ function buildSkillSourceHtml(sk: SkillView): string {
   return ''
 }
 
+/**
+ * Converts a suggestedAction template (backtick-delimited code spans, an
+ * optional `<skill>` placeholder inside those spans) into safe HTML.
+ * Splits on backticks FIRST (the template is our own trusted static string,
+ * so backtick count is always balanced) — only THEN substitutes `<skill>`
+ * inside the already-identified code segments. Substituting before splitting
+ * would let a skill_id containing a literal backtick shift segment parity.
+ */
+function renderSuggestedActionHtml(template: string, skillId: string): string {
+  const parts = template.split('`')
+  return parts
+    .map((part, i) => {
+      if (i % 2 === 1) {
+        const withSkill = part.split('<skill>').join(skillId)
+        return `<code>${escapeHtml(withSkill)}</code>`
+      }
+      return escapeHtml(part)
+    })
+    .join('')
+}
+
 /** Resolved human-readable label for a device, falling back to a truncated ID. */
 export function deviceDisplayName(d: DeviceView): string {
   return d.label ?? d.hostnameDisplay ?? `Device ${d.deviceId.slice(0, 8)}`
@@ -168,9 +194,15 @@ export function buildDeviceCardHtml(device: DeviceView): string {
   const staleTag = isStale ? ` <span class="stale-marker" aria-label="stale">(stale)</span>` : ''
 
   let skillsHtml = ''
+  let batchTipHtml = ''
   if (device.neverSynced) {
     skillsHtml = '<p class="never-synced-msg">No skills synced from this device yet.</p>'
   } else {
+    const batchTip = computeDeviceBatchTip(device.skills)
+    if (batchTip) {
+      batchTipHtml = `<p class="device-batch-tip">${renderSuggestedActionHtml(batchTip, '')}</p>`
+    }
+
     const byHarness = new Map<string, typeof device.skills>()
     for (const sk of device.skills) {
       const key = sk.harness || ''
@@ -184,12 +216,17 @@ export function buildDeviceCardHtml(device: DeviceView): string {
       skillsHtml += `<ul class="skill-list" aria-label="Skills for ${hLabel}">`
       for (const sk of skills) {
         const ver = sk.version ? escapeHtml(sk.version) : '—'
+        const meta = SKILL_STATE_META[sk.state]
+        const actionHtml = meta?.suggestedAction
+          ? `<span class="skill-action">${renderSuggestedActionHtml(meta.suggestedAction, sk.skillId)}</span>`
+          : ''
         skillsHtml +=
           `<li class="skill-item">` +
           `<span class="skill-id">${escapeHtml(sk.skillId)}</span>` +
           `<span class="skill-version">${ver}</span>` +
           buildStateBadgeHtml(sk.state) +
           buildSkillSourceHtml(sk) +
+          actionHtml +
           `</li>`
       }
       skillsHtml += '</ul>'
@@ -204,7 +241,7 @@ export function buildDeviceCardHtml(device: DeviceView): string {
     `</div>` +
     `<p class="device-freshness${isStale ? ' device-freshness--stale' : ''}" title="${absTime}">` +
     `Last synced ${relTime}${staleTag}</p>` +
-    `</div>${skillsHtml}</section>`
+    `</div>${batchTipHtml}${skillsHtml}</section>`
   )
 }
 
@@ -245,6 +282,11 @@ export function injectSkillsPageStyles(): void {
 .skill-source-tag{font-size:.6875rem;color:#52525b}
 .skill-source-link{color:#71717a;text-decoration:none}
 .skill-source-link:hover{color:#a1a1aa;text-decoration:underline}
+/* #a1a1aa (not .skill-source's #71717a, which is ~3.67:1 here — fails WCAG AA) computes to ~6.91:1 on the #18181b skill-item background */
+.skill-action{font-size:.75rem;color:#a1a1aa;flex-basis:100%;margin-top:.25rem;word-break:break-word}
+.skill-action code{font-family:'SF Mono','Fira Code',monospace;word-break:break-all}
+.device-batch-tip{font-size:.8125rem;color:#a1a1aa;margin:0 0 1rem;padding:.5rem .75rem;background:#18181b;border-radius:6px;word-break:break-word}
+.device-batch-tip code{font-family:'SF Mono','Fira Code',monospace;word-break:break-all}
 `
   document.head.appendChild(style)
 }

--- a/scripts/smoke-prod/surfaces.json
+++ b/scripts/smoke-prod/surfaces.json
@@ -25,7 +25,9 @@
       "owner": "website",
       "trigger_globs": [
         "packages/website/src/pages/docs/inventory.astro",
-        "packages/website/src/pages/account/skills.astro"
+        "packages/website/src/pages/account/skills.astro",
+        "packages/website/src/lib/inventory-view.ts",
+        "packages/website/src/lib/skills-page-render.ts"
       ],
       "script": "scripts/smoke-prod/website.sh",
       "checks": ["check_website_docs_inventory_renders"]


### PR DESCRIPTION
## Summary

Wave 3 (final wave) of the inventory-update-action plan (SMI-5595, parent SMI-5382). Waves 1 (`skillsmith update` CLI, PR #1756) and 2 (`.backups` ghost-row fix, PR #1757 + #1759/#1763) are merged, so the "Update available" copy this wave adds is now accurate.

- `inventory-view.ts`: `SKILL_STATE_META` gains a `suggestedAction: string | null` field per state, reusing the blessed copy from `docs/inventory.astro`'s state-badge table (drifted/missing/pinned/unknown/local verbatim, `source-identified` extended with a "what would change this" clause, `pending` corrected to its actual transient-refresh guidance). New `computeDeviceBatchTip()`: a device-wide (not per-harness) 2+-drifted threshold surfacing one generic batch-update tip per device.
- `skills-page-render.ts`: renders the suggested-action text inside the same `<li>` as its skill row (a11y — screen-reader association), converting backtick-delimited template spans to `<code>` and substituting the `<skill>` placeholder with the real (escaped) skill id. Device batch tip renders once, outside any `<ul>`/`<li>`. New `.skill-action`/`.device-batch-tip` text color `#a1a1aa` (~6.91:1 WCAG AA contrast, independently verified twice) — not `.skill-source`'s `#71717a` (~3.67:1, fails AA at this font size).
- `surfaces.json`: both edited lib files added to the `website-docs-inventory` trigger_globs entry for post-deploy smoke coverage.
- Test coverage split into sibling `*.suggested-action.test.ts` modules per lib file to keep everything under the 500-line standard.

## Process

Implemented via a queen/worktree model-tiered fleet: 2 parallel Sonnet subagents (one per lib file + tests) + 1 Haiku subagent (surfaces.json), followed by an Opus adversarial-review pass before commit (verdict: ship as-is; two optional test-hardening gaps closed here — a backtick-in-skill-id parity regression test and a batch-tip-outside-`<ul>` structural assertion). A second, independent `/governance` pass after commit re-derived the WCAG contrast math and cross-checked all 8 `suggestedAction` strings against the live docs table from scratch — 0 findings.

Two out-of-scope findings surfaced during review were filed rather than fixed here: SMI-5599 (pre-existing `openapi.yaml` rate-limit drift — since landed via PR #1761) and SMI-5610 (pre-existing `buildSkillSourceHtml` href scheme-validation gap, low-risk, filed this session).

## Test plan
- [x] `docker exec` typecheck/lint/prettier clean
- [x] 71/71 tests across 4 files (`inventory-view.test.ts`, `inventory-view.suggested-action.test.ts`, `skills-page-render.test.ts`, `skills-page-render.suggested-action.test.ts`)
- [x] `audit:standards`: 0 new failures
- [ ] Manual visual check on `/account/skills` dev server (contrast, batch-tip threshold, copy accuracy)

Refs SMI-5595