### PR TITLE
feat(hooks): PreToolUse guard blocks non-compliant Linear issue creation (SMI-5846)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -107,6 +107,16 @@
             "command": "$CLAUDE_PROJECT_DIR/scripts/dogfood-skill-telemetry.sh pre"
           }
         ]
+      },
+      {
+        "matcher": "^mcp__linear__save_issue$",
+        "hooks": [
+          {
+            "type": "command",
+            "timeout": 5,
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/linear-issue-creation-guard.mjs\""
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/scripts/lib/linear-issue-validation.mjs
+++ b/scripts/lib/linear-issue-validation.mjs
@@ -1,0 +1,87 @@
+/**
+ * Linear issue description validation contract (SMI-5841, extracted SMI-5846).
+ *
+ * This is the canonical home for `validateIssueDescription` and its
+ * constants. It is consumed by:
+ *   - `scripts/lint-linear-issues.mjs` (SMI-5841) — scheduled CI backstop
+ *     that queries Linear's API for recently-created issues and validates
+ *     them after the fact.
+ *   - `scripts/linear-issue-creation-guard.mjs` (SMI-5846) — client-side
+ *     PreToolUse hook that validates a `mcp__linear__save_issue` create
+ *     call's description before it reaches Linear.
+ *
+ * Extracted into this shared module so both consumers stay in sync by
+ * construction rather than by hand — the exact "ported copy, kept in sync
+ * by hand" risk this repo's own SMI-5841 plan doc flagged for its
+ * relationship to the *external* CLI-path source
+ * (`~/.claude/skills/linear/scripts/lib/issue-description.ts`) must not be
+ * repeated internally, between two files this repo does own.
+ *
+ * Validation contract is PORTED from
+ * `~/.claude/skills/linear/scripts/lib/issue-description.ts`'s
+ * `validateIssueDescription()` — that file is not trackable from this
+ * repo's CI (a personal, untracked package), so the rules below must be
+ * kept in sync BY HAND if that source ever changes its contract. Ported
+ * rules (all required to pass):
+ *   1. Non-empty after trim.
+ *   2. Body >= MIN_BODY_CHARS after stripping heading lines.
+ *   3. Contains an "Acceptance Criteria" heading (H1-H6).
+ *   4. >= MIN_AC_ITEMS non-placeholder bulleted items under that heading.
+ */
+
+export const MIN_BODY_CHARS = 120
+export const MIN_AC_ITEMS = 2
+export const AC_HEADING_RE = /^#{1,6}\s+Acceptance Criteria\b.*$/im
+export const PLACEHOLDER_RE =
+  /^\s*(TODO|FIXME|TBD|TBA|N\/A|XXX|\?+|<[^>]*>|\.\.\.|-{2,}|_{2,})\s*$/i
+
+/**
+ * Validate an issue description against the ported Acceptance Criteria
+ * contract. Returns a list of error strings (empty = valid).
+ *
+ * @param {string | null | undefined} description
+ * @returns {string[]}
+ */
+export function validateIssueDescription(description) {
+  const errors = []
+  const trimmed = (description ?? '').trim()
+
+  if (trimmed.length === 0) {
+    errors.push('Description is empty')
+    return errors
+  }
+
+  const bodyChars = trimmed
+    .split(/\r?\n/)
+    .filter((line) => !/^\s*#{1,6}\s/.test(line))
+    .join('\n').length
+  if (bodyChars < MIN_BODY_CHARS) {
+    errors.push(`Description body is ${bodyChars} chars; minimum is ${MIN_BODY_CHARS}`)
+  }
+
+  const acHeadingMatch = trimmed.match(AC_HEADING_RE)
+  if (!acHeadingMatch) {
+    errors.push('Acceptance Criteria heading missing')
+  } else {
+    const lines = trimmed.split(/\r?\n/)
+    const headingIdx = lines.findIndex((l) => AC_HEADING_RE.test(l))
+    const acItems = []
+    for (let i = headingIdx + 1; i < lines.length; i++) {
+      const line = lines[i]
+      if (/^#{1,6}\s/.test(line)) break // next heading ends the section
+      const bullet = line.match(/^\s*(?:-|\*)\s+(?:\[[ xX]\]\s+)?(.*)$/)
+      if (!bullet) continue
+      const body = bullet[1].trim()
+      if (body.length === 0) continue
+      if (PLACEHOLDER_RE.test(body)) continue
+      acItems.push(body)
+    }
+    if (acItems.length < MIN_AC_ITEMS) {
+      errors.push(
+        `Fewer than ${MIN_AC_ITEMS} acceptance-criteria items found (got ${acItems.length})`
+      )
+    }
+  }
+
+  return errors
+}

--- a/scripts/linear-issue-creation-guard.mjs
+++ b/scripts/linear-issue-creation-guard.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Linear issue creation guard (SMI-5846).
+ *
+ * A `PreToolUse` hook, matched to `mcp__linear__save_issue` in
+ * `.claude/settings.json`, that blocks (or, during shadow mode, warns on) a
+ * non-compliant Linear issue **create** call before it reaches Linear.
+ * `save_issue` does double duty (create when `id` is absent, update when
+ * present) — this guard only ever gates the create path.
+ *
+ * Complements SMI-5841's `scripts/lint-linear-issues.mjs`, a scheduled CI
+ * job that detects violations in already-created issues after the fact.
+ * This hook is the client-side prevention layer, scoped to this repo's own
+ * `.claude/settings.json` (and therefore this repo's own Claude Code
+ * sessions only — it cannot reach the Linear web UI, other repos, or other
+ * integrations).
+ *
+ * Validation contract lives in `scripts/lib/linear-issue-validation.mjs`
+ * (shared with `scripts/lint-linear-issues.mjs` so both stay in sync by
+ * construction).
+ *
+ * Env vars (both plain local environment variables — this hook runs
+ * client-side in a developer's own Claude Code session, not in CI):
+ *   SKILLSMITH_LINEAR_ISSUE_GUARD_DISABLE  - '1' to hard-disable; the hook
+ *     does not even compute a decision. Always checked first — this
+ *     precedence over SHADOW is an explicit invariant.
+ *   SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW   - default on (unset); while on,
+ *     a non-compliant description produces a `warn` (visible transcript
+ *     notice, call still proceeds). Set to '0' to start actually denying.
+ *
+ * @see docs/internal/implementation/smi-5846-linear-issue-creation-guard.md
+ */
+import { validateIssueDescription } from './lib/linear-issue-validation.mjs'
+
+/**
+ * Dated follow-up review target for the shadow-first rollout (matches
+ * Check 59/60's hardcoded-shadow-end-date convention, `scripts/audit-standards.mjs`).
+ * A dated Linear issue filed at merge time references this date; when it
+ * arrives, a session reviews the transcript-visible `warn` notices actually
+ * seen over the burn-in window before deciding whether to set
+ * SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW=0.
+ */
+export const LINEAR_ISSUE_GUARD_SHADOW_END_DATE = '2026-08-09'
+
+/**
+ * Pure decision function — no I/O. Given a raw PreToolUse `toolCall`
+ * payload and `process.env` (or an equivalent plain object), decides
+ * whether to allow, warn, or deny the call.
+ *
+ * @param {{ tool_name?: string, tool_input?: { id?: string, description?: string | null } } | null | undefined} toolCall
+ * @param {Record<string, string | undefined>} env
+ * @returns {{ action: 'allow' | 'warn' | 'deny', json: object | null, stderr: string | null }}
+ */
+export function decide(toolCall, env) {
+  try {
+    if (env?.SKILLSMITH_LINEAR_ISSUE_GUARD_DISABLE === '1') {
+      return { action: 'allow', json: null, stderr: null }
+    }
+
+    if (toolCall?.tool_name !== 'mcp__linear__save_issue') {
+      return { action: 'allow', json: null, stderr: null }
+    }
+
+    const id = toolCall?.tool_input?.id
+    if (typeof id === 'string' && id.length > 0) {
+      // An update, not a create — save_issue does double duty and updates
+      // must never be gated on the create-time template contract.
+      return { action: 'allow', json: null, stderr: null }
+    }
+
+    const errors = validateIssueDescription(toolCall?.tool_input?.description)
+
+    if (errors.length === 0) {
+      return { action: 'allow', json: null, stderr: null }
+    }
+
+    const reason =
+      errors.join('; ') +
+      ' — see .claude/templates/linear-issue-template.md for the required format.'
+
+    if (env?.SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW !== '0') {
+      // Shadow mode (default): warn, call still proceeds.
+      return { action: 'warn', json: null, stderr: reason }
+    }
+
+    // Shadow lifted: deny outright.
+    return {
+      action: 'deny',
+      json: {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: reason,
+        },
+      },
+      stderr: null,
+    }
+  } catch (err) {
+    // Fail open — a bug in this hook's own code must never block Linear
+    // issue creation in every session working in this repo.
+    return {
+      action: 'allow',
+      json: null,
+      stderr: `[linear-issue-creation-guard] internal error, failing open: ${err.message}`,
+    }
+  }
+}
+
+// --- Runtime wrapper (thin shell around the pure decide() core) ---
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const chunks = []
+  process.stdin.on('data', (chunk) => chunks.push(chunk))
+  process.stdin.on('end', () => {
+    let toolCall = null
+    try {
+      const raw = Buffer.concat(chunks).toString('utf8')
+      toolCall = raw.trim().length > 0 ? JSON.parse(raw) : null
+    } catch {
+      // Malformed/unparseable stdin — treat as absent; decide() reads
+      // every field via optional chaining, so a null toolCall resolves to
+      // undefined at every access rather than throwing, and falls through
+      // to the tool_name mismatch branch (allow).
+      toolCall = null
+    }
+
+    const result = decide(toolCall, process.env)
+
+    if (result.action === 'deny') {
+      process.stdout.write(JSON.stringify(result.json))
+      process.exit(0)
+    } else if (result.action === 'warn') {
+      process.stderr.write(`${result.stderr}\n`)
+      process.exit(1)
+    } else {
+      // allow — any diagnostic stderr from the fail-open path is still
+      // written, but exit 0 keeps it out of the transcript (--debug-log
+      // only), which is fine since it's a breadcrumb for the rare
+      // internal-bug case, not the load-bearing shadow signal.
+      if (result.stderr) {
+        process.stderr.write(`${result.stderr}\n`)
+      }
+      process.exit(0)
+    }
+  })
+}

--- a/scripts/lint-linear-issues.mjs
+++ b/scripts/lint-linear-issues.mjs
@@ -10,16 +10,13 @@
  * `~/.claude/skills/linear/`, not tracked by this repo) enforces it
  * programmatically. This script is the CI-side backstop for the MCP path.
  *
- * Validation contract is PORTED from
- * `~/.claude/skills/linear/scripts/lib/issue-description.ts`'s
- * `validateIssueDescription()` — that file is not trackable from this
- * repo's CI (a personal, untracked package), so the rules below must be
- * kept in sync BY HAND if that source ever changes its contract. Ported
- * rules (all required to pass):
- *   1. Non-empty after trim.
- *   2. Body >= MIN_BODY_CHARS after stripping heading lines.
- *   3. Contains an "Acceptance Criteria" heading (H1-H6).
- *   4. >= MIN_AC_ITEMS non-placeholder bulleted items under that heading.
+ * The validation contract itself (`validateIssueDescription` + its
+ * constants) lives in `scripts/lib/linear-issue-validation.mjs` (extracted
+ * SMI-5846) — that shared module is also consumed by
+ * `scripts/linear-issue-creation-guard.mjs`'s client-side PreToolUse hook,
+ * so both enforcement layers stay in sync by construction. See that
+ * module's header for the full ported-rules provenance and sync caveat
+ * against the untracked external source.
  *
  * Usage:
  *   node scripts/lint-linear-issues.mjs                       # last 48h
@@ -36,68 +33,11 @@
  *
  * npm script: npm run lint:linear-issues
  */
+import { validateIssueDescription } from './lib/linear-issue-validation.mjs'
 
 const LINEAR_API_URL = 'https://api.linear.app/graphql'
 const TEAM_KEY = 'SMI'
 const RETRY_DELAYS = [1000, 2000, 4000]
-
-// --- Ported validation contract (see file header for provenance) ---
-
-const MIN_BODY_CHARS = 120
-const MIN_AC_ITEMS = 2
-const AC_HEADING_RE = /^#{1,6}\s+Acceptance Criteria\b.*$/im
-const PLACEHOLDER_RE = /^\s*(TODO|FIXME|TBD|TBA|N\/A|XXX|\?+|<[^>]*>|\.\.\.|-{2,}|_{2,})\s*$/i
-
-/**
- * Validate an issue description against the ported Acceptance Criteria
- * contract. Returns a list of error strings (empty = valid).
- *
- * @param {string | null | undefined} description
- * @returns {string[]}
- */
-export function validateIssueDescription(description) {
-  const errors = []
-  const trimmed = (description ?? '').trim()
-
-  if (trimmed.length === 0) {
-    errors.push('Description is empty')
-    return errors
-  }
-
-  const bodyChars = trimmed
-    .split(/\r?\n/)
-    .filter((line) => !/^\s*#{1,6}\s/.test(line))
-    .join('\n').length
-  if (bodyChars < MIN_BODY_CHARS) {
-    errors.push(`Description body is ${bodyChars} chars; minimum is ${MIN_BODY_CHARS}`)
-  }
-
-  const acHeadingMatch = trimmed.match(AC_HEADING_RE)
-  if (!acHeadingMatch) {
-    errors.push('Acceptance Criteria heading missing')
-  } else {
-    const lines = trimmed.split(/\r?\n/)
-    const headingIdx = lines.findIndex((l) => AC_HEADING_RE.test(l))
-    const acItems = []
-    for (let i = headingIdx + 1; i < lines.length; i++) {
-      const line = lines[i]
-      if (/^#{1,6}\s/.test(line)) break // next heading ends the section
-      const bullet = line.match(/^\s*(?:-|\*)\s+(?:\[[ xX]\]\s+)?(.*)$/)
-      if (!bullet) continue
-      const body = bullet[1].trim()
-      if (body.length === 0) continue
-      if (PLACEHOLDER_RE.test(body)) continue
-      acItems.push(body)
-    }
-    if (acItems.length < MIN_AC_ITEMS) {
-      errors.push(
-        `Fewer than ${MIN_AC_ITEMS} acceptance-criteria items found (got ${acItems.length})`
-      )
-    }
-  }
-
-  return errors
-}
 
 // --- CLI / date parsing ---
 

--- a/scripts/tests/linear-issue-creation-guard.test.ts
+++ b/scripts/tests/linear-issue-creation-guard.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the SMI-5846 linear-issue-creation-guard PreToolUse hook.
+ *
+ * Two layers are covered:
+ *   1. `decide()` unit tests — the pure decision core, exercised directly
+ *      (no subprocess) for every branch in the plan.
+ *   2. A small set of subprocess tests that actually spawn the script,
+ *      piping a JSON payload via stdin, and assert on the real exit code
+ *      — this is the one place in this hook where the exit code itself
+ *      (not just the decision object) carries meaning: `allow` -> 0,
+ *      `warn` -> 1 (non-blocking, but transcript-visible), `deny` -> 0
+ *      with a JSON permissionDecision on stdout.
+ */
+import { execFileSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { decide, LINEAR_ISSUE_GUARD_SHADOW_END_DATE } from '../linear-issue-creation-guard.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SCRIPT_PATH = join(__dirname, '..', 'linear-issue-creation-guard.mjs')
+
+const VALID_DESCRIPTION = [
+  '## Context',
+  '',
+  'This is a sufficiently long description body explaining what changed and why, ' +
+    'well past the minimum character threshold for a real issue description.',
+  '',
+  '## Acceptance Criteria',
+  '',
+  '- The thing works as described',
+  '- A test confirms the behavior',
+].join('\n')
+
+const NON_COMPLIANT_DESCRIPTION = 'Too short, no Acceptance Criteria section.'
+
+function saveIssueCall(toolInput: Record<string, unknown>) {
+  return { tool_name: 'mcp__linear__save_issue', tool_input: toolInput }
+}
+
+describe('LINEAR_ISSUE_GUARD_SHADOW_END_DATE', () => {
+  it('is exported as a fixed date string', () => {
+    expect(LINEAR_ISSUE_GUARD_SHADOW_END_DATE).toBe('2026-08-09')
+  })
+})
+
+describe('decide() (SMI-5846)', () => {
+  it('a compliant description allows the call', () => {
+    const result = decide(saveIssueCall({ description: VALID_DESCRIPTION }), {})
+    expect(result).toEqual({ action: 'allow', json: null, stderr: null })
+  })
+
+  it('a missing description denies (with SHADOW=0) and populates json', () => {
+    const result = decide(saveIssueCall({}), { SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW: '0' })
+    expect(result.action).toBe('deny')
+    expect(result.json).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: expect.stringContaining('Description is empty'),
+      },
+    })
+    expect(result.json?.hookSpecificOutput.permissionDecisionReason).toContain(
+      '.claude/templates/linear-issue-template.md'
+    )
+  })
+
+  it('an empty description denies (with SHADOW=0) and populates json', () => {
+    const result = decide(saveIssueCall({ description: '' }), {
+      SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW: '0',
+    })
+    expect(result.action).toBe('deny')
+    expect(result.json).not.toBeNull()
+  })
+
+  it('tool_input.id present as a non-empty string allows regardless of description', () => {
+    const result = decide(saveIssueCall({ id: 'SMI-1234', description: '' }), {
+      SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW: '0',
+    })
+    expect(result).toEqual({ action: 'allow', json: null, stderr: null })
+  })
+
+  it('tool_input.id present as an empty string is treated as absent (validated as a create)', () => {
+    const result = decide(saveIssueCall({ id: '', description: NON_COMPLIANT_DESCRIPTION }), {
+      SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW: '0',
+    })
+    expect(result.action).toBe('deny')
+  })
+
+  it('disable var set allows regardless of description or shadow setting', () => {
+    const result = decide(saveIssueCall({ description: '' }), {
+      SKILLSMITH_LINEAR_ISSUE_GUARD_DISABLE: '1',
+      SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW: '0',
+    })
+    expect(result).toEqual({ action: 'allow', json: null, stderr: null })
+  })
+
+  it('disable var wins even when set alongside a non-compliant description and shadow lifted', () => {
+    const result = decide(saveIssueCall({ description: NON_COMPLIANT_DESCRIPTION }), {
+      SKILLSMITH_LINEAR_ISSUE_GUARD_DISABLE: '1',
+    })
+    expect(result.action).toBe('allow')
+  })
+
+  it('shadow mode (default, unset) with a non-compliant description warns with populated stderr and null json', () => {
+    const result = decide(saveIssueCall({ description: NON_COMPLIANT_DESCRIPTION }), {})
+    expect(result.action).toBe('warn')
+    expect(result.json).toBeNull()
+    expect(result.stderr).toContain('.claude/templates/linear-issue-template.md')
+  })
+
+  it('shadow mode with SHADOW set to a non-"0" value still warns (only "0" lifts shadow)', () => {
+    const result = decide(saveIssueCall({ description: NON_COMPLIANT_DESCRIPTION }), {
+      SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW: 'true',
+    })
+    expect(result.action).toBe('warn')
+  })
+
+  it('shadow lifted (SHADOW=0) with the same non-compliant description denies', () => {
+    const result = decide(saveIssueCall({ description: NON_COMPLIANT_DESCRIPTION }), {
+      SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW: '0',
+    })
+    expect(result.action).toBe('deny')
+    expect(result.json).not.toBeNull()
+  })
+
+  it('a tool_name other than mcp__linear__save_issue always allows', () => {
+    const result = decide(
+      { tool_name: 'mcp__linear__list_issues', tool_input: { description: '' } },
+      { SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW: '0' }
+    )
+    expect(result).toEqual({ action: 'allow', json: null, stderr: null })
+  })
+
+  it('a malformed/null toolCall fails open to allow, not a throw', () => {
+    expect(() => decide(null, {})).not.toThrow()
+    expect(decide(null, {})).toEqual({ action: 'allow', json: null, stderr: null })
+    expect(() => decide(undefined, {})).not.toThrow()
+    expect(decide(undefined, {})).toEqual({ action: 'allow', json: null, stderr: null })
+  })
+
+  it('a malformed toolCall missing tool_input entirely fails open to allow', () => {
+    const result = decide({ tool_name: 'mcp__linear__save_issue' }, {})
+    expect(result.action).toBe('warn') // no description -> non-compliant -> shadow warn, not a crash
+  })
+})
+
+describe('linear-issue-creation-guard.mjs runtime wrapper (subprocess, exit-code contract)', () => {
+  it('exits 0 for a compliant description (allow)', () => {
+    const payload = JSON.stringify(saveIssueCall({ description: VALID_DESCRIPTION }))
+    const stdout = execFileSync('node', [SCRIPT_PATH], {
+      input: payload,
+      encoding: 'utf8',
+    })
+    expect(stdout.trim()).toBe('')
+  })
+
+  it('exits 1 for a non-compliant description in shadow mode (warn)', () => {
+    const payload = JSON.stringify(saveIssueCall({ description: NON_COMPLIANT_DESCRIPTION }))
+    // Ensure shadow mode is at its default (unset) regardless of the
+    // ambient test environment.
+    const cleanEnv = { ...process.env }
+    delete cleanEnv.SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW
+    let threw = false
+    try {
+      execFileSync('node', [SCRIPT_PATH], {
+        input: payload,
+        encoding: 'utf8',
+        env: cleanEnv,
+      })
+    } catch (err) {
+      threw = true
+      const e = err as { status: number; stderr: string }
+      expect(e.status).toBe(1)
+      expect(e.stderr).toContain('.claude/templates/linear-issue-template.md')
+    }
+    expect(threw).toBe(true)
+  })
+
+  it('exits 0 with stdout JSON permissionDecision "deny" when SHADOW=0 and description is non-compliant', () => {
+    const payload = JSON.stringify(saveIssueCall({ description: NON_COMPLIANT_DESCRIPTION }))
+    const stdout = execFileSync('node', [SCRIPT_PATH], {
+      input: payload,
+      encoding: 'utf8',
+      env: { ...process.env, SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW: '0' },
+    })
+    const parsed = JSON.parse(stdout)
+    expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny')
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('PreToolUse')
+  })
+
+  it('exits 0 for malformed stdin (fail open)', () => {
+    const stdout = execFileSync('node', [SCRIPT_PATH], {
+      input: 'not valid json {{{',
+      encoding: 'utf8',
+    })
+    expect(stdout.trim()).toBe('')
+  })
+})

--- a/scripts/tests/linear-issue-validation.test.ts
+++ b/scripts/tests/linear-issue-validation.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the shared Linear issue description validation contract
+ * (SMI-5841, extracted into its own module SMI-5846).
+ *
+ * Covers `validateIssueDescription` in
+ * scripts/lib/linear-issue-validation.mjs. The validation rules are PORTED
+ * from ~/.claude/skills/linear/scripts/lib/issue-description.ts (untracked,
+ * not reachable from this repo's CI) — these tests exercise the ported
+ * copy's own behavior, not the original source.
+ *
+ * This module is consumed by both `scripts/lint-linear-issues.mjs`
+ * (SMI-5841, CI backstop) and `scripts/linear-issue-creation-guard.mjs`
+ * (SMI-5846, client-side PreToolUse hook) — moved here so both stay in
+ * sync by construction.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { validateIssueDescription } from '../lib/linear-issue-validation.mjs'
+
+const VALID_DESCRIPTION = [
+  '## Context',
+  '',
+  'This is a sufficiently long description body explaining what changed and why, ' +
+    'well past the minimum character threshold for a real issue description.',
+  '',
+  '## Acceptance Criteria',
+  '',
+  '- The thing works as described',
+  '- A test confirms the behavior',
+].join('\n')
+
+describe('validateIssueDescription (SMI-5841)', () => {
+  it('a well-formed description passes with zero errors', () => {
+    expect(validateIssueDescription(VALID_DESCRIPTION)).toEqual([])
+  })
+
+  it('null description fails safe (does not throw) — the exact mcp__linear__save_issue-with-no-description shape', () => {
+    expect(() => validateIssueDescription(null)).not.toThrow()
+    const errors = validateIssueDescription(null)
+    expect(errors).toContain('Description is empty')
+  })
+
+  it('undefined description fails safe (does not throw)', () => {
+    expect(() => validateIssueDescription(undefined)).not.toThrow()
+    expect(validateIssueDescription(undefined)).toContain('Description is empty')
+  })
+
+  it('empty string fails with "Description is empty"', () => {
+    expect(validateIssueDescription('')).toEqual(['Description is empty'])
+  })
+
+  it('whitespace-only string fails with "Description is empty"', () => {
+    expect(validateIssueDescription('   \n\n  ')).toEqual(['Description is empty'])
+  })
+
+  it('missing Acceptance Criteria heading is flagged', () => {
+    const description = 'A description with plenty of body text but no AC section at all here.'
+    const errors = validateIssueDescription(description)
+    expect(errors).toContain('Acceptance Criteria heading missing')
+  })
+
+  it('Acceptance Criteria heading with zero items below it is flagged', () => {
+    const description = [
+      'A sufficiently long description body explaining the change in enough detail.',
+      '',
+      '## Acceptance Criteria',
+    ].join('\n')
+    const errors = validateIssueDescription(description)
+    expect(errors.some((e) => e.includes('Fewer than 2'))).toBe(true)
+  })
+
+  it('Acceptance Criteria heading as the terminal line (no trailing newline/content) still produces a zero-item violation, not a crash', () => {
+    const description =
+      'Sufficiently long body text explaining the change in real detail.\n\n## Acceptance Criteria'
+    expect(() => validateIssueDescription(description)).not.toThrow()
+    const errors = validateIssueDescription(description)
+    expect(errors.some((e) => e.includes('Fewer than 2'))).toBe(true)
+  })
+
+  it('placeholder-only bullets do not count toward the minimum', () => {
+    const description = [
+      'A sufficiently long description body explaining the change in real detail here.',
+      '',
+      '## Acceptance Criteria',
+      '',
+      '- TODO',
+      '- <criterion>',
+      '- ???',
+      '- ...',
+    ].join('\n')
+    const errors = validateIssueDescription(description)
+    expect(errors.some((e) => e.includes('Fewer than 2'))).toBe(true)
+  })
+
+  it('nested/indented bullets under Acceptance Criteria are still counted', () => {
+    const description = [
+      'A sufficiently long description body explaining the change in real detail here.',
+      '',
+      '## Acceptance Criteria',
+      '',
+      '  - Indented first criterion that is concrete and testable',
+      '  - Indented second criterion that is concrete and testable',
+    ].join('\n')
+    expect(validateIssueDescription(description)).toEqual(
+      expect.not.arrayContaining([expect.stringContaining('Fewer than')])
+    )
+  })
+
+  it('body length is checked below the MIN_BODY_CHARS threshold', () => {
+    const description = ['## Acceptance Criteria', '', '- Short one', '- Short two'].join('\n')
+    const errors = validateIssueDescription(description)
+    expect(errors.some((e) => e.includes('minimum is 120'))).toBe(true)
+  })
+})

--- a/scripts/tests/lint-linear-issues.test.ts
+++ b/scripts/tests/lint-linear-issues.test.ts
@@ -1,116 +1,17 @@
 /**
- * Tests for the SMI-5841 lint-linear-issues ported validation contract.
+ * Tests for the SMI-5841 lint-linear-issues CLI arg parsing.
  *
- * Covers `validateIssueDescription` and `parseArgs` in
- * scripts/lint-linear-issues.mjs. The validation rules are PORTED from
- * ~/.claude/skills/linear/scripts/lib/issue-description.ts (untracked,
- * not reachable from this repo's CI) — these tests exercise the ported
- * copy's own behavior, not the original source.
+ * The `validateIssueDescription` validation-contract tests moved to
+ * `scripts/tests/linear-issue-validation.test.ts` (SMI-5846) alongside the
+ * extraction of that contract into `scripts/lib/linear-issue-validation.mjs`.
  */
 import { describe, expect, it } from 'vitest'
 
 const mod = (await import('../lint-linear-issues.mjs')) as {
-  validateIssueDescription: (description: string | null | undefined) => string[]
   parseArgs: (argv: string[]) => { since: Date; json: boolean }
 }
 
-const { validateIssueDescription, parseArgs } = mod
-
-const VALID_DESCRIPTION = [
-  '## Context',
-  '',
-  'This is a sufficiently long description body explaining what changed and why, ' +
-    'well past the minimum character threshold for a real issue description.',
-  '',
-  '## Acceptance Criteria',
-  '',
-  '- The thing works as described',
-  '- A test confirms the behavior',
-].join('\n')
-
-describe('validateIssueDescription (SMI-5841)', () => {
-  it('a well-formed description passes with zero errors', () => {
-    expect(validateIssueDescription(VALID_DESCRIPTION)).toEqual([])
-  })
-
-  it('null description fails safe (does not throw) — the exact mcp__linear__save_issue-with-no-description shape', () => {
-    expect(() => validateIssueDescription(null)).not.toThrow()
-    const errors = validateIssueDescription(null)
-    expect(errors).toContain('Description is empty')
-  })
-
-  it('undefined description fails safe (does not throw)', () => {
-    expect(() => validateIssueDescription(undefined)).not.toThrow()
-    expect(validateIssueDescription(undefined)).toContain('Description is empty')
-  })
-
-  it('empty string fails with "Description is empty"', () => {
-    expect(validateIssueDescription('')).toEqual(['Description is empty'])
-  })
-
-  it('whitespace-only string fails with "Description is empty"', () => {
-    expect(validateIssueDescription('   \n\n  ')).toEqual(['Description is empty'])
-  })
-
-  it('missing Acceptance Criteria heading is flagged', () => {
-    const description = 'A description with plenty of body text but no AC section at all here.'
-    const errors = validateIssueDescription(description)
-    expect(errors).toContain('Acceptance Criteria heading missing')
-  })
-
-  it('Acceptance Criteria heading with zero items below it is flagged', () => {
-    const description = [
-      'A sufficiently long description body explaining the change in enough detail.',
-      '',
-      '## Acceptance Criteria',
-    ].join('\n')
-    const errors = validateIssueDescription(description)
-    expect(errors.some((e) => e.includes('Fewer than 2'))).toBe(true)
-  })
-
-  it('Acceptance Criteria heading as the terminal line (no trailing newline/content) still produces a zero-item violation, not a crash', () => {
-    const description =
-      'Sufficiently long body text explaining the change in real detail.\n\n## Acceptance Criteria'
-    expect(() => validateIssueDescription(description)).not.toThrow()
-    const errors = validateIssueDescription(description)
-    expect(errors.some((e) => e.includes('Fewer than 2'))).toBe(true)
-  })
-
-  it('placeholder-only bullets do not count toward the minimum', () => {
-    const description = [
-      'A sufficiently long description body explaining the change in real detail here.',
-      '',
-      '## Acceptance Criteria',
-      '',
-      '- TODO',
-      '- <criterion>',
-      '- ???',
-      '- ...',
-    ].join('\n')
-    const errors = validateIssueDescription(description)
-    expect(errors.some((e) => e.includes('Fewer than 2'))).toBe(true)
-  })
-
-  it('nested/indented bullets under Acceptance Criteria are still counted', () => {
-    const description = [
-      'A sufficiently long description body explaining the change in real detail here.',
-      '',
-      '## Acceptance Criteria',
-      '',
-      '  - Indented first criterion that is concrete and testable',
-      '  - Indented second criterion that is concrete and testable',
-    ].join('\n')
-    expect(validateIssueDescription(description)).toEqual(
-      expect.not.arrayContaining([expect.stringContaining('Fewer than')])
-    )
-  })
-
-  it('body length is checked below the MIN_BODY_CHARS threshold', () => {
-    const description = ['## Acceptance Criteria', '', '- Short one', '- Short two'].join('\n')
-    const errors = validateIssueDescription(description)
-    expect(errors.some((e) => e.includes('minimum is 120'))).toBe(true)
-  })
-})
+const { parseArgs } = mod
 
 describe('parseArgs (SMI-5841)', () => {
   it('defaults to roughly 48h ago when --since is omitted', () => {


### PR DESCRIPTION
## Business Summary

**What shipped:** Claude Code sessions working in this repo now get a warning (and, once a burn-in period ends, an outright block) when they try to create a Linear issue via the MCP tool without the required Acceptance-Criteria section — closing the gap SMI-5841 could only detect after the fact.

**Quality bar:** Passed a 3-VP plan review before any code was written (caught and fixed a Critical design flaw: the original shadow-mode design would have made its own warning invisible), then an independent cross-provider review (GPT-5.6-Sol via NEEDLE) after implementation, then a governance pass with a sibling-implementation sweep. 32 tests, all passing; lint/typecheck/format/audit:standards all clean.

**Found along the way:** two other Linear issue-creation paths in this repo (an auto-generated drift-tracking script and a CLI fallback command) also bypass this same contract — filed as SMI-5853 rather than folded into this PR, since neither file's actual logic is touched here.

**Net result:** Fully shipped, in shadow mode (warn-only) by default. A dated follow-up (2026-08-09) will review what the warnings actually caught before deciding whether to start blocking outright.

---

## Technical detail

- `scripts/lib/linear-issue-validation.mjs` (new) — `validateIssueDescription` and its constants, extracted verbatim from `scripts/lint-linear-issues.mjs` so the CI detection script (SMI-5841) and this new hook share one validation contract instead of two.
- `scripts/linear-issue-creation-guard.mjs` (new) — a `PreToolUse` hook matched to `mcp__linear__save_issue`. Pure `decide(toolCall, env)` core returns `allow`/`warn`/`deny`; a thin runtime wrapper translates that into the actual process behavior Claude Code's hooks contract expects: `allow` → exit 0, no output; `warn` → exit 1 with stderr (non-blocking, but transcript-visible — this is the shadow-mode signal); `deny` → exit 0 with a JSON `permissionDecision: "deny"` payload on stdout. Skips entirely for updates (`tool_input.id` present) and fails open on any internal error.
- `.claude/settings.json` — one new `hooks.PreToolUse` entry (matcher `^mcp__linear__save_issue$`); the 3 existing entries are untouched.
- `scripts/tests/linear-issue-creation-guard.test.ts`, `scripts/tests/linear-issue-validation.test.ts` (new), `scripts/tests/lint-linear-issues.test.ts` (trimmed) — 32 tests total, including 4 subprocess-level tests asserting the real exit codes.
- `scripts/lint-linear-issues.mjs` — now imports from the shared module; header JSDoc updated.
- Plan doc + plan-review + guards registry + `linear-hygiene-guide.md` update + code review report: `smith-horn/skillsmith-docs` #551, #552, #553 (all merged; this outer repo's `docs/internal` pointer will be bumped in a small follow-up PR after this merges, matching the pattern used for SMI-5840/5841/5845).
- Rollout: `SKILLSMITH_LINEAR_ISSUE_GUARD_DISABLE=1` hard-disables; `SKILLSMITH_LINEAR_ISSUE_GUARD_SHADOW=0` lifts shadow mode to start actually denying. Both are local environment variables (this hook runs client-side, not in CI).
- The one thing not verified live: an actual `mcp__linear__save_issue` call inside a running session with this hook wired into that session's own live settings.json. Wiring it into the coordinating session mid-task risked interfering with that same session's own remaining Linear updates needed to close this issue out. The 4 subprocess tests exercise the exact mechanism Claude Code's hook runtime uses (spawn, pipe JSON stdin, read exit code + stdout) against the officially documented contract — the closest achievable verification without a session restart. Full rationale in the plan doc's Verification section.
