### PR TITLE
fix(deps): remediate SMI-5652 code-scanning + Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -276,6 +276,46 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.19.tgz",
+      "integrity": "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/rss/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@astrojs/telemetry": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
@@ -4720,36 +4760,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@fastify/ajv-compiler": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.6.0.tgz",
-      "integrity": "sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.11.0",
-        "ajv-formats": "^2.1.1",
-        "fast-uri": "^2.0.0"
-      }
-    },
-    "node_modules/@fastify/ajv-compiler/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@fastify/cors": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-9.0.1.tgz",
@@ -4759,33 +4769,6 @@
       "dependencies": {
         "fastify-plugin": "^4.0.0",
         "mnemonist": "0.39.6"
-      }
-    },
-    "node_modules/@fastify/error": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
-      "integrity": "sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@fastify/fast-json-stringify-compiler": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.3.0.tgz",
-      "integrity": "sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-json-stringify": "^5.7.0"
-      }
-    },
-    "node_modules/@fastify/merge-json-schemas": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.1.1.tgz",
-      "integrity": "sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
       }
     },
     "node_modules/@fastify/send": {
@@ -11991,9 +11974,9 @@
       }
     },
     "node_modules/@vercel/backends/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14938,9 +14921,9 @@
       }
     },
     "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15876,17 +15859,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/avvio": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.4.0.tgz",
-      "integrity": "sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/error": "^3.3.0",
-        "fastq": "^1.17.1"
       }
     },
     "node_modules/axe-core": {
@@ -19316,22 +19288,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-json-stringify": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.16.1.tgz",
-      "integrity": "sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/merge-json-schemas": "^0.1.0",
-        "ajv": "^8.10.0",
-        "ajv-formats": "^3.0.1",
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^2.1.0",
-        "json-schema-ref-resolver": "^1.0.1",
-        "rfdc": "^1.2.0"
-      }
-    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -19426,52 +19382,10 @@
         "fxparser": "src/cli/cli.js"
       }
     },
-    "node_modules/fastify": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.29.1.tgz",
-      "integrity": "sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/ajv-compiler": "^3.5.0",
-        "@fastify/error": "^3.4.0",
-        "@fastify/fast-json-stringify-compiler": "^4.3.0",
-        "abstract-logging": "^2.0.1",
-        "avvio": "^8.3.0",
-        "fast-content-type-parse": "^1.1.0",
-        "fast-json-stringify": "^5.8.0",
-        "find-my-way": "^8.0.0",
-        "light-my-request": "^5.11.0",
-        "pino": "^9.0.0",
-        "process-warning": "^3.0.0",
-        "proxy-addr": "^2.0.7",
-        "rfdc": "^1.3.0",
-        "secure-json-parse": "^2.7.0",
-        "semver": "^7.5.4",
-        "toad-cache": "^3.3.0"
-      }
-    },
     "node_modules/fastify-plugin": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
       "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fastify/node_modules/fast-content-type-parse": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz",
-      "integrity": "sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -19696,41 +19610,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/find-my-way": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
-      "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-querystring": "^1.0.0",
-        "safe-regex2": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/find-my-way/node_modules/ret": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.4.3.tgz",
-      "integrity": "sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/find-my-way/node_modules/safe-regex2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-3.1.0.tgz",
-      "integrity": "sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ret": "~0.4.0"
       }
     },
     "node_modules/find-up": {
@@ -20595,9 +20474,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -22154,9 +22033,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -22200,16 +22089,6 @@
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)",
       "optional": true
-    },
-    "node_modules/json-schema-ref-resolver": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-1.0.1.tgz",
-      "integrity": "sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      }
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
@@ -22675,18 +22554,6 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
-      }
-    },
-    "node_modules/light-my-request": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.14.0.tgz",
-      "integrity": "sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "cookie": "^0.7.0",
-        "process-warning": "^3.0.0",
-        "set-cookie-parser": "^2.4.1"
       }
     },
     "node_modules/lightningcss": {
@@ -26198,23 +26065,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pino/node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/pipenet": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.0.tgz",
@@ -26574,10 +26424,20 @@
       "license": "MIT"
     },
     "node_modules/process-warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -26789,16 +26649,6 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -28207,13 +28057,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/seek-bzip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-2.0.0.tgz",
@@ -28293,13 +28136,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {
@@ -29833,9 +29676,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -31693,6 +31536,74 @@
         }
       }
     },
+    "node_modules/wdio-vscode-service/node_modules/@fastify/ajv-compiler": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.6.0.tgz",
+      "integrity": "sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.0.0"
+      }
+    },
+    "node_modules/wdio-vscode-service/node_modules/@fastify/ajv-compiler/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wdio-vscode-service/node_modules/@fastify/error": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
+      "integrity": "sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wdio-vscode-service/node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.3.0.tgz",
+      "integrity": "sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^5.7.0"
+      }
+    },
+    "node_modules/wdio-vscode-service/node_modules/@fastify/merge-json-schemas": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.1.1.tgz",
+      "integrity": "sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "node_modules/wdio-vscode-service/node_modules/avvio": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.4.0.tgz",
+      "integrity": "sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^3.3.0",
+        "fastq": "^1.17.1"
+      }
+    },
     "node_modules/wdio-vscode-service/node_modules/decamelize": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
@@ -31704,6 +31615,79 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wdio-vscode-service/node_modules/fast-content-type-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz",
+      "integrity": "sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wdio-vscode-service/node_modules/fast-json-stringify": {
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.16.1.tgz",
+      "integrity": "sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.1.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^3.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^2.1.0",
+        "json-schema-ref-resolver": "^1.0.1",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/wdio-vscode-service/node_modules/fastify": {
+      "version": "4.29.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.29.1.tgz",
+      "integrity": "sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^3.5.0",
+        "@fastify/error": "^3.4.0",
+        "@fastify/fast-json-stringify-compiler": "^4.3.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^8.3.0",
+        "fast-content-type-parse": "^1.1.0",
+        "fast-json-stringify": "^5.8.0",
+        "find-my-way": "^8.0.0",
+        "light-my-request": "^5.11.0",
+        "pino": "^9.0.0",
+        "process-warning": "^3.0.0",
+        "proxy-addr": "^2.0.7",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.7.0",
+        "semver": "^7.5.4",
+        "toad-cache": "^3.3.0"
+      }
+    },
+    "node_modules/wdio-vscode-service/node_modules/find-my-way": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+      "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/wdio-vscode-service/node_modules/get-port": {
@@ -31718,6 +31702,62 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/wdio-vscode-service/node_modules/json-schema-ref-resolver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-1.0.1.tgz",
+      "integrity": "sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "node_modules/wdio-vscode-service/node_modules/light-my-request": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.14.0.tgz",
+      "integrity": "sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^0.7.0",
+        "process-warning": "^3.0.0",
+        "set-cookie-parser": "^2.4.1"
+      }
+    },
+    "node_modules/wdio-vscode-service/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wdio-vscode-service/node_modules/ret": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.4.3.tgz",
+      "integrity": "sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/wdio-vscode-service/node_modules/safe-regex2": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-3.1.0.tgz",
+      "integrity": "sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.4.0"
+      }
+    },
+    "node_modules/wdio-vscode-service/node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/wdio-vscode-service/node_modules/slash": {
       "version": "5.1.0",
@@ -32779,39 +32819,6 @@
         "node": ">=14"
       }
     },
-    "packages/cli/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.6",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.1.6",
-        "vitest": "4.1.6"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "packages/cli/node_modules/@vitest/expect": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
@@ -33256,39 +33263,6 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
-    "packages/doc-retrieval-mcp/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.6",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.1.6",
-        "vitest": "4.1.6"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "packages/doc-retrieval-mcp/node_modules/@vitest/expect": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
@@ -33582,39 +33556,6 @@
       },
       "engines": {
         "node": ">=22.22.0"
-      }
-    },
-    "packages/mcp-server/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.6",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.1.6",
-        "vitest": "4.1.6"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
       }
     },
     "packages/mcp-server/node_modules/@vitest/expect": {
@@ -34113,28 +34054,6 @@
         "node": ">=22.22.0"
       }
     },
-    "packages/website/node_modules/@astrojs/rss": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
-      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-parser": "^5.5.7",
-        "piccolore": "^0.1.3",
-        "zod": "^4.3.6"
-      }
-    },
-    "packages/website/node_modules/@astrojs/sitemap": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
-      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
-      "license": "MIT",
-      "dependencies": {
-        "sitemap": "^9.0.0",
-        "stream-replace-string": "^2.0.0",
-        "zod": "^4.3.6"
-      }
-    },
     "packages/website/node_modules/@supabase/auth-js": {
       "version": "2.108.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.1.tgz",
@@ -34261,39 +34180,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "packages/website/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.6",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.1.6",
-        "vitest": "4.1.6"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
       }
     },
     "packages/website/node_modules/@vitest/expect": {
@@ -34735,15 +34621,6 @@
       "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "packages/website/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -121,6 +121,16 @@
     "global-agent": "^4.1.3",
     "fast-uri": "^3.1.1",
     "tar": "^7.5.8",
+    "js-yaml": "^4.2.0",
+    "gray-matter": {
+      "js-yaml": "^3.15.0"
+    },
+    "@yarnpkg/parsers": {
+      "js-yaml": "^3.15.0"
+    },
+    "mocha": {
+      "serialize-javascript": "^7.0.5"
+    },
     "h3": "^1.15.9",
     "tmp": "^0.2.6",
     "hono": "^4.12.21",
@@ -158,7 +168,8 @@
       "smol-toml": "^1.6.1"
     },
     "@vercel/backends": {
-      "srvx": "^0.11.13"
+      "srvx": "^0.11.13",
+      "js-yaml": "^3.15.0"
     },
     "@vercel/rust": {
       "smol-toml": "^1.6.1"


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed 5 of 9 open GitHub security alerts via dependency-lockfile overrides (js-yaml DoS, serialize-javascript RCE/DoS, tar file-smuggling); the remaining 4 are being dismissed with a written justification after this PR merges — 2 CodeQL false positives in a test file, and 2 fastify alerts where the safe fix isn't available upstream yet.

**Quality bar:** Plan authored, then independently plan-reviewed (VP Product/Engineering/Design via `plan-review-skill`, 13 findings applied — including catching that this plan's original "no production code paths" claim was wrong). Each fix implemented by a dedicated worker, then independently re-verified by an adversarial Opus review pass before this push — including a live grep of `wdio-vscode-service`'s own source to confirm the fastify dismissal's "not reachable" claim actually holds.

**Found along the way:** shared `node_modules` in this environment has a pre-existing, unrelated corruption (a macOS binary sitting in the Linux `esbuild` slot, most likely from a concurrent session's raw host `npm install`) that intermittently breaks local build/test/typecheck across every active worktree — filed separately as SMI-5655, not fixed here since it's out of scope and risky to touch with several other sessions running against the same shared tree concurrently.

**Net result:** Dependency fixes are complete and pushed; CI is the authoritative verification given the local environment noise above. The 2 CodeQL + 2 fastify Dependabot dismissals execute after this PR merges (external GitHub-state mutations, sequenced after review rather than before, per the plan).

---

## Technical detail

- `package.json`/`package-lock.json` — scoped `overrides`:
  - `tar` unchanged (existing `^7.5.8` override already covered the patch; pure lockfile regen: 7.5.13 → 7.5.19)
  - `js-yaml: ^4.2.0` (top-level + `@vercel/python-analysis`'s exact pin) + scoped `^3.15.0` for `gray-matter`/`@vercel/backends`/`@yarnpkg/parsers` (kept off the breaking v4 API) — resolved 4.3.0 / 3.15.0
  - `mocha: { serialize-javascript: ^7.0.5 }` — resolved 7.0.7; mocha's own release caps at `^6.0.2` so a forced override was required
  - `wdio-vscode-service: { fastify: ^5.8.3 }` attempted, then reverted — `@fastify/cors@^9.0.1`/`@fastify/static@^7.0.4` (wdio-vscode-service's own pins) predate fastify-5 support
- Plan: `docs/internal/implementation/security-alert-remediation-july-2026.md`
- Linear: SMI-5652
- `docs/internal` pointer bump (separate commit) to include the plan doc

**Post-merge steps** (queen-executed, not part of this diff):
1. Dismiss CodeQL #110/#111 (`used in tests`)
2. Dismiss Dependabot #161/#166 (`not_used`, fastify)
3. File a Linear follow-up tracking re-check once `wdio-vscode-service` ships fastify-5 support

**Local verification caveat:** local build/typecheck/vitest were unreliable during this PR due to the SMI-5655 environment corruption (confirmed via direct binary inspection, unrelated to this diff) — several checks were bypassed locally with explicit sign-off, on the basis that CI runs in a clean environment and is the real gate here. Do not merge on red CI.

[skip-impl-check] — dependency-manifest-only change (package.json overrides + package-lock.json regen), no application source code. User-authorized after investigating the check's own source (scripts/ci/verify-implementation.ts): package.json/package-lock.json are categorized as "config" by design, and this marker is the documented path for a genuine config-only SMI-referencing PR.
