### PR TITLE
docs(blog): split dead-code story from Docker story, open-source the skill

### DIFF
--- a/packages/website/src/content/blog/the-function-we-almost-deleted.md
+++ b/packages/website/src/content/blog/the-function-we-almost-deleted.md
@@ -1,11 +1,11 @@
 ---
 title: "The Function We Almost Deleted"
-description: "We built a dead-code scanner for our own codebase, ran it for real, and it flagged a function that was actually load-bearing. Here's the near-miss, the fix, and what was really slowing down our Docker containers."
+description: "We built a dead-code scanner for our own codebase, ran it for real, and it flagged a function that was actually load-bearing. Here's the near-miss, the root cause, and why the tool is now open source."
 author: "Ryan Smith"
 date: 2026-08-14
-updated: 2026-08-14
+updated: 2026-08-15
 category: "Engineering"
-tags: ["dead-code", "code-health", "developer-tooling", "docker", "engineering-culture", "monorepo", "code-quality"]
+tags: ["dead-code", "code-health", "developer-tooling", "open-source", "engineering-culture", "monorepo", "code-quality"]
 featured: false
 draft: false
 ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/the-function-we-almost-deleted/01-hero"
@@ -28,11 +28,9 @@ Our scanner's report had one line that would have broken a working command: `com
 
 ## Why we went looking for dead code in the first place
 
-We'd noticed our Docker containers running hotter than they used to, and the easy explanation was sitting right there: our codebase has grown fast (over 2,700 commits in about seven months), so of course every build and test run costs more compute than it did six months ago. More code, more work. Obvious.
+Our codebase has grown fast: over 2,700 commits in about seven months. At that pace, dead code piles up quietly. Helpers get superseded by rewrites, wrappers get bypassed, and nobody circles back to delete the leftovers, because deleting code you didn't write feels riskier than ignoring it. We'd been eyeballing candidates ad hoc and wanted something principled instead.
 
-It's also only part of the story.
-
-We dug into `docker-compose.yml` and found the real bottleneck: our dev containers have no CPU or memory limit set. Picture a parking garage with no posted capacity. Cars keep pulling in, and nobody ever gets turned away at the gate. Every container we spin up, for every parallel task, competes for the exact same slice of the host machine's CPU and memory, with no ceiling on how many can pile in at once. We work in a style that spins up a fresh container per task by design, so as the number of things happening in parallel grows, the squeeze grows with it. That's an infrastructure fix, riskier and slower to review, and we've filed it separately. This post isn't about that fix. It's about the smaller, complementary thing we could actually ship this week: making sure every build only pays for code that's actually doing something.
+We're also not the first to take this seriously. Farhan Thawar, VP and Head of Engineering at Shopify, runs an internal program called the [Dead Code Club](https://x.com/fnthawar/status/2085713494838526424): 5 million lines of code deleted in one push last summer, then another 15 million at the company's Summit event in July. That's the precedent. Our version needed to be smaller and a lot more paranoid.
 
 ## Building a scanner that's allowed to say "I don't know"
 
@@ -46,7 +44,7 @@ So we added a fourth category most tools skip: *needs runtime verification, insu
 
 We pointed the finished tool at one package (our CLI) and let it work. Six functions came back tagged "safe to delete." Four more got flagged as possible duplicates worth a second look.
 
-Then we did something a lot of automated cleanup tools skip: we didn't trust the "safe" label at face value. We had a second, more careful pass re-check every single candidate by hand, searching the *entire* codebase (not just the one package the scanner looked at) and confirming none of it was secretly part of a public interface other code depends on.
+Then we did something a lot of automated cleanup tools skip: we didn't trust the "safe" label at face value. We had a second, more careful pass re-check every single candidate by hand, searching the *entire* codebase rather than only the one package the scanner looked at, and confirming none of it was secretly part of a public interface other code depends on.
 
 Two of the six didn't survive that check. `compareCandidates` was one false alarm. A validation function guarding our private registry install path was the other, which would have quietly removed a security check if we'd trusted the scanner's first answer.
 
@@ -56,16 +54,65 @@ The four functions that survived every check really were dead: two quota-display
 
 ## What this actually proves
 
-This first pass was small on purpose. Ninety-eight lines out of a codebase with a couple thousand test files isn't going to show up in a build-time chart, and pretending otherwise would be the kind of overclaiming we'd rather not do. What it *does* prove is that the safety net holds under a real test, not just a hypothetical one. The tool caught genuinely dead code. It also almost shipped two false positives, and the verification pass caught both before they became a real regression. That's why we built a scanner that proposes and a separate pass that verifies, instead of one script that just deletes: the interesting failures don't show up until you run it against a real, messy codebase with conventions the tool has never seen before.
+This first pass was small on purpose. Ninety-eight lines out of a codebase with a couple thousand test files isn't a headline number, and pretending otherwise would be the kind of overclaiming we'd rather not do. What it *does* prove is that the safety net holds under a real test instead of a hypothetical one. The tool caught genuinely dead code. It also almost shipped two false positives, and the verification pass caught both before they became a real regression. That's why we built a scanner that proposes and a separate pass that verifies, instead of one script that just deletes: the interesting failures don't show up until you run it against a real, messy codebase with conventions the tool has never seen before.
 
-The Docker fix is still ahead of us, tracked as its own piece of work with its own review. The dead-code tool keeps running, one package at a time, each pass teaching it more about our own codebase's quirks. Put the two together and you get a more honest answer than "the codebase got bigger" ever was.
+The tool keeps running here, one package at a time, each pass teaching it more about our own codebase's quirks. And now it can run on yours too.
+
+## The tool is public now
+
+The scanner started life as an internal skill for our own coding agents. As of this week the whole thing is public at [smith-horn/code-health-auditor](https://github.com/smith-horn/code-health-auditor). This post describes the tool; the repo lets you install it and point your own coding agent at your own codebase.
+
+Getting it from "works for us" to "honest to publish" took its own cleanup pass, and we used our own CLI to do it.
+
+### Commands we ran
+
+First, structure validation:
+
+```
+$ skillsmith validate .claude/skills/code-health-auditor
+VALID
+Warnings:
+  - Consider adding tags for better searchability
+```
+
+Sound structure, one warning about missing tags. We added the tags.
+
+Then the reference check. `skillsmith publish --check-references` ships with default patterns for structural leaks: Docker container names, npm scopes, project URLs, GitHub repo references, suspicious line counts. On top of those we supplied three custom patterns for this repo's own fingerprints: our brand name, our issue-tracker prefix, and our internal package paths.
+
+```
+$ skillsmith publish --check-references \
+    --reference-patterns 'Skillsmith,SMI-[0-9]+,packages/(cli|mcp-server|core)' \
+    .claude/skills/code-health-auditor
+
+  References in SKILL.md:
+    L4: Skillsmith (Custom pattern)
+    L82: SMI-5447 (Custom pattern)
+    L34: packages/cli (Custom pattern)
+    ...
+
+  References in patterns/README.md:
+    L24: SMI-5879 (Custom pattern)
+    ...
+
+  ⚠️  Found 30 project-specific reference(s) across 2 file(s)
+  These may leak internal project details. Review before publishing.
+
+✔ Skill prepared for publishing
+```
+
+Thirty real internal references across two files, and every one of them would have made the "reusable" claim a lie: package names from our monorepo, issue numbers from our tracker, our own product name woven through the prose.
+
+One honest note for anyone else preparing a skill for release: every hit above says "Custom pattern." The default patterns alone found zero of the thirty, because a plain-English mention of your own product name isn't a URL, a container name, or an npm scope. The defaults catch structural leaks; they can't know your brand. A clean default run is not the same as a clean skill, so pass your own name, tracker prefix, and internal paths as custom patterns before you trust the result.
+
+After genericizing the package names, stripping the issue-tracker numbers, and replacing brand mentions with generic language, a second `skillsmith publish --check-references` run came back clean: zero references found.
 
 ---
 
 ## Key Takeaways
 
-- **The obvious explanation was only part of the story.** Rising Docker compute looked like a codebase-growth problem; the bigger driver turned out to be containers with no resource ceiling competing for the same host machine, tracked as a separate fix.
+- **Dead-code deletion is a real engineering discipline, with real precedent.** Shopify's internal Dead Code Club deleted 5 million lines of code in one push, then 15 million more at its Summit event in July. Our version is smaller and adds a verification pass.
 - **A dead-code scanner needs a fourth answer besides "delete it" and "keep it."** Ours added "I can't tell yet" as an explicit, first-class category, after an adversarial design review found real cases where a confident answer would have been wrong.
 - **"Safe to delete" from a tool is a candidate, not a verdict.** A second, independent verification pass against the full codebase caught two false positives in this run's very first outing, one of them a security-relevant validation check.
 - **Both false positives traced back to one root cause**: a test-coverage check blind to half our test-file conventions. The tool now defends against it with a regression test.
 - **The real cleanup was small on purpose**: 4 functions, 98 lines, verified from three directions before deletion. Small and verifiably safe beats large and merely plausible.
+- **The tool is now open source.** [smith-horn/code-health-auditor](https://github.com/smith-horn/code-health-auditor) is public and installable. Preparing it surfaced 30 internal references across 2 files, all from custom patterns, so bring your own brand name and tracker prefix to `--check-references` before trusting a clean run.

--- a/packages/website/src/content/blog/the-function-we-almost-deleted.md
+++ b/packages/website/src/content/blog/the-function-we-almost-deleted.md
@@ -1,6 +1,6 @@
 ---
 title: "The Function We Almost Deleted"
-description: "We built a dead-code scanner for our own codebase, ran it for real, and it flagged a function that was actually load-bearing. Here's the near-miss, the root cause, and why the tool is now open source."
+description: "We built a dead-code scanner for our own codebase, ran it for real, and it flagged a function that was actually load-bearing. Here's the near-miss, the root cause, and why we spun the tool out as its own MIT-licensed repo."
 author: "Ryan Smith"
 date: 2026-08-14
 updated: 2026-08-15
@@ -86,12 +86,12 @@ $ skillsmith publish --check-references \
 
   References in SKILL.md:
     L4: Skillsmith (Custom pattern)
-    L82: SMI-5447 (Custom pattern)
+    L82: SMI-XXXX (Custom pattern)
     L34: packages/cli (Custom pattern)
     ...
 
   References in patterns/README.md:
-    L24: SMI-5879 (Custom pattern)
+    L24: SMI-XXXX (Custom pattern)
     ...
 
   ⚠️  Found 30 project-specific reference(s) across 2 file(s)
@@ -115,4 +115,4 @@ After genericizing the package names, stripping the issue-tracker numbers, and r
 - **"Safe to delete" from a tool is a candidate, not a verdict.** A second, independent verification pass against the full codebase caught two false positives in this run's very first outing, one of them a security-relevant validation check.
 - **Both false positives traced back to one root cause**: a test-coverage check blind to half our test-file conventions. The tool now defends against it with a regression test.
 - **The real cleanup was small on purpose**: 4 functions, 98 lines, verified from three directions before deletion. Small and verifiably safe beats large and merely plausible.
-- **The tool is now open source.** [smith-horn/code-health-auditor](https://github.com/smith-horn/code-health-auditor) is public and installable. Preparing it surfaced 30 internal references across 2 files, all from custom patterns, so bring your own brand name and tracker prefix to `--check-references` before trusting a clean run.
+- **The tool now has its own MIT-licensed repo.** [smith-horn/code-health-auditor](https://github.com/smith-horn/code-health-auditor) is public and installable, separate from Skillsmith's own source-available license. Preparing it surfaced 30 internal references across 2 files, all from custom patterns, so bring your own brand name and tracker prefix to `--check-references` before trusting a clean run.

--- a/packages/website/src/content/blog/the-parking-garage-with-no-gate.md
+++ b/packages/website/src/content/blog/the-parking-garage-with-no-gate.md
@@ -1,0 +1,90 @@
+---
+title: "The Parking Garage With No Gate"
+description: "We run a dedicated Docker container for every parallel coding-agent session. It worked great until the host machine started drowning. Here are the six things we had to build to make many concurrent containers survivable."
+author: "Ryan Smith"
+date: 2026-08-15
+updated: 2026-08-15
+category: "Engineering"
+tags: ["docker", "developer-tooling", "engineering-culture", "infrastructure", "agentic-engineering"]
+featured: false
+draft: false
+ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/the-parking-garage-with-no-gate/01-hero"
+---
+
+<!-- IMAGE: 01-hero
+  A wide-format hero graphic with a dark gradient background (deep navy to charcoal),
+  consistent with the existing Skillsmith blog aesthetic. Center composition: a
+  stylized multi-level parking garage rendered in a flat/geometric style, seen at
+  a three-quarter angle. Small glowing rectangular "containers" (like shipping
+  containers or server-rack blocks, doubling as "cars") are packed into every
+  level with no marked capacity and no barrier arm at the entrance ramp. One
+  level near the top shows a newly-added barrier arm / gate with a ticket-booth
+  icon, glowing amber, visually distinct from the rest of the still-open garage,
+  suggesting a fix in progress. Faint ghosted grid lines in the background evoke
+  a circuit board / server topology. Style: flat/geometric, dark, technical.
+  Dimensions: 1200x630.
+-->
+![The Parking Garage With No Gate](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/the-parking-garage-with-no-gate/01-hero)
+
+A few months ago we noticed our Docker containers running hotter than they used to. Fans spinning up on an idle-looking afternoon. Builds that used to take two minutes taking six. The first guess was the obvious one: our codebase got bigger. That was true. The monorepo had absorbed thousands of commits in a matter of months, and bigger codebases cost more to build and test.
+
+But it was only part of the story. The real driver was a decision we'd made on purpose and never finished. Our development workflow spins up a dedicated Docker container per task, because we run many coding-agent sessions in parallel, each on its own isolated git worktree. One session refactors a service while another writes tests for a different package while a third chases a flaky CI job. Isolation per task is a genuinely good pattern. Containers don't step on each other's files, branches, or dependency state.
+
+What we'd built was a parking garage with no posted capacity and no gate. Cars keep pulling in. Nobody ever gets turned away. Every container that enters competes for the exact same slice of host CPU and memory as every other one, unbounded. Three sessions, fine. Six, sluggish. Ten, and the whole machine is a line of cars idling in the aisles, every one of them convinced it's about to find a spot.
+
+The tempting fix is a bigger garage: more RAM, more cores. That treats the symptom. The actual fix is a gate with a real ticket system. Explicit limits, plus the operational tooling that makes many concurrent, isolated containers survivable instead of a free-for-all. Here's what that took, as six principles you can apply directly if your own agent tooling is about to run many concurrent sessions in Docker.
+
+## 1. Post a capacity number, because Docker won't
+
+Docker Compose gives your dev service no resource ceiling by default. No `cpus`, no `mem_limit`, no `deploy.resources.limits` means every container you start is entitled to the entire host. That's the garage with no posted capacity, literally: the constraint doesn't exist until you write it down.
+
+So write it down. Put a numeric ceiling on the compose service definition. And size it with a documented formula, not a hardcoded value. A limit calibrated for a 16-core, 64GB machine will starve a laptop with half the resources and waste half of a bigger workstation. The number itself matters less than the fact that it's derived from the host's real core and RAM count, and that the derivation is written where the next person can find it. Copy the formula between machines, never the value.
+
+## 2. Assign the parking spots
+
+If every dev container defaults to the same port, say 3000 or 3001, only one of them can bind it. The second container to start doesn't degrade gracefully. It fails outright, and in an agent-driven workflow, it fails while nobody is watching.
+
+A fixed port baked into the base compose file is a single parking spot with ten cars aimed at it. The fix is a port allocation scheme that is deterministic per worktree but collision-safe across worktrees: an env var override like `DEV_PORT=<n>`, combined with a bucket-assignment scheme so two worktrees don't land on the same number by coincidence. Deterministic matters because tooling needs to predict where a given worktree's server lives. Collision-safe matters because "pick a random port" trades one intermittent failure for another.
+
+## 3. Don't let two cars share one engine
+
+The nastiest failures came from native modules. If multiple containers bind-mount the same host directory read-write, say a shared `node_modules`, and any of those modules were compiled for the host's architecture instead of the container's, you're in trouble the moment two containers touch that mount concurrently. On a macOS ARM host running Linux containers, the mismatch is guaranteed. It surfaces as a cryptic "invalid ELF header" or a native binding that refuses to load, hours after the action that caused it, in a container that did nothing wrong.
+
+The durable pattern has two halves. Mount shared dependency directories read-only into each container, so no container can corrupt what its siblings depend on. Then seed the native modules, the handful that actually need per-architecture compilation, into separate named volumes per container, outside the shared mount. You get the speed of sharing everything that's safe to share, and isolation for exactly the parts that aren't.
+
+The pattern to avoid is a full dependency reinstall inside every container. It works, but it's slow, and it quietly defeats the reason you shared anything in the first place.
+
+## 4. Know which car is yours before you turn the key
+
+With one container, `docker exec` into "the dev container" is unambiguous. With ten containers across ten worktrees, any script, wrapper, or hook that resolves a container by a loose convention can silently land on the wrong one. This is the failure mode that scared us most, because it produces no error. You run tests against a sibling task's container, they pass against the sibling's code, and you ship a change you never actually tested.
+
+Two rules fixed it. First, container names are generated deterministically from the worktree path and branch at container-creation time, so identity is derived, never assumed. Second, every script that targets a container must fail loudly when it can't resolve the container it was aimed at. A tool that guesses is worse than a tool that stops, because the guess looks exactly like success.
+
+## 5. The garage has to reopen itself
+
+Agents run unattended for long stretches, and long stretches include Docker Desktop restarts, host reboots, and the occasional corrupted native binding from an architecture mismatch. If recovering from any of those requires a human to notice a cryptic error and run a manual rebuild command, your workflow has an availability problem, because the human is asleep and the agent is stuck.
+
+Two mechanisms cover most of it. `restart: unless-stopped` on the compose service brings containers back on their own after a host restart, while still honoring an explicit stop. And an entrypoint-level self-heal step detects broken native bindings on container start and rebuilds them automatically. Every failure that previously read "notice the error, look up the fix, run the rebuild" became "restart the container." Most of the time, nobody even does the restarting.
+
+## 6. Check the ticket still matches the car
+
+When multiple containers and worktrees share one host-side dependency tree, that tree drifts. A branch that added a dependency won't magically trigger a fresh install when you check it out. A branch that removed one leaves the old artifact sitting there. "It was installed at some point" is not evidence that it's correct for what's currently checked out, but it's exactly what an unguarded setup silently assumes.
+
+The fix is an explicit freshness check: hash the lockfile's content, compare it against a sentinel value stamped at the last real install, and warn or block when they diverge. It's a small amount of machinery for a large class of bug, the kind where a test fails against a dependency version that no branch actually specifies, and you spend an hour debugging code that was never wrong.
+
+## What changed when the gate went up
+
+The mechanical wins showed up first. The host stopped thrashing under load, because a container hitting its ceiling slows itself down instead of slowing everyone down. Port failures went to zero. The "invalid ELF header" class of corruption stopped happening, because no container can write into a sibling's dependencies anymore. Restarts and rebinding repairs happen without a human in the loop.
+
+But the bigger win was the one the analogy predicts. A garage with a gate and a ticket system doesn't only control entry. It tells you who's inside, and it lets you reason about capacity instead of discovering it through failure. When the machine slows down now, we can say which containers hold which resources and decide, deliberately, whether to admit another session. Before, the only signal was the whole building groaning.
+
+If your agent tooling is heading toward many concurrent sessions in Docker, the isolation-per-task pattern is worth keeping. Just don't do what we did and build the garage first, then wait for the traffic jam to design the gate. Docker gives you the walls and the spots. The ceiling, the ticket system, and the tow truck are yours to build.
+
+## Key Takeaways
+
+- Set explicit `cpus` and memory limits on your dev compose service, sized by a documented formula from the host's real core and RAM count, never a hardcoded value copied between machines.
+- Give each concurrent container a deterministic, collision-safe port via an env override and a bucket-assignment scheme, instead of a fixed port in the base compose file.
+- Mount shared dependency directories read-only and seed per-architecture native modules into per-container named volumes; skip the full reinstall-everywhere approach.
+- Derive container names deterministically from the worktree path and branch, and make every container-targeting script fail loudly when it can't resolve its intended target.
+- Add `restart: unless-stopped` plus an entrypoint self-heal that rebuilds broken native bindings on start, so recovery never waits on a human noticing a cryptic error.
+- Guard shared dependency trees with a lockfile content hash checked against a sentinel from the last real install, and warn or block on drift instead of running stale dependencies.


### PR DESCRIPTION
## Business Summary

**What shipped:** The code-delete-skill blog post got a focused rewrite — cut the Docker material, added a direct reference to Shopify's internal "Dead Code Club" (Farhan Thawar, VP and Head of Engineering — 5 million lines deleted in one push, then 15 million more at the company's Summit event in July), and documented the real commands used to open-source the skill. The Docker/concurrent-container story is now its own post, "The Parking Garage With No Gate," with six concrete principles for anyone running many parallel coding-agent sessions in Docker.

**Quality bar:** Both posts independently verified (not just trusted from the drafting pass) for zero em dashes, zero AI-tell vocabulary, and valid frontmatter. The new post's hero image was generated, uploaded to Cloudinary, and both URLs confirmed live with real HTTP requests, not just trusted from the upload API's response.

**Found along the way:** Preparing the code-health-auditor skill for its own public repo (a separate, non-code change — the user pushes that repo themselves) surfaced a real, useful finding now documented in the rewritten post: the skillsmith CLI's own `publish --check-references` tool caught 30 internal references across 2 files, but its *default* patterns alone found zero of them — a plain-English brand mention isn't a URL, container name, or npm scope, so custom patterns were required to catch the rest. Worth knowing before trusting a clean default run when preparing any skill for release.

**Net result:** Fully shipped. No follow-up needed on the blog content. The public skill repo itself is a separate manual step, already staged and ready for the user to push.

---

## Technical detail

- `packages/website/src/content/blog/the-function-we-almost-deleted.md` — rewritten in place. Removed the Docker/parking-garage section, added the Shopify Dead Code Club reference with a real link, added a "Commands we ran" section with the actual `skillsmith validate` + `skillsmith publish --check-references` transcript, linked the new public repo (github.com/smith-horn/code-health-auditor). `updated` bumped to reflect the rewrite date.
- `packages/website/src/content/blog/the-parking-garage-with-no-gate.md` — new post. Six sections (resource ceilings, port allocation, bind-mount native-module isolation, deterministic container naming, self-healing recovery, dependency-freshness checks), each extending the parking-garage analogy. No internal ticket numbers, repo paths, or tool names.
- Hero image for the new post: generated via Gemini (`gemini-3-pro-image-preview`), uploaded to Cloudinary under `blog/the-parking-garage-with-no-gate/01-hero`, both the blog (`w_1200`) and OG (`w_1200,h_630,c_fill`) transform URLs confirmed live via direct `curl -sI` (HTTP 200, `image/jpeg`).

Refs SMI-6023

[skip-impl-check]
