### PR TITLE
feat(indexer): SMI-5879 Wave 1 — gate infrastructure (Gates A-E)

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -51,6 +51,21 @@ jobs:
       mode: ${{ steps.detect.outputs.mode }}
       functions: ${{ steps.detect.outputs.functions }}
     steps:
+      - name: Deploy-freeze gate (E)
+        # SMI-5879: shares ONE variable with Gate D (indexer.yml) so a single operator
+        # action arms both -- the deployed revision D and the writer SHA S cannot
+        # desynchronize. Non-empty pin => the ONLY source that may reach prod is that
+        # exact commit. Blocks a workflow_dispatch from ANY ref (including a feature
+        # branch with deploy_all:true, which would otherwise take the mode=all arm
+        # below and push 31 functions from an unrelated tree). Inert when empty =
+        # steady state.
+        if: vars.INDEXER_RUN_PINNED_SHA != ''
+        run: |
+          if [ "${{ github.sha }}" != "${{ vars.INDEXER_RUN_PINNED_SHA }}" ]; then
+            echo "::error::SMI-5879 deploy freeze: source SHA ${{ github.sha }} != pinned ${{ vars.INDEXER_RUN_PINNED_SHA }}. Edge deploys are frozen for the change window. If this is the PR's own merge-triggered run, this red run is EXPECTED -- see the runbook; re-point the pin to the squash SHA and re-dispatch with deploy_all=true."
+            exit 1
+          fi
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2 # Need parent commit for diff (assumes squash-merge)

--- a/.github/workflows/indexer-backfill.yml
+++ b/.github/workflows/indexer-backfill.yml
@@ -238,8 +238,14 @@ jobs:
           # RUN_TYPE always discovery for backfill (no maintenance or recheck).
           RUN_TYPE: 'discovery'
           # STALE_DAYS not set -- backfill mode bypasses the freshness window entirely.
-          # CONCURRENCY_KILL_SWITCH honored via EFFECTIVE_KILL_SWITCH at job level;
-          # indexer run.ts also checks this env var for in-run abort.
+          # CONCURRENCY_KILL_SWITCH honored via EFFECTIVE_KILL_SWITCH at job level.
+          # SMI-5879 (8.3.2.1): CORRECTED -- this comment previously claimed
+          # "indexer run.ts also checks this env var for in-run abort," which is
+          # false. parse-env.ts's `kill_switch_engaged` is CONCURRENCY_KILL_SWITCH's
+          # ONLY consumer, and it only forces concurrency=1 -- there is no abort
+          # path in run.ts. What actually aborts THIS workflow before any work is
+          # the "Kill-switch gate" step above (checks EFFECTIVE_KILL_SWITCH itself,
+          # sourced from BACKFILL_KILL_SWITCH / the kill_switch input).
           CONCURRENCY_KILL_SWITCH: ${{ env.EFFECTIVE_KILL_SWITCH }}
         run: |
           set -eo pipefail

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -116,6 +116,34 @@ jobs:
       CONCURRENCY_KILL_SWITCH: ${{ (vars.INDEXER_CONCURRENCY_KILL_SWITCH == '1' || github.event.inputs.concurrency_kill_switch == 'true') && '1' || '0' }}
 
     steps:
+      - name: Allow-list gate (A)
+        # SMI-5879: job-level freeze switch, checked before ANY secret is read
+        # or run-type derived. No dependency on run-type derivation, so a
+        # blanket freeze cannot be defeated by a malformed dispatch payload.
+        # Byte-for-byte the indexer-backfill.yml "Kill-switch gate" shape.
+        # Inert in steady state (unset/'all', the default).
+        env:
+          INDEXER_RUN_ALLOWLIST: ${{ vars.INDEXER_RUN_ALLOWLIST }}
+        run: |
+          if [ "$INDEXER_RUN_ALLOWLIST" = "none" ]; then
+            echo "::error::Indexer run-type allow-list is engaged (INDEXER_RUN_ALLOWLIST=none) -- all indexer run types are frozen. Aborting before any secret is read."
+            exit 1
+          fi
+          echo "Allow-list gate (A): INDEXER_RUN_ALLOWLIST=${INDEXER_RUN_ALLOWLIST:-<unset>} -- proceeding."
+
+      - name: Pinned-SHA gate (D)
+        # SMI-5879: during a change window the operator pins the exact commit every
+        # substrate-N-CI writer may execute. A merge landing mid-cycle changes the code
+        # the NEXT phase runs (checkout has no `ref:`, so it tracks main's HEAD) -- this
+        # fails that phase red instead of running unverified code against the quarantine
+        # gate. Inert when the variable is empty, which is the steady-state default.
+        if: vars.INDEXER_RUN_PINNED_SHA != ''
+        run: |
+          if [ "${{ github.sha }}" != "${{ vars.INDEXER_RUN_PINNED_SHA }}" ]; then
+            echo "::error::Run SHA ${{ github.sha }} != pinned ${{ vars.INDEXER_RUN_PINNED_SHA }} -- a merge landed since the last canary. Aborting; re-canary before lifting the pin."
+            exit 1
+          fi
+
       - name: Validate Secrets
         env:
           # Issue #17: select prod vs staging secret pair based on supabase_env input.
@@ -271,6 +299,48 @@ jobs:
           echo "discovery_phase=$DISCOVERY_PHASE" >> "$GITHUB_OUTPUT"
           echo "Run type: $RUN_TYPE, Stale days: $STALE_DAYS, Cron slot: ${CRON_SLOT:-<none>}, Discovery phase: ${DISCOVERY_PHASE:-<none>}"
 
+      - name: Allow-list gate (B)
+        # SMI-5879: second layer -- after run-type derivation, before Run indexer.
+        # Same vocabulary as assertRunAllowed (scripts/indexer/run-gate.ts):
+        # unset/'all' permits everything; 'none' refuses everything; a
+        # comma-separated subset permits only the listed run types; any other
+        # value refuses (fail closed -- a typo must never read as 'all').
+        env:
+          INDEXER_RUN_ALLOWLIST: ${{ vars.INDEXER_RUN_ALLOWLIST }}
+          RUN_TYPE: ${{ steps.config.outputs.run_type }}
+        run: |
+          ALLOWLIST=$(echo "${INDEXER_RUN_ALLOWLIST:-}" | tr '[:upper:]' '[:lower:]' | xargs)
+          if [ -z "$ALLOWLIST" ] || [ "$ALLOWLIST" = "all" ]; then
+            echo "Allow-list gate (B): no restriction (INDEXER_RUN_ALLOWLIST=${ALLOWLIST:-<unset>}) -- proceeding with run_type=$RUN_TYPE."
+            exit 0
+          fi
+          if [ "$ALLOWLIST" = "none" ]; then
+            echo "::error::Indexer run-type allow-list is engaged (INDEXER_RUN_ALLOWLIST=none) -- refusing run_type=$RUN_TYPE."
+            exit 1
+          fi
+          # Validate every comma-separated token is a recognised run type;
+          # an unrecognised token anywhere fails the WHOLE value closed.
+          IFS=',' read -ra TOKENS <<< "$ALLOWLIST"
+          PERMITTED=false
+          for TOKEN in "${TOKENS[@]}"; do
+            TOKEN=$(echo "$TOKEN" | xargs)
+            case "$TOKEN" in
+              discovery|maintenance|recheck|dequarantine|purge|revalidate) ;;
+              *)
+                echo "::error::INDEXER_RUN_ALLOWLIST=\"$ALLOWLIST\" contains an unrecognised value \"$TOKEN\" -- refusing run_type=$RUN_TYPE (fail closed)."
+                exit 1
+                ;;
+            esac
+            if [ "$TOKEN" = "$RUN_TYPE" ]; then
+              PERMITTED=true
+            fi
+          done
+          if [ "$PERMITTED" != "true" ]; then
+            echo "::error::INDEXER_RUN_ALLOWLIST=\"$ALLOWLIST\" does not permit run_type=$RUN_TYPE. Aborting."
+            exit 1
+          fi
+          echo "Allow-list gate (B): run_type=$RUN_TYPE permitted by INDEXER_RUN_ALLOWLIST=\"$ALLOWLIST\"."
+
       - name: Checkout
         # SHA-pinned per audit-workflow-sha-pin (Check 42 / SMI-4758). Tag = v6.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -314,6 +384,11 @@ jobs:
           RECHECK_MAX_CANDIDATES: ${{ vars.RECHECK_MAX_CANDIDATES || '2000' }}
           RECHECK_BATCH: ${{ vars.RECHECK_BATCH || '5' }}
           RECHECK_DRY_RUN: ${{ vars.RECHECK_DRY_RUN || 'true' }}
+          # SMI-5879: plumbs recheck.ts's own execution gate (recheck.ts:188,
+          # 212-234) into the workflow -- previously dead code from the repo-variable
+          # surface (no workflow ever set it). Defaults enabled; an explicit
+          # 'false'/'0' repo var skips the recheck writer's own fetch/write path.
+          RECHECK_ENABLED: ${{ vars.RECHECK_ENABLED || 'true' }}
           # SMI-5356: dequarantine-sweep dry-run gate, independent of the workflow
           # dry_run input (mirrors RECHECK_DRY_RUN). Defaults 'true' so a dispatch
           # is read-only unless the repo var is deliberately flipped to 'false' for

--- a/scripts/indexer/dequarantine-false-positives.ts
+++ b/scripts/indexer/dequarantine-false-positives.ts
@@ -27,6 +27,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createSupabaseAdminClient } from './_shared/supabase.ts'
+import { assertRunAllowed, assertFreezeMarkerClear } from './run-gate.ts'
 import { buildGitHubHeaders } from './_shared/github-auth.ts'
 import {
   scanSkillContent,
@@ -287,6 +288,12 @@ export async function runSweep(opts: { apply: boolean; limit?: number }): Promis
 
 /** CLI entrypoint (skipped when imported by tests). */
 async function main(): Promise<void> {
+  // SMI-5879 Gate C: env-sourced check first (no dependency on a DB round
+  // trip), then the DB-sourced freeze marker immediately after client
+  // construction — see the call-site contract in the design doc (8.3.3.2).
+  assertRunAllowed('dequarantine')
+  const gateClient = createSupabaseAdminClient()
+  await assertFreezeMarkerClear(gateClient, 'dequarantine')
   const apply = process.argv.includes('--apply')
   const limitArg = process.argv.find((a) => a.startsWith('--limit'))
   const limit = limitArg

--- a/scripts/indexer/purge-dead-quarantines.ts
+++ b/scripts/indexer/purge-dead-quarantines.ts
@@ -68,6 +68,7 @@ import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createSupabaseAdminClient } from './_shared/supabase.ts'
+import { assertRunAllowed, assertFreezeMarkerClear } from './run-gate.ts'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -442,6 +443,12 @@ function parseLimitArg(argv: string[]): number | undefined {
 
 /** CLI entrypoint (skipped when imported by tests). */
 async function main(): Promise<void> {
+  // SMI-5879 Gate C: env-sourced check first (no dependency on a DB round
+  // trip), then the DB-sourced freeze marker immediately after client
+  // construction — see the call-site contract in the design doc (8.3.3.2).
+  assertRunAllowed('purge')
+  const gateClient = createSupabaseAdminClient()
+  await assertFreezeMarkerClear(gateClient, 'purge')
   const apply = process.argv.includes('--apply')
   await runPurge({
     apply,

--- a/scripts/indexer/revalidate-stale-quarantines.ts
+++ b/scripts/indexer/revalidate-stale-quarantines.ts
@@ -12,6 +12,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createSupabaseAdminClient } from './_shared/supabase.ts'
+import { assertRunAllowed, assertFreezeMarkerClear } from './run-gate.ts'
 import { buildGitHubHeaders } from './_shared/github-auth.ts'
 import {
   scanSkillContent,
@@ -463,6 +464,12 @@ export async function runSweep(opts: { apply: boolean; limit?: number }): Promis
 
 /** Parse CLI arguments and run the sweep. Skipped when imported by tests. */
 async function main(): Promise<void> {
+  // SMI-5879 Gate C: env-sourced check first (no dependency on a DB round
+  // trip), then the DB-sourced freeze marker immediately after client
+  // construction — see the call-site contract in the design doc (8.3.3.2).
+  assertRunAllowed('revalidate')
+  const gateClient = createSupabaseAdminClient()
+  await assertFreezeMarkerClear(gateClient, 'revalidate')
   const apply = process.argv.includes('--apply')
   const limitArg = process.argv.find((a) => a.startsWith('--limit'))
   const limit = limitArg

--- a/scripts/indexer/revalidate-stale-quarantines.ts
+++ b/scripts/indexer/revalidate-stale-quarantines.ts
@@ -340,9 +340,15 @@ export async function loadCandidates(
   return out
 }
 
-/** Run the full stale-revalidation sweep. */
-export async function runSweep(opts: { apply: boolean; limit?: number }): Promise<SweepCounts> {
-  const db = createSupabaseAdminClient()
+/**
+ * Run the full stale-revalidation sweep. `db` is caller-constructed (SMI-Q,
+ * design 11.2.7) so Gate C's client-construction ordering is observable in
+ * `main()`, not hidden behind a second client built inside this function.
+ */
+export async function runSweep(
+  db: SupabaseClient,
+  opts: { apply: boolean; limit?: number }
+): Promise<SweepCounts> {
   const headers = await buildGitHubHeaders()
 
   const rows = await loadCandidates(db, opts.limit)
@@ -465,17 +471,20 @@ export async function runSweep(opts: { apply: boolean; limit?: number }): Promis
 /** Parse CLI arguments and run the sweep. Skipped when imported by tests. */
 async function main(): Promise<void> {
   // SMI-5879 Gate C: env-sourced check first (no dependency on a DB round
-  // trip), then the DB-sourced freeze marker immediately after client
-  // construction — see the call-site contract in the design doc (8.3.3.2).
+  // trip), then the client is constructed ONCE (round-7 SMI-Q — the same
+  // client Gate C's freeze-marker check reads is the same client runSweep()
+  // writes with, so the "immediately after client construction" ordering is
+  // observable in one function, not hidden behind a second, independently
+  // constructed client inside runSweep() — see the design doc 11.2.7).
   assertRunAllowed('revalidate')
-  const gateClient = createSupabaseAdminClient()
-  await assertFreezeMarkerClear(gateClient, 'revalidate')
+  const db = createSupabaseAdminClient()
+  await assertFreezeMarkerClear(db, 'revalidate')
   const apply = process.argv.includes('--apply')
   const limitArg = process.argv.find((a) => a.startsWith('--limit'))
   const limit = limitArg
     ? Number(limitArg.split('=')[1] ?? process.argv[process.argv.indexOf(limitArg) + 1])
     : undefined
-  await runSweep({ apply, limit: Number.isFinite(limit) ? limit : undefined })
+  await runSweep(db, { apply, limit: Number.isFinite(limit) ? limit : undefined })
 }
 
 // Run only when invoked directly (not when imported by the test suite).

--- a/scripts/indexer/run-gate.ts
+++ b/scripts/indexer/run-gate.ts
@@ -1,0 +1,163 @@
+/**
+ * SMI-5879 (8.3.2/8.3.3): Shared execution-gate module for the indexer family.
+ * @module scripts/indexer/run-gate
+ *
+ * Node-side only. MUST NOT be mirrored into supabase/functions/: one file
+ * there converts the gate-infrastructure PR into a 31-function `mode=all`
+ * fanout (`classify-deploy-mode.sh:23-29`). The Deno equivalent (Gate F) ships
+ * separately, inside `supabase/functions/indexer/`, in the PR that deploys
+ * the ported scanner.
+ *
+ * Two independent layers:
+ *  - {@link assertRunAllowed} -- env-sourced (`INDEXER_RUN_ALLOWLIST`), reads
+ *    `process.env` directly (never `parseEnv()`: the three direct tools build
+ *    no `IndexerEnv`, and `parseEnv()` hard-fails on a missing SUPABASE_* pair).
+ *  - {@link assertFreezeMarkerClear} -- DB-sourced (`audit_logs`), raises the
+ *    host-side bar for tools whose `INDEXER_RUN_ALLOWLIST` read the operator
+ *    themselves could rewrite. Not called from `run.ts` (CI-only path; see
+ *    the call-site contract in the design doc 8.3.3.2).
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * The six run-type identifiers the gate understands. Five (`discovery`,
+ * `maintenance`, `recheck`, `dequarantine`, `purge`) mirror `parse-env.ts`'s
+ * `RUN_TYPE` union exactly; `revalidate` exists only in the gate's own
+ * vocabulary, for the host-only writer `revalidate-stale-quarantines.ts`,
+ * deliberately kept out of `parse-env.ts`'s union so the workflow-facing
+ * surface is unchanged.
+ */
+export const GATED_RUN_TYPES = [
+  'discovery',
+  'maintenance',
+  'recheck',
+  'dequarantine',
+  'purge',
+  'revalidate',
+] as const
+
+export type GatedRunType = (typeof GATED_RUN_TYPES)[number]
+
+/** Documented bypass for {@link assertFreezeMarkerClear} (Guards & Opt-Outs registry). */
+const FREEZE_MARKER_BYPASS_VAR = 'SKILLSMITH_INDEXER_FREEZE_MARKER_BYPASS'
+
+function isGatedRunType(value: string): value is GatedRunType {
+  return (GATED_RUN_TYPES as readonly string[]).includes(value)
+}
+
+/**
+ * Parse an allow-list string (either `INDEXER_RUN_ALLOWLIST` or a freeze
+ * marker's `metadata.allowlist`) into an allow/deny decision for `runType`.
+ *
+ * Semantics: unset/empty/'all' => permit; 'none' => refuse; a comma-separated
+ * subset of {@link GATED_RUN_TYPES} => permit iff `runType` is listed; ANY
+ * OTHER value (including a comma list containing an unrecognised token) =>
+ * refuse (fail closed), so a typo such as "nonw" can never read as "all".
+ * Values are trimmed and lower-cased before comparison.
+ */
+function isRunTypePermitted(rawAllowlist: string, runType: GatedRunType): boolean {
+  const raw = rawAllowlist.trim().toLowerCase()
+
+  if (raw === '' || raw === 'all') return true
+  if (raw === 'none') return false
+
+  const tokens = raw.split(',').map((t) => t.trim())
+  const allRecognised = tokens.length > 0 && tokens.every((t) => isGatedRunType(t))
+  if (!allRecognised) return false // fail closed on any unrecognised token/value
+
+  return tokens.includes(runType)
+}
+
+/**
+ * Refuse (throw; never return) when `INDEXER_RUN_ALLOWLIST` forbids `runType`.
+ * Reads `process.env` DIRECTLY and never calls `parseEnv()`: the three direct
+ * tools construct no `IndexerEnv`, `parseEnv()` hard-fails on a missing
+ * SUPABASE_* pair, and `parse-env.ts`'s `RUN_TYPE` validation covers the five
+ * WORKFLOW values only -- `revalidate` is deliberately outside that union.
+ *
+ * In CI this is enforced: `INDEXER_RUN_ALLOWLIST` arrives as a repo variable
+ * plumbed through the workflow's `env:` block, which the job cannot rewrite.
+ * On the host it is a tripwire, not a gate: the person it is meant to stop is
+ * the person who can unset the variable in their own shell (SMI-5879 8.3.3.3).
+ */
+export function assertRunAllowed(runType: GatedRunType): void {
+  const raw = process.env.INDEXER_RUN_ALLOWLIST ?? ''
+
+  if (isRunTypePermitted(raw, runType)) return
+
+  const normalized = raw.trim().toLowerCase()
+  throw new Error(
+    normalized === 'none'
+      ? `[run-gate] INDEXER_RUN_ALLOWLIST=none — the indexer run-type allow-list is engaged. Refusing run_type=${runType}.`
+      : `[run-gate] INDEXER_RUN_ALLOWLIST="${raw}" does not permit run_type=${runType} (expected unset/'all', 'none', or a comma-separated subset of ${GATED_RUN_TYPES.join(',')}). Refusing (fail closed).`
+  )
+}
+
+/**
+ * Second, DB-side layer. Reads the most recent `audit_logs` row with
+ * `event_type='indexer:freeze'`, `resource='skills'`; applies
+ * {@link assertRunAllowed}'s exact vocabulary (via {@link isRunTypePermitted})
+ * to that row's `metadata.allowlist`. Zero migrations: `audit_logs` is an
+ * existing table and this is an ordinary audit row.
+ *
+ * Fail-closed rules:
+ *  - a query ERROR (or a thrown exception) means the freeze state cannot be
+ *    confirmed -- refuse. A tool that cannot confirm the freeze is clear must
+ *    not proceed.
+ *  - a marker row that exists but carries no string `metadata.allowlist` is
+ *    malformed -- refuse.
+ *  - NO marker row at all (the steady-state default before any freeze has
+ *    ever been engaged, or after 8.3.2.5.6's final "pin unset last" step)
+ *    is treated the same as an empty `INDEXER_RUN_ALLOWLIST`: permit. The
+ *    tool must be inert outside a change window, exactly like Gates A/B/D/E.
+ *
+ * Documented bypass: `SKILLSMITH_INDEXER_FREEZE_MARKER_BYPASS=1` (registered
+ * in `docs/internal/process/guards-and-opt-outs.md` per the Guards & Opt-Outs
+ * rule).
+ */
+export async function assertFreezeMarkerClear(
+  supabase: SupabaseClient,
+  runType: GatedRunType
+): Promise<void> {
+  if (process.env[FREEZE_MARKER_BYPASS_VAR] === '1') return
+
+  let allowlistRaw: unknown
+  try {
+    const { data, error } = await supabase
+      .from('audit_logs')
+      .select('metadata')
+      .eq('event_type', 'indexer:freeze')
+      .eq('resource', 'skills')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (error) throw new Error(error.message)
+
+    if (data == null) {
+      // No marker row has ever been written — steady state. Permit.
+      return
+    }
+
+    allowlistRaw = (data.metadata as Record<string, unknown> | null | undefined)?.allowlist
+  } catch (err) {
+    throw new Error(
+      `[run-gate] could not confirm freeze-marker state for run_type=${runType} — refusing (fail closed): ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+  }
+
+  if (typeof allowlistRaw !== 'string') {
+    throw new Error(
+      `[run-gate] freeze marker row exists but carries no valid metadata.allowlist — refusing run_type=${runType} (fail closed).`
+    )
+  }
+
+  if (!isRunTypePermitted(allowlistRaw, runType)) {
+    throw new Error(
+      `[run-gate] freeze marker allowlist="${allowlistRaw}" does not permit run_type=${runType}. Refusing (fail closed).`
+    )
+  }
+}

--- a/scripts/indexer/run.ts
+++ b/scripts/indexer/run.ts
@@ -29,6 +29,7 @@ import {
   type RateLimitTelemetry,
 } from './_shared/rate-limit.ts'
 import { parseEnv, type IndexerEnv } from './parse-env.ts'
+import { assertRunAllowed } from './run-gate.ts'
 import { DEFAULT_TOPICS } from './topic-search.ts'
 import { DEFAULT_MIN_CONTENT_LENGTH } from './skill-processor.ts'
 import { selectTopics, type RotationSource } from './topic-rotation.ts'
@@ -295,6 +296,7 @@ async function runRecheckBranch(
 
 async function main(): Promise<void> {
   const env = parseEnv()
+  assertRunAllowed(env.RUN_TYPE)
   const requestId = getRequestId()
   const supabase = createSupabaseAdminClient()
   const telemetry = newRateLimitTelemetry()

--- a/scripts/tests/indexer/run-gate-ast-helpers.ts
+++ b/scripts/tests/indexer/run-gate-ast-helpers.ts
@@ -1,0 +1,174 @@
+/**
+ * SMI-5879 (8.3.3.5): Shared source-scanning helpers for the run-gate census
+ * and statement-order tests. Not a test file itself (no `*.test.ts` suffix),
+ * mirroring the existing `parity-utils.ts` / `recheck.test-helpers.ts`
+ * convention in this directory.
+ *
+ * These helpers deliberately work over raw source text and the TypeScript
+ * compiler API's syntactic AST (no type-checker, no `Program`) rather than
+ * importing the modules under test — the whole point of the census is to
+ * catch a NEW file/shape that the test suite doesn't yet know to import.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as ts from 'typescript'
+
+/** Absolute path to `scripts/indexer/`, resolved relative to this file (cwd-independent). */
+export const INDEXER_DIR = fileURLToPath(new URL('../../indexer', import.meta.url))
+
+/** The guard literally used by every Shape-1 (guarded direct-entry) script. */
+const DIRECT_ENTRY_GUARD_RE = /import\.meta\.url\s*===\s*`file:\/\/\$\{process\.argv\[1\]\}`/
+
+/**
+ * Recursively list every non-test `.ts` file under `scripts/indexer/`,
+ * returning paths relative to `scripts/indexer/` (e.g. `run.ts`,
+ * `_shared/supabase.ts`). Mirrors `getFilesRecursive` in
+ * `scripts/audit-standards.mjs`.
+ */
+export function listIndexerSourceFiles(): string[] {
+  const out: string[] = []
+
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry)
+      const stat = statSync(full)
+      if (stat.isDirectory()) {
+        walk(full)
+      } else if (entry.endsWith('.ts') && !entry.includes('.test.')) {
+        out.push(relative(INDEXER_DIR, full))
+      }
+    }
+  }
+
+  walk(INDEXER_DIR)
+  return out.sort()
+}
+
+/** Read a `scripts/indexer/`-relative file's raw source text. */
+export function readIndexerSource(relativePath: string): string {
+  return readFileSync(join(INDEXER_DIR, relativePath), 'utf8')
+}
+
+/** Whether `source` contains the Shape-1 conditional-execution guard. */
+export function hasDirectEntryGuard(source: string): boolean {
+  return DIRECT_ENTRY_GUARD_RE.test(source)
+}
+
+/** Whether the file's first line is a shebang (`#!...`). */
+export function hasShebang(source: string): boolean {
+  return source.startsWith('#!')
+}
+
+/** Parse a `scripts/indexer/`-relative file into a syntactic (no type-checker) TS AST. */
+export function parseIndexerSourceFile(relativePath: string): ts.SourceFile {
+  const source = readIndexerSource(relativePath)
+  return ts.createSourceFile(relativePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+}
+
+/** The textual callee name of a call expression: `foo(` -> "foo"; `x.bar(` -> "bar". */
+function calleeName(expr: ts.Expression): string | undefined {
+  if (ts.isIdentifier(expr)) return expr.text
+  if (ts.isPropertyAccessExpression(expr)) return expr.name.text
+  return undefined
+}
+
+/**
+ * Whether `sourceFile` has a top-level (module-scope) statement that invokes
+ * an identifier named `name` as a function call — e.g. `main()` or
+ * `main().catch(...)`. Only top-level statements are inspected (does not
+ * descend into any function/arrow body), so a definition like
+ * `const wrap = () => main()` correctly does NOT count: it never actually
+ * calls `main` at module-evaluation time.
+ */
+export function hasTopLevelCallInvocation(sourceFile: ts.SourceFile, name: string): boolean {
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isExpressionStatement(stmt)) continue
+    if (expressionInvokes(stmt.expression, name)) return true
+  }
+  return false
+}
+
+/** Whether `expr` is (or chains from) a direct call to identifier `name`, e.g. `name()` or `name().catch(...)`. */
+function expressionInvokes(expr: ts.Expression, name: string): boolean {
+  if (!ts.isCallExpression(expr)) return false
+  if (ts.isIdentifier(expr.expression) && expr.expression.text === name) return true
+  // Chained call, e.g. `main().catch(...)` — expr.expression is `main().catch`.
+  if (ts.isPropertyAccessExpression(expr.expression)) {
+    return expressionInvokes(expr.expression.expression, name)
+  }
+  return false
+}
+
+/** Find a top-level `function <name>(...) {...}` (or `async function`) declaration. */
+export function findTopLevelFunctionDeclaration(
+  sourceFile: ts.SourceFile,
+  name: string
+): ts.FunctionDeclaration | undefined {
+  for (const stmt of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name?.text === name) return stmt
+  }
+  return undefined
+}
+
+/**
+ * First source position (`.pos`, a monotonic character offset — trivia-inclusive
+ * but sufficient for before/after ordering) of a call expression anywhere inside
+ * `root` whose callee name is `name` (matches both a bare identifier call like
+ * `fetch(...)` and a property-access call like `db.rpc(...)` / `.insert(...)`).
+ * Returns undefined when no such call exists within `root`.
+ */
+export function firstCallPosition(root: ts.Node, name: string): number | undefined {
+  let found: number | undefined
+  function visit(node: ts.Node): void {
+    if (found !== undefined) return
+    if (ts.isCallExpression(node) && calleeName(node.expression) === name) {
+      found = node.pos
+      return
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(root)
+  return found
+}
+
+/** Top-level statement index of `func`'s body containing a call to `name` (or undefined). */
+export function topLevelStatementIndexOfCall(
+  func: ts.FunctionDeclaration,
+  name: string
+): number | undefined {
+  if (!func.body) return undefined
+  for (let i = 0; i < func.body.statements.length; i++) {
+    const stmt = func.body.statements[i]
+    let matches = false
+    function visit(node: ts.Node): void {
+      if (matches) return
+      if (ts.isCallExpression(node) && calleeName(node.expression) === name) {
+        matches = true
+        return
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(stmt)
+    if (matches) return i
+  }
+  return undefined
+}
+
+/** Whether an import declaration in `sourceFile` names `symbolName` from a module ending in `moduleSuffix`. */
+export function importsNamedSymbolFrom(
+  sourceFile: ts.SourceFile,
+  moduleSuffix: string,
+  symbolName: string
+): boolean {
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    if (!stmt.moduleSpecifier.text.endsWith(moduleSuffix)) continue
+    const clause = stmt.importClause
+    if (!clause?.namedBindings || !ts.isNamedImports(clause.namedBindings)) continue
+    if (clause.namedBindings.elements.some((el) => el.name.text === symbolName)) return true
+  }
+  return false
+}

--- a/scripts/tests/indexer/run-gate-callsites.test.ts
+++ b/scripts/tests/indexer/run-gate-callsites.test.ts
@@ -1,0 +1,124 @@
+/**
+ * SMI-5879 (8.3.3.5): The entry-point census.
+ *
+ * `scripts/indexer/` has three distinct executable-file shapes, and a
+ * guard-only glob (round 5's approach) is structurally blind to two of them:
+ *   - Shape 1: guarded direct entry (`import.meta.url === ...` guard).
+ *   - Shape 2: unconditional top-level `main()` invocation, no guard at all
+ *     (today, only `run.ts` — the exact writer every workflow-path run goes
+ *     through, which a guard-only census would silently never check).
+ *   - Shape 3: shebang-bearing file with NEITHER shape — an
+ *     "executable-looking library" (today, only `recheck.ts`) that must be
+ *     asserted to STAY that way, because the day it gains a `main()` call it
+ *     becomes an ungated direct entry point to a production writer.
+ *
+ * Each shape's set is pinned exactly (not just "at least") so a new file in
+ * any shape fails this suite with a message naming the new file, rather than
+ * being silently absorbed.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  listIndexerSourceFiles,
+  readIndexerSource,
+  hasDirectEntryGuard,
+  hasShebang,
+  parseIndexerSourceFile,
+  hasTopLevelCallInvocation,
+  importsNamedSymbolFrom,
+} from './run-gate-ast-helpers.ts'
+
+const PINNED_SHAPE1 = [
+  'dequarantine-false-positives.ts',
+  'purge-dead-quarantines.ts',
+  'revalidate-stale-quarantines.ts',
+].sort()
+
+const PINNED_SHAPE2 = ['run.ts']
+
+const PINNED_SHEBANG_FILES = [
+  'dequarantine-false-positives.ts',
+  'purge-dead-quarantines.ts',
+  'recheck.ts',
+  'revalidate-stale-quarantines.ts',
+  'run.ts',
+].sort()
+
+describe('Shape 1 — guarded direct-entry census', () => {
+  const files = listIndexerSourceFiles()
+  const shape1Files = files.filter((f) => hasDirectEntryGuard(readIndexerSource(f))).sort()
+
+  it('is EXACTLY the pinned set of three files', () => {
+    expect(shape1Files).toEqual(PINNED_SHAPE1)
+  })
+
+  it.each(PINNED_SHAPE1)(
+    '%s imports and calls assertRunAllowed AND assertFreezeMarkerClear',
+    (file) => {
+      const sourceFile = parseIndexerSourceFile(file)
+      expect(importsNamedSymbolFrom(sourceFile, 'run-gate.ts', 'assertRunAllowed')).toBe(true)
+      expect(importsNamedSymbolFrom(sourceFile, 'run-gate.ts', 'assertFreezeMarkerClear')).toBe(
+        true
+      )
+
+      const source = readIndexerSource(file)
+      expect(source).toMatch(/\bassertRunAllowed\s*\(/)
+      expect(source).toMatch(/\bassertFreezeMarkerClear\s*\(/)
+    }
+  )
+})
+
+describe('Shape 2 — run.ts is named explicitly, not discovered', () => {
+  // run.ts has NO import.meta.url guard — it invokes main() unconditionally
+  // at the bottom of the file (main().catch(...)). A guard-based glob cannot
+  // find it, which is exactly the gap round 5's census had.
+  const sourceFile = parseIndexerSourceFile('run.ts')
+
+  it('contains a top-level main() invocation', () => {
+    expect(hasTopLevelCallInvocation(sourceFile, 'main')).toBe(true)
+  })
+
+  it('imports assertRunAllowed from ./run-gate.ts', () => {
+    expect(importsNamedSymbolFrom(sourceFile, 'run-gate.ts', 'assertRunAllowed')).toBe(true)
+  })
+
+  it('calls assertRunAllowed(env.RUN_TYPE) inside main()', () => {
+    const source = readIndexerSource('run.ts')
+    expect(source).toMatch(/assertRunAllowed\s*\(\s*env\.RUN_TYPE\s*\)/)
+  })
+
+  it('does NOT call assertFreezeMarkerClear — the CI-only path adds no adversarial strength from the DB marker (8.3.3.2)', () => {
+    const source = readIndexerSource('run.ts')
+    expect(source).not.toMatch(/assertFreezeMarkerClear/)
+  })
+})
+
+describe('Shape 2 is a closed set', () => {
+  it('exactly {run.ts} has a top-level main() invocation', () => {
+    const files = listIndexerSourceFiles()
+    const shape2Files = files
+      .filter((f) => hasTopLevelCallInvocation(parseIndexerSourceFile(f), 'main'))
+      .sort()
+    expect(shape2Files).toEqual(PINNED_SHAPE2)
+  })
+})
+
+describe('Shape 3 — no executable-looking library gains an entry point', () => {
+  it('the shebang-bearing file set is exactly the pinned five', () => {
+    const files = listIndexerSourceFiles()
+    const shebangFiles = files.filter((f) => hasShebang(readIndexerSource(f))).sort()
+    expect(shebangFiles).toEqual(PINNED_SHEBANG_FILES)
+  })
+
+  it('shebangFiles \\ (shape1 ∪ shape2) is exactly {recheck.ts}', () => {
+    const files = listIndexerSourceFiles()
+    const shebangFiles = new Set(files.filter((f) => hasShebang(readIndexerSource(f))))
+    const shape1 = new Set(files.filter((f) => hasDirectEntryGuard(readIndexerSource(f))))
+    const shape2 = new Set(
+      files.filter((f) => hasTopLevelCallInvocation(parseIndexerSourceFile(f), 'main'))
+    )
+
+    const remainder = [...shebangFiles].filter((f) => !shape1.has(f) && !shape2.has(f)).sort()
+    expect(remainder).toEqual(['recheck.ts'])
+  })
+})

--- a/scripts/tests/indexer/run-gate-freeze-marker.test.ts
+++ b/scripts/tests/indexer/run-gate-freeze-marker.test.ts
@@ -1,0 +1,163 @@
+/**
+ * SMI-5879 (8.3.2.5.3/8.3.3.2): Unit tests for `assertFreezeMarkerClear`, the
+ * DB-sourced second layer of the shared indexer execution gate. Reads the
+ * most recent `audit_logs` row with `event_type='indexer:freeze'`,
+ * `resource='skills'` and applies `assertRunAllowed`'s exact vocabulary to
+ * that row's `metadata.allowlist` — 'maintenance' permits maintenance and
+ * refuses discovery; a malformed value refuses (fail closed); a query error
+ * refuses (fail closed); no marker row at all (steady state) permits.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { assertFreezeMarkerClear } from '../../indexer/run-gate.ts'
+
+const BYPASS_VAR = 'SKILLSMITH_INDEXER_FREEZE_MARKER_BYPASS'
+let prevBypass: string | undefined
+
+beforeEach(() => {
+  prevBypass = process.env[BYPASS_VAR]
+  delete process.env[BYPASS_VAR]
+})
+
+afterEach(() => {
+  if (prevBypass === undefined) delete process.env[BYPASS_VAR]
+  else process.env[BYPASS_VAR] = prevBypass
+})
+
+interface FakeQueryResult {
+  data: { metadata: unknown } | null
+  error: { message: string } | null
+}
+
+/** Records every `.eq(col, val)` call so tests can assert the exact filter shape. */
+function fakeSupabase(result: FakeQueryResult | (() => Promise<FakeQueryResult>)): {
+  client: SupabaseClient
+  eqCalls: Array<[string, unknown]>
+} {
+  const eqCalls: Array<[string, unknown]> = []
+  const chain = {
+    select: () => chain,
+    eq: (col: string, val: unknown) => {
+      eqCalls.push([col, val])
+      return chain
+    },
+    order: () => chain,
+    limit: () => chain,
+    maybeSingle: async () => (typeof result === 'function' ? await result() : result),
+  }
+  const client = { from: () => chain } as unknown as SupabaseClient
+  return { client, eqCalls }
+}
+
+describe('assertFreezeMarkerClear — query shape', () => {
+  it("filters on event_type='indexer:freeze' AND resource='skills'", async () => {
+    const { client, eqCalls } = fakeSupabase({ data: null, error: null })
+    await assertFreezeMarkerClear(client, 'maintenance')
+    expect(eqCalls).toContainEqual(['event_type', 'indexer:freeze'])
+    expect(eqCalls).toContainEqual(['resource', 'skills'])
+  })
+})
+
+describe('assertFreezeMarkerClear — no marker row (steady state)', () => {
+  it('permits every run type when no freeze marker has ever been written', async () => {
+    const { client } = fakeSupabase({ data: null, error: null })
+    await expect(assertFreezeMarkerClear(client, 'discovery')).resolves.toBeUndefined()
+  })
+})
+
+describe("assertFreezeMarkerClear — marker allowlist uses assertRunAllowed's exact vocabulary", () => {
+  it("'maintenance' permits maintenance and refuses discovery", async () => {
+    const { client } = fakeSupabase({
+      data: { metadata: { allowlist: 'maintenance' } },
+      error: null,
+    })
+    await expect(assertFreezeMarkerClear(client, 'maintenance')).resolves.toBeUndefined()
+  })
+
+  it("'maintenance' refuses discovery", async () => {
+    const { client } = fakeSupabase({
+      data: { metadata: { allowlist: 'maintenance' } },
+      error: null,
+    })
+    await expect(assertFreezeMarkerClear(client, 'discovery')).rejects.toThrow()
+  })
+
+  it("'none' refuses every run type", async () => {
+    const { client } = fakeSupabase({ data: { metadata: { allowlist: 'none' } }, error: null })
+    await expect(assertFreezeMarkerClear(client, 'purge')).rejects.toThrow()
+  })
+
+  it("'all' permits every run type", async () => {
+    const { client } = fakeSupabase({ data: { metadata: { allowlist: 'all' } }, error: null })
+    await expect(assertFreezeMarkerClear(client, 'revalidate')).resolves.toBeUndefined()
+  })
+
+  it('a comma-separated subset permits only the listed run types', async () => {
+    const { client } = fakeSupabase({
+      data: { metadata: { allowlist: 'recheck,revalidate' } },
+      error: null,
+    })
+    await expect(assertFreezeMarkerClear(client, 'recheck')).resolves.toBeUndefined()
+    await expect(assertFreezeMarkerClear(client, 'revalidate')).resolves.toBeUndefined()
+  })
+
+  it('a comma-separated subset refuses an unlisted run type', async () => {
+    const { client } = fakeSupabase({
+      data: { metadata: { allowlist: 'recheck,revalidate' } },
+      error: null,
+    })
+    await expect(assertFreezeMarkerClear(client, 'discovery')).rejects.toThrow()
+  })
+})
+
+describe('assertFreezeMarkerClear — malformed value refuses (fail closed)', () => {
+  it('refuses when metadata.allowlist is missing entirely', async () => {
+    const { client } = fakeSupabase({ data: { metadata: {} }, error: null })
+    await expect(assertFreezeMarkerClear(client, 'maintenance')).rejects.toThrow()
+  })
+
+  it('refuses when metadata.allowlist is not a string', async () => {
+    const { client } = fakeSupabase({ data: { metadata: { allowlist: 42 } }, error: null })
+    await expect(assertFreezeMarkerClear(client, 'maintenance')).rejects.toThrow()
+  })
+
+  it('refuses a nonsense allowlist token the way a typo must never read as "all"', async () => {
+    const { client } = fakeSupabase({ data: { metadata: { allowlist: 'nonw' } }, error: null })
+    await expect(assertFreezeMarkerClear(client, 'maintenance')).rejects.toThrow()
+  })
+})
+
+describe('assertFreezeMarkerClear — fails CLOSED on query error', () => {
+  it('refuses when the query returns a Supabase error', async () => {
+    const { client } = fakeSupabase({ data: null, error: { message: 'connection reset' } })
+    await expect(assertFreezeMarkerClear(client, 'maintenance')).rejects.toThrow(/connection reset/)
+  })
+
+  it('refuses when the query throws', async () => {
+    const { client } = fakeSupabase(() => {
+      throw new Error('network down')
+    })
+    await expect(assertFreezeMarkerClear(client, 'maintenance')).rejects.toThrow(/network down/)
+  })
+})
+
+describe('assertFreezeMarkerClear — documented bypass', () => {
+  it('skips the DB read entirely when SKILLSMITH_INDEXER_FREEZE_MARKER_BYPASS=1', async () => {
+    process.env[BYPASS_VAR] = '1'
+    // A client that would throw if ever queried — proves the bypass short-circuits
+    // before any `.from()` call.
+    const client = {
+      from: () => {
+        throw new Error('must not query when bypassed')
+      },
+    } as unknown as SupabaseClient
+    await expect(assertFreezeMarkerClear(client, 'discovery')).resolves.toBeUndefined()
+  })
+
+  it('does not bypass on any value other than the literal "1"', async () => {
+    process.env[BYPASS_VAR] = 'true'
+    const { client } = fakeSupabase({ data: { metadata: { allowlist: 'none' } }, error: null })
+    await expect(assertFreezeMarkerClear(client, 'discovery')).rejects.toThrow()
+  })
+})

--- a/scripts/tests/indexer/run-gate-line-budget.test.ts
+++ b/scripts/tests/indexer/run-gate-line-budget.test.ts
@@ -1,0 +1,43 @@
+/**
+ * SMI-5879 (8.3.3.2, SMI-O): `run.ts` line-budget backstop.
+ *
+ * `run.ts` is measured at 496 lines — four under the `audit:standards`
+ * 500-line gate (itself scoped to `packages/`+`apps/` only, so `scripts/`
+ * files aren't actually covered by that generic check; see this wave's
+ * final report for the discrepancy). Adding Gate C (import + call) consumes
+ * two of those four lines, landing at exactly 498/500 — two lines of
+ * headroom, zero comment budget. A later comment addition on those two new
+ * lines must fail HERE, on a named test with an explanatory message, rather
+ * than surface only as a generic audit finding at push time (or not at all,
+ * given the `scripts/` gap above). SMI-O (extracting run.ts's audit-summary
+ * assembly block to a sibling to restore headroom) is a separate follow-up,
+ * not fixed by this test.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readIndexerSource } from './run-gate-ast-helpers.ts'
+
+const MAX_LINES = 498
+
+/**
+ * Real (editor/`wc -l`-equivalent) line count. Deliberately NOT
+ * `content.split('\n').length` — for any file ending in a trailing newline
+ * (the prettier-enforced norm here), that naive form over-counts by exactly
+ * one (an empty trailing segment), which would silently make this test's
+ * true ceiling 499 rather than the 498 the design doc states and this file's
+ * arithmetic is pinned to.
+ */
+function countRealLines(content: string): number {
+  return content.endsWith('\n') ? content.split('\n').length - 1 : content.split('\n').length
+}
+
+describe('run.ts line budget', () => {
+  it(`stays at or under ${MAX_LINES} lines (SMI-5879 Gate C headroom)`, () => {
+    const lineCount = countRealLines(readIndexerSource('run.ts'))
+    expect(
+      lineCount,
+      `run.ts is ${lineCount} lines, over the ${MAX_LINES}-line Gate C budget (8.3.3.2). ` +
+        'See SMI-O: extract the audit-summary assembly block to a sibling module before adding more lines here.'
+    ).toBeLessThanOrEqual(MAX_LINES)
+  })
+})

--- a/scripts/tests/indexer/run-gate-order.test.ts
+++ b/scripts/tests/indexer/run-gate-order.test.ts
@@ -1,0 +1,95 @@
+/**
+ * SMI-5879 (8.3.3.2): AST statement-order assertions — "the gate must precede
+ * the first side effect," not merely "be the first statement." Guards
+ * against a future refactor silently demoting the gate below a write.
+ */
+
+import { describe, it, expect } from 'vitest'
+import * as ts from 'typescript'
+import {
+  parseIndexerSourceFile,
+  findTopLevelFunctionDeclaration,
+  firstCallPosition,
+  topLevelStatementIndexOfCall,
+} from './run-gate-ast-helpers.ts'
+
+/** Side-effect callee names the gate must precede, in every gated main(). */
+const SIDE_EFFECT_CALLEES = [
+  'createSupabaseAdminClient',
+  'fetch',
+  'buildGitHubHeaders',
+  'rpc',
+  'insert',
+  'update',
+  'delete',
+]
+
+const GATED_ENTRY_FILES = [
+  'run.ts',
+  'dequarantine-false-positives.ts',
+  'purge-dead-quarantines.ts',
+  'revalidate-stale-quarantines.ts',
+]
+
+describe('run-gate-order — the gate precedes every side effect, in each of the four main() bodies', () => {
+  it.each(GATED_ENTRY_FILES)(
+    '%s: assertRunAllowed precedes every side-effect call inside main()',
+    (file) => {
+      const sourceFile = parseIndexerSourceFile(file)
+      const mainFn = findTopLevelFunctionDeclaration(sourceFile, 'main')
+      expect(mainFn, `${file} must declare a top-level main()`).toBeDefined()
+
+      const gatePos = firstCallPosition(mainFn as ts.FunctionDeclaration, 'assertRunAllowed')
+      expect(gatePos, `${file}'s main() must call assertRunAllowed`).toBeDefined()
+
+      for (const callee of SIDE_EFFECT_CALLEES) {
+        const sideEffectPos = firstCallPosition(mainFn as ts.FunctionDeclaration, callee)
+        if (sideEffectPos === undefined) continue // not every file calls every callee
+        expect(
+          (gatePos as number) < sideEffectPos,
+          `${file}: assertRunAllowed (pos ${gatePos}) must precede ${callee}( (pos ${sideEffectPos})`
+        ).toBe(true)
+      }
+    }
+  )
+})
+
+describe('run-gate-order — run.ts: exact adjacency to parseEnv()', () => {
+  it('assertRunAllowed is the IMMEDIATE successor of `const env = parseEnv()`, no intervening statement', () => {
+    const sourceFile = parseIndexerSourceFile('run.ts')
+    const mainFn = findTopLevelFunctionDeclaration(sourceFile, 'main')
+    expect(mainFn).toBeDefined()
+    const body = (mainFn as ts.FunctionDeclaration).body
+    expect(body).toBeDefined()
+
+    const statements = body!.statements
+    const envDeclIndex = statements.findIndex(
+      (stmt) =>
+        ts.isVariableStatement(stmt) &&
+        stmt.declarationList.declarations.some(
+          (d) =>
+            ts.isIdentifier(d.name) &&
+            d.name.text === 'env' &&
+            d.initializer !== undefined &&
+            ts.isCallExpression(d.initializer) &&
+            ts.isIdentifier(d.initializer.expression) &&
+            d.initializer.expression.text === 'parseEnv'
+        )
+    )
+    expect(
+      envDeclIndex,
+      'could not find `const env = parseEnv()` in run.ts main()'
+    ).toBeGreaterThanOrEqual(0)
+
+    const gateStmtIndex = topLevelStatementIndexOfCall(
+      mainFn as ts.FunctionDeclaration,
+      'assertRunAllowed'
+    )
+    expect(
+      gateStmtIndex,
+      "could not find an assertRunAllowed call at main()'s top level"
+    ).toBeDefined()
+
+    expect(gateStmtIndex).toBe(envDeclIndex + 1)
+  })
+})

--- a/scripts/tests/indexer/run-gate-parseenv-purity.test.ts
+++ b/scripts/tests/indexer/run-gate-parseenv-purity.test.ts
@@ -1,0 +1,77 @@
+/**
+ * SMI-5879 (8.3.3.2): `parse-env.ts` purity backstop.
+ *
+ * The `run.ts` gate ordering (8.3.3.2 / run-gate-order.test.ts) is safe ONLY
+ * because `parseEnv()` — which necessarily runs BEFORE the gate, since the
+ * gate's argument (`env.RUN_TYPE`) is produced by it — has no side effects.
+ * This test verifies that claim against the source directly (deny-listed I/O
+ * identifiers, with comments and string literals stripped first so the
+ * module's own "SMI-5321: opt-in fetch-with-truncation" doc-comment doesn't
+ * false-positive) rather than trusting the module's own purity claim in its
+ * docstring. If `parseEnv()` ever gains I/O, this test fails and the ordering
+ * must be redesigned — it must never silently become unsafe.
+ */
+
+import { describe, it, expect } from 'vitest'
+import * as ts from 'typescript'
+import { readIndexerSource, parseIndexerSourceFile } from './run-gate-ast-helpers.ts'
+
+const DENY_LIST = [
+  'fetch',
+  'fs.',
+  'node:fs',
+  'node:child_process',
+  'execSync',
+  'spawn',
+  'createClient',
+  'http',
+  'Deno.',
+  'writeFile',
+  'readFile',
+]
+
+/** Tokenize with the TS scanner and drop every comment/string/template token. */
+function stripCommentsAndStrings(source: string): string {
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    /* skipTrivia */ false,
+    ts.LanguageVariant.Standard,
+    source
+  )
+  const DROP = new Set<ts.SyntaxKind>([
+    ts.SyntaxKind.SingleLineCommentTrivia,
+    ts.SyntaxKind.MultiLineCommentTrivia,
+    ts.SyntaxKind.StringLiteral,
+    ts.SyntaxKind.NoSubstitutionTemplateLiteral,
+    ts.SyntaxKind.TemplateHead,
+    ts.SyntaxKind.TemplateMiddle,
+    ts.SyntaxKind.TemplateTail,
+  ])
+
+  let out = ''
+  let tok = scanner.scan()
+  while (tok !== ts.SyntaxKind.EndOfFileToken) {
+    if (!DROP.has(tok)) out += scanner.getTokenText() + ' '
+    tok = scanner.scan()
+  }
+  return out
+}
+
+describe('parse-env.ts purity — deny-listed I/O identifiers', () => {
+  const stripped = stripCommentsAndStrings(readIndexerSource('parse-env.ts'))
+
+  it.each(DENY_LIST)('contains no occurrence of "%s" outside comments/strings', (identifier) => {
+    expect(stripped.includes(identifier)).toBe(false)
+  })
+})
+
+describe('parse-env.ts purity — its only import is `import type`', () => {
+  it('has exactly one ImportDeclaration, and it is type-only', () => {
+    const sourceFile = parseIndexerSourceFile('parse-env.ts')
+    const imports = sourceFile.statements.filter((s) => ts.isImportDeclaration(s))
+
+    expect(imports).toHaveLength(1)
+    const [importDecl] = imports as ts.ImportDeclaration[]
+    expect(importDecl.importClause?.isTypeOnly).toBe(true)
+  })
+})

--- a/scripts/tests/indexer/run-gate.test.ts
+++ b/scripts/tests/indexer/run-gate.test.ts
@@ -1,0 +1,120 @@
+/**
+ * SMI-5879 (8.3.2.3/8.3.3.5.2): Unit tests for `assertRunAllowed`, the
+ * env-sourced (`INDEXER_RUN_ALLOWLIST`) layer of the shared indexer execution
+ * gate. Six rows per the design doc: unset/'all' permits; 'none' refuses; a
+ * comma-separated subset permits only the listed run types; an unrecognised
+ * value fails closed; exhaustiveness over every `GATED_RUN_TYPES` member; and
+ * `parse-env.ts`'s `RUN_TYPE` union is a strict subset of `GATED_RUN_TYPES`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { assertRunAllowed, GATED_RUN_TYPES, type GatedRunType } from '../../indexer/run-gate.ts'
+
+const ENV_VAR = 'INDEXER_RUN_ALLOWLIST'
+let prevValue: string | undefined
+
+beforeEach(() => {
+  prevValue = process.env[ENV_VAR]
+  delete process.env[ENV_VAR]
+})
+
+afterEach(() => {
+  if (prevValue === undefined) delete process.env[ENV_VAR]
+  else process.env[ENV_VAR] = prevValue
+})
+
+describe('assertRunAllowed — unset/all permits', () => {
+  it('permits every run type when INDEXER_RUN_ALLOWLIST is unset', () => {
+    delete process.env[ENV_VAR]
+    for (const runType of GATED_RUN_TYPES) {
+      expect(() => assertRunAllowed(runType)).not.toThrow()
+    }
+  })
+
+  it("permits every run type when INDEXER_RUN_ALLOWLIST is 'all' (any case/whitespace)", () => {
+    for (const raw of ['all', 'ALL', ' All ']) {
+      process.env[ENV_VAR] = raw
+      for (const runType of GATED_RUN_TYPES) {
+        expect(() => assertRunAllowed(runType)).not.toThrow()
+      }
+    }
+  })
+})
+
+describe("assertRunAllowed — 'none' refuses", () => {
+  it('refuses every run type when INDEXER_RUN_ALLOWLIST=none', () => {
+    process.env[ENV_VAR] = 'none'
+    for (const runType of GATED_RUN_TYPES) {
+      expect(() => assertRunAllowed(runType)).toThrow(/none/i)
+    }
+  })
+})
+
+describe('assertRunAllowed — comma-separated subset', () => {
+  it('permits only the listed run types and refuses the rest', () => {
+    process.env[ENV_VAR] = 'discovery, maintenance'
+    expect(() => assertRunAllowed('discovery')).not.toThrow()
+    expect(() => assertRunAllowed('maintenance')).not.toThrow()
+    expect(() => assertRunAllowed('recheck')).toThrow()
+    expect(() => assertRunAllowed('dequarantine')).toThrow()
+    expect(() => assertRunAllowed('purge')).toThrow()
+    expect(() => assertRunAllowed('revalidate')).toThrow()
+  })
+
+  it('is case-insensitive on both the list and the token', () => {
+    process.env[ENV_VAR] = 'Purge'
+    expect(() => assertRunAllowed('purge')).not.toThrow()
+  })
+})
+
+describe('assertRunAllowed — unrecognised value fails closed', () => {
+  it('refuses a typo that could otherwise be misread as "all"', () => {
+    process.env[ENV_VAR] = 'nonw'
+    for (const runType of GATED_RUN_TYPES) {
+      expect(() => assertRunAllowed(runType)).toThrow()
+    }
+  })
+
+  it('refuses a comma list containing one unrecognised token, for every member', () => {
+    process.env[ENV_VAR] = 'discovery,bogus'
+    expect(() => assertRunAllowed('discovery')).toThrow()
+    expect(() => assertRunAllowed('bogus' as GatedRunType)).toThrow()
+  })
+})
+
+describe('assertRunAllowed — exhaustiveness over GATED_RUN_TYPES', () => {
+  it.each(GATED_RUN_TYPES)('permits %s under an unset allow-list', (runType) => {
+    delete process.env[ENV_VAR]
+    expect(() => assertRunAllowed(runType)).not.toThrow()
+  })
+
+  it.each(GATED_RUN_TYPES)('is exactly listed by its own comma entry for %s', (runType) => {
+    process.env[ENV_VAR] = runType
+    expect(() => assertRunAllowed(runType)).not.toThrow()
+    for (const other of GATED_RUN_TYPES) {
+      if (other === runType) continue
+      expect(() => assertRunAllowed(other)).toThrow()
+    }
+  })
+})
+
+describe('GATED_RUN_TYPES vs parse-env.ts RUN_TYPE union', () => {
+  it("parse-env.ts's RUN_TYPE union is a strict subset of GATED_RUN_TYPES", async () => {
+    // parse-env.ts's RUN_TYPE validation (161-173) accepts exactly these five
+    // literals; `revalidate` is deliberately outside that union (8.3.2.3) —
+    // this test pins that containment so the two vocabularies cannot drift.
+    const PARSE_ENV_RUN_TYPES = [
+      'discovery',
+      'maintenance',
+      'recheck',
+      'dequarantine',
+      'purge',
+    ] as const
+
+    for (const runType of PARSE_ENV_RUN_TYPES) {
+      expect(GATED_RUN_TYPES).toContain(runType)
+    }
+    expect(GATED_RUN_TYPES.length).toBeGreaterThan(PARSE_ENV_RUN_TYPES.length)
+    expect(GATED_RUN_TYPES).toContain('revalidate')
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** The first of four planned waves for SMI-5879 (edge-twin security-scanner parity). This wave adds a gate-and-freeze safety mechanism to the indexer's five writer scripts, so a security-scanner change can be safely rolled out with a coordinated "change window" — the ability to freeze all indexer writes during a deploy, and to restrict which run-types are allowed at all, both fail-closed by default.

**Quality bar:** Design went through 7 rounds of cross-model (Codex/gpt-5.6-sol) adversarial review before implementation began. This implementation PR itself went through 2 further rounds of cross-model code review, one of which caught a real gap (a duplicated database-client construction that made one of the new safety tests unable to see what it was supposed to be checking) — fixed and re-confirmed. Independently re-verified (not just trusting the implementer's or reviewer's own reports): typecheck/lint/format clean, full `scripts/tests` suite 194 files / 2742 tests passing, `audit:standards` unchanged (0 failures).

**Found along the way:** none new — all findings from review were fixed in this same PR, zero deferred.

**Net result:** Wave 1 of 4 fully shipped. Remaining waves (pattern port + a real under-counting bug fix, a pre-merge validation harness, and a hostile-update-recovery mechanism) are separate follow-up PRs, tracked under SMI-5879.

---

## Technical detail

- New module `scripts/indexer/run-gate.ts`: `assertRunAllowed()` (env-sourced allow-list check) and `assertFreezeMarkerClear()` (DB-sourced freeze-marker check against `audit_logs`, zero new migrations).
- Wired into `run.ts` (env-sourced gate only — its own env-parsing helper already validates run-type) and the three direct-entry host tools (`dequarantine-false-positives.ts`, `purge-dead-quarantines.ts`, `revalidate-stale-quarantines.ts` — both gates, since these can run outside CI's own controls).
- Workflow changes: `.github/workflows/indexer.yml` (freeze-check + allow-list gates as the first steps), `indexer-backfill.yml` (corrected a stale comment), `deploy-edge-functions.yml` (a deployment freeze on the `detect` job's first step).
- 6 new test files under `scripts/tests/indexer/run-gate*.test.ts`: unit coverage for both gate functions, a structural census pinning exactly which files are gated (fails CI if a new writer script is added without wiring the gate), an AST-based statement-ordering check (the gate must run before any side effect, not just be "a" call somewhere in `main()`), a purity check on the env-parsing helper, and a line-budget backstop.
- Code-review fix: `revalidate-stale-quarantines.ts` previously constructed two independent Supabase clients (one just for the gate check, a separate one for the real writes) — collapsed to one, constructed once in `main()` and passed through, so the AST ordering test actually observes the real write path.
- `docs/internal/process/guards-and-opt-outs.md` gains an entry for the new `SKILLSMITH_INDEXER_FREEZE_MARKER_BYPASS` opt-out.

Refs SMI-5879