### PR TITLE
fix(website): correct 4 remaining stale $55/user/mo Enterprise price copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Get your API key at [skillsmith.app/account/cli-token](https://skillsmith.app/ac
 | Community | 30/min | Free |
 | Individual | 60/min | $9.99/mo |
 | Team | 120/min | $25/user/mo |
-| Enterprise | 300/min | $55/user/mo |
+| Enterprise | 300/min | Custom |
 
 > **Note:** Never paste API keys in chat. Configure via settings.json only.
 

--- a/packages/website/src/pages/docs/getting-started.astro
+++ b/packages/website/src/pages/docs/getting-started.astro
@@ -182,7 +182,7 @@ EOF`}</code></pre>
       </tr>
       <tr>
         <td>Enterprise</td>
-        <td>$55/user/mo</td>
+        <td>Custom</td>
         <td>Unlimited</td>
         <td>600/min</td>
       </tr>

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -151,7 +151,7 @@ EOF`}</code></pre>
       <tr>
         <td>Enterprise</td>
         <td>600/min</td>
-        <td>$55/user/mo</td>
+        <td>Custom</td>
         <td>Large organizations</td>
       </tr>
     </tbody>

--- a/packages/website/src/pages/terms.astro
+++ b/packages/website/src/pages/terms.astro
@@ -224,7 +224,7 @@ const effectiveDate = 'January 17, 2026'
             <tr class="border-b border-dark-800">
               <td class="py-3 pr-4">Enterprise</td>
               <td class="py-3 pr-4">Unlimited</td>
-              <td class="py-3">$55/user/month</td>
+              <td class="py-3">Custom</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Business Summary

**What shipped:** PR #2239 unpublished the Enterprise price on the main `/pricing` page (showing "Custom" instead of "$55/user/mo") to support a "Book a call" custom-quote flow. This follow-up, found during that PR's post-merge governance retro, corrects four other static reference tables that independently hardcoded the same now-stale price and weren't touched by #2239: `README.md`'s API rate-limit table, `terms.astro`'s Terms of Service pricing table, and two docs pages (`mcp-server.astro`, `getting-started.astro`) rate-limit tables. All four now read "Custom", consistent with the live pricing page.

**Quality bar:** Verified via full production build of the website package plus direct inspection of the compiled HTML output for both changed pages (`terms/index.html`, `docs/getting-started/index.html`) — confirmed the correct rendered text. Typecheck and prettier clean.

**Found along the way — deliberately NOT changed (verified, out of scope):**
- `constants/terminology.ts`'s `PRICING_TIERS`: marked `@deprecated` (SMI-3909) pointing to the real source (`pricing-data.ts`), and confirmed zero live consumers via repo-wide grep — dead code, no live-surface risk.
- `account/index.astro`: shows an *existing subscriber's own real contracted price* on their account dashboard, not a marketing claim to a prospect — legitimately different from the pages above.
- `account/subscription.astro`: the live "Select Enterprise" self-serve checkout button still shows `$55` and redirects to a working `/signup?tier=enterprise` flow. This is a known, already-tracked gap — PR #2239's own body explicitly states "closing self-serve checkout for both tiers... is real, unplanned engineering work" and defers it to **SMI-5961** (own implementation plan already written). Not re-opened here.

**Net result:** Fully shipped, docs/copy-only. No new follow-up — SMI-5961 already tracks the one remaining, larger gap (self-serve checkout).

## Technical detail

- `README.md:167` — rate-limit table, Enterprise row
- `packages/website/src/pages/terms.astro:227` — ToS pricing table, Enterprise row
- `packages/website/src/pages/docs/mcp-server.astro:154` — rate-limit table, Enterprise row
- `packages/website/src/pages/docs/getting-started.astro:185` — rate-limit table, Enterprise row

All four: `$55/user/mo` (or `/month`) → `Custom`.

Refs SMI-5950