### PR TITLE
docs(test): fix stale H-18 coverage claim in audit-security.action.test.ts

### DIFF
--- a/packages/cli/src/commands/audit-security.action.test.ts
+++ b/packages/cli/src/commands/audit-security.action.test.ts
@@ -7,7 +7,10 @@
  * to isolate pure CLI presentation), this file exercises the REAL
  * `runSecurityAudit` + acceptance-store mutation, proving `runAuditSecurity`
  * resolves `--accept`/`--revoke` against a FRESH audit rather than a stale
- * caller-held one (R2). Covers H-4b, H-6b, H-8, H-17, H-18.
+ * caller-held one (R2). Covers H-4b, H-6b, H-8, H-17.
+ *
+ * H-18 (SKILLSMITH_AUDIT_ACCEPT_DISABLE=1 kill switch) moved to the sibling
+ * audit-security.action.killswitch.test.ts (SMI-5901 post-merge retro).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'


### PR DESCRIPTION
## Business Summary

**What shipped:** A one-line doc-comment fix — `audit-security.action.test.ts`'s file header still claimed to cover H-18 after that test block was relocated to a sibling file in PR #2147.

**Quality bar:** Found by the post-merge governance retro on PR #2147 (SMI-5901); fixed same-day, zero deferral. Typecheck/lint/format clean.

**Net result:** Done, no follow-up.

---

## Technical detail

`packages/cli/src/commands/audit-security.action.test.ts` — the `@fileoverview` comment dropped "H-18" from its coverage list and added a note pointing to `audit-security.action.killswitch.test.ts`, where that coverage actually lives now.

Refs SMI-5901