### PR TITLE
fix(website): fall back to unknown state meta for out-of-domain sk.state

### DIFF
--- a/packages/website/src/lib/skills-page-render.ts
+++ b/packages/website/src/lib/skills-page-render.ts
@@ -216,7 +216,7 @@ export function buildDeviceCardHtml(device: DeviceView): string {
       skillsHtml += `<ul class="skill-list" aria-label="Skills for ${hLabel}">`
       for (const sk of skills) {
         const ver = sk.version ? escapeHtml(sk.version) : '—'
-        const meta = SKILL_STATE_META[sk.state]
+        const meta = SKILL_STATE_META[sk.state] ?? SKILL_STATE_META.unknown
         const actionHtml = meta?.suggestedAction
           ? `<span class="skill-action">${renderSuggestedActionHtml(meta.suggestedAction, sk.skillId)}</span>`
           : ''


### PR DESCRIPTION
## Summary

Found during the SMI-5595 (Wave 3) post-merge governance retro on PR #1771 — a Low finding, not fixed there per SMI-5060 (governance-specialist agents must never commit to `main`).

`packages/website/src/lib/skills-page-render.ts`'s per-skill `suggestedAction` lookup had no fallback for a runtime `sk.state` outside the declared `SkillState` union, unlike its sibling `buildStateBadgeHtml` (which already does `SKILL_STATE_META[state] ?? SKILL_STATE_META.unknown`). An out-of-domain state would degrade the badge to "Unknown" but silently render no suggested-action text at all — an inconsistent degradation between the two renderers for the same skill row.

Fix mirrors the existing sibling pattern exactly. No new test — same as its untested sibling fallback path, both defensive and unreachable via the current RPC-emittable state set.

## Test plan
- [x] Typecheck/lint clean
- [x] 71/71 tests across the 4 inventory/skills-page-render test files (unchanged — this fix has no new test path, matching the sibling convention)

Refs SMI-5618