### PR TITLE
chore(codeowners): SMI-4829 sunset strategy-submodule pins (cutover stable 2 weeks)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,14 +17,3 @@ scripts/lib/reserved-ranges.mjs        @wrsmith108
 scripts/check-publish-collision.mjs    @wrsmith108
 scripts/prepare-release.ts             @wrsmith108
 .github/workflows/publish.yml          @wrsmith108
-
-# Strategy submodule mount-points (SMI-4829, gate #5) — pointer bumps and
-# submodule wiring touch repo-wide trust surface. Adds review requirement on
-# the gitlink commits and the .gitmodules / .gitattributes files that govern
-# them. Removable post-stabilization (≥2 weeks clean cutover); see
-# docs/internal/runbooks/smi-4829-strategy-rollback.md for sunset criteria.
-.claude/skills              @wrsmith108
-.claude/plans               @wrsmith108
-.claude/hive-mind           @wrsmith108
-.gitmodules                 @wrsmith108
-.gitattributes              @wrsmith108

--- a/scripts/audit-git-crypt-remediation-helpers.mjs
+++ b/scripts/audit-git-crypt-remediation-helpers.mjs
@@ -17,6 +17,13 @@
  *   - .git/, node_modules/, dist/, .worktrees/, .git-crypt/ (binary/VCS
  *     internals, or a nested worktree checkout that duplicates this
  *     repo's own history under a gitignored path)
+ *   - .beads/ (gitignored NEEDLE/bead-forge dispatch trace transcripts,
+ *     scripts/needle/README.md -- generated, local-only workspace state, not
+ *     reviewable source. A trace can legitimately echo CLAUDE.md's own
+ *     git-crypt troubleshooting prose verbatim (which describes the banned
+ *     pattern, same rationale as this file's own self-exemption below),
+ *     producing a host-history-dependent false positive in any worktree
+ *     that's ever run a Codex dispatch, found live 2026-08-06)
  *   - .ruvector/ (the local skillsmith-doc-retrieval semantic-search index,
  *     gitignored and never present in CI -- its embeddings payload verbatim-
  *     copies chunked text from indexed docs, including historical snippets
@@ -56,6 +63,7 @@ const EXCLUDED_DIR_NAMES = new Set([
   'dist',
   '.worktrees',
   '.git-crypt',
+  '.beads',
   '.ruvector',
 ])
 


### PR DESCRIPTION
## Business Summary

**What shipped:** Removed the temporary CODEOWNERS review-requirement pins added during the SMI-4829 strategy-submodule cutover — the cutover has been stable for 3 months, well past the runbook's own 2-week sunset window. The rollback runbook is archived (kept, not deleted, per its own instructions) with its stale "pin is active" claims marked historical.

**Quality bar:** GPT-5.6-Sol (cross-provider) code review on both the CODEOWNERS/runbook diff and a small unrelated test-infra fix found along the way — both reviewed clean. Evidence gathered before sunsetting: no rollback PR was ever opened, current submodule state is clean (no drift), no GitHub issue/PR reports a contributor blocked by submodule-init failures. Two of the runbook's five rollback triggers (historical indexer-count steadiness, whether a force-push ever hit the strategy repo) could not be independently verified — no retained telemetry or reliable retroactive signal exists for either — and that gap is stated explicitly in the archived runbook rather than papered over.

**Found along the way:** while testing this branch, `scripts/tests/git-crypt-remediation-strings.test.ts` failed for an unrelated reason — it scans the whole repo tree and had no exclusion for `.beads/` (gitignored NEEDLE dispatch trace output), so any worktree that's ever run a Codex code review trips a false positive. Fixed in this PR (one Set entry in the shared helper, reviewed separately and confirmed safe) rather than deferred, since it was blocking this push and would block any future one from an affected worktree.

**Net result:** Fully shipped. SMI-4829 and SMI-4850 both ready to move to Done once this merges.

---

## Technical detail

**Files**:
- `.github/CODEOWNERS` — removed the 5-line "Strategy submodule mount-points" pin block (`.claude/skills`, `.claude/plans`, `.claude/hive-mind`, `.gitmodules`, `.gitattributes`, all `@wrsmith108`).
- `docs/internal` gitlink — bumped to the already-merged runbook-archive commit (`docs/internal` PR #635, `2428e44`).
- `scripts/audit-git-crypt-remediation-helpers.mjs` — added `.beads` to `EXCLUDED_DIR_NAMES`; this helper backs both `audit:standards` Check 61 and its executable twin (T11 test), so one change fixes both.

**Evidence trail**: full investigation and both GPT-5.6-Sol review verdicts (NEEDLE beads `bf-2l8` and `bf-19x`) are recorded as comments on [SMI-4850](https://linear.app/smith-horn-group/issue/SMI-4850/smi-4829-sunset-remove-strategy-codeowners-pin-archive-runbook).

## Ticket

[SMI-4850](https://linear.app/smith-horn-group/issue/SMI-4850/smi-4829-sunset-remove-strategy-codeowners-pin-archive-runbook)