### PR TITLE
docs(changelog): Add SMI-5671 Unreleased entries (mcp-server, core)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: Widen `JournalAction` to include `'revert'` and bump `JOURNAL_SCHEMA_VERSION` 1→2 — an older reader's closed-set validation would otherwise flag a legitimate revert journal record as corrupt (SMI-5671) (#1878)
+
 ## v0.11.1
 
 - **Fix**: unified shutdown coordinator + awaitable sync stop (SMI-5649/SMI-5640) (#1826)

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: Expose `apply_namespace_rename`'s `action: 'revert'` — the CLI's `sklx audit revert` was never implemented and `undo_apply` only tracks same-process session state, so a rename applied in a prior session had no reachable undo path. Also fixes a shared journal-helper bug that mislabeled every genuine revert as an idempotent no-op apply (SMI-5671) (#1878)
+
 ## v0.7.3
 
 - **Fix**: Resolve real subscription tier via personal API key (#1870)


### PR DESCRIPTION
## Business Summary

**What shipped:** Backfilled changelog entries for SMI-5671's fix (PR #1878), which merged without updating either package's CHANGELOG — leaving it invisible to the release-prep tooling and unable to ever ship to real customers via npm.

**Net result:** Done. Next release-prep run will now correctly pick up both entries.

[skip-impl-check]