### PR TITLE
feat(audit): Add Check 60 — README What's New vs package.json drift (SMI-5613)

### DIFF
--- a/scripts/audit-readme-whats-new-helpers.mjs
+++ b/scripts/audit-readme-whats-new-helpers.mjs
@@ -1,0 +1,17 @@
+/**
+ * Helper for Check 60 (README "What's New" Currency, SMI-5613).
+ * Extracted for unit testability, matching the audit-mcp-tool-count-helpers.mjs
+ * precedent (Check 25).
+ */
+
+/**
+ * Extracts the version from a README's "## What's New in vX.Y.Z" heading.
+ * Tolerates a missing leading "v". Returns null if no such heading is found.
+ *
+ * @param {string} readmeContent
+ * @returns {string | null}
+ */
+export function extractWhatsNewVersion(readmeContent) {
+  const match = readmeContent.match(/^## What's New in v?(\d+\.\d+\.\d+)/m)
+  return match ? match[1] : null
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -49,6 +49,7 @@ import { VERCEL_JSON_SHARED_FIELDS, validateVercelJsonSync } from './audit-verce
 import { findRealpathAsymmetry } from './audit-realpath-asymmetry-helpers.mjs'
 import { findUnpinnedActionUses } from './audit-workflow-sha-pin-helpers.mjs'
 import { countToolDefinitions } from './audit-mcp-tool-count-helpers.mjs'
+import { extractWhatsNewVersion } from './audit-readme-whats-new-helpers.mjs'
 import { evaluateInternalVersionCoherence } from './audit-internal-version-coherence-helpers.mjs'
 import {
   findFloatingSupabaseCliInstalls,
@@ -5013,6 +5014,86 @@ console.log(`\n${BOLD}Check 59: CLI-tool pin invariants (SMI-5746)${RESET}`)
 
   if (check59Violations === 0) {
     pass('Check 59: no CLI-tool pin invariant violations found')
+  }
+}
+
+// Check 60: README "What's New" Currency (SMI-5613)
+//
+// packages/{core,cli,mcp-server}/README.md each carry a manually-maintained
+// "## What's New in vX.Y.Z" section that ships verbatim to npmjs.com.
+// scripts/prepare-release.ts bumps package.json/CHANGELOG.md/version constants
+// on every release but never touches README.md — this drift has silently
+// recurred three times (April 2026, SMI-5612, SMI-5759) with no automated
+// detection. See docs/internal/implementation/readme-whats-new-drift-check.md.
+//
+// Scoped to the dynamic packages/* glob (like Checks 24/58), not a hardcoded
+// package list — a package with no "What's New" heading at all is silently
+// skipped (matching Check 24's asymmetry), since most packages legitimately
+// have no such section.
+//
+// Ships warn-level through a shadow burn-in (CHECK_60_SHADOW_END_DATE below,
+// matching Check 59's convention) — this is new detection logic without a
+// battle-tested regex/heading-format assumption across a real release cycle
+// yet, unlike Check 58's immediate fail(). Promotes to fail-level after.
+console.log(`\n${BOLD}Check 60: README "What's New" Currency (SMI-5613)${RESET}`)
+{
+  const CHECK_60_SHADOW_END_DATE = '2026-08-02'
+  const inShadow = new Date() < new Date(CHECK_60_SHADOW_END_DATE)
+  const report = inShadow ? warn : fail
+  const shadowSuffix = inShadow
+    ? ` [shadow mode through ${CHECK_60_SHADOW_END_DATE} — advisory only]`
+    : ''
+
+  // [skip-whats-new-check] — PR-body marker for a genuinely deliberate
+  // exception once at fail-tier. Boolean marker + required prose reason
+  // paragraph, mirrors [skip-changelog-check] / [skip-version-coherence-check]
+  // exactly. Registered in docs/internal/process/guards-and-opt-outs.md.
+  // Gated on !inShadow: during shadow mode `report` is already `warn`
+  // regardless, so checking the marker then would just add a confusing
+  // "acknowledged" suffix implying something was blocked when nothing was.
+  const SKIP_MARKER = '[skip-whats-new-check]'
+  const PR_BODY = process.env.PR_BODY || ''
+  const skipAcknowledged = !inShadow && PR_BODY.includes(SKIP_MARKER)
+  if (skipAcknowledged) {
+    console.log(
+      `::notice::${SKIP_MARKER} opt-out found in PR body — Check 60 will report findings but not fail.`
+    )
+  }
+
+  const pkgDirs = existsSync('packages')
+    ? readdirSync('packages').filter((d) => existsSync(join('packages', d, 'package.json')))
+    : []
+
+  let whatsNewIssues = 0
+  for (const d of pkgDirs) {
+    const pkgPath = join('packages', d, 'package.json')
+    const readmePath = join('packages', d, 'README.md')
+    if (!existsSync(readmePath)) continue
+
+    try {
+      const pkgVersion = JSON.parse(readFileSync(pkgPath, 'utf8')).version
+      if (!pkgVersion) continue
+
+      const readmeVersion = extractWhatsNewVersion(readFileSync(readmePath, 'utf8'))
+      if (readmeVersion === null) continue // No "What's New" section — not this check's concern
+
+      if (readmeVersion !== pkgVersion) {
+        whatsNewIssues++
+        const msg = `packages/${d}: README "What's New" section is stale — heading says v${readmeVersion} but package.json is at v${pkgVersion}${shadowSuffix}`
+        const fix = `Update ${readmePath}'s "What's New" section for v${pkgVersion}`
+        if (skipAcknowledged) {
+          warn(msg + ' — [skip-whats-new-check] acknowledged', fix)
+        } else {
+          report(msg, fix)
+        }
+      }
+    } catch (e) {
+      warn(`Could not check README "What's New" currency for packages/${d}: ` + e.message)
+    }
+  }
+
+  if (whatsNewIssues === 0) {
+    pass(`Check 60: all README "What's New" sections are current with their package.json versions`)
   }
 }
 

--- a/scripts/tests/audit-readme-whats-new.test.ts
+++ b/scripts/tests/audit-readme-whats-new.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { extractWhatsNewVersion } from '../audit-readme-whats-new-helpers.mjs'
+
+describe('extractWhatsNewVersion', () => {
+  it('extracts the version from a heading with a leading "v"', () => {
+    expect(extractWhatsNewVersion("# Package\n\n## What's New in v0.11.2\n\n- Bullet")).toBe(
+      '0.11.2'
+    )
+  })
+
+  it('extracts the version from a heading with no leading "v"', () => {
+    expect(extractWhatsNewVersion("## What's New in 0.8.2\n\n- Bullet")).toBe('0.8.2')
+  })
+
+  it('returns null when no "What\'s New" heading exists', () => {
+    expect(extractWhatsNewVersion('# Package\n\n## Installation\n\nnpm install foo')).toBeNull()
+  })
+
+  it('returns null when the heading exists but has no parseable version', () => {
+    expect(extractWhatsNewVersion("## What's New\n\n- Bullet with no version")).toBeNull()
+  })
+
+  it('only matches a "## " heading at line start, not a deeper sub-heading', () => {
+    expect(extractWhatsNewVersion("### What's New in v1.2.3\n\n- Bullet")).toBeNull()
+  })
+
+  it('only matches at line start, not mid-sentence text with the same words', () => {
+    const content = "See the section on What's New in v1.2.3 for details, below the fold."
+    expect(extractWhatsNewVersion(content)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** CI now automatically catches it when one of our npm packages' README
"What's New" section falls behind the version we actually published — the exact drift
that's silently slipped through three times this year (April, then twice more in July)
and had to be manually fixed by hand each time.

**Quality bar:** This is an infrastructure change (touches our CI audit script), so it
went through our formal plan-review process before any code was written — an independent
review caught 4 real problems with the original design (wrong slot number, a severity
level that wouldn't have actually surfaced anywhere visible, a hardcoded package list
that would silently miss a future package, and a false-positive risk on packages that
never have this section) and all four were fixed before implementation started. A second,
independent review of the finished code found nothing further — confirmed the detection
logic matches the real README format byte-for-byte and manually simulated both the
"stale README" and "no README section at all" cases to prove it behaves correctly in
both directions.

**Net result:** Fully shipped. The check runs as an advisory warning for about two weeks
(through 2026-08-02) so it can prove itself against a couple of real release cycles,
then automatically starts blocking CI going forward.

---

## Technical detail

- `scripts/audit-standards.mjs` — new Check 60: scans `packages/*` dynamically (not a
  hardcoded package list, matching Checks 24/58's convention), extracts each package's
  README "What's New in vX.Y.Z" heading version, compares against `package.json`.
  Packages with no such heading are silently skipped (most don't have one).
- `scripts/audit-readme-whats-new-helpers.mjs` — new, extracted comparison logic for
  unit testability (matches the Check 25 precedent).
- `scripts/tests/audit-readme-whats-new.test.ts` — 6 unit tests covering the extraction
  regex.
- `docs/internal/process/guards-and-opt-outs.md` — registers the new
  `[skip-whats-new-check]` PR-body opt-out marker (only meaningful once the shadow
  burn-in lifts).
- `docs/internal/implementation/readme-whats-new-drift-check.md` — the ADR-109 plan doc,
  including the plan-review findings and how each was resolved.
- `docs/internal/code_review/2026-07-19-smi-5613-readme-whats-new-check-review.md` —
  pre-commit governance review, 0 findings.

Ships warn-level through `CHECK_60_SHADOW_END_DATE = '2026-08-02'`, then promotes to
fail-level (matching Check 59's shadow-burn-in pattern) — this is new detection logic
without a battle-tested regex/format assumption across a real release cycle yet, unlike
Check 58's immediate `fail()`.

Refs SMI-5613. Docker-validated: typecheck/lint/format/full test suite (14339 tests)/
`audit:standards` all pass locally.
