### PR TITLE
fix(agents): reduce plan-review-specialist.md to a thin dispatcher (SMI-5840)

### DIFF
--- a/.claude/agents/plan-review-specialist.md
+++ b/.claude/agents/plan-review-specialist.md
@@ -1,63 +1,25 @@
 ---
 name: plan-review-specialist
 description: Multi-perspective plan review specialist that coordinates VP Product, VP Engineering, and VP Design perspectives to identify blockers, anti-patterns, conflicts, and regressions. Use when reviewing implementation plans, design docs, or wave plans.
-skills: plan-review
-tools: Read, Write, Edit, Grep, Glob, Task, AskUserQuestion
+skills: plan-review-skill
+tools: Read, Task
 model: sonnet
 ---
 
 # Plan Review Specialist
 
+Thin dispatcher. All review logic — the VP Product / VP Engineering / VP Design perspectives, the full P-1...P-6 rubric, issue consolidation, and the approval workflow — lives in the `plan-review-skill`'s `agent-prompt.md`. This file exists only to forward to it, so there is exactly one source of truth for plan-review logic.
+
 ## Operating Protocol
 
-Execute multi-perspective plan reviews through coordinated VP analysis:
+When invoked, **immediately**:
 
-1. **Accept plan input** - Read the plan file or content provided
-2. **Spawn VP agents** - Launch Product, Engineering, Design reviewers in parallel
-3. **Consolidate findings** - Merge, deduplicate, and rank all issues
-4. **Present to user** - Show ALL issues with trade-offs and recommendations
-5. **Request approval** - Use AskUserQuestion for change decisions
-6. **Apply changes** - On approval, edit plan with itemized modifications
+1. Read `agent-prompt.md`'s full content from the `plan-review-skill` skill directory — prefer the project install if present, fall back to the user install only if it's absent, and error clearly if neither exists:
+   - Project install: `.claude/skills/plan-review-skill/agent-prompt.md`
+   - User install: `~/.claude/skills/plan-review-skill/agent-prompt.md`
+2. Build the Task prompt by prepending a clearly delimited invocation-context block — the caller's request, the plan file path or content, and the current working directory — to the agent-prompt.md content, which follows **verbatim** and unmodified
+3. Spawn a single **foreground** Task with `subagent_type: "general-purpose"` using that combined prompt (foreground is required: the subagent's workflow uses `AskUserQuestion` for approval, which a background execution would auto-deny)
+4. Wait for the subagent to complete
+5. Return the subagent's summary as your own output
 
-## VP Perspective Prompts
-
-### VP Product
-Evaluate: user value, scope creep, dependencies, timeline feasibility, missing requirements.
-Output: Issues with severity, category, description, recommendation.
-
-### VP Engineering
-Evaluate: technical debt, anti-patterns, architecture conflicts, regressions, security, performance.
-Output: Issues with severity, category, description, recommendation.
-
-### VP Design
-Evaluate: UX consistency, accessibility, design system alignment, user flow clarity.
-Output: Issues with severity, category, description, recommendation.
-
-## Output Format
-
-When delegated a plan review task, return:
-
-- **Plan**: [file path or identifier]
-- **Issues Found**: [total count by severity]
-- **Critical Issues**: [list with trade-offs]
-- **All Issues Table**: [ranked list with <240 char descriptions]
-- **Recommendation**: [suggested action]
-- **Approval Status**: [pending/approved/rejected]
-
-Keep response under 1000 tokens unless full issue details requested.
-
-## Severity Classification
-
-| Severity | Criteria |
-|----------|----------|
-| Critical | Blocks execution, security risk, data loss |
-| High | Major impact, breaks existing functionality |
-| Medium | Quality concern, technical debt |
-| Low | Minor improvement, nice-to-have |
-
-## Issue Categories
-
-- **Blocker**: Prevents plan from proceeding
-- **Anti-pattern**: Causes long-term problems
-- **Conflict**: Clashes with existing work
-- **Regression**: May break existing functionality
+Do NOT execute the review yourself and do NOT embed any part of the VP rubric, severity classification, or output format in this file — always read `agent-prompt.md` fresh so this dispatcher can never drift out of sync with the skill's actual logic. This mirrors the thin-dispatcher pattern already used by `plan-review-skill/SKILL.md` itself.


### PR DESCRIPTION
## Business Summary

**What shipped:** `.claude/agents/plan-review-specialist.md` no longer carries its own stale copy of the plan-review rubric — it now reads the real, actively-maintained rubric (`plan-review-skill/agent-prompt.md`, v1.4.0) fresh on every invocation and forwards it to a subagent, instead of running an out-of-date VP Product/Engineering/Design checklist that was missing the entire P-1 through P-6 rubric added since it was written.

**Quality bar:** Confirmed via repo-wide grep that nothing in the codebase spawns `plan-review-specialist` as an agent type today, so this change is behavior-safe. Cross-provider reviewed by GPT-5.6-Sol (NEEDLE dispatch), which caught a real ambiguity (the rewrite's first draft said to pass the rubric "verbatim" while also injecting caller context — contradictory) plus a stale frontmatter field and a missing foreground-execution note; all four addressed before this PR.

**Net result:** Done, no follow-up. This was one of three small follow-ups filed during SMI-5832's plan-review pass; the other two (SMI-5841, SMI-5845) are separate PRs.

---

## Technical detail

- `.claude/agents/plan-review-specialist.md`: 63 lines → 27 lines. Dropped the embedded VP rubric, severity table, and output-format spec entirely. New body instructs the agent to read `agent-prompt.md` (project install preferred, user install fallback, error if neither exists), prepend an invocation-context block (caller's request, plan path, cwd), and forward the combined prompt to a **foreground** `general-purpose` Task — mirroring the dispatch pattern `plan-review-skill/SKILL.md` already uses.
- Frontmatter: `tools` narrowed to `Read, Task` (just enough to read-and-forward); `skills: plan-review` → `skills: plan-review-skill` (was referencing a non-existent directory — the real folder is `plan-review-skill`).
- No other files touched. `npm run typecheck`/`format:check`/lint all pass; `preflight-check.ts`'s dependency scan reports 3 pre-existing missing-dependency findings (`@isaacs/keytar`, `async_hooks`, `@wdio/globals`) that are unrelated to this change and reproduce identically on `main`'s own container.

[skip-impl-check] — this PR only edits `.claude/agents/plan-review-specialist.md`, a docs/config agent-definition file, not application source code; correctly classified as docs/config-only by the implementation-completeness check.
