### PR TITLE
fix(mcp-server): Raise agent-harness-sim connect timeout, harden cleanup

### DIFF
--- a/packages/mcp-server/tests/integration/agent-harness-sim.helpers.ts
+++ b/packages/mcp-server/tests/integration/agent-harness-sim.helpers.ts
@@ -175,24 +175,163 @@ export interface HarnessConnection {
   close: () => Promise<void>
 }
 
+export interface ConnectHarnessOptions {
+  /** Overrides `CONNECT_HARNESS_TIMEOUT_MS` for a single call (tests only). */
+  timeoutMs?: number
+}
+
+export interface ConnectHarnessTimeoutDiagnostics {
+  elapsedMs: number
+  pid: number | null
+  /** Trailing stderr captured from the spawned process up to the timeout. */
+  stderr: string
+}
+
+/**
+ * SMI-6002: thrown when `connectHarness()`'s own liveness budget
+ * (`CONNECT_HARNESS_TIMEOUT_MS`) is exceeded. Carries the same
+ * stderr/pid/elapsed diagnostics baked into the message as structured fields,
+ * so a future caller can act on them programmatically instead of re-parsing
+ * the message string.
+ */
+export class HarnessConnectTimeoutError extends Error {
+  readonly diagnostics: ConnectHarnessTimeoutDiagnostics
+
+  constructor(message: string, diagnostics: ConnectHarnessTimeoutDiagnostics) {
+    super(message)
+    this.name = 'HarnessConnectTimeoutError'
+    this.diagnostics = diagnostics
+  }
+}
+
+/**
+ * SMI-6002: per-harness `connectHarness()` liveness budget. Sized from real
+ * reproduction data across two independent protocols (all 7 harnesses each
+ * run, exact `npx vitest run` invocations, see the Linear issue comment / PR
+ * description for the full protocol and container/load-average numbers):
+ *   - full `packages/mcp-server` suite running concurrently (75 files,
+ *     1204 tests): 2.0-22.2s per harness across contention levels
+ *   - `agent-harness-sim.test.ts` bundled with the other two historically-
+ *     heavy integration files (`crash-handler-integration.test.ts`,
+ *     `security-acceptance-lost-update.test.ts`) under genuine concurrent
+ *     host load (3-6 sibling worktree containers, host load average ~16-100
+ *     on a 10-core host, verified via `docker stats`/`uptime` at run time),
+ *     3 repeated runs, 21 samples: min 10.0s, median 36.2s, max 60.3s (the
+ *     60.3s sample — harness `hermes`, run 2 — occurred during a host-load
+ *     spike to ~90-100, an unusually extreme but genuinely observed
+ *     multi-session level, not synthetic)
+ * The original SMI-5999-session observation (3 of 7 harnesses exceeding the
+ * old 30s budget, file total ~194s) sits between these two protocols'
+ * observed maxima — the second protocol's 60.3s sample is the closest
+ * reproduction of that historical severity obtained so far. 120s gives real
+ * headroom (~2x the single most extreme observed sample, ~5.4x the
+ * full-suite protocol's max) without being unbounded, a contention allowance
+ * rather than a performance target: `connectHarness()` spawns a real Node
+ * child process and performs a genuine MCP `initialize` handshake, both
+ * sensitive to host CPU scheduling delay under load, not to any defect in
+ * the code under test. 21 samples is enough to characterize min/median/max
+ * but not a defensible p99, so this is a deliberately round, generous number
+ * rather than a tightly-fit percentile — matching the precedent already set
+ * by this same file's `crash-handler-integration.test.ts` sibling, whose own
+ * spawn-based outer `beforeAll` uses the same 120_000ms budget.
+ */
+export const CONNECT_HARNESS_TIMEOUT_MS = 120_000
+
 /**
  * Spawn the real built server and connect a real MCP `Client`, performing a
  * genuine `initialize` handshake with `clientInfo` — exactly what a harness
  * does. `env` is intentionally required (not defaulted) so every call site
  * makes its isolation/consent posture explicit.
+ *
+ * SMI-6002: races the connect attempt against `CONNECT_HARNESS_TIMEOUT_MS`
+ * (or `options.timeoutMs`) instead of relying solely on Vitest's own
+ * `beforeAll` hook timeout. A Vitest hook timeout alone does NOT cancel the
+ * in-flight `client.connect()` call or terminate the spawned child process —
+ * it just stops waiting and marks the hook failed, leaving the process (and
+ * this function's promise) running unobserved in the background. Racing
+ * internally lets this function itself detect the overrun, capture
+ * stderr/pid diagnostics at that moment, and terminate the spawned process
+ * deterministically, regardless of whether Vitest's own hook timeout ever
+ * fires (the caller sizes its hook timeout with headroom over this value).
  */
 export async function connectHarness(
   clientInfo: { name: string; version: string },
-  env: Record<string, string>
+  env: Record<string, string>,
+  options: ConnectHarnessOptions = {}
 ): Promise<HarnessConnection> {
+  const timeoutMs = options.timeoutMs ?? CONNECT_HARNESS_TIMEOUT_MS
+  const startedAt = Date.now()
+
   const transport = new StdioClientTransport({
     command: 'node',
     args: [DIST_ENTRY],
     env,
     stderr: 'pipe',
   })
+
+  const stderrChunks: Buffer[] = []
+  transport.stderr?.on('data', (chunk: Buffer | string) => {
+    stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  })
+
   const client = new Client(clientInfo)
-  await client.connect(transport)
+
+  const cleanupTransport = async (): Promise<void> => {
+    try {
+      // Idempotent and safe even if the process never finished spawning —
+      // StdioClientTransport#close() no-ops when there is nothing to kill.
+      await transport.close()
+    } catch (cleanupError) {
+      // SMI-6002 (cross-model PR review): best-effort cleanup, but a
+      // silently-swallowed failure here could mask a leaked spawned
+      // process — surface it diagnostically instead of dropping it. The
+      // caller's real error (timeout or connect failure) still takes
+      // priority and is what actually gets thrown/rejected.
+      console.error(
+        `[connectHarness] cleanupTransport() failed (pid=${transport.pid ?? 'unassigned'}): ` +
+          `${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+      )
+    }
+  }
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      const elapsedMs = Date.now() - startedAt
+      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim()
+      // Mirrors the SMI-5999 investigation's "empty stderr at kill time =
+      // still in Node bootstrap under contention, not a hang" check — an
+      // empty capture here is itself diagnostic, not an absence of data.
+      const stderrNote =
+        stderr.length > 0
+          ? stderr
+          : '<empty — process likely still in Node bootstrap under contention, not a hang>'
+      reject(
+        new HarnessConnectTimeoutError(
+          `connectHarness() exceeded its ${timeoutMs}ms liveness budget for ` +
+            `clientInfo=${JSON.stringify(clientInfo)} (elapsedMs=${elapsedMs}, ` +
+            `pid=${transport.pid ?? 'unassigned'}). stderr at timeout: ${stderrNote}`,
+          { elapsedMs, pid: transport.pid, stderr }
+        )
+      )
+    }, timeoutMs)
+  })
+
+  const connectPromise = client.connect(transport)
+
+  try {
+    await Promise.race([connectPromise, timeoutPromise])
+  } catch (error) {
+    await cleanupTransport()
+    // If the timeout branch won the race, connectPromise is still pending
+    // and will settle later (usually a rejection once the killed process's
+    // stdio closes) — swallow it so it doesn't surface as an unhandled
+    // rejection after this function has already thrown.
+    void connectPromise.catch(() => undefined)
+    throw error
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle)
+  }
 
   return {
     client,

--- a/packages/mcp-server/tests/integration/agent-harness-sim.test.ts
+++ b/packages/mcp-server/tests/integration/agent-harness-sim.test.ts
@@ -97,29 +97,84 @@ describe.skipIf(skipInPrePush)('SMI-5456 L2a — agent harness-simulation MCP cl
 
   describe.each(HARNESS_CASES)('harness: $id', ({ id, clientInfo }) => {
     let homeDir: string
-    let cleanupHome: () => void
-    let connection: HarnessConnection
+    // SMI-6002: `cleanupHome`/`connection` are only DEFINITELY assigned once
+    // their respective setup step completes. If `connectHarness()` rejects
+    // or exceeds its own liveness budget, `beforeAll` throws before
+    // `connection` is ever assigned — `afterAll` always runs regardless (it
+    // is not skipped just because `beforeAll` failed), so it must not assume
+    // either variable is set.
+    let cleanupHome: (() => void) | undefined
+    let connection: HarnessConnection | undefined
 
+    // SMI-6002: 30s -> 150s. Reproduction data (full packages/mcp-server
+    // suite, 75 files/1204 tests, running concurrently: 2.0-22.2s per
+    // harness; agent-harness-sim.test.ts bundled with the other two
+    // historically-heavy integration files under genuine concurrent host
+    // load, 3 runs/21 samples: min 10.0s, median 36.2s, max 60.3s) shows
+    // real per-harness connect time scales with host contention well past
+    // the old 30s budget — see connectHarness()'s own
+    // CONNECT_HARNESS_TIMEOUT_MS doc comment (agent-harness-sim.helpers.ts)
+    // for the full protocol and data. 150s gives this outer Vitest hook
+    // timeout ~30s of margin over connectHarness()'s own internal 120s
+    // liveness budget, so the internal race (which captures stderr/pid
+    // diagnostics and kills the spawned process) fires first in the normal
+    // case, rather than Vitest's own generic hook-timeout message —
+    // matching the "contention allowance, not a target" framing
+    // SMI-5999/SMI-6004/SMI-6005 used for their own timing budgets.
     beforeAll(async () => {
       const home = createIsolatedHome(`sklx-l2a-${id}-`)
       homeDir = home.homeDir
       cleanupHome = home.cleanup
       connection = await connectHarness(clientInfo, baseSpawnEnv(homeDir))
-    }, 30_000)
+    }, 150_000)
+
+    /**
+     * SMI-6002: narrows `connection` from `HarnessConnection | undefined` to
+     * `HarnessConnection` for the `it()` bodies below. Safe in practice —
+     * Vitest never runs a describe block's `it()`s once its `beforeAll` has
+     * thrown — but TypeScript can't see that hook-ordering guarantee, and a
+     * throwing accessor is more diagnosable than a bare `!` assertion if that
+     * invariant is ever violated by a future Vitest version or refactor.
+     */
+    function requireConnection(): HarnessConnection {
+      if (!connection) {
+        throw new Error(
+          `harness ${id}: connection was never established (beforeAll must have thrown or timed out)`
+        )
+      }
+      return connection
+    }
 
     afterAll(async () => {
-      await connection.close()
-      cleanupHome()
+      // SMI-6002: guarded against partial initialization — if
+      // `connectHarness()` rejected or timed out inside `beforeAll`,
+      // `connection` was never assigned, and dereferencing it here would
+      // throw a second, more confusing error on top of the real one.
+      // `connectHarness()` itself already terminates the spawned process on
+      // its own failure/timeout path, so there is no process to kill here
+      // even in that case — only the temp home may still need removing.
+      // `cleanupHome()` runs in `finally` (a cross-model code review caught
+      // this) so a rejecting `connection.close()` can never leak the temp
+      // home — `close()` failing is not a reason to skip removing it.
+      try {
+        if (connection) {
+          await connection.close()
+        }
+      } finally {
+        if (cleanupHome) {
+          cleanupHome()
+        }
+      }
     })
 
     it('ListTools returns exactly the curated agent-profile ∩ registered set', async () => {
-      const result = await connection.listTools()
+      const result = await requireConnection().listTools()
       const names = new Set(result.tools.map((tool) => tool.name))
       expect(names).toEqual(AGENT_PROFILE_SET)
     })
 
     it('includes the suggest -> apply -> undo trio', async () => {
-      const result = await connection.listTools()
+      const result = await requireConnection().listTools()
       const names = result.tools.map((tool) => tool.name)
       expect(names).toEqual(
         expect.arrayContaining(['skill_inventory_audit', 'apply_namespace_rename', 'undo_apply'])
@@ -128,7 +183,7 @@ describe.skipIf(skipInPrePush)('SMI-5456 L2a — agent harness-simulation MCP cl
 
     it('rounds-trips a CallTool through the `_meta` marker channel and completes fast with no telemetry configured (consent-off/no-network evidence)', async () => {
       const start = Date.now()
-      const result = await connection.callTool({
+      const result = await requireConnection().callTool({
         name: 'skill_outdated',
         arguments: { include_deps: false },
         _meta: { agent_session: true, nudge_origin: false, trigger_id: `eval-l2a-${id}` },
@@ -154,7 +209,7 @@ describe.skipIf(skipInPrePush)('SMI-5456 L2a — agent harness-simulation MCP cl
         triggerId: `nudge-${id}`,
       })
 
-      const result = await connection.callTool({
+      const result = await requireConnection().callTool({
         name: 'skill_outdated',
         arguments: { include_deps: false },
       })


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a flaky test (`agent-harness-sim.test.ts`) that intermittently failed under heavy CI load — spawning and connecting to the real MCP server sometimes took longer than an overly tight 30-second budget allowed, especially with other heavy tests running at the same time.

**Quality bar:** Went through a full reviewed pipeline — an implementation plan, an independent cross-model (GPT-5.6-Sol) plan review, real timing data gathered across two contention protocols (21 samples, max observed 60.3s under an extreme host-load spike), a cross-model code review that caught a cleanup-ordering gap, and a final cross-model pre-merge PR review that caught one more gap (a silent catch that could mask a leaked child process on cleanup failure). All three review passes' findings are fixed in this PR. Verified across multiple repeated real-load runs, including one that itself took 142s under heavy concurrent load — directly validating the chosen budget. Typecheck, lint, and format all clean.

**Found along the way:** three real robustness gaps in the connection-lifecycle handling, all fixed in this same PR — cleanup crashing on a never-created connection, cleanup skipping temp-home removal if `close()` failed, and a cleanup failure being silently swallowed instead of surfaced diagnostically.

**Net result:** Fully shipped, no follow-up needed.

---

## Technical detail

`packages/mcp-server/tests/integration/agent-harness-sim.test.ts` and `agent-harness-sim.helpers.ts`:
- Per-harness `beforeAll` timeout raised 30s → 150s, sized from real reproduction data across two protocols (full-suite: 2.0-22.2s per harness; repeated real-load runs matching original incident conditions: 21 samples, min 10.0s / median 36.2s / max 60.3s).
- `connectHarness()` now races its own internal 120s liveness budget against the connect attempt — captures stderr/pid diagnostics and deterministically terminates the process on overrun.
- `connection`/`cleanupHome` are now typed as possibly-undefined and `afterAll` is guarded against partial initialization, with cleanup wrapped in try/finally so a rejecting `close()` can't skip removing the temp home.
- `cleanupTransport()`'s catch now logs cleanup failures diagnostically instead of swallowing them silently, while still preserving and throwing the original timeout/connect error.

Implementation plan: `docs/internal/implementation/smi-6002-6010-flaky-test-fixes.md`. Pre-merge PR review report: `docs/internal/pr-reviews/2026-08-12-smi-6002-agent-harness-timeout.md`.

Fixes SMI-6002