### PR TITLE
fix(core,cli): resolve stray duplicate CHANGELOG [Unreleased] headings; tighten Check 43 (SMI-5845)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -121,6 +121,11 @@ All notable changes to `@skillsmith/cli` are documented here.
 ## v0.5.7
 
 - **Refactor**: initSkill throws InitSkillError instead of process.exit (SMI-4314) (#642)
+- **Fix**: `skillsmith author init` now reports a friendly error and cleans up
+  partial output when a file operation fails. When an init is run against a
+  pre-existing directory that the user confirms to overwrite, the existing
+  directory is preserved on mid-scaffold failure instead of being removed
+  (SMI-4289, closes #602).
 
 ## v0.5.6
 
@@ -129,14 +134,6 @@ All notable changes to `@skillsmith/cli` are documented here.
 ## v0.5.5
 
 - **Other**: SMI-4190: release cadence docs — ADR-114 + CHANGELOG backfill + CONTRIBUTING (#552)
-
-## [Unreleased]
-
-- **Fix**: `skillsmith author init` now reports a friendly error and cleans up
-  partial output when a file operation fails. When an init is run against a
-  pre-existing directory that the user confirms to overwrite, the existing
-  directory is preserved on mid-scaffold failure instead of being removed
-  (SMI-4289, closes #602).
 
 ## v0.5.4
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -148,7 +148,10 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## v0.5.4
 
-- **Fix**: rename webhook-dlq /retry → /resolve with migration 077 (SMI-4308) (#647)
+- **Feature**: Webhook dead-letter queue — new `WebhookDeadLetterRepository`, optional `deadLetterSink` on `WebhookQueueOptions`, and `webhook-dlq` authenticated edge function (SMI-4291, closes GitHub #601)
+- **Fix**: `WebhookDeadLetterRepository` gains `markResolved(id, resolvedBy?)` for operator acknowledgement and renames `listUnretried` → `listOpen` (the in-process filter now excludes both retried and resolved rows); `listUnretried` kept as a deprecated alias, removed when SMI-4322's delivery worker lands; repository types add `resolved_at` / `resolved_by` matching migration 077; `markRetried` unchanged — dormant until SMI-4322 (SMI-4308) (#647)
+- **Fix**: RLS recursion on `teams` and `team_members` that caused 500s on `/account/team*` pages once any user had a membership row — migration 072 rewrites the two legacy policies to call SECURITY DEFINER helpers (SMI-4306)
+- **Feature**: tree-sitter incremental parsing for Python analyzer — WASM-backed (`web-tree-sitter@0.25.10`), LRU tree cache (100 entries), query-based extraction replaces regex fallback; unchanged file re-parse ~0ms (memoised), incremental edit ~60ms on 1955-line fixture (well under 100ms target), ~27,000× speedup on cache hits vs cold parse; regression guard ensures query extraction matches or exceeds prior regex coverage on all fixtures (SMI-4293, PR #633, closes #604)
 - **Feature**: team provisioning on subscription (SMI-4307) (#646)
 - **Fix**: populate UndoSnapshot.backup_path in ActivationManager (SMI-4297) (#644)
 
@@ -161,17 +164,10 @@ All notable changes to `@skillsmith/core` are documented here.
 - **Fix**: restore category/security/repo in skill detail view (SMI-4240) (#583)
 - **Other**: SMI-4190: release cadence docs — ADR-114 + CHANGELOG backfill + CONTRIBUTING (#552)
 
-## [Unreleased]
-
-- **SMI-4308**: `WebhookDeadLetterRepository` gains `markResolved(id, resolvedBy?)` for operator acknowledgement and renames `listUnretried` → `listOpen` (the in-process filter now excludes both retried and resolved rows). `listUnretried` kept as a deprecated alias; removed when SMI-4322's delivery worker lands. Repository types add `resolved_at` / `resolved_by` matching migration 077. `markRetried` unchanged — dormant until SMI-4322.
-- **SMI-4306**: Fix RLS recursion on `teams` and `team_members` that caused 500s on `/account/team*` pages once any user had a membership row. Migration 072 rewrites the two legacy policies to call SECURITY DEFINER helpers.
-- **SMI-4293**: tree-sitter incremental parsing for Python analyzer — WASM-backed (`web-tree-sitter@0.25.10`), LRU tree cache (100 entries), query-based extraction replaces regex fallback. Unchanged file re-parse ~0ms (memoised); incremental edit ~60ms on 1955-line fixture (well under 100ms target); ~27,000× speedup on cache hits vs cold parse. Regression guard ensures query extraction matches or exceeds prior regex coverage on all fixtures (PR #633, closes #604).
-- **SMI-4291**: Webhook dead-letter queue — new `WebhookDeadLetterRepository`, optional `deadLetterSink` on `WebhookQueueOptions`, and `webhook-dlq` authenticated edge function. Closes GitHub #601.
-- **SMI-4124**: `skill_pack_audit` trigger-quality + namespace collision checks (PR #505).
-
 ## v0.5.1
 
 - **Fix**: SMI-4182 suppress CodeQL false positive on telemetry hash (#550 retro).
+- **Feature**: `skill_pack_audit` trigger-quality + namespace collision checks (SMI-4124, PR #505)
 
 ## v0.4.18
 

--- a/scripts/audit-standards-helpers.mjs
+++ b/scripts/audit-standards-helpers.mjs
@@ -1959,6 +1959,35 @@ export function countUnreleasedEntries(changelogContent) {
 }
 
 /**
+ * Find every `## [Unreleased]` heading in a CHANGELOG, in document order.
+ *
+ * A CHANGELOG should have exactly one `[Unreleased]` heading (matching the
+ * same case-insensitive, optional-brackets pattern `countUnreleasedEntries`
+ * uses: `## [Unreleased]`, `## Unreleased`, etc). A second, later one is
+ * invisible to Check 43's placement check (SMI-4776) — that check only ever
+ * compares the FIRST `[Unreleased]` heading's position against the first
+ * version heading, so a stray duplicate further down silently passes
+ * (SMI-5845: `packages/core/CHANGELOG.md` and `packages/cli/CHANGELOG.md`
+ * both carried one for months, undetected, because the check's own logic
+ * had no assertion that exactly one such heading exists).
+ *
+ * @param {string} changelogContent - Full CHANGELOG.md contents.
+ * @returns {number[]} 1-indexed line numbers of every `[Unreleased]` heading
+ *   found, in document order. Length 0 means no such heading exists; length
+ *   1 is the healthy case; length >= 2 means duplicates exist (Check 43 in
+ *   audit-standards.mjs decides how to report this).
+ */
+export function findUnreleasedHeadingLines(changelogContent) {
+  if (typeof changelogContent !== 'string') return []
+  const lines = changelogContent.split('\n')
+  const found = []
+  lines.forEach((line, i) => {
+    if (/^## \[?Unreleased\]?\s*$/i.test(line.trim())) found.push(i + 1)
+  })
+  return found
+}
+
+/**
  * Detect a release-prep diff for one package (SMI-5680 C1 / Step 0).
  *
  * `prepare-release.ts --all=patch` bumps a package's `package.json` version

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -40,6 +40,7 @@ import {
   auditSecdefAnonGrants,
   findServerJsonFieldLengthViolations,
   countUnreleasedEntries,
+  findUnreleasedHeadingLines,
   isReleasePrepDiff,
   parseGitCryptEncryptedFiles,
   classifyGitCryptScanResult,
@@ -2983,6 +2984,7 @@ console.log(`\n${BOLD}43. CHANGELOG [Unreleased] Placement (SMI-4776)${RESET}`)
   ]
 
   let placementIssues = 0
+  let duplicateIssues = 0
   for (const { changelogPath, label } of targets) {
     if (!existsSync(changelogPath)) continue
 
@@ -3005,6 +3007,23 @@ console.log(`\n${BOLD}43. CHANGELOG [Unreleased] Placement (SMI-4776)${RESET}`)
 
     if (headings.length === 0) continue
 
+    // SMI-5845: assert exactly one `[Unreleased]` heading BEFORE the
+    // firstVersionIdx/-1 guard below — a CHANGELOG with only [Unreleased]
+    // headings and zero version headings (e.g. packages/doc-retrieval-mcp,
+    // packages/skillsmith-cli) has firstVersionIdx === -1 and would `continue`
+    // past this check entirely if it ran after that guard, exactly
+    // reproducing the SMI-5845 root cause (a duplicate heading invisible to
+    // the placement logic) for that file shape.
+    const unreleasedLines = findUnreleasedHeadingLines(content)
+    if (unreleasedLines.length > 1) {
+      duplicateIssues++
+      const [keepLine, ...dupeLines] = unreleasedLines
+      fail(
+        `${label}: found ${unreleasedLines.length} '## [Unreleased]' headings in ${changelogPath} (line ${keepLine}, plus duplicate(s) at line ${dupeLines.join(', ')}) — expected exactly one`,
+        `Merge the content under the duplicate '## [Unreleased]' heading(s) at ${changelogPath}:${dupeLines.join(', ')} into their real version sections (or into line ${keepLine} if genuinely unreleased), then delete the duplicate heading(s)`
+      )
+    }
+
     const firstUnreleasedIdx = headings.findIndex((h) => h.isUnreleased)
     const firstVersionIdx = headings.findIndex((h) => h.isVersion)
 
@@ -3024,8 +3043,10 @@ console.log(`\n${BOLD}43. CHANGELOG [Unreleased] Placement (SMI-4776)${RESET}`)
     }
   }
 
-  if (placementIssues === 0) {
-    pass('All CHANGELOGs have [Unreleased] before any versioned section')
+  if (placementIssues === 0 && duplicateIssues === 0) {
+    pass(
+      'No CHANGELOG has more than one [Unreleased] heading, and placement is correct where present'
+    )
   }
 }
 

--- a/scripts/tests/audit-standards-changelog-gate.test.ts
+++ b/scripts/tests/audit-standards-changelog-gate.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from 'vitest'
 
 const helpers = (await import('../audit-standards-helpers.mjs')) as {
   countUnreleasedEntries: (changelogContent: string) => number | null
+  findUnreleasedHeadingLines: (changelogContent: string) => number[]
   isReleasePrepDiff: (
     pkgJsonAtBase: string,
     pkgJsonAtHead: string,
@@ -25,7 +26,7 @@ const helpers = (await import('../audit-standards-helpers.mjs')) as {
   ) => boolean
 }
 
-const { countUnreleasedEntries, isReleasePrepDiff } = helpers
+const { countUnreleasedEntries, findUnreleasedHeadingLines, isReleasePrepDiff } = helpers
 
 // ---------------------------------------------------------------------------
 // countUnreleasedEntries
@@ -272,5 +273,81 @@ describe('isReleasePrepDiff (SMI-5680 C1 / Step 0)', () => {
         changelogHeadNoHeading
       )
     ).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// findUnreleasedHeadingLines (SMI-5845)
+// ---------------------------------------------------------------------------
+
+describe('findUnreleasedHeadingLines (SMI-5845)', () => {
+  it('single heading → array of length 1 with its 1-indexed line number', () => {
+    const changelog = [
+      '# Changelog',
+      '',
+      '## [Unreleased]',
+      '',
+      '- **Fix**: something',
+      '',
+      '## v0.11.1',
+    ].join('\n')
+    expect(findUnreleasedHeadingLines(changelog)).toEqual([3])
+  })
+
+  it('two headings → array of length 2, in document order (reproduces SMI-5845)', () => {
+    const changelog = [
+      '## [Unreleased]',
+      '',
+      '## v0.5.2',
+      '',
+      '- **Fix**: restore category/security/repo',
+      '',
+      '## [Unreleased]',
+      '',
+      '- **SMI-4308**: stray entry that actually shipped in a later release',
+      '',
+      '## v0.5.1',
+    ].join('\n')
+    expect(findUnreleasedHeadingLines(changelog)).toEqual([1, 7])
+  })
+
+  it('three headings → array of length 3', () => {
+    const changelog = [
+      '## [Unreleased]',
+      '## v1.0.0',
+      '## Unreleased',
+      '## v0.9.0',
+      '## [unreleased]',
+    ].join('\n')
+    expect(findUnreleasedHeadingLines(changelog)).toEqual([1, 3, 5])
+  })
+
+  it('no heading at all → empty array', () => {
+    const changelog = ['# Changelog', '', '## v1.0.0', '', '- **Fix**: something'].join('\n')
+    expect(findUnreleasedHeadingLines(changelog)).toEqual([])
+  })
+
+  it('zero version headings, single [Unreleased] → array of length 1 (doc-retrieval-mcp/skillsmith-cli shape)', () => {
+    const changelog = ['# Changelog', '', '## [Unreleased]', '', '- **Fix**: something'].join('\n')
+    expect(findUnreleasedHeadingLines(changelog)).toEqual([3])
+  })
+
+  it('zero version headings, two [Unreleased] headings → still detected as duplicates (the exact shape the Check 43 insertion-point fix defends against — the existing headings.findIndex((h) => h.isVersion) === -1 short-circuit must not skip this check)', () => {
+    const changelog = [
+      '# Changelog',
+      '',
+      '## [Unreleased]',
+      '',
+      '- **Fix**: something',
+      '',
+      '## [Unreleased]',
+      '',
+      '- **Fix**: something else, stray',
+    ].join('\n')
+    expect(findUnreleasedHeadingLines(changelog)).toEqual([3, 7])
+  })
+
+  it('non-string input → empty array', () => {
+    expect(findUnreleasedHeadingLines(undefined as unknown as string)).toEqual([])
   })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** `packages/core/CHANGELOG.md` and `packages/cli/CHANGELOG.md` each had a second, stray "Unreleased" section buried mid-file holding entries that had actually already shipped months ago — cross-referenced against git history and the public npm registry to find the real release each one belongs to, then moved them there. Also closed the gap that let this slip through undetected: the CI check that validates CHANGELOG structure only ever looked at the *first* "Unreleased" heading, so a second one anywhere else in the file was invisible to it — it now catches that too.

**Quality bar:** ADR-109 infra-change process followed (SPARC plan → plan-review skill → implementation) since this touches the standards-audit script. Plan review (VP Product/Engineering/Design) independently discovered the `packages/cli/CHANGELOG.md` had the identical bug — folded into this same PR. Cross-provider reviewed by GPT-5.6-Sol (NEEDLE), which caught an inaccurate pass-message and a test-coverage gap; both fixed. 6 new unit tests for the new detection logic; full `audit:standards`/typecheck/lint/format all pass.

**Found along the way:** none beyond what's already bundled above — the second duplicated CHANGELOG was found during this PR's own plan review, not left for later.

**Net result:** Fully shipped, no follow-up. One of three small follow-ups filed during SMI-5832's plan-review pass; SMI-5840 and SMI-5841 are separate PRs.

---

## Technical detail

**CHANGELOG fixes** (data correction, not code):
- `packages/core/CHANGELOG.md`: SMI-4124 → `## v0.5.1`; SMI-4308/4306/4293/4291 → `## v0.5.4` (SMI-4308 reconciled with an existing condensed duplicate already in v0.5.4 — kept the more detailed description, retained the PR reference). Determined via `git blame`/`git log` commit dates cross-referenced with `npm view @skillsmith/core time --json` publish timestamps.
- `packages/cli/CHANGELOG.md`: SMI-4289 → `## v0.5.7`, same method.

**Check 43 tightening** (`scripts/audit-standards.mjs`, "CHANGELOG [Unreleased] Placement", SMI-4776):
- New pure helper `findUnreleasedHeadingLines()` (`scripts/audit-standards-helpers.mjs`) returns every `[Unreleased]`-matching heading's line number.
- Check 43 now fails when more than one is found, checked *before* the existing `firstVersionIdx === -1` early-exit — required because `packages/doc-retrieval-mcp` and `packages/skillsmith-cli` both have zero version headings today, and placing the check after that guard would silently skip it for that file shape.
- `scripts/tests/audit-standards-changelog-gate.test.ts`: 7 new cases covering single/two/three headings, zero headings, the zero-version-headings shape (both with and without duplicates), and non-string input.

**Process record**: `docs/internal/implementation/smi-5845-check-43-duplicate-unreleased.md` (smith-horn/skillsmith-docs PR #548 — tracked separately since `docs/internal` is its own submodule; does not block this PR).