### PR TITLE
docs: Record Codex 0.7.2 eval report + bump docs/internal pointer

### DIFF
--- a/scripts/agent-evals/results/0.7.2-eval-report.md
+++ b/scripts/agent-evals/results/0.7.2-eval-report.md
@@ -1,0 +1,59 @@
+# Skillsmith Agent — Eval Report (SMI-5456 Wave 1 Step 6, Validation Ladder Level 3)
+
+- **Release**: `@skillsmith/mcp-server`@`0.7.2`
+- **Date**: `2026-07-13`
+- **Evaluator**: `maintainer (this-session)`
+
+## Eval matrix
+
+| Harness | keep-current | audit-fix | vet-before-install | Marker channel verified | L2b log | Notes |
+|---|---|---|---|---|---|---|
+| Claude Code | pass / fail | pass / fail | pass / fail | yes / no | `results/claude-code-<date>.log` | Not run this release |
+| Cursor | pass / fail | pass / fail | pass / fail | yes / no | `results/cursor-<date>.log` | Not run this release |
+| Codex | pass | pass | pass | yes | `results/codex-2026-07-12.log` | See notes — headless MCP calls required an authorized diagnostic bypass; the committed `codex.sh` script itself surfaces the approval-gate cancellation as designed |
+| Copilot / VS Code | pass / fail | pass / fail | pass / fail | yes / no | `results/copilot-<date>.log` | Not run this release |
+| OpenCode | pass / fail | pass / fail | pass / fail | yes / no | `results/opencode-<date>.log` | Not run this release |
+| Hermes | N/A | N/A | N/A | N/A | pending | Unchanged from template |
+| Windsurf / Devin | N/A | N/A | N/A | N/A | N/A | Unchanged from template |
+
+## Per-harness free-form notes (L3)
+
+### Codex
+
+**Install flow (issue #1701 checklist step 1)**: `sklx agent install` correctly detected Codex, wrote the named shim, `[[hooks.SessionStart]]`, `[agents.skillsmith-agent]`, and `[mcp_servers.skillsmith]` blocks to `~/.codex/config.toml`, and wrote the `skillsmith-agent` skill pack to `~/.agents/skills/skillsmith-agent/` — confirmed against a pre-flight snapshot diff.
+
+**Curated skill set**: installed 12 skills (1 real `skillsmith install --client claude-code --also-link agents` flow for `getsentry/commit`, 11 via `cp -R` from global `~/.claude/skills` and the `skillsmith-strategy` submodule) + `skillsmith-agent` = 13 total in `~/.agents/skills/`.
+
+**Native skill discovery — verified, not a bug**: initially worried Skillsmith's `~/.agents/skills` path choice for the `agents` client might be wrong (Codex's own bundled `skill-creator`/`skill-installer` skills reference `$CODEX_HOME/skills`). Resolved via a clean test: a fresh `codex exec` asked to list its available skills *without running shell commands* correctly listed all 12 curated skills + `skillsmith-agent` alongside Codex's 5 bundled system skills — confirming Codex reads and merges both `~/.codex/skills` and `~/.agents/skills`. No defect; `CLIENT_NATIVE_PATHS.agents` is correct.
+
+**3 MVP jobs — headless (L2b) approval-gate finding**: the committed, unmodified `scripts/agent-evals/codex.sh` run (`results/codex-2026-07-12.log`) shows all three jobs' underlying MCP tool calls (`skill_outdated`, `skill_inventory_audit`, `search`/`get_skill`) reported `(failed)` / "user cancelled MCP tool call". Root cause: `codex exec`'s non-interactive mode has no way to grant the approval an MCP tool call requires, so it auto-cancels. This is inherent to headless Codex, not a Skillsmith defect — `codex exec --help` documents no narrower flag; only `--dangerously-bypass-approvals-and-sandbox` removes the gate (disables sandboxing too). **Recommendation**: update `codex.sh`'s own doc comment to note this expected headless limitation explicitly, so a future maintainer doesn't mistake the cancellation for a regression.
+
+**3 MVP jobs — re-verified with authorized bypass (user-approved diagnostic only, not part of the committed script)**: all three completed successfully:
+- **keep-current**: `skill_outdated` completed; correctly reported no outdated skills, with the caveat that hash-only comparison can't distinguish "current" from "unverifiable" without Version Tracking (Individual+ tier).
+- **audit-fix**: `skill_inventory_audit` completed; correctly found 12 exact namespace collisions across the full local inventory (85 entries scanned) — including a deliberately-introduced divergent `security-auditor` copy planted for this UAT's collision test, confirming the collision detector genuinely catches cross-harness divergence, not just exact dupes.
+- **vet-before-install**: confirmed the plan's open question — `anthropic/commit` (the script's hardcoded candidate) does **not** resolve in the registry or `anthropics/skills`. The agent correctly refused to vouch for it, flagged the name as a plausible brand-confusable typosquat, and redirected to the real `getsentry/commit` (verified, risk 0/100, quality 86/100) — a good outcome for the safety narrative, but `codex.sh`'s hardcoded candidate should be fixed to reference a real skill in a follow-up.
+
+**Collision test (job b, sub-steps 2-4)**: added a divergent `~/.agents/skills/security-auditor` (one-line append after the twin's content), re-ran the audit — caught as an exact collision — then removed it and verified removal via `ls` before proceeding. Hard barrier honored.
+
+**Major finding — MCP tier/license bug (not part of this UAT's scope, filed separately)**: while investigating why Version Tracking stayed gated, discovered the MCP server's license middleware (`packages/mcp-server/src/index.ts:123`, `middleware/license.ts`) only ever reads `SKILLSMITH_LICENSE_KEY` (for the optional, rarely-installed `@skillsmith/enterprise` offline validator) and never the `SKILLSMITH_API_KEY`/config.json `apiKey` the CLI itself uses — so every tier-gated MCP tool call silently reports "community tier" for any real paying Individual/Team customer. Reproduced live against this account's genuine active Team subscription. This is SMI-1953 (previously falsely marked Done 2026-01-29 with no actual fix; reopened today, raised to High priority). Not fixed in this session — tracked separately.
+
+**Marker channel**: `~/.skillsmith/agent-markers/<session-id>.json` correctly created at SessionStart across every `codex exec` invocation this session. Codex has no SessionEnd-equivalent event (confirmed, matches the README's documented limitation) — removal relies on the server-side 12h TTL rather than a session-end hook. This is expected/by-design, not a failure.
+
+**SessionStart nudge**: fired correctly (once per 72000-second cooldown) with the expected message ("The Skillsmith Agent is available. Ask it to audit your skills, check what is outdated, or vet a skill before you install it.").
+
+**Foreground L3 approval-flow / undo-path / upgrade-prompt observation**: **not completed this session** — this specifically requires a human physically present in an interactive `codex` session (not `codex exec`) to grant/deny a real approval prompt. Flagged as an outstanding item for a follow-up interactive pass before SMI-5459 can move past In Review.
+
+**Uninstall**: `sklx agent uninstall` cleanly reversed exactly what the installer wrote (7 removed, 2 restored) — `skillsmith-agent` skill pack gone, all three `config.toml` blocks removed, pre-existing `[projects...]` and `[tui.model_availability_nux]` content untouched. The 12 hand-seeded curated skills correctly persisted (outside uninstall's scope by design).
+
+**Dashboard verification**: `device_skills` query for `harness = 'agents'` returned exactly the expected 13 rows (12 curated + `skillsmith-agent`), all `present = true`. `https://skillsmith.app/account/skills` renders a distinct **AGENTS** section with the same 13 skills, alongside the existing **CLAUDE-CODE** section — confirming the original UAT goal (both harness inventories visible side by side on one dashboard).
+
+### Claude Code / Cursor / Copilot / OpenCode / Hermes / Windsurf
+
+- Not run this release.
+
+## Sign-off
+
+Codex row: 3/3 MVP jobs pass (via authorized diagnostic bypass; the committed headless script itself hits an expected, documented approval-gate limitation). Marker-channel creation verified. Foreground approval-flow/undo/upgrade-prompt observation still outstanding — SMI-5459 stays In Review until that's done.
+
+- **Report author**: maintainer (this-session)
+- **Reviewed by**: pending


### PR DESCRIPTION
## Business Summary

**What shipped:** Codex eval report for this session's UAT execution (SMI-5459 / issue #1701), plus the paired docs/internal pointer bump for the retro (skillsmith-docs #404).

**Quality bar:** Docs-only change; pre-push security/format/test gates all passed.

**Net result:** Done. SMI-5459 stays In Review pending the outstanding foreground L3 step (documented in the eval report and retro).

---

## Technical detail

- `scripts/agent-evals/results/0.7.2-eval-report.md` — new eval report.
- `docs/internal` pointer bumped to `e6807bc1` (skillsmith-docs #404).

[skip-impl-check]

Refs SMI-5459