### PR TITLE
fix(docs): correct tier-label and capability-claim drift in tutorials

### DIFF
--- a/packages/website/src/pages/docs/index.astro
+++ b/packages/website/src/pages/docs/index.astro
@@ -257,7 +257,7 @@ EOF`}</code></pre>
         <td><a href="/docs/mcp-server"><code>skill_audit</code> tool</a></td>
       </tr>
       <tr>
-        <td>Audit local inventory for namespace collisions <em>(Team+)</em></td>
+        <td>Audit local inventory for namespace collisions</td>
         <td><a href="/docs/cli"><code>skillsmith audit collisions</code></a></td>
         <td><a href="/docs/mcp-server"><code>skill_inventory_audit</code> tool</a></td>
       </tr>

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -350,11 +350,13 @@ EOF`}</code></pre>
     <li>"Ask Skillsmith to check if this skill structure is correct"</li>
   </ul>
 
-  <h2>Namespace Audit Tools (Team+)</h2>
+  <h2 id="namespace-audit-tools-team">Namespace Audit Tools</h2>
 
   <p>
     These tools detect and resolve namespace collisions across your local skills, commands, agents, and CLAUDE.md files.
-    Available on the Team and Enterprise tiers. Free and Individual receive a typed error if invoked.
+    <code>skill_inventory_audit</code>, <code>apply_namespace_rename</code>, and
+    <code>apply_recommended_edit</code> are all available on every tier today — Team/Enterprise
+    tier-gating for these tools is not yet enforced.
   </p>
 
   <h3>skill_inventory_audit</h3>
@@ -369,12 +371,12 @@ EOF`}</code></pre>
 }`}</code></pre>
 
   <p>
-    Three pass-modes control depth and ONNX cost:
+    Four pass-modes control depth and ONNX cost:
   </p>
   <ul>
-    <li><strong>preventative</strong> (default for community/individual once unlocked) — exact-name collisions + generic-token flags. No ONNX model load.</li>
+    <li><strong>preventative</strong> (default for Free/Individual) — exact-name collisions + generic-token flags. No ONNX model load.</li>
     <li><strong>power_user</strong> (default for Team) — adds semantic-overlap pass via <code>OverlapDetector</code>.</li>
-    <li><strong>governance</strong> (default for Enterprise) — same as power_user; deeper audit-history retention.</li>
+    <li><strong>governance</strong> (default for Enterprise) — same checks as power_user; reserved as the Enterprise default.</li>
     <li><strong>off</strong> — short-circuits to an empty result.</li>
   </ul>
 
@@ -505,7 +507,7 @@ Assistant: [Uses compare tool] Here's a comparison:
     <li><a href="/docs/tutorials/discover"><strong>Discover</strong></a> — <code>search</code>, <code>skill_recommend</code></li>
     <li><a href="/docs/tutorials/evaluate"><strong>Evaluate</strong></a> — <code>get_skill</code>, <code>skill_compare</code>, <code>skill_diff</code></li>
     <li><a href="/docs/tutorials/install-and-use"><strong>Install &amp; use</strong></a> — <code>install_skill</code>, <code>skill_validate</code></li>
-    <li><a href="/docs/tutorials/maintain"><strong>Maintain</strong></a> — <code>skill_updates</code>, <code>skill_outdated</code>, <code>skill_inventory_audit</code> (Team+)</li>
+    <li><a href="/docs/tutorials/maintain"><strong>Maintain</strong></a> — <code>skill_updates</code>, <code>skill_outdated</code>, <code>skill_inventory_audit</code></li>
     <li><a href="/docs/tutorials/govern"><strong>Govern</strong></a> — <code>skill_audit</code>, <code>compliance_report</code> (Team+), <code>audit_export</code>, <code>audit_query</code>, <code>siem_export</code> (Enterprise)</li>
     <li><a href="/docs/tutorials/uninstall"><strong>Uninstall</strong></a> — <code>uninstall_skill</code></li>
     <li><a href="/docs/inventory"><strong>Cross-machine skill inventory</strong></a> — view installed skills across devices</li>

--- a/packages/website/src/pages/docs/tutorials/govern.astro
+++ b/packages/website/src/pages/docs/tutorials/govern.astro
@@ -10,9 +10,8 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
 
   <p class="lead">
     The Govern stage is where Skillsmith stops being a personal tool and becomes infrastructure. It
-    covers audit logs, SIEM export, and the team-scope view of the same namespace audit you ran in
-    <a href="/docs/tutorials/maintain">Maintain</a> — all backed by the owner/admin/member roles your
-    team already has. Most flows here are Team or Enterprise tier.
+    covers audit logs, SIEM export, security review, and compliance reporting — all backed by the
+    owner/admin/member roles your team already has. Most flows here are Team or Enterprise tier.
   </p>
 
   <p>
@@ -63,7 +62,7 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
         <td>MCP</td>
         <td><code>skill_pack_audit</code></td>
         <td>Audit a pack of skills (bulk advisory check)</td>
-        <td>Team+</td>
+        <td>Individual+</td>
       </tr>
       <tr>
         <td>MCP</td>
@@ -98,19 +97,23 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
       <tr>
         <td>CLI</td>
         <td><code>skillsmith audit collisions</code></td>
-        <td>Same namespace audit as Maintain, with team-scope reporting</td>
+        <td>Same as MCP <code>skill_inventory_audit</code>, formatted for the terminal</td>
         <td>All (deeper modes Team+)</td>
       </tr>
     </tbody>
   </table>
 
   <div class="callout warning">
-    <p class="callout-heading">Tier gating is enforced</p>
+    <p class="callout-heading">Tier gating varies by tool</p>
     <p>
-      Governance tools require a Team or Enterprise license. Free and Individual tiers see typed
-      errors when they invoke these tools — not stub data. Configure <code
-        >SKILLSMITH_LICENSE_KEY</code
-      > in your MCP env config; missing keys produce a "license required" error rather than a silent fallback.
+      <code>skill_audit</code>, <code>compliance_report</code>, and <code
+        >skillsmith audit advisories</code
+      > require a Team or Enterprise license — Free and Individual tiers see typed errors when they
+      invoke these, not stub data. <code>skill_pack_audit</code> only needs Individual+.
+      <code>audit_export</code>, <code>audit_query</code>, and <code>siem_export</code> are
+      Enterprise-only. Configure <code>SKILLSMITH_LICENSE_KEY</code> in your MCP env config; missing
+      keys produce a "license required" error rather than a silent fallback for whichever tools your
+      tier doesn't cover.
     </p>
   </div>
 
@@ -244,27 +247,28 @@ skillsmith audit advisories --all   # Audit every installed skill`}</code></pre>
     >.
   </p>
 
-  <h2>Step 7 — Roll up namespace audit findings across a team</h2>
+  <h2>Step 7 — Apply rename and edit suggestions from your audit</h2>
 
   <p>
     The <a href="/docs/tutorials/maintain">Maintain tutorial</a>'s namespace audit reports
-    collisions for a single user. At team scope, the same audit rolls up across every developer in
-    your workspace, surfacing drift between team members' installed inventories.
+    collisions and suggested fixes for your own <code>~/.claude/</code> inventory. There's no
+    cross-team rollup yet — each developer runs the audit against their own machine.
   </p>
 
   <p>
     Combine the audit output with <code>apply_recommended_edit</code>
-    (Team+) and <code>apply_namespace_rename</code> (Team+) to act on rename suggestions across the
-    team, not just your own machine. Renames apply via the namespace-overrides ledger so subsequent
-    audits respect them. This is per-suggestion remediation, not a configurable rules engine — each
-    rename or edit is applied individually, the same way it is in <a
+    and <code>apply_namespace_rename</code> to act on those suggestions. Renames apply via the
+    namespace-overrides ledger so subsequent audits respect them. This is per-suggestion
+    remediation, not a configurable rules engine — each rename or edit is applied individually, the
+    same way it is in <a
       href="/docs/tutorials/maintain#namespace-audit">Maintain</a
-    >, just rolled up across more installs.
+    >.
   </p>
 
   <p>
     Both apply tools return a non-mutating preview by default; pass
-    <code>confirmed: true</code> to actually write the change.
+    <code>confirmed: true</code> to actually write the change. Neither tool is currently
+    tier-restricted, and team-wide audit rollup across multiple developers doesn't exist yet.
   </p>
 
   <h2 id="cyclonedx-export">Step 8 — Export a CycloneDX AI-BOM for compliance evidence</h2>

--- a/packages/website/src/pages/docs/tutorials/index.astro
+++ b/packages/website/src/pages/docs/tutorials/index.astro
@@ -81,8 +81,8 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
     <a href="/docs/tutorials/govern" class="doc-card">
       <h3>6. Govern</h3>
       <p>
-        Query audit logs, export events for a SIEM, and roll up namespace-audit findings at team
-        scale. Team and Enterprise tiers.
+        Query audit logs, export events for a SIEM, and run security reviews across your team.
+        Mostly Team and Enterprise tier.
       </p>
     </a>
 

--- a/packages/website/src/pages/docs/tutorials/maintain.astro
+++ b/packages/website/src/pages/docs/tutorials/maintain.astro
@@ -261,8 +261,10 @@ skillsmith config set audit_mode power_user`}</code></pre>
     <p>
       <code>apply_namespace_rename</code> and
       <code>apply_recommended_edit</code> are available on every tier today. Team/Enterprise
-      tier-gating for these two tools is not yet enforced. There's no CLI fallback for either tool
-      yet — apply suggestions via the MCP tools.
+      tier-gating for these two tools is not yet enforced. <code>apply_namespace_rename</code> also
+      has a CLI fallback (<code>skillsmith audit collisions</code>, same apply / custom / skip
+      flow, plus a <code>--apply-all</code> batch mode) — <code>apply_recommended_edit</code> does
+      not, so use the MCP tool directly for prose edits.
     </p>
   </div>
 

--- a/packages/website/src/pages/docs/tutorials/maintain.astro
+++ b/packages/website/src/pages/docs/tutorials/maintain.astro
@@ -46,7 +46,7 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
         <td>MCP</td>
         <td><code>skill_updates</code></td>
         <td>List installed skills with newer versions in the registry</td>
-        <td>All</td>
+        <td>Individual+</td>
       </tr>
       <tr>
         <td>MCP</td>
@@ -66,13 +66,13 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
         <td>MCP</td>
         <td><code>apply_namespace_rename</code></td>
         <td>Apply a rename suggestion (apply / custom / skip)</td>
-        <td>Team+</td>
+        <td>All (tier-gating on roadmap)</td>
       </tr>
       <tr>
         <td>MCP</td>
         <td><code>apply_recommended_edit</code></td>
         <td>Apply a recommended prose edit; gated on <code>APPLY_TEMPLATE_REGISTRY</code></td>
-        <td>Team+</td>
+        <td>All (tier-gating on roadmap)</td>
       </tr>
       <tr>
         <td>CLI</td>
@@ -219,7 +219,7 @@ skillsmith pin --list                     # See all currently pinned skills`}</c
       </tr>
       <tr>
         <td><code>governance</code></td>
-        <td>Same as <code>power_user</code> with deeper audit-history retention</td>
+        <td>Same checks as <code>power_user</code>; reserved as the Enterprise default</td>
         <td>Enterprise (default for Enterprise)</td>
       </tr>
       <tr>
@@ -257,12 +257,12 @@ skillsmith config set audit_mode power_user`}</code></pre>
   </ul>
 
   <div class="callout">
-    <p class="callout-heading">Team+ feature</p>
+    <p class="callout-heading">Not yet tier-restricted</p>
     <p>
       <code>apply_namespace_rename</code> and
-      <code>apply_recommended_edit</code> are gated to Team and Enterprise tiers. Free and Individual
-      tiers see the rename suggestions but cannot apply them via the MCP — the CLI fallback is also tier-gated.
-      See <a href="/pricing">pricing</a>.
+      <code>apply_recommended_edit</code> are available on every tier today. Team/Enterprise
+      tier-gating for these two tools is not yet enforced. There's no CLI fallback for either tool
+      yet — apply suggestions via the MCP tools.
     </p>
   </div>
 
@@ -327,9 +327,9 @@ skillsmith config set audit_mode power_user`}</code></pre>
   <h2>Where to next</h2>
 
   <p>
-    Maintain is for individual users. If you operate at team or enterprise scale, the same audit
-    signals roll up into the
-    <a href="/docs/tutorials/govern">Govern stage</a> — audit logs, SIEM export, team roles.
+    Maintain covers your own machine. At team or enterprise scale,
+    <a href="/docs/tutorials/govern">Govern</a> adds the org-wide controls — audit logs, SIEM
+    export, team roles.
   </p>
 
   <p>

--- a/packages/website/src/pages/pricing.astro
+++ b/packages/website/src/pages/pricing.astro
@@ -308,7 +308,7 @@ const jsonLdData = generateJsonLd(pricingTiers, pricingFaqs)
     </div>
   </section>
 
-  <section class="pricing-roadmap">
+  <section class="pricing-roadmap" id="roadmap">
     <h2>On the roadmap</h2>
     <p class="roadmap-subtitle">
       We're actively building these features. Availability will be announced as each ships.


### PR DESCRIPTION
## Business Summary

**What shipped:** Corrected tier-label and capability-claim accuracy across 6 website docs/tutorial pages. Two tools were mislabeled Team+ when they're actually Individual+ (`skill_pack_audit`, `skill_updates`). Four MCP audit tools were documented as license-enforced Team+ ("Free and Individual receive a typed error if invoked") when the code actually applies zero license enforcement to any of them. A team-wide namespace-audit "rollup" capability was described in four places and doesn't exist anywhere in the code. A "governance mode has deeper audit-history retention" claim wasn't backed by any code. One page's blanket "governance tools require Team or Enterprise" callout contradicted its own table. Also fixed: a wrong pass-mode count, a pre-existing broken heading anchor, and a broken roadmap link.

**Quality bar:** Every correction is traced to the actual gating code (`toolFeatureMapping.ts`, `audit-tool-dispatch.ts`) rather than assumed. Reviewed twice before merge — once by GPT-5.6-Sol (cross-provider, via NEEDLE) which caught the `skill_updates` mislabel and several more instances on the first draft, and once by the `governance` skill, which caught a factual regression this PR's own first draft introduced (a "no CLI fallback" claim that was false for one of the two tools).

**Found along the way:** filed **SMI-5959** to track the two real product gaps this PR's docs corrections surfaced — (1) `apply_namespace_rename`/`apply_recommended_edit`/`skill_inventory_audit` have no license/tier enforcement at all despite being designed as Team+ features, and (2) a team-wide namespace-audit rollup across multiple developers doesn't exist as a feature. This PR corrects the docs to match shipped behavior; it does not add the missing enforcement or build the missing feature, both of which are real, separately-scoped engineering decisions.

**Net result:** Fully shipped, docs-only. SMI-5959 tracks the follow-up engineering work, not blocking.

---

## Technical detail

Files touched (all `packages/website/src/pages/`): `docs/index.astro`, `docs/mcp-server.astro`, `docs/tutorials/govern.astro`, `docs/tutorials/index.astro`, `docs/tutorials/maintain.astro`, `pricing.astro`.

- `skill_pack_audit` / `skill_updates`: Team+ → Individual+ (both map to `version_tracking` in `toolFeatureMapping.ts`, tier `individual`).
- `apply_namespace_rename` / `apply_recommended_edit` / `skill_inventory_audit`: corrected from "Team+"/"gated"/"typed error if invoked" to "available on every tier today" — `audit-tool-dispatch.ts` dispatches all three via a bare `okBody(...)` call with no `withLicenseAndQuota` wrapper (unlike the neighboring `skill_audit`/`skill_pack_audit` cases in the same file), and none of the three appear in `TOOL_FEATURES` at all.
- Removed the fabricated "rolls up across every developer in your workspace" framing from `govern.astro` (Step 7 + lead paragraph), `maintain.astro` ("Where to next"), and the tutorials index card — `SkillInventoryAuditInput` has no `team_scope`/`teamId` field; the tool only ever audits the local `~/.claude/` of whoever's MCP client calls it.
- Corrected `apply_namespace_rename`'s CLI-fallback claim: it does have one (`skillsmith audit collisions`, same `applyRename()` the MCP tool calls, plus `--apply-all`) — only `apply_recommended_edit` has none.
- Removed "governance mode has deeper audit-history retention" (`maintain.astro`, `mcp-server.astro`) — `power_user` and `governance` share the same `collision-detector.ts` code path; no retention-behavior difference exists in code.
- `govern.astro`'s "Tier gating is enforced" callout rewritten from a blanket Team+/Enterprise claim to name the actual mixed tiers (`skill_audit`/`compliance_report`/CLI advisories = Team+, `skill_pack_audit` = Individual+, `audit_export`/`audit_query`/`siem_export` = Enterprise).
- `mcp-server.astro`: "Three pass-modes" → "Four" (it lists `preventative`/`power_user`/`governance`/`off`).
- Added `id="namespace-audit-tools-team"` to `mcp-server.astro`'s Namespace Audit Tools heading (fixes a pre-existing broken anchor `maintain.astro` already linked to) and `id="roadmap"` to `pricing.astro`'s roadmap section (fixes `tool-dispatch.ts`'s own `coming_soon` response, which already cited `pricing#roadmap` for unrelated gated tools).

No application code changed. `npm run build` (website), `npx prettier --check`, and `npm run typecheck` all pass. Linear: SMI-5952 (this PR), SMI-5959 (follow-up, linked in both directions).
