### PR TITLE
fix(mcp-server,ci): shorten server.json description, fix recovery text, add field-length check (SMI-5651)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -762,7 +762,7 @@ jobs:
         if: steps.version-check.outputs.exists != 'true' && steps.install-mcp-publisher.outcome == 'success'
         # audit:allow-continue-on-error — SMI-4534: registry publish is non-load-bearing;
         # npm publish is the binding artifact. Manual recovery: `mcp-publisher login
-        # github-oidc` + `mcp-publisher publish` from a maintainer machine. Loud-fail
+        # github` + `mcp-publisher publish` from a maintainer machine. Loud-fail
         # step below files a GitHub issue automatically.
         continue-on-error: true
         run: ./mcp-publisher login github-oidc
@@ -802,7 +802,7 @@ jobs:
             echo "**Login outcome:** ${LOGIN_OUTCOME}"
             echo "**Publish outcome:** ${PUBLISH_OUTCOME}"
             echo ""
-            echo "Triage: re-run \`mcp-publisher login github-oidc\` + \`mcp-publisher publish\` from a maintainer machine, or see <https://registry.modelcontextprotocol.io/>."
+            echo "Triage: re-run \`mcp-publisher login github\` + \`mcp-publisher publish\` from a maintainer machine, or see <https://registry.modelcontextprotocol.io/>."
           } >> "$GITHUB_STEP_SUMMARY"
           BODY_FILE=$(mktemp)
           {
@@ -813,7 +813,7 @@ jobs:
             echo ""
             echo "See SMI-4534 for context. Manual recovery:"
             echo '```bash'
-            echo "mcp-publisher login github-oidc"
+            echo "mcp-publisher login github"
             echo "cd packages/mcp-server && mcp-publisher publish"
             echo '```'
           } > "${BODY_FILE}"

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.smith-horn/skillsmith",
   "title": "Skillsmith",
-  "description": "Discover, install, and manage agent skills via MCP — 14,000+ curated skills for any MCP-compatible agent (Claude Code, Cursor, Copilot, Codex, Windsurf).",
+  "description": "Discover, install, and manage 14,000+ curated agent skills for any MCP-compatible agent.",
   "websiteUrl": "https://skillsmith.app",
   "repository": {
     "url": "https://github.com/smith-horn/skillsmith",

--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -1744,3 +1744,70 @@ export function auditSecdefAnonGrants(migrations, { cutoff, allowlist = [] } = {
   }
   return violations
 }
+
+/**
+ * MCP Registry field-length limits, per the schema referenced by
+ * `packages/mcp-server/server.json`'s own `$schema` URL
+ * (https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json).
+ * Exported so Check 53 (audit-standards.mjs) and its test fixtures share one
+ * source of truth instead of duplicating the magic numbers (SMI-5651).
+ */
+export const MCP_REGISTRY_FIELD_LIMITS = Object.freeze({
+  description: 100,
+  title: 100,
+  name: 200,
+  version: 255,
+  iconSrc: 255,
+})
+
+/**
+ * Validate a parsed server.json object's string fields against the MCP
+ * Registry schema's max-length constraints (SMI-5651). A 153-char
+ * `description` silently blocked every registry publish because nothing
+ * checked this before publish (confirmed via a live 422 response — "expected
+ * length <= 100"); this closes that gap.
+ *
+ * Checks the top-level `description`/`title`/`name`/`version` fields, every
+ * `packages[].version` entry (same `version` limit), and every `icons[].src`
+ * entry (`iconSrc` limit) when present. Fields absent from `serverJson` or of
+ * the wrong type are silently skipped — this is a length gate, not a schema
+ * validator.
+ *
+ * @param {object} serverJson  Parsed server.json content.
+ * @param {Record<string, number>} [limits]  Field-name -> max-length map;
+ *   defaults to MCP_REGISTRY_FIELD_LIMITS.
+ * @returns {{ field: string, length: number, limit: number }[]}  One entry per
+ *   field exceeding its limit.
+ */
+export function findServerJsonFieldLengthViolations(
+  serverJson,
+  limits = MCP_REGISTRY_FIELD_LIMITS
+) {
+  const violations = []
+  if (!serverJson || typeof serverJson !== 'object') return violations
+
+  const checkField = (label, value, limit) => {
+    if (typeof limit === 'number' && typeof value === 'string' && value.length > limit) {
+      violations.push({ field: label, length: value.length, limit })
+    }
+  }
+
+  checkField('description', serverJson.description, limits.description)
+  checkField('title', serverJson.title, limits.title)
+  checkField('name', serverJson.name, limits.name)
+  checkField('version', serverJson.version, limits.version)
+
+  if (Array.isArray(serverJson.packages)) {
+    serverJson.packages.forEach((pkg, i) => {
+      checkField(`packages[${i}].version`, pkg?.version, limits.version)
+    })
+  }
+
+  if (Array.isArray(serverJson.icons)) {
+    serverJson.icons.forEach((icon, i) => {
+      checkField(`icons[${i}].src`, icon?.src, limits.iconSrc)
+    })
+  }
+
+  return violations
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -37,6 +37,7 @@ import {
   parseNpmLsJson,
   findFunctionsWithoutSearchPath,
   auditSecdefAnonGrants,
+  findServerJsonFieldLengthViolations,
 } from './audit-standards-helpers.mjs'
 import { VERCEL_JSON_SHARED_FIELDS, validateVercelJsonSync } from './audit-vercel-sync-helpers.mjs'
 import { findRealpathAsymmetry } from './audit-realpath-asymmetry-helpers.mjs'
@@ -4545,6 +4546,39 @@ console.log(`\n${BOLD}52. SECURITY DEFINER anon-Grant Lockdown (SMI-5526)${RESET
             `scripts/audit-standards.mjs with a one-line justification if it is intentionally anon-callable.`
         )
       }
+    }
+  }
+}
+
+// Check 53: MCP registry server.json field-length limits (SMI-5651)
+// packages/mcp-server/server.json's `description` field grew to 153 chars
+// across several rebrand passes and silently blocked every registry publish
+// (the registry rejects it with a 422 — "expected length <= 100") — nothing
+// caught this before it shipped. This check fails loudly if description,
+// title, name, version (top-level or packages[].version), or icons[].src
+// ever exceed the registry schema's limits again.
+console.log(`\n${BOLD}Check 53: MCP registry server.json field-length limits (SMI-5651)${RESET}`)
+{
+  const SERVER_JSON_PATH = 'packages/mcp-server/server.json'
+  if (!existsSync(SERVER_JSON_PATH)) {
+    warn(`Check 53: ${SERVER_JSON_PATH} not found — skipping registry field-length check`)
+  } else {
+    try {
+      const serverJson = JSON.parse(readFileSync(SERVER_JSON_PATH, 'utf8'))
+      const violations = findServerJsonFieldLengthViolations(serverJson)
+      if (violations.length === 0) {
+        pass(`${SERVER_JSON_PATH} fields are within MCP registry schema length limits`)
+      } else {
+        for (const v of violations) {
+          fail(
+            `Check 53: ${SERVER_JSON_PATH}: ${v.field} is ${v.length} chars (limit ${v.limit})`,
+            `Shorten ${SERVER_JSON_PATH}'s ${v.field} to <= ${v.limit} chars — see the registry ` +
+              'schema at https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json'
+          )
+        }
+      }
+    } catch (e) {
+      warn(`Check 53: could not parse ${SERVER_JSON_PATH}: ${e.message}`)
     }
   }
 }

--- a/scripts/tests/audit-server-json-field-lengths.test.ts
+++ b/scripts/tests/audit-server-json-field-lengths.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the MCP Registry server.json field-length validation helper used
+ * by scripts/audit-standards.mjs Check 53 (SMI-5651).
+ *
+ * Background: packages/mcp-server/server.json's `description` field grew to
+ * 153 characters across several rebrand passes — the MCP Registry rejects
+ * any publish where `description` exceeds 100 chars (confirmed via a live
+ * 422 response: "expected length <= 100"). Nothing validated this before it
+ * shipped, silently blocking every registry publish. Check 53 closes that
+ * gap by validating server.json's length-limited fields against the schema
+ * referenced by its own `$schema` URL
+ * (https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json).
+ */
+import { describe, expect, it } from 'vitest'
+
+const helpers = (await import('../audit-standards-helpers.mjs')) as {
+  MCP_REGISTRY_FIELD_LIMITS: Readonly<Record<string, number>>
+  findServerJsonFieldLengthViolations: (
+    serverJson: Record<string, unknown> | null | undefined,
+    limits?: Record<string, number>
+  ) => Array<{ field: string; length: number; limit: number }>
+}
+
+const { MCP_REGISTRY_FIELD_LIMITS, findServerJsonFieldLengthViolations } = helpers
+
+describe('findServerJsonFieldLengthViolations (SMI-5651)', () => {
+  it('(1) flags the pre-fix 153-char description (the actual SMI-5651 regression)', () => {
+    const overLengthDescription =
+      'Discover, install, and manage agent skills via MCP — 14,000+ curated skills for any MCP-compatible agent (Claude Code, Cursor, Copilot, Codex, Windsurf).'
+    expect(overLengthDescription.length).toBeGreaterThan(100)
+
+    const serverJson = {
+      name: 'io.github.smith-horn/skillsmith',
+      title: 'Skillsmith',
+      description: overLengthDescription,
+      version: '0.7.1',
+    }
+    const violations = findServerJsonFieldLengthViolations(serverJson)
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({
+      field: 'description',
+      length: overLengthDescription.length,
+      limit: 100,
+    })
+  })
+
+  it('(2) passes the current (post-Wave-1 fix) server.json description', () => {
+    const fixedDescription =
+      'Discover, install, and manage 14,000+ curated agent skills for any MCP-compatible agent.'
+    expect(fixedDescription.length).toBeLessThanOrEqual(100)
+
+    const serverJson = {
+      name: 'io.github.smith-horn/skillsmith',
+      title: 'Skillsmith',
+      description: fixedDescription,
+      version: '0.7.1',
+      packages: [{ registryType: 'npm', identifier: '@skillsmith/mcp-server', version: '0.7.1' }],
+    }
+    const violations = findServerJsonFieldLengthViolations(serverJson)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('(3) flags an over-length title and name independently of description', () => {
+    const serverJson = {
+      name: 'x'.repeat(201),
+      title: 'y'.repeat(101),
+      description: 'fine',
+      version: '0.1.0',
+    }
+    const violations = findServerJsonFieldLengthViolations(serverJson)
+    const fields = violations.map((v) => v.field).sort()
+    expect(fields).toEqual(['name', 'title'])
+  })
+
+  it('(4) flags an over-length packages[].version and icons[].src', () => {
+    const serverJson = {
+      name: 'io.github.smith-horn/skillsmith',
+      title: 'Skillsmith',
+      description: 'fine',
+      version: '0.7.1',
+      packages: [
+        { registryType: 'npm', identifier: '@skillsmith/mcp-server', version: 'v'.repeat(256) },
+      ],
+      icons: [{ src: 'https://example.com/' + 'a'.repeat(256) + '.png' }],
+    }
+    const violations = findServerJsonFieldLengthViolations(serverJson)
+    const fields = violations.map((v) => v.field).sort()
+    expect(fields).toEqual(['icons[0].src', 'packages[0].version'])
+  })
+
+  it('(5) returns no violations for null/undefined/non-object input (fail-soft, not a schema validator)', () => {
+    expect(findServerJsonFieldLengthViolations(null)).toHaveLength(0)
+    expect(findServerJsonFieldLengthViolations(undefined)).toHaveLength(0)
+    expect(
+      findServerJsonFieldLengthViolations('not-an-object' as unknown as Record<string, unknown>)
+    ).toHaveLength(0)
+  })
+
+  it('(6) MCP_REGISTRY_FIELD_LIMITS matches the confirmed registry schema limits', () => {
+    expect(MCP_REGISTRY_FIELD_LIMITS).toMatchObject({
+      description: 100,
+      title: 100,
+      name: 200,
+      version: 255,
+      iconSrc: 255,
+    })
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** Three fixes completing the MCP Registry publish repair from earlier this session. First, the actual blocker preventing any registry publish from succeeding at all — a project description that had grown past the registry's length limit over several rewording passes — is fixed. Second, the automated failure-recovery instructions (both the one auto-filed as a GitHub issue and the one shown in the Actions summary) told whoever read them to run a command that only works inside GitHub's own automation, not on a person's own machine — now corrected to the right command. Third, a new automated check now catches this exact class of problem before it ships again, since nothing previously verified the description (or related fields) stayed within the registry's limits.

**Quality bar:** This builds on a plan that went through a full VP Product/Engineering/Design review before implementation (which itself satisfies this repo's infra-change-review policy for the workflow-file edit). One deviation from the plan's own verification instructions was caught and correctly handled during implementation: the plan expected exactly one remaining mention of the old command after the fix, but there are actually three additional legitimate mentions describing the automated mechanism itself (which correctly still uses that command) — the fix distinguishes between those and the three genuinely wrong human-facing instructions, rather than blindly forcing a count match. All changes verified in Docker: typecheck, lint, format, the new test (6 cases), the full `scripts/tests` suite (2,173 tests), and the standards audit all pass clean.

**Found along the way:** a real port-collision bug in this repo's worktree-container tooling (two sibling worktrees' containers were assigned the same ports) — not fixed here since it's out of scope, but worth its own follow-up, which I'll file separately.

**Net result:** Fully shipped for these three fixes. The remaining piece of the original registry-publish repair (proving the fix works end-to-end via a real automated publish) still needs a genuine new package release to occur naturally — expected within the next day or two based on this repo's own release schedule — and I'll do the manual registry catch-up (the piece that doesn't need to wait for that) right after this merges.

---

## Technical detail

- `packages/mcp-server/server.json` — `description` shortened from 153 to 88 chars (registry schema caps it at 100), preserving the "14,000+ curated skills" and "MCP-compatible" points
- `.github/workflows/publish.yml` — corrected `mcp-publisher login github-oidc` → `mcp-publisher login github` in the 3 human-facing recovery-instruction spots (the `registry-login` step's comment, the `$GITHUB_STEP_SUMMARY` triage line, the auto-filed issue body); the CI step's own actual command is untouched, since `github-oidc` is correct there
- `scripts/audit-standards.mjs` + `scripts/audit-standards-helpers.mjs` — new Check 53, validating `server.json`'s `description`/`title`/`name`/`version` (+ `packages[].version`, `icons[].src`) against the MCP Registry schema's length limits (fetched directly from `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`); confirmed `audit-standards.mjs` (not `validate-versions.ts`) is the actual CI-gating script before adding to it
- `scripts/tests/audit-server-json-field-lengths.test.ts` — new test file (6 cases), asserting the check fails on the original 153-char description and passes on the fixed one
- `docs/internal/implementation/mcp-shutdown-followup-hardening.md` — same recovery-command correction applied to the earlier Wave D doc that inherited the same wrong instruction (separate PR in skillsmith-docs, already merged)
- Plan: `docs/internal/implementation/smi-5651-mcp-registry-catchup.md` (plan-reviewed, VP Product/Engineering/Design)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)