### PR TITLE
fix(security): SMI-5887 fastify-static + CodeQL remediation

### DIFF
--- a/scripts/tests/git-crypt-remediation-strings.test.ts
+++ b/scripts/tests/git-crypt-remediation-strings.test.ts
@@ -65,13 +65,15 @@ describe('SMI-5702: direct string assertions on the two most operator-visible re
 
   it('print_git_crypt_filter_remediation() (the function rebase-worktree.sh calls) prints the safe one-liner', () => {
     const libScript = resolve(REPO_ROOT, 'scripts', '_lib.sh')
+    // Pass libScript via env rather than interpolating it into the -c string:
+    // JSON.stringify() only produces JS-string-safe quoting, not shell-safe
+    // quoting -- it doesn't escape `$`, so a checkout path containing `$(...)`
+    // would be live for bash's double-quote command substitution (CodeQL
+    // #113 finding, verified by direct reproduction during SMI-5887).
     const result = execFileSync(
       'bash',
-      [
-        '-c',
-        `source ${JSON.stringify(libScript)}; print_git_crypt_filter_remediation /some/worktree`,
-      ],
-      { encoding: 'utf8' }
+      ['-c', 'source "$LIB_SCRIPT"; print_git_crypt_filter_remediation /some/worktree'],
+      { encoding: 'utf8', env: { ...process.env, LIB_SCRIPT: libScript } }
     )
     expect(result).toContain('./scripts/worktree-crypt.sh fix /some/worktree')
     expect(result).not.toContain('--unset')

--- a/scripts/tests/smoke-prod-lib.test.ts
+++ b/scripts/tests/smoke-prod-lib.test.ts
@@ -44,16 +44,27 @@ const MCP_SERVER_SH = resolve(SMOKE_PROD_DIR, 'mcp-server.sh')
 const SMOKE_PROD_SH = resolve(__dirname, '..', 'smoke-prod.sh')
 
 describe('smoke-prod/lib.sh — SMOKE_LIB_SOURCED guard (L-1)', () => {
+  // LIB_SH is passed via env (below), not interpolated into the script
+  // string: a raw `${LIB_SH}` template-literal interpolation into a
+  // double-quoted `. "..."` line doesn't escape `$`, so a checkout path
+  // containing `$(...)` would be live for bash's command substitution —
+  // the same defect class CodeQL #113 flagged in the sibling
+  // git-crypt-remediation-strings.test.ts (SMI-5887), verified here by
+  // direct reproduction even though these alerts (#110/#111) were already
+  // dismissed under SMI-5652 before this was discovered.
   it('preserves SMOKE_FAIL_COUNT/SMOKE_PASS_COUNT/SMOKE_RESULTS_JSON across a re-source', () => {
     const script = `
       set -euo pipefail
-      . "${LIB_SH}"
+      . "$LIB_SH"
       report_fail "surfaceA" "checkA" "url" "expected" "actual" "10"
-      . "${LIB_SH}"
+      . "$LIB_SH"
       report_pass "surfaceB" "checkB" "url" "5"
       printf 'fail=%s pass=%s results=%s\\n' "$SMOKE_FAIL_COUNT" "$SMOKE_PASS_COUNT" "$SMOKE_RESULTS_JSON"
     `
-    const out = execFileSync('bash', ['-c', script], { encoding: 'utf-8' })
+    const out = execFileSync('bash', ['-c', script], {
+      encoding: 'utf-8',
+      env: { ...process.env, LIB_SH },
+    })
     expect(out).toContain('fail=1 pass=1')
     expect(out).toContain('"surface":"surfaceA"')
     expect(out).toContain('"surface":"surfaceB"')
@@ -62,10 +73,13 @@ describe('smoke-prod/lib.sh — SMOKE_LIB_SOURCED guard (L-1)', () => {
   it('still resets accumulators on the FIRST source of a fresh process', () => {
     const script = `
       set -euo pipefail
-      . "${LIB_SH}"
+      . "$LIB_SH"
       printf 'fail=%s pass=%s results=[%s]\\n' "$SMOKE_FAIL_COUNT" "$SMOKE_PASS_COUNT" "$SMOKE_RESULTS_JSON"
     `
-    const out = execFileSync('bash', ['-c', script], { encoding: 'utf-8' })
+    const out = execFileSync('bash', ['-c', script], {
+      encoding: 'utf-8',
+      env: { ...process.env, LIB_SH },
+    })
     expect(out.trim()).toBe('fail=0 pass=0 results=[]')
   })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** Closed all 3 open GitHub security findings on this repo. Two Dependabot alerts on `@fastify/static` (dev-only VS Code extension test tooling) are dismissed with a documented, independently-verified reason. One CodeQL alert flagged a real (if narrow) shell-injection-shaped bug in test code — fixed the actual code instead of dismissing it, and caught the identical bug in a second file while doing so.

**Quality bar:** Sonnet implemented and probed the fix attempt; an Opus adversarial-review pass independently re-derived the technical reasoning before anything was submitted to GitHub; a cross-provider (GPT-5.6-Sol) second opinion then caught a gap the plan and the Opus pass had both missed, reversing one of the two dispositions before it shipped. Every claim in the plan doc was checked against live `gh api`/`npm view` state, not narrative.

**Found along the way:** the same shell-injection-shaped pattern already existed in `scripts/tests/smoke-prod-lib.test.ts` (its own alerts, #110/#111, were dismissed under an earlier, unrelated plan before this defect class was understood) — fixed alongside the primary target rather than left in place. `npm run preflight`'s dependency-scanner failure is confirmed pre-existing on `main` itself and unrelated to this change — already tracked as SMI-5782/SMI-5694, not duplicated.

**Net result:** Fully shipped. `npm audit --omit=dev` clean, both touched test files pass 10/10. No follow-up blocking; SMI-5657 (the related "re-check on next wdio-vscode-service release" tracker) updated with this outcome.

---

## Technical detail

**Dependabot #187 (high) / #188 (medium) — `@fastify/static@7.0.4`, GHSA-83w8-p2f5-377r / GHSA-8pvw-jcv7-9cmj**

Pulled in solely by `wdio-vscode-service@8.0.0`'s own dependency declaration (`node_modules/wdio-vscode-service` → `@fastify/static@^7.0.4`), used only to host a local ephemeral WebdriverIO test server during `packages/vscode-extension`'s E2E suite — `dependency.scope: "development"` per the GitHub API, confirmed via direct dependency-tree inspection, not just the label. Attempted a scoped override to `10.1.2` (mirroring a prior remediation, SMI-5652, that hit the identical wall for the sibling `fastify` core package). A plugin-boot compatibility probe (`fastify().register(...)` + `await app.ready()`, run against an isolated scratch install of the exact resolved version pair since this worktree's `node_modules` is read-only) confirmed `FST_ERR_PLUGIN_VERSION_MISMATCH` — `@fastify/static@10.1.2` requires fastify `5.x`; `wdio-vscode-service` still pins fastify `^4.28.1` (resolves `4.29.1`), and has shipped no newer release. Override reverted (`package.json`/`package-lock.json` end up byte-identical to `HEAD`); both alerts dismissed via `gh api` (`dismissed_reason=not_used`) with that evidence recorded in the dismissal comment. Root cause note: the plan's own first-draft probe command (a bare `.register()` with no `await app.ready()`) silently exits 0 regardless of true compatibility — `avvio` only queues a plugin, it doesn't boot it — caught before it could produce a false "compatible" result.

**CodeQL #113 (medium) — `js/shell-command-injection-from-environment`, `scripts/tests/git-crypt-remediation-strings.test.ts:68-75`**

Originally planned as a false-positive dismissal (same disposition SMI-5652 already established for the identical rule/pattern at #110/#111). A cross-provider review caught that the justification was incomplete: `JSON.stringify(libScript)` provides JS-string-safe quoting only, not shell-safe quoting — it doesn't escape `$`, so a checkout/worktree path containing `$(...)` remains live for bash's double-quote command substitution once embedded in `source ${JSON.stringify(libScript)}; ...`. Verified by direct reproduction (a synthetic path containing a `$(...)` payload executed through the exact flagged pattern). Fixed instead of dismissed: `libScript` is now passed via `execFileSync`'s `env` option (a real shell environment variable, looked up with `$LIB_SCRIPT`, never re-interpolated into parsed command text). The identical pattern — one degree more exposed, since it wasn't even `JSON.stringify`-wrapped — was found and fixed in `scripts/tests/smoke-prod-lib.test.ts`. No `gh api` dismissal for #113: GitHub marks a code-scanning alert "fixed" automatically on the next default-branch scan once the flagged pattern is gone.

**Files changed:**
- `scripts/tests/git-crypt-remediation-strings.test.ts` — shell-injection fix
- `scripts/tests/smoke-prod-lib.test.ts` — same fix, second call site found during investigation
- `docs/internal` (submodule pointer, 5 bumps) — full plan + execution notes at `docs/internal/implementation/2026-07-29-fastify-static-codeql-security-alerts.md`

**Verification:** `npm audit --omit=dev` → 0 vulnerabilities. `npx vitest run scripts/tests/git-crypt-remediation-strings.test.ts scripts/tests/smoke-prod-lib.test.ts` → 10/10 pass (including the repo-wide `SMI-5702 T11` scan, which the fix must not break). `gh api .../dependabot/alerts/187` / `/188` → both `state: "dismissed"`. Pre-push security/format/test checks green.

**Not run:** the `packages/vscode-extension` host E2E suite — the compatibility probe already proved the override incompatible (and desktop-mode E2E structurally can't exercise the code path that would register this plugin anyway), so per the plan it was correctly skipped rather than run for no signal.

Linear: SMI-5887 (tracking issue). Related: SMI-5652, SMI-5657.

`[skip-impl-check]` — `verify-implementation.ts` (SMI-3541) categorizes both changed `.test.ts` files as `test`, not `source`, and this PR also touches `docs/internal` (categorized `docs`), so its heuristic reports "no source code changes" and fails. That's a false negative for this PR specifically: the two `.test.ts` files ARE the actual security fix (a real shell-command-injection-shaped defect lived in test code, not `packages/*/src/**`) — there is no other file to point the checker at. Confirmed via the check's own source (`scripts/ci/verify-implementation.ts`) before applying this escape hatch, not used speculatively.

