### PR TITLE
fix(website): SMI-5911 harden remaining JSON-LD blocks against parser breakage

### DIFF
--- a/packages/website/src/pages/account/cli-token.astro
+++ b/packages/website/src/pages/account/cli-token.astro
@@ -21,6 +21,17 @@ import AccountSidebar from '../../components/AccountSidebar.astro'
 import Nav from '../../components/Nav.astro'
 
 const supabaseConfig = getSupabaseConfig()
+
+// SMI-5911: JSON-LD moved into a frontmatter const + set:html={JSON.stringify(...)} to
+// avoid Astro template-parser breakage on a raw `>` inside a future string edit
+// (mirrors the SMI-5902 quickstart.astro fix).
+const webPageSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: 'CLI Token | Skillsmith',
+  url: 'https://www.skillsmith.app/account/cli-token',
+  description: 'Generate a Skillsmith CLI API token',
+}
 ---
 
 <!doctype html>
@@ -45,15 +56,7 @@ const supabaseConfig = getSupabaseConfig()
       window.__SUPABASE_CONFIG__ = supabaseConfig
     </script>
     <!-- JSON-LD: Page metadata -->
-    <script is:inline type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "WebPage",
-        "name": "CLI Token | Skillsmith",
-        "url": "https://www.skillsmith.app/account/cli-token",
-        "description": "Generate a Skillsmith CLI API token"
-      }
-    </script>
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(webPageSchema)} />
     <!-- Enable smooth page transitions (SMI-2066) -->
     <ClientRouter />
   </head>

--- a/packages/website/src/pages/docs/getting-started.astro
+++ b/packages/website/src/pages/docs/getting-started.astro
@@ -1,41 +1,45 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
 import { MCP_CLIENT_SNIPPETS, withApiKey } from '../../lib/mcp-client-snippets';
+
+const howToSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to Configure Skillsmith API Key',
+  description:
+    'Set up your personal API key for higher rate limits and usage tracking on your Skillsmith account dashboard',
+  totalTime: 'PT2M',
+  tool: [
+    {
+      '@type': 'HowToTool',
+      name: 'Skillsmith CLI or MCP server (installed via 5-Minute Setup)',
+    },
+  ],
+  step: [
+    {
+      '@type': 'HowToStep',
+      position: 1,
+      name: 'Generate an API Key',
+      text: 'Create a free account at www.skillsmith.app/signup and visit the CLI Token page to generate your personal API key.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 2,
+      name: 'Configure the Key',
+      text: "Run 'skillsmith login' to store the key securely in your OS keyring, or add it to ~/.skillsmith/config.json or your MCP client settings.",
+    },
+    {
+      '@type': 'HowToStep',
+      position: 3,
+      name: 'Verify Configuration',
+      text: "Ask your assistant 'List available MCP tools' or run 'skillsmith --version' to verify everything is working.",
+    },
+  ],
+};
 ---
 
 <DocsLayout title="Configuration Guide" description="Set up API keys, verify your installation, configure advanced options, and troubleshoot Skillsmith">
-  <script is:inline type="application/ld+json" slot="head">
-  {
-    "@context": "https://schema.org",
-    "@type": "HowTo",
-    "name": "How to Configure Skillsmith API Key",
-    "description": "Set up your personal API key for higher rate limits and usage tracking on your Skillsmith account dashboard",
-    "totalTime": "PT2M",
-    "tool": [
-      { "@type": "HowToTool", "name": "Skillsmith CLI or MCP server (installed via 5-Minute Setup)" }
-    ],
-    "step": [
-      {
-        "@type": "HowToStep",
-        "position": 1,
-        "name": "Generate an API Key",
-        "text": "Create a free account at www.skillsmith.app/signup and visit the CLI Token page to generate your personal API key."
-      },
-      {
-        "@type": "HowToStep",
-        "position": 2,
-        "name": "Configure the Key",
-        "text": "Run 'skillsmith login' to store the key securely in your OS keyring, or add it to ~/.skillsmith/config.json or your MCP client settings."
-      },
-      {
-        "@type": "HowToStep",
-        "position": 3,
-        "name": "Verify Configuration",
-        "text": "Ask your assistant 'List available MCP tools' or run 'skillsmith --version' to verify everything is working."
-      }
-    ]
-  }
-  </script>
+  <script is:inline type="application/ld+json" slot="head" set:html={JSON.stringify(howToSchema)} />
   <h1>Configuration Guide</h1>
 
   <div class="callout">

--- a/packages/website/src/pages/docs/index.astro
+++ b/packages/website/src/pages/docs/index.astro
@@ -1,98 +1,99 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
+
+const techArticleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Skillsmith Documentation',
+  description:
+    'Complete documentation for Skillsmith - AI-powered skill discovery and management for development environments',
+  url: 'https://www.skillsmith.app/docs',
+  author: {
+    '@id': 'https://www.skillsmith.app/#organization',
+  },
+  publisher: {
+    '@type': 'Organization',
+    '@id': 'https://www.skillsmith.app/#organization',
+    name: 'Skillsmith',
+    url: 'https://www.skillsmith.app',
+  },
+  about: {
+    '@type': 'SoftwareApplication',
+    name: 'Skillsmith',
+    applicationCategory: 'DeveloperApplication',
+  },
+  mainEntity: {
+    '@type': 'ItemList',
+    name: 'Documentation Sections',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Quickstart Guide',
+        url: 'https://www.skillsmith.app/docs/quickstart',
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Getting Started',
+        url: 'https://www.skillsmith.app/docs/getting-started',
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: 'CLI Reference',
+        url: 'https://www.skillsmith.app/docs/cli',
+      },
+      {
+        '@type': 'ListItem',
+        position: 4,
+        name: 'MCP Server',
+        url: 'https://www.skillsmith.app/docs/mcp-server',
+      },
+      {
+        '@type': 'ListItem',
+        position: 5,
+        name: 'API Reference',
+        url: 'https://www.skillsmith.app/docs/api',
+      },
+      {
+        '@type': 'ListItem',
+        position: 6,
+        name: 'Security',
+        url: 'https://www.skillsmith.app/docs/security',
+      },
+      {
+        '@type': 'ListItem',
+        position: 7,
+        name: 'Trust Tiers',
+        url: 'https://www.skillsmith.app/docs/trust-tiers',
+      },
+      {
+        '@type': 'ListItem',
+        position: 8,
+        name: 'Quarantine',
+        url: 'https://www.skillsmith.app/docs/quarantine',
+      },
+      {
+        '@type': 'ListItem',
+        position: 9,
+        name: 'Dependencies',
+        url: 'https://www.skillsmith.app/docs/dependencies',
+      },
+      {
+        '@type': 'ListItem',
+        position: 10,
+        name: 'Cross-machine skill inventory',
+        url: 'https://www.skillsmith.app/docs/inventory',
+      },
+    ],
+  },
+};
 ---
 
 <DocsLayout title="Documentation" description="Learn how to use Skillsmith for agent skill discovery and management">
   <!-- JSON-LD Schema -->
-  <script is:inline type="application/ld+json" slot="head">
-  {
-    "@context": "https://schema.org",
-    "@type": "TechArticle",
-    "headline": "Skillsmith Documentation",
-    "description": "Complete documentation for Skillsmith - AI-powered skill discovery and management for development environments",
-    "url": "https://www.skillsmith.app/docs",
-    "author": {
-      "@id": "https://www.skillsmith.app/#organization"
-    },
-    "publisher": {
-      "@type": "Organization",
-      "@id": "https://www.skillsmith.app/#organization",
-      "name": "Skillsmith",
-      "url": "https://www.skillsmith.app"
-    },
-    "about": {
-      "@type": "SoftwareApplication",
-      "name": "Skillsmith",
-      "applicationCategory": "DeveloperApplication"
-    },
-    "mainEntity": {
-      "@type": "ItemList",
-      "name": "Documentation Sections",
-      "itemListElement": [
-        {
-          "@type": "ListItem",
-          "position": 1,
-          "name": "Quickstart Guide",
-          "url": "https://www.skillsmith.app/docs/quickstart"
-        },
-        {
-          "@type": "ListItem",
-          "position": 2,
-          "name": "Getting Started",
-          "url": "https://www.skillsmith.app/docs/getting-started"
-        },
-        {
-          "@type": "ListItem",
-          "position": 3,
-          "name": "CLI Reference",
-          "url": "https://www.skillsmith.app/docs/cli"
-        },
-        {
-          "@type": "ListItem",
-          "position": 4,
-          "name": "MCP Server",
-          "url": "https://www.skillsmith.app/docs/mcp-server"
-        },
-        {
-          "@type": "ListItem",
-          "position": 5,
-          "name": "API Reference",
-          "url": "https://www.skillsmith.app/docs/api"
-        },
-        {
-          "@type": "ListItem",
-          "position": 6,
-          "name": "Security",
-          "url": "https://www.skillsmith.app/docs/security"
-        },
-        {
-          "@type": "ListItem",
-          "position": 7,
-          "name": "Trust Tiers",
-          "url": "https://www.skillsmith.app/docs/trust-tiers"
-        },
-        {
-          "@type": "ListItem",
-          "position": 8,
-          "name": "Quarantine",
-          "url": "https://www.skillsmith.app/docs/quarantine"
-        },
-        {
-          "@type": "ListItem",
-          "position": 9,
-          "name": "Dependencies",
-          "url": "https://www.skillsmith.app/docs/dependencies"
-        },
-        {
-          "@type": "ListItem",
-          "position": 10,
-          "name": "Cross-machine skill inventory",
-          "url": "https://www.skillsmith.app/docs/inventory"
-        }
-      ]
-    }
-  }
-  </script>
+  <script is:inline type="application/ld+json" slot="head" set:html={JSON.stringify(techArticleSchema)} />
 
   <h1>Skillsmith Documentation</h1>
 

--- a/packages/website/src/pages/docs/inventory.astro
+++ b/packages/website/src/pages/docs/inventory.astro
@@ -1,58 +1,57 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
+
+const howToSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to Set Up Cross-Machine Skill Inventory',
+  description:
+    "Push your installed agent skills to your Skillsmith account so you can compare what's installed across every machine and harness you use",
+  totalTime: 'PT5M',
+  tool: [{ '@type': 'HowToTool', name: 'Skillsmith CLI (npm install -g @skillsmith/cli)' }],
+  step: [
+    {
+      '@type': 'HowToStep',
+      position: 1,
+      name: 'Create or sign in to a Skillsmith account',
+      text: 'Create a free account, or sign in if you already have one, at https://www.skillsmith.app.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 2,
+      name: 'Install the CLI',
+      text: "Run 'npm install -g @skillsmith/cli'. Requires Node.js 22.22 or newer.",
+    },
+    {
+      '@type': 'HowToStep',
+      position: 3,
+      name: 'Log in',
+      text: "Run 'skillsmith login' to complete a device login in your browser, linking the CLI to the same account as your web session.",
+    },
+    {
+      '@type': 'HowToStep',
+      position: 4,
+      name: 'Enable cross-machine skill inventory',
+      text: "Visit https://www.skillsmith.app/account/telemetry, turn on 'Cross-machine skill inventory', and press Save.",
+    },
+    {
+      '@type': 'HowToStep',
+      position: 5,
+      name: 'Push your inventory',
+      text: "Run 'skillsmith inventory push'.",
+    },
+    {
+      '@type': 'HowToStep',
+      position: 6,
+      name: 'View your inventory',
+      text: 'Visit https://www.skillsmith.app/account/skills to see the skills installed across your machines.',
+    },
+  ],
+};
 ---
 
 <DocsLayout title="Cross-Machine Skill Inventory" description="See the agent skills installed across every machine and harness you use — opt-in, read-only, and synced from a CLI push">
-  <script is:inline type="application/ld+json" slot="head">
-  {
-    "@context": "https://schema.org",
-    "@type": "HowTo",
-    "name": "How to Set Up Cross-Machine Skill Inventory",
-    "description": "Push your installed agent skills to your Skillsmith account so you can compare what's installed across every machine and harness you use",
-    "totalTime": "PT5M",
-    "tool": [
-      { "@type": "HowToTool", "name": "Skillsmith CLI (npm install -g @skillsmith/cli)" }
-    ],
-    "step": [
-      {
-        "@type": "HowToStep",
-        "position": 1,
-        "name": "Create or sign in to a Skillsmith account",
-        "text": "Create a free account, or sign in if you already have one, at https://www.skillsmith.app."
-      },
-      {
-        "@type": "HowToStep",
-        "position": 2,
-        "name": "Install the CLI",
-        "text": "Run 'npm install -g @skillsmith/cli'. Requires Node.js 22.22 or newer."
-      },
-      {
-        "@type": "HowToStep",
-        "position": 3,
-        "name": "Log in",
-        "text": "Run 'skillsmith login' to complete a device login in your browser, linking the CLI to the same account as your web session."
-      },
-      {
-        "@type": "HowToStep",
-        "position": 4,
-        "name": "Enable cross-machine skill inventory",
-        "text": "Visit https://www.skillsmith.app/account/telemetry, turn on 'Cross-machine skill inventory', and press Save."
-      },
-      {
-        "@type": "HowToStep",
-        "position": 5,
-        "name": "Push your inventory",
-        "text": "Run 'skillsmith inventory push'."
-      },
-      {
-        "@type": "HowToStep",
-        "position": 6,
-        "name": "View your inventory",
-        "text": "Visit https://www.skillsmith.app/account/skills to see the skills installed across your machines."
-      }
-    ]
-  }
-  </script>
+  <script is:inline type="application/ld+json" slot="head" set:html={JSON.stringify(howToSchema)} />
 
   <h1>Cross-Machine Skill Inventory</h1>
 

--- a/packages/website/src/pages/skills/index.astro
+++ b/packages/website/src/pages/skills/index.astro
@@ -39,96 +39,109 @@ const trustTiers = [
 // structured data and card markup intact for GoogleBot et al.
 const userAgent = Astro.request.headers.get('user-agent') ?? ''
 const isCrawler = isCrawlerUserAgent(userAgent)
+
+// SMI-5911: JSON-LD moved into frontmatter consts + set:html={JSON.stringify(...)} to
+// avoid Astro template-parser breakage on a raw `>` inside a future string edit
+// (mirrors the SMI-5902 quickstart.astro fix).
+const collectionPageSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: 'Skillsmith Skills Browser',
+  description: 'Search and discover agent skills. Browse by category and trust tier.',
+  url: 'https://www.skillsmith.app/skills',
+  isPartOf: {
+    '@id': 'https://www.skillsmith.app/#website',
+  },
+  about: {
+    '@type': 'SoftwareApplication',
+    name: 'Agent Skills',
+    applicationCategory: 'DeveloperApplication',
+  },
+  mainEntity: {
+    '@type': 'ItemList',
+    name: 'Skill Categories',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Development',
+        description: 'Skills for software development workflows',
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Integrations',
+        description: 'MCP servers, API integrations, and protocol implementations',
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: 'Testing',
+        description: 'Testing frameworks and utilities',
+      },
+      {
+        '@type': 'ListItem',
+        position: 4,
+        name: 'DevOps',
+        description: 'CI/CD, deployment, and infrastructure skills',
+      },
+      {
+        '@type': 'ListItem',
+        position: 5,
+        name: 'Documentation',
+        description: 'Documentation generation and management',
+      },
+      {
+        '@type': 'ListItem',
+        position: 6,
+        name: 'Productivity',
+        description: 'Workflow automation and productivity tools',
+      },
+      {
+        '@type': 'ListItem',
+        position: 7,
+        name: 'Security',
+        description: 'Security scanning and best practices',
+      },
+    ],
+  },
+}
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Home',
+      item: 'https://www.skillsmith.app/',
+    },
+    {
+      '@type': 'ListItem',
+      position: 2,
+      name: 'Skills',
+      item: 'https://www.skillsmith.app/skills',
+    },
+  ],
+}
 ---
 
 <BaseLayout title="Skills" description="Search and discover agent skills">
   <!-- JSON-LD Schema -->
-  <script is:inline type="application/ld+json" slot="head">
-    {
-      "@context": "https://schema.org",
-      "@type": "CollectionPage",
-      "name": "Skillsmith Skills Browser",
-      "description": "Search and discover agent skills. Browse by category and trust tier.",
-      "url": "https://www.skillsmith.app/skills",
-      "isPartOf": {
-        "@id": "https://www.skillsmith.app/#website"
-      },
-      "about": {
-        "@type": "SoftwareApplication",
-        "name": "Agent Skills",
-        "applicationCategory": "DeveloperApplication"
-      },
-      "mainEntity": {
-        "@type": "ItemList",
-        "name": "Skill Categories",
-        "itemListElement": [
-          {
-            "@type": "ListItem",
-            "position": 1,
-            "name": "Development",
-            "description": "Skills for software development workflows"
-          },
-          {
-            "@type": "ListItem",
-            "position": 2,
-            "name": "Integrations",
-            "description": "MCP servers, API integrations, and protocol implementations"
-          },
-          {
-            "@type": "ListItem",
-            "position": 3,
-            "name": "Testing",
-            "description": "Testing frameworks and utilities"
-          },
-          {
-            "@type": "ListItem",
-            "position": 4,
-            "name": "DevOps",
-            "description": "CI/CD, deployment, and infrastructure skills"
-          },
-          {
-            "@type": "ListItem",
-            "position": 5,
-            "name": "Documentation",
-            "description": "Documentation generation and management"
-          },
-          {
-            "@type": "ListItem",
-            "position": 6,
-            "name": "Productivity",
-            "description": "Workflow automation and productivity tools"
-          },
-          {
-            "@type": "ListItem",
-            "position": 7,
-            "name": "Security",
-            "description": "Security scanning and best practices"
-          }
-        ]
-      }
-    }
-  </script>
+  <script
+    is:inline
+    type="application/ld+json"
+    slot="head"
+    set:html={JSON.stringify(collectionPageSchema)}
+  />
 
-  <script is:inline type="application/ld+json" slot="head">
-    {
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      "itemListElement": [
-        {
-          "@type": "ListItem",
-          "position": 1,
-          "name": "Home",
-          "item": "https://www.skillsmith.app/"
-        },
-        {
-          "@type": "ListItem",
-          "position": 2,
-          "name": "Skills",
-          "item": "https://www.skillsmith.app/skills"
-        }
-      ]
-    }
-  </script>
+  <script
+    is:inline
+    type="application/ld+json"
+    slot="head"
+    set:html={JSON.stringify(breadcrumbSchema)}
+  />
 
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 relative">
     {


### PR DESCRIPTION
## Business Summary

**What shipped:** Proactively hardened 5 more website pages against the same JSON-LD
parsing bug that broke `quickstart.astro` in SMI-5902 — none of these had an active bug yet,
but one (`docs/inventory.astro`) sat one routine text edit away from tripping the identical
failure. All 6 structured-data blocks across those 5 pages now use the same safe pattern
already proven elsewhere in the codebase.

**Quality bar:** Plan reviewed by GPT-5.6-Sol before implementation (caught two real
corrections to the verification approach). Every file's content independently re-verified
against the original — not just trusted from the diff — via a semantic (parsed, not text)
comparison of the built page output before and after the change, including a live
before/after fetch for the one page that's server-rendered rather than statically built.
Final governance review: zero findings.

**Found along the way:** landing this PR surfaced a repo-wide CI gate (`audit:standards`
Check 60, README currency) whose advisory grace period had just expired, blocking every PR
in the repo — fixed separately and already merged (SMI-5913, PR #2175), not part of this
diff.

**Net result:** Fully shipped, no follow-up needed.

---

## Technical detail

Fixes SMI-5911. Converts 6 raw-literal JSON-LD `<script type="application/ld+json">` blocks
across 5 files to the `set:html={JSON.stringify(...)}` pattern from SMI-5902:

- `docs/index.astro` (TechArticle)
- `docs/getting-started.astro` (HowTo)
- `docs/inventory.astro` (HowTo)
- `skills/index.astro` (CollectionPage + BreadcrumbList, 2 blocks)
- `account/cli-token.astro` (WebPage) — SSR-only (`prerender = false`), no `slot="head"`
  since this page builds its own `<head>` directly

**Verification:** `npm run lint`/`astro check` both clean. Semantic JSON diff (parsed, not
text — `JSON.stringify`'s compact output differs textually from the old pretty-printed
literals even with zero content change) between pre- and post-change build output for the 4
static pages, plus a live before/after SSR fetch for `account/cli-token.astro`. Zero content
drift in either direction. A full repo sweep confirms no raw-literal JSON-LD blocks remain
anywhere in the website package.

Plan: `docs/internal/implementation/smi-5911-jsonld-hardening.md`.

Refs SMI-5911
