### PR TITLE
fix(indexer): SMI-5930 RCA — validationCache-miss diagnostic + regression test

### DIFF
--- a/scripts/indexer/indexer-runners.ts
+++ b/scripts/indexer/indexer-runners.ts
@@ -26,6 +26,7 @@ import {
 import { minimalSkillPayload, repoUpdatedAtKey } from './skill-processor.helpers.ts'
 import { type RateLimitTelemetry } from './_shared/rate-limit.ts'
 import { buildGitHubHeaders } from './_shared/github-auth.ts'
+import { sanitizeForLog } from './_shared/validation.ts'
 import type { GitHubRepository } from './topic-search.ts'
 import { getHighTrustAuthor, type HighTrustAuthor } from './high-trust-authors.ts'
 import {
@@ -340,6 +341,27 @@ export async function runUpsertPhase(
         validationCache,
         repo.skillPath
       )
+      // SMI-5930 diagnostic: a repo discovered installable via subdirectory search
+      // whose validationCache lookup misses here means `repositoryToSkill` falls
+      // back to the repository's own name/description instead of SKILL.md's
+      // frontmatter (docs/internal/implementation/smi-5930-rca-progress.md).
+      // Static analysis + synthetic repro (subdirectory-search.validation-cache-
+      // roundtrip.test.ts) could not reproduce a miss for this write/read pairing,
+      // so this narrowly-scoped, high-signal log is the intended way to observe
+      // which real repos actually trigger it. Remove once the mechanism is
+      // confirmed and the corresponding fix lands.
+      if (
+        repo.installable &&
+        repo.discoveryPath?.startsWith('subdirectory_search') &&
+        (validation === undefined || !validation.metadata?.name)
+      ) {
+        console.log(
+          `[SMI-5930] validationCache miss at repositoryToSkill: ${repo.fullName} ` +
+            `skillPath=${sanitizeForLog(repo.skillPath ?? '')} branch=${repo.defaultBranch} ` +
+            `discoveryPath=${repo.discoveryPath} cacheSize=${validationCache.size} ` +
+            `validationPresent=${validation !== undefined} metadataPresent=${validation?.metadata !== undefined}`
+        )
+      }
       // SMI-4842: Exclude curated `awesome-*` link-list repos (e.g.
       // awesome-claude-skills) — README-only catalogs of links to other repos,
       // not skills. Conservative: requires the `awesome-` name prefix AND no

--- a/scripts/indexer/indexer-runners.ts
+++ b/scripts/indexer/indexer-runners.ts
@@ -225,6 +225,13 @@ export async function runUpsertPhase(
   let high_trust_fallback_hits = 0
   // SMI-3540: Collect IDs of hash-matched (unchanged) skills to touch last_seen_at
   const unchangedIds: string[] = []
+  // SMI-5930 diagnostic: total validationCache misses this run (see below). Only
+  // the first SMI_5930_DIAGNOSTIC_LOG_CAP get an individual log line — if the
+  // leading hypothesis is right this can fire on the bulk of a large backfill
+  // dispatch's rows, and GHA log volume is a real cost. A summary line at the
+  // end of this function reports the full count regardless of the cap.
+  let smi5930DiagnosticMisses = 0
+  const SMI_5930_DIAGNOSTIC_LOG_CAP = 50
   // SMI-5278: Touch last_seen_at on unchanged skills at most once per 12h (was 1h) — each
   // touch is a non-HOT UPDATE (last_seen_at is indexed) that rewrites the row + all skills
   // indexes. Safe: stale-quarantine fires at stale_days=7 = 168h of margin (SMI-4203).
@@ -355,12 +362,15 @@ export async function runUpsertPhase(
         repo.discoveryPath?.startsWith('subdirectory_search') &&
         (validation === undefined || !validation.metadata?.name)
       ) {
-        console.log(
-          `[SMI-5930] validationCache miss at repositoryToSkill: ${repo.fullName} ` +
-            `skillPath=${sanitizeForLog(repo.skillPath ?? '')} branch=${repo.defaultBranch} ` +
-            `discoveryPath=${repo.discoveryPath} cacheSize=${validationCache.size} ` +
-            `validationPresent=${validation !== undefined} metadataPresent=${validation?.metadata !== undefined}`
-        )
+        smi5930DiagnosticMisses++
+        if (smi5930DiagnosticMisses <= SMI_5930_DIAGNOSTIC_LOG_CAP) {
+          console.log(
+            `[SMI-5930] validationCache miss at repositoryToSkill: ${repo.fullName} ` +
+              `skillPath=${sanitizeForLog(repo.skillPath ?? '')} branch=${repo.defaultBranch} ` +
+              `discoveryPath=${repo.discoveryPath} cacheSize=${validationCache.size} ` +
+              `validationPresent=${validation !== undefined} metadataPresent=${validation?.metadata !== undefined}`
+          )
+        }
       }
       // SMI-4842: Exclude curated `awesome-*` link-list repos (e.g.
       // awesome-claude-skills) — README-only catalogs of links to other repos,
@@ -524,6 +534,15 @@ export async function runUpsertPhase(
       scoreDistribution.scores.reduce((a, b) => a + b, 0) / scoreDistribution.scores.length
     console.log(
       `[QualityScore] HT=${scoreDistribution.highTrust} C=${scoreDistribution.community} avg=${avg.toFixed(4)}`
+    )
+  }
+
+  // SMI-5930 diagnostic summary — always reports the true total even when
+  // individual lines above were capped at SMI_5930_DIAGNOSTIC_LOG_CAP.
+  if (smi5930DiagnosticMisses > 0) {
+    console.log(
+      `[SMI-5930] validationCache misses this run: ${smi5930DiagnosticMisses} ` +
+        `(${Math.min(smi5930DiagnosticMisses, SMI_5930_DIAGNOSTIC_LOG_CAP)} logged individually above)`
     )
   }
 

--- a/scripts/tests/indexer/subdirectory-search.validation-cache-roundtrip.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.validation-cache-roundtrip.test.ts
@@ -1,0 +1,233 @@
+/**
+ * SMI-5930: validationCache round-trip regression test.
+ * @module scripts/tests/indexer/subdirectory-search.validation-cache-roundtrip
+ *
+ * `subdirectory-search.perskill.test.ts` and `.license-branch.test.ts` both mock
+ * `checkSkillMdExists` entirely (`mockCheckSkillMdExists.mockResolvedValue(true)`),
+ * so neither exercises the real cache write (`checkSkillMdExists` ->
+ * `validationCache.set`) or the real cache read (`getCachedValidation` ->
+ * `repositoryToSkill`) — the exact round-trip SMI-5930 investigated after
+ * discovering 91%+ of `subdirectory_search`-path skills persist with
+ * `name`/`description` falling back to the repository's own name/description
+ * instead of the SKILL.md frontmatter's. This test closes that coverage gap:
+ * it drives the REAL `checkSkillMdExists` + `getCachedValidation` +
+ * `repositoryToSkill` (only `global.fetch`, `fetchRepoLicense`, and
+ * `enumerateRepoSkillPaths` are mocked) through `processSearchResults`, proving
+ * the write-key/read-key pairing SMI-5849 fixed still holds for both a
+ * single multi-skill repo and two DIFFERENT repos processed consecutively
+ * (the exact prod shape of GeoloeG-IsT/pitch + GeoloeG-IsT/agents-reverse-engineer,
+ * two unrelated repos sharing an identical `.claude/skills/are-*` path set).
+ *
+ * RCA status: this test PASSES on current `main` — the cache-key-mismatch
+ * hypothesis in docs/internal/implementation/smi-5898-wave5-design-proposal.md
+ * (Open Question 2) is empirically ruled out for this code path. See
+ * docs/internal/implementation/smi-5930-rca-progress.md for the full
+ * investigation and the production-diagnostic log this PR adds instead.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+
+vi.mock('../../indexer/_shared/rate-limit.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/_shared/rate-limit.ts')>()
+  return { ...actual, delay: vi.fn(async () => undefined), GITHUB_API_DELAY: 0 }
+})
+vi.mock('../../indexer/_shared/github-auth.ts', () => ({
+  buildGitHubHeaders: vi.fn(async () => ({})),
+}))
+
+const mockFetchRepoLicense = vi.fn()
+vi.mock('../../indexer/license-filter.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/license-filter.ts')>()
+  return { ...actual, fetchRepoLicense: (...args: unknown[]) => mockFetchRepoLicense(...args) }
+})
+
+const mockEnumerateRepoSkillPaths = vi.fn()
+vi.mock('../../indexer/trees-enumerate.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/trees-enumerate.ts')>()
+  return {
+    ...actual,
+    enumerateRepoSkillPaths: (...args: unknown[]) => mockEnumerateRepoSkillPaths(...args),
+  }
+})
+
+import { processSearchResults } from '../../indexer/subdirectory-search.process.ts'
+import {
+  getCachedValidation,
+  repositoryToSkill,
+  type SkillMdValidation,
+} from '../../indexer/skill-processor.ts'
+import type { GitHubRepository } from '../../indexer/topic-search.ts'
+
+function skillMdContent(name: string, repoLabel: string) {
+  return [
+    '---',
+    `name: ${name}`,
+    `description: Skill ${name} belonging to ${repoLabel}, long enough to clear the gate.`,
+    '---',
+    '',
+    `# ${name}`,
+    '',
+    'Body content long enough to clear the minimum length gate comfortably here.',
+  ].join('\n')
+}
+
+describe('SMI-5930: validationCache round-trip through processSearchResults (real checkSkillMdExists)', () => {
+  let originalFetch: typeof global.fetch
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+    mockFetchRepoLicense.mockReset()
+    mockFetchRepoLicense.mockResolvedValue({
+      license: 'MIT',
+      defaultBranch: 'main',
+      fetchFailed: false,
+    })
+    mockEnumerateRepoSkillPaths.mockReset()
+  })
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  function makeResultRepo(
+    owner: string,
+    repoName: string,
+    description: string | null
+  ): GitHubRepository {
+    return {
+      owner,
+      name: repoName,
+      fullName: `${owner}/${repoName}`,
+      description,
+      // Code search omits default_branch, so this is the (undefined) code-search
+      // shaped value — mirrors prod (SMI-5849).
+      url: `https://github.com/${owner}/${repoName}/tree/undefined/.claude/skills/are-clean`,
+      stars: 1,
+      forks: 0,
+      topics: [],
+      updatedAt: new Date().toISOString(),
+      defaultBranch: undefined as unknown as string,
+      installable: false,
+      repoName,
+      skillPath: '.claude/skills/are-clean',
+      discoveryPath: 'subdirectory_search:broad',
+    }
+  }
+
+  it('a single repo with two skills resolves distinct, correct names from the cache', async () => {
+    global.fetch = vi.fn(async (url: string) => {
+      if (url.includes('are-clean'))
+        return new Response(skillMdContent('are-clean', 'pitch'), { status: 200 })
+      if (url.includes('are-help'))
+        return new Response(skillMdContent('are-help', 'pitch'), { status: 200 })
+      return new Response('not found', { status: 404 })
+    }) as unknown as typeof global.fetch
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [
+        { path: '.claude/skills/are-clean', blobSha: 'sha-clean' },
+        { path: '.claude/skills/are-help', blobSha: 'sha-help' },
+      ],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+
+    const validationCache = new Map<string, SkillMdValidation>()
+    const repos: GitHubRepository[] = []
+    await processSearchResults(
+      [makeResultRepo('GeoloeG-IsT', 'pitch', null)],
+      new Set(),
+      validationCache,
+      { strictValidation: true },
+      repos,
+      {
+        licenseFiltered: 0,
+        licenseFetchFailed: 0,
+        admitted: 0,
+        licenseNull: 0,
+        noDefaultBranch: 0,
+      },
+      {} as RateLimitTelemetry,
+      {},
+      new Set(),
+      new Map()
+    )
+
+    expect(repos).toHaveLength(2)
+    const names = repos.map((repo) => {
+      const validation = getCachedValidation(
+        repo.owner,
+        repo.repoName,
+        repo.defaultBranch,
+        validationCache,
+        repo.skillPath
+      )
+      return repositoryToSkill(repo, undefined, validation, false).name
+    })
+    expect(new Set(names)).toEqual(new Set(['are-clean', 'are-help']))
+  })
+
+  it('two DIFFERENT repos sharing an identical skill_path set (prod shape: GeoloeG-IsT/pitch + GeoloeG-IsT/agents-reverse-engineer) do not cross-contaminate', async () => {
+    global.fetch = vi.fn(async (url: string) => {
+      const m = url.match(/raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/main\/(.+)\/SKILL\.md/)
+      if (!m) return new Response('not found', { status: 404 })
+      const [, , repo, path] = m
+      const skillName = path.endsWith('are-clean') ? 'are-clean' : 'are-help'
+      return new Response(skillMdContent(skillName, repo), { status: 200 })
+    }) as unknown as typeof global.fetch
+
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: [
+        { path: '.claude/skills/are-clean', blobSha: 'sha-clean' },
+        { path: '.claude/skills/are-help', blobSha: 'sha-help' },
+      ],
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+
+    const validationCache = new Map<string, SkillMdValidation>()
+    const repos: GitHubRepository[] = []
+    await processSearchResults(
+      [
+        makeResultRepo('GeoloeG-IsT', 'pitch', null),
+        makeResultRepo(
+          'GeoloeG-IsT',
+          'agents-reverse-engineer',
+          'Reverse engineer your codebase to let your agents work efficiently'
+        ),
+      ],
+      new Set(),
+      validationCache,
+      { strictValidation: true },
+      repos,
+      {
+        licenseFiltered: 0,
+        licenseFetchFailed: 0,
+        admitted: 0,
+        licenseNull: 0,
+        noDefaultBranch: 0,
+      },
+      {} as RateLimitTelemetry,
+      {},
+      new Set(),
+      new Map()
+    )
+
+    expect(repos).toHaveLength(4)
+    for (const repo of repos) {
+      const validation = getCachedValidation(
+        repo.owner,
+        repo.repoName,
+        repo.defaultBranch,
+        validationCache,
+        repo.skillPath
+      )
+      const expectedName = repo.skillPath?.endsWith('are-clean') ? 'are-clean' : 'are-help'
+      expect(validation?.metadata?.name, `${repo.fullName}:${repo.skillPath}`).toBe(expectedName)
+      const skill = repositoryToSkill(repo, undefined, validation, false)
+      expect(skill.name, `${repo.fullName}:${repo.skillPath}`).toBe(expectedName)
+      // Neither repo's name should ever fall back to the OTHER repo's name or
+      // to its own repository name (the SMI-5930 symptom).
+      expect(skill.name).not.toBe(repo.repoName)
+    }
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** Progress on the investigation into why 91%+ of registry skills discovered under `.claude/skills`-style paths get stored with the *repository's* name and description instead of the skill's own (SMI-5930, Urgent). Two things: (1) a regression test that closes a real test-coverage gap — no existing test exercised the actual cache write→read path this bug lives near — and (2) a narrowly-scoped, self-capping diagnostic log that will pinpoint the exact trigger the next time the indexer runs against a real affected repo.

**Quality bar:** Full investigation (static code tracing + three passing synthetic reproductions of the exact production repro case + targeted production-data queries against `vrcnzpmndtroqxxoqkzy`) empirically ruled out the leading hypothesis from the prior design doc. Typecheck/lint/format clean, full indexer test suite green (929 tests), `audit:standards` 0 failures. This PR does not change any name-resolution or data-repair logic — intentionally, per the parent design doc's own warning that a premature fix here would mask the diagnostic.

**Found along the way:** nothing filed separately — everything found this pass is captured in the RCA doc and the diagnostic added here.

**Net result:** RCA still open. The exact triggering mechanism is not yet identified — this PR narrows the search space substantially and instruments the codebase to close the gap with real evidence from the next indexer/backfill run, rather than guessing further. Follow-up: read `[SMI-5930]` log lines from the next real run, confirm the mechanism, then scope the actual name-repair fix.

---

## Technical detail

- `scripts/indexer/indexer-runners.ts` — adds a diagnostic log immediately after the `getCachedValidation` call, firing only when an `installable`, `subdirectory_search`-discovered skill's cache lookup misses (the exact SMI-5930 precondition). Capped at 50 individually-logged lines per run with a summary line reporting the true total, to bound GHA log volume if the hypothesis proves correct at scale. Temporary — remove once the mechanism is confirmed and the real fix lands.
- `scripts/tests/indexer/subdirectory-search.validation-cache-roundtrip.test.ts` — new regression test exercising the *real* `checkSkillMdExists` → `validationCache` → `getCachedValidation` → `repositoryToSkill` chain (existing `subdirectory-search.*.test.ts` suites all mock `checkSkillMdExists` entirely). Covers a single multi-skill repo and two *different* repos sharing an identical `skill_path` set (the exact prod shape: `GeoloeG-IsT/pitch` + `GeoloeG-IsT/agents-reverse-engineer`). Both pass on current `main`.
- `docs/internal/implementation/smi-5930-rca-progress.md` (via docs/internal submodule bump) — full writeup: the cache-key-mismatch hypothesis ruled out with test evidence; new prod-data findings (the defect is decided once per repo, not per file — 83% of multi-skill repos entirely wrong vs. 16% entirely right vs. <1% mixed; 87% of wrong-name rows also missing `content_hash`/`security_score`, meaning the whole `validation` object is absent, not just its `.metadata`; no time-based fix boundary across the SMI-5849 merge); confirms prod discovery/backfill both run the Node script (`scripts/indexer/run.ts`), not the untested-for-parity Deno edge-function twin.
- No migration, no schema change, no data mutation. Refs SMI-5930.