### PR TITLE
docs(website): SMI-6011 fix stale inventory-scan coverage claim

### DIFF
--- a/packages/website/src/pages/docs/inventory.astro
+++ b/packages/website/src/pages/docs/inventory.astro
@@ -256,8 +256,20 @@ skillsmith inventory purge --yes`}</code></pre>
         <td><code>~/.agents/skills</code></td>
       </tr>
       <tr>
+        <td>OpenCode</td>
+        <td><code>~/.config/opencode/skills</code></td>
+      </tr>
+      <tr>
+        <td>Hermes</td>
+        <td><code>~/.hermes/skills</code></td>
+      </tr>
+      <tr>
         <td>Grok Build</td>
         <td><code>~/.grok/skills</code></td>
+      </tr>
+      <tr>
+        <td>Antigravity</td>
+        <td><code>~/.gemini/config/skills</code></td>
       </tr>
     </tbody>
   </table>
@@ -277,8 +289,6 @@ skillsmith inventory purge --yes`}</code></pre>
     <code>skillsmith inventory push</code> does not upload it, so repo-local skills never appear at
     <a href="/account/skills">skillsmith.app/account/skills</a>.
   </p>
-
-  <p>OpenCode and Antigravity aren't scanned yet.</p>
 
   <h2 id="state-badges">State Badges</h2>
 


### PR DESCRIPTION
## Business Summary

**What shipped:** Corrected a false claim on 7 customer-facing and sales-facing surfaces — the product docs page, GTM outreach material, the pilot commercial kit, and the design-partner playbook — that our inventory-scan feature doesn't yet cover OpenCode and Antigravity. It's covered both tools for a while now (OpenCode since an earlier release, Antigravity as of today); the docs just never caught up.

**Quality bar:** Verified against the actual code before touching any copy — traced the scan loop in `inventory-collector.ts` line by line to confirm it covers every supported tool unconditionally, not just eyeballing the docs. A repo-wide search caught a 7th surface (a partner-readiness tracking doc) making the same stale claim that wasn't in the original report. One historical document was deliberately left as-is — a past PR review that quotes the old sentence as a record of a decision made at the time, not a live claim.

**Net result:** Fully shipped. No further surfaces found with the same claim.

---

## Technical detail

Two commits:

1. `packages/website/src/pages/docs/inventory.astro` — the harness-coverage table was missing rows for OpenCode, Hermes, and Antigravity entirely, and carried a standalone `<p>OpenCode and Antigravity aren't scanned yet.</p>`. Added the 3 missing rows (in `CLIENT_IDS` order), removed the stale paragraph.
2. Bumps the `docs/internal` submodule pointer — the companion fix across `docs/internal/runbooks/design-partner-concierge-playbook.md`, `docs/internal/gtm/{pilot-commercial-kit,inventory-beta-invite,wave-a-outreach-kit,partner-readiness-july-2026}.md` already merged separately (`docs/internal` is a different repo with no CI of its own).

Verification method: read `packages/core/src/sync/inventory-collector.ts`'s `collectDeviceSkills()` directly — it's a plain `for (const harness of CLIENT_IDS)` loop with no filtering, skip-list, or per-harness exclusion. `CLIENT_IDS` (`packages/core/src/install/paths.ts`) currently has 9 members: `claude-code, cursor, copilot, windsurf, agents, opencode, hermes, grok, antigravity`. So "we scan every supported harness" is the accurate claim, not a partial list.

Deliberately left untouched: `docs/internal/code_review/2026-07-14-smi-5697-grok-harness-review.md` quotes the old stale sentence while documenting that it was intentionally out of scope for that PR at the time — genuine historical record, not a live doc making a current claim.
