### PR TITLE
fix(indexer): SMI-5879 Wave 4 governance retro -- harden sibling CLI parsers

### DIFF
--- a/scripts/indexer/dequarantine-false-positives.ts
+++ b/scripts/indexer/dequarantine-false-positives.ts
@@ -288,6 +288,35 @@ export async function runSweep(
   return counts
 }
 
+/**
+ * Parse `--limit <n>` / `--limit=<n>` from argv. Returns `undefined` only
+ * when `--limit` is entirely ABSENT. If present but supplies no value — a
+ * bare flag as the last token, or immediately followed by another `--flag`
+ * — or the value isn't a positive number, this THROWS rather than silently
+ * falling through to `undefined` (unbounded run). SMI-5879 round-7
+ * governance-retro sibling-implementation finding: this file had the same
+ * flaw the round-7 `--ids`/`--ids-file` fix in
+ * revalidate-stale-quarantines.cli.ts's `findFlagValue` was written to
+ * close — `--apply --limit` (no number supplied) would silently dequarantine
+ * clear the ENTIRE candidate cohort instead of refusing.
+ */
+export function parseLimitArg(argv: string[]): number | undefined {
+  const idx = argv.findIndex((a) => a === '--limit' || a.startsWith('--limit='))
+  if (idx === -1) return undefined
+  const eq = argv[idx].split('=')[1]
+  const raw = eq !== undefined ? eq : argv[idx + 1]
+  if (raw === undefined || raw.startsWith('--')) {
+    throw new Error('[dequarantine-false-positives] --limit was supplied with no value — refusing.')
+  }
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(
+      `[dequarantine-false-positives] --limit must be a positive number, got: "${raw}"`
+    )
+  }
+  return n
+}
+
 /** CLI entrypoint (skipped when imported by tests). */
 async function main(): Promise<void> {
   // SMI-5879 Gate C: env-sourced check first (no dependency on a DB round
@@ -297,11 +326,8 @@ async function main(): Promise<void> {
   const db = createSupabaseAdminClient()
   await assertFreezeMarkerClear(db, 'dequarantine')
   const apply = process.argv.includes('--apply')
-  const limitArg = process.argv.find((a) => a.startsWith('--limit'))
-  const limit = limitArg
-    ? Number(limitArg.split('=')[1] ?? process.argv[process.argv.indexOf(limitArg) + 1])
-    : undefined
-  await runSweep(db, { apply, limit: Number.isFinite(limit) ? limit : undefined })
+  const limit = parseLimitArg(process.argv)
+  await runSweep(db, { apply, limit })
 }
 
 // Run only when invoked directly (not when imported by the test suite).

--- a/scripts/indexer/purge-dead-quarantines.ts
+++ b/scripts/indexer/purge-dead-quarantines.ts
@@ -423,21 +423,46 @@ export async function runPurge(db: SupabaseClient, opts: PurgeOptions): Promise<
 // CLI entrypoint
 // ---------------------------------------------------------------------------
 
-/** Parse `--export <path>` / `--export=<path>` from argv. */
-function parseExportArg(argv: string[]): string | undefined {
-  const idx = argv.findIndex((a) => a === '--export' || a.startsWith('--export='))
+/**
+ * Dual `--flag value` / `--flag=value` parse. Returns `undefined` only when
+ * `flag` is entirely ABSENT from argv. If `flag` IS present but supplies no
+ * value — a bare flag as the last token, or immediately followed by another
+ * `--flag` — this THROWS rather than returning `undefined` or silently
+ * consuming the next flag as this flag's value. Collapsing "present with no
+ * value" into "absent" would let `--apply --limit` (no number supplied)
+ * silently fall through to `limit: undefined` — an UNBOUNDED purge of every
+ * row matching the dead-set predicate under `--apply` (SMI-5879 round-7
+ * governance-retro sibling-implementation finding: this file has the same
+ * flaw the round-7 `--ids`/`--ids-file` fix in
+ * revalidate-stale-quarantines.cli.ts's `findFlagValue` was written to
+ * close).
+ */
+export function findFlagValue(argv: string[], flag: string): string | undefined {
+  const idx = argv.findIndex((a) => a === flag || a.startsWith(`${flag}=`))
   if (idx === -1) return undefined
   const eq = argv[idx].split('=')[1]
-  return eq ?? argv[idx + 1]
+  if (eq !== undefined) return eq
+  const next = argv[idx + 1]
+  if (next === undefined || next.startsWith('--')) {
+    throw new Error(`[purge-dead-quarantines] ${flag} was supplied with no value — refusing.`)
+  }
+  return next
 }
 
-/** Parse `--limit <n>` / `--limit=<n>` from argv. */
-function parseLimitArg(argv: string[]): number | undefined {
-  const idx = argv.findIndex((a) => a === '--limit' || a.startsWith('--limit='))
-  if (idx === -1) return undefined
-  const raw = argv[idx].split('=')[1] ?? argv[idx + 1]
+/** Parse `--export <path>` / `--export=<path>` from argv. */
+export function parseExportArg(argv: string[]): string | undefined {
+  return findFlagValue(argv, '--export')
+}
+
+/** Parse `--limit <n>` / `--limit=<n>` from argv. Throws if the value isn't a positive number. */
+export function parseLimitArg(argv: string[]): number | undefined {
+  const raw = findFlagValue(argv, '--limit')
+  if (raw === undefined) return undefined
   const n = Number(raw)
-  return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`[purge-dead-quarantines] --limit must be a positive number, got: "${raw}"`)
+  }
+  return Math.floor(n)
 }
 
 /** CLI entrypoint (skipped when imported by tests). */

--- a/scripts/tests/indexer/dequarantine-false-positives.test.ts
+++ b/scripts/tests/indexer/dequarantine-false-positives.test.ts
@@ -42,6 +42,7 @@ import {
   isFalsePositive,
   countFindings,
   processRow,
+  parseLimitArg,
   type QuarantinedRow,
 } from '../../indexer/dequarantine-false-positives.ts'
 import { scanSkillContent } from '../../indexer/_shared/security-scanner-edge.ts'
@@ -214,5 +215,38 @@ describe('processRow — not-found vs transient split (SMI-5357)', () => {
     const result = await processRow(baseRow, headers, true, mockDb)
     expect(result.outcome).toBe('fetch-failed')
     expect(retagMock).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SMI-5879 round-7 governance-retro sibling-implementation finding:
+// parseLimitArg had the same bare-flag-collapses-to-absent flaw the round-7
+// --ids/--ids-file fix in revalidate-stale-quarantines.cli.ts was written to
+// close — --apply --limit (no number supplied) fell through to `undefined`,
+// silently clearing the ENTIRE candidate cohort instead of refusing.
+// ---------------------------------------------------------------------------
+
+describe('parseLimitArg — a supplied-but-valueless or malformed --limit refuses, never falls through to unbounded', () => {
+  it('--limit absent entirely returns undefined (legitimate unbounded run)', () => {
+    expect(parseLimitArg(['node', 'script', '--apply'])).toBeUndefined()
+  })
+
+  it('--limit=<n> and --limit <n> both parse correctly', () => {
+    expect(parseLimitArg(['node', 'script', '--limit=10'])).toBe(10)
+    expect(parseLimitArg(['node', 'script', '--limit', '10'])).toBe(10)
+  })
+
+  it('--limit as the last token with no value throws, not undefined', () => {
+    expect(() => parseLimitArg(['node', 'script', '--apply', '--limit'])).toThrow(/no value/)
+  })
+
+  it('--limit immediately followed by another flag throws, not undefined', () => {
+    expect(() => parseLimitArg(['node', 'script', '--limit', '--apply'])).toThrow(/no value/)
+  })
+
+  it('a non-numeric or non-positive --limit value throws, never silently returns undefined', () => {
+    expect(() => parseLimitArg(['node', 'script', '--limit=abc'])).toThrow(/positive number/)
+    expect(() => parseLimitArg(['node', 'script', '--limit=0'])).toThrow(/positive number/)
+    expect(() => parseLimitArg(['node', 'script', '--limit=-5'])).toThrow(/positive number/)
   })
 })

--- a/scripts/tests/indexer/purge-dead-quarantines.test.ts
+++ b/scripts/tests/indexer/purge-dead-quarantines.test.ts
@@ -29,6 +29,8 @@ import {
   DELETE_BATCH,
   deleteInBatches,
   runPurge,
+  parseLimitArg,
+  parseExportArg,
   type DeadRow,
 } from '../../indexer/purge-dead-quarantines.ts'
 
@@ -398,4 +400,56 @@ describe('deleteInBatches — transient retry', () => {
       deleteInBatches(dbThrowsThenOk(99) as never, 'skills', 'id', ['a'], undefined, 1)
     ).rejects.toThrow(/after 2 attempts/)
   }, 10000)
+})
+
+// ---------------------------------------------------------------------------
+// SMI-5879 round-7 governance-retro sibling-implementation finding: this
+// tool's --limit/--export parsing had the same bare-flag-collapses-to-absent
+// flaw the round-7 --ids/--ids-file fix in
+// revalidate-stale-quarantines.cli.ts was written to close. Most severe here
+// specifically because this is a DESTRUCTIVE delete tool: --apply --limit
+// (no number supplied) fell through to `limit: undefined`, deleting the
+// ENTIRE dead-set cohort instead of refusing.
+// ---------------------------------------------------------------------------
+
+describe('parseLimitArg / parseExportArg — a supplied-but-valueless or malformed flag refuses, never falls through', () => {
+  it('--limit absent entirely returns undefined (legitimate unbounded run)', () => {
+    expect(parseLimitArg(['node', 'script', '--apply'])).toBeUndefined()
+  })
+
+  it('--limit=<n> and --limit <n> both parse correctly', () => {
+    expect(parseLimitArg(['node', 'script', '--limit=50'])).toBe(50)
+    expect(parseLimitArg(['node', 'script', '--limit', '50'])).toBe(50)
+  })
+
+  it('--limit as the last token with no value throws, not undefined (would otherwise delete the entire dead set)', () => {
+    expect(() => parseLimitArg(['node', 'script', '--apply', '--limit'])).toThrow(/no value/)
+  })
+
+  it('--limit immediately followed by another flag throws, not undefined', () => {
+    expect(() => parseLimitArg(['node', 'script', '--limit', '--apply'])).toThrow(/no value/)
+  })
+
+  it('a non-numeric or non-positive --limit value throws, never silently returns undefined', () => {
+    expect(() => parseLimitArg(['node', 'script', '--limit=abc'])).toThrow(/positive number/)
+    expect(() => parseLimitArg(['node', 'script', '--limit=0'])).toThrow(/positive number/)
+    expect(() => parseLimitArg(['node', 'script', '--limit=-5'])).toThrow(/positive number/)
+  })
+
+  it('--export absent entirely returns undefined (falls back to defaultExportPath)', () => {
+    expect(parseExportArg(['node', 'script', '--apply'])).toBeUndefined()
+  })
+
+  it('--export=<path> and --export <path> both parse correctly', () => {
+    expect(parseExportArg(['node', 'script', '--export=/tmp/dead.csv'])).toBe('/tmp/dead.csv')
+    expect(parseExportArg(['node', 'script', '--export', '/tmp/dead.csv'])).toBe('/tmp/dead.csv')
+  })
+
+  it('--export as the last token with no value throws (previously would have silently used undefined -> default path, or worse, consumed the next flag as a path)', () => {
+    expect(() => parseExportArg(['node', 'script', '--export'])).toThrow(/no value/)
+  })
+
+  it('--export immediately followed by another flag throws instead of treating the flag name as a path', () => {
+    expect(() => parseExportArg(['node', 'script', '--export', '--apply'])).toThrow(/no value/)
+  })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** Two production write-tools (`dequarantine-false-positives.ts`, and `purge-dead-quarantines.ts` — a **destructive delete tool**) previously had a hole where running `--apply --limit` with no number after `--limit` would silently ignore the limit entirely and process the *whole* candidate cohort — for the purge tool, that meant deleting every row matching the dead-set predicate instead of refusing. Both now refuse with a clear error instead of silently defaulting to the most destructive interpretation.

**Quality bar:** Found via a sibling-implementation sweep during the post-merge retro for PR #2332 (which fixed the identical bug in a third, sibling file) — not a new investigation, a direct application of "does this same flaw exist anywhere else." 14 new regression tests added (both functions were previously untested). Full indexer test suite re-verified: 1146 passed, 0 failed. Typecheck, lint, format, `audit:standards` all clean.

**Net result:** Fully shipped. Closes out the SMI-5879 Wave 4 post-merge retro with zero deferred findings.

---

## Technical detail

Retro report: `docs/internal/code_review/2026-08-12-smi5879-wave4-postmerge.md` (skillsmith-docs PR #739, squash `0bfde0038`).

- `scripts/indexer/dequarantine-false-positives.ts`: extracted the previously-inline `--limit` parse into an exported, testable `parseLimitArg()`. Throws when `--limit` is present but supplies no value, or when the value isn't a positive number.
- `scripts/indexer/purge-dead-quarantines.ts`: added a shared local `findFlagValue()` helper (mirrors `revalidate-stale-quarantines.cli.ts`'s from PR #2332), used by both `parseLimitArg` and `parseExportArg`. `parseExportArg` had a lower-severity variant of the same flaw — a bare `--export` would silently consume the next flag literally as a file path (e.g. `--export --apply` → export path `"--apply"`).
- `scripts/tests/indexer/dequarantine-false-positives.test.ts` / `purge-dead-quarantines.test.ts`: 14 new test cases covering flag-absent (legitimate), both `--flag=value`/`--flag value` forms, bare-flag-as-last-token, bare-flag-followed-by-another-flag, and malformed numeric values.
- `docs/internal` pointer bump for the retro report.

Every legitimate invocation is unchanged — only the previously-silent-and-dangerous case (flag present, no value) now throws instead of running unbounded.

Refs SMI-5879.
