### PR TITLE
fix(mcp-server): Expose apply_namespace_rename action:'revert'

### DIFF
--- a/packages/core/src/journal/reader.ts
+++ b/packages/core/src/journal/reader.ts
@@ -39,7 +39,10 @@ function isJournalRecordShape(value: unknown): value is JournalRecord {
     typeof r.ts === 'number' &&
     typeof r.session_id === 'string' &&
     typeof r.tool === 'string' &&
-    (r.action === 'apply' || r.action === 'error' || r.action === 'undo') &&
+    (r.action === 'apply' ||
+      r.action === 'error' ||
+      r.action === 'undo' ||
+      r.action === 'revert') &&
     (r.suggestion_id === null || typeof r.suggestion_id === 'string') &&
     (r.target_path === null || typeof r.target_path === 'string') &&
     (r.before_hash === null || typeof r.before_hash === 'string') &&

--- a/packages/core/src/journal/types.ts
+++ b/packages/core/src/journal/types.ts
@@ -17,16 +17,26 @@
  * which language eventually parses it.
  */
 
-/** Bump on a breaking shape change to `JournalRecord`. */
-export const JOURNAL_SCHEMA_VERSION = 1
+/**
+ * Bump on a breaking shape change to `JournalRecord` — including adding a
+ * new `JournalAction` literal, since `reader.ts`'s `isJournalRecordShape`
+ * validates `action` against a closed set: an older reader encountering an
+ * unrecognized value would misclassify a legitimate record as corrupt.
+ * (SMI-5671 bumped 1 → 2 for exactly this reason, adding `'revert'`.)
+ */
+export const JOURNAL_SCHEMA_VERSION = 2
 
 /**
  * `'apply'`   — an apply-family tool successfully mutated a file.
  * `'error'`   — an apply-family tool attempted a mutation and it failed
  *               (the `detail` field carries the typed error kind).
  * `'undo'`    — `undo_apply` successfully reversed a prior `'apply'` record.
+ * `'revert'`  — `apply_namespace_rename`'s `action: 'revert'` successfully
+ *               reversed a prior rename via the ledger (SMI-5671) — distinct
+ *               from `'undo'`, which is `undo_apply`'s same-process,
+ *               backup-restore mechanism.
  */
-export type JournalAction = 'apply' | 'error' | 'undo'
+export type JournalAction = 'apply' | 'error' | 'undo' | 'revert'
 
 /**
  * Every field the caller supplies. The writer (`writer.ts`) fills in

--- a/packages/mcp-server/src/audit/namespace-overrides.types.ts
+++ b/packages/mcp-server/src/audit/namespace-overrides.types.ts
@@ -75,6 +75,19 @@ export interface OverrideRecord {
    */
   auditId: string
   /**
+   * The collision this rename resolved — from the audit's
+   * `renameSuggestions[].collisionId`. Together with `auditId`, this is the
+   * key a revert uses to pick the correct entry when a single audit run
+   * resolved 2+ collisions (each accepted rename appends its own entry, all
+   * sharing one `auditId`). Optional for back-compat: pre-SMI-5671 ledger
+   * entries have no `collisionId`, and the original collision context isn't
+   * reconstructable for them — the revert lookup falls back to a single
+   * unambiguous `auditId`-only match and refuses when 2+ are ambiguous.
+   * Its optionality is additive (no incompatible shape change), so
+   * `CURRENT_VERSION` stays at 1.
+   */
+  collisionId?: string
+  /**
    * Human-readable reason — e.g.
    * `"collision with skillsmith/release-tools /ship"`. Surfaced verbatim
    * in the audit-report writer (Wave 2 PR #4 extension).

--- a/packages/mcp-server/src/audit/rename-engine.apply-paths.ts
+++ b/packages/mcp-server/src/audit/rename-engine.apply-paths.ts
@@ -135,8 +135,17 @@ export async function runBackup(suggestion: RenameSuggestion): Promise<string> {
 }
 
 /**
- * Build the inline revert summary (decision #10):
- *   `"Renamed /<OLD> → /<NEW>. To undo: sklx audit revert <auditId>"`
+ * Build the inline revert summary (decision #10, corrected by SMI-5671
+ * Change 2):
+ *   `"Renamed /<OLD> → /<NEW>. To undo: call apply_namespace_rename with
+ *   auditId: '<auditId>', collisionId: '<collisionId>', action: 'revert'."`
+ *
+ * The undo hint names the real mechanism (`apply_namespace_rename`'s
+ * `action: 'revert'` — SMI-5671; the CLI's `sklx audit revert` was never
+ * implemented) and interpolates BOTH literal identifiers a caller in a
+ * genuinely fresh session needs to invoke it: `auditId` alone is not
+ * sufficient once Change 0's `(auditId, collisionId)` disambiguation is
+ * load-bearing for a correct revert.
  *
  * For skill renames (no leading `/`), the summary still uses the `/`
  * prefix per the plan's literal text — agents render it as-is.
@@ -145,15 +154,11 @@ export function buildSummary(
   oldIdentifier: string,
   newIdentifier: string,
   auditId: string,
-  // Threaded through for SMI-5671 Change 0 so the later undo-hint fix
-  // (Change 2) can interpolate the collisionId into the message. Not yet
-  // referenced — the returned text is intentionally unchanged by Change 0,
-  // so the parameter is `_`-prefixed (accepted, deliberately unused for now).
-  _collisionId: string,
+  collisionId: string,
   action: 'apply' | 'revert'
 ): string {
   if (action === 'revert') {
     return `Reverted /${oldIdentifier} → /${newIdentifier}. Audit: ${auditId}`
   }
-  return `Renamed /${oldIdentifier} → /${newIdentifier}. To undo: sklx audit revert ${auditId}`
+  return `Renamed /${oldIdentifier} → /${newIdentifier}. To undo: call apply_namespace_rename with auditId: '${auditId}', collisionId: '${collisionId}', action: 'revert'.`
 }

--- a/packages/mcp-server/src/audit/rename-engine.apply-paths.ts
+++ b/packages/mcp-server/src/audit/rename-engine.apply-paths.ts
@@ -145,6 +145,11 @@ export function buildSummary(
   oldIdentifier: string,
   newIdentifier: string,
   auditId: string,
+  // Threaded through for SMI-5671 Change 0 so the later undo-hint fix
+  // (Change 2) can interpolate the collisionId into the message. Not yet
+  // referenced — the returned text is intentionally unchanged by Change 0,
+  // so the parameter is `_`-prefixed (accepted, deliberately unused for now).
+  _collisionId: string,
   action: 'apply' | 'revert'
 ): string {
   if (action === 'revert') {

--- a/packages/mcp-server/src/audit/rename-engine.revert.ts
+++ b/packages/mcp-server/src/audit/rename-engine.revert.ts
@@ -1,0 +1,221 @@
+/**
+ * @fileoverview Revert path for the rename engine (SMI-5671).
+ * @module @skillsmith/mcp-server/audit/rename-engine.revert
+ *
+ * Split out of `rename-engine.ts` (SMI-5671, <500-line file-length gate) —
+ * `revertRename` is the inverse of `applyRename`'s forward-rename paths and
+ * has no dependency on them beyond shared helpers.
+ *
+ * Plan: docs/internal/implementation/smi-5671-apply-namespace-rename-revert-action.md
+ */
+
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+import { readLedger, writeLedger } from './namespace-overrides.js'
+import {
+  buildSummary,
+  fsErr,
+  pathExists,
+  resolveRenameTarget,
+} from './rename-engine.apply-paths.js'
+import { rewriteFrontmatterName } from './rename-engine.helpers.js'
+import type { ApplyRenameResult, RenameSuggestion } from './rename-engine.types.js'
+
+/**
+ * Inverse of `applyRename`. Looks up the ledger entry by
+ * `(auditId, collisionId)`, renames the file back to `originalIdentifier`,
+ * and removes the ledger entry. Backup is kept for forensics until the
+ * 30-day GC sweep.
+ *
+ * Lookup disambiguation (SMI-5671 Change 0): a single audit run can resolve
+ * 2+ collisions, appending 2+ ledger entries that all share one `auditId`,
+ * so `auditId` alone is NOT sufficient to pick the entry to revert. The
+ * lookup: (1) filter by `auditId`; (2) prefer an entry whose `collisionId`
+ * matches exactly; (3) if none match by `collisionId` and exactly one
+ * `auditId`-only entry exists (a legacy pre-fix entry with no `collisionId`),
+ * fall back to it — safe, because it fires only when there's no ambiguity;
+ * (4) if 2+ `auditId`-only entries exist and none carry the requested
+ * `collisionId`, refuse with `namespace.rename.revert_ambiguous` rather than
+ * silently revert the wrong one.
+ *
+ * Idempotency: calling revert twice on the same `(auditId, collisionId)`
+ * returns success with `fromPath === toPath` on the second call (the entry
+ * is gone, so we treat it as a no-op success).
+ */
+export async function revertRename(
+  suggestion: RenameSuggestion,
+  auditId: string,
+  collisionId: string
+): Promise<ApplyRenameResult> {
+  const ledger = await readLedger()
+  const matches = ledger.overrides.filter((o) => o.auditId === auditId)
+
+  // Prefer an exact (auditId, collisionId) match. Fall back to a single
+  // unambiguous auditId-only match (legacy pre-collisionId entries). Refuse
+  // when 2+ candidates share the auditId and none carry the requested
+  // collisionId — guessing which to revert is silent corruption.
+  let entry = matches.find((o) => o.collisionId === collisionId)
+  if (!entry) {
+    if (matches.length >= 2) {
+      return {
+        success: false,
+        collisionId: suggestion.collisionId,
+        appliedAction: suggestion.applyAction,
+        appliedRequest: 'revert',
+        fromPath: resolveRenameTarget(suggestion),
+        toPath: '',
+        backupPath: '',
+        ledgerEntryId: '',
+        summary: '',
+        error: {
+          kind: 'namespace.rename.revert_ambiguous',
+          auditId,
+          collisionId,
+          candidateCount: matches.length,
+          message: `revert is ambiguous: ${matches.length} ledger entries share auditId ${auditId} and none match collisionId ${collisionId}; re-run skill_inventory_audit to obtain current collisionIds`,
+        },
+      }
+    }
+    // `matches.length` is 0 or 1 here: `matches[0]` is either the single
+    // legacy entry (safe fallback) or `undefined` (no entry → no-op below).
+    entry = matches[0]
+  }
+
+  if (!entry) {
+    // Idempotent no-op — already reverted (no ledger entry for this auditId).
+    return {
+      success: true,
+      collisionId: suggestion.collisionId,
+      appliedAction: suggestion.applyAction,
+      appliedRequest: 'revert',
+      fromPath: resolveRenameTarget(suggestion),
+      toPath: resolveRenameTarget(suggestion),
+      backupPath: '',
+      ledgerEntryId: '',
+      summary: buildSummary(
+        suggestion.currentName,
+        suggestion.currentName,
+        auditId,
+        collisionId,
+        'revert'
+      ),
+    }
+  }
+
+  const action = suggestion.applyAction
+  const onDisk = entry.renamedPath
+  const target = entry.originalPath
+
+  if (!(await pathExists(onDisk))) {
+    return {
+      success: false,
+      collisionId: suggestion.collisionId,
+      appliedAction: action,
+      appliedRequest: 'revert',
+      fromPath: onDisk,
+      toPath: target,
+      backupPath: '',
+      ledgerEntryId: entry.id,
+      summary: '',
+      error: {
+        kind: 'namespace.ledger.disk_divergence',
+        ledgerRenamedTo: entry.renamedTo,
+        onDisk,
+        message: `revert source missing on disk: ${onDisk}`,
+        remediationHint:
+          'restore from ~/.claude/skills/.backups or remove the ledger entry manually',
+      },
+    }
+  }
+
+  if (target !== onDisk && (await pathExists(target))) {
+    return {
+      success: false,
+      collisionId: suggestion.collisionId,
+      appliedAction: action,
+      appliedRequest: 'revert',
+      fromPath: onDisk,
+      toPath: target,
+      backupPath: '',
+      ledgerEntryId: entry.id,
+      summary: '',
+      error: {
+        kind: 'namespace.rename.target_exists',
+        target,
+        message: `revert target already exists: ${target}`,
+      },
+    }
+  }
+
+  // Inverse rename. For skills, also restore the SKILL.md frontmatter
+  // `name:` field to the original identifier. Backup is kept (forensics);
+  // no fresh backup is taken on revert — the apply backup covers this case.
+  try {
+    if (action === 'rename_skill_dir_and_frontmatter') {
+      const skillMdPath = path.join(onDisk, 'SKILL.md')
+      const current = await fs.readFile(skillMdPath, 'utf-8')
+      const restored = rewriteFrontmatterName(current, entry.originalIdentifier)
+      if (!restored.ok) {
+        return {
+          success: false,
+          collisionId: suggestion.collisionId,
+          appliedAction: action,
+          appliedRequest: 'revert',
+          fromPath: onDisk,
+          toPath: target,
+          backupPath: '',
+          ledgerEntryId: entry.id,
+          summary: '',
+          error: {
+            kind: 'namespace.rename.frontmatter_rewrite_failed',
+            reason: restored.error.message,
+            message: `revert frontmatter rewrite failed: ${restored.error.message}`,
+          },
+        }
+      }
+      await fs.writeFile(skillMdPath, restored.content, 'utf-8')
+      await fs.rename(onDisk, target)
+    } else {
+      await fs.rename(onDisk, target)
+    }
+  } catch (err) {
+    return {
+      success: false,
+      collisionId: suggestion.collisionId,
+      appliedAction: action,
+      appliedRequest: 'revert',
+      fromPath: onDisk,
+      toPath: target,
+      backupPath: '',
+      ledgerEntryId: entry.id,
+      summary: '',
+      error: fsErr((err as Error).message),
+    }
+  }
+
+  // Remove the ledger entry.
+  const filtered = {
+    version: ledger.version,
+    overrides: ledger.overrides.filter((o) => o.id !== entry.id),
+  }
+  await writeLedger(filtered)
+
+  return {
+    success: true,
+    collisionId: suggestion.collisionId,
+    appliedAction: action,
+    appliedRequest: 'revert',
+    fromPath: onDisk,
+    toPath: target,
+    backupPath: '',
+    ledgerEntryId: entry.id,
+    summary: buildSummary(
+      entry.renamedTo,
+      entry.originalIdentifier,
+      auditId,
+      collisionId,
+      'revert'
+    ),
+  }
+}

--- a/packages/mcp-server/src/audit/rename-engine.ts
+++ b/packages/mcp-server/src/audit/rename-engine.ts
@@ -34,7 +34,6 @@
  */
 
 import * as fs from 'node:fs/promises'
-import * as path from 'node:path'
 
 import { getBackupsDir } from '../tools/install.conflict-helpers.js'
 import { appendOverride, findOverride, readLedger, writeLedger } from './namespace-overrides.js'
@@ -49,11 +48,8 @@ import {
   runBackup,
 } from './rename-engine.apply-paths.js'
 import { rewriteFrontmatterName } from './rename-engine.helpers.js'
-import type {
-  ApplyRenameRequest,
-  ApplyRenameResult,
-  RenameSuggestion,
-} from './rename-engine.types.js'
+import { revertRename } from './rename-engine.revert.js'
+import type { ApplyRenameRequest, ApplyRenameResult } from './rename-engine.types.js'
 
 export { generateSuggestionChain } from './suggestion-chain.js'
 
@@ -82,7 +78,7 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
   const auditId = request.auditId
 
   if (request.action === 'revert') {
-    return revertRename(suggestion, auditId)
+    return revertRename(suggestion, auditId, request.collisionId)
   }
 
   const newName = request.customName ?? suggestion.suggested
@@ -111,7 +107,13 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
         toPath: existing.renamedPath,
         backupPath: '',
         ledgerEntryId: existing.id,
-        summary: buildSummary(suggestion.currentName, existing.renamedTo, auditId, 'apply'),
+        summary: buildSummary(
+          suggestion.currentName,
+          existing.renamedTo,
+          auditId,
+          suggestion.collisionId,
+          'apply'
+        ),
       }
     }
     // Divergence — ledger says renamedTo, but it's not on disk. Refuse.
@@ -255,6 +257,7 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
     originalPath: renameTarget,
     renamedPath: destPath,
     auditId,
+    collisionId: suggestion.collisionId,
     reason: suggestion.reason,
   })
   // `appendOverride` returns reference-equal ledger when a duplicate
@@ -281,148 +284,13 @@ export async function applyRename(input: ApplyRenameRequest): Promise<ApplyRenam
     toPath: destPath,
     backupPath,
     ledgerEntryId: newEntry?.id ?? '',
-    summary: buildSummary(suggestion.currentName, newName, auditId, 'apply'),
-  }
-}
-
-/**
- * Inverse of `applyRename`. Looks up the ledger entry by `auditId`,
- * renames the file back to `originalIdentifier`, and removes the ledger
- * entry. Backup is kept for forensics until the 30-day GC sweep.
- *
- * Idempotency: calling revert twice on the same `auditId` returns success
- * with `fromPath === toPath` on the second call (the entry is gone, so
- * we treat it as a no-op success).
- */
-async function revertRename(
-  suggestion: RenameSuggestion,
-  auditId: string
-): Promise<ApplyRenameResult> {
-  const ledger = await readLedger()
-  const entry = ledger.overrides.find((o) => o.auditId === auditId)
-  if (!entry) {
-    // Idempotent no-op — already reverted.
-    return {
-      success: true,
-      collisionId: suggestion.collisionId,
-      appliedAction: suggestion.applyAction,
-      appliedRequest: 'revert',
-      fromPath: resolveRenameTarget(suggestion),
-      toPath: resolveRenameTarget(suggestion),
-      backupPath: '',
-      ledgerEntryId: '',
-      summary: buildSummary(suggestion.currentName, suggestion.currentName, auditId, 'revert'),
-    }
-  }
-
-  const action = suggestion.applyAction
-  const onDisk = entry.renamedPath
-  const target = entry.originalPath
-
-  if (!(await pathExists(onDisk))) {
-    return {
-      success: false,
-      collisionId: suggestion.collisionId,
-      appliedAction: action,
-      appliedRequest: 'revert',
-      fromPath: onDisk,
-      toPath: target,
-      backupPath: '',
-      ledgerEntryId: entry.id,
-      summary: '',
-      error: {
-        kind: 'namespace.ledger.disk_divergence',
-        ledgerRenamedTo: entry.renamedTo,
-        onDisk,
-        message: `revert source missing on disk: ${onDisk}`,
-        remediationHint:
-          'restore from ~/.claude/skills/.backups or remove the ledger entry manually',
-      },
-    }
-  }
-
-  if (target !== onDisk && (await pathExists(target))) {
-    return {
-      success: false,
-      collisionId: suggestion.collisionId,
-      appliedAction: action,
-      appliedRequest: 'revert',
-      fromPath: onDisk,
-      toPath: target,
-      backupPath: '',
-      ledgerEntryId: entry.id,
-      summary: '',
-      error: {
-        kind: 'namespace.rename.target_exists',
-        target,
-        message: `revert target already exists: ${target}`,
-      },
-    }
-  }
-
-  // Inverse rename. For skills, also restore the SKILL.md frontmatter
-  // `name:` field to the original identifier. Backup is kept (forensics);
-  // no fresh backup is taken on revert — the apply backup covers this case.
-  try {
-    if (action === 'rename_skill_dir_and_frontmatter') {
-      const skillMdPath = path.join(onDisk, 'SKILL.md')
-      const current = await fs.readFile(skillMdPath, 'utf-8')
-      const restored = rewriteFrontmatterName(current, entry.originalIdentifier)
-      if (!restored.ok) {
-        return {
-          success: false,
-          collisionId: suggestion.collisionId,
-          appliedAction: action,
-          appliedRequest: 'revert',
-          fromPath: onDisk,
-          toPath: target,
-          backupPath: '',
-          ledgerEntryId: entry.id,
-          summary: '',
-          error: {
-            kind: 'namespace.rename.frontmatter_rewrite_failed',
-            reason: restored.error.message,
-            message: `revert frontmatter rewrite failed: ${restored.error.message}`,
-          },
-        }
-      }
-      await fs.writeFile(skillMdPath, restored.content, 'utf-8')
-      await fs.rename(onDisk, target)
-    } else {
-      await fs.rename(onDisk, target)
-    }
-  } catch (err) {
-    return {
-      success: false,
-      collisionId: suggestion.collisionId,
-      appliedAction: action,
-      appliedRequest: 'revert',
-      fromPath: onDisk,
-      toPath: target,
-      backupPath: '',
-      ledgerEntryId: entry.id,
-      summary: '',
-      error: fsErr((err as Error).message),
-    }
-  }
-
-  // Remove the ledger entry.
-  const filtered = {
-    version: ledger.version,
-    overrides: ledger.overrides.filter((o) => o.id !== entry.id),
-  }
-  await writeLedger(filtered)
-
-  return {
-    success: true,
-    collisionId: suggestion.collisionId,
-    appliedAction: action,
-    appliedRequest: 'revert',
-    fromPath: onDisk,
-    toPath: target,
-    backupPath: '',
-    ledgerEntryId: entry.id,
-    summary: buildSummary(entry.renamedTo, entry.originalIdentifier, auditId, 'revert'),
+    summary: buildSummary(
+      suggestion.currentName,
+      newName,
+      auditId,
+      suggestion.collisionId,
+      'apply'
+    ),
   }
 }
 

--- a/packages/mcp-server/src/audit/rename-engine.types.ts
+++ b/packages/mcp-server/src/audit/rename-engine.types.ts
@@ -105,10 +105,11 @@ export interface ApplyRenameResult {
   /** ULID of the appended ledger entry — `''` for revert (ledger entry removed). */
   ledgerEntryId: string
   /**
-   * Inline revert summary (decision #10). Populated on success; empty
-   * string on failure. Literal text:
+   * Inline revert summary (decision #10, corrected by SMI-5671 Change 2).
+   * Populated on success; empty string on failure. Literal text:
    *
-   *   `"Renamed /<OLD> → /<NEW>. To undo: sklx audit revert <auditId>"`
+   *   `"Renamed /<OLD> → /<NEW>. To undo: call apply_namespace_rename with
+   *   auditId: '<auditId>', collisionId: '<collisionId>', action: 'revert'."`
    *
    * The agent surfaces this directly to the user in tool-response output.
    */

--- a/packages/mcp-server/src/audit/rename-engine.types.ts
+++ b/packages/mcp-server/src/audit/rename-engine.types.ts
@@ -63,7 +63,7 @@ export interface RenameSuggestion {
  */
 export type RenameActionRequest =
   | { action: 'apply'; auditId: string; customName?: string }
-  | { action: 'revert'; auditId: string }
+  | { action: 'revert'; auditId: string; collisionId: string }
 
 /**
  * Top-level apply request. `auditId` is the FK into the audit-history
@@ -152,6 +152,13 @@ export type RenameError =
   | {
       kind: 'namespace.rename.revert_not_found'
       auditId: string
+      message: string
+    }
+  | {
+      kind: 'namespace.rename.revert_ambiguous'
+      auditId: string
+      collisionId: string
+      candidateCount: number
       message: string
     }
 

--- a/packages/mcp-server/src/tools/apply-journal.helpers.ts
+++ b/packages/mcp-server/src/tools/apply-journal.helpers.ts
@@ -16,14 +16,17 @@
  * single "content hash", and the directory-path-reversal half of that
  * mutation already has a dedicated, ledger-backed mechanism
  * (`rename-engine.ts`'s `action: 'revert'`, surfaced today via
- * `sklx audit revert`). Duplicating path-reversal here — driven only by
+ * `apply_namespace_rename`'s `action: 'revert'` — SMI-5671; the CLI's
+ * `sklx audit revert` this comment previously cited was never
+ * implemented). Duplicating path-reversal here — driven only by
  * this record's fixed `target_path` field, with no companion "restore to"
  * field in the schema — would create two independent undo mechanisms for
  * the same mutation with no shared source of truth, which is precisely the
  * kind of coordination hazard the P-5 single-writer invariant exists to
  * avoid. `undo_apply` therefore restores SKILL.md's CONTENT (reverting the
  * frontmatter rewrite) but does not rename the directory back; full-path
- * reversal for a skill-dir rename remains `sklx audit revert`'s job.
+ * reversal for a skill-dir rename remains `apply_namespace_rename`'s
+ * `action: 'revert'`'s job.
  *
  * Fail-soft by design: the file mutation the user asked for has already
  * succeeded (or definitively failed) by the time these helpers run. A
@@ -57,11 +60,25 @@ export interface JournalApplySuccessInput {
   /** The content-hashable file the mutation changed (see module header). */
   targetPath: string
   /** The apply tool's pre-mutation backup dir, or `''` for an idempotent
-   * re-apply that made no fresh backup (nothing changed on disk). */
+   * re-apply OR a revert — reverts never take a fresh backup (SMI-5671:
+   * the original apply's backup already covers this), so `backupRef`
+   * alone can't distinguish "nothing changed" from "reverted, no fresh
+   * backup needed". Use `isNoOp` for that. */
   backupRef: string
   /** Caller-supplied approval mode, e.g. `'apply'` / `'custom'` /
    * `'apply_with_confirmation'`. */
   approval: string
+  /** SMI-5671: which direction this mutation ran — `apply_namespace_rename`'s
+   * `action: 'revert'` calls this same success-journaling path as
+   * `apply`/`custom`, so the journal record's `action` field can no longer
+   * be hardcoded to `'apply'`. */
+  action: 'apply' | 'revert'
+  /** SMI-5671: the engine's own idempotency signal (`fromPath === toPath`).
+   * NOT the same thing as `backupRef === ''` — a genuine (non-no-op)
+   * revert also has `backupRef === ''` by design, so branching on
+   * `backupRef` alone would mislabel every real revert as
+   * `idempotent_no_op` in the audit trail. */
+  isNoOp: boolean
 }
 
 /**
@@ -73,23 +90,48 @@ export async function journalApplySuccess(input: JournalApplySuccessInput): Prom
     const afterHash = await hashFileSafe(input.targetPath)
 
     if (input.backupRef === '') {
-      // Idempotent no-op re-apply: nothing changed, so there is no fresh
-      // backup to undo TO. Journal the event for the evidence trail but
-      // don't add a session-apply entry — there is nothing for undo_apply
-      // to restore.
+      if (input.isNoOp) {
+        // Idempotent no-op (apply re-apply, or revert with no matching
+        // ledger entry): nothing changed, so there is no fresh backup to
+        // undo TO. Journal the event for the evidence trail but don't add
+        // a session-apply entry — there is nothing for undo_apply to
+        // restore.
+        await appendJournalRecord({
+          schema: JOURNAL_SCHEMA_VERSION,
+          ts: Date.now(),
+          session_id: getJournalSessionId(),
+          tool: input.tool,
+          action: input.action,
+          suggestion_id: input.suggestionId,
+          target_path: input.targetPath,
+          before_hash: afterHash,
+          after_hash: afterHash,
+          approval: input.approval,
+          backup_ref: null,
+          detail: 'idempotent_no_op',
+        })
+        return
+      }
+
+      // A genuine revert (SMI-5671): the mutation already happened (per
+      // the module's fail-soft contract, by the time this runs) and
+      // reverts never take a fresh backup, so there's no `backupRef` to
+      // resolve a `before_hash` from. Record what's actually verifiable —
+      // the post-revert content — rather than fabricate a `before_hash`
+      // this call site has no way to obtain.
       await appendJournalRecord({
         schema: JOURNAL_SCHEMA_VERSION,
         ts: Date.now(),
         session_id: getJournalSessionId(),
         tool: input.tool,
-        action: 'apply',
+        action: input.action,
         suggestion_id: input.suggestionId,
         target_path: input.targetPath,
-        before_hash: afterHash,
+        before_hash: null,
         after_hash: afterHash,
         approval: input.approval,
         backup_ref: null,
-        detail: 'idempotent_no_op',
+        detail: null,
       })
       return
     }
@@ -103,7 +145,7 @@ export async function journalApplySuccess(input: JournalApplySuccessInput): Prom
       ts: Date.now(),
       session_id: getJournalSessionId(),
       tool: input.tool,
-      action: 'apply',
+      action: input.action,
       suggestion_id: input.suggestionId,
       target_path: input.targetPath,
       before_hash: beforeHash,

--- a/packages/mcp-server/src/tools/apply-namespace-rename.ts
+++ b/packages/mcp-server/src/tools/apply-namespace-rename.ts
@@ -16,6 +16,15 @@
  *     enforces non-empty `customName` on this branch).
  *   - `action: 'skip'`   — no-op; returns `{ success: true }` with no
  *     `result`. The agent records the decision; nothing on disk changes.
+ *   - `action: 'revert'` — undo a previously applied `apply`/`custom`
+ *     rename (SMI-5671). `suggestions.json` is a static snapshot from
+ *     audit time, so the same `(auditId, collisionId)` lookup still
+ *     resolves after the forward rename already happened. Ledger-backed
+ *     via `applyRename({ request: { action: 'revert', collisionId } })` —
+ *     this is the only durable, cross-session undo path (the CLI's
+ *     `sklx audit revert` was never implemented, and the `undo_apply` tool
+ *     only tracks same-process session state). `collisionId` disambiguates
+ *     when a single audit run resolved 2+ collisions under one `auditId`.
  *
  * Failure modes (typed via `errorCode`):
  *   - `namespace.audit.invalid_input` — Zod rejection.
@@ -62,12 +71,16 @@ function journalTargetPath(toPath: string, appliedAction: string): string {
  * `confirmed !== true` (and `action !== 'skip'`), the tool returns a
  * non-mutating preview envelope describing the rename; the caller must
  * re-invoke with `confirmed: true` to actually rename the file.
+ *
+ * SMI-5671: `action: 'revert'` takes no `customName` — same as `apply`/
+ * `skip` — so the existing refinement (`action !== 'custom' &&
+ * customName !== undefined` → reject) already covers it with no change.
  */
 export const applyNamespaceRenameInputSchema = z
   .object({
     auditId: z.string().min(1),
     collisionId: z.string().min(1),
-    action: z.enum(['apply', 'custom', 'skip']),
+    action: z.enum(['apply', 'custom', 'skip', 'revert']),
     customName: z.string().min(1).optional(),
     confirmed: z.boolean().optional(),
   })
@@ -98,7 +111,7 @@ export const applyNamespaceRenameInputSchema = z
 export const applyNamespaceRenameToolSchema = {
   name: 'apply_namespace_rename',
   description:
-    "[Skillsmith — Maintain stage] Apply a rename suggestion from a prior `skill_inventory_audit`. MUTATES `~/.claude` (renames a skill/command/agent file) — but ONLY when `confirmed: true`. Without `confirmed`, returns a non-mutating preview ({ preview: true, before, after, applied: false }) so the agent can show the change before committing. `action: 'apply'` uses the suggested name; `'custom'` uses `customName`; `'skip'` records a no-op.",
+    "[Skillsmith — Maintain stage] Apply a rename suggestion from a prior `skill_inventory_audit`, or revert one already applied. MUTATES `~/.claude` (renames a skill/command/agent file) — but ONLY when `confirmed: true`. Without `confirmed`, returns a non-mutating preview ({ preview: true, before, after, applied: false, direction }) so the agent can show the change before committing. `action: 'apply'` uses the suggested name; `'custom'` uses `customName`; `'skip'` records a no-op; `'revert'` undoes a previously applied rename for the same auditId + collisionId — this is the durable, cross-session undo path (a fresh MCP server process, e.g. a new session, can still revert a rename applied by an earlier process, since the ledger persists to disk).",
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -108,22 +121,22 @@ export const applyNamespaceRenameToolSchema = {
       },
       collisionId: {
         type: 'string',
-        description: 'collisionId of the RenameSuggestion to apply.',
+        description: 'collisionId of the RenameSuggestion to apply or revert.',
       },
       action: {
         type: 'string',
         description:
-          "'apply' uses the suggested name; 'custom' uses customName; 'skip' is a no-op.",
-        enum: ['apply', 'custom', 'skip'],
+          "'apply' uses the suggested name; 'custom' uses customName; 'skip' is a no-op; 'revert' undoes a previously applied apply/custom rename for the same auditId + collisionId.",
+        enum: ['apply', 'custom', 'skip', 'revert'],
       },
       customName: {
         type: 'string',
-        description: "Required when action === 'custom'; forbidden otherwise.",
+        description: "Required when action === 'custom'; forbidden otherwise (including revert).",
       },
       confirmed: {
         type: 'boolean',
         description:
-          'When true, performs the file rename. When omitted/false, returns a non-mutating preview. Defaults to false.',
+          'When true, performs the file rename (or revert). When omitted/false, returns a non-mutating preview. Defaults to false.',
       },
     },
     required: ['auditId', 'collisionId', 'action'],
@@ -187,9 +200,16 @@ async function applyNamespaceRenameImpl(input: unknown): Promise<ApplyNamespaceR
     }
   }
 
+  // SMI-5671: `revert` is the inverse of apply/custom — same confirmation
+  // gate, same suggestion lookup, but no `customName` and no dependency
+  // on `suggestion.suggested` for the mutation itself (only for the
+  // preview's swapped-direction text below).
+  const isRevert = validInput.action === 'revert'
+
   // SMI-5213: confirmation gate. Without `confirmed: true`, return a
-  // non-mutating preview describing the rename. The agent surfaces this
-  // to the user and re-invokes with `confirmed: true` to apply.
+  // non-mutating preview describing the rename (or revert). The agent
+  // surfaces this to the user and re-invokes with `confirmed: true` to
+  // apply.
   const targetName = validInput.action === 'custom' ? validInput.customName! : suggestion.suggested
   if (validInput.confirmed !== true) {
     return {
@@ -198,18 +218,26 @@ async function applyNamespaceRenameImpl(input: unknown): Promise<ApplyNamespaceR
       collisionId: suggestion.collisionId,
       action: suggestion.applyAction,
       target: suggestion.entry.source_path,
-      before: suggestion.currentName,
-      after: targetName,
+      // Revert reverses the direction shown for apply/custom: "before" is
+      // the currently-renamed name, "after" is the original identifier
+      // being restored.
+      before: isRevert ? targetName : suggestion.currentName,
+      after: isRevert ? suggestion.currentName : targetName,
       applied: false,
+      direction: isRevert ? 'revert' : 'apply',
     }
   }
 
   // Translate to Wave 2's apply request shape. `'custom'` carries
-  // `customName` through; `'apply'` uses the suggested name verbatim.
+  // `customName` through; `'apply'` uses the suggested name verbatim;
+  // `'revert'` looks up the ledger entry by `(auditId, collisionId)` and
+  // undoes it (Change 0 — `collisionId` is required to disambiguate when
+  // 2+ renames share one `auditId`).
   const renameRequest: ApplyRenameRequest = {
     suggestion,
-    request:
-      validInput.action === 'custom'
+    request: isRevert
+      ? { action: 'revert', auditId: validInput.auditId, collisionId: validInput.collisionId }
+      : validInput.action === 'custom'
         ? { action: 'apply', auditId: validInput.auditId, customName: validInput.customName! }
         : { action: 'apply', auditId: validInput.auditId },
   }
@@ -235,18 +263,30 @@ async function applyNamespaceRenameImpl(input: unknown): Promise<ApplyNamespaceR
     }
   }
 
+  // SMI-5671: surface the engine's existing idempotency signal explicitly
+  // rather than requiring callers to infer it from `result` themselves.
+  // For `revert` this is the "no matching ledger entry" no-op case; for
+  // `apply`/`custom` it mirrors the pre-existing idempotent-re-apply case.
+  // Computed before the journal call: `isNoOp` (not `backupRef === ''`
+  // alone) is what tells `journalApplySuccess` whether a genuine revert
+  // mutation happened, since reverts always have `backupRef === ''`.
+  const noOp = result.fromPath === result.toPath && result.backupPath === ''
+
   await journalApplySuccess({
     tool: 'apply_namespace_rename',
     suggestionId: result.collisionId,
     targetPath: journalTargetPath(result.toPath, result.appliedAction),
     backupRef: result.backupPath,
     approval: validInput.action,
+    action: isRevert ? 'revert' : 'apply',
+    isNoOp: noOp,
   })
 
   return {
     success: true,
     collisionId: result.collisionId,
     result,
+    noOp,
   }
 }
 

--- a/packages/mcp-server/src/tools/apply-namespace-rename.types.ts
+++ b/packages/mcp-server/src/tools/apply-namespace-rename.types.ts
@@ -15,6 +15,12 @@ import type { ApplyRenameResult } from '../audit/rename-engine.types.js'
  * `action: 'apply'`  — apply the suggested rename (Wave 2 `applyRename`).
  * `action: 'custom'` — apply with `customName` (must be non-empty).
  * `action: 'skip'`   — record a no-op decision; no file mutation.
+ * `action: 'revert'` — undo a previously applied rename for the same
+ *   `(auditId, collisionId)` pair (SMI-5671). Reuses the same
+ *   `(auditId, collisionId)` lookup as apply/custom — `suggestions.json` is
+ *   a static snapshot from audit time, so it still resolves after the
+ *   forward rename has already happened. `collisionId` disambiguates when
+ *   a single audit run resolved 2+ collisions under one `auditId` (Change 0).
  *
  * `auditId` + `collisionId` are FKs into
  * `~/.skillsmith/audits/<auditId>/suggestions.json` (this PR — see
@@ -25,7 +31,7 @@ export interface ApplyNamespaceRenameInput {
   auditId: string
   /** `collisionId` from a `RenameSuggestion` in that response. */
   collisionId: string
-  action: 'apply' | 'custom' | 'skip'
+  action: 'apply' | 'custom' | 'skip' | 'revert'
   /** Required when `action === 'custom'`. */
   customName?: string
 }
@@ -64,4 +70,23 @@ export interface ApplyNamespaceRenameResponse {
   after?: string
   /** Always `false` on a preview; absent on a real apply. */
   applied?: boolean
+  /**
+   * SMI-5671: which way this preview describes — `'apply'` for `apply`/
+   * `custom`, `'revert'` for `revert`. Part of the confirmation-gate
+   * preview-field group (present when `preview: true`) so a generic
+   * renderer doesn't have to infer direction from `before`/`after`
+   * field-name convention alone.
+   */
+  direction?: 'apply' | 'revert'
+  /**
+   * SMI-5671: present on the non-preview (post-`confirmed: true`) success
+   * response; `true` when the engine's apply/revert call was a no-op —
+   * computed from `result.fromPath === result.toPath && result.backupPath
+   * === ''`. For `revert` this means no matching ledger entry was found
+   * for `(auditId, collisionId)` (already reverted, or never applied);
+   * for `apply`/`custom` it mirrors the pre-existing idempotent-re-apply
+   * case. Surfaces the engine's existing idempotency signal explicitly so
+   * callers don't have to infer it from `result` themselves.
+   */
+  noOp?: boolean
 }

--- a/packages/mcp-server/src/tools/apply-recommended-edit.ts
+++ b/packages/mcp-server/src/tools/apply-recommended-edit.ts
@@ -186,6 +186,11 @@ async function applyRecommendedEditToolImpl(input: unknown): Promise<ApplyRecomm
     targetPath: result.filePath,
     backupRef: result.backupPath,
     approval: 'apply_with_confirmation',
+    // Prose edits have no revert action and no idempotent-no-op path — a
+    // successful apply always takes a fresh backup (SMI-5671 added these
+    // fields for apply_namespace_rename's revert; they're inert here).
+    action: 'apply',
+    isNoOp: false,
   })
 
   return {

--- a/packages/mcp-server/src/tools/undo-apply.ts
+++ b/packages/mcp-server/src/tools/undo-apply.ts
@@ -72,7 +72,7 @@ export const undoApplyInputSchema = z
 export const undoApplyToolSchema = {
   name: 'undo_apply',
   description:
-    "[Skillsmith — Maintain stage] Undo the most recent apply_namespace_rename / apply_recommended_edit changeset(s) made in THIS server session. Session-scoped: restarting the MCP server clears the undo history. Restores from the apply tool's own pre-mutation backup and refuses (never throws) if the target was modified since the apply, the backup is missing, or the restore target falls outside the confined skill roots. Pass `count` to undo the N most-recent changesets (default 1), or `suggestion_id` to undo one specific changeset — mutually exclusive.",
+    "[Skillsmith — Maintain stage] Undo the most recent apply_namespace_rename / apply_recommended_edit changeset(s) made in THIS server session. Session-scoped: restarting the MCP server clears the undo history — for a namespace rename applied in a PRIOR session, use the durable, cross-session revert instead: apply_namespace_rename({ auditId, collisionId, action: 'revert' }) (SMI-5671). Restores from the apply tool's own pre-mutation backup and refuses (never throws) if the target was modified since the apply, the backup is missing, or the restore target falls outside the confined skill roots. Pass `count` to undo the N most-recent changesets (default 1), or `suggestion_id` to undo one specific changeset — mutually exclusive.",
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -242,14 +242,23 @@ async function undoApplyImpl(input: unknown): Promise<UndoApplyResponse> {
     suggestionId: validInput.suggestion_id,
   })
   if (targets.length === 0) {
+    // SMI-5671: this tool only tracks same-process session state (see the
+    // module header) — a fresh MCP server process (the normal case: a new
+    // Codex/Claude Code session) has no record of an apply from a prior
+    // process. For a namespace rename specifically, a durable, ledger-backed
+    // revert survives across sessions: `apply_namespace_rename({ auditId,
+    // collisionId, action: 'revert' })`. Point callers there so whichever
+    // tool they reach for first by name surfaces the working path.
+    const crossSessionHint =
+      "For a namespace rename applied in a prior session, use the durable, cross-session revert instead: apply_namespace_rename({ auditId, collisionId, action: 'revert' })."
     return {
       success: false,
       undone: [],
       errorCode: 'undo.no_session_applies',
       error:
         validInput.suggestion_id !== undefined
-          ? `No session-tracked apply found for suggestion_id ${validInput.suggestion_id}.`
-          : 'No applies were made in this server session; nothing to undo.',
+          ? `No session-tracked apply found for suggestion_id ${validInput.suggestion_id}. ${crossSessionHint}`
+          : `No applies were made in this server session; nothing to undo. ${crossSessionHint}`,
     }
   }
 

--- a/packages/mcp-server/tests/integration/install-namespace.integration.test.ts
+++ b/packages/mcp-server/tests/integration/install-namespace.integration.test.ts
@@ -471,7 +471,7 @@ describe('install namespace integration', () => {
     })
     expect(applyResult.success).toBe(true)
     expect(applyResult.summary).toMatch(
-      /Renamed \/code-helper → \/sibling-vendor-code-helper\. To undo: sklx/
+      /Renamed \/code-helper → \/sibling-vendor-code-helper\. To undo: call apply_namespace_rename with auditId: '.+', collisionId: 'e2e-01', action: 'revert'\./
     )
 
     // C: gate now proceeds.

--- a/packages/mcp-server/tests/unit/apply-namespace-rename.test.ts
+++ b/packages/mcp-server/tests/unit/apply-namespace-rename.test.ts
@@ -27,7 +27,13 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 
 import { skillInventoryAudit } from '../../src/tools/skill-inventory-audit.js'
-import { applyNamespaceRename } from '../../src/tools/apply-namespace-rename.js'
+import {
+  applyNamespaceRename,
+  applyNamespaceRenameInputSchema,
+  applyNamespaceRenameToolSchema,
+} from '../../src/tools/apply-namespace-rename.js'
+import { readLedger } from '../../src/audit/namespace-overrides.js'
+import { readJournalRecords } from '@skillsmith/core/journal'
 import type { SkillInventoryAuditResponse } from '../../src/tools/skill-inventory-audit.types.js'
 
 beforeEach(() => {
@@ -154,6 +160,7 @@ describe('apply_namespace_rename — confirmation gate (SMI-5213)', () => {
     expect(response.action).toBe(suggestion.applyAction)
     expect(response.before).toBe(suggestion.currentName)
     expect(response.after).toBe(suggestion.suggested)
+    expect(response.direction).toBe('apply')
     // File untouched.
     expect(fs.existsSync(cmdPath)).toBe(true)
     expect(fs.readFileSync(cmdPath, 'utf-8')).toBe(before)
@@ -261,6 +268,18 @@ describe('apply_namespace_rename — failure modes', () => {
     expect(response.success).toBe(false)
     expect(response.errorCode).toBe('namespace.audit.collision_not_found')
   })
+
+  it('returns collision_not_found for action: revert same as for apply (SMI-5671)', async () => {
+    const audit = await seedAuditWithCollision()
+    const response = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: 'collisionDoesNotExist',
+      action: 'revert',
+      confirmed: true,
+    })
+    expect(response.success).toBe(false)
+    expect(response.errorCode).toBe('namespace.audit.collision_not_found')
+  })
 })
 
 describe('apply_namespace_rename — idempotent re-apply', () => {
@@ -287,5 +306,162 @@ describe('apply_namespace_rename — idempotent re-apply', () => {
     expect(second.result?.success).toBe(true)
     expect(second.result?.fromPath).toBe(second.result?.toPath)
     expect(second.result?.backupPath).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SMI-5671: action: 'revert'
+// ---------------------------------------------------------------------------
+
+describe('apply_namespace_rename — action: revert', () => {
+  it('reverts a previously applied rename through the tool (apply → revert round-trip)', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+    const cmdPath = path.join(TEST_HOME, '.claude', 'commands', 'ship.md')
+
+    const applied = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'apply',
+      confirmed: true,
+    })
+    expect(applied.success).toBe(true)
+    expect(applied.result?.success).toBe(true)
+    const renamedPath = applied.result!.toPath
+    expect(fs.existsSync(cmdPath)).toBe(false)
+    expect(fs.existsSync(renamedPath)).toBe(true)
+
+    const reverted = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'revert',
+      confirmed: true,
+    })
+    expect(reverted.success).toBe(true)
+    expect(reverted.result?.success).toBe(true)
+    expect(reverted.noOp).toBe(false)
+    // Original file restored; renamed file gone — a genuine round-trip,
+    // not just a ledger-entry removal.
+    expect(fs.existsSync(cmdPath)).toBe(true)
+    expect(fs.existsSync(renamedPath)).toBe(false)
+
+    const ledger = await readLedger()
+    expect(ledger.overrides).toHaveLength(0)
+
+    // The journal must record this as a genuine 'revert' — NOT mislabeled
+    // as 'apply' (the journal helper's action field used to be hardcoded)
+    // or as 'idempotent_no_op' (revert has no fresh backupRef by design,
+    // which used to be conflated with "nothing changed").
+    const records = await readJournalRecords()
+    const revertRecord = records.at(-1)
+    expect(revertRecord?.action).toBe('revert')
+    expect(revertRecord?.detail).not.toBe('idempotent_no_op')
+  })
+
+  it('returns a non-mutating preview with swapped before/after and direction: revert', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+
+    const applied = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'apply',
+      confirmed: true,
+    })
+    expect(applied.success).toBe(true)
+    const renamedPath = applied.result!.toPath
+
+    const preview = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'revert',
+    })
+    expect(preview.success).toBe(true)
+    expect(preview.preview).toBe(true)
+    expect(preview.applied).toBe(false)
+    expect(preview.direction).toBe('revert')
+    // Swapped vs. the apply/custom preview: "before" is the currently
+    // renamed name, "after" is the original identifier being restored.
+    expect(preview.before).toBe(suggestion.suggested)
+    expect(preview.after).toBe(suggestion.currentName)
+    expect(preview.result).toBeUndefined()
+
+    // Preview must not mutate anything.
+    expect(fs.existsSync(renamedPath)).toBe(true)
+  })
+
+  it('returns noOp: true when reverting an auditId/collisionId with no matching ledger entry', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+    const cmdPath = path.join(TEST_HOME, '.claude', 'commands', 'ship.md')
+
+    // No apply call was made — the ledger has no entry for this audit at all.
+    const reverted = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'revert',
+      confirmed: true,
+    })
+    expect(reverted.success).toBe(true)
+    expect(reverted.noOp).toBe(true)
+    expect(reverted.result?.fromPath).toBe(reverted.result?.toPath)
+    expect(reverted.result?.backupPath).toBe('')
+    // Idempotent no-op — nothing on disk changed.
+    expect(fs.existsSync(cmdPath)).toBe(true)
+
+    // A genuine no-op (no matching ledger entry) is still journaled as
+    // 'idempotent_no_op' — this is the one case where that detail is
+    // actually correct, unlike a real revert.
+    const records = await readJournalRecords()
+    const revertRecord = records.at(-1)
+    expect(revertRecord?.action).toBe('revert')
+    expect(revertRecord?.detail).toBe('idempotent_no_op')
+  })
+
+  it('returns an explicit error (not a silent no-op) when the renamed path is missing on disk', async () => {
+    const audit = await seedAuditWithCollision()
+    const suggestion = audit.renameSuggestions[0]!
+
+    const applied = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'apply',
+      confirmed: true,
+    })
+    expect(applied.success).toBe(true)
+    const renamedPath = applied.result!.toPath
+
+    // Simulate the renamed file having been manually deleted since the
+    // apply — the ledger still says it lives at renamedPath.
+    fs.rmSync(renamedPath, { force: true })
+
+    const reverted = await applyNamespaceRename({
+      auditId: audit.auditId,
+      collisionId: suggestion.collisionId,
+      action: 'revert',
+      confirmed: true,
+    })
+    expect(reverted.success).toBe(false)
+    expect(reverted.errorCode).toBe('namespace.rename.subcall_failed')
+    expect(reverted.result?.error?.kind).toBe('namespace.ledger.disk_divergence')
+    // Not surfaced as a no-op — `noOp` is only computed on the success path.
+    expect(reverted.noOp).toBeUndefined()
+
+    // The ledger entry must NOT be silently removed on a divergence refusal.
+    const ledger = await readLedger()
+    expect(ledger.overrides).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SMI-5671: schema-drift guardrail
+// ---------------------------------------------------------------------------
+
+describe('apply_namespace_rename — schema drift guardrail', () => {
+  it('keeps the hand-written JSON Schema action enum in sync with the Zod schema', () => {
+    const zodValues = applyNamespaceRenameInputSchema.innerType().shape.action.options
+    const jsonSchemaValues = applyNamespaceRenameToolSchema.inputSchema.properties.action.enum
+    expect(new Set(jsonSchemaValues)).toEqual(new Set(zodValues))
+    expect(jsonSchemaValues).toHaveLength(zodValues.length)
   })
 })

--- a/packages/mcp-server/tests/unit/rename-engine.revert.test.ts
+++ b/packages/mcp-server/tests/unit/rename-engine.revert.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for SMI-5671 Change 0 — revert ledger lookup disambiguation.
+ *
+ * Split out of `rename-engine.test.ts` (<500-line file-length gate). Covers
+ * the `(auditId, collisionId)` lookup added to `revertRename()`:
+ *   1. Two ledger entries share one `auditId` with distinct `collisionId`s —
+ *      revert by `(auditId, collisionId)` reverts only the intended entry.
+ *   2. A legacy entry with no `collisionId`, sole match for its `auditId` —
+ *      revert still succeeds via the back-compat fallback.
+ *   3. Two legacy entries (no `collisionId`) share one `auditId` — revert
+ *      refuses with `namespace.rename.revert_ambiguous` rather than guess.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as fs from 'node:fs'
+import * as fsp from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { applyRename } from '../../src/audit/rename-engine.js'
+import { readLedger, writeLedger } from '../../src/audit/namespace-overrides.js'
+import type { CollisionId, InventoryEntry } from '../../src/audit/collision-detector.types.js'
+import type { RenameSuggestion } from '../../src/audit/rename-engine.types.js'
+
+let TEST_HOME: string
+let ORIGINAL_HOME: string | undefined
+
+beforeEach(() => {
+  TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-rename-engine-revert-'))
+  ORIGINAL_HOME = process.env['HOME']
+  process.env['HOME'] = TEST_HOME
+})
+
+afterEach(() => {
+  if (ORIGINAL_HOME !== undefined) {
+    process.env['HOME'] = ORIGINAL_HOME
+  } else {
+    delete process.env['HOME']
+  }
+  if (TEST_HOME && fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+  }
+})
+
+const cid = (s: string): CollisionId => s as CollisionId
+
+function makeSuggestion(args: {
+  source_path: string
+  identifier: string
+  applyAction: RenameSuggestion['applyAction']
+  suggested: string
+  author?: string
+  collisionId?: string
+}): RenameSuggestion {
+  const entry: InventoryEntry = {
+    kind: args.applyAction === 'rename_skill_dir_and_frontmatter' ? 'skill' : 'command',
+    source_path: args.source_path,
+    identifier: args.identifier,
+    triggerSurface: [args.identifier],
+    meta: args.author ? { author: args.author } : undefined,
+  }
+  return {
+    collisionId: cid(args.collisionId ?? 'test-collision-01'),
+    entry,
+    currentName: args.identifier,
+    suggested: args.suggested,
+    applyAction: args.applyAction,
+    reason: `collision test for ${args.identifier}`,
+  }
+}
+
+describe('applyRename — revert disambiguation (SMI-5671 Change 0)', () => {
+  it('reverts only the entry matching (auditId, collisionId) when 2 share one auditId', async () => {
+    const cmdDir = path.join(TEST_HOME, '.claude', 'commands')
+    await fsp.mkdir(cmdDir, { recursive: true })
+    const shipSrc = path.join(cmdDir, 'ship.md')
+    const deploySrc = path.join(cmdDir, 'deploy.md')
+    await fsp.writeFile(shipSrc, '---\nname: ship\n---\n', 'utf-8')
+    await fsp.writeFile(deploySrc, '---\nname: deploy\n---\n', 'utf-8')
+
+    const shipSuggestion = makeSuggestion({
+      source_path: shipSrc,
+      identifier: 'ship',
+      applyAction: 'rename_command_file',
+      suggested: 'anthropic-ship',
+      collisionId: 'collision-ship',
+    })
+    const deploySuggestion = makeSuggestion({
+      source_path: deploySrc,
+      identifier: 'deploy',
+      applyAction: 'rename_command_file',
+      suggested: 'anthropic-deploy',
+      collisionId: 'collision-deploy',
+    })
+
+    // One audit run resolved two collisions → two ledger entries, one auditId.
+    await applyRename({
+      suggestion: shipSuggestion,
+      request: { action: 'apply', auditId: 'audit_multi' },
+    })
+    await applyRename({
+      suggestion: deploySuggestion,
+      request: { action: 'apply', auditId: 'audit_multi' },
+    })
+    expect((await readLedger()).overrides).toHaveLength(2)
+
+    // Revert ONLY the ship rename by its collisionId.
+    const reverted = await applyRename({
+      suggestion: shipSuggestion,
+      request: { action: 'revert', auditId: 'audit_multi', collisionId: 'collision-ship' },
+    })
+    expect(reverted.success).toBe(true)
+    expect(reverted.error).toBeUndefined()
+
+    // ship is restored; deploy is untouched (still renamed).
+    expect(fs.existsSync(shipSrc)).toBe(true)
+    expect(fs.existsSync(path.join(cmdDir, 'anthropic-ship.md'))).toBe(false)
+    expect(fs.existsSync(deploySrc)).toBe(false)
+    expect(fs.existsSync(path.join(cmdDir, 'anthropic-deploy.md'))).toBe(true)
+
+    // Only the deploy entry survives in the ledger.
+    const ledger = await readLedger()
+    expect(ledger.overrides).toHaveLength(1)
+    expect(ledger.overrides[0]?.collisionId).toBe('collision-deploy')
+  })
+
+  it('falls back to a single legacy auditId-only entry that has no collisionId', async () => {
+    const cmdDir = path.join(TEST_HOME, '.claude', 'commands')
+    await fsp.mkdir(cmdDir, { recursive: true })
+    const src = path.join(cmdDir, 'ship.md')
+    await fsp.writeFile(src, '---\nname: ship\n---\n', 'utf-8')
+
+    const suggestion = makeSuggestion({
+      source_path: src,
+      identifier: 'ship',
+      applyAction: 'rename_command_file',
+      suggested: 'anthropic-ship',
+    })
+    await applyRename({
+      suggestion,
+      request: { action: 'apply', auditId: 'audit_legacy' },
+    })
+
+    // Simulate a pre-SMI-5671 ledger entry: strip the collisionId field so the
+    // sole entry for this auditId carries no collisionId at all.
+    const ledger = await readLedger()
+    for (const o of ledger.overrides) {
+      delete o.collisionId
+    }
+    await writeLedger(ledger)
+
+    // Revert by (auditId, collisionId): the collisionId matches nothing, but
+    // it's the ONLY entry for the auditId → safe back-compat fallback.
+    const reverted = await applyRename({
+      suggestion,
+      request: { action: 'revert', auditId: 'audit_legacy', collisionId: 'test-collision-01' },
+    })
+    expect(reverted.success).toBe(true)
+    expect(reverted.error).toBeUndefined()
+    expect(fs.existsSync(src)).toBe(true)
+    expect(fs.existsSync(path.join(cmdDir, 'anthropic-ship.md'))).toBe(false)
+    expect((await readLedger()).overrides).toHaveLength(0)
+  })
+
+  it('refuses with revert_ambiguous when 2+ legacy entries share an auditId', async () => {
+    const cmdDir = path.join(TEST_HOME, '.claude', 'commands')
+    await fsp.mkdir(cmdDir, { recursive: true })
+    const shipSrc = path.join(cmdDir, 'ship.md')
+    const deploySrc = path.join(cmdDir, 'deploy.md')
+    await fsp.writeFile(shipSrc, '---\nname: ship\n---\n', 'utf-8')
+    await fsp.writeFile(deploySrc, '---\nname: deploy\n---\n', 'utf-8')
+
+    const shipSuggestion = makeSuggestion({
+      source_path: shipSrc,
+      identifier: 'ship',
+      applyAction: 'rename_command_file',
+      suggested: 'anthropic-ship',
+      collisionId: 'collision-ship',
+    })
+    const deploySuggestion = makeSuggestion({
+      source_path: deploySrc,
+      identifier: 'deploy',
+      applyAction: 'rename_command_file',
+      suggested: 'anthropic-deploy',
+      collisionId: 'collision-deploy',
+    })
+    await applyRename({
+      suggestion: shipSuggestion,
+      request: { action: 'apply', auditId: 'audit_ambiguous' },
+    })
+    await applyRename({
+      suggestion: deploySuggestion,
+      request: { action: 'apply', auditId: 'audit_ambiguous' },
+    })
+
+    // Strip collisionId from BOTH entries → two legacy entries, one auditId.
+    const ledger = await readLedger()
+    for (const o of ledger.overrides) {
+      delete o.collisionId
+    }
+    await writeLedger(ledger)
+
+    // Revert with a collisionId that matches neither → must refuse, not guess.
+    const result = await applyRename({
+      suggestion: shipSuggestion,
+      request: { action: 'revert', auditId: 'audit_ambiguous', collisionId: 'collision-ship' },
+    })
+    expect(result.success).toBe(false)
+    expect(result.error?.kind).toBe('namespace.rename.revert_ambiguous')
+    if (result.error?.kind === 'namespace.rename.revert_ambiguous') {
+      expect(result.error.candidateCount).toBe(2)
+    }
+
+    // Nothing was reverted — both renames remain, both ledger entries intact.
+    expect(fs.existsSync(path.join(cmdDir, 'anthropic-ship.md'))).toBe(true)
+    expect(fs.existsSync(path.join(cmdDir, 'anthropic-deploy.md'))).toBe(true)
+    expect((await readLedger()).overrides).toHaveLength(2)
+  })
+})

--- a/packages/mcp-server/tests/unit/rename-engine.test.ts
+++ b/packages/mcp-server/tests/unit/rename-engine.test.ts
@@ -161,7 +161,7 @@ describe('applyRename — rename_command_file', () => {
     expect(fs.existsSync(result.toPath)).toBe(true)
     expect(fs.existsSync(src)).toBe(false)
     expect(result.summary).toBe(
-      'Renamed /ship → /anthropic-ship. To undo: sklx audit revert audit_01'
+      "Renamed /ship → /anthropic-ship. To undo: call apply_namespace_rename with auditId: 'audit_01', collisionId: 'test-collision-01', action: 'revert'."
     )
 
     const ledger = await readLedger()

--- a/packages/mcp-server/tests/unit/rename-engine.test.ts
+++ b/packages/mcp-server/tests/unit/rename-engine.test.ts
@@ -63,6 +63,7 @@ function makeSuggestion(args: {
   applyAction: RenameSuggestion['applyAction']
   suggested: string
   author?: string
+  collisionId?: string
 }): RenameSuggestion {
   const entry: InventoryEntry = {
     kind: args.applyAction === 'rename_skill_dir_and_frontmatter' ? 'skill' : 'command',
@@ -72,7 +73,7 @@ function makeSuggestion(args: {
     meta: args.author ? { author: args.author } : undefined,
   }
   return {
-    collisionId: cid('test-collision-01'),
+    collisionId: cid(args.collisionId ?? 'test-collision-01'),
     entry,
     currentName: args.identifier,
     suggested: args.suggested,
@@ -340,7 +341,7 @@ describe('applyRename — revert', () => {
 
     const reverted = await applyRename({
       suggestion,
-      request: { action: 'revert', auditId: 'audit_06' },
+      request: { action: 'revert', auditId: 'audit_06', collisionId: 'test-collision-01' },
     })
     expect(reverted.success).toBe(true)
     expect(fs.existsSync(src)).toBe(true)
@@ -367,11 +368,11 @@ describe('applyRename — revert', () => {
     })
     await applyRename({
       suggestion,
-      request: { action: 'revert', auditId: 'audit_07' },
+      request: { action: 'revert', auditId: 'audit_07', collisionId: 'test-collision-01' },
     })
     const second = await applyRename({
       suggestion,
-      request: { action: 'revert', auditId: 'audit_07' },
+      request: { action: 'revert', auditId: 'audit_07', collisionId: 'test-collision-01' },
     })
     expect(second.success).toBe(true)
     expect(second.fromPath).toBe(second.toPath)
@@ -396,7 +397,7 @@ describe('applyRename — revert', () => {
     })
     const reverted = await applyRename({
       suggestion,
-      request: { action: 'revert', auditId: 'audit_08' },
+      request: { action: 'revert', auditId: 'audit_08', collisionId: 'test-collision-01' },
     })
     expect(reverted.success).toBe(true)
     const restored = await fsp.readFile(path.join(skillDir, 'SKILL.md'), 'utf-8')


### PR DESCRIPTION
## Business Summary

**What shipped:** `apply_namespace_rename` can now revert a rename it previously applied — the CLI's advertised `sklx audit revert` command never existed, and the other undo tool (`undo_apply`) only works within the same MCP server process, so any rename applied in a prior session had no way back. Reverting now works from any session, disambiguated correctly even when one audit run resolved multiple collisions at once. The tool's own success message, which told users to run a command that doesn't exist, now names the real one.

**Quality bar:** Implementation split across two focused commits (the safety-critical ledger-lookup fix first, gated on its own tests before the rest proceeded), each independently re-verified — diffs reviewed, tests and typecheck re-run from scratch rather than trusting the implementing pass. Full `packages/mcp-server` + `packages/core` suites green (394 files / 7521 tests). A self-verification step the plan explicitly called for (confirming the shared audit-log helper still made sense for a revert) surfaced a real mislabeling bug, fixed in the same PR rather than deferred.

**Found along the way:** while fixing that mislabeling bug, spotted a sibling instance of the exact same broken-command citation in a different tool (`apply_recommended_edit`) — filed separately as SMI-5674 rather than folded in here, since that tool has no revert action to point the fix at yet (a distinct design decision).

**Net result:** Fully shipped, pending the live smoke test against a real pending ledger entry on this machine (next step after this PR merges) and the Linear/governance close-out.

---

## Technical detail

**Commit 1 (`f667aa71`) — Change 0, ledger lookup fix:** `revertRename()` looked up a ledger entry by `auditId` alone, first match wins. Since one `skill_inventory_audit` run can resolve 2+ collisions (appending 2+ ledger entries sharing an `auditId`), this was ambiguous — a revert could silently undo the wrong rename. Added optional `collisionId` to `OverrideRecord` (additive, no `CURRENT_VERSION` bump — historical entries have no reconstructable collision context), widened the revert request to require it, and rewrote the lookup: prefer an exact `(auditId, collisionId)` match → fall back to a single unambiguous legacy `auditId`-only entry → refuse with a new `namespace.rename.revert_ambiguous` error otherwise. `revertRename` split into its own `rename-engine.revert.ts` (and its tests into `rename-engine.revert.test.ts`) to stay under the repo's 500-line file gate.

**Commit 2 (`00041676`) — expose the revert action:**
- `apply_namespace_rename`'s Zod/JSON-Schema `action` enum widened to include `'revert'`; preview branch swaps `before`/`after` direction and adds a `direction` field; response gains `noOp` (surfacing the engine's existing idempotency signal explicitly).
- `buildSummary()`'s undo-hint text corrected to name the real mechanism and interpolate both `auditId` and `collisionId` (the old text only ever gave `auditId`, but Change 0 makes `collisionId` load-bearing for a correct revert). Same correction applied to two docstrings and `apply-journal.helpers.ts`'s module comment that repeated the broken citation.
- `undo_apply`'s `undo.no_session_applies` error and tool description now point callers at the durable revert path.
- **Journal-labeling fix (found during self-verification, not pre-planned):** the shared `journalApplySuccess` helper hardcoded `action: 'apply'` and treated any empty `backupRef` as proof nothing happened — but a revert never takes a fresh backup by design, even when it genuinely mutated a file, so every real revert was being journaled as an `idempotent_no_op` apply. Added an explicit `action`/`isNoOp` distinction (keyed off the engine's real `fromPath === toPath` signal, not `backupRef` alone) and widened `JournalAction` to a real `'revert'` value, bumping `JOURNAL_SCHEMA_VERSION` 1→2 since the reader's closed-set validation would otherwise flag a legitimate revert record as corrupt.
- Test coverage: apply→revert round-trip through the MCP tool layer (not just the engine), preview-direction assertion, no-op-revert case, collision-not-found-on-revert, a schema-drift guardrail (Zod enum vs hand-written JSON Schema enum), a disk-divergence-on-revert case, and two new assertions confirming the journal fix itself (a genuine revert is recorded as `'revert'` not `idempotent_no_op`; a genuine no-op still correctly gets `idempotent_no_op`).
- Diffed against the existing (unmerged) reference prototype `feat/apply-namespace-rename-revert-action` (`e4f0a3c9`) per the plan's requirement — verbatim overlaps were limited to mechanically-dictated expressions (enum value lists, the `isRevert` ternary shape), all independently arrived at rather than copied; Change 0's disambiguation logic has no prior in that branch at all.

**Plan:** `docs/internal/implementation/smi-5671-apply-namespace-rename-revert-action.md` (plan-reviewed, all 15 findings applied before implementation started).

**Refs:** SMI-5671. Follow-up filed: SMI-5674.