### PR TITLE
feat(ci): SMI-5629 sync packages/mcp-server to a public mirror repo

### DIFF
--- a/.claude/development/index.md
+++ b/.claude/development/index.md
@@ -18,7 +18,7 @@ Developer guides for local development, testing, and debugging.
 | [stripe-testing.md](stripe-testing.md) | Stripe CLI testing setup and webhooks |
 | [stripe-billing-portal.md](stripe-billing-portal.md) | Stripe billing portal integration |
 | [email-templates.md](email-templates.md) | Supabase Auth email template source (SMI-2758) |
-| [publishing-guide.md](publishing-guide.md) | npm package publishing, CI workflow, pre-publish checklist, break-glass, critical rules |
+| [publishing-guide.md](publishing-guide.md) | npm package publishing, CI workflow, pre-publish checklist, break-glass, critical rules, MCP server mirror repo (SMI-5629) |
 | [vscode-publishing-guide.md](vscode-publishing-guide.md) | VS Code Marketplace publishing, PAT rotation, troubleshooting |
 | [cloudinary-guide.md](cloudinary-guide.md) | Blog image upload workflow, URL transforms, folder conventions |
 | [subagent-tool-permissions-guide.md](subagent-tool-permissions-guide.md) | Subagent tool access by type, foreground/background behavior |

--- a/.claude/development/publishing-guide.md
+++ b/.claude/development/publishing-guide.md
@@ -92,6 +92,25 @@ Dependencies before consumers:
 2. `@skillsmith/mcp-server` and `@skillsmith/cli` (both depend on core)
 3. `@smith-horn/enterprise` (private, GitHub Packages)
 
+## MCP Server Mirror Repo (SMI-5629)
+
+The `smith-horn/skillsmith-mcp-server` mirror repo is a submodule-free public copy of `packages/mcp-server`, kept in sync by a CI job after each npm publish of `@skillsmith/mcp-server`. This unblocks Docker's MCP Registry submission — Docker's build tooling clones the full monorepo and fails on our private submodules (`.claude/skills`, `.claude/plans`, `.claude/hive-mind` → `smith-horn/skillsmith-strategy`; `docs/internal` → `smith-horn/skillsmith-docs`). The mirror avoids that blocker entirely.
+
+**Trigger**: A GitHub Actions workflow (`mirror-mcp-server.yml`) runs automatically after each successful `@skillsmith/mcp-server` npm publish (via `workflow_run` on `publish.yml` completion), plus `workflow_dispatch` for manual syncs and backfills. Idempotent: compares `npm view @skillsmith/mcp-server version` against the mirror's current `package.json` version and exits cleanly if already in sync. Daily staleness check compares `npm view @skillsmith/mcp-server version` against the mirror's last-synced `Source-Version` trailer and opens a GitHub issue on divergence, catching both workflow failures and missed `workflow_run` events.
+
+**Commit format**: Each mirror sync appends one append-only snapshot commit (never force-pushed) with message `sync: @skillsmith/mcp-server@<version>` and three git trailers:
+- `Source-Repo: https://github.com/smith-horn/skillsmith`
+- `Source-Commit: <monorepo SHA of the publish run's head>`
+- `Source-Version: <npm version>`
+
+Any mirror commit maps back to the exact originating monorepo commit via `git log --format='%(trailers:key=Source-Commit)'`.
+
+**Critical invariant**: the mirror repo must **never** gain a `.gitmodules` file. This is the entire reason the mirror works where the monorepo's own Docker Registry submission failed — BuildKit's full clone has no `.gitmodules` to recurse into and no private submodules to fail on. If `.gitmodules` ever appears in the mirror, both synchronization and Docker's build process will break silently.
+
+**Token rotation**: `MIRROR_PUSH_TOKEN` (fine-grained PAT, scoped to the mirror repo only) is owned by the **Skillsmith: CI Health** Linear project, not an individual assignee — SMI-5629 closes shortly after Wave 1 merges, well before the first annual rotation. A scheduled expiry-reminder check (mirroring the retrieval-liveness pattern) opens a deduped GitHub issue before token expiry to flag renewal. Annual cadence — vs. the 90-day quarterly cycle used for `VERCEL_DEPLOY_HOOK_TOKEN` — is justified by materially lower blast radius (scoped to a single public, non-critical mirror repo).
+
+**Fallback if `@skillsmith/mcp-server` or the monorepo is renamed or deprecated**: update the sync script's hardcoded package name and repo URL in `scripts/mirror-mcp-server.sh`, or archive the mirror repo with a final banner update. Otherwise, the sync script and trailers go stale silently, breaking Docker's registry automation. This is an operational procedure, not a code fix — file a Linear issue if namechange is anticipated.
+
 ## New-package onboarding
 
 Adding a brand-new package to the publish pipeline is a multi-step setup, and **the npmjs.com registration MUST come first**. SMI-4540 made all npm publishes OIDC-only (the granular token was revoked 2026-05-19), and **OIDC trusted-publishing cannot bootstrap a package that does not already exist on npm** — the very first publish of a never-seen package dies with an opaque `E404`. SMI-5122 added a `pre-publish-check` fail-fast (`scripts/check-npm-bootstrap.mjs`) that catches this with an actionable message before the expensive Docker build, but the only real fix is to register the package by hand first.

--- a/.claude/development/publishing-guide.md
+++ b/.claude/development/publishing-guide.md
@@ -99,6 +99,7 @@ The `smith-horn/skillsmith-mcp-server` mirror repo is a submodule-free public co
 **Trigger**: A GitHub Actions workflow (`mirror-mcp-server.yml`) runs automatically after each successful `@skillsmith/mcp-server` npm publish (via `workflow_run` on `publish.yml` completion), plus `workflow_dispatch` for manual syncs and backfills. Idempotent: compares `npm view @skillsmith/mcp-server version` against the mirror's current `package.json` version and exits cleanly if already in sync. Daily staleness check compares `npm view @skillsmith/mcp-server version` against the mirror's last-synced `Source-Version` trailer and opens a GitHub issue on divergence, catching both workflow failures and missed `workflow_run` events.
 
 **Commit format**: Each mirror sync appends one append-only snapshot commit (never force-pushed) with message `sync: @skillsmith/mcp-server@<version>` and three git trailers:
+
 - `Source-Repo: https://github.com/smith-horn/skillsmith`
 - `Source-Commit: <monorepo SHA of the publish run's head>`
 - `Source-Version: <npm version>`

--- a/.github/workflows/mirror-mcp-server.yml
+++ b/.github/workflows/mirror-mcp-server.yml
@@ -1,0 +1,240 @@
+# SMI-5629: sync packages/mcp-server to the public, submodule-free mirror repo
+# (smith-horn/skillsmith-mcp-server) after every npm publish of
+# @skillsmith/mcp-server. Docker's MCP registry build (BuildKit's git-source
+# loader) does a full clone of source.project and chokes on this monorepo's
+# private .gitmodules submodules before the build context is even assembled;
+# the mirror repo has no .gitmodules, ever, so the same build succeeds there.
+#
+# Full plan: docs/internal/implementation/mcp-server-mirror-repo.md
+# (decisions 1-5, changes 1-6). ADR-109: infra workflow, SPARC + plan-review
+# gated (see that plan's Review Summary -- 18 findings applied).
+#
+# Two independent jobs, gated by trigger (github.event_name):
+#   - sync (workflow_run on "Publish Packages" completion, or
+#     workflow_dispatch for manual/backfill sync): checks out the monorepo at
+#     the publish run's head_sha (or current ref for workflow_dispatch) and
+#     invokes scripts/mirror-mcp-server.sh, which is itself idempotent
+#     (no-ops if the mirror already has the published version) -- safe to
+#     re-run on retries/backfills.
+#   - staleness-check (daily schedule): compares the published npm version
+#     against the mirror's last-synced Source-Version trailer and opens/
+#     dedupes a GitHub issue on divergence beyond a grace window. This is
+#     deliberately NOT just the default workflow-failure notification -- it
+#     also catches a missed/dropped workflow_run event, which a
+#     failure-notification on THIS workflow would never see (there would be
+#     no run to fail).
+#
+# MIRROR_PUSH_TOKEN: fine-grained PAT scoped to smith-horn/skillsmith-mcp-server
+# only (contents read/write), stored as an Actions secret on this repo (the
+# default GITHUB_TOKEN cannot push to a different repo). Rotation: ANNUAL
+# (vs. VERCEL_DEPLOY_HOOK_TOKEN's 90-day cadence elsewhere in this repo) --
+# justified by materially lower blast radius: scoped to a single public,
+# non-critical mirror repo. Ownership: Skillsmith: CI Health Linear project
+# (not the SMI-5629 assignee individually -- that issue closes to Done
+# shortly after Wave 1 merges). A separate PAT-expiry reminder (same shape as
+# the retrieval-liveness pattern) is owned by that project and depends on the
+# PAT's actual creation/expiry date from Wave 1 Step 1 (which precedes this
+# file in the plan's own step ordering) -- it is intentionally not
+# implemented here.
+#
+# audit:carveout-pure-js -- pure git/npm-tarball work (git archive, npm pack,
+# tar, git clone/push); no native Node module compilation. Qualifies for the
+# SMI-4647 pure-JS host-runner carve-out.
+#
+# NOTE: validate-workflows.yml's paths: trigger does NOT cover this file
+# (scoped only to deploy-edge-functions.yml and its own scripts) -- only
+# audit:standards Check 21 applies here (continue-on-error id/marker rule).
+# This file uses no continue-on-error steps, so Check 21 is a no-op here.
+
+name: Mirror MCP Server
+
+on:
+  workflow_run:
+    workflows: ['Publish Packages']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run -- assemble + gate, do not push (default: false)'
+        required: false
+        default: 'false'
+        type: boolean
+  schedule:
+    # Daily staleness check (see the staleness-check job). Its grace window
+    # (24h) is sized to this cadence -- one missed sync cycle is tolerated
+    # before alerting.
+    - cron: '0 12 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mirror-mcp-server
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: '22'
+  MIRROR_REPO: smith-horn/skillsmith-mcp-server
+
+jobs:
+  sync:
+    name: Sync mirror repo
+    # workflow_dispatch always runs; workflow_run only runs when the
+    # triggering "Publish Packages" run actually succeeded (no point
+    # mirroring a failed/aborted publish). Never runs for schedule -- that's
+    # staleness-check below.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Determine target SHA
+        id: sha
+        env:
+          WF_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          TARGET_SHA="${WF_SHA:-${{ github.sha }}}"
+          echo "sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+          echo "Target SHA: $TARGET_SHA"
+
+      - name: Checkout monorepo at target SHA
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.sha.outputs.sha }}
+          # Never fetch the private strategy/docs submodules here -- the sync
+          # script only needs packages/mcp-server, and submodule fetch would
+          # require STRATEGY_SUBMODULE_PAT for no benefit.
+          submodules: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install gitleaks
+        # Same pinned version/install pattern as ci.yml's secret-scan job.
+        # Required: without gitleaks on PATH, the sync script's leak-audit
+        # gate falls back to a coarse manual grep with no allowlist, which
+        # aborts on the same synthetic test fixtures .gitleaks.toml already
+        # allowlists for the primary (gitleaks) path.
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz | tar -xz
+          sudo mv gitleaks /usr/local/bin/
+
+      - name: Run mirror sync
+        env:
+          MIRROR_PUSH_TOKEN: ${{ secrets.MIRROR_PUSH_TOKEN }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN_INPUT" = "true" ]; then
+            echo "Dry run requested via workflow_dispatch input -- no push."
+            ./scripts/mirror-mcp-server.sh --dry-run
+          else
+            ./scripts/mirror-mcp-server.sh
+          fi
+
+  staleness-check:
+    name: Staleness check
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Compare npm version to mirror's last-synced version
+        id: compare
+        run: |
+          set -euo pipefail
+
+          NPM_VERSION=$(npm view @skillsmith/mcp-server version)
+          echo "npm_version=$NPM_VERSION" >> "$GITHUB_OUTPUT"
+          echo "npm @skillsmith/mcp-server version: $NPM_VERSION"
+
+          rm -rf /tmp/mirror-check
+          set +e
+          git clone --depth 1 "https://github.com/${MIRROR_REPO}.git" /tmp/mirror-check 2>/tmp/mirror-clone.err
+          CLONE_STATUS=$?
+          set -e
+          MIRROR_HEAD="$(git -C /tmp/mirror-check log -1 --format=%H 2>/dev/null || true)"
+
+          if [ "$CLONE_STATUS" -ne 0 ] || [ -z "$MIRROR_HEAD" ]; then
+            # Expected before Wave 1 Step 4's first sync -- the mirror repo
+            # may not exist yet, or may exist with zero commits. Not an
+            # alertable condition.
+            echo "::notice::Mirror repo not yet populated (clone failed or zero commits) -- skipping staleness check."
+            cat /tmp/mirror-clone.err 2>/dev/null || true
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          MIRROR_VERSION="$(git -C /tmp/mirror-check log -1 --format='%(trailers:key=Source-Version,valueonly)' | tr -d '[:space:]')"
+          MIRROR_COMMIT_DATE="$(git -C /tmp/mirror-check log -1 --format=%cI)"
+          echo "mirror_version=$MIRROR_VERSION" >> "$GITHUB_OUTPUT"
+          echo "mirror sync commit: $MIRROR_HEAD ($MIRROR_COMMIT_DATE), Source-Version=$MIRROR_VERSION"
+
+          MIRROR_EPOCH=$(date -d "$MIRROR_COMMIT_DATE" +%s)
+          NOW_EPOCH=$(date -u +%s)
+          AGE_HOURS=$(( (NOW_EPOCH - MIRROR_EPOCH) / 3600 ))
+          echo "age_hours=$AGE_HOURS" >> "$GITHUB_OUTPUT"
+          echo "Mirror last-sync commit age: ${AGE_HOURS}h"
+
+          # Grace window: 24h (one daily cron cycle) -- absorbs normal
+          # workflow_run -> sync latency (typically minutes) without
+          # alerting on a sync that's merely in flight.
+          if [ "$MIRROR_VERSION" != "$NPM_VERSION" ] && [ "$AGE_HOURS" -gt 24 ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open/dedupe staleness issue
+        if: steps.compare.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_VERSION: ${{ steps.compare.outputs.npm_version }}
+          MIRROR_VERSION: ${{ steps.compare.outputs.mirror_version }}
+          AGE_HOURS: ${{ steps.compare.outputs.age_hours }}
+        run: |
+          set -euo pipefail
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          EXISTING=$(gh issue list --repo "${{ github.repository }}" --label "ci-alert" --search "Mirror repo stale" --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "${{ github.repository }}" --body "Still stale. npm version: \`$NPM_VERSION\`, mirror Source-Version: \`$MIRROR_VERSION\`, mirror sync commit age: ${AGE_HOURS}h. Run: $RUN_URL"
+            exit 0
+          fi
+
+          BODY="**Workflow**: Mirror MCP Server (staleness check)
+
+          npm \`@skillsmith/mcp-server\` version: \`$NPM_VERSION\`
+          Mirror's last-synced \`Source-Version\` trailer: \`$MIRROR_VERSION\`
+          Mirror's last sync commit age: ${AGE_HOURS}h (grace window: 24h)
+
+          The mirror repo (smith-horn/skillsmith-mcp-server) has not picked up
+          the latest published version within the grace window. This defeats
+          Docker's automatic-rebuild guarantee for the MCP registry entry --
+          the reason this mirror exists in the first place. See
+          docs/internal/implementation/mcp-server-mirror-repo.md.
+
+          Investigate the sync job in this workflow (mirror-mcp-server.yml,
+          triggered by workflow_run on Publish Packages): it may have failed,
+          or the workflow_run event may have been dropped/missed. A manual
+          workflow_dispatch of this workflow re-runs the sync.
+
+          Run: $RUN_URL
+
+          This issue was auto-created by SMI-5629. Close when resolved."
+
+          gh issue create --repo "${{ github.repository }}" \
+            --title "CI: Mirror repo stale ($(date -u +%Y-%m-%d))" \
+            --label "ci-alert" \
+            --body "$BODY"

--- a/.github/workflows/mirror-mcp-server.yml
+++ b/.github/workflows/mirror-mcp-server.yml
@@ -12,10 +12,13 @@
 # Two independent jobs, gated by trigger (github.event_name):
 #   - sync (workflow_run on "Publish Packages" completion, or
 #     workflow_dispatch for manual/backfill sync): checks out the monorepo at
-#     the publish run's head_sha (or current ref for workflow_dispatch) and
-#     invokes scripts/mirror-mcp-server.sh, which is itself idempotent
-#     (no-ops if the mirror already has the published version) -- safe to
-#     re-run on retries/backfills.
+#     its TRUSTED default-branch ref (never the workflow_run's head_sha --
+#     see the security comment on the checkout step) and invokes
+#     scripts/mirror-mcp-server.sh with SOURCE_COMMIT set to the publish
+#     run's head_sha (or current ref for workflow_dispatch), which the script
+#     uses only as `git archive` data, never as executed code. The script is
+#     itself idempotent (no-ops if the mirror already has the published
+#     version) -- safe to re-run on retries/backfills.
 #   - staleness-check (daily schedule): compares the published npm version
 #     against the mirror's last-synced Source-Version trailer and opens/
 #     dedupes a GitHub issue on divergence beyond a grace window. This is
@@ -99,10 +102,25 @@ jobs:
           echo "sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
           echo "Target SHA: $TARGET_SHA"
 
-      - name: Checkout monorepo at target SHA
+      - name: Checkout monorepo (trusted default-branch ref)
+        # SECURITY (CodeQL: "Checkout of untrusted code in a privileged
+        # context"): this is a workflow_run-triggered job with MIRROR_PUSH_TOKEN
+        # in scope below -- it must NEVER check out and then execute code at
+        # an attacker-influenceable ref (workflow_run's head_sha is keyed on
+        # the *workflow name* "Publish Packages", not path/file identity, so
+        # a malicious branch could in principle get a same-named workflow to
+        # complete and trigger this job with an attacker-chosen head_sha).
+        # Deliberately omit `ref:` so this always checks out the trusted
+        # default branch -- scripts/mirror-mcp-server.sh that actually RUNS is
+        # always the reviewed, already-merged version. steps.sha.outputs.sha
+        # is used ONLY as data (git archive of a specific commit, passed to
+        # the script below as SOURCE_COMMIT) -- git archive reads tree
+        # content, it never executes anything from the archived commit.
+        # fetch-depth: 0 (full history) so an older SOURCE_COMMIT still
+        # resolves locally for that archive step.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ steps.sha.outputs.sha }}
+          fetch-depth: 0
           # Never fetch the private strategy/docs submodules here -- the sync
           # script only needs packages/mcp-server, and submodule fetch would
           # require STRATEGY_SUBMODULE_PAT for no benefit.
@@ -127,6 +145,7 @@ jobs:
         env:
           MIRROR_PUSH_TOKEN: ${{ secrets.MIRROR_PUSH_TOKEN }}
           DRY_RUN_INPUT: ${{ github.event.inputs.dry_run || 'false' }}
+          SOURCE_COMMIT: ${{ steps.sha.outputs.sha }}
         run: |
           set -euo pipefail
           if [ "$DRY_RUN_INPUT" = "true" ]; then

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -141,6 +141,17 @@ regexes = [
   # generic-api-key regex by coincidence.
   '''pr-123-validation''',
 
+  # False positive (SMI-5629): identifiers in packages/mcp-server/src/tools/
+  # get-skill.ts that match the same 24-char vercel-token regex as the
+  # SMI-4577 entries above. `deriveSecuritySummaryFro` is the truncated
+  # 24-char body of `deriveSecuritySummaryFromAdvisories`; `skillDependencyRepositor`
+  # is the truncated body of `skillDependencyRepositoryLookup`. Only surfaced
+  # when the SMI-5629 mirror sync script scans in filesystem (--no-git) mode —
+  # gitleaks's git-mode scan of this same file returns clean, since the
+  # broad keyword-gated regex behaves differently across the two scan modes.
+  '''deriveSecuritySummaryFro''',
+  '''skillDependencyRepositor''',
+
 ]
 
 # Allow specific files that contain examples or tests

--- a/scripts/lib/mirror-mcp-server-gates.sh
+++ b/scripts/lib/mirror-mcp-server-gates.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# mirror-mcp-server-gates.sh — leak-audit and build-validity gates for
+# scripts/mirror-mcp-server.sh (SMI-5629, change 4). Split out of the main
+# script to keep it under the repo's 500-line file standard.
+#
+# Sourced (not executed) by mirror-mcp-server.sh — relies on that script's
+# globals (TREE_DIR, REPO_ROOT, NPM_VERSION) and log/warn/err helpers being
+# already defined in the calling shell.
+
+# ---------------------------------------------------------------------------
+# Leak audit (change 4) — runs against every candidate tree, every sync, not
+# just the one-time pre-first-push manual review.
+# ---------------------------------------------------------------------------
+
+run_manual_secret_grep() {
+  # Last-resort fallback only, when neither gitleaks nor trufflehog is on
+  # PATH. Deliberately coarse — e.g. the email-shaped pattern will also
+  # match benign test fixtures like test@example.com — so it will false
+  # positive far more often than the dedicated scanners; that's an accepted
+  # tradeoff for a fallback, not the primary path (install gitleaks/trufflehog
+  # to avoid it).
+  local hit=false
+
+  if grep -rlE 'sk_live_[A-Za-z0-9]+' "$TREE_DIR" >/dev/null 2>&1; then
+    warn "Manual grep found an 'sk_live_'-shaped string in the candidate tree."
+    hit=true
+  fi
+  if grep -rlE '[a-z0-9]{20}\.supabase\.co' "$TREE_DIR" >/dev/null 2>&1; then
+    warn "Manual grep found a supabase.co project-ref-shaped string in the candidate tree."
+    hit=true
+  fi
+  if grep -rlE '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' "$TREE_DIR" >/dev/null 2>&1; then
+    warn "Manual grep found an email-address-shaped string in the candidate tree."
+    hit=true
+  fi
+
+  [[ "$hit" == "false" ]] || err "manual secret-pattern grep found one or more hits — aborting sync (install gitleaks or trufflehog for a precise scan)"
+}
+
+check_dist_absolute_paths() {
+  # Excludes test files: the published tarball's dist/**/*.test.js fixtures
+  # contain synthetic placeholder paths (e.g. /home/user/.claude/skills/...,
+  # /Users/test/...) that aren't real build-host leaks — same test-file trust
+  # boundary .gitleaks.toml already applies (verified: real shipped code and
+  # sourcemaps have zero absolute-path hits; only *.test.js/*.test.js.map do).
+  local hits
+  hits="$(grep -rlE '(/Users/[A-Za-z]|/home/[A-Za-z]|/private/tmp/)' "$TREE_DIR/dist" 2>/dev/null \
+    | grep -vE '(\.test\.js(\.map)?$|/(tests|__tests__)/)' || true)"
+  if [[ -n "$hits" ]]; then
+    err "absolute build-host path(s) found in dist/ (leaks the build machine's filesystem layout):"$'\n'"$hits"
+  fi
+}
+
+check_no_dotenv_files() {
+  local hits
+  hits="$(find "$TREE_DIR" -type f -iname '.env*' 2>/dev/null || true)"
+  if [[ -n "$hits" ]]; then
+    err "one or more .env* files survived into the candidate tree:"$'\n'"$hits"
+  fi
+}
+
+run_leak_audit() {
+  log "Running leak audit against the candidate tree..."
+
+  if command -v gitleaks >/dev/null 2>&1; then
+    log "Scanning with gitleaks (repo config: ${REPO_ROOT}/.gitleaks.toml)..."
+    # Must pass --config: the repo's own .gitleaks.toml already allowlists
+    # the known-synthetic secret-scanner test fixtures that git-archived
+    # tests/ and the published dist/**/*.test.js otherwise trip on EVERY
+    # sync (verified: 25 hits with no --config, 0 with it, against a real
+    # assembled tree — see SMI-5629 Opus review). Without this flag the gate
+    # is not "aborts on a real leak", it's "aborts on every sync, forever".
+    gitleaks detect --no-git --source "$TREE_DIR" --config "$REPO_ROOT/.gitleaks.toml" \
+      || err "gitleaks detected a potential secret in the candidate tree — aborting sync"
+  elif command -v trufflehog >/dev/null 2>&1; then
+    log "gitleaks not found — scanning with trufflehog..."
+    # --fail is required: `trufflehog filesystem` exits 0 even when it finds
+    # verified secrets unless --fail is passed, so without it this gate never
+    # actually aborts. --no-update skips its self-update network call in CI.
+    # Note: trufflehog does not honor .gitleaks.toml, so it will FP on the
+    # same synthetic fixtures gitleaks is configured to skip — gitleaks is
+    # the primary, supported path; this fallback is genuinely last-resort.
+    trufflehog filesystem "$TREE_DIR" --fail --no-update \
+      || err "trufflehog detected a potential secret in the candidate tree — aborting sync"
+  else
+    warn "Neither gitleaks nor trufflehog found on PATH — falling back to manual grep patterns."
+    run_manual_secret_grep
+  fi
+
+  check_dist_absolute_paths
+  check_no_dotenv_files
+
+  log "Leak audit passed."
+}
+
+# ---------------------------------------------------------------------------
+# Build-validity gate (change 4) — must pass before any push, every sync.
+# ---------------------------------------------------------------------------
+run_build_gate() {
+  require_cmd docker
+  log "Running build-validity gate (docker build) against the candidate tree..."
+
+  local image_tag="skillsmith-mcp-server-mirror-check:${NPM_VERSION}"
+  local build_log="$TMP_ROOT/docker-build.log"
+
+  if ! docker build --tag "$image_tag" "$TREE_DIR" >"$build_log" 2>&1; then
+    tail -n 60 "$build_log" >&2
+    err "docker build failed against the candidate tree (see build log above) — aborting sync"
+  fi
+
+  log "docker build succeeded (${image_tag})."
+  docker image rm "$image_tag" >/dev/null 2>&1 || true
+}

--- a/scripts/mirror-mcp-server.sh
+++ b/scripts/mirror-mcp-server.sh
@@ -96,6 +96,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Leak-audit + build-validity gate functions (change 4) — split into a
+# sourced lib to keep this file under the repo's 500-line standard. Relies
+# on the globals/helpers above (TREE_DIR, REPO_ROOT, NPM_VERSION, log/warn/err).
+# shellcheck source=lib/mirror-mcp-server-gates.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/mirror-mcp-server-gates.sh"
+
 usage() {
   cat <<'EOF'
 Usage: mirror-mcp-server.sh [--dry-run] [--source-commit <sha>]
@@ -304,50 +310,6 @@ add_overlays() {
 }
 
 # ---------------------------------------------------------------------------
-# Leak audit (change 4) — runs against every candidate tree, every sync, not
-# just the one-time pre-first-push manual review.
-# ---------------------------------------------------------------------------
-
-run_manual_secret_grep() {
-  # Last-resort fallback only, when neither gitleaks nor trufflehog is on
-  # PATH. Deliberately coarse — e.g. the email-shaped pattern will also
-  # match benign test fixtures like test@example.com — so it will false
-  # positive far more often than the dedicated scanners; that's an accepted
-  # tradeoff for a fallback, not the primary path (install gitleaks/trufflehog
-  # to avoid it).
-  local hit=false
-
-  if grep -rlE 'sk_live_[A-Za-z0-9]+' "$TREE_DIR" >/dev/null 2>&1; then
-    warn "Manual grep found an 'sk_live_'-shaped string in the candidate tree."
-    hit=true
-  fi
-  if grep -rlE '[a-z0-9]{20}\.supabase\.co' "$TREE_DIR" >/dev/null 2>&1; then
-    warn "Manual grep found a supabase.co project-ref-shaped string in the candidate tree."
-    hit=true
-  fi
-  if grep -rlE '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' "$TREE_DIR" >/dev/null 2>&1; then
-    warn "Manual grep found an email-address-shaped string in the candidate tree."
-    hit=true
-  fi
-
-  [[ "$hit" == "false" ]] || err "manual secret-pattern grep found one or more hits — aborting sync (install gitleaks or trufflehog for a precise scan)"
-}
-
-check_dist_absolute_paths() {
-  # Excludes test files: the published tarball's dist/**/*.test.js fixtures
-  # contain synthetic placeholder paths (e.g. /home/user/.claude/skills/...,
-  # /Users/test/...) that aren't real build-host leaks — same test-file trust
-  # boundary .gitleaks.toml already applies (verified: real shipped code and
-  # sourcemaps have zero absolute-path hits; only *.test.js/*.test.js.map do).
-  local hits
-  hits="$(grep -rlE '(/Users/[A-Za-z]|/home/[A-Za-z]|/private/tmp/)' "$TREE_DIR/dist" 2>/dev/null \
-    | grep -vE '(\.test\.js(\.map)?$|/(tests|__tests__)/)' || true)"
-  if [[ -n "$hits" ]]; then
-    err "absolute build-host path(s) found in dist/ (leaks the build machine's filesystem layout):"$'\n'"$hits"
-  fi
-}
-
-# ---------------------------------------------------------------------------
 # Version-consistency gate (fail-closed) — the git-archived source
 # (SOURCE_COMMIT) and the npm-tarball dist/ (NPM_VERSION) are assembled from
 # two independent sources (decision 1); nothing else guarantees they agree.
@@ -367,67 +329,6 @@ check_version_consistency() {
   if [[ "$archived_version" != "$NPM_VERSION" ]]; then
     err "version mismatch: package.json at SOURCE_COMMIT ${SOURCE_COMMIT} is ${archived_version}, but npm's latest published version is ${NPM_VERSION} — refusing to push a mirror commit with mismatched Source-Commit/Source-Version trailers (SOURCE_COMMIT must point at the commit that published NPM_VERSION)"
   fi
-}
-
-check_no_dotenv_files() {
-  local hits
-  hits="$(find "$TREE_DIR" -type f -iname '.env*' 2>/dev/null || true)"
-  if [[ -n "$hits" ]]; then
-    err "one or more .env* files survived into the candidate tree:"$'\n'"$hits"
-  fi
-}
-
-run_leak_audit() {
-  log "Running leak audit against the candidate tree..."
-
-  if command -v gitleaks >/dev/null 2>&1; then
-    log "Scanning with gitleaks (repo config: ${REPO_ROOT}/.gitleaks.toml)..."
-    # Must pass --config: the repo's own .gitleaks.toml already allowlists
-    # the known-synthetic secret-scanner test fixtures that git-archived
-    # tests/ and the published dist/**/*.test.js otherwise trip on EVERY
-    # sync (verified: 25 hits with no --config, 0 with it, against a real
-    # assembled tree — see SMI-5629 Opus review). Without this flag the gate
-    # is not "aborts on a real leak", it's "aborts on every sync, forever".
-    gitleaks detect --no-git --source "$TREE_DIR" --config "$REPO_ROOT/.gitleaks.toml" \
-      || err "gitleaks detected a potential secret in the candidate tree — aborting sync"
-  elif command -v trufflehog >/dev/null 2>&1; then
-    log "gitleaks not found — scanning with trufflehog..."
-    # --fail is required: `trufflehog filesystem` exits 0 even when it finds
-    # verified secrets unless --fail is passed, so without it this gate never
-    # actually aborts. --no-update skips its self-update network call in CI.
-    # Note: trufflehog does not honor .gitleaks.toml, so it will FP on the
-    # same synthetic fixtures gitleaks is configured to skip — gitleaks is
-    # the primary, supported path; this fallback is genuinely last-resort.
-    trufflehog filesystem "$TREE_DIR" --fail --no-update \
-      || err "trufflehog detected a potential secret in the candidate tree — aborting sync"
-  else
-    warn "Neither gitleaks nor trufflehog found on PATH — falling back to manual grep patterns."
-    run_manual_secret_grep
-  fi
-
-  check_dist_absolute_paths
-  check_no_dotenv_files
-
-  log "Leak audit passed."
-}
-
-# ---------------------------------------------------------------------------
-# Build-validity gate (change 4) — must pass before any push, every sync.
-# ---------------------------------------------------------------------------
-run_build_gate() {
-  require_cmd docker
-  log "Running build-validity gate (docker build) against the candidate tree..."
-
-  local image_tag="skillsmith-mcp-server-mirror-check:${NPM_VERSION}"
-  local build_log="$TMP_ROOT/docker-build.log"
-
-  if ! docker build --tag "$image_tag" "$TREE_DIR" >"$build_log" 2>&1; then
-    tail -n 60 "$build_log" >&2
-    err "docker build failed against the candidate tree (see build log above) — aborting sync"
-  fi
-
-  log "docker build succeeded (${image_tag})."
-  docker image rm "$image_tag" >/dev/null 2>&1 || true
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/mirror-mcp-server.sh
+++ b/scripts/mirror-mcp-server.sh
@@ -1,0 +1,535 @@
+#!/usr/bin/env bash
+# mirror-mcp-server.sh — sync packages/mcp-server into the public, submodule-free
+# mirror repo smith-horn/skillsmith-mcp-server (SMI-5629).
+#
+# Why this exists: Docker's MCP registry build tooling does a *full* git clone
+# of source.project before assembling the source.directory build context, so
+# it recurses into our root .gitmodules and fails on our private submodules.
+# The fix is a small public mirror containing only packages/mcp-server, kept
+# in sync by this script. See docs/internal/implementation/mcp-server-mirror-repo.md
+# for the full design (decisions 1-5 referenced below by number).
+#
+# Content sources (decision 1): the mirror tree is assembled from TWO sources,
+# not a curated subset —
+#   (a) a full `git archive` of packages/mcp-server/ at SOURCE_COMMIT (every
+#       git-tracked file: src, tests, Dockerfile, package.json, README, etc.)
+#   (b) dist/ extracted from the PUBLISHED npm tarball for
+#       @skillsmith/mcp-server@<version> — not a fresh build of HEAD, which
+#       would reintroduce the semver-drift crash this design avoids.
+# Plus overlay files added by this script itself: root LICENSE, a locked
+# README banner, and a PR auto-close workflow for the mirror repo.
+#
+# History model (decision 3): append-only. Each sync adds exactly ONE new
+# commit to the mirror's main with the tree fully replaced — never a rewrite,
+# never `git push --force`. This keeps Docker's pinned source.commit SHAs
+# resolvable forever.
+#
+# Idempotency (decision 2): compares `npm view <pkg> version` against the
+# mirror's current package.json version; no-ops (exit 0) if already synced.
+# Self-healing across dry-runs, missed CI runs, and re-runs.
+#
+# Usage:
+#   scripts/mirror-mcp-server.sh --dry-run
+#   scripts/mirror-mcp-server.sh --dry-run --source-commit <sha>
+#   SOURCE_COMMIT=<sha> MIRROR_PUSH_TOKEN=<token> scripts/mirror-mcp-server.sh
+#
+# Env vars:
+#   SOURCE_COMMIT     Monorepo commit that produced the published npm version
+#                      (CI: the publish run's head_sha / $GITHUB_SHA). Falls
+#                      back to `git rev-parse HEAD` only under --dry-run.
+#                      May also be passed as --source-commit <sha>.
+#   MIRROR_PUSH_TOKEN  Fine-grained PAT scoped to the mirror repo only, used
+#                      to push. Required for a real (non---dry-run) sync;
+#                      never required, read, or logged in --dry-run mode.
+#
+# Exit codes: 0 on success or idempotent no-op; 1 on any gate failure
+# (leak audit, absolute-path check, .env* check, docker build) or usage error.
+
+set -euo pipefail
+
+# Never let a credential helper block on an interactive prompt in CI.
+export GIT_TERMINAL_PROMPT=0
+
+# ---------------------------------------------------------------------------
+# Hardcoded surfaces — grounded against the plan + live repo state before
+# writing this script (npm view, npm pack + tar -tzf, package.json, LICENSE).
+# ---------------------------------------------------------------------------
+readonly PACKAGE_NAME="@skillsmith/mcp-server"
+readonly PACKAGE_SUBDIR="packages/mcp-server"
+readonly MONOREPO_REPO_URL="https://github.com/smith-horn/skillsmith"
+readonly MIRROR_REPO_SLUG="smith-horn/skillsmith-mcp-server"
+readonly MIRROR_REPO_URL="https://github.com/${MIRROR_REPO_SLUG}.git"
+readonly MIRROR_BRANCH="main"
+
+# Locked, copy-paste-ready text from the plan (finding #18) — do not paraphrase.
+# shellcheck disable=SC2016 # single-quoted on purpose: the backticked `packages/mcp-server` must NOT expand
+readonly README_BANNER='> **This is an auto-generated, read-only mirror.** Source: [smith-horn/skillsmith](https://github.com/smith-horn/skillsmith) (`packages/mcp-server`). Do not open pull requests here — they will be closed automatically. File issues and contribute at the canonical repo instead.'
+
+REPO_ROOT_RESOLVED="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPO_ROOT="$REPO_ROOT_RESOLVED"
+
+# ---------------------------------------------------------------------------
+# Globals populated during execution (declared here so functions can rely on
+# them being defined, even before assignment, under `set -u`).
+# ---------------------------------------------------------------------------
+DRY_RUN=false
+SOURCE_COMMIT="${SOURCE_COMMIT:-}"
+NPM_VERSION=""
+TMP_ROOT=""
+TREE_DIR=""
+COMMIT_SUBJECT=""
+COMMIT_BODY=""
+FULL_COMMIT_MESSAGE=""
+
+# ---------------------------------------------------------------------------
+# Logging — all progress goes to stderr; stdout is reserved for the
+# --dry-run summary so it can be redirected/consumed cleanly.
+# ---------------------------------------------------------------------------
+log()  { printf '[mirror-mcp-server] %s\n' "$*" >&2; }
+warn() { printf '[mirror-mcp-server] WARNING: %s\n' "$*" >&2; }
+err()  { printf '[mirror-mcp-server] ERROR: %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  if [[ -n "$TMP_ROOT" && -d "$TMP_ROOT" ]]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<'EOF'
+Usage: mirror-mcp-server.sh [--dry-run] [--source-commit <sha>]
+
+Assembles the packages/mcp-server mirror tree, runs the leak-audit and
+docker-build gates, and (unless --dry-run) pushes one new commit to
+smith-horn/skillsmith-mcp-server.
+
+  --dry-run              Assemble + gate + print the would-be commit; never
+                          clones or pushes to the real mirror remote. Does
+                          not require MIRROR_PUSH_TOKEN.
+  --source-commit <sha>  Monorepo commit to archive. Overrides $SOURCE_COMMIT.
+                          Falls back to `git rev-parse HEAD` only in --dry-run.
+  -h, --help              Show this help.
+
+Env: SOURCE_COMMIT, MIRROR_PUSH_TOKEN (required for a real push only).
+EOF
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || err "required command '$1' not found on PATH"
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --source-commit)
+        [[ $# -ge 2 ]] || err "--source-commit requires a value"
+        SOURCE_COMMIT="$2"
+        shift 2
+        ;;
+      --source-commit=*)
+        SOURCE_COMMIT="${1#*=}"
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        err "unknown argument: $1 (see --help)"
+        ;;
+    esac
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+resolve_source_commit() {
+  if [[ -z "$SOURCE_COMMIT" ]]; then
+    if [[ "$DRY_RUN" == "true" ]]; then
+      SOURCE_COMMIT="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+      log "SOURCE_COMMIT not set — dry-run fallback to HEAD ($SOURCE_COMMIT)"
+    else
+      err "SOURCE_COMMIT must be set (env var or --source-commit) outside --dry-run; CI passes \$GITHUB_SHA / the triggering workflow_run's head_sha"
+    fi
+  fi
+
+  git -C "$REPO_ROOT" rev-parse --verify "${SOURCE_COMMIT}^{commit}" >/dev/null 2>&1 \
+    || err "SOURCE_COMMIT '$SOURCE_COMMIT' does not resolve to a commit in this checkout"
+
+  # Normalize to a full 40-char SHA regardless of what form was passed in —
+  # the Source-Commit trailer (decision 4) must be exact and unambiguous.
+  SOURCE_COMMIT="$(git -C "$REPO_ROOT" rev-parse "$SOURCE_COMMIT")"
+}
+
+resolve_npm_version() {
+  log "Resolving latest published version of ${PACKAGE_NAME} from npm..."
+  NPM_VERSION="$(npm view "$PACKAGE_NAME" version 2>/dev/null || true)"
+  [[ -n "$NPM_VERSION" ]] || err "npm view ${PACKAGE_NAME} version returned nothing — is it published?"
+  log "Latest published version: ${NPM_VERSION}"
+}
+
+# ---------------------------------------------------------------------------
+# Idempotency gate (decision 2). Exits 0 as a no-op if the mirror is already
+# at NPM_VERSION. Treats "mirror repo/branch doesn't exist yet" as "not yet
+# synced, proceed" — required because the mirror repo does not exist at the
+# time this script is first written (Step 1 creates it, but Step 4 is the
+# first real sync).
+# ---------------------------------------------------------------------------
+check_idempotency() {
+  local ls_remote_out="$TMP_ROOT/ls-remote.txt"
+
+  if ! git ls-remote --exit-code "$MIRROR_REPO_URL" "refs/heads/$MIRROR_BRANCH" >"$ls_remote_out" 2>/dev/null \
+      || [[ ! -s "$ls_remote_out" ]]; then
+    log "Mirror repo/branch not found yet (repo not created, or created but empty) — treating as first sync."
+    return 0
+  fi
+
+  log "Mirror branch exists — checking currently-synced version via a shallow clone..."
+  local check_dir="$TMP_ROOT/mirror-check"
+  if ! git clone --quiet --depth 1 --branch "$MIRROR_BRANCH" "$MIRROR_REPO_URL" "$check_dir" 2>/dev/null; then
+    warn "Could not shallow-clone ${MIRROR_REPO_SLUG} to verify its current version — proceeding with sync (self-healing by design)."
+    return 0
+  fi
+
+  if [[ ! -f "$check_dir/package.json" ]]; then
+    warn "Mirror has no package.json yet — proceeding with sync."
+    return 0
+  fi
+
+  local mirror_version
+  mirror_version="$(node -e "process.stdout.write(require('$check_dir/package.json').version || '')" 2>/dev/null || true)"
+
+  if [[ "$mirror_version" == "$NPM_VERSION" ]]; then
+    log "Mirror is already at ${PACKAGE_NAME}@${NPM_VERSION} — no-op."
+    exit 0
+  fi
+
+  log "Mirror is at version '${mirror_version:-<unknown>}'; syncing to ${NPM_VERSION}."
+}
+
+# ---------------------------------------------------------------------------
+# Tree assembly (decision 1)
+# ---------------------------------------------------------------------------
+
+assemble_git_archive() {
+  log "Archiving ${PACKAGE_SUBDIR} at ${SOURCE_COMMIT}..."
+  # packages/mcp-server/<file> has 2 path components before the file itself —
+  # strip-components=2 lands every git-tracked file at the tree root
+  # (verified against a real archive of this path before writing this script).
+  git -C "$REPO_ROOT" archive --format=tar "$SOURCE_COMMIT" -- "$PACKAGE_SUBDIR" \
+    | tar -x --strip-components=2 -C "$TREE_DIR" \
+    || err "git archive of ${PACKAGE_SUBDIR} at ${SOURCE_COMMIT} failed"
+
+  [[ -f "$TREE_DIR/Dockerfile" ]] || err "assembled tree is missing Dockerfile — git archive step produced an unexpected layout"
+}
+
+assemble_npm_dist() {
+  log "Packing ${PACKAGE_NAME}@${NPM_VERSION} from npm to extract dist/..."
+  local pack_dir="$TMP_ROOT/npm-pack"
+  mkdir -p "$pack_dir"
+  ( cd "$pack_dir" && npm pack "${PACKAGE_NAME}@${NPM_VERSION}" >/dev/null )
+
+  local tarball
+  tarball="$(find "$pack_dir" -maxdepth 1 -name '*.tgz' -print -quit)"
+  [[ -n "$tarball" ]] || err "npm pack did not produce a .tgz for ${PACKAGE_NAME}@${NPM_VERSION}"
+
+  # Tarball layout verified with a real `npm pack` + `tar -tzf` before writing
+  # this extraction step: everything lives under a `package/` prefix, dist/
+  # at `package/dist/` — strip-components=1, extract only that path.
+  tar -xzf "$tarball" -C "$TREE_DIR" --strip-components=1 package/dist \
+    || err "failed to extract dist/ from ${tarball##*/}"
+
+  [[ -d "$TREE_DIR/dist" ]] || err "expected dist/ was not present in the ${PACKAGE_NAME}@${NPM_VERSION} tarball"
+}
+
+write_pr_auto_close_workflow() {
+  local dest="$1"
+  # Pull requests can't be disabled via mirror repo settings the way
+  # issues/wiki/projects can (Step 1) — this workflow is the PR auto-responder.
+  cat >"$dest" <<'YAML'
+name: Close PRs (read-only mirror)
+
+# This repo is a read-only, auto-generated mirror (see README banner).
+# Pull requests can't be disabled via repo settings the way issues/wiki/
+# projects can, so this workflow comments on and closes any PR opened here,
+# pointing the author at the canonical repo. See SMI-5629, plan Step 1.
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: pr-auto-close-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  close-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "This is a read-only auto-generated mirror; open PRs against smith-horn/skillsmith instead."
+          gh pr close "$PR_NUMBER" --repo "$REPO"
+YAML
+}
+
+add_overlays() {
+  log "Adding overlay files (LICENSE, README banner, PR auto-close workflow)..."
+
+  [[ -f "$REPO_ROOT/LICENSE" ]] || err "root LICENSE not found at ${REPO_ROOT}/LICENSE"
+  cp "$REPO_ROOT/LICENSE" "$TREE_DIR/LICENSE"
+
+  [[ -f "$TREE_DIR/README.md" ]] || err "README.md missing from assembled tree — git archive step may have failed"
+  local readme_tmp="$TMP_ROOT/README.md.bannered"
+  { printf '%s\n\n' "$README_BANNER"; cat "$TREE_DIR/README.md"; } > "$readme_tmp"
+  mv "$readme_tmp" "$TREE_DIR/README.md"
+
+  mkdir -p "$TREE_DIR/.github/workflows"
+  write_pr_auto_close_workflow "$TREE_DIR/.github/workflows/pr-auto-close.yml"
+}
+
+# ---------------------------------------------------------------------------
+# Leak audit (change 4) — runs against every candidate tree, every sync, not
+# just the one-time pre-first-push manual review.
+# ---------------------------------------------------------------------------
+
+run_manual_secret_grep() {
+  # Last-resort fallback only, when neither gitleaks nor trufflehog is on
+  # PATH. Deliberately coarse — e.g. the email-shaped pattern will also
+  # match benign test fixtures like test@example.com — so it will false
+  # positive far more often than the dedicated scanners; that's an accepted
+  # tradeoff for a fallback, not the primary path (install gitleaks/trufflehog
+  # to avoid it).
+  local hit=false
+
+  if grep -rlE 'sk_live_[A-Za-z0-9]+' "$TREE_DIR" >/dev/null 2>&1; then
+    warn "Manual grep found an 'sk_live_'-shaped string in the candidate tree."
+    hit=true
+  fi
+  if grep -rlE '[a-z0-9]{20}\.supabase\.co' "$TREE_DIR" >/dev/null 2>&1; then
+    warn "Manual grep found a supabase.co project-ref-shaped string in the candidate tree."
+    hit=true
+  fi
+  if grep -rlE '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' "$TREE_DIR" >/dev/null 2>&1; then
+    warn "Manual grep found an email-address-shaped string in the candidate tree."
+    hit=true
+  fi
+
+  [[ "$hit" == "false" ]] || err "manual secret-pattern grep found one or more hits — aborting sync (install gitleaks or trufflehog for a precise scan)"
+}
+
+check_dist_absolute_paths() {
+  # Excludes test files: the published tarball's dist/**/*.test.js fixtures
+  # contain synthetic placeholder paths (e.g. /home/user/.claude/skills/...,
+  # /Users/test/...) that aren't real build-host leaks — same test-file trust
+  # boundary .gitleaks.toml already applies (verified: real shipped code and
+  # sourcemaps have zero absolute-path hits; only *.test.js/*.test.js.map do).
+  local hits
+  hits="$(grep -rlE '(/Users/[A-Za-z]|/home/[A-Za-z]|/private/tmp/)' "$TREE_DIR/dist" 2>/dev/null \
+    | grep -vE '(\.test\.js(\.map)?$|/(tests|__tests__)/)' || true)"
+  if [[ -n "$hits" ]]; then
+    err "absolute build-host path(s) found in dist/ (leaks the build machine's filesystem layout):"$'\n'"$hits"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Version-consistency gate (fail-closed) — the git-archived source
+# (SOURCE_COMMIT) and the npm-tarball dist/ (NPM_VERSION) are assembled from
+# two independent sources (decision 1); nothing else guarantees they agree.
+# A workflow_dispatch backfill against a not-yet-published HEAD, or a second
+# publish landing mid-run, could otherwise push a mirror commit whose source
+# and dist are different versions with self-contradictory Source-Commit/
+# Source-Version trailers, defeating decision-4 traceability. Fail closed
+# rather than push a skewed tree.
+# ---------------------------------------------------------------------------
+check_version_consistency() {
+  [[ -f "$TREE_DIR/package.json" ]] || err "assembled tree is missing package.json — git archive step produced an unexpected layout"
+
+  local archived_version
+  archived_version="$(node -e "process.stdout.write(require('$TREE_DIR/package.json').version || '')" 2>/dev/null || true)"
+  [[ -n "$archived_version" ]] || err "could not read a version from the archived package.json at ${SOURCE_COMMIT}"
+
+  if [[ "$archived_version" != "$NPM_VERSION" ]]; then
+    err "version mismatch: package.json at SOURCE_COMMIT ${SOURCE_COMMIT} is ${archived_version}, but npm's latest published version is ${NPM_VERSION} — refusing to push a mirror commit with mismatched Source-Commit/Source-Version trailers (SOURCE_COMMIT must point at the commit that published NPM_VERSION)"
+  fi
+}
+
+check_no_dotenv_files() {
+  local hits
+  hits="$(find "$TREE_DIR" -type f -iname '.env*' 2>/dev/null || true)"
+  if [[ -n "$hits" ]]; then
+    err "one or more .env* files survived into the candidate tree:"$'\n'"$hits"
+  fi
+}
+
+run_leak_audit() {
+  log "Running leak audit against the candidate tree..."
+
+  if command -v gitleaks >/dev/null 2>&1; then
+    log "Scanning with gitleaks (repo config: ${REPO_ROOT}/.gitleaks.toml)..."
+    # Must pass --config: the repo's own .gitleaks.toml already allowlists
+    # the known-synthetic secret-scanner test fixtures that git-archived
+    # tests/ and the published dist/**/*.test.js otherwise trip on EVERY
+    # sync (verified: 25 hits with no --config, 0 with it, against a real
+    # assembled tree — see SMI-5629 Opus review). Without this flag the gate
+    # is not "aborts on a real leak", it's "aborts on every sync, forever".
+    gitleaks detect --no-git --source "$TREE_DIR" --config "$REPO_ROOT/.gitleaks.toml" \
+      || err "gitleaks detected a potential secret in the candidate tree — aborting sync"
+  elif command -v trufflehog >/dev/null 2>&1; then
+    log "gitleaks not found — scanning with trufflehog..."
+    # --fail is required: `trufflehog filesystem` exits 0 even when it finds
+    # verified secrets unless --fail is passed, so without it this gate never
+    # actually aborts. --no-update skips its self-update network call in CI.
+    # Note: trufflehog does not honor .gitleaks.toml, so it will FP on the
+    # same synthetic fixtures gitleaks is configured to skip — gitleaks is
+    # the primary, supported path; this fallback is genuinely last-resort.
+    trufflehog filesystem "$TREE_DIR" --fail --no-update \
+      || err "trufflehog detected a potential secret in the candidate tree — aborting sync"
+  else
+    warn "Neither gitleaks nor trufflehog found on PATH — falling back to manual grep patterns."
+    run_manual_secret_grep
+  fi
+
+  check_dist_absolute_paths
+  check_no_dotenv_files
+
+  log "Leak audit passed."
+}
+
+# ---------------------------------------------------------------------------
+# Build-validity gate (change 4) — must pass before any push, every sync.
+# ---------------------------------------------------------------------------
+run_build_gate() {
+  require_cmd docker
+  log "Running build-validity gate (docker build) against the candidate tree..."
+
+  local image_tag="skillsmith-mcp-server-mirror-check:${NPM_VERSION}"
+  local build_log="$TMP_ROOT/docker-build.log"
+
+  if ! docker build --tag "$image_tag" "$TREE_DIR" >"$build_log" 2>&1; then
+    tail -n 60 "$build_log" >&2
+    err "docker build failed against the candidate tree (see build log above) — aborting sync"
+  fi
+
+  log "docker build succeeded (${image_tag})."
+  docker image rm "$image_tag" >/dev/null 2>&1 || true
+}
+
+# ---------------------------------------------------------------------------
+# Commit message (decision 4)
+# ---------------------------------------------------------------------------
+build_commit_message() {
+  COMMIT_SUBJECT="sync: ${PACKAGE_NAME}@${NPM_VERSION}"
+  COMMIT_BODY="Source-Repo: ${MONOREPO_REPO_URL}
+Source-Commit: ${SOURCE_COMMIT}
+Source-Version: ${NPM_VERSION}"
+  FULL_COMMIT_MESSAGE="${COMMIT_SUBJECT}
+
+${COMMIT_BODY}"
+}
+
+print_dry_run_summary() {
+  local file_count total_size
+  file_count="$(find "$TREE_DIR" -type f | wc -l | tr -d ' ')"
+  total_size="$(du -sh "$TREE_DIR" 2>/dev/null | cut -f1)"
+
+  echo ""
+  echo "=== mirror-mcp-server.sh --dry-run summary ==="
+  echo "Package:        ${PACKAGE_NAME}@${NPM_VERSION}"
+  echo "Source commit:  ${SOURCE_COMMIT}"
+  echo "Mirror repo:    ${MIRROR_REPO_SLUG} (branch: ${MIRROR_BRANCH})"
+  echo "Tree files:     ${file_count}"
+  echo "Tree size:      ${total_size:-unknown}"
+  echo ""
+  echo "--- would-be commit message ---"
+  echo "$FULL_COMMIT_MESSAGE"
+  echo "--- end commit message ---"
+  echo ""
+  echo "Dry run only — no clone/push performed against ${MIRROR_REPO_URL}."
+}
+
+# ---------------------------------------------------------------------------
+# Push (decision 3: one new commit, tree fully replaced, never --force)
+# ---------------------------------------------------------------------------
+push_mirror() {
+  log "Cloning ${MIRROR_REPO_SLUG} for push..."
+  local mirror_dir="$TMP_ROOT/mirror-push"
+  local auth_header
+  auth_header="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$MIRROR_PUSH_TOKEN" | base64 | tr -d '\n')"
+
+  git -c http.extraheader="$auth_header" clone --quiet --depth 1 "$MIRROR_REPO_URL" "$mirror_dir" \
+    || err "failed to clone ${MIRROR_REPO_SLUG} for push (check MIRROR_PUSH_TOKEN scope/expiry)"
+
+  # Replace the tree wholesale — everything except .git/ is removed and
+  # re-populated from the assembled candidate tree.
+  find "$mirror_dir" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+  cp -a "$TREE_DIR/." "$mirror_dir/"
+
+  (
+    cd "$mirror_dir"
+    git checkout -B "$MIRROR_BRANCH"
+    git add -A
+    git -c user.name="skillsmith-mirror-bot" -c user.email="ci@skillsmith.app" \
+      commit --quiet -m "$FULL_COMMIT_MESSAGE"
+  )
+
+  log "Pushing one new commit to ${MIRROR_REPO_SLUG}#${MIRROR_BRANCH} (plain push, never --force)..."
+  ( cd "$mirror_dir" && git -c http.extraheader="$auth_header" push origin "HEAD:${MIRROR_BRANCH}" ) \
+    || err "push to ${MIRROR_REPO_SLUG} failed"
+}
+
+# ---------------------------------------------------------------------------
+main() {
+  parse_args "$@"
+
+  require_cmd git
+  require_cmd npm
+  require_cmd tar
+  require_cmd node
+
+  TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/mirror-mcp-server.XXXXXX")"
+  TREE_DIR="$TMP_ROOT/tree"
+  mkdir -p "$TREE_DIR"
+
+  resolve_source_commit
+  resolve_npm_version
+
+  check_idempotency
+
+  assemble_git_archive
+  check_version_consistency
+  assemble_npm_dist
+  add_overlays
+
+  run_leak_audit
+  run_build_gate
+
+  build_commit_message
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    print_dry_run_summary
+    exit 0
+  fi
+
+  [[ -n "${MIRROR_PUSH_TOKEN:-}" ]] || err "MIRROR_PUSH_TOKEN is required for a real (non---dry-run) sync"
+
+  push_mirror
+  log "Sync complete: ${PACKAGE_NAME}@${NPM_VERSION} pushed to ${MIRROR_REPO_SLUG}."
+}
+
+main "$@"


### PR DESCRIPTION
## Business Summary

**What shipped:** A new CI pipeline that automatically syncs `packages/mcp-server` into a new public, submodule-free mirror repo (`smith-horn/skillsmith-mcp-server`) after every npm publish. This unblocks the Docker MCP Registry submission (SMI-5614), which was paused because Docker's build tooling clones the full private monorepo and fails on our private git submodules — the mirror never has any.

**Quality bar:** Three independent review passes before merge — a full `plan-review-skill` pass (18 findings, all applied, satisfying the ADR-109 infra-change gate), an adversarial Opus security review of the sync script/workflow specifically (5 findings — including a Critical one where the leak-audit gate as originally written would have aborted on *every* sync, not just a real leak — all fixed and verified with a real green `--dry-run`), and a governance code-review pass (found the script over the repo's 500-line-per-file standard, split into a `scripts/lib/` helper). A full manual one-time leak audit was also run against a real assembled tree before any code merged (results recorded on SMI-5629): no real credentials, PII, or unintended leaks found.

**Found along the way:** SMI-5635 — a newly-discovered Docker/virtiofs bug where this worktree's own dev container can't reliably resolve `@skillsmith/core` through its read-only `node_modules` bind mount when the container is running (distinct from the already-fixed "container down" case). This blocked normal pre-commit/pre-push locally; root-caused and verified as a pure environment artifact (host execution is clean) before bypassing with explicit sign-off. Filed separately rather than expanding this PR's scope, since it needs its own ADR-109 SPARC + plan-review pass.

**Net result:** The mirror-repo infrastructure (script, workflow, docs) is fully shipped in this PR. The mirror repo itself has been created and configured (issues/wiki/projects disabled, PAT stored). The first real sync, re-pointing the Docker registry `server.yaml` fork, and the actual `docker/mcp-registry` submission remain separately gated behind their own explicit confirmation checkpoints — not yet done.

---

## Technical detail

**New files:**
- `scripts/mirror-mcp-server.sh` (436 lines) — assembles the mirror tree from a `git archive` of `packages/mcp-server` + the published npm tarball's `dist/`, runs leak-audit + docker-build gates, and pushes one append-only commit with `Source-Repo`/`Source-Commit`/`Source-Version` git trailers. Never force-pushes.
- `scripts/lib/mirror-mcp-server-gates.sh` (113 lines) — leak-audit + build-validity gate functions, split out per the governance review's file-length finding.
- `.github/workflows/mirror-mcp-server.yml` — triggers on `workflow_run` (the real `Publish Packages` workflow completing) + `workflow_dispatch` + a daily staleness-check schedule that opens a GitHub issue if the mirror falls behind. Pure-JS host-runner carve-out (SMI-4647).

**Modified:**
- `.gitleaks.toml` — 2 new allowlist entries for verified false-positive 24-char identifier substrings in `get-skill.ts` (only trip in filesystem-scan mode, not git-mode).
- `.claude/development/publishing-guide.md`, `.claude/development/index.md` — new Mirror Repo section.
- `docs/internal` submodule pointer — plan-review Review Summary + this PR's governance code-review report.

**Verification performed:**
- `bash -n` / `shellcheck -S warning` (both files, CI's actual severity threshold) / `actionlint` / YAML parse: all clean.
- Real (non-mocked) `scripts/mirror-mcp-server.sh --dry-run` run twice (before and after the governance file-split): `gitleaks` → `no leaks found`, `docker build` → succeeded, correct commit trailers printed.
- `npm run lint` / `npm run format:check` / `npm run audit:standards` (0 Failed, 8 pre-existing unrelated warnings): all clean in-container.
- `npm run typecheck`: clean on host; blocked in-container by SMI-5635 (see below).

**Pre-commit/pre-push bypasses (both explicitly user-authorized, not silent):** SMI-5635 blocked in-container typecheck for both commits in this PR (`9507bc25`, `2919f72d`) — verified as a pure environment artifact via host typecheck (0 errors). The final push also hit a related, separate pre-existing gap on the host-fallback route (native/WASM SQLite unavailable, cascading into unrelated `tests/billing/*` failures; plus the already-documented `marked`/`sanitize-html` stale-`node_modules` false positive in `vscode-extension` tests) — all failures individually verified as pre-existing and unrelated to this diff's 6 files before bypassing. Full details on SMI-5635.

Refs SMI-5629, SMI-5614, SMI-5635