### PR TITLE
fix(scripts): resolve linear-api.mjs create-issue --parent/--labels to UUIDs (SMI-5854)

### DIFF
--- a/scripts/linear-api.mjs
+++ b/scripts/linear-api.mjs
@@ -819,4 +819,5 @@ export {
   getIssueId,
   resolveLabelIds,
   normalizeLabelEntries,
+  commands,
 }

--- a/scripts/linear-api.mjs
+++ b/scripts/linear-api.mjs
@@ -15,6 +15,18 @@
  * bypasses regardless of shadow state. See `help()` below for the full
  * flag/env-var reference.
  *
+ * `create-issue` also resolves `--parent`/`--labels` to real UUIDs
+ * (SMI-5854) instead of passing raw CLI values through to the mutation.
+ * `--parent` accepts an issue identifier (e.g. SMI-123) or an ID; an
+ * unresolvable parent throws (no silent orphan). `--labels` accepts
+ * comma-separated label names (matched exact-case) or IDs; an
+ * unresolvable/ambiguous label name is dropped with a warning and the
+ * issue is still created with whatever labels did resolve. Idempotent
+ * read queries (team/label/parent lookups) retry on transport failure or
+ * HTTP 429/5xx; the `issueCreate` mutation itself is never retried. Use
+ * `--dry-run` to resolve everything and print the mutation input without
+ * creating the issue.
+ *
  * Usage:
  *   node scripts/linear-api.mjs create-issue --title "Title" --description "Desc"
  *   node scripts/linear-api.mjs update-status --issue SMI-123 --status done
@@ -43,6 +55,14 @@ const VALIDATION_SHADOW_ENV_VAR = 'SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_SHADOW
 // dated follow-up review, not three staggered ones.
 export const VALIDATION_SHADOW_END_DATE = '2026-08-09'
 
+// SMI-5854: retry policy for idempotent READ queries only (team/label/
+// parent lookups). Never used for the issueCreate mutation.
+const RETRY_DELAYS_MS = [1000, 2000, 4000]
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+// Exact-name filter returns <= 1 label per team; a full page means the
+// name is ambiguous, not that pagination is needed.
+const LABEL_PAGE_SIZE = 50
+
 // State IDs for common workflow states (cached on first query)
 let stateCache = null
 let teamCache = null
@@ -68,16 +88,46 @@ async function graphql(query, variables = {}) {
 
   if (!response.ok) {
     const text = await response.text()
-    throw new Error(`Linear API error: ${response.status} ${text}`)
+    const err = new Error(`Linear API error: ${response.status} ${text}`)
+    err.status = response.status
+    throw err
   }
 
   const json = await response.json()
 
   if (json.errors) {
-    throw new Error(`GraphQL errors: ${JSON.stringify(json.errors, null, 2)}`)
+    const err = new Error(`GraphQL errors: ${JSON.stringify(json.errors, null, 2)}`)
+    err.graphqlError = true
+    throw err
   }
 
   return json.data
+}
+
+/**
+ * Whether a graphql() error is safe to retry. Deterministic
+ * application-level errors (json.errors) are never retryable; transport
+ * errors (no status) and HTTP 429/5xx are.
+ */
+function isRetryable(err) {
+  if (err?.graphqlError) return false
+  if (err?.status === undefined) return true
+  return err.status === 429 || (err.status >= 500 && err.status < 600)
+}
+
+/** Retry an idempotent READ query. Never used for mutations. */
+async function retryQuery(fn, delays = RETRY_DELAYS_MS) {
+  let lastErr
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    try {
+      return await fn()
+    } catch (e) {
+      lastErr = e
+      if (!isRetryable(e) || attempt === delays.length) throw e
+      await new Promise((resolve) => setTimeout(resolve, delays[attempt]))
+    }
+  }
+  throw lastErr
 }
 
 /**
@@ -148,6 +198,118 @@ async function getStates(teamKey = TEAM_KEY) {
 }
 
 /**
+ * Resolve an issue identifier (e.g. SMI-123) to its UUID. UUID input
+ * passes through unqueried. Returns null ONLY when the API successfully
+ * answered and no such issue exists — transport/5xx/429 failures
+ * propagate instead of masquerading as "not found".
+ */
+async function getIssueId(identifier) {
+  if (UUID_RE.test(identifier)) return identifier
+
+  const data = await retryQuery(() =>
+    graphql(
+      `
+        query ($id: String!) {
+          issue(id: $id) {
+            id
+          }
+        }
+      `,
+      { id: identifier }
+    )
+  )
+
+  return data.issue ? data.issue.id : null
+}
+
+/** Trim, drop blanks, dedupe preserving first-seen order. */
+function normalizeLabelEntries(entries) {
+  const seen = new Set()
+  const out = []
+  for (const raw of entries) {
+    const entry = String(raw).trim()
+    if (entry === '' || seen.has(entry)) continue
+    seen.add(entry)
+    out.push(entry)
+  }
+  return out
+}
+
+/**
+ * Resolve label names to UUIDs. UUID entries pass through unqueried.
+ * Exact-case team match, then exact-case workspace match; refuses to
+ * guess when more than one eligible node survives. Unresolvable/ambiguous
+ * entries are skipped with a warning and reported back to the caller via
+ * `omitted` rather than blocking issue creation.
+ *
+ * NOT wrapped in try/catch: an infrastructure failure must fail the
+ * creation, never masquerade as "label absent".
+ */
+async function resolveLabelIds(labels, teamKey = TEAM_KEY) {
+  const entries = normalizeLabelEntries(labels)
+  if (entries.length === 0) return { labelIds: [], omitted: [] }
+
+  const teamId = await retryQuery(() => getTeamId(teamKey))
+  const labelIds = []
+  const omitted = []
+
+  for (const entry of entries) {
+    if (UUID_RE.test(entry)) {
+      labelIds.push(entry)
+      continue
+    }
+
+    const data = await retryQuery(() =>
+      graphql(
+        `
+          query ($name: String!, $first: Int!) {
+            issueLabels(filter: { name: { eq: $name } }, first: $first) {
+              nodes {
+                id
+                name
+                team {
+                  id
+                }
+              }
+            }
+          }
+        `,
+        { name: entry, first: LABEL_PAGE_SIZE }
+      )
+    )
+    const nodes = data.issueLabels.nodes
+
+    // A full page means we cannot be confident we saw every candidate.
+    if (nodes.length >= LABEL_PAGE_SIZE) {
+      console.warn(`[linear-api] label "${entry}" matched ${nodes.length}+ labels — omitting it from this issue`)
+      omitted.push(entry)
+      continue
+    }
+
+    const teamMatches = nodes.filter((n) => n.team?.id === teamId)
+    const workspaceMatches = nodes.filter((n) => !n.team)
+    const eligible = teamMatches.length > 0 ? teamMatches : workspaceMatches
+
+    if (eligible.length === 0) {
+      // Zero nodes, or only other-team nodes — both are "not this team's label".
+      console.warn(`[linear-api] label "${entry}" not found — omitting it from this issue`)
+      omitted.push(entry)
+      continue
+    }
+    if (eligible.length > 1) {
+      console.warn(
+        `[linear-api] label "${entry}" matched ${eligible.length} labels, none unambiguously — omitting it from this issue`
+      )
+      omitted.push(entry)
+      continue
+    }
+    labelIds.push(eligible[0].id)
+  }
+
+  return { labelIds, omitted }
+}
+
+/**
  * Create a new issue
  */
 async function createIssue(options) {
@@ -159,6 +321,7 @@ async function createIssue(options) {
     parentId = null,
     teamKey = TEAM_KEY,
     force = false,
+    dryRun = false,
   } = options
 
   const descriptionText = typeof description === 'string' ? description : ''
@@ -191,7 +354,18 @@ async function createIssue(options) {
     }
   }
 
-  const teamId = await getTeamId(teamKey)
+  const teamId = await retryQuery(() => getTeamId(teamKey))
+
+  let resolvedParentId = null
+  if (parentId) {
+    resolvedParentId = await getIssueId(parentId)
+    if (!resolvedParentId) {
+      // No opt-out here: a silent orphan defeats the whole point of --parent.
+      throw new Error(`[linear-api] parent issue "${parentId}" not found — refusing to create an orphaned issue.`)
+    }
+  }
+
+  const { labelIds, omitted } = await resolveLabelIds(labels, teamKey)
 
   const input = {
     teamId,
@@ -200,12 +374,17 @@ async function createIssue(options) {
     priority,
   }
 
-  if (parentId) {
-    input.parentId = parentId
+  if (resolvedParentId) {
+    input.parentId = resolvedParentId
   }
 
-  if (labels.length > 0) {
-    input.labelIds = labels
+  if (labelIds.length > 0) {
+    input.labelIds = labelIds
+  }
+
+  if (dryRun) {
+    console.log(JSON.stringify({ input }, null, 2))
+    return { dryRun: true, input }
   }
 
   const data = await graphql(
@@ -227,6 +406,12 @@ async function createIssue(options) {
 
   if (!data.issueCreate.success) {
     throw new Error('Failed to create issue')
+  }
+
+  if (omitted.length > 0) {
+    console.warn(
+      `[linear-api] created ${data.issueCreate.issue.identifier} without requested label(s): ${omitted.join(', ')}`
+    )
   }
 
   return data.issueCreate.issue
@@ -446,6 +631,7 @@ function parseArgs(args) {
 const commands = {
   async 'create-issue'(args) {
     const { title, description, priority, labels, parent, force } = args
+    const dryRun = args['dry-run'] === true
 
     if (!title) {
       console.error('Error: --title is required')
@@ -459,7 +645,12 @@ const commands = {
       labels: labels ? labels.split(',') : [],
       parentId: parent || null,
       force,
+      dryRun,
     })
+
+    if (dryRun) {
+      return issue
+    }
 
     console.log(`Created: ${issue.identifier} - ${issue.title}`)
     console.log(`URL: ${issue.url}`)
@@ -546,10 +737,12 @@ Commands:
                     Acceptance-Criteria contract before the mutation,
                     SMI-5853 - see Environment below)
     --priority      Priority (1=urgent, 2=high, 3=medium, 4=low)
-    --labels        Comma-separated label IDs
-    --parent        Parent issue ID
+    --labels        Comma-separated label names (exact case) or IDs
+    --parent        Parent issue identifier (e.g. SMI-123) or ID
     --force         Bypass Acceptance-Criteria description validation,
                     regardless of shadow state (SMI-5853)
+    --dry-run       Resolve everything and print the mutation input
+                    without creating the issue
 
   update-status     Update issue status
     --issue         Issue identifier (e.g., SMI-123) (required)
@@ -623,4 +816,7 @@ export {
   getTeamId,
   getStates,
   graphql,
+  getIssueId,
+  resolveLabelIds,
+  normalizeLabelEntries,
 }

--- a/scripts/tests/linear-api-retry-classification.test.ts
+++ b/scripts/tests/linear-api-retry-classification.test.ts
@@ -1,0 +1,147 @@
+/**
+ * SMI-5854 (review follow-up): closes two test-coverage gaps a
+ * GPT-5.6-Sol cross-provider code review found in
+ * `linear-api-uuid-resolution.test.ts` — both are real gaps (verified
+ * against the actual code before fixing, not taken on faith):
+ *
+ * 1. `isRetryable()`'s classification was only exercised via 500/503
+ *    (retryable) and a GraphQL `errors` response (not retryable). Flipping
+ *    429 to non-retryable, or flipping an ordinary 4xx to retryable, or
+ *    breaking the no-`status` (pure transport failure) branch, would have
+ *    left every existing test green.
+ * 2. The one `--dry-run` test called `createIssue({ dryRun: true })`
+ *    directly, never exercising `commands['create-issue']`'s own
+ *    `args['dry-run'] === true` parsing — a typo'd flag name there would
+ *    also have left every existing test green.
+ *
+ * Split into its own file (rather than added to
+ * `linear-api-uuid-resolution.test.ts`) to stay clear of
+ * `scripts/check-file-length.mjs`'s 500-line pre-commit gate — that file
+ * was already at 471 lines.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  importLinearApi,
+  mockFetchSteps,
+  labelResponse,
+  TEAM_RESPONSE,
+  ISSUE_CREATE_RESPONSE,
+  VALID_DESCRIPTION,
+} from './linear-api-test-helpers'
+
+beforeEach(() => {
+  process.env.LINEAR_API_KEY = 'test-key'
+  vi.resetModules()
+})
+
+afterEach(() => {
+  // @ts-expect-error -- undo patch
+  delete global.fetch
+  vi.restoreAllMocks()
+})
+
+describe('retry classification (SMI-5854 review follow-up)', () => {
+  it('retries a 429 on the label-eq query, then succeeds', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'ok', body: TEAM_RESPONSE },
+      { kind: 'httpError', status: 429 },
+      {
+        kind: 'ok',
+        body: labelResponse([{ id: 'label-ci-uuid', name: 'ci', team: { id: 'team-uuid' } }]),
+      },
+      { kind: 'ok', body: ISSUE_CREATE_RESPONSE },
+    ])
+
+    const mod = await importLinearApi()
+    const promise = mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, labels: ['ci'] })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    const issue = await promise
+
+    expect(issue.identifier).toBe('SMI-9999')
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not retry a non-retryable 4xx (404) on the label-eq query', async () => {
+    const fetchMock = mockFetchSteps([
+      { kind: 'ok', body: TEAM_RESPONSE },
+      { kind: 'httpError', status: 404 },
+    ])
+
+    const mod = await importLinearApi()
+    await expect(
+      mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, labels: ['ci'] })
+    ).rejects.toThrow('404')
+
+    // team (1) + label-eq (1, no retry) = 2 — a 3rd call would mean 404 was
+    // incorrectly classified as retryable.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a pure transport failure (fetch() itself rejects, no status) on the parent lookup', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'ok', body: TEAM_RESPONSE },
+      { kind: 'transportError', error: new Error('ECONNRESET') },
+      { kind: 'ok', body: { data: { issue: { id: 'parent-uuid' } } } },
+      { kind: 'ok', body: ISSUE_CREATE_RESPONSE },
+    ])
+
+    const mod = await importLinearApi()
+    const promise = mod.createIssue({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+      parentId: 'SMI-4963',
+    })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    const issue = await promise
+
+    expect(issue.identifier).toBe('SMI-9999')
+    // team (1) + parent lookup (1 transport failure + 1 retry) + mutation (1) = 4
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+})
+
+describe('CLI --dry-run flag wiring (SMI-5854 review follow-up)', () => {
+  it('commands["create-issue"] with a parsed --dry-run flag skips issueCreate', async () => {
+    const fetchMock = mockFetchSteps([{ kind: 'ok', body: TEAM_RESPONSE }])
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    // Mirrors exactly what parseArgs() produces for a bare `--dry-run` flag
+    // (parseArgs sets `result[currentKey] = true` when no value token
+    // follows) — this is the CLI wiring itself, not createIssue() called
+    // directly with a dryRun option.
+    const result = (await mod.commands['create-issue']({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+      'dry-run': true,
+    })) as { dryRun: true; input: Record<string, unknown> }
+
+    expect(result.dryRun).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1) // team only — no issueCreate
+    const printedCall = logSpy.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('"input"')
+    )
+    expect(printedCall).toBeDefined()
+  })
+
+  it('commands["create-issue"] without --dry-run creates the issue for real', async () => {
+    const fetchMock = mockFetchSteps([
+      { kind: 'ok', body: TEAM_RESPONSE },
+      { kind: 'ok', body: ISSUE_CREATE_RESPONSE },
+    ])
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const issue = (await mod.commands['create-issue']({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+    })) as { identifier: string }
+
+    expect(issue.identifier).toBe('SMI-9999')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/scripts/tests/linear-api-test-helpers.ts
+++ b/scripts/tests/linear-api-test-helpers.ts
@@ -31,6 +31,7 @@ export interface CreatedIssue {
 
 export interface LinearApiModule {
   createIssue: (options: Record<string, unknown>) => Promise<CreatedIssue>
+  commands: Record<string, (args: Record<string, unknown>) => Promise<unknown>>
 }
 
 export interface LabelNode {
@@ -50,16 +51,22 @@ export function issueLookupResponse(id: string | null): GqlResponse {
 export type FetchStep =
   | { kind: 'ok'; body: GqlResponse }
   | { kind: 'httpError'; status: number; text?: string }
+  | { kind: 'transportError'; error?: Error }
 
 /**
  * Like mockFetchSequence(), but each step can also fail at the HTTP layer
- * (non-ok response) — needed for the retry/infrastructure-failure cases
- * (SMI-5854), which mockFetchSequence's always-ok shape can't express.
+ * (non-ok response) or reject outright at the transport layer (fetch()
+ * itself throwing, no response object at all) — needed for the
+ * retry/infrastructure-failure cases (SMI-5854), which mockFetchSequence's
+ * always-ok shape can't express.
  */
 export function mockFetchSteps(steps: FetchStep[]) {
   const fetchMock = vi.fn(async () => {
     const step = steps.shift()
     if (!step) throw new Error('fetch called more times than mocked steps')
+    if (step.kind === 'transportError') {
+      throw step.error ?? new Error('network down')
+    }
     if (step.kind === 'httpError') {
       return {
         ok: false,

--- a/scripts/tests/linear-api-test-helpers.ts
+++ b/scripts/tests/linear-api-test-helpers.ts
@@ -1,0 +1,143 @@
+/**
+ * Shared fixtures and helpers for `scripts/tests/linear-api.test.ts`
+ * (SMI-5853) and `scripts/tests/linear-api-uuid-resolution.test.ts`
+ * (SMI-5854), both of which exercise `scripts/linear-api.mjs`'s
+ * `createIssue()`.
+ *
+ * Split out of a single 656-line `linear-api.test.ts` to satisfy
+ * `scripts/check-file-length.mjs`'s 500-line pre-commit gate (hard fail,
+ * no grandfathering for new files). This module is deliberately NOT a test
+ * file itself — it must not match the `*.test.ts`/`*.spec.ts` naming
+ * vitest scans for (see `scripts/tests/**\/*.test.ts` in the Test File
+ * Locations table), or vitest would try to collect it as a suite with zero
+ * tests and fail.
+ *
+ * Pattern mirrors `scripts/tests/linear-upsert-drift-issue.test.ts`'s
+ * `mockFetchSequence()` helper.
+ */
+import { vi } from 'vitest'
+
+export interface GqlResponse {
+  data?: Record<string, unknown>
+  errors?: Array<{ message: string }>
+}
+
+export interface CreatedIssue {
+  id: string
+  identifier: string
+  title: string
+  url: string
+}
+
+export interface LinearApiModule {
+  createIssue: (options: Record<string, unknown>) => Promise<CreatedIssue>
+}
+
+export interface LabelNode {
+  id: string
+  name: string
+  team: { id: string } | null
+}
+
+export function labelResponse(nodes: LabelNode[]): GqlResponse {
+  return { data: { issueLabels: { nodes } } }
+}
+
+export function issueLookupResponse(id: string | null): GqlResponse {
+  return { data: { issue: id ? { id } : null } }
+}
+
+export type FetchStep =
+  | { kind: 'ok'; body: GqlResponse }
+  | { kind: 'httpError'; status: number; text?: string }
+
+/**
+ * Like mockFetchSequence(), but each step can also fail at the HTTP layer
+ * (non-ok response) — needed for the retry/infrastructure-failure cases
+ * (SMI-5854), which mockFetchSequence's always-ok shape can't express.
+ */
+export function mockFetchSteps(steps: FetchStep[]) {
+  const fetchMock = vi.fn(async () => {
+    const step = steps.shift()
+    if (!step) throw new Error('fetch called more times than mocked steps')
+    if (step.kind === 'httpError') {
+      return {
+        ok: false,
+        status: step.status,
+        json: async () => ({}),
+        text: async () => step.text ?? `error ${step.status}`,
+      } as unknown as Response
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => step.body,
+      text: async () => JSON.stringify(step.body),
+    } as unknown as Response
+  })
+  // @ts-expect-error -- patch global fetch
+  global.fetch = fetchMock
+  return fetchMock
+}
+
+export interface GqlRequestBody {
+  query: string
+  variables: Record<string, unknown>
+}
+
+/** Parse the JSON body of the Nth fetch() call for assertions. */
+export function requestBody(
+  fetchMock: ReturnType<typeof vi.fn>,
+  callIndex: number
+): GqlRequestBody {
+  const call = fetchMock.mock.calls[callIndex] as unknown as [string, { body: string }]
+  return JSON.parse(call[1].body) as GqlRequestBody
+}
+
+export function mockFetchSequence(responses: GqlResponse[]) {
+  const fetchMock = vi.fn(async () => {
+    const next = responses.shift()
+    if (!next) throw new Error('fetch called more times than mocked responses')
+    return {
+      ok: true,
+      status: 200,
+      json: async () => next,
+      text: async () => JSON.stringify(next),
+    } as unknown as Response
+  })
+  // @ts-expect-error -- patch global fetch
+  global.fetch = fetchMock
+  return fetchMock
+}
+
+export const TEAM_RESPONSE: GqlResponse = {
+  data: { teams: { nodes: [{ id: 'team-uuid', key: 'SMI', name: 'Skillsmith' }] } },
+}
+
+export const ISSUE_CREATE_RESPONSE: GqlResponse = {
+  data: {
+    issueCreate: {
+      success: true,
+      issue: {
+        id: 'new-uuid',
+        identifier: 'SMI-9999',
+        title: 'Test issue',
+        url: 'https://linear.app/smi/issue/SMI-9999',
+      },
+    },
+  },
+}
+
+// Compliant with validateIssueDescription's ported contract: non-empty,
+// >=120 body chars excluding heading lines, an "Acceptance Criteria"
+// heading, and >=2 non-placeholder bulleted items under it.
+export const VALID_DESCRIPTION = `This is a well-formed Linear issue description with enough body text to clear the minimum length requirement enforced by validateIssueDescription for a compliant issue.
+
+## Acceptance Criteria
+- [ ] The first acceptance criterion is met
+- [ ] The second acceptance criterion is met
+`
+
+export async function importLinearApi(): Promise<LinearApiModule> {
+  return (await import('../linear-api.mjs')) as unknown as LinearApiModule
+}

--- a/scripts/tests/linear-api-uuid-resolution.test.ts
+++ b/scripts/tests/linear-api-uuid-resolution.test.ts
@@ -1,0 +1,471 @@
+/**
+ * SMI-5854: Tests for `scripts/linear-api.mjs`'s `createIssue()`
+ * parent/label UUID resolution — resolving human-friendly `--parent`
+ * (issue identifier) and `--label` (name) CLI values to the UUIDs the
+ * Linear GraphQL API's `IssueCreateInput` actually requires, including
+ * disambiguation policy, CLI-value normalisation, retry behavior on
+ * infrastructure failures, and `--dry-run`.
+ *
+ * Split out of `scripts/tests/linear-api.test.ts` (SMI-5853's file) to
+ * keep both files under `scripts/check-file-length.mjs`'s 500-line
+ * pre-commit gate — see `scripts/tests/linear-api-test-helpers.ts` for the
+ * shared fixtures/helpers and its header comment for why that module isn't
+ * itself a `*.test.ts` file.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  importLinearApi,
+  mockFetchSequence,
+  mockFetchSteps,
+  labelResponse,
+  issueLookupResponse,
+  requestBody,
+  TEAM_RESPONSE,
+  ISSUE_CREATE_RESPONSE,
+  VALID_DESCRIPTION,
+  type LabelNode,
+} from './linear-api-test-helpers'
+
+beforeEach(() => {
+  process.env.LINEAR_API_KEY = 'test-key'
+  vi.resetModules()
+})
+
+afterEach(() => {
+  // @ts-expect-error -- undo patch
+  delete global.fetch
+  vi.restoreAllMocks()
+})
+
+describe('create-issue parent/label UUID resolution (SMI-5854)', () => {
+  afterEach(() => {
+    // Only the retry-backoff cases below enable fake timers; always reset so
+    // a failure inside one of them can't leak into a later test.
+    vi.useRealTimers()
+  })
+
+  // --- Happy path + passthrough --------------------------------------
+
+  it('resolves label names to UUIDs and sends them in labelIds', async () => {
+    const fetchMock = mockFetchSequence([
+      TEAM_RESPONSE,
+      labelResponse([{ id: 'label-security-uuid', name: 'Security', team: { id: 'team-uuid' } }]),
+      labelResponse([{ id: 'label-ci-uuid', name: 'ci', team: { id: 'team-uuid' } }]),
+      ISSUE_CREATE_RESPONSE,
+    ])
+
+    const mod = await importLinearApi()
+    await mod.createIssue({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+      labels: ['Security', 'ci'],
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    const body = requestBody(fetchMock, 3)
+    expect((body.variables.input as { labelIds?: string[] }).labelIds).toEqual([
+      'label-security-uuid',
+      'label-ci-uuid',
+    ])
+  })
+
+  it('passes a UUID-shaped label entry through without a lookup fetch', async () => {
+    const uuidLabel = '11111111-1111-1111-1111-111111111111'
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, ISSUE_CREATE_RESPONSE])
+
+    const mod = await importLinearApi()
+    await mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, labels: [uuidLabel] })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const body = requestBody(fetchMock, 1)
+    expect((body.variables.input as { labelIds?: string[] }).labelIds).toEqual([uuidLabel])
+  })
+
+  it('resolves a parent identifier to its UUID', async () => {
+    const fetchMock = mockFetchSequence([
+      TEAM_RESPONSE,
+      issueLookupResponse('parent-uuid'),
+      ISSUE_CREATE_RESPONSE,
+    ])
+
+    const mod = await importLinearApi()
+    await mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, parentId: 'SMI-4963' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    const body = requestBody(fetchMock, 2)
+    expect((body.variables.input as { parentId?: string }).parentId).toBe('parent-uuid')
+  })
+
+  it('passes a UUID-shaped parent through without an issue-query fetch', async () => {
+    const uuidParent = '22222222-2222-2222-2222-222222222222'
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, ISSUE_CREATE_RESPONSE])
+
+    const mod = await importLinearApi()
+    await mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, parentId: uuidParent })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const body = requestBody(fetchMock, 1)
+    expect((body.variables.input as { parentId?: string }).parentId).toBe(uuidParent)
+  })
+
+  it('omits parentId/labelIds entirely when neither is given (regression guard)', async () => {
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, ISSUE_CREATE_RESPONSE])
+
+    const mod = await importLinearApi()
+    await mod.createIssue({ title: 'T', description: VALID_DESCRIPTION })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const body = requestBody(fetchMock, 1)
+    expect(body.variables.input).not.toHaveProperty('parentId')
+    expect(body.variables.input).not.toHaveProperty('labelIds')
+  })
+
+  // --- Q1: resolution policy (parent fails hard, label warns) ---------
+
+  it('throws when --parent does not resolve, without ever calling issueCreate', async () => {
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, issueLookupResponse(null)])
+
+    const mod = await importLinearApi()
+    await expect(
+      mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, parentId: 'SMI-9999' })
+    ).rejects.toThrow('SMI-9999')
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('warns and omits an unresolvable label while still creating the issue (partial resolution)', async () => {
+    const fetchMock = mockFetchSequence([
+      TEAM_RESPONSE,
+      labelResponse([{ id: 'label-security-uuid', name: 'Security', team: { id: 'team-uuid' } }]),
+      labelResponse([]),
+      ISSUE_CREATE_RESPONSE,
+    ])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const issue = await mod.createIssue({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+      labels: ['Security', 'typo'],
+    })
+
+    expect(issue.identifier).toBe('SMI-9999')
+    const body = requestBody(fetchMock, 3)
+    expect((body.variables.input as { labelIds?: string[] }).labelIds).toEqual([
+      'label-security-uuid',
+    ])
+    const warnings = warnSpy.mock.calls.map((c) => c[0] as string)
+    expect(warnings.some((m) => m.includes('[linear-api]') && m.includes('"typo" not found'))).toBe(
+      true
+    )
+  })
+
+  it('prints a post-create summary naming the created issue and the omitted label', async () => {
+    mockFetchSequence([
+      TEAM_RESPONSE,
+      labelResponse([{ id: 'label-security-uuid', name: 'Security', team: { id: 'team-uuid' } }]),
+      labelResponse([]),
+      ISSUE_CREATE_RESPONSE,
+    ])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    await mod.createIssue({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+      labels: ['Security', 'typo'],
+    })
+
+    const warnings = warnSpy.mock.calls.map((c) => c[0] as string)
+    const summary = warnings.find((m) => m.includes('created SMI-9999'))
+    expect(summary).toBeDefined()
+    expect(summary).toContain('typo')
+  })
+
+  it('emits no summary warning when every label resolves', async () => {
+    mockFetchSequence([
+      TEAM_RESPONSE,
+      labelResponse([{ id: 'label-security-uuid', name: 'Security', team: { id: 'team-uuid' } }]),
+      ISSUE_CREATE_RESPONSE,
+    ])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    await mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, labels: ['Security'] })
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  // --- Q2: disambiguation ----------------------------------------------
+
+  it('prefers a team-SMI label match over a workspace-level match with the same name', async () => {
+    const fetchMock = mockFetchSequence([
+      TEAM_RESPONSE,
+      labelResponse([
+        { id: 'team-bug-uuid', name: 'Bug', team: { id: 'team-uuid' } },
+        { id: 'workspace-bug-uuid', name: 'Bug', team: null },
+      ]),
+      ISSUE_CREATE_RESPONSE,
+    ])
+
+    const mod = await importLinearApi()
+    await mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, labels: ['Bug'] })
+
+    const body = requestBody(fetchMock, 2)
+    expect((body.variables.input as { labelIds?: string[] }).labelIds).toEqual(['team-bug-uuid'])
+  })
+
+  it('resolves a workspace-level-only label match when no team match exists', async () => {
+    const fetchMock = mockFetchSequence([
+      TEAM_RESPONSE,
+      labelResponse([{ id: 'workspace-bug-uuid', name: 'Bug', team: null }]),
+      ISSUE_CREATE_RESPONSE,
+    ])
+
+    const mod = await importLinearApi()
+    await mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, labels: ['Bug'] })
+
+    const body = requestBody(fetchMock, 2)
+    expect((body.variables.input as { labelIds?: string[] }).labelIds).toEqual([
+      'workspace-bug-uuid',
+    ])
+  })
+
+  it('treats an other-team-only match as not found', async () => {
+    const fetchMock = mockFetchSequence([
+      TEAM_RESPONSE,
+      labelResponse([{ id: 'other-team-ci-uuid', name: 'ci', team: { id: 'other-team-uuid' } }]),
+      ISSUE_CREATE_RESPONSE,
+    ])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const issue = await mod.createIssue({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+      labels: ['ci'],
+    })
+
+    expect(issue.identifier).toBe('SMI-9999')
+    const body = requestBody(fetchMock, 2)
+    expect(body.variables.input).not.toHaveProperty('labelIds')
+    expect(warnSpy.mock.calls.some((c) => (c[0] as string).includes('"ci" not found'))).toBe(true)
+  })
+
+  it('refuses to guess when multiple team-SMI labels share a name', async () => {
+    const fetchMock = mockFetchSequence([
+      TEAM_RESPONSE,
+      labelResponse([
+        { id: 'dup-1', name: 'ci', team: { id: 'team-uuid' } },
+        { id: 'dup-2', name: 'ci', team: { id: 'team-uuid' } },
+      ]),
+      ISSUE_CREATE_RESPONSE,
+    ])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const issue = await mod.createIssue({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+      labels: ['ci'],
+    })
+
+    expect(issue.identifier).toBe('SMI-9999')
+    const body = requestBody(fetchMock, 2)
+    expect(body.variables.input).not.toHaveProperty('labelIds')
+    expect(warnSpy.mock.calls.some((c) => (c[0] as string).includes('none unambiguously'))).toBe(
+      true
+    )
+  })
+
+  it('treats a full 50-node page as ambiguous rather than silently accepting it', async () => {
+    const nodes: LabelNode[] = Array.from({ length: 50 }, (_, i) => ({
+      id: `label-${i}`,
+      name: 'ci',
+      team: { id: 'team-uuid' },
+    }))
+    const fetchMock = mockFetchSequence([
+      TEAM_RESPONSE,
+      labelResponse(nodes),
+      ISSUE_CREATE_RESPONSE,
+    ])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const issue = await mod.createIssue({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+      labels: ['ci'],
+    })
+
+    expect(issue.identifier).toBe('SMI-9999')
+    const body = requestBody(fetchMock, 2)
+    expect(body.variables.input).not.toHaveProperty('labelIds')
+    expect(warnSpy.mock.calls.some((c) => (c[0] as string).includes('matched 50+ labels'))).toBe(
+      true
+    )
+  })
+
+  // --- R3: CLI label normalisation --------------------------------------
+
+  it('trims whitespace from label entries before querying', async () => {
+    const fetchMock = mockFetchSequence([
+      TEAM_RESPONSE,
+      labelResponse([{ id: 'label-security-uuid', name: 'Security', team: { id: 'team-uuid' } }]),
+      labelResponse([{ id: 'label-ci-uuid', name: 'ci', team: { id: 'team-uuid' } }]),
+      ISSUE_CREATE_RESPONSE,
+    ])
+
+    const mod = await importLinearApi()
+    await mod.createIssue({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+      labels: 'Security, ci'.split(','),
+    })
+
+    expect(requestBody(fetchMock, 1).variables.name).toBe('Security')
+    expect(requestBody(fetchMock, 2).variables.name).toBe('ci')
+  })
+
+  it('dedupes a repeated label entry to a single lookup and a single UUID', async () => {
+    const fetchMock = mockFetchSequence([
+      TEAM_RESPONSE,
+      labelResponse([{ id: 'label-ci-uuid', name: 'ci', team: { id: 'team-uuid' } }]),
+      ISSUE_CREATE_RESPONSE,
+    ])
+
+    const mod = await importLinearApi()
+    await mod.createIssue({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+      labels: 'ci,ci'.split(','),
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    const body = requestBody(fetchMock, 2)
+    expect((body.variables.input as { labelIds?: string[] }).labelIds).toEqual(['label-ci-uuid'])
+  })
+
+  it('drops blank label entries entirely (no lookups, no labelIds key)', async () => {
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, ISSUE_CREATE_RESPONSE])
+
+    const mod = await importLinearApi()
+    await mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, labels: ','.split(',') })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const body = requestBody(fetchMock, 1)
+    expect(body.variables.input).not.toHaveProperty('labelIds')
+  })
+
+  // --- R4/R5: infrastructure failure vs absence, retry policy ----------
+
+  it('propagates a 500 on the label-eq query after retries are exhausted, without warn-and-omit', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'ok', body: TEAM_RESPONSE },
+      { kind: 'httpError', status: 500 },
+      { kind: 'httpError', status: 500 },
+      { kind: 'httpError', status: 500 },
+      { kind: 'httpError', status: 500 },
+    ])
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const promise = mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, labels: ['ci'] })
+    const assertion = expect(promise).rejects.toThrow('500')
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(4000)
+    await assertion
+
+    // team (1 success) + label-eq (1 initial + 3 retries, all failing) = 5
+    expect(fetchMock).toHaveBeenCalledTimes(5)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not retry a GraphQL errors response on the label-eq query', async () => {
+    const fetchMock = mockFetchSteps([
+      { kind: 'ok', body: TEAM_RESPONSE },
+      { kind: 'ok', body: { errors: [{ message: 'boom' }] } },
+    ])
+
+    const mod = await importLinearApi()
+    await expect(
+      mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, labels: ['ci'] })
+    ).rejects.toThrow('GraphQL errors')
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries once on a transient 503 on the label-eq query, then succeeds', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'ok', body: TEAM_RESPONSE },
+      { kind: 'httpError', status: 503 },
+      {
+        kind: 'ok',
+        body: labelResponse([{ id: 'label-ci-uuid', name: 'ci', team: { id: 'team-uuid' } }]),
+      },
+      { kind: 'ok', body: ISSUE_CREATE_RESPONSE },
+    ])
+
+    const mod = await importLinearApi()
+    const promise = mod.createIssue({ title: 'T', description: VALID_DESCRIPTION, labels: ['ci'] })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    const issue = await promise
+
+    expect(issue.identifier).toBe('SMI-9999')
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not retry the issueCreate mutation on a 500 (fails after exactly one attempt)', async () => {
+    const fetchMock = mockFetchSteps([
+      { kind: 'ok', body: TEAM_RESPONSE },
+      { kind: 'httpError', status: 500 },
+    ])
+
+    const mod = await importLinearApi()
+    await expect(mod.createIssue({ title: 'T', description: VALID_DESCRIPTION })).rejects.toThrow(
+      '500'
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  // --- Q5: --dry-run -----------------------------------------------------
+
+  it('--dry-run resolves everything and prints the input without creating the issue', async () => {
+    const fetchMock = mockFetchSequence([
+      TEAM_RESPONSE,
+      issueLookupResponse('parent-uuid'),
+      labelResponse([{ id: 'label-security-uuid', name: 'Security', team: { id: 'team-uuid' } }]),
+    ])
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    const mod = await importLinearApi()
+    const result = (await mod.createIssue({
+      title: 'T',
+      description: VALID_DESCRIPTION,
+      parentId: 'SMI-4963',
+      labels: ['Security'],
+      dryRun: true,
+    })) as unknown as { dryRun: true; input: Record<string, unknown> }
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(result.dryRun).toBe(true)
+    expect(result.input.teamId).toBe('team-uuid')
+    expect(result.input.parentId).toBe('parent-uuid')
+    expect(result.input.labelIds).toEqual(['label-security-uuid'])
+
+    const printedCall = logSpy.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('"input"')
+    )
+    expect(printedCall).toBeDefined()
+    const printed = JSON.parse(printedCall?.[0] as string) as { input: Record<string, unknown> }
+    expect(printed.input.teamId).toBe('team-uuid')
+    expect(printed.input.parentId).toBe('parent-uuid')
+    expect(printed.input.labelIds).toEqual(['label-security-uuid'])
+  })
+})

--- a/scripts/tests/linear-api.test.ts
+++ b/scripts/tests/linear-api.test.ts
@@ -20,82 +20,25 @@
  * doesn't leak between cases and silently change how many `fetch` calls a
  * given case's mocked sequence expects to see consumed.
  *
- * Pattern mirrors `scripts/tests/linear-upsert-drift-issue.test.ts`'s
- * `mockFetchSequence()` helper. The `vi.mock('node:child_process', ...)`
- * shape that file also uses is not needed here — `linear-api.mjs` never
- * shells out.
+ * Shared fixtures/helpers (also used by the SMI-5854 UUID-resolution suite
+ * in `scripts/tests/linear-api-uuid-resolution.test.ts`) live in
+ * `scripts/tests/linear-api-test-helpers.ts` — split out to keep this file
+ * under `scripts/check-file-length.mjs`'s 500-line pre-commit gate.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  importLinearApi,
+  mockFetchSequence,
+  TEAM_RESPONSE,
+  ISSUE_CREATE_RESPONSE,
+  VALID_DESCRIPTION,
+} from './linear-api-test-helpers'
 
 const DISABLE_VAR = 'SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_DISABLE'
 const SHADOW_VAR = 'SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_SHADOW'
 
-interface GqlResponse {
-  data?: Record<string, unknown>
-  errors?: Array<{ message: string }>
-}
-
-interface CreatedIssue {
-  id: string
-  identifier: string
-  title: string
-  url: string
-}
-
-interface LinearApiModule {
-  createIssue: (options: Record<string, unknown>) => Promise<CreatedIssue>
-}
-
-function mockFetchSequence(responses: GqlResponse[]) {
-  const fetchMock = vi.fn(async () => {
-    const next = responses.shift()
-    if (!next) throw new Error('fetch called more times than mocked responses')
-    return {
-      ok: true,
-      status: 200,
-      json: async () => next,
-      text: async () => JSON.stringify(next),
-    } as unknown as Response
-  })
-  // @ts-expect-error -- patch global fetch
-  global.fetch = fetchMock
-  return fetchMock
-}
-
-const TEAM_RESPONSE: GqlResponse = {
-  data: { teams: { nodes: [{ id: 'team-uuid', key: 'SMI', name: 'Skillsmith' }] } },
-}
-
-const ISSUE_CREATE_RESPONSE: GqlResponse = {
-  data: {
-    issueCreate: {
-      success: true,
-      issue: {
-        id: 'new-uuid',
-        identifier: 'SMI-9999',
-        title: 'Test issue',
-        url: 'https://linear.app/smi/issue/SMI-9999',
-      },
-    },
-  },
-}
-
-// Compliant with validateIssueDescription's ported contract: non-empty,
-// >=120 body chars excluding heading lines, an "Acceptance Criteria"
-// heading, and >=2 non-placeholder bulleted items under it.
-const VALID_DESCRIPTION = `This is a well-formed Linear issue description with enough body text to clear the minimum length requirement enforced by validateIssueDescription for a compliant issue.
-
-## Acceptance Criteria
-- [ ] The first acceptance criterion is met
-- [ ] The second acceptance criterion is met
-`
-
 // No Acceptance Criteria heading at all -> always fails validation.
 const INVALID_DESCRIPTION = 'Short description with no Acceptance Criteria section at all.'
-
-async function importLinearApi(): Promise<LinearApiModule> {
-  return (await import('../linear-api.mjs')) as unknown as LinearApiModule
-}
 
 beforeEach(() => {
   process.env.LINEAR_API_KEY = 'test-key'


### PR DESCRIPTION
## Business Summary

**What shipped:** the CLI fallback command for creating Linear issues now correctly translates a human-readable parent/label reference (like "SMI-4963" or "Security") into the actual internal ID Linear needs, instead of passing that text straight through. A missing parent now fails loudly instead of silently creating an orphaned issue; a missing label now just gets skipped with a warning so the issue still gets filed.

**Quality bar:** passed a plan review (GPT-5.6-Sol + an independent reconciliation pass) before any code was written — it caught that the originally-filed issue's description was partly wrong (parent linkage already worked in production; the real gap was untested label handling). An independent cross-provider code review after implementation found and required fixing 2 real test-coverage gaps. 27 new tests, all passing; lint/typecheck/audit:standards all clean; governance review separately confirmed 0 blocking findings.

**Found along the way:** two related-but-separate cleanup opportunities were spotted and filed as their own tracked work rather than folded in here — SMI-5858 (several scripts each reimplement their own Linear API client; worth consolidating into one shared one someday) and SMI-5859 (this same file's label-listing command under-reports past 50 labels — this PR works around that rather than fixing it, since the fix is a separable "list-labels output" bug).

**Net result:** Fully shipped, no follow-up needed on this PR.

---

## Technical detail

- `scripts/linear-api.mjs`'s `create-issue` command: new `getIssueId()` (resolves an `SMI-NNNN` identifier or passes a UUID through; throws if the parent genuinely doesn't exist — no bypass, since a silent orphan defeats the whole point of `--parent`) and `resolveLabelIds()` (per-name lookup with a disambiguation ladder — exact team match, then exact workspace match, then refuses to guess rather than picking an arbitrary match; an unresolvable/ambiguous label is dropped with a warning and the issue is still created, because the live CI workflow that calls this filed inside a `bash -e` loop where a hard failure would drop every remaining item in that run).
- Narrow retry policy (`retryQuery`/`isRetryable`): retries only the new read-only lookup queries on transport failure or HTTP 429/5xx — never the `issueCreate` mutation itself, so a transient failure can't cause a duplicate issue.
- New `--dry-run` flag: resolves everything and prints the exact mutation input without creating anything — the only way to verify the label-resolution path against the real API without leaving a permanent junk issue behind (this path had never been exercised in production before this PR).
- GPT-5.6-Sol review fixes (commit `49cc7c9f`): added retry-classification test coverage for HTTP 429, a non-retryable 4xx, and a pure transport failure (previously only 500/503 were tested, so a broken classification could have slipped through); added a test that actually exercises the CLI's `--dry-run` flag parsing end-to-end, rather than only testing the underlying function directly (a typo in the flag-parsing code would previously have gone undetected).
- Plan: `docs/internal/implementation/smi-5854-5855-linear-issue-label-parent-resolution.md` (merged, skillsmith-docs#560/#561). Governance reports: skillsmith-docs#562.
- Independent of the sibling SMI-5855 PR (`scripts/e2e/create-linear-issues.ts`) — separate branch off `main`, no shared files, no landing-order dependency.
