### PR TITLE
chore(release): weekly cadence bump — 2026-07-19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35513,7 +35513,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
@@ -35544,8 +35544,8 @@
         "sklx": "dist/cli.js"
       },
       "devDependencies": {
-        "@skillsmith/core": "^0.11.2",
-        "@skillsmith/mcp-server": "^0.7.4",
+        "@skillsmith/core": "^0.11.3",
+        "@skillsmith/mcp-server": "^0.7.5",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
         "vitest": "4.1.10"
@@ -35554,7 +35554,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@smith-horn/enterprise": "*"
+        "@smith-horn/enterprise": "^0.3.3"
       },
       "peerDependenciesMeta": {
         "@smith-horn/enterprise": {
@@ -35850,7 +35850,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -36172,18 +36172,18 @@
     },
     "packages/enterprise": {
       "name": "@smith-horn/enterprise",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1090.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.75.0",
-        "@skillsmith/core": "^0.11.2",
+        "@skillsmith/core": "^0.11.3",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.7.4",
+        "@skillsmith/mcp-server": "^0.7.5",
         "@smithy/config-resolver": "4.6.10",
         "@smithy/core": "3.29.5",
         "@smithy/middleware-endpoint": "4.6.10",
@@ -36198,7 +36198,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.7.4"
+        "@skillsmith/mcp-server": "^0.7.5"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -36261,12 +36261,12 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "Elastic-2.0",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "10.1.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.11.2",
+        "@skillsmith/core": "^0.11.3",
         "ajv-formats-draft2019": "1.6.1",
         "ulid": "3.0.1",
         "zod": "3.25.76"
@@ -36518,7 +36518,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.8.3
+
+- **Chore**: bump the opentelemetry group across 1 directory with 8 updates (#1862)
 - **Fix**: `utils/license-validation.ts`'s `tryLoadEnterpriseValidator()` now dynamically imports the enterprise package under its real name, `@smith-horn/enterprise` — previously imported `@skillsmith/enterprise`, a name that has never existed, so license validation silently failed for every Enterprise-tier install regardless of correct setup (SMI-5738)
 - **Fix**: `getSkillsFromDirectory()` now discovers an individually symlinked skill directory (`ln -s ~/.claude/skills/foo ~/.cursor/skills/foo`) — previously `entry.isDirectory()` alone silently skipped it, since `readdir(..., { withFileTypes: true })` reports a symlinked directory as a symlink, not a directory. `getInstalledSkillsPerHarness()` also no longer collapses a symlinked skill alias across harnesses into a single row — realpath is now used only to memoize the expensive `readSkillMd()` parse and to collapse multiple aliases WITHIN one harness's own directory, while a row is still returned for every harness that observes the skill, matching the function's own "two distinct rows" docstring contract (SMI-5717) (GH #1912)
 - **Change**: `compliance_reports`' displayed tier requirement expanded from Enterprise-only to Team + Enterprise (SMI-3140)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -39,14 +39,14 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@skillsmith/core": "^0.11.2",
-    "@skillsmith/mcp-server": "^0.7.4",
+    "@skillsmith/core": "^0.11.3",
+    "@skillsmith/mcp-server": "^0.7.5",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@smith-horn/enterprise": "*"
+    "@smith-horn/enterprise": "^0.3.3"
   },
   "peerDependenciesMeta": {
     "@smith-horn/enterprise": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.11.3
+
+- **Chore**: Migrate remaining stale references to ruflo v3 (#1952)
+- **Chore**: bump the opentelemetry group across 1 directory with 8 updates (#1862)
 - **Fix**: doc-comments in `telemetry/tracer.ts`/`tracer-imports.ts` referencing the optional enterprise instrumentation dependency now name the real package, `@smith-horn/enterprise` (SMI-5738; no behavior change here, see `@skillsmith/mcp-server`/`@skillsmith/cli` for the actual runtime import fix)
 - **Feature**: new `@skillsmith/core/security/scanner` export subpath, exposing `stripInvisible`/`confusableSkeleton`/`CONFUSABLES` for reuse outside the package (SMI-4703) — enables `@skillsmith/doc-retrieval-mcp`'s memory-write injection scanner to reuse the same confusable/homoglyph normalization primitives `SecurityScanner.exec.ts` uses, instead of reimplementing them
 - **Feature**: new `getOrCreateInstallId()` in `config/device-identity.ts` — a stable per-install telemetry identifier (`sha256(randomUUID())`), generated and persisted unconditionally regardless of legacy telemetry env-gating (SMI-5531)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.11.2'
+export const VERSION = '0.11.3'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+## v0.3.3
+
+- **Chore**: bump @aws-sdk/client-cloudwatch-logs (#1858)
+- **Chore**: bump the smithy group across 1 directory with 8 updates (#1860)
+- **Chore**: bump the opentelemetry group across 1 directory with 8 updates (#1862)
 - **Fix**: `@module` JSDoc tags across `src/audit/*.ts` and `src/index.ts` now name the package's real, published name, `@smith-horn/enterprise` — previously self-referenced `@skillsmith/enterprise`, a name that has never existed (SMI-5738; doc-comments only, see `@skillsmith/mcp-server`/`@skillsmith/cli` for the actual runtime import fix)
 - **Change**: `compliance_reports` moved from `EnterpriseFeatureFlag`/`ENTERPRISE_ONLY_FEATURES` to `TeamFeatureFlag`/`TEAM_FEATURES` (`FeatureFlags.ts`, `TierMapping.ts`, `types.ts`) — expanded from Enterprise-only to Team + Enterprise (SMI-3140)
 

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smith-horn/enterprise",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Enterprise features for Skillsmith including audit logging, SSO, and RBAC",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1090.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.75.0",
-    "@skillsmith/core": "^0.11.2",
+    "@skillsmith/core": "^0.11.3",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.7.4",
+    "@skillsmith/mcp-server": "^0.7.5",
     "@smithy/config-resolver": "4.6.10",
     "@smithy/core": "3.29.5",
     "@smithy/middleware-endpoint": "4.6.10",
@@ -62,7 +62,7 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.7.4"
+    "@skillsmith/mcp-server": "^0.7.5"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.7.5
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.7.4).
 - **Fix**: `middleware/license.ts`'s `tryLoadEnterpriseValidator()` and `tools/audit-tools.ts`'s `getAuditLogger()` now dynamically import the enterprise package under its real name, `@smith-horn/enterprise` — both previously imported `@skillsmith/enterprise`, a name that has never existed, so license validation and `audit_export`/`audit_query`/`siem_export` silently failed for every Enterprise-tier install regardless of correct setup. Masked in tests by a `vitest.e2e.config.ts` resolver alias with no equivalent in a real Node.js runtime (SMI-5738)
 - **Feature**: `compliance_report`'s `cyclonedx` format now emits a real CycloneDX 1.5 AI/ML-BOM (`@cyclonedx/cyclonedx-library`) instead of a hand-rolled flat JSON document — component/dependency-graph construction from `skill_dependencies`, per-skill sparse-data signaling with an opt-in `backfillDependencies` option (hard-gated to the `better-sqlite3` driver), and audit logging of export events (SMI-3140)
 - **Fix**: `compliance_report`'s skill inventory (`soc2`/`cyclonedx`/`json`, all three formats) now sources the installed-skill set from `~/.skillsmith/manifest.json`, not an unfiltered scan of the entire locally-indexed `skills` table, and reports each skill's real installed version instead of a hardcoded placeholder (SMI-5675)

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@cyclonedx/cyclonedx-library": "10.1.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.11.2",
+    "@skillsmith/core": "^0.11.3",
     "ajv-formats-draft2019": "1.6.1",
     "ulid": "3.0.1",
     "zod": "3.25.76"

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.7.4",
+  "version": "0.7.5",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -111,7 +111,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.7.4'
+const PACKAGE_VERSION = '0.7.5'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 const logger = createLogger('mcp', { version: PACKAGE_VERSION }) // SMI-5615
 import { installBundledSkills, installUserDocs } from './onboarding/install-assets.js'

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## v0.7.3
+
+- **Chore**: bump @wdio/mocha-framework from 9.29.0 to 9.29.1 (#1866)
 - **Internal**: Renamed the `audit:check-48-ack` opt-out marker comment in `telemetry-wrap.ts` to `audit:check-49-ack`, matching a governance-tooling relabel in the main repo (SMI-5684); no functional or user-visible change.
 
 ## v0.7.2

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Discover and install agent skills directly in VS Code",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"

--- a/scripts/lib/version-utils.ts
+++ b/scripts/lib/version-utils.ts
@@ -139,11 +139,13 @@ export const CORE_DEPENDENTS = [
  *
  * Replaces the older core-only `updateCoreDependency`. The natural
  * predicate "skip if dep key is not in the bump map" correctly handles
- * peerDependencies with `"*"` (e.g. cli → @smith-horn/enterprise: "*").
- * The `"*"` range maps to a key (@smith-horn/enterprise) that does not
- * exist in any PACKAGE_SPECS entry — the enterprise package's npm name is
- * @smith-horn/enterprise (SMI-5120) — so it's never in the bump map and is
- * naturally skipped.
+ * peerDependencies with `"*"` (e.g. cli → @smith-horn/enterprise: "*") —
+ * but only when that call's `plans` doesn't include enterprise. Since
+ * SMI-5120 added `@smith-horn/enterprise` to PACKAGE_SPECS (it publishes
+ * and gets bumped like any other target), a `plans` array that DOES
+ * include an enterprise bump will correctly rewrite this range to
+ * `^<newVersion>` rather than leaving it a no-op — the bump map is keyed
+ * off the current call's `plans`, not off PACKAGE_SPECS membership.
  */
 export function updateWorkspaceDependencies(
   plans: Array<{ spec: PackageSpec; newVersion: string }>

--- a/scripts/tests/prepare-release.test.ts
+++ b/scripts/tests/prepare-release.test.ts
@@ -192,9 +192,21 @@ describe('updateWorkspaceDependencies (SMI-5057)', () => {
   })
 
   it('treats peerDependencies with non-bumped key as a no-op (SMI-5057 M-5)', () => {
-    // @smith-horn/enterprise: "*" in cli's peerDependencies is NOT in
-    // PACKAGE_SPECS, so it never lands in the bump map and is naturally
-    // skipped. No `*`-string heuristic needed.
+    // This test's `plans` array below deliberately omits an enterprise bump,
+    // so "@smith-horn/enterprise" never lands in this call's bump map and is
+    // naturally skipped — regardless of its *current* range. `readFileSync`
+    // is unmocked here (only `writeFileSync` is spied), so this reads the
+    // real, currently-checked-out packages/cli/package.json. On a pristine
+    // checkout that range is "*"; on a release-cadence branch where a prior
+    // `--all` bump already advanced enterprise (SMI-5120 added it to
+    // PACKAGE_SPECS), it's already `^<version>`. Assert against whatever
+    // that pre-call value actually is, not a hardcoded "*" literal — the
+    // behavioral contract under test is "unchanged by this call", not "is
+    // the wildcard".
+    const cliPackageJsonPath = join(ROOT_DIR, 'packages/cli/package.json')
+    const cliPkgBefore = JSON.parse(readFileSync(cliPackageJsonPath, 'utf-8'))
+    const enterpriseRangeBefore = cliPkgBefore.peerDependencies?.['@smith-horn/enterprise']
+
     const corePlan = {
       spec: PACKAGE_SPECS.find((s) => s.shortName === 'core')!,
       newVersion: '0.7.3',
@@ -202,15 +214,15 @@ describe('updateWorkspaceDependencies (SMI-5057)', () => {
 
     updateWorkspaceDependencies([corePlan])
 
-    // If we wrote cli/package.json, verify the peerDependencies entry was
-    // preserved as "*" (not converted to a versioned range).
+    // If we wrote cli/package.json (e.g. because core's own dep range
+    // changed), verify the peerDependencies entry was left untouched.
     const cliWrite = mockedWriteFileSync.mock.calls.find((c) =>
       String(c[0]).endsWith('packages/cli/package.json')
     )
     if (cliWrite) {
       const cliPkg = JSON.parse(String(cliWrite![1]))
       if (cliPkg.peerDependencies?.['@smith-horn/enterprise']) {
-        expect(cliPkg.peerDependencies['@smith-horn/enterprise']).toBe('*')
+        expect(cliPkg.peerDependencies['@smith-horn/enterprise']).toBe(enterpriseRangeBefore)
       }
     }
   })


### PR DESCRIPTION
Automated weekly release cadence PR opened by `release-cadence.yml` (SMI-4191).

## What this PR does

Runs `scripts/prepare-release.ts --all=patch` to bump all packages by one patch version and drain per-package CHANGELOG `[Unreleased]` sections into the new versions.

## What to check before merging

1. The bumped versions match what you want to ship (patch/minor/major). If minor or major is needed, close this PR, run `prepare-release.ts` with the right flags locally, and open a manual PR.
2. The CHANGELOG entries read cleanly and reference the right Linear issues.
3. CI is green.

## After merging

Trigger publish: `gh workflow run publish.yml -f dry_run=false`. The `create-gh-release` job will create matching GitHub Releases automatically.

Parent: SMI-4144. See [ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md).