### PR TITLE
fix(hooks): Bound Ruflo tool interceptors

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -84,6 +84,7 @@
         "hooks": [
           {
             "type": "command",
+            "timeout": 5,
             "command": "CMD=$(cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' '); if [ -n \"$CMD\" ]; then \"$CLAUDE_PROJECT_DIR/scripts/claude-hooks-log-wrapper.sh\" pre-command \"$CMD\" -- --command \"$CMD\" --validate-safety true --prepare-resources true; fi"
           }
         ]
@@ -93,6 +94,7 @@
         "hooks": [
           {
             "type": "command",
+            "timeout": 5,
             "command": "FILE=$(cat | jq -r '.tool_input.file_path // .tool_input.path // empty'); if [ -n \"$FILE\" ]; then \"$CLAUDE_PROJECT_DIR/scripts/claude-hooks-log-wrapper.sh\" pre-edit \"$FILE\" -- --file \"$FILE\" --auto-assign-agents true --load-context true; fi"
           }
         ]
@@ -113,6 +115,7 @@
         "hooks": [
           {
             "type": "command",
+            "timeout": 5,
             "command": "CMD=$(cat | jq -r '.tool_input.command // empty' | head -c 4096 | tr '\\n' ' '); if [ -n \"$CMD\" ]; then \"$CLAUDE_PROJECT_DIR/scripts/claude-hooks-log-wrapper.sh\" post-command \"$CMD\" -- --command \"$CMD\" --success true --track-metrics true --store-results true; fi"
           }
         ]
@@ -122,6 +125,7 @@
         "hooks": [
           {
             "type": "command",
+            "timeout": 5,
             "command": "FILE=$(cat | jq -r '.tool_input.file_path // .tool_input.path // empty'); if [ -n \"$FILE\" ]; then \"$CLAUDE_PROJECT_DIR/scripts/claude-hooks-log-wrapper.sh\" post-edit \"$FILE\" -- --file \"$FILE\" --success true --format true --update-memory true; fi"
           }
         ]

--- a/scripts/claude-hooks-log-wrapper.sh
+++ b/scripts/claude-hooks-log-wrapper.sh
@@ -33,6 +33,10 @@ IDENTIFIER="${2:-}"
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 LOG_RETENTION_DAYS="${SKILLSMITH_HOOK_LOG_RETENTION_DAYS:-14}"
+HOOK_TIMEOUT_SECONDS="${SKILLSMITH_HOOK_TIMEOUT_SECONDS:-3}"
+case "$HOOK_TIMEOUT_SECONDS" in
+  ''|*[!0-9]*|0) HOOK_TIMEOUT_SECONDS=3 ;;
+esac
 # `set -u` aborts on an unset $HOME -- guard it explicitly rather than
 # relying on HOME always being set in every context this hook's shell runs in.
 LOG_DIR="${HOME:-/tmp}/.skillsmith/logs"
@@ -92,11 +96,39 @@ redact() {
     -e 's/([A-Z][A-Z0-9_]*_(TOKEN|KEY|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*=)[^ ]+/\1[REDACTED]/g'
 }
 
-# `2>&1 >/dev/null` (in that order) duplicates stderr to the substitution's
-# capture pipe first, then discards stdout only -- the standard idiom for
-# capturing just stderr via `$(...)`.
-STDERR_OUT=$(node "$PROJECT_DIR/node_modules/ruflo/bin/ruflo.js" hooks "$HOOK_NAME" "$@" 2>&1 >/dev/null)
-EXIT_CODE=$?
+# Ruflo is advisory on this hot path. Run it behind an internal watchdog so
+# a wedged state/database/network operation cannot consume Claude Code's much
+# larger command-hook timeout before an ordinary Bash/Edit tool is dispatched.
+STDERR_FILE=$(mktemp -t skillsmith-hook-stderr.XXXXXX 2>/dev/null) || STDERR_FILE=""
+TIMEOUT_FILE=$(mktemp -t skillsmith-hook-timeout.XXXXXX 2>/dev/null) || TIMEOUT_FILE=""
+if [ -n "$STDERR_FILE" ] && [ -n "$TIMEOUT_FILE" ]; then
+  node "$PROJECT_DIR/node_modules/ruflo/bin/ruflo.js" hooks "$HOOK_NAME" "$@" \
+    > /dev/null 2>"$STDERR_FILE" &
+  RUFLO_PID=$!
+  (
+    sleep "$HOOK_TIMEOUT_SECONDS"
+    printf '1' >"$TIMEOUT_FILE"
+    kill "$RUFLO_PID" 2>/dev/null || true
+  ) &
+  WATCHDOG_PID=$!
+  wait "$RUFLO_PID" 2>/dev/null
+  EXIT_CODE=$?
+  kill "$WATCHDOG_PID" 2>/dev/null || true
+  wait "$WATCHDOG_PID" 2>/dev/null || true
+  STDERR_OUT=$(cat "$STDERR_FILE" 2>/dev/null)
+  if [ -s "$TIMEOUT_FILE" ]; then
+    STDERR_OUT="${STDERR_OUT}${STDERR_OUT:+
+}ruflo hook timed out after ${HOOK_TIMEOUT_SECONDS}s"
+  fi
+  rm -f "$STDERR_FILE" "$TIMEOUT_FILE"
+else
+  # If temporary-file creation fails, fail open without invoking an unbounded
+  # downstream process. Logging below still records the local failure.
+  EXIT_CODE=1
+  STDERR_OUT="ruflo hook skipped: unable to create watchdog files"
+  [ -n "$STDERR_FILE" ] && rm -f "$STDERR_FILE"
+  [ -n "$TIMEOUT_FILE" ] && rm -f "$TIMEOUT_FILE"
+fi
 STDERR_EXCERPT=$(redact "$STDERR_OUT" | head -c 500)
 
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/scripts/tests/claude-hooks-log-wrapper.test.sh
+++ b/scripts/tests/claude-hooks-log-wrapper.test.sh
@@ -25,6 +25,8 @@
 #      (Bearer, provider-key prefixes, GitHub PAT, env-var assignment,
 #      quoted flag value) is actually stripped, and an ordinary command
 #      with no secrets passes through unmodified.
+#   G. A hanging ruflo subprocess is terminated by the internal watchdog,
+#      logged as a timeout, and still fails open.
 set -uo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
@@ -183,6 +185,27 @@ for SHELL_BIN in bash dash; do
   LINE=$(latest_log_line)
   assert_eq "[$SHELL_BIN] ordinary command with no secrets passes through unmodified" \
     "git status --short" "$(printf '%s' "$LINE" | jq -r .identifier)"
+  teardown_fixture
+
+  echo ""
+  echo "=== Group G: hanging ruflo is bounded and fails open ==="
+  setup_fixture 0 "unused"
+  cat > "$FIXTURE_DIR/node_modules/ruflo/bin/ruflo.js" << 'NODE_EOF'
+#!/usr/bin/env node
+setInterval(() => {}, 1000);
+NODE_EOF
+  START_SECONDS=$(date +%s)
+  SKILLSMITH_HOOK_TIMEOUT_SECONDS=1 run_wrapper "$SHELL_BIN" pre-command "pwd" -- --command "pwd" >/dev/null 2>&1
+  RC=$?
+  ELAPSED_SECONDS=$(($(date +%s) - START_SECONDS))
+  assert_eq "[$SHELL_BIN] timed-out wrapper still exits 0" "0" "$RC"
+  assert_true "[$SHELL_BIN] hanging ruflo returns within 3s (elapsed=${ELAPSED_SECONDS}s)" \
+    "$([ "$ELAPSED_SECONDS" -le 3 ] && echo 0 || echo 1)"
+  LINE=$(latest_log_line)
+  assert_contains "[$SHELL_BIN] timeout is recorded in the durable log" \
+    "$(printf '%s' "$LINE" | jq -r .stderr)" "ruflo hook timed out after 1s"
+  assert_true "[$SHELL_BIN] timeout records a non-zero downstream exit" \
+    "$([ "$(printf '%s' "$LINE" | jq -r .exitCode)" -ne 0 ] && echo 0 || echo 1)"
   teardown_fixture
 
   echo ""

--- a/scripts/tests/claude-hooks-xargs-regression.test.sh
+++ b/scripts/tests/claude-hooks-xargs-regression.test.sh
@@ -62,6 +62,15 @@ echo "--- Layer 1: structural (OS-independent primary guard) ---"
 XARGS_HITS=$(grep -c "xargs -I\|xargs -0" "$SETTINGS_JSON" || true)
 assert_true "settings.json has zero xargs -I/-0 instances (found: ${XARGS_HITS:-0})" \
   "$([ "${XARGS_HITS:-0}" -eq 0 ] && echo 0 || echo 1)"
+BOUNDED_WRAPPER_HOOKS=$(jq '
+  [.hooks.PreToolUse[], .hooks.PostToolUse[]]
+  | map(.hooks[]
+    | select(.command | contains("claude-hooks-log-wrapper.sh"))
+    | select(.timeout > 0 and .timeout <= 5))
+  | length
+' "$SETTINGS_JSON")
+assert_true "all 4 wrapper hooks have an explicit timeout of at most 5s (found: $BOUNDED_WRAPPER_HOOKS)" \
+  "$([ "$BOUNDED_WRAPPER_HOOKS" -eq 4 ] && echo 0 || echo 1)"
 
 # -----------------------------------------------------------------------
 # Layer 2: shimmed xargs — deterministic OS-independent behavioral guard


### PR DESCRIPTION
## Business Summary

**What shipped:** Claude sessions no longer wait up to ten minutes when the advisory Ruflo hook wedges before or after a Bash or file-edit tool.

**What shipped:** Hook failures still fail open and remain recorded for diagnosis, while ordinary tool execution resumes within a few seconds.

**Quality bar:** A deliberately hanging Ruflo fixture passes under both Bash and Dash, alongside all 46 wrapper assertions, seven settings/integration assertions, shellcheck, formatting, TypeScript, security checks, and the complete guarded pre-push suite.

**Net result:** The project hooks can remain enabled without making routine commands such as `pwd` indefinitely slow.

---

## Technical detail

- Gives each Ruflo-backed PreToolUse/PostToolUse handler an explicit five-second Claude Code timeout.
- Adds a portable three-second internal watchdog to `claude-hooks-log-wrapper.sh`.
- Terminates a stuck Ruflo process, records a bounded timeout diagnostic, and exits zero so advisory telemetry cannot block work.
- Fails open without launching Ruflo if watchdog temporary files cannot be created.
- Adds structural coverage requiring all four wrapper hooks to retain an explicit timeout of at most five seconds.
- Adds a hanging Node fixture under both Bash and Dash; each returns in one second during verification.

### Verification

- Wrapper regression suite — 46/46 passed under Bash and Dash
- Settings/xargs integration suite — 7/7 passed, one expected macOS-only check skipped in Linux
- JSON validation, Bash/Dash syntax, and shellcheck — passed
- `npm run format:check` — passed
- Pre-commit full TypeScript check and staged lint/format — passed
- Complete guarded pre-push security and test suites — passed
- `npm run preflight` reaches the existing dependency-scanner baseline and stops on `@isaacs/keytar`, Node's `async_hooks`, and runtime-provided `@wdio/globals`; unchanged from `origin/main`

Refs SMI-5813.
