### PR TITLE
docs: document publish.yml's main-branch dispatch requirement

### DIFF
--- a/.claude/development/publishing-guide.md
+++ b/.claude/development/publishing-guide.md
@@ -16,9 +16,13 @@ The script updates all 6 version locations (package.json, VERSION constants, ser
 
 ## CI Workflow (the only supported publish path)
 
+**The release-prep PR must be merged to `main` before dispatching `publish.yml`.** `gh workflow run publish.yml` with no `--ref` always dispatches against the repository's default branch (`main`) — not your local checkout's branch, even if you're sitting on the release-prep branch when you run it. Push and merge the version-bump PR first; dispatching before merge silently republishes whatever was already on `main`, not your bump.
+
 ```bash
 git push
-gh workflow run publish.yml -f dry_run=false
+gh pr create --base main --head <release-prep-branch> --title "chore(release): ..." --body "..."
+gh pr merge <PR#> --squash --delete-branch       # merge to main FIRST
+gh workflow run publish.yml -f dry_run=false      # then dispatch — always targets main
 gh run watch <run-id> --exit-status              # Monitor progress
 ```
 
@@ -31,9 +35,10 @@ If CI fails, fix CI. Do not reach for a local publish — see [`publish-ci-recov
 1. Build in Docker: `docker exec skillsmith-dev-1 npm run build`
 2. Run preflight: `docker exec skillsmith-dev-1 npm run preflight`
 3. Verify dependency versions are committed and pushed
-4. Trigger CI: `gh workflow run publish.yml -f dry_run=false`
-5. Watch the run: `gh run watch <run-id> --exit-status`
-6. Post-publish (CI smoke-tests automatically; manual fallback): `npx tsx scripts/smoke-test-published.ts @skillsmith/<pkg> <version>`
+4. Open a PR for the release-prep branch and **merge it to `main`** — `publish.yml` always dispatches against `main`, not the branch you're on
+5. Trigger CI: `gh workflow run publish.yml -f dry_run=false`
+6. Watch the run: `gh run watch <run-id> --exit-status`
+7. Post-publish (CI smoke-tests automatically; manual fallback): `npx tsx scripts/smoke-test-published.ts @skillsmith/<pkg> <version>`
 
 If CI fails, do NOT reach for a local publish. Fix the underlying issue. Genuine break-glass: see [Break-Glass](#break-glass) below (requires `SKILLSMITH_PUBLISH_OVERRIDE=SMI-NNNN <rationale>` and a Linear retro within 24h). For workspace-resolution version-pin pitfalls and the `packaging-test.yml` registry-resolution caveat, see [Critical Rules](#critical-rules) below.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ Full agent catalog, swarm topologies, and hive-mind examples: [claude-flow-guide
 
 ## Publishing Packages
 
-**Release prep**: `docker exec skillsmith-dev-1 npx tsx scripts/prepare-release.ts --all=patch` (also `--core=minor --cli=patch`, `--dry-run`). **Publish (CI-only)**: `git push && gh workflow run publish.yml -f dry_run=false`. Cadence: weekly (Sun 03:00 UTC) OR `[Unreleased]` ≥ 15 entries ([ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md)). Order: core → mcp-server, cli, enterprise. Local fallback deprecated (SMI-4533). Pre-publish checklist, version-pin rules, break-glass: [publishing-guide.md](.claude/development/publishing-guide.md).
+**Release prep**: `docker exec skillsmith-dev-1 npx tsx scripts/prepare-release.ts --all=patch` (also `--core=minor --cli=patch`, `--dry-run`). **Publish (CI-only)**: push the release-prep branch, open a PR, **merge it to `main`**, then `gh workflow run publish.yml -f dry_run=false` — the workflow always dispatches against `main` (no `--ref` defaults to the repo's default branch), never the release-prep branch itself, so publishing before merge silently republishes whatever was already on `main`. Cadence: weekly (Sun 03:00 UTC) OR `[Unreleased]` ≥ 15 entries ([ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md)). Order: core → mcp-server, cli, enterprise. Local fallback deprecated (SMI-4533). Pre-publish checklist, version-pin rules, break-glass: [publishing-guide.md](.claude/development/publishing-guide.md).
 
 ---
 


### PR DESCRIPTION
## Summary

- `gh workflow run publish.yml` with no `--ref` always dispatches against `main`, never the caller's local branch — even if you're sitting on the release-prep branch when you run it. This was previously only inferable from historical workflow-run metadata, never written down.
- Discovered and confirmed during the 2026-08-12 release retro (outer-repo PR #2351): every past `publish.yml` run's `head_branch` is `main`, confirmed again live on this release's own run.
- Makes the "merge to main first, then dispatch" prerequisite explicit in both `CLAUDE.md`'s Publishing Packages section and `publishing-guide.md`'s CI Workflow + Pre-publish checklist sections, so the next release doesn't have to re-derive this from run history.
- Bumps the `docs/internal` submodule pointer to include the release retro (skillsmith-docs#751) documenting this session's full findings.

## Test plan

- [x] Docs-only change (CLAUDE.md, `.claude/development/publishing-guide.md`, submodule pointer) — no source/package files touched
- [x] Pre-push security suite, format check, and per-package test check all passed

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)