### PR TITLE
chore(release): bump core 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32743,11 +32743,11 @@
         "sklx": "dist/cli.js"
       },
       "devDependencies": {
-        "@skillsmith/core": "^0.10.0",
+        "@skillsmith/core": "^0.11.0",
         "@skillsmith/mcp-server": "^0.7.0",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
-        "vitest": "4.1.6"
+        "vitest": "4.1.10"
       },
       "engines": {
         "node": ">=22.22.0"
@@ -33091,7 +33091,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -33177,7 +33177,7 @@
       "devDependencies": {
         "@types/better-sqlite3": "7.6.13",
         "tsx": "4.21.0",
-        "vitest": "4.1.6"
+        "vitest": "4.1.10"
       },
       "engines": {
         "node": ">=22.22.0"
@@ -33508,7 +33508,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1083.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-        "@skillsmith/core": "^0.10.0",
+        "@skillsmith/core": "^0.11.0",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
@@ -33569,7 +33569,7 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.10.0",
+        "@skillsmith/core": "^0.11.0",
         "ulid": "3.0.1",
         "zod": "3.25.76"
       },
@@ -33578,7 +33578,7 @@
       },
       "devDependencies": {
         "tsx": "4.21.0",
-        "vitest": "4.1.6"
+        "vitest": "4.1.10"
       },
       "engines": {
         "node": ">=22.22.0"
@@ -34078,10 +34078,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/check": "0.9.9",
-        "@astrojs/rss": "4.0.18",
-        "@astrojs/sitemap": "3.7.2",
+        "@astrojs/rss": "4.0.19",
+        "@astrojs/sitemap": "3.7.3",
         "@astrojs/vercel": "10.0.7",
-        "@supabase/supabase-js": "2.108.1",
+        "@supabase/supabase-js": "2.110.1",
         "@tailwindcss/vite": "4.1.18",
         "astro": "6.4.7",
         "sharp": "0.34.5",
@@ -34105,8 +34105,8 @@
         "strip-ansi": "6.0.1",
         "strip-literal": "3.1.0",
         "typescript": "5.9.3",
-        "typescript-eslint": "8.59.1",
-        "vitest": "4.1.6",
+        "typescript-eslint": "8.63.0",
+        "vitest": "4.1.10",
         "web-vitals": "5.1.0"
       },
       "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@skillsmith/core": "^0.10.0",
+    "@skillsmith/core": "^0.11.0",
     "@skillsmith/mcp-server": "^0.7.0",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.11.0
+
+- **Feature**: production-grade error logging and diagnostics (SMI-5615) (#1774)
+
 ## v0.10.0
 
 - **Feature**: per-user inventory purge, hard-delete (SMI-5510, R0 Wave 1a) (#1684)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.10.0'
+export const VERSION = '0.11.0'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1083.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-    "@skillsmith/core": "^0.10.0",
+    "@skillsmith/core": "^0.11.0",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.10.0",
+    "@skillsmith/core": "^0.11.0",
     "ulid": "3.0.1",
     "zod": "3.25.76"
   },


### PR DESCRIPTION
## Summary
- Bumps `@skillsmith/core` 0.10.0 -> 0.11.0 (minor: additive `DEFAULT_RISK_THRESHOLD`/`compareScanReports` exports already on main, plus the 6 other commits landed since the 0.10.0 cut).
- Auto-bumps the `@skillsmith/core` dependency floor to `^0.11.0` in `mcp-server`, `cli`, and `enterprise` (publishing-guide.md dependency-floor rule).
- Out-of-cycle release (normal cadence is weekly/15-entry per ADR-114) to unblock SMI-5614: the Docker MCP registry `server.yaml` `source.commit` can't be pinned until a published core version exports `DEFAULT_RISK_THRESHOLD`, which current mcp-server source requires at startup.

## Test plan
- [x] `prepare-release.ts --core=minor` dry-run + real run, npm collision guard passed
- [x] Targeted build (`core`, `mcp-server`, `cli`) succeeds; verified `DEFAULT_RISK_THRESHOLD` present in built `dist/src/index.js`
- [x] Full pre-push suite passed (6,867 tests across core/cli/mcp-server/enterprise/root)
- [x] Main HEAD (734cb111) CI + E2E Tests confirmed green before branching
- [ ] Post-merge: trigger `publish.yml -f dry_run=false`, verify `npm view @skillsmith/core version` -> 0.11.0

Refs SMI-5614
Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>