### PR TITLE
fix(website): correct pricing.astro Audit Logging/SIEM roadmap staleness

### DIFF
--- a/packages/website/src/pages/pricing.astro
+++ b/packages/website/src/pages/pricing.astro
@@ -272,7 +272,14 @@ const jsonLdData = generateJsonLd(pricingTiers, pricingFaqs)
             <td><span class="dash" aria-label="No">&mdash;</span></td>
             <td><span class="dash" aria-label="No">&mdash;</span></td>
             <td class="highlighted"><span class="dash" aria-label="No">&mdash;</span></td>
-            <td><span class="roadmap" aria-label="On roadmap">&#128336;</span></td>
+            <td><span class="check" aria-label="Yes">&#10003;</span></td>
+          </tr>
+          <tr>
+            <td>SIEM Export</td>
+            <td><span class="dash" aria-label="No">&mdash;</span></td>
+            <td><span class="dash" aria-label="No">&mdash;</span></td>
+            <td class="highlighted"><span class="dash" aria-label="No">&mdash;</span></td>
+            <td><span class="check" aria-label="Yes">&#10003;</span></td>
           </tr>
           <tr>
             <td>Compliance Reports (SOC 2 / CycloneDX AI-BOM)</td>
@@ -320,8 +327,6 @@ const jsonLdData = generateJsonLd(pricingTiers, pricingFaqs)
         <ul>
           <li>SSO / SAML integration</li>
           <li>Role-based access control</li>
-          <li>Audit logging (MCP tools)</li>
-          <li>SIEM export</li>
           <li>Custom integrations</li>
           <li>Private skill registry</li>
         </ul>


### PR DESCRIPTION
## Business Summary

**What shipped:** `packages/website/src/pages/pricing.astro`'s Enterprise "On the roadmap" list incorrectly showed Audit Logging and SIEM export as unshipped, and the comparison table's Audit Logging row showed a roadmap clock instead of a checkmark. Both are actually shipped, Enterprise-only gated MCP tools (`audit_export`, `audit_query`, `siem_export`) — verified directly against `toolFeatureMapping.ts`, not inferred. Fixed the table row, added the missing SIEM Export table row, and removed the two stale roadmap bullets.

**Quality bar:** `astro check` clean (169 files, 0 errors/warnings/hints). Independent cross-provider review (Sol/Codex via NEEDLE) of the diff: PASS, 0 defects. Followed up on Sol's one recommendation (verify no other page text — JSON-LD, FAQ — still references these as roadmap-only): confirmed clean via full-file grep, only the two table rows reference either term.

**Found along the way:** SSO/SAML and RBAC were investigated in the same pass and confirmed genuinely still unshipped (stub-only backing services, `createStubSSOService()`/`createStubRBACService()`, no production caller ever swaps in a real implementation) — correctly left as roadmap, not touched.

**Net result:** Pricing page now accurately reflects shipped Enterprise capabilities for audit/SIEM tooling.

---

## Technical detail

- Comparison table: Audit Logging row's Enterprise cell changed from roadmap-clock to check (Enterprise-only — NOT Team+Enterprise, unlike the neighboring Compliance Reports row). New SIEM Export row added, same Enterprise-only pattern.
- Roadmap `<li>` list: removed "Audit logging (MCP tools)" and "SIEM export"; left SSO/SAML and RBAC untouched (verified separately as genuinely unshipped).
- Evidence chain (tool-dispatch.ts, audit-tools.ts, toolFeatureMapping.ts:145/146, TierMapping.ts:59/60) confirms Enterprise-only gating for all three tools.

## Pre-existing issue exception (CLAUDE.md zero-deferral exception clause)

Pushed via `--no-verify` with explicit consent — pre-push's npm audit check fails on **SMI-5775** (brace-expansion High/DoS + astro Moderate/XSS + others on `main`), a pre-existing, already-tracked, unrelated dependency vulnerability independently discovered by a concurrent session ~30 min before this PR. This diff touches only `pricing.astro` content — no `package.json`/`package-lock.json` changes. Every other pre-push check (format, tests, secrets, typecheck, `astro check`) passed clean before hitting the audit gate. SMI-5775's actual fix requires `npm audit fix` inside the long-lived `skillsmith-dev-1` container (worktree containers structurally can't run it — read-only `node_modules` mounts by design), which was contended by other concurrent sessions at push time.

Refs SMI-5735, SMI-3140, SMI-5688, SMI-5775.