### PR TITLE
fix(ci): pin tier1-skill-drift-canary to prod, fix events check

### DIFF
--- a/scripts/smoke-prod/events.sh
+++ b/scripts/smoke-prod/events.sh
@@ -2,10 +2,14 @@
 # SMI-5023 Wave 4 Step 1 — skill-invocation telemetry smoke checks.
 #
 # Checks:
-#   check_events_skill_invoke_accepted  — POST a synthetic skill_invoke event;
-#                                         assert HTTP 200 and body contains
-#                                         "accepted" (proves INSERT into
-#                                         search_metrics completed).
+#   check_events_skill_invoke_accepted  — POST a synthetic skill_invoke event as
+#                                         a 1-item batch; assert HTTP 200 and body
+#                                         contains "accepted":1. The batch path
+#                                         increments `accepted` ONLY after the
+#                                         search_metrics INSERT lands, so this
+#                                         proves the write path end-to-end (the
+#                                         single-event path returns {"ok":true}
+#                                         even on insert failure).
 #   check_events_skill_invoke_row_visible — Optional: verify the synthetic row
 #                                           is queryable via PostgREST REST API
 #                                           using SMOKE_SKILLS_* creds against
@@ -13,8 +17,10 @@
 #                                           Skips gracefully when creds absent.
 #
 # Synthetic events are tagged source='smoke-prod' so production dashboards
-# can filter them. The anonymous_id uses smoke-test-<epoch-s> to ensure
-# dedup-safety across concurrent smoke runs.
+# can filter them (that field, not the anonymous_id, carries smoke
+# identifiability). The anonymous_id is a random 32-char hex string
+# (events' isValidAnonymousId requires /^[a-f0-9-]+$/i, length 16-128), which
+# is also dedup-safe across concurrent smoke runs.
 #
 # See docs/internal/implementation/skill-invoke-telemetry.md Wave 4 Step 1.
 
@@ -37,14 +43,16 @@ _require_events_supabase_url() {
 }
 
 # ---- check_events_skill_invoke_accepted ----------------------------------
-# POSTs a synthetic skill_invoke event to prod /functions/v1/events.
-# The events function is anonymous (no-verify-jwt) and returns {"accepted":N}
-# after a successful INSERT into search_metrics. Asserting the response body
-# contains "accepted" proves the write path is live end-to-end.
+# POSTs a synthetic skill_invoke event as a 1-item batch to prod
+# /functions/v1/events. The events function is anonymous (no-verify-jwt); the
+# batch path returns {"ok":true,"accepted":N} and increments `accepted` ONLY
+# after the search_metrics INSERT lands (a single-event POST returns
+# {"ok":true} even when the insert fails). Asserting "accepted":1 therefore
+# proves the write path is live end-to-end.
 #
 # Failure modes:
 #   non-2xx HTTP     — function not reachable or threw an error
-#   body missing "accepted" — INSERT path broken or response schema changed
+#   body missing "accepted":1 — INSERT path broken or response schema changed
 check_events_skill_invoke_accepted() {
   _require_events_supabase_url || {
     report_fail "edge-fn-events" "check_events_skill_invoke_accepted" "" "SUPABASE_URL" "unset"
@@ -52,10 +60,11 @@ check_events_skill_invoke_accepted() {
   }
 
   local url="${SMOKE_SUPABASE_URL}/functions/v1/events"
-  local anon_id="smoke-test-$(date +%s)"
-  local run_id="smoke-$(date +%s)"
-  local payload
-  payload=$(printf '{"event":"skill_invoke","anonymous_id":"%s","metadata":{"skill_name":"smoke","session_id":"%s","duration_ms":1,"source":"smoke-prod","framework":"smoke","platform":"linux","is_subagent":false,"success":true}}' \
+  # SC2155: declare then assign so a subshell failure isn't masked by `local`.
+  local anon_id run_id payload
+  anon_id="$(openssl rand -hex 16)"
+  run_id="smoke-$(date +%s)"
+  payload=$(printf '{"events":[{"event":"skill_invoke","anonymous_id":"%s","metadata":{"skill_name":"smoke","session_id":"%s","duration_ms":1,"source":"smoke-prod","framework":"smoke","platform":"linux","is_subagent":false,"success":true}}]}' \
     "$anon_id" "$run_id")
 
   local t0 t1 ms status body resp
@@ -77,9 +86,9 @@ check_events_skill_invoke_accepted() {
       ;;
   esac
 
-  if ! assert_contains "$body" "accepted" "events-response-accepted-field"; then
+  if ! assert_contains "$body" '"accepted":1' "events-batch-accepted-one"; then
     report_fail "edge-fn-events" "check_events_skill_invoke_accepted" \
-      "$url" 'body contains "accepted"' "${body:0:120}" "$ms"
+      "$url" 'body contains "accepted":1' "${body:0:120}" "$ms"
     return 1
   fi
 

--- a/scripts/smoke-prod/registry-health.sh
+++ b/scripts/smoke-prod/registry-health.sh
@@ -21,17 +21,20 @@ TIER1_SKILLS=(
   "getsentry/code-review"
 )
 
-# SMOKE_SKILLS_URL: same fallback convention as website.sh's skills-endpoint
-# checks — supports a separate skills Supabase project override.
-SMOKE_SKILLS_URL="${SMOKE_SKILLS_SUPABASE_URL:-${SUPABASE_URL:-}}"
+# REGISTRY_HEALTH_URL: the tier1 drift canary must read the REAL PROD registry
+# that end users query — always prod SUPABASE_URL, independent of the SMI-4755
+# staging override (SMOKE_SKILLS_SUPABASE_URL) used by the usage-counter checks.
+# Renamed from SMOKE_SKILLS_URL (SMI-5631) so this prod-pinned global can't
+# collide with website.sh's staging-routed SMOKE_SKILLS_URL in the shared shell.
+REGISTRY_HEALTH_URL="${SUPABASE_URL:-}"
 
 _require_registry_health_creds() {
-  if [ -z "$SMOKE_SKILLS_URL" ]; then
+  if [ -z "$REGISTRY_HEALTH_URL" ]; then
     smoke_warn "SUPABASE_URL not set — failing tier1 drift check"
     return 1
   fi
-  if [ -z "${SMOKE_SKILLS_API_KEY:-}" ]; then
-    smoke_warn "SMOKE_SKILLS_API_KEY not set — failing tier1 drift check"
+  if [ -z "${SUPABASE_ANON_KEY:-}" ]; then
+    smoke_warn "SUPABASE_ANON_KEY not set — failing tier1 drift check"
     return 1
   fi
   return 0
@@ -41,14 +44,19 @@ _require_registry_health_creds() {
 _check_tier1_skill() {
   local skill_id="$1"
   local encoded_id="${skill_id/\//%2F}"
-  local url="${SMOKE_SKILLS_URL}/functions/v1/skills-get?id=${encoded_id}"
+  local url="${REGISTRY_HEALTH_URL}/functions/v1/skills-get?id=${encoded_id}"
   local t0 t1 ms resp status body tier repo_url
 
   t0=$(now_ms)
-  # Authenticated (SMI-5582 S1): an anonymous call goes through the trial
-  # rate limiter (see supabase/functions/_shared/auth-middleware.ts) and can
-  # 429 under normal cadence. Mirrors website.sh's skills-get check.
-  resp=$(with_retry http_body GET "$url" -H "X-API-Key: ${SMOKE_SKILLS_API_KEY}" -H "Accept: application/json") || true
+  # Authenticate to PROD with the anon key (SMI-5631): the `anon_key` auth
+  # method (supabase/functions/_shared/auth-middleware.ts) is `authenticated`,
+  # so it BYPASSES the per-IP trial limiter that 401s shared GitHub-runner
+  # traffic. BOTH headers are required — `apikey:` alone returns 401
+  # (live-verified). Do NOT drop either header.
+  resp=$(with_retry http_body GET "$url" \
+    -H "apikey: ${SUPABASE_ANON_KEY}" \
+    -H "Authorization: Bearer ${SUPABASE_ANON_KEY}" \
+    -H "Accept: application/json") || true
   t1=$(now_ms)
   ms=$((t1 - t0))
 
@@ -89,7 +97,7 @@ _check_tier1_skill() {
 }
 
 check_tier1_skills_available() {
-  _require_registry_health_creds || { report_fail "tier1-skill-drift-canary" "check_tier1_skills_available" "" "SUPABASE_URL+SMOKE_SKILLS_API_KEY" "unset"; return 1; }
+  _require_registry_health_creds || { report_fail "tier1-skill-drift-canary" "check_tier1_skills_available" "" "SUPABASE_URL+SUPABASE_ANON_KEY" "unset"; return 1; }
 
   local failed=0
   for skill_id in "${TIER1_SKILLS[@]}"; do


### PR DESCRIPTION
## Business Summary

**What shipped:** Skillsmith's post-deploy smoke check for the three auto-installed starter skills (getsentry/skill-writer, commit, code-review) was flagging them as broken on every single run for weeks — it was actually reading stale test data instead of the real, live registry. It now reads the real thing, so the alert only fires on genuine problems. Also fixed a companion check that was silently mis-verifying whether skill-usage events actually get recorded (it would have reported success even if the recording had failed).

**Quality bar:** Both fixes independently verified against real production (not just staging) before this PR was opened. `shellcheck` clean, `audit:standards` clean, plan reviewed by a second pass before implementation (VP Product/Engineering/Design perspectives) per this repo's infra-change process.

**Found along the way:** two issues filed separately rather than bundled in here — SMI-5632 (a related but distinct smoke-check bug that needs a design decision, not a mechanical fix) and SMI-5633 (a Docker environment issue discovered while testing this PR, unrelated to the actual code change).

**Net result:** Code is fully shipped and verified. **One manual step is required before merging**: `SUPABASE_ANON_KEY` needs to be added to this repo's GitHub Actions secrets (Settings → Secrets and variables → Actions) — it's a documented requirement that was simply never provisioned. Without it, the fixed check will fail loud (by design — see Technical detail) immediately post-merge.

---

## Technical detail

**Root cause**: `scripts/smoke-prod/registry-health.sh`'s `tier1-skill-drift-canary` check reused a staging-routing env var (`SMOKE_SKILLS_SUPABASE_URL`) intended for a different set of checks, so it queried a staging Supabase project whose skill registry lags production — producing false "drift" 404s every run, even though the skills are healthy in prod (verified live via the Skillsmith MCP server against the prod project).

**Fix**: `registry-health.sh` now always targets prod `SUPABASE_URL`, authenticating with `SUPABASE_ANON_KEY` (the `anon_key` auth method, which bypasses the shared-CI-runner-IP trial rate limiter that a plain anonymous or staging-key call would hit). Renamed the script-global to `REGISTRY_HEALTH_URL` so it no longer collides with the staging-routed global used by unrelated checks in `website.sh`.

**Also fixed** — `scripts/smoke-prod/events.sh`'s `check_events_skill_invoke_accepted`:
- The synthetic event's `anonymous_id` (`smoke-test-<epoch>`) contained non-hex characters, which the `events` edge function's validator always rejects (HTTP 400). Switched to a random 32-char hex string.
- The check asserted on the response containing `"accepted"`, but a single-event POST returns `{"ok":true}` regardless of whether the database write actually succeeded — a false-pass risk. Switched to a 1-event batch POST and assert `"accepted":1`, which the events function only sets after the database insert genuinely lands.

**Not fixed in this PR**: `edge-fn-skills-get :: check_skills_get_usage_counter` fails for a separate, deterministic reason (it probes a nonexistent skill and asserts a usage-counter increment that a 404 response never triggers) — needs a design decision on the right probe strategy, not reproducible without staging credentials. Filed as SMI-5632.

**Merge precondition**: `SUPABASE_ANON_KEY` must exist in GitHub Actions secrets before merge (`gh secret list | grep SUPABASE_ANON_KEY`). It's already documented as required in `.claude/development/smoke-prod-guide.md` but was never added — this also unblocks a separate, already-broken set of usage-counter checks that depend on the same secret. Until it's added, the fixed canary will `report_fail` loudly with an explicit "missing secret" message rather than silently skip — this is intentional (an always-run canary that silently skips provides zero coverage) and is not a regression: smoke-prod is already red on every run today for the same underlying reason.

**Files changed**: `scripts/smoke-prod/registry-health.sh`, `scripts/smoke-prod/events.sh`, plus a `docs/internal` submodule pointer bump for the SPARC + plan-review implementation plan (`docs/internal/implementation/smi-5631-tier1-canary-staging-fix.md`), required by this repo's ADR-109 infra-change process since this touches CI scripts.

**Verification**:
- `varlock run -- ./scripts/smoke-prod.sh --surface=tier1-skill-drift-canary` → PASS, 3/3 skills verified against prod
- `varlock run -- ./scripts/smoke-prod.sh --surface=edge-fn-events` → PASS
- `shellcheck` both changed files → clean
- `npm run audit:standards` → 0 failures

Refs SMI-5631