### PR TITLE
fix(scripts): SMI-5990 repair approval_status drift in E2E seed fixture

### DIFF
--- a/scripts/seed-e2e-registry-users.ts
+++ b/scripts/seed-e2e-registry-users.ts
@@ -252,6 +252,44 @@ async function main(): Promise<void> {
     )
     process.exit(1)
   }
+
+  // 7c. Repair approval_status/approval_mode too, same rationale as 7b (SMI-5990). The
+  //     20260809000000_private_registry_approval_gate.sql migration installs an UNCONDITIONAL
+  //     `trg_prs_approval` BEFORE INSERT trigger with no service-role carve-out, so this row is
+  //     born approval_status='pending'/approval_mode='review' on first insert regardless of who
+  //     or what inserted it -- and ignoreDuplicates above means a re-run never touches an
+  //     already-existing row's columns, so it stays 'pending' forever. Because
+  //     private_registry_skills_member_read requires approval_status = 'approved', a pending row
+  //     has NO RLS read path at all (not just denied), so it silently 404s instead of 403ing for
+  //     e2e-registry-roundtrip.ts's row5/row6/mcp-live-row6 assertions -- this is the exact bug
+  //     SMI-5990 diagnosed against staging. Can't repair via review_private_registry_submission()
+  //     instead: it refuses a service-role caller AND refuses self-approval, and Team B's only
+  //     admin (nonentId) is this row's own publisher, so a direct service-role UPDATE is the only
+  //     path. approval_mode is set to 'auto' (not left as 'review') to preserve the invariant
+  //     documented on the column itself (20260809000000_private_registry_approval_gate.sql): "an
+  //     approved row with approved_by NULL is legitimate iff approval_mode = 'auto'" --
+  //     approved_by/approved_at are nulled here for the same reason. `.neq('approval_status',
+  //     'approved')` rather than `.eq(..., 'pending')` so a 'rejected' drift is repaired too, not
+  //     just 'pending'.
+  const { error: approvalRepairErr } = await admin
+    .from('private_registry_skills')
+    .update({
+      approval_status: 'approved',
+      approval_mode: 'auto',
+      approved_by: null,
+      approved_at: null,
+    })
+    .eq('team_id', teamBId)
+    .eq('skill_id', durableSkillId)
+    .eq('version', DURABLE_SKILL_VERSION)
+    .neq('approval_status', 'approved')
+  if (approvalRepairErr) {
+    console.error(
+      `[SMI-5922 seed] Durable skill approval-status repair failed (SMI-5990): ${approvalRepairErr.message}`
+    )
+    process.exit(1)
+  }
+
   console.error(`[SMI-5922 seed] Durable Team B skill ready: ${durableSkillId}`)
 
   // 8. Final-state assertion before printing IDs — a partial prior run must self-heal on
@@ -311,7 +349,7 @@ async function main(): Promise<void> {
 
   const { data: finalSkill, error: finalSkillErr } = await admin
     .from('private_registry_skills')
-    .select('team_id,deprecated')
+    .select('team_id,deprecated,approval_status,approval_mode')
     .eq('team_id', teamBId)
     .eq('skill_id', durableSkillId)
     .eq('version', DURABLE_SKILL_VERSION)
@@ -321,7 +359,17 @@ async function main(): Promise<void> {
     process.exit(1)
   }
   if (!finalSkill) missing.push('Team B durable skill row')
-  else if (finalSkill.deprecated) missing.push('Team B durable skill row (still deprecated)')
+  else {
+    if (finalSkill.deprecated) missing.push('Team B durable skill row (still deprecated)')
+    // SMI-5990: a non-'approved' row has NO RLS read path at all (private_registry_skills_member_
+    // read requires approval_status = 'approved'), so a silent pass here would mask a real
+    // production-shaped 404-vs-403 bug for every read transport, not just a test artifact.
+    if (finalSkill.approval_status !== 'approved')
+      missing.push(
+        `Team B durable skill row approval_status (got ${finalSkill.approval_status}, want ` +
+          'approved -- otherwise RLS hides the row from every read transport, SMI-5990)'
+      )
+  }
 
   const { data: finalSubs, error: finalSubsErr } = await admin
     .from('subscriptions')


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a gap in the E2E staging fixture setup that let the private registry's cross-team entitlement-denial safety check go silently unverified — the test that proves a user can't read a skill via another team's Enterprise plan was returning "not found" instead of the expected "forbidden," which meant the specific historical bug class it guards against (leaking access via an unrelated team's Enterprise membership) wasn't actually being exercised in CI.

**Quality bar:** Root-caused against live staging data (not assumed) via a direct read-only query confirming the fixture's real database state, plus inspection of the deployed RLS policy. Typecheck/lint/format clean. Re-validated end-to-end against staging post-fix before opening this PR (see Technical detail for the run link).

**Net result:** Fully shipped — the durable test fixture now self-repairs its approval status on every seed run, and a new assertion makes this specific failure mode loud instead of silent going forward.

---

## Technical detail

**Root cause:** `20260809000000_private_registry_approval_gate.sql`'s `trg_prs_approval` trigger unconditionally sets `approval_status='pending'` on every row insert, with no service-role carve-out. `scripts/seed-e2e-registry-users.ts`'s durable Team B fixture is inserted via a service-role upsert with `ignoreDuplicates: true`, so it was born `pending` and stayed that way forever on re-runs — unlike the `deprecated` column, which already had an explicit repair step (7b). A `pending` row has zero RLS read path under `private_registry_skills_member_read` (requires `approval_status = 'approved'`), so `private-registry-get`'s metadata read returned zero rows and short-circuited to 404 before the entitlement check it was supposed to exercise ever ran.

**Fix (`scripts/seed-e2e-registry-users.ts`):**
- New step 7c: repairs `approval_status`/`approval_mode`/`approved_by`/`approved_at` on every seed run, mirroring step 7b's existing `deprecated` repair. Uses `service_role` directly (not `review_private_registry_submission()`, which refuses service-role callers and self-approval, and Team B's only admin is this row's own publisher).
- Extended the step-8 final-state assertion to check `approval_status`, so a drifted fixture fails loudly instead of reporting a false "OK".

**Staging remediation:** Applied a one-time direct `UPDATE` to the live staging fixture (`durable-skill`, Team B) to unblock CI immediately, separate from the durable code fix above.

**Validation:** Manually dispatched `private-registry-e2e.yml` (`workflow_dispatch`) against this branch post-fix, targeting staging (`ovhcifugwqnzoebwfuku`): https://github.com/smith-horn/skillsmith/actions/runs/31508347693. Confirmed via the spec step's actual stdout and the guard step's `SPEC_EXIT`/`SPEC_OUTCOME` env (not just job conclusion — the spec step carries `continue-on-error: true` by design, SMI-5965) that `18/18 checks passed`, including:
- `row5-nonent-403` — now 403 `"Enterprise subscription required for this private registry"`
- `row6-dual-membership-403` — now 403, same message (the dual-membership actor's OTHER team's Enterprise plan no longer leaks access)
- `mcp-live-row6` — now throws the expected entitlement-denial message instead of returning `null`

Refs SMI-5990
