### PR TITLE
fix(deps): Bump nanoid to 3.3.18 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2266,6 +2266,26 @@
         "@ruvector/ruvllm-win32-x64-msvc": "2.3.0"
       }
     },
+    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-arm64-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-x64-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-win32-x64-msvc": {
+      "dev": true,
+      "optional": true
+    },
     "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3983,6 +4003,26 @@
         "@ruvector/ruvllm-linux-x64-gnu": "2.3.0",
         "@ruvector/ruvllm-win32-x64-msvc": "2.3.0"
       }
+    },
+    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-arm64-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-x64-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-win32-x64-msvc": {
+      "dev": true,
+      "optional": true
     },
     "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/chalk": {
       "version": "4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2266,26 +2266,6 @@
         "@ruvector/ruvllm-win32-x64-msvc": "2.3.0"
       }
     },
-    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-arm64-gnu": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-x64-gnu": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-win32-x64-msvc": {
-      "dev": true,
-      "optional": true
-    },
     "node_modules/@claude-flow/cli/node_modules/@ruvector/ruvllm/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4003,26 +3983,6 @@
         "@ruvector/ruvllm-linux-x64-gnu": "2.3.0",
         "@ruvector/ruvllm-win32-x64-msvc": "2.3.0"
       }
-    },
-    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-darwin-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-arm64-gnu": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-linux-x64-gnu": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/@ruvector/ruvllm-win32-x64-msvc": {
-      "dev": true,
-      "optional": true
     },
     "node_modules/@claude-flow/memory/node_modules/@ruvector/ruvllm/node_modules/chalk": {
       "version": "4.1.2",
@@ -25338,9 +25298,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed the high-severity `nanoid` vulnerability (GHSA-2v37-7h3g-55p8) that's been blocking pushes to this repo.

**Quality bar:** Plan reviewed by GPT-5.6-Sol before execution (6 required changes, all applied — npm-version pinning, peer-session coordination, minimal-diff remediation, and more). The fix's own lockfile was verified against a real `npm ci`, which caught a subtle lockfile-consistency issue the first pass introduced and missed with `npm install` alone — fixed in a second commit before this ever reached CI.

**Found along the way:** a separate, pre-existing, unrelated `npm run preflight` failure (SMI-6030) — not fixed here, and not a CI gate today, so out of scope for this PR.

**Net result:** This nanoid fix is fully shipped once merged. The repo's *second* open high-severity alert (`extract-zip`, dev-only, no patched release exists) is handled separately by dismissing the Dependabot alert after this merges — tracked on the same issue (SMI-6031), not part of this diff.

---

## Technical detail

**Commit 1** — `fix(deps): Bump nanoid 3.3.17 -> 3.3.18 (GHSA-2v37-7h3g-55p8)`: `npm update nanoid` on the host (repo-pinned `npm@11.9.0` via corepack). nanoid was pulled in transitively via `postcss@8.5.26`'s `^3.3.17` range (reached from vite/vitest and `eslint-plugin-astro`) — a single hoisted copy, so this one bump covers every path. `package-lock.json` only; `package.json` unchanged; `jose@5.10.0` anchor (SMI-5272) unaffected. This was the sole finding in `npm audit --audit-level=high --omit=dev`, the exact command both the pre-push hook and CI's `Security Audit` job run.

**Commit 2** — `fix(deps): Restore npm-ci-required optional platform stub entries`: commit 1's `npm update` had also pruned two blocks of `@ruvector/ruvllm` platform-optional stub entries (`darwin-arm64`/`darwin-x64`/`linux-arm64-gnu`/`linux-x64-gnu`/`win32-x64-msvc`, nested under `@claude-flow/cli` and `@claude-flow/memory`). That looked like benign lockfile cleanup, but a real `npm ci` flagged the result as out of sync (`Missing: @ruvector/ruvllm-* from lock file`) — these stub entries are load-bearing for `npm ci`'s strict validator even though they only declare unused-on-this-platform variants. Restored via a plain `npm install`; re-verified `npm ci` no longer reports the lockfile as out of sync. No change to nanoid's resolved version or to `package.json`.

**Not in this PR**: the second open high-severity Dependabot alert, `extract-zip` (GHSA-jmr9-qjv8-65gv) — no patched version has ever been published (Dependabot `first_patched_version: null`), it's dev-only (via the VS Code extension's wdio 9.x e2e toolchain → `@puppeteer/browsers` → `extract-zip`), and the only automated "fix" is a breaking wdio v9→v8 downgrade. Handled by dismissing the Dependabot alert (`tolerable_risk`, with a 90-day manual review-by date) after this merges.

**Cross-branch note**: PR #2358 and PR #2192 each independently added their own scoped `"nanoid": "^3.3.18"` override in `package.json` on their own unmerged branches, for this same CVE. Whichever of those merges after this PR should verify the override is now redundant (this fix already resolves nanoid to 3.3.18 on `main`) and drop it.

Plan (reviewed by GPT-5.6-Sol before execution): `docs/internal/implementation/npm-high-severity-vuln-fix-2026-08.md`. Linear: SMI-6031 (this fix), SMI-6030 (unrelated preflight-script issue found along the way).



[skip-impl-check] — lockfile-only dependency bump (package-lock.json), no source code change; SMI references are the tracking issues, not implementation work.
