### PR TITLE
fix(claude-config): Match ruflo in statusline sub-agent process count

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -310,14 +310,15 @@ function getSystemMetrics() {
     if (isWindows) {
       // Windows: use tasklist and findstr for agent counting
       const agents = execSync(
-        'tasklist 2>NUL | findstr /I "claude-flow" 2>NUL | find /C /V "" 2>NUL || echo 0',
+        'tasklist 2>NUL | findstr /I "claude-flow ruflo" 2>NUL | find /C /V "" 2>NUL || echo 0',
         { encoding: 'utf-8' }
       )
       subAgents = Math.max(0, parseInt(agents.trim()) || 0)
     } else {
-      const agents = execSync('ps aux 2>/dev/null | grep -c "claude-flow.*agent" || echo "0"', {
-        encoding: 'utf-8',
-      })
+      const agents = execSync(
+        'ps aux 2>/dev/null | grep -cE "(claude-flow|ruflo).*agent" || echo "0"',
+        { encoding: 'utf-8' }
+      )
       subAgents = Math.max(0, parseInt(agents.trim()) - 1)
     }
   } catch (e) {


### PR DESCRIPTION
## Business Summary

**What shipped:** A follow-up fix found during the mandatory post-merge retro on PR #1911 (SMI-5706). That PR fixed the Claude Code statusline's always-wrong model name and repointed 5 hooks from the old `claude-flow` tool name to its renamed successor `ruflo`. The retro found one more spot the rebrand missed in the same file: the statusline's "active sub-agent count" indicator counts processes by searching for the literal string `claude-flow` in the process list, which stopped matching once the hooks and MCP server started running as `ruflo` — so the counter has been silently stuck reporting 0 since PR #1911 merged.

**Quality bar:** Manually verified the process-list search now matches real running `ruflo` processes (confirmed via `ps aux` against this machine's live MCP server processes) while still matching the still-unmigrated `claude-flow` swarm-orchestration scripts (`scripts/*.sh`, flagged separately in SMI-5706 as out of scope pending an ADR-109 SPARC pass). `npx prettier --check` and full pre-push suite (security tests, typecheck, format, tests) all green.

**Found along the way:** Nothing further — this was itself a "found along the way" item from SMI-5706's retro.

**Net result:** Fully shipped, no blocking follow-up. Statusline sub-agent counter works again for both the migrated and not-yet-migrated invocation paths.

## Technical detail

`.claude/helpers/statusline.cjs`'s `getUserInfo()`/agent-counting block greps `ps aux` (and `tasklist` on Windows) for `"claude-flow.*agent"` / `"claude-flow"` to count active sub-agent processes for the statusline display. PR #1911 repointed the harness's own hooks to invoke `node node_modules/ruflo/bin/ruflo.js` directly instead of `npx claude-flow@3`, so those processes no longer contain the string `claude-flow` anywhere in their command line — the grep still exits 0 (no match found is not an error), so this failed exactly the same silent-wrong-data way the model name bug did.

Fix: match `(claude-flow|ruflo)` instead of `claude-flow` alone, on both the POSIX (`grep -cE`) and Windows (`findstr /I "claude-flow ruflo"`) branches. Matching both names (not just `ruflo`) keeps the counter working against the out-of-scope swarm-orchestration scripts that still invoke `claude-flow` directly until their own ADR-109-gated cleanup lands.

This PR only touches a harness config helper (`.claude/helpers/statusline.cjs`) — no `packages/` source — so it hits the same `verify-implementation` false-positive #1911 did.

[skip-impl-check]

Refs SMI-5706