### PR TITLE
fix(indexer): SMI-5879 Wave 1 post-merge retro — 3 gate infra gaps

### DIFF
--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -318,6 +318,18 @@ jobs:
             echo "::error::Indexer run-type allow-list is engaged (INDEXER_RUN_ALLOWLIST=none) -- refusing run_type=$RUN_TYPE."
             exit 1
           fi
+          # SMI-5879 retro fix: a trailing/leading/doubled comma must fail
+          # closed here exactly as it does in run-gate.ts's isRunTypePermitted
+          # (.split(',') keeps the resulting empty string as a token, which
+          # matches no recognised run type). `IFS=',' read -ra` below silently
+          # drops a trailing empty field, which previously let Gate B permit
+          # on the identical malformed input that Gate C refuses.
+          case "$ALLOWLIST" in
+            ,*|*,|*,,*)
+              echo "::error::INDEXER_RUN_ALLOWLIST=\"$ALLOWLIST\" contains a leading/trailing/doubled comma -- refusing run_type=$RUN_TYPE (fail closed)."
+              exit 1
+              ;;
+          esac
           # Validate every comma-separated token is a recognised run type;
           # an unrecognised token anywhere fails the WHOLE value closed.
           IFS=',' read -ra TOKENS <<< "$ALLOWLIST"
@@ -369,6 +381,12 @@ jobs:
           MAX_REPOS: ${{ github.event.client_payload.max_repos || '100' }}
           CODE_SEARCH_MAX_PAGES: ${{ github.event.client_payload.code_search_max_pages || '1' }}
           RUN_TYPE: ${{ steps.config.outputs.run_type }}
+          # SMI-5879 retro fix: Gate C (assertRunAllowed inside run.ts) reads
+          # this from process.env. Gates A/B already check the same repo
+          # variable earlier in this job, but without this line Gate C was
+          # silently dead code -- run.ts always saw an unset var and permitted
+          # unconditionally, regardless of the real INDEXER_RUN_ALLOWLIST value.
+          INDEXER_RUN_ALLOWLIST: ${{ vars.INDEXER_RUN_ALLOWLIST }}
           STALE_DAYS: ${{ steps.config.outputs.stale_days }}
           CRON_SLOT: ${{ steps.config.outputs.cron_slot }}
           # SMI-4870: empty = full sequential discovery; 1/2/3 = single phase.

--- a/scripts/indexer/dequarantine-false-positives.ts
+++ b/scripts/indexer/dequarantine-false-positives.ts
@@ -181,8 +181,10 @@ export async function processRow(
 }
 
 /** Run the full sweep over every `security_scan`-quarantined row. */
-export async function runSweep(opts: { apply: boolean; limit?: number }): Promise<SweepCounts> {
-  const db = createSupabaseAdminClient()
+export async function runSweep(
+  db: SupabaseClient,
+  opts: { apply: boolean; limit?: number }
+): Promise<SweepCounts> {
   const headers = await buildGitHubHeaders()
 
   let query = db
@@ -292,14 +294,14 @@ async function main(): Promise<void> {
   // trip), then the DB-sourced freeze marker immediately after client
   // construction — see the call-site contract in the design doc (8.3.3.2).
   assertRunAllowed('dequarantine')
-  const gateClient = createSupabaseAdminClient()
-  await assertFreezeMarkerClear(gateClient, 'dequarantine')
+  const db = createSupabaseAdminClient()
+  await assertFreezeMarkerClear(db, 'dequarantine')
   const apply = process.argv.includes('--apply')
   const limitArg = process.argv.find((a) => a.startsWith('--limit'))
   const limit = limitArg
     ? Number(limitArg.split('=')[1] ?? process.argv[process.argv.indexOf(limitArg) + 1])
     : undefined
-  await runSweep({ apply, limit: Number.isFinite(limit) ? limit : undefined })
+  await runSweep(db, { apply, limit: Number.isFinite(limit) ? limit : undefined })
 }
 
 // Run only when invoked directly (not when imported by the test suite).

--- a/scripts/indexer/purge-dead-quarantines.ts
+++ b/scripts/indexer/purge-dead-quarantines.ts
@@ -339,8 +339,7 @@ interface PurgeOptions {
 }
 
 /** Run the purge (dry-run by default). Returns the run counts. */
-export async function runPurge(opts: PurgeOptions): Promise<PurgeCounts> {
-  const db = createSupabaseAdminClient()
+export async function runPurge(db: SupabaseClient, opts: PurgeOptions): Promise<PurgeCounts> {
   const exportPath = opts.exportPath ?? defaultExportPath()
 
   if (opts.apply) {
@@ -447,10 +446,10 @@ async function main(): Promise<void> {
   // trip), then the DB-sourced freeze marker immediately after client
   // construction — see the call-site contract in the design doc (8.3.3.2).
   assertRunAllowed('purge')
-  const gateClient = createSupabaseAdminClient()
-  await assertFreezeMarkerClear(gateClient, 'purge')
+  const db = createSupabaseAdminClient()
+  await assertFreezeMarkerClear(db, 'purge')
   const apply = process.argv.includes('--apply')
-  await runPurge({
+  await runPurge(db, {
     apply,
     limit: parseLimitArg(process.argv),
     exportPath: parseExportArg(process.argv),

--- a/scripts/indexer/run-dequarantine-branch.ts
+++ b/scripts/indexer/run-dequarantine-branch.ts
@@ -43,9 +43,9 @@ export async function runDequarantineBranch(
   requestId: string
 ): Promise<DequarantineBranchResult> {
   const dryRun = env.DEQUARANTINE_DRY_RUN
-  const counts = await runSweep({ apply: !dryRun })
-
   const supabase = createSupabaseAdminClient()
+  const counts = await runSweep(supabase, { apply: !dryRun })
+
   await writeIndexerAuditLog(supabase, counts.errors > 0 ? 'partial' : 'success', {
     requestId,
     topics: [],

--- a/scripts/indexer/run-purge-branch.ts
+++ b/scripts/indexer/run-purge-branch.ts
@@ -48,11 +48,11 @@ export async function runPurgeBranch(
   requestId: string
 ): Promise<PurgeBranchResult> {
   const dryRun = env.PURGE_DRY_RUN
+  const supabase = createSupabaseAdminClient()
   // SMI-5357: PURGE_LIMIT (optional) caps rows per apply for a staged first prod
   // run; undefined = no cap (delete the full dead set).
-  const counts = await runPurge({ apply: !dryRun, limit: env.PURGE_LIMIT })
+  const counts = await runPurge(supabase, { apply: !dryRun, limit: env.PURGE_LIMIT })
 
-  const supabase = createSupabaseAdminClient()
   await writeIndexerAuditLog(supabase, 'success', {
     requestId,
     topics: [],

--- a/scripts/tests/indexer/purge-dead-quarantines.test.ts
+++ b/scripts/tests/indexer/purge-dead-quarantines.test.ts
@@ -291,7 +291,7 @@ describe('runPurge', () => {
     installMockDb({ selectRows: [makeRow({ id: 'a' }), makeRow({ id: 'b' })] })
     const exportPath = join(dir, 'export.csv')
 
-    const counts = await runPurge({ apply: false, exportPath })
+    const counts = await runPurge(mockDb, { apply: false, exportPath })
 
     expect(counts.total).toBe(2)
     expect(counts.deleted).toBe(0)
@@ -308,7 +308,7 @@ describe('runPurge', () => {
     installMockDb({ selectRows: rows })
     const exportPath = join(dir, 'export.csv')
 
-    const counts = await runPurge({ apply: true, exportPath })
+    const counts = await runPurge(mockDb, { apply: true, exportPath })
 
     expect(counts.total).toBe(1200)
     expect(counts.deleted).toBe(1200)
@@ -332,7 +332,11 @@ describe('runPurge', () => {
     const rows = Array.from({ length: 100 }, (_, i) => makeRow({ id: `id-${i}` }))
     installMockDb({ selectRows: rows })
 
-    const counts = await runPurge({ apply: true, limit: 10, exportPath: join(dir, 'e.csv') })
+    const counts = await runPurge(mockDb, {
+      apply: true,
+      limit: 10,
+      exportPath: join(dir, 'e.csv'),
+    })
 
     expect(counts.total).toBe(10)
     expect(counts.deleted).toBe(10)
@@ -345,7 +349,7 @@ describe('runPurge', () => {
     installMockDb({
       selectRows: [makeRow({ id: 'a', quarantine_reason: 'security scan:\ninjected' })],
     })
-    const counts = await runPurge({ apply: true, exportPath: join(dir, 'e.csv') })
+    const counts = await runPurge(mockDb, { apply: true, exportPath: join(dir, 'e.csv') })
     expect(counts.deleted).toBe(1)
     expect(skillDeleteBatches.flat()).toEqual(['a'])
   })

--- a/scripts/tests/indexer/run-dequarantine-branch.test.ts
+++ b/scripts/tests/indexer/run-dequarantine-branch.test.ts
@@ -53,13 +53,13 @@ describe('runDequarantineBranch (SMI-5356)', () => {
   it('DEQUARANTINE_DRY_RUN=true => runSweep apply:false (read-only failsafe)', async () => {
     const res = await runDequarantineBranch(envWith(true), 'req-1')
     expect(runSweepMock).toHaveBeenCalledTimes(1)
-    expect(runSweepMock).toHaveBeenCalledWith({ apply: false })
+    expect(runSweepMock).toHaveBeenCalledWith({ __client: 'mock' }, { apply: false })
     expect(res).toEqual({ dequarantine: sample, dryRun: true })
   })
 
   it('DEQUARANTINE_DRY_RUN=false => runSweep apply:true (deliberate apply)', async () => {
     const res = await runDequarantineBranch(envWith(false), 'req-2')
-    expect(runSweepMock).toHaveBeenCalledWith({ apply: true })
+    expect(runSweepMock).toHaveBeenCalledWith({ __client: 'mock' }, { apply: true })
     expect(res.dryRun).toBe(false)
   })
 
@@ -69,7 +69,7 @@ describe('runDequarantineBranch (SMI-5356)', () => {
       { DEQUARANTINE_DRY_RUN: true, DRY_RUN: false } as unknown as IndexerEnv,
       'req-3'
     )
-    expect(runSweepMock).toHaveBeenCalledWith({ apply: false })
+    expect(runSweepMock).toHaveBeenCalledWith({ __client: 'mock' }, { apply: false })
   })
 
   it('writes a top-level indexer:run audit row carrying the sweep counts', async () => {

--- a/scripts/tests/indexer/run-purge-branch.test.ts
+++ b/scripts/tests/indexer/run-purge-branch.test.ts
@@ -50,13 +50,16 @@ describe('runPurgeBranch (SMI-5357)', () => {
   it('PURGE_DRY_RUN=true => runPurge apply:false (read-only failsafe)', async () => {
     const res = await runPurgeBranch(envWith(true), 'req-1')
     expect(runPurgeMock).toHaveBeenCalledTimes(1)
-    expect(runPurgeMock).toHaveBeenCalledWith({ apply: false })
+    expect(runPurgeMock).toHaveBeenCalledWith({ __client: 'mock' }, { apply: false })
     expect(res).toEqual({ purge: sample, dryRun: true })
   })
 
   it('PURGE_DRY_RUN=false => runPurge apply:true (deliberate apply)', async () => {
     const res = await runPurgeBranch(envWith(false), 'req-2')
-    expect(runPurgeMock).toHaveBeenCalledWith({ apply: true, limit: undefined })
+    expect(runPurgeMock).toHaveBeenCalledWith(
+      { __client: 'mock' },
+      { apply: true, limit: undefined }
+    )
     expect(res.dryRun).toBe(false)
   })
 
@@ -65,13 +68,13 @@ describe('runPurgeBranch (SMI-5357)', () => {
       { PURGE_DRY_RUN: false, PURGE_LIMIT: 100 } as unknown as IndexerEnv,
       'req-limit'
     )
-    expect(runPurgeMock).toHaveBeenCalledWith({ apply: true, limit: 100 })
+    expect(runPurgeMock).toHaveBeenCalledWith({ __client: 'mock' }, { apply: true, limit: 100 })
   })
 
   it('the gate is !PURGE_DRY_RUN, NOT the workflow dry_run input', async () => {
     // Even with DRY_RUN-ish noise on the env, only PURGE_DRY_RUN decides.
     await runPurgeBranch({ PURGE_DRY_RUN: true, DRY_RUN: false } as unknown as IndexerEnv, 'req-3')
-    expect(runPurgeMock).toHaveBeenCalledWith({ apply: false })
+    expect(runPurgeMock).toHaveBeenCalledWith({ __client: 'mock' }, { apply: false })
   })
 
   it('writes a top-level indexer:run audit row carrying the purge counts', async () => {


### PR DESCRIPTION
## Business Summary

**What shipped:** Post-merge retro fixes for the SMI-5879 Wave 1 gate infrastructure (PR #2160). Three real gaps found in the just-merged production quarantine-gate code, fixed immediately: (1) the indexer workflow never actually passed the allow-list value into the step that runs the indexer, so one of the four defense-in-depth gates was silently inert in CI; (2) two of the four gated scripts (dequarantine, purge) still opened a second, separate database connection for their real writes instead of reusing the one the gate check already used — meaning a future refactor could reorder the gate past a write without any test catching it; (3) the workflow's allow-list parser and the script's own parser disagreed on how to handle a malformed value with an extra comma, so the two safety layers could contradict each other on that one edge case.

**Quality bar:** Found by a dedicated post-merge governance retro (mandatory after every PR merge per this repo's process), with every finding independently re-verified against the actual merged code before fixing — not just taken on faith. All three fixes mirror an already-reviewed pattern used elsewhere in the same PR. Full test suite (2742 tests, 194 files) green; typecheck/lint/format/`audit:standards` all clean; the workflow's shell-script fix manually cross-checked against the TypeScript parser to confirm both sides now agree.

**Net result:** All three gaps closed. The gate infrastructure now matches its own design intent (four independent, mutually-consistent layers) rather than three-with-one-silently-dead.

---

## Technical detail

Retro on PR #2160 (squash `23ad52f8a`) surfaced:

1. **Gate C dead in CI** — `.github/workflows/indexer.yml`'s "Run indexer" step never set `INDEXER_RUN_ALLOWLIST` in its own `env:` block (GitHub Actions step `env:` doesn't persist across steps). `run.ts`'s `assertRunAllowed()` always saw `undefined`, which its unset-permits-all default reads as no restriction — regardless of the real repo variable. Mitigated in practice (Gates A/B already enforce the same check earlier in the job) but the documented "A+B+C+D" defense-in-depth was actually only "A+B+D". Fixed by adding the missing env line.

2. **Vacuous ordering test for 2 of 4 gated scripts** — `dequarantine-false-positives.ts` and `purge-dead-quarantines.ts` each constructed a throwaway Supabase client for the freeze-marker gate while `runSweep()`/`runPurge()` separately constructed their own client for the real writes. `run-gate-order.test.ts`'s AST-based ordering assertion could therefore only see the position of the decoy client, not the real write path — reproducing the exact failure mode SMI-5879's design doc (§11.2.7) diagnosed and had already fixed in `revalidate-stale-quarantines.ts`. Fixed identically: `runSweep`/`runPurge` now take the client as a parameter; `main()` constructs exactly one and reuses it for both the gate and the writes (also removes a redundant client construction in `run-dequarantine-branch.ts`/`run-purge-branch.ts`).

3. **Gate B/Gate C disagreement on malformed input** — Gate B's bash (`IFS=',' read -ra`) silently drops a trailing empty field, so `INDEXER_RUN_ALLOWLIST="discovery,"` was permitted by Gate B but refused by `run-gate.ts`'s `.split(',')`-based parser (which keeps the empty token). Fixed with an explicit leading/trailing/doubled-comma rejection ahead of the `IFS` read; manually verified both sides now reject the same five malformed/valid inputs identically.

Files: `.github/workflows/indexer.yml`, `scripts/indexer/{dequarantine-false-positives,purge-dead-quarantines,run-dequarantine-branch,run-purge-branch}.ts`, `scripts/tests/indexer/{purge-dead-quarantines,run-dequarantine-branch,run-purge-branch}.test.ts`.

Refs SMI-5879
