### PR TITLE
fix(scripts): refuse dependabot-regenerate-lockfile.sh from a worktree (SMI-5733)

### DIFF
--- a/scripts/dependabot-regenerate-lockfile.sh
+++ b/scripts/dependabot-regenerate-lockfile.sh
@@ -5,7 +5,19 @@
 # Sources scripts/_lib.sh for consistent logging (colors, error/warn/info/success).
 # Uses Docker-first npm execution per CLAUDE.md policy.
 #
-# Prerequisites: gh CLI authenticated, Docker container running, clean working tree.
+# Prerequisites: gh CLI authenticated, Docker container running, clean working tree,
+# run from the MAIN checkout (see SMI-5733 below).
+#
+# SMI-5733: main-checkout only. This script checks out an arbitrary Dependabot
+#   branch directly into the CURRENT working tree, then regenerates the lockfile
+#   via `docker exec skillsmith-dev-1`. From a worktree, that container's /app
+#   bind-mount reflects the MAIN checkout's files, not the worktree's — the
+#   lockfile write and the `git diff --quiet package-lock.json` check would
+#   operate on two different trees, so every PR would silently report "already
+#   up to date" (the SMI-5724 failure mode, in a sibling script). Unlike
+#   regen-lockfile.sh, there's no clean host/container routing split here (this
+#   script's whole-branch-checkout model would also hijack whatever the
+#   worktree currently has checked out) — refuse outright instead.
 
 set -euo pipefail
 
@@ -73,6 +85,24 @@ done
 if [[ ${#PR_NUMBERS[@]} -eq 0 ]]; then
   usage >&2
   exit 1
+fi
+
+# SMI-5733: hard-error (not silent fallback) if git itself can't answer —
+# see scripts/regen-lockfile.sh's identical guard for why a silent default
+# here would reproduce the exact bug this check exists to prevent.
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null)" || error "Not inside a git checkout — cannot determine worktree vs main checkout."
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null)" || error "Not inside a git checkout — cannot determine worktree vs main checkout."
+if [[ "$GIT_DIR" != "$GIT_COMMON_DIR" ]]; then
+  error "This script must run from the MAIN checkout, not a worktree (SMI-5733).
+
+It checks out each Dependabot branch directly into the current working tree,
+then regenerates the lockfile via the main checkout's own container
+(docker exec skillsmith-dev-1) — from a worktree, that container's files are
+unrelated to the worktree's own checked-out tree, so the lockfile diff check
+would always report a false 'already up to date'.
+
+Run from the main checkout:
+  cd $(dirname "$GIT_COMMON_DIR") && ./scripts/$(basename "$0") $*"
 fi
 
 # Ensure clean working tree (staged, unstaged, and untracked)


### PR DESCRIPTION
## Business Summary

**What shipped:** `dependabot-regenerate-lockfile.sh` (the manual fallback tool for fixing Dependabot lockfile drift) now refuses to run from a worktree instead of silently doing nothing useful — it previously always targeted the main checkout's container regardless of where it was run, so from a worktree it could process every Dependabot PR and report "already up to date" without ever actually checking anything.

**Quality bar:** Same guard pattern as SMI-5724 (already plan-reviewed this session), applied directly since this is a narrow, mechanical single-guard addition to a sibling script. Verified both the refusal (from a worktree) and normal operation (`--help` still works from anywhere; unaffected from the main checkout) manually. Full regression suite green via the pre-push gate (security, format, all package test suites).

**Found along the way:** discovered during SMI-5724's post-merge governance retro — not a new investigation, a direct consequence of that fix's own review process.

**Net result:** Fully shipped, no follow-up.

---

## Technical detail

`scripts/dependabot-regenerate-lockfile.sh`: added the same `git rev-parse --git-dir`/`--git-common-dir` hard-error guard from SMI-5724, positioned after arg parsing (so `--help` still works from a worktree) and before the existing "clean working tree" check. Refuses with a clear message pointing at the main checkout path (computed via `dirname "$GIT_COMMON_DIR"`) if invoked from a worktree.

Unlike `regen-lockfile.sh`, this script has no viable host-routing alternative — it checks out an arbitrary Dependabot branch directly into the current working tree, which would hijack whatever a worktree currently has checked out. Refusing outright is the safe fix; a full redesign is out of scope (SMI-5733).
