### PR TITLE
fix(git-crypt): Complete SMI-5702 — submodule fix + retire Check 61 carve-out

### DIFF
--- a/scripts/audit-git-crypt-remediation-helpers.mjs
+++ b/scripts/audit-git-crypt-remediation-helpers.mjs
@@ -29,14 +29,20 @@
  *     the SMI-5873 fix's own post-merge retro report, itself filed there
  *     per the governance skill's convention, tripped this exact check by
  *     quoting the banned pattern while describing what was fixed)
- *   - the skillsmith-strategy submodule mount-points (.claude/skills,
- *     .claude/plans, .claude/hive-mind) -- fixed in a separate PR against
- *     that submodule's own checkout (SMI-5702 plan doc Wave 4), gated
- *     behind that repo's own review, sequenced last so the main-repo fix
- *     is not blocked on it
  *   - this file and audit-standards.mjs itself, and the T11 test file --
  *     each legitimately names the banned pattern in comments/regex source
  *     to describe what it detects
+ *
+ * SMI-5702 Wave 4 (this commit): the skillsmith-strategy submodule
+ * mount-points (.claude/skills, .claude/plans, .claude/hive-mind) used to
+ * be exempted here, pending a separate PR against that submodule's own
+ * checkout, gated behind that repo's own review, sequenced last so the
+ * main-repo fix wasn't blocked on it. That PR (skillsmith-strategy#11) has
+ * now merged and this commit bumps the pointer to it, so the exemption is
+ * retired -- these mount-points are scanned like any other path from here
+ * on, closing the regression gap a standing carve-out would otherwise
+ * leave (nothing in this submodule's own repo re-runs this check, since it
+ * has no CI of its own).
  */
 
 import { readFileSync, readdirSync, statSync } from 'fs'
@@ -51,10 +57,6 @@ const EXCLUDED_DIR_NAMES = new Set([
   '.ruvector',
 ])
 
-// SMI-5702 Wave 4: fixed separately against the skillsmith-strategy
-// submodule's own checkout/review gate -- see file header.
-const EXCLUDED_SUBMODULE_MOUNTS = ['.claude/skills', '.claude/plans', '.claude/hive-mind']
-
 // Files that legitimately contain the literal banned substrings in
 // comments, regex source, or descriptive strings, not as an executable
 // remediation snippet.
@@ -68,6 +70,12 @@ const SELF_EXEMPT_FILES = new Set([
   // check exists to ban. Same rationale as the docs-exempt carve-out above,
   // applied to test code instead of historical plan prose.
   'scripts/tests/create-worktree-base.test.ts',
+  // SMI-5702 Wave 4 (skillsmith-strategy#11): both files' own fix comments
+  // describe the banned pattern they just removed, the same "describe what
+  // it detects/fixed" rationale as this file's own self-exemption above --
+  // not executable remediation snippets.
+  '.claude/skills/git-crypt/SKILL.md',
+  '.claude/skills/git-crypt/scripts/git-crypt-worktree.sh',
 ])
 
 const UNSET_RE = /--unset/
@@ -79,10 +87,6 @@ function isDocsExemptPath(relPath) {
     relPath.startsWith('docs/internal/retros/') ||
     relPath.startsWith('docs/internal/code_review/')
   )
-}
-
-function isSubmoduleMountPath(relPath) {
-  return EXCLUDED_SUBMODULE_MOUNTS.some((m) => relPath === m || relPath.startsWith(`${m}/`))
 }
 
 function walk(dir, out) {
@@ -125,7 +129,6 @@ export function findGitCryptUnsetRemediations(repoRoot) {
   for (const full of files) {
     const relPath = relative(repoRoot, full).split('\\').join('/')
     if (SELF_EXEMPT_FILES.has(relPath)) continue
-    if (isSubmoduleMountPath(relPath)) continue
     if (isDocsExemptPath(relPath)) continue
 
     let content

--- a/scripts/tests/git-crypt-remediation-strings.test.ts
+++ b/scripts/tests/git-crypt-remediation-strings.test.ts
@@ -34,7 +34,7 @@ const REPO_WALK_TIMEOUT_MS = 60_000
 
 describe('SMI-5702 T11: no `--unset filter.git-crypt` remediation text anywhere', () => {
   it(
-    'finds zero occurrences repo-wide outside historical plan docs and the strategy submodule',
+    'finds zero occurrences repo-wide outside historical plan docs and self-exempt explanatory comments',
     () => {
       const findings = findGitCryptUnsetRemediations(REPO_ROOT)
       expect(findings).toEqual([])


### PR DESCRIPTION
## Business Summary

**What shipped:** Closed out SMI-5702's git-crypt hardening work — the private submodule that holds this repo's dev-workflow skills had the same "delete-instead-of-restore" bug already fixed here, and this PR both points at that fix and turns the automated scanner that guards against it back on for that submodule.

**Quality bar:** The submodule fix (skillsmith-strategy#11) went through two full rounds of adversarial security review before merging — the first round caught 7 issues including 2 real regressions, the second round caught one more. This PR itself is a mechanical follow-up: bump a pointer, delete a carve-out, verified via a live run of the exact check being re-enabled (0 findings) plus the full `audit:standards` suite (green).

**Found along the way:** Nothing new.

**Net result:** Fully shipped. SMI-5702's git-crypt filter-registration hardening is now complete across every place the vulnerable pattern existed — the main repo (already merged, PR #2106) and this submodule (this PR).

---

## Technical detail

Two commits:

1. **`a42249de3`** — bumps `.claude/skills` to `skillsmith-strategy#11` (merged `ffa0d6b`), which ports the `--unset filter.git-crypt` hardening already shipped here (PR #2106) to the 3 files in that submodule that had the identical anti-pattern independently (`git-crypt/scripts/git-crypt-worktree.sh`, `git-crypt/SKILL.md`, `hive-mind-execution/agent-prompt.md`) — the last of these is the one the design doc calls "the confirmed root cause, not a hypothesis," since it hands every hive-mind worker a checkout recipe agents follow literally.

2. **`331f48662`** — retires Check 61's carve-out for the `skillsmith-strategy` submodule mount-points (`.claude/skills`, `.claude/plans`, `.claude/hive-mind`), added specifically pending commit 1 and gated on it landing first — removing it any earlier would have failed `main`'s CI against the still-unpatched pinned commit. Also adds 2 of the submodule fix's own explanatory comments to `SELF_EXEMPT_FILES` (they legitimately name the banned pattern to describe what was fixed, same rationale as this file's existing self-exemptions), and updates the T11 test's stale description.

**Split into two commits** rather than one: staging the submodule gitlink bump alongside regular file changes trips lint-staged's stash-restore mechanism on this repo (a known conflict pattern, not specific to this PR).

**Verified**: a direct run of `findGitCryptUnsetRemediations()` returns 0 findings against the post-bump repo state; the T11 unit test passes; a full `npm run audit:standards` run is green (77 passed, 0 failed, 11 pre-existing unrelated warnings — README "What's New" staleness, shadow mode).

**Not in scope for ADR-109 SPARC+plan-review**: this is Wave 4 of an already-VP-reviewed design (`docs/internal/implementation/smi-5702-worktree-git-crypt-filter-deadlock.md`, reviewed 2026-07-27) — faithful implementation and mechanical follow-through of an already-approved spec, not new design.

Refs SMI-5702
