### PR TITLE
feat(indexer): SMI-5930 batched repair script for latched-name rows

### DIFF
--- a/scripts/indexer/repair-latched-name-rows.cli.ts
+++ b/scripts/indexer/repair-latched-name-rows.cli.ts
@@ -21,21 +21,38 @@ export function isFlagLikeToken(token: string | undefined): boolean {
   return token !== undefined && token.startsWith('--')
 }
 
-/** Parse `--log-path <path>` / `--log-path=<path>` from argv. Throws on a missing/flag-like value. */
+/**
+ * Parse `--log-path <path>` / `--log-path=<path>` from argv. Throws on a
+ * missing/flag-like/empty value.
+ *
+ * PR-review finding (BLOCKING): the `=` form's empty-string case
+ * (`--log-path=`) previously passed straight through unchecked — the
+ * missing/flag-like guard below only ever ran for the bare-next-token form.
+ * `runRepair` resolves `opts.logPath ?? defaultLogPath()` once via `??`,
+ * which does NOT substitute on an empty string (only null/undefined), so an
+ * empty log path survived all the way to `appendBatchLog`, which fails
+ * AFTER that batch's UPDATE has already committed against prod — the
+ * operator loses the log for every committed id, discovering the mistake
+ * only after data has already changed. Reject empty here so this fails
+ * before the first batch ever touches the database.
+ */
 export function parseLogPathArg(argv: string[]): string | undefined {
   const idx = argv.findIndex((a) => a === '--log-path' || a.startsWith('--log-path='))
   if (idx === -1) return undefined
   const eq = argv[idx]?.split('=')[1]
-  if (eq !== undefined) return eq
-  const next = argv[idx + 1]
-  if (next === undefined || isFlagLikeToken(next)) {
+  const value = eq !== undefined ? eq : argv[idx + 1]
+  if (value === undefined || value === '' || isFlagLikeToken(value)) {
     throw new Error(
-      `repair-latched-name-rows: --log-path requires a value (got ${
-        next === undefined ? 'nothing' : `the flag-like token "${next}"`
+      `repair-latched-name-rows: --log-path requires a non-empty value (got ${
+        value === undefined
+          ? 'nothing'
+          : value === ''
+            ? 'an empty string'
+            : `the flag-like token "${value}"`
       }) — use --log-path=<path> to disambiguate if the path itself starts with --.`
     )
   }
-  return next
+  return value
 }
 
 /** Parse `--batch-size <n>` / `--batch-size=<n>` from argv. Throws on a missing/malformed/fractional value. */

--- a/scripts/indexer/repair-latched-name-rows.cli.ts
+++ b/scripts/indexer/repair-latched-name-rows.cli.ts
@@ -1,0 +1,58 @@
+/**
+ * SMI-5930 Wave 2: CLI argument parsing for repair-latched-name-rows.ts.
+ *
+ * Split out of repair-latched-name-rows.ts to stay under the 500-line CI
+ * gate (same rationale as skill-installation.io.symlink.test.ts's own split
+ * note) -- these three functions were the newest, most self-contained
+ * addition (code-review pass, MEDIUM findings) and have no dependency on
+ * anything else in the parent module.
+ */
+
+/**
+ * A bare, space-separated flag value (`--log-path <value>`) must not itself
+ * look like another recognized flag -- code-review finding, MEDIUM:
+ * `--log-path --apply` previously silently took the literal string
+ * `'--apply'` as the log path, discovering the mistake only after a batch
+ * had already committed against prod. `--foo=bar` form is unaffected (the
+ * value is unambiguously attached), only the bare-next-token form needs
+ * this guard.
+ */
+export function isFlagLikeToken(token: string | undefined): boolean {
+  return token !== undefined && token.startsWith('--')
+}
+
+/** Parse `--log-path <path>` / `--log-path=<path>` from argv. Throws on a missing/flag-like value. */
+export function parseLogPathArg(argv: string[]): string | undefined {
+  const idx = argv.findIndex((a) => a === '--log-path' || a.startsWith('--log-path='))
+  if (idx === -1) return undefined
+  const eq = argv[idx]?.split('=')[1]
+  if (eq !== undefined) return eq
+  const next = argv[idx + 1]
+  if (next === undefined || isFlagLikeToken(next)) {
+    throw new Error(
+      `repair-latched-name-rows: --log-path requires a value (got ${
+        next === undefined ? 'nothing' : `the flag-like token "${next}"`
+      }) — use --log-path=<path> to disambiguate if the path itself starts with --.`
+    )
+  }
+  return next
+}
+
+/** Parse `--batch-size <n>` / `--batch-size=<n>` from argv. Throws on a missing/malformed/fractional value. */
+export function parseBatchSizeArg(argv: string[]): number | undefined {
+  const idx = argv.findIndex((a) => a === '--batch-size' || a.startsWith('--batch-size='))
+  if (idx === -1) return undefined
+  const eq = argv[idx]?.split('=')[1]
+  const raw = eq ?? (isFlagLikeToken(argv[idx + 1]) ? undefined : argv[idx + 1])
+  if (raw === undefined) {
+    throw new Error('repair-latched-name-rows: --batch-size requires a value')
+  }
+  const n = Number(raw)
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    throw new Error(
+      `repair-latched-name-rows: --batch-size must be a whole number, got "${raw}" — refusing ` +
+        `to silently floor a fractional value or fall back to the default.`
+    )
+  }
+  return n
+}

--- a/scripts/indexer/repair-latched-name-rows.ts
+++ b/scripts/indexer/repair-latched-name-rows.ts
@@ -6,11 +6,10 @@
  * via organic re-crawl.
  *
  * ── Why these rows are stuck ─────────────────────────────────────────────
- * The indexer's own skip-gate takes a skinny update path (never touches
- * `name`) whenever a row's `content_hash` already matches what a re-fetch
- * would compute AND `security_score` is non-NULL. For the affected rows that
- * condition is permanently true, so organic re-crawl can never reach the
- * code path that re-derives `name` from frontmatter.
+ * The indexer's own skip-gate skips writing `name` whenever `content_hash`
+ * already matches a re-fetch AND `security_score` is non-NULL -- for the
+ * affected rows that condition is permanently true, so organic re-crawl
+ * can never reach the path that re-derives `name` from frontmatter.
  *
  * ── The fix (data-only, no DDL) ──────────────────────────────────────────
  * NULL `content_hash` for exactly the rows matching {@link LATCHED_ROW_PREDICATE}.
@@ -403,6 +402,11 @@ export async function runRepair(
   }
 
   const logPath = opts.logPath ?? defaultLogPath()
+  // PR-review finding (BLOCKING): preflight the log dir before the first
+  // batch commits -- an unwritable path previously wasn't caught until the
+  // first appendBatchLog, by which point that batch's UPDATE had already
+  // committed (empty logPath is rejected earlier, at CLI parse time).
+  await mkdir(dirname(logPath), { recursive: true })
   const updatedIds: string[] = []
   const errors: string[] = []
 

--- a/scripts/indexer/repair-latched-name-rows.ts
+++ b/scripts/indexer/repair-latched-name-rows.ts
@@ -1,0 +1,495 @@
+#!/usr/bin/env tsx
+/**
+ * SMI-5930 Wave 2 (Wave 1 of docs/internal/implementation/smi-5930-wave2-and-adjacent-fixes.md):
+ * Targeted repair for the ~42,487 "latched" `skills` rows whose `name` equals
+ * the repo name (not the skill's own declared name) but can never self-heal
+ * via organic re-crawl.
+ *
+ * ── Why these rows are stuck ─────────────────────────────────────────────
+ * The indexer's own skip-gate takes a skinny update path (never touches
+ * `name`) whenever a row's `content_hash` already matches what a re-fetch
+ * would compute AND `security_score` is non-NULL. For the affected rows that
+ * condition is permanently true, so organic re-crawl can never reach the
+ * code path that re-derives `name` from frontmatter.
+ *
+ * ── The fix (data-only, no DDL) ──────────────────────────────────────────
+ * NULL `content_hash` for exactly the rows matching {@link LATCHED_ROW_PREDICATE}.
+ * This does NOT touch `name` directly -- it un-sticks the row so the next
+ * organic re-crawl's hash-match check fails and routes it through the full
+ * path where `name` gets correctly re-derived. Safe to run now because the
+ * prior plan's Wave 1 (re-key trigger, `supabase/migrations/
+ * 20260811000000_skill_name_change_rekey_trigger.sql`) is deployed +
+ * smoke-tested: any name correction this enables re-keys
+ * `workspace_skills`/`skill_update_notifications_sent` atomically.
+ *
+ * ── Critical design point (plan-review finding) ──────────────────────────
+ * Re-running {@link LATCHED_ROW_PREDICATE} after this script applies will
+ * trivially show fewer matches -- but that is CIRCULAR, not proof anything
+ * was actually fixed. It only proves the row got unlatched (content_hash is
+ * NULL again), never that `name` was corrected -- that only happens on the
+ * row's NEXT organic re-crawl, which is out of this script's control and
+ * out of scope for this script to verify. So every row this script
+ * successfully unlatches has its id appended to a log file (see
+ * {@link defaultLogPath}) as soon as its batch's UPDATE commits -- a
+ * SEPARATE, later, manual process (the plan owner) re-checks those EXACT
+ * ids' `name` after their next re-crawl. This script's job ends at "recorded
+ * the ids it unlatched", not at "proved the name is now correct". The log is
+ * best-effort, not a completeness guarantee -- see {@link appendBatchLog}'s
+ * own doc comment for the honest bound on that.
+ *
+ * ── Conventions mirrored (do not invent new shapes) ──────────────────────
+ *  - `--dry-run` (default) / `--apply` (opt-in), logging shape, and the
+ *    "skipped when imported by tests" guard mirror
+ *    `scripts/indexer/dequarantine-false-positives.ts`.
+ *  - Session-pooler access reuses `smi5879-census.pg.ts`'s
+ *    `poolerSessionConnParams`/`queryRows`, already shared by
+ *    `smi5879-census.ts`/`smi5879-gate-check.ts`/`smi5879-simulate-full.ts`.
+ *  - {@link updateBatchWithRetry}'s halve-and-retry logic mirrors
+ *    `upsertChunkWithRetry` (`indexer-runners.batch.ts`): same halving math
+ *    (`Math.ceil(len / 2)`), sequential await of both halves, same
+ *    `MAX_TIMEOUT_SPLIT_DEPTH` cap, same terminal-error behavior (record an
+ *    error string, never throw past this function).
+ *  - The default log path mirrors `purge-dead-quarantines.ts`'s
+ *    `defaultExportPath()` convention.
+ *
+ * ── Run-gated (CORRECTED -- code-review finding) ─────────────────────────
+ * An earlier version of this comment wrongly claimed this script (and
+ * `purge-dead-quarantines.ts`) were exempt from `run-gate.ts` -- unverified;
+ * `purge-dead-quarantines.ts` actually DOES call `assertRunAllowed`/
+ * `assertFreezeMarkerClear`. This script now does the same via a new
+ * `'repair'` `GatedRunType` -- a genuine one-time `skills` WRITER, same class
+ * as dequarantine/purge/revalidate, not a reader like `smi5879-census.ts`
+ * (correctly exempt). See `run-gate.ts`'s `GATED_RUN_TYPES` doc comment.
+ *
+ * ── Usage (host tool -- requires Docker container running for varlock) ────
+ *   varlock run -- npx tsx scripts/indexer/repair-latched-name-rows.ts             # dry-run
+ *   varlock run -- npx tsx scripts/indexer/repair-latched-name-rows.ts --apply     # live
+ *   varlock run -- npx tsx scripts/indexer/repair-latched-name-rows.ts --batch-size 500
+ */
+
+import { mkdir, appendFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { poolerSessionConnParams, queryRows, type PgConnParams } from './smi5879-census.pg.ts'
+import { parseLogPathArg, parseBatchSizeArg } from './repair-latched-name-rows.cli.ts'
+import { assertRunAllowed, assertFreezeMarkerClear } from './run-gate.ts'
+import { createSupabaseAdminClient } from './_shared/supabase.ts'
+
+export {
+  isFlagLikeToken,
+  parseLogPathArg,
+  parseBatchSizeArg,
+} from './repair-latched-name-rows.cli.ts'
+
+// ---------------------------------------------------------------------------
+// Predicate (single source of truth -- reused by both the fetch and the
+// eventual manual Step-2-style verification query so they can never drift)
+// ---------------------------------------------------------------------------
+
+/**
+ * Identifies a "latched" row: `discovery_path` came from the subdirectory
+ * search path, the stored `name` equals the repo name (not the skill's own
+ * declared name), AND both gate columns the indexer's skip-check reads are
+ * non-NULL. No `AND TRUE` -- this predicate is already fully selective.
+ */
+export const LATCHED_ROW_PREDICATE = `discovery_path LIKE 'subdirectory_search%'
+  AND lower(name) = lower(split_part(replace(repo_url, 'https://github.com/', ''), '/', 2))
+  AND content_hash IS NOT NULL
+  AND security_score IS NOT NULL`
+
+/** `SELECT` fetching every candidate id, ordered by `id` (stable batch boundaries). */
+export function buildFetchCandidateIdsSql(): string {
+  return `SELECT id FROM skills WHERE ${LATCHED_ROW_PREDICATE} ORDER BY id;`
+}
+
+/**
+ * `UPDATE` nulling `content_hash` for exactly the ids in `:'ids'` (a
+ * comma-joined string, split server-side -- `psql -v` only substitutes a
+ * single quoted string literal, so an explicit id LIST is passed this way
+ * rather than as a native SQL array literal) -- AND still matching
+ * {@link LATCHED_ROW_PREDICATE} at UPDATE time, not just at the original
+ * fetch (code-review finding, HIGH): a candidate id list is fetched once,
+ * but this script's batches run over an extended window (potentially
+ * minutes to hours across ~85 batches). Without re-checking the predicate
+ * here, a row organically corrected by a concurrent re-crawl BETWEEN the
+ * fetch and this specific batch's UPDATE -- which would already have a
+ * freshly-computed, correct `content_hash` -- would be wrongly nulled back
+ * out by this script, undoing a legitimate write. Re-checking the full
+ * predicate makes this UPDATE self-correcting: it only ever touches rows
+ * that are STILL latched at the moment it actually runs.
+ */
+export function buildNullContentHashSql(): string {
+  return `UPDATE skills
+    SET content_hash = NULL
+    WHERE id = ANY(string_to_array(:'ids', ','))
+      AND ${LATCHED_ROW_PREDICATE}
+    RETURNING id;`
+}
+
+// ---------------------------------------------------------------------------
+// DB access (thin, injectable -- mirrors createSmi5879SimulateFullDbDeps)
+// ---------------------------------------------------------------------------
+
+export interface RepairDbDeps {
+  /** Every candidate id matching {@link LATCHED_ROW_PREDICATE}, ordered by id. */
+  fetchCandidateIds(): Promise<string[]>
+  /**
+   * NULL `content_hash` for exactly `ids`. Returns the ids actually updated
+   * (via `RETURNING id`). Throws on any DB error, including a detectable
+   * statement-timeout error -- callers use {@link updateBatchWithRetry} to
+   * retry on that specific case.
+   */
+  nullContentHashForIds(ids: readonly string[]): Promise<string[]>
+}
+
+/**
+ * A `queryRows` result row always has as many cells as the query's column
+ * list; a genuinely missing cell means the SELECT's column count drifted
+ * from what this function destructures -- worth throwing on rather than
+ * silently letting `undefined` flow downstream (matches the `requireCell`
+ * convention in every other `smi5879-census.pg.ts` consumer).
+ */
+function requireIdCell(value: string | undefined): string {
+  if (value === undefined) {
+    throw new Error(
+      'repair-latched-name-rows: missing id cell in query result row — column count drift?'
+    )
+  }
+  return value
+}
+
+/**
+ * `skills.id` is an unconstrained `TEXT` column (code-review finding,
+ * MEDIUM) -- {@link buildNullContentHashSql} comma-joins a batch of ids into
+ * a single `:'ids'` string, split server-side via `string_to_array`. A
+ * comma-joined list is not value-safe against an id that itself contains a
+ * comma: it would silently split into the wrong set of values, matching a
+ * broader or narrower row set than intended. Every id this script ever
+ * handles originates from `fetchCandidateIds()`'s own `SELECT id FROM
+ * skills`, never from external/user input, and this repo's actual `skills`
+ * ids are UUIDs in practice -- but rather than assert that unverified
+ * assumption (and risk false positives against a real id shape this script
+ * hasn't seen), this checks the ONE thing that's actually unsafe about the
+ * comma-join encoding itself: a literal comma. Anything else `string_to_array`
+ * would split on unmodified is fine; a comma is the sole failure mode.
+ */
+export function assertJoinableId(id: string): string {
+  if (id.includes(',')) {
+    throw new Error(
+      `repair-latched-name-rows: id "${id}" contains a comma and is not safe to comma-join — ` +
+        `refusing to build a batch UPDATE that could silently split into the wrong id list ` +
+        `and match the wrong rows. Stop and investigate before re-running.`
+    )
+  }
+  return id
+}
+
+/** Build the real, psql-backed dependency set for a given session-pooler connection. */
+export function createRepairDbDeps(conn: PgConnParams): RepairDbDeps {
+  return {
+    async fetchCandidateIds() {
+      const rows = await queryRows(conn, buildFetchCandidateIdsSql())
+      return rows.map(([id]) => requireIdCell(id))
+    },
+    async nullContentHashForIds(ids) {
+      if (ids.length === 0) return []
+      const joined = ids.map(assertJoinableId).join(',')
+      const rows = await queryRows(conn, buildNullContentHashSql(), { ids: joined })
+      return rows.map(([id]) => requireIdCell(id))
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Batching
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_BATCH_SIZE = 750
+export const MIN_BATCH_SIZE = 500
+export const MAX_BATCH_SIZE = 1000
+
+/** Slice `ids` (already ordered by id) into fixed-size batches. Pure, unit-tested. */
+export function planBatches(ids: readonly string[], batchSize: number): string[][] {
+  if (!Number.isInteger(batchSize) || batchSize <= 0) {
+    throw new Error(
+      `repair-latched-name-rows: batch size must be a positive integer, got ${batchSize}`
+    )
+  }
+  const batches: string[][] = []
+  for (let i = 0; i < ids.length; i += batchSize) {
+    batches.push(ids.slice(i, i + batchSize))
+  }
+  return batches
+}
+
+// ---------------------------------------------------------------------------
+// Statement-timeout halve-and-retry (structural mirror of upsertChunkWithRetry
+// in indexer-runners.batch.ts -- see module doc for the exact correspondence)
+// ---------------------------------------------------------------------------
+
+/** Postgres's `canceling statement due to statement timeout` message substring. */
+const STATEMENT_TIMEOUT_SUBSTRING = 'statement timeout'
+
+/** Same depth cap as `upsertChunkWithRetry` -- bounds a systemic-timeout run to 2^depth leaves. */
+export const MAX_TIMEOUT_SPLIT_DEPTH = 8
+
+function isStatementTimeoutError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return message.includes(STATEMENT_TIMEOUT_SUBSTRING)
+}
+
+export interface BatchUpdateResult {
+  updatedIds: string[]
+  errors: string[]
+}
+
+/**
+ * Attempt to null `content_hash` for exactly `ids`. On a statement-timeout
+ * error, halve `ids` and retry each half independently (depth-first,
+ * sequential -- the left half is fully awaited before the right half
+ * starts), bounded by {@link MAX_TIMEOUT_SPLIT_DEPTH}. A non-timeout error,
+ * or a timeout at max depth, is recorded as an error string covering that
+ * (sub)batch and NEVER thrown past this function -- one bad batch must not
+ * abort the whole run, exactly like `upsertChunkWithRetry`.
+ */
+export async function updateBatchWithRetry(
+  db: RepairDbDeps,
+  ids: readonly string[],
+  depth = 0
+): Promise<BatchUpdateResult> {
+  try {
+    const updatedIds = await db.nullContentHashForIds(ids)
+    return { updatedIds, errors: [] }
+  } catch (err) {
+    if (isStatementTimeoutError(err) && ids.length > 1 && depth < MAX_TIMEOUT_SPLIT_DEPTH) {
+      const mid = Math.ceil(ids.length / 2)
+      const left = await updateBatchWithRetry(db, ids.slice(0, mid), depth + 1)
+      const right = await updateBatchWithRetry(db, ids.slice(mid), depth + 1)
+      return {
+        updatedIds: [...left.updatedIds, ...right.updatedIds],
+        errors: [...left.errors, ...right.errors],
+      }
+    }
+    const message = err instanceof Error ? err.message : String(err)
+    return {
+      updatedIds: [],
+      errors: [`Batch update failed (${ids.length} row(s)): ${message}`],
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dry-run sampling (bounded output -- never dump the full ~42,487-row list)
+// ---------------------------------------------------------------------------
+
+export const DRY_RUN_SAMPLE_SIZE = 10
+
+export interface DryRunSample {
+  first: string[]
+  last: string[]
+}
+
+/** First/last `n` ids of an (already `id`-ordered) candidate list, for a bounded dry-run preview. */
+export function sampleIdsForDryRun(
+  ids: readonly string[],
+  n: number = DRY_RUN_SAMPLE_SIZE
+): DryRunSample {
+  const first = ids.slice(0, n)
+  const last = ids.length > n ? ids.slice(-n) : []
+  return { first, last }
+}
+
+// ---------------------------------------------------------------------------
+// Unlatched-ids log (the record a later, separate process needs to check
+// each row's `name` after its next re-crawl -- see module doc)
+// ---------------------------------------------------------------------------
+
+/** Timestamped default path under `~/.skillsmith/backups/`, mirroring `purge-dead-quarantines.ts`. */
+export function defaultLogPath(now: Date = new Date()): string {
+  const stamp = now.toISOString().replace(/[:.]/g, '-')
+  return join(homedir(), '.skillsmith', 'backups', `repair-latched-name-rows-${stamp}.jsonl`)
+}
+
+export interface BatchLogEntry {
+  batchIndex: number
+  batchCount: number
+  unlatchedAt: string
+  ids: string[]
+}
+
+/**
+ * Append one JSONL line per successful batch, immediately after that batch's
+ * UPDATE commits -- NOT buffered to end-of-run, so a crash mid-run leaves a
+ * record of every batch that had already finished logging at that point.
+ *
+ * HONEST LIMIT (code-review finding, HIGH -- corrects an earlier version of
+ * this comment that overclaimed "durable record"): this filesystem append
+ * and the database UPDATE it follows are two separate systems and cannot be
+ * made atomic without a real two-phase-commit / outbox mechanism, which is
+ * disproportionate infrastructure for a one-time maintenance script. A crash
+ * landing in the narrow window between "UPDATE committed" and "this append
+ * returns" loses that one batch's ids from the log -- the DB mutation itself
+ * is unaffected and correct (see {@link buildNullContentHashSql}'s own
+ * predicate re-check), but the plan's later convergence-sampling step won't
+ * have those specific ids to check. This is a bounded risk to audit
+ * COMPLETENESS only, not to data correctness: the affected rows still
+ * self-heal via the normal predicate-driven re-crawl path, and Step 2's own
+ * count-query re-run (see the plan doc) is the actual verification of
+ * overall progress, not a substitute for per-row tracking. Do not treat this
+ * log as a system of record -- it is an operational convenience for
+ * sampling, not a completeness guarantee.
+ */
+export async function appendBatchLog(path: string, entry: BatchLogEntry): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await appendFile(path, JSON.stringify(entry) + '\n', 'utf-8')
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+export interface RunRepairOptions {
+  apply: boolean
+  batchSize?: number
+  logPath?: string
+}
+
+export interface RunRepairResult {
+  totalCandidates: number
+  batchCount: number
+  batchSize: number
+  updatedIds: string[]
+  errors: string[]
+  logPath?: string
+}
+
+/** Run the repair (dry-run by default). Returns the run counts. */
+export async function runRepair(
+  db: RepairDbDeps,
+  opts: RunRepairOptions
+): Promise<RunRepairResult> {
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE
+  if (batchSize < MIN_BATCH_SIZE || batchSize > MAX_BATCH_SIZE) {
+    throw new Error(
+      `repair-latched-name-rows: --batch-size must be between ${MIN_BATCH_SIZE} and ${MAX_BATCH_SIZE} (got ${batchSize}), per the SMI-5930 plan.`
+    )
+  }
+
+  const ids = await db.fetchCandidateIds()
+  const batches = planBatches(ids, batchSize)
+
+  console.log(
+    `\n${opts.apply ? '🔧 APPLY' : '🔍 DRY-RUN'} — repair-latched-name-rows (SMI-5930 Wave 2)\n` +
+      `Predicate: ${LATCHED_ROW_PREDICATE.replace(/\s+/g, ' ')}\n`
+  )
+  console.log(`  total candidates: ${ids.length}`)
+  console.log(`  batch size:       ${batchSize}`)
+  console.log(`  batch count:      ${batches.length}`)
+
+  if (!opts.apply) {
+    const { first, last } = sampleIdsForDryRun(ids)
+    console.log(`  first ${first.length} id(s): ${first.join(', ') || '(none)'}`)
+    if (last.length > 0) console.log(`  last ${last.length} id(s):  ${last.join(', ')}`)
+    console.log(
+      '\nDry-run only — no rows modified. Re-run with --apply to null content_hash for these rows.\n'
+    )
+    return {
+      totalCandidates: ids.length,
+      batchCount: batches.length,
+      batchSize,
+      updatedIds: [],
+      errors: [],
+    }
+  }
+
+  const logPath = opts.logPath ?? defaultLogPath()
+  const updatedIds: string[] = []
+  const errors: string[] = []
+
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i] ?? []
+    const result = await updateBatchWithRetry(db, batch)
+    updatedIds.push(...result.updatedIds)
+    errors.push(...result.errors)
+
+    if (result.updatedIds.length > 0) {
+      await appendBatchLog(logPath, {
+        batchIndex: i,
+        batchCount: batches.length,
+        unlatchedAt: new Date().toISOString(),
+        ids: result.updatedIds,
+      })
+    }
+
+    console.log(
+      `  progress: ${updatedIds.length}/${ids.length} rows unlatched (batch ${i + 1}/${batches.length})`
+    )
+    for (const e of result.errors) console.error(`  ERROR: ${e}`)
+  }
+
+  console.log(
+    `\n── Summary ──\n` +
+      `  candidates:  ${ids.length}\n` +
+      `  unlatched:   ${updatedIds.length}\n` +
+      `  errors:      ${errors.length}\n` +
+      `  log:         ${logPath}\n`
+  )
+  if (errors.length > 0) {
+    console.log(
+      'Some batches failed — re-run with --apply to retry the remaining rows (idempotent: only still-latched rows match the predicate).\n'
+    )
+  }
+
+  return {
+    totalCandidates: ids.length,
+    batchCount: batches.length,
+    batchSize,
+    updatedIds,
+    errors,
+    logPath,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint
+// ---------------------------------------------------------------------------
+
+/** CLI entrypoint (skipped when imported by tests). */
+async function main(): Promise<void> {
+  // SMI-5879 Gate C: env-sourced check first (no dependency on a DB round
+  // trip), then the DB-sourced freeze marker immediately after client
+  // construction -- same call-site contract as purge-dead-quarantines.ts's
+  // main() (code-review finding: this script must be gated like its true
+  // siblings, dequarantine/purge/revalidate, not exempt like a reader).
+  assertRunAllowed('repair')
+  const gateClient = createSupabaseAdminClient()
+  await assertFreezeMarkerClear(gateClient, 'repair')
+
+  // `--dry-run` wins over `--apply` if both are somehow passed -- the safe
+  // default for a ~42K-row prod data mutation.
+  const dryRunFlag = process.argv.includes('--dry-run')
+  const apply = process.argv.includes('--apply') && !dryRunFlag
+
+  const conn = poolerSessionConnParams()
+  const db = createRepairDbDeps(conn)
+  const result = await runRepair(db, {
+    apply,
+    batchSize: parseBatchSizeArg(process.argv),
+    logPath: parseLogPathArg(process.argv),
+  })
+  // Code-review finding, MEDIUM: a run with one or more failed batches must
+  // not exit 0 -- a caller piping this into automation, or just checking
+  // `$?` after a long unattended run, needs to be able to tell "some rows
+  // were not repaired" from "everything succeeded" without parsing stdout.
+  if (result.errors.length > 0) {
+    process.exitCode = 1
+  }
+}
+
+// Run only when invoked directly (not when imported by the test suite).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/scripts/indexer/run-gate.ts
+++ b/scripts/indexer/run-gate.ts
@@ -21,12 +21,24 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 /**
- * The six run-type identifiers the gate understands. Five (`discovery`,
+ * The seven run-type identifiers the gate understands. Five (`discovery`,
  * `maintenance`, `recheck`, `dequarantine`, `purge`) mirror `parse-env.ts`'s
- * `RUN_TYPE` union exactly; `revalidate` exists only in the gate's own
- * vocabulary, for the host-only writer `revalidate-stale-quarantines.ts`,
+ * `RUN_TYPE` union exactly; `revalidate` and `repair` exist only in the
+ * gate's own vocabulary, for host-only writers
+ * (`revalidate-stale-quarantines.ts`, `repair-latched-name-rows.ts`),
  * deliberately kept out of `parse-env.ts`'s union so the workflow-facing
  * surface is unchanged.
+ *
+ * SMI-5930 (code-review finding): `repair` was added because
+ * `repair-latched-name-rows.ts` is a genuine one-time WRITER against the
+ * same `skills` table the freeze window protects (it nulls `content_hash`
+ * for a targeted row set), the same class of operation as `dequarantine`/
+ * `purge`/`revalidate` above — not a reader like `smi5879-census.ts` et al.
+ * (run-gate-callsites.test.ts's Shape 4), which are deliberately exempt
+ * because they ARE the freeze window's own verification tooling. Using a
+ * psql/session-pooler connection instead of PostgREST doesn't change
+ * whether a script needs this gate — what matters is read vs. write to
+ * `skills`, not the connection mechanism.
  */
 export const GATED_RUN_TYPES = [
   'discovery',
@@ -35,6 +47,7 @@ export const GATED_RUN_TYPES = [
   'dequarantine',
   'purge',
   'revalidate',
+  'repair',
 ] as const
 
 export type GatedRunType = (typeof GATED_RUN_TYPES)[number]

--- a/scripts/tests/indexer/repair-latched-name-rows.cli.test.ts
+++ b/scripts/tests/indexer/repair-latched-name-rows.cli.test.ts
@@ -13,6 +13,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   runRepair,
   MIN_BATCH_SIZE,
@@ -55,7 +58,18 @@ describe('parseLogPathArg (code-review finding, MEDIUM)', () => {
   })
 
   it('throws when --log-path is the last token with no value at all', () => {
-    expect(() => parseLogPathArg(['--log-path'])).toThrow(/requires a value/)
+    expect(() => parseLogPathArg(['--log-path'])).toThrow(/requires a non-empty value/)
+  })
+
+  it('throws on --log-path= (empty string via the attached form) — PR-review finding, BLOCKING', () => {
+    // The `=` form's empty-string case previously bypassed the
+    // missing/flag-like guard entirely (that guard only ran for the
+    // bare-next-token form), and runRepair's `opts.logPath ?? defaultLogPath()`
+    // does not substitute on an empty string (only null/undefined) -- so an
+    // empty log path used to survive all the way to appendBatchLog, which
+    // fails only AFTER that batch's UPDATE has already committed against prod.
+    expect(() => parseLogPathArg(['--log-path='])).toThrow(/requires a non-empty value/)
+    expect(() => parseLogPathArg(['--log-path='])).toThrow(/an empty string/)
   })
 })
 
@@ -129,5 +143,33 @@ describe('runRepair — reports errors for the CLI entrypoint to act on', () => 
 
     expect(result.errors).toEqual([])
     expect(result.updatedIds.sort()).toEqual([...ids].sort())
+  })
+
+  it('preflights the log path BEFORE any batch commits — PR-review finding, BLOCKING', async () => {
+    // A bad log path used to only fail at the first appendBatchLog call,
+    // AFTER that batch's nullContentHashForIds had already run against
+    // prod. Point logPath's directory at a path segment that is a plain
+    // FILE, not a directory -- mkdir(dirname(logPath), {recursive:true})
+    // must throw (ENOTDIR) before nullContentHashForIds is ever called.
+    const tmpDir = await mkdtemp(join(tmpdir(), 'smi5930-preflight-'))
+    const notADir = join(tmpDir, 'this-is-a-file')
+    await writeFile(notADir, 'x')
+    const badLogPath = join(notADir, 'subdir', 'log.jsonl')
+
+    const calls: string[][] = []
+    const db: RepairDbDeps = {
+      fetchCandidateIds: async () => makeIds(10),
+      nullContentHashForIds: async (ids) => {
+        calls.push([...ids])
+        return [...ids]
+      },
+    }
+
+    await expect(
+      runRepair(db, { apply: true, batchSize: MIN_BATCH_SIZE, logPath: badLogPath })
+    ).rejects.toThrow()
+    expect(calls).toEqual([])
+
+    await rm(tmpDir, { recursive: true, force: true })
   })
 })

--- a/scripts/tests/indexer/repair-latched-name-rows.cli.test.ts
+++ b/scripts/tests/indexer/repair-latched-name-rows.cli.test.ts
@@ -1,0 +1,133 @@
+/**
+ * SMI-5930 Wave 2: CLI arg-parsing + partial-failure exit-status tests for
+ * scripts/indexer/repair-latched-name-rows.ts / .cli.ts.
+ *
+ * Split out of repair-latched-name-rows.test.ts to stay under the 500-line
+ * CI gate, mirroring the source split (repair-latched-name-rows.cli.ts) --
+ * these are exactly the code-review-finding (MEDIUM) cases: a value-taking
+ * flag must reject a missing or flag-like value rather than silently
+ * misinterpreting it, --batch-size must reject non-integer input rather
+ * than silently flooring or falling back to the default, and a run with any
+ * failed batch must surface that in `result.errors` so the CLI entrypoint
+ * can set a non-zero exit code.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  runRepair,
+  MIN_BATCH_SIZE,
+  isFlagLikeToken,
+  parseLogPathArg,
+  parseBatchSizeArg,
+  type RepairDbDeps,
+} from '../../indexer/repair-latched-name-rows.ts'
+
+function makeIds(n: number, prefix = 'id'): string[] {
+  return Array.from({ length: n }, (_, i) => `${prefix}-${String(i).padStart(5, '0')}`)
+}
+
+describe('isFlagLikeToken', () => {
+  it('true for a token starting with --', () => {
+    expect(isFlagLikeToken('--apply')).toBe(true)
+  })
+
+  it('false for a plain value, and false for undefined', () => {
+    expect(isFlagLikeToken('/tmp/out.jsonl')).toBe(false)
+    expect(isFlagLikeToken(undefined)).toBe(false)
+  })
+})
+
+describe('parseLogPathArg (code-review finding, MEDIUM)', () => {
+  it('returns undefined when the flag is absent', () => {
+    expect(parseLogPathArg(['--apply'])).toBeUndefined()
+  })
+
+  it('parses the --log-path=<path> attached form', () => {
+    expect(parseLogPathArg(['--log-path=/tmp/out.jsonl'])).toBe('/tmp/out.jsonl')
+  })
+
+  it('parses the --log-path <path> space-separated form', () => {
+    expect(parseLogPathArg(['--log-path', '/tmp/out.jsonl'])).toBe('/tmp/out.jsonl')
+  })
+
+  it('throws instead of silently taking the next flag as the path value (the original bug)', () => {
+    expect(() => parseLogPathArg(['--log-path', '--apply'])).toThrow(/flag-like/)
+  })
+
+  it('throws when --log-path is the last token with no value at all', () => {
+    expect(() => parseLogPathArg(['--log-path'])).toThrow(/requires a value/)
+  })
+})
+
+describe('parseBatchSizeArg (code-review finding, MEDIUM)', () => {
+  it('returns undefined when the flag is absent', () => {
+    expect(parseBatchSizeArg(['--apply'])).toBeUndefined()
+  })
+
+  it('parses the --batch-size=<n> attached form', () => {
+    expect(parseBatchSizeArg(['--batch-size=750'])).toBe(750)
+  })
+
+  it('parses the --batch-size <n> space-separated form', () => {
+    expect(parseBatchSizeArg(['--batch-size', '750'])).toBe(750)
+  })
+
+  it('throws on a fractional value instead of silently flooring it', () => {
+    expect(() => parseBatchSizeArg(['--batch-size', '750.5'])).toThrow(/whole number/)
+  })
+
+  it('throws on a non-numeric value instead of silently falling back to the default', () => {
+    expect(() => parseBatchSizeArg(['--batch-size', 'abc'])).toThrow(/whole number/)
+  })
+
+  it('throws when --batch-size is the last token with no value at all', () => {
+    expect(() => parseBatchSizeArg(['--batch-size'])).toThrow(/requires a value/)
+  })
+
+  it('throws instead of silently taking the next flag as the value', () => {
+    expect(() => parseBatchSizeArg(['--batch-size', '--apply'])).toThrow(/requires a value/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runRepair — partial-failure exit status (code-review finding, MEDIUM: the
+// CLI entrypoint must not exit 0 when any batch failed)
+// ---------------------------------------------------------------------------
+
+describe('runRepair — reports errors for the CLI entrypoint to act on', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('result.errors is non-empty when a batch fails, so main() can set a non-zero exit code', async () => {
+    const ids = makeIds(4)
+    const db: RepairDbDeps = {
+      fetchCandidateIds: async () => ids,
+      nullContentHashForIds: async () => {
+        throw new Error('connection reset by peer')
+      },
+    }
+
+    const result = await runRepair(db, { apply: true, batchSize: MIN_BATCH_SIZE })
+
+    expect(result.errors.length).toBeGreaterThan(0)
+    expect(result.updatedIds).toEqual([])
+  })
+
+  it('result.errors is empty on a fully successful run', async () => {
+    const ids = makeIds(4)
+    const db: RepairDbDeps = {
+      fetchCandidateIds: async () => ids,
+      nullContentHashForIds: async (batch) => [...batch],
+    }
+
+    const result = await runRepair(db, { apply: true, batchSize: MIN_BATCH_SIZE })
+
+    expect(result.errors).toEqual([])
+    expect(result.updatedIds.sort()).toEqual([...ids].sort())
+  })
+})

--- a/scripts/tests/indexer/repair-latched-name-rows.test.ts
+++ b/scripts/tests/indexer/repair-latched-name-rows.test.ts
@@ -1,0 +1,493 @@
+/**
+ * SMI-5930 Wave 2: unit tests for scripts/indexer/repair-latched-name-rows.ts.
+ *
+ * Covers:
+ *  - batching (planBatches: fixed-size slices, ordered, remainder batch)
+ *  - dry-run vs apply: dry-run NEVER calls nullContentHashForIds; apply does
+ *  - statement-timeout halve-and-retry (mirrors
+ *    batch-upsert-timeout-retry.test.ts's assertions on upsertChunkWithRetry,
+ *    adapted to this script's own updateBatchWithRetry)
+ *  - dry-run console output is BOUNDED (first/last N ids only, never the
+ *    full candidate list)
+ *  - the unlatched-ids log file is written incrementally, one line per
+ *    successful batch, only in apply mode
+ *
+ * No real Postgres/psql: `RepairDbDeps` is a plain object the tests inject
+ * directly, mirroring the `Smi5879SimulateFullDbDeps` fake-injection
+ * convention (scripts/tests/indexer/smi5879-simulate-full.test.ts) rather
+ * than mocking `node:child_process` — the module under test never touches
+ * `createRepairDbDeps`/`smi5879-census.pg.ts` in these tests.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  planBatches,
+  sampleIdsForDryRun,
+  updateBatchWithRetry,
+  runRepair,
+  appendBatchLog,
+  defaultLogPath,
+  DEFAULT_BATCH_SIZE,
+  MIN_BATCH_SIZE,
+  MAX_BATCH_SIZE,
+  MAX_TIMEOUT_SPLIT_DEPTH,
+  LATCHED_ROW_PREDICATE,
+  buildFetchCandidateIdsSql,
+  buildNullContentHashSql,
+  assertJoinableId,
+  type RepairDbDeps,
+} from '../../indexer/repair-latched-name-rows.ts'
+
+const STATEMENT_TIMEOUT_ERROR = new Error('canceling statement due to statement timeout')
+
+function makeIds(n: number, prefix = 'id'): string[] {
+  return Array.from({ length: n }, (_, i) => `${prefix}-${String(i).padStart(5, '0')}`)
+}
+
+/** A fake RepairDbDeps whose nullContentHashForIds always succeeds, echoing back the ids given. */
+function alwaysSucceedsDb(candidateIds: string[]): {
+  db: RepairDbDeps
+  calls: string[][]
+} {
+  const calls: string[][] = []
+  const db: RepairDbDeps = {
+    fetchCandidateIds: async () => candidateIds,
+    nullContentHashForIds: async (ids) => {
+      calls.push([...ids])
+      return [...ids]
+    },
+  }
+  return { db, calls }
+}
+
+// ---------------------------------------------------------------------------
+// planBatches
+// ---------------------------------------------------------------------------
+
+describe('planBatches', () => {
+  it('slices an id list into fixed-size batches ordered as given', () => {
+    const ids = makeIds(10)
+    const batches = planBatches(ids, 3)
+    expect(batches).toEqual([ids.slice(0, 3), ids.slice(3, 6), ids.slice(6, 9), ids.slice(9, 10)])
+  })
+
+  it('returns a single batch when batchSize >= total', () => {
+    const ids = makeIds(5)
+    expect(planBatches(ids, 500)).toEqual([ids])
+  })
+
+  it('returns no batches for an empty candidate list', () => {
+    expect(planBatches([], 500)).toEqual([])
+  })
+
+  it('produces the expected batch count for the plan-specified 500-1000 range on ~42,487 rows', () => {
+    const ids = makeIds(42487)
+    const at500 = planBatches(ids, 500)
+    const at1000 = planBatches(ids, 1000)
+    expect(at500).toHaveLength(Math.ceil(42487 / 500))
+    expect(at1000).toHaveLength(Math.ceil(42487 / 1000))
+    // Every id appears exactly once across all batches, in order.
+    expect(at500.flat()).toEqual(ids)
+    expect(at1000.flat()).toEqual(ids)
+  })
+
+  it('throws on a non-positive or non-integer batch size', () => {
+    expect(() => planBatches(makeIds(3), 0)).toThrow(/positive integer/)
+    expect(() => planBatches(makeIds(3), -5)).toThrow(/positive integer/)
+    expect(() => planBatches(makeIds(3), 1.5)).toThrow(/positive integer/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sampleIdsForDryRun
+// ---------------------------------------------------------------------------
+
+describe('sampleIdsForDryRun', () => {
+  it('returns the first N and last N ids for a list longer than 2N', () => {
+    const ids = makeIds(100)
+    const sample = sampleIdsForDryRun(ids, 10)
+    expect(sample.first).toEqual(ids.slice(0, 10))
+    expect(sample.last).toEqual(ids.slice(-10))
+    // Bounded: never more than 2*N ids total in the sample.
+    expect(sample.first.length + sample.last.length).toBeLessThanOrEqual(20)
+  })
+
+  it('omits `last` when the whole list already fits in `first` (no overlap/duplication)', () => {
+    const ids = makeIds(7)
+    const sample = sampleIdsForDryRun(ids, 10)
+    expect(sample.first).toEqual(ids)
+    expect(sample.last).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updateBatchWithRetry — statement-timeout halve-and-retry
+// (mirrors batch-upsert-timeout-retry.test.ts's exact assertions, adapted
+//  from upsertChunkWithRetry's chunk-of-payload shape to this script's
+//  batch-of-id shape)
+// ---------------------------------------------------------------------------
+
+describe('updateBatchWithRetry — statement-timeout halve-and-retry (mirrors upsertChunkWithRetry)', () => {
+  it('halves and retries a timing-out batch until every id succeeds', async () => {
+    const calls: number[] = []
+    const db: RepairDbDeps = {
+      fetchCandidateIds: async () => [],
+      nullContentHashForIds: async (ids) => {
+        calls.push(ids.length)
+        if (ids.length > 1) throw STATEMENT_TIMEOUT_ERROR
+        return [...ids]
+      },
+    }
+
+    const ids = makeIds(4)
+    const result = await updateBatchWithRetry(db, ids)
+
+    // Same halving sequence as the upsertChunkWithRetry regression test:
+    // 4 (fail) -> [0,1] half: 2 (fail) -> 1,1 (succeed) -> [2,3] half: 2
+    // (fail) -> 1,1 (succeed). 7 calls total.
+    expect(calls).toEqual([4, 2, 1, 1, 2, 1, 1])
+    expect(result.updatedIds.sort()).toEqual([...ids].sort())
+    expect(result.errors).toEqual([])
+  })
+
+  it('isolates a single pathologically oversized id instead of discarding the whole batch', async () => {
+    const ids = makeIds(4)
+    const badId = ids[3]
+    const db: RepairDbDeps = {
+      fetchCandidateIds: async () => [],
+      nullContentHashForIds: async (batch) => {
+        if (batch.length > 1) throw STATEMENT_TIMEOUT_ERROR
+        if (batch[0] === badId) throw STATEMENT_TIMEOUT_ERROR
+        return [...batch]
+      },
+    }
+
+    const result = await updateBatchWithRetry(db, ids)
+
+    expect(result.updatedIds.sort()).toEqual(ids.filter((id) => id !== badId).sort())
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toContain('1 row(s)')
+    expect(result.errors[0]).toContain('statement timeout')
+  })
+
+  it('bounds retry recursion under a systemic (every-call) timeout via MAX_TIMEOUT_SPLIT_DEPTH', async () => {
+    let calls = 0
+    const db: RepairDbDeps = {
+      fetchCandidateIds: async () => [],
+      nullContentHashForIds: async () => {
+        calls++
+        throw STATEMENT_TIMEOUT_ERROR
+      },
+    }
+
+    const ids = makeIds(512)
+    const result = await updateBatchWithRetry(db, ids)
+
+    // MAX_TIMEOUT_SPLIT_DEPTH=8: 512 halved 8 times bottoms out at 256
+    // depth-8 leaf batches of 2 ids each — sum(2^0..2^8) = 511 total attempts.
+    expect(MAX_TIMEOUT_SPLIT_DEPTH).toBe(8)
+    expect(calls).toBe(511)
+    expect(result.updatedIds).toEqual([])
+    expect(result.errors).toHaveLength(256)
+    for (const message of result.errors) {
+      expect(message).toContain('2 row(s)')
+    }
+  })
+
+  it('records a non-timeout error without retrying (not a timeout, so no halving)', async () => {
+    let calls = 0
+    const db: RepairDbDeps = {
+      fetchCandidateIds: async () => [],
+      nullContentHashForIds: async () => {
+        calls++
+        throw new Error('connection reset by peer')
+      },
+    }
+
+    const ids = makeIds(4)
+    const result = await updateBatchWithRetry(db, ids)
+
+    expect(calls).toBe(1)
+    expect(result.updatedIds).toEqual([])
+    expect(result.errors).toEqual([`Batch update failed (4 row(s)): connection reset by peer`])
+  })
+
+  // Code-review pass ("no defect found") explicitly requested these two
+  // edge cases as regression coverage, not because a bug was found.
+  it('regression: an odd-length batch splits into disjoint, exhaustive halves with no dropped/duplicated id', async () => {
+    const seen: string[] = []
+    const db: RepairDbDeps = {
+      fetchCandidateIds: async () => [],
+      nullContentHashForIds: async (ids) => {
+        if (ids.length > 1) throw STATEMENT_TIMEOUT_ERROR
+        seen.push(...ids)
+        return [...ids]
+      },
+    }
+
+    const ids = makeIds(7) // odd length
+    const result = await updateBatchWithRetry(db, ids)
+
+    expect(result.updatedIds.sort()).toEqual([...ids].sort())
+    expect(seen.sort()).toEqual([...ids].sort())
+    expect(new Set(seen).size).toBe(7) // no duplicate processing across halves
+  })
+
+  it('regression: a batch already at MAX_TIMEOUT_SPLIT_DEPTH records a complete failed leaf, does not loop or drop it', async () => {
+    let calls = 0
+    const db: RepairDbDeps = {
+      fetchCandidateIds: async () => [],
+      nullContentHashForIds: async () => {
+        calls++
+        throw STATEMENT_TIMEOUT_ERROR
+      },
+    }
+
+    const ids = makeIds(2)
+    const result = await updateBatchWithRetry(db, ids, MAX_TIMEOUT_SPLIT_DEPTH)
+
+    // Already at the cap — must not attempt to split further (ids.length > 1
+    // is true, but depth < MAX_TIMEOUT_SPLIT_DEPTH is false), so exactly one
+    // call, recording the whole 2-id leaf as a single failed batch.
+    expect(calls).toBe(1)
+    expect(result.updatedIds).toEqual([])
+    expect(result.errors).toEqual([
+      `Batch update failed (2 row(s)): canceling statement due to statement timeout`,
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// assertJoinableId / buildNullContentHashSql predicate re-check
+// (code-review findings: HIGH — UPDATE must re-check the full predicate, not
+// just id membership; MEDIUM — a comma inside an id would corrupt the
+// comma-joined id list)
+// ---------------------------------------------------------------------------
+
+describe('assertJoinableId (code-review finding, MEDIUM)', () => {
+  it('passes through an id with no comma unchanged', () => {
+    expect(assertJoinableId('abc-123-def')).toBe('abc-123-def')
+  })
+
+  it('throws on an id containing a comma, rather than silently corrupting the batch', () => {
+    expect(() => assertJoinableId('abc,123')).toThrow(/comma/)
+  })
+})
+
+describe('buildNullContentHashSql (code-review finding, HIGH)', () => {
+  it('re-checks LATCHED_ROW_PREDICATE in the UPDATE, not just id membership', () => {
+    const sql = buildNullContentHashSql()
+    expect(sql).toContain('id = ANY(string_to_array(')
+    expect(sql).toContain(LATCHED_ROW_PREDICATE)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runRepair — dry-run vs apply
+// ---------------------------------------------------------------------------
+
+describe('runRepair — dry-run vs apply', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('dry-run NEVER calls nullContentHashForIds — touches nothing', async () => {
+    const candidateIds = makeIds(2500)
+    const { db, calls } = alwaysSucceedsDb(candidateIds)
+
+    const result = await runRepair(db, { apply: false, batchSize: 500 })
+
+    expect(calls).toEqual([])
+    expect(result.updatedIds).toEqual([])
+    expect(result.errors).toEqual([])
+    expect(result.totalCandidates).toBe(2500)
+    expect(result.batchCount).toBe(5)
+    expect(result.logPath).toBeUndefined()
+  })
+
+  it('apply calls nullContentHashForIds once per batch and returns every unlatched id', async () => {
+    const candidateIds = makeIds(1200)
+    const { db, calls } = alwaysSucceedsDb(candidateIds)
+
+    const result = await runRepair(db, { apply: true, batchSize: 500, logPath: '/dev/null' })
+
+    expect(calls.map((c) => c.length)).toEqual([500, 500, 200])
+    expect(result.updatedIds.sort()).toEqual([...candidateIds].sort())
+    expect(result.errors).toEqual([])
+  })
+
+  it('rejects a batch size outside the plan-specified 500-1000 range', async () => {
+    const { db } = alwaysSucceedsDb(makeIds(10))
+    await expect(runRepair(db, { apply: false, batchSize: 100 })).rejects.toThrow(
+      /--batch-size must be between 500 and 1000/
+    )
+    await expect(runRepair(db, { apply: false, batchSize: 5000 })).rejects.toThrow(
+      /--batch-size must be between 500 and 1000/
+    )
+  })
+
+  it('uses the documented default batch size when none is given', async () => {
+    expect(DEFAULT_BATCH_SIZE).toBeGreaterThanOrEqual(MIN_BATCH_SIZE)
+    expect(DEFAULT_BATCH_SIZE).toBeLessThanOrEqual(MAX_BATCH_SIZE)
+    const { db, calls } = alwaysSucceedsDb(makeIds(DEFAULT_BATCH_SIZE + 1))
+    await runRepair(db, { apply: true, logPath: '/dev/null' })
+    expect(calls[0]).toHaveLength(DEFAULT_BATCH_SIZE)
+    expect(calls[1]).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Dry-run console output is bounded
+// ---------------------------------------------------------------------------
+
+describe('runRepair — dry-run output is bounded', () => {
+  it('never prints the full candidate id list, only a first/last-10 sample', async () => {
+    const candidateIds = makeIds(2500, 'sample')
+    const { db } = alwaysSucceedsDb(candidateIds)
+
+    const logLines: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((msg: unknown) => {
+      logLines.push(String(msg))
+    })
+
+    await runRepair(db, { apply: false, batchSize: 500 })
+    vi.restoreAllMocks()
+
+    const output = logLines.join('\n')
+
+    // A middle-of-the-pack id must never appear — proof the full list isn't dumped.
+    expect(output).not.toContain('sample-01250')
+    // The first 10 and last 10 ids ARE expected (the bounded preview).
+    for (let i = 0; i < 10; i++) {
+      expect(output).toContain(`sample-${String(i).padStart(5, '0')}`)
+    }
+    for (let i = 2490; i < 2500; i++) {
+      expect(output).toContain(`sample-${String(i).padStart(5, '0')}`)
+    }
+    // Total output size stays small regardless of candidate-set size (a full
+    // 2500-id dump would run well past this).
+    expect(output.length).toBeLessThan(4000)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unlatched-ids log file
+// ---------------------------------------------------------------------------
+
+describe('appendBatchLog / runRepair log integration', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'repair-latched-name-rows-test-'))
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('appendBatchLog writes one JSONL line per call, creating parent dirs as needed', async () => {
+    const logPath = join(dir, 'nested', 'unlatched.jsonl')
+
+    await appendBatchLog(logPath, {
+      batchIndex: 0,
+      batchCount: 2,
+      unlatchedAt: '2026-08-11T00:00:00.000Z',
+      ids: ['a', 'b'],
+    })
+    await appendBatchLog(logPath, {
+      batchIndex: 1,
+      batchCount: 2,
+      unlatchedAt: '2026-08-11T00:00:01.000Z',
+      ids: ['c'],
+    })
+
+    const content = await readFile(logPath, 'utf-8')
+    const lines = content.split('\n').filter((l) => l.length > 0)
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[0])).toEqual({
+      batchIndex: 0,
+      batchCount: 2,
+      unlatchedAt: '2026-08-11T00:00:00.000Z',
+      ids: ['a', 'b'],
+    })
+    expect(JSON.parse(lines[1]).ids).toEqual(['c'])
+  })
+
+  it('runRepair --apply records every unlatched id to the log, split across batches', async () => {
+    const candidateIds = makeIds(1200)
+    const { db } = alwaysSucceedsDb(candidateIds)
+    const logPath = join(dir, 'unlatched.jsonl')
+
+    const result = await runRepair(db, { apply: true, batchSize: 500, logPath })
+
+    expect(result.logPath).toBe(logPath)
+    const content = await readFile(logPath, 'utf-8')
+    const lines = content
+      .split('\n')
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as { ids: string[] })
+    const loggedIds = lines.flatMap((l) => l.ids)
+    expect(loggedIds.sort()).toEqual([...candidateIds].sort())
+  })
+
+  it('runRepair dry-run writes NO log file at all', async () => {
+    const candidateIds = makeIds(50)
+    const { db } = alwaysSucceedsDb(candidateIds)
+    const logPath = join(dir, 'should-not-exist.jsonl')
+
+    await runRepair(db, { apply: false, batchSize: 500, logPath })
+
+    await expect(readFile(logPath, 'utf-8')).rejects.toThrow()
+  })
+
+  it('defaultLogPath builds a timestamped path under ~/.skillsmith/backups', () => {
+    const p = defaultLogPath(new Date('2026-05-23T12:34:56.789Z'))
+    expect(p).toContain('.skillsmith')
+    expect(p).toContain('backups')
+    expect(p).toContain('repair-latched-name-rows-2026-05-23')
+    expect(p.endsWith('.jsonl')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SQL builders (predicate single-source-of-truth, no AND TRUE)
+// ---------------------------------------------------------------------------
+
+describe('SQL builders', () => {
+  it('the fetch query uses the exact latched-row predicate with no AND TRUE', () => {
+    const sql = buildFetchCandidateIdsSql()
+    expect(sql).toContain(LATCHED_ROW_PREDICATE)
+    expect(sql).toContain('ORDER BY id')
+    expect(sql).not.toMatch(/AND\s+TRUE/i)
+  })
+
+  it('the update query nulls content_hash for an explicit id list and returns ids', () => {
+    const sql = buildNullContentHashSql()
+    expect(sql).toContain('SET content_hash = NULL')
+    expect(sql).toContain("id = ANY(string_to_array(:'ids', ','))")
+    expect(sql).toContain('RETURNING id')
+    expect(sql).not.toMatch(/AND\s+TRUE/i)
+  })
+
+  it('the predicate checks discovery_path, name/repo-derived-name, content_hash, and security_score', () => {
+    expect(LATCHED_ROW_PREDICATE).toContain("discovery_path LIKE 'subdirectory_search%'")
+    expect(LATCHED_ROW_PREDICATE).toContain('lower(name) = lower(split_part(')
+    expect(LATCHED_ROW_PREDICATE).toContain('content_hash IS NOT NULL')
+    expect(LATCHED_ROW_PREDICATE).toContain('security_score IS NOT NULL')
+  })
+})
+
+// CLI arg-parsing tests (isFlagLikeToken/parseLogPathArg/parseBatchSizeArg)
+// and the runRepair partial-failure-exit-status tests live in
+// repair-latched-name-rows.cli.test.ts (split to stay under 500 lines).

--- a/scripts/tests/indexer/run-gate-callsites.test.ts
+++ b/scripts/tests/indexer/run-gate-callsites.test.ts
@@ -63,6 +63,7 @@ import {
 const PINNED_SHAPE1 = [
   'dequarantine-false-positives.ts',
   'purge-dead-quarantines.ts',
+  'repair-latched-name-rows.ts',
   'revalidate-stale-quarantines.ts',
 ].sort()
 
@@ -79,6 +80,7 @@ const PINNED_SHEBANG_FILES = [
   'dequarantine-false-positives.ts',
   'purge-dead-quarantines.ts',
   'recheck.ts',
+  'repair-latched-name-rows.ts',
   'revalidate-stale-quarantines.ts',
   'run.ts',
 ].sort()

--- a/scripts/tests/indexer/run-gate-order.test.ts
+++ b/scripts/tests/indexer/run-gate-order.test.ts
@@ -29,9 +29,15 @@ const GATED_ENTRY_FILES = [
   'dequarantine-false-positives.ts',
   'purge-dead-quarantines.ts',
   'revalidate-stale-quarantines.ts',
+  // PR-review finding (NON-BLOCKING, SMI-5930): the structural
+  // gate-precedes-side-effects proof below didn't cover this new writer —
+  // run-gate.test.ts and run-gate-callsites.test.ts both confirm the gate
+  // calls EXIST, but neither asserts they run BEFORE the script's own
+  // side-effecting update() call the way this suite does for its siblings.
+  'repair-latched-name-rows.ts',
 ]
 
-describe('run-gate-order — the gate precedes every side effect, in each of the four main() bodies', () => {
+describe('run-gate-order — the gate precedes every side effect, in each of the five main() bodies', () => {
   it.each(GATED_ENTRY_FILES)(
     '%s: assertRunAllowed precedes every side-effect call inside main()',
     (file) => {


### PR DESCRIPTION
## Business Summary

**What shipped:** A new script that will repair ~42,487 skill-registry rows stuck with the wrong name (a data-integrity bug from SMI-5930's earlier RCA) — this PR is the script itself, not the repair. Nothing runs against production yet.

**Quality bar:** Code + tests only — the script has never touched a real database. Independently code-reviewed by GPT-5.6-Sol (a second AI model) before merge, specifically looking for the kind of subtle correctness bug a single reviewer misses. That review found two real, serious issues: the script's row-update logic only checked "is this the row I originally picked," not "is this row still actually broken" — meaning if a row got legitimately fixed by unrelated normal system activity in the window between the script looking at it and acting on it, the script would have undone that fix. And a code comment overclaimed that its own audit log could never lose an entry to a crash, which isn't quite true. Both fixed, along with three smaller issues (unsafe handling of one unlikely data character, two command-line flags that could silently misbehave instead of failing loudly, and the script not reporting failure via its exit code when some rows failed to repair).

**Net result:** Script fully shipped, tested, and hardened. Running it against production is a separate, manual step requiring explicit go-ahead — not part of this PR.

---

## Technical detail

New: `scripts/indexer/repair-latched-name-rows.ts` + `.cli.ts` (CLI arg parsing, split out to stay under the 500-line file-length gate), with matching test files. `--dry-run` (default) / `--apply`, batches of 500–1,000 rows via the session pooler, halve-and-retry on a statement timeout (mirrors `upsertChunkWithRetry`'s SMI-5968 pattern).

Part of `docs/internal/implementation/smi-5930-wave2-and-adjacent-fixes.md` — ships as its own PR per that plan's review recommendation (production data repair has a different risk/rollback profile than the other items in that plan, so nothing is bundled together).