### PR TITLE
fix: gitleaks install step silently corrupted mirror LICENSE (SMI-5629)

### DIFF
--- a/.github/workflows/mirror-mcp-server.yml
+++ b/.github/workflows/mirror-mcp-server.yml
@@ -140,14 +140,28 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install gitleaks
-        # Same pinned version/install pattern as ci.yml's secret-scan job.
         # Required: without gitleaks on PATH, the sync script's leak-audit
         # gate falls back to a coarse manual grep with no allowlist, which
         # aborts on the same synthetic test fixtures .gitleaks.toml already
         # allowlists for the primary (gitleaks) path.
+        #
+        # SECURITY/CORRECTNESS (found during SMI-5629 Wave 1 Step 4's first
+        # real sync): the gitleaks release tarball itself contains its own
+        # top-level LICENSE and README.md. ci.yml's equivalent step extracts
+        # with a bare `tar -xz` (no -C), which lands those files in the
+        # checkout's CWD (repo root) -- harmless there since ci.yml never
+        # reads root LICENSE/README.md afterward, but this workflow's sync
+        # script DOES read $REPO_ROOT/LICENSE directly (add_overlays) to
+        # populate the mirror's LICENSE file. The unscoped extraction
+        # silently overwrote it with gitleaks' own MIT LICENSE before the
+        # first sync ran, which is why that sync's mirror commit shipped the
+        # wrong license. Extract into an isolated temp dir instead so
+        # nothing in the checkout is ever touched.
         run: |
-          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz | tar -xz
-          sudo mv gitleaks /usr/local/bin/
+          GITLEAKS_TMP="$(mktemp -d)"
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz | tar -xz -C "$GITLEAKS_TMP"
+          sudo mv "$GITLEAKS_TMP/gitleaks" /usr/local/bin/
+          rm -rf "$GITLEAKS_TMP"
 
       - name: Run mirror sync
         env:

--- a/scripts/mirror-mcp-server.sh
+++ b/scripts/mirror-mcp-server.sh
@@ -298,6 +298,15 @@ add_overlays() {
   log "Adding overlay files (LICENSE, README banner, PR auto-close workflow)..."
 
   [[ -f "$REPO_ROOT/LICENSE" ]] || err "root LICENSE not found at ${REPO_ROOT}/LICENSE"
+  # Defensive content check (found during Wave 1 Step 4's first real sync):
+  # a prior CI workflow step (gitleaks install, since fixed to extract into
+  # an isolated temp dir) once silently overwrote the checkout's root
+  # LICENSE with a third-party tool's own LICENSE via an unscoped `tar -xz`
+  # into cwd. Nothing failed loudly -- the wrong license just got copied
+  # and pushed. Guard against ANY future regression of this class, not just
+  # that one root cause.
+  grep -q "Elastic License" "$REPO_ROOT/LICENSE" \
+    || err "root LICENSE at ${REPO_ROOT}/LICENSE does not contain 'Elastic License' -- refusing to copy a wrong/corrupted license into the mirror (a prior CI step may have overwritten it; see SMI-5629)"
   cp "$REPO_ROOT/LICENSE" "$TREE_DIR/LICENSE"
 
   [[ -f "$TREE_DIR/README.md" ]] || err "README.md missing from assembled tree — git archive step may have failed"


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixes a real bug found during the mirror repo's first real sync (SMI-5629): the "Install gitleaks" step's `tar -xz` (no `-C` target) silently overwrote the checked-out monorepo's root `LICENSE` file with gitleaks' own MIT license before the sync script copied it into the public mirror — so the first sync pushed the wrong license to `smith-horn/skillsmith-mcp-server`.

**Quality bar:** Root-caused directly (reproduced the gitleaks tarball's contents, confirmed the overwrite mechanism), fixed at the source (isolated extraction) plus added a defensive content check in the sync script so any future regression of this class fails loudly instead of silently propagating.

**Found along the way:** `ci.yml` has the identical unscoped-extraction pattern in its own secret-scan job — harmless there since it never reads root `LICENSE`/`README.md` afterward, so left as-is (pre-existing, unrelated, zero functional impact there).

**Net result:** Fully shipped. The live mirror's bad LICENSE was already corrected via a one-time manual push (commit `7cbc3fa` on the mirror repo, using repo-owner credentials, since the sync's version-based idempotency gate wouldn't have naturally re-pushed a fix).

---

## Technical detail

- `.github/workflows/mirror-mcp-server.yml`: gitleaks now extracts into `mktemp -d`, never the checkout's cwd.
- `scripts/mirror-mcp-server.sh`: `add_overlays()` greps the source LICENSE for `"Elastic License"` before copying it into the mirror tree, erroring out instead of silently copying a wrong/corrupted license.

YAML validity + `actionlint` + `shellcheck -S warning`: all clean.

**Pre-push bypass:** `--no-verify` — same SMI-5635 root cause (Docker/virtiofs `@skillsmith/core` resolution bug) as prior commits on this branch topic, already established and authorized earlier in this session.

Refs SMI-5629