### PR TITLE
docs(hooks): Add MCP equivalent cross-reference to setup.md (SMI-5777)

### DIFF
--- a/.claude/commands/hooks/setup.md
+++ b/.claude/commands/hooks/setup.md
@@ -7,6 +7,8 @@
 npx -y ruflo@3.14.2 init hooks
 ```
 
+MCP equivalent: `mcp__ruflo__hooks_init`.
+
 This automatically creates:
 - `.claude/settings.json` with hook configurations
 - Hook command documentation


### PR DESCRIPTION
## Business Summary

**What shipped:** One documentation line added to the hooks setup guide, cross-referencing the MCP tool equivalent (`mcp__ruflo__hooks_init`) for the `init hooks` CLI command — matching the convention already used in sibling docs from the same migration.

**Quality bar:** Verified `hooks_init` is a real, live MCP tool (checked against the actual tool catalog) before writing it in.

**Net result:** Fully shipped, no follow-up needed. Found during a user-requested re-verification pass confirming SMI-5777's hooks-family (F1) work satisfies the plan's own Definition of Done — everything else checked out; this was the one small gap.

---

## Technical detail

`.claude/commands/hooks/setup.md` — added `MCP equivalent: `mcp__ruflo__hooks_init`.` right after the `init hooks` command block.

[skip-impl-check] — single documentation line, no source code changes.

Refs SMI-5777