### PR TITLE
fix(core): Make sql.js persist() atomic and detect empty DBs

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `@skillsmith/core` are documented here.
 ## [Unreleased]
 
 - **Fix**: new shared `extractContextWords()` (`services/context-words.ts`, exported from the package root) replaces a `.filter((w) => w.length > 3)` threshold both `@skillsmith/mcp-server`'s `skill_recommend` and `@skillsmith/cli`'s `recommend --context` used independently — it was silently dropping real short technical terms ("git", "ci", "aws", "sql", "k8s") from the recommendation stack, tripping the empty-stack guard even when usable context was supplied (SMI-5986)
+- **Fix**: `SqlJsDatabaseAdapter.persist()` (`db/drivers/sqljsDriver.ts`) now writes the exported database buffer atomically — to a temp file, then `renameSync` over the target — instead of a direct `writeFileSync` that truncates the file before the new bytes land. A process kill mid-write (OOM, SIGKILL, machine sleep) could previously leave a 0-byte `skills.db` on disk. `openDatabaseAsync()` (`db/schema.ts`) also now distinguishes a genuinely empty/corrupt database (zero tables) from a real legacy import (has tables, just missing `schema_version`), failing loudly with remediation for the former instead of silently stamping `schema_version=1` and running every migration against a schema that was never created — which previously crashed server startup with an opaque `no such table: skills`/`no such table: cache` error and no actionable diagnostic (SMI-5997)
 
 ## v0.11.5
 

--- a/packages/core/src/db/drivers/sqljsDriver.ts
+++ b/packages/core/src/db/drivers/sqljsDriver.ts
@@ -17,7 +17,7 @@
 
 import { createRequire } from 'node:module'
 import type { Database, Statement, RunResult, DatabaseOptions } from '../database-interface.js'
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs'
 import { isCorruptionError, backupCorruptDbFile } from './corruption.js'
 
 // ESM-compatible require for dynamic module loading
@@ -320,12 +320,31 @@ export class SqlJsDatabaseAdapter implements Database {
 
   /**
    * Persist the in-memory database to file
+   *
+   * SMI-5997: writes atomically (temp file + rename) rather than a direct
+   * writeFileSync to filePath. A direct write truncates the target file
+   * before the new bytes land; a process kill/crash mid-write (OOM, SIGKILL,
+   * machine sleep) during that window leaves a 0-byte file on disk, which
+   * openDatabaseAsync() then silently misclassifies as a fresh/legacy import
+   * instead of a corrupt file — see schema.ts. rename() is atomic on the
+   * same filesystem, so the target is only ever fully-old or fully-new.
    */
   persist(): void {
     if (this._memory || !this.filePath) return
 
     const data = this.db.export()
-    writeFileSync(this.filePath, Buffer.from(data))
+    const tmpPath = `${this.filePath}.tmp`
+    try {
+      writeFileSync(tmpPath, Buffer.from(data))
+      renameSync(tmpPath, this.filePath)
+    } catch (error) {
+      try {
+        if (existsSync(tmpPath)) unlinkSync(tmpPath)
+      } catch {
+        // best-effort cleanup — surface the original error either way
+      }
+      throw error
+    }
   }
 
   /**

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -162,7 +162,29 @@ export async function openDatabaseAsync(path: string): Promise<DatabaseType> {
     .get()
 
   if (!hasSchemaVersion) {
-    // Database has no version tracking - assume it's a legacy import
+    // SMI-5997: a database with no schema_version table is only a legacy
+    // import if it has OTHER tables. A file with zero tables at all is an
+    // empty or corrupt database (e.g. truncated by an interrupted sql.js
+    // persist() — see sqljsDriver.ts) — silently stamping schema_version=1
+    // here used to run every migration against a database with no base
+    // tables, failing opaquely with "no such table: skills" and eventually
+    // crashing server startup entirely. Fail loudly with remediation instead.
+    const tableCount = db
+      .prepare("SELECT count(*) as count FROM sqlite_master WHERE type='table'")
+      .get() as { count: number } | undefined
+
+    if (!tableCount || tableCount.count === 0) {
+      throw new Error(
+        `[Skillsmith] Database at ${path} has no tables and no version metadata — ` +
+          'it is empty or corrupt, not a legacy import.\n' +
+          '[skillsmith] Run this command in the repo root, then reconnect via /mcp:\n\n' +
+          `    mv "${path}" "${path}.corrupt-$(date +%s)"\n\n` +
+          '[skillsmith] (a fresh database will be created automatically on next start)'
+      )
+    }
+
+    // Database has no version tracking but has other tables - assume it's a
+    // legacy import. Create schema_version table and set to version 1.
     db.exec(`
       CREATE TABLE IF NOT EXISTS schema_version (
         version INTEGER PRIMARY KEY,

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -60,6 +60,32 @@ export function initializeSchema(db: DatabaseType): void {
   runMigrations(db)
 }
 
+/**
+ * SMI-5997: shared by openDatabase() and openDatabaseAsync() — a database
+ * missing schema_version is only a legacy import if it has OTHER tables. A
+ * file with zero tables at all is empty or corrupt (e.g. truncated by an
+ * interrupted sql.js persist() — see sqljsDriver.ts), not a legacy import.
+ * Silently stamping schema_version=1 in that case used to run every
+ * migration against a database with no base tables, failing opaquely with
+ * "no such table: skills" and eventually crashing entirely. Fail loudly
+ * with remediation instead.
+ */
+function assertLegacyImportHasTables(db: DatabaseType, path: string): void {
+  const tableCount = db
+    .prepare("SELECT count(*) as count FROM sqlite_master WHERE type='table'")
+    .get() as { count: number } | undefined
+
+  if (!tableCount || tableCount.count === 0) {
+    throw new Error(
+      `[Skillsmith] Database at ${path} has no tables and no version metadata — ` +
+        'it is empty or corrupt, not a legacy import.\n' +
+        '[skillsmith] Run this command in the repo root, then reconnect via /mcp:\n\n' +
+        `    mv "${path}" "${path}.corrupt-$(date +%s)"\n\n` +
+        '[skillsmith] (a fresh database will be created automatically on next start)'
+    )
+  }
+}
+
 /** @deprecated Use createDatabaseAsync() — requires better-sqlite3 native module. */
 export function createDatabase(path: string = ':memory:'): DatabaseType {
   const db = createDatabaseSync(path)
@@ -89,8 +115,11 @@ export function openDatabase(path: string): DatabaseType {
     .get()
 
   if (!hasSchemaVersion) {
-    // Database has no version tracking - assume it's a Phase 5 import or similar
-    // Create schema_version table and set to version 1
+    assertLegacyImportHasTables(db, path)
+
+    // Database has no version tracking but has other tables - assume it's a
+    // legacy import (Phase 5 or similar). Create schema_version table and
+    // set to version 1.
     db.exec(`
       CREATE TABLE IF NOT EXISTS schema_version (
         version INTEGER PRIMARY KEY,
@@ -162,26 +191,7 @@ export async function openDatabaseAsync(path: string): Promise<DatabaseType> {
     .get()
 
   if (!hasSchemaVersion) {
-    // SMI-5997: a database with no schema_version table is only a legacy
-    // import if it has OTHER tables. A file with zero tables at all is an
-    // empty or corrupt database (e.g. truncated by an interrupted sql.js
-    // persist() — see sqljsDriver.ts) — silently stamping schema_version=1
-    // here used to run every migration against a database with no base
-    // tables, failing opaquely with "no such table: skills" and eventually
-    // crashing server startup entirely. Fail loudly with remediation instead.
-    const tableCount = db
-      .prepare("SELECT count(*) as count FROM sqlite_master WHERE type='table'")
-      .get() as { count: number } | undefined
-
-    if (!tableCount || tableCount.count === 0) {
-      throw new Error(
-        `[Skillsmith] Database at ${path} has no tables and no version metadata — ` +
-          'it is empty or corrupt, not a legacy import.\n' +
-          '[skillsmith] Run this command in the repo root, then reconnect via /mcp:\n\n' +
-          `    mv "${path}" "${path}.corrupt-$(date +%s)"\n\n` +
-          '[skillsmith] (a fresh database will be created automatically on next start)'
-      )
-    }
+    assertLegacyImportHasTables(db, path)
 
     // Database has no version tracking but has other tables - assume it's a
     // legacy import. Create schema_version table and set to version 1.

--- a/packages/core/tests/db/schema-async.test.ts
+++ b/packages/core/tests/db/schema-async.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest'
-import { existsSync, unlinkSync, mkdirSync, rmSync } from 'node:fs'
+import { existsSync, unlinkSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
@@ -310,6 +310,53 @@ describe('Async Schema Functions (SMI-2206)', () => {
       testDatabases.push(db2)
 
       const version = getSchemaVersion(db2)
+      expect(version).toBe(SCHEMA_VERSION)
+    })
+  })
+
+  describe('openDatabaseAsync — empty/corrupt database detection (SMI-5997)', () => {
+    it('throws an actionable error for a 0-byte file (no tables, no schema_version)', async () => {
+      if (!isBetterSqlite3Available()) {
+        console.log('Skipping test: no SQLite driver available')
+        return
+      }
+
+      mkdirSync(TEST_DIR, { recursive: true })
+
+      const testPath = join(TEST_DIR, `test-empty-corrupt-${Date.now()}.db`)
+      testPaths.push(testPath)
+
+      // Reproduces the SMI-5997 incident: a 0-byte file left behind by an
+      // interrupted persist() (or any other truncation). SQLite treats a
+      // 0-byte file as a valid, openable, empty database, so this must be
+      // caught by schema.ts's zero-table check rather than SQLITE_CANTOPEN.
+      writeFileSync(testPath, Buffer.alloc(0))
+
+      await expect(openDatabaseAsync(testPath)).rejects.toThrow(/empty or corrupt/)
+    })
+
+    it('still treats a file with real tables but no schema_version as a legacy import', async () => {
+      if (!isBetterSqlite3Available()) {
+        console.log('Skipping test: no SQLite driver available')
+        return
+      }
+
+      mkdirSync(TEST_DIR, { recursive: true })
+
+      const testPath = join(TEST_DIR, `test-legacy-import-${Date.now()}.db`)
+      testPaths.push(testPath)
+
+      // Build a database with a table but no schema_version, without going
+      // through createDatabaseAsync (which would stamp schema_version itself).
+      const seedDb = await createDatabaseAsync(testPath)
+      seedDb.exec('DROP TABLE schema_version')
+      closeDatabase(seedDb)
+
+      const db = await openDatabaseAsync(testPath)
+      testDatabases.push(db)
+
+      expect(db.open).toBe(true)
+      const version = getSchemaVersion(db)
       expect(version).toBe(SCHEMA_VERSION)
     })
   })

--- a/packages/core/tests/db/sqljsDriver.test.ts
+++ b/packages/core/tests/db/sqljsDriver.test.ts
@@ -6,12 +6,35 @@
  * to prevent contaminating betterSqlite3Driver.test.ts.
  */
 
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { existsSync, readFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   createSqlJsDatabase,
   SqlJsDatabaseAdapter,
   isSqlJsAvailable,
 } from '../../src/db/drivers/sqljsDriver.js'
+
+// SMI-5997: sqljsDriver.ts imports writeFileSync from 'node:fs' as a live ESM
+// binding, which vi.spyOn cannot redefine ("Module namespace is not
+// configurable in ESM"). vi.mock + importOriginal is the supported way to
+// intercept a single named export while passing everything else through.
+const failNextWrite = vi.hoisted(() => ({ value: false }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    writeFileSync: (...args: Parameters<typeof actual.writeFileSync>) => {
+      if (failNextWrite.value) {
+        failNextWrite.value = false
+        throw new Error('simulated crash mid-write')
+      }
+      return actual.writeFileSync(...args)
+    },
+  }
+})
 
 describe('sqljsDriver — edge cases', () => {
   describe('isSqlJsAvailable', () => {
@@ -93,6 +116,60 @@ describe('sqljsDriver — edge cases', () => {
       await expect(createSqlJsDatabase(nonExistentPath, { fileMustExist: true })).rejects.toThrow(
         /SQLITE_CANTOPEN/
       )
+    })
+  })
+
+  describe('persist() — atomic write (SMI-5997)', () => {
+    let dir: string
+    let dbPath: string
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'sqljs-persist-'))
+      dbPath = join(dir, 'test.db')
+    })
+
+    afterEach(() => {
+      failNextWrite.value = false
+      rmSync(dir, { recursive: true, force: true })
+    })
+
+    it('writes via temp file + rename, leaving no leftover .tmp file', async () => {
+      const db = await createSqlJsDatabase(dbPath)
+      db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)')
+      db.exec("INSERT INTO t (name) VALUES ('alpha')")
+      db.persist()
+
+      expect(existsSync(dbPath)).toBe(true)
+      expect(existsSync(`${dbPath}.tmp`)).toBe(false)
+      expect(readFileSync(dbPath).length).toBeGreaterThan(0)
+
+      db.close()
+    })
+
+    it('leaves the original file byte-for-byte untouched if the write is interrupted', async () => {
+      const db = await createSqlJsDatabase(dbPath)
+      db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)')
+      db.exec("INSERT INTO t (name) VALUES ('alpha')")
+      db.persist()
+
+      const originalContent = readFileSync(dbPath)
+      expect(originalContent.length).toBeGreaterThan(0)
+
+      db.exec("INSERT INTO t (name) VALUES ('beta')")
+
+      // Simulate a crash/kill mid-write: writeFileSync (to the temp file)
+      // throws before rename() ever runs.
+      failNextWrite.value = true
+
+      expect(() => db.persist()).toThrow('simulated crash mid-write')
+
+      // Reproduces the SMI-5997 incident check in reverse: the real file
+      // must never be truncated by a failed write, only ever replaced
+      // wholesale by a successful rename().
+      expect(readFileSync(dbPath)).toEqual(originalContent)
+      expect(existsSync(`${dbPath}.tmp`)).toBe(false)
+
+      db.close()
     })
   })
 })

--- a/packages/core/tests/schema.test.ts
+++ b/packages/core/tests/schema.test.ts
@@ -3,14 +3,19 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import type { Database } from '../src/db/database-interface.js'
 import {
   createDatabase,
+  openDatabase,
   closeDatabase,
   getSchemaVersion,
   runMigrations,
   SCHEMA_VERSION,
 } from '../src/db/schema.js'
+import { isBetterSqlite3Available } from '../src/db/drivers/betterSqlite3Driver.js'
 
 describe('Database Schema', () => {
   let db: Database
@@ -231,6 +236,54 @@ describe('Database Schema', () => {
       expect(indexNames).toContain('idx_skills_author')
       expect(indexNames).toContain('idx_skills_trust_tier')
       expect(indexNames).toContain('idx_skills_quality_score')
+    })
+  })
+
+  describe('openDatabase — empty/corrupt database detection (SMI-5997)', () => {
+    let dir: string
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'schema-open-sync-'))
+    })
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true })
+    })
+
+    it('throws an actionable error for a 0-byte file (no tables, no schema_version)', () => {
+      if (!isBetterSqlite3Available()) {
+        console.log('Skipping test: no SQLite driver available')
+        return
+      }
+
+      const testPath = join(dir, 'empty-corrupt.db')
+      // Reproduces the SMI-5997 incident via the deprecated sync path
+      // (packages/cli/src/commands/merge.ts still calls openDatabase()
+      // directly) — SQLite treats a 0-byte file as a valid, openable, empty
+      // database, so this must be caught by the zero-table check rather
+      // than a native SQLITE_CANTOPEN/corruption error.
+      writeFileSync(testPath, Buffer.alloc(0))
+
+      expect(() => openDatabase(testPath)).toThrow(/empty or corrupt/)
+    })
+
+    it('still treats a file with real tables but no schema_version as a legacy import', () => {
+      if (!isBetterSqlite3Available()) {
+        console.log('Skipping test: no SQLite driver available')
+        return
+      }
+
+      const testPath = join(dir, 'legacy-import.db')
+
+      const seedDb = createDatabase(testPath)
+      seedDb.exec('DROP TABLE schema_version')
+      closeDatabase(seedDb)
+
+      const reopened = openDatabase(testPath)
+      expect(reopened.open).toBe(true)
+      const version = getSchemaVersion(reopened)
+      expect(version).toBe(SCHEMA_VERSION)
+      closeDatabase(reopened)
     })
   })
 


### PR DESCRIPTION
## Business Summary

**What shipped:** the local Skillsmith database (`~/.skillsmith/skills.db`) can no longer be silently corrupted into a 0-byte file by an interrupted write, and if it ever does end up empty for another reason, the server now fails with a clear, actionable error instead of crashing opaquely.

**Quality bar:** full `packages/core` suite (5,388 tests) green, plus two new regression tests reproducing the exact incident (an interrupted write leaving the file untouched, and a 0-byte file producing a clear error instead of a migration crash). Lint, typecheck, and `audit:standards` all clean.

**Found along the way:** a pre-existing flaky test (`crash-handler-integration.test.ts`, SMI-5787) — a spawn-based integration test with a hardcoded 15s timeout that races under concurrent host load — filed separately as SMI-5999 rather than touched here, since it's unrelated to this change.

**Net result:** fully shipped, no follow-up on this PR itself. SMI-5999 tracks the unrelated flaky test found while pushing.

---

## Technical detail

**Root cause of the incident:** `~/.skillsmith/skills.db` was found truncated to 0 bytes, causing the `skillsmith` MCP server to fail every reconnect with `CONNECTION_CLOSED` on this machine (all sessions). Two compounding bugs in `@skillsmith/core`'s WASM (sql.js) database layer:

1. `SqlJsDatabaseAdapter.persist()` (`packages/core/src/db/drivers/sqljsDriver.ts`) wrote the exported DB buffer via a single `writeFileSync()` call to the live file path — not atomic. A process kill mid-write (OOM, SIGKILL, machine sleep) truncates the file before the new bytes land.
2. `openDatabaseAsync()` (`packages/core/src/db/schema.ts`) treated any file missing a `schema_version` table as a legacy import, silently stamping `schema_version=1` and running every migration without ever creating the base schema. Against an empty file this failed opaquely (`no such table: skills`, ..., fatally `no such table: cache`), crashing server startup with no diagnostic surfaced to the MCP host.

**Fix:**
- `persist()` now writes to a temp file (`<path>.tmp`) and `renameSync`s it over the target — rename is atomic on the same filesystem, so the target file is always either fully-old or fully-new, never truncated.
- `openDatabaseAsync()` now distinguishes a genuinely empty/corrupt database (zero tables at all) from a real legacy import (has tables, just missing `schema_version`) — the former throws an actionable error with remediation instead of silently misclassifying it and crashing later.

**Tests added:** `packages/core/tests/db/sqljsDriver.test.ts` (atomic-write + interrupted-write-leaves-original-untouched), `packages/core/tests/db/schema-async.test.ts` (0-byte file throws actionable error; legacy-import path still works).

**CI caveat:** pushed with `--no-verify` after explicit user sign-off — the pre-push hook's only failure was the unrelated flaky SMI-5787 test (confirmed via isolated run: passes reliably in 6-7s; only times out in the full suite while two other tests in the same run consume 85s/117s under heavy concurrent load from 16 sibling Docker containers on this machine). CI on this PR will run cleanly regardless of host contention.

Fixes SMI-5997
