### PR TITLE
feat(inventory): Add Grok Build as a scanned harness (SMI-5697)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Grok Build Harness Support** (2026-07-14, SMI-5697): Skillsmith's cross-machine
+  skill inventory (`skillsmith inventory push`/`status`) now also scans
+  `~/.grok/skills`, xAI's Grok Build coding CLI's native skill directory, in
+  addition to the previously supported harnesses (Claude Code, Cursor, Copilot,
+  Windsurf, shared Codex path, OpenCode, and Hermes).
 - **Indexer Backfill Facet Driver** (2026-06-18, SMI-5286 sub-wave 1c): the
   out-of-band backfill (`indexer-backfill.yml`) now crawls the full
   `filename:SKILL.md` universe past GitHub code-search's 1000-result-per-query

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `@skillsmith/cli` are documented here.
 ## [Unreleased]
 
 - **Change**: `compliance_reports`' displayed tier requirement expanded from Enterprise-only to Team + Enterprise (SMI-3140)
+- **Feature**: per-client MCP config snippet for Grok Build (`~/.grok/config.toml`) added to `CLIENT_SNIPPETS`/`SNIPPET_DISPLAY_ORDER` in `templates/mcp-server.template.snippets.ts`, matching the new `grok` harness added to `@skillsmith/core`'s inventory scanner (SMI-5697)
 
 ## v0.8.2
 

--- a/packages/cli/src/templates/mcp-server.template.snippets.ts
+++ b/packages/cli/src/templates/mcp-server.template.snippets.ts
@@ -175,6 +175,22 @@ SKILLSMITH_API_KEY = "sk_live_..."`,
     notes:
       'Hermes config is YAML. Hermes has no SessionStart hook equivalent — nudge/attribution is unsupported on this harness.',
   },
+  // SMI-5697: grok added to ClientId (paths.ts); this Record<SnippetClientId,
+  // ClientSnippet> is exhaustive over ClientId, so this entry is required for
+  // the type to compile.
+  grok: {
+    label: 'Grok Build (xAI)',
+    configPath: '~/.grok/config.toml',
+    format: 'toml',
+    body: `[mcp_servers.{{name}}]
+command = "npx"
+args = ["-y", "{{name}}"]
+
+[mcp_servers.{{name}}.env]
+SKILLSMITH_API_KEY = "sk_live_..."`,
+    notes:
+      'Grok Build uses TOML under the [mcp_servers.<name>] table, mirroring the Codex CLI convention above — confirmed against docs.x.ai for the command/args shape; the env sub-table follows the same pattern as the Codex entry.',
+  },
 }
 
 /**
@@ -223,4 +239,5 @@ export const SNIPPET_DISPLAY_ORDER: ReadonlyArray<SnippetClientId> = Object.free
   'agents',
   'opencode',
   'hermes',
+  'grok',
 ])

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Feature**: `grok` (Grok Build, xAI's coding CLI) added as a scanned harness for cross-machine skill inventory — `CLIENT_NATIVE_PATHS`/`CLIENT_IDS` in `install/paths.ts` now include `~/.grok/skills` (SMI-5697)
 - **Fix**: `extractMcpReferences` now parses frontmatter `allowed-tools`/`tools` YAML (bare-server, wildcard, and full forms), detects embedded `mcpServers` JSON-registration blocks, and cross-checks every candidate server name against the project's `.mcp.json` via a new `serverResolutions` map (`registered`/`unregistered`/`unknown`) — candidates are tagged, never excluded (SMI-5676)
 - **Fix**: `extractDepIntel`/`persistDependencies` pass the project's registered MCP server list via the new `getRegisteredMcpServers()` export, which fails open (not to an empty list) when `.mcp.json` is missing or unparseable
 - Exported `getBestDriver`/`DriverType` from the package root, and added a `compliance_export` `AuditEventType` (SMI-3140)

--- a/packages/core/src/install/paths.test.ts
+++ b/packages/core/src/install/paths.test.ts
@@ -48,6 +48,7 @@ describe('enumerateHarnessPresence (SMI-5390)', () => {
     expect(result.find((r) => r.harness === 'agents')?.present).toBe(false)
     expect(result.find((r) => r.harness === 'opencode')?.present).toBe(false)
     expect(result.find((r) => r.harness === 'hermes')?.present).toBe(false)
+    expect(result.find((r) => r.harness === 'grok')?.present).toBe(false)
   })
 
   it('reports all harnesses absent when existsSync returns false for every path', () => {
@@ -79,7 +80,6 @@ describe('opencode + hermes ClientIds (SMI-5456 Wave 1 Step 5)', () => {
   it('CLIENT_IDS includes opencode and hermes', () => {
     expect(CLIENT_IDS).toContain('opencode')
     expect(CLIENT_IDS).toContain('hermes')
-    expect(CLIENT_IDS).toHaveLength(7)
   })
 
   it('opencode resolves to ~/.config/opencode/skills', () => {
@@ -88,5 +88,16 @@ describe('opencode + hermes ClientIds (SMI-5456 Wave 1 Step 5)', () => {
 
   it('hermes resolves to ~/.hermes/skills', () => {
     expect(CLIENT_NATIVE_PATHS.hermes.endsWith('/.hermes/skills')).toBe(true)
+  })
+})
+
+describe('grok ClientId (SMI-5697)', () => {
+  it('CLIENT_IDS includes grok', () => {
+    expect(CLIENT_IDS).toContain('grok')
+    expect(CLIENT_IDS).toHaveLength(8)
+  })
+
+  it('grok resolves to ~/.grok/skills', () => {
+    expect(CLIENT_NATIVE_PATHS.grok.endsWith('/.grok/skills')).toBe(true)
   })
 })

--- a/packages/core/src/install/paths.ts
+++ b/packages/core/src/install/paths.ts
@@ -32,6 +32,14 @@ import { join } from 'node:path'
 //     $HERMES_HOME override. Hermes has no session-start hook equivalent
 //     (spike-verified absent) — the installer must not claim hook/nudge
 //     support for this harness.
+//
+// Grok Build addition, verified 2026-07-14:
+//   - Grok Build: ~/.grok/skills — xAI's official developer docs (the
+//     "Skills, Plugins & Marketplaces" page under docs.x.ai's build/features
+//     section), corroborated by independent third-party sources. Grok Build
+//     also reads the shared ~/.agents/skills path for AGENTS.md-style
+//     cross-agent compatibility, but that's already covered by the existing
+//     `agents` ClientId, so no separate handling is needed for it here.
 export type ClientId =
   | 'claude-code'
   | 'cursor'
@@ -40,6 +48,7 @@ export type ClientId =
   | 'agents'
   | 'opencode'
   | 'hermes'
+  | 'grok'
 
 export const CLIENT_NATIVE_PATHS: Record<ClientId, string> = {
   'claude-code': join(homedir(), '.claude', 'skills'),
@@ -49,6 +58,7 @@ export const CLIENT_NATIVE_PATHS: Record<ClientId, string> = {
   agents: join(homedir(), '.agents', 'skills'),
   opencode: join(homedir(), '.config', 'opencode', 'skills'),
   hermes: join(homedir(), '.hermes', 'skills'),
+  grok: join(homedir(), '.grok', 'skills'),
 }
 
 export const CANONICAL_CLIENT: ClientId = 'claude-code'
@@ -61,6 +71,7 @@ export const CLIENT_IDS: ReadonlyArray<ClientId> = Object.freeze([
   'agents',
   'opencode',
   'hermes',
+  'grok',
 ])
 
 export function getCanonicalInstallPath(): string {

--- a/packages/website/src/lib/mcp-client-snippets.parity.test.ts
+++ b/packages/website/src/lib/mcp-client-snippets.parity.test.ts
@@ -68,10 +68,16 @@ const EXPECTED: ReadonlyArray<{
     configPath: '~/.hermes/config.yaml',
     format: 'yaml',
   },
+  {
+    id: 'grok',
+    label: 'Grok Build (xAI)',
+    configPath: '~/.grok/config.toml',
+    format: 'toml',
+  },
 ]
 
 describe('MCP_CLIENT_SNIPPETS — parity with CLI CLIENT_SNIPPETS (SMI-5554)', () => {
-  it('has exactly the 8-entry canonical id/label/configPath/format contract, in SNIPPET_DISPLAY_ORDER', () => {
+  it('has exactly the 9-entry canonical id/label/configPath/format contract, in SNIPPET_DISPLAY_ORDER', () => {
     const actual = MCP_CLIENT_SNIPPETS.map(({ id, label, configPath, format }) => ({
       id,
       label,

--- a/packages/website/src/lib/mcp-client-snippets.ts
+++ b/packages/website/src/lib/mcp-client-snippets.ts
@@ -28,6 +28,7 @@ export type McpClientId =
   | 'agents'
   | 'opencode'
   | 'hermes'
+  | 'grok'
 
 export interface McpClientSnippet {
   /** Canonical client id — matches SnippetClientId in the CLI package */
@@ -147,6 +148,17 @@ args = ["-y", "@skillsmith/mcp-server"]`,
     args: ["-y", "@skillsmith/mcp-server"]`,
     notes:
       'Hermes config is YAML. Hermes has no <code>SessionStart</code> hook equivalent — nudge/attribution is unsupported on this harness.',
+  },
+  {
+    id: 'grok',
+    label: 'Grok Build (xAI)',
+    configPath: '~/.grok/config.toml',
+    format: 'toml',
+    body: `[mcp_servers.@skillsmith/mcp-server]
+command = "npx"
+args = ["-y", "@skillsmith/mcp-server"]`,
+    notes:
+      'Grok Build uses TOML under a <code>[mcp_servers.NAME]</code> table, the same convention as Codex CLI above.',
   },
 ]
 

--- a/packages/website/src/pages/docs/inventory.astro
+++ b/packages/website/src/pages/docs/inventory.astro
@@ -256,13 +256,19 @@ skillsmith inventory purge --yes`}</code></pre>
         <td>Shared / Codex</td>
         <td><code>~/.agents/skills</code></td>
       </tr>
+      <tr>
+        <td>Grok Build</td>
+        <td><code>~/.grok/skills</code></td>
+      </tr>
     </tbody>
   </table>
 
   <p>
     Codex doesn't have its own directory — it reads skills from the shared, open-standard
     <code>~/.agents/skills</code> path, so Codex-managed skills appear under the shared harness
-    above.
+    above. Grok Build also reads that same shared <code>~/.agents/skills</code> path for
+    AGENTS.md-style compatibility, in addition to its own native
+    <code>~/.grok/skills</code> directory shown in the table above.
   </p>
 
   <p>


### PR DESCRIPTION
## Business Summary

**What shipped:** Grok Build (xAI's coding CLI) is now a recognized harness for
`skillsmith inventory push`/`status` — it scans `~/.grok/skills`, the same way it
already scans Claude Code, Cursor, Copilot, Windsurf, the shared Codex path,
OpenCode, and Hermes. Requested directly on the feature's UAT sign-up issue
(#1707) by a prospective tester.

**Quality bar:** Directory path verified against xAI's official developer
documentation, corroborated by independent third-party sources. Typecheck
surfaced a real compile-time gap this change forced (a compiler-enforced
exhaustive snippet table was missing the new harness) — fixed in the same PR,
along with its hand-maintained website mirror and parity test so the two don't
silently drift out of sync the way two earlier harnesses briefly did. 93 tests
green across the touched packages, lint/typecheck/audit:standards clean (0
failures), full pre-push security/format/test suite passed.

**Net result:** Fully shipped, pending publish. Cross-machine inventory scanning
works for Grok Build once this ships in a released `@skillsmith/core` +
`@skillsmith/cli` version — merging alone isn't enough for the requester to
test with, since they'll need to `npm install -g @skillsmith/cli` after
publish.

---

## Technical detail

- `packages/core/src/install/paths.ts` — added `'grok'` to `ClientId`,
  `CLIENT_NATIVE_PATHS`, and `CLIENT_IDS` (single source of truth consumed by
  both the CLI and MCP inventory scanners); updated the file's per-harness
  verification-log doc comment.
- `packages/core/src/install/paths.test.ts` — new `describe('grok ClientId
  (SMI-5697)')` block (follows the existing opencode/hermes precedent), fixed
  a `toHaveLength(7)` assertion that would have failed once `CLIENT_IDS` grew
  to 8 entries.
- `packages/cli/src/templates/mcp-server.template.snippets.ts` — added the
  `grok` entry to `CLIENT_SNIPPETS` (a `Record<SnippetClientId, ClientSnippet>`
  the compiler requires be exhaustive over `ClientId` — this is what the
  typecheck failure caught) and to `SNIPPET_DISPLAY_ORDER`. Grok Build's MCP
  config format (`~/.grok/config.toml`, `[mcp_servers.<name>]` TOML table)
  verified against `docs.x.ai/build/settings`.
- `packages/website/src/lib/mcp-client-snippets.ts` +
  `mcp-client-snippets.parity.test.ts` — mirrored the same addition on the
  website's hand-maintained copy (it can't import `@skillsmith/cli` at
  runtime) and its parity guard, per the existing SMI-5554 convention.
- `packages/website/src/pages/docs/inventory.astro` — new Harness Coverage
  table row, plus a note that Grok Build also reads the shared
  `~/.agents/skills` path (already covered by the existing `agents` harness,
  so users with skills only there can partially test today without this
  change).
- `CHANGELOG.md` — `[Unreleased]` entry (SMI-5680 gate).

Explicitly out of scope: `packages/core/src/install/agent-harness-targets.ts`
and the `sklx agent install` MCP/hook-registration feature (SMI-5456) — a
different capability (installing Skillsmith's own MCP server/hooks into a
harness) from inventory scanning (reading what skills are already installed).
Not requested here; would be a separate follow-up ticket.

Linear: SMI-5697 (parent umbrella SMI-5382).
