### PR TITLE
fix(core,cli): Harden manifest concurrency (uninstall lock, temp-file races)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `saveManifest()` (`utils/manifest.ts`) computed its temp filename from just the process
+  id, so two concurrent saves in the same process could collide on the same temp path and corrupt
+  one of them. The temp filename now includes a random UUID suffix, with best-effort cleanup of
+  only that invocation's own temp file on failure (mirrors the same fix in
+  `@skillsmith/core`'s `ManifestManager.save()`) (SMI-6007).
 - **Changed**: bumps `@skillsmith/core` for the SMI-5929 compatibility-ranking change —
   `SearchResponse.compatibilityHidden` is renamed to `compatibilityDeprioritized` and
   `SearchOptions` gains an optional `compatibility` field. `skillsmith search` does not currently

--- a/packages/cli/src/utils/manifest.test.ts
+++ b/packages/cli/src/utils/manifest.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mkdir, writeFile, rename } from 'fs/promises'
+import { mkdir, writeFile, rename, unlink } from 'fs/promises'
 
 // ============================================================================
 // In-memory fs mock for isolation — covers save/load roundtrip tests
@@ -47,6 +47,12 @@ vi.mock('fs/promises', () => ({
     const content = memfs[path]
     if (content === undefined) throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
     return content
+  }),
+  unlink: vi.fn(async (path: string) => {
+    if (memfs[path] === undefined) {
+      throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+    }
+    delete memfs[path]
   }),
 }))
 
@@ -395,6 +401,56 @@ describe('telemetry block', () => {
       expect(mkdir).toHaveBeenCalled()
       expect(writeFile).toHaveBeenCalledWith(expect.stringContaining('.tmp.'), expect.any(String))
       expect(rename).toHaveBeenCalledWith(expect.stringContaining('.tmp.'), MANIFEST_PATH)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Same-pid temp-file collision fix (SMI-6007)
+  //
+  // Two concurrent saveManifest() calls in the same process previously
+  // computed the identical `.tmp.<pid>` path with no per-call uniqueness.
+  // --------------------------------------------------------------------------
+
+  describe('temp-file collision resistance (SMI-6007)', () => {
+    it('two overlapping saveManifest() calls use distinct temp paths and neither throws', async () => {
+      const writeFileMock = vi.mocked(writeFile)
+      const first = saveManifest(makeManifest({ enabled: false }))
+      const second = saveManifest(makeManifest({ enabled: true, anonymousId: 'e'.repeat(64) }))
+
+      await expect(Promise.all([first, second])).resolves.toBeDefined()
+
+      const tmpPathsWritten = writeFileMock.mock.calls.map((call) => call[0] as string)
+      expect(new Set(tmpPathsWritten).size).toBe(tmpPathsWritten.length)
+    })
+
+    it('on a write failure, cleanup removes only this invocation temp file and rethrows the original error', async () => {
+      const writeFileMock = vi.mocked(writeFile)
+      const originalError = new Error('ENOSPC: no space left on device')
+      writeFileMock.mockImplementationOnce(async () => {
+        throw originalError
+      })
+
+      await expect(saveManifest(makeManifest({ enabled: false }))).rejects.toThrow(originalError)
+
+      // unlink was attempted for cleanup (best-effort — the temp file was
+      // never actually written, so it ENOENTs, but the call must happen).
+      expect(unlink).toHaveBeenCalledWith(expect.stringContaining('.tmp.'))
+      // No stray temp entries left behind in the backing store.
+      expect(Object.keys(memfs).some((k) => k.includes('.tmp.'))).toBe(false)
+    })
+
+    it('on a rename failure, cleanup removes the temp file and the manifest file is left untouched', async () => {
+      const renameMock = vi.mocked(rename)
+      const originalError = new Error('EPERM: operation not permitted')
+      renameMock.mockImplementationOnce(async () => {
+        throw originalError
+      })
+
+      const { MANIFEST_PATH } = await import('./manifest.js')
+      await expect(saveManifest(makeManifest({ enabled: false }))).rejects.toThrow(originalError)
+
+      expect(memfs[MANIFEST_PATH]).toBeUndefined()
+      expect(Object.keys(memfs).some((k) => k.includes('.tmp.'))).toBe(false)
     })
   })
 })

--- a/packages/cli/src/utils/manifest.ts
+++ b/packages/cli/src/utils/manifest.ts
@@ -22,7 +22,7 @@
  */
 
 import { createHash, randomUUID } from 'crypto'
-import { readFile, writeFile, mkdir, rename } from 'fs/promises'
+import { readFile, writeFile, mkdir, rename, unlink } from 'fs/promises'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
 
@@ -116,12 +116,30 @@ export async function loadManifest(): Promise<SkillManifest> {
 
 /**
  * Save the manifest atomically (temp file → rename).
+ *
+ * SMI-6007: the temp filename includes a `randomUUID()` suffix (not just
+ * `process.pid`) — two concurrent `saveManifest()` calls in the same process
+ * previously collided on an identical `.tmp.<pid>` path. Each call now owns
+ * a uniquely-named temp file, and the write+rename is wrapped in try/catch
+ * so a failure best-effort removes only *this invocation's* temp file
+ * before rethrowing the original error (mirrors `ManifestManager.save()` in
+ * `@skillsmith/core`, and `sqljsDriver.ts`'s `persist()`, SMI-5997) — the
+ * error is never swallowed.
  */
 export async function saveManifest(manifest: SkillManifest): Promise<void> {
   await mkdir(dirname(MANIFEST_PATH), { recursive: true })
-  const tmpPath = `${MANIFEST_PATH}.tmp.${process.pid}`
-  await writeFile(tmpPath, JSON.stringify(manifest, null, 2))
-  await rename(tmpPath, MANIFEST_PATH)
+  const tmpPath = `${MANIFEST_PATH}.tmp.${process.pid}.${randomUUID()}`
+  try {
+    await writeFile(tmpPath, JSON.stringify(manifest, null, 2))
+    await rename(tmpPath, MANIFEST_PATH)
+  } catch (error) {
+    try {
+      await unlink(tmpPath)
+    } catch {
+      // best-effort cleanup — surface the original error either way
+    }
+    throw error
+  }
 }
 
 /**

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: `ManifestManager` (`services/skill-manifest.ts`) had two concurrency gaps in the skill
+  manifest write path. `performUninstall()` (`skill-installation.helpers.ts`) loaded the manifest,
+  mutated an in-memory snapshot, and saved it back directly, bypassing the lock/`updateSafely()`
+  mechanism the install path uses — a concurrent update to an unrelated entry in that window could
+  be silently overwritten. `save()` also computed its temp filename from just the process id, so
+  two concurrent saves in the same process could collide on the same temp path. Uninstall now
+  routes its final mutation through `updateSafely()`, and both `save()` and the CLI's separate
+  manifest writer now suffix the temp filename with a random UUID, with best-effort cleanup on
+  failure. `load()` also now distinguishes a missing manifest file (returns empty, expected) from
+  one that exists but is corrupt/unreadable (throws, instead of silently returning empty and
+  risking a subsequent save erasing real state) (SMI-6007).
 - **Fix**: `runMigrations()`/`runMigrationsSafe()` (`db/migration-runner.ts`) had an unguarded
   concurrent-migration race — two processes opening the same fresh DB at the same time could both
   read the same `currentVersion`, both apply the same migration, and the loser's plain

--- a/packages/core/src/services/skill-installation.helpers.test.ts
+++ b/packages/core/src/services/skill-installation.helpers.test.ts
@@ -3,10 +3,15 @@
  *   skill-installation.helpers.ts (`getRegisteredMcpServers`, and the
  *   resolution-aware warning filtering in `extractDepIntel`), plus the
  *   SMI-5894 Wave 1 multi-client manifest-keying + tips additions
- *   (`manifestKeyFor`, `generateTips`).
+ *   (`manifestKeyFor`, `generateTips`), plus the SMI-6007 `performUninstall`
+ *   manifest-concurrency hardening.
  * @module @skillsmith/core/services/skill-installation.helpers.test
  * @see SMI-5676: Wave 1 Step 3b — harden extractMcpReferences
  * @see SMI-5894: Wave 1 Steps 3/5 — multi-client manifest re-keying + tips
+ * @see SMI-6007: performUninstall now routes its final manifest mutation
+ *   through ManifestManager.updateSafely() instead of a direct load+save,
+ *   closing a lost-update hazard against concurrent operations on other
+ *   manifest entries.
  */
 import { describe, expect, it, beforeEach, afterEach } from 'vitest'
 import * as fs from 'fs'
@@ -18,7 +23,11 @@ import {
   getRegisteredMcpServers,
   generateTips,
   manifestKeyFor,
+  performUninstall,
 } from './skill-installation.helpers.js'
+import { ManifestManager } from './skill-manifest.js'
+import type { SkillManifestEntry } from './skill-installation.types.js'
+import type { SkillDependencyRepository } from '../repositories/SkillDependencyRepository.js'
 
 describe('getRegisteredMcpServers (SMI-5676)', () => {
   let tmpDir: string
@@ -144,5 +153,83 @@ describe('generateTips (SMI-5894 Wave 1 Step 5)', () => {
     expect(joined).toContain('mention it in Cursor')
     expect(joined).toContain('ls /home/user/.cursor/skills/')
     expect(joined).not.toContain('Claude Code')
+  })
+})
+
+describe('performUninstall manifest concurrency (SMI-6007)', () => {
+  let tmpDir: string
+  let manifest: ManifestManager
+  let skillDependencyRepo: SkillDependencyRepository
+
+  function makeEntry(overrides: Partial<SkillManifestEntry> = {}): SkillManifestEntry {
+    const now = new Date().toISOString()
+    return {
+      id: overrides.id ?? 'author/skill-to-remove',
+      name: overrides.name ?? 'skill-to-remove',
+      version: overrides.version ?? '1.0.0',
+      source: overrides.source ?? 'github:author/skill-to-remove',
+      installPath: overrides.installPath ?? path.join(tmpDir, 'skill-to-remove'),
+      installedAt: overrides.installedAt ?? now,
+      lastUpdated: overrides.lastUpdated ?? now,
+      ...overrides,
+    }
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-uninstall-race-'))
+    manifest = new ManifestManager(path.join(tmpDir, 'manifest.json'))
+    // clearAll is best-effort (wrapped in try/catch by performUninstall) — a
+    // minimal stub is sufficient for these manifest-concurrency tests.
+    skillDependencyRepo = { clearAll: () => {} } as unknown as SkillDependencyRepository
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('an unrelated entry survives a concurrent update racing an uninstall (core SMI-6007 fix)', async () => {
+    await manifest.save({
+      version: '1.0.0',
+      installedSkills: {
+        'skill-to-remove': makeEntry(),
+        'unrelated-skill': makeEntry({
+          id: 'author/unrelated-skill',
+          name: 'unrelated-skill',
+          installPath: path.join(tmpDir, 'unrelated-skill'),
+        }),
+      },
+    })
+
+    const uninstall = performUninstall({
+      skillName: 'skill-to-remove',
+      force: true,
+      skillsDir: tmpDir,
+      manifest,
+      skillDependencyRepo,
+      onProgress: () => {},
+    })
+
+    // Simulates a second operation (e.g. a concurrent install) racing the
+    // uninstall above, touching a DIFFERENT manifest entry.
+    const concurrentUpdate = manifest.updateSafely((current) => ({
+      ...current,
+      installedSkills: {
+        ...current.installedSkills,
+        'concurrent-skill': makeEntry({
+          id: 'author/concurrent-skill',
+          name: 'concurrent-skill',
+          installPath: path.join(tmpDir, 'concurrent-skill'),
+        }),
+      },
+    }))
+
+    const [uninstallResult] = await Promise.all([uninstall, concurrentUpdate])
+
+    expect(uninstallResult.success).toBe(true)
+
+    const finalManifest = await manifest.load()
+    expect(finalManifest.installedSkills['skill-to-remove']).toBeUndefined()
+    expect(finalManifest.installedSkills['unrelated-skill']).toBeDefined()
+    expect(finalManifest.installedSkills['concurrent-skill']).toBeDefined()
   })
 })

--- a/packages/core/src/services/skill-installation.helpers.ts
+++ b/packages/core/src/services/skill-installation.helpers.ts
@@ -301,8 +301,25 @@ export async function performUninstall(params: {
     }
 
     onProgress('manifest', 'Updating manifest')
-    delete manifestData.installedSkills[manifestKey]
-    await manifest.save(manifestData)
+    // SMI-6007: route the final mutation through updateSafely() (lock +
+    // fresh re-read + save) instead of saving the `manifestData` snapshot
+    // loaded above. That snapshot can be stale by the time we get here —
+    // filesystem cleanup and the dependency-repo clear happened in between —
+    // so saving it directly could clobber an *unrelated* manifest entry
+    // written by a concurrent install/uninstall in that window. This closes
+    // that lost-update hazard for entries other than this one.
+    //
+    // Scope: this does NOT make the full uninstall sequence (lookup ->
+    // filesystem cleanup -> manifest mutation) atomic. A concurrent
+    // operation racing on the SAME key (e.g. a reinstall of this exact
+    // skill while its uninstall is mid-flight) can still leave disk and
+    // manifest inconsistent — only the unrelated-entry data loss is fixed
+    // here, not full transactional safety across the whole method.
+    await manifest.updateSafely((current) => {
+      const next: typeof current = { ...current, installedSkills: { ...current.installedSkills } }
+      delete next.installedSkills[manifestKey]
+      return next
+    })
 
     onProgress('done', 'Uninstall complete')
     return {

--- a/packages/core/src/services/skill-manifest.test.ts
+++ b/packages/core/src/services/skill-manifest.test.ts
@@ -1,0 +1,243 @@
+/**
+ * @fileoverview Tests for ManifestManager concurrency hardening (SMI-6007)
+ * @module @skillsmith/core/services/skill-manifest.test
+ * @see SMI-6007: manifest write-path concurrency hardening — split out of
+ *   the flaky-test investigation SMI-6004. Two confirmed hazards:
+ *     1. performUninstall() bypassed the lock (fixed in
+ *        skill-installation.helpers.ts — see its own test coverage).
+ *     2. save() computed a temp filename from `process.pid` alone, so two
+ *        concurrent `save()` calls in the same process collided on the
+ *        identical `.tmp.<pid>` path.
+ *   Plus a load()-hardening item: distinguish "no manifest yet" (ENOENT,
+ *   legitimate first run) from "manifest exists but is corrupt/unreadable"
+ *   (should throw, not silently return an empty manifest that a later
+ *   save() could use to erase real state).
+ *
+ * These tests use a real temp directory + real fs/promises calls (not an
+ * in-memory mock) so the concurrent cases exercise actual OS-level file
+ * operations — `acquireLock()`'s `wx`-flag file creation is only
+ * meaningfully racy against real fs semantics.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as os from 'os'
+import * as path from 'path'
+
+// The Node ESM module namespace object is not configurable, so a plain
+// `vi.spyOn(fs, 'readFile')` throws "Cannot redefine property" under this
+// runtime. Instead, wrap the specific functions the write/rename-failure
+// tests need to override in `vi.fn(actual.fn)` at mock-registration time —
+// each defaults to forwarding to the real implementation (so every other
+// test that doesn't override them still hits the real filesystem), and
+// individual tests can layer a `mockImplementationOnce`/`mockRejectedValueOnce`
+// on top without needing `vi.spyOn`.
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>()
+  return {
+    ...actual,
+    readFile: vi.fn(actual.readFile),
+    writeFile: vi.fn(actual.writeFile),
+    rename: vi.fn(actual.rename),
+    unlink: vi.fn(actual.unlink),
+  }
+})
+
+import * as fs from 'fs/promises'
+import { ManifestManager } from './skill-manifest.js'
+import type { SkillManifest, SkillManifestEntry } from './skill-installation.types.js'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeEntry(overrides: Partial<SkillManifestEntry> = {}): SkillManifestEntry {
+  const now = new Date().toISOString()
+  return {
+    id: overrides.id ?? 'author/skill',
+    name: overrides.name ?? 'skill',
+    version: overrides.version ?? '1.0.0',
+    source: overrides.source ?? 'github:author/skill',
+    installPath: overrides.installPath ?? '/tmp/skill',
+    installedAt: overrides.installedAt ?? now,
+    lastUpdated: overrides.lastUpdated ?? now,
+    ...overrides,
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('ManifestManager concurrency hardening (SMI-6007)', () => {
+  let tmpDir: string
+  let manifestPath: string
+  let manager: ManifestManager
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skillsmith-manifest-test-'))
+    manifestPath = path.join(tmpDir, 'manifest.json')
+    manager = new ManifestManager(manifestPath)
+  })
+
+  afterEach(async () => {
+    vi.clearAllMocks()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  // --------------------------------------------------------------------------
+  // Item 1: two direct save() calls overlap; neither throws (temp-file fix)
+  // --------------------------------------------------------------------------
+
+  describe('save() same-pid temp-file collision', () => {
+    it('two overlapping save() calls both resolve without throwing', async () => {
+      const first: SkillManifest = {
+        version: '1.0.0',
+        installedSkills: { a: makeEntry({ id: 'a' }) },
+      }
+      const second: SkillManifest = {
+        version: '1.0.0',
+        installedSkills: { b: makeEntry({ id: 'b' }) },
+      }
+
+      await expect(Promise.all([manager.save(first), manager.save(second)])).resolves.toBeDefined()
+
+      // Whichever write landed last, the file must be a full, valid write —
+      // never a partial/corrupt mix of the two.
+      const loaded = await manager.load()
+      expect(Object.keys(loaded.installedSkills)).toHaveLength(1)
+    })
+
+    it('does not leave stray .tmp.* files behind after concurrent saves', async () => {
+      await Promise.all([
+        manager.save({ version: '1.0.0', installedSkills: {} }),
+        manager.save({ version: '1.0.0', installedSkills: {} }),
+      ])
+
+      const files = await fs.readdir(tmpDir)
+      expect(files.some((f) => f.includes('.tmp.'))).toBe(false)
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Item 2: two concurrent updateSafely() calls on DISTINCT entries; both
+  // survive (validates the lock actually serializes correctly)
+  // --------------------------------------------------------------------------
+
+  describe('updateSafely() serializes concurrent updates to distinct entries', () => {
+    it('both entries survive when two updateSafely() calls run concurrently', async () => {
+      await manager.save({ version: '1.0.0', installedSkills: {} })
+
+      await Promise.all([
+        manager.updateSafely((m) => ({
+          ...m,
+          installedSkills: { ...m.installedSkills, 'skill-a': makeEntry({ id: 'skill-a' }) },
+        })),
+        manager.updateSafely((m) => ({
+          ...m,
+          installedSkills: { ...m.installedSkills, 'skill-b': makeEntry({ id: 'skill-b' }) },
+        })),
+      ])
+
+      const loaded = await manager.load()
+      expect(Object.keys(loaded.installedSkills).sort()).toEqual(['skill-a', 'skill-b'])
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Item 4: load() distinguishes ENOENT (expected first run) from a
+  // corrupt/unreadable manifest (should throw, not silently go empty)
+  // --------------------------------------------------------------------------
+
+  describe('load() distinguishes missing vs corrupt manifest', () => {
+    it('returns an empty manifest when the file does not exist (ENOENT — expected first run)', async () => {
+      const loaded = await manager.load()
+      expect(loaded).toEqual({ version: '1.0.0', installedSkills: {} })
+    })
+
+    it('throws (does not silently return an empty manifest) when the file contains unparseable JSON', async () => {
+      await fs.writeFile(manifestPath, '{ not valid json')
+      await expect(manager.load()).rejects.toThrow(/corrupt|unparseable/i)
+    })
+
+    it('rethrows a non-ENOENT read error (e.g. EACCES) instead of returning an empty manifest', async () => {
+      const permissionError = Object.assign(new Error('EACCES: permission denied'), {
+        code: 'EACCES',
+      })
+      vi.mocked(fs.readFile).mockRejectedValueOnce(permissionError)
+
+      await expect(manager.load()).rejects.toThrow('EACCES')
+    })
+  })
+
+  // --------------------------------------------------------------------------
+  // Item 5: inject a write/rename failure — verify the unique-temp-file
+  // cleanup removes only that invocation's own temp file and the original
+  // error still propagates (not swallowed)
+  // --------------------------------------------------------------------------
+
+  describe('save() write/rename failure cleanup', () => {
+    it('on a writeFile failure, the temp file is cleaned up and the original error propagates', async () => {
+      const originalError = new Error('ENOSPC: no space left on device')
+      vi.mocked(fs.writeFile).mockRejectedValueOnce(originalError)
+
+      await expect(manager.save({ version: '1.0.0', installedSkills: {} })).rejects.toThrow(
+        originalError
+      )
+
+      const files = await fs.readdir(tmpDir).catch(() => [])
+      expect(files.some((f) => f.includes('.tmp.'))).toBe(false)
+    })
+
+    it('on a rename failure, the temp file is cleaned up, the original error propagates, and the manifest is untouched', async () => {
+      await manager.save({
+        version: '1.0.0',
+        installedSkills: { existing: makeEntry({ id: 'existing' }) },
+      })
+
+      const originalError = new Error('EPERM: operation not permitted')
+      vi.mocked(fs.rename).mockRejectedValueOnce(originalError)
+
+      await expect(
+        manager.save({ version: '1.0.0', installedSkills: { other: makeEntry({ id: 'other' }) } })
+      ).rejects.toThrow(originalError)
+
+      const loaded = await manager.load()
+      expect(Object.keys(loaded.installedSkills)).toEqual(['existing'])
+
+      const files = await fs.readdir(tmpDir)
+      expect(files.some((f) => f.includes('.tmp.'))).toBe(false)
+    })
+
+    it('a failed save() only removes its own temp file, leaving a concurrently in-flight one untouched', async () => {
+      // call A's rename fails and must be cleaned up; call B's rename must
+      // succeed normally. Because each call's temp filename is now
+      // per-invocation-unique (SMI-6007), A's cleanup cannot touch B's file.
+      // mockRejectedValueOnce queues exactly one rejection ahead of the
+      // default (real) implementation, so whichever of the two concurrent
+      // renames happens to run first gets it — order isn't asserted below.
+      vi.mocked(fs.rename).mockRejectedValueOnce(new Error('simulated rename failure for call A'))
+
+      const callA = manager.save({
+        version: '1.0.0',
+        installedSkills: { a: makeEntry({ id: 'a' }) },
+      })
+      const callB = manager.save({
+        version: '1.0.0',
+        installedSkills: { b: makeEntry({ id: 'b' }) },
+      })
+
+      const results = await Promise.allSettled([callA, callB])
+
+      // Order between the two concurrent calls isn't guaranteed by real fs
+      // I/O scheduling — assert the invariant that matters: exactly one
+      // call's rename failed (and was cleaned up), the other succeeded, and
+      // no cross-contamination between their distinct temp files occurred.
+      const rejected = results.filter((r) => r.status === 'rejected')
+      const fulfilled = results.filter((r) => r.status === 'fulfilled')
+      expect(rejected).toHaveLength(1)
+      expect(fulfilled).toHaveLength(1)
+
+      const files = await fs.readdir(tmpDir)
+      expect(files.some((f) => f.includes('.tmp.'))).toBe(false)
+    })
+  })
+})

--- a/packages/core/src/services/skill-manifest.ts
+++ b/packages/core/src/services/skill-manifest.ts
@@ -6,6 +6,7 @@
 
 import * as fs from 'fs/promises'
 import * as path from 'path'
+import { randomUUID } from 'node:crypto'
 
 import type { SkillManifest } from './skill-installation.types.js'
 
@@ -19,20 +20,64 @@ const MANIFEST_LOCK_RETRY_MS = 100
 export class ManifestManager {
   constructor(private readonly manifestPath: string) {}
 
+  /**
+   * SMI-6007: distinguishes "no manifest yet" (ENOENT — legitimate first-run
+   * case, safe to synthesize an empty manifest) from "a manifest file exists
+   * but couldn't be read/parsed" (corrupt JSON, permission error, I/O
+   * failure). The latter used to be silently swallowed into the same empty
+   * manifest, which is a real data-loss risk: a caller that then `save()`s
+   * that empty snapshot back out would erase every previously-recorded
+   * install. Now it throws loudly instead, so a corrupt manifest surfaces as
+   * an error rather than silently wiping state on the next write.
+   */
   async load(): Promise<SkillManifest> {
+    let content: string
     try {
-      const content = await fs.readFile(this.manifestPath, 'utf-8')
+      content = await fs.readFile(this.manifestPath, 'utf-8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { version: '1.0.0', installedSkills: {} }
+      }
+      throw error
+    }
+
+    try {
       return JSON.parse(content)
-    } catch {
-      return { version: '1.0.0', installedSkills: {} }
+    } catch (error) {
+      throw new Error(
+        'Manifest file at ' +
+          this.manifestPath +
+          ' exists but is corrupt/unparseable: ' +
+          (error instanceof Error ? error.message : String(error))
+      )
     }
   }
 
+  /**
+   * SMI-6007: the temp filename now includes a `randomUUID()` suffix (not
+   * just `process.pid`) — two concurrent `save()` calls in the same process
+   * previously collided on an identical `.tmp.<pid>` path, letting one
+   * call's temp file win the write while the other's `rename()` either
+   * clobbered it mid-flight or failed outright. Each call now owns a
+   * uniquely-named temp file for its own lifetime. The write+rename is
+   * wrapped in try/catch so a failure best-effort removes only *this
+   * invocation's* temp file before rethrowing the original error (mirrors
+   * `sqljsDriver.ts`'s `persist()`, SMI-5997) — the error is never swallowed.
+   */
   async save(manifest: SkillManifest): Promise<void> {
     await fs.mkdir(path.dirname(this.manifestPath), { recursive: true })
-    const tempPath = this.manifestPath + '.tmp.' + process.pid
-    await fs.writeFile(tempPath, JSON.stringify(manifest, null, 2))
-    await fs.rename(tempPath, this.manifestPath)
+    const tempPath = this.manifestPath + '.tmp.' + process.pid + '.' + randomUUID()
+    try {
+      await fs.writeFile(tempPath, JSON.stringify(manifest, null, 2))
+      await fs.rename(tempPath, this.manifestPath)
+    } catch (error) {
+      try {
+        await fs.unlink(tempPath)
+      } catch {
+        // best-effort cleanup — surface the original error either way
+      }
+      throw error
+    }
   }
 
   async acquireLock(): Promise<void> {


### PR DESCRIPTION
## Business Summary

**What shipped:** Closed two real concurrency gaps in how the skill manifest gets written to disk. Uninstalling a skill could previously overwrite an unrelated install recorded moments earlier by a concurrent operation. Two simultaneous manifest writes in the same process could also collide on an identical temp filename, corrupting one of them.

**Quality bar:** Found while investigating an unrelated flaky test (SMI-6004), then independently reviewed by a cross-model (GPT-5.6-Sol) pass that confirmed both hazards were real, corrected the proposed test coverage, and flagged the fix's actual scope boundary explicitly (see below). 54 new/modified tests added and passing; full `packages/core` (5456 tests) and `packages/cli` (971 tests) suites pass; typecheck/lint/format clean.

**Found along the way:** the review also flagged that `ManifestManager.acquireLock()`'s 30-second stale-lock reclaim has no liveness check before reclaiming — a real latent concern, deliberately left out of this PR's scope; noted here rather than silently fixed or silently dropped, for a separate decision on whether it needs its own issue.

**Net result:** Fully shipped for the two confirmed hazards. The stale-lock-reclaim item above is the one explicit follow-up, not yet tracked as its own issue.

---

## Technical detail

- `packages/core/src/services/skill-installation.helpers.ts`: `performUninstall()`'s final manifest mutation now goes through `ManifestManager.updateSafely()` (lock + fresh re-read + save) instead of saving a snapshot loaded earlier in the method. Explicitly scoped in a code comment: this prevents loss of *unrelated* manifest entries, not full atomicity of the whole uninstall sequence — a same-key install/uninstall race can still leave disk and manifest inconsistent.
- `packages/core/src/services/skill-manifest.ts` and `packages/cli/src/utils/manifest.ts`: both manifest writers' temp filenames now include a random UUID suffix (previously just the process id, which two concurrent same-process writes could collide on), with try/catch cleanup that removes only that invocation's own temp file on failure without swallowing the original error.
- `ManifestManager.load()` now distinguishes a missing file (legitimate, returns an empty manifest) from a file that exists but is corrupt/unreadable (throws loudly instead of silently returning empty — the old behavior risked a subsequent save silently erasing real state).
- New test file `packages/core/src/services/skill-manifest.test.ts`, plus additions to `skill-installation.helpers.test.ts` and `packages/cli/src/utils/manifest.test.ts`, covering: overlapping saves, concurrent `updateSafely()` on distinct keys, corrupt-file load behavior, injected write/rename failure cleanup, and the core regression case (uninstall racing a concurrent update to an unrelated entry).

Split from SMI-6004 per cross-model review recommendation — this is production hardening, not the cause of that flaky test.

Refs SMI-6007