### PR TITLE
chore(docs): bump docs/internal pointer for SMI-5893 Waves 9-12 plan

### DIFF
--- a/packages/mcp-server/tests/unit/undo-apply.test.ts
+++ b/packages/mcp-server/tests/unit/undo-apply.test.ts
@@ -230,7 +230,7 @@ describe('undo_apply — refusal: content changed since apply', () => {
 
 describe('undo_apply — scope fence (SMI-4287 reuse)', () => {
   it('refuses to restore a target that escapes the confined skill root via a symlink', async () => {
-    const outsideDir = fs.mkdtempSync('/var/skillsmith-undo-escape-')
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skillsmith-undo-escape-'))
     try {
       const secretPath = path.join(outsideDir, 'secret.md')
       fs.writeFileSync(secretPath, 'top secret content', 'utf-8')


### PR DESCRIPTION
## Business Summary

**What shipped:** Bumps the `docs/internal` submodule pointer to include the GH#2368 V2 retest plan (Waves 9-12) — root-causes and scopes fixes for Tony's 2026-08-16 Cursor UAT follow-up (score 40→56/100), reviewed by GPT-5.6-Sol before merge. No app code change.

**Found along the way:** an unrelated pre-existing test bug (hardcoded `/var/` path requiring root on macOS) that was blocking every push from this branch's pre-push suite — fixed alongside since it was the actual blocker, not scope creep. (Same fix independently landed on PR #2397 for Wave 9's own branch; whichever merges first, the second is a no-op on that line.)

**Net result:** Docs-only, no follow-up beyond the four wave PRs this plan describes (SMI-6057–6060), tracked separately.

---

## Technical detail

- `docs/internal` submodule pointer bump (content already merged at [skillsmith-docs#777](https://github.com/smith-horn/skillsmith-docs/pull/777)).
- `packages/mcp-server/tests/unit/undo-apply.test.ts` — `/var/skillsmith-undo-escape-` → `os.tmpdir()`.