### PR TITLE
chore(docs): Bump docs/internal pointer for SMI-5702 retro + fix Check 61 index.md gap

### DIFF
--- a/scripts/audit-git-crypt-remediation-helpers.mjs
+++ b/scripts/audit-git-crypt-remediation-helpers.mjs
@@ -78,6 +78,15 @@ const SELF_EXEMPT_FILES = new Set([
   // not executable remediation snippets.
   '.claude/skills/git-crypt/SKILL.md',
   '.claude/skills/git-crypt/scripts/git-crypt-worktree.sh',
+  // docs/internal/index.md is a rolling changelog whose "Last updated" line
+  // permanently accumulates prior entries -- unlike docs/internal/*/**
+  // subdirectories (already exempted below via isDocsExemptPath), the root
+  // index.md itself isn't covered by that prefix match. It will keep
+  // legitimately describing git-crypt-related fixes as they land (as this
+  // one does), so it gets the same file-level exemption as this file's own
+  // self-description above, rather than requiring every future changelog
+  // entry to route around the literal phrase.
+  'docs/internal/index.md',
 ])
 
 const UNSET_RE = /--unset/


### PR DESCRIPTION
## Business Summary

**What shipped:** Points this repo's internal-docs pointer at the SMI-5702 Wave 4 post-merge retro (already merged), and closes one more small gap in the same automated-scanner exemption list — a real one, found by the scanner correctly doing its job.

**Quality bar:** The retro report's own "0 remaining occurrences" summary line was itself flagged as a violation by the scanner it was summarizing, because the changelog file it landed in isn't covered by the existing exemption rules. Fixed with the same narrow, precedented approach used for the two prior instances of this exact class of gap.

**Net result:** Fully shipped, no follow-up. This closes out every open thread from SMI-5702 Wave 4.

---

## Technical detail

Two commits:

1. **`92cd40793`** bumps `docs/internal` to `skillsmith-docs#593` (the SMI-5702 Wave 4 post-merge retro).
2. **`ce696022b`** adds `docs/internal/index.md` to `SELF_EXEMPT_FILES` in `scripts/audit-git-crypt-remediation-helpers.mjs` (Check 61's helper) — the root changelog's "Last updated" line legitimately quotes `--unset filter.git-crypt` while describing what the retro just verified. `isDocsExemptPath()`'s existing subdirectory prefixes (`implementation/`, `retros/`, `code_review/`, `pr-reviews/`) don't cover the root `index.md` file itself, and it will keep needing to describe this class of fix as a permanent historical record, so it gets a file-level exemption rather than requiring every future changelog entry to route around the phrase.

This is the third time this general class of gap has surfaced (after `docs/internal/code_review/` for SMI-5873, and `docs/internal/pr-reviews/` earlier in this same PR chain) — each time the automated scanner correctly caught a real, previously-unconsidered docs path that legitimately needs to discuss the banned pattern.

Verified: `findGitCryptUnsetRemediations()` returns 0 findings; pre-push's full root test suite (including T11) passes clean.

Refs SMI-5702
