### PR TITLE
fix(core): SMI-6003 guard concurrent-migration race with INSERT OR IGNORE

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `runMigrations()`/`runMigrationsSafe()` (`db/migration-runner.ts`) had an unguarded
+  concurrent-migration race — two processes opening the same fresh DB at the same time could both
+  read the same `currentVersion`, both apply the same migration, and the loser's plain
+  `INSERT INTO schema_version` throw `UNIQUE constraint failed: schema_version.version`. Both now
+  use `INSERT OR IGNORE`, matching the existing v1-stamp hardening in `initializeSchema()`
+  (`schema.ts`, SMI-4486) that was never extended to per-migration inserts. Found via a flaky
+  `startup-probe.test.ts` failure traced to a real production race, not test-only flakiness
+  (SMI-6003).
 - **Changed (breaking)**: `SearchResponse.compatibilityHidden` renamed to
   `compatibilityDeprioritized` — the compatibility filter is now a ranking signal, not a hard
   exclusion (SMI-5929), so results are never actually "hidden" by it anymore; the renamed field is

--- a/packages/core/src/db/migration-runner.ts
+++ b/packages/core/src/db/migration-runner.ts
@@ -161,7 +161,18 @@ export function runMigrations(db: Database): number {
           throw error
         }
       }
-      db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(migration.version)
+      // SMI-6003: OR IGNORE — two processes opening the same fresh DB
+      // concurrently can both read currentVersion above before either has
+      // stamped a row, so both reach this INSERT for the same version. The
+      // loser's plain INSERT used to throw "UNIQUE constraint failed:
+      // schema_version.version"; OR IGNORE makes the loser's insert a silent
+      // no-op instead (matches the existing v1-stamp pattern in
+      // initializeSchema(), schema.ts:59 — SMI-4486). `migrationsRun` is a
+      // best-effort diagnostic count only (see migration.ts's `ensureSchema
+      // Compatibility` log line) — nothing downstream branches on whether
+      // this specific INSERT actually affected a row, so incrementing it
+      // even on a lost-race no-op is safe.
+      db.prepare('INSERT OR IGNORE INTO schema_version (version) VALUES (?)').run(migration.version)
       migrationsRun++
     }
   }
@@ -213,7 +224,19 @@ export function runMigrationsSafe(db: Database): number {
         // applyMigration threw a non-duplicate-column error we DO NOT advance
         // the version — the next run will retry. Guards against a v16 SQL
         // failure being silently masked.
-        db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(migration.version)
+        //
+        // SMI-6003: OR IGNORE — same concurrent-migration race as
+        // runMigrations() above (two processes both reading currentVersion
+        // before either stamps a row). Without OR IGNORE the loser's INSERT
+        // threw a UNIQUE constraint error that landed in the catch below and
+        // was merely console.warn'd — silently skipping migrationsRun++ for
+        // that iteration but NOT re-throwing, so this specific race was
+        // already non-fatal here (unlike runMigrations()); OR IGNORE removes
+        // the spurious warning entirely and lets migrationsRun++ run
+        // unconditionally, same best-effort-count reasoning as above.
+        db.prepare('INSERT OR IGNORE INTO schema_version (version) VALUES (?)').run(
+          migration.version
+        )
         migrationsRun++
       } catch (error) {
         // Log but don't fail on migration errors

--- a/packages/core/tests/db/migration-runner-race.test.ts
+++ b/packages/core/tests/db/migration-runner-race.test.ts
@@ -1,0 +1,94 @@
+/**
+ * SMI-6003: regression test for the unguarded concurrent-migration race in
+ * runMigrations() (packages/core/src/db/migration-runner.ts).
+ *
+ * Two processes opening the same fresh DB concurrently can both read
+ * currentVersion = getSchemaVersion(db) BEFORE either has stamped a row,
+ * both decide the same migration is pending, and the loser's plain
+ * `INSERT INTO schema_version (version) VALUES (?)` throws `UNIQUE
+ * constraint failed: schema_version.version`. This is the exact real-world
+ * failure crash-handler-integration.test.ts's SMI-5999 fix sidesteps by
+ * isolating each spawned mcp-server process's HOME — that test proves the
+ * SYMPTOM is contained by isolation; this test proves the underlying
+ * migration-runner bug itself is fixed, independent of any caller-side
+ * isolation.
+ *
+ * Genuine concurrency is required to reproduce this — see
+ * migration-runner-race-child.mjs's header for why a single-process
+ * Promise.all() over synchronous better-sqlite3 calls cannot do it. This
+ * spawns two REAL child processes (same established pattern as
+ * owned-lock-lost-update.test.ts), each opening its own connection to the
+ * same DB file, barrier-synced so both call the real `runMigrations()` at
+ * effectively the same instant.
+ */
+import { describe, it, expect } from 'vitest'
+import { spawn } from 'node:child_process'
+import { mkdirSync, rmSync } from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createDatabaseSync } from '../../src/db/createDatabase.js'
+import { SCHEMA_SQL } from '../../src/db/schema-sql.js'
+import { closeDatabase } from '../../src/db/schema.js'
+import { isBetterSqlite3Available } from '../../src/db/drivers/betterSqlite3Driver.js'
+
+// Evaluated once at module load — used by describe.skipIf() to skip this
+// suite when the native SQLite driver is unavailable (e.g. WASM fallback
+// mode); the race under test is specific to a real, file-backed SQLite
+// connection shared across processes, not the in-memory WASM driver.
+const skipIfNoSqlite = !isBetterSqlite3Available()
+
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+const childPath = path.join(testDir, '..', 'helpers', 'migration-runner-race-child.mjs')
+
+interface ChildResult {
+  code: number | null
+  stderr: string
+}
+
+function spawnChild(dbPath: string, barrierDir: string, id: number): Promise<ChildResult> {
+  return new Promise((resolve) => {
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', childPath, dbPath, barrierDir, String(id)],
+      { stdio: ['ignore', 'ignore', 'pipe'] }
+    )
+    let stderr = ''
+    child.stderr.on('data', (d: Buffer) => (stderr += d.toString()))
+    child.on('exit', (code) => resolve({ code, stderr }))
+  })
+}
+
+describe.skipIf(skipIfNoSqlite)('SMI-6003 runMigrations concurrent-migration race', () => {
+  it('two concurrent runMigrations() calls against the same fresh DB file do not throw', async () => {
+    const dir = path.join(
+      os.tmpdir(),
+      `migration-runner-race-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    )
+    mkdirSync(dir, { recursive: true })
+    const dbPath = path.join(dir, 'race.db')
+
+    // Set up a "fresh" DB already stamped at v16 — only migration v17 (the
+    // last entry in MIGRATIONS) is pending, so BOTH children will race to
+    // apply and INSERT the exact same version row. This isolates the test
+    // to the check-then-act bug itself (one contested INSERT) rather than
+    // incidental concurrent DDL from re-running the full 17-migration chain
+    // (which would also happen to trip the same bug, just less
+    // deterministically — v17's own apply() short-circuits to a cheap SELECT
+    // probe on a fresh SCHEMA_SQL base, since the base schema already
+    // includes 'curated' in the trust_tier CHECK — see
+    // migrations/v17-curated-trust-tier.ts).
+    const setupDb = createDatabaseSync(dbPath)
+    setupDb.exec(SCHEMA_SQL)
+    setupDb.prepare('INSERT INTO schema_version (version) VALUES (16)').run()
+    closeDatabase(setupDb)
+
+    const results = await Promise.all([spawnChild(dbPath, dir, 0), spawnChild(dbPath, dir, 1)])
+
+    for (const r of results) {
+      expect(r.code, `child stderr:\n${r.stderr}`).toBe(0)
+    }
+
+    rmSync(dir, { recursive: true, force: true })
+  }, 30_000)
+})

--- a/packages/core/tests/helpers/migration-runner-race-child.mjs
+++ b/packages/core/tests/helpers/migration-runner-race-child.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Cross-process child harness for migration-runner-race.test.ts (SMI-6003).
+ * Deliberately OUTSIDE every vitest glob (plain `.mjs`, not `*.test.ts` /
+ * `*.spec.ts`) -- exists only to be spawned as a real child process by the
+ * parent test.
+ *
+ * WHY A CHILD PROCESS (not Promise.all() in-process): the bug under test is
+ * a check-then-act race inside the fully-synchronous `runMigrations()` (no
+ * `await` anywhere in its body). JS run-to-completion semantics mean two
+ * purely-synchronous calls in a single process can never actually
+ * interleave -- whichever Promise.all() branch's continuation runs first
+ * would finish its entire synchronous `runMigrations()` call (including its
+ * INSERT) before the other branch's continuation ever got a turn, so the
+ * "loser reads a stale currentVersion" window could never open in-process.
+ * Real OS-level concurrency (separate processes, same pattern as
+ * owned-lock-lost-update.test.ts) is required to reproduce it.
+ *
+ * Spawned as:
+ *   node --import tsx migration-runner-race-child.mjs <dbPath> <barrierDir> <id>
+ *
+ * Protocol: open its own better-sqlite3 connection to the shared `dbPath`,
+ * touch `barrierDir/ready-<id>`, poll until BOTH `ready-*` markers exist
+ * (tightens the race window to the actual check-then-act critical section
+ * inside runMigrations, rather than relying on process-spawn jitter alone),
+ * then call the real production `runMigrations(db)`. Reports outcome via
+ * exit code (0 = no throw, 1 = threw -- message written to
+ * barrierDir/error-<id> and to stderr) so the parent can assert both
+ * children survived.
+ */
+import { existsSync, readdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { createDatabaseSync } from '../../src/db/createDatabase.ts'
+import { runMigrations } from '../../src/db/migration-runner.ts'
+
+const [dbPath, barrierDir, id] = process.argv.slice(2)
+
+const WAIT_CAP_MS = 10_000
+
+function touch(name) {
+  writeFileSync(join(barrierDir, name), '')
+}
+
+function waitFor(predicate, label) {
+  const deadline = Date.now() + WAIT_CAP_MS
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`[migration-runner-race-child ${id}] timed out waiting for ${label}`)
+    }
+  }
+}
+
+function countReady() {
+  return readdirSync(barrierDir).filter((f) => f.startsWith('ready-')).length
+}
+
+try {
+  const db = createDatabaseSync(dbPath)
+  touch(`ready-${id}`)
+  waitFor(() => countReady() >= 2, 'both children to be ready')
+  runMigrations(db)
+  db.close()
+  process.exit(0)
+} catch (err) {
+  const message = String(err && err.stack ? err.stack : err)
+  if (existsSync(barrierDir)) {
+    writeFileSync(join(barrierDir, `error-${id}`), message)
+  }
+  console.error(message)
+  process.exit(1)
+}

--- a/packages/mcp-server/tests/startup-probe.test.ts
+++ b/packages/mcp-server/tests/startup-probe.test.ts
@@ -19,6 +19,7 @@ import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { createIsolatedHome } from './integration/agent-harness-sim.helpers.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -222,9 +223,20 @@ describe.skipIf(skipInPrePush)('SMI-5009 startup probe — integration (spawn)',
     // / commit), not the probe itself which still has its own internal 2s
     // Promise.race. If 60s also flakes, switch to Option B (poll-loop wait)
     // or skip the integration test on CI.
+    // SMI-6003: per-spawn isolated HOME, reusing agent-harness-sim.helpers.ts's
+    // createIsolatedHome() — same pattern as crash-handler-integration.test.ts
+    // (SMI-5999). Without it this spawn shares the real ~/.skillsmith/skills.db
+    // with any other concurrently-running spawn integration test in this
+    // package; two servers racing schema init on the same fresh DB can hit
+    // the migration-runner concurrent-migration race (loser exits 1 with
+    // "UNIQUE constraint failed: schema_version.version") before either ever
+    // prints "running".
+    const { homeDir, cleanup: cleanupHome } = createIsolatedHome('skillsmith-startup-probe-')
+
     const proc = spawn('node', [DIST_ENTRY], {
       env: {
         ...process.env,
+        HOME: homeDir,
         SKILLSMITH_SKIP_SKILL_INSTALL: '1',
         SKILLSMITH_AUTO_UPDATE_CHECK: 'false',
       },
@@ -268,6 +280,11 @@ describe.skipIf(skipInPrePush)('SMI-5009 startup probe — integration (spawn)',
       })
     } finally {
       proc.kill('SIGTERM')
+      // Best-effort isolated-HOME cleanup (createIsolatedHome's cleanup()
+      // uses force: true — removing files the just-signaled process may
+      // still have open is fine on POSIX, same rationale as
+      // crash-handler-integration.test.ts's identical cleanup call).
+      cleanupHome()
     }
 
     const stderr = stderrChunks.join('')


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a real production bug found tonight while investigating an unrelated flaky test: two Skillsmith MCP server instances starting concurrently against the same brand-new install could crash on first boot with a database error, because the migration code didn't guard against two processes racing to stamp the same schema version.

**Quality bar:** Root-caused via an independent investigation pass, implemented and verified by a second independent pass — the new regression test was proven to fail against the pre-fix code (reproducing the exact real-world error) and pass with the fix. Full `packages/core` and `packages/mcp-server` test suites green (4140 + 1029 tests). Governance review (audit:standards) clean, 0 failures.

**Found along the way:** the root investigation also confirmed a timeout-tuning fix already merged tonight (SMI-5999/#2318) was correct and sufficient for its own symptom, and surfaced a separate, unrelated worktree-container infra gap (missing npm packages, structurally unfixable from inside a worktree container) — filed separately as SMI-6006, not fixed here.

**Net result:** Fully shipped. The regression test guards against this exact race recurring.

---

## Technical detail

- `packages/core/src/db/migration-runner.ts` — both `runMigrations()` and `runMigrationsSafe()` now use `INSERT OR IGNORE INTO schema_version`, matching the existing v1-stamp hardening in `schema.ts:59` (SMI-4486) that was never extended to per-migration inserts.
- `packages/mcp-server/tests/startup-probe.test.ts` — isolates its spawned server's HOME (`createIsolatedHome()`, same pattern as `crash-handler-integration.test.ts`'s SMI-5999 fix) — it was the last unisolated spawn in the package, racing the real `~/.skillsmith/skills.db` against any concurrently-running spawn test.
- New regression test: `packages/core/tests/db/migration-runner-race.test.ts` + `packages/core/tests/helpers/migration-runner-race-child.mjs` — spawns two real child processes (genuine OS concurrency required since `runMigrations()` is fully synchronous) racing against a shared pre-stamped DB.
- Pre-push bypassed (`--no-verify`) with explicit user consent for this push only — the local full-suite pre-push hook fails on 4 unrelated `packages/vscode-extension` tests due to a confirmed pre-existing, repo-wide `node_modules` drift (missing `marked`/`sanitize-html`, present even on the main checkout before any of tonight's changes) that is structurally unfixable from inside a worktree container (read-only `node_modules` by design). Tracked separately as SMI-6006. CI on this PR will still run normally and is not bypassed.