### PR TITLE
fix(mcp-server): Raise cold-path search-performance threshold to 250ms

### DIFF
--- a/packages/mcp-server/tests/performance/search-performance.test.ts
+++ b/packages/mcp-server/tests/performance/search-performance.test.ts
@@ -91,12 +91,23 @@ describe('SMI-797: Performance Validation', () => {
   })
 
   describe('Search Performance', () => {
-    it('should complete single search under 50ms with 500 skills', async () => {
+    // SMI-6005: this is the FIRST search executed in the suite, so it pays a
+    // one-time cold-path cost (statement prep / JIT warm-up) that later
+    // search tests don't. Isolated runs average ~2-3ms, but under real
+    // suite/host contention this specific assertion has been observed to
+    // climb to 15-40ms, and historical CI failures hit 63.9ms and 86.8ms
+    // against the old 50ms threshold. 250ms is a CI-contention allowance,
+    // not a performance target — do not read it as the expected latency.
+    // Tradeoff: a real ~50ms-scale regression on this specific cold path
+    // would not be caught by this test alone, but sustained/steady-state
+    // regressions are still caught by the sibling 'repeated searches' warm
+    // test below (avg < 30ms over 20 iterations).
+    it('should complete single search under 250ms with 500 skills', async () => {
       const start = performance.now()
       const result = await executeSearch({ query: 'test' }, context)
       const elapsed = performance.now() - start
 
-      expect(elapsed).toBeLessThan(50)
+      expect(elapsed).toBeLessThan(250)
       expect(result.results.length).toBeGreaterThan(0)
     })
 
@@ -155,7 +166,7 @@ describe('SMI-797: Performance Validation', () => {
   })
 
   describe('Get Skill Performance', () => {
-    it('should complete single get-skill under 20ms', async () => {
+    it('should complete single get-skill under 50ms', async () => {
       const start = performance.now()
       const result = await executeGetSkill({ id: 'test-org/skill-0' }, context)
       const elapsed = performance.now() - start
@@ -175,7 +186,7 @@ describe('SMI-797: Performance Validation', () => {
       expect(elapsed).toBeLessThan(500)
     })
 
-    it('should handle 20 concurrent get-skill calls under 100ms', async () => {
+    it('should handle 20 concurrent get-skill calls under 200ms', async () => {
       const ids = Array.from({ length: 20 }, (_, i) => `test-org/skill-${i}`)
 
       const start = performance.now()


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a flaky performance test that intermittently failed CI — the very first search executed in the test suite pays a one-time warm-up cost that later searches don't, and under real CI load that cost was occasionally exceeding an overly tight 50ms budget.

**Quality bar:** Timing data collected directly (isolated baseline ~2-3ms, historical real CI failures at 63.9ms and 86.8ms). A cross-model review caught and corrected a flaw in the original fix proposal — a sibling assertion had been mistakenly identified as needing the same threshold increase, when it's actually a warm (not cold) measurement and raising it would have weakened real regression detection. Implemented the corrected, narrower fix. Verified across multiple full `packages/mcp-server` suite runs. Typecheck, lint, and format all clean.

**Net result:** Fully shipped, no follow-up needed.

---

## Technical detail

`packages/mcp-server/tests/performance/search-performance.test.ts`: raised only the genuinely cold "single search" assertion from 50ms to 250ms (with an explanatory comment framing 250ms as a CI-contention allowance, not a performance target). The "search → get flow" assertion — which runs after many prior operations and is therefore warm, not cold — is left untouched at 50ms. Also fixed two unrelated pre-existing title/assertion mismatches in the same file (titles only, no threshold changes).

Fixes SMI-6005