### PR TITLE
docs(scaffold): SMI-5742 Wave A mechanical claude-flow->ruflo rename

### DIFF
--- a/.claude/agents/core/planner.md
+++ b/.claude/agents/core/planner.md
@@ -143,7 +143,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Monitor task progress
-mcp__claude-flow__task_status {
+mcp__ruflo__task_status {
   taskId: "auth-implementation"
 }
 ```

--- a/.claude/agents/core/researcher.md
+++ b/.claude/agents/core/researcher.md
@@ -160,7 +160,7 @@ mcp__claude-flow__memory_search {
 ### Analysis Tools
 ```javascript
 // Analyze codebase
-mcp__claude-flow__github_repo_analyze {
+mcp__ruflo__github_repo_analyze {
   repo: "current",
   analysis_type: "code_quality"
 }

--- a/.claude/agents/core/reviewer.md
+++ b/.claude/agents/core/reviewer.md
@@ -311,13 +311,13 @@ mcp__claude-flow__memory_usage {
 ### Code Analysis
 ```javascript
 // Analyze code quality
-mcp__claude-flow__github_repo_analyze {
+mcp__ruflo__github_repo_analyze {
   repo: "current",
   analysis_type: "code_quality"
 }
 
 // Run security scan
-mcp__claude-flow__github_repo_analyze {
+mcp__ruflo__github_repo_analyze {
   repo: "current",
   analysis_type: "security"
 }

--- a/.claude/agents/core/tester.md
+++ b/.claude/agents/core/tester.md
@@ -300,7 +300,7 @@ mcp__claude-flow__benchmark_run {
 }
 
 // Monitor test execution
-mcp__claude-flow__performance_report {
+mcp__ruflo__performance_report {
   format: "detailed"
 }
 ```

--- a/.claude/agents/github/code-review-swarm.md
+++ b/.claude/agents/github/code-review-swarm.md
@@ -1,7 +1,7 @@
 ---
 name: code-review-swarm
 description: Deploy specialized AI agents to perform comprehensive, intelligent code reviews that go beyond traditional static analysis
-tools: mcp__claude-flow__swarm_init, mcp__claude-flow__agent_spawn, mcp__claude-flow__task_orchestrate, Bash, Read, Write, TodoWrite
+tools: mcp__ruflo__swarm_init, mcp__ruflo__agent_spawn, mcp__claude-flow__task_orchestrate, Bash, Read, Write, TodoWrite
 color: blue
 type: development
 capabilities:

--- a/.claude/agents/github/github-modes.md
+++ b/.claude/agents/github/github-modes.md
@@ -1,7 +1,7 @@
 ---
 name: github-modes
 description: Comprehensive GitHub integration modes for workflow orchestration, PR management, and repository coordination with batch optimization
-tools: mcp__claude-flow__swarm_init, mcp__claude-flow__agent_spawn, mcp__claude-flow__task_orchestrate, Bash, TodoWrite, Read, Write
+tools: mcp__ruflo__swarm_init, mcp__ruflo__agent_spawn, mcp__claude-flow__task_orchestrate, Bash, TodoWrite, Read, Write
 color: purple
 type: development
 capabilities:
@@ -27,7 +27,7 @@ hooks:
 # GitHub Integration Modes
 
 ## Overview
-This document describes all GitHub integration modes available in Claude-Flow with ruv-swarm coordination. Each mode is optimized for specific GitHub workflows and includes batch tool integration for maximum efficiency.
+This document describes all GitHub integration modes available in Ruflo with ruv-swarm coordination. Each mode is optimized for specific GitHub workflows and includes batch tool integration for maximum efficiency.
 
 ## GitHub Workflow Modes
 
@@ -163,10 +163,10 @@ All GitHub modes can be enhanced with ruv-swarm coordination:
 
 ```javascript
 // Initialize swarm for GitHub workflow
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Agent" }
+mcp__ruflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__ruflo__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
+mcp__ruflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__ruflo__agent_spawn { type: "tester", name: "QA Agent" }
 
 // Execute GitHub workflow with coordination
 mcp__claude-flow__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }

--- a/.claude/agents/github/issue-tracker.md
+++ b/.claude/agents/github/issue-tracker.md
@@ -1,7 +1,7 @@
 ---
 name: issue-tracker
 description: Intelligent issue management and project coordination with automated tracking, progress monitoring, and team coordination
-tools: mcp__claude-flow__swarm_init, mcp__claude-flow__agent_spawn, mcp__claude-flow__task_orchestrate, mcp__claude-flow__memory_usage, Bash, TodoWrite, Read, Write
+tools: mcp__ruflo__swarm_init, mcp__ruflo__agent_spawn, mcp__claude-flow__task_orchestrate, mcp__claude-flow__memory_usage, Bash, TodoWrite, Read, Write
 color: green
 type: development
 capabilities:
@@ -52,10 +52,10 @@ Intelligent issue management and project coordination with ruv-swarm integration
 ### 1. Create Coordinated Issue with Swarm Tracking
 ```javascript
 // Initialize issue management swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 3 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "researcher", name: "Requirements Analyst" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Implementation Planner" }
+mcp__ruflo__swarm_init { topology: "star", maxAgents: 3 }
+mcp__ruflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__ruflo__agent_spawn { type: "researcher", name: "Requirements Analyst" }
+mcp__ruflo__agent_spawn { type: "coder", name: "Implementation Planner" }
 
 // Create comprehensive issue
 mcp__github__create_issue {
@@ -152,10 +152,10 @@ mcp__github__update_issue {
 ```javascript
 [Single Message - Issue Lifecycle Management]:
   // Initialize issue coordination swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Manager" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Progress Tracker" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Context Gatherer" }
+  mcp__ruflo__swarm_init { topology: "mesh", maxAgents: 4 }
+  mcp__ruflo__agent_spawn { type: "coordinator", name: "Issue Manager" }
+  mcp__ruflo__agent_spawn { type: "analyst", name: "Progress Tracker" }
+  mcp__ruflo__agent_spawn { type: "researcher", name: "Context Gatherer" }
   
   // Create multiple related issues using gh CLI
   Bash(`gh issue create \

--- a/.claude/agents/github/multi-repo-swarm.md
+++ b/.claude/agents/github/multi-repo-swarm.md
@@ -12,15 +12,15 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
+  - mcp__ruflo__swarm_init
+  - mcp__ruflo__agent_spawn
   - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
+  - mcp__ruflo__swarm_status
   - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_repo_analyze
-  - mcp__claude-flow__github_pr_manage
+  - mcp__ruflo__github_repo_analyze
+  - mcp__ruflo__github_pr_manage
   - mcp__claude-flow__github_sync_coord
-  - mcp__claude-flow__github_metrics
+  - mcp__ruflo__github_metrics
 hooks:
   pre:
     - "gh auth status || (echo 'GitHub CLI not authenticated' && exit 1)"

--- a/.claude/agents/github/pr-manager.md
+++ b/.claude/agents/github/pr-manager.md
@@ -12,14 +12,14 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
+  - mcp__ruflo__swarm_init
+  - mcp__ruflo__agent_spawn
   - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
+  - mcp__ruflo__swarm_status
   - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_pr_manage
+  - mcp__ruflo__github_pr_manage
   - mcp__claude-flow__github_code_review
-  - mcp__claude-flow__github_metrics
+  - mcp__ruflo__github_metrics
 hooks:
   pre:
     - "gh auth status || (echo 'GitHub CLI not authenticated' && exit 1)"
@@ -50,10 +50,10 @@ Comprehensive pull request management with swarm coordination for automated revi
 ### 1. Create and Manage PR with Swarm Coordination
 ```javascript
 // Initialize review swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Testing Agent" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "PR Coordinator" }
+mcp__ruflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__ruflo__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
+mcp__ruflo__agent_spawn { type: "tester", name: "Testing Agent" }
+mcp__ruflo__agent_spawn { type: "coordinator", name: "PR Coordinator" }
 
 // Create PR and orchestrate review
 mcp__github__create_pull_request {
@@ -121,10 +121,10 @@ mcp__claude-flow__memory_usage {
 ```javascript
 [Single Message - Complete PR Management]:
   // Initialize coordination
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
+  mcp__ruflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+  mcp__ruflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__ruflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__ruflo__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
   
   // Create and manage PR using gh CLI
   Bash("gh pr create --repo :owner/:repo --title '...' --head '...' --base 'main'")

--- a/.claude/agents/github/project-board-sync.md
+++ b/.claude/agents/github/project-board-sync.md
@@ -12,17 +12,17 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
+  - mcp__ruflo__swarm_init
+  - mcp__ruflo__agent_spawn
   - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
+  - mcp__ruflo__swarm_status
   - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_repo_analyze
-  - mcp__claude-flow__github_pr_manage
-  - mcp__claude-flow__github_issue_track
-  - mcp__claude-flow__github_metrics
-  - mcp__claude-flow__workflow_create
-  - mcp__claude-flow__workflow_execute
+  - mcp__ruflo__github_repo_analyze
+  - mcp__ruflo__github_pr_manage
+  - mcp__ruflo__github_issue_track
+  - mcp__ruflo__github_metrics
+  - mcp__ruflo__workflow_create
+  - mcp__ruflo__workflow_execute
 hooks:
   pre:
     - "gh auth status || (echo 'GitHub CLI not authenticated' && exit 1)"

--- a/.claude/agents/github/release-manager.md
+++ b/.claude/agents/github/release-manager.md
@@ -17,8 +17,8 @@ tools:
   - mcp__github__create_branch
   - mcp__github__push_files
   - mcp__github__create_issue
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
+  - mcp__ruflo__swarm_init
+  - mcp__ruflo__agent_spawn
   - mcp__claude-flow__task_orchestrate
   - mcp__claude-flow__memory_usage
 hooks:
@@ -53,12 +53,12 @@ Automated release coordination and deployment with ruv-swarm orchestration for s
 ### 1. Coordinated Release Preparation
 ```javascript
 // Initialize release management swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Coordinator" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Release Reviewer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Version Manager" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Deployment Analyst" }
+mcp__ruflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+mcp__ruflo__agent_spawn { type: "coordinator", name: "Release Coordinator" }
+mcp__ruflo__agent_spawn { type: "tester", name: "QA Engineer" }
+mcp__ruflo__agent_spawn { type: "reviewer", name: "Release Reviewer" }
+mcp__ruflo__agent_spawn { type: "coder", name: "Version Manager" }
+mcp__ruflo__agent_spawn { type: "analyst", name: "Deployment Analyst" }
 
 // Create release preparation branch
 mcp__github__create_branch {
@@ -87,7 +87,7 @@ mcp__github__push_files {
     {
       path: "claude-code-flow/claude-code-flow/package.json",
       content: JSON.stringify({
-        name: "claude-flow",
+        name: "ruflo",
         version: "1.0.72",
         // ... rest of package.json
       }, null, 2)
@@ -154,7 +154,7 @@ mcp__github__create_pull_request {
 - **Improved Testing**: Comprehensive integration test suite with 89% success rate
 
 ### 📦 Package Updates
-- **claude-flow**: v1.0.71 → v1.0.72
+- **ruflo**: v1.0.71 → v1.0.72
 - **ruv-swarm**: v1.0.11 → v1.0.12
 
 ### 🔧 Changes
@@ -206,13 +206,13 @@ This release is production-ready with comprehensive validation and testing.
 ```javascript
 [Single Message - Complete Release Management]:
   // Initialize comprehensive release swarm
-  mcp__claude-flow__swarm_init { topology: "star", maxAgents: 8 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Director" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Lead" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Version Controller" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Performance Analyst" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Compatibility Checker" }
+  mcp__ruflo__swarm_init { topology: "star", maxAgents: 8 }
+  mcp__ruflo__agent_spawn { type: "coordinator", name: "Release Director" }
+  mcp__ruflo__agent_spawn { type: "tester", name: "QA Lead" }
+  mcp__ruflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__ruflo__agent_spawn { type: "coder", name: "Version Controller" }
+  mcp__ruflo__agent_spawn { type: "analyst", name: "Performance Analyst" }
+  mcp__ruflo__agent_spawn { type: "researcher", name: "Compatibility Checker" }
   
   // Create release branch and prepare files using gh CLI
   Bash("gh api repos/:owner/:repo/git/refs --method POST -f ref='refs/heads/release/v1.0.72' -f sha=$(gh api repos/:owner/:repo/git/refs/heads/main --jq '.object.sha')")
@@ -258,7 +258,7 @@ This release is production-ready with comprehensive validation and testing.
       timestamp: Date.now(),
       version: "1.0.72",
       stage: "validation_complete",
-      packages: ["claude-flow", "ruv-swarm"],
+      packages: ["ruflo", "ruv-swarm"],
       validation_passed: true,
       ready_for_review: true
     }

--- a/.claude/agents/github/release-swarm.md
+++ b/.claude/agents/github/release-swarm.md
@@ -17,8 +17,8 @@ tools:
   - mcp__github__create_branch
   - mcp__github__push_files
   - mcp__github__create_issue
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
+  - mcp__ruflo__swarm_init
+  - mcp__ruflo__agent_spawn
   - mcp__claude-flow__task_orchestrate
   - mcp__claude-flow__parallel_execute
   - mcp__claude-flow__load_balance

--- a/.claude/agents/github/repo-architect.md
+++ b/.claude/agents/github/repo-architect.md
@@ -19,8 +19,8 @@ tools:
   - mcp__github__search_repositories
   - mcp__github__push_files
   - mcp__github__create_or_update_file
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
+  - mcp__ruflo__swarm_init
+  - mcp__ruflo__agent_spawn
   - mcp__claude-flow__task_orchestrate
   - mcp__claude-flow__memory_usage
 hooks:
@@ -55,11 +55,11 @@ Repository structure optimization and multi-repo management with ruv-swarm coord
 ### 1. Repository Structure Analysis and Optimization
 ```javascript
 // Initialize architecture analysis swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyzer" }
-mcp__claude-flow__agent_spawn { type: "architect", name: "Repository Architect" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+mcp__ruflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__ruflo__agent_spawn { type: "analyst", name: "Structure Analyzer" }
+mcp__ruflo__agent_spawn { type: "architect", name: "Repository Architect" }
+mcp__ruflo__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
+mcp__ruflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
 
 // Analyze current repository structure
 LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -200,12 +200,12 @@ jobs:
 ```javascript
 [Single Message - Repository Architecture Review]:
   // Initialize comprehensive architecture swarm
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "architect", name: "Senior Architect" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyst" }
-  mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+  mcp__ruflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+  mcp__ruflo__agent_spawn { type: "architect", name: "Senior Architect" }
+  mcp__ruflo__agent_spawn { type: "analyst", name: "Structure Analyst" }
+  mcp__ruflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+  mcp__ruflo__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
+  mcp__ruflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
   
   // Analyze current repository structures
   LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")

--- a/.claude/agents/github/swarm-issue.md
+++ b/.claude/agents/github/swarm-issue.md
@@ -9,8 +9,8 @@ tools:
   - mcp__github__update_issue
   - mcp__github__list_issues
   - mcp__github__create_issue_comment
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
+  - mcp__ruflo__swarm_init
+  - mcp__ruflo__agent_spawn
   - mcp__claude-flow__task_orchestrate
   - mcp__claude-flow__memory_usage
   - TodoWrite
@@ -516,11 +516,11 @@ npx ruv-swarm github issue-init 567 \
 ### Multi-Agent Issue Processing
 ```bash
 # Initialize issue-specific swarm with optimal topology
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 8 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Issue Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Solution Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__ruflo__swarm_init { topology: "hierarchical", maxAgents: 8 }
+mcp__ruflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__ruflo__agent_spawn { type: "analyst", name: "Issue Analyzer" }
+mcp__ruflo__agent_spawn { type: "coder", name: "Solution Developer" }
+mcp__ruflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 # Store issue context in swarm memory
 mcp__claude-flow__memory_usage {

--- a/.claude/agents/github/swarm-pr.md
+++ b/.claude/agents/github/swarm-pr.md
@@ -11,11 +11,11 @@ tools:
   - mcp__github__create_pr_comment
   - mcp__github__get_pr_diff
   - mcp__github__merge_pull_request
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
+  - mcp__ruflo__swarm_init
+  - mcp__ruflo__agent_spawn
   - mcp__claude-flow__task_orchestrate
   - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__coordination_sync
+  - mcp__ruflo__coordination_sync
   - TodoWrite
   - TodoRead
   - Bash
@@ -323,12 +323,12 @@ When using with Claude Code:
 ### Multi-Agent PR Analysis
 ```bash
 # Initialize PR-specific swarm with intelligent topology selection
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 8 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "PR Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Test Engineer" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Impact Analyzer" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+mcp__ruflo__swarm_init { topology: "mesh", maxAgents: 8 }
+mcp__ruflo__agent_spawn { type: "coordinator", name: "PR Coordinator" }
+mcp__ruflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__ruflo__agent_spawn { type: "tester", name: "Test Engineer" }
+mcp__ruflo__agent_spawn { type: "analyst", name: "Impact Analyzer" }
+mcp__ruflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
 
 # Store PR context for swarm coordination
 mcp__claude-flow__memory_usage {
@@ -403,7 +403,7 @@ const prPostHook = async (results) => {
 ### Intelligent PR Merge Coordination
 ```bash
 # Coordinate merge decision with swarm consensus
-mcp__claude-flow__coordination_sync { swarmId: "pr-review-swarm" }
+mcp__ruflo__coordination_sync { swarmId: "pr-review-swarm" }
 
 # Analyze merge readiness with multiple agents
 mcp__claude-flow__task_orchestrate {

--- a/.claude/agents/github/sync-coordinator.md
+++ b/.claude/agents/github/sync-coordinator.md
@@ -10,11 +10,11 @@ tools:
   - mcp__github__create_pull_request
   - mcp__github__search_repositories
   - mcp__github__list_repositories
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
+  - mcp__ruflo__swarm_init
+  - mcp__ruflo__agent_spawn
   - mcp__claude-flow__task_orchestrate
   - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__coordination_sync
+  - mcp__ruflo__coordination_sync
   - mcp__claude-flow__load_balance
   - TodoWrite
   - TodoRead
@@ -60,11 +60,11 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 ### 1. Synchronize Package Dependencies
 ```javascript
 // Initialize sync coordination swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__ruflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__ruflo__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
+mcp__ruflo__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
+mcp__ruflo__agent_spawn { type: "coder", name: "Integration Developer" }
+mcp__ruflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 // Analyze current package states
 Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -183,12 +183,12 @@ This integration uses ruv-swarm agents for:
 ```javascript
 [Single Message - Complete Synchronization]:
   // Initialize comprehensive sync swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Package Analyzer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Coder" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Tester" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
+  mcp__ruflo__swarm_init { topology: "mesh", maxAgents: 6 }
+  mcp__ruflo__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
+  mcp__ruflo__agent_spawn { type: "analyst", name: "Package Analyzer" }
+  mcp__ruflo__agent_spawn { type: "coder", name: "Integration Coder" }
+  mcp__ruflo__agent_spawn { type: "tester", name: "Validation Tester" }
+  mcp__ruflo__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
   
   // Read current state of both packages
   Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -327,13 +327,13 @@ const testMatrix = {
 ### Multi-Agent Coordination Architecture
 ```bash
 # Initialize comprehensive synchronization swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 10 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Quality Assurance" }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Sync Monitor" }
+mcp__ruflo__swarm_init { topology: "hierarchical", maxAgents: 10 }
+mcp__ruflo__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
+mcp__ruflo__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
+mcp__ruflo__agent_spawn { type: "coder", name: "Integration Developer" }
+mcp__ruflo__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__ruflo__agent_spawn { type: "reviewer", name: "Quality Assurance" }
+mcp__ruflo__agent_spawn { type: "monitor", name: "Sync Monitor" }
 
 # Orchestrate complex synchronization workflow
 mcp__claude-flow__task_orchestrate {
@@ -415,13 +415,13 @@ mcp__claude-flow__memory_usage {
 ### Swarm-Coordinated Error Recovery
 ```bash
 # Initialize error recovery swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Error Monitor" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Failure Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Recovery Developer" }
+mcp__ruflo__swarm_init { topology: "star", maxAgents: 5 }
+mcp__ruflo__agent_spawn { type: "monitor", name: "Error Monitor" }
+mcp__ruflo__agent_spawn { type: "analyst", name: "Failure Analyzer" }
+mcp__ruflo__agent_spawn { type: "coder", name: "Recovery Developer" }
 
 # Coordinate recovery procedures
-mcp__claude-flow__coordination_sync { swarmId: "error-recovery-swarm" }
+mcp__ruflo__coordination_sync { swarmId: "error-recovery-swarm" }
 
 # Store recovery state
 mcp__claude-flow__memory_usage {

--- a/.claude/agents/github/workflow-automation.md
+++ b/.claude/agents/github/workflow-automation.md
@@ -9,13 +9,13 @@ tools:
   - mcp__github__list_workflows
   - mcp__github__get_workflow_runs
   - mcp__github__create_workflow_dispatch
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
+  - mcp__ruflo__swarm_init
+  - mcp__ruflo__agent_spawn
   - mcp__claude-flow__task_orchestrate
   - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__performance_report
+  - mcp__ruflo__performance_report
   - mcp__claude-flow__bottleneck_analyze
-  - mcp__claude-flow__workflow_create
+  - mcp__ruflo__workflow_create
   - mcp__claude-flow__automation_setup
   - TodoWrite
   - TodoRead
@@ -481,14 +481,14 @@ npx ruv-swarm actions profile \
 ### Multi-Agent Pipeline Orchestration
 ```bash
 # Initialize comprehensive workflow automation swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 12 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Workflow Coordinator" }
-mcp__claude-flow__agent_spawn { type: "architect", name: "Pipeline Architect" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Workflow Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "CI/CD Tester" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Automation Monitor" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Workflow Analyzer" }
+mcp__ruflo__swarm_init { topology: "mesh", maxAgents: 12 }
+mcp__ruflo__agent_spawn { type: "coordinator", name: "Workflow Coordinator" }
+mcp__ruflo__agent_spawn { type: "architect", name: "Pipeline Architect" }
+mcp__ruflo__agent_spawn { type: "coder", name: "Workflow Developer" }
+mcp__ruflo__agent_spawn { type: "tester", name: "CI/CD Tester" }
+mcp__ruflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+mcp__ruflo__agent_spawn { type: "monitor", name: "Automation Monitor" }
+mcp__ruflo__agent_spawn { type: "analyst", name: "Workflow Analyzer" }
 
 # Create intelligent workflow automation rules
 mcp__claude-flow__automation_setup {
@@ -518,7 +518,7 @@ mcp__claude-flow__task_orchestrate {
 ### Intelligent Performance Monitoring
 ```bash
 # Generate comprehensive workflow performance reports
-mcp__claude-flow__performance_report {
+mcp__ruflo__performance_report {
   format: "detailed",
   timeframe: "30d"
 }

--- a/.claude/agents/goal/code-goal-planner.md
+++ b/.claude/agents/goal/code-goal-planner.md
@@ -97,24 +97,14 @@ The SPARC methodology enhances GOAP planning by providing a structured framework
 
 ### SPARC Command Integration
 
-```bash
-# Execute SPARC phases for goal achievement
-npx claude-flow sparc run spec-pseudocode "OAuth2 authentication system"
-npx claude-flow sparc run architect "microservices communication layer"
-npx claude-flow sparc tdd "payment processing feature"
-npx claude-flow sparc pipeline "complete feature implementation"
-
-# Batch processing for complex goals
-npx claude-flow sparc batch spec,arch,refine "user management system"
-npx claude-flow sparc concurrent tdd tasks.json
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run`/`sparc tdd`/`sparc pipeline`/`sparc batch`/`sparc concurrent`. Use the `sparc-methodology` skill for SPARC-phase guidance, or dispatch a role-specific subagent per phase via the Agent tool.
 
 ### SPARC-GOAP Feature Implementation Plan
 ```yaml
 goal: implement_payment_processing_with_sparc
 sparc_phases:
   specification:
-    command: "npx claude-flow sparc run spec-pseudocode 'payment processing'"
+    command: "N/A -- sparc CLI unavailable in v3; use sparc-methodology skill"
     deliverables:
       - requirements_doc
       - acceptance_criteria
@@ -125,7 +115,7 @@ sparc_phases:
       - compliance_standards_identified
       
   pseudocode:
-    command: "npx claude-flow sparc run pseudocode 'payment flow algorithms'"
+    command: "N/A -- sparc CLI unavailable in v3; use sparc-methodology skill"
     deliverables:
       - payment_flow_logic
       - error_handling_patterns
@@ -135,7 +125,7 @@ sparc_phases:
       - edge_cases_covered
       
   architecture:
-    command: "npx claude-flow sparc run architect 'payment system design'"
+    command: "N/A -- sparc CLI unavailable in v3; use sparc-methodology skill"
     deliverables:
       - system_components
       - api_contracts
@@ -145,7 +135,7 @@ sparc_phases:
       - security_layers_defined
       
   refinement:
-    command: "npx claude-flow sparc tdd 'payment feature'"
+    command: "N/A -- sparc CLI unavailable in v3; use sparc-methodology skill"
     deliverables:
       - unit_tests
       - integration_tests
@@ -155,7 +145,7 @@ sparc_phases:
       - all_tests_passing
       
   completion:
-    command: "npx claude-flow sparc run integration 'deploy payment system'"
+    command: "N/A -- sparc CLI unavailable in v3; use sparc-methodology skill"
     deliverables:
       - deployed_system
       - documentation
@@ -330,19 +320,19 @@ async function implementFeatureWithSPARC(feature: string) {
 
 ```javascript
 // Initialize SPARC-enhanced development swarm
-mcp__claude-flow__swarm_init {
+mcp__ruflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 5
 }
 
 // Spawn SPARC-specific agents
-mcp__claude-flow__agent_spawn {
+mcp__ruflo__agent_spawn {
   type: "sparc-coder",
   capabilities: ["specification", "pseudocode", "architecture", "refinement", "completion"]
 }
 
 // Spawn specialized agents
-mcp__claude-flow__agent_spawn {
+mcp__ruflo__agent_spawn {
   type: "coder",
   capabilities: ["refactoring", "optimization"]
 }
@@ -412,22 +402,7 @@ class SPARCGoalPlanner {
 
 ### Example: Complete Feature Implementation
 
-```bash
-# 1. Initialize SPARC-GOAP planning
-npx claude-flow sparc run spec-pseudocode "user authentication feature"
-
-# 2. Execute architecture phase
-npx claude-flow sparc run architect "authentication system design"
-
-# 3. TDD implementation with goal tracking
-npx claude-flow sparc tdd "authentication feature" --track-goals
-
-# 4. Complete integration with goal validation
-npx claude-flow sparc run integration "deploy authentication" --validate-goals
-
-# 5. Verify goal achievement
-npx claude-flow sparc verify "authentication feature complete"
-```
+SPARC-GOAP planning proceeds through the five phases above (specification, pseudocode, architecture, refinement, completion). There is no `sparc` CLI to drive this in ruflo v3 -- use the `sparc-methodology` skill for phase guidance, or dispatch a role-specific subagent per phase via the Agent tool.
 
 ## Continuous Improvement
 

--- a/.claude/agents/goal/goal-planner.md
+++ b/.claude/agents/goal/goal-planner.md
@@ -137,7 +137,7 @@ When handling requests:
 4. Present the plan with clear action sequences and dependencies
 5. Be prepared to replan if conditions change during execution
 
-Integration with Claude Flow:
+Integration with Ruflo:
 - Coordinate with other specialized agents for specific actions
 - Use swarm coordination for parallel action execution
 - Leverage SPARC methodology for structured development tasks

--- a/.claude/agents/neural/safla-neural.md
+++ b/.claude/agents/neural/safla-neural.md
@@ -47,7 +47,7 @@ Your memory system architecture:
 
 ```javascript
 // Initialize SAFLA neural patterns
-mcp__claude-flow__neural_train {
+mcp__ruflo__neural_train {
   pattern_type: "coordination",
   training_data: JSON.stringify({
     architecture: "safla-transformer",

--- a/.claude/agents/reasoning/agent.md
+++ b/.claude/agents/reasoning/agent.md
@@ -48,7 +48,7 @@ A sophisticated Goal-Oriented Action Planning (GOAP) specialist that dynamically
 - `mcp__sublinear-time-solver__calculateLightTravel` - Compute temporal advantages for time-critical planning
 - `mcp__sublinear-time-solver__demonstrateTemporalLead` - Validate predictive planning scenarios
 
-### Claude Flow Integration Tools
+### Ruflo Integration Tools
 - `mcp__flow-nexus__swarm_init` - Initialize multi-agent execution systems
 - `mcp__flow-nexus__task_orchestrate` - Execute planned action sequences
 - `mcp__flow-nexus__agent_spawn` - Create specialized agents for specific goals
@@ -813,4 +813,4 @@ Leverage light-speed delays for predictive planning:
 - Identify emergent opportunities from goal interactions
 - Optimize for multiple success criteria simultaneously
 
-This goal-planner agent represents the cutting edge of AI-driven objective achievement, combining mathematical rigor with practical execution capabilities through the powerful sublinear-time-solver toolkit and Claude Flow ecosystem.
+This goal-planner agent represents the cutting edge of AI-driven objective achievement, combining mathematical rigor with practical execution capabilities through the powerful sublinear-time-solver toolkit and Ruflo ecosystem.

--- a/.claude/agents/reasoning/goal-planner.md
+++ b/.claude/agents/reasoning/goal-planner.md
@@ -58,7 +58,7 @@ mcp__claude-flow__task_orchestrate {
 }
 
 // Coordinate with swarm for parallel planning
-mcp__claude-flow__swarm_init {
+mcp__ruflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 5
 }

--- a/.claude/agents/swarm/adaptive-coordinator.md
+++ b/.claude/agents/swarm/adaptive-coordinator.md
@@ -15,21 +15,21 @@ hooks:
   pre: |
     echo "🔄 Adaptive Coordinator analyzing workload patterns: $TASK"
     # Initialize with auto-detection
-    mcp__claude-flow__swarm_init auto --maxAgents=15 --strategy=adaptive
+    mcp__ruflo__swarm_init auto --maxAgents=15 --strategy=adaptive
     # Analyze current workload patterns
-    mcp__claude-flow__neural_patterns analyze --operation="workload_analysis" --metadata="{\"task\":\"$TASK\"}"
+    mcp__ruflo__neural_patterns analyze --operation="workload_analysis" --metadata="{\"task\":\"$TASK\"}"
     # Train adaptive models
-    mcp__claude-flow__neural_train coordination --training_data="historical_swarm_data" --epochs=30
+    mcp__ruflo__neural_train coordination --training_data="historical_swarm_data" --epochs=30
     # Store baseline metrics
-    mcp__claude-flow__memory_usage store "adaptive:baseline:${TASK_ID}" "$(mcp__claude-flow__performance_report --format=json)" --namespace=adaptive
+    mcp__claude-flow__memory_usage store "adaptive:baseline:${TASK_ID}" "$(mcp__ruflo__performance_report --format=json)" --namespace=adaptive
     # Set up real-time monitoring
     mcp__claude-flow__swarm_monitor --interval=2000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Adaptive coordination complete - topology optimized"
     # Generate comprehensive analysis
-    mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+    mcp__ruflo__performance_report --format=detailed --timeframe=24h
     # Store learning outcomes
-    mcp__claude-flow__neural_patterns learn --operation="coordination_complete" --outcome="success" --metadata="{\"final_topology\":\"$(mcp__claude-flow__swarm_status | jq -r '.topology')\"}"
+    mcp__ruflo__neural_patterns learn --operation="coordination_complete" --outcome="success" --metadata="{\"final_topology\":\"$(mcp__ruflo__swarm_status | jq -r '.topology')\"}"
     # Export learned patterns
     mcp__claude-flow__model_save "adaptive-coordinator-${TASK_ID}" "/tmp/adaptive-model-$(date +%s).json"
     # Update persistent knowledge base
@@ -133,22 +133,22 @@ Switch to HYBRID when:
 ### Pattern Recognition & Learning
 ```bash
 # Analyze coordination patterns
-mcp__claude-flow__neural_patterns analyze --operation="topology_analysis" --metadata="{\"current_topology\":\"mesh\",\"performance_metrics\":{}}"
+mcp__ruflo__neural_patterns analyze --operation="topology_analysis" --metadata="{\"current_topology\":\"mesh\",\"performance_metrics\":{}}"
 
 # Train adaptive models
-mcp__claude-flow__neural_train coordination --training_data="swarm_performance_history" --epochs=50
+mcp__ruflo__neural_train coordination --training_data="swarm_performance_history" --epochs=50
 
 # Make predictions
-mcp__claude-flow__neural_predict --modelId="adaptive-coordinator" --input="{\"workload\":\"high_complexity\",\"agents\":10}"
+mcp__ruflo__neural_predict --modelId="adaptive-coordinator" --input="{\"workload\":\"high_complexity\",\"agents\":10}"
 
 # Learn from outcomes
-mcp__claude-flow__neural_patterns learn --operation="topology_switch" --outcome="improved_performance_15%" --metadata="{\"from\":\"hierarchical\",\"to\":\"mesh\"}"
+mcp__ruflo__neural_patterns learn --operation="topology_switch" --outcome="improved_performance_15%" --metadata="{\"from\":\"hierarchical\",\"to\":\"mesh\"}"
 ```
 
 ### Performance Optimization
 ```bash
 # Real-time performance monitoring
-mcp__claude-flow__performance_report --format=json --timeframe=1h
+mcp__ruflo__performance_report --format=json --timeframe=1h
 
 # Bottleneck analysis
 mcp__claude-flow__bottleneck_analyze --component="coordination" --metrics="latency,throughput,success_rate"
@@ -166,7 +166,7 @@ mcp__claude-flow__load_balance --swarmId="${SWARM_ID}" --strategy="ml_optimized"
 mcp__claude-flow__trend_analysis --metric="agent_utilization" --period="7d"
 
 # Predict resource needs
-mcp__claude-flow__neural_predict --modelId="resource-predictor" --input="{\"time_horizon\":\"4h\",\"current_load\":0.7}"
+mcp__ruflo__neural_predict --modelId="resource-predictor" --input="{\"time_horizon\":\"4h\",\"current_load\":0.7}"
 
 # Auto-scale swarm
 mcp__claude-flow__swarm_scale --swarmId="${SWARM_ID}" --targetSize="12" --strategy="predictive"

--- a/.claude/agents/swarm/hierarchical-coordinator.md
+++ b/.claude/agents/swarm/hierarchical-coordinator.md
@@ -15,7 +15,7 @@ hooks:
   pre: |
     echo "👑 Hierarchical Coordinator initializing swarm: $TASK"
     # Initialize swarm topology
-    mcp__claude-flow__swarm_init hierarchical --maxAgents=10 --strategy=adaptive
+    mcp__ruflo__swarm_init hierarchical --maxAgents=10 --strategy=adaptive
     # MANDATORY: Write initial status to coordination namespace
     mcp__claude-flow__memory_usage store "swarm/hierarchical/status" "{\"agent\":\"hierarchical-coordinator\",\"status\":\"initializing\",\"timestamp\":$(date +%s),\"topology\":\"hierarchical\"}" --namespace=coordination
     # Set up monitoring
@@ -23,11 +23,11 @@ hooks:
   post: |
     echo "✨ Hierarchical coordination complete"
     # Generate performance report
-    mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+    mcp__ruflo__performance_report --format=detailed --timeframe=24h
     # MANDATORY: Write completion status
-    mcp__claude-flow__memory_usage store "swarm/hierarchical/complete" "{\"status\":\"complete\",\"agents_used\":$(mcp__claude-flow__swarm_status | jq '.agents.total'),\"timestamp\":$(date +%s)}" --namespace=coordination
+    mcp__claude-flow__memory_usage store "swarm/hierarchical/complete" "{\"status\":\"complete\",\"agents_used\":$(mcp__ruflo__swarm_status | jq '.agents.total'),\"timestamp\":$(date +%s)}" --namespace=coordination
     # Cleanup resources
-    mcp__claude-flow__coordination_sync --swarmId="${SWARM_ID}"
+    mcp__ruflo__coordination_sync --swarmId="${SWARM_ID}"
 ---
 
 # Hierarchical Swarm Coordinator
@@ -69,22 +69,22 @@ WORKERS WORKERS WORKERS WORKERS
 ### Research Workers 🔬
 - **Capabilities**: Information gathering, market research, competitive analysis
 - **Use Cases**: Requirements analysis, technology research, feasibility studies
-- **Spawn Command**: `mcp__claude-flow__agent_spawn researcher --capabilities="research,analysis,information_gathering"`
+- **Spawn Command**: `mcp__ruflo__agent_spawn researcher --capabilities="research,analysis,information_gathering"`
 
 ### Code Workers 💻  
 - **Capabilities**: Implementation, code review, testing, documentation
 - **Use Cases**: Feature development, bug fixes, code optimization
-- **Spawn Command**: `mcp__claude-flow__agent_spawn coder --capabilities="code_generation,testing,optimization"`
+- **Spawn Command**: `mcp__ruflo__agent_spawn coder --capabilities="code_generation,testing,optimization"`
 
 ### Analyst Workers 📊
 - **Capabilities**: Data analysis, performance monitoring, reporting
 - **Use Cases**: Metrics analysis, performance optimization, reporting
-- **Spawn Command**: `mcp__claude-flow__agent_spawn analyst --capabilities="data_analysis,performance_monitoring,reporting"`
+- **Spawn Command**: `mcp__ruflo__agent_spawn analyst --capabilities="data_analysis,performance_monitoring,reporting"`
 
 ### Test Workers 🧪
 - **Capabilities**: Quality assurance, validation, compliance checking
 - **Use Cases**: Testing, validation, quality gates
-- **Spawn Command**: `mcp__claude-flow__agent_spawn tester --capabilities="testing,validation,quality_assurance"`
+- **Spawn Command**: `mcp__ruflo__agent_spawn tester --capabilities="testing,validation,quality_assurance"`
 
 ## Coordination Workflow
 
@@ -218,12 +218,12 @@ mcp__claude-flow__memory_usage {
 ### Swarm Management
 ```bash
 # Initialize hierarchical swarm
-mcp__claude-flow__swarm_init hierarchical --maxAgents=10 --strategy=centralized
+mcp__ruflo__swarm_init hierarchical --maxAgents=10 --strategy=centralized
 
 # Spawn specialized workers
-mcp__claude-flow__agent_spawn researcher --capabilities="research,analysis"
-mcp__claude-flow__agent_spawn coder --capabilities="implementation,testing"  
-mcp__claude-flow__agent_spawn analyst --capabilities="data_analysis,reporting"
+mcp__ruflo__agent_spawn researcher --capabilities="research,analysis"
+mcp__ruflo__agent_spawn coder --capabilities="implementation,testing"  
+mcp__ruflo__agent_spawn analyst --capabilities="data_analysis,reporting"
 
 # Monitor swarm health
 mcp__claude-flow__swarm_monitor --interval=5000
@@ -238,13 +238,13 @@ mcp__claude-flow__task_orchestrate "Build authentication service" --strategy=seq
 mcp__claude-flow__load_balance --tasks="auth_api,auth_tests,auth_docs" --strategy=capability_based
 
 # Sync coordination state
-mcp__claude-flow__coordination_sync --namespace=hierarchy
+mcp__ruflo__coordination_sync --namespace=hierarchy
 ```
 
 ### Performance & Analytics
 ```bash
 # Generate performance reports
-mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+mcp__ruflo__performance_report --format=detailed --timeframe=24h
 
 # Analyze bottlenecks
 mcp__claude-flow__bottleneck_analyze --component=coordination --metrics="throughput,latency,success_rate"

--- a/.claude/agents/swarm/mesh-coordinator.md
+++ b/.claude/agents/swarm/mesh-coordinator.md
@@ -15,7 +15,7 @@ hooks:
   pre: |
     echo "🌐 Mesh Coordinator establishing peer network: $TASK"
     # Initialize mesh topology
-    mcp__claude-flow__swarm_init mesh --maxAgents=12 --strategy=distributed
+    mcp__ruflo__swarm_init mesh --maxAgents=12 --strategy=distributed
     # Set up peer discovery and communication
     mcp__claude-flow__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_init\",\"topology\":\"mesh\"}"
     # Initialize consensus mechanisms
@@ -25,9 +25,9 @@ hooks:
   post: |
     echo "✨ Mesh coordination complete - network resilient"
     # Generate network analysis
-    mcp__claude-flow__performance_report --format=json --timeframe=24h
+    mcp__ruflo__performance_report --format=json --timeframe=24h
     # Store final network metrics
-    mcp__claude-flow__memory_usage store "mesh:metrics:${TASK_ID}" "$(mcp__claude-flow__swarm_status)" --namespace=mesh
+    mcp__claude-flow__memory_usage store "mesh:metrics:${TASK_ID}" "$(mcp__ruflo__swarm_status)" --namespace=mesh
     # Graceful network shutdown
     mcp__claude-flow__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_shutdown\",\"reason\":\"task_complete\"}"
 ---
@@ -190,7 +190,7 @@ class TaskAuction:
 ### Network Management
 ```bash
 # Initialize mesh network
-mcp__claude-flow__swarm_init mesh --maxAgents=12 --strategy=distributed
+mcp__ruflo__swarm_init mesh --maxAgents=12 --strategy=distributed
 
 # Establish peer connections
 mcp__claude-flow__daa_communication --from="node-1" --to="node-2" --message="{\"type\":\"peer_connect\"}"
@@ -208,7 +208,7 @@ mcp__claude-flow__daa_consensus --agents="all" --proposal="{\"task_assignment\":
 mcp__claude-flow__daa_consensus --agents="current" --vote="approve" --proposal_id="prop-123"
 
 # Monitor consensus status
-mcp__claude-flow__neural_patterns analyze --operation="consensus_tracking" --outcome="decision_approved"
+mcp__ruflo__neural_patterns analyze --operation="consensus_tracking" --outcome="decision_approved"
 ```
 
 ### Fault Tolerance

--- a/.claude/agents/templates/migration-plan.md
+++ b/.claude/agents/templates/migration-plan.md
@@ -25,7 +25,7 @@ hooks:
     echo "🚀 Ready for systematic agent system rollout"
 ---
 
-# Claude Flow Commands to Agent System Migration Plan
+# Ruflo Commands to Agent System Migration Plan
 
 ## Overview
 This document provides a comprehensive migration plan to convert existing .claude/commands to the new agent-based system. Each command is mapped to an equivalent agent with defined roles, responsibilities, capabilities, and tool access restrictions.
@@ -75,7 +75,7 @@ capabilities:
   - network-configuration
 tools:
   allowed:
-    - mcp__claude-flow__swarm_init
+    - mcp__ruflo__swarm_init
     - mcp__claude-flow__topology_optimize
     - mcp__claude-flow__memory_usage
     - TodoWrite
@@ -107,9 +107,9 @@ capabilities:
   - pattern-recognition
 tools:
   allowed:
-    - mcp__claude-flow__agent_spawn
-    - mcp__claude-flow__daa_agent_create
-    - mcp__claude-flow__agent_list
+    - mcp__ruflo__agent_spawn
+    - mcp__ruflo__daa_agent_create
+    - mcp__ruflo__agent_list
     - mcp__claude-flow__memory_usage
   restricted:
     - Bash
@@ -142,7 +142,7 @@ capabilities:
 tools:
   allowed:
     - mcp__claude-flow__task_orchestrate
-    - mcp__claude-flow__task_status
+    - mcp__ruflo__task_status
     - mcp__claude-flow__task_results
     - mcp__claude-flow__parallel_execute
     - TodoWrite
@@ -180,8 +180,8 @@ capabilities:
 tools:
   allowed:
     - Bash  # For gh CLI commands
-    - mcp__claude-flow__swarm_init
-    - mcp__claude-flow__agent_spawn
+    - mcp__ruflo__swarm_init
+    - mcp__ruflo__agent_spawn
     - mcp__claude-flow__task_orchestrate
     - mcp__claude-flow__memory_usage
     - TodoWrite
@@ -218,8 +218,8 @@ tools:
     - Bash  # For gh CLI
     - Read
     - Grep
-    - mcp__claude-flow__swarm_init
-    - mcp__claude-flow__agent_spawn
+    - mcp__ruflo__swarm_init
+    - mcp__ruflo__agent_spawn
     - mcp__claude-flow__github_code_review
     - mcp__claude-flow__memory_usage
   restricted:
@@ -254,7 +254,7 @@ tools:
     - Bash
     - Read
     - mcp__claude-flow__github_release_coord
-    - mcp__claude-flow__swarm_init
+    - mcp__ruflo__swarm_init
     - mcp__claude-flow__task_orchestrate
     - TodoWrite
   restricted:
@@ -289,8 +289,8 @@ capabilities:
 tools:
   allowed:
     - mcp__claude-flow__sparc_mode
-    - mcp__claude-flow__swarm_init
-    - mcp__claude-flow__agent_spawn
+    - mcp__ruflo__swarm_init
+    - mcp__ruflo__agent_spawn
     - mcp__claude-flow__task_orchestrate
     - TodoWrite
     - TodoRead
@@ -333,7 +333,7 @@ tools:
     - mcp__claude-flow__sparc_mode
     - TodoWrite
   restricted:
-    - mcp__claude-flow__swarm_init  # Focus on implementation
+    - mcp__ruflo__swarm_init  # Focus on implementation
 triggers:
   - pattern: "implement|code|develop|build.*feature"
     priority: high
@@ -368,7 +368,7 @@ tools:
     - TodoWrite
     - mcp__claude-flow__parallel_execute
   restricted:
-    - mcp__claude-flow__swarm_init
+    - mcp__ruflo__swarm_init
 triggers:
   - pattern: "test|verify|validate|check.*quality"
     priority: high
@@ -398,7 +398,7 @@ capabilities:
 tools:
   allowed:
     - mcp__claude-flow__bottleneck_analyze
-    - mcp__claude-flow__performance_report
+    - mcp__ruflo__performance_report
     - mcp__claude-flow__metrics_collect
     - mcp__claude-flow__trend_analysis
     - Read
@@ -473,7 +473,7 @@ tools:
     - mcp__claude-flow__memory_usage
     - mcp__claude-flow__memory_search
     - mcp__claude-flow__memory_namespace
-    - mcp__claude-flow__memory_compress
+    - mcp__ruflo__memory_compress
     - mcp__claude-flow__memory_sync
   restricted:
     - Write
@@ -505,9 +505,9 @@ capabilities:
   - transfer-learning
 tools:
   allowed:
-    - mcp__claude-flow__neural_train
-    - mcp__claude-flow__neural_patterns
-    - mcp__claude-flow__neural_predict
+    - mcp__ruflo__neural_train
+    - mcp__ruflo__neural_patterns
+    - mcp__ruflo__neural_predict
     - mcp__claude-flow__cognitive_analyze
     - mcp__claude-flow__learning_adapt
   restricted:
@@ -542,7 +542,7 @@ capabilities:
   - auto-scaling
 tools:
   allowed:
-    - mcp__claude-flow__daa_agent_create
+    - mcp__ruflo__daa_agent_create
     - mcp__claude-flow__daa_capability_match
     - mcp__claude-flow__daa_resource_alloc
     - mcp__claude-flow__swarm_scale
@@ -616,7 +616,7 @@ tools:
     - mcp__claude-flow__parallel_execute
     - mcp__claude-flow__load_balance
     - mcp__claude-flow__batch_process
-    - mcp__claude-flow__performance_report
+    - mcp__ruflo__performance_report
     - TodoWrite
   restricted:
     - Write
@@ -649,8 +649,8 @@ tools:
   allowed:
     - mcp__claude-flow__topology_optimize
     - mcp__claude-flow__swarm_monitor
-    - mcp__claude-flow__coordination_sync
-    - mcp__claude-flow__swarm_status
+    - mcp__ruflo__coordination_sync
+    - mcp__ruflo__swarm_status
     - mcp__claude-flow__metrics_collect
   restricted:
     - Write
@@ -684,11 +684,11 @@ capabilities:
   - alert-generation
 tools:
   allowed:
-    - mcp__claude-flow__swarm_status
+    - mcp__ruflo__swarm_status
     - mcp__claude-flow__swarm_monitor
     - mcp__claude-flow__agent_metrics
     - mcp__claude-flow__health_check
-    - mcp__claude-flow__performance_report
+    - mcp__ruflo__performance_report
   restricted:
     - Write
     - Edit

--- a/.claude/commands/agents/README.md
+++ b/.claude/commands/agents/README.md
@@ -1,6 +1,6 @@
 # Agents Commands
 
-Commands for agents operations in Claude Flow.
+Commands for agents operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/agents/agent-spawning.md
+++ b/.claude/commands/agents/agent-spawning.md
@@ -17,8 +17,8 @@ Task("Tester", "Create tests...", "tester")
 
 MCP tools are ONLY for coordination:
 ```javascript
-mcp__claude-flow__swarm_init { topology: "mesh" }
-mcp__claude-flow__agent_spawn { type: "researcher" }
+mcp__ruflo__swarm_init { topology: "mesh" }
+mcp__ruflo__agent_spawn { type: "researcher" }
 ```
 
 ## Best Practices

--- a/.claude/commands/agents/agent-types.md
+++ b/.claude/commands/agents/agent-types.md
@@ -1,6 +1,6 @@
 # agent-types
 
-Complete guide to all 54 available agent types in Claude Flow.
+Complete guide to all 54 available agent types in Ruflo.
 
 ## Core Development Agents
 - `coder` - Implementation specialist

--- a/.claude/commands/analysis/README.md
+++ b/.claude/commands/analysis/README.md
@@ -1,6 +1,6 @@
 # Analysis Commands
 
-Commands for analysis operations in Claude Flow.
+Commands for analysis operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/automation/README.md
+++ b/.claude/commands/automation/README.md
@@ -1,6 +1,6 @@
 # Automation Commands
 
-Commands for automation operations in Claude Flow.
+Commands for automation operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/automation/self-healing.md
+++ b/.claude/commands/automation/self-healing.md
@@ -56,7 +56,7 @@ mcp__claude-flow__memory_usage({
 })
 
 // Analyze patterns
-mcp__claude-flow__neural_patterns({
+mcp__ruflo__neural_patterns({
   "action": "analyze",
   "operation": "error-recovery",
   "outcome": "success"
@@ -68,14 +68,14 @@ mcp__claude-flow__neural_patterns({
 ### MCP Tool Coordination
 ```javascript
 // Initialize self-healing swarm
-mcp__claude-flow__swarm_init({
+mcp__ruflo__swarm_init({
   "topology": "star",
   "maxAgents": 4,
   "strategy": "adaptive"
 })
 
 // Spawn recovery agents
-mcp__claude-flow__agent_spawn({
+mcp__ruflo__agent_spawn({
   "type": "monitor",
   "name": "Error Monitor",
   "capabilities": ["error-detection", "recovery"]

--- a/.claude/commands/automation/session-memory.md
+++ b/.claude/commands/automation/session-memory.md
@@ -77,7 +77,7 @@ mcp__claude-flow__memory_backup({
 **Manual control:**
 ```bash
 # View stored memory
-ls .claude-flow/memory/
+ls .ruflo/memory/
 
 # Disable memory
 export CLAUDE_FLOW_MEMORY_PERSIST=false

--- a/.claude/commands/automation/smart-agents.md
+++ b/.claude/commands/automation/smart-agents.md
@@ -30,7 +30,7 @@ The system monitors workload and spawns additional agents when:
 **Status Monitoring:**
 ```javascript
 // Check swarm health
-mcp__claude-flow__swarm_status({
+mcp__ruflo__swarm_status({
   "swarmId": "current"
 })
 
@@ -43,17 +43,17 @@ mcp__claude-flow__agent_metrics({
 ## Configuration
 
 ### MCP Tool Integration
-Uses Claude Flow MCP tools for agent coordination:
+Uses Ruflo MCP tools for agent coordination:
 ```javascript
 // Initialize swarm with appropriate topology
-mcp__claude-flow__swarm_init({
+mcp__ruflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 8,
   "strategy": "auto"
 })
 
 // Spawn agents based on file type
-mcp__claude-flow__agent_spawn({
+mcp__ruflo__agent_spawn({
   "type": "coder",
   "name": "JavaScript Handler",
   "capabilities": ["javascript", "typescript"]

--- a/.claude/commands/coordination/README.md
+++ b/.claude/commands/coordination/README.md
@@ -1,6 +1,6 @@
 # Coordination Commands
 
-Commands for coordination operations in Claude Flow.
+Commands for coordination operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/coordination/init.md
+++ b/.claude/commands/coordination/init.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__swarm_init`
+**Tool:** `mcp__ruflo__swarm_init`
 
 ## Parameters
 ```json
@@ -27,7 +27,7 @@ Remember: This does NOT create actual coding agents. It creates a coordination p
 ## Example Usage
 
 **In Claude Code:**
-1. Use the tool: `mcp__claude-flow__swarm_init`
+1. Use the tool: `mcp__ruflo__swarm_init`
 2. With parameters: `{"topology": "mesh", "maxAgents": 5, "strategy": "balanced"}`
 3. Claude Code then executes the coordinated plan using its native tools
 

--- a/.claude/commands/coordination/spawn.md
+++ b/.claude/commands/coordination/spawn.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__agent_spawn`
+**Tool:** `mcp__ruflo__agent_spawn`
 
 ## Parameters
 ```json
@@ -28,7 +28,7 @@ These patterns guide how Claude Code approaches different aspects of your task.
 ## Example Usage
 
 **In Claude Code:**
-1. Use the tool: `mcp__claude-flow__agent_spawn`
+1. Use the tool: `mcp__ruflo__agent_spawn`
 2. With parameters: `{"type": "researcher", "name": "Literature Analysis", "capabilities": ["deep-analysis"]}`
 3. Claude Code then executes the coordinated plan using its native tools
 

--- a/.claude/commands/coordination/swarm-init.md
+++ b/.claude/commands/coordination/swarm-init.md
@@ -1,6 +1,6 @@
 # swarm init
 
-Initialize a Claude Flow swarm with specified topology and configuration.
+Initialize a Ruflo swarm with specified topology and configuration.
 
 ## Usage
 
@@ -74,7 +74,7 @@ npx claude-flow swarm init --topology star --github --memory
 Once initialized, use MCP tools in Claude Code:
 
 ```javascript
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 8 }
+mcp__ruflo__swarm_init { topology: "hierarchical", maxAgents: 8 }
 ```
 
 ## See Also

--- a/.claude/commands/github/README.md
+++ b/.claude/commands/github/README.md
@@ -1,6 +1,6 @@
 # Github Commands
 
-Commands for github operations in Claude Flow.
+Commands for github operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/hive-mind/README.md
+++ b/.claude/commands/hive-mind/README.md
@@ -1,6 +1,6 @@
 # Hive-mind Commands
 
-Commands for hive-mind operations in Claude Flow.
+Commands for hive-mind operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/hooks/README.md
+++ b/.claude/commands/hooks/README.md
@@ -1,6 +1,6 @@
 # Hooks Commands
 
-Commands for hooks operations in Claude Flow.
+Commands for hooks operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/memory/README.md
+++ b/.claude/commands/memory/README.md
@@ -1,6 +1,6 @@
 # Memory Commands
 
-Commands for memory operations in Claude Flow.
+Commands for memory operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/memory/neural.md
+++ b/.claude/commands/memory/neural.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__neural_train`
+**Tool:** `mcp__ruflo__neural_train`
 
 ## Parameters
 ```json
@@ -29,10 +29,10 @@ Training improves:
 ## Example Usage
 
 **In Claude Code:**
-1. Train coordination patterns: Use tool `mcp__claude-flow__neural_train` with parameters `{"pattern_type": "coordination", "training_data": "successful task patterns", "epochs": 50}`
-2. Train optimization patterns: Use tool `mcp__claude-flow__neural_train` with parameters `{"pattern_type": "optimization", "training_data": "performance metrics", "epochs": 30}`
-3. Check training status: Use tool `mcp__claude-flow__neural_status`
-4. Analyze patterns: Use tool `mcp__claude-flow__neural_patterns` with parameters `{"action": "analyze"}`
+1. Train coordination patterns: Use tool `mcp__ruflo__neural_train` with parameters `{"pattern_type": "coordination", "training_data": "successful task patterns", "epochs": 50}`
+2. Train optimization patterns: Use tool `mcp__ruflo__neural_train` with parameters `{"pattern_type": "optimization", "training_data": "performance metrics", "epochs": 30}`
+3. Check training status: Use tool `mcp__ruflo__neural_status`
+4. Analyze patterns: Use tool `mcp__ruflo__neural_patterns` with parameters `{"action": "analyze"}`
 
 ## Important Reminders
 - ✅ This tool provides coordination and structure

--- a/.claude/commands/monitoring/README.md
+++ b/.claude/commands/monitoring/README.md
@@ -1,6 +1,6 @@
 # Monitoring Commands
 
-Commands for monitoring operations in Claude Flow.
+Commands for monitoring operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/monitoring/agents.md
+++ b/.claude/commands/monitoring/agents.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__agent_list`
+**Tool:** `mcp__ruflo__agent_list`
 
 ## Parameters
 ```json
@@ -27,7 +27,7 @@ Filters:
 ## Example Usage
 
 **In Claude Code:**
-1. List all agents: Use tool `mcp__claude-flow__agent_list`
+1. List all agents: Use tool `mcp__ruflo__agent_list`
 2. Get specific agent metrics: Use tool `mcp__claude-flow__agent_metrics` with parameters `{"agentId": "coder-123"}`
 3. Monitor agent performance: Use tool `mcp__claude-flow__swarm_monitor` with parameters `{"interval": 2000}`
 

--- a/.claude/commands/monitoring/status.md
+++ b/.claude/commands/monitoring/status.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__swarm_status`
+**Tool:** `mcp__ruflo__swarm_status`
 
 ## Parameters
 ```json
@@ -28,7 +28,7 @@ Shows:
 ## Example Usage
 
 **In Claude Code:**
-1. Check swarm status: Use tool `mcp__claude-flow__swarm_status`
+1. Check swarm status: Use tool `mcp__ruflo__swarm_status`
 2. Monitor in real-time: Use tool `mcp__claude-flow__swarm_monitor` with parameters `{"interval": 1000}`
 3. Get agent metrics: Use tool `mcp__claude-flow__agent_metrics` with parameters `{"agentId": "agent-123"}`
 4. Health check: Use tool `mcp__claude-flow__health_check` with parameters `{"components": ["swarm", "memory", "neural"]}`

--- a/.claude/commands/optimization/README.md
+++ b/.claude/commands/optimization/README.md
@@ -1,6 +1,6 @@
 # Optimization Commands
 
-Commands for optimization operations in Claude Flow.
+Commands for optimization operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/sparc/analyzer.md
+++ b/.claude/commands/sparc/analyzer.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run analyzer "analyze codebase performance"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run analyzer "analyze codebase performance"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run analyzer "analyze codebase performance"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run analyzer "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `analyzer`-type work (e.g. `analyze codebase performance`).
 
 ## Core Capabilities
 - Code analysis with parallel file processing

--- a/.claude/commands/sparc/architect.md
+++ b/.claude/commands/sparc/architect.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run architect "design microservices architecture"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run architect "design microservices architecture"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run architect "design microservices architecture"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run architect "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `architect`-type work (e.g. `design microservices architecture`).
 
 ## Core Capabilities
 - System architecture design

--- a/.claude/commands/sparc/batch-executor.md
+++ b/.claude/commands/sparc/batch-executor.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run batch-executor "process multiple files"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run batch-executor "process multiple files"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run batch-executor "process multiple files"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run batch-executor "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `batch-executor`-type work (e.g. `process multiple files`).
 
 ## Core Capabilities
 - Parallel file operations

--- a/.claude/commands/sparc/coder.md
+++ b/.claude/commands/sparc/coder.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run coder "implement user authentication"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run coder "implement user authentication"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run coder "implement user authentication"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run coder "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `coder`-type work (e.g. `implement user authentication`).
 
 ## Core Capabilities
 - Feature implementation

--- a/.claude/commands/sparc/debugger.md
+++ b/.claude/commands/sparc/debugger.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run debugger "fix authentication issues"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run debugger "fix authentication issues"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run debugger "fix authentication issues"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run debugger "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `debugger`-type work (e.g. `fix authentication issues`).
 
 ## Core Capabilities
 - Issue reproduction

--- a/.claude/commands/sparc/designer.md
+++ b/.claude/commands/sparc/designer.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run designer "create dashboard UI"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run designer "create dashboard UI"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run designer "create dashboard UI"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run designer "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `designer`-type work (e.g. `create dashboard UI`).
 
 ## Core Capabilities
 - Interface design

--- a/.claude/commands/sparc/documenter.md
+++ b/.claude/commands/sparc/documenter.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run documenter "create API documentation"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run documenter "create API documentation"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run documenter "create API documentation"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run documenter "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `documenter`-type work (e.g. `create API documentation`).
 
 ## Core Capabilities
 - API documentation

--- a/.claude/commands/sparc/innovator.md
+++ b/.claude/commands/sparc/innovator.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run innovator "innovative solutions for scaling"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run innovator "innovative solutions for scaling"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run innovator "innovative solutions for scaling"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run innovator "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `innovator`-type work (e.g. `innovative solutions for scaling`).
 
 ## Core Capabilities
 - Creative ideation

--- a/.claude/commands/sparc/memory-manager.md
+++ b/.claude/commands/sparc/memory-manager.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run memory-manager "organize project knowledge"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run memory-manager "organize project knowledge"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run memory-manager "organize project knowledge"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run memory-manager "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `memory-manager`-type work (e.g. `organize project knowledge`).
 
 ## Core Capabilities
 - Knowledge organization

--- a/.claude/commands/sparc/optimizer.md
+++ b/.claude/commands/sparc/optimizer.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run optimizer "optimize application performance"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run optimizer "optimize application performance"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run optimizer "optimize application performance"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run optimizer "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `optimizer`-type work (e.g. `optimize application performance`).
 
 ## Core Capabilities
 - Performance profiling

--- a/.claude/commands/sparc/researcher.md
+++ b/.claude/commands/sparc/researcher.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run researcher "research AI trends 2024"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run researcher "research AI trends 2024"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run researcher "research AI trends 2024"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run researcher "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `researcher`-type work (e.g. `research AI trends 2024`).
 
 ## Core Capabilities
 - Information gathering

--- a/.claude/commands/sparc/reviewer.md
+++ b/.claude/commands/sparc/reviewer.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run reviewer "review pull request #123"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run reviewer "review pull request #123"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run reviewer "review pull request #123"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run reviewer "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `reviewer`-type work (e.g. `review pull request #123`).
 
 ## Core Capabilities
 - Code quality assessment

--- a/.claude/commands/sparc/swarm-coordinator.md
+++ b/.claude/commands/sparc/swarm-coordinator.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run swarm-coordinator "manage development swarm"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run swarm-coordinator "manage development swarm"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run swarm-coordinator "manage development swarm"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run swarm-coordinator "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `swarm-coordinator`-type work (e.g. `manage development swarm`).
 
 ## Core Capabilities
 - Swarm initialization

--- a/.claude/commands/sparc/tdd.md
+++ b/.claude/commands/sparc/tdd.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run tdd "shopping cart feature"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run tdd "shopping cart feature"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run tdd "shopping cart feature"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run tdd "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `tdd`-type work (e.g. `shopping cart feature`).
 
 ## Core Capabilities
 - Test-first development

--- a/.claude/commands/sparc/tester.md
+++ b/.claude/commands/sparc/tester.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run tester "full regression suite"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run tester "full regression suite"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run tester "full regression suite"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run tester "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `tester`-type work (e.g. `full regression suite`).
 
 ## Core Capabilities
 - Test planning

--- a/.claude/commands/sparc/workflow-manager.md
+++ b/.claude/commands/sparc/workflow-manager.md
@@ -17,20 +17,9 @@ mcp__claude-flow__sparc_mode {
 }
 ```
 
-### Option 2: Using NPX CLI (Fallback when MCP not available)
-```bash
-# Use when running from terminal or MCP tools unavailable
-npx claude-flow sparc run workflow-manager "automate deployment"
+### Option 2: SPARC CLI is unavailable in v3
 
-# For alpha features
-npx claude-flow@alpha sparc run workflow-manager "automate deployment"
-```
-
-### Option 3: Local Installation
-```bash
-# If claude-flow is installed locally
-./claude-flow sparc run workflow-manager "automate deployment"
-```
+The `sparc` subcommand does not exist in ruflo v3 (`npx -y ruflo@3.14.2 sparc --help` returns `[ERROR] Unknown command: sparc`) -- there is no CLI equivalent to `sparc run workflow-manager "..."`. Use the `sparc-methodology` skill for SPARC-workflow guidance, or dispatch a role-specific subagent via the Agent tool for `workflow-manager`-type work (e.g. `automate deployment`).
 
 ## Core Capabilities
 - Workflow design

--- a/.claude/commands/swarm/README.md
+++ b/.claude/commands/swarm/README.md
@@ -1,6 +1,6 @@
 # Swarm Commands
 
-Commands for swarm operations in Claude Flow.
+Commands for swarm operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/swarm/swarm.md
+++ b/.claude/commands/swarm/swarm.md
@@ -1,27 +1,24 @@
 # swarm
 
-Main swarm orchestration command for Claude Flow.
+Main swarm orchestration command for Ruflo.
 
 ## Usage
 ```bash
-npx claude-flow swarm <objective> [options]
+npx ruflo swarm start -o <objective> [options]
 ```
 
 ## Options
-- `--strategy <type>` - Execution strategy (research, development, analysis, testing)
-- `--mode <type>` - Coordination mode (centralized, distributed, hierarchical, mesh)
-- `--max-agents <n>` - Maximum number of agents (default: 5)
-- `--claude` - Open Claude Code CLI with swarm prompt
-- `--parallel` - Enable parallel execution
+- `-s, --strategy <type>` - Execution strategy
+- `-p, --parallel` - Enable parallel execution (default: true)
+- `--monitor` - Enable real-time monitoring (default: true)
+
+`--mode`, `--max-agents`, `--config`, and `--claude` (v2-only flags) have no v3 equivalent and are not available.
 
 ## Examples
 ```bash
 # Basic swarm
-npx claude-flow swarm "Build REST API"
+npx ruflo swarm start -o "Build REST API"
 
 # With strategy
-npx claude-flow swarm "Research AI patterns" --strategy research
-
-# Open in Claude Code
-npx claude-flow swarm "Build API" --claude
+npx ruflo swarm start -o "Research AI patterns" -s research
 ```

--- a/.claude/commands/training/README.md
+++ b/.claude/commands/training/README.md
@@ -1,6 +1,6 @@
 # Training Commands
 
-Commands for training operations in Claude Flow.
+Commands for training operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/training/neural-patterns.md
+++ b/.claude/commands/training/neural-patterns.md
@@ -14,7 +14,7 @@ Every successful operation trains the neural networks:
 
 ### 2. Manual Training
 ```
-Tool: mcp__claude-flow__neural_train
+Tool: mcp__ruflo__neural_train
 Parameters: {
   "pattern_type": "coordination",
   "training_data": "successful task patterns",
@@ -34,7 +34,7 @@ Parameters: {
 
 ### 4. Improvement Tracking
 ```
-Tool: mcp__claude-flow__neural_status
+Tool: mcp__ruflo__neural_status
 Result: {
   "patterns": {
     "convergent": 0.92,
@@ -48,7 +48,7 @@ Result: {
 
 ## Pattern Analysis
 ```
-Tool: mcp__claude-flow__neural_patterns
+Tool: mcp__ruflo__neural_patterns
 Parameters: {
   "action": "analyze",
   "operation": "recent_edits"

--- a/.claude/commands/training/specialization.md
+++ b/.claude/commands/training/specialization.md
@@ -14,7 +14,7 @@ Agents automatically specialize based on file extensions:
 
 ### 2. By Task Type
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__ruflo__agent_spawn
 Parameters: {
   "type": "coder",
   "capabilities": ["react", "typescript", "testing"],
@@ -32,7 +32,7 @@ The system trains through:
 ### 4. Specialization Benefits
 ```
 # Check agent specializations
-Tool: mcp__claude-flow__agent_list
+Tool: mcp__ruflo__agent_list
 Parameters: {"swarmId": "current"}
 
 Result shows expertise levels:

--- a/.claude/commands/workflows/README.md
+++ b/.claude/commands/workflows/README.md
@@ -1,6 +1,6 @@
 # Workflows Commands
 
-Commands for workflows operations in Claude Flow.
+Commands for workflows operations in Ruflo.
 
 ## Available Commands
 

--- a/.claude/commands/workflows/development.md
+++ b/.claude/commands/workflows/development.md
@@ -7,14 +7,14 @@ Structure Claude Code's approach to complex development tasks for maximum effici
 
 ### 1. Initialize Development Framework
 ```
-Tool: mcp__claude-flow__swarm_init
+Tool: mcp__ruflo__swarm_init
 Parameters: {"topology": "hierarchical", "maxAgents": 8, "strategy": "specialized"}
 ```
 Creates hierarchical structure for organized, top-down development.
 
 ### 2. Define Development Perspectives
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__ruflo__agent_spawn
 Parameters: {
   "type": "architect",
   "name": "System Design",
@@ -22,7 +22,7 @@ Parameters: {
 }
 ```
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__ruflo__agent_spawn
 Parameters: {
   "type": "coder",
   "name": "Implementation Focus",
@@ -30,7 +30,7 @@ Parameters: {
 }
 ```
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__ruflo__agent_spawn
 Parameters: {
   "type": "tester",
   "name": "Quality Assurance",
@@ -52,7 +52,7 @@ Parameters: {
 
 ### 4. Monitor Progress
 ```
-Tool: mcp__claude-flow__task_status
+Tool: mcp__ruflo__task_status
 Parameters: {"taskId": "api-build-task-123"}
 ```
 

--- a/.claude/commands/workflows/research.md
+++ b/.claude/commands/workflows/research.md
@@ -7,18 +7,18 @@ Coordinate Claude Code's research activities for comprehensive, systematic explo
 
 ### 1. Initialize Research Framework
 ```
-Tool: mcp__claude-flow__swarm_init
+Tool: mcp__ruflo__swarm_init
 Parameters: {"topology": "mesh", "maxAgents": 5, "strategy": "balanced"}
 ```
 Creates a mesh topology for comprehensive exploration from multiple angles.
 
 ### 2. Define Research Perspectives
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__ruflo__agent_spawn
 Parameters: {"type": "researcher", "name": "Literature Review"}
 ```
 ```
-Tool: mcp__claude-flow__agent_spawn  
+Tool: mcp__ruflo__agent_spawn  
 Parameters: {"type": "analyst", "name": "Data Analysis"}
 ```
 Sets up different analytical approaches for Claude Code to use.


### PR DESCRIPTION
## Business Summary

**What shipped:** Claude Code scaffold docs (`.claude/commands`, `.claude/agents`) now correctly point agents at the live `ruflo` toolset instead of the dead `claude-flow` name, for the subset of tool references and CLI examples that map cleanly — 19 renamed tools, plain brand-name mentions, and two fully-verified CLI command patterns.

**Quality bar:** Investigation found the original issue's scope description ("Haiku-tier mechanical find-and-replace") was wrong on contact with the real registry diff — of 61 distinct tool names referenced, only 19 have a real `ruflo` equivalent; a blind rename would have shipped scaffold docs pointing at tools that don't exist. Split into two explicit waves with the user rather than either rushing a broken rename or stalling on the full scope. This PR (Wave A) covers only what's fully grounded against the live `ruflo` tool registry and CLI (`--help` output, not documentation). Went through `plan-review-skill` given the scale even though not procedurally required — the review caught a real mistake (the `swarm` CLI family looked uniform but wasn't; narrowed from 29 to 3 covered occurrences before implementing) that would have shipped broken command examples if unreviewed.

**Found along the way:** Wave B — the remaining 42 tools with no `ruflo` equivalent, the `hook` CLI family, and every other un-grounded CLI family (github, hive-mind, workflow, training, etc.) — filed as SMI-5777 rather than bundled here, since each needs its own per-occurrence editorial judgment (map to closest tool / rewrite / drop) that deserves focused review.

**Net result:** Wave A fully shipped. Wave B tracked separately, not blocking.

---

## Technical detail

- `.claude/commands/**` (91 files) + `.claude/agents/**` (37 files), 71 touched.
- **19-tool rename**: `mcp__claude-flow__<X>` → `mcp__ruflo__<X>` for tools with a confirmed 1:1 equivalent in the live registry (`agent_list`, `agent_spawn`, `coordination_sync`, `daa_agent_create`, `github_issue_track`, `github_metrics`, `github_pr_manage`, `github_repo_analyze`, `memory_compress`, `neural_patterns`, `neural_predict`, `neural_status`, `neural_train`, `performance_report`, `swarm_init`, `swarm_status`, `task_status`, `workflow_create`, `workflow_execute`) — 234 occurrences fixed.
- **Brand-name prose**: occurrence-level (not line-level) `claude-flow`/`Claude-Flow`/`Claude Flow` → `ruflo`/`Ruflo`, excluding `@claude-flow/*` npm scope and `ruvnet/claude-flow` GitHub identity (0 collisions, confirmed via grep).
- **`swarm` CLI, bare-objective form**: `npx claude-flow swarm "<objective>" [flags]` → `npx ruflo swarm start -o "<objective>" [-s <strategy>] [-p]`, dropping `--mode`/`--max-agents`/`--config`/`--claude` (confirmed absent from `swarm start --help`). Only 3 of 29 `swarm` occurrences — the rest (`init`/`spawn`/`monitor`/stub-filler/`swarm-scale`) moved to Wave B after plan review found they aren't uniform.
- **`sparc` CLI**: all 32 occurrences — the `sparc` subcommand doesn't exist in v3 at all (confirmed live). Removed and repointed to the `sparc-methodology` skill / Agent tool, matching the same disposition SMI-5719 already established for this exact family.
- Plan: `docs/internal/implementation/smi-5742-wave-a-mechanical-cf-ruflo-rename.md` (reviewed). Governance review: `docs/internal/code_review/2026-07-20-smi-5742-wave-a-review.md` (0 findings). Wave B: SMI-5777.
- Verified: zero residual matches for all 4 Wave A patterns; Wave B carve-outs (hook family, 42 tools, non-bare-objective swarm) confirmed untouched via diff; YAML frontmatter parse-checked on every changed agent file (1 pre-existing, unrelated parse issue found and confirmed out of scope); `audit:standards` clean.

Refs SMI-5742


[skip-impl-check]
