### PR TITLE
fix(readme): SMI-5913 update stale What's New sections to current versions

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@ Command-line interface for Skillsmith - discover, manage, and author agent skill
 
 ## Contents
 
-- [What's New](#whats-new-in-v082)
+- [What's New](#whats-new-in-v084)
 - [Installation](#installation)
 - [Commands](#commands)
   - [inventory](#inventory)
@@ -14,11 +14,13 @@ Command-line interface for Skillsmith - discover, manage, and author agent skill
 - [Examples](#examples)
 - [Privacy & Data Handling](#privacy--data-handling)
 
-## What's New in v0.8.2
+## What's New in v0.8.4
 
-- **Corrected tier quota display**: Community/Individual/Team quota labels shown by the CLI are reduced 10x (100/mo, 1,000/mo, 10,000/mo respectively) to match actual enforcement — display-only; enforcement lives in `@skillsmith/mcp-server`.
-
-> v0.8.2 is a scheduled cadence release with no functional changes beyond v0.8.1.
+- **`sklx logs --tail` covers doc-retrieval**: now watches the doc-retrieval reindex CLI's structured log surface alongside the other tail-able components.
+- **Enterprise license validation fixed**: license checks now import `@smith-horn/enterprise` (the package's real name) instead of a name that never existed, which had silently broken Enterprise-tier license validation for every install.
+- **Symlinked skill discovery fixed**: a skill installed via a symlinked directory (e.g. `ln -s ~/.claude/skills/foo ~/.cursor/skills/foo`) is now correctly discovered per-harness instead of being silently skipped.
+- **Compliance reports expanded**: `compliance_reports` availability widened from Enterprise-only to Team + Enterprise.
+- **New MCP client support**: Grok Build (`~/.grok/config.toml`) added to the per-client MCP config snippets.
 
 See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,18 +4,19 @@ Core library for Skillsmith - provides database operations, search services, cac
 
 ## Contents
 
-- [What's New](#whats-new-in-v0112)
+- [What's New](#whats-new-in-v0114)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Features](#features)
 - [Exports](#exports)
 
-## What's New in v0.11.2
+## What's New in v0.11.4
 
-- **Cross-session rename revert**: `apply_namespace_rename`'s `action: 'revert'` is now exposed, and `JournalAction`/`JOURNAL_SCHEMA_VERSION` are widened so an older reader no longer flags a legitimate revert journal record as corrupt.
-- **Unified shutdown coordinator**: Awaitable sync stop consolidates shutdown handling across the database and background writers.
-- **Production-grade error logging and diagnostics**: Structured error logging and diagnostics for easier triage in production.
-- **Dependency backfill**: `skill_dependencies` now backfills correctly for installs that predate v0.7.1.
+- **Security scanner false-positive fix**: jailbreak/AI-defence findings now carry an evidence tier instead of a flat severity, so a skill that *documents* these patterns defensively (a security-checklist skill, Skillsmith's own bundled SKILL.md) no longer scores identically to a skill containing an actual attack payload.
+- **Denial-of-service fix**: a regex pattern used in security scanning had catastrophic-backtracking behavior reachable through the public `SecurityScanner.scan()` API with no crafted payload — fixed and verified against a 20,000-case fuzz suite with zero mismatches.
+- **Typosquat/impersonation detection**: new detector for skill names using confusable-character matching, edit-distance, and authority-claiming affixes (e.g. `-official`, `-verified`).
+- **Atomic config writes**: config saves now run under a cross-process exclusive lock with temp-file-then-rename, closing a lost-update race between concurrent writers.
+- **New harness support**: Grok Build (xAI's coding CLI) added to cross-machine skill inventory scanning.
 
 See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -4,12 +4,13 @@
 
 MCP (Model Context Protocol) server for agent skill discovery, installation, and management.
 
-## What's New in v0.7.4
+## What's New in v0.7.6
 
-- **Cross-session rename revert**: `apply_namespace_rename`'s `action: 'revert'` is now exposed, closing the gap where a rename applied in a prior session had no reachable undo path.
-- **Shutdown persistence fix**: Recently-installed skills and dependency data are now correctly persisted on shutdown — previously silently discarded when running without native SQLite support (common on macOS/npx installs).
-- **Corrected quota enforcement**: Local quota limits reduced 10x to match actual tier limits, with a `SKILLSMITH_ENFORCE_MCP_QUOTA` kill-switch to disable hard-blocking without a redeploy.
-- **Subscription tier resolution fix**: Personal API keys now resolve the real subscription tier correctly.
+- **Private registry hardened and made live**: `private_registry_manage`/`private_registry_publish` are now a real implementation backed by Supabase (previously a stub), with `deprecate`/`undeprecate` requiring proper team-admin authentication instead of falling back to an unrestricted service-role client.
+- **Crash resilience**: process-wide handlers now log any unhandled error or rejection to the structured logger (disk + stderr) before exiting, instead of only surfacing in the MCP host's live panel.
+- **Enterprise license validation fixed**: license checks now import `@smith-horn/enterprise` (the package's real name) instead of a name that never existed, which had silently broken Enterprise-tier license validation and audit tools for every install.
+- **Real CycloneDX export**: `compliance_report`'s `cyclonedx` format now emits a genuine CycloneDX 1.5 AI/ML-BOM instead of a hand-rolled document.
+- **Compliance reports expanded**: `compliance_reports` availability widened from Enterprise-only to Team + Enterprise.
 
 See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 


### PR DESCRIPTION
## Business Summary

**What shipped:** Updated the "What's New" sections in 3 package READMEs (`cli`, `core`, `mcp-server`) that had fallen out of sync with their actual released versions — each now reflects real, current release highlights instead of stale content from several versions back.

**Quality bar:** Content summarizes the real CHANGELOG.md deltas since each README's previously-documented version, matching each README's existing bullet style. Lint, typecheck, and format all clean.

**Found along the way:** discovered while landing an unrelated docs-only PR — a CI gate (`audit:standards` Check 60, README currency) had been advisory-only and just crossed its shadow-mode expiration date, so it started hard-failing `Quality Checks` for every PR in the repo, not just ones touching these 3 packages. This fix is urgent because of that blast radius, not because of the READMEs themselves.

**Net result:** Fully shipped. Unblocks CI for every other pending PR in the repo.

---

## Technical detail

Fixes SMI-5913. `packages/cli/README.md`, `packages/core/README.md`, `packages/mcp-server/README.md` — each "What's New in vX.Y.Z" heading and its bullet list updated to the current `package.json` version, content drawn from the package's own `CHANGELOG.md`. README-only, no `src/` changes.

Refs SMI-5913

[skip-impl-check]