### PR TITLE
fix(cli): Derive --also-link fan-out path from resolved install path

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -8,6 +8,7 @@
 import { Command } from 'commander'
 import chalk from 'chalk'
 import ora from 'ora'
+import * as path from 'node:path'
 import {
   SkillRepository,
   SkillDependencyRepository,
@@ -346,11 +347,16 @@ async function installActionImpl(
       // primary install succeeds. Any fan-out failure is reported as
       // a warning but does NOT mark the overall install as failed —
       // the canonical install at `client` is already complete.
+      // addLink's `skillId` is a directory-basename contract, not the
+      // `owner/repo` argument the user typed — derive it from the real
+      // on-disk install path so it matches what SkillInstallationService
+      // actually wrote (registry resolution can rename owner/repo -> name).
       if (result.success && alsoLinkClients.length > 0) {
+        const linkSkillName = path.basename(result.installPath)
         for (const target of alsoLinkClients) {
           try {
             const linked = await addLink({
-              skillId,
+              skillId: linkSkillName,
               fromClient: client,
               toClient: target,
               preferSymlink: opts.symlink ?? false,

--- a/packages/cli/tests/install-multi-client.test.ts
+++ b/packages/cli/tests/install-multi-client.test.ts
@@ -17,6 +17,38 @@ import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Regression-test-only mocks for the `install` command's --also-link path.
+// SkillInstallationService.install is a network+DB call we don't want to
+// exercise for real here; @skillsmith/core/install (addLink, getInstallPath)
+// stays real so the fan-out itself runs against the temp $HOME below.
+const alsoLinkMocks = vi.hoisted(() => ({
+  installFn: vi.fn(),
+}))
+
+vi.mock('@skillsmith/core', () => ({
+  createDatabaseAsync: vi.fn().mockResolvedValue({ close: vi.fn() }),
+  initializeSchema: vi.fn(),
+  SkillRepository: vi.fn().mockImplementation(function () {
+    return { findById: vi.fn(() => null) }
+  }),
+  SkillDependencyRepository: vi.fn().mockImplementation(function () {
+    return { clearAll: vi.fn() }
+  }),
+  SkillInstallationService: vi.fn().mockImplementation(function () {
+    return { install: alsoLinkMocks.installFn }
+  }),
+  QuarantineRepository: vi.fn().mockImplementation(function () {
+    return { isQuarantined: vi.fn(() => false) }
+  }),
+  SkillsmithApiClient: Object.assign(vi.fn(), {
+    toSkill: (r: { trust_tier?: string }) => ({ trustTier: r.trust_tier ?? 'community' }),
+  }),
+  loadStoredAccessToken: vi.fn().mockResolvedValue(null),
+  createApiClient: vi.fn(() => ({ isOffline: () => true, getSkill: vi.fn() })),
+  isGitHubUrl: vi.fn((url: string) => url.startsWith('https://github.com/')),
+  emitInstallEvent: vi.fn(async () => undefined),
+}))
+
 const ORIGINAL_HOME = process.env['HOME']
 const ORIGINAL_USERPROFILE = process.env['USERPROFILE']
 const ORIGINAL_CLIENT = process.env['SKILLSMITH_CLIENT']
@@ -232,6 +264,47 @@ describe('install --client / --also-link', () => {
       const { removeLinks } = await import('@skillsmith/core/install')
       const removed = await removeLinks('nothing-installed')
       expect(removed).toBe(0)
+    })
+  })
+
+  describe('install command --also-link with an owner/repo skillId', () => {
+    beforeEach(() => {
+      alsoLinkMocks.installFn.mockReset()
+    })
+
+    it('fans out using the resolved directory name, not the raw owner/repo skillId', async () => {
+      // Real installs key the manifest/directory by the resolved skill name
+      // (e.g. "commit"), which can differ from the owner/repo argument the
+      // user typed (e.g. "getsentry/commit"). Seed the source dir the way
+      // SkillInstallationService really lays it out.
+      const installPath = await seedSkill('commit', '# commit skill\n')
+      alsoLinkMocks.installFn.mockResolvedValue({
+        success: true,
+        skillId: 'getsentry/commit',
+        installPath,
+        trustTier: 'verified',
+      })
+
+      const { createInstallCommand } = await import('../src/commands/install.js')
+      const cmd = createInstallCommand()
+      await cmd.parseAsync([
+        'node',
+        'test',
+        'getsentry/commit',
+        '--client',
+        'claude-code',
+        '--also-link',
+        'agents',
+      ])
+
+      const dest = path.join(homeDir, '.agents', 'skills', 'commit')
+      const skillMd = await readFile(path.join(dest, 'SKILL.md'), 'utf-8')
+      expect(skillMd).toContain('# commit skill')
+
+      // The buggy path constructed .../.agents/skills/getsentry/commit instead.
+      await expect(stat(path.join(homeDir, '.agents', 'skills', 'getsentry'))).rejects.toThrow(
+        /ENOENT/
+      )
     })
   })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** `skillsmith install <owner>/<name> --also-link <client>` now actually fans out to the secondary client — previously it silently no-op'd for any skill whose registry name differs from its `owner/repo` argument (the primary install still reported success, with only a swallowed stderr warning).

**Quality bar:** Root-caused against the working MCP-server equivalent (which never had this bug), fixed, and covered by a new end-to-end regression test that exercises the real CLI action (not just `addLink` in isolation, which is how the existing test suite missed this). Full CLI suite (873 tests), typecheck, lint, prettier, build, and `audit:standards` (0 failed) all verified clean in Docker.

**Found along the way:** nothing filed separately — this was itself found mid-execution of the Codex UAT (SMI-5459) and is being fixed immediately per repo policy rather than deferred.

**Net result:** Fully shipped, no follow-up. SMI-5669 tracks it, In Review.

---

## Technical detail

- `packages/cli/src/commands/install.ts`: fan-out block now derives the `addLink` skillId from `path.basename(result.installPath)` instead of the raw CLI argument, matching the convention `packages/mcp-server/src/tools/install.ts`'s `extractSkillName()` already uses.
- `packages/cli/tests/install-multi-client.test.ts`: new `describe` block mocks `@skillsmith/core`'s install service (network+DB free) while leaving `@skillsmith/core/install`'s `addLink`/`getInstallPath` real, invoking `createInstallCommand()` end-to-end with an `owner/repo` skillId + `--also-link` in a temp `$HOME`. Fails pre-fix, passes post-fix.
- Refs SMI-5669, discovered during SMI-5459 (issue #1701 Codex UAT).