### PR TITLE
fix(claude-config): Repoint stale claude-flow hooks and statusline to ruflo

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -121,9 +121,10 @@ function getUserInfo() {
             }
           }
           // Parse model ID to human-readable name
-          if (modelId.includes('opus')) modelName = 'Opus 4.5'
-          else if (modelId.includes('sonnet')) modelName = 'Sonnet 4'
+          if (modelId.includes('opus')) modelName = 'Opus 4.8'
+          else if (modelId.includes('sonnet')) modelName = 'Sonnet 5'
           else if (modelId.includes('haiku')) modelName = 'Haiku 4.5'
+          else if (modelId.includes('fable')) modelName = 'Fable 5'
           else modelName = modelId.split('-').slice(1, 3).join(' ')
         }
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' ' | xargs -I {} sh -c 'CMD=\"{}\"; if [ -n \"$CMD\" ]; then npx claude-flow@3 hooks pre-command --command \"$CMD\" --validate-safety true --prepare-resources true 2>/dev/null || true; fi'"
+            "command": "cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' ' | xargs -I {} sh -c 'CMD=\"{}\"; if [ -n \"$CMD\" ]; then node node_modules/ruflo/bin/ruflo.js hooks pre-command --command \"$CMD\" --validate-safety true --prepare-resources true 2>/dev/null || true; fi'"
           }
         ]
       },
@@ -92,7 +92,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@3 hooks pre-edit --file '{}' --auto-assign-agents true --load-context true"
+            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} node node_modules/ruflo/bin/ruflo.js hooks pre-edit --file '{}' --auto-assign-agents true --load-context true"
           }
         ]
       },
@@ -112,7 +112,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' ' | xargs -I {} sh -c 'CMD=\"{}\"; if [ -n \"$CMD\" ]; then npx claude-flow@3 hooks post-command --command \"$CMD\" --success true --track-metrics true --store-results true 2>/dev/null || true; fi'"
+            "command": "cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' ' | xargs -I {} sh -c 'CMD=\"{}\"; if [ -n \"$CMD\" ]; then node node_modules/ruflo/bin/ruflo.js hooks post-command --command \"$CMD\" --success true --track-metrics true --store-results true 2>/dev/null || true; fi'"
           }
         ]
       },
@@ -121,7 +121,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} sh -c 'FILE=\"{}\"; if [ -n \"$FILE\" ]; then npx claude-flow@3 hooks post-edit --file \"$FILE\" --success true --format true --update-memory true 2>/dev/null || true; fi'"
+            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} sh -c 'FILE=\"{}\"; if [ -n \"$FILE\" ]; then node node_modules/ruflo/bin/ruflo.js hooks post-edit --file \"$FILE\" --success true --format true --update-memory true 2>/dev/null || true; fi'"
           }
         ]
       },
@@ -188,7 +188,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx claude-flow@3 hooks session-end --generate-summary true --persist-state true --export-metrics true"
+            "command": "node node_modules/ruflo/bin/ruflo.js hooks session-end --generate-summary true --persist-state true --export-metrics true"
           }
         ]
       }
@@ -198,6 +198,6 @@
   "enabledMcpjsonServers": ["skillsmith", "skillsmith-doc-retrieval", "ruflo"],
   "statusLine": {
     "type": "command",
-    "command": "node node_modules/ruflo/bin/ruflo.js hooks statusline || node .claude/helpers/statusline.cjs || echo RuFlo V3"
+    "command": "node .claude/helpers/statusline.cjs || echo RuFlo V3"
   }
 }


### PR DESCRIPTION
## Business Summary

**What shipped:** The Claude Code statusline stopped showing a hardcoded, always-wrong "Opus 4.6 (1M context)" and now shows the actual active model. Five internal Claude Code hooks that were still calling the old `claude-flow` tool name now call its renamed successor, `ruflo`, directly.

**Quality bar:** Both changed commands manually verified end-to-end (hook binary runs and exits clean; statusline renders a correct, current model name). `npm run audit:standards`: 0 failures, only pre-existing warnings unrelated to this change. Governance code-review report on file (SMI-5706).

**Found along the way:** other stale `claude-flow` references remain in `docker-compose.yml` and several `scripts/*.sh` orchestration scripts — flagged in SMI-5706's description rather than fixed here, since those paths require the heavier SPARC + plan-review process (ADR-109). Also surfaced a legitimate upstream bug in the third-party `@claude-flow/cli` package itself (hardcodes the model name, ignores its own documented stdin contract) — worth reporting to `ruvnet/claude-flow`.

**Net result:** Fully shipped, no blocking follow-up.

---

## Technical detail

- `.claude/settings.json`: dropped the broken `ruflo hooks statusline` call from the `statusLine` command chain (it always "succeeded" with the wrong hardcoded model name, permanently masking the working `.claude/helpers/statusline.cjs` fallback). Swapped all 5 hook commands (`pre-command`, `pre-edit`, `post-command`, `post-edit`, `session-end`) from `npx claude-flow@3 hooks X` to `node node_modules/ruflo/bin/ruflo.js hooks X` — a literal binary substitution (`ruflo` is a thin wrapper around the same `@claude-flow/cli` code, identical CLI surface), using the local binary to avoid `npx` version-resolution drift vs. `.mcp.json`'s pinned `ruflo@3.14.2`.
- `.claude/helpers/statusline.cjs`: corrected its own independently-stale model-ID map (`Opus 4.5`→`4.8`, `Sonnet 4`→`5`, added a missing `fable` branch).
- `docs/internal` submodule pointer bump: mandatory governance code-review report (SMI-5706), no functional change.

Linear: SMI-5706. Related: filed the docker-compose.yml/scripts/*.sh follow-up in the same issue's description rather than a separate ticket, since it's advisory/tracked, not actioned.

[skip-impl-check]
