### PR TITLE
fix(website): SMI-5966 a11y fix for roadmap-marker on /product

### DIFF
--- a/packages/website/src/pages/product.astro
+++ b/packages/website/src/pages/product.astro
@@ -338,8 +338,11 @@ const lifecycleIcons = {
         <h3>Private skills <span class="tier-badge">Team</span></h3>
         <p>
           Mark a skill private on your machine today, hidden from public search. Team-wide sync is
-          on the roadmap <span class="roadmap-marker" title="Not yet shipped">🕐</span> — for a fully
-          shared registry now, see Enterprise.
+          on the roadmap <span class="roadmap-marker" aria-hidden="true">🕐</span><span
+            class="visually-hidden"
+          >
+            (not yet shipped)</span
+          > — for a fully shared registry now, see Enterprise.
         </p>
       </article>
       <article class="product-lifecycle-card">


### PR DESCRIPTION
## Business Summary

**What shipped:** The "not yet shipped" clock icon on the Team-tier private-skills card on /product is now announced correctly to screen readers, and its meaning no longer disappears on touch devices.

**Quality bar:** Found by a governance retrospective on the already-merged PR #2261. Fix matches the page's own established accessibility pattern (already used in both capability matrices on the same page), rather than introducing a new one. Prettier/lint/typecheck/build all clean.

**Net result:** Fully shipped, no follow-up. This page is already live in production, so this ships as its own small PR rather than amending #2261.

---

## Technical detail

`packages/website/src/pages/product.astro` — the roadmap-marker span for "Team-wide sync" relied solely on a `title` attribute for its accessible meaning, which is not reliably announced by screen readers on a non-interactive `<span>` and is unreachable on touch devices. Replaced with `aria-hidden="true"` on the emoji plus a new `.visually-hidden` span carrying " (not yet shipped)" — the exact pairing already used elsewhere on this same page for its capability-matrix cells.