### PR TITLE
fix(needle): Add pre-flight secret-scanner guard, document trace gap

### DIFF
--- a/scripts/needle/README.md
+++ b/scripts/needle/README.md
@@ -178,3 +178,53 @@ guaranteed for every model/prompt.
   retrying the same dispatch.** Pass `--expect-write` whenever the prompt
   asks Codex to make a real change; omit it for pure analysis/review
   prompts, where "no diff" is the expected, successful outcome.
+- **`bf create` fails with `secret detected: ... [Azure Key]` on an
+  ordinary long file path in the title/body — or, a separate and unrelated
+  finding from the same investigation, an analysis-only dispatch's trace
+  file never contains the model's final answer.** (SMI-5709) Two
+  unconnected things, bundled into one entry because they surfaced
+  together.
+  **Part 1 — secret-scanner guard + allowlist.** `bf`'s own secret scanner
+  has a generic heuristic — confirmed via `strings $(which bf)` to be
+  labeled "Azure Key" — that flags any unbroken run of 44+ characters from
+  `[A-Za-z0-9/_-]` in `--title`/`--description` content regardless of
+  whether it's a real secret; an ordinary long file/worktree path trips it
+  just as reliably as a credential would. `dispatch.sh` now pre-scans the
+  exact raw title/body bytes for this same pattern — in grep's default
+  per-line mode, so a match can never span a newline — before calling `bf
+  create`, and fails fast with a redacted preview (the first ~10 and last
+  ~4 characters of up to 5 matches, never the full matched substring, since
+  a real credential could theoretically match this class too — remaining
+  matches beyond 5 are counted but not shown) plus which field, and for the
+  body which line, each shown match was found in. If a title or prompt body
+  genuinely needs a long path, state the directory prefix once in prose and
+  refer to bare filenames afterward. This guard is a pure compatibility
+  pre-check with no knowledge of `bf`'s own `secret_protection.allowlist`
+  (`.beads/config.yaml`) — allowlisting a pattern there does NOT get you
+  past this guard, only past `bf`'s own scanner. To bypass this guard for a
+  single dispatch, set `SKILLSMITH_NEEDLE_SECRET_GUARD_DISABLE=1` (registered
+  in `docs/internal/process/guards-and-opt-outs.md`); `bf`'s own scanner
+  still runs afterward, so a genuinely-allowlisted pattern needs both. On
+  the allowlist itself: as observed behavior against the `bf` version in
+  use at the time of this investigation (not a guarantee for every future
+  `bf` release), matching there is a substring match against the *entire*
+  scanned field's content — a pattern anchored at both ends (`^...$`) only
+  matches a field whose full content equals it, a pattern anchored at one
+  end only matches at that corresponding boundary, and an unanchored
+  pattern matches text embedded anywhere in a longer field. Also note: this
+  guard's character class (`[A-Za-z0-9/_-]`) is verified against ordinary
+  long paths, not against `bf`'s real rule for base64-shaped secrets (which
+  may include `+`/`=`) — a real base64 credential could in principle slip
+  past this guard and still hit `bf`'s own rejection.
+  **Part 2 — trace gap, unrelated to Part 1.** For a dispatch made without
+  `--expect-write`, the trace file `dispatch.sh` prints (built by
+  `needle_bead_trace_path()` in `scripts/needle/lib.sh`) only ever contains
+  `tool_call`/`tool_result`/`tokens` events — never the dispatched model's
+  final text response. That response lives only in the Codex CLI's own
+  session log, `~/.codex/sessions/<year>/<month>/<day>/rollout-<timestamp>-<uuid>.jsonl`,
+  as JSON lines where `type == "event_msg"` and
+  `payload.type == "agent_message"` — the *last* such line is the final
+  answer, extractable with a small `jq`/Python snippet reading
+  `payload.message`. Don't expect an analysis-only Codex review's actual
+  answer to show up in the bead trace; go to the Codex session log
+  instead.

--- a/scripts/needle/dispatch.sh
+++ b/scripts/needle/dispatch.sh
@@ -174,6 +174,121 @@ CODEX_VERSION="$(codex --version 2>/dev/null || echo 'unknown')"
 
 echo "[needle-dispatch] workspace=$WORKSPACE model=$MODEL timeout=${TIMEOUT}s codex_version=$CODEX_VERSION"
 
+# ---- SMI-5709: secret-scanner compatibility guard ----
+#
+# `bf create` (invoked below) runs its own secret scanner over --title and
+# --description before this dispatch ever reaches Codex. That scanner has a
+# generic heuristic — labeled "Azure Key" in its own output, confirmed via
+# `strings $(which bf)` in a prior investigation — that flags any unbroken
+# run of 44+ characters from [A-Za-z0-9/_-]. Ordinary long file/worktree
+# paths in a title or prompt body trip this constantly; it has nothing to
+# do with real secrets. Left unguarded, that surfaces as an opaque
+# "secret detected: ... [Azure Key]" failure deep inside `bf create`,
+# after this script has already committed to the dispatch. This block
+# scans the exact raw bytes that will be passed to `bf create` below and
+# fails fast, before any `bf`/`codex` process is touched, with actionable
+# guidance instead of bf's own opaque error.
+#
+# The character class ([A-Za-z0-9/_-]) intentionally reproduces bf's own
+# broad heuristic exactly, as confirmed against the actual compiled rule in
+# a prior investigation — this is deliberately NOT a smarter/narrower
+# filter. Do not "improve" this into a tighter pattern later; that would
+# desync this guard from what bf actually rejects and defeat the entire
+# point of a compatibility pre-check.
+#
+# Matching runs in grep's default per-line mode only, never a
+# multiline/slurp mode — a match must never be allowed to span a newline
+# (44 path-safe characters split across two lines are two separate short
+# runs in the real content, not one long one that should trip anything).
+#
+# Separate, related fact (also from a prior investigation, not re-verified
+# here): bf additionally supports a `secret_protection.allowlist` key in a
+# workspace's `.beads/config.yaml`, and — as observed behavior against the
+# bf version in use at the time of that investigation, not an unconditional
+# guarantee for every future bf release — the scanner consults it with
+# substring-match semantics against the *entire* scanned field's content:
+# a pattern anchored at both ends (^...$) can only match a field whose
+# entire content equals the pattern; a pattern anchored at only one end can
+# only match at that corresponding boundary; an unanchored pattern must
+# match text embedded anywhere within a longer field.
+#
+# IMPORTANT: this guard has no knowledge of that allowlist — it is a pure
+# compatibility pre-check and cannot tell whether bf would actually accept
+# a given match. Allowlisting a pattern in bf's own config does NOT get you
+# past THIS guard; use SKILLSMITH_NEEDLE_SECRET_GUARD_DISABLE=1 for that (see
+# below and docs/internal/process/guards-and-opt-outs.md). Note bf's own
+# scanner still runs after this guard is skipped, so the allowlist entry is
+# still required for the dispatch to actually succeed end-to-end.
+#
+# Scope note: this pattern is verified against ordinary long file/worktree
+# paths (its actual purpose) — it has not been verified against bf's real
+# rule for base64-shaped secrets (which may include `+`/`=`, outside this
+# class), so a real base64 credential could in principle still slip past
+# this guard and hit bf's own rejection instead. That's an acceptable gap:
+# this guard exists to fail fast on the common path-false-positive case,
+# not to be a complete re-implementation of bf's scanner.
+needle_secret_scan_guard() {
+    local pattern='[A-Za-z0-9/_-]{44,}'
+    local findings=() entry field lineinfo m rest head tail redacted
+    local report="" shown=0 total
+
+    while IFS= read -r m; do
+        [[ -z "$m" ]] && continue
+        findings+=("title||$m")
+    done < <(printf '%s\n' "$TITLE" | grep -oE "$pattern" || true)
+
+    local line_match lineno
+    while IFS= read -r line_match; do
+        [[ -z "$line_match" ]] && continue
+        lineno="${line_match%%:*}"
+        m="${line_match#*:}"
+        findings+=("body|$lineno|$m")
+    done < <(grep -n -oE "$pattern" "$BODY_FILE" || true)
+
+    total=${#findings[@]}
+    if [[ "$total" -eq 0 ]]; then
+        return 0
+    fi
+
+    for entry in "${findings[@]}"; do
+        shown=$((shown + 1))
+        if [[ $shown -gt 5 ]]; then
+            continue
+        fi
+        field="${entry%%|*}"
+        rest="${entry#*|}"
+        lineinfo="${rest%%|*}"
+        m="${rest#*|}"
+        head="${m:0:10}"
+        tail="${m: -4}"
+        redacted="${head}…${tail}"
+        if [[ "$field" == "body" ]]; then
+            report+="  - body (line $lineinfo): $redacted (${#m} chars)"$'\n'
+        else
+            report+="  - title: $redacted (${#m} chars)"$'\n'
+        fi
+    done
+    if [[ "$total" -gt 5 ]]; then
+        report+="  ... and $((total - 5)) more match(es) not shown"$'\n'
+    fi
+
+    needle_error "Title/body contains $total unbroken run(s) of 44+ characters from [A-Za-z0-9/_-] — bf create's own secret scanner will very likely reject this dispatch with a 'secret detected: ... [Azure Key]' error before Codex is ever invoked.
+
+$report
+Most matches like this are ordinary long file/worktree paths, not real
+secrets — but this guard (matching bf's own heuristic on purpose) can't
+tell the difference, and neither can bf. Fix: state any long directory
+prefix ONCE in prose (e.g. 'files under scripts/needle/') and refer to
+bare filenames afterward instead of repeating a full path in every
+reference."
+}
+
+if [[ "${SKILLSMITH_NEEDLE_SECRET_GUARD_DISABLE:-0}" == "1" ]]; then
+    echo "[needle-dispatch] WARNING: SKILLSMITH_NEEDLE_SECRET_GUARD_DISABLE=1 — skipping the SMI-5709 secret-scanner compatibility guard. bf's own scanner still runs on 'bf create' below and may still reject this dispatch." >&2
+else
+    needle_secret_scan_guard
+fi
+
 # ---- Ensure a bead-forge workspace exists ----
 if [[ ! -d "$WORKSPACE/.beads" ]]; then
     bf init --workspace "$WORKSPACE" >/dev/null

--- a/scripts/tests/needle-dispatch.test.sh
+++ b/scripts/tests/needle-dispatch.test.sh
@@ -250,6 +250,57 @@ else
     echo "PASS (case 5): non-git --workspace skips the diff check without crashing"
 fi
 
+# ---- Cases 6-7 (SMI-5709): secret-scanner compatibility guard ----
+# A 50-char hex run (matches [A-Za-z0-9/_-], mirrors a realistic long
+# token/path) — distinct characters, not a repeated single char, so "the
+# full run never appears in output" is a meaningful assertion rather than
+# trivially true/false from repetition.
+LONG_RUN="$(openssl rand -hex 25)"
+LONG_RUN_BODY_FILE="$(mktemp)"
+printf 'some prompt text\n%s\nmore prompt text\n' "$LONG_RUN" > "$LONG_RUN_BODY_FILE"
+
+# Case 6: title contains a 44+ char run -> guard fires before any bf/codex
+# invocation, exit 1, output shows a redacted preview (contains the ellipsis
+# marker) but never the full matched run.
+set +e
+PATH="$TEST_PATH" "$DISPATCH" \
+    --workspace "$GIT_WORKTREE_DIR" \
+    --title "$LONG_RUN" \
+    --body-file "$BODY_FILE" \
+    --timeout 5 \
+    >/tmp/needle-dispatch-test-case6.out 2>&1
+EXIT_CODE=$?
+set -e
+if [[ "$EXIT_CODE" -ne 1 ]] \
+    || ! grep -q "…" /tmp/needle-dispatch-test-case6.out \
+    || grep -qF "$LONG_RUN" /tmp/needle-dispatch-test-case6.out; then
+    echo "FAIL (case 6): expected exit 1, a redacted (…) preview, and the full run absent from output, got exit $EXIT_CODE" >&2
+    cat /tmp/needle-dispatch-test-case6.out >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "PASS (case 6): a 44+ char run in the title fails fast with a redacted preview, never the full match"
+fi
+
+# Case 7: same long run, but in the body, with the guard disabled via its
+# registered opt-out var -> guard is skipped (no redaction message), and
+# the dispatch proceeds through the faked bf/needle stack to success.
+EXIT_CODE="$(SKILLSMITH_NEEDLE_SECRET_GUARD_DISABLE=1 FAKE_SCENARIO=clean FAKE_TOUCH_FILE=0 PATH="$TEST_PATH" "$DISPATCH" \
+    --workspace "$GIT_WORKTREE_DIR" \
+    --title "fixture case 7" \
+    --body-file "$LONG_RUN_BODY_FILE" \
+    --timeout 5 \
+    >/tmp/needle-dispatch-test-case7.out 2>&1; echo $?)"
+if [[ "$EXIT_CODE" -ne 0 ]] \
+    || ! grep -q "outcome=success" /tmp/needle-dispatch-test-case7.out \
+    || ! grep -q "SKILLSMITH_NEEDLE_SECRET_GUARD_DISABLE=1" /tmp/needle-dispatch-test-case7.out; then
+    echo "FAIL (case 7): expected exit 0, outcome=success, and the opt-out warning, got exit $EXIT_CODE" >&2
+    cat /tmp/needle-dispatch-test-case7.out >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "PASS (case 7): SKILLSMITH_NEEDLE_SECRET_GUARD_DISABLE=1 skips the guard and the dispatch proceeds"
+fi
+rm -f "$LONG_RUN_BODY_FILE"
+
 if [[ "$FAIL_COUNT" -gt 0 ]]; then
     echo "FAILED: $FAIL_COUNT case(s) failed" >&2
     exit 1


### PR DESCRIPTION
## Business Summary

**What shipped:** Dispatching a task to Codex (our second-model review tool) used to fail with a cryptic "secret detected" error whenever the prompt happened to mention an ordinary long file path — nothing to do with real secrets, just a false alarm in a third-party scanner. It now fails fast instead, with a clear message naming the problem and how to fix it. Also documented a separate gap: for a review-only Codex dispatch, the tool's own log never contains the actual answer — we wrote down exactly where to find it instead.

**Quality bar:** Reviewed twice before commit — once by Codex itself (an independent cross-check on the plan) and once by an Opus adversarial pass on the finished code, which caught 3 real gaps (a documented workaround that didn't actually work, no way to turn the new check off if needed, and no tests) — all fixed in this same PR. A fresh audit afterward found nothing new.

**Net result:** Fully shipped, no follow-up.

---

## Technical detail

- `scripts/needle/dispatch.sh` — new pre-flight guard before `bf create`: scans the raw title/body for 44+-char runs of `[A-Za-z0-9/_-]` (mirroring `bf`'s own "Azure Key" heuristic exactly, on purpose), fails fast with a redacted preview (never the full match). Escape hatch: `SKILLSMITH_NEEDLE_SECRET_GUARD_DISABLE=1`.
- `scripts/needle/README.md` — new Troubleshooting entry covering the guard + the separate NEEDLE trace-doesn't-capture-response finding (real answer is in `~/.codex/sessions/.../rollout-*.jsonl`, `event_msg`/`agent_message` entries).
- `scripts/tests/needle-dispatch.test.sh` — 2 new cases (guard fires + redacts; opt-out skips it), all 8 cases pass.
- `docs/internal` (gitlink) — registers the new opt-out in `guards-and-opt-outs.md` per SMI-5418 DoD #5, plus a governance code review report.
- `audit:standards`: 76 passed / 0 failed / 7 pre-existing unrelated warnings. Typecheck/lint/format:check clean.

Refs SMI-5709.
