### PR TITLE
fix(mcp-server): Raise crash-handler test timeout, isolate HOME

### DIFF
--- a/packages/mcp-server/tests/crash-handler-integration.test.ts
+++ b/packages/mcp-server/tests/crash-handler-integration.test.ts
@@ -16,6 +16,7 @@ import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { beforeAll, describe, expect, it } from 'vitest'
+import { createIsolatedHome } from './integration/agent-harness-sim.helpers.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -36,9 +37,20 @@ interface SpawnResult {
 }
 
 async function spawnForced(envVar: string): Promise<SpawnResult> {
+  // SMI-5999: per-spawn isolated HOME, reusing agent-harness-sim.helpers.ts's
+  // createIsolatedHome() (os.homedir() reads $HOME on the Linux Docker target).
+  // These spawns previously shared the real `~/.skillsmith` with
+  // startup-probe.test.ts's spawn: on a fresh HOME (new container / CI) two
+  // concurrently-booting servers race schema init on the same skills.db and
+  // the loser exits 1 with "UNIQUE constraint failed: schema_version.version"
+  // before ever printing "running"; a mid-boot SIGKILL could likewise leave a
+  // 0-byte skills.db that poisons every later spawn ("empty or corrupt").
+  const { homeDir, cleanup: cleanupHome } = createIsolatedHome('skillsmith-crash-')
+
   const proc = spawn('node', [DIST_ENTRY], {
     env: {
       ...process.env,
+      HOME: homeDir,
       SKILLSMITH_SKIP_SKILL_INSTALL: '1',
       SKILLSMITH_AUTO_UPDATE_CHECK: 'false',
       [envVar]: '1',
@@ -52,10 +64,21 @@ async function spawnForced(envVar: string): Promise<SpawnResult> {
   proc.stderr.on('data', (d: Buffer) => stderrChunks.push(d.toString()))
 
   const exitCode = await new Promise<number | null>((resolve, reject) => {
+    // SMI-5999: 60s budget, up from 15s — a pure timing-budget fix, not a
+    // crash-handler bug. In isolation each spawn finishes in ~6-7s, but under
+    // the full-package suite Vitest's worker parallelism runs this alongside
+    // two heavy integration tests (agent-harness-sim ~50s,
+    // security-acceptance-lost-update ~90s) whose CPU load starves the
+    // spawned node process: at 15s it was SIGKILLed with stderr still EMPTY
+    // (still in Node bootstrap, no real hang). That mid-boot SIGKILL can also
+    // leave a 0-byte ~/.skillsmith/skills.db behind, cascading into
+    // startup-probe.test.ts's "empty or corrupt" DB refusal. 60s matches
+    // startup-probe.test.ts's boot budget (SMI-5056), which was bumped
+    // 10s→30s→60s for the same contention class — 30s already flaked there.
     const timeout = setTimeout(() => {
       proc.kill('SIGKILL')
-      reject(new Error(`server did not exit within 15s — stderr so far:\n${stderrChunks.join('')}`))
-    }, 15_000)
+      reject(new Error(`server did not exit within 60s — stderr so far:\n${stderrChunks.join('')}`))
+    }, 60_000)
     proc.on('exit', (code) => {
       clearTimeout(timeout)
       resolve(code)
@@ -64,6 +87,11 @@ async function spawnForced(envVar: string): Promise<SpawnResult> {
       clearTimeout(timeout)
       reject(err)
     })
+  }).finally(() => {
+    // Best-effort isolated-HOME cleanup (createIsolatedHome's cleanup() uses
+    // force: true — Linux allows removing files the just-SIGKILLed process
+    // may still have had open).
+    cleanupHome()
   })
 
   return { stderr: stderrChunks.join(''), stdout: stdoutChunks.join(''), exitCode }
@@ -94,7 +122,8 @@ describe.skipIf(skipInPrePush)('SMI-5787 global crash handlers — integration (
     expect(exitCode).toBe(1)
     // R2 invariant: never pollute the MCP stdio JSON-RPC channel.
     expect(stdout).not.toContain('[skillsmith] Uncaught exception')
-  }, 20_000)
+    // SMI-5999: must exceed spawnForced's 60s internal budget (was 20s).
+  }, 75_000)
 
   it('logs and exits 1 on a forced unhandled rejection after startup', async () => {
     const { stderr, stdout, exitCode } = await spawnForced(
@@ -105,5 +134,6 @@ describe.skipIf(skipInPrePush)('SMI-5787 global crash handlers — integration (
     expect(stderr).toContain('[skillsmith] Unhandled promise rejection — server exiting')
     expect(exitCode).toBe(1)
     expect(stdout).not.toContain('[skillsmith] Unhandled promise rejection')
-  }, 20_000)
+    // SMI-5999: must exceed spawnForced's 60s internal budget (was 20s).
+  }, 75_000)
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a flaky test (`crash-handler-integration.test.ts`) that was intermittently failing CI and local pre-push runs — not because anything was actually broken, but because its 15-second timeout was too tight once other heavy tests in the same suite were running at the same time.

**Quality bar:** Root cause independently reproduced (isolated runs passed reliably; full-suite runs failed at the 15s mark with the spawned process still mid-startup, not hung). Fix verified across 3 full-suite runs spanning light, moderate, and extreme concurrent load — passed all 3, with the final run fully green (61/61 files, 1029 tests passed). Typecheck, lint, format, and standards audit all clean.

**Found along the way:** the same verification surfaced a second, unrelated flake in `agent-harness-sim.test.ts`'s 30-second connection-setup timeout under extreme load — filed separately as SMI-6002 rather than folded into this PR, since it's a different file with its own timing budget.

**Net result:** Fully shipped, no follow-up needed on this specific test. SMI-6002 tracks the adjacent finding.

---

## Technical detail

`packages/mcp-server/tests/crash-handler-integration.test.ts`:

1. **Timeout budget: 15s → 60s** in `spawnForced()`'s internal SIGKILL timer, and the per-`it` Vitest timeout 20s → 75s to give it room. 60s matches `startup-probe.test.ts`'s own boot budget (SMI-5056), which needed the same bump for the same suite-contention reason.
2. **Per-spawn isolated `HOME`** via `mkdtempSync`, mirroring the existing `createIsolatedHome()` pattern in `agent-harness-sim.helpers.ts`. This was needed because the old shared-HOME spawns could (a) race `startup-probe.test.ts`'s spawn on the same `skills.db` during schema init on a fresh container, and (b) leave a 0-byte `skills.db` behind after a mid-boot SIGKILL, poisoning every later spawn with an "empty or corrupt database" refusal.

No production code changed — test file only, no CHANGELOG entry needed.

Fixes SMI-5999