### PR TITLE
fix(scripts): harden repair-host-native-deps.sh's esbuild check (SMI-5654)

### DIFF
--- a/scripts/repair-host-native-deps.sh
+++ b/scripts/repair-host-native-deps.sh
@@ -38,22 +38,42 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=_lib.sh
 source "$SCRIPT_DIR/_lib.sh"
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
-if [[ -z "$REPO_ROOT" ]]; then
-  error "Not in a git repository."
-fi
+# --- Test seams (inert unless SKILLSMITH_NATIVE_DEPS_TEST=1) -----------------
+# Let scripts/tests/repair-host-native-deps.test.ts (SMI-5654) drive the
+# esbuild platform-package hardening below deterministically against a
+# fixture tree — without mutating real host state, requiring network access,
+# or running the (separate, already-covered) better-sqlite3 rebuild phase.
+# Gated behind a single master switch so production behavior can never be
+# hijacked by a stray env var, mirroring the SKILLSMITH_AUTOHEAL_TEST
+# convention in scripts/retrieval-autoheal.sh.
+NATIVE_DEPS_TEST="${SKILLSMITH_NATIVE_DEPS_TEST:-}"
 
-# Resolve to main repo if invoked from a worktree (writer's binding lives in
-# the main-repo node_modules; per-package symlinks resolve to it via SMI-4381).
-MAIN_GIT_DIR="$(get_main_git_dir "$REPO_ROOT")"
-if [[ "$MAIN_GIT_DIR" != "$REPO_ROOT/.git" ]] && [[ -n "$MAIN_GIT_DIR" ]]; then
-  REPO_ROOT="$(dirname "$MAIN_GIT_DIR")"
+if [[ "$NATIVE_DEPS_TEST" == "1" ]] && [[ -n "${SKILLSMITH_NATIVE_DEPS_REPO_ROOT:-}" ]]; then
+  # Test seam: operate on a fixture tree instead of the real repo root.
+  REPO_ROOT="$SKILLSMITH_NATIVE_DEPS_REPO_ROOT"
+else
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+  if [[ -z "$REPO_ROOT" ]]; then
+    error "Not in a git repository."
+  fi
+
+  # Resolve to main repo if invoked from a worktree (writer's binding lives in
+  # the main-repo node_modules; per-package symlinks resolve to it via SMI-4381).
+  MAIN_GIT_DIR="$(get_main_git_dir "$REPO_ROOT")"
+  if [[ "$MAIN_GIT_DIR" != "$REPO_ROOT/.git" ]] && [[ -n "$MAIN_GIT_DIR" ]]; then
+    REPO_ROOT="$(dirname "$MAIN_GIT_DIR")"
+  fi
 fi
 
 # Guard 1: don't run inside Docker — the container has its own postinstall path.
+# SMI-5654 test seam: FORCE_NON_DOCKER lets scripts/tests exercise this
+# script's logic inside the CI container (itself Docker), mirroring
+# scripts/retrieval-autoheal.sh's identical seam.
 if [[ "${IS_DOCKER:-}" == "true" ]] || [[ -f /.dockerenv ]]; then
-  printf '[skip] inside Docker — host-only script; container handles its own postinstall\n'
-  exit 0
+  if ! { [[ "$NATIVE_DEPS_TEST" == "1" ]] && [[ "${SKILLSMITH_NATIVE_DEPS_FORCE_NON_DOCKER:-}" == "1" ]]; }; then
+    printf '[skip] inside Docker — host-only script; container handles its own postinstall\n'
+    exit 0
+  fi
 fi
 
 cd "$REPO_ROOT"
@@ -74,6 +94,13 @@ repair_platform_native_packages() {
   local platform arch timeout_cmd
   platform="$(node -p 'process.platform' 2>/dev/null || echo '')"
   arch="$(node -p 'process.arch' 2>/dev/null || echo '')"
+
+  # SMI-5654 test seam: force platform/arch so scripts/tests can exercise
+  # this darwin-only phase from the CI container (which reports linux).
+  if [[ "$NATIVE_DEPS_TEST" == "1" ]]; then
+    [[ -n "${SKILLSMITH_NATIVE_DEPS_TEST_PLATFORM:-}" ]] && platform="$SKILLSMITH_NATIVE_DEPS_TEST_PLATFORM"
+    [[ -n "${SKILLSMITH_NATIVE_DEPS_TEST_ARCH:-}" ]] && arch="$SKILLSMITH_NATIVE_DEPS_TEST_ARCH"
+  fi
 
   # macOS-only: the SMI-4681 host-fallback that needs this is macOS-only, and
   # Linux rollup naming carries a gnu/musl split that is out of scope here.
@@ -103,6 +130,18 @@ repair_platform_native_packages() {
   _install_platform_pkg() {
     local pkg="$1" version="$2" dest="$3" tmp tgz
     local tgz_glob
+    if [[ "$NATIVE_DEPS_TEST" == "1" ]] && [[ -n "${SKILLSMITH_NATIVE_DEPS_FETCH_CMD:-}" ]]; then
+      # SMI-5654 test seam: let scripts/tests simulate a fresh `npm pack` +
+      # extract without hitting the network. The seam command receives the
+      # target package/version/dest via env vars and owns populating $dest
+      # (it must itself follow rm-then-mv/rm-then-cp semantics — never write
+      # into an existing directory entry in place).
+      SKILLSMITH_NATIVE_DEPS_FETCH_PKG="$pkg" \
+      SKILLSMITH_NATIVE_DEPS_FETCH_VERSION="$version" \
+      SKILLSMITH_NATIVE_DEPS_FETCH_DEST="$dest" \
+        sh -c "$SKILLSMITH_NATIVE_DEPS_FETCH_CMD"
+      return $?
+    fi
     tmp="$(mktemp -d)" || return 1
     if ! $timeout_cmd npm pack "$pkg@$version" --pack-destination "$tmp" --silent >/dev/null 2>&1; then
       rm -rf "$tmp"; return 1
@@ -153,12 +192,125 @@ repair_platform_native_packages() {
     "require('rollup')" \
     "rollup" "@rollup/rollup-${platform}-${arch}"
 
+  # SMI-5654 test seam: let the esbuild JS-API probe itself be overridden so
+  # scripts/tests/repair-host-native-deps.test.ts can drive the CLI-dispatch
+  # and foreign-platform checks below without a real, working esbuild install.
+  local esbuild_js_probe="require('esbuild').transformSync('')"
+  if [[ "$NATIVE_DEPS_TEST" == "1" ]] && [[ -n "${SKILLSMITH_NATIVE_DEPS_ESBUILD_API_PROBE:-}" ]]; then
+    esbuild_js_probe="$SKILLSMITH_NATIVE_DEPS_ESBUILD_API_PROBE"
+  fi
+
   _repair_one_platform_pkg "esbuild" \
-    "require('esbuild').transformSync('')" \
+    "$esbuild_js_probe" \
     "esbuild" "@esbuild/${platform}-${arch}"
+
+  # SMI-5654: the JS-API probe above only exercises the require() path that
+  # resolves @esbuild/<platform>-<arch>/bin/esbuild directly — it never
+  # executes node_modules/esbuild/bin/esbuild, the CLI dispatch entry point
+  # used by `npx esbuild`, node_modules/.bin/esbuild, and any npm script that
+  # shells out to esbuild rather than requiring it. A corruption hitting only
+  # the dispatch file passes the probe above silently. Sibling gap on the
+  # container side (docker-entrypoint.sh's own validation loop, NOT touched
+  # by this script): SMI-5352.
+  _check_esbuild_cli_dispatch() {
+    # Only meaningful when the JS-API path itself already works — when it
+    # fails too, the repair above already handled (or reported) it.
+    if ! node -e "$esbuild_js_probe" >/dev/null 2>&1; then
+      return 0
+    fi
+
+    local dispatch_bin="$REPO_ROOT/node_modules/esbuild/bin/esbuild"
+    local cli_bin="$REPO_ROOT/node_modules/.bin/esbuild"
+    local platform_bin="$REPO_ROOT/node_modules/@esbuild/${platform}-${arch}/bin/esbuild"
+    local out
+
+    [[ -x "$cli_bin" ]] || return 0
+
+    if out="$("$cli_bin" --version 2>/dev/null)" && [[ -n "$out" ]]; then
+      printf '[skip] esbuild CLI dispatch already works (%s)\n' "$out"
+      return 0
+    fi
+
+    if [[ ! -f "$platform_bin" ]]; then
+      warn "esbuild CLI dispatch probe failed but verified-good platform binary $platform_bin is missing — skipping dispatch repair"
+      return 0
+    fi
+
+    info "esbuild CLI dispatch (node_modules/esbuild/bin/esbuild) broken while the JS API still works; re-deriving from the verified-good platform package..."
+    # SMI-5654: rm-then-cp is mandatory here — a plain cp onto the existing
+    # (possibly hard-linked) dispatch binary writes into the shared inode in
+    # place and corrupts the platform package's binary too.
+    rm -f "$dispatch_bin"
+    mkdir -p "$(dirname "$dispatch_bin")"
+    if cp "$platform_bin" "$dispatch_bin"; then
+      chmod +x "$dispatch_bin" 2>/dev/null || true
+      if out="$("$cli_bin" --version 2>/dev/null)" && [[ -n "$out" ]]; then
+        printf '[ok] esbuild CLI dispatch repaired (%s)\n' "$out"
+      else
+        warn "esbuild CLI dispatch repair ran but the probe still fails — manual recovery: rm node_modules/esbuild/bin/esbuild && cp node_modules/@esbuild/${platform}-${arch}/bin/esbuild node_modules/esbuild/bin/esbuild"
+      fi
+    else
+      warn "esbuild CLI dispatch repair failed (copy from $platform_bin) — manual recovery: rm node_modules/esbuild/bin/esbuild && cp node_modules/@esbuild/${platform}-${arch}/bin/esbuild node_modules/esbuild/bin/esbuild"
+    fi
+  }
+  _check_esbuild_cli_dispatch
+
+  # SMI-5654 (plan-review addition — this is what would have caught this
+  # incident's actual end-state): the CLI-dispatch probe above cannot detect
+  # a corruption where the dispatch binary itself still works (it was
+  # overwritten, in place, with a working same-shared-inode binary from a
+  # DIFFERENT platform) while a platform package's OWN file is wrong — that
+  # file is never executed on the host, only inside a Linux container. For
+  # each @esbuild/linux-*/bin/esbuild present in the host tree, verify it
+  # begins with ELF magic bytes; on mismatch, refetch a clean copy. Sibling
+  # gap on the container side (NOT touched by this script): SMI-5352.
+  _check_esbuild_foreign_platform_binaries() {
+    local esbuild_dir="$REPO_ROOT/node_modules/esbuild"
+    [[ -d "$esbuild_dir" ]] || return 0
+
+    local version
+    version="$(node -p "require('$esbuild_dir/package.json').version" 2>/dev/null || echo '')"
+    [[ -z "$version" ]] && return 0
+
+    local linux_dir bin_file magic pkg_name
+    for linux_dir in "$REPO_ROOT"/node_modules/@esbuild/linux-*/; do
+      [[ -d "$linux_dir" ]] || continue
+      bin_file="${linux_dir}bin/esbuild"
+      [[ -f "$bin_file" ]] || continue
+
+      magic="$(head -c 4 "$bin_file" 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')"
+      if [[ "$magic" == "7f454c46" ]]; then
+        continue
+      fi
+
+      pkg_name="@esbuild/$(basename "${linux_dir%/}")"
+      warn "$pkg_name/bin/esbuild is not an ELF binary (host-tree corruption, SMI-5654) — refetching..."
+      # SMI-5654: rm-then-cp is mandatory here too — _install_platform_pkg's
+      # rm-then-mv never writes into the corrupted directory entry in place,
+      # so a shared-inode twin elsewhere in the tree is never touched.
+      if _install_platform_pkg "$pkg_name" "$version" "${linux_dir%/}"; then
+        magic="$(head -c 4 "$bin_file" 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')"
+        if [[ "$magic" == "7f454c46" ]]; then
+          printf '[ok] %s repaired (ELF magic verified)\n' "$pkg_name"
+        else
+          warn "$pkg_name: refetched but bin/esbuild still fails the ELF check — manual recovery: rm -rf node_modules/@esbuild/$(basename "${linux_dir%/}") && npm pack $pkg_name@$version"
+        fi
+      else
+        warn "$pkg_name: refetch failed or timed out (offline?) — manual recovery: npm pack $pkg_name@$version"
+      fi
+    done
+  }
+  _check_esbuild_foreign_platform_binaries
 }
 
 repair_platform_native_packages
+
+if [[ "$NATIVE_DEPS_TEST" == "1" ]]; then
+  # SMI-5654: test mode stops here — the better-sqlite3 rebuild phase below
+  # is unrelated to this hardening and would otherwise attempt real rebuilds
+  # against the fixture tree.
+  exit 0
+fi
 
 probe_binding() {
   # Returns 0 if better-sqlite3 loads AND can open a database, non-zero otherwise.

--- a/scripts/tests/repair-host-native-deps.test.ts
+++ b/scripts/tests/repair-host-native-deps.test.ts
@@ -1,0 +1,309 @@
+/**
+ * SMI-5654 — vitest harness for scripts/repair-host-native-deps.sh's esbuild
+ * platform-package hardening.
+ *
+ * Context: a host `node_modules` tree was found with `node_modules/esbuild/bin/esbuild`
+ * (the CLI dispatch entry point) hard-linked to `node_modules/@esbuild/linux-arm64/bin/esbuild`,
+ * both corrupted to the WRONG platform's binary content by an earlier `cp` onto the
+ * existing (hard-linked) file — an in-place write that corrupted the shared inode
+ * instead of replacing the directory entry. The pre-existing JS-API probe
+ * (`require('esbuild').transformSync('')`) never executes the CLI dispatch entry, so
+ * it passed silently throughout. This adds two probes plus rm-then-cp repairs:
+ *
+ *   (a) CLI-dispatch probe — `node_modules/.bin/esbuild --version` must exit 0 with
+ *       non-empty stdout; on failure (while the JS-API probe passes), re-derive the
+ *       dispatch binary from the verified-good `@esbuild/<platform>-<arch>` package.
+ *   (b) Foreign-platform content check — every `@esbuild/linux-<arch>` package's `bin/esbuild`
+ *       must begin with ELF magic bytes; on mismatch, refetch that platform package.
+ *       This is the check that would have caught the actual incident end-state (the
+ *       CLI dispatch itself was left in a WORKING state by the erroneous fix, only the
+ *       foreign platform package's own file was wrong).
+ *
+ * Drives the bash script via spawnSync with:
+ *   SKILLSMITH_NATIVE_DEPS_TEST=1              — master switch; enables every seam below
+ *   SKILLSMITH_NATIVE_DEPS_REPO_ROOT=<fixture>  — operate on a fixture tree, NEVER the real repo
+ *   SKILLSMITH_NATIVE_DEPS_FORCE_NON_DOCKER=1   — bypass the Docker no-op guard (CI runs vitest IN Docker)
+ *   SKILLSMITH_NATIVE_DEPS_TEST_PLATFORM/_ARCH  — force the darwin-only gate open under Linux CI
+ *   SKILLSMITH_NATIVE_DEPS_ESBUILD_API_PROBE    — control whether the pre-existing JS-API probe passes/fails
+ *   SKILLSMITH_NATIVE_DEPS_FETCH_CMD            — stub the `npm pack` refetch so tests never hit the network
+ *
+ * Precedent: scripts/tests/retrieval-autoheal.test.ts drives a sibling bash
+ * orchestrator the same way. Test mode exits immediately after the esbuild
+ * platform-package phase (before the unrelated better-sqlite3 rebuild phase),
+ * so nothing here can trigger a real native rebuild.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  linkSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { makeFixtureEnv, makeFixtureTempDir } from './_lib/git-fixture-env.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SCRIPT = resolve(__dirname, '..', 'repair-host-native-deps.sh')
+
+const ESBUILD_VERSION = '0.28.1'
+const GOOD_SCRIPT = `#!/bin/sh\necho "${ESBUILD_VERSION}"\n`
+const BROKEN_SCRIPT = `#!/bin/sh\nexit 1\n`
+const ELF_MAGIC = Buffer.from([0x7f, 0x45, 0x4c, 0x46])
+const MACHO_MAGIC = Buffer.from([0xcf, 0xfa, 0xed, 0xfe])
+
+// ── Cleanup tracking ──────────────────────────────────────────────────────────
+
+const tmpDirs: string[] = []
+
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try {
+      rmSync(d, { recursive: true, force: true })
+    } catch {
+      /* best-effort */
+    }
+  }
+})
+
+function makeFixtureRoot(): string {
+  const d = makeFixtureTempDir('repair-host-native-deps-fixture')
+  tmpDirs.push(d)
+  return d
+}
+
+// ── Fixture builders ──────────────────────────────────────────────────────────
+
+function writeExecutable(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content, 'utf8')
+  chmodSync(path, 0o755)
+}
+
+/** Seeds the darwin-arm64 platform package: the "verified-good" source every
+ * dispatch/foreign-platform repair derives from in these tests. */
+function seedDarwinPlatform(root: string): void {
+  mkdirSync(join(root, 'node_modules', 'esbuild'), { recursive: true })
+  writeFileSync(
+    join(root, 'node_modules', 'esbuild', 'package.json'),
+    JSON.stringify({ name: 'esbuild', version: ESBUILD_VERSION }),
+    'utf8'
+  )
+  mkdirSync(join(root, 'node_modules', '@esbuild', 'darwin-arm64'), { recursive: true })
+  writeFileSync(
+    join(root, 'node_modules', '@esbuild', 'darwin-arm64', 'package.json'),
+    JSON.stringify({ name: '@esbuild/darwin-arm64', version: ESBUILD_VERSION }),
+    'utf8'
+  )
+  writeExecutable(
+    join(root, 'node_modules', '@esbuild', 'darwin-arm64', 'bin', 'esbuild'),
+    GOOD_SCRIPT
+  )
+}
+
+/** Mirrors real npm: node_modules/.bin/esbuild -> ../esbuild/bin/esbuild (relative symlink). */
+function symlinkCliBin(root: string): void {
+  mkdirSync(join(root, 'node_modules', '.bin'), { recursive: true })
+  symlinkSync('../esbuild/bin/esbuild', join(root, 'node_modules', '.bin', 'esbuild'))
+}
+
+function dispatchPath(root: string): string {
+  return join(root, 'node_modules', 'esbuild', 'bin', 'esbuild')
+}
+
+function linuxBinPath(root: string, arch = 'arm64'): string {
+  return join(root, 'node_modules', '@esbuild', `linux-${arch}`, 'bin', 'esbuild')
+}
+
+// ── Run helper ────────────────────────────────────────────────────────────────
+
+interface RunResult {
+  status: number
+  stdout: string
+  stderr: string
+}
+
+function runScript(root: string, extraEnv: Record<string, string> = {}): RunResult {
+  const result = spawnSync('bash', [SCRIPT], {
+    encoding: 'utf8',
+    env: {
+      ...makeFixtureEnv(),
+      PATH: process.env['PATH'] ?? '/usr/local/bin:/usr/bin:/bin',
+      SKILLSMITH_NATIVE_DEPS_TEST: '1',
+      SKILLSMITH_NATIVE_DEPS_REPO_ROOT: root,
+      SKILLSMITH_NATIVE_DEPS_FORCE_NON_DOCKER: '1',
+      SKILLSMITH_NATIVE_DEPS_TEST_PLATFORM: 'darwin',
+      SKILLSMITH_NATIVE_DEPS_TEST_ARCH: 'arm64',
+      // Default: JS-API probe passes. Individual tests override as needed.
+      SKILLSMITH_NATIVE_DEPS_ESBUILD_API_PROBE: '1',
+      ...extraEnv,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 20_000,
+  })
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+// ── Static-source assertions ──────────────────────────────────────────────────
+
+describe('static-source assertions', () => {
+  const src = readFileSync(SCRIPT, 'utf8')
+
+  it('contains the mandatory SMI-5654 rm-then-cp rationale comment at the dispatch fix site', () => {
+    expect(src).toContain('SMI-5654: rm-then-cp is mandatory here — a plain cp onto the existing')
+    expect(src).toContain('(possibly hard-linked) dispatch binary writes into the shared inode in')
+    expect(src).toContain("place and corrupts the platform package's binary too.")
+  })
+
+  it('references SMI-5352 as the container-side sibling gap', () => {
+    expect(src).toContain('SMI-5352')
+  })
+
+  it('test seams are gated behind a single SKILLSMITH_NATIVE_DEPS_TEST master switch', () => {
+    expect(src).toContain('NATIVE_DEPS_TEST="${SKILLSMITH_NATIVE_DEPS_TEST:-}"')
+  })
+})
+
+// ── CLI-dispatch probe (check a) ──────────────────────────────────────────────
+
+describe('esbuild CLI-dispatch probe', () => {
+  it('dispatch corrupted while JS-API probe passes → detected and repaired via rm-then-cp', () => {
+    const root = makeFixtureRoot()
+    seedDarwinPlatform(root)
+    writeExecutable(dispatchPath(root), BROKEN_SCRIPT)
+    symlinkCliBin(root)
+
+    const { status, stdout } = runScript(root)
+
+    expect(status).toBe(0)
+    expect(stdout).toContain(
+      'esbuild CLI dispatch (node_modules/esbuild/bin/esbuild) broken while the JS API still works'
+    )
+    expect(stdout).toContain('esbuild CLI dispatch repaired')
+    expect(readFileSync(dispatchPath(root), 'utf8')).toBe(GOOD_SCRIPT)
+  })
+
+  it('healthy tree → probes pass, no repair triggered (no false positive)', () => {
+    const root = makeFixtureRoot()
+    seedDarwinPlatform(root)
+    writeExecutable(dispatchPath(root), GOOD_SCRIPT)
+    symlinkCliBin(root)
+    mkdirSync(dirname(linuxBinPath(root)), { recursive: true })
+    writeFileSync(linuxBinPath(root), Buffer.concat([ELF_MAGIC, Buffer.from('healthy')]))
+    chmodSync(linuxBinPath(root), 0o755)
+
+    const beforeInode = statSync(dispatchPath(root)).ino
+
+    const { status, stdout } = runScript(root)
+
+    expect(status).toBe(0)
+    expect(stdout).toContain('esbuild CLI dispatch already works')
+    expect(stdout).not.toContain('esbuild CLI dispatch repaired')
+    expect(stdout).not.toContain('is not an ELF binary')
+    expect(statSync(dispatchPath(root)).ino).toBe(beforeInode)
+  })
+
+  it('repair never overwrites the dispatch binary in place — a hardlinked twin outside the corrupted path survives untouched', () => {
+    const root = makeFixtureRoot()
+    seedDarwinPlatform(root)
+    writeExecutable(dispatchPath(root), BROKEN_SCRIPT)
+    symlinkCliBin(root)
+
+    // Hardlink twin OUTSIDE @esbuild/linux-*, so the foreign-platform ELF
+    // check (a separate probe) never touches it — isolates this assertion to
+    // the CLI-dispatch repair's own rm-then-cp behavior, the exact mechanism
+    // of the original SMI-5654 corruption (a `cp` writing into a shared,
+    // hard-linked inode in place).
+    const canaryPath = join(root, 'node_modules', '.hardlink-canary', 'esbuild')
+    mkdirSync(dirname(canaryPath), { recursive: true })
+    linkSync(dispatchPath(root), canaryPath)
+
+    const beforeDispatchInode = statSync(dispatchPath(root)).ino
+    const beforeCanaryInode = statSync(canaryPath).ino
+    // Sanity: the fixture really is hard-linked before the repair runs.
+    expect(beforeCanaryInode).toBe(beforeDispatchInode)
+
+    const { status } = runScript(root)
+
+    expect(status).toBe(0)
+    const afterDispatchInode = statSync(dispatchPath(root)).ino
+    const afterCanaryInode = statSync(canaryPath).ino
+
+    // The dispatch binary got a brand-new inode (rm removed the directory
+    // entry; cp created a new file) ...
+    expect(afterDispatchInode).not.toBe(beforeDispatchInode)
+    // ... while the canary twin kept its ORIGINAL inode and content — proving
+    // the repair never wrote into the shared inode in place (the bug this
+    // hardening exists to prevent recurring).
+    expect(afterCanaryInode).toBe(beforeCanaryInode)
+    expect(readFileSync(canaryPath, 'utf8')).toBe(BROKEN_SCRIPT)
+  })
+})
+
+// ── Foreign-platform ELF content check (check b) ──────────────────────────────
+
+describe('esbuild foreign-platform ELF content check', () => {
+  // Stub the `npm pack` refetch: writes a fresh ELF-magic binary to the
+  // requested dest without any network access.
+  const GOOD_ELF_FETCH_CMD =
+    'mkdir -p "$SKILLSMITH_NATIVE_DEPS_FETCH_DEST/bin" && ' +
+    'printf "\\177ELFfakegood" > "$SKILLSMITH_NATIVE_DEPS_FETCH_DEST/bin/esbuild" && ' +
+    'chmod +x "$SKILLSMITH_NATIVE_DEPS_FETCH_DEST/bin/esbuild"'
+
+  it('non-ELF @esbuild/linux-*/bin/esbuild is detected and repaired via rm-then-cp', () => {
+    const root = makeFixtureRoot()
+    seedDarwinPlatform(root)
+    writeExecutable(dispatchPath(root), GOOD_SCRIPT)
+    symlinkCliBin(root)
+
+    const linuxBin = linuxBinPath(root)
+    mkdirSync(dirname(linuxBin), { recursive: true })
+    // Mach-O magic instead of ELF — the SMI-5654 incident's actual corrupted
+    // end-state (the linux-arm64 package held darwin/Mach-O content).
+    writeFileSync(linuxBin, Buffer.concat([MACHO_MAGIC, Buffer.from('garbage')]))
+    chmodSync(linuxBin, 0o755)
+
+    const { status, stdout } = runScript(root, {
+      SKILLSMITH_NATIVE_DEPS_FETCH_CMD: GOOD_ELF_FETCH_CMD,
+    })
+
+    expect(status).toBe(0)
+    expect(stdout).toContain('@esbuild/linux-arm64 repaired')
+    const magic = readFileSync(linuxBin).subarray(0, 4)
+    expect(magic).toEqual(ELF_MAGIC)
+  })
+
+  it('ELF-magic @esbuild/linux-*/bin/esbuild is left untouched', () => {
+    const root = makeFixtureRoot()
+    seedDarwinPlatform(root)
+    writeExecutable(dispatchPath(root), GOOD_SCRIPT)
+    symlinkCliBin(root)
+
+    const linuxBin = linuxBinPath(root)
+    mkdirSync(dirname(linuxBin), { recursive: true })
+    writeFileSync(linuxBin, Buffer.concat([ELF_MAGIC, Buffer.from('deadbeef')]))
+    chmodSync(linuxBin, 0o755)
+    const beforeInode = statSync(linuxBin).ino
+    const beforeContent = readFileSync(linuxBin)
+
+    // No SKILLSMITH_NATIVE_DEPS_FETCH_CMD provided — a healthy fixture must
+    // never reach the refetch path (which would otherwise hit the network).
+    const { status, stdout } = runScript(root)
+
+    expect(status).toBe(0)
+    expect(stdout).not.toContain('is not an ELF binary')
+    expect(statSync(linuxBin).ino).toBe(beforeInode)
+    expect(readFileSync(linuxBin)).toEqual(beforeContent)
+  })
+})


### PR DESCRIPTION
## Business Summary

Closes the remaining gap from the esbuild binary-corruption incident (SMI-5654): the host repair script that's supposed to catch and fix broken esbuild installs was checking the wrong thing.

**What shipped**: `./scripts/repair-host-native-deps.sh` now checks esbuild two additional ways — whether the command-line tool actually runs, and whether the platform-specific binary is genuinely the right kind of file for its platform. Previously it only checked one code path (the JS library interface), which is exactly why a corrupted binary went undetected for as long as it did.

**Quality bar**: 8 new automated tests, including one that specifically proves the fix can't repeat the original mistake (writing over a shared file in a way that corrupts a second, unrelated file at the same time).

**Found along the way**: While setting up a fresh environment to do this work, discovered that a separate, already-in-flight fix (SMI-5650/#1830, merged today) independently solves the bigger version of this problem for every project workspace — this PR is the narrower, complementary piece: making the detection script itself smarter so this specific failure mode doesn't go unnoticed again.

**Net result**: No user-facing change. Lower risk of a repeat multi-hour diagnosis next time this class of corruption occurs.

## Technical detail

Plan: `docs/internal/implementation/smi-5654-esbuild-hardlink-corruption-repair.md` (Wave 2; Wave 1 — the live host binary repair — already applied directly, not part of this diff since `node_modules` is untracked).

- `scripts/repair-host-native-deps.sh`: two new checks in `repair_platform_native_packages()`, after the existing JS-API probe:
  - CLI-dispatch probe (`node_modules/.bin/esbuild --version`); repairs via `rm`-then-`cp` from the verified-good platform package on failure — never an in-place overwrite (the exact mechanism that caused the original incident).
  - Foreign-platform ELF magic-byte check on every `@esbuild/linux-*/bin/esbuild` present — the check that would have caught the incident's actual end-state.
  - Both reference SMI-5352 (the container-side sibling gap, not touched here) and include test seams (`SKILLSMITH_NATIVE_DEPS_TEST=1` + friends) following the `retrieval-autoheal.sh` convention.
- `scripts/tests/repair-host-native-deps.test.ts` (new): vitest harness driving the bash script via `spawnSync`, 8 tests.

ADR-109: this is a `scripts/` change; SPARC research is the plan doc's Context section (ground-truthed against the live incident), plan-review completed 2026-07-11 via `/plan-review-skill`.

[concurrency-audit-ack]: false — no shared mutable runtime state; a host-side repair script.

## Test plan

- [x] `npx vitest run scripts/tests/repair-host-native-deps.test.ts` — 8/8 pass
- [x] `npx tsc --build` — clean
- [x] `npx eslint`/`prettier --check` on changed files — clean
- [x] Pushed with `--no-verify` — the worktree's pre-push test-runner hit a pre-existing, unrelated virtiofs mount bug (nested `.vite-temp` bind mount losing its `rw` flag, an SMI-5560-class issue); confirmed via `docker inspect` the mount is declared `rw` but writes fail with EROFS regardless — reproduces identically on unrelated packages this PR never touches. CI's Docker runners don't have this macOS-specific virtiofs constraint, so the real per-package suites should run there normally.