### PR TITLE
feat(website): Add status.skillsmith.app subdomain rewrite (SMI-5812)

### DIFF
--- a/packages/website/src/layouts/BaseLayout.astro
+++ b/packages/website/src/layouts/BaseLayout.astro
@@ -24,6 +24,8 @@ interface Props {
   activePath?: string
   /** Prevent search engines from indexing this page */
   noindex?: boolean
+  /** Override for pages reachable under more than one host (e.g. the status page, also served at status.skillsmith.app/), to pin canonical + og:url to one indexable URL */
+  canonical?: string
 }
 
 const {
@@ -31,7 +33,10 @@ const {
   description = 'Skillsmith - AI-powered agent skill discovery and management',
   activePath = '',
   noindex = false,
+  canonical,
 } = Astro.props
+
+const canonicalHref = canonical ?? new URL(Astro.url.pathname, Astro.site).href
 
 // Get Supabase config for auth-aware navigation
 const supabaseConfig = getSupabaseConfig()
@@ -49,7 +54,7 @@ const supabaseConfig = getSupabaseConfig()
         ? 'noindex, nofollow'
         : 'max-image-preview:large, max-snippet:-1, max-video-preview:-1'}
     />
-    <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).href} />
+    <link rel="canonical" href={canonicalHref} />
     <meta name="generator" content={Astro.generator} />
 
     <!-- Font preconnect hints (SMI-2349: moved from CSS @import to HTML link for faster discovery) -->
@@ -105,7 +110,7 @@ const supabaseConfig = getSupabaseConfig()
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content={new URL(Astro.url.pathname, Astro.site).href} />
+    <meta property="og:url" content={canonicalHref} />
     <!-- TODO: Replace og-image.png once design creates the actual PNG (risk R3-1, SMI-2352) -->
     <meta property="og:image" content={new URL('/og-image.png', Astro.site).href} />
     <meta property="og:image:width" content="1200" />

--- a/packages/website/src/pages/status.astro
+++ b/packages/website/src/pages/status.astro
@@ -23,13 +23,14 @@ const banner = OVERALL_BANNER.unknown
   title="Status | Skillsmith"
   description="Live status and 90-day uptime history for Skillsmith's website, API, MCP backend, and infrastructure."
   activePath="/status"
+  canonical="https://www.skillsmith.app/status/"
 >
   <Fragment slot="head">
     <link
       rel="alternate"
       type="application/rss+xml"
       title="Skillsmith Status"
-      href="/status.rss.xml"
+      href="https://www.skillsmith.app/status.rss.xml"
     />
   </Fragment>
 

--- a/packages/website/src/pages/status.rss.xml.ts
+++ b/packages/website/src/pages/status.rss.xml.ts
@@ -99,6 +99,14 @@ const FEED_DESCRIPTION = 'Incident history and status updates for Skillsmith ser
 // rss() library at all.
 const DEFAULT_SITE_URL = 'https://www.skillsmith.app'
 
+// SMI-5812: the feed is discoverable from status.skillsmith.app too, but must
+// always self-identify (channel <link> and <atom:link rel="self">) against
+// the canonical www host and the /status page, never the subdomain.
+const FEED_SELF_URL = new URL('/status.rss.xml', DEFAULT_SITE_URL).href
+const STATUS_PAGE_LINK = new URL('/status', DEFAULT_SITE_URL).href
+const ATOM_XMLNS = { atom: 'http://www.w3.org/2005/Atom' } as const
+const ATOM_SELF_LINK = `<atom:link href="${FEED_SELF_URL}" rel="self" type="application/rss+xml"/>`
+
 /**
  * FIX (high): a hand-built, minimal, well-formed RSS/XML string that depends
  * on NOTHING — not `context.site`, not the `rss()` library, not any upstream
@@ -111,10 +119,11 @@ const DEFAULT_SITE_URL = 'https://www.skillsmith.app'
  */
 const STATIC_FALLBACK_RSS_XML =
   '<?xml version="1.0" encoding="UTF-8"?>' +
-  '<rss version="2.0"><channel>' +
+  '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel>' +
   `<title>${FEED_TITLE}</title>` +
   `<description>${FEED_DESCRIPTION}</description>` +
-  `<link>${DEFAULT_SITE_URL}</link>` +
+  `<link>${STATUS_PAGE_LINK}</link>` +
+  `${ATOM_SELF_LINK}` +
   '</channel></rss>'
 
 function staticFallbackResponse(): Response {
@@ -129,6 +138,7 @@ function staticFallbackResponse(): Response {
 
 export async function GET(context: APIContext): Promise<Response> {
   const site = context.site ?? new URL(DEFAULT_SITE_URL)
+  const channelSite = new URL('/status/', site)
 
   // FIX (Codex #5, merge-blocking): the ENTIRE handler — fetch, JSON parse,
   // normalization, and the rss() call itself — is wrapped in one try/catch.
@@ -149,8 +159,10 @@ export async function GET(context: APIContext): Promise<Response> {
     const rssResponse = await rss({
       title: FEED_TITLE,
       description: FEED_DESCRIPTION,
-      site,
+      site: channelSite,
       trailingSlash: false,
+      xmlns: ATOM_XMLNS,
+      customData: ATOM_SELF_LINK,
       items,
     })
     return withNoSniffHeader(rssResponse)
@@ -163,8 +175,10 @@ export async function GET(context: APIContext): Promise<Response> {
       const emptyFeedResponse = await rss({
         title: FEED_TITLE,
         description: FEED_DESCRIPTION,
-        site,
+        site: channelSite,
         trailingSlash: false,
+        xmlns: ATOM_XMLNS,
+        customData: ATOM_SELF_LINK,
         items: [],
       })
       return withNoSniffHeader(emptyFeedResponse)

--- a/packages/website/tests/api/status.rss.xml.test.ts
+++ b/packages/website/tests/api/status.rss.xml.test.ts
@@ -23,6 +23,21 @@ function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1
 }
 
+// SMI-5812: a single regex verifying href/rel/type are all attributes on ONE
+// <atom:link> element (not three independent substrings that could exist
+// unrelated to each other, e.g. on different elements). Attribute order
+// (href, rel, type) verified empirically against the actual serialized
+// output of @astrojs/rss@4.0.19 with this code's customData string, and it
+// matches the STATIC_FALLBACK_RSS_XML literal in status.rss.xml.ts exactly.
+const ATOM_SELF_LINK_RE =
+  /<atom:link[^>]*href="https:\/\/www\.skillsmith\.app\/status\.rss\.xml"[^>]*rel="self"[^>]*type="application\/rss\+xml"[^>]*\/>/
+
+function expectAtomSelfLink(xml: string): void {
+  expect(xml).toMatch(ATOM_SELF_LINK_RE)
+  // The atom namespace declaration must be on the root <rss> element.
+  expect(xml).toMatch(/<rss[^>]*xmlns:atom="http:\/\/www\.w3\.org\/2005\/Atom"[^>]*>/)
+}
+
 async function parseItems(
   xml: string
 ): Promise<{ titles: string[]; links: string[]; guids: string[] }> {
@@ -99,6 +114,13 @@ describe('status.rss.xml GET', () => {
     expect(response.status).toBe(200)
     const xml = await response.text()
     expect(countOccurrences(xml, '<item>')).toBe(4) // 2 incidents x 2 updates each
+  })
+
+  it('SMI-5812: channel <link> points at /status (not the bare origin), and the feed advertises a complete atom:link self reference', async () => {
+    mockFetchJson(VALID_PAYLOAD)
+    const xml = await (await GET(makeContext())).text()
+    expect(xml).toContain('<link>https://www.skillsmith.app/status</link>')
+    expectAtomSelfLink(xml)
   })
 
   it('sorts items descending by pubDate ACROSS incidents, not grouped by incident', async () => {
@@ -283,6 +305,8 @@ describe('status.rss.xml GET', () => {
     const xml = await response.text()
     expect(xml).toContain('<rss')
     expect(countOccurrences(xml, '<item>')).toBe(0)
+    // SMI-5812: the empty-feed fallback still advertises a complete atom:link self reference.
+    expectAtomSelfLink(xml)
   })
 
   it('FIX (Codex #5): a non-OK upstream response returns a zero-item feed', async () => {
@@ -395,6 +419,9 @@ describe('status.rss.xml GET', () => {
     expect(countOccurrences(xml, '<item>')).toBe(0)
     expect(response.headers.get('content-type')).toContain('rss')
     expect(response.headers.get('x-content-type-options')).toBe('nosniff')
+    // SMI-5812: this is the hand-built STATIC_FALLBACK_RSS_XML string --
+    // it too must advertise a complete atom:link self reference.
+    expectAtomSelfLink(xml)
   })
 
   it('FIX (high): a primary rss() call throwing for a non-fetch/parse/shape reason still recovers via the fallback', async () => {

--- a/packages/website/vercel.json
+++ b/packages/website/vercel.json
@@ -8,7 +8,30 @@
       "main": false
     }
   },
+  "rewrites": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "status.skillsmith.app"
+        }
+      ],
+      "destination": "/status"
+    }
+  ],
   "redirects": [
+    {
+      "source": "/:path((?!_astro/).+)",
+      "has": [
+        {
+          "type": "host",
+          "value": "status.skillsmith.app"
+        }
+      ],
+      "destination": "https://www.skillsmith.app/:path",
+      "permanent": true
+    },
     {
       "source": "/changelog",
       "destination": "https://github.com/smith-horn/skillsmith/releases",

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,30 @@
   "framework": "astro",
   "installCommand": "npm install",
   "buildCommand": "npx turbo run build --filter=@skillsmith/website && rm -rf .vercel/output && mkdir -p .vercel && cp -r packages/website/.vercel/output .vercel/output",
+  "rewrites": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "status.skillsmith.app"
+        }
+      ],
+      "destination": "/status"
+    }
+  ],
   "redirects": [
+    {
+      "source": "/:path((?!_astro/).+)",
+      "has": [
+        {
+          "type": "host",
+          "value": "status.skillsmith.app"
+        }
+      ],
+      "destination": "https://www.skillsmith.app/:path",
+      "permanent": true
+    },
     {
       "source": "/changelog",
       "destination": "https://github.com/smith-horn/skillsmith/releases",


### PR DESCRIPTION
## Business Summary

**What shipped:** `status.skillsmith.app` now serves the public status page directly (URL bar
stays on the subdomain), instead of only being reachable at `www.skillsmith.app/status`. Every
other path on that subdomain (e.g. `/pricing`, `/login`) redirects to the equivalent `www` page
rather than silently serving the wrong content. Along the way, two pre-existing bugs in the
status page's RSS feed were fixed: the feed's channel link pointed at the site homepage instead
of the status page, and it was missing the standard `atom:link rel="self"` element entirely.

**Quality bar:** Design produced by an Opus pass that verified every routing/build assumption
against the actual production build output (not guessed), then adversarially reviewed twice by
an independent model (Sol/gpt-5.6-sol via NEEDLE) — once before implementation and once against
the finished diff — plus a governance/standards pass. Across all three rounds, 6 real issues were
found and fixed, zero deferred: an undefined route boundary that would have exposed every site
page on the new subdomain, a canonical-URL edge case, the two pre-existing RSS bugs above, a
redirect-ordering bug that would have shadowed the new rule for two existing routes, a weak test
assertion, and a repo-root config file that hadn't been kept in sync with the website one.
Typecheck, full website test suite (603/603), build, prettier, and eslint all pass;
`npm run audit:standards` is clean.

**Net result:** Code is fully shipped and reviewed. Two things remain outside this PR's control:
(1) the `status.skillsmith.app` domain + DNS record still need to be added in Vercel — a manual,
dashboard-only step — before the new hostname can actually resolve; (2) staging verification on
a live Vercel preview with that domain attached is the last gate before this can be considered
done end-to-end.

---

## Technical detail

- `packages/website/vercel.json` / repo-root `vercel.json` (kept byte-identical per the existing
  SMI-4641 structural-sync check): one `rewrites` rule (`/` → `/status`, host-scoped to
  `status.skillsmith.app`) and one `redirects` rule (every other path on that host → the `www`
  equivalent, excluding `/_astro/*` so CSP `script-src`/`style-src 'self'` isn't broken by a
  cross-origin redirect on the page's own JS/CSS). The redirect entry is first in the array so
  it isn't shadowed by the pre-existing unconditional `/changelog`/`/docs/authoring` rules.
- `packages/website/src/layouts/BaseLayout.astro`: new optional `canonical` prop so a page
  reachable under more than one hostname can pin its canonical/`og:url` to one indexable URL;
  falls back to the previous expression when unset (verified byte-identical for every other
  page).
- `packages/website/src/pages/status.astro`: passes the canonical override
  (`https://www.skillsmith.app/status/`) and makes the RSS discovery `<link>` absolute.
- `packages/website/src/pages/status.rss.xml.ts`: adds the channel `<link>` fix and
  `atom:link rel="self"` to both the normal feed and the static-string error fallback.
- `packages/website/tests/api/status.rss.xml.test.ts`: structural regex assertions (replacing
  three independent substring checks) across all three feed-generation code paths.
- `docs/internal` pointer bump: carries the governance code-review report
  (`docs/internal/code_review/2026-07-23-smi-5812-status-subdomain-review.md`).

**Staging gate (not yet run, blocked on the manual domain step):** once `status.skillsmith.app`
is attached to the `website` Vercel project, verify via the checks in the plan doc's Wave 6
staging-gate section — page loads correctly, non-root paths redirect, `_astro/*` assets stay
same-origin, canonical/RSS values are correct, and `www.skillsmith.app/` is unaffected.