### PR TITLE
fix(worktree): Fetch missing submodule objects

### DIFF
--- a/scripts/_rebase-submodule.sh
+++ b/scripts/_rebase-submodule.sh
@@ -41,6 +41,22 @@ step_rebase_submodule() {
         target_sub_sha=$(git -C "$WORKTREE_PATH" ls-tree "$TARGET_REF" -- "$sub_path" 2>/dev/null | awk '{print $3}')
         if [ -z "$target_sub_sha" ]; then info "  ($sub_path) target has no entry — skipping"; continue; fi
         if [ "$target_sub_sha" = "$expected_sha" ]; then info "  ($sub_path) already at target pointer"; continue; fi
+
+        # SMI-5823: distinguish "objects genuinely unavailable" (Step 5's
+        # fetch attempts — main checkout's copy, then origin — didn't obtain
+        # them) from "objects present but neither is an ancestor of the
+        # other" (a real divergence). Both used to hit the identical hard
+        # error below, which is what made a fixable missing-object gap look
+        # like an unresolvable submodule conflict.
+        if ! git -C "$wt_sub" cat-file -e "${expected_sha}^{commit}" 2>/dev/null || \
+           ! git -C "$wt_sub" cat-file -e "${target_sub_sha}^{commit}" 2>/dev/null; then
+            error "Worktree submodule ($sub_path): could not verify ancestry — one or both commit objects are unavailable locally.
+  Worktree: $expected_sha
+  Target:   $target_sub_sha
+Step 5's cross-fetch (main checkout's copy, then origin) could not obtain the missing object. Check network/auth access to this submodule's origin remote, then retry.
+This is NOT necessarily a real divergence — it means the objects couldn't be verified, not that they conflict."
+        fi
+
         # Directional guard: worktree's submodule must not be ahead of target
         if ! git -C "$wt_sub" merge-base --is-ancestor "$expected_sha" "$target_sub_sha" 2>/dev/null; then
             if git -C "$wt_sub" merge-base --is-ancestor "$target_sub_sha" "$expected_sha" 2>/dev/null; then

--- a/scripts/rebase-worktree.sh
+++ b/scripts/rebase-worktree.sh
@@ -167,6 +167,16 @@ step_check_uptodate() {
 
 # Step 5: Cross-fetch submodule objects (worktree submodule lacks main repo's
 # objects). SMI-4829: iterates over every initialized submodule.
+#
+# SMI-5823: resolves each submodule's target object explicitly and only
+# reaches out to the submodule's own `origin` when the cheap local-copy
+# fetch didn't supply it — avoids an unconditional network fetch (and
+# possible auth prompt, since 3 of the 4 declared submodules are on a
+# privately-hosted repo) against every submodule on every single rebase.
+# The origin fetch is reached independently of whether the main checkout's
+# own submodule copy exists — the prior version's early `continue` when it
+# was absent used to skip a fetch here entirely, which was the actual
+# false-divergence trigger when main's copy was stale AND missing.
 step_crossfetch_submodule() {
     if [ "$SKIP_SUBMODULE" = true ]; then
         info "Step 5: Skipping submodule cross-fetch (--no-submodule)"; return 0
@@ -180,7 +190,7 @@ step_crossfetch_submodule() {
     MAIN_REPO_ROOT=$(cd "$common_dir/.." && pwd)
 
     WT_SUB_PATHS=()
-    local i sub_path sha wt_sub main_sub fetched_any=false
+    local i sub_path sha wt_sub main_sub fetched_any=false target_sha
     for i in "${!SUBMODULES[@]}"; do
         sub_path="${SUBMODULES[$i]}"
         sha="${EXPECTED_SUBMODULE_SHAS[$i]:-}"
@@ -191,17 +201,51 @@ step_crossfetch_submodule() {
         if [ ! -d "$wt_sub/.git" ] && [ ! -f "$wt_sub/.git" ]; then
             info "  ($sub_path) submodule .git not found — skipping cross-fetch"; continue
         fi
-        if [ ! -d "$main_sub/.git" ] && [ ! -f "$main_sub/.git" ]; then
-            warn "Main repo submodule not found at $main_sub — skipping cross-fetch"; continue
+
+        # Resolve the target's recorded pointer now — Step 8 re-resolves the
+        # same value, but Step 5 needs it FIRST to know whether a fetch is
+        # even necessary before doing one.
+        target_sha=$(git -C "$WORKTREE_PATH" ls-tree "$TARGET_REF" -- "$sub_path" 2>/dev/null | awk '{print $3}')
+        if [ -z "$target_sha" ]; then
+            info "  ($sub_path) target has no entry — skipping cross-fetch"; continue
         fi
+
         if [ "$DRY_RUN" = true ]; then
-            info "  [dry-run] Would cross-fetch: git -C \"$wt_sub\" fetch \"$main_sub\""
+            info "  [dry-run] Would cross-fetch: ensure object ${target_sha:0:12} is present for ($sub_path) — try the main checkout's copy, then origin if still missing"
             fetched_any=true; continue
         fi
-        git -C "$wt_sub" fetch "$main_sub" 2>/dev/null || true
-        fetched_any=true
+
+        # Already have the target object? No network I/O needed at all —
+        # the common case once the sync-main.sh submodule-update fix lands.
+        if git -C "$wt_sub" cat-file -e "${target_sha}^{commit}" 2>/dev/null; then
+            continue
+        fi
+
+        # Cheap, local, no-auth: try the main repo's own submodule copy first.
+        if [ -d "$main_sub/.git" ] || [ -f "$main_sub/.git" ]; then
+            git -C "$wt_sub" fetch "$main_sub" 2>/dev/null || true
+            fetched_any=true
+        else
+            info "  ($sub_path) main repo submodule not found at $main_sub — trying origin"
+        fi
+
+        # Still missing? Fall through to the submodule's actual origin,
+        # bounded so a wedged network/auth prompt can't hang the rebase.
+        if ! git -C "$wt_sub" cat-file -e "${target_sha}^{commit}" 2>/dev/null; then
+            run_with_timeout 15 -- git -C "$wt_sub" fetch origin 2>/dev/null || true
+            fetched_any=true
+        fi
+
+        # Object still absent after both attempts — surface it now, not as
+        # an opaque "diverged" error three steps later in Step 8.
+        if ! git -C "$wt_sub" cat-file -e "${target_sha}^{commit}" 2>/dev/null; then
+            warn "  ($sub_path) could not obtain object ${target_sha:0:12} from the local main copy or origin — Step 8's ancestry check may report a false divergence. Check network/auth access to this submodule's origin remote."
+        fi
     done
-    [ "$fetched_any" = true ] && success "  Submodule objects cross-fetched"
+    if [ "$fetched_any" = true ]; then
+        success "  Submodule objects cross-fetched"
+    fi
+    return 0
 }
 
 # Step 6: Stash unstaged changes (captures specific ref for safe pop)

--- a/scripts/tests/rebase-worktree.multi-submodule.test.ts
+++ b/scripts/tests/rebase-worktree.multi-submodule.test.ts
@@ -322,4 +322,147 @@ describe('SMI-4829: rebase-worktree.sh multi-submodule', () => {
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('Submodules: none declared in .gitmodules')
   })
+
+  // SMI-5823: reproduces the actual false-divergence bug — main checkout's
+  // own submodule copy is stale (lacks the object the parent's tree now
+  // declares), but the submodule's real origin has it. Before the fix,
+  // Step 5 only ever fetched from the stale main-copy, so Step 8's ancestry
+  // check couldn't find a common ancestor and reported a hard "diverged"
+  // error even though this is a plain fast-forward.
+  it('succeeds when main checkout submodule copy is stale but origin has the target object', () => {
+    const tempRoot = makeTempDir('rw-multi-7')
+    tempDirs.push(tempRoot)
+    const { cloneDir, worktreeDir, subABare } = setupTwoSubmoduleWorktree(tempRoot)
+
+    // Advance submodule A on its real origin via an independent clone —
+    // simulating a different session having pushed this commit.
+    const subAClone = join(tempRoot, 'subA-advance')
+    git(tempRoot, `clone "${subABare}" "${subAClone}"`)
+    sh(`echo a-advance > "${join(subAClone, 'a-new.md')}"`)
+    git(subAClone, 'add a-new.md')
+    git(subAClone, 'commit -m "subA advance on origin"')
+    git(subAClone, 'push origin main')
+    const newASha = git(subAClone, 'rev-parse HEAD')
+
+    // Bump the parent's gitlink via --cacheinfo directly (gitlinks are
+    // never dereferenced by git, so this is valid without the object being
+    // present locally), WITHOUT running `submodule update` in cloneDir —
+    // its own submodule copy stays at the old SHA and never fetches the
+    // new commit. This reproduces the staleness precondition exactly.
+    git(cloneDir, 'checkout main')
+    git(cloneDir, `update-index --cacheinfo 160000,${newASha},docs/internal`)
+    git(cloneDir, 'commit -m "bump subA on main (cacheinfo only, no local checkout)"')
+    git(cloneDir, 'push origin main')
+    git(cloneDir, 'checkout -')
+
+    // Sanity: cloneDir's own submodule copy genuinely lacks the new object.
+    expect(() =>
+      git(join(cloneDir, 'docs', 'internal'), `cat-file -e ${newASha}^{commit}`)
+    ).toThrow()
+
+    const result = runScript(`"${worktreeDir}"`)
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Rebase complete')
+    const wtSubA = join(worktreeDir, 'docs', 'internal')
+    expect(git(wtSubA, 'rev-parse HEAD')).toBe(newASha)
+  })
+
+  // SMI-5823: reproduces the control-flow trap — main checkout has NO local
+  // submodule copy at all (deinit'd/never initialized). Before the fix, the
+  // "main repo submodule not found" branch `continue`d past any fetch
+  // attempt whatsoever, so origin was never tried either.
+  it('succeeds via origin when the main checkout has no local submodule copy at all', () => {
+    const tempRoot = makeTempDir('rw-multi-8')
+    tempDirs.push(tempRoot)
+    const { cloneDir, worktreeDir, subABare } = setupTwoSubmoduleWorktree(tempRoot)
+
+    const subAClone = join(tempRoot, 'subA-advance')
+    git(tempRoot, `clone "${subABare}" "${subAClone}"`)
+    sh(`echo a-advance > "${join(subAClone, 'a-new.md')}"`)
+    git(subAClone, 'add a-new.md')
+    git(subAClone, 'commit -m "subA advance on origin"')
+    git(subAClone, 'push origin main')
+    const newASha = git(subAClone, 'rev-parse HEAD')
+
+    git(cloneDir, 'checkout main')
+    git(cloneDir, `update-index --cacheinfo 160000,${newASha},docs/internal`)
+    git(cloneDir, 'commit -m "bump subA on main"')
+    git(cloneDir, 'push origin main')
+    git(cloneDir, 'submodule deinit -f docs/internal')
+    git(cloneDir, 'checkout -')
+
+    expect(existsSync(join(cloneDir, 'docs', 'internal', '.git'))).toBe(false)
+
+    const result = runScript(`"${worktreeDir}"`)
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Rebase complete')
+    const wtSubA = join(worktreeDir, 'docs', 'internal')
+    expect(git(wtSubA, 'rev-parse HEAD')).toBe(newASha)
+  })
+
+  // SMI-5823 regression guard: with BOTH submodule objects genuinely
+  // present and fetchable (real divergence, not a missing-object gap), the
+  // script must still report divergence — proves the new object-presence
+  // check doesn't swallow a real conflict into a misleading diagnostic.
+  it('still reports genuine divergence when both submodule objects are present', () => {
+    const tempRoot = makeTempDir('rw-multi-9')
+    tempDirs.push(tempRoot)
+    const { cloneDir, worktreeDir, subABare } = setupTwoSubmoduleWorktree(tempRoot)
+
+    const subAClone = join(tempRoot, 'subA-advance')
+    git(tempRoot, `clone "${subABare}" "${subAClone}"`)
+    sh(`echo a-on-origin > "${join(subAClone, 'a-origin.md')}"`)
+    git(subAClone, 'add a-origin.md')
+    git(subAClone, 'commit -m "subA advance on origin"')
+    git(subAClone, 'push origin main')
+    git(cloneDir, 'checkout main')
+    git(cloneDir, 'submodule update --remote docs/internal')
+    git(cloneDir, 'add docs/internal')
+    git(cloneDir, 'commit -m "bump subA on main"')
+    git(cloneDir, 'push origin main')
+    git(cloneDir, 'checkout -')
+
+    // Independently advance the WORKTREE's submodule with a real, fetchable
+    // commit that exists only there — neither side is an ancestor of the
+    // other.
+    const wtSubA = join(worktreeDir, 'docs', 'internal')
+    sh(`echo a-in-worktree > "${join(wtSubA, 'a-worktree.md')}"`)
+    git(wtSubA, 'add a-worktree.md')
+    git(wtSubA, 'commit -m "subA diverges in worktree"')
+
+    const result = runScript(`"${worktreeDir}"`)
+    expect(result.status).toBe(1)
+    const combined = result.stdout + result.stderr
+    expect(combined).toContain('diverged')
+    expect(combined).not.toContain('could not verify ancestry')
+  })
+
+  // SMI-5823: if neither the main checkout's local copy nor origin can
+  // supply the target object, Step 8 must report object unavailability
+  // instead of misclassifying the unverifiable history as divergence.
+  it('reports unavailable objects when origin cannot supply the target commit', () => {
+    const tempRoot = makeTempDir('rw-multi-10')
+    tempDirs.push(tempRoot)
+    const { cloneDir, worktreeDir } = setupTwoSubmoduleWorktree(tempRoot)
+    const missingSha = '1111111111111111111111111111111111111111'
+
+    // A gitlink can record an object the parent repository does not have.
+    // Point main at such an object, then make the worktree submodule's
+    // origin unavailable so both Step 5 fetch sources fail.
+    git(cloneDir, 'checkout main')
+    git(cloneDir, `update-index --cacheinfo 160000,${missingSha},docs/internal`)
+    git(cloneDir, 'commit -m "point subA at unavailable object"')
+    git(cloneDir, 'push origin main')
+    git(cloneDir, 'checkout -')
+
+    const wtSubA = join(worktreeDir, 'docs', 'internal')
+    git(wtSubA, `remote set-url origin "${join(tempRoot, 'missing-origin.git')}"`)
+
+    const result = runScript(`"${worktreeDir}"`)
+    expect(result.status).toBe(1)
+    const combined = result.stdout + result.stderr
+    expect(combined).toContain('could not verify ancestry')
+    expect(combined).toContain('commit objects are unavailable locally')
+    expect(combined).not.toContain('has diverged from target')
+  })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** Worktree rebases no longer report a false gitlink divergence when the target submodule commit is simply missing locally; they recover it from a cheap local copy or a timeout-bounded origin fetch.

**What shipped:** When commit objects genuinely remain unavailable, the rebase now says ancestry could not be verified instead of telling contributors to resolve a divergence that may not exist.

**Quality bar:** The design passed both a Codex cross-provider review and a 15-finding VP-panel plan review. Ten focused multi-submodule regressions pass on the final rebased commit, covering local/origin recovery, unavailable objects, genuine divergence, and scoped ahead permissions.

**Net result:** Phase 1 is complete and independently shippable. The reviewed sync-main, worktree-creation, and container-sprawl improvements remain intentionally sequenced as Phases 2–4.

## Ticket

[SMI-5823](https://linear.app/skillsmith/issue/SMI-5823)

## Changes

- [x] Check target submodule commit availability before ancestry validation.
- [x] Fetch missing objects from the main checkout’s local submodule first, then `origin` with a 15-second timeout.
- [x] Distinguish unavailable commit objects from genuine submodule divergence.
- [x] Preserve the skip-if-present fast path under `set -e`.
- [x] Add four Phase 1 regressions; the complete focused suite is now 10 tests.
- [x] Land the twice-reviewed implementation plan through skillsmith-docs PR #531.

## Checklist

### Code Quality
- [ ] TypeScript compiles without errors (`npm run typecheck`) — blocked by pre-existing `origin/main` errors in `apply-namespace-rename.test.ts` (`innerType`) and `CloudWatchExporter.ts` (`@smithy/types`), unrelated to this shell/test diff.
- [ ] Linting passes (`npm run lint`) — full preflight stops earlier at the dependency scanner.
- [x] Tests added/updated and passing (`npx vitest run scripts/tests/rebase-worktree.multi-submodule.test.ts`, 10/10).
- [x] No `console.log` statements in production code.

### Security
- [x] No hardcoded secrets or credentials.
- [x] No new user-provided input surface.
- [x] Fetches are timeout-bounded and only contact the existing submodule `origin`.

### Mock Data Review (SMI-763)
- [x] No mock data in production code paths.
- [x] Test data is isolated in self-created temporary Git repositories.
- [x] No mock/real-service environment flag is applicable.
- [x] Real submodule Git operations are exercised by the fixtures.

### Documentation
- [x] Shell behavior is documented inline.
- [x] Canonical implementation plan merged in skillsmith-docs PR #531.
- [x] No new ADR required; this is Phase 1 of the reviewed remediation plan.

## Testing

- [x] `bash -n scripts/rebase-worktree.sh scripts/_rebase-submodule.sh`
- [x] `git diff --check`
- [x] `npx vitest run scripts/tests/rebase-worktree.multi-submodule.test.ts` — 10/10 after rebasing onto current `origin/main`.
- [ ] `npm run preflight` — attempted in the dedicated worktree container; blocked before tests by three pre-existing `origin/main` scanner false positives: optional `@isaacs/keytar`, Node built-in `node:async_hooks`, and runtime-provided `@wdio/globals`.

### E2E Tests

- [x] Not applicable: no MCP or install behavior changes.

## Screenshots

Not applicable.
