### PR TITLE
fix(mcp-server): SMI-5991 stop reading real ~/.claude/skills/ in recommend.test.ts

### DIFF
--- a/packages/mcp-server/tests/recommend-format.test.ts
+++ b/packages/mcp-server/tests/recommend-format.test.ts
@@ -126,9 +126,12 @@ describe('formatRecommendations', () => {
       toolContext
     )
 
-    if (result.role_filtered > 0) {
-      const formatted = formatRecommendations(result)
-      expect(formatted).toContain(`Filtered for role: ${result.role_filtered}`)
-    }
+    // SMI-5991 (code review): role_filtered counts across the whole
+    // candidate pool (58-skill fixture set spanning many categories), not
+    // just the returned limit — filtering to a single role deterministically
+    // excludes the majority of it, so this is no longer a conditional skip.
+    expect(result.role_filtered).toBeGreaterThan(0)
+    const formatted = formatRecommendations(result)
+    expect(formatted).toContain(`Filtered for role: ${result.role_filtered}`)
   })
 })

--- a/packages/mcp-server/tests/recommend-format.test.ts
+++ b/packages/mcp-server/tests/recommend-format.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for SMI-741: MCP Skill Recommend Tool — formatRecommendations output
+ *
+ * SMI-5991: split from recommend.test.ts (which was pushed over the 500-line
+ * cap by that fix) to keep each file under 500 lines — same precedent as
+ * recommend-online-path.test.ts (SMI-2755 Wave 2).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest'
+import { executeRecommend, formatRecommendations } from '../src/tools/recommend.js'
+import { createTestDatabase, type TestDatabaseContext } from './integration/setup.js'
+import type { ToolContext } from '../src/context.js'
+import * as InstalledSkillsModule from '../src/utils/installed-skills.js'
+
+let testDbContext: TestDatabaseContext
+let toolContext: ToolContext
+
+beforeAll(async () => {
+  testDbContext = await createTestDatabase()
+  toolContext = {
+    db: testDbContext.db,
+    searchService: testDbContext.searchService,
+    skillRepository: testDbContext.skillRepository,
+    coInstallRepository: testDbContext.coInstallRepository,
+    skillDependencyRepository: testDbContext.skillDependencyRepository,
+    sessionInstalledSkillIds: [],
+    apiClient: testDbContext.apiClient,
+  }
+})
+
+afterAll(async () => {
+  await testDbContext.cleanup()
+})
+
+// SMI-5991: see recommend.test.ts's beforeEach for the full rationale — a
+// synthetic, non-fixture-colliding ID so auto-detection is deterministic
+// without perturbing the installed-skill/overlap-detection filtering paths.
+beforeEach(() => {
+  vi.spyOn(InstalledSkillsModule, 'getInstalledSkills').mockResolvedValue([
+    'local/smi-5991-autodetect-stub',
+  ])
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('formatRecommendations', () => {
+  it('should format recommendations for terminal display', async () => {
+    const result = await executeRecommend(
+      {
+        installed_skills: ['anthropic/commit'],
+        detect_overlap: false, // Disable overlap detection for consistent testing
+        limit: 3,
+      },
+      toolContext
+    )
+    const formatted = formatRecommendations(result)
+
+    expect(formatted).toContain('Skill Recommendations')
+    expect(formatted).toContain('recommendation(s)')
+    expect(formatted).toContain('Score:')
+    expect(formatted).toContain('Relevance:')
+    expect(formatted).toContain('ID:')
+  })
+
+  it('should display trust badges', async () => {
+    const result = await executeRecommend(
+      {
+        installed_skills: [],
+        detect_overlap: false, // Disable overlap detection for consistent testing
+        limit: 5,
+      },
+      toolContext
+    )
+    const formatted = formatRecommendations(result)
+
+    // Should contain at least one trust badge
+    const hasBadge =
+      formatted.includes('[VERIFIED]') ||
+      formatted.includes('[COMMUNITY]') ||
+      formatted.includes('[STANDARD]') ||
+      formatted.includes('[UNVERIFIED]')
+    expect(hasBadge).toBe(true)
+  })
+
+  it('should show candidates considered and timing', async () => {
+    const result = await executeRecommend(
+      {
+        installed_skills: [],
+        detect_overlap: false, // Disable overlap detection for consistent testing
+        limit: 3,
+      },
+      toolContext
+    )
+    const formatted = formatRecommendations(result)
+
+    expect(formatted).toContain('Candidates considered:')
+    expect(formatted).toContain('ms')
+  })
+
+  // SMI-1631: Role display in formatted output
+  it('should show role filter in formatted output when applied', async () => {
+    const result = await executeRecommend(
+      {
+        installed_skills: [],
+        role: 'testing',
+        detect_overlap: false,
+        limit: 5,
+      },
+      toolContext
+    )
+    const formatted = formatRecommendations(result)
+
+    expect(formatted).toContain('Role filter: testing')
+  })
+
+  it('should show role filtered count when skills were filtered', async () => {
+    const result = await executeRecommend(
+      {
+        installed_skills: [],
+        role: 'testing',
+        detect_overlap: false,
+        limit: 10,
+      },
+      toolContext
+    )
+
+    if (result.role_filtered > 0) {
+      const formatted = formatRecommendations(result)
+      expect(formatted).toContain(`Filtered for role: ${result.role_filtered}`)
+    }
+  })
+})

--- a/packages/mcp-server/tests/recommend.test.ts
+++ b/packages/mcp-server/tests/recommend.test.ts
@@ -239,7 +239,11 @@ describe('Skill Recommend Tool', () => {
           name.toLowerCase().includes('jest') ||
           name.toLowerCase().includes('test')
       )
-      expect(hasRelevantSkill || result.recommendations.length > 0).toBe(true)
+      // SMI-5991 (code review): the original `hasRelevantSkill ||
+      // recommendations.length > 0` made this vacuously true whenever ANY
+      // recommendation existed, regardless of relevance. Assert relevance
+      // directly.
+      expect(hasRelevantSkill).toBe(true)
     })
 
     it('should return candidates_considered count', async () => {
@@ -369,46 +373,45 @@ describe('Skill Recommend Tool', () => {
     })
 
     it('should boost quality score by 30 for role matches', async () => {
-      // First, get recommendations without role filter
+      // SMI-5991 (code review): fetch the role-filtered set FIRST — role
+      // filtering deterministically selects only testing-role skills from
+      // the whole candidate pool, unlike the unfiltered call below, whose
+      // similarity ranking gives no guarantee a testing-role skill lands
+      // within any particular limit. The previous version's `if
+      // (testingSkill)` / `if (boostedSkill)` guards let this test pass
+      // with zero assertions executed whenever either lookup missed.
+      const withRole = await executeRecommend(
+        {
+          installed_skills: [],
+          role: 'testing',
+          detect_overlap: false,
+          limit: 20,
+        },
+        toolContext
+      )
+      const boostedSkill = withRole.recommendations[0]
+      expect(boostedSkill).toBeDefined()
+
+      // Fetch a wide unfiltered set (close to the full 58-skill fixture
+      // pool) so the same skill is virtually certain to appear, letting us
+      // read its pre-boost baseline score.
       const withoutRole = await executeRecommend(
         {
           installed_skills: [],
           detect_overlap: false,
-          limit: 10,
+          limit: 50,
         },
         toolContext
       )
-
-      // Find a skill that has the 'testing' role
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const testingSkill = withoutRole.recommendations.find((r: any) =>
-        r.roles?.includes('testing')
+      const testingSkill = withoutRole.recommendations.find(
+        (r) => r.skill_id === boostedSkill.skill_id
       )
+      expect(testingSkill).toBeDefined()
 
       if (testingSkill) {
-        const originalScore = testingSkill.quality_score
-
-        // Now get recommendations with testing role filter
-        const withRole = await executeRecommend(
-          {
-            installed_skills: [],
-            role: 'testing',
-            detect_overlap: false,
-            limit: 10,
-          },
-          toolContext
-        )
-
-        const boostedSkill = withRole.recommendations.find(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (r: any) => r.skill_id === testingSkill.skill_id
-        )
-
-        if (boostedSkill) {
-          // Score should be boosted by 30 (capped at 100)
-          const expectedScore = Math.min(100, originalScore + 30)
-          expect(boostedSkill.quality_score).toBe(expectedScore)
-        }
+        // Score should be boosted by 30 (capped at 100)
+        const expectedScore = Math.min(100, testingSkill.quality_score + 30)
+        expect(boostedSkill.quality_score).toBe(expectedScore)
       }
     })
 

--- a/packages/mcp-server/tests/recommend.test.ts
+++ b/packages/mcp-server/tests/recommend.test.ts
@@ -3,14 +3,11 @@
  * Updated for SMI-902: Use real database instead of hardcoded skills
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import {
-  executeRecommend,
-  formatRecommendations,
-  recommendInputSchema,
-} from '../src/tools/recommend.js'
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest'
+import { executeRecommend, recommendInputSchema } from '../src/tools/recommend.js'
 import { createTestDatabase, type TestDatabaseContext } from './integration/setup.js'
 import type { ToolContext } from '../src/context.js'
+import * as InstalledSkillsModule from '../src/utils/installed-skills.js'
 
 // Test context with database
 let testDbContext: TestDatabaseContext
@@ -32,6 +29,30 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await testDbContext.cleanup()
+})
+
+// SMI-5991: this file's `installed_skills: []` cases rely on SMI-906
+// auto-detection to populate the context.stack — reading the real host
+// `~/.claude/skills/` directory made results depend on execution
+// environment (a dev host with skills installed vs. a clean Docker
+// container/CI runner with none), and an empty auto-detect result trips
+// the SMI-5896 empty-stack guard, silently degrading assertions written
+// against real recommendations. Stub to a fixed, non-empty, synthetic
+// skill ID that deliberately does NOT match any seeded fixture in
+// TEST_SKILLS (unlike a real fixture ID such as 'anthropic/commit', which
+// — with detect_overlap defaulted true — engages OverlapDetector and can
+// legitimately filter every candidate away): this keeps the stub's only
+// effect "make the derived stack non-empty," without perturbing the
+// installed-skill exclusion or overlap-detection filtering paths that
+// other tests in this file exercise deliberately via an explicit array.
+beforeEach(() => {
+  vi.spyOn(InstalledSkillsModule, 'getInstalledSkills').mockResolvedValue([
+    'local/smi-5991-autodetect-stub',
+  ])
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('Skill Recommend Tool', () => {
@@ -408,91 +429,7 @@ describe('Skill Recommend Tool', () => {
     })
   })
 
-  describe('formatRecommendations', () => {
-    it('should format recommendations for terminal display', async () => {
-      const result = await executeRecommend(
-        {
-          installed_skills: ['anthropic/commit'],
-          detect_overlap: false, // Disable overlap detection for consistent testing
-          limit: 3,
-        },
-        toolContext
-      )
-      const formatted = formatRecommendations(result)
-
-      expect(formatted).toContain('Skill Recommendations')
-      expect(formatted).toContain('recommendation(s)')
-      expect(formatted).toContain('Score:')
-      expect(formatted).toContain('Relevance:')
-      expect(formatted).toContain('ID:')
-    })
-
-    it('should display trust badges', async () => {
-      const result = await executeRecommend(
-        {
-          installed_skills: [],
-          detect_overlap: false, // Disable overlap detection for consistent testing
-          limit: 5,
-        },
-        toolContext
-      )
-      const formatted = formatRecommendations(result)
-
-      // Should contain at least one trust badge
-      const hasBadge =
-        formatted.includes('[VERIFIED]') ||
-        formatted.includes('[COMMUNITY]') ||
-        formatted.includes('[STANDARD]') ||
-        formatted.includes('[UNVERIFIED]')
-      expect(hasBadge).toBe(true)
-    })
-
-    it('should show candidates considered and timing', async () => {
-      const result = await executeRecommend(
-        {
-          installed_skills: [],
-          detect_overlap: false, // Disable overlap detection for consistent testing
-          limit: 3,
-        },
-        toolContext
-      )
-      const formatted = formatRecommendations(result)
-
-      expect(formatted).toContain('Candidates considered:')
-      expect(formatted).toContain('ms')
-    })
-
-    // SMI-1631: Role display in formatted output
-    it('should show role filter in formatted output when applied', async () => {
-      const result = await executeRecommend(
-        {
-          installed_skills: [],
-          role: 'testing',
-          detect_overlap: false,
-          limit: 5,
-        },
-        toolContext
-      )
-      const formatted = formatRecommendations(result)
-
-      expect(formatted).toContain('Role filter: testing')
-    })
-
-    it('should show role filtered count when skills were filtered', async () => {
-      const result = await executeRecommend(
-        {
-          installed_skills: [],
-          role: 'testing',
-          detect_overlap: false,
-          limit: 10,
-        },
-        toolContext
-      )
-
-      if (result.role_filtered > 0) {
-        const formatted = formatRecommendations(result)
-        expect(formatted).toContain(`Filtered for role: ${result.role_filtered}`)
-      }
-    })
-  })
+  // SMI-5991: formatRecommendations tests split to recommend-format.test.ts
+  // to keep this file under the 500-line cap (same precedent as
+  // recommend-online-path.test.ts, SMI-2755 Wave 2).
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** `recommend.test.ts` no longer depends on the real host `~/.claude/skills/` directory — it was silently order/environment-dependent (passes with skills installed on a dev host, fails or vacuously "passes" with an empty/absent directory, e.g. inside a clean Docker container). Also fixed 3 pre-existing weak assertions in the same file family that could pass without ever actually checking anything, caught during code review.

**Quality bar:** Root-caused by tracing the actual code path (the SMI-5896 empty-stack guard), not guessed. Fix verified deterministic across 7+ consecutive runs. GPT-5.6-Sol code review caught the 3 vacuous-assertion bugs, now fixed in the same PR. Full mcp-server suite (2853+ tests) shows no other regressions from either commit.

**Found along the way:** none new — this closes out SMI-5991, itself discovered during the SMI-5986 investigation (already merged, PR #2295).

**Net result:** Fully shipped, no follow-up.

---

## Technical detail

**Root cause:** `recommend.test.ts`'s `installed_skills: []` test cases rely on SMI-906 auto-detection (`getInstalledSkills()`, reading `~/.claude/skills/`) to populate the derived `context.stack`. When that directory is empty or absent (confirmed empirically: `/root/.claude/skills/` doesn't exist in a fresh Docker worktree container), the SMI-5896 empty-stack guard fires and short-circuits to `recommendations: []`, which silently turned most of this file's assertions into vacuous passes (loops/conditionals over an empty array never execute their body) and failed the two assertions that actually check for non-empty results.

**Fix:**
- Stub `getInstalledSkills` via `vi.spyOn` in `beforeEach`, `mockResolvedValue(['local/smi-5991-autodetect-stub'])`, `vi.restoreAllMocks()` in `afterEach`. The stub value is a synthetic ID deliberately chosen NOT to match any of the 58 real `TEST_SKILLS` fixtures — an earlier draft used a real fixture ID (`anthropic/commit`) and that broke two *different* tests, since `detect_overlap` defaults `true` and a real installed-skill match engages `OverlapDetector` against real fixture data, legitimately zeroing every candidate.
- This pushed the file to 524 lines (over the 500-line cap), so `formatRecommendations` tests were split to a new `recommend-format.test.ts` — same precedent as `recommend-online-path.test.ts` (SMI-2755 Wave 2).
- Second commit, from code review: fixed 3 vacuous assertions (`hasRelevantSkill || recommendations.length > 0` always-true pattern; two `if (lookup) { assert }` guards that silently skipped their only assertion when the lookup missed).

**Files:** `packages/mcp-server/tests/recommend.test.ts` (modified), `packages/mcp-server/tests/recommend-format.test.ts` (new).

**Verification:** 28/28 tests pass across both files, 7+ consecutive runs in Docker. Full `packages/mcp-server` suite: 2853 tests, only unrelated pre-existing failures (`crash-handler-integration.test.ts`, a spawn-timing test — a fix worktree already exists elsewhere in this repo for that, `fix/smi-5999-crash-handler-test-timeout`). Lint/typecheck clean.

Fixes SMI-5991