### PR TITLE
fix(indexer): SMI-5964 bound backfill checkpoint overshoot, close alert gap

### DIFF
--- a/.github/workflows/indexer-backfill-watch.yml
+++ b/.github/workflows/indexer-backfill-watch.yml
@@ -1,0 +1,117 @@
+# SMI-5964: Skill Indexer Backfill alert-gap watcher.
+#
+# PROBLEM: `indexer-backfill.yml`'s `Run backfill indexer` step has
+# `timeout-minutes: 330` at the JOB level. A job killed by that job-level
+# timeout concludes `cancelled`, not `failure` -- and both of the workflow's
+# existing alert steps (`Report Failure`, `Send Alert on Failure`) are gated
+# `if: failure()`. `cancelled()` and `failure()` are disjoint in GitHub
+# Actions, so a timeout-kill (the single most likely way this workflow dies)
+# produces NO step summary, NO alert-notify call, and NO email -- verified
+# against run `31287555575` (SMI-5964), which lost ~13,488 admitted-but-
+# unwritten skills silently.
+#
+# WHY OUT-OF-JOB, NOT AN IN-JOB `cancelled()` STEP: an in-job step still runs
+# inside the cancellation grace window of the job that just died, still needs
+# `$GITHUB_ENV` values and `Validate Secrets`' outputs to have survived
+# cancellation, and cannot alert at all if cancellation lands before
+# `Validate Secrets` completes. A `workflow_run`-triggered watcher is a
+# SEPARATE run with its OWN fresh `timeout-minutes` and reads secrets/context
+# directly -- its headroom is not a subset of the dying job's exhausted
+# budget. See docs/internal/implementation/smi-5964-backfill-checkpoint-timing.md
+# §3 for the full design + the alternatives this rejects.
+#
+# PRECEDENT: `workflow_run: {workflows: […], types: [completed],
+# branches: [main]}` is already used by smoke-prod.yml, billing-monitor.yml,
+# mirror-mcp-server.yml, e2e-usage-counter.yml -- not a novel mechanism here.
+#
+# SCOPE: `cancelled` only. The existing in-job `if: failure()` steps in
+# indexer-backfill.yml are untouched and keep handling genuine failures with
+# their richer context (http_code, response body). `cancelled` and `failure`
+# are disjoint conclusions, so there is no duplicate-alert path.
+#
+# NO THIRD-PARTY ACTIONS: this workflow needs neither `checkout` nor
+# `setup-node` -- audit-workflow-sha-pin (Check 42 / SMI-4758) has nothing to
+# pin here.
+#
+# ADR-109: this is an infra workflow -- SPARC + plan-review gated before
+# implementation. See the plan doc above for the reviewed design.
+# audit:carveout-pure-js -- no code execution, gh/curl/jq only (ubuntu-latest built-ins)
+
+name: Skill Indexer Backfill Watch
+
+on:
+  workflow_run:
+    workflows: ['Skill Indexer Backfill'] # must match indexer-backfill.yml:39's `name:` exactly
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read # for the /jobs API call that labels the alert (§3c)
+  contents: read
+
+jobs:
+  alert-on-cancelled:
+    name: Alert on cancelled backfill run
+    if: github.event.workflow_run.conclusion == 'cancelled'
+    runs-on: ubuntu-latest
+    # Independent of the dying job's own (330-min) budget -- a fresh run.
+    timeout-minutes: 5
+    steps:
+      - name: Classify and alert
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_STARTED_AT: ${{ github.event.workflow_run.run_started_at }}
+          GH_REPOSITORY: ${{ github.repository }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_PROD }}
+        run: |
+          set -eo pipefail
+
+          # ── Classification is a LABEL, never a gate (review finding 5) ──
+          # The alert fires on conclusion=='cancelled', full stop (the `if:`
+          # above). Everything below only shapes the message.
+          NOW=$(date +%s)
+          STARTED=$(date -u -d "$RUN_STARTED_AT" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$RUN_STARTED_AT" +%s)
+          ELAPSED_MIN=$(( (NOW - STARTED) / 60 ))
+
+          # Fail-open: if the API call or the field is unavailable, KIND
+          # degrades to cancelled-unknown but the alert STILL fires -- the
+          # uncertainty is removed from the critical path, not "verified".
+          STEP_CONCLUSION=$(gh api "/repos/$GH_REPOSITORY/actions/runs/$RUN_ID/jobs" \
+            --jq '.jobs[].steps[]? | select(.name == "Run backfill indexer") | .conclusion' 2>/dev/null || true)
+
+          if [ -z "$STEP_CONCLUSION" ]; then
+            KIND="cancelled-unknown"
+          elif [ "$STEP_CONCLUSION" != "cancelled" ] && [ "$STEP_CONCLUSION" != "in_progress" ]; then
+            KIND="cancelled-before-backfill" # nothing was in flight
+          elif [ "$ELAPSED_MIN" -ge 325 ]; then
+            KIND="likely-gha-timeout-kill"
+          else
+            KIND="cancelled-check-if-manual"
+          fi
+
+          BODY=$(jq -n \
+            --arg msg "Skill Indexer Backfill run $RUN_ID ended in 'cancelled' after ${ELAPSED_MIN}m (kind: $KIND). Any admitted-but-unwritten skills in the in-flight batch were discarded (Phase-4 upsert and checkpoint are both end-of-dispatch). Re-dispatch with resume_from=latest." \
+            --arg rid "$RUN_ID" --arg url "$RUN_URL" --arg kind "$KIND" \
+            '{type:"indexer_backfill_cancelled", message:$msg, workflow:"Skill Indexer Backfill", runId:$rid, runUrl:$url, kind:$kind}')
+
+          # ── No silent alert failures (§3d) ──
+          HTTP=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Content-Type: application/json" -d "$BODY" \
+            "$SUPABASE_URL/functions/v1/alert-notify" || echo "000")
+
+          {
+            echo "### Backfill run cancelled"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Run | [$RUN_ID]($RUN_URL) |"
+            echo "| Elapsed | ${ELAPSED_MIN} min |"
+            echo "| Kind | $KIND |"
+            echo "| alert-notify HTTP | $HTTP |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          [ "$HTTP" = "200" ] || echo "::warning::alert-notify returned $HTTP -- email may not have been sent"

--- a/.github/workflows/indexer-backfill-watch.yml
+++ b/.github/workflows/indexer-backfill-watch.yml
@@ -98,10 +98,24 @@ jobs:
             '{type:"indexer_backfill_cancelled", message:$msg, workflow:"Skill Indexer Backfill", runId:$rid, runUrl:$url, kind:$kind}')
 
           # ── No silent alert failures (§3d) ──
-          HTTP=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+          # SMI-5964 code-review finding: the original `|| echo "000"` fallback
+          # only guarded curl's own exit code, but the step still exited 0
+          # regardless of the alert's actual delivery outcome -- so a failed
+          # alert-notify call could leave THIS watcher job green, defeating
+          # the entire point of building a reliable out-of-job alert path.
+          # HTTP now defaults to "000" and is only overwritten on a completed
+          # curl invocation (avoids the "000\n000" double-value some curl
+          # failure modes produced when -w and the `||` fallback both fired),
+          # and the step now fails (non-zero exit) on anything but 200 so a
+          # delivery failure is visibly recorded as a job failure, not just a
+          # step-summary annotation nobody is watching.
+          HTTP="000"
+          if RESPONSE_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
             -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
             -H "Content-Type: application/json" -d "$BODY" \
-            "$SUPABASE_URL/functions/v1/alert-notify" || echo "000")
+            "$SUPABASE_URL/functions/v1/alert-notify"); then
+            HTTP="$RESPONSE_CODE"
+          fi
 
           {
             echo "### Backfill run cancelled"
@@ -114,4 +128,7 @@ jobs:
             echo "| alert-notify HTTP | $HTTP |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          [ "$HTTP" = "200" ] || echo "::warning::alert-notify returned $HTTP -- email may not have been sent"
+          if [ "$HTTP" != "200" ]; then
+            echo "::error::alert-notify returned $HTTP -- email was NOT sent. Failing this job so the delivery failure is visible in the Actions UI, not just a step-summary annotation."
+            exit 1
+          fi

--- a/.github/workflows/indexer-backfill.yml
+++ b/.github/workflows/indexer-backfill.yml
@@ -377,13 +377,21 @@ jobs:
             '{type:"indexer_backfill_failed", message:$msg, workflow:"Skill Indexer Backfill", runId:$rid, runUrl:$url}')
           # SMI-5964: capture the alert-notify HTTP code instead of discarding
           # it (the prior `|| true` made a failed alert POST silently
-          # invisible) -- surface it in the step summary and annotate on
-          # anything but 200.
-          HTTP=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+          # invisible) -- surface it in the step summary and fail the step
+          # (not just annotate) on anything but 200, so a delivery failure
+          # is visibly recorded rather than leaving this step green (same
+          # code-review finding applied to the indexer-backfill-watch.yml
+          # sibling step -- HTTP defaults to "000" and is only overwritten on
+          # a completed curl call, avoiding a doubled "000\n000" value on some
+          # curl failure modes).
+          HTTP="000"
+          if RESPONSE_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
             -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
             -H "Content-Type: application/json" \
             -d "$BODY" \
-            "$SUPABASE_URL/functions/v1/alert-notify" || echo "000")
+            "$SUPABASE_URL/functions/v1/alert-notify"); then
+            HTTP="$RESPONSE_CODE"
+          fi
           {
             echo "### Backfill Failure Alert"
             echo ""
@@ -391,4 +399,7 @@ jobs:
             echo "|-------|-------|"
             echo "| alert-notify HTTP | $HTTP |"
           } >> "$GITHUB_STEP_SUMMARY"
-          [ "$HTTP" = "200" ] || echo "::warning::alert-notify returned $HTTP -- email may not have been sent"
+          if [ "$HTTP" != "200" ]; then
+            echo "::error::alert-notify returned $HTTP -- email was NOT sent."
+            exit 1
+          fi

--- a/.github/workflows/indexer-backfill.yml
+++ b/.github/workflows/indexer-backfill.yml
@@ -82,7 +82,7 @@ on:
         default: '0'
         type: string
       max_elapsed_minutes:
-        description: 'SMI-5448: per-dispatch wall-clock budget in MINUTES (default 280, safely below the 330-min GHA timeout). The crawl checkpoints and exits at a clean boundary before the GHA kill, turning a timeout rollback into forward progress. 0 = disabled. A single in-flight page can run ~10-15 min past the trip point before the page loop breaks.'
+        description: 'SMI-5448: per-dispatch wall-clock budget in MINUTES (default 280, safely below the 330-min GHA timeout). The crawl checkpoints and exits at a clean boundary before the GHA kill, turning a timeout rollback into forward progress. 0 = disabled. SMI-5964: a dense leaf can run ~54 min/page under the pre-fix per-page-only observation granularity; the intra-page budget check (default SKILLSMITH_INDEXER_FETCH_TIMEOUT_MS=30s per request) now bounds the overshoot to ~4-6 min instead.'
         required: false
         default: '280'
         type: string
@@ -371,12 +371,24 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ env.SELECTED_SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           BODY=$(jq -n \
-            --arg msg "The skill indexer backfill workflow failed. HTTP Code: $HTTP_CODE" \
+            --arg msg "The skill indexer backfill workflow failed. HTTP Code: ${HTTP_CODE:-n/a}" \
             --arg rid "$RUN_ID" \
             --arg url "$RUN_URL" \
             '{type:"indexer_backfill_failed", message:$msg, workflow:"Skill Indexer Backfill", runId:$rid, runUrl:$url}')
-          curl -s -X POST \
+          # SMI-5964: capture the alert-notify HTTP code instead of discarding
+          # it (the prior `|| true` made a failed alert POST silently
+          # invisible) -- surface it in the step summary and annotate on
+          # anything but 200.
+          HTTP=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
             -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
             -H "Content-Type: application/json" \
             -d "$BODY" \
-            "$SUPABASE_URL/functions/v1/alert-notify" || true
+            "$SUPABASE_URL/functions/v1/alert-notify" || echo "000")
+          {
+            echo "### Backfill Failure Alert"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| alert-notify HTTP | $HTTP |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          [ "$HTTP" = "200" ] || echo "::warning::alert-notify returned $HTTP -- email may not have been sent"

--- a/scripts/indexer/_shared/rate-limit.ts
+++ b/scripts/indexer/_shared/rate-limit.ts
@@ -250,6 +250,28 @@ export function summarizeRateLimitTelemetry(t: RateLimitTelemetry): {
 }
 
 /**
+ * SMI-5964: default per-request wall-clock cap (ms) applied at the
+ * `withRateLimitTracking` chokepoint. Bounds BOTH the header phase and the
+ * body-read phase — aborting a fetch's signal errors the response body
+ * stream, so a pending `reader.read()` (e.g. `readResponseWithLimit`,
+ * `skill-processor.security.ts:80`) rejects rather than hanging.
+ * `0` disables the cap entirely (byte-identical to pre-SMI-5964 behavior).
+ * Override via `SKILLSMITH_INDEXER_FETCH_TIMEOUT_MS` (registered in
+ * docs/internal/process/guards-and-opt-outs.md).
+ */
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000
+
+/** SMI-5964: resolve the effective per-request timeout from env, falling back
+ * to {@link DEFAULT_FETCH_TIMEOUT_MS} on an absent/blank/non-numeric/negative
+ * override. */
+function resolveFetchTimeoutMs(): number {
+  const raw = process.env.SKILLSMITH_INDEXER_FETCH_TIMEOUT_MS
+  if (raw == null || raw === '') return DEFAULT_FETCH_TIMEOUT_MS
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_FETCH_TIMEOUT_MS
+}
+
+/**
  * SMI-4852: Wrap a GitHub `fetch` call so its rate-limit headers and
  * 403/429 incidents are recorded into a shared telemetry object.
  *
@@ -262,6 +284,13 @@ export function summarizeRateLimitTelemetry(t: RateLimitTelemetry): {
  * have received. On 403/429, ALSO throws a `RateLimitError` so `withBackoff`
  * can drive retry. Callers that don't want retry semantics can catch and
  * ignore the throw (the side-effect on telemetry is already recorded).
+ *
+ * SMI-5964: injects a default `AbortSignal.timeout(...)` when the caller did
+ * NOT already supply its own `init.signal` (e.g. `org-verification.ts:94`'s
+ * existing 1s SMI-4743 precedent is never overridden). No fetch on the
+ * indexer path had any timeout before this — a single stalled connection
+ * could block the crawl indefinitely, defeating every position-based budget
+ * check downstream (§1a of the SMI-5964 plan).
  */
 export async function withRateLimitTracking(
   telemetry: RateLimitTelemetry,
@@ -269,7 +298,12 @@ export async function withRateLimitTracking(
   init?: RequestInit & { _throwOnRateLimit?: boolean }
 ): Promise<Response> {
   const throwOnRateLimit = init?._throwOnRateLimit !== false
-  const response = await fetch(url, init)
+  const timeoutMs = resolveFetchTimeoutMs()
+  const effectiveInit: RequestInit | undefined =
+    timeoutMs > 0 && init?.signal == null
+      ? { ...init, signal: AbortSignal.timeout(timeoutMs) }
+      : init
+  const response = await fetch(url, effectiveInit)
 
   // SMI-4918: `raw.githubusercontent.com` is CDN-served and carries no
   // GitHub rate-limit headers — exclude it so its responses can't pollute

--- a/scripts/indexer/backfill-checkpoint.ts
+++ b/scripts/indexer/backfill-checkpoint.ts
@@ -63,6 +63,19 @@ export interface BackfillCursor {
    * represent a partial bisection tree, C-2).
    */
   pending_subranges?: PersistedSubrange[]
+  /**
+   * SMI-5964 §1e: consecutive dispatches that stopped at THIS exact crawl
+   * position (`path` + `facet` + `last_page`) without moving the cursor. Reset
+   * to 0 by any dispatch that makes net progress. Purely advisory: absent/lost
+   * reads as 0 (one extra dispatch before escalation), spuriously high
+   * escalates one dispatch early on a unit that is already recorded truncated.
+   * Nothing skips, advances, or persists based on this value alone — it only
+   * chooses between "hold" and "escalate" in `runBackfillFacetCrawl`. Never
+   * enters {@link FacetCrawlState} or {@link cursorToFacetState}'s output — it
+   * is a cursor-only field, round-tripped exclusively through
+   * {@link facetStateToCursor}'s 4th parameter.
+   */
+  no_progress_stalls?: number
 }
 
 /** Map a runtime {@link SizeFacet} to its JSON-safe persisted form (`Infinity` → `null`). */
@@ -160,11 +173,20 @@ export function isFacetCrawlDone(
   return state.facetIndex >= facets.length && state.pendingSubranges.length === 0
 }
 
-/** Serialize the crawl frontier back into a persisted {@link BackfillCursor}. */
+/**
+ * Serialize the crawl frontier back into a persisted {@link BackfillCursor}.
+ *
+ * @param noProgressStalls - SMI-5964 §1e: the `no_progress_stalls` value to
+ *   persist on the returned cursor. Optional and defaults to 0 so the three
+ *   existing call sites in `backfill-checkpoint.statemachine.test.ts` (which
+ *   pass only the first 3 args) stay byte-stable. `runBackfillFacetCrawl` is
+ *   the one production caller that ever passes a non-zero value.
+ */
 export function facetStateToCursor(
   state: FacetCrawlState,
   pathPrefix: string,
-  facets: SizeFacet[] = buildSizeFacets()
+  facets: SizeFacet[] = buildSizeFacets(),
+  noProgressStalls = 0
 ): BackfillCursor {
   const range = currentFacetRange(state, facets)
   return {
@@ -173,6 +195,7 @@ export function facetStateToCursor(
     last_page: state.lastPage,
     facet_index: state.facetIndex,
     pending_subranges: state.pendingSubranges.map(serializeRange),
+    no_progress_stalls: noProgressStalls,
   }
 }
 

--- a/scripts/indexer/subdirectory-search.escalation.ts
+++ b/scripts/indexer/subdirectory-search.escalation.ts
@@ -1,0 +1,59 @@
+/**
+ * SMI-5964 §1e: no-progress escalation policy -- the threshold constant and
+ * shared log line consumed by `runBackfillFacetCrawl` (`subdirectory-search.helpers.ts`).
+ * @module scripts/indexer/subdirectory-search.escalation
+ *
+ * Split out of `subdirectory-search.helpers.ts` to keep that file under the
+ * 500-line convention this repo enforces on the `subdirectory-search.*`
+ * family (SMI-5286 1c originally split `subdirectory-search.ts`;
+ * SMI-5319 then split `subdirectory-search.process.ts` out of THIS file for
+ * the same reason; this is the same pattern applied a third time). No
+ * upward imports -- `code-search.facets.ts` and `backfill-checkpoint.ts`
+ * only.
+ */
+
+import { facetId, type SizeFacet } from './code-search.facets.ts'
+import type { FacetCrawlState } from './backfill-checkpoint.ts'
+
+/**
+ * SMI-5964 §1e: consecutive zero-progress dispatches tolerated at one crawl
+ * position before forward progress is forced. `2` is the smallest value that
+ * never escalates a recoverable stall: a FIRST stall is genuinely ambiguous
+ * (the dispatch may have reached the unit late, with its budget already spent
+ * elsewhere), but a SECOND consecutive stall began at that exact position with
+ * a full budget and still failed -- by construction, a livelock. Deliberately
+ * NOT an env var (a source constant with no override) -- the termination bound
+ * (`NO_PROGRESS_ESCALATION_THRESHOLD + 1` dispatches per position) is only a
+ * guarantee if it cannot be turned off.
+ */
+export const NO_PROGRESS_ESCALATION_THRESHOLD = 2
+
+/**
+ * SMI-5964 §1e: shared escalation log line for both stop sites (the §1b
+ * page-loop limb and the §1c acceptTruncation-leaf limb). Fired whenever
+ * `escalate` is true, BEFORE the (possibly cap-suppressed, possibly still
+ * deadline-bound) `processSearchResults` attempt -- not just when that
+ * attempt ALSO has to force progress. Cap suppression alone often completes
+ * the unit losslessly (no forced advance at all); the caller pushes a
+ * separate, more specific `errors[]` entry only in the forced-progress case.
+ * MUST be called BEFORE the forced `state.lastPage` assignment on the
+ * page-loop limb (when that limb is reached) -- it reads `state.lastPage + 1`,
+ * which is the about-to-be-escalated page there. On the truncation leaf
+ * `state.lastPage` is always 0 (the saturation break happens at page 1,
+ * before any `state.lastPage = page` assignment), so the same expression
+ * correctly reports page 1 -- the leaf's only page.
+ */
+export function logEscalation(
+  state: FacetCrawlState,
+  range: SizeFacet,
+  pathLabel: string,
+  stallsAtThisPosition: number
+): void {
+  console.warn(
+    `[Backfill] ESCALATED past no-progress position (facet ${facetId(range)}, ` +
+      `page ${state.lastPage + 1}, path ${pathLabel}) after ${stallsAtThisPosition} ` +
+      `zero-progress dispatches -- suppressing the skill cap for this unit. If the ` +
+      `deadline still stops it, the remainder is forced forward and recorded truncated. ` +
+      `Raise max_elapsed_minutes or narrow BACKFILL_PATH_PREFIX to crawl it completely.`
+  )
+}

--- a/scripts/indexer/subdirectory-search.helpers.ts
+++ b/scripts/indexer/subdirectory-search.helpers.ts
@@ -36,6 +36,13 @@ import {
 import type { GitHubRepository } from './topic-search.ts'
 import type { SkillMdValidation } from './skill-processor.ts'
 import type { EnumerateTelemetry } from './trees-enumerate.ts'
+// SMI-5964 §1e: escalation policy, split into its own module to keep this
+// file under the 500-line convention (see subdirectory-search.escalation.ts's
+// module docstring for the full split rationale).
+import {
+  NO_PROGRESS_ESCALATION_THRESHOLD,
+  logEscalation,
+} from './subdirectory-search.escalation.ts'
 
 // Types and the result-processor used internally by runBackfillFacetCrawl.
 // Also re-exported so callers that import from this path continue to work.
@@ -49,7 +56,10 @@ export {
   processSearchResults,
   type RepoMeta,
   type SubdirSearchStats,
+  type ProcessBudget,
+  type ProcessOutcome,
 } from './subdirectory-search.process.ts'
+export { NO_PROGRESS_ESCALATION_THRESHOLD } from './subdirectory-search.escalation.ts'
 
 /**
  * SMI-5286 1c: a single dispatch's facet-crawl plan. The driver in `run.ts`
@@ -169,18 +179,59 @@ export async function runBackfillFacetCrawl(
   let rangesCrawled = 0
   // SMI-5448: per-dispatch wall-clock anchor for the elapsed-budget guard.
   const startedAt = Date.now()
+  // SMI-5964 §1a/§1b: absolute deadline threaded into `processSearchResults` so
+  // the budget is observed INSIDE a page/leaf, not just between them (the
+  // SMI-5448 mid-range/range-boundary checks below still observe it between
+  // pages/ranges -- both are required; see §1a Context in the plan). `null`
+  // when the budget is disabled (0/undefined), preserving the SMI-5448
+  // falsy-disabled convention.
+  const deadlineAt = plan.maxElapsedMs ? startedAt + plan.maxElapsedMs : null
+
+  // SMI-5964 §1e: consecutive zero-progress dispatches recorded at the crawl
+  // position the incoming cursor stopped at. Hoisted because the post-loop
+  // return reads `stallsAtThisPosition`.
+  const inheritedStalls = plan.startCursor?.no_progress_stalls ?? 0
+  let stallsAtThisPosition = 0
+  // SMI-5964 §1e: true only when this dispatch exits via one of the two
+  // partial-stop sites this section polices (the page-loop intra-page stop, or
+  // the acceptTruncation-leaf intra-leaf stop). Any OTHER exit (ladder
+  // exhausted, maxRangesPerDispatch reached) writes the counter back to 0.
+  let partialStop = false
 
   while (rangesCrawled < plan.maxRangesPerDispatch) {
     const range = currentFacetRange(state, facets)
     if (!range) break // ladder exhausted
+
+    // SMI-5964 §1e(ii): position-scoped read, immediately after `range` is
+    // resolved. The (path, facet, last_page) triple IS the crawl position; the
+    // C-1 retirement invariant in `bisectCurrentFacet` guarantees a facet is
+    // never revisited within a dispatch, so at most the FIRST range of a
+    // dispatch can match -- no later range accidentally inherits a stale count.
+    stallsAtThisPosition =
+      plan.startCursor != null &&
+      plan.startCursor.path === (plan.pathPrefix ?? '') &&
+      plan.startCursor.facet === facetId(range) &&
+      plan.startCursor.last_page === state.lastPage
+        ? inheritedStalls
+        : 0
+    // SMI-5964 §1e(iv): a second consecutive zero-progress dispatch at this
+    // exact position is unambiguous -- forces the stalled unit through (cap
+    // suppressed first; the deadline still applies).
+    const escalate = stallsAtThisPosition >= NO_PROGRESS_ESCALATION_THRESHOLD
+
     const qualifier = facetToQualifier(range)
 
     let saturated = false
     let errored = false
     // SMI-5448: write-once-true flag set only after `state.lastPage = page`
     // (never on the saturation/error path), so a timed-out range is not
-    // advanced/bisected -- resume re-enters this facet at lastPage+1.
+    // advanced/bisected -- resume re-enters this facet at lastPage+1. SMI-5964:
+    // now also set on the NEW intra-page stop (§1b), which has the identical
+    // "hold, don't advance" semantic -- see the escalated exception below.
     let timedOut = false
+    // SMI-5964: logging-only -- must never be tested for control flow (the
+    // four-branch post-page structure below is unchanged).
+    let stopReason: string | undefined
     // SMI-5321: capture page-1 repos during saturation detection so the
     // acceptTruncation floor can reuse them without a second code-search fetch.
     let saturatedPageRepos: GitHubRepository[] | null = null
@@ -205,7 +256,14 @@ export async function runBackfillFacetCrawl(
         saturatedPageRepos = result.repos
         break
       }
-      await processSearchResults(
+      // SMI-5964 §1b/§1e: intra-page budget -- observed INSIDE this page's
+      // per-repo/per-entry processing, not just at the range/page boundaries
+      // below. The skill cap is suppressed on an escalated dispatch; the
+      // deadline is never suppressed. Announce the escalation BEFORE the
+      // attempt (§1e(iv)) -- cap suppression alone often completes the page
+      // losslessly, with no further "forced past" event below.
+      if (escalate) logEscalation(state, range, pathLabel, stallsAtThisPosition)
+      const outcome = await processSearchResults(
         result.repos,
         seenUrls,
         validationCache,
@@ -215,8 +273,32 @@ export async function runBackfillFacetCrawl(
         telemetry,
         enumerateTelemetry,
         enumeratedRepos,
-        repoMetaCache
+        repoMetaCache,
+        { deadlineAt, maxSkills: escalate ? undefined : plan.maxSkillsPerDispatch }
       )
+      if (outcome.stopped) {
+        stopReason = outcome.reason === 'skill-cap' ? 'skill-cap-intra-page' : 'elapsed-intra-page'
+        if (escalate) {
+          // SMI-5964 §1e(iv) limb 2: the cap-suppressed attempt STILL stopped
+          // (necessarily on the deadline) -- force the cursor forward rather
+          // than repeat the same livelock a fourth time. `partialStop` is
+          // deliberately NOT set here: the escalated attempt DID move the
+          // cursor (the forced `state.lastPage` assignment below), so this is
+          // progress, not a stall -- the counter must reset to 0, not keep
+          // climbing. Only the un-escalated "hold" branch below counts as a
+          // stall against this position.
+          truncatedRanges++
+          errors.push(
+            `[backfill ${pathLabel} ${facetId(range)} p${page}] escalated past a ` +
+              `no-progress page after ${stallsAtThisPosition} stalled dispatches (${stopReason})`
+          )
+          state.lastPage = page // the ONLY guarded assignment on this limb -- forced progress
+        } else {
+          partialStop = true
+        }
+        timedOut = true
+        break // page is PARTIAL unless `escalate` moved the cursor above
+      }
       state.lastPage = page
       if (result.repos.length < plan.perPage) break // short page -> range exhausted
       if (plan.maxElapsedMs && Date.now() - startedAt >= plan.maxElapsedMs) {
@@ -246,6 +328,11 @@ export async function runBackfillFacetCrawl(
         // observability), then either fetch the first ≤1000 results (opt-in)
         // or skip (default, byte-identical to the prior behavior).
         truncatedRanges++
+        // SMI-5964 §1c: gates `advanceFacet` below on THIS branch only -- a
+        // dedicated flag (not `timedOut`) so the SMI-5448 F-1 mutual-exclusivity
+        // invariant (`timedOut` never set in the same iteration as `saturated`)
+        // stays true byte-for-byte.
+        let truncationStopped = false
         if (plan.acceptTruncation) {
           // SMI-5321: fetch-with-truncation floor. Reuses the page-1 result
           // already in memory from the saturation detection branch above —
@@ -258,7 +345,13 @@ export async function runBackfillFacetCrawl(
               `acceptTruncation=true, admitting page-1 results already in memory (up to ${plan.perPage}), recorded as truncated`
           )
           if (saturatedPageRepos !== null) {
-            await processSearchResults(
+            // SMI-5964 §1c: the SAME budget as the page loop -- this call site
+            // was previously unbounded (review blocker 2). Announce the
+            // escalation BEFORE the attempt (§1e(iv)) -- cap suppression
+            // alone often completes the leaf losslessly, with no further
+            // "forced past" event below.
+            if (escalate) logEscalation(state, range, pathLabel, stallsAtThisPosition)
+            const outcome = await processSearchResults(
               saturatedPageRepos,
               seenUrls,
               validationCache,
@@ -268,15 +361,48 @@ export async function runBackfillFacetCrawl(
               telemetry,
               enumerateTelemetry,
               enumeratedRepos,
-              repoMetaCache
+              repoMetaCache,
+              { deadlineAt, maxSkills: escalate ? undefined : plan.maxSkillsPerDispatch }
             )
+            if (outcome.stopped) {
+              stopReason =
+                outcome.reason === 'skill-cap'
+                  ? 'skill-cap-intra-truncation'
+                  : 'elapsed-intra-truncation'
+              // Normal path: hold the leaf (advanceFacet below is skipped) --
+              // this IS a stall against this position, so `partialStop` is
+              // set. Escalated path: leave `truncationStopped` false so the
+              // `advanceFacet(state)` below runs and the cursor moves (§1e) --
+              // `partialStop` is deliberately NOT set here, matching the
+              // page-loop limb above: a forced advance is progress, not a
+              // stall, so the counter must reset to 0 on the next write.
+              truncationStopped = !escalate
+              if (escalate) {
+                errors.push(
+                  `[backfill ${pathLabel} ${facetId(range)}] escalated past a no-progress ` +
+                    `acceptTruncation leaf after ${stallsAtThisPosition} stalled dispatches ` +
+                    `(${stopReason}) -- remaining page-1 results skipped, leaf recorded truncated`
+                )
+              } else {
+                partialStop = true
+              }
+            }
           }
         } else {
           console.warn(
             `[Backfill] facet ${facetId(range)} (${pathLabel}) saturated at the 1000-cap and cannot subdivide -- recorded as truncated, skipping`
           )
         }
-        advanceFacet(state)
+        // :279 (original) -- advance when the truncated leaf was fully
+        // consumed, OR when §1e escalated (truncationStopped left false).
+        if (!truncationStopped) advanceFacet(state)
+        if (truncationStopped) {
+          console.log(
+            `[Backfill] budget reached inside acceptTruncation leaf (facet ${facetId(range)}, ` +
+              `reason ${stopReason}) -- leaf NOT advanced, checkpointing and exiting`
+          )
+          break // outer while loop -- the leaf is NOT advanced (see above)
+        }
       }
     } else if (timedOut) {
       // SMI-5448: elapsed budget tripped mid-range -- the range is NOT exhausted.
@@ -287,6 +413,9 @@ export async function runBackfillFacetCrawl(
       // at lastPage+1 > maxPagesPerRange, its body never runs, no flags are set,
       // and the outer `else` advances the facet -- correct: this range is treated
       // as page-cap exhausted, identical to the pre-5448 exhaustion path.
+      // SMI-5964: on the ESCALATED page-loop limb, `state.lastPage` was already
+      // forced forward (above, before this branch runs) -- this comment's "hold"
+      // description applies to the unescalated case only.
     } else {
       // Range exhausted (short page, or page cap reached with total <= cap).
       advanceFacet(state)
@@ -329,7 +458,19 @@ export async function runBackfillFacetCrawl(
   }
 
   return {
-    cursor: facetStateToCursor(state, plan.pathPrefix ?? '', facets),
+    cursor: facetStateToCursor(
+      state,
+      plan.pathPrefix ?? '',
+      facets,
+      // SMI-5964 §1e(iii): position-scoped, not dispatch-scoped -- the ONLY
+      // write sites for this counter are the two partial-stop sites above.
+      // Any other exit (ladder exhausted, maxRangesPerDispatch reached) writes
+      // 0. Whether this dispatch made progress EARLIER at a different position
+      // is irrelevant: `stallsAtThisPosition` (read above) already resets to 0
+      // whenever the incoming cursor's position doesn't match the position now
+      // being crawled.
+      partialStop ? stallsAtThisPosition + 1 : 0
+    ),
     done: isFacetCrawlDone(state, facets),
     cap_saturated: capSaturated,
     truncated_repo_count: truncatedRanges,

--- a/scripts/indexer/subdirectory-search.process.ts
+++ b/scripts/indexer/subdirectory-search.process.ts
@@ -75,6 +75,49 @@ export interface SubdirSearchStats {
 }
 
 /**
+ * SMI-5964: intra-page/intra-leaf budget threaded into
+ * {@link processSearchResults}. Omitted (`undefined`) is unbounded and
+ * byte-identical to pre-5964 behavior — the two cron call sites
+ * (`subdirectory-search.ts:238`, `:292`) pass nothing.
+ */
+export interface ProcessBudget {
+  /** Absolute epoch-ms deadline; stop before starting more work past it. */
+  deadlineAt?: number | null
+  /** Stop once `repos.length >= maxSkills` (0/undefined = no cap). */
+  maxSkills?: number
+}
+
+/** SMI-5964: the outcome of one {@link processSearchResults} call. */
+export interface ProcessOutcome {
+  /** True when the function returned before consuming every input result. */
+  stopped: boolean
+  reason?: 'deadline' | 'skill-cap'
+}
+
+/**
+ * SMI-5964: evaluate `budget` at a loop-top. Returns the {@link ProcessOutcome}
+ * to return immediately when tripped, or `null` when the caller should keep
+ * going. `repos` is the dispatch-wide accumulator already threaded through
+ * every caller, so this reads the SAME quantity the existing range-boundary
+ * cap measures (`subdirectory-search.helpers.ts`) — no new counter, no new
+ * key-shape. Checked skill-cap first, deadline second, matching the existing
+ * range-boundary checks' own ordering.
+ */
+function checkBudget(
+  budget: ProcessBudget | undefined,
+  repos: GitHubRepository[]
+): ProcessOutcome | null {
+  if (!budget) return null
+  if (budget.maxSkills && repos.length >= budget.maxSkills) {
+    return { stopped: true, reason: 'skill-cap' }
+  }
+  if (budget.deadlineAt != null && Date.now() >= budget.deadlineAt) {
+    return { stopped: true, reason: 'deadline' }
+  }
+  return null
+}
+
+/**
  * Process code search results: deduplicate, validate, resolve license, and collect repos.
  * Shared by both broad and fallback search paths.
  *
@@ -120,8 +163,9 @@ export async function processSearchResults(
   telemetry: RateLimitTelemetry,
   enumerateTelemetry: EnumerateTelemetry,
   enumeratedRepos: Set<string>,
-  repoMetaCache: Map<string, RepoMeta>
-): Promise<void> {
+  repoMetaCache: Map<string, RepoMeta>,
+  budget?: ProcessBudget
+): Promise<ProcessOutcome> {
   // SMI-5319 kill-switch: when set to the literal string 'true', restore the
   // legacy pre-validity license ADMISSION gate (exclude non-permissive repos)
   // so ops can re-enable the old behavior without a deploy. Default (unset /
@@ -129,6 +173,11 @@ export async function processSearchResults(
   const legacyLicenseGate = process.env.SKILLSMITH_INDEXER_LICENSE_GATE === 'true'
 
   for (const repo of resultRepos) {
+    // SMI-5964: top-of-loop budget check -- no work is started that is about
+    // to be discarded.
+    const repoLoopTripped = checkBudget(budget, repos)
+    if (repoLoopTripped) return repoLoopTripped
+
     // Deduplication key includes skillPath: one repo can have multiple skills
     const dedupKey = repo.skillPath ? `${repo.url}/${repo.skillPath}` : repo.url
     if (seenUrls.has(dedupKey)) continue
@@ -254,6 +303,11 @@ export async function processSearchResults(
     // Validate each enumerated SKILL.md independently (sec#4 strict gate) and emit
     // one per-skill GitHubRepository with a distinct tree URL (C-1) per valid path.
     for (const entry of entries) {
+      // SMI-5964: top-of-loop budget check -- no work is started that is about
+      // to be discarded.
+      const entryLoopTripped = checkBudget(budget, repos)
+      if (entryLoopTripped) return entryLoopTripped
+
       const skillPath = entry.path
       const installable = await checkSkillMdExists(
         repo.owner,
@@ -298,4 +352,8 @@ export async function processSearchResults(
       await delay(50)
     }
   }
+
+  // SMI-5964: every input result was consumed without tripping `budget`
+  // (or `budget` was never supplied — the cron call sites' byte-identical case).
+  return { stopped: false }
 }

--- a/scripts/tests/_lib/index.ts
+++ b/scripts/tests/_lib/index.ts
@@ -7,3 +7,17 @@
  * existing imports.
  */
 export { makeFixtureEnv, makeFixtureTempDir } from './git-fixture-env.js'
+export { extractStep, type WorkflowStep } from './workflow-yaml.js'
+export {
+  LADDER_SIZE,
+  PER_PAGE,
+  resetRepoCounter,
+  makeCodeSearchRepo,
+  fullPage,
+  shortPage,
+  saturatedPage,
+  makePlan,
+  omitStartCursor,
+  leafCursor,
+  pageCursor,
+} from './subdirectory-search-fixtures.js'

--- a/scripts/tests/_lib/subdirectory-search-fixtures.ts
+++ b/scripts/tests/_lib/subdirectory-search-fixtures.ts
@@ -1,0 +1,116 @@
+/**
+ * SMI-5448 / SMI-5964 — shared pure fixture factories for the backfill
+ * elapsed-budget / no-progress-escalation test suites.
+ *
+ * Extracted from `subdirectory-search.helpers.test.ts` when that file grew
+ * past the 500-line convention (SMI-5964 added Cases 9-17). Only PURE,
+ * non-mock factory functions live here — `vi.mock()` calls and the
+ * `beforeEach`/`afterEach` fake-timer lifecycle cannot be shared this way
+ * (vitest hoists `vi.mock()` per test file), so those stay duplicated in
+ * each `*.test.ts` file that needs them.
+ */
+
+import type { BackfillFacetPlan } from '../../indexer/subdirectory-search.ts'
+import type { BackfillCursor } from '../../indexer/backfill-checkpoint.ts'
+
+export const LADDER_SIZE = 9
+export const PER_PAGE = 100
+
+let repoCounter = 0
+
+/** Call from `beforeEach` alongside the mock `.mockReset()` calls. */
+export function resetRepoCounter(): void {
+  repoCounter = 0
+}
+
+export function makeCodeSearchRepo(overrides: Record<string, unknown> = {}) {
+  repoCounter += 1
+  const owner = `elapsed-owner${repoCounter}`
+  return {
+    owner,
+    name: 'skills-repo',
+    fullName: `${owner}/skills-repo`,
+    description: 'test',
+    url: `https://github.com/${owner}/skills-repo/tree/main/skills/x`,
+    stars: 5,
+    forks: 0,
+    topics: ['claude-code-skill'],
+    updatedAt: new Date().toISOString(),
+    defaultBranch: 'main',
+    installable: false,
+    repoName: 'skills-repo',
+    skillPath: 'skills/x',
+    discoveryPath: 'subdirectory_search:broad',
+    ...overrides,
+  }
+}
+
+/** A FULL page (repos.length === perPage): total <= cap so no saturation/bisect,
+ *  but the page is NOT short, so the range does NOT exhaust and keeps paginating. */
+export function fullPage() {
+  const repos = Array.from({ length: PER_PAGE }, () => makeCodeSearchRepo())
+  return { repos, total: 500, retries: 0, incomplete_results: false }
+}
+
+/** A single-repo short page: total under the cap, repos.length < perPage, so the
+ *  range exhausts in one page (clean advance). */
+export function shortPage() {
+  return { repos: [makeCodeSearchRepo()], total: 5, retries: 0, incomplete_results: false }
+}
+
+/** SMI-5964: a SATURATED page-1 result (`total > 1000`) carrying `count` repos --
+ *  the `acceptTruncation` leaf's `saturatedPageRepos`. */
+export function saturatedPage(count: number) {
+  return {
+    repos: Array.from({ length: count }, () => makeCodeSearchRepo()),
+    total: 1001,
+    retries: 0,
+    incomplete_results: false,
+  }
+}
+
+export function makePlan(overrides: Partial<BackfillFacetPlan> = {}): BackfillFacetPlan {
+  return {
+    startCursor: null,
+    pathPrefix: undefined,
+    perPage: PER_PAGE,
+    maxPagesPerRange: 20,
+    maxRangesPerDispatch: 100,
+    ...overrides,
+  }
+}
+
+/** SMI-5964: strip `startCursor` for the Case 10/15/16 plan-equality self-check --
+ *  the ONLY field allowed to differ across dispatches sharing "one plan literal". */
+export function omitStartCursor(plan: BackfillFacetPlan): Omit<BackfillFacetPlan, 'startCursor'> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { startCursor: _startCursor, ...rest } = plan
+  return rest
+}
+
+/** SMI-5964: an unsplittable leaf cursor (`lo === hi`, `bisectFacet` returns null),
+ *  the realistic shape of a saturated-and-unbisectable `acceptTruncation` position
+ *  (reached in production via repeated bisection of a dense top-level facet). */
+export function leafCursor(noProgressStalls?: number): BackfillCursor {
+  return {
+    path: '',
+    facet: '5-5',
+    last_page: 0,
+    facet_index: 0,
+    pending_subranges: [[5, 5]],
+    ...(noProgressStalls != null ? { no_progress_stalls: noProgressStalls } : {}),
+  }
+}
+
+/** SMI-5964: a resume cursor mid-facet-0 at the given `last_page` (a NORMAL,
+ *  non-saturated range -- the §1b page-loop twin of {@link leafCursor}). */
+export function pageCursor(lastPage: number, noProgressStalls?: number): BackfillCursor {
+  return {
+    path: '',
+    facet: '0-127',
+    last_page: lastPage,
+    facet_index: 0,
+    pending_subranges: [],
+    ...(noProgressStalls != null ? { no_progress_stalls: noProgressStalls } : {}),
+  }
+}

--- a/scripts/tests/_lib/workflow-yaml.ts
+++ b/scripts/tests/_lib/workflow-yaml.ts
@@ -1,0 +1,62 @@
+/**
+ * SMI-4241 / SMI-5964 -- lightweight GitHub Actions workflow YAML walker.
+ *
+ * Extracted from `scripts/tests/indexer-workflow-report-failure.test.ts`
+ * (SMI-5964 Case 13) so `indexer-backfill-alert-gap.test.ts` can reuse the
+ * same `extractStep` logic instead of copy-pasting it. No YAML parser
+ * dependency is added -- the repo has none, and every existing workflow test
+ * is string/regex based; this only needs three-ish known steps per file.
+ */
+
+/** A single workflow step's `env:` map and `run:` script body. */
+export interface WorkflowStep {
+  name: string
+  envBlock: Record<string, string>
+  runScript: string
+}
+
+/**
+ * Extract a step's `env:` map and `run:` script body. Lightweight YAML
+ * walker -- we don't pull in a YAML parser because we only need a handful of
+ * known steps per workflow file.
+ *
+ * @param yaml - The full workflow file contents.
+ * @param stepName - The step's `name:` value (matched via `- name: <name>`).
+ */
+export function extractStep(yaml: string, stepName: string): WorkflowStep {
+  const startMarker = `- name: ${stepName}`
+  const startIdx = yaml.indexOf(startMarker)
+  if (startIdx === -1) {
+    throw new Error(`Step "${stepName}" not found in workflow`)
+  }
+  // Find next "- name: " or end of file.
+  const after = yaml.slice(startIdx + startMarker.length)
+  const nextStepIdx = after.search(/\n {6}- name: /)
+  const block = nextStepIdx === -1 ? after : after.slice(0, nextStepIdx)
+
+  // Parse env: block (lines before `run: |`).
+  const envBlock: Record<string, string> = {}
+  const envMatch = block.match(/\n {8}env:\n((?: {10}[^\n]+\n)+)/)
+  if (envMatch) {
+    for (const line of envMatch[1].split('\n')) {
+      const m = line.match(/^ {10}(\w+): (.+?)$/)
+      if (m) envBlock[m[1]] = m[2].trim()
+    }
+  }
+
+  // Extract run: | body (lines indented 10 spaces under run:). Each line is
+  // EITHER 10-space-indented content OR wholly blank (SMI-5964: the original
+  // extraction required every line to carry the 10-space prefix, so a
+  // genuinely blank line inside a `run: |` block silently truncated the
+  // capture -- `indexer.yml`'s existing steps route around this by using
+  // `echo ""` instead of blank YAML lines; newer steps should not have to).
+  const runMatch = block.match(/\n {8}run: \|\n((?:(?: {10}[^\n]*)?\n)+)/)
+  if (!runMatch) {
+    throw new Error(`Step "${stepName}" has no \`run: |\` block`)
+  }
+  const runScript = runMatch[1]
+    .split('\n')
+    .map((l) => l.replace(/^ {10}/, ''))
+    .join('\n')
+  return { name: stepName, envBlock, runScript }
+}

--- a/scripts/tests/indexer-backfill-alert-gap.test.ts
+++ b/scripts/tests/indexer-backfill-alert-gap.test.ts
@@ -1,0 +1,209 @@
+/**
+ * SMI-5964 Case 13: static assertions over the alert-gap watcher
+ * (`.github/workflows/indexer-backfill-watch.yml`, new) and the three §3e
+ * edits to `.github/workflows/indexer-backfill.yml`.
+ *
+ * No live dispatch (the driver owns that workflow -- see the plan's §Smoke
+ * vs CI FORBIDDEN clause), no YAML parser dependency -- string/regex +
+ * `bash -n`, matching every existing workflow test in this repo. `extractStep`
+ * is shared with `indexer-workflow-report-failure.test.ts` via
+ * `_lib/workflow-yaml.ts` (SMI-4241's original home for this walker).
+ */
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// SMI-4693: this file invokes `bash -n` (syntax check only) — no git
+// mutation. Use `makeFixtureTempDir` for symlink consistency.
+import { makeFixtureTempDir } from './_lib/git-fixture-env.js'
+import { extractStep } from './_lib/workflow-yaml.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const BACKFILL_PATH = join(REPO_ROOT, '.github', 'workflows', 'indexer-backfill.yml')
+const WATCHER_PATH = join(REPO_ROOT, '.github', 'workflows', 'indexer-backfill-watch.yml')
+
+// ── Helpers (mirror indexer-workflow-report-failure.test.ts's pattern) ─────
+
+function bashSyntaxCheck(script: string): { ok: true } | { ok: false; stderr: string } {
+  const dir = makeFixtureTempDir('backfill-watch-test')
+  const file = join(dir, 'script.sh')
+  try {
+    writeFileSync(file, script, 'utf8')
+    execFileSync('bash', ['-n', file], { stdio: ['ignore', 'ignore', 'pipe'] })
+    return { ok: true }
+  } catch (err) {
+    const stderr =
+      err && typeof err === 'object' && 'stderr' in err
+        ? String((err as { stderr: Buffer }).stderr)
+        : String(err)
+    return { ok: false, stderr }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+function injectEnv(script: string, env: Record<string, string>): string {
+  const assignments = Object.entries(env)
+    .map(([k, v]) => `${k}=${shellQuote(v)}`)
+    .join('\n')
+  return `${assignments}\n${script}`
+}
+
+function shellQuote(value: string): string {
+  // POSIX-safe single-quote wrap; embedded `'` becomes `'\''`.
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+const HOSTILE_FIXTURES: Array<{ label: string; value: string }> = [
+  { label: 'embedded single quote', value: "it's broken" },
+  { label: 'embedded backticks', value: '`backtick`' },
+  { label: 'embedded double quote', value: 'line "with" quote' },
+  { label: 'embedded newline', value: 'line 1\nline 2' },
+  { label: 'subshell-looking $(rm -rf /)', value: '$(rm -rf /)' },
+  { label: 'process substitution <(cat /etc/passwd)', value: '<(cat /etc/passwd)' },
+]
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('SMI-5964 Case 13: indexer-backfill-watch.yml (the new alert-gap watcher)', () => {
+  const watcher = readFileSync(WATCHER_PATH, 'utf8')
+  const backfill = readFileSync(BACKFILL_PATH, 'utf8')
+
+  it("the watcher's workflows: value matches indexer-backfill.yml's name: byte-for-byte -- a mismatch means workflow_run silently never fires", () => {
+    const nameMatch = backfill.match(/^name: (.+)$/m)
+    expect(nameMatch).not.toBeNull()
+    const backfillName = nameMatch![1].trim()
+    expect(watcher).toContain(`workflows: ['${backfillName}']`)
+  })
+
+  it('triggers on workflow_run / types: [completed] / branches: [main] (the established repo pattern -- smoke-prod.yml, billing-monitor.yml, mirror-mcp-server.yml, e2e-usage-counter.yml)', () => {
+    expect(watcher).toMatch(/workflow_run:/)
+    expect(watcher).toMatch(/types: \[completed\]/)
+    expect(watcher).toMatch(/branches: \[main\]/)
+  })
+
+  it("the job's if: condition is scoped to conclusion == 'cancelled' only", () => {
+    expect(watcher).toMatch(/if: github\.event\.workflow_run\.conclusion == 'cancelled'/)
+  })
+
+  it('permissions include actions: read (for the /jobs API call that labels the alert)', () => {
+    const permsMatch = watcher.match(/permissions:\n((?: {2}[^\n]+\n)+)/)
+    expect(permsMatch).not.toBeNull()
+    expect(permsMatch![1]).toMatch(/actions: read/)
+  })
+
+  it("has its own timeout-minutes, independent of the dying job's 330-min budget", () => {
+    expect(watcher).toMatch(/timeout-minutes: 5/)
+  })
+
+  it('has no `uses:` step -- nothing for audit-workflow-sha-pin (Check 42) to pin', () => {
+    expect(watcher).not.toMatch(/uses:/)
+  })
+
+  it('the run: body survives bash -n under hostile $RUN_ID/$RUN_URL-shaped fixtures', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    for (const fixture of HOSTILE_FIXTURES) {
+      const injected = injectEnv(step.runScript, {
+        RUN_STARTED_AT: '2026-08-09T01:05:54Z',
+        RUN_ID: fixture.value,
+        RUN_URL: fixture.value,
+        GH_REPOSITORY: 'smith-horn/skillsmith',
+        SUPABASE_URL: 'https://example.supabase.co',
+        SUPABASE_SERVICE_ROLE_KEY: 'dummy',
+        GITHUB_STEP_SUMMARY: '/tmp/dummy-summary',
+      })
+      const result = bashSyntaxCheck(injected)
+      expect(result, `${fixture.label}: ${JSON.stringify(result)}`).toEqual({ ok: true })
+    }
+  })
+
+  it('classification is a label, never a gate -- the alert-notify POST is never wrapped in a $KIND conditional', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    const curlIdx = step.runScript.indexOf('curl -s -o /dev/null')
+    expect(curlIdx).toBeGreaterThan(-1)
+    expect(step.runScript).not.toMatch(/if \[ "\$KIND"/)
+  })
+
+  it('fail-open: an absent STEP_CONCLUSION degrades to cancelled-unknown rather than skipping the alert', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    expect(step.runScript).toMatch(/KIND="cancelled-unknown"/)
+  })
+
+  it('the alert-notify HTTP code is captured, written to the step summary, and a non-200 raises a workflow annotation', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    expect(step.runScript).toMatch(/HTTP=\$\(curl -s -o \/dev\/null -w '%\{http_code\}'/)
+    expect(step.runScript).toMatch(/alert-notify HTTP \| \$HTTP/)
+    expect(step.runScript).toMatch(/::warning::alert-notify returned \$HTTP/)
+  })
+
+  it('posts the type: "indexer_backfill_cancelled" alert (a free-form string alert-notify only presence-validates)', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    expect(step.runScript).toMatch(/type:"indexer_backfill_cancelled"/)
+  })
+})
+
+describe('SMI-5964 Case 13: indexer-backfill.yml (§3e edits only -- no if:/timeout-minutes change)', () => {
+  const backfill = readFileSync(BACKFILL_PATH, 'utf8')
+
+  it('no timeout-minutes was added to any step -- only the pre-existing job-level 330 remains', () => {
+    const matches = backfill.match(/timeout-minutes:/g) ?? []
+    expect(matches).toHaveLength(1)
+    expect(backfill).toMatch(/timeout-minutes: 330/)
+  })
+
+  it('the two if: failure() conditions are unchanged', () => {
+    const matches = backfill.match(/if: failure\(\)/g) ?? []
+    expect(matches).toHaveLength(2)
+  })
+
+  it('Send Alert on Failure captures the alert-notify HTTP code and writes it to the step summary', () => {
+    const step = extractStep(backfill, 'Send Alert on Failure')
+    expect(step.runScript).toMatch(/HTTP=\$\(curl -s -o \/dev\/null -w '%\{http_code\}'/)
+    expect(step.runScript).toMatch(/alert-notify HTTP \| \$HTTP/)
+    expect(step.runScript).toMatch(/::warning::alert-notify returned \$HTTP/)
+  })
+
+  it("Send Alert on Failure uses ${HTTP_CODE:-n/a}, matching Report Failure's existing convention", () => {
+    const step = extractStep(backfill, 'Send Alert on Failure')
+    expect(step.runScript).toMatch(/\$\{HTTP_CODE:-n\/a\}/)
+  })
+
+  it('Send Alert on Failure survives bash -n under hostile fixtures', () => {
+    const step = extractStep(backfill, 'Send Alert on Failure')
+    for (const fixture of HOSTILE_FIXTURES) {
+      const injected = injectEnv(step.runScript, {
+        HTTP_CODE: '500',
+        RUN_ID: fixture.value,
+        RUN_URL: fixture.value,
+        SUPABASE_URL: 'https://example.supabase.co',
+        SUPABASE_SERVICE_ROLE_KEY: 'dummy',
+        GITHUB_STEP_SUMMARY: '/tmp/dummy-summary',
+      })
+      const result = bashSyntaxCheck(injected)
+      expect(result, `${fixture.label}: ${JSON.stringify(result)}`).toEqual({ ok: true })
+    }
+  })
+
+  it('the max_elapsed_minutes input description no longer asserts the falsified "~10-15 min" per-page assumption', () => {
+    expect(backfill).not.toMatch(/10-15 min/)
+  })
+
+  it('all eight workflow_dispatch input names backfill-rollout-driver.sh passes (:117-119) are unchanged', () => {
+    const inputNames = [
+      'dry_run',
+      'resume_from',
+      'path_prefix',
+      'min_size_bytes',
+      'max_ranges',
+      'max_skills_per_dispatch',
+      'max_skills_per_repo',
+      'max_elapsed_minutes',
+    ]
+    for (const name of inputNames) {
+      expect(backfill).toMatch(new RegExp(`^\\s+${name}:`, 'm'))
+    }
+  })
+})

--- a/scripts/tests/indexer-backfill-alert-gap.test.ts
+++ b/scripts/tests/indexer-backfill-alert-gap.test.ts
@@ -132,11 +132,14 @@ describe('SMI-5964 Case 13: indexer-backfill-watch.yml (the new alert-gap watche
     expect(step.runScript).toMatch(/KIND="cancelled-unknown"/)
   })
 
-  it('the alert-notify HTTP code is captured, written to the step summary, and a non-200 raises a workflow annotation', () => {
+  it('the alert-notify HTTP code is captured, written to the step summary, and a non-200 fails the job (code-review finding: a warning-only annotation left this watcher green on a failed delivery, defeating its purpose)', () => {
     const step = extractStep(watcher, 'Classify and alert')
-    expect(step.runScript).toMatch(/HTTP=\$\(curl -s -o \/dev\/null -w '%\{http_code\}'/)
+    expect(step.runScript).toMatch(
+      /if RESPONSE_CODE=\$\(curl -s -o \/dev\/null -w '%\{http_code\}'/
+    )
     expect(step.runScript).toMatch(/alert-notify HTTP \| \$HTTP/)
-    expect(step.runScript).toMatch(/::warning::alert-notify returned \$HTTP/)
+    expect(step.runScript).toMatch(/::error::alert-notify returned \$HTTP/)
+    expect(step.runScript).toMatch(/exit 1/)
   })
 
   it('posts the type: "indexer_backfill_cancelled" alert (a free-form string alert-notify only presence-validates)', () => {
@@ -159,11 +162,14 @@ describe('SMI-5964 Case 13: indexer-backfill.yml (§3e edits only -- no if:/time
     expect(matches).toHaveLength(2)
   })
 
-  it('Send Alert on Failure captures the alert-notify HTTP code and writes it to the step summary', () => {
+  it('Send Alert on Failure captures the alert-notify HTTP code, writes it to the step summary, and fails the step on non-200 (code-review finding: a warning-only annotation left this step green on a failed delivery)', () => {
     const step = extractStep(backfill, 'Send Alert on Failure')
-    expect(step.runScript).toMatch(/HTTP=\$\(curl -s -o \/dev\/null -w '%\{http_code\}'/)
+    expect(step.runScript).toMatch(
+      /if RESPONSE_CODE=\$\(curl -s -o \/dev\/null -w '%\{http_code\}'/
+    )
     expect(step.runScript).toMatch(/alert-notify HTTP \| \$HTTP/)
-    expect(step.runScript).toMatch(/::warning::alert-notify returned \$HTTP/)
+    expect(step.runScript).toMatch(/::error::alert-notify returned \$HTTP/)
+    expect(step.runScript).toMatch(/exit 1/)
   })
 
   it("Send Alert on Failure uses ${HTTP_CODE:-n/a}, matching Report Failure's existing convention", () => {

--- a/scripts/tests/indexer-workflow-report-failure.test.ts
+++ b/scripts/tests/indexer-workflow-report-failure.test.ts
@@ -31,55 +31,15 @@ import { fileURLToPath } from 'node:url'
 // SMI-4693: this file invokes `bash -n` (syntax check only) — no git
 // mutation. Use `makeFixtureTempDir` for symlink consistency.
 import { makeFixtureTempDir } from './_lib/git-fixture-env.js'
+// SMI-5964 Case 13: `extractStep` extracted to `_lib/workflow-yaml.ts` so
+// `indexer-backfill-alert-gap.test.ts` can share it instead of copy-pasting.
+import { extractStep } from './_lib/workflow-yaml.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..', '..')
 const WORKFLOW_PATH = join(REPO_ROOT, '.github', 'workflows', 'indexer.yml')
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-interface WorkflowStep {
-  name: string
-  envBlock: Record<string, string>
-  runScript: string
-}
-
-/**
- * Extract a step's `env:` map and `run:` script body. Lightweight YAML walker —
- * we don't pull in a YAML parser because we only need three known steps.
- */
-function extractStep(yaml: string, stepName: string): WorkflowStep {
-  const startMarker = `- name: ${stepName}`
-  const startIdx = yaml.indexOf(startMarker)
-  if (startIdx === -1) {
-    throw new Error(`Step "${stepName}" not found in workflow`)
-  }
-  // Find next "- name: " or end of file.
-  const after = yaml.slice(startIdx + startMarker.length)
-  const nextStepIdx = after.search(/\n {6}- name: /)
-  const block = nextStepIdx === -1 ? after : after.slice(0, nextStepIdx)
-
-  // Parse env: block (lines before `run: |`).
-  const envBlock: Record<string, string> = {}
-  const envMatch = block.match(/\n {8}env:\n((?: {10}[^\n]+\n)+)/)
-  if (envMatch) {
-    for (const line of envMatch[1].split('\n')) {
-      const m = line.match(/^ {10}(\w+): (.+?)$/)
-      if (m) envBlock[m[1]] = m[2].trim()
-    }
-  }
-
-  // Extract run: | body (lines indented 10 spaces under run:).
-  const runMatch = block.match(/\n {8}run: \|\n((?: {10}[^\n]*\n?)+)/)
-  if (!runMatch) {
-    throw new Error(`Step "${stepName}" has no \`run: |\` block`)
-  }
-  const runScript = runMatch[1]
-    .split('\n')
-    .map((l) => l.replace(/^ {10}/, ''))
-    .join('\n')
-  return { name: stepName, envBlock, runScript }
-}
 
 /**
  * Run `bash -n` (syntax check only — does not execute) on a script string.

--- a/scripts/tests/indexer/backfill-checkpoint.statemachine.test.ts
+++ b/scripts/tests/indexer/backfill-checkpoint.statemachine.test.ts
@@ -197,4 +197,40 @@ describe('facet driver state machine (SMI-5286 1c)', () => {
     expect(cursor.facet).toBe('done')
     expect(cursor.facet_index).toBe(FACETS.length)
   })
+
+  // SMI-5964 §1e Case 17: the `no_progress_stalls` cursor field round-trips
+  // exactly like every other cursor field, but is NEVER read back into
+  // FacetCrawlState -- it is a cursor-only, advisory field.
+  it('SMI-5964: facetStateToCursor accepts an optional 4th no_progress_stalls arg; cursorToFacetState ignores it entirely', () => {
+    const state: FacetCrawlState = { facetIndex: 2, pendingSubranges: [], lastPage: 3 }
+
+    const cursor = facetStateToCursor(state, '', FACETS, 2)
+    expect(cursor.no_progress_stalls).toBe(2)
+
+    // The counter never enters FacetCrawlState -- cursorToFacetState's output
+    // shape is UNCHANGED (the toEqual guard above stays exactly
+    // {facetIndex, pendingSubranges, lastPage}).
+    expect(cursorToFacetState(cursor)).toEqual({
+      facetIndex: 2,
+      pendingSubranges: [],
+      lastPage: 3,
+    })
+
+    // Omitting the 4th arg defaults to 0 -- byte-stable for the existing
+    // 3-arg call sites elsewhere in this suite.
+    expect(facetStateToCursor(state, '', FACETS).no_progress_stalls).toBe(0)
+
+    // Round-trips through JSON like every other cursor field (the
+    // audit_logs metadata path), and a legacy row missing the field entirely
+    // reads back as `undefined` on the cursor, not a throw.
+    const roundTripped = JSON.parse(JSON.stringify(cursor))
+    expect(roundTripped.no_progress_stalls).toBe(2)
+    expect(cursorToFacetState(roundTripped)).toEqual({
+      facetIndex: 2,
+      pendingSubranges: [],
+      lastPage: 3,
+    })
+    const legacyCursor = { path: '', facet: '0-127', last_page: 0 }
+    expect(() => cursorToFacetState(legacyCursor)).not.toThrow()
+  })
 })

--- a/scripts/tests/indexer/rate-limit-fetch-timeout.test.ts
+++ b/scripts/tests/indexer/rate-limit-fetch-timeout.test.ts
@@ -1,0 +1,136 @@
+/**
+ * SMI-5964 §1a: per-request fetch timeout at the `withRateLimitTracking`
+ * chokepoint (Cases 11, 12, 14).
+ *
+ * MUST NOT mock `_shared/rate-limit.ts` -- `subdirectory-search.helpers.test.ts`
+ * mocks it wholesale (module-level `vi.mock`), which is exactly why these
+ * cases live in their own file. Cases 11/12 exercise the REAL platform
+ * `fetch`/`AbortSignal`/`ReadableStream` wiring against a real, in-process,
+ * deliberately-hanging `node:http` server -- a wired `global.fetch` stub
+ * cannot prove the body-read phase, because it never produces a genuine
+ * `ReadableStream` whose abort propagation is governed by the runtime rather
+ * than by the stub's own bookkeeping. Case 14 only needs to inspect what
+ * `init` a stubbed `fetch` received, so it stubs `global.fetch` directly.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { withRateLimitTracking, newRateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+
+const ENV_VAR = 'SKILLSMITH_INDEXER_FETCH_TIMEOUT_MS'
+
+describe('_shared/rate-limit.ts -- SMI-5964 per-request fetch timeout (§1a)', () => {
+  let originalEnv: string | undefined
+
+  beforeEach(() => {
+    originalEnv = process.env[ENV_VAR]
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[ENV_VAR]
+    else process.env[ENV_VAR] = originalEnv
+  })
+
+  describe('Case 11: a stalled HEADER phase', () => {
+    let server: Server
+    let baseUrl: string
+
+    beforeEach(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      server = createServer((_req, _res) => {
+        // Deliberately never call res.writeHead/res.end -- the header phase
+        // hangs forever on its own.
+      })
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+      const { port } = server.address() as AddressInfo
+      baseUrl = `http://127.0.0.1:${port}`
+    })
+
+    afterEach(async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    })
+
+    it('`withRateLimitTracking` rejects within the configured timeout instead of hanging', async () => {
+      process.env[ENV_VAR] = '50'
+      const telemetry = newRateLimitTelemetry()
+      await expect(withRateLimitTracking(telemetry, baseUrl)).rejects.toThrow()
+    }, 2_000)
+  })
+
+  describe('Case 12: a stalled BODY phase', () => {
+    let server: Server
+    let baseUrl: string
+
+    beforeEach(async () => {
+      server = createServer((_req, res) => {
+        // Flush headers + one chunk (chunked transfer -- no Content-Length),
+        // then hang -- the body phase stalls after the response resolves.
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.write('partial')
+        // Deliberately no res.end() -- the stream never completes on its own.
+      })
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+      const { port } = server.address() as AddressInfo
+      baseUrl = `http://127.0.0.1:${port}`
+    })
+
+    afterEach(async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    })
+
+    it("the response resolves (header phase fine) but a pending reader.read() aborts within the configured timeout -- proves §1a bounds readResponseWithLimit's reader.read() loop (skill-processor.security.ts:80) WITHOUT editing it", async () => {
+      process.env[ENV_VAR] = '50'
+      const telemetry = newRateLimitTelemetry()
+      const response = await withRateLimitTracking(telemetry, baseUrl)
+      expect(response.status).toBe(200)
+
+      const reader = response.body!.getReader()
+      // The already-flushed first chunk reads immediately.
+      const first = await reader.read()
+      expect(first.done).toBe(false)
+      // The NEXT read() would hang on the network forever -- the SAME
+      // AbortSignal that bounded the header phase must also bound this.
+      await expect(reader.read()).rejects.toThrow()
+    }, 2_000)
+  })
+
+  describe('Case 14: disable + caller-supplied signal passthrough', () => {
+    let originalFetch: typeof global.fetch
+
+    beforeEach(() => {
+      originalFetch = global.fetch
+    })
+    afterEach(() => {
+      global.fetch = originalFetch
+    })
+
+    it('SKILLSMITH_INDEXER_FETCH_TIMEOUT_MS=0 -- fetch receives an init with NO signal (byte-identical to pre-5964 behavior)', async () => {
+      process.env[ENV_VAR] = '0'
+      let capturedInit: RequestInit | undefined
+      global.fetch = (async (_url: string, init?: RequestInit) => {
+        capturedInit = init
+        return new Response('{}', { status: 200 })
+      }) as unknown as typeof global.fetch
+
+      const telemetry = newRateLimitTelemetry()
+      await withRateLimitTracking(telemetry, 'https://api.github.com/x')
+
+      expect(capturedInit?.signal).toBeUndefined()
+    })
+
+    it('a caller-supplied signal (the org-verification.ts:94 shape) is passed through UNMODIFIED, never overridden', async () => {
+      process.env[ENV_VAR] = '30' // active default -- must still not override a caller-supplied signal
+      let capturedInit: RequestInit | undefined
+      global.fetch = (async (_url: string, init?: RequestInit) => {
+        capturedInit = init
+        return new Response('{}', { status: 200 })
+      }) as unknown as typeof global.fetch
+
+      const callerSignal = AbortSignal.timeout(60_000)
+      const telemetry = newRateLimitTelemetry()
+      await withRateLimitTracking(telemetry, 'https://api.github.com/x', { signal: callerSignal })
+
+      expect(capturedInit?.signal).toBe(callerSignal)
+    })
+  })
+})

--- a/scripts/tests/indexer/subdirectory-search.budget.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.budget.test.ts
@@ -1,0 +1,258 @@
+/**
+ * SMI-5964 §1a/§1b/§1c: intra-page and intra-leaf budget tests.
+ *
+ * Split out of `subdirectory-search.helpers.test.ts` (Cases 4-9) when that
+ * file grew past the 500-line convention. Shares the same mock/fake-timer
+ * strategy documented there and in `scripts/tests/_lib/subdirectory-search-fixtures.ts`.
+ * Covers: a deadline crossing mid-page (via entry-processing, not code-search
+ * itself) holds the cursor at the previous page; a skill-cap trip mid-page is
+ * bounded to at most one repo's entries; the `acceptTruncation` leaf's own
+ * intra-leaf budget trip does NOT advance the facet (round-2 plan-review
+ * blocker 2, fixed in §1c).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+import {
+  LADDER_SIZE,
+  PER_PAGE,
+  resetRepoCounter,
+  fullPage,
+  shortPage,
+  saturatedPage,
+  makePlan,
+  leafCursor,
+} from '../_lib/subdirectory-search-fixtures.js'
+
+// ---------------------------------------------------------------------------
+// Module-level mocks -- declared before any import of the SUT
+// ---------------------------------------------------------------------------
+
+vi.mock('../../indexer/_shared/rate-limit.ts', () => ({
+  GITHUB_API_DELAY: 0,
+  delay: vi.fn(async () => undefined),
+  withRateLimitTracking: vi.fn(),
+  withBackoff: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  newRateLimitTelemetry: vi.fn(() => ({})),
+}))
+
+vi.mock('../../indexer/_shared/github-auth.ts', () => ({
+  buildGitHubHeaders: vi.fn(async () => ({})),
+}))
+
+const mockSearchCode = vi.fn()
+vi.mock('../../indexer/code-search.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/code-search.ts')>()
+  return {
+    ...actual,
+    searchCodeForSkillMdInSubdirectory: (...args: unknown[]) => mockSearchCode(...args),
+  }
+})
+
+const mockFetchRepoLicense = vi.fn()
+vi.mock('../../indexer/license-filter.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/license-filter.ts')>()
+  return {
+    ...actual,
+    fetchRepoLicense: (...args: unknown[]) => mockFetchRepoLicense(...args),
+  }
+})
+
+const mockCheckSkillMdExists = vi.fn()
+vi.mock('../../indexer/skill-processor.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/skill-processor.ts')>()
+  return {
+    ...actual,
+    checkSkillMdExists: (...args: unknown[]) => mockCheckSkillMdExists(...args),
+  }
+})
+
+const mockEnumerateRepoSkillPaths = vi.fn()
+vi.mock('../../indexer/trees-enumerate.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/trees-enumerate.ts')>()
+  return {
+    ...actual,
+    enumerateRepoSkillPaths: (...args: unknown[]) => mockEnumerateRepoSkillPaths(...args),
+  }
+})
+
+// SUT imported AFTER mocks so it binds the stubs.
+import { runSubdirectorySearch } from '../../indexer/subdirectory-search.ts'
+
+const noTelemetry: RateLimitTelemetry = {} as RateLimitTelemetry
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-07-01T00:00:00Z'))
+
+  resetRepoCounter()
+  mockSearchCode.mockReset()
+  mockFetchRepoLicense.mockReset()
+  mockCheckSkillMdExists.mockReset()
+  mockEnumerateRepoSkillPaths.mockReset()
+
+  mockFetchRepoLicense.mockResolvedValue({
+    license: 'MIT',
+    defaultBranch: 'main',
+    fetchFailed: false,
+  })
+  mockCheckSkillMdExists.mockResolvedValue(true)
+  mockEnumerateRepoSkillPaths.mockResolvedValue({
+    entries: [{ path: 'skills/x', blobSha: 'sha1' }],
+    truncatedByCap: false,
+    truncatedByApi: false,
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ---------------------------------------------------------------------------
+
+describe('runSubdirectorySearch -- SMI-5964 intra-page/intra-leaf budget (§1a/§1b/§1c)', () => {
+  it('Case 4: deadline crosses mid-page (via entry-processing mock, not code-search) -- cursor holds at the PREVIOUS page', async () => {
+    const budgetMs = 100
+    // No clock advance from the code-search mock -- page 1 fetches cleanly.
+    mockSearchCode.mockImplementation(async () => fullPage())
+    let skillCheckCount = 0
+    mockCheckSkillMdExists.mockImplementation(async () => {
+      skillCheckCount++
+      // Page 1 has PER_PAGE (100) repos, each with 1 skill -- call 101 is the
+      // FIRST skill of page 2. Page 1 completes cleanly before the budget crosses.
+      if (skillCheckCount === PER_PAGE + 1) {
+        vi.advanceTimersByTime(1000)
+      }
+      return true
+    })
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100, maxElapsedMs: budgetMs })
+    )
+    const backfill = result.backfill!
+
+    expect(backfill.done).toBe(false)
+    expect(backfill.cursor.facet_index).toBe(0)
+    expect(backfill.cursor.facet).not.toBe('done')
+    // Page 1 fully processed (100 admits) before the intra-page check on page 2
+    // caught the already-crossed budget -- cursor holds at the PREVIOUS page (1).
+    expect(backfill.cursor.last_page).toBe(1)
+    expect(backfill.cursor.pending_subranges).toEqual([])
+  })
+
+  it('Case 5: deadline crosses mid-page on a cold-start PAGE 1 (via entry-processing mock) -- cursor holds at page 0', async () => {
+    const budgetMs = 100
+    mockSearchCode.mockImplementation(async () => fullPage())
+    let skillCheckCount = 0
+    mockCheckSkillMdExists.mockImplementation(async () => {
+      skillCheckCount++
+      if (skillCheckCount === 1) {
+        vi.advanceTimersByTime(1000)
+      }
+      return true
+    })
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100, maxElapsedMs: budgetMs })
+    )
+    const backfill = result.backfill!
+
+    expect(backfill.done).toBe(false)
+    expect(backfill.cursor.facet_index).toBe(0)
+    // Cold start -- page 1 never completed, so last_page holds at 0 (its prior
+    // value). Resume re-enters at page 1 -- no gap, no lost work.
+    expect(backfill.cursor.last_page).toBe(0)
+    expect(backfill.cursor.pending_subranges).toEqual([])
+  })
+
+  it("Case 6: intra-page skill cap trips mid-page -- overshoot bounded to at most one repo's entries, cursor holds", async () => {
+    const cap = 5
+    const entriesPerRepo = 3
+    mockSearchCode.mockImplementation(async () => fullPage()) // no clock advance -- pure skill-cap test
+    mockEnumerateRepoSkillPaths.mockResolvedValue({
+      entries: Array.from({ length: entriesPerRepo }, (_v, i) => ({
+        path: `skills/${i}`,
+        blobSha: `sha-${i}`,
+      })),
+      truncatedByCap: false,
+      truncatedByApi: false,
+    })
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100, maxSkillsPerDispatch: cap })
+    )
+    const backfill = result.backfill!
+
+    expect(backfill.done).toBe(false)
+    expect(backfill.cursor.facet_index).toBe(0)
+    expect(backfill.cursor.last_page).toBe(0)
+    expect(backfill.cursor.pending_subranges).toEqual([])
+    // Stopped well short of the full page's potential admits (100 repos * 3
+    // skills each), and the overshoot past the cap is bounded to at most one
+    // repo's entries -- the loop-top check in process.ts fires before the
+    // FULL page (or even a full repo beyond the boundary) can be consumed.
+    expect(result.admitted).toBeGreaterThanOrEqual(cap)
+    expect(result.admitted).toBeLessThan(PER_PAGE * entriesPerRepo)
+    expect(result.admitted - cap).toBeLessThanOrEqual(entriesPerRepo)
+  })
+
+  it('Case 7: maxElapsedMs=0 AND maxSkillsPerDispatch=0 together stay fully disabled (compound regression guard)', async () => {
+    mockSearchCode.mockImplementation(async () => shortPage())
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100, maxElapsedMs: 0, maxSkillsPerDispatch: 0 })
+    )
+    const backfill = result.backfill!
+    expect(backfill.done).toBe(true)
+    expect(backfill.facets_completed).toBe(LADDER_SIZE)
+    expect(backfill.cursor.facet).toBe('done')
+  })
+
+  it('Case 9: acceptTruncation leaf -- an intra-leaf budget trip does NOT advance the facet (review blocker 2)', async () => {
+    mockSearchCode.mockImplementation(async () => saturatedPage(10))
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({
+        maxRangesPerDispatch: 100,
+        maxSkillsPerDispatch: 5,
+        acceptTruncation: true,
+        startCursor: leafCursor(),
+      })
+    )
+    const backfill = result.backfill!
+
+    // advanceFacet NOT taken: facet_index/pending_subranges unchanged from the
+    // seeded cursor, last_page stays 0, done=false.
+    expect(backfill.cursor.facet_index).toBe(0)
+    expect(backfill.cursor.pending_subranges).toEqual([[5, 5]])
+    expect(backfill.cursor.last_page).toBe(0)
+    expect(backfill.done).toBe(false)
+    // Observability preserved: the leaf is still recorded truncated even
+    // though the budget (not the saturation cap) is what stopped it this time.
+    expect(backfill.truncated_repo_count).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/scripts/tests/indexer/subdirectory-search.escalation.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.escalation.test.ts
@@ -1,0 +1,417 @@
+/**
+ * SMI-5964 §1e: no-progress escalation termination bound.
+ *
+ * Split out of `subdirectory-search.helpers.test.ts` (Cases 10, 15-17) when
+ * that file grew past the 500-line convention. Shares the same mock/fake-timer
+ * strategy documented there and in `scripts/tests/_lib/subdirectory-search-fixtures.ts`.
+ *
+ * Proves the termination bound at all three stop sites the escalation covers
+ * (the `acceptTruncation` leaf's cap-suppression limb, its forced-progress
+ * limb, and the §1b page-loop twin), plus counter-hygiene edge cases (a
+ * legacy resume cursor with the field absent, cross-position immunity per the
+ * still-open SMI-5333 unfiltered-read gap, and a net-progress reset). Every
+ * multi-dispatch case self-checks that all dispatches share byte-identical
+ * plan knobs except `startCursor` -- round-2 plan review found the original
+ * Case 10 masked the livelock defect by quietly widening a later dispatch's
+ * budget; these tests cannot pass that way.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+import type { BackfillFacetPlan } from '../../indexer/subdirectory-search.ts'
+import type { BackfillCursor } from '../../indexer/backfill-checkpoint.ts'
+import {
+  PER_PAGE,
+  resetRepoCounter,
+  makeCodeSearchRepo,
+  shortPage,
+  saturatedPage,
+  makePlan,
+  omitStartCursor,
+  leafCursor,
+  pageCursor,
+} from '../_lib/subdirectory-search-fixtures.js'
+
+// ---------------------------------------------------------------------------
+// Module-level mocks -- declared before any import of the SUT
+// ---------------------------------------------------------------------------
+
+vi.mock('../../indexer/_shared/rate-limit.ts', () => ({
+  GITHUB_API_DELAY: 0,
+  delay: vi.fn(async () => undefined),
+  withRateLimitTracking: vi.fn(),
+  withBackoff: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  newRateLimitTelemetry: vi.fn(() => ({})),
+}))
+
+vi.mock('../../indexer/_shared/github-auth.ts', () => ({
+  buildGitHubHeaders: vi.fn(async () => ({})),
+}))
+
+const mockSearchCode = vi.fn()
+vi.mock('../../indexer/code-search.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/code-search.ts')>()
+  return {
+    ...actual,
+    searchCodeForSkillMdInSubdirectory: (...args: unknown[]) => mockSearchCode(...args),
+  }
+})
+
+const mockFetchRepoLicense = vi.fn()
+vi.mock('../../indexer/license-filter.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/license-filter.ts')>()
+  return {
+    ...actual,
+    fetchRepoLicense: (...args: unknown[]) => mockFetchRepoLicense(...args),
+  }
+})
+
+const mockCheckSkillMdExists = vi.fn()
+vi.mock('../../indexer/skill-processor.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/skill-processor.ts')>()
+  return {
+    ...actual,
+    checkSkillMdExists: (...args: unknown[]) => mockCheckSkillMdExists(...args),
+  }
+})
+
+const mockEnumerateRepoSkillPaths = vi.fn()
+vi.mock('../../indexer/trees-enumerate.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/trees-enumerate.ts')>()
+  return {
+    ...actual,
+    enumerateRepoSkillPaths: (...args: unknown[]) => mockEnumerateRepoSkillPaths(...args),
+  }
+})
+
+// SUT imported AFTER mocks so it binds the stubs.
+import { runSubdirectorySearch } from '../../indexer/subdirectory-search.ts'
+// SMI-5964: NO_PROGRESS_ESCALATION_THRESHOLD is not re-exported through
+// subdirectory-search.ts's re-export chain -- imported directly.
+import { NO_PROGRESS_ESCALATION_THRESHOLD } from '../../indexer/subdirectory-search.helpers.ts'
+
+const noTelemetry: RateLimitTelemetry = {} as RateLimitTelemetry
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-07-01T00:00:00Z'))
+
+  resetRepoCounter()
+  mockSearchCode.mockReset()
+  mockFetchRepoLicense.mockReset()
+  mockCheckSkillMdExists.mockReset()
+  mockEnumerateRepoSkillPaths.mockReset()
+
+  mockFetchRepoLicense.mockResolvedValue({
+    license: 'MIT',
+    defaultBranch: 'main',
+    fetchFailed: false,
+  })
+  mockCheckSkillMdExists.mockResolvedValue(true)
+  mockEnumerateRepoSkillPaths.mockResolvedValue({
+    entries: [{ path: 'skills/x', blobSha: 'sha1' }],
+    truncatedByCap: false,
+    truncatedByApi: false,
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ---------------------------------------------------------------------------
+
+describe('runSubdirectorySearch -- SMI-5964 no-progress escalation termination bound (§1e)', () => {
+  it('NO_PROGRESS_ESCALATION_THRESHOLD is 2 -- the smallest value that never escalates a recoverable single-dispatch stall while still bounding the termination cost at N+1=3 dispatches per position', () => {
+    expect(NO_PROGRESS_ESCALATION_THRESHOLD).toBe(2)
+  })
+
+  it('Case 10: same-cap acceptTruncation livelock terminates by escalation at dispatch N+1 (cap-suppression limb)', async () => {
+    const sharedPlan: Omit<BackfillFacetPlan, 'startCursor'> = {
+      pathPrefix: undefined,
+      perPage: PER_PAGE,
+      maxPagesPerRange: 20,
+      maxRangesPerDispatch: 100,
+      maxSkillsPerDispatch: 5,
+      maxElapsedMs: 0,
+      acceptTruncation: true,
+    }
+
+    // Every page-1 query for the leaf ('size:5..5') saturates with MORE admits
+    // (10 repos, 1 skill each) than the shared cap (5). Any OTHER qualifier
+    // (reached only once the leaf retires) gets a normal, non-saturated
+    // short page.
+    mockSearchCode.mockImplementation(
+      async (
+        _prefix: unknown,
+        _page: unknown,
+        _perPage: unknown,
+        _telemetry: unknown,
+        qualifier: unknown
+      ) => (qualifier === 'size:5..5' ? saturatedPage(10) : shortPage())
+    )
+
+    const warnSpy = vi.spyOn(console, 'warn')
+
+    const plan1: BackfillFacetPlan = { ...sharedPlan, startCursor: leafCursor() }
+    const d1 = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry, plan1)
+    const b1 = d1.backfill!
+
+    const plan2: BackfillFacetPlan = { ...sharedPlan, startCursor: b1.cursor }
+    const d2 = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry, plan2)
+    const b2 = d2.backfill!
+
+    const plan3: BackfillFacetPlan = { ...sharedPlan, startCursor: b2.cursor }
+    const d3 = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry, plan3)
+    const b3 = d3.backfill!
+
+    const plan4: BackfillFacetPlan = { ...sharedPlan, startCursor: b3.cursor }
+    const d4 = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry, plan4)
+    const b4 = d4.backfill!
+
+    // (a) Self-check: every knob except startCursor is byte-identical across
+    // all four dispatches -- the test cannot pass by quietly widening a later
+    // dispatch's budget.
+    expect(omitStartCursor(plan2)).toEqual(omitStartCursor(plan1))
+    expect(omitStartCursor(plan3)).toEqual(omitStartCursor(plan1))
+    expect(omitStartCursor(plan4)).toEqual(omitStartCursor(plan1))
+
+    // (b) D1 stops in the leaf, holding the cursor.
+    expect(b1.cursor.facet_index).toBe(0)
+    expect(b1.cursor.pending_subranges).toEqual([[5, 5]])
+    expect(b1.cursor.last_page).toBe(0)
+    expect(b1.cursor.no_progress_stalls).toBe(1)
+
+    // (c) D2, the SAME shared cap: still does NOT advance -- the livelock is
+    // real, so this fails loudly if the escalation is ever removed.
+    expect(b2.cursor.pending_subranges).toEqual([[5, 5]])
+    expect(b2.cursor.no_progress_stalls).toBe(2)
+
+    // (d) D3: escalation fires on the CAP-SUPPRESSION limb -- the cap is
+    // provably suppressed (admits exceed it), the leaf retires (cursor
+    // strictly past it), and the counter resets to 0.
+    expect(d3.admitted).toBeGreaterThan(sharedPlan.maxSkillsPerDispatch!)
+    expect(b3.cursor.pending_subranges).not.toEqual([[5, 5]])
+    expect(b3.cursor.facet).not.toBe('5-5')
+    expect(b3.cursor.no_progress_stalls).toBe(0)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/ESCALATED past no-progress position/)
+    )
+
+    // (e) D4 (from D3's cursor) does NOT re-enter the retired leaf.
+    expect(b4.cursor.facet).not.toBe('5-5')
+    expect(b4.cursor.pending_subranges).not.toEqual([[5, 5]])
+
+    warnSpy.mockRestore()
+  })
+
+  it('Case 15: deadline-caused acceptTruncation livelock terminates by FORCED-PROGRESS escalation (not cap suppression)', async () => {
+    const sharedPlan: Omit<BackfillFacetPlan, 'startCursor'> = {
+      pathPrefix: undefined,
+      perPage: PER_PAGE,
+      maxPagesPerRange: 20,
+      maxRangesPerDispatch: 100,
+      maxSkillsPerDispatch: 0, // disabled -- ONLY the deadline governs
+      maxElapsedMs: 100,
+      acceptTruncation: true,
+    }
+
+    mockSearchCode.mockImplementation(
+      async (
+        _prefix: unknown,
+        _page: unknown,
+        _perPage: unknown,
+        _telemetry: unknown,
+        qualifier: unknown
+      ) => (qualifier === 'size:5..5' ? saturatedPage(3) : shortPage())
+    )
+    // Every checkSkillMdExists call advances the clock well past the 100ms
+    // budget -- so admitting even ONE skill always crosses the deadline
+    // before the NEXT repo's top-of-loop check, on EVERY dispatch (cap
+    // suppression cannot rescue this one -- there never was a cap).
+    mockCheckSkillMdExists.mockImplementation(async () => {
+      vi.advanceTimersByTime(1000)
+      return true
+    })
+
+    const warnSpy = vi.spyOn(console, 'warn')
+
+    const plan1: BackfillFacetPlan = { ...sharedPlan, startCursor: leafCursor() }
+    const d1 = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry, plan1)
+    const b1 = d1.backfill!
+
+    const plan2: BackfillFacetPlan = { ...sharedPlan, startCursor: b1.cursor }
+    const d2 = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry, plan2)
+    const b2 = d2.backfill!
+
+    const plan3: BackfillFacetPlan = { ...sharedPlan, startCursor: b2.cursor }
+    const d3 = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry, plan3)
+    const b3 = d3.backfill!
+
+    expect(omitStartCursor(plan2)).toEqual(omitStartCursor(plan1))
+    expect(omitStartCursor(plan3)).toEqual(omitStartCursor(plan1))
+
+    // D1/D2 hold the leaf -- the deadline stops every attempt.
+    expect(b1.cursor.pending_subranges).toEqual([[5, 5]])
+    expect(b1.cursor.no_progress_stalls).toBe(1)
+    expect(b2.cursor.pending_subranges).toEqual([[5, 5]])
+    expect(b2.cursor.no_progress_stalls).toBe(2)
+
+    // D3 escalates on the FORCED-PROGRESS limb: cap suppression is irrelevant
+    // here (there was never a cap) -- the deadline STILL trips, so the leaf is
+    // forced forward instead, recorded truncated, and the counter resets to 0.
+    expect(b3.cursor.pending_subranges).not.toEqual([[5, 5]])
+    expect(b3.cursor.no_progress_stalls).toBe(0)
+    expect(b3.truncated_repo_count).toBeGreaterThanOrEqual(1)
+    expect(d3.errors.some((e) => /escalated past a no-progress/.test(e))).toBe(true)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/ESCALATED past no-progress position/)
+    )
+
+    warnSpy.mockRestore()
+  })
+
+  it('Case 16: §1b page-loop twin -- same-cap livelock off the truncation path terminates by FORCED-PROGRESS escalation', async () => {
+    const sharedPlan: Omit<BackfillFacetPlan, 'startCursor'> = {
+      pathPrefix: undefined,
+      perPage: PER_PAGE,
+      maxPagesPerRange: 20,
+      maxRangesPerDispatch: 100,
+      maxSkillsPerDispatch: 5,
+      maxElapsedMs: 100,
+      acceptTruncation: false,
+    }
+    const P = 2 // resuming at page 2 (startCursor.last_page = 1 = P-1)
+
+    // A normal (non-saturated) page carrying MORE admits (8) than the shared
+    // cap (5) -- the same livelock shape as Case 10, one call site over.
+    mockSearchCode.mockImplementation(async () => ({
+      repos: Array.from({ length: 8 }, () => makeCodeSearchRepo()),
+      total: 500,
+      retries: 0,
+      incomplete_results: false,
+    }))
+
+    const warnSpy = vi.spyOn(console, 'warn')
+
+    const plan1: BackfillFacetPlan = { ...sharedPlan, startCursor: pageCursor(P - 1) }
+    const d1 = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry, plan1)
+    const b1 = d1.backfill!
+
+    const plan2: BackfillFacetPlan = { ...sharedPlan, startCursor: b1.cursor }
+    const d2 = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry, plan2)
+    const b2 = d2.backfill!
+
+    // D3's escalated (cap-suppressed) attempt STILL stops -- this time on the
+    // deadline -- exercising the ONE guarded `state.lastPage = page`
+    // assignment §1b's "forbidden variant" clause permits.
+    mockCheckSkillMdExists.mockImplementation(async () => {
+      vi.advanceTimersByTime(1000)
+      return true
+    })
+    const plan3: BackfillFacetPlan = { ...sharedPlan, startCursor: b2.cursor }
+    const d3 = await runSubdirectorySearch(new Set(), new Map(), {}, 1, noTelemetry, plan3)
+    const b3 = d3.backfill!
+
+    expect(omitStartCursor(plan2)).toEqual(omitStartCursor(plan1))
+    expect(omitStartCursor(plan3)).toEqual(omitStartCursor(plan1))
+
+    // D1/D2 hold at page P-1 -- state.lastPage is NEVER touched by these two
+    // dispatches (the "forbidden variant" stays unreachable by default).
+    expect(b1.cursor.last_page).toBe(P - 1)
+    expect(b1.cursor.no_progress_stalls).toBe(1)
+    expect(b2.cursor.last_page).toBe(P - 1)
+    expect(b2.cursor.no_progress_stalls).toBe(2)
+
+    // D3: state.lastPage moves to P via the ONE guarded, escalation-only
+    // assignment; the counter resets to 0.
+    expect(b3.cursor.last_page).toBe(P)
+    expect(b3.cursor.no_progress_stalls).toBe(0)
+    expect(b3.truncated_repo_count).toBeGreaterThanOrEqual(1)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/ESCALATED past no-progress position/)
+    )
+
+    warnSpy.mockRestore()
+  })
+
+  it('Case 17a: a legacy resume cursor (no_progress_stalls absent) reads as 0 -- never escalates early, never throws', async () => {
+    mockSearchCode.mockImplementation(async () => saturatedPage(10))
+    const legacyCursor: BackfillCursor = {
+      path: '',
+      facet: '5-5',
+      last_page: 0,
+      facet_index: 0,
+      pending_subranges: [[5, 5]],
+      // no_progress_stalls intentionally OMITTED -- simulates a pre-SMI-5964 row.
+    }
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({
+        maxRangesPerDispatch: 100,
+        maxSkillsPerDispatch: 5,
+        acceptTruncation: true,
+        startCursor: legacyCursor,
+      })
+    )
+    const backfill = result.backfill!
+
+    // Reads as 0 -- holds the leaf exactly like a fresh first attempt (no
+    // throw on the missing field, no premature escalation).
+    expect(backfill.cursor.pending_subranges).toEqual([[5, 5]])
+    expect(backfill.cursor.no_progress_stalls).toBe(1)
+  })
+
+  it('Case 17b: an inherited no_progress_stalls at a DIFFERENT position (SMI-5333 cross-path immunity) is not inherited', async () => {
+    mockSearchCode.mockImplementation(async () => saturatedPage(10))
+    // The incoming cursor claims 2 prior stalls, but under a DIFFERENT `path`
+    // -- e.g. a checkpoint written under a different BACKFILL_PATH_PREFIX,
+    // reachable via the still-open SMI-5333 unfiltered-read gap.
+    const foreignPathCursor: BackfillCursor = {
+      path: '.some-other-prefix/skills',
+      facet: '5-5',
+      last_page: 0,
+      facet_index: 0,
+      pending_subranges: [[5, 5]],
+      no_progress_stalls: 2,
+    }
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({
+        maxRangesPerDispatch: 100,
+        maxSkillsPerDispatch: 5,
+        acceptTruncation: true,
+        pathPrefix: undefined, // crawling the BROAD query (path '') this time
+        startCursor: foreignPathCursor,
+      })
+    )
+    const backfill = result.backfill!
+
+    // Treated as a first attempt AT THIS position (path '' !== the foreign
+    // cursor's path) -- holds rather than escalating.
+    expect(backfill.cursor.no_progress_stalls).toBe(1)
+  })
+
+  it('Case 17c: a dispatch that makes net progress writes no_progress_stalls=0', async () => {
+    mockSearchCode.mockImplementation(async () => shortPage())
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 3 })
+    )
+    expect(result.backfill!.cursor.no_progress_stalls).toBe(0)
+  })
+})

--- a/scripts/tests/indexer/subdirectory-search.helpers.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.helpers.test.ts
@@ -26,10 +26,23 @@
  * Mock strategy: mirrors backfill-facet-crawl.test.ts / backfill-skill-cap.test.ts
  * -- every I/O boundary stubbed at the module level, SUT imported after the mocks,
  * driven through the public entry `runSubdirectorySearch(..., backfillPlan)`.
+ *
+ * SMI-5964: the intra-page/intra-leaf budget tests (Cases 4-9) and the
+ * no-progress-escalation tests (Cases 10, 15-17) split out to
+ * `subdirectory-search.budget.test.ts` / `subdirectory-search.escalation.test.ts`
+ * when this file grew past the 500-line convention. Pure fixture factories now
+ * live in `scripts/tests/_lib/subdirectory-search-fixtures.ts`, shared by all three.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { RateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+import {
+  LADDER_SIZE,
+  resetRepoCounter,
+  fullPage,
+  shortPage,
+  makePlan,
+} from '../_lib/subdirectory-search-fixtures.js'
 
 // ---------------------------------------------------------------------------
 // Module-level mocks -- declared before any import of the SUT
@@ -85,62 +98,9 @@ vi.mock('../../indexer/trees-enumerate.ts', async (importOriginal) => {
 })
 
 // SUT imported AFTER mocks so it binds the stubs.
-import { runSubdirectorySearch, type BackfillFacetPlan } from '../../indexer/subdirectory-search.ts'
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+import { runSubdirectorySearch } from '../../indexer/subdirectory-search.ts'
 
 const noTelemetry: RateLimitTelemetry = {} as RateLimitTelemetry
-const LADDER_SIZE = 9
-const PER_PAGE = 100
-
-let repoCounter = 0
-function makeCodeSearchRepo(overrides: Record<string, unknown> = {}) {
-  repoCounter += 1
-  const owner = `elapsed-owner${repoCounter}`
-  return {
-    owner,
-    name: 'skills-repo',
-    fullName: `${owner}/skills-repo`,
-    description: 'test',
-    url: `https://github.com/${owner}/skills-repo/tree/main/skills/x`,
-    stars: 5,
-    forks: 0,
-    topics: ['claude-code-skill'],
-    updatedAt: new Date().toISOString(),
-    defaultBranch: 'main',
-    installable: false,
-    repoName: 'skills-repo',
-    skillPath: 'skills/x',
-    discoveryPath: 'subdirectory_search:broad',
-    ...overrides,
-  }
-}
-
-/** A FULL page (repos.length === perPage): total <= cap so no saturation/bisect,
- *  but the page is NOT short, so the range does NOT exhaust and keeps paginating. */
-function fullPage() {
-  const repos = Array.from({ length: PER_PAGE }, () => makeCodeSearchRepo())
-  return { repos, total: 500, retries: 0, incomplete_results: false }
-}
-
-/** A single-repo short page: total under the cap, repos.length < perPage, so the
- *  range exhausts in one page (clean advance). */
-function shortPage() {
-  return { repos: [makeCodeSearchRepo()], total: 5, retries: 0, incomplete_results: false }
-}
-
-function makePlan(overrides: Partial<BackfillFacetPlan> = {}): BackfillFacetPlan {
-  return {
-    startCursor: null,
-    pathPrefix: undefined,
-    perPage: PER_PAGE,
-    maxPagesPerRange: 20,
-    maxRangesPerDispatch: 100,
-    ...overrides,
-  }
-}
 
 beforeEach(() => {
   // F-3: fake timers make Date.now() deterministic. Established at a fixed epoch
@@ -148,7 +108,7 @@ beforeEach(() => {
   vi.useFakeTimers()
   vi.setSystemTime(new Date('2026-07-01T00:00:00Z'))
 
-  repoCounter = 0
+  resetRepoCounter()
   mockSearchCode.mockReset()
   mockFetchRepoLicense.mockReset()
   mockCheckSkillMdExists.mockReset()
@@ -178,10 +138,19 @@ describe('runSubdirectorySearch -- SMI-5448 elapsed-time budget guard', () => {
   it('Case 1: mid-range trip -- cursor holds at lastPage, facet not advanced, done=false', async () => {
     const budgetMs = 100
     // Facet 0 returns FULL pages (never short-exhausts). The code-search mock
-    // advances the fake clock past the budget as page 1 is fetched, so after
-    // page 1 is processed (state.lastPage = 1) the mid-range elapsed check trips:
-    // timedOut = true, break, NO advanceFacet. Every call advances 1000ms so the
-    // budget is already crossed on the first inter-page check.
+    // advances the fake clock past the budget as page 1 is FETCHED (before
+    // `processSearchResults` for that page is ever called), so by the time
+    // page 1's per-repo processing begins the budget is already exceeded.
+    //
+    // SMI-5964: `processSearchResults` now checks the deadline at the TOP of
+    // its own per-repo loop (§1b), which is reached BEFORE the pre-existing
+    // SMI-5448 mid-range check (positioned after `state.lastPage = page`). So
+    // this scenario is now caught by the FINER-grained intra-page check,
+    // before page 1 processes a single repo -- catching the crossing sooner
+    // than the pre-5964 per-page granularity did (the whole point of §1b).
+    // `state.lastPage` therefore holds at its PRIOR value (0, page 1 never
+    // completed) rather than 1. Every call advances 1000ms so the budget is
+    // already crossed on the very first check.
     mockSearchCode.mockImplementation(async () => {
       vi.advanceTimersByTime(1000) // push Date.now() well past the 100ms budget
       return fullPage()
@@ -205,9 +174,11 @@ describe('runSubdirectorySearch -- SMI-5448 elapsed-time budget guard', () => {
     // Cursor NOT advanced: still on the first facet (index 0, sentinel not 'done').
     expect(backfill.cursor.facet_index).toBe(0)
     expect(backfill.cursor.facet).not.toBe('done')
-    // Cursor holds at the last fully-processed page (page 1), so resume re-enters
-    // at lastPage+1 = page 2 -- no gap, no lost work.
-    expect(backfill.cursor.last_page).toBe(1)
+    // SMI-5964: cursor holds at page 0 (no page fully processed) -- the
+    // intra-page check caught the already-crossed budget before page 1's
+    // per-repo processing started. Resume re-enters at page 1 -- no gap, no
+    // lost work (page 1 was never partially admitted either).
+    expect(backfill.cursor.last_page).toBe(0)
     // The bisection frontier is untouched (range was not bisected).
     expect(backfill.cursor.pending_subranges).toEqual([])
   })
@@ -215,10 +186,21 @@ describe('runSubdirectorySearch -- SMI-5448 elapsed-time budget guard', () => {
   it('Case 2: range-boundary trip across multiple small ranges -> clean advanced cursor', async () => {
     const budgetMs = 100
     // Every facet exhausts in ONE short page (clean advance). The clock advances
-    // per page so the cumulative elapsed crosses the budget at a RANGE BOUNDARY
-    // (after advanceFacet), taking the range-boundary break, not the mid-range one.
+    // per page so the cumulative elapsed crosses the budget while FETCHING the
+    // next range's page 1.
+    //
+    // SMI-5964: because the crossing happens inside the code-search mock (i.e.
+    // before that range's `processSearchResults` call), the intra-page check
+    // (§1b) now intercepts it at the START of that range -- before it can
+    // reach the pre-existing range-boundary check (which sits even later,
+    // after that range's own post-page branch). So the range this trips on
+    // does NOT get a chance to advance; only the ranges BEFORE it do. This is
+    // the same "caught sooner" property as Case 1 -- the range-boundary check
+    // remains reachable in production for a genuine cumulative-but-no-single-
+    // page-slow crossing (real wall-clock time, not an atomic fake-timer jump
+    // inside one mock call).
     mockSearchCode.mockImplementation(async () => {
-      vi.advanceTimersByTime(60) // 60ms/range -> budget (100ms) crossed after range 2
+      vi.advanceTimersByTime(60) // 60ms/range -> budget (100ms) crossed fetching range 2
       return shortPage()
     })
 
@@ -236,9 +218,12 @@ describe('runSubdirectorySearch -- SMI-5448 elapsed-time budget guard', () => {
     expect(backfill.ranges_crawled).toBeLessThan(LADDER_SIZE)
     expect(backfill.ranges_crawled).toBeGreaterThanOrEqual(2)
     expect(backfill.done).toBe(false)
-    // Cursor is ADVANCED (clean boundary): facet_index equals the number of fully
-    // completed ranges, and last_page reset to 0 for the next (un-entered) facet.
-    expect(backfill.cursor.facet_index).toBe(backfill.ranges_crawled)
+    // SMI-5964: the LAST range attempted is the one whose page-1 fetch crossed
+    // the budget -- it is intercepted intra-page (§1b) and does NOT advance.
+    // Every range BEFORE it completed cleanly and did advance, so facet_index
+    // is one less than ranges_crawled (the attempted-but-stopped range still
+    // counts toward ranges_crawled). last_page reset to 0 for that stopped range.
+    expect(backfill.cursor.facet_index).toBe(backfill.ranges_crawled - 1)
     expect(backfill.cursor.facet).not.toBe('done')
     expect(backfill.cursor.last_page).toBe(0)
     expect(backfill.cursor.pending_subranges).toEqual([])
@@ -267,7 +252,7 @@ describe('runSubdirectorySearch -- SMI-5448 elapsed-time budget guard', () => {
     expect(zeroBackfill.cursor.facet).toBe('done')
 
     // Regression parity: a plan with the field OMITTED reaches the same terminal.
-    repoCounter = 0
+    resetRepoCounter()
     mockSearchCode.mockImplementation(async () => {
       vi.advanceTimersByTime(10_000)
       return shortPage()

--- a/scripts/tests/indexer/subdirectory-search.validation-cache-roundtrip.test.ts
+++ b/scripts/tests/indexer/subdirectory-search.validation-cache-roundtrip.test.ts
@@ -133,7 +133,11 @@ describe('SMI-5930: validationCache round-trip through processSearchResults (rea
 
     const validationCache = new Map<string, SkillMdValidation>()
     const repos: GitHubRepository[] = []
-    await processSearchResults(
+    // SMI-5964 Case 8: `budget` omitted entirely -- the exact shape the two
+    // cron call sites (subdirectory-search.ts:238, :292) use. Must return
+    // { stopped: false } and consume every input repo, proving the cron path
+    // is byte-identical to pre-5964 behavior.
+    const outcome = await processSearchResults(
       [makeResultRepo('GeoloeG-IsT', 'pitch', null)],
       new Set(),
       validationCache,
@@ -152,6 +156,7 @@ describe('SMI-5930: validationCache round-trip through processSearchResults (rea
       new Map()
     )
 
+    expect(outcome).toEqual({ stopped: false })
     expect(repos).toHaveLength(2)
     const names = repos.map((repo) => {
       const validation = getCachedValidation(


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixes a bug where the backfill indexer could silently lose thousands of discovered skills. A prior dispatch lost ~13,488 admitted skills when GitHub's own 330-minute hard time limit killed the job 59 seconds before the indexer's internal safety checkpoint finished writing — and because of a second bug, the failure alert never fired, so nobody was told. Three changes close this: (1) every network request the indexer makes now has its own 30-second timeout, so one dense/slow page of work can no longer silently eat most of the safety margin; (2) a stuck spot in the crawl now automatically escalates and forces itself forward within at most 3 attempts, instead of potentially retrying forever; (3) a new, independent alert watcher now reliably notifies on any cancelled run, from outside the job that died, so this class of loss can never go unnoticed again.

**Quality bar:** Went through three rounds of adversarial review by a second AI model (GPT-5.6-Sol, independent of Claude) before implementation began — round 1 rejected the first design outright (3 real blockers); round 2 caught a subtle livelock bug in the revised fix; round 3 approved with one small precision correction. During implementation, three more real bugs were found and fixed in the reviewed design's own code sketches (independently re-verified, not just trusted). Full monorepo test suite green (1075/1075 relevant tests), clean lint/typecheck/security audit, zero findings in a follow-up code review.

**Found along the way:** the regular (non-backfill) indexer cron has the identical missing-alert pattern on its own timeout — filed separately as SMI-5974 (not fixed here, to avoid an unrelated file conflict with a concurrently-landing sibling fix).

**Net result:** Fully shipped. One residual, disclosed limitation: the fetch timeout bounds network wait time but not CPU-bound content-scanning time on a maliciously large file — an existing, separately-reviewed security surface, documented as a known residual risk rather than silently ignored.

---

## Technical detail

- `scripts/indexer/_shared/rate-limit.ts` — `AbortSignal.timeout()` (default 30s, `SKILLSMITH_INDEXER_FETCH_TIMEOUT_MS` opt-out) at the single fetch chokepoint every indexer request routes through, generalizing an existing precedent (`org-verification.ts`, SMI-4743).
- `scripts/indexer/subdirectory-search.process.ts` / `.helpers.ts` / `.escalation.ts` (new) — deadline + skill-cap budget threaded into both crawl call sites; a position-scoped `no_progress_stalls` counter on the checkpoint cursor with a two-limb forward-progress escalation, guaranteeing termination within 3 dispatches at any position. Preserves the existing SMI-5448 mutual-exclusivity invariant exactly.
- `scripts/indexer/backfill-checkpoint.ts` — additive-only cursor field; `run.ts` untouched.
- `.github/workflows/indexer-backfill-watch.yml` (new) — `workflow_run`-triggered watcher, independent 5-min budget, fail-open classification (never gates whether the alert fires, only labels it).
- `.github/workflows/indexer-backfill.yml` — 2 hunks: input description update, alert-notify HTTP-code capture (was silently swallowed via `|| true`). No `if:`/`timeout-minutes` changes; all 8 `workflow_dispatch` input names unchanged (a live driver session depends on these).
- Does not touch `.github/workflows/indexer.yml` or `scripts/indexer/run.ts`.
- Test suite for the new logic split across `subdirectory-search.helpers.test.ts` / `.budget.test.ts` / `.escalation.test.ts` plus a new shared `_lib/subdirectory-search-fixtures.ts` — the original single-file implementation grew to 807 lines adding the new cases, caught by the pre-commit file-length gate and split before commit.
- ADR-109 infra-change gate satisfied — plan doc: `docs/internal/implementation/smi-5964-backfill-checkpoint-timing.md` (4 revisions, 3 adversarial review rounds documented in full).

Refs SMI-5964