### PR TITLE
chore(docs): bump docs/internal pointer for registry catalog refresh

### DIFF
--- a/scripts/audit-git-crypt-remediation-helpers.mjs
+++ b/scripts/audit-git-crypt-remediation-helpers.mjs
@@ -23,8 +23,12 @@
  *     that legitimately quote the pre-fix pattern under the docs-exempt
  *     carve-out below; without this exclusion, `npm run audit:standards`
  *     non-reproducibly fails only on machines with a stale local index)
- *   - docs/internal/{implementation,retros}/** (historical plan docs
- *     legitimately quote the old broken snippet as before/after examples)
+ *   - docs/internal/{implementation,retros,code_review}/** (historical plan
+ *     docs, retros, and code-review reports legitimately quote the old
+ *     broken snippet as before/after examples -- code_review/ added after
+ *     the SMI-5873 fix's own post-merge retro report, itself filed there
+ *     per the governance skill's convention, tripped this exact check by
+ *     quoting the banned pattern while describing what was fixed)
  *   - the skillsmith-strategy submodule mount-points (.claude/skills,
  *     .claude/plans, .claude/hive-mind) -- fixed in a separate PR against
  *     that submodule's own checkout (SMI-5702 plan doc Wave 4), gated
@@ -72,7 +76,8 @@ const FILTER_GIT_CRYPT_RE = /filter\.git-crypt/
 function isDocsExemptPath(relPath) {
   return (
     relPath.startsWith('docs/internal/implementation/') ||
-    relPath.startsWith('docs/internal/retros/')
+    relPath.startsWith('docs/internal/retros/') ||
+    relPath.startsWith('docs/internal/code_review/')
   )
 }
 


### PR DESCRIPTION
## Summary
- Re-points `docs/internal` at skillsmith-docs main tip (`1399db35`) to pick up the 2026-07-27 registry catalog figure refresh across the product strategy and GTM doc families.
- Fixes a real, unrelated pre-existing gap found while landing this: `audit:standards` Check 61 / its executable-twin test (T11) didn't exempt `docs/internal/code_review/` from the git-crypt `--unset` remediation-text scanner, even though it's the governance skill's documented location for code-review/retro reports (already exempted for `docs/internal/{implementation,retros}/`). SMI-5873's own post-merge retro report (fixing this same check's earlier `.ruvector/` false-positive) quotes the banned string while describing the bug it fixed — tripping the check the moment this docs pointer bump pulled that retro in.

Refs SMI-5793, SMI-5702, SMI-5873
[skip-smoke]
[skip-impl-check]

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)