### PR TITLE
fix(ci): SMI-5666 allowlist ai-security-guard privilege_escalation FP; renew 4 expiring entries

### DIFF
--- a/data/skills-security-allowlist.json
+++ b/data/skills-security-allowlist.json
@@ -6,38 +6,38 @@
       "skillId": "github/kcmadden/claude-code-1password-skill",
       "findingType": "sensitive_path",
       "messagePattern": "password|credentials",
-      "reason": "1Password integration skill. The product literally contains the word 'password' and its SKILL.md is security guidance telling Claude Code NEVER to ask users to paste passwords/credentials in chat. Bare-keyword sensitive_path regex cannot distinguish 'documents handling of passwords' from 'hardcoded password'. Wave 2 tightens patterns to require assignment/path context.",
+      "reason": "1Password integration skill. The product literally contains the word 'password' and its SKILL.md is security guidance telling Claude Code NEVER to ask users to paste passwords/credentials in chat. Bare-keyword sensitive_path regex cannot distinguish 'documents handling of passwords' from 'hardcoded password'. Wave 2 tightens patterns to require assignment/path context. Renewed 2026-07-12 under SMI-5666 (repo re-verified unchanged via gh api) — expiring 2026-07-21 would have re-tripped the weekly gate.",
       "reviewedBy": "ryansmith108",
-      "reviewedAt": "2026-04-21",
-      "expiresAt": "2026-07-21"
+      "reviewedAt": "2026-07-12",
+      "expiresAt": "2026-10-10"
     },
     {
       "skillId": "github/StrategicPromptArchitect-AI/MalPromptSentinel-CC-Skill",
       "findingType": "privilege_escalation",
       "messagePattern": "escalation",
-      "reason": "Prompt-injection scanner skill whose description enumerates adversarial techniques it detects ('role manipulation, privilege escalation, ...'). Bare /escalat(e|ion)/i pattern triggered CRITICAL on a defensive-security tool describing its own subject matter. Wave 2 replaces with contextual patterns (privilege_escalation, escalate to root, exploit-to-escalate).",
+      "reason": "Prompt-injection scanner skill whose description enumerates adversarial techniques it detects ('role manipulation, privilege escalation, ...'). Bare /escalat(e|ion)/i pattern triggered CRITICAL on a defensive-security tool describing its own subject matter. Wave 2 replaces with contextual patterns (privilege_escalation, escalate to root, exploit-to-escalate). Renewed 2026-07-12 under SMI-5666 (repo re-verified unchanged via gh api) — expiring 2026-07-21 would have re-tripped the weekly gate.",
       "reviewedBy": "ryansmith108",
-      "reviewedAt": "2026-04-21",
-      "expiresAt": "2026-07-21"
+      "reviewedAt": "2026-07-12",
+      "expiresAt": "2026-10-10"
     },
     {
       "skillId": "github/rhysha/claude-security-research-skill",
       "findingType": "sensitive_path",
       "messagePattern": "secrets?",
-      "reason": "Security-research skill. 'Secrets' is domain vocabulary (talks about finding/handling secrets as a research topic), not an instruction to access a sensitive path. Bare-keyword match. Wave 2 tightens sensitive_path patterns to require assignment/path/file-extension context.",
+      "reason": "Security-research skill. 'Secrets' is domain vocabulary (talks about finding/handling secrets as a research topic), not an instruction to access a sensitive path. Bare-keyword match. Wave 2 tightens sensitive_path patterns to require assignment/path/file-extension context. Renewed 2026-07-12 under SMI-5666 (repo re-verified unchanged via gh api) — expiring 2026-07-21 would have re-tripped the weekly gate.",
       "reviewedBy": "ryansmith108",
-      "reviewedAt": "2026-04-21",
-      "expiresAt": "2026-07-21"
+      "reviewedAt": "2026-07-12",
+      "expiresAt": "2026-10-10"
     },
     {
       "skillId": "github/straygizmo/mdium",
       "findingType": "ai_defence",
       "matchField": "location",
       "messagePattern": "[\\u200B-\\u200F\\u2028-\\u202F\\uFEFF\\u3000]",
-      "reason": "Japanese-authored markdown-to-Medium skill. Repo description renders as 'designed for the AI  era' where the gap between AI and era is a U+3000 CJK full-width space from Japanese keyboard input — not an invisible-char prompt-injection payload. matchField=location required because finding.message embeds the literal bytes, which do not round-trip through JSON escape sequences.",
+      "reason": "Japanese-authored markdown-to-Medium skill. Repo description renders as 'designed for the AI  era' where the gap between AI and era is a U+3000 CJK full-width space from Japanese keyboard input — not an invisible-char prompt-injection payload. matchField=location required because finding.message embeds the literal bytes, which do not round-trip through JSON escape sequences. Renewed 2026-07-12 under SMI-5666 (repo re-verified unchanged via gh api) — expiring 2026-07-21 would have re-tripped the weekly gate.",
       "reviewedBy": "ryansmith108",
-      "reviewedAt": "2026-04-21",
-      "expiresAt": "2026-07-21"
+      "reviewedAt": "2026-07-12",
+      "expiresAt": "2026-10-10"
     },
     {
       "skillId": "github/RobinGase/skill-protocol-rs",
@@ -74,6 +74,15 @@
       "reviewedBy": "ryansmith108",
       "reviewedAt": "2026-05-31",
       "expiresAt": "2026-08-29"
+    },
+    {
+      "skillId": "github/leksman/ai-security-guard",
+      "findingType": "privilege_escalation",
+      "messagePattern": "escalation",
+      "reason": "Defensive LLM-hardening skill (prompt injection / jailbreak / privilege escalation / marker forgery guard) whose GitHub repo description enumerates 'privilege escalation' as one of the threats it defends against — same self-describing-security-tool FP class as github/StrategicPromptArchitect-AI/MalPromptSentinel-CC-Skill (SMI-4396 Wave 2). Verified via SKILL.md: no other finding category present, no sudo/chmod/exec/exfil content. Triaged 2026-07-12 under SMI-5666 — closes GH #1839.",
+      "reviewedBy": "ryansmith108",
+      "reviewedAt": "2026-07-12",
+      "expiresAt": "2026-10-10"
     }
   ]
 }

--- a/packages/core/src/scripts/__tests__/scan-imported-skills.test.ts
+++ b/packages/core/src/scripts/__tests__/scan-imported-skills.test.ts
@@ -14,6 +14,7 @@ import type { ScanReport, SecurityFinding } from '../../security/index.js'
 import { determineSeverityCategory, type SeverityCategory } from '../skill-scanner/categorizer.js'
 import { shouldQuarantine } from '../skill-scanner/trust-scorer.js'
 import { extractScannableContent } from '../skill-scanner/file-scanner.js'
+import { loadAllowlist } from '../skill-scanner/allowlist.js'
 import type { ImportedSkill } from '../skill-scanner/types.js'
 
 // ============================================================================
@@ -438,6 +439,46 @@ A helpful skill for formatting code.
       const jailbreak = results.find((r) => r.skillId === 'malicious/jailbreak')
       expect(jailbreak?.isQuarantined).toBe(true)
       expect(jailbreak?.severity).toBe('CRITICAL')
+    })
+  })
+
+  // SMI-5666: github/leksman/ai-security-guard false-positive regression.
+  //
+  // Unlike the SMI-4396 Wave 2 frontmatter fixtures (scanner-wave2-fixtures.test.ts),
+  // which exercise hand-authored SKILL.md content with real `---` YAML fences, this
+  // reproduces the ACTUAL content shape the GitHub-import pipeline produces via
+  // extractScannableContent() — `# name\n\ndescription\n\n...`, no frontmatter fences
+  // at all. That matters: the inFrontmatter doc-context downgrade never applies here,
+  // so this false-positive class can only be caught by the per-skill allowlist, not by
+  // the frontmatter heuristic.
+  describe('SMI-5666: GitHub-import content-shape allowlist regression', () => {
+    it('ai-security-guard privilege_escalation FP is critical pre-allowlist, cleared post-allowlist', () => {
+      const skill: ImportedSkill = {
+        id: 'github/leksman/ai-security-guard',
+        name: 'github/leksman/ai-security-guard',
+        description:
+          'Claude skill + drop-in code for hardening & auditing LLM features against prompt injection, privilege escalation, marker forgery, and data leaks',
+      }
+
+      const content = extractScannableContent(skill)
+      // Confirms the real pipeline shape: no YAML frontmatter fence present.
+      expect(content.startsWith('---')).toBe(false)
+
+      const scanner = new SecurityScanner()
+      const report = scanner.scan(skill.id, content)
+
+      const privFindings = report.findings.filter((f) => f.type === 'privilege_escalation')
+      expect(privFindings.length).toBeGreaterThan(0)
+      expect(privFindings.some((f) => f.severity === 'critical')).toBe(true)
+      expect(shouldQuarantine(report)).toBe(true)
+
+      const allowlistPath = path.resolve(
+        __dirname,
+        '../../../../../data/skills-security-allowlist.json'
+      )
+      const allowlist = loadAllowlist(allowlistPath)
+
+      expect(shouldQuarantine(report, undefined, allowlist)).toBe(false)
     })
   })
 })

--- a/packages/core/tests/skill-scanner/allowlist.test.ts
+++ b/packages/core/tests/skill-scanner/allowlist.test.ts
@@ -393,11 +393,16 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
   // utility whose repo description mentions '.env file' as one of eight routing
   // destinations; bare-keyword sensitive_path regex false-positives until
   // Wave 2 tightens.
+  // SMI-5666 (2026-07-12): leksman/ai-security-guard added — defensive LLM-
+  // hardening skill whose repo description enumerates 'privilege escalation'
+  // as a threat it detects; same self-describing-security-tool FP class as
+  // MalPromptSentinel-CC-Skill. Also renewed the 4 entries that were about to
+  // expire 2026-07-21 (kcmadden, MalPromptSentinel, rhysha, mdium).
   it('is parseable and every entry expires 90 days after review', () => {
     const filePath = path.resolve(__dirname, '../../../../data/skills-security-allowlist.json')
     const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
     const parsed = parseAllowlistFile(raw)
-    expect(parsed.allowlist.length).toBe(8)
+    expect(parsed.allowlist.length).toBe(9)
     const ids = parsed.allowlist.map((e) => e.skillId).sort()
     expect(ids).toEqual(
       [
@@ -407,6 +412,7 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
         'github/StrategicPromptArchitect-AI/MalPromptSentinel-CC-Skill',
         'github/dokind/qpay-skills',
         'github/kcmadden/claude-code-1password-skill',
+        'github/leksman/ai-security-guard',
         'github/rhysha/claude-security-research-skill',
         'github/straygizmo/mdium',
       ].sort()


### PR DESCRIPTION
## Business Summary

**What shipped:** The weekly automated security scan of GitHub-imported skills was failing because it flagged a legitimate LLM-security tool (`ai-security-guard`) as a critical threat — its own description of what it *defends against* ("privilege escalation") tripped a keyword match. That skill is now cleared. Four earlier clearances that were about to expire and would have caused the same failure again next week are also renewed.

**Quality bar:** Root-caused by reading the flagged skill's actual source (not just the scan output) to confirm it's genuinely benign before clearing it — same standard applied to the 4 renewed entries (each source repo re-verified unchanged via the GitHub API before extending). Full `@skillsmith/core` suite (184 files / 3916 tests), lint, typecheck, `audit:standards`, and `format:check` all pass. Added a regression test that reproduces the exact content shape this scan pipeline produces (distinct from the existing frontmatter-based fixtures), so this specific false-positive class stays covered going forward.

**Found along the way:** none new — this recurring false-positive class (a security tool's own description tripping the scanner) already has a tracked architecture-level fix (SMI-4398, "Marketplace security policy for red-team / security-research skills"), deliberately left in Backlog pending prioritization. This PR doesn't change that scope; it's the same triage-and-clear pattern already used for the 6 prior occurrences.

**Net result:** Fully shipped — the weekly scan's gate should pass clean on the next scheduled run (2026-07-19). GH #1839 will be closed once this merges.

---

## Technical detail

- `data/skills-security-allowlist.json` — added entry for `github/leksman/ai-security-guard` (`privilege_escalation`); renewed `reviewedAt`/`expiresAt` for `github/kcmadden/claude-code-1password-skill`, `github/StrategicPromptArchitect-AI/MalPromptSentinel-CC-Skill`, `github/rhysha/claude-security-research-skill`, `github/straygizmo/mdium` (all were expiring 2026-07-21).
- `packages/core/src/scripts/__tests__/scan-imported-skills.test.ts` — new regression fixture reconstructing `extractScannableContent()`'s real output shape (no YAML frontmatter fences, unlike the SMI-4396 Wave 2 fixtures in `scanner-wave2-fixtures.test.ts`), asserting the finding is critical pre-allowlist and cleared post-allowlist.
- `packages/core/tests/skill-scanner/allowlist.test.ts` — updated the "ship-it sanity" test's hardcoded entry count/list (8 → 9).
- Fixes: [run 29176436980](https://github.com/smith-horn/skillsmith/actions/runs/29176436980), closes #1839.
- Linear: SMI-5666.

[skip-impl-check] — intentionally data + test only: this fix is an allowlist data entry (`data/skills-security-allowlist.json`) plus regression tests, no `src/` implementation change; that is the correct shape for an SMI-4396 allowlist triage.
