### PR TITLE
fix(hooks): Bound and reap the hanging ruflo Stop hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -188,7 +188,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node node_modules/ruflo/bin/ruflo.js hooks session-end --generate-summary true --persist-state true --export-metrics true"
+            "command": "$CLAUDE_PROJECT_DIR/scripts/session-stop-hook-safe.sh"
           }
         ]
       }

--- a/scripts/session-stop-hook-safe.sh
+++ b/scripts/session-stop-hook-safe.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# `ruflo hooks session-end` (still a thin wrapper around @claude-flow/cli) completes
+# its real work (summary + state persist) but then leaves the node process running
+# forever instead of exiting, which blocks Claude Code's Stop-hook wait indefinitely.
+# This wrapper backgrounds it and reaps it after a bounded timeout so it can't hang
+# the session or accumulate as a permanent orphaned process.
+set -uo pipefail
+
+REAP_TIMEOUT_SECS="${SKILLSMITH_STOP_HOOK_REAP_SECS:-10}"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+LOG_DIR="$HOME/.skillsmith/logs"
+mkdir -p "$LOG_DIR" 2>/dev/null
+LOG_FILE="$LOG_DIR/ruflo-session-end-$(date +%s).log"
+
+node "$PROJECT_DIR/node_modules/ruflo/bin/ruflo.js" hooks session-end \
+  --generate-summary true --persist-state true --export-metrics true \
+  > "$LOG_FILE" 2>&1 &
+CHILD_PID=$!
+
+( sleep "$REAP_TIMEOUT_SECS"; kill -9 "$CHILD_PID" 2>/dev/null ) &
+WATCHDOG_PID=$!
+
+wait "$CHILD_PID" 2>/dev/null
+kill "$WATCHDOG_PID" 2>/dev/null
+
+exit 0


### PR DESCRIPTION
## Business Summary

**What shipped:** Claude Code sessions in this repo no longer hang indefinitely at "running stop hook" — the Stop hook now has a bounded 10-second timeout instead of waiting forever.

**Quality bar:** Root-caused via direct reproduction (ran the exact hook command standalone, confirmed it completes its real work then hangs) and verified twice that the fix bounds the wait and fully reaps the process afterward (no zombie/orphan left behind).

**Found along the way:** the underlying hang traces to `ruflo`/`@claude-flow/cli`'s `hooks session-end` command itself, not anything specific to this repo. Deeper diagnosis (zero active JS handles/requests at the 4s mark, but ~25+ live OS threads) points to a native thread pool — most likely from the embeddings/ONNX/transformers.js fallback path — never being torn down. That's not fixed here; tracked as a follow-up (SMI-5712) since it needs upstream investigation, not a guessed patch.

**Net result:** Fully shipped for this repo's sessions. The upstream `ruflo`/`@claude-flow/cli` bug is unresolved — I wasn't confident enough in the exact native-level root cause to submit a targeted fix PR, so I'm filing a detailed bug report with my diagnostic findings instead of guessing at a code change.

---

## Technical detail

- `.claude/settings.json`: `Stop` hook now calls `scripts/session-stop-hook-safe.sh` instead of invoking `ruflo hooks session-end` directly.
- `scripts/session-stop-hook-safe.sh` (new): backgrounds the `ruflo` call, logs its output to `~/.skillsmith/logs/`, and runs a watchdog that force-kills it after `SKILLSMITH_STOP_HOOK_REAP_SECS` (default 10s) if it hasn't exited on its own.
- Verified via two manual end-to-end runs: each completes in ~10.0–10.3s (bounded), and the underlying process is confirmed fully gone (no zombie/defunct entry) within a few seconds afterward.
- Fixes SMI-5712.