### PR TITLE
fix(scripts): Relabel Check 49, recognize .sh as source (SMI-5684/5690)

### DIFF
--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+- **Internal**: Renamed the `audit:check-48-ack` opt-out marker comment in `telemetry-wrap.ts` to `audit:check-49-ack`, matching a governance-tooling relabel in the main repo (SMI-5684); no functional or user-visible change.
+
 ## v0.7.2
 
 - **Cadence**: Mechanical cadence alignment (no changes since v0.7.1).

--- a/packages/vscode-extension/src/services/telemetry-wrap.ts
+++ b/packages/vscode-extension/src/services/telemetry-wrap.ts
@@ -29,7 +29,7 @@ export interface VscodeTelemetryOpts {
  * Telemetry emission is fire-and-forget and never alters the handler's
  * observable behaviour (errors are swallowed; `track` self-gates + self-times).
  */
-// audit:check-48-ack — intentional parallel definition: the extension bundles
+// audit:check-49-ack — intentional parallel definition: the extension bundles
 // standalone (esbuild) and cannot import the canonical core HOF (would inline
 // posthog-node + OTel SDK). See the file header for the full rationale.
 export function withTelemetry<TArgs extends readonly unknown[], TReturn>(

--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -161,10 +161,13 @@ export const extractCompletionIssues = (subject, body) => {
 // SMI-5681: Check 23 infra/config-only fix recognition
 // ============================================================================
 //
-// SRC_PATTERNS below is the pre-SMI-5681 definition: it only recognizes
-// application source under packages/**, supabase/functions/**, and
-// scripts/**. A commit whose subject/body claims to fix/close/resolve an
-// SMI-NNNN issue (per extractCompletionIssues above) but which legitimately
+// SRC_PATTERNS recognizes application source under packages/**,
+// supabase/functions/**, and scripts/**. SMI-5690 adds `.sh` under scripts/**
+// so genuine shell-script-only commits count as implementation source; shell
+// tests under scripts/tests/** remain excluded by SRC_EXCLUDED. Extensionless,
+// `.bash`, and other script extensions remain unmatched by design.
+// A commit whose subject/body claims to fix/close/resolve an SMI-NNNN issue
+// (per extractCompletionIssues above) but which legitimately
 // only touches an ADR-109 infra/config trigger path — .claude/settings.json,
 // .github/workflows/**, docker-compose.yml, Dockerfile,
 // docker-entrypoint.sh, a .husky/* hook, turbo.json, or a root
@@ -195,7 +198,7 @@ export const extractCompletionIssues = (subject, body) => {
 export const SRC_PATTERNS = [
   /^packages\/.*\.(ts|tsx|js|jsx|astro)$/,
   /^supabase\/functions\/.*\.(ts|js)$/,
-  /^scripts\/.*\.(ts|js|mjs)$/,
+  /^scripts\/.*\.(ts|js|mjs|sh)$/,
 ]
 
 export const INFRA_PATTERNS = [
@@ -218,7 +221,12 @@ export const INFRA_PATTERNS = [
   /^[^/]+\.config(\.[^./]+)?\.(ts|mjs|cjs|js)$/,
 ]
 
-export const SRC_EXCLUDED = [/\.test\.(ts|tsx|js)$/, /\.spec\.(ts|tsx|js)$/, /\.md$/]
+export const SRC_EXCLUDED = [
+  /\.test\.(ts|tsx|js)$/,
+  /\.spec\.(ts|tsx|js)$/,
+  /^scripts\/tests\/.*\.sh$/,
+  /\.md$/,
+]
 
 /**
  * Return true if `files` (repo-relative paths changed by one commit)
@@ -1087,21 +1095,26 @@ export function findFunctionDefinitions(srcByPath, symbol) {
   return out
 }
 
+const hasCheck49AckMarker = (line) =>
+  line.includes('audit:check-49-ack') || line.includes('audit:check-48-ack')
+
 /**
  * Returns `true` if the definition at `line` (1-indexed) in `src` is opted out
- * of Check 48c via an `audit:check-48-ack` marker — either on the definition
- * line itself or anywhere in the contiguous comment block immediately preceding
- * it. The upward walk stops at the first blank OR non-comment line, so a distant
- * comment carrying the token cannot reach an unrelated definition.
+ * of Check 49c via the canonical `audit:check-49-ack` marker or its
+ * deprecated-but-supported `audit:check-48-ack` alias — either on the
+ * definition line itself or anywhere in the contiguous comment block
+ * immediately preceding it. The upward walk stops at the first blank OR
+ * non-comment line, so a distant comment carrying either token cannot reach
+ * an unrelated definition.
  *
- * Why preceding-comment-aware (not same-line only, like 48d): a `withTelemetry`
+ * Why preceding-comment-aware (not same-line only, like 49d): a `withTelemetry`
  * signature is frequently multi-line (generics + params), so a trailing same-line
  * marker would fight the formatter. The one legitimate parallel definition
  * (the esbuild-bundled VS Code extension's local wrapper, which cannot import the
  * canonical core HOF) carries its ack on the comment block above the def.
  *
  * A comment line is one whose trimmed form starts with `//`, `*`, or `/*`.
- * Detection is substring (`String.prototype.includes`), matching 48d's existing
+ * Detection is substring (`String.prototype.includes`), matching 49d's existing
  * tradeoff: a def line containing the literal token inside an unrelated string
  * would be falsely suppressed — narrow, and the audit script excludes itself
  * from the survey.
@@ -1110,18 +1123,18 @@ export function findFunctionDefinitions(srcByPath, symbol) {
  * @param {number} line - 1-indexed definition line
  * @returns {boolean}
  */
-export function defHasCheck48Ack(src, line) {
+export function defHasCheck49Ack(src, line) {
   const lines = src.split('\n')
   const defIdx = line - 1
   if (defIdx < 0 || defIdx >= lines.length) return false
-  if (lines[defIdx].includes('audit:check-48-ack')) return true
+  if (hasCheck49AckMarker(lines[defIdx])) return true
   for (let i = defIdx - 1; i >= 0; i--) {
     const trimmed = lines[i].trim()
     if (trimmed === '') break
     const isComment =
       trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')
     if (!isComment) break
-    if (lines[i].includes('audit:check-48-ack')) return true
+    if (hasCheck49AckMarker(lines[i])) return true
   }
   return false
 }
@@ -1132,10 +1145,11 @@ export function defHasCheck48Ack(src, line) {
  * `_tests_/`, `/e2e/`, `fixtures/`) — those legitimately use the prefix as
  * a sandbox path per the test-isolation convention.
  *
- * Per-line opt-out marker `audit:check-48-ack` is honoured: any line
- * containing this token is excluded. The marker is the documented escape
- * hatch for legitimate edge cases (example code in comments, etc) and MUST
- * sit on the same physical line as the violation alongside a rationale.
+ * The canonical per-line opt-out marker `audit:check-49-ack` and its
+ * deprecated-but-supported `audit:check-48-ack` alias are honoured: any line
+ * containing either token is excluded. The marker is the documented escape
+ * hatch for legitimate edge cases (example code in comments, etc) and MUST sit
+ * on the same physical line as the violation alongside a rationale.
  *
  * @param {Record<string, string>} srcByPath
  * @returns {{ file: string, line: number, snippet: string }[]}
@@ -1150,7 +1164,7 @@ export function findTmpSkillsmithRefs(srcByPath) {
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]
       if (!line.includes('/tmp/skillsmith-')) continue
-      if (line.includes('audit:check-48-ack')) continue
+      if (hasCheck49AckMarker(line)) continue
       out.push({ file, line: i + 1, snippet: line.trim() })
     }
   }
@@ -1163,24 +1177,25 @@ export function findTmpSkillsmithRefs(srcByPath) {
  * per-sub-check messages with `fail()` / `warn()`.
  *
  * Sub-checks:
- *   48a: SkillsmithEventType union ⊇ {expected event names}    (FAIL)
- *   48b: ALLOWED_EVENTS array     ⊇ {expected event names}    (FAIL)
- *   48c: withTelemetry has exactly ONE definition site         (WARN)
- *   48d: /tmp/skillsmith- absent from prod source              (WARN)
+ *   49a: SkillsmithEventType union ⊇ {expected event names}    (FAIL)
+ *   49b: ALLOWED_EVENTS array     ⊇ {expected event names}    (FAIL)
+ *   49c: withTelemetry has exactly ONE definition site         (WARN)
+ *   49d: /tmp/skillsmith- absent from prod source              (WARN)
  *
- * Severity rationale: 48a/48b are exact-string set-membership tests against
+ * Severity rationale: 49a/49b are exact-string set-membership tests against
  * declared sources of truth (no false-positive surface — drift IS the bug).
- * 48c/48d are grep-based heuristics that might over-flag in legitimate
+ * 49c/49d are grep-based heuristics that might over-flag in legitimate
  * edge cases — `warn()` keeps them visible without blocking PRs, matching
  * the false-positive-fatigue guidance in CLAUDE.md governance retros. Both
- * honor an `audit:check-48-ack` opt-out marker: 48d per-line (same line as the
- * reference), 48c on the def line or the comment block immediately above the
- * parallel definition (see defHasCheck48Ack).
+ * honor canonical `audit:check-49-ack` and its deprecated-but-supported
+ * `audit:check-48-ack` alias: 49d per-line (same line as the reference), 49c
+ * on the def line or the comment block immediately above the parallel
+ * definition (see defHasCheck49Ack).
  *
  * @param {object} input
  * @param {string} input.posthogSrc - contents of packages/core/src/telemetry/posthog.ts
  * @param {string} input.eventsSrc - contents of supabase/functions/events/index.ts
- * @param {Record<string,string>} input.surveySrcByPath - all .ts files in scope for 48c/48d
+ * @param {Record<string,string>} input.surveySrcByPath - all .ts files in scope for 49c/49d
  * @param {string[]} input.expectedNewEvents - canonical list (e.g. ['skill_invoke', ...])
  * @param {string} input.canonicalWithTelemetryPath - the ONE allowed definition site
  * @returns {{
@@ -1196,29 +1211,30 @@ export function findConventionDrift(input) {
   const { posthogSrc, eventsSrc, surveySrcByPath, expectedNewEvents, canonicalWithTelemetryPath } =
     input
 
-  // 48a: SkillsmithEventType union must list every expectedNewEvents member.
+  // 49a: SkillsmithEventType union must list every expectedNewEvents member.
   const union = parseStringUnionType(posthogSrc, 'SkillsmithEventType')
   const eventTypeUnionParseFailed = union === null
   const eventTypeUnionMissing = union ? expectedNewEvents.filter((e) => !union.has(e)) : []
 
-  // 48b: ALLOWED_EVENTS const must include every expectedNewEvents member.
+  // 49b: ALLOWED_EVENTS const must include every expectedNewEvents member.
   const allowed = parseTsLiteralArray(eventsSrc, 'ALLOWED_EVENTS')
   const allowedEventsParseFailed = allowed === null
   const allowedEventsMissing = allowed ? expectedNewEvents.filter((e) => !allowed.has(e)) : []
 
-  // 48c: exactly one withTelemetry definition (in canonicalWithTelemetryPath).
-  // A parallel definition can opt out via an `audit:check-48-ack` marker on the
-  // def line or in the comment block immediately above it (genuinely-justified
-  // surfaces, e.g. the esbuild-bundled VS Code extension that cannot import the
-  // core HOF). See defHasCheck48Ack.
+  // 49c: exactly one withTelemetry definition (in canonicalWithTelemetryPath).
+  // A parallel definition can opt out via canonical `audit:check-49-ack` or its
+  // deprecated-but-supported `audit:check-48-ack` alias on the def line or in
+  // the comment block immediately above it (genuinely-justified surfaces, e.g.
+  // the esbuild-bundled VS Code extension that cannot import the core HOF). See
+  // defHasCheck49Ack.
   const allDefs = findFunctionDefinitions(surveySrcByPath, 'withTelemetry')
   const parallelWithTelemetryDefs = allDefs.filter(
     (d) =>
       d.file !== canonicalWithTelemetryPath &&
-      !defHasCheck48Ack(surveySrcByPath[d.file] ?? '', d.line)
+      !defHasCheck49Ack(surveySrcByPath[d.file] ?? '', d.line)
   )
 
-  // 48d: /tmp/skillsmith- must not appear in production source.
+  // 49d: /tmp/skillsmith- must not appear in production source.
   const tmpSkillsmithRefs = findTmpSkillsmithRefs(surveySrcByPath)
 
   return {

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -4147,25 +4147,26 @@ console.log(`\n${BOLD}48. publish.yml dependent-gate soundness (SMI-5060/SMI-506
 // pattern surveys would require knowing the plan's `<pattern-prefix>` to
 // grep for, which can't be statically discovered. We therefore encode the
 // four telemetry-specific assertions explicitly here. Adding a future
-// Check-48-style invariant for a different SMI = extending the helper's
+// Check-49-style invariant for a different SMI = extending the helper's
 // `findConventionDrift` input shape, not rewriting the audit loop.
 //
 // Sub-checks:
-//   48a (fail): SkillsmithEventType union ⊇ {skill_invoke, skill_context_load,
+//   49a (fail): SkillsmithEventType union ⊇ {skill_invoke, skill_context_load,
 //               skill_invoke_unparsed}
-//   48b (fail): ALLOWED_EVENTS in supabase/functions/events/index.ts ⊇ same set
-//   48c (warn): withTelemetry has exactly ONE definition site, at
+//   49b (fail): ALLOWED_EVENTS in supabase/functions/events/index.ts ⊇ same set
+//   49c (warn): withTelemetry has exactly ONE definition site, at
 //               packages/core/src/telemetry/wrap.ts
-//   48d (warn): /tmp/skillsmith-* not used in production source (M8 — runtime
+//   49d (warn): /tmp/skillsmith-* not used in production source (M8 — runtime
 //               state lives in ~/.skillsmith/run/, /tmp doesn't survive reboot)
 //
-// Exemption: a comment containing `audit:check-48-ack` opts out of the
-// grep-heuristic warns — 48d per-line (same line as the reference) and 48c on
+// Exemption: a comment containing canonical `audit:check-49-ack` or its
+// deprecated-but-supported `audit:check-48-ack` alias opts out of the
+// grep-heuristic warns — 49d per-line (same line as the reference) and 49c on
 // the def line or the comment block immediately above the parallel definition.
-// 48a/48b are exact-string set membership against declared sources of truth —
+// 49a/49b are exact-string set membership against declared sources of truth —
 // there is no legitimate exemption.
 //
-// Severity: 48c/48d are `warn()` for v1 to avoid false-positive fatigue
+// Severity: 49c/49d are `warn()` for v1 to avoid false-positive fatigue
 // blocking unrelated PRs (CLAUDE.md governance retro guidance). Promote to
 // `fail()` after a soak period if the warn rate is zero.
 console.log(`\n${BOLD}49. Convention drift backstop (SMI-5026 M5)${RESET}`)
@@ -4176,13 +4177,13 @@ console.log(`\n${BOLD}49. Convention drift backstop (SMI-5026 M5)${RESET}`)
   const EXPECTED_EVENTS = ['skill_invoke', 'skill_context_load', 'skill_invoke_unparsed']
 
   if (!existsSync(POSTHOG_PATH) || !existsSync(EVENTS_PATH)) {
-    warn('Check 48: required telemetry source file(s) missing — skipping convention-drift backstop')
+    warn('Check 49: required telemetry source file(s) missing — skipping convention-drift backstop')
   } else {
     try {
       const posthogSrc = readFileSync(POSTHOG_PATH, 'utf8')
       const eventsSrc = readFileSync(EVENTS_PATH, 'utf8')
 
-      // 48c/48d scope: all .ts files under packages/ and scripts/, excluding
+      // 49c/49d scope: all .ts files under packages/ and scripts/, excluding
       // node_modules, dist, build, and the audit script itself (which discusses
       // /tmp/skillsmith- in comments and references withTelemetry as an
       // identifier — the audit must not flag itself).
@@ -4216,7 +4217,7 @@ console.log(`\n${BOLD}49. Convention drift backstop (SMI-5026 M5)${RESET}`)
           } else if (
             (p.endsWith('.ts') || p.endsWith('.tsx') || p.endsWith('.mjs') || p.endsWith('.js')) &&
             // Exclude the audit script itself — it references withTelemetry
-            // as a string identifier in comments + check-48 prose.
+            // as a string identifier in comments + check-49 prose.
             p !== 'scripts/audit-standards.mjs' &&
             p !== 'scripts/audit-standards-helpers.mjs'
           ) {
@@ -4240,73 +4241,73 @@ console.log(`\n${BOLD}49. Convention drift backstop (SMI-5026 M5)${RESET}`)
         canonicalWithTelemetryPath: CANONICAL_WRAP_PATH,
       })
 
-      // 48a — SkillsmithEventType union coherence (FAIL)
+      // 49a — SkillsmithEventType union coherence (FAIL)
       if (result.eventTypeUnionParseFailed) {
         warn(
-          `Check 48a: Could not locate \`export type SkillsmithEventType\` in ` +
+          `Check 49a: Could not locate \`export type SkillsmithEventType\` in ` +
             `${POSTHOG_PATH} — file may have been restructured; check that the ` +
             `discriminated-union shape still uses the canonical \`= | 'foo' | 'bar'\` form.`
         )
       } else if (result.eventTypeUnionMissing.length > 0) {
         fail(
-          `Check 48a: SkillsmithEventType union missing event(s): ` +
+          `Check 49a: SkillsmithEventType union missing event(s): ` +
             `${result.eventTypeUnionMissing.join(', ')}`,
           `Add the missing literal(s) to the union in ${POSTHOG_PATH}. ` +
             `The events are the canonical SMI-5026 telemetry surface — see ` +
             `docs/internal/implementation/skill-invoke-telemetry.md § Wire format.`
         )
       } else {
-        pass(`Check 48a: SkillsmithEventType union includes all SMI-5026 telemetry events`)
+        pass(`Check 49a: SkillsmithEventType union includes all SMI-5026 telemetry events`)
       }
 
-      // 48b — ALLOWED_EVENTS validation list coherence (FAIL)
+      // 49b — ALLOWED_EVENTS validation list coherence (FAIL)
       if (result.allowedEventsParseFailed) {
         warn(
-          `Check 48b: Could not locate \`const ALLOWED_EVENTS = [...]\` in ` +
+          `Check 49b: Could not locate \`const ALLOWED_EVENTS = [...]\` in ` +
             `${EVENTS_PATH} — file may have been restructured.`
         )
       } else if (result.allowedEventsMissing.length > 0) {
         fail(
-          `Check 48b: ALLOWED_EVENTS in ${EVENTS_PATH} missing event(s): ` +
+          `Check 49b: ALLOWED_EVENTS in ${EVENTS_PATH} missing event(s): ` +
             `${result.allowedEventsMissing.join(', ')}`,
           `Add the missing literal(s) to ALLOWED_EVENTS. The edge function ` +
             `rejects any event not in this list — drift here causes silent ` +
             `400s for clients on the new event names.`
         )
       } else {
-        pass(`Check 48b: ALLOWED_EVENTS includes all SMI-5026 telemetry events`)
+        pass(`Check 49b: ALLOWED_EVENTS includes all SMI-5026 telemetry events`)
       }
 
-      // 48c — withTelemetry single-source-of-truth (WARN)
+      // 49c — withTelemetry single-source-of-truth (WARN)
       if (result.parallelWithTelemetryDefs.length === 0) {
-        pass(`Check 48c: withTelemetry has a single definition site ` + `(${CANONICAL_WRAP_PATH})`)
+        pass(`Check 49c: withTelemetry has a single definition site ` + `(${CANONICAL_WRAP_PATH})`)
       } else {
         const sites = result.parallelWithTelemetryDefs
           .map((d) => `  ${d.file}:${d.line} — ${d.snippet}`)
           .join('\n')
         warn(
-          `Check 48c: parallel withTelemetry definition(s) detected — ` +
+          `Check 49c: parallel withTelemetry definition(s) detected — ` +
             `single-source-of-truth violation per SMI-5016 H1:\n${sites}`,
           `The canonical definition is in ${CANONICAL_WRAP_PATH}. Re-export ` +
             `from there instead of redefining. Suppress a genuinely-justified ` +
-            `parallel definition with \`// audit:check-48-ack <reason>\` on the ` +
+            `parallel definition with \`// audit:check-49-ack <reason>\` on the ` +
             `definition line or in the comment block immediately above it.`
         )
       }
 
-      // 48d — /tmp/skillsmith- absent from prod source (WARN)
+      // 49d — /tmp/skillsmith- absent from prod source (WARN)
       if (result.tmpSkillsmithRefs.length === 0) {
-        pass(`Check 48d: /tmp/skillsmith- not referenced in production source (M8)`)
+        pass(`Check 49d: /tmp/skillsmith- not referenced in production source (M8)`)
       } else {
         const refs = result.tmpSkillsmithRefs
           .map((r) => `  ${r.file}:${r.line} — ${r.snippet}`)
           .join('\n')
         warn(
-          `Check 48d: /tmp/skillsmith- referenced in production source — ` +
+          `Check 49d: /tmp/skillsmith- referenced in production source — ` +
             `should live under ~/.skillsmith/run/ per M8 (/tmp doesn't survive reboot):\n${refs}`,
           `Move runtime state to ~/.skillsmith/run/ (mkdir -p, atomic temp ` +
             `rename). For inline doc/example references, append ` +
-            `\`// audit:check-48-ack <reason>\` to the line.`
+            `\`// audit:check-49-ack <reason>\` to the line.`
         )
       }
     } catch (e) {

--- a/scripts/tests/audit-standards-convention-drift.test.ts
+++ b/scripts/tests/audit-standards-convention-drift.test.ts
@@ -5,10 +5,10 @@
  * `skill-invoke-telemetry.md` plan as static invariants that re-run on every
  * PR. This test file covers the four pure helpers it composes:
  *
- *   - parseStringUnionType    (48a)
- *   - parseTsLiteralArray     (48b)
- *   - findFunctionDefinitions (48c)
- *   - findTmpSkillsmithRefs   (48d)
+ *   - parseStringUnionType    (49a)
+ *   - parseTsLiteralArray     (49b)
+ *   - findFunctionDefinitions (49c)
+ *   - findTmpSkillsmithRefs   (49d)
  *
  * Plus the composer `findConventionDrift` end-to-end.
  *
@@ -33,7 +33,7 @@ const helpers = (await import('../audit-standards-helpers.mjs')) as {
     srcByPath: Record<string, string>,
     symbol: string
   ) => { file: string; line: number; snippet: string }[]
-  defHasCheck48Ack: (src: string, line: number) => boolean
+  defHasCheck49Ack: (src: string, line: number) => boolean
   findTmpSkillsmithRefs: (
     srcByPath: Record<string, string>
   ) => { file: string; line: number; snippet: string }[]
@@ -50,7 +50,7 @@ const {
   parseStringUnionType,
   parseTsLiteralArray,
   findFunctionDefinitions,
-  defHasCheck48Ack,
+  defHasCheck49Ack,
   findTmpSkillsmithRefs,
   findConventionDrift,
 } = helpers
@@ -199,67 +199,67 @@ describe('findFunctionDefinitions', () => {
 })
 
 // ---------------------------------------------------------------------------
-// defHasCheck48Ack (48c opt-out)
+// defHasCheck49Ack (49c opt-out)
 // ---------------------------------------------------------------------------
 
-describe('defHasCheck48Ack', () => {
+describe('defHasCheck49Ack', () => {
   it('honors a marker on the definition line itself', () => {
-    const src = 'export function withTelemetry(fn) { return fn } // audit:check-48-ack inline'
-    expect(defHasCheck48Ack(src, 1)).toBe(true)
+    const src = 'export function withTelemetry(fn) { return fn } // audit:check-49-ack inline'
+    expect(defHasCheck49Ack(src, 1)).toBe(true)
   })
 
   it('honors a marker in the contiguous // comment block above the def', () => {
     // Mirrors the real packages/vscode-extension/.../telemetry-wrap.ts shape:
     // a multi-line // block carrying the token, immediately above the def.
     const src = [
-      '// audit:check-48-ack — intentional parallel definition: the extension',
+      '// audit:check-49-ack — intentional parallel definition: the extension',
       '// bundles standalone and cannot import the canonical core HOF.',
       'export function withTelemetry<F>(fn: F): F {',
     ].join('\n')
-    expect(defHasCheck48Ack(src, 3)).toBe(true)
+    expect(defHasCheck49Ack(src, 3)).toBe(true)
   })
 
-  it('honors a marker on a * block-comment continuation line above the def', () => {
+  it('honors the deprecated audit:check-48-ack alias above the def', () => {
     const src = [
       '/**',
       ' * audit:check-48-ack rationale here',
       ' */',
       'const withTelemetry = (fn) => fn',
     ].join('\n')
-    expect(defHasCheck48Ack(src, 4)).toBe(true)
+    expect(defHasCheck49Ack(src, 4)).toBe(true)
   })
 
   it('does NOT honor a marker separated from the def by a blank line', () => {
     const src = [
-      '// audit:check-48-ack stale',
+      '// audit:check-49-ack stale',
       '',
       'export function withTelemetry(fn) { return fn }',
     ].join('\n')
-    expect(defHasCheck48Ack(src, 3)).toBe(false)
+    expect(defHasCheck49Ack(src, 3)).toBe(false)
   })
 
   it('does NOT honor a marker separated from the def by a code line (walk stops at non-comment)', () => {
     const src = [
-      '// audit:check-48-ack from an unrelated symbol',
+      '// audit:check-49-ack from an unrelated symbol',
       'const unrelated = 1',
       'export function withTelemetry(fn) { return fn }',
     ].join('\n')
-    expect(defHasCheck48Ack(src, 3)).toBe(false)
+    expect(defHasCheck49Ack(src, 3)).toBe(false)
   })
 
   it('does NOT honor a marker on an unrelated distant line', () => {
     const src = [
-      '// audit:check-48-ack',
+      '// audit:check-49-ack',
       'const a = 1',
       'const b = 2',
       'function withTelemetry() {}',
     ].join('\n')
-    expect(defHasCheck48Ack(src, 4)).toBe(false)
+    expect(defHasCheck49Ack(src, 4)).toBe(false)
   })
 
   it('returns false for an out-of-range line', () => {
-    expect(defHasCheck48Ack('const x = 1', 99)).toBe(false)
-    expect(defHasCheck48Ack('const x = 1', 0)).toBe(false)
+    expect(defHasCheck49Ack('const x = 1', 99)).toBe(false)
+    expect(defHasCheck49Ack('const x = 1', 0)).toBe(false)
   })
 })
 
@@ -289,14 +289,14 @@ describe('findTmpSkillsmithRefs', () => {
     expect(result).toHaveLength(0)
   })
 
-  it('honours the audit:check-48-ack opt-out marker', () => {
+  it('honours the canonical audit:check-49-ack opt-out marker', () => {
     const result = findTmpSkillsmithRefs({
-      'packages/cli/src/x.ts': "const r = '/tmp/skillsmith-doc'  // audit:check-48-ack example",
+      'packages/cli/src/x.ts': "const r = '/tmp/skillsmith-doc'  // audit:check-49-ack example",
     })
     expect(result).toHaveLength(0)
   })
 
-  it('flags only the un-acked line when both present', () => {
+  it('honours the deprecated audit:check-48-ack alias and flags only the un-acked line', () => {
     const src = `const a = '/tmp/skillsmith-1'  // audit:check-48-ack docs\nconst b = '/tmp/skillsmith-2'`
     const result = findTmpSkillsmithRefs({ 'p/x.ts': src })
     expect(result).toHaveLength(1)
@@ -343,7 +343,7 @@ export interface Foo {}`
     expect(r.tmpSkillsmithRefs).toEqual([])
   })
 
-  it('flags a missing union member (48a fail surface)', () => {
+  it('flags a missing union member (49a fail surface)', () => {
     const r = findConventionDrift({
       posthogSrc: `export type SkillsmithEventType = | 'skill_search'\n\nexport const x = 1`,
       eventsSrc: CANONICAL_EVENTS,
@@ -354,7 +354,7 @@ export interface Foo {}`
     expect(r.eventTypeUnionMissing).toEqual(EXPECTED)
   })
 
-  it('flags a missing ALLOWED_EVENTS entry (48b fail surface)', () => {
+  it('flags a missing ALLOWED_EVENTS entry (49b fail surface)', () => {
     const r = findConventionDrift({
       posthogSrc: CANONICAL_POSTHOG,
       eventsSrc: `const ALLOWED_EVENTS = ['skill_view'] as const`,
@@ -365,7 +365,7 @@ export interface Foo {}`
     expect(r.allowedEventsMissing).toEqual(EXPECTED)
   })
 
-  it('flags a parallel withTelemetry definition (48c warn surface)', () => {
+  it('flags a parallel withTelemetry definition (49c warn surface)', () => {
     const r = findConventionDrift({
       posthogSrc: CANONICAL_POSTHOG,
       eventsSrc: CANONICAL_EVENTS,
@@ -380,7 +380,7 @@ export interface Foo {}`
     expect(r.parallelWithTelemetryDefs[0].file).toBe('packages/website/src/shim.ts')
   })
 
-  it('does NOT flag a parallel def acked on the same line (48c opt-out)', () => {
+  it('does NOT flag a parallel def acked with the deprecated alias (49c opt-out)', () => {
     const r = findConventionDrift({
       posthogSrc: CANONICAL_POSTHOG,
       eventsSrc: CANONICAL_EVENTS,
@@ -402,7 +402,7 @@ export interface Foo {}`
       surveySrcByPath: {
         [CANONICAL_WRAP]: 'export function withTelemetry<F>(fn: F): F { return fn }',
         'packages/vscode-extension/src/services/telemetry-wrap.ts': [
-          '// audit:check-48-ack — intentional parallel definition: the extension',
+          '// audit:check-49-ack — intentional parallel definition: the extension',
           '// bundles standalone (esbuild) and cannot import the canonical core HOF.',
           'export function withTelemetry<A, R>(fn: (...a: A[]) => R): (...a: A[]) => R {',
           '  return fn',
@@ -430,7 +430,7 @@ export interface Foo {}`
     expect(r.parallelWithTelemetryDefs[0].file).toBe('packages/website/src/shim.ts')
   })
 
-  it('does not flag call sites (48c true-negative)', () => {
+  it('does not flag call sites (49c true-negative)', () => {
     const r = findConventionDrift({
       posthogSrc: CANONICAL_POSTHOG,
       eventsSrc: CANONICAL_EVENTS,
@@ -445,7 +445,7 @@ export interface Foo {}`
     expect(r.parallelWithTelemetryDefs).toEqual([])
   })
 
-  it('flags /tmp/skillsmith- in prod but ignores tests (48d)', () => {
+  it('flags /tmp/skillsmith- in prod but ignores tests (49d)', () => {
     const r = findConventionDrift({
       posthogSrc: CANONICAL_POSTHOG,
       eventsSrc: CANONICAL_EVENTS,

--- a/scripts/tests/audit-standards.test.ts
+++ b/scripts/tests/audit-standards.test.ts
@@ -343,12 +343,20 @@ describe('audit-standards Check 23: INFRA_PATTERNS + hasCompletionSource', () =>
     })
   })
 
-  describe('hasCompletionSource: the two SMI-5681 regression scenarios', () => {
+  describe('hasCompletionSource: SMI-5681 and SMI-5690 regression scenarios', () => {
     it('REGRESSION (SMI-5681 ground truth, commit 3395b24b/SMI-5679): a .claude/settings.json-only change now counts as completion source', () => {
       // Confirmed repro: commit 3395b24b ("fix(statusline): Point tier-1 at
       // local ruflo bin, not npx (#1887)", body "Fixes SMI-5679") changed
       // only .claude/settings.json and was misflagged by Check 23 pre-fix.
       expect(hasCompletionSource(['.claude/settings.json'])).toBe(true)
+    })
+
+    it('REGRESSION (SMI-5690 ground truth, commit 9c695d5d/SMI-5668): a scripts/ .sh-only change now counts as completion source', () => {
+      // Confirmed repro: commit 9c695d5d ("feat(scripts): SMI-5668
+      // NEEDLE-based Codex dispatch (ADR-128 pilot) (#1896)") changed shell
+      // scripts but no previously recognized source path.
+      expect(hasCompletionSource(['scripts/needle/dispatch.sh'])).toBe(true)
+      expect(hasCompletionSource(['scripts/live-services/launch-ci-testing.sh'])).toBe(true)
     })
 
     it('a genuinely source-less docs-only change still trips the check (original purpose preserved)', () => {
@@ -381,8 +389,20 @@ describe('audit-standards Check 23: INFRA_PATTERNS + hasCompletionSource', () =>
       expect(hasCompletionSource(['scripts/audit-standards.mjs'])).toBe(true)
     })
 
-    it('a .test.ts-only change is still excluded (SRC_EXCLUDED unchanged)', () => {
+    it('test-only changes remain excluded from implementation source', () => {
       expect(hasCompletionSource(['packages/core/src/index.test.ts'])).toBe(false)
+      expect(hasCompletionSource(['scripts/tests/needle-dispatch.test.sh'])).toBe(false)
+      expect(hasCompletionSource(['scripts/tests/verify-claude-md-extraction.sh'])).toBe(false)
+    })
+
+    it('a .sh-adjacent docs/config-only change still trips the check', () => {
+      expect(
+        hasCompletionSource([
+          'scripts/needle/README.md',
+          'scripts/needle/dispatch.yaml',
+          'docs/internal/implementation/needle.md',
+        ])
+      ).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** `npm run audit:standards` no longer prints a check labeled "Check 48" for two completely different things — a real gate for `publish.yml`, and several unrelated sub-findings that were always meant to say "Check 49." Separately, the same audit no longer wrongly flags a genuine shell-script-only commit as "done without source changes" — a false positive that would have hit real PRs (e.g. today's own NEEDLE-dispatch commit).

**Quality bar:** SPARC research + plan-review (VP Product/Engineering/Design) before implementation, per ADR-109 — caught that the original draft only fixed the printed labels and never touched the underlying `defHasCheck48Ack` function, which would have shipped the exact "48 vs 49" naming collision this PR exists to remove, plus 7 other completeness gaps (all fixed). Implemented via Codex (GPT 5.6 Sol) dispatch through NEEDLE (ADR-128) — its generated diffs had real defects on 2 of 6 files (hunk line-count errors; two files where the surrounding context didn't match the actual repo), caught and hand-corrected against the real files rather than force-applied. 110/110 relevant tests, typecheck, lint, `format:check`, and `audit:standards` all pass clean.

**Found along the way:** none — this PR's own scope already covers everything the plan review surfaced.

**Net result:** Fully shipped, no follow-up.

---

## Technical detail

- `scripts/audit-standards.mjs`: relabels the Check 49 block's display strings/comments from "Check 48"/"48a-d" to "Check 49"/"49a-d" (main sequence's own genuine Check 48 — the publish.yml gate — untouched).
- `scripts/audit-standards-helpers.mjs`: renames the exported `defHasCheck48Ack` helper to `defHasCheck49Ack`; renames the functional opt-out marker `audit:check-48-ack` to `audit:check-49-ack`, keeping the old token as a backward-compatible alias via a new shared `hasCheck49AckMarker` predicate (used at all 3 functional match sites, replacing 3 duplicated checks); adds `.sh` to `SRC_PATTERNS` (SMI-5690) with a directory-scoped `scripts/tests/**/*.sh` exclusion.
- `packages/vscode-extension/src/services/telemetry-wrap.ts`: migrates its one live usage of the marker to the new canonical name.
- `scripts/tests/audit-standards-convention-drift.test.ts` / `scripts/tests/audit-standards.test.ts`: renamed symbol references, new backward-compat alias regression cases, and new SMI-5690 regression tests (including an existing un-suffixed shell test that a naive suffix-match would have missed).
- `docs/internal/process/guards-and-opt-outs.md`: adds a registry row for this marker (none existed before — a pre-existing SMI-5418 DoD #5 gap this closes as a side effect).
- Plan (SPARC + plan-review, APPROVE-WITH-EDITS): `docs/internal/implementation/smi-5684-5690-audit-standards-followups.md`.
- Verified in a dedicated worktree: `audit:standards` 74 passed / 8 pre-existing warnings / 0 failed; full relevant vitest suite (110 tests) green; typecheck/lint/prettier clean.

Refs SMI-5684, SMI-5690
