### PR TITLE
feat(indexer): SMI-5879 Wave 4 -- id-targeted stale-quarantine remediation

### DIFF
--- a/scripts/indexer/revalidate-stale-quarantines.cli.ts
+++ b/scripts/indexer/revalidate-stale-quarantines.cli.ts
@@ -25,8 +25,15 @@ import { readFileSync } from 'node:fs'
 export interface IdSelection {
   /** Cutoff over the discovered cohort in ascending-id page order. Mutually exclusive with `ids`. */
   limit?: number
-  /** Deduped, order-preserving explicit id allowlist. Mutually exclusive with `limit`. */
+  /** Deduped, order-preserving explicit id allowlist ("requested_unique"). Mutually exclusive with `limit`. */
   ids?: string[]
+  /**
+   * Count of validated tokens BEFORE dedup ("requested_raw", design §11.2.3:
+   * "duplicate ids → deduped, order-preserving; requested_raw and
+   * requested_unique both reported"). Deduping silently would hide genuine
+   * duplicate input from the operator. Present only when `ids` is present.
+   */
+  requestedRawCount?: number
 }
 
 /** Only letters, digits, `_`, `-` are permitted in an id token; length 1..64. */
@@ -174,7 +181,7 @@ export function parseIdSelection(argv: string[]): IdSelection {
   }
 
   const validated = rawTokens.map(validateToken)
-  return { ids: dedupeOrderPreserving(validated) }
+  return { ids: dedupeOrderPreserving(validated), requestedRawCount: validated.length }
 }
 
 // ---------------------------------------------------------------------------
@@ -186,8 +193,10 @@ export const PREDICATE_CLAUSES_BANNER =
   "quarantined = true AND repo_url ILIKE 'https://github.com/%' AND (quarantine_reason IS NULL OR quarantine_reason = 'stale')"
 
 export interface IdReconciliation {
-  /** Parsed ids after dedupe (phase 1 output), unchanged. */
+  /** Parsed ids after dedupe (phase 1 output), unchanged — "requested_unique" (design §11.2.3). */
   requested: string[]
+  /** Count of validated tokens BEFORE dedupe — "requested_raw" (design §11.2.3). */
+  requestedRawCount: number
   /** requested ∩ predicate — the ids `loadCandidates` actually returned rows for. */
   loaded: string[]
   /** requested \ loaded — skipped and reported, never force-processed. */
@@ -214,6 +223,7 @@ export interface IdReconciliation {
  */
 export function reconcileIdSelection(
   requestedIds: readonly string[],
+  requestedRawCount: number,
   loadedRows: readonly { id: string }[],
   apply: boolean
 ): IdReconciliation {
@@ -241,13 +251,13 @@ export function reconcileIdSelection(
     )
   }
 
-  return { requested: [...requestedIds], loaded: loadedIds, notLoaded, status }
+  return { requested: [...requestedIds], requestedRawCount, loaded: loadedIds, notLoaded, status }
 }
 
 /** Format the id-selection summary + `not-loaded` section (design §11.2.5) for console output. */
 export function formatIdSelectionReport(reconciliation: IdReconciliation): string {
   const lines: string[] = [
-    `\nid-selection: requested=${reconciliation.requested.length} loaded=${reconciliation.loaded.length} not-loaded=${reconciliation.notLoaded.length} status=${reconciliation.status}`,
+    `\nid-selection: requested_raw=${reconciliation.requestedRawCount} requested_unique=${reconciliation.requested.length} loaded=${reconciliation.loaded.length} not-loaded=${reconciliation.notLoaded.length} status=${reconciliation.status}`,
   ]
   if (reconciliation.notLoaded.length > 0) {
     lines.push(
@@ -256,4 +266,27 @@ export function formatIdSelectionReport(reconciliation: IdReconciliation): strin
     for (const id of reconciliation.notLoaded) lines.push(`  - ${id}`)
   }
   return lines.join('\n') + '\n'
+}
+
+/**
+ * Reconcile + print the id-selection report, if an id selection was given.
+ * Wraps {@link reconcileIdSelection} + {@link formatIdSelectionReport} +
+ * `console.log` in one call so the main file's `runSweep` doesn't need to
+ * import either directly — keeps the id-selection/reconciliation logic
+ * fully inside this sibling (design §11.2.8's line-budget split).
+ */
+export function reportIdSelectionIfPresent(
+  ids: readonly string[] | undefined,
+  requestedRawCount: number | undefined,
+  loadedRows: readonly { id: string }[],
+  apply: boolean
+): void {
+  if (ids === undefined) return
+  const reconciliation = reconcileIdSelection(
+    ids,
+    requestedRawCount ?? ids.length,
+    loadedRows,
+    apply
+  )
+  console.log(formatIdSelectionReport(reconciliation))
 }

--- a/scripts/indexer/revalidate-stale-quarantines.cli.ts
+++ b/scripts/indexer/revalidate-stale-quarantines.cli.ts
@@ -1,0 +1,259 @@
+/**
+ * CLI argument parsing and id-selection reconciliation for
+ * revalidate-stale-quarantines.ts, split out (SMI-5879 round-7, design doc
+ * §11.2.8) to keep that file under its line budget.
+ *
+ * Two phases (design §11.2.3), with different guarantees:
+ *
+ *  - Phase 1 ({@link parseIdSelection}): PURE — argv only, plus exactly one
+ *    `fs.readFileSync` call for `--ids-file`. Throws synchronously on any
+ *    invalid input, so the process dies before `createSupabaseAdminClient()`
+ *    is ever constructed. No console output, no DB touch, no network.
+ *  - Phase 2 ({@link reconcileIdSelection} / {@link formatIdSelectionReport}):
+ *    runs AFTER the single candidate read (`loadCandidates`) and BEFORE the
+ *    processing loop — a refusal here still precedes every write in the
+ *    file.
+ */
+
+import { readFileSync } from 'node:fs'
+
+// ---------------------------------------------------------------------------
+// Phase 1 — pure argv/file parsing
+// ---------------------------------------------------------------------------
+
+/** Parsed CLI selection, ready to hand to `loadCandidates`/`runSweep`. */
+export interface IdSelection {
+  /** Cutoff over the discovered cohort in ascending-id page order. Mutually exclusive with `ids`. */
+  limit?: number
+  /** Deduped, order-preserving explicit id allowlist. Mutually exclusive with `limit`. */
+  ids?: string[]
+}
+
+/** Only letters, digits, `_`, `-` are permitted in an id token; length 1..64. */
+const ID_TOKEN_RE = /^[A-Za-z0-9_-]{1,64}$/
+
+/**
+ * Dual `--flag value` / `--flag=value` parse, matching `purge-dead-quarantines.ts`'s
+ * `parseLimitArg`/`parseExportArg` convention. Returns `undefined` only when
+ * `flag` is entirely ABSENT from argv. If `flag` IS present but supplies no
+ * value — a bare flag as the last token, or immediately followed by another
+ * `--flag` — this THROWS rather than returning `undefined`: collapsing
+ * "present with no value" into the same `undefined` as "absent" would let
+ * `--apply --ids` (or any of `--ids`/`--ids-file`/`--limit` given with no
+ * value) silently fall through to the unbounded whole-table sweep under
+ * `--apply` — the exact failure class this file's phase-1 validation exists
+ * to close (round-7-review finding, GPT-5.6-Sol adversarial pass).
+ */
+function findFlagValue(argv: string[], flag: string): string | undefined {
+  const idx = argv.findIndex((a) => a === flag || a.startsWith(`${flag}=`))
+  if (idx === -1) return undefined
+  const eq = argv[idx].split('=')[1]
+  if (eq !== undefined) return eq
+  const next = argv[idx + 1]
+  if (next === undefined || next.startsWith('--')) {
+    throw new Error(
+      `[revalidate-stale-quarantines] ${flag} was supplied with no value — refusing rather than treating it as absent.`
+    )
+  }
+  return next
+}
+
+function parseLimitValue(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : undefined
+}
+
+interface RawToken {
+  value: string
+  location: string
+}
+
+/** Validate one trimmed token; throws naming the offending token and its location. */
+function validateToken(token: RawToken): string {
+  const trimmed = token.value.trim()
+  if (trimmed.length === 0) {
+    throw new Error(
+      `[revalidate-stale-quarantines] empty id token at ${token.location} — refusing (phase 1).`
+    )
+  }
+  if (!ID_TOKEN_RE.test(trimmed)) {
+    const reason =
+      trimmed.length > 64
+        ? 'exceeds the 64-character limit'
+        : 'contains a disallowed character (only letters, digits, "_", "-" are permitted)'
+    throw new Error(
+      `[revalidate-stale-quarantines] id token at ${token.location} ${reason}: "${trimmed.slice(0, 80)}"`
+    )
+  }
+  return trimmed
+}
+
+/** Split `--ids=<a,b,c>` into raw (unvalidated) tokens. An all-whitespace value collapses to zero tokens. */
+function parseIdsArgTokens(raw: string): RawToken[] {
+  if (raw.trim().length === 0) return []
+  return raw.split(',').map((value, i) => ({ value, location: `--ids position ${i + 1}` }))
+}
+
+/**
+ * Read and tokenize `--ids-file`: one id per line; blank lines and lines
+ * whose first non-whitespace character is `#` are ignored. The single
+ * `fs.readFileSync` call for the whole module lives here.
+ */
+function readIdsFileTokens(path: string): RawToken[] {
+  let content: string
+  try {
+    content = readFileSync(path, 'utf8')
+  } catch (err) {
+    throw new Error(
+      `[revalidate-stale-quarantines] --ids-file path unreadable: ${path} (${
+        err instanceof Error ? err.message : String(err)
+      })`
+    )
+  }
+  const lines = content.split('\n')
+  const tokens: RawToken[] = []
+  for (let i = 0; i < lines.length; i++) {
+    const trimmedForCheck = lines[i].trim()
+    if (trimmedForCheck.length === 0) continue // blank line
+    if (trimmedForCheck.startsWith('#')) continue // comment
+    tokens.push({ value: lines[i], location: `--ids-file line ${i + 1}` })
+  }
+  return tokens
+}
+
+/** Dedupe an array, preserving first-occurrence order. */
+function dedupeOrderPreserving(values: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const v of values) {
+    if (seen.has(v)) continue
+    seen.add(v)
+    out.push(v)
+  }
+  return out
+}
+
+/**
+ * Phase-1 (pure) CLI parser. Throws on: `--ids` + `--ids-file` both present;
+ * an id selection together with `--limit`; an unreadable `--ids-file`; any
+ * token failing shape validation; or a selection parsing to ZERO ids — the
+ * single most important check (design §11.2.3): an empty selection must
+ * NEVER fall through to the unbounded whole-table sweep.
+ */
+export function parseIdSelection(argv: string[]): IdSelection {
+  const idsArg = findFlagValue(argv, '--ids')
+  const idsFileArg = findFlagValue(argv, '--ids-file')
+  const limitArg = findFlagValue(argv, '--limit')
+
+  if (idsArg !== undefined && idsFileArg !== undefined) {
+    throw new Error(
+      '[revalidate-stale-quarantines] --ids and --ids-file are mutually exclusive — supply exactly one recorded source of truth.'
+    )
+  }
+
+  const hasIdSelection = idsArg !== undefined || idsFileArg !== undefined
+
+  if (hasIdSelection && limitArg !== undefined) {
+    throw new Error(
+      '[revalidate-stale-quarantines] --limit is mutually exclusive with --ids/--ids-file — composing them would silently truncate the requested id set (design §11.2.2).'
+    )
+  }
+
+  if (!hasIdSelection) {
+    return { limit: parseLimitValue(limitArg) }
+  }
+
+  const rawTokens =
+    idsArg !== undefined ? parseIdsArgTokens(idsArg) : readIdsFileTokens(idsFileArg as string)
+
+  if (rawTokens.length === 0) {
+    throw new Error(
+      '[revalidate-stale-quarantines] the --ids/--ids-file selection parsed to zero ids — refusing. An empty selection must never fall through to the unbounded whole-table sweep.'
+    )
+  }
+
+  const validated = rawTokens.map(validateToken)
+  return { ids: dedupeOrderPreserving(validated) }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 — post-read, pre-write reconciliation
+// ---------------------------------------------------------------------------
+
+/** Human-readable statement of the fixed predicate, for the not-loaded banner. */
+export const PREDICATE_CLAUSES_BANNER =
+  "quarantined = true AND repo_url ILIKE 'https://github.com/%' AND (quarantine_reason IS NULL OR quarantine_reason = 'stale')"
+
+export interface IdReconciliation {
+  /** Parsed ids after dedupe (phase 1 output), unchanged. */
+  requested: string[]
+  /** requested ∩ predicate — the ids `loadCandidates` actually returned rows for. */
+  loaded: string[]
+  /** requested \ loaded — skipped and reported, never force-processed. */
+  notLoaded: string[]
+  status: 'complete' | 'partial'
+}
+
+/**
+ * Reconcile the requested id set against what `loadCandidates` actually
+ * loaded (design §11.2.5). Two independent checks:
+ *
+ *  1. `loaded ⊆ requested` — structural, asserted in BOTH dry-run and apply
+ *     mode. Intersection makes this true by construction, so a violation can
+ *     only mean a chunking or filter-composition bug leaking an unrequested
+ *     row into the write path; refusing converts that from a silent
+ *     production write into a loud failure.
+ *  2. Disposition of a non-empty `notLoaded` set — asymmetric by mode.
+ *     Dry-run NEVER fails on it (dry-run is the discovery step). `--apply`
+ *     throws HERE, before the caller's processing loop runs, so a divergence
+ *     between what the operator asserted and what will be written can never
+ *     pass unnoticed into a runbook checkbox. There is deliberately no
+ *     override flag — the forward path for a benign divergence is pruning
+ *     the id from the file.
+ */
+export function reconcileIdSelection(
+  requestedIds: readonly string[],
+  loadedRows: readonly { id: string }[],
+  apply: boolean
+): IdReconciliation {
+  const requestedSet = new Set(requestedIds)
+  const loadedIds = loadedRows.map((r) => r.id)
+
+  const unrequested = loadedIds.filter((id) => !requestedSet.has(id))
+  if (unrequested.length > 0) {
+    throw new Error(
+      `[revalidate-stale-quarantines] loadCandidates returned id(s) not present in the requested set: ${unrequested.join(
+        ', '
+      )} — refusing. This indicates a chunking or filter-composition bug, not a legitimate outcome (design §11.2.5's loaded ⊆ requested invariant).`
+    )
+  }
+
+  const loadedSet = new Set(loadedIds)
+  const notLoaded = requestedIds.filter((id) => !loadedSet.has(id))
+  const status: 'complete' | 'partial' = notLoaded.length === 0 ? 'complete' : 'partial'
+
+  if (apply && notLoaded.length > 0) {
+    throw new Error(
+      `[revalidate-stale-quarantines] --apply refused: ${notLoaded.length} requested id(s) did not match the fixed predicate (${PREDICATE_CLAUSES_BANNER}): ${notLoaded.join(
+        ', '
+      )}. No writes were made. Prune these ids from the file (recording why) and re-run, or investigate why they diverged — there is no override flag.`
+    )
+  }
+
+  return { requested: [...requestedIds], loaded: loadedIds, notLoaded, status }
+}
+
+/** Format the id-selection summary + `not-loaded` section (design §11.2.5) for console output. */
+export function formatIdSelectionReport(reconciliation: IdReconciliation): string {
+  const lines: string[] = [
+    `\nid-selection: requested=${reconciliation.requested.length} loaded=${reconciliation.loaded.length} not-loaded=${reconciliation.notLoaded.length} status=${reconciliation.status}`,
+  ]
+  if (reconciliation.notLoaded.length > 0) {
+    lines.push(
+      `\nnot-loaded — requested id(s) that did not match the fixed predicate (${PREDICATE_CLAUSES_BANNER}):`
+    )
+    for (const id of reconciliation.notLoaded) lines.push(`  - ${id}`)
+  }
+  return lines.join('\n') + '\n'
+}

--- a/scripts/indexer/revalidate-stale-quarantines.load.ts
+++ b/scripts/indexer/revalidate-stale-quarantines.load.ts
@@ -1,0 +1,168 @@
+/**
+ * Candidate-loading for revalidate-stale-quarantines.ts, split out (SMI-5879
+ * round-7, design doc §11.2.8) to keep that file under its line budget.
+ * Re-exported from revalidate-stale-quarantines.ts so existing importers
+ * (guards.test.ts) are unaffected — mirrors the `.types.ts:1-7` convention
+ * already established at that file's own re-export line.
+ *
+ * Two load paths, both over the SAME fixed predicate:
+ *  - Paginated (`opts.limit` or unbounded): pages past PostgREST's 1000-row
+ *    cap in ascending-id order.
+ *  - Id-mode (`opts.ids`): design §11.2.4 — the id list INTERSECTS the fixed
+ *    predicate, never bypasses it. See {@link LoadCandidatesOptions}'s doc
+ *    comment for the three source-grounded safety reasons a bypass would be
+ *    a real production-security bug, not merely an inconvenience.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { IN_QUERY_BATCH_SIZE } from './batch-utils.ts'
+import type { StaleQuarantinedRow } from './revalidate-stale-quarantines.types.ts'
+
+/** PostgREST caps a single response at 1000 rows; the candidate set is larger. */
+export const PAGE_SIZE = 1000
+
+/**
+ * Columns `loadCandidates` reads off `skills`, shared verbatim by both the
+ * paginated and id-mode query paths so the two can never silently drift.
+ */
+const CANDIDATE_SELECT_COLUMNS =
+  'id, author, name, repo_url, skill_path, quarantine_reason, security_findings'
+
+/**
+ * Options for {@link loadCandidates}. `limit` and `ids` are mutually
+ * exclusive — enforced in phase 1 of CLI parsing
+ * (`revalidate-stale-quarantines.cli.ts`'s `parseIdSelection`), before any DB
+ * client exists, so `loadCandidates` itself does not need to re-check it.
+ */
+export interface LoadCandidatesOptions {
+  /** Cutoff over the discovered cohort in ascending-id page order. Mutually exclusive with `ids`. */
+  limit?: number
+  /**
+   * Explicit id allowlist. INTERSECTED with the fixed predicate below —
+   * NEVER a bypass of it (design doc §11.2.4). A bypass would be a real
+   * production-security bug, forced by three source facts:
+   *  1. `loadCandidates` does not select `quarantined`, so every row it
+   *     returns carries `quarantined === undefined` and `processRow` routes
+   *     it down the fail-closed sibling-rescan arm, whose precondition
+   *     ("already known to satisfy quarantined = true") would be false for
+   *     a bypassed row.
+   *  2. `writeSiblingRequarantine` has NO `quarantined` CAS guard — it would
+   *     unconditionally quarantine a live, healthy skill reached via a
+   *     bypass and judged malicious by the sibling scan.
+   *  3. `repo_url ILIKE 'https://github.com/%'` is a precondition of
+   *     `parseSkillMdUrl`; a bypassed non-GitHub row would be
+   *     `retagUnreachable`'d as "Repository deleted or not found" — a write
+   *     that mislabels a healthy row. And the `quarantine_reason` clause is
+   *     what keeps security-quarantined rows out of the sweep at all.
+   *
+   * When set, `loadCandidates` chunks the id list at `IN_QUERY_BATCH_SIZE`
+   * and issues one `.in('id', chunk)` query per chunk — sequentially, never
+   * concurrently, and never via `.range()` (chunks are ≤100 rows, far under
+   * `PAGE_SIZE`). Round-7-review correction (design §11.2.6): this does NOT
+   * reuse `batchedIn()` (`batch-utils.ts`) — that helper discards a
+   * PostgREST/network `error` and silently returns `[]`, indistinguishable
+   * from "no row in this chunk matched the filter." That would let a
+   * transient query failure masquerade as a genuine `not-loaded` id (design
+   * §11.2.5) that an operator could then prune from an `--ids-file` without
+   * the row ever having actually been checked — 11.1's exact failure class,
+   * reintroduced by the fix meant to close it. `batchedIn()` itself is
+   * untouched by this change; its error-swallowing is filed separately as
+   * SMI-T.
+   */
+  ids?: readonly string[]
+}
+
+/**
+ * Load all stale-quarantined candidates.
+ *
+ * Candidate set (both paths): `quarantined = true` AND `repo_url ILIKE
+ * 'https://github.com/%'` AND (`quarantine_reason IS NULL` OR
+ * `quarantine_reason = 'stale'`). `quarantine_reason IS NULL` covers legacy
+ * rows quarantined before the reason column was populated; `'stale'` is what
+ * the stale-reconciliation path writes.
+ *
+ * `opts.ids`, when present, selects the id-mode path (see
+ * {@link LoadCandidatesOptions.ids}); otherwise the paginated path applies
+ * `opts.limit` as a page-arithmetic cutoff over the ascending-id ordering.
+ */
+export async function loadCandidates(
+  db: SupabaseClient,
+  opts: LoadCandidatesOptions = {}
+): Promise<StaleQuarantinedRow[]> {
+  if (opts.ids !== undefined) return loadCandidatesByIds(db, opts.ids)
+  return loadCandidatesPaginated(db, opts.limit)
+}
+
+/**
+ * Paginated whole-cohort load, ordered by `id` (stable PK) so page
+ * boundaries are consistent. ALL rows are collected before the caller
+ * processes them, so apply-mode mutations (which drop rows out of the
+ * candidate set) cannot shift later page offsets.
+ */
+async function loadCandidatesPaginated(
+  db: SupabaseClient,
+  limit?: number
+): Promise<StaleQuarantinedRow[]> {
+  const out: StaleQuarantinedRow[] = []
+  for (let page = 0; ; page++) {
+    const remaining = limit === undefined ? PAGE_SIZE : Math.min(PAGE_SIZE, limit - out.length)
+    if (remaining <= 0) break
+    const from = page * PAGE_SIZE
+    const { data, error } = await db
+      .from('skills')
+      .select(CANDIDATE_SELECT_COLUMNS)
+      .eq('quarantined', true)
+      .ilike('repo_url', 'https://github.com/%')
+      .or('quarantine_reason.is.null,quarantine_reason.eq.stale')
+      .order('id', { ascending: true })
+      .range(from, from + remaining - 1)
+    if (error)
+      throw new Error(`Failed to load stale-quarantined rows (page ${page}): ${error.message}`)
+    const rows = (data ?? []) as StaleQuarantinedRow[]
+    out.push(...rows)
+    if (limit !== undefined && out.length >= limit) return out.slice(0, limit)
+    if (rows.length < remaining) break
+  }
+  return out
+}
+
+/**
+ * Id-mode candidate load (design §11.2.6, round-7-review correction).
+ * Chunks `ids` at `IN_QUERY_BATCH_SIZE` and issues one `.in('id', chunk)`
+ * query per chunk, sequentially — each chunk is `await`ed before the next
+ * runs, so an error on chunk N is thrown before chunk N+1 ever executes.
+ *
+ * Deliberately does NOT call `batchedIn()` — see
+ * {@link LoadCandidatesOptions.ids}'s doc comment. This loop destructures
+ * BOTH `data` and `error` and throws on a non-null `error` BEFORE `data` is
+ * read at all (a PostgREST timeout can return a non-null PARTIAL `data`
+ * alongside a non-null `error` — the `error` check must not be skipped just
+ * because `data` looks usable). Fatal in both dry-run and apply mode: unlike
+ * a genuine `not-loaded` divergence (design §11.2.5), a query error is never
+ * a legitimate outcome to report past.
+ */
+async function loadCandidatesByIds(
+  db: SupabaseClient,
+  ids: readonly string[]
+): Promise<StaleQuarantinedRow[]> {
+  const out: StaleQuarantinedRow[] = []
+  for (let i = 0; i < ids.length; i += IN_QUERY_BATCH_SIZE) {
+    const chunk = ids.slice(i, i + IN_QUERY_BATCH_SIZE)
+    const { data, error } = await db
+      .from('skills')
+      .select(CANDIDATE_SELECT_COLUMNS)
+      .eq('quarantined', true)
+      .ilike('repo_url', 'https://github.com/%')
+      .or('quarantine_reason.is.null,quarantine_reason.eq.stale')
+      .order('id', { ascending: true })
+      .in('id', chunk)
+    if (error) {
+      const chunkNumber = Math.floor(i / IN_QUERY_BATCH_SIZE) + 1
+      throw new Error(
+        `Failed to load stale-quarantined rows by id (chunk ${chunkNumber}, ids: ${chunk.join(', ')}): ${error.message}`
+      )
+    }
+    out.push(...((data ?? []) as StaleQuarantinedRow[]))
+  }
+  return out
+}

--- a/scripts/indexer/revalidate-stale-quarantines.ts
+++ b/scripts/indexer/revalidate-stale-quarantines.ts
@@ -34,11 +34,7 @@ import {
   writeSiblingRequarantine,
   writeSiblingRecovery,
 } from './revalidate-stale-quarantines.sibling.ts'
-import {
-  parseIdSelection,
-  reconcileIdSelection,
-  formatIdSelectionReport,
-} from './revalidate-stale-quarantines.cli.ts'
+import { parseIdSelection, reportIdSelectionIfPresent } from './revalidate-stale-quarantines.cli.ts'
 
 // ---------------------------------------------------------------------------
 // Types (split into revalidate-stale-quarantines.types.ts, SMI-5866)
@@ -331,16 +327,18 @@ export async function processRow(
  */
 export async function runSweep(
   db: SupabaseClient,
-  opts: { apply: boolean; limit?: number; ids?: readonly string[] }
+  opts: {
+    apply: boolean
+    limit?: number
+    ids?: readonly string[]
+    /** Count of ids before dedupe (design §11.2.3's "requested_raw"). Defaults to `ids.length` if omitted. */
+    requestedRawCount?: number
+  }
 ): Promise<SweepCounts> {
   const headers = await buildGitHubHeaders()
 
   const rows = await loadCandidates(db, { limit: opts.limit, ids: opts.ids })
-
-  if (opts.ids !== undefined) {
-    const reconciliation = reconcileIdSelection(opts.ids, rows, opts.apply)
-    console.log(formatIdSelectionReport(reconciliation))
-  }
+  reportIdSelectionIfPresent(opts.ids, opts.requestedRawCount, rows, opts.apply)
 
   const counts: SweepCounts = {
     total: rows.length,

--- a/scripts/indexer/revalidate-stale-quarantines.ts
+++ b/scripts/indexer/revalidate-stale-quarantines.ts
@@ -7,7 +7,14 @@
  * Safety: `--dry-run` is DEFAULT (`--apply` writes); CAS guards prevent double-flip;
  * run OUTSIDE the 00/06/12/18 UTC indexer cron window.
  *
- * Usage: varlock run -- npx tsx scripts/indexer/revalidate-stale-quarantines.ts [--apply] [--limit N]
+ * Usage: varlock run -- npx tsx scripts/indexer/revalidate-stale-quarantines.ts [--apply] [--limit N | --ids=<a,b,c> | --ids-file=<path>]
+ *
+ * `--ids`/`--ids-file` (SMI-5879 round-7): target the sweep at an explicit id
+ * set (e.g. a remediation report's excluded list), INTERSECTED with the fixed
+ * predicate below — never a bypass of it. Mutually exclusive with `--limit`
+ * and with each other. See `revalidate-stale-quarantines.cli.ts` and the
+ * design doc's §11 round-7 addendum for the full targeting/reconciliation
+ * contract.
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js'
@@ -27,6 +34,11 @@ import {
   writeSiblingRequarantine,
   writeSiblingRecovery,
 } from './revalidate-stale-quarantines.sibling.ts'
+import {
+  parseIdSelection,
+  reconcileIdSelection,
+  formatIdSelectionReport,
+} from './revalidate-stale-quarantines.cli.ts'
 
 // ---------------------------------------------------------------------------
 // Types (split into revalidate-stale-quarantines.types.ts, SMI-5866)
@@ -34,6 +46,14 @@ import {
 
 export type { StaleQuarantinedRow, StaleOutcome } from './revalidate-stale-quarantines.types.ts'
 import type { StaleQuarantinedRow, StaleOutcome } from './revalidate-stale-quarantines.types.ts'
+
+// ---------------------------------------------------------------------------
+// Candidate loading (split into revalidate-stale-quarantines.load.ts, SMI-5879 round-7)
+// ---------------------------------------------------------------------------
+
+export type { LoadCandidatesOptions } from './revalidate-stale-quarantines.load.ts'
+import { loadCandidates } from './revalidate-stale-quarantines.load.ts'
+export { loadCandidates }
 
 interface RowResult {
   row: StaleQuarantinedRow
@@ -298,60 +318,29 @@ export async function processRow(
 // Sweep orchestration
 // ---------------------------------------------------------------------------
 
-/** PostgREST caps a single response at 1000 rows; the candidate set is larger. */
-const PAGE_SIZE = 1000
-
-/**
- * Load all stale-quarantined candidates, paging past PostgREST's max-rows cap.
- *
- * Candidate set: `quarantined = true` AND `repo_url ILIKE 'https://github.com/%'`
- * AND (`quarantine_reason IS NULL` OR `quarantine_reason = 'stale'`).
- * `quarantine_reason IS NULL` covers legacy rows quarantined before the reason
- * column was populated; `'stale'` is what the stale-reconciliation path writes.
- *
- * Ordered by `id` (stable PK) so page boundaries are consistent. ALL rows are
- * collected before the caller processes them, so apply-mode mutations (which
- * drop rows out of the candidate set) cannot shift later page offsets.
- */
-export async function loadCandidates(
-  db: SupabaseClient,
-  limit?: number
-): Promise<StaleQuarantinedRow[]> {
-  const out: StaleQuarantinedRow[] = []
-  for (let page = 0; ; page++) {
-    const remaining = limit === undefined ? PAGE_SIZE : Math.min(PAGE_SIZE, limit - out.length)
-    if (remaining <= 0) break
-    const from = page * PAGE_SIZE
-    const { data, error } = await db
-      .from('skills')
-      .select('id, author, name, repo_url, skill_path, quarantine_reason, security_findings')
-      .eq('quarantined', true)
-      .ilike('repo_url', 'https://github.com/%')
-      .or('quarantine_reason.is.null,quarantine_reason.eq.stale')
-      .order('id', { ascending: true })
-      .range(from, from + remaining - 1)
-    if (error)
-      throw new Error(`Failed to load stale-quarantined rows (page ${page}): ${error.message}`)
-    const rows = (data ?? []) as StaleQuarantinedRow[]
-    out.push(...rows)
-    if (limit !== undefined && out.length >= limit) return out.slice(0, limit)
-    if (rows.length < remaining) break
-  }
-  return out
-}
-
 /**
  * Run the full stale-revalidation sweep. `db` is caller-constructed (SMI-Q,
  * design 11.2.7) so Gate C's client-construction ordering is observable in
  * `main()`, not hidden behind a second client built inside this function.
+ *
+ * `opts.ids` (round-7): when present, phase-2 reconciliation
+ * (`reconcileIdSelection`) runs between `loadCandidates` and the processing
+ * loop below — a refusal there (structural `loaded ⊆ requested` violation in
+ * either mode, or a non-empty `not-loaded` set under `--apply`) throws before
+ * any row is processed, so zero writes occur.
  */
 export async function runSweep(
   db: SupabaseClient,
-  opts: { apply: boolean; limit?: number }
+  opts: { apply: boolean; limit?: number; ids?: readonly string[] }
 ): Promise<SweepCounts> {
   const headers = await buildGitHubHeaders()
 
-  const rows = await loadCandidates(db, opts.limit)
+  const rows = await loadCandidates(db, { limit: opts.limit, ids: opts.ids })
+
+  if (opts.ids !== undefined) {
+    const reconciliation = reconcileIdSelection(opts.ids, rows, opts.apply)
+    console.log(formatIdSelectionReport(reconciliation))
+  }
 
   const counts: SweepCounts = {
     total: rows.length,
@@ -471,20 +460,20 @@ export async function runSweep(
 /** Parse CLI arguments and run the sweep. Skipped when imported by tests. */
 async function main(): Promise<void> {
   // SMI-5879 Gate C: env-sourced check first (no dependency on a DB round
-  // trip), then the client is constructed ONCE (round-7 SMI-Q — the same
-  // client Gate C's freeze-marker check reads is the same client runSweep()
-  // writes with, so the "immediately after client construction" ordering is
-  // observable in one function, not hidden behind a second, independently
-  // constructed client inside runSweep() — see the design doc 11.2.7).
+  // trip). Phase-1 id-selection parsing (round-7, design 11.2.7) runs next —
+  // it is PURE plus one fs.readFileSync, and throws on any invalid input, so
+  // a malformed --ids/--ids-file/--limit selection is refused before the
+  // client is ever constructed. The client is then constructed ONCE
+  // (round-7 SMI-Q — the same client Gate C's freeze-marker check reads is
+  // the same client runSweep() writes with, so the "immediately after client
+  // construction" ordering is observable in one function, not hidden behind
+  // a second, independently constructed client inside runSweep()).
   assertRunAllowed('revalidate')
+  const sel = parseIdSelection(process.argv)
   const db = createSupabaseAdminClient()
   await assertFreezeMarkerClear(db, 'revalidate')
   const apply = process.argv.includes('--apply')
-  const limitArg = process.argv.find((a) => a.startsWith('--limit'))
-  const limit = limitArg
-    ? Number(limitArg.split('=')[1] ?? process.argv[process.argv.indexOf(limitArg) + 1])
-    : undefined
-  await runSweep(db, { apply, limit: Number.isFinite(limit) ? limit : undefined })
+  await runSweep(db, { apply, ...sel })
 }
 
 // Run only when invoked directly (not when imported by the test suite).

--- a/scripts/tests/indexer/revalidate-stale-quarantines.guards.test.ts
+++ b/scripts/tests/indexer/revalidate-stale-quarantines.guards.test.ts
@@ -208,7 +208,7 @@ describe('loadCandidates — pagination', () => {
 
   it('respects an explicit limit without over-fetching', async () => {
     const rows = Array.from({ length: 1074 }, (_, i) => makeRow({ id: `id-${i}` }))
-    const loaded = await loadCandidates(makeSelectDb(rows) as never, 10)
+    const loaded = await loadCandidates(makeSelectDb(rows) as never, { limit: 10 })
     expect(loaded).toHaveLength(10)
   })
 })

--- a/scripts/tests/indexer/revalidate-stale-quarantines.ids.test.ts
+++ b/scripts/tests/indexer/revalidate-stale-quarantines.ids.test.ts
@@ -1,0 +1,648 @@
+/**
+ * SMI-5879 round-7: `--ids`/`--ids-file` targeting for the stale-quarantine
+ * revalidation escalation. Design doc §11 ("the escalation named in 8.3.5.3.4
+ * cannot target the rows it names") and the `##### 8.3.5.7 Required tests —
+ * remediation CAS and exclusion reporting` table's round-7-tagged rows.
+ *
+ * Covers:
+ *  - loadCandidates id-mode scopes to exactly the named rows regardless of
+ *    table-wide (lexicographic UUID) ordering, and is disjoint from the
+ *    `--limit`-based escalation this PR replaces.
+ *  - id-mode INTERSECTS the fixed predicate (quarantined=true, GitHub-only
+ *    repo_url, non-security quarantine_reason) — never bypasses it.
+ *  - `--ids`/`--ids-file`/`--limit` mutual exclusion, refused in phase 1
+ *    before any DB client is constructed.
+ *  - malformed/empty phase-1 input (table-driven).
+ *  - phase-2 reconciliation: not-loaded disposition (dry-run-safe,
+ *    apply-throws-before-processing-loop), and the structural
+ *    `loaded ⊆ requested` invariant.
+ *  - the id-mode chunk loader's error-propagating batch loop (never
+ *    `batchedIn()` — see revalidate-stale-quarantines.load.ts's doc comment).
+ *  - the round-7 file-split's line budget and shape constraints.
+ *
+ * Network is never touched: `fetchSkillMd` and `runSiblingRescan` are mocked
+ * deterministically-clean (same approach as
+ * revalidate-stale-quarantines.guards.test.ts), so `processRow`'s presence
+ * can be verified indirectly via fetch-call count/identity without spying a
+ * same-module function (`processRow`/`runSweep` live in the same file, which
+ * Vitest's ESM mocking cannot intercept for same-module calls).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { runSweep, loadCandidates } from '../../indexer/revalidate-stale-quarantines.ts'
+import type { StaleQuarantinedRow } from '../../indexer/revalidate-stale-quarantines.ts'
+import {
+  parseIdSelection,
+  reconcileIdSelection,
+  formatIdSelectionReport,
+} from '../../indexer/revalidate-stale-quarantines.cli.ts'
+import { IN_QUERY_BATCH_SIZE } from '../../indexer/batch-utils.ts'
+import { fetchSkillMd } from '../../indexer/_shared/skill-md-fetch.ts'
+import { readIndexerSource, hasShebang, hasDirectEntryGuard } from './run-gate-ast-helpers.ts'
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { createSupabaseAdminClientMock } = vi.hoisted(() => ({
+  createSupabaseAdminClientMock: vi.fn(() => {
+    throw new Error(
+      '[test] createSupabaseAdminClient must never be called from phase-1 parsing (parseIdSelection).'
+    )
+  }),
+}))
+
+vi.mock('../../indexer/_shared/supabase.ts', () => ({
+  createSupabaseAdminClient: createSupabaseAdminClientMock,
+}))
+
+// processRow's sibling-rescan step is mocked deterministically clean (same
+// pattern as guards.test.ts) so the clean-SKILL.md path reaches
+// 'sibling-recovered' without any real network call.
+vi.mock('../../indexer/revalidate-stale-quarantines.sibling.ts', async (importOriginal) => {
+  const real =
+    await importOriginal<typeof import('../../indexer/revalidate-stale-quarantines.sibling.ts')>()
+  return {
+    ...real,
+    runSiblingRescan: vi.fn(async () => ({
+      status: 'clean' as const,
+      findings: [],
+      mergedScore: 5,
+    })),
+  }
+})
+
+// fetchSkillMd is mocked to always resolve clean content; parseSkillMdUrl
+// stays real so `parsed.repo` (derived from each row's distinct repo_url)
+// can be used to map fetch calls back to row identity.
+vi.mock('../../indexer/_shared/skill-md-fetch.ts', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../../indexer/_shared/skill-md-fetch.ts')>()
+  const cleanContent = `---
+name: test-skill
+description: A helpful skill.
+---
+
+# Test Skill
+
+Run the following to use this skill:
+
+\`\`\`bash
+/test-skill --help
+\`\`\`
+`
+  return {
+    ...real,
+    fetchSkillMd: vi.fn(async () => ({ kind: 'content' as const, content: cleanContent })),
+  }
+})
+
+beforeEach(() => {
+  createSupabaseAdminClientMock.mockClear()
+  vi.mocked(fetchSkillMd).mockClear()
+})
+
+// ---------------------------------------------------------------------------
+// Shared fixtures — a filtering, chunk-aware mock Supabase client
+// ---------------------------------------------------------------------------
+
+interface FilterableRow extends StaleQuarantinedRow {
+  quarantined: boolean
+}
+
+function makeFilterableRow(id: string, overrides: Partial<FilterableRow> = {}): FilterableRow {
+  return {
+    id,
+    author: 'acme',
+    name: `skill-${id}`,
+    repo_url: `https://github.com/acme/skill-${id}`,
+    skill_path: null,
+    quarantine_reason: 'stale',
+    security_findings: [],
+    quarantined: true,
+    ...overrides,
+  }
+}
+
+interface ChunkErrorInjection {
+  /** 0-indexed `.in()` call number to fail on. */
+  atCallIndex: number
+  shape: 'null-data' | 'partial-data'
+}
+
+/** Strip the mock-only `quarantined` backing field, matching CANDIDATE_SELECT_COLUMNS's real projection (which never selects it). */
+function projectRow(row: FilterableRow): StaleQuarantinedRow {
+  const { quarantined, ...rest } = row
+  void quarantined
+  return rest
+}
+
+/**
+ * A mock Supabase client whose `.eq`/`.ilike`/`.or` calls accumulate real
+ * predicate functions applied at `.in()`/`.range()` resolution time — so a
+ * production regression that OMITS a predicate clause from the id-mode query
+ * (e.g. forgetting `.eq('quarantined', true)`) would let an excluded row
+ * leak through, and this mock would surface it (it does not hardcode "apply
+ * the whole fixed predicate" independent of what was actually chained).
+ */
+function makeFilterableDb(
+  rows: FilterableRow[],
+  opts: { errorInjection?: ChunkErrorInjection } = {}
+) {
+  const inCalls: string[][] = []
+  const rangeCalls: Array<[number, number]> = []
+  const eqCalls: Array<[string, unknown]> = []
+  const ilikeCalls: Array<[string, string]> = []
+  const orCalls: string[] = []
+  const writeCalls = { update: 0, insert: 0, delete: 0 }
+  let inCallCount = 0
+
+  function newBuilder() {
+    const predicates: Array<(r: FilterableRow) => boolean> = []
+    const chain = {
+      select: vi.fn(() => chain),
+      eq: vi.fn((col: string, val: unknown) => {
+        eqCalls.push([col, val])
+        predicates.push((r) => (r as unknown as Record<string, unknown>)[col] === val)
+        return chain
+      }),
+      ilike: vi.fn((col: string, pattern: string) => {
+        ilikeCalls.push([col, pattern])
+        const prefix = pattern.replace(/%$/, '').toLowerCase()
+        predicates.push((r) => {
+          const v = (r as unknown as Record<string, unknown>)[col]
+          return typeof v === 'string' && v.toLowerCase().startsWith(prefix)
+        })
+        return chain
+      }),
+      or: vi.fn((expr: string) => {
+        orCalls.push(expr)
+        // The only `.or()` expression this codebase issues here.
+        predicates.push((r) => r.quarantine_reason === null || r.quarantine_reason === 'stale')
+        return chain
+      }),
+      order: vi.fn(() => chain),
+      update: vi.fn(() => {
+        writeCalls.update++
+        return chain
+      }),
+      insert: vi.fn(() => {
+        writeCalls.insert++
+        return Promise.resolve({ data: null, error: null })
+      }),
+      delete: vi.fn(() => {
+        writeCalls.delete++
+        return chain
+      }),
+      in: vi.fn((_col: string, values: string[]) => {
+        inCalls.push(values)
+        const callIndex = inCallCount++
+        if (opts.errorInjection && opts.errorInjection.atCallIndex === callIndex) {
+          const error = { message: 'simulated PostgREST timeout' }
+          if (opts.errorInjection.shape === 'partial-data') {
+            const partial = rows
+              .filter((r) => values.includes(r.id))
+              .slice(0, 1)
+              .map(projectRow)
+            return Promise.resolve({ data: partial, error })
+          }
+          return Promise.resolve({ data: null, error })
+        }
+        const matches = rows
+          .filter((r) => values.includes(r.id) && predicates.every((p) => p(r)))
+          .map(projectRow)
+        return Promise.resolve({ data: matches, error: null })
+      }),
+      range: vi.fn((from: number, to: number) => {
+        rangeCalls.push([from, to])
+        const sorted = [...rows].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+        const matches = sorted.filter((r) => predicates.every((p) => p(r))).map(projectRow)
+        return Promise.resolve({ data: matches.slice(from, to + 1), error: null })
+      }),
+    }
+    return chain
+  }
+
+  const db = { from: vi.fn(() => newBuilder()) }
+  return { db, inCalls, rangeCalls, eqCalls, ilikeCalls, orCalls, writeCalls }
+}
+
+// ---------------------------------------------------------------------------
+// Row 1: id-mode scopes to exactly the named rows, regardless of table-wide
+// id ordering (round-7 regression test)
+// ---------------------------------------------------------------------------
+
+describe('loadCandidates / runSweep — id-mode scopes to exactly the named rows (round-7 regression test)', () => {
+  // 35 bulk ids ("id-000".."id-034") + 5 targets deliberately given the
+  // lexicographically LARGEST ids in the cohort ("id-zz0".."id-zz4") — the
+  // exact rows `--limit 5` (ascending-id order) would never select.
+  const bulkIds = Array.from({ length: 35 }, (_, i) => `id-${String(i).padStart(3, '0')}`)
+  const targetIds = ['id-zz0', 'id-zz1', 'id-zz2', 'id-zz3', 'id-zz4']
+  const allRows = [...bulkIds, ...targetIds].map((id) => makeFilterableRow(id))
+
+  it('(a) returns exactly the 5 target rows, set-equal', async () => {
+    const { db } = makeFilterableDb(allRows)
+    const loaded = await loadCandidates(db as never, { ids: targetIds })
+    expect(new Set(loaded.map((r) => r.id))).toEqual(new Set(targetIds))
+    expect(loaded).toHaveLength(5)
+  })
+
+  it('(b) runSweep processes exactly those 5 rows via processRow (proven via fetchSkillMd identity)', async () => {
+    const { db } = makeFilterableDb(allRows)
+    const counts = await runSweep(db as never, { apply: false, ids: targetIds })
+    expect(counts.total).toBe(5)
+    const fetchedRepos = new Set(vi.mocked(fetchSkillMd).mock.calls.map(([parsed]) => parsed.repo))
+    expect(fetchedRepos).toEqual(new Set(targetIds.map((id) => `skill-${id}`)))
+  })
+
+  it('(c) a control run with --limit 5 (no ids) returns a DISJOINT set — the defect this row exists to prevent', async () => {
+    const { db } = makeFilterableDb(allRows)
+    const loaded = await loadCandidates(db as never, { limit: 5 })
+    const loadedIds = new Set(loaded.map((r) => r.id))
+    const overlap = targetIds.filter((id) => loadedIds.has(id))
+    expect(overlap).toHaveLength(0)
+  })
+
+  it('(d) chunks .in() at IN_QUERY_BATCH_SIZE and never calls .range()', async () => {
+    const manyIds = Array.from({ length: 250 }, (_, i) => `id-${String(i).padStart(3, '0')}`)
+    const manyRows = manyIds.map((id) => makeFilterableRow(id))
+    const { db, inCalls, rangeCalls } = makeFilterableDb(manyRows)
+    const loaded = await loadCandidates(db as never, { ids: manyIds })
+    expect(loaded).toHaveLength(250)
+    expect(inCalls).toHaveLength(3)
+    expect(inCalls[0]).toHaveLength(IN_QUERY_BATCH_SIZE)
+    expect(inCalls[1]).toHaveLength(IN_QUERY_BATCH_SIZE)
+    expect(inCalls[2]).toHaveLength(50)
+    expect(rangeCalls).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Row 2: id-mode intersects the fixed predicate and never bypasses it
+// (round-7)
+// ---------------------------------------------------------------------------
+
+describe('loadCandidates / runSweep — id-mode intersects the fixed predicate, never bypasses it (round-7)', () => {
+  const okRow = makeFilterableRow('id-ok')
+  const failsQuarantined = makeFilterableRow('id-fail-quarantined', { quarantined: false })
+  const failsRepoHost = makeFilterableRow('id-fail-repo', { repo_url: 'https://gitlab.com/x/y' })
+  const failsReason = makeFilterableRow('id-fail-reason', {
+    quarantine_reason: 'malicious: prompt injection',
+  })
+
+  it.each([
+    ['quarantined = false', failsQuarantined],
+    ["repo_url not github.com ('https://gitlab.com/x/y')", failsRepoHost],
+    ["quarantine_reason not NULL/'stale'", failsReason],
+  ])(
+    'a row failing "%s" is excluded by loadCandidates, appears in not-loaded, and processRow is never invoked for it',
+    async (_label, badRow) => {
+      const requestedIds = [okRow.id, badRow.id]
+      const rows = [okRow, badRow]
+
+      const { db } = makeFilterableDb(rows)
+      const loaded = await loadCandidates(db as never, { ids: requestedIds })
+      expect(loaded.map((r) => r.id)).toEqual([okRow.id])
+
+      const { db: db2 } = makeFilterableDb(rows)
+      const counts = await runSweep(db2 as never, { apply: false, ids: requestedIds })
+      expect(counts.total).toBe(1)
+      const fetchedRepos = vi.mocked(fetchSkillMd).mock.calls.map(([parsed]) => parsed.repo)
+      expect(fetchedRepos).toContain(`skill-${okRow.id}`)
+      expect(fetchedRepos).not.toContain(`skill-${badRow.id}`)
+    }
+  )
+
+  it('the emitted query still contains all three fixed-predicate clauses in id-mode', async () => {
+    const { db, eqCalls, ilikeCalls, orCalls } = makeFilterableDb([okRow])
+    await loadCandidates(db as never, { ids: [okRow.id] })
+    expect(eqCalls).toContainEqual(['quarantined', true])
+    expect(ilikeCalls).toContainEqual(['repo_url', 'https://github.com/%'])
+    expect(orCalls).toContainEqual('quarantine_reason.is.null,quarantine_reason.eq.stale')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Row 3: --ids/--ids-file/--limit mutual exclusion, refused before any DB
+// touch (round-7)
+// ---------------------------------------------------------------------------
+
+describe('parseIdSelection — mutual exclusion, refused before any DB touch (round-7)', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'smi5879-ids-'))
+  })
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writeTmpFile(name: string, content: string): string {
+    const p = join(tmpDir, name)
+    writeFileSync(p, content, 'utf8')
+    return p
+  }
+
+  it('--ids-file (valid file) + --limit: throws naming both flags; createSupabaseAdminClient never called', () => {
+    const file = writeTmpFile('valid.txt', 'a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1\n')
+    expect(() =>
+      parseIdSelection(['node', 'script', `--ids-file=${file}`, '--limit', '50'])
+    ).toThrow(/--limit/i)
+    expect(createSupabaseAdminClientMock).not.toHaveBeenCalled()
+  })
+
+  it('--ids + --limit: throws naming both flags; createSupabaseAdminClient never called', () => {
+    expect(() => parseIdSelection(['node', 'script', '--ids=aaaa,bbbb', '--limit=50'])).toThrow(
+      /--limit/i
+    )
+    expect(createSupabaseAdminClientMock).not.toHaveBeenCalled()
+  })
+
+  it('--ids + --ids-file together: throws naming both flags; createSupabaseAdminClient never called', () => {
+    const file = writeTmpFile('valid2.txt', 'c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1\n')
+    expect(() => parseIdSelection(['node', 'script', '--ids=aaaa', `--ids-file=${file}`])).toThrow(
+      /--ids-file/i
+    )
+    expect(createSupabaseAdminClientMock).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Row 4: malformed and empty --ids input is rejected before any DB touch
+// (round-7)
+// ---------------------------------------------------------------------------
+
+describe('parseIdSelection — malformed and empty input rejected before any DB touch (round-7)', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'smi5879-ids-bad-'))
+  })
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writeTmpFile(name: string, content: string): string {
+    const p = join(tmpDir, name)
+    writeFileSync(p, content, 'utf8')
+    return p
+  }
+
+  it.each([
+    ['--ids= (empty)', () => ['--ids=']],
+    ['--ids-file nonexistent path', () => [`--ids-file=${join(tmpDir, 'does-not-exist.txt')}`]],
+    [
+      'file containing only # comments and blank lines',
+      () => [
+        `--ids-file=${writeTmpFile('comments.txt', '# nothing here\n\n   \n# still nothing\n')}`,
+      ],
+    ],
+    [
+      'a psql border-artifact line',
+      () => [
+        `--ids-file=${writeTmpFile('psql.txt', '| 8f3a1234-aaaa-bbbb-cccc-dddddddddddd |\n')}`,
+      ],
+    ],
+    [
+      'a token with an embedded space',
+      () => [`--ids-file=${writeTmpFile('space.txt', '8f3a 1234\n')}`],
+    ],
+    ['a 200-character token', () => [`--ids=${'a'.repeat(200)}`]],
+    ['--ids=a,,b (empty element)', () => ['--ids=a,,b']],
+    // Round-7-review finding (GPT-5.6-Sol adversarial pass): a bare flag with
+    // no following value must NOT collapse to "flag absent" — that would
+    // fall through to the unbounded whole-table sweep under --apply.
+    ['--ids with no value, as the last token', () => ['--apply', '--ids']],
+    ['--ids with no value, followed immediately by another flag', () => ['--ids', '--apply']],
+    ['--ids-file with no value, as the last token', () => ['--apply', '--ids-file']],
+    ['--limit with no value, as the last token', () => ['--limit']],
+  ])(
+    '%s: throws in phase 1; createSupabaseAdminClient never called; no fetch issued',
+    (_label, buildArgs) => {
+      expect(() => parseIdSelection(['node', 'script', ...buildArgs()])).toThrow()
+      expect(createSupabaseAdminClientMock).not.toHaveBeenCalled()
+      expect(vi.mocked(fetchSkillMd)).not.toHaveBeenCalled()
+    }
+  )
+
+  // The zero-ids case is asserted separately and explicitly (design §11.2.3):
+  // the failure mode it prevents is not "a bad run" but an UNBOUNDED one — a
+  // selection that parses to zero ids must never fall through to the
+  // whole-table sweep, so it needs its own distinguishable error, not a
+  // generic "no selection given" that a `--limit`-shaped path could inherit.
+  it('--ids= collapses to a dedicated zero-ids error, never "no selection given"', () => {
+    expect(() => parseIdSelection(['node', 'script', '--ids='])).toThrow(/zero ids/i)
+  })
+
+  it('a comments-only --ids-file collapses to the same dedicated zero-ids error', () => {
+    const file = writeTmpFile('only-comments.txt', '# nothing\n\n# still nothing\n')
+    expect(() => parseIdSelection(['node', 'script', `--ids-file=${file}`])).toThrow(/zero ids/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Row: no override flag exists in the source (part of the "skipped and
+// reported, never force-processed" row)
+// ---------------------------------------------------------------------------
+
+describe('no override flag exists in source (round-7)', () => {
+  it('revalidate-stale-quarantines.{ts,load.ts,cli.ts} contain no allow-partial/force/--yes-shaped identifier', () => {
+    for (const file of [
+      'revalidate-stale-quarantines.ts',
+      'revalidate-stale-quarantines.load.ts',
+      'revalidate-stale-quarantines.cli.ts',
+    ]) {
+      const source = readIndexerSource(file)
+      expect(source).not.toMatch(/allow-partial/i)
+      expect(source).not.toMatch(/--force\b/)
+      expect(source).not.toMatch(/--yes\b/)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Row 5: loaded ⊆ requested is enforced, not assumed (round-7, structural)
+// ---------------------------------------------------------------------------
+
+describe('reconcileIdSelection — loaded ⊆ requested is enforced, not assumed (round-7, structural)', () => {
+  it('refuses before the processing loop when a loaded id is not in the requested set, in BOTH modes', () => {
+    const requested = ['id-a', 'id-b']
+    const loadedRows = [{ id: 'id-a' }, { id: 'id-unexpected' }]
+    expect(() => reconcileIdSelection(requested, loadedRows, false)).toThrow(/id-unexpected/)
+    expect(() => reconcileIdSelection(requested, loadedRows, true)).toThrow(/id-unexpected/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Row 6: a requested id that does not match the predicate is skipped and
+// reported, never force-processed (round-7)
+// ---------------------------------------------------------------------------
+
+describe('a requested id that does not match the predicate is skipped and reported, never force-processed (round-7)', () => {
+  const passingIds = Array.from({ length: 7 }, (_, i) => `id-pass-${i}`)
+  const failingIds = ['id-fail-0', 'id-fail-1', 'id-fail-2']
+  const requested = [...passingIds, ...failingIds]
+
+  function buildRows(): FilterableRow[] {
+    return [
+      ...passingIds.map((id) => makeFilterableRow(id)),
+      ...failingIds.map((id) => makeFilterableRow(id, { quarantined: false })),
+    ]
+  }
+
+  it('dry-run: loaded=7, not-loaded=exactly the 3 failing ids, processRow invoked exactly 7 times, exits 0 (prints the divergence)', async () => {
+    const { db } = makeFilterableDb(buildRows())
+    const counts = await runSweep(db as never, { apply: false, ids: requested })
+    expect(counts.total).toBe(7)
+    const fetchedRepos = new Set(vi.mocked(fetchSkillMd).mock.calls.map(([parsed]) => parsed.repo))
+    expect(fetchedRepos.size).toBe(7)
+    for (const id of passingIds) expect(fetchedRepos.has(`skill-${id}`)).toBe(true)
+    for (const id of failingIds) expect(fetchedRepos.has(`skill-${id}`)).toBe(false)
+  })
+
+  it('reconcileIdSelection reports requested=10 loaded=7 not-loaded=3 (exactly the failing ids), status "partial"', () => {
+    const loadedRows = passingIds.map((id) => ({ id }))
+    const reconciliation = reconcileIdSelection(requested, loadedRows, false)
+    expect(reconciliation.requested).toHaveLength(10)
+    expect(reconciliation.loaded).toHaveLength(7)
+    expect(new Set(reconciliation.notLoaded)).toEqual(new Set(failingIds))
+    expect(reconciliation.status).toBe('partial')
+    const report = formatIdSelectionReport(reconciliation)
+    for (const id of failingIds) expect(report).toContain(id)
+  })
+
+  it('--apply: throws BEFORE the processing loop — zero fetches, zero writes', async () => {
+    const { db, writeCalls } = makeFilterableDb(buildRows())
+    await expect(runSweep(db as never, { apply: true, ids: requested })).rejects.toThrow(
+      /did not match the fixed predicate/i
+    )
+    expect(vi.mocked(fetchSkillMd)).not.toHaveBeenCalled()
+    expect(writeCalls.update).toBe(0)
+    expect(writeCalls.insert).toBe(0)
+    expect(writeCalls.delete).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Row 7: a chunk query error aborts before any write, in both modes, and is
+// never reported as not-loaded (round-7, added after review round 7)
+// ---------------------------------------------------------------------------
+
+describe('a chunk query error aborts before any write, in both modes, never reported as not-loaded (round-7, added after review round 7)', () => {
+  const ids = Array.from({ length: 5 }, (_, i) => `id-${i}`)
+
+  function buildRows(): FilterableRow[] {
+    return ids.map((id) => makeFilterableRow(id))
+  }
+
+  it.each([
+    ['{ data: null, error }', 'null-data' as const],
+    ['{ data: <partial rows>, error }', 'partial-data' as const],
+  ])(
+    '%s: throws before the processing loop in DRY-RUN mode; zero fetches',
+    async (_label, shape) => {
+      const { db } = makeFilterableDb(buildRows(), { errorInjection: { atCallIndex: 0, shape } })
+      await expect(runSweep(db as never, { apply: false, ids })).rejects.toThrow(
+        /simulated PostgREST timeout/i
+      )
+      expect(vi.mocked(fetchSkillMd)).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each([
+    ['{ data: null, error }', 'null-data' as const],
+    ['{ data: <partial rows>, error }', 'partial-data' as const],
+  ])('%s: throws before the processing loop in APPLY mode; zero writes', async (_label, shape) => {
+    const { db, writeCalls } = makeFilterableDb(buildRows(), {
+      errorInjection: { atCallIndex: 0, shape },
+    })
+    await expect(runSweep(db as never, { apply: true, ids })).rejects.toThrow(
+      /simulated PostgREST timeout/i
+    )
+    expect(vi.mocked(fetchSkillMd)).not.toHaveBeenCalled()
+    expect(writeCalls.update).toBe(0)
+    expect(writeCalls.insert).toBe(0)
+    expect(writeCalls.delete).toBe(0)
+  })
+
+  it('the thrown message names the failed chunk\'s ids and the underlying PostgREST error, never a generic "not found"', async () => {
+    const { db } = makeFilterableDb(buildRows(), {
+      errorInjection: { atCallIndex: 0, shape: 'null-data' },
+    })
+    let caught: Error | undefined
+    try {
+      await loadCandidates(db as never, { ids })
+    } catch (err) {
+      caught = err as Error
+    }
+    expect(caught).toBeDefined()
+    expect(caught?.message).toContain('simulated PostgREST timeout')
+    for (const id of ids) expect(caught?.message).toContain(id)
+  })
+
+  it('a chunk error never surfaces as a not-loaded id — the whole sweep rejects instead of reporting a divergence', async () => {
+    const { db } = makeFilterableDb(buildRows(), {
+      errorInjection: { atCallIndex: 0, shape: 'partial-data' },
+    })
+    await expect(runSweep(db as never, { apply: false, ids })).rejects.not.toThrow(/not-loaded/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Row 8: the round-7 split holds its shape (round-7, structural, mirrors
+// SMI-O's budget test)
+// ---------------------------------------------------------------------------
+
+/**
+ * Real (editor/`wc -l`-equivalent) line count. Deliberately NOT
+ * `content.split('\n').length` — see run-gate-line-budget.test.ts's
+ * identical helper for the off-by-one rationale.
+ */
+function countRealLines(content: string): number {
+  return content.endsWith('\n') ? content.split('\n').length - 1 : content.split('\n').length
+}
+
+describe('the round-7 split holds its shape (round-7, structural, mirrors SMI-O budget test)', () => {
+  // Measured after the round-7 split (design §11.2.8): PAGE_SIZE/
+  // loadCandidates moved to .load.ts; parseIdSelection/reconcileIdSelection/
+  // the report formatter moved to .cli.ts. Round 7 is net NON-INCREASING on
+  // this file versus its pre-round-7 (post-Wave-1) baseline of 496 lines —
+  // the design doc's own "480" baseline was already stale by the time this
+  // PR started (Wave 1 had already consumed that headroom); this budget is
+  // pinned to the file's REAL measured post-split line count, not the design
+  // doc's arithmetic. audit:standards Check 3 does NOT cover `scripts/`
+  // (`audit-standards.mjs:186`) and `warn()`s rather than `fail()`s where it
+  // does (`:248`, design §11.3.1) — this test is the ONLY enforcement.
+  const MAX_LINES = 485
+
+  it(`revalidate-stale-quarantines.ts stays at or under ${MAX_LINES} lines`, () => {
+    const lineCount = countRealLines(readIndexerSource('revalidate-stale-quarantines.ts'))
+    expect(
+      lineCount,
+      `revalidate-stale-quarantines.ts is ${lineCount} lines, over the ${MAX_LINES}-line round-7 budget (design §11.2.8). ` +
+        'Split more of the id-selection/reconciliation logic into .cli.ts or .load.ts before adding more lines here.'
+    ).toBeLessThanOrEqual(MAX_LINES)
+  })
+
+  it('neither .load.ts nor .cli.ts begins with a shebang (shape-3 pinned set unchanged)', () => {
+    expect(hasShebang(readIndexerSource('revalidate-stale-quarantines.load.ts'))).toBe(false)
+    expect(hasShebang(readIndexerSource('revalidate-stale-quarantines.cli.ts'))).toBe(false)
+  })
+
+  it('neither .load.ts nor .cli.ts contains an import.meta.url direct-entry guard (shape-1 pinned set unchanged)', () => {
+    expect(hasDirectEntryGuard(readIndexerSource('revalidate-stale-quarantines.load.ts'))).toBe(
+      false
+    )
+    expect(hasDirectEntryGuard(readIndexerSource('revalidate-stale-quarantines.cli.ts'))).toBe(
+      false
+    )
+  })
+
+  it('loadCandidates remains importable from revalidate-stale-quarantines.ts (guards.test.ts import path unaffected)', async () => {
+    const mod = await import('../../indexer/revalidate-stale-quarantines.ts')
+    expect(typeof mod.loadCandidates).toBe('function')
+  })
+})

--- a/scripts/tests/indexer/revalidate-stale-quarantines.ids.test.ts
+++ b/scripts/tests/indexer/revalidate-stale-quarantines.ids.test.ts
@@ -444,6 +444,37 @@ describe('parseIdSelection — malformed and empty input rejected before any DB 
 })
 
 // ---------------------------------------------------------------------------
+// Duplicate ids: deduped, order-preserving, AND both requested_raw and
+// requested_unique are reported (design §11.2.3). Round-7-review finding
+// (GPT-5.6-Sol adversarial pass on PR #2332): the raw (pre-dedupe) count was
+// silently discarded, so an operator running --ids with duplicate entries
+// had no way to see that dedupe happened at all.
+// ---------------------------------------------------------------------------
+
+describe('parseIdSelection — duplicate ids are deduped, order-preserving, with both counts reported', () => {
+  it('parseIdSelection: ids is deduped order-preserving; requestedRawCount reflects the PRE-dedupe count', () => {
+    const sel = parseIdSelection(['node', 'script', '--ids=id-a,id-b,id-a,id-c,id-b'])
+    expect(sel.ids).toEqual(['id-a', 'id-b', 'id-c'])
+    expect(sel.requestedRawCount).toBe(5)
+  })
+
+  it('formatIdSelectionReport prints requested_raw and requested_unique as distinct values when duplicates were supplied', () => {
+    const sel = parseIdSelection(['node', 'script', '--ids=id-a,id-b,id-a'])
+    const reconciliation = reconcileIdSelection(
+      sel.ids as string[],
+      sel.requestedRawCount as number,
+      [{ id: 'id-a' }, { id: 'id-b' }],
+      false
+    )
+    expect(reconciliation.requestedRawCount).toBe(3)
+    expect(reconciliation.requested).toHaveLength(2)
+    const report = formatIdSelectionReport(reconciliation)
+    expect(report).toContain('requested_raw=3')
+    expect(report).toContain('requested_unique=2')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Row: no override flag exists in the source (part of the "skipped and
 // reported, never force-processed" row)
 // ---------------------------------------------------------------------------
@@ -471,8 +502,12 @@ describe('reconcileIdSelection — loaded ⊆ requested is enforced, not assumed
   it('refuses before the processing loop when a loaded id is not in the requested set, in BOTH modes', () => {
     const requested = ['id-a', 'id-b']
     const loadedRows = [{ id: 'id-a' }, { id: 'id-unexpected' }]
-    expect(() => reconcileIdSelection(requested, loadedRows, false)).toThrow(/id-unexpected/)
-    expect(() => reconcileIdSelection(requested, loadedRows, true)).toThrow(/id-unexpected/)
+    expect(() => reconcileIdSelection(requested, requested.length, loadedRows, false)).toThrow(
+      /id-unexpected/
+    )
+    expect(() => reconcileIdSelection(requested, requested.length, loadedRows, true)).toThrow(
+      /id-unexpected/
+    )
   })
 })
 
@@ -505,7 +540,7 @@ describe('a requested id that does not match the predicate is skipped and report
 
   it('reconcileIdSelection reports requested=10 loaded=7 not-loaded=3 (exactly the failing ids), status "partial"', () => {
     const loadedRows = passingIds.map((id) => ({ id }))
-    const reconciliation = reconcileIdSelection(requested, loadedRows, false)
+    const reconciliation = reconcileIdSelection(requested, requested.length, loadedRows, false)
     expect(reconciliation.requested).toHaveLength(10)
     expect(reconciliation.loaded).toHaveLength(7)
     expect(new Set(reconciliation.notLoaded)).toEqual(new Set(failingIds))

--- a/scripts/tests/indexer/run-gate-order.test.ts
+++ b/scripts/tests/indexer/run-gate-order.test.ts
@@ -22,6 +22,11 @@ const SIDE_EFFECT_CALLEES = [
   'insert',
   'update',
   'delete',
+  // SMI-5879 round-7 (design 11.2.7): revalidate-stale-quarantines.ts's
+  // --ids-file read (parseIdSelection, revalidate-stale-quarantines.cli.ts)
+  // is also pinned to run after assertRunAllowed.
+  'readFileSync',
+  'readFile',
 ]
 
 const GATED_ENTRY_FILES = [


### PR DESCRIPTION
## Business Summary

**What shipped:** The security team's row-recovery tool (`revalidate-stale-quarantines.ts`) can now target an exact set of rows by id (`--ids`/`--ids-file`), instead of only "the first N rows in random order" (`--limit`). The tool exists specifically to recover rows a remediation pass deliberately excludes and reports by id — but it previously had no way to actually reach those rows, so it silently re-scanned an unrelated random slice and reported success while the rows it was supposed to recover stayed untouched.

**Quality bar:** Implementation + two independent adversarial review passes (GPT-5.6-Sol via NEEDLE) before merge — one code-focused, one PR-level (spec-completeness + export/silent-catch checks). Together they found two real gaps, both fixed in this PR with regression tests: (1) a malformed command (a flag supplied with no value) could silently fall through to an unbounded whole-table sweep under `--apply`; (2) duplicate ids in a selection were deduped but the pre-dedupe count was silently discarded instead of being reported alongside the deduped count, as the design requires. Full test suite for the affected area re-verified independently at each step: typecheck, lint, format, `audit:standards` (0 failures), and 1132 tests, 0 failures.

**Found along the way:** a pre-existing, unrelated data-integrity bug in a shared batching helper (`batchedIn()` silently discards query errors as "no rows matched," affecting 3 existing callers) — filed separately as [SMI-6009](https://linear.app/smith-horn-group/issue/SMI-6009/batchedin-silently-discards-postgrestnetwork-errors-as-empty-results) rather than folded into this PR (wider blast radius: shared helper with a Deno-edge parity twin).

**Net result:** Fully shipped. This was the last unimplemented precondition blocking PR #2192 (a separate, already-implemented live security-scanner fix) from scheduling its production merge window — that PR can now proceed to rebase and scheduling.

---

## Technical detail

SMI-5879 "Wave 4" / design doc round-7 addendum (`docs/internal/implementation/smi-5879-edge-twin-parity-design.md` §11).

**New files:**
- `scripts/indexer/revalidate-stale-quarantines.load.ts` — `loadCandidates()`, split out to stay under the file's line budget. Id-mode branch intersects the existing fixed predicate (`quarantined = true AND repo_url ILIKE 'https://github.com/%' AND (quarantine_reason IS NULL OR quarantine_reason = 'stale')`) rather than bypassing it — a bypass would let `writeSiblingRequarantine`'s unconditional CAS quarantine a live, healthy skill, or `retagUnreachable` mislabel a non-GitHub row. Chunks at `IN_QUERY_BATCH_SIZE` via a local loop (not `batchedIn()` — see SMI-6009 above) that checks `error` before touching `data` and throws immediately on any chunk failure, in both dry-run and apply mode.
- `scripts/indexer/revalidate-stale-quarantines.cli.ts` — two-phase validation. Phase 1 (`parseIdSelection`, pure argv + one `fs.readFileSync`) rejects mutual-exclusion violations, malformed tokens, and — the single most important check — a selection parsing to zero ids, before any DB client is constructed. Phase 2 (`reconcileIdSelection`) runs between `loadCandidates` and the row-processing loop: `--apply` refuses on any `requested`/`loaded` divergence (dry-run reports and continues), and `loaded ⊆ requested` is asserted structurally in both modes.
- `scripts/tests/indexer/revalidate-stale-quarantines.ids.test.ts` — the ~8 round-7 test-table rows from the design doc, plus 6 additional regression cases for the two adversarial-review findings below.

**Modified:**
- `scripts/indexer/revalidate-stale-quarantines.ts` — re-exports `loadCandidates`/`LoadCandidatesOptions`; `main()` now runs `parseIdSelection(process.argv)` between `assertRunAllowed` and `createSupabaseAdminClient()`. 483 lines post-split (design doc's own "≤480" figure was stale — it predated Wave 1's gate-infrastructure additions to this same file; the budget test asserts the real measured count, currently 485).
- `scripts/tests/indexer/run-gate-order.test.ts` — added `readFileSync`/`readFile` to the side-effect deny-list so the new `--ids-file` read is also pinned to run after the gate.
- `scripts/tests/indexer/revalidate-stale-quarantines.guards.test.ts` — updated the one `loadCandidates` call site to the new options-object shape.

**Adversarial-review fixes:**
1. `findFlagValue()` previously returned `undefined` both when a flag was entirely absent AND when it was present but supplied no value (a bare `--ids` as the last token, or immediately followed by another flag). `--apply --ids` would therefore silently fall through to `{ limit: undefined }` — the unbounded whole-table sweep. Now throws in phase 1 when a flag is present without a value.
2. `parseIdSelection` deduped a supplied id list but discarded the pre-dedupe count, so `requested_raw` (design §11.2.3) was never actually reported — only `requested_unique`. Threaded `requestedRawCount` through `IdSelection`/`IdReconciliation`/`reconcileIdSelection`/`formatIdSelectionReport`, and moved the reconcile+report call into a new `reportIdSelectionIfPresent()` helper in `.cli.ts` to keep the main file under its line budget.

**No production behavior change on its own** — this adds a new opt-in CLI flag to an existing operator-run tool; nothing invokes it automatically. The actual production-impacting event (PR #2192's merge + the multi-day freeze/simulation runbook) is separate and still requires explicit scheduling.

**Verification:** `docker exec`/`worktree-docker.sh exec` (this worktree's own container) — `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run audit:standards` (0 failures), `npx vitest run scripts/tests/indexer/` (1132 passed, 0 failed, 54 skipped — all pre-existing live-Postgres-gated).

Refs SMI-5879.
