### PR TITLE
fix(hooks): Fix xargs buffer overflow in Claude Code hooks + add failure logging

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -84,7 +84,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' ' | xargs -I {} sh -c 'CMD=\"{}\"; if [ -n \"$CMD\" ]; then node node_modules/ruflo/bin/ruflo.js hooks pre-command --command \"$CMD\" --validate-safety true --prepare-resources true 2>/dev/null || true; fi'"
+            "command": "CMD=$(cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' '); if [ -n \"$CMD\" ]; then node node_modules/ruflo/bin/ruflo.js hooks pre-command --command \"$CMD\" --validate-safety true --prepare-resources true 2>/dev/null || true; fi"
           }
         ]
       },
@@ -93,7 +93,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} node node_modules/ruflo/bin/ruflo.js hooks pre-edit --file '{}' --auto-assign-agents true --load-context true"
+            "command": "FILE=$(cat | jq -r '.tool_input.file_path // .tool_input.path // empty'); if [ -n \"$FILE\" ]; then node node_modules/ruflo/bin/ruflo.js hooks pre-edit --file \"$FILE\" --auto-assign-agents true --load-context true; fi"
           }
         ]
       },
@@ -113,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' ' | xargs -I {} sh -c 'CMD=\"{}\"; if [ -n \"$CMD\" ]; then node node_modules/ruflo/bin/ruflo.js hooks post-command --command \"$CMD\" --success true --track-metrics true --store-results true 2>/dev/null || true; fi'"
+            "command": "CMD=$(cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' '); if [ -n \"$CMD\" ]; then node node_modules/ruflo/bin/ruflo.js hooks post-command --command \"$CMD\" --success true --track-metrics true --store-results true 2>/dev/null || true; fi"
           }
         ]
       },
@@ -122,7 +122,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} sh -c 'FILE=\"{}\"; if [ -n \"$FILE\" ]; then node node_modules/ruflo/bin/ruflo.js hooks post-edit --file \"$FILE\" --success true --format true --update-memory true 2>/dev/null || true; fi'"
+            "command": "FILE=$(cat | jq -r '.tool_input.file_path // .tool_input.path // empty'); if [ -n \"$FILE\" ]; then node node_modules/ruflo/bin/ruflo.js hooks post-edit --file \"$FILE\" --success true --format true --update-memory true 2>/dev/null || true; fi"
           }
         ]
       },
@@ -131,7 +131,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r 'if (.tool_input.description // \"\" | test(\"review|code review\"; \"i\")) then \"GOVERNANCE_CHECK\" else empty end' | xargs -I {} sh -c 'echo \"🔒 Governance Gate: Running standards audit...\"; docker exec skillsmith-dev-1 npm run audit:standards || (echo \"❌ BLOCKED: Governance audit failed. Fix violations before continuing.\" && exit 1)'"
+            "command": "CHECK=$(cat | jq -r 'if (.tool_input.description // \"\" | test(\"review|code review\"; \"i\")) then \"GOVERNANCE_CHECK\" else empty end'); if [ -n \"$CHECK\" ]; then echo \"🔒 Governance Gate: Running standards audit...\"; docker exec skillsmith-dev-1 npm run audit:standards || (echo \"❌ BLOCKED: Governance audit failed. Fix violations before continuing.\" && exit 1); fi"
           }
         ]
       },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -84,7 +84,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CMD=$(cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' '); if [ -n \"$CMD\" ]; then node node_modules/ruflo/bin/ruflo.js hooks pre-command --command \"$CMD\" --validate-safety true --prepare-resources true 2>/dev/null || true; fi"
+            "command": "CMD=$(cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' '); if [ -n \"$CMD\" ]; then \"$CLAUDE_PROJECT_DIR/scripts/claude-hooks-log-wrapper.sh\" pre-command \"$CMD\" -- --command \"$CMD\" --validate-safety true --prepare-resources true; fi"
           }
         ]
       },
@@ -93,7 +93,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=$(cat | jq -r '.tool_input.file_path // .tool_input.path // empty'); if [ -n \"$FILE\" ]; then node node_modules/ruflo/bin/ruflo.js hooks pre-edit --file \"$FILE\" --auto-assign-agents true --load-context true; fi"
+            "command": "FILE=$(cat | jq -r '.tool_input.file_path // .tool_input.path // empty'); if [ -n \"$FILE\" ]; then \"$CLAUDE_PROJECT_DIR/scripts/claude-hooks-log-wrapper.sh\" pre-edit \"$FILE\" -- --file \"$FILE\" --auto-assign-agents true --load-context true; fi"
           }
         ]
       },
@@ -113,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CMD=$(cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' '); if [ -n \"$CMD\" ]; then node node_modules/ruflo/bin/ruflo.js hooks post-command --command \"$CMD\" --success true --track-metrics true --store-results true 2>/dev/null || true; fi"
+            "command": "CMD=$(cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' '); if [ -n \"$CMD\" ]; then \"$CLAUDE_PROJECT_DIR/scripts/claude-hooks-log-wrapper.sh\" post-command \"$CMD\" -- --command \"$CMD\" --success true --track-metrics true --store-results true; fi"
           }
         ]
       },
@@ -122,7 +122,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=$(cat | jq -r '.tool_input.file_path // .tool_input.path // empty'); if [ -n \"$FILE\" ]; then node node_modules/ruflo/bin/ruflo.js hooks post-edit --file \"$FILE\" --success true --format true --update-memory true 2>/dev/null || true; fi"
+            "command": "FILE=$(cat | jq -r '.tool_input.file_path // .tool_input.path // empty'); if [ -n \"$FILE\" ]; then \"$CLAUDE_PROJECT_DIR/scripts/claude-hooks-log-wrapper.sh\" post-edit \"$FILE\" -- --file \"$FILE\" --success true --format true --update-memory true; fi"
           }
         ]
       },

--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -42,6 +42,10 @@ on:
       - 'scripts/tests/session-start-mcp-command-guard.test.sh'
       - 'scripts/check-file-length.mjs'
       - 'lint-staged.config.js'
+      - '.claude/settings.json'
+      - 'scripts/claude-hooks-log-wrapper.sh'
+      - 'scripts/tests/claude-hooks-xargs-regression.test.sh'
+      - 'scripts/tests/claude-hooks-log-wrapper.test.sh'
       - '.github/workflows/validate-hooks.yml'
 
 permissions:
@@ -83,7 +87,10 @@ jobs:
             scripts/tests/worktree-port-collision.test.sh \
             scripts/tests/regen-worktree-overrides.test.sh \
             scripts/tests/worktree-docker-resolve.test.sh \
-            scripts/tests/session-start-mcp-command-guard.test.sh
+            scripts/tests/session-start-mcp-command-guard.test.sh \
+            scripts/claude-hooks-log-wrapper.sh \
+            scripts/tests/claude-hooks-xargs-regression.test.sh \
+            scripts/tests/claude-hooks-log-wrapper.test.sh
 
       - name: Syntax check (bash -n)
         run: |
@@ -111,6 +118,9 @@ jobs:
           bash -n scripts/tests/regen-worktree-overrides.test.sh
           bash -n scripts/tests/worktree-docker-resolve.test.sh
           bash -n scripts/tests/session-start-mcp-command-guard.test.sh
+          bash -n scripts/tests/claude-hooks-xargs-regression.test.sh
+          bash -n scripts/tests/claude-hooks-log-wrapper.test.sh
+          sh -n scripts/claude-hooks-log-wrapper.sh
           sh -n .husky/pre-commit
           sh -n .husky/post-merge
 
@@ -139,3 +149,5 @@ jobs:
           bash scripts/tests/regen-worktree-overrides.test.sh
           bash scripts/tests/worktree-docker-resolve.test.sh
           bash scripts/tests/session-start-mcp-command-guard.test.sh
+          bash scripts/tests/claude-hooks-xargs-regression.test.sh
+          bash scripts/tests/claude-hooks-log-wrapper.test.sh

--- a/scripts/claude-hooks-log-wrapper.sh
+++ b/scripts/claude-hooks-log-wrapper.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env sh
+# Wraps a `ruflo hooks <subcommand>` invocation called from .claude/settings.json's
+# PreToolUse/PostToolUse hooks with best-effort JSON-lines logging to
+# ~/.skillsmith/logs/claude-hooks-<date>.log, mirroring the existing
+# session-audit logging convention (scripts/lib/session-start-audit-helper.ts's
+# {timestamp, code, payload} shape) and session-stop-hook-safe.sh's
+# retention-day env-var precedent.
+#
+# Usage: claude-hooks-log-wrapper.sh <hook-name> <identifier> -- <ruflo-args...>
+#   hook-name   pre-command | post-command | pre-edit | post-edit  (log field only)
+#   identifier  the (already-truncated by caller) command/file string, logged
+#               (after best-effort secret redaction) for the log record
+#   -- <args>   forwarded verbatim to `node .../ruflo.js hooks <hook-name> <args>`
+#
+# Always exits 0 -- wrapping/logging must never turn a call that previously
+# succeeded (or was already suppressed) into a blocking hook error. This
+# uniformly normalizes all 4 call sites to non-blocking, INCLUDING
+# PreToolUse:Write|Edit|MultiEdit, which previously surfaced raw ruflo
+# failures (no `2>/dev/null || true`). That's a deliberate, recorded
+# plan-review decision (SMI-5813) -- the bounded stderr excerpt captured
+# below into the log record is the mitigation for the lost raw-surfacing
+# behavior: a failure is no longer visible live, but it is now durably
+# inspectable with its actual error text, which the pre-fix state never had.
+set -u
+umask 077
+
+HOOK_NAME="${1:-unknown}"
+IDENTIFIER="${2:-}"
+# `shift 2` is a fatal (uncatchable-by-`|| true`) error under dash when
+# $# < 2 -- guard the count explicitly instead.
+[ $# -ge 2 ] && shift 2 || shift $#
+[ "${1:-}" = "--" ] && shift
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+LOG_RETENTION_DAYS="${SKILLSMITH_HOOK_LOG_RETENTION_DAYS:-14}"
+# `set -u` aborts on an unset $HOME -- guard it explicitly rather than
+# relying on HOME always being set in every context this hook's shell runs in.
+LOG_DIR="${HOME:-/tmp}/.skillsmith/logs"
+mkdir -p "$LOG_DIR" 2>/dev/null
+LOG_FILE="$LOG_DIR/claude-hooks-$(date -u +%Y-%m-%d).log"
+
+# Sweep stale daily logs only when rolling to a NEW day's file, not on every
+# invocation -- this hook fires on every Bash/Edit tool call (unlike
+# session-stop-hook-safe.sh's once-per-session cadence), so an unconditional
+# `find -delete` per call would add needless I/O to the hot path this fix
+# exists to make less fragile.
+if [ ! -f "$LOG_FILE" ]; then
+  find "$LOG_DIR" -maxdepth 1 -name 'claude-hooks-*.log' -mtime "+${LOG_RETENTION_DAYS}" -delete 2>/dev/null
+fi
+
+# Best-effort secret redaction (defense-in-depth, not exhaustive -- Varlock
+# already keeps most real secrets out of raw command text; this is a safety
+# net for an ad-hoc token pasted into a curl/API call that would otherwise
+# land verbatim in a 14-day-retained local log file). Expanded during the
+# Sol/Codex cross-provider pass (SMI-5813) to cover modern provider-key
+# prefixes, auth headers, env-var-style assignments, and quoted flag values
+# (the original flag-value rule truncated at the first space, missing
+# `--password 'two words'`-shaped values).
+#
+# No standalone `Authorization:` header rule -- an earlier draft had one and
+# manual testing (during SMI-5813 plan-review) found it either double-
+# redacted "Authorization: Bearer <token>" into "Bearer [REDACTED]
+# [REDACTED]" or, worse, truncated the match at the first space and LEAKED
+# the token ("Authorization: [REDACTED] abc123..."). The Bearer/Basic rules
+# above already redact the two Authorization value schemes actually seen in
+# practice; a raw unscoped-Authorization opaque token (no Bearer/Basic
+# prefix) is the one shape this still misses -- accepted as a known,
+# documented gap in a best-effort tool, not silently unhandled.
+#
+# Deliberately NOT routed through the repo's existing gitleaks-based
+# pre-commit secret scanner (.husky/pre-commit) -- that would add an
+# external-binary runtime dependency with an unverified CLI contract for
+# scanning arbitrary strings (gitleaks' documented interface is
+# git-diff/repo-scan-shaped, not "scan this string") into a hook-invoked
+# script that must degrade gracefully when tools are missing. A reasonable
+# future hardening if the patterns below prove to under-catch in practice.
+redact() {
+  printf '%s' "$1" | sed -E \
+    -e 's/[Bb]earer [A-Za-z0-9._-]+/Bearer [REDACTED]/g' \
+    -e 's/(sk|pk|rk)_(live|test)_[A-Za-z0-9]+/[REDACTED]/g' \
+    -e 's/sk-(proj|ant|live|test)-[A-Za-z0-9_-]+/[REDACTED]/g' \
+    -e 's/gh[pousr]_[A-Za-z0-9]{20,}/[REDACTED]/g' \
+    -e 's/github_pat_[A-Za-z0-9_]+/[REDACTED]/g' \
+    -e 's/xox[abprs]-[A-Za-z0-9-]+/[REDACTED]/g' \
+    -e 's/npm_[A-Za-z0-9]+/[REDACTED]/g' \
+    -e 's/AKIA[0-9A-Z]{16}/[REDACTED]/g' \
+    -e 's/[Bb]asic [A-Za-z0-9+\/=]{8,}/Basic [REDACTED]/g' \
+    -e 's/([Xx]-[Aa]pi-[Kk]ey|[Xx]-[Aa]pi-[Tt]oken): *[^ "]+/\1: [REDACTED]/g' \
+    -e "s/(-{1,2}[A-Za-z_-]*([Tt]oken|[Kk]ey|[Ss]ecret|[Pp]assword)[A-Za-z_-]*[= ])'[^']*'/\1'[REDACTED]'/g" \
+    -e 's/(-{1,2}[A-Za-z_-]*([Tt]oken|[Kk]ey|[Ss]ecret|[Pp]assword)[A-Za-z_-]*[= ])"[^"]*"/\1"[REDACTED]"/g' \
+    -e 's/(-{1,2}[A-Za-z_-]*([Tt]oken|[Kk]ey|[Ss]ecret|[Pp]assword)[A-Za-z_-]*[= ])[^ ]+/\1[REDACTED]/g' \
+    -e 's/([A-Z][A-Z0-9_]*_(TOKEN|KEY|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*=)[^ ]+/\1[REDACTED]/g'
+}
+
+# `2>&1 >/dev/null` (in that order) duplicates stderr to the substitution's
+# capture pipe first, then discards stdout only -- the standard idiom for
+# capturing just stderr via `$(...)`.
+STDERR_OUT=$(node "$PROJECT_DIR/node_modules/ruflo/bin/ruflo.js" hooks "$HOOK_NAME" "$@" 2>&1 >/dev/null)
+EXIT_CODE=$?
+STDERR_EXCERPT=$(redact "$STDERR_OUT" | head -c 500)
+
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+IDENTIFIER_REDACTED=$(redact "$IDENTIFIER")
+# HOOK_NAME is JSON-escaped like the other string fields rather than
+# interpolated raw -- safe today only because all real call sites pass a
+# fixed literal (pre-command/post-command/pre-edit/post-edit), but the
+# wrapper's own public argument interface doesn't enforce that (found during
+# the Sol/Codex cross-provider pass, SMI-5813).
+ESCAPED_HOOK=$(printf '%s' "$HOOK_NAME" | jq -Rs . 2>/dev/null) || ESCAPED_HOOK='"unknown"'
+ESCAPED_ID=$(printf '%s' "$IDENTIFIER_REDACTED" | jq -Rs . 2>/dev/null) || ESCAPED_ID='""'
+ESCAPED_ERR=$(printf '%s' "$STDERR_EXCERPT" | jq -Rs . 2>/dev/null) || ESCAPED_ERR='""'
+
+printf '{"timestamp":"%s","hook":%s,"exitCode":%s,"identifier":%s,"stderr":%s}\n' \
+  "$TS" "$ESCAPED_HOOK" "$EXIT_CODE" "$ESCAPED_ID" "$ESCAPED_ERR" >> "$LOG_FILE" 2>/dev/null
+
+exit 0

--- a/scripts/tests/claude-hooks-log-wrapper.test.sh
+++ b/scripts/tests/claude-hooks-log-wrapper.test.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# SMI-5813: Unit tests for scripts/claude-hooks-log-wrapper.sh -- the
+# wrapper introduced to add JSON-lines failure logging to the 4 core
+# Claude Code PreToolUse/PostToolUse hooks (pre-command/post-command/
+# pre-edit/post-edit), on top of the xargs-removal fix covered by the
+# sibling claude-hooks-xargs-regression.test.sh.
+#
+# Runs the wrapper under BOTH bash (this harness) and real `dash`, since
+# the wrapper itself targets POSIX sh and this repo's Docker base image
+# (Debian bookworm) symlinks /bin/sh -> dash -- a bash-only pass would
+# miss a dash-specific bug (this test suite exists because exactly that
+# kind of bug -- `shift 2` being fatal under dash but not bash -- was
+# found and fixed during SMI-5813's own plan-review).
+#
+# Covers:
+#   A. Normal invocation: exit-code capture, JSON validity, all 5 fields
+#      present, secret redaction applied to both identifier and stderr.
+#   B. Always exits 0 regardless of the wrapped ruflo call's exit code.
+#   C. Dash-safety: 0 args and 1 arg do not crash the wrapper (the
+#      `shift 2` guard fix).
+#   D. `set -u` does not abort when $HOME is unset.
+#   E. Retention sweep deletes a log file older than the configured
+#      SKILLSMITH_HOOK_LOG_RETENTION_DAYS, and only on a new-day rollover.
+#   F. Redaction breadth: each secret shape added during plan-review
+#      (Bearer, provider-key prefixes, GitHub PAT, env-var assignment,
+#      quoted flag value) is actually stripped, and an ordinary command
+#      with no secrets passes through unmodified.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+WRAPPER="$REPO_ROOT/scripts/claude-hooks-log-wrapper.sh"
+
+fail=0
+pass=0
+
+assert_true() {
+  local name="$1" cond="$2"
+  if [ "$cond" = "0" ]; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name (expected '$expected', got '$actual')"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name (expected to find '$needle' in: $haystack)"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "FAIL $name (did NOT expect to find '$needle' in: $haystack)"
+    fail=$((fail + 1))
+  else
+    echo "PASS $name"
+    pass=$((pass + 1))
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Fixture: a stub ruflo.js that echoes an argv marker to stderr and exits
+# with a caller-controlled code, plus a fake HOME for log isolation.
+# -----------------------------------------------------------------------
+setup_fixture() {
+  local exit_code="$1"
+  local stderr_msg="$2"
+  FIXTURE_DIR=$(mktemp -d)
+  mkdir -p "$FIXTURE_DIR/node_modules/ruflo/bin" "$FIXTURE_DIR/home"
+  # `${var@Q}` (bash 4.4+) is not used here -- macOS ships bash 3.2 by
+  # default (GPLv2 license freeze), which does not support it and would
+  # fail at runtime with "bad substitution". Portable manual JS single-
+  # quoted-string escaping instead.
+  local escaped
+  escaped=$(printf '%s' "$stderr_msg" | sed "s/\\\\/\\\\\\\\/g; s/'/\\\\'/g")
+  cat > "$FIXTURE_DIR/node_modules/ruflo/bin/ruflo.js" << NODE_EOF
+#!/usr/bin/env node
+console.error('$escaped');
+console.log("stdout noise that must be discarded, not logged");
+process.exit($exit_code);
+NODE_EOF
+}
+
+teardown_fixture() {
+  rm -rf "$FIXTURE_DIR"
+}
+
+run_wrapper() {
+  local shell="$1"
+  shift
+  CLAUDE_PROJECT_DIR="$FIXTURE_DIR" HOME="$FIXTURE_DIR/home" "$shell" "$WRAPPER" "$@"
+}
+
+latest_log_line() {
+  tail -n 1 "$FIXTURE_DIR/home/.skillsmith/logs/claude-hooks-$(date -u +%Y-%m-%d).log"
+}
+
+for SHELL_BIN in bash dash; do
+  if ! command -v "$SHELL_BIN" >/dev/null 2>&1; then
+    echo "SKIP $SHELL_BIN not available on this host"
+    continue
+  fi
+
+  echo ""
+  echo "=== Group A/B: normal invocation under $SHELL_BIN ==="
+  setup_fixture 0 "diagnostic stderr text"
+  run_wrapper "$SHELL_BIN" pre-command "npm run test:unit -- --coverage" -- --command "npm run test:unit -- --coverage" --validate-safety true >/dev/null 2>&1
+  RC=$?
+  assert_eq "[$SHELL_BIN] wrapper always exits 0 (success case)" "0" "$RC"
+  LINE=$(latest_log_line)
+  assert_true "[$SHELL_BIN] log line is valid JSON" "$(printf '%s' "$LINE" | jq . >/dev/null 2>&1 && echo 0 || echo 1)"
+  assert_eq "[$SHELL_BIN] hook field correct" "pre-command" "$(printf '%s' "$LINE" | jq -r .hook)"
+  assert_eq "[$SHELL_BIN] identifier field correct" "npm run test:unit -- --coverage" "$(printf '%s' "$LINE" | jq -r .identifier)"
+  assert_eq "[$SHELL_BIN] exitCode field reflects the wrapped call" "0" "$(printf '%s' "$LINE" | jq -r .exitCode)"
+  assert_eq "[$SHELL_BIN] stderr field captured" "diagnostic stderr text" "$(printf '%s' "$LINE" | jq -r .stderr)"
+  assert_true "[$SHELL_BIN] timestamp field present and non-empty" "$(printf '%s' "$LINE" | jq -e '.timestamp | length > 0' >/dev/null 2>&1 && echo 0 || echo 1)"
+  teardown_fixture
+
+  echo ""
+  echo "=== Group B: always exits 0 even when the wrapped call fails ==="
+  setup_fixture 1 "some failure"
+  run_wrapper "$SHELL_BIN" post-edit "/some/file.ts" -- --file "/some/file.ts" --success true >/dev/null 2>&1
+  RC=$?
+  assert_eq "[$SHELL_BIN] wrapper always exits 0 (failure case)" "0" "$RC"
+  LINE=$(latest_log_line)
+  assert_eq "[$SHELL_BIN] exitCode field reflects the failure" "1" "$(printf '%s' "$LINE" | jq -r .exitCode)"
+  teardown_fixture
+
+  echo ""
+  echo "=== Group C: dash-safety, 0 and 1 args don't crash ==="
+  setup_fixture 0 "n/a"
+  run_wrapper "$SHELL_BIN" >/dev/null 2>&1
+  assert_eq "[$SHELL_BIN] 0 args exits 0" "0" "$?"
+  run_wrapper "$SHELL_BIN" pre-command >/dev/null 2>&1
+  assert_eq "[$SHELL_BIN] 1 arg exits 0" "0" "$?"
+  teardown_fixture
+
+  echo ""
+  echo "=== Group D: set -u does not abort on unset HOME ==="
+  setup_fixture 0 "n/a"
+  ( unset HOME; CLAUDE_PROJECT_DIR="$FIXTURE_DIR" "$SHELL_BIN" "$WRAPPER" pre-command "x" -- --command "x" >/dev/null 2>&1 )
+  assert_eq "[$SHELL_BIN] unset HOME does not crash the wrapper" "0" "$?"
+  teardown_fixture
+
+  echo ""
+  echo "=== Group F: redaction breadth ==="
+  setup_fixture 0 "leaked Bearer abcDEF123token in stderr too"
+  run_wrapper "$SHELL_BIN" pre-command \
+    'curl -H "Authorization: Bearer abcDEF123token" --password '"'"'two words'"'"' AWS_SECRET_ACCESS_KEY=shouldnotleak123' \
+    -- --command "ignored-for-this-test" >/dev/null 2>&1
+  LINE=$(latest_log_line)
+  ID_FIELD=$(printf '%s' "$LINE" | jq -r .identifier)
+  ERR_FIELD=$(printf '%s' "$LINE" | jq -r .stderr)
+  assert_not_contains "[$SHELL_BIN] Bearer token redacted from identifier" "$ID_FIELD" "abcDEF123token"
+  assert_not_contains "[$SHELL_BIN] quoted password value redacted from identifier" "$ID_FIELD" "two words"
+  assert_not_contains "[$SHELL_BIN] env-var-style secret redacted from identifier" "$ID_FIELD" "shouldnotleak123"
+  assert_not_contains "[$SHELL_BIN] Bearer token redacted from stderr" "$ERR_FIELD" "abcDEF123token"
+  assert_contains "[$SHELL_BIN] non-secret surrounding text preserved in identifier" "$ID_FIELD" "curl -H"
+  teardown_fixture
+
+  setup_fixture 0 "clean stderr, nothing sensitive"
+  run_wrapper "$SHELL_BIN" pre-command "git status --short" -- --command "git status --short" >/dev/null 2>&1
+  LINE=$(latest_log_line)
+  assert_eq "[$SHELL_BIN] ordinary command with no secrets passes through unmodified" \
+    "git status --short" "$(printf '%s' "$LINE" | jq -r .identifier)"
+  teardown_fixture
+
+  echo ""
+  echo "=== Group E: retention sweep ==="
+  setup_fixture 0 "n/a"
+  LOG_DIR="$FIXTURE_DIR/home/.skillsmith/logs"
+  mkdir -p "$LOG_DIR"
+  STALE_FILE="$LOG_DIR/claude-hooks-2020-01-01.log"
+  echo '{"stale":"entry"}' > "$STALE_FILE"
+  touch -d "30 days ago" "$STALE_FILE" 2>/dev/null || touch -t "$(date -v-30d +%Y%m%d%H%M 2>/dev/null || date -d '30 days ago' +%Y%m%d%H%M)" "$STALE_FILE" 2>/dev/null || true
+  SKILLSMITH_HOOK_LOG_RETENTION_DAYS=7 run_wrapper "$SHELL_BIN" pre-command "trigger a new day's file" -- --command "x" >/dev/null 2>&1
+  if [ -f "$STALE_FILE" ]; then
+    echo "FAIL [$SHELL_BIN] stale log file was not swept (this can be a false failure on a fresh mtime touch across platforms; verify manually if it recurs)"
+    fail=$((fail + 1))
+  else
+    echo "PASS [$SHELL_BIN] stale log file (30 days old, 7-day retention) was swept"
+    pass=$((pass + 1))
+  fi
+  teardown_fixture
+done
+
+echo ""
+echo "===== Results: $pass passed, $fail failed ====="
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/tests/claude-hooks-xargs-regression.test.sh
+++ b/scripts/tests/claude-hooks-xargs-regression.test.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# SMI-5813: Regression test for the `.claude/settings.json` hook `xargs -I`
+# buffer-overflow bug (BSD xargs' default 255-byte replsize, ~244-byte
+# effective ceiling, well below the 4096-byte truncation these hooks
+# intended to allow).
+#
+# Three layers, all required (per the SPARC plan's "Smoke vs CI" section —
+# GNU xargs on Linux CI does NOT reproduce the BSD-specific failure, so a
+# single-layer test would give false confidence on Linux CI runners):
+#
+#   1. Structural (OS-independent, PRIMARY regression guard): asserts none
+#      of the 5 hook command strings extracted live from .claude/settings.json
+#      contain `xargs -I` or `xargs -0`. Runs everywhere, fails closed.
+#   2. Shimmed xargs (OS-independent, DETERMINISTIC behavioral guard): a
+#      test-only `xargs` reimplementing BSD's -I replsize=255 limit is
+#      placed first on PATH. The OLD (pre-fix, from git history) command
+#      string is run through it and MUST fail; the NEW (live) command
+#      string no longer calls xargs at all, so it trivially isn't affected
+#      by the shim, and is asserted to succeed with the full untruncated
+#      value reaching the downstream flag.
+#   3. Real BSD xargs (macOS only, BEST-EFFORT/INFORMATIONAL): same OLD
+#      command string against the actual system `xargs` binary. Skipped
+#      (not failed) on Linux, since GNU xargs' `-I` has a much larger
+#      practical limit and won't reproduce the failure -- that's expected,
+#      not a test gap, and is logged as SKIP rather than silently omitted.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+SETTINGS_JSON="$REPO_ROOT/.claude/settings.json"
+
+fail=0
+pass=0
+skip=0
+
+assert_true() {
+  local name="$1" cond="$2"
+  if [ "$cond" = "0" ]; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name (expected to find '$needle')"
+    fail=$((fail + 1))
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Layer 1: Structural — live settings.json must not contain xargs -I/-0
+# -----------------------------------------------------------------------
+echo "--- Layer 1: structural (OS-independent primary guard) ---"
+XARGS_HITS=$(grep -c "xargs -I\|xargs -0" "$SETTINGS_JSON" || true)
+assert_true "settings.json has zero xargs -I/-0 instances (found: ${XARGS_HITS:-0})" \
+  "$([ "${XARGS_HITS:-0}" -eq 0 ] && echo 0 || echo 1)"
+
+# -----------------------------------------------------------------------
+# Layer 2: shimmed xargs — deterministic OS-independent behavioral guard
+# -----------------------------------------------------------------------
+echo ""
+echo "--- Layer 2: shimmed xargs (deterministic, OS-independent) ---"
+
+SHIM_DIR=$(mktemp -d)
+trap 'rm -rf "$SHIM_DIR"' EXIT
+
+cat > "$SHIM_DIR/xargs" << 'SHIM_EOF'
+#!/usr/bin/env bash
+# Test-only shim reimplementing BSD xargs' documented -I replsize=255
+# default (man xargs: "-S replsize ... The default for replsize is 255.").
+# Only supports the -I {} form this repo's hooks used; anything else falls
+# through to the real system xargs so this shim doesn't break other callers
+# on PATH during the test run.
+#
+# Bash (not POSIX sh) deliberately, for real arrays -- substituting {}
+# within each already-tokenized argv element and re-exec'ing that array
+# directly (not concatenating into one string and re-splitting it) is
+# required to preserve argv element boundaries when an element contains
+# shell-meaningful characters like nested quotes (the real `sh -c '...'`
+# hook payloads do). This is a TEST fixture only; the wrapper script under
+# test stays POSIX sh and is separately verified under dash.
+#
+# The length check is against each argv element's length AFTER
+# substitution, not the raw replacement text's length alone -- empirically
+# verified against real BSD xargs (see Layer 3 below): a replacement as
+# short as ~90 bytes still fails once embedded in the `sh -c 'CMD="{}"; ...'`
+# template, because the template itself is long enough that the combined
+# per-argv-element length crosses 255.
+REPLSIZE=255
+if [ "$1" = "-I" ]; then
+  shift
+  REPL="$1"
+  shift
+  INPUT=$(cat)
+  args=()
+  for a in "$@"; do
+    subst="${a//$REPL/$INPUT}"
+    if [ ${#subst} -ge "$REPLSIZE" ]; then
+      echo "xargs: command line cannot be assembled, too long" >&2
+      exit 1
+    fi
+    args+=("$subst")
+  done
+  exec "${args[@]}"
+fi
+exec /usr/bin/xargs "$@"
+SHIM_EOF
+chmod +x "$SHIM_DIR/xargs"
+
+# The OLD (pre-fix) PreToolUse:Bash command string, transcribed verbatim
+# from the live file's content before SMI-5813's fix (verified byte-for-byte
+# against `.claude/settings.json` during plan-review, and re-verified against
+# git history at authoring time). Deliberately NOT read via `git show HEAD~N`
+# -- squash-merging this PR collapses history to one commit, so any relative
+# HEAD~N offset that works today silently breaks the moment this lands on
+# main, and a shallow CI checkout may not even have the needed history at
+# all. A literal fixture is the only form of "the old command" that stays
+# correct regardless of how this repo's history is later rewritten.
+OLD_CMD='cat | jq -r '\''.tool_input.command // empty'\'' | head -c 4096 | tr '\''\n'\'' '\'' '\'' | xargs -I {} sh -c '\''CMD="{}"; if [ -n "$CMD" ]; then node node_modules/ruflo/bin/ruflo.js hooks pre-command --command "$CMD" --validate-safety true --prepare-resources true 2>/dev/null || true; fi'\'''
+
+TEST_INPUT=$(python3 -c "import json; print(json.dumps({'tool_input':{'command':'git commit -m \"a moderately long commit message that exceeds the buffer\" --allow-empty'}}))")
+
+OLD_OUT=$(printf '%s' "$TEST_INPUT" | PATH="$SHIM_DIR:$PATH" sh -c "$OLD_CMD" 2>&1)
+OLD_RC=$?
+assert_true "OLD command fails under shimmed BSD-behavior xargs (rc=$OLD_RC)" "$([ "$OLD_RC" -ne 0 ] && echo 0 || echo 1)"
+assert_contains "OLD failure message matches the real reported bug" "$OLD_OUT" "command line cannot be assembled, too long"
+
+# -----------------------------------------------------------------------
+# New (live, post-fix) command string: no xargs involved at all, so the
+# shim is irrelevant to it -- assert success + full untruncated value.
+# -----------------------------------------------------------------------
+NEW_CMD=$(jq -r '.hooks.PreToolUse[] | select(.matcher=="Bash") | .hooks[0].command' "$SETTINGS_JSON")
+assert_true "live command string no longer references xargs" \
+  "$(printf '%s' "$NEW_CMD" | grep -q "xargs" && echo 1 || echo 0)"
+
+STUB_DIR=$(mktemp -d)
+mkdir -p "$STUB_DIR/node_modules/ruflo/bin" "$STUB_DIR/scripts"
+# The live call site routes through the real wrapper script (Part B) -- copy
+# it into the stub project dir so this integration test exercises the real
+# xargs-removal -> wrapper -> ruflo pipeline end-to-end, not just a fragment.
+cp "$REPO_ROOT/scripts/claude-hooks-log-wrapper.sh" "$STUB_DIR/scripts/claude-hooks-log-wrapper.sh"
+chmod +x "$STUB_DIR/scripts/claude-hooks-log-wrapper.sh"
+cat > "$STUB_DIR/node_modules/ruflo/bin/ruflo.js" << 'NODE_EOF'
+#!/usr/bin/env node
+const fs = require('fs');
+fs.writeFileSync('/tmp/claude-hooks-regression-argv-capture.json', JSON.stringify(process.argv.slice(2)));
+process.exit(0);
+NODE_EOF
+rm -f /tmp/claude-hooks-regression-argv-capture.json
+mkdir -p "$STUB_DIR/fakehome"
+(cd "$STUB_DIR" && printf '%s' "$TEST_INPUT" | CLAUDE_PROJECT_DIR="$STUB_DIR" HOME="$STUB_DIR/fakehome" sh -c "$NEW_CMD" >/dev/null 2>&1)
+NEW_RC=$?
+assert_true "NEW command string succeeds (rc=$NEW_RC)" "$([ "$NEW_RC" -eq 0 ] && echo 0 || echo 1)"
+if [ -f /tmp/claude-hooks-regression-argv-capture.json ]; then
+  CAPTURED=$(cat /tmp/claude-hooks-regression-argv-capture.json)
+  assert_contains "full untruncated command value reached the downstream --command flag" \
+    "$CAPTURED" "a moderately long commit message that exceeds the buffer"
+  rm -f /tmp/claude-hooks-regression-argv-capture.json
+else
+  echo "FAIL argv capture file was not written (NEW command may not have invoked ruflo.js)"
+  fail=$((fail + 1))
+fi
+rm -rf "$STUB_DIR"
+
+# -----------------------------------------------------------------------
+# Layer 3: real BSD xargs — macOS only, best-effort/informational
+# -----------------------------------------------------------------------
+echo ""
+echo "--- Layer 3: real system xargs (best-effort, macOS-only) ---"
+if [ "$(uname -s)" = "Darwin" ]; then
+  REAL_OUT=$(printf '%s' "$TEST_INPUT" | sh -c "$OLD_CMD" 2>&1)
+  REAL_RC=$?
+  assert_true "real BSD xargs fails on the OLD command (rc=$REAL_RC)" "$([ "$REAL_RC" -ne 0 ] && echo 0 || echo 1)"
+  assert_contains "real BSD xargs failure message matches the actual reported bug" "$REAL_OUT" "command line cannot be assembled, too long"
+else
+  echo "SKIP real BSD xargs check -- not running on Darwin (GNU xargs on Linux does not reproduce this failure; expected, see SPARC plan doc's Smoke vs CI section)"
+  skip=$((skip + 1))
+fi
+
+echo ""
+echo "===== Results: $pass passed, $fail failed, $skip skipped ====="
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## Business Summary

**What shipped:** Claude Code's own hooks were silently failing on nearly every ordinary Bash tool call in this repo — a live, actively-reproducing bug (`xargs: command line cannot be assembled, too long`) hit mid-session. Root cause: 5 of the hooks in `.claude/settings.json` piped a single value through `xargs -I {}`, and macOS's built-in `xargs` has a buffer far smaller than these hooks assumed — small enough that an ordinary `git commit` or multi-flag `npm run` command routinely overflowed it. Replaced `xargs` with a simpler, equivalent shell construct that has no such limit. Also added durable logging for these hooks (previously zero — a failure was only ever visible as text that vanished when the session ended), so future problems are diagnosable after the fact instead of only in the moment.

**Quality bar:** Two independent design reviews before implementation — an internal panel (10 issues found, all fixed) and a cross-provider second opinion via a different AI vendor (7 more issues found, all fixed, including two bugs in my own first-draft fix for one of the internal panel's findings that were caught by hands-on testing before they ever reached the real script). Every fix was tested for real: the original bug was reproduced with a realistic ~90-byte command, then the fix was confirmed to resolve it, with the full command value verified reaching its destination intact. The two new test files run 46 real assertions under both of the two shell interpreters this fix has to work under, verified in a Linux environment matching the real CI runner exactly (not just this repo's own dev container, which turned out to be missing an unrelated dependency).

**Found along the way:** two follow-ups intentionally left for separate work rather than folded into this PR — surfacing hook failure counts in the startup banner (SMI-5814) and designing a self-healing/auto-retry mechanism for these hooks (SMI-5815, explicitly blocked on this PR's own log data existing first).

**Net result:** Fully shipped. The reported bug is fixed and independently reproduced/verified; the new logging is live and tested; both follow-ups are tracked, neither blocking.

---

## Technical detail

**Part A** (`d7fb1690`) — `.claude/settings.json`: replaced all 5 `xargs -I {}`/`xargs -0 -I {}` pipelines (4 originally reported + 1 more found during review, in the Governance Gate hook) with plain `$(...)` command substitution. None of these hooks ever handles more than one value per invocation, so `xargs` was never actually necessary — it was the wrong tool, and the one carrying the BSD-specific buffer limit (default 255 bytes per `man xargs`, effective ceiling ~244 bytes empirically). Root-caused by direct file read + local reproduction (`man xargs`, plus `for n in 240 245 249; do ...`), not guesswork.

**Part B** (`e2fe273c`) — new `scripts/claude-hooks-log-wrapper.sh` wraps the downstream `ruflo hooks <name>` call for 4 of the 5 hooks, captures exit code + a bounded (500-byte), secret-redacted stderr excerpt, and appends one JSON-line record per invocation to `~/.skillsmith/logs/claude-hooks-<date>.log` (14-day retention), matching this repo's existing session-audit logging conventions. Always exits 0, so a hook that used to fail silently now fails silently-but-logged — deliberate, not accidental (see the plan doc for the full reasoning on the one hook this changes non-blocking behavior for). Secret redaction covers Bearer tokens, provider-key prefixes, GitHub PATs, Slack/npm tokens, AWS access key IDs, Basic auth, API-key headers, and env-var-style secret assignments — best-effort, not exhaustive, documented as such.

**Tests**: `scripts/tests/claude-hooks-xargs-regression.test.sh` (3-layer regression guard: an OS-independent structural check that's the real CI gate, a shimmed-`xargs` behavioral check that deterministically reproduces the actual bug on Linux CI where the real bug can't otherwise reproduce, and a best-effort real-BSD-`xargs` check informational-only on Linux) and `scripts/tests/claude-hooks-log-wrapper.test.sh` (exit-code normalization, JSON validity, dash-safety, redaction breadth, retention sweep) — both wired into `validate-hooks.yml`'s paths/shellcheck/syntax-check/test-run steps.

**Plan doc**: `docs/internal/implementation/claude-hooks-xargs-fix-and-logging.md` (ADR-109 SPARC doc, includes the full internal-panel and cross-provider review summaries with every finding and fix).

**CI caveat**: `validate-hooks.yml` is not yet a required/blocking check (still in its own 4-week trial window per its own header comment), independent of this PR.
