### PR TITLE
ci(publish): fix MCP Registry OIDC audience mismatch (SMI-5651)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -609,11 +609,16 @@ jobs:
     # - SMI-4534: `mcp-publisher login github-oidc` for the MCP Registry publish step
     # - SMI-4540: npm trusted-publisher OIDC for the npm publish step (sole npm auth
     #   path; granular token revoked 2026-05-19)
+    # issues: write (SMI-5651) — required so the Annotate registry publish failure step's
+    # `gh issue create` fallback can actually file an issue; without it, that fallback
+    # itself failed (`Resource not accessible by integration`), doubly hiding every
+    # registry publish failure.
     # Job-scoped (not workflow-scoped) for least privilege. contents: read overrides
     # the workflow default of contents: write since this job does not push tags or releases.
     permissions:
       contents: read
       id-token: write
+      issues: write
     # SMI-4803: `!cancelled() &&` overrides GitHub Actions' implicit `success()`
     # check on `needs:`. Without it, when `publish-core` skips (because core is
     # already published), this job is auto-skipped before its `if:` is evaluated
@@ -736,6 +741,11 @@ jobs:
       # silently broke the env-var auth flow. Bump intentionally; SMI-4537 tracks drift
       # detection. Auth via GitHub Actions OIDC (`mcp-publisher login github-oidc`);
       # MCP_REGISTRY_TOKEN is no longer used.
+      # SMI-5651: v1.7.6+ is the minimum required version — upstream PR #1229 ("auth: bind
+      # GitHub OIDC token exchange to a per-deployment audience") changed the CLI to derive
+      # the OIDC `aud` claim from `--registry` (scheme+host) instead of a hardcoded
+      # `mcp-registry` constant, fixing an `invalid audience` failure on every publish.
+      # Pinned to v1.7.9 (latest as of 2026-05-12; no audience-relevant changes since v1.7.6).
       - name: Install mcp-publisher
         id: install-mcp-publisher
         if: steps.version-check.outputs.exists != 'true'
@@ -744,7 +754,7 @@ jobs:
         # issue is never filed and the outage is silent.
         continue-on-error: true
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.3/mcp-publisher_linux_amd64.tar.gz" | tar xz
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz" | tar xz
           chmod +x mcp-publisher
 
       - name: Login to MCP Registry (github-oidc)
@@ -770,6 +780,12 @@ jobs:
         if: |
           steps.version-check.outputs.exists != 'true' &&
           (steps.install-mcp-publisher.outcome == 'failure' || steps.registry-login.outcome == 'failure' || steps.registry-publish.outcome == 'failure' || steps.registry-publish.conclusion == 'skipped')
+        # SMI-5651: a transient `gh issue create` failure (API hiccup, rate-limit,
+        # drifted label) must not cascade into failing this job — that would block
+        # publish-cli/publish-skillsmith-cli via `needs:` and skip the mcp-server
+        # release tag/smoke, even though npm publish already succeeded.
+        # audit:allow-continue-on-error — see rationale above.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGE_VERSION: ${{ steps.version-check.outputs.package_version }}
@@ -805,7 +821,7 @@ jobs:
             --title "MCP Registry publish failed for @skillsmith/mcp-server@${PACKAGE_VERSION}" \
             --label "ci-failure" \
             --body-file "${BODY_FILE}" \
-            || echo "::warning::gh issue create failed; check Actions log"
+            || echo "::error::gh issue create failed — see step log"
           rm -f "${BODY_FILE}"
 
   # SMI-1319: Use pre-publish-check outputs to skip already-published packages


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed the MCP Registry publish step in `publish.yml`, which has been silently failing on every release since the registry started validating the OIDC audience claim more strictly. The step's own failure-notification fallback was also broken, so this outage had zero visibility until this investigation. Both are fixed now, without introducing a new risk: a bare fix to the notification fallback would have let a transient GitHub API hiccup cascade into failing the entire publish job (blocking sibling package publishes) — that failure mode was caught and avoided.

**Quality bar:** This is an ADR-109-gated infrastructure change (`.github/workflows/`) — went through SPARC research and a dedicated plan-review pass specifically scoped to this change (not just the broader plan doc it's part of) before any code was written. That review independently re-verified the version-pin fix against upstream, and caught the cascade-failure risk described above before it shipped.

**Found along the way:** none new — this PR is itself the fix for a finding (SMI-5651) surfaced during the SMI-5639 investigation.

**Net result:** Code fix is complete and ready to merge, but the issue itself (SMI-5651) stays "In Review," not "Done," until a real publish run is observed succeeding post-merge (weekly release cadence — may take up to a week) and the 14-version registry backlog is manually caught up. Both are tracked as explicit next steps, not silently assumed.

---

## Technical detail

- `.github/workflows/publish.yml`, `publish-mcp-server` job only:
  - Bumped pinned `mcp-publisher` from v1.7.3 to v1.7.9 (min v1.7.6 required — upstream PR #1229 changed OIDC audience derivation from a hardcoded constant to the `--registry` URL)
  - Added `issues: write` to the job's permissions block (needed for the Annotate step's `gh issue create` fallback to actually work)
  - Added `continue-on-error: true` to the Annotate step + changed its swallowed `::warning::` to a loud but non-cascading `::error::` — this is the fix for the cascade-failure risk found during dedicated review (a bare un-swallow without `continue-on-error` would fail the whole job on a transient issue-filing hiccup, blocking `publish-cli`/`publish-skillsmith-cli` via `needs:`)
  - Added the `# audit:allow-continue-on-error` marker for the new `continue-on-error: true` line (Check 21)
- Verified host-side (this worktree's container is in the unrelated SMI-5656 restart-loop bug): `npx prettier --check`, YAML syntax validation, and a direct run of `scripts/audit-standards.mjs` (73 passed, 0 failed, Check 21 explicitly green)
- Confirmed via diff inspection that only `publish-mcp-server` is touched — `publish-core`, `publish-cli`, `publish-skillsmith-cli`, `publish-enterprise`, `smoke-test`, `create-gh-release`, and workflow-level permissions are all untouched
- Plan: `docs/internal/implementation/mcp-shutdown-followup-hardening.md`, Wave D section (includes the dedicated review findings this PR implements)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)