### PR TITLE
fix(ruflo): Deny hooks_model-route; bump docs/internal pointer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,7 +73,8 @@
       "mcp__ruflo__claims_handoff",
       "mcp__ruflo__claims_accept-handoff",
       "mcp__ruflo__hooks_post-task",
-      "mcp__ruflo__hooks_model-outcome"
+      "mcp__ruflo__hooks_model-outcome",
+      "mcp__ruflo__hooks_model-route"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Business Summary

**What shipped:** A Ruflo MCP tool (`hooks_model-route`) that was configured as safe to use is now correctly blocked — it was silently mutating shared session state on every call, even when called from an isolated worktree. This closes out fact-checking a vendor's reply about a third-party tool Skillsmith already declined to adopt (companion docs PR: smith-horn/skillsmith-docs#463), which is where this misclassification was found.

**Quality bar:** The tool's actual write behavior was confirmed with a controlled before/after test of the real state file, independently re-checked by a second reviewer, then the fix itself was reviewed via `/plan-review-skill` before being applied — including source-level confirmation (reading the installed package directly, not assuming) that blocking it is the right call and doesn't foreclose a working capability. Full pre-push suite green: security tests, npm audit (no high-severity findings), format, and the full package test suite. Governance code review: 0 findings in the diff (report in the docs/internal companion PR).

**Found along the way:** the same plan-review pass found three more Ruflo tools with this same class of misclassification (documented read-only, actually persist data) — filed separately as SMI-5729 since they need the same rigor of verification this fix used, which would have expanded this PR's scope.

**Net result:** Fully shipped, no follow-up needed on this specific tool. SMI-5729 is open, tracked separately, not blocking.

---

## Technical detail

- `.claude/settings.json` — `permissions.deny` gains `mcp__ruflo__hooks_model-route` (42 → 43 `mcp__ruflo__*` entries), the enforced surface for Ruflo tool blocking per SMI-4427.
- `docs/internal` submodule pointer bump — picks up `ruflo-tool-classification.md`'s reclassification, an ADR-127 addendum, and the governance code review report (skillsmith-docs#463).
- This PR is config + submodule-pointer only, no application source code — `[skip-impl-check]` (verify-implementation's SMI-ref scan otherwise expects source changes for the referenced issues).
- Verification: `docker exec` pre-push suite (security tests, prod npm audit, format, full test suite across `core`/`cli`/`mcp-server`/`enterprise`) all green. A full negative/positive test of the new deny entry (attempt the tool, confirm refusal; confirm the MCP server still connects) needs a live-session restart to pick up the settings change — not something this PR's CI can exercise, noted for whoever restarts next.

Refs SMI-5659, SMI-5728