### PR TITLE
fix(website): SMI-5902 remaining pre-existing ESLint debt

### DIFF
--- a/packages/website/src/components/CookieConsent.astro
+++ b/packages/website/src/components/CookieConsent.astro
@@ -111,10 +111,10 @@
 
 <script is:inline>
   ;(function () {
-    var consent = localStorage.getItem('skillsmith_cookie_consent')
+    const consent = localStorage.getItem('skillsmith_cookie_consent')
     if (consent) return // Already made a choice
 
-    var banner = document.getElementById('cookie-consent')
+    const banner = document.getElementById('cookie-consent')
     if (!banner) return
     banner.hidden = false
 

--- a/packages/website/src/components/CopyableCodeBlock.astro
+++ b/packages/website/src/components/CopyableCodeBlock.astro
@@ -71,8 +71,8 @@ const uniqueId = `code-block-${Math.random().toString(36).substring(7)}`
         button.classList.add('bg-[#81B29A]')
 
         // Track in GA if available
-        if (typeof (window as any).gtag === 'function') {
-          ;(window as any).gtag('event', 'copy_config', {
+        if (typeof window.gtag === 'function') {
+          window.gtag('event', 'copy_config', {
             event_category: 'engagement',
             event_label: 'mcp_install_snippet',
           })

--- a/packages/website/src/env.d.ts
+++ b/packages/website/src/env.d.ts
@@ -28,6 +28,8 @@ declare global {
     __AUTH_REDIRECT_TO__?: string
     /** Google Analytics gtag function (injected by GA script in BaseLayout) */
     gtag?: (...args: unknown[]) => void
+    /** SMI-3909: tier pricing lookup injected server-side for client-side plan display. */
+    __TIER_LOOKUP__?: Record<string, { name: string; price: string; apiCalls: string }>
     /** SMI-4895/4896: device-login state — on window so it survives hard navigations. */
     __deviceInited?: boolean
     __deviceState?: 'input' | 'preview' | 'approved' | 'expired' | 'denied'

--- a/packages/website/src/layouts/BaseLayout.astro
+++ b/packages/website/src/layouts/BaseLayout.astro
@@ -79,10 +79,11 @@ const supabaseConfig = getSupabaseConfig()
     <script is:inline>
       window.dataLayer = window.dataLayer || []
       function gtag() {
+        // eslint-disable-next-line prefer-rest-params -- Google's official gtag.js/GTM Consent Mode snippet, copied verbatim; do not modify (SMI-5902)
         dataLayer.push(arguments)
       }
       // Set default consent state BEFORE loading gtag.js
-      var consent = localStorage.getItem('skillsmith_cookie_consent')
+      const consent = localStorage.getItem('skillsmith_cookie_consent')
       gtag('consent', 'default', {
         analytics_storage: consent === 'accepted' ? 'granted' : 'denied',
         ad_storage: 'denied',
@@ -94,7 +95,7 @@ const supabaseConfig = getSupabaseConfig()
       gtag('config', 'G-GGZQZM1Y1L')
       // Defer the 149KB gtag.js network fetch until idle — removes it from the critical path
       function loadGtag() {
-        var s = document.createElement('script')
+        const s = document.createElement('script')
         s.async = true
         s.src = 'https://www.googletagmanager.com/gtag/js?id=G-GGZQZM1Y1L'
         document.head.appendChild(s)

--- a/packages/website/src/lib/skills-utils.test.ts
+++ b/packages/website/src/lib/skills-utils.test.ts
@@ -46,8 +46,8 @@ describe('formatNumber', () => {
   it('formats numbers with locale grouping', () => {
     // Asserts grouping happens without pinning a locale-specific separator.
     expect(formatNumber(0)).toBe('0')
-    expect(formatNumber(1234).replace(/[,.\s ]/g, '')).toBe('1234')
-    expect(formatNumber(10000).replace(/[,.\s ]/g, '')).toBe('10000')
+    expect(formatNumber(1234).replace(/[,.\s]/g, '')).toBe('1234')
+    expect(formatNumber(10000).replace(/[,.\s]/g, '')).toBe('10000')
   })
 })
 

--- a/packages/website/src/pages/account/subscription.astro
+++ b/packages/website/src/pages/account/subscription.astro
@@ -830,7 +830,7 @@ const tierLookup = Object.fromEntries(
       ) as HTMLElement
 
       // Tier data injected from canonical pricing source (SMI-3909)
-      const tl = (window as any).__TIER_LOOKUP__ || {}
+      const tl = window.__TIER_LOOKUP__ || {}
       const tierInfo = tl[tier] || {
         name: 'Community Plan',
         price: 'Free',

--- a/packages/website/src/pages/device.astro
+++ b/packages/website/src/pages/device.astro
@@ -322,7 +322,7 @@ const rawCode = Astro.url.searchParams.get('user_code')?.trim().toUpperCase() ??
 
       codeInput?.addEventListener('paste', (e: ClipboardEvent) => {
         e.preventDefault()
-        const pasted = (e.clipboardData?.getData('text') ?? '').replace(/[\s\-]/g, '')
+        const pasted = (e.clipboardData?.getData('text') ?? '').replace(/[\s-]/g, '')
         if (codeInput) {
           codeInput.value = ''
           codeInput.value = formatCode(pasted)

--- a/packages/website/src/pages/docs/quickstart.astro
+++ b/packages/website/src/pages/docs/quickstart.astro
@@ -7,128 +7,130 @@
  */
 import DocsLayout from '../../layouts/DocsLayout.astro';
 import { MCP_CLIENT_SNIPPETS } from '../../lib/mcp-client-snippets';
+
+const howToSchema = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'HowTo',
+      name: 'How to Set Up Skillsmith with an MCP Client',
+      description:
+        'Install Skillsmith MCP server to discover and install skills using natural language',
+      totalTime: 'PT5M',
+      tool: [
+        {
+          '@type': 'HowToTool',
+          name: 'Node.js >=22.22',
+        },
+        {
+          '@type': 'HowToTool',
+          name: 'npm',
+        },
+        {
+          '@type': 'HowToTool',
+          name: 'MCP-compatible AI assistant',
+        },
+      ],
+      step: [
+        {
+          '@type': 'HowToStep',
+          position: 1,
+          name: 'Open Your Project, Then Open Your AI Agent',
+          text: 'Navigate to your project directory, then open your AI coding agent (Claude Code, Cursor, GitHub Copilot, Windsurf, Codex CLI, or another MCP client) from inside it.',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 2,
+          name: 'Add the Skillsmith MCP Server',
+          text: "Add the Skillsmith MCP server using Claude Code's built-in 'claude mcp add' command, by asking your agent in chat, or by editing your MCP client's config file directly. Then restart your agent to load Skillsmith.",
+        },
+        {
+          '@type': 'HowToStep',
+          position: 3,
+          name: 'Discover Skills for Your Project',
+          text: "Ask your agent: 'What skills would be helpful for this project?'",
+        },
+      ],
+    },
+    {
+      '@type': 'HowTo',
+      name: 'How to Use Skillsmith CLI Directly',
+      description:
+        'Install and use the Skillsmith CLI for skill discovery and installation from any terminal',
+      totalTime: 'PT5M',
+      tool: [
+        {
+          '@type': 'HowToTool',
+          name: 'Node.js >=22.22',
+        },
+        {
+          '@type': 'HowToTool',
+          name: 'npm',
+        },
+      ],
+      step: [
+        {
+          '@type': 'HowToStep',
+          position: 1,
+          name: 'Install Skillsmith CLI',
+          text: 'Install globally: npm install -g @skillsmith/cli. Or use npx: npx @skillsmith/cli search testing',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 2,
+          name: 'Navigate to Project',
+          text: 'Open terminal and navigate to your project directory where package.json is located',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 3,
+          name: 'Search for Skills',
+          text: 'Search by keyword: skillsmith search testing. Or get recommendations: skillsmith recommend',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 4,
+          name: 'Install Skills',
+          text: 'Install a skill: skillsmith install jest-helper. Skills are installed to ~/.claude/skills/',
+        },
+      ],
+    },
+    {
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is the recommended way to use Skillsmith?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: "The recommended way is to use an MCP client with the Skillsmith MCP server. This allows you to discover and install skills using natural language, like asking 'Find skills for this React project' or 'Install the commit helper skill'.",
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Where are skills installed?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Skills are installed to ~/.claude/skills/ and are automatically available in all your sessions.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Can I use Skillsmith without an MCP client?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: "Yes, you can use the Skillsmith CLI directly in any terminal without an MCP client. Install with 'npm install -g @skillsmith/cli' or use npx without installing.",
+          },
+        },
+      ],
+    },
+  ],
+};
 ---
 
 <DocsLayout title="5-Minute Setup" description="Get started with Skillsmith in 5 minutes. Two ways to discover and install skills for your development environment.">
   <!-- JSON-LD HowTo Schema -->
-  <script is:inline type="application/ld+json" slot="head">
-  {
-    "@context": "https://schema.org",
-    "@graph": [
-      {
-        "@type": "HowTo",
-        "name": "How to Set Up Skillsmith with an MCP Client",
-        "description": "Install Skillsmith MCP server to discover and install skills using natural language",
-        "totalTime": "PT5M",
-        "tool": [
-          {
-            "@type": "HowToTool",
-            "name": "Node.js >=22.22"
-          },
-          {
-            "@type": "HowToTool",
-            "name": "npm"
-          },
-          {
-            "@type": "HowToTool",
-            "name": "MCP-compatible AI assistant"
-          }
-        ],
-        "step": [
-          {
-            "@type": "HowToStep",
-            "position": 1,
-            "name": "Open Your Project, Then Open Your AI Agent",
-            "text": "Navigate to your project directory, then open your AI coding agent (Claude Code, Cursor, GitHub Copilot, Windsurf, Codex CLI, or another MCP client) from inside it."
-          },
-          {
-            "@type": "HowToStep",
-            "position": 2,
-            "name": "Add the Skillsmith MCP Server",
-            "text": "Add the Skillsmith MCP server using Claude Code's built-in 'claude mcp add' command, by asking your agent in chat, or by editing your MCP client's config file directly. Then restart your agent to load Skillsmith."
-          },
-          {
-            "@type": "HowToStep",
-            "position": 3,
-            "name": "Discover Skills for Your Project",
-            "text": "Ask your agent: 'What skills would be helpful for this project?'"
-          }
-        ]
-      },
-      {
-        "@type": "HowTo",
-        "name": "How to Use Skillsmith CLI Directly",
-        "description": "Install and use the Skillsmith CLI for skill discovery and installation from any terminal",
-        "totalTime": "PT5M",
-        "tool": [
-          {
-            "@type": "HowToTool",
-            "name": "Node.js >=22.22"
-          },
-          {
-            "@type": "HowToTool",
-            "name": "npm"
-          }
-        ],
-        "step": [
-          {
-            "@type": "HowToStep",
-            "position": 1,
-            "name": "Install Skillsmith CLI",
-            "text": "Install globally: npm install -g @skillsmith/cli. Or use npx: npx @skillsmith/cli search testing"
-          },
-          {
-            "@type": "HowToStep",
-            "position": 2,
-            "name": "Navigate to Project",
-            "text": "Open terminal and navigate to your project directory where package.json is located"
-          },
-          {
-            "@type": "HowToStep",
-            "position": 3,
-            "name": "Search for Skills",
-            "text": "Search by keyword: skillsmith search testing. Or get recommendations: skillsmith recommend"
-          },
-          {
-            "@type": "HowToStep",
-            "position": 4,
-            "name": "Install Skills",
-            "text": "Install a skill: skillsmith install jest-helper. Skills are installed to ~/.claude/skills/"
-          }
-        ]
-      },
-      {
-        "@type": "FAQPage",
-        "mainEntity": [
-          {
-            "@type": "Question",
-            "name": "What is the recommended way to use Skillsmith?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "The recommended way is to use an MCP client with the Skillsmith MCP server. This allows you to discover and install skills using natural language, like asking 'Find skills for this React project' or 'Install the commit helper skill'."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "Where are skills installed?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Skills are installed to ~/.claude/skills/ and are automatically available in all your sessions."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "Can I use Skillsmith without an MCP client?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Yes, you can use the Skillsmith CLI directly in any terminal without an MCP client. Install with 'npm install -g @skillsmith/cli' or use npx without installing."
-            }
-          }
-        ]
-      }
-    ]
-  }
-  </script>
+  <script is:inline type="application/ld+json" slot="head" set:html={JSON.stringify(howToSchema)} />
 
   <h1>5-Minute Setup</h1>
 
@@ -150,7 +152,7 @@ import { MCP_CLIENT_SNIPPETS } from '../../lib/mcp-client-snippets';
         <svg class="quickstart-check-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
         </svg>
-        <span><strong>Node.js >=22.22</strong> installed (<code>node --version</code> to check)</span>
+        <span><strong>Node.js &gt;=22.22</strong> installed (<code>node --version</code> to check)</span>
       </li>
       <li class="quickstart-check-item">
         <svg class="quickstart-check-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/packages/website/src/pages/docs/trust-tiers.astro
+++ b/packages/website/src/pages/docs/trust-tiers.astro
@@ -161,7 +161,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
     <h3>Requirements</h3>
     <ul>
       <li>Published under a GitHub-verified organization, OR manually curated by Skillsmith editors</li>
-      <li>Quality score >= 0.80</li>
+      <li>Quality score &gt;= 0.80</li>
       <li>Has valid LICENSE file</li>
       <li>Complete README and SKILL.md</li>
     </ul>

--- a/packages/website/src/pages/index-v2.astro
+++ b/packages/website/src/pages/index-v2.astro
@@ -53,9 +53,10 @@ const supabaseConfig = getSupabaseConfig()
     <script is:inline>
       window.dataLayer = window.dataLayer || []
       function gtag() {
+        // eslint-disable-next-line prefer-rest-params -- Google's official gtag.js/GTM Consent Mode snippet, copied verbatim; do not modify (SMI-5902)
         dataLayer.push(arguments)
       }
-      var consent = localStorage.getItem('skillsmith_cookie_consent')
+      const consent = localStorage.getItem('skillsmith_cookie_consent')
       gtag('consent', 'default', {
         analytics_storage: consent === 'accepted' ? 'granted' : 'denied',
         ad_storage: 'denied',
@@ -299,15 +300,15 @@ const supabaseConfig = getSupabaseConfig()
     <!-- MCP config copy button -->
     <script is:inline>
       document.addEventListener('astro:page-load', function () {
-        var btn = document.getElementById('copy-mcp-config')
+        const btn = document.getElementById('copy-mcp-config')
         if (!btn) return
         btn.addEventListener('click', function () {
-          var code = document.getElementById('mcp-install-code')
+          const code = document.getElementById('mcp-install-code')
           if (!code) return
           navigator.clipboard.writeText(code.textContent || '').then(function () {
-            var copyIcon = document.getElementById('copy-icon')
-            var checkIcon = document.getElementById('check-icon')
-            var copyText = document.getElementById('copy-text')
+            const copyIcon = document.getElementById('copy-icon')
+            const checkIcon = document.getElementById('check-icon')
+            const copyText = document.getElementById('copy-text')
             if (copyIcon) copyIcon.classList.add('hidden')
             if (checkIcon) checkIcon.classList.remove('hidden')
             if (copyText) copyText.textContent = 'Copied!'
@@ -333,11 +334,11 @@ const supabaseConfig = getSupabaseConfig()
       }}
     >
       document.addEventListener('astro:page-load', function () {
-        var input = document.getElementById('v2-search-input')
-        var results = document.getElementById('v2-search-results')
+        const input = document.getElementById('v2-search-input')
+        const results = document.getElementById('v2-search-results')
         if (!input || !results) return
 
-        var debounceTimer = null
+        let debounceTimer = null
 
         // SMI-5217: 5-tier public vocabulary (ApiTrustTier). Colors come from the
         // shared trustTierPillClasses map (define:vars). The API never returns
@@ -348,21 +349,21 @@ const supabaseConfig = getSupabaseConfig()
         }
 
         function renderSkill(skill) {
-          var a = document.createElement('a')
+          const a = document.createElement('a')
           a.href = '/skills/' + encodeURIComponent(skill.id || '')
           a.className =
             'flex flex-col gap-1 p-4 rounded-xl border border-white/[0.06] hover:border-primary-400/40 bg-dark-900/40 hover:bg-dark-900 transition-all'
-          var top = document.createElement('div')
+          const top = document.createElement('div')
           top.className = 'flex items-center gap-2'
-          var name = document.createElement('span')
+          const name = document.createElement('span')
           name.className = 'font-semibold text-white text-sm truncate'
           name.textContent = skill.name || skill.id || ''
-          var badge = document.createElement('span')
+          const badge = document.createElement('span')
           badge.className = badgeClasses(skill.trust_tier)
           badge.textContent = skill.trust_tier || 'unverified'
           top.appendChild(name)
           top.appendChild(badge)
-          var desc = document.createElement('p')
+          const desc = document.createElement('p')
           desc.className = 'text-xs text-dark-400 line-clamp-2'
           desc.textContent = skill.description || ''
           a.appendChild(top)
@@ -381,7 +382,7 @@ const supabaseConfig = getSupabaseConfig()
             })
             .then(function (data) {
               results.innerHTML = ''
-              var skills = data.skills || []
+              const skills = data.skills || []
               if (skills.length === 0) {
                 results.innerHTML =
                   '<p class="text-dark-500 text-sm col-span-2 text-center pt-8">No results for &ldquo;' +


### PR DESCRIPTION
## Business Summary

**What shipped:** Closed out the remaining pre-existing ESLint debt in the website package — 10
files, 26 errors + 3 warnings down to zero. Three more files got the same Google-snippet-vs-glue
treatment as the earlier SMI-5899 fix; five files each got a one-off fix for an unrelated lint
rule; and one file's JSON-LD structured data block was rewritten to stop confusing the page
parser, which also uncovered and fixed a second, previously-hidden parsing bug on that same page.

**Quality bar:** Plan reviewed and the finished implementation independently cross-checked by
GPT-5.6-Sol (a different model family, via NEEDLE) both before and after coding, on top of my own
verification of every claim against the actual source. Final governance review: zero findings.
Lint, typecheck, Prettier, the standards audit, and the affected test suite all green.

**Found along the way:** `docs/quickstart.astro` wasn't in this issue's original file list —
it picked up the same class of parsing bug from an unrelated PR after the issue was filed.
Folded it into this PR rather than opening a new issue, since it's the identical root cause as
an already-scoped file, not new/separate debt. Separately, while waiting on this PR's CI, the
`Website Account E2E` check flaked 2 of 3 reruns on a pre-existing, unrelated mobile-WebKit
navigation timing test (`account-page-load-guards.spec.ts`) — filed as SMI-5906, not touched
here since it's unrelated to any file in this diff.

**Net result:** Fully shipped, no follow-up needed.

---

## Technical detail

Fixes SMI-5902 (Linear), the broader follow-up filed while executing SMI-5899 (merged, #2148).

**Same-pattern files (Google's verbatim Consent Mode v2 snippet vs. Skillsmith glue code) —**
`index-v2.astro`, `BaseLayout.astro`, `CookieConsent.astro`: `dataLayer.push(arguments)` stays
untouched behind a scoped `eslint-disable-next-line prefer-rest-params` comment; every other
`var` becomes `const`, except `index-v2.astro`'s `debounceTimer` (reassigned in the search-input
handler), which becomes `let`.

**Individually triaged, unrelated rule violations:**
- `skills-utils.test.ts` — removed a stray NBSP hiding inside a regex character class that
  already contained `\s` (which matches NBSP per spec) — same behavior, no lint violation.
- `device.astro` — dropped an unnecessary escape on a trailing hyphen in a character class.
- `CopyableCodeBlock.astro`, `subscription.astro` — removed `(window as any)` casts by relying
  on (and, for `__TIER_LOOKUP__`, adding) an ambient `Window` type in `env.d.ts`.
- `trust-tiers.astro` — HTML-entity-encoded a literal `>` in prose text that was breaking the
  Astro template parser.
- `quickstart.astro` — root-cause fix: replaced a 118-line hand-written literal JSON
  `<script type="application/ld+json">` block with a frontmatter object serialized via
  `set:html={JSON.stringify(...)}`, matching the pattern already used by `index.astro` and
  `faq.astro` (this page was the lone holdout still using the raw-literal anti-pattern). Verified
  the rendered output is semantically identical JSON by parsing the built `dist/` output. Fixing
  this surfaced a second, previously-masked parsing error in visible prose (`Node.js >=22.22`
  inside a `<strong>` tag) — fixed the same way as `trust-tiers.astro`.

**Verification:** `npm run lint`, `astro check`, `prettier --check`, `npm run audit:standards`,
and the touched vitest suite (`skills-utils.test.ts`, 16/16) all run clean in the worktree
container before commit.

Refs SMI-5902
