### PR TITLE
fix(ci): SMI-5987 detect real test failures through ANSI coloring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1430,7 +1430,18 @@ jobs:
             skillsmith-ci:${{ github.sha }} \
             npx vitest run --config vitest.config.colocated.ts --passWithNoTests 2>&1 | tee /tmp/vitest-colocated.log
           DOCKER_EXIT=${PIPESTATUS[0]}
-          if grep -qE '❯.*\| [1-9][0-9]* failed' /tmp/vitest-colocated.log; then
+          # SMI-5987: vitest's own colored terminal output interleaves ANSI
+          # escape codes between the `|` and the failure-count digit (e.g.
+          # `❯ ... | <ESC>[22m<ESC>[31m2 failed`), so the failure-marker
+          # regex above never matched a real failure line — this job has
+          # been structurally unable to fail on a genuine test failure
+          # since 05a9bb632 (2026-05-03). Strip SGR color codes before matching
+          # so failure detection is robust to terminal coloring; the raw
+          # (colored) log is still what a human reads in the Actions UI.
+          # (Code-review nit, SMI-5987: this regex targets SGR/color codes
+          # specifically, not every ANSI/CSI sequence — vitest's stdout here
+          # is a pipe, not a TTY, so cursor/erase controls aren't expected.)
+          if sed -r 's/\x1b\[[0-9;]*m//g' /tmp/vitest-colocated.log | grep -qE '❯.*\| [1-9][0-9]* failed'; then
             echo "::error::vitest reported test failures (see ❯ lines above)"
             exit 1
           fi


### PR DESCRIPTION
## Business Summary

**What shipped:** The CI job meant to catch test failures on every PR has been unable to actually fail on a real test failure since May — a color-formatting mismatch meant its failure-detection check silently never matched. Fixed the detection so it correctly sees through terminal coloring.

**Quality bar:** Code-reviewed by GPT-5.6-Sol (cross-provider, via NEEDLE) — APPROVE WITH NITS, nit applied. Verified against real captured vitest output (a deliberately-failing throwaway test): the old check misses a real failure, the new one catches it, and a real passing run produces no false alarm.

**Net result:** Implemented and ready, but held as a **draft PR** — merging this before SMI-5986 (PR #2295) lands would immediately turn every other open PR red on that pre-existing, unrelated regression, since this is the exact bug this fix repairs. Mark ready for review once #2295 merges.

---

## Technical detail

`.github/workflows/ci.yml` — strips ANSI SGR color codes from the captured vitest log before the existing failure-count grep runs. The SMI-4667 advisory-ignore fallback (nonzero Docker exit with no detected failures) is unaffected.

Refs SMI-5987