### PR TITLE
fix(cli): Correct dangling @skillsmith/enterprise peer dep name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32942,10 +32942,10 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/enterprise": "*"
+        "@smith-horn/enterprise": "*"
       },
       "peerDependenciesMeta": {
-        "@skillsmith/enterprise": {
+        "@smith-horn/enterprise": {
           "optional": true
         }
       }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,10 +46,10 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@skillsmith/enterprise": "*"
+    "@smith-horn/enterprise": "*"
   },
   "peerDependenciesMeta": {
-    "@skillsmith/enterprise": {
+    "@smith-horn/enterprise": {
       "optional": true
     }
   },


### PR DESCRIPTION
## Business Summary

**What shipped:** `packages/cli`'s optional peer dependency on the enterprise package now references its real name, `@smith-horn/enterprise`, instead of a name (`@skillsmith/enterprise`) that no package in this workspace has ever used.

**Quality bar:** Typecheck, lint, `audit:standards` (Check 58's version-coherence guard now passes cleanly instead of warning on this dangling name), and the full pre-push security + test suite all green. Verified the fix takes effect in Turborepo's own dependency graph — `@skillsmith/cli`'s build now correctly picks up `@smith-horn/enterprise` as a build dependency.

**Net result:** Done, no follow-up. This was a dead/inert wildcard optional peer dep, so the rename can only make an already-inert declaration correct — it cannot introduce a new resolution failure.

---

## Technical detail

- `packages/cli/package.json` — renamed the `peerDependencies` + `peerDependenciesMeta` key from `@skillsmith/enterprise` to `@smith-horn/enterprise` (matching `packages/enterprise/package.json`'s real `name` field).
- `package-lock.json` — regenerated to match (2-line diff).
- Surfaced by SMI-5715's plan-review pass while auditing internal `@skillsmith/*`/`@smith-horn/*` dependency declarations for the new Check 58 version-coherence guard.

Refs SMI-5720.

[skip-impl-check]
