### PR TITLE
fix(blog): correct resource-ceiling overclaim in parking-garage post

### DIFF
--- a/packages/website/src/content/blog/the-parking-garage-with-no-gate.md
+++ b/packages/website/src/content/blog/the-parking-garage-with-no-gate.md
@@ -3,7 +3,7 @@ title: "The Parking Garage With No Gate"
 description: "We run a dedicated Docker container for every parallel coding-agent session. It worked great until the host machine started drowning. Here are the six things we had to build to make many concurrent containers survivable."
 author: "Ryan Smith"
 date: 2026-08-15
-updated: 2026-08-15
+updated: 2026-08-16
 category: "Engineering"
 tags: ["docker", "developer-tooling", "engineering-culture", "infrastructure", "agentic-engineering"]
 featured: false
@@ -74,11 +74,11 @@ The fix is an explicit freshness check: hash the lockfile's content, compare it 
 
 ## What changed when the gate went up
 
-The mechanical wins showed up first. The host stopped thrashing under load, because a container hitting its ceiling slows itself down instead of slowing everyone down. Port failures went to zero. The "invalid ELF header" class of corruption stopped happening, because no container can write into a sibling's dependencies anymore. Restarts and rebinding repairs happen without a human in the loop.
+Some of the mechanical wins showed up already. Port failures went to zero. The "invalid ELF header" class of corruption stopped happening, because no container can write into a sibling's dependencies anymore. Restarts and rebinding repairs happen without a human in the loop.
 
-But the bigger win was the one the analogy predicts. A garage with a gate and a ticket system doesn't only control entry. It tells you who's inside, and it lets you reason about capacity instead of discovering it through failure. When the machine slows down now, we can say which containers hold which resources and decide, deliberately, whether to admit another session. Before, the only signal was the whole building groaning.
+The capacity number is the piece we haven't built yet. Right now, when the machine slows down, the only signal is the whole building groaning, exactly the failure mode principle #1 describes, because nothing on the host can tell you which container is over its limit until the limit is written down somewhere. That's next, and it's deliberately not a hardcoded value: it needs the same per-machine formula and Decision Log treatment as every other threshold in this post.
 
-If your agent tooling is heading toward many concurrent sessions in Docker, the isolation-per-task pattern is worth keeping. Just don't do what we did and build the garage first, then wait for the traffic jam to design the gate. Docker gives you the walls and the spots. The ceiling, the ticket system, and the tow truck are yours to build.
+If your agent tooling is heading toward many concurrent sessions in Docker, the isolation-per-task pattern is worth keeping. Just don't do what we did and build the garage before the gate. Docker gives you the walls and the spots. The ceiling, the ticket system, and the tow truck are yours to build, and building them together beats waiting for the first traffic jam to force the order.
 
 ## Key Takeaways
 


### PR DESCRIPTION
## Business Summary

The published post "The Parking Garage With No Gate" said, in its "What changed when the gate went up" section, that Docker containers hitting a resource ceiling were already slowing themselves down instead of slowing the whole host. That's not true yet — `docker-compose.yml`'s `dev` service has no `cpus`, `mem_limit`, or `deploy.resources.limits` configured. The post's own principle #1 and its Key Takeaways bullet correctly describe this as something to build, not something already built; only the narrative "what changed" section contradicted them.

Caught while answering a follow-up question about next steps for Docker optimization — verified directly against `docker-compose.yml` rather than trusted from the post's own text.

## What changed

Reworded the "What changed when the gate went up" section to only claim the wins that are real (port collisions resolved, native-module ELF corruption stopped, self-healing restarts), and to name the resource ceiling honestly as the next piece to build, consistent with the rest of the post.

## Quality bar

Diff-scoped to the one section; verified against the actual `docker-compose.yml` state before and after the edit. `updated` frontmatter bumped.

## Net result

Fully done. No further follow-up needed on the post itself. The resource-ceiling fix is real outstanding infra work (tracked as a next step, ADR-109-gated), not something this PR claims to solve.