### PR TITLE
feat(website): SMI-5966 rebuild /product around lifecycle governance

### DIFF
--- a/packages/website/src/pages/product.astro
+++ b/packages/website/src/pages/product.astro
@@ -263,6 +263,17 @@ function cellClass(value: string): string {
 function boolCellClass(value: boolean): string {
   return value ? 'cell-yes' : 'cell-no'
 }
+
+// Heroicons-outline paths, matching the site's existing hand-copied-SVG convention
+// (FeatureCard.astro's defaultIcons, Badge.astro). The governance path is the exact
+// `security` glyph already defined in FeatureCard.astro:26-27 -- reused, not reinvented.
+const lifecycleIcons = {
+  registry:
+    'M4 7c0-1.1 3.6-2 8-2s8 .9 8 2-3.6 2-8 2-8-.9-8-2zm0 0v10c0 1.1 3.6 2 8 2s8-.9 8-2V7M4 12c0 1.1 3.6 2 8 2s8-.9 8-2',
+  lock: 'M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z',
+  governance:
+    'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
+}
 ---
 
 <BaseLayout
@@ -272,13 +283,11 @@ function boolCellClass(value: boolean): string {
 >
   <section class="product-hero">
     <p class="product-eyebrow">The lifecycle layer for agent skills</p>
-    <h1>Author, version, deprecate, and govern the skills your team owns</h1>
+    <h1>Author, version, deprecate, and govern <strong>the skills your team owns</strong></h1>
     <p class="product-subtitle">
       Skills spread across teams faster than anyone can govern them — forked, copy-pasted, and
-      scattered across gists and shared drives with no source of truth, no audit trail, and no way
-      to retire what's gone stale. Skillsmith gives them a lifecycle instead: a private, versioned
-      registry your team actually owns, reachable from wherever your team already works — the CLI,
-      the MCP server, VS Code, or your account dashboard.
+      scattered across gists with no source of truth and no audit trail. Skillsmith gives them a
+      lifecycle instead: a private, versioned registry your team actually owns.
     </p>
     <div class="product-hero-ctas">
       {
@@ -294,28 +303,57 @@ function boolCellClass(value: boolean): string {
   <section class="product-lifecycle">
     <h2>What makes the lifecycle real</h2>
     <p class="product-lifecycle-caption">
-      A registry is only as good as what backs it. Here's what's actually shipped today — nothing
-      below is a roadmap item.
+      You've felt this: someone forks a skill, tweaks it, and a month later nobody's sure which copy
+      is the real one. A registry is only as good as what backs it — here's what's actually shipped
+      today, not roadmap.
     </p>
     <div class="product-lifecycle-grid">
       <article class="product-lifecycle-card">
+        <svg
+          class="lifecycle-icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d={lifecycleIcons.registry}></path>
+        </svg>
         <h3>Private registry <span class="tier-badge">Enterprise</span></h3>
         <p>
-          A real, hosted, team-scoped registry — versioned, RLS-enforced at the database level,
-          shared across every teammate. This is where skills your org owns actually live, not a
-          folder someone forked.
+          A real, hosted registry your whole team shares — versioned and access-controlled. This is
+          where skills your org owns actually live, not a folder someone forked.
         </p>
       </article>
       <article class="product-lifecycle-card">
+        <svg
+          class="lifecycle-icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d={lifecycleIcons.lock}></path>
+        </svg>
         <h3>Private skills <span class="tier-badge">Team</span></h3>
         <p>
-          Mark a skill private on your own machine today, hidden from public search. Cross-teammate
-          sync into a shared team namespace is on the roadmap
-          <span class="roadmap-marker" title="Not yet shipped">🕐</span> — for a fully shared team registry
-          today, see Enterprise above.
+          Mark a skill private on your machine today, hidden from public search. Team-wide sync is
+          on the roadmap <span class="roadmap-marker" title="Not yet shipped">🕐</span> — for a fully
+          shared registry now, see Enterprise.
         </p>
       </article>
       <article class="product-lifecycle-card">
+        <svg
+          class="lifecycle-icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d={lifecycleIcons.governance}></path>
+        </svg>
         <h3>Governance, end to end</h3>
         <p>
           Deprecate a version without deleting it. Query and export an audit trail. Generate
@@ -385,8 +423,8 @@ function boolCellClass(value: boolean): string {
   <section class="product-matrix product-matrix-lifecycle">
     <h2>Lifecycle &amp; governance capabilities</h2>
     <p class="product-matrix-caption">
-      Registry, audit, and compliance capabilities, and which surface delivers each one today. Tier
-      column matches <a href="/pricing">pricing</a> exactly.
+      Registry, audit, and compliance capabilities, and which surface delivers each one today. See
+      <a href="/pricing">pricing</a> for full tier details.
     </p>
     <div class="product-matrix-scroll">
       <table class="product-matrix-table">
@@ -484,7 +522,7 @@ function boolCellClass(value: boolean): string {
     margin: 0 auto;
   }
   .product-eyebrow {
-    color: var(--color-coral, #ff6b5b);
+    color: var(--color-coral, #e07a5f);
     font-size: 0.95rem;
     font-weight: 600;
     letter-spacing: 0.05em;
@@ -495,6 +533,10 @@ function boolCellClass(value: boolean): string {
     font-size: clamp(1.75rem, 5vw, 2.75rem);
     line-height: 1.15;
     margin-bottom: 1.25rem;
+  }
+  .product-hero h1 strong {
+    color: var(--color-coral, #e07a5f);
+    font-weight: inherit;
   }
   .product-subtitle {
     font-size: 1.1rem;
@@ -512,7 +554,7 @@ function boolCellClass(value: boolean): string {
     display: inline-block;
     padding: 0.65rem 1.4rem;
     border-radius: 0.5rem;
-    background: var(--color-coral, #ff6b5b);
+    background: var(--color-coral, #e07a5f);
     color: #0d0d0f;
     font-weight: 600;
     text-decoration: none;
@@ -548,6 +590,12 @@ function boolCellClass(value: boolean): string {
     border-radius: 0.75rem;
     padding: 1.5rem;
   }
+  .lifecycle-icon {
+    width: 1.75rem;
+    height: 1.75rem;
+    color: var(--color-coral, #e07a5f);
+    margin-bottom: 0.75rem;
+  }
   .product-lifecycle-card h3 {
     margin: 0 0 0.75rem;
     font-size: 1.1rem;
@@ -570,8 +618,8 @@ function boolCellClass(value: boolean): string {
     letter-spacing: 0.04em;
     padding: 0.15rem 0.5rem;
     border-radius: 999px;
-    background: rgba(255, 107, 91, 0.15);
-    color: var(--color-coral, #ff6b5b);
+    background: rgba(224, 122, 95, 0.15);
+    color: var(--color-coral, #e07a5f);
   }
   .roadmap-marker {
     font-size: 0.85em;
@@ -593,7 +641,7 @@ function boolCellClass(value: boolean): string {
     font-size: 0.95rem;
   }
   .product-matrix-caption a {
-    color: var(--color-coral, #ff6b5b);
+    color: var(--color-coral, #e07a5f);
     text-decoration: none;
     font-weight: 600;
   }
@@ -638,7 +686,7 @@ function boolCellClass(value: boolean): string {
     font-weight: 600;
   }
   .product-matrix-table .cell-yes {
-    color: var(--color-coral, #ff6b5b);
+    color: var(--color-coral, #e07a5f);
     font-size: 1.1rem;
   }
   .product-matrix-table .cell-no {
@@ -673,7 +721,7 @@ function boolCellClass(value: boolean): string {
     color: var(--color-text-muted, #b8bcc8);
   }
   .product-matrix-decision a {
-    color: var(--color-coral, #ff6b5b);
+    color: var(--color-coral, #e07a5f);
     text-decoration: none;
     font-weight: 600;
   }
@@ -716,7 +764,7 @@ function boolCellClass(value: boolean): string {
     line-height: 1.55;
   }
   .product-card-cta {
-    color: var(--color-coral, #ff6b5b);
+    color: var(--color-coral, #e07a5f);
     text-decoration: none;
     font-weight: 600;
   }
@@ -732,7 +780,7 @@ function boolCellClass(value: boolean): string {
   }
   .product-deep-dive blockquote {
     margin: 0 0 1.5rem;
-    border-left: 3px solid var(--color-coral, #ff6b5b);
+    border-left: 3px solid var(--color-coral, #e07a5f);
     padding-left: 1.5rem;
     text-align: left;
     font-size: 1.05rem;
@@ -747,7 +795,7 @@ function boolCellClass(value: boolean): string {
   }
   .product-deep-dive-cta {
     display: inline-block;
-    color: var(--color-coral, #ff6b5b);
+    color: var(--color-coral, #e07a5f);
     text-decoration: none;
     font-weight: 600;
     font-size: 1.05rem;
@@ -764,7 +812,7 @@ function boolCellClass(value: boolean): string {
     color: var(--color-text-muted, #b8bcc8);
   }
   .product-faq-teaser a {
-    color: var(--color-coral, #ff6b5b);
+    color: var(--color-coral, #e07a5f);
     text-decoration: none;
     font-weight: 600;
   }

--- a/packages/website/src/pages/product.astro
+++ b/packages/website/src/pages/product.astro
@@ -1,12 +1,22 @@
 ---
 /**
- * Product / Surface Comparison Page
+ * Product Page — Lifecycle Governance Positioning
  *
- * SMI-4571: Public comparison of MCP server, CLI, and VS Code extension —
- * the three end-user surfaces that all share the same local skill database.
- * Wave 2 of SMI-4569 (parent epic).
+ * SMI-5966: rebuilt around the product's actual thesis — Skillsmith is the
+ * lifecycle-governance layer for agent skills (author, version, deprecate,
+ * govern), not a comparison of three unrelated client tools. CLI, MCP
+ * server, VS Code extension, and the website dashboard are four access
+ * surfaces onto one lifecycle; the private registry and governance
+ * features are what make that lifecycle real. Positioning source:
+ * docs/internal/product/02-positioning-messaging.md. Supersedes SMI-4571's
+ * surface-comparison-only framing; the comparison matrix below is retained
+ * and expanded, not removed.
  *
- * Marketing route. Uses BaseLayout to match /pricing, /index.
+ * Every capability below is verified shipped as of this page's authoring —
+ * see the governance retro in docs/internal/retros/ for the underlying
+ * code-level audit. Nothing here describes a stub or roadmap item as live.
+ *
+ * Marketing route. Uses BaseLayout to match /pricing, /docs, /index.
  */
 
 export const prerender = false
@@ -38,6 +48,14 @@ const surfaces = [
     cta: 'Get on the Marketplace',
     href: 'https://marketplace.visualstudio.com/items?itemName=skillsmith.skillsmith-vscode',
     external: true,
+  },
+  {
+    id: 'website',
+    title: 'Website dashboard',
+    pkg: 'account.skillsmith.app',
+    pickIf: 'Managing billing, seats, team members, or reviewing your cross-device skill inventory',
+    cta: 'Go to your account',
+    href: '/account',
   },
 ]
 
@@ -98,12 +116,6 @@ const matrix: CapabilityRow[] = [
     vscode: 'no',
   },
   {
-    capability: 'Publish to registry (author publish)',
-    mcp: 'no',
-    cli: 'yes',
-    vscode: 'no',
-  },
-  {
     capability: 'CI-safe exit codes + JSON output',
     mcp: 'no',
     cli: 'yes',
@@ -122,16 +134,116 @@ const matrix: CapabilityRow[] = [
     vscode: 'no',
   },
   {
-    capability: 'Team workspaces / audit export / SIEM / RBAC',
-    mcp: 'yes',
-    cli: 'no',
-    vscode: 'no',
-  },
-  {
     capability: 'Single API key works across all three',
     mcp: 'yes',
     cli: 'yes',
     vscode: 'yes',
+  },
+]
+
+interface LifecycleRow {
+  capability: string
+  description: string
+  mcp: boolean
+  cli: boolean
+  website: boolean
+  tier: string
+}
+
+const lifecycleMatrix: LifecycleRow[] = [
+  {
+    capability: 'Private registry publish',
+    description: 'Publish a versioned skill to your team-scoped, RLS-enforced hosted registry.',
+    mcp: true,
+    cli: false,
+    website: false,
+    tier: 'Enterprise',
+  },
+  {
+    capability: 'Deprecate / restore a version',
+    description:
+      'Mark a registry version stale, or undo it — the version stays, it just stops being installed by default.',
+    mcp: true,
+    cli: false,
+    website: false,
+    tier: 'Enterprise',
+  },
+  {
+    capability: 'Namespace-collision audit + guided rename',
+    description:
+      'Find naming collisions across your local skills/commands/agents and apply suggested fixes, with undo.',
+    mcp: true,
+    cli: true,
+    website: false,
+    tier: 'Every tier',
+  },
+  {
+    capability: 'CycloneDX AI-BOM export',
+    description:
+      'Export a CycloneDX 1.5 AI/ML bill-of-materials of your installed skills, with dependency graph, for compliance evidence.',
+    mcp: true,
+    cli: false,
+    website: false,
+    tier: 'Team+',
+  },
+  {
+    capability: 'Compliance reports',
+    description:
+      'Generate SOC 2-oriented, JSON, or CycloneDX reports from your local skill inventory and audit trail.',
+    mcp: true,
+    cli: false,
+    website: false,
+    tier: 'Team+',
+  },
+  {
+    capability: 'Security scoring + quarantine',
+    description:
+      'Every indexed skill is scanned and scored; flagged skills are quarantined out of search automatically.',
+    mcp: true,
+    cli: true,
+    website: false,
+    tier: 'Every tier',
+  },
+  {
+    capability: 'Audit log query + export',
+    description: 'Query and export the persistent trail of security and registry-lifecycle events.',
+    mcp: true,
+    cli: false,
+    website: false,
+    tier: 'Enterprise',
+  },
+  {
+    capability: 'SIEM export',
+    description: 'Export audit events as JSON for ingestion into your SIEM pipeline.',
+    mcp: true,
+    cli: false,
+    website: false,
+    tier: 'Enterprise',
+  },
+  {
+    capability: 'Team workspaces',
+    description: 'Shared, RLS-secured spaces for your team to organize and share skills.',
+    mcp: true,
+    cli: false,
+    website: true,
+    tier: 'Team+',
+  },
+  {
+    capability: 'Team member roles + invites',
+    description: 'Invite teammates and manage owner/admin/member roles.',
+    mcp: false,
+    cli: false,
+    website: true,
+    tier: 'Team+',
+  },
+  {
+    capability: 'Cross-device skill inventory',
+    description:
+      'Opt-in, read-only view of which skills are installed across your machines and harnesses.',
+    mcp: false,
+    cli: false,
+    website: true,
+    tier: 'Every tier',
   },
 ]
 
@@ -147,24 +259,26 @@ function cellClass(value: string): string {
   if (value === 'partial') return 'cell-partial'
   return 'cell-conditional'
 }
+
+function boolCellClass(value: boolean): string {
+  return value ? 'cell-yes' : 'cell-no'
+}
 ---
 
 <BaseLayout
   title="Product | Skillsmith"
-  description="MCP for any agent. CLI for the terminal. VS Code for the editor. One Skillsmith registry under all three — pick the surface that fits your workflow."
+  description="Skillsmith is the lifecycle-governance layer for agent skills — author, version, deprecate, and govern skills your team owns, from the CLI, MCP, VS Code, or your dashboard."
   activePath="/product"
 >
   <section class="product-hero">
-    <!-- SMI-4839: SDK-for-teams reframe — surfaces are lifecycle access points, not discovery only. -->
-    <p class="product-eyebrow">Three surfaces for your team's skill lifecycle</p>
-    <h1>MCP for any agent. CLI for the terminal. VS Code for the editor.</h1>
+    <p class="product-eyebrow">The lifecycle layer for agent skills</p>
+    <h1>Author, version, deprecate, and govern the skills your team owns</h1>
     <p class="product-subtitle">
-      One local skill database. One API key. Three surfaces over the same registry — publish,
-      version, and deprecate skills from wherever your team already works. (Throughout this page, <em
-        >MCP</em
-      >
-      means the Model Context Protocol — the standard agents like Claude Code, Cursor, Copilot, Codex,
-      and Windsurf use to talk to external tools.)
+      Skills spread across teams faster than anyone can govern them — forked, copy-pasted, and
+      scattered across gists and shared drives with no source of truth, no audit trail, and no way
+      to retire what's gone stale. Skillsmith gives them a lifecycle instead: a private, versioned
+      registry your team actually owns, reachable from wherever your team already works — the CLI,
+      the MCP server, VS Code, or your account dashboard.
     </p>
     <div class="product-hero-ctas">
       {
@@ -177,12 +291,46 @@ function cellClass(value: string): string {
     </div>
   </section>
 
+  <section class="product-lifecycle">
+    <h2>What makes the lifecycle real</h2>
+    <p class="product-lifecycle-caption">
+      A registry is only as good as what backs it. Here's what's actually shipped today — nothing
+      below is a roadmap item.
+    </p>
+    <div class="product-lifecycle-grid">
+      <article class="product-lifecycle-card">
+        <h3>Private registry <span class="tier-badge">Enterprise</span></h3>
+        <p>
+          A real, hosted, team-scoped registry — versioned, RLS-enforced at the database level,
+          shared across every teammate. This is where skills your org owns actually live, not a
+          folder someone forked.
+        </p>
+      </article>
+      <article class="product-lifecycle-card">
+        <h3>Private skills <span class="tier-badge">Team</span></h3>
+        <p>
+          Mark a skill private on your own machine today, hidden from public search. Cross-teammate
+          sync into a shared team namespace is on the roadmap
+          <span class="roadmap-marker" title="Not yet shipped">🕐</span> — for a fully shared team registry
+          today, see Enterprise above.
+        </p>
+      </article>
+      <article class="product-lifecycle-card">
+        <h3>Governance, end to end</h3>
+        <p>
+          Deprecate a version without deleting it. Query and export an audit trail. Generate
+          compliance reports. Every indexed skill is security-scanned and quarantined automatically
+          if flagged. Full breakdown below.
+        </p>
+      </article>
+    </div>
+  </section>
+
   <section class="product-matrix">
-    <h2>Capability comparison</h2>
+    <h2>One lifecycle, four surfaces</h2>
     <p class="product-matrix-caption">
       Capabilities marked <em>via MCP</em> for VS Code mean the extension actively spawns the MCP server
-      to deliver them — not every tool the MCP server happens to expose. Team workspaces, audit export,
-      SIEM, and RBAC are MCP-only and have no VS Code UI affordance today.
+      to deliver them — not every tool the MCP server happens to expose.
     </p>
     <div class="product-matrix-scroll">
       <table class="product-matrix-table">
@@ -234,6 +382,52 @@ function cellClass(value: string): string {
     </p>
   </section>
 
+  <section class="product-matrix product-matrix-lifecycle">
+    <h2>Lifecycle &amp; governance capabilities</h2>
+    <p class="product-matrix-caption">
+      Registry, audit, and compliance capabilities, and which surface delivers each one today. Tier
+      column matches <a href="/pricing">pricing</a> exactly.
+    </p>
+    <div class="product-matrix-scroll">
+      <table class="product-matrix-table">
+        <thead>
+          <tr>
+            <th scope="col" class="capability-col">Capability</th>
+            <th scope="col">MCP</th>
+            <th scope="col">CLI</th>
+            <th scope="col">Website</th>
+            <th scope="col">Tier</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            lifecycleMatrix.map((row) => (
+              <tr>
+                <th scope="row" class="capability-col">
+                  {row.capability}
+                  <span class="lifecycle-row-desc">{row.description}</span>
+                </th>
+                <td class={boolCellClass(row.mcp)}>
+                  <span class="visually-hidden">{row.mcp ? 'yes' : 'Not supported'}</span>
+                  <span aria-hidden="true">{row.mcp ? '✓' : ''}</span>
+                </td>
+                <td class={boolCellClass(row.cli)}>
+                  <span class="visually-hidden">{row.cli ? 'yes' : 'Not supported'}</span>
+                  <span aria-hidden="true">{row.cli ? '✓' : ''}</span>
+                </td>
+                <td class={boolCellClass(row.website)}>
+                  <span class="visually-hidden">{row.website ? 'yes' : 'Not supported'}</span>
+                  <span aria-hidden="true">{row.website ? '✓' : ''}</span>
+                </td>
+                <td class="cell-tier">{row.tier}</td>
+              </tr>
+            ))
+          }
+        </tbody>
+      </table>
+    </div>
+  </section>
+
   <section class="product-cards">
     {
       surfaces.map((s) => (
@@ -260,11 +454,12 @@ function cellClass(value: string): string {
   <section class="product-deep-dive">
     <blockquote>
       <p>
-        All three surfaces read the same local SQLite database at
+        All three client surfaces read the same local SQLite database at
         <code>~/.skillsmith/skills.db</code>. Search runs against an FTS5 full-text index (SQLite's
         built-in keyword search) by default; semantic search is opt-in and uses local ONNX
         embeddings (an open ML model format that runs on CPU, no API call) — your queries never
-        leave your machine.
+        leave your machine. The private registry is a separate, hosted layer above that: a
+        Supabase-backed store with row-level security, not a copy of the local database.
       </p>
     </blockquote>
     <a href="/blog/inside-the-local-skill-database" class="product-deep-dive-cta">
@@ -327,6 +522,61 @@ function cellClass(value: string): string {
     transform: translateY(-2px);
   }
 
+  .product-lifecycle {
+    max-width: 64rem;
+    margin: 3rem auto;
+    padding: 0 1.5rem;
+  }
+  .product-lifecycle h2 {
+    text-align: center;
+    margin-bottom: 0.5rem;
+  }
+  .product-lifecycle-caption {
+    text-align: center;
+    color: var(--color-text-muted, #b8bcc8);
+    margin-bottom: 1.5rem;
+    font-size: 0.95rem;
+  }
+  .product-lifecycle-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: 1.5rem;
+  }
+  .product-lifecycle-card {
+    background: var(--color-surface-elevated, #1a1c22);
+    border: 1px solid var(--color-border, #2a2c33);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+  }
+  .product-lifecycle-card h3 {
+    margin: 0 0 0.75rem;
+    font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .product-lifecycle-card p {
+    margin: 0;
+    line-height: 1.6;
+    color: var(--color-text-muted, #b8bcc8);
+    font-size: 0.95rem;
+  }
+  .tier-badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    background: rgba(255, 107, 91, 0.15);
+    color: var(--color-coral, #ff6b5b);
+  }
+  .roadmap-marker {
+    font-size: 0.85em;
+  }
+
   .product-matrix {
     max-width: 64rem;
     margin: 3rem auto;
@@ -341,6 +591,14 @@ function cellClass(value: string): string {
     color: var(--color-text-muted, #b8bcc8);
     margin-bottom: 1.5rem;
     font-size: 0.95rem;
+  }
+  .product-matrix-caption a {
+    color: var(--color-coral, #ff6b5b);
+    text-decoration: none;
+    font-weight: 600;
+  }
+  .product-matrix-caption a:hover {
+    text-decoration: underline;
   }
   .product-matrix-scroll {
     overflow-x: auto;
@@ -392,6 +650,21 @@ function cellClass(value: string): string {
     font-size: 0.85rem;
     font-weight: 500;
     font-style: italic;
+  }
+  .product-matrix-table .cell-tier {
+    text-align: center;
+    font-weight: 500;
+    font-size: 0.8rem;
+    color: var(--color-text-muted, #b8bcc8);
+    text-transform: none;
+  }
+  .lifecycle-row-desc {
+    display: block;
+    font-weight: 400;
+    font-size: 0.82rem;
+    color: var(--color-text-muted, #b8bcc8);
+    margin-top: 0.25rem;
+    line-height: 1.4;
   }
   .product-matrix-decision {
     text-align: center;

--- a/packages/website/src/pages/product.astro
+++ b/packages/website/src/pages/product.astro
@@ -304,8 +304,7 @@ const lifecycleIcons = {
     <h2>What makes the lifecycle real</h2>
     <p class="product-lifecycle-caption">
       You've felt this: someone forks a skill, tweaks it, and a month later nobody's sure which copy
-      is the real one. A registry is only as good as what backs it — here's what's actually shipped
-      today, not roadmap.
+      is the real one. A registry is only as good as what backs it.
     </p>
     <div class="product-lifecycle-grid">
       <article class="product-lifecycle-card">


### PR DESCRIPTION
## Status: DRAFT — for staging review, not merge

Opened as a draft specifically to generate a Vercel preview deployment for founder review and critique. **Do not merge** until that review is complete and any requested changes are incorporated.

## Business Summary

**What shipped (proposed):** `/product` is rebuilt around the actual product thesis — Skillsmith is the lifecycle-governance layer for agent skills (author, version, deprecate, govern), not three unrelated client tools. The page previously (SMI-4571) was purely a CLI-vs-MCP-vs-VS-Code capability-comparison matrix; it never mentioned the private registry, governance features, or the website dashboard, and had drifted out of step with the already-reframed `/docs` and `/pricing` pages.

New structure: a lifecycle-governance hero (echoing `/docs`'s established lead-line style), a "what makes the lifecycle real" section explaining the private registry, a governance capability matrix (private registry publish, deprecate/restore, CycloneDX AI-BOM export, compliance reports, security scoring/quarantine, audit log export, SIEM export, team workspaces, and more), and CLI/MCP/VS Code/website framed explicitly as four access surfaces onto one lifecycle rather than four separate products. The original client-capability matrix is retained unchanged, just repositioned lower on the page.

**Quality bar:** Every capability claim on this page was independently verified against current code immediately before writing the copy — not assumed from any prior doc. A dedicated research pass confirmed exact shipped/stub/roadmap status for every candidate capability (private registry, private skills, approval gate, RBAC, SSO, webhooks, version pinning, etc.), and one important distinction came out of that: "private registry" (Enterprise, real hosted cross-teammate storage) and "private skills" (Team, a local-only visibility flag with no cross-teammate sync yet) are NOT the same capability today, and the page is explicit about that rather than conflating them. Nothing described as shipped is actually a stub or roadmap item.

**Found along the way:** RBAC, SSO/SAML, webhook/API-key management, and enforced version pinning all have MCP tool surfaces that could be mistaken for shipped features, but are confirmed stub-only in current code — none of them appear on this page. The Individual private namespace (SMI-5962) and the registry approval gate (SMI-5949, still an open PR as of this writing) are both confirmed not yet merged and are also excluded.

**Net result:** Ready for staging review. Visual identity unchanged (per docs/internal/product/00's D20 — copy/structure only, no redesign); build, typecheck, and prettier all pass locally.

## Technical detail

Single file changed: `packages/website/src/pages/product.astro`. See the commit message for the full section-by-section breakdown. Linear: SMI-5966.