### PR TITLE
fix(hooks): stop-hook watchdog waited full timeout on the happy path

### DIFF
--- a/scripts/session-stop-hook-safe.sh
+++ b/scripts/session-stop-hook-safe.sh
@@ -7,20 +7,47 @@
 set -uo pipefail
 
 REAP_TIMEOUT_SECS="${SKILLSMITH_STOP_HOOK_REAP_SECS:-10}"
+LOG_RETENTION_DAYS="${SKILLSMITH_STOP_HOOK_LOG_RETENTION_DAYS:-7}"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 LOG_DIR="$HOME/.skillsmith/logs"
 mkdir -p "$LOG_DIR" 2>/dev/null
 LOG_FILE="$LOG_DIR/ruflo-session-end-$(date +%s).log"
+
+# One log file per Stop hook invocation, unbounded otherwise. Prune stale
+# ones before writing a new one so this doesn't accumulate forever.
+find "$LOG_DIR" -maxdepth 1 -name 'ruflo-session-end-*.log' -mtime "+${LOG_RETENTION_DAYS}" -delete 2>/dev/null
 
 node "$PROJECT_DIR/node_modules/ruflo/bin/ruflo.js" hooks session-end \
   --generate-summary true --persist-state true --export-metrics true \
   > "$LOG_FILE" 2>&1 &
 CHILD_PID=$!
 
-( sleep "$REAP_TIMEOUT_SECS"; kill -9 "$CHILD_PID" 2>/dev/null ) &
+# SKILLSMITH_STOP_HOOK follow-up (retro on SMI-5712/PR #1915): the watchdog
+# must be the `sleep` process ITSELF, not a wrapping `( sleep N; kill ... ) &`
+# subshell. A wrapped subshell forks `sleep` as its OWN child, so killing the
+# subshell's PID (below) does not kill that grandchild — the orphaned sleep
+# keeps running and keeps its inherited stdout/stderr fd open. A caller that
+# captures this script's output via a pipe (Node's `child_process.spawnSync`,
+# which is how Claude Code itself invokes hook commands, and how this file's
+# own test harness invokes it) doesn't see EOF until every fd holder exits —
+# so the ORIGINAL wrapped-subshell version silently waited the FULL
+# REAP_TIMEOUT_SECS on every single happy-path exit, not just on an actual
+# hang. Tracking the bare `sleep` PID directly means killing it terminates
+# the real blocking process immediately, closing its fd right away.
+sleep "$REAP_TIMEOUT_SECS" &
 WATCHDOG_PID=$!
 
-wait "$CHILD_PID" 2>/dev/null
+while kill -0 "$CHILD_PID" 2>/dev/null && kill -0 "$WATCHDOG_PID" 2>/dev/null; do
+  sleep 0.2
+done
+
+if kill -0 "$CHILD_PID" 2>/dev/null; then
+  # Watchdog fired first: the real command is still running past the bound.
+  kill -9 "$CHILD_PID" 2>/dev/null
+fi
 kill "$WATCHDOG_PID" 2>/dev/null
+
+wait "$CHILD_PID" 2>/dev/null
+wait "$WATCHDOG_PID" 2>/dev/null
 
 exit 0

--- a/scripts/tests/session-stop-hook-safe.test.ts
+++ b/scripts/tests/session-stop-hook-safe.test.ts
@@ -1,0 +1,97 @@
+/**
+ * SMI-5712 retro follow-up: tests for scripts/session-stop-hook-safe.sh.
+ *
+ * Drives the script against a fabricated `$CLAUDE_PROJECT_DIR` containing a
+ * stub `node_modules/ruflo/bin/ruflo.js` — never the real ruflo binary, which
+ * is the very thing this wrapper exists to bound. Each fixture stub is a tiny
+ * Node script controlling its own exit timing so the reap/no-reap paths are
+ * deterministic.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, writeFileSync, rmSync, readdirSync, utimesSync } from 'node:fs'
+import { join } from 'node:path'
+import { makeFixtureTempDir } from './_lib/git-fixture-env'
+
+const SCRIPT = join(__dirname, '..', 'session-stop-hook-safe.sh')
+
+function writeStub(projectDir: string, body: string) {
+  const binDir = join(projectDir, 'node_modules', 'ruflo', 'bin')
+  mkdirSync(binDir, { recursive: true })
+  writeFileSync(join(binDir, 'ruflo.js'), body)
+}
+
+function runHook(projectDir: string, extraEnv: Record<string, string> = {}) {
+  return spawnSync('bash', [SCRIPT], {
+    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir, HOME: projectDir, ...extraEnv },
+    encoding: 'utf8',
+  })
+}
+
+describe('session-stop-hook-safe.sh', () => {
+  let projectDir: string
+
+  beforeEach(() => {
+    projectDir = makeFixtureTempDir('stop-hook-safe')
+  })
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true })
+  })
+
+  it('exits 0 well before the reap timeout when the underlying command finishes on its own', () => {
+    // Regression guard: an earlier version wrapped the watchdog's `sleep` in
+    // an extra `( sleep N; kill ... ) &` subshell. Killing the subshell's PID
+    // didn't kill the `sleep` it forked as ITS OWN child, so the orphaned
+    // sleep kept the inherited stdout/stderr pipe open for the FULL
+    // REAP_TIMEOUT_SECS regardless of how fast the real command exited — a
+    // caller reading this script's output via a pipe (spawnSync, exactly how
+    // Claude Code itself invokes hook commands) saw no EOF until then. This
+    // asserts the happy path is fast, not merely "eventually returns".
+    writeStub(projectDir, 'process.exit(0)')
+    const start = Date.now()
+    const result = runHook(projectDir, { SKILLSMITH_STOP_HOOK_REAP_SECS: '20' })
+    const elapsed = Date.now() - start
+    expect(result.status).toBe(0)
+    expect(elapsed).toBeLessThan(3000)
+  })
+
+  it('reaps a hanging process after the bounded timeout instead of hanging forever', () => {
+    // Never exits on its own — the exact SMI-5712 failure mode.
+    writeStub(projectDir, 'setInterval(() => {}, 1000)')
+    const start = Date.now()
+    const result = runHook(projectDir, { SKILLSMITH_STOP_HOOK_REAP_SECS: '1' })
+    const elapsed = Date.now() - start
+    expect(result.status).toBe(0)
+    expect(elapsed).toBeGreaterThanOrEqual(900)
+    expect(elapsed).toBeLessThan(5000)
+  })
+
+  it('prunes log files older than the retention window before writing a new one', () => {
+    writeStub(projectDir, 'process.exit(0)')
+    const logDir = join(projectDir, '.skillsmith', 'logs')
+    mkdirSync(logDir, { recursive: true })
+    const staleLog = join(logDir, 'ruflo-session-end-111.log')
+    writeFileSync(staleLog, 'old')
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000)
+    utimesSync(staleLog, eightDaysAgo, eightDaysAgo)
+
+    runHook(projectDir, { SKILLSMITH_STOP_HOOK_LOG_RETENTION_DAYS: '7' })
+
+    const remaining = readdirSync(logDir)
+    expect(remaining).not.toContain('ruflo-session-end-111.log')
+  })
+
+  it('does not prune a log file within the retention window', () => {
+    writeStub(projectDir, 'process.exit(0)')
+    const logDir = join(projectDir, '.skillsmith', 'logs')
+    mkdirSync(logDir, { recursive: true })
+    const freshLog = join(logDir, 'ruflo-session-end-222.log')
+    writeFileSync(freshLog, 'recent')
+
+    runHook(projectDir, { SKILLSMITH_STOP_HOOK_LOG_RETENTION_DAYS: '7' })
+
+    const remaining = readdirSync(logDir)
+    expect(remaining).toContain('ruflo-session-end-222.log')
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** A follow-up fix to the just-merged Stop-hook fix (PR #1915, SMI-5712). That fix correctly stopped Claude Code sessions from hanging forever, but a bug in it meant every single session close was now silently taking the full 10-second timeout, every time — not just when something actually hung. This PR fixes that, so a normal session close is fast again, and the 10-second bound only kicks in on an actual hang. Also adds basic cleanup so the wrapper's log files don't accumulate forever.

**Quality bar:** Found via a governance retrospective on the merged PR (writing a test for the fix exposed the bug — the "happy path" test consistently took exactly the configured timeout instead of finishing quickly). Root-caused precisely (a subshell/orphaned-process quirk in how the watchdog killed its own timer) and fixed with a regression test that specifically guards against this exact failure mode recurring.

**Found along the way:** the log file this wrapper writes on every session close had no cleanup — harmless short-term, but would accumulate indefinitely over time. Added a 7-day retention prune.

**Net result:** Fully shipped. Also noted for the record: upstream `ruflo` confirmed the underlying hang as a real bug (ruvnet/ruflo#2691) and has a fix landing in 3.32.2 — once we bump the pinned `ruflo` version, this whole local workaround may become removable (tracked on SMI-5712, not actioned here since we can't depend on an unreleased version).

---

## Technical detail

Governance retrospective follow-up on PR #1915 (SMI-5712). Two issues found reviewing the merged diff:

1. **Log accumulation**: `scripts/session-stop-hook-safe.sh` wrote one timestamped log file per Stop-hook invocation with no rotation, growing unbounded. Added retention pruning (default 7 days, `SKILLSMITH_STOP_HOOK_LOG_RETENTION_DAYS`).

2. **Watchdog didn't actually kill its own timer**: the original watchdog wrapped its sleep in a subshell — `( sleep N; kill CHILD_PID ) &`. Killing that subshell's PID doesn't kill the `sleep` it forked as its OWN child; the orphaned `sleep` keeps running and keeps the inherited stdout/stderr pipe open. A caller reading this script's output via a pipe (Node's `child_process.spawnSync`, which is how Claude Code itself invokes hook commands) doesn't see EOF until that orphan exits — so every happy-path session end silently waited the FULL `REAP_TIMEOUT_SECS` (10s default), not just an actual hang, defeating the fix's own intent. Fixed by tracking the bare `sleep` PID directly instead of wrapping it, so killing it terminates the real process immediately.

Added `scripts/tests/session-stop-hook-safe.test.ts` (4 tests) covering both the happy-path and reap-timeout paths plus log rotation, using a stub `ruflo.js` so the tests don't depend on the real binary's behavior. Writing the happy-path test is what caught bug #2 — it consistently measured the exact configured timeout instead of finishing quickly.

Refs SMI-5712.