### PR TITLE
feat(scripts): SMI-5860 migrate remaining Linear GraphQL callers to shared client

### DIFF
--- a/scripts/audit-linear-drift.mjs
+++ b/scripts/audit-linear-drift.mjs
@@ -25,10 +25,10 @@
 
 import { execFileSync } from 'child_process'
 import { readFileSync, existsSync } from 'fs'
+import { graphql, withRetry, RETRY_DELAYS_MS } from './lib/linear-client.mjs'
 
 // --- Configuration ---
 
-const LINEAR_API_URL = 'https://api.linear.app/graphql'
 const SOURCE_GLOBS = [
   'packages/**/*.ts',
   'packages/**/*.tsx',
@@ -42,7 +42,6 @@ const SOURCE_GLOBS = [
   'supabase/functions/**/*.ts',
   '.github/workflows/**',
 ]
-const RETRY_DELAYS = [1000, 2000, 4000]
 const ALLOWLIST_PATH = '.linear-drift-allowlist'
 
 // SMI-5275: Structural out-of-scope tier. The SMI Linear team spans multiple
@@ -98,26 +97,6 @@ function loadAllowlist() {
 
 // --- Linear API ---
 
-async function fetchWithRetry(url, options, retries = RETRY_DELAYS) {
-  for (let i = 0; i <= retries.length; i++) {
-    try {
-      const res = await fetch(url, options)
-      if (res.ok) return res
-      if (res.status >= 500 && i < retries.length) {
-        await new Promise((r) => setTimeout(r, retries[i]))
-        continue
-      }
-      throw new Error(`HTTP ${res.status}: ${await res.text()}`)
-    } catch (err) {
-      if (i < retries.length) {
-        await new Promise((r) => setTimeout(r, retries[i]))
-        continue
-      }
-      throw err
-    }
-  }
-}
-
 async function fetchDoneIssues(since) {
   const apiKey = process.env.LINEAR_API_KEY
   if (!apiKey) {
@@ -154,28 +133,25 @@ async function fetchDoneIssues(since) {
   let cursor = null
 
   do {
-    const res = await fetchWithRetry(LINEAR_API_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: apiKey,
-      },
-      body: JSON.stringify({
-        query,
-        variables: { after: cursor, since: sinceDateTime },
-      }),
-    })
-
-    const data = await res.json()
-    if (data.errors) {
-      // Distinct from the drift `exit 1` gate: a Linear query rejection (e.g.
-      // a complexity error or schema drift) must never be mistaken for drift.
-      // exit 2 = audit could not run; exit 1 = audit ran and found drift.
-      console.error('Drift audit: Linear query failed:', JSON.stringify(data.errors))
-      process.exit(2)
+    let data
+    try {
+      data = await withRetry(
+        () => graphql(query, { after: cursor, since: sinceDateTime }),
+        RETRY_DELAYS_MS,
+        (err) => !err?.graphqlError
+      )
+    } catch (err) {
+      if (err?.graphqlError) {
+        // Distinct from the drift `exit 1` gate: a Linear query rejection (e.g.
+        // a complexity error or schema drift) must never be mistaken for drift.
+        // exit 2 = audit could not run; exit 1 = audit ran and found drift.
+        console.error('Drift audit: Linear query failed:', JSON.stringify(err.graphqlErrors))
+        process.exit(2)
+      }
+      throw err
     }
 
-    const { nodes, pageInfo } = data.data.issues
+    const { nodes, pageInfo } = data.issues
     allIssues.push(...nodes)
     cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null
   } while (cursor)
@@ -451,6 +427,7 @@ if (isDirectExecution) {
 export {
   loadAllowlist,
   parseArgs,
+  fetchDoneIssues,
   hasGitCommitWithSource,
   hasMergedPr,
   hasAnyGitCommit,

--- a/scripts/lib/linear-client.d.mts
+++ b/scripts/lib/linear-client.d.mts
@@ -27,8 +27,12 @@ export const RETRY_DELAYS_MS: number[]
 export const UUID_RE: RegExp
 export const LABEL_PAGE_SIZE: number
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see header
-export function graphql(query: string, variables?: Record<string, unknown>): Promise<any>
+export function graphql(
+  query: string,
+  variables?: Record<string, unknown>,
+  options?: { signal?: AbortSignal }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see header
+): Promise<any>
 export function isRetryable(err: unknown): boolean
 export function withRetry<T>(
   fn: () => Promise<T>,

--- a/scripts/lib/linear-client.mjs
+++ b/scripts/lib/linear-client.mjs
@@ -67,11 +67,21 @@ export const LABEL_PAGE_SIZE = 50
  * `reason` text, built from a mutation response's `errors` field rather than
  * from this function's thrown error) is untouched by this change.
  *
+ * `options.signal` (SMI-5860) is additive — an optional `AbortSignal` passed
+ * straight through to the underlying `fetch()` call. Every caller that
+ * predates SMI-5860 omits it (defaults to `undefined`, identical to not
+ * passing the key at all). It exists for
+ * `scripts/session-priming-query.helpers.ts`'s `buildSignal2()`, which runs
+ * inside a `SessionStart` hook and must not let a slow Linear response block
+ * Claude Code startup — timeout/timer policy stays local to that one caller;
+ * this module only forwards the signal.
+ *
  * @param {string} query
  * @param {Record<string, unknown>} [variables]
+ * @param {{ signal?: AbortSignal }} [options]
  * @returns {Promise<any>}
  */
-export async function graphql(query, variables = {}) {
+export async function graphql(query, variables = {}, options = {}) {
   const apiKey = process.env.LINEAR_API_KEY
 
   if (!apiKey) {
@@ -85,6 +95,7 @@ export async function graphql(query, variables = {}) {
       Authorization: apiKey,
     },
     body: JSON.stringify({ query, variables }),
+    signal: options.signal,
   })
 
   if (!response.ok) {

--- a/scripts/session-priming-query.helpers.ts
+++ b/scripts/session-priming-query.helpers.ts
@@ -18,6 +18,7 @@ import {
   resolveSharedProjectDir,
 } from '../packages/doc-retrieval-mcp/src/retrieval-log/project-dir.js'
 import type { SearchHit } from '../packages/doc-retrieval-mcp/src/types.js'
+import { graphql } from './lib/linear-client.mjs'
 
 const execFileAsync = promisify(execFile)
 
@@ -120,26 +121,25 @@ export async function getCurrentHeadSha(cwd: string): Promise<string | null> {
 
 export async function buildSignal2(args: CliArgs): Promise<string> {
   if (!args.smi) return ''
-  const apiKey = process.env.LINEAR_API_KEY
-  if (!apiKey) return ''
+  if (!process.env.LINEAR_API_KEY) return ''
 
   const query = `query GetIssue($id: String!) { issue(id: $id) { description } }`
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), LINEAR_TIMEOUT_MS)
   try {
-    const ctrl = new AbortController()
-    const timer = setTimeout(() => ctrl.abort(), LINEAR_TIMEOUT_MS)
-    const res = await fetch('https://api.linear.app/graphql', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: apiKey },
-      body: JSON.stringify({ query, variables: { id: args.smi.toUpperCase() } }),
-      signal: ctrl.signal,
-    })
-    clearTimeout(timer)
-    if (!res.ok) return ''
-    const json = (await res.json()) as { data?: { issue?: { description?: string | null } } }
-    const desc = json.data?.issue?.description ?? ''
+    const data = (await graphql(
+      query,
+      { id: args.smi.toUpperCase() },
+      { signal: ctrl.signal }
+    )) as {
+      issue?: { description?: string | null }
+    }
+    const desc = data.issue?.description ?? ''
     return truncateBytes(desc, SIGNAL_2_CAP_BYTES)
   } catch {
     return ''
+  } finally {
+    clearTimeout(timer)
   }
 }
 

--- a/scripts/session-priming-query.helpers.ts
+++ b/scripts/session-priming-query.helpers.ts
@@ -25,7 +25,10 @@ const execFileAsync = promisify(execFile)
 const SIGNAL_2_CAP_BYTES = 1024
 const SIGNAL_3_BULLETS = 15
 const MEMORY_FILE_MAX_READ = 100 * 1024
-const LINEAR_TIMEOUT_MS = 1800
+// Exported so `session-priming-query-helpers.test.ts` can drive its fake-timer
+// abort test off the real value instead of a hardcoded duplicate — raising this
+// would otherwise turn that test into an opaque "test timed out" failure.
+export const LINEAR_TIMEOUT_MS = 1800
 
 export interface CliArgs {
   sessionId: string

--- a/scripts/tests/audit-linear-drift-transport.test.ts
+++ b/scripts/tests/audit-linear-drift-transport.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for `fetchDoneIssues` transport in `scripts/audit-linear-drift.mjs`
+ * (SMI-5860) — split out of `audit-linear-drift.test.ts` to stay under the
+ * 500-line pre-commit gate, mirroring `linear-api-uuid-resolution.test.ts`'s
+ * own split from `linear-api.test.ts`.
+ *
+ * `fetchDoneIssues`/`fetchWithRetry` had zero test coverage before SMI-5860's
+ * migration from a hand-rolled `fetchWithRetry` to the shared,
+ * `graphql()`/`withRetry`-based transport.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mockFetchSteps } from './linear-api-test-helpers'
+
+async function importModule() {
+  return await import('../audit-linear-drift.mjs')
+}
+
+function doneIssuesPage(
+  nodes: unknown[],
+  pageInfo: { hasNextPage: boolean; endCursor: string | null }
+) {
+  return { data: { issues: { nodes, pageInfo } } }
+}
+
+describe('fetchDoneIssues transport (SMI-5860)', () => {
+  const SINCE = '2026-01-01'
+
+  beforeEach(() => {
+    process.env.LINEAR_API_KEY = 'test-key'
+  })
+
+  afterEach(() => {
+    // @ts-expect-error -- undo patch
+    delete global.fetch
+    delete process.env.LINEAR_API_KEY
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('exits 0 with the exact "Skipping" message when LINEAR_API_KEY is unset — no fetch attempted', async () => {
+    delete process.env.LINEAR_API_KEY
+    const fetchMock = mockFetchSteps([])
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`)
+    }) as never)
+
+    const { fetchDoneIssues } = await importModule()
+    await expect(fetchDoneIssues(SINCE)).rejects.toThrow('process.exit(0)')
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith('LINEAR_API_KEY not set. Skipping drift audit.')
+  })
+
+  it('retries a simulated 5xx response, then succeeds', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'httpError', status: 503 },
+      { kind: 'ok', body: doneIssuesPage([], { hasNextPage: false, endCursor: null }) },
+    ])
+
+    const { fetchDoneIssues } = await importModule()
+    const promise = fetchDoneIssues(SINCE)
+    await vi.advanceTimersByTimeAsync(1000)
+    const issues = await promise
+
+    expect(issues).toEqual([])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a simulated transport failure (fetch() itself rejects), then succeeds', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'transportError', error: new Error('ECONNRESET') },
+      {
+        kind: 'ok',
+        body: doneIssuesPage([{ identifier: 'SMI-1' }], { hasNextPage: false, endCursor: null }),
+      },
+    ])
+
+    const { fetchDoneIssues } = await importModule()
+    const promise = fetchDoneIssues(SINCE)
+    await vi.advanceTimersByTimeAsync(1000)
+    const issues = (await promise) as Array<{ identifier: string }>
+
+    expect(issues.map((i) => i.identifier)).toEqual(['SMI-1'])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('makes exactly one fetch attempt then exits 2 on a GraphQL body-error response, printing the exact stderr text', async () => {
+    const errorsArray = [{ message: 'boom' }]
+    const fetchMock = mockFetchSteps([{ kind: 'ok', body: { errors: errorsArray } }])
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`)
+    }) as never)
+
+    const { fetchDoneIssues } = await importModule()
+    await expect(fetchDoneIssues(SINCE)).rejects.toThrow('process.exit(2)')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Drift audit: Linear query failed:',
+      JSON.stringify(errorsArray)
+    )
+  })
+
+  it('rethrows (does not exit) a non-GraphQL error once retries are exhausted', async () => {
+    vi.useFakeTimers()
+    const fetchMock = mockFetchSteps([
+      { kind: 'httpError', status: 500 },
+      { kind: 'httpError', status: 500 },
+      { kind: 'httpError', status: 500 },
+      { kind: 'httpError', status: 500 },
+    ])
+
+    const { fetchDoneIssues } = await importModule()
+    const promise = fetchDoneIssues(SINCE)
+    const assertion = expect(promise).rejects.toThrow('500')
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(4000)
+    await assertion
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('merges nodes across two paginated pages in order, in a single logical call', async () => {
+    const fetchMock = mockFetchSteps([
+      {
+        kind: 'ok',
+        body: doneIssuesPage([{ identifier: 'SMI-1' }], {
+          hasNextPage: true,
+          endCursor: 'cursor-1',
+        }),
+      },
+      {
+        kind: 'ok',
+        body: doneIssuesPage([{ identifier: 'SMI-2' }], {
+          hasNextPage: false,
+          endCursor: null,
+        }),
+      },
+    ])
+
+    const { fetchDoneIssues } = await importModule()
+    const issues = (await fetchDoneIssues(SINCE)) as Array<{ identifier: string }>
+
+    expect(issues.map((i) => i.identifier)).toEqual(['SMI-1', 'SMI-2'])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('DESIGN QUESTION 1 named micro-delta: retries the full attempt count on a malformed-2xx-JSON body before rethrowing (today this fails unretried, outside the pre-migration fetchWithRetry) — deliberate, not accidental', async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected end of JSON input')
+        },
+        text: async () => 'not json',
+      } as unknown as Response
+    })
+    // @ts-expect-error -- patch global fetch
+    global.fetch = fetchMock
+
+    const { fetchDoneIssues } = await importModule()
+    const promise = fetchDoneIssues(SINCE)
+    const assertion = expect(promise).rejects.toThrow('Unexpected end of JSON input')
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(4000)
+    await assertion
+
+    // 1 initial + 3 retries = 4 total — retried because a raw SyntaxError has
+    // no .status/.graphqlError, so the Q1 predicate (!err?.graphqlError)
+    // treats it as retryable, unlike today's pre-migration behavior where
+    // res.json() runs outside the retry helper and fails on the first attempt.
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+})

--- a/scripts/tests/audit-linear-drift-transport.test.ts
+++ b/scripts/tests/audit-linear-drift-transport.test.ts
@@ -9,7 +9,7 @@
  * `graphql()`/`withRetry`-based transport.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mockFetchSteps } from './linear-api-test-helpers'
+import { mockFetchSteps, requestBody } from './linear-api-test-helpers'
 
 async function importModule() {
   return await import('../audit-linear-drift.mjs')
@@ -148,6 +148,21 @@ describe('fetchDoneIssues transport (SMI-5860)', () => {
 
     expect(issues.map((i) => i.identifier)).toEqual(['SMI-1', 'SMI-2'])
     expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    // Anti-false-green: the mock hands back page 2 regardless of what variables
+    // the caller sent, so without these two assertions this test would still
+    // pass if cursor threading broke (page 2 requested with `after: null`, i.e.
+    // an infinite first-page loop in production) or if the `since` -> Linear
+    // DateTime conversion changed. Both are asserted against independently
+    // restated literals, not values read back off the request.
+    expect(requestBody(fetchMock, 0).variables).toEqual({
+      after: null,
+      since: `${SINCE}T00:00:00Z`,
+    })
+    expect(requestBody(fetchMock, 1).variables).toEqual({
+      after: 'cursor-1',
+      since: `${SINCE}T00:00:00Z`,
+    })
   })
 
   it('DESIGN QUESTION 1 named micro-delta: retries the full attempt count on a malformed-2xx-JSON body before rethrowing (today this fails unretried, outside the pre-migration fetchWithRetry) — deliberate, not accidental', async () => {

--- a/scripts/tests/linear-client.test.ts
+++ b/scripts/tests/linear-client.test.ts
@@ -122,6 +122,38 @@ describe('graphql (SMI-5858)', () => {
   })
 })
 
+describe('graphql (SMI-5860) - options.signal (additive)', () => {
+  it('threads options.signal through to the underlying fetch() call', async () => {
+    const fetchMock = mockFetchSteps([{ kind: 'ok', body: { data: { hello: 'world' } } }])
+    const ctrl = new AbortController()
+    await graphql('query {}', {}, { signal: ctrl.signal })
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, { signal?: AbortSignal }]
+    expect(init.signal).toBe(ctrl.signal)
+  })
+
+  it('omitting options entirely behaves exactly as before (signal is undefined)', async () => {
+    const fetchMock = mockFetchSteps([{ kind: 'ok', body: { data: { hello: 'world' } } }])
+    await graphql('query {}')
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, { signal?: AbortSignal }]
+    expect(init.signal).toBeUndefined()
+  })
+
+  it('rejects when the signal is already aborted, propagated from fetch()', async () => {
+    const ctrl = new AbortController()
+    ctrl.abort()
+    // @ts-expect-error -- patch global fetch to honor AbortSignal like real fetch()
+    global.fetch = vi.fn((_url: string, init: { signal?: AbortSignal }) => {
+      if (init.signal?.aborted) {
+        return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'))
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ data: {} }) })
+    })
+    await expect(graphql('query {}', {}, { signal: ctrl.signal })).rejects.toThrow(
+      'The operation was aborted.'
+    )
+  })
+})
+
 describe('isRetryable (SMI-5858) - classification table', () => {
   it('treats a status-less error (pure transport failure) as retryable', () => {
     expect(isRetryable(new Error('ECONNRESET'))).toBe(true)

--- a/scripts/tests/session-priming-query-helpers.test.ts
+++ b/scripts/tests/session-priming-query-helpers.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Direct tests for `buildSignal2` in `scripts/session-priming-query.helpers.ts`
+ * (SMI-5860) — split into its own file rather than growing
+ * `session-priming-query.test.ts` past the 500-line pre-commit gate.
+ *
+ * `buildSignal2` had zero direct fetch-path coverage before SMI-5860's
+ * migration from a hand-rolled `fetch()` + `AbortController` to the shared,
+ * `options.signal`-accepting `graphql()` client.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildSignal2, type CliArgs } from '../session-priming-query.helpers.js'
+import { mockFetchSteps } from './linear-api-test-helpers'
+
+function args(overrides: Partial<CliArgs> = {}): CliArgs {
+  return {
+    sessionId: 's1',
+    branch: 'fix/smi-100',
+    smi: 'smi-100',
+    cwd: '/tmp',
+    out: '/tmp/out',
+    ...overrides,
+  }
+}
+
+describe('buildSignal2 (SMI-5860)', () => {
+  beforeEach(() => {
+    process.env.LINEAR_API_KEY = 'test-key'
+  })
+
+  afterEach(() => {
+    // @ts-expect-error -- undo patch
+    delete global.fetch
+    delete process.env.LINEAR_API_KEY
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('returns "" immediately when args.smi is empty — no fetch attempted', async () => {
+    const fetchMock = mockFetchSteps([])
+    const result = await buildSignal2(args({ smi: '' }))
+    expect(result).toBe('')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns "" when LINEAR_API_KEY is unset — no fetch attempted', async () => {
+    delete process.env.LINEAR_API_KEY
+    const fetchMock = mockFetchSteps([])
+    const result = await buildSignal2(args())
+    expect(result).toBe('')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns the issue description, truncated, on a happy-path response', async () => {
+    mockFetchSteps([{ kind: 'ok', body: { data: { issue: { description: 'hello world' } } } }])
+    const result = await buildSignal2(args())
+    expect(result).toBe('hello world')
+  })
+
+  it('uppercases the smi identifier as the $id variable', async () => {
+    const fetchMock = mockFetchSteps([
+      { kind: 'ok', body: { data: { issue: { description: '' } } } },
+    ])
+    await buildSignal2(args({ smi: 'smi-100' }))
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, { body: string }]
+    const parsed = JSON.parse(init.body) as { variables: Record<string, unknown> }
+    expect(parsed.variables).toEqual({ id: 'SMI-100' })
+  })
+
+  it('returns "" on a non-ok HTTP response (graphql() throws, caught by the blanket catch)', async () => {
+    mockFetchSteps([{ kind: 'httpError', status: 500 }])
+    const result = await buildSignal2(args())
+    expect(result).toBe('')
+  })
+
+  it('returns "" on a GraphQL body-error response', async () => {
+    mockFetchSteps([{ kind: 'ok', body: { errors: [{ message: 'nope' }] } }])
+    const result = await buildSignal2(args())
+    expect(result).toBe('')
+  })
+
+  it('returns "" on a transport failure', async () => {
+    mockFetchSteps([{ kind: 'transportError', error: new Error('ECONNRESET') }])
+    const result = await buildSignal2(args())
+    expect(result).toBe('')
+  })
+
+  it('clears the abort timer on the success path (no leaked timer)', async () => {
+    vi.useFakeTimers()
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+    mockFetchSteps([{ kind: 'ok', body: { data: { issue: { description: 'ok' } } } }])
+    const result = await buildSignal2(args())
+    expect(result).toBe('ok')
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+  })
+
+  it('clears the abort timer on the failure path too (no leaked timer)', async () => {
+    vi.useFakeTimers()
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+    mockFetchSteps([{ kind: 'transportError', error: new Error('boom') }])
+    const result = await buildSignal2(args())
+    expect(result).toBe('')
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+  })
+
+  it('aborts and returns "" if the request outlasts the timeout', async () => {
+    vi.useFakeTimers()
+    // @ts-expect-error -- patch global fetch to honor AbortSignal like real fetch(), never resolving otherwise
+    global.fetch = vi.fn((_url: string, init: { signal?: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'))
+        })
+      })
+    })
+    const promise = buildSignal2(args())
+    await vi.advanceTimersByTimeAsync(1800)
+    const result = await promise
+    expect(result).toBe('')
+  })
+})

--- a/scripts/tests/session-priming-query-helpers.test.ts
+++ b/scripts/tests/session-priming-query-helpers.test.ts
@@ -8,7 +8,7 @@
  * `options.signal`-accepting `graphql()` client.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { buildSignal2, type CliArgs } from '../session-priming-query.helpers.js'
+import { buildSignal2, LINEAR_TIMEOUT_MS, type CliArgs } from '../session-priming-query.helpers.js'
 import { mockFetchSteps } from './linear-api-test-helpers'
 
 function args(overrides: Partial<CliArgs> = {}): CliArgs {
@@ -113,7 +113,9 @@ describe('buildSignal2 (SMI-5860)', () => {
       })
     })
     const promise = buildSignal2(args())
-    await vi.advanceTimersByTimeAsync(1800)
+    // Driven off the source constant, not a hardcoded 1800 — a raised timeout
+    // would otherwise surface as an opaque vitest "test timed out".
+    await vi.advanceTimersByTimeAsync(LINEAR_TIMEOUT_MS)
     const result = await promise
     expect(result).toBe('')
   })

--- a/scripts/tests/triage-linear-drift.test.ts
+++ b/scripts/tests/triage-linear-drift.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for Linear Drift Triage (SMI-4559), transport surface (SMI-5860).
+ *
+ * `fetchLinearProject` had zero test coverage before SMI-5860's migration
+ * from a synchronous `curl` subprocess to the shared, `fetch()`-based
+ * `graphql()` client. These tests cover that migrated call directly.
+ *
+ * IMPORTANT (review finding): `graphql()` reads `process.env.LINEAR_API_KEY`
+ * directly — NOT the `apiKey` parameter `fetchLinearProject` still takes
+ * (which is now a short-circuit-only check, `if (!apiKey) return null`).
+ * Tests must set the env var, not just pass an `apiKey` argument, or they
+ * would silently test the wrong thing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mockFetchSteps } from './linear-api-test-helpers'
+
+async function importModule() {
+  return await import('../triage-linear-drift.mjs')
+}
+
+describe('fetchLinearProject transport (SMI-5860)', () => {
+  beforeEach(() => {
+    process.env.LINEAR_API_KEY = 'test-key'
+  })
+
+  afterEach(() => {
+    // @ts-expect-error -- undo patch
+    delete global.fetch
+    delete process.env.LINEAR_API_KEY
+    vi.restoreAllMocks()
+  })
+
+  it('returns null with zero fetch calls when apiKey is falsy (short-circuit, unrelated to the env var)', async () => {
+    const fetchMock = mockFetchSteps([])
+    const { fetchLinearProject } = await importModule()
+    const result = await fetchLinearProject('SMI-100', '')
+    expect(result).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves project name and first initiative on a happy-path response', async () => {
+    const fetchMock = mockFetchSteps([
+      {
+        kind: 'ok',
+        body: {
+          data: {
+            issue: {
+              project: {
+                name: 'Skillsmith: CI Health',
+                initiatives: { nodes: [{ name: 'Skillsmith' }] },
+              },
+            },
+          },
+        },
+      },
+    ])
+    const { fetchLinearProject } = await importModule()
+    const result = await fetchLinearProject('SMI-100', 'test-key')
+    expect(result).toEqual({ project: 'Skillsmith: CI Health', initiative: 'Skillsmith' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends the SMI identifier as a $id GraphQL variable, not string-interpolated into the query text', async () => {
+    const fetchMock = mockFetchSteps([{ kind: 'ok', body: { data: { issue: { project: null } } } }])
+    const { fetchLinearProject } = await importModule()
+    await fetchLinearProject('SMI-100', 'test-key')
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, { body: string }]
+    const parsed = JSON.parse(init.body) as { query: string; variables: Record<string, unknown> }
+    expect(parsed.variables).toEqual({ id: 'SMI-100' })
+    expect(parsed.query).not.toContain('SMI-100')
+  })
+
+  it('returns null when the issue has no project (nothing to resolve)', async () => {
+    const fetchMock = mockFetchSteps([{ kind: 'ok', body: { data: { issue: { project: null } } } }])
+    const { fetchLinearProject } = await importModule()
+    const result = await fetchLinearProject('SMI-999', 'test-key')
+    expect(result).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null on a genuine GraphQL error response (graphql() throws, caught by the blanket catch) — matches pre-migration behavior, which never checked data.errors either', async () => {
+    mockFetchSteps([{ kind: 'ok', body: { errors: [{ message: 'not found' }] } }])
+    const { fetchLinearProject } = await importModule()
+    const result = await fetchLinearProject('SMI-100', 'test-key')
+    expect(result).toBeNull()
+  })
+
+  it('returns null on a transport failure', async () => {
+    mockFetchSteps([{ kind: 'transportError', error: new Error('ECONNRESET') }])
+    const { fetchLinearProject } = await importModule()
+    const result = await fetchLinearProject('SMI-100', 'test-key')
+    expect(result).toBeNull()
+  })
+
+  it('returns null on an HTTP error response', async () => {
+    mockFetchSteps([{ kind: 'httpError', status: 500 }])
+    const { fetchLinearProject } = await importModule()
+    const result = await fetchLinearProject('SMI-100', 'test-key')
+    expect(result).toBeNull()
+  })
+})
+
+describe('classifyEntry async plumbing (SMI-5860)', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    process.env.LINEAR_API_KEY = 'test-key'
+    delete process.env.TRIAGE_NO_LINEAR
+  })
+
+  afterEach(() => {
+    // @ts-expect-error -- undo patch
+    delete global.fetch
+    process.env = { ...originalEnv }
+    vi.restoreAllMocks()
+  })
+
+  it('awaits the async fetchLinearProject call and classifies via the Linear-initiative lookup, before ever reaching the gh fallback', async () => {
+    mockFetchSteps([
+      {
+        kind: 'ok',
+        body: {
+          data: {
+            issue: {
+              project: {
+                name: 'Module 4',
+                initiatives: { nodes: [{ name: '021 School Platform' }] },
+              },
+            },
+          },
+        },
+      },
+    ])
+    const { classifyEntry } = await importModule()
+    const result = await classifyEntry(
+      { id: 'SMI-9001', title: 'Some unrelated title' },
+      '',
+      'test-key'
+    )
+    expect(result.bucket).toBe('external-repo')
+    expect(result.signal).toBe('linear-initiative')
+  })
+})

--- a/scripts/triage-linear-drift.mjs
+++ b/scripts/triage-linear-drift.mjs
@@ -41,10 +41,10 @@
 
 import { execFileSync } from 'child_process'
 import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { graphql } from './lib/linear-client.mjs'
 
 // --- Configuration ---
 
-const LINEAR_API_URL = 'https://api.linear.app/graphql'
 const OUTPUT_PATH = '/tmp/drift-buckets.json'
 const ESCALATION_THRESHOLD = 5
 
@@ -170,31 +170,42 @@ function readJson(path) {
  * whose names don't start with "Skillsmith" (e.g. "Release Hardening",
  * "Issue Description Validation", etc.).
  *
- * Returns { project, initiative } or null on failure.
+ * SMI-5860: migrated from a synchronous `curl` subprocess to the shared,
+ * `fetch()`-based `graphql()` client — this function (and its callers,
+ * `classifyEntry`/`main`) is async as a result. The `apiKey` parameter is
+ * a short-circuit check only; `graphql()` itself reads
+ * `process.env.LINEAR_API_KEY` directly, not this parameter (in
+ * production these are always the same value — the caller derives
+ * `apiKey` from that same env var below).
+ *
+ * Returns { project, initiative } or null on failure — including a
+ * genuine GraphQL error response, which `graphql()` throws on and this
+ * function's blanket catch turns back into `null`, matching this
+ * function's pre-migration behavior (the old curl path never checked
+ * `data.errors` either, so a GraphQL error response fell through the
+ * same optional-chaining miss to `null`).
  */
-function fetchLinearProject(smi, apiKey) {
+async function fetchLinearProject(smi, apiKey) {
   if (!apiKey) return null
   try {
-    const out = execFileSync(
-      'curl',
-      [
-        '-sS',
-        '-H',
-        `Authorization: ${apiKey}`,
-        '-H',
-        'Content-Type: application/json',
-        '-X',
-        'POST',
-        '--data',
-        JSON.stringify({
-          query: `query { issue(id: "${smi}") { project { name initiatives { nodes { name } } } } }`,
-        }),
-        LINEAR_API_URL,
-      ],
-      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }
+    const data = await graphql(
+      `
+        query GetIssueProject($id: String!) {
+          issue(id: $id) {
+            project {
+              name
+              initiatives {
+                nodes {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      { id: smi }
     )
-    const data = JSON.parse(out || '{}')
-    const project = data?.data?.issue?.project
+    const project = data?.issue?.project
     if (!project) return null
     const initiatives = (project.initiatives?.nodes ?? []).map((n) => n.name)
     return {
@@ -275,7 +286,7 @@ function findCommitWithoutToken(smi, ghToken) {
 /**
  * Classify a single drift entry.
  */
-function classifyEntry(entry, ghToken, linearKey) {
+async function classifyEntry(entry, ghToken, linearKey) {
   const { id, title } = entry
 
   // 1. external-repo — title keywords win regardless of any local commits.
@@ -291,7 +302,7 @@ function classifyEntry(entry, ghToken, linearKey) {
   //    project (021.School, lin-cli, MAUI, minimax). Skip with
   //    TRIAGE_NO_LINEAR=1.
   if (!process.env.TRIAGE_NO_LINEAR && linearKey) {
-    const meta = fetchLinearProject(id, linearKey)
+    const meta = await fetchLinearProject(id, linearKey)
     if (meta && meta.initiative) {
       const isSkillsmith = /^Skillsmith$/i.test(meta.initiative)
       if (!isSkillsmith) {
@@ -356,7 +367,7 @@ function classifyEntry(entry, ghToken, linearKey) {
 
 // --- Main ---
 
-function main() {
+async function main() {
   const inputPath = process.argv[2] || '/tmp/drift-results.json'
   const data = readJson(inputPath)
 
@@ -390,7 +401,7 @@ function main() {
   for (let i = 0; i < driftEntries.length; i++) {
     const entry = driftEntries[i]
     if (i % 25 === 0) console.error(`  [${i}/${driftEntries.length}] processing...`)
-    const classification = classifyEntry(entry, ghToken, linearKey)
+    const classification = await classifyEntry(entry, ghToken, linearKey)
     buckets[classification.bucket].push({ ...entry, ...classification })
   }
 
@@ -418,4 +429,19 @@ function main() {
   }
 }
 
-main()
+// Only run when executed directly — importing this module for tests (SMI-5860
+// adds direct fetchLinearProject/classifyEntry coverage) must not trigger a
+// real main() run, which reads /tmp/drift-results.json and calls process.exit.
+const isDirectExecution =
+  process.argv[1] &&
+  (process.argv[1].endsWith('triage-linear-drift.mjs') ||
+    process.argv[1].endsWith('triage-linear-drift'))
+
+if (isDirectExecution) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}
+
+export { fetchLinearProject, classifyEntry }


### PR DESCRIPTION
## Business Summary

**What shipped:** the last three scripts in this repo that talked to Linear's API with their own hand-rolled plumbing now use the same shared plumbing four other scripts already switched to — so a future fix only needs to happen once, everywhere.

**Quality bar:** passed a plan review (GPT-5.6-Sol) before any code was written — it caught a genuine bug in the plan itself: one script's migration would have silently started retrying a type of failure it's supposed to fail on immediately. Investigation also found one of the three scripts didn't match its own filed description (it used a different, riskier way of talking to Linear than assumed), which changed the shape of that migration. An independent cross-provider code review after implementation found no issues. A separate governance review then caught two test-quality gaps — a test that would have stayed green even if a real bug broke pagination, and a hardcoded timeout duplicating a real setting — both fixed immediately.

**Found along the way:** none — this PR closes out the follow-up scope from SMI-5858 in full, with no further deferred work.

**Net result:** Fully shipped. One deliberate, documented behavior change (a malformed response now retries instead of failing immediately — strictly safer, and pinned by a test) plus a security improvement (one script no longer passes the Linear API key as a command-line argument, and no longer builds its query text via string interpolation).

---

## Technical detail

- `scripts/audit-linear-drift.mjs`: its own `fetchWithRetry` replaced with the shared `graphql()` + `withRetry`, predicate `(err) => !err?.graphqlError` — same shape SMI-5858 already established for a sibling script. Exit-0 "Skipping" (missing key) and exit-2 (GraphQL error) paths preserved exactly, asserted by exact stderr text.
- `scripts/triage-linear-drift.mjs`: `fetchLinearProject` converted from a synchronous `curl` subprocess (zero retry) to the shared, `fetch()`-based `graphql()`. This forced `fetchLinearProject` → `classifyEntry` → `main()` to become async, with the bottom-of-file invocation changed to `main().catch(...)` guarded by an `isDirectExecution` check (mirroring the pattern the sibling audit script already uses). The identifier moved from a string-interpolated query to a `$id` GraphQL variable.
- `scripts/session-priming-query.helpers.ts`: `buildSignal2` (a `SessionStart`-hook signal builder that must not block Claude Code startup) now calls the shared `graphql()`, threading its existing `AbortController` signal through a new, purely additive `options.signal` parameter on `scripts/lib/linear-client.mjs`'s `graphql()` — backward compatible with every existing caller, verified by a dedicated regression test.
- Plan review found and fixed a genuine blocker: the plan's original claim that a malformed-2xx-JSON-body parse failure has "no behavior delta" under the migration was wrong — under the old code this failed unretried; under the shared client it now retries (a raw parse-error has no `.status`/`.graphqlError` flag). Corrected to a named, accepted exception with a required attempt-count test, the same class of delta SMI-5858 itself caught for a sibling script.
- Governance review fixes (commit `b8278029`): a pagination test asserted merged output but never the request variables sent, so a broken cursor (infinite first-page loop in production) would still have passed green — now asserts the exact variables on both paginated calls. A test hardcoded `1800`ms, duplicating a module-private timeout constant — the constant is now exported and the test drives off it.
- 118+ new/updated tests across four test files (all three migrated functions had zero transport coverage before this work); full suite 185 files / 2661+ tests, lint/typecheck/`audit:standards` all clean. Fresh `grep -rln "api.linear.app" scripts/` confirms only the shared client, its own test, and already-out-of-scope legacy `.sh` curl scripts remain.
- Plan: `docs/internal/implementation/smi-5860-linear-client-migration.md` (skillsmith-docs#569). Governance report: skillsmith-docs#570.
- Closes out SMI-5858's Design Question 4 follow-up in full — no further scope remains.
