### PR TITLE
fix(worktree): Keep synced submodules aligned

### DIFF
--- a/scripts/sync-main.sh
+++ b/scripts/sync-main.sh
@@ -6,7 +6,10 @@
 set -euo pipefail
 
 # Capture all output, filter noise, report result
-output=$(git checkout main 2>&1 && git fetch origin main 2>&1) || {
+# Submodules are synchronized independently below. Disable recursive fetching
+# here so one inaccessible submodule cannot abort the parent fetch before the
+# per-path fail-soft reporting has a chance to run.
+output=$(git checkout main 2>&1 && git fetch --no-recurse-submodules origin main 2>&1) || {
   # On failure, show unfiltered output for debugging
   echo "$output"
   exit 1
@@ -41,6 +44,53 @@ output=$(git reset --hard origin/main 2>&1) || {
   echo "$output"
   exit 1
 }
+
+# SMI-5823 Phase 2: keep every declared submodule checkout aligned with the
+# gitlink recorded by the freshly-reset parent. Update paths independently so
+# one inaccessible private remote does not hide successful updates elsewhere.
+# Dirty initialized submodules are never passed to `submodule update`: even
+# without --force, skipping explicitly makes the preservation contract clear.
+submodule_mismatches=()
+if [ -f .gitmodules ]; then
+  repo_root=$(git rev-parse --show-toplevel)
+  gitmodules="$repo_root/.gitmodules"
+  while IFS= read -r submodule_path; do
+    [ -n "$submodule_path" ] || continue
+
+    expected_sha=$(git ls-tree HEAD -- "$submodule_path" 2>/dev/null | awk '{print $3}')
+    [ -n "$expected_sha" ] || continue
+
+    mismatch_reason=""
+    if git -C "$submodule_path" rev-parse --is-inside-work-tree >/dev/null 2>&1 &&
+      [ -n "$(git -C "$submodule_path" status --porcelain 2>/dev/null)" ]; then
+      mismatch_reason="dirty worktree preserved"
+    else
+      git submodule update --init -- "$submodule_path" >/dev/null 2>&1 || {
+        mismatch_reason="update failed"
+      }
+    fi
+
+    actual_sha=$(git -C "$submodule_path" rev-parse HEAD 2>/dev/null || true)
+    if [ "$actual_sha" != "$expected_sha" ]; then
+      [ -n "$mismatch_reason" ] || mismatch_reason="checkout remains mismatched"
+      submodule_mismatches+=(
+        "$submodule_path|$mismatch_reason|${actual_sha:-unavailable}|$expected_sha"
+      )
+    fi
+  done < <(
+    (cd / && git config --file "$gitmodules" --get-regexp 'submodule\..*\.path' 2>/dev/null) |
+      awk '{print $2}' || true
+  )
+fi
+
+if [ "${#submodule_mismatches[@]}" -gt 0 ]; then
+  echo "WARNING: Submodule sync incomplete:"
+  for mismatch in "${submodule_mismatches[@]}"; do
+    IFS='|' read -r path reason actual expected <<<"$mismatch"
+    echo "  - $path: $reason (found ${actual:0:12}, expected ${expected:0:12})"
+  done
+  echo "Parent main is synced; resolve the named submodule path(s) and retry."
+fi
 
 # SMI-5548: cheap dist-staleness hint — NO build here, just a heads-up. If
 # source moved while syncing, dist/ (built before the sync) likely no longer

--- a/scripts/tests/sync-main.test.ts
+++ b/scripts/tests/sync-main.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { existsSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { makeFixtureEnv, makeFixtureTempDir } from './_lib/git-fixture-env.js'
+
+const SCRIPT_PATH = join(__dirname, '..', 'sync-main.sh')
+const GIT_ENV = makeFixtureEnv({ GIT_ALLOW_PROTOCOL: 'file' })
+const tempDirs: string[] = []
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync(
+    'git',
+    ['-c', 'init.defaultBranch=main', '-c', 'protocol.file.allow=always', ...args],
+    {
+      cwd,
+      encoding: 'utf8',
+      env: GIT_ENV,
+    }
+  ).trim()
+}
+
+function runSync(cwd: string): { status: number; output: string } {
+  const result = spawnSync('bash', [SCRIPT_PATH], {
+    cwd,
+    encoding: 'utf8',
+    env: GIT_ENV,
+    timeout: 30_000,
+  })
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+  }
+}
+
+interface Fixture {
+  root: string
+  parentSource: string
+  syncClone: string
+  subABare: string
+  subBBare: string
+}
+
+function seedSubmodule(root: string, bare: string, name: string): void {
+  const seed = join(root, `${name}-seed`)
+  git(root, 'init', '--bare', bare)
+  git(root, 'clone', bare, seed)
+  writeFileSync(join(seed, `${name}.md`), `${name} initial\n`)
+  git(seed, 'add', `${name}.md`)
+  git(seed, 'commit', '-m', `${name} initial`)
+  git(seed, 'push', 'origin', 'main')
+}
+
+function makeFixture(): Fixture {
+  const root = makeFixtureTempDir('sync-main')
+  tempDirs.push(root)
+
+  const parentBare = join(root, 'parent-bare.git')
+  const parentSource = join(root, 'parent-source')
+  const syncClone = join(root, 'sync-clone')
+  const subABare = join(root, 'subA-bare.git')
+  const subBBare = join(root, 'subB-bare.git')
+
+  git(root, 'init', '--bare', parentBare)
+  seedSubmodule(root, subABare, 'subA')
+  seedSubmodule(root, subBBare, 'subB')
+
+  git(root, 'clone', parentBare, parentSource)
+  writeFileSync(join(parentSource, 'README.md'), 'parent\n')
+  git(parentSource, 'add', 'README.md')
+  git(parentSource, 'commit', '-m', 'parent initial')
+  git(parentSource, 'submodule', 'add', subABare, 'docs/internal')
+  git(parentSource, 'submodule', 'add', subBBare, '.claude/skills')
+  git(parentSource, 'commit', '-m', 'add submodules')
+  git(parentSource, 'push', 'origin', 'main')
+
+  git(root, 'clone', parentBare, syncClone)
+  // The production remotes are HTTPS. Fixtures use local bare repositories,
+  // so allow file transport for submodule fetches spawned by sync-main.sh.
+  git(syncClone, 'config', '--local', 'protocol.file.allow', 'always')
+  git(syncClone, 'submodule', 'update', '--init')
+
+  return { root, parentSource, syncClone, subABare, subBBare }
+}
+
+function advanceSubmodule(fixture: Fixture, path: 'docs/internal' | '.claude/skills'): string {
+  const isA = path === 'docs/internal'
+  const bare = isA ? fixture.subABare : fixture.subBBare
+  const name = isA ? 'subA' : 'subB'
+  const advance = join(fixture.root, `${name}-advance-${Date.now()}`)
+
+  git(fixture.root, 'clone', bare, advance)
+  writeFileSync(join(advance, `${name}-advance.md`), `${name} advance\n`)
+  git(advance, 'add', `${name}-advance.md`)
+  git(advance, 'commit', '-m', `${name} advance`)
+  git(advance, 'push', 'origin', 'main')
+  const sha = git(advance, 'rev-parse', 'HEAD')
+
+  git(fixture.parentSource, 'submodule', 'update', '--remote', '--', path)
+  git(fixture.parentSource, 'add', path)
+  git(fixture.parentSource, 'commit', '-m', `bump ${name}`)
+  git(fixture.parentSource, 'push', 'origin', 'main')
+  return sha
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true })
+  }
+  tempDirs.length = 0
+})
+
+describe('SMI-5823 Phase 2: sync-main submodule alignment', () => {
+  it('updates every submodule to the gitlinks recorded by origin/main', () => {
+    const fixture = makeFixture()
+    const expectedA = advanceSubmodule(fixture, 'docs/internal')
+    const expectedB = advanceSubmodule(fixture, '.claude/skills')
+
+    const result = runSync(fixture.syncClone)
+
+    expect(result.status, result.output).toBe(0)
+    expect(git(join(fixture.syncClone, 'docs/internal'), 'rev-parse', 'HEAD'), result.output).toBe(
+      expectedA
+    )
+    expect(git(join(fixture.syncClone, '.claude/skills'), 'rev-parse', 'HEAD')).toBe(expectedB)
+    expect(result.output).not.toContain('Submodule sync incomplete')
+  })
+
+  it('continues updating other paths and names an inaccessible submodule', () => {
+    const fixture = makeFixture()
+    const expectedA = advanceSubmodule(fixture, 'docs/internal')
+    const expectedB = advanceSubmodule(fixture, '.claude/skills')
+    const subB = join(fixture.syncClone, '.claude/skills')
+    const oldB = git(subB, 'rev-parse', 'HEAD')
+    git(subB, 'remote', 'set-url', 'origin', join(fixture.root, 'missing.git'))
+
+    const result = runSync(fixture.syncClone)
+
+    expect(result.status, result.output).toBe(0)
+    expect(git(join(fixture.syncClone, 'docs/internal'), 'rev-parse', 'HEAD'), result.output).toBe(
+      expectedA
+    )
+    expect(git(subB, 'rev-parse', 'HEAD')).toBe(oldB)
+    expect(result.output).toContain(
+      `.claude/skills: update failed (found ${oldB.slice(0, 12)}, expected ${expectedB.slice(0, 12)})`
+    )
+    expect(result.output).not.toContain('docs/internal:')
+  })
+
+  it('preserves a dirty submodule and reports its exact mismatch', () => {
+    const fixture = makeFixture()
+    const subA = join(fixture.syncClone, 'docs/internal')
+    const oldA = git(subA, 'rev-parse', 'HEAD')
+    const expectedA = advanceSubmodule(fixture, 'docs/internal')
+    writeFileSync(join(subA, 'subA.md'), 'dirty local work\n')
+
+    const result = runSync(fixture.syncClone)
+
+    expect(result.status, result.output).toBe(0)
+    expect(git(subA, 'rev-parse', 'HEAD')).toBe(oldA)
+    expect(git(subA, 'status', '--porcelain')).toContain('M subA.md')
+    expect(result.output).toContain(
+      `docs/internal: dirty worktree preserved (found ${oldA.slice(0, 12)}, expected ${expectedA.slice(0, 12)})`
+    )
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** Syncing `main` now brings every accessible submodule to the exact version recorded by the parent repository instead of leaving stale checkouts behind.

**What shipped:** One inaccessible private submodule no longer blocks successful updates elsewhere, and dirty submodule work is preserved with a precise warning rather than overwritten.

**Quality bar:** Three real-Git fixtures cover complete success, partial remote failure with continued progress, and dirty-work preservation with exact mismatch reporting. Lint, formatting, TypeScript, Bash syntax, and shellcheck all pass.

**Net result:** SMI-5823 Phase 2 is independently complete. The reviewed worktree-creation and container-sprawl improvements remain intentionally sequenced as Phases 3–4.

---

## Ticket

[SMI-5823](https://linear.app/skillsmith/issue/SMI-5823)

## Technical detail

- Disable recursive submodule fetching during the parent `origin/main` fetch so a private-remote failure cannot abort before per-path handling.
- After resetting the parent, enumerate declared submodules and update each path independently with `git submodule update --init` and no `--force`.
- Skip dirty initialized submodules, preserve their working state, and report actual versus expected commit IDs.
- Continue after an inaccessible submodule and summarize only paths that remain mismatched.
- Add `scripts/tests/sync-main.test.ts` using disposable parent and submodule repositories.

## Verification

- [x] `npx vitest run scripts/tests/sync-main.test.ts` — 3/3 passed
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `bash -n scripts/sync-main.sh`
- [x] `shellcheck scripts/sync-main.sh`
- [ ] `npm run preflight` — reaches the dependency scanner, then stops on the three confirmed `origin/main` false positives: optional `@isaacs/keytar`, Node built-in `async_hooks`, and runtime-provided `@wdio/globals`.

## Scope

Phase 3 (`create-worktree.sh`) and Phase 4 (container-sprawl visibility) are intentionally excluded from this PR per the reviewed sequencing plan.
