### PR TITLE
chore(release): weekly cadence bump — 2026-07-26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35628,7 +35628,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
@@ -35659,8 +35659,8 @@
         "sklx": "dist/cli.js"
       },
       "devDependencies": {
-        "@skillsmith/core": "^0.11.3",
-        "@skillsmith/mcp-server": "^0.7.5",
+        "@skillsmith/core": "^0.11.4",
+        "@skillsmith/mcp-server": "^0.7.6",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
         "vitest": "4.1.10"
@@ -35669,7 +35669,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@smith-horn/enterprise": "^0.3.3"
+        "@smith-horn/enterprise": "^0.3.4"
       },
       "peerDependenciesMeta": {
         "@smith-horn/enterprise": {
@@ -35965,7 +35965,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -36287,18 +36287,18 @@
     },
     "packages/enterprise": {
       "name": "@smith-horn/enterprise",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1090.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.75.0",
-        "@skillsmith/core": "^0.11.3",
+        "@skillsmith/core": "^0.11.4",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.7.5",
+        "@skillsmith/mcp-server": "^0.7.6",
         "@smithy/config-resolver": "4.6.10",
         "@smithy/core": "3.29.5",
         "@smithy/middleware-endpoint": "4.6.10",
@@ -36313,7 +36313,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.7.5"
+        "@skillsmith/mcp-server": "^0.7.6"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -36376,12 +36376,12 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "Elastic-2.0",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "10.1.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.11.3",
+        "@skillsmith/core": "^0.11.4",
         "ajv-formats-draft2019": "1.6.1",
         "ulid": "3.0.1",
         "zod": "3.25.76"
@@ -36633,7 +36633,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.8.4
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.8.3).
 - **Fix**: `sklx logs --tail` now watches the doc-retrieval reindex CLI's structured log surface — added `'doc-retrieval'` to `commands/logs.ts`'s `TAIL_SURFACES` array (SMI-5793)
 
 ## v0.8.3

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "CLI tools for Skillsmith skill discovery and authentication",
   "type": "module",
   "bin": {
@@ -39,14 +39,14 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@skillsmith/core": "^0.11.3",
-    "@skillsmith/mcp-server": "^0.7.5",
+    "@skillsmith/core": "^0.11.4",
+    "@skillsmith/mcp-server": "^0.7.6",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@smith-horn/enterprise": "^0.3.3"
+    "@smith-horn/enterprise": "^0.3.4"
   },
   "peerDependenciesMeta": {
     "@smith-horn/enterprise": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.11.4
+
 - **Fix**: `PRIVILEGE_ESCALATION_PATTERNS` (`security/scanner/patterns.ts`) gains two new contextual entries detecting credential/auth-level substitution used to defeat an auth check (e.g. "use the service_role key instead of your admin JWT to bypass the 403") — closes a double-miss where this exact phrasing, grammatical and lexically benign, slipped past both the internal SecurityScanner and AIDefence during a real staged-payload hardening pass (SMI-5833)
 - **Fix**: `checkForModifications()` (`services/skill-installation.io.ts`) now tolerates up to 2 seconds of clock skew between a skill's `installDate` and its on-disk mtime, instead of a strict `mtime > installDate` comparison — closes a race where `install()`'s `writeInstallFiles()` timestamp and its later `installedAt` capture could disagree by a few milliseconds under load, causing `uninstall()` to spuriously report the skill as locally modified and fail (SMI-5828)
 - **Feature**: `sha256Hex` (`journal/hash.ts`) exposed from the package root — one shared content-hash implementation for every `content_hash` computation (public inventory, private registry) instead of independent inline `createHash('sha256')` copies that could silently drift. `sync/inventory-collector.ts` switched to it (SMI-5816)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Core types and utilities for Skillsmith",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.11.3'
+export const VERSION = '0.11.4'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+## v0.3.4
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.3.3).
+
 ## v0.3.3
 
 - **Chore**: bump @aws-sdk/client-cloudwatch-logs (#1858)

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smith-horn/enterprise",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Enterprise features for Skillsmith including audit logging, SSO, and RBAC",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1090.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.75.0",
-    "@skillsmith/core": "^0.11.3",
+    "@skillsmith/core": "^0.11.4",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.7.5",
+    "@skillsmith/mcp-server": "^0.7.6",
     "@smithy/config-resolver": "4.6.10",
     "@smithy/core": "3.29.5",
     "@smithy/middleware-endpoint": "4.6.10",
@@ -62,7 +62,7 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.7.5"
+    "@skillsmith/mcp-server": "^0.7.6"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.7.6
+
 - **Feature**: `private_registry_manage`/`private_registry_publish` (`tools/registry-tools.live.ts`) — real, live implementation of the private skill registry backed by Supabase's `private_registry_skills` table, replacing the stub. Publish computes `content_hash` via `@skillsmith/core`'s shared `sha256Hex`, enforces (team, skill, version) immutability, and scopes list/get to the resolved team; deprecate/undeprecate correctly request a PostgREST representation via `.select()` so affected-row data is actually returned instead of always reporting "not found" (SMI-5816)
 - **Fix**: added process-wide `uncaughtException`/`unhandledRejection` handlers — previously, any unhandled error anywhere in the running server (not just at startup) crashed the process with only a stderr stack trace, visible solely in the MCP host's live `/mcp` panel and never persisted. Both handlers now log via the existing structured logger (disk record + stderr mirror) before exiting, matching the crash-vs-continue behavior Node already had by default (SMI-5787)
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "MCP server for Skillsmith skill discovery",
   "type": "module",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@cyclonedx/cyclonedx-library": "10.1.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.11.3",
+    "@skillsmith/core": "^0.11.4",
     "ajv-formats-draft2019": "1.6.1",
     "ulid": "3.0.1",
     "zod": "3.25.76"

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.7.5",
+  "version": "0.7.6",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": [
@@ -23,7 +23,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -115,7 +115,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.7.5'
+const PACKAGE_VERSION = '0.7.6'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 const logger = createLogger('mcp', { version: PACKAGE_VERSION }) // SMI-5615
 import { installBundledSkills, installUserDocs } from './onboarding/install-assets.js'

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## v0.7.4
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.7.3).
+
 ## v0.7.3
 
 - **Chore**: bump @wdio/mocha-framework from 9.29.0 to 9.29.1 (#1866)

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Discover and install agent skills directly in VS Code",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
Automated weekly release cadence PR opened by `release-cadence.yml` (SMI-4191).

## What this PR does

Runs `scripts/prepare-release.ts --all=patch` to bump all packages by one patch version and drain per-package CHANGELOG `[Unreleased]` sections into the new versions.

## What to check before merging

1. The bumped versions match what you want to ship (patch/minor/major). If minor or major is needed, close this PR, run `prepare-release.ts` with the right flags locally, and open a manual PR.
2. The CHANGELOG entries read cleanly and reference the right Linear issues.
3. CI is green.

## After merging

Trigger publish: `gh workflow run publish.yml -f dry_run=false`. The `create-gh-release` job will create matching GitHub Releases automatically.

Parent: SMI-4144. See [ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md).