### PR TITLE
fix(statusline): Point tier-1 at local ruflo bin, not npx

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -198,6 +198,6 @@
   "enabledMcpjsonServers": ["skillsmith", "skillsmith-doc-retrieval", "ruflo"],
   "statusLine": {
     "type": "command",
-    "command": "npx -y ruflo@3.14.2 hooks statusline || node .claude/helpers/statusline.cjs || echo RuFlo V3"
+    "command": "node node_modules/ruflo/bin/ruflo.js hooks statusline || node .claude/helpers/statusline.cjs || echo RuFlo V3"
   }
 }


### PR DESCRIPTION
## Business Summary

**What shipped:** The Ruflo statusline, which had stopped displaying entirely, now renders reliably again.

**Quality bar:** Root-caused with live timing measurements (not guesswork), verified against a schema-accurate synthetic payload, and confirmed the fallback path still works when forced to fail. `/governance` retro ran clean.

**Found along the way:** N/A — this is itself the fix for a regression introduced by an earlier PR (SMI-5399/#1576).

**Net result:** Fully shipped. One open, non-blocking question tracked in SMI-5679: whether the live session shows a context/token-usage segment from the older local `ruflo` bin — needs a real in-session check, not resolvable via synthetic testing.

---

## Technical detail

`.claude/settings.json`'s `statusLine` tier-1 command was `npx -y ruflo@3.14.2 hooks statusline` (shipped in SMI-5399/#1576 as a workaround for a `package.json` bump that would've pulled in 9 high-severity vulnerabilities). That command takes a measured ~2.0-2.1s per call — npx does a registry round-trip even for an exact pinned version. Claude Code cancels an in-flight statusLine command outright (no `||` fallback) when a new update fires before the previous one finishes, and updates fire on every assistant message — so in an actively-worked session the ~2s tier-1 was chronically killed before it could render.

Fix repoints tier-1 at the already-installed local bin: `node node_modules/ruflo/bin/ruflo.js hooks statusline`. This is what SMI-5399's own reviewed plan (Wave 3) specified before implementation substituted the npx command. Measured ~0.25-0.42s per call, well under the per-message refresh cadence. Verified the bin path matches `node_modules/ruflo/package.json`'s declared `bin` field, and live-tested a forced tier-1 failure to confirm the tier-2 (`.claude/helpers/statusline.cjs`) fallback still renders correctly.

Second commit bumps the `docs/internal` submodule pointer to include the code review report (skillsmith-docs PR #417, open).

Refs SMI-5679

[skip-impl-check] — config-only change (.claude/settings.json + docs/internal submodule pointer), no packages/*/src code to add.
