### PR TITLE
fix(scripts): route .sh files through check-file-length pre-commit gate

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -22,9 +22,9 @@ export default {
     'prettier --write',
   ],
 
-  // TypeScript files: file-length check (SMI-3493)
+  // TypeScript + shell files: file-length check (SMI-3493, extended to .sh in SMI-5658)
   // CI rejects files over 500 lines; catch early in pre-commit.
-  '*.ts': ['node scripts/check-file-length.mjs'],
+  '*.{ts,sh}': ['node scripts/check-file-length.mjs'],
 
   // Astro files: format only (ESLint handled by website's own config)
   '*.astro': ['prettier --write'],

--- a/scripts/check-file-length.ignore
+++ b/scripts/check-file-length.ignore
@@ -15,7 +15,17 @@
 #   - Blank lines and lines starting with `#` are ignored.
 #   - Trailing whitespace and CRLF line endings are tolerated.
 #   - Each grandfathered path is preceded by a `# SMI-XXXX split follow-up`
-#     comment naming the Linear issue that will split the file.
+#     comment naming the Linear issue that will split the file. The
+#     preceding-comment's SMI reference is what the hook cites in its
+#     "skipped (grandfathered — SMI-XXXX split pending)" console message
+#     (SMI-5658) — so an active entry's comment must NOT start with `(`
+#     (see below), or the message will attribute the wrong issue.
+#   - A CLEARED entry (the file has since been split) is converted to a
+#     parenthesized historical note instead of being deleted outright —
+#     `# (SMI-XXXX split follow-up cleared YYYY-MM-DD: ...)` — so the
+#     leading `(` is load-bearing: it's what stops the parser from
+#     treating a cleared block as an active `# SMI-XXXX split follow-up`
+#     comment and attributing its ref to an unrelated path below it.
 #
 # Do not add new files here without a corresponding split follow-up issue.
 

--- a/scripts/check-file-length.ignore
+++ b/scripts/check-file-length.ignore
@@ -1,12 +1,13 @@
 # check-file-length.ignore — grandfather list for the pre-commit length hook (SMI-4397)
 #
 # Purpose:
-#   scripts/check-file-length.mjs hard-fails any staged .ts file over 500
-#   lines. The paths below are pre-existing over-limit files exempted from
-#   that hard-fail so they can still be committed without `git commit
-#   --no-verify`. The exemption is conditional: it applies ONLY while the
-#   file remains over 500 lines. Once a listed file is split below the
-#   limit it re-enters normal enforcement and the hook prints an
+#   scripts/check-file-length.mjs hard-fails any staged file routed to the
+#   hook (currently .ts and .sh) over 500 lines. The paths below are
+#   pre-existing over-limit files exempted from that hard-fail so they can
+#   still be committed without `git commit --no-verify`. The exemption is
+#   conditional: it applies ONLY while the file remains over 500 lines.
+#   Once a listed file is split below the limit it re-enters normal
+#   enforcement and the hook prints an
 #   "eligible to de-list" notice — remove its entry here at that point.
 #
 # Format:
@@ -36,3 +37,18 @@ scripts/tests/indexer/parity.test.ts
 # (SMI-5263 split follow-up cleared 2026-06-12: install.integration.test.ts was
 #  split into 3 concern-scoped siblings under 500 lines each —
 #  install.{parsing,execution}.integration.test.ts; suite still 174 passed / 6 skipped.)
+
+# SMI-5660 split follow-up
+scripts/_lib.sh
+
+# SMI-5660 split follow-up
+scripts/smoke-prod/website.sh
+
+# SMI-5660 split follow-up
+scripts/create-worktree.sh
+
+# SMI-5660 split follow-up
+scripts/tests/create-worktree-hooks.test.sh
+
+# SMI-5660 split follow-up
+scripts/phases/phase-7-enterprise.sh

--- a/scripts/check-file-length.mjs
+++ b/scripts/check-file-length.mjs
@@ -1,7 +1,10 @@
 /**
  * Pre-commit file-length check (SMI-3493)
  *
- * Ensures staged .ts files do not exceed the 500-line CI limit.
+ * Checks whatever staged file paths lint-staged passes it — currently
+ * .ts and .sh per lint-staged.config.js (SMI-5658 widened this from
+ * .ts-only) — against the 500-line CI limit. The script itself has no
+ * extension filter; the routing is entirely lint-staged.config.js's glob.
  * Called by lint-staged with file paths as arguments.
  *
  * Usage: node scripts/check-file-length.mjs <file1> [file2] ...
@@ -47,39 +50,53 @@ export function getRepoRoot() {
   return canonicalize(resolve(dirname(fileURLToPath(import.meta.url)), '..'))
 }
 
+/** Matches the `# SMI-XXXX split follow-up` comment convention (SMI-4397). */
+const SMI_FOLLOW_UP_RE = /^#\s*(SMI-\d+)\s+split follow-up/
+
 /**
- * Parse the ignore-list file contents into a Set of trimmed,
- * repo-relative paths. Comment (`#`) and blank lines are skipped;
- * trailing whitespace and CRLF line endings are tolerated.
+ * Parse the ignore-list file contents into a Map of trimmed,
+ * repo-relative paths to the SMI issue reference named by the
+ * `# SMI-XXXX split follow-up` comment immediately preceding that path
+ * (or `null` if no such comment directly precedes it — e.g. a stale entry
+ * added without following the convention). Comment (`#`) and blank lines
+ * are otherwise skipped; trailing whitespace and CRLF line endings are
+ * tolerated.
  *
  * @param {string} contents - raw ignore-file text
- * @returns {Set<string>} repo-relative paths to grandfather
+ * @returns {Map<string, string|null>} repo-relative path -> SMI reference (or null)
  */
 export function parseIgnoreList(contents) {
-  const entries = new Set()
+  const entries = new Map()
+  let pendingSmiRef = null
   for (const rawLine of contents.split('\n')) {
     const line = rawLine.replace(/\r$/, '').trim()
-    if (line.length === 0 || line.startsWith('#')) {
+    if (line.length === 0) {
       continue
     }
-    entries.add(line)
+    if (line.startsWith('#')) {
+      const match = line.match(SMI_FOLLOW_UP_RE)
+      pendingSmiRef = match ? match[1] : null
+      continue
+    }
+    entries.set(line, pendingSmiRef)
+    pendingSmiRef = null
   }
   return entries
 }
 
 /**
  * Load and parse the sibling check-file-length.ignore file.
- * Returns an empty Set if the file is absent (graceful default).
+ * Returns an empty Map if the file is absent (graceful default).
  *
  * @param {string} ignorePath - absolute path to the ignore file
- * @returns {Set<string>} grandfathered repo-relative paths
+ * @returns {Map<string, string|null>} grandfathered repo-relative paths -> SMI reference
  */
 export function loadIgnoreList(ignorePath) {
   try {
     return parseIgnoreList(readFileSync(ignorePath, 'utf8'))
   } catch (err) {
     if (err && err.code === 'ENOENT') {
-      return new Set()
+      return new Map()
     }
     throw err
   }
@@ -94,10 +111,10 @@ export function loadIgnoreList(ignorePath) {
  * exempt WHILE still over-limit (SMI-4397 H1).
  *
  * @param {string[]} files - staged file paths (absolute or relative)
- * @param {Set<string>} ignoreList - grandfathered repo-relative paths
+ * @param {Map<string, string|null>} ignoreList - grandfathered repo-relative paths -> SMI reference
  * @param {string} repoRoot - absolute repo root
  * @returns {{violations: {relPath: string, lineCount: number}[],
- *            skipped: {relPath: string, lineCount: number}[],
+ *            skipped: {relPath: string, lineCount: number, smiRef: string|null}[],
  *            delistable: {relPath: string, lineCount: number}[]}}
  */
 export function checkFiles(files, ignoreList, repoRoot) {
@@ -119,7 +136,7 @@ export function checkFiles(files, ignoreList, repoRoot) {
 
     if (lineCount > MAX_LINES) {
       if (grandfathered) {
-        skipped.push({ relPath, lineCount })
+        skipped.push({ relPath, lineCount, smiRef: ignoreList.get(relPath) ?? null })
       } else {
         violations.push({ relPath, lineCount })
       }
@@ -143,8 +160,11 @@ function main() {
   const ignoreList = loadIgnoreList(join(repoRoot, 'scripts', 'check-file-length.ignore'))
   const { violations, skipped, delistable } = checkFiles(files, ignoreList, repoRoot)
 
-  for (const { relPath } of skipped) {
-    console.log(`  ${relPath}: skipped (grandfathered — SMI-4948 split pending)`)
+  for (const { relPath, smiRef } of skipped) {
+    const reason = smiRef
+      ? `grandfathered — ${smiRef} split pending`
+      : 'grandfathered — see scripts/check-file-length.ignore for the tracking issue'
+    console.log(`  ${relPath}: skipped (${reason})`)
   }
 
   for (const { relPath, lineCount } of delistable) {

--- a/scripts/tests/check-file-length.test.ts
+++ b/scripts/tests/check-file-length.test.ts
@@ -22,8 +22,11 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync, cpSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import picomatch from 'picomatch'
 // @ts-expect-error - .mjs script has no typings
 import { parseIgnoreList, checkFiles, loadIgnoreList } from '../check-file-length.mjs'
+// @ts-expect-error - .js config has no typings
+import lintStagedConfig from '../../lint-staged.config.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const SCRIPT_PATH = resolve(__dirname, '..', 'check-file-length.mjs')
@@ -41,6 +44,22 @@ function writeTsFile(root: string, relPath: string, lines: number): string {
   // `lines` lines == `lines - 1` newline characters via split('\n').length.
   const body = Array.from({ length: lines }, (_, i) => `const x${i} = ${i}`).join('\n')
   writeFileSync(abs, body, 'utf8')
+  return abs
+}
+
+/**
+ * Build a .sh file with exactly `lines` lines under `root` (SMI-5658 .sh
+ * routing coverage). Content need not be valid bash since the hook only
+ * counts lines; a shebang + comment-body reads plausibly.
+ */
+function writeShFile(root: string, relPath: string, lines: number): string {
+  const abs = join(root, relPath)
+  mkdirSync(dirname(abs), { recursive: true })
+  const contentLines = [
+    '#!/usr/bin/env bash',
+    ...Array.from({ length: Math.max(lines - 1, 0) }, (_, i) => `# line ${i}`),
+  ]
+  writeFileSync(abs, contentLines.join('\n'), 'utf8')
   return abs
 }
 
@@ -62,6 +81,10 @@ describe('parseIgnoreList', () => {
     expect(entries.has('supabase/functions/_shared/ops-report-templates.ts')).toBe(true)
     expect(entries.has('# header comment')).toBe(false)
     expect(entries.size).toBe(2)
+    // SMI-5658 Step 6: each entry carries the SMI ref from its immediately
+    // preceding `# SMI-XXXX split follow-up` comment (or null if absent).
+    expect(entries.get('supabase/functions/indexer/index.test.ts')).toBe('SMI-4948')
+    expect(entries.get('supabase/functions/_shared/ops-report-templates.ts')).toBe(null)
   })
 
   it('returns an empty set for empty input', () => {
@@ -94,7 +117,7 @@ describe('checkFiles', () => {
 
   it('flags an over-limit file as a violation', () => {
     const abs = writeTsFile(root, 'src/big.ts', 600)
-    const { violations, skipped } = checkFiles([abs], new Set(), root)
+    const { violations, skipped } = checkFiles([abs], new Map(), root)
     expect(violations).toHaveLength(1)
     expect(violations[0].relPath).toBe('src/big.ts')
     expect(violations[0].lineCount).toBe(600)
@@ -103,7 +126,7 @@ describe('checkFiles', () => {
 
   it('passes an under-limit file with no violations', () => {
     const abs = writeTsFile(root, 'src/small.ts', 300)
-    const { violations, skipped, delistable } = checkFiles([abs], new Set(), root)
+    const { violations, skipped, delistable } = checkFiles([abs], new Map(), root)
     expect(violations).toHaveLength(0)
     expect(skipped).toHaveLength(0)
     expect(delistable).toHaveLength(0)
@@ -111,11 +134,12 @@ describe('checkFiles', () => {
 
   it('skips an ignore-listed over-limit path instead of failing', () => {
     const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
-    const ignoreList = new Set(['supabase/functions/indexer/index.test.ts'])
+    const ignoreList = new Map([['supabase/functions/indexer/index.test.ts', 'SMI-4948']])
     const { violations, skipped } = checkFiles([abs], ignoreList, root)
     expect(violations).toHaveLength(0)
     expect(skipped).toHaveLength(1)
     expect(skipped[0].relPath).toBe('supabase/functions/indexer/index.test.ts')
+    expect(skipped[0].smiRef).toBe('SMI-4948')
   })
 
   it('matches an ABSOLUTE-path argument against a repo-relative ignore entry (C1)', () => {
@@ -124,7 +148,7 @@ describe('checkFiles', () => {
     // absolute path as unmatched and fail the commit.
     const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
     expect(resolve(abs)).toBe(abs) // sanity: abs really is absolute
-    const ignoreList = new Set(['supabase/functions/indexer/index.test.ts'])
+    const ignoreList = new Map([['supabase/functions/indexer/index.test.ts', 'SMI-4948']])
     const { violations, skipped } = checkFiles([abs], ignoreList, root)
     expect(violations).toHaveLength(0)
     expect(skipped).toHaveLength(1)
@@ -132,7 +156,7 @@ describe('checkFiles', () => {
 
   it('re-enforces a grandfathered file once it drops below the limit (H1)', () => {
     const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 420)
-    const ignoreList = new Set(['supabase/functions/indexer/index.test.ts'])
+    const ignoreList = new Map([['supabase/functions/indexer/index.test.ts', 'SMI-4948']])
     const { violations, skipped, delistable } = checkFiles([abs], ignoreList, root)
     expect(violations).toHaveLength(0)
     expect(skipped).toHaveLength(0)
@@ -143,7 +167,7 @@ describe('checkFiles', () => {
 
   it('checks every file when the ignore-list is empty', () => {
     const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
-    const { violations } = checkFiles([abs], new Set(), root)
+    const { violations } = checkFiles([abs], new Map(), root)
     expect(violations).toHaveLength(1)
   })
 })
@@ -196,16 +220,47 @@ describe('check-file-length.mjs (end-to-end)', () => {
     expect(stderr).toContain('600 lines')
   })
 
-  it('exits 0 and prints a skip notice for a grandfathered over-limit file (absolute path)', () => {
+  it('exits 1 for a non-grandfathered over-limit .sh file (SMI-5658 routing)', () => {
+    const abs = writeShFile(root, 'scripts/oversized.sh', 600)
+    const { status, stderr } = runHook([abs])
+    expect(status).toBe(1)
+    expect(stderr).toContain('scripts/oversized.sh')
+    expect(stderr).toContain('600 lines')
+  })
+
+  it('exits 0 and prints a skip notice naming the correct SMI ref for a grandfathered over-limit file (absolute path)', () => {
+    // SMI-5658 Step 6: the ignore file's own `# SMI-XXXX split follow-up`
+    // comment must drive the message, not a hardcoded issue number. Uses
+    // SMI-5211, one of the two live ignore-list entries.
     writeFileSync(
       join(root, 'scripts', 'check-file-length.ignore'),
-      '# SMI-4948 split follow-up\nsupabase/functions/indexer/index.test.ts\n',
+      '# SMI-5211 split follow-up\nsupabase/functions/indexer/index.test.ts\n',
       'utf8'
     )
     const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
     const { status, stdout } = runHook([abs])
     expect(status).toBe(0)
-    expect(stdout).toContain('supabase/functions/indexer/index.test.ts: skipped (grandfathered')
+    expect(stdout).toContain(
+      'supabase/functions/indexer/index.test.ts: skipped (grandfathered — SMI-5211 split pending)'
+    )
+  })
+
+  it('exits 0 and prints the generic fallback notice when a grandfathered path has no preceding SMI comment', () => {
+    // SMI-5658 Step 6 defensive fallback: a grandfathered path added
+    // without the ignore-list's own `# SMI-XXXX split follow-up`
+    // convention still gets skipped, but the message degrades gracefully
+    // instead of naming a wrong/hardcoded issue.
+    writeFileSync(
+      join(root, 'scripts', 'check-file-length.ignore'),
+      'supabase/functions/indexer/index.test.ts\n',
+      'utf8'
+    )
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
+    const { status, stdout } = runHook([abs])
+    expect(status).toBe(0)
+    expect(stdout).toContain(
+      'supabase/functions/indexer/index.test.ts: skipped (grandfathered — see scripts/check-file-length.ignore for the tracking issue)'
+    )
   })
 
   it('exits 0 and prints an eligible-to-de-list notice once a grandfathered file is under the limit (H1)', () => {
@@ -224,5 +279,44 @@ describe('check-file-length.mjs (end-to-end)', () => {
     const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
     const { status } = runHook([abs])
     expect(status).toBe(1)
+  })
+})
+
+/**
+ * Guards the routing layer directly, not just the script (SMI-5658
+ * plan-review resolution): a future revert of the glob key from
+ * '*.{ts,sh}' back to '*.ts' would leave the script-level tests above
+ * green while silently reintroducing the SMI-5658 bug. Uses picomatch
+ * with matchBase, mirroring lint-staged's own matcher
+ * (node_modules/lint-staged/lib/matchFiles.js).
+ */
+describe('lint-staged.config.js glob', () => {
+  const config = lintStagedConfig as Record<string, unknown>
+
+  /**
+   * Every lint-staged.config.js key whose glob matches `filename`, using
+   * the same picomatch options lint-staged itself uses (matchBase for
+   * slash-free patterns). A single filename can legitimately match more
+   * than one key (e.g. a .ts file matches both the eslint/prettier key
+   * and the length-check key) — do not assume a unique match.
+   */
+  function matchingKeys(filename: string): string[] {
+    return Object.keys(config).filter((pattern) => {
+      const isMatch = picomatch(pattern, { matchBase: !pattern.includes('/') })
+      return isMatch(filename)
+    })
+  }
+
+  it('routes a .sh path through the length-check key (SMI-5658)', () => {
+    const keys = matchingKeys('foo.sh')
+    expect(keys).toContain('*.{ts,sh}')
+
+    const tasks = config['*.{ts,sh}'] as string[]
+    expect(tasks).toContain('node scripts/check-file-length.mjs')
+  })
+
+  it('still routes a .ts path through the length-check key (no regression)', () => {
+    const keys = matchingKeys('foo.ts')
+    expect(keys).toContain('*.{ts,sh}')
   })
 })

--- a/scripts/tests/check-file-length.test.ts
+++ b/scripts/tests/check-file-length.test.ts
@@ -87,13 +87,30 @@ describe('parseIgnoreList', () => {
     expect(entries.get('supabase/functions/_shared/ops-report-templates.ts')).toBe(null)
   })
 
-  it('returns an empty set for empty input', () => {
+  it('does not leak a ref from a parenthesized "cleared" block onto a later comment-less path', () => {
+    // SMI-5658 Step 6: SMI_FOLLOW_UP_RE only matches `# SMI-XXXX split
+    // follow-up` immediately after '#\s*' — a cleared block's leading
+    // '(' (the real ignore file's convention for historical entries,
+    // e.g. "# (SMI-5036 split follow-up cleared ...)") must NOT match,
+    // or its ref would attach to an unrelated path below it.
+    const raw = [
+      '# (SMI-9999 split follow-up cleared 2026-08-01: foo was split)',
+      '',
+      'packages/core/tests/no-preceding-comment.test.ts',
+    ].join('\n')
+
+    const entries = parseIgnoreList(raw)
+
+    expect(entries.get('packages/core/tests/no-preceding-comment.test.ts')).toBe(null)
+  })
+
+  it('returns an empty map for empty input', () => {
     expect(parseIgnoreList('').size).toBe(0)
   })
 })
 
 describe('loadIgnoreList', () => {
-  it('returns an empty set when the ignore file is absent', () => {
+  it('returns an empty map when the ignore file is absent', () => {
     const dir = makeTempDir()
     try {
       const entries = loadIgnoreList(join(dir, 'does-not-exist.ignore'))
@@ -287,22 +304,29 @@ describe('check-file-length.mjs (end-to-end)', () => {
  * plan-review resolution): a future revert of the glob key from
  * '*.{ts,sh}' back to '*.ts' would leave the script-level tests above
  * green while silently reintroducing the SMI-5658 bug. Uses picomatch
- * with matchBase, mirroring lint-staged's own matcher
- * (node_modules/lint-staged/lib/matchFiles.js).
+ * with the same option set lint-staged itself passes
+ * (node_modules/lint-staged/lib/matchFiles.js: dot, matchBase,
+ * posixSlashes, strictBrackets) so this test's notion of a "match"
+ * doesn't diverge from lint-staged's real behavior (e.g. dotfiles).
  */
 describe('lint-staged.config.js glob', () => {
   const config = lintStagedConfig as Record<string, unknown>
 
   /**
    * Every lint-staged.config.js key whose glob matches `filename`, using
-   * the same picomatch options lint-staged itself uses (matchBase for
-   * slash-free patterns). A single filename can legitimately match more
-   * than one key (e.g. a .ts file matches both the eslint/prettier key
-   * and the length-check key) — do not assume a unique match.
+   * the same picomatch options lint-staged itself uses. A single filename
+   * can legitimately match more than one key (e.g. a .ts file matches
+   * both the eslint/prettier key and the length-check key) — do not
+   * assume a unique match.
    */
   function matchingKeys(filename: string): string[] {
     return Object.keys(config).filter((pattern) => {
-      const isMatch = picomatch(pattern, { matchBase: !pattern.includes('/') })
+      const isMatch = picomatch(pattern, {
+        dot: true,
+        matchBase: !pattern.includes('/'),
+        posixSlashes: true,
+        strictBrackets: true,
+      })
       return isMatch(filename)
     })
   }


### PR DESCRIPTION
## Business Summary

**What shipped:** The pre-commit check that blocks oversized files (500-line limit) now actually catches oversized shell scripts, not just TypeScript. Before this fix, a `.sh` file could grow indefinitely with zero warning — that's exactly how a shell test file quietly grew to 594 lines undetected across two recent PRs.

**Quality bar:** Full ADR-109 process — research, a reviewed design plan, implementation, and an independent adversarial code review — before this shipped. Verified against a real pre-commit hook, not just unit tests: staged an oversized `.sh` file and watched it get correctly rejected, then confirmed the existing TypeScript check still works exactly as before.

**Found along the way:** The same gap also affects `.mjs` files — and it's worse there, since the script meant to *enforce* file-length limits (`audit-standards.mjs`) is itself over 9x the limit. Filed separately as SMI-5662 rather than folded in here, since fixing it responsibly means deciding whether to split that script first. Also filed SMI-5660 to track splitting five pre-existing oversized shell scripts that this fix grandfathers in (so nobody gets blindsided on their next unrelated edit).

**Net result:** Fully shipped, no follow-up needed on this PR. SMI-5660 and SMI-5662 are tracked separately.

---

## Technical detail

**Root cause**: `lint-staged.config.js`'s `'*.ts'` glob was the *only* thing invoking `check-file-length.mjs` — the script itself has no extension filter and checks whatever paths it's handed. The original issue framing ("extend the script's extension-filter logic") was imprecise; there was no such logic to extend.

**Files changed** (commits `d0670a6a` + `ca429b39`):
- `lint-staged.config.js` — `'*.ts'` → `'*.{ts,sh}'`
- `scripts/check-file-length.mjs` — corrected the now-inaccurate `.ts`-only header comment; migrated `parseIgnoreList`/`loadIgnoreList`/`checkFiles` from `Set<string>` to `Map<string, string|null>` so the grandfather skip-message cites each ignore-list entry's own `# SMI-XXXX` tracking issue instead of a previously hardcoded, stale `SMI-4948`
- `scripts/check-file-length.ignore` — corrected the same `.ts`-only header prose; grandfathered 5 pre-existing over-limit `.sh` files (`scripts/_lib.sh` at 1075 lines and 4 others) under new tracking issue SMI-5660; documented the paren-exclusion convention for cleared entries
- `scripts/tests/check-file-length.test.ts` — new `.sh` end-to-end case, a config-level test asserting `lint-staged.config.js`'s glob actually routes `.sh` paths via `picomatch` (matching lint-staged's real matcher options), coverage for the corrected skip-message + its fallback path, and a regression test pinning the "cleared block doesn't leak its ref" invariant

**Process**: SPARC research → plan doc (`docs/internal/implementation/smi-5658-check-file-length-sh-coverage.md`) → `/plan-review-skill` (7 findings applied, including the Critical `.mjs` finding above) → implementation → adversarial governance review (3 Low findings — an untested regex invariant, partial-fidelity test options, stale test labels — all fixed; report at `docs/internal/code_review/2026-07-11-smi-5658-check-file-length-sh-coverage-review.md`).

**Verification**: 19/19 new/updated tests pass; full `scripts/tests/` regression suite 2173/2177 (4 pre-existing unrelated skips); typecheck/lint/format:check clean; `audit:standards` 0 failures. Manually staged a 600-line `.sh` fixture through a real `git commit` and confirmed the hook hard-fails; confirmed `.ts` enforcement is unaffected; confirmed all 5 grandfathered `.sh` files print the correct `SMI-5660` reference.

Fixes SMI-5658

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)