### PR TITLE
test(hooks): fix stale docstring in worktree-port-collision fixture

### DIFF
--- a/scripts/tests/worktree-port-collision.test.sh
+++ b/scripts/tests/worktree-port-collision.test.sh
@@ -140,11 +140,22 @@ add_worktree() {
 }
 
 # write_fixed_override <worktree_path> <name> <base_port> -> hand-writes a
-# minimal override whose 4 port lines match the real generator's shape
-# (quoted "HOST:CONTAINER") at HOST ports base_port..base_port+3, regardless
-# of what bucket <name>'s own cksum hash would produce. Used to manufacture
-# an exact bucket collision without needing the fixture name's hash to
-# cooperate.
+# minimal override with 4 quoted "HOST:CONTAINER" port lines at HOST ports
+# base_port..base_port+3, regardless of what bucket <name>'s own cksum hash
+# would produce. Used to manufacture an exact bucket collision without
+# needing the fixture name's hash to cooperate.
+#
+# SMI-5748: the 4th port (base+3, "orchestrator" service below) no longer
+# matches the REAL generator's shape post-SMI-5719, which deleted the
+# orchestrator service and now only ever writes 3 ports (see _lib.sh:1239-
+# 1244's own comment). Kept here anyway, deliberately: _resolve_worktree_
+# port_offset's collision-check loop (_lib.sh:1058-1066) still reserves and
+# checks all 4 slots in a bucket regardless of what a real override
+# populates, and _parse_override_host_ports (_lib.sh:950-954) is
+# service-name-agnostic — it greps port VALUES, not service names. Shrinking
+# this fixture to 3 ports would silently drop test coverage for that 4th
+# reserved-but-currently-unwritten slot. "orchestrator" below is a fixture
+# label only — no such service exists in docker-compose.yml anymore.
 write_fixed_override() {
   local wt_path="$1" name="$2" base="$3"
   cat > "$wt_path/docker-compose.override.yml" << EOF
@@ -161,6 +172,8 @@ services:
   orchestrator:
     container_name: ${name}-orchestrator-1
     ports:
+      # SMI-5748: fictional 4th slot -- see docstring above. Exercises the
+      # collision loop's full reserved bucket width, not a real service.
       - "$((base + 3)):3000"  # Orchestrator
 EOF
 }


### PR DESCRIPTION
## Business Summary

**What shipped:** A test-fixture docstring that claimed to "match the real generator's shape" was corrected — it no longer does, since an earlier cleanup deleted the service that shape referred to. Investigated the alternative fix (shrinking the fixture to match) and found it would have silently reduced test coverage, so kept the wider shape and documented why instead.

**Quality bar:** Plan-reviewed (no blockers) with an independent trace through the actual collision-detection code confirming the reasoning. No functional change — still 22/22 tests passing, same port values.

**Net result:** Fully shipped, no follow-up (this file's own CI-wiring gap is tracked separately under SMI-5771).

---

## Technical detail

`scripts/tests/worktree-port-collision.test.sh` — rewrote `write_fixed_override`'s docstring to explain why it intentionally still emits a 4th "orchestrator" port slot (no such service exists anymore) rather than shrinking to match the real generator's current 3-port output: the collision-check loop it tests still reserves and checks the full 4-port bucket width regardless of what a real override populates, so shrinking the fixture would drop coverage of that reserved slot. Added an inline comment at the fixture body's fictional `orchestrator:` block so this is visible without reading the docstring 14 lines above.

Fixes SMI-5748.