### PR TITLE
feat(website): wire private registry + governance content into SEO/AEO surfaces

### DIFF
--- a/.claude/development/mcp-tools-guide.md
+++ b/.claude/development/mcp-tools-guide.md
@@ -15,6 +15,9 @@ Reference for Skillsmith MCP server tools, authentication, and CLI.
 | `compare` | Compare 2-5 skills side-by-side |
 | `skill_diff` | Diff two installed skill versions side-by-side |
 | `skill_audit` | Audit skill for security advisories (Team+) |
+| `publish_private` | Mark a skill private on this device, hidden from your own search results (Team+) |
+| `private_registry_publish` | Publish a skill version to your team's private registry as a pending submission (Enterprise) |
+| `private_registry_manage` | List/get/install/deprecate/undeprecate/review your team's private registry via the `action` parameter (Enterprise) |
 
 ## Authentication
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,9 @@ Vitest only runs tests matching these patterns. Tests elsewhere are **silently i
 | `apply_namespace_rename` | Apply a rename suggestion from an audit (`apply` / `custom` / `skip`) (SMI-4590) |
 | `apply_recommended_edit` | Apply a recommended prose edit; gated on `APPLY_TEMPLATE_REGISTRY` (SMI-4590) |
 | `undo_apply` | Session-scoped undo of the most recent apply_namespace_rename/apply_recommended_edit changeset(s), restored from the apply tool's own backup (SMI-5456/SMI-5470) |
+| `publish_private` | Mark a skill private on this device, hidden from your own search results (Team+) |
+| `private_registry_publish` | Publish a skill version to your team's private registry as a pending submission (Enterprise) |
+| `private_registry_manage` | List/get/install/deprecate/undeprecate/review your team's private registry via the `action` parameter, including `submissions`/`approve`/`reject` (Enterprise) |
 | `audit_export` | Export audit log events for a time range (Enterprise) |
 | `audit_query` | Query audit logs with filters (Enterprise) |
 | `siem_export` | Export audit events for SIEM ingestion (Enterprise) |

--- a/packages/website/public/llms-full.txt
+++ b/packages/website/public/llms-full.txt
@@ -52,6 +52,9 @@ When using the MCP server, these tools are available:
 | `recommend` | context (optional) | Get project-based skill recommendations |
 | `validate` | path | Validate a skill's YAML structure |
 | `compare` | ids (2-5 skill IDs) | Compare skills side-by-side |
+| `publish_private` (Team+) | skillId | Mark a skill private on this device, hiding it from your own search results |
+| `private_registry_publish` (Enterprise) | skillId, version, content | Publish a skill version to your team's private registry as a pending submission requiring admin approval |
+| `private_registry_manage` (Enterprise) | action (list/get/install/deprecate/undeprecate/namespace/submissions/approve/reject), skillId | Manage your team's private registry, including reviewing pending submissions |
 
 ## CLI Commands
 
@@ -173,6 +176,9 @@ A: Open an issue at github.com/smith-horn/skillsmith/issues. Enterprise customer
 Q: Where are skills installed?
 A: Skills install to ~/.claude/skills/ by default and are automatically available in all sessions.
 
+Q: What is the private registry, and how does publishing get approved?
+A: The private registry (Enterprise tier) is a shared, org-scoped skill store — publish a skill once and every teammate can find and install it. A published version sits as a pending submission, invisible to search, get, and install (even to the person who published it) until a different team admin approves or rejects it. Self-approval is blocked at the database level. Both approve and reject are terminal — a rejected version can only be superseded by publishing a new version.
+
 ## Packages
 
 | Package | Install | Description |
@@ -194,6 +200,8 @@ Engineering and product articles covering Skillsmith development and AI-native w
 
 - Website: https://www.skillsmith.app
 - Documentation: https://www.skillsmith.app/docs
+- Private Registry: https://www.skillsmith.app/docs/private-registry
+- Governance: https://www.skillsmith.app/docs/governance
 - Skills Browser: https://www.skillsmith.app/skills
 - Pricing: https://www.skillsmith.app/pricing
 - GitHub: https://github.com/smith-horn/skillsmith

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -36,6 +36,8 @@ skillsmith list
 - [CLI Reference](https://www.skillsmith.app/docs/cli): Complete CLI command documentation
 - [MCP Server](https://www.skillsmith.app/docs/mcp-server): MCP integration configuration
 - [API Reference](https://www.skillsmith.app/docs/api): REST API documentation
+- [Private Registry](https://www.skillsmith.app/docs/private-registry): Enterprise-tier team registry — versioned, access-controlled, with a publish-and-approval workflow
+- [Governance](https://www.skillsmith.app/docs/governance): Publish review, deprecation, audit trails, compliance reporting, and automatic quarantine
 
 ## What Are Skills?
 
@@ -81,6 +83,9 @@ When using Skillsmith MCP server:
 - `recommend`: Get project-based skill recommendations
 - `validate`: Validate a skill's structure
 - `compare`: Compare multiple skills side-by-side
+- `publish_private` (Team+): Mark a skill private on this device, hiding it from your own search results
+- `private_registry_publish` (Enterprise): Publish a skill version to your team's private registry as a pending submission
+- `private_registry_manage` (Enterprise): List, get, install, deprecate, and review skills in your team's private registry — including approving/rejecting pending submissions
 
 ## Packages
 

--- a/packages/website/src/pages/docs/governance.astro
+++ b/packages/website/src/pages/docs/governance.astro
@@ -1,8 +1,34 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
+
+const techArticleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Governance, End to End',
+  description:
+    'How Skillsmith handles publish review, deprecation, audit trails, compliance reporting, and automatic quarantine across the skill lifecycle.',
+  url: 'https://www.skillsmith.app/docs/governance',
+  author: {
+    '@id': 'https://www.skillsmith.app/#organization',
+  },
+  publisher: {
+    '@type': 'Organization',
+    '@id': 'https://www.skillsmith.app/#organization',
+    name: 'Skillsmith',
+    url: 'https://www.skillsmith.app',
+  },
+  about: {
+    '@type': 'SoftwareApplication',
+    name: 'Skillsmith',
+    applicationCategory: 'DeveloperApplication',
+  },
+};
 ---
 
-<DocsLayout title="Governance, End to End" description="How Skillsmith handles deprecation, audit trails, compliance reporting, and automatic quarantine across the skill lifecycle">
+<DocsLayout title="Governance, End to End" description="How Skillsmith handles publish review, deprecation, audit trails, compliance reporting, and automatic quarantine across the skill lifecycle">
+  <!-- JSON-LD TechArticle Schema -->
+  <script is:inline type="application/ld+json" slot="head" set:html={JSON.stringify(techArticleSchema)} />
+
   <h1>Governance, End to End</h1>
 
   <p class="lead">

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -1,8 +1,43 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
+
+const howToSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to Configure the Skillsmith MCP Server',
+  description:
+    'Add the Skillsmith MCP server to an MCP-compatible AI assistant to search, install, and manage agent skills using natural language.',
+  tool: [
+    { '@type': 'HowToTool', name: 'Node.js 18+' },
+    { '@type': 'HowToTool', name: 'MCP-compatible AI assistant' },
+  ],
+  step: [
+    {
+      '@type': 'HowToStep',
+      position: 1,
+      name: 'Add the server to your MCP client config',
+      text: 'Add an entry for "skillsmith" running "npx -y @skillsmith/mcp-server" to your MCP client configuration file, e.g. ~/.claude/settings.json.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 2,
+      name: 'Restart your MCP client',
+      text: 'Restart your AI coding agent to load the new server configuration.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 3,
+      name: 'Trigger it with a natural-language prompt',
+      text: 'Prefix requests with "Use Skillsmith to..." or "Ask Skillsmith for..." so your assistant invokes the Skillsmith tools instead of answering from training data.',
+    },
+  ],
+};
 ---
 
-<DocsLayout title="MCP Server" description="Configure and use the Skillsmith MCP server">
+<DocsLayout title="MCP Server" description="Configure the Skillsmith MCP server and use its tools to search, install, and manage skills — including publishing to your team's private registry">
+  <!-- JSON-LD HowTo Schema -->
+  <script is:inline type="application/ld+json" slot="head" set:html={JSON.stringify(howToSchema)} />
+
   <h1>MCP Server</h1>
 
   <p class="lead">
@@ -374,8 +409,8 @@ EOF`}</code></pre>
   <p>
     Publish a skill version to your organization's shared private registry as a pending
     submission — a team admin has to approve it before anyone (including you) can install it.
-    Enterprise tier. See <a href="/docs/private-registry">Private Registry</a> for the full
-    approval workflow and access-control model.
+    Enterprise tier. See <a href="/docs/private-registry#publish-approval">Private Registry</a> for
+    the full approval workflow and access-control model.
   </p>
 
   <pre><code>{`// Tool: private_registry_publish

--- a/packages/website/src/pages/docs/private-registry.astro
+++ b/packages/website/src/pages/docs/private-registry.astro
@@ -1,8 +1,45 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
+
+const howToSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: "How to Publish a Skill to Your Team's Private Registry",
+  description:
+    "Publish a versioned skill to your organization's Enterprise-tier private registry and get it approved by a team admin before it goes live.",
+  step: [
+    {
+      '@type': 'HowToStep',
+      position: 1,
+      name: 'Sign in personally',
+      text: "Run skillsmith login. Publishing requires a real signed-in identity, not just the team's shared license key, so approval decisions can be tied to the actual person who made them.",
+    },
+    {
+      '@type': 'HowToStep',
+      position: 2,
+      name: 'Publish a version',
+      text: 'Use the private_registry_publish MCP tool to submit a skill ID and version. This creates a pending submission, invisible to search, get, and install until reviewed.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 3,
+      name: 'A different admin reviews it',
+      text: 'A team admin other than the submitter approves or rejects the submission using private_registry_manage. Self-approval is blocked at the database level.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 4,
+      name: 'Approved versions go live',
+      text: 'Once approved, the version becomes immediately visible and installable to the whole team. Both approve and reject are terminal; a rejected version can only be superseded by publishing a new version.',
+    },
+  ],
+};
 ---
 
-<DocsLayout title="Private Registry" description="How Skillsmith's Enterprise-tier private registry keeps your team's skills versioned, access-controlled, and namespaced to your organization">
+<DocsLayout title="Private Registry" description="How Skillsmith's Enterprise-tier private registry keeps your team's skills versioned, review-approved, access-controlled, and namespaced to your organization">
+  <!-- JSON-LD HowTo Schema -->
+  <script is:inline type="application/ld+json" slot="head" set:html={JSON.stringify(howToSchema)} />
+
   <h1>Private Registry</h1>
 
   <p class="lead">


### PR DESCRIPTION
## Business Summary

**What shipped:** The private registry publish/approval workflow and governance content added earlier this cycle (skillsmith#2271) was fully documented on the website but invisible to the AI agents and answer engines that discover Skillsmith via `llms.txt` — those files, plus the three new docs pages' search-engine metadata, never got updated. This closes that gap: `llms.txt`/`llms-full.txt` now list the Private Registry and Governance pages and the three new MCP tools (`publish_private`, `private_registry_publish`, `private_registry_manage`); the three affected docs pages now carry structured data (JSON-LD) so search engines can understand them as more than plain text, matching sibling pages that already had it; their meta descriptions now reflect what's actually on the page instead of pre-dating it.

**Quality bar:** `astro check` clean (0 errors/warnings/hints across all 186 site files). Each new JSON-LD block independently validated to round-trip through `JSON.parse`/`JSON.stringify` without error. Full `typecheck`/`audit:standards` run — 78 passed / 8 pre-existing warnings / 0 failed, matching the current `main` baseline exactly (no new warnings introduced).

**Found along the way:** the audit that surfaced this gap also found the tool tables in `llms.txt`/`llms-full.txt` have never listed *any* Team/Enterprise-tier MCP tool beyond the three added here (a pre-existing, broader gap — not addressed in this PR, out of scope for the approved fix), and that the sitemap's `lastmod` is frozen at a static date for all non-blog pages including these three (a deliberate, documented design choice to avoid Google Search Console churn, not a bug).

**Net result:** Fully shipped. The three specific tools and two pages from the original content addition are now correctly wired into every discoverability surface (website SEO, AEO/`llms.txt`, and this repo's own internal MCP tool references in `CLAUDE.md`/`mcp-tools-guide.md`).

---

## Technical detail

**AEO** (`packages/website/public/llms.txt`, `llms-full.txt`):
- Added `/docs/private-registry` and `/docs/governance` to Key Pages / Links.
- Added `publish_private`, `private_registry_publish`, `private_registry_manage` to both MCP tool tables.
- Added a private-registry Q&A to `llms-full.txt`'s FAQ section.

**SEO** — JSON-LD added to three pages that previously had none beyond `DocsLayout`'s automatic `BreadcrumbList`:
- `private-registry.astro`: `HowTo` schema for the publish → pending → admin-review → approved/rejected workflow (4 steps, matches the page's own "Publish & Approval" section verbatim).
- `governance.astro`: `TechArticle` schema (matches `getting-started.astro`'s existing pattern — headline/description/author/publisher/about).
- `mcp-server.astro`: `HowTo` schema for MCP server setup (3 steps: add config, restart client, trigger via natural-language prompt).
- Meta descriptions refreshed on all three; `mcp-server.astro`'s was generic boilerplate before this ("Configure and use the Skillsmith MCP server") and now names what it actually covers.
- Fixed `mcp-server.astro`'s `private_registry_publish` section link to deep-link to `/docs/private-registry#publish-approval` instead of the page root, matching what its own prose already promised ("full approval workflow").

**Internal tool references**: added the same 3 tools to `CLAUDE.md`'s and `.claude/development/mcp-tools-guide.md`'s MCP tools tables.

**Not in scope** (explicitly deferred by the approved fix scope, not silently skipped): sitemap `lastmod` freshness signal, and backfilling the other Team/Enterprise tools `llms.txt`/`llms-full.txt` have never listed.

Refs SMI-5996
