### PR TITLE
fix(hooks): Preserve staged submodule gitlinks in pre-commit re-add

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -196,6 +196,20 @@ echo "${YELLOW}[3/3] Running lint and format on staged files...${NC}"
 # on the full working tree. After lint-staged, we re-add only originally-staged files.
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=d)
 
+# SMI-5713: source the gitlink-preservation library (scripts/lib/preserve-gitlinks.sh
+# has the full rationale). Missing-lib case degrades LOUDLY, not silently — a stale
+# checkout must not reintroduce this bug without at least a visible warning.
+PRESERVE_GITLINKS_LIB="$(dirname "$0")/../scripts/lib/preserve-gitlinks.sh"
+if [ -r "$PRESERVE_GITLINKS_LIB" ]; then
+  # shellcheck source=../scripts/lib/preserve-gitlinks.sh
+  . "$PRESERVE_GITLINKS_LIB"
+else
+  echo "${YELLOW}⚠️  scripts/lib/preserve-gitlinks.sh missing — gitlink clobber protection disabled (rebase onto main to pick up SMI-5713)${NC}"
+  capture_staged_gitlinks() { :; }
+  restore_staged_gitlinks() { :; }
+fi
+STAGED_GITLINKS=$(capture_staged_gitlinks)
+
 # SMI-4451 Step 5 — frontmatter lint mode flag, consumed by the
 # `docs/internal/retros/*.md` rule in lint-staged.config.js. Default is
 # `warn` for the Wave 1 soak window. Flip to `error` ONLY after the 3-AND
@@ -209,6 +223,9 @@ if npx lint-staged --no-stash; then
     if [ -n "$STAGED_FILES" ]; then
       echo "$STAGED_FILES" | xargs git add --
     fi
+    # SMI-5713: Re-apply staged gitlink SHAs the blind `git add` above
+    # replaced with the locally-checked-out submodule commit.
+    restore_staged_gitlinks "$STAGED_GITLINKS"
     echo "${GREEN}  ✓ Lint and format passed${NC}"
 else
     echo ""

--- a/scripts/lib/preserve-gitlinks.sh
+++ b/scripts/lib/preserve-gitlinks.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# SMI-5713: Protect staged submodule gitlinks (mode 160000) from being
+# silently clobbered by .husky/pre-commit's post-lint-staged blind re-add.
+# `git add <submodule-path>` stages the working-tree checkout's commit, NOT
+# the previously staged SHA — a pointer staged via `git update-index
+# --cacheinfo` (e.g. a docs/internal bump to an upstream commit not checked
+# out locally) would otherwise be silently overwritten.
+
+# Prints "<new-sha> <path>" (one per line) for every staged mode-160000
+# entry in the current diff-cached. Call BEFORE anything mutates the index
+# (same snapshot point as pre-commit's own STAGED_FILES capture, line 197).
+capture_staged_gitlinks() {
+  git diff --cached --raw --no-abbrev --no-renames --diff-filter=d \
+    | while read -r _old_mode new_mode _old_sha new_sha _status path; do
+        if [ "$new_mode" = "160000" ]; then
+          printf '%s %s\n' "$new_sha" "$path"
+        fi
+      done
+}
+
+# Re-applies a capture_staged_gitlinks snapshot (passed as $1) via
+# `git update-index --cacheinfo`, overwriting whatever a blind `git add`
+# staged for that path in the meantime. Idempotent — a no-op if the path
+# was never actually clobbered. On a `git update-index` failure for a given
+# path, prints a diagnostic to stderr so a rare soft-failure is diagnosable
+# rather than silently wrong; does not abort the remaining entries (matches
+# the hook's no-`set -e` philosophy).
+restore_staged_gitlinks() {
+  snapshot="$1"
+  [ -n "$snapshot" ] || return 0
+  printf '%s\n' "$snapshot" | while read -r sha path; do
+    if ! git update-index --cacheinfo 160000 "$sha" "$path" 2>/dev/null; then
+      echo "⚠️  SMI-5713: could not restore gitlink $path to $sha — check its staged state before pushing" >&2
+    fi
+  done
+}

--- a/scripts/tests/preserve-gitlinks.test.ts
+++ b/scripts/tests/preserve-gitlinks.test.ts
@@ -1,0 +1,218 @@
+/**
+ * SMI-5713: Tests for scripts/lib/preserve-gitlinks.sh.
+ *
+ * `.husky/pre-commit`'s post-lint-staged re-add (`git add <path>`) is safe for
+ * regular files but wrong for a submodule gitlink (mode 160000): it stages the
+ * submodule's currently-checked-out working-tree commit, not whatever SHA was
+ * previously staged via `git update-index --cacheinfo`. This silently clobbers
+ * a deliberately-staged pointer to a commit not locally checked out — exactly
+ * the scenario a concurrent session sharing the same submodule checkout on a
+ * different branch produces.
+ *
+ * The library exposes two pure shell functions (capture/restore), not a
+ * standalone script — tests source it inside `sh -c` rather than spawning it
+ * directly, mirroring how `.husky/pre-commit` itself sources it.
+ *
+ * Drives against an isolated temp-dir fixture (a real parent+submodule git
+ * pair) — never the live repo tree.
+ *
+ * Cases (G- prefix):
+ *   G-1 CLOBBER FIXED:    capture before blind re-add, restore after → staged
+ *                         gitlink SHA is the pre-add value (SHA-B), not the
+ *                         submodule's live checkout (SHA-A).
+ *   G-2 NEGATIVE CONTROL: same fixture, WITHOUT calling capture/restore →
+ *                         blind re-add wins → staged SHA reverts to SHA-A —
+ *                         proves the fixture actually reproduces the bug.
+ *   G-3 REGRESSION GUARD: a regular staged file, modified between staging and
+ *                         the blind re-add, is still correctly re-added (the
+ *                         original SMI-retro behavior is untouched).
+ *   G-4 RESTORE FAILURE:  a malformed path in the snapshot causes
+ *                         `git update-index --cacheinfo` to fail for that
+ *                         entry — restore_staged_gitlinks writes an SMI-5713
+ *                         diagnostic naming the path to stderr, and still
+ *                         restores the remaining (valid) entries.
+ *
+ * SMI-4693: uses makeFixtureEnv (strips GIT_DISCOVERY_VARS) and
+ * makeFixtureTempDir (realpath-canonical tmpdir) for git fixture isolation.
+ */
+import { describe, it, expect } from 'vitest'
+import { spawnSync, execFileSync } from 'node:child_process'
+import { writeFileSync, rmSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { makeFixtureEnv, makeFixtureTempDir } from './_lib/git-fixture-env.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Absolute path to the sourced library under test.
+const LIB = resolve(__dirname, '..', 'lib', 'preserve-gitlinks.sh')
+
+/**
+ * Build a minimal parent repo with a real submodule checked out at `sub/`.
+ * Returns the parent repo root and the submodule's initial commit SHA (A).
+ */
+function makeFixture(): { root: string; shaA: string } {
+  const subSource = makeFixtureTempDir('preserve-gitlinks-sub')
+  const env = makeFixtureEnv()
+
+  execFileSync('git', ['-c', 'init.defaultBranch=main', 'init', '--quiet', subSource], { env })
+  writeFileSync(join(subSource, 'README.md'), 'sub\n', 'utf8')
+  execFileSync('git', ['-C', subSource, 'add', '-A'], { env })
+  execFileSync('git', ['-C', subSource, 'commit', '--quiet', '-m', 'sub init'], { env })
+  const shaA = execFileSync('git', ['-C', subSource, 'rev-parse', 'HEAD'], { env })
+    .toString()
+    .trim()
+
+  const root = makeFixtureTempDir('preserve-gitlinks-parent')
+  execFileSync('git', ['-c', 'init.defaultBranch=main', 'init', '--quiet', root], { env })
+  writeFileSync(join(root, 'README.md'), 'parent\n', 'utf8')
+
+  // Add `sub` as a real submodule entry (mode 160000) without requiring
+  // network access — `git update-index --add --cacheinfo` creates the
+  // gitlink index entry directly; the working-tree checkout at sub/ is a
+  // plain clone (not a `git submodule add`), which is sufficient for
+  // `git add sub` to read its HEAD when simulating the blind re-add.
+  execFileSync('git', ['clone', '--quiet', subSource, join(root, 'sub')], { env })
+  rmSync(join(root, 'sub', '.git'), { recursive: true, force: true })
+  execFileSync(
+    'git',
+    ['-C', join(root, 'sub'), '-c', 'init.defaultBranch=main', 'init', '--quiet'],
+    { env }
+  )
+  execFileSync('git', ['-C', join(root, 'sub'), 'add', '-A'], { env })
+  execFileSync('git', ['-C', join(root, 'sub'), 'commit', '--quiet', '-m', 'sub init'], { env })
+  execFileSync('git', ['-C', root, 'update-index', '--add', '--cacheinfo', '160000', shaA, 'sub'], {
+    env,
+  })
+  execFileSync('git', ['-C', root, 'add', 'README.md'], { env })
+  execFileSync('git', ['-C', root, 'commit', '--quiet', '-m', 'init with submodule'], { env })
+
+  return { root, shaA }
+}
+
+/** `git ls-files -s <path>` → staged SHA for that path (40-hex). */
+function stagedSha(root: string, path: string, env: NodeJS.ProcessEnv): string {
+  const out = execFileSync('git', ['-C', root, 'ls-files', '-s', path], { env }).toString()
+  const match = out.match(/^160000 ([0-9a-f]{40})/)
+  if (!match) throw new Error(`no staged gitlink entry for ${path}: ${out}`)
+  return match[1]!
+}
+
+/** Run a shell snippet with the library sourced, mirroring how the hook sources it. */
+function runSourced(
+  root: string,
+  snippet: string,
+  env: NodeJS.ProcessEnv
+): { status: number; stdout: string; stderr: string } {
+  const result = spawnSync('sh', ['-c', `. "${LIB}" && ${snippet}`], {
+    cwd: root,
+    encoding: 'utf8',
+    env,
+    timeout: 15_000,
+  })
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+describe('scripts/lib/preserve-gitlinks.sh', () => {
+  it('G-1: capture + restore preserves a staged gitlink SHA across a blind re-add', () => {
+    const { root, shaA } = makeFixture()
+    const env = { ...makeFixtureEnv(), PATH: process.env['PATH'] ?? '/usr/bin:/bin' }
+
+    // A well-formed but non-existent 40-hex SHA — gitlinks are never
+    // dereferenced by git itself, so this is accepted for staging purposes.
+    const shaB = 'b'.repeat(40)
+    execFileSync('git', ['-C', root, 'update-index', '--cacheinfo', '160000', shaB, 'sub'], {
+      env,
+    })
+    expect(stagedSha(root, 'sub', env)).toBe(shaB)
+
+    const capture = runSourced(root, 'capture_staged_gitlinks', env)
+    expect(capture.status).toBe(0)
+    expect(capture.stdout.trim()).toBe(`${shaB} sub`)
+
+    // Simulate the hook's blind re-add — this is the clobber.
+    execFileSync('git', ['-C', root, 'add', 'sub'], { env })
+    expect(stagedSha(root, 'sub', env)).toBe(shaA) // clobbered back to the live checkout
+
+    const restore = runSourced(
+      root,
+      `restore_staged_gitlinks "$(printf '%s\\n' '${shaB} sub')"`,
+      env
+    )
+    expect(restore.status).toBe(0)
+    expect(restore.stderr).toBe('')
+    expect(stagedSha(root, 'sub', env)).toBe(shaB) // restored
+  })
+
+  it('G-2: negative control — without capture/restore, the blind re-add clobbers the staged SHA', () => {
+    const { root, shaA } = makeFixture()
+    const env = { ...makeFixtureEnv(), PATH: process.env['PATH'] ?? '/usr/bin:/bin' }
+
+    const shaB = 'c'.repeat(40)
+    execFileSync('git', ['-C', root, 'update-index', '--cacheinfo', '160000', shaB, 'sub'], {
+      env,
+    })
+    expect(stagedSha(root, 'sub', env)).toBe(shaB)
+
+    // No capture/restore this time — just the blind re-add.
+    execFileSync('git', ['-C', root, 'add', 'sub'], { env })
+
+    expect(stagedSha(root, 'sub', env)).toBe(shaA)
+    expect(stagedSha(root, 'sub', env)).not.toBe(shaB)
+  })
+
+  it('G-3: a regular staged file modified before the re-add is still correctly re-staged', () => {
+    const { root } = makeFixture()
+    const env = { ...makeFixtureEnv(), PATH: process.env['PATH'] ?? '/usr/bin:/bin' }
+
+    writeFileSync(join(root, 'README.md'), 'parent v2\n', 'utf8')
+    execFileSync('git', ['-C', root, 'add', 'README.md'], { env })
+
+    const capture = runSourced(root, 'capture_staged_gitlinks', env)
+    // No gitlinks staged in this scenario — capture is empty.
+    expect(capture.stdout.trim()).toBe('')
+
+    // Simulate lint-staged further modifying the file before the re-add.
+    writeFileSync(join(root, 'README.md'), 'parent v3 (formatted)\n', 'utf8')
+    execFileSync('git', ['-C', root, 'add', 'README.md'], { env })
+    runSourced(root, 'restore_staged_gitlinks ""', env)
+
+    // Plain `git diff` (no --cached) compares the working tree against the
+    // index — empty means the index already reflects the latest working-tree
+    // content (v3), i.e. the re-add correctly picked up the post-capture edit.
+    const diff = execFileSync('git', ['-C', root, 'diff', 'README.md'], {
+      env,
+    }).toString()
+    expect(diff).toBe('') // index matches working tree — re-add picked up the latest edit
+    const content = execFileSync('git', ['-C', root, 'show', ':README.md'], {
+      env,
+    }).toString()
+    expect(content).toBe('parent v3 (formatted)\n')
+  })
+
+  it('G-4: a restore failure for one entry is diagnosed on stderr without aborting the rest', () => {
+    const { root, shaA } = makeFixture()
+    const env = { ...makeFixtureEnv(), PATH: process.env['PATH'] ?? '/usr/bin:/bin' }
+    void shaA
+
+    const shaB = 'd'.repeat(40)
+    const snapshot = `deadbeef sub-does-not-exist\n${shaB} sub`
+
+    const restore = runSourced(
+      root,
+      `restore_staged_gitlinks "$(printf '%s\\n' '${snapshot}')"`,
+      env
+    )
+    expect(restore.status).toBe(0) // no set -e in the caller's philosophy — soft failure
+    expect(restore.stderr).toContain('SMI-5713')
+    expect(restore.stderr).toContain('sub-does-not-exist')
+    // The valid entry after the bad one still gets restored.
+    expect(stagedSha(root, 'sub', env)).toBe(shaB)
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** `.husky/pre-commit` no longer silently overwrites a deliberately-staged submodule gitlink (e.g. a `docs/internal` pointer bump) with whatever commit that submodule happens to be checked out to locally — a real bug that already corrupted `main`'s `docs/internal` reference once (fixed directly via `git commit-tree` at the time; this PR fixes the hook so it can't recur).

**Quality bar:** Full plan-review pass before implementation (VP Product/Engineering/Design, all 8 findings applied to the plan doc). New test suite with 4 cases including a negative control that proves the test fixture actually reproduces the original bug, not just that it passes trivially. Verified the missing-library degradation path (warns loudly, doesn't silently disable). Full pre-push security + test suite green.

**Found along the way:** two related, lower-severity risk classes (symlink and mode-only `--chmod` clobbers, same underlying mechanism) — already tracked separately as SMI-5721, not bundled into this PR since they need their own capture/restore design.

**Net result:** Fully shipped, no follow-up needed for this specific bug. SMI-5721 remains open as a separate, lower-priority tracked item.

---

## Technical detail

- `scripts/lib/preserve-gitlinks.sh` (new) — `capture_staged_gitlinks` / `restore_staged_gitlinks`, pure stdin/stdout functions, no shared mutable state.
- `.husky/pre-commit` — sources the library with the same existence-guard idiom used for its 3 other sourced libs; captures staged gitlink SHAs before `lint-staged` runs, restores them after the existing blind re-add step.
- `scripts/tests/preserve-gitlinks.test.ts` (new) — 4 cases: clobber-fixed, negative control, regular-file regression guard, restore-failure diagnostic.
- Root cause + full design rationale: `docs/internal/implementation/smi-5713-husky-gitlink-clobber.md`.

Refs SMI-5713.