### PR TITLE
chore(release): weekly cadence bump — 2026-08-16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34034,7 +34034,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
@@ -34065,8 +34065,8 @@
         "sklx": "dist/cli.js"
       },
       "devDependencies": {
-        "@skillsmith/core": "^0.11.6",
-        "@skillsmith/mcp-server": "^0.7.8",
+        "@skillsmith/core": "^0.11.7",
+        "@skillsmith/mcp-server": "^0.7.9",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
         "vitest": "4.1.10"
@@ -34075,7 +34075,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@smith-horn/enterprise": "^0.3.6"
+        "@smith-horn/enterprise": "^0.3.7"
       },
       "peerDependenciesMeta": {
         "@smith-horn/enterprise": {
@@ -34184,7 +34184,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.11.6",
+      "version": "0.11.7",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -34318,18 +34318,18 @@
     },
     "packages/enterprise": {
       "name": "@smith-horn/enterprise",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1106.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.76.0",
-        "@skillsmith/core": "^0.11.6",
+        "@skillsmith/core": "^0.11.7",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.7.8",
+        "@skillsmith/mcp-server": "^0.7.9",
         "@smithy/config-resolver": "4.6.16",
         "@smithy/core": "3.31.1",
         "@smithy/middleware-endpoint": "4.6.16",
@@ -34344,7 +34344,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.7.8"
+        "@skillsmith/mcp-server": "^0.7.9"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -34380,12 +34380,12 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "license": "Elastic-2.0",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "10.1.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.11.6",
+        "@skillsmith/core": "^0.11.7",
         "ajv-formats-draft2019": "1.6.1",
         "ulid": "3.0.1",
         "zod": "3.25.76"
@@ -34434,7 +34434,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.8.7
+
+- **Fix**: Cursor UAT follow-up — website onboarding, CLI/MCP parity, hooks schema (#2375)
 - **Chore**: removed 3 confirmed-dead exports flagged by the new `code-health-auditor` skill's first real dogfooding run (SMI-6023) — `displayQuotaProgressBar`/`displayQuotaWarning` (`utils/license.ts`, superseded by inline rendering in `displayLicenseStatus`) and `getTrustTierColor` (`commands/search-formatters.ts`, a one-line wrapper — real call sites already index `TRUST_TIER_COLORS` directly), plus the now-dead re-export of `getTrustTierColor` from `commands/search.ts`. No public API surface change — `packages/cli` ships as a bin-only bundle with no `exports`/`main`/`types` field. 3 other candidates the scan flagged were verified as false positives (same-file callers the tool's coverage check missed) and kept.
 - **Fix**: `list --client cursor`'s footer no longer hardcodes `~/.claude/skills` — it now names the resolved client's actual install path, via `manage.action.ts` reusing the existing `getInstallPath(client)` pattern (SMI-5893 Wave 7, GH#2368)
 - **Fix**: `recommend`'s footer no longer hardcodes `~/.claude/skills` either — since `recommend`'s auto-detection scans across every installed client rather than one, the footer now describes multi-harness detection accurately instead of naming one client path. `recommend --context` also dedupes duplicate rows by `skill.id` (client-side mitigation; the schema-level root cause stays with the separately-tracked SMI-5898) (SMI-5893 Wave 7, GH#2368)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@ Part of Skillsmith: a lifecycle layer for agent skills across teams.
 
 ## Contents
 
-- [What's New](#whats-new-in-v086)
+- [What's New](#whats-new-in-v087)
 - [Installation](#installation)
 - [Commands](#commands)
   - [inventory](#inventory)
@@ -16,7 +16,7 @@ Part of Skillsmith: a lifecycle layer for agent skills across teams.
 - [Examples](#examples)
 - [Privacy & Data Handling](#privacy--data-handling)
 
-## What's New in v0.8.6
+## What's New in v0.8.7
 
 - **Multi-client targeting fixed across the board**: `install`, `list`, `remove`, `update`, `sync`, and `search -i`'s install action now all honor `SKILLSMITH_CLIENT`/`--client` consistently — previously several of these silently acted on the Claude Code directory regardless of the flag or env var.
 - **`update` no longer fails after a fresh install**: now resolves the installed skill's registry source from the manifest `install` already writes, instead of a dead-code path that could never find it.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
   "type": "module",
   "bin": {
@@ -39,14 +39,14 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@skillsmith/core": "^0.11.6",
-    "@skillsmith/mcp-server": "^0.7.8",
+    "@skillsmith/core": "^0.11.7",
+    "@skillsmith/mcp-server": "^0.7.9",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@smith-horn/enterprise": "^0.3.6"
+    "@smith-horn/enterprise": "^0.3.7"
   },
   "peerDependenciesMeta": {
     "@smith-horn/enterprise": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.11.7
+
+- **Fix**: Cursor UAT follow-up — website onboarding, CLI/MCP parity, hooks schema (#2375)
+- **Feature**: SMI-5879 Wave 1 -- implement G-5 fixture-corpus corroboration (#2354)
 - **Fix**: Cursor's `hooks.json` is now written in Cursor's actual native schema (`{ version: 1, hooks: { sessionStart: [{ command }] } }`) instead of Claude Code's entry shape (`{ matcher, hooks: [{ type, command }] }`) — the prior shape was silently invalid, and Cursor drops all hooks when the required top-level `version` key is missing. New `install/agent-pack-installer.cursor-hooks.ts` builder, split out from the shared Claude/generic JSON-hooks installer since the two schemas are structurally different, not just differently-keyed (SMI-5893 Wave 8, GH#2368)
 - **Feature**: bundled agent-pack SKILL.md generation (`services/agent-pack/skill-md.ts`) now includes a "CLI Fallback" section, matching the pattern already shipped in `@skillsmith/cli`'s bundled skill, so an agent with a disconnected MCP server has a documented fallback instead of instructing dead tool calls (SMI-5893 Wave 6, GH#2368)
 - **Feature**: new `services/recommend-guard.ts` shared helper (footer-text + dedup-by-`skill.id`) used by both `@skillsmith/cli` and `@skillsmith/mcp-server`'s `recommend` implementations, replacing two independent hardcoded-footer implementations (SMI-5893 Wave 7, GH#2368)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,13 +6,13 @@ Part of Skillsmith: a lifecycle layer for agent skills across teams.
 
 ## Contents
 
-- [What's New](#whats-new-in-v0116)
+- [What's New](#whats-new-in-v0117)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Features](#features)
 - [Exports](#exports)
 
-## What's New in v0.11.6
+## What's New in v0.11.7
 
 - **Security-status reporting unified**: CLI and MCP now derive security-scan status (pass/fail, risk score, findings count) from one shared `deriveSecuritySummaryFromApiSkill`/`deriveSecuritySummaryFromSkillRow`, instead of two independently-maintained copies that could disagree on the same skill.
 - **`skill_compare` reuses `get_skill`'s resolution**: new shared `resolveSkillApiFirst()` fixes compare only ever hitting the local SQLite cache (no longer kept in sync with the remote-first registry), which made real, searchable skills report "not found."

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.11.6'
+export const VERSION = '0.11.7'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+## v0.3.7
+
+- **Chore**: bump the smithy group across 1 directory with 7 updates (#2254)
+- **Chore**: bump the opentelemetry group across 1 directory with 7 updates (#2257)
+- **Chore**: bump @aws-sdk/client-cloudwatch-logs (#2251)
+
 ## v0.3.6
 
 - **Cadence**: Mechanical cadence alignment (no changes since v0.3.5).

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smith-horn/enterprise",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1106.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.76.0",
-    "@skillsmith/core": "^0.11.6",
+    "@skillsmith/core": "^0.11.7",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.7.8",
+    "@skillsmith/mcp-server": "^0.7.9",
     "@smithy/config-resolver": "4.6.16",
     "@smithy/core": "3.31.1",
     "@smithy/middleware-endpoint": "4.6.16",
@@ -62,7 +62,7 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.7.8"
+    "@skillsmith/mcp-server": "^0.7.9"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.7.9
+
+- **Fix**: Cursor UAT follow-up — website onboarding, CLI/MCP parity, hooks schema (#2375)
 - **Fix**: both bundled SKILL.md assets (`assets/agent-pack/SKILL.md`, `assets/skills/skillsmith/SKILL.md`) now include a "CLI Fallback" section, ported from `@skillsmith/cli`'s existing one, instead of instructing MCP tool calls with no fallback when the server isn't connected. A new parity regression test in `@skillsmith/core` guards against the three bundled copies drifting again (SMI-5893 Wave 6, GH#2368)
 - **Fix**: `recommend`'s footer no longer hardcodes `~/.claude/skills` — now uses a shared `recommend-guard.ts` helper (`@skillsmith/core`) so the CLI and MCP formatters can't drift, and describes multi-harness detection accurately since `recommend`'s auto-detection scans every installed client rather than one (SMI-5893 Wave 7, GH#2368)
 - **Fix**: first-run install messaging (`onboarding/first-run.ts`) now names both opt-out env vars (`SKILLSMITH_SKIP_SKILL_INSTALL`, `SKILLSMITH_TIER1_AUTOINSTALL_DISABLE`) so a silent first-connect skill install is at least explainable — still emitted via stderr only (this is a stdio MCP server; stdout is reserved for JSON-RPC) and only after the fire-and-forget Tier-1 registry install actually resolves (SMI-5893 Wave 8, GH#2368)

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,7 +6,7 @@ MCP (Model Context Protocol) server for agent skill publishing, installation, an
 
 Part of Skillsmith: a lifecycle layer for agent skills across teams.
 
-## What's New in v0.7.8
+## What's New in v0.7.9
 
 - **`search`'s `limit` parameter actually works now**: previously advertised in the tool description but silently dropped — no `limit` field existed in the input schema at all. Now threaded through both the API and local-fallback paths, clamped to `[1, 100]`.
 - **`skill_compare` and `skill_recommend` fixed**: compare now resolves any skill `search`/`get_skill` can find (was local-cache-only); recommend no longer 400s or silently zeroes on an empty derived stack — both return a structured, actionable result instead.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
   "type": "module",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@cyclonedx/cyclonedx-library": "10.1.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.11.6",
+    "@skillsmith/core": "^0.11.7",
     "ajv-formats-draft2019": "1.6.1",
     "ulid": "3.0.1",
     "zod": "3.25.76"

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.7.8",
+  "version": "0.7.9",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": ["claude-code", "agent-skills", "autonomous-agents", "openclaw"]
@@ -17,7 +17,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -116,7 +116,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.7.8'
+const PACKAGE_VERSION = '0.7.9'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 const logger = createLogger('mcp', { version: PACKAGE_VERSION }) // SMI-5615
 import { installBundledSkills, installUserDocs } from './onboarding/install-assets.js'

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## v0.7.7
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.7.6).
+
 ## v0.7.6
 
 - **Cadence**: Mechanical cadence alignment (no changes since v0.7.5).

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
Automated weekly release cadence PR opened by `release-cadence.yml` (SMI-4191).

## What this PR does

Runs `scripts/prepare-release.ts --all=patch` to bump all packages by one patch version and drain per-package CHANGELOG `[Unreleased]` sections into the new versions.

## What to check before merging

1. The bumped versions match what you want to ship (patch/minor/major). If minor or major is needed, close this PR, run `prepare-release.ts` with the right flags locally, and open a manual PR.
2. The CHANGELOG entries read cleanly and reference the right Linear issues.
3. CI is green.

## After merging

Trigger publish: `gh workflow run publish.yml -f dry_run=false`. The `create-gh-release` job will create matching GitHub Releases automatically.

Parent: SMI-4144. See [ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md).