### PR TITLE
fix(indexer): SMI-5926 ops-wire STALE_QUARANTINE_DISABLE incident brake

### DIFF
--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -391,6 +391,12 @@ jobs:
           CRON_SLOT: ${{ steps.config.outputs.cron_slot }}
           # SMI-4870: empty = full sequential discovery; 1/2/3 = single phase.
           DISCOVERY_PHASE: ${{ steps.config.outputs.discovery_phase }}
+          # SMI-5926: wires reconcileStaleSkills()'s incident brake (staleQuarantineDisabled(),
+          # scripts/indexer/stale-reconciliation.ts:78-94) into the job env. Defaults OFF
+          # (empty string) — unlike the *_DRY_RUN gates above, this disables a wanted sweep,
+          # so an unset repo variable must resolve to "sweep runs normally," not "brake engaged."
+          # Registered in docs/internal/process/guards-and-opt-outs.md.
+          STALE_QUARANTINE_DISABLE: ${{ vars.STALE_QUARANTINE_DISABLE || '' }}
           CONCURRENCY: ${{ github.event.inputs.concurrency || '2' }}
           # CONCURRENCY_KILL_SWITCH inherited from the job-level env (kill-switch sources).
           # SMI-5166 recheck vars - sourced from optional repo variables with safe defaults.


### PR DESCRIPTION
## Business Summary

**What shipped:** The stale-quarantine incident brake — an emergency off-switch for the indexer's automated dead-skill quarantine sweep — can now actually be flipped in production. It's been fully built and tested since a prior fix (SMI-5551), but nobody could turn it on without a code redeploy; it just sat there unusable.

**Quality bar:** Went through two rounds of adversarial review by a second AI model (GPT-5.6-Sol, independent of Claude) before any code was written, catching three real gaps in the first draft (wrong scope claim about which cron runs it affects, missing rollback commands, GitHub commands that silently depended on the operator's current directory) — all fixed and re-verified APPROVE AS-IS. Full test suite green (1014/1014), clean lint/typecheck/security audit, zero new findings in a follow-up code review.

**Net result:** Fully shipped. The brake ships OFF by default — nothing is proactively enabled by this change. An operator can flip it at incident time with a documented one-line command on either side (GitHub Actions or Supabase).

---

## Technical detail

- `.github/workflows/indexer.yml` — adds `STALE_QUARANTINE_DISABLE: ${{ vars.STALE_QUARANTINE_DISABLE || '' }}` to the "Run indexer" step's env block, following the existing `INDEXER_RUN_ALLOWLIST`/`status-external-prober.yml` default-off `vars.*` convention. Unset repo variable → empty string → brake off, verified against the actual parsing logic (`scripts/indexer/stale-reconciliation.ts`, both Node and its Deno edge twin) which treats undefined/empty/`'0'`/`'false'` identically as disabled.
- `docs/internal` gitlink bump — the paired `skillsmith-docs` PRs (#684, #685) land the SPARC implementation plan, the updated Guards & Opt-Outs registry entry, and a governance code-review report (zero findings).
- ADR-109 infra-change gate (SPARC + plan-review before any `.github/workflows/` change) satisfied — plan doc: `docs/internal/implementation/smi-5926-stale-quarantine-disable-wiring.md`.
- Does **not** touch `.github/workflows/indexer-backfill.yml` — that file is being modified concurrently by a sibling fix (SMI-5964) in a separate worktree; zero file overlap by design.

Refs SMI-5926