### PR TITLE
fix(release): SMI-5663 fix release-cadence PR staleness watcher

### DIFF
--- a/.github/workflows/release-cadence-pr-staleness.yml
+++ b/.github/workflows/release-cadence-pr-staleness.yml
@@ -5,17 +5,32 @@
 # A PR cut on Sun can sit open while main moves several PRs forward, leading
 # to a release that drains a `[Unreleased]` no longer representing main.
 #
-# This workflow runs daily, iterates open `release-cadence/*` PRs, and
-# auto-closes any that drift > N hours OR > M commits behind origin/main.
-# The cadence cron re-rolls cleanly the next Sunday tick (or via manual
-# `workflow_dispatch` on `release-cadence.yml`).
+# SMI-5663 recalibration (2026-08-11, GPT-5.6-Sol plan review):
+# the original design (immediate `gh pr close --delete-branch` at 24h old OR
+# 5 commits behind) auto-closed 6 of the last 8 weekly cadence PRs unmerged —
+# it was reaping PRs that were still legitimately awaiting merge, not
+# genuinely abandoned ones. Three changes:
 #
-# Action choice: close + comment + delete branch (NOT auto-rebase). Lockfile
-# / changelog / version-bump conflicts during rebase produce silent broken
-# PRs. Re-firing the deterministic cron from current main is cheaper than
-# reconciling a rebased PR.
+#   1. Age is measured from the PR's `createdAt` (not the head commit's own
+#      timestamp) — the semantically correct clock for "how long has this sat
+#      open", and immune to a follow-up commit resetting it.
+#   2. Commits-behind-main is no longer a close/nag trigger by itself — kept
+#      only as informational context in the comment body. GitHub's own
+#      `mergeable == "CONFLICTING"` status is the real staleness signal a
+#      PR that's simply old but still cleanly mergeable isn't broken, just
+#      waiting on a human. `mergeable == "UNKNOWN"` (a transient GitHub
+#      computation state) never counts as stale on its own.
+#   3. Two-stage nag-then-close instead of an immediate destructive close:
+#      a non-destructive "nag" comment (idempotent — marked with a hidden
+#      HTML comment so it never re-nags) posts once staleness is first
+#      detected; the PR is only closed if it is STILL open a full 7 days
+#      after that nag. The branch is preserved on close (no
+#      `--delete-branch`) — this is what produced SMI-5663's actual
+#      documented symptom (a later `git push` recreating a branch ref that
+#      GitHub won't resync commits against for an already-closed PR).
 #
 # See: docs/internal/implementation/smi-4779-cadence-cron-staleness-gate.md
+#      docs/internal/implementation/smi-5663-release-cadence-staleness-fix.md
 #      docs/internal/runbooks/release-cadence-stale-pr.md
 #      docs/internal/adr/114-release-cadence-and-gh-release-alignment.md
 
@@ -27,17 +42,17 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'List stale PRs without closing them'
+        description: 'List stale/nag-eligible/close-eligible PRs without acting on them'
         required: false
         default: 'false'
         type: boolean
       max_hours:
-        description: 'Max hours behind main before close (default 24)'
+        description: 'Max hours since PR creation before a nag (default 24)'
         required: false
         default: '24'
         type: string
       max_commits:
-        description: 'Max commits behind main before close (default 5)'
+        description: 'Commits behind main shown as informational context only (default 5) — no longer a stale/close trigger, SMI-5663'
         required: false
         default: '5'
         type: string
@@ -70,7 +85,7 @@ jobs:
           set -euo pipefail
           PRS=$(gh pr list --state open \
             --search 'head:release-cadence/' \
-            --json number,headRefName,headRefOid,createdAt,url)
+            --json number,headRefName,headRefOid,createdAt,url,mergeable)
           COUNT=$(echo "$PRS" | jq 'length')
           # Multiline-safe output via heredoc delimiter (GHA recommended).
           {
@@ -85,10 +100,25 @@ jobs:
             echo "Open release-cadence/* PRs: $COUNT"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # SMI-5663: staleness signal is (age-since-createdAt > MAX_HOURS) OR
+      # (mergeable == "CONFLICTING"). mergeable == "UNKNOWN" (GitHub hasn't
+      # finished computing it yet — transient) never counts. Commits-behind is
+      # still computed for the comment body, but no longer gates anything.
+      #
+      # Per stale PR, this step also determines which of the two stages
+      # applies by checking for a prior nag marker comment (idempotent via a
+      # hidden `<!-- release-cadence-staleness-nag -->` HTML comment):
+      #   - No prior nag found            -> NAG (non-destructive comment only)
+      #   - Nagged < 7 days ago           -> NONE (already nagged, waiting)
+      #   - Nagged >= 7 days ago,
+      #     current mergeable != UNKNOWN  -> CLOSE (branch preserved)
+      #   - Nagged >= 7 days ago,
+      #     current mergeable == UNKNOWN  -> NONE (defer — transient state)
       - name: Evaluate staleness
         if: steps.find.outputs.count != '0'
         id: evaluate
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRS_JSON: ${{ steps.find.outputs.prs }}
           MAX_HOURS: ${{ github.event.inputs.max_hours || '24' }}
           MAX_COMMITS: ${{ github.event.inputs.max_commits || '5' }}
@@ -96,81 +126,153 @@ jobs:
           set -euo pipefail
           git fetch origin main
 
-          : > /tmp/stale-prs.tsv
-          STALE_COUNT=0
+          NAG_MARKER='<!-- release-cadence-staleness-nag -->'
+          NAG_TO_CLOSE_DAYS=7
+
+          : > /tmp/nag-prs.tsv
+          : > /tmp/close-prs.tsv
+          NAG_COUNT=0
+          CLOSE_COUNT=0
+          NOW_TS=$(date -u +%s)
+
           while read -r pr; do
             NUMBER=$(echo "$pr" | jq -r '.number')
             HEAD_OID=$(echo "$pr" | jq -r '.headRefOid')
             HEAD_REF=$(echo "$pr" | jq -r '.headRefName')
             URL=$(echo "$pr" | jq -r '.url')
+            CREATED_AT=$(echo "$pr" | jq -r '.createdAt')
+            MERGEABLE=$(echo "$pr" | jq -r '.mergeable')
 
-            # Best-effort fetch of the PR head; comparison still works via OID
-            # if the branch is already gone or fetch fails.
+            # Best-effort fetch of the PR head; commits-behind (informational
+            # only, SMI-5663) still works via OID if the branch is gone or
+            # this fetch fails.
             git fetch origin "$HEAD_REF" 2>/dev/null || true
-
             COMMITS_BEHIND=$(git rev-list --count "$HEAD_OID..origin/main" 2>/dev/null || echo 0)
-            HEAD_TS=$(git log -1 --format=%ct "$HEAD_OID" 2>/dev/null || echo 0)
-            NOW_TS=$(date -u +%s)
-            if [ "$HEAD_TS" = "0" ]; then
-              AGE_HOURS=0
-            else
-              AGE_HOURS=$(( (NOW_TS - HEAD_TS) / 3600 ))
-            fi
+
+            CREATED_TS=$(date -u -d "$CREATED_AT" +%s)
+            AGE_HOURS=$(( (NOW_TS - CREATED_TS) / 3600 ))
 
             STALE=0
             REASONS=""
             if [ "$AGE_HOURS" -gt "$MAX_HOURS" ]; then
               STALE=1
-              REASONS="${AGE_HOURS}h old"
+              REASONS="${AGE_HOURS}h old (since createdAt)"
             fi
-            if [ "$COMMITS_BEHIND" -gt "$MAX_COMMITS" ]; then
+            if [ "$MERGEABLE" = "CONFLICTING" ]; then
               STALE=1
               if [ -n "$REASONS" ]; then
-                REASONS="${REASONS}, ${COMMITS_BEHIND} commits behind main"
+                REASONS="${REASONS}, mergeable=CONFLICTING"
               else
-                REASONS="${COMMITS_BEHIND} commits behind main"
+                REASONS="mergeable=CONFLICTING"
               fi
             fi
+            # Always-informational, never a stale trigger (SMI-5663 §3).
+            INFO="${COMMITS_BEHIND} commit(s) behind main (informational, threshold ${MAX_COMMITS} — no longer a trigger, SMI-5663)"
 
-            if [ "$STALE" -eq 1 ]; then
-              {
-                echo "- ❌ PR #${NUMBER} (\`$HEAD_REF\`): stale — $REASONS"
-                echo "    Recovery: \`gh workflow run release-cadence.yml -f dry_run=false\` to re-cut from current main."
-              } >> "$GITHUB_STEP_SUMMARY"
-              # TSV for downstream steps. URL retained for closure comment + email.
-              printf '%s\t%s\t%s\t%s\n' "$NUMBER" "$HEAD_REF" "$REASONS" "$URL" >> /tmp/stale-prs.tsv
-              STALE_COUNT=$((STALE_COUNT + 1))
-            else
-              echo "- ✓ PR #${NUMBER} (\`$HEAD_REF\`): fresh (${AGE_HOURS}h old, ${COMMITS_BEHIND} commits behind)" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$STALE" -eq 0 ]; then
+              echo "- ✓ PR #${NUMBER} (\`$HEAD_REF\`): fresh (${AGE_HOURS}h old, mergeable=${MERGEABLE}, ${INFO})" >> "$GITHUB_STEP_SUMMARY"
+              continue
             fi
+
+            # Stale — determine nag vs. close via prior-nag lookup.
+            #
+            # Code-review correction (SMI-5663): `gh pr view --json comments`
+            # does not reliably return every comment on a long thread (a
+            # documented gh CLI limitation) — on a busy PR the marker could be
+            # silently missed, causing this to duplicate-nag forever instead
+            # of ever advancing to close. `gh api --paginate` against the
+            # underlying REST comments endpoint walks every page explicitly.
+            PRIOR_NAG=$(gh api --paginate "repos/{owner}/{repo}/issues/${NUMBER}/comments" \
+              --jq --arg marker "$NAG_MARKER" \
+              '.[] | select((.body // "") | contains($marker)) | .created_at' \
+              | sort | head -1)
+
+            if [ -z "$PRIOR_NAG" ]; then
+              echo "- 🔔 PR #${NUMBER} (\`$HEAD_REF\`): stale — $REASONS. $INFO. No prior nag -> nagging." >> "$GITHUB_STEP_SUMMARY"
+              printf '%s\t%s\t%s\t%s\t%s\n' "$NUMBER" "$HEAD_REF" "$REASONS" "$URL" "$INFO" >> /tmp/nag-prs.tsv
+              NAG_COUNT=$((NAG_COUNT + 1))
+              continue
+            fi
+
+            NAG_TS=$(date -u -d "$PRIOR_NAG" +%s)
+            NAG_AGE_DAYS=$(( (NOW_TS - NAG_TS) / 86400 ))
+
+            if [ "$NAG_AGE_DAYS" -lt "$NAG_TO_CLOSE_DAYS" ]; then
+              echo "- ⏳ PR #${NUMBER} (\`$HEAD_REF\`): stale — $REASONS. Already nagged ${NAG_AGE_DAYS}d ago (< ${NAG_TO_CLOSE_DAYS}d) -> waiting." >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            if [ "$MERGEABLE" = "UNKNOWN" ]; then
+              echo "- ⏳ PR #${NUMBER} (\`$HEAD_REF\`): nagged ${NAG_AGE_DAYS}d ago (>= ${NAG_TO_CLOSE_DAYS}d) but mergeable=UNKNOWN (transient) -> deferring close." >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            echo "- ❌ PR #${NUMBER} (\`$HEAD_REF\`): nagged ${NAG_AGE_DAYS}d ago (>= ${NAG_TO_CLOSE_DAYS}d), still open -> closing (branch preserved)." >> "$GITHUB_STEP_SUMMARY"
+            printf '%s\t%s\t%s\t%s\t%s\n' "$NUMBER" "$HEAD_REF" "$REASONS" "$URL" "$PRIOR_NAG" >> /tmp/close-prs.tsv
+            CLOSE_COUNT=$((CLOSE_COUNT + 1))
           done < <(echo "$PRS_JSON" | jq -c '.[]')
 
-          echo "stale_count=$STALE_COUNT" >> "$GITHUB_OUTPUT"
-          if [ "$STALE_COUNT" -gt 0 ]; then
+          echo "nag_count=$NAG_COUNT" >> "$GITHUB_OUTPUT"
+          echo "close_count=$CLOSE_COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$NAG_COUNT" -gt 0 ] || [ "$CLOSE_COUNT" -gt 0 ]; then
             {
               echo ""
-              echo "Override: \`gh workflow run release-cadence-pr-staleness.yml -f max_hours=48 -f max_commits=10\` to bypass thresholds."
+              echo "Override: \`gh workflow run release-cadence-pr-staleness.yml -f max_hours=48\` to bypass the age threshold (mergeable=CONFLICTING still applies)."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Close stale PRs
-        if: steps.evaluate.outputs.stale_count != '0' && (github.event.inputs.dry_run || 'false') != 'true'
+      - name: Post nag comments
+        if: steps.evaluate.outputs.nag_count != '0' && (github.event.inputs.dry_run || 'false') != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          while IFS=$'\t' read -r NUMBER HEAD_REF REASON URL; do
+          while IFS=$'\t' read -r NUMBER HEAD_REF REASON URL INFO; do
             [ -z "$NUMBER" ] && continue
             BODY=$(cat <<EOF
-          ## Auto-closed by release-cadence PR staleness watcher (SMI-4779)
+          ## ⚠️ Release-cadence PR staleness nag (SMI-5663)
 
           This PR is stale: ${REASON}.
 
-          Auto-closing rather than auto-rebasing because lockfile/changelog/version conflicts during rebase create silent broken PRs.
+          ${INFO}
+
+          This is a **non-destructive nag** — no action has been taken. If this PR is still open **7 days from now**, it will be closed automatically (branch preserved, not deleted — SMI-5663) so a fresh cadence PR can be re-cut cleanly.
+
+          To resolve before then: merge it, or bring it up to date with \`gh pr update-branch ${NUMBER}\`.
+
+          See [docs/internal/runbooks/release-cadence-stale-pr.md](../blob/main/docs/internal/runbooks/release-cadence-stale-pr.md) for the full operator runbook.
+
+          Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          <!-- release-cadence-staleness-nag -->
+          EOF
+          )
+            gh pr comment "$NUMBER" --body "$BODY"
+            echo "  Nagged PR #$NUMBER (\`$HEAD_REF\`)" >> "$GITHUB_STEP_SUMMARY"
+          done < /tmp/nag-prs.tsv
+
+      - name: Close stale PRs (branch preserved)
+        if: steps.evaluate.outputs.close_count != '0' && (github.event.inputs.dry_run || 'false') != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          while IFS=$'\t' read -r NUMBER HEAD_REF REASON URL NAGGED_AT; do
+            [ -z "$NUMBER" ] && continue
+            BODY=$(cat <<EOF
+          ## Auto-closed by release-cadence PR staleness watcher (SMI-5663)
+
+          This PR was nagged as stale on ${NAGGED_AT} and is still open 7+ days later (${REASON}).
+
+          **Branch preserved** (not deleted, SMI-5663) — a later \`git push\` to \`${HEAD_REF}\` will pick up cleanly; run \`gh pr reopen ${NUMBER}\` afterward if GitHub doesn't resync commits/checks against an already-closed PR automatically.
 
           ### Recovery
 
-          To re-cut a fresh release PR from current main:
+          \`\`\`
+          gh pr reopen ${NUMBER}
+          \`\`\`
+
+          Or re-cut a fresh release PR from current main:
 
           \`\`\`
           gh workflow run release-cadence.yml -f dry_run=false
@@ -182,12 +284,12 @@ jobs:
           EOF
           )
             gh pr comment "$NUMBER" --body "$BODY"
-            gh pr close "$NUMBER" --delete-branch
-            echo "  Closed PR #$NUMBER and deleted branch \`$HEAD_REF\`" >> "$GITHUB_STEP_SUMMARY"
-          done < /tmp/stale-prs.tsv
+            gh pr close "$NUMBER"
+            echo "  Closed PR #$NUMBER (branch \`$HEAD_REF\` preserved)" >> "$GITHUB_STEP_SUMMARY"
+          done < /tmp/close-prs.tsv
 
       - name: Notify support via alert-notify
-        if: steps.evaluate.outputs.stale_count != '0' && (github.event.inputs.dry_run || 'false') != 'true'
+        if: steps.evaluate.outputs.close_count != '0' && (github.event.inputs.dry_run || 'false') != 'true'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -199,9 +301,9 @@ jobs:
           fi
 
           # Format the closure list as a plain-text message body.
-          STALE_LIST=$(awk -F'\t' '{ printf "  - PR #%s (%s): %s\n    %s\n", $1, $2, $3, $4 }' /tmp/stale-prs.tsv)
+          CLOSE_LIST=$(awk -F'\t' '{ printf "  - PR #%s (%s): %s\n    %s\n", $1, $2, $3, $4 }' /tmp/close-prs.tsv)
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          BODY=$(printf 'The release-cadence PR-staleness watcher auto-closed the following stale PR(s):\n\n%s\nRunbook: docs/internal/runbooks/release-cadence-stale-pr.md\nWorkflow run: %s\n\nTo re-cut a fresh release PR: `gh workflow run release-cadence.yml -f dry_run=false`\n' "$STALE_LIST" "$RUN_URL")
+          BODY=$(printf 'The release-cadence PR-staleness watcher auto-closed the following PR(s) (branch preserved, nagged 7+ days prior — SMI-5663):\n\n%s\nRunbook: docs/internal/runbooks/release-cadence-stale-pr.md\nWorkflow run: %s\n\nTo resume: `git push` to the (preserved) branch, then `gh pr reopen <number>`. Or re-cut a fresh release PR: `gh workflow run release-cadence.yml -f dry_run=false`\n' "$CLOSE_LIST" "$RUN_URL")
 
           PAYLOAD=$(jq -nc \
             --arg msg "$BODY" \

--- a/.github/workflows/release-cadence-pr-staleness.yml
+++ b/.github/workflows/release-cadence-pr-staleness.yml
@@ -182,8 +182,16 @@ jobs:
             # silently missed, causing this to duplicate-nag forever instead
             # of ever advancing to close. `gh api --paginate` against the
             # underlying REST comments endpoint walks every page explicitly.
+            #
+            # PR-review correction (SMI-5663): `gh api --jq` accepts exactly
+            # one jq expression string — it does not additionally accept jq's
+            # own `--arg` flag. The prior form here (`--jq --arg marker ...`)
+            # made gh see 4 positional args and fail every single evaluation
+            # under `set -euo pipefail`, silently breaking the entire
+            # nag/close mechanism at runtime. Pipe into a standalone `jq`
+            # invocation instead, which does support `--arg`.
             PRIOR_NAG=$(gh api --paginate "repos/{owner}/{repo}/issues/${NUMBER}/comments" \
-              --jq --arg marker "$NAG_MARKER" \
+              | jq -r --arg marker "$NAG_MARKER" \
               '.[] | select((.body // "") | contains($marker)) | .created_at' \
               | sort | head -1)
 

--- a/scripts/audit-readme-whats-new-helpers.mjs
+++ b/scripts/audit-readme-whats-new-helpers.mjs
@@ -15,3 +15,106 @@ export function extractWhatsNewVersion(readmeContent) {
   const match = readmeContent.match(/^## What's New in v?(\d+\.\d+\.\d+)/m)
   return match ? match[1] : null
 }
+
+/**
+ * Matches a "## What's New in vX.Y.Z" heading, capturing the version, with
+ * the `g` flag so callers can detect ambiguity (more than one match) — unlike
+ * `extractWhatsNewVersion`'s non-global regex, which silently returns only
+ * the first match.
+ */
+const WHATS_NEW_HEADING_RE = /^## What's New in v?(\d+\.\d+\.\d+)$/gm
+
+/**
+ * Loose detector for "this README has a What's New section at all", regardless
+ * of whether the version suffix parses. Used by callers to distinguish "no
+ * What's New section — not our concern" (most packages) from "has one but it's
+ * malformed" (should fail closed, not be silently skipped).
+ */
+const LOOSE_WHATS_NEW_HEADING_RE = /^## What's New\b/m
+
+/**
+ * @param {string} readmeContent
+ * @returns {boolean}
+ */
+export function hasWhatsNewHeading(readmeContent) {
+  return LOOSE_WHATS_NEW_HEADING_RE.test(readmeContent)
+}
+
+/**
+ * Reproduces GitHub's Markdown heading-to-anchor slug algorithm closely enough
+ * for this file's own headings: lowercase, strip characters that aren't a
+ * word character/space/hyphen (drops apostrophes and periods entirely, not
+ * replaced with a hyphen), then hyphenate whitespace. Verified against the
+ * real anchors this repo's READMEs currently use — "What's New in v0.11.4" ->
+ * "whats-new-in-v0114" (packages/core/README.md) and "What's New in v0.8.4" ->
+ * "whats-new-in-v084" (packages/cli/README.md).
+ *
+ * @param {string} headingText
+ * @returns {string}
+ */
+export function githubHeadingSlug(headingText) {
+  return headingText
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+}
+
+/**
+ * Write-side counterpart to `extractWhatsNewVersion` (SMI-5663 Wave 1). Updates
+ * a README's "## What's New in vX.Y.Z" heading — and any table-of-contents
+ * anchor link referencing it (e.g. `[What's New](#whats-new-in-v0114)`) — to
+ * `newVersion`, so `prepare-release.ts` and Check 60 (SMI-5613) structurally
+ * cannot drift apart again.
+ *
+ * Fails closed: throws if the heading is missing entirely, or matches more
+ * than once (ambiguous), rather than silently updating the first occurrence
+ * or leaving the file untouched. Callers that need to distinguish "this
+ * package legitimately has no What's New section at all" (skip) from "it has
+ * one but this function can't safely update it" (fail closed) should check
+ * `hasWhatsNewHeading()` first — most packages fall in the former bucket.
+ *
+ * @param {string} readmeContent
+ * @param {string} newVersion - e.g. "0.11.5"
+ * @returns {string} updated README content
+ */
+export function updateWhatsNewVersion(readmeContent, newVersion) {
+  const headingMatches = [...readmeContent.matchAll(WHATS_NEW_HEADING_RE)]
+
+  if (headingMatches.length === 0) {
+    throw new Error(
+      'updateWhatsNewVersion: no "## What\'s New in vX.Y.Z" heading found — cannot sync version'
+    )
+  }
+  if (headingMatches.length > 1) {
+    throw new Error(
+      `updateWhatsNewVersion: ambiguous — found ${headingMatches.length} "## What's New in vX.Y.Z" headings, expected exactly 1`
+    )
+  }
+
+  const [oldHeadingLine] = headingMatches[0]
+  const newHeadingText = `What's New in v${newVersion}`
+  let updated = readmeContent.replace(oldHeadingLine, `## ${newHeadingText}`)
+
+  // Update a matching TOC anchor link, if one exists — e.g.
+  // "- [What's New](#whats-new-in-v0114)". Not every README with a What's New
+  // heading has a "## Contents" TOC (packages/mcp-server/README.md doesn't),
+  // so this is best-effort: only rewrite the anchor when the OLD slug is
+  // actually referenced somewhere in the file.
+  //
+  // Code-review correction (SMI-5663): derive the old slug from the ACTUAL
+  // matched heading text, not by reconstructing it with a hardcoded "v" —
+  // `extractWhatsNewVersion`/this regex both tolerate a heading without the
+  // leading "v" (e.g. "## What's New in 1.2.3"), and reconstructing with a
+  // hardcoded "v" would compute the wrong old slug for that case, silently
+  // leaving a stale TOC link behind.
+  const oldHeadingText = oldHeadingLine.replace(/^## /, '')
+  const oldSlug = githubHeadingSlug(oldHeadingText)
+  const newSlug = githubHeadingSlug(newHeadingText)
+  if (oldSlug !== newSlug) {
+    const tocLinkRe = new RegExp(`(\\(#)${oldSlug}(\\))`, 'g')
+    updated = updated.replace(tocLinkRe, `$1${newSlug}$2`)
+  }
+
+  return updated
+}

--- a/scripts/lib/release-readme.ts
+++ b/scripts/lib/release-readme.ts
@@ -1,0 +1,64 @@
+/**
+ * README "What's New" sync, extracted from prepare-release.ts (SMI-5663 Wave 1)
+ * to keep the orchestrator under the 500-line file-length budget, matching the
+ * SMI-4783 release-collision/release-changelog/release-git split.
+ *
+ * `scripts/prepare-release.ts` bumps each package's package.json version but
+ * historically never touched the corresponding packages/*\/README.md's
+ * "## What's New in vX.Y.Z" heading — Check 60 (SMI-5613,
+ * scripts/audit-standards.mjs) compares that heading against package.json and
+ * fails the release-cadence PR on drift. This module closes that gap by
+ * reusing the checker's own read-side parser (`extractWhatsNewVersion`) and a
+ * paired write-side helper (`updateWhatsNewVersion`), both defined in
+ * scripts/audit-readme-whats-new-helpers.mjs, so the writer and the checker
+ * structurally cannot drift apart again.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+import { ROOT_DIR } from './version-utils.js'
+import { type BumpPlan } from './release-collision.js'
+import { hasWhatsNewHeading, updateWhatsNewVersion } from '../audit-readme-whats-new-helpers.mjs'
+
+/**
+ * Syncs each bumped package's README "What's New" heading (and TOC anchor, if
+ * present) to its new version and writes the file to disk. Returns the
+ * repo-relative paths of every README actually modified, so the caller can
+ * stage them into the release commit alongside package.json — writing them to
+ * disk without staging leaves Check 60 failing on the resulting PR exactly as
+ * before this fix (the single most load-bearing correction from the
+ * GPT-5.6-Sol plan review, SMI-5663).
+ *
+ * Per package:
+ *   - No README.md at all -> skipped (nothing to sync).
+ *   - README exists but has no "## What's New" heading at all -> skipped
+ *     silently. This mirrors Check 60's own asymmetric skip (most packages —
+ *     enterprise, vscode-extension, website, doc-retrieval-mcp — legitimately
+ *     have no such section).
+ *   - README has a "## What's New" heading but `updateWhatsNewVersion` can't
+ *     resolve it to exactly one parseable "## What's New in vX.Y.Z" match
+ *     (missing version suffix, or more than one heading) -> throws. Fails the
+ *     whole release-prep run rather than silently shipping a still-stale
+ *     README that Check 60 will catch anyway, later, with less context.
+ */
+export function syncReadmeWhatsNew(plans: BumpPlan[]): { updated: string[] } {
+  const updated: string[] = []
+
+  for (const plan of plans) {
+    const relPath = join(plan.spec.dir, 'README.md')
+    const fullPath = join(ROOT_DIR, relPath)
+    if (!existsSync(fullPath)) continue
+
+    const content = readFileSync(fullPath, 'utf-8')
+    if (!hasWhatsNewHeading(content)) continue
+
+    // Fail closed (not caught here) if the heading exists but is missing or
+    // ambiguous — see updateWhatsNewVersion's own doc comment.
+    const nextContent = updateWhatsNewVersion(content, plan.newVersion)
+    writeFileSync(fullPath, nextContent)
+    updated.push(relPath)
+  }
+
+  return { updated }
+}

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -51,6 +51,7 @@ import {
   buildFilesToAdd,
   regenerateLockfile,
 } from './lib/release-git.js'
+import { syncReadmeWhatsNew } from './lib/release-readme.js'
 
 // Re-export the helper surface so existing test imports continue to resolve
 // against `../prepare-release` (SMI-4783 keeps the public surface stable).
@@ -333,6 +334,19 @@ async function main(): Promise<void> {
     console.log(`  ✓ ${plan.spec.name}@${plan.newVersion}`)
   }
 
+  // Step 5.5: Sync each bumped package's README "What's New" heading (SMI-5663
+  // Wave 1) — Check 60 (SMI-5613) compares this heading against package.json
+  // and fails the release-cadence PR on drift. Throws (aborting this run) if
+  // a package's README has a "What's New" section that can't be resolved to
+  // exactly one heading; silently skips packages with no such section at all.
+  const { updated: updatedReadmeFiles } = syncReadmeWhatsNew(plans)
+  if (updatedReadmeFiles.length > 0) {
+    console.log(
+      `  ✓ Synced README "What's New" heading in ${updatedReadmeFiles.length} package(s):`
+    )
+    for (const path of updatedReadmeFiles) console.log(`    - ${path}`)
+  }
+
   // Step 6: Update workspace dep ranges in all sibling packages.
   //
   // SMI-5057: Replaces the older core-only updateCoreDependency. Walks every
@@ -345,6 +359,13 @@ async function main(): Promise<void> {
     console.log(`  ✓ Updated workspace dep ranges in ${updatedDepFiles.length} package(s):`)
     for (const path of updatedDepFiles) console.log(`    - ${path}`)
   }
+
+  // SMI-5663: combine every non-plan-derived file this run touched — README
+  // "What's New" syncs (Step 5.5) and workspace dep-range writes (Step 6) —
+  // into one extraFiles list, threaded through both the --no-commit preview
+  // (Step 10) and the real commit (Step 11) so neither can drift from what
+  // was actually written, matching SMI-5672's buildFilesToAdd contract.
+  const extraFiles = [...updatedReadmeFiles, ...updatedDepFiles]
 
   // Step 6.5: Regenerate package-lock.json so the lockfile matches the bumped
   // dep ranges (SMI-4775). Without this, the publish workflow ships a
@@ -405,7 +426,7 @@ async function main(): Promise<void> {
     // --no-changelog was passed.
     const modified = buildFilesToAdd(plans, {
       includeLockfile: !noLockfileRegen,
-      extraFiles: updatedDepFiles,
+      extraFiles,
       noChangelog,
     })
     for (const f of modified) console.log(`    - ${f}`)
@@ -414,9 +435,10 @@ async function main(): Promise<void> {
   }
 
   // Step 11: Commit (include package-lock.json when regen ran, plus the
-  // workspace dep-range files updateWorkspaceDependencies wrote — SMI-5672).
+  // workspace dep-range files updateWorkspaceDependencies wrote, plus any
+  // synced README "What's New" headings — SMI-5672, SMI-5663).
   const preBranch = getCurrentBranch()
-  createCommit(plans, !noLockfileRegen, updatedDepFiles)
+  createCommit(plans, !noLockfileRegen, extraFiles)
 
   // Step 12: Post-commit branch verification
   const postBranch = getCurrentBranch()
@@ -433,7 +455,7 @@ async function main(): Promise<void> {
   // closing the trust gap that let the original dep-range-drop bug ship silently.
   const staged = buildFilesToAdd(plans, {
     includeLockfile: !noLockfileRegen,
-    extraFiles: updatedDepFiles,
+    extraFiles,
   })
   console.log('  Staged files:')
   for (const f of staged) console.log(`    - ${f}`)

--- a/scripts/tests/audit-readme-whats-new.test.ts
+++ b/scripts/tests/audit-readme-whats-new.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { extractWhatsNewVersion } from '../audit-readme-whats-new-helpers.mjs'
+import {
+  extractWhatsNewVersion,
+  hasWhatsNewHeading,
+  githubHeadingSlug,
+  updateWhatsNewVersion,
+} from '../audit-readme-whats-new-helpers.mjs'
 
 describe('extractWhatsNewVersion', () => {
   it('extracts the version from a heading with a leading "v"', () => {
@@ -27,5 +32,103 @@ describe('extractWhatsNewVersion', () => {
   it('only matches at line start, not mid-sentence text with the same words', () => {
     const content = "See the section on What's New in v1.2.3 for details, below the fold."
     expect(extractWhatsNewVersion(content)).toBeNull()
+  })
+})
+
+describe('hasWhatsNewHeading (SMI-5663 Wave 1)', () => {
+  it('returns true when a versioned heading exists', () => {
+    expect(hasWhatsNewHeading("## What's New in v1.2.3\n\n- Bullet")).toBe(true)
+  })
+
+  it('returns true for a heading with no parseable version (loose match)', () => {
+    expect(hasWhatsNewHeading("## What's New\n\n- Bullet with no version")).toBe(true)
+  })
+
+  it('returns false when no "What\'s New" heading exists at all', () => {
+    expect(hasWhatsNewHeading('# Package\n\n## Installation\n\nnpm install foo')).toBe(false)
+  })
+
+  it('returns false for a deeper sub-heading', () => {
+    expect(hasWhatsNewHeading("### What's New in v1.2.3\n\n- Bullet")).toBe(false)
+  })
+})
+
+describe('githubHeadingSlug (SMI-5663 Wave 1)', () => {
+  it('matches the real anchor packages/core/README.md uses for "What\'s New in v0.11.4"', () => {
+    expect(githubHeadingSlug("What's New in v0.11.4")).toBe('whats-new-in-v0114')
+  })
+
+  it('matches the real anchor packages/cli/README.md uses for "What\'s New in v0.8.4"', () => {
+    expect(githubHeadingSlug("What's New in v0.8.4")).toBe('whats-new-in-v084')
+  })
+})
+
+describe('updateWhatsNewVersion (SMI-5663 Wave 1)', () => {
+  it('rewrites a versioned heading to the new version', () => {
+    const content = "# Package\n\n## What's New in v0.11.4\n\n- Bullet\n"
+    expect(updateWhatsNewVersion(content, '0.11.5')).toBe(
+      "# Package\n\n## What's New in v0.11.5\n\n- Bullet\n"
+    )
+  })
+
+  it('preserves everything else in the file untouched', () => {
+    const content =
+      "# @skillsmith/core\n\n## Contents\n\n- [Installation](#installation)\n\n## What's New in v0.11.4\n\n- Security fix\n\n## Installation\n\nnpm install\n"
+    const updated = updateWhatsNewVersion(content, '0.11.5')
+    expect(updated).toContain('## Installation\n\nnpm install')
+    expect(updated).toContain('- Security fix')
+    expect(updated).toContain("## What's New in v0.11.5")
+  })
+
+  it('also rewrites a matching TOC anchor link', () => {
+    const content =
+      "# @skillsmith/core\n\n## Contents\n\n- [What's New](#whats-new-in-v0114)\n- [Installation](#installation)\n\n## What's New in v0.11.4\n\n- Bullet\n"
+    const updated = updateWhatsNewVersion(content, '0.11.5')
+    expect(updated).toContain("- [What's New](#whats-new-in-v0115)")
+    expect(updated).not.toContain('#whats-new-in-v0114')
+  })
+
+  it('does not touch an unrelated TOC anchor', () => {
+    const content =
+      "## Contents\n\n- [What's New](#whats-new-in-v084)\n- [Installation](#installation)\n\n## What's New in v0.8.4\n\n- Bullet\n"
+    const updated = updateWhatsNewVersion(content, '0.8.5')
+    expect(updated).toContain('#installation')
+  })
+
+  it('rewrites the TOC anchor correctly when the heading has no leading "v" (code-review regression, SMI-5663)', () => {
+    // The heading regex tolerates a missing "v" ("## What's New in 1.2.3"),
+    // but the old slug used to be reconstructed with a hardcoded "v" prefix
+    // regardless of what the real heading said — computing "whats-new-in-v123"
+    // instead of the real old anchor "whats-new-in-123", so the TOC link
+    // rewrite never matched and silently left a stale anchor behind.
+    const content =
+      "## Contents\n\n- [What's New](#whats-new-in-123)\n\n## What's New in 1.2.3\n\n- Bullet\n"
+    const updated = updateWhatsNewVersion(content, '1.2.4')
+    expect(updated).toContain("- [What's New](#whats-new-in-v124)")
+    expect(updated).not.toContain('#whats-new-in-123')
+  })
+
+  it('leaves the file unchanged when there is no TOC anchor to update (mcp-server shape)', () => {
+    const content = "# @skillsmith/mcp-server\n\n## What's New in v0.7.6\n\n- Bullet\n"
+    const updated = updateWhatsNewVersion(content, '0.7.7')
+    expect(updated).toBe("# @skillsmith/mcp-server\n\n## What's New in v0.7.7\n\n- Bullet\n")
+  })
+
+  it('throws when no "What\'s New" heading exists', () => {
+    expect(() => updateWhatsNewVersion('# Package\n\n## Installation\n', '1.0.0')).toThrow(
+      /no "## What's New in vX.Y.Z" heading found/
+    )
+  })
+
+  it('throws when the heading exists but has no parseable version', () => {
+    expect(() =>
+      updateWhatsNewVersion("## What's New\n\n- Bullet with no version", '1.0.0')
+    ).toThrow(/no "## What's New in vX.Y.Z" heading found/)
+  })
+
+  it('throws (fails closed) when more than one matching heading exists — ambiguous', () => {
+    const content =
+      "## What's New in v1.0.0\n\n- Bullet\n\n## Archive\n\n## What's New in v0.9.0\n\n- Old bullet\n"
+    expect(() => updateWhatsNewVersion(content, '1.1.0')).toThrow(/ambiguous/)
   })
 })

--- a/scripts/tests/release-readme.test.ts
+++ b/scripts/tests/release-readme.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for scripts/lib/release-readme.ts (SMI-5663 Wave 1) — README "What's
+ * New" sync, the missing half of the fix for Check 60 (SMI-5613) failing every
+ * release-cadence PR since 2026-08-02.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { writeFileSync, readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+
+// ESM-safe module mock (must be declared before importing SUT) — matches the
+// convention in scripts/tests/prepare-release.test.ts and
+// scripts/tests/release-git.test.ts. All three fs functions are wrapped so
+// individual tests can override read-side behavior for synthetic fixtures
+// while defaulting to calling through to the real implementation (needed by
+// the "real repo packages" tests below, which read this repo's actual
+// packages/*/README.md files).
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    writeFileSync: vi.fn(actual.writeFileSync),
+    readFileSync: vi.fn(actual.readFileSync),
+    existsSync: vi.fn(actual.existsSync),
+  }
+})
+
+import { syncReadmeWhatsNew } from '../lib/release-readme'
+import { PACKAGE_SPECS, ROOT_DIR, type PackageSpec } from '../lib/version-utils'
+import type { BumpPlan } from '../lib/release-collision'
+
+const mockedWriteFileSync = vi.mocked(writeFileSync)
+const mockedReadFileSync = vi.mocked(readFileSync)
+const mockedExistsSync = vi.mocked(existsSync)
+
+function planFor(shortName: string, newVersion: string): BumpPlan {
+  const spec = PACKAGE_SPECS.find((s) => s.shortName === shortName)!
+  return { spec, currentVersion: '0.0.0', newVersion }
+}
+
+describe('syncReadmeWhatsNew — real repo packages (SMI-5663 Wave 1)', () => {
+  beforeEach(() => {
+    mockedWriteFileSync.mockClear()
+    // Critical: prevent the spy from calling through to the real
+    // writeFileSync — this test must never mutate the working tree's READMEs.
+    mockedWriteFileSync.mockImplementation(() => {})
+  })
+
+  it('updates and stages the README for each of the 3 packages that carry a "What\'s New" section', () => {
+    const plans = [
+      planFor('core', '9.9.9'),
+      planFor('cli', '9.9.9'),
+      planFor('mcp-server', '9.9.9'),
+    ]
+
+    const { updated } = syncReadmeWhatsNew(plans)
+
+    expect(updated).toContain('packages/core/README.md')
+    expect(updated).toContain('packages/cli/README.md')
+    expect(updated).toContain('packages/mcp-server/README.md')
+    expect(updated).toHaveLength(3)
+    expect(mockedWriteFileSync).toHaveBeenCalledTimes(3)
+  })
+
+  it('writes the new heading text into the file content passed to writeFileSync', () => {
+    syncReadmeWhatsNew([planFor('core', '9.9.9')])
+
+    const write = mockedWriteFileSync.mock.calls.find((c) =>
+      String(c[0]).endsWith('packages/core/README.md')
+    )
+    expect(write).toBeDefined()
+    const writtenContent = String(write![1])
+    expect(writtenContent).toContain("## What's New in v9.9.9")
+    // The real core README's own current heading version must be gone.
+    expect(writtenContent).not.toMatch(/^## What's New in v(?!9\.9\.9)/m)
+  })
+
+  it("also rewrites the core README's TOC anchor to match the new version", () => {
+    syncReadmeWhatsNew([planFor('core', '9.9.9')])
+
+    const write = mockedWriteFileSync.mock.calls.find((c) =>
+      String(c[0]).endsWith('packages/core/README.md')
+    )
+    const writtenContent = String(write![1])
+    expect(writtenContent).toContain('#whats-new-in-v999')
+  })
+
+  it('skips packages with no "What\'s New" section at all (enterprise) without writing or throwing', () => {
+    const enterprisePlan = planFor('enterprise', '9.9.9')
+    expect(existsSync(join(ROOT_DIR, 'packages/enterprise/README.md'))).toBe(true)
+
+    const { updated } = syncReadmeWhatsNew([enterprisePlan])
+
+    expect(updated).not.toContain('packages/enterprise/README.md')
+    expect(mockedWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('skips a package with no README.md at all without throwing', () => {
+    const fakeSpec: PackageSpec = {
+      name: '@fake/package',
+      shortName: 'fake',
+      dir: 'packages/does-not-exist',
+      packageJsonPath: 'packages/does-not-exist/package.json',
+    }
+    const plan: BumpPlan = { spec: fakeSpec, currentVersion: '1.0.0', newVersion: '1.0.1' }
+
+    const { updated } = syncReadmeWhatsNew([plan])
+
+    expect(updated).toHaveLength(0)
+    expect(mockedWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op returning an empty updated list for an empty plans array', () => {
+    expect(syncReadmeWhatsNew([])).toEqual({ updated: [] })
+    expect(mockedWriteFileSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('syncReadmeWhatsNew — fail-closed on a malformed/ambiguous heading (SMI-5663 Wave 1)', () => {
+  // These scenarios can't be reproduced against real repo READMEs (none are
+  // malformed today), so this block overrides the read-side fs mocks for a
+  // synthetic package that "exists" only inside the mock.
+  const fixtureSpec: PackageSpec = {
+    name: '@fixture/pkg',
+    shortName: 'fixture-pkg',
+    dir: 'packages/fixture-pkg',
+    packageJsonPath: 'packages/fixture-pkg/package.json',
+  }
+  const fixturePlan: BumpPlan = {
+    spec: fixtureSpec,
+    currentVersion: '1.0.0',
+    newVersion: '1.1.0',
+  }
+
+  beforeEach(() => {
+    mockedWriteFileSync.mockClear()
+    mockedWriteFileSync.mockImplementation(() => {})
+    mockedExistsSync.mockReset()
+    mockedExistsSync.mockReturnValue(true)
+  })
+
+  // This is the last describe block in the file — readFileSync/existsSync are
+  // left permanently overridden after it runs rather than restored to a
+  // call-through default, since nothing later in this file needs real reads.
+  afterEach(() => {
+    mockedReadFileSync.mockReset()
+  })
+
+  it('throws when the README has a "What\'s New" heading with no parseable version', () => {
+    mockedReadFileSync.mockReturnValue(
+      "# Fixture\n\n## What's New\n\n- Bullet with no version\n" as unknown as Buffer
+    )
+
+    expect(() => syncReadmeWhatsNew([fixturePlan])).toThrow(
+      /no "## What's New in vX\.Y\.Z" heading found/
+    )
+    expect(mockedWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  it('throws (does not silently pick the first match) when two headings exist', () => {
+    mockedReadFileSync.mockReturnValue(
+      "## What's New in v1.0.0\n\n- Bullet\n\n## Archive\n\n## What's New in v0.9.0\n\n- Old\n" as unknown as Buffer
+    )
+
+    expect(() => syncReadmeWhatsNew([fixturePlan])).toThrow(/ambiguous/)
+    expect(mockedWriteFileSync).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** The weekly automated release PR now has a real chance to merge — 6 of the last 8 got auto-closed unmerged instead of landing. Fixed the root causes: the release script wasn't syncing a README section that a separate check requires, the staleness watcher was measuring age from the wrong timestamp (effectively shrinking the review window below a weekend), and a too-low commits-behind threshold was closing PRs a full day before they'd even hit the age limit. The watcher also now warns before it closes anything, and preserves the branch when it does close.

**Quality bar:** Plan-reviewed and code-reviewed twice by GPT-5.6-Sol (cross-provider, via NEEDLE). Both review rounds found real defects — a policy conflict that removed an entire wave from scope, a fix that wouldn't have actually worked (writing a file without staging it into the commit), a wrong-attribution bug, an anchor-link bug for an edge-case heading format, and a comment-pagination reliability gap — all fixed and verified. 29 tests covering the README-sync logic, all passing; the workflow change validated with actionlint and reasoned through against the real PR history that caused this bug.

**Found along the way:** the original plan called for enabling auto-merge on these PRs (Wave 3). Plan review caught that this would let a PR merge mid-review, since branch protection currently requires zero approvals — directly contradicting this repo's own release policy (ADR-114). That wave is intentionally **not** included here; it needs a separate policy decision (either keep manual merge, or add a required-review rule first) before it's safe to build.

**Net result:** Fully shipped for the two waves that don't require a policy call. PR #2277 already served as the immediate stopgap and is merged. Auto-merge remains open, tracked separately.

---

## Technical detail

- `scripts/prepare-release.ts` + new `scripts/lib/release-readme.ts` — syncs each bumped package's README "What's New" heading and TOC anchor, using a new write-side helper (`updateWhatsNewVersion`, paired with the existing read-side `extractWhatsNewVersion` in `scripts/audit-readme-whats-new-helpers.mjs`), and stages the updated READMEs into the actual release commit.
- `.github/workflows/release-cadence-pr-staleness.yml` — age from PR `createdAt` (not head-commit timestamp); `mergeable == "CONFLICTING"` replaces commits-behind as the real staleness signal; two-stage nag-then-close (idempotent nag comment, close only if still open 7 days later, branch preserved).
- Plan doc: `docs/internal/implementation/smi-5663-release-cadence-staleness-fix.md` (separate PR #697 in skillsmith-docs, twice plan-reviewed).

Refs SMI-5663