### PR TITLE
ci(hooks): wire enumerate-compose-mounts-smi5650 into validate-hooks

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -29,6 +29,7 @@ on:
       - 'scripts/tests/session-start-audit.test.sh'
       - 'scripts/tests/reclaim-node-modules.test.sh'
       - 'scripts/tests/enumerate-compose-mounts.test.sh'
+      - 'scripts/tests/enumerate-compose-mounts-smi5650.test.sh'
       - 'scripts/check-file-length.mjs'
       - 'lint-staged.config.js'
       - '.github/workflows/validate-hooks.yml'
@@ -61,7 +62,8 @@ jobs:
             scripts/tests/create-worktree-hooks.test.sh \
             scripts/tests/session-start-audit.test.sh \
             scripts/tests/reclaim-node-modules.test.sh \
-            scripts/tests/enumerate-compose-mounts.test.sh
+            scripts/tests/enumerate-compose-mounts.test.sh \
+            scripts/tests/enumerate-compose-mounts-smi5650.test.sh
 
       - name: Syntax check (bash -n)
         run: |
@@ -78,6 +80,7 @@ jobs:
           bash -n scripts/tests/session-start-audit.test.sh
           bash -n scripts/tests/reclaim-node-modules.test.sh
           bash -n scripts/tests/enumerate-compose-mounts.test.sh
+          bash -n scripts/tests/enumerate-compose-mounts-smi5650.test.sh
           sh -n .husky/pre-commit
           sh -n .husky/post-merge
 
@@ -99,3 +102,4 @@ jobs:
           bash scripts/tests/session-start-audit.test.sh
           bash scripts/tests/reclaim-node-modules.test.sh
           bash scripts/tests/enumerate-compose-mounts.test.sh
+          bash scripts/tests/enumerate-compose-mounts-smi5650.test.sh


### PR DESCRIPTION
## Business Summary

**What shipped:** `validate-hooks.yml`'s CI now actually runs `enumerate-compose-mounts-smi5650.test.sh` — a 54-assertion test covering SMI-5650's tmpfs alias-scope overlays and native-module volume mounts, previously invisible to CI entirely (same gap its sibling file had before an earlier merge wired that one in).

**Quality bar:** Direct copy of an already-proven pattern (the sibling file's exact 4 CI insertion points), plan-reviewed with no blockers. Local verification: valid YAML, clean shellcheck, and the full 54-test suite passing.

**Found along the way:** while verifying no other test file had this same gap, found 7 more — `pooler-psql`, `needle-dispatch`, `regen-worktree-overrides`, `repair-worktree-container-symlinks`, `session-start-mcp-command-guard`, `worktree-docker-resolve`, and `worktree-port-collision` — none wired into any GitHub Actions workflow. Filed as SMI-5771 rather than bundled here (real scope creep otherwise).

**Net result:** Fully shipped. SMI-5771 tracked separately, not blocking.

---

## Technical detail

`.github/workflows/validate-hooks.yml` — added `scripts/tests/enumerate-compose-mounts-smi5650.test.sh` at the same 4 points as its sibling: `paths:` trigger, shellcheck step, `bash -n` syntax check, unit-test step. No other changes.

Fixes SMI-5745.