### PR TITLE
feat(indexer): SMI-5879 Wave 3 item 3 — the pre-merge simulator

### DIFF
--- a/scripts/indexer/smi5879-fetch-retry.ts
+++ b/scripts/indexer/smi5879-fetch-retry.ts
@@ -1,0 +1,131 @@
+/**
+ * SMI-5879 Wave 3 item 3, tier 1: per-fetch retry wrapper with full-jitter backoff.
+ * @module scripts/indexer/smi5879-fetch-retry
+ *
+ * Plan: docs/internal/implementation/smi-5879-wave3-census-simulation-plan.md §3b (tier 1)
+ * Design: docs/internal/implementation/smi-5879-edge-twin-parity-design.md §8.2.3
+ *
+ * `withBackoff` (`_shared/rate-limit.ts:120-138`) only retries a thrown
+ * `RateLimitError` — but `fetchSiblingContent` (`skill-processor.security.ts`)
+ * and `fetchSkillMd` (`_shared/skill-md-fetch.ts`) both return `null`/`{kind:
+ * 'transient'}` for every transient failure class (429, oversized, non-ok,
+ * network error) and never throw for those cases, so `withBackoff` cannot be
+ * applied to either directly. Changing `withBackoff` itself to accommodate
+ * them would alter the retry behaviour of every live indexer fetch path that
+ * already depends on its current contract — out of scope and explicitly
+ * forbidden by the Wave 3 plan. This module is therefore a sibling helper,
+ * NOT a modification of `_shared/rate-limit.ts` (verified unmodified by
+ * `smi5879-fetch-retry.test.ts`'s source-diff assertion).
+ *
+ * Contract (plan §3b):
+ *  - `{ content }` / `{ removed: true }` return immediately — never retried. A
+ *    404 is a *positive absence* signal, not a failure.
+ *  - `null` (or a thrown `RateLimitError`) is retried. Wait is full jitter:
+ *    `random(0, min(maxMs, baseMs × 2^attempt))` — the AWS "Exponential
+ *    Backoff and Jitter" formulation, chosen over equal/decorrelated jitter
+ *    because ~314K sequential retries against one host benefit most from
+ *    maximum dispersion.
+ *  - Retry exhaustion returns a distinguished `{ exhausted: true, lastStatus }`
+ *    — NEVER collapses back to a bare `null`, which would be indistinguishable
+ *    from a first-attempt failure to tier-2 outcome classification.
+ *
+ * `fetchSiblingContent`'s own return shape (`{content}|{removed:true}|null`)
+ * carries no HTTP status on its `null` case, so this module's `attempt`
+ * parameter is typed against that exact shape and callers who DO have a
+ * status to report (the primary `fetchSkillMd` path, whose `transient` kind
+ * carries one) pass it via the optional `captureStatus` callback rather than
+ * this module inventing a fourth return variant that `fetchSiblingContent`
+ * itself doesn't have — see `smi5879-simulate-full.helpers.ts` for that
+ * adapter.
+ */
+
+import { RateLimitError } from './_shared/rate-limit.ts'
+
+/** The exact shape `fetchSiblingContent` (skill-processor.security.ts) returns. */
+export type RetryableFetchResult = { content: string } | { removed: true } | null
+
+export interface FetchRetryOptions {
+  /** Max retry attempts after the first. Default 5. */
+  maxRetries?: number
+  /** Base backoff, ms. Default 1000. */
+  baseMs?: number
+  /** Backoff ceiling, ms. Default 60_000. */
+  maxMs?: number
+  /** Invoked before each wait with the 1-indexed attempt number and computed wait. */
+  onRetry?: (attempt: number, waitMs: number) => void
+  /**
+   * Invoked immediately after a `null`/retryable-throw attempt to capture an
+   * HTTP status for the eventual `{ exhausted: true, lastStatus }` result.
+   * `fetchSiblingContent` itself carries no status on `null`, so this is
+   * `undefined` for sibling fetches and populated by the primary-fetch
+   * adapter, which does have one (`SkillMdFetch`'s `transient.status`).
+   */
+  captureStatus?: () => number | undefined
+}
+
+export type FetchRetryOutcome =
+  | { content: string }
+  | { removed: true }
+  | { exhausted: true; lastStatus: number | null }
+
+export const DEFAULT_MAX_RETRIES = 5
+export const DEFAULT_BASE_MS = 1000
+export const DEFAULT_MAX_MS = 60_000
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Full-jitter wait for a given 0-indexed attempt: `random(0, min(maxMs, baseMs * 2^attempt))`. */
+export function fullJitterWaitMs(attempt: number, baseMs: number, maxMs: number): number {
+  const cap = Math.min(maxMs, baseMs * 2 ** attempt)
+  return Math.random() * cap
+}
+
+/**
+ * Wrap a `fetchSiblingContent`/`fetchSkillMd`-shaped attempt with full-jitter
+ * retry. See module header for the exact contract. `attempt` may either
+ * resolve to `RetryableFetchResult` or throw a `RateLimitError` (the shape
+ * `_shared/rate-limit.ts`'s `withRateLimitTracking` throws on 403/429 when
+ * `_throwOnRateLimit` isn't disabled) — both are treated as retryable
+ * signals, handled entirely within this module without depending on
+ * `withBackoff`.
+ */
+export async function withFetchRetry(
+  attempt: () => Promise<RetryableFetchResult>,
+  options: FetchRetryOptions = {}
+): Promise<FetchRetryOutcome> {
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
+  const baseMs = options.baseMs ?? DEFAULT_BASE_MS
+  const maxMs = options.maxMs ?? DEFAULT_MAX_MS
+
+  let lastStatus: number | null = null
+
+  for (let i = 0; i <= maxRetries; i++) {
+    let result: RetryableFetchResult
+    try {
+      result = await attempt()
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        lastStatus = err.status
+        result = null
+      } else {
+        // Not a retryable-shaped error — a genuine bug in the caller, not a
+        // transient fetch condition. Propagate rather than silently retrying
+        // (and eventually masking) an unrelated failure.
+        throw err
+      }
+    }
+
+    if (result !== null) return result // { content } or { removed: true } — immediate, never retried
+
+    const captured = options.captureStatus?.()
+    if (captured !== undefined) lastStatus = captured
+
+    if (i === maxRetries) break
+
+    const waitMs = fullJitterWaitMs(i, baseMs, maxMs)
+    options.onRetry?.(i + 1, waitMs)
+    await sleep(waitMs)
+  }
+
+  return { exhausted: true, lastStatus }
+}

--- a/scripts/indexer/smi5879-simulate-full.baseline.ts
+++ b/scripts/indexer/smi5879-simulate-full.baseline.ts
@@ -1,0 +1,124 @@
+/**
+ * Pre-port baseline materialization for smi5879-simulate-full.ts.
+ * @module scripts/indexer/smi5879-simulate-full.baseline
+ *
+ * Design doc §8.2.3: "The baseline (pre-port) twin set is materialised into a
+ * temp directory via a git-show of the merge-base commit and dynamically
+ * imported at runtime... A feature flag inside the scanner was rejected — a
+ * runtime branch in a production quarantine gate is a worse artifact than a
+ * build-time import."
+ *
+ * The pinned commit is PR-2192a's own squash SHA (`b4368d04522993cab01b4026592f0bfb857a124d`,
+ * "feat(indexer): SMI-5879 PR-2192a extract scanSkillBundle from
+ * validateSkillMd (#2213)") — per the plan's PR-2192a interaction note, the
+ * baseline must postdate PR-2192a's extraction so BOTH the post-port and
+ * pre-port scans can call the identical `scanSkillBundle(...)` signature; an
+ * earlier baseline would still have the inline enumerate-fetch-scan-merge
+ * loop and no comparable entry point at all.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type { ScanSkillBundleFn } from './smi5879-simulate-full.types.ts'
+
+/** PR-2192a's own squash SHA — see module header. Confirmed a real, reachable ancestor commit. */
+export const BASELINE_COMMIT_SHA = 'b4368d04522993cab01b4026592f0bfb857a124d'
+
+/**
+ * Files the pre-port `scanSkillBundle` closure needs, resolved at the pinned
+ * commit. Kept to the minimal transitive set `skill-processor.security.ts`
+ * imports rather than the whole `scripts/indexer/` tree, so materialization
+ * stays cheap per row-batch and a baseline-only file that doesn't exist yet
+ * at the pinned SHA fails loudly (`git show` exits non-zero) instead of
+ * silently missing.
+ *
+ * FULL closure, verified directly against the pinned commit's actual import
+ * graph (`git show <sha>:<path> | grep '^import'` on every file transitively,
+ * not just `skill-processor.security.ts`'s own top-level imports — the first
+ * version of this list only checked the top level and silently omitted two
+ * files `security-scanner-edge.ts` itself pulls in, which would have made
+ * `importBaselineScanSkillBundle()` throw a module-not-found error the first
+ * time the simulator actually ran):
+ *   skill-processor.security.ts
+ *     -> security-scanner-edge.ts, security-scanner-edge.context.ts,
+ *        rate-limit.ts, github-auth.ts
+ *   security-scanner-edge.ts
+ *     -> (all four above, already listed) + security-scanner-edge.exec.ts,
+ *        security-scanner-edge.patterns.ts
+ *   security-scanner-edge.exec.ts -> security-scanner-edge.context.ts (already listed)
+ *   security-scanner-edge.patterns.ts, security-scanner-edge.context.ts,
+ *   rate-limit.ts, github-auth.ts -> no further imports (leaf files)
+ */
+export const BASELINE_FILES = [
+  'scripts/indexer/skill-processor.security.ts',
+  'scripts/indexer/_shared/security-scanner-edge.ts',
+  'scripts/indexer/_shared/security-scanner-edge.context.ts',
+  'scripts/indexer/_shared/security-scanner-edge.exec.ts',
+  'scripts/indexer/_shared/security-scanner-edge.patterns.ts',
+  'scripts/indexer/_shared/rate-limit.ts',
+  'scripts/indexer/_shared/github-auth.ts',
+] as const
+
+/** Throws with an actionable message unless `commitSha` is a real, reachable commit object. */
+export function assertBaselineCommitReachable(commitSha: string): void {
+  try {
+    execFileSync('git', ['cat-file', '-e', `${commitSha}^{commit}`], { stdio: 'pipe' })
+  } catch {
+    throw new Error(
+      `SMI-5879: baseline commit ${commitSha} is not a reachable commit object in this repo's ` +
+        `history. The simulator refuses to run against an unpinnable baseline.`
+    )
+  }
+}
+
+/**
+ * `git show <commitSha>:<relPath>` for each of {@link BASELINE_FILES} into a
+ * fresh temp directory, preserving relative paths so the materialized
+ * `skill-processor.security.ts`'s own relative imports (`./_shared/...`)
+ * resolve correctly. Returns the temp directory root.
+ */
+export function materializeBaseline(commitSha: string = BASELINE_COMMIT_SHA): string {
+  assertBaselineCommitReachable(commitSha)
+  const dir = mkdtempSync(join(tmpdir(), 'smi5879-baseline-'))
+  for (const relPath of BASELINE_FILES) {
+    let content: string
+    try {
+      content = execFileSync('git', ['show', `${commitSha}:${relPath}`], {
+        encoding: 'utf8',
+        maxBuffer: 16 * 1024 * 1024,
+      })
+    } catch (err) {
+      throw new Error(
+        `SMI-5879: failed to materialize baseline file ${relPath} at ${commitSha}: ${(err as Error).message}`
+      )
+    }
+    const dest = join(dir, relPath)
+    mkdirSync(dirname(dest), { recursive: true })
+    writeFileSync(dest, content)
+  }
+  return dir
+}
+
+/**
+ * Dynamically import the materialized baseline's `scanSkillBundle`. Requires
+ * the host process to run under `tsx` (or another runtime whose loader
+ * transforms `.ts` on `import()`) — true for every production invocation of
+ * this tool. Tests inject a fake `ScanSkillBundleFn` directly instead of
+ * exercising this path (see smi5879-simulate-full.test.ts's header for why).
+ */
+export async function importBaselineScanSkillBundle(baselineDir: string): Promise<{
+  scanSkillBundle: ScanSkillBundleFn
+}> {
+  const entry = join(baselineDir, 'scripts/indexer/skill-processor.security.ts')
+  const mod = (await import(pathToFileURL(entry).href)) as { scanSkillBundle: ScanSkillBundleFn }
+  if (typeof mod.scanSkillBundle !== 'function') {
+    throw new Error(
+      `SMI-5879: materialized baseline at ${entry} has no scanSkillBundle export — ` +
+        `the pinned commit predates PR-2192a's extraction, or BASELINE_FILES is stale.`
+    )
+  }
+  return { scanSkillBundle: mod.scanSkillBundle }
+}

--- a/scripts/indexer/smi5879-simulate-full.db.ts
+++ b/scripts/indexer/smi5879-simulate-full.db.ts
@@ -1,0 +1,177 @@
+/**
+ * Production `Smi5879SimulateFullDbDeps` implementation for smi5879-simulate-full.ts.
+ * @module scripts/indexer/smi5879-simulate-full.db
+ *
+ * Thin wrapper over item 1's `smi5879-census.pg.ts` psql helper (imported,
+ * never modified — item 1 is merged and out of scope) plus the SQL functions
+ * item 1's migration already ships (`smi5879_claim_run`, `smi5879_heartbeat`,
+ * `smi5879_release_run`, `smi5879_population_digest`, `smi5879_branch_digest`).
+ * No new SQL objects are created here.
+ */
+
+import {
+  queryRows,
+  queryScalar,
+  nullable,
+  runPsql,
+  type PgConnParams,
+} from './smi5879-census.pg.ts'
+import type {
+  BranchMap,
+  RepoBranchInfo,
+  SimSnapshotRow,
+  SimulatedCohort,
+  Smi5879SimulateFullDbDeps,
+} from './smi5879-simulate-full.types.ts'
+import type { Smi5879Purpose, Smi5879RunStatus } from './smi5879-census.types.ts'
+
+const SIMULATED_COHORTS: readonly SimulatedCohort[] = ['C1', 'C2', 'C3', 'C4']
+
+/**
+ * Assert a raw `queryRows` cell is present. `tsconfig.base.json`'s
+ * `noUncheckedIndexedAccess` types every destructured cell as `string | undefined`
+ * even though a `queryRows` result row always has as many cells as the `SELECT`'s
+ * column list — a genuinely missing cell here means the query's column count has
+ * drifted from what this function destructures, which is a real bug worth
+ * throwing on rather than silently letting `undefined` flow into code that
+ * expects a definite `string`.
+ */
+function requireCell(value: string | undefined, column: string): string {
+  if (value === undefined) {
+    throw new Error(`SMI-5879: missing '${column}' cell in query result row — column count drift?`)
+  }
+  return value
+}
+
+/** Build the real, psql-backed dependency set for a given connection. */
+export function createSmi5879SimulateFullDbDeps(conn: PgConnParams): Smi5879SimulateFullDbDeps {
+  return {
+    async getRunSummary(runId) {
+      const rows = await queryRows(
+        conn,
+        `SELECT purpose, status FROM smi5879_run WHERE run_id = :'run_id'`,
+        { run_id: runId }
+      )
+      const row = rows[0]
+      if (!row) return null
+      const [purposeRaw, statusRaw] = row
+      return {
+        purpose: requireCell(purposeRaw, 'purpose') as Smi5879Purpose,
+        status: requireCell(statusRaw, 'status') as Smi5879RunStatus,
+      }
+    },
+
+    async claimRun(runId, token, holder) {
+      const rows = await queryRows(
+        conn,
+        `SELECT run_id FROM smi5879_claim_run(:'run_id', :'token', :'holder');`,
+        { run_id: runId, token, holder }
+      )
+      return { claimed: rows.length > 0 }
+    },
+
+    async heartbeat(runId, token) {
+      // queryScalar already resolves the SQL NULL sentinel to `null` — a bare
+      // `SELECT smi5879_heartbeat(...)` returns exactly one scalar row.
+      return queryScalar(conn, `SELECT smi5879_heartbeat(:'run_id', :'token');`, {
+        run_id: runId,
+        token,
+      })
+    },
+
+    async releaseRun(runId, token) {
+      await runPsql(conn, `SELECT smi5879_release_run(:'run_id', :'token');`, {
+        run_id: runId,
+        token,
+      })
+    },
+
+    async verifyDigest(runId) {
+      const rows = await queryRows(
+        conn,
+        `SELECT
+           (population_digest = smi5879_population_digest(:'run_id')),
+           (branch_digest     = smi5879_branch_digest(:'run_id'))
+         FROM smi5879_run WHERE run_id = :'run_id';`,
+        { run_id: runId }
+      )
+      const row = rows[0]
+      if (!row) {
+        throw new Error(`SMI-5879: no smi5879_run row for run_id=${runId} — cannot verify digest.`)
+      }
+      const [populationMatchesRaw, branchMatchesRaw] = row
+      return {
+        populationMatches: requireCell(populationMatchesRaw, 'population_matches') === 't',
+        branchMatches: requireCell(branchMatchesRaw, 'branch_matches') === 't',
+      }
+    },
+
+    async loadCohortRows(runId) {
+      const rows = await queryRows(
+        conn,
+        `SELECT c.cohort, s.id, s.repo_url, s.skill_path, s.author, s.name,
+                s.content_hash, s.security_score, s.quarantined
+           FROM v_smi5879_census_cohort c
+           JOIN smi5879_snapshot_pre s ON s.run_id = c.run_id AND s.id = c.id
+          WHERE c.run_id = :'run_id' AND c.cohort IN ('C1','C2','C3','C4')
+          ORDER BY s.id COLLATE "C";`,
+        { run_id: runId }
+      )
+      const out: SimSnapshotRow[] = []
+      for (const [
+        cohortRaw,
+        idRaw,
+        repoUrlRaw,
+        skillPathRaw,
+        authorRaw,
+        nameRaw,
+        contentHashRaw,
+        scoreRaw,
+        quarantinedRaw,
+      ] of rows) {
+        const score = nullable(requireCell(scoreRaw, 'security_score'))
+        const quarantined = nullable(requireCell(quarantinedRaw, 'quarantined'))
+        out.push({
+          id: requireCell(idRaw, 'id'),
+          cohort: requireCell(cohortRaw, 'cohort') as SimulatedCohort,
+          repo_url: nullable(requireCell(repoUrlRaw, 'repo_url')),
+          skill_path: nullable(requireCell(skillPathRaw, 'skill_path')),
+          author: nullable(requireCell(authorRaw, 'author')),
+          name: nullable(requireCell(nameRaw, 'name')),
+          content_hash: nullable(requireCell(contentHashRaw, 'content_hash')),
+          snapshot_security_score: score === null ? null : Number(score),
+          snapshot_quarantined: quarantined === null ? null : quarantined === 't',
+        })
+      }
+      return out
+    },
+
+    async loadBranchMap(runId) {
+      const rows = await queryRows(
+        conn,
+        `SELECT owner, repo, default_branch, resolution FROM smi5879_repo_branch WHERE run_id = :'run_id';`,
+        { run_id: runId }
+      )
+      const map: BranchMap = new Map()
+      for (const [ownerRaw, repoRaw, defaultBranchRaw, resolutionRaw] of rows) {
+        const owner = requireCell(ownerRaw, 'owner')
+        const repo = requireCell(repoRaw, 'repo')
+        const info: RepoBranchInfo = {
+          resolution: requireCell(resolutionRaw, 'resolution') as RepoBranchInfo['resolution'],
+          default_branch: nullable(requireCell(defaultBranchRaw, 'default_branch')),
+        }
+        map.set(`${owner}/${repo}`, info)
+      }
+      return map
+    },
+  }
+}
+
+/** Total row count across the simulated cohorts, for a fresh run's coverage denominators. */
+export function countByCohort(rows: SimSnapshotRow[]): Record<SimulatedCohort, number> {
+  const counts: Record<SimulatedCohort, number> = { C1: 0, C2: 0, C3: 0, C4: 0 }
+  for (const row of rows) counts[row.cohort]++
+  return counts
+}
+
+export { SIMULATED_COHORTS }

--- a/scripts/indexer/smi5879-simulate-full.helpers.ts
+++ b/scripts/indexer/smi5879-simulate-full.helpers.ts
@@ -1,0 +1,336 @@
+/**
+ * Core per-row control-flow helpers for smi5879-simulate-full.ts: the
+ * retry-wrapped fetch adapters, verdict extraction, and tier-1/tier-2 outcome
+ * classification (`processRow`). Coverage aggregation, checkpoint I/O, and
+ * the tier-3 sweep loop live in the sibling `smi5879-simulate-full.sweep.ts`
+ * (split for CLAUDE.md's <500-line-per-file convention).
+ * @module scripts/indexer/smi5879-simulate-full.helpers
+ *
+ * Plan: docs/internal/implementation/smi-5879-wave3-census-simulation-plan.md §3a/§3b
+ * Design: docs/internal/implementation/smi-5879-edge-twin-parity-design.md §8.2.3
+ */
+
+import { shouldQuarantine, generateContentHash } from './_shared/security-scanner-edge.ts'
+import { parseSkillMdUrl, fetchSkillMd, type ParsedSkillUrl } from './_shared/skill-md-fetch.ts'
+import { fetchSiblingContent, type ScanSkillBundleResult } from './skill-processor.security.ts'
+import type { RateLimitTelemetry } from './_shared/rate-limit.ts'
+import { withFetchRetry, type FetchRetryOptions } from './smi5879-fetch-retry.ts'
+import { resolveTokenSource } from './backfill-checkpoint.ts'
+import type {
+  BranchMap,
+  ScanSkillBundleFn,
+  SimRowOutcome,
+  SimRowResult,
+  SimSnapshotRow,
+  TokenSource,
+} from './smi5879-simulate-full.types.ts'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const HEARTBEAT_INTERVAL_MS = 60_000
+/** Bounded concurrency + batch size for the main pass, matching revalidate-stale-quarantines.ts's polite BATCH. */
+export const PROCESS_CONCURRENCY = 5
+export const CHECKPOINT_BATCH_SIZE = 25
+
+/**
+ * Hard-refuses (throws) when `token_source` resolves to `'app'` — plan §3a.
+ * Shared by BOTH `smi5879-simulate-full.ts` and
+ * `smi5879-simulate-preflight-estimate.ts` (plan §3c: "Both tools share...
+ * a token_source field — hard-refuses to start on 'app'"), so it lives here
+ * rather than in either CLI file.
+ */
+export function assertPatTokenSource(env: NodeJS.ProcessEnv = process.env): TokenSource {
+  const source = resolveTokenSource(env)
+  if (source === 'app') {
+    throw new Error(
+      'SMI-5879: token_source resolved to "app" — the simulator MUST authenticate via PAT, ' +
+        'never the GitHub App (plan §3a: a multi-day unattended batch on the App installation ' +
+        'would compete with the 00:00/03:00 indexer crons for the same core bucket). Unset ' +
+        'GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and GITHUB_APP_PRIVATE_KEY for this run.'
+    )
+  }
+  return source
+}
+
+const DEFAULT_FETCH_RETRY_OPTIONS: FetchRetryOptions = {}
+
+// ---------------------------------------------------------------------------
+// Retry-wrapped fetch adapters
+// ---------------------------------------------------------------------------
+
+/**
+ * Adapt `fetchSkillMd`'s `{kind:'content'|'not-found'|'transient'}` shape to
+ * `RetryableFetchResult` (`{content}|{removed:true}|null`) so the SAME
+ * tier-1 wrapper drives both the primary and sibling fetch paths. `retries=0`
+ * is passed to `fetchSkillMd` itself — `withFetchRetry` owns ALL retry
+ * decisions uniformly; letting `fetchSkillMd`'s own internal retry loop also
+ * fire would double-apply backoff with two independent schedules.
+ */
+export async function retryPrimaryFetch(
+  parsed: ParsedSkillUrl,
+  headers: Record<string, string>,
+  options: FetchRetryOptions = DEFAULT_FETCH_RETRY_OPTIONS
+): Promise<ReturnType<typeof withFetchRetry>> {
+  let lastStatus: number | null = null
+  return withFetchRetry(
+    async () => {
+      const result = await fetchSkillMd(parsed, headers, 0)
+      if (result.kind === 'content') return { content: result.content }
+      if (result.kind === 'not-found') return { removed: true }
+      lastStatus = result.status
+      return null
+    },
+    { ...options, captureStatus: () => lastStatus ?? undefined }
+  )
+}
+
+/**
+ * Build a per-row, per-relPath-cached sibling fetcher. Both the post-port and
+ * pre-port `scanSkillBundle` calls share this SAME instance (passed as
+ * `deps.fetchSiblingContent`), so each sibling is physically fetched (with
+ * tier-1 retry) at most ONCE per row regardless of which scan triggers it
+ * first — production `scanSkillBundle`'s own fail-open `null` handling then
+ * runs identically for both scans, exactly matching what a single production
+ * call would observe.
+ */
+export function makeCachingSiblingFetcher(
+  options: FetchRetryOptions = DEFAULT_FETCH_RETRY_OPTIONS
+): {
+  fetchSiblingContent: (
+    owner: string,
+    repo: string,
+    branch: string,
+    relPath: string,
+    telemetry: RateLimitTelemetry
+  ) => Promise<{ content: string } | { removed: true } | null>
+  getExhausted: () => { relPath: string; lastStatus: number | null }[]
+} {
+  const cache = new Map<string, { content: string } | { removed: true } | null>()
+  const exhausted: { relPath: string; lastStatus: number | null }[] = []
+
+  const cachingFetch = async (
+    owner: string,
+    repo: string,
+    branch: string,
+    relPath: string,
+    tel: RateLimitTelemetry
+  ): Promise<{ content: string } | { removed: true } | null> => {
+    if (cache.has(relPath)) return cache.get(relPath) ?? null
+    const outcome = await withFetchRetry(
+      () => fetchSiblingContent(owner, repo, branch, relPath, tel),
+      options
+    )
+    let result: { content: string } | { removed: true } | null
+    if ('exhausted' in outcome) {
+      exhausted.push({ relPath, lastStatus: outcome.lastStatus })
+      result = null
+    } else {
+      result = outcome
+    }
+    cache.set(relPath, result)
+    return result
+  }
+
+  return { fetchSiblingContent: cachingFetch, getExhausted: () => exhausted }
+}
+
+// ---------------------------------------------------------------------------
+// Verdict extraction + tier-2 classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical "effective verdict" derivation — matches skill-processor.ts's own
+ * `mergedScan ? mergedScan.quarantine : securityScan ? shouldQuarantine(securityScan) : false`
+ * (skill-processor.ts:398-402), so the simulator's comparison basis is
+ * identical to what production actually decides on.
+ */
+export function effectiveVerdict(result: ScanSkillBundleResult): {
+  quarantine: boolean
+  riskScore: number
+} {
+  if (result.mergedSecurityScan) {
+    return {
+      quarantine: result.mergedSecurityScan.quarantine,
+      riskScore: result.mergedSecurityScan.riskScore,
+    }
+  }
+  return {
+    quarantine: shouldQuarantine(result.securityScan),
+    riskScore: result.securityScan.riskScore,
+  }
+}
+
+/** Verdict-delta classification (one of the four non-terminal outcomes). */
+export function classifyVerdictDelta(prePort: boolean, postPort: boolean): SimRowOutcome {
+  if (!prePort && postPort) return 'newly_quarantined'
+  if (prePort && !postPort) return 'newly_cleared'
+  if (!prePort && !postPort) return 'unchanged_clean'
+  return 'unchanged_quarantined'
+}
+
+/**
+ * True iff every sibling target 404'd (bundle scope confirmed empty) — checked
+ * against the post-port scan's `siblingFailures`, which is identical to the
+ * pre-port scan's by construction (both share the same caching fetcher).
+ */
+export function isBundleAbsent(result: ScanSkillBundleResult): boolean {
+  return (
+    result.siblingScans.length === 0 &&
+    result.siblingFailures.length > 0 &&
+    result.siblingFailures.every((f) => f.kind === 'removed')
+  )
+}
+
+export interface ProcessRowDeps {
+  scanPostPort: ScanSkillBundleFn
+  scanPrePort: ScanSkillBundleFn
+  telemetry: RateLimitTelemetry
+  headers: Record<string, string>
+  fetchRetryOptions?: FetchRetryOptions
+}
+
+/**
+ * Process one row end-to-end: parse -> resolve branch -> fetch primary
+ * (tier-1) -> content-drift check -> dual-scan (shared cached sibling
+ * fetcher) -> tier-2 classification. Never throws for a data-shaped
+ * condition (parse/fetch/drift/exhaustion failures all resolve to a terminal
+ * `SimRowResult`); throws ONLY for the "simulator bug" case the design doc
+ * calls out explicitly (a fetching generation with a missing
+ * `smi5879_repo_branch` row — I-5 should have caught this at census time).
+ */
+export async function processRow(
+  row: SimSnapshotRow,
+  branchMap: BranchMap,
+  deps: ProcessRowDeps
+): Promise<SimRowResult> {
+  const base = { id: row.id, cohort: row.cohort, author: row.author, name: row.name }
+  const retryOptions = deps.fetchRetryOptions ?? DEFAULT_FETCH_RETRY_OPTIONS
+
+  const parsed = parseSkillMdUrl(row.repo_url, row.skill_path)
+  if (!parsed) {
+    return {
+      ...base,
+      outcome: 'unfetchable',
+      reason: `repo_url did not parse to a fetchable target (repo_url=${row.repo_url ?? '(null)'})`,
+    }
+  }
+
+  let branch: string
+  if (parsed.ref) {
+    branch = parsed.ref
+  } else {
+    const info = branchMap.get(`${parsed.owner}/${parsed.repo}`)
+    if (!info) {
+      throw new Error(
+        `SMI-5879 simulator bug: no smi5879_repo_branch row for ${parsed.owner}/${parsed.repo} ` +
+          `(row id=${row.id}) — I-5 branch coverage should have refused the census before this ` +
+          `generation could be sealed. Never silently falls back to 'main'.`
+      )
+    }
+    if (info.resolution === 'not-found' || info.resolution === 'unparseable') {
+      return {
+        ...base,
+        outcome: 'unfetchable',
+        reason: `default_branch resolution=${info.resolution}`,
+      }
+    }
+    if (info.resolution === 'transient') {
+      return { ...base, outcome: 'unevaluable', reason: 'default_branch resolution=transient' }
+    }
+    branch = info.default_branch as string // resolution === 'resolved' — default_branch is NOT NULL (CHECK constraint)
+  }
+
+  const primaryOutcome = await retryPrimaryFetch(parsed, deps.headers, retryOptions)
+  if ('exhausted' in primaryOutcome) {
+    return {
+      ...base,
+      outcome: 'unevaluable',
+      reason: `primary fetch exhausted retries (lastStatus=${primaryOutcome.lastStatus ?? 'unknown'})`,
+    }
+  }
+  if ('removed' in primaryOutcome) {
+    // JUDGMENT CALL (documented in the implementation report): a primary
+    // SKILL.md 404 has no dedicated bucket in the plan's closed vocabulary —
+    // `unfetchable` is reserved for structurally-undecidable ROW SHAPES
+    // determined without any network attempt; `bundle_absent` requires
+    // "primary OK". Routed to `unevaluable` (the conservative, G-2-blocking
+    // choice) because the post-port verdict is categorically unknowable with
+    // no primary content to score, matching unevaluable's own definition.
+    return {
+      ...base,
+      outcome: 'unevaluable',
+      reason: 'primary SKILL.md confirmed absent (404) since the generation was sealed',
+    }
+  }
+  const primaryContent = primaryOutcome.content
+
+  if (row.content_hash) {
+    const hash = await generateContentHash(primaryContent)
+    if (hash !== row.content_hash) {
+      return {
+        ...base,
+        outcome: 'content_drifted',
+        reason: `content hash mismatch (snapshot=${row.content_hash}, fetched=${hash})`,
+      }
+    }
+  }
+  // row.content_hash === null (C2, never scanned before the snapshot): no
+  // baseline to drift-check against — proceed to scan directly.
+
+  const { fetchSiblingContent: cachingFetch, getExhausted } =
+    makeCachingSiblingFetcher(retryOptions)
+
+  const postPortResult = await deps.scanPostPort(
+    parsed.owner,
+    parsed.repo,
+    branch,
+    parsed.dir || undefined,
+    primaryContent,
+    deps.telemetry,
+    { fetchSiblingContent: cachingFetch }
+  )
+  const prePortResult = await deps.scanPrePort(
+    parsed.owner,
+    parsed.repo,
+    branch,
+    parsed.dir || undefined,
+    primaryContent,
+    deps.telemetry,
+    { fetchSiblingContent: cachingFetch }
+  )
+
+  const exhausted = getExhausted()
+  if (exhausted.length > 0) {
+    return {
+      ...base,
+      outcome: 'unevaluable',
+      reason: `${exhausted.length} sibling(s) exhausted retries: ${exhausted.map((e) => e.relPath).join(', ')}`,
+    }
+  }
+
+  const preVerdict = effectiveVerdict(prePortResult)
+  const postVerdict = effectiveVerdict(postPortResult)
+
+  if (isBundleAbsent(postPortResult)) {
+    return {
+      ...base,
+      outcome: 'bundle_absent',
+      reason: 'primary OK, all sibling targets confirmed 404 — bundle scope confirmed empty',
+      prePortQuarantine: preVerdict.quarantine,
+      postPortQuarantine: postVerdict.quarantine,
+      prePortRiskScore: preVerdict.riskScore,
+      postPortRiskScore: postVerdict.riskScore,
+    }
+  }
+
+  return {
+    ...base,
+    outcome: classifyVerdictDelta(preVerdict.quarantine, postVerdict.quarantine),
+    prePortQuarantine: preVerdict.quarantine,
+    postPortQuarantine: postVerdict.quarantine,
+    prePortRiskScore: preVerdict.riskScore,
+    postPortRiskScore: postVerdict.riskScore,
+  }
+}

--- a/scripts/indexer/smi5879-simulate-full.sweep.ts
+++ b/scripts/indexer/smi5879-simulate-full.sweep.ts
@@ -1,0 +1,480 @@
+/**
+ * Coverage aggregation, checkpoint I/O, and the tier-3 sweep loop for
+ * smi5879-simulate-full.ts. Split out of smi5879-simulate-full.helpers.ts
+ * (CLAUDE.md's <500-line-per-file convention — helpers.ts plus this file
+ * together are still one logical unit; `processRow`'s per-row tier-1/tier-2
+ * logic stays in helpers.ts, and everything ABOVE the per-row level — how
+ * many rows got what outcome, how to persist/resume progress, and how to
+ * re-sweep the unevaluable residual — lives here).
+ * @module scripts/indexer/smi5879-simulate-full.sweep
+ *
+ * Plan: docs/internal/implementation/smi-5879-wave3-census-simulation-plan.md §3b (tier 3) / §3c
+ * Design: docs/internal/implementation/smi-5879-edge-twin-parity-design.md §8.3.5.2.4/§8.4
+ */
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import type {
+  CohortCoverage,
+  CoverageByCohort,
+  SimRowOutcome,
+  SimRowResult,
+  SimSnapshotRow,
+  SimulatedCohort,
+  Smi5879SimulateCheckpoint,
+  SweepHardStopReason,
+  TokenSource,
+} from './smi5879-simulate-full.types.ts'
+import type { Smi5879Purpose } from './smi5879-census.types.ts'
+
+// ---------------------------------------------------------------------------
+// Constants (design doc 8.3.5.2.5's interval table + plan §3b tier 3)
+// ---------------------------------------------------------------------------
+
+export const MAX_SWEEP_PASSES = 8
+export const SWEEP_COOLDOWN_MS = 15 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// Coverage aggregation
+// ---------------------------------------------------------------------------
+
+export function computeCoverage(
+  rowsByCohort: Record<SimulatedCohort, SimSnapshotRow[]>,
+  results: Map<string, SimRowResult>
+): CoverageByCohort {
+  const coverage = {} as CoverageByCohort
+  for (const cohort of Object.keys(rowsByCohort) as SimulatedCohort[]) {
+    const rows = rowsByCohort[cohort]
+    const total = rows.length
+    let scanned = 0
+    let unevaluable = 0
+    let unfetchable = 0
+    for (const row of rows) {
+      const result = results.get(row.id)
+      if (!result) continue
+      scanned++
+      if (result.outcome === 'unevaluable') unevaluable++
+      if (result.outcome === 'unfetchable') unfetchable++
+    }
+    const status: CohortCoverage['status'] =
+      scanned === total && unevaluable === 0 ? 'full' : 'partial'
+    coverage[cohort] = { status, scanned, total, unevaluable, unfetchable }
+  }
+  return coverage
+}
+
+/**
+ * Single source of truth for the closed `SimRowOutcome` vocabulary at
+ * runtime — `summarizeCounts`'s zeroed accumulator doubles as the
+ * membership set `assertValidCheckpointShape` checks a resumed
+ * checkpoint's recorded outcomes against (SMI-5879 review finding 1), so
+ * the two can never drift apart.
+ */
+const EMPTY_OUTCOME_COUNTS: Record<SimRowOutcome, number> = {
+  newly_quarantined: 0,
+  newly_cleared: 0,
+  unchanged_clean: 0,
+  unchanged_quarantined: 0,
+  content_drifted: 0,
+  bundle_absent: 0,
+  unevaluable: 0,
+  unfetchable: 0,
+}
+
+export const SIM_ROW_OUTCOMES: readonly SimRowOutcome[] = Object.keys(
+  EMPTY_OUTCOME_COUNTS
+) as SimRowOutcome[]
+
+function isValidSimRowOutcome(value: unknown): value is SimRowOutcome {
+  return typeof value === 'string' && (SIM_ROW_OUTCOMES as readonly string[]).includes(value)
+}
+
+export function summarizeCounts(results: Iterable<SimRowResult>): Record<SimRowOutcome, number> {
+  const counts: Record<SimRowOutcome, number> = { ...EMPTY_OUTCOME_COUNTS }
+  for (const r of results) counts[r.outcome]++
+  return counts
+}
+
+/**
+ * G-2-shaped exit code decision: 0 when every cohort is `full` and the sweep
+ * converged (no hard stop); 1 otherwise. Extracted as a pure function so the
+ * CLI's exit behaviour is independently unit-testable without spawning a
+ * process — mirrors what `gate-check.ts` (item 4) will independently re-derive
+ * from the same report fields.
+ */
+export function decideExitCode(
+  coverage: CoverageByCohort,
+  sweepHardStopped: SweepHardStopReason
+): 0 | 1 {
+  const anyPartial = (Object.keys(coverage) as SimulatedCohort[]).some(
+    (c) => coverage[c].status === 'partial'
+  )
+  return anyPartial || sweepHardStopped !== null ? 1 : 0
+}
+
+/** Simple linear-throughput ETA — null when there isn't yet enough signal (0 elapsed or 0 scanned). */
+export function estimateCompletionAt(
+  startedAt: Date,
+  now: Date,
+  totalRows: number,
+  scannedRows: number
+): string | null {
+  const elapsedMs = now.getTime() - startedAt.getTime()
+  if (elapsedMs <= 0 || scannedRows <= 0) return null
+  const remaining = totalRows - scannedRows
+  if (remaining <= 0) return now.toISOString()
+  const msPerRow = elapsedMs / scannedRows
+  return new Date(now.getTime() + remaining * msPerRow).toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint I/O
+// ---------------------------------------------------------------------------
+
+export function checkpointPathFor(runId: string): string {
+  return `smi5879-simulate-checkpoint-${runId}.json`
+}
+
+const VALID_COHORTS_FOR_SHAPE_CHECK: readonly SimulatedCohort[] = ['C1', 'C2', 'C3', 'C4']
+const VALID_PURPOSES_FOR_SHAPE_CHECK: readonly Smi5879Purpose[] = [
+  'rehearsal',
+  'decision',
+  'window',
+]
+const VALID_TOKEN_SOURCES_FOR_SHAPE_CHECK: readonly TokenSource[] = ['app', 'pat']
+const VALID_HARD_STOP_REASONS_FOR_SHAPE_CHECK: readonly SweepHardStopReason[] = [
+  'non_convergence',
+  'max_passes',
+  null,
+]
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Runtime shape validation for a checkpoint read off disk — a bare
+ * `JSON.parse(raw) as Smi5879SimulateCheckpoint` casts arbitrary JSON
+ * straight to the type with zero verification, so a wrong
+ * `--checkpoint-path` or a hand-edited file could silently carry an
+ * unrecognised `outcome` value (or the wrong overall shape) straight into
+ * `runSimulateFull` (SMI-5879 review finding 1). Throws — never returns a
+ * best-effort partial object — because a checkpoint that fails shape
+ * validation means real prior progress may exist in a form we can no
+ * longer trust, which is categorically different from "no checkpoint yet"
+ * (cold start) and must not be treated the same way.
+ */
+function assertValidCheckpointShape(
+  value: unknown,
+  path: string
+): asserts value is Smi5879SimulateCheckpoint {
+  if (!isPlainObject(value)) {
+    throw new Error(`SMI-5879: checkpoint at ${path} is not a JSON object.`)
+  }
+  const errors: string[] = []
+
+  // Bracket notation throughout this function is required, not stylistic —
+  // `value`/`rawResult`/`sweep` are `Record<string, unknown>` (from the
+  // `isPlainObject` guard), which `noPropertyAccessFromIndexSignature`
+  // (tsconfig.base.json) refuses to let dot-notation read.
+  const runId = value['run_id']
+  const purpose = value['purpose']
+  const baselineCommit = value['baseline_commit']
+  const tokenSource = value['token_source']
+  const cleanShutdown = value['clean_shutdown']
+  const startedAt = value['started_at']
+  const updatedAt = value['updated_at']
+  const rowResults = value['row_results']
+  const sweepRaw = value['sweep']
+
+  if (typeof runId !== 'string' || runId.length === 0) errors.push('run_id')
+  if (
+    typeof purpose !== 'string' ||
+    !VALID_PURPOSES_FOR_SHAPE_CHECK.includes(purpose as Smi5879Purpose)
+  ) {
+    errors.push(`purpose=${String(purpose)}`)
+  }
+  if (typeof baselineCommit !== 'string' || baselineCommit.length === 0) {
+    errors.push('baseline_commit')
+  }
+  if (
+    typeof tokenSource !== 'string' ||
+    !VALID_TOKEN_SOURCES_FOR_SHAPE_CHECK.includes(tokenSource as TokenSource)
+  ) {
+    errors.push(`token_source=${String(tokenSource)}`)
+  }
+  if (typeof cleanShutdown !== 'boolean') errors.push('clean_shutdown')
+  if (typeof startedAt !== 'string') errors.push('started_at')
+  if (typeof updatedAt !== 'string') errors.push('updated_at')
+
+  if (!isPlainObject(rowResults)) {
+    errors.push('row_results')
+  } else {
+    for (const [id, rawResult] of Object.entries(rowResults)) {
+      if (!isPlainObject(rawResult)) {
+        errors.push(`row_results.${id} (not an object)`)
+        continue
+      }
+      const resultId = rawResult['id']
+      const cohort = rawResult['cohort']
+      const outcome = rawResult['outcome']
+      if (typeof resultId !== 'string') errors.push(`row_results.${id}.id`)
+      if (
+        typeof cohort !== 'string' ||
+        !VALID_COHORTS_FOR_SHAPE_CHECK.includes(cohort as SimulatedCohort)
+      ) {
+        errors.push(`row_results.${id}.cohort=${String(cohort)}`)
+      }
+      if (!isValidSimRowOutcome(outcome)) {
+        errors.push(`row_results.${id}.outcome=${String(outcome)}`)
+      }
+    }
+  }
+
+  if (!isPlainObject(sweepRaw)) {
+    errors.push('sweep')
+  } else {
+    const pass = sweepRaw['pass']
+    const residualHistory = sweepRaw['residual_history']
+    const nonDecreaseStreak = sweepRaw['non_decrease_streak']
+    const hardStopped = sweepRaw['hard_stopped']
+    if (typeof pass !== 'number') errors.push('sweep.pass')
+    if (!Array.isArray(residualHistory) || !residualHistory.every((n) => typeof n === 'number')) {
+      errors.push('sweep.residual_history')
+    }
+    if (typeof nonDecreaseStreak !== 'number') errors.push('sweep.non_decrease_streak')
+    if (!VALID_HARD_STOP_REASONS_FOR_SHAPE_CHECK.includes(hardStopped as SweepHardStopReason)) {
+      errors.push(`sweep.hard_stopped=${String(hardStopped)}`)
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `SMI-5879: checkpoint at ${path} failed shape validation — invalid/missing field(s): ` +
+        `${errors.join(', ')}. Refusing to trust a malformed checkpoint file — fix or remove it ` +
+        'before resuming (removing it is a COLD START, not a safe default: confirm no real ' +
+        'progress is being discarded first).'
+    )
+  }
+}
+
+export function readCheckpoint(path: string): Smi5879SimulateCheckpoint | null {
+  if (!existsSync(path)) return null
+  const raw = readFileSync(path, 'utf8')
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    // A parse failure is NOT "no checkpoint" — it's "a checkpoint existed and
+    // may hold real progress we can no longer read." Silently falling back to
+    // cold start here would be the destructive choice (SMI-5879 review finding 3).
+    throw new Error(
+      `SMI-5879: checkpoint at ${path} exists but is not valid JSON (${(err as Error).message}). ` +
+        'This is NOT the same as "no checkpoint" — a prior run may have written real progress to ' +
+        'this file before crashing mid-write. Inspect the file (and any `.tmp` sibling left by an ' +
+        'interrupted write) before deciding whether to delete it and cold-start.'
+    )
+  }
+  assertValidCheckpointShape(parsed, path)
+  return parsed
+}
+
+/**
+ * Refuses to reuse a checkpoint whose identity doesn't match THIS
+ * invocation — a wrong `--checkpoint-path` pointing at another
+ * generation's checkpoint could otherwise silently skip rows that are
+ * still live-unattempted for the current run (SMI-5879 review finding 1).
+ * `baseline_commit` is checked separately by the caller (pre-existing).
+ */
+export function assertCheckpointIdentity(
+  checkpoint: Smi5879SimulateCheckpoint,
+  expected: { runId: string; purpose: Smi5879Purpose; tokenSource: TokenSource },
+  path: string
+): void {
+  const mismatches: string[] = []
+  if (checkpoint.run_id !== expected.runId) {
+    mismatches.push(`run_id (checkpoint=${checkpoint.run_id}, this run=${expected.runId})`)
+  }
+  if (checkpoint.purpose !== expected.purpose) {
+    mismatches.push(`purpose (checkpoint=${checkpoint.purpose}, this run=${expected.purpose})`)
+  }
+  if (checkpoint.token_source !== expected.tokenSource) {
+    mismatches.push(
+      `token_source (checkpoint=${checkpoint.token_source}, this run=${expected.tokenSource})`
+    )
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      `SMI-5879: checkpoint at ${path} does not match this invocation — ${mismatches.join('; ')}. ` +
+        'A resume must reuse a checkpoint from the SAME run_id/purpose/token_source — use a fresh ' +
+        '--checkpoint-path for a different generation instead of pointing at this one.'
+    )
+  }
+}
+
+/**
+ * Refuses to reuse a checkpoint whose `row_results` keys reference row ids
+ * outside the CURRENT generation's loaded row set — e.g. a stale checkpoint
+ * from a different generation whose row ids happen to overlap with
+ * globally-stable skill ids from this one. Must be called only after the
+ * real row set for this generation has been loaded (SMI-5879 review finding 1).
+ */
+export function assertCheckpointRowsBelongToGeneration(
+  checkpoint: Smi5879SimulateCheckpoint,
+  rows: readonly SimSnapshotRow[],
+  path: string
+): void {
+  const validIds = new Set(rows.map((r) => r.id))
+  const staleIds = Object.keys(checkpoint.row_results).filter((id) => !validIds.has(id))
+  if (staleIds.length > 0) {
+    throw new Error(
+      `SMI-5879: checkpoint at ${path} has ${staleIds.length} row_results key(s) that are not in ` +
+        `this generation's row set (e.g. ${staleIds.slice(0, 5).join(', ')}) — this checkpoint was ` +
+        'likely written for a different generation. Refusing to reuse stale verdicts; use a fresh ' +
+        '--checkpoint-path for this generation instead.'
+    )
+  }
+}
+
+/**
+ * Atomic replace: write to a temp file in the SAME directory as `path`,
+ * then `renameSync` over the real path. `renameSync` on the same
+ * filesystem is atomic on POSIX, so a crash mid-write (OOM-kill, host
+ * reboot) can never leave `path` itself truncated/corrupt — it is always
+ * either the previous complete checkpoint or the new one (SMI-5879 review
+ * finding 3). A `.bak` of the prior checkpoint was considered and
+ * deliberately skipped: the atomic rename already guarantees `path` is
+ * never syntactically corrupt, which was the actual failure mode observed;
+ * a backup would only help against a LOGICALLY wrong-but-valid checkpoint
+ * (an application bug writing bad data), which a single stale `.bak` isn't
+ * a reliable defense against either.
+ */
+export function writeCheckpoint(path: string, checkpoint: Smi5879SimulateCheckpoint): void {
+  const tmpPath = `${path}.tmp-${process.pid}`
+  writeFileSync(tmpPath, JSON.stringify(checkpoint, null, 2))
+  renameSync(tmpPath, path)
+}
+
+/** True when the on-disk checkpoint represents an abnormal prior termination (design 8.3.5.2.4 point 2). */
+export function isAbnormalResume(checkpoint: Smi5879SimulateCheckpoint | null): boolean {
+  return checkpoint !== null && checkpoint.clean_shutdown === false
+}
+
+// ---------------------------------------------------------------------------
+// Tier-3 sweep loop
+// ---------------------------------------------------------------------------
+
+export type SweepPassRunner = (residualIds: string[]) => Promise<Map<string, SimRowResult>>
+
+export interface SweepOptions {
+  maxPasses?: number
+  cooldownMs?: number
+  sleep?: (ms: number) => Promise<void>
+  /**
+   * Fires after each completed pass with the ABSOLUTE (resume-inclusive)
+   * pass number, that pass's resulting residual size, and the
+   * non-decrease streak as of that pass — the caller's single source of
+   * truth for writing a durable per-pass checkpoint segment, so a crash
+   * mid-sweep loses at most one pass of progress (SMI-5879 review
+   * finding 2). Do NOT independently increment a separate pass counter
+   * alongside this — that's exactly the doubled-accounting bug this
+   * finding flagged.
+   */
+  onPass?: (pass: number, residualSize: number, nonDecreaseStreak: number) => void
+  /**
+   * Resume state from a prior (possibly crashed) invocation's checkpoint
+   * (SMI-5879 review finding 2a) — a crash mid-sweep must not reset the
+   * `MAX_SWEEP_PASSES` budget or the two-consecutive-non-decrease
+   * hard-stop streak back to zero. Both default to 0 (cold start).
+   */
+  startingPass?: number
+  startingNonDecreaseStreak?: number
+}
+
+export interface SweepOutcome {
+  finalResults: Map<string, SimRowResult>
+  hardStopped: SweepHardStopReason
+  /** ABSOLUTE (resume-inclusive) total pass count — NOT just this invocation's own passes. */
+  passesRun: number
+  /** Only the passes actually run by THIS invocation — the caller prepends any prior history once. */
+  residualHistory: number[]
+  finalResidualSize: number
+  /** Final non-decrease streak value, for persisting back into the checkpoint across a resume. */
+  nonDecreaseStreak: number
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Re-run ONLY the rows currently classified `unevaluable`, in repeated sweep
+ * passes, until fixed point (`|R_k| = 0`) or a hard stop (plan §3b tier 3).
+ * `unfetchable` rows are never included in `initialResidual` by the caller —
+ * being terminal, they can never cause non-convergence.
+ */
+export async function runTier3Sweep(
+  initialResidual: SimRowResult[],
+  runPass: SweepPassRunner,
+  options: SweepOptions = {}
+): Promise<SweepOutcome> {
+  const maxPasses = options.maxPasses ?? MAX_SWEEP_PASSES
+  const cooldownMs = options.cooldownMs ?? SWEEP_COOLDOWN_MS
+  const sleep = options.sleep ?? defaultSleep
+  const startingPass = options.startingPass ?? 0
+  const startingNonDecreaseStreak = options.startingNonDecreaseStreak ?? 0
+
+  const finalResults = new Map<string, SimRowResult>(initialResidual.map((r) => [r.id, r]))
+  let residual = initialResidual
+  // `initialResidual` IS already "the residual as of the end of the last
+  // completed pass" on a resume (it's recomputed fresh from the checkpoint's
+  // row_results by the caller), so no special-casing is needed here for
+  // continuity — it's the correct `prevSize` baseline whether this is a cold
+  // start or a resume.
+  let prevSize = initialResidual.length
+  let nonDecreaseStreak = startingNonDecreaseStreak
+  let hardStopped: SweepHardStopReason = null
+  let passesRun = startingPass
+  const residualHistory: number[] = []
+
+  for (let pass = startingPass + 1; pass <= maxPasses; pass++) {
+    if (residual.length === 0) break
+    await sleep(cooldownMs)
+    passesRun = pass
+
+    const updated = await runPass(residual.map((r) => r.id))
+    for (const [id, result] of updated) finalResults.set(id, result)
+
+    const newResidual = residual
+      .map((r) => finalResults.get(r.id) as SimRowResult)
+      .filter((r) => r.outcome === 'unevaluable')
+    residualHistory.push(newResidual.length)
+
+    if (newResidual.length === 0) {
+      nonDecreaseStreak = 0
+      residual = newResidual
+      options.onPass?.(pass, newResidual.length, nonDecreaseStreak)
+      break
+    }
+
+    if (newResidual.length >= prevSize) nonDecreaseStreak++
+    else nonDecreaseStreak = 0
+    prevSize = newResidual.length
+    residual = newResidual
+    options.onPass?.(pass, newResidual.length, nonDecreaseStreak)
+
+    if (nonDecreaseStreak >= 2) {
+      hardStopped = 'non_convergence'
+      break
+    }
+  }
+
+  if (residual.length > 0 && hardStopped === null) hardStopped = 'max_passes'
+
+  return {
+    finalResults,
+    hardStopped,
+    passesRun,
+    residualHistory,
+    finalResidualSize: residual.length,
+    nonDecreaseStreak,
+  }
+}

--- a/scripts/indexer/smi5879-simulate-full.ts
+++ b/scripts/indexer/smi5879-simulate-full.ts
@@ -1,0 +1,478 @@
+/**
+ * SMI-5879 Wave 3 item 3: the real, gate-eligible pre-merge simulator.
+ * @module scripts/indexer/smi5879-simulate-full
+ *
+ * Writes `report_kind: "full_simulation"` — the ONLY report shape
+ * `gate-check.ts` (item 4) accepts for G-2. See
+ * `smi5879-simulate-preflight-estimate.ts` for the sampled, non-gate-eligible
+ * sibling tool.
+ *
+ * Plan: docs/internal/implementation/smi-5879-wave3-census-simulation-plan.md §3
+ * Design: docs/internal/implementation/smi-5879-edge-twin-parity-design.md §8.2/§8.3.5/§8.5
+ *
+ * Lifecycle: validate args (hard-refuse `token_source==='app'`) -> load run
+ * summary, refuse if not `sealed`/purpose mismatch -> claim
+ * (`smi5879_claim_run`) -> start independent-timer heartbeat -> verify digest
+ * (cold start, or resuming an abnormal prior termination) -> load population +
+ * branch map -> main pass (batched, checkpointed) -> tier-3 sweep on the
+ * `unevaluable` residual -> release claim -> write report.
+ *
+ * CLI contract, mirroring smi5879-census.ts's own --dry-run/--apply
+ * precedent (which itself follows revalidate-stale-quarantines.ts's):
+ * `--dry-run` is the DEFAULT — validates args, DB connectivity, and
+ * PAT-only GitHub auth, WITHOUT claiming or fetching anything. `--apply`
+ * performs the real run. UNLIKE revalidate-stale-quarantines.ts, this tool
+ * NEVER writes to `skills` in either mode — "apply" here means only "claim
+ * the generation, perform GitHub I/O, and write this tool's own
+ * report/checkpoint files, plus the generation's own claim/heartbeat/release
+ * fields" — never a `skills` row.
+ *
+ * Usage:
+ *   varlock run -- npx tsx scripts/indexer/smi5879-simulate-full.ts \
+ *     --run-id=<sealed generation run_id> --purpose=<decision|window|rehearsal> \
+ *     [--apply] [--checkpoint-path=<path>] [--report-path=<path>] [--baseline-commit=<sha>]
+ */
+
+import { hostname } from 'node:os'
+import { randomUUID } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
+import { writeFileSync } from 'node:fs'
+import { buildGitHubHeaders } from './_shared/github-auth.ts'
+import { newRateLimitTelemetry, pMapBounded } from './_shared/rate-limit.ts'
+import { poolerSessionConnParams, runPsql } from './smi5879-census.pg.ts'
+import { createSmi5879SimulateFullDbDeps } from './smi5879-simulate-full.db.ts'
+import {
+  materializeBaseline,
+  importBaselineScanSkillBundle,
+  BASELINE_COMMIT_SHA,
+} from './smi5879-simulate-full.baseline.ts'
+import { scanSkillBundle as headScanSkillBundle } from './skill-processor.security.ts'
+import {
+  processRow,
+  assertPatTokenSource,
+  CHECKPOINT_BATCH_SIZE,
+  PROCESS_CONCURRENCY,
+  HEARTBEAT_INTERVAL_MS,
+} from './smi5879-simulate-full.helpers.ts'
+import {
+  computeCoverage,
+  summarizeCounts,
+  estimateCompletionAt,
+  checkpointPathFor,
+  readCheckpoint,
+  writeCheckpoint,
+  isAbnormalResume,
+  runTier3Sweep,
+  decideExitCode,
+  assertCheckpointIdentity,
+  assertCheckpointRowsBelongToGeneration,
+} from './smi5879-simulate-full.sweep.ts'
+import type {
+  Smi5879SimulateFullDbDeps,
+  Smi5879SimulateCheckpoint,
+  Smi5879SimulateFullReport,
+  SimSnapshotRow,
+  SimulatedCohort,
+  ScanSkillBundleFn,
+} from './smi5879-simulate-full.types.ts'
+import type { Smi5879Purpose } from './smi5879-census.types.ts'
+
+const SIMULATED_COHORTS: readonly SimulatedCohort[] = ['C1', 'C2', 'C3', 'C4']
+const VALID_PURPOSES: readonly Smi5879Purpose[] = ['rehearsal', 'decision', 'window']
+
+export interface CliArgs {
+  runId: string
+  purpose: Smi5879Purpose
+  apply: boolean
+  checkpointPath?: string
+  reportPath?: string
+  baselineCommit: string
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const find = (name: string): string | undefined => {
+    const prefix = `--${name}=`
+    const hit = argv.find((a) => a.startsWith(prefix))
+    return hit ? hit.slice(prefix.length) : undefined
+  }
+  const runId = find('run-id')
+  if (!runId) throw new Error('SMI-5879: --run-id=<generation run_id> is required.')
+  const purpose = find('purpose')
+  if (!purpose || !VALID_PURPOSES.includes(purpose as Smi5879Purpose)) {
+    throw new Error(
+      `SMI-5879: --purpose=<${VALID_PURPOSES.join('|')}> is required, got ${purpose ?? '(missing)'}.`
+    )
+  }
+  // `checkpointPath`/`reportPath` are genuinely optional (downstream defaults via
+  // `?? checkpointPathFor(...)` / `?? 'smi5879-simulate-report-...'`) — under
+  // `exactOptionalPropertyTypes`, an optional property means "may be omitted",
+  // not "may be omitted OR explicitly `undefined`", so the key must be left off
+  // entirely when the flag wasn't passed rather than assigned `undefined`.
+  const checkpointPath = find('checkpoint-path')
+  const reportPath = find('report-path')
+  return {
+    runId,
+    purpose: purpose as Smi5879Purpose,
+    apply: argv.includes('--apply'),
+    ...(checkpointPath !== undefined ? { checkpointPath } : {}),
+    ...(reportPath !== undefined ? { reportPath } : {}),
+    baselineCommit: find('baseline-commit') ?? BASELINE_COMMIT_SHA,
+  }
+}
+
+/** `host:pid:git-head`, for `smi5879_run.runner_holder` — mirrors smi5879-census.ts's buildHolder(). */
+function buildHolder(): string {
+  let head = 'unknown'
+  try {
+    head = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim()
+  } catch {
+    // Not fatal — operator legibility only.
+  }
+  return `${hostname()}:${process.pid}:${head}`
+}
+
+/**
+ * Run the main pass over every not-yet-attempted row (from the checkpoint, if
+ * resuming), in concurrency-bounded batches, checkpointing after each batch.
+ */
+async function runMainPass(
+  rows: SimSnapshotRow[],
+  alreadyResults: Map<string, import('./smi5879-simulate-full.types.ts').SimRowResult>,
+  branchMap: import('./smi5879-simulate-full.types.ts').BranchMap,
+  scanDeps: {
+    scanPostPort: ScanSkillBundleFn
+    scanPrePort: ScanSkillBundleFn
+    telemetry: ReturnType<typeof newRateLimitTelemetry>
+    headers: Record<string, string>
+  },
+  onBatchDone: (
+    results: Map<string, import('./smi5879-simulate-full.types.ts').SimRowResult>
+  ) => Promise<void>
+): Promise<void> {
+  const pending = rows.filter((r) => !alreadyResults.has(r.id))
+  for (let i = 0; i < pending.length; i += CHECKPOINT_BATCH_SIZE) {
+    const batch = pending.slice(i, i + CHECKPOINT_BATCH_SIZE)
+    const outcomes = await pMapBounded(batch, (row) => processRow(row, branchMap, scanDeps), {
+      concurrency: PROCESS_CONCURRENCY,
+    })
+    for (const outcome of outcomes) alreadyResults.set(outcome.id, outcome)
+    await onBatchDone(alreadyResults)
+  }
+}
+
+/**
+ * Run the full generation lifecycle and return the assembled report.
+ * Exported for the test suite; `main()` is the CLI entrypoint.
+ */
+export async function runSimulateFull(
+  db: Smi5879SimulateFullDbDeps,
+  scanPostPort: ScanSkillBundleFn,
+  scanPrePort: ScanSkillBundleFn,
+  args: CliArgs,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<Smi5879SimulateFullReport> {
+  const tokenSource = assertPatTokenSource(env)
+
+  const summary = await db.getRunSummary(args.runId)
+  if (!summary) throw new Error(`SMI-5879: no smi5879_run row for run_id=${args.runId}.`)
+  if (summary.status !== 'sealed') {
+    throw new Error(
+      `SMI-5879: generation ${args.runId} is "${summary.status}", not "sealed" — the simulator ` +
+        'only runs against a sealed generation.'
+    )
+  }
+  if (summary.purpose !== args.purpose) {
+    throw new Error(
+      `SMI-5879: generation ${args.runId} has purpose "${summary.purpose}", but --purpose=` +
+        `${args.purpose} was given. Refusing to run against the wrong generation.`
+    )
+  }
+
+  const checkpointPath = args.checkpointPath ?? checkpointPathFor(args.runId)
+  const existingCheckpoint = readCheckpoint(checkpointPath)
+  const isColdStart = existingCheckpoint === null
+
+  if (existingCheckpoint) {
+    // Identity check FIRST, before the (pre-existing) baseline_commit check
+    // and before claiming — a wrong --checkpoint-path pointing at another
+    // generation's checkpoint must be refused loudly, never silently
+    // trusted (SMI-5879 review finding 1).
+    assertCheckpointIdentity(
+      existingCheckpoint,
+      { runId: args.runId, purpose: args.purpose, tokenSource },
+      checkpointPath
+    )
+    if (existingCheckpoint.baseline_commit !== args.baselineCommit) {
+      throw new Error(
+        `SMI-5879: existing checkpoint at ${checkpointPath} was computed against baseline commit ` +
+          `${existingCheckpoint.baseline_commit}, but this run resolved ${args.baselineCommit}. A ` +
+          'resume must use the SAME baseline pin as the original run — start a fresh checkpoint path instead.'
+      )
+    }
+  }
+
+  const token = randomUUID()
+  const holder = buildHolder()
+  const claimed = await db.claimRun(args.runId, token, holder)
+  if (!claimed.claimed) {
+    throw new Error(
+      `SMI-5879: claim of generation ${args.runId} was refused — held by another runner.`
+    )
+  }
+
+  const startedAt = new Date(existingCheckpoint?.started_at ?? new Date().toISOString())
+
+  let checkpoint: Smi5879SimulateCheckpoint = existingCheckpoint ?? {
+    run_id: args.runId,
+    purpose: args.purpose,
+    baseline_commit: args.baselineCommit,
+    token_source: tokenSource,
+    clean_shutdown: false,
+    row_results: {},
+    sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+    started_at: startedAt.toISOString(),
+    updated_at: new Date().toISOString(),
+  }
+
+  // Self-rescheduling setTimeout loop rather than setInterval (SMI-5879
+  // review finding 4): the NEXT heartbeat call is only scheduled after the
+  // current one settles, so a slow db.heartbeat() call from one tick can
+  // never overlap with a second in-flight call from the next tick.
+  // db.heartbeat()'s own rejection (transient network/psql failure) gets
+  // the SAME fatal-abort treatment as a `result === null` (lost claim) —
+  // design doc 8.3.5.2.5 treats "lost claim OR a genuine error" identically,
+  // never re-claiming and never silently swallowing either.
+  let heartbeatTimer: NodeJS.Timeout | null = null
+  let heartbeatStopped = false
+
+  const fatalHeartbeatAbort = (message: string): void => {
+    heartbeatStopped = true
+    checkpoint.clean_shutdown = false
+    writeCheckpoint(checkpointPath, checkpoint)
+    console.error(`[smi5879-simulate-full] FATAL: ${message} Exiting without re-claiming.`)
+    process.exit(1)
+  }
+
+  const scheduleHeartbeat = (): void => {
+    heartbeatTimer = setTimeout(() => {
+      void runHeartbeatTick()
+    }, HEARTBEAT_INTERVAL_MS)
+    heartbeatTimer.unref?.()
+  }
+
+  const runHeartbeatTick = async (): Promise<void> => {
+    if (heartbeatStopped) return
+    let result: string | null
+    try {
+      result = await db.heartbeat(args.runId, token)
+    } catch (err) {
+      fatalHeartbeatAbort(
+        `heartbeat call threw for run_id=${args.runId}: ${(err as Error).message}`
+      )
+      return
+    }
+    if (result === null) {
+      fatalHeartbeatAbort(
+        `heartbeat lost for run_id=${args.runId} — claim was stolen or the run was abandoned.`
+      )
+      return
+    }
+    if (!heartbeatStopped) scheduleHeartbeat()
+  }
+
+  scheduleHeartbeat()
+
+  try {
+    if (isColdStart || isAbnormalResume(existingCheckpoint)) {
+      const digest = await db.verifyDigest(args.runId)
+      if (!digest.populationMatches || !digest.branchMatches) {
+        checkpoint.clean_shutdown = false
+        writeCheckpoint(checkpointPath, checkpoint)
+        throw new Error(
+          `SMI-5879: digest verification failed for run_id=${args.runId} ` +
+            `(population_matches=${digest.populationMatches}, branch_matches=${digest.branchMatches}). ` +
+            'The generation is corrupt — the correct action is a new generation, not a repair.'
+        )
+      }
+    }
+
+    const rows = await db.loadCohortRows(args.runId)
+    if (existingCheckpoint) {
+      // Must run only after the real row set for this generation is loaded
+      // (SMI-5879 review finding 1) — refuses a checkpoint whose row_results
+      // keys don't correspond to any row in THIS generation.
+      assertCheckpointRowsBelongToGeneration(existingCheckpoint, rows, checkpointPath)
+    }
+    const branchMap = await db.loadBranchMap(args.runId)
+    const rowsByCohort = { C1: [], C2: [], C3: [], C4: [] } as Record<
+      SimulatedCohort,
+      SimSnapshotRow[]
+    >
+    for (const row of rows) rowsByCohort[row.cohort].push(row)
+
+    const telemetry = newRateLimitTelemetry()
+    const headers = await buildGitHubHeaders('skillsmith-smi5879-simulate/1.0')
+    const scanDeps = { scanPostPort, scanPrePort, telemetry, headers }
+
+    const results = new Map(Object.entries(checkpoint.row_results))
+
+    await runMainPass(rows, results, branchMap, scanDeps, async (current) => {
+      checkpoint = {
+        ...checkpoint,
+        clean_shutdown: false,
+        row_results: Object.fromEntries(current),
+        updated_at: new Date().toISOString(),
+      }
+      writeCheckpoint(checkpointPath, checkpoint)
+    })
+
+    // Resume state threaded into the sweep (SMI-5879 review finding 2a) —
+    // a crash mid-sweep must not reset the MAX_SWEEP_PASSES budget or the
+    // non-decrease hard-stop streak. `priorResidualHistory` is captured ONCE
+    // here and `sweepResidualHistory` grows it incrementally via `onPass`
+    // (below) as the single source of truth for every per-pass checkpoint
+    // write — the final write after the sweep returns reuses the exact same
+    // running total rather than re-deriving/re-adding it (finding 2b).
+    const priorSweepPass = checkpoint.sweep.pass
+    const priorNonDecreaseStreak = checkpoint.sweep.non_decrease_streak
+    const priorResidualHistory = [...checkpoint.sweep.residual_history]
+    const sweepResidualHistory: number[] = [...priorResidualHistory]
+
+    const residual = [...results.values()].filter((r) => r.outcome === 'unevaluable')
+    const sweep = await runTier3Sweep(
+      residual,
+      async (residualIds) => {
+        const idSet = new Set(residualIds)
+        const targets = rows.filter((r) => idSet.has(r.id))
+        const outcomes = await pMapBounded(targets, (row) => processRow(row, branchMap, scanDeps), {
+          concurrency: PROCESS_CONCURRENCY,
+        })
+        const updated = new Map(outcomes.map((o) => [o.id, o]))
+        for (const [id, result] of updated) results.set(id, result)
+        return updated
+      },
+      {
+        startingPass: priorSweepPass,
+        startingNonDecreaseStreak: priorNonDecreaseStreak,
+        onPass: (pass, residualSize, nonDecreaseStreak) => {
+          sweepResidualHistory.push(residualSize)
+          checkpoint = {
+            ...checkpoint,
+            clean_shutdown: false,
+            row_results: Object.fromEntries(results),
+            sweep: {
+              pass,
+              residual_history: [...sweepResidualHistory],
+              non_decrease_streak: nonDecreaseStreak,
+              hard_stopped: null,
+            },
+            updated_at: new Date().toISOString(),
+          }
+          writeCheckpoint(checkpointPath, checkpoint)
+        },
+      }
+    )
+
+    const coverage = computeCoverage(rowsByCohort, results)
+    const counts = summarizeCounts(results.values())
+    const totalRows = rows.length
+    const scannedRows = results.size
+
+    checkpoint = {
+      ...checkpoint,
+      clean_shutdown: true,
+      row_results: Object.fromEntries(results),
+      sweep: {
+        pass: sweep.passesRun,
+        residual_history: [...priorResidualHistory, ...sweep.residualHistory],
+        non_decrease_streak: sweep.nonDecreaseStreak,
+        hard_stopped: sweep.hardStopped,
+      },
+      updated_at: new Date().toISOString(),
+    }
+    writeCheckpoint(checkpointPath, checkpoint)
+
+    const report: Smi5879SimulateFullReport = {
+      report_kind: 'full_simulation',
+      run_id: args.runId,
+      purpose: args.purpose,
+      status: summary.status,
+      token_source: tokenSource,
+      baseline_commit: args.baselineCommit,
+      coverage,
+      estimated_completion_at: estimateCompletionAt(startedAt, new Date(), totalRows, scannedRows),
+      sweep: { passes_run: checkpoint.sweep.pass, hard_stopped: sweep.hardStopped },
+      rows: [...results.values()],
+      counts,
+      generated_at: new Date().toISOString(),
+    }
+    return report
+  } finally {
+    heartbeatStopped = true
+    if (heartbeatTimer) clearTimeout(heartbeatTimer)
+    await db.releaseRun(args.runId, token).catch((err) => {
+      console.error(`[smi5879-simulate-full] release failed (non-fatal): ${(err as Error).message}`)
+    })
+  }
+}
+
+function printSummary(report: Smi5879SimulateFullReport): void {
+  console.log(
+    `\n── Simulation Summary (${report.run_id}) ──\n` +
+      `  report_kind:       ${report.report_kind}\n` +
+      `  token_source:      ${report.token_source}\n` +
+      `  baseline_commit:   ${report.baseline_commit}\n` +
+      `  sweep:             ${report.sweep.passes_run} pass(es), hard_stopped=${report.sweep.hard_stopped ?? 'none'}\n` +
+      SIMULATED_COHORTS.map(
+        (c) =>
+          `  coverage.${c}:       ${report.coverage[c].status} (${report.coverage[c].scanned}/${report.coverage[c].total}, unevaluable=${report.coverage[c].unevaluable}, unfetchable=${report.coverage[c].unfetchable})`
+      ).join('\n') +
+      `\n  counts: ${JSON.stringify(report.counts)}\n`
+  )
+}
+
+async function dryRun(args: CliArgs): Promise<void> {
+  console.log(
+    `[DRY-RUN] run-id=${args.runId} purpose=${args.purpose} baseline-commit=${args.baselineCommit}`
+  )
+  assertPatTokenSource()
+  const conn = poolerSessionConnParams()
+  await runPsql(conn, 'SELECT 1;')
+  console.log('[DRY-RUN] DB connectivity OK (session pooler).')
+  const headers = await buildGitHubHeaders('skillsmith-smi5879-simulate/1.0')
+  console.log(
+    `[DRY-RUN] GitHub auth headers built (Authorization present: ${'Authorization' in headers}).`
+  )
+  console.log(
+    '[DRY-RUN] No generation claimed, no GitHub fetches performed, no checkpoint/report written. ' +
+      'Re-run with --apply to perform the real simulation.'
+  )
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  if (!args.apply) {
+    await dryRun(args)
+    return
+  }
+  const conn = poolerSessionConnParams()
+  const db = createSmi5879SimulateFullDbDeps(conn)
+  const baselineDir = materializeBaseline(args.baselineCommit)
+  const { scanSkillBundle: scanPrePort } = await importBaselineScanSkillBundle(baselineDir)
+
+  const report = await runSimulateFull(db, headScanSkillBundle, scanPrePort, args)
+  const reportPath = args.reportPath ?? `smi5879-simulate-report-${args.runId}.json`
+  writeFileSync(reportPath, JSON.stringify(report, null, 2))
+  printSummary(report)
+  console.log(`Report written to ${reportPath}`)
+
+  process.exitCode = decideExitCode(report.coverage, report.sweep.hard_stopped)
+}
+
+// Run only when invoked directly (not when imported by the test suite).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/scripts/indexer/smi5879-simulate-full.types.ts
+++ b/scripts/indexer/smi5879-simulate-full.types.ts
@@ -1,0 +1,180 @@
+/**
+ * Types for smi5879-simulate-full.ts, split out per CLAUDE.md's `foo.types.ts`
+ * convention.
+ * @module scripts/indexer/smi5879-simulate-full.types
+ *
+ * Plan: docs/internal/implementation/smi-5879-wave3-census-simulation-plan.md §3
+ * Design: docs/internal/implementation/smi-5879-edge-twin-parity-design.md §8.2/§8.3.5/§8.5
+ */
+
+import type { ScanSkillBundleResult } from './skill-processor.security.ts'
+import type { RateLimitTelemetry } from './_shared/rate-limit.ts'
+import type { Smi5879Purpose, Smi5879RunStatus } from './smi5879-census.types.ts'
+
+/** Cohorts the simulator fully evaluates. Cohort E is structurally excluded (item 2). */
+export type SimulatedCohort = 'C1' | 'C2' | 'C3' | 'C4'
+
+/**
+ * Closed tier-2 outcome vocabulary (plan §3b). `gate-check.ts` refuses an
+ * unrecognised value — this union is the enforcement point on our side.
+ */
+export type SimRowOutcome =
+  | 'newly_quarantined'
+  | 'newly_cleared'
+  | 'unchanged_clean'
+  | 'unchanged_quarantined'
+  | 'content_drifted'
+  | 'bundle_absent'
+  | 'unevaluable'
+  | 'unfetchable'
+
+/** One row read from the sealed generation's population (`smi5879_snapshot_pre`), cohort-tagged. */
+export interface SimSnapshotRow {
+  id: string
+  cohort: SimulatedCohort
+  repo_url: string | null
+  skill_path: string | null
+  author: string | null
+  name: string | null
+  /** SHA-256 of the SKILL.md content as recorded at snapshot time, or null (never scanned). */
+  content_hash: string | null
+  /** Snapshot-time state, carried through for G-1 reviewer legibility only — never compared against. */
+  snapshot_security_score: number | null
+  snapshot_quarantined: boolean | null
+}
+
+/** `smi5879_repo_branch` resolution for one distinct `(owner, repo)` — item 1, design 8.3.5.2.2. */
+export interface RepoBranchInfo {
+  resolution: 'resolved' | 'not-found' | 'transient' | 'unparseable'
+  default_branch: string | null
+}
+
+/** Keyed `${owner}/${repo}`. */
+export type BranchMap = Map<string, RepoBranchInfo>
+
+/** Per-row simulation result. */
+export interface SimRowResult {
+  id: string
+  cohort: SimulatedCohort
+  author: string | null
+  name: string | null
+  outcome: SimRowOutcome
+  /** Populated whenever `outcome` isn't a plain verdict-delta bucket — names the exact cause. */
+  reason?: string
+  prePortQuarantine?: boolean
+  postPortQuarantine?: boolean
+  prePortRiskScore?: number
+  postPortRiskScore?: number
+}
+
+/** `coverage.<cohort>` — design doc 8.4 / plan §3c. */
+export interface CohortCoverage {
+  status: 'full' | 'partial'
+  scanned: number
+  total: number
+  unevaluable: number
+  unfetchable: number
+}
+
+export type CoverageByCohort = Record<SimulatedCohort, CohortCoverage>
+
+/** `token_source` — plan §3a. Hard-refuses to start when resolved as `'app'`. */
+export type TokenSource = 'app' | 'pat'
+
+/** Tier-3 sweep termination reason (plan §3b tier 3), or `null` on convergence. */
+export type SweepHardStopReason = 'non_convergence' | 'max_passes' | null
+
+/**
+ * On-disk resumable checkpoint (plan §3c "resumable, checkpointed"). Written
+ * after every processing batch and every sweep pass. `clean_shutdown` starts
+ * `false` for every interim write and is flipped to `true` only immediately
+ * before a graceful process exit — see design doc 8.3.5.2.4's "abnormal
+ * termination" definition, which this field directly feeds.
+ */
+export interface Smi5879SimulateCheckpoint {
+  run_id: string
+  purpose: Smi5879Purpose
+  baseline_commit: string
+  token_source: TokenSource
+  /** True only immediately before a graceful exit; false at every interim write. */
+  clean_shutdown: boolean
+  /** Per-row outcomes recorded so far (main pass + all sweep passes), keyed by row id. */
+  row_results: Record<string, SimRowResult>
+  sweep: {
+    pass: number
+    residual_history: number[]
+    /**
+     * The tier-3 sweep's two-consecutive-non-decrease hard-stop streak, as of
+     * the last persisted pass. Threaded back into `runTier3Sweep`'s
+     * `startingNonDecreaseStreak` on resume so a crash mid-sweep can't reset
+     * the streak and let a non-converging run keep going past where it
+     * should have hard-stopped (SMI-5879 review finding 2a).
+     */
+    non_decrease_streak: number
+    hard_stopped: SweepHardStopReason
+  }
+  started_at: string
+  updated_at: string
+}
+
+/** Machine-readable simulator report — the gate-eligible artifact (plan §3, design 8.4). */
+export interface Smi5879SimulateFullReport {
+  report_kind: 'full_simulation'
+  run_id: string
+  purpose: Smi5879Purpose
+  status: Smi5879RunStatus
+  token_source: TokenSource
+  baseline_commit: string
+  coverage: CoverageByCohort
+  estimated_completion_at: string | null
+  sweep: {
+    passes_run: number
+    hard_stopped: SweepHardStopReason
+  }
+  /** Full per-row results — the source of R (union of newly_quarantined/newly_cleared) for G-1. */
+  rows: SimRowResult[]
+  counts: Record<SimRowOutcome, number>
+  generated_at: string
+}
+
+/** Injectable DB-facing dependencies — production wires real psql calls; tests inject fakes. */
+export interface Smi5879SimulateFullDbDeps {
+  getRunSummary(
+    runId: string
+  ): Promise<{ purpose: Smi5879Purpose; status: Smi5879RunStatus } | null>
+  claimRun(runId: string, token: string, holder: string): Promise<{ claimed: boolean }>
+  /** Returns the new heartbeat timestamp, or null when the claim was lost (fatal — see design 8.3.5.2.5). */
+  heartbeat(runId: string, token: string): Promise<string | null>
+  releaseRun(runId: string, token: string): Promise<void>
+  /** Recomputes and compares both digests against the sealed values recorded at seal time. */
+  verifyDigest(runId: string): Promise<{ populationMatches: boolean; branchMatches: boolean }>
+  loadCohortRows(runId: string): Promise<SimSnapshotRow[]>
+  loadBranchMap(runId: string): Promise<BranchMap>
+}
+
+/** Injectable scan-surface dependencies — the dual-scan mechanics (design 8.2.3). */
+export interface Smi5879SimulateFullScanDeps {
+  scanPostPort: ScanSkillBundleFn
+  scanPrePort: ScanSkillBundleFn
+  telemetry: RateLimitTelemetry
+  headers: Record<string, string>
+}
+
+/** `scanSkillBundle`'s exact signature — matched structurally so a baseline-materialized twin type-checks. */
+export type ScanSkillBundleFn = (
+  owner: string,
+  repo: string,
+  branch: string,
+  skillPath: string | undefined,
+  primaryContent: string,
+  telemetry: RateLimitTelemetry,
+  deps?: {
+    fetchSiblingContent?: (
+      owner: string,
+      repo: string,
+      branch: string,
+      relPath: string,
+      telemetry: RateLimitTelemetry
+    ) => Promise<{ content: string } | { removed: true } | null>
+  }
+) => Promise<ScanSkillBundleResult>

--- a/scripts/indexer/smi5879-simulate-preflight-estimate.ts
+++ b/scripts/indexer/smi5879-simulate-preflight-estimate.ts
@@ -1,0 +1,317 @@
+/**
+ * SMI-5879 Wave 3 item 3: the §8.4-permitted sampled pre-flight estimate.
+ * @module scripts/indexer/smi5879-simulate-preflight-estimate
+ *
+ * Writes `report_kind: "preflight_estimate"` — structurally distinct from
+ * `smi5879-simulate-full.ts`'s `"full_simulation"` so `gate-check.ts` (item 4)
+ * can never mistake one for the other. Design doc §8.4: "seeded sampling is an
+ * estimator, never a substitute for coverage... a sampled result may not
+ * satisfy any 8.5 acceptance criterion for C1, C2, C3 or C4."
+ *
+ * Samples ONLY cohorts C2 and C3 (per §8.4: "sample C2 and C3 to estimate the
+ * verdict-change rate and hence the expected size of R") — those two
+ * dominate population size (per the plan's sizing table, C2 is ~91% of the
+ * full-simulation workload) and are where "did the scanner change verdicts"
+ * is actually in question; C1/C4 are already-scored/quarantined cohorts whose
+ * inclusion here would dilute the estimate this tool exists to produce.
+ *
+ * Sampling: deterministic PRNG (mulberry32, seeded), population sorted by
+ * `id` before sampling (design doc §8.4's retained-unchanged mechanism), and
+ * the report prints the seed, sampling-frame size, a SHA-256 hash of the
+ * FULL sampling frame's sorted id list (proving the frame itself is
+ * reproducible, not just the drawn sample), and a 95% normal-approximation
+ * confidence interval on both the verdict-change rate and the resulting
+ * |R| estimate.
+ *
+ * Every output surface — console AND the report JSON's own `label` field —
+ * prints `ESTIMATE — NOT GATE INPUT` so this can never be mistaken for
+ * `smi5879-simulate-full.ts`'s gate-eligible output even by a human skimming
+ * a terminal.
+ *
+ * Usage:
+ *   varlock run -- npx tsx scripts/indexer/smi5879-simulate-preflight-estimate.ts \
+ *     --run-id=<sealed generation run_id> --purpose=<decision|window|rehearsal> \
+ *     [--sample-size=200] [--seed=42] [--apply] [--report-path=<path>] [--baseline-commit=<sha>]
+ */
+
+import { writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { buildGitHubHeaders } from './_shared/github-auth.ts'
+import { newRateLimitTelemetry } from './_shared/rate-limit.ts'
+import { poolerSessionConnParams, runPsql } from './smi5879-census.pg.ts'
+import { createSmi5879SimulateFullDbDeps } from './smi5879-simulate-full.db.ts'
+import {
+  materializeBaseline,
+  importBaselineScanSkillBundle,
+  BASELINE_COMMIT_SHA,
+} from './smi5879-simulate-full.baseline.ts'
+import { scanSkillBundle as headScanSkillBundle } from './skill-processor.security.ts'
+import { processRow, assertPatTokenSource } from './smi5879-simulate-full.helpers.ts'
+import { summarizeCounts } from './smi5879-simulate-full.sweep.ts'
+import type {
+  Smi5879SimulateFullDbDeps,
+  SimRowOutcome,
+  SimSnapshotRow,
+  ScanSkillBundleFn,
+  TokenSource,
+} from './smi5879-simulate-full.types.ts'
+import type { Smi5879Purpose } from './smi5879-census.types.ts'
+
+export const LABEL = 'ESTIMATE — NOT GATE INPUT'
+const VALID_PURPOSES: readonly Smi5879Purpose[] = ['rehearsal', 'decision', 'window']
+const VERDICT_OUTCOMES: readonly SimRowOutcome[] = [
+  'newly_quarantined',
+  'newly_cleared',
+  'unchanged_clean',
+  'unchanged_quarantined',
+]
+export const DEFAULT_SAMPLE_SIZE = 200
+export const DEFAULT_SEED = 42
+
+export interface CliArgs {
+  runId: string
+  purpose: Smi5879Purpose
+  apply: boolean
+  sampleSize: number
+  seed: number
+  reportPath?: string
+  baselineCommit: string
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const find = (name: string): string | undefined => {
+    const prefix = `--${name}=`
+    const hit = argv.find((a) => a.startsWith(prefix))
+    return hit ? hit.slice(prefix.length) : undefined
+  }
+  const runId = find('run-id')
+  if (!runId) throw new Error('SMI-5879: --run-id=<generation run_id> is required.')
+  const purpose = find('purpose')
+  if (!purpose || !VALID_PURPOSES.includes(purpose as Smi5879Purpose)) {
+    throw new Error(
+      `SMI-5879: --purpose=<${VALID_PURPOSES.join('|')}> is required, got ${purpose ?? '(missing)'}.`
+    )
+  }
+  const sampleSizeRaw = find('sample-size')
+  const sampleSize = sampleSizeRaw ? Number(sampleSizeRaw) : DEFAULT_SAMPLE_SIZE
+  if (!Number.isFinite(sampleSize) || sampleSize <= 0) {
+    throw new Error(`SMI-5879: --sample-size must be a positive number, got ${sampleSizeRaw}.`)
+  }
+  const seedRaw = find('seed')
+  const seed = seedRaw ? Number(seedRaw) : DEFAULT_SEED
+  if (!Number.isFinite(seed)) {
+    throw new Error(`SMI-5879: --seed must be a finite number, got ${seedRaw}.`)
+  }
+  // `reportPath` is genuinely optional (defaulted downstream) — under
+  // `exactOptionalPropertyTypes`, an optional property means "may be omitted",
+  // not "may be omitted OR explicitly `undefined`", so the key must be left off
+  // entirely when the flag wasn't passed rather than assigned `undefined`.
+  const reportPath = find('report-path')
+  return {
+    runId,
+    purpose: purpose as Smi5879Purpose,
+    apply: argv.includes('--apply'),
+    sampleSize,
+    seed,
+    ...(reportPath !== undefined ? { reportPath } : {}),
+    baselineCommit: find('baseline-commit') ?? BASELINE_COMMIT_SHA,
+  }
+}
+
+/** mulberry32 — small, fast, deterministic PRNG. Returns a function yielding floats in [0,1). */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return function next(): number {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** Deterministic partial Fisher-Yates draw of `n` items from `rows` (already sorted by caller). */
+export function seededSample<T>(rows: readonly T[], n: number, seed: number): T[] {
+  const pool = [...rows]
+  const rng = mulberry32(seed)
+  const count = Math.min(n, pool.length)
+  for (let i = 0; i < count; i++) {
+    const j = i + Math.floor(rng() * (pool.length - i))
+    // `i < count <= pool.length` and `j` is drawn from `[i, pool.length)`, so both
+    // indices are always in bounds — but `noUncheckedIndexedAccess` can't see that
+    // invariant, and a bare `[pool[i], pool[j]] = [pool[j], pool[i]]` swap would
+    // silently write `undefined` into the pool if it were ever violated by a
+    // future refactor. Confirm it explicitly rather than casting past it.
+    const a = pool[i]
+    const b = pool[j]
+    if (a === undefined || b === undefined) {
+      throw new Error(
+        `SMI-5879: seededSample index out of bounds (i=${i}, j=${j}, pool.length=${pool.length}) — should be unreachable.`
+      )
+    }
+    pool[i] = b
+    pool[j] = a
+  }
+  return pool.slice(0, count)
+}
+
+/** SHA-256 of the sorted-by-id sampling frame's id list, netstring-joined (deterministic, injection-proof). */
+export function samplingFrameHash(sortedIds: readonly string[]): string {
+  const hash = createHash('sha256')
+  for (const id of sortedIds) hash.update(`${Buffer.byteLength(id, 'utf8')}:${id}`)
+  return hash.digest('hex')
+}
+
+/** 95% normal-approximation CI on a sample proportion, clamped to [0,1]. */
+export function wilsonNormalCi95(successes: number, n: number): [number, number] {
+  if (n === 0) return [0, 0]
+  const p = successes / n
+  const margin = 1.96 * Math.sqrt((p * (1 - p)) / n)
+  return [Math.max(0, p - margin), Math.min(1, p + margin)]
+}
+
+export interface Smi5879PreflightEstimateReport {
+  report_kind: 'preflight_estimate'
+  label: typeof LABEL
+  run_id: string
+  purpose: Smi5879Purpose
+  token_source: TokenSource
+  baseline_commit: string
+  seed: number
+  sampling_frame_size: number
+  sampling_frame_id_hash: string
+  sample_size: number
+  fully_scanned_sample_size: number
+  verdict_change_rate: number
+  verdict_change_rate_ci95: [number, number]
+  estimated_R: number
+  estimated_R_ci95: [number, number]
+  counts: Record<SimRowOutcome, number>
+  generated_at: string
+}
+
+export async function runPreflightEstimate(
+  db: Smi5879SimulateFullDbDeps,
+  scanPostPort: ScanSkillBundleFn,
+  scanPrePort: ScanSkillBundleFn,
+  args: CliArgs,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<Smi5879PreflightEstimateReport> {
+  const tokenSource = assertPatTokenSource(env)
+
+  const summary = await db.getRunSummary(args.runId)
+  if (!summary) throw new Error(`SMI-5879: no smi5879_run row for run_id=${args.runId}.`)
+  if (summary.status !== 'sealed') {
+    throw new Error(`SMI-5879: generation ${args.runId} is "${summary.status}", not "sealed".`)
+  }
+  if (summary.purpose !== args.purpose) {
+    throw new Error(
+      `SMI-5879: generation ${args.runId} has purpose "${summary.purpose}", not --purpose=${args.purpose}.`
+    )
+  }
+
+  const allRows = await db.loadCohortRows(args.runId)
+  const frame: SimSnapshotRow[] = allRows
+    .filter((r) => r.cohort === 'C2' || r.cohort === 'C3')
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+  const frameIds = frame.map((r) => r.id)
+  const frameHash = samplingFrameHash(frameIds)
+
+  const branchMap = await db.loadBranchMap(args.runId)
+  const telemetry = newRateLimitTelemetry()
+  const headers = await buildGitHubHeaders('skillsmith-smi5879-preflight-estimate/1.0')
+  const scanDeps = { scanPostPort, scanPrePort, telemetry, headers }
+
+  const sample = seededSample(frame, args.sampleSize, args.seed)
+  const results = []
+  for (const row of sample) {
+    results.push(await processRow(row, branchMap, scanDeps))
+  }
+
+  const counts = summarizeCounts(results)
+  const fullyScanned = results.filter((r) => VERDICT_OUTCOMES.includes(r.outcome))
+  const changed = counts.newly_quarantined + counts.newly_cleared
+  const rate = fullyScanned.length > 0 ? changed / fullyScanned.length : 0
+  const rateCi = wilsonNormalCi95(changed, fullyScanned.length)
+  const estimatedR = rate * frame.length
+  const estimatedRCi: [number, number] = [rateCi[0] * frame.length, rateCi[1] * frame.length]
+
+  return {
+    report_kind: 'preflight_estimate',
+    label: LABEL,
+    run_id: args.runId,
+    purpose: args.purpose,
+    token_source: tokenSource,
+    baseline_commit: args.baselineCommit,
+    seed: args.seed,
+    sampling_frame_size: frame.length,
+    sampling_frame_id_hash: frameHash,
+    sample_size: sample.length,
+    fully_scanned_sample_size: fullyScanned.length,
+    verdict_change_rate: rate,
+    verdict_change_rate_ci95: rateCi,
+    estimated_R: estimatedR,
+    estimated_R_ci95: estimatedRCi,
+    counts,
+    generated_at: new Date().toISOString(),
+  }
+}
+
+function printSummary(report: Smi5879PreflightEstimateReport): void {
+  console.log(
+    `\n── ${LABEL} — Preflight Sample (${report.run_id}) ──\n` +
+      `  seed:                    ${report.seed}\n` +
+      `  sampling_frame_size:     ${report.sampling_frame_size} (C2 ∪ C3)\n` +
+      `  sampling_frame_id_hash:  ${report.sampling_frame_id_hash}\n` +
+      `  sample_size:             ${report.sample_size} (${report.fully_scanned_sample_size} fully scanned)\n` +
+      `  verdict_change_rate:     ${(report.verdict_change_rate * 100).toFixed(2)}% ` +
+      `[${(report.verdict_change_rate_ci95[0] * 100).toFixed(2)}%, ${(report.verdict_change_rate_ci95[1] * 100).toFixed(2)}%]\n` +
+      `  estimated_R:             ${report.estimated_R.toFixed(0)} ` +
+      `[${report.estimated_R_ci95[0].toFixed(0)}, ${report.estimated_R_ci95[1].toFixed(0)}]\n` +
+      `  counts: ${JSON.stringify(report.counts)}\n\n` +
+      `${LABEL} — this report may NOT satisfy any G-2/G-5 acceptance criterion.\n`
+  )
+}
+
+async function dryRun(args: CliArgs): Promise<void> {
+  console.log(
+    `[DRY-RUN] ${LABEL} — run-id=${args.runId} purpose=${args.purpose} sample-size=${args.sampleSize} seed=${args.seed}`
+  )
+  assertPatTokenSource()
+  const conn = poolerSessionConnParams()
+  await runPsql(conn, 'SELECT 1;')
+  console.log('[DRY-RUN] DB connectivity OK (session pooler).')
+  const headers = await buildGitHubHeaders('skillsmith-smi5879-preflight-estimate/1.0')
+  console.log(
+    `[DRY-RUN] GitHub auth headers built (Authorization present: ${'Authorization' in headers}).`
+  )
+  console.log(
+    '[DRY-RUN] No sampling or GitHub fetches performed. Re-run with --apply for the real estimate.'
+  )
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  if (!args.apply) {
+    await dryRun(args)
+    return
+  }
+  const conn = poolerSessionConnParams()
+  const db = createSmi5879SimulateFullDbDeps(conn)
+  const baselineDir = materializeBaseline(args.baselineCommit)
+  const { scanSkillBundle: scanPrePort } = await importBaselineScanSkillBundle(baselineDir)
+
+  const report = await runPreflightEstimate(db, headScanSkillBundle, scanPrePort, args)
+  const reportPath = args.reportPath ?? `smi5879-preflight-estimate-report-${args.runId}.json`
+  writeFileSync(reportPath, JSON.stringify(report, null, 2))
+  printSummary(report)
+  console.log(`Report written to ${reportPath} — ${LABEL}`)
+}
+
+// Run only when invoked directly (not when imported by the test suite).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/scripts/tests/indexer/run-gate-callsites.test.ts
+++ b/scripts/tests/indexer/run-gate-callsites.test.ts
@@ -11,20 +11,28 @@
  *     "executable-looking library" (today, only `recheck.ts`) that must be
  *     asserted to STAY that way, because the day it gains a `main()` call it
  *     becomes an ungated direct entry point to a production writer.
- *   - Shape 4 (SMI-5879 Wave 3 item 1, new): guarded direct entry that is
- *     deliberately NOT run-gated. `smi5879-census.ts` uses the identical
- *     Shape-1 guard (so `hasDirectEntryGuard` matches it too) but must NOT
- *     call `assertRunAllowed`/`assertFreezeMarkerClear` — it is a READER of
- *     `skills` (never a writer through the indexer's normal write path;
- *     its own `smi5879_snapshot_pre`/`smi5879_repo_branch` tables are
+ *   - Shape 4 (SMI-5879 Wave 3 item 1, new; extended item 3): guarded direct
+ *     entry that is deliberately NOT run-gated. `smi5879-census.ts` uses the
+ *     identical Shape-1 guard (so `hasDirectEntryGuard` matches it too) but
+ *     must NOT call `assertRunAllowed`/`assertFreezeMarkerClear` — it is a
+ *     READER of `skills` (never a writer through the indexer's normal write
+ *     path; its own `smi5879_snapshot_pre`/`smi5879_repo_branch` tables are
  *     independently guarded by `smi5879_snapshot_guard()`,
  *     `supabase/migrations/20260808000000_smi5879_snapshot_generations.sql`)
  *     and, more fundamentally, it is the tool the SMI-5879 change-window
  *     freeze exists to PROTECT, not one the freeze should block: design doc
  *     8.3.2.5.7's runbook runs it at T-3d/T-0 20:15 UTC while
  *     `INDEXER_RUN_ALLOWLIST=maintenance,recheck`/`none` is already engaged,
- *     so gating it on the same mechanism would be circular. Pinned as its own
- *     explicit single-file set (Shape 1's "exactly 3" assertion below is
+ *     so gating it on the same mechanism would be circular. Item 3's
+ *     `smi5879-simulate-full.ts`/`smi5879-simulate-preflight-estimate.ts` are
+ *     the identical shape for the identical reason: both are pure READERS
+ *     (they never write to `skills`, only to their own report/checkpoint
+ *     artifacts and their generation's own claim/heartbeat fields — see
+ *     `smi5879-simulate-full.ts`'s own module doc), and both are designed to
+ *     run concurrently with the live 00:00/03:00 crons over a multi-day
+ *     window (plan §3a), so gating them on the same freeze mechanism they are
+ *     explicitly meant to coexist with would be exactly as circular. Pinned
+ *     as its own explicit set (Shape 1's "exactly 3" assertion below is
  *     `PINNED_SHAPE1 ∪ PINNED_SHAPE4_UNGATED_GUARD`) rather than silently
  *     absorbed, so a FUTURE guard-shaped file that SHOULD be gated cannot
  *     hide behind this exclusion.
@@ -53,7 +61,11 @@ const PINNED_SHAPE1 = [
 
 const PINNED_SHAPE2 = ['run.ts']
 
-const PINNED_SHAPE4_UNGATED_GUARD = ['smi5879-census.ts']
+const PINNED_SHAPE4_UNGATED_GUARD = [
+  'smi5879-census.ts',
+  'smi5879-simulate-full.ts',
+  'smi5879-simulate-preflight-estimate.ts',
+].sort()
 
 const PINNED_SHEBANG_FILES = [
   'dequarantine-false-positives.ts',
@@ -88,7 +100,7 @@ describe('Shape 1 — guarded direct-entry census', () => {
 })
 
 describe('Shape 4 — guarded direct entry that is deliberately NOT an indexer writer', () => {
-  it('is EXACTLY the pinned single-file set {smi5879-census.ts}', () => {
+  it('is EXACTLY the pinned set {smi5879-census.ts, smi5879-simulate-full.ts, smi5879-simulate-preflight-estimate.ts}', () => {
     const files = listIndexerSourceFiles()
     const shape4Files = files
       .filter(

--- a/scripts/tests/indexer/smi5879-fetch-retry.test.ts
+++ b/scripts/tests/indexer/smi5879-fetch-retry.test.ts
@@ -1,0 +1,179 @@
+/**
+ * SMI-5879 Wave 3 item 3, tier 1: smi5879-fetch-retry.ts tests.
+ * @module scripts/tests/indexer/smi5879-fetch-retry
+ *
+ * Covers plan §3b tier 1's exact contract: `{content}`/`{removed:true}`
+ * return without retry; `null` retries with full-jitter waits bounded by
+ * `[0, min(maxMs, baseMs * 2^attempt)]`; retry exhaustion returns a
+ * distinguished `{exhausted:true, lastStatus}` (never a bare `null`); a
+ * `RateLimitError`-shaped throw is retried without depending on `withBackoff`;
+ * and — the module's own must-not-modify guarantee — `_shared/rate-limit.ts`'s
+ * `withBackoff` export is byte-identical to a hash captured at authoring time.
+ */
+
+import { readFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { join } from 'node:path'
+import { describe, it, expect, vi } from 'vitest'
+import {
+  withFetchRetry,
+  fullJitterWaitMs,
+  DEFAULT_BASE_MS,
+  DEFAULT_MAX_MS,
+} from '../../indexer/smi5879-fetch-retry.ts'
+import { RateLimitError } from '../../indexer/_shared/rate-limit.ts'
+
+describe('withFetchRetry', () => {
+  it('returns { content } immediately, without retry', async () => {
+    const attempt = vi.fn().mockResolvedValue({ content: 'hello' })
+    const result = await withFetchRetry(attempt)
+    expect(result).toEqual({ content: 'hello' })
+    expect(attempt).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns { removed: true } immediately, without retry — a 404 is a positive absence signal', async () => {
+    const attempt = vi.fn().mockResolvedValue({ removed: true })
+    const result = await withFetchRetry(attempt)
+    expect(result).toEqual({ removed: true })
+    expect(attempt).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries on null with waits inside [0, min(maxMs, baseMs * 2^attempt)]', async () => {
+    const waits: number[] = []
+    const attempt = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ content: 'ok' })
+
+    const result = await withFetchRetry(attempt, {
+      baseMs: 10,
+      maxMs: 1000,
+      onRetry: (_attempt, waitMs) => waits.push(waitMs),
+    })
+
+    expect(result).toEqual({ content: 'ok' })
+    expect(attempt).toHaveBeenCalledTimes(3)
+    expect(waits).toHaveLength(2)
+    // attempt index 0: cap = min(1000, 10*2^0) = 10
+    expect(waits[0]).toBeGreaterThanOrEqual(0)
+    expect(waits[0]).toBeLessThanOrEqual(10)
+    // attempt index 1: cap = min(1000, 10*2^1) = 20
+    expect(waits[1]).toBeGreaterThanOrEqual(0)
+    expect(waits[1]).toBeLessThanOrEqual(20)
+  })
+
+  it('exhaustion returns a distinguished { exhausted: true, lastStatus } — never collapses to a bare null', async () => {
+    const attempt = vi.fn().mockResolvedValue(null)
+    const result = await withFetchRetry(attempt, { maxRetries: 2, baseMs: 1, maxMs: 5 })
+    expect(result).toEqual({ exhausted: true, lastStatus: null })
+    expect(result).not.toBeNull()
+    // 1 initial attempt + 2 retries = 3 calls
+    expect(attempt).toHaveBeenCalledTimes(3)
+  })
+
+  it('exhaustion carries lastStatus when the caller supplies one via captureStatus', async () => {
+    const attempt = vi.fn().mockResolvedValue(null)
+    const result = await withFetchRetry(attempt, {
+      maxRetries: 1,
+      baseMs: 1,
+      maxMs: 5,
+      captureStatus: () => 503,
+    })
+    expect(result).toEqual({ exhausted: true, lastStatus: 503 })
+  })
+
+  it('a RateLimitError-shaped throw is treated as retryable, handled without depending on withBackoff', async () => {
+    let calls = 0
+    const attempt = vi.fn().mockImplementation(async () => {
+      calls++
+      if (calls === 1) throw new RateLimitError('rate limited', 429, 0)
+      return { content: 'recovered' }
+    })
+    const result = await withFetchRetry(attempt, { baseMs: 1, maxMs: 5 })
+    expect(result).toEqual({ content: 'recovered' })
+    expect(attempt).toHaveBeenCalledTimes(2)
+  })
+
+  it('a RateLimitError throw contributes its .status to lastStatus on exhaustion', async () => {
+    const attempt = vi.fn().mockRejectedValue(new RateLimitError('rate limited', 429, 0))
+    const result = await withFetchRetry(attempt, { maxRetries: 1, baseMs: 1, maxMs: 5 })
+    expect(result).toEqual({ exhausted: true, lastStatus: 429 })
+  })
+
+  it('propagates a non-RateLimitError throw rather than silently retrying it', async () => {
+    const attempt = vi.fn().mockRejectedValue(new Error('boom'))
+    await expect(withFetchRetry(attempt, { maxRetries: 3 })).rejects.toThrow('boom')
+    expect(attempt).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors overridden maxRetries/baseMs/maxMs defaults', () => {
+    expect(DEFAULT_BASE_MS).toBe(1000)
+    expect(DEFAULT_MAX_MS).toBe(60_000)
+  })
+})
+
+describe('fullJitterWaitMs', () => {
+  it('is always within [0, min(maxMs, baseMs * 2^attempt)]', () => {
+    for (let attempt = 0; attempt < 8; attempt++) {
+      const cap = Math.min(60_000, 1000 * 2 ** attempt)
+      for (let i = 0; i < 20; i++) {
+        const wait = fullJitterWaitMs(attempt, 1000, 60_000)
+        expect(wait).toBeGreaterThanOrEqual(0)
+        expect(wait).toBeLessThanOrEqual(cap)
+      }
+    }
+  })
+
+  it('respects the maxMs ceiling even at a high attempt count', () => {
+    const wait = fullJitterWaitMs(20, 1000, 60_000)
+    expect(wait).toBeLessThanOrEqual(60_000)
+  })
+})
+
+describe('_shared/rate-limit.ts must-not-modify guard', () => {
+  /**
+   * Extract `withBackoff`'s exact exported source text via brace matching
+   * (robust to reformatting elsewhere in the file) and hash it. A hardcoded
+   * expected hash — captured when this test was authored — is more robust
+   * than a `git diff HEAD` comparison (trivially zero at authoring time
+   * regardless of whether anything is actually protected, and brittle across
+   * shallow clones / rebase mechanics) and more targeted than hashing the
+   * whole file (which would also trip on unrelated future changes to this
+   * shared module, e.g. new telemetry fields).
+   */
+  function extractWithBackoffSource(fileSrc: string): string {
+    const marker = 'export async function withBackoff'
+    const start = fileSrc.indexOf(marker)
+    if (start === -1) {
+      throw new Error(
+        'withBackoff export not found in _shared/rate-limit.ts — has it been renamed/removed?'
+      )
+    }
+    let depth = 0
+    let started = false
+    let end = -1
+    for (let i = start; i < fileSrc.length; i++) {
+      if (fileSrc[i] === '{') {
+        depth++
+        started = true
+      } else if (fileSrc[i] === '}') {
+        depth--
+        if (started && depth === 0) {
+          end = i + 1
+          break
+        }
+      }
+    }
+    if (end === -1) throw new Error('Could not locate the end of withBackoff — unbalanced braces?')
+    return fileSrc.slice(start, end)
+  }
+
+  it("withBackoff's source is byte-identical to the hash captured when smi5879-fetch-retry.ts was authored", () => {
+    const filePath = join(process.cwd(), 'scripts/indexer/_shared/rate-limit.ts')
+    const src = readFileSync(filePath, 'utf8')
+    const withBackoffSrc = extractWithBackoffSource(src)
+    const hash = createHash('sha256').update(withBackoffSrc).digest('hex')
+    expect(hash).toBe('bd424985a8b41895dd1bb95e1e8b24998a753ccdeea54f5d0f7db06857d0441f')
+  })
+})

--- a/scripts/tests/indexer/smi5879-simulate-full.checkpoint.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.checkpoint.test.ts
@@ -1,0 +1,156 @@
+/**
+ * SMI-5879 Wave 3 item 3: smi5879-simulate-full — checkpoint I/O tests
+ * (`checkpointPathFor`/`readCheckpoint`/`writeCheckpoint`/`isAbnormalResume`,
+ * including SMI-5879 review findings 1 and 3's shape-validation/corruption
+ * hard-refusals). Split out of the original `smi5879-simulate-full.test.ts`
+ * (grew past the 500-line-per-file gate) — shared fixtures live in
+ * `./smi5879-simulate-full.fixtures.ts`, which also documents the
+ * suite-wide mocked-dependencies judgment call. This file doesn't need any
+ * of those fixtures itself (pure filesystem round-trips against real temp
+ * dirs, no `fetch`/DB mocking).
+ * @module scripts/tests/indexer/smi5879-simulate-full.checkpoint
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  checkpointPathFor,
+  readCheckpoint,
+  writeCheckpoint,
+  isAbnormalResume,
+} from '../../indexer/smi5879-simulate-full.sweep.ts'
+import type { Smi5879SimulateCheckpoint } from '../../indexer/smi5879-simulate-full.types.ts'
+
+// ---------------------------------------------------------------------------
+// Checkpoint I/O
+// ---------------------------------------------------------------------------
+
+describe('checkpoint I/O', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'smi5879-sim-ckpt-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('readCheckpoint returns null when no file exists', () => {
+    expect(readCheckpoint(join(dir, 'missing.json'))).toBeNull()
+  })
+
+  it('round-trips a checkpoint through write then read', () => {
+    const path = join(dir, 'ckpt.json')
+    const checkpoint: Smi5879SimulateCheckpoint = {
+      run_id: 'run-1',
+      purpose: 'decision',
+      baseline_commit: 'abc123',
+      token_source: 'pat',
+      clean_shutdown: true,
+      row_results: {},
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    writeCheckpoint(path, checkpoint)
+    const loaded = readCheckpoint(path)
+    expect(loaded).toEqual(checkpoint)
+  })
+
+  it('isAbnormalResume is true only when clean_shutdown is explicitly false', () => {
+    const base: Smi5879SimulateCheckpoint = {
+      run_id: 'r',
+      purpose: 'decision',
+      baseline_commit: 'x',
+      token_source: 'pat',
+      clean_shutdown: true,
+      row_results: {},
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: '',
+      updated_at: '',
+    }
+    expect(isAbnormalResume(null)).toBe(false)
+    expect(isAbnormalResume(base)).toBe(false)
+    expect(isAbnormalResume({ ...base, clean_shutdown: false })).toBe(true)
+  })
+
+  it('checkpointPathFor is deterministic per run_id', () => {
+    expect(checkpointPathFor('run-a')).toBe(checkpointPathFor('run-a'))
+    expect(checkpointPathFor('run-a')).not.toBe(checkpointPathFor('run-b'))
+  })
+
+  // -------------------------------------------------------------------------
+  // SMI-5879 review finding 1: `readCheckpoint` no longer does a bare
+  // `JSON.parse(raw) as Smi5879SimulateCheckpoint` — it validates shape and
+  // throws loudly on anything malformed rather than silently trusting the file.
+  // -------------------------------------------------------------------------
+
+  it('readCheckpoint rejects a checkpoint whose row_results contains an unrecognised outcome value', () => {
+    const path = join(dir, 'bad-outcome.json')
+    const raw = {
+      run_id: 'run-1',
+      purpose: 'decision',
+      baseline_commit: 'abc123',
+      token_source: 'pat',
+      clean_shutdown: true,
+      row_results: {
+        'row-1': {
+          id: 'row-1',
+          cohort: 'C2',
+          author: null,
+          name: null,
+          outcome: 'totally_not_a_real_outcome',
+        },
+      },
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    writeFileSync(path, JSON.stringify(raw))
+    expect(() => readCheckpoint(path)).toThrow(/outcome=totally_not_a_real_outcome/)
+  })
+
+  it('readCheckpoint rejects a checkpoint missing required top-level fields', () => {
+    const path = join(dir, 'missing-fields.json')
+    writeFileSync(path, JSON.stringify({ run_id: 'run-1' }))
+    expect(() => readCheckpoint(path)).toThrow(/failed shape validation/)
+  })
+
+  // -------------------------------------------------------------------------
+  // SMI-5879 review finding 3: a corrupted checkpoint file is NOT the same
+  // as "no checkpoint" (cold start) — it must fail loudly, since real
+  // progress may have been lost, not be silently treated as absent.
+  // -------------------------------------------------------------------------
+
+  it('readCheckpoint throws loudly on a corrupted (non-JSON) checkpoint file rather than treating it as absent', () => {
+    const path = join(dir, 'corrupt.json')
+    writeFileSync(path, '{"run_id": "run-1", "row_results": {') // truncated mid-write
+    expect(() => readCheckpoint(path)).toThrow(/is not valid JSON/)
+    // Specifically NOT null — a corrupted file must never look like a cold start.
+    expect(() => readCheckpoint(path)).not.toThrow(/^$/) // (guards against a swallowed/empty message)
+  })
+
+  it('writeCheckpoint replaces the target atomically (no truncated intermediate state observable)', () => {
+    const path = join(dir, 'atomic.json')
+    const checkpoint: Smi5879SimulateCheckpoint = {
+      run_id: 'run-1',
+      purpose: 'decision',
+      baseline_commit: 'abc123',
+      token_source: 'pat',
+      clean_shutdown: true,
+      row_results: {},
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    writeCheckpoint(path, checkpoint)
+    // A second write must fully replace the file, and never leave a stray
+    // `.tmp-<pid>` sibling behind once the rename has completed.
+    writeCheckpoint(path, { ...checkpoint, clean_shutdown: false })
+    const loaded = readCheckpoint(path)
+    expect(loaded?.clean_shutdown).toBe(false)
+    expect(() => readCheckpoint(`${path}.tmp-${process.pid}`)).not.toThrow()
+    expect(readCheckpoint(`${path}.tmp-${process.pid}`)).toBeNull()
+  })
+})

--- a/scripts/tests/indexer/smi5879-simulate-full.classification.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.classification.test.ts
@@ -1,0 +1,311 @@
+/**
+ * SMI-5879 Wave 3 item 3: smi5879-simulate-full — pure-function classification
+ * tests (`processRow`'s tier-2 outcome matrix, `computeCoverage`,
+ * `decideExitCode`, `assertPatTokenSource`). Split out of the original
+ * `smi5879-simulate-full.test.ts` (grew past the 500-line-per-file gate) —
+ * shared fixtures live in `./smi5879-simulate-full.fixtures.ts`, which also
+ * documents the suite-wide mocked-dependencies judgment call.
+ * @module scripts/tests/indexer/smi5879-simulate-full.classification
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { processRow, assertPatTokenSource } from '../../indexer/smi5879-simulate-full.helpers.ts'
+import {
+  computeCoverage,
+  summarizeCounts,
+  decideExitCode,
+} from '../../indexer/smi5879-simulate-full.sweep.ts'
+import type {
+  BranchMap,
+  SimRowResult,
+  SimSnapshotRow,
+  SimulatedCohort,
+} from '../../indexer/smi5879-simulate-full.types.ts'
+import {
+  CLEAN_RISK,
+  DIRTY_RISK,
+  makeRow,
+  makeVerdictScanner,
+  makeBundleAbsentScanner,
+  makeSiblingTouchingScanner,
+  baseDeps,
+  contentsApiResponse,
+  registerPrimary,
+  registerSibling,
+  resetRowCounter,
+  installFetchMock,
+  restoreFetchMock,
+} from './smi5879-simulate-full.fixtures.ts'
+
+beforeEach(() => {
+  resetRowCounter()
+  installFetchMock()
+})
+
+afterEach(() => {
+  restoreFetchMock()
+})
+
+// ---------------------------------------------------------------------------
+// Tier-2 outcome matrix — one test case per outcome (plus extra causes for
+// unevaluable/unfetchable, since the plan calls out their asymmetric G-2
+// effect as the "obvious way to get this wrong").
+// ---------------------------------------------------------------------------
+
+describe('processRow — tier-2 outcome classification', () => {
+  const cleanScanner = makeVerdictScanner(new Map())
+
+  it('unfetchable: repo_url does not parse (structurally undecidable, no network attempt)', async () => {
+    const row = makeRow({ repo_url: null })
+    const result = await processRow(row, new Map(), baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unfetchable')
+  })
+
+  it('unfetchable: default_branch resolution is not-found', async () => {
+    const row = makeRow({ repo_url: 'https://github.com/acme/bare-repo' })
+    const branchMap: BranchMap = new Map([
+      ['acme/bare-repo', { resolution: 'not-found', default_branch: null }],
+    ])
+    const result = await processRow(row, branchMap, baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unfetchable')
+  })
+
+  it('unfetchable: default_branch resolution is unparseable', async () => {
+    const row = makeRow({ repo_url: 'https://github.com/acme/bare-repo2' })
+    const branchMap: BranchMap = new Map([
+      ['acme/bare-repo2', { resolution: 'unparseable', default_branch: null }],
+    ])
+    const result = await processRow(row, branchMap, baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unfetchable')
+  })
+
+  it('unevaluable: default_branch resolution is transient', async () => {
+    const row = makeRow({ repo_url: 'https://github.com/acme/bare-repo3' })
+    const branchMap: BranchMap = new Map([
+      ['acme/bare-repo3', { resolution: 'transient', default_branch: null }],
+    ])
+    const result = await processRow(row, branchMap, baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unevaluable')
+  })
+
+  it('unevaluable: primary fetch exhausts retries', async () => {
+    const row = makeRow()
+    registerPrimary(row, [
+      new Response('rate limited', { status: 429 }),
+      new Response('rate limited', { status: 429 }),
+      new Response('rate limited', { status: 429 }),
+    ])
+    const result = await processRow(row, new Map(), baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unevaluable')
+    expect(result.reason).toMatch(/primary fetch exhausted/)
+  })
+
+  it('unevaluable: primary SKILL.md confirmed absent (404) since the snapshot (judgment call)', async () => {
+    const row = makeRow()
+    registerPrimary(row, [new Response('Not Found', { status: 404 })])
+    const result = await processRow(row, new Map(), baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unevaluable')
+    expect(result.reason).toMatch(/confirmed absent/)
+  })
+
+  it('unevaluable: a sibling exhausts retries', async () => {
+    const row = makeRow()
+    registerPrimary(row, [contentsApiResponse('# SKILL')])
+    registerSibling(row, 'README.md', [
+      new Response('rate limited', { status: 429 }),
+      new Response('rate limited', { status: 429 }),
+      new Response('rate limited', { status: 429 }),
+    ])
+    const scanner = makeSiblingTouchingScanner()
+    const result = await processRow(row, new Map(), baseDeps(scanner, scanner))
+    expect(result.outcome).toBe('unevaluable')
+    expect(result.reason).toMatch(/sibling\(s\) exhausted/)
+  })
+
+  it('content_drifted: fetched content hash does not match the snapshot content_hash', async () => {
+    const row = makeRow({ content_hash: 'deadbeef'.repeat(8) })
+    registerPrimary(row, [contentsApiResponse('# SKILL (changed since snapshot)')])
+    const result = await processRow(row, new Map(), baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('content_drifted')
+  })
+
+  it('bundle_absent: primary OK, all 7 sibling targets confirmed absent — primary-only verdict is still carried', async () => {
+    const row = makeRow()
+    registerPrimary(row, [contentsApiResponse('# SKILL')])
+    const scanner = makeBundleAbsentScanner(CLEAN_RISK)
+    const result = await processRow(row, new Map(), baseDeps(scanner, scanner))
+    expect(result.outcome).toBe('bundle_absent')
+    expect(result.prePortQuarantine).toBe(false)
+    expect(result.postPortQuarantine).toBe(false)
+  })
+
+  it('newly_quarantined: pre-port clean, post-port quarantined', async () => {
+    const row = makeRow()
+    registerPrimary(row, [contentsApiResponse('# SKILL')])
+    const postPort = makeVerdictScanner(new Map([['acme/row-1', DIRTY_RISK]]))
+    const prePort = makeVerdictScanner(new Map())
+    const result = await processRow(row, new Map(), baseDeps(postPort, prePort))
+    expect(result.outcome).toBe('newly_quarantined')
+  })
+
+  it('newly_cleared: pre-port quarantined, post-port clean', async () => {
+    const row = makeRow()
+    registerPrimary(row, [contentsApiResponse('# SKILL')])
+    const postPort = makeVerdictScanner(new Map())
+    const prePort = makeVerdictScanner(new Map([[`acme/${row.id}`, DIRTY_RISK]]))
+    const result = await processRow(row, new Map(), baseDeps(postPort, prePort))
+    expect(result.outcome).toBe('newly_cleared')
+  })
+
+  it('unchanged_clean: both scans clean', async () => {
+    const row = makeRow()
+    registerPrimary(row, [contentsApiResponse('# SKILL')])
+    const result = await processRow(row, new Map(), baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unchanged_clean')
+  })
+
+  it('unchanged_quarantined: both scans quarantined', async () => {
+    const row = makeRow()
+    registerPrimary(row, [contentsApiResponse('# SKILL')])
+    const dirty = makeVerdictScanner(new Map([[`acme/${row.id}`, DIRTY_RISK]]))
+    const result = await processRow(row, new Map(), baseDeps(dirty, dirty))
+    expect(result.outcome).toBe('unchanged_quarantined')
+  })
+
+  it('two-sided reporting: newly_quarantined and newly_cleared are both first-class, neither dropped by summarizeCounts', () => {
+    const results: SimRowResult[] = [
+      { id: '1', cohort: 'C2', author: null, name: null, outcome: 'newly_quarantined' },
+      { id: '2', cohort: 'C2', author: null, name: null, outcome: 'newly_cleared' },
+    ]
+    const counts = summarizeCounts(results)
+    expect(counts.newly_quarantined).toBe(1)
+    expect(counts.newly_cleared).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Coverage: the unfetchable/unevaluable asymmetry
+// ---------------------------------------------------------------------------
+
+describe('computeCoverage — unfetchable does NOT block full coverage, unevaluable DOES', () => {
+  it('a cohort where every row is unfetchable or a resolved verdict reports full', () => {
+    // Typed as a fixed-length tuple (not `SimSnapshotRow[]`) so `rows[0]`/`rows[1]`
+    // are known-defined under `noUncheckedIndexedAccess` — this array is always
+    // constructed with exactly 2 elements, never mutated.
+    const rows: [SimSnapshotRow, SimSnapshotRow] = [
+      makeRow({ cohort: 'C2' }),
+      makeRow({ cohort: 'C2' }),
+    ]
+    const results = new Map<string, SimRowResult>([
+      [
+        rows[0].id,
+        { id: rows[0].id, cohort: 'C2', author: null, name: null, outcome: 'unfetchable' },
+      ],
+      [
+        rows[1].id,
+        { id: rows[1].id, cohort: 'C2', author: null, name: null, outcome: 'unchanged_clean' },
+      ],
+    ])
+    const coverage = computeCoverage({ C1: [], C2: rows, C3: [], C4: [] }, results)
+    expect(coverage.C2.status).toBe('full')
+    expect(coverage.C2.unfetchable).toBe(1)
+    expect(coverage.C2.unevaluable).toBe(0)
+  })
+
+  it('a cohort with even one unevaluable row reports partial — a partial cohort can never be reported as full', () => {
+    const rows: [SimSnapshotRow, SimSnapshotRow] = [
+      makeRow({ cohort: 'C2' }),
+      makeRow({ cohort: 'C2' }),
+    ]
+    const results = new Map<string, SimRowResult>([
+      [
+        rows[0].id,
+        { id: rows[0].id, cohort: 'C2', author: null, name: null, outcome: 'unevaluable' },
+      ],
+      [
+        rows[1].id,
+        { id: rows[1].id, cohort: 'C2', author: null, name: null, outcome: 'unchanged_clean' },
+      ],
+    ])
+    const coverage = computeCoverage({ C1: [], C2: rows, C3: [], C4: [] }, results)
+    expect(coverage.C2.status).toBe('partial')
+    expect(coverage.C2.unevaluable).toBe(1)
+  })
+
+  it('a cohort with rows not yet attempted (scanned < total) reports partial', () => {
+    const rows: [SimSnapshotRow, SimSnapshotRow] = [
+      makeRow({ cohort: 'C3' }),
+      makeRow({ cohort: 'C3' }),
+    ]
+    const results = new Map<string, SimRowResult>([
+      [
+        rows[0].id,
+        { id: rows[0].id, cohort: 'C3', author: null, name: null, outcome: 'unchanged_clean' },
+      ],
+    ])
+    const coverage = computeCoverage({ C1: [], C2: [], C3: rows, C4: [] }, results)
+    expect(coverage.C3.status).toBe('partial')
+    expect(coverage.C3.scanned).toBe(1)
+    expect(coverage.C3.total).toBe(2)
+  })
+})
+
+describe('decideExitCode', () => {
+  const fullCoverage = (cohorts: SimulatedCohort[]) => {
+    const c = {} as Record<
+      SimulatedCohort,
+      {
+        status: 'full' | 'partial'
+        scanned: number
+        total: number
+        unevaluable: number
+        unfetchable: number
+      }
+    >
+    for (const cohort of ['C1', 'C2', 'C3', 'C4'] as SimulatedCohort[]) {
+      c[cohort] = {
+        status: cohorts.includes(cohort) ? 'partial' : 'full',
+        scanned: 1,
+        total: 1,
+        unevaluable: 0,
+        unfetchable: 0,
+      }
+    }
+    return c
+  }
+
+  it('is 0 when every cohort is full and the sweep did not hard-stop', () => {
+    expect(decideExitCode(fullCoverage([]), null)).toBe(0)
+  })
+
+  it('is 1 when any cohort is partial', () => {
+    expect(decideExitCode(fullCoverage(['C3']), null)).toBe(1)
+  })
+
+  it('is 1 when the sweep hard-stopped, even if coverage looks full', () => {
+    expect(decideExitCode(fullCoverage([]), 'max_passes')).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// token_source hard-refusal (plan §3a)
+// ---------------------------------------------------------------------------
+
+describe('assertPatTokenSource', () => {
+  it('resolves "pat" when no GITHUB_APP_* vars are set', () => {
+    expect(assertPatTokenSource({})).toBe('pat')
+  })
+
+  it('throws naming the three GITHUB_APP_* vars when all three are set', () => {
+    const env = {
+      GITHUB_APP_ID: 'x',
+      GITHUB_APP_INSTALLATION_ID: 'y',
+      GITHUB_APP_PRIVATE_KEY: 'z',
+    }
+    expect(() => assertPatTokenSource(env)).toThrow(/GITHUB_APP_ID/)
+  })
+
+  it('does not throw when only some GITHUB_APP_* vars are set (resolveTokenSource requires all three)', () => {
+    expect(assertPatTokenSource({ GITHUB_APP_ID: 'x' })).toBe('pat')
+  })
+})

--- a/scripts/tests/indexer/smi5879-simulate-full.fixtures.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.fixtures.ts
@@ -1,0 +1,233 @@
+/**
+ * SMI-5879 Wave 3 item 3: shared fixtures/helpers for the split
+ * smi5879-simulate-full.test.ts / .classification.test.ts / .sweep.test.ts /
+ * .checkpoint.test.ts suite (the original single test file grew past the
+ * 500-line-per-file gate — see each sibling test file's header for its slice
+ * of the suite).
+ * @module scripts/tests/indexer/smi5879-simulate-full.fixtures
+ *
+ * JUDGMENT CALL (flagged per task instructions, carried over unchanged from
+ * the original single-file suite before this split): this suite injects fake
+ * `Smi5879SimulateFullDbDeps` and `ScanSkillBundleFn` implementations rather
+ * than standing up a live Postgres instance (the pattern
+ * `smi5879-census.test-helpers.ts` uses for item 1). Item 1's live-PG harness
+ * exists specifically to verify trigger/PL-pgSQL/GC-timing logic that item 1
+ * owns; this item introduces NO new SQL objects — it only calls item 1's
+ * already-tested `smi5879_claim_run`/`smi5879_heartbeat`/`smi5879_release_run`/
+ * `smi5879_population_digest`/`smi5879_branch_digest` via
+ * `smi5879-simulate-full.db.ts`, a thin wrapper this suite does not need to
+ * re-verify against Postgres. What THIS item actually adds — tier-1/2/3
+ * outcome classification, checkpoint/resume, coverage aggregation, and the
+ * sweep loop's termination conditions — is pure TypeScript control flow that
+ * mocked dependencies exercise more precisely (and deterministically, and
+ * without a live-Postgres/CI-availability dependency) than a live-DB harness
+ * would. `global.fetch` IS mocked (not skipped) for the primary/sibling
+ * GitHub fetch paths, matching `rate-limit-tracking.test.ts`'s established
+ * convention, so the REAL `fetchSkillMd`/`fetchSiblingContent`/
+ * `parseSkillMdUrl`/`withFetchRetry` machinery is exercised end-to-end; only
+ * the network transport and the DB round trip are faked.
+ *
+ * Split note: `fetchHandlers`/`originalFetch`/`rowCounter` used to be plain
+ * module-level `let`s shared implicitly across all `describe` blocks via one
+ * file-scoped `beforeEach`/`afterEach`. Vitest instantiates a fresh copy of
+ * this module per test file (default `isolate: true`), so that closure no
+ * longer spans files once split — each consuming test file must call
+ * `installFetchMock()`/`restoreFetchMock()`/`resetRowCounter()` from its OWN
+ * `beforeEach`/`afterEach`, not just import the raw mutable state.
+ */
+
+import { vi } from 'vitest'
+import { newRateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+import type { ProcessRowDeps } from '../../indexer/smi5879-simulate-full.helpers.ts'
+import type {
+  ScanSkillBundleFn,
+  SimSnapshotRow,
+  Smi5879SimulateFullDbDeps,
+} from '../../indexer/smi5879-simulate-full.types.ts'
+
+// ---------------------------------------------------------------------------
+// Fixtures / fakes
+// ---------------------------------------------------------------------------
+
+export const CLEAN_RISK = 0
+export const DIRTY_RISK = 80 // >= QUARANTINE_THRESHOLD (40)
+
+let rowCounter = 0
+
+/** Reset the `makeRow` auto-id counter — call from each consuming file's own `beforeEach`. */
+export function resetRowCounter(): void {
+  rowCounter = 0
+}
+
+export function makeRow(overrides: Partial<SimSnapshotRow> = {}): SimSnapshotRow {
+  rowCounter++
+  const id = overrides.id ?? `row-${rowCounter}`
+  return {
+    id,
+    cohort: 'C2',
+    repo_url: `https://github.com/acme/${id}/tree/main`,
+    skill_path: null,
+    author: 'acme',
+    name: id,
+    content_hash: null,
+    snapshot_security_score: null,
+    snapshot_quarantined: null,
+    ...overrides,
+  }
+}
+
+export function emptyEdgeScan(riskScore: number) {
+  return {
+    passed: riskScore < 40,
+    riskScore,
+    findings: [] as never[],
+    contentHash: 'x',
+    scannedAt: new Date().toISOString(),
+    scanDurationMs: 0,
+  }
+}
+
+/** A scanner that never touches `deps.fetchSiblingContent` — pure verdict-delta control. */
+export function makeVerdictScanner(verdictByRepoKey: Map<string, number>): ScanSkillBundleFn {
+  return async (owner, repo) => {
+    const riskScore = verdictByRepoKey.get(`${owner}/${repo}`) ?? CLEAN_RISK
+    return {
+      securityScan: emptyEdgeScan(riskScore),
+      siblingScans: [],
+      siblingFailures: [],
+      // `mergedSecurityScan` is optional on `ScanSkillBundleResult` — under
+      // `exactOptionalPropertyTypes`, "no merged scan" means OMITTING the key,
+      // not assigning it `undefined` explicitly (that's a type error, since an
+      // optional property's value type itself doesn't include `undefined`).
+    }
+  }
+}
+
+/** A scanner that reports the bundle as fully absent (7 confirmed-404 siblings), primary OK. */
+export function makeBundleAbsentScanner(riskScore = CLEAN_RISK): ScanSkillBundleFn {
+  return async () => ({
+    securityScan: emptyEdgeScan(riskScore),
+    siblingScans: [],
+    siblingFailures: Array.from({ length: 7 }, (_, i) => ({
+      relPath: `sibling-${i}.txt`,
+      kind: 'removed' as const,
+    })),
+    // See makeVerdictScanner above — `mergedSecurityScan` omitted, not `undefined`.
+  })
+}
+
+/** A scanner that actually calls `deps.fetchSiblingContent` once, for exhaustion tests. */
+export function makeSiblingTouchingScanner(riskScore = CLEAN_RISK): ScanSkillBundleFn {
+  return async (owner, repo, branch, _skillPath, _content, telemetry, deps) => {
+    const siblingFailures: { relPath: string; kind: 'transient' | 'removed' }[] = []
+    if (deps?.fetchSiblingContent) {
+      const result = await deps.fetchSiblingContent(owner, repo, branch, 'README.md', telemetry)
+      if (result === null) siblingFailures.push({ relPath: 'README.md', kind: 'transient' })
+    }
+    return {
+      securityScan: emptyEdgeScan(riskScore),
+      siblingScans: [],
+      siblingFailures,
+      // See makeVerdictScanner above — `mergedSecurityScan` omitted, not `undefined`.
+    }
+  }
+}
+
+export function makeFakeDb(
+  overrides: Partial<Smi5879SimulateFullDbDeps> = {}
+): Smi5879SimulateFullDbDeps {
+  return {
+    async getRunSummary() {
+      return { purpose: 'decision', status: 'sealed' }
+    },
+    async claimRun() {
+      return { claimed: true }
+    },
+    async heartbeat() {
+      return new Date().toISOString()
+    },
+    async releaseRun() {},
+    async verifyDigest() {
+      return { populationMatches: true, branchMatches: true }
+    },
+    async loadCohortRows() {
+      return []
+    },
+    async loadBranchMap() {
+      return new Map()
+    },
+    ...overrides,
+  }
+}
+
+export const FAST_RETRY = { maxRetries: 2, baseMs: 1, maxMs: 2 }
+
+/**
+ * Drain the microtask queue without advancing any (real or fake) timer —
+ * used by the heartbeat tests (SMI-5879 review finding 4) to let
+ * `runSimulateFull`'s own sequence of `await`s (getRunSummary -> claimRun ->
+ * ... -> the heartbeat's `setTimeout` registration) run to completion before
+ * a fake-timer advance, without guessing an exact tick count.
+ */
+export async function flushMicrotasks(times = 20): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve()
+}
+
+export function contentsApiResponse(content: string, status = 200): Response {
+  return new Response(
+    JSON.stringify({
+      content: Buffer.from(content, 'utf8').toString('base64'),
+      encoding: 'base64',
+    }),
+    { status, headers: { 'content-type': 'application/json' } }
+  )
+}
+
+let fetchHandlers: Map<string, Response[]> = new Map()
+let originalFetch: typeof global.fetch
+
+/** Install the `global.fetch` mock — call from each consuming file's own `beforeEach`. */
+export function installFetchMock(): void {
+  fetchHandlers = new Map()
+  originalFetch = global.fetch
+  const fetchMock = vi.fn(async (input: unknown) => {
+    const url = typeof input === 'string' ? input : String(input)
+    const queue = fetchHandlers.get(url)
+    if (!queue || queue.length === 0) {
+      throw new Error(`Unexpected fetch to unregistered URL: ${url}`)
+    }
+    return queue.length > 1 ? (queue.shift() as Response) : queue[0]
+  })
+  global.fetch = fetchMock as unknown as typeof global.fetch
+}
+
+/** Restore the real `global.fetch` — call from each consuming file's own `afterEach`. */
+export function restoreFetchMock(): void {
+  global.fetch = originalFetch
+}
+
+export function registerPrimary(row: SimSnapshotRow, responses: Response[]): void {
+  const [owner, repo] = new URL(row.repo_url as string).pathname.slice(1).split('/')
+  fetchHandlers.set(
+    `https://api.github.com/repos/${owner}/${repo}/contents/SKILL.md?ref=main`,
+    responses
+  )
+}
+
+export function registerSibling(row: SimSnapshotRow, relPath: string, responses: Response[]): void {
+  const [owner, repo] = new URL(row.repo_url as string).pathname.slice(1).split('/')
+  fetchHandlers.set(`https://raw.githubusercontent.com/${owner}/${repo}/main/${relPath}`, responses)
+}
+
+export function baseDeps(
+  scanPostPort: ScanSkillBundleFn,
+  scanPrePort: ScanSkillBundleFn
+): ProcessRowDeps {
+  return {
+    scanPostPort,
+    scanPrePort,
+    telemetry: newRateLimitTelemetry(),
+    headers: {},
+    fetchRetryOptions: FAST_RETRY,
+  }
+}

--- a/scripts/tests/indexer/smi5879-simulate-full.sweep.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.sweep.test.ts
@@ -1,0 +1,169 @@
+/**
+ * SMI-5879 Wave 3 item 3: smi5879-simulate-full — `runTier3Sweep` loop tests
+ * (termination conditions + resume durability, SMI-5879 review finding 2a).
+ * Split out of the original `smi5879-simulate-full.test.ts` (grew past the
+ * 500-line-per-file gate) — shared fixtures live in
+ * `./smi5879-simulate-full.fixtures.ts`, which also documents the
+ * suite-wide mocked-dependencies judgment call. This file doesn't need any
+ * of those fixtures itself (no `fetch`/`makeRow` usage — `runTier3Sweep` is
+ * exercised with synthetic `SimRowResult`s directly).
+ * @module scripts/tests/indexer/smi5879-simulate-full.sweep
+ */
+
+import { describe, it, expect } from 'vitest'
+import { runTier3Sweep, MAX_SWEEP_PASSES } from '../../indexer/smi5879-simulate-full.sweep.ts'
+import type { SimRowResult } from '../../indexer/smi5879-simulate-full.types.ts'
+
+// ---------------------------------------------------------------------------
+// Tier-3 sweep loop — the three termination conditions
+// ---------------------------------------------------------------------------
+
+describe('runTier3Sweep', () => {
+  const noCooldown = { sleep: async () => {} }
+
+  function seedRow(id: string): SimRowResult {
+    return { id, cohort: 'C2', author: null, name: null, outcome: 'unevaluable' }
+  }
+
+  it('converges to |R_k| = 0 and reports no hard stop', async () => {
+    const initial = [seedRow('a'), seedRow('b')]
+    const outcome = await runTier3Sweep(
+      initial,
+      async (ids) => {
+        // Resolve the first row of the CURRENT residual each pass — with 2
+        // rows this converges in exactly 2 passes (1 resolved per pass).
+        const map = new Map<string, SimRowResult>()
+        ids.forEach((id, i) => {
+          map.set(id, {
+            id,
+            cohort: 'C2',
+            author: null,
+            name: null,
+            outcome: i === 0 ? 'unchanged_clean' : 'unevaluable',
+          })
+        })
+        return map
+      },
+      noCooldown
+    )
+    expect(outcome.hardStopped).toBeNull()
+    expect(outcome.finalResidualSize).toBe(0)
+    expect(outcome.passesRun).toBe(2)
+  })
+
+  it('hard-stops on two consecutive non-decreasing passes', async () => {
+    const initial = [seedRow('a'), seedRow('b')]
+    const outcome = await runTier3Sweep(
+      initial,
+      async (ids) => {
+        // Never resolves anything — residual stays flat at 2 forever.
+        return new Map(ids.map((id) => [id, seedRow(id)]))
+      },
+      noCooldown
+    )
+    expect(outcome.hardStopped).toBe('non_convergence')
+    expect(outcome.finalResidualSize).toBe(2)
+    // Non-decrease detected after pass 1 (baseline) vs pass 2 -> stop at pass 2.
+    expect(outcome.passesRun).toBe(2)
+  })
+
+  it('hard-stops at MAX_SWEEP_PASSES when residual keeps shrinking but never reaches zero', async () => {
+    const initial = Array.from({ length: MAX_SWEEP_PASSES + 2 }, (_, i) => seedRow(`r${i}`))
+    const outcome = await runTier3Sweep(
+      initial,
+      async (ids) => {
+        // Resolve exactly one row per pass — always strictly decreasing, but
+        // with (MAX_SWEEP_PASSES + 2) rows it can never reach zero within
+        // MAX_SWEEP_PASSES passes.
+        const map = new Map<string, SimRowResult>()
+        ids.forEach((id, i) => {
+          map.set(id, {
+            id,
+            cohort: 'C2',
+            author: null,
+            name: null,
+            outcome: i === 0 ? 'unchanged_clean' : 'unevaluable',
+          })
+        })
+        return map
+      },
+      noCooldown
+    )
+    expect(outcome.hardStopped).toBe('max_passes')
+    expect(outcome.passesRun).toBe(MAX_SWEEP_PASSES)
+    expect(outcome.finalResidualSize).toBeGreaterThan(0)
+  })
+
+  it('never includes unfetchable rows in the residual (terminal, cannot cause non-convergence)', async () => {
+    // Caller contract: initialResidual only ever contains 'unevaluable' rows.
+    // Verified here structurally — an empty residual converges trivially with
+    // zero passes run, proving the loop does no work when there's nothing to sweep.
+    const outcome = await runTier3Sweep(
+      [],
+      async (ids) => new Map(ids.map((id) => [id, seedRow(id)])),
+      noCooldown
+    )
+    expect(outcome.hardStopped).toBeNull()
+    expect(outcome.passesRun).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SMI-5879 review finding 2a: resume state (pass count, non-decrease streak)
+// must be continuous across a crash/resume boundary, not reset.
+// ---------------------------------------------------------------------------
+
+describe('runTier3Sweep — resume durability (SMI-5879 review finding 2a)', () => {
+  const noCooldown = { sleep: async () => {} }
+
+  function seedRow(id: string): SimRowResult {
+    return { id, cohort: 'C2', author: null, name: null, outcome: 'unevaluable' }
+  }
+
+  it('a resume at the 2-non-decrease boundary hard-stops at the correct TOTAL pass count, not a fresh streak', async () => {
+    // Simulates: pass 1 already ran pre-crash (residual stayed flat at 2,
+    // non-decrease streak reached 1) and was checkpointed; resuming with
+    // that state threaded in via startingPass/startingNonDecreaseStreak. A
+    // single additional pass that ALSO doesn't shrink the residual must
+    // hard-stop immediately (streak reaches 2) at TOTAL pass count 2 — pre-fix,
+    // the streak would have reset to 0 on resume, requiring two MORE passes.
+    const postPass1Residual = [seedRow('a'), seedRow('b')]
+    const outcome = await runTier3Sweep(
+      postPass1Residual,
+      async (ids) => new Map(ids.map((id) => [id, seedRow(id)])), // never resolves anything
+      { ...noCooldown, startingPass: 1, startingNonDecreaseStreak: 1 }
+    )
+    expect(outcome.hardStopped).toBe('non_convergence')
+    expect(outcome.passesRun).toBe(2) // 1 pre-crash + 1 this invocation, NOT reset to 1
+  })
+
+  it('a resume after pass 7 pre-crash hard-stops after pass 8 TOTAL, not a fresh 8-pass allowance', async () => {
+    // 3 residual rows, strictly decreasing by 1 each pass (never triggers
+    // the non-decrease hard-stop) — with only 1 pass of budget left
+    // (startingPass = MAX_SWEEP_PASSES - 1), it can never reach zero within
+    // that budget, so it must hard-stop at max_passes after exactly 1 more
+    // pass (TOTAL 8) — pre-fix, a fresh 8-pass budget would let it run to
+    // (7 + 8 =) 15 total passes.
+    const postPass7Residual = [seedRow('a'), seedRow('b'), seedRow('c')]
+    const outcome = await runTier3Sweep(
+      postPass7Residual,
+      async (ids) => {
+        const map = new Map<string, SimRowResult>()
+        ids.forEach((id, i) => {
+          map.set(id, {
+            id,
+            cohort: 'C2',
+            author: null,
+            name: null,
+            outcome: i === 0 ? 'unchanged_clean' : 'unevaluable',
+          })
+        })
+        return map
+      },
+      { ...noCooldown, startingPass: MAX_SWEEP_PASSES - 1, startingNonDecreaseStreak: 0 }
+    )
+    expect(outcome.hardStopped).toBe('max_passes')
+    expect(outcome.passesRun).toBe(MAX_SWEEP_PASSES) // 7 pre-crash + 1 this invocation = 8, NOT 15
+    expect(outcome.finalResidualSize).toBeGreaterThan(0)
+  })
+})

--- a/scripts/tests/indexer/smi5879-simulate-full.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.test.ts
@@ -1,0 +1,465 @@
+/**
+ * SMI-5879 Wave 3 item 3: smi5879-simulate-full.ts / .helpers.ts / .sweep.ts
+ * tests — `runSimulateFull` end-to-end orchestration, including SMI-5879
+ * review finding 2b (sweep-pass-accounting) and finding 4 (heartbeat). This
+ * is the primary file of a suite split across several siblings (this file
+ * kept the original name) after the single-file suite grew past the
+ * 500-line-per-file gate (`scripts/check-file-length.mjs`):
+ *   - `smi5879-simulate-full.classification.test.ts` — `processRow` tier-2
+ *     outcome classification, `computeCoverage`, `decideExitCode`,
+ *     `assertPatTokenSource`.
+ *   - `smi5879-simulate-full.sweep.test.ts` — `runTier3Sweep` (termination
+ *     conditions + resume durability, review finding 2a).
+ *   - `smi5879-simulate-full.checkpoint.test.ts` — checkpoint I/O.
+ *   - `smi5879-simulate-full.fixtures.ts` — shared fixtures/fakes.
+ * @module scripts/tests/indexer/smi5879-simulate-full
+ *
+ * JUDGMENT CALL (flagged per task instructions, carried over unchanged from
+ * before the split — see `smi5879-simulate-full.fixtures.ts` for the full
+ * rationale): this suite injects fake `Smi5879SimulateFullDbDeps` and
+ * `ScanSkillBundleFn` implementations rather than standing up a live
+ * Postgres instance. `global.fetch` IS mocked (not skipped) for the
+ * primary/sibling GitHub fetch paths, so the REAL `fetchSkillMd`/
+ * `fetchSiblingContent`/`parseSkillMdUrl`/`withFetchRetry` machinery is
+ * exercised end-to-end; only the network transport and the DB round trip
+ * are faked.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { HEARTBEAT_INTERVAL_MS } from '../../indexer/smi5879-simulate-full.helpers.ts'
+import {
+  readCheckpoint,
+  writeCheckpoint,
+  SWEEP_COOLDOWN_MS,
+} from '../../indexer/smi5879-simulate-full.sweep.ts'
+import { runSimulateFull, type CliArgs } from '../../indexer/smi5879-simulate-full.ts'
+import type {
+  BranchMap,
+  SimSnapshotRow,
+  Smi5879SimulateCheckpoint,
+} from '../../indexer/smi5879-simulate-full.types.ts'
+import {
+  makeRow,
+  makeFakeDb,
+  makeVerdictScanner,
+  registerPrimary,
+  contentsApiResponse,
+  flushMicrotasks,
+  resetRowCounter,
+  installFetchMock,
+  restoreFetchMock,
+} from './smi5879-simulate-full.fixtures.ts'
+
+beforeEach(() => {
+  resetRowCounter()
+  installFetchMock()
+})
+
+afterEach(() => {
+  restoreFetchMock()
+})
+
+// ---------------------------------------------------------------------------
+// runSimulateFull — end-to-end orchestration
+// ---------------------------------------------------------------------------
+
+describe('runSimulateFull', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'smi5879-sim-e2e-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function baseArgs(overrides: Partial<CliArgs> = {}): CliArgs {
+    return {
+      runId: 'run-e2e',
+      purpose: 'decision',
+      apply: true,
+      baselineCommit: 'deadbeef',
+      checkpointPath: join(dir, 'checkpoint.json'),
+      reportPath: join(dir, 'report.json'),
+      ...overrides,
+    }
+  }
+
+  it('refuses to run when the generation is not sealed', async () => {
+    const db = makeFakeDb({ getRunSummary: async () => ({ purpose: 'decision', status: 'open' }) })
+    const scanner = makeVerdictScanner(new Map())
+    await expect(runSimulateFull(db, scanner, scanner, baseArgs())).rejects.toThrow(/not "sealed"/)
+  })
+
+  it('refuses to run when the purpose does not match the generation', async () => {
+    const db = makeFakeDb({ getRunSummary: async () => ({ purpose: 'window', status: 'sealed' }) })
+    const scanner = makeVerdictScanner(new Map())
+    await expect(
+      runSimulateFull(db, scanner, scanner, baseArgs({ purpose: 'decision' }))
+    ).rejects.toThrow(/purpose/)
+  })
+
+  it('hard-refuses to start when token_source resolves to app', async () => {
+    const db = makeFakeDb()
+    const scanner = makeVerdictScanner(new Map())
+    await expect(
+      runSimulateFull(db, scanner, scanner, baseArgs(), {
+        GITHUB_APP_ID: 'x',
+        GITHUB_APP_INSTALLATION_ID: 'y',
+        GITHUB_APP_PRIVATE_KEY: 'z',
+      })
+    ).rejects.toThrow(/token_source resolved to "app"/)
+  })
+
+  it('produces a report_kind: full_simulation report with token_source: pat and full coverage on a clean run', async () => {
+    const rows: [SimSnapshotRow, SimSnapshotRow] = [
+      makeRow({ cohort: 'C2' }),
+      makeRow({ cohort: 'C4' }),
+    ]
+    registerPrimary(rows[0], [contentsApiResponse('# a')])
+    registerPrimary(rows[1], [contentsApiResponse('# b')])
+    const db = makeFakeDb({ loadCohortRows: async () => rows })
+    const scanner = makeVerdictScanner(new Map())
+
+    const report = await runSimulateFull(db, scanner, scanner, baseArgs(), {})
+
+    expect(report.report_kind).toBe('full_simulation')
+    expect(report.token_source).toBe('pat')
+    expect(report.run_id).toBe('run-e2e')
+    expect(report.coverage.C2.status).toBe('full')
+    expect(report.coverage.C4.status).toBe('full')
+    expect(report.rows).toHaveLength(2)
+    expect(report.sweep.hard_stopped).toBeNull()
+  })
+
+  it('resuming from an existing checkpoint does not re-fetch already-resolved rows', async () => {
+    const rows: [SimSnapshotRow, SimSnapshotRow] = [
+      makeRow({ cohort: 'C2', id: 'resume-a' }),
+      makeRow({ cohort: 'C2', id: 'resume-b' }),
+    ]
+    const db = makeFakeDb({ loadCohortRows: async () => rows })
+    const scanner = makeVerdictScanner(new Map())
+    const args = baseArgs()
+
+    // Seed a checkpoint where row 'resume-a' is already resolved. Only
+    // 'resume-b' needs its primary URL registered — if the resume logic
+    // incorrectly re-fetched 'resume-a', the unregistered-URL fetch mock
+    // would throw and fail this test.
+    const seeded: Smi5879SimulateCheckpoint = {
+      run_id: args.runId,
+      purpose: args.purpose,
+      baseline_commit: args.baselineCommit,
+      token_source: 'pat',
+      clean_shutdown: true,
+      row_results: {
+        'resume-a': {
+          id: 'resume-a',
+          cohort: 'C2',
+          author: 'acme',
+          name: 'resume-a',
+          outcome: 'unchanged_clean',
+        },
+      },
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    writeCheckpoint(args.checkpointPath as string, seeded)
+    registerPrimary(rows[1], [contentsApiResponse('# b')])
+
+    const report = await runSimulateFull(db, scanner, scanner, args, {})
+
+    expect(report.rows).toHaveLength(2)
+    expect(report.coverage.C2.status).toBe('full')
+    const byId = Object.fromEntries(report.rows.map((r) => [r.id, r]))
+    expect(byId['resume-a']).toBeDefined()
+    expect(byId['resume-b']).toBeDefined()
+    expect(byId['resume-a']?.outcome).toBe('unchanged_clean')
+    expect(byId['resume-b']?.outcome).toBe('unchanged_clean')
+  })
+
+  it('verifies digest at a cold start but not on a clean resume', async () => {
+    const rows: [SimSnapshotRow] = [makeRow({ cohort: 'C2', id: 'digest-row' })]
+    registerPrimary(rows[0], [contentsApiResponse('# a')])
+    const verifyDigest = vi.fn(async () => ({ populationMatches: true, branchMatches: true }))
+    const db = makeFakeDb({ loadCohortRows: async () => rows, verifyDigest })
+    const scanner = makeVerdictScanner(new Map())
+
+    await runSimulateFull(db, scanner, scanner, baseArgs(), {})
+    expect(verifyDigest).toHaveBeenCalledTimes(1)
+
+    // Second invocation resumes from the checkpoint written by the first
+    // (clean_shutdown: true) — digest must NOT be re-verified.
+    await runSimulateFull(db, scanner, scanner, baseArgs(), {})
+    expect(verifyDigest).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-verifies digest when resuming an abnormal (clean_shutdown: false) checkpoint', async () => {
+    const rows: [SimSnapshotRow] = [makeRow({ cohort: 'C2', id: 'abnormal-row' })]
+    const args = baseArgs()
+    const seeded: Smi5879SimulateCheckpoint = {
+      run_id: args.runId,
+      purpose: args.purpose,
+      baseline_commit: args.baselineCommit,
+      token_source: 'pat',
+      clean_shutdown: false, // abnormal prior termination
+      row_results: {},
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    writeCheckpoint(args.checkpointPath as string, seeded)
+    registerPrimary(rows[0], [contentsApiResponse('# a')])
+
+    const verifyDigest = vi.fn(async () => ({ populationMatches: true, branchMatches: true }))
+    const db = makeFakeDb({ loadCohortRows: async () => rows, verifyDigest })
+    const scanner = makeVerdictScanner(new Map())
+
+    await runSimulateFull(db, scanner, scanner, args, {})
+    expect(verifyDigest).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws when digest verification fails', async () => {
+    const rows = [makeRow({ cohort: 'C2' })]
+    const db = makeFakeDb({
+      loadCohortRows: async () => rows,
+      verifyDigest: async () => ({ populationMatches: false, branchMatches: true }),
+    })
+    const scanner = makeVerdictScanner(new Map())
+    await expect(runSimulateFull(db, scanner, scanner, baseArgs(), {})).rejects.toThrow(
+      /digest verification failed/
+    )
+  })
+
+  // -------------------------------------------------------------------------
+  // SMI-5879 review finding 1: a wrong --checkpoint-path pointing at another
+  // generation's checkpoint must be refused loudly — never silently trusted,
+  // even when the checkpoint file itself is syntactically well-formed.
+  // -------------------------------------------------------------------------
+
+  it('refuses to resume a checkpoint whose run_id does not match this invocation', async () => {
+    const args = baseArgs()
+    const seeded: Smi5879SimulateCheckpoint = {
+      run_id: 'a-completely-different-generation',
+      purpose: args.purpose,
+      baseline_commit: args.baselineCommit,
+      token_source: 'pat',
+      clean_shutdown: true,
+      row_results: {},
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    writeCheckpoint(args.checkpointPath as string, seeded)
+    const db = makeFakeDb()
+    const scanner = makeVerdictScanner(new Map())
+    await expect(runSimulateFull(db, scanner, scanner, args, {})).rejects.toThrow(
+      /does not match this invocation.*run_id/s
+    )
+  })
+
+  it('refuses to resume a checkpoint whose row_results reference a row id outside this generation', async () => {
+    const rows: [SimSnapshotRow] = [makeRow({ cohort: 'C2', id: 'real-row-in-this-generation' })]
+    const args = baseArgs()
+    const seeded: Smi5879SimulateCheckpoint = {
+      run_id: args.runId,
+      purpose: args.purpose,
+      baseline_commit: args.baselineCommit,
+      token_source: 'pat',
+      clean_shutdown: true,
+      row_results: {
+        'row-from-a-different-generation': {
+          id: 'row-from-a-different-generation',
+          cohort: 'C2',
+          author: null,
+          name: null,
+          outcome: 'unchanged_clean',
+        },
+      },
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    writeCheckpoint(args.checkpointPath as string, seeded)
+    const db = makeFakeDb({ loadCohortRows: async () => rows })
+    const scanner = makeVerdictScanner(new Map())
+    await expect(runSimulateFull(db, scanner, scanner, args, {})).rejects.toThrow(
+      /row_results key\(s\) that are not in this generation/
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SMI-5879 review finding 2b: `checkpoint.sweep.pass`/`residual_history` must
+// be recorded exactly ONCE per pass, using `runTier3Sweep`'s own return
+// values as the source of truth — not independently incremented inside the
+// per-pass callback AND then added again after the sweep returns.
+// ---------------------------------------------------------------------------
+
+describe('runSimulateFull — sweep pass accounting is not doubled (SMI-5879 review finding 2b)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'smi5879-sim-sweep-acct-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+    vi.useRealTimers()
+  })
+
+  it('report.sweep.passes_run and the persisted checkpoint pass count reflect the actual passes run exactly once', async () => {
+    vi.useFakeTimers()
+    // `default_branch resolution: 'transient'` resolves to 'unevaluable' with
+    // ZERO network calls, and NEVER changes between passes (branchMap is
+    // loaded once and reused) — so every sweep pass re-resolves to the SAME
+    // 'unevaluable' outcome, hard-stopping on non-convergence after exactly
+    // 2 real sweep passes, with none of the retry/backoff complexity a
+    // network-fetch-based residual would need.
+    const row = makeRow({ cohort: 'C2', repo_url: 'https://github.com/acme/transient-repo' })
+    const branchMap: BranchMap = new Map([
+      ['acme/transient-repo', { resolution: 'transient', default_branch: null }],
+    ])
+    const db = makeFakeDb({
+      loadCohortRows: async () => [row],
+      loadBranchMap: async () => branchMap,
+    })
+    const scanner = makeVerdictScanner(new Map())
+    const args: CliArgs = {
+      runId: 'run-sweep-acct',
+      purpose: 'decision',
+      apply: true,
+      baselineCommit: 'deadbeef',
+      checkpointPath: join(dir, 'checkpoint.json'),
+      reportPath: join(dir, 'report.json'),
+    }
+
+    const runPromise = runSimulateFull(db, scanner, scanner, args, {})
+    // Two sweep passes, each gated behind a SWEEP_COOLDOWN_MS sleep, plus
+    // generous slack for heartbeat noise (HEARTBEAT_INTERVAL_MS) along the way.
+    await vi.advanceTimersByTimeAsync(SWEEP_COOLDOWN_MS * 2 + HEARTBEAT_INTERVAL_MS * 5)
+    const report = await runPromise
+
+    expect(report.sweep.hard_stopped).toBe('non_convergence')
+    // The pre-fix bug double-counted: the per-pass callback incremented
+    // checkpoint.sweep.pass by 1 on each of the 2 real passes (-> 2), then
+    // the final block added sweep.passesRun (2) AGAIN on top (-> 4).
+    expect(report.sweep.passes_run).toBe(2)
+
+    const checkpoint = readCheckpoint(args.checkpointPath as string)
+    expect(checkpoint?.sweep.pass).toBe(2)
+    expect(checkpoint?.sweep.residual_history).toEqual([1, 1])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SMI-5879 review finding 4: a heartbeat rejection must trigger the SAME
+// fatal-abort path as a `null` (lost-claim) result, never an unhandled
+// rejection; a slow in-flight heartbeat call must never overlap with a
+// second concurrent call from the next tick.
+// ---------------------------------------------------------------------------
+
+describe('runSimulateFull — heartbeat (SMI-5879 review finding 4)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'smi5879-sim-heartbeat-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+    vi.useRealTimers()
+  })
+
+  function heartbeatArgs(): CliArgs {
+    return {
+      runId: 'run-heartbeat',
+      purpose: 'decision',
+      apply: true,
+      baselineCommit: 'deadbeef',
+      checkpointPath: join(dir, 'checkpoint.json'),
+      reportPath: join(dir, 'report.json'),
+    }
+  }
+
+  it('a rejected heartbeat call triggers the same fatal-abort path as a null result', async () => {
+    vi.useFakeTimers()
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as typeof process.exit)
+
+    let resolveDigest: (v: {
+      populationMatches: boolean
+      branchMatches: boolean
+    }) => void = () => {}
+    const digestPromise = new Promise<{ populationMatches: boolean; branchMatches: boolean }>(
+      (resolve) => {
+        resolveDigest = resolve
+      }
+    )
+    const heartbeat = vi.fn().mockRejectedValueOnce(new Error('transient network failure'))
+    const db = makeFakeDb({ verifyDigest: () => digestPromise, heartbeat })
+    const scanner = makeVerdictScanner(new Map())
+    const args = heartbeatArgs()
+
+    const runPromise = runSimulateFull(db, scanner, scanner, args, {})
+    // Drain the microtask chain (getRunSummary -> claimRun -> ... -> the
+    // heartbeat's setTimeout registration -> the blocking verifyDigest await)
+    // before advancing the fake heartbeat timer.
+    await flushMicrotasks()
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+
+    expect(heartbeat).toHaveBeenCalledTimes(1)
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    const checkpoint = readCheckpoint(args.checkpointPath as string)
+    expect(checkpoint?.clean_shutdown).toBe(false)
+
+    // Let the still-pending runSimulateFull promise settle so the test
+    // doesn't leave a floating unhandled promise behind.
+    resolveDigest({ populationMatches: true, branchMatches: true })
+    await runPromise
+    exitSpy.mockRestore()
+  })
+
+  it('a slow heartbeat call does not allow a second concurrent in-flight call, and normal ticking resumes once it settles', async () => {
+    vi.useFakeTimers()
+    let resolveDigest: (v: {
+      populationMatches: boolean
+      branchMatches: boolean
+    }) => void = () => {}
+    const digestPromise = new Promise<{ populationMatches: boolean; branchMatches: boolean }>(
+      (resolve) => {
+        resolveDigest = resolve
+      }
+    )
+    let resolveFirstHeartbeat: (v: string | null) => void = () => {}
+    const firstHeartbeatPromise = new Promise<string | null>((resolve) => {
+      resolveFirstHeartbeat = resolve
+    })
+    const heartbeat = vi
+      .fn()
+      .mockReturnValueOnce(firstHeartbeatPromise)
+      .mockResolvedValue(new Date().toISOString())
+    const db = makeFakeDb({ verifyDigest: () => digestPromise, heartbeat })
+    const scanner = makeVerdictScanner(new Map())
+    const args = heartbeatArgs()
+
+    const runPromise = runSimulateFull(db, scanner, scanner, args, {})
+    await flushMicrotasks()
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+    expect(heartbeat).toHaveBeenCalledTimes(1) // first tick fired, still in flight
+
+    // A second interval's worth of time passes while the first call is
+    // STILL pending — must NOT fire a second, overlapping call.
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+    expect(heartbeat).toHaveBeenCalledTimes(1)
+
+    // Now let the first call settle, and confirm ticking resumes normally.
+    resolveFirstHeartbeat(new Date().toISOString())
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+    expect(heartbeat).toHaveBeenCalledTimes(2)
+
+    resolveDigest({ populationMatches: true, branchMatches: true })
+    await runPromise
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** the tool that actually proves SMI-5879's security-scanner fix is safe to deploy across the full ~345K-skill catalog before it ships. It re-scans every skill that genuinely needs re-checking (skipping the large, already-proven-safe slice from item 2) with both the old and new scanner, and reports exactly which skills would change status — catching a would-be regression before it reaches production instead of after.

**Quality bar:** went through two independent rounds of adversarial review from a second AI model (GPT-5.6-Sol, a different provider than the one that wrote it), specifically hunting for ways the tool's safety guarantees could be wrong. Round 1 found two serious issues in how the tool recovers from a crash during its multi-day run — a crash-and-resume could let its own safety limits (a "stop and ask a human" circuit breaker) reset instead of carrying over, and progress-tracking numbers were being counted twice — plus two smaller robustness gaps (a corrupted progress file wasn't being caught, and a background health-check could silently miss a real failure). All four fixed and re-verified by the second round. Along the way, I independently caught and fixed a bug of my own (a missing file reference that would have made the tool fail immediately on its first real run) and several type-safety issues the implementation's own self-check had missed — verified end-to-end with real infrastructure access before treating it as fixed, not just taken on faith.

**Found along the way:** confirmed a genuine, pre-existing gap — none of this project's `scripts/` directory (not just this PR's new code) is actually type-checked by CI, only linted; filed separately (SMI-5947) since it's infrastructure work requiring its own review process, not something to bolt onto this PR.

**Net result:** In progress. One piece left in this phase — an automated go/no-go check that reads this tool's output (and everything else built so far) and makes the final call on whether the real security fix is safe to merge.

---

## Technical detail

New files under `scripts/indexer/`: `smi5879-simulate-full.ts` (CLI orchestration — claim/heartbeat/digest-verification/checkpointed main pass/tier-3 retry sweep/report) plus `.types/.baseline/.db/.helpers/.sweep.ts` siblings (split to stay under the repo's 500-line-per-file limit); `smi5879-fetch-retry.ts` (retry wrapper, never modifies the production rate-limit module it wraps); `smi5879-simulate-preflight-estimate.ts` (a smaller, explicitly non-authoritative sampled estimate tool, clearly marked as such everywhere it prints output). Both new CLI tools run on a dedicated API credential path (not the one production's own automated jobs use), and hard-refuse to start if misconfigured to use the wrong one.

No production code touched — this is pure new tooling, plus a corresponding extension to an existing structural test file. Typecheck (against the repo's real strict settings — `scripts/` has no CI-wired typecheck yet, SMI-5947)/lint/format/audit:standards all clean. 969/969 relevant tests pass locally (921 non-database-gated including 50 new/updated for this item, 49 pre-existing skipped pending a separate CI-database-provisioning follow-up already tracked).

Refs SMI-5879
