### PR TITLE
chore(security): allowlist github/fitz2882/narthex jailbreak/exfil FPs

### DIFF
--- a/data/skills-security-allowlist.json
+++ b/data/skills-security-allowlist.json
@@ -83,6 +83,24 @@
       "reviewedBy": "ryansmith108",
       "reviewedAt": "2026-07-12",
       "expiresAt": "2026-10-10"
+    },
+    {
+      "skillId": "github/fitz2882/narthex",
+      "findingType": "jailbreak",
+      "messagePattern": "jailbreak",
+      "reason": "Prompt-injection defense tool for Claude Code — a PreToolUse Bash hook plus a sanitizing MCP server that strips invisible unicode and 'flags jailbreaks'. Repo has no SKILL.md at root (examples/hooks/mcp subdirs, install.py/uninstall.py — a defensive tool FOR Claude Code, not a skill itself), same shape as github/RobinGase/skill-protocol-rs. Bare /jailbreak/i pattern triggered on the repo description's own use of the word to describe what it detects — same class as github/RENJI04/prompt-injection-auditor (SMI-4765). Both findings trace to line 3 of the repo description; no actual code or behavior implicated. Triaged 2026-08-13.",
+      "reviewedBy": "ryansmith108",
+      "reviewedAt": "2026-08-13",
+      "expiresAt": "2026-11-11"
+    },
+    {
+      "skillId": "github/fitz2882/narthex",
+      "findingType": "data_exfiltration",
+      "messagePattern": "exfil",
+      "reason": "Same tool and same false-positive line as the jailbreak entry above — the bare 'exfil' keyword pattern triggered on the repo description's own phrase 'blocks compositional credential-exfiltration shapes', describing what the tool defends against, not an exfiltration mechanism it contains. Corroboration between this and the co-occurring jailbreak finding (both line 3, both from the same description text) is exactly the same self-describing-security-tool pattern as the other allowlisted entries. Triaged 2026-08-13.",
+      "reviewedBy": "ryansmith108",
+      "reviewedAt": "2026-08-13",
+      "expiresAt": "2026-11-11"
     }
   ]
 }

--- a/packages/core/tests/skill-scanner/allowlist.test.ts
+++ b/packages/core/tests/skill-scanner/allowlist.test.ts
@@ -408,11 +408,17 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
   // as a threat it detects; same self-describing-security-tool FP class as
   // MalPromptSentinel-CC-Skill. Also renewed the 4 entries that were about to
   // expire 2026-07-21 (kcmadden, MalPromptSentinel, rhysha, mdium).
+  // SMI-6018 (2026-08-13): fitz2882/narthex added — defensive prompt-injection
+  // tool for Claude Code whose repo description says it 'flags jailbreaks'
+  // and 'blocks compositional credential-exfiltration shapes'; two entries
+  // (jailbreak, data_exfiltration findingTypes) since both bare-keyword
+  // patterns trip on the same description line — same self-describing-
+  // security-tool FP class as RENJI04/prompt-injection-auditor.
   it('is parseable and every entry expires 90 days after review', () => {
     const filePath = path.resolve(__dirname, '../../../../data/skills-security-allowlist.json')
     const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
     const parsed = parseAllowlistFile(raw)
-    expect(parsed.allowlist.length).toBe(9)
+    expect(parsed.allowlist.length).toBe(11)
     const ids = parsed.allowlist.map((e) => e.skillId).sort()
     expect(ids).toEqual(
       [
@@ -421,6 +427,8 @@ describe('data/skills-security-allowlist.json (ship-it sanity)', () => {
         'github/RobinGase/skill-protocol-rs',
         'github/StrategicPromptArchitect-AI/MalPromptSentinel-CC-Skill',
         'github/dokind/qpay-skills',
+        'github/fitz2882/narthex',
+        'github/fitz2882/narthex',
         'github/kcmadden/claude-code-1password-skill',
         'github/leksman/ai-security-guard',
         'github/rhysha/claude-security-research-skill',


### PR DESCRIPTION
## Business Summary

**What shipped**: While confirming an earlier security-scan fix (PR #2281) actually worked, we manually triggered the weekly security scan and it still failed — but for a new reason: a defensive security tool got mistakenly flagged as a threat. This PR clears that false alarm.

**Quality bar**: Verified via the scan's own artifacts before touching anything — confirmed the flagged content was the tool's own self-description, not real malicious code, and confirmed PR #2281's original fix was in fact working correctly (this is a separate, new issue).

**Found along the way**: A "ship-it sanity" golden test hardcoded the exact allowlist entry count and skill-ID list; updated it alongside the data change, since it needs to move in lockstep.

**Net result**: `github/fitz2882/narthex` (a prompt-injection defense tool for Claude Code) no longer trips the weekly security scan on its own description text.

## Technical Detail

`github/fitz2882/narthex` was quarantined HIGH severity by `weekly-security-scan.yml` — a PreToolUse Bash hook + sanitizing MCP server whose own repo description says it "flags jailbreaks" and "blocks compositional credential-exfiltration shapes." Both findings (jailbreak, data_exfiltration) traced to line 3 of that description text via the scan's `quarantine-skills.json`/`security-report.json` artifacts — no actual code or behavior implicated. Same self-describing-security-tool false-positive class as the existing `RENJI04/prompt-injection-auditor` and `RobinGase/skill-protocol-rs` allowlist entries (repo has no root `SKILL.md` either — a tool FOR Claude Code, not an installable skill, same shape as `skill-protocol-rs`).

Two allowlist entries added (one per `findingType`) since the allowlist scopes on `(skillId, findingType, messagePattern, matchField)` per `allowlist.ts`. Updated `packages/core/tests/skill-scanner/allowlist.test.ts`'s hardcoded golden-list test (9→11 entries) to match.

Refs SMI-6018

Co-Authored-By: claude-flow <ruv@ruv.net>
Co-Authored-By: Claude <noreply@anthropic.com>

[skip-impl-check]