### PR TITLE
fix(website): set vite preserveSymlinks to fix worktree Astro build

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -88,6 +88,15 @@ export default defineConfig({
 
   // Vite configuration for API proxy in development
   vite: {
+    // SMI-5747: worktree node_modules is a symlink back to the main checkout,
+    // so Docker's bind mount at /app/node_modules resolves through it and
+    // Node canonicalizes module paths to /node_modules/*, splitting Astro's
+    // compile-cache key from its lookup key ("No cached compile metadata
+    // found"). Keep resolution under the symlinked path Astro actually built
+    // the cache under, instead of the realpath.
+    resolve: {
+      preserveSymlinks: true,
+    },
     plugins: [
       tailwindcss(),
       // SMI-5205: publish OpenAPI spec from docs/internal submodule to public/ at build time.


### PR DESCRIPTION
## Business Summary

**What shipped:** `packages/website`'s build now succeeds inside any git worktree — previously `npm run build`/`turbo run build` always failed on `@skillsmith/website#build` with an Astro `No cached compile metadata found` error, blocking anyone developing the website in a worktree.

**Quality bar:** Root cause investigated end-to-end (Fable investigation pass → Opus SPARC draft → Sol/Codex cross-provider adversarial review via NEEDLE) before choosing this fix. Reproduced the failure first, then verified the fix against: isolated website build (2 clean runs), full monorepo build (7/7 tasks), typecheck, lint, and the website's own test suite (31 files / 490 tests) — all clean.

**Found along the way:** the investigation surfaced a genuine architectural tension with already-merged commit `154a384f` (SMI-5689) around worktree `node_modules` shape — tracked on SMI-5747 itself, not a new issue. Also found the repo's audit:standards compliance score sitting at 89% (9 warnings, 0 failures) — none related to this change — filed separately as SMI-5765. Also found a `verify-implementation` false-positive on `.mjs` files under `packages/**` (this PR's only file) — filed as SMI-5767, `[skip-impl-check]` used below as the documented workaround.

**Net result:** Fully shipped. This is "Option B" from the SMI-5747 investigation — deliberately the smaller, reversible fix, chosen over a fleet-wide worktree `node_modules` migration ("Option A") after review found Option A's consumer inventory and migration safety incomplete.

---

## Technical detail

`packages/website/astro.config.mjs` — added `vite.resolve.preserveSymlinks: true` (9 lines, config + explanatory comment).

**Root cause:** worktree `node_modules` is a relative symlink back to the main checkout. Docker's bind mount at `/app/node_modules` resolves through that symlink at mount time, so the repo's own root bind mount (`scripts/_lib.sh`, SMI-5626) lands at container-root `/node_modules` instead of `/app/node_modules`. Node then canonicalizes `/app/node_modules` → `/node_modules`, splitting Astro's compile-cache write path from its read path. `preserveSymlinks` keeps Vite/Astro's module resolution under the symlinked path instead of realpath-ing through it.

**Regression risk:** `packages/website/package.json` has zero `@skillsmith/*`/`@smith-horn/*` workspace dependencies, so the workspace-symlink-dedup concern raised in review doesn't apply to this package.

**CI note:** `[skip-impl-check]` — `scripts/ci/source-patterns.mjs`'s `SOURCE_PATTERNS` doesn't recognize `.mjs` files under `packages/**` (or nested `*.config.mjs`) as source, so `verify-implementation` false-fires "no source code changes" on this PR's one real, tested fix. Root cause + proper fix tracked separately as SMI-5767 (ADR-109 gated — needs SPARC + plan-review, out of scope for this PR).

Fixes SMI-5747.