### PR TITLE
docs(readme): Resync stale What's New sections in npm package READMEs

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@ Command-line interface for Skillsmith - discover, manage, and author agent skill
 
 ## Contents
 
-- [What's New](#whats-new-in-v080)
+- [What's New](#whats-new-in-v082)
 - [Installation](#installation)
 - [Commands](#commands)
   - [inventory](#inventory)
@@ -14,12 +14,11 @@ Command-line interface for Skillsmith - discover, manage, and author agent skill
 - [Examples](#examples)
 - [Privacy & Data Handling](#privacy--data-handling)
 
-## What's New in v0.8.0
+## What's New in v0.8.2
 
-- **`sklx agent install` / `uninstall`**: New command group installs a portable agent pack (SKILL.md + shims + hooks) to detected harnesses with per-harness MCP registration.
-- **Per-user inventory purge**: New hard-delete path for clearing a user's full skill inventory.
-- **`sklx audit collisions` / `audit advisories`**: Namespace-collision and legacy security-advisory audit subcommands, plus `sklx config set audit_mode <preventative|power_user|governance|off>`.
-- **Remote-default search + provenance**: `search` now defaults to the remote registry with safety filters, and install provenance is reported as Local / source-identified / Pending.
+- **Corrected tier quota display**: Community/Individual/Team quota labels shown by the CLI are reduced 10x (100/mo, 1,000/mo, 10,000/mo respectively) to match actual enforcement — display-only; enforcement lives in `@skillsmith/mcp-server`.
+
+> v0.8.2 is a scheduled cadence release with no functional changes beyond v0.8.1.
 
 See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,19 +4,18 @@ Core library for Skillsmith - provides database operations, search services, cac
 
 ## Contents
 
-- [What's New](#whats-new-in-v0100)
+- [What's New](#whats-new-in-v0112)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Features](#features)
 - [Exports](#exports)
 
-## What's New in v0.10.0
+## What's New in v0.11.2
 
-- **Cross-harness agent-pack generation**: Multi-target agent-pack generator, installer, and uninstaller emitting `SKILL.md` plus Claude Code, Codex, OpenCode, and Copilot shims and hooks, with manifest tracking and path-guarded uninstall.
-- **Change journal**: Hash-chained, fsync'd change-journal module — the foundation for the session-scoped undo now surfaced by `@skillsmith/mcp-server`'s `undo_apply` tool.
-- **Cross-harness skill inventory**: Data-plane and write-path support for auditing and syncing skill inventories across multiple agent harnesses, plus a local CLI/MCP push agent.
-- **Quarantine hardening**: Split scanner architecture with chmod-evasion detection and sibling re-scan on quarantine recheck.
-- **Per-user inventory purge**: New hard-delete path for removing a user's full skill inventory.
+- **Cross-session rename revert**: `apply_namespace_rename`'s `action: 'revert'` is now exposed, and `JournalAction`/`JOURNAL_SCHEMA_VERSION` are widened so an older reader no longer flags a legitimate revert journal record as corrupt.
+- **Unified shutdown coordinator**: Awaitable sync stop consolidates shutdown handling across the database and background writers.
+- **Production-grade error logging and diagnostics**: Structured error logging and diagnostics for easier triage in production.
+- **Dependency backfill**: `skill_dependencies` now backfills correctly for installs that predate v0.7.1.
 
 See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -4,12 +4,12 @@
 
 MCP (Model Context Protocol) server for agent skill discovery, installation, and management.
 
-## What's New in v0.7.0
+## What's New in v0.7.4
 
-- **`undo_apply` tool**: Session-scoped undo for `apply_namespace_rename` / `apply_recommended_edit`, restoring from the apply tool's own backup.
-- **Curated agent tool profile**: Set `SKILLSMITH_TOOL_PROFILE=agent` to expose a focused ~15-tool listing sized for harness/agent integration instead of the full tool surface.
-- **Installable-only search by default**: `search` and `skill_recommend` now hide discovery-only entries (no resolvable install source) by default; pass `installable_only: false` to restore the previous inclusive behavior.
-- **Cross-harness skill inventory**: New local CLI/MCP push agent keeps skill inventories in sync across multiple agent harnesses.
+- **Cross-session rename revert**: `apply_namespace_rename`'s `action: 'revert'` is now exposed, closing the gap where a rename applied in a prior session had no reachable undo path.
+- **Shutdown persistence fix**: Recently-installed skills and dependency data are now correctly persisted on shutdown — previously silently discarded when running without native SQLite support (common on macOS/npx installs).
+- **Corrected quota enforcement**: Local quota limits reduced 10x to match actual tier limits, with a `SKILLSMITH_ENFORCE_MCP_QUOTA` kill-switch to disable hard-blocking without a redeploy.
+- **Subscription tier resolution fix**: Personal API keys now resolve the real subscription tier correctly.
 
 See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 
@@ -18,7 +18,7 @@ See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 The MCP server checks for updates on startup and notifies you when a newer version is available:
 
 ```
-[skillsmith] Update available: 0.6.x → 0.7.0
+[skillsmith] Update available: 0.7.3 → 0.7.4
 Restart your MCP client to use the latest version.
 ```
 


### PR DESCRIPTION
## Business Summary

**What shipped:** The "What's New" sections on the npm pages for `@skillsmith/core`, `@skillsmith/cli`, and `@skillsmith/mcp-server` were stale (2-4 releases behind what's actually published) — they now reflect the real current version and highlights of each package.

**Quality bar:** Every new bullet was cross-checked word-for-word against each package's own CHANGELOG.md; one elaborated claim was additionally verified against its implementing commit. Docs-only change — typecheck/lint/format all clean via pre-commit hook.

**Found along the way:** This is the third time this exact drift has happened (once in April, once via SMI-5612 in early July, now this one — each time within weeks of the last fix), because nothing in the release pipeline actually checks for it. Bumped the still-open durable fix (SMI-5613, an automated check) from "No priority" to Medium given the pattern; it remains a separate, larger piece of work gated behind this repo's infra-change review process (ADR-109), not something folded into this PR.

**Net result:** Fully shipped, no follow-up in this PR. SMI-5613 (the durable prevention) is tracked separately and intentionally out of scope here — scope was confirmed with the user up front.

---

## Technical detail

- `packages/core/README.md`: heading v0.10.0 → v0.11.2, TOC anchor updated, bullets sourced from CHANGELOG.md v0.11.0–v0.11.2 (rename revert, unified shutdown coordinator, production error logging, dependency backfill).
- `packages/cli/README.md`: heading v0.8.0 → v0.8.2, TOC anchor updated, bullet + cadence-release blockquote sourced from CHANGELOG.md v0.8.1–v0.8.2 (tier-quota display fix).
- `packages/mcp-server/README.md`: heading v0.7.0 → v0.7.4, bullets sourced from CHANGELOG.md v0.7.1–v0.7.4 (rename revert, shutdown persistence fix, quota enforcement fix, subscription-tier resolution fix), stale auto-update example refreshed.
- `docs/internal` pointer bump for the paired code review report (`2026-07-19-smi-5759-npm-readme-whats-new-third-recurrence.md`).

Docs-only — no source, test, or CI files touched; qualifies for docs-tier CI (3 checks).

Refs SMI-5759. Related: SMI-5612 (prior fix), SMI-5613 (durable fix, priority bumped).


[skip-impl-check] — docs-only change (README content), no source code by design; referenced SMI issues track the doc drift itself, not an implementation.
