### PR TITLE
feat(ci): validate create-issue descriptions in linear-api.mjs, shadow-first (SMI-5853)

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -114,7 +114,7 @@ jobs:
           GAP_LINES=$(echo "$RESPONSE" | jq -r '.data.true_coverage_gaps // [] | .[] | "- " + .owner + "/" + .repo + " (" + (.license // "no license") + ")"')
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          BODY=$(printf 'Weekly coverage-report job (SMI-4963) flagged %s publisher(s).\n\nQuarantine-threshold breaches:\n%s\n\nTrue coverage gaps:\n%s\n\nRun: %s' \
+          BODY=$(printf 'Weekly coverage-report job (SMI-4963) flagged %s publisher(s).\n\nQuarantine-threshold breaches:\n%s\n\nTrue coverage gaps:\n%s\n\n## Acceptance Criteria\n- [ ] The flagged publisher(s) are re-verified as passing the quarantine threshold\n- [ ] OR the regression is confirmed a false positive, with rationale documented in a comment on this issue\n\nRun: %s' \
             "$FLAGGED" "${BREACH_LINES:-none}" "${GAP_LINES:-none}" "$RUN_URL")
 
           # Dedupe: look for an open issue whose title starts with the stable

--- a/.github/workflows/esm-sh-staleness-sweep.yml
+++ b/.github/workflows/esm-sh-staleness-sweep.yml
@@ -112,6 +112,10 @@ jobs:
           - Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
           Action: bump the pinned esm.sh version in \`supabase/functions/**/*.ts\` to a release outside the affected range. Verify via \`npm view $PKG versions --json\` and update the import URL to a fresh semver pin.
+
+          ## Acceptance Criteria
+          - [ ] The pinned version is bumped past the affected range ($RANGE)
+          - [ ] Verified via \`npm view $PKG versions --json\` that the new pin is outside the affected range
           EOF
           )
             node scripts/linear-api.mjs create-issue \
@@ -141,6 +145,10 @@ jobs:
           - Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
           This is an advisory signal only — staleness alone is NOT a CVE. Consider bumping if the diff is small and there is no behavior change. The advisory check (separate Linear issues) is the load-bearing supply-chain signal.
+
+          ## Acceptance Criteria
+          - [ ] The pin is bumped to \`$LATEST\` (or a newer release), OR an explicit decision to defer is documented in a comment on this issue
+          - [ ] If deferred, the rationale references why the diff/behavior-change risk outweighs the staleness signal
           EOF
           )
             node scripts/linear-api.mjs create-issue \

--- a/scripts/linear-api.mjs
+++ b/scripts/linear-api.mjs
@@ -5,6 +5,16 @@
  * Provides reliable Linear API operations with proper JSON escaping
  * and error handling. Replaces fragile curl-based scripts.
  *
+ * `create-issue` validates its description against the shared
+ * Acceptance-Criteria contract (`scripts/lib/linear-issue-validation.mjs`,
+ * SMI-5841/5846) before calling the mutation (SMI-5853). Ships
+ * shadow-first, matching that same convention: a non-compliant
+ * description warns and still creates the issue by default; set
+ * SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_SHADOW=0 to block instead.
+ * --force (or SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_DISABLE=1) always
+ * bypasses regardless of shadow state. See `help()` below for the full
+ * flag/env-var reference.
+ *
  * Usage:
  *   node scripts/linear-api.mjs create-issue --title "Title" --description "Desc"
  *   node scripts/linear-api.mjs update-status --issue SMI-123 --status done
@@ -13,10 +23,25 @@
  *
  * Environment:
  *   LINEAR_API_KEY - Required API key for authentication
+ *   SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_DISABLE - '1' to bypass
+ *     create-issue description validation entirely, regardless of shadow
+ *     state (SMI-5853)
+ *   SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_SHADOW - default on (warn-only,
+ *     issue still created); set to '0' to make a non-compliant
+ *     create-issue description block instead of warn (SMI-5853)
  */
+import { validateIssueDescription } from './lib/linear-issue-validation.mjs'
 
 const TEAM_KEY = 'SMI'
 const API_URL = 'https://api.linear.app/graphql'
+
+const VALIDATION_DISABLE_ENV_VAR = 'SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_DISABLE'
+const VALIDATION_SHADOW_ENV_VAR = 'SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_SHADOW'
+// Aligned to SMI-5846's LINEAR_ISSUE_GUARD_SHADOW_END_DATE so all three
+// Linear-issue-creation enforcement layers (SMI-5841 CI lint, SMI-5846
+// MCP hook, this create-issue gate) flip to blocking together in one
+// dated follow-up review, not three staggered ones.
+export const VALIDATION_SHADOW_END_DATE = '2026-08-09'
 
 // State IDs for common workflow states (cached on first query)
 let stateCache = null
@@ -133,7 +158,38 @@ async function createIssue(options) {
     labels = [],
     parentId = null,
     teamKey = TEAM_KEY,
+    force = false,
   } = options
+
+  const descriptionText = typeof description === 'string' ? description : ''
+  const validationErrors = validateIssueDescription(descriptionText)
+  if (validationErrors.length > 0) {
+    const bypassed =
+      force === true ||
+      force === 'true' ||
+      force === '1' ||
+      process.env[VALIDATION_DISABLE_ENV_VAR] === '1'
+    const inShadow = process.env[VALIDATION_SHADOW_ENV_VAR] !== '0'
+    const reason =
+      validationErrors.join('; ') +
+      ' — see .claude/templates/linear-issue-template.md for the required format.'
+
+    if (!bypassed && !inShadow) {
+      throw new Error(
+        `[linear-api] description failed Acceptance-Criteria validation: ${reason} ` +
+          `Pass --force to create anyway, or set ${VALIDATION_DISABLE_ENV_VAR}=1.`
+      )
+    }
+    if (bypassed) {
+      console.warn(
+        `[linear-api] description failed Acceptance-Criteria validation (bypassed): ${reason}`
+      )
+    } else {
+      console.warn(
+        `[linear-api] description failed Acceptance-Criteria validation (shadow mode, proceeding): ${reason}`
+      )
+    }
+  }
 
   const teamId = await getTeamId(teamKey)
 
@@ -389,7 +445,7 @@ function parseArgs(args) {
 // CLI Commands
 const commands = {
   async 'create-issue'(args) {
-    const { title, description, priority, labels, parent } = args
+    const { title, description, priority, labels, parent, force } = args
 
     if (!title) {
       console.error('Error: --title is required')
@@ -402,6 +458,7 @@ const commands = {
       priority: priority ? parseInt(priority, 10) : 2,
       labels: labels ? labels.split(',') : [],
       parentId: parent || null,
+      force,
     })
 
     console.log(`Created: ${issue.identifier} - ${issue.title}`)
@@ -485,10 +542,14 @@ Usage:
 Commands:
   create-issue      Create a new issue
     --title         Issue title (required)
-    --description   Issue description
+    --description   Issue description (validated against the shared
+                    Acceptance-Criteria contract before the mutation,
+                    SMI-5853 - see Environment below)
     --priority      Priority (1=urgent, 2=high, 3=medium, 4=low)
     --labels        Comma-separated label IDs
     --parent        Parent issue ID
+    --force         Bypass Acceptance-Criteria description validation,
+                    regardless of shadow state (SMI-5853)
 
   update-status     Update issue status
     --issue         Issue identifier (e.g., SMI-123) (required)
@@ -510,6 +571,13 @@ Commands:
 
 Environment:
   LINEAR_API_KEY    API key for authentication (required)
+  SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_DISABLE
+                    '1' to bypass create-issue description validation
+                    entirely, regardless of shadow state (SMI-5853)
+  SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_SHADOW
+                    Default on (warn-only, issue still created). Set to
+                    '0' to make a non-compliant create-issue description
+                    block instead of warn (SMI-5853)
 
 Examples:
   node scripts/linear-api.mjs create-issue --title "New feature" --priority 2

--- a/scripts/tests/linear-api.test.ts
+++ b/scripts/tests/linear-api.test.ts
@@ -1,0 +1,220 @@
+/**
+ * SMI-5853 Gap 2: Tests for `scripts/linear-api.mjs`'s `create-issue`
+ * Acceptance-Criteria validation gate.
+ *
+ * The gate lives inside the already-exported `createIssue()`, not
+ * `commands['create-issue']` — `commands`/`parseArgs` are not exported
+ * (`grep -n "^export" scripts/linear-api.mjs`), so they can't be imported
+ * directly from a test (C2 fix, plan-review). On a blocked failure it
+ * throws a regular `Error` rather than calling `process.exit(1)` directly;
+ * `main()`'s existing top-level try/catch already converts any thrown
+ * error into the same exit-1-with-message CLI behavior, so this file only
+ * needs to prove `createIssue()` itself throws the right error at the
+ * right time — no `process.exit` mock needed.
+ *
+ * `scripts/linear-api.mjs` declares pre-existing, un-reset module-level
+ * state (`teamCache`/`stateCache`, populated by `getTeamId()`/`getStates()`)
+ * that predates this change and isn't touched by it. Each test case below
+ * resets the module registry (`vi.resetModules()` in `beforeEach`) and
+ * re-imports the module fresh inside the `it()` itself, so that cache
+ * doesn't leak between cases and silently change how many `fetch` calls a
+ * given case's mocked sequence expects to see consumed.
+ *
+ * Pattern mirrors `scripts/tests/linear-upsert-drift-issue.test.ts`'s
+ * `mockFetchSequence()` helper. The `vi.mock('node:child_process', ...)`
+ * shape that file also uses is not needed here — `linear-api.mjs` never
+ * shells out.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const DISABLE_VAR = 'SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_DISABLE'
+const SHADOW_VAR = 'SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_SHADOW'
+
+interface GqlResponse {
+  data?: Record<string, unknown>
+  errors?: Array<{ message: string }>
+}
+
+interface CreatedIssue {
+  id: string
+  identifier: string
+  title: string
+  url: string
+}
+
+interface LinearApiModule {
+  createIssue: (options: Record<string, unknown>) => Promise<CreatedIssue>
+}
+
+function mockFetchSequence(responses: GqlResponse[]) {
+  const fetchMock = vi.fn(async () => {
+    const next = responses.shift()
+    if (!next) throw new Error('fetch called more times than mocked responses')
+    return {
+      ok: true,
+      status: 200,
+      json: async () => next,
+      text: async () => JSON.stringify(next),
+    } as unknown as Response
+  })
+  // @ts-expect-error -- patch global fetch
+  global.fetch = fetchMock
+  return fetchMock
+}
+
+const TEAM_RESPONSE: GqlResponse = {
+  data: { teams: { nodes: [{ id: 'team-uuid', key: 'SMI', name: 'Skillsmith' }] } },
+}
+
+const ISSUE_CREATE_RESPONSE: GqlResponse = {
+  data: {
+    issueCreate: {
+      success: true,
+      issue: {
+        id: 'new-uuid',
+        identifier: 'SMI-9999',
+        title: 'Test issue',
+        url: 'https://linear.app/smi/issue/SMI-9999',
+      },
+    },
+  },
+}
+
+// Compliant with validateIssueDescription's ported contract: non-empty,
+// >=120 body chars excluding heading lines, an "Acceptance Criteria"
+// heading, and >=2 non-placeholder bulleted items under it.
+const VALID_DESCRIPTION = `This is a well-formed Linear issue description with enough body text to clear the minimum length requirement enforced by validateIssueDescription for a compliant issue.
+
+## Acceptance Criteria
+- [ ] The first acceptance criterion is met
+- [ ] The second acceptance criterion is met
+`
+
+// No Acceptance Criteria heading at all -> always fails validation.
+const INVALID_DESCRIPTION = 'Short description with no Acceptance Criteria section at all.'
+
+async function importLinearApi(): Promise<LinearApiModule> {
+  return (await import('../linear-api.mjs')) as unknown as LinearApiModule
+}
+
+beforeEach(() => {
+  process.env.LINEAR_API_KEY = 'test-key'
+  vi.resetModules()
+  delete process.env[DISABLE_VAR]
+  delete process.env[SHADOW_VAR]
+})
+
+afterEach(() => {
+  // @ts-expect-error -- undo patch
+  delete global.fetch
+  delete process.env[DISABLE_VAR]
+  delete process.env[SHADOW_VAR]
+  vi.restoreAllMocks()
+})
+
+describe('createIssue validation gate (SMI-5853)', () => {
+  it('lets a valid/compliant description through untouched', async () => {
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, ISSUE_CREATE_RESPONSE])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const issue = await mod.createIssue({ title: 'Valid issue', description: VALID_DESCRIPTION })
+
+    expect(issue.identifier).toBe('SMI-9999')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('shadow-on (default): a non-compliant description warns and still creates the issue', async () => {
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, ISSUE_CREATE_RESPONSE])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const issue = await mod.createIssue({
+      title: 'Non-compliant issue',
+      description: INVALID_DESCRIPTION,
+    })
+
+    expect(issue.identifier).toBe('SMI-9999')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const message = warnSpy.mock.calls[0]?.[0] as string
+    expect(message).toContain('[linear-api]')
+    expect(message).toContain('shadow mode, proceeding')
+  })
+
+  it('shadow-lifted, no bypass: a non-compliant description blocks before any fetch call', async () => {
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, ISSUE_CREATE_RESPONSE])
+    process.env[SHADOW_VAR] = '0'
+
+    const mod = await importLinearApi()
+
+    let caught: Error | null = null
+    try {
+      await mod.createIssue({ title: 'Blocked issue', description: INVALID_DESCRIPTION })
+    } catch (err) {
+      caught = err as Error
+    }
+
+    expect(caught).not.toBeNull()
+    expect(caught?.message).toContain('--force')
+    expect(caught?.message).toContain(DISABLE_VAR)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('--force bypasses regardless of shadow state', async () => {
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, ISSUE_CREATE_RESPONSE])
+    process.env[SHADOW_VAR] = '0'
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const issue = await mod.createIssue({
+      title: 'Forced issue',
+      description: INVALID_DESCRIPTION,
+      force: true,
+    })
+
+    expect(issue.identifier).toBe('SMI-9999')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0] as string).toContain('(bypassed)')
+  })
+
+  it('the disable env var bypasses regardless of shadow state', async () => {
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, ISSUE_CREATE_RESPONSE])
+    process.env[SHADOW_VAR] = '0'
+    process.env[DISABLE_VAR] = '1'
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const issue = await mod.createIssue({
+      title: 'Disable-var issue',
+      description: INVALID_DESCRIPTION,
+    })
+
+    expect(issue.identifier).toBe('SMI-9999')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0] as string).toContain('(bypassed)')
+  })
+
+  it('force as a string value ("true") bypasses, matching a two-token --force true CLI parse (H6)', async () => {
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, ISSUE_CREATE_RESPONSE])
+    process.env[SHADOW_VAR] = '0'
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const issue = await mod.createIssue({
+      title: 'String-force issue',
+      description: INVALID_DESCRIPTION,
+      force: 'true',
+    })
+
+    expect(issue.identifier).toBe('SMI-9999')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0] as string).toContain('(bypassed)')
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** the CLI fallback command for creating Linear issues (used when the normal integration is unavailable) now checks that a new issue has the required fields before creating it — matching the same check already in place on the two other creation paths. Non-compliant issues currently get a warning, not a block, while we confirm the check doesn't misfire on real traffic.

**Quality bar:** passed a 3-VP plan review before any code was written — it caught that going straight to "block" (the original plan) would have broken three live automated workflows that already call this command with issues that don't have the required fields. Also passed an independent cross-provider review (GPT-5.6-Sol) after implementation. 6 new tests, all passing; lint/typecheck/audit:standards all clean.

**Found along the way:** nothing new in this PR — the two related gaps found during planning were already filed as SMI-5854 and SMI-5855 and called out in Part 1's PR.

**Net result:** Fully shipped, in warn-only mode by default. A dated follow-up (2026-08-09, same date as the related MCP-tool guard) will review what the warnings caught before deciding whether to start blocking outright — by then, the three automated workflows this PR also updated should already be compliant.

---

## Technical detail

- `scripts/linear-api.mjs` — `validateIssueDescription` import; new `VALIDATION_DISABLE_ENV_VAR`/`VALIDATION_SHADOW_ENV_VAR`/`VALIDATION_SHADOW_END_DATE` constants; the gate lives inside the already-exported `createIssue()` (not the unexported `commands` object) and throws a plain `Error` on a blocked failure — `main()`'s existing top-level try/catch already converts that into the same CLI exit-1 behavior. `--force` (accepts `true`/`'true'`/`'1'`) and the disable env var both bypass regardless of shadow state.
- `.github/workflows/esm-sh-staleness-sweep.yml` (2 issue-body sites) and `.github/workflows/coverage-report.yml` (1 site) — added real `## Acceptance Criteria` sections so these three live call sites already comply before the shadow-end-date review.
- `scripts/tests/linear-api.test.ts` (new) — 6 cases covering valid/shadow-warn/shadow-blocked/force-bypass/env-bypass/string-force-value, using `vi.resetModules()` + per-test re-import to avoid this file's pre-existing `teamCache`/`stateCache` module-state bleeding between cases.
- Plan doc + plan-review + registry updates: `smith-horn/skillsmith-docs` #556 (shared with Part 1), #559.
- Rollout: `SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_DISABLE=1` hard-disables; `SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_SHADOW=0` lifts shadow mode to start blocking. Shadow-end-date (2026-08-09) matches SMI-5846's, so all three Linear-issue-creation enforcement layers can flip to blocking in one dated review instead of three staggered ones.
- Stacked on Part 1's branch (`fix/smi-5853-linear-issue-creation-gaps`, PR #2082) — this PR's base will need retargeting to `main` once #2082 merges.
