### PR TITLE
fix(mcp-server): Resolve skill directory correctly in apply_namespace_rename

### DIFF
--- a/packages/mcp-server/src/audit/rename-engine.apply-paths.ts
+++ b/packages/mcp-server/src/audit/rename-engine.apply-paths.ts
@@ -37,16 +37,30 @@ export function actionToKind(action: RenameAction): OverrideRecord['kind'] {
 }
 
 /**
+ * `InventoryEntry.source_path` differs by kind (see local-inventory.ts):
+ * for `skill` entries it is the `SKILL.md` FILE path, not the skill
+ * directory; for `command`/`agent` entries it already is the target file.
+ * Every rename/backup operation needs the actual on-disk thing being
+ * renamed — resolve that once here instead of re-deriving it ad hoc at
+ * each call site (that duplication is exactly how this bug happened:
+ * multiple sites assumed `source_path` was already the skill directory).
+ */
+export function resolveRenameTarget(suggestion: RenameSuggestion): string {
+  const src = suggestion.entry.source_path
+  return suggestion.applyAction === 'rename_skill_dir_and_frontmatter' ? path.dirname(src) : src
+}
+
+/**
  * Compute the destination path on disk for a rename. For command/agent
  * files, swap the basename (sans `.md`) with `newName.md`. For skill
- * directories, rename the directory itself.
+ * directories, rename the directory itself (a sibling of the current one).
  */
 export function computeDestPath(suggestion: RenameSuggestion, newName: string): string {
-  const src = suggestion.entry.source_path
+  const target = resolveRenameTarget(suggestion)
   if (suggestion.applyAction === 'rename_skill_dir_and_frontmatter') {
-    return path.join(path.dirname(src), newName)
+    return path.join(path.dirname(target), newName)
   }
-  return path.join(path.dirname(src), `${newName}.md`)
+  return path.join(path.dirname(target), `${newName}.md`)
 }
 
 /**
@@ -99,13 +113,16 @@ async function stageSingleFileForBackup(srcFile: string): Promise<string> {
  * via the canonical helper (plan §1 Edit 4).
  */
 export async function runBackup(suggestion: RenameSuggestion): Promise<string> {
-  const skillName = path.basename(suggestion.entry.source_path).replace(/\.md$/, '')
   const action = suggestion.applyAction
+  const target = resolveRenameTarget(suggestion)
   if (action === 'rename_skill_dir_and_frontmatter') {
-    return createSkillBackup(skillName, suggestion.entry.source_path, 'namespace-rename')
+    // `target` is the skill directory itself here — back it up directly.
+    const skillName = path.basename(target)
+    return createSkillBackup(skillName, target, 'namespace-rename')
   }
   // Single-file path — stage, back up the staged dir, clean up.
-  const staged = await stageSingleFileForBackup(suggestion.entry.source_path)
+  const skillName = path.basename(target).replace(/\.md$/, '')
+  const staged = await stageSingleFileForBackup(target)
   try {
     return await createSkillBackup(skillName, staged, 'namespace-rename')
   } finally {

--- a/packages/mcp-server/src/audit/rename-engine.ts
+++ b/packages/mcp-server/src/audit/rename-engine.ts
@@ -45,6 +45,7 @@ import {
   deriveSkillId,
   fsErr,
   pathExists,
+  resolveRenameTarget,
   runBackup,
 } from './rename-engine.apply-paths.js'
 import { rewriteFrontmatterName } from './rename-engine.helpers.js'
@@ -119,7 +120,7 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
       collisionId: suggestion.collisionId,
       appliedAction: action,
       appliedRequest: 'apply',
-      fromPath: suggestion.entry.source_path,
+      fromPath: resolveRenameTarget(suggestion),
       toPath: '',
       backupPath: '',
       ledgerEntryId: '',
@@ -127,7 +128,7 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
       error: {
         kind: 'namespace.ledger.disk_divergence',
         ledgerRenamedTo: existing.renamedTo,
-        onDisk: suggestion.entry.source_path,
+        onDisk: resolveRenameTarget(suggestion),
         message: `ledger records rename to ${existing.renamedTo} but no file at ${existing.renamedPath}`,
         remediationHint:
           're-run skill_inventory_audit and reapply, or call apply_namespace_rename with customName to overwrite the ledger entry',
@@ -137,14 +138,15 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
 
   // Compute destination + verify it doesn't already exist (other than as
   // the source for an idempotent no-op handled above).
+  const renameTarget = resolveRenameTarget(suggestion)
   const destPath = computeDestPath(suggestion, newName)
-  if (destPath !== suggestion.entry.source_path && (await pathExists(destPath))) {
+  if (destPath !== renameTarget && (await pathExists(destPath))) {
     return {
       success: false,
       collisionId: suggestion.collisionId,
       appliedAction: action,
       appliedRequest: 'apply',
-      fromPath: suggestion.entry.source_path,
+      fromPath: renameTarget,
       toPath: destPath,
       backupPath: '',
       ledgerEntryId: '',
@@ -167,7 +169,7 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
       collisionId: suggestion.collisionId,
       appliedAction: action,
       appliedRequest: 'apply',
-      fromPath: suggestion.entry.source_path,
+      fromPath: renameTarget,
       toPath: destPath,
       backupPath: '',
       ledgerEntryId: '',
@@ -184,7 +186,10 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
   // directory. For command/agent: just rename.
   try {
     if (action === 'rename_skill_dir_and_frontmatter') {
-      const skillMdPath = path.join(suggestion.entry.source_path, 'SKILL.md')
+      // `entry.source_path` IS the SKILL.md file for skill-kind entries
+      // (see local-inventory.ts) — no path.join needed. `renameTarget` is
+      // its parent, the actual skill directory to rename.
+      const skillMdPath = suggestion.entry.source_path
       let original: string
       try {
         original = await fs.readFile(skillMdPath, 'utf-8')
@@ -194,7 +199,7 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
           collisionId: suggestion.collisionId,
           appliedAction: action,
           appliedRequest: 'apply',
-          fromPath: suggestion.entry.source_path,
+          fromPath: renameTarget,
           toPath: destPath,
           backupPath,
           ledgerEntryId: '',
@@ -209,7 +214,7 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
           collisionId: suggestion.collisionId,
           appliedAction: action,
           appliedRequest: 'apply',
-          fromPath: suggestion.entry.source_path,
+          fromPath: renameTarget,
           toPath: destPath,
           backupPath,
           ledgerEntryId: '',
@@ -222,9 +227,9 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
         }
       }
       await fs.writeFile(skillMdPath, rewriteResult.content, 'utf-8')
-      await fs.rename(suggestion.entry.source_path, destPath)
+      await fs.rename(renameTarget, destPath)
     } else {
-      await fs.rename(suggestion.entry.source_path, destPath)
+      await fs.rename(renameTarget, destPath)
     }
   } catch (err) {
     return {
@@ -232,7 +237,7 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
       collisionId: suggestion.collisionId,
       appliedAction: action,
       appliedRequest: 'apply',
-      fromPath: suggestion.entry.source_path,
+      fromPath: renameTarget,
       toPath: destPath,
       backupPath,
       ledgerEntryId: '',
@@ -247,7 +252,7 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
     kind,
     originalIdentifier: suggestion.currentName,
     renamedTo: newName,
-    originalPath: suggestion.entry.source_path,
+    originalPath: renameTarget,
     renamedPath: destPath,
     auditId,
     reason: suggestion.reason,
@@ -272,7 +277,7 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
     collisionId: suggestion.collisionId,
     appliedAction: action,
     appliedRequest: 'apply',
-    fromPath: suggestion.entry.source_path,
+    fromPath: renameTarget,
     toPath: destPath,
     backupPath,
     ledgerEntryId: newEntry?.id ?? '',
@@ -302,8 +307,8 @@ async function revertRename(
       collisionId: suggestion.collisionId,
       appliedAction: suggestion.applyAction,
       appliedRequest: 'revert',
-      fromPath: suggestion.entry.source_path,
-      toPath: suggestion.entry.source_path,
+      fromPath: resolveRenameTarget(suggestion),
+      toPath: resolveRenameTarget(suggestion),
       backupPath: '',
       ledgerEntryId: '',
       summary: buildSummary(suggestion.currentName, suggestion.currentName, auditId, 'revert'),

--- a/packages/mcp-server/tests/integration/install-namespace.integration.test.ts
+++ b/packages/mcp-server/tests/integration/install-namespace.integration.test.ts
@@ -215,7 +215,7 @@ describe('install namespace integration', () => {
     // B: rename the EXISTING shadowing sibling (frees the namespace).
     const applyResult = await applyRename({
       suggestion: skillSuggestion({
-        source_path: path.join(SKILLS_DIR, 'sibling-pack'),
+        source_path: path.join(SKILLS_DIR, 'sibling-pack', 'SKILL.md'),
         identifier: 'code-helper',
         suggested: 'sibling-vendor-code-helper',
         author: 'sibling-vendor',
@@ -306,7 +306,7 @@ describe('install namespace integration', () => {
 
     const result = await applyRename({
       suggestion: skillSuggestion({
-        source_path: skillDir,
+        source_path: path.join(skillDir, 'SKILL.md'),
         identifier: 'code-helper',
         suggested: 'sibling-code-helper',
         author: 'sibling',
@@ -461,7 +461,7 @@ describe('install namespace integration', () => {
     // B: apply rename to the existing shadowing sibling.
     const applyResult = await applyRename({
       suggestion: skillSuggestion({
-        source_path: path.join(SKILLS_DIR, 'sibling-pack'),
+        source_path: path.join(SKILLS_DIR, 'sibling-pack', 'SKILL.md'),
         identifier: 'code-helper',
         suggested: 'sibling-vendor-code-helper',
         author: 'sibling-vendor',

--- a/packages/mcp-server/tests/unit/rename-engine.test.ts
+++ b/packages/mcp-server/tests/unit/rename-engine.test.ts
@@ -229,8 +229,13 @@ describe('applyRename — rename_skill_dir_and_frontmatter', () => {
       'utf-8'
     )
 
+    // `source_path` is the SKILL.md file for skill-kind entries — matching
+    // what the real scanner (local-inventory.ts) produces — not the skill
+    // directory. Passing the directory here masked a real bug (SMI-5459
+    // UAT): apply_namespace_rename failed with backup_failed against a
+    // live skill because runBackup/computeDestPath assumed the directory.
     const suggestion = makeSuggestion({
-      source_path: skillDir,
+      source_path: skillMd,
       identifier: 'code-review',
       applyAction: 'rename_skill_dir_and_frontmatter',
       suggested: 'anthropic-code-review',
@@ -380,7 +385,7 @@ describe('applyRename — revert', () => {
     await fsp.writeFile(skillMd, '---\nname: code-review\n---\n', 'utf-8')
 
     const suggestion = makeSuggestion({
-      source_path: skillDir,
+      source_path: skillMd,
       identifier: 'code-review',
       applyAction: 'rename_skill_dir_and_frontmatter',
       suggested: 'anthropic-code-review',


### PR DESCRIPTION
## Business Summary

**What shipped:** `apply_namespace_rename` now actually works for skill-directory collisions — previously it failed on every real one with a generic "backup failed" error, because the engine assumed the wrong on-disk path shape for skill entries.

**Quality bar:** Root-caused to four separate sites in the rename engine that all made the same wrong assumption, consolidated into one resolver function. Both the affected unit and integration test files had fabricated fixtures matching the bug rather than real production data shape — corrected both, and independently verified the corrected tests fail against the pre-fix code (4 failures) before confirming they pass against the fix. Full mcp-server suite (2429 tests), typecheck, lint, build, and `audit:standards` (0 failed) all verified clean in Docker.

**Found along the way:** nothing filed separately — found and fixed in the same session it was discovered, live during the Codex UAT's foreground testing pass (SMI-5459).

**Net result:** Fully shipped, no follow-up. SMI-5670 tracks it, In Review.

---

## Technical detail

- `packages/mcp-server/src/audit/rename-engine.apply-paths.ts`: new `resolveRenameTarget()` helper resolves the real on-disk rename target (the SKILL.md file's parent directory for skill-kind entries; the file itself for command/agent entries) — single source of truth instead of four independent (and inconsistent) derivations. `computeDestPath()` and `runBackup()` updated to use it.
- `packages/mcp-server/src/audit/rename-engine.ts`: the SKILL.md read/rewrite step no longer double-joins `'SKILL.md'` onto an already-file path; the actual `fs.rename()` now renames the directory, not the file; the ledger's `originalPath` now stores the directory too, so a subsequent revert resolves correctly.
- `packages/mcp-server/tests/unit/rename-engine.test.ts`, `packages/mcp-server/tests/integration/install-namespace.integration.test.ts`: fixed fabricated `source_path` fixtures (previously the directory) to match the real `InventoryEntry` shape (`local-inventory.ts`'s `source_path: skillMd`, the file).
- Refs SMI-5670, discovered during SMI-5459 (issue #1701 Codex UAT, foreground Level-3 session).