### PR TITLE
fix(worktree): Export DEV_PORT to dedupe stray port-3001 publish (SMI-4298)

### DIFF
--- a/.claude/development/docker-guide.md
+++ b/.claude/development/docker-guide.md
@@ -124,6 +124,30 @@ worktree, replace `docker exec skillsmith-dev-1` with `./scripts/worktree-docker
 container-name volume/recipe substitutions below down to whatever `docker ps` shows for
 that worktree.
 
+### Worktree Host-Port Collisions (SMI-4298)
+
+Docker Compose **concatenates** `ports:` across `-f` files instead of replacing them, so the base
+`docker-compose.yml`'s `${DEV_PORT:-3001}:3001` is published in *every* worktree in addition to that
+worktree's own bucketed ports. `.env` is a symlink shared by main and all worktrees, so `DEV_PORT`
+cannot be set per-worktree there — it must be exported at `docker compose up` time.
+
+Use the wrapper, which reads the port back out of the worktree's own override and exports it:
+
+```bash
+./scripts/worktree-docker.sh start .        # from inside the worktree
+```
+
+By hand, the prefix is required — take the value from the worktree's own override
+(`grep ':3001' docker-compose.override.yml`), never from a fresh guess:
+
+```bash
+DEV_PORT=$(grep -oE '"[0-9]+:3001"' docker-compose.override.yml | head -1 | tr -d '"' | cut -d: -f1) \
+  docker compose --profile dev up -d
+```
+
+Symptom without it: `EADDRINUSE` on 3001 if the main checkout's `skillsmith-dev-1` is up — or, if
+it is down, a *silent* squat on 3001 that breaks main's next `up` instead.
+
 ### Container Won't Start
 
 ```bash

--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -28,6 +28,7 @@ on:
       - 'scripts/lib/repair-worktree-container-symlinks.sh'
       - 'scripts/regen-worktree-overrides.sh'
       - 'scripts/worktree-docker.sh'
+      - 'scripts/docker-health.sh'
       - 'scripts/session-start-mcp-command-guard.sh'
       - 'scripts/tests/create-worktree-hooks.test.sh'
       - 'scripts/tests/session-start-audit.test.sh'
@@ -37,6 +38,7 @@ on:
       - 'scripts/tests/enumerate-compose-mounts-smi5784.test.sh'
       - 'scripts/tests/repair-worktree-container-symlinks.test.sh'
       - 'scripts/tests/worktree-port-collision.test.sh'
+      - 'scripts/tests/worktree-dev-port.test.sh'
       - 'scripts/tests/regen-worktree-overrides.test.sh'
       - 'scripts/tests/worktree-docker-resolve.test.sh'
       - 'scripts/tests/session-start-mcp-command-guard.test.sh'
@@ -76,6 +78,7 @@ jobs:
             scripts/lib/repair-worktree-container-symlinks.sh \
             scripts/regen-worktree-overrides.sh \
             scripts/worktree-docker.sh \
+            scripts/docker-health.sh \
             scripts/session-start-mcp-command-guard.sh \
             scripts/tests/create-worktree-hooks.test.sh \
             scripts/tests/session-start-audit.test.sh \
@@ -85,6 +88,7 @@ jobs:
             scripts/tests/enumerate-compose-mounts-smi5784.test.sh \
             scripts/tests/repair-worktree-container-symlinks.test.sh \
             scripts/tests/worktree-port-collision.test.sh \
+            scripts/tests/worktree-dev-port.test.sh \
             scripts/tests/regen-worktree-overrides.test.sh \
             scripts/tests/worktree-docker-resolve.test.sh \
             scripts/tests/session-start-mcp-command-guard.test.sh \
@@ -106,6 +110,7 @@ jobs:
           bash -n scripts/lib/repair-worktree-container-symlinks.sh
           bash -n scripts/regen-worktree-overrides.sh
           bash -n scripts/worktree-docker.sh
+          bash -n scripts/docker-health.sh
           bash -n scripts/session-start-mcp-command-guard.sh
           bash -n scripts/tests/create-worktree-hooks.test.sh
           bash -n scripts/tests/session-start-audit.test.sh
@@ -115,6 +120,7 @@ jobs:
           bash -n scripts/tests/enumerate-compose-mounts-smi5784.test.sh
           bash -n scripts/tests/repair-worktree-container-symlinks.test.sh
           bash -n scripts/tests/worktree-port-collision.test.sh
+          bash -n scripts/tests/worktree-dev-port.test.sh
           bash -n scripts/tests/regen-worktree-overrides.test.sh
           bash -n scripts/tests/worktree-docker-resolve.test.sh
           bash -n scripts/tests/session-start-mcp-command-guard.test.sh
@@ -146,6 +152,7 @@ jobs:
           bash scripts/tests/enumerate-compose-mounts-smi5784.test.sh
           bash scripts/tests/repair-worktree-container-symlinks.test.sh
           bash scripts/tests/worktree-port-collision.test.sh
+          bash scripts/tests/worktree-dev-port.test.sh
           bash scripts/tests/regen-worktree-overrides.test.sh
           bash scripts/tests/worktree-docker-resolve.test.sh
           bash scripts/tests/session-start-mcp-command-guard.test.sh

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -1038,6 +1038,125 @@ _parse_override_host_ports() {
 }
 
 #######################################
+# Read back the host port a worktree's OWN docker-compose.override.yml
+# already publishes for the `dev` service's container port 3001 (SMI-4298).
+#
+# Why this exists: Docker Compose CONCATENATES `ports:` lists across `-f`
+# files rather than replacing them, so the base docker-compose.yml's
+# `'${DEV_PORT:-3001}:3001'` (docker-compose.yml:23) survives into every
+# worktree's merged config ALONGSIDE that worktree's own bucketed
+# `<base+1>:3001` entry from generate_docker_override_to_stdout. Every
+# worktree therefore also silently claims host port 3001 and collides with
+# the main checkout's skillsmith-dev-1 (verified live via `docker compose
+# --profile dev config`: 3 published entries without DEV_PORT, 2 with it).
+# `.env` is a symlink shared by the main checkout and every worktree
+# (create-worktree.sh:427), so DEV_PORT can never be set per-worktree
+# there -- it has to be exported by whatever invokes `docker compose up`.
+#
+# READS BACK the already-assigned value rather than recomputing the bucket
+# via _resolve_worktree_port_offset: that resolver is deliberately stateful
+# (sticky start-offset, sibling scan, host-bound probe), so a second
+# independent computation can disagree with what the override already
+# wrote. The override file is what actually provisioned the running
+# container -- the same ground-truth argument worktree-docker.sh's
+# resolve_container_name makes for container_name.
+#
+# Parsing: scoped to the `dev:` service block, because DEV_PORT governs the
+# `dev` service's 3001 publish specifically and the `test` service must
+# never supply it. The generator emits service keys at exactly 2-space
+# indent and their bodies at 4+, so `/^  dev:/,/^  [a-z]/` bounds the block
+# (sed evaluates the end pattern from the line AFTER the start, so `  dev:`
+# cannot close its own range). The grep/tr/cut chain is the same shape
+# _parse_override_host_ports already uses, narrowed to `:3001`.
+#
+# Arguments:
+#   $1 - Path to a docker-compose.override.yml (may not exist)
+# Outputs:
+#   stdout - the host port (e.g. 3891) when the dev block has a ":3001" map
+# Returns:
+#   0 on success; 1 if the file is absent or its dev block has no ":3001"
+#######################################
+resolve_worktree_dev_port() {
+    local file="$1"
+    local port
+    [ -f "$file" ] || return 1
+    port="$(sed -n '/^  dev:/,/^  [a-z]/p' "$file" 2>/dev/null \
+                | grep -oE '"[0-9]+:3001"' \
+                | head -1 | tr -d '"' | cut -d: -f1)"
+    [ -n "$port" ] || return 1
+    printf '%s\n' "$port"
+}
+
+#######################################
+# Export DEV_PORT for a worktree's `docker compose` invocation (SMI-4298).
+#
+# Sets DEV_PORT to the SAME host port the worktree's own override already
+# maps to container port 3001, so Compose's config resolution dedupes the
+# two now-identical `<port>:3001` entries into exactly one instead of
+# publishing an extra 3001. Verified live: with DEV_PORT unset the merged
+# config has 3 published entries (one of them the colliding 3001); with it
+# set to the override's own value, exactly 2, no stray 3001, no error.
+#
+# No override file at all (main checkout -- repair_worktrees_compose_override
+# skips repo_root at _lib.sh:1492 and the file is gitignored there; or a
+# worktree predating SMI-4377): SILENT no-op. There is no per-worktree port
+# assignment to honor and the base `:-3001` default is correct.
+#
+# Override present but with no dev-block ":3001" (hand-edited, or an old
+# format): print a one-line NOTE and fall through to the same default. That
+# is exactly today's behavior for every worktree -- degrading to the status
+# quo is not a regression, and hard-failing here would break `up` outright.
+#
+# Deliberately OVERWRITES a caller-supplied DEV_PORT: the override is ground
+# truth for what this compose project publishes, and a stale hand-set value
+# is precisely the drift recorded in
+# docs/internal/retros/2026-05-19-smi-5001-gh-866-882-historical-triage.md
+# ("DEV_PORT=3013 was ignored"). The printed line names the source so the
+# change is never silent. Typing `DEV_PORT=x docker compose up` by hand
+# still works -- it bypasses these scripts entirely.
+#
+# Uses `printf` rather than warn(): callers such as worktree-docker.sh
+# deliberately redefine warn() AFTER sourcing this file (see its header
+# comment at worktree-docker.sh:21-30), so warn()'s destination would
+# otherwise be caller-dependent. The two messages deliberately use
+# DIFFERENT streams (plan-review Critical #1): the success-path
+# confirmation goes to stderr, matching the neighboring SMI-5661 helpers'
+# style; the fallback NOTE goes to stdout, because it is the one message
+# that must survive `docker-health.sh`'s `pretest: "... 2>/dev/null || true"`
+# wiring (package.json:14) -- a stderr-only NOTE would be silently
+# swallowed on exactly the call site most likely to run unattended.
+#
+# Arguments:
+#   $1 - Absolute path to the worktree (NOT to the override file)
+# Returns:
+#   Always 0 -- every call site runs under `set -e` and the fallback is a
+#   documented degradation, not an error.
+#######################################
+export_worktree_dev_port() {
+    local worktree_path="$1"
+    local override="$worktree_path/docker-compose.override.yml"
+    local port
+
+    [ -f "$override" ] || return 0
+
+    if port="$(resolve_worktree_dev_port "$override")"; then
+        export DEV_PORT="$port"
+        printf 'DEV_PORT=%s (read back from %s -- SMI-4298)\n' "$port" "$override" >&2
+    else
+        # Plan-review fix (Critical #1): this NOTE — unlike the success-path
+        # confirmation above — goes to STDOUT, not stderr. docker-health.sh
+        # is wired into `npm test` as `pretest: "bash scripts/docker-health.sh
+        # 2>/dev/null || true"` (package.json:14), which discards stderr
+        # entirely. A stderr-only NOTE would be silently swallowed on
+        # exactly the call site most likely to run unattended, reproducing
+        # -- invisibly -- the exact collision this plan exists to fix.
+        printf 'NOTE: %s has no dev-service ":3001" port mapping -- leaving DEV_PORT unset, so this compose project ALSO publishes host port 3001 and can collide with the main checkout container. Regenerate it: ./scripts/worktree-docker.sh generate %s (SMI-4298)\n' \
+            "$override" "$worktree_path"
+    fi
+    return 0
+}
+
+#######################################
 # Enumerate host ports already claimed by SIBLING worktrees' override files,
 # excluding the main repo and the worktree being resolved itself (half of the
 # self-collision-avoidance fix — see _resolve_worktree_port_offset for the

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -373,6 +373,97 @@ Check your network and repository access, then retry."
 }
 
 #######################################
+# Print the post-creation "next steps" guidance for a freshly created
+# worktree. Extracted verbatim from create_worktree for SMI-4298 so the
+# DEV_PORT line is unit-testable via `source` (the BASH_SOURCE guard at the
+# bottom of this file already supports that, per SMI-5596) without running
+# a full worktree creation.
+#
+# SMI-4298: the hand-run compose command shown here now carries an explicit
+# DEV_PORT=<port> prefix read back from this worktree's own override, so a
+# copy-pasted `docker compose up` does not ALSO publish host port 3001 (the
+# base compose file's default) and collide with skillsmith-dev-1.
+#
+# Arguments:
+#   $1 - Worktree path
+#   $2 - Branch name
+#   $3 - Main repository root (for the worktree-docker.sh path shown)
+#######################################
+print_worktree_next_steps() {
+    local worktree_path="$1"
+    local branch_name="$2"
+    local repo_root="$3"
+
+    echo ""
+    success "Worktree created successfully!"
+    echo ""
+    echo "Worktree location: $worktree_path"
+    echo "Branch: $branch_name"
+    echo ""
+    echo "To start working:"
+    echo "  cd $worktree_path"
+    if [[ -f "$worktree_path/docker-compose.override.yml" ]]; then
+        # SMI-4298: read the assigned port back out of the override we just
+        # generated -- never recompute it (see _lib.sh's helper docstring).
+        local dev_port=""
+        dev_port="$(resolve_worktree_dev_port "$worktree_path/docker-compose.override.yml" || true)"
+        echo ""
+        echo "To start Docker in this worktree:"
+        echo "  $repo_root/scripts/worktree-docker.sh start $worktree_path"
+        echo "  (^ sets DEV_PORT for you -- SMI-4298)"
+        if [[ -n "$dev_port" ]]; then
+            echo ""
+            echo "Or by hand. The DEV_PORT prefix is REQUIRED (SMI-4298): Docker Compose"
+            echo "concatenates 'ports:' across -f files rather than replacing them, so"
+            echo "without it this worktree ALSO publishes host port 3001 and collides"
+            echo "with the main checkout's skillsmith-dev-1 container:"
+            echo "  cd $worktree_path && DEV_PORT=$dev_port docker compose --profile dev up -d"
+        else
+            # Plan-review fix (High #3): this override has no dev-block
+            # ":3001" mapping to read back, so there is no safe DEV_PORT to
+            # print -- but a bare, unwarned command here would silently
+            # reproduce the collision on copy-paste, exactly like the
+            # pre-fix `up -d` guidance this plan replaces. Warn explicitly
+            # instead of only warning on the happy path.
+            echo ""
+            echo "WARNING (SMI-4298): $worktree_path/docker-compose.override.yml has no"
+            echo "dev-service \":3001\" port mapping, so the command below will ALSO publish"
+            echo "host port 3001 and can collide with the main checkout's skillsmith-dev-1"
+            echo "container. Regenerate the override first:"
+            echo "  $repo_root/scripts/worktree-docker.sh generate $worktree_path"
+            echo "  cd $worktree_path && docker compose --profile dev up -d"
+        fi
+        echo ""
+        echo "SMI-5559: run commands via the container matching THIS worktree, not a"
+        echo "hardcoded name (the main checkout's container is long-lived, so"
+        echo "'docker exec skillsmith-dev-1 <cmd>' silently \"succeeds\" from any"
+        echo "worktree even if this one's own container never came up):"
+        echo "  $repo_root/scripts/worktree-docker.sh exec $worktree_path -- npm run preflight  # like: docker exec <container> npm run preflight"
+        echo "This errors loudly (not silently) if the container isn't running yet —"
+        echo "see CLAUDE.md's Troubleshooting table, 'Container won't start', if it does."
+        echo ""
+        echo "SMI-5570/SMI-5074: git push now requires THIS worktree's OWN container to"
+        echo "be running (the command above) — pre-push no longer routes through the"
+        echo "main checkout's container, which was silently testing main's own"
+        echo "dependency state instead of this branch's. If you push before starting"
+        echo "this container on a non-docs-only change, pre-push hard-fails with the"
+        echo "exact remediation command; escape hatches:"
+        echo "  SKILLSMITH_PRE_PUSH_HOST=1 git push                       # fall back to host once"
+        echo "  SKILLSMITH_WORKTREE_PREPUSH_HARDFAIL_DISABLE=1 git push   # always fall back this push"
+    fi
+    echo ""
+    echo "Pre-commit hooks: active (SMI-4377 + SMI-4381)"
+    echo "  - Hook discovery: .husky/_/ is tracked in main repo (inherited via checkout)"
+    echo "  - Host tooling: node_modules symlinked to main repo (relative)"
+    echo "  - Per-package: each packages/<pkg>/node_modules also symlinked"
+    echo "  - Typecheck: runs in Docker on Linux; on macOS Docker Desktop falls back"
+    echo "    to host (virtiofs cannot traverse relative symlinks); host fallback works"
+    echo ""
+    echo "Note: existing worktrees need a one-time manual fix if skillsmith MCP fails:"
+    echo "  Edit .mcp.json: set skillsmith command to 'npx', args to ['-y', '@skillsmith/mcp-server']"
+}
+
+#######################################
 # Create worktree with git-crypt support
 #######################################
 create_worktree() {
@@ -486,46 +577,7 @@ create_worktree() {
     (cd "$worktree_path" && git update-index --skip-worktree .mcp.json)
     success "  .mcp.json marked skip-worktree (SMI-4973)"
 
-    echo ""
-    success "Worktree created successfully!"
-    echo ""
-    echo "Worktree location: $worktree_path"
-    echo "Branch: $branch_name"
-    echo ""
-    echo "To start working:"
-    echo "  cd $worktree_path"
-    if [[ -f "$worktree_path/docker-compose.override.yml" ]]; then
-        echo ""
-        echo "To start Docker in this worktree:"
-        echo "  cd $worktree_path && docker compose --profile dev up -d"
-        echo ""
-        echo "SMI-5559: run commands via the container matching THIS worktree, not a"
-        echo "hardcoded name (the main checkout's container is long-lived, so"
-        echo "'docker exec skillsmith-dev-1 <cmd>' silently \"succeeds\" from any"
-        echo "worktree even if this one's own container never came up):"
-        echo "  $REPO_ROOT/scripts/worktree-docker.sh exec $worktree_path -- npm run preflight  # like: docker exec <container> npm run preflight"
-        echo "This errors loudly (not silently) if the container isn't running yet —"
-        echo "see CLAUDE.md's Troubleshooting table, 'Container won't start', if it does."
-        echo ""
-        echo "SMI-5570/SMI-5074: git push now requires THIS worktree's OWN container to"
-        echo "be running (docker compose --profile dev up -d above) — pre-push no longer"
-        echo "routes through the main checkout's container, which was silently testing"
-        echo "main's own dependency state instead of this branch's. If you push before"
-        echo "starting this container on a non-docs-only change, pre-push hard-fails"
-        echo "with the exact remediation command; escape hatches:"
-        echo "  SKILLSMITH_PRE_PUSH_HOST=1 git push                       # fall back to host once"
-        echo "  SKILLSMITH_WORKTREE_PREPUSH_HARDFAIL_DISABLE=1 git push   # always fall back this push"
-    fi
-    echo ""
-    echo "Pre-commit hooks: active (SMI-4377 + SMI-4381)"
-    echo "  - Hook discovery: .husky/_/ is tracked in main repo (inherited via checkout)"
-    echo "  - Host tooling: node_modules symlinked to main repo (relative)"
-    echo "  - Per-package: each packages/<pkg>/node_modules also symlinked"
-    echo "  - Typecheck: runs in Docker on Linux; on macOS Docker Desktop falls back"
-    echo "    to host (virtiofs cannot traverse relative symlinks); host fallback works"
-    echo ""
-    echo "Note: existing worktrees need a one-time manual fix if skillsmith MCP fails:"
-    echo "  Edit .mcp.json: set skillsmith command to 'npx', args to ['-y', '@skillsmith/mcp-server']"
+    print_worktree_next_steps "$worktree_path" "$branch_name" "$REPO_ROOT"
 }
 
 #######################################

--- a/scripts/docker-health.sh
+++ b/scripts/docker-health.sh
@@ -9,6 +9,16 @@ COMPOSE_PROFILE="${COMPOSE_PROFILE:-dev}"
 MAX_WAIT_SECONDS=60
 CHECK_INTERVAL=2
 
+# SMI-4298: shared worktree helpers (export_worktree_dev_port). Sourced
+# BEFORE this script's own color/log definitions below so those local
+# definitions take precedence -- mirrors worktree-docker.sh:21-30's ordering
+# and rationale. _lib.sh guards against double-sourcing (_LIB_SH_LOADED) and
+# its top level is nothing but variable assignments and function
+# definitions, so this is safe under `set -e`.
+DOCKER_HEALTH_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "$DOCKER_HEALTH_LIB_DIR/_lib.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -101,6 +111,16 @@ wait_for_healthy() {
 main() {
     log_info "Checking Docker environment..."
     check_docker
+
+    # SMI-4298: the `up`/`restart` below run in the CALLER's cwd -- this
+    # script is wired into npm `pretest` (package.json), so from a worktree
+    # they act on THAT worktree's compose project. Export DEV_PORT from that
+    # worktree's own override first, or the base file's `${DEV_PORT:-3001}`
+    # publishes an extra host 3001: it either fails with EADDRINUSE against
+    # the main checkout's container, or -- worse -- silently squats 3001
+    # while main is down and breaks main's next `up`. Silent no-op in the
+    # main checkout, which has no override file (AC-6/AC-7).
+    export_worktree_dev_port "$PWD"
 
     if is_container_running; then
         log_info "Container '$CONTAINER_NAME' is already running"

--- a/scripts/tests/worktree-dev-port.test.sh
+++ b/scripts/tests/worktree-dev-port.test.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+# SMI-4298: Unit + integration tests for the worktree DEV_PORT port-collision
+# fix added to scripts/_lib.sh (resolve_worktree_dev_port,
+# export_worktree_dev_port), wired into scripts/worktree-docker.sh's
+# cmd_start and scripts/create-worktree.sh's print_worktree_next_steps.
+#
+# Root cause: Docker Compose CONCATENATES `ports:` lists across `-f` files
+# rather than replacing them, so the base docker-compose.yml's
+# `${DEV_PORT:-3001}:3001` survives into every worktree's merged config
+# ALONGSIDE that worktree's own bucketed `<port>:3001` entry from the
+# SMI-5661 generator. Every worktree therefore also silently claims host
+# port 3001. The fix exports DEV_PORT to the worktree's own already-assigned
+# port before `docker compose up`, so Compose dedupes the two now-identical
+# entries into exactly one.
+#
+# Uses REAL `git worktree add` fixtures (like worktree-port-collision.test.sh
+# and worktree-docker-resolve.test.sh) rather than faking git plumbing, since
+# cmd_generate / get_worktree_name genuinely shell out to git.
+#
+# Covers:
+#   A. resolve_worktree_dev_port unit (sources the real _lib.sh directly).
+#   B. export_worktree_dev_port unit (DEV_PORT export + NOTE/stream behavior).
+#   C. worktree-docker.sh `start` integration, docker shimmed via a PATH
+#      binary that logs its argv and DEV_PORT env — the bash analogue of
+#      repair-worktrees-docker-guard.test.ts's writeDockerShim.
+#   D. create-worktree.sh's print_worktree_next_steps guidance text (AC-9),
+#      covered by sourcing the script — its BASH_SOURCE guard permits this,
+#      same precedent as create-worktree-ready-probe.test.ts.
+#   E. Docker-gated (skipped, not failed, when no daemon is reachable): a
+#      real `docker compose --profile dev config` run against a fixture that
+#      copies the REAL docker-compose.yml, automating the AC-3 manual
+#      verification (every test above stubs `docker`, so none of them
+#      exercise real Compose config merging).
+# No `-e`: several assertions deliberately provoke a non-zero return
+# (resolve_worktree_dev_port's not-found path) and inspect it directly,
+# matching worktree-port-collision.test.sh's own rationale.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+# shellcheck source=../_lib.sh
+source "$SCRIPT_DIR/_lib.sh"
+WORKTREE_DOCKER="$SCRIPT_DIR/worktree-docker.sh"
+CREATE_WORKTREE="$SCRIPT_DIR/create-worktree.sh"
+REAL_DOCKER_COMPOSE_YML="$SCRIPT_DIR/../docker-compose.yml"
+REAL_DOCKERFILE="$SCRIPT_DIR/../Dockerfile"
+
+fail=0
+pass=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name: expected='$expected' actual='$actual'"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name: '$needle' not in output"
+    echo "  Haystack: $haystack"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo "FAIL $name: '$needle' should NOT be in output"
+    fail=$((fail + 1))
+  else
+    echo "PASS $name"
+    pass=$((pass + 1))
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Fixture builders
+# -----------------------------------------------------------------------
+
+# Global accumulator of every temp dir created below, removed by a single
+# EXIT trap (mirrors worktree-port-collision.test.sh).
+ALL_TMP_DIRS=""
+trap 'rm -rf $ALL_TMP_DIRS' EXIT
+
+# new_tmp_dir -> a plain throwaway directory (no git), tracked for cleanup,
+# echoes its canonicalized path.
+new_tmp_dir() {
+  local dir
+  dir=$(mktemp -d)
+  dir=$(cd "$dir" && pwd -P)
+  ALL_TMP_DIRS="$ALL_TMP_DIRS $dir"
+  printf '%s' "$dir"
+}
+
+# new_fixture_repo -> a throwaway git repo with one commit, tracked for
+# cleanup, echoes its path. Canonicalized eagerly (macOS mktemp -d returns a
+# /var/... symlink to /private/var/...) so `git worktree`/`git rev-parse`
+# comparisons never trip over the difference.
+new_fixture_repo() {
+  local root
+  root=$(mktemp -d)
+  root=$(cd "$root" && pwd -P)
+  ALL_TMP_DIRS="$ALL_TMP_DIRS $root"
+  git -C "$root" init -q -b main
+  git -C "$root" config user.email test@example.com
+  git -C "$root" config user.name "Test"
+  git -C "$root" config commit.gpgsign false
+  : > "$root/README.md"
+  git -C "$root" add README.md
+  git -C "$root" commit -qm init >/dev/null
+  printf '%s' "$root"
+}
+
+# add_worktree <repo_root> <name> -> `git worktree add` on a new branch named
+# <name> at <repo_root>/.worktrees/<name>, echoes the path.
+add_worktree() {
+  local root="$1" name="$2" path
+  path="$root/.worktrees/$name"
+  git -C "$root" worktree add -q -b "$name" "$path" HEAD >/dev/null 2>&1
+  printf '%s' "$path"
+}
+
+# Docker shim: PATH-shadows `docker`, logging every invocation's argv AND its
+# DEV_PORT env to DOCKER_SHIM_LOG, then exits 0 without touching a real
+# daemon. Bash analogue of repair-worktrees-docker-guard.test.ts's
+# writeDockerShim.
+write_docker_shim() {
+  local bin_dir="$1"
+  cat > "$bin_dir/docker" << 'SHIM'
+#!/bin/sh
+echo "DEV_PORT=${DEV_PORT:-} ARGS=$*" >> "$DOCKER_SHIM_LOG"
+exit 0
+SHIM
+  chmod +x "$bin_dir/docker"
+}
+
+# =========================================================================
+# Group A: resolve_worktree_dev_port unit (real _lib.sh, no git needed)
+# =========================================================================
+
+# A1: dev: block has "3891:3001" -> stdout is exactly 3891, rc 0.
+DIR_A1=$(new_tmp_dir)
+cat > "$DIR_A1/docker-compose.override.yml" << 'EOF'
+services:
+  dev:
+    container_name: fixture-dev-1
+    ports:
+      - "3890:3000"   # Main app
+      - "3891:3001"   # MCP server
+  test:
+    container_name: fixture-test-1
+    ports:
+      - "3892:3000"      # Test app
+EOF
+RC_A1=0
+OUT_A1=$(resolve_worktree_dev_port "$DIR_A1/docker-compose.override.yml") || RC_A1=$?
+assert_eq "groupA1: dev-block 3891:3001 resolves to 3891" "3891" "$OUT_A1"
+assert_eq "groupA1: rc 0 on success" "0" "$RC_A1"
+
+# A2: override file does not exist -> rc 1, stdout empty.
+DIR_A2=$(new_tmp_dir)
+RC_A2=0
+OUT_A2=$(resolve_worktree_dev_port "$DIR_A2/docker-compose.override.yml") || RC_A2=$?
+assert_eq "groupA2: missing file returns rc 1" "1" "$RC_A2"
+assert_eq "groupA2: missing file -> empty stdout" "" "$OUT_A2"
+
+# A3: dev: block has only a :3000 mapping (no :3001 anywhere) -> rc 1, empty.
+DIR_A3=$(new_tmp_dir)
+cat > "$DIR_A3/docker-compose.override.yml" << 'EOF'
+services:
+  dev:
+    container_name: fixture-dev-1
+    ports:
+      - "3890:3000"   # Main app
+  test:
+    container_name: fixture-test-1
+    ports:
+      - "3892:3000"      # Test app
+EOF
+RC_A3=0
+OUT_A3=$(resolve_worktree_dev_port "$DIR_A3/docker-compose.override.yml") || RC_A3=$?
+assert_eq "groupA3: no :3001 mapping anywhere returns rc 1" "1" "$RC_A3"
+assert_eq "groupA3: no :3001 mapping -> empty stdout" "" "$OUT_A3"
+
+# A4: dev: block has "3891:3001" AND a later test: block has "9999:3001" ->
+# stdout is 3891 -- proves dev-block scoping, not first-match-in-file luck.
+DIR_A4=$(new_tmp_dir)
+cat > "$DIR_A4/docker-compose.override.yml" << 'EOF'
+services:
+  dev:
+    container_name: fixture-dev-1
+    ports:
+      - "3890:3000"   # Main app
+      - "3891:3001"   # MCP server
+  test:
+    container_name: fixture-test-1
+    ports:
+      - "9999:3001"      # Deliberately shaped like a dev mcp port
+EOF
+RC_A4=0
+OUT_A4=$(resolve_worktree_dev_port "$DIR_A4/docker-compose.override.yml") || RC_A4=$?
+assert_eq "groupA4: dev-block scoping picks 3891, not the test block's 9999" "3891" "$OUT_A4"
+assert_eq "groupA4: rc 0" "0" "$RC_A4"
+
+# A5: :3001 present ONLY in the test: block -> rc 1 (AC-4: never hand back a
+# non-dev port).
+DIR_A5=$(new_tmp_dir)
+cat > "$DIR_A5/docker-compose.override.yml" << 'EOF'
+services:
+  dev:
+    container_name: fixture-dev-1
+    ports:
+      - "3890:3000"   # Main app
+  test:
+    container_name: fixture-test-1
+    ports:
+      - "9999:3001"      # Only :3001 mapping in the whole file
+EOF
+RC_A5=0
+OUT_A5=$(resolve_worktree_dev_port "$DIR_A5/docker-compose.override.yml") || RC_A5=$?
+assert_eq "groupA5: :3001 only in test block refuses to hand it back (AC-4)" "1" "$RC_A5"
+assert_eq "groupA5: refusal produces no stdout" "" "$OUT_A5"
+
+# =========================================================================
+# Group B: export_worktree_dev_port unit
+# =========================================================================
+
+# B1: worktree dir with a 3891:3001 override -> DEV_PORT is 3891 after the
+# call; rc 0. Run as a DIRECT call (not $(...)) so `export` persists into
+# this shell; redirect combined output to a file instead.
+DIR_B1=$(new_tmp_dir)
+cat > "$DIR_B1/docker-compose.override.yml" << 'EOF'
+services:
+  dev:
+    container_name: fixture-dev-1
+    ports:
+      - "3890:3000"   # Main app
+      - "3891:3001"   # MCP server
+EOF
+unset DEV_PORT
+OUT_FILE_B1=$(mktemp)
+ALL_TMP_DIRS="$ALL_TMP_DIRS $OUT_FILE_B1"
+RC_B1=0
+export_worktree_dev_port "$DIR_B1" > "$OUT_FILE_B1" 2>&1 || RC_B1=$?
+assert_eq "groupB1: DEV_PORT is exported to 3891" "3891" "${DEV_PORT:-}"
+assert_eq "groupB1: rc 0" "0" "$RC_B1"
+
+# B2: worktree dir with NO override file -> DEV_PORT stays unset; rc 0;
+# combined output is empty (silent no-op -- AC-6).
+DIR_B2=$(new_tmp_dir)
+unset DEV_PORT
+OUT_FILE_B2=$(mktemp)
+ALL_TMP_DIRS="$ALL_TMP_DIRS $OUT_FILE_B2"
+RC_B2=0
+export_worktree_dev_port "$DIR_B2" > "$OUT_FILE_B2" 2>&1 || RC_B2=$?
+assert_eq "groupB2: DEV_PORT stays unset (no override file)" "" "${DEV_PORT:-}"
+assert_eq "groupB2: rc 0" "0" "$RC_B2"
+assert_eq "groupB2: combined output is empty (AC-6 silent no-op)" "" "$(cat "$OUT_FILE_B2")"
+
+# B3: override present, no dev :3001 mapping -> DEV_PORT stays unset; rc 0;
+# combined output carries the NOTE and SMI-4298 (AC-5).
+DIR_B3=$(new_tmp_dir)
+cat > "$DIR_B3/docker-compose.override.yml" << 'EOF'
+services:
+  dev:
+    container_name: fixture-dev-1
+    ports:
+      - "3890:3000"   # Main app
+EOF
+unset DEV_PORT
+OUT_FILE_B3=$(mktemp)
+ALL_TMP_DIRS="$ALL_TMP_DIRS $OUT_FILE_B3"
+RC_B3=0
+export_worktree_dev_port "$DIR_B3" > "$OUT_FILE_B3" 2>&1 || RC_B3=$?
+assert_eq "groupB3: DEV_PORT stays unset (fallback path)" "" "${DEV_PORT:-}"
+assert_eq "groupB3: rc 0" "0" "$RC_B3"
+assert_contains "groupB3: fallback message carries NOTE:" "NOTE:" "$(cat "$OUT_FILE_B3")"
+assert_contains "groupB3: fallback message carries SMI-4298" "SMI-4298" "$(cat "$OUT_FILE_B3")"
+
+# B4: DEV_PORT=3001 pre-exported, override maps 3891:3001 -> DEV_PORT is
+# 3891 after the call, documenting the deliberate overwrite (edge case 4).
+DIR_B4=$(new_tmp_dir)
+cat > "$DIR_B4/docker-compose.override.yml" << 'EOF'
+services:
+  dev:
+    container_name: fixture-dev-1
+    ports:
+      - "3890:3000"   # Main app
+      - "3891:3001"   # MCP server
+EOF
+export DEV_PORT=3001
+OUT_FILE_B4=$(mktemp)
+ALL_TMP_DIRS="$ALL_TMP_DIRS $OUT_FILE_B4"
+export_worktree_dev_port "$DIR_B4" > "$OUT_FILE_B4" 2>&1
+assert_eq "groupB4: a stale pre-exported DEV_PORT is overwritten to 3891" "3891" "${DEV_PORT:-}"
+unset DEV_PORT
+
+# =========================================================================
+# Group C: worktree-docker.sh `start` integration (real script, shimmed
+# docker)
+# =========================================================================
+ROOT_C=$(new_fixture_repo)
+BIN_C=$(new_tmp_dir)
+write_docker_shim "$BIN_C"
+DOCKER_SHIM_LOG_C=$(mktemp)
+ALL_TMP_DIRS="$ALL_TMP_DIRS $DOCKER_SHIM_LOG_C"
+export SKILLSMITH_WORKTREE_PORT_SKIP_HOST_CHECK=1
+
+# C1: override mapping host 3891 -> container 3001; run `start`. The shim
+# log's `up -d` line must carry DEV_PORT=3891 (AC-1).
+WT_C1=$(add_worktree "$ROOT_C" "wt-c1")
+printf 'services: {}\n' > "$WT_C1/docker-compose.yml"
+cat > "$WT_C1/docker-compose.override.yml" << 'EOF'
+services:
+  dev:
+    container_name: wt-c1-dev-1
+    ports:
+      - "3890:3000"   # Main app
+      - "3891:3001"   # MCP server
+  test:
+    container_name: wt-c1-test-1
+    ports:
+      - "3892:3000"      # Test app
+EOF
+: > "$DOCKER_SHIM_LOG_C"
+DOCKER_SHIM_LOG="$DOCKER_SHIM_LOG_C" PATH="$BIN_C:$PATH" \
+  bash "$WORKTREE_DOCKER" start "$WT_C1" > /dev/null 2>&1
+assert_contains "groupC1: up -d call carries DEV_PORT=3891 (AC-1)" \
+  "DEV_PORT=3891 ARGS=compose --profile dev up -d" "$(cat "$DOCKER_SHIM_LOG_C")"
+
+# C2: override with dev ports but NO :3001 -> up -d runs with DEV_PORT
+# unset, and combined script output carries the SMI-4298 NOTE end-to-end
+# (AC-5).
+WT_C2=$(add_worktree "$ROOT_C" "wt-c2")
+printf 'services: {}\n' > "$WT_C2/docker-compose.yml"
+cat > "$WT_C2/docker-compose.override.yml" << 'EOF'
+services:
+  dev:
+    container_name: wt-c2-dev-1
+    ports:
+      - "3890:3000"   # Main app
+  test:
+    container_name: wt-c2-test-1
+    ports:
+      - "3892:3000"      # Test app
+EOF
+: > "$DOCKER_SHIM_LOG_C"
+COMBINED_C2=$(DOCKER_SHIM_LOG="$DOCKER_SHIM_LOG_C" PATH="$BIN_C:$PATH" \
+  bash "$WORKTREE_DOCKER" start "$WT_C2" 2>&1)
+assert_contains "groupC2: up -d call has DEV_PORT unset (fallback)" \
+  "DEV_PORT= ARGS=compose --profile dev up -d" "$(cat "$DOCKER_SHIM_LOG_C")"
+assert_contains "groupC2: script output carries SMI-4298 end-to-end (AC-5)" \
+  "SMI-4298" "$COMBINED_C2"
+
+# C3: no-drift / read-back check. Fresh worktree with no override; run
+# `generate` (real _lib.sh generator) then `start`. The DEV_PORT value the
+# shim observed must equal what the generated file itself says -- proving
+# the value is READ BACK, never recomputed (AC-2).
+WT_C3=$(add_worktree "$ROOT_C" "wt-c3")
+cp "$REAL_DOCKER_COMPOSE_YML" "$WT_C3/docker-compose.yml"
+: > "$DOCKER_SHIM_LOG_C"
+DOCKER_SHIM_LOG="$DOCKER_SHIM_LOG_C" PATH="$BIN_C:$PATH" \
+  bash "$WORKTREE_DOCKER" generate "$WT_C3" > /dev/null 2>&1
+GENERATED_PORT_C3=$(grep -oE '"[0-9]+:3001"' "$WT_C3/docker-compose.override.yml" \
+  | head -1 | tr -d '"' | cut -d: -f1)
+: > "$DOCKER_SHIM_LOG_C"
+DOCKER_SHIM_LOG="$DOCKER_SHIM_LOG_C" PATH="$BIN_C:$PATH" \
+  bash "$WORKTREE_DOCKER" start "$WT_C3" > /dev/null 2>&1
+assert_contains "groupC3: start's DEV_PORT equals the generated file's own value (AC-2)" \
+  "DEV_PORT=${GENERATED_PORT_C3} ARGS=compose --profile dev up -d" "$(cat "$DOCKER_SHIM_LOG_C")"
+
+# C4: negative control on the harness -- the same shim log must ALSO record
+# cmd_status's trailing `docker ps` call, proving the shim really is on PATH
+# and intercepting (so C2's empty DEV_PORT is a real observation, not a
+# silently-missing invocation).
+assert_contains "groupC4: shim also recorded the cmd_status docker ps call" \
+  "ARGS=ps -a" "$(cat "$DOCKER_SHIM_LOG_C")"
+
+unset SKILLSMITH_WORKTREE_PORT_SKIP_HOST_CHECK
+
+# =========================================================================
+# Group D: create-worktree.sh's print_worktree_next_steps guidance (AC-9)
+# =========================================================================
+# Sourced in a fresh `bash -c` subprocess (not our own shell) so
+# create-worktree.sh's top-level `set -euo pipefail` never leaks into this
+# test runner. $0 is deliberately a PLACEHOLDER, not the real script path:
+# create-worktree.sh's own BASH_SOURCE guard at its bottom
+# (`[[ "${BASH_SOURCE[0]}" == "${0}" ]]`) exists so `source` can pull in its
+# functions WITHOUT running `main` -- but that guard trips true (running a
+# real worktree-creation main()) if $0 happens to equal the sourced file's
+# own path, which is exactly what BASH_SOURCE[0] resolves to while it is
+# being sourced. Keeping $0 a distinct placeholder string is what makes
+# `source` a pure function-definition import here.
+run_print_next_steps() {
+  bash -c '
+    source "$1"
+    print_worktree_next_steps "$2" "$3" "$4"
+  ' _test_runner_ "$CREATE_WORKTREE" "$1" "fix/demo" "$2"
+}
+
+# D1/D2: worktree dir with a 3891:3001 override.
+DIR_D=$(new_tmp_dir)
+cat > "$DIR_D/docker-compose.override.yml" << 'EOF'
+services:
+  dev:
+    container_name: fixture-dev-1
+    ports:
+      - "3890:3000"   # Main app
+      - "3891:3001"   # MCP server
+EOF
+OUT_D=$(run_print_next_steps "$DIR_D" "/repo")
+assert_contains "groupD1: guidance carries DEV_PORT=3891 ... up -d (AC-9)" \
+  "DEV_PORT=3891 docker compose --profile dev up -d" "$OUT_D"
+assert_contains "groupD2: no-prefix worktree-docker.sh start form is offered first" \
+  "worktree-docker.sh start" "$OUT_D"
+
+# D3: worktree dir with an override lacking :3001 -> WARNING, the bare `up`
+# fallback, and NOT a malformed empty-valued DEV_PORT= (plan-review High #3).
+DIR_D3=$(new_tmp_dir)
+cat > "$DIR_D3/docker-compose.override.yml" << 'EOF'
+services:
+  dev:
+    container_name: fixture-dev-1
+    ports:
+      - "3890:3000"   # Main app
+EOF
+OUT_D3=$(run_print_next_steps "$DIR_D3" "/repo")
+assert_contains "groupD3: WARNING (SMI-4298) shown when no dev :3001 mapping exists" \
+  "WARNING (SMI-4298)" "$OUT_D3"
+assert_contains "groupD3: bare up -d fallback still printed" \
+  "docker compose --profile dev up -d" "$OUT_D3"
+assert_not_contains "groupD3: no malformed empty DEV_PORT= prefix" \
+  "DEV_PORT=" "$OUT_D3"
+
+# =========================================================================
+# Group E: plan-review Medium #5 -- Docker-gated real Compose integration
+# for AC-3. Every test above stubs `docker`; none of them exercise real
+# Compose config merging. Skipped (not failed) when Docker is unavailable.
+# =========================================================================
+if ! command -v docker > /dev/null 2>&1 || ! docker info > /dev/null 2>&1; then
+  echo "SKIP: docker unavailable (Group E)"
+else
+  ROOT_E=$(new_fixture_repo)
+  cp "$REAL_DOCKER_COMPOSE_YML" "$ROOT_E/docker-compose.yml"
+  if [ -f "$REAL_DOCKERFILE" ]; then
+    cp "$REAL_DOCKERFILE" "$ROOT_E/Dockerfile"
+  else
+    printf 'FROM scratch\n' > "$ROOT_E/Dockerfile"
+  fi
+  git -C "$ROOT_E" add docker-compose.yml Dockerfile
+  git -C "$ROOT_E" commit -qm "add real compose files" > /dev/null
+
+  WT_E=$(add_worktree "$ROOT_E" "wt-e")
+  export SKILLSMITH_WORKTREE_PORT_SKIP_HOST_CHECK=1
+  generate_docker_override "$WT_E" "wt-e" "$ROOT_E" > /dev/null 2>/dev/null
+  unset SKILLSMITH_WORKTREE_PORT_SKIP_HOST_CHECK
+  PORT_E=$(resolve_worktree_dev_port "$WT_E/docker-compose.override.yml")
+
+  # E1: pre-fix negative control -- DEV_PORT unset. Reproduces the
+  # collision: MORE THAN ONE port mapping targets container port 3001 (the
+  # base file's stray default AND the worktree's own bucketed mcp port).
+  unset DEV_PORT
+  TARGET_3001_COUNT_E1=$(cd "$WT_E" && docker compose --profile dev config 2>/dev/null \
+    | grep -c 'target: 3001')
+  if [ "$TARGET_3001_COUNT_E1" -gt 1 ]; then
+    echo "PASS groupE1: DEV_PORT unset reproduces the pre-fix double-publish of container port 3001 (count=$TARGET_3001_COUNT_E1)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL groupE1: expected more than one target:3001 entry with DEV_PORT unset, got $TARGET_3001_COUNT_E1"
+    fail=$((fail + 1))
+  fi
+
+  # E2: post-fix -- DEV_PORT=<resolved> collapses to exactly ONE entry
+  # targeting container port 3001, published at the override's own bucketed
+  # port (the literal AC-3 assertion).
+  TARGET_3001_COUNT_E2=$(cd "$WT_E" && DEV_PORT="$PORT_E" docker compose --profile dev config 2>/dev/null \
+    | grep -c 'target: 3001')
+  assert_eq "groupE2: DEV_PORT=<resolved> dedupes to exactly one target:3001 entry (AC-3)" \
+    "1" "$TARGET_3001_COUNT_E2"
+  PUBLISHED_E2=$(cd "$WT_E" && DEV_PORT="$PORT_E" docker compose --profile dev config 2>/dev/null \
+    | grep -A2 'target: 3001' | grep 'published:')
+  assert_contains "groupE2: the single entry publishes the override's own port ($PORT_E)" \
+    "\"$PORT_E\"" "$PUBLISHED_E2"
+fi
+
+# -----------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------
+echo ""
+echo "===== Results: $pass passed, $fail failed ====="
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/worktree-docker.sh
+++ b/scripts/worktree-docker.sh
@@ -189,7 +189,19 @@ cmd_start() {
     fi
 
     info "Starting Docker containers..."
-    (cd "$worktree_path" && docker compose --profile dev up -d)
+    # SMI-4298: export DEV_PORT to the SAME host port this worktree's own
+    # override already maps to container port 3001, BEFORE `up`. Compose
+    # concatenates `ports:` across -f files rather than replacing them, so
+    # without this the base file's `${DEV_PORT:-3001}:3001` is published in
+    # ADDITION to this worktree's bucketed pair and every worktree also
+    # claims host port 3001. Runs AFTER the auto-generate block above so a
+    # just-generated override is read back, never a stale or absent one.
+    # Confined to this subshell so DEV_PORT does not leak into cmd_status.
+    (
+        cd "$worktree_path" \
+            && export_worktree_dev_port "$worktree_path" \
+            && docker compose --profile dev up -d
+    )
 
     echo ""
     success "Docker containers started!"


### PR DESCRIPTION
## Summary

Fixes a recurring worktree Docker port-collision bug (SMI-4298, open since 2026-04-18, hit ~8 times across sessions per linked retros). Every worktree's dev container silently claimed host port 3001 in addition to its own collision-free bucketed ports, because Docker Compose **concatenates** `ports:` lists across `-f` files rather than replacing them — the base `docker-compose.yml`'s `${DEV_PORT:-3001}:3001` default was never neutralized for worktrees despite their own bucketed `docker-compose.override.yml`.

Root cause and fix confirmed empirically live against a real worktree (not just theorized) — see the full SPARC plan + VP Product/Engineering/Design review at `docs/internal/implementation/smi-4298-worktree-dev-port-collision.md` (landing via a separate `docs/internal` pointer-bump PR, #2056).

- `scripts/_lib.sh`: new `resolve_worktree_dev_port()` / `export_worktree_dev_port()` — read the host port a worktree's own override already maps to container 3001, and export `DEV_PORT` to that value so Compose dedupes the two now-identical entries instead of publishing an extra 3001.
- `scripts/worktree-docker.sh`: `cmd_start` exports it before `docker compose up -d`.
- `scripts/create-worktree.sh`: post-creation guidance now prints the correct `DEV_PORT=<port>` prefix (with an explicit warning on the fallback path if no port can be resolved).
- `scripts/docker-health.sh`: exports it in `main()` — its warning message specifically goes to stdout (not stderr) since this script is wired into `npm test`'s `pretest` with `2>/dev/null`, which would otherwise silently swallow it (a real gap plan-review caught).
- `.github/workflows/validate-hooks.yml` / `.claude/development/docker-guide.md`: CI registration + docs.
- New `scripts/tests/worktree-dev-port.test.sh` (33 assertions, Groups A–E, real `git worktree add` fixtures + PATH-shimmed `docker`, including a Docker-gated integration test for the core Compose-dedup claim).

Three follow-up gaps identified during planning (a live instance of the same bug in a different repo/submodule, a possible Compose `!override`-tag simplification, and a separate pre-existing bug where `worktree-docker.sh start` run from the main checkout moves its ports) were filed rather than left as open questions: SMI-5834, SMI-5835, SMI-5836.

Main checkout is provably unaffected — `export_worktree_dev_port` no-ops silently when no override file exists, which is always true for the main checkout.

## Test plan
- [x] `bash -n` + `shellcheck -S warning` clean on all 5 changed/new shell files
- [x] New test suite: 33/33 assertions pass, including a live Docker-gated integration test
- [x] SMI-5661 regression suite (`worktree-port-collision.test.sh`): 22/22 pass, unaffected
- [x] Sibling worktree/docker test suites (`worktree-docker-resolve`, `enumerate-compose-mounts`, `regen-worktree-overrides`, plus the vitest `repair-worktrees-docker-guard`/`create-worktree-base`/`create-worktree-ready-probe` suites): all pass
- [x] Live-verified: `docker compose --profile dev config` shows the stray 3001 entry without the fix, and exactly the worktree's own bucketed ports with it
- [x] End-to-end `./scripts/worktree-docker.sh start .` and full `create-worktree.sh` throwaway-worktree flow (AC-9), both verified against real running containers
- [x] Fallback path (AC-5, missing `:3001` mapping) exercised live — degrades to today's exact pre-fix behavior, no hard-fail
- [x] Main checkout's `skillsmith-dev-1` confirmed undisturbed throughout

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)