### PR TITLE
docs(website): SMI-6011 follow-up -- fix remaining stale harness-count claims

### DIFF
--- a/packages/website/src/pages/docs/inventory.astro
+++ b/packages/website/src/pages/docs/inventory.astro
@@ -64,9 +64,8 @@ const howToSchema = {
 
   <p>
     Cross-machine skill inventory is a read-only view of the agent skills installed across every
-    machine and harness you use — Claude Code, Cursor, Copilot, Windsurf, and the shared,
-    open-standard directory that Codex reads. It isn't scoped to one agent; it scans wherever any
-    supported harness looks for skills.
+    machine and harness you use. It isn't scoped to one agent; it scans wherever any of the
+    supported harnesses listed below look for skills.
   </p>
 
   <p>


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a related loose end from the SMI-6011 fix (#2344) — the inventory page's intro paragraph named only 5 of the 9 harnesses we now scan, and 6 GTM/sales docs made the same stale "5 harnesses" claim in different words than the sentence already caught. All now accurate.

**Quality bar:** Found via the SMI-6011 post-merge governance retro's own check for "any other stale claim pattern nearby" — typecheck/lint clean, re-verified with a fresh repo-wide grep after the edits.

**Net result:** Fully shipped. No further surfaces found.

---

## Technical detail

`packages/website/src/pages/docs/inventory.astro` — rewrote the intro paragraph to defer to the harness table below it instead of maintaining a second, parallel enumeration that can drift again next time a harness is added.

Bumps the `docs/internal` pointer for the companion fix across 6 GTM docs (`product-strategy-roadmap-july-2026.md`, `meta-harness-category-thesis-july-2026.md`, `inventory-beta-invite.md`, `customer-segments-july-2026.md`, `wave-a-outreach-kit.md`, `fi-idea-exploration-july-2026.md`), already merged separately.