### PR TITLE
fix(ci): Exclude .ruvector/ from Check 61's git-crypt scanner (SMI-5873)

### DIFF
--- a/scripts/audit-git-crypt-remediation-helpers.mjs
+++ b/scripts/audit-git-crypt-remediation-helpers.mjs
@@ -17,6 +17,12 @@
  *   - .git/, node_modules/, dist/, .worktrees/, .git-crypt/ (binary/VCS
  *     internals, or a nested worktree checkout that duplicates this
  *     repo's own history under a gitignored path)
+ *   - .ruvector/ (the local skillsmith-doc-retrieval semantic-search index,
+ *     gitignored and never present in CI -- its embeddings payload verbatim-
+ *     copies chunked text from indexed docs, including historical snippets
+ *     that legitimately quote the pre-fix pattern under the docs-exempt
+ *     carve-out below; without this exclusion, `npm run audit:standards`
+ *     non-reproducibly fails only on machines with a stale local index)
  *   - docs/internal/{implementation,retros}/** (historical plan docs
  *     legitimately quote the old broken snippet as before/after examples)
  *   - the skillsmith-strategy submodule mount-points (.claude/skills,
@@ -32,7 +38,14 @@
 import { readFileSync, readdirSync, statSync } from 'fs'
 import { join, relative } from 'path'
 
-const EXCLUDED_DIR_NAMES = new Set(['.git', 'node_modules', 'dist', '.worktrees', '.git-crypt'])
+const EXCLUDED_DIR_NAMES = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  '.worktrees',
+  '.git-crypt',
+  '.ruvector',
+])
 
 // SMI-5702 Wave 4: fixed separately against the skillsmith-strategy
 // submodule's own checkout/review gate -- see file header.

--- a/scripts/tests/git-crypt-remediation-strings.test.ts
+++ b/scripts/tests/git-crypt-remediation-strings.test.ts
@@ -24,11 +24,23 @@ import { findGitCryptUnsetRemediations } from '../audit-git-crypt-remediation-he
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..', '..')
 
+// A full recursive repo-root walk + readFileSync of every non-excluded file
+// legitimately exceeds the 15s vitest.preset.ts default under normal
+// multi-worktree-container contention (this repo's default dev workflow,
+// CLAUDE.md § Default Execution Model) -- 60s matches the E2E convention
+// (vitest.e2e.config.ts) rather than widening the global preset for one
+// inherently I/O-heavy test.
+const REPO_WALK_TIMEOUT_MS = 60_000
+
 describe('SMI-5702 T11: no `--unset filter.git-crypt` remediation text anywhere', () => {
-  it('finds zero occurrences repo-wide outside historical plan docs and the strategy submodule', () => {
-    const findings = findGitCryptUnsetRemediations(REPO_ROOT)
-    expect(findings).toEqual([])
-  })
+  it(
+    'finds zero occurrences repo-wide outside historical plan docs and the strategy submodule',
+    () => {
+      const findings = findGitCryptUnsetRemediations(REPO_ROOT)
+      expect(findings).toEqual([])
+    },
+    REPO_WALK_TIMEOUT_MS
+  )
 })
 
 describe('SMI-5702: direct string assertions on the two most operator-visible remediation sites', () => {


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a governance/CI check (`audit:standards` Check 61) that could fail on a developer's machine for reasons completely unrelated to their actual code change — it was accidentally scanning a local search-index cache file that CI never has, and randomly matching old, already-fixed example text buried inside it. Also gave one related test more breathing room to finish, since it was timing out under normal day-to-day working conditions (running several project checkouts at once) even though nothing was actually broken.

**Quality bar:** Both fixes verified directly — re-ran the full standards check (clean), ran the two affected test files both standalone and inside a complete pre-push run of all 8,146 repo tests (all passing), and confirmed the type checker is still clean.

**Found along the way:** Discovered during the mandatory post-merge review of PR #2107 (SMI-5866) — re-running the same checks that had just passed in CI, against the same commit, failed locally. Root-caused and fixed immediately as its own issue (SMI-5873) rather than folded into #2107, since it's an unrelated pre-existing gap in tooling from a different, already-merged PR (SMI-5702).

**Net result:** Fully shipped, no follow-up.

---

## Technical detail

**Files**: `scripts/audit-git-crypt-remediation-helpers.mjs`, `scripts/tests/git-crypt-remediation-strings.test.ts`. Dev-tooling only — no `packages/*/src`, no migration, no deploy surface.

**Root cause 1**: Check 61 (added by SMI-5702) walks the entire repo root looking for a banned `--unset filter.git-crypt.*` remediation string, excluding `.git/`, `node_modules/`, `dist/`, `.worktrees/`, `.git-crypt/`, plus a few docs/submodule carve-outs. It missed `.ruvector/` — the local `skillsmith-doc-retrieval` semantic-search vector index, gitignored (`.gitignore:13`) and never present in CI's ephemeral checkout. `.ruvector/metadata.json` / `.ruvector/skillsmith-docs/vectors` embed verbatim chunked text from indexed docs, including historical snippets that legitimately quote the pre-SMI-5702 pattern as a before/after example (the exact class of content `docs/internal/implementation/` and `docs/internal/retros/` already carve out). `readFileSync(..., 'utf8')` on that binary/JSON payload doesn't throw, so the scanner matched real embedded text and failed — reproducing only on machines with a stale local index, never in CI, contradicting the check's own stated "CI gate and unit test walk the same file set" guarantee. **Fix**: add `.ruvector` to `EXCLUDED_DIR_NAMES`, same treatment already given to `dist/` and `.git-crypt/`.

**Root cause 2**: fixing the above surfaced a second, independent latent bug — T11 (`git-crypt-remediation-strings.test.ts`, Check 61's executable twin) has no per-test timeout override, so it inherits `vitest.preset.ts`'s global 15s default. The full recursive repo-root walk + `readFileSync` reproducibly took 37–38s (twice in a row) under this repo's own normal multi-worktree-container dev workflow (CLAUDE.md's Default Execution Model recommends running a dedicated Docker container per active worktree; 9 concurrent containers is standard, not an edge case). **Fix**: scoped a 60s override to this one I/O-heavy test (matching the existing E2E convention in `vitest.e2e.config.ts`) rather than widening the global 15s preset for the whole 8,000+ test suite.

**Scope note**: both are corrections to SMI-5702's own already-plan-reviewed exclusion-list design (extending an established pattern to a directory/test that were missed), not new infra design — landing via the normal PR/review/merge pipeline rather than a fresh ADR-109 SPARC cycle.

Refs SMI-5873
