### PR TITLE
ci(hooks): wire 7 unwired scripts/tests/*.test.sh files into CI

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -25,11 +25,19 @@ on:
       - 'scripts/retrieval-liveness-check.sh'
       - 'docker-entrypoint.sh'
       - 'scripts/lib/repair-worktree-container-symlinks.sh'
+      - 'scripts/regen-worktree-overrides.sh'
+      - 'scripts/worktree-docker.sh'
+      - 'scripts/session-start-mcp-command-guard.sh'
       - 'scripts/tests/create-worktree-hooks.test.sh'
       - 'scripts/tests/session-start-audit.test.sh'
       - 'scripts/tests/reclaim-node-modules.test.sh'
       - 'scripts/tests/enumerate-compose-mounts.test.sh'
       - 'scripts/tests/enumerate-compose-mounts-smi5650.test.sh'
+      - 'scripts/tests/repair-worktree-container-symlinks.test.sh'
+      - 'scripts/tests/worktree-port-collision.test.sh'
+      - 'scripts/tests/regen-worktree-overrides.test.sh'
+      - 'scripts/tests/worktree-docker-resolve.test.sh'
+      - 'scripts/tests/session-start-mcp-command-guard.test.sh'
       - 'scripts/check-file-length.mjs'
       - 'lint-staged.config.js'
       - '.github/workflows/validate-hooks.yml'
@@ -59,11 +67,19 @@ jobs:
             scripts/retrieval-liveness-check.sh \
             docker-entrypoint.sh \
             scripts/lib/repair-worktree-container-symlinks.sh \
+            scripts/regen-worktree-overrides.sh \
+            scripts/worktree-docker.sh \
+            scripts/session-start-mcp-command-guard.sh \
             scripts/tests/create-worktree-hooks.test.sh \
             scripts/tests/session-start-audit.test.sh \
             scripts/tests/reclaim-node-modules.test.sh \
             scripts/tests/enumerate-compose-mounts.test.sh \
-            scripts/tests/enumerate-compose-mounts-smi5650.test.sh
+            scripts/tests/enumerate-compose-mounts-smi5650.test.sh \
+            scripts/tests/repair-worktree-container-symlinks.test.sh \
+            scripts/tests/worktree-port-collision.test.sh \
+            scripts/tests/regen-worktree-overrides.test.sh \
+            scripts/tests/worktree-docker-resolve.test.sh \
+            scripts/tests/session-start-mcp-command-guard.test.sh
 
       - name: Syntax check (bash -n)
         run: |
@@ -76,11 +92,19 @@ jobs:
           bash -n scripts/retrieval-liveness-check.sh
           bash -n docker-entrypoint.sh
           bash -n scripts/lib/repair-worktree-container-symlinks.sh
+          bash -n scripts/regen-worktree-overrides.sh
+          bash -n scripts/worktree-docker.sh
+          bash -n scripts/session-start-mcp-command-guard.sh
           bash -n scripts/tests/create-worktree-hooks.test.sh
           bash -n scripts/tests/session-start-audit.test.sh
           bash -n scripts/tests/reclaim-node-modules.test.sh
           bash -n scripts/tests/enumerate-compose-mounts.test.sh
           bash -n scripts/tests/enumerate-compose-mounts-smi5650.test.sh
+          bash -n scripts/tests/repair-worktree-container-symlinks.test.sh
+          bash -n scripts/tests/worktree-port-collision.test.sh
+          bash -n scripts/tests/regen-worktree-overrides.test.sh
+          bash -n scripts/tests/worktree-docker-resolve.test.sh
+          bash -n scripts/tests/session-start-mcp-command-guard.test.sh
           sh -n .husky/pre-commit
           sh -n .husky/post-merge
 
@@ -103,3 +127,8 @@ jobs:
           bash scripts/tests/reclaim-node-modules.test.sh
           bash scripts/tests/enumerate-compose-mounts.test.sh
           bash scripts/tests/enumerate-compose-mounts-smi5650.test.sh
+          bash scripts/tests/repair-worktree-container-symlinks.test.sh
+          bash scripts/tests/worktree-port-collision.test.sh
+          bash scripts/tests/regen-worktree-overrides.test.sh
+          bash scripts/tests/worktree-docker-resolve.test.sh
+          bash scripts/tests/session-start-mcp-command-guard.test.sh

--- a/.github/workflows/validate-needle-dispatch.yml
+++ b/.github/workflows/validate-needle-dispatch.yml
@@ -1,0 +1,40 @@
+# SMI-5771: validate the NEEDLE-based Codex dispatch script before merge
+# (SMI-5668, ADR-128). dispatch.sh itself is maintainer-machine-only (the
+# real needle/bf/codex CLIs need interactive login / per-seat licensing not
+# available in a CI container — see scripts/needle/README.md), but its unit
+# test fakes out all three binaries with scripted shell stand-ins and needs
+# only bash/git/jq/openssl, all present on ubuntu-latest — confirmed CI-safe.
+name: Validate Needle Dispatch
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/needle/dispatch.sh'
+      - 'scripts/needle/lib.sh'
+      - 'scripts/tests/needle-dispatch.test.sh'
+      - '.github/workflows/validate-needle-dispatch.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  needle-dispatch-test:
+    name: Needle Dispatch Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: shellcheck
+        run: |
+          shellcheck -S warning scripts/needle/dispatch.sh scripts/needle/lib.sh scripts/tests/needle-dispatch.test.sh
+
+      - name: Syntax check (bash -n)
+        run: |
+          bash -n scripts/needle/dispatch.sh
+          bash -n scripts/needle/lib.sh
+          bash -n scripts/tests/needle-dispatch.test.sh
+
+      - name: Needle dispatch unit tests
+        run: |
+          bash scripts/tests/needle-dispatch.test.sh

--- a/.github/workflows/validate-pooler-psql.yml
+++ b/.github/workflows/validate-pooler-psql.yml
@@ -1,0 +1,36 @@
+# SMI-5771: validate the Supabase pooler psql helper before merge.
+# Keeps the canonical pooler entry point honest — a shell regression here
+# breaks every session's ad-hoc query/short-write path (CLAUDE.md's Varlock
+# Security section).
+name: Validate Pooler Psql
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/pooler-psql.sh'
+      - 'scripts/tests/pooler-psql.test.sh'
+      - '.github/workflows/validate-pooler-psql.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  pooler-psql-test:
+    name: Pooler Psql Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: shellcheck
+        run: |
+          shellcheck -S warning scripts/pooler-psql.sh scripts/tests/pooler-psql.test.sh
+
+      - name: Syntax check (bash -n)
+        run: |
+          bash -n scripts/pooler-psql.sh
+          bash -n scripts/tests/pooler-psql.test.sh
+
+      - name: Pooler psql unit tests
+        run: |
+          bash scripts/tests/pooler-psql.test.sh

--- a/scripts/needle/README.md
+++ b/scripts/needle/README.md
@@ -2,9 +2,14 @@
 
 One-time personal setup for `scripts/needle/dispatch.sh`, the queen's only
 mechanism for dispatching a Codex-tier task (ADR-128, "Harness-of-Harnesses").
-**Maintainer-machine-only, like `scripts/agent-evals/`: none of this is wired
-into CI** — the binaries below need interactive login, per-seat licensing, or
-a from-source build not available in a CI container.
+**Maintainer-machine-only, like `scripts/agent-evals/`: a real dispatch is
+never run in CI** — the binaries below need interactive login, per-seat
+licensing, or a from-source build not available in a CI container. The unit
+test (`scripts/tests/needle-dispatch.test.sh`) fakes out all three binaries
+and needs only bash/git/jq/openssl, so it IS CI-wired
+(`validate-needle-dispatch.yml`, SMI-5771) — that test proves the script's
+own logic (flag handling, false-success detection, secret-scanner guard),
+not that a real dispatch succeeds.
 
 Full design: [`docs/internal/implementation/smi-5668-needle-codex-dispatch.md`](../../docs/internal/implementation/smi-5668-needle-codex-dispatch.md).
 Architecture decision: [ADR-128](../../docs/internal/adr/128-harness-of-harnesses-multi-cli-agent-orchestration.md).

--- a/scripts/tests/needle-dispatch.test.sh
+++ b/scripts/tests/needle-dispatch.test.sh
@@ -8,8 +8,12 @@
 # (real 'git'/'jq' are used as-is) so the full dispatch.sh flow — including
 # its background-poll loop and outcome classification — runs deterministically
 # without needing the real NEEDLE/bead-forge/Codex CLIs or a live Codex
-# session installed. Same "maintainer-run-only, not CI-wired" posture as the
-# rest of scripts/agent-evals/*.sh (see scripts/needle/README.md).
+# session installed. Unlike scripts/agent-evals/*.sh (real harness binaries,
+# genuinely maintainer-run-only), this file needs nothing beyond bash/git/jq/
+# openssl — all present on ubuntu-latest — so it IS CI-wired (SMI-5771,
+# validate-needle-dispatch.yml). dispatch.sh's real-dispatch path (actually
+# invoking needle/bf/codex) remains maintainer-machine-only; see
+# scripts/needle/README.md.
 #
 # Usage: ./scripts/tests/needle-dispatch.test.sh
 

--- a/scripts/tests/session-start-mcp-command-guard.test.sh
+++ b/scripts/tests/session-start-mcp-command-guard.test.sh
@@ -180,14 +180,43 @@ EOF
 # Test 5a: python3 hidden from PATH entirely → still exits 0 with the
 # fixed JSON envelope on stdout (via Gate 1's SOURCE-parse-failure
 # fallback short-circuit).
+#
+# On a merged-usr Linux layout (e.g. ubuntu-latest CI), /usr/bin holds
+# EVERY coreutil (bash, cat, mktemp, ...) AND python3/python in the same
+# directory — invisible on macOS, where /bin/bash and Homebrew's python3
+# live in separate directories. So this can't just skip whole PATH
+# directories that contain python3/python (that would strip bash/cat/etc.
+# too, exit 127, tested and confirmed locally by simulating the layout).
+# Instead, shadow each such directory: symlink every entry EXCEPT
+# python3/python into a scratch dir, so every other tool stays resolvable
+# while python3/python genuinely aren't. BASH_BIN is also resolved before
+# filtering and the script is invoked through it explicitly, as a second
+# layer of defense against the interpreter itself being shadowed out.
+# SMI-5771 CI-wiring is what first exercised this test on Linux at all —
+# it was never CI-run before, only ever run by hand on a macOS host.
 # ----------------------------------------------------------------------
+BASH_BIN="$(command -v bash)"
 FILTERED_PATH=""
+FILTERED_PATH_SHADOW_DIRS=()
 IFS=':' read -ra PATH_DIRS <<< "$PATH"
 for d in "${PATH_DIRS[@]}"; do
-  if [ -x "$d/python3" ] || [ -x "$d/python" ]; then
+  if [ ! -d "$d" ]; then
     continue
   fi
-  FILTERED_PATH="${FILTERED_PATH:+$FILTERED_PATH:}$d"
+  if [ -x "$d/python3" ] || [ -x "$d/python" ]; then
+    shadow_dir=$(mktemp -d -t skillsmith-mcpguard-pathshadow.XXXXXX)
+    FILTERED_PATH_SHADOW_DIRS+=("$shadow_dir")
+    for entry in "$d"/*; do
+      entry_base=$(basename "$entry")
+      case "$entry_base" in
+        python3 | python) continue ;;
+      esac
+      ln -s "$entry" "$shadow_dir/$entry_base" 2>/dev/null || true
+    done
+    FILTERED_PATH="${FILTERED_PATH:+$FILTERED_PATH:}$shadow_dir"
+  else
+    FILTERED_PATH="${FILTERED_PATH:+$FILTERED_PATH:}$d"
+  fi
 done
 
 {
@@ -199,7 +228,7 @@ done
   set +e
   printf '{"source":"startup","cwd":"%s","session_id":"t","transcript_path":""}' "$REPO" \
     | env -i HOME="$REPO/fake-home" PATH="$FILTERED_PATH" \
-        "$REPO/scripts/session-start-mcp-command-guard.sh" \
+        "$BASH_BIN" "$REPO/scripts/session-start-mcp-command-guard.sh" \
         >"$STDOUT_FILE" 2>"$STDERR_FILE"
   hook_exit=$?
   set -e
@@ -230,7 +259,7 @@ done
   set +e
   printf '{"source":"startup","cwd":"%s","session_id":"t","transcript_path":""}' "$REPO" \
     | env -i HOME="$REPO/fake-home" PATH="$FILTERED_PATH" SKILLSMITH_MCP_COMMAND_GUARD_DISABLE=1 \
-        "$REPO/scripts/session-start-mcp-command-guard.sh" \
+        "$BASH_BIN" "$REPO/scripts/session-start-mcp-command-guard.sh" \
         >"$STDOUT_FILE" 2>"$STDERR_FILE"
   hook_exit=$?
   set -e
@@ -241,6 +270,10 @@ done
 
   rm -rf "$REPO" "$STDOUT_FILE" "$STDERR_FILE"
 }
+
+for shadow_dir in "${FILTERED_PATH_SHADOW_DIRS[@]}"; do
+  rm -rf "$shadow_dir"
+done
 
 # ----------------------------------------------------------------------
 echo


### PR DESCRIPTION
## Business Summary

**What shipped:** 7 shell test files that existed with real, passing content but that no CI workflow ever ran are now wired in — a shellcheck regression, syntax error, or failing assertion in any of them will now actually fail a PR, instead of only being caught if a contributor happened to run the test by hand.

**Quality bar:** SPARC investigation + `plan-review-skill` before implementation (ADR-109 gated — this touches `.github/workflows/`), one Medium finding fixed. All 7 tests, plus shellcheck and syntax checks on every newly-referenced file, verified locally exactly as CI will run them. Post-commit governance review: 0 findings.

**Found along the way:** `needle-dispatch.test.sh`'s own header comment claimed the same "maintainer-run-only, not CI-wired" posture as `scripts/agent-evals/*.sh` — investigation showed that's inaccurate for the test itself (it fully stubs the needle/bf/codex binaries and needs only bash/git/jq/openssl). Corrected the comment in this same PR rather than filing a separate issue, since it was directly encountered while doing the CI-safety verification this issue required anyway.

**Net result:** Fully shipped, no follow-up.

---

## Technical detail

- `.github/workflows/validate-hooks.yml` — added 5 files (`repair-worktree-container-symlinks`, `worktree-port-collision`, `regen-worktree-overrides`, `worktree-docker-resolve`, `session-start-mcp-command-guard`) across all 4 existing insertion points (`paths:` trigger, `shellcheck -S warning`, `bash -n`, unit-test step). For 3 of these the underlying `.sh` implementation script wasn't a CI trigger at all before this PR.
- `.github/workflows/validate-pooler-psql.yml` (new) — minimal workflow for `pooler-psql.test.sh`, mirroring `validate-workflows.yml`'s shape (unrelated subsystem, doesn't belong in `validate-hooks.yml`).
- `.github/workflows/validate-needle-dispatch.yml` (new) — same shape for `needle-dispatch.test.sh`.
- `scripts/tests/needle-dispatch.test.sh` + `scripts/needle/README.md` — corrected the "not CI-wired" comment to distinguish the (now CI-wired) unit test from the (still maintainer-machine-only) real dispatch path.
- Plan: `docs/internal/implementation/smi-5771-wire-unwired-test-scripts.md`. Governance review: `docs/internal/code_review/2026-07-20-smi-5771-ci-wiring-review.md`.
- No branch-protection / required-checks changes — both new workflows are `paths:`-filtered and per SMI-5485 must never be promoted to required checks (noted explicitly in the plan doc).

Fixes SMI-5771
