### PR TITLE
fix(website): surface upstream failures in skills-search SSR route

### DIFF
--- a/packages/website/src/pages/api/skills-search.test.ts
+++ b/packages/website/src/pages/api/skills-search.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression tests for SMI-5608: skills-search API route must distinguish
+ * genuine empty-results from upstream failure. Both failure branches
+ * (`!res.ok` and thrown fetch exceptions) previously returned HTTP 200
+ * with `{skills: []}`, making a real upstream outage indistinguishable
+ * from a legitimate "no results found".
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { GET } from './skills-search'
+
+import type { APIContext } from 'astro'
+
+function makeContext(query: string): APIContext {
+  return { url: new URL(`https://site/api/skills-search${query}`) } as APIContext
+}
+
+describe('GET /api/skills-search', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns 502 (not 200) when upstream responds non-ok', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response)
+
+    const response = await GET(makeContext('?q=react&limit=12'))
+    expect(response.status).toBe(502)
+    expect(response.status).not.toBe(200)
+
+    const body = await response.json()
+    expect(body).toHaveProperty('error')
+    expect(body.skills).toEqual([])
+  })
+
+  it('returns 502 (not 200) when fetch throws', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('network'))
+
+    const response = await GET(makeContext('?q=react&limit=12'))
+    expect(response.status).toBe(502)
+    expect(response.status).not.toBe(200)
+
+    const body = await response.json()
+    expect(body).toHaveProperty('error')
+    expect(body.skills).toEqual([])
+  })
+
+  it('returns 200 with empty skills for a genuinely short query, without calling fetch', async () => {
+    const response = await GET(makeContext('?q=ab&limit=12'))
+    expect(response.status).toBe(200)
+
+    const body = await response.json()
+    expect(body).toEqual({ skills: [] })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 with results on a successful upstream response', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: 'a/b' }] }),
+    } as Response)
+
+    const response = await GET(makeContext('?q=react&limit=12'))
+    expect(response.status).toBe(200)
+
+    const body = await response.json()
+    expect(body.skills).toHaveLength(1)
+    expect(body.skills[0]).toEqual({ id: 'a/b' })
+  })
+})

--- a/packages/website/src/pages/api/skills-search.ts
+++ b/packages/website/src/pages/api/skills-search.ts
@@ -23,8 +23,8 @@ export const GET: APIRoute = async ({ url }) => {
   try {
     const res = await fetch(apiUrl, { headers: { Accept: 'application/json' } })
     if (!res.ok) {
-      return new Response(JSON.stringify({ skills: [] }), {
-        status: 200,
+      return new Response(JSON.stringify({ error: 'search_upstream_error', skills: [] }), {
+        status: 502,
         headers: { 'Content-Type': 'application/json' },
       })
     }
@@ -33,8 +33,8 @@ export const GET: APIRoute = async ({ url }) => {
       headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
     })
   } catch {
-    return new Response(JSON.stringify({ skills: [] }), {
-      status: 200,
+    return new Response(JSON.stringify({ error: 'search_unavailable', skills: [] }), {
+      status: 502,
       headers: { 'Content-Type': 'application/json' },
     })
   }

--- a/packages/website/tests/api/skills-search.test.ts
+++ b/packages/website/tests/api/skills-search.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-import { GET } from './skills-search'
+import { GET } from '../../src/pages/api/skills-search'
 
 import type { APIContext } from 'astro'
 


### PR DESCRIPTION
## Summary
- `packages/website/src/pages/api/skills-search.ts` previously returned HTTP 200 with `{skills:[]}` on ANY upstream failure — both a non-ok response from the edge function and a thrown exception (network error, JSON parse failure) were silently swallowed into the same "no results" shape, masking real outages as empty search results.
- Now returns a distinguishable error response (502) on both failure branches instead of a silent 200.
- Added regression tests covering: non-200 upstream, thrown exception, genuine empty results (still 200), and successful results (still 200).

## Test plan
- [x] `npx vitest run packages/website/src/pages/api/skills-search.test.ts` — 4 cases, all pass
- [x] Full root+colocated test suite: 477/477 files, 7016/7016 tests pass
- [x] Prettier format check clean
- [x] Verified locally via Docker dev container

Fixes SMI-5608
Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>