### PR TITLE
fix(website,cli,mcp-server): Cursor MCP onboarding + quota/pricing honesty (SMI-6059)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ Restart Claude Code after editing settings.json.
 {
   "mcpServers": {
     "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
+      "command": "<paste output of: which skillsmith-mcp (macOS/Linux) or where skillsmith-mcp (Windows)>",
       "env": {
         "SKILLSMITH_API_KEY": "sk_live_...",
         "SKILLSMITH_CLIENT": "cursor"
@@ -52,9 +51,9 @@ Restart Claude Code after editing settings.json.
 }
 ```
 
-Cursor 2.4+ required. Reload the window after saving. `SKILLSMITH_CLIENT` routes installs to `~/.cursor/skills` instead of the default `~/.claude/skills`.
+Cursor 2.4+ required, Node >=22.22 (Cursor's own bundled Node meets this). `SKILLSMITH_CLIENT` routes installs to `~/.cursor/skills` instead of the default `~/.claude/skills`.
 
-**Recommended**: `npm install -g @skillsmith/mcp-server` first, then point `command` at the installed `skillsmith-mcp` binary — run `which skillsmith-mcp` after installing to get the exact path (it's platform/npm-prefix specific, e.g. `/opt/homebrew/bin/skillsmith-mcp` on macOS/Homebrew; Linux and Windows paths differ). The `npx -y @skillsmith/mcp-server` form above still works as a fallback, but re-resolves the package on every launch — expect a slower cold start, and watch for `EBADENGINE` (Cursor bundles its own Node, sometimes older than the `>=22.22` this package requires) or `ENOTEMPTY` errors on repeated installs.
+**Setup**: run `npm install -g @skillsmith/mcp-server`, then run `which skillsmith-mcp` (macOS/Linux) or `where skillsmith-mcp` (Windows) and paste that path into `command` above — Cursor's bundled Node cannot resolve packages via `npx` (a real `ENOENT` on a missing `Resources/app/resources/lib` directory), so pointing directly at the installed binary is the only form confirmed to work inside Cursor. Prefer to try `npx` first anyway? Replace `command` with `"npx"` and add `"args": ["-y", "@skillsmith/mcp-server"]` — simpler, but may hit the same `ENOENT`, plus `EBADENGINE` or `ENOTEMPTY` on repeated installs. After saving: enable the server in Cursor's Settings → MCP panel and start a new chat — a correctly-configured entry still shows disconnected until toggled on there — then reload the window.
 
 </details>
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: The Cursor MCP snippet (root README, `@skillsmith/mcp-server`'s README, and the website) no longer defaults to `npx`, which failed inside Cursor on two separate live UAT passes (a real Cursor-bundled-Node ENOENT). The copied `command` is now a resolved-path placeholder (`which`/`where skillsmith-mcp`) that can never point at a wrong path; `npx` stays documented as an explicit, clearly-labeled fallback. Also fixed in the canonical CLI snippet matrix (`templates/mcp-server.template.snippets.ts`, used to scaffold non-Skillsmith MCP servers via `skillsmith author mcp-init`): its Cursor placeholder was hardcoding the literal binary name `skillsmith-mcp` instead of deriving it from the scaffolded server's own package name, and `{{name}}` was never interpolated in a snippet's `notes` text at all — either bug would leak Skillsmith-specific text into a scaffolded (non-Skillsmith) server's generated README (SMI-5893 Wave 11, GH#2368 C-01)
+- **Fix**: Community-tier quota corrected from a stale `1,000` to the actual `100` API calls/month in `displayLicenseStatus` (SMI-5893 Wave 11, GH#2368 C-19)
+
 ## v0.8.7
 
 - **Fix**: Cursor UAT follow-up — website onboarding, CLI/MCP parity, hooks schema (#2375)

--- a/packages/cli/src/templates/mcp-server.template.snippets.ts
+++ b/packages/cli/src/templates/mcp-server.template.snippets.ts
@@ -60,11 +60,22 @@ export const CLIENT_SNIPPETS: Record<SnippetClientId, ClientSnippet> = {
     // SMI-5894 Wave 1 Step 7: SKILLSMITH_CLIENT tells the server to install
     // to ~/.cursor/skills instead of the default ~/.claude/skills — without
     // it, Cursor users silently get Claude Code's install path.
+    //
+    // SMI-5893 Wave 11 (GH#2368 C-01): `command` is a resolved-path
+    // placeholder, not `npx` — Cursor's bundled Node cannot resolve `npx`
+    // packages (a real ENOENT on a missing Resources/app/resources/lib
+    // directory), confirmed by an external tester hitting this on two
+    // separate live UAT passes even after `npx` carried strong caveat text.
+    // A guessed default path (e.g. a Homebrew-style tab) can *also* be
+    // wrong for an nvm/asdf/custom-prefix install, which fails silently
+    // differently instead of predictably — so this deliberately never
+    // guesses a path at all; the primary copied snippet can never be wrong,
+    // only require one resolve-and-paste step. `npx` stays available as an
+    // explicit, clearly-labeled fallback in `notes` below, not removed.
     body: `{
   "mcpServers": {
     "{{name}}": {
-      "command": "npx",
-      "args": ["-y", "{{name}}"],
+      "command": "<paste output of: which {{name}} (macOS/Linux) or where {{name}} (Windows)>",
       "env": {
         "SKILLSMITH_API_KEY": "sk_live_...",
         "SKILLSMITH_CLIENT": "cursor"
@@ -72,16 +83,26 @@ export const CLIENT_SNIPPETS: Record<SnippetClientId, ClientSnippet> = {
     }
   }
 }`,
+    // Assumes the package's `bin` name matches its npm package name — true for
+    // every server scaffolded by mcp-server.template.ts (PACKAGE_JSON_TEMPLATE's
+    // `bin` field is literally `{{name}}`), the only production caller of this
+    // matrix today. The real @skillsmith/mcp-server package is the one exception
+    // (bin is the shorter `skillsmith-mcp`, not the scoped package name) — its
+    // docs are hand-maintained separately (root README, packages/mcp-server/README.md,
+    // website's mcp-client-snippets.ts) rather than rendered through this file.
     notes:
-      'Cursor 2.4+ required. Reload the window after saving. ' +
-      'Recommended: `npm install -g {{name}}` first, then point `command` at the ' +
-      'installed `skillsmith-mcp` binary (run `which skillsmith-mcp` after installing ' +
-      'to get the exact path — it varies by platform/npm prefix, e.g. ' +
-      '`/opt/homebrew/bin/skillsmith-mcp` on macOS/Homebrew, a different path on Linux/Windows). ' +
-      'The `npx -y {{name}}` form above still works as a fallback, but re-resolves the ' +
-      'package on every launch — expect a slower cold start, and watch for EBADENGINE ' +
-      '(Cursor bundles its own Node, sometimes older than the >=22.22 this package requires) ' +
-      'or ENOTEMPTY errors on repeated installs.',
+      "Cursor 2.4+ required, Node >=22.22 (Cursor's own bundled Node meets this). " +
+      'Setup: run `npm install -g {{name}}`, then run `which {{name}}` ' +
+      '(macOS/Linux) or `where {{name}}` (Windows) and paste that path into ' +
+      "`command` above — Cursor's bundled Node cannot resolve packages via `npx` " +
+      '(a real ENOENT on a missing Resources/app/resources/lib directory), so ' +
+      'pointing directly at the installed binary is the only form confirmed to work ' +
+      'inside Cursor. Prefer to try `npx` first anyway? Replace `command` with ' +
+      '`"npx"` and add `"args": ["-y", "{{name}}"]` — simpler, but may hit the same ' +
+      'ENOENT, plus EBADENGINE or ENOTEMPTY on repeated installs. After saving: ' +
+      "enable the server in Cursor's Settings -> MCP panel and start a new chat " +
+      '— a correctly-configured entry still shows disconnected until toggled on ' +
+      'there — then reload the window.',
   },
   copilot: {
     label: 'GitHub Copilot (VS Code)',
@@ -249,7 +270,14 @@ export function renderAllSnippetsAsMarkdown(packageName: string): string {
   const sections = (Object.keys(CLIENT_SNIPPETS) as SnippetClientId[]).map((id) => {
     const snippet = CLIENT_SNIPPETS[id]
     const body = renderSnippet(id, packageName)
-    const notes = snippet.notes ? `\n\n${snippet.notes}` : ''
+    // Found while touching this file for SMI-5893 Wave 11: `notes` was
+    // never interpolated even though the cursor entry's notes text contains
+    // literal `{{name}}` placeholders — a scaffolded server with a
+    // non-Skillsmith packageName (this function's real generic use, per
+    // mcp-server.template.ts:471) would show that placeholder unsubstituted
+    // in its own README.
+    const renderedNotes = snippet.notes?.replace(/\{\{name\}\}/g, packageName)
+    const notes = renderedNotes ? `\n\n${renderedNotes}` : ''
     return [
       `<details>`,
       `<summary><strong>${snippet.label}</strong> — \`${snippet.configPath}\`</summary>`,

--- a/packages/cli/src/utils/license.test.ts
+++ b/packages/cli/src/utils/license.test.ts
@@ -336,6 +336,9 @@ describe('license utilities', () => {
 
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Community'))
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('free tier'))
+      // SMI-5893 Wave 11 (GH#2368 C-19): was wrong by 10x ('1,000 API calls/month');
+      // regression guard for the corrected quota number.
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('100 API calls/month'))
     })
 
     it('displays team tier with expiration date', () => {

--- a/packages/cli/src/utils/license.ts
+++ b/packages/cli/src/utils/license.ts
@@ -72,7 +72,7 @@ export function displayLicenseStatus(status: LicenseStatus): void {
   const tierBadge = formatTierBadge(status.tier)
 
   if (status.tier === 'community') {
-    console.error(`License: ${tierBadge} ${chalk.dim('(free tier - 1,000 API calls/month)')}`)
+    console.error(`License: ${tierBadge} ${chalk.dim('(free tier - 100 API calls/month)')}`)
   } else if (status.tier === 'individual') {
     const expiresInfo = status.expiresAt
       ? chalk.green(`(expires: ${status.expiresAt.toISOString().split('T')[0]})`)

--- a/packages/cli/tests/mcp-server-template-snippets.test.ts
+++ b/packages/cli/tests/mcp-server-template-snippets.test.ts
@@ -1,0 +1,99 @@
+/**
+ * SMI-5893 Wave 11 (GH#2368 C-01): tests for the canonical per-client MCP
+ * config snippet matrix. Previously had zero test coverage — added while
+ * touching this file to fix Cursor's `npx` reliability problem.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  CLIENT_SNIPPETS,
+  renderSnippet,
+  renderAllSnippetsAsMarkdown,
+  SNIPPET_DISPLAY_ORDER,
+} from '../src/templates/mcp-server.template.snippets.js'
+
+describe('mcp-server.template.snippets', () => {
+  describe('cursor entry (SMI-5893 Wave 11, GH#2368 C-01)', () => {
+    // Uses a plain scaffold-shaped name, not '@skillsmith/mcp-server' — this
+    // matrix's only production caller is mcp-server.template.ts's scaffold
+    // path (data.name), where `bin` always equals the package name by the
+    // scaffold's own PACKAGE_JSON_TEMPLATE convention. The real Skillsmith
+    // package's binary name (`skillsmith-mcp`) differs from its scoped
+    // package name and is handled by hand-maintained docs instead (see the
+    // comment on CLIENT_SNIPPETS.cursor in the source file).
+    it('command is a resolved-path placeholder, not npx', () => {
+      const rendered = renderSnippet('cursor', 'my-custom-server')
+      const parsed = JSON.parse(rendered) as {
+        mcpServers: Record<string, { command: unknown; args?: unknown }>
+      }
+      const entry = parsed.mcpServers['my-custom-server']!
+      expect(entry.command).not.toBe('npx')
+      // Unmistakably a placeholder — not a real, plausible-looking path
+      // someone could paste without noticing it's fake.
+      expect(entry.command).toContain('which my-custom-server')
+      expect(entry.command).toContain('where my-custom-server')
+      expect(entry.args).toBeUndefined()
+    })
+
+    it('SKILLSMITH_CLIENT env var is still present', () => {
+      const rendered = renderSnippet('cursor', 'my-custom-server')
+      const parsed = JSON.parse(rendered) as {
+        mcpServers: Record<string, { env?: Record<string, string> }>
+      }
+      // This matrix's cursor body carries a hardcoded API-key placeholder
+      // alongside SKILLSMITH_CLIENT (unlike the website mirror, which
+      // derives the API-key variant separately via withApiKey()) — assert
+      // the key is present, not exact env-block equality.
+      const entry = parsed.mcpServers['my-custom-server']!
+      expect(entry.env?.['SKILLSMITH_CLIENT']).toBe('cursor')
+    })
+
+    it('notes document npx as an explicit, working fallback', () => {
+      const notes = CLIENT_SNIPPETS.cursor.notes ?? ''
+      expect(notes).toContain('npx')
+      expect(notes).toContain('"args": ["-y", "{{name}}"]')
+    })
+
+    it('notes document the Settings -> MCP enable step (GH#2368 C-21)', () => {
+      const notes = CLIENT_SNIPPETS.cursor.notes ?? ''
+      expect(notes.toLowerCase()).toContain('settings')
+      expect(notes.toLowerCase()).toContain('mcp')
+      expect(notes.toLowerCase()).toContain('disconnected')
+    })
+
+    it('notes explain WHY (the real ENOENT), not just what to do', () => {
+      const notes = CLIENT_SNIPPETS.cursor.notes ?? ''
+      expect(notes).toContain('ENOENT')
+    })
+  })
+
+  describe('every other client (regression guard: still uses npx)', () => {
+    const nonCursorIds = SNIPPET_DISPLAY_ORDER.filter((id) => id !== 'cursor')
+
+    it.each(nonCursorIds)('%s body still launches via npx', (id) => {
+      const rendered = renderSnippet(id, '@skillsmith/mcp-server')
+      expect(rendered).toContain('npx')
+    })
+  })
+
+  describe('renderAllSnippetsAsMarkdown — {{name}} interpolation (found while touching this file)', () => {
+    it('interpolates {{name}} in body for every client', () => {
+      const markdown = renderAllSnippetsAsMarkdown('my-custom-server')
+      expect(markdown).not.toContain('{{name}}')
+    })
+
+    it('interpolates {{name}} in notes too — regression guard for the fix', () => {
+      // Before this fix, notes were inserted raw (no .replace()), so any
+      // notes text containing a literal {{name}} placeholder (cursor's did)
+      // would leak into a scaffolded server's own generated README.
+      const markdown = renderAllSnippetsAsMarkdown('my-custom-server')
+      expect(markdown).toContain('npm install -g my-custom-server')
+      expect(markdown).not.toContain('npm install -g {{name}}')
+    })
+
+    it('renders the real Skillsmith package name correctly (the common call site)', () => {
+      const markdown = renderAllSnippetsAsMarkdown('@skillsmith/mcp-server')
+      expect(markdown).toContain('npm install -g @skillsmith/mcp-server')
+      expect(markdown).not.toContain('{{name}}')
+    })
+  })
+})

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -50,6 +50,12 @@ All notable changes to `@skillsmith/core` are documented here.
   that each invocation is a fresh process, are now actually reset at the top of every
   `Deno.serve` invocation (`index.ts`) — left unreset, a warm isolate could silently report a stale
   scan as fully covered.
+- **Fix**: `prompt-source.ts`'s `agent-pack` T2 quota-forecast job body still had the stale
+  `1,000-call`/`10,000 calls` quota numbers, while the committed `packages/mcp-server` bundled
+  SKILL.md output was hand-corrected to `100-call`/`1,000 calls` — generator and committed
+  artifact had drifted, which `agent-pack.assets.test.ts`'s byte-identical drift-gate test would
+  have failed on merge. Fixed at the actual generator source so the two stay in sync
+  (SMI-5893 Wave 11, GH#2368 C-19)
 - **Fix**: PR #2375 post-merge review follow-up (three findings). `recommend`'s shared footer text no longer claims detection "across all clients" — each surface (CLI, MCP) scans exactly one client per call, never a union. Cursor `hooks.json` installation's `ensureTopLevelDefaults` now fails closed (`status: 'conflict'`, no write) instead of silently preserving an existing incompatible top-level value (e.g. a wrong `version`) while still merging hook entries in (SMI-5893)
 - **Fix**: Restored two verified drift points between the core and edge (production) security
   scanners — the edge co-signal escalation set now includes `sensitive_path` (matching core), and

--- a/packages/core/src/services/agent-pack/prompt-source.ts
+++ b/packages/core/src/services/agent-pack/prompt-source.ts
@@ -163,7 +163,7 @@ export const PAYWALL_TRIGGERS: readonly PaywallTrigger[] = [
   {
     id: 'T2',
     title: 'T2 - quota forecast (to Individual)',
-    body: 'When usage is on track to exhaust the free 1,000-call monthly quota, you may note the forecast ("at this pace you reach the cap in about K days") and mention Individual\'s 10,000 calls. Use this sparingly; a quota nag reads as a tax.',
+    body: 'When usage is on track to exhaust the free 100-call monthly quota, you may note the forecast ("at this pace you reach the cap in about K days") and mention Individual\'s 1,000 calls. Use this sparingly; a quota nag reads as a tax.',
   },
   {
     id: 'T4',

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: README's Enterprise Tier heading exposed a specific unpublished price
+  (`$55/user/month`) contradicting the "Custom (Contact Sales)" pricing policy — now
+  `Custom pricing — Contact Sales` (SMI-5893 Wave 11, GH#2368 C-19)
+
 ## v0.3.7
 
 - **Chore**: bump the smithy group across 1 directory with 7 updates (#2254)

--- a/packages/enterprise/README.md
+++ b/packages/enterprise/README.md
@@ -8,7 +8,7 @@ The enterprise package provides security, compliance, and team collaboration fea
 
 ## Features
 
-### Enterprise Tier ($55/user/month)
+### Enterprise Tier (Custom pricing — Contact Sales)
 
 | Feature | Description |
 |---------|-------------|

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -11,6 +11,22 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
   lines above it. Shared rendering (`scan-coverage.format.ts`) translates the machine-readable
   cause token(s) persisted on the row (`scan_coverage_note`) into a human-readable phrase, so the
   three surfaces cannot drift in wording.
+- **Fix**: `formatAuthenticationError`'s 401 message corrected a stale `1,000 requests/month`
+  to the actual `100`, and replaced a Claude-Code-specific "Add to your Claude settings"
+  instruction with a client-neutral pointer at the docs URL already passed to the formatter
+  (SMI-5893 Wave 11, GH#2368 C-19)
+- **Fix**: two bundled SKILL.md pricing/quota tables corrected — the `skills/skillsmith`
+  copy's whole pricing table was off by 10x (Community showed 1,000 instead of 100,
+  Individual 10,000 instead of 1,000, Team 100,000 instead of 10,000) and its Enterprise
+  row exposed a specific price (`$55/user/mo`) that's deliberately unpublished
+  (Contact Sales) — now `Custom (Contact Sales)`. The `agent-pack` copy's quota-forecast
+  guidance had the same Community/Individual numbers swapped-and-scaled — also fixed at
+  its actual source (`@skillsmith/core`'s `prompt-source.ts`, which generates this copy
+  and had drifted from it), so the byte-identical drift-gate test stays green. Also
+  corrected: `skill_suggest`'s tool description (`Community: 1,000/mo` → `100/mo`), the
+  `LicenseTier` TSDoc in `middleware/license.ts` (same 10x error plus the same unpublished
+  Enterprise price), and the equivalent Cursor `npx`/pricing text in both this package's
+  and the root repo's README.md (SMI-5893 Wave 11, GH#2368 C-19)
 - **Feature**: `skill_validate` now runs the existing (previously unwired) typosquat-name
   detector, checking a candidate skill's name against a bundled, periodically-regenerated
   reference-list snapshot of high-trust authors and top-starred skills. Warn-tier only — this

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -73,8 +73,7 @@ Restart Claude Code after editing settings.json.
 {
   "mcpServers": {
     "skillsmith": {
-      "command": "npx",
-      "args": ["-y", "-p", "@skillsmith/mcp-server", "skillsmith-mcp"],
+      "command": "<paste output of: which skillsmith-mcp (macOS/Linux) or where skillsmith-mcp (Windows)>",
       "env": {
         "SKILLSMITH_API_KEY": "sk_live_...",
         "SKILLSMITH_CLIENT": "cursor"
@@ -84,9 +83,9 @@ Restart Claude Code after editing settings.json.
 }
 ```
 
-Cursor 2.4+ required. Reload the window after saving. `SKILLSMITH_CLIENT` routes installs to `~/.cursor/skills` instead of the default `~/.claude/skills`.
+Cursor 2.4+ required, Node >=22.22 (Cursor's own bundled Node meets this). `SKILLSMITH_CLIENT` routes installs to `~/.cursor/skills` instead of the default `~/.claude/skills`.
 
-**Recommended**: `npm install -g @skillsmith/mcp-server` first, then point `command` at the installed `skillsmith-mcp` binary — run `which skillsmith-mcp` after installing to get the exact path (it's platform/npm-prefix specific, e.g. `/opt/homebrew/bin/skillsmith-mcp` on macOS/Homebrew; Linux and Windows paths differ). The `npx` form above still works as a fallback, but re-resolves the package on every launch — expect a slower cold start, and watch for `EBADENGINE` (Cursor bundles its own Node, sometimes older than the `>=22.22` this package requires) or `ENOTEMPTY` errors on repeated installs.
+**Setup**: run `npm install -g @skillsmith/mcp-server`, then run `which skillsmith-mcp` (macOS/Linux) or `where skillsmith-mcp` (Windows) and paste that path into `command` above — Cursor's bundled Node cannot resolve packages via `npx` (a real `ENOENT` on a missing `Resources/app/resources/lib` directory), so pointing directly at the installed binary is the only form confirmed to work inside Cursor. Prefer to try `npx` first anyway? Replace `command` with `"npx"` and add `"args": ["-y", "-p", "@skillsmith/mcp-server", "skillsmith-mcp"]` — simpler, but may hit the same `ENOENT`, plus `EBADENGINE` or `ENOTEMPTY` on repeated installs. After saving: enable the server in Cursor's Settings → MCP panel and start a new chat — a correctly-configured entry still shows disconnected until toggled on there — then reload the window.
 
 </details>
 
@@ -243,7 +242,7 @@ Without an API key, you're limited to **10 total requests** (trial mode). With a
 | Community | 30/min | Free | Personal projects |
 | Individual | 60/min | $9.99/mo | Active developers |
 | Team | 120/min | $25/user/mo | Development teams |
-| Enterprise | 300/min | $55/user/mo | Large organizations |
+| Enterprise | 300/min | Custom (Contact Sales) | Large organizations |
 
 All tiers include:
 - Full access to skill search, details, and recommendations

--- a/packages/mcp-server/src/assets/agent-pack/SKILL.md
+++ b/packages/mcp-server/src/assets/agent-pack/SKILL.md
@@ -110,7 +110,7 @@ When skill_outdated finds outdated skills: show the count and which ones have br
 
 ### T2 - quota forecast (to Individual)
 
-When usage is on track to exhaust the free 1,000-call monthly quota, you may note the forecast ("at this pace you reach the cap in about K days") and mention Individual's 10,000 calls. Use this sparingly; a quota nag reads as a tax.
+When usage is on track to exhaust the free 100-call monthly quota, you may note the forecast ("at this pace you reach the cap in about K days") and mention Individual's 1,000 calls. Use this sparingly; a quota nag reads as a tax.
 
 ### T4 - security depth (to Team)
 

--- a/packages/mcp-server/src/assets/skills/skillsmith/SKILL.md
+++ b/packages/mcp-server/src/assets/skills/skillsmith/SKILL.md
@@ -113,10 +113,10 @@ For criteria detail, see https://skillsmith.app/docs/trust-tiers.
 
 | Tier | API calls/month | Price |
 |---|---|---|
-| **Community** | 1,000 | Free |
-| **Individual** | 10,000 | $9.99/mo |
-| **Team** | 100,000 | $25/user/mo |
-| **Enterprise** | Unlimited | $55/user/mo |
+| **Community** | 100 | Free |
+| **Individual** | 1,000 | $9.99/mo |
+| **Team** | 10,000 | $25/user/mo |
+| **Enterprise** | Unlimited | Custom (Contact Sales) |
 
 Usage warnings at 80% and 90%. Upgrade at https://skillsmith.app/upgrade.
 

--- a/packages/mcp-server/src/middleware/errorFormatter.builders.ts
+++ b/packages/mcp-server/src/middleware/errorFormatter.builders.ts
@@ -203,10 +203,10 @@ export function formatAuthenticationError(details: ApiAuthErrorDetails = {}): MC
 
 ${details.reason || 'API key required for this request.'}
 
-**Get Started (Free - 1,000 requests/month):**
+**Get Started (Free - 100 requests/month):**
 1. Create account: ${signupUrl}
 2. Your API key will be generated automatically
-3. Add to your Claude settings:
+3. Add to your MCP client's config (see ${docsUrl} for the client-specific path/format):
 
 \`\`\`json
 {

--- a/packages/mcp-server/src/middleware/license.ts
+++ b/packages/mcp-server/src/middleware/license.ts
@@ -40,10 +40,10 @@ export interface LicenseValidationResult {
 
 /**
  * License tiers available in Skillsmith
- * - community: Free tier (1,000 API calls/month)
- * - individual: Solo developers ($9.99/mo, 10,000 API calls/month)
- * - team: Development teams ($25/user/mo, 100,000 API calls/month)
- * - enterprise: Full enterprise ($55/user/mo, unlimited)
+ * - community: Free tier (100 API calls/month)
+ * - individual: Solo developers ($9.99/mo, 1,000 API calls/month)
+ * - team: Development teams ($25/user/mo, 10,000 API calls/month)
+ * - enterprise: Full enterprise (Custom pricing, Contact Sales, unlimited)
  */
 export type LicenseTier = 'community' | 'individual' | 'team' | 'enterprise'
 

--- a/packages/mcp-server/src/tools/suggest.ts
+++ b/packages/mcp-server/src/tools/suggest.ts
@@ -104,7 +104,7 @@ export interface SuggestResponse {
 export const suggestToolSchema = {
   name: 'skill_suggest',
   description:
-    'Proactively suggest relevant skills based on current context (files, commands, errors, project structure). Counts against your monthly API quota (Community: 1,000/mo — see www.skillsmith.app/pricing).',
+    'Proactively suggest relevant skills based on current context (files, commands, errors, project structure). Counts against your monthly API quota (Community: 100/mo — see www.skillsmith.app/pricing).',
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/website/src/lib/mcp-client-snippets.parity.test.ts
+++ b/packages/website/src/lib/mcp-client-snippets.parity.test.ts
@@ -95,6 +95,10 @@ describe('MCP_CLIENT_SNIPPETS — parity with CLI CLIENT_SNIPPETS (SMI-5554)', (
 
   it('every body contains the expected npx launch shape for its client', () => {
     for (const snippet of MCP_CLIENT_SNIPPETS) {
+      // SMI-5893 Wave 11 (GH#2368 C-01): cursor is the one client whose
+      // primary `command` is a resolved-path placeholder, not `npx` — see
+      // the CURSOR_JSON_BODY comment in mcp-client-snippets.ts for why.
+      if (snippet.id === 'cursor') continue
       if (snippet.format === 'json') {
         const parsed = JSON.parse(snippet.body) as Record<string, unknown>
         if (snippet.id === 'opencode') {
@@ -122,6 +126,24 @@ describe('MCP_CLIENT_SNIPPETS — parity with CLI CLIENT_SNIPPETS (SMI-5554)', (
         expect(snippet.body).toContain('args: ["-y", "@skillsmith/mcp-server"]')
       }
     }
+  })
+
+  it('cursor body is a resolved-path placeholder (never a guessed or npx path), with npx documented as an explicit fallback in notes', () => {
+    const cursor = MCP_CLIENT_SNIPPETS.find((s) => s.id === 'cursor')
+    expect(cursor).toBeDefined()
+    const parsed = JSON.parse(cursor!.body) as {
+      mcpServers: Record<string, { command: unknown; args?: unknown }>
+    }
+    const entry = parsed.mcpServers['@skillsmith/mcp-server']
+    expect(entry.command).not.toBe('npx')
+    // The placeholder must be unmistakably a placeholder — not a real,
+    // plausible-looking path someone could copy-paste without noticing.
+    expect(entry.command).toContain('which skillsmith-mcp')
+    expect(entry.command).toContain('where skillsmith-mcp')
+    expect(entry.args).toBeUndefined()
+    // npx must still be documented as a real, working fallback.
+    expect(cursor!.notes).toContain('npx')
+    expect(cursor!.notes).toContain('@skillsmith/mcp-server')
   })
 
   it('withApiKey() injects a valid env block for every format without disturbing the launch shape', () => {

--- a/packages/website/src/lib/mcp-client-snippets.ts
+++ b/packages/website/src/lib/mcp-client-snippets.ts
@@ -72,11 +72,17 @@ const STANDARD_JSON_BODY = `{
 // the OpenCode branch) to merge SKILLSMITH_API_KEY into the EXISTING env
 // block rather than creating a new one via the generic STANDARD_ARGS_LINE
 // path, which assumes no env block is present yet.
+//
+// SMI-5893 Wave 11 (GH#2368 C-01): `command` is a resolved-path placeholder,
+// not `npx` — mirrors packages/cli/src/templates/mcp-server.template.snippets.ts's
+// cursor entry (parity required, see that file's own comment for the full
+// rationale: Cursor's bundled Node can't resolve `npx` packages, confirmed
+// on two separate live UAT passes; a guessed default path can be wrong too,
+// just silently differently, so this never guesses at all).
 const CURSOR_JSON_BODY = `{
   "mcpServers": {
     "@skillsmith/mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"],
+      "command": "<paste output of: which skillsmith-mcp (macOS/Linux) or where skillsmith-mcp (Windows)>",
       "env": {
         "SKILLSMITH_CLIENT": "cursor"
       }
@@ -101,7 +107,7 @@ export const MCP_CLIENT_SNIPPETS: ReadonlyArray<McpClientSnippet> = [
     format: 'json',
     body: CURSOR_JSON_BODY,
     notes:
-      'Cursor 2.4+ required. Reload the window after saving. <code>SKILLSMITH_CLIENT</code> routes installs to <code>~/.cursor/skills</code> instead of the default <code>~/.claude/skills</code>. Recommended: <code>npm install -g @skillsmith/mcp-server</code> first, then point <code>command</code> at the installed <code>skillsmith-mcp</code> binary (run <code>which skillsmith-mcp</code> to get the exact path — it is platform/npm-prefix specific, e.g. <code>/opt/homebrew/bin/skillsmith-mcp</code> on macOS/Homebrew; Linux and Windows paths differ). The <code>npx</code> form above still works as a fallback, but re-resolves the package on every launch and may hit <code>EBADENGINE</code> (Cursor bundles its own Node, sometimes older than the <code>&gt;=22.22</code> this package requires) or <code>ENOTEMPTY</code> on repeated installs.',
+      'Cursor 2.4+ required, Node &gt;=22.22 (Cursor\'s own bundled Node meets this). Setup: run <code>npm install -g @skillsmith/mcp-server</code>, then run <code>which skillsmith-mcp</code> (macOS/Linux) or <code>where skillsmith-mcp</code> (Windows) and paste that path into <code>command</code> above — Cursor\'s bundled Node cannot resolve packages via <code>npx</code> (a real <code>ENOENT</code> on a missing <code>Resources/app/resources/lib</code> directory), so pointing directly at the installed binary is the only form confirmed to work inside Cursor. <code>SKILLSMITH_CLIENT</code> routes installs to <code>~/.cursor/skills</code> instead of the default <code>~/.claude/skills</code>. Prefer to try <code>npx</code> first anyway? Replace <code>command</code> with <code>"npx"</code> and add <code>"args": ["-y", "@skillsmith/mcp-server"]</code> — simpler, but may hit the same <code>ENOENT</code>, plus <code>EBADENGINE</code> or <code>ENOTEMPTY</code> on repeated installs. After saving: enable the server in Cursor\'s Settings → MCP panel and start a new chat — a correctly-configured entry still shows disconnected until toggled on there — then reload the window.',
   },
   {
     id: 'copilot',

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -1,5 +1,6 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
+import { MCP_CLIENT_SNIPPETS } from '../../lib/mcp-client-snippets';
 
 const howToSchema = {
   '@context': 'https://schema.org',
@@ -8,7 +9,7 @@ const howToSchema = {
   description:
     'Add the Skillsmith MCP server to an MCP-compatible AI assistant to search, install, and manage agent skills using natural language.',
   tool: [
-    { '@type': 'HowToTool', name: 'Node.js 18+' },
+    { '@type': 'HowToTool', name: 'Node.js >=22.22.0' },
     { '@type': 'HowToTool', name: 'MCP-compatible AI assistant' },
   ],
   step: [
@@ -16,7 +17,7 @@ const howToSchema = {
       '@type': 'HowToStep',
       position: 1,
       name: 'Add the server to your MCP client config',
-      text: 'Add an entry for "skillsmith" running "npx -y @skillsmith/mcp-server" to your MCP client configuration file, e.g. ~/.claude/settings.json for Claude Code, ~/.cursor/mcp.json for Cursor, or the equivalent config file for your MCP client.',
+      text: 'Add an entry for "skillsmith" to your MCP client configuration file, e.g. ~/.claude/settings.json for Claude Code or the equivalent config file for your MCP client. Most clients launch it via "npx -y @skillsmith/mcp-server"; Cursor is an exception and needs the installed binary\'s resolved path instead (see the Cursor-specific setup notes on this page).',
     },
     {
       '@type': 'HowToStep',
@@ -57,20 +58,28 @@ const howToSchema = {
 
   <h3>Basic Setup</h3>
 
-  <p>Add Skillsmith to your Claude settings at <code>~/.claude/settings.json</code>:</p>
+  <p>
+    Pick the snippet for your MCP client and add it to the matching config file. Every
+    snippet uses the same shape — only the config-file path (and, for Codex/Hermes, the
+    format) differs.
+  </p>
 
-  <pre><code>{`{
-  "mcpServers": {
-    "skillsmith": {
-      "command": "npx",
-      "args": ["-y", "@skillsmith/mcp-server"]
-    }
-  }
-}`}</code></pre>
+  {MCP_CLIENT_SNIPPETS.map((client) => (
+    <details open={client.openByDefault}>
+      <summary><strong>{client.label}</strong> — <code>{client.configPath}</code>{client.format !== 'json' ? ` (${client.format.toUpperCase()})` : ''}</summary>
+      <pre><code>{client.body}</code></pre>
+      {client.notes && <p set:html={client.notes} />}
+    </details>
+  ))}
 
   <h3>Advanced Configuration</h3>
 
-  <p>For more control, you can specify additional options:</p>
+  <p>
+    For more control, add extra options to the <code>env</code> block of whichever
+    client snippet you used above — keep that snippet's own <code>command</code> and
+    <code>args</code> (or, for Cursor, its resolved-path <code>command</code>) and
+    just add to its <code>env</code>. Example (Claude Code shape shown):
+  </p>
 
   <pre><code>{`{
   "mcpServers": {
@@ -84,6 +93,14 @@ const howToSchema = {
     }
   }
 }`}</code></pre>
+
+  <p>
+    This <code>env</code>-block pattern applies as shown to every JSON-shaped client
+    (Claude Code, Cursor, Copilot, Windsurf, Antigravity, cross-agent). OpenCode uses
+    an <code>environment</code> key instead of <code>env</code> (with <code>command</code>
+    as an array); Codex, Grok, and Hermes use TOML/YAML, not JSON — add the same
+    variables under each format's own env table/mapping instead.
+  </p>
 
   <h3>API Key Configuration</h3>
 
@@ -118,9 +135,14 @@ const howToSchema = {
 }
 EOF`}</code></pre>
 
-  <p><strong>Method B: Claude Settings</strong></p>
+  <p><strong>Method B: MCP Client Config</strong></p>
 
-  <p>Add to your <code>~/.claude/settings.json</code>:</p>
+  <p>
+    Add <code>SKILLSMITH_API_KEY</code> to the <code>env</code> block of whichever
+    client snippet you used above — keep that snippet's own <code>command</code> and
+    <code>args</code> (or, for Cursor, its resolved-path <code>command</code>) and
+    just add the key. Example (Claude Code shape shown):
+  </p>
 
   <pre><code>{`{
   "mcpServers": {
@@ -133,6 +155,14 @@ EOF`}</code></pre>
     }
   }
 }`}</code></pre>
+
+  <p>
+    This <code>env</code>-block pattern applies as shown to every JSON-shaped client
+    (Claude Code, Cursor, Copilot, Windsurf, Antigravity, cross-agent). OpenCode uses
+    an <code>environment</code> key instead of <code>env</code> (with <code>command</code>
+    as an array); Codex, Grok, and Hermes use TOML/YAML, not JSON — add the same
+    variable under each format's own env table/mapping instead.
+  </p>
 
   <p><strong>Step 3:</strong> Restart your MCP client to load the updated configuration.</p>
 
@@ -618,7 +648,7 @@ Assistant: [Uses compare tool] Here's a comparison:
 
   <div class="callout">
     <p class="callout-heading">Check Node.js Version</p>
-    <p>Ensure you have Node.js 18+ installed. Run <code>node --version</code> to verify.</p>
+    <p>Ensure you have Node.js &gt;=22.22.0 installed. Run <code>node --version</code> to verify.</p>
   </div>
 
   <h3>Tools Not Available</h3>

--- a/packages/website/src/pages/docs/quickstart.astro
+++ b/packages/website/src/pages/docs/quickstart.astro
@@ -326,15 +326,28 @@ before you save. Use this entry:
   }
 }
 
+If you are NOT Claude Code, also add an "env" block to that entry with
+SKILLSMITH_CLIENT set to your own client name (e.g. "windsurf" for Windsurf,
+"copilot" for GitHub Copilot) so skills install to your own skills directory
+instead of Claude Code's default. If you're not sure of the right value,
+ask me before saving.
+
 Tell me which file you changed when you're done.`}</code></pre>
 
   <p>
     <strong>Not using Claude Code?</strong> Skills install to your agent's own
-    directory by default (e.g. <code>~/.claude/skills/</code> for Claude Code). If your
-    agent isn't Claude Code, ask it to add an <code>env</code> block with
-    <code>SKILLSMITH_CLIENT</code> set to your client's name (e.g. <code>"cursor"</code>)
-    so installs land in the right place — see the client-specific snippets in Option C
-    below for exact examples.
+    directory by default (e.g. <code>~/.claude/skills/</code> for Claude Code). The
+    prompt above already asks your agent to set <code>SKILLSMITH_CLIENT</code> for
+    itself when it isn't Claude Code — see the client-specific snippets in Option C
+    below for exact examples if you'd rather edit the file yourself.
+  </p>
+
+  <p>
+    <strong>Using Cursor?</strong> Skip the prompt above and use Option C's Cursor
+    snippet instead — Cursor's bundled Node cannot resolve packages via
+    <code>npx</code> (a real <code>ENOENT</code>), so the <code>"command": "npx"</code>
+    entry above will not connect. Option C's Cursor section gives you the
+    resolved-path form that's confirmed to work.
   </p>
 
   <h4>Option C — Edit the config file yourself</h4>

--- a/packages/website/src/pages/docs/tutorials/author.astro
+++ b/packages/website/src/pages/docs/tutorials/author.astro
@@ -19,7 +19,7 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
       totalTime: 'PT15M',
       tool: [
         { '@type': 'HowToTool', name: 'Skillsmith CLI' },
-        { '@type': 'HowToTool', name: 'Node.js 18+' },
+        { '@type': 'HowToTool', name: 'Node.js >=22.22.0' },
       ],
       step: [
         {

--- a/packages/website/src/pages/docs/tutorials/install-and-use.astro
+++ b/packages/website/src/pages/docs/tutorials/install-and-use.astro
@@ -154,10 +154,14 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
   <h3>The /skillsmith slash command — most reliable trigger</h3>
 
   <p>
-    Claude Code installs a bundled <code>/skillsmith</code> slash command when you run <code
-      >skillsmith setup</code
-    >. It gives you an unambiguous way to route any lifecycle action to the right Skillsmith tool,
-    regardless of how natural-language tool selection might drift.
+    Running <code>skillsmith setup</code> (add <code
+      >--client &lt;id&gt;</code
+    > for a non-Claude-Code agent) installs a bundled <code>/skillsmith</code> slash
+    command. It gives you an unambiguous way to route any lifecycle action to the right
+    Skillsmith tool, regardless of how natural-language tool selection might drift.
+    Slash-command triggering is most reliably confirmed on Claude Code; other clients
+    that support skill-driven slash commands should pick it up the same way once
+    installed to their own skills directory.
   </p>
 
   <pre><code>{`/skillsmith discover testing


### PR DESCRIPTION
## Business Summary

**What shipped:** Cursor users can now actually connect the Skillsmith MCP server. The copied config no longer defaults to `npx`, which two separate live user tests confirmed fails inside Cursor with a real, unrecoverable error (Cursor's bundled Node can't resolve packages that way) — it's now a resolve-and-paste-your-own-path snippet that can never point somewhere wrong, with `npx` kept as a clearly labeled fallback for anyone who wants to try it anyway. Alongside that, several places that quoted the free-tier quota or the required Node version were wrong (the numbers didn't match what the product actually enforces) — all now say the same, correct thing everywhere a user might read them.

**Quality bar:** Full build, typecheck, lint, the complete test suite (16,945 tests), Prettier, `astro check`, and `audit:standards` all pass clean. A backgrounded GPT-5.6-Sol code review ran against the diff before commit and found 13 issues — all fixed here, including one that would have broken CI on merge (a documentation generator had drifted from a file this same PR hand-corrected, which a byte-identical drift-check test would have caught and failed) and two more instances of an unpublished Enterprise price appearing in text visitors can read (beyond the one this PR's own earlier commit already fixed).

**Found along the way:** the code review also surfaced that the same unpublished Enterprise price appears in several *live, runtime* product surfaces — most notably the upgrade message shown to a non-Enterprise user hitting a paywall — which is a materially bigger, business-decision-gated fix than this PR's scope (docs/description text). Filed separately as SMI-6069 rather than folded in here, since it touches CLI/MCP-server tier-gating logic and its own existing tests, and needs a call on whether the number is actually current or should be scrubbed.

**Net result:** Fully shipped, no follow-up needed on this PR's own scope. SMI-6069 tracks the separate runtime-pricing finding.

---

## Technical detail

**Files touched** (22): Cursor snippet + parity fix — `packages/website/src/lib/mcp-client-snippets.ts` (+ its parity test), `packages/cli/src/templates/mcp-server.template.snippets.ts` (+ new test file `packages/cli/tests/mcp-server-template-snippets.test.ts` — this canonical matrix had zero prior coverage), root `README.md`, `packages/mcp-server/README.md`. Docs pages: `packages/website/src/pages/docs/mcp-server.astro` (client-neutral setup section, corrected JSON-LD HowTo schema, scoped an inaccurate "same idea for every client" claim to the clients it's actually true for), `quickstart.astro` (added a Cursor-specific callout so Option B's generic prompt doesn't walk a Cursor user into the same npx failure), `tutorials/author.astro`, `tutorials/install-and-use.astro`. Quota/pricing text: `packages/cli/src/utils/license.ts` (+ test), `packages/mcp-server/src/middleware/errorFormatter.builders.ts`, `src/middleware/license.ts`, `src/tools/suggest.ts`, both bundled `SKILL.md` assets, `packages/enterprise/README.md`. Generator-drift fix: `packages/core/src/services/agent-pack/prompt-source.ts`. CHANGELOGs: `packages/cli`, `packages/mcp-server`, `packages/enterprise`.

**Verification**: `npm run build` (7/7 packages), `npm run typecheck` (`tsc --build`, clean), `npm run lint` (clean), `npx vitest run` (1049 test files / 16,945 tests passed, 0 failed — explicitly re-confirmed `agent-pack.assets.test.ts`'s drift gate passes after the generator fix), `npm run format:check` (clean), `npm run audit:standards` (0 failed / 7 pre-existing unrelated warnings, 92% compliance), `astro check --minimumSeverity error` (188 files, 0 errors) — all run inside this worktree's own dedicated Docker container (`DEV_PORT=3822` to avoid a port-3001 collision with another running container), confirming its own edited `packages/core` copy resolves correctly rather than a stale main-checkout copy. Committed and pushed through pre-commit/pre-push hooks with no bypass needed.

Part of the GH#2368 Cursor UAT V2 retest follow-up (Waves 9–12, epic SMI-5893). Wave 9 (#2397) and Wave 10 (#2402) are already open/merged; this is Wave 11 (SMI-6059). Wave 12 (SMI-6060, footer hygiene) follows next.