### PR TITLE
feat(scripts): targeted orphaned Docker volume/image prune (SMI-5750)

### DIFF
--- a/.claude/development/docker-guide.md
+++ b/.claude/development/docker-guide.md
@@ -275,6 +275,8 @@ docker info
 docker system df                        # see what's reclaimable
 docker system prune -a -f --volumes     # removes unused images/volumes/build cache/networks
 df -h / /System/Volumes/Data            # confirm space recovered
+
+# Routine cleanup (when Docker is healthy): `./scripts/prune-orphaned-docker-volumes.sh` is the safe, concurrency-safe targeted path; reserve the aggressive `docker system prune -a -f --volumes` for the incident-recovery scenario above.
 ```
 
 **Caveat**: `docker system prune -a -f --volumes` removes ANY volume/image not attached to a currently-running container — including cached `node_modules` volumes for worktrees that exist but whose containers are temporarily stopped, forcing a slower next start (native-module rebuild) for those. Safe to run without hesitation only when Docker Desktop itself is already down for everyone (no live containers to disrupt, as in this failure mode). If Docker is otherwise healthy and you just want routine cleanup, prefer `./scripts/remove-worktree.sh --prune` (safe subset: networks + dangling images + build cache) and only reach for the aggressive `--volumes` prune when you've confirmed via `docker ps` that no other worktree session needs to resume.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,13 @@ services:
       context: .
       dockerfile: Dockerfile
       target: dev
+      # SMI-5750: positive ownership marker so prune-orphaned-docker-volumes.sh
+      # can distinguish a Skillsmith-built `<project>-dev` image from another
+      # repo's generically-shaped `dev` service image sharing the same Compose
+      # conventions. Applies at build time only -- pre-existing images stay
+      # unlabeled (report-only "UNCONFIRMED ownership" until --include-unlabeled).
+      labels:
+        app.skillsmith.owned: 'true'
     container_name: skillsmith-dev-1
     # SMI-5245: auto-recover the long-lived dev container after a Docker daemon /
     # machine restart so the doc-retrieval + skillsmith MCP servers (launched via
@@ -69,3 +76,11 @@ services:
 
 volumes:
   node_modules:
+    # SMI-5750: positive ownership marker so prune-orphaned-docker-volumes.sh
+    # can distinguish a Skillsmith-owned `<project>_node_modules` volume from
+    # another repo's generically-shaped `node_modules` volume sharing the same
+    # Compose conventions. Applies at creation time only -- Compose does not
+    # recreate an existing named volume when its label config changes, so this
+    # does not disturb any currently-live worktree's volume.
+    labels:
+      app.skillsmith.owned: 'true'

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -63,6 +63,30 @@ native_module_volume_name() {
 }
 
 #######################################
+# Sanitize an arbitrary name (worktree directory basename, branch name) into
+# a Docker Compose v2 project name: lowercase, then strip any character
+# outside [a-z0-9_-]. This is the single canonical implementation --
+# remove-worktree.sh's project_name derivation and
+# prune-orphaned-docker-volumes.sh's protected-set derivation both call this
+# rather than each inlining their own copy of the tr/sed pipeline, so the two
+# can never independently drift out of sync (SMI-5750 governance finding:
+# they previously duplicated this logic verbatim).
+#
+# A trailing newline is always emitted (needed by callers that invoke this
+# in a loop and capture the combined output via one outer `$(...)` --
+# without it, BSD sed's no-trailing-newline-preserving behavior would
+# silently glue consecutive outputs together with no separator).
+#
+# Arguments:
+#   $1 - Name to sanitize (e.g. a worktree directory basename)
+# Outputs:
+#   Sanitized project-name-safe string, followed by a newline, to stdout
+#######################################
+sanitize_project_name() {
+    printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]//g'
+}
+
+#######################################
 # Print error message and exit
 #######################################
 error() {

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -913,6 +913,14 @@ enumerate_native_module_volumes() {
         if [[ -d "$repo_root/node_modules/$native_module" && ! -L "$repo_root/node_modules/$native_module" ]]; then
             printf '  native-seed-%s:\n' "$(native_module_volume_name "$native_module")"
             printf '    driver: local\n'
+            # SMI-5750: positive ownership marker so
+            # prune-orphaned-docker-volumes.sh can identify these as
+            # Skillsmith-owned and auto-reclaim orphaned ones (worktree
+            # removed without going through remove-worktree.sh) instead of
+            # leaving them perpetually UNCONFIRMED. Same label/rationale as
+            # docker-compose.yml's node_modules volume.
+            printf '    labels:\n'
+            printf '      app.skillsmith.owned: "true"\n'
         fi
     done
 }

--- a/scripts/prune-orphaned-docker-volumes.sh
+++ b/scripts/prune-orphaned-docker-volumes.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+#
+# prune-orphaned-docker-volumes.sh - Targeted reclaim of orphaned per-worktree
+# Docker volumes/images (SMI-5750)
+#
+# Problem: <slug>_node_modules and <slug>_native-seed-<module> volumes (the
+# latter declared per-worktree by _lib.sh's enumerate_native_module_volumes,
+# SMI-5650) and <slug>-dev images accumulate whenever a worktree disappears
+# without remove-worktree.sh running (crashes, manual `rm -rf`, `git worktree
+# remove` by hand), and nothing safe ever reclaims them. On this machine, the
+# native-seed volumes are the numerically DOMINANT orphan class (5 volumes
+# per worktree vs. 1 node_modules volume) -- both conventions must be covered
+# or this script does not meet its own goal of preventing unbounded orphan
+# accumulation (SMI-5616). A blanket `docker volume prune` is unsafe: it
+# deletes ANY volume not attached to a RUNNING container, including a
+# still-existing worktree's volume whose container is merely stopped, forcing
+# an expensive native-module rebuild (better-sqlite3 / onnxruntime-node /
+# hnswlib-node, SMI-4698) in a concurrently-active session.
+#
+# Safety predicate: WORKTREE EXISTENCE (`git worktree list`), NOT
+# container-running-state. A volume/image is only a deletion candidate if its
+# derived project name is absent from every worktree git currently knows
+# about, regardless of whether that worktree's container is running,
+# stopped, or was never started. This is what makes the prune safe at ANY
+# concurrency level, unlike a blanket `docker volume prune`.
+#
+# Ownership gate: the generic Compose-label shape checks below
+# (com.docker.compose.volume=<key>, com.docker.compose.service=dev) are
+# conventions ANY other repo's `dev` service + same-named volume also
+# satisfies -- they are not proof a resource belongs to Skillsmith. Real
+# ownership is the `app.skillsmith.owned=true` label (added to
+# docker-compose.yml's node_modules volume and to each per-worktree
+# native-seed-<module> volume declaration in _lib.sh's
+# enumerate_native_module_volumes, by this same change). A candidate that
+# passes the generic checks but lacks that label is REPORT-ONLY ("UNCONFIRMED
+# ownership") unless --include-unlabeled is passed explicitly.
+#
+# Residual risks (accepted, NOT eliminated -- see docs/internal/implementation/
+# smi-5750-targeted-volume-prune.md § Shared-State audit):
+#   1. TOCTOU -- narrowed, not eliminated. The protected set is re-derived
+#      immediately before the delete loop, but this is NOT a locking
+#      mechanism: a concurrent create-worktree.sh can still register a
+#      worktree after that re-scan and before `docker volume rm` /
+#      `docker rmi` runs. Worst case: a just-created worktree's still-empty
+#      volume is deleted and silently recreated empty by its next
+#      `compose up` -- one redundant native-module rebuild, no data loss.
+#   2. Cross-repo -- another repo's `*_node_modules` / `*_native-seed-*`
+#      volume or `*-dev` image that happens to pass the generic Compose-shape
+#      checks is never auto-deleted (the ownership gate above). The residual
+#      is confined to explicit --include-unlabeled runs, where the operator
+#      reviews the reported UNCONFIRMED list first, and the deleted artifact
+#      is always a rebuildable dependency cache, never data.
+#
+# Usage: ./scripts/prune-orphaned-docker-volumes.sh [--dry-run] [--include-unlabeled]
+#   --dry-run             Report what would be deleted; delete nothing.
+#   --include-unlabeled   Also delete UNCONFIRMED-ownership candidates (the
+#                          one-time pre-label backlog escape hatch).
+#
+# Opt-out: SKILLSMITH_ORPHAN_PRUNE_DISABLE=1 skips the prune entirely (exit
+# 0), used when invoked from remove-worktree.sh. Registered in
+# docs/internal/process/guards-and-opt-outs.md (SMI-5418).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "$SCRIPT_DIR/_lib.sh"
+
+DRY_RUN=false
+INCLUDE_UNLABELED=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --include-unlabeled)
+            INCLUDE_UNLABELED=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $(basename "$0") [--dry-run] [--include-unlabeled]"
+            exit 0
+            ;;
+        *)
+            error "Unknown option: $1"
+            ;;
+    esac
+done
+
+if [[ "${SKILLSMITH_ORPHAN_PRUNE_DISABLE:-}" == "1" ]]; then
+    info "SKILLSMITH_ORPHAN_PRUNE_DISABLE=1 set -- skipping targeted orphan prune"
+    exit 0
+fi
+
+if ! command -v docker &>/dev/null; then
+    warn "Docker not found -- skipping targeted orphan prune"
+    exit 0
+fi
+
+if ! docker info &>/dev/null; then
+    warn "Docker daemon not reachable -- skipping targeted orphan prune"
+    exit 0
+fi
+
+repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+main_gitdir="$(get_main_git_dir "$repo_root" 2>/dev/null || true)"
+if [[ -n "$main_gitdir" ]]; then
+    main_repo="$(dirname "$main_gitdir")"
+else
+    main_repo="$repo_root"
+fi
+
+# sanitize(name): IDENTICAL sanitization result to remove-worktree.sh:121's
+# project_name derivation (docker compose v2 ProjectName sanitization) --
+# lowercase, then strip any char outside [a-z0-9_-]. The trailing '\n' in the
+# printf (absent from remove-worktree.sh:121, which only ever captures one
+# value per invocation) is required here: derive_protected() calls this in a
+# loop and concatenates every call's stdout into one command substitution. On
+# BSD sed (macOS), a sed input with no trailing newline produces output with
+# no trailing newline either, so without the '\n' every sanitized name would
+# be glued onto the next one -- e.g. "foo-bar" + "baz-qux" -> "foo-barbaz-qux"
+# on one line -- silently breaking is_protected()'s exact-line grep -qxF match
+# for every case with more than one worktree registered (i.e. almost always).
+sanitize() {
+    printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]//g'
+}
+
+# derive_protected(): canonical enumeration via `git worktree list
+# --porcelain` (covers out-of-tree worktrees -- create-worktree.sh:49-52),
+# UNIONED with a `.worktrees/*/` directory scan as conservative
+# belt-and-braces. Two distinct names sanitizing to the same project name
+# can only OVER-protect (both land in the set) -- never false-orphan.
+derive_protected() {
+    local wt_path base
+    while IFS= read -r wt_path; do
+        [[ -z "$wt_path" ]] && continue
+        base="$(basename "$wt_path")"
+        sanitize "$base"
+    done < <(git -C "$main_repo" worktree list --porcelain 2>/dev/null | awk '/^worktree / { print $2 }')
+
+    if [[ -d "$main_repo/.worktrees" ]]; then
+        local d
+        for d in "$main_repo"/.worktrees/*/; do
+            [[ -d "$d" ]] || continue
+            sanitize "$(basename "${d%/}")"
+        done
+    fi
+}
+
+is_protected() {
+    local project="$1" protected_set="$2"
+    grep -qxF "$project" <<< "$protected_set"
+}
+
+# Classify a volume name into a (project, expected compose.volume label)
+# pair, covering both conventions this script recognizes: the base
+# `<project>_node_modules` volume (docker-compose.yml) and the per-module
+# `<project>_native-seed-<module>` volumes (_lib.sh's
+# enumerate_native_module_volumes, SMI-5650) -- 5 of the latter per worktree,
+# the numerically dominant orphan class on this machine (see header). Sets
+# $project and $expected_vol_key; returns 1 (no match) for anything else, so
+# `classify_volume "$vol" || continue` skips unrelated volumes cleanly.
+# Native module names can themselves contain hyphens (e.g.
+# onnxruntime-node), so the split point is the LAST "_native-seed-"
+# occurrence (bash `%pattern` removes the shortest matching suffix, which
+# for a "*_native-seed-*" glob means matching starts as late as possible in
+# the string, i.e. at the last occurrence) -- project names never embed that
+# literal substring in practice, so there is normally only one occurrence
+# anyway.
+classify_volume() {
+    local vol="$1"
+    if [[ "$vol" == *_node_modules ]]; then
+        project="${vol%_node_modules}"
+        expected_vol_key="node_modules"
+    elif [[ "$vol" == *_native-seed-* ]]; then
+        project="${vol%_native-seed-*}"
+        expected_vol_key="${vol#"${project}"_}"
+    else
+        return 1
+    fi
+}
+
+protected="$(derive_protected)"
+
+# --- volumes: build candidates against the initial protected snapshot ---
+declare -a vol_candidates=()
+while IFS= read -r vol; do
+    [[ -z "$vol" ]] && continue
+    classify_volume "$vol" || continue
+    is_protected "$project" "$protected" && continue
+
+    vol_shape_label="$(docker volume inspect "$vol" --format '{{index .Labels "com.docker.compose.volume"}}' 2>/dev/null || true)"
+    vol_project_label="$(docker volume inspect "$vol" --format '{{index .Labels "com.docker.compose.project"}}' 2>/dev/null || true)"
+    vol_owned_label="$(docker volume inspect "$vol" --format '{{index .Labels "app.skillsmith.owned"}}' 2>/dev/null || true)"
+
+    [[ "$vol_shape_label" == "$expected_vol_key" ]] || continue
+    [[ "$vol_project_label" == "$project" ]] || continue
+    [[ -n "$(docker ps -aq --filter "volume=$vol" 2>/dev/null || true)" ]] && continue
+
+    if [[ "$vol_owned_label" != "true" ]]; then
+        echo "UNCONFIRMED ownership: $vol"
+        [[ "$INCLUDE_UNLABELED" != true ]] && continue
+    fi
+
+    vol_candidates+=("$vol")
+done < <(docker volume ls --format '{{.Name}}' 2>/dev/null || true)
+
+# TOCTOU narrowing (NOT elimination -- see header + Shared-State audit):
+# re-derive the protected set once, immediately before the delete loop. A
+# concurrent create-worktree.sh can still register a worktree after this
+# re-scan and before `volume rm` -- that residual window is accepted, not
+# closed. This is a narrowing measure, not a locking mechanism.
+protected="$(derive_protected)"
+
+if (( ${#vol_candidates[@]} > 0 )); then
+    for vol in "${vol_candidates[@]}"; do
+        classify_volume "$vol" || continue
+        is_protected "$project" "$protected" && continue
+        if [[ "$DRY_RUN" == true ]]; then
+            info "[dry-run] would remove volume $vol"
+        elif docker volume rm "$vol" >/dev/null 2>&1; then
+            success "  Removed volume $vol"
+        else
+            warn "  Could not remove volume $vol (already gone or in use -- continuing)"
+        fi
+    done
+fi
+
+# --- images: same existence + ownership checks, against the re-derived set ---
+while IFS= read -r img; do
+    [[ -z "$img" || "$img" == "<none>" ]] && continue
+    [[ "$img" == *-dev ]] || continue
+    project="${img%-dev}"
+    is_protected "$project" "$protected" && continue
+
+    img_service_label="$(docker image inspect "$img" --format '{{index .Config.Labels "com.docker.compose.service"}}' 2>/dev/null || true)"
+    [[ "$img_service_label" == "dev" ]] || continue
+    [[ -n "$(docker ps -aq --filter "ancestor=$img" 2>/dev/null || true)" ]] && continue
+
+    img_owned_label="$(docker image inspect "$img" --format '{{index .Config.Labels "app.skillsmith.owned"}}' 2>/dev/null || true)"
+    if [[ "$img_owned_label" != "true" ]]; then
+        echo "UNCONFIRMED ownership: $img"
+        [[ "$INCLUDE_UNLABELED" != true ]] && continue
+    fi
+
+    if [[ "$DRY_RUN" == true ]]; then
+        info "[dry-run] would remove image $img"
+    elif docker rmi "$img" >/dev/null 2>&1; then
+        success "  Removed image $img"
+    else
+        warn "  Could not remove image $img (already gone or in use -- continuing)"
+    fi
+done < <(docker images --format '{{.Repository}}' 2>/dev/null | sort -u || true)

--- a/scripts/prune-orphaned-docker-volumes.sh
+++ b/scripts/prune-orphaned-docker-volumes.sh
@@ -112,20 +112,16 @@ else
     main_repo="$repo_root"
 fi
 
-# sanitize(name): IDENTICAL sanitization result to remove-worktree.sh:121's
-# project_name derivation (docker compose v2 ProjectName sanitization) --
-# lowercase, then strip any char outside [a-z0-9_-]. The trailing '\n' in the
-# printf (absent from remove-worktree.sh:121, which only ever captures one
-# value per invocation) is required here: derive_protected() calls this in a
-# loop and concatenates every call's stdout into one command substitution. On
-# BSD sed (macOS), a sed input with no trailing newline produces output with
-# no trailing newline either, so without the '\n' every sanitized name would
-# be glued onto the next one -- e.g. "foo-bar" + "baz-qux" -> "foo-barbaz-qux"
-# on one line -- silently breaking is_protected()'s exact-line grep -qxF match
-# for every case with more than one worktree registered (i.e. almost always).
-sanitize() {
-    printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]//g'
-}
+# sanitize_project_name() (_lib.sh) is the single canonical sanitization
+# implementation -- shared with remove-worktree.sh's project_name derivation
+# so the two can never drift apart (SMI-5750 governance fix; a prior version
+# of this script had its own verbatim copy). Its trailing '\n' matters here
+# specifically: derive_protected() below calls it in a loop and concatenates
+# every call's stdout into one command substitution -- without a guaranteed
+# trailing newline per call, BSD sed (macOS) would silently glue consecutive
+# sanitized names together on one line (e.g. "foo-bar" + "baz-qux" ->
+# "foo-barbaz-qux"), breaking is_protected()'s exact-line grep -qxF match for
+# every case with more than one worktree registered (i.e. almost always).
 
 # derive_protected(): canonical enumeration via `git worktree list
 # --porcelain` (covers out-of-tree worktrees -- create-worktree.sh:49-52),
@@ -137,14 +133,14 @@ derive_protected() {
     while IFS= read -r wt_path; do
         [[ -z "$wt_path" ]] && continue
         base="$(basename "$wt_path")"
-        sanitize "$base"
+        sanitize_project_name "$base"
     done < <(git -C "$main_repo" worktree list --porcelain 2>/dev/null | awk '/^worktree / { print $2 }')
 
     if [[ -d "$main_repo/.worktrees" ]]; then
         local d
         for d in "$main_repo"/.worktrees/*/; do
             [[ -d "$d" ]] || continue
-            sanitize "$(basename "${d%/}")"
+            sanitize_project_name "$(basename "${d%/}")"
         done
     fi
 }

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -125,9 +125,11 @@ cleanup_worktree_docker_resources() {
     # Compose-equivalent project name: lowercase + drop chars outside
     # [a-z0-9_-]. Matches docker compose v2 ProjectName sanitization.
     # Plain `basename` would diverge for dirs containing uppercase or
-    # special chars.
+    # special chars. sanitize_project_name() (_lib.sh) is the single
+    # canonical implementation -- shared with
+    # prune-orphaned-docker-volumes.sh so the two can't drift (SMI-5750).
     local project_name
-    project_name="$(basename "$worktree_path" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]//g')"
+    project_name="$(sanitize_project_name "$(basename "$worktree_path")")"
 
     # Path A: prefer compose-managed teardown when the override file exists.
     # `down --volumes --rmi local` removes named volumes declared in compose

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -25,7 +25,7 @@ NETWORK_WARN_THRESHOLD=5
 #######################################
 usage() {
     cat << EOF
-Usage: $(basename "$0") <worktree-path> [--force] [--prune] [--keep-docker]
+Usage: $(basename "$0") <worktree-path> [--force] [--prune] [--keep-docker] [--no-orphan-prune]
 
 Remove a git worktree and clean up associated Docker resources.
 
@@ -39,6 +39,10 @@ Options:
                   the post-removal reclaimable report)
   --keep-docker   Preserve the per-worktree Docker image and node_modules volume
                   (default: both are removed alongside the worktree)
+  --no-orphan-prune
+                  Skip the automatic targeted orphan prune (SMI-5750) that
+                  otherwise runs on every removal (see also
+                  SKILLSMITH_ORPHAN_PRUNE_DISABLE=1)
   -h, --help      Show this help message and exit
 
 Examples:
@@ -56,7 +60,12 @@ What this script does:
   5. Checks Docker network count and reports global reclaimable Docker
      resources (images / volumes / build cache) with manual reclaim commands
   6. Optionally prunes stale networks + dangling images + build cache (--prune);
-     aggressive image -a / volume prune are left to the operator
+     this refers only to the BLANKET docker volume prune / image prune -a
+     shown in the reclaimable report, which stay manual-only — see item 7
+  7. Automatically runs a targeted orphan prune (SMI-5750): deletes only
+     volumes/images belonging to worktrees git no longer knows about, safe at
+     any concurrency level; skip with --no-orphan-prune or
+     SKILLSMITH_ORPHAN_PRUNE_DISABLE=1
 
 EOF
 }
@@ -203,6 +212,14 @@ prune_docker_networks() {
 # native-module rebuilds (better-sqlite3 / onnxruntime, SMI-4698) in other
 # still-active worktrees.
 #
+# SMI-5750: a separate, TARGETED orphan prune (only volumes/images belonging
+# to worktrees git no longer knows about) now runs automatically at the end
+# of every removal, unconditionally — see the call site in main() below,
+# after the --prune block. It is safe at any concurrency level because its
+# deletion predicate is worktree-existence, not container-running state. The
+# two BLANKET commands printed below remain manual-only; the SMI-4698
+# concurrent-session rebuild-cost warning is unchanged by this.
+#
 # No GB-threshold gate (cf. NETWORK_WARN_THRESHOLD): parsing docker's
 # human-readable sizes would reintroduce a numeric-parse/errexit landmine;
 # this report is informational, so `docker system df` output is echoed raw.
@@ -222,6 +239,9 @@ check_docker_reclaimable() {
     echo -e "${YELLOW}  docker image prune -a   # unused tagged images${NC}"
     echo -e "${YELLOW}  docker volume prune     # orphaned volumes (WARNING: forces native-module rebuilds in other worktrees)${NC}"
     echo ""
+    info "Note: a targeted orphan prune (SMI-5750) already runs automatically,"
+    info "below, on every removal — the two blanket commands above stay manual"
+    info "only, for the same SMI-4698 concurrent-session rebuild-cost reason."
 }
 
 #######################################
@@ -255,6 +275,7 @@ main() {
     local force_flag=""
     local prune_flag=false
     local keep_docker=false
+    local no_orphan_prune=false
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -273,6 +294,10 @@ main() {
                 ;;
             --keep-docker)
                 keep_docker=true
+                shift
+                ;;
+            --no-orphan-prune)
+                no_orphan_prune=true
                 shift
                 ;;
             -*)
@@ -406,6 +431,23 @@ Commit or discard them first, or re-run with --force to discard:
     if [[ "$prune_flag" == true ]]; then
         prune_docker_networks
         prune_docker_safe
+    fi
+
+    # Step 3.5: Targeted orphaned-volume/image prune (SMI-5750) — runs
+    # unconditionally on every removal, not gated behind --prune. Deliberately
+    # placed here, LAST, after `git worktree remove` (Step 2, so the
+    # just-removed worktree is already deregistered from `git worktree list`)
+    # and after every other docker-call-producing step above (Step 3's
+    # reclaimable report, Step 4's optional --prune block) — appending it here
+    # means it can never shift the position of an earlier docker call within
+    # the docker-shim tests' recorded `dockerCalls`, which the existing
+    # aggressive-reclaim fixtures assert on positionally. Skipped entirely
+    # (the call is never attempted) when --no-orphan-prune was passed or
+    # SKILLSMITH_ORPHAN_PRUNE_DISABLE=1 is set.
+    if [[ "$no_orphan_prune" == true || "${SKILLSMITH_ORPHAN_PRUNE_DISABLE:-}" == "1" ]]; then
+        info "Skipping targeted orphan prune (--no-orphan-prune or SKILLSMITH_ORPHAN_PRUNE_DISABLE=1)"
+    else
+        "$SCRIPT_DIR/prune-orphaned-docker-volumes.sh" || warn "targeted orphan prune returned non-zero (continuing)"
     fi
 
     echo ""

--- a/scripts/tests/prune-orphaned-docker-volumes.helpers.ts
+++ b/scripts/tests/prune-orphaned-docker-volumes.helpers.ts
@@ -1,0 +1,292 @@
+/**
+ * Fixture/shim infrastructure for prune-orphaned-docker-volumes.test.ts
+ * (SMI-5750). Split out per CLAUDE.md's 500-line file-length guidance --
+ * see the sibling test file's header for the full rationale (docker shim
+ * conventions, canned-stdout key scheme, why each fixture copies the real
+ * script + _lib.sh into its own throwaway repo).
+ */
+
+import { execSync, spawnSync } from 'child_process'
+import { rmSync, existsSync, writeFileSync, chmodSync, readFileSync, mkdirSync, cpSync } from 'fs'
+import { dirname, join } from 'path'
+
+import { makeFixtureEnv, makeFixtureTempDir } from './_lib/git-fixture-env.js'
+
+const REAL_SCRIPT_PATH = join(__dirname, '..', 'prune-orphaned-docker-volumes.sh')
+const REAL_LIB_PATH = join(__dirname, '..', '_lib.sh')
+
+/**
+ * SMI-4693: GIT_DISCOVERY_VARS-stripped env for every git invocation AND the
+ * prune-script subprocess. Same pattern as remove-worktree.test.ts.
+ */
+const GIT_ENV = makeFixtureEnv()
+
+export function makeTempDir(prefix: string): string {
+  return makeFixtureTempDir(prefix)
+}
+
+function git(cwd: string, args: string): string {
+  return execSync(`git -c init.defaultBranch=main -c protocol.file.allow=always ${args}`, {
+    cwd,
+    encoding: 'utf8',
+    env: GIT_ENV,
+  }).trim()
+}
+
+function sh(cmd: string, opts?: { cwd?: string }): string {
+  return execSync(cmd, { encoding: 'utf8', env: GIT_ENV, ...opts }).trim()
+}
+
+export interface FixtureRepo {
+  tempRoot: string
+  repoDir: string
+  scriptPath: string
+  binDir: string
+  logPath: string
+  responsesDir: string
+}
+
+/**
+ * Write a `docker` shim to `binDir/docker` that, in addition to recording
+ * every invocation to `logPath` (exact convention as the shared
+ * `writeDockerShim`: `echo "$@" >> logPath`), emits canned STDOUT read from
+ * `responsesDir`, keyed by subcommand + target name + (for label queries)
+ * which label was asked for. Response files are plain text; a missing file
+ * means "no output" (empty string), which is also how a real absent/
+ * mismatched label naturally reads in the script under test -- so tests
+ * only need to write the response files that matter for that case.
+ *
+ * Key scheme (must match the JS-side helpers below exactly):
+ *   volume_ls                                  <- `docker volume ls --format {{.Name}}`
+ *   images                                      <- `docker images --format {{.Repository}}`
+ *   volume_inspect__<vol>__volume                <- compose.volume label
+ *   volume_inspect__<vol>__project                <- compose.project label
+ *   volume_inspect__<vol>__owned                <- app.skillsmith.owned label
+ *   image_inspect__<img>__service                <- compose.service label
+ *   image_inspect__<img>__owned                <- app.skillsmith.owned label
+ *   ps_volume__<vol>                             <- `docker ps -aq --filter volume=<vol>`
+ *   ps_ancestor__<img>                           <- `docker ps -aq --filter ancestor=<img>`
+ *   exit__volume_rm__<vol>                       <- exit code override for `docker volume rm <vol>`
+ *   exit__rmi__<img>                             <- exit code override for `docker rmi <img>`
+ */
+function writeResponsiveDockerShim(binDir: string, logPath: string, responsesDir: string): void {
+  const lines = [
+    '#!/bin/sh',
+    `echo "$@" >> "${logPath}"`,
+    `RESP_DIR="${responsesDir}"`,
+    '',
+    'emit() {',
+    '  key="$1"',
+    '  if [ -n "$key" ] && [ -f "$RESP_DIR/$key" ]; then',
+    '    cat "$RESP_DIR/$key"',
+    '  fi',
+    '}',
+    '',
+    'exit_override() {',
+    '  file="$RESP_DIR/exit__$1"',
+    '  if [ -f "$file" ]; then',
+    '    code="$(cat "$file")"',
+    '    exit "${code:-0}"',
+    '  fi',
+    '  exit 0',
+    '}',
+    '',
+    'cmd="$1"',
+    'sub="$2"',
+    '',
+    'case "$cmd" in',
+    '  info)',
+    '    exit 0',
+    '    ;;',
+    '  volume)',
+    '    case "$sub" in',
+    '      ls)',
+    '        emit "volume_ls"',
+    '        exit 0',
+    '        ;;',
+    '      inspect)',
+    '        vol="$3"',
+    '        fmt="$5"',
+    '        case "$fmt" in',
+    '          *compose.volume*) emit "volume_inspect__${vol}__volume" ;;',
+    '          *compose.project*) emit "volume_inspect__${vol}__project" ;;',
+    '          *skillsmith.owned*) emit "volume_inspect__${vol}__owned" ;;',
+    '        esac',
+    '        exit 0',
+    '        ;;',
+    '      rm)',
+    '        exit_override "volume_rm__$3"',
+    '        ;;',
+    '    esac',
+    '    exit 0',
+    '    ;;',
+    '  images)',
+    '    emit "images"',
+    '    exit 0',
+    '    ;;',
+    '  image)',
+    '    case "$sub" in',
+    '      inspect)',
+    '        img="$3"',
+    '        fmt="$5"',
+    '        case "$fmt" in',
+    '          *compose.service*) emit "image_inspect__${img}__service" ;;',
+    '          *skillsmith.owned*) emit "image_inspect__${img}__owned" ;;',
+    '        esac',
+    '        exit 0',
+    '        ;;',
+    '    esac',
+    '    exit 0',
+    '    ;;',
+    '  rmi)',
+    '    exit_override "rmi__$2"',
+    '    ;;',
+    '  ps)',
+    '    key=""',
+    '    for arg in "$@"; do',
+    '      case "$arg" in',
+    '        volume=*) key="ps_volume__${arg#volume=}" ;;',
+    '        ancestor=*) key="ps_ancestor__${arg#ancestor=}" ;;',
+    '      esac',
+    '    done',
+    '    emit "$key"',
+    '    exit 0',
+    '    ;;',
+    '  *)',
+    '    exit 0',
+    '    ;;',
+    'esac',
+    '',
+  ]
+  const shimPath = join(binDir, 'docker')
+  writeFileSync(shimPath, `${lines.join('\n')}\n`)
+  chmodSync(shimPath, 0o755)
+}
+
+/**
+ * Build a throwaway main-checkout repo with the real script + _lib.sh copied
+ * into its own scripts/ dir (see file header for why this is required), plus
+ * a docker shim wired up on a dedicated bin dir.
+ */
+export function setupFixture(prefix: string): FixtureRepo {
+  const tempRoot = makeTempDir(prefix)
+  const repoDir = join(tempRoot, 'repo')
+
+  git(tempRoot, `init "${repoDir}"`)
+  sh(`touch "${join(repoDir, 'README.md')}"`)
+  git(repoDir, 'add README.md')
+  git(repoDir, 'commit -m "initial"')
+
+  const scriptsDir = join(repoDir, 'scripts')
+  mkdirSync(scriptsDir, { recursive: true })
+  const scriptPath = join(scriptsDir, 'prune-orphaned-docker-volumes.sh')
+  cpSync(REAL_SCRIPT_PATH, scriptPath)
+  cpSync(REAL_LIB_PATH, join(scriptsDir, '_lib.sh'))
+  chmodSync(scriptPath, 0o755)
+
+  const binDir = join(tempRoot, 'bin')
+  mkdirSync(binDir, { recursive: true })
+  const responsesDir = join(tempRoot, 'responses')
+  mkdirSync(responsesDir, { recursive: true })
+  const logPath = join(tempRoot, 'docker.log')
+
+  writeResponsiveDockerShim(binDir, logPath, responsesDir)
+
+  return { tempRoot, repoDir, scriptPath, binDir, logPath, responsesDir }
+}
+
+/** Register a real worktree (in-tree or out-of-tree) via `git worktree add`. */
+export function addWorktree(repoDir: string, worktreePath: string, branch: string): void {
+  mkdirSync(dirname(worktreePath), { recursive: true })
+  git(repoDir, `worktree add -b ${branch} "${worktreePath}"`)
+}
+
+function setResponse(responsesDir: string, key: string, value: string): void {
+  writeFileSync(join(responsesDir, key), value.endsWith('\n') ? value : `${value}\n`)
+}
+
+export function volumeListResponse(fixture: FixtureRepo, names: string[]): void {
+  setResponse(fixture.responsesDir, 'volume_ls', names.join('\n'))
+}
+
+export function imagesResponse(fixture: FixtureRepo, repos: string[]): void {
+  setResponse(fixture.responsesDir, 'images', repos.join('\n'))
+}
+
+export function volumeLabels(
+  fixture: FixtureRepo,
+  vol: string,
+  labels: { volume?: string; project?: string; owned?: string }
+): void {
+  if (labels.volume !== undefined) {
+    setResponse(fixture.responsesDir, `volume_inspect__${vol}__volume`, labels.volume)
+  }
+  if (labels.project !== undefined) {
+    setResponse(fixture.responsesDir, `volume_inspect__${vol}__project`, labels.project)
+  }
+  if (labels.owned !== undefined) {
+    setResponse(fixture.responsesDir, `volume_inspect__${vol}__owned`, labels.owned)
+  }
+}
+
+export function imageLabels(
+  fixture: FixtureRepo,
+  img: string,
+  labels: { service?: string; owned?: string }
+): void {
+  if (labels.service !== undefined) {
+    setResponse(fixture.responsesDir, `image_inspect__${img}__service`, labels.service)
+  }
+  if (labels.owned !== undefined) {
+    setResponse(fixture.responsesDir, `image_inspect__${img}__owned`, labels.owned)
+  }
+}
+
+export function volumePsResponse(fixture: FixtureRepo, vol: string, containerIds: string): void {
+  setResponse(fixture.responsesDir, `ps_volume__${vol}`, containerIds)
+}
+
+export function setVolumeRmExit(fixture: FixtureRepo, vol: string, code: number): void {
+  writeFileSync(join(fixture.responsesDir, `exit__volume_rm__${vol}`), String(code))
+}
+
+export function resetLog(fixture: FixtureRepo): void {
+  if (existsSync(fixture.logPath)) rmSync(fixture.logPath)
+}
+
+/**
+ * Run the fixture's copy of prune-orphaned-docker-volumes.sh with the fake
+ * docker shim on PATH. Uses spawnSync (not execSync) so stdout AND stderr
+ * are both captured regardless of exit code -- several cases here assert on
+ * stderr (warn()) or stdout (info()/echo) on a SUCCESSFUL (exit 0) run,
+ * which execSync cannot give you (it only exposes stderr via the thrown
+ * error on a non-zero exit).
+ */
+export function runPrune(
+  fixture: FixtureRepo,
+  args: string[] = [],
+  extraEnv: Record<string, string> = {}
+): { status: number; stdout: string; stderr: string; dockerCalls: string[] } {
+  const env = {
+    ...GIT_ENV,
+    PATH: `${fixture.binDir}:${GIT_ENV.PATH ?? ''}`,
+    ...extraEnv,
+  }
+  const result = spawnSync('bash', [fixture.scriptPath, ...args], {
+    encoding: 'utf8',
+    timeout: 30_000,
+    env,
+    cwd: fixture.repoDir,
+  })
+  const dockerCalls = existsSync(fixture.logPath)
+    ? readFileSync(fixture.logPath, 'utf8')
+        .split('\n')
+        .filter((line) => line.length > 0)
+    : []
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    dockerCalls,
+  }
+}

--- a/scripts/tests/prune-orphaned-docker-volumes.test.ts
+++ b/scripts/tests/prune-orphaned-docker-volumes.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Integration tests for prune-orphaned-docker-volumes.sh (SMI-5750)
+ *
+ * Plan: docs/internal/implementation/smi-5750-targeted-volume-prune.md
+ * (Wave 1 > Step 3, test cases 1-15; tests 16-19 added post-implementation
+ * adversarial review to cover the `*_native-seed-*` convention -- see the
+ * Review Summary section of the plan doc).
+ *
+ * Verifies the targeted orphan-reclaim script's safety predicate
+ * (worktree-existence via `git worktree list --porcelain`, unioned with a
+ * `.worktrees/*` scan, NOT container-running-state) and the ownership gate
+ * (generic Compose-label shape checks are never deletion authority by
+ * themselves -- only `app.skillsmith.owned=true` authorizes an automatic
+ * delete; everything else is report-only unless --include-unlabeled).
+ *
+ * Tests use a fake `docker` shim on PATH, following the
+ * `remove-worktree.test.ts` convention (docker shim records invocations;
+ * `dockerCalls` assertions are positional/exact-string). ONE extension is
+ * needed here that the shared `writeDockerShim` helper (remove-worktree.
+ * test.ts) does not support: canned STDOUT keyed by subcommand -- `docker
+ * volume ls` needs to return specific volume names, `docker volume inspect
+ * <name>` needs to return specific label values per label queried, `docker
+ * ps -aq --filter ...` needs to return empty or a fake container id, etc.
+ * That variant (`writeResponsiveDockerShim`) plus all fixture-building
+ * helpers live in the sibling `prune-orphaned-docker-volumes.helpers.ts`
+ * (split out per CLAUDE.md's 500-line file-length guidance) -- the shared
+ * shim in remove-worktree.test.ts is untouched.
+ *
+ * Because prune-orphaned-docker-volumes.sh derives its own operating scope
+ * from `${BASH_SOURCE[0]}` (there is no `<worktree-path>` argument the way
+ * remove-worktree.sh takes one), each fixture copies the REAL script +
+ * `_lib.sh` into a throwaway git repo's own `scripts/` directory and invokes
+ * that copy -- so `SCRIPT_DIR`/`repo_root` resolve inside the fixture, and
+ * `git worktree list --porcelain` reflects the fixture's own worktrees, not
+ * this checkout's.
+ *
+ * No real Docker daemon is needed; no git-crypt encryption is used.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { existsSync, rmSync } from 'fs'
+import { join } from 'path'
+
+import {
+  setupFixture,
+  addWorktree,
+  volumeListResponse,
+  imagesResponse,
+  volumeLabels,
+  imageLabels,
+  volumePsResponse,
+  setVolumeRmExit,
+  resetLog,
+  runPrune,
+} from './prune-orphaned-docker-volumes.helpers.js'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+  tempDirs.length = 0
+})
+
+describe('SMI-5750: prune-orphaned-docker-volumes.sh', () => {
+  it('1. deletes a labeled orphan volume (no matching worktree, app.skillsmith.owned=true)', () => {
+    const fixture = setupFixture('prune-orphan')
+    tempDirs.push(fixture.tempRoot)
+
+    volumeListResponse(fixture, ['gone-wt_node_modules'])
+    volumeLabels(fixture, 'gone-wt_node_modules', {
+      volume: 'node_modules',
+      project: 'gone-wt',
+      owned: 'true',
+    })
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls).toContain('volume rm gone-wt_node_modules')
+  })
+
+  it('2. preserves a live worktree volume even with a stopped container (the safety property)', () => {
+    const fixture = setupFixture('prune-live')
+    tempDirs.push(fixture.tempRoot)
+    addWorktree(fixture.repoDir, join(fixture.repoDir, '.worktrees', 'live-wt'), 'feat-live')
+
+    volumeListResponse(fixture, ['live-wt_node_modules'])
+    // Deliberately NOT wiring any inspect/ps response for this volume: the
+    // safety property under test is that worktree-existence alone protects
+    // it BEFORE any container-state check ever runs -- so no `docker
+    // volume inspect` or `docker ps --filter volume=...` call referencing it
+    // should be made at all, regardless of whether its container is
+    // stopped, running, or was never started.
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c.includes('live-wt_node_modules'))).toBe(false)
+  })
+
+  it('3. never touches the main-checkout volume', () => {
+    const fixture = setupFixture('prune-main')
+    tempDirs.push(fixture.tempRoot)
+    // repoDir is named "repo" -> sanitize("repo") === "repo", and the main
+    // checkout is always the first `git worktree list --porcelain` entry.
+
+    volumeListResponse(fixture, ['repo_node_modules'])
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c.includes('repo_node_modules'))).toBe(false)
+  })
+
+  it('4. protects an out-of-tree worktree volume (blocker-1 regression)', () => {
+    const fixture = setupFixture('prune-outside')
+    tempDirs.push(fixture.tempRoot)
+    // NOT under repo/.worktrees/ -- a sibling directory, exactly like the
+    // create-worktree.sh usage examples (../worktrees/bugfix, absolute
+    // paths) that a directory-only scan would miss.
+    addWorktree(fixture.repoDir, join(fixture.tempRoot, 'outside-wt'), 'feat-outside')
+
+    volumeListResponse(fixture, ['outside-wt_node_modules'])
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c.includes('outside-wt_node_modules'))).toBe(false)
+  })
+
+  it('5. leaves a non-convention volume (no _node_modules suffix) untouched', () => {
+    const fixture = setupFixture('prune-nonconv')
+    tempDirs.push(fixture.tempRoot)
+
+    volumeListResponse(fixture, ['somedata'])
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c.includes('somedata'))).toBe(false)
+    expect(result.dockerCalls.some((c) => c.startsWith('volume rm'))).toBe(false)
+  })
+
+  it('6. sanitizes a worktree dir name to protect the matching volume (SMI-4700_Test -> smi-4700_test)', () => {
+    const fixture = setupFixture('prune-sanitize')
+    tempDirs.push(fixture.tempRoot)
+    addWorktree(fixture.repoDir, join(fixture.repoDir, '.worktrees', 'SMI-4700_Test'), 'feat-4700')
+
+    volumeListResponse(fixture, ['smi-4700_test_node_modules'])
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c.includes('smi-4700_test_node_modules'))).toBe(false)
+  })
+
+  it('7. sanitization collision over-protects conservatively, never false-orphans', () => {
+    const fixture = setupFixture('prune-collision')
+    tempDirs.push(fixture.tempRoot)
+    // "Foo.Bar" and "Foo,Bar" are distinct directory names (no macOS
+    // case-insensitive-filesystem collision the literal plan example
+    // "Foo-Bar"/"foo-bar" would hit) that BOTH sanitize -- lowercase, then
+    // strip anything outside [a-z0-9_-] -- to the identical "foobar".
+    addWorktree(fixture.repoDir, join(fixture.repoDir, '.worktrees', 'Foo.Bar'), 'feat-foobar-1')
+    addWorktree(fixture.repoDir, join(fixture.repoDir, '.worktrees', 'Foo,Bar'), 'feat-foobar-2')
+
+    volumeListResponse(fixture, ['foobar_node_modules'])
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    // Both distinct names land in the protected set -- collisions can only
+    // OVER-protect, never false-orphan.
+    expect(result.dockerCalls.some((c) => c.includes('foobar_node_modules'))).toBe(false)
+  })
+
+  it('8. skips a volume still referenced by any container (running or stopped)', () => {
+    const fixture = setupFixture('prune-container-ref')
+    tempDirs.push(fixture.tempRoot)
+
+    volumeListResponse(fixture, ['other-wt_node_modules'])
+    volumeLabels(fixture, 'other-wt_node_modules', {
+      volume: 'node_modules',
+      project: 'other-wt',
+    })
+    volumePsResponse(fixture, 'other-wt_node_modules', 'abc123def456')
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c === 'volume rm other-wt_node_modules')).toBe(false)
+  })
+
+  it('9. skips a volume with a mismatched com.docker.compose.volume label', () => {
+    const fixture = setupFixture('prune-vol-label-mismatch')
+    tempDirs.push(fixture.tempRoot)
+
+    volumeListResponse(fixture, ['other-repo_node_modules'])
+    volumeLabels(fixture, 'other-repo_node_modules', {
+      volume: 'some_other_volume_key',
+      project: 'other-repo',
+      owned: 'true',
+    })
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c === 'volume rm other-repo_node_modules')).toBe(false)
+  })
+
+  it('10. skips a volume with a mismatched com.docker.compose.project label (distinct guard from #9)', () => {
+    const fixture = setupFixture('prune-project-label-mismatch')
+    tempDirs.push(fixture.tempRoot)
+
+    volumeListResponse(fixture, ['other-repo_node_modules'])
+    volumeLabels(fixture, 'other-repo_node_modules', {
+      volume: 'node_modules', // correct shape -- passes check #9's guard
+      project: 'wrong-project', // inconsistent with derived project "other-repo"
+      owned: 'true',
+    })
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c === 'volume rm other-repo_node_modules')).toBe(false)
+  })
+
+  it('11. reports an unlabeled orphan as UNCONFIRMED; --include-unlabeled deletes it on re-run', () => {
+    const fixture = setupFixture('prune-unlabeled')
+    tempDirs.push(fixture.tempRoot)
+
+    volumeListResponse(fixture, ['gone-wt_node_modules'])
+    volumeLabels(fixture, 'gone-wt_node_modules', {
+      volume: 'node_modules',
+      project: 'gone-wt',
+      // no `owned` label -- passes all generic Compose-shape checks but has
+      // no positive Skillsmith ownership signal.
+    })
+
+    const first = runPrune(fixture)
+
+    expect(first.status).toBe(0)
+    expect(first.stdout).toContain('UNCONFIRMED ownership: gone-wt_node_modules')
+    expect(first.dockerCalls.some((c) => c === 'volume rm gone-wt_node_modules')).toBe(false)
+
+    // Same fixture (same responses), re-run with the explicit escape hatch.
+    resetLog(fixture)
+    const second = runPrune(fixture, ['--include-unlabeled'])
+
+    expect(second.status).toBe(0)
+    expect(second.dockerCalls).toContain('volume rm gone-wt_node_modules')
+  })
+
+  it('12. removes an orphaned image and preserves a live one', () => {
+    const fixture = setupFixture('prune-image')
+    tempDirs.push(fixture.tempRoot)
+    addWorktree(fixture.repoDir, join(fixture.repoDir, '.worktrees', 'live-wt'), 'feat-live-img')
+
+    // repo-dev (main checkout) and live-wt-dev (registered worktree) are
+    // both protected; gone-wt-dev has no matching worktree.
+    imagesResponse(fixture, ['gone-wt-dev', 'live-wt-dev', 'repo-dev'])
+    imageLabels(fixture, 'gone-wt-dev', { service: 'dev', owned: 'true' })
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls).toContain('rmi gone-wt-dev')
+    expect(result.dockerCalls.some((c) => c.includes('live-wt-dev'))).toBe(false)
+    expect(result.dockerCalls.some((c) => c.includes('repo-dev'))).toBe(false)
+  })
+
+  it('13. --dry-run deletes nothing but reports would-delete names (auto and UNCONFIRMED)', () => {
+    const fixture = setupFixture('prune-dry-run')
+    tempDirs.push(fixture.tempRoot)
+
+    volumeListResponse(fixture, ['gone-wt_node_modules', 'unlabeled-wt_node_modules'])
+    volumeLabels(fixture, 'gone-wt_node_modules', {
+      volume: 'node_modules',
+      project: 'gone-wt',
+      owned: 'true',
+    })
+    volumeLabels(fixture, 'unlabeled-wt_node_modules', {
+      volume: 'node_modules',
+      project: 'unlabeled-wt',
+      // no owned label -> UNCONFIRMED
+    })
+
+    const result = runPrune(fixture, ['--dry-run'])
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c.startsWith('volume rm'))).toBe(false)
+    expect(result.stdout).toContain('[dry-run] would remove volume gone-wt_node_modules')
+    expect(result.stdout).toContain('UNCONFIRMED ownership: unlabeled-wt_node_modules')
+    // UNCONFIRMED candidates never reach the auto-deletable dry-run list
+    // without --include-unlabeled.
+    expect(result.stdout).not.toContain('[dry-run] would remove volume unlabeled-wt_node_modules')
+  })
+
+  it('14. SKILLSMITH_ORPHAN_PRUNE_DISABLE=1 skips entirely with zero docker calls', () => {
+    const fixture = setupFixture('prune-disabled')
+    tempDirs.push(fixture.tempRoot)
+
+    volumeListResponse(fixture, ['gone-wt_node_modules'])
+    volumeLabels(fixture, 'gone-wt_node_modules', {
+      volume: 'node_modules',
+      project: 'gone-wt',
+      owned: 'true',
+    })
+
+    const result = runPrune(fixture, [], { SKILLSMITH_ORPHAN_PRUNE_DISABLE: '1' })
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.length).toBe(0)
+  })
+
+  it('15. tolerates a volume rm failure and still exits 0 with a warning', () => {
+    const fixture = setupFixture('prune-rm-fail')
+    tempDirs.push(fixture.tempRoot)
+
+    volumeListResponse(fixture, ['gone-wt_node_modules'])
+    volumeLabels(fixture, 'gone-wt_node_modules', {
+      volume: 'node_modules',
+      project: 'gone-wt',
+      owned: 'true',
+    })
+    setVolumeRmExit(fixture, 'gone-wt_node_modules', 1)
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls).toContain('volume rm gone-wt_node_modules')
+    expect(result.stderr).toContain('Could not remove volume gone-wt_node_modules')
+  })
+
+  // Tests 16-19: the `<project>_native-seed-<module>` convention (_lib.sh's
+  // enumerate_native_module_volumes, SMI-5650) -- added after the initial
+  // implementation's adversarial review found this convention was
+  // numerically the DOMINANT orphan class on the real machine (5 volumes per
+  // worktree vs. 1 node_modules volume) and completely invisible to the
+  // original `*_node_modules`-only scope. Mirrors tests 1/2/9/11 for the
+  // parallel convention.
+
+  it('16. deletes a labeled orphan native-seed volume (no matching worktree)', () => {
+    const fixture = setupFixture('prune-native-orphan')
+    tempDirs.push(fixture.tempRoot)
+
+    volumeListResponse(fixture, ['gone-wt_native-seed-better-sqlite3'])
+    volumeLabels(fixture, 'gone-wt_native-seed-better-sqlite3', {
+      volume: 'native-seed-better-sqlite3',
+      project: 'gone-wt',
+      owned: 'true',
+    })
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls).toContain('volume rm gone-wt_native-seed-better-sqlite3')
+  })
+
+  it('17. preserves a live worktree native-seed volume even with a stopped container', () => {
+    const fixture = setupFixture('prune-native-live')
+    tempDirs.push(fixture.tempRoot)
+    addWorktree(fixture.repoDir, join(fixture.repoDir, '.worktrees', 'live-wt'), 'feat-live')
+
+    volumeListResponse(fixture, ['live-wt_native-seed-onnxruntime-node'])
+    // Deliberately no inspect/ps response wired -- same safety property as
+    // test #2: worktree-existence alone protects it before any container- or
+    // label-state check runs.
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c.includes('live-wt_native-seed-onnxruntime-node'))).toBe(
+      false
+    )
+  })
+
+  it('18. skips a native-seed volume with a mismatched compose.volume label (per-module, not just "node_modules")', () => {
+    const fixture = setupFixture('prune-native-mismatch')
+    tempDirs.push(fixture.tempRoot)
+
+    // Labeled as the WRONG module's native-seed key -- the shape check must
+    // compare against the volume's OWN expected key (native-seed-esbuild),
+    // not merely "starts with native-seed-".
+    volumeListResponse(fixture, ['gone-wt_native-seed-esbuild'])
+    volumeLabels(fixture, 'gone-wt_native-seed-esbuild', {
+      volume: 'native-seed-hnswlib-node',
+      project: 'gone-wt',
+      owned: 'true',
+    })
+
+    const result = runPrune(fixture)
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c.startsWith('volume rm'))).toBe(false)
+  })
+
+  it('19. reports an unlabeled native-seed orphan as UNCONFIRMED; --include-unlabeled deletes it', () => {
+    const fixture = setupFixture('prune-native-unlabeled')
+    tempDirs.push(fixture.tempRoot)
+
+    volumeListResponse(fixture, ['gone-wt_native-seed-esbuild-scope'])
+    volumeLabels(fixture, 'gone-wt_native-seed-esbuild-scope', {
+      volume: 'native-seed-esbuild-scope',
+      project: 'gone-wt',
+      // no `owned` label -- matches the real pre-label backlog on this
+      // machine (enumerate_native_module_volumes only started emitting the
+      // label as of this same change).
+    })
+
+    const first = runPrune(fixture)
+
+    expect(first.status).toBe(0)
+    expect(first.stdout).toContain('UNCONFIRMED ownership: gone-wt_native-seed-esbuild-scope')
+    expect(first.dockerCalls.some((c) => c === 'volume rm gone-wt_native-seed-esbuild-scope')).toBe(
+      false
+    )
+
+    resetLog(fixture)
+    const second = runPrune(fixture, ['--include-unlabeled'])
+
+    expect(second.status).toBe(0)
+    expect(second.dockerCalls).toContain('volume rm gone-wt_native-seed-esbuild-scope')
+  })
+})

--- a/scripts/tests/remove-worktree.test.ts
+++ b/scripts/tests/remove-worktree.test.ts
@@ -355,3 +355,44 @@ describe('SMI-5145: reclaimable Docker report + safe --prune', () => {
     expect(result.dockerCalls.some((c) => c.includes('image prune -a'))).toBe(false)
   })
 })
+
+describe('SMI-5750: remove-worktree.sh targeted orphan-prune wiring (Step 3.5)', () => {
+  it('a default --force run invokes the targeted orphan prune (docker volume ls)', () => {
+    const tempRoot = makeTempDir('rmwt-orphan-prune')
+    tempDirs.push(tempRoot)
+    const { repoDir, worktreeDir } = setupRepoWithWorktree(tempRoot, 'wt-orphanprune')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    writeDockerShim(binDir, logPath)
+
+    const result = runScriptWithDockerShim(`"${worktreeDir}" --force`, binDir, logPath, repoDir)
+
+    expect(result.status).toBe(0)
+    // Step 3.5 shells out to prune-orphaned-docker-volumes.sh, which sources
+    // the same docker shim on PATH -- its `docker volume ls --format
+    // '{{.Name}}'` call (scripts/prune-orphaned-docker-volumes.sh:174) shows
+    // up positionally-appended in the same recorded dockerCalls array.
+    expect(result.dockerCalls).toContain('volume ls --format {{.Name}}')
+  })
+
+  it('--no-orphan-prune suppresses the targeted orphan prune (no volume ls call)', () => {
+    const tempRoot = makeTempDir('rmwt-no-orphan-prune')
+    tempDirs.push(tempRoot)
+    const { repoDir, worktreeDir } = setupRepoWithWorktree(tempRoot, 'wt-noorphanprune')
+    const binDir = join(tempRoot, 'bin')
+    sh(`mkdir -p "${binDir}"`)
+    const logPath = join(tempRoot, 'docker.log')
+    writeDockerShim(binDir, logPath)
+
+    const result = runScriptWithDockerShim(
+      `"${worktreeDir}" --force --no-orphan-prune`,
+      binDir,
+      logPath,
+      repoDir
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.dockerCalls.some((c) => c.includes('volume ls'))).toBe(false)
+  })
+})

--- a/scripts/tests/worktree-override-root-mount-smi5650.test.ts
+++ b/scripts/tests/worktree-override-root-mount-smi5650.test.ts
@@ -24,6 +24,12 @@
  * entry, sanitized to `native-seed-esbuild-scope` (volume names can't
  * contain `@`).
  *
+ * SMI-5750: each top-level native-seed volume declaration also carries an
+ * `app.skillsmith.owned: "true"` label (added in enumerate_native_module_
+ * volumes alongside `driver: local`) so prune-orphaned-docker-volumes.sh can
+ * identify and auto-reclaim orphaned native-seed volumes -- these are the
+ * numerically dominant orphan class (5 per worktree).
+ *
  * Cases:
  *   6  Darwin: the 2 alias-scope tmpfs overlays present per service with
  *      valid YAML shape (Wave 1).
@@ -31,10 +37,10 @@
  *      per service (dev/test, 10 total, including the @esbuild
  *      -> native-seed-esbuild-scope sanitization), the generated override's
  *      top-level `volumes:` YAML key exists with exactly the 5 expected
- *      `driver: local` entries (no driver_opts, no tmpfs annotation), and
- *      the root `:ro` mount precedes every native-module volume-reference
- *      line within each service (same order invariant as the alias-scope
- *      tmpfs entries) (Wave 2).
+ *      `driver: local` + `app.skillsmith.owned` entries (no driver_opts, no
+ *      tmpfs annotation), and the root `:ro` mount precedes every
+ *      native-module volume-reference line within each service (same order
+ *      invariant as the alias-scope tmpfs entries) (Wave 2).
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { join } from 'node:path'
@@ -180,9 +186,12 @@ describe('SMI-5650 (Wave 1 + Wave 2): alias-scope tmpfs overlays and native-modu
     }
 
     // Top-level `volumes:` YAML key: exactly the 5 expected named volumes,
-    // each declared as a bare `{ driver: 'local' }` — no driver_opts, no
-    // tmpfs annotation at all (the fix for Compose's tmpfs-hardcodes-noexec
-    // discovery is an ordinary named volume, not a tmpfs variant of it).
+    // each declared as `{ driver: 'local' }` — no driver_opts, no tmpfs
+    // annotation at all (the fix for Compose's tmpfs-hardcodes-noexec
+    // discovery is an ordinary named volume, not a tmpfs variant of it) —
+    // plus the SMI-5750 `app.skillsmith.owned` ownership label so
+    // prune-orphaned-docker-volumes.sh can identify and auto-reclaim
+    // orphaned native-seed volumes.
     expect(doc.volumes, 'top-level volumes: key').toBeDefined()
     const topLevelVolumeNames = Object.keys(doc.volumes!).sort()
     expect(topLevelVolumeNames).toEqual(
@@ -195,7 +204,10 @@ describe('SMI-5650 (Wave 1 + Wave 2): alias-scope tmpfs overlays and native-modu
       ].sort()
     )
     for (const [name, decl] of Object.entries(doc.volumes!)) {
-      expect(decl, `top-level volume declaration for ${name}`).toEqual({ driver: 'local' })
+      expect(decl, `top-level volume declaration for ${name}`).toEqual({
+        driver: 'local',
+        labels: { 'app.skillsmith.owned': 'true' },
+      })
     }
 
     // Mount order: the root :ro mount (a plain string) must precede every


### PR DESCRIPTION
## Business Summary

**What shipped:** `remove-worktree.sh` now automatically reclaims orphaned Docker volumes and images left behind by crashed or hand-deleted worktrees on every run, instead of relying on a manual step that this environment's continuous concurrent-worktree workflow never actually exercised — the root cause of a Docker Desktop crash (SMI-5616) that took the host disk down to 1.6GB free. A `--no-orphan-prune` flag opts out per-invocation if needed. Both the base `node_modules` volume and the 5 per-worktree native-module volumes now carry a positive ownership marker so newly-created volumes are unambiguously reclaimable; pre-existing unlabeled resources are only ever reported, never auto-deleted, unless an operator explicitly confirms with `--include-unlabeled`.

**Quality bar:** Plan reviewed pre-implementation by an independent model (Codex via NEEDLE) — 3 blockers found and fixed before any code was written. The implementation was then adversarially re-reviewed twice more after building it, which caught and fixed two additional real bugs: one that would have silently defeated the whole safety check on any machine with more than one worktree, and one where the numerically most common kind of orphaned volume on this machine wasn't being cleaned up at all. A follow-up governance pass caught and fixed a maintainability issue (the same sanitization logic duplicated across two scripts) and split an oversized test file to stay under the repo's file-length standard. 39 new/updated automated tests plus a pre-existing 54-test suite all pass; also live dry-run-verified against this machine's real backlog of ~240 leftover volumes/images with zero false positives against any currently active worktree.

**Found along the way:** the disk-space-threshold trigger for `create-worktree.sh` recommended by the plan was intentionally scoped out of this PR and filed separately as SMI-5757 (blocked on this PR landing first).

**Net result:** Fully shipped. One follow-up (SMI-5757) tracked, not blocking.

---

## Technical detail

**New**: `scripts/prune-orphaned-docker-volumes.sh` — targeted prune whose safety predicate is worktree-existence (`git worktree list --porcelain`, unioned with a `.worktrees/*` scan), not container-running-state, so it's safe to run unconditionally at any concurrency level. Recognizes both the `<project>_node_modules` and `<project>_native-seed-<module>` (SMI-5650) volume conventions, plus `<project>-dev` images. `--dry-run` and `--include-unlabeled` flags; `SKILLSMITH_ORPHAN_PRUNE_DISABLE=1` opt-out (registered in `docs/internal/process/guards-and-opt-outs.md`).

**Changed**:
- `scripts/remove-worktree.sh` — new Step 3.5 invoking the prune script unconditionally after all existing steps (so it can't shift any docker-call position the existing shim-based tests assert on positionally); `--no-orphan-prune` flag.
- `scripts/_lib.sh` — `enumerate_native_module_volumes()` now emits the `app.skillsmith.owned` label; new shared `sanitize_project_name()` (de-dup fix, see governance report below).
- `docker-compose.yml` — `app.skillsmith.owned` label on the `node_modules` volume + dev `build.labels`.
- `.claude/development/docker-guide.md` — one-line pointer to the new routine-reclaim path.

**Tests**: `scripts/tests/prune-orphaned-docker-volumes.test.ts` (19 cases) + sibling `.helpers.ts` fixture file (split for the 500-line file-length gate), 2 new cases in `scripts/tests/remove-worktree.test.ts`, updated assertion in `scripts/tests/worktree-override-root-mount-smi5650.test.ts` for the new label.

**Plan + reviews**: `docs/internal/implementation/smi-5750-targeted-volume-prune.md` (full Review Summary with both external reviews' findings). Governance report: `docs/internal/code_review/2026-07-19-smi-5750-targeted-volume-prune-review.md`.

**CI**: docs/internal submodule pointer bumped alongside code (4 commits total: feature, pointer bump, governance de-dup fix, pointer bump). Full pre-push suite green (security tests, npm audit, secrets scan, format, full package test suite).
