### PR TITLE
feat(worktree): Report container sprawl at startup

### DIFF
--- a/scripts/prune-orphaned-docker-volumes.sh
+++ b/scripts/prune-orphaned-docker-volumes.sh
@@ -56,7 +56,7 @@
 #      reviews the reported UNCONFIRMED list first, and the deleted artifact
 #      is always a rebuildable dependency cache, never data.
 #
-# Usage: ./scripts/prune-orphaned-docker-volumes.sh [--dry-run] [--include-unlabeled]
+# Usage: ./scripts/prune-orphaned-docker-volumes.sh [--dry-run] [--include-unlabeled] [--report-containers]
 #   --dry-run             Report what would be deleted; delete nothing.
 #   --include-unlabeled   Also delete UNCONFIRMED-ownership candidates (the
 #                          one-time pre-label backlog escape hatch).
@@ -73,6 +73,7 @@ source "$SCRIPT_DIR/_lib.sh"
 
 DRY_RUN=false
 INCLUDE_UNLABELED=false
+REPORT_CONTAINERS=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -84,8 +85,13 @@ while [[ $# -gt 0 ]]; do
             INCLUDE_UNLABELED=true
             shift
             ;;
+        --report-containers)
+            REPORT_CONTAINERS=true
+            shift
+            ;;
         -h|--help)
-            echo "Usage: $(basename "$0") [--dry-run] [--include-unlabeled]"
+            echo "Usage: $(basename "$0") [--dry-run] [--include-unlabeled] [--report-containers]"
+            echo "  --report-containers  Report live-old, excessive, and orphaned Skillsmith dev containers; mutate nothing."
             exit 0
             ;;
         *)
@@ -115,6 +121,61 @@ if [[ -n "$main_gitdir" ]]; then
     main_repo="$(dirname "$main_gitdir")"
 else
     main_repo="$repo_root"
+fi
+
+report_containers() {
+    local max_age="${SKILLSMITH_CONTAINER_SPRAWL_MAX_AGE_HOURS:-24}"
+    local max_count="${SKILLSMITH_CONTAINER_SPRAWL_MAX_COUNT:-3}"
+    [[ "$max_age" =~ ^[0-9]+$ ]] || max_age=24
+    [[ "$max_count" =~ ^[0-9]+$ ]] || max_count=3
+
+    local worktrees now count=0 shown=0
+    worktrees="$(git -C "$main_repo" worktree list --porcelain 2>/dev/null |
+        awk '/^worktree / { sub(/^worktree /, ""); print }' || true)"
+    now="$(date +%s)"
+    local -a findings=()
+    local id name created path created_epoch age_hours class normalized
+
+    while IFS= read -r id; do
+        [[ -n "$id" ]] || continue
+        name="$(docker inspect "$id" --format '{{.Name}}' 2>/dev/null | sed 's#^/##' || true)"
+        created="$(docker inspect "$id" --format '{{.Created}}' 2>/dev/null || true)"
+        path="$(docker inspect "$id" --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' 2>/dev/null || true)"
+        [[ -n "$name" && -n "$created" && -n "$path" && "$path" = /* ]] || continue
+        count=$((count + 1))
+        normalized="$(cd "$path" 2>/dev/null && pwd -P || printf '%s' "$path")"
+        if date -j -f '%Y-%m-%dT%H:%M:%S' "${created%%.*}" +%s >/dev/null 2>&1; then
+            created_epoch="$(date -j -f '%Y-%m-%dT%H:%M:%S' "${created%%.*}" +%s)"
+        else
+            created_epoch="$(date -d "$created" +%s 2>/dev/null || printf '%s' "$now")"
+        fi
+        age_hours=$(((now - created_epoch) / 3600))
+        class=""
+        if ! grep -qxF "$normalized" <<< "$worktrees"; then
+            class="orphaned"
+        elif (( age_hours >= max_age )); then
+            class="live-old"
+        fi
+        [[ -n "$class" ]] && findings+=("$name"$'\t'"$class"$'\t'"${age_hours}h"$'\t'"$normalized")
+    done < <(docker ps -q \
+        --filter 'label=app.skillsmith.owned=true' \
+        --filter 'label=com.docker.compose.service=dev' 2>/dev/null || true)
+
+    if (( count > max_count )); then
+        findings+=("all-live"$'\t'"excessive"$'\t'"${count}/${max_count}"$'\t'"$main_repo")
+    fi
+    (( ${#findings[@]} == 0 )) && return 0
+    echo "Skillsmith container inventory: ${#findings[@]} finding(s); inspect resource use with: docker stats"
+    for finding in "${findings[@]}"; do
+        (( shown >= 5 )) && break
+        printf '  %s\n' "$finding"
+        shown=$((shown + 1))
+    done
+}
+
+if [[ "$REPORT_CONTAINERS" == true ]]; then
+    report_containers
+    exit 0
 fi
 
 # sanitize_project_name() (_lib.sh) is the single canonical sanitization

--- a/scripts/session-start-audit.sh
+++ b/scripts/session-start-audit.sh
@@ -37,11 +37,6 @@ emit_empty_and_exit() {
   exit 0
 }
 
-# Gate 0: opt-out via env var.
-if [ "${SKILLSMITH_SESSION_AUDIT_DISABLE:-0}" = "1" ]; then
-  emit_empty_and_exit
-fi
-
 # Parse stdin for source + cwd. Anything missing → fall through to silent.
 SOURCE=$(printf '%s' "$INPUT" | python3 -c "
 import json, sys
@@ -75,6 +70,44 @@ if [ -z "$REPO_ROOT" ]; then
   emit_empty_and_exit
 fi
 
+# SMI-5823: all-tier, report-only local container inventory. This has its
+# own 2-second cap because the helper's later 5-second cap cannot bound Docker.
+run_container_sprawl_audit() {
+  [ "${SKILLSMITH_CONTAINER_SPRAWL_AUDIT_DISABLE:-0}" = "1" ] && return 0
+  local reporter="$REPO_ROOT/scripts/prune-orphaned-docker-volumes.sh"
+  [ -x "$reporter" ] || return 0
+  local out state_dir state_file digest previous now
+  if [ -n "$TIMEOUT_BIN" ]; then
+    out=$("$TIMEOUT_BIN" --kill-after=1s 2s "$reporter" --report-containers 2>/dev/null || true)
+  else
+    local tmp pid wd
+    tmp=$(mktemp -t skillsmith-sprawl.XXXXXX) || return 0
+    ("$reporter" --report-containers >"$tmp" 2>/dev/null) & pid=$!
+    (sleep 2; kill "$pid" 2>/dev/null || true) & wd=$!
+    wait "$pid" 2>/dev/null || true
+    kill "$wd" 2>/dev/null || true
+    wait "$wd" 2>/dev/null || true
+    out=$(head -c 8192 "$tmp" 2>/dev/null || true)
+    rm -f "$tmp"
+  fi
+  [ -n "$out" ] || return 0
+  out=$(printf '%s' "$out" | head -c 8192)
+  state_dir="${HOME}/.skillsmith"
+  state_file="$state_dir/container-sprawl-audit.state"
+  digest=$(printf '%s' "$out" | cksum | awk '{print $1}')
+  now=$(date +%s)
+  previous=$(cat "$state_file" 2>/dev/null || true)
+  if printf '%s' "$previous" | grep -qE '^[0-9]+ [0-9]+$'; then
+    if [ "${previous%% *}" = "$digest" ] && [ $((now - ${previous#* })) -lt 86400 ]; then
+      return 0
+    fi
+  fi
+  printf '%s\n' "$out" >&2
+  mkdir -p "$state_dir" 2>/dev/null || return 0
+  printf '%s %s\n' "$digest" "$now" >"$state_file.tmp" 2>/dev/null &&
+    mv "$state_file.tmp" "$state_file" 2>/dev/null || true
+}
+
 # Resolve the helper path. If missing (e.g., running on an older checkout),
 # fail soft.
 HELPER="$REPO_ROOT/scripts/lib/session-start-audit-helper.ts"
@@ -93,6 +126,13 @@ elif command -v timeout >/dev/null 2>&1 && timeout 1 true >/dev/null 2>&1; then
   # (`timeout --kill-after=0 0 true`) used GNU-specific flag syntax and
   # falsely failed on BusyBox, forcing the job-control fallback. (SMI-4753)
   TIMEOUT_BIN="timeout"
+fi
+
+run_container_sprawl_audit
+
+# Existing namespace audit opt-out does not disable the machine-health probe.
+if [ "${SKILLSMITH_SESSION_AUDIT_DISABLE:-0}" = "1" ]; then
+  emit_empty_and_exit
 fi
 
 # Stage B: invoke the helper via tsx with a 5-second wall-clock cap. The

--- a/scripts/tests/prune-orphaned-docker-volumes.helpers.ts
+++ b/scripts/tests/prune-orphaned-docker-volumes.helpers.ts
@@ -142,6 +142,10 @@ function writeResponsiveDockerShim(binDir: string, logPath: string, responsesDir
     '    exit_override "rmi__$2"',
     '    ;;',
     '  ps)',
+    '    if [ "$2" = "-q" ]; then',
+    '      emit "container_ids"',
+    '      exit 0',
+    '    fi',
     '    key=""',
     '    for arg in "$@"; do',
     '      case "$arg" in',
@@ -150,6 +154,16 @@ function writeResponsiveDockerShim(binDir: string, logPath: string, responsesDir
     '      esac',
     '    done',
     '    emit "$key"',
+    '    exit 0',
+    '    ;;',
+    '  inspect)',
+    '    id="$2"',
+    '    fmt="$4"',
+    '    case "$fmt" in',
+    '      *".Name"*) emit "container__${id}__name" ;;',
+    '      *".Created"*) emit "container__${id}__created" ;;',
+    '      *working_dir*) emit "container__${id}__path" ;;',
+    '    esac',
     '    exit 0',
     '    ;;',
     '  *)',
@@ -252,6 +266,22 @@ export function setVolumeRmExit(fixture: FixtureRepo, vol: string, code: number)
 
 export function resetLog(fixture: FixtureRepo): void {
   if (existsSync(fixture.logPath)) rmSync(fixture.logPath)
+}
+
+export function containerResponses(
+  fixture: FixtureRepo,
+  containers: Array<{ id: string; name: string; created: string; path: string }>
+): void {
+  setResponse(
+    fixture.responsesDir,
+    'container_ids',
+    containers.map((container) => container.id).join('\n')
+  )
+  for (const container of containers) {
+    setResponse(fixture.responsesDir, `container__${container.id}__name`, `/${container.name}`)
+    setResponse(fixture.responsesDir, `container__${container.id}__created`, container.created)
+    setResponse(fixture.responsesDir, `container__${container.id}__path`, container.path)
+  }
 }
 
 /**

--- a/scripts/tests/prune-orphaned-docker-volumes.test.ts
+++ b/scripts/tests/prune-orphaned-docker-volumes.test.ts
@@ -52,6 +52,7 @@ import {
   setVolumeRmExit,
   resetLog,
   runPrune,
+  containerResponses,
 } from './prune-orphaned-docker-volumes.helpers.js'
 
 const tempDirs: string[] = []
@@ -66,6 +67,39 @@ afterEach(() => {
 })
 
 describe('SMI-5750: prune-orphaned-docker-volumes.sh', () => {
+  it('reports live-old, orphaned, and excessive containers without mutation', () => {
+    const fixture = setupFixture('container-report')
+    tempDirs.push(fixture.tempRoot)
+    const livePath = join(fixture.repoDir, '.worktrees', 'live-wt')
+    addWorktree(fixture.repoDir, livePath, 'feat-report-live')
+    containerResponses(fixture, [
+      {
+        id: 'live1',
+        name: 'live-wt-dev-1',
+        created: '2000-01-01T00:00:00Z',
+        path: livePath,
+      },
+      {
+        id: 'gone1',
+        name: 'gone-wt-dev-1',
+        created: '2000-01-01T00:00:00Z',
+        path: join(fixture.tempRoot, 'gone-wt'),
+      },
+      { id: 'bad1', name: '', created: '', path: 'not-absolute' },
+    ])
+
+    const result = runPrune(fixture, ['--report-containers'], {
+      SKILLSMITH_CONTAINER_SPRAWL_MAX_AGE_HOURS: '1',
+      SKILLSMITH_CONTAINER_SPRAWL_MAX_COUNT: '1',
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('live-wt-dev-1\tlive-old')
+    expect(result.stdout).toContain('gone-wt-dev-1\torphaned')
+    expect(result.stdout).toContain('all-live\texcessive\t2/1')
+    expect(result.dockerCalls.some((call) => /\b(rm|rmi|stop|kill)\b/.test(call))).toBe(false)
+  })
+
   it('1. deletes a labeled orphan volume (no matching worktree, app.skillsmith.owned=true)', () => {
     const fixture = setupFixture('prune-orphan')
     tempDirs.push(fixture.tempRoot)

--- a/scripts/tests/session-start-audit.test.sh
+++ b/scripts/tests/session-start-audit.test.sh
@@ -292,6 +292,49 @@ EOF
 }
 
 # ----------------------------------------------------------------------
+# Test 7: all-tier sprawl report, disable, debounce, and independent 2s cap.
+# ----------------------------------------------------------------------
+{
+  REPO=$(mk_test_repo)
+  cp "$HOOK" "$REPO/scripts/session-start-audit.sh"
+  chmod +x "$REPO/scripts/session-start-audit.sh"
+  mk_stub_helper "$REPO/scripts/lib/session-start-audit-helper.ts" 'namespace-audit'
+  cat > "$REPO/scripts/prune-orphaned-docker-volumes.sh" <<'EOF'
+#!/bin/sh
+echo 'Skillsmith container inventory: 1 finding(s)'
+echo '  sample-dev-1	live-old	25h	/tmp/sample'
+EOF
+  chmod +x "$REPO/scripts/prune-orphaned-docker-volumes.sh"
+  TMPHOME=$(mktemp -d -t skillsmith-sprawl-home.XXXXXX)
+  EVENT=$(printf '{"source":"startup","cwd":"%s"}' "$REPO")
+
+  FIRST=$(printf '%s' "$EVENT" | env HOME="$TMPHOME" "$REPO/scripts/session-start-audit.sh" 2>&1)
+  SECOND=$(printf '%s' "$EVENT" | env HOME="$TMPHOME" "$REPO/scripts/session-start-audit.sh" 2>&1)
+  DISABLED=$(printf '%s' "$EVENT" | env HOME="$TMPHOME/disabled" \
+    SKILLSMITH_CONTAINER_SPRAWL_AUDIT_DISABLE=1 "$REPO/scripts/session-start-audit.sh" 2>&1)
+  assert_contains "sprawl-all-tier-first-render" 'sample-dev-1' "$FIRST"
+  assert_not_contains "sprawl-debounce-second-silent" 'sample-dev-1' "$SECOND"
+  assert_not_contains "sprawl-disable-silent" 'sample-dev-1' "$DISABLED"
+
+  cat > "$REPO/scripts/prune-orphaned-docker-volumes.sh" <<'EOF'
+#!/bin/sh
+sleep 30
+echo 'too-late'
+EOF
+  start_s=$(date +%s)
+  printf '%s' "$EVENT" | env HOME="$TMPHOME/slow" "$REPO/scripts/session-start-audit.sh" >/dev/null 2>&1
+  elapsed=$(( $(date +%s) - start_s ))
+  if [ "$elapsed" -le 4 ]; then
+    echo "PASS sprawl-independent-timeout-${elapsed}s"
+    pass=$((pass + 1))
+  else
+    echo "FAIL sprawl-independent-timeout: took ${elapsed}s"
+    fail=$((fail + 1))
+  fi
+  rm -rf "$REPO" "$TMPHOME"
+}
+
+# ----------------------------------------------------------------------
 echo
 echo "SUMMARY: $pass passed, $fail failed"
 if [ "$fail" -gt 0 ]; then


### PR DESCRIPTION
## Business Summary

**What shipped:** Skillsmith now reports stale, excessive, and orphaned development containers at session startup without stopping or removing anything.

**What shipped:** The advisory is available to every product tier, has its own two-second timeout, debounces unchanged findings for 24 hours, and exposes documented disable and threshold controls.

**Quality bar:** Twenty report/prune fixtures and eighteen startup-hook checks cover classification, malformed data, no mutation, tier independence, disable, debounce, timeout, and output bounds. Lint, formatting, TypeScript, Bash syntax, shellcheck, standards audit, and the full guarded pre-push suite pass.

**What shipped:** The global session-cleanup skill is released as v1.6.0 and now separates advisory live-container findings from safe orphan-cleanup candidates.

**Net result:** All four reviewed SMI-5823 remediation phases are complete; only merge verification, the disposable-container smoke, and final cleanup remain.

---

## Technical detail

- Extends the existing orphan-volume cleanup script with a report-only `--report-containers` mode.
- Classifies Skillsmith-owned Compose dev containers against registered Git worktrees as orphaned, live-old, or excessive.
- Adds an all-tier startup probe with an independent two-second timeout, bounded output, 24-hour content debounce, and fail-soft parsing.
- Documents the dedicated disable and threshold controls in the guard registry.
- Updates the plan pointer to docs PR #534 (`bff7742`).
- Coordinates with the separately released global session-cleanup skill v1.6.0 (`7bc6b74`).

### Verification

- `npx vitest run scripts/tests/prune-orphaned-docker-volumes.test.ts` — 20/20 passed
- `bash scripts/tests/session-start-audit.test.sh` — 18/18 passed
- `npm run lint` — passed
- `npm run format:check` — passed
- `npm run typecheck` — passed
- `npm run audit:standards` — passed with existing warnings
- Bash syntax and shellcheck — passed
- Full guarded pre-push security and test suites — passed
- Real report-only Docker smoke — correctly distinguished live-old/excessive containers and performed no mutation
- `npm run preflight` reaches the existing dependency-scanner baseline and stops on `@isaacs/keytar`, Node's `async_hooks`, and runtime-provided `@wdio/globals`; unchanged from `origin/main` and prior phases

Refs SMI-5823.
