### PR TITLE
fix: SMI-5981 MCP stderr path + SMI-5992 file-length gate exemption

### DIFF
--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: the startup stderr log printed either an unexpanded `~/.skillsmith/skills.db` literal
+  or the raw, unvalidated `SKILLSMITH_DB_PATH` env value — neither reflected the actual path
+  `getToolContextAsync()` resolved and validated. Now logs the new
+  `buildDbInitializedLogMessage()` (`context.helpers.ts`), which calls `getDefaultDbPath()`
+  internally, so the logged path and the real DB path can never disagree (SMI-5981)
 - **Feature**: `private_registry_publish` now requires a genuine two-party review before a version
   becomes installable — a submission lands `pending` and is invisible on every read surface
   (`list`/`get`/`install`) until a different team admin/owner approves it via three new

--- a/packages/mcp-server/src/context.helpers.ts
+++ b/packages/mcp-server/src/context.helpers.ts
@@ -47,6 +47,20 @@ export function getDefaultDbPath(): string {
 }
 
 /**
+ * Build the exact startup stderr message `index.ts` logs once the tool
+ * context is ready (SMI-5981). Extracted so it can be unit-tested directly —
+ * `index.ts` itself can't be imported in tests (it calls `main()` at module
+ * scope), so without this extraction a test can only assert on
+ * {@link getDefaultDbPath} in isolation, which stays green even if the log
+ * line in `index.ts` is reverted to interpolating the raw, unvalidated
+ * `SKILLSMITH_DB_PATH` env value again (code-review finding — the earlier
+ * test suite didn't actually cover the regression it was named for).
+ */
+export function buildDbInitializedLogMessage(): string {
+  return `Database initialized at: ${getDefaultDbPath()}`
+}
+
+/**
  * Ensure the database directory exists
  */
 export function ensureDbDirectory(dbPath: string): void {

--- a/packages/mcp-server/src/context.ts
+++ b/packages/mcp-server/src/context.ts
@@ -51,7 +51,11 @@ export type {
   BackgroundSyncConfig,
   ToolContextOptions,
 } from './context.types.js'
-export { getDefaultDbPath, ensureDbDirectory } from './context.helpers.js'
+export {
+  getDefaultDbPath,
+  ensureDbDirectory,
+  buildDbInitializedLogMessage,
+} from './context.helpers.js'
 export {
   createToolContextAsync,
   getToolContextAsync,

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -1,4 +1,17 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
+import { homedir } from 'os'
+import { join } from 'path'
+// SMI-5981: safe to import — context.js has no top-level side effects, unlike
+// index.ts itself (which runs main() at module scope on import, see
+// index.ts's own SMI-5615 comment). buildDbInitializedLogMessage() is the
+// EXACT function index.ts's startup stderr log line now calls (`console.error
+// (buildDbInitializedLogMessage())`) — asserting on its output, not just the
+// underlying getDefaultDbPath() helper, is what lets these tests actually
+// catch a regression of the log line itself (code-review finding: the
+// earlier version of this test suite only exercised getDefaultDbPath() in
+// isolation, which stayed green even under a hypothetical revert of index.ts
+// back to inlining the raw env interpolation).
+import { getDefaultDbPath, buildDbInitializedLogMessage } from './context.js'
 
 // Basic tests - full MCP server testing requires more complex setup
 describe('MCP Server Module', () => {
@@ -45,5 +58,53 @@ describe('Tool Definitions', () => {
     }
 
     expect(serverInfoSchema.type).toBe('object')
+  })
+})
+
+// SMI-5981: the startup stderr line in index.ts ("Database initialized at:
+// ...") previously interpolated `process.env.SKILLSMITH_DB_PATH` directly
+// (raw, unvalidated) or an unexpanded `'~/.skillsmith/skills.db'` literal for
+// the fallback case. Both were wrong. The fix now calls
+// `buildDbInitializedLogMessage()` — the exact function index.ts's log line
+// delegates to (context.helpers.ts). index.ts itself can't be imported
+// directly in tests (it calls main() at module scope), so these tests assert
+// on that function's actual returned MESSAGE STRING, not just the underlying
+// getDefaultDbPath() path helper — this is what makes the tests fail if the
+// log line is ever reverted back to inlining the raw interpolation, since a
+// reverted index.ts would no longer produce this exact message shape even
+// though getDefaultDbPath() itself would be untouched.
+describe('Database Path Logging (SMI-5981)', () => {
+  // Explicit reset between test cases (not just relying on describe-block
+  // scoping) — an earlier draft of this test relied on shared beforeEach/
+  // afterEach hooks at an outer scope only, which the plan review flagged as
+  // a leak risk between the default-path and custom-path cases below.
+  afterEach(() => {
+    delete process.env.SKILLSMITH_DB_PATH
+  })
+
+  it('logs the real expanded home path, not an unexpanded "~" literal, when SKILLSMITH_DB_PATH is unset', () => {
+    delete process.env.SKILLSMITH_DB_PATH
+    const message = buildDbInitializedLogMessage()
+    const expectedPath = join(homedir(), '.skillsmith', 'skills.db')
+
+    expect(message).toBe(`Database initialized at: ${expectedPath}`)
+    expect(message).not.toContain('~')
+    // Also confirm it's not silently drifted from the underlying resolver.
+    expect(message).toContain(getDefaultDbPath())
+  })
+
+  it('logs the resolved path, not the raw env value, when SKILLSMITH_DB_PATH normalizes differently than its literal input', () => {
+    // Double slash: a valid path (stays under the allowed ~/.skillsmith
+    // directory, no ".." traversal) that validateDbPath's normalize()/
+    // resolve() collapses to a different string than the literal input.
+    const rawInput = `${join(homedir(), '.skillsmith')}//custom.db`
+    process.env.SKILLSMITH_DB_PATH = rawInput
+    const message = buildDbInitializedLogMessage()
+
+    const expectedResolvedPath = join(homedir(), '.skillsmith', 'custom.db')
+    expect(message).toBe(`Database initialized at: ${expectedResolvedPath}`)
+    // Prove this is actually a normalization-difference case, not a no-op,
+    // and that the raw env value never leaks into the logged message.
+    expect(message).not.toContain(rawInput)
   })
 })

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, beforeAll } from 'vitest'
 import { homedir } from 'os'
 import { join } from 'path'
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
 // SMI-5981: safe to import — context.js has no top-level side effects, unlike
 // index.ts itself (which runs main() at module scope on import, see
 // index.ts's own SMI-5615 comment). buildDbInitializedLogMessage() is the
@@ -107,4 +111,83 @@ describe('Database Path Logging (SMI-5981)', () => {
     // and that the raw env value never leaks into the logged message.
     expect(message).not.toContain(rawInput)
   })
+})
+
+// PR-review finding (BLOCKING): the two tests above only assert on
+// buildDbInitializedLogMessage()'s OWN return value in isolation -- they'd
+// stay green even if index.ts's real startup line reverted to inlining the
+// raw env interpolation, since nothing here exercises the actual call site.
+// index.ts can't be imported directly (runs main() at module scope), so this
+// mirrors tests/startup-probe.test.ts's own spawn-the-real-binary pattern:
+// start the built dist/src/index.js, capture stderr, and assert it contains
+// the EXACT line buildDbInitializedLogMessage() itself produces. This fails
+// if the call site is ever reverted, because a raw-interpolation stderr line
+// would not match this string.
+describe('Database Path Logging (SMI-5981) — integration (spawn)', () => {
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = path.dirname(__filename)
+  const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+  const DIST_ENTRY = path.join(REPO_ROOT, 'packages', 'mcp-server', 'dist', 'src', 'index.js')
+  const skipInPrePush = process.env['SKILLSMITH_PREPUSH'] === '1' && !existsSync(DIST_ENTRY)
+
+  beforeAll(() => {
+    if (skipInPrePush) return
+    if (!existsSync(DIST_ENTRY)) {
+      const build = spawnSync('npm', ['run', 'build', '--workspace=@skillsmith/mcp-server'], {
+        stdio: 'inherit',
+        cwd: REPO_ROOT,
+      })
+      if (build.status !== 0) throw new Error('mcp-server build failed in beforeAll')
+    }
+    if (!existsSync(DIST_ENTRY)) throw new Error(`Expected ${DIST_ENTRY} to exist after build`)
+  }, 120_000)
+
+  it.skipIf(skipInPrePush)(
+    "the real startup stderr line matches buildDbInitializedLogMessage()'s exact output",
+    async () => {
+      delete process.env.SKILLSMITH_DB_PATH
+      const expectedLine = buildDbInitializedLogMessage()
+
+      const proc = spawn('node', [DIST_ENTRY], {
+        env: {
+          ...process.env,
+          SKILLSMITH_SKIP_SKILL_INSTALL: '1',
+          SKILLSMITH_AUTO_UPDATE_CHECK: 'false',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+
+      const stderrChunks: string[] = []
+      proc.stderr.on('data', (d: Buffer) => stderrChunks.push(d.toString()))
+
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            reject(new Error(`server boot timeout — stderr so far:\n${stderrChunks.join('')}`))
+          }, 60_000)
+          proc.stderr.on('data', (d: Buffer) => {
+            if (d.toString().includes('Skillsmith MCP server running')) {
+              clearTimeout(timeout)
+              resolve()
+            }
+          })
+          proc.on('error', (err) => {
+            clearTimeout(timeout)
+            reject(err)
+          })
+          proc.on('exit', (code) => {
+            if (code !== null && code !== 0) {
+              clearTimeout(timeout)
+              reject(new Error(`mcp-server exited ${code}; stderr:\n${stderrChunks.join('')}`))
+            }
+          })
+        })
+      } finally {
+        proc.kill('SIGTERM')
+      }
+
+      expect(stderrChunks.join('')).toContain(expectedLine)
+    },
+    75_000
+  )
 })

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -16,7 +16,8 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 
 // SMI-2208: Use async context for WASM fallback support
-import { getToolContextAsync, type ToolContext } from './context.js'
+// SMI-5981: buildDbInitializedLogMessage prints the actually-resolved DB path.
+import { getToolContextAsync, buildDbInitializedLogMessage, type ToolContext } from './context.js'
 import { searchToolSchema } from './tools/search.js'
 import { getSkillToolSchema } from './tools/get-skill.js'
 import { installTool } from './tools/install.js'
@@ -380,10 +381,8 @@ async function main() {
   // CRITICAL: Must complete before any tool handlers access toolContext
   try {
     toolContext = await getToolContextAsync()
-    // SMI-5615: plain console.error — same rationale as runFirstTimeSetup above.
-    console.error(
-      `Database initialized at: ${process.env.SKILLSMITH_DB_PATH || '~/.skillsmith/skills.db'}`
-    )
+    // SMI-5615/SMI-5981: plain console.error of the resolved path (not raw env).
+    console.error(buildDbInitializedLogMessage())
     // SMI-5640: arm the periodic autosave timer now that toolContext exists.
     // No-op unless the db is WASM + file-backed (see shutdown.ts).
     startPeriodicFlush(() => toolContext?.db)

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -61,6 +61,17 @@ import {
 } from './audit-cli-pin-drift-helpers.mjs'
 import { TEST_PATTERNS } from './ci/source-patterns.mjs'
 import { PACKAGE_SPECS } from './lib/version-utils.ts'
+// SMI-5992: MAX_LINES + isExemptFromLengthCheck are shared with pre-commit's
+// scripts/check-file-length.mjs via scripts/file-length-policy.mjs. Only the
+// threshold + test-file exemption predicate are shared — Check 3's own
+// directory scope (packages/+apps/ only), extensions (.ts+.tsx), and
+// severity (warn()-only, never fails the run) remain intentionally
+// different from the pre-commit check. See SMI-5994 for the still-tracked
+// scope/severity divergence.
+import {
+  MAX_LINES as FILE_LENGTH_MAX_LINES,
+  isExemptFromLengthCheck,
+} from './file-length-policy.mjs'
 
 const RED = '\x1b[31m'
 const GREEN = '\x1b[32m'
@@ -227,25 +238,33 @@ try {
 }
 
 // 3. File Length
-console.log(`\n${BOLD}3. File Length (max 500 lines)${RESET}`)
+// SMI-5992: the exemption predicate (isExemptFromLengthCheck — matches both
+// .test. and .spec.) is shared with pre-commit's scripts/check-file-length.mjs
+// via scripts/file-length-policy.mjs. Scope (packages/+apps/ only) and
+// severity (warn(), never fails the run) are intentionally NOT shared — see
+// the import comment above and SMI-5994.
+console.log(`\n${BOLD}3. File Length (max ${FILE_LENGTH_MAX_LINES} lines)${RESET}`)
 try {
   const sourceFiles = TYPE_SAFETY_AND_LENGTH_ROOTS.flatMap((root) =>
     getFilesRecursive(root, ['.ts', '.tsx'])
-  ).filter((f) => !f.includes('.test.'))
+  ).filter((f) => !isExemptFromLengthCheck(f))
 
   const longFiles = []
   for (const file of sourceFiles) {
     const content = readFileSync(file, 'utf8')
     const lineCount = content.split('\n').length
-    if (lineCount > 500) {
+    if (lineCount > FILE_LENGTH_MAX_LINES) {
       longFiles.push({ file: relative(process.cwd(), file), lines: lineCount })
     }
   }
 
   if (longFiles.length === 0) {
-    pass('All source files under 500 lines')
+    pass(`All source files under ${FILE_LENGTH_MAX_LINES} lines`)
   } else {
-    warn(`${longFiles.length} files exceed 500 lines`, 'Split into smaller modules')
+    warn(
+      `${longFiles.length} files exceed ${FILE_LENGTH_MAX_LINES} lines`,
+      'Split into smaller modules'
+    )
     longFiles.forEach(({ file, lines }) => {
       console.log(`    ${file}: ${lines} lines`)
     })

--- a/scripts/check-file-length.mjs
+++ b/scripts/check-file-length.mjs
@@ -17,13 +17,21 @@
  * passes absolute paths, so both sides are normalized to repo-relative
  * before matching. A grandfathered file split below the limit re-enters
  * enforcement and prints an "eligible to de-list" notice.
+ *
+ * SMI-5992: MAX_LINES and the test-file exemption predicate
+ * (isExemptFromLengthCheck) are shared with CI's Check 3 in
+ * scripts/audit-standards.mjs via scripts/file-length-policy.mjs. Only
+ * the threshold + exemption predicate are shared — this script's own
+ * directory scope (whatever's staged, not just packages/+apps/), its
+ * extensions (.ts + .sh), and its severity (hard-fail, vs. Check 3's
+ * warn-only) remain intentionally different. See SMI-5994 for the
+ * still-tracked scope/severity divergence.
  */
 
 import { readFileSync, realpathSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-
-const MAX_LINES = 500
+import { MAX_LINES, isExemptFromLengthCheck } from './file-length-policy.mjs'
 
 /**
  * Resolve a path to its canonical, symlink-free absolute form.
@@ -110,11 +118,15 @@ export function loadIgnoreList(ignorePath) {
  * an exact comparison (SMI-4397 C1). A grandfathered path is only
  * exempt WHILE still over-limit (SMI-4397 H1).
  *
+ * SMI-5992: a `.test.`/`.spec.` file over the limit is also reported via
+ * `skipped` (shared `isExemptFromLengthCheck` predicate, same as CI's
+ * Check 3) rather than silently passing with no output.
+ *
  * @param {string[]} files - staged file paths (absolute or relative)
  * @param {Map<string, string|null>} ignoreList - grandfathered repo-relative paths -> SMI reference
  * @param {string} repoRoot - absolute repo root
  * @returns {{violations: {relPath: string, lineCount: number}[],
- *            skipped: {relPath: string, lineCount: number, smiRef: string|null}[],
+ *            skipped: {relPath: string, lineCount: number, smiRef: string|null, reason: string}[],
  *            delistable: {relPath: string, lineCount: number}[]}}
  */
 export function checkFiles(files, ignoreList, repoRoot) {
@@ -133,10 +145,30 @@ export function checkFiles(files, ignoreList, repoRoot) {
     const content = readFileSync(filePath, 'utf8')
     const lineCount = content.split('\n').length
     const grandfathered = ignoreList.has(relPath)
+    // SMI-5992: shared with CI's Check 3 — see scripts/file-length-policy.mjs.
+    const testExempt = isExemptFromLengthCheck(relPath)
 
     if (lineCount > MAX_LINES) {
-      if (grandfathered) {
-        skipped.push({ relPath, lineCount, smiRef: ignoreList.get(relPath) ?? null })
+      if (testExempt) {
+        // Test-file exemption takes precedence over (and makes redundant
+        // any pre-existing) grandfather-list entry for the same path.
+        skipped.push({
+          relPath,
+          lineCount,
+          smiRef: null,
+          reason:
+            'test file (.test./.spec.) — exempt per scripts/file-length-policy.mjs (SMI-5992)',
+        })
+      } else if (grandfathered) {
+        const smiRef = ignoreList.get(relPath) ?? null
+        skipped.push({
+          relPath,
+          lineCount,
+          smiRef,
+          reason: smiRef
+            ? `grandfathered — ${smiRef} split pending`
+            : 'grandfathered — see scripts/check-file-length.ignore for the tracking issue',
+        })
       } else {
         violations.push({ relPath, lineCount })
       }
@@ -160,10 +192,10 @@ function main() {
   const ignoreList = loadIgnoreList(join(repoRoot, 'scripts', 'check-file-length.ignore'))
   const { violations, skipped, delistable } = checkFiles(files, ignoreList, repoRoot)
 
-  for (const { relPath, smiRef } of skipped) {
-    const reason = smiRef
-      ? `grandfathered — ${smiRef} split pending`
-      : 'grandfathered — see scripts/check-file-length.ignore for the tracking issue'
+  // SMI-5992: `reason` is computed in checkFiles() itself (test-file
+  // exemption or grandfather-list, each with its own message) — main()
+  // just prints it, so the two skip reasons stay in one place.
+  for (const { relPath, reason } of skipped) {
     console.log(`  ${relPath}: skipped (${reason})`)
   }
 

--- a/scripts/file-length-policy.mjs
+++ b/scripts/file-length-policy.mjs
@@ -1,0 +1,53 @@
+/**
+ * Shared file-length policy (SMI-5992)
+ *
+ * Exports the 500-line threshold and the test-file exemption predicate
+ * shared between two otherwise-independent file-length checks:
+ *   - scripts/check-file-length.mjs — pre-commit, hard-fails, checks
+ *     whatever lint-staged passes it (any staged directory).
+ *   - scripts/audit-standards.mjs Check 3 — CI, warn()-only (never fails
+ *     the run), scans only packages/ + apps/.
+ *
+ * SCOPE NOTE — this module intentionally shares ONLY the threshold
+ * (MAX_LINES) and the test-file exemption predicate
+ * (isExemptFromLengthCheck). The two checks still deliberately differ in
+ * everything else: directory scope, file extensions scanned (.ts + .sh
+ * for pre-commit vs. .ts + .tsx for CI), and severity (hard-fail vs.
+ * warn-only). This is NOT a full reconciliation of the two checks — see
+ * the cross-referencing comments in scripts/check-file-length.mjs and
+ * scripts/audit-standards.mjs Check 3, and SMI-5994, which tracks the
+ * still-open scope/severity divergence separately.
+ */
+
+import { basename } from 'node:path'
+
+/** The shared 500-line threshold both checks enforce (or warn on). */
+export const MAX_LINES = 500
+
+/**
+ * True when `path` is a test file exempt from the length check.
+ *
+ * Matches both `.test.` and `.spec.` substrings — a deliberate decision,
+ * not an oversight (SMI-5992): this repo's own test-file recognition
+ * elsewhere already treats `.spec.` files as the same category as
+ * `.test.` files — see scripts/audit-standards.mjs's own Check 4
+ * (`getFilesRecursive('packages', ['.test.ts', '.test.tsx', '.spec.ts'])`)
+ * and CLAUDE.md's "Test File Locations" table, which lists `*.spec.ts`
+ * as an equally valid pattern alongside `*.test.ts`. Exempting one
+ * pattern but not the other from this specific check was an unjustified
+ * inconsistency, not a considered choice.
+ *
+ * Matches against the BASENAME only, not the full path (code-review
+ * finding, SMI-5992) — matching the full path would wrongly exempt a
+ * genuinely non-test file sitting under a directory whose name happens to
+ * contain `.test.` or `.spec.` (e.g. `packages/foo.test.fixtures/src/
+ * runtime.ts`), silently weakening both gates for a file that was never a
+ * test file at all.
+ *
+ * @param {string} path - a file path (absolute or relative; any separator)
+ * @returns {boolean} true if the file is exempt from the length check
+ */
+export function isExemptFromLengthCheck(path) {
+  const base = basename(path)
+  return base.includes('.test.') || base.includes('.spec.')
+}

--- a/scripts/tests/audit-standards-apps-root.test.ts
+++ b/scripts/tests/audit-standards-apps-root.test.ts
@@ -18,6 +18,12 @@
  * `makeFixtureTempDir`. Keep the re-implementation in sync with
  * scripts/audit-standards.mjs (`getFilesRecursive`, `TYPE_SAFETY_AND_LENGTH_ROOTS`,
  * and the Check 2 / Check 3 bodies).
+ *
+ * SMI-5992: Check 3's exemption predicate is now the real, imported
+ * `isExemptFromLengthCheck` from scripts/file-length-policy.mjs (not a
+ * re-implemented `.filter((f) => !f.includes('.test.'))`) — that module has
+ * no top-level side effects, so it's safe to import directly here, unlike
+ * audit-standards.mjs itself.
  */
 import { afterEach, describe, expect, it } from 'vitest'
 import {
@@ -32,6 +38,7 @@ import {
 import { join } from 'node:path'
 
 import { makeFixtureTempDir } from './_lib/git-fixture-env.js'
+import { isExemptFromLengthCheck } from '../file-length-policy.mjs'
 
 // Verbatim mirror of getFilesRecursive() in scripts/audit-standards.mjs.
 function getFilesRecursive(dir: string, extensions: string[]): string[] {
@@ -76,11 +83,13 @@ function findAnyTypedFiles(repoRoot: string): string[] {
   return [...filesWithAny]
 }
 
-// Mirror of the Check 3 body (the file-length detector).
+// Mirror of the Check 3 body (the file-length detector). SMI-5992: uses the
+// real shared isExemptFromLengthCheck predicate (matches .test. and .spec.),
+// not a re-implemented .test.-only filter.
 function findLongFiles(repoRoot: string): string[] {
   const sourceFiles = TYPE_SAFETY_AND_LENGTH_ROOTS.flatMap((root) =>
     getFilesRecursive(join(repoRoot, root), ['.ts', '.tsx'])
-  ).filter((f) => !f.includes('.test.'))
+  ).filter((f) => !isExemptFromLengthCheck(f))
 
   const longFiles: string[] = []
   for (const file of sourceFiles) {
@@ -165,6 +174,21 @@ describe('audit-standards Check 2/3: apps/ root coverage (SMI-5603)', () => {
 
     expect(findAnyTypedFiles(tmpRoot)).toEqual([])
     expect(findLongFiles(tmpRoot)).toEqual([])
+  })
+
+  it('SMI-5992: does NOT flag an over-limit .spec.ts file (shared exemption predicate, code-review finding)', () => {
+    tmpRoot = makeFixtureTempDir('audit-standards-apps-root')
+    const pkgDir = join(tmpRoot, 'packages', 'core', 'src')
+    mkdirSync(pkgDir, { recursive: true })
+    writeFileSync(join(pkgDir, 'huge.spec.ts'), longFileBody())
+    // Non-test control in the same run — an over-limit file WITHOUT a
+    // .test./.spec. marker in its own filename must still be flagged, proving
+    // the exemption isn't accidentally swallowing everything.
+    writeFileSync(join(pkgDir, 'huge.ts'), longFileBody())
+
+    const flagged = findLongFiles(tmpRoot)
+    expect(flagged).not.toContain(join(pkgDir, 'huge.spec.ts'))
+    expect(flagged).toContain(join(pkgDir, 'huge.ts'))
   })
 
   it('combines findings from both roots in a single pass (mixed packages/ + apps/ tree)', () => {

--- a/scripts/tests/check-file-length.test.ts
+++ b/scripts/tests/check-file-length.test.ts
@@ -30,6 +30,10 @@ import lintStagedConfig from '../../lint-staged.config.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const SCRIPT_PATH = resolve(__dirname, '..', 'check-file-length.mjs')
+// SMI-5992: check-file-length.mjs now imports the shared policy module — the
+// end-to-end fixture repo below must carry a copy of it too, or the spawned
+// script fails to resolve './file-length-policy.mjs' at runtime.
+const POLICY_SCRIPT_PATH = resolve(__dirname, '..', 'file-length-policy.mjs')
 
 /** Create a unique temp directory for a fixture repo. */
 function makeTempDir(): string {
@@ -150,12 +154,16 @@ describe('checkFiles', () => {
   })
 
   it('skips an ignore-listed over-limit path instead of failing', () => {
-    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
-    const ignoreList = new Map([['supabase/functions/indexer/index.test.ts', 'SMI-4948']])
+    // SMI-5992: non-test filename (not supabase/functions/indexer/index.test.ts)
+    // — deliberately so this exercises the grandfather-list branch, not the
+    // new .test./.spec. exemption branch (see the dedicated SMI-5992 tests
+    // below, which cover the test-file-exemption branch specifically).
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.ts', 977)
+    const ignoreList = new Map([['supabase/functions/indexer/index.ts', 'SMI-4948']])
     const { violations, skipped } = checkFiles([abs], ignoreList, root)
     expect(violations).toHaveLength(0)
     expect(skipped).toHaveLength(1)
-    expect(skipped[0].relPath).toBe('supabase/functions/indexer/index.test.ts')
+    expect(skipped[0].relPath).toBe('supabase/functions/indexer/index.ts')
     expect(skipped[0].smiRef).toBe('SMI-4948')
   })
 
@@ -163,29 +171,48 @@ describe('checkFiles', () => {
     // lint-staged v16 passes absolute paths; the ignore file stores
     // repo-relative. A naive string-equality impl would treat the
     // absolute path as unmatched and fail the commit.
-    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
+    // SMI-5992: non-test filename — see note above.
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.ts', 977)
     expect(resolve(abs)).toBe(abs) // sanity: abs really is absolute
-    const ignoreList = new Map([['supabase/functions/indexer/index.test.ts', 'SMI-4948']])
+    const ignoreList = new Map([['supabase/functions/indexer/index.ts', 'SMI-4948']])
     const { violations, skipped } = checkFiles([abs], ignoreList, root)
     expect(violations).toHaveLength(0)
     expect(skipped).toHaveLength(1)
   })
 
   it('re-enforces a grandfathered file once it drops below the limit (H1)', () => {
-    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 420)
-    const ignoreList = new Map([['supabase/functions/indexer/index.test.ts', 'SMI-4948']])
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.ts', 420)
+    const ignoreList = new Map([['supabase/functions/indexer/index.ts', 'SMI-4948']])
     const { violations, skipped, delistable } = checkFiles([abs], ignoreList, root)
     expect(violations).toHaveLength(0)
     expect(skipped).toHaveLength(0)
     expect(delistable).toHaveLength(1)
-    expect(delistable[0].relPath).toBe('supabase/functions/indexer/index.test.ts')
+    expect(delistable[0].relPath).toBe('supabase/functions/indexer/index.ts')
     expect(delistable[0].lineCount).toBe(420)
   })
 
   it('checks every file when the ignore-list is empty', () => {
-    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
+    // SMI-5992: non-test filename — see note above.
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.ts', 977)
     const { violations } = checkFiles([abs], new Map(), root)
     expect(violations).toHaveLength(1)
+  })
+
+  it('SMI-5992: reports a test file over the limit via skipped (test-exempt), not violations', () => {
+    const abs = writeTsFile(root, 'packages/core/src/foo.test.ts', 600)
+    const { violations, skipped } = checkFiles([abs], new Map(), root)
+    expect(violations).toHaveLength(0)
+    expect(skipped).toHaveLength(1)
+    expect(skipped[0].relPath).toBe('packages/core/src/foo.test.ts')
+    expect(skipped[0].reason).toContain('test file')
+  })
+
+  it('SMI-5992: reports a .spec.ts file over the limit via skipped (test-exempt), not violations', () => {
+    const abs = writeTsFile(root, 'packages/core/src/foo.spec.ts', 600)
+    const { violations, skipped } = checkFiles([abs], new Map(), root)
+    expect(violations).toHaveLength(0)
+    expect(skipped).toHaveLength(1)
+    expect(skipped[0].relPath).toBe('packages/core/src/foo.spec.ts')
   })
 })
 
@@ -202,6 +229,7 @@ describe('check-file-length.mjs (end-to-end)', () => {
     root = makeTempDir()
     mkdirSync(join(root, 'scripts'), { recursive: true })
     cpSync(SCRIPT_PATH, join(root, 'scripts', 'check-file-length.mjs'))
+    cpSync(POLICY_SCRIPT_PATH, join(root, 'scripts', 'file-length-policy.mjs'))
   })
 
   afterEach(() => {
@@ -249,16 +277,19 @@ describe('check-file-length.mjs (end-to-end)', () => {
     // SMI-5658 Step 6: the ignore file's own `# SMI-XXXX split follow-up`
     // comment must drive the message, not a hardcoded issue number. Uses
     // SMI-5211, one of the two live ignore-list entries.
+    // SMI-5992: non-test filename (not ...index.test.ts) — deliberately, so
+    // this exercises the grandfather-list branch specifically, not the new
+    // .test./.spec. exemption branch (covered by its own tests below).
     writeFileSync(
       join(root, 'scripts', 'check-file-length.ignore'),
-      '# SMI-5211 split follow-up\nsupabase/functions/indexer/index.test.ts\n',
+      '# SMI-5211 split follow-up\nsupabase/functions/indexer/index.ts\n',
       'utf8'
     )
-    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.ts', 977)
     const { status, stdout } = runHook([abs])
     expect(status).toBe(0)
     expect(stdout).toContain(
-      'supabase/functions/indexer/index.test.ts: skipped (grandfathered — SMI-5211 split pending)'
+      'supabase/functions/indexer/index.ts: skipped (grandfathered — SMI-5211 split pending)'
     )
   })
 
@@ -267,35 +298,65 @@ describe('check-file-length.mjs (end-to-end)', () => {
     // without the ignore-list's own `# SMI-XXXX split follow-up`
     // convention still gets skipped, but the message degrades gracefully
     // instead of naming a wrong/hardcoded issue.
+    // SMI-5992: non-test filename — see note above.
     writeFileSync(
       join(root, 'scripts', 'check-file-length.ignore'),
-      'supabase/functions/indexer/index.test.ts\n',
+      'supabase/functions/indexer/index.ts\n',
       'utf8'
     )
-    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.ts', 977)
     const { status, stdout } = runHook([abs])
     expect(status).toBe(0)
     expect(stdout).toContain(
-      'supabase/functions/indexer/index.test.ts: skipped (grandfathered — see scripts/check-file-length.ignore for the tracking issue)'
+      'supabase/functions/indexer/index.ts: skipped (grandfathered — see scripts/check-file-length.ignore for the tracking issue)'
     )
   })
 
   it('exits 0 and prints an eligible-to-de-list notice once a grandfathered file is under the limit (H1)', () => {
     writeFileSync(
       join(root, 'scripts', 'check-file-length.ignore'),
-      '# SMI-4948 split follow-up\nsupabase/functions/indexer/index.test.ts\n',
+      '# SMI-4948 split follow-up\nsupabase/functions/indexer/index.ts\n',
       'utf8'
     )
-    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 410)
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.ts', 410)
     const { status, stdout } = runHook([abs])
     expect(status).toBe(0)
     expect(stdout).toContain('eligible to de-list')
   })
 
   it('still fails an over-limit file when the ignore-list file is absent', () => {
-    const abs = writeTsFile(root, 'supabase/functions/indexer/index.test.ts', 977)
+    // SMI-5992: non-test filename — see note above; this test's whole point
+    // is that a non-exempt, non-grandfathered file still hard-fails.
+    const abs = writeTsFile(root, 'supabase/functions/indexer/index.ts', 977)
     const { status } = runHook([abs])
     expect(status).toBe(1)
+  })
+
+  // SMI-5992: the actual regression fix — a .test.ts or .spec.ts file over
+  // the limit now passes (previously it hard-failed; CI's Check 3 already
+  // exempted .test. files, so pre-commit rejecting one was surprising and
+  // is the pain SMI-5992 was filed for). A plain, non-test .ts file over the
+  // limit must still fail — guards against silently widening the exemption
+  // beyond .test./.spec.
+  it('SMI-5992: a .test.ts file over 500 lines now passes (regression fix)', () => {
+    const abs = writeTsFile(root, 'packages/core/src/big-module.test.ts', 600)
+    const { status, stdout } = runHook([abs])
+    expect(status).toBe(0)
+    expect(stdout).toContain('packages/core/src/big-module.test.ts: skipped')
+  })
+
+  it('SMI-5992: a .spec.ts file over 500 lines also passes', () => {
+    const abs = writeTsFile(root, 'packages/core/src/big-module.spec.ts', 600)
+    const { status, stdout } = runHook([abs])
+    expect(status).toBe(0)
+    expect(stdout).toContain('packages/core/src/big-module.spec.ts: skipped')
+  })
+
+  it('SMI-5992: a non-test .ts file over 500 lines still fails (exemption not widened)', () => {
+    const abs = writeTsFile(root, 'packages/core/src/big-module.ts', 600)
+    const { status, stderr } = runHook([abs])
+    expect(status).toBe(1)
+    expect(stderr).toContain('packages/core/src/big-module.ts')
   })
 })
 

--- a/scripts/tests/file-length-policy.test.ts
+++ b/scripts/tests/file-length-policy.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the shared file-length policy module (SMI-5992).
+ *
+ * scripts/file-length-policy.mjs exports MAX_LINES and
+ * isExemptFromLengthCheck(path) — the threshold + test-file exemption
+ * predicate shared between scripts/check-file-length.mjs (pre-commit,
+ * hard-fail) and scripts/audit-standards.mjs Check 3 (CI, warn-only).
+ * Scope and severity are deliberately NOT shared (SMI-5994 tracks that).
+ *
+ * The predicate is a deliberate decision (not an oversight): it matches
+ * both `.test.` and `.spec.` — this repo's own test-file recognition
+ * elsewhere (audit-standards.mjs's own Check 4, CLAUDE.md's "Test File
+ * Locations" table) already treats `.spec.` as the same category as
+ * `.test.`.
+ */
+import { describe, it, expect } from 'vitest'
+import { MAX_LINES, isExemptFromLengthCheck } from '../file-length-policy.mjs'
+
+describe('file-length-policy: MAX_LINES', () => {
+  it('is the documented 500-line threshold', () => {
+    expect(MAX_LINES).toBe(500)
+  })
+})
+
+describe('file-length-policy: isExemptFromLengthCheck', () => {
+  it('exempts a .test.ts path', () => {
+    expect(isExemptFromLengthCheck('packages/core/src/foo.test.ts')).toBe(true)
+  })
+
+  it('exempts a .spec.ts path', () => {
+    expect(isExemptFromLengthCheck('packages/mcp-server/src/bar.spec.ts')).toBe(true)
+  })
+
+  it('does not exempt a plain, non-test .ts path', () => {
+    expect(isExemptFromLengthCheck('packages/core/src/foo.ts')).toBe(false)
+  })
+
+  it('exempts a .test.tsx path', () => {
+    expect(isExemptFromLengthCheck('packages/website/src/components/Foo.test.tsx')).toBe(true)
+  })
+
+  it('exempts a .spec.tsx path', () => {
+    expect(isExemptFromLengthCheck('packages/website/src/components/Bar.spec.tsx')).toBe(true)
+  })
+
+  it('does not exempt a .d.ts declaration file (no .test. or .spec. substring)', () => {
+    expect(isExemptFromLengthCheck('packages/core/dist/foo.d.ts')).toBe(false)
+  })
+
+  it('exempts an absolute path containing .test.', () => {
+    expect(isExemptFromLengthCheck('/repo/packages/core/src/foo.test.ts')).toBe(true)
+  })
+
+  it('exempts a .sh test file (pre-commit also scans .sh)', () => {
+    expect(isExemptFromLengthCheck('scripts/tests/deploy.test.sh')).toBe(true)
+  })
+
+  it('does NOT exempt a non-test file living under a marker-like directory name (code-review finding)', () => {
+    // packages/foo.test.fixtures/ is a real directory NAME, not a test file —
+    // matching the full path here would wrongly exempt runtime.ts, which is
+    // a genuine production file and should still be length-checked.
+    expect(isExemptFromLengthCheck('packages/foo.test.fixtures/src/runtime.ts')).toBe(false)
+  })
+
+  it('does NOT exempt a non-test file under a .spec.-named directory', () => {
+    expect(isExemptFromLengthCheck('packages/bar.spec.data/src/loader.ts')).toBe(false)
+  })
+
+  it('still exempts a real test file that happens to live under such a directory', () => {
+    expect(isExemptFromLengthCheck('packages/foo.test.fixtures/src/runtime.test.ts')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** Two small, unrelated fixes bundled into one maintenance PR (per the plan's own recommendation for low-risk diagnostics/tooling changes). First: the MCP server's startup log line printed a wrong/misleading database path in some configurations — now always prints the real one. Second: two separate code-quality checks in this repo (one at commit time, one in CI) both enforce a 500-line file-length limit but disagreed on which test files were exempt, so a file could pass one and fail the other — they now share one definition of "is this a test file."

**Quality bar:** Independently code-reviewed by GPT-5.6-Sol (a second AI model) before merge. That review caught that the exemption check was looking at a file's whole path instead of just its filename — meaning a real, non-test file sitting in an oddly-named folder could have wrongly skipped the length check — and that the new test for the database-path fix only tested a helper function, not the actual code path that logs the message, so it wouldn't have caught a regression of the fix itself. Both fixed.

**Found along the way:** An earlier draft of the file-length fix's own tracking cited the wrong existing issue for "the parts of this gate we're not fixing here." Verified against Linear, found the citation was wrong, and filed the real tracking issue (SMI-5994) instead.

**Net result:** Both fixed, fully shipped. Deliberately NOT a full reconciliation of the two length checks — remaining differences (scope, severity) stay tracked separately on SMI-5994.

---

## Technical detail

`packages/mcp-server/src/index.ts` now logs `buildDbInitializedLogMessage()` (new, `context.helpers.ts`) instead of interpolating a raw env value. New shared module `scripts/file-length-policy.mjs` (exports the threshold + exemption predicate), imported by both `scripts/check-file-length.mjs` and `scripts/audit-standards.mjs` Check 3.

Part of `docs/internal/implementation/smi-5930-wave2-and-adjacent-fixes.md` — ships as its own PR per that plan's review recommendation.