### PR TITLE
fix(cli): Raise manage-multi-client test suite timeouts to 60s

### DIFF
--- a/packages/cli/tests/manage-multi-client.test.ts
+++ b/packages/cli/tests/manage-multi-client.test.ts
@@ -101,6 +101,23 @@ async function readManifest(): Promise<Record<string, unknown>> {
   return JSON.parse(raw) as Record<string, unknown>
 }
 
+// SMI-6004: suite-level timeout bumped 15s (default) -> 60s. Root cause is
+// pure test-suite timing budget, not a bug in the code under test: this
+// file exercises the REAL SkillInstallationService end-to-end (install x2 +
+// remove/list/getSkillDiff) against a temp $HOME, and under full-suite CI
+// load with other packages' tests contending for CPU, that real work can
+// still be in flight when the vitest default 15s test timeout fires.
+// Vitest's timeout wrapper rejects the test promise but does NOT cancel the
+// original async chain (confirmed against Vitest 4.1.10 runner source) --
+// the abandoned chain's manifest write then races the next test's
+// afterEach() rm -rf of the temp HOME, producing
+// `ENOENT ... rename '.../manifest.json.tmp.NNNNN'`, and the
+// abandoned/poisoned install path calling process.exit(1) produces the
+// third observed flake symptom ("process.exit unexpectedly called with
+// '1'"). Mirrors SMI-5999's identical-class fix in
+// packages/mcp-server/tests/crash-handler-integration.test.ts (same 15s ->
+// 60s bump for the same suite-contention reason). Do NOT touch the shared
+// vitest.config.ts default timeout -- this is scoped to just this file.
 describe('SMI-5894 Wave 1: same-name skill installed under two clients', () => {
   it('remove --client cursor removes only the Cursor copy, leaving Claude Code untouched', async () => {
     await installForClient('claude-code')
@@ -241,4 +258,4 @@ describe('SMI-5894 Wave 1: same-name skill installed under two clients', () => {
     const claudeDiff = await getSkillDiff('test-skill', dbPath, 'claude-code')
     expect(claudeDiff).toBe('not-installed')
   })
-})
+}, 60_000)

--- a/packages/cli/tests/manage-update-multi-client.test.ts
+++ b/packages/cli/tests/manage-update-multi-client.test.ts
@@ -108,6 +108,22 @@ async function readManifest(): Promise<Record<string, unknown>> {
   return JSON.parse(raw) as Record<string, unknown>
 }
 
+// SMI-6004: suite-level timeout bumped 15s (default) -> 60s. Root cause is
+// pure test-suite timing budget, not a bug in the code under test: this
+// file exercises the REAL SkillInstallationService end-to-end (install x2 +
+// update) against a temp $HOME, and under full-suite CI load with other
+// packages' tests contending for CPU, that real work can still be in flight
+// when the vitest default 15s test timeout fires. Vitest's timeout wrapper
+// rejects the test promise but does NOT cancel the original async chain
+// (confirmed against Vitest 4.1.10 runner source) -- the abandoned chain's
+// manifest write then races the next test's afterEach() rm -rf of the temp
+// HOME, producing `ENOENT ... rename '.../manifest.json.tmp.NNNNN'`, and the
+// abandoned/poisoned install path calling process.exit(1) produces the
+// third observed flake symptom ("process.exit unexpectedly called with
+// '1'"). Mirrors SMI-5999's identical-class fix in
+// packages/mcp-server/tests/crash-handler-integration.test.ts (same 15s ->
+// 60s bump for the same suite-contention reason). Do NOT touch the shared
+// vitest.config.ts default timeout -- this is scoped to just this file.
 describe('SMI-5895 Wave 2: getSkillDiff manifest resolution — same skill name, two independently-sourced clients', () => {
   it("resolves the manifest id recorded for THIS client, not the other client's, when both installed the same skill name from different sources", async () => {
     // Two fully independent installs of the same skill NAME ("test-repo"),
@@ -160,4 +176,4 @@ describe('SMI-5895 Wave 2: getSkillDiff manifest resolution — same skill name,
     // ...and the Claude Code entry was never touched by this update.
     expect(installedSkills['test-repo']?.id).toBe('https://github.com/owner-a/test-repo')
   })
-})
+}, 60_000)


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a flaky test (`manage-multi-client.test.ts` / `manage-update-multi-client.test.ts`) that intermittently failed CI and pre-push runs — not because anything was broken, but because a 15-second timeout was too tight once these tests ran alongside other heavy tests in the same suite.

**Quality bar:** Root cause independently confirmed against actual Vitest 4.1.10 runner behavior (verified by both an investigating pass and a separate cross-model review). Fix verified across multiple full `packages/cli` suite runs — one run's contention pushed the first test in each file to 17.5-18s, directly proving the old 15s budget was too tight and the new 60s budget holds. Typecheck, lint, and format all clean.

**Found along the way:** two real production concurrency hazards in the manifest write path (unlocked uninstall write, temp-file collision risk) were found while investigating this flake, but are NOT its cause — split into a separate PR/issue (SMI-6007) per cross-model review recommendation, since folding them in here would make it harder to tell which change actually fixed the flake.

**Net result:** Fully shipped, no follow-up needed on this specific test.

---

## Technical detail

`packages/cli/tests/manage-multi-client.test.ts` and `manage-update-multi-client.test.ts`: bumped each file's suite-level Vitest timeout from the 15s default to 60s (`describe(name, fn, 60_000)`), with a comment explaining the causal chain. The shared `vitest.config.ts` default is untouched — scoped to just these two files.

Fixes SMI-6004