### PR TITLE
fix(ci): smoke-prod budget/counter fixes + vitest git-crypt skip for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,6 +593,19 @@ jobs:
       - name: Smoke - --surface=health canary against prod
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          # SMI-5620: --surface=health auto-includes every always_run canary
+          # (health, api-proxy-header-fidelity, tier1-skill-drift-canary,
+          # website-homepage-canary), not just the named surface. This step
+          # previously only passed SUPABASE_URL, so tier1-skill-drift-canary
+          # always genuinely failed here (SMOKE_SKILLS_API_KEY unset) and
+          # api-proxy-header-fidelity always soft-skipped (SUPABASE_ANON_KEY
+          # unset). That real failure was masked pre-SMI-5620 by a since-fixed
+          # bug in scripts/smoke-prod/lib.sh (re-sourcing wiped the
+          # accumulated fail count, so this job showed green regardless).
+          # Wiring in the same secrets smoke-prod.yml already uses for these
+          # exact checks fixes it at the source instead of re-masking it.
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SMOKE_SKILLS_API_KEY: ${{ secrets.SMOKE_SKILLS_API_KEY }}
         run: |
           # Skip if SUPABASE_URL secret is unavailable (forks). The harness
           # exits 1 with a clear message in that case; in-tree PRs always

--- a/scripts/smoke-prod.sh
+++ b/scripts/smoke-prod.sh
@@ -21,6 +21,12 @@
 #
 # Conventions: ASCII-only output, no `set -x`, 60s total budget enforced
 # via foreground SECONDS check. Per-call HTTP timeouts in lib.sh.
+#
+# SMI-5620: exceeding the budget skips remaining non-canary surfaces/checks
+# and sets `budget_exceeded: true` in the JSON report, but is NOT itself a
+# failure — the exit code stays keyed on SMOKE_FAIL_COUNT alone. always_run
+# canary surfaces (health, website-homepage-canary, tier1-skill-drift-
+# canary) are exempt from the budget skip and always execute their checks.
 
 set -euo pipefail
 
@@ -34,6 +40,7 @@ SINCE_REF=""
 REPORT_PATH=""
 EMIT_JSON=0
 SMOKE_BUDGET_SEC="${SMOKE_BUDGET_SEC:-60}"
+SMOKE_BUDGET_EXCEEDED=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -211,10 +218,18 @@ SECONDS=0
 
 while IFS= read -r surface_id; do
   [ -z "$surface_id" ] && continue
-  if [ "$SECONDS" -ge "$SMOKE_BUDGET_SEC" ]; then
-    smoke_warn "60s budget exceeded — aborting remaining surfaces"
-    SMOKE_FAIL_COUNT=$((SMOKE_FAIL_COUNT + 1))
-    break
+  # always_run surfaces (health, website-homepage-canary, tier1-skill-drift-
+  # canary) are the always-on prod canaries — they must never be silently
+  # skipped by the budget, so we look this up before the budget check below
+  # and reuse it in the inner per-check loop too.
+  always=$(jq -r --arg id "$surface_id" '.surfaces[] | select(.id == $id) | .always_run // false' "$SURFACES_JSON")
+  if [ "$SMOKE_BUDGET_EXCEEDED" = "1" ] || [ "$SECONDS" -ge "$SMOKE_BUDGET_SEC" ]; then
+    SMOKE_BUDGET_EXCEEDED=1
+    if [ "$always" != "true" ]; then
+      smoke_warn "budget exceeded (${SECONDS}s >= ${SMOKE_BUDGET_SEC}s) — skipping surface $surface_id"
+      continue
+    fi
+    smoke_warn "budget exceeded — running always-run surface $surface_id anyway"
   fi
   script_rel=$(jq -r --arg id "$surface_id" '.surfaces[] | select(.id == $id) | .script' "$SURFACES_JSON")
   if [ -z "$script_rel" ] || [ "$script_rel" = "null" ]; then
@@ -238,6 +253,17 @@ while IFS= read -r surface_id; do
   # parent-shell side effects in lib.sh).
   while IFS= read -r fn; do
     if [ -z "$fn" ]; then continue; fi
+    # Mid-surface budget check. A slow earlier check can blow the budget
+    # partway through a multi-check surface; skip the rest — but NEVER for
+    # an always_run surface (its canary check must always execute, per the
+    # outer-loop exemption above).
+    if [ "$SECONDS" -ge "$SMOKE_BUDGET_SEC" ]; then
+      SMOKE_BUDGET_EXCEEDED=1
+      if [ "$always" != "true" ]; then
+        smoke_warn "budget exceeded (${SECONDS}s >= ${SMOKE_BUDGET_SEC}s) — skipping remaining checks for $surface_id"
+        break
+      fi
+    fi
     if ! command -v "$fn" >/dev/null 2>&1 && ! declare -f "$fn" >/dev/null 2>&1; then
       smoke_warn "check function not defined: $fn (surface $surface_id)"
       continue
@@ -255,8 +281,9 @@ REPORT_JSON=$(jq -nc \
   --argjson duration "$DURATION_MS" \
   --argjson pass "$SMOKE_PASS_COUNT" \
   --argjson fail "$SMOKE_FAIL_COUNT" \
+  --argjson budget_exceeded "$SMOKE_BUDGET_EXCEEDED" \
   --argjson results "[${SMOKE_RESULTS_JSON}]" \
-  '{smoke_run_id: $sha, started_at: $started, duration_ms: $duration, pass: $pass, fail: $fail, results: $results}')
+  '{smoke_run_id: $sha, started_at: $started, duration_ms: $duration, pass: $pass, fail: $fail, budget_exceeded: ($budget_exceeded == 1), results: $results}')
 
 if [ "$EMIT_JSON" = "1" ]; then
   printf '%s\n' "$REPORT_JSON"
@@ -266,8 +293,8 @@ if [ -n "$REPORT_PATH" ]; then
 fi
 
 if [ "$SMOKE_FAIL_COUNT" -gt 0 ]; then
-  smoke_log "smoke complete: pass=$SMOKE_PASS_COUNT fail=$SMOKE_FAIL_COUNT duration=${DURATION_MS}ms"
+  smoke_log "smoke complete: pass=$SMOKE_PASS_COUNT fail=$SMOKE_FAIL_COUNT budget_exceeded=$SMOKE_BUDGET_EXCEEDED duration=${DURATION_MS}ms"
   exit 1
 fi
-smoke_log "smoke complete: pass=$SMOKE_PASS_COUNT fail=0 duration=${DURATION_MS}ms"
+smoke_log "smoke complete: pass=$SMOKE_PASS_COUNT fail=0 budget_exceeded=$SMOKE_BUDGET_EXCEEDED duration=${DURATION_MS}ms"
 exit 0

--- a/scripts/smoke-prod/lib.sh
+++ b/scripts/smoke-prod/lib.sh
@@ -12,9 +12,20 @@ SMOKE_HTTP_TIMEOUT="${SMOKE_HTTP_TIMEOUT:-10}"
 
 # Result accumulators populated by report_pass/report_fail. The orchestrator
 # reads these at the end to format the summary table / JSON.
-SMOKE_RESULTS_JSON=""
-SMOKE_FAIL_COUNT=0
-SMOKE_PASS_COUNT=0
+#
+# SMI-5620: this file is sourced once by the orchestrator up front, then
+# AGAIN by every per-surface module it loads in the per-surface loop (each
+# module sources lib.sh at its own top). Without a guard, each re-source
+# reset these to empty/zero, silently discarding every earlier surface's
+# accumulated pass/fail counts so only the last-processed surface's results
+# ever reached the final report/exit code — confirmed live: a run with 5
+# real check failures across 2 surfaces reported pass=1 fail=0 exit=0.
+if [ -z "${SMOKE_LIB_SOURCED:-}" ]; then
+  SMOKE_LIB_SOURCED=1
+  SMOKE_RESULTS_JSON=""
+  SMOKE_FAIL_COUNT=0
+  SMOKE_PASS_COUNT=0
+fi
 
 # ---- logging -------------------------------------------------------------
 

--- a/scripts/smoke-prod/mcp-server.sh
+++ b/scripts/smoke-prod/mcp-server.sh
@@ -2,13 +2,17 @@
 # SMI-4459 — published MCP server boot smoke.
 # SMI-4590 Wave 4 PR 5/6 — extended with audit-tool registration checks.
 #
-# The boot/version check is intentionally lightweight per plan Q8.
-# The three audit-tool checks install the published tarball into a temp
-# prefix once, then grep the compiled tool-dispatch artifact for the
-# registered tool names. This catches packaging regressions where a
-# tool source file lands in src/ but is excluded from `files` in
-# package.json (the exact failure mode that the post-deploy harness is
-# meant to surface). A deeper JSON-RPC round-trip is SMI-4460 territory.
+# SMI-5620 — the version check now shares the same cached install as the
+# three audit-tool checks instead of its own `npx -y -p ...@latest` fetch
+# (npx re-resolves the registry on every call, so a per-check npx was
+# paying the install cost 4x on top of the flakiness of an npx-managed
+# temp cache). All four checks now install the published tarball into a
+# temp prefix once, then either invoke the installed bin directly or grep
+# the compiled tool-dispatch artifact for the registered tool names. The
+# grep-based checks catch packaging regressions where a tool source file
+# lands in src/ but is excluded from `files` in package.json (the exact
+# failure mode that the post-deploy harness is meant to surface). A deeper
+# JSON-RPC round-trip is SMI-4460 territory.
 
 # shellcheck shell=bash
 # shellcheck source=scripts/smoke-prod/lib.sh
@@ -35,17 +39,29 @@ _smoke_mcp_cleanup() {
 # Append (don't overwrite) so other smoke modules' EXIT traps still fire.
 trap '_smoke_mcp_cleanup' EXIT
 
-# Lazily install the published mcp-server tarball into a shared temp prefix
-# and echo the directory containing its compiled JS. Subsequent calls reuse
-# the cached install. Echoes the install root on stdout, returns 1 on
+# Lazily install the published mcp-server tarball into a shared temp prefix.
+# Subsequent calls reuse the cached install. Sets the global
+# $SMOKE_MCP_INSTALL_DIR to the install root; does NOT echo it. Returns 1 on
 # install failure (after recording a per-check failure via report_fail).
+#
+# SMI-5620: callers MUST invoke this directly (`_smoke_mcp_install_once ...
+# || return 1` then read `$SMOKE_MCP_INSTALL_DIR`) and must NEVER wrap the
+# call in a command substitution (`install=$(_smoke_mcp_install_once ...)`).
+# Command substitution forks a subshell, which silently discards BOTH the
+# `SMOKE_MCP_INSTALL_DIR="$prefix"` assignment below (so the cache never
+# actually got reused — every check paid a full npm install) AND, more
+# seriously, the `report_fail` call on the install-failure path below (so a
+# real install failure never reached SMOKE_FAIL_COUNT / the JSON report —
+# confirmed live: a run with `timeout: command not found` failing every
+# install still reported fail=0 for this surface). No echo/printf of the
+# install path on stdout, deliberately — this function's stdout must stay
+# clean since `smoke-prod.sh --json` writes the report to stdout.
 #
 # Args: $1=surface-id $2=check-name (used for failure attribution).
 _smoke_mcp_install_once() {
   local surface="$1"
   local check="$2"
   if [ -n "$SMOKE_MCP_INSTALL_DIR" ] && [ -d "$SMOKE_MCP_INSTALL_DIR/node_modules" ]; then
-    printf '%s' "$SMOKE_MCP_INSTALL_DIR"
     return 0
   fi
   local prefix
@@ -67,32 +83,32 @@ _smoke_mcp_install_once() {
   fi
   rm -f "$install_log"
   SMOKE_MCP_INSTALL_DIR="$prefix"
-  printf '%s' "$prefix"
   return 0
 }
 
 check_mcp_server_version_exits_zero() {
-  local t0 t1 ms tmp out rc
+  local t0 t1 ms install bin out rc
   t0=$(now_ms)
-  tmp=$(mktemp -d)
+  _smoke_mcp_install_once "mcp-server-published" "check_mcp_server_version_exits_zero" || return 1
+  install="$SMOKE_MCP_INSTALL_DIR"
+  bin="$install/node_modules/.bin/skillsmith-mcp"
   set +e
-  out=$(cd "$tmp" && timeout "$SMOKE_MCP_TIMEOUT" npx -y -p "${SMOKE_MCP_PKG}@latest" skillsmith-mcp --version 2>&1)
+  out=$(timeout "$SMOKE_MCP_TIMEOUT" "$bin" --version 2>&1)
   rc=$?
   set -e
-  rm -rf "$tmp"
   t1=$(now_ms)
   ms=$((t1 - t0))
 
   if [ "$rc" -ne 0 ]; then
     local snippet="${out:0:200}"
-    report_fail "mcp-server-published" "check_mcp_server_version_exits_zero" "npx -p ${SMOKE_MCP_PKG}@latest skillsmith-mcp --version" "exit 0" "exit $rc: $snippet" "$ms"
+    report_fail "mcp-server-published" "check_mcp_server_version_exits_zero" "skillsmith-mcp --version (cached install)" "exit 0" "exit $rc: $snippet" "$ms"
     return 1
   fi
   if ! printf '%s' "$out" | grep -qE '[0-9]+\.[0-9]+\.[0-9]+'; then
-    report_fail "mcp-server-published" "check_mcp_server_version_exits_zero" "npx -p ${SMOKE_MCP_PKG}@latest skillsmith-mcp --version" "semver" "${out:0:80}" "$ms"
+    report_fail "mcp-server-published" "check_mcp_server_version_exits_zero" "skillsmith-mcp --version (cached install)" "semver" "${out:0:80}" "$ms"
     return 1
   fi
-  report_pass "mcp-server-published" "check_mcp_server_version_exits_zero" "npx -p ${SMOKE_MCP_PKG}@latest skillsmith-mcp --version" "$ms"
+  report_pass "mcp-server-published" "check_mcp_server_version_exits_zero" "skillsmith-mcp --version (cached install)" "$ms"
   return 0
 }
 
@@ -102,7 +118,8 @@ check_mcp_server_version_exits_zero() {
 check_skill_inventory_audit_tool_listed() {
   local t0 t1 ms install dispatch
   t0=$(now_ms)
-  install=$(_smoke_mcp_install_once "mcp-server-published" "check_skill_inventory_audit_tool_listed") || return 1
+  _smoke_mcp_install_once "mcp-server-published" "check_skill_inventory_audit_tool_listed" || return 1
+  install="$SMOKE_MCP_INSTALL_DIR"
   dispatch="$install/node_modules/${SMOKE_MCP_PKG}/dist/src/audit-tool-dispatch.js"
   t1=$(now_ms)
   ms=$((t1 - t0))
@@ -122,7 +139,8 @@ check_skill_inventory_audit_tool_listed() {
 check_apply_namespace_rename_tool_listed() {
   local t0 t1 ms install dispatch
   t0=$(now_ms)
-  install=$(_smoke_mcp_install_once "mcp-server-published" "check_apply_namespace_rename_tool_listed") || return 1
+  _smoke_mcp_install_once "mcp-server-published" "check_apply_namespace_rename_tool_listed" || return 1
+  install="$SMOKE_MCP_INSTALL_DIR"
   dispatch="$install/node_modules/${SMOKE_MCP_PKG}/dist/src/audit-tool-dispatch.js"
   t1=$(now_ms)
   ms=$((t1 - t0))
@@ -146,7 +164,8 @@ check_apply_namespace_rename_tool_listed() {
 check_apply_recommended_edit_conditional() {
   local t0 t1 ms install dispatch
   t0=$(now_ms)
-  install=$(_smoke_mcp_install_once "mcp-server-published" "check_apply_recommended_edit_conditional") || return 1
+  _smoke_mcp_install_once "mcp-server-published" "check_apply_recommended_edit_conditional" || return 1
+  install="$SMOKE_MCP_INSTALL_DIR"
   dispatch="$install/node_modules/${SMOKE_MCP_PKG}/dist/src/audit-tool-dispatch.js"
   t1=$(now_ms)
   ms=$((t1 - t0))

--- a/scripts/tests/smoke-prod-lib.test.ts
+++ b/scripts/tests/smoke-prod-lib.test.ts
@@ -116,4 +116,19 @@ describe('smoke-prod.sh — inner budget break respects always_run (L-3)', () =>
     expect(innerLoop).toMatch(/SECONDS.*SMOKE_BUDGET_SEC/)
     expect(innerLoop).toMatch(/\$always/)
   })
+
+  it('reports budget_exceeded in the JSON report and keys exit purely on SMOKE_FAIL_COUNT', () => {
+    const src = readFileSync(SMOKE_PROD_SH, 'utf-8')
+    // The JSON report object must carry the observability field...
+    expect(src).toMatch(/budget_exceeded:\s*\(\s*\$budget_exceeded\s*==\s*1\s*\)/)
+    // ...and the exit-code decision must reference SMOKE_FAIL_COUNT alone,
+    // never SMOKE_BUDGET_EXCEEDED — a budget-exceeded run with zero real
+    // failures must exit 0 (this is the entire point of SMI-5620).
+    const exitBlockMatch = src.match(/if \[ "\$SMOKE_FAIL_COUNT" -gt 0 \];[\s\S]*?\nexit 0\n?$/)
+    expect(
+      exitBlockMatch,
+      'could not locate the final exit-code block in smoke-prod.sh'
+    ).toBeTruthy()
+    expect(exitBlockMatch![0]).not.toMatch(/if.*SMOKE_BUDGET_EXCEEDED.*exit 1/)
+  })
 })

--- a/scripts/tests/smoke-prod-lib.test.ts
+++ b/scripts/tests/smoke-prod-lib.test.ts
@@ -1,0 +1,119 @@
+/**
+ * SMI-5620: regression coverage for three bugs found and fixed in the
+ * smoke-prod harness. No network calls — deterministic and fast.
+ *
+ * L-1 LIB ACCUMULATOR SURVIVES RE-SOURCE: scripts/smoke-prod/lib.sh is
+ *     sourced once by scripts/smoke-prod.sh, then AGAIN by every per-surface
+ *     module it loads (each module sources lib.sh at its own top). Before
+ *     the SMOKE_LIB_SOURCED guard, every re-source unconditionally reset
+ *     SMOKE_RESULTS_JSON/SMOKE_FAIL_COUNT/SMOKE_PASS_COUNT, so a multi-
+ *     surface run only ever reported the last-processed surface's results —
+ *     confirmed live against prod: a run with 5 real check failures across
+ *     2 surfaces reported pass=1 fail=0. This test reproduces that exact
+ *     shape (report → re-source → report) and asserts accumulation holds.
+ *
+ * L-2 NO COMMAND-SUBSTITUTION AROUND _smoke_mcp_install_once: a caller
+ *     written as `install=$(_smoke_mcp_install_once ...)` forks a subshell,
+ *     which silently discards the function's `report_fail` call on an
+ *     install failure (report_fail mutates SMOKE_FAIL_COUNT, a shell
+ *     variable — subshell mutations don't propagate to the caller). This
+ *     was confirmed live: a forced install failure vanished from the JSON
+ *     report entirely, even though it printed to stderr (I/O passes through
+ *     subshells; variable mutations don't). Static regression guard: the
+ *     dangerous call shape must never reappear in mcp-server.sh.
+ *
+ * L-3 ALWAYS-RUN SURFACES EXEMPT FROM THE INNER BUDGET BREAK: adversarial
+ *     plan-review (SMI-5620) found the inner per-check budget break, as
+ *     first researched, did not respect the always_run exemption the outer
+ *     loop adds — so a canary surface's single check (health,
+ *     website-homepage-canary, tier1-skill-drift-canary) could be silently
+ *     skipped when the budget was already blown, with the run still exiting
+ *     0. Static regression guard: the inner break must stay conditioned on
+ *     the surface's always_run flag.
+ */
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SMOKE_PROD_DIR = resolve(__dirname, '..', 'smoke-prod')
+const LIB_SH = resolve(SMOKE_PROD_DIR, 'lib.sh')
+const MCP_SERVER_SH = resolve(SMOKE_PROD_DIR, 'mcp-server.sh')
+const SMOKE_PROD_SH = resolve(__dirname, '..', 'smoke-prod.sh')
+
+describe('smoke-prod/lib.sh — SMOKE_LIB_SOURCED guard (L-1)', () => {
+  it('preserves SMOKE_FAIL_COUNT/SMOKE_PASS_COUNT/SMOKE_RESULTS_JSON across a re-source', () => {
+    const script = `
+      set -euo pipefail
+      . "${LIB_SH}"
+      report_fail "surfaceA" "checkA" "url" "expected" "actual" "10"
+      . "${LIB_SH}"
+      report_pass "surfaceB" "checkB" "url" "5"
+      printf 'fail=%s pass=%s results=%s\\n' "$SMOKE_FAIL_COUNT" "$SMOKE_PASS_COUNT" "$SMOKE_RESULTS_JSON"
+    `
+    const out = execFileSync('bash', ['-c', script], { encoding: 'utf-8' })
+    expect(out).toContain('fail=1 pass=1')
+    expect(out).toContain('"surface":"surfaceA"')
+    expect(out).toContain('"surface":"surfaceB"')
+  })
+
+  it('still resets accumulators on the FIRST source of a fresh process', () => {
+    const script = `
+      set -euo pipefail
+      . "${LIB_SH}"
+      printf 'fail=%s pass=%s results=[%s]\\n' "$SMOKE_FAIL_COUNT" "$SMOKE_PASS_COUNT" "$SMOKE_RESULTS_JSON"
+    `
+    const out = execFileSync('bash', ['-c', script], { encoding: 'utf-8' })
+    expect(out.trim()).toBe('fail=0 pass=0 results=[]')
+  })
+})
+
+// Strips full-line `#` comments so regression regexes only see live code —
+// the file's own header comment deliberately quotes the dangerous pattern
+// as a documented "don't do this" example, which would otherwise false-
+// match a naive full-source regex.
+function codeOnly(src: string): string {
+  return src
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('#'))
+    .join('\n')
+}
+
+describe('smoke-prod/mcp-server.sh — no command-substitution around _smoke_mcp_install_once (L-2)', () => {
+  it('never invokes the helper via `=$(_smoke_mcp_install_once ...)`', () => {
+    const src = codeOnly(readFileSync(MCP_SERVER_SH, 'utf-8'))
+    expect(src).not.toMatch(/=\s*\$\(\s*_smoke_mcp_install_once/)
+  })
+
+  it('every call site reads the shared install path from $SMOKE_MCP_INSTALL_DIR', () => {
+    const src = readFileSync(MCP_SERVER_SH, 'utf-8')
+    const callSites =
+      src.match(/_smoke_mcp_install_once\s+"[^"]+"\s+"[^"]+"\s*\|\|\s*return 1/g) ?? []
+    // Four checks share the helper (version + three audit-tool dispatch greps).
+    expect(callSites.length).toBe(4)
+    for (const call of callSites) {
+      const idx = src.indexOf(call)
+      const nextLine = src.slice(idx + call.length, idx + call.length + 200)
+      expect(nextLine).toMatch(/install="\$SMOKE_MCP_INSTALL_DIR"/)
+    }
+  })
+})
+
+describe('smoke-prod.sh — inner budget break respects always_run (L-3)', () => {
+  it('gates the per-check budget break on the surface not being always_run', () => {
+    const src = readFileSync(SMOKE_PROD_SH, 'utf-8')
+    // The inner per-check loop's budget break must be conditioned on
+    // `$always` (or equivalent) so an always_run surface's single check can
+    // never be short-circuited by a blown budget.
+    const innerLoopMatch = src.match(/while IFS= read -r fn;[\s\S]*?done < <\(jq[^\n]*\)/)
+    expect(
+      innerLoopMatch,
+      'could not locate the inner per-check loop in smoke-prod.sh'
+    ).toBeTruthy()
+    const innerLoop = innerLoopMatch![0]
+    expect(innerLoop).toMatch(/SECONDS.*SMOKE_BUDGET_SEC/)
+    expect(innerLoop).toMatch(/\$always/)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,32 @@
+import { existsSync, readFileSync } from 'node:fs'
 import { defineConfig } from 'vitest/config'
 import { sharedTestConfig, coverageDefaults, coverageThresholds } from './vitest.preset'
+
+// SMI-5617: Detect git-crypt lock state at config load, mirroring the
+// gitCryptLocked() sentinel check in vitest.config.root-tests.ts (SMI-4221)
+// and the independent reimplementation in scripts/audit-standards.mjs Check
+// 47 predicate 5 ("Sentinel pattern mirrors vitest.config.root-tests.ts:
+// gitCryptLocked"). dependabot/fork PRs never receive secrets.GIT_CRYPT_KEY
+// (SMI-2159), so the `Test (root)` ci.yml job's "Unlock git-crypt" step is
+// skipped and supabase/functions/** remains \x00GITCRYPT ciphertext at test
+// time. THIS is the config that job (and publish.yml's identical
+// `npx vitest run scripts/tests supabase/functions` invocation) loads
+// implicitly with no --config flag — vitest.config.root-tests.ts's existing
+// guard does not protect either of them. Skip encrypted test paths when
+// locked; pre-push and the ci.yml PR matrix's own git-crypt unlock steps run
+// first in trusted contexts, so those paths still run there.
+function gitCryptLocked(): boolean {
+  const sentinel = 'supabase/functions/_shared/cors.ts'
+  if (!existsSync(sentinel)) return false
+  try {
+    const head = readFileSync(sentinel).subarray(0, 9).toString('binary')
+    return head.startsWith('\x00GITCRYPT')
+  } catch {
+    return false
+  }
+}
+
+const encryptedPathsExcluded = gitCryptLocked() ? ['supabase/functions/**'] : []
 
 export default defineConfig({
   test: {
@@ -44,6 +71,7 @@ export default defineConfig({
       // SMI-4958: the `supabase/functions/indexer/**` exclude was removed —
       // the indexer edge-function tests are vitest-native and now run in the
       // `Test (root)` CI job (git-crypt unlocked, Docker). See ci-reference.md.
+      ...encryptedPathsExcluded,
     ],
     coverage: {
       ...coverageDefaults,


### PR DESCRIPTION
## Business Summary
Two CI-health fixes from the SMI-5611 remediation pass: (1) the post-deploy smoke harness was filing 16 duplicate false-positive GitHub issues because a "ran out of time" abort was indistinguishable from a real check failure — now fixed, and two additional related bugs (a silent results-reset and a silently-swallowed failure report) were found and fixed along the way. (2) Dependabot/fork PRs can never pass the required "Test (root)" check because encrypted test files crash the test runner when secrets aren't available — now skips gracefully instead.

## Summary
- **SMI-5620**: `scripts/smoke-prod.sh`'s 60s budget-exceeded check incremented the same counter real check failures use, conflating "ran out of time" with "something broke." Decoupled budget from the fail count; moved the budget check into the per-check loop; always-run canary surfaces are now provably exempt from ever being skipped by budget.
- Two additional bugs found and fixed during live post-implementation validation (not caught by the original research): `scripts/smoke-prod/lib.sh` had no include-guard (re-sourcing wiped accumulated results across surfaces — confirmed live: 5 real failures reported as `pass=1 fail=0`), and `scripts/smoke-prod/mcp-server.sh` invoked its install helper via command substitution, silently discarding `report_fail` on a subshell-scoped install failure.
- **SMI-5617**: `vitest.config.ts` now skips `supabase/functions/**` when git-crypt-locked (dependabot/fork PRs), porting the existing `gitCryptLocked()` pattern already proven in `vitest.config.root-tests.ts` and `audit-standards.mjs` Check 47, rather than adding a fourth divergent implementation.
- `scripts/tests/smoke-prod-lib.test.ts` (new) adds permanent, network-free regression coverage for all three smoke-prod fixes plus the SMI-5617 JSON-report invariants.

## Plan + Review
Full ADR-109 SPARC plan, adversarial plan-review record, and post-implementation discovery trail: smith-horn/skillsmith-docs#354 (merge first, then bump the docs/internal pointer here).

## Test plan
- [x] Full vitest suite: 142 files, 2079 tests passing (4 pre-existing skips, unrelated)
- [x] `eslint` clean, `npx prettier --check` clean, `shellcheck -x` clean on all 3 changed shell files
- [x] `npm run audit:standards`: 0 failures (8 pre-existing warnings, unrelated — one spun off as SMI-5622)
- [x] Live re-runs of `scripts/smoke-prod.sh --surface=mcp-server-published --json` against prod, before/after each fix, confirming the false-positive is gone and real failures are correctly reported
- [x] Real end-to-end esbuild reproduction proving the SMI-5617 fix (crashes without it, cleanly excludes with it, doesn't over-exclude when unlocked)
- [x] Governance code review: PASS, one Medium finding fixed immediately (docs/internal/code_review/2026-07-09-smi-5620-5617-smoke-prod-vitest-fix-review.md)

Refs SMI-5620, SMI-5617, SMI-5611

🤖 Generated with [Claude Code](https://claude.com/claude-code)