### PR TITLE
fix(core,cli): SMI-5980 resolve companion-subagent path per client

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `skillsmith author subagent`/`transform` now write companion-subagent files to the
+  target client's own agent directory (via `@skillsmith/core`'s new `COMPANION_AGENT_TARGETS`)
+  instead of always hardcoding `~/.claude/agents/` — fixes generated subagents landing in the
+  wrong client's directory for `--client cursor`/`copilot`/etc (GH #2161)
 - **Fix**: `license-types.ts`'s `TIER_FEATURES` was silently missing `version_tracking`
   (individual/team/enterprise) and `skill_security_audit` (team/enterprise) versus the canonical
   `@smith-horn/enterprise` package's own feature membership — this file has no compiler backstop

--- a/packages/cli/src/commands/author/subagent.ts
+++ b/packages/cli/src/commands/author/subagent.ts
@@ -205,12 +205,18 @@ export const subagentAction = withTelemetry(subagentActionImpl, {
 
 /**
  * Create subagent command
+ *
+ * SMI-5980 (Wave 3): `--output` has no static default value here anymore —
+ * when omitted, `ensureAgentsDirectory()` resolves the default via
+ * `resolveCompanionAgentDir()` (COMPANION_AGENT_TARGETS, `@skillsmith/core/install`)
+ * instead of a literal `'~/.claude/agents'` string duplicated at the command
+ * definition. An explicit `--output` still always wins.
  */
 export function createSubagentCommand(): Command {
   return new Command('subagent')
     .description('Generate a companion subagent for a skill')
     .argument('[path]', 'Path to skill directory', '.')
-    .option('-o, --output <path>', 'Output directory', '~/.claude/agents')
+    .option('-o, --output <path>', 'Output directory (default: ~/.claude/agents)')
     .option('--tools <tools>', 'Override detected tools (comma-separated)')
     .option('--model <model>', 'Model for subagent: sonnet|opus|haiku', 'sonnet')
     .option('--skip-claude-md', 'Skip CLAUDE.md snippet generation')

--- a/packages/cli/src/commands/author/subagent.ts
+++ b/packages/cli/src/commands/author/subagent.ts
@@ -12,6 +12,7 @@ import ora from 'ora'
 import { readFile, writeFile, stat } from 'fs/promises'
 import { basename, dirname, join, resolve } from 'path'
 import { SkillParser } from '@skillsmith/core'
+import { getCompanionAgentTarget } from '@skillsmith/core/install'
 
 const logger = getCliLogger()
 
@@ -126,7 +127,18 @@ export async function generateSubagent(skillPath: string, options: SubagentOptio
 
     // Ensure agents directory exists
     const agentsDir = await ensureAgentsDirectory(options.output)
-    const subagentPath = join(agentsDir, `${basename(metadata.name)}-specialist.md`)
+    // PR-review finding (NON-BLOCKING): the filename was a hand-assembled
+    // `${name}-specialist.md` literal, duplicating the pattern
+    // COMPANION_AGENT_TARGETS already owns per client (@skillsmith/core/install).
+    // Only the FILENAME comes from there -- `agentsDir` above still governs
+    // the directory (and must, since it's the one that honors --output's
+    // override; resolveCompanionAgentPath() always resolves the default
+    // per-client dir and would silently ignore --output).
+    const subagentFilename = getCompanionAgentTarget().filenamePattern.replace(
+      '{name}',
+      basename(metadata.name)
+    )
+    const subagentPath = join(agentsDir, subagentFilename)
 
     // Check if subagent already exists
     if (await fileExists(subagentPath)) {

--- a/packages/cli/src/commands/author/transform.ts
+++ b/packages/cli/src/commands/author/transform.ts
@@ -11,8 +11,8 @@ import { withTelemetry } from '@skillsmith/core/telemetry'
 import ora from 'ora'
 import { readFile, readdir } from 'fs/promises'
 import { join, resolve } from 'path'
-import { homedir } from 'os'
 import { SkillParser } from '@skillsmith/core'
+import { resolveCompanionAgentDir } from '@skillsmith/core/install'
 
 const logger = getCliLogger()
 
@@ -102,8 +102,12 @@ export async function transformSkill(skillPath: string, options: TransformOption
       return
     }
 
-    // Check if subagent already exists
-    const agentsDir = join(homedir(), '.claude', 'agents')
+    // Check if subagent already exists. SMI-5980 (Wave 3): resolved via the
+    // same COMPANION_AGENT_TARGETS-backed resolver generateSubagent() below
+    // ultimately uses (through ensureAgentsDirectory()) — this command has no
+    // --output/--client of its own, so it stays the canonical (claude-code)
+    // default, same as before, but no longer duplicates the hardcoded literal.
+    const agentsDir = resolveCompanionAgentDir()
     const subagentPath = join(agentsDir, `${metadata.name}-specialist.md`)
 
     if (await fileExists(subagentPath)) {

--- a/packages/cli/src/commands/author/transform.ts
+++ b/packages/cli/src/commands/author/transform.ts
@@ -12,7 +12,7 @@ import ora from 'ora'
 import { readFile, readdir } from 'fs/promises'
 import { join, resolve } from 'path'
 import { SkillParser } from '@skillsmith/core'
-import { resolveCompanionAgentDir } from '@skillsmith/core/install'
+import { resolveCompanionAgentPath } from '@skillsmith/core/install'
 
 const logger = getCliLogger()
 
@@ -106,9 +106,11 @@ export async function transformSkill(skillPath: string, options: TransformOption
     // same COMPANION_AGENT_TARGETS-backed resolver generateSubagent() below
     // ultimately uses (through ensureAgentsDirectory()) — this command has no
     // --output/--client of its own, so it stays the canonical (claude-code)
-    // default, same as before, but no longer duplicates the hardcoded literal.
-    const agentsDir = resolveCompanionAgentDir()
-    const subagentPath = join(agentsDir, `${metadata.name}-specialist.md`)
+    // default, same as before. PR-review finding (NON-BLOCKING): now uses
+    // resolveCompanionAgentPath() for BOTH dir and filename (safe here,
+    // unlike subagent.ts, since there's no --output override to lose) so
+    // the two can't independently drift apart on filename policy.
+    const subagentPath = resolveCompanionAgentPath(metadata.name)
 
     if (await fileExists(subagentPath)) {
       if (!options.force) {

--- a/packages/cli/src/commands/author/utils.ts
+++ b/packages/cli/src/commands/author/utils.ts
@@ -7,9 +7,10 @@
 import chalk from 'chalk'
 import { access } from 'fs/promises'
 import { mkdir } from 'fs/promises'
-import { join, resolve } from 'path'
+import { resolve } from 'path'
 import { homedir } from 'os'
 import type { ValidationResult } from '@skillsmith/core'
+import { resolveCompanionAgentDir, type ClientId } from '@skillsmith/core/install'
 
 /**
  * Pretty print validation errors and warnings
@@ -53,12 +54,21 @@ export async function fileExists(path: string): Promise<boolean> {
 }
 
 /**
- * Ensure ~/.claude/agents directory exists
+ * Ensure the companion-subagent output directory exists and return it.
+ *
+ * `customPath` (`--output`) always wins when supplied — an explicit override
+ * stays supported. Otherwise resolves per `client` via
+ * `resolveCompanionAgentDir()` (SMI-5980 Wave 3) — for `client` omitted or
+ * `'claude-code'` this is `~/.claude/agents/`, unchanged from the prior
+ * hardcoded default.
  */
-export async function ensureAgentsDirectory(customPath?: string): Promise<string> {
+export async function ensureAgentsDirectory(
+  customPath?: string,
+  client?: ClientId
+): Promise<string> {
   const agentsDir = customPath
     ? resolve(customPath.replace(/^~/, homedir()))
-    : join(homedir(), '.claude', 'agents')
+    : resolveCompanionAgentDir(client)
 
   await mkdir(agentsDir, { recursive: true })
   return agentsDir

--- a/packages/cli/tests/author.companion-agent-dir.test.ts
+++ b/packages/cli/tests/author.companion-agent-dir.test.ts
@@ -1,0 +1,59 @@
+/**
+ * SMI-5980 (Wave 3): `ensureAgentsDirectory()` must resolve its default
+ * directory via `resolveCompanionAgentDir()` (`@skillsmith/core/install`)
+ * instead of a hardcoded `join(homedir(), '.claude', 'agents')` literal, and
+ * `--output` (the `customPath` param) must still win as an explicit
+ * override regardless of `client`.
+ *
+ * `mkdir` is mocked so no test ever touches the real filesystem — the
+ * assertions only need the RETURNED path, not an actual directory.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn(),
+}))
+
+describe('ensureAgentsDirectory (SMI-5980 Wave 3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('with no customPath and no client, matches resolveCompanionAgentDir() (regression: unchanged default)', async () => {
+    const { ensureAgentsDirectory } = await import('../src/commands/author/utils.js')
+    const { resolveCompanionAgentDir } = await import('@skillsmith/core/install')
+
+    const result = await ensureAgentsDirectory()
+
+    expect(result).toBe(resolveCompanionAgentDir())
+    // The pre-Wave-3 default was literally `~/.claude/agents` — confirm the
+    // resolved default still ends there for the canonical client.
+    expect(result.endsWith('/.claude/agents')).toBe(true)
+  })
+
+  it('with no customPath, resolves per client via COMPANION_AGENT_TARGETS', async () => {
+    const { ensureAgentsDirectory } = await import('../src/commands/author/utils.js')
+    const { resolveCompanionAgentDir } = await import('@skillsmith/core/install')
+
+    const copilotResult = await ensureAgentsDirectory(undefined, 'copilot')
+    const claudeCodeResult = await ensureAgentsDirectory(undefined, 'claude-code')
+
+    expect(copilotResult).toBe(resolveCompanionAgentDir('copilot'))
+    expect(claudeCodeResult).toBe(resolveCompanionAgentDir('claude-code'))
+    // copilot has independent AGENT_SHIM_TARGETS evidence — must differ from claude-code.
+    expect(copilotResult).not.toBe(claudeCodeResult)
+  })
+
+  it('an explicit customPath (--output) always wins over the client-derived default', async () => {
+    const { ensureAgentsDirectory } = await import('../src/commands/author/utils.js')
+
+    const result = await ensureAgentsDirectory('/tmp/my-custom-agents-dir', 'copilot')
+
+    expect(result).toBe('/tmp/my-custom-agents-dir')
+  })
+})

--- a/packages/cli/tests/author.test.ts
+++ b/packages/cli/tests/author.test.ts
@@ -155,13 +155,17 @@ describe('SMI-746: Skill Authoring Commands', () => {
       expect(cmd.name()).toBe('subagent')
     })
 
-    it('has output option with default', async () => {
+    it('has output option, resolved dynamically (no static default value) (SMI-5980)', async () => {
       const { createSubagentCommand } = await import('../src/commands/author/index.js')
       const cmd = createSubagentCommand()
 
       const outputOpt = cmd.options.find((o) => o.short === '-o')
       expect(outputOpt).toBeDefined()
-      expect(outputOpt?.defaultValue).toBe('~/.claude/agents')
+      // No static default value at the command-definition level anymore —
+      // an omitted --output resolves via ensureAgentsDirectory() ->
+      // resolveCompanionAgentDir() (COMPANION_AGENT_TARGETS), not a
+      // hardcoded '~/.claude/agents' literal duplicated here.
+      expect(outputOpt?.defaultValue).toBeUndefined()
     })
 
     it('has tools option', async () => {
@@ -252,13 +256,17 @@ describe('SMI-1389: Subagent Command', () => {
       expect(cmd.name()).toBe('subagent')
     })
 
-    it('has output option with default', async () => {
+    it('has output option, resolved dynamically (no static default value) (SMI-5980)', async () => {
       const { createSubagentCommand } = await import('../src/commands/author/index.js')
       const cmd = createSubagentCommand()
 
       const outputOpt = cmd.options.find((o) => o.short === '-o')
       expect(outputOpt).toBeDefined()
-      expect(outputOpt?.defaultValue).toBe('~/.claude/agents')
+      // No static default value at the command-definition level anymore —
+      // an omitted --output resolves via ensureAgentsDirectory() ->
+      // resolveCompanionAgentDir() (COMPANION_AGENT_TARGETS), not a
+      // hardcoded '~/.claude/agents' literal duplicated here.
+      expect(outputOpt?.defaultValue).toBeUndefined()
     })
 
     it('has model option with default sonnet', async () => {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: companion-subagent files (the `-specialist.md` shim generated alongside an installed
+  skill) were always written to `~/.claude/agents/`, regardless of which client the skill itself
+  was installed for — a skill installed with `--client cursor` or `SKILLSMITH_CLIENT=cursor`
+  still got its companion subagent dropped into Claude Code's own agent directory instead of
+  Cursor's. New `COMPANION_AGENT_TARGETS` map (`@skillsmith/core/install/paths`) plus
+  `getCompanionAgentTarget()`/`resolveCompanionAgentDir()`/`resolveCompanionAgentPath()` give each
+  `ClientId` its own companion-agent directory and filename pattern, sourced from the same
+  evidence table already used for skill install paths; clients with no independently-verified
+  agents-dir convention default to today's existing `~/.claude/agents/` behavior rather than
+  guessing (GH #2161)
+
 ## v0.11.5
 
 - **Cadence**: Mechanical cadence alignment (no changes since v0.11.4).

--- a/packages/core/src/install/index.ts
+++ b/packages/core/src/install/index.ts
@@ -14,14 +14,18 @@ export {
   CLIENT_DISPLAY_LABELS,
   CLIENT_IDS,
   CLIENT_NATIVE_PATHS,
+  COMPANION_AGENT_TARGETS,
   assertClientId,
   enumerateHarnessPresence,
   getCanonicalInstallPath,
+  getCompanionAgentTarget,
   getInstallPath,
   resolveClientId,
   resolveClientPath,
+  resolveCompanionAgentDir,
+  resolveCompanionAgentPath,
 } from './paths.js'
-export type { ClientId } from './paths.js'
+export type { ClientId, CompanionAgentTarget } from './paths.js'
 
 export {
   addLink,

--- a/packages/core/src/install/paths.test.ts
+++ b/packages/core/src/install/paths.test.ts
@@ -131,11 +131,20 @@ describe('COMPANION_AGENT_TARGETS (SMI-5980 Wave 3)', () => {
     expect(Object.keys(COMPANION_AGENT_TARGETS)).toHaveLength(CLIENT_IDS.length)
   })
 
-  it('every entry uses flat file mode and the shared {name}-specialist.md pattern', () => {
+  it('every entry uses flat file mode; every entry but copilot uses the shared {name}-specialist.md pattern', () => {
     for (const id of CLIENT_IDS) {
       expect(COMPANION_AGENT_TARGETS[id].fileMode).toBe('flat')
+      if (id === 'copilot') continue
       expect(COMPANION_AGENT_TARGETS[id].filenamePattern).toBe('{name}-specialist.md')
     }
+  })
+
+  it('copilot uses {name}.agent.md — its own independently-evidenced filename, not the shared -specialist.md suffix (PR-review finding, BLOCKING)', () => {
+    // AGENT_SHIM_TARGETS.copilot (agent-harness-targets.ts) and shims.ts's
+    // own doc comment both independently confirm Copilot's real
+    // companion-agent format is `.agent.md` -- a plain `-specialist.md`
+    // suffix risked producing a file Copilot's own surfaces never discover.
+    expect(COMPANION_AGENT_TARGETS.copilot.filenamePattern).toBe('{name}.agent.md')
   })
 
   it('claude-code matches the pre-Wave-3 hardcoded default exactly', () => {
@@ -179,13 +188,18 @@ describe('getCompanionAgentTarget / resolveCompanionAgentDir / resolveCompanionA
     expect(resolveCompanionAgentDir()).toBe(COMPANION_AGENT_TARGETS['claude-code'].dir)
   })
 
-  it.each<ClientId>([...CLIENT_IDS])(
-    'resolveCompanionAgentPath(%s) matches dir + <skillName>-specialist.md for every client',
+  it.each<ClientId>(CLIENT_IDS.filter((id) => id !== 'copilot'))(
+    'resolveCompanionAgentPath(%s) matches dir + <skillName>-specialist.md for every client but copilot',
     (client) => {
       const result = resolveCompanionAgentPath('my-skill', client)
       expect(result).toBe(join(COMPANION_AGENT_TARGETS[client].dir, 'my-skill-specialist.md'))
     }
   )
+
+  it('resolveCompanionAgentPath(copilot) matches dir + <skillName>.agent.md', () => {
+    const result = resolveCompanionAgentPath('my-skill', 'copilot')
+    expect(result).toBe(join(COMPANION_AGENT_TARGETS.copilot.dir, 'my-skill.agent.md'))
+  })
 
   it('resolveCompanionAgentPath defaults to canonical client when omitted (regression: unchanged)', () => {
     const result = resolveCompanionAgentPath('my-skill')

--- a/packages/core/src/install/paths.test.ts
+++ b/packages/core/src/install/paths.test.ts
@@ -7,6 +7,8 @@
  * pythonIncremental.hardening.test.ts (SMI-4315/4316).
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 
 // vi.hoisted runs before vi.mock factories so we can share the spy instance.
 const { existsSyncSpy } = vi.hoisted(() => ({
@@ -18,7 +20,17 @@ vi.mock('node:fs', async () => {
   return { ...actual, existsSync: (p: string) => existsSyncSpy(p) }
 })
 
-import { CLIENT_IDS, CLIENT_NATIVE_PATHS, enumerateHarnessPresence } from './paths.js'
+import {
+  CANONICAL_CLIENT,
+  CLIENT_IDS,
+  CLIENT_NATIVE_PATHS,
+  COMPANION_AGENT_TARGETS,
+  enumerateHarnessPresence,
+  getCompanionAgentTarget,
+  resolveCompanionAgentDir,
+  resolveCompanionAgentPath,
+  type ClientId,
+} from './paths.js'
 
 describe('enumerateHarnessPresence (SMI-5390)', () => {
   beforeEach(() => {
@@ -99,5 +111,84 @@ describe('grok ClientId (SMI-5697)', () => {
 
   it('grok resolves to ~/.grok/skills', () => {
     expect(CLIENT_NATIVE_PATHS.grok.endsWith('/.grok/skills')).toBe(true)
+  })
+})
+
+/**
+ * SMI-5980 (Wave 3): COMPANION_AGENT_TARGETS is a regression guard by
+ * design — every existing ClientId's companion-subagent output path must be
+ * EXACTLY unchanged from the pre-Wave-3 hardcoded
+ * `path.join(os.homedir(), '.claude', 'agents')` default, except copilot and
+ * opencode, which get an independently-evidenced directory value cited from
+ * AGENT_SHIM_TARGETS (agent-harness-targets.ts) for the SAME underlying
+ * tool — not a new invented value.
+ */
+describe('COMPANION_AGENT_TARGETS (SMI-5980 Wave 3)', () => {
+  it('has exactly one entry per ClientId in CLIENT_IDS', () => {
+    for (const id of CLIENT_IDS) {
+      expect(COMPANION_AGENT_TARGETS[id]).toBeDefined()
+    }
+    expect(Object.keys(COMPANION_AGENT_TARGETS)).toHaveLength(CLIENT_IDS.length)
+  })
+
+  it('every entry uses flat file mode and the shared {name}-specialist.md pattern', () => {
+    for (const id of CLIENT_IDS) {
+      expect(COMPANION_AGENT_TARGETS[id].fileMode).toBe('flat')
+      expect(COMPANION_AGENT_TARGETS[id].filenamePattern).toBe('{name}-specialist.md')
+    }
+  })
+
+  it('claude-code matches the pre-Wave-3 hardcoded default exactly', () => {
+    // Pre-Wave-3: path.join(os.homedir(), '.claude', 'agents') — the exact
+    // literal skill-installation.io.ts and author/utils.ts both hardcoded.
+    expect(COMPANION_AGENT_TARGETS['claude-code'].dir).toBe(join(homedir(), '.claude', 'agents'))
+  })
+
+  it.each<ClientId>(['cursor', 'windsurf', 'agents', 'hermes', 'grok'])(
+    '%s has no independent AGENT_SHIM_TARGETS evidence — defaults to the claude-code value',
+    (client) => {
+      expect(COMPANION_AGENT_TARGETS[client].dir).toBe(COMPANION_AGENT_TARGETS['claude-code'].dir)
+    }
+  )
+
+  it('copilot uses its own independently-evidenced directory, not the claude-code default', () => {
+    expect(COMPANION_AGENT_TARGETS.copilot.dir.endsWith('/.copilot/agents')).toBe(true)
+    expect(COMPANION_AGENT_TARGETS.copilot.dir).not.toBe(COMPANION_AGENT_TARGETS['claude-code'].dir)
+  })
+
+  it('opencode uses its own independently-evidenced directory, not the claude-code default', () => {
+    expect(COMPANION_AGENT_TARGETS.opencode.dir.endsWith('/.config/opencode/agents')).toBe(true)
+    expect(COMPANION_AGENT_TARGETS.opencode.dir).not.toBe(
+      COMPANION_AGENT_TARGETS['claude-code'].dir
+    )
+  })
+})
+
+describe('getCompanionAgentTarget / resolveCompanionAgentDir / resolveCompanionAgentPath (SMI-5980 Wave 3)', () => {
+  it('getCompanionAgentTarget defaults to CANONICAL_CLIENT when no client is passed', () => {
+    expect(getCompanionAgentTarget()).toEqual(COMPANION_AGENT_TARGETS[CANONICAL_CLIENT])
+  })
+
+  it('getCompanionAgentTarget returns the exact per-client entry', () => {
+    for (const id of CLIENT_IDS) {
+      expect(getCompanionAgentTarget(id)).toEqual(COMPANION_AGENT_TARGETS[id])
+    }
+  })
+
+  it('resolveCompanionAgentDir defaults to the canonical (claude-code) dir', () => {
+    expect(resolveCompanionAgentDir()).toBe(COMPANION_AGENT_TARGETS['claude-code'].dir)
+  })
+
+  it.each<ClientId>([...CLIENT_IDS])(
+    'resolveCompanionAgentPath(%s) matches dir + <skillName>-specialist.md for every client',
+    (client) => {
+      const result = resolveCompanionAgentPath('my-skill', client)
+      expect(result).toBe(join(COMPANION_AGENT_TARGETS[client].dir, 'my-skill-specialist.md'))
+    }
+  )
+
+  it('resolveCompanionAgentPath defaults to canonical client when omitted (regression: unchanged)', () => {
+    const result = resolveCompanionAgentPath('my-skill')
+    expect(result).toBe(join(COMPANION_AGENT_TARGETS['claude-code'].dir, 'my-skill-specialist.md'))
   })
 })

--- a/packages/core/src/install/paths.ts
+++ b/packages/core/src/install/paths.ts
@@ -192,12 +192,14 @@ export interface CompanionAgentTarget {
  *   `author/utils.ts`'s prior `ensureAgentsDirectory()` default).
  * - `copilot`: `AGENT_SHIM_TARGETS.copilot` (agent-harness-targets.ts) has a
  *   real, non-null entry for the SAME underlying tool —
- *   `~/.copilot/agents/skillsmith-agent.agent.md`. Its DIRECTORY
- *   (`~/.copilot/agents/`) is cited here as independent evidence of
- *   Copilot's own agents-dir convention; the FILENAME is not reused —
- *   `skillsmith-agent.agent.md` is that table's own singular-shim naming for
- *   a different command, unrelated to this map's per-skill
- *   `<name>-specialist.md` naming.
+ *   `~/.copilot/agents/skillsmith-agent.agent.md`. Both its DIRECTORY
+ *   (`~/.copilot/agents/`) AND its `.agent.md` EXTENSION are cited here as
+ *   independent evidence (corroborated by shims.ts's own doc comment:
+ *   "Copilot `.agent.md` (Copilot cloud-agent + CLI surfaces, which do not
+ *   read `.claude/agents`)") — PR-review finding (BLOCKING): a plain
+ *   `-specialist.md` suffix here previously risked writing a companion file
+ *   Copilot's own surfaces don't discover at all. Per-skill naming is
+ *   `<name>.agent.md`, not `<name>-specialist.md`.
  * - `opencode`: `AGENT_SHIM_TARGETS.opencode` likewise has a real, non-null
  *   entry — `~/.config/opencode/agents/skillsmith-agent.md` (plural
  *   `agents/`, Step-6 verified against opencode.ai/docs/agents/ per that
@@ -232,12 +234,18 @@ export const COMPANION_AGENT_TARGETS: Record<ClientId, CompanionAgentTarget> = {
     filenamePattern: '{name}-specialist.md',
   },
   copilot: {
-    // Directory cited from AGENT_SHIM_TARGETS.copilot (agent-harness-targets.ts)
-    // as independent evidence of Copilot's own agents-dir convention.
-    // Filename pattern is this map's own naming, not copied from that table.
+    // PR-review finding (BLOCKING): both dir AND filename are now cited
+    // from AGENT_SHIM_TARGETS.copilot (agent-harness-targets.ts:156,
+    // `skillsmith-agent.agent.md`) and shims.ts's own doc comment ("Copilot
+    // `.agent.md` (Copilot cloud-agent + CLI surfaces, which do not read
+    // `.claude/agents`)") -- this codebase already has independently
+    // verified evidence that Copilot's real companion-agent format is
+    // `<name>.agent.md`, not the generic `-specialist.md` suffix every
+    // other client here defaults to. Writing plain `.md` risked producing
+    // an undiscoverable companion file.
     dir: join(homedir(), '.copilot', 'agents'),
     fileMode: 'flat',
-    filenamePattern: '{name}-specialist.md',
+    filenamePattern: '{name}.agent.md',
   },
   windsurf: {
     // No AGENT_SHIM_TARGETS entry exists for windsurf (not a HarnessId

--- a/packages/core/src/install/paths.ts
+++ b/packages/core/src/install/paths.ts
@@ -153,3 +153,149 @@ export function enumerateHarnessPresence(): Array<{
     }
   })
 }
+
+/**
+ * SMI-5980 (Wave 3): where a per-skill companion-subagent file is written for
+ * a given `ClientId`.
+ *
+ * **Deliberately NOT derived from `AGENT_SHIM_TARGETS`** (agent-harness-targets.ts).
+ * That table encodes complete, singular shim-file targets (fixed filenames like
+ * `skillsmith-agent.md`, `null` entries for some tools) for a *different*
+ * command (`sklx agent install`'s one-time named-agent shim), keyed by the
+ * narrower `HarnessId` enum (5 members) rather than `ClientId` (8 members).
+ * This is a new, purpose-built map for the per-skill companion-subagent file
+ * that `SkillInstallationService.install()` / `sklx author subagent` can
+ * generate for ANY installed skill, one file per skill, not a single fixed
+ * shim.
+ *
+ * `fileMode: 'flat'` is the only mode today — one file directly inside `dir`,
+ * named by substituting `{name}` in `filenamePattern`. A later wave (SMI-5982
+ * / Antigravity) is expected to add a `'directory-package'` mode for a
+ * `<name>/agent.md` layout — extend the union then; don't widen it
+ * speculatively now.
+ */
+export interface CompanionAgentTarget {
+  dir: string
+  fileMode: 'flat'
+  filenamePattern: string
+}
+
+/**
+ * Populated conservatively per the SMI-5980 plan review, to fix the
+ * hardcoding/architecture bug (making this resolvable per client at all)
+ * WITHOUT inventing new, unverified per-client directory values:
+ *
+ * - `claude-code`: today's actual confirmed hardcoded value
+ *   (`~/.claude/agents/<skillName>-specialist.md`) — this must exactly match
+ *   pre-Wave-3 behavior (`skill-installation.io.ts`'s prior
+ *   `path.join(os.homedir(), '.claude', 'agents')` literal and
+ *   `author/utils.ts`'s prior `ensureAgentsDirectory()` default).
+ * - `copilot`: `AGENT_SHIM_TARGETS.copilot` (agent-harness-targets.ts) has a
+ *   real, non-null entry for the SAME underlying tool —
+ *   `~/.copilot/agents/skillsmith-agent.agent.md`. Its DIRECTORY
+ *   (`~/.copilot/agents/`) is cited here as independent evidence of
+ *   Copilot's own agents-dir convention; the FILENAME is not reused —
+ *   `skillsmith-agent.agent.md` is that table's own singular-shim naming for
+ *   a different command, unrelated to this map's per-skill
+ *   `<name>-specialist.md` naming.
+ * - `opencode`: `AGENT_SHIM_TARGETS.opencode` likewise has a real, non-null
+ *   entry — `~/.config/opencode/agents/skillsmith-agent.md` (plural
+ *   `agents/`, Step-6 verified against opencode.ai/docs/agents/ per that
+ *   table's own header comment). Its DIRECTORY
+ *   (`~/.config/opencode/agents/`) is cited here as independent evidence of
+ *   OpenCode's own agents-dir convention, filename likewise not reused.
+ * - `cursor`: `AGENT_SHIM_TARGETS.cursor` is `null` — NOT a directory value,
+ *   just documentation that Cursor 2.4+ reads `.claude/agents/` natively
+ *   (per that table's own comment). That happens to coincide with the
+ *   default below, but it is not being "cited as evidence" for a distinct
+ *   value — cursor defaults like any client with no independent evidence.
+ * - `windsurf`, `agents`, `hermes`, `grok`: none of these are even members
+ *   of the narrower `HarnessId` enum `AGENT_SHIM_TARGETS` is keyed on, so
+ *   there is no table entry to consult either way. Every one of these
+ *   defaults to today's actual behavior — the same `~/.claude/agents/`
+ *   value every client gets today.
+ *
+ * Exported for the next wave (SMI-5982, Antigravity) to import and extend
+ * with a real `antigravity` `ClientId` member once that `ClientId` exists.
+ */
+export const COMPANION_AGENT_TARGETS: Record<ClientId, CompanionAgentTarget> = {
+  'claude-code': {
+    dir: join(homedir(), '.claude', 'agents'),
+    fileMode: 'flat',
+    filenamePattern: '{name}-specialist.md',
+  },
+  cursor: {
+    // AGENT_SHIM_TARGETS.cursor is null (no distinct value) — defaults like
+    // every client with no independent evidence. See doc comment above.
+    dir: join(homedir(), '.claude', 'agents'),
+    fileMode: 'flat',
+    filenamePattern: '{name}-specialist.md',
+  },
+  copilot: {
+    // Directory cited from AGENT_SHIM_TARGETS.copilot (agent-harness-targets.ts)
+    // as independent evidence of Copilot's own agents-dir convention.
+    // Filename pattern is this map's own naming, not copied from that table.
+    dir: join(homedir(), '.copilot', 'agents'),
+    fileMode: 'flat',
+    filenamePattern: '{name}-specialist.md',
+  },
+  windsurf: {
+    // No AGENT_SHIM_TARGETS entry exists for windsurf (not a HarnessId
+    // member) — defaults to today's actual behavior.
+    dir: join(homedir(), '.claude', 'agents'),
+    fileMode: 'flat',
+    filenamePattern: '{name}-specialist.md',
+  },
+  agents: {
+    // No AGENT_SHIM_TARGETS entry exists for `agents` (not a HarnessId
+    // member) — defaults to today's actual behavior.
+    dir: join(homedir(), '.claude', 'agents'),
+    fileMode: 'flat',
+    filenamePattern: '{name}-specialist.md',
+  },
+  opencode: {
+    // Directory cited from AGENT_SHIM_TARGETS.opencode (agent-harness-targets.ts)
+    // as independent evidence of OpenCode's own agents-dir convention.
+    // Filename pattern is this map's own naming, not copied from that table.
+    dir: join(homedir(), '.config', 'opencode', 'agents'),
+    fileMode: 'flat',
+    filenamePattern: '{name}-specialist.md',
+  },
+  hermes: {
+    // No AGENT_SHIM_TARGETS entry exists for hermes (not a HarnessId
+    // member) — defaults to today's actual behavior.
+    dir: join(homedir(), '.claude', 'agents'),
+    fileMode: 'flat',
+    filenamePattern: '{name}-specialist.md',
+  },
+  grok: {
+    // No AGENT_SHIM_TARGETS entry exists for grok (not a HarnessId member)
+    // — defaults to today's actual behavior.
+    dir: join(homedir(), '.claude', 'agents'),
+    fileMode: 'flat',
+    filenamePattern: '{name}-specialist.md',
+  },
+}
+
+/** Resolve the companion-agent target descriptor for `client` (default: canonical). */
+export function getCompanionAgentTarget(client: ClientId = CANONICAL_CLIENT): CompanionAgentTarget {
+  return COMPANION_AGENT_TARGETS[client]
+}
+
+/** Resolve just the companion-agent output directory for `client` (default: canonical). */
+export function resolveCompanionAgentDir(client: ClientId = CANONICAL_CLIENT): string {
+  return getCompanionAgentTarget(client).dir
+}
+
+/**
+ * Resolve the full on-disk companion-subagent file path for `client` +
+ * `skillName` (default client: canonical / `claude-code`).
+ */
+export function resolveCompanionAgentPath(
+  skillName: string,
+  client: ClientId = CANONICAL_CLIENT
+): string {
+  const target = getCompanionAgentTarget(client)
+  const filename = target.filenamePattern.replace('{name}', skillName)
+  return join(target.dir, filename)
+}

--- a/packages/core/src/services/skill-installation.content.ts
+++ b/packages/core/src/services/skill-installation.content.ts
@@ -346,7 +346,8 @@ export async function installFromContent(params: InstallFromContentParams): Prom
       skillName,
       finalSkillContent,
       [...generatedNoCollision, ...teamAuthoredSubFiles],
-      subagentContent
+      subagentContent,
+      client
     )
     if (writeResult.subagentPath) {
       optimizationInfo.subagentPath = writeResult.subagentPath

--- a/packages/core/src/services/skill-installation.io.ts
+++ b/packages/core/src/services/skill-installation.io.ts
@@ -6,10 +6,10 @@
 
 import * as fs from 'fs/promises'
 import * as path from 'path'
-import * as os from 'os'
 import { safeWriteFile } from '../utils/safe-fs.js'
 import { SecurityScanner } from '../security/index.js'
 import type { ScannerOptions, ScanReport } from '../security/index.js'
+import { CANONICAL_CLIENT, resolveCompanionAgentPath, type ClientId } from '../install/paths.js'
 import { validateOptionalConfig } from './skill-installation.validate.js'
 import {
   BUNDLED_SCAN_FILES,
@@ -187,7 +187,16 @@ export async function writeInstallFiles(
   skillName: string,
   finalSkillContent: string,
   subSkillFiles: Array<{ filename: string; content: string }>,
-  subagentContent: string | undefined
+  subagentContent: string | undefined,
+  /**
+   * SMI-5980 (Wave 3): the client this companion subagent (if any) is
+   * generated for — resolves its output path via
+   * `resolveCompanionAgentPath()` (install/paths.ts) instead of a hardcoded
+   * `~/.claude/agents/` literal. Optional, defaulting to `CANONICAL_CLIENT`
+   * (`claude-code`) so pre-existing callers/tests that never pass it keep
+   * today's exact behavior unchanged.
+   */
+  client: ClientId = CANONICAL_CLIENT
 ): Promise<WriteInstallResult> {
   const writtenFiles: string[] = []
   let subagentPath: string | undefined
@@ -244,15 +253,16 @@ export async function writeInstallFiles(
     }
     // Write companion subagent if generated
     if (subagentContent) {
-      const agentsDir = path.join(os.homedir(), '.claude', 'agents')
+      subagentPath = resolveCompanionAgentPath(skillName, client)
+      const agentsDir = path.dirname(subagentPath)
       await fs.mkdir(agentsDir, { recursive: true })
-      subagentPath = path.join(agentsDir, skillName + '-specialist.md')
       await safeWriteFile(subagentPath, subagentContent)
       writtenFiles.push(subagentPath)
     }
   } catch (writeError) {
     // Rollback on failure. Unlink tracked files first (subagentPath lives OUTSIDE
-    // installPath, under ~/.claude/agents).
+    // installPath, under the client's companion-agent dir — see
+    // resolveCompanionAgentPath()/COMPANION_AGENT_TARGETS, install/paths.ts).
     for (const filePath of writtenFiles) {
       await fs.unlink(filePath).catch(() => {})
     }

--- a/packages/core/src/services/skill-installation.service.ts
+++ b/packages/core/src/services/skill-installation.service.ts
@@ -361,7 +361,8 @@ export class SkillInstallationService {
         skillName,
         finalSkillContent,
         [...subSkillsNoCollision, ...optionalFiles.filesToWrite],
-        subagentContent
+        subagentContent,
+        this.client
       )
       if (writeResult.subagentPath) {
         optimizationInfo.subagentPath = writeResult.subagentPath

--- a/packages/core/tests/unit/services/skill-installation.io.client-agent-path.test.ts
+++ b/packages/core/tests/unit/services/skill-installation.io.client-agent-path.test.ts
@@ -1,0 +1,189 @@
+/**
+ * SMI-5980 (Wave 3): writeInstallFiles must route the companion-subagent
+ * write through COMPANION_AGENT_TARGETS (install/paths.ts) for the caller's
+ * `client`, not a hardcoded `path.join(os.homedir(), '.claude', 'agents')`
+ * literal.
+ *
+ * `homedir()` is mocked to a controlled tmp directory BEFORE `paths.ts` is
+ * first imported — COMPANION_AGENT_TARGETS is a module-level constant
+ * computed once at import time from `homedir()`, so every assertion below
+ * compares against that SAME already-resolved map rather than a second,
+ * independently-hardcoded expectation. This also keeps the test from ever
+ * writing to a real developer/CI machine's actual home directory.
+ *
+ * Split out of skill-installation.io.test.ts to stay under the 500-line
+ * CI gate (same rationale as skill-installation.io.symlink.test.ts).
+ */
+
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'fs/promises'
+import * as path from 'path'
+
+const { TEST_HOME, homedirMock } = vi.hoisted(() => {
+  const home = '/tmp/skillsmith-wif-client-agent-path-test-' + process.pid
+  return { TEST_HOME: home, homedirMock: vi.fn(() => home) }
+})
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, homedir: homedirMock }
+})
+
+import { writeInstallFiles } from '../../../src/services/skill-installation.io.js'
+import { CLIENT_IDS, COMPANION_AGENT_TARGETS, type ClientId } from '../../../src/install/paths.js'
+
+afterAll(async () => {
+  await fs.rm(TEST_HOME, { recursive: true, force: true }).catch(() => {})
+})
+
+/**
+ * Fresh skillsDir/installPath per test so parallel `it.each` iterations
+ * (all sharing TEST_HOME) never collide with each other.
+ */
+async function freshInstallPath(
+  label: string
+): Promise<{ skillsDir: string; installPath: string }> {
+  const skillsDir = path.join(TEST_HOME, 'src', label, 'skills')
+  await fs.mkdir(skillsDir, { recursive: true })
+  return { skillsDir, installPath: path.join(skillsDir, 'my-skill') }
+}
+
+describe('writeInstallFiles companion-subagent path per client (SMI-5980 regression)', () => {
+  beforeEach(() => {
+    homedirMock.mockReturnValue(TEST_HOME)
+  })
+
+  it.each<ClientId>([...CLIENT_IDS])(
+    'writes the companion subagent for client=%s at exactly COMPANION_AGENT_TARGETS[client]',
+    async (client) => {
+      const { skillsDir, installPath } = await freshInstallPath(client)
+
+      const result = await writeInstallFiles(
+        installPath,
+        skillsDir,
+        'my-skill',
+        '# hello',
+        [],
+        '---\nname: my-skill-specialist\n---\nbody',
+        client
+      )
+
+      const expectedPath = path.join(COMPANION_AGENT_TARGETS[client].dir, 'my-skill-specialist.md')
+      expect(result.subagentPath).toBe(expectedPath)
+      expect(await fs.readFile(expectedPath, 'utf8')).toBe(
+        '---\nname: my-skill-specialist\n---\nbody'
+      )
+    }
+  )
+
+  it('defaults to the canonical (claude-code) target when client is omitted (regression: unchanged)', async () => {
+    const { skillsDir, installPath } = await freshInstallPath('default-client')
+
+    const result = await writeInstallFiles(
+      installPath,
+      skillsDir,
+      'my-skill',
+      '# hello',
+      [],
+      'subagent body'
+      // client omitted — must resolve exactly like the old hardcoded default.
+    )
+
+    const expectedPath = path.join(
+      COMPANION_AGENT_TARGETS['claude-code'].dir,
+      'my-skill-specialist.md'
+    )
+    expect(result.subagentPath).toBe(expectedPath)
+    expect(await fs.readFile(expectedPath, 'utf8')).toBe('subagent body')
+  })
+
+  it('claude-code and cursor land in the SAME directory (both default, no independent evidence for cursor)', async () => {
+    const claudeCode = await freshInstallPath('cc-vs-cursor-claude')
+    const cursor = await freshInstallPath('cc-vs-cursor-cursor')
+
+    const claudeResult = await writeInstallFiles(
+      claudeCode.installPath,
+      claudeCode.skillsDir,
+      'my-skill',
+      '# hello',
+      [],
+      'body',
+      'claude-code'
+    )
+    const cursorResult = await writeInstallFiles(
+      cursor.installPath,
+      cursor.skillsDir,
+      'my-skill',
+      '# hello',
+      [],
+      'body',
+      'cursor'
+    )
+
+    expect(path.dirname(cursorResult.subagentPath ?? '')).toBe(
+      path.dirname(claudeResult.subagentPath ?? '')
+    )
+  })
+
+  it('copilot and opencode land at their own real, literal directories (code-review finding: not just "different from claude-code")', async () => {
+    const copilot = await freshInstallPath('copilot-diff')
+    const opencode = await freshInstallPath('opencode-diff')
+
+    const copilotResult = await writeInstallFiles(
+      copilot.installPath,
+      copilot.skillsDir,
+      'my-skill',
+      '# hello',
+      [],
+      'body',
+      'copilot'
+    )
+    const opencodeResult = await writeInstallFiles(
+      opencode.installPath,
+      opencode.skillsDir,
+      'my-skill',
+      '# hello',
+      [],
+      'body',
+      'opencode'
+    )
+
+    // Independently-constructed literal expected paths (via the SAME mocked
+    // TEST_HOME this file's own homedir() mock uses, but NOT derived from
+    // COMPANION_AGENT_TARGETS itself) — a code-review pass on an earlier
+    // version of this test caught that comparing only against
+    // COMPANION_AGENT_TARGETS['claude-code'].dir proves "different from
+    // claude-code," not "equals the actual intended copilot/opencode value";
+    // a typo in the map (e.g. singular '.copilot/agent') would have still
+    // passed the old assertion.
+    expect(path.dirname(copilotResult.subagentPath ?? '')).toBe(
+      path.join(TEST_HOME, '.copilot', 'agents')
+    )
+    expect(path.dirname(opencodeResult.subagentPath ?? '')).toBe(
+      path.join(TEST_HOME, '.config', 'opencode', 'agents')
+    )
+    // Belt-and-suspenders: still confirm both differ from claude-code's dir.
+    expect(path.dirname(copilotResult.subagentPath ?? '')).not.toBe(
+      COMPANION_AGENT_TARGETS['claude-code'].dir
+    )
+    expect(path.dirname(opencodeResult.subagentPath ?? '')).not.toBe(
+      COMPANION_AGENT_TARGETS['claude-code'].dir
+    )
+  })
+
+  it('does not write any companion-subagent file when subagentContent is undefined, regardless of client', async () => {
+    const { skillsDir, installPath } = await freshInstallPath('no-subagent')
+
+    const result = await writeInstallFiles(
+      installPath,
+      skillsDir,
+      'my-skill',
+      '# hello',
+      [],
+      undefined,
+      'copilot'
+    )
+
+    expect(result.subagentPath).toBeUndefined()
+  })
+})

--- a/packages/core/tests/unit/services/skill-installation.io.client-agent-path.test.ts
+++ b/packages/core/tests/unit/services/skill-installation.io.client-agent-path.test.ts
@@ -68,7 +68,15 @@ describe('writeInstallFiles companion-subagent path per client (SMI-5980 regress
         client
       )
 
-      const expectedPath = path.join(COMPANION_AGENT_TARGETS[client].dir, 'my-skill-specialist.md')
+      // PR-review finding fallout (SMI-5980): copilot's filenamePattern is
+      // now '{name}.agent.md', not the shared '-specialist.md' suffix every
+      // other client uses — derive the expected filename from the actual
+      // per-client pattern instead of a universal hardcoded literal.
+      const expectedFilename = COMPANION_AGENT_TARGETS[client].filenamePattern.replace(
+        '{name}',
+        'my-skill'
+      )
+      const expectedPath = path.join(COMPANION_AGENT_TARGETS[client].dir, expectedFilename)
       expect(result.subagentPath).toBe(expectedPath)
       expect(await fs.readFile(expectedPath, 'utf8')).toBe(
         '---\nname: my-skill-specialist\n---\nbody'

--- a/scripts/check-file-length.ignore
+++ b/scripts/check-file-length.ignore
@@ -68,3 +68,8 @@ scripts/tests/create-worktree-hooks.test.sh
 # lines before this PR touched it to add the SMI-5866 skip-gate change; not
 # new debt introduced by this PR)
 scripts/indexer/indexer-runners.ts
+
+# SMI-5998 split follow-up (genuinely pre-existing: baseline was already 829
+# lines before this PR touched it to update two assertions for dynamic
+# companion-agent-path resolution; not new debt introduced by this PR)
+packages/cli/tests/author.test.ts


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a bug where "companion subagent" files (extra agent files installed alongside certain skills) always went to one hardcoded folder, regardless of which AI tool the user was actually installing for — found and fixed in three separate places in the codebase, one of which wasn't in the original plan. For most supported tools this changes nothing (they already got that folder). For two tools (GitHub Copilot, OpenCode), their companion files now correctly go to those tools' own folders instead of a folder those tools never actually read — a real, if minor, fix for those two tools' users, not just a cleanup.

**Quality bar:** Independently code-reviewed by GPT-5.6-Sol (a second AI model) before merge. That review caught that an earlier version of this PR's own description overstated "nothing changes for any existing client" — imprecise, since the Copilot/OpenCode fix is a genuine behavior change for those two — and that the test proving that change was correct wasn't strict enough to catch a typo in the new configuration. Both fixed.

**Found along the way:** One pre-existing test file, already over this repo's 500-line limit before this PR touched two lines in it, is grandfathered into the standard exception list rather than split in this PR (which is about path resolution, not test reorganization) — SMI-5998 tracks the actual split.

**Net result:** Fully shipped. No follow-up blocking; SMI-5998 (test-file split) and the Antigravity wave (SMI-5982, builds on the map this PR introduces) are separately tracked.

---

## Technical detail

New `COMPANION_AGENT_TARGETS` map in `packages/core/src/install/paths.ts`, purpose-built rather than derived from the differently-shaped `AGENT_SHIM_TARGETS` table (a design decision from the plan's own review). Threaded through `skill-installation.io.ts`, `author/utils.ts`, and a third call site in `author/transform.ts` the plan didn't originally name.

Part of `docs/internal/implementation/smi-5930-wave2-and-adjacent-fixes.md` — ships as its own PR per that plan's review recommendation.