### PR TITLE
fix(worktree): Prevent SIGPIPE crash and wrong-stash capture in rebase-worktree.sh

### DIFF
--- a/scripts/_rebase-git-crypt.sh
+++ b/scripts/_rebase-git-crypt.sh
@@ -4,9 +4,13 @@
 # Split out of rebase-worktree.sh per CLAUDE.md's 500-line file-length
 # convention (SMI-5773). Sourced only, never run standalone — relies on
 # rebase-worktree.sh's globals (WORKTREE_PATH, ORIG_SMUDGE, ORIG_CLEAN,
-# FILTERS_DISABLED, RESMUDGE_SCAN_FAILED, SCAN_RESULT_BAD, SCAN_RESULT_MISSING)
-# and _lib.sh's info/warn/success/error, all already in scope via bash's
-# shared-process sourcing model regardless of which file defines them.
+# FILTERS_DISABLED, RESMUDGE_SCAN_FAILED, SCAN_RESULT_BAD, SCAN_RESULT_MISSING,
+# STASH_REF, DRY_RUN) and _lib.sh's info/warn/success/error, all already in
+# scope via bash's shared-process sourcing model regardless of which file
+# defines them. step_stash() (Step 6) also lives here (moved from
+# rebase-worktree.sh when it again crossed the 500-line cap) — thematically
+# it belongs with the rest of this file's stash/index-timestamp-stability
+# logic, which it calls directly.
 #
 # SMI-5773: `git checkout HEAD -- <paths>` skips stat-clean files (Git's
 # checkout_entry_ca()/ie_match_stat() short-circuit) — files a rebase
@@ -312,4 +316,44 @@ check_resmudge_scan_result() {
     echo "    git -C $WORKTREE_PATH ls-files -z -- $enc_paths | while IFS= read -r -d '' f; do rm -f -- \"$WORKTREE_PATH/\$f\"; done"
     echo "    git -C $WORKTREE_PATH checkout HEAD -- $enc_paths"
     exit 4   # new exit code: rebase (and stash pop) succeeded, but working tree needs re-smudge
+}
+
+# Step 6: Stash unstaged changes (captures specific ref for safe pop)
+step_stash() {
+    info "Step 6: Stashing unstaged changes..."
+    if git -C "$WORKTREE_PATH" diff --quiet; then info "  No unstaged changes to stash"; return 0; fi
+    if [ "$DRY_RUN" = true ]; then info "  [dry-run] Would stash unstaged changes"; return 0; fi
+    # `git diff --quiet` above can report "dirty" purely from a dirty
+    # submodule (e.g. untracked content sitting inside docs/internal's own
+    # working tree), which `git stash push` cannot capture -- it then prints
+    # "No local changes to save" and creates no new stash entry. Capturing
+    # refs/stash before/after (instead of blindly reading `stash list | head
+    # -1`) detects that case: previously, a no-op push here would (a) grab
+    # whatever UNRELATED stash another session/branch had left at stash@{0},
+    # which Step 11 would then `stash pop` onto this worktree, and (b)
+    # SIGPIPE-crash under `pipefail` once the shared stash list (refs/stash
+    # is repo-wide, not per-worktree) grew past a couple of entries -- `head
+    # -1` closes its read end while `git stash list` is still writing.
+    local before_stash after_stash
+    before_stash=$(git -C "$WORKTREE_PATH" rev-parse -q --verify refs/stash 2>/dev/null || echo "")
+    git -C "$WORKTREE_PATH" stash push -m "rebase-worktree: auto-stash before rebase"
+    after_stash=$(git -C "$WORKTREE_PATH" rev-parse -q --verify refs/stash 2>/dev/null || echo "")
+    if [ "$before_stash" = "$after_stash" ]; then
+        info "  Nothing actually stashed (dirty state was submodule-only, not a real diff)"
+        STASH_REF=""
+        return 0
+    fi
+    STASH_REF="stash@{0}"
+    # SMI-5781: `git stash push` above re-checks-out every previously-unstaged
+    # path back to HEAD's content, leaving a racy mtime on each -- if left
+    # unresolved, Step 9's rebase pre-flight can spuriously reject an
+    # encrypted path as dirty once Step 7 swaps in the identity clean filter.
+    # Must run here: after the stash exists, before Step 7's filter swap.
+    # force_racy_stash_restore_for_test is a test-only, inert-by-default
+    # determinism seam (SKILLSMITH_REBASE_FORCE_RACY_TEST=1) -- see its
+    # doc comment above.
+    force_racy_stash_restore_for_test
+    info "  Stabilizing encrypted-file index timestamps..."
+    stabilize_encrypted_index_stats
+    success "  Stashed as $STASH_REF"
 }

--- a/scripts/rebase-worktree.sh
+++ b/scripts/rebase-worktree.sh
@@ -15,15 +15,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=_lib.sh
 source "$SCRIPT_DIR/_lib.sh"
-# SMI-5773: git-crypt filter management (get_encrypted_paths, restore_filter_config,
-# force_resmudge, scan_ciphertext, check_resmudge_scan_result) split out per
-# CLAUDE.md's 500-line file-length convention. SMI-5781 added
-# stabilize_encrypted_index_stats() to the same file.
+# SMI-5773/5781: git-crypt filter mgmt + index-stat stabilization + step_stash()
+# (Step 6); SMI-5773: submodule directional-guard alignment (is_allow_ahead_for,
+# step_rebase_submodule) — both split out per CLAUDE.md's 500-line file cap.
 # shellcheck source=_rebase-git-crypt.sh
 source "$SCRIPT_DIR/_rebase-git-crypt.sh"
-# SMI-5773: submodule directional-guard alignment (is_allow_ahead_for,
-# step_rebase_submodule) split out per CLAUDE.md's 500-line file-length
-# convention.
 # shellcheck source=_rebase-submodule.sh
 source "$SCRIPT_DIR/_rebase-submodule.sh"
 
@@ -248,26 +244,7 @@ step_crossfetch_submodule() {
     return 0
 }
 
-# Step 6: Stash unstaged changes (captures specific ref for safe pop)
-step_stash() {
-    info "Step 6: Stashing unstaged changes..."
-    if git -C "$WORKTREE_PATH" diff --quiet; then info "  No unstaged changes to stash"; return 0; fi
-    if [ "$DRY_RUN" = true ]; then info "  [dry-run] Would stash unstaged changes"; return 0; fi
-    git -C "$WORKTREE_PATH" stash push -m "rebase-worktree: auto-stash before rebase"
-    STASH_REF=$(git -C "$WORKTREE_PATH" stash list | head -1 | cut -d: -f1)
-    # SMI-5781: `git stash push` above re-checks-out every previously-unstaged
-    # path back to HEAD's content, leaving a racy mtime on each -- if left
-    # unresolved, Step 9's rebase pre-flight can spuriously reject an
-    # encrypted path as dirty once Step 7 swaps in the identity clean filter.
-    # Must run here: after the stash exists, before Step 7's filter swap.
-    # force_racy_stash_restore_for_test is a test-only, inert-by-default
-    # determinism seam (SKILLSMITH_REBASE_FORCE_RACY_TEST=1) -- see its
-    # doc comment in _rebase-git-crypt.sh.
-    force_racy_stash_restore_for_test
-    info "  Stabilizing encrypted-file index timestamps..."
-    stabilize_encrypted_index_stats
-    success "  Stashed as $STASH_REF"
-}
+# Step 6 (step_stash — stash unstaged changes) lives in _rebase-git-crypt.sh.
 
 # Step 7: Disable git-crypt filters (with EXIT trap for restore)
 step_disable_filters() {


### PR DESCRIPTION
## Summary
- `step_stash()` previously read the just-created stash ref via `git stash list | head -1 | cut -d: -f1`. Two bugs:
  1. **SIGPIPE crash under `pipefail`**: once the shared repo-wide stash list (`refs/stash` is not per-worktree) grows past a couple of entries, `head -1` closes its read end while `git stash list` is still writing, and the resulting non-zero exit aborts the script with no error message.
  2. **Wrong-stash-capture correctness bug**: `git diff --quiet` can report "dirty" purely from a dirty submodule (e.g. untracked content sitting inside `docs/internal`'s own working tree), which `git stash push` cannot capture — it prints "No local changes to save" and creates no new stash entry. The old code didn't check for this, so it would grab whatever UNRELATED stash another session/branch had left at `stash@{0}` and record it as this run's own — Step 11 would then `stash pop` that unrelated WIP onto the current worktree.
- Fixed by comparing `refs/stash` before/after the push instead of reading `stash list`: unchanged → nothing was stashed (`STASH_REF` stays empty); changed → the new entry is always `stash@{0}`.
- Moved `step_stash()` into `_rebase-git-crypt.sh` (which already holds the stash/index-timestamp-stability logic it calls directly) to stay under the 500-line file cap after the fix's growth.

Found and fixed live during the SMI-5816 (PR #2040) rebase — the repo's shared stash list had grown to 27 entries across sessions, reliably triggering the SIGPIPE crash.

## Test plan
- [x] `bash -n` syntax check on both modified files
- [x] Live-reproduced the original SIGPIPE crash via an isolated `bash -c` pipeline test before the fix
- [x] Live-verified the fix resolves it and correctly reports "Nothing actually stashed" for the submodule-only-dirty case
- [x] Used successfully end-to-end for the real PR #2040 rebase this session (multiple runs, including a real conflict-resolution path)
- [x] Full pre-push suite passed (security tests, format, per-workspace test check)

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)