### PR TITLE
chore(deps): dedupe vulnerable nested postcss@8.5.20 under website workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35917,34 +35917,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "packages/website/node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.16",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "packages/website/node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,11 @@
     "ip-address": "^10.3.1",
     "tar": "^7.5.22",
     "postcss": "^8.5.23",
+    "astro": {
+      "vite": {
+        "postcss": "^8.5.23"
+      }
+    },
     "sharp": "0.35.3",
     "js-yaml": "^4.3.1",
     "gray-matter": {


### PR DESCRIPTION
## Business Summary

**What shipped:** Closes Dependabot alert #199 (moderate) — a duplicated, unpatched copy of `postcss` inside the website package's dependency tree could disclose local file contents via a crafted CSS source-map comment during a build.

**Quality bar:** Website build verified clean with the fix in place. Full local test suite could not run for this push — see "Found along the way" — but the change itself is a two-line dependency dedup with no source-code footprint; GitHub CI (clean runner) is the authoritative gate before merge.

**Found along the way:** A pre-existing, unrelated Docker/virtiofs mount quirk isolated to this one worktree's container — `packages/cli` tests fail to resolve `chalk` from a bind-mounted `node_modules` path. Reproduces identically after a full container and image rebuild from scratch, but passes cleanly in the main checkout's own container on the exact same test. Root cause lives in the worktree-docker override generator (`scripts/` — infra, gated by ADR-109's SPARC+plan-review requirement), out of proportion to fix as part of this change. Pre-push was bypassed for this one push with explicit approval; not filed as a separate issue since it's environmental to a single now-recycled worktree container, not a reproducible defect in tracked infra state.

**Net result:** Fully shipped pending CI. No application code touched.

---

## Technical detail

`astro@7.1.3`'s own internal `vite@8.1.5` dependency resolved a separate, redundant copy of `postcss@8.5.20` at `packages/website/node_modules/postcss` — below the root `package.json` override's `^8.5.23` floor, and vulnerable to GHSA-fxqj-rqcc-2cmp / CVE-2026-69153 (incomplete fix of an earlier `sourceMappingURL` path-traversal advisory; discloses `.map` file contents when PostCSS is invoked without a `from` option).

Removed the stale, redundant lockfile entry so resolution dedupes to the already-overridden, already-patched `postcss@8.5.26` used everywhere else in the tree (top-level override alone didn't reach this specific nested chain — a flat `npm install --package-lock-only` re-resolve doesn't recompute an already-present duplicate entry; had to delete the entry directly to force fresh resolution). Also added a nested `overrides.astro.vite.postcss` rule for defense-in-depth against a future re-split of this same chain.

Files: `package.json`, `package-lock.json` only.