### PR TITLE
fix(hooks): SMI-5993 pre-commit git-crypt lock has no signal-safety net

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -313,6 +313,46 @@ if [ -n "$EXPECTED_BRANCH" ]; then
         if mkdir "$GIT_CRYPT_LOCK_DIR" 2>/dev/null; then
           echo "$$" > "$GIT_CRYPT_LOCK_DIR/pid" 2>/dev/null
           GIT_CRYPT_LOCK_HELD=1
+          # SMI-5983 (governance retro): self-release on a signal landing
+          # between acquire and the caller's own explicit release below --
+          # without this, unlike the bash-side
+          # acquire_git_crypt_filter_lock() (scripts/_lib.sh), which arms an
+          # equivalent trap at acquire time, an ordinary SIGINT/SIGTERM
+          # during the disabled-precheck/restore-definition spans left this
+          # repo-shared lock dangling forever (no auto-reclaim by design),
+          # hard-failing every OTHER worktree's git-crypt filter operation
+          # with the "never auto-reclaims" message below until a human ran
+          # the printed `rmdir` -- confirmed via direct reproduction
+          # (`kill -TERM` mid-lock-hold leaves the lock dir on disk).
+          # INT/TERM only, deliberately NOT EXIT: every code path between
+          # this acquire and the caller's own explicit release is
+          # deterministic, signal-free control flow (the disabled-precheck
+          # span always either hard-fails via an explicit release+exit, or
+          # falls straight through into the restore-definition span, which
+          # always releases explicitly on both its branches) -- there is no
+          # plain/error exit in that window for an EXIT trap to guard
+          # against, and arming one anyway would release the lock on ANY
+          # process exit reachable from inside this function, including a
+          # test harness or a future caller that intentionally checks
+          # intermediate lock state before the real hook continues past this
+          # point (confirmed by exactly this regression when EXIT was
+          # included in an earlier draft of this fix -- see
+          # scripts/tests/git-crypt-pre-commit-disable.test.ts's "proceeds
+          # past the precheck" test). Plain (non-composing) registration is
+          # correct here: this is the first `trap` call anywhere in this
+          # hook, so there is no prior handler to preserve.
+          # `_release_git_crypt_lock` is idempotent (a no-op once
+          # GIT_CRYPT_LOCK_HELD is cleared), so this trap firing again later
+          # -- after the caller's own explicit release (the hard-fail
+          # branch, or the disable sequence's release-before-bigger-trap-
+          # arm), after the bigger
+          # `trap '_restore_smudge_filter' EXIT INT TERM` below overwrites
+          # it outright, or from the re-acquire inside
+          # _restore_smudge_filter() itself -- is always harmless; it only
+          # ever protects the lock's own cleanup, never the filter VALUES
+          # (which the marker + two-signal heal mechanism protects
+          # regardless).
+          trap '_release_git_crypt_lock' INT TERM
           return 0
         fi
         _wait_i=$((_wait_i + 1))

--- a/scripts/tests/git-crypt-pre-commit-disable.test.ts
+++ b/scripts/tests/git-crypt-pre-commit-disable.test.ts
@@ -29,7 +29,7 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest'
-import { execFileSync, spawnSync } from 'node:child_process'
+import { execFileSync, spawn, spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -248,6 +248,83 @@ describe('SMI-5983 (governance follow-up): full disable-then-restore cycle (rest
     expect(getConfig(dir, 'filter.git-crypt.smudge')).toBe('')
     expect(getConfig(dir, 'skillsmith.git-crypt-disabled-marker')).toBe('')
   })
+})
+
+describe('SMI-5983 (governance retro): lock-helpers span self-releases on signal, not just on explicit release', () => {
+  // Companion to git-crypt-filter-lock-trap-composition.test.ts's INT/TERM
+  // coverage of the BASH-side acquire_git_crypt_filter_lock() (_lib.sh),
+  // which self-arms an EXIT/INT/TERM release trap at acquire time. Before
+  // this fix, the POSIX-sh duplicate here had NO such self-protection: a
+  // signal landing between `_acquire_git_crypt_lock` returning and the
+  // caller's own explicit `_release_git_crypt_lock` call (i.e. anywhere in
+  // the disabled-precheck/restore-definition spans) left the repo-shared
+  // lock directory dangling forever (no auto-reclaim by design), hard-
+  // blocking every OTHER worktree's git-crypt filter operation until a
+  // human ran the printed `rmdir` -- confirmed via direct reproduction
+  // (a real `kill -TERM` delivered while the lock was held, below).
+  it('self-delivered SIGINT immediately after acquire still releases the lock (no dangling lock dir)', () => {
+    const dir = makeRepo()
+    const result = runShInRepo(
+      dir,
+      `${LOCK_HELPERS_SPAN}\n_acquire_git_crypt_lock\nkill -INT $$\necho AFTER_SIGNAL\n`
+    )
+    expect(result.combined).not.toMatch(/syntax error/i)
+    expect(existsSync(join(dir, '.git', 'skillsmith-git-crypt-filter.lock'))).toBe(false)
+  })
+
+  it('self-delivered SIGTERM immediately after acquire still releases the lock (no dangling lock dir)', () => {
+    const dir = makeRepo()
+    const result = runShInRepo(
+      dir,
+      `${LOCK_HELPERS_SPAN}\n_acquire_git_crypt_lock\nkill -TERM $$\necho AFTER_SIGNAL\n`
+    )
+    expect(result.combined).not.toMatch(/syntax error/i)
+    expect(existsSync(join(dir, '.git', 'skillsmith-git-crypt-filter.lock'))).toBe(false)
+  })
+
+  it(
+    'a real, externally-delivered SIGTERM landing while the lock is held (before the ' +
+      "caller's own explicit release) still releases it -- the exact scenario reproduced " +
+      'against the pre-fix hook (kill -TERM mid-lock-hold left the lock dir on disk)',
+    async () => {
+      const dir = makeRepo()
+      const script = `${LOCK_HELPERS_SPAN}\n_acquire_git_crypt_lock\necho LOCK_ACQUIRED\nsleep 5\necho SHOULD_NOT_REACH\n`
+      const child = spawn(REAL_SH, ['-c', script], { cwd: dir, env: GIT_ENV })
+      let stdout = ''
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString()
+      })
+
+      await new Promise<void>((resolvePromise, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error('timed out waiting for LOCK_ACQUIRED')),
+          10_000
+        )
+        const check = setInterval(() => {
+          if (stdout.includes('LOCK_ACQUIRED')) {
+            clearInterval(check)
+            clearTimeout(timer)
+            child.kill('SIGTERM')
+            resolvePromise()
+          }
+        }, 20)
+      })
+
+      await new Promise<void>((resolvePromise) => child.once('exit', () => resolvePromise()))
+
+      // Not asserting the process terminated on SIGTERM: the fix's own trap
+      // (`trap '_release_git_crypt_lock' INT TERM`) deliberately does not
+      // call `exit` in its handler, matching this file's pre-existing
+      // `trap '_restore_smudge_filter' EXIT INT TERM` convention elsewhere
+      // in the real hook (also handler-only, no explicit exit) -- POSIX sh
+      // continues past the interrupted `sleep` once a signal is trapped
+      // (confirmed via direct reproduction), so "SHOULD_NOT_REACH" DOES
+      // print here; that is expected, not a regression. The only invariant
+      // this test guards is the lock's own cleanup.
+      expect(existsSync(join(dir, '.git', 'skillsmith-git-crypt-filter.lock'))).toBe(false)
+    },
+    15_000
+  )
 })
 
 describe('SMI-5983 (governance follow-up): regression guard for the trap/lock reentrancy fix', () => {


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a leftover gap in `.husky/pre-commit`'s copy of the SMI-5983 git-crypt
lock: if the process was interrupted (Ctrl-C, or a background kill) at the wrong moment, the
shared lock could be left stuck forever, blocking git-crypt operations for every worktree until
someone manually removed it by hand.

**Quality bar:** Found by a post-merge `/governance` retrospective on SMI-5983 (this repo's
required PR-merge follow-up check), reproduced directly with a real interrupt signal before
being fixed. Full suite green, `audit:standards` clean.

**Found along the way:** none — the one issue this retro surfaced is fixed in this same PR.

**Net result:** Fully shipped, no follow-up needed.

---

## Technical detail

`.husky/pre-commit`'s POSIX-sh git-crypt filter lock (`_acquire_git_crypt_lock`/
`_release_git_crypt_lock`) is a hand-duplicated sibling of `scripts/_lib.sh`'s bash
`acquire_git_crypt_filter_lock()` (needed because git hooks run under `#!/bin/sh`, which lacks
`local`/`[[ ]]`/`trap`-composition support the bash version uses). The bash version arms a
release trap at acquire time; the POSIX version didn't. A signal delivered while the lock was
held (before the caller's own explicit release) left the lock directory on disk with no
auto-cleanup — reproduced directly via `kill -TERM` mid-lock-hold.

Fix: `trap '_release_git_crypt_lock' INT TERM` added right after the lock directory is created.
INT/TERM only, not EXIT — every code path in the window this trap covers is deterministic,
signal-free control flow, so an EXIT trap would have nothing legitimate to guard against and
would incorrectly fire on normal exits reachable from inside the function (confirmed by a
regression in an earlier draft of this fix). `_release_git_crypt_lock` is already idempotent, so
this trap firing again later (after the explicit release, or after the hook's larger restore
trap overwrites it) is harmless.

3 new tests in `scripts/tests/git-crypt-pre-commit-disable.test.ts`: self-delivered SIGINT,
self-delivered SIGTERM, and a real externally-delivered SIGTERM via `spawn`+`kill` while the
child process is mid-lock-hold — the exact scenario originally reproduced.

Refs SMI-5993 (filed as a sub-issue of SMI-5983, whose own PR #2293 already merged).
