### PR TITLE
fix(website): Format status-page timestamps and clarify today's uptime tile (SMI-5811)

### DIFF
--- a/packages/website/src/components/StatusComponentRow.astro
+++ b/packages/website/src/components/StatusComponentRow.astro
@@ -62,7 +62,12 @@ const {
       <span>Last checked: <span data-role="checked-at">{checkedAtText}</span></span>
     </div>
     <div class="mt-4">
-      <UptimeBarStrip uptime90d={uptime90d} anchorIsoDate={anchorIsoDate} label={name} />
+      <UptimeBarStrip
+        uptime90d={uptime90d}
+        anchorIsoDate={anchorIsoDate}
+        liveStatus={status}
+        label={name}
+      />
     </div>
   </Card>
 </div>

--- a/packages/website/src/components/UptimeBarStrip.astro
+++ b/packages/website/src/components/UptimeBarStrip.astro
@@ -34,19 +34,23 @@ import {
   buildUptimeStripAriaLabel,
   uptimeTileClassName,
   uptimeTileText,
+  withLiveAnchorStatus,
+  type ComponentStatus,
   type UptimeDay,
 } from '../lib/status-vocab'
 
 interface Props {
   uptime90d: UptimeDay[]
   anchorIsoDate: string
+  /** The component's LIVE current status — see withLiveAnchorStatus's header comment. */
+  liveStatus: ComponentStatus
   label: string
   class?: string
 }
 
-const { uptime90d, anchorIsoDate, label, class: className = '' } = Astro.props
+const { uptime90d, anchorIsoDate, liveStatus, label, class: className = '' } = Astro.props
 
-const tiles = buildUptimeGrid(uptime90d, anchorIsoDate)
+const tiles = withLiveAnchorStatus(buildUptimeGrid(uptime90d, anchorIsoDate), liveStatus)
 const lastIndex = tiles.length - 1
 
 // FIX (medium): counting logic now lives in buildUptimeStripAriaLabel

--- a/packages/website/src/lib/status-render.test.ts
+++ b/packages/website/src/lib/status-render.test.ts
@@ -47,6 +47,19 @@ function makeIncident(overrides: Partial<StatusIncident> = {}): StatusIncident {
 // ---------------------------------------------------------------------------
 
 describe('buildComponentRowContent / applyComponentRowContent', () => {
+  it('FIX: formats checked_at for human display, never the raw ISO string', () => {
+    const content = buildComponentRowContent(makeComponent({ checked_at: '2026-07-15T00:00:00Z' }))
+    expect(content.checkedAtText).not.toBe('2026-07-15T00:00:00Z')
+    expect(content.checkedAtText).not.toContain('T')
+  })
+
+  it('renders a missing or invalid checked_at as the em-dash placeholder, not "Invalid Date"', () => {
+    expect(buildComponentRowContent(makeComponent({ checked_at: null })).checkedAtText).toBe('—')
+    expect(
+      buildComponentRowContent(makeComponent({ checked_at: 'not-a-date' })).checkedAtText
+    ).toBe('—')
+  })
+
   it('preserves an adversarial name/message unchanged in the content descriptor', () => {
     const content = buildComponentRowContent(
       makeComponent({ name: ADVERSARIAL, message: ADVERSARIAL })
@@ -174,6 +187,28 @@ describe('buildIncidentContent', () => {
     expect(content.affectedText).toBe('Website')
   })
 
+  it('FIX: formats started_at/resolved_at/posted_at for human display, never the raw ISO string', () => {
+    const content = buildIncidentContent(
+      makeIncident({
+        started_at: '2026-07-15T00:00:00Z',
+        resolved_at: '2026-07-15T01:00:00Z',
+        updates: [{ status: 'resolved', message: 'fixed', posted_at: '2026-07-15T01:00:00Z' }],
+      }),
+      new Map()
+    )
+    expect(content.startedAtText).not.toBe('2026-07-15T00:00:00Z')
+    expect(content.startedAtText).not.toContain('T')
+    expect(content.resolvedAtText).not.toBe('2026-07-15T01:00:00Z')
+    expect(content.resolvedAtText).not.toContain('T')
+    expect(content.updates[0].postedAtText).not.toBe('2026-07-15T01:00:00Z')
+    expect(content.updates[0].postedAtText).not.toContain('T')
+  })
+
+  it('an unresolved incident (resolved_at: null) reads "Ongoing", not a formatted null', () => {
+    const content = buildIncidentContent(makeIncident({ resolved_at: null }), new Map())
+    expect(content.resolvedAtText).toBe('Ongoing')
+  })
+
   it('falls back to the raw status string when the incident status is unrecognized', () => {
     const content = buildIncidentContent(makeIncident({ status: 'weird' as never }), new Map())
     expect(content.statusLabel).toBe('weird')
@@ -234,5 +269,29 @@ describe('refreshUptimeStripTiles', () => {
     expect(stripAttrs['aria-label']).toBe(
       'Website: 90-day uptime — 1 operational, 0 degraded, 0 outage, 89 no data'
     )
+  })
+
+  it("FIX: a supplied liveStatus overrides today's tile instead of leaving it perpetually gray", () => {
+    const handles = Array.from({ length: 90 }, () => ({
+      className: '',
+      attrs: {} as Record<string, string>,
+      setAttribute(n: string, v: string) {
+        this.attrs[n] = v
+      },
+    }))
+    refreshUptimeStripTiles(handles, [], '2026-07-15', null, undefined, 'operational')
+    expect(handles[89].className).toContain('bg-green-500')
+    expect(handles[89].attrs['aria-label']).toContain('current, today in progress')
+    // Untouched historical tiles remain no-data.
+    expect(handles[0].className).toContain('bg-gray-700')
+  })
+
+  it("omitting liveStatus leaves today's tile as ordinary no-data (backward compatible)", () => {
+    const handles = Array.from({ length: 90 }, () => ({
+      className: '',
+      setAttribute() {},
+    }))
+    refreshUptimeStripTiles(handles, [], '2026-07-15')
+    expect(handles[89].className).toContain('bg-gray-700')
   })
 })

--- a/packages/website/src/lib/status-render.ts
+++ b/packages/website/src/lib/status-render.ts
@@ -17,6 +17,7 @@ import {
   buildUptimeGrid,
   buildUptimeStripAriaLabel,
   coerceComponentStatus,
+  formatTimestamp,
   IMPACT_CLASSES,
   IMPACT_LABELS,
   INCIDENT_STATUS_LABELS,
@@ -28,6 +29,7 @@ import {
   STATUS_PILL_CLASSES,
   uptimeTileClassName,
   uptimeTileText,
+  withLiveAnchorStatus,
   type ComponentScaffoldEntry,
   type ComponentStatus,
   type StatusComponent,
@@ -67,7 +69,7 @@ export function buildComponentRowContent(component: StatusComponent): ComponentR
     statusLabel: STATUS_LABELS[status],
     pillClassName: buildPillClassName(status),
     latencyText: isFiniteNumber(component.latency_ms) ? `${component.latency_ms} ms` : '—',
-    checkedAtText: component.checked_at ?? '—',
+    checkedAtText: formatTimestamp(component.checked_at),
   }
 }
 
@@ -145,15 +147,24 @@ export interface UptimeStripHandle {
  * `buildUptimeStripAriaLabel` (../lib/status-vocab.ts) — previously only the
  * per-tile `aria-label`s were refreshed, leaving the group-level summary
  * stuck at its SSR-time "0 operational ... 90 no data" reading forever.
+ *
+ * FIX: `liveStatus`, when supplied, overrides today's tile with the
+ * component's live current status via `withLiveAnchorStatus` (../lib/
+ * status-vocab.ts) — see that function's header comment for why today's
+ * rollup-derived tile is otherwise always gray/no-data and easily misread as
+ * yesterday's real status. Optional/trailing for the same backward-
+ * compatibility reason as `stripHandle`/`label`.
  */
 export function refreshUptimeStripTiles(
   tileHandles: UptimeTileHandle[],
   uptime90d: UptimeDay[],
   anchorIsoDate: string,
   stripHandle?: UptimeStripHandle | null,
-  label?: string
+  label?: string,
+  liveStatus?: ComponentStatus
 ): void {
-  const tiles = buildUptimeGrid(uptime90d, anchorIsoDate)
+  const rawTiles = buildUptimeGrid(uptime90d, anchorIsoDate)
+  const tiles = liveStatus !== undefined ? withLiveAnchorStatus(rawTiles, liveStatus) : rawTiles
   const count = Math.min(tileHandles.length, tiles.length)
   for (let i = 0; i < count; i++) {
     const tile = tiles[i]
@@ -242,12 +253,12 @@ export function buildIncidentContent(
     impactClassName: IMPACT_CLASSES[incident.impact] ?? IMPACT_CLASSES.none,
     statusLabel: INCIDENT_STATUS_LABELS[incident.status] ?? incident.status,
     affectedText: buildAffectedComponentsText(incident.affected_components, componentsBySlug),
-    startedAtText: incident.started_at || '—',
-    resolvedAtText: incident.resolved_at ?? 'Ongoing',
+    startedAtText: formatTimestamp(incident.started_at),
+    resolvedAtText: incident.resolved_at ? formatTimestamp(incident.resolved_at) : 'Ongoing',
     updates: incident.updates.map((update) => ({
       statusLabel: INCIDENT_STATUS_LABELS[update.status] ?? update.status,
       message: update.message,
-      postedAtText: update.posted_at || '—',
+      postedAtText: formatTimestamp(update.posted_at),
     })),
   }
 }

--- a/packages/website/src/lib/status-vocab.test.ts
+++ b/packages/website/src/lib/status-vocab.test.ts
@@ -4,6 +4,7 @@ import {
   buildUptimeStripAriaLabel,
   coerceComponentStatus,
   COMPONENTS,
+  formatTimestamp,
   isFiniteNumber,
   isNonNegativeInteger,
   isValidDayString,
@@ -14,6 +15,7 @@ import {
   STATUS_PILL_CLASSES,
   STATUS_TILE_CLASSES,
   uptimeTileText,
+  withLiveAnchorStatus,
   type ComponentStatus,
   type DayStatus,
   type UptimeDay,
@@ -286,5 +288,81 @@ describe('buildUptimeStripAriaLabel', () => {
   it('reflects the supplied label, not a hardcoded one', () => {
     const tiles = buildUptimeGrid([], ANCHOR)
     expect(buildUptimeStripAriaLabel(tiles, 'Search API')).toContain('Search API: 90-day uptime')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatTimestamp (SMI-5755 follow-up fix — checked_at/started_at/resolved_at/
+// posted_at were each displayed as raw, unreadable ISO strings)
+// ---------------------------------------------------------------------------
+
+describe('formatTimestamp', () => {
+  it('formats a valid ISO timestamp as a locale-aware string, never the raw ISO form', () => {
+    const result = formatTimestamp('2026-07-15T12:34:56Z')
+    expect(result).not.toBe('2026-07-15T12:34:56Z')
+    expect(result).not.toContain('T')
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  it('returns the em-dash placeholder for null/undefined/empty input', () => {
+    expect(formatTimestamp(null)).toBe('—')
+    expect(formatTimestamp(undefined)).toBe('—')
+    expect(formatTimestamp('')).toBe('—')
+  })
+
+  it('returns the em-dash placeholder for an unparseable string, never "Invalid Date"', () => {
+    expect(formatTimestamp('not-a-real-date')).toBe('—')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// withLiveAnchorStatus (UX follow-up: today always has no rollup row until
+// 00:15 UTC the next day, so it was previously perpetually gray — easily
+// misread as yesterday's real, colored tile right next to it)
+// ---------------------------------------------------------------------------
+
+describe('withLiveAnchorStatus', () => {
+  it("overrides only the LAST (today) tile with the component's live status", () => {
+    const tiles = buildUptimeGrid(
+      [makeDay('2026-07-14', { worst_status: 'degraded', uptime_pct: 90 })],
+      ANCHOR
+    )
+    const result = withLiveAnchorStatus(tiles, 'operational')
+    expect(result[89].status).toBe('operational')
+    // Yesterday's real rollup tile is untouched.
+    expect(result[88].status).toBe('degraded')
+    expect(result[88].uptimePct).toBe(90)
+  })
+
+  it("today's overridden tile never carries a fabricated percentage", () => {
+    const tiles = buildUptimeGrid([], ANCHOR)
+    const result = withLiveAnchorStatus(tiles, 'outage')
+    expect(result[89].status).toBe('outage')
+    expect(result[89].uptimePct).toBeNull()
+    expect(result[89].totalChecks).toBeNull()
+  })
+
+  it("a live status of 'unknown' leaves today as ordinary no-data (there is no DayStatus for it)", () => {
+    const tiles = buildUptimeGrid([], ANCHOR)
+    const result = withLiveAnchorStatus(tiles, 'unknown')
+    expect(result[89].status).toBeNull()
+  })
+
+  it('does not throw on an empty tile array', () => {
+    expect(withLiveAnchorStatus([], 'operational')).toEqual([])
+  })
+
+  it("uptimeTileText renders the override as 'current, today in progress', not a fake percentage", () => {
+    const tiles = buildUptimeGrid([], ANCHOR)
+    const result = withLiveAnchorStatus(tiles, 'degraded')
+    expect(uptimeTileText(result[89])).toBe(`${ANCHOR}: Degraded (current, today in progress)`)
+  })
+
+  it('a completed day with a real percentage is unaffected by the qualifier', () => {
+    const tiles = buildUptimeGrid([makeDay(ANCHOR, { uptime_pct: 99.5 })], '2026-07-16')
+    // ANCHOR (2026-07-15) is now yesterday relative to the new anchor 2026-07-16.
+    const yesterday = tiles.find((t) => t.date === ANCHOR)!
+    expect(uptimeTileText(yesterday)).toContain('99.50% uptime')
+    expect(uptimeTileText(yesterday)).not.toContain('current')
   })
 })

--- a/packages/website/src/lib/status-vocab.ts
+++ b/packages/website/src/lib/status-vocab.ts
@@ -182,6 +182,37 @@ export function buildUptimeGrid(uptime90d: UptimeDay[], anchorIsoDate: string): 
   return tiles
 }
 
+/**
+ * FIX: "today" never has a daily-rollup row — the rollup cron only aggregates
+ * fully-elapsed calendar days (00:15 UTC for the PREVIOUS day), so
+ * buildUptimeGrid's last tile is ALWAYS `status: null` ("no data") until
+ * midnight, every single day. That gray tile sits immediately next to
+ * yesterday's real (possibly colored) tile, and with only a loose "Today"
+ * caption below the whole strip (not pointing at one specific tile), it's
+ * easy to misread yesterday's status as today's — the exact confusion this
+ * fixes. Overrides the LAST tile's status with the component's LIVE current
+ * status (already fetched for the pill above the strip), leaving
+ * `uptimePct`/`totalChecks` null (there is no historical percentage for an
+ * in-progress day — never fabricate one). `uptimeTileText` renders this
+ * combination (a real status with a null uptimePct) as "(current, today in
+ * progress)", a qualifier no other tile can produce, so hovering it can never
+ * be confused with a completed day's rollup reading. `liveStatus: 'unknown'`
+ * leaves the tile as the ordinary no-data gray (there is no DayStatus value
+ * for 'unknown' — it means the same thing as no data here).
+ */
+export function withLiveAnchorStatus(
+  tiles: UptimeTile[],
+  liveStatus: ComponentStatus
+): UptimeTile[] {
+  if (tiles.length === 0) return tiles
+  const lastIndex = tiles.length - 1
+  const dayStatus = toDayStatus(liveStatus)
+  if (dayStatus === null) return tiles
+  return tiles.map((tile, index) =>
+    index === lastIndex ? { ...tile, status: dayStatus, uptimePct: null, totalChecks: null } : tile
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Component status coercion
 // ---------------------------------------------------------------------------
@@ -367,6 +398,23 @@ export const COMPONENTS: ComponentScaffoldEntry[] = [
 /** "No data reported." — distinct from a tile's "No data" and a live 'unknown' status (Codex #15). */
 export const SCAFFOLD_NO_DATA_MESSAGE = 'No data reported.'
 
+/**
+ * Formats an ISO timestamp for human display (locale-aware date + time),
+ * never the raw ISO string. Shared by every builder in status-render.ts
+ * that surfaces a timestamp (component checked_at, incident started_at/
+ * resolved_at, incident-update posted_at) so none of them can independently
+ * regress back to displaying a raw ISO string — the bug this function fixes
+ * (SMI-5755 follow-up: `checkedAtText`/`startedAtText`/`resolvedAtText`/
+ * `postedAtText` were each assigned directly from the raw API string with
+ * no formatting at all).
+ */
+export function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const parsed = new Date(iso)
+  if (Number.isNaN(parsed.getTime())) return '—'
+  return parsed.toLocaleString()
+}
+
 // ---------------------------------------------------------------------------
 // Uptime tile presentation — shared by UptimeBarStrip.astro's SSR render and
 // status-client.ts's client-side tile refresh, so the two never drift.
@@ -382,8 +430,13 @@ export function uptimeTileClassName(status: DayStatus | null): string {
 /** "No data" (a calendar day with no checks) — distinct from STATUS_LABELS.unknown (Codex #15). */
 export function uptimeTileText(tile: UptimeTile): string {
   if (tile.status === null) return `${tile.date}: No data`
-  const pctText = tile.uptimePct !== null ? ` (${tile.uptimePct.toFixed(2)}% uptime)` : ''
-  return `${tile.date}: ${STATUS_LABELS[tile.status]}${pctText}`
+  // A real status with a null uptimePct only ever comes from
+  // withLiveAnchorStatus's live override on today's tile (every OTHER tile
+  // either has a real rollup percentage or is no-data) — the qualifier makes
+  // this unambiguous on hover, never mistakable for a completed day's rollup.
+  if (tile.uptimePct === null)
+    return `${tile.date}: ${STATUS_LABELS[tile.status]} (current, today in progress)`
+  return `${tile.date}: ${STATUS_LABELS[tile.status]} (${tile.uptimePct.toFixed(2)}% uptime)`
 }
 
 /**

--- a/packages/website/src/pages/status.astro
+++ b/packages/website/src/pages/status.astro
@@ -115,6 +115,7 @@ const banner = OVERALL_BANNER.unknown
     } from '../lib/status-client'
     import {
       COMPONENTS,
+      formatTimestamp,
       OVERALL_BANNER,
       type ComponentStatus,
       type StatusComponent,
@@ -140,13 +141,6 @@ const banner = OVERALL_BANNER.unknown
         currentPoller.stop()
         currentPoller = null
       }
-    }
-
-    function formatTimestamp(iso: string): string {
-      if (!iso) return '—'
-      const parsed = new Date(iso)
-      if (Number.isNaN(parsed.getTime())) return '—'
-      return parsed.toLocaleString()
     }
 
     function getRowElements(rowEl: Element): ComponentRowElements {
@@ -238,7 +232,8 @@ const banner = OVERALL_BANNER.unknown
             component.uptime_90d,
             anchorIsoDate,
             getUptimeStripHandle(rowEl),
-            component.name
+            component.name,
+            component.status
           )
         }
 
@@ -250,7 +245,8 @@ const banner = OVERALL_BANNER.unknown
             component.uptime_90d,
             anchorIsoDate,
             getUptimeStripHandle(rowEl),
-            component.name
+            component.name,
+            component.status
           )
         }
 
@@ -268,7 +264,8 @@ const banner = OVERALL_BANNER.unknown
             [],
             anchorIsoDate,
             getUptimeStripHandle(rowEl),
-            scaffold.name
+            scaffold.name,
+            'unknown'
           )
         }
       }


### PR DESCRIPTION
## Business Summary

**What shipped:** Two visible bugs fixed on the just-launched public status page — timestamps
("Last checked", incident start/resolve times, update times) now show in a normal readable
format instead of a raw code-style string, and today's uptime tile in the 90-day history now
shows today's real current status instead of always appearing blank/gray next to yesterday's
tile, which was easy to mistake for today's status.

**Quality bar:** Both fixes independently verified against real production data before writing
any code — confirmed the underlying status/uptime calculation logic was correct throughout;
these were display-only bugs. Full test suite green (611/611), typecheck/lint/standards audit
clean.

**Net result:** Fully shipped.

---

## Technical detail

**Bug 1**: `component.checked_at`/`incident.started_at`/`incident.resolved_at`/
`incident.updates[].posted_at` were assigned directly from the raw API ISO string with no
formatting. Moved the existing `formatTimestamp()` (previously local to `status.astro`'s client
script, only ever called for the page's own "Last updated" line) into `status-vocab.ts` as the
single shared implementation, applied in `status-render.ts`'s `buildComponentRowContent`/
`buildIncidentContent`.

**Bug 2**: the daily rollup only aggregates fully-elapsed calendar days (00:15 UTC for the
*previous* day), so the 90-day strip's last tile has no rollup row until midnight — every single
day, it renders "no data" (gray), sitting next to yesterday's real tile. New
`withLiveAnchorStatus()` in `status-vocab.ts` overrides the last tile with the component's
already-fetched live `status`, leaving the uptime percentage `null` (never fabricated) —
`uptimeTileText` renders this combination as `"(current, today in progress)"`, a qualifier no
other tile can produce, so hovering it can never be confused with a completed day's rollup.
Threaded through `UptimeBarStrip.astro` (new `liveStatus` prop), `StatusComponentRow.astro`,
and `status.astro`'s three reconcile call sites (`toUpsert`/`toCreate` pass the component's real
status; `toResetSlugs` passes `'unknown'`, correctly leaving the tile gray when there's no live
data at all for that component).

**Verified against live production data** (Linear SMI-5811 has the full query output): the
reported "Database operational now, but degraded/98.90% today" was actually **yesterday's**
rollup (2 real checks at 1211ms/1450ms tripping the 1000ms threshold) — confirms this PR's fix
as the root cause, not a threshold miscalibration.
