### PR TITLE
docs(needle): bump pinned NEEDLE fork rev for the SMI-5678 transform fix

### DIFF
--- a/scripts/needle/README.md
+++ b/scripts/needle/README.md
@@ -14,10 +14,14 @@ Architecture decision: [ADR-128](../../docs/internal/adr/128-harness-of-harnesse
 1. **Rust toolchain**, if not already present: install via [rustup](https://rustup.rs).
 2. **Install NEEDLE**, pinned to the diligenced, macOS-compatible fork commit
    (upstream `jedarden/NEEDLE` has never published a macOS binary and has a
-   real Darwin compile bug — see the implementation doc § 2):
+   real Darwin compile bug — see the implementation doc § 2). This also
+   carries the transform-kill grace-period fix (SMI-5678) that fixed a
+   spurious `TransformFailed` event and `model: "unknown"` cost attribution
+   on every Codex dispatch — see
+   [`docs/internal/implementation/smi-5678-needle-fork-followups.md`](../../docs/internal/implementation/smi-5678-needle-fork-followups.md):
 
    ```sh
-   cargo install --git https://github.com/wrsmith108/NEEDLE --rev c2eed7e3 --no-default-features
+   cargo install --git https://github.com/wrsmith108/NEEDLE --rev 96e669e8 --no-default-features
    ```
 
    `--no-default-features` skips the `otlp` telemetry feature (needs

--- a/scripts/needle/README.md
+++ b/scripts/needle/README.md
@@ -15,10 +15,12 @@ Architecture decision: [ADR-128](../../docs/internal/adr/128-harness-of-harnesse
 2. **Install NEEDLE**, pinned to the diligenced, macOS-compatible fork commit
    (upstream `jedarden/NEEDLE` has never published a macOS binary and has a
    real Darwin compile bug — see the implementation doc § 2). This also
-   carries the transform-kill grace-period fix (SMI-5678) that fixed a
-   spurious `TransformFailed` event and `model: "unknown"` cost attribution
-   on every Codex dispatch — see
-   [`docs/internal/implementation/smi-5678-needle-fork-followups.md`](../../docs/internal/implementation/smi-5678-needle-fork-followups.md):
+   carries the transform-kill grace-period fix
+   ([SMI-5678](https://linear.app/smith-horn-group/issue/SMI-5678/needle-transform-codex-fails-to-parse-jsonl-output-model-attribution))
+   that fixed a spurious `TransformFailed` event and `model: "unknown"` cost
+   attribution on every Codex dispatch — see the Linear issue for the
+   root-cause and validation record (the paired implementation doc for the
+   broader SMI-5691 fork-followups work has not been written yet):
 
    ```sh
    cargo install --git https://github.com/wrsmith108/NEEDLE --rev 96e669e8 --no-default-features
@@ -144,9 +146,10 @@ guaranteed for every model/prompt.
   `.agents/skills/` content: don't dispatch anything to Codex that a
   Sonnet/Haiku worker would finish in under ~2 minutes. See CLAUDE.md's
   Default Execution Model, Codex row.
-- **`transform.failed error="exit code -1"` in `needle logs`.** Known,
-  tracked gap: `needle-transform-codex` fails to parse some dispatch output
-  even though the underlying `codex exec` call succeeded. Effect: NEEDLE's
-  own cost/token attribution for that dispatch shows `model: "unknown"`.
-  Task execution itself is unaffected. Tracked at SMI-5678, not a
-  `dispatch.sh` bug.
+- **`transform.failed error="exit code -1"` in `needle logs`, or Codex-dispatch
+  cost/token attribution showing `model: "unknown"`.** Fixed as of the pinned
+  fork rev bump to `96e669e8` (SMI-5678) — `needle-transform-codex` now
+  parses the dispatch output correctly and attributes the real model. If you
+  still see this, confirm the install actually picked up `96e669e8` (re-run
+  setup step 2; `cargo install` is a no-op if an older pinned rev is already
+  installed under the same binary name).


### PR DESCRIPTION
## Business Summary

**What shipped:** `scripts/needle/README.md` now points Codex dispatch setup at a fixed NEEDLE fork build — the previous pinned commit had a real bug where a successful Codex dispatch would still log a false "transform failed" event and lose the real model name from its cost/token attribution (it fell back to `model: "unknown"` every time).

**Quality bar:** Root-caused via direct source inspection and cross-checked against 9 real production telemetry logs from the original SMI-5668 rollout. Fix validated with 4 real end-to-end Codex dispatches (correct model attribution, no false failures each time) plus 2 targeted negative-path checks (a genuinely broken transform still reports as broken; a transform that hangs is still caught as a failure, not silently read as success).

**Found along the way:** while live-testing the hang scenario, found and fixed a second, related bug — the dispatcher only killed the top-level transform process, not any subprocess it had spawned, which could leave an orphan alive and holding a log-writer pipe open past the intended timeout. Fixed in the same commit; covered by the same validation above.

**Net result:** Fully shipped. The fixed fork commit is also submitted upstream ([jedarden/NEEDLE#3](https://github.com/jedarden/NEEDLE/pull/3)) so this patch can eventually retire in favor of the original project.

---

## Technical detail

- `scripts/needle/README.md` — bumps the pinned `cargo install --git https://github.com/wrsmith108/NEEDLE --rev` from `c2eed7e3` to `96e669e8`, and links the SMI-5678 Linear issue.
- No `packages/` changes — this is the maintainer-machine-only NEEDLE dispatch tooling (never wired into CI), so `preflight` / package builds are unaffected.
- Full design + validation record: [SMI-5678](https://linear.app/smith-horn-group/issue/SMI-5678/needle-transform-codex-fails-to-parse-jsonl-output-model-attribution) (the paired implementation doc for the broader SMI-5691 fork-followups work has not been written yet).
- The actual fix lives in the fork itself: `wrsmith108/NEEDLE` branch `fix/transform-grace-period-before-kill` (commit `96e669e8`), stacked on the existing macOS errno-portability fix.

[skip-impl-check]

This PR only bumps a pinned commit reference in a doc; the actual implementation (the NEEDLE fork's Rust fix) lives in an external repo (`wrsmith108/NEEDLE`), not in this monorepo's `packages/`.
