### PR TITLE
chore(release): bump core 0.11.2, mcp-server 0.7.4, cli 0.8.2, vscode 0.7.2, enterprise 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32752,7 +32752,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
@@ -32783,8 +32783,8 @@
         "sklx": "dist/cli.js"
       },
       "devDependencies": {
-        "@skillsmith/core": "^0.11.1",
-        "@skillsmith/mcp-server": "^0.7.3",
+        "@skillsmith/core": "^0.11.2",
+        "@skillsmith/mcp-server": "^0.7.4",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
         "vitest": "4.1.10"
@@ -33098,7 +33098,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -33477,18 +33477,18 @@
     },
     "packages/enterprise": {
       "name": "@smith-horn/enterprise",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1083.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-        "@skillsmith/core": "^0.11.1",
+        "@skillsmith/core": "^0.11.2",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.7.3",
+        "@skillsmith/mcp-server": "^0.7.4",
         "@smithy/config-resolver": "4.6.7",
         "@smithy/core": "3.29.2",
         "@smithy/middleware-endpoint": "4.6.7",
@@ -33503,7 +33503,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.7.3"
+        "@skillsmith/mcp-server": "^0.7.4"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -33539,11 +33539,11 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.11.1",
+        "@skillsmith/core": "^0.11.2",
         "ulid": "3.0.1",
         "zod": "3.25.76"
       },
@@ -33930,7 +33930,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.8.2
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.8.1).
+
 ## v0.8.1
 
 - **Cadence**: Mechanical cadence alignment (no changes since v0.8.0).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -39,8 +39,8 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@skillsmith/core": "^0.11.1",
-    "@skillsmith/mcp-server": "^0.7.3",
+    "@skillsmith/core": "^0.11.2",
+    "@skillsmith/mcp-server": "^0.7.4",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",
     "vitest": "4.1.10"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.11.2
+
+- **Fix**: Expose apply_namespace_rename action:'revert'
 - **Fix**: Widen `JournalAction` to include `'revert'` and bump `JOURNAL_SCHEMA_VERSION` 1→2 — an older reader's closed-set validation would otherwise flag a legitimate revert journal record as corrupt (SMI-5671) (#1878)
 
 ## v0.11.1

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.11.1'
+export const VERSION = '0.11.2'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+## v0.3.2
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.3.1).
+
 ## v0.3.1
 
 - **Cadence**: Mechanical cadence alignment (no changes since v0.3.0).

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smith-horn/enterprise",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Enterprise features for Skillsmith including audit logging, SSO, and RBAC",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1083.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.73.0",
-    "@skillsmith/core": "^0.11.1",
+    "@skillsmith/core": "^0.11.2",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.7.3",
+    "@skillsmith/mcp-server": "^0.7.4",
     "@smithy/config-resolver": "4.6.7",
     "@smithy/core": "3.29.2",
     "@smithy/middleware-endpoint": "4.6.7",
@@ -62,7 +62,7 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.7.3"
+    "@skillsmith/mcp-server": "^0.7.4"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.7.4
+
+- **Fix**: Expose apply_namespace_rename action:'revert'
 - **Fix**: Expose `apply_namespace_rename`'s `action: 'revert'` — the CLI's `sklx audit revert` was never implemented and `undo_apply` only tracks same-process session state, so a rename applied in a prior session had no reachable undo path. Also fixes a shared journal-helper bug that mislabeled every genuine revert as an idempotent no-op apply (SMI-5671) (#1878)
 
 ## v0.7.3

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.11.1",
+    "@skillsmith/core": "^0.11.2",
     "ulid": "3.0.1",
     "zod": "3.25.76"
   },

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.7.3",
+  "version": "0.7.4",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -111,7 +111,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.7.3'
+const PACKAGE_VERSION = '0.7.4'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 const logger = createLogger('mcp', { version: PACKAGE_VERSION }) // SMI-5615
 import { installBundledSkills, installUserDocs } from './onboarding/install-assets.js'

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## v0.7.2
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.7.1).
+
 ## v0.7.1
 
 - **Cadence**: Mechanical cadence alignment (no changes since v0.7.0).

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Discover and install agent skills directly in VS Code",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
Release prep for SMI-5671's fix (undo/revert capability) reaching real customers via npm — the fix merged in PR #1878 but wasn't picked up by any release since.

Bumps all 5 packages per the established cadence pattern (ADR-114).

[skip-impl-check]