### PR TITLE
fix(agent-evals): Use a real, resolvable skill for the vet-before-install job

### DIFF
--- a/scripts/agent-evals/README.md
+++ b/scripts/agent-evals/README.md
@@ -29,7 +29,7 @@ in [`packages/core/src/services/agent-pack/prompt-source.ts`](../../packages/cor
 
 1. **keep-current** — "What skills do I have installed that are outdated, and what changed?"
 2. **audit-fix** — "Audit my installed skills for namespace collisions or issues, and tell me what you would fix. Do not apply anything yet."
-3. **vet-before-install** — "I am thinking about installing the skill anthropic/commit. Look it up and tell me whether it is safe to install."
+3. **vet-before-install** — "I am thinking about installing the skill getsentry/commit. Look it up and tell me whether it is safe to install."
 
 (`find-recommend`, the fourth pack job, is routing-only per the plan and is
 not part of the MVP eval matrix.)

--- a/scripts/agent-evals/claude.sh
+++ b/scripts/agent-evals/claude.sh
@@ -36,6 +36,6 @@ run_job "$LOG" "audit-fix" -- claude -p \
   "Audit my installed skills for namespace collisions or issues, and tell me what you would fix. Do not apply anything yet."
 
 run_job "$LOG" "vet-before-install" -- claude -p \
-  "I am thinking about installing the skill anthropic/commit. Look it up and tell me whether it is safe to install."
+  "I am thinking about installing the skill getsentry/commit. Look it up and tell me whether it is safe to install."
 
 echo "[agent-eval] done -- see $LOG"

--- a/scripts/agent-evals/codex.sh
+++ b/scripts/agent-evals/codex.sh
@@ -33,6 +33,6 @@ run_job "$LOG" "audit-fix" -- codex exec \
   "Audit my installed skills for namespace collisions or issues, and tell me what you would fix. Do not apply anything yet."
 
 run_job "$LOG" "vet-before-install" -- codex exec \
-  "I am thinking about installing the skill anthropic/commit. Look it up and tell me whether it is safe to install."
+  "I am thinking about installing the skill getsentry/commit. Look it up and tell me whether it is safe to install."
 
 echo "[agent-eval] done -- see $LOG"

--- a/scripts/agent-evals/copilot.sh
+++ b/scripts/agent-evals/copilot.sh
@@ -43,6 +43,6 @@ run_job "$LOG" "audit-fix" -- copilot -p \
   "Audit my installed skills for namespace collisions or issues, and tell me what you would fix. Do not apply anything yet." --allow-all-tools
 
 run_job "$LOG" "vet-before-install" -- copilot -p \
-  "I am thinking about installing the skill anthropic/commit. Look it up and tell me whether it is safe to install." --allow-all-tools
+  "I am thinking about installing the skill getsentry/commit. Look it up and tell me whether it is safe to install." --allow-all-tools
 
 echo "[agent-eval] done -- see $LOG"

--- a/scripts/agent-evals/cursor.sh
+++ b/scripts/agent-evals/cursor.sh
@@ -38,6 +38,6 @@ run_job "$LOG" "audit-fix" -- cursor-agent -p --force --output-format json \
   "Audit my installed skills for namespace collisions or issues, and tell me what you would fix. Do not apply anything yet."
 
 run_job "$LOG" "vet-before-install" -- cursor-agent -p --force --output-format json \
-  "I am thinking about installing the skill anthropic/commit. Look it up and tell me whether it is safe to install."
+  "I am thinking about installing the skill getsentry/commit. Look it up and tell me whether it is safe to install."
 
 echo "[agent-eval] done -- see $LOG"

--- a/scripts/agent-evals/opencode.sh
+++ b/scripts/agent-evals/opencode.sh
@@ -34,6 +34,6 @@ run_job "$LOG" "audit-fix" -- opencode run \
   "Audit my installed skills for namespace collisions or issues, and tell me what you would fix. Do not apply anything yet."
 
 run_job "$LOG" "vet-before-install" -- opencode run \
-  "I am thinking about installing the skill anthropic/commit. Look it up and tell me whether it is safe to install."
+  "I am thinking about installing the skill getsentry/commit. Look it up and tell me whether it is safe to install."
 
 echo "[agent-eval] done -- see $LOG"


### PR DESCRIPTION
## Business Summary

**What shipped:** The `vet-before-install` MVP job in all 5 harness eval scripts (Codex, Cursor, Copilot, Claude, OpenCode) used to ask agents to vet `anthropic/commit` — a skill that doesn't exist in the registry, so the job could only ever exercise the 'candidate not found' refusal path. Swapped to `getsentry/commit`, a real, verified skill (confirmed live during this session's Codex UAT: risk 0/100, quality 86/100), so the job can now also test the correct positive-recommendation path.

**Quality bar:** Mechanical, single-string swap across 5 shell scripts + their README, syntax-checked, no test files reference the old string.

**Net result:** Fully shipped. Closes a follow-up noted (but not yet actioned) during this session's SMI-5459 UAT sign-off.

[skip-impl-check]