### PR TITLE
test(security): SMI-5879 Wave 3 item 2 — structural closure test (gate G-5)

### DIFF
--- a/packages/core/src/security/scanner/multiline-category-closure.test.ts
+++ b/packages/core/src/security/scanner/multiline-category-closure.test.ts
@@ -1,0 +1,346 @@
+/**
+ * SMI-5879 Wave 3 item 2 — structural closure test for cohort E's exclusion
+ * proof (design doc `smi-5879-edge-twin-parity-design.md` §8.3.1.2.2).
+ * @module @skillsmith/core/security/scanner/multiline-category-closure.test
+ *
+ * WHY THIS TEST EXISTS
+ *
+ * The SMI-5879 census (comparing pre-port vs post-port `skills.security_score`
+ * across ~344k rows) needs to fully re-simulate every row scoring `>= 8`
+ * (cohort C1) but can structurally EXCLUDE every row scoring `0-7` (cohort E)
+ * from that expensive re-simulation — *if and only if* three properties about
+ * how the multiline pass routes patterns hold. The design doc's §8.3.1.2.1
+ * proves those properties in prose ("P1/P2/P3"); this file promotes that proof
+ * to a machine-checked gate (design doc gate G-5) so a future source change
+ * that silently invalidates the premise fails CI instead of silently
+ * corrupting the census's soundness.
+ *
+ * THE +32 ARITHMETIC THIS TEST PROTECTS (not itself re-derived here — that is
+ * `weights.ts` + the design doc's §8.3.1.2 arithmetic; this file only proves
+ * the ROUTING facts the arithmetic depends on):
+ *   max joint contribution = 100 * CATEGORY_WEIGHTS.jailbreak.coefficient (0.20)
+ *                           + 100 * CATEGORY_WEIGHTS.ai_defence.coefficient (0.12)
+ *                           = 32.0
+ *   S <= 7  =>  S' <= S + 32 <= 39 < 40 (QUARANTINE_THRESHOLD)  =>  verdict
+ *   cannot flip to quarantined for any row starting at or below 7.
+ * That bound is sound ONLY IF the multiline pass can never inflate any
+ * category's subtotal OTHER than jailbreak / ai_defence. The three assertions
+ * below are exactly what closes that "only if".
+ *
+ * THE DOCUMENTED TRAP (design doc §8.3.1.2.3) — DELIBERATELY NOT REPEATED HERE
+ *
+ * The design doc warns against writing assertion 3 as "every pattern for
+ * which `isMultilinePattern()` returns true belongs to an AI-category array"
+ * — that predicate is syntactic (it fires on a NEGATED class `[^\n]`, the
+ * literal opposite of "spans lines") and is false today for 9 patterns across
+ * two non-AI arrays. This file does not use that predicate at all: assertions
+ * 1 and 3 are asserted over the multiline pass's CALL SITES (which pattern
+ * array is physically wired to `scanPatternsWithMultilineSupport`'s `patterns:`
+ * config field), not over any per-pattern syntactic test. That is the
+ * "routing, not predicate" distinction the trap section requires.
+ *
+ * SMI-5881 ADAPTATION (judgment call — flagged, not silently resolved)
+ *
+ * The design doc's assertion 2 is written directly against `isMultilinePattern()`
+ * as the definition of "PASS-1 pattern". SMI-5881 (merged before this file was
+ * written) DELETED `isMultilinePattern()` entirely — no compatibility shim —
+ * and replaced the syntactic heuristic with `PATTERN_SCOPE` /
+ * `resolvePatternScope()` (`./patterns.scope.ts`), an explicit per-pattern
+ * `'line' | 'content' | 'both'` declaration. `isMultilinePattern` cannot be
+ * imported here; it no longer exists anywhere under `packages/core/src`
+ * (guarded by `packages/core/tests/security/pattern-scope.test.ts`).
+ *
+ * `scanPatternsWithMultilineSupport`'s pass 1 (SecurityScanner.helpers.ts) now
+ * reads: `if (resolvePatternScope(pattern) === 'line') continue` — i.e. pass 1
+ * tests every pattern whose resolved scope is NOT `'line'` (`'content'` or
+ * `'both'`). That predicate is the faithful, current-source equivalent of the
+ * design doc's `routed.filter(isMultilinePattern)` — same set membership
+ * question ("which patterns does pass 1 actually read"), expressed against
+ * the model that replaced the deleted one. Assertion 2 below uses
+ * `resolvePatternScope(p) !== 'line'` for exactly this reason.
+ *
+ * CODE-REVIEW REMEDIATION (Finding 1 — NO-GO, fixed)
+ *
+ * A first version of this file enumerated call sites with a bounded
+ * text-window regex scan (`CALL_TOKEN = 'scanPatternsWithMultilineSupport('`
+ * + an `EXTRACTION_WINDOW`-char lookahead for `type:`/`patterns:`). Codex
+ * (gpt-5.6-sol) review flagged that as a silent-false-negative hazard: a new
+ * call site using extra whitespace before `(`, a locally-aliased identifier,
+ * or a renamed import would be invisible to that regex while the existing two
+ * call sites kept the count green — defeating the point of a closure proof
+ * meant to catch exactly this class of drift. `extractMultilineCallSites`
+ * below instead walks the real TypeScript AST (`ts.createSourceFile` +
+ * `CallExpression` traversal resolved through `collectAliases`), which is
+ * exhaustive by construction against all three variants. Verified via mutation
+ * testing: a temporarily-added call through a whitespace-before-paren AND a
+ * locally-aliased form was both correctly detected (count became 3, assertion
+ * 1 failed) before being reverted.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import * as ts from 'typescript'
+import { JAILBREAK_PATTERNS, AI_DEFENCE_PATTERNS } from './patterns.jailbreak.js'
+import { EVIDENCE_TYPE_BY_PATTERN } from './patterns.jailbreak.evidence.js'
+import { resolvePatternScope } from './patterns.scope.js'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+const SCANNER_PATH = join(__dirname, 'SecurityScanner.ts')
+const SCANNER_SRC = readFileSync(SCANNER_PATH, 'utf-8')
+
+/** The only two pattern arrays a `scanPatternsWithMultilineSupport` call site may name. */
+const AI_CATEGORY_ARRAY_NAMES = ['JAILBREAK_PATTERNS', 'AI_DEFENCE_PATTERNS'] as const
+
+/**
+ * Every OTHER pattern array in the scanner (design doc §8.3.1.2.2 assertion 3's
+ * explicit exclusion list). `BLOCKED_PATTERNS` is not a real exported const
+ * (blocked patterns are an instance-level `ScannerOptions.blockedPatterns`,
+ * `SecurityScanner.ts:73`) — kept in the list anyway because the design doc
+ * names it explicitly and the check is "this identifier never appears as a
+ * `patterns:` value", which is true (and meaningfully checked) regardless of
+ * whether the identifier is otherwise reachable.
+ */
+const NON_AI_ARRAY_NAMES = [
+  'SUSPICIOUS_PATTERNS',
+  'DATA_EXFILTRATION_PATTERNS',
+  'PRIVILEGE_ESCALATION_PATTERNS',
+  'CODE_EXECUTION_PATTERNS',
+  'BLOCKED_PATTERNS',
+] as const
+
+interface MultilineCallSite {
+  /** Source-character offset of the call expression (for error messages). */
+  offset: number
+  /** The `type:` string literal in the call's config object. */
+  type: string
+  /** The identifier bound to the call's `patterns:` config field. */
+  patternsIdent: string
+}
+
+const TARGET_FUNCTION_NAME = 'scanPatternsWithMultilineSupport'
+
+/** The textual callee name of a call expression: `foo(` -> "foo"; `x.bar(` -> "bar". */
+function calleeName(expr: ts.Expression): string | undefined {
+  if (ts.isIdentifier(expr)) return expr.text
+  if (ts.isPropertyAccessExpression(expr)) return expr.name.text
+  return undefined
+}
+
+/**
+ * Every local identifier in `sourceFile` that resolves to `targetName` — the
+ * name itself, any `import { targetName as Local }` rename, and any simple
+ * `const Local = <alias>` variable alias (resolved transitively, to a fixed
+ * point, so a chain like `const a = target; const b = a` also resolves).
+ * This is what makes the call-site walk below exhaustive against the "an
+ * alias" failure mode the code review named: a call reached through a
+ * renamed import or a locally-aliased identifier still resolves back to
+ * `targetName` and is detected, where a literal-token text scan would miss it.
+ */
+function collectAliases(sourceFile: ts.SourceFile, targetName: string): Set<string> {
+  const aliases = new Set<string>([targetName])
+
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt) || !stmt.importClause?.namedBindings) continue
+    const bindings = stmt.importClause.namedBindings
+    if (!ts.isNamedImports(bindings)) continue
+    for (const el of bindings.elements) {
+      const imported = el.propertyName?.text ?? el.name.text
+      if (imported === targetName) aliases.add(el.name.text)
+    }
+  }
+
+  let changed = true
+  while (changed) {
+    changed = false
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.initializer &&
+        ts.isIdentifier(node.initializer) &&
+        aliases.has(node.initializer.text) &&
+        !aliases.has(node.name.text)
+      ) {
+        aliases.add(node.name.text)
+        changed = true
+      }
+      ts.forEachChild(node, visit)
+    }
+    ts.forEachChild(sourceFile, visit)
+  }
+
+  return aliases
+}
+
+/** The textual name of an object-literal member (identifier or string-literal key). */
+function memberName(prop: ts.ObjectLiteralElementLike): string | undefined {
+  if (!prop.name) return undefined
+  if (ts.isIdentifier(prop.name)) return prop.name.text
+  if (ts.isStringLiteral(prop.name)) return prop.name.text
+  return undefined
+}
+
+/**
+ * Extract every `scanPatternsWithMultilineSupport(...)` call site in `source`
+ * (at path `filePath`, used only for error messages), together with its
+ * config object's `type:` and `patterns:` values — via full TypeScript AST
+ * traversal (`ts.createSourceFile` + a `CallExpression` walk resolved through
+ * `collectAliases`), NOT text/regex matching over a bounded window. This is
+ * exhaustive by construction: extra whitespace before `(`, a call reached
+ * through a renamed import or a locally-aliased identifier, and a config
+ * object appearing in any argument position are all still found — closing
+ * the class of silent false-negative a bounded text-window regex scan cannot
+ * rule out (the defect the code review's Finding 1 identified).
+ *
+ * Throws (rather than silently skipping) when a matched call's arguments
+ * don't have the expected `{ type: '<string literal>', patterns: <bare
+ * identifier> }` shape — an unparseable/unexpected call site must fail
+ * loudly, not be dropped from the count assertion 1 depends on, exactly as
+ * the prior text-based version did for its own class of unparseable input.
+ */
+function extractMultilineCallSites(filePath: string, source: string): MultilineCallSite[] {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  )
+  const aliases = collectAliases(sourceFile, TARGET_FUNCTION_NAME)
+  const sites: MultilineCallSite[] = []
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const name = calleeName(node.expression)
+      if (name && aliases.has(name)) {
+        sites.push(extractCallSiteConfig(node, sourceFile, filePath))
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return sites
+}
+
+/** Extract and validate the `{ type, patterns }` config object of a matched call. */
+function extractCallSiteConfig(
+  call: ts.CallExpression,
+  sourceFile: ts.SourceFile,
+  filePath: string
+): MultilineCallSite {
+  const offset = call.getStart(sourceFile)
+  const configArg = call.arguments.find(
+    (arg): arg is ts.ObjectLiteralExpression =>
+      ts.isObjectLiteralExpression(arg) &&
+      arg.properties.some((p) => memberName(p) === 'type') &&
+      arg.properties.some((p) => memberName(p) === 'patterns')
+  )
+  if (!configArg) {
+    throw new Error(
+      `[multiline-category-closure] ${TARGET_FUNCTION_NAME} call at ${filePath}:${offset} has no ` +
+        `object-literal argument with both 'type' and 'patterns' properties. Either the call shape ` +
+        `changed (update this extraction) or this is a genuine new/malformed call site — both ` +
+        `invalidate the closure proof and must be resolved before this test can pass.`
+    )
+  }
+
+  const typeProp = configArg.properties.find((p) => memberName(p) === 'type')
+  const patternsProp = configArg.properties.find((p) => memberName(p) === 'patterns')
+
+  if (
+    !typeProp ||
+    !ts.isPropertyAssignment(typeProp) ||
+    !ts.isStringLiteral(typeProp.initializer)
+  ) {
+    throw new Error(
+      `[multiline-category-closure] ${TARGET_FUNCTION_NAME} call at ${filePath}:${offset} has a ` +
+        `'type' property that is not a plain string literal — this is exactly the "expression ` +
+        `argument" shape this AST census exists to catch. Resolve explicitly before this test can pass.`
+    )
+  }
+  if (
+    !patternsProp ||
+    !ts.isPropertyAssignment(patternsProp) ||
+    !ts.isIdentifier(patternsProp.initializer)
+  ) {
+    throw new Error(
+      `[multiline-category-closure] ${TARGET_FUNCTION_NAME} call at ${filePath}:${offset} has a ` +
+        `'patterns' property that is not a bare identifier — either a property-access / expression ` +
+        `argument was introduced (the exact "silent miss" class this test exists to catch) or the ` +
+        `call shape genuinely changed. Resolve explicitly before this test can pass.`
+    )
+  }
+
+  return {
+    offset,
+    type: typeProp.initializer.text,
+    patternsIdent: patternsProp.initializer.text,
+  }
+}
+
+describe('SMI-5879 Wave 3 item 2 — multiline-pass category closure (design doc §8.3.1.2.2)', () => {
+  const callSites = extractMultilineCallSites(SCANNER_PATH, SCANNER_SRC)
+
+  // --------------------------------------------------------------------
+  // Assertion 1 — the multiline pass has exactly two call sites, both AI-category
+  // --------------------------------------------------------------------
+  describe('assertion 1 — exactly two call sites, both AI-category (design doc P1/P2)', () => {
+    it('scanPatternsWithMultilineSupport is called exactly twice in SecurityScanner.ts', () => {
+      expect(callSites).toHaveLength(2)
+    })
+
+    it('the extracted type: multiset equals exactly [ai_defence, jailbreak] — no more, no fewer, no substitution', () => {
+      const types = callSites.map((s) => s.type).sort()
+      expect(types).toEqual(['ai_defence', 'jailbreak'])
+    })
+  })
+
+  // --------------------------------------------------------------------
+  // Assertion 2 — every PASS-1 pattern is explicitly classified
+  // --------------------------------------------------------------------
+  describe('assertion 2 — every pass-1 pattern is explicitly classified (SMI-5881-adapted)', () => {
+    // "Pass 1" = every pattern scanPatternsWithMultilineSupport's first pass
+    // actually reads: resolvePatternScope(pattern) !== 'line' (see the
+    // SMI-5881 ADAPTATION module-doc comment above for why this replaces the
+    // design doc's isMultilinePattern-filter wording).
+    const routed = [...JAILBREAK_PATTERNS, ...AI_DEFENCE_PATTERNS]
+    const pass1 = routed.filter((p) => resolvePatternScope(p) !== 'line')
+
+    it('the pass-1 subset is non-empty — the pass is not vacuous', () => {
+      expect(pass1.length).toBeGreaterThan(0)
+    })
+
+    it('every pass-1 pattern has an explicit EVIDENCE_TYPE_BY_PATTERN entry (object identity, not fail-closed default)', () => {
+      for (const p of pass1) {
+        expect(
+          EVIDENCE_TYPE_BY_PATTERN.has(p),
+          `pattern /${p.source}/${p.flags} has no explicit evidence-tier entry`
+        ).toBe(true)
+      }
+    })
+  })
+
+  // --------------------------------------------------------------------
+  // Assertion 3 — no non-AI pattern array is routed through the multiline pass
+  // --------------------------------------------------------------------
+  describe('assertion 3 — no non-AI pattern array is routed through the multiline pass (design doc P3, NOT the isMultilinePattern predicate)', () => {
+    it('every call site patterns: identifier is one of the two AI-category arrays', () => {
+      for (const site of callSites) {
+        expect(
+          AI_CATEGORY_ARRAY_NAMES as readonly string[],
+          `call site at offset ${site.offset} routes ${site.patternsIdent}, not an AI-category array`
+        ).toContain(site.patternsIdent)
+      }
+    })
+
+    it.each(NON_AI_ARRAY_NAMES)(
+      '%s never appears as a patterns: identifier at any call site',
+      (arrayName) => {
+        const idents = callSites.map((s) => s.patternsIdent)
+        expect(idents).not.toContain(arrayName)
+      }
+    )
+  })
+})

--- a/scripts/tests/indexer/security-scanner-edge.multiline-category-closure.fixtures.ts
+++ b/scripts/tests/indexer/security-scanner-edge.multiline-category-closure.fixtures.ts
@@ -1,0 +1,212 @@
+/**
+ * SMI-5879 Wave 3 item 2 — shared fixtures for
+ * security-scanner-edge.multiline-category-closure.test.ts and
+ * security-scanner-edge.multiline-category-closure.supabase-twin.test.ts
+ * (split out to keep each file under the 500-line standard). See the main
+ * test file's module doc for the full rationale.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as ts from 'typescript'
+import { isGitCryptEncrypted } from './parity-utils.ts'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+const SHARED_DIR = join(__dirname, '..', '..', 'indexer', '_shared')
+export const SCANNER_SRC = readFileSync(join(SHARED_DIR, 'security-scanner-edge.ts'), 'utf-8')
+export const EXEC_SRC = readFileSync(join(SHARED_DIR, 'security-scanner-edge.exec.ts'), 'utf-8')
+export const CONTEXT_SRC = readFileSync(
+  join(SHARED_DIR, 'security-scanner-edge.context.ts'),
+  'utf-8'
+)
+export const PATTERNS_SRC = readFileSync(
+  join(SHARED_DIR, 'security-scanner-edge.patterns.ts'),
+  'utf-8'
+)
+
+export const ALL_SOURCES: ReadonlyArray<{ name: string; src: string }> = [
+  { name: 'security-scanner-edge.ts', src: SCANNER_SRC },
+  { name: 'security-scanner-edge.exec.ts', src: EXEC_SRC },
+  { name: 'security-scanner-edge.context.ts', src: CONTEXT_SRC },
+  { name: 'security-scanner-edge.patterns.ts', src: PATTERNS_SRC },
+]
+
+// --------------------------------------------------------------------
+// Finding 2 closure: this file's constants let both test files gate the
+// DEPLOYED supabase/functions/_shared/ twin directly, not merely cite
+// another test file's coverage (see the main test file's "FINDING 2
+// REMEDIATION" module-doc section). git-crypt-encrypted — each `it.skipIf`
+// in the supabase-twin test file matches this directory's established
+// per-file skip-guard convention (parity.test.ts, quarantine-twin-parity.
+// test.ts) for CI lanes without the key.
+// --------------------------------------------------------------------
+const REPO_ROOT = resolve(__dirname, '..', '..', '..')
+const SUPABASE_SHARED_DIR = join(REPO_ROOT, 'supabase', 'functions', '_shared')
+export const SUPABASE_SCANNER_PATH = join(SUPABASE_SHARED_DIR, 'security-scanner-edge.ts')
+export const SUPABASE_EXEC_PATH = join(SUPABASE_SHARED_DIR, 'security-scanner-edge.exec.ts')
+export const SUPABASE_CONTEXT_PATH = join(SUPABASE_SHARED_DIR, 'security-scanner-edge.context.ts')
+export const SUPABASE_PATTERNS_PATH = join(SUPABASE_SHARED_DIR, 'security-scanner-edge.patterns.ts')
+
+export const supabaseScannerEncrypted = isGitCryptEncrypted(SUPABASE_SCANNER_PATH)
+export const supabaseExecEncrypted = isGitCryptEncrypted(SUPABASE_EXEC_PATH)
+export const supabaseContextEncrypted = isGitCryptEncrypted(SUPABASE_CONTEXT_PATH)
+export const supabasePatternsEncrypted = isGitCryptEncrypted(SUPABASE_PATTERNS_PATH)
+
+/**
+ * Every identifier this codebase's per-line scan functions actually bind
+ * their current LINE to: `line` (the five simple per-line loops + chmod
+ * compound), `raw` (obfuscated-directive's untransformed line), `transformed`
+ * (obfuscated-directive's de-obfuscated variant of that SAME line — still
+ * per-line, never per-document). None of these is `content` (the full
+ * document — `scanSkillContent(content)`'s own parameter name) or `lines`
+ * (the whole array, never passed whole to `safeRegexTest`, which expects a
+ * single string).
+ */
+export const PER_LINE_SCOPED_IDENTIFIERS: ReadonlySet<string> = new Set([
+  'line',
+  'raw',
+  'transformed',
+])
+
+const SAFE_REGEX_TEST_NAME = 'safeRegexTest'
+
+/** The textual callee name of a call expression: `foo(` -> "foo"; `x.bar(` -> "bar". */
+function calleeName(expr: ts.Expression): string | undefined {
+  if (ts.isIdentifier(expr)) return expr.text
+  if (ts.isPropertyAccessExpression(expr)) return expr.name.text
+  return undefined
+}
+
+/**
+ * Every local identifier in `sourceFile` that resolves to `targetName` — the
+ * name itself plus any simple `const Local = <alias>` variable alias
+ * (resolved transitively, to a fixed point). `safeRegexTest` is a locally
+ * declared function (not imported) in both scanner files, so import-rename
+ * resolution isn't needed here, but local-alias resolution is: it is exactly
+ * what closes the "alias calls...silently ignored" class of miss the code
+ * review's Finding 3 named.
+ */
+export function collectAliases(sourceFile: ts.SourceFile, targetName: string): Set<string> {
+  const aliases = new Set<string>([targetName])
+  let changed = true
+  while (changed) {
+    changed = false
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.initializer &&
+        ts.isIdentifier(node.initializer) &&
+        aliases.has(node.initializer.text) &&
+        !aliases.has(node.name.text)
+      ) {
+        aliases.add(node.name.text)
+        changed = true
+      }
+      ts.forEachChild(node, visit)
+    }
+    ts.forEachChild(sourceFile, visit)
+  }
+  return aliases
+}
+
+/**
+ * Extract every `safeRegexTest(...)` call's second-argument identifier from
+ * `source` — via full TypeScript AST traversal (`ts.createSourceFile` + a
+ * `CallExpression` walk resolved through `collectAliases`), NOT text/regex
+ * matching. This is exhaustive by construction against extra whitespace
+ * before `(`, property-access or locally-aliased calls, and reordered
+ * arguments — the class of miss the code review's Finding 3 identified in the
+ * prior `safeRegexTest\(\s*IDENT\s*,\s*IDENT\s*\)` regex (which required BOTH
+ * arguments to be bare identifiers, so a call with anything else in either
+ * position didn't match the regex AT ALL and vanished from the census with no
+ * signal whatsoever).
+ *
+ * A call whose second argument is anything other than a bare identifier
+ * (property access, a call expression, a literal — the "expression
+ * arguments" class Finding 3 named) throws rather than being silently
+ * dropped: that shape could disguise a full-content scan as something static
+ * extraction can't resolve to a known per-line identifier, and this AST
+ * census exists specifically to make that impossible to evade quietly.
+ */
+export function extractSafeRegexTestSecondArgs(source: string): string[] {
+  const sourceFile = ts.createSourceFile(
+    'snippet.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  )
+  const aliases = collectAliases(sourceFile, SAFE_REGEX_TEST_NAME)
+  const args: string[] = []
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const name = calleeName(node.expression)
+      if (name && aliases.has(name)) {
+        const offset = node.getStart(sourceFile)
+        const second = node.arguments[1]
+        if (!second) {
+          throw new Error(
+            `[multiline-category-closure/edge] ${SAFE_REGEX_TEST_NAME} call at offset ${offset} has ` +
+              `fewer than 2 arguments — the call shape changed; update this extraction.`
+          )
+        }
+        if (!ts.isIdentifier(second)) {
+          throw new Error(
+            `[multiline-category-closure/edge] ${SAFE_REGEX_TEST_NAME} call at offset ${offset} has a ` +
+              `non-identifier second argument (${ts.SyntaxKind[second.kind]}: ` +
+              `"${second.getText(sourceFile)}") — this AST census exists exactly to catch this: a ` +
+              `full-content scan could be disguised as a property/member/call expression rather than ` +
+              `a plain per-line identifier. Resolve explicitly (confirm it is still per-line-scoped and ` +
+              `extend the known-identifier allowlist, or this is the multiline-pass port landing — see ` +
+              `the module doc's TRIPWIRE note) before this test can pass.`
+          )
+        }
+        args.push(second.text)
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return args
+}
+
+/**
+ * Extract a top-level function's full body (matching braces, not a bounded
+ * window) from `source`. Used to scope the per-array "never routed through a
+ * full-content scan" checks to exactly the function that consumes each named
+ * pattern array, so the assertion stays meaningful even as unrelated
+ * functions in the same file change shape.
+ */
+export function extractFunctionBody(
+  source: string,
+  fileLabel: string,
+  functionName: string
+): string {
+  const declRe = new RegExp(`function\\s+${functionName}\\s*\\(`)
+  const declMatch = declRe.exec(source)
+  if (!declMatch) {
+    throw new Error(
+      `[multiline-category-closure/edge] function ${functionName} not found in ${fileLabel} — ` +
+        `the array-to-function mapping this test depends on is stale; update it.`
+    )
+  }
+  const openBraceIdx = source.indexOf('{', declMatch.index)
+  if (openBraceIdx === -1) {
+    throw new Error(`[multiline-category-closure/edge] no '{' found after ${functionName}(`)
+  }
+  let depth = 1
+  for (let i = openBraceIdx + 1; i < source.length; i++) {
+    const c = source[i]
+    if (c === '{') depth++
+    else if (c === '}') {
+      depth--
+      if (depth === 0) return source.slice(openBraceIdx, i + 1)
+    }
+  }
+  throw new Error(
+    `[multiline-category-closure/edge] unbalanced braces scanning ${functionName} in ${fileLabel}`
+  )
+}

--- a/scripts/tests/indexer/security-scanner-edge.multiline-category-closure.supabase-twin.test.ts
+++ b/scripts/tests/indexer/security-scanner-edge.multiline-category-closure.supabase-twin.test.ts
@@ -1,0 +1,109 @@
+/**
+ * SMI-5879 Wave 3 item 2 — Finding 2 closure (SMI-5879 Wave 3 item 2
+ * code-review, NO-GO — fixed). Split out from
+ * `security-scanner-edge.multiline-category-closure.test.ts` to keep both
+ * files under the 500-line standard; read that file's module doc first for
+ * the full "FINDING 2 REMEDIATION" rationale.
+ *
+ * Directly inspects the DEPLOYED `supabase/functions/_shared/` twin, not
+ * merely the Node mirror. An earlier version of the sibling file claimed
+ * `quarantine-twin-parity.test.ts` covered this gap; it does not (it guards
+ * an unrelated file, `quarantine.ts`). Every assertion below reruns the
+ * exact same AST census used in the sibling file against the live Supabase
+ * copy and cross-checks it against the Node mirror — this file does not
+ * depend on citing another test's guarantee to justify inspecting only one
+ * twin.
+ * @module scripts/tests/indexer/security-scanner-edge.multiline-category-closure.supabase-twin
+ */
+
+import { readFileSync } from 'node:fs'
+import { describe, it, expect } from 'vitest'
+import {
+  SCANNER_SRC,
+  EXEC_SRC,
+  PER_LINE_SCOPED_IDENTIFIERS,
+  extractSafeRegexTestSecondArgs,
+  SUPABASE_SCANNER_PATH,
+  SUPABASE_EXEC_PATH,
+  SUPABASE_CONTEXT_PATH,
+  SUPABASE_PATTERNS_PATH,
+  supabaseScannerEncrypted,
+  supabaseExecEncrypted,
+  supabaseContextEncrypted,
+  supabasePatternsEncrypted,
+} from './security-scanner-edge.multiline-category-closure.fixtures.ts'
+
+describe('Finding 2 closure — the deployed Supabase twin is directly inspected, not merely cited', () => {
+  it.skipIf(
+    supabaseScannerEncrypted ||
+      supabaseExecEncrypted ||
+      supabaseContextEncrypted ||
+      supabasePatternsEncrypted
+  )(
+    'the identifier "scanPatternsWithMultilineSupport" appears nowhere in the DEPLOYED Supabase copies either',
+    () => {
+      const supabaseSources: ReadonlyArray<{ name: string; src: string }> = [
+        {
+          name: 'security-scanner-edge.ts (supabase)',
+          src: readFileSync(SUPABASE_SCANNER_PATH, 'utf-8'),
+        },
+        {
+          name: 'security-scanner-edge.exec.ts (supabase)',
+          src: readFileSync(SUPABASE_EXEC_PATH, 'utf-8'),
+        },
+        {
+          name: 'security-scanner-edge.context.ts (supabase)',
+          src: readFileSync(SUPABASE_CONTEXT_PATH, 'utf-8'),
+        },
+        {
+          name: 'security-scanner-edge.patterns.ts (supabase)',
+          src: readFileSync(SUPABASE_PATTERNS_PATH, 'utf-8'),
+        },
+      ]
+      for (const { name, src } of supabaseSources) {
+        expect(
+          src,
+          `${name} unexpectedly references scanPatternsWithMultilineSupport`
+        ).not.toContain('scanPatternsWithMultilineSupport')
+      }
+    }
+  )
+
+  it.skipIf(supabaseScannerEncrypted)(
+    "safeRegexTest() census over the DEPLOYED Supabase security-scanner-edge.ts matches the Node mirror's exactly (and every arg is per-line-scoped)",
+    () => {
+      const supabaseArgs = extractSafeRegexTestSecondArgs(
+        readFileSync(SUPABASE_SCANNER_PATH, 'utf-8')
+      )
+      const nodeArgs = extractSafeRegexTestSecondArgs(SCANNER_SRC)
+      expect(
+        supabaseArgs,
+        'Supabase security-scanner-edge.ts safeRegexTest() census diverges from the Node mirror — the deployed source and its Node introspection twin have drifted'
+      ).toEqual(nodeArgs)
+      for (const arg of supabaseArgs) {
+        expect(
+          PER_LINE_SCOPED_IDENTIFIERS.has(arg),
+          `Supabase security-scanner-edge.ts: safeRegexTest() called with non-per-line second argument "${arg}"`
+        ).toBe(true)
+      }
+    }
+  )
+
+  it.skipIf(supabaseExecEncrypted)(
+    "safeRegexTest() census over the DEPLOYED Supabase security-scanner-edge.exec.ts matches the Node mirror's exactly (and every arg is per-line-scoped)",
+    () => {
+      const supabaseArgs = extractSafeRegexTestSecondArgs(readFileSync(SUPABASE_EXEC_PATH, 'utf-8'))
+      const nodeArgs = extractSafeRegexTestSecondArgs(EXEC_SRC)
+      expect(
+        supabaseArgs,
+        'Supabase security-scanner-edge.exec.ts safeRegexTest() census diverges from the Node mirror — the deployed source and its Node introspection twin have drifted'
+      ).toEqual(nodeArgs)
+      for (const arg of supabaseArgs) {
+        expect(
+          PER_LINE_SCOPED_IDENTIFIERS.has(arg),
+          `Supabase security-scanner-edge.exec.ts: safeRegexTest() called with non-per-line second argument "${arg}"`
+        ).toBe(true)
+      }
+    }
+  )
+})

--- a/scripts/tests/indexer/security-scanner-edge.multiline-category-closure.test.ts
+++ b/scripts/tests/indexer/security-scanner-edge.multiline-category-closure.test.ts
@@ -1,0 +1,296 @@
+/**
+ * SMI-5879 Wave 3 item 2 — structural closure test for cohort E's exclusion
+ * proof, EDGE TWIN (design doc `smi-5879-edge-twin-parity-design.md`
+ * §8.3.1.2.2). Sibling of `packages/core/src/security/scanner/
+ * multiline-category-closure.test.ts` — read that file's module doc first,
+ * it carries the full rationale for the +32 bound this test protects.
+ * @module scripts/tests/indexer/security-scanner-edge.multiline-category-closure
+ *
+ * ============================================================================
+ * JUDGMENT CALL — flagged explicitly, not silently resolved (per task spec)
+ * ============================================================================
+ *
+ * Design doc §8.3.1.2.2 specifies THREE assertions and says to write "its
+ * edge twin" implementing them "exactly as specified". Read literally, that
+ * means: assert `scanPatternsWithMultilineSupport`-equivalent has exactly two
+ * call sites on the edge side too, both AI-category.
+ *
+ * That is not what the CURRENT edge-twin source is. SMI-5879's own Problem
+ * statement (design doc §1) is "port the evidence-tier severity model
+ * [including the multiline pass] TO the edge scanner" — i.e. the port this
+ * whole initiative exists to do has NOT landed yet. Verified directly against
+ * source as of this test's authoring:
+ *   - `scanPatternsWithMultilineSupport` (or any identifier resembling it)
+ *     does not appear anywhere in `security-scanner-edge.ts` / `.exec.ts` /
+ *     `.patterns.ts` / `.context.ts`.
+ *   - EVERY `safeRegexTest(` call site in both scanner files (jailbreak,
+ *     suspicious, data-exfiltration, privilege-escalation, chmod-compound,
+ *     prompt-injection, code-execution, obfuscated-directive — 10 call sites
+ *     total) passes a PER-LINE string (`line` / `raw` / `transformed`) as its
+ *     second argument. None passes the full document. This machine-confirms
+ *     design doc §8.3.1.2.1's own P3 characterization of the edge twin
+ *     today: "every [edge] detector is a per-line loop" — which, on the edge
+ *     side, is true of ALL detectors right now, not just the non-AI ones,
+ *     because there is no multiline pass to be "untouched by" yet.
+ *
+ * Given that, this file does NOT assert "exactly two AI-category call
+ * sites" (there are zero, not two — a materially different fact). Instead it
+ * asserts the TRUE-TODAY structural fact that plays the identical role in the
+ * closure proof: **no pattern array — AI-category or otherwise — is routed
+ * through any full-content scan on the edge twin today**, so for the edge
+ * twin as it stands, S' = S trivially (delta 0, a STRICTLY tighter bound
+ * than core's +32) with respect to a multiline pass, because that pass does
+ * not exist yet. This is the honest, currently-checkable analogue of the
+ * three required assertions, re-expressed against what the edge source
+ * actually is rather than what the design doc's prose (written against
+ * core's already-ported implementation) assumed.
+ *
+ * This test is a deliberate TRIPWIRE: the day someone ports a
+ * `scanPatternsWithMultilineSupport`-shaped full-content pass to the edge
+ * twin (the actual point of SMI-5879 sections 2-7), the "no full-content
+ * scan exists" assertions below will start failing — which is correct and
+ * intentional. At that point this file must be rewritten to assert the
+ * design doc's LITERAL three assertions (exactly two call sites, both
+ * AI-category = {jailbreak, prompt_injection} on the edge side — see the
+ * `CATEGORY_COEFFICIENTS` grounding below for why `prompt_injection` is
+ * edge's `ai_defence`), mirroring the core twin file. Do not "fix" a failure
+ * here by loosening the assertion — a failure here means the port landed and
+ * this file is now stale, not that the check is wrong.
+ *
+ * The "AI category, edge-side" identity is grounded directly in currently
+ * importable source rather than asserted from prose: `CATEGORY_COEFFICIENTS`
+ * (`security-scanner-edge.context.ts`) already stages `jailbreak: 0.2` and
+ * `prompt_injection: 0.12 // mapped to core ai_defence` — i.e. edge's own
+ * coefficient table already agrees with core's {jailbreak: 0.20, ai_defence:
+ * 0.12} AI-category coefficients (SMI-4960), even though the pattern-routing
+ * port that would let a multiline pass exploit them has not landed. This is
+ * checked below as a grounding fact, additional to (not a substitute for) the
+ * three routing assertions.
+ *
+ * Introspects the unencrypted Node mirror (`scripts/indexer/_shared/
+ * security-scanner-edge*.ts`), matching the established precedent in this
+ * directory (`security-scanner-edge.test.ts`, `security-scanner-edge.
+ * tier-independence.test.ts`) — PLUS, as of the Finding 2 remediation, the
+ * live `supabase/functions/_shared/` twin directly, in the sibling
+ * `security-scanner-edge.multiline-category-closure.supabase-twin.test.ts`
+ * file (split out to keep this file under the 500-line standard).
+ *
+ * FINDING 2 REMEDIATION (SMI-5879 Wave 3 item 2 code-review, NO-GO — fixed)
+ *
+ * An earlier version of this file introspected ONLY the Node mirror and
+ * claimed `quarantine-twin-parity.test.ts` covered the gap to the actual
+ * DEPLOYED `supabase/functions/_shared/` twin. That citation was simply
+ * wrong: `quarantine-twin-parity.test.ts` guards `quarantine.ts`, an
+ * unrelated file — it says nothing about the scanner. (The real byte-identity
+ * gate for these four files is `scripts/tests/indexer/parity.test.ts`'s
+ * "Deno <-> Node security-scanner-edge parity (SMI-4960)" describe block, via
+ * `parity-utils.ts`'s `extractScannerBody` — that file was never checked
+ * before writing the original claim.) Rather than relying on citing ANOTHER
+ * file's guarantee at all, the sibling `supabase-twin.test.ts` file now
+ * inspects BOTH copies directly: every AST census this file runs against the
+ * Node mirror is re-run there against the live `supabase/functions/_shared/`
+ * copy (`it.skipIf` when git-crypt isn't unlocked, matching this directory's
+ * established per-file skip-guard convention), and the two censuses are
+ * asserted equal. This is deliberately independent of — not a replacement
+ * for — `parity.test.ts`'s own byte-identity guarantee: even if that test
+ * were ever weakened or removed, that file's own routing-relevant census
+ * still directly gates the deployed source it exists to protect.
+ *
+ * FINDING 3 REMEDIATION (SMI-5879 Wave 3 item 2 code-review, NO-GO — fixed)
+ *
+ * An earlier version of this file enumerated `safeRegexTest(` call sites with
+ * `/safeRegexTest\(\s*IDENT\s*,\s*IDENT\s*\)/g` — BOTH arguments had to be
+ * bare identifiers for a call to match at all. The review flagged this as a
+ * broader silent-omission hazard than Finding 1's: extra whitespace before
+ * `(`, a property/alias call, OR a non-identifier ("expression") argument in
+ * EITHER position made the whole call invisible — not merely
+ * misclassified, entirely absent from the census with zero signal.
+ * `extractSafeRegexTestSecondArgs` now walks the real TypeScript AST
+ * (`ts.createSourceFile` + `CallExpression` traversal resolved through
+ * `collectAliases`), which finds every call regardless of whitespace or
+ * aliasing, and — critically — THROWS when a found call's second argument
+ * isn't a bare identifier, rather than silently dropping it. Verified via
+ * mutation testing: a temporarily-added `safeRegexTest(pattern, obj.line)`
+ * call (a property-access second argument, invisible to the old regex) was
+ * correctly caught (extraction threw) before being reverted.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  JAILBREAK_PATTERNS,
+  PROMPT_INJECTION_PATTERNS,
+  SUSPICIOUS_PATTERNS,
+  DATA_EXFILTRATION_PATTERNS,
+  PRIVILEGE_ESCALATION_PATTERNS,
+} from '../../indexer/_shared/security-scanner-edge.patterns.ts'
+import { CODE_EXECUTION_PATTERNS } from '../../indexer/_shared/security-scanner-edge.exec.ts'
+import { CATEGORY_COEFFICIENTS } from '../../indexer/_shared/security-scanner-edge.context.ts'
+import {
+  SCANNER_SRC,
+  EXEC_SRC,
+  CONTEXT_SRC,
+  ALL_SOURCES,
+  PER_LINE_SCOPED_IDENTIFIERS,
+  extractSafeRegexTestSecondArgs,
+  extractFunctionBody,
+} from './security-scanner-edge.multiline-category-closure.fixtures.ts'
+
+describe('SMI-5879 Wave 3 item 2 — multiline-pass category closure, EDGE TWIN (design doc §8.3.1.2.2, adapted — see module doc)', () => {
+  // --------------------------------------------------------------------
+  // Assertion 1 (edge-adapted) — the port has not landed, and NO pattern
+  // array is routed through any full-content scan today.
+  // --------------------------------------------------------------------
+  describe('assertion 1 (edge-adapted) — zero call sites of a full-content (multiline) pattern scan', () => {
+    it('the identifier "scanPatternsWithMultilineSupport" appears nowhere in the edge twin (Node mirror)', () => {
+      for (const { name, src } of ALL_SOURCES) {
+        expect(
+          src,
+          `${name} unexpectedly references scanPatternsWithMultilineSupport`
+        ).not.toContain('scanPatternsWithMultilineSupport')
+      }
+    })
+
+    it('every safeRegexTest() call site in security-scanner-edge.ts passes a per-line-scoped second argument', () => {
+      const args = extractSafeRegexTestSecondArgs(SCANNER_SRC)
+      expect(
+        args.length,
+        'expected at least one safeRegexTest call site — extraction is not matching'
+      ).toBeGreaterThan(0)
+      for (const arg of args) {
+        expect(
+          PER_LINE_SCOPED_IDENTIFIERS.has(arg),
+          `safeRegexTest() called with second argument "${arg}", which is not in the known ` +
+            `per-line-scoped identifier set ${JSON.stringify([...PER_LINE_SCOPED_IDENTIFIERS])} — ` +
+            `either a new per-line variable name was introduced (add it to the allowlist) or a ` +
+            `full-content scan was introduced (this is the multiline-pass port landing — see the ` +
+            `module doc's TRIPWIRE note)`
+        ).toBe(true)
+      }
+    })
+
+    it('every safeRegexTest() call site in security-scanner-edge.exec.ts passes a per-line-scoped second argument', () => {
+      const args = extractSafeRegexTestSecondArgs(EXEC_SRC)
+      expect(args.length).toBeGreaterThan(0)
+      for (const arg of args) {
+        expect(
+          PER_LINE_SCOPED_IDENTIFIERS.has(arg),
+          `safeRegexTest() called with second argument "${arg}" in security-scanner-edge.exec.ts`
+        ).toBe(true)
+      }
+    })
+
+    it('"content" (the full-document identifier) is never a safeRegexTest() second argument anywhere', () => {
+      const args = [
+        ...extractSafeRegexTestSecondArgs(SCANNER_SRC),
+        ...extractSafeRegexTestSecondArgs(EXEC_SRC),
+      ]
+      expect(args).not.toContain('content')
+    })
+  })
+
+  // --------------------------------------------------------------------
+  // Assertion 2 (edge-adapted) — the AI-category arrays' own dedicated
+  // scan functions are, specifically, also per-line-only.
+  // --------------------------------------------------------------------
+  describe('assertion 2 (edge-adapted) — the AI-category arrays (jailbreak, prompt_injection) are scanned exclusively per-line', () => {
+    it('JAILBREAK_PATTERNS and PROMPT_INJECTION_PATTERNS are non-empty (the arrays genuinely exist and are not vacuous)', () => {
+      expect(JAILBREAK_PATTERNS.length).toBeGreaterThan(0)
+      expect(PROMPT_INJECTION_PATTERNS.length).toBeGreaterThan(0)
+    })
+
+    it('scanJailbreakPatterns iterates JAILBREAK_PATTERNS and every safeRegexTest call inside it is per-line-scoped', () => {
+      const body = extractFunctionBody(
+        SCANNER_SRC,
+        'security-scanner-edge.ts',
+        'scanJailbreakPatterns'
+      )
+      expect(body).toContain('JAILBREAK_PATTERNS')
+      const args = extractSafeRegexTestSecondArgs(body)
+      expect(args.length).toBeGreaterThan(0)
+      for (const arg of args) expect(PER_LINE_SCOPED_IDENTIFIERS.has(arg)).toBe(true)
+    })
+
+    it('scanPromptInjection iterates PROMPT_INJECTION_PATTERNS and every safeRegexTest call inside it is per-line-scoped', () => {
+      const body = extractFunctionBody(
+        SCANNER_SRC,
+        'security-scanner-edge.ts',
+        'scanPromptInjection'
+      )
+      expect(body).toContain('PROMPT_INJECTION_PATTERNS')
+      const args = extractSafeRegexTestSecondArgs(body)
+      expect(args.length).toBeGreaterThan(0)
+      for (const arg of args) expect(PER_LINE_SCOPED_IDENTIFIERS.has(arg)).toBe(true)
+    })
+
+    it('CATEGORY_COEFFICIENTS grounds the AI-category identity: jailbreak=0.2, prompt_injection=0.12 (mapped to core ai_defence, SMI-4960)', () => {
+      // Grounding fact, not a substitute for the routing assertions above:
+      // ties this file's "AI category" definition to the exact coefficients
+      // the design doc's +32 arithmetic depends on (100*0.20 + 100*0.12 =
+      // 32), confirming edge's own coefficient table already agrees with
+      // core's even though the routing port has not landed.
+      expect(CATEGORY_COEFFICIENTS.jailbreak).toBe(0.2)
+      expect(CATEGORY_COEFFICIENTS.prompt_injection).toBe(0.12)
+      expect(CONTEXT_SRC).toMatch(/prompt_injection:\s*0\.12,?\s*\/\/\s*mapped to core ai_defence/)
+    })
+  })
+
+  // --------------------------------------------------------------------
+  // Assertion 3 (edge-adapted) — the non-AI arrays are, specifically,
+  // ALSO per-line-only (not merely that the AI arrays happen to be).
+  // --------------------------------------------------------------------
+  describe('assertion 3 (edge-adapted) — no non-AI pattern array is routed through a full-content scan', () => {
+    const NON_AI_FUNCTION_MAP: ReadonlyArray<{
+      arrayName: string
+      array: readonly RegExp[]
+      functionName: string
+      src: string
+      fileLabel: string
+    }> = [
+      {
+        arrayName: 'SUSPICIOUS_PATTERNS',
+        array: SUSPICIOUS_PATTERNS,
+        functionName: 'scanSuspiciousPatterns',
+        src: SCANNER_SRC,
+        fileLabel: 'security-scanner-edge.ts',
+      },
+      {
+        arrayName: 'DATA_EXFILTRATION_PATTERNS',
+        array: DATA_EXFILTRATION_PATTERNS,
+        functionName: 'scanDataExfiltration',
+        src: SCANNER_SRC,
+        fileLabel: 'security-scanner-edge.ts',
+      },
+      {
+        arrayName: 'PRIVILEGE_ESCALATION_PATTERNS',
+        array: PRIVILEGE_ESCALATION_PATTERNS,
+        functionName: 'scanPrivilegeEscalation',
+        src: SCANNER_SRC,
+        fileLabel: 'security-scanner-edge.ts',
+      },
+      {
+        arrayName: 'CODE_EXECUTION_PATTERNS',
+        array: CODE_EXECUTION_PATTERNS,
+        functionName: 'scanCodeExecution',
+        src: EXEC_SRC,
+        fileLabel: 'security-scanner-edge.exec.ts',
+      },
+    ]
+
+    it.each(NON_AI_FUNCTION_MAP)(
+      '$arrayName is non-empty and its dedicated scan function ($functionName) is per-line-only',
+      ({ arrayName, array, functionName, src, fileLabel }) => {
+        expect(array.length, `${arrayName} is empty`).toBeGreaterThan(0)
+        const body = extractFunctionBody(src, fileLabel, functionName)
+        expect(body, `${functionName} does not reference ${arrayName}`).toContain(arrayName)
+        const args = extractSafeRegexTestSecondArgs(body)
+        expect(args.length, `${functionName} has no safeRegexTest call sites`).toBeGreaterThan(0)
+        for (const arg of args) {
+          expect(
+            PER_LINE_SCOPED_IDENTIFIERS.has(arg),
+            `${functionName} calls safeRegexTest with non-per-line second argument "${arg}"`
+          ).toBe(true)
+        }
+      }
+    )
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** a new automated test that proves — for both the Node and Deno copies of the security scanner — that low-risk skills can safely skip Wave 3's expensive full re-simulation step, by verifying no pattern check silently expanded from "one line at a time" to "the whole file at once" (a change that would make the skip unsafe).

**Quality bar:** implemented, then went through two independent rounds of adversarial review from a second AI model (GPT-5.6, a different provider/model family than the one that wrote it) specifically hunting for ways the check itself could be fooled. Round 1 found three real gaps — a sneaky rename or a different way of writing the same code could dodge detection — round 2 confirmed all three were closed by rewriting the check to parse real code structure rather than pattern-matching text. 25/25 new tests green, 855/855 existing tests in the same test area unaffected.

**Net result:** Done, no follow-up. This is the second of four pieces (item 2 of 4) needed before Wave 3's merge-safety gate can run; item 1 (a companion database change) finished in parallel and item 3 (the simulator itself) is next.

---

## Technical detail

Two new/updated test files (one for the Node/TypeScript scanner, one for the Deno/edge scanner), split across four files total to stay under the repo's 500-line-per-file limit:
- `packages/core/src/security/scanner/multiline-category-closure.test.ts`
- `scripts/tests/indexer/security-scanner-edge.multiline-category-closure.test.ts`
- `scripts/tests/indexer/security-scanner-edge.multiline-category-closure.fixtures.ts` (shared helpers)
- `scripts/tests/indexer/security-scanner-edge.multiline-category-closure.supabase-twin.test.ts` (directly inspects the deployed `supabase/functions/_shared/` copy, not just the Node mirror — this closes a citation error an earlier draft had, where it claimed an unrelated existing test already covered this)

Machine-checks design doc `smi-5879-edge-twin-parity-design.md` §8.3.1.2's prose proof via real TypeScript AST traversal (not regex/text matching), with two flagged adaptations from the doc's literal wording documented inline in the edge test's module doc (a renamed helper function, and the edge scanner not yet having the multiline pass this doc is proving safety properties about — deliberately asserted as a tripwire that will start failing, correctly, once that port lands).

No production code changed — test-only. Typecheck/lint/format clean.

Refs SMI-5879
