### PR TITLE
docs(claude): PR bodies lead with a Business Summary; Linear update every PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,14 @@
-## Summary
+## Business Summary
 
-[Brief description of what this PR does]
+**What shipped:** [one line per user/system-visible change, in outcome terms — "X now works", not "added a field to a Record type"]
+
+**Quality bar:** [what was reviewed, at what depth — one or two sentences]
+
+**Found along the way:** [anything spotted but filed separately rather than bundled in, with issue numbers — omit this line if there's nothing to report]
+
+**Net result:** [fully shipped, or what's still open]
+
+See the `pr-description` skill for the full template and writing guidance. This section is reused verbatim as the Linear project-update body on merge.
 
 ## Ticket
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Git-crypt smudge filters can silently switch branches during stash/pop (includin
 **After EVERY PR merges**:
 
 1. Move the issue to `Done` with the squash-merge SHA in a closing comment.
-2. Post a **project update** on the Linear project when a wave/PR-cluster lands or a blocker changes state — keep stakeholders current without them having to read the issue feed.
+2. Post a **project update** on the Linear project — with every PR, not just when a wave/PR-cluster lands or a blocker changes state. Content: reuse the `pr-description` skill's Business Summary verbatim — keep stakeholders current without them having to read the issue feed.
 
 **Tooling**: MCP Linear tools when connected; fallback `varlock run -- node scripts/linear-api.mjs` (never `npm run linear:done` — broken). Team: **Smith Horn Group**. Always set `project` + a detailed description + labels on issue creation. Full conventions: [linear-hygiene-guide.md](docs/internal/process/linear-hygiene-guide.md).
 
@@ -356,5 +356,6 @@ NEVER say "worth a note for next time" or "consider X in future". If something i
 After context compaction or session continuation, ALWAYS verify claimed-complete work by reading the actual files before proceeding. Never trust the summary alone — compaction can conflate "planned" with "implemented".
 After EVERY commit, run `/governance` to review the changed code. Resolve ALL issues it surfaces before pushing. No exceptions — do not skip, defer, or downgrade findings.
 After EVERY commit, update the relevant Linear issue(s) in the Skillsmith initiative (SMI-xxx) to reflect progress. Add a comment with the commit SHA and a brief summary of what changed. Move the issue status forward if the commit completes the work (e.g., "In Progress" → "Done"). If no Linear issue exists for the work, create one under the appropriate project before pushing.
+Before every `gh pr create`, use the `pr-description` skill — PR bodies lead with a plain-language Business Summary, not technical detail first.
 After EVERY PR is merged, run `/governance` as a retrospective on the full PR diff. Resolve ALL issues it surfaces immediately — create follow-up commits or Linear issues as needed. Do not close the session until the retro is clean.
 After the governance retro, update any `index.md` files in directories where files were added or removed during the PR. Check `docs/internal/`, `.claude/development/`, and `.claude/templates/`. If the root `docs/internal/index.md` folder counts have drifted, update those too.


### PR DESCRIPTION
## Business Summary

**What shipped:** every future PR description now leads with a plain-language Business Summary (What shipped / Quality bar / Found along the way / Net result) before technical detail — the existing generic "Summary" placeholder in the PR template is replaced with this structure. Linear project updates now happen with every PR merge, not just at wave/milestone boundaries, reusing the same text.

**Quality bar:** docs-only change (`CLAUDE.md` + `.github/PULL_REQUEST_TEMPLATE.md`), paired with a new `pr-description` skill in `skillsmith-strategy` (PR #8) that owns the actual template and writing guidance — CLAUDE.md only carries two one-line pointers, matching how `pr-reviewer`/`governance` are referenced elsewhere in this repo.

**Found along the way:** this worktree's shared `node_modules` volume hit three unrelated environmental issues across four push attempts (native binary platform mismatch, a corrupted tree-sitter WASM grammar, a genuinely-missing `marked` package) — all confirmed unrelated to this 2-file diff via an independent investigation. Pushed with `--no-verify` after user approval rather than chase a fourth environment flake; CI on this PR will catch anything real.

**Net result:** done. Dependent on `skillsmith-strategy` PR #8 landing first for the skill itself to be invocable, but this PR's own content (template + CLAUDE.md pointers) is self-contained and mergeable independently.

---

## Technical detail

- `.github/PULL_REQUEST_TEMPLATE.md`: `## Summary` → `## Business Summary` with the 4-field structure; rest of the checklist (Code Quality/Security/Mock Data/Testing) unchanged.
- `CLAUDE.md`: one line added to Important Instruction Reminders (mandate the skill before `gh pr create`), one line tightened in Linear Hygiene (cadence: every PR, not wave/cluster; content: reuse the skill's Business Summary).

[skip-impl-check]