### PR TITLE
feat(website): Add public status page and RSS feed (SMI-5755)

### DIFF
--- a/packages/website/src/components/Footer.astro
+++ b/packages/website/src/components/Footer.astro
@@ -19,6 +19,7 @@ const footerLinks = {
   resources: [
     { href: '/docs', label: 'Documentation' },
     { href: '/docs/api', label: 'API Reference' },
+    { href: '/status', label: 'Status' },
     { href: 'https://github.com/smith-horn/skillsmith', label: 'GitHub', external: true },
   ],
   legal: [

--- a/packages/website/src/components/StatusComponentRow.astro
+++ b/packages/website/src/components/StatusComponentRow.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * StatusComponentRow — one status-page component row (SMI-5755, Wave 5).
+ *
+ * Rendered twice from status.astro with IDENTICAL markup: once per fixed
+ * scaffold component (visible), and once more inside a hidden
+ * `<template id="status-row-template">` (never visible, cloned by the client
+ * script in `../lib/status-client.ts` to create a "dynamic" row for a
+ * component slug the API returns that isn't one of the 6 fixed rows). Using
+ * one component for both guarantees the scaffold and dynamic-row markup can
+ * never drift apart (Codex #3 point 5 — "the shared renderer uses the exact
+ * same safe text/accessibility path regardless of whether the row is a
+ * scaffold row or a dynamic one").
+ *
+ * `data-role` attributes are the stable hooks the client script queries once
+ * per row and updates via `textContent`/`className` only — see
+ * `applyComponentRowContent()` in `../lib/status-client.ts`.
+ */
+import Card from './Card.astro'
+import StatusPill from './StatusPill.astro'
+import UptimeBarStrip from './UptimeBarStrip.astro'
+import { SCAFFOLD_NO_DATA_MESSAGE, type ComponentStatus, type UptimeDay } from '../lib/status-vocab'
+
+interface Props {
+  slug: string
+  name: string
+  message?: string
+  status?: ComponentStatus
+  latencyText?: string
+  checkedAtText?: string
+  uptime90d?: UptimeDay[]
+  anchorIsoDate: string
+}
+
+const {
+  slug,
+  name,
+  message = SCAFFOLD_NO_DATA_MESSAGE,
+  status = 'unknown',
+  latencyText = '—',
+  checkedAtText = '—',
+  uptime90d = [],
+  anchorIsoDate,
+} = Astro.props
+---
+
+<div data-component={slug}>
+  <Card variant="bordered" padding="md">
+    <div class="flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <h3 class="text-white font-semibold" data-role="name">
+          {name}
+        </h3>
+        <p class="text-sm text-gray-400 mt-1" data-role="message">
+          {message}
+        </p>
+      </div>
+      <StatusPill status={status} size="sm" />
+    </div>
+    <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
+      <span>Latency: <span data-role="latency">{latencyText}</span></span>
+      <span>Last checked: <span data-role="checked-at">{checkedAtText}</span></span>
+    </div>
+    <div class="mt-4">
+      <UptimeBarStrip uptime90d={uptime90d} anchorIsoDate={anchorIsoDate} label={name} />
+    </div>
+  </Card>
+</div>

--- a/packages/website/src/components/StatusPill.astro
+++ b/packages/website/src/components/StatusPill.astro
@@ -1,0 +1,61 @@
+---
+/**
+ * StatusPill — direct structural clone of Badge.astro for the public status
+ * page (SMI-5755, Wave 5). Sources every class/label/icon from
+ * `lib/status-vocab.ts`. Only trusted vocab constants are interpolated here —
+ * no incident/component free text ever reaches this component.
+ */
+import type { ComponentStatus } from '../lib/status-vocab'
+import {
+  PILL_BASE,
+  PILL_ICON_SIZE,
+  PILL_SIZE,
+  STATUS_ICONS,
+  STATUS_LABELS,
+  STATUS_PILL_CLASSES,
+} from '../lib/status-vocab'
+
+interface Props {
+  status: ComponentStatus
+  size?: 'sm' | 'md'
+  showIcon?: boolean
+  class?: string
+}
+
+const { status, size = 'md', showIcon = true, class: className = '' } = Astro.props
+
+// Graceful fallback to 'unknown' for any unrecognized value — mirrors
+// Badge's `?? tierConfig.unverified` pattern, but the fallback here is
+// 'unknown', never 'operational' (an unrecognized status must never read as
+// healthy).
+const safeStatus: ComponentStatus = STATUS_PILL_CLASSES[status] ? status : 'unknown'
+const colors = STATUS_PILL_CLASSES[safeStatus]
+const label = STATUS_LABELS[safeStatus]
+const iconPath = STATUS_ICONS[safeStatus]
+
+const classes = [
+  PILL_BASE,
+  colors.bgColor,
+  colors.textColor,
+  colors.borderColor,
+  PILL_SIZE[size],
+  className,
+].join(' ')
+---
+
+<span class={classes} data-status-pill data-status={safeStatus}>
+  {
+    showIcon && (
+      <svg
+        class={`${PILL_ICON_SIZE[size]} mr-1`}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        data-status-pill-icon
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={iconPath} />
+      </svg>
+    )
+  }
+  <span data-status-pill-text>{label}</span>
+</span>

--- a/packages/website/src/components/UptimeBarStrip.astro
+++ b/packages/website/src/components/UptimeBarStrip.astro
@@ -1,0 +1,78 @@
+---
+/**
+ * UptimeBarStrip — 90-day uptime strip for one status component
+ * (SMI-5755, Wave 5).
+ *
+ * FIX (Codex #14, accessibility, merge-blocking): does NOT make all 90 tiles
+ * independently `tabindex="0"` (540 tab stops across 6 strips would be
+ * unusable). Instead: roving tabindex — this strip is `role="group"` with a
+ * summary `aria-label`, exactly one tile starts at `tabindex="0"` (the most
+ * recent/last tile), every other tile is `tabindex="-1"`. Arrow-key
+ * (Left/Right, Home/End) navigation moves focus and updates which tile has
+ * `tabindex="0"`.
+ *
+ * Astro components can't easily own imperative keyboard logic shared across
+ * 6 instances, so the keydown handler is NOT implemented per-component here —
+ * it's a single delegated listener wired once from status.astro's client
+ * script, calling `wireUptimeStripKeyboardNav()` /
+ * `computeRovingTabindexMove()` in `../lib/status-client.ts`. This file only
+ * emits the `data-uptime-strip` / `data-uptime-tile` hooks that handler
+ * listens for.
+ *
+ * Each tile gets both a native `title` and an `aria-label` with the full date
+ * + status/uptime (or "No data"). Screen readers announce `aria-label` on
+ * focus regardless of `title`'s cross-browser hover-vs-focus inconsistency —
+ * that inconsistency is exactly why `aria-label` is the load-bearing channel;
+ * `title` is a bonus for mouse users only.
+ *
+ * Tile fill: solid `bg-{green|yellow|red}-500` for real statuses,
+ * `bg-gray-700` for no-data — never a border; tiles are separated by a flex
+ * gap.
+ */
+import {
+  buildUptimeGrid,
+  buildUptimeStripAriaLabel,
+  uptimeTileClassName,
+  uptimeTileText,
+  type UptimeDay,
+} from '../lib/status-vocab'
+
+interface Props {
+  uptime90d: UptimeDay[]
+  anchorIsoDate: string
+  label: string
+  class?: string
+}
+
+const { uptime90d, anchorIsoDate, label, class: className = '' } = Astro.props
+
+const tiles = buildUptimeGrid(uptime90d, anchorIsoDate)
+const lastIndex = tiles.length - 1
+
+// FIX (medium): counting logic now lives in buildUptimeStripAriaLabel
+// (../lib/status-vocab.ts) so this SSR computation and status-render.ts's
+// client-side refresh path share one implementation and can never drift.
+const groupAriaLabel = buildUptimeStripAriaLabel(tiles, label)
+---
+
+<div class={`flex flex-col gap-1 ${className}`}>
+  <div class="flex gap-0.5" role="group" aria-label={groupAriaLabel} data-uptime-strip>
+    {
+      tiles.map((tile, index) => (
+        <div
+          class={uptimeTileClassName(tile.status)}
+          tabindex={index === lastIndex ? '0' : '-1'}
+          role="img"
+          title={uptimeTileText(tile)}
+          aria-label={uptimeTileText(tile)}
+          data-uptime-tile
+          data-date={tile.date}
+        />
+      ))
+    }
+  </div>
+  <div class="flex justify-between text-xs text-gray-500">
+    <span>90 days ago</span>
+    <span>Today</span>
+  </div>
+</div>

--- a/packages/website/src/lib/status-client.ts
+++ b/packages/website/src/lib/status-client.ts
@@ -1,0 +1,88 @@
+/**
+ * Status page client-side runtime logic (SMI-5755, Wave 5) — barrel
+ * re-export over four focused sibling modules (kept under the repo's
+ * 500-line-per-file gate):
+ *
+ *   - `status-payload.ts`   — payload validation + TTL'd localStorage cache (Codex #7/#8/#10)
+ *   - `status-reconcile.ts` — dynamic-row reconciliation plan (Codex #3)
+ *   - `status-render.ts`    — safe textContent-only render-content builders (Codex #1/#2/#15)
+ *   - `status-poller.ts`    — roving-tabindex keyboard nav (Codex #14) + poll
+ *                             lifecycle controller (Codex #4/#10)
+ *
+ * `status.astro` and this module's own tests import from here so the split
+ * is an implementation detail, not a call-site concern.
+ *
+ * DEVIATION from the brief's literal "one is:inline define:vars script"
+ * instruction: this logic is a regular (bundled) ES module imported by
+ * status.astro's non-inline `<script>` tag, not inlined directly. Rationale:
+ *
+ *   1. `import.meta.env.PUBLIC_API_BASE_URL` is available in a bundled
+ *      Astro `<script>` exactly as it is in an `is:inline` one (it's a Vite
+ *      `define`, not something `define:vars` uniquely provides — see
+ *      astro.config.mjs's `vite.define` block) — so the URL-construction
+ *      idiom is unaffected either way.
+ *   2. BaseLayout.astro already establishes this exact split for
+ *      SMI-3595's Supabase client: an `is:inline define:vars` shim for the
+ *      truly server-computed value, followed by a regular `<script>` that
+ *      imports real logic from `../lib/*`. This module follows that
+ *      established precedent.
+ *   3. The brief mandates real, executable tests for the untrusted-field
+ *      rendering path and the dynamic-row reconciliation contract. Logic
+ *      that only ever exists as inert text inside an `is:inline` block can't
+ *      be imported by a test file, which would force either (a) no real test
+ *      of the shipped code, just a hand-maintained "twin" copy that can
+ *      silently drift from production, or (b) executing raw script text
+ *      through a headless browser — disproportionate for this change. A
+ *      single importable module avoids that drift risk entirely.
+ *
+ * Untrusted-field inventory (never `innerHTML`/`insertAdjacentHTML`/`set:html`
+ * for any of these — always `textContent`/`createElement` + property assign):
+ * `component.message`, `component.name`, `incident.title`,
+ * `incident.updates[].message`, and the affected-component display-name
+ * lookup + raw-slug fallback built from those same fields.
+ */
+
+export {
+  readCachedStatusPayload,
+  STATUS_CACHE_KEY,
+  STATUS_CACHE_TTL_MS,
+  validateStatusPayload,
+  writeCachedStatusPayload,
+} from './status-payload'
+
+export {
+  dedupeComponentsBySlug,
+  planComponentReconciliation,
+  type ComponentDedupeResult,
+  type ReconcilePlan,
+} from './status-reconcile'
+
+export {
+  applyComponentRowContent,
+  buildAffectedComponentsText,
+  buildComponentRowContent,
+  buildComponentsBySlug,
+  buildIncidentContent,
+  buildScaffoldResetContent,
+  refreshUptimeStripTiles,
+  type ComponentRowContent,
+  type ComponentRowElements,
+  type IncidentContent,
+  type IncidentUpdateContent,
+  type UptimeStripHandle,
+  type UptimeTileHandle,
+} from './status-render'
+
+export {
+  computeRovingTabindexMove,
+  createStatusPoller,
+  INITIAL_POLL_OUTCOME_STATE,
+  isRovingNavKey,
+  nextPollOutcomeState,
+  STALE_AFTER_CONSECUTIVE_FAILURES,
+  wireUptimeStripKeyboardNav,
+  type PollOutcomeState,
+  type StatusPoller,
+  type StatusPollerCallbacks,
+  type StatusPollerOptions,
+} from './status-poller'

--- a/packages/website/src/lib/status-payload.test.ts
+++ b/packages/website/src/lib/status-payload.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from 'vitest'
+import {
+  readCachedStatusPayload,
+  STATUS_CACHE_KEY,
+  STATUS_CACHE_TTL_MS,
+  validateStatusPayload,
+  writeCachedStatusPayload,
+} from './status-payload'
+import { buildUptimeGrid } from './status-vocab'
+
+const ADVERSARIAL = '<script>alert(1)</script>'
+
+// ---------------------------------------------------------------------------
+// validateStatusPayload
+// ---------------------------------------------------------------------------
+
+describe('validateStatusPayload', () => {
+  it('accepts a well-formed payload and preserves untrusted text unchanged', () => {
+    const raw = {
+      cached: false,
+      data: {
+        generated_at: '2026-07-15T00:00:00Z',
+        overall_status: 'operational',
+        components: [
+          {
+            slug: 'website',
+            name: ADVERSARIAL,
+            description: '',
+            display_order: 0,
+            status: 'operational',
+            latency_ms: 12,
+            message: ADVERSARIAL,
+            checked_at: null,
+            uptime_90d: [],
+          },
+        ],
+        incidents: [
+          {
+            id: 'inc-1',
+            title: ADVERSARIAL,
+            impact: 'major',
+            status: 'monitoring',
+            started_at: '2026-07-15T00:00:00Z',
+            resolved_at: null,
+            affected_components: ['website'],
+            updates: [
+              { status: 'monitoring', message: ADVERSARIAL, posted_at: '2026-07-15T00:00:00Z' },
+            ],
+          },
+        ],
+      },
+    }
+    const result = validateStatusPayload(raw)
+    expect(result).not.toBeNull()
+    expect(result!.data.components[0].name).toBe(ADVERSARIAL)
+    expect(result!.data.components[0].message).toBe(ADVERSARIAL)
+    expect(result!.data.incidents[0].title).toBe(ADVERSARIAL)
+    expect(result!.data.incidents[0].updates[0].message).toBe(ADVERSARIAL)
+  })
+
+  it('FIX (Codex #8): rejects a payload whose components is not an array (structural failure)', () => {
+    expect(
+      validateStatusPayload({
+        cached: false,
+        data: {
+          generated_at: '',
+          overall_status: 'operational',
+          components: 'not-an-array',
+          incidents: [],
+        },
+      })
+    ).toBeNull()
+  })
+
+  it('FIX (Codex #8): rejects a payload whose incidents is not an array', () => {
+    expect(
+      validateStatusPayload({
+        cached: false,
+        data: { generated_at: '', overall_status: 'operational', components: [], incidents: {} },
+      })
+    ).toBeNull()
+  })
+
+  it('rejects non-object top-level and missing data', () => {
+    expect(validateStatusPayload(null)).toBeNull()
+    expect(validateStatusPayload('a string')).toBeNull()
+    expect(validateStatusPayload([])).toBeNull()
+    expect(validateStatusPayload({ cached: true })).toBeNull()
+  })
+
+  it('coerces an unrecognized overall_status to unknown rather than rejecting', () => {
+    const result = validateStatusPayload({
+      cached: false,
+      data: {
+        generated_at: '2026-07-15T00:00:00Z',
+        overall_status: 'totally-fine',
+        components: [],
+        incidents: [],
+      },
+    })
+    expect(result!.data.overall_status).toBe('unknown')
+  })
+
+  it('drops a component missing a valid slug rather than invalidating the whole payload', () => {
+    const result = validateStatusPayload({
+      cached: false,
+      data: {
+        generated_at: '',
+        overall_status: 'operational',
+        components: [{ name: 'no slug here' }, { slug: 'ok', name: 'Ok' }],
+        incidents: [],
+      },
+    })
+    expect(result!.data.components).toHaveLength(1)
+    expect(result!.data.components[0].slug).toBe('ok')
+  })
+
+  it('drops an incident missing a valid id', () => {
+    const result = validateStatusPayload({
+      cached: false,
+      data: {
+        generated_at: '',
+        overall_status: 'operational',
+        components: [],
+        incidents: [{ title: 'no id' }],
+      },
+    })
+    expect(result!.data.incidents).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// End-to-end: validateStatusPayload -> buildUptimeGrid (FIX, high) — a
+// malformed uptime_pct must never survive the real pipeline as a fake green
+// "Operational" tile. Exercised through the ACTUAL payload-validation path
+// (not a pre-sanitized object handed directly to buildUptimeGrid), since
+// sanitizeUptimeDay (status-payload.ts) deliberately lets a malformed
+// uptime_pct through as NaN rather than dropping the whole day entry -- the
+// real fix lives downstream in buildUptimeGrid.
+// ---------------------------------------------------------------------------
+
+describe('validateStatusPayload -> buildUptimeGrid pipeline (Fix: no fake-green tile)', () => {
+  const ANCHOR = '2026-07-15'
+
+  it('a malformed uptime_pct survives payload validation but resolves as no-data through the real pipeline', () => {
+    const raw = {
+      cached: false,
+      data: {
+        generated_at: `${ANCHOR}T00:00:00Z`,
+        overall_status: 'operational',
+        components: [
+          {
+            slug: 'website',
+            name: 'Website',
+            description: '',
+            display_order: 0,
+            status: 'operational',
+            latency_ms: 10,
+            message: '',
+            checked_at: null,
+            uptime_90d: [
+              {
+                day: ANCHOR,
+                uptime_pct: 'not-a-number', // malformed
+                worst_status: 'operational', // genuinely valid on its own
+                total_checks: 288,
+              },
+            ],
+          },
+        ],
+        incidents: [],
+      },
+    }
+
+    const validated = validateStatusPayload(raw)
+    expect(validated).not.toBeNull()
+
+    const uptime90d = validated!.data.components[0].uptime_90d
+    // sanitizeUptimeDay lets the malformed entry through (day is valid, so
+    // uptime_pct falls back to NaN rather than dropping the whole entry).
+    expect(uptime90d).toHaveLength(1)
+
+    const tiles = buildUptimeGrid(uptime90d, ANCHOR)
+    const anchorTile = tiles[89]
+    expect(anchorTile.date).toBe(ANCHOR)
+    // Must render as "No data" -- never a fabricated green "Operational"
+    // tile just because worst_status happened to still look valid.
+    expect(anchorTile.status).toBeNull()
+    expect(anchorTile.uptimePct).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// localStorage cache (Codex #7, #10)
+// ---------------------------------------------------------------------------
+
+describe('readCachedStatusPayload / writeCachedStatusPayload', () => {
+  it('round-trips a valid payload written just now', () => {
+    const store = new Map<string, string>()
+    const storage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+    }
+    const payload = validateStatusPayload({
+      cached: false,
+      data: { generated_at: 'x', overall_status: 'operational', components: [], incidents: [] },
+    })!
+    writeCachedStatusPayload(storage, payload)
+    expect(readCachedStatusPayload(storage)).toEqual(payload)
+  })
+
+  it('FIX (Codex #7): applies the same validation to a cached blob as a network response', () => {
+    const store = new Map<string, string>([
+      [
+        STATUS_CACHE_KEY,
+        JSON.stringify({
+          cachedAt: Date.now(),
+          payload: { cached: true, data: { components: 'nope', incidents: [] } },
+        }),
+      ],
+    ])
+    const storage = { getItem: (k: string) => store.get(k) ?? null }
+    expect(readCachedStatusPayload(storage)).toBeNull()
+  })
+
+  it('discards unparseable JSON without throwing', () => {
+    const store = new Map<string, string>([[STATUS_CACHE_KEY, 'not json{{']])
+    const storage = { getItem: (k: string) => store.get(k) ?? null }
+    expect(readCachedStatusPayload(storage)).toBeNull()
+  })
+
+  it('a storage.getItem that throws is handled (private-browsing/quota)', () => {
+    const storage = {
+      getItem: () => {
+        throw new Error('boom')
+      },
+    }
+    expect(readCachedStatusPayload(storage)).toBeNull()
+  })
+
+  it('a storage.setItem that throws does not propagate', () => {
+    const storage = {
+      setItem: () => {
+        throw new Error('quota exceeded')
+      },
+    }
+    const payload = validateStatusPayload({
+      cached: false,
+      data: { generated_at: '', overall_status: 'operational', components: [], incidents: [] },
+    })!
+    expect(() => writeCachedStatusPayload(storage, payload)).not.toThrow()
+  })
+
+  it('FIX (Codex #10): rejects a legacy bare-payload entry (pre-TTL v2 shape) as a miss, not a crash', () => {
+    const store = new Map<string, string>([
+      [
+        STATUS_CACHE_KEY,
+        JSON.stringify({
+          cached: false,
+          data: { generated_at: 'x', overall_status: 'operational', components: [], incidents: [] },
+        }),
+      ],
+    ])
+    const storage = { getItem: (k: string) => store.get(k) ?? null }
+    expect(readCachedStatusPayload(storage)).toBeNull()
+  })
+
+  it('FIX (Codex #10, "Expire stale cached data"): an entry older than the TTL is treated as a miss', () => {
+    const payload = validateStatusPayload({
+      cached: false,
+      data: { generated_at: 'x', overall_status: 'operational', components: [], incidents: [] },
+    })!
+    const store = new Map<string, string>([
+      [
+        STATUS_CACHE_KEY,
+        JSON.stringify({ cachedAt: Date.now() - STATUS_CACHE_TTL_MS - 1, payload }),
+      ],
+    ])
+    const storage = { getItem: (k: string) => store.get(k) ?? null }
+    expect(readCachedStatusPayload(storage)).toBeNull()
+  })
+
+  it('an entry within the TTL is still used', () => {
+    const payload = validateStatusPayload({
+      cached: false,
+      data: { generated_at: 'x', overall_status: 'operational', components: [], incidents: [] },
+    })!
+    const store = new Map<string, string>([
+      [
+        STATUS_CACHE_KEY,
+        JSON.stringify({ cachedAt: Date.now() - (STATUS_CACHE_TTL_MS - 1000), payload }),
+      ],
+    ])
+    const storage = { getItem: (k: string) => store.get(k) ?? null }
+    expect(readCachedStatusPayload(storage)).toEqual(payload)
+  })
+
+  it('a malformed cachedAt (non-numeric) is treated as a miss', () => {
+    const payload = validateStatusPayload({
+      cached: false,
+      data: { generated_at: 'x', overall_status: 'operational', components: [], incidents: [] },
+    })!
+    const store = new Map<string, string>([
+      [STATUS_CACHE_KEY, JSON.stringify({ cachedAt: 'not-a-number', payload })],
+    ])
+    const storage = { getItem: (k: string) => store.get(k) ?? null }
+    expect(readCachedStatusPayload(storage)).toBeNull()
+  })
+})

--- a/packages/website/src/lib/status-payload.ts
+++ b/packages/website/src/lib/status-payload.ts
@@ -1,0 +1,184 @@
+/**
+ * Status page payload validation + localStorage cache (SMI-5755, Wave 5).
+ * Split out of status-client.ts to stay under the repo's 500-line-per-file
+ * gate — see status-client.ts's barrel re-export + header comment for the
+ * full module-split rationale.
+ */
+
+import {
+  coerceComponentStatus,
+  isFiniteNumber,
+  isNonNegativeInteger,
+  type StatusComponent,
+  type StatusData,
+  type StatusIncident,
+  type StatusResponse,
+  type UptimeDay,
+} from './status-vocab'
+
+// ---------------------------------------------------------------------------
+// Payload validation (Codex #7, #8) — applied identically to a fresh network
+// response AND to a `localStorage`-cached blob. Structural failures (missing/
+// non-array `components`/`incidents`) invalidate the WHOLE payload (return
+// null) rather than partially repainting; per-field enum values are coerced
+// to 'unknown' rather than hard-failing the payload.
+// ---------------------------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function sanitizeUptimeDay(raw: unknown): UptimeDay | null {
+  if (!isPlainObject(raw)) return null
+  if (typeof raw.day !== 'string') return null
+  return {
+    day: raw.day,
+    uptime_pct: isFiniteNumber(raw.uptime_pct) ? raw.uptime_pct : Number.NaN,
+    worst_status:
+      raw.worst_status === 'operational' ||
+      raw.worst_status === 'degraded' ||
+      raw.worst_status === 'outage'
+        ? raw.worst_status
+        : 'operational',
+    total_checks: isNonNegativeInteger(raw.total_checks) ? raw.total_checks : 0,
+  }
+}
+
+function sanitizeComponent(raw: unknown): StatusComponent | null {
+  if (!isPlainObject(raw)) return null
+  if (typeof raw.slug !== 'string' || raw.slug.length === 0) return null
+  const uptimeRaw = Array.isArray(raw.uptime_90d) ? raw.uptime_90d : []
+  return {
+    slug: raw.slug,
+    name: typeof raw.name === 'string' ? raw.name : raw.slug,
+    description: typeof raw.description === 'string' ? raw.description : '',
+    display_order: typeof raw.display_order === 'number' ? raw.display_order : 0,
+    status: coerceComponentStatus(raw.status),
+    latency_ms: isFiniteNumber(raw.latency_ms) ? raw.latency_ms : null,
+    message: typeof raw.message === 'string' ? raw.message : '',
+    checked_at: typeof raw.checked_at === 'string' ? raw.checked_at : null,
+    uptime_90d: uptimeRaw.map(sanitizeUptimeDay).filter((d): d is UptimeDay => d !== null),
+  }
+}
+
+const KNOWN_INCIDENT_STATUSES = new Set(['investigating', 'identified', 'monitoring', 'resolved'])
+const KNOWN_IMPACTS = new Set(['none', 'minor', 'major', 'critical'])
+
+function sanitizeIncident(raw: unknown): StatusIncident | null {
+  if (!isPlainObject(raw)) return null
+  if (typeof raw.id !== 'string' || raw.id.length === 0) return null
+  const updatesRaw = Array.isArray(raw.updates) ? raw.updates : []
+  const updates = updatesRaw.filter(isPlainObject).map((u) => ({
+    status: KNOWN_INCIDENT_STATUSES.has(String(u.status))
+      ? (u.status as StatusIncident['status'])
+      : 'investigating',
+    message: typeof u.message === 'string' ? u.message : '',
+    posted_at: typeof u.posted_at === 'string' ? u.posted_at : '',
+  }))
+  return {
+    id: raw.id,
+    title: typeof raw.title === 'string' ? raw.title : '',
+    impact: KNOWN_IMPACTS.has(String(raw.impact))
+      ? (raw.impact as StatusIncident['impact'])
+      : 'none',
+    status: KNOWN_INCIDENT_STATUSES.has(String(raw.status))
+      ? (raw.status as StatusIncident['status'])
+      : 'investigating',
+    started_at: typeof raw.started_at === 'string' ? raw.started_at : '',
+    resolved_at: typeof raw.resolved_at === 'string' ? raw.resolved_at : null,
+    affected_components: Array.isArray(raw.affected_components)
+      ? raw.affected_components.filter((s): s is string => typeof s === 'string')
+      : [],
+    updates,
+  }
+}
+
+/**
+ * Validates+sanitizes an unknown blob (network JSON or a `localStorage`
+ * cache read) into a well-formed `StatusResponse`, or `null` if the payload
+ * is structurally invalid. A `null` result must be treated the same as a
+ * fetch failure by the caller — never partially repaint from an invalid
+ * shape (Codex #8).
+ */
+export function validateStatusPayload(raw: unknown): StatusResponse | null {
+  if (!isPlainObject(raw)) return null
+  if (!isPlainObject(raw.data)) return null
+  const data = raw.data
+  if (!Array.isArray(data.components)) return null
+  if (!Array.isArray(data.incidents)) return null
+
+  const components = data.components
+    .map(sanitizeComponent)
+    .filter((c): c is StatusComponent => c !== null)
+  const incidents = data.incidents
+    .map(sanitizeIncident)
+    .filter((i): i is StatusIncident => i !== null)
+
+  const sanitizedData: StatusData = {
+    generated_at: typeof data.generated_at === 'string' ? data.generated_at : '',
+    overall_status: coerceComponentStatus(data.overall_status),
+    components,
+    incidents,
+  }
+
+  return {
+    cached: raw.cached === true,
+    data: sanitizedData,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// localStorage cache (Codex #7 + #10) — cache key bumped to v3 (envelope shape
+// changed: a bare payload is no longer valid, so v2 entries are naturally
+// discarded rather than partially trusted). Every read/write independently
+// wrapped in its own try/catch (existing convention).
+//
+// FIX (Codex #10, high, "Expire stale cached data"): mirrors index.astro's
+// existing `{ ..., timestamp }` + `Date.now() - timestamp < CACHE_TTL` pattern
+// (see index.astro's CACHE_TTL = 5 * 60 * 1000 for skill/GitHub counts) with a
+// shorter TTL appropriate to a live status page — an unbounded-age cached
+// payload could otherwise paint arbitrarily stale "all operational" data
+// indefinitely for a returning visitor before the first live poll resolves.
+// ---------------------------------------------------------------------------
+
+export const STATUS_CACHE_KEY = 'skillsmith_status_v3'
+
+/** Slightly above the 45s poll interval — only bridges the instant-paint gap
+ * before the first live poll resolves, never substitutes for one. */
+export const STATUS_CACHE_TTL_MS = 60_000
+
+interface CachedEnvelope {
+  cachedAt: number
+  payload: unknown
+}
+
+function isCachedEnvelope(value: unknown): value is CachedEnvelope {
+  return (
+    isPlainObject(value) && typeof value.cachedAt === 'number' && Number.isFinite(value.cachedAt)
+  )
+}
+
+export function readCachedStatusPayload(storage: Pick<Storage, 'getItem'>): StatusResponse | null {
+  try {
+    const raw = storage.getItem(STATUS_CACHE_KEY)
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (!isCachedEnvelope(parsed)) return null
+    if (Date.now() - parsed.cachedAt > STATUS_CACHE_TTL_MS) return null // expired (Codex #10)
+    return validateStatusPayload(parsed.payload)
+  } catch {
+    return null
+  }
+}
+
+export function writeCachedStatusPayload(
+  storage: Pick<Storage, 'setItem'>,
+  payload: StatusResponse
+): void {
+  try {
+    const envelope: CachedEnvelope = { cachedAt: Date.now(), payload }
+    storage.setItem(STATUS_CACHE_KEY, JSON.stringify(envelope))
+  } catch {
+    // Storage full/unavailable (private browsing, quota) — non-fatal.
+  }
+}

--- a/packages/website/src/lib/status-poller.test.ts
+++ b/packages/website/src/lib/status-poller.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  computeRovingTabindexMove,
+  createStatusPoller,
+  INITIAL_POLL_OUTCOME_STATE,
+  nextPollOutcomeState,
+  STALE_AFTER_CONSECUTIVE_FAILURES,
+} from './status-poller'
+
+// ---------------------------------------------------------------------------
+// Roving-tabindex arithmetic (Codex #14)
+// ---------------------------------------------------------------------------
+
+describe('computeRovingTabindexMove', () => {
+  it('ArrowRight advances, clamped at the last tile', () => {
+    expect(computeRovingTabindexMove(0, 90, 'ArrowRight')).toBe(1)
+    expect(computeRovingTabindexMove(89, 90, 'ArrowRight')).toBe(89)
+  })
+
+  it('ArrowLeft retreats, clamped at the first tile', () => {
+    expect(computeRovingTabindexMove(5, 90, 'ArrowLeft')).toBe(4)
+    expect(computeRovingTabindexMove(0, 90, 'ArrowLeft')).toBe(0)
+  })
+
+  it('Home jumps to 0, End jumps to the last tile', () => {
+    expect(computeRovingTabindexMove(42, 90, 'Home')).toBe(0)
+    expect(computeRovingTabindexMove(0, 90, 'End')).toBe(89)
+  })
+
+  it('an unrelated key returns null', () => {
+    expect(computeRovingTabindexMove(5, 90, 'Tab')).toBeNull()
+    expect(computeRovingTabindexMove(5, 90, 'a')).toBeNull()
+  })
+
+  it('an empty tile set returns null for any key', () => {
+    expect(computeRovingTabindexMove(0, 0, 'ArrowRight')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Staleness tracking (Codex #10)
+// ---------------------------------------------------------------------------
+
+describe('nextPollOutcomeState', () => {
+  it('a single transient failure does not flag stale', () => {
+    let state = INITIAL_POLL_OUTCOME_STATE
+    state = nextPollOutcomeState(state, false)
+    expect(state.isStale).toBe(false)
+    expect(state.consecutiveFailures).toBe(1)
+  })
+
+  it(`flags stale only after ${STALE_AFTER_CONSECUTIVE_FAILURES} consecutive failures`, () => {
+    let state = INITIAL_POLL_OUTCOME_STATE
+    for (let i = 0; i < STALE_AFTER_CONSECUTIVE_FAILURES - 1; i++) {
+      state = nextPollOutcomeState(state, false)
+      expect(state.isStale).toBe(false)
+    }
+    state = nextPollOutcomeState(state, false)
+    expect(state.isStale).toBe(true)
+    expect(state.consecutiveFailures).toBe(STALE_AFTER_CONSECUTIVE_FAILURES)
+  })
+
+  it('a success resets the counter and clears stale', () => {
+    let state = { consecutiveFailures: STALE_AFTER_CONSECUTIVE_FAILURES, isStale: true }
+    state = nextPollOutcomeState(state, true)
+    expect(state).toEqual({ consecutiveFailures: 0, isStale: false })
+  })
+
+  it('a failure sandwiched between successes never accumulates toward stale', () => {
+    let state = INITIAL_POLL_OUTCOME_STATE
+    state = nextPollOutcomeState(state, false)
+    state = nextPollOutcomeState(state, true)
+    state = nextPollOutcomeState(state, false)
+    expect(state.isStale).toBe(false)
+    expect(state.consecutiveFailures).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Poll lifecycle controller (Codex #4)
+// ---------------------------------------------------------------------------
+
+describe('createStatusPoller', () => {
+  const validPayload = {
+    cached: false,
+    data: { generated_at: 'x', overall_status: 'operational', components: [], incidents: [] },
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('start() fires an immediate fetch and reports success', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => validPayload })
+    const onResult = vi.fn()
+    const onStaleChange = vi.fn()
+    const poller = createStatusPoller(
+      { apiUrl: 'https://example/status', fetchImpl },
+      { onResult, onStaleChange }
+    )
+
+    poller.start()
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledTimes(1))
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(onStaleChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('a single fetch failure does not flag stale; three in a row does', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('network down'))
+    const onResult = vi.fn()
+    const onStaleChange = vi.fn()
+    const poller = createStatusPoller(
+      { apiUrl: 'https://example/status', fetchImpl, intervalMs: 1000 },
+      { onResult, onStaleChange }
+    )
+
+    poller.start()
+    await vi.waitFor(() => expect(onStaleChange).toHaveBeenCalledTimes(1))
+    expect(onStaleChange).toHaveBeenLastCalledWith(false)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.waitFor(() => expect(onStaleChange).toHaveBeenCalledTimes(2))
+    expect(onStaleChange).toHaveBeenLastCalledWith(false)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.waitFor(() => expect(onStaleChange).toHaveBeenCalledTimes(3))
+    expect(onStaleChange).toHaveBeenLastCalledWith(true)
+
+    expect(onResult).not.toHaveBeenCalled()
+  })
+
+  it('handleBeforeSwap aborts the in-flight fetch and discards a late response', async () => {
+    let rejectFn: (reason: unknown) => void = () => {}
+    const fetchImpl = vi.fn().mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectFn = reject
+        })
+    )
+    const onResult = vi.fn()
+    const onStaleChange = vi.fn()
+    const poller = createStatusPoller(
+      { apiUrl: 'https://example/status', fetchImpl },
+      { onResult, onStaleChange }
+    )
+
+    poller.start()
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1))
+
+    poller.handleBeforeSwap()
+
+    // Simulate the aborted fetch's promise rejecting (as a real AbortController would).
+    rejectFn(new DOMException('aborted', 'AbortError'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(onResult).not.toHaveBeenCalled()
+  })
+
+  it('handleVisibilityHidden pauses the recursive-timeout loop', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => validPayload })
+    const onResult = vi.fn()
+    const onStaleChange = vi.fn()
+    const poller = createStatusPoller(
+      { apiUrl: 'https://example/status', fetchImpl, intervalMs: 1000 },
+      { onResult, onStaleChange }
+    )
+
+    poller.start()
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledTimes(1))
+
+    poller.handleVisibilityHidden()
+    await vi.advanceTimersByTimeAsync(5000)
+    // No further polls fire while hidden/paused.
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+
+    poller.handleVisibilityVisible()
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2))
+  })
+})

--- a/packages/website/src/lib/status-poller.ts
+++ b/packages/website/src/lib/status-poller.ts
@@ -1,0 +1,230 @@
+/**
+ * Roving-tabindex keyboard nav + poll lifecycle controller for the status
+ * page (SMI-5755, Wave 5). Split out of status-client.ts to stay under the
+ * repo's 500-line-per-file gate — see status-client.ts's barrel re-export +
+ * header comment for the full module-split rationale.
+ */
+
+import { validateStatusPayload } from './status-payload'
+import type { StatusResponse } from './status-vocab'
+
+// ---------------------------------------------------------------------------
+// Roving-tabindex keyboard navigation (Codex #14) — pure arithmetic. The
+// imperative DOM wiring (querySelectorAll/closest/focus/setAttribute) lives in
+// the small wireUptimeStripKeyboardNav() below, which calls this calculator;
+// see UptimeBarStrip.astro's own comment pointing back here.
+// ---------------------------------------------------------------------------
+
+const ROVING_KEYS = new Set(['ArrowRight', 'ArrowLeft', 'Home', 'End'])
+
+export function isRovingNavKey(key: string): boolean {
+  return ROVING_KEYS.has(key)
+}
+
+/** Returns the next tile index for a roving-tabindex keypress, or null if the key is irrelevant. */
+export function computeRovingTabindexMove(
+  currentIndex: number,
+  tileCount: number,
+  key: string
+): number | null {
+  if (tileCount <= 0) return null
+  switch (key) {
+    case 'ArrowRight':
+      return Math.min(currentIndex + 1, tileCount - 1)
+    case 'ArrowLeft':
+      return Math.max(currentIndex - 1, 0)
+    case 'Home':
+      return 0
+    case 'End':
+      return tileCount - 1
+    default:
+      return null
+  }
+}
+
+/**
+ * Wires ONE delegated keydown listener implementing roving tabindex across
+ * every `[data-uptime-strip]` on the page (shared handler, not per-component —
+ * see UptimeBarStrip.astro's comment). Returns an unwire function.
+ */
+export function wireUptimeStripKeyboardNav(root: ParentNode = document): () => void {
+  const handler = (event: Event) => {
+    const keyboardEvent = event as KeyboardEvent
+    if (!isRovingNavKey(keyboardEvent.key)) return
+    const target = event.target
+    if (!(target instanceof Element)) return
+    const tile = target.closest('[data-uptime-tile]')
+    if (!tile) return
+    const strip = tile.closest('[data-uptime-strip]')
+    if (!strip) return
+    const tiles = Array.from(strip.querySelectorAll('[data-uptime-tile]'))
+    const currentIndex = tiles.indexOf(tile)
+    if (currentIndex === -1) return
+
+    const nextIndex = computeRovingTabindexMove(currentIndex, tiles.length, keyboardEvent.key)
+    if (nextIndex === null || nextIndex === currentIndex) return
+
+    keyboardEvent.preventDefault()
+    tiles[currentIndex].setAttribute('tabindex', '-1')
+    const nextTile = tiles[nextIndex] as HTMLElement
+    nextTile.setAttribute('tabindex', '0')
+    nextTile.focus()
+  }
+  root.addEventListener('keydown', handler)
+  return () => root.removeEventListener('keydown', handler)
+}
+
+// ---------------------------------------------------------------------------
+// Staleness tracking (Codex #10) — pure decision logic. A single transient
+// failure must NOT wipe good data or show an error state; only 3 consecutive
+// failures (~2+ minutes at the 45s poll interval) flags the displayed data as
+// potentially stale.
+// ---------------------------------------------------------------------------
+
+export const STALE_AFTER_CONSECUTIVE_FAILURES = 3
+
+export interface PollOutcomeState {
+  consecutiveFailures: number
+  isStale: boolean
+}
+
+export function nextPollOutcomeState(
+  previous: PollOutcomeState,
+  succeeded: boolean
+): PollOutcomeState {
+  if (succeeded) {
+    return { consecutiveFailures: 0, isStale: false }
+  }
+  const consecutiveFailures = previous.consecutiveFailures + 1
+  return {
+    consecutiveFailures,
+    isStale: consecutiveFailures >= STALE_AFTER_CONSECUTIVE_FAILURES,
+  }
+}
+
+export const INITIAL_POLL_OUTCOME_STATE: PollOutcomeState = {
+  consecutiveFailures: 0,
+  isStale: false,
+}
+
+// ---------------------------------------------------------------------------
+// Poll lifecycle controller (Codex #4) — recursive setTimeout (never
+// setInterval), AbortController per in-flight fetch, and a monotonically
+// incrementing generation counter so a response resolving after
+// astro:before-swap is discarded rather than applied to a torn-down page.
+// ---------------------------------------------------------------------------
+
+export interface StatusPollerCallbacks {
+  onResult(payload: StatusResponse): void
+  onStaleChange(isStale: boolean): void
+}
+
+export interface StatusPollerOptions {
+  apiUrl: string
+  fetchImpl?: typeof fetch
+  intervalMs?: number
+  setTimeoutImpl?: typeof setTimeout
+  clearTimeoutImpl?: typeof clearTimeout
+}
+
+export interface StatusPoller {
+  /** Fires an immediate poll, then starts the recursive-timeout loop. */
+  start(): void
+  /** Permanently tears down the poller (page unload). */
+  stop(): void
+  /** astro:before-swap — abort in-flight, clear pending timeout, bump generation. */
+  handleBeforeSwap(): void
+  /** visibilitychange → hidden — true pause; does not abort an almost-done fetch. */
+  handleVisibilityHidden(): void
+  /** visibilitychange → visible — fetch immediately if idle; otherwise let the loop resume. */
+  handleVisibilityVisible(): void
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 45_000
+
+export function createStatusPoller(
+  options: StatusPollerOptions,
+  callbacks: StatusPollerCallbacks
+): StatusPoller {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const intervalMs = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  const setTimeoutImpl = options.setTimeoutImpl ?? setTimeout
+  const clearTimeoutImpl = options.clearTimeoutImpl ?? clearTimeout
+
+  let generation = 0
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null
+  let abortController: AbortController | null = null
+  let inFlight = false
+  let paused = false
+  let outcomeState: PollOutcomeState = INITIAL_POLL_OUTCOME_STATE
+
+  function clearPendingTimeout(): void {
+    if (timeoutHandle !== null) {
+      clearTimeoutImpl(timeoutHandle)
+      timeoutHandle = null
+    }
+  }
+
+  function scheduleNext(): void {
+    clearPendingTimeout()
+    if (paused) return
+    timeoutHandle = setTimeoutImpl(() => {
+      void runPoll()
+    }, intervalMs)
+  }
+
+  async function runPoll(): Promise<void> {
+    const thisGeneration = generation
+    abortController = new AbortController()
+    inFlight = true
+    try {
+      const res = await fetchImpl(options.apiUrl, { signal: abortController.signal })
+      if (thisGeneration !== generation) return
+      if (!res.ok) throw new Error(`status-public HTTP ${res.status}`)
+      const json: unknown = await res.json()
+      if (thisGeneration !== generation) return
+      const validated = validateStatusPayload(json)
+      if (!validated) throw new Error('status-public: invalid payload shape')
+
+      outcomeState = nextPollOutcomeState(outcomeState, true)
+      callbacks.onResult(validated)
+      callbacks.onStaleChange(outcomeState.isStale)
+    } catch {
+      if (thisGeneration !== generation) return
+      outcomeState = nextPollOutcomeState(outcomeState, false)
+      callbacks.onStaleChange(outcomeState.isStale)
+    } finally {
+      inFlight = false
+      abortController = null
+      if (thisGeneration === generation) scheduleNext()
+    }
+  }
+
+  return {
+    start() {
+      void runPoll()
+    },
+    stop() {
+      generation++
+      clearPendingTimeout()
+      abortController?.abort()
+    },
+    handleBeforeSwap() {
+      abortController?.abort()
+      clearPendingTimeout()
+      generation++
+    },
+    handleVisibilityHidden() {
+      paused = true
+      clearPendingTimeout()
+    },
+    handleVisibilityVisible() {
+      paused = false
+      if (!inFlight && timeoutHandle === null) {
+        void runPoll()
+      }
+      // If a fetch is already in-flight, runPoll's `finally` block calls
+      // scheduleNext() once it settles — paused is already false by then.
+    },
+  }
+}

--- a/packages/website/src/lib/status-reconcile.test.ts
+++ b/packages/website/src/lib/status-reconcile.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { dedupeComponentsBySlug, planComponentReconciliation } from './status-reconcile'
+import { COMPONENTS, type StatusComponent } from './status-vocab'
+
+function makeComponent(overrides: Partial<StatusComponent> = {}): StatusComponent {
+  return {
+    slug: 'website',
+    name: 'Website',
+    description: 'desc',
+    display_order: 0,
+    status: 'operational',
+    latency_ms: 42,
+    message: 'All good',
+    checked_at: '2026-07-15T00:00:00Z',
+    uptime_90d: [],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic-row reconciliation contract (Codex #3)
+// ---------------------------------------------------------------------------
+
+describe('dedupeComponentsBySlug', () => {
+  it('skips a duplicate slug, keeping the first occurrence', () => {
+    const { components, duplicateSlugs } = dedupeComponentsBySlug([
+      makeComponent({ slug: 'a', name: 'First' }),
+      makeComponent({ slug: 'a', name: 'Second' }),
+      makeComponent({ slug: 'b' }),
+    ])
+    expect(components.map((c) => c.slug)).toEqual(['a', 'b'])
+    expect(components[0].name).toBe('First')
+    expect(duplicateSlugs).toEqual(['a'])
+  })
+})
+
+describe('planComponentReconciliation', () => {
+  const scaffoldSlugs = new Set(COMPONENTS.map((c) => c.slug))
+
+  it('an unrecognized slug is planned for creation as a dynamic row', () => {
+    const plan = planComponentReconciliation(
+      [makeComponent({ slug: 'a-new-service' })],
+      new Set(scaffoldSlugs),
+      scaffoldSlugs
+    )
+    expect(plan.toCreate.map((c) => c.slug)).toEqual(['a-new-service'])
+    expect(plan.toUpsert).toHaveLength(0)
+  })
+
+  it('the dynamic-row contract: created on first poll, removed once absent from a later poll', () => {
+    // First poll: a payload with an unrecognized slug.
+    const firstPlan = planComponentReconciliation(
+      [makeComponent({ slug: 'ephemeral-service' })],
+      new Set(scaffoldSlugs),
+      scaffoldSlugs
+    )
+    expect(firstPlan.toCreate.map((c) => c.slug)).toEqual(['ephemeral-service'])
+
+    // Simulate the row having been created and now existing in the DOM.
+    const existingAfterCreate = new Set([...scaffoldSlugs, 'ephemeral-service'])
+
+    // Second poll: the payload no longer includes that slug.
+    const secondPlan = planComponentReconciliation([], existingAfterCreate, scaffoldSlugs)
+    expect(secondPlan.toRemoveSlugs).toEqual(['ephemeral-service'])
+    // Every fixed scaffold slug is reset, never removed.
+    expect(secondPlan.toResetSlugs.sort()).toEqual([...scaffoldSlugs].sort())
+    expect(secondPlan.toRemoveSlugs).not.toEqual(expect.arrayContaining([...scaffoldSlugs]))
+  })
+
+  it('a scaffold slug absent from the payload is reset, never removed', () => {
+    const plan = planComponentReconciliation([], new Set(scaffoldSlugs), scaffoldSlugs)
+    expect(plan.toResetSlugs.sort()).toEqual([...scaffoldSlugs].sort())
+    expect(plan.toRemoveSlugs).toEqual([])
+  })
+
+  it('an existing scaffold slug present in the payload is upserted, not recreated', () => {
+    const plan = planComponentReconciliation(
+      [makeComponent({ slug: 'website' })],
+      new Set(scaffoldSlugs),
+      scaffoldSlugs
+    )
+    expect(plan.toUpsert.map((c) => c.slug)).toEqual(['website'])
+    expect(plan.toCreate).toHaveLength(0)
+  })
+
+  it('deduplicates the payload before planning (a duplicate slug is not created twice)', () => {
+    const plan = planComponentReconciliation(
+      [makeComponent({ slug: 'dup' }), makeComponent({ slug: 'dup' })],
+      new Set(scaffoldSlugs),
+      scaffoldSlugs
+    )
+    expect(plan.toCreate).toHaveLength(1)
+  })
+})

--- a/packages/website/src/lib/status-reconcile.ts
+++ b/packages/website/src/lib/status-reconcile.ts
@@ -1,0 +1,81 @@
+/**
+ * Dynamic-row reconciliation contract (SMI-5755, Wave 5, Codex #3,
+ * merge-blocking). Split out of status-client.ts to stay under the repo's
+ * 500-line-per-file gate — see status-client.ts's barrel re-export + header
+ * comment for the full module-split rationale.
+ */
+
+import type { StatusComponent } from './status-vocab'
+
+export interface ComponentDedupeResult {
+  components: StatusComponent[]
+  duplicateSlugs: string[]
+}
+
+/** Validates `data.components` slugs are unique; a duplicate is skipped (not rendered twice). */
+export function dedupeComponentsBySlug(components: StatusComponent[]): ComponentDedupeResult {
+  const seen = new Set<string>()
+  const deduped: StatusComponent[] = []
+  const duplicateSlugs: string[] = []
+  for (const component of components) {
+    if (seen.has(component.slug)) {
+      duplicateSlugs.push(component.slug)
+      continue
+    }
+    seen.add(component.slug)
+    deduped.push(component)
+  }
+  return { components: deduped, duplicateSlugs }
+}
+
+export interface ReconcilePlan {
+  /** Existing rows (scaffold or previously-dynamic) to update in place. */
+  toUpsert: StatusComponent[]
+  /** Payload components with no existing row — create and track as "dynamic". */
+  toCreate: StatusComponent[]
+  /** Dynamic rows whose slug is no longer in the payload — remove entirely. */
+  toRemoveSlugs: string[]
+  /** Fixed scaffold rows whose slug is absent from the payload — reset, never removed. */
+  toResetSlugs: string[]
+}
+
+/**
+ * The reconciliation contract run on every poll:
+ *   1. Dedupe payload components by slug (skip/log duplicates).
+ *   2. Existing row for a payload slug → update in place; no existing row →
+ *      create + track as dynamic.
+ *   3. A dynamic row whose slug is no longer present → removed entirely.
+ *   4. A fixed scaffold row whose slug is absent → reset to unknown/no-data,
+ *      never removed.
+ */
+export function planComponentReconciliation(
+  payloadComponents: StatusComponent[],
+  existingSlugs: ReadonlySet<string>,
+  scaffoldSlugs: ReadonlySet<string>
+): ReconcilePlan {
+  const { components: deduped } = dedupeComponentsBySlug(payloadComponents)
+  const payloadSlugs = new Set(deduped.map((c) => c.slug))
+
+  const toUpsert: StatusComponent[] = []
+  const toCreate: StatusComponent[] = []
+  for (const component of deduped) {
+    if (existingSlugs.has(component.slug)) {
+      toUpsert.push(component)
+    } else {
+      toCreate.push(component)
+    }
+  }
+
+  const toRemoveSlugs: string[] = []
+  const toResetSlugs: string[] = []
+  for (const slug of existingSlugs) {
+    if (payloadSlugs.has(slug)) continue
+    if (scaffoldSlugs.has(slug)) {
+      toResetSlugs.push(slug)
+    } else {
+      toRemoveSlugs.push(slug)
+    }
+  }
+
+  return { toUpsert, toCreate, toRemoveSlugs, toResetSlugs }
+}

--- a/packages/website/src/lib/status-render.test.ts
+++ b/packages/website/src/lib/status-render.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applyComponentRowContent,
+  buildAffectedComponentsText,
+  buildComponentRowContent,
+  buildComponentsBySlug,
+  buildIncidentContent,
+  buildScaffoldResetContent,
+  refreshUptimeStripTiles,
+  type ComponentRowElements,
+} from './status-render'
+import { COMPONENTS, type StatusComponent, type StatusIncident } from './status-vocab'
+
+const ADVERSARIAL = '<script>alert(1)</script>'
+
+function makeComponent(overrides: Partial<StatusComponent> = {}): StatusComponent {
+  return {
+    slug: 'website',
+    name: 'Website',
+    description: 'desc',
+    display_order: 0,
+    status: 'operational',
+    latency_ms: 42,
+    message: 'All good',
+    checked_at: '2026-07-15T00:00:00Z',
+    uptime_90d: [],
+    ...overrides,
+  }
+}
+
+function makeIncident(overrides: Partial<StatusIncident> = {}): StatusIncident {
+  return {
+    id: 'inc-1',
+    title: 'Some incident',
+    impact: 'minor',
+    status: 'investigating',
+    started_at: '2026-07-15T00:00:00Z',
+    resolved_at: null,
+    affected_components: [],
+    updates: [],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Untrusted-field rendering path — proven inert (never innerHTML)
+// ---------------------------------------------------------------------------
+
+describe('buildComponentRowContent / applyComponentRowContent', () => {
+  it('preserves an adversarial name/message unchanged in the content descriptor', () => {
+    const content = buildComponentRowContent(
+      makeComponent({ name: ADVERSARIAL, message: ADVERSARIAL })
+    )
+    expect(content.name).toBe(ADVERSARIAL)
+    expect(content.message).toBe(ADVERSARIAL)
+  })
+
+  it('applies content via textContent/className only — never touches innerHTML', () => {
+    let innerHtmlWrites = 0
+    function makeTrapEl() {
+      let text = ''
+      return {
+        get textContent() {
+          return text
+        },
+        set textContent(v: string) {
+          text = v
+        },
+        get innerHTML() {
+          return ''
+        },
+        set innerHTML(_v: string) {
+          innerHtmlWrites++
+        },
+      }
+    }
+    const elements: ComponentRowElements = {
+      nameEl: makeTrapEl(),
+      messageEl: makeTrapEl(),
+      latencyEl: makeTrapEl(),
+      checkedAtEl: makeTrapEl(),
+      pillTextEl: makeTrapEl(),
+      pillEl: { className: '' },
+    }
+
+    const content = buildComponentRowContent(
+      makeComponent({ name: ADVERSARIAL, message: ADVERSARIAL })
+    )
+    applyComponentRowContent(elements, content)
+
+    expect(innerHtmlWrites).toBe(0)
+    // The adversarial string is inert — it landed as a literal text value,
+    // never parsed as markup (there is no element for it to have become).
+    expect(elements.nameEl.textContent).toBe(ADVERSARIAL)
+    expect(elements.messageEl.textContent).toBe(ADVERSARIAL)
+    expect(typeof elements.pillEl.className).toBe('string')
+  })
+
+  it('never fabricates an "operational"-looking pill for an unrecognized status', () => {
+    const content = buildComponentRowContent(makeComponent({ status: 'totally-bogus' as never }))
+    expect(content.status).toBe('unknown')
+    expect(content.statusLabel).toBe('Unknown')
+  })
+})
+
+describe('buildScaffoldResetContent', () => {
+  it('resets to unknown status with the distinct "No data reported." message', () => {
+    const content = buildScaffoldResetContent({ slug: 'website', name: 'Website', description: '' })
+    expect(content.status).toBe('unknown')
+    expect(content.message).toBe('No data reported.')
+  })
+})
+
+describe('buildAffectedComponentsText', () => {
+  it('resolves a known slug to its display name', () => {
+    const map = new Map([['website', { name: 'Website' }]])
+    expect(buildAffectedComponentsText(['website'], map)).toBe('Website')
+  })
+
+  it('falls back to the raw slug when it matches no current component', () => {
+    const map = new Map([['website', { name: 'Website' }]])
+    expect(buildAffectedComponentsText(['website', 'deleted-service'], map)).toBe(
+      'Website, deleted-service'
+    )
+  })
+
+  it("preserves an adversarial name/slug unchanged (safety is the caller's textContent usage)", () => {
+    const map = new Map([['x', { name: ADVERSARIAL }]])
+    expect(buildAffectedComponentsText(['x'], map)).toBe(ADVERSARIAL)
+    expect(buildAffectedComponentsText([ADVERSARIAL], new Map())).toBe(ADVERSARIAL)
+  })
+})
+
+describe('buildComponentsBySlug', () => {
+  it('FIX (medium): uses the LIVE payload display name for a fixed scaffold slug, even when renamed from the compile-time scaffold', () => {
+    const scaffoldWebsite = COMPONENTS.find((c) => c.slug === 'website')!
+    const map = buildComponentsBySlug(
+      [makeComponent({ slug: 'website', name: 'Renamed Website Component' })],
+      COMPONENTS
+    )
+    expect(map.get('website')?.name).toBe('Renamed Website Component')
+    expect(map.get('website')?.name).not.toBe(scaffoldWebsite.name)
+  })
+
+  it('resolves a dynamic (non-scaffold) component to its live display name, not its raw slug', () => {
+    const map = buildComponentsBySlug(
+      [makeComponent({ slug: 'a-new-service', name: 'A New Service' })],
+      COMPONENTS
+    )
+    expect(map.get('a-new-service')?.name).toBe('A New Service')
+  })
+
+  it('falls back to the static scaffold name for a fixed slug absent from the current payload', () => {
+    const map = buildComponentsBySlug([], COMPONENTS)
+    const scaffoldWebsite = COMPONENTS.find((c) => c.slug === 'website')!
+    expect(map.get('website')?.name).toBe(scaffoldWebsite.name)
+  })
+})
+
+describe('buildIncidentContent', () => {
+  it('preserves an adversarial title/update-message unchanged', () => {
+    const content = buildIncidentContent(
+      makeIncident({
+        title: ADVERSARIAL,
+        affected_components: ['website'],
+        updates: [
+          { status: 'investigating', message: ADVERSARIAL, posted_at: '2026-07-15T00:00:00Z' },
+        ],
+      }),
+      new Map([['website', { name: 'Website' }]])
+    )
+    expect(content.title).toBe(ADVERSARIAL)
+    expect(content.updates[0].message).toBe(ADVERSARIAL)
+    expect(content.affectedText).toBe('Website')
+  })
+
+  it('falls back to the raw status string when the incident status is unrecognized', () => {
+    const content = buildIncidentContent(makeIncident({ status: 'weird' as never }), new Map())
+    expect(content.statusLabel).toBe('weird')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Uptime tile refresh (uses the same shared vocab helpers as the SSR render)
+// ---------------------------------------------------------------------------
+
+describe('refreshUptimeStripTiles', () => {
+  it('updates exactly 90 pre-existing tile handles in place, never adding/removing', () => {
+    const handles = Array.from({ length: 90 }, () => ({
+      className: '',
+      attrs: {} as Record<string, string>,
+      setAttribute(n: string, v: string) {
+        this.attrs[n] = v
+      },
+    }))
+    refreshUptimeStripTiles(handles, [], '2026-07-15')
+    expect(handles).toHaveLength(90)
+    expect(handles[89].className).toContain('bg-gray-700')
+    expect(handles[89].attrs['aria-label']).toContain('No data')
+  })
+
+  it('does not touch a strip handle when none is supplied (backward compatible)', () => {
+    const handles = Array.from({ length: 90 }, () => ({
+      className: '',
+      setAttribute() {},
+    }))
+    expect(() => refreshUptimeStripTiles(handles, [], '2026-07-15')).not.toThrow()
+  })
+
+  it('FIX (medium): also refreshes the containing strip group aria-label from real data, not the stale SSR-time empty-scaffold summary', () => {
+    const handles = Array.from({ length: 90 }, () => ({
+      className: '',
+      setAttribute() {},
+    }))
+    const stripAttrs: Record<string, string> = {}
+    const stripHandle = {
+      setAttribute(n: string, v: string) {
+        stripAttrs[n] = v
+      },
+    }
+    const uptime90d = [
+      {
+        day: '2026-07-15',
+        uptime_pct: 100,
+        worst_status: 'operational' as const,
+        total_checks: 288,
+      },
+    ]
+
+    refreshUptimeStripTiles(handles, uptime90d, '2026-07-15', stripHandle, 'Website')
+
+    // A stale SSR-time (empty-scaffold) label would read "0 operational ...
+    // 90 no data" regardless of what actually got painted.
+    expect(stripAttrs['aria-label']).toBe(
+      'Website: 90-day uptime — 1 operational, 0 degraded, 0 outage, 89 no data'
+    )
+  })
+})

--- a/packages/website/src/lib/status-render.ts
+++ b/packages/website/src/lib/status-render.ts
@@ -1,0 +1,253 @@
+/**
+ * Safe render-content builders for the status page (SMI-5755, Wave 5).
+ * Split out of status-client.ts to stay under the repo's 500-line-per-file
+ * gate — see status-client.ts's barrel re-export + header comment for the
+ * full module-split rationale.
+ *
+ * Untrusted-field inventory handled here (Codex #1/#2): `component.message`,
+ * `component.name`, `incident.title`, `incident.updates[].message`, and the
+ * affected-component display-name lookup + raw-slug fallback. Every builder
+ * below is pure and DOM-free; the shared applier
+ * (`applyComponentRowContent`) writes via `textContent`/`className` only —
+ * never `innerHTML` — for BOTH scaffold and dynamic rows alike (Codex #3
+ * point 5).
+ */
+
+import {
+  buildUptimeGrid,
+  buildUptimeStripAriaLabel,
+  coerceComponentStatus,
+  IMPACT_CLASSES,
+  IMPACT_LABELS,
+  INCIDENT_STATUS_LABELS,
+  isFiniteNumber,
+  PILL_BASE,
+  PILL_SIZE,
+  SCAFFOLD_NO_DATA_MESSAGE,
+  STATUS_LABELS,
+  STATUS_PILL_CLASSES,
+  uptimeTileClassName,
+  uptimeTileText,
+  type ComponentScaffoldEntry,
+  type ComponentStatus,
+  type StatusComponent,
+  type StatusIncident,
+  type UptimeDay,
+} from './status-vocab'
+
+export interface ComponentRowContent {
+  slug: string
+  /** Untrusted — apply via textContent only. */
+  name: string
+  /** Untrusted — apply via textContent only. */
+  message: string
+  status: ComponentStatus
+  /** Trusted vocab label. */
+  statusLabel: string
+  /** Trusted vocab-only class string. */
+  pillClassName: string
+  /** Trusted, computed. */
+  latencyText: string
+  /** Trusted, computed. */
+  checkedAtText: string
+}
+
+function buildPillClassName(status: ComponentStatus): string {
+  const colors = STATUS_PILL_CLASSES[status] ?? STATUS_PILL_CLASSES.unknown
+  return [PILL_BASE, colors.bgColor, colors.textColor, colors.borderColor, PILL_SIZE.sm].join(' ')
+}
+
+export function buildComponentRowContent(component: StatusComponent): ComponentRowContent {
+  const status = coerceComponentStatus(component.status)
+  return {
+    slug: component.slug,
+    name: component.name,
+    message: component.message,
+    status,
+    statusLabel: STATUS_LABELS[status],
+    pillClassName: buildPillClassName(status),
+    latencyText: isFiniteNumber(component.latency_ms) ? `${component.latency_ms} ms` : '—',
+    checkedAtText: component.checked_at ?? '—',
+  }
+}
+
+/** Reset content for a fixed scaffold row absent from the current payload (Codex #15). */
+export function buildScaffoldResetContent(scaffold: ComponentScaffoldEntry): ComponentRowContent {
+  return {
+    slug: scaffold.slug,
+    name: scaffold.name,
+    message: SCAFFOLD_NO_DATA_MESSAGE,
+    status: 'unknown',
+    statusLabel: STATUS_LABELS.unknown,
+    pillClassName: buildPillClassName('unknown'),
+    latencyText: '—',
+    checkedAtText: '—',
+  }
+}
+
+/**
+ * Minimal structural contract for a rendered row's DOM handles — real
+ * `HTMLElement`s satisfy this interface directly (no adapter needed in
+ * production); tests pass plain objects instead of standing up a DOM.
+ */
+export interface ComponentRowElements {
+  nameEl: { textContent: string }
+  messageEl: { textContent: string }
+  latencyEl: { textContent: string }
+  checkedAtEl: { textContent: string }
+  pillTextEl: { textContent: string }
+  pillEl: { className: string }
+}
+
+/**
+ * The single shared row-render function used for both the initial scaffold
+ * rows and any dynamically-appended row (Codex #3 point 5). Untrusted fields
+ * (`content.name`, `content.message`) are written via `textContent` only.
+ */
+export function applyComponentRowContent(
+  elements: ComponentRowElements,
+  content: ComponentRowContent
+): void {
+  elements.nameEl.textContent = content.name
+  elements.messageEl.textContent = content.message
+  elements.latencyEl.textContent = content.latencyText
+  elements.checkedAtEl.textContent = content.checkedAtText
+  elements.pillTextEl.textContent = content.statusLabel
+  elements.pillEl.className = content.pillClassName
+}
+
+/**
+ * Minimal structural contract for a rendered uptime tile's DOM handle — real
+ * tile `HTMLElement`s satisfy this directly.
+ */
+export interface UptimeTileHandle {
+  className: string
+  setAttribute(name: string, value: string): void
+}
+
+/**
+ * Minimal structural contract for the containing strip's `[data-uptime-strip]`
+ * DOM handle — real `HTMLElement`s satisfy this directly.
+ */
+export interface UptimeStripHandle {
+  setAttribute(name: string, value: string): void
+}
+
+/**
+ * Refreshes an already-rendered 90-tile uptime strip in place (the strip
+ * always starts with exactly 90 "no data" tiles from the SSR scaffold or the
+ * cloned row template, so this only ever updates class/title/aria-label on
+ * existing tiles — it never adds or removes tile elements).
+ *
+ * FIX (medium): `stripHandle`/`label` are optional so existing callers keep
+ * working unchanged, but when supplied, the containing strip's OWN
+ * `role="group"` `aria-label` is also recomputed from the same tile grid via
+ * `buildUptimeStripAriaLabel` (../lib/status-vocab.ts) — previously only the
+ * per-tile `aria-label`s were refreshed, leaving the group-level summary
+ * stuck at its SSR-time "0 operational ... 90 no data" reading forever.
+ */
+export function refreshUptimeStripTiles(
+  tileHandles: UptimeTileHandle[],
+  uptime90d: UptimeDay[],
+  anchorIsoDate: string,
+  stripHandle?: UptimeStripHandle | null,
+  label?: string
+): void {
+  const tiles = buildUptimeGrid(uptime90d, anchorIsoDate)
+  const count = Math.min(tileHandles.length, tiles.length)
+  for (let i = 0; i < count; i++) {
+    const tile = tiles[i]
+    const handle = tileHandles[i]
+    const text = uptimeTileText(tile)
+    handle.className = uptimeTileClassName(tile.status)
+    handle.setAttribute('title', text)
+    handle.setAttribute('aria-label', text)
+  }
+
+  if (stripHandle && label !== undefined) {
+    stripHandle.setAttribute('aria-label', buildUptimeStripAriaLabel(tiles, label))
+  }
+}
+
+/**
+ * Resolves each affected-component slug to its current display name, falling
+ * back to the raw slug when it doesn't match any current component. Returns
+ * plain text — safe only because every caller assigns the result via
+ * `textContent`, never `innerHTML`.
+ */
+export function buildAffectedComponentsText(
+  affectedSlugs: string[],
+  componentsBySlug: ReadonlyMap<string, { name: string }>
+): string {
+  return affectedSlugs.map((slug) => componentsBySlug.get(slug)?.name ?? slug).join(', ')
+}
+
+/**
+ * Builds the affected-components lookup map FRESH from the current poll's
+ * live `components` (FIX, medium: previously a static map built ONCE at
+ * module scope from the compile-time scaffold, never updated with live
+ * data — a renamed fixed component or an incident affecting a dynamic
+ * non-scaffold component would resolve to a stale/raw-slug name forever).
+ *
+ * Seeded from the static scaffold first (so a fixed slug still resolves to
+ * something sane if a later poll's payload omits it — mirroring the same
+ * reset-to-scaffold-name semantics `buildScaffoldResetContent` already uses
+ * for a missing scaffold row), then every live component overwrites its own
+ * slug with its CURRENT display name — this covers both a renamed fixed
+ * component and any dynamic (non-scaffold) component.
+ */
+export function buildComponentsBySlug(
+  components: StatusComponent[],
+  scaffold: ComponentScaffoldEntry[]
+): Map<string, { name: string }> {
+  const map = new Map<string, { name: string }>()
+  for (const entry of scaffold) {
+    map.set(entry.slug, { name: entry.name })
+  }
+  for (const component of components) {
+    map.set(component.slug, { name: component.name })
+  }
+  return map
+}
+
+export interface IncidentUpdateContent {
+  statusLabel: string
+  /** Untrusted — apply via textContent only. */
+  message: string
+  postedAtText: string
+}
+
+export interface IncidentContent {
+  id: string
+  /** Untrusted — apply via textContent only. */
+  title: string
+  impactLabel: string
+  impactClassName: string
+  statusLabel: string
+  /** Untrusted (component names / raw-slug fallback) — apply via textContent only. */
+  affectedText: string
+  startedAtText: string
+  resolvedAtText: string
+  updates: IncidentUpdateContent[]
+}
+
+export function buildIncidentContent(
+  incident: StatusIncident,
+  componentsBySlug: ReadonlyMap<string, { name: string }>
+): IncidentContent {
+  return {
+    id: incident.id,
+    title: incident.title,
+    impactLabel: IMPACT_LABELS[incident.impact] ?? IMPACT_LABELS.none,
+    impactClassName: IMPACT_CLASSES[incident.impact] ?? IMPACT_CLASSES.none,
+    statusLabel: INCIDENT_STATUS_LABELS[incident.status] ?? incident.status,
+    affectedText: buildAffectedComponentsText(incident.affected_components, componentsBySlug),
+    startedAtText: incident.started_at || '—',
+    resolvedAtText: incident.resolved_at ?? 'Ongoing',
+    updates: incident.updates.map((update) => ({
+      statusLabel: INCIDENT_STATUS_LABELS[update.status] ?? update.status,
+      message: update.message,
+      postedAtText: update.posted_at || '—',
+    })),
+  }
+}

--- a/packages/website/src/lib/status-vocab.test.ts
+++ b/packages/website/src/lib/status-vocab.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildUptimeGrid,
+  buildUptimeStripAriaLabel,
+  coerceComponentStatus,
+  COMPONENTS,
+  isFiniteNumber,
+  isNonNegativeInteger,
+  isValidDayString,
+  NO_DATA_TILE_CLASS,
+  OVERALL_BANNER,
+  SCAFFOLD_NO_DATA_MESSAGE,
+  STATUS_LABELS,
+  STATUS_PILL_CLASSES,
+  STATUS_TILE_CLASSES,
+  uptimeTileText,
+  type ComponentStatus,
+  type DayStatus,
+  type UptimeDay,
+} from './status-vocab'
+
+const ANCHOR = '2026-07-15' // arbitrary fixed calendar date, well within a plausible UTC day
+
+function makeDay(day: string, overrides: Partial<UptimeDay> = {}): UptimeDay {
+  return {
+    day,
+    uptime_pct: 99.9,
+    worst_status: 'operational',
+    total_checks: 288,
+    ...overrides,
+  }
+}
+
+describe('buildUptimeGrid', () => {
+  it('returns exactly 90 tiles, oldest first, anchor day last', () => {
+    const tiles = buildUptimeGrid([], ANCHOR)
+    expect(tiles).toHaveLength(90)
+    expect(tiles[89].date).toBe(ANCHOR)
+    // Oldest tile is 89 days before the anchor.
+    expect(tiles[0].date).toBe('2026-04-17')
+  })
+
+  it('is anchored to the supplied ISO date, not the system clock (Codex #6)', () => {
+    // Regardless of when the test runs, the grid must reflect the anchor we
+    // pass in, never Date.now()/local "today".
+    const tiles = buildUptimeGrid([], '2020-01-01')
+    expect(tiles[89].date).toBe('2020-01-01')
+    expect(tiles[0].date).toBe('2019-10-04')
+  })
+
+  it('walks across a month/year boundary correctly using UTC arithmetic', () => {
+    const tiles = buildUptimeGrid([], '2026-01-01')
+    expect(tiles[89].date).toBe('2026-01-01')
+    expect(tiles[88].date).toBe('2025-12-31')
+    expect(tiles[0].date).toBe('2025-10-04')
+  })
+
+  it('places a present day at the correct tile with its real status/uptime', () => {
+    const tiles = buildUptimeGrid(
+      [makeDay(ANCHOR, { worst_status: 'degraded', uptime_pct: 87.5 })],
+      ANCHOR
+    )
+    const anchorTile = tiles[89]
+    expect(anchorTile.status).toBe('degraded')
+    expect(anchorTile.uptimePct).toBe(87.5)
+  })
+
+  it('a day absent from uptime_90d renders as no-data (status null), never fabricated', () => {
+    const tiles = buildUptimeGrid([], ANCHOR)
+    for (const tile of tiles) {
+      expect(tile.status).toBeNull()
+      expect(tile.uptimePct).toBeNull()
+    }
+  })
+
+  it('FIX (Codex #6/#9): a malformed `day` string is skipped, not silently mismatched', () => {
+    const tiles = buildUptimeGrid(
+      [
+        makeDay('not-a-date'),
+        makeDay('2026-13-40'), // wrong format, still matches nothing real
+        makeDay(ANCHOR, { worst_status: 'outage' }),
+      ],
+      ANCHOR
+    )
+    // The malformed entries must not corrupt the anchor day's real entry.
+    expect(tiles[89].status).toBe('outage')
+    // And they must not appear as a spurious tile anywhere in the grid.
+    expect(tiles.some((t) => t.date === 'not-a-date')).toBe(false)
+  })
+
+  it('FIX (Codex #6): a duplicate valid day key is last-one-wins (documented, low-risk default)', () => {
+    const tiles = buildUptimeGrid(
+      [
+        makeDay(ANCHOR, { worst_status: 'operational', uptime_pct: 100 }),
+        makeDay(ANCHOR, { worst_status: 'outage', uptime_pct: 12.3 }),
+      ],
+      ANCHOR
+    )
+    expect(tiles[89].status).toBe('outage')
+    expect(tiles[89].uptimePct).toBe(12.3)
+  })
+
+  it('FIX (high): an invalid uptime_pct forces the WHOLE day to no-data, never a fake green tile', () => {
+    const tiles = buildUptimeGrid(
+      [makeDay(ANCHOR, { uptime_pct: null as unknown as number, worst_status: 'operational' })],
+      ANCHOR
+    )
+    // Previously: the day's `worst_status` was kept ('operational') while
+    // only `uptime_pct` fell back to null -- rendering a plain green
+    // "Operational" tile with no percentage shown instead of "No data". A
+    // corrupted uptime_pct signals the whole rollup row can't be trusted,
+    // not just this one field, so BOTH must resolve to no-data now.
+    expect(tiles[89].status).toBeNull()
+    expect(tiles[89].uptimePct).toBeNull()
+  })
+
+  it('FIX (Codex #9): empty-string uptime_pct also forces no-data, never a fake 0%', () => {
+    const tiles = buildUptimeGrid(
+      [makeDay(ANCHOR, { uptime_pct: '' as unknown as number })],
+      ANCHOR
+    )
+    expect(tiles[89].status).toBeNull()
+    expect(tiles[89].uptimePct).toBeNull()
+  })
+
+  it('clamps an out-of-range but numeric uptime_pct into [0, 100]', () => {
+    const tiles = buildUptimeGrid([makeDay(ANCHOR, { uptime_pct: 150 })], ANCHOR)
+    expect(tiles[89].uptimePct).toBe(100)
+    const tilesNeg = buildUptimeGrid([makeDay(ANCHOR, { uptime_pct: -10 })], ANCHOR)
+    expect(tilesNeg[89].uptimePct).toBe(0)
+  })
+
+  it('validates total_checks as a non-negative finite integer, falling back to null', () => {
+    const tiles = buildUptimeGrid(
+      [makeDay(ANCHOR, { total_checks: -5 as unknown as number })],
+      ANCHOR
+    )
+    expect(tiles[89].totalChecks).toBeNull()
+
+    const tilesNonInt = buildUptimeGrid(
+      [makeDay(ANCHOR, { total_checks: 1.5 as unknown as number })],
+      ANCHOR
+    )
+    expect(tilesNonInt[89].totalChecks).toBeNull()
+
+    const tilesGood = buildUptimeGrid([makeDay(ANCHOR, { total_checks: 288 })], ANCHOR)
+    expect(tilesGood[89].totalChecks).toBe(288)
+  })
+
+  it('an unrecognized worst_status coerces the tile status to null (no-data), not a guess', () => {
+    const tiles = buildUptimeGrid(
+      [makeDay(ANCHOR, { worst_status: 'bogus' as unknown as DayStatus })],
+      ANCHOR
+    )
+    expect(tiles[89].status).toBeNull()
+  })
+
+  it('returns an empty array for a malformed anchorIsoDate rather than throwing', () => {
+    expect(buildUptimeGrid([], 'not-a-date')).toEqual([])
+    expect(buildUptimeGrid([], '')).toEqual([])
+  })
+})
+
+describe('isValidDayString / isFiniteNumber / isNonNegativeInteger', () => {
+  it('accepts only YYYY-MM-DD strings', () => {
+    expect(isValidDayString('2026-01-01')).toBe(true)
+    expect(isValidDayString('2026-1-1')).toBe(false)
+    expect(isValidDayString(20260101)).toBe(false)
+    expect(isValidDayString(null)).toBe(false)
+    expect(isValidDayString(undefined)).toBe(false)
+  })
+
+  it('isFiniteNumber rejects null/NaN/Infinity/strings', () => {
+    expect(isFiniteNumber(1)).toBe(true)
+    expect(isFiniteNumber(0)).toBe(true)
+    expect(isFiniteNumber(null)).toBe(false)
+    expect(isFiniteNumber(undefined)).toBe(false)
+    expect(isFiniteNumber(Number.NaN)).toBe(false)
+    expect(isFiniteNumber(Number.POSITIVE_INFINITY)).toBe(false)
+    expect(isFiniteNumber('1')).toBe(false)
+  })
+
+  it('isNonNegativeInteger rejects negatives and non-integers', () => {
+    expect(isNonNegativeInteger(0)).toBe(true)
+    expect(isNonNegativeInteger(42)).toBe(true)
+    expect(isNonNegativeInteger(-1)).toBe(false)
+    expect(isNonNegativeInteger(1.5)).toBe(false)
+    expect(isNonNegativeInteger(null)).toBe(false)
+  })
+})
+
+describe('coerceComponentStatus', () => {
+  it('passes through known statuses unchanged', () => {
+    for (const status of ['operational', 'degraded', 'outage', 'unknown'] as ComponentStatus[]) {
+      expect(coerceComponentStatus(status)).toBe(status)
+    }
+  })
+
+  it('falls back to unknown for any unrecognized value -- never operational', () => {
+    expect(coerceComponentStatus('healthy')).toBe('unknown')
+    expect(coerceComponentStatus(null)).toBe('unknown')
+    expect(coerceComponentStatus(undefined)).toBe('unknown')
+    expect(coerceComponentStatus(1)).toBe('unknown')
+    expect(coerceComponentStatus('<script>alert(1)</script>')).toBe('unknown')
+  })
+})
+
+describe('vocab coverage', () => {
+  const ALL_COMPONENT_STATUSES: ComponentStatus[] = ['operational', 'degraded', 'outage', 'unknown']
+  const ALL_DAY_STATUSES: DayStatus[] = ['operational', 'degraded', 'outage']
+
+  it('STATUS_LABELS / STATUS_PILL_CLASSES / OVERALL_BANNER cover exactly the 4 ComponentStatus values', () => {
+    expect(Object.keys(STATUS_LABELS).sort()).toEqual([...ALL_COMPONENT_STATUSES].sort())
+    expect(Object.keys(STATUS_PILL_CLASSES).sort()).toEqual([...ALL_COMPONENT_STATUSES].sort())
+    expect(Object.keys(OVERALL_BANNER).sort()).toEqual([...ALL_COMPONENT_STATUSES].sort())
+  })
+
+  it('STATUS_TILE_CLASSES covers exactly the 3 DayStatus values (no "unknown" key)', () => {
+    expect(Object.keys(STATUS_TILE_CLASSES).sort()).toEqual([...ALL_DAY_STATUSES].sort())
+    expect(STATUS_TILE_CLASSES).not.toHaveProperty('unknown')
+  })
+
+  it('unknown overall banner reads as neutral "Status unavailable", never operational-looking', () => {
+    expect(OVERALL_BANNER.unknown.headline).toBe('Status unavailable')
+    expect(OVERALL_BANNER.unknown.dot).toContain('gray')
+    expect(OVERALL_BANNER.unknown.text).toContain('gray')
+    expect(OVERALL_BANNER.unknown.headline).not.toBe(OVERALL_BANNER.operational.headline)
+  })
+
+  it('COMPONENTS has exactly the 6 fixed rows', () => {
+    expect(COMPONENTS).toHaveLength(6)
+    expect(COMPONENTS.map((c) => c.slug)).toEqual([
+      'website',
+      'search-api',
+      'mcp-backend',
+      'database',
+      'skill-indexer',
+      'billing',
+    ])
+  })
+
+  it('FIX (Codex #15): the three "no data"-ish strings are textually distinct', () => {
+    const noDataTileText = uptimeTileText({
+      date: ANCHOR,
+      status: null,
+      uptimePct: null,
+      totalChecks: null,
+    })
+    expect(noDataTileText).toContain('No data')
+    expect(STATUS_LABELS.unknown).toBe('Unknown')
+    expect(SCAFFOLD_NO_DATA_MESSAGE).toBe('No data reported.')
+
+    const distinctStrings = new Set([
+      noDataTileText,
+      STATUS_LABELS.unknown,
+      SCAFFOLD_NO_DATA_MESSAGE,
+    ])
+    expect(distinctStrings.size).toBe(3)
+  })
+
+  it('NO_DATA_TILE_CLASS is a solid gray fill (no border utility)', () => {
+    expect(NO_DATA_TILE_CLASS).toBe('bg-gray-700')
+    expect(NO_DATA_TILE_CLASS).not.toContain('border')
+  })
+})
+
+describe('buildUptimeStripAriaLabel', () => {
+  it('counts tiles into operational/degraded/outage/no-data buckets', () => {
+    const tiles = buildUptimeGrid(
+      [
+        makeDay('2026-07-14', { worst_status: 'degraded' }),
+        makeDay('2026-07-13', { worst_status: 'outage' }),
+      ],
+      ANCHOR
+    )
+    const label = buildUptimeStripAriaLabel(tiles, 'Website')
+    expect(label).toBe('Website: 90-day uptime — 0 operational, 1 degraded, 1 outage, 88 no data')
+  })
+
+  it('an all-empty grid (SSR scaffold, no live data yet) reads as entirely no-data', () => {
+    const tiles = buildUptimeGrid([], ANCHOR)
+    const label = buildUptimeStripAriaLabel(tiles, 'Website')
+    expect(label).toBe('Website: 90-day uptime — 0 operational, 0 degraded, 0 outage, 90 no data')
+  })
+
+  it('reflects the supplied label, not a hardcoded one', () => {
+    const tiles = buildUptimeGrid([], ANCHOR)
+    expect(buildUptimeStripAriaLabel(tiles, 'Search API')).toContain('Search API: 90-day uptime')
+  })
+})

--- a/packages/website/src/lib/status-vocab.ts
+++ b/packages/website/src/lib/status-vocab.ts
@@ -1,0 +1,410 @@
+/**
+ * Status page vocabulary — single source of truth for the public status page
+ * (SMI-5755, Wave 5).
+ *
+ * Imported by StatusPill.astro, UptimeBarStrip.astro, status.astro's
+ * frontmatter (server-rendered scaffold), and forwarded into status.astro's
+ * client script via `define:vars` for the plain constants (label/class maps
+ * are JSON-serializable so they cross that boundary cleanly).
+ *
+ * The live API contract (`GET /functions/v1/status-public`, shipped Wave 4 /
+ * SMI-5754) is: `{ cached: boolean, data: StatusData }`. Every field on
+ * `component.message`, `component.name`, `incident.title`, and
+ * `incident.updates[].message` is attacker-controlled admin-authored text —
+ * treat as untrusted. Nothing in this file renders that text; this module is
+ * vocab/types/pure-math only.
+ */
+
+// ---------------------------------------------------------------------------
+// API contract types
+// ---------------------------------------------------------------------------
+
+export type ComponentStatus = 'operational' | 'degraded' | 'outage' | 'unknown'
+
+/** Rollup days are NEVER 'unknown' — a day either happened or is absent. */
+export type DayStatus = 'operational' | 'degraded' | 'outage'
+
+export interface UptimeDay {
+  day: string
+  uptime_pct: number
+  worst_status: DayStatus
+  total_checks: number
+}
+
+export interface StatusComponent {
+  slug: string
+  name: string
+  description: string
+  display_order: number
+  status: ComponentStatus
+  latency_ms: number | null
+  message: string
+  checked_at: string | null
+  /** SPARSE — a day with zero checks is ABSENT, never present with total_checks:0. */
+  uptime_90d: UptimeDay[]
+}
+
+export type IncidentStatus = 'investigating' | 'identified' | 'monitoring' | 'resolved'
+export type IncidentImpact = 'none' | 'minor' | 'major' | 'critical'
+
+export interface IncidentUpdate {
+  status: IncidentStatus
+  message: string
+  posted_at: string
+}
+
+export interface StatusIncident {
+  id: string
+  title: string
+  impact: IncidentImpact
+  status: IncidentStatus
+  started_at: string
+  resolved_at: string | null
+  /** Slugs — resolved against the current component list for a display name. */
+  affected_components: string[]
+  /** Ascending by posted_at within one incident. */
+  updates: IncidentUpdate[]
+}
+
+export interface StatusData {
+  generated_at: string
+  overall_status: ComponentStatus
+  /** 6 today, in display_order. */
+  components: StatusComponent[]
+  /** Descending by started_at. */
+  incidents: StatusIncident[]
+}
+
+export interface StatusResponse {
+  cached: boolean
+  data: StatusData
+}
+
+// ---------------------------------------------------------------------------
+// Uptime grid
+// ---------------------------------------------------------------------------
+
+export interface UptimeTile {
+  date: string
+  status: DayStatus | null
+  uptimePct: number | null
+  totalChecks: number | null
+}
+
+const DAY_STRING_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/** Guards a `day` string before it is used as a map key (Codex #6/#9). */
+export function isValidDayString(value: unknown): value is string {
+  return typeof value === 'string' && DAY_STRING_RE.test(value)
+}
+
+/**
+ * `Number(null) === 0` and `Number('') === 0` — validate BEFORE clamping so a
+ * malformed/missing `uptime_pct` falls back to "no data" instead of rendering
+ * as a fabricated 0% (full-outage-looking) tile (Codex #9).
+ */
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+export function isNonNegativeInteger(value: unknown): value is number {
+  return isFiniteNumber(value) && value >= 0 && Number.isInteger(value)
+}
+
+const KNOWN_DAY_STATUSES: ReadonlySet<string> = new Set<DayStatus>([
+  'operational',
+  'degraded',
+  'outage',
+])
+
+function toDayStatus(value: unknown): DayStatus | null {
+  return typeof value === 'string' && KNOWN_DAY_STATUSES.has(value) ? (value as DayStatus) : null
+}
+
+/**
+ * Builds the ordered 90-tile uptime grid, oldest first / anchor day last (the
+ * "most recent" tile UptimeBarStrip gives the initial `tabindex="0"`).
+ *
+ * FIX (Codex #6, merge-blocking): anchored to a caller-supplied ISO calendar
+ * date (`anchorIsoDate`, e.g. `data.generated_at.slice(0, 10)`), NOT
+ * `Date.now()`/browser-local "today" — a cached-then-repainted-after-midnight-UTC
+ * paint must not misalign the 90-day window against stale data. Parsed as UTC
+ * and walked back via `Date.UTC(...)` arithmetic only (never local-time `Date`
+ * methods, which are DST-sensitive).
+ *
+ * FIX (Codex #6 + #9, merge-blocking): each `day` string is validated against
+ * `/^\d{4}-\d{2}-\d{2}$/` before use as a map key; a malformed value is
+ * skipped (treated as absent), not silently mismatched. If two entries share
+ * the same valid `day` key, last-one-wins — an intentional, low-risk default
+ * (the DB's `(component_id, day)` primary key makes this unreachable live),
+ * not an oversight.
+ */
+export function buildUptimeGrid(uptime90d: UptimeDay[], anchorIsoDate: string): UptimeTile[] {
+  const byDay = new Map<string, UptimeDay>()
+  for (const entry of uptime90d) {
+    if (!entry || !isValidDayString(entry.day)) continue
+    byDay.set(entry.day, entry)
+  }
+
+  if (!isValidDayString(anchorIsoDate)) return []
+  const anchor = new Date(`${anchorIsoDate}T00:00:00Z`)
+  if (Number.isNaN(anchor.getTime())) return []
+
+  const anchorYear = anchor.getUTCFullYear()
+  const anchorMonth = anchor.getUTCMonth()
+  const anchorDate = anchor.getUTCDate()
+
+  const tiles: UptimeTile[] = []
+  for (let i = 89; i >= 0; i--) {
+    const dayMs = Date.UTC(anchorYear, anchorMonth, anchorDate - i)
+    const dateStr = new Date(dayMs).toISOString().slice(0, 10)
+    const entry = byDay.get(dateStr)
+
+    if (!entry) {
+      tiles.push({ date: dateStr, status: null, uptimePct: null, totalChecks: null })
+      continue
+    }
+
+    const uptimePctValid = isFiniteNumber(entry.uptime_pct)
+    const uptimePct = uptimePctValid ? Math.min(100, Math.max(0, entry.uptime_pct)) : null
+    // FIX (high): an invalid uptime_pct invalidates the WHOLE day, not just
+    // that one field — a genuinely valid-looking `worst_status` on a row
+    // whose uptime_pct is corrupt must NOT survive as a fabricated green
+    // "operational" tile with no percentage shown. Forcing status: null here
+    // (regardless of worst_status) collapses the tile to "no data", matching
+    // the "a day is either fully absent or fully valid" invariant.
+    const status = uptimePctValid ? toDayStatus(entry.worst_status) : null
+    const totalChecks = isNonNegativeInteger(entry.total_checks) ? entry.total_checks : null
+
+    tiles.push({ date: dateStr, status, uptimePct, totalChecks })
+  }
+
+  return tiles
+}
+
+// ---------------------------------------------------------------------------
+// Component status coercion
+// ---------------------------------------------------------------------------
+
+const KNOWN_COMPONENT_STATUSES: ReadonlySet<string> = new Set<ComponentStatus>([
+  'operational',
+  'degraded',
+  'outage',
+  'unknown',
+])
+
+/** Graceful fallback to 'unknown' for any unrecognized value — never 'operational'. */
+export function coerceComponentStatus(value: unknown): ComponentStatus {
+  return typeof value === 'string' && KNOWN_COMPONENT_STATUSES.has(value)
+    ? (value as ComponentStatus)
+    : 'unknown'
+}
+
+// ---------------------------------------------------------------------------
+// Labels, classes, icons
+// ---------------------------------------------------------------------------
+
+export const STATUS_LABELS: Record<ComponentStatus, string> = {
+  operational: 'Operational',
+  degraded: 'Degraded',
+  outage: 'Outage',
+  unknown: 'Unknown',
+}
+
+interface PillColorConfig {
+  bgColor: string
+  textColor: string
+  borderColor: string
+}
+
+/** Mirrors Badge.astro's tierConfig shape (bgColor/textColor/borderColor triple). */
+export const STATUS_PILL_CLASSES: Record<ComponentStatus, PillColorConfig> = {
+  operational: {
+    bgColor: 'bg-green-500/10',
+    textColor: 'text-green-400',
+    borderColor: 'border-green-500/30',
+  },
+  degraded: {
+    bgColor: 'bg-yellow-500/10',
+    textColor: 'text-yellow-400',
+    borderColor: 'border-yellow-500/30',
+  },
+  outage: {
+    bgColor: 'bg-red-500/10',
+    textColor: 'text-red-400',
+    borderColor: 'border-red-500/30',
+  },
+  unknown: {
+    bgColor: 'bg-gray-500/10',
+    textColor: 'text-gray-400',
+    borderColor: 'border-gray-500/30',
+  },
+}
+
+/** heroicons-style outline paths, viewBox 0 0 24 24 (matches Badge.astro's icons). */
+export const STATUS_ICONS: Record<ComponentStatus, string> = {
+  operational: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
+  degraded:
+    'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
+  outage: 'M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+  unknown:
+    'M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+}
+
+/** Solid tiles for the 90-day uptime strip — keyed by DayStatus only (no 'unknown'). */
+export const STATUS_TILE_CLASSES: Record<DayStatus, string> = {
+  operational: 'bg-green-500',
+  degraded: 'bg-yellow-500',
+  outage: 'bg-red-500',
+}
+
+/** A calendar day absent from uptime_90d (genuinely no checks ran that day). */
+export const NO_DATA_TILE_CLASS = 'bg-gray-700'
+
+/** Mirrors Badge.astro's exact structure. */
+export const PILL_BASE = 'inline-flex items-center font-medium rounded-full border'
+export const PILL_SIZE: Record<'sm' | 'md', string> = {
+  sm: 'px-2 py-0.5 text-xs',
+  md: 'px-2.5 py-1 text-sm',
+}
+export const PILL_ICON_SIZE: Record<'sm' | 'md', string> = {
+  sm: 'w-3 h-3',
+  md: 'w-4 h-4',
+}
+
+export interface OverallBannerConfig {
+  headline: string
+  sub: string
+  dot: string
+  text: string
+}
+
+/** `unknown` must read as "Status unavailable" in neutral gray — never look operational. */
+export const OVERALL_BANNER: Record<ComponentStatus, OverallBannerConfig> = {
+  operational: {
+    headline: 'All systems operational',
+    sub: 'All Skillsmith services are running normally.',
+    dot: 'bg-green-500',
+    text: 'text-green-400',
+  },
+  degraded: {
+    headline: 'Partial system disruption',
+    sub: 'Some services are experiencing degraded performance.',
+    dot: 'bg-yellow-500',
+    text: 'text-yellow-400',
+  },
+  outage: {
+    headline: 'Major system outage',
+    sub: 'One or more services are currently unavailable.',
+    dot: 'bg-red-500',
+    text: 'text-red-400',
+  },
+  unknown: {
+    headline: 'Status unavailable',
+    sub: "We couldn't load live status data. This page will keep retrying.",
+    dot: 'bg-gray-500',
+    text: 'text-gray-400',
+  },
+}
+
+export const IMPACT_LABELS: Record<IncidentImpact, string> = {
+  none: 'None',
+  minor: 'Minor',
+  major: 'Major',
+  critical: 'Critical',
+}
+
+export const IMPACT_CLASSES: Record<IncidentImpact, string> = {
+  none: 'bg-gray-500/10 text-gray-400 border-gray-500/30',
+  minor: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/30',
+  major: 'bg-orange-500/10 text-orange-400 border-orange-500/30',
+  critical: 'bg-red-500/10 text-red-400 border-red-500/30',
+}
+
+export const INCIDENT_STATUS_LABELS: Record<IncidentStatus, string> = {
+  investigating: 'Investigating',
+  identified: 'Identified',
+  monitoring: 'Monitoring',
+  resolved: 'Resolved',
+}
+
+// ---------------------------------------------------------------------------
+// Fixed component scaffold (server-rendered, no-JS baseline)
+// ---------------------------------------------------------------------------
+
+export interface ComponentScaffoldEntry {
+  slug: string
+  name: string
+  description: string
+}
+
+/** The 6 fixed rows, in display order — used to build the server-rendered scaffold. */
+export const COMPONENTS: ComponentScaffoldEntry[] = [
+  { slug: 'website', name: 'Website', description: 'www.skillsmith.app and the marketing site' },
+  {
+    slug: 'search-api',
+    name: 'Search API',
+    description: 'Skill search, get, and recommend edge functions',
+  },
+  {
+    slug: 'mcp-backend',
+    name: 'MCP Backend',
+    description: 'MCP server tool calls (search, install, audit, etc.)',
+  },
+  { slug: 'database', name: 'Database', description: 'Supabase Postgres (skills, users, billing)' },
+  {
+    slug: 'skill-indexer',
+    name: 'Skill Indexer',
+    description: 'Registry discovery, metadata refresh, and maintenance jobs',
+  },
+  {
+    slug: 'billing',
+    name: 'Billing',
+    description: 'Stripe checkout, subscriptions, and invoicing',
+  },
+]
+
+/** "No data reported." — distinct from a tile's "No data" and a live 'unknown' status (Codex #15). */
+export const SCAFFOLD_NO_DATA_MESSAGE = 'No data reported.'
+
+// ---------------------------------------------------------------------------
+// Uptime tile presentation — shared by UptimeBarStrip.astro's SSR render and
+// status-client.ts's client-side tile refresh, so the two never drift.
+// ---------------------------------------------------------------------------
+
+const UPTIME_TILE_BASE_CLASS = 'h-6 w-1.5 rounded-sm sm:w-2'
+
+export function uptimeTileClassName(status: DayStatus | null): string {
+  const fill = status ? STATUS_TILE_CLASSES[status] : NO_DATA_TILE_CLASS
+  return `${UPTIME_TILE_BASE_CLASS} ${fill}`
+}
+
+/** "No data" (a calendar day with no checks) — distinct from STATUS_LABELS.unknown (Codex #15). */
+export function uptimeTileText(tile: UptimeTile): string {
+  if (tile.status === null) return `${tile.date}: No data`
+  const pctText = tile.uptimePct !== null ? ` (${tile.uptimePct.toFixed(2)}% uptime)` : ''
+  return `${tile.date}: ${STATUS_LABELS[tile.status]}${pctText}`
+}
+
+/**
+ * The `role="group"` uptime strip's own accessible summary — "X
+ * operational, Y degraded, Z outage, W no data". Shared by
+ * UptimeBarStrip.astro's SSR render AND status-render.ts's client-side
+ * `refreshUptimeStripTiles` refresh path so the two can never drift (FIX,
+ * medium: previously computed only once at SSR time from the empty
+ * scaffold, then never recomputed after live data painted).
+ */
+export function buildUptimeStripAriaLabel(tiles: UptimeTile[], label: string): string {
+  const counts = tiles.reduce(
+    (acc, tile) => {
+      if (tile.status === null) acc.noData += 1
+      else acc[tile.status] += 1
+      return acc
+    },
+    { operational: 0, degraded: 0, outage: 0, noData: 0 }
+  )
+  return (
+    `${label}: 90-day uptime — ${counts.operational} operational, ${counts.degraded} degraded, ` +
+    `${counts.outage} outage, ${counts.noData} no data`
+  )
+}

--- a/packages/website/src/pages/status.astro
+++ b/packages/website/src/pages/status.astro
@@ -1,0 +1,396 @@
+---
+/**
+ * Skillsmith public status page (SMI-5755, Wave 5).
+ *
+ * Static page — no `export const prerender = false` (matches this repo's
+ * convention for static pages like contact.astro/faq.astro; the page itself
+ * renders a fixed no-JS scaffold, and the client script below progressively
+ * enhances it with live data from status-public).
+ */
+import BaseLayout from '../layouts/BaseLayout.astro'
+import StatusComponentRow from '../components/StatusComponentRow.astro'
+import { COMPONENTS, OVERALL_BANNER } from '../lib/status-vocab'
+
+// Server-computed anchor for the initial (all-empty) uptime strips. The
+// client script recomputes its own anchor from each payload's own
+// `generated_at` on every poll (Codex #6) — this value is only ever used for
+// the very first, data-free paint.
+const todayIso = new Date().toISOString().slice(0, 10)
+const banner = OVERALL_BANNER.unknown
+---
+
+<BaseLayout
+  title="Status | Skillsmith"
+  description="Live status and 90-day uptime history for Skillsmith's website, API, MCP backend, and infrastructure."
+  activePath="/status"
+>
+  <Fragment slot="head">
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="Skillsmith Status"
+      href="/status.rss.xml"
+    />
+  </Fragment>
+
+  <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16" data-smoke="status-page">
+    <div class="text-center mb-10">
+      <h1 class="text-4xl font-bold text-white mb-2">Skillsmith Status</h1>
+      <p class="text-dark-300">
+        Live status and 90-day uptime history for Skillsmith's core services.
+      </p>
+    </div>
+
+    <div
+      id="status-overall-banner"
+      class="rounded-xl border border-dark-700 bg-dark-900 p-6 mb-10 flex items-center gap-4"
+    >
+      <span id="status-overall-dot" class={`h-3 w-3 rounded-full flex-shrink-0 ${banner.dot}`}
+      ></span>
+      <div>
+        <p id="status-overall-headline" class={`font-semibold ${banner.text}`}>
+          {banner.headline}
+        </p>
+        <p id="status-overall-sub" class="text-sm text-gray-400 mt-1">
+          {banner.sub}
+        </p>
+      </div>
+    </div>
+
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-xl font-semibold text-white">Components</h2>
+      <p class="text-xs text-gray-500">
+        Last updated: <span id="status-last-updated">—</span>
+        <span id="status-stale-flag" class="text-yellow-400" hidden></span>
+      </p>
+    </div>
+
+    <div id="status-components-list" class="space-y-4 mb-16">
+      {
+        COMPONENTS.map((component) => (
+          <StatusComponentRow
+            slug={component.slug}
+            name={component.name}
+            anchorIsoDate={todayIso}
+          />
+        ))
+      }
+    </div>
+
+    <!--
+      Hidden clone source for dynamically-created rows (a component slug the
+      API returns that isn't one of the 6 fixed COMPONENTS). Rendered via the
+      exact same StatusComponentRow used for the visible scaffold above, so
+      the two can never drift (Codex #3 point 5). Never displayed directly —
+      `<template>` content is inert until cloned by ../lib/status-client.ts.
+    -->
+    <template id="status-row-template">
+      <StatusComponentRow slug="__template__" name="" anchorIsoDate={todayIso} />
+    </template>
+
+    <div>
+      <h2 class="text-xl font-semibold text-white mb-4">Incident History</h2>
+      <div id="status-incidents-list">
+        <p id="status-no-incidents" class="text-gray-400">No incidents reported.</p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    import {
+      applyComponentRowContent,
+      buildComponentRowContent,
+      buildComponentsBySlug,
+      buildIncidentContent,
+      buildScaffoldResetContent,
+      createStatusPoller,
+      planComponentReconciliation,
+      readCachedStatusPayload,
+      refreshUptimeStripTiles,
+      wireUptimeStripKeyboardNav,
+      writeCachedStatusPayload,
+      type ComponentRowElements,
+      type UptimeStripHandle,
+      type UptimeTileHandle,
+    } from '../lib/status-client'
+    import {
+      COMPONENTS,
+      OVERALL_BANNER,
+      type ComponentStatus,
+      type StatusComponent,
+      type StatusIncident,
+      type StatusResponse,
+    } from '../lib/status-vocab'
+
+    // DEVIATION from the brief's literal "is:inline define:vars" instruction
+    // — see the header comment in ../lib/status-client.ts for the full
+    // rationale (testability of the reconciliation contract without risking
+    // a shipped/tested-twin drift, matching BaseLayout.astro's own
+    // is:inline-shim + regular-imported-module split for the Supabase
+    // client). import.meta.env.PUBLIC_API_BASE_URL is available in a
+    // bundled <script> exactly as in an is:inline one (astro.config.mjs's
+    // vite.define), so the URL-construction idiom itself is unchanged.
+
+    const SCAFFOLD_SLUGS = new Set(COMPONENTS.map((c) => c.slug))
+
+    let currentPoller: ReturnType<typeof createStatusPoller> | null = null
+
+    function teardownCurrentPoller(): void {
+      if (currentPoller) {
+        currentPoller.stop()
+        currentPoller = null
+      }
+    }
+
+    function formatTimestamp(iso: string): string {
+      if (!iso) return '—'
+      const parsed = new Date(iso)
+      if (Number.isNaN(parsed.getTime())) return '—'
+      return parsed.toLocaleString()
+    }
+
+    function getRowElements(rowEl: Element): ComponentRowElements {
+      return {
+        nameEl: rowEl.querySelector('[data-role="name"]') as HTMLElement,
+        messageEl: rowEl.querySelector('[data-role="message"]') as HTMLElement,
+        latencyEl: rowEl.querySelector('[data-role="latency"]') as HTMLElement,
+        checkedAtEl: rowEl.querySelector('[data-role="checked-at"]') as HTMLElement,
+        pillTextEl: rowEl.querySelector('[data-status-pill-text]') as HTMLElement,
+        pillEl: rowEl.querySelector('[data-status-pill]') as HTMLElement,
+      }
+    }
+
+    function getUptimeTileHandles(rowEl: Element): UptimeTileHandle[] {
+      return Array.from(rowEl.querySelectorAll('[data-uptime-tile]'))
+    }
+
+    // FIX (medium): resolves the containing strip's own group-level
+    // `[data-uptime-strip]` element so `refreshUptimeStripTiles` can also
+    // recompute its `aria-label` — see ../lib/status-render.ts.
+    function getUptimeStripHandle(rowEl: Element): UptimeStripHandle | null {
+      return rowEl.querySelector('[data-uptime-strip]')
+    }
+
+    function initStatusPageInstance(): void {
+      const listEl = document.getElementById('status-components-list')
+      const templateEl = document.getElementById(
+        'status-row-template'
+      ) as HTMLTemplateElement | null
+      const overallDotEl = document.getElementById('status-overall-dot')
+      const overallHeadlineEl = document.getElementById('status-overall-headline')
+      const overallSubEl = document.getElementById('status-overall-sub')
+      const lastUpdatedEl = document.getElementById('status-last-updated')
+      const staleFlagEl = document.getElementById('status-stale-flag')
+      const incidentsListEl = document.getElementById('status-incidents-list')
+
+      if (
+        !listEl ||
+        !templateEl ||
+        !overallDotEl ||
+        !overallHeadlineEl ||
+        !overallSubEl ||
+        !lastUpdatedEl ||
+        !staleFlagEl ||
+        !incidentsListEl
+      ) {
+        // Navigated away from /status — stop any previous instance's poller
+        // so it doesn't keep fetching against now-detached DOM.
+        teardownCurrentPoller()
+        return
+      }
+
+      function buildRowMap(): Map<string, Element> {
+        const map = new Map<string, Element>()
+        listEl!.querySelectorAll('[data-component]').forEach((el) => {
+          const slug = (el as HTMLElement).dataset.component
+          if (slug) map.set(slug, el)
+        })
+        return map
+      }
+
+      function createRowElement(slug: string): Element {
+        const fragment = templateEl!.content.cloneNode(true) as DocumentFragment
+        const rowEl = fragment.firstElementChild as HTMLElement
+        rowEl.dataset.component = slug
+        listEl!.appendChild(rowEl)
+        return rowEl
+      }
+
+      function updateOverallBanner(status: ComponentStatus): void {
+        const banner = OVERALL_BANNER[status] ?? OVERALL_BANNER.unknown
+        overallDotEl!.className = `h-3 w-3 rounded-full flex-shrink-0 ${banner.dot}`
+        overallHeadlineEl!.className = `font-semibold ${banner.text}`
+        overallHeadlineEl!.textContent = banner.headline
+        overallSubEl!.textContent = banner.sub
+      }
+
+      function reconcileComponents(components: StatusComponent[], anchorIsoDate: string): void {
+        const rowMap = buildRowMap()
+        const existingSlugs = new Set(rowMap.keys())
+        const plan = planComponentReconciliation(components, existingSlugs, SCAFFOLD_SLUGS)
+
+        for (const component of plan.toUpsert) {
+          const rowEl = rowMap.get(component.slug)
+          if (!rowEl) continue
+          applyComponentRowContent(getRowElements(rowEl), buildComponentRowContent(component))
+          refreshUptimeStripTiles(
+            getUptimeTileHandles(rowEl),
+            component.uptime_90d,
+            anchorIsoDate,
+            getUptimeStripHandle(rowEl),
+            component.name
+          )
+        }
+
+        for (const component of plan.toCreate) {
+          const rowEl = createRowElement(component.slug)
+          applyComponentRowContent(getRowElements(rowEl), buildComponentRowContent(component))
+          refreshUptimeStripTiles(
+            getUptimeTileHandles(rowEl),
+            component.uptime_90d,
+            anchorIsoDate,
+            getUptimeStripHandle(rowEl),
+            component.name
+          )
+        }
+
+        for (const slug of plan.toRemoveSlugs) {
+          rowMap.get(slug)?.remove()
+        }
+
+        for (const slug of plan.toResetSlugs) {
+          const rowEl = rowMap.get(slug)
+          const scaffold = COMPONENTS.find((c) => c.slug === slug)
+          if (!rowEl || !scaffold) continue
+          applyComponentRowContent(getRowElements(rowEl), buildScaffoldResetContent(scaffold))
+          refreshUptimeStripTiles(
+            getUptimeTileHandles(rowEl),
+            [],
+            anchorIsoDate,
+            getUptimeStripHandle(rowEl),
+            scaffold.name
+          )
+        }
+      }
+
+      function renderIncidents(
+        incidents: StatusIncident[],
+        componentsBySlug: ReadonlyMap<string, { name: string }>
+      ): void {
+        incidentsListEl!.textContent = ''
+        if (incidents.length === 0) {
+          const emptyEl = document.createElement('p')
+          emptyEl.id = 'status-no-incidents'
+          emptyEl.className = 'text-gray-400'
+          emptyEl.textContent = 'No incidents reported.'
+          incidentsListEl!.appendChild(emptyEl)
+          return
+        }
+
+        for (const incident of incidents) {
+          const content = buildIncidentContent(incident, componentsBySlug)
+
+          const wrapperEl = document.createElement('div')
+          wrapperEl.id = `incident-${content.id}`
+          wrapperEl.className = 'border border-dark-700 rounded-lg p-4 mb-4'
+
+          const titleEl = document.createElement('h3')
+          titleEl.className = 'text-white font-semibold'
+          titleEl.textContent = content.title // untrusted — textContent only
+          wrapperEl.appendChild(titleEl)
+
+          const metaEl = document.createElement('p')
+          metaEl.className = 'text-xs text-gray-500 mt-1'
+          metaEl.textContent =
+            `${content.impactLabel} impact · ${content.statusLabel} · ` +
+            `Affects: ${content.affectedText} · Started: ${content.startedAtText} · ` +
+            `Resolved: ${content.resolvedAtText}`
+          wrapperEl.appendChild(metaEl)
+
+          const updatesEl = document.createElement('ul')
+          updatesEl.className = 'mt-3 space-y-2'
+          for (const update of content.updates) {
+            const itemEl = document.createElement('li')
+            itemEl.className = 'text-sm'
+
+            const statusEl = document.createElement('span')
+            statusEl.className = 'text-gray-300 font-medium'
+            statusEl.textContent = `${update.statusLabel} (${update.postedAtText}): `
+            itemEl.appendChild(statusEl)
+
+            const messageEl = document.createElement('span')
+            messageEl.className = 'text-gray-400'
+            messageEl.textContent = update.message // untrusted — textContent only
+            itemEl.appendChild(messageEl)
+
+            updatesEl.appendChild(itemEl)
+          }
+          wrapperEl.appendChild(updatesEl)
+          incidentsListEl!.appendChild(wrapperEl)
+        }
+      }
+
+      function onResult(payload: StatusResponse): void {
+        const data = payload.data
+        const anchorIsoDate =
+          typeof data.generated_at === 'string' && data.generated_at.length >= 10
+            ? data.generated_at.slice(0, 10)
+            : new Date().toISOString().slice(0, 10)
+
+        // FIX (medium): built FRESH from this poll's live components on every
+        // call — never a static map frozen from the compile-time scaffold at
+        // module scope — so a renamed fixed component or an incident
+        // affecting a dynamic (non-scaffold) component resolves to its real
+        // current display name (see buildComponentsBySlug in
+        // ../lib/status-render.ts).
+        const componentsBySlug = buildComponentsBySlug(data.components, COMPONENTS)
+
+        updateOverallBanner(data.overall_status)
+        reconcileComponents(data.components, anchorIsoDate)
+        renderIncidents(data.incidents, componentsBySlug)
+        lastUpdatedEl!.textContent = formatTimestamp(data.generated_at)
+
+        writeCachedStatusPayload(localStorage, payload)
+      }
+
+      function onStaleChange(isStale: boolean): void {
+        staleFlagEl!.hidden = !isStale
+        staleFlagEl!.textContent = isStale ? ' (may be outdated)' : ''
+      }
+
+      teardownCurrentPoller()
+
+      const cached = readCachedStatusPayload(localStorage)
+      if (cached) onResult(cached)
+
+      const apiUrl = `${import.meta.env.PUBLIC_API_BASE_URL || 'https://api.skillsmith.app'}/functions/v1/status-public`
+      currentPoller = createStatusPoller({ apiUrl }, { onResult, onStaleChange })
+      if (document.visibilityState === 'visible') {
+        currentPoller.start()
+      }
+    }
+
+    document.addEventListener('astro:page-load', () => {
+      initStatusPageInstance()
+
+      // Document-level lifecycle listeners are wired exactly once across
+      // view-transition navigations — see ../lib/status-client.ts's header
+      // comment. `currentPoller` is reassigned on every page-load above, so
+      // these always act on whichever instance is current.
+      if (document.documentElement.dataset.statusWired === 'true') return
+      document.documentElement.dataset.statusWired = 'true'
+
+      document.addEventListener('astro:before-swap', () => {
+        currentPoller?.handleBeforeSwap()
+      })
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+          currentPoller?.handleVisibilityHidden()
+        } else {
+          currentPoller?.handleVisibilityVisible()
+        }
+      })
+      wireUptimeStripKeyboardNav(document)
+    })
+  </script>
+</BaseLayout>

--- a/packages/website/src/pages/status.rss.xml.ts
+++ b/packages/website/src/pages/status.rss.xml.ts
@@ -1,0 +1,194 @@
+/**
+ * RSS feed for the Skillsmith public status page (SMI-5755, Wave 5).
+ *
+ * `export const prerender = false` is a deliberate deviation from the static
+ * `blog/rss.xml.ts` precedent — incident data changes continuously and must
+ * be served fresh per-request, not baked at build time.
+ */
+export const prerender = false
+
+import rss from '@astrojs/rss'
+import type { APIContext } from 'astro'
+import { INCIDENT_STATUS_LABELS, type StatusIncident } from '../lib/status-vocab'
+import { validateStatusPayload } from '../lib/status-client'
+
+/** Keeps tab/LF/CR, strips other C0 control characters that are illegal raw in XML 1.0. */
+// eslint-disable-next-line no-control-regex -- Intentional: stripping illegal raw XML control bytes
+const CONTROL_CHARS_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F]/g
+
+function stripControlChars(value: string): string {
+  return value.replace(CONTROL_CHARS_RE, '')
+}
+
+/** XML-escapes text destined for a raw `customData` fragment (the <guid> element below). */
+function escapeXmlText(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+interface FeedItem {
+  title: string
+  description: string
+  pubDate: Date
+  link: string
+  customData: string
+}
+
+/**
+ * FIX (Codex #12, merge-blocking): one item PER INCIDENT UPDATE (matching the
+ * master plan's "RSS feed over incident_updates" wording), not one item per
+ * incident using only its latest update.
+ *
+ * FIX (Codex #11, high): a stable, unique `<guid>` per item
+ * (`${incident.id}:${update.posted_at}`) via `customData` (the installed
+ * @astrojs/rss@4.0.19 has no first-class `guid` field on RSSFeedItem — only
+ * `customData`, a raw XML fragment parsed and merged into the <item>,
+ * verified empirically against the installed version). Emitted AFTER the
+ * library's own auto-guid-from-link assignment in its item-building order,
+ * so `Object.assign` overwrites it — confirmed empirically. An
+ * invalid/unparseable `posted_at` is skipped rather than emitting
+ * `Invalid Date`.
+ */
+function buildFeedItems(incidents: StatusIncident[]): FeedItem[] {
+  const items: FeedItem[] = []
+  // FIX (Codex #11, "duplicate-timestamp rule"): `${incident.id}:${posted_at}`
+  // is unique across incidents but not guaranteed unique WITHIN one incident
+  // if two updates share an identical posted_at string (clock/authoring-tool
+  // granularity) — tracked per incident and disambiguated with a `:n` suffix
+  // so no two items in the same feed ever share a <guid>.
+  const guidSeenCounts = new Map<string, number>()
+
+  for (const incident of incidents) {
+    for (const update of incident.updates) {
+      const pubDate = new Date(update.posted_at)
+      if (Number.isNaN(pubDate.getTime())) continue // invalid posted_at — skip, don't emit "Invalid Date"
+
+      const statusLabel = INCIDENT_STATUS_LABELS[update.status] ?? update.status
+      const title = stripControlChars(`${incident.title} — ${statusLabel}`)
+      const description = stripControlChars(update.message)
+      const baseGuid = stripControlChars(`${incident.id}:${update.posted_at}`)
+      const seenCount = guidSeenCounts.get(baseGuid) ?? 0
+      guidSeenCounts.set(baseGuid, seenCount + 1)
+      const guidValue = escapeXmlText(seenCount === 0 ? baseGuid : `${baseGuid}:${seenCount}`)
+
+      items.push({
+        title,
+        description,
+        pubDate,
+        // trailingSlash:false (below) strips the trailing slash the library
+        // would otherwise append AFTER the #incident-<id> hash fragment —
+        // verified empirically against the installed @astrojs/rss version.
+        link: `/status/#incident-${incident.id}`,
+        customData: `<guid isPermaLink="false">${guidValue}</guid>`,
+      })
+    }
+  }
+
+  // RSS convention: newest first, across all incidents (not grouped by incident).
+  items.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())
+  return items
+}
+
+const FEED_TITLE = 'Skillsmith Status'
+const FEED_DESCRIPTION = 'Incident history and status updates for Skillsmith services.'
+
+// FIX (high): resolved up front so `context.site` is never actually
+// undefined at either rss() call site below — but this alone is NOT the
+// backstop (astro's own `site` config could still be missing, and this is
+// belt-and-suspenders, not a guarantee). See STATIC_FALLBACK_RSS_XML below
+// for the true backstop that depends on neither `context.site` nor the
+// rss() library at all.
+const DEFAULT_SITE_URL = 'https://www.skillsmith.app'
+
+/**
+ * FIX (high): a hand-built, minimal, well-formed RSS/XML string that depends
+ * on NOTHING — not `context.site`, not the `rss()` library, not any upstream
+ * data. This is the true backstop: previously, the catch block's own
+ * "empty feed" fallback called `rss(...)` completely unprotected — if THAT
+ * call also threw (e.g. `context.site` genuinely undefined, or anything
+ * inside the `rss()` library itself throwing for a reason unrelated to
+ * fetch/parse/shape), the whole `GET` handler rejected uncaught, exactly the
+ * outcome this design exists to prevent.
+ */
+const STATIC_FALLBACK_RSS_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<rss version="2.0"><channel>' +
+  `<title>${FEED_TITLE}</title>` +
+  `<description>${FEED_DESCRIPTION}</description>` +
+  `<link>${DEFAULT_SITE_URL}</link>` +
+  '</channel></rss>'
+
+function staticFallbackResponse(): Response {
+  return new Response(STATIC_FALLBACK_RSS_XML, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/rss+xml',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  })
+}
+
+export async function GET(context: APIContext): Promise<Response> {
+  const site = context.site ?? new URL(DEFAULT_SITE_URL)
+
+  // FIX (Codex #5, merge-blocking): the ENTIRE handler — fetch, JSON parse,
+  // normalization, and the rss() call itself — is wrapped in one try/catch.
+  // ANY failure at any stage falls through to the catch block's own fallback
+  // feed rather than letting an exception escape as a generic error
+  // response.
+  try {
+    const apiUrl = `${import.meta.env.PUBLIC_API_BASE_URL || 'https://api.skillsmith.app'}/functions/v1/status-public`
+    const response = await fetch(apiUrl)
+    if (!response.ok) throw new Error(`status-public HTTP ${response.status}`)
+
+    const rawJson: unknown = await response.json()
+    const validated = validateStatusPayload(rawJson)
+    if (!validated) throw new Error('status-public: invalid payload shape')
+
+    const items = buildFeedItems(validated.data.incidents)
+
+    const rssResponse = await rss({
+      title: FEED_TITLE,
+      description: FEED_DESCRIPTION,
+      site,
+      trailingSlash: false,
+      items,
+    })
+    return withNoSniffHeader(rssResponse)
+  } catch {
+    // FIX (high): the fallback path must be unable to throw, full stop — it
+    // is now wrapped in its OWN try/catch. If the fallback rss() call also
+    // throws, fall all the way back to the hardcoded static XML string
+    // above rather than letting the handler reject uncaught.
+    try {
+      const emptyFeedResponse = await rss({
+        title: FEED_TITLE,
+        description: FEED_DESCRIPTION,
+        site,
+        trailingSlash: false,
+        items: [],
+      })
+      return withNoSniffHeader(emptyFeedResponse)
+    } catch {
+      return staticFallbackResponse()
+    }
+  }
+}
+
+/**
+ * Adds `X-Content-Type-Options: nosniff` (mirroring status-public's own
+ * Wave-4 header) without disturbing whatever Content-Type the rss() library
+ * itself sets — constructing a fresh Response with merged Headers is the
+ * portable way to add a header across Astro/Vercel's Response implementation
+ * (a directly-constructed Response's headers ARE mutable in practice, but a
+ * fresh Response + merged Headers avoids relying on that across runtimes).
+ */
+async function withNoSniffHeader(response: Response): Promise<Response> {
+  const body = await response.text()
+  const headers = new Headers(response.headers)
+  headers.set('X-Content-Type-Options', 'nosniff')
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}

--- a/packages/website/tests/api/status.rss.xml.test.ts
+++ b/packages/website/tests/api/status.rss.xml.test.ts
@@ -1,0 +1,415 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type { APIContext } from 'astro'
+import rss from '@astrojs/rss'
+import { GET } from '../../src/pages/status.rss.xml'
+
+// FIX (high): wraps the REAL @astrojs/rss implementation by default (so
+// every existing test below is unaffected) but lets one test below force
+// the library itself to throw on a specific call — proving the fallback
+// path (the catch block's own "empty feed" rss() call) can no longer
+// escape as an uncaught rejection.
+vi.mock('@astrojs/rss', async (importOriginal) => {
+  const actual = await importOriginal<{ default: typeof rss }>()
+  return { default: vi.fn(actual.default) }
+})
+
+const SITE = new URL('https://www.skillsmith.app')
+
+function makeContext(): APIContext {
+  return { site: SITE } as APIContext
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1
+}
+
+async function parseItems(
+  xml: string
+): Promise<{ titles: string[]; links: string[]; guids: string[] }> {
+  const titles = [...xml.matchAll(/<item>[\s\S]*?<title>([\s\S]*?)<\/title>/g)].map((m) => m[1])
+  const links = [...xml.matchAll(/<item>[\s\S]*?<link>([\s\S]*?)<\/link>/g)].map((m) => m[1])
+  const guids = [...xml.matchAll(/<guid[^>]*>([\s\S]*?)<\/guid>/g)].map((m) => m[1])
+  return { titles, links, guids }
+}
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+function mockFetchJson(payload: unknown, ok = true, status = 200): void {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: async () => payload,
+  }) as unknown as typeof fetch
+}
+
+const VALID_PAYLOAD = {
+  cached: false,
+  data: {
+    generated_at: '2026-07-15T12:00:00Z',
+    overall_status: 'operational',
+    components: [],
+    incidents: [
+      {
+        id: 'inc-older',
+        title: 'Older incident',
+        impact: 'minor',
+        status: 'resolved',
+        started_at: '2026-07-10T00:00:00Z',
+        resolved_at: '2026-07-10T02:00:00Z',
+        affected_components: ['website'],
+        updates: [
+          {
+            status: 'investigating',
+            message: 'Looking into it.',
+            posted_at: '2026-07-10T00:00:00Z',
+          },
+          { status: 'resolved', message: 'Fixed.', posted_at: '2026-07-10T02:00:00Z' },
+        ],
+      },
+      {
+        id: 'inc-newer',
+        title: 'Newer incident',
+        impact: 'major',
+        status: 'monitoring',
+        started_at: '2026-07-15T00:00:00Z',
+        resolved_at: null,
+        affected_components: ['search-api'],
+        updates: [
+          {
+            status: 'investigating',
+            message: 'Newer investigating.',
+            posted_at: '2026-07-15T00:00:00Z',
+          },
+          { status: 'monitoring', message: 'Newer monitoring.', posted_at: '2026-07-15T01:00:00Z' },
+        ],
+      },
+    ],
+  },
+}
+
+describe('status.rss.xml GET', () => {
+  it('FIX (Codex #12): emits one item PER incident update, not one per incident', async () => {
+    mockFetchJson(VALID_PAYLOAD)
+    const response = await GET(makeContext())
+    expect(response.status).toBe(200)
+    const xml = await response.text()
+    expect(countOccurrences(xml, '<item>')).toBe(4) // 2 incidents x 2 updates each
+  })
+
+  it('sorts items descending by pubDate ACROSS incidents, not grouped by incident', async () => {
+    mockFetchJson(VALID_PAYLOAD)
+    const xml = await (await GET(makeContext())).text()
+    const { titles } = await parseItems(xml)
+    // Newest posted_at first: newer-monitoring (07-15T01), newer-investigating (07-15T00),
+    // older-resolved (07-10T02), older-investigating (07-10T00).
+    expect(titles[0]).toContain('Newer incident')
+    expect(titles[0]).toContain('Monitoring')
+    expect(titles[3]).toContain('Older incident')
+    expect(titles[3]).toContain('Investigating')
+  })
+
+  it('title is "<incident title> — <update status label>"; description is that update\'s own message', async () => {
+    mockFetchJson(VALID_PAYLOAD)
+    const xml = await (await GET(makeContext())).text()
+    expect(xml).toContain('Newer incident — Monitoring')
+    expect(xml).toContain('Newer monitoring.')
+    // Must not blend a different update's message onto this item.
+    expect(xml.indexOf('Newer monitoring.')).toBeGreaterThan(-1)
+  })
+
+  it('FIX (Codex #11): each item has a stable, unique guid', async () => {
+    mockFetchJson(VALID_PAYLOAD)
+    const xml = await (await GET(makeContext())).text()
+    const { guids } = await parseItems(xml)
+    expect(guids).toHaveLength(4)
+    expect(new Set(guids).size).toBe(4)
+    expect(guids).toContain('inc-newer:2026-07-15T01:00:00Z')
+  })
+
+  it('FIX (Codex #11, "duplicate-timestamp rule"): two updates on the same incident sharing an identical posted_at still get distinct guids', async () => {
+    mockFetchJson({
+      cached: false,
+      data: {
+        generated_at: 'x',
+        overall_status: 'operational',
+        components: [],
+        incidents: [
+          {
+            id: 'inc-clock-skew',
+            title: 'Clock skew incident',
+            impact: 'minor',
+            status: 'resolved',
+            started_at: '2026-07-15T00:00:00Z',
+            resolved_at: '2026-07-15T00:00:00Z',
+            affected_components: [],
+            updates: [
+              {
+                status: 'investigating',
+                message: 'First update, same timestamp.',
+                posted_at: '2026-07-15T00:00:00Z',
+              },
+              {
+                status: 'resolved',
+                message: 'Second update, same timestamp.',
+                posted_at: '2026-07-15T00:00:00Z',
+              },
+            ],
+          },
+        ],
+      },
+    })
+    const xml = await (await GET(makeContext())).text()
+    const { guids } = await parseItems(xml)
+    expect(guids).toHaveLength(2)
+    expect(new Set(guids).size).toBe(2)
+    expect(guids).toContain('inc-clock-skew:2026-07-15T00:00:00Z')
+    expect(guids).toContain('inc-clock-skew:2026-07-15T00:00:00Z:1')
+  })
+
+  it('the item link points at #incident-<id> without a spurious trailing slash after the hash', async () => {
+    mockFetchJson(VALID_PAYLOAD)
+    const xml = await (await GET(makeContext())).text()
+    const { links } = await parseItems(xml)
+    expect(links[0]).toBe('https://www.skillsmith.app/status/#incident-inc-newer')
+    expect(links[0].endsWith('/')).toBe(false)
+  })
+
+  it('FIX (Codex #11): an invalid posted_at is skipped rather than emitting Invalid Date', async () => {
+    mockFetchJson({
+      cached: false,
+      data: {
+        generated_at: 'x',
+        overall_status: 'operational',
+        components: [],
+        incidents: [
+          {
+            id: 'inc-1',
+            title: 'T',
+            impact: 'none',
+            status: 'resolved',
+            started_at: '2026-07-15T00:00:00Z',
+            resolved_at: null,
+            affected_components: [],
+            updates: [
+              { status: 'investigating', message: 'good one', posted_at: 'not-a-date' },
+              { status: 'resolved', message: 'also good', posted_at: '2026-07-15T00:00:00Z' },
+            ],
+          },
+        ],
+      },
+    })
+    const xml = await (await GET(makeContext())).text()
+    expect(countOccurrences(xml, '<item>')).toBe(1)
+    expect(xml).not.toContain('Invalid Date')
+    expect(xml).toContain('also good')
+    expect(xml).not.toContain('good one</description>')
+  })
+
+  it('escapes XML-unsafe characters in title/description via the library only (no double-escaping)', async () => {
+    mockFetchJson({
+      cached: false,
+      data: {
+        generated_at: 'x',
+        overall_status: 'operational',
+        components: [],
+        incidents: [
+          {
+            id: 'inc-xss',
+            title: '<script>alert(1)</script>',
+            impact: 'none',
+            status: 'resolved',
+            started_at: '2026-07-15T00:00:00Z',
+            resolved_at: null,
+            affected_components: [],
+            updates: [
+              { status: 'resolved', message: 'a & b < c > d', posted_at: '2026-07-15T00:00:00Z' },
+            ],
+          },
+        ],
+      },
+    })
+    const xml = await (await GET(makeContext())).text()
+    expect(xml).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(xml).not.toContain('<script>alert(1)</script>')
+    expect(xml).not.toContain('&amp;lt;') // not double-escaped
+    expect(xml).toContain('a &amp; b &lt; c &gt; d')
+  })
+
+  it('FIX (Codex #11): strips illegal raw control characters before passing to rss()', async () => {
+    mockFetchJson({
+      cached: false,
+      data: {
+        generated_at: 'x',
+        overall_status: 'operational',
+        components: [],
+        incidents: [
+          {
+            id: 'inc-ctl',
+            title: 'Bad\x07Title',
+            impact: 'none',
+            status: 'resolved',
+            started_at: '2026-07-15T00:00:00Z',
+            resolved_at: null,
+            affected_components: [],
+            updates: [
+              {
+                status: 'resolved',
+                message: 'line1\nline2\ttabbed',
+                posted_at: '2026-07-15T00:00:00Z',
+              },
+            ],
+          },
+        ],
+      },
+    })
+    const xml = await (await GET(makeContext())).text()
+    expect(xml).not.toContain('\x07')
+    expect(xml).toContain('BadTitle')
+    // Tab/LF/CR are explicitly preserved.
+    expect(xml).toContain('line1\nline2\ttabbed')
+  })
+
+  it('FIX (Codex #5): a fetch rejection returns a valid, well-formed, zero-item feed (not an error response)', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error('network down')) as unknown as typeof fetch
+    const response = await GET(makeContext())
+    expect(response.status).toBe(200)
+    const xml = await response.text()
+    expect(xml).toContain('<rss')
+    expect(countOccurrences(xml, '<item>')).toBe(0)
+  })
+
+  it('FIX (Codex #5): a non-OK upstream response returns a zero-item feed', async () => {
+    mockFetchJson({}, false, 502)
+    const response = await GET(makeContext())
+    expect(response.status).toBe(200)
+    expect(countOccurrences(await response.text(), '<item>')).toBe(0)
+  })
+
+  it('FIX (Codex #5 + #8): a structurally invalid payload (components not an array) returns a zero-item feed', async () => {
+    mockFetchJson({
+      cached: false,
+      data: { generated_at: 'x', overall_status: 'operational', components: 'nope', incidents: [] },
+    })
+    const response = await GET(makeContext())
+    expect(response.status).toBe(200)
+    const xml = await response.text()
+    expect(countOccurrences(xml, '<item>')).toBe(0)
+    expect(xml).toContain('<rss')
+  })
+
+  it('a malformed (non-JSON-parseable) upstream response returns a zero-item feed', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError('Unexpected token')
+      },
+    }) as unknown as typeof fetch
+    const response = await GET(makeContext())
+    expect(response.status).toBe(200)
+    expect(countOccurrences(await response.text(), '<item>')).toBe(0)
+  })
+
+  it("sends X-Content-Type-Options: nosniff without disturbing the library's Content-Type", async () => {
+    mockFetchJson(VALID_PAYLOAD)
+    const response = await GET(makeContext())
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(response.headers.get('content-type')).toContain('xml')
+  })
+
+  it('an incident with zero updates contributes zero items (no fabricated placeholder item)', async () => {
+    mockFetchJson({
+      cached: false,
+      data: {
+        generated_at: 'x',
+        overall_status: 'operational',
+        components: [],
+        incidents: [
+          {
+            id: 'inc-no-updates',
+            title: 'T',
+            impact: 'none',
+            status: 'investigating',
+            started_at: '2026-07-15T00:00:00Z',
+            resolved_at: null,
+            affected_components: [],
+            updates: [],
+          },
+        ],
+      },
+    })
+    const xml = await (await GET(makeContext())).text()
+    expect(countOccurrences(xml, '<item>')).toBe(0)
+  })
+
+  // ---------------------------------------------------------------------
+  // FIX (high): the fallback path can no longer throw uncaught, and
+  // context.site is never actually undefined at either rss() call site.
+  // ---------------------------------------------------------------------
+
+  it('FIX (high): context.site undefined does not throw -- falls back to a default site URL', async () => {
+    mockFetchJson(VALID_PAYLOAD)
+    const contextNoSite = { site: undefined } as unknown as APIContext
+    const response = await GET(contextNoSite)
+    expect(response.status).toBe(200)
+    const xml = await response.text()
+    expect(xml).toContain('<rss')
+    expect(countOccurrences(xml, '<item>')).toBe(4)
+  })
+
+  it('FIX (high): context.site undefined on the failure path still returns a valid zero-item feed', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error('network down')) as unknown as typeof fetch
+    const contextNoSite = { site: undefined } as unknown as APIContext
+    const response = await GET(contextNoSite)
+    expect(response.status).toBe(200)
+    const xml = await response.text()
+    expect(xml).toContain('<rss')
+    expect(countOccurrences(xml, '<item>')).toBe(0)
+  })
+
+  it('FIX (high): the fallback rss() call itself throwing still returns a valid static feed, not an uncaught rejection', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error('network down')) as unknown as typeof fetch
+    // Force the NEXT rss() call (the catch block's own "empty feed"
+    // fallback, since the primary path never reaches rss() when fetch
+    // itself rejects) to throw, simulating a library-internal failure
+    // unrelated to fetch/parse/shape.
+    vi.mocked(rss).mockImplementationOnce(() => {
+      throw new Error('rss library exploded')
+    })
+
+    const response = await GET(makeContext())
+    expect(response.status).toBe(200)
+    const xml = await response.text()
+    expect(xml).toContain('<rss')
+    expect(countOccurrences(xml, '<item>')).toBe(0)
+    expect(response.headers.get('content-type')).toContain('rss')
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+  })
+
+  it('FIX (high): a primary rss() call throwing for a non-fetch/parse/shape reason still recovers via the fallback', async () => {
+    mockFetchJson(VALID_PAYLOAD)
+    // The primary rss() call throws for a reason unrelated to
+    // fetch/parse/shape (e.g. an internal library failure) -- the outer
+    // catch must still recover via the (unmocked, real) fallback call.
+    vi.mocked(rss).mockImplementationOnce(() => {
+      throw new Error('unexpected internal rss() failure')
+    })
+
+    const response = await GET(makeContext())
+    expect(response.status).toBe(200)
+    const xml = await response.text()
+    expect(xml).toContain('<rss')
+    expect(countOccurrences(xml, '<item>')).toBe(0)
+  })
+})

--- a/packages/website/tests/e2e/status-page-load-guards.spec.ts
+++ b/packages/website/tests/e2e/status-page-load-guards.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * status-page-load-guards.spec.ts (SMI-5755)
+ *
+ * `status.astro` registers `astro:page-load` (poller init) and, on its own
+ * `dataset.statusWired` guard, `astro:before-swap`/`visibilitychange`
+ * listeners on `document` — the exact shape flagged by the governance
+ * skill's Shared-State/Concurrency Audit (P-5) as requiring a synthetic
+ * re-fire test (SMI-4902 helpers), following the precedent set by
+ * `account-page-load-guards.spec.ts` and `device.spec.ts` D-6.
+ *
+ * This drives real `astro:page-load` re-fires (via `refireAstroPageLoad`)
+ * against a mocked `status-public` route and asserts: (1) the rendered
+ * overall-status banner is stable across a re-fire (no stale/torn-down
+ * repaint), and (2) each re-fire's `initStatusPageInstance()` call produces
+ * exactly one immediate fetch, not a duplicate/stacked one from two live
+ * pollers both reacting to the same event. The deeper timer-accumulation
+ * property (does the OLD poller's own next *scheduled* poll, ~45s out,
+ * also get torn down, not just its immediate fetch) is covered at the unit
+ * level in status-poller.test.ts's createStatusPoller suite with fake
+ * timers — see that file's tests for the AbortController + generation-token
+ * mechanism this page's poller relies on.
+ */
+
+import { test, expect } from '@playwright/test'
+import { refireAstroPageLoad, assertStateStableAcrossRefire } from './astro-helpers'
+
+const STATUS_PUBLIC_ROUTE = '**/functions/v1/status-public'
+
+function mockPayload() {
+  return {
+    cached: false,
+    data: {
+      generated_at: new Date().toISOString(),
+      overall_status: 'operational',
+      components: [],
+      incidents: [],
+    },
+  }
+}
+
+test.describe('status page — astro:page-load re-fire guards (SMI-5755)', () => {
+  test('the overall-status banner is stable across a synthetic astro:page-load re-fire', async ({
+    page,
+  }) => {
+    await page.route(STATUS_PUBLIC_ROUTE, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockPayload()),
+      })
+    })
+
+    await page.goto('/status')
+    await expect(page.locator('#status-overall-headline')).toHaveText('All systems operational')
+
+    await assertStateStableAcrossRefire(page, '#status-overall-headline')
+    await expect(page.locator('#status-overall-headline')).toHaveText('All systems operational')
+  })
+
+  test('each astro:page-load re-fire produces exactly one fresh poller, not an accumulating one', async ({
+    page,
+  }) => {
+    // This proves the DOM/wiring-level contract: initStatusPageInstance()
+    // runs exactly once per real astro:page-load event, and each run tears
+    // down the previous poller before creating a new one — one immediate
+    // fetch per re-fire, no duplicate/stacked immediate fetches from two
+    // live pollers both reacting to the same re-fire.
+    //
+    // This is deliberately NOT trying to also prove the deeper "the OLD
+    // poller's *next scheduled* poll, ~45s out, never fires" property here —
+    // that's a timer-accumulation question already covered rigorously at the
+    // unit level in status-poller.test.ts's createStatusPoller suite (fake
+    // timers, vi.advanceTimersByTimeAsync), which exercises the exact same
+    // AbortController + generation-token + recursive-setTimeout mechanism
+    // this page's poller instance uses. Splitting it this way — e2e proves
+    // real wiring, unit test proves real timing — is more reliable than
+    // fighting Playwright's page.clock against a page.route-mocked fetch in
+    // the same test.
+    let hits = 0
+    await page.route(STATUS_PUBLIC_ROUTE, async (route) => {
+      hits += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockPayload()),
+      })
+    })
+
+    await page.goto('/status')
+    await expect(page.locator('#status-overall-headline')).toHaveText('All systems operational')
+    expect(hits, 'initial mount should fetch exactly once').toBe(1)
+
+    for (let i = 0; i < 3; i += 1) {
+      await refireAstroPageLoad(page)
+      // eslint-disable-next-line no-await-in-loop -- each re-fire's fetch must settle before the next
+      await expect.poll(() => hits).toBe(2 + i)
+    }
+
+    expect(hits, 'exactly one immediate fetch per re-fire — no duplicate/stacked pollers').toBe(4)
+  })
+})

--- a/scripts/smoke-prod/surfaces.json
+++ b/scripts/smoke-prod/surfaces.json
@@ -163,6 +163,25 @@
       "checks": ["check_status_public_healthy"]
     },
     {
+      "id": "website-status-page",
+      "owner": "website",
+      "trigger_globs": [
+        "packages/website/src/pages/status.astro",
+        "packages/website/src/pages/status.rss.xml.ts",
+        "packages/website/src/components/StatusPill.astro",
+        "packages/website/src/components/StatusComponentRow.astro",
+        "packages/website/src/components/UptimeBarStrip.astro",
+        "packages/website/src/lib/status-vocab.ts",
+        "packages/website/src/lib/status-client.ts",
+        "packages/website/src/lib/status-payload.ts",
+        "packages/website/src/lib/status-reconcile.ts",
+        "packages/website/src/lib/status-render.ts",
+        "packages/website/src/lib/status-poller.ts"
+      ],
+      "script": "scripts/smoke-prod/website.sh",
+      "checks": ["check_status_page_renders", "check_status_rss_feed_well_formed"]
+    },
+    {
       "id": "edge-fn-fuzzy-search",
       "owner": "edge-functions",
       "trigger_globs": ["supabase/functions/skills-recommend/**"],

--- a/scripts/smoke-prod/website.sh
+++ b/scripts/smoke-prod/website.sh
@@ -966,3 +966,81 @@ except Exception:
   report_pass "status-public" "check_status_public_healthy" "$url" "$ms"
   return 0
 }
+
+# ---- check_status_page_renders -----------------------------------------
+# SMI-5755 Wave 5 (public status page). Verifies /status returns 200 and
+# renders the server-rendered no-JS scaffold. Uses the
+# data-smoke="status-page" attribute (present without JS, mirroring
+# check_device_page_renders' data-smoke fingerprint pattern above) rather
+# than prose text, so a copy edit can't silently break the check.
+check_status_page_renders() {
+  local url="${SMOKE_WEBSITE_URL}/status"
+  local t0 t1 ms resp status body
+  t0=$(now_ms)
+  resp=$(with_retry http_body GET "$url") || true
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  status=$(printf '%s' "$resp" | head -n1)
+  body=$(printf '%s' "$resp" | tail -n +2)
+
+  if [ "$status" != "200" ]; then
+    report_fail "website-status-page" "check_status_page_renders" "$url" "200" "$status" "$ms"
+    return 1
+  fi
+  if ! assert_contains "$body" 'data-smoke="status-page"' "status-page-fingerprint"; then
+    report_fail "website-status-page" "check_status_page_renders" "$url" 'data-smoke="status-page"' "missing-fingerprint" "$ms"
+    return 1
+  fi
+  report_pass "website-status-page" "check_status_page_renders" "$url" "$ms"
+  return 0
+}
+
+# ---- check_status_rss_feed_well_formed ----------------------------------
+# SMI-5755 Wave 5. Verifies /status.rss.xml returns 200, an XML content type,
+# and ACTUALLY PARSES as well-formed XML -- not just a `<rss` substring grep,
+# which a truncated/malformed feed could still satisfy. Uses python3's
+# xml.etree.ElementTree, matching this script's existing idiom of shelling
+# out to python3 for structured-output validation (see
+# check_status_public_healthy / _skills_usage_count above) rather than
+# introducing a new tool -- xmllint is not guaranteed present in the smoke
+# environment, python3 already is (used extensively above).
+check_status_rss_feed_well_formed() {
+  local url="${SMOKE_WEBSITE_URL}/status.rss.xml"
+  local t0 t1 ms resp status body content_type parse_ok
+  t0=$(now_ms)
+  resp=$(with_retry http_body GET "$url") || true
+  t1=$(now_ms)
+  ms=$((t1 - t0))
+  status=$(printf '%s' "$resp" | head -n1)
+  body=$(printf '%s' "$resp" | tail -n +2)
+
+  if [ "$status" != "200" ]; then
+    report_fail "website-status-page" "check_status_rss_feed_well_formed" "$url" "200" "$status" "$ms"
+    return 1
+  fi
+
+  content_type=$(curl --silent --max-time "$SMOKE_HTTP_TIMEOUT" -D - -o /dev/null "$url" 2>/dev/null \
+    | tr -d '\r' | awk -F': ' 'tolower($1)=="content-type"{print $2; exit}')
+  if ! assert_contains "$content_type" "xml" "status-rss-content-type"; then
+    report_fail "website-status-page" "check_status_rss_feed_well_formed" "$url" "*/xml content-type" "$content_type" "$ms"
+    return 1
+  fi
+
+  parse_ok=$(printf '%s' "$body" | python3 -c "
+import sys
+import xml.etree.ElementTree as ET
+try:
+    root = ET.fromstring(sys.stdin.read())
+    print('ok' if root.tag == 'rss' else 'bad-root')
+except Exception:
+    print('parse-error')
+" 2>/dev/null) || parse_ok="parse-error"
+
+  if [ "$parse_ok" != "ok" ]; then
+    report_fail "website-status-page" "check_status_rss_feed_well_formed" "$url" "well-formed <rss> XML" "$parse_ok" "$ms"
+    return 1
+  fi
+
+  report_pass "website-status-page" "check_status_rss_feed_well_formed" "$url" "$ms"
+  return 0
+}


### PR DESCRIPTION
## Business Summary

**What shipped:** Skillsmith now has a public status page at `/status`, showing live health for
6 core services (website, search API, MCP backend, database, skill indexer, billing), a 90-day
uptime history per service, and an incident timeline — plus an RSS feed so people can subscribe
to incident updates. This is the user-facing payoff of the status-page initiative's earlier
waves (schema, health checks, incident management, the public API).

**Quality bar:** Design reviewed adversarially before any code was written (18 findings, all
fixed), then the implemented code reviewed adversarially again on the real diff (4 more
findings, all fixed — including a real bug where corrupted uptime data could have displayed a
fabricated "healthy" tile instead of "no data"). A governance pass then caught one more gap
(a required accessibility/lifecycle regression test) and it was fixed immediately. Every fix
was independently re-verified against the actual code, not just trusted from reports.
Independently re-run (not just reported): typecheck, lint, and build clean; 591/591 tests
passing; the standards audit clean (76 passed, 0 failed, 12 pre-existing/unrelated warnings).

**Found along the way:** the new page's browser-navigation regression test has no CI wiring
yet — this repo has no generic end-to-end test runner, and adding a brand-new one is an
infrastructure change requiring its own separate design-and-review process. Filed as SMI-5807,
not blocking this PR (the test itself exists, passes, and was run for real locally).

**Net result:** Fully shipped, pending a staging/preview verification pass before promoting to
production (per this initiative's standing staging-gate requirement).

---

## Technical detail

**New files** (`packages/website/src/`):
- `lib/status-vocab.ts` — shared status vocabulary/types and the 90-day uptime-grid builder
  (anchored to the API payload's own `generated_at`, never the browser's live clock, so a
  cached-then-repainted view can't misalign across a UTC-midnight rollover)
- `lib/status-payload.ts` — full payload validation, shared between network responses and the
  localStorage cache (versioned, TTL'd)
- `lib/status-reconcile.ts` — the dynamic-row reconciliation contract for a component slug the
  API returns outside the fixed six
- `lib/status-render.ts` — `textContent`-only render builders for every admin-authored
  free-text field (component message/name, incident title, incident update messages,
  affected-component display names) — this diff is the first place in the whole initiative
  where that text becomes real HTML instead of staying inside a JSON response
- `lib/status-poller.ts` — roving-tabindex keyboard nav for the 90-tile uptime strip, plus a
  recursive-`setTimeout` poll controller (`AbortController` + a generation token so a stale
  response can never paint a torn-down page)
- `lib/status-client.ts` — barrel re-export (kept the four modules above independently
  importable/testable and each under the 500-line file gate)
- `components/StatusPill.astro`, `components/UptimeBarStrip.astro`,
  `components/StatusComponentRow.astro`, `pages/status.astro`, `pages/status.rss.xml.ts`
- `tests/e2e/status-page-load-guards.spec.ts` — Playwright regression test for the
  `astro:page-load` view-transition lifecycle (governance's Shared-State/Concurrency Audit,
  P-5); verified locally with real Chromium against a static build (the Vercel adapter doesn't
  support `astro preview`, so this was run against `dist/client` served statically)

**Edits**: one new `Footer.astro` resources link; a new `scripts/smoke-prod/surfaces.json`
surface entry (`website-status-page`) plus two new check functions in
`scripts/smoke-prod/website.sh`.

**Adversarial review findings fixed** (design phase, pre-implementation): incident-blind
`overall_status`, no freshness guarantee on stale data, an old active incident that could get
buried behind newer resolved ones, plus 15 more spanning lifecycle, accessibility, and payload
validation. **Code-review-phase findings fixed** (post-implementation, on the actual diff):
`uptime_pct` corruption fabricating a green "Operational" tile instead of "no data"; the RSS
feed's own error-fallback path being unprotected against its own failure; incident
affected-component names resolving against a frozen compile-time list instead of the live API
payload; the uptime strip's screen-reader summary never refreshing after real data loads.

**Follow-up filed separately**: SMI-5807 (CI wiring for the new e2e spec — ADR-109-gated,
needs its own SPARC + plan-review pass before a new GitHub Actions workflow can be authored).

**Verification before merge**: Vercel preview deployment check, RSS feed XML validity check,
confirm `smoke-prod` picks up the new surface — per this initiative's plan.
