### PR TITLE
docs: update README What's New sections for currency (Check 60)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,11 +14,11 @@ Command-line interface for Skillsmith - discover, manage, and author agent skill
 - [Examples](#examples)
 - [Privacy & Data Handling](#privacy--data-handling)
 
-## What's New in v0.8.2
+## What's New in v0.8.4
 
-- **Corrected tier quota display**: Community/Individual/Team quota labels shown by the CLI are reduced 10x (100/mo, 1,000/mo, 10,000/mo respectively) to match actual enforcement — display-only; enforcement lives in `@skillsmith/mcp-server`.
+- **Fix**: `sklx logs --tail` now watches the doc-retrieval reindex CLI's structured log surface, alongside the MCP server and CLI's own logs.
 
-> v0.8.2 is a scheduled cadence release with no functional changes beyond v0.8.1.
+> v0.8.4 also includes a mechanical cadence release (v0.8.3 → v0.8.4) with no additional functional changes.
 
 See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,12 +10,11 @@ Core library for Skillsmith - provides database operations, search services, cac
 - [Features](#features)
 - [Exports](#exports)
 
-## What's New in v0.11.2
+## What's New in v0.11.4
 
-- **Cross-session rename revert**: `apply_namespace_rename`'s `action: 'revert'` is now exposed, and `JournalAction`/`JOURNAL_SCHEMA_VERSION` are widened so an older reader no longer flags a legitimate revert journal record as corrupt.
-- **Unified shutdown coordinator**: Awaitable sync stop consolidates shutdown handling across the database and background writers.
-- **Production-grade error logging and diagnostics**: Structured error logging and diagnostics for easier triage in production.
-- **Dependency backfill**: `skill_dependencies` now backfills correctly for installs that predate v0.7.1.
+- **Evidence-tier security scanning**: jailbreak/`ai_defence` findings now carry an evidence tier (mention / role-turn-with-body / imperative-instruction / instruction-override / state-assertion) instead of a flat severity, closing a false-positive class where a skill that *documents* jailbreak/prompt-injection patterns defensively scored identically to a skill containing an actual attack payload.
+- **Fixed a live production denial-of-service**: `AD_CRLF_INJECTION` no longer has catastrophic-backtracking behavior — an ~80-byte adversarial input could previously hang a scan for hours.
+- **Locality-bounded corroboration**: `escalateCodeExecution` now only escalates to `critical` when its corroborating finding is within 40 lines, matching an existing bound on the sibling escalation mechanism.
 
 See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -4,12 +4,11 @@
 
 MCP (Model Context Protocol) server for agent skill discovery, installation, and management.
 
-## What's New in v0.7.4
+## What's New in v0.7.6
 
-- **Cross-session rename revert**: `apply_namespace_rename`'s `action: 'revert'` is now exposed, closing the gap where a rename applied in a prior session had no reachable undo path.
-- **Shutdown persistence fix**: Recently-installed skills and dependency data are now correctly persisted on shutdown — previously silently discarded when running without native SQLite support (common on macOS/npx installs).
-- **Corrected quota enforcement**: Local quota limits reduced 10x to match actual tier limits, with a `SKILLSMITH_ENFORCE_MCP_QUOTA` kill-switch to disable hard-blocking without a redeploy.
-- **Subscription tier resolution fix**: Personal API keys now resolve the real subscription tier correctly.
+- **Private-registry privilege hardening**: `deprecate`/`undeprecate` actions now require an authenticated user JWT instead of the unrestricted service-role client, closing a gap where any team member's shared license key could deprecate or undeprecate any skill in the team's private registry.
+- **Evidence-tier security scanning**: jailbreak/`ai_defence` findings now carry an evidence tier instead of a flat severity, closing a false-positive class in the scanner shared with `@skillsmith/core`.
+- **Crash resilience**: process-wide `uncaughtException`/`unhandledRejection` handlers now log via the structured logger (disk + stderr) before exiting, instead of a stderr-only crash visible solely in the MCP host's live panel.
 
 See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 


### PR DESCRIPTION
## Business Summary

**What shipped:** The three published packages' README "What's New" sections now match their actual current versions — `cli` (v0.8.2 → v0.8.4), `core` (v0.11.2 → v0.11.4), and `mcp-server` (v0.7.4 → v0.7.6), each with real content pulled from the corresponding CHANGELOG.

**Quality bar:** This is a mechanical currency fix, not new functionality. Verified locally: `audit:standards` Check 60 (README currency) now passes; 0 failures overall.

**Net result:** Done, no follow-up.

---

## Technical detail

Check 60's shadow-mode grace period expired 2026-08-02, converting a warn into a hard fail — this started blocking `Quality Checks` CI for every PR repo-wide, including in-flight, unrelated work (found via SMI-5879 Wave 1, PR #2160). Fixed the 3 stale headings with content summarizing each package's actual recent CHANGELOG entries.

[skip-impl-check]