### PR TITLE
fix(cli): Add per-client targeting to install/list/remove/update/sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,17 @@ Restart Claude Code after editing settings.json.
       "command": "npx",
       "args": ["-y", "@skillsmith/mcp-server"],
       "env": {
-        "SKILLSMITH_API_KEY": "sk_live_..."
+        "SKILLSMITH_API_KEY": "sk_live_...",
+        "SKILLSMITH_CLIENT": "cursor"
       }
     }
   }
 }
 ```
 
-Cursor 2.4+ required. Reload the window after saving.
+Cursor 2.4+ required. Reload the window after saving. `SKILLSMITH_CLIENT` routes installs to `~/.cursor/skills` instead of the default `~/.claude/skills`.
+
+**Recommended**: `npm install -g @skillsmith/mcp-server` first, then point `command` at the installed `skillsmith-mcp` binary — run `which skillsmith-mcp` after installing to get the exact path (it's platform/npm-prefix specific, e.g. `/opt/homebrew/bin/skillsmith-mcp` on macOS/Homebrew; Linux and Windows paths differ). The `npx -y @skillsmith/mcp-server` form above still works as a fallback, but re-resolves the package on every launch — expect a slower cold start, and watch for `EBADENGINE` (Cursor bundles its own Node, sometimes older than the `>=22.22` this package requires) or `ENOTEMPTY` errors on repeated installs.
 
 </details>
 
@@ -377,7 +380,7 @@ See [CLAUDE.md](CLAUDE.md) for full development workflow and skill configuration
 
 ## Tech Stack
 
-- **Runtime**: Node.js 20+ (Docker with glibc)
+- **Runtime**: Node.js >=22.22 (Docker with glibc)
 - **Protocol**: MCP (Model Context Protocol)
 - **Database**: SQLite with FTS5
 - **Embeddings**: all-MiniLM-L6-v2 via onnxruntime-node

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -27,13 +27,24 @@ import {
 import { getCliLogger } from '../cli-logger.js'
 import { withTelemetry } from '@skillsmith/core/telemetry'
 import { openCliDatabase } from '../utils/open-database.js'
-import { addLink, assertClientId, getInstallPath, type ClientId } from '@skillsmith/core/install'
+import {
+  addLink,
+  assertClientId,
+  getInstallPath,
+  resolveClientId,
+  type ClientId,
+} from '@skillsmith/core/install'
 import { DEFAULT_DB_PATH, DEFAULT_MANIFEST_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
 
 const logger = getCliLogger()
 
-const VALID_CLIENT_HINT =
+/**
+ * SMI-5894 (Wave 1 Step 1/2/4): shared help-text fragment for every
+ * `--client` flag across install/list/remove/update/sync — kept in one
+ * place so the valid-IDs list can't drift between commands.
+ */
+export const VALID_CLIENT_HINT =
   'Valid IDs: claude-code | cursor | copilot | windsurf | agents | opencode | hermes ' +
   '(Codex users pass --client agents).'
 
@@ -258,16 +269,20 @@ async function installActionImpl(
   const jsonOutput = opts.json ?? false
 
   try {
-    // SMI-4578: validate --client and parse --also-link before any
-    // I/O so a bad flag fails fast with a friendly hint.
-    const rawClient = opts.client ?? 'claude-code'
-    if (rawClient.includes(',')) {
+    // SMI-4578 / SMI-5894 Wave 1 Step 1: validate --client and parse
+    // --also-link before any I/O so a bad flag fails fast with a friendly
+    // hint. An explicit --client always wins; otherwise fall back to
+    // SKILLSMITH_CLIENT (mirrors MCP's install_skill tool pattern —
+    // packages/mcp-server/src/tools/install.ts's `resolveClientPath()`
+    // call) instead of silently defaulting to claude-code and ignoring the
+    // env var, which was the actual bug (SKILLSMITH_CLIENT=cursor was
+    // silently ignored unless --client was ALSO passed explicitly).
+    if (opts.client !== undefined && opts.client.includes(',')) {
       throw new Error(
-        `--client takes a single value (got '${rawClient}'). Pass --also-link <ids> to fan-out into additional clients.`
+        `--client takes a single value (got '${opts.client}'). Pass --also-link <ids> to fan-out into additional clients.`
       )
     }
-    assertClientId(rawClient)
-    const client: ClientId = rawClient
+    const client: ClientId = resolveClientId(opts.client ?? process.env['SKILLSMITH_CLIENT'])
     const alsoLinkClients = parseAlsoLink(opts.alsoLink, client)
     const skillsDir = getInstallPath(client)
 
@@ -308,6 +323,7 @@ async function installActionImpl(
         skillsDir,
         manifestPath: DEFAULT_MANIFEST_PATH,
         registryLookup,
+        client,
         onProgress: (_stage: string, detail: string) => {
           if (spinner) {
             spinner.text = detail
@@ -425,7 +441,10 @@ export function createInstallCommand(): Command {
     .option('-q, --quiet', 'Suppress advisory output')
     .option('--json', 'Output structured JSON result')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
-    .option('--client <id>', `install for a specific agent (${VALID_CLIENT_HINT})`, 'claude-code')
+    .option(
+      '--client <id>',
+      `install for a specific agent (defaults to SKILLSMITH_CLIENT env or claude-code; ${VALID_CLIENT_HINT})`
+    )
     .option(
       '--also-link <ids>',
       'comma-separated additional clients to fan-out into (default: copy; pair with --symlink for POSIX symlinks)',

--- a/packages/cli/src/commands/manage.action.ts
+++ b/packages/cli/src/commands/manage.action.ts
@@ -22,15 +22,37 @@ import {
   type TrustTier,
 } from '@skillsmith/core'
 import { openCliDatabase } from '../utils/open-database.js'
-import { DEFAULT_DB_PATH, DEFAULT_SKILLS_DIR, DEFAULT_MANIFEST_PATH } from '../config.js'
-import { removeLinks } from '@skillsmith/core/install'
+import { DEFAULT_DB_PATH, DEFAULT_MANIFEST_PATH } from '../config.js'
+import {
+  removeLinks,
+  getInstallPath,
+  resolveClientId,
+  CANONICAL_CLIENT,
+  type ClientId,
+} from '@skillsmith/core/install'
 import { getCliLogger } from '../cli-logger.js'
 import { sanitizeError } from '../utils/sanitize.js'
 import { withTelemetry } from '@skillsmith/core/telemetry'
-import { getInstalledSkills, type InstalledSkill } from '../utils/skills-directory.js'
+import {
+  getInstalledSkills,
+  getInstalledSkillsForClient,
+  type InstalledSkill,
+} from '../utils/skills-directory.js'
 import { getSkillDiff, updateSkill, updateSkills } from './manage.update.js'
 
 const logger = getCliLogger()
+
+/**
+ * SMI-5894 (Wave 1 Step 2): resolve the effective client for `remove` and
+ * `update` the same way `install` does (Wave 1 Step 1) — an explicit
+ * `--client` wins, otherwise fall back to `SKILLSMITH_CLIENT`, otherwise
+ * the canonical client. This replaces the frozen `DEFAULT_SKILLS_DIR`
+ * constant these commands used to read (always Claude Code, regardless of
+ * the env var) with a per-invocation resolution.
+ */
+function resolveEffectiveClient(explicit: string | undefined): ClientId {
+  return resolveClientId(explicit ?? process.env['SKILLSMITH_CLIENT'])
+}
 
 /**
  * SMI-1809: Added 'local' tier color for local skills
@@ -91,15 +113,32 @@ function displaySkillsTable(skills: InstalledSkill[]): void {
 /**
  * Remove a skill using SkillInstallationService for manifest-aware removal.
  * Falls back to direct removal for orphan skills (on disk but not in manifest).
+ *
+ * SMI-5894 (Wave 1 Steps 2/3): `client` selects which agent's copy to
+ * target — resolved by the caller via `resolveEffectiveClient()` (explicit
+ * `--client`, else `SKILLSMITH_CLIENT`, else canonical). Both the
+ * pre-confirm lookup and the actual removal now consistently target the
+ * SAME resolved client's directory; previously the confirm-dialog lookup
+ * scanned every client (`getInstalledSkills()`) while the actual removal
+ * was hardcoded to Claude Code's directory regardless — so a skill
+ * installed ONLY under a non-canonical client would show correctly in the
+ * confirm dialog, then fail ("not installed") when actually removed.
  */
-async function removeSkill(skillName: string, force: boolean, dbPath: string): Promise<boolean> {
+async function removeSkill(
+  skillName: string,
+  force: boolean,
+  dbPath: string,
+  client: ClientId
+): Promise<boolean> {
+  const skillsDir = getInstallPath(client)
+
   // Show skill info and confirm before proceeding (unless --force)
   if (!force) {
-    const installed = await getInstalledSkills()
+    const installed = await getInstalledSkillsForClient(client)
     const skill = installed.find((s) => s.name.toLowerCase() === skillName.toLowerCase())
 
     if (!skill) {
-      console.log(chalk.red(`Skill "${skillName}" is not installed`))
+      console.log(chalk.red(`Skill "${skillName}" is not installed for client "${client}"`))
       return false
     }
 
@@ -134,8 +173,9 @@ async function removeSkill(skillName: string, force: boolean, dbPath: string): P
       db,
       skillRepo,
       skillDependencyRepo,
-      skillsDir: DEFAULT_SKILLS_DIR,
+      skillsDir,
       manifestPath: DEFAULT_MANIFEST_PATH,
+      client,
       onProgress: (_stage: string, detail: string) => {
         spinner.text = detail
       },
@@ -147,17 +187,28 @@ async function removeSkill(skillName: string, force: boolean, dbPath: string): P
       // SMI-4578: tear down any --also-link fan-out destinations recorded
       // for this skill. Best-effort — uninstall must succeed even if the
       // manifest is missing or a destination was already cleaned up.
-      try {
-        const linkCount = await removeLinks(skillName)
-        if (linkCount > 0) {
-          spinner.text = `Removed ${linkCount} cross-client link${linkCount > 1 ? 's' : ''}`
-        }
-      } catch (linkErr) {
-        console.log(
-          chalk.yellow(
-            `  Warning: could not clean up cross-client links: ${sanitizeError(linkErr)}`
+      //
+      // SMI-5894 review: fan-out links are always recorded FROM the
+      // canonical install (getDefaultFromClient()) -- removeLinks(skillId)
+      // has no per-destination client scoping, so calling it unconditionally
+      // would delete a canonical install's unrelated fan-out links whenever
+      // a *non-canonical* independent install of the same-named skill is
+      // removed (e.g. `remove foo --client cursor` nuking a canonical
+      // `foo`'s `--also-link vscode` copy). Only the canonical removal path
+      // legitimately owns those links.
+      if (client === CANONICAL_CLIENT) {
+        try {
+          const linkCount = await removeLinks(skillName)
+          if (linkCount > 0) {
+            spinner.text = `Removed ${linkCount} cross-client link${linkCount > 1 ? 's' : ''}`
+          }
+        } catch (linkErr) {
+          console.log(
+            chalk.yellow(
+              `  Warning: could not clean up cross-client links: ${sanitizeError(linkErr)}`
+            )
           )
-        )
+        }
       }
 
       spinner.succeed(`Successfully removed ${skillName}`)
@@ -189,8 +240,19 @@ async function listActionImpl(opts: Record<string, string | boolean | undefined>
   try {
     const dbPath = opts['db'] as string
     const outdated = (opts['outdated'] as boolean) ?? false
+    const clientOpt = opts['client'] as string | undefined
 
-    const skills = await getInstalledSkills(dbPath)
+    // SMI-5894 (Wave 1 Step 2): `list` already scans every client by
+    // default (this is a working cross-client inventory, not a detection
+    // gap) — `--client` narrows that inventory down to one client. Unlike
+    // `remove`/`update`, this is an explicit-opt-in filter only: it does
+    // NOT fall back to SKILLSMITH_CLIENT, since that would silently change
+    // `list`'s existing "show everything" default for anyone who already
+    // sets the env var for install/remove/update.
+    const skills =
+      clientOpt !== undefined
+        ? await getInstalledSkillsForClient(resolveClientId(clientOpt), dbPath)
+        : await getInstalledSkills(dbPath)
     const filtered = outdated ? skills.filter((s) => s.hasUpdates) : skills
 
     if (outdated && filtered.length === 0) {
@@ -228,15 +290,16 @@ async function updateActionImpl(
   const dryRun = (opts['dryRun'] as boolean) ?? false
 
   try {
+    const client = resolveEffectiveClient(opts['client'] as string | undefined)
     if (updateAll) {
       if (skillNames.length > 0) {
         logger.error(chalk.red('Cannot combine --all with specific skill names.'))
         process.exit(1)
         return
       }
-      await updateSkills(undefined, dbPath, dryRun)
+      await updateSkills(undefined, dbPath, dryRun, client)
     } else if (skillNames.length > 0) {
-      await updateSkills(skillNames, dbPath, dryRun)
+      await updateSkills(skillNames, dbPath, dryRun, client)
     } else {
       console.log(
         chalk.yellow('Specify one or more skills to update, or pass --all for everything.')
@@ -270,7 +333,8 @@ async function removeActionImpl(
   const dbPath = (opts['db'] as string) ?? DEFAULT_DB_PATH
 
   try {
-    const success = await removeSkill(skillName, force, dbPath)
+    const client = resolveEffectiveClient(opts['client'] as string | undefined)
+    const success = await removeSkill(skillName, force, dbPath, client)
     process.exit(success ? 0 : 1)
   } catch (error) {
     logger.error(`${chalk.red('Error removing skill:')} ${sanitizeError(error)}`)

--- a/packages/cli/src/commands/manage.ts
+++ b/packages/cli/src/commands/manage.ts
@@ -11,6 +11,7 @@
 import { Command } from 'commander'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { listAction, updateAction, removeAction } from './manage.action.js'
+import { VALID_CLIENT_HINT } from './install.js'
 
 export {
   getInstalledSkills,
@@ -32,6 +33,13 @@ export function createListCommand(): Command {
     .description('List all installed skills')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
     .option('--outdated', 'Show only skills with available updates (requires Individual tier)')
+    .option(
+      '--client <id>',
+      // SMI-5894 Wave 1 Step 2: `list` already scans every client's
+      // directory by default — this flag NARROWS that inventory to one
+      // client, it does not fix a detection gap (there wasn't one).
+      `show only this client's installed skills, instead of every client (${VALID_CLIENT_HINT})`
+    )
     .action(listAction)
 }
 
@@ -49,6 +57,10 @@ export function createUpdateCommand(): Command {
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
     .option('-a, --all', 'Update all installed skills')
     .option('-n, --dry-run', 'Show what would update without installing')
+    .option(
+      '--client <id>',
+      `update the copy installed for a specific agent (defaults to SKILLSMITH_CLIENT env or claude-code; ${VALID_CLIENT_HINT})`
+    )
     .action(updateAction)
 }
 
@@ -63,5 +75,9 @@ export function createRemoveCommand(): Command {
     .argument('<skill>', 'Skill name to remove')
     .option('-f, --force', 'Skip confirmation prompt and force removal of modified/orphan skills')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
+    .option(
+      '--client <id>',
+      `remove the copy installed for a specific agent (defaults to SKILLSMITH_CLIENT env or claude-code; ${VALID_CLIENT_HINT})`
+    )
     .action(removeAction)
 }

--- a/packages/cli/src/commands/manage.update.ts
+++ b/packages/cli/src/commands/manage.update.ts
@@ -19,10 +19,11 @@ import {
   type Skill,
 } from '@skillsmith/core'
 import { openCliDatabase } from '../utils/open-database.js'
-import { DEFAULT_SKILLS_DIR, DEFAULT_MANIFEST_PATH } from '../config.js'
+import { DEFAULT_MANIFEST_PATH } from '../config.js'
 import { sanitizeError } from '../utils/sanitize.js'
-import { getInstalledSkills, type InstalledSkill } from '../utils/skills-directory.js'
+import { getInstalledSkillsForClient, type InstalledSkill } from '../utils/skills-directory.js'
 import { createApiBackedRegistryLookup } from './install.js'
+import { CANONICAL_CLIENT, getInstallPath, type ClientId } from '@skillsmith/core/install'
 
 /**
  * Extended Skill type with optional version field.
@@ -70,12 +71,21 @@ interface SkillDiff {
  * Returns `'not-installed'` when the skill isn't installed at all, or
  * `'unresolvable'` when it's installed but has no recorded registry ID
  * (locally or in its own SKILL.md front-matter) to update against.
+ *
+ * SMI-5894 (Wave 1 Steps 2/3): `client` scopes the "is this installed"
+ * lookup to the resolved client's own directory (plus repo-local skills)
+ * via `getInstalledSkillsForClient`, instead of `getInstalledSkills()`'s
+ * global cross-client dedup. Without this, a skill installed under two
+ * clients with the same name would always resolve to whichever client wins
+ * that dedup's precedence (Claude Code), not necessarily the client the
+ * caller asked `update --client <id>` to target.
  */
 async function getSkillDiff(
   skillName: string,
-  dbPath: string
+  dbPath: string,
+  client: ClientId = CANONICAL_CLIENT
 ): Promise<SkillDiff | 'not-installed' | 'unresolvable'> {
-  const installed = (await getInstalledSkills(dbPath)).find(
+  const installed = (await getInstalledSkillsForClient(client, dbPath)).find(
     (s) => s.name.toLowerCase() === skillName.toLowerCase()
   )
   if (!installed) {
@@ -147,12 +157,23 @@ async function getSkillDiff(
 /**
  * Update a single skill. With `dryRun`, shows the same diff preview without
  * prompting or installing.
+ *
+ * SMI-5894 (Wave 1 Steps 2/3): `client` selects which agent's copy to
+ * update — resolved by the caller (explicit `--client`, else
+ * `SKILLSMITH_CLIENT`, else canonical). Replaces the previously frozen
+ * `DEFAULT_SKILLS_DIR` (always Claude Code) with a per-invocation
+ * resolution via `getInstallPath(client)`.
  */
-async function updateSkill(skillName: string, dbPath: string, dryRun = false): Promise<boolean> {
+async function updateSkill(
+  skillName: string,
+  dbPath: string,
+  dryRun = false,
+  client: ClientId = CANONICAL_CLIENT
+): Promise<boolean> {
   const spinner = ora(`Checking updates for ${skillName}...`).start()
 
   try {
-    const diff = await getSkillDiff(skillName, dbPath)
+    const diff = await getSkillDiff(skillName, dbPath, client)
 
     if (diff === 'not-installed') {
       spinner.fail(
@@ -208,9 +229,10 @@ async function updateSkill(skillName: string, dbPath: string, dryRun = false): P
         db,
         skillRepo,
         skillDependencyRepo,
-        skillsDir: DEFAULT_SKILLS_DIR,
+        skillsDir: getInstallPath(client),
         manifestPath: DEFAULT_MANIFEST_PATH,
         registryLookup,
+        client,
         onProgress: (_stage: string, detail: string) => {
           updateSpinner.text = detail
         },
@@ -238,13 +260,18 @@ async function updateSkill(skillName: string, dbPath: string, dryRun = false): P
  * Update a set of skills by name, or every installed skill when `names` is
  * omitted (the `--all` path). Shared by the explicit-list and `--all`
  * commander paths so both print the same per-skill progress + summary.
+ *
+ * SMI-5894 (Wave 1 Steps 2/3): `client` scopes both the `--all` skill-name
+ * enumeration and each per-skill update to the resolved client.
  */
 async function updateSkills(
   names: string[] | undefined,
   dbPath: string,
-  dryRun: boolean
+  dryRun: boolean,
+  client: ClientId = CANONICAL_CLIENT
 ): Promise<void> {
-  const targetNames = names ?? (await getInstalledSkills(dbPath)).map((s) => s.name)
+  const targetNames =
+    names ?? (await getInstalledSkillsForClient(client, dbPath)).map((s) => s.name)
 
   if (targetNames.length === 0) {
     console.log(chalk.yellow('No skills installed'))
@@ -257,7 +284,7 @@ async function updateSkills(
   let failed = 0
 
   for (const name of targetNames) {
-    const success = await updateSkill(name, dbPath, dryRun)
+    const success = await updateSkill(name, dbPath, dryRun, client)
     if (success) {
       updated++
     } else {

--- a/packages/cli/src/commands/sync.action.ts
+++ b/packages/cli/src/commands/sync.action.ts
@@ -154,8 +154,18 @@ async function syncActionImpl(options: {
 
 /**
  * Show sync status
+ *
+ * SMI-5894 (Wave 1 Step 4): `client` (optional) scopes the local-skills
+ * adapter-warnings scan to a specific agent's directory, resolved by
+ * `scanLocalSkillsForWarnings()` the same way install/list/remove/update
+ * resolve their target directory (explicit --client, else
+ * SKILLSMITH_CLIENT, else the canonical client).
  */
-async function syncStatusActionImpl(options: { dbPath: string; json: boolean }): Promise<void> {
+async function syncStatusActionImpl(options: {
+  dbPath: string
+  json: boolean
+  client?: string | undefined
+}): Promise<void> {
   try {
     const db = await openCliDatabase(options.dbPath)
 
@@ -238,7 +248,7 @@ async function syncStatusActionImpl(options: { dbPath: string; json: boolean }):
       // Local-skills adapter warnings (SMI-4287, GitHub #600).
       // Surface symlink-escape / permission / loop errors so the user can
       // act on them (e.g. `chmod +r`, remove rogue symlink).
-      const adapterWarnings = await scanLocalSkillsForWarnings()
+      const adapterWarnings = await scanLocalSkillsForWarnings(options.client)
       if (adapterWarnings.length > 0) {
         console.log()
         console.log(chalk.bold.yellow('Local skill warnings:'))

--- a/packages/cli/src/commands/sync.helpers.ts
+++ b/packages/cli/src/commands/sync.helpers.ts
@@ -8,7 +8,7 @@
 
 import chalk from 'chalk'
 import { createLocalFilesystemAdapter, type AdapterError, type SyncResult } from '@skillsmith/core'
-import { DEFAULT_SKILLS_DIR } from '../config.js'
+import { resolveClientPath } from '@skillsmith/core/install'
 
 /**
  * SMI-4482: Detect whether a failed sync was caused by exhausted/absent
@@ -51,15 +51,21 @@ export function formatAuthGuidance(): string[] {
 }
 
 /**
- * Scan `~/.claude/skills` for non-fatal adapter warnings.
+ * Scan the resolved client's skills directory for non-fatal adapter warnings.
  *
  * Pulls `SourceSearchResult.warnings[]` from a fresh LocalFilesystemAdapter
  * so `sync status` surfaces symlink-escape / permission / loop issues.
  * Returns an empty array if the skills dir does not exist (e.g. fresh
  * install) or the adapter fails to initialise — `sync status` must not
  * crash just because local skills couldn't be scanned.
+ *
+ * SMI-5894 (Wave 1 Step 4): `client` is resolved the same way as
+ * install/list/remove/update — explicit `--client`, else
+ * `SKILLSMITH_CLIENT`, else the canonical client — via
+ * `resolveClientPath()`, replacing the previously frozen `DEFAULT_SKILLS_DIR`
+ * (always Claude Code regardless of the env var).
  */
-export async function scanLocalSkillsForWarnings(): Promise<AdapterError[]> {
+export async function scanLocalSkillsForWarnings(client?: string): Promise<AdapterError[]> {
   try {
     const adapter = createLocalFilesystemAdapter({
       id: 'sync-status-local',
@@ -67,7 +73,7 @@ export async function scanLocalSkillsForWarnings(): Promise<AdapterError[]> {
       type: 'local',
       baseUrl: 'file://',
       enabled: true,
-      rootDir: DEFAULT_SKILLS_DIR,
+      rootDir: resolveClientPath(client),
       followSymlinks: true,
     })
     await adapter.initialize()

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -19,6 +19,7 @@
 import { Command } from 'commander'
 import { DEFAULT_DB_PATH } from '../config.js'
 import { syncAction, syncStatusAction, syncHistoryAction, syncConfigAction } from './sync.action.js'
+import { VALID_CLIENT_HINT } from './install.js'
 
 /**
  * Create sync status subcommand
@@ -28,10 +29,18 @@ function createStatusCommand(): Command {
     .description('Show sync status and statistics')
     .option('-d, --db <path>', 'Database file path', DEFAULT_DB_PATH)
     .option('--json', 'Output as JSON')
+    .option(
+      '--client <id>',
+      // SMI-5894 Wave 1 Step 4: local-skills adapter-warnings scan follows
+      // the same per-invocation client resolution as install/list/remove/
+      // update, replacing the previously frozen (always Claude Code) default.
+      `scan a specific agent's skills directory for warnings (defaults to SKILLSMITH_CLIENT env or claude-code; ${VALID_CLIENT_HINT})`
+    )
     .action(async (opts: Record<string, string | boolean | undefined>) => {
       await syncStatusAction({
         dbPath: opts['db'] as string,
         json: (opts['json'] as boolean) ?? false,
+        client: opts['client'] as string | undefined,
       })
     })
 }

--- a/packages/cli/src/templates/mcp-server.template.snippets.ts
+++ b/packages/cli/src/templates/mcp-server.template.snippets.ts
@@ -57,18 +57,31 @@ export const CLIENT_SNIPPETS: Record<SnippetClientId, ClientSnippet> = {
     label: 'Cursor',
     configPath: '~/.cursor/mcp.json',
     format: 'json',
+    // SMI-5894 Wave 1 Step 7: SKILLSMITH_CLIENT tells the server to install
+    // to ~/.cursor/skills instead of the default ~/.claude/skills — without
+    // it, Cursor users silently get Claude Code's install path.
     body: `{
   "mcpServers": {
     "{{name}}": {
       "command": "npx",
       "args": ["-y", "{{name}}"],
       "env": {
-        "SKILLSMITH_API_KEY": "sk_live_..."
+        "SKILLSMITH_API_KEY": "sk_live_...",
+        "SKILLSMITH_CLIENT": "cursor"
       }
     }
   }
 }`,
-    notes: 'Cursor 2.4+ required. Reload the window after saving.',
+    notes:
+      'Cursor 2.4+ required. Reload the window after saving. ' +
+      'Recommended: `npm install -g {{name}}` first, then point `command` at the ' +
+      'installed `skillsmith-mcp` binary (run `which skillsmith-mcp` after installing ' +
+      'to get the exact path — it varies by platform/npm prefix, e.g. ' +
+      '`/opt/homebrew/bin/skillsmith-mcp` on macOS/Homebrew, a different path on Linux/Windows). ' +
+      'The `npx -y {{name}}` form above still works as a fallback, but re-resolves the ' +
+      'package on every launch — expect a slower cold start, and watch for EBADENGINE ' +
+      '(Cursor bundles its own Node, sometimes older than the >=22.22 this package requires) ' +
+      'or ENOTEMPTY errors on repeated installs.',
   },
   copilot: {
     label: 'GitHub Copilot (VS Code)',

--- a/packages/cli/src/utils/skills-directory.ts
+++ b/packages/cli/src/utils/skills-directory.ts
@@ -47,7 +47,7 @@ export interface InstalledSkill {
  * Returns the local skills directory path.
  * Computed at call time to handle working directory changes.
  */
-function getLocalSkillsDir(): string {
+export function getLocalSkillsDir(): string {
   return join(process.cwd(), '.claude', 'skills')
 }
 
@@ -407,6 +407,33 @@ export async function getInstalledSkillsPerHarness(): Promise<HarnessSkillEntry[
  * @param dbPath Optional path to the Skillsmith SQLite database for
  *               update detection.
  */
+/**
+ * Dedup a precedence-ordered list of scan results by both skill name AND
+ * resolved path. Name-keying enforces "first entry in the array wins" when
+ * two directories carry independently-installed copies of the same skill.
+ * Realpath-keying collapses symlinked aliases (e.g. `~/.agents/skills` ->
+ * `~/.claude/skills`) so the symlinked entry doesn't appear twice when the
+ * second hop has a different `installedVia` label.
+ *
+ * Shared by {@link getInstalledSkills} (dedupes across every client) and
+ * {@link getInstalledSkillsForClient} (dedupes across just local + one
+ * client) so the two functions can't drift on dedup semantics (SMI-5894).
+ */
+async function dedupeByNameAndPath(ordered: InstalledSkill[]): Promise<InstalledSkill[]> {
+  const seenNames = new Set<string>()
+  const seenPaths = new Set<string>()
+  const out: InstalledSkill[] = []
+  for (const skill of ordered) {
+    if (seenNames.has(skill.name)) continue
+    const realPath = await safeRealpath(skill.path)
+    if (seenPaths.has(realPath)) continue
+    seenNames.add(skill.name)
+    seenPaths.add(realPath)
+    out.push(skill)
+  }
+  return out
+}
+
 export async function getInstalledSkills(dbPath?: string): Promise<InstalledSkill[]> {
   const resolvedDbPath = dbPath ?? DEFAULT_DB_PATH
 
@@ -429,22 +456,36 @@ export async function getInstalledSkills(dbPath?: string): Promise<InstalledSkil
     if (list) ordered.push(...list)
   }
 
-  // Dedup by both skill name AND resolved path. Name-keying enforces the
-  // precedence rule (local > canonical > others) when two clients carry
-  // independently-installed copies of the same skill. Realpath-keying
-  // collapses symlinked aliases (e.g. `~/.agents/skills` → `~/.claude/skills`)
-  // so the symlinked entry doesn't appear twice when the second hop has a
-  // different `installedVia` label.
-  const seenNames = new Set<string>()
-  const seenPaths = new Set<string>()
-  const out: InstalledSkill[] = []
-  for (const skill of ordered) {
-    if (seenNames.has(skill.name)) continue
-    const realPath = await safeRealpath(skill.path)
-    if (seenPaths.has(realPath)) continue
-    seenNames.add(skill.name)
-    seenPaths.add(realPath)
-    out.push(skill)
-  }
-  return out
+  return dedupeByNameAndPath(ordered)
+}
+
+/**
+ * SMI-5894 (Wave 1 Steps 2/3): like {@link getInstalledSkills}, but scoped
+ * to a single resolved client's directory instead of scanning + deduping
+ * across every client.
+ *
+ * Repo-local skills (`./.claude/skills`) still take precedence, matching
+ * the SMI-1630 "repo-local overrides global" rule `getInstalledSkills()`
+ * already applies — local skills aren't tied to any particular client's
+ * harness config, so they stay in scope regardless of which client is
+ * targeted.
+ *
+ * This is what lets `remove`/`update --client cursor` resolve unambiguously
+ * to the Cursor copy of a same-named skill, instead of being silently
+ * redirected to a different client's copy by {@link getInstalledSkills}'s
+ * global cross-client dedup (which keeps whichever client wins precedence,
+ * not necessarily the one the caller asked about).
+ */
+export async function getInstalledSkillsForClient(
+  client: ClientId,
+  dbPath?: string
+): Promise<InstalledSkill[]> {
+  const resolvedDbPath = dbPath ?? DEFAULT_DB_PATH
+
+  const [localSkills, clientSkills] = await Promise.all([
+    getSkillsFromDirectory(getLocalSkillsDir(), resolvedDbPath, 'local'),
+    getSkillsFromDirectory(CLIENT_NATIVE_PATHS[client], resolvedDbPath, client),
+  ])
+
+  return dedupeByNameAndPath([...localSkills, ...clientSkills])
 }

--- a/packages/cli/tests/manage-multi-client.test.ts
+++ b/packages/cli/tests/manage-multi-client.test.ts
@@ -1,0 +1,244 @@
+/**
+ * SMI-5894 Wave 1 Step 3 — same-name, multi-client regression test.
+ *
+ * Cross-cutting Verification requirement (plan doc: "Same-name-installed-
+ * under-two-clients regression scenario covered by tests in both Wave 1
+ * (remove/update --client) and Wave 2 (manifest resolution)"). This file
+ * covers the Wave 1 half: installing the same skill name independently
+ * under both Claude Code and Cursor, then verifying `remove`/`update
+ * --client cursor` acts only on the Cursor copy and leaves the Claude Code
+ * copy untouched (and vice versa).
+ *
+ * Unlike manage.test.ts / manage.update.test.ts (which mock
+ * @skillsmith/core's SkillInstallationService entirely — appropriate for
+ * their shallow command-shape / dispatch tests), this file exercises the
+ * REAL SkillInstallationService end-to-end against a temp $HOME, mocking
+ * only `fetch` (GitHub SKILL.md fetch), the same technique
+ * skill-installation.service.test.ts uses at the core level. This is the
+ * only way to actually prove the manifest re-keying + per-invocation
+ * skillsDir resolution fix (Wave 1 Steps 2/3) behaves correctly end to end
+ * through the CLI's own install/remove/update actions, not just that a
+ * mock was called with the right arguments.
+ */
+import { mkdtemp, rm, readFile, access } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const VALID_SKILL_MD = `---
+name: test-skill
+description: A test skill for the SMI-5894 multi-client regression test
+---
+
+# Test Skill
+
+This is a valid skill file with enough content to pass the 100-character
+minimum validation threshold that the install service checks during
+installation. Nothing suspicious here, just plain instructional prose.
+`
+
+const ORIGINAL_HOME = process.env['HOME']
+const ORIGINAL_USERPROFILE = process.env['USERPROFILE']
+const ORIGINAL_CLIENT = process.env['SKILLSMITH_CLIENT']
+
+let homeDir: string
+let dbPath: string
+
+beforeEach(async () => {
+  homeDir = await mkdtemp(path.join(tmpdir(), 'smi5894-manage-multi-'))
+  process.env['HOME'] = homeDir
+  process.env['USERPROFILE'] = homeDir
+  delete process.env['SKILLSMITH_CLIENT']
+  dbPath = path.join(homeDir, 'skills.db')
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL) => {
+      const urlStr = typeof url === 'string' ? url : url.toString()
+      if (urlStr.includes('SKILL.md')) {
+        return new Response(VALID_SKILL_MD, { status: 200 })
+      }
+      return new Response('Not found', { status: 404 })
+    })
+  )
+
+  // CLIENT_NATIVE_PATHS and DEFAULT_MANIFEST_PATH compute homedir() at
+  // module import time — reset modules so each test sees its own $HOME
+  // (same technique as install-multi-client.test.ts).
+  vi.resetModules()
+
+  // Quiet the install/remove commands' own console.log output — none of
+  // these tests assert on stdout, only on filesystem/manifest state.
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterEach(async () => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  if (ORIGINAL_HOME === undefined) delete process.env['HOME']
+  else process.env['HOME'] = ORIGINAL_HOME
+  if (ORIGINAL_USERPROFILE === undefined) delete process.env['USERPROFILE']
+  else process.env['USERPROFILE'] = ORIGINAL_USERPROFILE
+  if (ORIGINAL_CLIENT === undefined) delete process.env['SKILLSMITH_CLIENT']
+  else process.env['SKILLSMITH_CLIENT'] = ORIGINAL_CLIENT
+  await rm(homeDir, { recursive: true, force: true })
+})
+
+/** Install the fixture skill for a given client, asserting success. */
+async function installForClient(client: string): Promise<void> {
+  const { installAction } = await import('../src/commands/install.js')
+  await installAction('https://github.com/owner/test-repo', {
+    db: dbPath,
+    client,
+    quiet: true,
+    json: true,
+    skipOptimize: true,
+  })
+}
+
+async function readManifest(): Promise<Record<string, unknown>> {
+  const raw = await readFile(path.join(homeDir, '.skillsmith', 'manifest.json'), 'utf-8')
+  return JSON.parse(raw) as Record<string, unknown>
+}
+
+describe('SMI-5894 Wave 1: same-name skill installed under two clients', () => {
+  it('remove --client cursor removes only the Cursor copy, leaving Claude Code untouched', async () => {
+    await installForClient('claude-code')
+    await installForClient('cursor')
+
+    const claudePath = path.join(homeDir, '.claude', 'skills', 'test-repo')
+    const cursorPath = path.join(homeDir, '.cursor', 'skills', 'test-repo')
+    await expect(access(claudePath)).resolves.toBeUndefined()
+    await expect(access(cursorPath)).resolves.toBeUndefined()
+
+    const { removeAction } = await import('../src/commands/manage.js')
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    await removeAction('test-repo', { force: true, db: dbPath, client: 'cursor' })
+    exitSpy.mockRestore()
+
+    // Cursor copy removed from disk...
+    await expect(access(cursorPath)).rejects.toThrow()
+    // ...Claude Code copy untouched on disk.
+    await expect(access(claudePath)).resolves.toBeUndefined()
+
+    const manifest = await readManifest()
+    const installedSkills = manifest['installedSkills'] as Record<string, unknown>
+    expect(installedSkills['test-repo::cursor']).toBeUndefined()
+    expect(installedSkills['test-repo']).toBeDefined()
+  })
+
+  it('remove --client cursor on an independent Cursor install does not tear down an unrelated canonical fan-out link (SMI-5894 review finding)', async () => {
+    // Canonical install, fanned out to Windsurf via addLink -- this
+    // fan-out link is NOT related to the independent Cursor install below;
+    // it belongs entirely to the canonical copy. Calling the fan-out
+    // primitive directly (rather than through `install --also-link`)
+    // isolates the behavior under test -- removeLinks scoping -- from the
+    // CLI's own fan-out wiring.
+    await installForClient('claude-code')
+    const { addLink } = await import('@skillsmith/core/install')
+    await addLink({ skillId: 'test-repo', fromClient: 'claude-code', toClient: 'windsurf' })
+
+    // A second, fully independent install of the SAME skill name directly
+    // for Cursor (not a fan-out of the canonical copy).
+    await installForClient('cursor')
+
+    const windsurfPath = path.join(homeDir, '.codeium', 'windsurf', 'skills', 'test-repo')
+    const cursorPath = path.join(homeDir, '.cursor', 'skills', 'test-repo')
+    await expect(access(windsurfPath)).resolves.toBeUndefined()
+    await expect(access(cursorPath)).resolves.toBeUndefined()
+
+    const { removeAction } = await import('../src/commands/manage.js')
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    await removeAction('test-repo', { force: true, db: dbPath, client: 'cursor' })
+    exitSpy.mockRestore()
+
+    // The independent Cursor install is gone...
+    await expect(access(cursorPath)).rejects.toThrow()
+    // ...but the canonical install's unrelated Windsurf fan-out link must
+    // survive -- removeLinks(skillId) has no per-destination client
+    // scoping, so calling it for a non-canonical client-scoped removal
+    // would previously delete every fan-out link for this skill name,
+    // including this one, even though it belongs to a completely
+    // different (canonical) install.
+    await expect(access(windsurfPath)).resolves.toBeUndefined()
+  })
+
+  it('remove --client claude-code (the default, no flag) removes only the Claude Code copy, leaving Cursor untouched', async () => {
+    await installForClient('claude-code')
+    await installForClient('cursor')
+
+    const claudePath = path.join(homeDir, '.claude', 'skills', 'test-repo')
+    const cursorPath = path.join(homeDir, '.cursor', 'skills', 'test-repo')
+
+    const { removeAction } = await import('../src/commands/manage.js')
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    // No --client passed and no SKILLSMITH_CLIENT set — defaults to
+    // claude-code, matching install's own default (Wave 1 Step 1).
+    await removeAction('test-repo', { force: true, db: dbPath })
+    exitSpy.mockRestore()
+
+    await expect(access(claudePath)).rejects.toThrow()
+    await expect(access(cursorPath)).resolves.toBeUndefined()
+
+    const manifest = await readManifest()
+    const installedSkills = manifest['installedSkills'] as Record<string, unknown>
+    expect(installedSkills['test-repo']).toBeUndefined()
+    expect(installedSkills['test-repo::cursor']).toBeDefined()
+  })
+
+  it('SKILLSMITH_CLIENT=cursor (no --client flag) scopes remove to the Cursor copy', async () => {
+    await installForClient('claude-code')
+    await installForClient('cursor')
+    process.env['SKILLSMITH_CLIENT'] = 'cursor'
+
+    const claudePath = path.join(homeDir, '.claude', 'skills', 'test-repo')
+    const cursorPath = path.join(homeDir, '.cursor', 'skills', 'test-repo')
+
+    const { removeAction } = await import('../src/commands/manage.js')
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    await removeAction('test-repo', { force: true, db: dbPath })
+    exitSpy.mockRestore()
+
+    await expect(access(cursorPath)).rejects.toThrow()
+    await expect(access(claudePath)).resolves.toBeUndefined()
+  })
+
+  it('list --client cursor shows only the Cursor copy, not the Claude Code copy', async () => {
+    await installForClient('claude-code')
+    await installForClient('cursor')
+
+    // Scoped scans also include repo-local (`./.claude/skills`) skills —
+    // real when this test runs from the actual monorepo checkout, whose
+    // own `.claude/skills` mount-point is populated. Filter down to the
+    // fixture skill under test so that pre-existing local inventory
+    // doesn't make this assertion flaky depending on cwd.
+    const { getInstalledSkillsForClient } = await import('../src/utils/skills-directory.js')
+    const cursorSkills = (await getInstalledSkillsForClient('cursor', dbPath)).filter(
+      (s) => s.name === 'test-skill'
+    )
+    expect(cursorSkills.map((s) => s.installedVia)).toEqual(['cursor'])
+
+    const claudeSkills = (await getInstalledSkillsForClient('claude-code', dbPath)).filter(
+      (s) => s.name === 'test-skill'
+    )
+    expect(claudeSkills.map((s) => s.installedVia)).toEqual(['claude-code'])
+  })
+
+  it("update --client cursor resolves the Cursor copy as installed without being redirected to Claude Code's copy", async () => {
+    // Install ONLY under Cursor — a Claude Code copy of the same name does
+    // NOT exist. Before Wave 1 Step 3, getSkillDiff() consulted the global,
+    // cross-client-deduped getInstalledSkills(), so a client-scoped lookup
+    // for a skill that only exists under a non-canonical client had no way
+    // to distinguish "not installed anywhere" from "not installed under
+    // Claude Code but installed elsewhere" — this is exactly that case.
+    await installForClient('cursor')
+
+    const { getSkillDiff } = await import('../src/commands/manage.js')
+
+    const cursorDiff = await getSkillDiff('test-skill', dbPath, 'cursor')
+    expect(cursorDiff).not.toBe('not-installed')
+
+    const claudeDiff = await getSkillDiff('test-skill', dbPath, 'claude-code')
+    expect(claudeDiff).toBe('not-installed')
+  })
+})

--- a/packages/core/src/install/index.ts
+++ b/packages/core/src/install/index.ts
@@ -11,6 +11,7 @@
  */
 export {
   CANONICAL_CLIENT,
+  CLIENT_DISPLAY_LABELS,
   CLIENT_IDS,
   CLIENT_NATIVE_PATHS,
   assertClientId,

--- a/packages/core/src/install/paths.ts
+++ b/packages/core/src/install/paths.ts
@@ -63,6 +63,26 @@ export const CLIENT_NATIVE_PATHS: Record<ClientId, string> = {
 
 export const CANONICAL_CLIENT: ClientId = 'claude-code'
 
+/**
+ * SMI-5894 (Wave 1 Step 5): human-readable label per client, used by
+ * post-install tips/guidance so the messaging names the actual install
+ * target (e.g. "mention it in Cursor:") instead of unconditionally saying
+ * "Claude Code" regardless of `SKILLSMITH_CLIENT`/`--client`. Lives here
+ * (not in the CLI's `CLIENT_SNIPPETS` table) so both `@skillsmith/core`
+ * (shared install/uninstall tip generation) and any MCP-side caller can use
+ * it without introducing a core -> cli dependency.
+ */
+export const CLIENT_DISPLAY_LABELS: Record<ClientId, string> = {
+  'claude-code': 'Claude Code',
+  cursor: 'Cursor',
+  copilot: 'GitHub Copilot',
+  windsurf: 'Windsurf',
+  agents: 'your agent',
+  opencode: 'OpenCode',
+  hermes: 'Hermes',
+  grok: 'Grok Build',
+}
+
 export const CLIENT_IDS: ReadonlyArray<ClientId> = Object.freeze([
   'claude-code',
   'cursor',

--- a/packages/core/src/services/skill-installation.helpers.test.ts
+++ b/packages/core/src/services/skill-installation.helpers.test.ts
@@ -1,16 +1,24 @@
 /**
  * @fileoverview Tests for the SMI-5676 `.mcp.json` cross-check additions to
  *   skill-installation.helpers.ts (`getRegisteredMcpServers`, and the
- *   resolution-aware warning filtering in `extractDepIntel`).
+ *   resolution-aware warning filtering in `extractDepIntel`), plus the
+ *   SMI-5894 Wave 1 multi-client manifest-keying + tips additions
+ *   (`manifestKeyFor`, `generateTips`).
  * @module @skillsmith/core/services/skill-installation.helpers.test
  * @see SMI-5676: Wave 1 Step 3b — harden extractMcpReferences
+ * @see SMI-5894: Wave 1 Steps 3/5 — multi-client manifest re-keying + tips
  */
 import { describe, expect, it, beforeEach, afterEach } from 'vitest'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 
-import { extractDepIntel, getRegisteredMcpServers } from './skill-installation.helpers.js'
+import {
+  extractDepIntel,
+  getRegisteredMcpServers,
+  generateTips,
+  manifestKeyFor,
+} from './skill-installation.helpers.js'
 
 describe('getRegisteredMcpServers (SMI-5676)', () => {
   let tmpDir: string
@@ -101,5 +109,40 @@ describe('extractDepIntel resolution-aware warnings (SMI-5676)', () => {
     const result = extractDepIntel('Use mcp__linear__save_issue to create issues.')
 
     expect(result.dep_warnings.some((w) => w.includes('linear'))).toBe(true)
+  })
+})
+
+describe('manifestKeyFor (SMI-5894 Wave 1 Step 3)', () => {
+  it('keys the canonical client (claude-code) by bare name — backward compatible', () => {
+    expect(manifestKeyFor('my-skill', 'claude-code')).toBe('my-skill')
+  })
+
+  it('keys a non-canonical client with a composite name::client key', () => {
+    expect(manifestKeyFor('my-skill', 'cursor')).toBe('my-skill::cursor')
+    expect(manifestKeyFor('my-skill', 'windsurf')).toBe('my-skill::windsurf')
+  })
+
+  it('produces distinct keys for the same skill name under different clients', () => {
+    const claudeKey = manifestKeyFor('same-name', 'claude-code')
+    const cursorKey = manifestKeyFor('same-name', 'cursor')
+    expect(claudeKey).not.toBe(cursorKey)
+  })
+})
+
+describe('generateTips (SMI-5894 Wave 1 Step 5)', () => {
+  const optimizationInfo = { optimized: false } as const
+
+  it('defaults to Claude Code wording when client/skillsDir are omitted (backward compatible)', () => {
+    const tips = generateTips('my-skill', optimizationInfo)
+    expect(tips.join('\n')).toContain('mention it in Claude Code')
+    expect(tips.join('\n')).toContain('ls ~/.claude/skills/')
+  })
+
+  it('names the actual client and install path when a non-canonical client is resolved', () => {
+    const tips = generateTips('my-skill', optimizationInfo, 'cursor', '/home/user/.cursor/skills')
+    const joined = tips.join('\n')
+    expect(joined).toContain('mention it in Cursor')
+    expect(joined).toContain('ls /home/user/.cursor/skills/')
+    expect(joined).not.toContain('Claude Code')
   })
 })

--- a/packages/core/src/services/skill-installation.helpers.ts
+++ b/packages/core/src/services/skill-installation.helpers.ts
@@ -33,6 +33,7 @@ import type {
 import { checkForModifications } from './skill-installation.io.js'
 export { fetchFromGitHub } from './skill-installation.io.js'
 import type { ManifestManager } from './skill-manifest.js'
+import { CANONICAL_CLIENT, CLIENT_DISPLAY_LABELS, type ClientId } from '../install/paths.js'
 
 /** Result of applying optimization to a skill's content. */
 export interface OptimizationResult {
@@ -47,11 +48,26 @@ export function hashContent(content: string): string {
   return createHash('sha256').update(content).digest('hex')
 }
 
-export function generateTips(skillName: string, optimizationInfo: OptimizationInfo): string[] {
+/**
+ * SMI-5894 (Wave 1 Step 5): `client`/`skillsDir` default to the canonical
+ * (Claude Code) client so every existing caller that doesn't pass them
+ * (tests, and anywhere the service is constructed without `client`) keeps
+ * seeing exactly the previous "Claude Code" / `~/.claude/skills/` wording —
+ * only a caller that actually resolved a non-canonical client sees the tips
+ * name that client and its real install path.
+ */
+export function generateTips(
+  skillName: string,
+  optimizationInfo: OptimizationInfo,
+  client: ClientId = CANONICAL_CLIENT,
+  skillsDir?: string
+): string[] {
+  const clientLabel = CLIENT_DISPLAY_LABELS[client]
+  const dir = skillsDir ?? '~/.claude/skills'
   const tips = [
     'Skill "' + skillName + '" installed successfully!',
-    'To use this skill, mention it in Claude Code: "Use the ' + skillName + ' skill to..."',
-    'View installed skills: ls ~/.claude/skills/',
+    'To use this skill, mention it in ' + clientLabel + ': "Use the ' + skillName + ' skill to..."',
+    'View installed skills: ls ' + dir + '/',
   ]
 
   if (optimizationInfo.optimized) {
@@ -173,6 +189,28 @@ export function persistDependencies(
   return rows.length
 }
 
+/**
+ * SMI-5894 (Wave 1 Step 3): compute the `~/.skillsmith/manifest.json`
+ * `installedSkills` key for a given skill name + client.
+ *
+ * Canonical-client (`claude-code`) entries keep the legacy bare-name key —
+ * every manifest reader written before multi-client installs existed
+ * (`pin.ts`, `diff.ts`, MCP's `install.conflict.ts`, MCP's `uninstall_skill`
+ * `listInstalledSkills()`, none of which are in this wave's scope) indexes
+ * `installedSkills[name]` directly and must keep working unmodified for the
+ * single-client-install case, which remains the overwhelming majority.
+ * Only non-canonical clients get the composite `name::client` key, since
+ * those are the ONLY entries that could previously silently collide with
+ * (overwrite) a same-named install recorded under a different client —
+ * exactly the bug this function exists to close. See the plan doc
+ * (docs/internal/implementation/cursor-integration-readiness-cli-mcp-parity.md,
+ * Wave 1 Step 3) for the full rationale and the deliberately additive,
+ * backward-compatible shape of this fix.
+ */
+export function manifestKeyFor(name: string, client: ClientId): string {
+  return client === CANONICAL_CLIENT ? name : `${name}::${client}`
+}
+
 /** Perform skill uninstall with manifest awareness and orphan fallback. */
 export async function performUninstall(params: {
   skillName: string
@@ -181,13 +219,25 @@ export async function performUninstall(params: {
   manifest: ManifestManager
   skillDependencyRepo: SkillDependencyRepository
   onProgress: ProgressCallback
+  /** SMI-5894 Wave 1 Step 3: defaults to the canonical client for callers
+   *  that don't yet resolve a client (preserves pre-existing behavior). */
+  client?: ClientId
 }): Promise<UninstallResult> {
-  const { skillName, force, skillsDir, manifest, skillDependencyRepo, onProgress } = params
+  const {
+    skillName,
+    force,
+    skillsDir,
+    manifest,
+    skillDependencyRepo,
+    onProgress,
+    client = CANONICAL_CLIENT,
+  } = params
+  const manifestKey = manifestKeyFor(skillName, client)
 
   try {
     onProgress('manifest', 'Loading manifest')
     const manifestData = await manifest.load()
-    const skillEntry = manifestData.installedSkills[skillName]
+    const skillEntry = manifestData.installedSkills[manifestKey]
 
     if (!skillEntry) {
       const potentialPath = path.join(skillsDir, skillName)
@@ -251,7 +301,7 @@ export async function performUninstall(params: {
     }
 
     onProgress('manifest', 'Updating manifest')
-    delete manifestData.installedSkills[skillName]
+    delete manifestData.installedSkills[manifestKey]
     await manifest.save(manifestData)
 
     onProgress('done', 'Uninstall complete')

--- a/packages/core/src/services/skill-installation.service.ts
+++ b/packages/core/src/services/skill-installation.service.ts
@@ -29,7 +29,9 @@ import {
   applyOptimization,
   performUninstall,
   sanitizeInstallError,
+  manifestKeyFor,
 } from './skill-installation.helpers.js'
+import { CANONICAL_CLIENT, type ClientId } from '../install/paths.js'
 import {
   parseSkillIdInternal,
   validateSkillMd,
@@ -57,6 +59,17 @@ export interface SkillInstallationServiceParams {
   quarantineLookup?: (skillId: string) => QuarantineStatus | null // SMI-3871
   riskHistoryRepo?: RiskScoreHistoryRepository // SMI-3874
   aiDefenceFeedback?: AiDefenceFeedback // SMI-3873
+  /**
+   * SMI-5894 (Wave 1 Step 3): the client this install/uninstall targets.
+   * Defaults to the canonical client (`claude-code`) — every existing
+   * caller that doesn't pass it (MCP's install/uninstall tools, and any
+   * pre-Wave-1 test) keeps writing/reading manifest entries under the
+   * legacy bare-name key, unchanged. Only used for manifest keying
+   * (`manifestKeyFor`) and post-install tips — callers still supply their
+   * own already-resolved `skillsDir` (e.g. via `resolveClientPath`/
+   * `getInstallPath`); this does not re-derive `skillsDir` from `client`.
+   */
+  client?: ClientId
 }
 export class SkillInstallationService {
   private readonly db: Database
@@ -71,6 +84,7 @@ export class SkillInstallationService {
   private readonly quarantineLookup?: (skillId: string) => QuarantineStatus | null
   private readonly riskHistoryRepo?: RiskScoreHistoryRepository
   private readonly aiDefenceFeedback?: AiDefenceFeedback
+  private readonly client: ClientId
   constructor(params: SkillInstallationServiceParams) {
     this.db = params.db
     this.skillRepo = params.skillRepo
@@ -84,6 +98,7 @@ export class SkillInstallationService {
     this.riskHistoryRepo = params.riskHistoryRepo
     this.aiDefenceFeedback = params.aiDefenceFeedback
     this.sessionInstalledSkillIds = params.sessionInstalledSkillIds ?? []
+    this.client = params.client ?? CANONICAL_CLIENT
   }
   async install(skillId: string, options: InstallOptions = {}): Promise<InstallResult> {
     let trustTier: TrustTier = 'unknown'
@@ -128,7 +143,8 @@ export class SkillInstallationService {
       const installPath = path.join(this.skillsDir, skillName)
       this.onProgress('manifest', 'Checking manifest')
       const manifest = await this.manifest.load()
-      if (manifest.installedSkills[skillName] && !options.force) {
+      const manifestKey = manifestKeyFor(skillName, this.client)
+      if (manifest.installedSkills[manifestKey] && !options.force) {
         return buildInstallFailure('ALREADY_INSTALLED', {
           skillId,
           installPath,
@@ -354,7 +370,7 @@ export class SkillInstallationService {
         ...currentManifest,
         installedSkills: {
           ...currentManifest.installedSkills,
-          [skillName]: {
+          [manifestKey]: {
             id: skillId,
             name: skillName,
             version: '1.0.0',
@@ -363,6 +379,7 @@ export class SkillInstallationService {
             installedAt: new Date().toISOString(),
             lastUpdated: new Date().toISOString(),
             originalContentHash: contentHash, // hash of optimized content (post-applyOptimization)
+            client: this.client,
           },
         },
       }))
@@ -409,7 +426,7 @@ export class SkillInstallationService {
         blocked: false,
       })
       this.onProgress('done', 'Installation complete')
-      const tips = generateTips(skillName, optimizationInfo)
+      const tips = generateTips(skillName, optimizationInfo, this.client, this.skillsDir)
       tips.unshift(...trendWarnings)
       tips.push(...optionalFiles.configWarnings)
       if (options.skipScan) {
@@ -451,6 +468,7 @@ export class SkillInstallationService {
       manifest: this.manifest,
       skillDependencyRepo: this.skillDependencyRepo,
       onProgress: this.onProgress,
+      client: this.client,
     })
   }
 }

--- a/packages/core/src/services/skill-installation.types.ts
+++ b/packages/core/src/services/skill-installation.types.ts
@@ -9,6 +9,7 @@
 import type { ScanReport, ScannerOptions } from '../security/index.js'
 import type { TrustTier } from '../types/skill.js'
 import type { DependencyDeclaration } from '../types/dependencies.js'
+import type { ClientId } from '../install/paths.js'
 
 // ============================================================================
 // Progress Callback
@@ -182,6 +183,13 @@ export interface SkillManifestEntry {
   pinnedVersion?: string
   /** How updates are handled */
   updatePolicy?: 'auto' | 'manual' | 'never'
+  /**
+   * SMI-5894 (Wave 1 Step 3): which client this installation targets.
+   * Absent on manifest entries written before multi-client re-keying —
+   * treat a missing value as the canonical client (`claude-code`), matching
+   * `manifestKeyFor()`'s own default.
+   */
+  client?: ClientId
 }
 
 /** Manifest tracking all installed skills */

--- a/packages/core/tests/unit/services/skill-installation.service.error-codes.test.ts
+++ b/packages/core/tests/unit/services/skill-installation.service.error-codes.test.ts
@@ -1,0 +1,241 @@
+/**
+ * SMI-4795: errorCode taxonomy on install failures
+ *
+ * Each failing return path inside install() must populate `errorCode` with
+ * a code from InstallErrorCode. Telemetry (emitInstallEvent) reads this
+ * field; without it the install funnel cannot classify failures.
+ *
+ * Split out of skill-installation.service.test.ts (CLAUDE.md's 500-line
+ * file cap) after SMI-5894 Wave 1 added its own multi-client suite there —
+ * this block predates that change and is unrelated to it, but moving it
+ * out (rather than the newly-added block alone) was the smallest change
+ * that got the original file back under the cap.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import * as os from 'os'
+import { SkillInstallationService } from '../../../src/services/skill-installation.service.js'
+import { SkillRepository } from '../../../src/repositories/SkillRepository.js'
+import { SkillDependencyRepository } from '../../../src/repositories/SkillDependencyRepository.js'
+import { createTestDatabase } from '../../helpers/database.js'
+import type { Database } from '../../../src/db/database-interface.js'
+import type { TrustTier } from '../../../src/types/skill.js'
+import type { RegistryLookup } from '../../../src/services/skill-installation.types.js'
+
+const VALID_SKILL_MD = `---
+name: test-skill
+description: A test skill for unit testing
+---
+
+# Test Skill
+
+This is a valid skill file with enough content to pass the 100-character minimum
+validation threshold that the service checks during installation.
+
+## Usage
+
+Use this skill by saying "Use the test-skill skill to..."
+`
+
+const SHORT_SKILL_MD = '# Short\nToo short.'
+
+let tmpDir: string
+let skillsDir: string
+let manifestPath: string
+
+async function createTmpDirs(): Promise<void> {
+  tmpDir = path.join(
+    os.tmpdir(),
+    'skillsmith-test-' + Date.now() + '-' + Math.random().toString(36).slice(2)
+  )
+  skillsDir = path.join(tmpDir, 'skills')
+  manifestPath = path.join(tmpDir, 'manifest.json')
+  await fs.mkdir(skillsDir, { recursive: true })
+}
+
+async function cleanupTmpDirs(): Promise<void> {
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+}
+
+function createMockRegistryLookup(
+  skills: Record<
+    string,
+    {
+      repoUrl: string
+      name: string
+      quarantined?: boolean
+      trustTier?: TrustTier
+      contentHash?: string
+    }
+  >
+): RegistryLookup {
+  return {
+    async lookup(skillId: string) {
+      const entry = skills[skillId]
+      if (!entry) return null
+      return {
+        repoUrl: entry.repoUrl,
+        name: entry.name,
+        trustTier: entry.trustTier ?? ('community' as const),
+        quarantined: entry.quarantined,
+        contentHash: entry.contentHash,
+      }
+    },
+  }
+}
+
+function createService(
+  db: Database,
+  overrides: Partial<ConstructorParameters<typeof SkillInstallationService>[0]> = {}
+): SkillInstallationService {
+  const skillRepo = new SkillRepository(db)
+  const skillDependencyRepo = new SkillDependencyRepository(db)
+
+  return new SkillInstallationService({
+    db,
+    skillRepo,
+    skillDependencyRepo,
+    skillsDir,
+    manifestPath,
+    ...overrides,
+  })
+}
+
+describe('SMI-4795: install failures populate errorCode', () => {
+  let db: Database
+
+  beforeEach(async () => {
+    db = await createTestDatabase()
+    await createTmpDirs()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(async () => {
+    db.close()
+    await cleanupTmpDirs()
+    vi.restoreAllMocks()
+  })
+
+  it('REGISTRY_LOOKUP_UNAVAILABLE when registry id supplied without lookup adapter', async () => {
+    const service = createService(db) // no registryLookup
+    const result = await service.install('author/some-skill')
+
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('REGISTRY_LOOKUP_UNAVAILABLE')
+  })
+
+  it('REGISTRY_SKILL_NOT_FOUND when registry returns null', async () => {
+    const service = createService(db, {
+      registryLookup: createMockRegistryLookup({}), // empty registry
+    })
+    const result = await service.install('author/missing-skill')
+
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('REGISTRY_SKILL_NOT_FOUND')
+  })
+
+  it('QUARANTINED when registry flags the skill', async () => {
+    const service = createService(db, {
+      registryLookup: createMockRegistryLookup({
+        'author/quarantined-skill': {
+          repoUrl: 'https://github.com/author/quarantined-skill',
+          name: 'quarantined-skill',
+          quarantined: true,
+          trustTier: 'community',
+        },
+      }),
+    })
+    const result = await service.install('author/quarantined-skill')
+
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('QUARANTINED')
+    expect(result.trustTier).toBe('community')
+  })
+
+  it('FETCH_FAILED when SKILL.md is unreachable', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValue(new Response('Not found', { status: 404 }))
+
+    const service = createService(db)
+    const result = await service.install('https://github.com/owner/missing-repo')
+
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('FETCH_FAILED')
+  })
+
+  it('VALIDATION_FAILED when SKILL.md is malformed/short', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockImplementation(async (url) => {
+      const urlStr = typeof url === 'string' ? url : url.toString()
+      if (urlStr.includes('SKILL.md')) {
+        return new Response(SHORT_SKILL_MD, { status: 200 })
+      }
+      return new Response('Not found', { status: 404 })
+    })
+
+    const service = createService(db)
+    const result = await service.install('https://github.com/owner/short-repo')
+
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('VALIDATION_FAILED')
+  })
+
+  it('ALREADY_INSTALLED on repeat install without force', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockImplementation(async (url) => {
+      const urlStr = typeof url === 'string' ? url : url.toString()
+      if (urlStr.includes('SKILL.md')) {
+        return new Response(VALID_SKILL_MD, { status: 200 })
+      }
+      return new Response('Not found', { status: 404 })
+    })
+
+    const service = createService(db)
+    const first = await service.install('https://github.com/owner/dup-repo')
+    expect(first.success).toBe(true)
+
+    const second = await service.install('https://github.com/owner/dup-repo')
+    expect(second.success).toBe(false)
+    expect(second.errorCode).toBe('ALREADY_INSTALLED')
+  })
+
+  it('SKIP_SCAN_FORBIDDEN when skipScan requested on unknown tier', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockImplementation(async (url) => {
+      const urlStr = typeof url === 'string' ? url : url.toString()
+      if (urlStr.includes('SKILL.md')) {
+        return new Response(VALID_SKILL_MD, { status: 200 })
+      }
+      return new Response('Not found', { status: 404 })
+    })
+
+    // Direct GitHub URL → trust tier defaults to 'unknown', skipScan disallowed
+    const service = createService(db)
+    const result = await service.install('https://github.com/owner/skip-repo', {
+      skipScan: true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.errorCode).toBe('SKIP_SCAN_FORBIDDEN')
+    expect(result.trustTier).toBe('unknown')
+  })
+
+  it('successful install does NOT carry errorCode', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockImplementation(async (url) => {
+      const urlStr = typeof url === 'string' ? url : url.toString()
+      if (urlStr.includes('SKILL.md')) {
+        return new Response(VALID_SKILL_MD, { status: 200 })
+      }
+      return new Response('Not found', { status: 404 })
+    })
+
+    const service = createService(db)
+    const result = await service.install('https://github.com/owner/ok-repo')
+
+    expect(result.success).toBe(true)
+    expect(result.errorCode).toBeUndefined()
+  })
+})

--- a/packages/core/tests/unit/services/skill-installation.service.multi-client.test.ts
+++ b/packages/core/tests/unit/services/skill-installation.service.multi-client.test.ts
@@ -1,0 +1,158 @@
+/**
+ * SMI-5894 Wave 1 Step 3: multi-client manifest re-keying
+ *
+ * getInstalledSkills() dedupes same-named skills across clients with
+ * Claude Code precedence; before this fix, SkillInstallationService wrote
+ * every manifest entry under a bare skill-name key regardless of client,
+ * so installing the same skill name under two clients silently collided
+ * (the second install's manifest write overwrote the first). This suite
+ * is the required cross-cutting regression scenario from the plan's
+ * Verification section (both Wave 1 and Wave 2 require coverage).
+ *
+ * Split out of skill-installation.service.test.ts (CLAUDE.md's 500-line
+ * file cap) rather than left inline -- this scenario is also cohesive
+ * enough to stand alone.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import * as os from 'os'
+import { SkillInstallationService } from '../../../src/services/skill-installation.service.js'
+import { SkillRepository } from '../../../src/repositories/SkillRepository.js'
+import { SkillDependencyRepository } from '../../../src/repositories/SkillDependencyRepository.js'
+import { createTestDatabase } from '../../helpers/database.js'
+import type { Database } from '../../../src/db/database-interface.js'
+
+const VALID_SKILL_MD = `---
+name: test-skill
+description: A test skill for unit testing
+---
+
+# Test Skill
+
+This is a valid skill file with enough content to pass the 100-character minimum
+validation threshold that the service checks during installation.
+
+## Usage
+
+Use this skill by saying "Use the test-skill skill to..."
+`
+
+let tmpDir: string
+let skillsDir: string
+let manifestPath: string
+
+async function createTmpDirs(): Promise<void> {
+  tmpDir = path.join(
+    os.tmpdir(),
+    'skillsmith-test-' + Date.now() + '-' + Math.random().toString(36).slice(2)
+  )
+  skillsDir = path.join(tmpDir, 'skills')
+  manifestPath = path.join(tmpDir, 'manifest.json')
+  await fs.mkdir(skillsDir, { recursive: true })
+}
+
+async function cleanupTmpDirs(): Promise<void> {
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+}
+
+function createService(
+  db: Database,
+  overrides: Partial<ConstructorParameters<typeof SkillInstallationService>[0]> = {}
+): SkillInstallationService {
+  const skillRepo = new SkillRepository(db)
+  const skillDependencyRepo = new SkillDependencyRepository(db)
+
+  return new SkillInstallationService({
+    db,
+    skillRepo,
+    skillDependencyRepo,
+    skillsDir,
+    manifestPath,
+    ...overrides,
+  })
+}
+
+describe('SMI-5894 Wave 1 Step 3: multi-client manifest re-keying', () => {
+  let db: Database
+  let cursorSkillsDir: string
+
+  beforeEach(async () => {
+    db = await createTestDatabase()
+    await createTmpDirs()
+
+    vi.stubGlobal('fetch', vi.fn())
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockImplementation(async (url) => {
+      const urlStr = typeof url === 'string' ? url : url.toString()
+      if (urlStr.includes('SKILL.md')) {
+        return new Response(VALID_SKILL_MD, { status: 200 })
+      }
+      return new Response('Not found', { status: 404 })
+    })
+
+    cursorSkillsDir = path.join(tmpDir, 'cursor-skills')
+    await fs.mkdir(cursorSkillsDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    db.close()
+    await cleanupTmpDirs()
+    vi.restoreAllMocks()
+  })
+
+  it('installs the same skill name independently under two clients without collision', async () => {
+    const claudeService = createService(db, { client: 'claude-code' })
+    const cursorService = createService(db, { client: 'cursor', skillsDir: cursorSkillsDir })
+
+    const claudeResult = await claudeService.install('https://github.com/owner/test-repo', {
+      skipOptimize: true,
+    })
+    const cursorResult = await cursorService.install('https://github.com/owner/test-repo', {
+      skipOptimize: true,
+    })
+
+    expect(claudeResult.success).toBe(true)
+    expect(cursorResult.success).toBe(true)
+
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf-8'))
+    // Canonical client keeps the legacy bare-name key (backward compat).
+    expect(manifest.installedSkills['test-repo']).toBeDefined()
+    expect(manifest.installedSkills['test-repo'].installPath).toBe(
+      path.join(skillsDir, 'test-repo')
+    )
+    expect(manifest.installedSkills['test-repo'].client).toBe('claude-code')
+    // Non-canonical client gets a distinct composite key — does NOT
+    // overwrite the claude-code entry above.
+    expect(manifest.installedSkills['test-repo::cursor']).toBeDefined()
+    expect(manifest.installedSkills['test-repo::cursor'].installPath).toBe(
+      path.join(cursorSkillsDir, 'test-repo')
+    )
+    expect(manifest.installedSkills['test-repo::cursor'].client).toBe('cursor')
+
+    // Both physical directories exist independently.
+    await expect(fs.access(path.join(skillsDir, 'test-repo'))).resolves.toBeUndefined()
+    await expect(fs.access(path.join(cursorSkillsDir, 'test-repo'))).resolves.toBeUndefined()
+  })
+
+  it('uninstalling the Cursor copy leaves the Claude Code copy untouched (and vice versa)', async () => {
+    const claudeService = createService(db, { client: 'claude-code' })
+    const cursorService = createService(db, { client: 'cursor', skillsDir: cursorSkillsDir })
+
+    await claudeService.install('https://github.com/owner/test-repo', { skipOptimize: true })
+    await cursorService.install('https://github.com/owner/test-repo', { skipOptimize: true })
+
+    const uninstallResult = await cursorService.uninstall('test-repo')
+    expect(uninstallResult.success).toBe(true)
+
+    // Cursor copy removed from disk and the manifest...
+    await expect(fs.access(path.join(cursorSkillsDir, 'test-repo'))).rejects.toThrow()
+    const manifestAfterCursorRemove = JSON.parse(await fs.readFile(manifestPath, 'utf-8'))
+    expect(manifestAfterCursorRemove.installedSkills['test-repo::cursor']).toBeUndefined()
+
+    // ...but the Claude Code copy is untouched on disk and in the manifest.
+    await expect(fs.access(path.join(skillsDir, 'test-repo'))).resolves.toBeUndefined()
+    expect(manifestAfterCursorRemove.installedSkills['test-repo']).toBeDefined()
+  })
+})

--- a/packages/core/tests/unit/services/skill-installation.service.test.ts
+++ b/packages/core/tests/unit/services/skill-installation.service.test.ts
@@ -404,6 +404,10 @@ describe('SMI-3483: SkillInstallationService', () => {
     })
   })
 
+  // SMI-5894 Wave 1 Step 3's multi-client manifest re-keying suite now
+  // lives in skill-installation.service.multi-client.test.ts (split out
+  // to stay under CLAUDE.md's 500-line file cap).
+
   // ==========================================================================
   // Uninstall
   // ==========================================================================
@@ -438,138 +442,8 @@ describe('SMI-3483: SkillInstallationService', () => {
     })
   })
 
-  // ==========================================================================
-  // SMI-4795: errorCode taxonomy on install failures
-  //
-  // Each failing return path inside install() must populate `errorCode` with
-  // a code from InstallErrorCode. Telemetry (emitInstallEvent) reads this
-  // field; without it the install funnel cannot classify failures.
-  // ==========================================================================
-
-  describe('SMI-4795: install failures populate errorCode', () => {
-    beforeEach(() => {
-      vi.stubGlobal('fetch', vi.fn())
-    })
-
-    it('REGISTRY_LOOKUP_UNAVAILABLE when registry id supplied without lookup adapter', async () => {
-      const service = createService(db) // no registryLookup
-      const result = await service.install('author/some-skill')
-
-      expect(result.success).toBe(false)
-      expect(result.errorCode).toBe('REGISTRY_LOOKUP_UNAVAILABLE')
-    })
-
-    it('REGISTRY_SKILL_NOT_FOUND when registry returns null', async () => {
-      const service = createService(db, {
-        registryLookup: createMockRegistryLookup({}), // empty registry
-      })
-      const result = await service.install('author/missing-skill')
-
-      expect(result.success).toBe(false)
-      expect(result.errorCode).toBe('REGISTRY_SKILL_NOT_FOUND')
-    })
-
-    it('QUARANTINED when registry flags the skill', async () => {
-      const service = createService(db, {
-        registryLookup: createMockRegistryLookup({
-          'author/quarantined-skill': {
-            repoUrl: 'https://github.com/author/quarantined-skill',
-            name: 'quarantined-skill',
-            quarantined: true,
-            trustTier: 'community',
-          },
-        }),
-      })
-      const result = await service.install('author/quarantined-skill')
-
-      expect(result.success).toBe(false)
-      expect(result.errorCode).toBe('QUARANTINED')
-      expect(result.trustTier).toBe('community')
-    })
-
-    it('FETCH_FAILED when SKILL.md is unreachable', async () => {
-      const mockFetch = vi.mocked(fetch)
-      mockFetch.mockResolvedValue(new Response('Not found', { status: 404 }))
-
-      const service = createService(db)
-      const result = await service.install('https://github.com/owner/missing-repo')
-
-      expect(result.success).toBe(false)
-      expect(result.errorCode).toBe('FETCH_FAILED')
-    })
-
-    it('VALIDATION_FAILED when SKILL.md is malformed/short', async () => {
-      const mockFetch = vi.mocked(fetch)
-      mockFetch.mockImplementation(async (url) => {
-        const urlStr = typeof url === 'string' ? url : url.toString()
-        if (urlStr.includes('SKILL.md')) {
-          return new Response(SHORT_SKILL_MD, { status: 200 })
-        }
-        return new Response('Not found', { status: 404 })
-      })
-
-      const service = createService(db)
-      const result = await service.install('https://github.com/owner/short-repo')
-
-      expect(result.success).toBe(false)
-      expect(result.errorCode).toBe('VALIDATION_FAILED')
-    })
-
-    it('ALREADY_INSTALLED on repeat install without force', async () => {
-      const mockFetch = vi.mocked(fetch)
-      mockFetch.mockImplementation(async (url) => {
-        const urlStr = typeof url === 'string' ? url : url.toString()
-        if (urlStr.includes('SKILL.md')) {
-          return new Response(VALID_SKILL_MD, { status: 200 })
-        }
-        return new Response('Not found', { status: 404 })
-      })
-
-      const service = createService(db)
-      const first = await service.install('https://github.com/owner/dup-repo')
-      expect(first.success).toBe(true)
-
-      const second = await service.install('https://github.com/owner/dup-repo')
-      expect(second.success).toBe(false)
-      expect(second.errorCode).toBe('ALREADY_INSTALLED')
-    })
-
-    it('SKIP_SCAN_FORBIDDEN when skipScan requested on unknown tier', async () => {
-      const mockFetch = vi.mocked(fetch)
-      mockFetch.mockImplementation(async (url) => {
-        const urlStr = typeof url === 'string' ? url : url.toString()
-        if (urlStr.includes('SKILL.md')) {
-          return new Response(VALID_SKILL_MD, { status: 200 })
-        }
-        return new Response('Not found', { status: 404 })
-      })
-
-      // Direct GitHub URL → trust tier defaults to 'unknown', skipScan disallowed
-      const service = createService(db)
-      const result = await service.install('https://github.com/owner/skip-repo', {
-        skipScan: true,
-      })
-
-      expect(result.success).toBe(false)
-      expect(result.errorCode).toBe('SKIP_SCAN_FORBIDDEN')
-      expect(result.trustTier).toBe('unknown')
-    })
-
-    it('successful install does NOT carry errorCode', async () => {
-      const mockFetch = vi.mocked(fetch)
-      mockFetch.mockImplementation(async (url) => {
-        const urlStr = typeof url === 'string' ? url : url.toString()
-        if (urlStr.includes('SKILL.md')) {
-          return new Response(VALID_SKILL_MD, { status: 200 })
-        }
-        return new Response('Not found', { status: 404 })
-      })
-
-      const service = createService(db)
-      const result = await service.install('https://github.com/owner/ok-repo')
-
-      expect(result.success).toBe(true)
-      expect(result.errorCode).toBeUndefined()
-    })
-  })
+  // SMI-4795's errorCode-taxonomy suite now lives in
+  // skill-installation.service.error-codes.test.ts (split out to stay
+  // under CLAUDE.md's 500-line file cap once SMI-5894 Wave 1 added its
+  // own multi-client suite here).
 })

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -72,14 +72,17 @@ Restart Claude Code after editing settings.json.
       "command": "npx",
       "args": ["-y", "-p", "@skillsmith/mcp-server", "skillsmith-mcp"],
       "env": {
-        "SKILLSMITH_API_KEY": "sk_live_..."
+        "SKILLSMITH_API_KEY": "sk_live_...",
+        "SKILLSMITH_CLIENT": "cursor"
       }
     }
   }
 }
 ```
 
-Cursor 2.4+ required. Reload the window after saving.
+Cursor 2.4+ required. Reload the window after saving. `SKILLSMITH_CLIENT` routes installs to `~/.cursor/skills` instead of the default `~/.claude/skills`.
+
+**Recommended**: `npm install -g @skillsmith/mcp-server` first, then point `command` at the installed `skillsmith-mcp` binary — run `which skillsmith-mcp` after installing to get the exact path (it's platform/npm-prefix specific, e.g. `/opt/homebrew/bin/skillsmith-mcp` on macOS/Homebrew; Linux and Windows paths differ). The `npx` form above still works as a fallback, but re-resolves the package on every launch — expect a slower cold start, and watch for `EBADENGINE` (Cursor bundles its own Node, sometimes older than the `>=22.22` this package requires) or `ENOTEMPTY` errors on repeated installs.
 
 </details>
 

--- a/packages/mcp-server/src/tools/install.helpers.tips.test.ts
+++ b/packages/mcp-server/src/tools/install.helpers.tips.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Tests for `generateTips`/`generateOptimizedTips` in
+ *   install.helpers.ts — SMI-5894 Wave 1 Step 5.
+ *
+ * Both functions previously hardcoded "Claude Code" / `~/.claude/skills/`
+ * regardless of the actual install target. Note: as of this fix, neither
+ * function has a live caller in this package (the real MCP install flow's
+ * tips come from the shared `@skillsmith/core` `generateTips`, which
+ * received the equivalent fix) — these tests exist so the fix here can't
+ * silently regress if either function is ever wired back up.
+ */
+import { describe, expect, it } from 'vitest'
+import { generateTips, generateOptimizedTips } from './install.helpers.js'
+
+describe('generateTips (SMI-5894 Wave 1 Step 5)', () => {
+  it('defaults to Claude Code wording when client/skillsDir are omitted (backward compatible)', () => {
+    const tips = generateTips('my-skill')
+    const joined = tips.join('\n')
+    expect(joined).toContain('mention it in Claude Code')
+    expect(joined).toContain('ls ~/.claude/skills/')
+  })
+
+  it('names the actual client and install path when a non-canonical client is resolved', () => {
+    const tips = generateTips('my-skill', 'cursor', '/home/user/.cursor/skills')
+    const joined = tips.join('\n')
+    expect(joined).toContain('mention it in Cursor')
+    expect(joined).toContain('ls /home/user/.cursor/skills/')
+    expect(joined).not.toContain('Claude Code')
+  })
+})
+
+describe('generateOptimizedTips (SMI-5894 Wave 1 Step 5)', () => {
+  const optimizationInfo = { optimized: false }
+
+  it('defaults to Claude Code wording when client/skillsDir are omitted (backward compatible)', () => {
+    const tips = generateOptimizedTips('my-skill', optimizationInfo)
+    const joined = tips.join('\n')
+    expect(joined).toContain('mention it in Claude Code')
+    expect(joined).toContain('ls ~/.claude/skills/')
+  })
+
+  it('names the actual client and install path when a non-canonical client is resolved', () => {
+    const tips = generateOptimizedTips(
+      'my-skill',
+      optimizationInfo,
+      undefined,
+      'cursor',
+      '/home/user/.cursor/skills'
+    )
+    const joined = tips.join('\n')
+    expect(joined).toContain('mention it in Cursor')
+    expect(joined).toContain('ls /home/user/.cursor/skills/')
+    expect(joined).not.toContain('Claude Code')
+  })
+
+  it('still renders the CLAUDE.md snippet section regardless of client', () => {
+    const tips = generateOptimizedTips(
+      'my-skill',
+      {
+        optimized: true,
+        subagentGenerated: true,
+        subagentPath: '/home/user/.claude/agents/my-skill.md',
+      },
+      '# CLAUDE.md snippet\nUse the my-skill subagent.',
+      'cursor'
+    )
+    const joined = tips.join('\n')
+    expect(joined).toContain('Add this to your CLAUDE.md for automatic delegation')
+    expect(joined).toContain('mention it in Cursor')
+  })
+})

--- a/packages/mcp-server/src/tools/install.helpers.ts
+++ b/packages/mcp-server/src/tools/install.helpers.ts
@@ -8,6 +8,7 @@ import * as path from 'path'
 import type { ToolContext } from '../context.js'
 // SMI-2171: Import parseRepoUrl from @skillsmith/core for shared use
 import { parseRepoUrl, QuarantineRepository, type ParsedRepoUrl } from '@skillsmith/core'
+import { CANONICAL_CLIENT, CLIENT_DISPLAY_LABELS, type ClientId } from '@skillsmith/core/install'
 import {
   MANIFEST_PATH,
   SKILLSMITH_DIR,
@@ -358,12 +359,27 @@ export function validateSkillMd(content: string): SkillMdValidation {
 
 /**
  * Generate post-install tips
+ *
+ * SMI-5894 (Wave 1 Step 5): `client`/`skillsDir` default to the canonical
+ * (Claude Code) client so any caller that doesn't pass them keeps seeing
+ * exactly the previous "Claude Code" / `~/.claude/skills/` wording. Note:
+ * as of this fix this function has no remaining callers in this package —
+ * the actual MCP install flow's tips come from the shared
+ * `@skillsmith/core` `generateTips()` (via `SkillInstallationService`),
+ * which received the equivalent fix. This one is fixed too so it can't
+ * reintroduce the same hardcoded-client bug if it's ever wired back up.
  */
-export function generateTips(skillName: string): string[] {
+export function generateTips(
+  skillName: string,
+  client: ClientId = CANONICAL_CLIENT,
+  skillsDir?: string
+): string[] {
+  const clientLabel = CLIENT_DISPLAY_LABELS[client]
+  const dir = skillsDir ?? '~/.claude/skills'
   return [
     'Skill "' + skillName + '" installed successfully!',
-    'To use this skill, mention it in Claude Code: "Use the ' + skillName + ' skill to..."',
-    'View installed skills: ls ~/.claude/skills/',
+    'To use this skill, mention it in ' + clientLabel + ': "Use the ' + skillName + ' skill to..."',
+    'View installed skills: ls ' + dir + '/',
     'To uninstall: use the uninstall_skill tool',
   ]
 }
@@ -384,16 +400,26 @@ export interface OptimizationInfoForTips {
 
 /**
  * SMI-1788: Generate post-install tips with optimization info
+ *
+ * SMI-5894 (Wave 1 Step 5): `client`/`skillsDir` (both optional, added after
+ * `claudeMdSnippet` to preserve the existing positional signature) default
+ * to the canonical client, same rationale as `generateTips` above — this
+ * function currently has no live caller either; see that function's
+ * docstring for the full explanation.
  */
 export function generateOptimizedTips(
   skillName: string,
   optimizationInfo: OptimizationInfoForTips,
-  claudeMdSnippet?: string
+  claudeMdSnippet?: string,
+  client: ClientId = CANONICAL_CLIENT,
+  skillsDir?: string
 ): string[] {
+  const clientLabel = CLIENT_DISPLAY_LABELS[client]
+  const dir = skillsDir ?? '~/.claude/skills'
   const tips = [
     'Skill "' + skillName + '" installed successfully!',
-    'To use this skill, mention it in Claude Code: "Use the ' + skillName + ' skill to..."',
-    'View installed skills: ls ~/.claude/skills/',
+    'To use this skill, mention it in ' + clientLabel + ': "Use the ' + skillName + ' skill to..."',
+    'View installed skills: ls ' + dir + '/',
   ]
 
   if (optimizationInfo.optimized) {

--- a/packages/mcp-server/src/tools/install.ts
+++ b/packages/mcp-server/src/tools/install.ts
@@ -21,7 +21,7 @@ import {
   type RegistrySkillInfo,
 } from '@skillsmith/core'
 import { withTelemetry } from '@skillsmith/core/telemetry'
-import { addLink, getInstallPath, resolveClientPath } from '@skillsmith/core/install'
+import { addLink, getInstallPath, resolveClientId } from '@skillsmith/core/install'
 import { resolveAuditMode, isAuditMode, type Tier } from '@skillsmith/core/config/audit-mode'
 import type { ToolContext } from '../context.js'
 import { getToolContext } from '../context.js'
@@ -164,11 +164,16 @@ async function installSkillImpl(input: unknown, _context?: ToolContext): Promise
 
   const context = _context ?? getToolContext()
 
-  // SMI-4578: resolve target install directory. Explicit `client` arg
-  // wins; otherwise fall back to SKILLSMITH_CLIENT env (or claude-code).
-  const effectiveSkillsDir = validInput.client
-    ? getInstallPath(validInput.client)
-    : resolveClientPath()
+  // SMI-4578: resolve target client + install directory together. Explicit
+  // `client` arg wins; otherwise fall back to SKILLSMITH_CLIENT env (or
+  // claude-code). SMI-5894 review: previously only the directory was
+  // resolved here and `client` was never passed to SkillInstallationService,
+  // so a non-canonical MCP install (e.g. Cursor) landed in the right
+  // directory but was keyed in the manifest as if it were canonical --
+  // colliding with a real canonical install of the same skill name and
+  // invisible to `name::cursor`-scoped removal.
+  const effectiveClient = resolveClientId(validInput.client)
+  const effectiveSkillsDir = getInstallPath(effectiveClient)
 
   // SMI-3483: Create core service instance with MCP context wiring
   // SMI-3873: aiDefenceFeedback omitted -- MCP server cannot call Ruflo tools.
@@ -180,6 +185,7 @@ async function installSkillImpl(input: unknown, _context?: ToolContext): Promise
     coInstallRecorder: context.coInstallRepository,
     sessionInstalledSkillIds: context.sessionInstalledSkillIds,
     skillsDir: effectiveSkillsDir,
+    client: effectiveClient,
   })
 
   // SMI-1867: Pre-flight conflict check for reinstall with force

--- a/packages/website/src/lib/mcp-client-snippets.parity.test.ts
+++ b/packages/website/src/lib/mcp-client-snippets.parity.test.ts
@@ -134,9 +134,15 @@ describe('MCP_CLIENT_SNIPPETS — parity with CLI CLIENT_SNIPPETS (SMI-5554)', (
           })
         } else {
           const mcpServers = parsed.mcpServers as Record<string, { env?: Record<string, string> }>
-          expect(mcpServers['@skillsmith/mcp-server'].env).toEqual({
-            SKILLSMITH_API_KEY: expectedValue,
-          })
+          // SMI-5894 Wave 1 Step 7: cursor's body already carries
+          // SKILLSMITH_CLIENT before withApiKey() runs — the merged env
+          // block keeps that key alongside the injected API key, unlike
+          // every other JSON client whose env block starts empty.
+          const expectedEnv =
+            snippet.id === 'cursor'
+              ? { SKILLSMITH_CLIENT: 'cursor', SKILLSMITH_API_KEY: expectedValue }
+              : { SKILLSMITH_API_KEY: expectedValue }
+          expect(mcpServers['@skillsmith/mcp-server'].env).toEqual(expectedEnv)
         }
       } else if (snippet.format === 'toml') {
         expect(withKey).toContain(`SKILLSMITH_API_KEY = "${expectedValue}"`)
@@ -144,5 +150,19 @@ describe('MCP_CLIENT_SNIPPETS — parity with CLI CLIENT_SNIPPETS (SMI-5554)', (
         expect(withKey).toContain(`SKILLSMITH_API_KEY: "${expectedValue}"`)
       }
     }
+  })
+
+  // SMI-5894 Wave 1 Step 7: without SKILLSMITH_CLIENT, a Cursor user who
+  // copies the MCP snippet gets Claude Code's default install path
+  // (~/.claude/skills) instead of ~/.cursor/skills.
+  it('cursor snippet includes SKILLSMITH_CLIENT="cursor" even before an API key is added', () => {
+    const cursor = MCP_CLIENT_SNIPPETS.find((s) => s.id === 'cursor')
+    expect(cursor).toBeDefined()
+    const parsed = JSON.parse(cursor!.body) as {
+      mcpServers: Record<string, { env?: Record<string, string> }>
+    }
+    expect(parsed.mcpServers['@skillsmith/mcp-server'].env).toEqual({
+      SKILLSMITH_CLIENT: 'cursor',
+    })
   })
 })

--- a/packages/website/src/lib/mcp-client-snippets.ts
+++ b/packages/website/src/lib/mcp-client-snippets.ts
@@ -64,6 +64,25 @@ const STANDARD_JSON_BODY = `{
   }
 }`
 
+// SMI-5894 Wave 1 Step 7: Cursor is the one "standard" JSON client that
+// does NOT reuse STANDARD_JSON_BODY — it needs SKILLSMITH_CLIENT in its own
+// env block so installs route to ~/.cursor/skills instead of the default
+// ~/.claude/skills. withApiKeyJson() below special-cases this body (like
+// the OpenCode branch) to merge SKILLSMITH_API_KEY into the EXISTING env
+// block rather than creating a new one via the generic STANDARD_ARGS_LINE
+// path, which assumes no env block is present yet.
+const CURSOR_JSON_BODY = `{
+  "mcpServers": {
+    "@skillsmith/mcp-server": {
+      "command": "npx",
+      "args": ["-y", "@skillsmith/mcp-server"],
+      "env": {
+        "SKILLSMITH_CLIENT": "cursor"
+      }
+    }
+  }
+}`
+
 /** Per-client snippet matrix, in SNIPPET_DISPLAY_ORDER. */
 export const MCP_CLIENT_SNIPPETS: ReadonlyArray<McpClientSnippet> = [
   {
@@ -79,8 +98,9 @@ export const MCP_CLIENT_SNIPPETS: ReadonlyArray<McpClientSnippet> = [
     label: 'Cursor',
     configPath: '~/.cursor/mcp.json',
     format: 'json',
-    body: STANDARD_JSON_BODY,
-    notes: 'Cursor 2.4+ required. Reload the window after saving.',
+    body: CURSOR_JSON_BODY,
+    notes:
+      'Cursor 2.4+ required. Reload the window after saving. <code>SKILLSMITH_CLIENT</code> routes installs to <code>~/.cursor/skills</code> instead of the default <code>~/.claude/skills</code>. Recommended: <code>npm install -g @skillsmith/mcp-server</code> first, then point <code>command</code> at the installed <code>skillsmith-mcp</code> binary (run <code>which skillsmith-mcp</code> to get the exact path — it is platform/npm-prefix specific, e.g. <code>/opt/homebrew/bin/skillsmith-mcp</code> on macOS/Homebrew; Linux and Windows paths differ). The <code>npx</code> form above still works as a fallback, but re-resolves the package on every launch and may hit <code>EBADENGINE</code> (Cursor bundles its own Node, sometimes older than the <code>&gt;=22.22</code> this package requires) or <code>ENOTEMPTY</code> on repeated installs.',
   },
   {
     id: 'copilot',
@@ -164,6 +184,11 @@ args = ["-y", "@skillsmith/mcp-server"]`,
 
 const STANDARD_ARGS_LINE = /(\n {6}"args": \[[^\n]*\])\n( {4}\}\n)/
 const OPENCODE_ENABLED_LINE = /(\n {6}"enabled": true)\n( {4}\}\n)/
+// SMI-5894 Wave 1 Step 7: cursor's body already has an "env" block
+// (SKILLSMITH_CLIENT) before withApiKey() runs — matches the
+// "SKILLSMITH_CLIENT" line so SKILLSMITH_API_KEY is merged INTO that block
+// instead of STANDARD_ARGS_LINE trying (and failing) to insert a second one.
+const CURSOR_ENV_LINE = /(\n {8}"SKILLSMITH_CLIENT": "cursor")\n( {6}\}\n)/
 
 function withApiKeyJson(body: string, id?: McpClientId): string {
   // OpenCode's shape is keyed differently (`mcp` + `environment`, not
@@ -173,6 +198,15 @@ function withApiKeyJson(body: string, id?: McpClientId): string {
     return body.replace(
       OPENCODE_ENABLED_LINE,
       '$1,\n      "environment": {\n        "SKILLSMITH_API_KEY": "sk_live_your_key_here"\n      }\n$2'
+    )
+  }
+  // Cursor already has an "env" block (SKILLSMITH_CLIENT) — merge the API
+  // key into it rather than inserting a second "env" block via the generic
+  // STANDARD_ARGS_LINE branch below, which assumes none exists yet.
+  if (id === 'cursor') {
+    return body.replace(
+      CURSOR_ENV_LINE,
+      '$1,\n        "SKILLSMITH_API_KEY": "sk_live_your_key_here"\n$2'
     )
   }
   // Windsurf documents `${env:VAR}` interpolation, so its example shows the

--- a/packages/website/src/pages/docs/quickstart.astro
+++ b/packages/website/src/pages/docs/quickstart.astro
@@ -23,7 +23,7 @@ import { MCP_CLIENT_SNIPPETS } from '../../lib/mcp-client-snippets';
         "tool": [
           {
             "@type": "HowToTool",
-            "name": "Node.js 18+"
+            "name": "Node.js >=22.22"
           },
           {
             "@type": "HowToTool",
@@ -63,7 +63,7 @@ import { MCP_CLIENT_SNIPPETS } from '../../lib/mcp-client-snippets';
         "tool": [
           {
             "@type": "HowToTool",
-            "name": "Node.js 18+"
+            "name": "Node.js >=22.22"
           },
           {
             "@type": "HowToTool",
@@ -150,7 +150,7 @@ import { MCP_CLIENT_SNIPPETS } from '../../lib/mcp-client-snippets';
         <svg class="quickstart-check-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
         </svg>
-        <span><strong>Node.js 18+</strong> installed (<code>node --version</code> to check)</span>
+        <span><strong>Node.js >=22.22</strong> installed (<code>node --version</code> to check)</span>
       </li>
       <li class="quickstart-check-item">
         <svg class="quickstart-check-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Business Summary

**What shipped:**
- `skillsmith install` now honors `SKILLSMITH_CLIENT` when `--client` is omitted — previously the flag's own default silently overrode the environment variable.
- `list`, `remove`, `update`, and `sync status` all gained `--client` targeting; before this, `remove`/`update` always acted on the Claude Code directory regardless of the flag or env var.
- Fixed a real bug: `remove`'s confirmation prompt and its actual removal previously could target different clients (prompt scanned all clients, removal was hardcoded to Claude Code).
- Installing the same skill name independently under two clients (e.g. Claude Code and Cursor) no longer collides in the manifest — each client now gets its own tracked entry, so `remove`/`update --client` can safely target just one.
- Post-install guidance text and all four copies of the Cursor MCP setup snippet (README, mcp-server README, website) now name the real client/path instead of hardcoding Claude Code, and the Node version requirement is corrected to match `engines.node` (was stated as 18+/20+ in two places, actually >=22.22 — the likely cause of the original EBADENGINE report).

**Quality bar:** Implementation + full quality gates (typecheck, lint, audit:standards, build, full test suites) green. Reviewed twice post-implementation: a GPT-5.6-Sol second opinion (cross-provider, via NEEDLE) and a manual adversarial follow-up after Opus hit repeated API overload. Both passes found real issues, both fixed in this same PR:
- MCP's `install_skill` tool resolved the correct target directory but never passed the resolved client into the shared install service, so an MCP-driven Cursor install would still collide with a Claude Code install of the same name — this would have widened, not closed, the CLI/MCP parity gap this wave is about.
- `remove`'s cross-client link cleanup had no awareness of which install triggered a given `--client` removal, so removing an independently-installed non-canonical copy could delete an unrelated canonical install's link to a third client. Added a dedicated regression test for this exact scenario.

**Found along the way:** MCP's `uninstall_skill` has the same class of gap on the removal side (always operates on the canonical directory, and leaks an internal composite storage key when listing) — filed separately as SMI-5903 rather than folded in here, since it's a pre-existing gap this PR doesn't touch or worsen, and the right fix needs a real decision on data shape, not a mechanical patch.

**Net result:** Fully shipped for Wave 1's scope (GH #2131, #2132). SMI-5903 tracks a related follow-up on the MCP uninstall path, not blocking.

---

## Technical detail

23 files, ~1263 insertions / 238 deletions. Core: `manifestKeyFor(name, client)` in `skill-installation.helpers.ts` — canonical client keeps the legacy bare-name key for backward compat with existing manifests, non-canonical clients get a `name::client` composite key. `SkillInstallationService` now stores/threads a resolved `client`. CLI: `install.ts`, `manage.ts`/`manage.action.ts`/`manage.update.ts`, `sync.ts`/`sync.helpers.ts`/`sync.action.ts`, `skills-directory.ts` (new `getInstalledSkillsForClient`). MCP: `install.ts` now threads `client` into the service constructor. Split `skill-installation.service.test.ts` into three files (original + `.multi-client.test.ts` + `.error-codes.test.ts`) to stay under the 500-line file cap after this wave's additions.

Linear: SMI-5894 (this issue). Closes GH #2131, GH #2132.