### PR TITLE
feat(scripts): Add CHANGELOG entry gate (SMI-5680)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1076,6 +1076,13 @@ jobs:
         run: npm run -w packages/vscode-extension typecheck:e2e
 
       - name: Run standards audit
+        env:
+          # SMI-5680 H1: feeds Check 54's [skip-changelog-check] opt-out
+          # marker detection. Zero-cost — github.event.pull_request.body is
+          # already part of the pull_request event payload (this job's
+          # trigger, see the on: block above); no new permission grant or API
+          # call needed. Mirrors concurrency-audit-pr.yml's PR_BODY wiring.
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: npm run audit:standards
 
   # SMI-2192: Matrix-based test execution for affected packages

--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -1888,3 +1888,140 @@ export function findServerJsonFieldLengthViolations(
 
   return violations
 }
+
+// -----------------------------------------------------------------------------
+// Check 54 helpers — SMI-5680: CHANGELOG entry gate.
+//
+// Powers audit-standards.mjs Check 54: a PR touching a released package's
+// non-test src/** must also grow that package's CHANGELOG.md `## [Unreleased]`
+// section in the same diff. PR #1878 (SMI-5671) merged real source changes to
+// packages/mcp-server/src/** and packages/core/src/** with zero CHANGELOG
+// entries in either package — nothing caught it (backfilled manually in PR
+// #1881). See docs/internal/implementation/smi-5680-changelog-entry-gate.md
+// for the full VP-reviewed design.
+//
+// Both helpers are pure: no git, no fs. Check 54 in audit-standards.mjs does
+// all I/O (git show <ref>:<path>, package.json/CHANGELOG.md reads) and passes
+// plain strings in.
+// -----------------------------------------------------------------------------
+
+/**
+ * Count qualifying entries in a CHANGELOG's `## [Unreleased]` section.
+ *
+ * The section runs from the `## [Unreleased]` heading (case-insensitive,
+ * optional surrounding brackets, e.g. `## Unreleased` or `## [Unreleased]`) to
+ * the next `## ` heading, or EOF if there is none. A "qualifying" entry is a
+ * non-blank line with >= 4 whitespace-separated tokens (SMI-5680 L1) — a lone
+ * `-` or a two-word `- fix` bullet doesn't count, closing the cheapest
+ * bad-faith case (a single throwaway character/word satisfying the gate).
+ * This is deliberately not a content-quality judgment — PR #1878's incident
+ * was "zero entries," a presence problem, not a quality one.
+ *
+ * @param {string} changelogContent - Full CHANGELOG.md contents.
+ * @returns {number | null} Qualifying entry count, or `null` — the SENTINEL
+ *   value — when the `## [Unreleased]` heading itself cannot be found (missing
+ *   or malformed file). Check 54 turns a `null` return into a `warn()`, not a
+ *   `fail()` (mirrors Check 47's "could not parse — warn" convention for a
+ *   file the check cannot safely reason about) rather than treating an
+ *   unparseable file as "0 entries" and risking a false fail().
+ */
+export function countUnreleasedEntries(changelogContent) {
+  if (typeof changelogContent !== 'string') return null
+  const lines = changelogContent.split('\n')
+  const unreleasedIdx = lines.findIndex((l) => /^## \[?Unreleased\]?\s*$/i.test(l.trim()))
+  if (unreleasedIdx === -1) return null // sentinel: heading missing/malformed
+
+  let count = 0
+  for (let i = unreleasedIdx + 1; i < lines.length; i++) {
+    const trimmed = lines[i].trim()
+    if (/^## /.test(trimmed)) break // next heading — [Unreleased] section ends here
+    if (trimmed === '') continue
+    const tokenCount = trimmed.split(/\s+/).filter(Boolean).length
+    if (tokenCount >= 4) count++
+  }
+  return count
+}
+
+/**
+ * Detect a release-prep diff for one package (SMI-5680 C1 / Step 0).
+ *
+ * `prepare-release.ts --all=patch` bumps a package's `package.json` version
+ * AND drains (not grows) its CHANGELOG's `## [Unreleased]` section by moving
+ * any content there into a newly-inserted `## vX.Y.Z` heading directly below
+ * `## [Unreleased]` — exactly the shape `insertVersionSection`
+ * (scripts/lib/release-changelog.ts) produces. A naive line-count comparison
+ * therefore sees the Unreleased section SHRINK on every release commit, which
+ * would fail Check 54 on every core/mcp-server release forever without this
+ * exemption. Verified against this repo's actual release commit `2e31a616`
+ * ("chore(release): bump core 0.11.2..."): packages/core/CHANGELOG.md's
+ * Unreleased body went from 1 non-blank line to 0, with the new `## v0.11.2`
+ * heading inserted directly below `## [Unreleased]`, and
+ * packages/core/src/index.ts's VERSION const changed in the same commit.
+ *
+ * Returns true iff BOTH:
+ *   1. `pkgJsonAtBase`'s and `pkgJsonAtHead`'s `"version"` fields are valid
+ *      strings and differ (a real version bump happened in this diff), AND
+ *   2. The `## ` heading found DIRECTLY below `## [Unreleased]` (skipping
+ *      only blank lines) in `changelogAtHead` is exactly `v<newVersion>`, AND
+ *      that same heading is NOT found directly below `## [Unreleased]` in
+ *      `changelogAtBase` (it's new in this diff, not pre-existing).
+ *
+ * Malformed/unparseable package.json JSON, or a missing/non-string
+ * `"version"` field, fails safe by returning `false` — Check 54 then falls
+ * through to the normal count-comparison path rather than silently exempting
+ * a package it can't actually verify is mid-release.
+ *
+ * Known limitation (accepted, per plan): a bad-faith PR could fake this exact
+ * signature (a version-looking bump + a matching heading insertion) to
+ * smuggle an undocumented change past the gate. `prepare-release.ts`'s
+ * commits are mechanical and run separately from feature work in practice
+ * (every release commit in this repo's history only touches
+ * package.json/CHANGELOG.md/package-lock.json/the version-const
+ * file/server.json) — defending against a deliberately-forged release
+ * signature is a different problem than the accidental-omission gap this
+ * check closes (matches Check 51's own "acceptable scope for a file-level
+ * static check" precedent for a comparable limitation).
+ *
+ * @param {string} pkgJsonAtBase - packages/<dir>/package.json contents at mergeBase.
+ * @param {string} pkgJsonAtHead - packages/<dir>/package.json contents at HEAD.
+ * @param {string} changelogAtBase - packages/<dir>/CHANGELOG.md contents at mergeBase.
+ * @param {string} changelogAtHead - packages/<dir>/CHANGELOG.md contents at HEAD.
+ * @returns {boolean}
+ */
+export function isReleasePrepDiff(pkgJsonAtBase, pkgJsonAtHead, changelogAtBase, changelogAtHead) {
+  const parseVersion = (raw) => {
+    if (typeof raw !== 'string') return null
+    try {
+      const parsed = JSON.parse(raw)
+      return typeof parsed?.version === 'string' ? parsed.version : null
+    } catch {
+      return null
+    }
+  }
+
+  const baseVersion = parseVersion(pkgJsonAtBase)
+  const headVersion = parseVersion(pkgJsonAtHead)
+  if (!baseVersion || !headVersion || baseVersion === headVersion) return false
+
+  // Return the (trimmed, without '## ') text of the first `## ` heading
+  // appearing directly below `## [Unreleased]` — skipping only blank lines —
+  // or null if `[Unreleased]` is absent, has no following heading, or the
+  // very next non-blank line is itself an entry (not a heading).
+  const headingDirectlyBelowUnreleased = (changelogContent) => {
+    if (typeof changelogContent !== 'string') return null
+    const lines = changelogContent.split('\n')
+    const unreleasedIdx = lines.findIndex((l) => /^## \[?Unreleased\]?\s*$/i.test(l.trim()))
+    if (unreleasedIdx === -1) return null
+    for (let i = unreleasedIdx + 1; i < lines.length; i++) {
+      const trimmed = lines[i].trim()
+      if (trimmed === '') continue
+      const m = trimmed.match(/^## (.+)$/)
+      return m ? m[1].trim() : null
+    }
+    return null
+  }
+
+  const expectedHeading = `v${headVersion}`
+  if (headingDirectlyBelowUnreleased(changelogAtHead) !== expectedHeading) return false
+  return headingDirectlyBelowUnreleased(changelogAtBase) !== expectedHeading
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -39,11 +39,15 @@ import {
   findFunctionsWithoutSearchPath,
   auditSecdefAnonGrants,
   findServerJsonFieldLengthViolations,
+  countUnreleasedEntries,
+  isReleasePrepDiff,
 } from './audit-standards-helpers.mjs'
 import { VERCEL_JSON_SHARED_FIELDS, validateVercelJsonSync } from './audit-vercel-sync-helpers.mjs'
 import { findRealpathAsymmetry } from './audit-realpath-asymmetry-helpers.mjs'
 import { findUnpinnedActionUses } from './audit-workflow-sha-pin-helpers.mjs'
 import { countToolDefinitions } from './audit-mcp-tool-count-helpers.mjs'
+import { TEST_PATTERNS } from './ci/source-patterns.mjs'
+import { PACKAGE_SPECS } from './lib/version-utils.ts'
 
 const RED = '\x1b[31m'
 const GREEN = '\x1b[32m'
@@ -4577,6 +4581,182 @@ console.log(`\n${BOLD}Check 53: MCP registry server.json field-length limits (SM
     } catch (e) {
       warn(`Check 53: could not parse ${SERVER_JSON_PATH}: ${e.message}`)
     }
+  }
+}
+
+// Check 54: CHANGELOG entry gate (SMI-5680)
+//
+// PR #1878 (SMI-5671) merged real source changes to packages/mcp-server/src/**
+// and packages/core/src/** with zero CHANGELOG.md entries in either package —
+// nothing caught it (backfilled manually in PR #1881). This check fails a PR
+// that touches a released package's non-test src/** with no matching growth
+// in that package's CHANGELOG.md `## [Unreleased]` section, in the same diff.
+// Ships as fail() from day one — no warn-only burn-in (see plan §3 / C2).
+// See docs/internal/implementation/smi-5680-changelog-entry-gate.md for the
+// full VP-reviewed design.
+console.log(`\n${BOLD}54. CHANGELOG Entry Gate (SMI-5680)${RESET}`)
+console.log('(content, not placement — see Check 43 for heading order)')
+{
+  const SKIP_MARKER = '[skip-changelog-check]'
+  const PR_BODY = process.env.PR_BODY || ''
+  const skipAcknowledged = PR_BODY.includes(SKIP_MARKER)
+  if (skipAcknowledged) {
+    console.log(
+      `::notice::${SKIP_MARKER} opt-out found in PR body — Check 54 will report findings but not fail.`
+    )
+    // L3: log the paragraph following the marker for audit trail, matching
+    // concurrency-audit-pr.yml's ::group::Acknowledgement reason pattern.
+    const idx = PR_BODY.indexOf(SKIP_MARKER)
+    const after = PR_BODY.slice(idx + SKIP_MARKER.length)
+    const reasonParagraph = after.split(/\n\s*\n/)[0].trim()
+    console.log('::group::Acknowledgement reason')
+    console.log(reasonParagraph || '(no reason paragraph found immediately after the marker)')
+    console.log('::endgroup::')
+  }
+
+  let mergeBase = null
+  let skipReason = null
+  try {
+    const baseRef = process.env.GITHUB_BASE_REF
+    if (baseRef && baseRef.length > 0) {
+      // PR context: resolve the merge-base SHA, matching Checks 50/51.
+      mergeBase = execSync(`git merge-base origin/${baseRef} HEAD`, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim()
+    } else {
+      // Local run (no PR base ref). Fall back to origin/main if present; else skip.
+      const originMain = execSync('git rev-parse --verify --quiet origin/main || true', {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim()
+      if (!originMain) {
+        skipReason = 'no origin/main ref (shallow/local)'
+      } else {
+        mergeBase = execSync('git merge-base origin/main HEAD', {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim()
+      }
+    }
+  } catch (e) {
+    // Shallow clone, detached HEAD, no base — must NOT false-fail. Mirrors
+    // Checks 45/50/51's catch-and-skip behaviour.
+    skipReason = e.message
+  }
+
+  if (skipReason) {
+    pass(`Check 54: CHANGELOG entry gate skipped (${skipReason})`)
+  } else {
+    const gitShow = (ref, path) => {
+      try {
+        return execSync(`git show ${ref}:${path}`, {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
+      } catch {
+        return null // file absent at this ref (or unreadable) — caller degrades gracefully
+      }
+    }
+
+    let touchedTotal = 0
+    let touchedMissing = 0
+
+    for (const spec of PACKAGE_SPECS) {
+      // H2: path construction always uses spec.dir ('packages/vscode-extension'),
+      // never spec.shortName ('vscode') — the shortName has no corresponding
+      // directory and would silently exempt vscode-extension from this gate.
+      const pkgDir = spec.dir
+      const pkg = pkgDir.replace(/^packages\//, '')
+
+      let changedFiles = []
+      try {
+        changedFiles = execSync(`git diff --name-only ${mergeBase}...HEAD -- ${pkgDir}/src/`, {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
+          .split('\n')
+          .filter(Boolean)
+      } catch {
+        changedFiles = []
+      }
+
+      // M1: exclude test files via the shared TEST_PATTERNS export
+      // (scripts/ci/source-patterns.mjs) rather than reinventing a third ad
+      // hoc test-file regex.
+      const nonTestChanged = changedFiles.filter((f) => !TEST_PATTERNS.some((p) => p.test(f)))
+      if (nonTestChanged.length === 0) continue // nothing to check for this package
+
+      touchedTotal++
+
+      const changelogPath = `${pkgDir}/CHANGELOG.md`
+      const pkgJsonAtBase = gitShow(mergeBase, spec.packageJsonPath)
+      const pkgJsonAtHead = gitShow('HEAD', spec.packageJsonPath)
+      const changelogAtBase = gitShow(mergeBase, changelogPath)
+      const changelogAtHead = gitShow('HEAD', changelogPath)
+
+      // Step 0 (C1): release-prep commits drain, not grow, [Unreleased] —
+      // exempt them structurally rather than false-failing every
+      // core/mcp-server release PR forever.
+      if (
+        pkgJsonAtBase &&
+        pkgJsonAtHead &&
+        changelogAtBase &&
+        changelogAtHead &&
+        isReleasePrepDiff(pkgJsonAtBase, pkgJsonAtHead, changelogAtBase, changelogAtHead)
+      ) {
+        pass(
+          `Check 54: packages/${pkg} — release-prep commit detected (version bump + CHANGELOG version-section insertion); [Unreleased] growth not required`
+        )
+        continue
+      }
+
+      if (changelogAtHead === null) {
+        warn(`Check 54: ${changelogPath} not found at HEAD — cannot verify [Unreleased] growth`)
+        continue
+      }
+
+      const headCount = countUnreleasedEntries(changelogAtHead)
+      const baseCount = changelogAtBase === null ? 0 : countUnreleasedEntries(changelogAtBase)
+
+      // Sentinel (null): '## [Unreleased]' heading missing/malformed — cannot
+      // safely reason about growth. Warn, don't fail (mirrors Check 47's
+      // "could not parse — warn" convention for a file the check can't
+      // safely reason about).
+      if (headCount === null || baseCount === null) {
+        warn(
+          `Check 54: ${changelogPath}'s '## [Unreleased]' heading could not be found/parsed — skipping content-growth check`
+        )
+        continue
+      }
+
+      if (headCount > baseCount) {
+        pass(`Check 54: ${changelogPath}'s [Unreleased] section grew (${baseCount} → ${headCount})`)
+      } else if (skipAcknowledged) {
+        pass(
+          `Check 54: packages/${pkg} — [skip-changelog-check] acknowledged; [Unreleased] growth not required`
+        )
+      } else {
+        touchedMissing++
+        fail(
+          `Check 54: packages/${pkg}/src/** changed (${nonTestChanged.join(', ')}) with no new content in packages/${pkg}/CHANGELOG.md's '## [Unreleased]' section`,
+          `Add a bullet under '## [Unreleased]' in packages/${pkg}/CHANGELOG.md describing this change. ` +
+            `If this is a revert of work that was never released, or another package's entry already covers this change, add '[skip-changelog-check]' plus a reason paragraph to the PR body — see docs/internal/process/guards-and-opt-outs.md.`
+        )
+      }
+    }
+
+    if (touchedTotal === 0) {
+      pass('Check 54: no packages had src/** changes requiring a CHANGELOG entry in this diff')
+    }
+
+    // M7: rollup tally as a plain console.log — NOT a second pass()/fail()
+    // call (would double-increment the global counters) — so a multi-package
+    // PR's earlier per-package pass() can't be misread as an overall pass
+    // while a later fail() for a different package goes unnoticed.
+    console.log(
+      `Check 54: ${touchedMissing}/${touchedTotal} touched package(s) missing a CHANGELOG entry — see above`
+    )
   }
 }
 

--- a/scripts/tests/audit-standards-changelog-gate.test.ts
+++ b/scripts/tests/audit-standards-changelog-gate.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for the SMI-5680 CHANGELOG entry gate helpers.
+ *
+ * Covers `countUnreleasedEntries` and `isReleasePrepDiff` in
+ * audit-standards-helpers.mjs. Background: PR #1878 (SMI-5671) merged real
+ * source changes to packages/mcp-server/src/** and packages/core/src/** with
+ * zero CHANGELOG.md entries in either package — nothing caught it. These two
+ * pure helpers are the logic layer; Check 54 in audit-standards.mjs provides
+ * the git I/O layer (mergeBase/HEAD reads via `git show`).
+ *
+ * See docs/internal/implementation/smi-5680-changelog-entry-gate.md for the
+ * full VP-reviewed design, including the Step 0 release-prep exemption this
+ * file's `isReleasePrepDiff` suite verifies against the actual shape of
+ * commit 2e31a616 ("chore(release): bump core 0.11.2...").
+ */
+import { describe, expect, it } from 'vitest'
+
+const helpers = (await import('../audit-standards-helpers.mjs')) as {
+  countUnreleasedEntries: (changelogContent: string) => number | null
+  isReleasePrepDiff: (
+    pkgJsonAtBase: string,
+    pkgJsonAtHead: string,
+    changelogAtBase: string,
+    changelogAtHead: string
+  ) => boolean
+}
+
+const { countUnreleasedEntries, isReleasePrepDiff } = helpers
+
+// ---------------------------------------------------------------------------
+// countUnreleasedEntries
+// ---------------------------------------------------------------------------
+
+describe('countUnreleasedEntries (SMI-5680)', () => {
+  it('empty section: heading present, no content below it → 0', () => {
+    const changelog = [
+      '# Changelog',
+      '',
+      'All notable changes to `@skillsmith/core` are documented here.',
+      '',
+      '## [Unreleased]',
+      '',
+      '## v0.11.1',
+      '',
+      '- **Fix**: something already released',
+      '',
+    ].join('\n')
+    expect(countUnreleasedEntries(changelog)).toBe(0)
+  })
+
+  it('single qualifying entry: >= 4 whitespace-separated tokens → 1', () => {
+    const changelog = [
+      '## [Unreleased]',
+      '',
+      '- **Fix**: Widen `JournalAction` to include revert',
+      '',
+      '## v0.11.1',
+    ].join('\n')
+    expect(countUnreleasedEntries(changelog)).toBe(1)
+  })
+
+  it('single junk (<4-token) entry does NOT count (SMI-5680 L1) → 0', () => {
+    const changelog = ['## [Unreleased]', '', '- fix', '', '## v0.11.1'].join('\n')
+    expect(countUnreleasedEntries(changelog)).toBe(0)
+  })
+
+  it('a lone dash bullet does NOT count → 0', () => {
+    const changelog = ['## [Unreleased]', '', '-', '', '## v0.11.1'].join('\n')
+    expect(countUnreleasedEntries(changelog)).toBe(0)
+  })
+
+  it('multiple entries: qualifying + junk mixed → counts only qualifying lines', () => {
+    const changelog = [
+      '## [Unreleased]',
+      '',
+      '- **Fix**: Widen JournalAction to include revert',
+      '- fix',
+      '- **Feature**: Add another cool thing entirely',
+      '',
+      '## v0.11.1',
+    ].join('\n')
+    expect(countUnreleasedEntries(changelog)).toBe(2)
+  })
+
+  it('entries after the next ## heading are NOT counted (section boundary)', () => {
+    const changelog = [
+      '## [Unreleased]',
+      '',
+      '- **Fix**: Widen JournalAction to include revert',
+      '',
+      '## v0.11.1',
+      '',
+      '- **Fix**: A previously released four token entry',
+    ].join('\n')
+    expect(countUnreleasedEntries(changelog)).toBe(1)
+  })
+
+  it('missing heading returns the sentinel (null), not 0', () => {
+    const changelog = ['# Changelog', '', '## v0.11.1', '', '- **Fix**: something'].join('\n')
+    expect(countUnreleasedEntries(changelog)).toBeNull()
+  })
+
+  it('malformed heading text (typo) returns the sentinel (null)', () => {
+    const changelog = ['# Changelog', '', '## Unrelesed', '', '- **Fix**: something'].join('\n')
+    expect(countUnreleasedEntries(changelog)).toBeNull()
+  })
+
+  it('non-string input returns the sentinel (null)', () => {
+    // @ts-expect-error — deliberately exercising the defensive typeof guard
+    expect(countUnreleasedEntries(undefined)).toBeNull()
+  })
+
+  it('accepts the bracket-less "## Unreleased" heading form too', () => {
+    const changelog = ['## Unreleased', '', '- **Fix**: Widen JournalAction to revert'].join('\n')
+    expect(countUnreleasedEntries(changelog)).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isReleasePrepDiff
+// ---------------------------------------------------------------------------
+
+// Real package.json / CHANGELOG.md shapes lifted from this repo's actual
+// release commit 2e31a616 ("chore(release): bump core 0.11.2, mcp-server
+// 0.7.4, cli 0.8.2, vscode 0.7.2, enterprise 0.3.2"). Confirmed via
+// `git show 2e31a616 -- packages/core/CHANGELOG.md packages/core/package.json`.
+const CORE_PKG_JSON_BASE = JSON.stringify({ name: '@skillsmith/core', version: '0.11.1' })
+const CORE_PKG_JSON_HEAD = JSON.stringify({ name: '@skillsmith/core', version: '0.11.2' })
+
+const CORE_CHANGELOG_BASE = [
+  '# Changelog',
+  '',
+  'All notable changes to `@skillsmith/core` are documented here.',
+  '',
+  '## [Unreleased]',
+  '',
+  "- **Fix**: Widen `JournalAction` to include `'revert'` and bump `JOURNAL_SCHEMA_VERSION` 1→2 — an older reader's closed-set validation would otherwise flag a legitimate revert journal record as corrupt (SMI-5671) (#1878)",
+  '',
+  '## v0.11.1',
+  '',
+  '- **Fix**: unified shutdown coordinator + awaitable sync stop (SMI-5649/SMI-5640) (#1826)',
+].join('\n')
+
+// insertVersionSection's actual output shape (scripts/lib/release-changelog.ts):
+// `## [Unreleased]` stays on top (now empty), the carried-forward entry is
+// re-parented under the newly-inserted `## v0.11.2` heading directly below it.
+const CORE_CHANGELOG_HEAD = [
+  '# Changelog',
+  '',
+  'All notable changes to `@skillsmith/core` are documented here.',
+  '',
+  '## [Unreleased]',
+  '',
+  '## v0.11.2',
+  '',
+  "- **Fix**: Expose apply_namespace_rename action:'revert'",
+  "- **Fix**: Widen `JournalAction` to include `'revert'` and bump `JOURNAL_SCHEMA_VERSION` 1→2 — an older reader's closed-set validation would otherwise flag a legitimate revert journal record as corrupt (SMI-5671) (#1878)",
+  '',
+  '## v0.11.1',
+  '',
+  '- **Fix**: unified shutdown coordinator + awaitable sync stop (SMI-5649/SMI-5640) (#1826)',
+].join('\n')
+
+describe('isReleasePrepDiff (SMI-5680 C1 / Step 0)', () => {
+  it('true: actual 2e31a616 release-commit shape (version bump + heading inserted below Unreleased)', () => {
+    expect(
+      isReleasePrepDiff(
+        CORE_PKG_JSON_BASE,
+        CORE_PKG_JSON_HEAD,
+        CORE_CHANGELOG_BASE,
+        CORE_CHANGELOG_HEAD
+      )
+    ).toBe(true)
+  })
+
+  it('false: no version bump (package.json version unchanged) even if changelog structure matches', () => {
+    expect(
+      isReleasePrepDiff(
+        CORE_PKG_JSON_BASE,
+        CORE_PKG_JSON_BASE,
+        CORE_CHANGELOG_BASE,
+        CORE_CHANGELOG_HEAD
+      )
+    ).toBe(false)
+  })
+
+  it('false: version bumped but CHANGELOG unchanged (no version heading inserted) — the plain omission case', () => {
+    expect(
+      isReleasePrepDiff(
+        CORE_PKG_JSON_BASE,
+        CORE_PKG_JSON_HEAD,
+        CORE_CHANGELOG_BASE,
+        CORE_CHANGELOG_BASE
+      )
+    ).toBe(false)
+  })
+
+  it('false: the new version heading already existed at base (pre-existing, not new in this diff)', () => {
+    const changelogBaseAlreadyHasHeading = [
+      '## [Unreleased]',
+      '',
+      '## v0.11.2',
+      '',
+      '- pre-existing entry, not part of this diff',
+    ].join('\n')
+    expect(
+      isReleasePrepDiff(
+        CORE_PKG_JSON_BASE,
+        CORE_PKG_JSON_HEAD,
+        changelogBaseAlreadyHasHeading,
+        CORE_CHANGELOG_HEAD
+      )
+    ).toBe(false)
+  })
+
+  it('false: version bumped but the inserted heading does not match the new version', () => {
+    const wrongVersionChangelogHead = [
+      '## [Unreleased]',
+      '',
+      '## v9.9.9',
+      '',
+      '- unrelated version heading',
+    ].join('\n')
+    expect(
+      isReleasePrepDiff(
+        CORE_PKG_JSON_BASE,
+        CORE_PKG_JSON_HEAD,
+        CORE_CHANGELOG_BASE,
+        wrongVersionChangelogHead
+      )
+    ).toBe(false)
+  })
+
+  it('false: malformed package.json JSON at HEAD fails safe (no throw, no exemption)', () => {
+    expect(
+      isReleasePrepDiff(
+        CORE_PKG_JSON_BASE,
+        '{ not valid json',
+        CORE_CHANGELOG_BASE,
+        CORE_CHANGELOG_HEAD
+      )
+    ).toBe(false)
+  })
+
+  it('false: package.json missing a "version" field fails safe', () => {
+    const pkgJsonNoVersion = JSON.stringify({ name: '@skillsmith/core' })
+    expect(
+      isReleasePrepDiff(
+        CORE_PKG_JSON_BASE,
+        pkgJsonNoVersion,
+        CORE_CHANGELOG_BASE,
+        CORE_CHANGELOG_HEAD
+      )
+    ).toBe(false)
+  })
+
+  it('false: heading directly below Unreleased at HEAD is itself missing (entry, not a heading)', () => {
+    // Simulates a hand-edited Unreleased section where an entry line sits
+    // where the version heading should be — must not be misread as release-prep.
+    const changelogHeadNoHeading = [
+      '## [Unreleased]',
+      '',
+      '- **Fix**: some manually-added entry, not a version heading',
+      '',
+      '## v0.11.1',
+    ].join('\n')
+    expect(
+      isReleasePrepDiff(
+        CORE_PKG_JSON_BASE,
+        CORE_PKG_JSON_HEAD,
+        CORE_CHANGELOG_BASE,
+        changelogHeadNoHeading
+      )
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** A new standing check (`audit:standards` Check 54) that catches a PR touching `core`, `mcp-server`, `cli`, `enterprise`, or `vscode-extension` source code with no matching entry added to that package's changelog — the exact gap that let a real bug fix (PR #1878) ship to `main` with nothing recording it, invisible to the next release until a person happened to notice by hand.

**Quality bar:** Full VP Product/Engineering/Design plan review before any code was written (required by this repo's infra-change policy, since this adds a permanent gate that will run on every future PR) — 20 findings surfaced and fixed, including two that would have broken the check on day one: it would have wrongly flagged every routine release PR as "missing a changelog entry," and its planned soft-launch (warnings only, no hard fail) repeats a rollout shape that has already quietly failed once before in this repo. Implementation independently re-verified against a real historical violation and a real release commit, plus the full existing test suite (2,250 tests) confirmed with no regressions.

**Net result:** Fully shipped — check ships live (not a trial period), with a documented escape hatch for the rare legitimate exception.

---

## Technical detail

- `scripts/audit-standards-helpers.mjs` — two new pure helpers: `countUnreleasedEntries` (counts qualifying `[Unreleased]` bullets) and `isReleasePrepDiff` (detects a release-prep commit structurally so it's exempted rather than false-flagged).
- `scripts/audit-standards.mjs` — Check 54: `GITHUB_BASE_REF` + merge-base diff (matching Checks 45/50/51's existing pattern), scoped to the 5 packages with a release cadence, `TEST_PATTERNS`-based test-file exclusion, the release-prep exemption, and a `[skip-changelog-check]` opt-out (boolean + mandatory reason paragraph, mirroring `[concurrency-audit-ack]`).
- `.github/workflows/ci.yml` — wires `PR_BODY` into the `quality-checks` job so the opt-out marker is actually readable (zero-cost, matches `concurrency-audit-pr.yml`'s existing wiring).
- `docs/internal/process/guards-and-opt-outs.md` — registry row for the new opt-out marker.
- `scripts/tests/audit-standards-changelog-gate.test.ts` (new, 18 tests) — covers both helpers, including the real shape of release commit `2e31a616` and the real SMI-5671 backfill commit.
- Manually verified end-to-end (outside the test suite) against a throwaway commit: fails on a real violation, passes once an entry is added, passes when the opt-out marker + reason is present — then cleanly reverted before this PR.
- Plan: `docs/internal/implementation/smi-5680-changelog-entry-gate.md` (plan-reviewed, ADR-109).

Refs SMI-5680