### PR TITLE
fix(test): Pin commit dates in preserve-gitlinks fixture to close flake window

### DIFF
--- a/scripts/tests/preserve-gitlinks.test.ts
+++ b/scripts/tests/preserve-gitlinks.test.ts
@@ -50,17 +50,43 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const LIB = resolve(__dirname, '..', 'lib', 'preserve-gitlinks.sh')
 
 /**
+ * SMI-5741: fixed author/committer timestamp shared by both `sub init`
+ * commits below (the one in `subSource` and the independent one replayed
+ * in `root/sub` after the clone + `.git` wipe + re-init). Both commits
+ * have identical tree content, message, and identity — Git hashes a
+ * commit object over that content PLUS the author/committer date, so
+ * without pinning the date, the commit SHAs are only equal when both
+ * `git commit` calls land in the same one-second wall-clock window
+ * (Git's default date granularity). Several `git` subprocess calls run
+ * between them (clone, rm -rf .git, init, add -A), which can straddle a
+ * 1-second boundary on a loaded CI runner — producing two different but
+ * individually valid SHAs and a spurious assertion failure in G-1/G-2
+ * (which assert the two commits hash identically). Pinning the date
+ * makes both commits byte-identical (and thus SHA-identical) regardless
+ * of real wall-clock time or runner speed.
+ */
+const FIXTURE_COMMIT_DATE = '2020-01-01T00:00:00Z'
+
+/**
  * Build a minimal parent repo with a real submodule checked out at `sub/`.
  * Returns the parent repo root and the submodule's initial commit SHA (A).
  */
 function makeFixture(): { root: string; shaA: string } {
   const subSource = makeFixtureTempDir('preserve-gitlinks-sub')
   const env = makeFixtureEnv()
+  // SMI-5741: pin both `sub init` commits (below) to the same author/
+  // committer date so their SHAs are guaranteed identical.
+  const pinnedCommitEnv = makeFixtureEnv({
+    GIT_AUTHOR_DATE: FIXTURE_COMMIT_DATE,
+    GIT_COMMITTER_DATE: FIXTURE_COMMIT_DATE,
+  })
 
   execFileSync('git', ['-c', 'init.defaultBranch=main', 'init', '--quiet', subSource], { env })
   writeFileSync(join(subSource, 'README.md'), 'sub\n', 'utf8')
   execFileSync('git', ['-C', subSource, 'add', '-A'], { env })
-  execFileSync('git', ['-C', subSource, 'commit', '--quiet', '-m', 'sub init'], { env })
+  execFileSync('git', ['-C', subSource, 'commit', '--quiet', '-m', 'sub init'], {
+    env: pinnedCommitEnv,
+  })
   const shaA = execFileSync('git', ['-C', subSource, 'rev-parse', 'HEAD'], { env })
     .toString()
     .trim()
@@ -82,7 +108,9 @@ function makeFixture(): { root: string; shaA: string } {
     { env }
   )
   execFileSync('git', ['-C', join(root, 'sub'), 'add', '-A'], { env })
-  execFileSync('git', ['-C', join(root, 'sub'), 'commit', '--quiet', '-m', 'sub init'], { env })
+  execFileSync('git', ['-C', join(root, 'sub'), 'commit', '--quiet', '-m', 'sub init'], {
+    env: pinnedCommitEnv,
+  })
   execFileSync('git', ['-C', root, 'update-index', '--add', '--cacheinfo', '160000', shaA, 'sub'], {
     env,
   })


### PR DESCRIPTION
## Business Summary

**What shipped:** Closes a test flake that was intermittently failing `main` and unrelated PRs — `preserve-gitlinks.test.ts` occasionally reported a spurious failure with no connection to whatever the PR actually changed.

**Quality bar:** Root cause reproduced directly — an artificial delay was injected to force the original race, confirmed it fails without the fix and passes with it, then reverted the stress-test scaffolding. 11 consecutive clean test runs after the fix. Typecheck/lint/format all clean.

**Found along the way:** discovered while investigating a real-looking `Test (root)` failure on unrelated Dependabot PR #1864 (tailwindcss bump) during a GitHub issue/PR triage batch — confirmed the failure had nothing to do with that PR's dependency bump.

**Net result:** Done, no follow-up. Closes SMI-5741.

---

## Technical detail

`scripts/tests/preserve-gitlinks.test.ts` — `makeFixture()` creates two independent git commits expected to hash identically, but never pinned `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` (git hashes commit date at 1-second granularity). Several git subprocesses run between the two commits, so a loaded CI runner could straddle a 1-second boundary and produce two different (but individually valid) SHAs. Added a fixed `FIXTURE_COMMIT_DATE`, threaded through `makeFixtureEnv()`'s existing `extra`-overrides parameter (no signature change) into both commit sites.