### PR TITLE
fix(mcp-server): persist SQLite writes on shutdown (SMI-5639)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,7 @@ Project skills load from the `.claude/skills/` mount-point of the `skillsmith-st
 | Session-start audit unexpected stderr (SMI-4590) | `export SKILLSMITH_SESSION_AUDIT_DISABLE=1`. Logs: `~/.skillsmith/logs/session-audit-<date>.log` |
 | Strategy submodule uninitialized | Empty `.claude/{skills,plans,hive-mind}/` mount-points are expected for external contributors. Skillsmith team members: `git submodule update --init .claude/skills .claude/plans .claude/hive-mind` (each pinned to its own branch in `smith-horn/skillsmith-strategy` per shape b′; no extra setup script). |
 | Local typecheck/vitest fails with missing \`marked\`/\`sanitize-html\`/\`@types/sanitize-html\` (TS2688 / "Cannot find package") | Stale \`node_modules\` vs \`package-lock.json\`. Run \`docker exec skillsmith-dev-1 npm install\` + host \`npm install\`. The pre-commit hook now warns on this; pre-push blocks. Bypass a false positive with \`SKILLSMITH_SKIP_DEPS_FRESHNESS=1\` (SMI-5343/5344). |
+| MCP server logs `Failed to close database on shutdown` | Non-fatal — the process still exits cleanly, but recently-installed skills' dependency metadata may not be persisted. If this recurs, check disk space and file permissions on `~/.skillsmith/skills.db`. The error is logged (not silent) specifically so this is diagnosable. See SMI-5639. |
 
 **Detailed diagnostics**: [docker-guide.md](.claude/development/docker-guide.md#troubleshooting).
 

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: MCP server now persists recently-installed skills and dependency data on shutdown when running without native SQLite support (common on macOS/npx installs) — previously all writes were silently discarded on exit. The server was missing a database close() call in its shutdown handler (SMI-5639).
 - **Fix**: reduced local quota-enforcement limits 10x (SMI-5558) — Community was 1,000/mo now 100/mo, Individual was 10,000/mo now 1,000/mo, Team was 100,000/mo now 10,000/mo. Added a `SKILLSMITH_ENFORCE_MCP_QUOTA` kill-switch (defaults to enforcing, matching prior unconditional-block behavior) so hard-blocking can be disabled without a redeploy.
 
 ## v0.7.0

--- a/packages/mcp-server/src/index.startup-helpers.ts
+++ b/packages/mcp-server/src/index.startup-helpers.ts
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Startup-flag and bundled-skill helpers extracted from index.ts (SMI-5639).
+ * @module @skillsmith/mcp-server/index.startup-helpers
+ *
+ * Extracted to keep index.ts under the `audit:standards` 500-LOC gate after
+ * SMI-5639's shutdown-hook fix. No behavior change from the prior in-file
+ * versions.
+ */
+
+import { exec } from 'child_process'
+import { createLogger } from '@skillsmith/core/logging'
+import { installBundledSkills, getUserGuidePath } from './onboarding/install-assets.js'
+
+const logger = createLogger('mcp')
+
+/**
+ * Handle --docs flag to open user documentation
+ */
+export function handleDocsFlag(): void {
+  const userGuidePath = getUserGuidePath()
+  const onlineDocsUrl = 'https://skillsmith.app/docs'
+
+  if (userGuidePath) {
+    const cmd =
+      process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open'
+    exec(`${cmd} "${userGuidePath}"`)
+    console.log(`Opening documentation: ${userGuidePath}`)
+  } else {
+    const cmd =
+      process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open'
+    exec(`${cmd} "${onlineDocsUrl}"`)
+    console.log(`Opening online documentation: ${onlineDocsUrl}`)
+  }
+  process.exit(0)
+}
+
+/**
+ * SMI-4790: Idempotent install of the bundled `skillsmith` slash-command skill
+ * for MCP-only users (who never ran `skillsmith setup`) and recovery if the
+ * skill was uninstalled. Delegates routing to the existing
+ * `installBundledSkills()` which honours the SKILLSMITH_CLIENT env var via
+ * `resolveClientPath()` (Claude Code default; cursor/copilot/windsurf via env).
+ *
+ * Quiet by design: `installBundledSkills()` only logs when it actually copies
+ * a skill or hits an error, so happy-path startup adds zero stderr.
+ */
+export function ensureSkillsmithSkillInstalled(): void {
+  try {
+    installBundledSkills()
+  } catch (error) {
+    // Fail-soft: never block MCP startup on bundled-skill install failure.
+    const msg = error instanceof Error ? error.message : 'Unknown error'
+    logger.warn(`[skillsmith] Bundled skill install failed (non-fatal): ${msg}`, { err: error })
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -8,7 +8,6 @@
  */
 
 import { createRequire } from 'node:module'
-import { exec } from 'child_process'
 
 // ESM-compatible require for dynamic module resolution
 const require = createRequire(import.meta.url)
@@ -114,11 +113,8 @@ export type {
 const PACKAGE_VERSION = '0.7.0'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 const logger = createLogger('mcp', { version: PACKAGE_VERSION }) // SMI-5615
-import {
-  installBundledSkills,
-  installUserDocs,
-  getUserGuidePath,
-} from './onboarding/install-assets.js'
+import { installBundledSkills, installUserDocs } from './onboarding/install-assets.js'
+import { handleDocsFlag, ensureSkillsmithSkillInstalled } from './index.startup-helpers.js'
 
 // SMI-2679: Quota enforcement middleware — module-level singletons, initialized once
 // licenseMiddleware uses a cache (TTL) so the first-call @skillsmith/enterprise lazy-load
@@ -217,47 +213,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 server.setRequestHandler(CallToolRequestSchema, (request) =>
   handleCallToolRequest(request, { toolContext, licenseMiddleware, quotaMiddleware })
 )
-
-/**
- * Handle --docs flag to open user documentation
- */
-function handleDocsFlag(): void {
-  const userGuidePath = getUserGuidePath()
-  const onlineDocsUrl = 'https://skillsmith.app/docs'
-
-  if (userGuidePath) {
-    const cmd =
-      process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open'
-    exec(`${cmd} "${userGuidePath}"`)
-    console.log(`Opening documentation: ${userGuidePath}`)
-  } else {
-    const cmd =
-      process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open'
-    exec(`${cmd} "${onlineDocsUrl}"`)
-    console.log(`Opening online documentation: ${onlineDocsUrl}`)
-  }
-  process.exit(0)
-}
-
-/**
- * SMI-4790: Idempotent install of the bundled `skillsmith` slash-command skill
- * for MCP-only users (who never ran `skillsmith setup`) and recovery if the
- * skill was uninstalled. Delegates routing to the existing
- * `installBundledSkills()` which honours the SKILLSMITH_CLIENT env var via
- * `resolveClientPath()` (Claude Code default; cursor/copilot/windsurf via env).
- *
- * Quiet by design: `installBundledSkills()` only logs when it actually copies
- * a skill or hits an error, so happy-path startup adds zero stderr.
- */
-function ensureSkillsmithSkillInstalled(): void {
-  try {
-    installBundledSkills()
-  } catch (error) {
-    // Fail-soft: never block MCP startup on bundled-skill install failure.
-    const msg = error instanceof Error ? error.message : 'Unknown error'
-    logger.warn(`[skillsmith] Bundled skill install failed (non-fatal): ${msg}`, { err: error })
-  }
-}
 
 /**
  * SMI-5582: run only the SYNCHRONOUS, zero-network part of first-time setup —
@@ -377,7 +332,10 @@ function runStartupDiagnostics(): void {
 // so this explicitly exits once the bounded flush settles, preserving
 // today's default (process exits promptly on those signals) instead of
 // leaving the process hanging.
-const shutdownAndExit = createShutdownTrigger(() => process.exit(0))
+const shutdownAndExit = createShutdownTrigger(
+  () => process.exit(0),
+  () => toolContext?.db
+)
 
 // Start server
 async function main() {

--- a/packages/mcp-server/src/shutdown.test.ts
+++ b/packages/mcp-server/src/shutdown.test.ts
@@ -13,12 +13,50 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { initializePostHog, shutdownPostHog, isPostHogEnabled } from '@skillsmith/core/telemetry'
+import type { DatabaseType } from '@skillsmith/core'
 import {
   flushTelemetryOnShutdown,
   createShutdownTrigger,
+  closeDbOnShutdown,
   _resetShutdownGuardForTests,
   TELEMETRY_SHUTDOWN_FLUSH_TIMEOUT_MS,
 } from './shutdown.js'
+
+// SMI-5639: `shutdown.ts` builds its `logger` via `createLogger('mcp')` ONCE at
+// module load (`const logger = createLogger('mcp')`), so the only way to
+// assert what it logged is to mock the factory itself before `./shutdown.js`
+// is imported. `vi.mock` is hoisted above ALL imports in this file (including
+// the one above), so this works regardless of where it's declared textually.
+// `vi.hoisted` gives the factory a stable object the tests below can also
+// reference directly.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+vi.mock('@skillsmith/core/logging', () => ({
+  createLogger: vi.fn(() => mockLogger),
+}))
+
+/**
+ * Minimal mutable mock matching the slice of the `Database` interface
+ * `closeDbOnShutdown` actually touches (`open`, `close`). `open` is a plain
+ * mutable property (not a getter) so idempotency tests can flip it inside a
+ * `close()` mock the same way the real WASM/native drivers flip their own
+ * internal `_open` flag.
+ */
+interface MockDb {
+  open: boolean
+  close: ReturnType<typeof vi.fn>
+}
+
+function createMockDb(open = true): MockDb {
+  return { open, close: vi.fn() }
+}
 
 describe('flushTelemetryOnShutdown (SMI-5479)', () => {
   beforeEach(() => {
@@ -118,5 +156,206 @@ describe('createShutdownTrigger (SMI-5479)', () => {
       expect(onDoneA).toHaveBeenCalledTimes(1)
       expect(onDoneB).toHaveBeenCalledTimes(1)
     })
+  })
+})
+
+/**
+ * SMI-5639 Wave 2 Step 1 (part 1): direct coverage of the `closeDbOnShutdown`
+ * export itself, independent of `createShutdownTrigger`'s wiring. This is
+ * the fail-soft synchronous close that persists the WASM driver's in-memory
+ * database to disk on shutdown (`sqljsDriver.ts`'s `close()` -> `persist()`).
+ */
+describe('closeDbOnShutdown (SMI-5639)', () => {
+  beforeEach(() => {
+    mockLogger.error.mockClear()
+  })
+
+  it('calls db.close() when the db is open', () => {
+    const db = createMockDb(true)
+
+    closeDbOnShutdown(() => db as unknown as DatabaseType)
+
+    expect(db.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call close() when db.open is already false', () => {
+    const db = createMockDb(false)
+
+    closeDbOnShutdown(() => db as unknown as DatabaseType)
+
+    expect(db.close).not.toHaveBeenCalled()
+  })
+
+  it('no-ops safely when getDb is undefined', () => {
+    expect(() => closeDbOnShutdown(undefined)).not.toThrow()
+  })
+
+  it('no-ops safely when getDb returns undefined (toolContext not yet assigned)', () => {
+    expect(() => closeDbOnShutdown(() => undefined)).not.toThrow()
+  })
+
+  it('no-ops safely when getDb itself throws — the error never propagates', () => {
+    const getDb = vi.fn(() => {
+      throw new Error('toolContext accessor exploded')
+    })
+
+    expect(() => closeDbOnShutdown(getDb)).not.toThrow()
+    expect(getDb).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs via logger.error (not .debug/.info) when db.close() itself throws, and does not rethrow', () => {
+    const closeError = new Error('database is locked')
+    const db = createMockDb(true)
+    db.close.mockImplementation(() => {
+      throw closeError
+    })
+
+    expect(() => closeDbOnShutdown(() => db as unknown as DatabaseType)).not.toThrow()
+
+    // Per SMI-5615, a failed persist must be visible on stderr — logger.error
+    // (not .debug/.info, which are disk-only) is the only level that
+    // guarantees that. Assert the specific level, not just "some log call".
+    expect(mockLogger.error).toHaveBeenCalledTimes(1)
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to close database'),
+      expect.objectContaining({ err: closeError })
+    )
+    expect(mockLogger.debug).not.toHaveBeenCalled()
+    expect(mockLogger.info).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * SMI-5639 Wave 2 Step 1 (part 2): `createShutdownTrigger`'s new `getDb`
+ * wiring — the db close/persist runs SYNCHRONOUSLY, before the (async)
+ * telemetry flush is even kicked off, so these assertions can check
+ * `db.close()` immediately after calling `trigger()` without needing to wait.
+ */
+describe('createShutdownTrigger — getDb wiring (SMI-5639)', () => {
+  beforeEach(() => {
+    _resetShutdownGuardForTests()
+    mockLogger.error.mockClear()
+    initializePostHog({ apiKey: 'phc_test_key_smi_5639_shutdown_getdb' })
+  })
+
+  afterEach(async () => {
+    await shutdownPostHog()
+    _resetShutdownGuardForTests()
+  })
+
+  it('closes an open mock db when the trigger fires', async () => {
+    const db = createMockDb(true)
+    const onDone = vi.fn()
+    const trigger = createShutdownTrigger(onDone, () => db as unknown as DatabaseType)
+
+    trigger()
+
+    // Synchronous — closeDbOnShutdown runs to completion before the trigger
+    // even kicks off flushTelemetryOnShutdown, let alone awaits it.
+    expect(db.close).toHaveBeenCalledTimes(1)
+
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalledTimes(1))
+  })
+
+  it('no-ops safely when getDb is undefined — onDone still fires via the telemetry flush', async () => {
+    const onDone = vi.fn()
+    const trigger = createShutdownTrigger(onDone)
+
+    expect(() => trigger()).not.toThrow()
+
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalledTimes(1))
+  })
+
+  it('no-ops safely when getDb itself throws — does not propagate, onDone still fires', async () => {
+    const onDone = vi.fn()
+    const getDb = vi.fn(() => {
+      throw new Error('toolContext not ready')
+    })
+    const trigger = createShutdownTrigger(onDone, getDb)
+
+    expect(() => trigger()).not.toThrow()
+
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalledTimes(1))
+  })
+
+  it('no-ops safely when db.close() itself throws — logs via logger.error, does not hang, onDone still fires', async () => {
+    const closeError = new Error('database is locked')
+    const db = createMockDb(true)
+    db.close.mockImplementation(() => {
+      throw closeError
+    })
+    const onDone = vi.fn()
+    const trigger = createShutdownTrigger(onDone, () => db as unknown as DatabaseType)
+
+    const start = Date.now()
+    expect(() => trigger()).not.toThrow()
+    const elapsed = Date.now() - start
+
+    // closeDbOnShutdown is fully synchronous (try/catch, no await) and runs
+    // BEFORE the telemetry flush is even started, so a regression that made
+    // the close-on-error path hang (e.g. awaiting something inside the catch)
+    // would blow well past this bound. This is a distinct assertion from the
+    // telemetry flush's own 2000ms timeout bound (TELEMETRY_SHUTDOWN_FLUSH_TIMEOUT_MS) —
+    // it pins the SYNCHRONOUS close path specifically.
+    expect(elapsed).toBeLessThan(100)
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to close database'),
+      expect.objectContaining({ err: closeError })
+    )
+
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalledTimes(1))
+  })
+
+  it('same-instance reuse: calling the SAME trigger instance twice only closes the db once (db.open flips false after the first close)', async () => {
+    // Scope note: this test covers a single trigger closure being invoked
+    // twice (e.g. transport.onclose firing after a signal already fired the
+    // same registered listener). Cross-instance/racing-trigger scenarios —
+    // two INDEPENDENTLY created triggers firing concurrently (e.g. SIGTERM
+    // racing SIGINT) — are Wave 3's manual verification scope, not this test.
+    const db = createMockDb(true)
+    db.close.mockImplementation(() => {
+      db.open = false
+    })
+    const onDone = vi.fn()
+    const trigger = createShutdownTrigger(onDone, () => db as unknown as DatabaseType)
+
+    trigger()
+    trigger()
+
+    expect(db.close).toHaveBeenCalledTimes(1)
+
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalledTimes(2))
+  })
+})
+
+/**
+ * SMI-5639 Wave 2 Step 5: native-driver (better-sqlite3-shaped) regression
+ * coverage. `closeDbOnShutdown` must behave identically for a driver that
+ * has no persist-on-close semantics — a future refactor that special-cased
+ * WASM behavior here could otherwise silently break the native path the same
+ * way the original bug went unnoticed on WASM for months.
+ */
+describe('closeDbOnShutdown — native driver shape (SMI-5639 Wave 2 Step 5)', () => {
+  it('calls close() exactly once for a native-driver-shaped db (boolean-backed open getter, no persist side effects) and throws nothing', () => {
+    let isOpen = true
+    const nativeShapedDb = {
+      get open() {
+        return isOpen
+      },
+      close: vi.fn(() => {
+        isOpen = false
+      }),
+    }
+
+    expect(() => closeDbOnShutdown(() => nativeShapedDb as unknown as DatabaseType)).not.toThrow()
+    expect(nativeShapedDb.close).toHaveBeenCalledTimes(1)
+
+    // A second call (e.g. a racing trigger) must not call close() again now
+    // that `open` correctly reflects the closed state — same guard behavior
+    // as the WASM-shaped mocks above, confirming closeDbOnShutdown doesn't
+    // special-case either driver.
+    expect(() => closeDbOnShutdown(() => nativeShapedDb as unknown as DatabaseType)).not.toThrow()
+    expect(nativeShapedDb.close).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/mcp-server/src/shutdown.ts
+++ b/packages/mcp-server/src/shutdown.ts
@@ -19,9 +19,13 @@
  */
 
 import { shutdownPostHog } from '@skillsmith/core/telemetry'
+import type { DatabaseType } from '@skillsmith/core'
+import { createLogger } from '@skillsmith/core/logging'
 
 /** Bound on how long a shutdown flush may block process exit. */
 export const TELEMETRY_SHUTDOWN_FLUSH_TIMEOUT_MS = 2000
+
+const logger = createLogger('mcp')
 
 let shuttingDown = false
 
@@ -59,16 +63,63 @@ export function _resetShutdownGuardForTests(): void {
 }
 
 /**
- * Build a shutdown trigger: run {@link flushTelemetryOnShutdown} then call
- * `onDone` (index.ts passes `() => process.exit(0)`). Registering ANY
- * listener for SIGTERM/SIGINT overrides Node's default terminate-on-signal
- * behavior, so `index.ts` MUST call this for each of transport `onclose` /
- * SIGTERM / SIGINT to preserve today's default (process exits promptly on
- * those signals) rather than leaving the process hanging once a listener is
- * registered.
+ * Fail-soft, synchronous close of the tool-context database on shutdown.
+ *
+ * On the WASM (`sql.js`) driver, `close()` is the only thing that ever
+ * persists the in-memory database to disk (`sqljsDriver.ts`'s `close()` →
+ * `persist()` → `writeFileSync`) — see SMI-5639. Before this, nothing in the
+ * shutdown path ever called `close()`, so every write made during a session
+ * was silently discarded on normal exit.
+ *
+ * Never throws — a `getDb()` that itself throws, or a `close()` that
+ * throws, is caught and logged via `logger.error` (NOT `.debug`/`.info`,
+ * which are disk-only per SMI-5615 — a failed persist is a genuine
+ * data-loss event and must be visible on stderr, not silently swallowed the
+ * same way the original bug was invisible).
+ *
+ * Idempotent by construction: `db.open` reflects the driver's real closed
+ * state (both `SqlJsDatabaseAdapter` and `BetterSqlite3Database` expose a
+ * reliable `open` getter), so calling this twice — e.g. `transport.onclose`
+ * racing a signal — only calls `.close()` once. No separate module-level
+ * guard flag is needed.
+ *
+ * @param getDb - Lazy getter for the current db (late-bound, so it can read
+ *   a `toolContext` that isn't assigned yet at trigger-creation time).
  */
-export function createShutdownTrigger(onDone: () => void): () => void {
+export function closeDbOnShutdown(getDb?: () => DatabaseType | undefined): void {
+  try {
+    const db = getDb?.()
+    if (db && db.open) {
+      db.close()
+    }
+  } catch (error) {
+    logger.error(
+      '[skillsmith] Failed to close database on shutdown — recent writes may not be persisted',
+      { err: error }
+    )
+  }
+}
+
+/**
+ * Build a shutdown trigger: close the tool-context database (via
+ * {@link closeDbOnShutdown}, synchronously, so WASM-driver persistence isn't
+ * gated behind the telemetry flush's timeout), then run
+ * {@link flushTelemetryOnShutdown}, then call `onDone` (index.ts passes
+ * `() => process.exit(0)`). Registering ANY listener for SIGTERM/SIGINT
+ * overrides Node's default terminate-on-signal behavior, so `index.ts` MUST
+ * call this for each of transport `onclose` / SIGTERM / SIGINT to preserve
+ * today's default (process exits promptly on those signals) rather than
+ * leaving the process hanging once a listener is registered.
+ *
+ * @param getDb - Optional lazy getter for the current db, so shutdown can
+ *   close/persist it before the process exits (SMI-5639).
+ */
+export function createShutdownTrigger(
+  onDone: () => void,
+  getDb?: () => DatabaseType | undefined
+): () => void {
   return () => {
+    closeDbOnShutdown(getDb)
     void flushTelemetryOnShutdown().finally(onDone)
   }
 }

--- a/packages/mcp-server/tests/integration/shutdown-persistence.integration.test.ts
+++ b/packages/mcp-server/tests/integration/shutdown-persistence.integration.test.ts
@@ -1,0 +1,234 @@
+/**
+ * @fileoverview SMI-5639 Wave 2 Step 3 — exact-repro integration test (no subprocess).
+ *
+ * Reproduces the original bug end-to-end, in-process: install a real skill
+ * (via the actual `installSkill()` flow, network mocked per the
+ * `install.execution.integration.test.ts` pattern) whose SKILL.md genuinely
+ * references `mcp__*` tools, so dependency intelligence is written to
+ * `skill_dependencies` through the real `SkillInstallationService` ->
+ * `SkillDependencyRepository` path. Then invoke the REAL
+ * `createShutdownTrigger`/`closeDbOnShutdown` exports from `shutdown.ts`
+ * (not a reimplementation) against a real temp-file WASM (`sql.js`) database,
+ * and open a FRESH connection to the same file afterward to prove the write
+ * actually survived the close — this is the exact scenario SMI-5639
+ * describes: before the fix, nothing in the shutdown path ever called
+ * `db.close()`, so this assertion would fail (0 rows) against the
+ * unpatched `shutdown.ts`.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest'
+import * as os from 'os'
+import * as path from 'path'
+import * as fs from 'fs/promises'
+import { existsSync } from 'fs'
+import { createToolContextAsync, closeToolContext } from '../../src/context.js'
+import type { ToolContext } from '../../src/context.js'
+import { closeDbOnShutdown, flushTelemetryOnShutdown } from '../../src/shutdown.js'
+import { createTestFilesystem, type TestFilesystemContext } from './setup.js'
+
+// Same mocking seams as install.execution.integration.test.ts — this is the
+// only other integration file exercising the real installSkill() flow in
+// this suite, so the rationale below mirrors that file's header comment.
+vi.mock('../../src/tools/install.helpers.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../src/tools/install.helpers.js')>()
+  return {
+    ...actual,
+    lookupSkillFromRegistry: vi.fn(),
+    fetchFromGitHub: vi.fn(),
+  }
+})
+
+vi.mock('@skillsmith/core/services/skill-installation-io', async (importActual) => {
+  const actual = await importActual<Record<string, unknown>>()
+  return {
+    ...actual,
+    fetchFromGitHub: vi.fn(),
+    fetchAndScanOptionalFiles: vi.fn(),
+  }
+})
+
+vi.mock('@skillsmith/core/install', async (importActual) => {
+  const actual = await importActual<Record<string, unknown>>()
+  return {
+    ...actual,
+    resolveClientPath: vi.fn(),
+    getInstallPath: vi.fn(),
+  }
+})
+
+describe('SMI-5639: shutdown persistence — exact repro (integration, no subprocess)', () => {
+  const TEST_SKILL_ID = 'a129e127-a82c-47e5-8bc5-09d7ba2e8734'
+
+  // Genuine mcp__<server>__<tool> references, outside any fenced code block,
+  // so McpReferenceExtractor treats them as high-confidence (matches the
+  // real-world `linear` skill's SKILL.md referenced in the plan doc's
+  // Context section).
+  const SKILL_MD_WITH_MCP_REFS = [
+    '---',
+    'name: shutdown-persistence-fixture',
+    'description: SMI-5639 integration fixture skill with real mcp tool references',
+    '---',
+    '# Shutdown Persistence Fixture',
+    '',
+    'This skill calls mcp__linear__save_issue and mcp__linear__list_issues directly',
+    'to manage Linear issues without leaving the assistant session.',
+    '',
+    'It has enough body text to satisfy SKILL.md content-length validation checks',
+    'so the install proceeds all the way through dependency-intelligence persistence.',
+  ].join('\n')
+
+  let fsContext: TestFilesystemContext
+  let dbPath: string
+  let previousForceWasm: string | undefined
+
+  let installSkill: (typeof import('../../src/tools/install.js'))['installSkill']
+  let installInputSchema: (typeof import('../../src/tools/install.types.js'))['installInputSchema']
+  let lookupSkillFromRegistry: ReturnType<typeof vi.fn>
+  let fetchFromGitHub: ReturnType<typeof vi.fn>
+  let coreFetchFromGitHub: ReturnType<typeof vi.fn>
+  let coreFetchAndScanOptionalFiles: ReturnType<typeof vi.fn>
+  let resolveClientPath: ReturnType<typeof vi.fn>
+  let getInstallPath: ReturnType<typeof vi.fn>
+
+  beforeAll(async () => {
+    // Dynamic import after vi.mock() has been hoisted — mirrors
+    // install.execution.integration.test.ts's own beforeAll pattern.
+    const installModule = await import('../../src/tools/install.js')
+    installSkill = installModule.installSkill
+
+    const typesModule = await import('../../src/tools/install.types.js')
+    installInputSchema = typesModule.installInputSchema
+
+    const helpersModule = await import('../../src/tools/install.helpers.js')
+    lookupSkillFromRegistry = vi.mocked(helpersModule.lookupSkillFromRegistry)
+    fetchFromGitHub = vi.mocked(helpersModule.fetchFromGitHub)
+
+    const coreIoModule = await import('@skillsmith/core/services/skill-installation-io')
+    coreFetchFromGitHub = vi.mocked(coreIoModule.fetchFromGitHub as (...args: unknown[]) => unknown)
+    coreFetchAndScanOptionalFiles = vi.mocked(
+      coreIoModule.fetchAndScanOptionalFiles as (...args: unknown[]) => unknown
+    )
+
+    const coreInstallModule = await import('@skillsmith/core/install')
+    resolveClientPath = vi.mocked(
+      coreInstallModule.resolveClientPath as (...args: unknown[]) => unknown
+    )
+    getInstallPath = vi.mocked(coreInstallModule.getInstallPath as (...args: unknown[]) => unknown)
+  })
+
+  beforeEach(async () => {
+    fsContext = await createTestFilesystem()
+
+    // SMI-5639: force the WASM (sql.js) driver — this bug only manifests
+    // there, since only sqljsDriver's close() -> persist() ever writes to
+    // disk. Restored in afterEach so this test file can't leak the override
+    // into other test files sharing the same worker process.
+    previousForceWasm = process.env.SKILLSMITH_FORCE_WASM
+    process.env.SKILLSMITH_FORCE_WASM = 'true'
+
+    dbPath = path.join(
+      os.tmpdir(),
+      `skillsmith-shutdown-persistence-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+    )
+
+    vi.clearAllMocks()
+    resolveClientPath.mockReturnValue(fsContext.skillsDir)
+    getInstallPath.mockReturnValue(fsContext.skillsDir)
+    coreFetchAndScanOptionalFiles.mockResolvedValue({
+      configWarnings: [],
+      failedScans: [],
+      filesToWrite: [],
+    })
+  })
+
+  afterEach(async () => {
+    await fsContext.cleanup()
+    vi.restoreAllMocks()
+
+    if (previousForceWasm === undefined) {
+      delete process.env.SKILLSMITH_FORCE_WASM
+    } else {
+      process.env.SKILLSMITH_FORCE_WASM = previousForceWasm
+    }
+
+    try {
+      await fs.rm(dbPath, { force: true })
+    } catch {
+      // Best-effort cleanup — not test-critical.
+    }
+  })
+
+  it('persists skill_dependencies rows written before shutdown into a fresh connection reopened after close()', async () => {
+    // 1. Build a REAL ToolContext against a real temp-file WASM database.
+    //    Background sync / LLM failover / telemetry all stay off so this
+    //    context has no side effects beyond the db itself.
+    const context: ToolContext = await createToolContextAsync({
+      dbPath,
+      backgroundSyncConfig: { enabled: false },
+      apiClientConfig: { offlineMode: true },
+    })
+
+    let freshContext: ToolContext | undefined
+    try {
+      // 2. Install a skill with genuine mcp__* references through the REAL
+      //    installSkill() flow (network mocked), so skill_dependencies gets
+      //    written via the actual SkillInstallationService ->
+      //    SkillDependencyRepository path — the same path the original bug
+      //    silently discarded on every WASM-fallback session.
+      lookupSkillFromRegistry.mockResolvedValue({
+        repoUrl: 'https://github.com/owner/shutdown-persistence-fixture',
+        name: 'shutdown-persistence-fixture',
+        trustTier: 'community',
+        quarantined: false,
+      })
+      fetchFromGitHub.mockResolvedValue(SKILL_MD_WITH_MCP_REFS)
+      coreFetchFromGitHub.mockResolvedValue(SKILL_MD_WITH_MCP_REFS)
+
+      const result = await installSkill(
+        installInputSchema.parse({ skillId: TEST_SKILL_ID, skipScan: true, force: true }),
+        context
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.skillId).toBe(TEST_SKILL_ID)
+
+      // Anti-false-green: confirm the dependency rows actually landed in
+      // THIS (pre-shutdown) connection before we even test persistence —
+      // otherwise a failure below could just mean the install itself never
+      // wrote anything, not that shutdown failed to persist it.
+      const depsBeforeClose = context.skillDependencyRepository.getDependencies(TEST_SKILL_ID)
+      expect(depsBeforeClose.length).toBeGreaterThan(0)
+
+      // 3. Invoke the REAL shutdown path — closeDbOnShutdown (exactly what
+      //    createShutdownTrigger calls internally) plus flushTelemetryOnShutdown,
+      //    not a reimplementation. closeDbOnShutdown runs synchronously and,
+      //    for the WASM driver, IS what calls persist() -> writeFileSync.
+      closeDbOnShutdown(() => context.db)
+      await flushTelemetryOnShutdown()
+
+      expect(context.db.open).toBe(false)
+      expect(existsSync(dbPath)).toBe(true)
+
+      // 4. Open a FRESH connection against the same on-disk file — a
+      //    completely separate Database instance/process boundary in spirit
+      //    (mirrors sqljs-driver.test.ts's own "persist across open/close
+      //    cycles" pattern) — and confirm the dependency rows survived.
+      freshContext = await createToolContextAsync({
+        dbPath,
+        backgroundSyncConfig: { enabled: false },
+        apiClientConfig: { offlineMode: true },
+      })
+
+      const depsAfterReopen = freshContext.skillDependencyRepository.getDependencies(TEST_SKILL_ID)
+      expect(depsAfterReopen.length).toBeGreaterThan(0)
+      expect(depsAfterReopen.some((dep) => dep.dep_target.includes('linear'))).toBe(true)
+    } finally {
+      if (freshContext) {
+        await closeToolContext(freshContext)
+      }
+      // closeToolContext -> db.close() is idempotent (guarded by `_open` in
+      // both drivers) even though this context's db was already closed above.
+      await closeToolContext(context)
+    }
+  })
+})

--- a/packages/mcp-server/tests/shutdown-persistence-subprocess.test.ts
+++ b/packages/mcp-server/tests/shutdown-persistence-subprocess.test.ts
@@ -1,0 +1,186 @@
+/**
+ * SMI-5639 Wave 2 Step 4: End-to-end subprocess SIGTERM persistence check.
+ *
+ * Spawns the real BUILT `dist/src/index.js` binary (not source — mirrors
+ * `startup-probe.test.ts`'s own pattern, including its `beforeAll`
+ * build-if-absent gate and pre-push carve-out) against a temp WASM
+ * (`sql.js`) database, waits for it to report ready, sends a real `SIGTERM`,
+ * and asserts the temp DB file went from "does not exist" to "exists with
+ * non-zero size" as a direct result of the signal.
+ *
+ * This is the single most direct proof the fix works against the real
+ * binary: the WASM driver's `close()` is the only thing that ever calls
+ * `persist()` (`writeFileSync`), so the DB file does not exist AT ALL until
+ * the first successful close — before SMI-5639's fix, nothing in the
+ * shutdown path ever called `close()`, so this file would never appear no
+ * matter how long the server ran or how many writes it made.
+ */
+
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, statSync, rmSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import * as os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+const DIST_ENTRY = path.join(REPO_ROOT, 'packages', 'mcp-server', 'dist', 'src', 'index.js')
+
+// SMI-5548: mirrors startup-probe.test.ts's pre-push carve-out — a local
+// pre-push run has no built dist/ in a worktree (the build itself fails
+// there), so skip only in that exact combination. CI never sets
+// SKILLSMITH_PREPUSH, so it always builds dist and runs this suite for real.
+const skipInPrePush = process.env['SKILLSMITH_PREPUSH'] === '1' && !existsSync(DIST_ENTRY)
+if (skipInPrePush) {
+  console.warn(
+    '[SMI-5548] skipping shutdown-persistence subprocess test in pre-push (dist absent; covered by CI)'
+  )
+}
+
+describe.skipIf(skipInPrePush)('SMI-5639 shutdown persistence — subprocess SIGTERM', () => {
+  let tmpDbPath: string
+
+  beforeAll(() => {
+    // H9 pattern (startup-probe.test.ts): build mcp-server explicitly if dist
+    // is missing, fail loudly if it still isn't present afterwards. Ensures
+    // this test never silently runs against a stale binary.
+    if (!existsSync(DIST_ENTRY)) {
+      const build = spawnSync('npm', ['run', 'build', '--workspace=@skillsmith/mcp-server'], {
+        stdio: 'inherit',
+        cwd: REPO_ROOT,
+      })
+      if (build.status !== 0) {
+        throw new Error('mcp-server build failed in beforeAll')
+      }
+    }
+    if (!existsSync(DIST_ENTRY)) {
+      throw new Error(`Expected ${DIST_ENTRY} to exist after build`)
+    }
+  }, 120_000)
+
+  afterEach(() => {
+    if (tmpDbPath) {
+      try {
+        rmSync(tmpDbPath, { force: true })
+      } catch {
+        // Best-effort cleanup — not test-critical.
+      }
+    }
+  })
+
+  it('creates and persists the WASM database file to disk on SIGTERM shutdown', async () => {
+    tmpDbPath = path.join(
+      os.tmpdir(),
+      `skillsmith-shutdown-subprocess-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+    )
+
+    // Before boot: nothing has ever written to this path.
+    expect(existsSync(tmpDbPath)).toBe(false)
+
+    // IMPORTANT: stdin must stay an open pipe, NOT 'ignore'. `StdioServerTransport`
+    // (the MCP SDK) only listens for stdin 'data'/'error' — it never wires up
+    // 'end'/'close', so it does NOT call `onclose()` on stdin EOF. With
+    // `stdio: 'ignore'`, stdin is immediately at EOF, and — since nothing else
+    // keeps the event loop alive — the process exits NATURALLY (bypassing
+    // `shutdownAndExit` entirely) before this test ever gets to send SIGTERM,
+    // which would make this test pass/fail for the wrong reason (a race, not
+    // the shutdown-hook contract this test exists to verify). Keeping stdin
+    // open as a real pipe (and never calling `proc.stdin.end()`) keeps the
+    // child alive until the explicit SIGTERM below, exercising the REAL
+    // `process.on('SIGTERM', shutdownAndExit)` path.
+    const proc = spawn('node', [DIST_ENTRY], {
+      env: {
+        ...process.env,
+        SKILLSMITH_FORCE_WASM: 'true',
+        SKILLSMITH_DB_PATH: tmpDbPath,
+        SKILLSMITH_SKIP_SKILL_INSTALL: '1',
+        SKILLSMITH_AUTO_UPDATE_CHECK: 'false',
+        SKILLSMITH_TIER1_AUTOINSTALL_DISABLE: '1',
+        SKILLSMITH_AUDIT_EMAIL_DISABLE: '1',
+        SKILLSMITH_BACKGROUND_SYNC: 'false',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    const stderrChunks: string[] = []
+    const stdoutChunks: string[] = []
+    proc.stderr.on('data', (d: Buffer) => stderrChunks.push(d.toString()))
+    proc.stdout.on('data', (d: Buffer) => stdoutChunks.push(d.toString()))
+
+    try {
+      // 1. Wait for the server to report it's up and running.
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(
+            new Error(
+              `server boot timeout — stderr so far:\n${stderrChunks.join('')}\nstdout so far:\n${stdoutChunks.join('')}`
+            )
+          )
+        }, 60_000)
+        proc.stderr.on('data', (d: Buffer) => {
+          // SMI-5615: this exact stderr line is emitted via console.error in
+          // index.ts's main(), immediately after transport.connect().
+          if (d.toString().includes('Skillsmith MCP server running')) {
+            clearTimeout(timeout)
+            resolve()
+          }
+        })
+        proc.on('error', (err) => {
+          clearTimeout(timeout)
+          reject(err)
+        })
+        proc.on('exit', (code) => {
+          if (code !== null && code !== 0) {
+            clearTimeout(timeout)
+            reject(
+              new Error(
+                `mcp-server exited ${code} before reporting "running"; stderr:\n${stderrChunks.join('')}`
+              )
+            )
+          }
+        })
+      })
+
+      // 2. The server is fully booted (schema initialized in-memory), but the
+      //    WASM driver only ever calls persist() -> writeFileSync inside
+      //    close() — so the file must still not exist yet.
+      expect(existsSync(tmpDbPath)).toBe(false)
+
+      // 3. Send a real SIGTERM and wait for the process to actually exit —
+      //    this exercises the REAL process.on('SIGTERM', shutdownAndExit)
+      //    wiring in index.ts, not a mocked trigger call.
+      const exitCode = await new Promise<number | null>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(
+            new Error(
+              `process did not exit within 10s of SIGTERM — stderr:\n${stderrChunks.join('')}`
+            )
+          )
+        }, 10_000)
+        proc.on('exit', (code) => {
+          clearTimeout(timeout)
+          resolve(code)
+        })
+        proc.kill('SIGTERM')
+      })
+
+      // shutdownAndExit's onDone is `() => process.exit(0)` — a clean exit
+      // code confirms the shutdown trigger ran to completion rather than the
+      // process being force-killed by some other mechanism.
+      expect(exitCode).toBe(0)
+
+      // 4. The definitive assertion: this specific check fails before the
+      //    SMI-5639 fix (file never appears, no matter how the process
+      //    exits) and passes after it.
+      expect(existsSync(tmpDbPath)).toBe(true)
+      const stats = statSync(tmpDbPath)
+      expect(stats.size).toBeGreaterThan(0)
+    } finally {
+      if (proc.exitCode === null && proc.signalCode === null) {
+        proc.kill('SIGKILL')
+      }
+    }
+  }, 75_000)
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** The Skillsmith MCP server now correctly saves data before it shuts down. Previously, on the common case of a Mac or npx install running without native SQLite support, any skill you installed, dependency data, or sync history recorded during a session was silently thrown away the moment the server stopped — with no error, no warning, nothing. The server just quietly forgot everything from that session. This is now fixed: shutting down properly saves everything first.

**Quality bar:** Root-caused with a live repro on a real machine (22 installed skills, zero saved dependency records, confirmed the exact missing step in the code). Fix implemented, then adversarially tested by a separate pass whose only job was to try to break it — real signals sent to the real running server, races between multiple shutdown signals, a forced write failure, and a real native-database instance — all six attempts to break it failed, each with recorded proof. Five layers of automated tests added, including one that spawns the actual server binary and sends it a real shutdown signal.

**Found along the way:** while investigating, we found and fixed a related file-size issue during code review (details below), and filed four follow-ups that are deliberately NOT part of this fix: SMI-5640 (extra safety net against a hard crash/kill, due 2026-07-31), SMI-5641 (removing confirmed-dead duplicate code), SMI-5645 (a confirmed gap — skills installed before this fix still need a way to recover their lost data), and merged our own rediscovery of a known, unrelated worktree tooling bug (SMI-5644) into its original tracking issue (SMI-5635) rather than duplicating it.

**Net result:** Fully shipped and verified. This should publish out-of-cycle promptly after merge (it's an urgent data-integrity fix — see Technical detail) rather than waiting for the normal weekly release.

---

## Technical detail

### Root cause
`packages/mcp-server/src/shutdown.ts`'s `createShutdownTrigger()` flushed telemetry and exited, but never called `close()` on the database. On the WASM (`sql.js`) driver — the fallback used whenever native `better-sqlite3` isn't loaded, which the code's own log message calls "expected on direct macOS/npx installs" — `close()` is the *only* thing that ever persists the in-memory database to disk. Every other shutdown path (`transport.onclose`, SIGTERM, SIGINT) shared this same gap.

### Changes
- `packages/mcp-server/src/shutdown.ts`: new `closeDbOnShutdown()` helper + `createShutdownTrigger()` now takes a lazy db getter and closes the db synchronously before the telemetry flush. Failures are logged via `logger.error` (stderr-visible), not silently swallowed.
- `packages/mcp-server/src/index.ts`: one-line wiring change to pass `() => toolContext?.db` into the trigger.
- `packages/mcp-server/src/index.startup-helpers.ts` (new): extracted `handleDocsFlag()`/`ensureSkillsmithSkillInstalled()` out of `index.ts` — prettier's mandatory reflow of the trigger call site pushed `index.ts` to 502 lines, over the `audit:standards` 500-line gate; caught and fixed during governance review, not deferred.

### Test coverage (5 layers)
Unit tests (idempotency, native-driver non-regression, failure logging), a new integration test (real WASM db + real skill install + real close + fresh reopen asserting persisted rows), and a subprocess test spawning the real built binary and sending a real `SIGTERM`. Mutation-tested: confirmed each new test actually fails when the fix is removed.

### Adversarial verification (Wave 3)
Independently re-ran against the *built* binary, not just mocks: real SIGTERM against a real process (DB file goes from nonexistent to a valid 274KB SQLite file, ~28ms); racing/double signals (TERM+INT, TERM+TERM, INT+TERM — no double-close, no hang); a forced `close()` failure (read-only directory) — process still exits cleanly and the failure is visible on stderr; a real native `better-sqlite3` instance through the actual shipped code. All 6 checklist gates passed with recorded command output.

### CI / verification note
This worktree's own Docker container is broken for any cross-package module resolution (SMI-5635 — a virtiofs bind-mount bug affecting every worktree container on this machine, confirmed via `realpathSync` diagnosis, unrelated to this change). All local verification (`tsc --build`, `vitest run`, lint, prettier, `audit:standards`) was run from the host directly and is clean; the commit and this push both used explicitly user-approved hook bypasses (`--no-verify` / documented skip flags) for that reason, with the exact justification recorded in the commit message. CI runs on Linux and is unaffected by this macOS-Docker-Desktop-specific bug.

### Docs
- Plan (reviewed via `plan-review-skill`, 14 findings applied): `docs/internal/implementation/mcp-server-shutdown-db-persistence-fix.md`
- Governance code review (1 Medium found + fixed): `docs/internal/code_review/2026-07-10-smi-5639-mcp-shutdown-persistence-fix-review.md`
- CHANGELOG entry + CLAUDE.md troubleshooting row added.

Fixes SMI-5639