### PR TITLE
fix(mcp-server,core): unified shutdown coordinator + awaitable sync stop (SMI-5649/SMI-5640)

### DIFF
--- a/packages/core/src/sync/BackgroundSyncService.ts
+++ b/packages/core/src/sync/BackgroundSyncService.ts
@@ -8,6 +8,12 @@
 
 import type { SyncEngine, SyncResult } from './SyncEngine.js'
 import type { SyncConfigRepository } from '../repositories/SyncConfigRepository.js'
+import { createLogger } from '../logging/index.js'
+
+// SMI-5649: sync errors were previously invisible by default (a no-op
+// `onSyncError`); mirrors shutdown.ts's SMI-5615 stderr-visibility pattern
+// so a background sync failure is never silently swallowed.
+const logger = createLogger('mcp')
 
 /**
  * Background sync service options
@@ -48,6 +54,10 @@ export class BackgroundSyncService {
   private timer: ReturnType<typeof setInterval> | null = null
   private isRunning = false
   private isStopped = false
+  // SMI-5649: abort + in-flight tracking so stop() can await settlement
+  // instead of being fire-and-forget (the root cause of the shutdown race).
+  private abortController: AbortController | null = null
+  private inFlightSync: Promise<void> | null = null
 
   private state: BackgroundSyncState = {
     isStarted: false,
@@ -69,7 +79,14 @@ export class BackgroundSyncService {
       checkIntervalMs: options.checkIntervalMs ?? 60000, // 1 minute
       syncOnStart: options.syncOnStart ?? true,
       onSyncComplete: options.onSyncComplete ?? (() => {}),
-      onSyncError: options.onSyncError ?? (() => {}),
+      // SMI-5649: default now logs (was a silent no-op) — mirrors
+      // closeDbOnShutdown's SMI-5615 stderr-visibility rationale so a
+      // background sync failure is visible even when no caller overrides it.
+      onSyncError:
+        options.onSyncError ??
+        ((error: Error) => {
+          logger.error('[skillsmith] Background sync failed', { err: error })
+        }),
       debug: options.debug ?? false,
     }
   }
@@ -97,6 +114,9 @@ export class BackgroundSyncService {
 
     this.state.isStarted = true
     this.isStopped = false
+    // SMI-5649: fresh controller per start() so a stop()->start() cycle
+    // (e.g. in tests) doesn't reuse an already-aborted signal.
+    this.abortController = new AbortController()
     this.log('Starting background sync service', {
       frequency: config.frequency,
       intervalMs: config.intervalMs,
@@ -119,10 +139,18 @@ export class BackgroundSyncService {
   }
 
   /**
-   * Stop the background sync service
+   * Stop the background sync service.
+   *
+   * SMI-5649: returns `Promise<void>` (was `void`, fire-and-forget) so a
+   * caller — namely the shutdown coordinator — can await settlement of any
+   * in-flight sync before proceeding to close the database. Non-awaiting
+   * callers still get the synchronous timer-clear + abort-signal behavior
+   * unchanged, since steps 1-2 below run before any `await` point.
    */
-  stop(): void {
+  stop(): Promise<void> {
     this.log('Stopping background sync service')
+    // 1. Synchronous first — preserves fire-and-forget semantics for
+    //    existing non-awaiting callers.
     this.isStopped = true
     this.state.isStarted = false
 
@@ -130,6 +158,15 @@ export class BackgroundSyncService {
       clearInterval(this.timer)
       this.timer = null
     }
+
+    // 2. Signal the in-flight sync (if any) to bail at its next checkpoint.
+    this.abortController?.abort()
+
+    // 3. Await settlement, never letting a rejection escape.
+    return Promise.resolve(this.inFlightSync ?? undefined).catch(() => {
+      // inFlightSync is already normalized to never reject (see
+      // triggerSync/manualSync below); this is belt-and-suspenders.
+    })
   }
 
   /**
@@ -189,9 +226,18 @@ export class BackgroundSyncService {
     this.state.isRunning = true
     this.state.syncsTriggered++
 
+    // SMI-5649: track the raw sync() promise (never rejects — SyncEngine.sync
+    // try/catches everything internally) so stop() can await its settlement
+    // without depending on this method's own try/catch/finally timing.
+    const syncPromise = this.syncEngine.sync({ signal: this.abortController?.signal })
+    this.inFlightSync = syncPromise.then(
+      () => undefined,
+      () => undefined
+    )
+
     try {
       this.log('Starting sync')
-      const result = await this.syncEngine.sync()
+      const result = await syncPromise
       this.state.lastResult = result
       this.state.lastError = null
 
@@ -212,6 +258,7 @@ export class BackgroundSyncService {
     } finally {
       this.isRunning = false
       this.state.isRunning = false
+      this.inFlightSync = null
     }
   }
 
@@ -229,8 +276,14 @@ export class BackgroundSyncService {
     this.isRunning = true
     this.state.isRunning = true
 
+    const syncPromise = this.syncEngine.sync({ signal: this.abortController?.signal })
+    this.inFlightSync = syncPromise.then(
+      () => undefined,
+      () => undefined
+    )
+
     try {
-      const result = await this.syncEngine.sync()
+      const result = await syncPromise
       this.state.lastResult = result
       this.state.lastError = null
       this.options.onSyncComplete(result)
@@ -243,6 +296,7 @@ export class BackgroundSyncService {
     } finally {
       this.isRunning = false
       this.state.isRunning = false
+      this.inFlightSync = null
     }
   }
 

--- a/packages/core/src/sync/SyncEngine.ts
+++ b/packages/core/src/sync/SyncEngine.ts
@@ -37,6 +37,15 @@ export interface SyncOptions {
   pageSize?: number
   /** Progress callback */
   onProgress?: (progress: SyncProgress) => void
+  /**
+   * Abort signal (SMI-5649). Checked at loop and pre-write boundaries so a
+   * shutdown quiesce can stop an in-flight sync before it writes against a
+   * db that is about to be closed. Every driver write is synchronous, so
+   * once the signal is aborted, no new write ever begins — this is what
+   * makes it safe for the coordinator to proceed to `db.close()` once its
+   * bounded quiesce timeout elapses, even if this method hasn't returned yet.
+   */
+  signal?: AbortSignal
 }
 
 /**
@@ -120,7 +129,7 @@ export class SyncEngine {
    * Run sync operation
    */
   async sync(options: SyncOptions = {}): Promise<SyncResult> {
-    const { force = false, dryRun = false, pageSize = 100, onProgress } = options
+    const { force = false, dryRun = false, pageSize = 100, onProgress, signal } = options
 
     const startTime = Date.now()
     const errors: string[] = []
@@ -177,10 +186,17 @@ export class SyncEngine {
       const seenIds = new Set<string>()
 
       for (const searchQuery of searchQueries) {
+        // SMI-5649: stop fetching new query batches once aborted.
+        if (signal?.aborted) break
         offset = 0
         hasMore = true
 
         while (hasMore) {
+          // SMI-5649: stop paginating the current query once aborted.
+          if (signal?.aborted) {
+            hasMore = false
+            break
+          }
           try {
             const response = await this.apiClient.search({
               query: searchQuery,
@@ -257,17 +273,26 @@ export class SyncEngine {
       })
 
       // Upsert changed skills
-      if (!dryRun && skillsToProcess.length > 0) {
-        const stats = await this.upsertSkills(skillsToProcess, (current) => {
-          onProgress?.({
-            phase: 'upserting',
-            current,
-            total: skillsToProcess.length,
-            skillsProcessed: totalProcessed,
-            skillsChanged: skillsToProcess.length,
-            message: `Upserting skill ${current}/${skillsToProcess.length}...`,
-          })
-        })
+      // SMI-5649: if aborted before any writes began, skip the upsert
+      // entirely and report as if nothing changed — never start a partial
+      // write once the shutdown quiesce has signaled abort.
+      if (signal?.aborted) {
+        skillsUnchanged = allSkills.length
+      } else if (!dryRun && skillsToProcess.length > 0) {
+        const stats = await this.upsertSkills(
+          skillsToProcess,
+          (current) => {
+            onProgress?.({
+              phase: 'upserting',
+              current,
+              total: skillsToProcess.length,
+              skillsProcessed: totalProcessed,
+              skillsChanged: skillsToProcess.length,
+              message: `Upserting skill ${current}/${skillsToProcess.length}...`,
+            })
+          },
+          signal
+        )
 
         skillsAdded = stats.added
         skillsUpdated = stats.updated
@@ -372,13 +397,18 @@ export class SyncEngine {
    */
   private async upsertSkills(
     skills: ApiSearchResult[],
-    onProgress?: (current: number) => void
+    onProgress?: (current: number) => void,
+    signal?: AbortSignal
   ): Promise<UpsertStats> {
     let added = 0
     let updated = 0
     let unchanged = 0
 
     for (let i = 0; i < skills.length; i++) {
+      // SMI-5649: stop before the next skill once aborted. Each
+      // already-issued skillRepo.create/update + recordVersion call above
+      // this point is already committed — we simply don't start another.
+      if (signal?.aborted) break
       const skill = skills[i]
       const existing = this.skillRepo.findById(skill.id)
 

--- a/packages/core/tests/sync/BackgroundSyncService.abort.test.ts
+++ b/packages/core/tests/sync/BackgroundSyncService.abort.test.ts
@@ -1,0 +1,231 @@
+/**
+ * SMI-5649: BackgroundSyncService — abort + awaitable stop(), and the new
+ * logs-by-default onSyncError.
+ *
+ * Split from BackgroundSyncService.test.ts to stay under the 500-LOC
+ * file-size gate. Reuses that file's mock factories (createMockSyncEngine,
+ * createMockConfigRepo, createMockSyncResult — exported there for this
+ * purpose).
+ *
+ * The shutdown coordinator relies on `stop()` resolving only once any
+ * in-flight sync has settled, and on the `AbortSignal` it threads into
+ * `syncEngine.sync()` actually being aborted synchronously by `stop()` (so
+ * `SyncEngine`'s abort checkpoints see it before the process ever gets to
+ * `db.close()`).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { SyncEngine, SyncResult } from '../../src/sync/SyncEngine.js'
+
+// SMI-5649: BackgroundSyncService.ts builds its default `onSyncError` logger
+// via `createLogger('mcp')` (`../logging/index.js`, relative from
+// `packages/core/src/sync/`) ONCE at module load, so asserting what it logs
+// requires mocking the factory before the module under test is imported.
+// `vi.mock` is hoisted above all imports (including the one below), so this
+// works regardless of declaration order. Mirrors the identical pattern in
+// `packages/mcp-server/src/shutdown.test.ts`.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+vi.mock('../../src/logging/index.js', () => ({
+  createLogger: vi.fn(() => mockLogger),
+}))
+
+import { BackgroundSyncService } from '../../src/sync/BackgroundSyncService.js'
+import {
+  createMockSyncResult,
+  createMockSyncEngine,
+  createMockConfigRepo,
+} from './BackgroundSyncService.test.js'
+
+/**
+ * SMI-5649: abort + awaitable stop(). The shutdown coordinator relies on
+ * `stop()` resolving only once any in-flight sync has settled, and on the
+ * `AbortSignal` it threads into `syncEngine.sync()` actually being aborted
+ * synchronously by `stop()` (so `SyncEngine`'s abort checkpoints see it
+ * before the process ever gets to `db.close()`).
+ */
+describe('stop() — abort + awaitable settlement (SMI-5649)', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+  afterEach(() => {
+    vi.useFakeTimers()
+  })
+
+  it('passes an AbortSignal into syncEngine.sync()', async () => {
+    // start() is what creates the abortController (design doc §2.2) — the
+    // production path always calls start() before any sync can occur
+    // (createToolContextAsync calls `backgroundSync.start()` immediately
+    // after construction), so tests exercising the abort-signal plumbing
+    // must too.
+    const engine = createMockSyncEngine()
+    const service = new BackgroundSyncService(engine, createMockConfigRepo(), {
+      syncOnStart: false,
+    })
+    service.start()
+
+    await service.manualSync()
+
+    expect(engine.sync).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+    await service.stop()
+  })
+
+  it('stop() returns a Promise and resolves only after an in-flight sync settles', async () => {
+    let resolveSync!: () => void
+    const engine = {
+      sync: vi.fn().mockReturnValue(
+        new Promise<SyncResult>((resolve) => {
+          resolveSync = () => resolve(createMockSyncResult())
+        })
+      ),
+    } as unknown as SyncEngine
+
+    const service = new BackgroundSyncService(engine, createMockConfigRepo(), {
+      syncOnStart: false,
+    })
+    service.start()
+
+    const inFlight = service.manualSync()
+    let stopSettled = false
+    const stopPromise = service.stop().then(() => {
+      stopSettled = true
+    })
+
+    // Give the microtask queue a chance to run — stop() must NOT resolve
+    // while the sync is still pending.
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(stopSettled).toBe(false)
+
+    resolveSync()
+    await stopPromise
+    expect(stopSettled).toBe(true)
+
+    await inFlight.catch(() => {})
+  })
+
+  it("aborts the in-flight sync's AbortSignal when stop() is called", async () => {
+    let capturedSignal: AbortSignal | undefined
+    let resolveSync!: () => void
+    const engine = {
+      sync: vi.fn().mockImplementation(({ signal }: { signal?: AbortSignal }) => {
+        capturedSignal = signal
+        return new Promise<SyncResult>((resolve) => {
+          resolveSync = () => resolve(createMockSyncResult())
+        })
+      }),
+    } as unknown as SyncEngine
+
+    const service = new BackgroundSyncService(engine, createMockConfigRepo(), {
+      syncOnStart: false,
+    })
+    service.start()
+
+    const inFlight = service.manualSync()
+    expect(capturedSignal?.aborted).toBe(false)
+
+    const stopPromise = service.stop()
+    expect(capturedSignal?.aborted).toBe(true)
+
+    resolveSync()
+    await stopPromise
+    await inFlight.catch(() => {})
+  })
+
+  it('stop() still clears the timer and flips isStarted synchronously for non-awaiting callers', () => {
+    vi.useFakeTimers()
+    const service = new BackgroundSyncService(createMockSyncEngine(), createMockConfigRepo(), {
+      syncOnStart: false,
+    })
+
+    service.start()
+    expect(service.isServiceStarted()).toBe(true)
+
+    // Fire-and-forget — the original callers of stop() never awaited it.
+    void service.stop()
+    expect(service.isServiceStarted()).toBe(false)
+    vi.useRealTimers()
+  })
+
+  it('stop() resolves cleanly (no unhandled rejection) even when the in-flight sync rejects', async () => {
+    let rejectSync!: (err: Error) => void
+    const engine = {
+      sync: vi.fn().mockReturnValue(
+        new Promise<SyncResult>((_resolve, reject) => {
+          rejectSync = reject
+        })
+      ),
+    } as unknown as SyncEngine
+
+    const service = new BackgroundSyncService(engine, createMockConfigRepo(), {
+      syncOnStart: false,
+      onSyncError: () => {},
+    })
+
+    const inFlight = service.manualSync().catch(() => {})
+    const stopPromise = service.stop()
+
+    rejectSync(new Error('network exploded'))
+
+    await expect(stopPromise).resolves.toBeUndefined()
+    await inFlight
+  })
+})
+
+/**
+ * SMI-5649: sync errors were previously invisible by default (a no-op
+ * `onSyncError`) — this asserts the new default logs via the shared
+ * logger at error level, mirroring `closeDbOnShutdown`'s SMI-5615
+ * stderr-visibility rationale.
+ */
+describe('default onSyncError logs by default (SMI-5649)', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    mockLogger.error.mockClear()
+  })
+  afterEach(() => {
+    vi.useFakeTimers()
+  })
+
+  it('logs via logger.error when no onSyncError override is provided', async () => {
+    const engine = {
+      sync: vi.fn().mockRejectedValue(new Error('Network timeout')),
+    } as unknown as SyncEngine
+
+    const service = new BackgroundSyncService(engine, createMockConfigRepo(), {
+      syncOnStart: false,
+    })
+
+    await service.manualSync().catch(() => {})
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Background sync failed'),
+      expect.objectContaining({ err: expect.any(Error) })
+    )
+  })
+
+  it('does not log via the default when a caller-provided onSyncError override is given', async () => {
+    const onError = vi.fn()
+    const engine = {
+      sync: vi.fn().mockRejectedValue(new Error('Network timeout')),
+    } as unknown as SyncEngine
+
+    const service = new BackgroundSyncService(engine, createMockConfigRepo(), {
+      syncOnStart: false,
+      onSyncError: onError,
+    })
+
+    await service.manualSync().catch(() => {})
+
+    expect(onError).toHaveBeenCalled()
+    expect(mockLogger.error).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/tests/sync/BackgroundSyncService.test.ts
+++ b/packages/core/tests/sync/BackgroundSyncService.test.ts
@@ -11,12 +11,18 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { SyncEngine, SyncResult } from '../../src/sync/SyncEngine.js'
+import type { SyncConfigRepository } from '../../src/repositories/SyncConfigRepository.js'
 import {
   BackgroundSyncService,
   createBackgroundSyncService,
 } from '../../src/sync/BackgroundSyncService.js'
-import type { SyncEngine, SyncResult } from '../../src/sync/SyncEngine.js'
-import type { SyncConfigRepository } from '../../src/repositories/SyncConfigRepository.js'
+
+// SMI-5649: BackgroundSyncService.abort.test.ts covers the new
+// abort/awaitable-stop() behavior and the default onSyncError logging
+// (which requires mocking `createLogger` before module load — split there
+// to avoid an unused mock in this file, and to stay under the 500-LOC
+// file-size gate).
 
 /** Flush microtask queue so fire-and-forget promises resolve */
 function flushPromises(): Promise<void> {
@@ -27,7 +33,7 @@ function flushPromises(): Promise<void> {
 // Mock Factories
 // ============================================================================
 
-function createMockSyncResult(overrides?: Partial<SyncResult>): SyncResult {
+export function createMockSyncResult(overrides?: Partial<SyncResult>): SyncResult {
   return {
     success: true,
     skillsAdded: 2,
@@ -41,13 +47,13 @@ function createMockSyncResult(overrides?: Partial<SyncResult>): SyncResult {
   }
 }
 
-function createMockSyncEngine(result?: SyncResult): SyncEngine {
+export function createMockSyncEngine(result?: SyncResult): SyncEngine {
   return {
     sync: vi.fn().mockResolvedValue(result ?? createMockSyncResult()),
   } as unknown as SyncEngine
 }
 
-function createMockConfigRepo(overrides?: {
+export function createMockConfigRepo(overrides?: {
   enabled?: boolean
   lastSyncAt?: string | null
   isSyncDue?: boolean

--- a/packages/core/tests/sync/SyncEngine.abort.test.ts
+++ b/packages/core/tests/sync/SyncEngine.abort.test.ts
@@ -1,0 +1,143 @@
+/**
+ * SyncEngine Tests — abort-signal threading (SMI-5649)
+ *
+ * Split from SyncEngine.test.ts to stay under the 500-LOC file-size gate.
+ * Reuses that file's mock factories (createMockSkill, createMockApiClient,
+ * createMockSkillVersionRepo — exported there for this purpose).
+ *
+ * The load-bearing safety property under test: once `signal.aborted` is
+ * true, NO NEW db write ever begins — checked at loop/write boundaries
+ * (search-query loop, pagination loop, pre-upsert, per-skill upsert loop).
+ * Every write already issued before the abort checkpoint is a real,
+ * committed write; nothing already in flight is rolled back.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { createDatabase, closeDatabase } from '../../src/db/schema.js'
+import { SyncConfigRepository } from '../../src/repositories/SyncConfigRepository.js'
+import { SyncHistoryRepository } from '../../src/repositories/SyncHistoryRepository.js'
+import { SkillRepository } from '../../src/repositories/SkillRepository.js'
+import { SyncEngine } from '../../src/sync/SyncEngine.js'
+import type { DatabaseType } from '../../src/db/schema.js'
+import type { SkillsmithApiClient } from '../../src/api/client.js'
+import {
+  createMockSkillVersionRepo,
+  createMockSkill,
+  createMockApiClient,
+} from './SyncEngine.test.js'
+
+describe('SyncEngine - abort signal (SMI-5649)', () => {
+  let db: DatabaseType
+  let syncConfigRepo: SyncConfigRepository
+  let syncHistoryRepo: SyncHistoryRepository
+  let skillRepo: SkillRepository
+
+  beforeEach(() => {
+    db = createDatabase(':memory:')
+    syncConfigRepo = new SyncConfigRepository(db)
+    syncHistoryRepo = new SyncHistoryRepository(db)
+    skillRepo = new SkillRepository(db)
+  })
+
+  afterEach(() => {
+    closeDatabase(db)
+  })
+
+  it('performs no writes and returns a clean result when the signal is already aborted', async () => {
+    const skills = [createMockSkill('test/skill-1'), createMockSkill('test/skill-2')]
+    const apiClient = createMockApiClient({ skills })
+    const engine = new SyncEngine(
+      apiClient,
+      skillRepo,
+      syncConfigRepo,
+      syncHistoryRepo,
+      createMockSkillVersionRepo()
+    )
+
+    const controller = new AbortController()
+    controller.abort()
+
+    const result = await engine.sync({ signal: controller.signal })
+
+    // Never throws — an abort surfaces as a clean, successful-shaped
+    // result, not an error (design doc §2.1).
+    expect(result.success).toBe(true)
+    expect(result.skillsAdded).toBe(0)
+    expect(result.skillsUpdated).toBe(0)
+    expect(skillRepo.findById('test/skill-1')).toBeNull()
+    expect(skillRepo.findById('test/skill-2')).toBeNull()
+  })
+
+  it('stops issuing new skillRepo writes once aborted mid-upsert, keeping already-committed writes', async () => {
+    const skills = [
+      createMockSkill('test/skill-1'),
+      createMockSkill('test/skill-2'),
+      createMockSkill('test/skill-3'),
+    ]
+    const apiClient = createMockApiClient({ skills })
+    const engine = new SyncEngine(
+      apiClient,
+      skillRepo,
+      syncConfigRepo,
+      syncHistoryRepo,
+      createMockSkillVersionRepo()
+    )
+
+    const controller = new AbortController()
+    let createCount = 0
+    const originalCreate = skillRepo.create.bind(skillRepo)
+    vi.spyOn(skillRepo, 'create').mockImplementation(
+      (...args: Parameters<typeof skillRepo.create>) => {
+        createCount++
+        const result = originalCreate(...args)
+        if (createCount === 1) {
+          // Abort right after the first skill commits — the per-skill loop's
+          // abort checkpoint must stop before issuing a second create().
+          controller.abort()
+        }
+        return result
+      }
+    )
+
+    const result = await engine.sync({ signal: controller.signal })
+
+    expect(createCount).toBe(1)
+    expect(skillRepo.findById('test/skill-1')).not.toBeNull()
+    expect(skillRepo.findById('test/skill-2')).toBeNull()
+    expect(skillRepo.findById('test/skill-3')).toBeNull()
+    expect(result.success).toBe(true)
+  })
+
+  it('stops fetching new pages once aborted mid-fetch', async () => {
+    const skills = Array.from({ length: 150 }, (_, i) => createMockSkill(`test/skill-${i}`))
+    const apiClient = createMockApiClient({ skills })
+    const engine = new SyncEngine(
+      apiClient,
+      skillRepo,
+      syncConfigRepo,
+      syncHistoryRepo,
+      createMockSkillVersionRepo()
+    )
+
+    const controller = new AbortController()
+    let searchCallCount = 0
+    const searchMock = apiClient.search as ReturnType<typeof vi.fn>
+    const originalImpl = searchMock.getMockImplementation() as (
+      opts: Parameters<SkillsmithApiClient['search']>[0]
+    ) => ReturnType<SkillsmithApiClient['search']>
+    searchMock.mockImplementation((opts: Parameters<SkillsmithApiClient['search']>[0]) => {
+      searchCallCount++
+      if (searchCallCount === 3) {
+        controller.abort()
+      }
+      return originalImpl(opts)
+    })
+
+    await engine.sync({ signal: controller.signal, pageSize: 100 })
+
+    // Unaborted, this fixture makes 16 search calls (8 queries x 2 pages
+    // each — see the pagination test in SyncEngine.test.ts). Aborting on
+    // the 3rd call must stop the loop well short of that.
+    expect(searchCallCount).toBeLessThan(16)
+  })
+})

--- a/packages/core/tests/sync/SyncEngine.status.test.ts
+++ b/packages/core/tests/sync/SyncEngine.status.test.ts
@@ -1,0 +1,168 @@
+/**
+ * SyncEngine Tests — history tracking + getStatus
+ *
+ * Split from SyncEngine.test.ts (pre-existing at 508 lines, over the
+ * 500-LOC file-size gate, before any SMI-5649 changes) to bring both files
+ * under the limit. Reuses that file's mock factories (createMockSkill,
+ * createMockApiClient, createMockSkillVersionRepo — exported there).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createDatabase, closeDatabase } from '../../src/db/schema.js'
+import { SyncConfigRepository } from '../../src/repositories/SyncConfigRepository.js'
+import { SyncHistoryRepository } from '../../src/repositories/SyncHistoryRepository.js'
+import { SkillRepository } from '../../src/repositories/SkillRepository.js'
+import { SyncEngine } from '../../src/sync/SyncEngine.js'
+import type { DatabaseType } from '../../src/db/schema.js'
+import {
+  createMockSkillVersionRepo,
+  createMockSkill,
+  createMockApiClient,
+} from './SyncEngine.test.js'
+
+describe('SyncEngine - history tracking + getStatus', () => {
+  let db: DatabaseType
+  let syncConfigRepo: SyncConfigRepository
+  let syncHistoryRepo: SyncHistoryRepository
+  let skillRepo: SkillRepository
+
+  beforeEach(() => {
+    db = createDatabase(':memory:')
+    syncConfigRepo = new SyncConfigRepository(db)
+    syncHistoryRepo = new SyncHistoryRepository(db)
+    skillRepo = new SkillRepository(db)
+  })
+
+  afterEach(() => {
+    closeDatabase(db)
+  })
+
+  describe('sync - history tracking', () => {
+    it('should record sync history on success', async () => {
+      const skills = [createMockSkill('test/skill-1')]
+      const apiClient = createMockApiClient({ skills })
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        createMockSkillVersionRepo()
+      )
+
+      await engine.sync()
+
+      const history = syncHistoryRepo.getHistory()
+      expect(history).toHaveLength(1)
+      expect(history[0].status).toBe('success')
+      expect(history[0].skillsAdded).toBe(1)
+    })
+
+    it('should record sync history on failure', async () => {
+      const apiClient = createMockApiClient({
+        throwOnSearch: new Error('Network failure'),
+      })
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        createMockSkillVersionRepo()
+      )
+
+      await engine.sync()
+
+      const history = syncHistoryRepo.getHistory()
+      expect(history).toHaveLength(1)
+      expect(history[0].status).toBe('failed')
+      expect(history[0].errorMessage).toContain('Network failure')
+    })
+
+    it('should update sync config on success', async () => {
+      const skills = [createMockSkill('test/skill-1')]
+      const apiClient = createMockApiClient({ skills })
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        createMockSkillVersionRepo()
+      )
+
+      await engine.sync()
+
+      const config = syncConfigRepo.getConfig()
+      expect(config.lastSyncAt).not.toBeNull()
+      expect(config.lastSyncCount).toBe(1)
+      expect(config.lastSyncError).toBeNull()
+    })
+
+    it('should set error in config on failure', async () => {
+      const apiClient = createMockApiClient({ offline: true })
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        createMockSkillVersionRepo()
+      )
+
+      await engine.sync()
+
+      const config = syncConfigRepo.getConfig()
+      expect(config.lastSyncError).toBe('API client is in offline mode. Cannot sync.')
+    })
+  })
+
+  describe('getStatus', () => {
+    it('should return sync status summary', () => {
+      const apiClient = createMockApiClient()
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        createMockSkillVersionRepo()
+      )
+
+      const status = engine.getStatus()
+
+      expect(status).toHaveProperty('config')
+      expect(status).toHaveProperty('lastRun')
+      expect(status).toHaveProperty('isRunning')
+      expect(status).toHaveProperty('isDue')
+    })
+
+    it('should show sync is due when never synced', () => {
+      const apiClient = createMockApiClient()
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        createMockSkillVersionRepo()
+      )
+
+      const status = engine.getStatus()
+
+      expect(status.isDue).toBe(true)
+      expect(status.lastRun).toBeNull()
+    })
+
+    it('should reflect running state', async () => {
+      const apiClient = createMockApiClient()
+      const engine = new SyncEngine(
+        apiClient,
+        skillRepo,
+        syncConfigRepo,
+        syncHistoryRepo,
+        createMockSkillVersionRepo()
+      )
+
+      // Start a run manually
+      syncHistoryRepo.startRun()
+
+      const status = engine.getStatus()
+      expect(status.isRunning).toBe(true)
+    })
+  })
+})

--- a/packages/core/tests/sync/SyncEngine.test.ts
+++ b/packages/core/tests/sync/SyncEngine.test.ts
@@ -19,7 +19,7 @@ import type { SkillsmithApiClient, ApiSearchResult } from '../../src/api/client.
  * All methods return resolved promises so SyncEngine can call recordVersion
  * after each upsert without errors.
  */
-function createMockSkillVersionRepo(): SkillVersionRepository {
+export function createMockSkillVersionRepo(): SkillVersionRepository {
   return {
     recordVersion: vi.fn().mockResolvedValue(undefined),
     pruneVersions: vi.fn().mockResolvedValue(undefined),
@@ -33,7 +33,7 @@ function createMockSkillVersionRepo(): SkillVersionRepository {
  * Create a mock skill for testing
  * Note: quality_score must be between 0 and 1 (database constraint)
  */
-function createMockSkill(
+export function createMockSkill(
   id: string,
   updatedAt: string = new Date().toISOString()
 ): ApiSearchResult {
@@ -56,7 +56,7 @@ function createMockSkill(
 /**
  * Create a mock API client with customizable behavior
  */
-function createMockApiClient(
+export function createMockApiClient(
   config: {
     offline?: boolean
     healthStatus?: 'healthy' | 'degraded' | 'unhealthy'
@@ -374,135 +374,6 @@ describe('SyncEngine', () => {
       // Each query paginates through results: 8 queries × 2 pages (100 + 50) = 16 calls
       // Skills are deduplicated across queries
       expect(apiClient.search as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(16)
-    })
-  })
-
-  describe('sync - history tracking', () => {
-    it('should record sync history on success', async () => {
-      const skills = [createMockSkill('test/skill-1')]
-      const apiClient = createMockApiClient({ skills })
-      const engine = new SyncEngine(
-        apiClient,
-        skillRepo,
-        syncConfigRepo,
-        syncHistoryRepo,
-        createMockSkillVersionRepo()
-      )
-
-      await engine.sync()
-
-      const history = syncHistoryRepo.getHistory()
-      expect(history).toHaveLength(1)
-      expect(history[0].status).toBe('success')
-      expect(history[0].skillsAdded).toBe(1)
-    })
-
-    it('should record sync history on failure', async () => {
-      const apiClient = createMockApiClient({
-        throwOnSearch: new Error('Network failure'),
-      })
-      const engine = new SyncEngine(
-        apiClient,
-        skillRepo,
-        syncConfigRepo,
-        syncHistoryRepo,
-        createMockSkillVersionRepo()
-      )
-
-      await engine.sync()
-
-      const history = syncHistoryRepo.getHistory()
-      expect(history).toHaveLength(1)
-      expect(history[0].status).toBe('failed')
-      expect(history[0].errorMessage).toContain('Network failure')
-    })
-
-    it('should update sync config on success', async () => {
-      const skills = [createMockSkill('test/skill-1')]
-      const apiClient = createMockApiClient({ skills })
-      const engine = new SyncEngine(
-        apiClient,
-        skillRepo,
-        syncConfigRepo,
-        syncHistoryRepo,
-        createMockSkillVersionRepo()
-      )
-
-      await engine.sync()
-
-      const config = syncConfigRepo.getConfig()
-      expect(config.lastSyncAt).not.toBeNull()
-      expect(config.lastSyncCount).toBe(1)
-      expect(config.lastSyncError).toBeNull()
-    })
-
-    it('should set error in config on failure', async () => {
-      const apiClient = createMockApiClient({ offline: true })
-      const engine = new SyncEngine(
-        apiClient,
-        skillRepo,
-        syncConfigRepo,
-        syncHistoryRepo,
-        createMockSkillVersionRepo()
-      )
-
-      await engine.sync()
-
-      const config = syncConfigRepo.getConfig()
-      expect(config.lastSyncError).toBe('API client is in offline mode. Cannot sync.')
-    })
-  })
-
-  describe('getStatus', () => {
-    it('should return sync status summary', () => {
-      const apiClient = createMockApiClient()
-      const engine = new SyncEngine(
-        apiClient,
-        skillRepo,
-        syncConfigRepo,
-        syncHistoryRepo,
-        createMockSkillVersionRepo()
-      )
-
-      const status = engine.getStatus()
-
-      expect(status).toHaveProperty('config')
-      expect(status).toHaveProperty('lastRun')
-      expect(status).toHaveProperty('isRunning')
-      expect(status).toHaveProperty('isDue')
-    })
-
-    it('should show sync is due when never synced', () => {
-      const apiClient = createMockApiClient()
-      const engine = new SyncEngine(
-        apiClient,
-        skillRepo,
-        syncConfigRepo,
-        syncHistoryRepo,
-        createMockSkillVersionRepo()
-      )
-
-      const status = engine.getStatus()
-
-      expect(status.isDue).toBe(true)
-      expect(status.lastRun).toBeNull()
-    })
-
-    it('should reflect running state', async () => {
-      const apiClient = createMockApiClient()
-      const engine = new SyncEngine(
-        apiClient,
-        skillRepo,
-        syncConfigRepo,
-        syncHistoryRepo,
-        createMockSkillVersionRepo()
-      )
-
-      // Start a run manually
-      syncHistoryRepo.startRun()
-
-      const status = engine.getStatus()
-      expect(status.isRunning).toBe(true)
     })
   })
 })

--- a/packages/mcp-server/src/__tests__/context-listeners.test.ts
+++ b/packages/mcp-server/src/__tests__/context-listeners.test.ts
@@ -1,10 +1,24 @@
 /**
- * SMI-4694: Listener-count audit for context.ts (Module 2).
+ * SMI-4694 (updated SMI-5649): Listener-count audit for the tool-context
+ * factories (Module 2).
  *
- * Verifies that createToolContext + closeToolContext is symmetric for
- * SIGTERM/SIGINT signal handlers, including when backgroundSync and
- * llmFailover paths are forced on (the only conditions that register
- * handlers — see context.ts:244-260).
+ * Prior to SMI-5649, the tool-context factories registered their OWN
+ * SIGTERM/SIGINT handlers whenever backgroundSync or llmFailover was
+ * enabled — this test verified that registration was symmetric with
+ * `closeToolContext`/`disposeTestContext`. SMI-5649 deleted that
+ * registration entirely (both the async factory AND its sync sibling,
+ * `createToolContext` in context.ts — the sync sibling's identical latent
+ * bug found during the Wave A design pass): it was the root cause of the
+ * shutdown race (two independent, unordered handler sets could both fire on
+ * the same signal, racing a fire-and-forget `backgroundSync?.stop()`
+ * against `index.ts`'s db close). Signal ownership now belongs SOLELY to
+ * `index.ts`'s single shutdown coordinator (`shutdown.ts`) — see
+ * docs/internal/implementation/mcp-shutdown-followup-hardening-wave-a-design.md
+ * §Deliverable 4.
+ *
+ * These tests now assert the NEW invariant: creating/closing/disposing a
+ * tool context NEVER touches process-level SIGTERM/SIGINT listeners at all,
+ * even with backgroundSync and llmFailover both enabled.
  *
  * Reference pattern: packages/core/tests/api/client.events.test.ts:39-72
  */
@@ -14,8 +28,8 @@ import { SyncConfigRepository } from '@skillsmith/core'
 import { closeToolContext, createToolContextAsync } from '../context.js'
 import { createTestContext, disposeTestContext } from './test-utils.js'
 
-describe('SMI-4694: context.ts listener-count audit', () => {
-  it('does NOT leak SIGTERM/SIGINT listeners when sync + failover are enabled', async () => {
+describe('SMI-4694/SMI-5649: context.ts listener-count audit', () => {
+  it('never registers SIGTERM/SIGINT listeners, even when sync + failover are enabled', async () => {
     const before = {
       sigterm: process.listenerCount('SIGTERM'),
       sigint: process.listenerCount('SIGINT'),
@@ -39,11 +53,12 @@ describe('SMI-4694: context.ts listener-count audit', () => {
 
       // Note: createToolContextAsync re-creates the DB; the seed above is mostly
       // a sanity probe that SyncConfigRepository.enable() does not throw.
-      // The actual handler registration is gated on syncConfig.enabled
-      // returning true, which is the default for fresh DBs created with
-      // ensureTable() — see SyncConfigRepository.ts:174 ('enabled BOOLEAN
-      // DEFAULT 1'). With backgroundSyncConfig.enabled !== false AND
-      // llmFailoverConfig.enabled === true, both branches register handlers.
+      // Service construction is gated on syncConfig.enabled returning true,
+      // which is the default for fresh DBs created with ensureTable() — see
+      // SyncConfigRepository.ts:174 ('enabled BOOLEAN DEFAULT 1'). With
+      // backgroundSyncConfig.enabled !== false AND llmFailoverConfig.enabled
+      // === true, both services ARE created — but post-SMI-5649, neither
+      // registers a process-level signal listener.
       const ctx = await createToolContextAsync({
         dbPath: ':memory:',
         apiClientConfig: { offlineMode: true },
@@ -51,15 +66,18 @@ describe('SMI-4694: context.ts listener-count audit', () => {
         llmFailoverConfig: { enabled: true },
       })
 
-      // Sanity: at least one handler must be registered for the audit to
-      // be meaningful — otherwise the test passes trivially even if dispose
-      // is broken.
+      // Sanity: the services themselves must actually be constructed for
+      // this audit to be meaningful (otherwise "no listeners" would be
+      // trivially true because nothing was created).
+      expect(ctx.backgroundSync).toBeDefined()
+      expect(ctx.llmFailover).toBeDefined()
+
       const mid = {
         sigterm: process.listenerCount('SIGTERM'),
         sigint: process.listenerCount('SIGINT'),
       }
-      expect(mid.sigterm).toBeGreaterThan(before.sigterm)
-      expect(mid.sigint).toBeGreaterThan(before.sigint)
+      expect(mid.sigterm).toBe(before.sigterm)
+      expect(mid.sigint).toBe(before.sigint)
 
       await closeToolContext(ctx)
     }
@@ -73,7 +91,7 @@ describe('SMI-4694: context.ts listener-count audit', () => {
     expect(after.sigint).toBe(before.sigint)
   })
 
-  it('disposeTestContext is symmetric with createTestContext', async () => {
+  it('disposeTestContext is symmetric with createTestContext (no listeners registered or leaked)', async () => {
     const before = {
       sigterm: process.listenerCount('SIGTERM'),
       sigint: process.listenerCount('SIGINT'),
@@ -89,9 +107,11 @@ describe('SMI-4694: context.ts listener-count audit', () => {
       sigint: process.listenerCount('SIGINT'),
     }
 
-    // createTestContext uses offline mode; backgroundSync default is on but
-    // syncConfig.enabled defaults to TRUE (DB schema default), so handlers
-    // ARE registered. disposeTestContext must remove them symmetrically.
+    // createTestContext uses offline mode; backgroundSync default is on and
+    // syncConfig.enabled defaults to TRUE (DB schema default), so the
+    // service IS constructed — but post-SMI-5649 it no longer registers a
+    // process-level signal listener. disposeTestContext still must not leak
+    // (trivially true now, but kept as a regression guard).
     expect(after.sigterm).toBe(before.sigterm)
     expect(after.sigint).toBe(before.sigint)
   })

--- a/packages/mcp-server/src/__tests__/context.test.ts
+++ b/packages/mcp-server/src/__tests__/context.test.ts
@@ -303,31 +303,16 @@ describe('Context Module', () => {
       })
     })
 
-    describe('signal handler registration', () => {
-      it('should register signal handlers when services are created', async () => {
-        process.env.SKILLSMITH_LLM_FAILOVER_ENABLED = 'true'
-
-        const context = await createToolContextAsync({ dbPath: ':memory:' })
-
-        expect(context._signalHandlers).toBeDefined()
-        expect(context._signalHandlers!.length).toBeGreaterThan(0)
-
-        await closeToolContext(context)
-      })
-
-      it('should not register signal handlers without services', async () => {
-        process.env.SKILLSMITH_BACKGROUND_SYNC = 'false'
-
-        const context = await createToolContextAsync({
-          dbPath: ':memory:',
-          backgroundSyncConfig: { enabled: false },
-        })
-
-        expect(context._signalHandlers).toBeUndefined()
-
-        await closeToolContext(context)
-      })
-    })
+    // SMI-5649: `_signalHandlers` was deleted from `ToolContext` — the factory
+    // no longer registers its own process-level SIGTERM/SIGINT handlers at
+    // all (that was the root cause of the shutdown race fixed in this wave).
+    // Signal ownership now belongs solely to index.ts's single shutdown
+    // coordinator (shutdown.ts). The invariant this "signal handler
+    // registration" describe block used to cover — exactly one
+    // SIGTERM/SIGINT registration site — is now covered by
+    // shutdown.test.ts's dedicated in-process listenerCount unit test and by
+    // tests/context-async-listeners.test.ts / __tests__/context-listeners.test.ts
+    // (updated to assert this factory registers ZERO listeners).
   })
 
   describe('closeToolContext', () => {
@@ -340,17 +325,17 @@ describe('Context Module', () => {
       expect(() => context.db.exec('SELECT 1')).toThrow()
     })
 
-    it('should remove signal handlers', async () => {
+    it('should not touch process-level signal listeners (SMI-5649 — see context-listeners.test.ts for the full audit)', async () => {
       process.env.SKILLSMITH_LLM_FAILOVER_ENABLED = 'true'
 
+      const before = process.listenerCount('SIGTERM')
       const context = await createToolContextAsync({ dbPath: ':memory:' })
-      const initialHandlerCount = context._signalHandlers?.length ?? 0
 
-      expect(initialHandlerCount).toBeGreaterThan(0)
+      expect(process.listenerCount('SIGTERM')).toBe(before)
 
       await closeToolContext(context)
 
-      // Signal handlers should be removed (verified by not causing memory leak)
+      expect(process.listenerCount('SIGTERM')).toBe(before)
     })
 
     it('should stop background sync if running', async () => {

--- a/packages/mcp-server/src/context.async.ts
+++ b/packages/mcp-server/src/context.async.ts
@@ -196,11 +196,6 @@ export async function createToolContextAsync(
             )
           }
         },
-        onSyncError: (error: Error) => {
-          if (options.backgroundSyncConfig?.debug) {
-            console.error(`[skillsmith] Background sync error: ${error.message}`)
-          }
-        },
       })
 
       backgroundSync.start()
@@ -230,26 +225,16 @@ export async function createToolContextAsync(
     }
   }
 
-  // Create signal handlers for cleanup
-  const signalHandlers: Array<{ signal: NodeJS.Signals; handler: () => void }> = []
-
-  if (backgroundSync || llmFailover) {
-    const cleanup = () => {
-      backgroundSync?.stop()
-      llmFailover?.close()
-    }
-
-    const sigTermHandler = () => cleanup()
-    const sigIntHandler = () => cleanup()
-
-    process.on('SIGTERM', sigTermHandler)
-    process.on('SIGINT', sigIntHandler)
-
-    signalHandlers.push(
-      { signal: 'SIGTERM', handler: sigTermHandler },
-      { signal: 'SIGINT', handler: sigIntHandler }
-    )
-  }
+  // SMI-5649: this factory no longer registers its own SIGTERM/SIGINT
+  // handlers. That was the root cause of the shutdown race — a context
+  // factory registering PROCESS-GLOBAL signal handlers on every context
+  // creation meant two independent, unordered handler sets could both fire
+  // on the same signal, racing a fire-and-forget `backgroundSync?.stop()`
+  // against `index.ts`'s db close. Signal ownership now belongs solely to
+  // `index.ts`'s single shutdown coordinator (`shutdown.ts`), which performs
+  // this same cleanup (`quiesce` + `closeLlmFailover` hooks) in a defined
+  // order. See docs/internal/implementation/mcp-shutdown-followup-hardening-wave-a-design.md
+  // §Deliverable 4.
 
   return {
     db,
@@ -262,7 +247,6 @@ export async function createToolContextAsync(
     distinctId,
     backgroundSync,
     llmFailover,
-    _signalHandlers: signalHandlers.length > 0 ? signalHandlers : undefined,
   }
 }
 
@@ -295,13 +279,10 @@ export async function resetAsyncToolContext(): Promise<void> {
     const context = asyncGlobalContext
     asyncGlobalContext = null
 
-    if (context._signalHandlers) {
-      for (const { signal, handler } of context._signalHandlers) {
-        process.removeListener(signal, handler)
-      }
-    }
     if (context.backgroundSync) {
-      context.backgroundSync.stop()
+      // SMI-5649: stop() is now awaitable (aborts + awaits any in-flight
+      // sync) — was fire-and-forget.
+      await context.backgroundSync.stop()
     }
     if (context.llmFailover) {
       context.llmFailover.close()

--- a/packages/mcp-server/src/context.ts
+++ b/packages/mcp-server/src/context.ts
@@ -238,26 +238,18 @@ export function createToolContext(options: ToolContextOptions = {}): ToolContext
     }
   }
 
-  // Create signal handlers for cleanup (stored for removal to prevent memory leaks)
-  const signalHandlers: Array<{ signal: NodeJS.Signals; handler: () => void }> = []
-
-  if (backgroundSync || llmFailover) {
-    const cleanup = () => {
-      backgroundSync?.stop()
-      llmFailover?.close()
-    }
-
-    const sigTermHandler = () => cleanup()
-    const sigIntHandler = () => cleanup()
-
-    process.on('SIGTERM', sigTermHandler)
-    process.on('SIGINT', sigIntHandler)
-
-    signalHandlers.push(
-      { signal: 'SIGTERM', handler: sigTermHandler },
-      { signal: 'SIGINT', handler: sigIntHandler }
-    )
-  }
+  // SMI-5649 (Finding 1): this factory no longer registers its own
+  // SIGTERM/SIGINT handlers — structurally identical to the bug fixed in
+  // context.async.ts (Deliverable 4). This sync `createToolContext` is only
+  // called by the unused `getToolContext` singleton (the running MCP server
+  // uses `getToolContextAsync` -> context.async.ts exclusively), so it never
+  // corrupted the runtime `listenerCount`, but it DID make the "exactly one
+  // registration site" invariant false: the Surface Grounding convention
+  // check (`grep -rn "process.on('SIG" packages/mcp-server/src`) would still
+  // return this file as a second hit. Signal ownership now belongs solely to
+  // `index.ts`'s single shutdown coordinator (`shutdown.ts`). See
+  // docs/internal/implementation/mcp-shutdown-followup-hardening-wave-a-design.md
+  // §0 (Finding 1) and §Deliverable 4.
 
   return {
     db,
@@ -270,7 +262,6 @@ export function createToolContext(options: ToolContextOptions = {}): ToolContext
     distinctId,
     backgroundSync,
     llmFailover,
-    _signalHandlers: signalHandlers.length > 0 ? signalHandlers : undefined,
   }
 }
 
@@ -282,16 +273,11 @@ export function createToolContext(options: ToolContextOptions = {}): ToolContext
  * @param context - Tool context to close
  */
 export async function closeToolContext(context: ToolContext): Promise<void> {
-  // Remove signal handlers to prevent memory leaks
-  if (context._signalHandlers) {
-    for (const { signal, handler } of context._signalHandlers) {
-      process.removeListener(signal, handler)
-    }
-  }
-
   // Stop background sync service if running
   if (context.backgroundSync) {
-    context.backgroundSync.stop()
+    // SMI-5649: stop() is now awaitable (aborts + awaits any in-flight
+    // sync) — was fire-and-forget.
+    await context.backgroundSync.stop()
   }
 
   // SMI-1524: Close LLM failover chain if initialized

--- a/packages/mcp-server/src/context.types.ts
+++ b/packages/mcp-server/src/context.types.ts
@@ -46,8 +46,6 @@ export interface ToolContext {
   backgroundSync?: BackgroundSyncService
   /** LLM failover chain for multi-provider support (SMI-1524) */
   llmFailover?: LLMFailoverChain
-  /** Internal: Signal handlers for cleanup (prevents memory leaks) */
-  _signalHandlers?: Array<{ signal: NodeJS.Signals; handler: () => void }>
 }
 
 /**

--- a/packages/mcp-server/src/index.shutdown-helpers.test.ts
+++ b/packages/mcp-server/src/index.shutdown-helpers.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Tests for the shutdown-coordinator helpers extracted from
+ * index.ts (SMI-5649).
+ *
+ * `quiesceBackgroundSync` is the bounded-timeout wrapper `index.ts` passes
+ * as the coordinator's `quiesce` hook. It has no top-level side effects
+ * (unlike `index.ts` itself), so it can be imported and unit-tested
+ * directly — this is the in-process complement to the subprocess proof in
+ * `tests/shutdown-persistence-subprocess.test.ts` (which exercises the same
+ * bound end-to-end against a real stalled network call, but isn't captured
+ * by source-file coverage since it runs the compiled binary in a separate
+ * process).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { BackgroundSyncService } from '@skillsmith/core'
+
+// SMI-5649: index.shutdown-helpers.ts builds its `logger` via
+// `createLogger('mcp')` ONCE at module load, so the only way to assert what
+// it logged is to mock the factory before the module under test is
+// imported. Mirrors the identical pattern in shutdown.test.ts.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+vi.mock('@skillsmith/core/logging', () => ({
+  createLogger: vi.fn(() => mockLogger),
+}))
+
+import { quiesceBackgroundSync } from './index.shutdown-helpers.js'
+import { SHUTDOWN_QUIESCE_TIMEOUT_MS } from './shutdown.js'
+
+/** Minimal mock matching the slice of BackgroundSyncService's surface
+ * quiesceBackgroundSync actually calls. */
+function createMockBg(stopImpl: () => Promise<void>): BackgroundSyncService {
+  return { stop: vi.fn(stopImpl) } as unknown as BackgroundSyncService
+}
+
+describe('quiesceBackgroundSync (SMI-5649)', () => {
+  beforeEach(() => {
+    mockLogger.error.mockClear()
+  })
+
+  it('resolves immediately (no-op) when bg is undefined', async () => {
+    await expect(quiesceBackgroundSync(undefined)).resolves.toBeUndefined()
+    expect(mockLogger.error).not.toHaveBeenCalled()
+  })
+
+  it('resolves promptly when bg.stop() settles well within the bound, without logging', async () => {
+    const bg = createMockBg(() => Promise.resolve())
+
+    await quiesceBackgroundSync(bg)
+
+    expect(bg.stop).toHaveBeenCalledTimes(1)
+    expect(mockLogger.error).not.toHaveBeenCalled()
+  })
+
+  it('proceeds and logs once the bound elapses when bg.stop() never settles', async () => {
+    vi.useFakeTimers()
+    try {
+      // A stop() that never resolves — mirrors the real scenario where the
+      // in-flight sync is parked on a stuck network await (design doc §2.3):
+      // the bound must still let the coordinator proceed to close the db.
+      const bg = createMockBg(() => new Promise<void>(() => {}))
+
+      const quiescePromise = quiesceBackgroundSync(bg)
+      await vi.advanceTimersByTimeAsync(SHUTDOWN_QUIESCE_TIMEOUT_MS)
+      await quiescePromise
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('did not quiesce within the shutdown bound'),
+        expect.anything()
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not log when bg.stop() settles exactly at the bound (race-tolerant)', async () => {
+    vi.useFakeTimers()
+    try {
+      let resolveStop!: () => void
+      const bg = createMockBg(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveStop = resolve
+          })
+      )
+
+      const quiescePromise = quiesceBackgroundSync(bg)
+      resolveStop()
+      await vi.advanceTimersByTimeAsync(0)
+      await quiescePromise
+
+      expect(mockLogger.error).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/mcp-server/src/index.shutdown-helpers.ts
+++ b/packages/mcp-server/src/index.shutdown-helpers.ts
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Shutdown-coordinator helpers extracted from index.ts (SMI-5649).
+ * @module @skillsmith/mcp-server/index.shutdown-helpers
+ *
+ * Extracted to keep index.ts under the `audit:standards` 500-LOC gate after
+ * SMI-5649's unified shutdown coordinator wiring. No behavior change from the
+ * inline version.
+ */
+
+import type { BackgroundSyncService } from '@skillsmith/core'
+import { createLogger } from '@skillsmith/core/logging'
+import { SHUTDOWN_QUIESCE_TIMEOUT_MS } from './shutdown.js'
+
+const logger = createLogger('mcp')
+
+/**
+ * SMI-5649: bounded quiesce of the background sync service. `bg.stop()`
+ * itself aborts the in-flight sync immediately and awaits its settlement;
+ * this wrapper additionally bounds that await so a hung sync (e.g. a stuck
+ * network call) can never block process exit indefinitely. On timeout,
+ * proceeds anyway and logs — safe because SyncEngine's abort checkpoints
+ * guarantee no NEW write begins once the signal is aborted (see
+ * `SyncEngine.ts`'s abort checkpoints and the design doc §2.3).
+ */
+export async function quiesceBackgroundSync(bg?: BackgroundSyncService): Promise<void> {
+  if (!bg) return
+  let settled = false
+  await Promise.race([
+    bg.stop().then(() => {
+      settled = true
+    }),
+    new Promise<void>((resolve) => setTimeout(resolve, SHUTDOWN_QUIESCE_TIMEOUT_MS)),
+  ])
+  if (!settled) {
+    logger.error(
+      '[skillsmith] Background sync did not quiesce within the shutdown bound; proceeding to close db',
+      {}
+    )
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -81,7 +81,8 @@ import { checkForUpdates, formatUpdateNotification } from '@skillsmith/core'
 // SMI-5479: flush-on-shutdown wiring lives in shutdown.js (own module — no
 // top-level side effects, so it stays independently unit-testable; this file
 // has `main().catch(...)` at module scope, which importing would trigger).
-import { createShutdownTrigger } from './shutdown.js'
+import { createShutdownTrigger, startPeriodicFlush } from './shutdown.js'
+import { quiesceBackgroundSync } from './index.shutdown-helpers.js'
 // SMI-5039: probe extracted from this file to @skillsmith/core/embeddings/probe.
 // The call site (before server.connect) is unchanged; only the implementation
 // moved so doc-retrieval-mcp + cli can share the same audited probe contract.
@@ -326,16 +327,24 @@ function runStartupDiagnostics(): void {
 // contract (hard 2 s timeout, try/catch wrapper, stderr-only, never throws).
 // Call site below preserved verbatim — invoke before server.connect(transport).
 
-// SMI-5479 (pass 2): flush-on-shutdown trigger — see shutdown.ts for the
-// rationale and the bounded-flush implementation. Registering ANY listener
-// for SIGTERM/SIGINT overrides Node's default terminate-on-signal behavior,
-// so this explicitly exits once the bounded flush settles, preserving
-// today's default (process exits promptly on those signals) instead of
-// leaving the process hanging.
-const shutdownAndExit = createShutdownTrigger(
-  () => process.exit(0),
-  () => toolContext?.db
-)
+// SMI-5479 (pass 2) / SMI-5649 (extended): the ONE shutdown-trigger
+// registration site — see shutdown.ts for the coordinator's ordered
+// sequence (quiesce -> close LLM failover -> close/persist db -> flush
+// telemetry). `context.async.ts` and `context.ts` previously each registered
+// their own independent SIGTERM/SIGINT handlers whose fire-and-forget
+// `backgroundSync?.stop()` raced this trigger's db close with no ordering
+// guarantee (SMI-5649) — both are now deleted; this is the only site.
+// Registering ANY listener for SIGTERM/SIGINT overrides Node's default
+// terminate-on-signal behavior, so this explicitly exits once the sequence
+// settles, preserving today's default (process exits promptly on those
+// signals) instead of leaving the process hanging. Hooks are late-bound
+// (mirroring `getDb`) since `toolContext` isn't assigned until inside
+// `main()`, after this module-scope call.
+const shutdownAndExit = createShutdownTrigger(() => process.exit(0), {
+  getDb: () => toolContext?.db,
+  quiesce: () => quiesceBackgroundSync(toolContext?.backgroundSync),
+  closeLlmFailover: () => toolContext?.llmFailover?.close(),
+})
 
 // Start server
 async function main() {
@@ -365,6 +374,9 @@ async function main() {
     console.error(
       `Database initialized at: ${process.env.SKILLSMITH_DB_PATH || '~/.skillsmith/skills.db'}`
     )
+    // SMI-5640: arm the periodic autosave timer now that toolContext exists.
+    // No-op unless the db is WASM + file-backed (see shutdown.ts).
+    startPeriodicFlush(() => toolContext?.db)
   } catch (error) {
     const errorDetail = error instanceof Error ? error.message : String(error)
     // SMI-5615: single '\n'-joined message reproduces the prior 8-line stderr output.

--- a/packages/mcp-server/src/shutdown-coordinator.test.ts
+++ b/packages/mcp-server/src/shutdown-coordinator.test.ts
@@ -1,0 +1,420 @@
+/**
+ * @fileoverview Tests for the unified shutdown coordinator + periodic
+ * autosave (SMI-5649 + SMI-5640).
+ *
+ * Split from shutdown.test.ts (SMI-5649) to stay under the 500-LOC file-size
+ * gate — same module under test, same mocking approach (see that file's
+ * header comment for the `createLogger` mocking rationale, duplicated below
+ * since both files need it independently).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { initializePostHog, shutdownPostHog, isPostHogEnabled } from '@skillsmith/core/telemetry'
+import type { DatabaseType } from '@skillsmith/core'
+import {
+  createShutdownTrigger,
+  runShutdownSequence,
+  persistDbIfSupported,
+  startPeriodicFlush,
+  stopPeriodicFlush,
+  _resetShutdownGuardForTests,
+  SHUTDOWN_QUIESCE_TIMEOUT_MS,
+} from './shutdown.js'
+
+// SMI-5639/SMI-5649: `shutdown.ts` builds its `logger` via `createLogger('mcp')`
+// ONCE at module load, so the only way to assert what it logged is to mock
+// the factory itself before `./shutdown.js` is imported. `vi.mock` is hoisted
+// above ALL imports in this file, so this works regardless of declaration
+// order. `vi.hoisted` gives the factory a stable object the tests below can
+// also reference directly.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+vi.mock('@skillsmith/core/logging', () => ({
+  createLogger: vi.fn(() => mockLogger),
+}))
+
+/**
+ * Minimal mutable mock matching the slice of the `Database` interface
+ * `closeDbOnShutdown` actually touches (`open`, `close`).
+ */
+interface MockDb {
+  open: boolean
+  close: ReturnType<typeof vi.fn>
+}
+
+function createMockDb(open = true): MockDb {
+  return { open, close: vi.fn() }
+}
+
+/**
+ * Mock matching the WASM-driver-shaped surface `persistDbIfSupported` /
+ * `startPeriodicFlush` structurally detect via `isPersistable` (an explicit
+ * `persist()` method) — see shutdown.ts's `Persistable` type guard.
+ */
+interface MockPersistableDb {
+  open: boolean
+  memory: boolean
+  persist: ReturnType<typeof vi.fn>
+}
+
+function createMockPersistableDb(overrides?: Partial<MockPersistableDb>): MockPersistableDb {
+  return { open: true, memory: false, persist: vi.fn(), ...overrides }
+}
+
+/**
+ * SMI-5649: `runShutdownSequence` — the ONE coordinator. Tests the ordered
+ * sequence (quiesce -> close LLM failover -> close/persist db -> flush
+ * telemetry) and the re-entrancy latch that prevents a second signal from
+ * racing a mid-persist first sequence.
+ */
+describe('runShutdownSequence (SMI-5649)', () => {
+  beforeEach(() => {
+    _resetShutdownGuardForTests()
+    mockLogger.error.mockClear()
+    initializePostHog({ apiKey: 'phc_test_key_smi_5649_coordinator' })
+  })
+
+  afterEach(async () => {
+    await shutdownPostHog()
+    _resetShutdownGuardForTests()
+  })
+
+  it('runs quiesce -> closeLlmFailover -> closeDb, in that order', async () => {
+    const callOrder: string[] = []
+    const db = createMockDb(true)
+
+    await runShutdownSequence({
+      getDb: () => db as unknown as DatabaseType,
+      quiesce: async () => {
+        callOrder.push('quiesce')
+      },
+      closeLlmFailover: () => {
+        callOrder.push('closeLlmFailover')
+      },
+    })
+
+    callOrder.push('closeDb-observed')
+    expect(db.close).toHaveBeenCalledTimes(1)
+    expect(callOrder).toEqual(['quiesce', 'closeLlmFailover', 'closeDb-observed'])
+  })
+
+  it('awaits an in-flight (slow) quiesce hook before closing the db', async () => {
+    const db = createMockDb(true)
+    let quiesceResolved = false
+    let dbWasOpenDuringQuiesce = true
+
+    await runShutdownSequence({
+      getDb: () => db as unknown as DatabaseType,
+      quiesce: async () => {
+        dbWasOpenDuringQuiesce = db.close.mock.calls.length === 0
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        quiesceResolved = true
+      },
+    })
+
+    expect(quiesceResolved).toBe(true)
+    expect(dbWasOpenDuringQuiesce).toBe(true)
+    expect(db.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('is fail-soft when the quiesce hook throws — closeDb + telemetry flush still run', async () => {
+    const db = createMockDb(true)
+
+    await runShutdownSequence({
+      getDb: () => db as unknown as DatabaseType,
+      quiesce: async () => {
+        throw new Error('quiesce exploded')
+      },
+    })
+
+    expect(db.close).toHaveBeenCalledTimes(1)
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('quiesce failed'),
+      expect.objectContaining({ err: expect.any(Error) })
+    )
+  })
+
+  it('is fail-soft when closeLlmFailover throws — closeDb still runs', async () => {
+    const db = createMockDb(true)
+
+    await runShutdownSequence({
+      getDb: () => db as unknown as DatabaseType,
+      closeLlmFailover: () => {
+        throw new Error('failover close exploded')
+      },
+    })
+
+    expect(db.close).toHaveBeenCalledTimes(1)
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to close LLM failover chain'),
+      expect.objectContaining({ err: expect.any(Error) })
+    )
+  })
+
+  it('re-entrancy: a second call while the first is in flight returns the SAME promise and the body runs only once', async () => {
+    const db = createMockDb(true)
+    let quiesceCallCount = 0
+
+    const hooks = {
+      getDb: () => db as unknown as DatabaseType,
+      quiesce: async () => {
+        quiesceCallCount++
+        await new Promise((resolve) => setTimeout(resolve, 20))
+      },
+    }
+
+    const first = runShutdownSequence(hooks)
+    const second = runShutdownSequence(hooks)
+
+    // Load-bearing (design doc §1.3 Subtlety A): a naive re-implementation
+    // would start a SECOND independent sequence here, which could exit the
+    // process mid-persist on the first. The coordinator must return the
+    // exact same in-flight promise instead.
+    expect(second).toBe(first)
+
+    await Promise.all([first, second])
+
+    expect(quiesceCallCount).toBe(1)
+    expect(db.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not skip its own telemetry flush despite setting shuttingDown=true at step 0 (Subtlety B)', async () => {
+    expect(isPostHogEnabled()).toBe(true)
+
+    await runShutdownSequence({})
+
+    // The coordinator's step 4 must still flush PostHog even though it set
+    // the module-level `shuttingDown` flag at step 0 — a naive
+    // implementation that called the GUARDED `flushTelemetryOnShutdown`
+    // internally would see its own guard already tripped and skip the flush.
+    expect(isPostHogEnabled()).toBe(false)
+  })
+})
+
+/**
+ * SMI-5640: periodic autosave for the WASM driver — `persistDbIfSupported`
+ * (the fail-soft persist helper) and `startPeriodicFlush`/`stopPeriodicFlush`
+ * (the timer lifecycle). Exercises the structural `isPersistable` guard
+ * indirectly via db shapes with/without an explicit `persist()` method.
+ */
+describe('persistDbIfSupported (SMI-5640)', () => {
+  beforeEach(() => {
+    mockLogger.error.mockClear()
+  })
+
+  it('calls persist() on an open, file-backed, persistable db', () => {
+    const db = createMockPersistableDb()
+
+    persistDbIfSupported(() => db as unknown as DatabaseType)
+
+    expect(db.persist).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call persist() on a closed db', () => {
+    const db = createMockPersistableDb({ open: false })
+
+    persistDbIfSupported(() => db as unknown as DatabaseType)
+
+    expect(db.persist).not.toHaveBeenCalled()
+  })
+
+  it('does not call persist() on an in-memory db', () => {
+    const db = createMockPersistableDb({ memory: true })
+
+    persistDbIfSupported(() => db as unknown as DatabaseType)
+
+    expect(db.persist).not.toHaveBeenCalled()
+  })
+
+  it('no-ops on a native-driver-shaped db with no persist() method', () => {
+    const nativeShapedDb = { open: true, memory: false, close: vi.fn() }
+
+    expect(() =>
+      persistDbIfSupported(() => nativeShapedDb as unknown as DatabaseType)
+    ).not.toThrow()
+  })
+
+  it('no-ops safely when getDb is undefined or returns undefined', () => {
+    expect(() => persistDbIfSupported(undefined)).not.toThrow()
+    expect(() => persistDbIfSupported(() => undefined)).not.toThrow()
+  })
+
+  it('logs via logger.error (fail-soft) when persist() itself throws', () => {
+    const persistError = new Error('disk full')
+    const db = createMockPersistableDb()
+    db.persist.mockImplementation(() => {
+      throw persistError
+    })
+
+    expect(() => persistDbIfSupported(() => db as unknown as DatabaseType)).not.toThrow()
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Periodic autosave persist failed'),
+      expect.objectContaining({ err: persistError })
+    )
+  })
+})
+
+describe('startPeriodicFlush / stopPeriodicFlush (SMI-5640)', () => {
+  const ORIGINAL_ENV = { ...process.env }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    _resetShutdownGuardForTests()
+  })
+
+  afterEach(() => {
+    stopPeriodicFlush()
+    vi.useRealTimers()
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it('persists on the configured interval and is unref-able', () => {
+    delete process.env.SKILLSMITH_AUTOSAVE_DISABLE
+    process.env.SKILLSMITH_AUTOSAVE_INTERVAL_MS = '1000'
+    const db = createMockPersistableDb()
+
+    startPeriodicFlush(() => db as unknown as DatabaseType)
+
+    expect(db.persist).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1000)
+    expect(db.persist).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(1000)
+    expect(db.persist).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not arm the timer when SKILLSMITH_AUTOSAVE_DISABLE=1', () => {
+    process.env.SKILLSMITH_AUTOSAVE_DISABLE = '1'
+    process.env.SKILLSMITH_AUTOSAVE_INTERVAL_MS = '1000'
+    const db = createMockPersistableDb()
+
+    startPeriodicFlush(() => db as unknown as DatabaseType)
+
+    vi.advanceTimersByTime(10_000)
+    expect(db.persist).not.toHaveBeenCalled()
+  })
+
+  it('does not arm the timer for a non-persistable (native-shaped) db', () => {
+    delete process.env.SKILLSMITH_AUTOSAVE_DISABLE
+    process.env.SKILLSMITH_AUTOSAVE_INTERVAL_MS = '1000'
+    const nativeShapedDb = { open: true, memory: false, close: vi.fn() }
+
+    startPeriodicFlush(() => nativeShapedDb as unknown as DatabaseType)
+
+    vi.advanceTimersByTime(10_000)
+    // Nothing to assert beyond "does not throw" — a native-shaped db has no
+    // persist() to spy on; the real assertion is the absence of a crash from
+    // calling a nonexistent method, proven by not throwing.
+  })
+
+  it('does not arm the timer for an in-memory db', () => {
+    delete process.env.SKILLSMITH_AUTOSAVE_DISABLE
+    process.env.SKILLSMITH_AUTOSAVE_INTERVAL_MS = '1000'
+    const db = createMockPersistableDb({ memory: true })
+
+    startPeriodicFlush(() => db as unknown as DatabaseType)
+
+    vi.advanceTimersByTime(10_000)
+    expect(db.persist).not.toHaveBeenCalled()
+  })
+
+  it('stopPeriodicFlush clears the timer (no further persists after stop)', () => {
+    delete process.env.SKILLSMITH_AUTOSAVE_DISABLE
+    process.env.SKILLSMITH_AUTOSAVE_INTERVAL_MS = '1000'
+    const db = createMockPersistableDb()
+
+    startPeriodicFlush(() => db as unknown as DatabaseType)
+    vi.advanceTimersByTime(1000)
+    expect(db.persist).toHaveBeenCalledTimes(1)
+
+    stopPeriodicFlush()
+    vi.advanceTimersByTime(10_000)
+    expect(db.persist).toHaveBeenCalledTimes(1)
+  })
+
+  it('the flush callback no-ops once shuttingDown is set, even if the timer fires again before it is stopped', () => {
+    delete process.env.SKILLSMITH_AUTOSAVE_DISABLE
+    process.env.SKILLSMITH_AUTOSAVE_INTERVAL_MS = '1000'
+    const db = createMockPersistableDb()
+
+    startPeriodicFlush(() => db as unknown as DatabaseType)
+    vi.advanceTimersByTime(1000)
+    expect(db.persist).toHaveBeenCalledTimes(1)
+
+    // Simulate the coordinator having started (sets shuttingDown) without
+    // yet having called stopPeriodicFlush — belt-and-suspenders guard.
+    void runShutdownSequence({ getDb: () => db as unknown as DatabaseType })
+    vi.advanceTimersByTime(1000)
+    // No additional persist beyond whatever the coordinator's own db-close
+    // step triggers (it does not call persistDbIfSupported directly — this
+    // asserts the TIMER callback specifically stayed a no-op).
+    expect(db.persist.mock.calls.length).toBeLessThanOrEqual(2)
+  })
+
+  it('defaults to a 5-minute interval when SKILLSMITH_AUTOSAVE_INTERVAL_MS is unset', () => {
+    delete process.env.SKILLSMITH_AUTOSAVE_DISABLE
+    delete process.env.SKILLSMITH_AUTOSAVE_INTERVAL_MS
+    const db = createMockPersistableDb()
+
+    startPeriodicFlush(() => db as unknown as DatabaseType)
+
+    vi.advanceTimersByTime(299_999)
+    expect(db.persist).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(db.persist).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('SHUTDOWN_QUIESCE_TIMEOUT_MS (SMI-5649)', () => {
+  it('exports the documented default timeout constant', () => {
+    expect(SHUTDOWN_QUIESCE_TIMEOUT_MS).toBe(2000)
+  })
+})
+
+/**
+ * SMI-5649: single-registration-site invariant. Per the design doc's Finding
+ * 2, this MUST be an in-process vitest unit test (not the full-boot
+ * subprocess test in tests/shutdown-persistence-subprocess.test.ts) —
+ * `packages/core/src/api/event-batcher.ts` attaches its own SIGTERM/SIGINT
+ * drain handlers when a real `SkillsmithApiClient` is constructed outside a
+ * VITEST-detected environment, which would be a confounder in a spawned
+ * subprocess. This test builds ONLY the shutdown.ts coordinator trigger
+ * (mirroring index.ts's wiring) — no API client, no ToolContext — so the
+ * measured delta is attributable solely to the coordinator.
+ *
+ * Uses a before/after delta (not an absolute `=== 1`) because other listeners
+ * may already be registered in this worker process by unrelated code paths —
+ * the same rationale as the existing SMI-4694 listener audits
+ * (tests/context-async-listeners.test.ts, src/__tests__/context-listeners.test.ts).
+ */
+describe('single shutdown-trigger registration site (SMI-5649)', () => {
+  it('registers exactly one SIGTERM and one SIGINT listener when wired the way index.ts wires it', () => {
+    const before = {
+      sigterm: process.listenerCount('SIGTERM'),
+      sigint: process.listenerCount('SIGINT'),
+    }
+
+    const trigger = createShutdownTrigger(() => {})
+    process.on('SIGTERM', trigger)
+    process.on('SIGINT', trigger)
+
+    const after = {
+      sigterm: process.listenerCount('SIGTERM'),
+      sigint: process.listenerCount('SIGINT'),
+    }
+
+    try {
+      expect(after.sigterm - before.sigterm).toBe(1)
+      expect(after.sigint - before.sigint).toBe(1)
+    } finally {
+      process.removeListener('SIGTERM', trigger)
+      process.removeListener('SIGINT', trigger)
+    }
+  })
+})

--- a/packages/mcp-server/src/shutdown.test.ts
+++ b/packages/mcp-server/src/shutdown.test.ts
@@ -58,6 +58,11 @@ function createMockDb(open = true): MockDb {
   return { open, close: vi.fn() }
 }
 
+// SMI-5649: coordinator (runShutdownSequence), autosave
+// (persistDbIfSupported/startPeriodicFlush/stopPeriodicFlush), and the
+// single-registration-site tests moved to shutdown-coordinator.test.ts
+// (SMI-5649) to keep this file under the 500-LOC file-size gate.
+
 describe('flushTelemetryOnShutdown (SMI-5479)', () => {
   beforeEach(() => {
     _resetShutdownGuardForTests()
@@ -226,10 +231,12 @@ describe('closeDbOnShutdown (SMI-5639)', () => {
 })
 
 /**
- * SMI-5639 Wave 2 Step 1 (part 2): `createShutdownTrigger`'s new `getDb`
- * wiring — the db close/persist runs SYNCHRONOUSLY, before the (async)
- * telemetry flush is even kicked off, so these assertions can check
- * `db.close()` immediately after calling `trigger()` without needing to wait.
+ * SMI-5639 Wave 2 Step 1 (part 2), updated SMI-5649: `createShutdownTrigger`'s
+ * `getDb` wiring. Since SMI-5649, the coordinator quiesces background work
+ * (an inherently async step, awaited even when no `quiesce` hook is given)
+ * BEFORE calling `closeDbOnShutdown` — so, unlike before, `db.close()` is no
+ * longer observable perfectly synchronously on the same tick as the
+ * `trigger()` call. These assertions now poll via `vi.waitFor` instead.
  */
 describe('createShutdownTrigger — getDb wiring (SMI-5639)', () => {
   beforeEach(() => {
@@ -246,14 +253,11 @@ describe('createShutdownTrigger — getDb wiring (SMI-5639)', () => {
   it('closes an open mock db when the trigger fires', async () => {
     const db = createMockDb(true)
     const onDone = vi.fn()
-    const trigger = createShutdownTrigger(onDone, () => db as unknown as DatabaseType)
+    const trigger = createShutdownTrigger(onDone, { getDb: () => db as unknown as DatabaseType })
 
     trigger()
 
-    // Synchronous — closeDbOnShutdown runs to completion before the trigger
-    // even kicks off flushTelemetryOnShutdown, let alone awaits it.
-    expect(db.close).toHaveBeenCalledTimes(1)
-
+    await vi.waitFor(() => expect(db.close).toHaveBeenCalledTimes(1))
     await vi.waitFor(() => expect(onDone).toHaveBeenCalledTimes(1))
   })
 
@@ -271,7 +275,7 @@ describe('createShutdownTrigger — getDb wiring (SMI-5639)', () => {
     const getDb = vi.fn(() => {
       throw new Error('toolContext not ready')
     })
-    const trigger = createShutdownTrigger(onDone, getDb)
+    const trigger = createShutdownTrigger(onDone, { getDb })
 
     expect(() => trigger()).not.toThrow()
 
@@ -285,24 +289,26 @@ describe('createShutdownTrigger — getDb wiring (SMI-5639)', () => {
       throw closeError
     })
     const onDone = vi.fn()
-    const trigger = createShutdownTrigger(onDone, () => db as unknown as DatabaseType)
+    const trigger = createShutdownTrigger(onDone, { getDb: () => db as unknown as DatabaseType })
 
     const start = Date.now()
     expect(() => trigger()).not.toThrow()
+
+    await vi.waitFor(() =>
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to close database'),
+        expect.objectContaining({ err: closeError })
+      )
+    )
     const elapsed = Date.now() - start
 
-    // closeDbOnShutdown is fully synchronous (try/catch, no await) and runs
-    // BEFORE the telemetry flush is even started, so a regression that made
-    // the close-on-error path hang (e.g. awaiting something inside the catch)
-    // would blow well past this bound. This is a distinct assertion from the
-    // telemetry flush's own 2000ms timeout bound (TELEMETRY_SHUTDOWN_FLUSH_TIMEOUT_MS) —
-    // it pins the SYNCHRONOUS close path specifically.
-    expect(elapsed).toBeLessThan(100)
-
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to close database'),
-      expect.objectContaining({ err: closeError })
-    )
+    // The close-on-error path itself has no await inside its try/catch, so a
+    // regression that made it hang would still blow well past this bound —
+    // this is a distinct assertion from the telemetry flush's own 2000ms
+    // timeout bound (TELEMETRY_SHUTDOWN_FLUSH_TIMEOUT_MS). It no longer pins
+    // the FIRST microtask tick (quiesce now legitimately runs before close),
+    // just that the whole sequence isn't hanging.
+    expect(elapsed).toBeLessThan(500)
 
     await vi.waitFor(() => expect(onDone).toHaveBeenCalledTimes(1))
   })
@@ -312,20 +318,20 @@ describe('createShutdownTrigger — getDb wiring (SMI-5639)', () => {
     // twice (e.g. transport.onclose firing after a signal already fired the
     // same registered listener). Cross-instance/racing-trigger scenarios —
     // two INDEPENDENTLY created triggers firing concurrently (e.g. SIGTERM
-    // racing SIGINT) — are Wave 3's manual verification scope, not this test.
+    // racing SIGINT) — are covered by the re-entrancy test below (SMI-5649
+    // made this load-bearing: a second sequence must never race the first).
     const db = createMockDb(true)
     db.close.mockImplementation(() => {
       db.open = false
     })
     const onDone = vi.fn()
-    const trigger = createShutdownTrigger(onDone, () => db as unknown as DatabaseType)
+    const trigger = createShutdownTrigger(onDone, { getDb: () => db as unknown as DatabaseType })
 
     trigger()
     trigger()
-
-    expect(db.close).toHaveBeenCalledTimes(1)
 
     await vi.waitFor(() => expect(onDone).toHaveBeenCalledTimes(2))
+    expect(db.close).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/mcp-server/src/shutdown.ts
+++ b/packages/mcp-server/src/shutdown.ts
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Flush-on-shutdown wiring for the Skillsmith MCP server (SMI-5479).
+ * @fileoverview Unified shutdown coordinator for the Skillsmith MCP server
+ * (SMI-5479, extended SMI-5649 + SMI-5640).
  * @module @skillsmith/mcp-server/shutdown
  *
  * Extracted from `index.ts`'s `main()` into its own module for two reasons:
@@ -16,6 +17,22 @@
  * on the mediation-gate metric (systematically undercounts short sessions)
  * and a smoke run that calls one tool and exits loses the event 100% of the
  * time.
+ *
+ * SMI-5649 + SMI-5640: this module grew from a single db-close+telemetry-flush
+ * trigger into the ONE shutdown coordinator for the whole process. Previously,
+ * `context.async.ts` (and its sync sibling `context.ts`) each registered their
+ * OWN independent SIGTERM/SIGINT handlers whose fire-and-forget
+ * `backgroundSync?.stop()` raced this module's `closeDbOnShutdown()` with no
+ * ordering guarantee — an in-flight sync write could hit a closed db. Both
+ * independent registrations are now deleted; `index.ts` is the single
+ * registration site, and `runShutdownSequence` below owns the ordered
+ * sequence: quiesce background work -> close LLM failover -> close/persist db
+ * -> flush telemetry. A periodic autosave timer (SMI-5640) also lives here,
+ * bounding data loss on an *ungraceful* kill (SIGKILL/crash/power-loss) that
+ * no shutdown hook can ever catch.
+ *
+ * See docs/internal/implementation/mcp-shutdown-followup-hardening-wave-a-design.md
+ * for the full design rationale.
  */
 
 import { shutdownPostHog } from '@skillsmith/core/telemetry'
@@ -25,9 +42,49 @@ import { createLogger } from '@skillsmith/core/logging'
 /** Bound on how long a shutdown flush may block process exit. */
 export const TELEMETRY_SHUTDOWN_FLUSH_TIMEOUT_MS = 2000
 
+/**
+ * Bound on how long background-work quiesce (awaiting an in-flight sync) may
+ * block process exit (SMI-5649). Symmetric with
+ * {@link TELEMETRY_SHUTDOWN_FLUSH_TIMEOUT_MS} — see the design doc §2.3 for
+ * the full rationale on why proceeding to close the db on timeout is safe.
+ */
+export const SHUTDOWN_QUIESCE_TIMEOUT_MS = 2000
+
+/**
+ * Default periodic autosave cadence for the WASM driver (SMI-5640): 5
+ * minutes. Overridable via `SKILLSMITH_AUTOSAVE_INTERVAL_MS` (primarily so
+ * tests don't wait 5 real minutes); disable entirely via
+ * `SKILLSMITH_AUTOSAVE_DISABLE=1`. See
+ * docs/internal/process/guards-and-opt-outs.md.
+ */
+const DEFAULT_AUTOSAVE_INTERVAL_MS = 300_000
+
 const logger = createLogger('mcp')
 
+// ── coordinator-owned module state ──────────────────────────────────────────
 let shuttingDown = false
+/** Re-entrancy latch (SMI-5649): a second trigger awaits the SAME in-flight
+ * sequence rather than racing a second, independent one. Load-bearing, not
+ * cosmetic — see the design doc §1.3 Subtlety A. */
+let shutdownPromise: Promise<void> | null = null
+/** Periodic autosave timer handle (SMI-5640). */
+let flushTimer: ReturnType<typeof setInterval> | null = null
+
+/**
+ * Late-bound cleanup steps handed to the ONE shutdown coordinator by
+ * `index.ts`. All hooks are optional and called fail-soft — a missing or
+ * throwing hook never blocks or crashes the shutdown sequence.
+ */
+export interface ShutdownHooks {
+  /** Lazy getter for the tool-context db (late-bound; `toolContext` is
+   * assigned in `main()` AFTER the trigger is built). */
+  getDb?: () => DatabaseType | undefined
+  /** Quiesce background async work: abort + await in-flight sync. Resolves
+   * when settled (or when the caller's own bounded timeout elapses). */
+  quiesce?: () => Promise<void>
+  /** Close the LLM failover chain (synchronous, idempotent). */
+  closeLlmFailover?: () => void
+}
 
 /**
  * Attempt to flush + shut down the PostHog client, bounded by `timeoutMs`
@@ -35,15 +92,13 @@ let shuttingDown = false
  * block process exit. Fail-soft — mirrors `shutdownPostHog`'s own internal
  * try/catch; a flush error must never propagate.
  *
- * Idempotent within a process: a second call while a flush is already in
- * flight (or has completed) is a no-op, so wiring this to multiple shutdown
- * triggers (transport close, SIGTERM, SIGINT) can never double-flush or race.
+ * Unguarded internal helper — see {@link flushTelemetryOnShutdown} for the
+ * guarded public wrapper. Split out (SMI-5649) so the coordinator's own
+ * step 4 isn't skipped by the `shuttingDown` guard it itself sets at step 0.
  */
-export async function flushTelemetryOnShutdown(
+async function doFlushTelemetry(
   timeoutMs: number = TELEMETRY_SHUTDOWN_FLUSH_TIMEOUT_MS
 ): Promise<void> {
-  if (shuttingDown) return
-  shuttingDown = true
   try {
     await Promise.race([
       shutdownPostHog(),
@@ -55,11 +110,32 @@ export async function flushTelemetryOnShutdown(
 }
 
 /**
- * Test-only reset of the module-level shutdown guard. Not exported from the
- * package index.
+ * Attempt to flush + shut down the PostHog client, bounded by `timeoutMs`.
+ *
+ * Idempotent within a process: a second call while a flush is already in
+ * flight (or has completed) is a no-op, so wiring this to multiple shutdown
+ * triggers (transport close, SIGTERM, SIGINT) can never double-flush or race.
+ * This guarded wrapper is for standalone callers (e.g. the integration test);
+ * the coordinator's own step 4 calls the internal unguarded
+ * {@link doFlushTelemetry} directly so its own `shuttingDown = true` (set at
+ * step 0) can't short-circuit its own flush (design doc §1.3 Subtlety B).
+ */
+export async function flushTelemetryOnShutdown(
+  timeoutMs: number = TELEMETRY_SHUTDOWN_FLUSH_TIMEOUT_MS
+): Promise<void> {
+  if (shuttingDown) return
+  shuttingDown = true
+  await doFlushTelemetry(timeoutMs)
+}
+
+/**
+ * Test-only reset of the module-level shutdown coordinator state. Not
+ * exported from the package index.
  */
 export function _resetShutdownGuardForTests(): void {
   shuttingDown = false
+  shutdownPromise = null
+  stopPeriodicFlush()
 }
 
 /**
@@ -101,25 +177,154 @@ export function closeDbOnShutdown(getDb?: () => DatabaseType | undefined): void 
 }
 
 /**
- * Build a shutdown trigger: close the tool-context database (via
- * {@link closeDbOnShutdown}, synchronously, so WASM-driver persistence isn't
- * gated behind the telemetry flush's timeout), then run
- * {@link flushTelemetryOnShutdown}, then call `onDone` (index.ts passes
- * `() => process.exit(0)`). Registering ANY listener for SIGTERM/SIGINT
- * overrides Node's default terminate-on-signal behavior, so `index.ts` MUST
- * call this for each of transport `onclose` / SIGTERM / SIGINT to preserve
- * today's default (process exits promptly on those signals) rather than
- * leaving the process hanging once a listener is registered.
- *
- * @param getDb - Optional lazy getter for the current db, so shutdown can
- *   close/persist it before the process exits (SMI-5639).
+ * Fail-soft wrapper around `hooks.quiesce`: awaits background-work quiesce
+ * (abort + await in-flight sync), never letting a throwing/rejecting hook
+ * escape into the shutdown sequence. The bounded timeout itself lives in the
+ * hook implementation (`index.ts`'s `quiesceBackgroundSync`, SMI-5649 §2.3) —
+ * this wrapper is defense-in-depth for a hook that misbehaves outside that
+ * contract.
  */
-export function createShutdownTrigger(
-  onDone: () => void,
-  getDb?: () => DatabaseType | undefined
-): () => void {
+async function runQuiesce(quiesce?: () => Promise<void>): Promise<void> {
+  if (!quiesce) return
+  try {
+    await quiesce()
+  } catch (error) {
+    logger.error('[skillsmith] Background sync quiesce failed during shutdown', { err: error })
+  }
+}
+
+/**
+ * Fail-soft wrapper around `hooks.closeLlmFailover`: closes the LLM failover
+ * chain (if configured), never letting a throwing hook escape into the
+ * shutdown sequence.
+ */
+function safeCloseLlmFailover(closeLlmFailover?: () => void): void {
+  try {
+    closeLlmFailover?.()
+  } catch (error) {
+    logger.error('[skillsmith] Failed to close LLM failover chain on shutdown', { err: error })
+  }
+}
+
+/**
+ * The ONE shutdown coordinator (SMI-5649 + SMI-5640). Idempotent and
+ * re-entrant: a second call while a sequence is already in flight returns
+ * the SAME promise rather than racing a second, independent sequence — this
+ * is load-bearing (design doc §1.3 Subtlety A), not cosmetic: without it, a
+ * second trigger (e.g. `onclose` firing while a `SIGTERM`-triggered sequence
+ * is still parked in quiesce) could exit the process mid-persist, re-losing
+ * exactly the data this wave protects.
+ *
+ * Ordered sequence: stop the autosave timer -> quiesce background work
+ * (abort + await in-flight sync, bounded fail-soft) -> close the LLM
+ * failover chain -> close/persist the db (idempotent via `db.open`) -> flush
+ * telemetry (bounded fail-soft).
+ */
+export function runShutdownSequence(hooks: ShutdownHooks): Promise<void> {
+  if (shutdownPromise) return shutdownPromise
+  shutdownPromise = (async () => {
+    shuttingDown = true
+    stopPeriodicFlush() // 0. stop autosave before we begin tearing down
+    await runQuiesce(hooks.quiesce) // 1. abort + await in-flight sync (bounded, fail-soft)
+    safeCloseLlmFailover(hooks.closeLlmFailover) // 2. close LLM failover
+    closeDbOnShutdown(hooks.getDb) // 3. close/persist db (idempotent via db.open)
+    await doFlushTelemetry() // 4. flush PostHog (bounded, fail-soft)
+  })()
+  return shutdownPromise
+}
+
+/**
+ * Build the single shutdown trigger. `index.ts` registers the returned
+ * function on `transport.onclose` + `SIGTERM` + `SIGINT` — the ONE
+ * registration site for the whole server (SMI-5649: `context.async.ts` and
+ * `context.ts` previously each registered their own independent, racing set).
+ * Registering ANY listener for SIGTERM/SIGINT overrides Node's default
+ * terminate-on-signal behavior, so `index.ts` MUST call this for each trigger
+ * to preserve today's default (process exits promptly on those signals)
+ * rather than leaving the process hanging once a listener is registered.
+ *
+ * @param onDone - Called once the shutdown sequence settles (index.ts passes
+ *   `() => process.exit(0)`).
+ * @param hooks - Late-bound cleanup steps (see {@link ShutdownHooks}).
+ */
+export function createShutdownTrigger(onDone: () => void, hooks: ShutdownHooks = {}): () => void {
   return () => {
-    closeDbOnShutdown(getDb)
-    void flushTelemetryOnShutdown().finally(onDone)
+    void runShutdownSequence(hooks).finally(onDone)
+  }
+}
+
+// ── SMI-5640: periodic autosave (WASM driver only) ──────────────────────────
+
+/** Structural shape of the WASM driver's explicit persist method. Not on the
+ * shared `Database`/`DatabaseType` interface — `SqlJsDatabaseAdapter` alone
+ * exposes it (`sqljsDriver.ts`). Kept localized here (a structural guard)
+ * rather than widening the shared interface, since the native
+ * (better-sqlite3) driver has no meaningful equivalent — it writes through
+ * to disk on every statement and needs no timer. */
+type Persistable = { persist: () => void }
+
+function isPersistable(db: unknown): db is Persistable {
+  return !!db && typeof (db as Partial<Persistable>).persist === 'function'
+}
+
+/**
+ * Fail-soft periodic persist for the WASM driver (SMI-5640): calls the
+ * driver's own `persist()` (export + `writeFileSync`, without tearing down
+ * the WASM instance — see the design doc §3.1 for why this is preferred over
+ * `close()`+reopen). No-op on the native (better-sqlite3) driver — it has no
+ * `persist` method and needs none — and on a closed or in-memory db.
+ */
+export function persistDbIfSupported(getDb?: () => DatabaseType | undefined): void {
+  try {
+    const db = getDb?.()
+    if (db && db.open && !db.memory && isPersistable(db)) {
+      db.persist()
+    }
+  } catch (error) {
+    logger.error(
+      '[skillsmith] Periodic autosave persist failed — recent writes may not survive an ungraceful kill',
+      { err: error }
+    )
+  }
+}
+
+/**
+ * Start the periodic autosave timer (SMI-5640): defense-in-depth for an
+ * *ungraceful* kill (SIGKILL, crash, power loss) that no shutdown hook can
+ * ever catch. Only arms the timer for a WASM + file-backed db — no pointless
+ * wakeups on the native path or in-memory tests. `unref()`'d so it can never
+ * keep the event loop alive or block process exit.
+ *
+ * Cadence: `SKILLSMITH_AUTOSAVE_INTERVAL_MS` env override, else
+ * {@link DEFAULT_AUTOSAVE_INTERVAL_MS} (5 minutes — see design doc §3.3 for
+ * the cost/benefit rationale). Disable entirely via
+ * `SKILLSMITH_AUTOSAVE_DISABLE=1`.
+ *
+ * The flush callback no-ops while `shuttingDown` is set — the shutdown
+ * sequence owns the final persist (step 3 above), so once it starts, the
+ * timer callback (if it fires again before `stopPeriodicFlush()` clears it)
+ * must not race it. See design doc §3.5 for the full flush-vs-live-query
+ * atomicity argument (every driver op is synchronous within one microtask,
+ * so a timer-driven `persist()` can never observe a half-applied statement).
+ */
+export function startPeriodicFlush(getDb: () => DatabaseType | undefined): void {
+  if (process.env.SKILLSMITH_AUTOSAVE_DISABLE === '1') return
+  const db = getDb()
+  if (!db || db.memory || !isPersistable(db)) return // WASM + file-backed only
+  const intervalMs =
+    Number(process.env.SKILLSMITH_AUTOSAVE_INTERVAL_MS) || DEFAULT_AUTOSAVE_INTERVAL_MS
+  flushTimer = setInterval(() => {
+    if (shuttingDown) return // shutdown owns the final persist
+    persistDbIfSupported(getDb)
+  }, intervalMs)
+  flushTimer.unref?.()
+}
+
+/** Stop the periodic autosave timer. Idempotent. Called as step 0 of
+ * {@link runShutdownSequence} and by {@link _resetShutdownGuardForTests}. */
+export function stopPeriodicFlush(): void {
+  if (flushTimer) {
+    clearInterval(flushTimer)
+    flushTimer = null
   }
 }

--- a/packages/mcp-server/tests/context-async-listeners.test.ts
+++ b/packages/mcp-server/tests/context-async-listeners.test.ts
@@ -1,10 +1,23 @@
 /**
- * SMI-4694: Listener-count audit for context.async.ts (Module 1).
+ * SMI-4694 (updated SMI-5649): Listener-count audit for context.async.ts
+ * (Module 1).
  *
- * Verifies that createToolContextAsync + closeToolContext is symmetric for
- * SIGTERM/SIGINT signal handlers, including when backgroundSync and
- * llmFailover paths are forced on (the only conditions that register
- * handlers — see context.async.ts:236-252).
+ * Prior to SMI-5649, `createToolContextAsync` registered its OWN
+ * SIGTERM/SIGINT handlers whenever backgroundSync or llmFailover was enabled
+ * — this test verified that registration was symmetric with
+ * `closeToolContext`. SMI-5649 deleted that registration entirely: it was
+ * the root cause of the shutdown race (two independent, unordered handler
+ * sets could both fire on the same signal, racing a fire-and-forget
+ * `backgroundSync?.stop()` against `index.ts`'s db close). Signal ownership
+ * now belongs SOLELY to `index.ts`'s single shutdown coordinator
+ * (`shutdown.ts`) — see
+ * docs/internal/implementation/mcp-shutdown-followup-hardening-wave-a-design.md
+ * §Deliverable 4.
+ *
+ * This test now asserts the NEW invariant: creating/closing a tool context
+ * NEVER touches process-level SIGTERM/SIGINT listeners at all, even with
+ * backgroundSync and llmFailover both enabled — that's exactly what makes
+ * "exactly one registration site" (the coordinator) true.
  *
  * Reference pattern: packages/core/tests/api/client.events.test.ts:39-72
  */
@@ -14,8 +27,8 @@ import { SyncConfigRepository } from '@skillsmith/core'
 import { createToolContextAsync } from '../src/context.async.js'
 import { closeToolContext } from '../src/context.js'
 
-describe('SMI-4694: context.async.ts listener-count audit', () => {
-  it('does NOT leak SIGTERM/SIGINT listeners when sync + failover are enabled', async () => {
+describe('SMI-4694/SMI-5649: context.async.ts listener-count audit', () => {
+  it('never registers SIGTERM/SIGINT listeners, even when sync + failover are enabled', async () => {
     const before = {
       sigterm: process.listenerCount('SIGTERM'),
       sigint: process.listenerCount('SIGINT'),
@@ -39,7 +52,8 @@ describe('SMI-4694: context.async.ts listener-count audit', () => {
       // syncConfig.enabled returning true. Fresh DB defaults syncConfig.enabled
       // to TRUE (SyncConfigRepository.ts:96 — 'enabled INTEGER NOT NULL
       // DEFAULT 1'). With backgroundSyncConfig.enabled !== false AND
-      // llmFailoverConfig.enabled === true, both branches register handlers.
+      // llmFailoverConfig.enabled === true, both services ARE created — but
+      // post-SMI-5649, neither registers a process-level signal listener.
       const ctx = await createToolContextAsync({
         dbPath: ':memory:',
         apiClientConfig: { offlineMode: true },
@@ -47,13 +61,18 @@ describe('SMI-4694: context.async.ts listener-count audit', () => {
         llmFailoverConfig: { enabled: true },
       })
 
-      // Sanity: handlers must be registered for the audit to be meaningful.
+      // Sanity: the services themselves must actually be constructed for
+      // this audit to be meaningful (otherwise "no listeners" would be
+      // trivially true because nothing was created).
+      expect(ctx.backgroundSync).toBeDefined()
+      expect(ctx.llmFailover).toBeDefined()
+
       const mid = {
         sigterm: process.listenerCount('SIGTERM'),
         sigint: process.listenerCount('SIGINT'),
       }
-      expect(mid.sigterm).toBeGreaterThan(before.sigterm)
-      expect(mid.sigint).toBeGreaterThan(before.sigint)
+      expect(mid.sigterm).toBe(before.sigterm)
+      expect(mid.sigint).toBe(before.sigint)
 
       await closeToolContext(ctx)
     }

--- a/packages/mcp-server/tests/shutdown-persistence-subprocess.test.ts
+++ b/packages/mcp-server/tests/shutdown-persistence-subprocess.test.ts
@@ -19,9 +19,12 @@
 import { spawn, spawnSync } from 'node:child_process'
 import { existsSync, statSync, rmSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import * as http from 'node:http'
+import type { AddressInfo } from 'node:net'
 import * as os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { createToolContextAsync, closeToolContext } from '../src/context.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -177,6 +180,224 @@ describe.skipIf(skipInPrePush)('SMI-5639 shutdown persistence — subprocess SIG
       expect(existsSync(tmpDbPath)).toBe(true)
       const stats = statSync(tmpDbPath)
       expect(stats.size).toBeGreaterThan(0)
+    } finally {
+      if (proc.exitCode === null && proc.signalCode === null) {
+        proc.kill('SIGKILL')
+      }
+    }
+  }, 75_000)
+
+  /**
+   * SMI-5649 Wave A Step 4: the race-fix proof. Before this wave,
+   * `context.async.ts` registered its OWN independent SIGTERM/SIGINT
+   * handlers whose `backgroundSync?.stop()` was fire-and-forget — it did not
+   * await the in-flight sync, so a write from `SyncEngine.upsertSkills()`
+   * could still be issued after `index.ts`'s independently-registered
+   * handlers had already closed the db. This test forces a REAL background
+   * sync to be genuinely in flight (deliberately does NOT set
+   * `SKILLSMITH_BACKGROUND_SYNC=false`, unlike the test above) by pointing
+   * the API client at a local HTTP stub (`SKILLSMITH_API_URL`) that stalls
+   * its `/skills-search` response, then sends SIGTERM while that request is
+   * still pending. The coordinator must quiesce (abort + await) that sync
+   * before closing the db — a clean exit 0 and a valid persisted file prove
+   * no write raced the close.
+   */
+  it('an in-flight background sync at SIGTERM time settles cleanly before db close (no write races the close)', async () => {
+    tmpDbPath = path.join(
+      os.tmpdir(),
+      `skillsmith-shutdown-subprocess-race-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+    )
+
+    let searchRequestReceived: () => void
+    const searchRequestReceivedPromise = new Promise<void>((resolve) => {
+      searchRequestReceived = resolve
+    })
+
+    // Minimal local stub: /health responds fast (checkApiHealth's own 5s
+    // timeout must not trip); /skills-search stalls for well longer than the
+    // test needs to observe + send SIGTERM, simulating a genuinely in-flight
+    // sync request at signal time.
+    const stubServer = http.createServer((req, res) => {
+      if (req.url?.startsWith('/health')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ status: 'healthy', version: '1.0.0' }))
+        return
+      }
+      if (req.url?.startsWith('/skills-search')) {
+        searchRequestReceived()
+        // Never respond within this test's lifetime — the abort signal (not
+        // a resolved/rejected fetch) is what ends this request from the
+        // client's perspective once quiesce runs.
+        return
+      }
+      res.writeHead(404)
+      res.end()
+    })
+
+    await new Promise<void>((resolve) => stubServer.listen(0, '127.0.0.1', resolve))
+    const stubPort = (stubServer.address() as AddressInfo).port
+
+    const proc = spawn('node', [DIST_ENTRY], {
+      env: {
+        ...process.env,
+        SKILLSMITH_FORCE_WASM: 'true',
+        SKILLSMITH_DB_PATH: tmpDbPath,
+        SKILLSMITH_SKIP_SKILL_INSTALL: '1',
+        SKILLSMITH_AUTO_UPDATE_CHECK: 'false',
+        SKILLSMITH_TIER1_AUTOINSTALL_DISABLE: '1',
+        SKILLSMITH_AUDIT_EMAIL_DISABLE: '1',
+        SKILLSMITH_AUTOSAVE_DISABLE: '1',
+        // Deliberately NOT setting SKILLSMITH_BACKGROUND_SYNC=false — the
+        // whole point of this test is a REAL in-flight background sync.
+        SKILLSMITH_API_URL: `http://127.0.0.1:${stubPort}`,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    const stderrChunks: string[] = []
+    proc.stderr.on('data', (d: Buffer) => stderrChunks.push(d.toString()))
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error(`server boot timeout — stderr so far:\n${stderrChunks.join('')}`))
+        }, 60_000)
+        proc.stderr.on('data', (d: Buffer) => {
+          if (d.toString().includes('Skillsmith MCP server running')) {
+            clearTimeout(timeout)
+            resolve()
+          }
+        })
+        proc.on('error', (err) => {
+          clearTimeout(timeout)
+          reject(err)
+        })
+      })
+
+      // Wait for the stub to actually receive the search request — proves a
+      // real sync is genuinely mid-fetch, not a race against an assumption
+      // about startup timing.
+      await Promise.race([
+        searchRequestReceivedPromise,
+        new Promise<void>((_resolve, reject) =>
+          setTimeout(
+            () => reject(new Error('background sync never reached /skills-search in time')),
+            20_000
+          )
+        ),
+      ])
+
+      const exitCode = await new Promise<number | null>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(
+            new Error(
+              `process did not exit within 10s of SIGTERM — stderr:\n${stderrChunks.join('')}`
+            )
+          )
+        }, 10_000)
+        proc.on('exit', (code) => {
+          clearTimeout(timeout)
+          resolve(code)
+        })
+        proc.kill('SIGTERM')
+      })
+
+      // The whole point: a clean exit 0 proves the coordinator's quiesce
+      // (abort + await the in-flight sync) settled before db close/process
+      // exit — not a hang, not a crash from a write hitting a closed db.
+      expect(exitCode).toBe(0)
+      expect(existsSync(tmpDbPath)).toBe(true)
+      expect(statSync(tmpDbPath).size).toBeGreaterThan(0)
+    } finally {
+      if (proc.exitCode === null && proc.signalCode === null) {
+        proc.kill('SIGKILL')
+      }
+      await new Promise<void>((resolve) => stubServer.close(() => resolve()))
+    }
+  }, 75_000)
+
+  /**
+   * SMI-5640: autosave survives an ungraceful kill. Unlike the SIGTERM test
+   * above (which asserts the db file does NOT exist until the graceful
+   * shutdown persists it), this is the novel proof for the periodic
+   * autosave: the file must exist BEFORE any signal is ever sent, and its
+   * content must survive a SIGKILL (which bypasses every shutdown hook
+   * entirely — no coordinator, no `onclose`, nothing).
+   */
+  it('the periodic autosave persists to disk before any signal, and survives SIGKILL', async () => {
+    tmpDbPath = path.join(
+      os.tmpdir(),
+      `skillsmith-shutdown-subprocess-autosave-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+    )
+
+    const proc = spawn('node', [DIST_ENTRY], {
+      env: {
+        ...process.env,
+        SKILLSMITH_FORCE_WASM: 'true',
+        SKILLSMITH_DB_PATH: tmpDbPath,
+        SKILLSMITH_SKIP_SKILL_INSTALL: '1',
+        SKILLSMITH_AUTO_UPDATE_CHECK: 'false',
+        SKILLSMITH_TIER1_AUTOINSTALL_DISABLE: '1',
+        SKILLSMITH_AUDIT_EMAIL_DISABLE: '1',
+        SKILLSMITH_BACKGROUND_SYNC: 'false',
+        // Short interval so the test doesn't wait the real 5-minute default.
+        SKILLSMITH_AUTOSAVE_INTERVAL_MS: '200',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    const stderrChunks: string[] = []
+    proc.stderr.on('data', (d: Buffer) => stderrChunks.push(d.toString()))
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error(`server boot timeout — stderr so far:\n${stderrChunks.join('')}`))
+        }, 60_000)
+        proc.stderr.on('data', (d: Buffer) => {
+          if (d.toString().includes('Skillsmith MCP server running')) {
+            clearTimeout(timeout)
+            resolve()
+          }
+        })
+        proc.on('error', (err) => {
+          clearTimeout(timeout)
+          reject(err)
+        })
+      })
+
+      // Wait comfortably past several flush intervals — no signal sent yet.
+      await new Promise((resolve) => setTimeout(resolve, 1500))
+
+      // The novel assertion (contrast the SIGTERM test above, which asserts
+      // non-existence until the signal): the autosave timer, not any
+      // shutdown hook, has already written the file to disk.
+      expect(existsSync(tmpDbPath)).toBe(true)
+      expect(statSync(tmpDbPath).size).toBeGreaterThan(0)
+
+      // An ungraceful kill — bypasses transport.onclose, SIGTERM, SIGINT,
+      // the whole shutdown coordinator entirely.
+      const exitPromise = new Promise<void>((resolve) => proc.on('exit', () => resolve()))
+      proc.kill('SIGKILL')
+      await exitPromise
+
+      // Reopen a FRESH connection against the same on-disk file — proves the
+      // autosave's last flush produced a valid, non-corrupt export that
+      // survives a kill no shutdown hook could ever catch.
+      const freshContext = await createToolContextAsync({
+        dbPath: tmpDbPath,
+        backgroundSyncConfig: { enabled: false },
+        apiClientConfig: { offlineMode: true },
+      })
+      try {
+        expect(freshContext.db.open).toBe(true)
+        const tables = freshContext.db
+          .prepare<{ name: string }>("SELECT name FROM sqlite_master WHERE type='table'")
+          .all()
+        expect(tables.some((t) => t.name === 'skills')).toBe(true)
+      } finally {
+        await closeToolContext(freshContext)
+      }
     } finally {
       if (proc.exitCode === null && proc.signalCode === null) {
         proc.kill('SIGKILL')


### PR DESCRIPTION
## Business Summary

**What shipped:** Two related shutdown-safety fixes, designed and implemented together since they share the same underlying machinery. First, a race that the recent shutdown-persistence fix itself introduced: a background sync write in flight at the exact moment of shutdown could throw against a database that had just been closed — impossible before that fix (the database was never actually closed at all), so this is new-but-latent, not a regression in shipped behavior. Second, defense-in-depth against an *ungraceful* kill (crash, force-quit, power loss) that no graceful-shutdown fix can ever catch — the server now periodically saves its data in the background, bounding how much could ever be lost to a kill nobody could have caught cleanly.

**Quality bar:** Went through a dedicated Opus-tier design pass (written up as its own design document) before implementation, plus the standard plan-review process. Along the way, found and fixed two additional copies of the same underlying bug (in code paths not originally scoped) rather than leaving them as known gaps. Full test suite (7,430 tests) passes with the same 4 pre-existing, unrelated failures both before and after this change — confirmed by comparing with the change temporarily removed.

**Found along the way:** none new — this PR itself resolves two already-tracked issues (SMI-5649, SMI-5640) plus two additional instances of the same pattern discovered and fixed in the same pass (documented in Technical detail below).

**Net result:** Fully shipped, ready to merge.

---

## Technical detail

- `packages/mcp-server/src/shutdown.ts` — grew from a single db-close+telemetry-flush trigger into the one shutdown coordinator (`runShutdownSequence`): quiesce background work → close LLM failover → close/persist db → flush telemetry, with a re-entrancy latch so a second trigger can't race a mid-persist exit. Also adds the SMI-5640 periodic autosave (WASM driver only, 5-min default via `SKILLSMITH_AUTOSAVE_INTERVAL_MS`/`SKILLSMITH_AUTOSAVE_DISABLE` — both registered in `docs/internal/process/guards-and-opt-outs.md`).
- `packages/core/src/sync/BackgroundSyncService.ts` — `stop()` is now `Promise<void>` (aborts + awaits any in-flight sync via a fresh `AbortController` per start, instead of fire-and-forget); default `onSyncError` now logs instead of silently swallowing.
- `packages/core/src/sync/SyncEngine.ts` — `sync()` accepts an `AbortSignal`, checked at each write boundary so an aborted sync never starts a new write.
- `packages/mcp-server/src/index.ts` (+ new `index.shutdown-helpers.ts` sibling, to stay under the file-size gate) — the single SIGTERM/SIGINT registration site, with a bounded 2s quiesce timeout (safe to proceed past on timeout since the abort checkpoint guarantees no new write begins).
- `packages/mcp-server/src/context.async.ts` **and** `packages/mcp-server/src/context.ts` — both deleted their own independent SIGTERM/SIGINT registrations (the second one, in `context.ts`, was an identical latent copy of the same bug found during implementation, not in the original scope — it never actually corrupted runtime behavior since that code path is unused by the running server, but it broke the "exactly one registration site" invariant, so it's fixed here too).
- `event-batcher.ts`'s own separate SIGTERM/SIGINT registration (a telemetry-batch-drain concern, already suppressed under `VITEST=true`) was deliberately left untouched, per the design doc's explicit finding that it's a legitimate separate concern out of this PR's scope — instead, the "exactly one registration site" test was placed as an in-process unit test (not a full-boot subprocess test) specifically to avoid a false/flaky assertion from this other listener.
- Tests: a real subprocess test forcing an in-flight sync at SIGTERM and asserting it settles before db close; an autosave-survives-SIGKILL subprocess test; an in-process single-registration-site unit test; coordinator ordering/re-entrancy/fail-soft unit tests; abortable-sync/awaitable-stop unit tests.
- Design doc: `docs/internal/implementation/mcp-shutdown-followup-hardening-wave-a-design.md` (Opus design pass, referenced throughout the diff's comments for full rationale).
- Verified host-side (this worktree's container hit the unrelated SMI-5656 restart-loop at push time, bypassed via `--no-verify` per standing authorization — commits themselves went through the pre-commit hook cleanly): `tsc --build`, `eslint`, `prettier --check` all clean; full `core`+`mcp-server` vitest suite (7,430 tests) — same 4 pre-existing unrelated failures before and after (confirmed via `git stash`); `npm run audit:standards` clean; a `/concurrency-audit` Mode B diff scan found 0 unmitigated hits.

Part of the SMI-5639 followups plan (`docs/internal/implementation/mcp-shutdown-followup-hardening.md`, Wave A).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)