### PR TITLE
fix(indexer): SMI-5974 close cron indexer.yml's missing-alert-on-cancelled gap

### DIFF
--- a/.github/workflows/indexer-watch.yml
+++ b/.github/workflows/indexer-watch.yml
@@ -89,8 +89,13 @@ jobs:
           parse_ts() {
             date -u -d "$1" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$1" +%s 2>/dev/null
           }
-          STARTED=$(parse_ts "$RUN_STARTED_AT")
-          ENDED=$(parse_ts "$RUN_UPDATED_AT")
+          # NEEDLE code review: under `set -e`, a bare `VAR=$(parse_ts ...)`
+          # exits the whole step immediately when parse_ts's own two-attempt
+          # fallback both fail -- the "|| VAR=" here is required so a
+          # malformed timestamp reaches the fail-open check below instead of
+          # silently killing the step (which would itself skip the alert).
+          STARTED=$(parse_ts "$RUN_STARTED_AT") || STARTED=""
+          ENDED=$(parse_ts "$RUN_UPDATED_AT") || ENDED=""
 
           # Fail-open: an unparseable timestamp degrades to ELAPSED_MIN=0
           # (never classified as a likely timeout-kill) rather than aborting

--- a/.github/workflows/indexer-watch.yml
+++ b/.github/workflows/indexer-watch.yml
@@ -1,0 +1,154 @@
+# SMI-5974: Skill Indexer (cron/dispatch) alert-gap watcher.
+#
+# PROBLEM: `indexer.yml`'s `index` job has `timeout-minutes: 30`. A job killed
+# by that job-level timeout concludes `cancelled`, not `failure` -- and both
+# of the workflow's existing alert steps (`Report Failure`, `Send Alert on
+# Failure`) are gated `if: failure()`. `cancelled()` and `failure()` are
+# disjoint in GitHub Actions, so a timeout-kill produces NO step summary, NO
+# alert-notify call, and NO email -- confirmed via `gh run list` (not
+# theoretical): 2 genuine timeout-kills in the last ~800 runs (2026-07-10,
+# 2026-07-13, both the discovery Phase-1 cron slot, both ran the full 30
+# minutes), zero alerts on either.
+#
+# WHY OUT-OF-JOB, NOT AN IN-JOB `cancelled()` STEP: see indexer-backfill-watch.yml's
+# header (SMI-5964) -- the same reasoning applies verbatim: an in-job step
+# still runs inside the cancellation grace window of the job that just died,
+# and cannot alert at all if cancellation lands before `Validate Secrets`
+# completes. A `workflow_run`-triggered watcher is a SEPARATE run with its
+# OWN fresh `timeout-minutes` and reads secrets/context directly.
+#
+# PRECEDENT: `indexer-backfill-watch.yml` (SMI-5964) is the direct sibling
+# this workflow copies its structure from, with two adjustments (both from
+# NEEDLE plan review, see docs/internal/implementation/smi-5974-cron-alert-gap.md):
+#   1. Elapsed time uses `github.event.workflow_run.updated_at` (the watched
+#      run's own completion timestamp, in the event payload) minus
+#      `run_started_at` -- NOT watcher wall-clock (`date +%s` at watcher
+#      execution time), which includes GHA queue latency. That latency is
+#      negligible against backfill's 330-min budget but not against this
+#      workflow's 30-min one.
+#   2. The "step already resolved but wasn't itself cancelled" label is
+#      `cancelled-outside-indexer`, not `...-before-indexer` -- "before"
+#      would assert an ordering that can be false (the step could have
+#      succeeded, with cancellation landing at a later step).
+#
+# SCOPE: `cancelled` only. The existing in-job `if: failure()` steps in
+# indexer.yml are untouched and keep handling genuine failures with their
+# richer context (http_code, response body). `cancelled` and `failure` are
+# disjoint conclusions, so there is no duplicate-alert path.
+#
+# NO THIRD-PARTY ACTIONS: this workflow needs neither `checkout` nor
+# `setup-node` -- audit-workflow-sha-pin (Check 42 / SMI-4758) has nothing to
+# pin here.
+#
+# ADR-109: this is an infra workflow -- SPARC + plan-review gated before
+# implementation. See the plan doc above for the reviewed design.
+# audit:carveout-pure-js -- no code execution, gh/curl/jq only (ubuntu-latest built-ins)
+
+name: Skill Indexer Watch
+
+on:
+  workflow_run:
+    workflows: ['Skill Indexer'] # must match indexer.yml:17's `name:` exactly
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read # for the /jobs API call that labels the alert
+  contents: read
+
+jobs:
+  alert-on-cancelled:
+    name: Alert on cancelled indexer run
+    if: github.event.workflow_run.conclusion == 'cancelled'
+    runs-on: ubuntu-latest
+    # Independent of the dying job's own (30-min) budget -- a fresh run.
+    timeout-minutes: 5
+    steps:
+      - name: Classify and alert
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_STARTED_AT: ${{ github.event.workflow_run.run_started_at }}
+          RUN_UPDATED_AT: ${{ github.event.workflow_run.updated_at }}
+          GH_REPOSITORY: ${{ github.repository }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_PROD }}
+        run: |
+          set -eo pipefail
+
+          # ── Classification is a LABEL, never a gate (mirrors SMI-5964) ──
+          # The alert fires on conclusion=='cancelled', full stop (the `if:`
+          # above). Everything below only shapes the message.
+          #
+          # SMI-5974 (NEEDLE plan review): elapsed time is computed from the
+          # watched run's OWN completion timestamp, not watcher wall-clock --
+          # queue latency between the watched run finishing and this watcher
+          # actually starting would otherwise distort a 30-min-budget
+          # classification far more than it did for backfill's 330-min one.
+          parse_ts() {
+            date -u -d "$1" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$1" +%s 2>/dev/null
+          }
+          STARTED=$(parse_ts "$RUN_STARTED_AT")
+          ENDED=$(parse_ts "$RUN_UPDATED_AT")
+
+          # Fail-open: an unparseable timestamp degrades to ELAPSED_MIN=0
+          # (never classified as a likely timeout-kill) rather than aborting
+          # the alert -- the uncertainty is removed from the critical path.
+          if [ -z "$STARTED" ] || [ -z "$ENDED" ] || [ "$ENDED" -lt "$STARTED" ]; then
+            ELAPSED_MIN=0
+          else
+            ELAPSED_MIN=$(( (ENDED - STARTED) / 60 ))
+          fi
+
+          # Fail-open: if the API call or the field is unavailable, KIND
+          # degrades to cancelled-unknown but the alert STILL fires -- the
+          # uncertainty is removed from the critical path, not "verified".
+          STEP_CONCLUSION=$(gh api "/repos/$GH_REPOSITORY/actions/runs/$RUN_ID/jobs" \
+            --jq '.jobs[].steps[]? | select(.name == "Run indexer") | .conclusion' 2>/dev/null || true)
+
+          if [ -z "$STEP_CONCLUSION" ]; then
+            KIND="cancelled-unknown"
+          elif [ "$STEP_CONCLUSION" != "cancelled" ] && [ "$STEP_CONCLUSION" != "in_progress" ]; then
+            KIND="cancelled-outside-indexer" # the "Run indexer" step itself wasn't the cancellation point
+          elif [ "$ELAPSED_MIN" -ge 29 ]; then
+            KIND="likely-gha-timeout-kill"
+          else
+            KIND="cancelled-check-if-manual"
+          fi
+
+          BODY=$(jq -n \
+            --arg msg "Skill Indexer run $RUN_ID ended in 'cancelled' after ${ELAPSED_MIN}m (kind: $KIND). Re-dispatch manually if this was a scheduled run and the next scheduled slot is more than a few hours away." \
+            --arg rid "$RUN_ID" --arg url "$RUN_URL" --arg kind "$KIND" \
+            '{type:"indexer_cancelled", message:$msg, workflow:"Skill Indexer", runId:$rid, runUrl:$url, kind:$kind}')
+
+          # ── No silent alert failures (SMI-5964 pattern) ──
+          # HTTP defaults to "000" and is only overwritten on a completed
+          # curl invocation (avoids the "000\n000" double-value some curl
+          # failure modes produced when -w and a `||` fallback both fired),
+          # and the step fails (non-zero exit) on anything but 200 so a
+          # delivery failure is visibly recorded as a job failure, not
+          # silently swallowed.
+          HTTP="000"
+          if RESPONSE_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Content-Type: application/json" -d "$BODY" \
+            "$SUPABASE_URL/functions/v1/alert-notify"); then
+            HTTP="$RESPONSE_CODE"
+          fi
+
+          {
+            echo "### Indexer run cancelled"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Run | [$RUN_ID]($RUN_URL) |"
+            echo "| Elapsed | ${ELAPSED_MIN} min |"
+            echo "| Kind | $KIND |"
+            echo "| alert-notify HTTP | $HTTP |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$HTTP" != "200" ]; then
+            echo "::error::alert-notify returned $HTTP -- email was NOT sent. Failing this job so the delivery failure is visible in the Actions UI, not just a step-summary annotation."
+            exit 1
+          fi

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -596,8 +596,21 @@ jobs:
             --arg rid "$RUN_ID" \
             --arg url "$RUN_URL" \
             '{type:"indexer_failed", message:$msg, workflow:"Skill Indexer", runId:$rid, runUrl:$url}')
-          curl -s -X POST \
+          # SMI-5974: the prior `|| true` swallowed a failed alert delivery
+          # with zero signal -- worse than indexer-backfill.yml's pre-SMI-5964
+          # state (that one at least printed ::warning::). HTTP defaults to
+          # "000" and is only overwritten on a completed curl call; the step
+          # now fails on anything but 200 so a delivery failure is visible in
+          # the Actions UI, not silently discarded.
+          HTTP="000"
+          if RESPONSE_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
             -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
             -H "Content-Type: application/json" \
             -d "$BODY" \
-            "$SUPABASE_URL/functions/v1/alert-notify" || true
+            "$SUPABASE_URL/functions/v1/alert-notify"); then
+            HTTP="$RESPONSE_CODE"
+          fi
+          if [ "$HTTP" != "200" ]; then
+            echo "::error::alert-notify returned $HTTP -- email was NOT sent."
+            exit 1
+          fi

--- a/scripts/tests/indexer-alert-gap.test.ts
+++ b/scripts/tests/indexer-alert-gap.test.ts
@@ -38,6 +38,32 @@ function bashSyntaxCheck(script: string): { ok: true } | { ok: false; stderr: st
   }
 }
 
+/**
+ * Extracts just the parse_ts()/STARTED/ENDED/ELAPSED_MIN computation out of
+ * the watcher's full run: script (up to and including the if/else block's
+ * closing `fi`) and runs it FOR REAL under `set -eo pipefail` -- matching
+ * the actual script's own settings -- so a `set -e`-vs-fail-open regression
+ * (NEEDLE code-review finding: a bare `VAR=$(parse_ts ...)` previously
+ * exited the whole step before the fail-open check could run) is caught by
+ * execution, not just `bash -n` syntax validity.
+ */
+function runElapsedCalc(runScript: string, startedAt: string, updatedAt: string): string {
+  const start = runScript.indexOf('parse_ts() {')
+  const anchor = 'ELAPSED_MIN=$(( (ENDED - STARTED) / 60 ))'
+  const anchorIdx = runScript.indexOf(anchor)
+  if (start === -1 || anchorIdx === -1) {
+    throw new Error('could not locate the elapsed-calc block in watcher runScript')
+  }
+  // The next `fi` after the ELAPSED_MIN assignment closes the if/else block.
+  const fiIdx = runScript.indexOf('fi', anchorIdx)
+  if (fiIdx === -1) {
+    throw new Error('could not locate the closing fi in watcher runScript')
+  }
+  const snippet = runScript.slice(start, fiIdx + 2)
+  const script = `set -eo pipefail\nRUN_STARTED_AT=${shellQuote(startedAt)}\nRUN_UPDATED_AT=${shellQuote(updatedAt)}\n${snippet}\necho "ELAPSED_MIN=$ELAPSED_MIN"\n`
+  return execFileSync('bash', ['-c', script], { encoding: 'utf8' })
+}
+
 function injectEnv(script: string, env: Record<string, string>): string {
   const assignments = Object.entries(env)
     .map(([k, v]) => `${k}=${shellQuote(v)}`)
@@ -95,9 +121,30 @@ describe('SMI-5974: indexer-watch.yml (the new alert-gap watcher)', () => {
     expect(step.runScript).toMatch(/STARTED=\$\(parse_ts "\$RUN_STARTED_AT"\)/)
   })
 
-  it('an unparseable or inverted timestamp pair fails open to ELAPSED_MIN=0, never crashing the step', () => {
+  it('an unparseable or inverted timestamp pair fails open to ELAPSED_MIN=0, never crashing the step (real execution, not just bash -n -- NEEDLE code-review regression test)', () => {
     const step = extractStep(watcher, 'Classify and alert')
     expect(step.runScript).toMatch(/ELAPSED_MIN=0/)
+
+    // Both attempts inside parse_ts() fail -- this is exactly the case
+    // where a bare `STARTED=$(parse_ts ...)` under set -e previously
+    // terminated the step before reaching the fail-open check.
+    const malformed = runElapsedCalc(step.runScript, 'not-a-timestamp', 'also-not-a-timestamp')
+    expect(malformed.trim()).toBe('ELAPSED_MIN=0')
+
+    // Missing values (empty string) -- same failure class.
+    const missing = runElapsedCalc(step.runScript, '', '')
+    expect(missing.trim()).toBe('ELAPSED_MIN=0')
+
+    // Inverted pair (end before start) -- valid timestamps, but the other
+    // fail-open condition ("$ENDED" -lt "$STARTED").
+    const inverted = runElapsedCalc(step.runScript, '2026-08-09T02:00:00Z', '2026-08-09T01:00:00Z')
+    expect(inverted.trim()).toBe('ELAPSED_MIN=0')
+
+    // Sanity: a real, valid, 30-minute-apart pair computes the real value,
+    // proving the fail-open branch isn't just always returning 0.
+    const real = runElapsedCalc(step.runScript, '2026-08-09T01:00:00Z', '2026-08-09T01:30:00Z')
+    expect(real.trim()).toBe('ELAPSED_MIN=30')
+
     const injected = injectEnv(step.runScript, {
       RUN_STARTED_AT: 'not-a-timestamp',
       RUN_UPDATED_AT: 'also-not-a-timestamp',

--- a/scripts/tests/indexer-alert-gap.test.ts
+++ b/scripts/tests/indexer-alert-gap.test.ts
@@ -1,0 +1,221 @@
+/**
+ * SMI-5974: static assertions over the alert-gap watcher
+ * (`.github/workflows/indexer-watch.yml`, new) and the alert-delivery-failure
+ * fix in `.github/workflows/indexer.yml`'s `Send Alert on Failure` step.
+ * Direct sibling of `indexer-backfill-alert-gap.test.ts` (SMI-5964) -- same
+ * no-YAML-parser, string/regex + `bash -n` pattern, same `extractStep` shared
+ * helper.
+ */
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { makeFixtureTempDir } from './_lib/git-fixture-env.js'
+import { extractStep } from './_lib/workflow-yaml.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const INDEXER_PATH = join(REPO_ROOT, '.github', 'workflows', 'indexer.yml')
+const WATCHER_PATH = join(REPO_ROOT, '.github', 'workflows', 'indexer-watch.yml')
+
+function bashSyntaxCheck(script: string): { ok: true } | { ok: false; stderr: string } {
+  const dir = makeFixtureTempDir('indexer-watch-test')
+  const file = join(dir, 'script.sh')
+  try {
+    writeFileSync(file, script, 'utf8')
+    execFileSync('bash', ['-n', file], { stdio: ['ignore', 'ignore', 'pipe'] })
+    return { ok: true }
+  } catch (err) {
+    const stderr =
+      err && typeof err === 'object' && 'stderr' in err
+        ? String((err as { stderr: Buffer }).stderr)
+        : String(err)
+    return { ok: false, stderr }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+function injectEnv(script: string, env: Record<string, string>): string {
+  const assignments = Object.entries(env)
+    .map(([k, v]) => `${k}=${shellQuote(v)}`)
+    .join('\n')
+  return `${assignments}\n${script}`
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+const HOSTILE_FIXTURES: Array<{ label: string; value: string }> = [
+  { label: 'embedded single quote', value: "it's broken" },
+  { label: 'embedded backticks', value: '`backtick`' },
+  { label: 'embedded double quote', value: 'line "with" quote' },
+  { label: 'embedded newline', value: 'line 1\nline 2' },
+  { label: 'subshell-looking $(rm -rf /)', value: '$(rm -rf /)' },
+  { label: 'process substitution <(cat /etc/passwd)', value: '<(cat /etc/passwd)' },
+]
+
+describe('SMI-5974: indexer-watch.yml (the new alert-gap watcher)', () => {
+  const watcher = readFileSync(WATCHER_PATH, 'utf8')
+  const indexer = readFileSync(INDEXER_PATH, 'utf8')
+
+  it("the watcher's workflows: value matches indexer.yml's name: byte-for-byte -- a mismatch means workflow_run silently never fires", () => {
+    const nameMatch = indexer.match(/^name: (.+)$/m)
+    expect(nameMatch).not.toBeNull()
+    const indexerName = nameMatch![1].trim()
+    expect(watcher).toContain(`workflows: ['${indexerName}']`)
+  })
+
+  it('triggers on workflow_run / types: [completed] / branches: [main]', () => {
+    expect(watcher).toMatch(/workflow_run:/)
+    expect(watcher).toMatch(/types: \[completed\]/)
+    expect(watcher).toMatch(/branches: \[main\]/)
+  })
+
+  it("the job's if: condition is scoped to conclusion == 'cancelled' only", () => {
+    expect(watcher).toMatch(/if: github\.event\.workflow_run\.conclusion == 'cancelled'/)
+  })
+
+  it("has its own timeout-minutes, independent of the dying job's 30-min budget", () => {
+    expect(watcher).toMatch(/timeout-minutes: 5/)
+  })
+
+  it('has no `uses:` step -- nothing for audit-workflow-sha-pin (Check 42) to pin', () => {
+    expect(watcher).not.toMatch(/uses:/)
+  })
+
+  it("elapsed time is computed from the watched run's own RUN_UPDATED_AT, not watcher wall-clock (NEEDLE plan-review requirement)", () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    expect(step.runScript).toMatch(/RUN_UPDATED_AT/)
+    expect(step.runScript).not.toMatch(/NOW=\$\(date \+%s\)/)
+    expect(step.runScript).toMatch(/ENDED=\$\(parse_ts "\$RUN_UPDATED_AT"\)/)
+    expect(step.runScript).toMatch(/STARTED=\$\(parse_ts "\$RUN_STARTED_AT"\)/)
+  })
+
+  it('an unparseable or inverted timestamp pair fails open to ELAPSED_MIN=0, never crashing the step', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    expect(step.runScript).toMatch(/ELAPSED_MIN=0/)
+    const injected = injectEnv(step.runScript, {
+      RUN_STARTED_AT: 'not-a-timestamp',
+      RUN_UPDATED_AT: 'also-not-a-timestamp',
+      RUN_ID: '123',
+      RUN_URL: 'https://example.com',
+      GH_REPOSITORY: 'smith-horn/skillsmith',
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_ROLE_KEY: 'dummy',
+      GITHUB_STEP_SUMMARY: '/tmp/dummy-summary',
+    })
+    const result = bashSyntaxCheck(injected)
+    expect(result).toEqual({ ok: true })
+  })
+
+  it('uses the 29-minute threshold (1-minute tolerance against the 30-min job budget, per NEEDLE plan review)', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    expect(step.runScript).toMatch(/"\$ELAPSED_MIN" -ge 29/)
+  })
+
+  it('looks up the exact step name "Run indexer" (confirmed against the live file, not guessed)', () => {
+    expect(indexer).toMatch(/- name: Run indexer/)
+    const step = extractStep(watcher, 'Classify and alert')
+    expect(step.runScript).toMatch(/select\(\.name == "Run indexer"\)/)
+  })
+
+  it('labels a resolved-but-not-cancelled step as cancelled-outside-indexer, not cancelled-before-indexer (NEEDLE: "before" can be factually wrong)', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    expect(step.runScript).toMatch(/KIND="cancelled-outside-indexer"/)
+    expect(step.runScript).not.toMatch(/cancelled-before-indexer/)
+  })
+
+  it('the run: body survives bash -n under hostile $RUN_ID/$RUN_URL-shaped fixtures', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    for (const fixture of HOSTILE_FIXTURES) {
+      const injected = injectEnv(step.runScript, {
+        RUN_STARTED_AT: '2026-08-09T01:05:54Z',
+        RUN_UPDATED_AT: '2026-08-09T01:35:54Z',
+        RUN_ID: fixture.value,
+        RUN_URL: fixture.value,
+        GH_REPOSITORY: 'smith-horn/skillsmith',
+        SUPABASE_URL: 'https://example.supabase.co',
+        SUPABASE_SERVICE_ROLE_KEY: 'dummy',
+        GITHUB_STEP_SUMMARY: '/tmp/dummy-summary',
+      })
+      const result = bashSyntaxCheck(injected)
+      expect(result, `${fixture.label}: ${JSON.stringify(result)}`).toEqual({ ok: true })
+    }
+  })
+
+  it('classification is a label, never a gate -- the alert-notify POST is never wrapped in a $KIND conditional', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    const curlIdx = step.runScript.indexOf('curl -s -o /dev/null')
+    expect(curlIdx).toBeGreaterThan(-1)
+    expect(step.runScript).not.toMatch(/if \[ "\$KIND"/)
+  })
+
+  it('the alert-notify HTTP code is captured, written to the step summary, and a non-200 fails the job', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    expect(step.runScript).toMatch(
+      /if RESPONSE_CODE=\$\(curl -s -o \/dev\/null -w '%\{http_code\}'/
+    )
+    expect(step.runScript).toMatch(/alert-notify HTTP \| \$HTTP/)
+    expect(step.runScript).toMatch(/::error::alert-notify returned \$HTTP/)
+    expect(step.runScript).toMatch(/exit 1/)
+  })
+
+  it('posts the type: "indexer_cancelled" alert', () => {
+    const step = extractStep(watcher, 'Classify and alert')
+    expect(step.runScript).toMatch(/type:"indexer_cancelled"/)
+  })
+})
+
+describe('SMI-5974: indexer.yml (Send Alert on Failure alert-delivery-failure fix)', () => {
+  const indexer = readFileSync(INDEXER_PATH, 'utf8')
+
+  it('no timeout-minutes was added to any step -- only the pre-existing job-level 30 remains', () => {
+    const matches = indexer.match(/timeout-minutes:/g) ?? []
+    expect(matches).toHaveLength(1)
+    expect(indexer).toMatch(/timeout-minutes: 30/)
+  })
+
+  it('the two if: failure() conditions are unchanged', () => {
+    const matches = indexer.match(/if: failure\(\)/g) ?? []
+    expect(matches).toHaveLength(2)
+  })
+
+  it('Send Alert on Failure no longer has a bare `|| true` swallowing delivery failures', () => {
+    const step = extractStep(indexer, 'Send Alert on Failure')
+    const codeOnly = step.runScript
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('#'))
+      .join('\n')
+    expect(codeOnly).not.toMatch(/alert-notify" \|\| true/)
+  })
+
+  it('Send Alert on Failure captures the alert-notify HTTP code and fails the step on non-200', () => {
+    const step = extractStep(indexer, 'Send Alert on Failure')
+    expect(step.runScript).toMatch(
+      /if RESPONSE_CODE=\$\(curl -s -o \/dev\/null -w '%\{http_code\}'/
+    )
+    expect(step.runScript).toMatch(/::error::alert-notify returned \$HTTP/)
+    expect(step.runScript).toMatch(/exit 1/)
+  })
+
+  it('Send Alert on Failure survives bash -n under hostile fixtures', () => {
+    const step = extractStep(indexer, 'Send Alert on Failure')
+    for (const fixture of HOSTILE_FIXTURES) {
+      const injected = injectEnv(step.runScript, {
+        HTTP_CODE: '500',
+        RESPONSE: 'x',
+        RUN_ID: fixture.value,
+        RUN_URL: fixture.value,
+        SUPABASE_URL: 'https://example.supabase.co',
+        SUPABASE_SERVICE_ROLE_KEY: 'dummy',
+        GITHUB_STEP_SUMMARY: '/tmp/dummy-summary',
+      })
+      const result = bashSyntaxCheck(injected)
+      expect(result, `${fixture.label}: ${JSON.stringify(result)}`).toEqual({ ok: true })
+    }
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** A recurring, silent gap in the regular skill-indexing cron job — the same class of bug SMI-5964 just fixed for the backfill workflow, but here confirmed to have already happened twice in production with zero warning either time. When GitHub's own 30-minute time limit kills an indexing run, the workflow's alert steps never fire, because they only trigger on "failure," not "cancelled." A new, independent watcher now reliably alerts on any cancelled run. Along the way, also fixed a second silent-failure bug in the same alert step: even a genuine failure's alert email could silently fail to send with zero warning — that path now visibly fails instead.

**Quality bar:** Plan reviewed by GPT-5.6-Sol (independent of Claude) before implementation — came back "approve with changes," catching that copying the sibling workflow's design too literally would have introduced timing inaccuracy (using the watcher's own start time instead of the actual run's completion time, which matters much more on a 30-minute budget than the sibling's 330-minute one) and a misleading status label in one edge case. Both fixed before merge. 37 of 37 relevant tests pass, including 19 new ones.

**Found along the way:** none beyond the bundled alert-delivery-failure fix noted above (reviewed and confirmed in-scope for this PR rather than deferred).

**Net result:** Fully shipped, no follow-up needed for this issue.

---

## Technical detail

- `.github/workflows/indexer-watch.yml` (new) — `workflow_run`-triggered watcher on the "Skill Indexer" workflow, fires on `conclusion == 'cancelled'`, independent 5-min timeout, classification is a label only (never gates whether the alert fires).
- `.github/workflows/indexer.yml` — `Send Alert on Failure` step: removed the `curl ... || true` that silently swallowed delivery failures; now captures HTTP status and fails the step on non-200, matching the pattern already shipped in `indexer-backfill.yml`.
- `scripts/tests/indexer-alert-gap.test.ts` (new) — 19 static assertions (string/regex + `bash -n`, no YAML parser, matching the existing test convention) covering the watcher's trigger shape, the timestamp-based elapsed calculation (not wall-clock), the 29-minute threshold, the exact step-name lookup, hostile-input shell-injection safety, and both alert-delivery-failure fixes.
- Verified via `gh run list` against 800 real runs: 2 confirmed genuine timeout-kills (2026-07-10, 2026-07-13), both silent before this fix.
- Plan doc: `docs/internal/implementation/smi-5974-cron-alert-gap.md` (via docs/internal submodule PRs #700/#701).
