### PR TITLE
fix(website): Add missing cheerio devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36759,6 +36759,7 @@
         "@tailwindcss/typography": "0.5.19",
         "@types/node": "^25.9.3",
         "@types/turndown": "^5.0.5",
+        "cheerio": "1.2.0",
         "eslint": "9.39.2",
         "eslint-plugin-astro": "1.5.0",
         "globals": "17.6.0",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -37,6 +37,7 @@
     "@playwright/test": "1.59.1",
     "@tailwindcss/typography": "0.5.19",
     "@types/node": "^25.9.3",
+    "cheerio": "1.2.0",
     "@types/turndown": "^5.0.5",
     "eslint": "9.39.2",
     "eslint-plugin-astro": "1.5.0",


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a pre-existing gap where `@skillsmith/website`'s production Vercel
deploy build could fail because `cheerio` (used directly by two test files) was only resolved
transitively at the monorepo root, not declared as a direct dependency of the website package.

**Quality bar:** Minimal, one-line fix (plus its lockfile entry). Verified live against a real
production deploy.

**Net result:** Fully shipped. Discovered and fixed while deploying an unrelated feature PR —
the build failed on this gap before reaching any of that PR's own code, confirming it as
pre-existing and unrelated to that change.

`[skip-impl-check]` — this PR is a dependency-declaration fix, not implementation work tied to
any specific SMI issue; no source code behavior changes.

---

## Technical detail

`packages/website/package.json`: added `"cheerio": "1.2.0"` to `devDependencies` (matching the
version already resolved elsewhere in the lockfile). Vercel's isolated build for the `website`
project only installs from that package's own manifest, unlike CI's `Website Build`/`Test
(website)` jobs which run inside the full monorepo Docker container with root devDependencies
present — so this gap was invisible to CI but fatal to `vercel --prod`.