### PR TITLE
fix(ci): add branches: [main] filter to mirror-mcp-server.yml (SMI-5629)

### DIFF
--- a/.github/workflows/mirror-mcp-server.yml
+++ b/.github/workflows/mirror-mcp-server.yml
@@ -55,6 +55,14 @@ on:
   workflow_run:
     workflows: ['Publish Packages']
     types: [completed]
+    # Defense-in-depth (post-merge governance retro, SMI-5629): narrows which
+    # workflow_run events are even considered, on top of (not instead of) the
+    # primary mitigation above -- this job never checks out or executes code
+    # at head_sha, only uses it as `git archive` data. publish.yml triggers
+    # on `release: types: [published]` + workflow_dispatch, both of which are
+    # only ever exercised against main in this repo's actual release flow
+    # (ADR-114 weekly/15-entry cadence, always cut from main).
+    branches: [main]
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Business Summary

**What shipped:** Adds a `branches: [main]` filter to `mirror-mcp-server.yml`'s `workflow_run` trigger, narrowing which upstream workflow completions it even considers — defense-in-depth on top of (not instead of) the untrusted-checkout fix already merged in PR #1804.

**Quality bar:** Found during the mandatory post-merge governance retro on PR #1804 — this repo already has precedent for this exact filter (`smoke-prod.yml`), which the retro surfaced while checking for the same anti-pattern elsewhere.

**Found along the way:** `smoke-prod.yml` itself has the same underlying checkout-of-untrusted-code pattern (and predates this PR) — flagged separately as a Linear issue, not folded into this PR since it's pre-existing and needs its own careful fix given it has `SUPABASE_SERVICE_ROLE_KEY` in scope.

**Net result:** Done, small additive-only change.

---

## Technical detail

`.github/workflows/mirror-mcp-server.yml` — added `branches: [main]` under the `workflow_run:` trigger. `publish.yml` (the upstream workflow) only ever runs against main in this repo's actual release flow (ADR-114), so this has no legitimate-case cost; the workflow's own staleness-check job provides a safety net if the filter ever mis-fires.

YAML validity + `actionlint`: both clean.

**Pre-push bypass:** `--no-verify` — same SMI-5635 root cause (Docker/virtiofs `@skillsmith/core` resolution bug) as the prior commits on this branch topic, already established and authorized earlier in this session.

Refs SMI-5629