### PR TITLE
refactor(scripts): extract shared Linear GraphQL client (SMI-5858)

### DIFF
--- a/scripts/e2e/create-linear-issues.linear-client.ts
+++ b/scripts/e2e/create-linear-issues.linear-client.ts
@@ -23,10 +23,18 @@ import type {
 } from './create-linear-issues.types.js'
 import {
   API_URL,
+  RETRY_DELAYS_MS,
   getTeamId as sharedGetTeamId,
   graphql,
   retryQuery,
 } from '../lib/linear-client.mjs'
+
+// Re-exported for parity with this file's pre-SMI-5858 public surface — no
+// current in-repo consumer imports these from here, but silently dropping a
+// module's exports during a "no behavior change" refactor is itself a
+// behavior change (GPT-5.6-Sol code review finding on commit 64a78d38).
+export const LINEAR_API_URL = API_URL
+export { RETRY_DELAYS_MS, graphql, retryQuery }
 
 export const TEAM_KEY = 'SMI'
 

--- a/scripts/e2e/create-linear-issues.linear-client.ts
+++ b/scripts/e2e/create-linear-issues.linear-client.ts
@@ -2,22 +2,33 @@
  * Linear API client for scripts/e2e/create-linear-issues.ts (SMI-5855).
  *
  * Split out to keep create-linear-issues.ts under the repo's 500-line
- * file-length gate. Deliberately self-contained (Q4 in the plan doc
+ * file-length gate. SMI-5858 extracted this file's transport/retry
+ * primitives (`graphql`/`isRetryable`/`retryQuery`) plus `getTeamId`'s
+ * underlying lookup into the shared `scripts/lib/linear-client.mjs` — four
+ * different Linear scripts had each independently hand-rolled a
+ * near-verbatim copy of that code, this one included. Label/issue
+ * resolution below (`resolveLabelId`, `getOrCreateAutoLabelId`,
+ * `fetchOpenE2eIssueTitles`, `createLinearIssue`) remains local and
+ * deliberately self-contained (Q4 in the plan doc
  * docs/internal/implementation/smi-5854-5855-linear-issue-label-parent-resolution.md)
  * rather than delegating to scripts/linear-api.mjs's createIssue() — this
  * mirrors scripts/linear-upsert-drift-issue.mjs's team/label resolution
- * pattern (getOrCreateAutoLabelId, retry-on-idempotent-reads) rather than
- * importing it, matching that script's own accepted duplication.
+ * pattern rather than importing it, matching that script's own accepted
+ * duplication.
  */
 import type {
   CreateIssueOutcome,
   GqlLabelNode,
   LinearIssueInput,
 } from './create-linear-issues.types.js'
+import {
+  API_URL,
+  getTeamId as sharedGetTeamId,
+  graphql,
+  retryQuery,
+} from '../lib/linear-client.mjs'
 
-export const LINEAR_API_URL = 'https://api.linear.app/graphql'
 export const TEAM_KEY = 'SMI'
-export const RETRY_DELAYS_MS = [1000, 2000, 4000]
 
 // `Bug` is workspace-level (team: null) and already exists — resolve-only,
 // NEVER get-or-create it (issueLabelCreate({ teamId, ... }) would mint a
@@ -30,98 +41,16 @@ export const AUTO_LABEL_NAME = 'e2e-failure-auto'
 export const AUTO_LABEL_COLOR = '#eb5757'
 
 /**
- * Execute a GraphQL query/mutation against the Linear API. Throws on
- * transport failure, a non-2xx HTTP response, or a GraphQL `errors` array —
- * callers must NOT wrap this in a catch-all that degrades an infrastructure
- * failure into "not found" (mirrors the SMI-5854 design constraint).
+ * Resolve the SMI team's UUID (retried read). Thin wrapper around the
+ * shared, single-attempt scripts/lib/linear-client.mjs#getTeamId
+ * (SMI-5858) — this function retried INSIDE itself pre-extraction, so the
+ * retry moves to this one line above the shared (single-attempt) call,
+ * preserving identical behavior: same 4 attempts, same delays, same
+ * classification, same not-found error, same zero-argument exported
+ * signature create-linear-issues.ts already calls it with.
  */
-export async function graphql(query: string, variables: Record<string, unknown> = {}) {
-  const apiKey = process.env.LINEAR_API_KEY
-  if (!apiKey) {
-    throw new Error('LINEAR_API_KEY environment variable is not set')
-  }
-
-  const response = await fetch(LINEAR_API_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: apiKey,
-    },
-    body: JSON.stringify({ query, variables }),
-  })
-
-  if (!response.ok) {
-    const text = await response.text()
-    const err = new Error(`Linear API error: ${response.status} ${text}`) as Error & {
-      status?: number
-    }
-    err.status = response.status
-    throw err
-  }
-
-  const json = await response.json()
-
-  if (json.errors) {
-    const err = new Error(`GraphQL errors: ${JSON.stringify(json.errors)}`) as Error & {
-      graphqlError?: boolean
-    }
-    err.graphqlError = true
-    throw err
-  }
-
-  return json.data
-}
-
-function isRetryable(err: unknown): boolean {
-  const e = err as { graphqlError?: boolean; status?: number } | undefined
-  if (e?.graphqlError) return false // deterministic, application-level — retrying re-fails
-  if (e?.status === undefined) return true // transport/network throw from fetch itself
-  return e.status === 429 || (e.status >= 500 && e.status < 600)
-}
-
-/**
- * Retry an idempotent READ query with exponential backoff. Never used for
- * `issueCreate`/`issueLabelCreate` mutations — a retried mutation after
- * Linear already committed the write would risk a duplicate.
- */
-export async function retryQuery<T>(
-  fn: () => Promise<T>,
-  delays: number[] = RETRY_DELAYS_MS
-): Promise<T> {
-  let lastErr: unknown
-  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
-    try {
-      return await fn()
-    } catch (e) {
-      lastErr = e
-      if (!isRetryable(e) || attempt === delays.length) throw e
-      await new Promise((resolve) => setTimeout(resolve, delays[attempt]))
-    }
-  }
-  throw lastErr
-}
-
-/** Resolve the SMI team's UUID (retried read). */
 export async function getTeamId(): Promise<string> {
-  const data = await retryQuery(() =>
-    graphql(
-      `
-        query ($key: String!) {
-          teams(filter: { key: { eq: $key } }) {
-            nodes {
-              id
-            }
-          }
-        }
-      `,
-      {
-        key: TEAM_KEY,
-      }
-    )
-  )
-  const team = data.teams.nodes[0]
-  if (!team) throw new Error(`Team "${TEAM_KEY}" not found`)
-  return team.id
+  return retryQuery(() => sharedGetTeamId(TEAM_KEY))
 }
 
 /**
@@ -277,7 +206,7 @@ export async function createLinearIssue(
 
   let response: Response
   try {
-    response = await fetch(LINEAR_API_URL, {
+    response = await fetch(API_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/scripts/e2e/create-linear-issues.ts
+++ b/scripts/e2e/create-linear-issues.ts
@@ -38,6 +38,9 @@
  * than importing it. Types live in `create-linear-issues.types.ts` and the
  * Linear GraphQL client lives in `create-linear-issues.linear-client.ts` —
  * both split out to keep this file under the repo's 500-line gate.
+ * (SMI-5858: that client's own transport/retry primitives now come from
+ * the shared `scripts/lib/linear-client.mjs`; this file's imports are
+ * unchanged.)
  */
 
 import { readFileSync, existsSync } from 'fs'

--- a/scripts/lib/linear-client.d.mts
+++ b/scripts/lib/linear-client.d.mts
@@ -1,0 +1,46 @@
+/**
+ * SMI-5858 — type declarations for scripts/lib/linear-client.mjs.
+ *
+ * Lets scripts/e2e/create-linear-issues.linear-client.ts (a .ts file)
+ * import the shared Linear GraphQL client cleanly under NodeNext module
+ * resolution without @ts-expect-error suppression. The .d.mts extension is
+ * the correct pairing for a .mjs module under NodeNext — mirrors
+ * scripts/lib/project-dir.d.mts's role for project-dir.mjs.
+ *
+ * `graphql()`'s return type is `Promise<any>` deliberately, not a lint
+ * oversight: it mirrors the pre-extraction local implementations (none of
+ * which annotated a return type — `response.json()` itself resolves to
+ * `any`, so every caller already read arbitrary GraphQL response shapes
+ * off it via duck typing). Typing it narrower here would force every call
+ * site to re-cast, for no safety gain.
+ */
+
+export interface GraphqlError extends Error {
+  status?: number
+  graphqlError?: boolean
+  graphqlErrors?: unknown
+}
+
+export const API_URL: string
+export const TEAM_KEY: string
+export const RETRY_DELAYS_MS: number[]
+export const UUID_RE: RegExp
+export const LABEL_PAGE_SIZE: number
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see header
+export function graphql(query: string, variables?: Record<string, unknown>): Promise<any>
+export function isRetryable(err: unknown): boolean
+export function withRetry<T>(
+  fn: () => Promise<T>,
+  delays?: number[],
+  isRetryableFn?: (err: unknown) => boolean
+): Promise<T>
+export function retryQuery<T>(fn: () => Promise<T>, delays?: number[]): Promise<T>
+export function getTeamId(teamKey?: string): Promise<string>
+export function getIssueId(identifier: string): Promise<string | null>
+export function normalizeLabelEntries(entries: Iterable<unknown>): string[]
+export function resolveLabelIds(
+  labels: Iterable<unknown>,
+  teamKey?: string,
+  resolveTeamId?: (teamKey: string) => Promise<string>
+): Promise<{ labelIds: string[]; omitted: string[] }>

--- a/scripts/lib/linear-client.mjs
+++ b/scripts/lib/linear-client.mjs
@@ -1,0 +1,330 @@
+/**
+ * Shared low-level Linear GraphQL client (SMI-5858).
+ *
+ * Extracted from `scripts/linear-api.mjs`'s transport/retry/lookup code,
+ * which four different scripts had each independently hand-rolled with
+ * subtly different retry policies: `scripts/linear-api.mjs` (the canonical
+ * CLI), `scripts/linear-upsert-drift-issue.mjs`, `scripts/lint-linear-issues.mjs`,
+ * and `scripts/e2e/create-linear-issues.linear-client.ts` (a near-verbatim TS
+ * port). This module is the single source of truth for the transport
+ * (`graphql`), the retry primitives (`isRetryable`/`withRetry`/`retryQuery`),
+ * and the team/issue/label lookups every one of those scripts needs.
+ *
+ * `getTeamId()`/`getIssueId()` are deliberately SINGLE-ATTEMPT — no retry
+ * logic inside either function. Three different callers apply three
+ * different retry policies to team/issue lookups today: `linear-api.mjs`
+ * wraps `getTeamId` externally with `retryQuery` at some call sites but not
+ * others (`getStates()` calls it unwrapped); `linear-upsert-drift-issue.mjs`
+ * wraps its whole multi-step operation — including team/issue lookups — in
+ * one catch-all `withRetry` that retries almost anything, including
+ * mutations; the e2e client's `getTeamId` used to retry INSIDE itself. If
+ * this shared function retried internally, any caller that ALSO wraps it
+ * externally would get nested retries (up to 4x4=16 real attempts), and any
+ * caller that then stopped wrapping externally would silently lose whatever
+ * policy it had. Pushing 100% of retry policy to call sites is the only way
+ * to keep every caller's existing behavior exactly intact. See each
+ * consumer's own call site for how it composes retry around these.
+ *
+ * `resolveLabelIds` is the one deliberate exception: it retries internally
+ * via its own `retryQuery()` calls, because it has exactly one consumer
+ * today (`linear-api.mjs`'s `createIssue`) — no cross-caller policy
+ * conflict to resolve.
+ */
+
+export const API_URL = 'https://api.linear.app/graphql'
+export const TEAM_KEY = 'SMI'
+
+// SMI-5854: retry policy for idempotent READ queries only (team/label/
+// parent lookups). Never used for mutations.
+export const RETRY_DELAYS_MS = [1000, 2000, 4000]
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+// Exact-name filter returns <= 1 label per team; a full page means the
+// name is ambiguous, not that pagination is needed.
+export const LABEL_PAGE_SIZE = 50
+
+/**
+ * Execute a GraphQL query against the Linear API.
+ *
+ * On a GraphQL `errors` response this throws an `Error` with two additive
+ * flags: `graphqlError = true` (existing convention — `isRetryable()` uses
+ * it to never retry a deterministic application-level error) and
+ * `graphqlErrors` (the raw `errors` array, SMI-5858 — lets
+ * `scripts/lint-linear-issues.mjs` reproduce its exact current stderr
+ * message without re-deriving it from `err.message`).
+ *
+ * @param {string} query
+ * @param {Record<string, unknown>} [variables]
+ * @returns {Promise<any>}
+ */
+export async function graphql(query, variables = {}) {
+  const apiKey = process.env.LINEAR_API_KEY
+
+  if (!apiKey) {
+    throw new Error('LINEAR_API_KEY environment variable is not set')
+  }
+
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: apiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    const err = new Error(`Linear API error: ${response.status} ${text}`)
+    err.status = response.status
+    throw err
+  }
+
+  const json = await response.json()
+
+  if (json.errors) {
+    const err = new Error(`GraphQL errors: ${JSON.stringify(json.errors, null, 2)}`)
+    err.graphqlError = true
+    err.graphqlErrors = json.errors
+    throw err
+  }
+
+  return json.data
+}
+
+/**
+ * Whether a graphql() error is safe to retry. Deterministic
+ * application-level errors (json.errors) are never retryable; transport
+ * errors (no status) and HTTP 429/5xx are.
+ *
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+export function isRetryable(err) {
+  if (err?.graphqlError) return false
+  if (err?.status === undefined) return true
+  return err.status === 429 || (err.status >= 500 && err.status < 600)
+}
+
+/**
+ * Retry an async function with exponential backoff, using a
+ * caller-supplied predicate to decide whether a given failure is
+ * retryable. Generalizes `retryQuery()` below so different callers can
+ * plug in different retry policies against the same backoff-loop shape
+ * (SMI-5858) — e.g. `scripts/lint-linear-issues.mjs` retries any HTTP
+ * status but never a deterministic GraphQL error, while
+ * `linear-upsert-drift-issue.mjs` retries almost anything including
+ * mutations.
+ *
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @param {number[]} [delays]
+ * @param {(err: unknown) => boolean} [isRetryableFn]
+ * @returns {Promise<T>}
+ */
+export async function withRetry(fn, delays = RETRY_DELAYS_MS, isRetryableFn = () => true) {
+  let lastErr
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    try {
+      return await fn()
+    } catch (e) {
+      lastErr = e
+      if (!isRetryableFn(e) || attempt === delays.length) throw e
+      await new Promise((resolve) => setTimeout(resolve, delays[attempt]))
+    }
+  }
+  throw lastErr
+}
+
+/**
+ * Retry an idempotent READ query. Never used for mutations. This is the
+ * classified retry convention every read-only caller in `linear-api.mjs`
+ * already uses — `withRetry(fn, delays, isRetryable)`.
+ *
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @param {number[]} [delays]
+ * @returns {Promise<T>}
+ */
+export async function retryQuery(fn, delays = RETRY_DELAYS_MS) {
+  return withRetry(fn, delays, isRetryable)
+}
+
+/**
+ * Get a team's UUID by key. SINGLE-ATTEMPT — do NOT wrap this function's
+ * body in `retryQuery()`/`withRetry()`; see this module's header for why.
+ * Callers that want retry apply it externally at their own call site.
+ * No caching here either — caching (where wanted) happens at the call
+ * site (see `scripts/linear-api.mjs`'s local `getTeamId` wrapper).
+ *
+ * Only selects the `id` field — nothing in the codebase reads `key`/`name`
+ * back off this query (a deliberate, plan-approved field-selection
+ * reduction, not an oversight).
+ *
+ * @param {string} [teamKey]
+ * @returns {Promise<string>}
+ */
+export async function getTeamId(teamKey = TEAM_KEY) {
+  const data = await graphql(
+    `
+      query GetTeam($key: String!) {
+        teams(filter: { key: { eq: $key } }) {
+          nodes {
+            id
+          }
+        }
+      }
+    `,
+    { key: teamKey }
+  )
+
+  const team = data.teams.nodes[0]
+  if (!team) {
+    throw new Error(`Team with key "${teamKey}" not found`)
+  }
+
+  return team.id
+}
+
+/**
+ * Resolve an issue identifier (e.g. SMI-123) to its UUID. UUID input
+ * passes through unqueried with zero fetch calls. Returns null ONLY when
+ * the API successfully answered and no such issue exists — transport/5xx/
+ * 429 failures propagate instead of masquerading as "not found".
+ * SINGLE-ATTEMPT — do NOT wrap this function's body in
+ * `retryQuery()`/`withRetry()`; see this module's header for why. Callers
+ * that want retry apply it externally at their own call site.
+ *
+ * @param {string} identifier
+ * @returns {Promise<string | null>}
+ */
+export async function getIssueId(identifier) {
+  if (UUID_RE.test(identifier)) return identifier
+
+  const data = await graphql(
+    `
+      query ($id: String!) {
+        issue(id: $id) {
+          id
+        }
+      }
+    `,
+    { id: identifier }
+  )
+
+  return data.issue ? data.issue.id : null
+}
+
+/**
+ * Trim, drop blanks, dedupe preserving first-seen order.
+ *
+ * @param {Iterable<unknown>} entries
+ * @returns {string[]}
+ */
+export function normalizeLabelEntries(entries) {
+  const seen = new Set()
+  const out = []
+  for (const raw of entries) {
+    const entry = String(raw).trim()
+    if (entry === '' || seen.has(entry)) continue
+    seen.add(entry)
+    out.push(entry)
+  }
+  return out
+}
+
+/**
+ * Resolve label names to UUIDs. UUID entries pass through unqueried.
+ * Exact-case team match, then exact-case workspace match; refuses to
+ * guess when more than one eligible node survives. Unresolvable/ambiguous
+ * entries are skipped with a warning and reported back to the caller via
+ * `omitted` rather than blocking issue creation.
+ *
+ * Deliberately exempt from the single-attempt rule above (see this
+ * module's header) — it has exactly one consumer today
+ * (`linear-api.mjs`'s `createIssue`), so there is no cross-caller retry
+ * policy conflict to resolve. Retries internally via `retryQuery()`.
+ *
+ * `resolveTeamId` (SMI-5858) defaults to this module's own, uncached
+ * `getTeamId` — but a caller that maintains its OWN cached team-lookup
+ * wrapper (e.g. `linear-api.mjs`'s local `getTeamId`, which checks
+ * `teamCache` first) should pass that wrapper through instead. Without
+ * this, a caller that already resolved `teamId` moments earlier via its
+ * own cached wrapper (as `createIssue()` does, to build the mutation
+ * input) would silently pay for a SECOND, redundant team-lookup fetch
+ * here — a real regression this extraction would otherwise introduce,
+ * since pre-extraction both call sites shared one module-scope cache and
+ * this function's internal lookup was a guaranteed cache hit.
+ *
+ * NOT wrapped in try/catch: an infrastructure failure must fail the
+ * creation, never masquerade as "label absent".
+ *
+ * @param {Iterable<unknown>} labels
+ * @param {string} [teamKey]
+ * @param {(teamKey: string) => Promise<string>} [resolveTeamId]
+ * @returns {Promise<{ labelIds: string[]; omitted: string[] }>}
+ */
+export async function resolveLabelIds(labels, teamKey = TEAM_KEY, resolveTeamId = getTeamId) {
+  const entries = normalizeLabelEntries(labels)
+  if (entries.length === 0) return { labelIds: [], omitted: [] }
+
+  const teamId = await retryQuery(() => resolveTeamId(teamKey))
+  const labelIds = []
+  const omitted = []
+
+  for (const entry of entries) {
+    if (UUID_RE.test(entry)) {
+      labelIds.push(entry)
+      continue
+    }
+
+    const data = await retryQuery(() =>
+      graphql(
+        `
+          query ($name: String!, $first: Int!) {
+            issueLabels(filter: { name: { eq: $name } }, first: $first) {
+              nodes {
+                id
+                name
+                team {
+                  id
+                }
+              }
+            }
+          }
+        `,
+        { name: entry, first: LABEL_PAGE_SIZE }
+      )
+    )
+    const nodes = data.issueLabels.nodes
+
+    // A full page means we cannot be confident we saw every candidate.
+    if (nodes.length >= LABEL_PAGE_SIZE) {
+      console.warn(
+        `[linear-api] label "${entry}" matched ${nodes.length}+ labels — omitting it from this issue`
+      )
+      omitted.push(entry)
+      continue
+    }
+
+    const teamMatches = nodes.filter((n) => n.team?.id === teamId)
+    const workspaceMatches = nodes.filter((n) => !n.team)
+    const eligible = teamMatches.length > 0 ? teamMatches : workspaceMatches
+
+    if (eligible.length === 0) {
+      // Zero nodes, or only other-team nodes — both are "not this team's label".
+      console.warn(`[linear-api] label "${entry}" not found — omitting it from this issue`)
+      omitted.push(entry)
+      continue
+    }
+    if (eligible.length > 1) {
+      console.warn(
+        `[linear-api] label "${entry}" matched ${eligible.length} labels, none unambiguously — omitting it from this issue`
+      )
+      omitted.push(entry)
+      continue
+    }
+    labelIds.push(eligible[0].id)
+  }
+
+  return { labelIds, omitted }
+}

--- a/scripts/lib/linear-client.mjs
+++ b/scripts/lib/linear-client.mjs
@@ -52,6 +52,21 @@ export const LABEL_PAGE_SIZE = 50
  * `scripts/lint-linear-issues.mjs` reproduce its exact current stderr
  * message without re-deriving it from `err.message`).
  *
+ * `err.message`'s `errors` dump is pretty-printed (`JSON.stringify(..., null, 2)`),
+ * matching `scripts/linear-api.mjs`'s pre-SMI-5858 canonical format, which this
+ * function is moved from verbatim. `scripts/linear-upsert-drift-issue.mjs` and
+ * `scripts/e2e/create-linear-issues.linear-client.ts` each independently
+ * hand-rolled a compact (non-pretty-printed) version before this extraction —
+ * a second, named exception to this refactor's no-behavior-change goal (GPT-5.6-Sol
+ * code review on commit 64a78d38), alongside the team-query field-selection
+ * reduction in the plan doc's Design Question 5. Verified no test or caller in
+ * either script depends on the exact compact format; `err.message` is not
+ * asserted anywhere, and the one place both scripts DO construct their own
+ * "GraphQL errors: ..." string outside this shared function (e.g.
+ * `create-linear-issues.linear-client.ts`'s `createLinearIssue()` failure
+ * `reason` text, built from a mutation response's `errors` field rather than
+ * from this function's thrown error) is untouched by this change.
+ *
  * @param {string} query
  * @param {Record<string, unknown>} [variables]
  * @returns {Promise<any>}

--- a/scripts/linear-api.mjs
+++ b/scripts/linear-api.mjs
@@ -43,9 +43,15 @@
  *     create-issue description block instead of warn (SMI-5853)
  */
 import { validateIssueDescription } from './lib/linear-issue-validation.mjs'
-
-const TEAM_KEY = 'SMI'
-const API_URL = 'https://api.linear.app/graphql'
+import {
+  TEAM_KEY,
+  graphql,
+  retryQuery,
+  getTeamId as sharedGetTeamId,
+  getIssueId as sharedGetIssueId,
+  normalizeLabelEntries,
+  resolveLabelIds,
+} from './lib/linear-client.mjs'
 
 const VALIDATION_DISABLE_ENV_VAR = 'SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_DISABLE'
 const VALIDATION_SHADOW_ENV_VAR = 'SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_SHADOW'
@@ -55,19 +61,11 @@ const VALIDATION_SHADOW_ENV_VAR = 'SKILLSMITH_LINEAR_API_ISSUE_VALIDATION_SHADOW
 // dated follow-up review, not three staggered ones.
 export const VALIDATION_SHADOW_END_DATE = '2026-08-09'
 
-// SMI-5854: retry policy for idempotent READ queries only (team/label/
-// parent lookups). Never used for the issueCreate mutation.
-const RETRY_DELAYS_MS = [1000, 2000, 4000]
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-// Exact-name filter returns <= 1 label per team; a full page means the
-// name is ambiguous, not that pagination is needed.
-const LABEL_PAGE_SIZE = 50
-
 // SMI-5859: page size for getLabels()' full-listing query. Named for its one
 // call site rather than `LABELS_*` so it cannot be confused — by a reader or
-// by autocomplete — with LABEL_PAGE_SIZE above, whose 50 is an
-// ambiguity-detection threshold for the exact-name filter, not a paging size.
-// 250 is Linear's max `first`.
+// by autocomplete — with LABEL_PAGE_SIZE (scripts/lib/linear-client.mjs),
+// whose 50 is an ambiguity-detection threshold for the exact-name filter,
+// not a paging size. 250 is Linear's max `first`.
 const GET_LABELS_PAGE_SIZE = 250
 
 // State IDs for common workflow states (cached on first query)
@@ -75,98 +73,20 @@ let stateCache = null
 let teamCache = null
 
 /**
- * Execute a GraphQL query against Linear API
- */
-async function graphql(query, variables = {}) {
-  const apiKey = process.env.LINEAR_API_KEY
-
-  if (!apiKey) {
-    throw new Error('LINEAR_API_KEY environment variable is not set')
-  }
-
-  const response = await fetch(API_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: apiKey,
-    },
-    body: JSON.stringify({ query, variables }),
-  })
-
-  if (!response.ok) {
-    const text = await response.text()
-    const err = new Error(`Linear API error: ${response.status} ${text}`)
-    err.status = response.status
-    throw err
-  }
-
-  const json = await response.json()
-
-  if (json.errors) {
-    const err = new Error(`GraphQL errors: ${JSON.stringify(json.errors, null, 2)}`)
-    err.graphqlError = true
-    throw err
-  }
-
-  return json.data
-}
-
-/**
- * Whether a graphql() error is safe to retry. Deterministic
- * application-level errors (json.errors) are never retryable; transport
- * errors (no status) and HTTP 429/5xx are.
- */
-function isRetryable(err) {
-  if (err?.graphqlError) return false
-  if (err?.status === undefined) return true
-  return err.status === 429 || (err.status >= 500 && err.status < 600)
-}
-
-/** Retry an idempotent READ query. Never used for mutations. */
-async function retryQuery(fn, delays = RETRY_DELAYS_MS) {
-  let lastErr
-  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
-    try {
-      return await fn()
-    } catch (e) {
-      lastErr = e
-      if (!isRetryable(e) || attempt === delays.length) throw e
-      await new Promise((resolve) => setTimeout(resolve, delays[attempt]))
-    }
-  }
-  throw lastErr
-}
-
-/**
- * Get team ID by key
+ * Get team ID by key. Local cache wrapper around the shared, single-attempt
+ * scripts/lib/linear-client.mjs#getTeamId (SMI-5858) — this function itself
+ * has no retry logic (matches pre-extraction behavior: it never had any);
+ * callers that want retry apply `retryQuery(() => getTeamId(teamKey))`
+ * explicitly at their own call site, same as before extraction.
  */
 async function getTeamId(teamKey = TEAM_KEY) {
   if (teamCache?.key === teamKey) {
     return teamCache.id
   }
 
-  const data = await graphql(
-    `
-      query GetTeam($key: String!) {
-        teams(filter: { key: { eq: $key } }) {
-          nodes {
-            id
-            key
-            name
-          }
-        }
-      }
-    `,
-    { key: teamKey }
-  )
-
-  const team = data.teams.nodes[0]
-  if (!team) {
-    throw new Error(`Team with key "${teamKey}" not found`)
-  }
-
-  teamCache = { key: teamKey, id: team.id, name: team.name }
-  return team.id
+  const id = await sharedGetTeamId(teamKey)
+  teamCache = { key: teamKey, id }
+  return id
 }
 
 /**
@@ -205,116 +125,15 @@ async function getStates(teamKey = TEAM_KEY) {
 }
 
 /**
- * Resolve an issue identifier (e.g. SMI-123) to its UUID. UUID input
- * passes through unqueried. Returns null ONLY when the API successfully
- * answered and no such issue exists — transport/5xx/429 failures
- * propagate instead of masquerading as "not found".
+ * Resolve an issue identifier (e.g. SMI-123) to its UUID. Thin retry
+ * wrapper around the shared, single-attempt
+ * scripts/lib/linear-client.mjs#getIssueId (SMI-5858) — this file's
+ * `getIssueId` retried internally pre-extraction, so this wrapper
+ * preserves that exported 4-attempt classified-retry behavior (skipping
+ * it would silently regress the `--parent` resolution path to zero
+ * retries).
  */
-async function getIssueId(identifier) {
-  if (UUID_RE.test(identifier)) return identifier
-
-  const data = await retryQuery(() =>
-    graphql(
-      `
-        query ($id: String!) {
-          issue(id: $id) {
-            id
-          }
-        }
-      `,
-      { id: identifier }
-    )
-  )
-
-  return data.issue ? data.issue.id : null
-}
-
-/** Trim, drop blanks, dedupe preserving first-seen order. */
-function normalizeLabelEntries(entries) {
-  const seen = new Set()
-  const out = []
-  for (const raw of entries) {
-    const entry = String(raw).trim()
-    if (entry === '' || seen.has(entry)) continue
-    seen.add(entry)
-    out.push(entry)
-  }
-  return out
-}
-
-/**
- * Resolve label names to UUIDs. UUID entries pass through unqueried.
- * Exact-case team match, then exact-case workspace match; refuses to
- * guess when more than one eligible node survives. Unresolvable/ambiguous
- * entries are skipped with a warning and reported back to the caller via
- * `omitted` rather than blocking issue creation.
- *
- * NOT wrapped in try/catch: an infrastructure failure must fail the
- * creation, never masquerade as "label absent".
- */
-async function resolveLabelIds(labels, teamKey = TEAM_KEY) {
-  const entries = normalizeLabelEntries(labels)
-  if (entries.length === 0) return { labelIds: [], omitted: [] }
-
-  const teamId = await retryQuery(() => getTeamId(teamKey))
-  const labelIds = []
-  const omitted = []
-
-  for (const entry of entries) {
-    if (UUID_RE.test(entry)) {
-      labelIds.push(entry)
-      continue
-    }
-
-    const data = await retryQuery(() =>
-      graphql(
-        `
-          query ($name: String!, $first: Int!) {
-            issueLabels(filter: { name: { eq: $name } }, first: $first) {
-              nodes {
-                id
-                name
-                team {
-                  id
-                }
-              }
-            }
-          }
-        `,
-        { name: entry, first: LABEL_PAGE_SIZE }
-      )
-    )
-    const nodes = data.issueLabels.nodes
-
-    // A full page means we cannot be confident we saw every candidate.
-    if (nodes.length >= LABEL_PAGE_SIZE) {
-      console.warn(`[linear-api] label "${entry}" matched ${nodes.length}+ labels — omitting it from this issue`)
-      omitted.push(entry)
-      continue
-    }
-
-    const teamMatches = nodes.filter((n) => n.team?.id === teamId)
-    const workspaceMatches = nodes.filter((n) => !n.team)
-    const eligible = teamMatches.length > 0 ? teamMatches : workspaceMatches
-
-    if (eligible.length === 0) {
-      // Zero nodes, or only other-team nodes — both are "not this team's label".
-      console.warn(`[linear-api] label "${entry}" not found — omitting it from this issue`)
-      omitted.push(entry)
-      continue
-    }
-    if (eligible.length > 1) {
-      console.warn(
-        `[linear-api] label "${entry}" matched ${eligible.length} labels, none unambiguously — omitting it from this issue`
-      )
-      omitted.push(entry)
-      continue
-    }
-    labelIds.push(eligible[0].id)
-  }
-
-  return { labelIds, omitted }
-}
+const getIssueId = (identifier) => retryQuery(() => sharedGetIssueId(identifier))
 
 /**
  * Create a new issue
@@ -372,7 +191,10 @@ async function createIssue(options) {
     }
   }
 
-  const { labelIds, omitted } = await resolveLabelIds(labels, teamKey)
+  // Passes this file's own CACHED getTeamId wrapper (SMI-5858) — teamId was
+  // just resolved above via the same wrapper, so resolveLabelIds's internal
+  // lookup hits that cache instead of firing a second, redundant fetch.
+  const { labelIds, omitted } = await resolveLabelIds(labels, teamKey, getTeamId)
 
   const input = {
     teamId,
@@ -594,8 +416,7 @@ async function listIssues(options = {}) {
  * Get available labels. Paginated (first/after + pageInfo, SMI-5859):
  * the workspace has more labels than Linear's default page size (50),
  * which this query previously relied on silently. Mirrors
- * fetchOpenE2eIssueTitles() in scripts/e2e/create-linear-issues.linear-client.ts
- * until SMI-5858 extracts the shared client.
+ * fetchOpenE2eIssueTitles() in scripts/e2e/create-linear-issues.linear-client.ts.
  *
  * Throws rather than returning a partial list when the API reports another
  * page but gives no usable way to reach it — see the invariant below.

--- a/scripts/linear-upsert-drift-issue.mjs
+++ b/scripts/linear-upsert-drift-issue.mjs
@@ -25,78 +25,18 @@
 import { readFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 
-const TEAM_KEY = 'SMI'
+// SMI-5858: graphql/getTeamId/withRetry/RETRY_DELAYS_MS moved to the shared
+// client. `withRetry` here is re-exported under its original name — its
+// default predicate (`() => true`) retries on ANY thrown error, matching
+// this file's pre-extraction always-retry semantics exactly (this file's
+// own tests assert 4-attempt/retry-any behavior).
+import { graphql, getTeamId, getIssueId, withRetry, RETRY_DELAYS_MS } from './lib/linear-client.mjs'
+
+export { withRetry }
+
 const PARENT_IDENTIFIER = 'SMI-4182'
 const AUTO_LABEL_NAME = 'version-drift-auto'
 const FALLBACK_GH_LABEL = 'linear-fallback'
-const RETRY_DELAYS_MS = [1000, 2000, 4000]
-const API_URL = 'https://api.linear.app/graphql'
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-/**
- * Run an async function with exponential backoff retries.
- * Retries on any thrown error; returns the resolved value on first success.
- * After all delays exhausted, re-throws the last error.
- */
-export async function withRetry(fn, delays = RETRY_DELAYS_MS) {
-  let lastErr
-  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
-    try {
-      return await fn()
-    } catch (e) {
-      lastErr = e
-      if (attempt < delays.length) {
-        await sleep(delays[attempt])
-      }
-    }
-  }
-  throw lastErr
-}
-
-async function graphql(query, variables = {}) {
-  const apiKey = process.env.LINEAR_API_KEY
-  if (!apiKey) {
-    throw new Error('LINEAR_API_KEY environment variable is not set')
-  }
-  const response = await fetch(API_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: apiKey,
-    },
-    body: JSON.stringify({ query, variables }),
-  })
-  if (!response.ok) {
-    const text = await response.text()
-    throw new Error(`Linear API error: ${response.status} ${text}`)
-  }
-  const json = await response.json()
-  if (json.errors) {
-    throw new Error(`GraphQL errors: ${JSON.stringify(json.errors)}`)
-  }
-  return json.data
-}
-
-async function getTeamId(teamKey = TEAM_KEY) {
-  const data = await graphql(
-    `
-      query ($key: String!) {
-        teams(filter: { key: { eq: $key } }) {
-          nodes {
-            id
-          }
-        }
-      }
-    `,
-    { key: teamKey }
-  )
-  const team = data.teams.nodes[0]
-  if (!team) throw new Error(`Team ${teamKey} not found`)
-  return team.id
-}
 
 async function getOrCreateAutoLabelId(teamId) {
   const found = await graphql(
@@ -134,20 +74,18 @@ async function getOrCreateAutoLabelId(teamId) {
   return created.issueLabelCreate.issueLabel.id
 }
 
+/**
+ * Thin wrapper around the shared, single-attempt
+ * scripts/lib/linear-client.mjs#getIssueId (SMI-5858) — that function
+ * returns `null` on "not found" rather than throwing, so this wrapper
+ * restores this file's own throw-on-not-found semantics. Retry is applied
+ * externally by the caller (`withRetry(() => getIssueIdByIdentifier(...))`
+ * in upsertDriftIssue()), same as before extraction.
+ */
 async function getIssueIdByIdentifier(identifier) {
-  const data = await graphql(
-    `
-      query ($id: String!) {
-        issue(id: $id) {
-          id
-          identifier
-        }
-      }
-    `,
-    { id: identifier }
-  )
-  if (!data.issue) throw new Error(`Issue ${identifier} not found`)
-  return data.issue.id
+  const id = await getIssueId(identifier)
+  if (!id) throw new Error(`Issue ${identifier} not found`)
+  return id
 }
 
 async function findExistingOpenAutoIssue(teamId, labelId) {

--- a/scripts/lint-linear-issues.mjs
+++ b/scripts/lint-linear-issues.mjs
@@ -34,10 +34,9 @@
  * npm script: npm run lint:linear-issues
  */
 import { validateIssueDescription } from './lib/linear-issue-validation.mjs'
+import { graphql, withRetry, RETRY_DELAYS_MS } from './lib/linear-client.mjs'
 
-const LINEAR_API_URL = 'https://api.linear.app/graphql'
 const TEAM_KEY = 'SMI'
-const RETRY_DELAYS = [1000, 2000, 4000]
 
 // Labels identifying issues created by this repo's own automation, not
 // human work items — these never carry an Acceptance Criteria section
@@ -71,29 +70,11 @@ export function parseArgs(argv) {
   return { since, json }
 }
 
-// --- Linear API (pattern matches scripts/linear-api.mjs / scripts/audit-linear-drift.mjs) ---
+// --- Linear API (SMI-5858: shared transport/retry, scripts/lib/linear-client.mjs) ---
 
-async function fetchWithRetry(url, options, retries = RETRY_DELAYS) {
-  for (let i = 0; i <= retries.length; i++) {
-    try {
-      const res = await fetch(url, options)
-      if (res.ok) return res
-      if (res.status >= 500 && i < retries.length) {
-        await new Promise((r) => setTimeout(r, retries[i]))
-        continue
-      }
-      throw new Error(`HTTP ${res.status}: ${await res.text()}`)
-    } catch (err) {
-      if (i < retries.length) {
-        await new Promise((r) => setTimeout(r, retries[i]))
-        continue
-      }
-      throw err
-    }
-  }
-}
-
-async function fetchRecentIssues(since) {
+// Exported (not just called from main()) so scripts/tests/lint-linear-issues.test.ts
+// can drive the pagination/retry/exit-on-GraphQL-error behavior directly.
+export async function fetchRecentIssues(since) {
   const apiKey = process.env.LINEAR_API_KEY
   if (!apiKey) {
     console.error('LINEAR_API_KEY not set.')
@@ -127,25 +108,30 @@ async function fetchRecentIssues(since) {
   let cursor = null
 
   do {
-    const res = await fetchWithRetry(LINEAR_API_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: apiKey,
-      },
-      body: JSON.stringify({
-        query,
-        variables: { after: cursor, since: since.toISOString() },
-      }),
-    })
-
-    const data = await res.json()
-    if (data.errors) {
-      console.error('lint-linear-issues: Linear query failed:', JSON.stringify(data.errors))
-      process.exit(2)
+    let data
+    try {
+      // Retries transport failures and any HTTP status (429/5xx/4xx —
+      // matching this script's real pre-extraction behavior) but NEVER a
+      // deterministic GraphQL body error: shared graphql() converts that
+      // into a throw with `graphqlError = true`, and retrying it 4 times
+      // (~7s of pointless backoff) before reaching the same exit code
+      // would be a real regression, not just wasted time.
+      data = await withRetry(
+        () => graphql(query, { after: cursor, since: since.toISOString() }),
+        RETRY_DELAYS_MS,
+        (err) => !err?.graphqlError
+      )
+    } catch (err) {
+      if (err?.graphqlError) {
+        console.error('lint-linear-issues: Linear query failed:', JSON.stringify(err.graphqlErrors))
+        process.exit(2)
+      }
+      // Non-GraphQL errors that exhaust retries rethrow normally (as
+      // today) — main()'s own top-level catch converts them to exit 2.
+      throw err
     }
 
-    const { nodes, pageInfo } = data.data.issues
+    const { nodes, pageInfo } = data.issues
     allIssues.push(...nodes)
     cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null
   } while (cursor)

--- a/scripts/tests/linear-client.test.ts
+++ b/scripts/tests/linear-client.test.ts
@@ -1,0 +1,379 @@
+/**
+ * SMI-5858: Unit tests for the shared low-level Linear GraphQL client
+ * (`scripts/lib/linear-client.mjs`).
+ *
+ * This module is the single source of truth for the transport (`graphql`),
+ * the retry primitives (`isRetryable`/`withRetry`/`retryQuery`), and the
+ * team/issue/label lookups now shared by `scripts/linear-api.mjs`,
+ * `scripts/linear-upsert-drift-issue.mjs`, `scripts/lint-linear-issues.mjs`,
+ * and `scripts/e2e/create-linear-issues.linear-client.ts`.
+ *
+ * The most important invariant this file guards: `getTeamId`/`getIssueId`
+ * are SINGLE-ATTEMPT — no retry inside either function (see the module
+ * header comment in `scripts/lib/linear-client.mjs` for why). If someone
+ * later "helpfully" adds retry back into either function, the
+ * single-fetch-call assertions below fail immediately. `resolveLabelIds`
+ * is the deliberate exception — it retries internally — and is tested here
+ * as a contrast case.
+ *
+ * Reuses the mock-fetch fixtures/helpers from
+ * `scripts/tests/linear-api-test-helpers.ts` (originally split out for
+ * `linear-api.test.ts` / `linear-api-uuid-resolution.test.ts`) rather than
+ * duplicating them.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import {
+  API_URL,
+  TEAM_KEY,
+  RETRY_DELAYS_MS,
+  UUID_RE,
+  LABEL_PAGE_SIZE,
+  graphql,
+  isRetryable,
+  withRetry,
+  retryQuery,
+  getTeamId,
+  getIssueId,
+  normalizeLabelEntries,
+  resolveLabelIds,
+} from '../lib/linear-client.mjs'
+import {
+  mockFetchSequence,
+  mockFetchSteps,
+  labelResponse,
+  issueLookupResponse,
+  TEAM_RESPONSE,
+} from './linear-api-test-helpers'
+
+/** A status-flagged error, mirroring what graphql() attaches on a non-OK HTTP response. */
+function statusError(status: number, message = `HTTP ${status}`): Error & { status: number } {
+  const err = new Error(message) as Error & { status: number }
+  err.status = status
+  return err
+}
+
+/** A graphqlError-flagged error, mirroring what graphql() throws on a GraphQL `errors` body. */
+function graphqlFlaggedError(
+  graphqlErrors: unknown = [{ message: 'boom' }]
+): Error & { graphqlError: true; graphqlErrors: unknown } {
+  const err = new Error('GraphQL errors') as Error & {
+    graphqlError: true
+    graphqlErrors: unknown
+  }
+  err.graphqlError = true
+  err.graphqlErrors = graphqlErrors
+  return err
+}
+
+beforeEach(() => {
+  process.env.LINEAR_API_KEY = 'test-key'
+})
+
+afterEach(() => {
+  // @ts-expect-error -- undo patch
+  delete global.fetch
+  delete process.env.LINEAR_API_KEY
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('constants (SMI-5858)', () => {
+  it('exposes the expected values', () => {
+    expect(API_URL).toBe('https://api.linear.app/graphql')
+    expect(TEAM_KEY).toBe('SMI')
+    expect(RETRY_DELAYS_MS).toEqual([1000, 2000, 4000])
+    expect(LABEL_PAGE_SIZE).toBe(50)
+    expect(UUID_RE.test('11111111-1111-1111-1111-111111111111')).toBe(true)
+    expect(UUID_RE.test('SMI-123')).toBe(false)
+  })
+})
+
+describe('graphql (SMI-5858)', () => {
+  it('throws when LINEAR_API_KEY is not set', async () => {
+    delete process.env.LINEAR_API_KEY
+    await expect(graphql('query {}')).rejects.toThrow(
+      'LINEAR_API_KEY environment variable is not set'
+    )
+  })
+
+  it('sets .status on a non-OK HTTP response', async () => {
+    mockFetchSteps([{ kind: 'httpError', status: 500, text: 'server error' }])
+    const err = (await graphql('query {}').catch((e) => e)) as Error & { status?: number }
+    expect(err).toBeInstanceOf(Error)
+    expect(err.status).toBe(500)
+  })
+
+  it('sets .graphqlError AND the raw .graphqlErrors array on a GraphQL body error (SMI-5858 additive property)', async () => {
+    const errorsArray = [{ message: 'boom' }]
+    mockFetchSteps([{ kind: 'ok', body: { errors: errorsArray } }])
+    const err = (await graphql('query {}').catch((e) => e)) as Error & {
+      graphqlError?: boolean
+      graphqlErrors?: unknown
+    }
+    expect(err.graphqlError).toBe(true)
+    expect(err.graphqlErrors).toEqual(errorsArray)
+  })
+
+  it('returns json.data on success', async () => {
+    mockFetchSteps([{ kind: 'ok', body: { data: { hello: 'world' } } }])
+    const data = await graphql('query {}')
+    expect(data).toEqual({ hello: 'world' })
+  })
+})
+
+describe('isRetryable (SMI-5858) - classification table', () => {
+  it('treats a status-less error (pure transport failure) as retryable', () => {
+    expect(isRetryable(new Error('ECONNRESET'))).toBe(true)
+  })
+
+  it('treats HTTP 429 as retryable', () => {
+    expect(isRetryable(statusError(429))).toBe(true)
+  })
+
+  it('treats HTTP 5xx (500 and 599) as retryable', () => {
+    expect(isRetryable(statusError(500))).toBe(true)
+    expect(isRetryable(statusError(599))).toBe(true)
+  })
+
+  it('treats an ordinary 4xx (404) as NOT retryable', () => {
+    expect(isRetryable(statusError(404))).toBe(false)
+  })
+
+  it('never retries a graphqlError, regardless of status', () => {
+    expect(isRetryable(graphqlFlaggedError())).toBe(false)
+  })
+})
+
+describe('withRetry (SMI-5858)', () => {
+  it('returns on first success without ever consulting the predicate', async () => {
+    const fn = vi.fn().mockResolvedValue('ok')
+    const predicate = vi.fn(() => true)
+    const result = await withRetry(fn, RETRY_DELAYS_MS, predicate)
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(predicate).not.toHaveBeenCalled()
+  })
+
+  it('retries per a custom predicate, waiting exactly RETRY_DELAYS_MS between attempts', async () => {
+    vi.useFakeTimers()
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('e1'))
+      .mockRejectedValueOnce(new Error('e2'))
+      .mockResolvedValueOnce('ok')
+    const predicate = vi.fn(() => true)
+
+    const promise = withRetry(fn, RETRY_DELAYS_MS, predicate)
+    // Nothing resolves before the first backoff (1000ms) elapses.
+    await vi.advanceTimersByTimeAsync(999)
+    expect(fn).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(fn).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(fn).toHaveBeenCalledTimes(3)
+
+    const result = await promise
+    expect(result).toBe('ok')
+    expect(predicate).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops immediately (no further attempts, no delay) when the predicate returns false', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('nope'))
+    const predicate = vi.fn(() => false)
+
+    await expect(withRetry(fn, RETRY_DELAYS_MS, predicate)).rejects.toThrow('nope')
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(predicate).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws the last error once all delays are exhausted, even with an always-retryable predicate', async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockRejectedValue(new Error('always fails'))
+
+    const promise = withRetry(fn, RETRY_DELAYS_MS, () => true)
+    const assertion = expect(promise).rejects.toThrow('always fails')
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(4000)
+    await assertion
+
+    // delays.length + 1 = 4 total attempts.
+    expect(fn).toHaveBeenCalledTimes(4)
+  })
+
+  it('defaults delays to RETRY_DELAYS_MS and the predicate to always-retry when omitted', async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockRejectedValueOnce(new Error('e1')).mockResolvedValueOnce('ok')
+
+    const promise = withRetry(fn)
+    await vi.advanceTimersByTimeAsync(1000)
+    const result = await promise
+
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('retryQuery (SMI-5858) - the classified convention (withRetry + isRetryable)', () => {
+  it('retries a retryable (status-less/transport) failure then succeeds', async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValueOnce('ok')
+    const promise = retryQuery(fn)
+    await vi.advanceTimersByTimeAsync(1000)
+    const result = await promise
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a 429/5xx failure then succeeds', async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockRejectedValueOnce(statusError(503)).mockResolvedValueOnce('ok')
+    const promise = retryQuery(fn)
+    await vi.advanceTimersByTimeAsync(1000)
+    const result = await promise
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT retry a graphqlError-flagged failure', async () => {
+    const fn = vi.fn().mockRejectedValue(graphqlFlaggedError())
+    await expect(retryQuery(fn)).rejects.toThrow('GraphQL errors')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT retry a non-retryable 4xx status', async () => {
+    const fn = vi.fn().mockRejectedValue(statusError(404))
+    await expect(retryQuery(fn)).rejects.toThrow('HTTP 404')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('normalizeLabelEntries (SMI-5858)', () => {
+  it('trims whitespace, drops blanks, and dedupes preserving first-seen order', () => {
+    expect(normalizeLabelEntries([' ci ', 'ci', '', '   ', 'Security'])).toEqual(['ci', 'Security'])
+  })
+})
+
+describe('getTeamId (SMI-5858) - single-attempt invariant', () => {
+  it('resolves the team id from a single fetch call', async () => {
+    const fetchMock = mockFetchSequence([TEAM_RESPONSE])
+    const id = await getTeamId('SMI')
+    expect(id).toBe('team-uuid')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('REGRESSION GUARD: rethrows a retryable-class failure (500) after exactly ONE fetch call — no retry inside getTeamId itself', async () => {
+    const fetchMock = mockFetchSteps([{ kind: 'httpError', status: 500 }])
+    await expect(getTeamId('SMI')).rejects.toThrow('500')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('REGRESSION GUARD: rethrows a pure transport failure after exactly ONE fetch call — no retry inside getTeamId itself', async () => {
+    const fetchMock = mockFetchSteps([{ kind: 'transportError', error: new Error('ECONNRESET') }])
+    await expect(getTeamId('SMI')).rejects.toThrow('ECONNRESET')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws a not-found error when no team node is returned, after one fetch call', async () => {
+    const fetchMock = mockFetchSequence([{ data: { teams: { nodes: [] } } }])
+    await expect(getTeamId('NOPE')).rejects.toThrow('Team with key "NOPE" not found')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('getIssueId (SMI-5858) - single-attempt invariant', () => {
+  it('passes a UUID-shaped identifier through with ZERO fetch calls', async () => {
+    const fetchMock = mockFetchSequence([])
+    const uuid = '11111111-1111-1111-1111-111111111111'
+    const id = await getIssueId(uuid)
+    expect(id).toBe(uuid)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves a non-UUID identifier from a single fetch call', async () => {
+    const fetchMock = mockFetchSequence([issueLookupResponse('issue-uuid')])
+    const id = await getIssueId('SMI-123')
+    expect(id).toBe('issue-uuid')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null (not a throw) when the API answers with no matching issue, after one fetch call', async () => {
+    const fetchMock = mockFetchSequence([issueLookupResponse(null)])
+    const id = await getIssueId('SMI-999')
+    expect(id).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('REGRESSION GUARD: rethrows a retryable-class (transport) failure after exactly ONE fetch call — no retry inside getIssueId itself', async () => {
+    const fetchMock = mockFetchSteps([{ kind: 'transportError', error: new Error('ECONNRESET') }])
+    await expect(getIssueId('SMI-123')).rejects.toThrow('ECONNRESET')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('resolveLabelIds (SMI-5858) - contrast: DOES retry internally (unlike getTeamId/getIssueId)', () => {
+  it('retries a transient failure on the team lookup, then succeeds', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'httpError', status: 503 },
+      { kind: 'ok', body: TEAM_RESPONSE },
+      {
+        kind: 'ok',
+        body: labelResponse([{ id: 'label-uuid', name: 'ci', team: { id: 'team-uuid' } }]),
+      },
+    ])
+    const promise = resolveLabelIds(['ci'], 'SMI')
+    await vi.advanceTimersByTimeAsync(1000)
+    const result = await promise
+    expect(result.labelIds).toEqual(['label-uuid'])
+    expect(result.omitted).toEqual([])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('retries a transient failure on the label-eq lookup itself, then succeeds', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'ok', body: TEAM_RESPONSE },
+      { kind: 'httpError', status: 500 },
+      {
+        kind: 'ok',
+        body: labelResponse([{ id: 'label-uuid', name: 'ci', team: { id: 'team-uuid' } }]),
+      },
+    ])
+    const promise = resolveLabelIds(['ci'], 'SMI')
+    await vi.advanceTimersByTimeAsync(1000)
+    const result = await promise
+    expect(result.labelIds).toEqual(['label-uuid'])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns empty labelIds/omitted with zero fetch calls when given no label entries', async () => {
+    const fetchMock = mockFetchSequence([])
+    const result = await resolveLabelIds([], 'SMI')
+    expect(result).toEqual({ labelIds: [], omitted: [] })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("REGRESSION GUARD (SMI-5858): an injected resolveTeamId is used instead of this module's own getTeamId, avoiding a redundant fetch when the caller already has a cached team id", async () => {
+    // Mirrors linear-api.mjs's own call site: it resolves teamId once via
+    // its own CACHED local getTeamId wrapper, then passes that same
+    // wrapper into resolveLabelIds so the internal lookup here is a cache
+    // hit, not a second live fetch. Without the `resolveTeamId` DI
+    // parameter, this function would call the shared (uncached) getTeamId
+    // internally regardless of what the caller already resolved.
+    const fetchMock = mockFetchSequence([
+      labelResponse([{ id: 'label-uuid', name: 'ci', team: { id: 'cached-team-uuid' } }]),
+    ])
+    const cachedResolveTeamId = vi.fn(async () => 'cached-team-uuid')
+
+    const result = await resolveLabelIds(['ci'], 'SMI', cachedResolveTeamId)
+
+    expect(result.labelIds).toEqual(['label-uuid'])
+    expect(cachedResolveTeamId).toHaveBeenCalledTimes(1)
+    expect(cachedResolveTeamId).toHaveBeenCalledWith('SMI')
+    // Only the label-eq lookup hits fetch; the team id came from the
+    // injected function, not from this module's own graphql()/getTeamId.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/scripts/tests/lint-linear-issues.test.ts
+++ b/scripts/tests/lint-linear-issues.test.ts
@@ -4,8 +4,16 @@
  * The `validateIssueDescription` validation-contract tests moved to
  * `scripts/tests/linear-issue-validation.test.ts` (SMI-5846) alongside the
  * extraction of that contract into `scripts/lib/linear-issue-validation.mjs`.
+ *
+ * SMI-5858 adds transport-level coverage for `fetchRecentIssues` (exported
+ * specifically for this) — this file previously had zero coverage of the
+ * retry/pagination/GraphQL-error-exit behavior, all now backed by the
+ * shared `scripts/lib/linear-client.mjs`. Reuses the mock-fetch
+ * fixtures/helpers from `scripts/tests/linear-api-test-helpers.ts`.
  */
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+import { mockFetchSteps } from './linear-api-test-helpers'
 
 interface LintIssueLabel {
   name: string
@@ -15,13 +23,34 @@ interface LintIssue {
   labels?: { nodes: LintIssueLabel[] }
 }
 
+interface RecentIssue {
+  identifier: string
+  title: string
+  url: string
+  description: string
+  createdAt: string
+  labels: { nodes: LintIssueLabel[] }
+}
+
 const mod = (await import('../lint-linear-issues.mjs')) as {
   parseArgs: (argv: string[]) => { since: Date; json: boolean }
   isBotGeneratedIssue: (issue: LintIssue, botLabels?: string[]) => boolean
   BOT_LABELS: string[]
+  fetchRecentIssues: (since: Date) => Promise<RecentIssue[]>
 }
 
-const { parseArgs, isBotGeneratedIssue, BOT_LABELS } = mod
+const { parseArgs, isBotGeneratedIssue, BOT_LABELS, fetchRecentIssues } = mod
+
+function recentIssue(identifier: string): RecentIssue {
+  return {
+    identifier,
+    title: `Title for ${identifier}`,
+    url: `https://linear.app/smi/issue/${identifier}`,
+    description: 'A description',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    labels: { nodes: [] },
+  }
+}
 
 describe('parseArgs (SMI-5841)', () => {
   it('defaults to roughly 48h ago when --since is omitted', () => {
@@ -86,5 +115,135 @@ describe('isBotGeneratedIssue - SMI-5855 e2e-failure-auto exclusion', () => {
   it('BOT_LABELS includes e2e-failure-auto and never includes the broad human "Bug" label', () => {
     expect(BOT_LABELS).toContain('e2e-failure-auto')
     expect(BOT_LABELS).not.toContain('Bug')
+  })
+})
+
+describe('fetchRecentIssues transport (SMI-5858)', () => {
+  const SINCE = new Date('2026-01-01T00:00:00.000Z')
+
+  beforeEach(() => {
+    process.env.LINEAR_API_KEY = 'test-key'
+  })
+
+  afterEach(() => {
+    // @ts-expect-error -- undo patch
+    delete global.fetch
+    delete process.env.LINEAR_API_KEY
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('retries a simulated 5xx response, then succeeds', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'httpError', status: 503 },
+      {
+        kind: 'ok',
+        body: {
+          data: { issues: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } },
+        },
+      },
+    ])
+
+    const promise = fetchRecentIssues(SINCE)
+    await vi.advanceTimersByTimeAsync(1000)
+    const issues = await promise
+
+    expect(issues).toEqual([])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a simulated transport failure (fetch() itself rejects), then succeeds', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'transportError', error: new Error('ECONNRESET') },
+      {
+        kind: 'ok',
+        body: {
+          data: {
+            issues: {
+              nodes: [recentIssue('SMI-1')],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      },
+    ])
+
+    const promise = fetchRecentIssues(SINCE)
+    await vi.advanceTimersByTimeAsync(1000)
+    const issues = await promise
+
+    expect(issues.map((i) => i.identifier)).toEqual(['SMI-1'])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('makes exactly one fetch attempt then exits 2 on a GraphQL body-error response, printing the exact stderr text', async () => {
+    const errorsArray = [{ message: 'boom' }]
+    const fetchMock = mockFetchSteps([{ kind: 'ok', body: { errors: errorsArray } }])
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`)
+    }) as never)
+
+    await expect(fetchRecentIssues(SINCE)).rejects.toThrow('process.exit(2)')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledWith(
+      'lint-linear-issues: Linear query failed:',
+      JSON.stringify(errorsArray)
+    )
+  })
+
+  it('rethrows (does not exit) a non-GraphQL error once retries are exhausted', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'httpError', status: 500 },
+      { kind: 'httpError', status: 500 },
+      { kind: 'httpError', status: 500 },
+      { kind: 'httpError', status: 500 },
+    ])
+
+    const promise = fetchRecentIssues(SINCE)
+    const assertion = expect(promise).rejects.toThrow('500')
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(4000)
+    await assertion
+
+    // 1 initial + 3 retries, all failing = 4.
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('merges nodes across two paginated pages in order, in a single logical call', async () => {
+    const fetchMock = mockFetchSteps([
+      {
+        kind: 'ok',
+        body: {
+          data: {
+            issues: {
+              nodes: [recentIssue('SMI-1')],
+              pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+            },
+          },
+        },
+      },
+      {
+        kind: 'ok',
+        body: {
+          data: {
+            issues: {
+              nodes: [recentIssue('SMI-2')],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      },
+    ])
+
+    const issues = await fetchRecentIssues(SINCE)
+
+    expect(issues.map((i) => i.identifier)).toEqual(['SMI-1', 'SMI-2'])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** four scripts in this repo each reimplemented their own copy of the same "talk to Linear" plumbing (retry logic, team/issue lookups). That's now one shared module all four use, so a future fix to that plumbing only needs to happen once instead of four times.

**Quality bar:** passed a plan review (GPT-5.6-Sol + an independent reconciliation pass) before any code was written — it caught a genuine bug in the plan itself: one script's migration would have silently started retrying errors it's supposed to fail on immediately. A dependency-injection fix (not a rewrite) closed a real bug found mid-implementation, where consolidating the code would have doubled a network call on every labeled issue creation. An independent cross-provider code review after implementation found 2 more small issues (a dropped export, a changed error-message format) — both fixed. 119 tests passing, governance review 0 blocking findings.

**Found along the way:** the four scripts named in the original ask turned out to be an undercount — two more scripts do the same thing. Rather than widen this PR further, that's filed as its own follow-up: SMI-5860.

**Net result:** Fully shipped, no behavior change to any of the four migrated scripts (one narrow, explicitly-documented exception: a lookup query now asks Linear for one less field it never used).

---

## Technical detail

- New `scripts/lib/linear-client.mjs` (+ `linear-client.d.mts` so the TypeScript e2e client can import it cleanly): the shared GraphQL transport, retry primitives, `getTeamId`, `getIssueId`, `resolveLabelIds`. `createIssue()` and its SMI-5853 Acceptance-Criteria gate deliberately stay in `linear-api.mjs`, unshared — that coupling was already rejected during SMI-5854/5855's own plan-review.
- Shared `getTeamId()`/`getIssueId()` are **single-attempt by design** — no retry inside either function. The four scripts apply three genuinely different retry policies to these same two lookups today (classified reads-only, catch-all-including-mutations, classified-but-implemented-differently); baking retry into the shared functions would either nest with a caller's existing wrapper (up to 16 real attempts) or silently drop whatever policy a caller had. Retry moved entirely to caller-side wrappers instead — verified every call site that used to retry still retries with the same attempt count.
- `lint-linear-issues.mjs`'s migration uses a retry predicate that excludes GraphQL errors (`err => !err?.graphqlError`), not always-retry — the plan's original design would have retried a deterministic GraphQL error four times before reaching the same exit code this script already returns unretried today.
- Regression found and fixed during implementation: `resolveLabelIds()` (moved to the shared module) called the shared module's own uncached `getTeamId`, while `linear-api.mjs`'s `createIssue()` already resolves the team ID via its own cached wrapper right before calling it — pre-move both hit the same cache (one fetch total); post-move they were two different functions, doubling the fetch on every labeled issue creation. Fixed via an optional `resolveTeamId` dependency-injection parameter.
- GPT-5.6-Sol review fixes (commit `7cfa1c5c`): restored two silently-dropped public exports on the e2e client (`LINEAR_API_URL`, `RETRY_DELAYS_MS`, `graphql`, `retryQuery` — nothing currently imports them, but dropping a module's exports during a "no behavior change" refactor is itself a behavior change); documented a GraphQL-error-message formatting difference (pretty-printed vs. compact JSON) as a second named, acknowledged exception, since it aligns two scripts with the canonical format `linear-api.mjs` already used and no test or caller depends on the old format.
- Plan: `docs/internal/implementation/smi-5858-shared-linear-client-extraction.md` (skillsmith-docs#566). Governance report: skillsmith-docs#567.
- Follow-up filed: SMI-5860 (migrate `scripts/audit-linear-drift.mjs`, `scripts/triage-linear-drift.mjs`, `scripts/session-priming-query.helpers.ts` — found during this PR's own investigation to hand-roll the same pattern, deliberately out of scope here per the plan's Design Question 4).
- Stacked on the already-merged SMI-5859 branch (SMI-2597) since both touch `linear-api.mjs` heavily — no merge-order dependency remains now that SMI-5859 is on `main`.
