### PR TITLE
fix(website): Set compressHTML: true to stop swallowing prose spaces

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -81,6 +81,14 @@ export default defineConfig({
   // Build output configuration - static with SSR adapter for dynamic routes
   output: 'static',
 
+  // SMI-5892: default compressHTML "jsx" mode applies JSX whitespace
+  // semantics to .astro templates — it removes (not collapses) a
+  // newline-containing whitespace-only text node at an inline-tag
+  // boundary, silently swallowing spaces in hand-wrapped prose
+  // (e.g. "Install & Use</a>\ntutorial." -> "Install & Usetutorial.").
+  // `true` uses standard HTML-spec whitespace collapsing instead.
+  compressHTML: true,
+
   // TypeScript configuration
   typescript: {
     strict: true,


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a site-wide rendering bug where spaces between words could silently disappear next to links, code snippets, or bold/italic text throughout skillsmith.app's docs and marketing pages — e.g. "Install & Use" running into "tutorial" as "Install & Usetutorial." Root cause was a build-tool default, not individual typos, so this one config change fixes every current occurrence and prevents new ones.

**Quality bar:** Build verified clean; both user-reported instances confirmed fixed against the compiled output. A site-wide automated sweep for the same bug class, independently adjudicated by a second review pass, found no other real instances. A full read-through of all 108 website source files (every page, component, and blog post) found no unrelated typos. Manually confirmed correct rendering in a real browser on the affected pages.

**Found along the way:** a pre-existing, unrelated ESLint debt in four files' inline Google Tag Manager scripts, filed as [SMI-5899](https://linear.app/smith-horn-group/issue/SMI-5899) rather than folded into this PR.

**Net result:** Fully shipped, no follow-up needed for the reported bug.

---

## Technical detail

**Root cause:** `packages/website/astro.config.mjs` never set `compressHTML`, so Astro used its default, `"jsx"` mode. That mode applies JSX whitespace semantics to `.astro` templates: a whitespace-only text node containing a newline, sitting at an inline-element boundary (`<a>`, `<code>`, `<em>`, `<strong>`, etc.), is removed entirely at build time instead of collapsed to one space the way normal HTML rendering does. Any hand-wrapped prose paragraph that line-wraps right at a tag boundary silently lost its space — confirmed against the compiled output in `dist/client/docs/tutorials/evaluate/index.html` for both user-reported strings ("Install & Usetutorial.", "fall through topinning in").

**Fix:** `compressHTML: true` in `astro.config.mjs` — switches to standard HTML-spec whitespace collapsing (multiple/newline whitespace → one space) instead of JSX-style stripping.

**Verification:**
- Build + grep sweep of the two originally-reported exact strings: zero hits post-fix.
- Broadened regex sweep (`</(a|code|strong|em|b|i|span)>[A-Za-z]` and the mirror pattern) across the *entire* built `dist/client` (not just docs): 11 residual hits, all the identical `<span class="sr-only">Read article: </span>{title}` pattern in `BlogPostCard.astro` (blog listing cards) — an intentional, CSS-clipped screen-reader label immediately followed by visible text, not a rendering defect. Independently verified by a separate review pass against the source, the compiled CSS, and the built HTML.
- 8 parallel proofread passes across all 108 website source files (62 pages, 33 components, 13 blog posts) for genuine authored typos unrelated to the compressHTML bug class: none found.
- `npm run lint` (scoped to changed files via pre-commit) and `astro check` (via the build script): clean. A full-package `eslint src` run surfaced pre-existing, unrelated `no-var`/`prefer-rest-params` violations in GTM inline scripts across 4 files (confirmed via `git log`/`git show` to predate this branch on `origin/main`) — filed as SMI-5899, not fixed here (out of scope).
- `npm run audit:standards`: 0 failures, 11 warnings (all pre-existing, unrelated to `packages/website`).
- The repo's Playwright visual-regression suite (`test:visual`) currently can't run at all due to a pre-existing, already-tracked issue (SMI-4494 — the Vercel adapter breaks `astro preview`) unrelated to this change. Substituted a direct browser check: served the built `dist/client` statically and confirmed correct rendering (via accessibility-tree text extraction, not raw HTML) on the two originally-buggy pages plus one more previously-affected tutorial page.

Refs SMI-5892