### PR TITLE
fix(doc-retrieval-mcp): Refuse to promote current:0 into prior on write (SMI-5708 governance retro)

### DIFF
--- a/packages/doc-retrieval-mcp/eval/eval-runner-baseline.ts
+++ b/packages/doc-retrieval-mcp/eval/eval-runner-baseline.ts
@@ -200,6 +200,40 @@ export function updateBaseline(
     // at this point (never null -- unlike `prior`, which may legitimately be
     // null only alongside `bootstrapped: true`).
     existingCurrent = validated.current
+    // Governance retro finding (SMI-5708 post-merge) -- `current`'s valid
+    // range is [0, 1] INCLUSIVE of 0 (a genuinely terrible eval run that
+    // found zero relevant results is real data, not corruption -- see Test
+    // 10 in corpus-stats.test.ts), but the top-level `prior` field's valid
+    // range deliberately EXCLUDES exactly 0 (validateBaselineFile rejects
+    // `prior === 0` -- it was the original silent-skip loophole Item #3
+    // closes). Promoting an existing `current: 0` forward unchecked as the
+    // new `prior` (the line below, before this guard existed) writes a
+    // baseline.json that fails ITS OWN schema validation on the very next
+    // read: both check-baseline-drift.ts's unconditional per-CI-run
+    // validation (hard-failing every subsequent PR that touches
+    // ranking/eval files, not just the one that produced it, with a
+    // misleading "corrupted/hand-edited" message) and this very function's
+    // own existing-file check on the NEXT updateBaseline() call -- which
+    // means the "just re-run RETRIEVAL_EVAL_REAL=1 npm run eval:retrieval"
+    // self-service recovery every error message in this file recommends
+    // throws instead of fixing anything. Empirically reproduced: seed an
+    // existing baseline with current: 0, call updateBaseline() once (writes
+    // prior: 0 successfully), then call it again -- the second call throws
+    // reading its own prior output. Fail loudly HERE instead, before ever
+    // writing the unpromotable value, mirroring this function's existing
+    // "hard error, not silent" handling of malformed/corrupted existing
+    // files just above.
+    if (existingCurrent === 0) {
+      throw new Error(
+        `updateBaseline: existing baseline.json at ${baselinePath} has current: 0, which cannot ` +
+          'be safely promoted to prior (prior must be > 0 -- a value of exactly 0 fails schema ' +
+          'validation on the next read, per validateBaselineFile). This usually means a prior ' +
+          'real-mode run scored zero recall -- a severe regression that should have been caught ' +
+          'by the drift gate before merging -- or baseline.json was hand-edited. Investigate the ' +
+          'zero-recall run, then either fix the underlying regression and re-run, or restore ' +
+          'baseline.json from git history before running eval:retrieval again.'
+      )
+    }
     if (validated.byCategory && validated.byCategory.recallAt5) {
       existingByCategoryCurrent = validated.byCategory.recallAt5
     }

--- a/packages/doc-retrieval-mcp/tests/eval/corpus-stats.test.ts
+++ b/packages/doc-retrieval-mcp/tests/eval/corpus-stats.test.ts
@@ -241,11 +241,22 @@ describe('updateBaseline (SMI-4763 regression guard)', () => {
   // pass through and get silently promoted as the new prior. updateBaseline()
   // now reuses the full schema validator (validateBaselineFile) instead,
   // closing this gap the same way the reader is closed.
-  it('Test 10: an EXISTING baseline.json with current: 0 is valid (a real run can score zero recall)', () => {
-    // Unlike `prior` (where exactly 0 was the original silent-skip loophole
-    // and is deliberately rejected), `current`'s range is inclusive [0, 1] --
-    // a genuinely terrible eval run that found zero relevant results is real
-    // data, not corruption, and must not be rejected.
+  //
+  // Governance retro finding (SMI-5708 post-merge): this test originally
+  // asserted that promoting an existing `current: 0` forward to a new
+  // `prior: 0` SUCCEEDS -- but `prior === 0` fails validateBaselineFile's
+  // OWN schema check (it's the original silent-skip loophole this whole
+  // item closes), so that "successful" write immediately failed schema
+  // validation on the very next read: both check-baseline-drift.ts's
+  // unconditional per-CI-run validation (blocking every subsequent PR that
+  // touches ranking/eval files, not just this one) and updateBaseline()'s
+  // own existing-file check on the NEXT call (breaking the "just re-run the
+  // eval" self-service recovery path every error message in this file
+  // recommends). `current: 0` itself remains valid, readable data (a
+  // genuinely terrible eval run that found zero relevant results is real,
+  // not corruption) -- what's now rejected is silently PROMOTING it forward
+  // as an unpromotable `prior`.
+  it('Test 10: an EXISTING baseline.json with current: 0 cannot be silently promoted to prior: 0 (would fail schema validation on the next read)', () => {
     const baselinePath = join(tmpDir, 'baseline.json')
     const stateFile = writeStateFile({ 'memory://a.md': 5 })
     writeFileSync(
@@ -254,9 +265,14 @@ describe('updateBaseline (SMI-4763 regression guard)', () => {
       'utf8'
     )
 
-    expect(() => updateBaseline(makeReport(0.5), { baselinePath, stateFile })).not.toThrow()
-    const after = JSON.parse(readFileSync(baselinePath, 'utf8')) as BaselineFile
-    expect(after.prior).toBe(0) // promoted correctly from the existing current: 0
+    expect(() => updateBaseline(makeReport(0.5), { baselinePath, stateFile })).toThrow(
+      /current: 0, which cannot be safely promoted to prior/
+    )
+    // The existing (pre-corruption) file must be left byte-for-byte
+    // unchanged -- the throw happens before writeFileAtomicSync is ever
+    // called, so nothing on disk was touched.
+    const after = readFileSync(baselinePath, 'utf8')
+    expect(JSON.parse(after)).toEqual({ prior: 0.5, current: 0, bootstrapped: false })
   })
 
   it('Test 10b: an EXISTING baseline.json with current: -1 (genuinely out of range) throws', () => {


### PR DESCRIPTION
## Business Summary

**What shipped:** A follow-up fix for a bug the post-merge governance retro on [PR #1920](https://github.com/smith-horn/skillsmith/pull/1920) (SMI-5708 Wave 1) found — a real gap between two of that PR's six fixes that neither's individual review caught, because each was reviewed in isolation.

The retrieval-eval harness's `baseline.json` has two related numeric fields: `current` (this run's score, where exactly 0 is valid — a real eval run can genuinely find zero relevant results) and `prior` (last run's score, promoted forward from `current` on the next write). Wave 1 made the schema validator reject `prior: 0` specifically (closing an old loophole where a zeroed baseline could silently disable the regression check) — but left the promotion logic unguarded, so an existing `current: 0` still got carried forward unchanged into the new `prior` field. The result: a baseline write that immediately fails its own validation on the very next read, blocking every subsequent PR touching ranking/eval files (not just the one that triggered it) and breaking the harness's own documented "just re-run the eval" recovery instructions.

**Quality bar:** Found by an independent governance-specialist subagent doing a fresh, whole-diff pass over the six merged Wave 1 fixes together (rather than re-confirming each fix individually, which is what the pre-merge review already did three times over). I independently verified the claim against the actual validator source (confirmed the asymmetric range check: `current` allows `[0, 1]`, `prior` requires `(0, 1]`), confirmed the unguarded promotion line, and reproduced the failure chain before accepting the fix. Full eval test suite (178 tests) plus the specific regression test pass; lint/typecheck clean.

**Net result:** Closes a latent edge case in already-merged Wave 1 code — not a live production break (the real committed `baseline.json` has healthy non-zero values), but a real trap for the next zero-recall run.

---

## Technical detail

`packages/doc-retrieval-mcp/eval/eval-runner-baseline.ts` — `updateBaseline()` now throws before promoting an existing `current: 0` to the new `prior`, with an actionable error message pointing at the underlying zero-recall run.

`packages/doc-retrieval-mcp/tests/eval/corpus-stats.test.ts` — Test 10 previously asserted the buggy promotion as correct; now asserts the throw and confirms the existing file is left byte-for-byte unchanged (the throw happens before the atomic write).

Refs SMI-5708
