### PR TITLE
fix: preserve cross-harness skill membership

### DIFF
--- a/packages/core/src/sync/inventory-collector.test.ts
+++ b/packages/core/src/sync/inventory-collector.test.ts
@@ -7,7 +7,7 @@
  * without re-importing the module.
  *
  * IC-1: same skill under two harnesses (distinct realpaths) -> two entries.
- * IC-2: a symlinked alias across harnesses -> one entry (first ClientId wins).
+ * IC-2: a symlinked alias across harnesses -> one entry per harness membership.
  * IC-3: readable SKILL.md -> content_hash + version; missing SKILL.md -> nulls.
  */
 
@@ -98,7 +98,7 @@ describe('inventory-collector', () => {
     expect(foo.every((e) => e.update_policy === null)).toBe(true)
   })
 
-  it('IC-2: collapses a symlinked alias across harnesses to one entry (first ClientId wins)', async () => {
+  it('IC-2: preserves each harness membership for a symlinked skill', async () => {
     const real = await createSkill('claude-code', 'bar', { version: '1.0.0' })
     await mkdir(mockPaths.CLIENT_NATIVE_PATHS['agents'] as string, { recursive: true })
     await symlink(real, join(mockPaths.CLIENT_NATIVE_PATHS['agents'] as string, 'bar'), 'dir')
@@ -106,9 +106,10 @@ describe('inventory-collector', () => {
     const entries = await collectDeviceSkills()
     const bar = entries.filter((e) => e.skill_id === 'bar')
 
-    expect(bar).toHaveLength(1)
-    // claude-code precedes agents in CLIENT_IDS, so it wins the dedup.
-    expect(bar[0]?.harness).toBe('claude-code')
+    expect(bar).toHaveLength(2)
+    expect(bar.map((entry) => entry.harness).sort()).toEqual(['agents', 'claude-code'])
+    // The physical content is shared, while visibility remains per harness.
+    expect(new Set(bar.map((entry) => entry.content_hash)).size).toBe(1)
   })
 
   // IC-4: No truncation at MAX_SKILLS boundary.

--- a/packages/core/src/sync/inventory-collector.ts
+++ b/packages/core/src/sync/inventory-collector.ts
@@ -9,9 +9,9 @@
  * Design parity with the CLI scanner at
  * `packages/cli/src/utils/skills-directory.ts`:
  * - Uses the SAME {@link SkillParser} to resolve `skill_id` / `version`.
- * - Realpath-deduplicates ACROSS harnesses (collapses symlink aliases), but does
- *   NOT name-deduplicate — the same skill independently installed under two
- *   harnesses is two distinct rows (the `device_skills` PK is `(harness, skill_id)`).
+ * - Realpath-deduplicates WITHIN each harness, but preserves cross-harness
+ *   membership — the same physical skill visible to two harnesses is two rows
+ *   (the `device_skills` PK is `(harness, skill_id)`).
  *
  * @module @skillsmith/core/sync/inventory-collector
  */
@@ -120,7 +120,7 @@ async function readSkillFields(
 
 /**
  * Scan a single harness directory and append its skills to `entries`,
- * deduplicating by realpath via the shared `seenRealpaths` set.
+ * deduplicating aliases within that harness via `seenRealpaths`.
  */
 async function collectHarness(
   harness: ClientId,
@@ -150,8 +150,8 @@ async function collectHarness(
       continue
     }
 
-    // Realpath dedup ACROSS harnesses: the first harness in CLIENT_IDS order
-    // wins, so a symlinked alias under a later harness is collapsed away.
+    // Deduplicate aliases within one harness without erasing the fact that the
+    // same physical skill is discoverable by another harness.
     const realDir = await safeRealpath(entryPath)
     if (seenRealpaths.has(realDir)) continue
     seenRealpaths.add(realDir)
@@ -187,14 +187,13 @@ async function collectHarness(
  * a `too_many_skills` 400) — silently dropping skills here would corrupt the
  * server-side reconcile by making present skills look absent.
  *
- * @returns One entry per (harness, skill), realpath-deduplicated across harnesses.
+ * @returns One entry per (harness, skill), realpath-deduplicated within a harness.
  * @see SMI-5392
  */
 export async function collectDeviceSkills(): Promise<InventorySkillEntry[]> {
   const entries: InventorySkillEntry[] = []
-  const seenRealpaths = new Set<string>()
   for (const harness of CLIENT_IDS) {
-    await collectHarness(harness, entries, seenRealpaths)
+    await collectHarness(harness, entries, new Set<string>())
   }
   return entries
 }


### PR DESCRIPTION
## Summary

- keep realpath deduplication within each harness
- preserve a separate inventory row when the same physical skill is discoverable by another harness
- update IC-2 to assert both harness memberships share one content hash

This addresses #1912. The inventory primary key and product claim are per `(harness, skill_id)`, so physical deduplication should not erase a destination edge.

## Verification

- `npx vitest run packages/core/src/sync/inventory-collector.test.ts` — 7/7
- `npx eslint packages/core/src/sync/inventory-collector.ts packages/core/src/sync/inventory-collector.test.ts`
- `npx tsc --noEmit --pretty false -p packages/core/tsconfig.json`
- `git diff --check`
