### PR TITLE
fix(worktree): Refuse worktree-docker.sh start/generate against main (SMI-5836)

### DIFF
--- a/.claude/development/docker-guide.md
+++ b/.claude/development/docker-guide.md
@@ -134,7 +134,9 @@ cannot be set per-worktree there — it must be exported at `docker compose up` 
 Use the wrapper, which reads the port back out of the worktree's own override and exports it:
 
 ```bash
-./scripts/worktree-docker.sh start .        # from inside the worktree
+./scripts/worktree-docker.sh start .        # from inside the worktree ONLY
+# From the MAIN checkout this hard-errors (SMI-5836) — use plain
+# `docker compose --profile dev up -d` there.
 ```
 
 By hand, the prefix is required — take the value from the worktree's own override

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -1157,6 +1157,109 @@ export_worktree_dev_port() {
 }
 
 #######################################
+# True if $1 is the MAIN checkout; false for a linked worktree (SMI-5836).
+#
+# A linked worktree's `--git-dir` is main's `.git/worktrees/<name>` while its
+# `--git-common-dir` is main's `.git`, so the two differ; in the main checkout
+# both resolve to the same path (`.git`, relative, with cwd at the root).
+# Verified live: main -> `.git`/`.git`; worktree -> `<root>/.git/worktrees/wt`
+# and `<root>/.git`.
+#
+# The `-n "$gcd"` test is load-bearing: on a NON-git path both rev-parse calls
+# fail and both vars are empty, which would otherwise compare equal and report
+# a non-git directory as the main checkout.
+#
+# Extracted from worktree-docker.sh's resolve_container_name so that script
+# holds exactly ONE copy of the test (SMI-5626 precedent: two copies of one
+# derivation drifted apart). Lives here, not locally, because _lib.sh already
+# owns every other worktree derivation helper -- and because the same idiom is
+# independently reimplemented in six OTHER places (hook-docker-detect.sh:137,
+# check-dist-fresh.sh:71, check-node-modules-fresh.sh:124, .husky/post-merge:26,
+# regen-lockfile.sh:75, dependabot-regenerate-lockfile.sh:94), two of them
+# POSIX `sh` hooks that cannot source this file. Consolidating those is a
+# separate refactor; this at least gives it a destination.
+#
+# Arguments:
+#   $1 - Path to a checkout or worktree
+# Returns:
+#   0 if $1 is the main checkout; 1 otherwise (including non-git paths)
+#######################################
+is_main_checkout() {
+    local path="$1" gcd gd
+    gcd=$(git -C "$path" rev-parse --git-common-dir 2>/dev/null)
+    gd=$(git -C "$path" rev-parse --git-dir 2>/dev/null)
+    [[ -n "$gcd" && "$gcd" == "$gd" ]]
+}
+
+#######################################
+# Refuse a worktree-only subcommand pointed at the MAIN checkout (SMI-5836).
+#
+# `start` and `generate` both WRITE a worktree-shaped
+# docker-compose.override.yml for whatever path they are given (cmd_start
+# auto-generates one when missing, worktree-docker.sh:184-189). Applied to
+# the main checkout that file overrides the base compose file's
+# `container_name: skillsmith-dev-1` (docker-compose.yml:14) with
+# `main-dev-1` (_lib.sh:1507), moves the documented 3001 publish to a
+# bucketed pair (3070/3071 for branch `main`), and on macOS bind-mounts
+# main's own node_modules READ-ONLY over /app/node_modules (_lib.sh:703-704),
+# replacing the base named volume at docker-compose.yml:26 -- so
+# `docker exec skillsmith-dev-1 npm install` afterwards fails EROFS against
+# a container that no longer exists under that name. Nothing undoes it: the
+# file is gitignored (.gitignore:190) and repair_worktrees_compose_override
+# skips the repo root (_lib.sh:1611).
+#
+# Hard error rather than degrading to a base-file-only `up`: `start .` from
+# main is a location mistake (docker-guide.md:137 documents that exact form
+# "from inside the worktree"), so quietly starting MAIN's container would
+# report success while the container the user actually wanted never came up --
+# the invisible-success class SMI-5559/SMI-5570 already fixed twice for
+# `docker exec`. Neither subcommand has any programmatic caller in the repo
+# (hook-docker-detect.sh:157 uses `resolve`), so this cannot break CI, hooks
+# or npm scripts. Full rationale:
+# docs/internal/implementation/smi-5836-worktree-docker-start-main-guard.md
+#
+# Lives here alongside is_main_checkout, not in worktree-docker.sh (SMI-5836
+# plan-review Critical #2): that script has only ~12 lines of headroom under
+# the 500-line check-file-length.mjs hard limit and is not grandfathered in
+# check-file-length.ignore, while _lib.sh already is (SMI-5660). Calls
+# error(), defined identically here (_lib.sh:92-95) and in worktree-docker.sh
+# (:83-86); which copy actually runs is inert since both are functionally
+# identical.
+#
+# Arguments:
+#   $1 - Subcommand name, for the message
+#   $2 - Path to check (no-op unless it is the main checkout)
+#######################################
+refuse_if_main_checkout() {
+    local subcommand="$1" path="$2" stray=""
+
+    is_main_checkout "$path" || return 0
+
+    if [[ -f "$path/docker-compose.override.yml" ]]; then
+        stray="
+
+Also, a stray override already exists here:
+  rm $path/docker-compose.override.yml
+Nothing regenerates or removes it automatically, so it keeps overriding this
+checkout's container name, ports and node_modules mount until you delete it."
+    fi
+
+    error "'$subcommand' is for linked worktrees, but $path is the MAIN checkout (SMI-5836).
+
+The base docker-compose.yml already provisions the main checkout completely:
+container skillsmith-dev-1 on host port 3001. A worktree override here renames
+that container, moves its ports, and (on macOS) remounts its node_modules
+read-only.
+
+If you meant the main checkout:
+  cd $path && docker compose --profile dev up -d
+
+If you meant a worktree ('$subcommand .' only works from INSIDE one):
+  $(basename "$0") $subcommand .worktrees/<name>
+  ./scripts/create-worktree.sh <branch>   # if it does not exist yet$stray"
+}
+
+#######################################
 # Enumerate host ports already claimed by SIBLING worktrees' override files,
 # excluding the main repo and the worktree being resolved itself (half of the
 # self-collision-avoidance fix — see _resolve_worktree_port_offset for the

--- a/scripts/tests/worktree-docker-resolve.test.sh
+++ b/scripts/tests/worktree-docker-resolve.test.sh
@@ -2,6 +2,12 @@
 # SMI-5570/SMI-5074: Unit tests for worktree-docker.sh's `resolve` subcommand
 # and its shared resolve_container_name() helper.
 #
+# SMI-5836: also covers refuse_if_main_checkout()/is_main_checkout() (now in
+# _lib.sh) via `start`/`generate` against the same $SUPER main-checkout
+# fixture -- this file already builds exactly the fixture the guard needs
+# (a real main checkout plus a real linked worktree), so tests 6-7 extend it
+# rather than adding a new file.
+#
 # Covers:
 #   1. Main checkout resolves to "skillsmith-dev-1" / "main checkout".
 #   2. A worktree with a docker-compose.override.yml resolves the
@@ -16,6 +22,11 @@
 #   5. `resolve` exits 0 when the resolved container is running, 1 when not
 #      (verified via `docker ps` filtering — no real container needed
 #      since we assert on the exit code / stdout only, not run_cmd).
+#   6. `start` against the MAIN checkout hard-refuses (SMI-5836, AC-1/AC-3):
+#      non-zero exit, message names "MAIN checkout" and "SMI-5836", no
+#      override file written, and `docker` is never invoked at all.
+#   7. `generate` against the MAIN checkout behaves identically (AC-2/AC-3),
+#      independently of `start`.
 
 set -uo pipefail
 
@@ -32,6 +43,20 @@ assert_eq() {
     pass=$((pass + 1))
   else
     echo "FAIL $name: expected='$expected' actual='$actual'"
+    fail=$((fail + 1))
+  fi
+}
+
+# SMI-5836: needed for the free-text main-checkout refusal message below --
+# assert_eq alone can only test "message equals X", not "message contains X".
+assert_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo "PASS $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL $name: '$needle' not in output"
+    echo "  Haystack: $haystack"
     fail=$((fail + 1))
   fi
 }
@@ -106,6 +131,67 @@ assert_eq "test4: source label flags the fallback" "worktree branch (recomputed 
 bash "$WORKTREE_DOCKER" resolve "$WT" >/dev/null 2>&1
 EXIT5=$?
 assert_eq "test5: exit 1 when the resolved container isn't actually running" "1" "$EXIT5"
+
+# -----------------------------------------------------------------------
+# Docker shim (SMI-5836): PATH-shadows `docker`, appending its argv to
+# DOCKER_SHIM_LOG. Tests 6-7 assert this log stays EMPTY -- the
+# main-checkout refusal must fire before docker is invoked AT ALL (AC-3),
+# not merely before `up -d`.
+# -----------------------------------------------------------------------
+DOCKER_SHIM_BIN="$SANDBOX/shim-bin"
+mkdir -p "$DOCKER_SHIM_BIN"
+cat > "$DOCKER_SHIM_BIN/docker" << 'SHIM'
+#!/bin/sh
+echo "$*" >> "$DOCKER_SHIM_LOG"
+exit 0
+SHIM
+chmod +x "$DOCKER_SHIM_BIN/docker"
+DOCKER_SHIM_LOG="$SANDBOX/docker-shim.log"
+
+# Stub docker-compose.yml in $SUPER so the refusal below cannot be
+# attributed to the missing-file precondition (worktree-docker.sh's
+# `No docker-compose.yml found` check) rather than the main-checkout guard.
+printf 'services: {}\n' > "$SUPER/docker-compose.yml"
+
+# -----------------------------------------------------------------------
+# Test 6 (SMI-5836, AC-1/AC-3): `start` against the MAIN checkout
+# hard-refuses before any side effect.
+# -----------------------------------------------------------------------
+: > "$DOCKER_SHIM_LOG"
+OUT6=$(DOCKER_SHIM_LOG="$DOCKER_SHIM_LOG" PATH="$DOCKER_SHIM_BIN:$PATH" \
+  bash "$WORKTREE_DOCKER" start "$SUPER" 2>&1)
+RC6=$?
+assert_eq "test6: start against main checkout exits non-zero" "1" "$RC6"
+assert_contains "test6: refusal names the MAIN checkout" "MAIN checkout" "$OUT6"
+assert_contains "test6: refusal names SMI-5836" "SMI-5836" "$OUT6"
+if [ -f "$SUPER/docker-compose.override.yml" ]; then
+  echo "FAIL test6: override file was written despite the refusal (AC-3)"
+  fail=$((fail + 1))
+else
+  echo "PASS test6: no override file written (AC-3)"
+  pass=$((pass + 1))
+fi
+assert_eq "test6: docker was never invoked (AC-3)" "" "$(cat "$DOCKER_SHIM_LOG")"
+
+# -----------------------------------------------------------------------
+# Test 7 (SMI-5836, AC-2/AC-3): `generate` against the MAIN checkout
+# behaves identically, independently of `start`.
+# -----------------------------------------------------------------------
+: > "$DOCKER_SHIM_LOG"
+OUT7=$(DOCKER_SHIM_LOG="$DOCKER_SHIM_LOG" PATH="$DOCKER_SHIM_BIN:$PATH" \
+  bash "$WORKTREE_DOCKER" generate "$SUPER" 2>&1)
+RC7=$?
+assert_eq "test7: generate against main checkout exits non-zero" "1" "$RC7"
+assert_contains "test7: refusal names the MAIN checkout" "MAIN checkout" "$OUT7"
+assert_contains "test7: refusal names SMI-5836" "SMI-5836" "$OUT7"
+if [ -f "$SUPER/docker-compose.override.yml" ]; then
+  echo "FAIL test7: override file was written despite the refusal (AC-2/AC-3)"
+  fail=$((fail + 1))
+else
+  echo "PASS test7: no override file written (AC-2/AC-3)"
+  pass=$((pass + 1))
+fi
+assert_eq "test7: docker was never invoked (AC-3)" "" "$(cat "$DOCKER_SHIM_LOG")"
 
 # -----------------------------------------------------------------------
 # Summary

--- a/scripts/worktree-docker.sh
+++ b/scripts/worktree-docker.sh
@@ -75,6 +75,11 @@ Note:
   This script ensures each worktree has unique container names and ports
   to allow parallel Docker development across multiple worktrees.
 
+  start and generate REFUSE the main checkout (SMI-5836): the base
+  docker-compose.yml already provisions it, and writing a worktree override
+  there renames skillsmith-dev-1 and moves its ports. In the main checkout
+  run docker compose --profile dev up -d instead.
+
 EOF
 }
 
@@ -133,6 +138,14 @@ get_worktree_name() {
 cmd_generate() {
     local worktree_path="$1"
 
+    # SMI-5836: refuse before ANY side effect. Guarded here as well as in
+    # cmd_start because `generate` is the command that actually writes the
+    # file, and alone it is the worse of the two -- it leaves a gitignored,
+    # worktree-shaped override behind with no `up` in the same invocation to
+    # make the consequence visible, so the main checkout's NEXT plain
+    # `docker compose --profile dev up -d` silently picks it up.
+    refuse_if_main_checkout "generate" "$worktree_path"
+
     if [[ ! -f "$worktree_path/docker-compose.yml" ]]; then
         error "No docker-compose.yml found in $worktree_path"
     fi
@@ -176,6 +189,13 @@ cmd_generate() {
 #######################################
 cmd_start() {
     local worktree_path="$1"
+
+    # SMI-5836: refuse before the auto-generate block below, which writes a
+    # worktree-shaped override for whatever path it is given. Checked before
+    # the docker-compose.yml precondition because the target's IDENTITY is
+    # prior to its contents -- "No docker-compose.yml found in <main>" would
+    # send the user after the wrong thing.
+    refuse_if_main_checkout "start" "$worktree_path"
 
     if [[ ! -f "$worktree_path/docker-compose.yml" ]]; then
         error "No docker-compose.yml found in $worktree_path"
@@ -272,11 +292,12 @@ resolve_container_name() {
         error "Not a git checkout: $worktree_path"
     fi
 
-    local gcd gd container_name resolved_from
-    gcd=$(git -C "$worktree_path" rev-parse --git-common-dir 2>/dev/null)
-    gd=$(git -C "$worktree_path" rev-parse --git-dir 2>/dev/null)
+    local container_name resolved_from
 
-    if [[ -n "$gcd" && "$gcd" == "$gd" ]]; then
+    # SMI-5836: the main-checkout test now lives in _lib.sh's
+    # is_main_checkout, shared with refuse_if_main_checkout in _lib.sh so
+    # this script carries one copy rather than two.
+    if is_main_checkout "$worktree_path"; then
         # Main checkout (git-common-dir == git-dir, i.e. not a linked
         # worktree) — container name is the hardcoded base-compose name,
         # never a derived slug.


### PR DESCRIPTION
## Summary

**Breaking change to a previously-documented command form** — flagging explicitly per plan-review (see below).

`scripts/worktree-docker.sh`'s `cmd_start` auto-generates a worktree-shaped `docker-compose.override.yml` for whatever path it is pointed at and then runs `docker compose --profile dev up -d`. Neither `cmd_start` nor `cmd_generate` ever checked whether that path was a **linked worktree** or the **main checkout**. Running `./scripts/worktree-docker.sh start .` from the main checkout — the exact form `.claude/development/docker-guide.md:137` documented, annotated "from inside the worktree" — silently:

1. Renamed main's long-lived container (`skillsmith-dev-1` → `main-dev-1`)
2. Moved its published port off the documented `3001` to a bucketed pair
3. On macOS, remounted main's own `node_modules` **read-only** over `/app/node_modules`, replacing the base named volume

Nothing ever cleaned the resulting file up — it's gitignored and `repair_worktrees_compose_override` explicitly skips the repo root. This was found and explicitly deferred during SMI-4298.

## Changes

- **`scripts/_lib.sh`**: adds `is_main_checkout()` and `refuse_if_main_checkout()`. Both live here (not in `worktree-docker.sh`) because that script has only ~39 lines of headroom under the 500-line `check-file-length.mjs` hard limit and is not grandfathered, while `_lib.sh` already is (SMI-5660).
- **`scripts/worktree-docker.sh`**:
  - `cmd_generate` and `cmd_start` both call `refuse_if_main_checkout` as their first statement, before any `docker-compose.yml` precondition or side effect.
  - `resolve_container_name` refactored onto the same `is_main_checkout()` helper, so the script carries exactly one copy of the `--git-common-dir`-vs-`--git-dir` test instead of two.
  - `usage()`'s `Note:` block documents the refusal.
- **`scripts/tests/worktree-docker-resolve.test.sh`**: adds an `assert_contains` helper, a `docker` PATH shim, and tests 6-7 covering the refusal (non-zero exit, message names "MAIN checkout" and "SMI-5836", no override file written, `docker` never invoked).
- **`.claude/development/docker-guide.md`**: annotates the `start .` example with the main-checkout refusal.
- **`docs/internal/process/guards-and-opt-outs.md`** (submodule, separate PR): registers this guard — see smith-horn/skillsmith-docs#543.

No opt-out env var — writing a worktree-shaped override into the main checkout has no legitimate use case.

Full RCA, spec, and plan-review record: `docs/internal/implementation/smi-5836-worktree-docker-start-main-guard.md` (smith-horn/skillsmith-docs#542).

## Why a hard error

`start`/`generate` have zero programmatic callers in the repo (only `hook-docker-detect.sh` invokes `resolve`, never `start`/`generate`), so this cannot break CI, hooks, or npm scripts. `stop`/`status`/`ports`/`exec`/`resolve` are unaffected — either harmless against main or already main-aware.

## Test plan

- [x] `bash scripts/tests/worktree-docker-resolve.test.sh` — 18/18 pass (including new T6/T7)
- [x] `bash scripts/tests/worktree-dev-port.test.sh` — 30/30 pass (Group E skipped, no nested docker daemon)
- [x] `bash scripts/tests/worktree-port-collision.test.sh` — 22/22 pass
- [x] `bash scripts/tests/regen-worktree-overrides.test.sh` — skipped (macOS-only, container is Linux)
- [x] `npx vitest run scripts/tests/repair-worktrees-docker-guard.test.ts` — 7/7 pass
- [x] `shellcheck -S warning scripts/_lib.sh scripts/worktree-docker.sh scripts/tests/worktree-docker-resolve.test.sh` — clean
- [x] `bash -n` on the same three files — clean
- [x] `node scripts/check-file-length.mjs scripts/worktree-docker.sh scripts/_lib.sh` — `worktree-docker.sh` 461 lines (under 500, not grandfathered); `_lib.sh` 1804 lines (grandfathered, SMI-5660)
- [x] Manual: `is_main_checkout` verified live against the real main checkout and this worktree (correctly discriminates both)
- [x] Manual negative control: `resolve`/`status`/`ports` against the real main checkout are unaffected (`resolve` still returns `skillsmith-dev-1`/"main checkout"; no override file exists)
- [x] Manual positive control: `start`/`generate`/`resolve`/`status` against this worktree still work end-to-end (AC-6)
- [x] Full pre-push suite passed on push (security tests, npm audit, format, test check)

Refs SMI-5836