### PR TITLE
fix(scripts): resolve worktree port-bucket collisions

### DIFF
--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -807,6 +807,283 @@ enumerate_native_module_volumes() {
 }
 
 #######################################
+# Worktree port-bucket collision resolution (SMI-5661).
+#
+# Problem: generate_docker_override_to_stdout previously derived a worktree's
+# port bucket (1-99, mapped to host ports 3000+offset*10 .. +3) purely from a
+# `cksum` hash of the worktree name. Two independent worktree names can hash
+# to the SAME bucket (verified live: "smi-5641-remove-dead-dep-helpers" and
+# "smi-5651-registry-catchup" both hash to bucket 79), and a bucket can also
+# collide with a port some OTHER process already has bound on the host (e.g.
+# a lingering container, or an unrelated dev server). Either collision made
+# `docker compose up` fail with a host-level EADDRINUSE for one of the two
+# worktrees, with no retry or reassignment.
+#
+# Fix: probe candidate buckets in order (deterministic hash first, so the
+# common case is unchanged), skipping any bucket whose 4 ports collide with
+# a SIBLING worktree's override file or with a port already LISTENing on the
+# host, wrapping around the full 1-99 space before giving up.
+#######################################
+
+#######################################
+# Parse the HOST-side ports out of a generated docker-compose.override.yml.
+#
+# Override port lines have the fixed shape (quoted "HOST:CONTAINER"):
+#   - "37910:3000"   # Main app
+#
+# Arguments:
+#   $1 - Path to a docker-compose.override.yml (may not exist)
+# Outputs:
+#   stdout - one host port per line; empty if the file is absent or has none
+#######################################
+_parse_override_host_ports() {
+    local file="$1"
+    [ -f "$file" ] || return 0
+    grep -oE '"[0-9]+:[0-9]+"' "$file" 2>/dev/null | tr -d '"' | cut -d: -f1
+}
+
+#######################################
+# Enumerate host ports already claimed by SIBLING worktrees' override files,
+# excluding the main repo and the worktree being resolved itself (half of the
+# self-collision-avoidance fix — see _resolve_worktree_port_offset for the
+# other half).
+#
+# Arguments:
+#   $1 - repo_root    Main repository root (for `git worktree list`)
+#   $2 - self_path    Worktree path currently being resolved (excluded)
+# Outputs:
+#   stdout - one host port per line, across all other worktrees
+#######################################
+_worktree_sibling_taken_ports() {
+    local repo_root="$1" self_path="$2" wt
+    while IFS= read -r wt; do
+        [ -z "$wt" ] && continue
+        [ "$wt" = "$repo_root" ] && continue
+        [ "$wt" = "$self_path" ] && continue
+        _parse_override_host_ports "$wt/docker-compose.override.yml"
+    done < <(git -C "$repo_root" worktree list --porcelain 2>/dev/null \
+                 | sed -n 's/^worktree //p')
+}
+
+#######################################
+# Check whether a port is already bound (LISTENing) on the host.
+#
+# `lsof -nP -iTCP:<port> -sTCP:LISTEN` reads the kernel socket table for
+# LISTEN-state sockets, ships on both macOS and Linux, and generates no
+# network traffic. `nc -z` opens a real connection (flaky, and flag syntax
+# diverges between BSD and GNU `nc`); `ss` is Linux-only; `netstat` is
+# deprecated on macOS. Known limitation: this only sees sockets owned by
+# processes the current user can enumerate — Docker's own EADDRINUSE at
+# `up` time remains the final backstop.
+#
+# Arguments:
+#   $1 - port number to check
+# Returns:
+#   0 if bound (or check skipped/unavailable — fails toward "assume bound"
+#     only when a real check ran and found a LISTENer); 1 if free or lsof
+#     is unavailable / the check is disabled.
+#######################################
+_worktree_host_port_bound() {
+    local port="$1"
+    [ "${SKILLSMITH_WORKTREE_PORT_SKIP_HOST_CHECK:-}" = "1" ] && return 1
+    command -v lsof >/dev/null 2>&1 || return 1
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+#######################################
+# Resolve a collision-free port bucket (1-99) for a worktree.
+#
+# Two mechanisms cooperate to avoid a worktree reprobing itself away from its
+# OWN currently-assigned bucket (self-collision avoidance):
+#   1. _worktree_sibling_taken_ports (above) excludes self_path from the
+#      sibling scan.
+#   2. This function's "sticky" start-offset: if the worktree already has an
+#      override file, the probe STARTS from the bucket already recorded
+#      there (recovered from its own host ports) rather than from the
+#      deterministic hash, and treats the worktree's OWN 4 ports as never a
+#      collision. Without this, repair_worktrees_compose_override
+#      regenerating a worktree whose container is live on a probed
+#      (non-deterministic) bucket would reprobe it back toward the
+#      deterministic hash and desync the override from the running
+#      container.
+#
+# Loop invariant: `offset=$(( (offset % 99) + 1 ))` cycles through the full
+# 1..99 space exactly once before repeating — no infinite loop, no silent
+# reuse; after 99 failed attempts this returns failure instead.
+#
+# Arguments:
+#   $1 - worktree_path   Absolute path to the worktree being resolved
+#   $2 - worktree_name   Sanitized worktree name (input to the cksum hash)
+#   $3 - repo_root       Main repository root
+# Outputs:
+#   stdout - the resolved offset (1-99) on success
+#   stderr - a NOTE when reassigned away from the deterministic hash, or an
+#            ERROR when no free bucket was found
+# Returns:
+#   0 on success, 1 if no free bucket was found after a full cycle
+#######################################
+_resolve_worktree_port_offset() {
+    local worktree_path="$1" worktree_name="$2" repo_root="$3"
+
+    local deterministic_offset
+    deterministic_offset=$(printf '%s' "$worktree_name" | cksum | awk '{print ($1 % 99) + 1}')
+
+    local own_ports start_offset own_base cand
+    own_ports="$(_parse_override_host_ports "$worktree_path/docker-compose.override.yml" | tr '\n' ' ')"
+    start_offset="$deterministic_offset"
+    if [ -n "${own_ports// /}" ]; then
+        own_base=$(printf '%s\n' $own_ports | sort -n | head -1)
+        if [ -n "$own_base" ] && [ $(( (own_base - 3000) % 10 )) -eq 0 ]; then
+            cand=$(( (own_base - 3000) / 10 ))
+            [ "$cand" -ge 1 ] && [ "$cand" -le 99 ] && start_offset="$cand"
+        fi
+    fi
+
+    local sibling_ports
+    sibling_ports="$(_worktree_sibling_taken_ports "$repo_root" "$worktree_path" | tr '\n' ' ')"
+
+    [ -n "${SKILLSMITH_WORKTREE_PORT_TEST_DELAY:-}" ] && sleep "$SKILLSMITH_WORKTREE_PORT_TEST_DELAY"
+
+    local offset="$start_offset" attempt=0 p base free
+    while [ "$attempt" -lt 99 ]; do
+        base=$(( 3000 + offset * 10 ))
+        free=1
+        for p in "$base" $((base+1)) $((base+2)) $((base+3)); do
+            case " $own_ports " in *" $p "*) continue ;; esac
+            case " $sibling_ports " in *" $p "*) free=0; break ;; esac
+            if _worktree_host_port_bound "$p"; then free=0; break; fi
+        done
+        if [ "$free" -eq 1 ]; then
+            if [ "$offset" != "$deterministic_offset" ]; then
+                printf 'NOTE: worktree port bucket %s (deterministic) unavailable — reassigned to bucket %s (SMI-5661)\n' \
+                    "$deterministic_offset" "$offset" >&2
+            fi
+            printf '%s\n' "$offset"
+            return 0
+        fi
+        offset=$(( (offset % 99) + 1 ))
+        attempt=$(( attempt + 1 ))
+    done
+
+    printf 'ERROR: no free worktree port bucket found after 99 attempts — free up host ports or remove stale worktrees (SMI-5661)\n' >&2
+    return 1
+}
+
+#######################################
+# Concurrency lock guarding worktree port-bucket resolution + override write
+# (SMI-5661). Adapted from retrieval-autoheal.sh's acquire_lock/release_lock
+# (scripts/retrieval-autoheal.sh:108-198): flock when available (fd 8, held
+# for the caller's life — the kernel releases it on any exit including a
+# crash), else a non-evicting atomic `mkdir` lock for stock macOS bash 3.2
+# (no `flock`, no `exec {var}>` fd auto-allocation, so the fd is hardcoded).
+#
+# One lock per MAIN-REPO checkout (key = `cksum` of repo_root, so all
+# worktrees of the same repo — which all read/write each other's override
+# files — serialize against each other; different repos never contend).
+# Test-isolated via SKILLSMITH_WORKTREE_PORT_LOCK_HOME (mirrors
+# SKILLSMITH_AUTOHEAL_HOME in retrieval-autoheal.sh).
+#
+# Best-effort: on timeout (busy flock, or a live mkdir-lock holder), WARN and
+# return non-zero; the caller proceeds UNLOCKED rather than refusing to
+# create/repair a worktree over lock contention — Docker's own EADDRINUSE at
+# `up` time is the final backstop, same as the host-port-bound check above.
+#######################################
+WORKTREE_PORT_LOCK_MODE=""
+WORKTREE_PORT_LOCK_DIR=""
+WORKTREE_PORT_LOCK_PID_FILE=""
+_WORKTREE_PORT_LOCK_FD=8
+WORKTREE_PORT_LOCK_WAIT="${SKILLSMITH_WORKTREE_PORT_LOCK_WAIT:-10}"
+WORKTREE_PORT_LOCK_TMAX="${SKILLSMITH_WORKTREE_PORT_LOCK_TMAX:-60}"
+
+#######################################
+# Acquire the worktree port-bucket lock. See the block comment above.
+#
+# Arguments:
+#   $1 - repo_root   Main repository root (used to derive the lock key)
+# Returns:
+#   0 if the lock was acquired (or locking is disabled); 1 if acquisition
+#   timed out (caller proceeds unlocked; a warning has already been printed)
+#######################################
+acquire_worktree_port_lock() {
+    local repo_root="$1"
+    [ "${SKILLSMITH_WORKTREE_PORT_LOCK_DISABLE:-}" = "1" ] && { WORKTREE_PORT_LOCK_MODE="disabled"; return 0; }
+
+    local home key state_dir flock_file
+    home="${SKILLSMITH_WORKTREE_PORT_LOCK_HOME:-$HOME}"
+    key="$(printf '%s' "$repo_root" | cksum | awk '{print $1}')"
+    state_dir="$home/.skillsmith"
+    mkdir -p "$state_dir" 2>/dev/null || true
+    WORKTREE_PORT_LOCK_DIR="$state_dir/worktree-ports-$key.lock"
+    WORKTREE_PORT_LOCK_PID_FILE="$WORKTREE_PORT_LOCK_DIR/pid"
+    flock_file="$state_dir/worktree-ports-$key.flock"
+
+    local force_mkdir=""
+    [ "${SKILLSMITH_WORKTREE_PORT_FORCE_MKDIR_LOCK:-}" = "1" ] && force_mkdir="1"
+
+    if [ -z "$force_mkdir" ] && command -v flock >/dev/null 2>&1; then
+        if eval "exec ${_WORKTREE_PORT_LOCK_FD}>\"$flock_file\""; then
+            if flock -w "$WORKTREE_PORT_LOCK_WAIT" "$_WORKTREE_PORT_LOCK_FD"; then
+                WORKTREE_PORT_LOCK_MODE="flock"
+                return 0
+            fi
+            eval "exec ${_WORKTREE_PORT_LOCK_FD}>&-" 2>/dev/null || true
+            warn "  Worktree port lock busy after ${WORKTREE_PORT_LOCK_WAIT}s — proceeding best-effort (SMI-5661)"
+            return 1
+        fi
+    fi
+
+    local deadline hpid hstart age
+    deadline=$(( $(date +%s) + WORKTREE_PORT_LOCK_WAIT ))
+    while :; do
+        if mkdir "$WORKTREE_PORT_LOCK_DIR" 2>/dev/null; then
+            printf '%s %s\n' "$$" "$(date +%s)" > "$WORKTREE_PORT_LOCK_PID_FILE" 2>/dev/null || true
+            if [ "$(awk '{print $1}' "$WORKTREE_PORT_LOCK_PID_FILE" 2>/dev/null)" != "$$" ]; then
+                continue
+            fi
+            trap 'release_worktree_port_lock' EXIT
+            trap 'release_worktree_port_lock; exit 130' INT
+            trap 'release_worktree_port_lock; exit 143' TERM
+            WORKTREE_PORT_LOCK_MODE="mkdir"
+            return 0
+        fi
+        hpid="$(awk '{print $1}' "$WORKTREE_PORT_LOCK_PID_FILE" 2>/dev/null)"
+        hstart="$(awk '{print $2}' "$WORKTREE_PORT_LOCK_PID_FILE" 2>/dev/null)"
+        if [ -n "$hpid" ] && ! kill -0 "$hpid" 2>/dev/null; then
+            rm -rf "$WORKTREE_PORT_LOCK_DIR" 2>/dev/null || true; continue
+        fi
+        age=0; [ -n "$hstart" ] && age=$(( $(date +%s) - hstart ))
+        if [ "$age" -gt "$WORKTREE_PORT_LOCK_TMAX" ]; then
+            rm -rf "$WORKTREE_PORT_LOCK_DIR" 2>/dev/null || true; continue
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+            warn "  Worktree port lock held by live pid ${hpid:-?} after ${WORKTREE_PORT_LOCK_WAIT}s — proceeding best-effort (SMI-5661)"
+            return 1
+        fi
+        sleep 0.2
+    done
+}
+
+#######################################
+# Release the worktree port-bucket lock acquired by acquire_worktree_port_lock.
+# Ownership-checked in mkdir mode: only removes the lock dir if THIS process
+# still owns it (a stale/reclaimed lock's original holder must not delete a
+# reclaimer's live lock).
+#######################################
+release_worktree_port_lock() {
+    case "$WORKTREE_PORT_LOCK_MODE" in
+        flock)
+            eval "exec ${_WORKTREE_PORT_LOCK_FD}>&-" 2>/dev/null || true
+            ;;
+        mkdir)
+            local owner
+            owner="$(awk '{print $1}' "$WORKTREE_PORT_LOCK_PID_FILE" 2>/dev/null)"
+            [ "$owner" = "$$" ] && rm -rf "$WORKTREE_PORT_LOCK_DIR" 2>/dev/null || true
+            ;;
+    esac
+    WORKTREE_PORT_LOCK_MODE=""
+}
+
+#######################################
 # Emit worktree docker-compose.override.yml content to stdout (SMI-4738 split).
 #
 # Pure-output form of generate_docker_override: produces the same YAML body
@@ -833,17 +1110,20 @@ generate_docker_override_to_stdout() {
     local worktree_path="$1"
     local branch_name="$2"
     local repo_root="$3"
-    # worktree_path is part of the function contract (caller may switch back to a
-    # path-aware variant later); reference it once to silence shellcheck.
-    : "$worktree_path"
 
     # Extract a short name from branch (e.g., feature/jwt-rollout -> jwt-rollout)
     local worktree_name
     worktree_name=$(basename "$branch_name" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
 
-    # Calculate port offset based on hash of worktree name (1-99)
+    # Resolve a collision-free port bucket (SMI-5661). Deterministic cksum hash is
+    # the first candidate (common case unchanged); probes the next bucket on a
+    # sibling-override or host-bound collision; sticky to this worktree's own
+    # existing override so a live container is not reprobed away from its ports.
+    # CALLER holds acquire_worktree_port_lock across this + the override write.
     local port_offset
-    port_offset=$(echo -n "$worktree_name" | cksum | awk '{print ($1 % 99) + 1}')
+    if ! port_offset="$(_resolve_worktree_port_offset "$worktree_path" "$worktree_name" "$repo_root")"; then
+        return 1
+    fi
 
     # Base ports: dev=3001, test=3002, orchestrator=3003
     local dev_app_port=$((3000 + port_offset * 10))
@@ -932,18 +1212,32 @@ EOF
 # to <worktree_path>/docker-compose.override.yml. Preserves the existing API
 # used by create-worktree.sh and repair-worktrees.sh callers.
 #
+# SMI-5661: the port-bucket resolution + write are guarded by the worktree
+# port-bucket lock so two concurrent create-worktree.sh invocations can't both
+# read the same "free" bucket before either has written its override (a
+# TOCTOU race the resolver's own probe cannot close by itself). Best-effort —
+# see acquire_worktree_port_lock's own doc comment for the unlocked fallback.
+#
 # Arguments:
 #   $1 - Worktree path
 #   $2 - Branch name (used for unique container names + port hash)
 #   $3 - Repository root path (for resolving per-package node_modules; main repo)
+# Returns:
+#   0 on success; 1 if generate_docker_override_to_stdout failed (e.g. no
+#   free port bucket found)
 #######################################
 generate_docker_override() {
     local worktree_path="$1"
     local branch_name="$2"
     local repo_root="$3"
+    local rc=0
 
+    acquire_worktree_port_lock "$repo_root" || true
     generate_docker_override_to_stdout "$worktree_path" "$branch_name" "$repo_root" \
-        > "$worktree_path/docker-compose.override.yml"
+        > "$worktree_path/docker-compose.override.yml" || rc=$?
+    release_worktree_port_lock
+
+    return $rc
 }
 
 #######################################
@@ -981,6 +1275,16 @@ repair_worktrees_compose_override() {
         info "  macOS-only — skipping per-package bind-mount regen on $(uname)"
         return 0
     fi
+
+    # SMI-5661: acquire the port-bucket lock ONCE for the whole regen pass
+    # (not per-iteration) since the loop below calls
+    # generate_docker_override_to_stdout directly — not through the
+    # generate_docker_override wrapper — so there is no nested acquire and
+    # thus no self-deadlock risk. Released once after the loop, before the
+    # summary. Best-effort: acquire_worktree_port_lock warns and returns
+    # non-zero on contention; the regen proceeds unlocked rather than
+    # skipping worktrees outright.
+    acquire_worktree_port_lock "$repo_root" || true
 
     while IFS= read -r wt_path; do
         [[ -z "$wt_path" ]] && continue
@@ -1027,6 +1331,8 @@ repair_worktrees_compose_override() {
         mv "$tmp" "$override"
         modified=$((modified + 1))
     done < <(git -C "$repo_root" worktree list --porcelain | awk '/^worktree / { print $2 }')
+
+    release_worktree_port_lock
 
     if [[ $modified -gt 0 ]]; then
         success "  Regenerated docker-compose.override.yml for $modified worktree(s) (SMI-4689)"

--- a/scripts/tests/worktree-port-collision.test.sh
+++ b/scripts/tests/worktree-port-collision.test.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+# SMI-5661: Unit tests for the worktree port-bucket collision-resolution
+# helpers added to scripts/_lib.sh — _parse_override_host_ports,
+# _worktree_sibling_taken_ports, _worktree_host_port_bound,
+# _resolve_worktree_port_offset — plus the acquire_worktree_port_lock /
+# release_worktree_port_lock concurrency guard wrapped around
+# generate_docker_override and repair_worktrees_compose_override.
+#
+# Split into its own file (rather than folded into the sibling
+# enumerate-compose-mounts*.test.sh files) per CLAUDE.md's 500-line
+# guidance — those files already have no headroom for this addition.
+#
+# Uses REAL `git worktree add` fixtures, NOT enumerate-compose-mounts.test.sh's
+# non-git `make_repo` helper: _worktree_sibling_taken_ports reads real
+# `git worktree list --porcelain` output, which only a real repo produces.
+#
+# Deviates from the sibling test files' `set -euo pipefail` in one respect
+# (see below `set` line) because of the concurrency section's background
+# jobs.
+#
+# Covers:
+#   A. Sibling-file collision + probe, using the SMI-5661 Wave 1 research's
+#      verified same-bucket pair: "smi-5641-remove-dead-dep-helpers" and
+#      "smi-5651-registry-catchup" both hash to bucket 79.
+#   B. Host-bound port collision via a mocked _worktree_host_port_bound
+#      (worktree name "wt71", verified deterministic bucket 98).
+#   C. Wraparound boundary: buckets 99 and 1 both taken -> bucket 2
+#      (worktree name "wt41", verified deterministic bucket 99).
+#   D. Self-collision avoidance: (D1) _worktree_sibling_taken_ports excludes
+#      the worktree being resolved; (D2) the sticky start-offset keeps a
+#      simulated repair regen on a live worktree's OWN bucket ("wt92",
+#      verified deterministic bucket 2) even after the bucket that displaced
+#      it originally becomes free again.
+#   E. Concurrency: (E1) lock active -> two racing resolutions land on
+#      disjoint buckets; (E2) SKILLSMITH_WORKTREE_PORT_LOCK_DISABLE=1 negative
+#      control -> the SAME race DOES collide, proving the harness has real
+#      discriminating power; (E3) SKILLSMITH_WORKTREE_PORT_FORCE_MKDIR_LOCK=1
+#      -> same disjoint-buckets assertion as E1, so the macOS mkdir-lock
+#      fallback gets exercised even on a flock-equipped Linux CI host.
+
+# No `-e`: the concurrency section (E) intentionally inspects `wait`'s exit
+# status and deliberately provokes a FAILING (colliding) negative-control run
+# (E2) as evidence the harness can detect a real collision. Mirrors
+# retrieval-autoheal.sh's own `set -uo pipefail` (no `-e`) for the same
+# reason — a script whose control flow depends on intentional non-zero
+# returns must not have `-e` aborting it mid-flight.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+# shellcheck source=../_lib.sh
+source "$SCRIPT_DIR/_lib.sh"
+
+fail=0
+pass=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name: expected='$expected' actual='$actual'"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name: '$needle' not in output"
+    echo "  Haystack: $haystack"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo "FAIL $name: '$needle' should NOT be in output"
+    fail=$((fail + 1))
+  else
+    echo "PASS $name"
+    pass=$((pass + 1))
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Fixture builders
+# -----------------------------------------------------------------------
+
+# Global accumulator of every temp dir created below, removed by a single
+# EXIT trap. Single-quoted trap string so $ALL_TMP_DIRS is expanded when the
+# trap FIRES (reading its then-current value), not when it was registered.
+ALL_TMP_DIRS=""
+trap 'rm -rf $ALL_TMP_DIRS' EXIT
+
+# new_fixture_repo -> creates a throwaway git repo with one commit, tracks it
+# for cleanup, echoes its path.
+new_fixture_repo() {
+  local root
+  root=$(mktemp -d)
+  # Canonicalize eagerly (macOS `mktemp -d` returns a /var/... path that is
+  # itself a symlink to /private/var/...): `git worktree list --porcelain`
+  # reports the REALPATH, so every path this helper hands back must already
+  # be in that same canonical form or self-path comparisons (the
+  # self-collision-avoidance exclusion under test) silently fail on macOS
+  # even though the underlying resolver logic is correct.
+  root=$(cd "$root" && pwd -P)
+  ALL_TMP_DIRS="$ALL_TMP_DIRS $root"
+  git -C "$root" init -q
+  git -C "$root" config user.email test@example.com
+  git -C "$root" config user.name "Test"
+  git -C "$root" config commit.gpgsign false
+  : > "$root/README.md"
+  git -C "$root" add README.md
+  git -C "$root" commit -qm init >/dev/null
+  printf '%s' "$root"
+}
+
+# new_lock_home -> a fresh SKILLSMITH_WORKTREE_PORT_LOCK_HOME, tracked for
+# cleanup, echoes its path. Isolated per test group so lock state from one
+# scenario can never leak into another.
+new_lock_home() {
+  local home
+  home=$(mktemp -d)
+  ALL_TMP_DIRS="$ALL_TMP_DIRS $home"
+  printf '%s' "$home"
+}
+
+# add_worktree <repo_root> <name> -> `git worktree add` on a new branch named
+# <name> at <repo_root>/.worktrees/<name>, echoes the path.
+add_worktree() {
+  local root="$1" name="$2" path
+  path="$root/.worktrees/$name"
+  git -C "$root" worktree add -q -b "$name" "$path" HEAD >/dev/null 2>&1
+  printf '%s' "$path"
+}
+
+# write_fixed_override <worktree_path> <name> <base_port> -> hand-writes a
+# minimal override whose 4 port lines match the real generator's shape
+# (quoted "HOST:CONTAINER") at HOST ports base_port..base_port+3, regardless
+# of what bucket <name>'s own cksum hash would produce. Used to manufacture
+# an exact bucket collision without needing the fixture name's hash to
+# cooperate.
+write_fixed_override() {
+  local wt_path="$1" name="$2" base="$3"
+  cat > "$wt_path/docker-compose.override.yml" << EOF
+services:
+  dev:
+    container_name: ${name}-dev-1
+    ports:
+      - "$((base)):3000"   # Main app
+      - "$((base + 1)):3001"   # MCP server
+  test:
+    container_name: ${name}-test-1
+    ports:
+      - "$((base + 2)):3000"      # Test app
+  orchestrator:
+    container_name: ${name}-orchestrator-1
+    ports:
+      - "$((base + 3)):3000"  # Orchestrator
+EOF
+}
+
+# ports_overlap <list1> <list2> -> 0 (true) if any space-separated port in
+# list1 also appears in list2; 1 (false) if disjoint.
+ports_overlap() {
+  local list1="$1" list2="$2" p
+  for p in $list1; do
+    case " $list2 " in *" $p "*) return 0 ;; esac
+  done
+  return 1
+}
+
+# =========================================================================
+# Group A: sibling-file collision + probe (verified same-bucket pair)
+# =========================================================================
+ROOT_A=$(new_fixture_repo)
+export SKILLSMITH_WORKTREE_PORT_LOCK_HOME
+SKILLSMITH_WORKTREE_PORT_LOCK_HOME=$(new_lock_home)
+export SKILLSMITH_WORKTREE_PORT_SKIP_HOST_CHECK=1
+
+WT_A1=$(add_worktree "$ROOT_A" "smi-5641-remove-dead-dep-helpers")
+OUT_A1=$(generate_docker_override "$WT_A1" "smi-5641-remove-dead-dep-helpers" "$ROOT_A" 2>&1)
+assert_not_contains "groupA: first worktree (bucket 79, uncontested) -- no reassignment NOTE" "NOTE" "$OUT_A1"
+OVERRIDE_A1=$(cat "$WT_A1/docker-compose.override.yml")
+assert_contains "groupA: first worktree lands on deterministic bucket 79" '"3790:3000"' "$OVERRIDE_A1"
+
+WT_A2=$(add_worktree "$ROOT_A" "smi-5651-registry-catchup")
+OUT_A2=$(generate_docker_override "$WT_A2" "smi-5651-registry-catchup" "$ROOT_A" 2>&1)
+assert_contains "groupA: second worktree (same bucket-79 hash) gets a reassignment NOTE" "bucket 79" "$OUT_A2"
+assert_contains "groupA: reassignment NOTE names the resolved bucket 80" "reassigned to bucket 80" "$OUT_A2"
+OVERRIDE_A2=$(cat "$WT_A2/docker-compose.override.yml")
+assert_contains "groupA: second worktree lands on probed bucket 80" '"3800:3000"' "$OVERRIDE_A2"
+assert_not_contains "groupA: second worktree's ports do not overlap bucket 79" '"3790:3000"' "$OVERRIDE_A2"
+
+# =========================================================================
+# Group B: host-bound collision via a mocked _worktree_host_port_bound
+# =========================================================================
+ROOT_B=$(new_fixture_repo)
+WT_B=$(add_worktree "$ROOT_B" "wt71")
+
+# "wt71" hashes deterministically to bucket 98 (base port 3980). Mock the
+# host-bound probe to report exactly that bucket's 4 ports as LISTENing;
+# every other port is reported free. Run in a command-substitution subshell
+# so the function redefinition never leaks into later groups.
+ERR_B=$(mktemp)
+ALL_TMP_DIRS="$ALL_TMP_DIRS $ERR_B"
+OFFSET_B=$(
+  # NOTE: each case arm's pattern is wrapped in a leading `(` -- stock bash
+  # 3.2's parser otherwise mis-tracks an unadorned `pattern)` arm terminator
+  # as closing the ENCLOSING `$(...)` command substitution one level up
+  # (verified live: a bare `3980 | 3981) ... ;; esac` here throws "syntax
+  # error near unexpected token \`;;'"). The leading `(` is the standard
+  # portable workaround.
+  _worktree_host_port_bound() {
+    case "$1" in
+      (3980 | 3981 | 3982 | 3983) return 0 ;;
+      (*) return 1 ;;
+    esac
+  }
+  _resolve_worktree_port_offset "$WT_B" "wt71" "$ROOT_B" 2>"$ERR_B"
+)
+assert_eq "groupB: host-bound bucket 98 forces reassignment to bucket 99" "99" "$OFFSET_B"
+assert_contains "groupB: host-bound reassignment emits a NOTE" "reassigned to bucket 99" "$(cat "$ERR_B")"
+
+# =========================================================================
+# Group C: wraparound boundary (bucket 99 AND bucket 1 both taken -> 2)
+# =========================================================================
+ROOT_C=$(new_fixture_repo)
+WT_C_BLOCK99=$(add_worktree "$ROOT_C" "blocker99")
+write_fixed_override "$WT_C_BLOCK99" "blocker99" 3990
+WT_C_BLOCK1=$(add_worktree "$ROOT_C" "blocker1")
+write_fixed_override "$WT_C_BLOCK1" "blocker1" 3010
+
+# "wt41" hashes deterministically to bucket 99. With 99 taken, the resolver
+# wraps ((99 % 99) + 1 = 1); with 1 ALSO taken, it wraps again ((1 % 99) + 1
+# = 2) and lands there.
+WT_C_TARGET=$(add_worktree "$ROOT_C" "wt41")
+ERR_C=$(mktemp)
+ALL_TMP_DIRS="$ALL_TMP_DIRS $ERR_C"
+OFFSET_C=$(_resolve_worktree_port_offset "$WT_C_TARGET" "wt41" "$ROOT_C" 2>"$ERR_C")
+assert_eq "groupC: wraparound past 99 and 1 lands on bucket 2" "2" "$OFFSET_C"
+assert_contains "groupC: wraparound NOTE cites the original bucket 99" "bucket 99" "$(cat "$ERR_C")"
+assert_contains "groupC: wraparound NOTE cites the final bucket 2" "reassigned to bucket 2" "$(cat "$ERR_C")"
+
+# =========================================================================
+# Group D: self-collision avoidance
+# =========================================================================
+ROOT_D=$(new_fixture_repo)
+
+# --- D1: _worktree_sibling_taken_ports excludes the worktree being resolved.
+WT_D_SELF=$(add_worktree "$ROOT_D" "self-wt")
+WT_D_OTHER=$(add_worktree "$ROOT_D" "other-wt")
+write_fixed_override "$WT_D_SELF" "self-wt" 3100
+write_fixed_override "$WT_D_OTHER" "other-wt" 3200
+
+SIBLING_PORTS_D1=$(_worktree_sibling_taken_ports "$ROOT_D" "$WT_D_SELF" | tr '\n' ' ')
+assert_contains "groupD1: sibling scan reports the OTHER worktree's port" "3200" "$SIBLING_PORTS_D1"
+assert_not_contains "groupD1: sibling scan excludes the SELF worktree's own port" "3100" "$SIBLING_PORTS_D1"
+
+# --- D2: sticky start-offset survives a simulated repair regen even after
+# the bucket that originally displaced the worktree frees up again.
+WT_D_BLOCK2=$(add_worktree "$ROOT_D" "blocker2")
+write_fixed_override "$WT_D_BLOCK2" "blocker2" 3020
+
+# "wt92" hashes deterministically to bucket 2; blocker2 occupies it, so the
+# FIRST resolution (no override yet for wt92) must land on bucket 3.
+WT_D_TARGET=$(add_worktree "$ROOT_D" "wt92")
+OFFSET_D_FIRST=$(_resolve_worktree_port_offset "$WT_D_TARGET" "wt92" "$ROOT_D" 2>/dev/null)
+assert_eq "groupD2: first resolution avoids blocker2's bucket 2, lands on bucket 3" "3" "$OFFSET_D_FIRST"
+
+# Persist that assignment as the worktree's own override (what
+# create-worktree.sh would have written), THEN free bucket 2 by removing the
+# blocker entirely.
+write_fixed_override "$WT_D_TARGET" "wt92" 3030
+git -C "$ROOT_D" worktree remove --force "$WT_D_BLOCK2" >/dev/null 2>&1
+
+OFFSET_D_SECOND=$(_resolve_worktree_port_offset "$WT_D_TARGET" "wt92" "$ROOT_D" 2>/dev/null)
+assert_eq "groupD2: repair regen stays STICKY on bucket 3, does not revert to freed bucket 2" "3" "$OFFSET_D_SECOND"
+
+# =========================================================================
+# Group E: concurrency (lock active / disabled negative control / forced mkdir)
+# =========================================================================
+ROOT_E=$(new_fixture_repo)
+WT_E1=$(add_worktree "$ROOT_E" "smi-5641-remove-dead-dep-helpers")
+WT_E2=$(add_worktree "$ROOT_E" "smi-5651-registry-catchup")
+
+# Both worktree names hash to the SAME deterministic bucket 79 (the verified
+# same-bucket pair, reused here to stress the exact real-world race). The
+# SKILLSMITH_WORKTREE_PORT_TEST_DELAY seam widens the window between each
+# racer's "read siblings" step and its "decide + write" step, so the race is
+# reliably provoked rather than depending on real scheduler luck.
+run_race() {
+  # Runs both generate_docker_override calls concurrently against a clean
+  # (no pre-existing override) starting state, waits for both, and prints
+  # "PORTS1|PORTS2|RC1|RC2" to stdout.
+  rm -f "$WT_E1/docker-compose.override.yml" "$WT_E2/docker-compose.override.yml"
+  export SKILLSMITH_WORKTREE_PORT_TEST_DELAY=1
+
+  ( generate_docker_override "$WT_E1" "smi-5641-remove-dead-dep-helpers" "$ROOT_E" ) &
+  local pid1=$!
+  ( generate_docker_override "$WT_E2" "smi-5651-registry-catchup" "$ROOT_E" ) &
+  local pid2=$!
+
+  local rc1=0 rc2=0
+  wait "$pid1" || rc1=$?
+  wait "$pid2" || rc2=$?
+  unset SKILLSMITH_WORKTREE_PORT_TEST_DELAY
+
+  local p1 p2
+  p1="$(_parse_override_host_ports "$WT_E1/docker-compose.override.yml" | tr '\n' ' ')"
+  p2="$(_parse_override_host_ports "$WT_E2/docker-compose.override.yml" | tr '\n' ' ')"
+  printf '%s|%s|%s|%s\n' "$p1" "$p2" "$rc1" "$rc2"
+}
+
+# --- E1: lock active (flock if available, else the mkdir fallback -- both
+# are the real production path depending on host; see file header).
+SKILLSMITH_WORKTREE_PORT_LOCK_HOME=$(new_lock_home)
+unset SKILLSMITH_WORKTREE_PORT_LOCK_DISABLE SKILLSMITH_WORKTREE_PORT_FORCE_MKDIR_LOCK 2>/dev/null || true
+RESULT_E1="$(run_race)"
+P1_E1="$(printf '%s' "$RESULT_E1" | cut -d'|' -f1)"
+P2_E1="$(printf '%s' "$RESULT_E1" | cut -d'|' -f2)"
+RC1_E1="$(printf '%s' "$RESULT_E1" | cut -d'|' -f3)"
+RC2_E1="$(printf '%s' "$RESULT_E1" | cut -d'|' -f4)"
+assert_eq "groupE1 (locked): worktree 1 succeeded" "0" "$RC1_E1"
+assert_eq "groupE1 (locked): worktree 2 succeeded" "0" "$RC2_E1"
+if ports_overlap "$P1_E1" "$P2_E1"; then
+  echo "FAIL groupE1 (locked): concurrent resolutions collided (ports1='$P1_E1' ports2='$P2_E1')"
+  fail=$((fail + 1))
+else
+  echo "PASS groupE1 (locked): concurrent resolutions landed on disjoint buckets"
+  pass=$((pass + 1))
+fi
+
+# --- E2: negative/discrimination control. Locking DISABLED -> the identical
+# race must actually COLLIDE, proving this harness has real discriminating
+# power (i.e. E1's clean result is because the lock works, not because the
+# fixture can't collide in the first place).
+SKILLSMITH_WORKTREE_PORT_LOCK_HOME=$(new_lock_home)
+export SKILLSMITH_WORKTREE_PORT_LOCK_DISABLE=1
+RESULT_E2="$(run_race)"
+unset SKILLSMITH_WORKTREE_PORT_LOCK_DISABLE
+P1_E2="$(printf '%s' "$RESULT_E2" | cut -d'|' -f1)"
+P2_E2="$(printf '%s' "$RESULT_E2" | cut -d'|' -f2)"
+if ports_overlap "$P1_E2" "$P2_E2"; then
+  echo "PASS groupE2 (lock disabled, negative control): race DOES collide as expected"
+  pass=$((pass + 1))
+else
+  echo "FAIL groupE2 (lock disabled, negative control): race did NOT collide -- harness has no discriminating power (ports1='$P1_E2' ports2='$P2_E2')"
+  fail=$((fail + 1))
+fi
+
+# --- E3: force the mkdir lock fallback even on a flock-equipped host (e.g.
+# Linux CI), so that path gets real coverage everywhere, not just on stock
+# macOS.
+SKILLSMITH_WORKTREE_PORT_LOCK_HOME=$(new_lock_home)
+export SKILLSMITH_WORKTREE_PORT_FORCE_MKDIR_LOCK=1
+RESULT_E3="$(run_race)"
+unset SKILLSMITH_WORKTREE_PORT_FORCE_MKDIR_LOCK
+P1_E3="$(printf '%s' "$RESULT_E3" | cut -d'|' -f1)"
+P2_E3="$(printf '%s' "$RESULT_E3" | cut -d'|' -f2)"
+RC1_E3="$(printf '%s' "$RESULT_E3" | cut -d'|' -f3)"
+RC2_E3="$(printf '%s' "$RESULT_E3" | cut -d'|' -f4)"
+assert_eq "groupE3 (forced mkdir lock): worktree 1 succeeded" "0" "$RC1_E3"
+assert_eq "groupE3 (forced mkdir lock): worktree 2 succeeded" "0" "$RC2_E3"
+if ports_overlap "$P1_E3" "$P2_E3"; then
+  echo "FAIL groupE3 (forced mkdir lock): concurrent resolutions collided (ports1='$P1_E3' ports2='$P2_E3')"
+  fail=$((fail + 1))
+else
+  echo "PASS groupE3 (forced mkdir lock): concurrent resolutions landed on disjoint buckets"
+  pass=$((pass + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------
+echo ""
+echo "===== Results: $pass passed, $fail failed ====="
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## Business Summary

**What shipped:** Worktree Docker containers no longer silently collide on ports. Previously, each worktree's 4 host ports were derived purely from a hash of its branch name — two worktrees with different names could still hash to the same bucket (this actually happened: `smi-5641-remove-dead-dep-helpers` and `smi-5651-registry-catchup` both landed on the same ports), and one worktree's `docker compose up` would fail with no retry. Worktree creation and repair now detect a colliding bucket and automatically pick the next free one, while never reassigning a worktree away from the ports its own running container already has.

**Quality bar:** Full pipeline — Opus designed the exact algorithm (including a concurrency lock reusing this repo's existing `retrieval-autoheal.sh` pattern) against a plan-reviewed spec, Sonnet implemented it, and a separate governance code review independently re-ran every test rather than trusting the implementer's report. 22 new test assertions plus the 90 pre-existing worktree-tooling tests, all green. `audit:standards` clean.

**Net result:** Fully shipped. `create-worktree.sh` and `repair-worktrees.sh` themselves are unchanged — all new logic lives in the shared `scripts/_lib.sh` helper both already call.

---

## Technical detail

- `scripts/_lib.sh`: new `_parse_override_host_ports`, `_worktree_sibling_taken_ports`, `_worktree_host_port_bound`, `_resolve_worktree_port_offset` (collision-check + probe-next-bucket, 99-attempt wraparound cap), `acquire_worktree_port_lock`/`release_worktree_port_lock` (flock when available, mkdir fallback for stock macOS bash 3.2 which lacks `flock`). Wired into `generate_docker_override_to_stdout`, `generate_docker_override`, and `repair_worktrees_compose_override`.
- New `scripts/tests/worktree-port-collision.test.sh` (22 assertions): sibling collision + probe, host-bound collision, wraparound boundary, self-collision-avoidance across a repair regen, and concurrency (locked vs. a lock-disabled negative control that must still collide, proving the test discriminates, plus a forced-mkdir-path variant).
- Plan doc: `docs/internal/implementation/smi-5661-worktree-port-collision-fix.md` (ADR-109 gate). Code review: `docs/internal/code_review/2026-07-12-smi-5661-worktree-port-collision-review.md`.
- `create-worktree.sh:448` and `repair-worktrees.sh:156` confirmed byte-unchanged.

Fixes SMI-5661