### PR TITLE
fix(scripts): paginate linear-api.mjs getLabels() (SMI-5859)

### DIFF
--- a/scripts/linear-api.mjs
+++ b/scripts/linear-api.mjs
@@ -63,6 +63,13 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 // name is ambiguous, not that pagination is needed.
 const LABEL_PAGE_SIZE = 50
 
+// SMI-5859: page size for getLabels()' full-listing query. Named for its one
+// call site rather than `LABELS_*` so it cannot be confused — by a reader or
+// by autocomplete — with LABEL_PAGE_SIZE above, whose 50 is an
+// ambiguity-detection threshold for the exact-name filter, not a paging size.
+// 250 is Linear's max `first`.
+const GET_LABELS_PAGE_SIZE = 250
+
 // State IDs for common workflow states (cached on first query)
 let stateCache = null
 let teamCache = null
@@ -584,27 +591,72 @@ async function listIssues(options = {}) {
 }
 
 /**
- * Get available labels
+ * Get available labels. Paginated (first/after + pageInfo, SMI-5859):
+ * the workspace has more labels than Linear's default page size (50),
+ * which this query previously relied on silently. Mirrors
+ * fetchOpenE2eIssueTitles() in scripts/e2e/create-linear-issues.linear-client.ts
+ * until SMI-5858 extracts the shared client.
+ *
+ * Throws rather than returning a partial list when the API reports another
+ * page but gives no usable way to reach it — see the invariant below.
  */
 async function getLabels(teamKey = TEAM_KEY) {
-  const teamId = await getTeamId(teamKey)
+  const teamId = await retryQuery(() => getTeamId(teamKey))
+  const labels = []
+  let after = null
 
-  const data = await graphql(
-    `
-      query GetLabels($teamId: ID!) {
-        issueLabels(filter: { team: { id: { eq: $teamId } } }) {
-          nodes {
-            id
-            name
-            color
+  for (;;) {
+    const data = await retryQuery(() =>
+      graphql(
+        `
+          query GetLabels($teamId: ID!, $first: Int!, $after: String) {
+            issueLabels(
+              filter: { team: { id: { eq: $teamId } } }
+              first: $first
+              after: $after
+            ) {
+              nodes {
+                id
+                name
+                color
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
           }
-        }
-      }
-    `,
-    { teamId }
-  )
+        `,
+        { teamId, first: GET_LABELS_PAGE_SIZE, after }
+      )
+    )
+    labels.push(...data.issueLabels.nodes)
 
-  return data.issueLabels.nodes
+    const { hasNextPage, endCursor } = data.issueLabels.pageInfo
+    if (!hasNextPage) break
+
+    // Cursor-progress invariant (SMI-5859). A page claiming hasNextPage but
+    // carrying no cursor, or repeating the cursor we just sent, cannot be
+    // advanced past. Throw instead of breaking: returning what we have would
+    // be a silent partial result indistinguishable from success — the exact
+    // failure class this function is being fixed to eliminate.
+    //
+    // Deliberately OUTSIDE the retryQuery() callback above. isRetryable()
+    // treats a status-less Error as retryable, so throwing from inside would
+    // spend 1s+2s+4s re-issuing the same request against a deterministic fault.
+    if (!endCursor || endCursor === after) {
+      throw new Error(
+        `Linear issueLabels pagination did not advance ` +
+          `(hasNextPage: true, endCursor: ${JSON.stringify(endCursor)}, ` +
+          `after: ${JSON.stringify(after)}); refusing to return ` +
+          `${labels.length} possibly-partial labels`
+      )
+    }
+
+    after = endCursor
+  }
+
+  return labels
 }
 
 // CLI Argument Parsing

--- a/scripts/tests/linear-api-test-helpers.ts
+++ b/scripts/tests/linear-api-test-helpers.ts
@@ -31,6 +31,7 @@ export interface CreatedIssue {
 
 export interface LinearApiModule {
   createIssue: (options: Record<string, unknown>) => Promise<CreatedIssue>
+  getLabels: (teamKey?: string) => Promise<GetLabelsNode[]>
   commands: Record<string, (args: Record<string, unknown>) => Promise<unknown>>
 }
 
@@ -42,6 +43,27 @@ export interface LabelNode {
 
 export function labelResponse(nodes: LabelNode[]): GqlResponse {
   return { data: { issueLabels: { nodes } } }
+}
+
+export interface GetLabelsNode {
+  id: string
+  name: string
+  color: string
+}
+
+export interface LabelsPageInfo {
+  hasNextPage: boolean
+  endCursor: string | null
+}
+
+/**
+ * Mocked `issueLabels` page response for getLabels()'s paginated query
+ * (SMI-5859) — distinct from labelResponse() above, whose fixed
+ * `{ nodes }` shape has no `pageInfo` and backs the unrelated
+ * exact-name-filter query.
+ */
+export function labelsPageResponse(nodes: GetLabelsNode[], pageInfo: LabelsPageInfo): GqlResponse {
+  return { data: { issueLabels: { nodes, pageInfo } } }
 }
 
 export function issueLookupResponse(id: string | null): GqlResponse {

--- a/scripts/tests/linear-api.test.ts
+++ b/scripts/tests/linear-api.test.ts
@@ -29,9 +29,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   importLinearApi,
   mockFetchSequence,
+  requestBody,
   TEAM_RESPONSE,
   ISSUE_CREATE_RESPONSE,
   VALID_DESCRIPTION,
+  labelsPageResponse,
 } from './linear-api-test-helpers'
 
 const DISABLE_VAR = 'SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_DISABLE'
@@ -159,5 +161,98 @@ describe('createIssue validation gate (SMI-5853)', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(warnSpy).toHaveBeenCalledTimes(1)
     expect(warnSpy.mock.calls[0]?.[0] as string).toContain('(bypassed)')
+  })
+})
+
+describe('getLabels pagination (SMI-5859)', () => {
+  it('merges multiple pages in order, paging first:250 with the right cursor each time', async () => {
+    const page1 = labelsPageResponse(
+      [
+        { id: 'label-1', name: 'Bug', color: '#e11d21' },
+        { id: 'label-2', name: 'Feature', color: '#2ecc40' },
+      ],
+      { hasNextPage: true, endCursor: 'cursor-1' }
+    )
+    const page2 = labelsPageResponse([{ id: 'label-3', name: 'Security', color: '#b71c1c' }], {
+      hasNextPage: false,
+      endCursor: null,
+    })
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, page1, page2])
+
+    const mod = await importLinearApi()
+    const labels = await mod.getLabels()
+
+    expect(labels).toEqual([
+      { id: 'label-1', name: 'Bug', color: '#e11d21' },
+      { id: 'label-2', name: 'Feature', color: '#2ecc40' },
+      { id: 'label-3', name: 'Security', color: '#b71c1c' },
+    ])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    const secondRequest = requestBody(fetchMock, 1)
+    const thirdRequest = requestBody(fetchMock, 2)
+    expect(secondRequest.variables.after).toBeNull()
+    expect(thirdRequest.variables.after).toBe('cursor-1')
+    expect(secondRequest.variables.first).toBe(250)
+    expect(thirdRequest.variables.first).toBe(250)
+  })
+
+  it('terminates after a single page with no phantom second-page request', async () => {
+    const page = labelsPageResponse(
+      [
+        { id: 'label-1', name: 'Bug', color: '#e11d21' },
+        { id: 'label-2', name: 'Feature', color: '#2ecc40' },
+      ],
+      { hasNextPage: false, endCursor: null }
+    )
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, page])
+
+    const mod = await importLinearApi()
+    const labels = await mod.getLabels()
+
+    expect(labels).toEqual([
+      { id: 'label-1', name: 'Bug', color: '#e11d21' },
+      { id: 'label-2', name: 'Feature', color: '#2ecc40' },
+    ])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects with a specific pagination-invariant message when hasNextPage is true but endCursor is null', async () => {
+    const page = labelsPageResponse(
+      [
+        { id: 'label-1', name: 'Bug', color: '#e11d21' },
+        { id: 'label-2', name: 'Feature', color: '#2ecc40' },
+      ],
+      { hasNextPage: true, endCursor: null }
+    )
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, page])
+
+    const mod = await importLinearApi()
+
+    await expect(mod.getLabels()).rejects.toThrow(/pagination did not advance/)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects with a specific pagination-invariant message when endCursor repeats the cursor just sent', async () => {
+    const page1 = labelsPageResponse(
+      [
+        { id: 'label-1', name: 'Bug', color: '#e11d21' },
+        { id: 'label-2', name: 'Feature', color: '#2ecc40' },
+      ],
+      { hasNextPage: true, endCursor: 'cursor-1' }
+    )
+    const page2 = labelsPageResponse([{ id: 'label-3', name: 'Security', color: '#b71c1c' }], {
+      hasNextPage: true,
+      endCursor: 'cursor-1',
+    })
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE, page1, page2])
+
+    const mod = await importLinearApi()
+
+    await expect(mod.getLabels()).rejects.toThrow(/pagination did not advance/)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    const thirdRequest = requestBody(fetchMock, 2)
+    expect(thirdRequest.variables.after).toBe('cursor-1')
   })
 })

--- a/scripts/tests/linear-api.test.ts
+++ b/scripts/tests/linear-api.test.ts
@@ -229,7 +229,9 @@ describe('getLabels pagination (SMI-5859)', () => {
 
     const mod = await importLinearApi()
 
-    await expect(mod.getLabels()).rejects.toThrow(/pagination did not advance/)
+    await expect(mod.getLabels()).rejects.toThrow(
+      'Linear issueLabels pagination did not advance (hasNextPage: true, endCursor: null, after: null); refusing to return 2 possibly-partial labels'
+    )
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
@@ -249,7 +251,9 @@ describe('getLabels pagination (SMI-5859)', () => {
 
     const mod = await importLinearApi()
 
-    await expect(mod.getLabels()).rejects.toThrow(/pagination did not advance/)
+    await expect(mod.getLabels()).rejects.toThrow(
+      'Linear issueLabels pagination did not advance (hasNextPage: true, endCursor: "cursor-1", after: "cursor-1"); refusing to return 3 possibly-partial labels'
+    )
     expect(fetchMock).toHaveBeenCalledTimes(3)
 
     const thirdRequest = requestBody(fetchMock, 2)


### PR DESCRIPTION
## Business Summary

**What shipped:** the CLI command that lists Linear labels (`list-labels`) was silently dropping about 70 of the workspace's ~120 labels — including a real label named "Security" — because it only ever asked Linear for the first page of results. It now pages through everything.

**Quality bar:** passed a plan review (GPT-5.6-Sol + an independent reconciliation pass) before any code was written — it caught that the plan's original fallback behavior (silently stop paging on a malformed response) would have recreated the exact silent-truncation bug this fix exists to eliminate, and required it to fail loudly instead. An independent cross-provider code review after implementation found one small test-quality gap (two tests checked only a generic error pattern instead of the exact diagnostic) — fixed. 10 tests passing, governance review 0 blocking findings.

**Found along the way:** two related-but-separate cleanup opportunities were spotted during a sibling PR's plan-review and filed as their own tracked work rather than folded in here — SMI-5858 (several scripts each reimplement their own Linear API client; being worked on right now) and SMI-5859, which is this PR itself.

**Net result:** Fully shipped. Live-verified against the real workspace: `list-labels` now returns 101 labels including "Security", up from the previous 50-row truncation.

---

## Technical detail

- `scripts/linear-api.mjs`'s `getLabels()`: now paginates via `first`/`after` + `pageInfo`, mirroring the already-reviewed `fetchOpenE2eIssueTitles()` pattern from SMI-5855. Both the team lookup and each page fetch wrap in the existing `retryQuery()` convention from SMI-5854 (idempotent reads only).
- Throws — does not silently return a partial list — when the API reports `hasNextPage: true` but the pagination cursor is missing or hasn't advanced. The throw sits outside the `retryQuery()` callback, since `isRetryable()` treats a status-less error as retryable and would otherwise burn 3 pointless retries against a deterministic fault.
- GPT-5.6-Sol review fix (commit `c188ede7`): the two invariant-violation tests now assert the exact thrown message (specific `endCursor`/`after`/label-count values) instead of a generic regex, so a bug that reports the wrong diagnostic values would actually be caught.
- Plan: `docs/internal/implementation/smi-5859-paginate-linear-labels.md` (PR #563). Governance report: `docs/internal/code_review/2026-07-27-smi-5859-getlabels-pagination-review.md`.
- Independent of the sibling SMI-5858 PR (shared Linear client extraction, in progress on the same worktree) — separate branch off `main`, no shared files yet, no landing-order dependency.
