### PR TITLE
docs(tests): correct anon-budget.test.ts's call-depth claim

### DIFF
--- a/scripts/tests/anon-budget.test.ts
+++ b/scripts/tests/anon-budget.test.ts
@@ -73,10 +73,12 @@ function runShadowCheck(opts: { searchStatus: string; searchUsed?: string }): {
     now_ms() { printf '0'; }
     _anon_budget_search_request() { printf '${opts.searchStatus}\\n${opts.searchUsed ?? ''}\\n{}'; }
 
-    # Real call depth: an intermediate caller between the check and the
-    # top level, matching how smoke-prod.sh's own dispatch loop calls each
-    # check function — this is exactly the shape that exposed TRAP-1 (the
-    # trap fired again on THIS function's return too, not just the check's).
+    # Deliberately MORE sensitive than production's own call depth, not an
+    # exact match of it: smoke-prod.sh:271 calls check functions directly
+    # from its dispatch loop ("$fn" || true), with no intermediate wrapper
+    # function. This extra run_check layer adds one more RETURN-trap firing
+    # point on top of that -- so if TRAP-1 ever reappears, this harness
+    # catches it at least as reliably as production would, never less.
     run_check() {
       check_anon_budget_identity_derivation
       return $?


### PR DESCRIPTION
## Business Summary

**What shipped:** A one-line comment correction in the regression test merged in #2390 — no behavior change.

**Quality bar:** Caught by a post-merge governance retro on #2390 that went further than reading the test: it actually reverted both fixed bugs in scratch copies and confirmed the test suite goes red for each before reporting this as the only (harmless) finding.

**Net result:** Done, no further follow-up.

---

## Technical detail

`scripts/tests/anon-budget.test.ts` claimed its `run_check` wrapper "matches smoke-prod.sh's own dispatch loop's exact call depth" — not accurate. `smoke-prod.sh:271` calls check functions directly (`"$fn" || true`), no intermediate wrapper. Corrected to say the wrapper is deliberately *more* sensitive than production's real call depth, not a literal replica of it.
