### PR TITLE
chore(release): bump mcp-server 0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32744,7 +32744,7 @@
       },
       "devDependencies": {
         "@skillsmith/core": "^0.11.0",
-        "@skillsmith/mcp-server": "^0.7.0",
+        "@skillsmith/mcp-server": "^0.7.1",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
         "vitest": "4.1.10"
@@ -33514,7 +33514,7 @@
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.7.0",
+        "@skillsmith/mcp-server": "^0.7.1",
         "@smithy/config-resolver": "4.6.7",
         "@smithy/core": "3.29.2",
         "@smithy/middleware-endpoint": "4.6.7",
@@ -33529,7 +33529,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.7.0"
+        "@skillsmith/mcp-server": "^0.7.1"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -33565,7 +33565,7 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@skillsmith/core": "^0.11.0",
-    "@skillsmith/mcp-server": "^0.7.0",
+    "@skillsmith/mcp-server": "^0.7.1",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",
     "vitest": "4.1.10"

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -50,7 +50,7 @@
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.7.0",
+    "@skillsmith/mcp-server": "^0.7.1",
     "@smithy/config-resolver": "4.6.7",
     "@smithy/core": "3.29.2",
     "@smithy/middleware-endpoint": "4.6.7",
@@ -62,7 +62,7 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.7.0"
+    "@skillsmith/mcp-server": "^0.7.1"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.7.1
+
 - **Fix**: MCP server now persists recently-installed skills and dependency data on shutdown when running without native SQLite support (common on macOS/npx installs) — previously all writes were silently discarded on exit. The server was missing a database close() call in its shutdown handler (SMI-5639).
 - **Fix**: reduced local quota-enforcement limits 10x (SMI-5558) — Community was 1,000/mo now 100/mo, Individual was 10,000/mo now 1,000/mo, Team was 100,000/mo now 10,000/mo. Added a `SKILLSMITH_ENFORCE_MCP_QUOTA` kill-switch (defaults to enforcing, matching prior unconditional-block behavior) so hard-blocking can be disabled without a redeploy.
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.7.0",
+  "version": "0.7.1",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -110,7 +110,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.7.0'
+const PACKAGE_VERSION = '0.7.1'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 const logger = createLogger('mcp', { version: PACKAGE_VERSION }) // SMI-5615
 import { installBundledSkills, installUserDocs } from './onboarding/install-assets.js'


### PR DESCRIPTION
## Summary

Out-of-cycle patch release for **@skillsmith/mcp-server 0.7.1**, per ADR-114's own carve-out for Urgent fixes — not waiting for the weekly (Sun 03:00 UTC) publish cadence.

**Why urgent**: SMI-5639 (PR #1815, merged) fixed a data-integrity bug where the MCP server silently discarded all SQLite writes on shutdown (WASM driver — the common path for macOS/npx installs). Every day this stays unpublished, real users on the currently-published 0.7.0 keep losing their skill dependency data on every server restart.

## Changes

- `packages/mcp-server`: 0.7.0 → 0.7.1 (patch)
- `PACKAGE_VERSION` constant in `index.ts` synced to match
- `CHANGELOG.md` entries (SMI-5639 fix + `[skip-impl-check]`-eligible mechanical bump)
- Workspace dependency ranges bumped in `packages/cli` and `packages/enterprise` (devDependency/peerDependency on `@skillsmith/mcp-server`)
- `package-lock.json` regenerated
- `server.json` version-synced (MCP registry)

[skip-impl-check]