### PR TITLE
docs: Fix stale Skill Indexer cadence description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ npx supabase functions deploy team-compliance-check --no-verify-jwt
 
 ## Monitoring & Alerts
 
-High-cadence: Skill Indexer (4× daily 00/06/12/18 UTC, `indexer`), Metadata Refresh (every 4h :30, `skills-refresh-metadata`), Quota Monitor (hourly, Supabase pg_cron — SMI-4798; max quota-warning delay is 60 min), Edge Function Deploy (on merge to main, GHA). Liveness-alert: weekly retrieval-eval cron also runs a telemetry-feed stale-detection backstop that opens a deduped GitHub issue (`telemetry-liveness` label) when the local `retrieval_events` feed hasn't produced a row in >N days (shadow-default). Full table: [deployment-guide.md § Scheduled Jobs](.claude/development/deployment-guide.md#scheduled-jobs). Alerts to `support@smithhorn.ca` via Resend on failures. All jobs log to `audit_logs` table.
+High-cadence: Skill Indexer (maintenance 00:00 UTC + recheck 03:00 UTC + discovery in 3 hourly phase-slots per 6h cycle at 06/07/08, 12/13/14, 18/19/20 UTC per SMI-4870, `indexer`), Metadata Refresh (every 4h :30, `skills-refresh-metadata`), Quota Monitor (hourly, Supabase pg_cron — SMI-4798; max quota-warning delay is 60 min), Edge Function Deploy (on merge to main, GHA). Liveness-alert: weekly retrieval-eval cron also runs a telemetry-feed stale-detection backstop that opens a deduped GitHub issue (`telemetry-liveness` label) when the local `retrieval_events` feed hasn't produced a row in >N days (shadow-default). Full table: [deployment-guide.md § Scheduled Jobs](.claude/development/deployment-guide.md#scheduled-jobs). Alerts to `support@smithhorn.ca` via Resend on failures. All jobs log to `audit_logs` table.
 
 ---
 


### PR DESCRIPTION
## Business Summary

**What shipped:** Corrected the Skill Indexer's documented run cadence in CLAUDE.md — it said
"4× daily 00/06/12/18 UTC", but the actual schedule (in place since SMI-4870) runs 11×/day:
maintenance at 00:00 UTC, a recheck pass at 03:00 UTC, and discovery split into 3 hourly
phase-slots per 6h cycle (06/07/08, 12/13/14, 18/19/20 UTC) so each phase gets a fresh GitHub
rate-limit bucket.

**Quality bar:** Docs-only, no code path touched. Verified the new line against the live cron
entries in `.github/workflows/indexer.yml`.

**Net result:** Done, no follow-up.

---

## Technical detail

`CLAUDE.md:243` — one-line change in the Monitoring & Alerts section.

Surfaced while triaging a transient `Skill Indexer` failure (GitHub Actions run 29085888878 —
`lock_rpc_error` / `fetch failed`, self-healed on the next scheduled run 24 minutes later): the
failure's actual timestamp (10:17 UTC) didn't line up with the documented 00/06/12/18 slots,
which is what surfaced the doc drift.

Refs SMI-5634

[skip-impl-check]
