### PR TITLE
fix(mcp-server): backfill skill_dependencies for pre-0.7.1 installs (SMI-5645)

### DIFF
--- a/packages/core/src/services/skill-installation.helpers.ts
+++ b/packages/core/src/services/skill-installation.helpers.ts
@@ -83,15 +83,27 @@ export function extractDepIntel(skillMdContent: string): DepIntelResult {
   }
 }
 
+/**
+ * Extract + persist dependency intelligence for a skill.
+ *
+ * @returns The number of dependency rows written (inserted or upserted) this
+ *   call — i.e. `merged.length`. Because `SkillDependencyRepository.setDependencies`
+ *   upserts on (skill_id, dep_type, dep_target, dep_source), calling this
+ *   repeatedly with the same skillId/content is idempotent: the count
+ *   reflects the size of the currently-extracted dependency set on every
+ *   call, not a cumulative "newly inserted since last call" delta. Callers
+ *   that need a per-run backfill count (SMI-5645) can rely on this return
+ *   value directly.
+ */
 export function persistDependencies(
   repo: SkillDependencyRepository,
   skillId: string,
   content: string,
   declared: DepIntelResult['dep_declared']
-): void {
+): number {
   const mcpResult = extractMcpReferences(content)
   const merged = mergeDependencies(declared, mcpResult)
-  if (merged.length === 0) return
+  if (merged.length === 0) return 0
 
   const rows: SkillDependencyRow[] = merged.map((dep) => ({
     skill_id: skillId,
@@ -113,6 +125,8 @@ export function persistDependencies(
   for (const [source, sourceRows] of bySource) {
     repo.setDependencies(skillId, sourceRows, source as SkillDependencyRow['dep_source'])
   }
+
+  return rows.length
 }
 
 /** Perform skill uninstall with manifest awareness and orphan fallback. */

--- a/packages/mcp-server/src/tool-dispatch.ts
+++ b/packages/mcp-server/src/tool-dispatch.ts
@@ -228,7 +228,16 @@ export async function dispatchToolCall(
       if (!parsed.ok) return parsed.response
       // SMI-5358: pass QuarantineRepository so over-threshold findings are persisted
       const quarantineRepo = new QuarantineRepository(toolContext.db)
-      return ok(await executeSkillRescan(parsed.data, undefined, quarantineRepo))
+      // SMI-5645: pass SkillDependencyRepository so skill_dependencies rows
+      // are backfilled for skills installed before the SMI-5639 fix shipped
+      return ok(
+        await executeSkillRescan(
+          parsed.data,
+          undefined,
+          quarantineRepo,
+          toolContext.skillDependencyRepository
+        )
+      )
     }
 
     // SMI-5392: inventory_push returns a CallToolResult directly (success or

--- a/packages/mcp-server/src/tools/skill-rescan.helpers.ts
+++ b/packages/mcp-server/src/tools/skill-rescan.helpers.ts
@@ -1,0 +1,162 @@
+/**
+ * @fileoverview Helpers for the skill_rescan MCP tool -- dependency backfill.
+ * @module @skillsmith/mcp-server/tools/skill-rescan.helpers
+ * @see SMI-5645: `skill_rescan` never backfilled `skill_dependencies` for
+ *   skills installed before the SMI-5639 dependency-persistence fix shipped
+ *   (`@skillsmith/mcp-server@0.7.1`). Skills installed before that release
+ *   have zero `skill_dependencies` rows and, absent this backfill, always
+ *   would.
+ *
+ * Split from skill-rescan.ts to stay under the repo's 500-line file-size
+ * gate (`audit:standards`), following the established `foo.ts`/`foo.helpers.ts`
+ * split convention used elsewhere in this directory (e.g. install.helpers.ts,
+ * validate.helpers.ts).
+ */
+
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import type { SkillDependencyRepository } from '@skillsmith/core'
+import {
+  extractDepIntel,
+  persistDependencies,
+} from '@skillsmith/core/services/skill-installation-helpers'
+
+/**
+ * Discover installed skill directories under ~/.claude/skills/.
+ *
+ * Skills are installed as either:
+ *   - ~/.claude/skills/{skillName}/SKILL.md
+ *   - ~/.claude/skills/{author}/{skillName}/SKILL.md
+ *
+ * Returns an array of { name, skillMdPath } objects.
+ *
+ * Moved here from skill-rescan.ts (SMI-5645) purely to keep that file under
+ * the 500-line file-size gate -- no behavior change.
+ */
+export async function discoverInstalledSkills(
+  skillsDir: string
+): Promise<Array<{ name: string; skillMdPath: string }>> {
+  const results: Array<{ name: string; skillMdPath: string }> = []
+
+  let entries: string[]
+  try {
+    entries = await fs.readdir(skillsDir)
+  } catch {
+    return results
+  }
+
+  for (const entry of entries) {
+    const entryPath = join(skillsDir, entry)
+    const stat = await fs.stat(entryPath).catch(() => null)
+    if (!stat?.isDirectory()) continue
+
+    // Check for SKILL.md directly in this directory
+    const directSkillMd = join(entryPath, 'SKILL.md')
+    const directExists = await fs
+      .access(directSkillMd)
+      .then(() => true)
+      .catch(() => false)
+
+    if (directExists) {
+      results.push({ name: entry, skillMdPath: directSkillMd })
+      continue
+    }
+
+    // Check for author/skill-name subdirectories
+    const subEntries = await fs.readdir(entryPath).catch(() => [] as string[])
+    for (const subEntry of subEntries) {
+      const subPath = join(entryPath, subEntry)
+      const subStat = await fs.stat(subPath).catch(() => null)
+      if (!subStat?.isDirectory()) continue
+
+      const nestedSkillMd = join(subPath, 'SKILL.md')
+      const nestedExists = await fs
+        .access(nestedSkillMd)
+        .then(() => true)
+        .catch(() => false)
+
+      if (nestedExists) {
+        results.push({
+          name: `${entry}/${subEntry}`,
+          skillMdPath: nestedSkillMd,
+        })
+      }
+    }
+  }
+
+  return results
+}
+
+/**
+ * Backfill `skill_dependencies` rows for one installed skill by re-running
+ * the SAME extraction+persistence pipeline SMI-5639 added at install time
+ * (`extractDepIntel()` + `persistDependencies()`,
+ * `packages/core/src/services/skill-installation.helpers.ts`), against the
+ * skill's SKILL.md content as read by the caller.
+ *
+ * ## Design decision: reflects CURRENT SKILL.md, not historical install-time state
+ *
+ * There is no historical snapshot of a skill's SKILL.md as it existed at
+ * original-install time -- capturing that is precisely the gap SMI-5645
+ * exists to close. This function therefore necessarily reads whatever
+ * content the caller currently has on disk, not a reconstruction of what
+ * would have been extracted at install time. **This is intentional,
+ * best-effort behavior, not a bug**: if a skill's SKILL.md was edited (or
+ * deleted and reinstalled with different content) between original install
+ * and this rescan, the backfilled rows reflect the file's CURRENT content.
+ * Callers surfacing the returned count (see `dependenciesBackfilled` /
+ * `totalDependenciesBackfilled` on `SkillRescanEntry`/`SkillRescanResponse`)
+ * must not present it as if it reconstructed original-install-time
+ * dependency data.
+ *
+ * ## Idempotency
+ *
+ * `persistDependencies` upserts on (skill_id, dep_type, dep_target,
+ * dep_source), so calling this repeatedly against the same skillId/content
+ * does not accumulate duplicate `skill_dependencies` rows -- the returned
+ * count reflects the size of the CURRENTLY-extracted dependency set on every
+ * call, not a cumulative "new since last run" delta. A skill rescanned 10
+ * times in a row reports the same non-zero count every time while the
+ * underlying table holds a constant row count.
+ *
+ * ## Failure containment
+ *
+ * Best-effort: any error (malformed content, DB error, missing table) is
+ * swallowed and reported as zero dependencies backfilled -- mirroring the
+ * install-time call site's own best-effort `try`/`catch` around
+ * `persistDependencies` (`skill-installation.service.ts`, ~lines 374-380) so
+ * a dependency-extraction failure for one skill never fails the security
+ * rescan itself, for that skill or any other.
+ *
+ * @param repo    Dependency repository to persist into. When undefined (no
+ *                DB-backed context available to the caller), returns 0
+ *                without attempting extraction -- mirrors `quarantineRepo`'s
+ *                existing optional/backward-compatible pattern in this tool.
+ * @param skillId Canonical identity key for the scanned skill. skill_rescan
+ *                has no manifest access and operates purely off the
+ *                filesystem, so this is the tool's own local identity key
+ *                (`local/${canonicalName}`, matching the quarantine key
+ *                already used elsewhere in this tool) -- NOT necessarily the
+ *                original registry `owner/repo` skillId used at install
+ *                time, which this tool cannot recover from disk alone.
+ * @param content Currently-installed SKILL.md content (already read from
+ *                disk by the caller; this function performs no I/O).
+ * @returns Number of dependency rows written (inserted or upserted) for this
+ *          skill during this call. 0 on error, missing repo, or when no
+ *          dependencies are detected.
+ */
+export function backfillSkillDependencies(
+  repo: SkillDependencyRepository | undefined,
+  skillId: string,
+  content: string
+): number {
+  if (!repo) return 0
+  try {
+    const depIntel = extractDepIntel(content)
+    return persistDependencies(repo, skillId, content, depIntel.dep_declared)
+  } catch {
+    // Best-effort -- a dependency-extraction/persistence failure must never
+    // fail the security rescan itself (mirrors the install-time try/catch).
+    return 0
+  }
+}

--- a/packages/mcp-server/src/tools/skill-rescan.test.ts
+++ b/packages/mcp-server/src/tools/skill-rescan.test.ts
@@ -1,12 +1,16 @@
 /**
  * @fileoverview Unit tests for skill_rescan MCP tool
  * @see SMI-3511: GAP-08 re-scan installed skills with current patterns
+ * @see SMI-5645: dependency backfill for skills installed before the
+ *   SMI-5639 dependency-persistence fix shipped.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { promises as fs } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import { SkillDependencyRepository, type Database } from '@skillsmith/core'
+import { createTestDatabase, closeDatabase } from '@skillsmith/core/testkit'
 import { executeSkillRescan, discoverInstalledSkills } from './skill-rescan.js'
 
 // ============================================================================
@@ -299,5 +303,205 @@ describe('executeSkillRescan', () => {
     const bad = result.results.find((r: any) => r.skill === 'bad-skill')
     expect(good?.passed).toBe(true)
     expect(bad?.passed).toBe(false)
+  })
+})
+
+// ============================================================================
+// Tests: dependency backfill (SMI-5645)
+//
+// skill_rescan never backfilled `skill_dependencies` for skills installed
+// before the SMI-5639 dependency-persistence fix shipped
+// (@skillsmith/mcp-server@0.7.1) -- these skills have zero dependency rows
+// and, absent this backfill, always would. See
+// packages/mcp-server/src/tools/skill-rescan.helpers.ts::backfillSkillDependencies
+// for the full design rationale.
+// ============================================================================
+
+describe('executeSkillRescan → dependency backfill (SMI-5645)', () => {
+  let skillsDir: string
+  let db: Database
+  let depRepo: SkillDependencyRepository
+
+  beforeEach(async () => {
+    skillsDir = await createTempSkillsDir()
+    db = await createTestDatabase()
+    depRepo = new SkillDependencyRepository(db)
+  })
+
+  afterEach(async () => {
+    closeDatabase(db)
+    await fs.rm(skillsDir, { recursive: true, force: true })
+  })
+
+  /** SKILL.md whose prose references an MCP tool -- extractable as an inferred dependency. */
+  function skillWithMcpRef(name: string): string {
+    return `---
+name: ${name}
+description: A skill that references the Linear MCP server
+version: "1.0.0"
+---
+
+# ${name}
+
+Call \`mcp__linear__save_issue\` to file an issue.
+`
+  }
+
+  // --------------------------------------------------------------------------
+  // Pre-0.7.1-shaped fixture: installed skill, zero skill_dependencies rows
+  // --------------------------------------------------------------------------
+
+  it('backfills skill_dependencies rows for a pre-0.7.1-shaped fixture (zero existing rows)', async () => {
+    await writeSkill(skillsDir, 'uses-linear', skillWithMcpRef('uses-linear'))
+
+    // Precondition: simulates a skill installed before SMI-5639 shipped --
+    // no dependency rows exist yet even though the skill is installed.
+    expect(depRepo.getDependencies('local/uses-linear')).toHaveLength(0)
+
+    const result = await executeSkillRescan({}, skillsDir, undefined, depRepo)
+
+    expect(result.scannedCount).toBe(1)
+    const entry = result.results[0]
+    expect(entry.dependenciesBackfilled).toBeGreaterThan(0)
+    expect(result.totalDependenciesBackfilled).toBe(entry.dependenciesBackfilled)
+
+    const rows = depRepo.getDependencies('local/uses-linear')
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows.some((r) => r.dep_target === 'linear')).toBe(true)
+  })
+
+  // --------------------------------------------------------------------------
+  // Idempotency: re-run must not accumulate duplicate rows
+  // --------------------------------------------------------------------------
+
+  it('is idempotent: re-running the rescan does not create duplicate rows', async () => {
+    await writeSkill(skillsDir, 'uses-linear', skillWithMcpRef('uses-linear'))
+
+    const first = await executeSkillRescan({}, skillsDir, undefined, depRepo)
+    const rowsAfterFirst = depRepo.getDependencies('local/uses-linear')
+    expect(rowsAfterFirst.length).toBeGreaterThan(0)
+
+    const second = await executeSkillRescan({}, skillsDir, undefined, depRepo)
+    const rowsAfterSecond = depRepo.getDependencies('local/uses-linear')
+
+    // Real DB state: row count must not double on the second run.
+    expect(rowsAfterSecond.length).toBe(rowsAfterFirst.length)
+    // The per-run count is reported the same both times -- upsert semantics,
+    // not a cumulative "new since last run" delta.
+    expect(second.results[0].dependenciesBackfilled).toBe(first.results[0].dependenciesBackfilled)
+  })
+
+  // --------------------------------------------------------------------------
+  // Failure containment: one skill's backfill error must not affect others
+  // or fail the security scan itself
+  // --------------------------------------------------------------------------
+
+  it('contains a dependency-persistence failure to the affected skill only', async () => {
+    await writeSkill(skillsDir, 'good-skill', skillWithMcpRef('good-skill'))
+    await writeSkill(skillsDir, 'throws-skill', skillWithMcpRef('throws-skill'))
+
+    const originalSetDependencies = depRepo.setDependencies.bind(depRepo)
+    const setDependenciesSpy = vi
+      .spyOn(depRepo, 'setDependencies')
+      .mockImplementation((skillId, deps, source) => {
+        if (skillId === 'local/throws-skill') {
+          throw new Error('simulated dependency persistence failure')
+        }
+        originalSetDependencies(skillId, deps, source)
+      })
+
+    const result = await executeSkillRescan({}, skillsDir, undefined, depRepo)
+
+    // The scan itself is completely unaffected by the backfill failure.
+    expect(result.scannedCount).toBe(2)
+    expect(result.failedCount).toBe(0)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const good = result.results.find((r: any) => r.skill === 'good-skill')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const throwsEntry = result.results.find((r: any) => r.skill === 'throws-skill')
+
+    expect(good?.passed).toBe(true)
+    expect(good?.dependenciesBackfilled).toBeGreaterThan(0)
+
+    // The failing skill's scan result is unaffected -- error is contained to
+    // the backfill step, not surfaced as a scan `error`.
+    expect(throwsEntry?.passed).toBe(true)
+    expect(throwsEntry?.error).toBeUndefined()
+    expect(throwsEntry?.dependenciesBackfilled).toBe(0)
+
+    expect(result.totalDependenciesBackfilled).toBe(good?.dependenciesBackfilled)
+
+    setDependenciesSpy.mockRestore()
+  })
+
+  // --------------------------------------------------------------------------
+  // Stale-SKILL.md-since-install: backfill reflects CURRENT content, not a
+  // historical/original-install-time snapshot (resolved during plan-review)
+  // --------------------------------------------------------------------------
+
+  it('backfills against the CURRENT SKILL.md when content changed since original install', async () => {
+    const originalContent = `---
+name: stale-skill
+description: Originally referenced no MCP servers
+version: "1.0.0"
+---
+
+# Stale Skill
+
+Nothing special here at original-install time.
+`
+    await writeSkill(skillsDir, 'stale-skill', originalContent)
+
+    // Precondition: simulates original-install-time state (pre-0.7.1) --
+    // zero dependency rows, regardless of content.
+    expect(depRepo.getDependencies('local/stale-skill')).toHaveLength(0)
+
+    // SKILL.md is edited AFTER original install, before this rescan runs --
+    // there is no historical snapshot of the original content available to
+    // the backfill (that data was never captured; recovering it is exactly
+    // the gap SMI-5645 closes).
+    await writeSkill(skillsDir, 'stale-skill', skillWithMcpRef('stale-skill'))
+
+    const result = await executeSkillRescan({}, skillsDir, undefined, depRepo)
+
+    const entry = result.results[0]
+    // Backfill succeeds against the CURRENT (edited) content -- this is the
+    // documented best-effort behavior, not a correctness bug.
+    expect(entry.dependenciesBackfilled).toBeGreaterThan(0)
+    const rows = depRepo.getDependencies('local/stale-skill')
+    expect(rows.some((r) => r.dep_target === 'linear')).toBe(true)
+  })
+
+  // --------------------------------------------------------------------------
+  // Backward-compat: no SkillDependencyRepository supplied
+  // --------------------------------------------------------------------------
+
+  it('does not attempt backfill when no SkillDependencyRepository is supplied', async () => {
+    await writeSkill(skillsDir, 'uses-linear', skillWithMcpRef('uses-linear'))
+
+    // 2-arg call, matching the tool's original signature before SMI-5645.
+    const result = await executeSkillRescan({}, skillsDir)
+
+    expect(result.results[0].dependenciesBackfilled).toBe(0)
+    expect(result.totalDependenciesBackfilled).toBe(0)
+  })
+
+  // --------------------------------------------------------------------------
+  // "Skill not found" early-return path still carries the new aggregate field
+  // --------------------------------------------------------------------------
+
+  it('includes totalDependenciesBackfilled: 0 on the "skill not found" error path', async () => {
+    await writeSkill(skillsDir, 'existing-skill', skillWithMcpRef('existing-skill'))
+
+    const result = await executeSkillRescan(
+      { skillName: 'nonexistent' },
+      skillsDir,
+      undefined,
+      depRepo
+    )
+
+    expect(result.error).toBeDefined()
+    expect(result.totalDependenciesBackfilled).toBe(0)
   })
 })

--- a/packages/mcp-server/src/tools/skill-rescan.ts
+++ b/packages/mcp-server/src/tools/skill-rescan.ts
@@ -3,6 +3,10 @@
  * SecurityScanner patterns.
  * @module @skillsmith/mcp-server/tools/skill-rescan
  * @see SMI-3511: GAP-08 No re-scanning of installed skills
+ * @see SMI-5645: dependency backfill for skills installed before the SMI-5639
+ *   dependency-persistence fix shipped (`@skillsmith/mcp-server@0.7.1`) --
+ *   see `backfillSkillDependencies` in `./skill-rescan.helpers.ts` for the
+ *   full design rationale (current-vs-historical SKILL.md, idempotency).
  *
  * When new detection patterns are added (SSRF, split-word, homoglyph, etc.),
  * already-installed skills are never re-evaluated. This tool fills that gap
@@ -11,12 +15,18 @@
 
 import { z } from 'zod'
 import { promises as fs } from 'fs'
-import { join, dirname } from 'path'
-import { SecurityScanner, QuarantineRepository, type QuarantineSeverity } from '@skillsmith/core'
+import { dirname } from 'path'
+import {
+  SecurityScanner,
+  QuarantineRepository,
+  type QuarantineSeverity,
+  type SkillDependencyRepository,
+} from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 import { resolveClientPath } from '@skillsmith/core/install'
 import { scanLocalBundleSiblings } from '@skillsmith/core/services/bundled-sibling-scan'
 import { parseFrontmatter } from '../indexer/FrontmatterParser.js'
+import { backfillSkillDependencies, discoverInstalledSkills } from './skill-rescan.helpers.js'
 
 // ============================================================================
 // Input / Output types
@@ -83,6 +93,21 @@ export interface SkillRescanEntry {
   }
   /** Error message if skill could not be read */
   error?: string
+  /**
+   * SMI-5645: number of `skill_dependencies` rows written (inserted or
+   * upserted) for this skill during this rescan. Reflects the CURRENTLY
+   * installed SKILL.md content, not a historical/original-install-time
+   * snapshot -- there is no such snapshot to recover (that gap is exactly
+   * what this backfill closes). A skill whose SKILL.md was edited since
+   * install backfills against the edited content; this is intentional,
+   * best-effort behavior, not a correctness bug. Idempotent: rescanning the
+   * same skill repeatedly reports the same non-zero count each time without
+   * accumulating duplicate rows (see `backfillSkillDependencies` in
+   * `./skill-rescan.helpers.ts`). Always `0` when no dependency repository
+   * is supplied to the scan, on extraction/persistence error (contained,
+   * never fails the scan), or when no dependencies are detected.
+   */
+  dependenciesBackfilled: number
 }
 
 /**
@@ -97,6 +122,12 @@ export interface SkillRescanResponse {
   results: SkillRescanEntry[]
   /** Error message when a specific skill is not found */
   error?: string
+  /**
+   * SMI-5645: sum of every entry's `dependenciesBackfilled` this run. See
+   * that field's doc for the current-vs-historical-SKILL.md caveat and
+   * idempotency guarantee.
+   */
+  totalDependenciesBackfilled: number
 }
 
 // ============================================================================
@@ -151,68 +182,10 @@ export function findingsToQuarantineSeverity(
   return 'RISKY'
 }
 
-/**
- * Discover installed skill directories under ~/.claude/skills/.
- *
- * Skills are installed as either:
- *   - ~/.claude/skills/{skillName}/SKILL.md
- *   - ~/.claude/skills/{author}/{skillName}/SKILL.md
- *
- * Returns an array of { name, skillMdPath } objects.
- */
-export async function discoverInstalledSkills(
-  skillsDir: string
-): Promise<Array<{ name: string; skillMdPath: string }>> {
-  const results: Array<{ name: string; skillMdPath: string }> = []
-
-  let entries: string[]
-  try {
-    entries = await fs.readdir(skillsDir)
-  } catch {
-    return results
-  }
-
-  for (const entry of entries) {
-    const entryPath = join(skillsDir, entry)
-    const stat = await fs.stat(entryPath).catch(() => null)
-    if (!stat?.isDirectory()) continue
-
-    // Check for SKILL.md directly in this directory
-    const directSkillMd = join(entryPath, 'SKILL.md')
-    const directExists = await fs
-      .access(directSkillMd)
-      .then(() => true)
-      .catch(() => false)
-
-    if (directExists) {
-      results.push({ name: entry, skillMdPath: directSkillMd })
-      continue
-    }
-
-    // Check for author/skill-name subdirectories
-    const subEntries = await fs.readdir(entryPath).catch(() => [] as string[])
-    for (const subEntry of subEntries) {
-      const subPath = join(entryPath, subEntry)
-      const subStat = await fs.stat(subPath).catch(() => null)
-      if (!subStat?.isDirectory()) continue
-
-      const nestedSkillMd = join(subPath, 'SKILL.md')
-      const nestedExists = await fs
-        .access(nestedSkillMd)
-        .then(() => true)
-        .catch(() => false)
-
-      if (nestedExists) {
-        results.push({
-          name: `${entry}/${subEntry}`,
-          skillMdPath: nestedSkillMd,
-        })
-      }
-    }
-  }
-
-  return results
-}
+// SMI-5645: discoverInstalledSkills moved to ./skill-rescan.helpers.ts to
+// keep this file under the 500-line gate; re-exported below for existing
+// callers/tests that import it from this module.
+export { discoverInstalledSkills } from './skill-rescan.helpers.js'
 
 // ============================================================================
 // Execution
@@ -232,17 +205,31 @@ export async function discoverInstalledSkills(
  *
  * @see SMI-5358: advisory → quarantine linkage for rescan (gap fix)
  *
+ * SMI-5645: also backfills `skill_dependencies` rows for every scanned skill
+ * via `backfillSkillDependencies` (`./skill-rescan.helpers.ts`), re-running
+ * the same extraction+persistence pipeline SMI-5639 added at install time.
+ * This always reflects the skill's CURRENTLY installed SKILL.md, not a
+ * historical/original-install-time snapshot (see that helper's doc for the
+ * full rationale) -- a best-effort, contained step that never fails the
+ * security scan.
+ *
  * @param input         Validated tool input
  * @param overrideDir   Optional skills directory override (for testing)
  * @param quarantineRepo Optional QuarantineRepository for persisting quarantine
  *                       entries when findings exceed the threshold (production
  *                       callers pass new QuarantineRepository(toolContext.db))
+ * @param skillDependencyRepo Optional SkillDependencyRepository for backfilling
+ *                       dependency intelligence (SMI-5645; production callers
+ *                       pass toolContext.skillDependencyRepository). When
+ *                       omitted, no backfill is attempted and every entry's
+ *                       `dependenciesBackfilled` is 0.
  * @returns SkillRescanResponse with per-skill scan results
  */
 async function executeSkillRescanImpl(
   input: SkillRescanInput,
   overrideDir?: string,
-  quarantineRepo?: QuarantineRepository
+  quarantineRepo?: QuarantineRepository,
+  skillDependencyRepo?: SkillDependencyRepository
 ): Promise<SkillRescanResponse> {
   // SMI-4578: defaults to SKILLSMITH_CLIENT-resolved directory; override
   // wins for ad-hoc rescan of an arbitrary path.
@@ -267,12 +254,14 @@ async function executeSkillRescanImpl(
         error:
           `Skill "${input.skillName}" not found. ` +
           `${installedSkills.length} skill(s) currently installed.`,
+        totalDependenciesBackfilled: 0,
       }
     }
   }
 
   // Scan each skill
   const results: SkillRescanEntry[] = []
+  let totalDependenciesBackfilled = 0
 
   for (const skill of targetSkills) {
     let content: string
@@ -287,9 +276,29 @@ async function executeSkillRescanImpl(
         severityCounts: { critical: 0, high: 0, medium: 0, low: 0 },
         topFindings: [],
         error: `Could not read ${skill.skillMdPath}`,
+        dependenciesBackfilled: 0,
       })
       continue
     }
+
+    // SMI-5645: canonical local identity key, matching the same
+    // frontmatter-name-wins derivation already used for the quarantine key
+    // below (KEY PARITY note) -- shared here so both consumers key on the
+    // exact same string and only parse frontmatter once per skill.
+    const canonicalName = parseFrontmatter(content).name || skill.name
+    const localSkillKey = `local/${canonicalName}`
+
+    // SMI-5645: best-effort dependency backfill -- reflects the CURRENT
+    // on-disk SKILL.md, not a historical/original-install-time snapshot
+    // (see backfillSkillDependencies in ./skill-rescan.helpers.ts). Runs
+    // regardless of scan outcome and never throws (contained internally).
+    const dependenciesBackfilled = backfillSkillDependencies(
+      skillDependencyRepo,
+      localSkillKey,
+      content
+    )
+    totalDependenciesBackfilled += dependenciesBackfilled
+
     const report = scanner.scan(skill.name, content)
 
     // SMI-5422 Phase 2: also scan sibling bundled files (.mcp.json, settings,
@@ -346,6 +355,7 @@ async function executeSkillRescanImpl(
         lineNumber: f.lineNumber,
         ...(f.location ? { location: f.location } : {}),
       })),
+      dependenciesBackfilled,
       ...(hasSiblingActivity
         ? {
             bundledSiblings: {
@@ -370,16 +380,15 @@ async function executeSkillRescanImpl(
     // (LocalIndexer is top-level-only; indexLocalSkill derives name the same way).
     // discoverInstalledSkills yields the DIRECTORY name, so a SKILL.md whose
     // `name:` differs from its directory would be quarantined under the wrong key
-    // and silently evade the filter. Derive the canonical name from frontmatter
-    // first, mirroring LocalIndexer, then fall back to the directory name.
+    // and silently evade the filter. Reuses `localSkillKey` (computed once above,
+    // pre-scan, alongside the SMI-5645 dependency backfill) rather than
+    // re-deriving it here.
     if ((!report.passed || siblingRejected) && quarantineRepo) {
-      const canonicalName = parseFrontmatter(content).name || skill.name
-      const skillKey = `local/${canonicalName}`
       // Idempotent: a persistently-failing skill rescanned repeatedly must not
       // accumulate duplicate pending rows (the quarantine table has no
       // UNIQUE(skill_id, source)). Skip if already quarantined; a previously
       // APPROVED entry (isQuarantined === false) still re-quarantines as intended.
-      if (!quarantineRepo.isQuarantined(skillKey)) {
+      if (!quarantineRepo.isQuarantined(localSkillKey)) {
         // Quarantine-driving findings: SKILL.md findings only when SKILL.md
         // itself failed, plus the sibling execution-threat drivers. Doc-class
         // siblings are excluded upstream and so can never reach this set (B2).
@@ -410,7 +419,7 @@ async function executeSkillRescanImpl(
           )
         }
         quarantineRepo.create({
-          skillId: skillKey,
+          skillId: localSkillKey,
           source: 'rescan',
           quarantineReason:
             `Security rescan detected ${reasonParts.join('; ')} ` +
@@ -428,6 +437,7 @@ async function executeSkillRescanImpl(
     scannedCount: results.length,
     failedCount,
     results,
+    totalDependenciesBackfilled,
   }
 }
 


### PR DESCRIPTION
## Business Summary

**What shipped:** `skill_rescan` now backfills dependency data for any skill installed before the recent shutdown-persistence fix shipped — those skills previously had zero recorded dependencies and always would have, since nothing ever went back and filled them in. Running a rescan now closes that gap automatically, as a side effect of the security scan it already performs.

**Quality bar:** Implementation + tests covering the backfill's happy path, idempotency (verified against real database row counts, not assumed), failure containment (one skill's extraction error can't affect another skill or fail the security scan), and the edge case flagged during plan-review — a skill whose file was edited since its original install backfills against the current file content, which is documented as an intentional best-effort choice, not silently assumed.

**Found along the way:** none new.

**Net result:** Fully shipped, ready to merge.

---

## Technical detail

- `packages/core/src/services/skill-installation.helpers.ts` — `persistDependencies()` now returns the row count written (was `void`); purely additive, existing call site ignores the return value
- `packages/mcp-server/src/tools/skill-rescan.helpers.ts` (new) — `backfillSkillDependencies()`, a best-effort wrapper reusing the exact extraction/persistence pipeline from original install time; also holds `discoverInstalledSkills()` (moved, re-exported for compatibility) to keep `skill-rescan.ts` under the 500-line file-size gate
- `packages/mcp-server/src/tools/skill-rescan.ts` — threads an optional `SkillDependencyRepository` through; adds `dependenciesBackfilled` (per-entry) and `totalDependenciesBackfilled` (aggregate) to the response, both additive; reuses one canonical `local/${canonicalName}` key for both the new backfill and the existing quarantine logic (previously computed twice)
- `packages/mcp-server/src/tool-dispatch.ts` — wires `toolContext.skillDependencyRepository` into the `skill_rescan` dispatch call
- Tests: happy path, idempotency (real row-count assertions), failure containment (injected persistence error), stale-SKILL.md-since-install (explicit plan-review-flagged edge case), backward-compat (no repo supplied), and the "skill not found" error path

**Verification note**: this worktree's dedicated container is in the unrelated SMI-5656 restart-loop bug, so verification ran host-side. `eslint`/`prettier` clean; `packages/core`'s own suite (24/24) and the pre-existing `skill-rescan-quarantine` suite (18/18) both pass unaffected. 17/20 of this file's own new tests pass on host; the remaining 3 fail only because this worktree's `node_modules` symlink resolves cross-package `@skillsmith/core` imports to the **main checkout's** stale pre-built `dist/` (confirmed directly — that resolved dist's `persistDependencies` lacks this PR's return-value change) — a known worktree host-tooling artifact (SMI-4377/4381), not a defect in this diff. CI builds fresh from this branch and won't hit it.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)