### PR TITLE
fix(scripts): Fix audit-standards Check 18 double-encrypted false positive (SMI-5740)

### DIFF
--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -2041,3 +2041,51 @@ export function isReleasePrepDiff(pkgJsonAtBase, pkgJsonAtHead, changelogAtBase,
   if (headingDirectlyBelowUnreleased(changelogAtHead) !== expectedHeading) return false
   return headingDirectlyBelowUnreleased(changelogAtBase) !== expectedHeading
 }
+
+/**
+ * Parse `git-crypt status`'s per-file output and return only the paths git-crypt
+ * reports as genuinely encrypted.
+ *
+ * `git-crypt status` emits a `not encrypted: <path>` line for every tracked file
+ * outside the encrypted scope, and that line contains the substring `encrypted:`
+ * — a naive `.includes('encrypted:')` filter (SMI-5740) matches both lines, not
+ * just the genuinely-encrypted `    encrypted: <path>` ones. Matching on the
+ * trimmed line's leading token instead of a bare substring structurally excludes
+ * `not encrypted:` lines, since their leading token differs entirely.
+ * @param {string} status - raw stdout of `git-crypt status`.
+ * @returns {string[]}
+ */
+export function parseGitCryptEncryptedFiles(status) {
+  return status
+    .split('\n')
+    .filter((line) => line.trim().startsWith('encrypted:'))
+    .map((line) => line.trim().slice('encrypted:'.length).trim())
+    .filter(Boolean)
+}
+
+/**
+ * Classify a git-crypt double-encryption scan result (SMI-5740).
+ *
+ * `git-crypt status` succeeds (no throw) regardless of whether the repo's key
+ * is actually unlocked — its own output never distinguishes "locked" from
+ * "unlocked" (confirmed against git-crypt's own source: status() reports
+ * purely from .gitattributes + blob-content inspection, neither of which
+ * needs the key). On a genuinely-locked-but-installed checkout, the smudge
+ * filter never ran, so EVERY real encrypted-scope file's on-disk bytes are
+ * ciphertext — indistinguishable per-file from double-encryption. Treat "all
+ * encrypted-scope files are ciphertext" as locked, not double-encrypted; a
+ * genuine double-encryption anomaly affects only SOME of them. (Known
+ * limitation: ANY anomaly affecting every single encrypted-scope file — not
+ * just the exactly-one-file case — is observationally identical to a locked
+ * repo and reads as 'locked' rather than 'double-encrypted'. Not a concern
+ * for this repo's actual scope of hundreds of files, where an anomaly
+ * affecting literally all of them simultaneously is implausible.)
+ * @param {number} encryptedCount - total encrypted-scope files found.
+ * @param {number} doubleEncryptedCount - of those, how many are ciphertext on disk.
+ * @returns {'locked' | 'double-encrypted' | 'clean'}
+ */
+export function classifyGitCryptScanResult(encryptedCount, doubleEncryptedCount) {
+  if (encryptedCount > 0 && doubleEncryptedCount === encryptedCount) return 'locked'
+  if (doubleEncryptedCount > 0) return 'double-encrypted'
+  return 'clean'
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -14,7 +14,7 @@ import { parseArgs } from 'node:util'
 import { createHash } from 'node:crypto'
 import { execSync, execFileSync } from 'child_process'
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
-import { dirname, extname, join, relative, resolve as resolvePath } from 'path'
+import { dirname, join, relative, resolve as resolvePath } from 'path'
 import {
   satisfies,
   extractCompletionIssues,
@@ -41,7 +41,10 @@ import {
   findServerJsonFieldLengthViolations,
   countUnreleasedEntries,
   isReleasePrepDiff,
+  parseGitCryptEncryptedFiles,
+  classifyGitCryptScanResult,
 } from './audit-standards-helpers.mjs'
+import { isGitCryptEncrypted } from './ci/check-supply-chain-pins.mjs'
 import { VERCEL_JSON_SHARED_FIELDS, validateVercelJsonSync } from './audit-vercel-sync-helpers.mjs'
 import { findRealpathAsymmetry } from './audit-realpath-asymmetry-helpers.mjs'
 import { findUnpinnedActionUses } from './audit-workflow-sha-pin-helpers.mjs'
@@ -575,12 +578,11 @@ if (existsSync(MIGRATIONS_DIR)) {
 
     for (const file of migrationFiles) {
       const filePath = join(MIGRATIONS_DIR, file)
-      const contentBuf = readFileSync(filePath)
       // Skip git-crypt encrypted files (binary blobs starting with \x00GITCRYPT)
-      if (contentBuf[0] === 0x00 && contentBuf.toString('utf8', 1, 9) === 'GITCRYPT') {
+      if (isGitCryptEncrypted(filePath)) {
         continue
       }
-      const content = contentBuf.toString('utf8')
+      const content = readFileSync(filePath, 'utf8')
       const lines = content.split('\n')
       const headerLines = lines.slice(0, 10).join('\n')
 
@@ -1231,51 +1233,36 @@ console.log(`\n${BOLD}17. Email Consistency (SMI-2562)${RESET}`)
 // 18. No Double-Encrypted Files (SMI-2607)
 console.log(`\n${BOLD}18. No Double-Encrypted Files (SMI-2607)${RESET}`)
 try {
+  // SMI-5740: `git-crypt status`'s own output never contains the substring
+  // "locked" (confirmed against git-crypt's own source — status() reports
+  // purely from .gitattributes + blob-content inspection, neither of which
+  // needs the key). A genuinely-locked-but-installed checkout still runs this
+  // scan successfully and, since the smudge filter never ran, every real
+  // encrypted-scope file's on-disk bytes are ciphertext — indistinguishable
+  // from double-encryption on a per-file basis. classifyGitCryptScanResult
+  // detects "locked" instead by whether ALL encrypted-scope files are
+  // ciphertext (locked) vs. only SOME of them (a genuine per-file anomaly).
   const status = execSync('git-crypt status 2>/dev/null', { encoding: 'utf8' })
-  if (status.includes('locked')) {
-    pass('Skipped (git-crypt locked)')
+  const encryptedFiles = parseGitCryptEncryptedFiles(status)
+  const doubleEncrypted = encryptedFiles.filter((file) => isGitCryptEncrypted(file))
+  const result = classifyGitCryptScanResult(encryptedFiles.length, doubleEncrypted.length)
+
+  if (result === 'locked') {
+    warn(
+      `All ${encryptedFiles.length} git-crypt-scoped file(s) still show ciphertext on disk — ` +
+        'this repository appears locked (key not unlocked), not double-encrypted',
+      'Unlock git-crypt on this runner to exercise this check for real'
+    )
+  } else if (result === 'double-encrypted') {
+    fail(`${doubleEncrypted.length} double-encrypted files found:\n${doubleEncrypted.join('\n')}`)
   } else {
-    const encryptedFiles = status
-      .split('\n')
-      .filter((line) => line.includes('encrypted:') && !line.includes('NOT ENCRYPTED'))
-      .map((line) => line.trim().split(/\s+/).pop())
-      .filter(Boolean)
-
-    const binaryExtensions = [
-      '.svg',
-      '.png',
-      '.jpg',
-      '.jpeg',
-      '.gif',
-      '.ico',
-      '.woff',
-      '.woff2',
-      '.db',
-      '.wasm',
-    ]
-    const doubleEncrypted = []
-
-    for (const file of encryptedFiles) {
-      const ext = extname(file).toLowerCase()
-      if (binaryExtensions.includes(ext)) continue
-      try {
-        const fileType = execSync(`file -b "${file}"`, { encoding: 'utf8' }).trim()
-        if (fileType === 'data') {
-          doubleEncrypted.push(file)
-        }
-      } catch {
-        /* File might not exist on disk */
-      }
-    }
-
-    if (doubleEncrypted.length > 0) {
-      fail(`${doubleEncrypted.length} double-encrypted files found:\n${doubleEncrypted.join('\n')}`)
-    } else {
-      pass('No double-encrypted files')
-    }
+    pass('No double-encrypted files')
   }
 } catch {
-  pass('Skipped (git-crypt not installed)')
+  warn(
+    'Skipped (git-crypt not installed) — Check 18 did not run',
+    'Install git-crypt on this runner to exercise this check'
+  )
 }
 
 // 19. docs/ Directory Structure Guard (SMI-2607)
@@ -3934,16 +3921,7 @@ console.log(`\n${BOLD}47. Edge-function registration coherence (SMI-4963)${RESET
         // would then fail-to-match and falsely fire "missing tag". Skip the
         // predicate in that case — quality-checks already enforces it.
         // Sentinel pattern mirrors vitest.config.root-tests.ts:gitCryptLocked.
-        const gitCryptLocked =
-          existsSync(AUTH_PATH) &&
-          (() => {
-            try {
-              const head = readFileSync(AUTH_PATH).subarray(0, 9).toString('binary')
-              return head.startsWith('\x00GITCRYPT')
-            } catch {
-              return false
-            }
-          })()
+        const gitCryptLocked = existsSync(AUTH_PATH) && isGitCryptEncrypted(AUTH_PATH)
         if (!existsSync(AUTH_PATH)) {
           warn(
             'Check 47 predicate 5: supabase/functions/_shared/auth.ts ' +
@@ -4625,13 +4603,12 @@ console.log(`\n${BOLD}52. SECURITY DEFINER anon-Grant Lockdown (SMI-5526)${RESET
     const migrationsForSecdefAudit = []
     for (const file of readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith('.sql'))) {
       const filePath = join(MIGRATIONS_DIR, file)
-      const contentBuf = readFileSync(filePath)
       // Skip git-crypt encrypted files (binary blobs starting with \x00GITCRYPT) —
       // same idiom as the Check 11 migration-header scan above.
-      if (contentBuf[0] === 0x00 && contentBuf.toString('utf8', 1, 9) === 'GITCRYPT') {
+      if (isGitCryptEncrypted(filePath)) {
         continue
       }
-      migrationsForSecdefAudit.push({ name: file, content: contentBuf.toString('utf8') })
+      migrationsForSecdefAudit.push({ name: file, content: readFileSync(filePath, 'utf8') })
     }
 
     const secdefViolations = auditSecdefAnonGrants(migrationsForSecdefAudit, {

--- a/scripts/tests/audit-standards-double-encrypted.test.ts
+++ b/scripts/tests/audit-standards-double-encrypted.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the SMI-5740 fix to audit-standards.mjs Check 18
+ * ("No Double-Encrypted Files", SMI-2607).
+ *
+ * Covers `parseGitCryptEncryptedFiles` and `classifyGitCryptScanResult` in
+ * audit-standards-helpers.mjs — the pure parsing/decision layer for
+ * `git-crypt status` output. Check 18 itself provides the I/O layer
+ * (execSync + isGitCryptEncrypted + warn/fail/pass), which, per this repo's
+ * established convention (see audit-standards-migration-ordering.test.ts's
+ * own note on Check 50), is exercised by actually running the script rather
+ * than unit-tested in isolation.
+ *
+ * The git-crypt magic-header byte check itself (`isGitCryptEncrypted`) is
+ * already covered by scripts/tests/check-supply-chain-pins.test.ts and is
+ * not re-tested here — this file adds only the one additional case (a
+ * binary, non-GITCRYPT-header buffer) that documents the specific regression
+ * Check 18's `binaryExtensions` allowlist removal must not reintroduce.
+ */
+import { describe, expect, it } from 'vitest'
+
+const helpers = (await import('../audit-standards-helpers.mjs')) as {
+  parseGitCryptEncryptedFiles: (status: string) => string[]
+  classifyGitCryptScanResult: (
+    encryptedCount: number,
+    doubleEncryptedCount: number
+  ) => 'locked' | 'double-encrypted' | 'clean'
+}
+const { parseGitCryptEncryptedFiles, classifyGitCryptScanResult } = helpers
+
+const pinsMod = (await import('../ci/check-supply-chain-pins.mjs')) as {
+  isGitCryptEncrypted: (p: string) => boolean
+}
+const { isGitCryptEncrypted } = pinsMod
+
+describe('parseGitCryptEncryptedFiles (SMI-5740)', () => {
+  it('excludes "not encrypted:" lines even though they contain the substring "encrypted:"', () => {
+    const status = [
+      '    encrypted: supabase/functions/_shared/api-key-auth.ts',
+      'not encrypted: scripts/tests/indexer/parity.test.ts',
+    ].join('\n')
+    expect(parseGitCryptEncryptedFiles(status)).toEqual([
+      'supabase/functions/_shared/api-key-auth.ts',
+    ])
+  })
+
+  it('handles leading whitespace before "encrypted:"', () => {
+    const status = '        encrypted: supabase/migrations/030_foo.sql'
+    expect(parseGitCryptEncryptedFiles(status)).toEqual(['supabase/migrations/030_foo.sql'])
+  })
+
+  it('ignores empty and trailing blank lines', () => {
+    const status = '\n    encrypted: a.ts\n\n\n'
+    expect(parseGitCryptEncryptedFiles(status)).toEqual(['a.ts'])
+  })
+
+  it('preserves spaces inside the path (does not whitespace-split the path)', () => {
+    const status = '    encrypted: supabase/functions/has space/index.ts'
+    expect(parseGitCryptEncryptedFiles(status)).toEqual(['supabase/functions/has space/index.ts'])
+  })
+
+  it('handles CRLF line endings', () => {
+    const status = '    encrypted: a.ts\r\nnot encrypted: b.ts\r\n'
+    expect(parseGitCryptEncryptedFiles(status)).toEqual(['a.ts'])
+  })
+
+  it('returns an empty array when nothing is encrypted', () => {
+    const status = 'not encrypted: a.ts\nnot encrypted: b.ts'
+    expect(parseGitCryptEncryptedFiles(status)).toEqual([])
+  })
+
+  it('returns multiple paths in the order git-crypt reported them', () => {
+    const status = ['    encrypted: a.ts', 'not encrypted: b.ts', '    encrypted: c.ts'].join('\n')
+    expect(parseGitCryptEncryptedFiles(status)).toEqual(['a.ts', 'c.ts'])
+  })
+})
+
+describe('classifyGitCryptScanResult (SMI-5740 — locked vs. double-encrypted)', () => {
+  it('classifies as clean when nothing is encrypted', () => {
+    expect(classifyGitCryptScanResult(0, 0)).toBe('clean')
+  })
+
+  it('classifies as clean when encrypted files exist but none are ciphertext on disk', () => {
+    expect(classifyGitCryptScanResult(5, 0)).toBe('clean')
+  })
+
+  it('classifies as double-encrypted when only some encrypted-scope files are ciphertext', () => {
+    expect(classifyGitCryptScanResult(5, 2)).toBe('double-encrypted')
+  })
+
+  it('classifies as locked when ALL encrypted-scope files are still ciphertext', () => {
+    expect(classifyGitCryptScanResult(377, 377)).toBe('locked')
+  })
+
+  it('documents the known single-file limitation: 1-of-1 reads as locked, not anomaly', () => {
+    // With exactly one encrypted-scope file total, a genuine single-file
+    // double-encryption anomaly is indistinguishable from a locked repo.
+    // Not a concern for this repo's real scope (dozens of files), but pinned
+    // here so the tradeoff can't silently regress unnoticed.
+    expect(classifyGitCryptScanResult(1, 1)).toBe('locked')
+  })
+
+  it('does not misclassify zero encrypted-scope files as locked', () => {
+    // encryptedCount === 0 must never satisfy the "all" condition trivially.
+    expect(classifyGitCryptScanResult(0, 0)).not.toBe('locked')
+  })
+})
+
+describe('isGitCryptEncrypted post-binaryExtensions-removal regression (SMI-5740)', () => {
+  it('returns false for a binary (non-GITCRYPT-header) buffer written to disk', async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const dir = mkdtempSync(join(tmpdir(), 'smi-5740-'))
+    try {
+      const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      const p = join(dir, 'image.png')
+      writeFileSync(p, pngHeader)
+      // Previously exempted by Check 18's binaryExtensions allowlist purely by
+      // extension; now must be correctly not-flagged by the byte-signature
+      // check itself, with no allowlist involved.
+      expect(isGitCryptEncrypted(p)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** A required CI security check ("No Double-Encrypted Files") was silently useless on most CI runners and prone to false-positiving on unrelated files on the runners where it did run — both are fixed. The check now reliably distinguishes a real problem from a locked or git-crypt-less environment, and no longer flags legitimate text files.

**Quality bar:** Full ADR-109 process (this touches a CI script) — SPARC investigation, VP plan review, dual implementation review (two independent Opus passes plus an independent Codex pass via NEEDLE), and 14 new regression tests. One review round caught and fixed a real documentation-accuracy gap in the plan itself (a claimed test that didn't actually exist).

**Found along the way:** SMI-5744, a low-priority follow-up tracking a broader code-duplication cleanup opportunity (the same git-crypt byte-signature check independently reimplemented ~6 times across the codebase) — not folded into this PR, correctly out of scope for a targeted bug fix.

**Net result:** Fully shipped. This also absorbs and closes out SMI-5739, an earlier, independently-filed duplicate of part of this same bug — cross-linked in Linear rather than left as an orphaned duplicate.

---

## Technical detail

Six compounding bugs in `scripts/audit-standards.mjs` Check 18 (SMI-2607), confirmed by direct inspection and dual review:

1. **Broken filter** — `line.includes('encrypted:')` matched `not encrypted:` lines too (the substring is present in both). Fixed with `line.trim().startsWith('encrypted:')`.
2. **NUL-byte-sensitive heuristic** — the old `file -b` binary-detection check false-positived on legitimate text files with an embedded NUL byte (e.g. `scripts/tests/indexer/parity.test.ts`). Replaced by reusing the existing, already-tested `isGitCryptEncrypted` from `scripts/ci/check-supply-chain-pins.mjs` — a direct git-crypt magic-header byte check, no shell-out. Also deduplicates 3 pre-existing inline copies of the same idiom (Checks 11, 47, 52) onto the same import.
3. **Path corruption** — whitespace-split path extraction broke on paths containing spaces. Fixed with prefix-slicing.
4. **Shell injection surface** — `execSync(`file -b "${file}"`)` interpolated an unescaped path into a shell string. Eliminated along with bug 2's fix (no shell-out at all now).
5. **Silent no-op** (absorbed from SMI-5739) — `catch { pass(...) }` reported a clean pass whenever `git-crypt` isn't installed, which is most GitHub-hosted runners — the check provided zero protection on most runs, silently. Changed to `warn()`.
6. **Dead lock-state detection** (found during post-implementation Opus review, confirmed against git-crypt's own C++ source via `gh api repos/AGWA/git-crypt/contents/commands.cpp`) — the pre-existing `status.includes('locked')` branch never actually matches anything git-crypt prints. A genuinely-locked-but-installed checkout would have scanned into the buggy branch and flagged every real encrypted-scope file en masse. Fixed with a new `classifyGitCryptScanResult` helper that distinguishes "all encrypted-scope files still ciphertext" (locked → warn) from "some" (real anomaly → fail) from "none" (clean → pass).

New file: `scripts/tests/audit-standards-double-encrypted.test.ts` (14 tests, covering the parser and classifier). Verified locally on both the real-unlocked path (`No double-encrypted files`) and the not-installed path (`⚠ Skipped (git-crypt not installed)`), plus confirmed the 3 refactored call sites are behavior-unchanged.

Refs SMI-5740, SMI-5739