### PR TITLE
fix(indexer): SMI-6061 point fallback token at GH_PAT_SKILLSMITH

### DIFF
--- a/.github/workflows/indexer-backfill.yml
+++ b/.github/workflows/indexer-backfill.yml
@@ -30,7 +30,7 @@
 #   3. Read the operator runbook: docs/internal/runbooks/indexer-backfill.md
 #
 # SMI-6061: the token_source input (backfill/fallback) is a MANUAL escape
-# hatch, not automatic failover -- select `fallback` to run through GH_PAT
+# hatch, not automatic failover -- select `fallback` to run through GH_PAT_SKILLSMITH
 # instead of BACKFILL_GITHUB_TOKEN (e.g. to isolate a token-specific issue).
 # Both are validated by the same live GET /user probe in Validate Secrets.
 #
@@ -106,7 +106,7 @@ on:
           - prod
           - staging
       token_source:
-        description: 'Which GitHub token to use (SMI-6061 manual fallback): backfill = BACKFILL_GITHUB_TOKEN (default), fallback = GH_PAT'
+        description: 'Which GitHub token to use (SMI-6061 manual fallback): backfill = BACKFILL_GITHUB_TOKEN (default), fallback = GH_PAT_SKILLSMITH'
         required: true
         default: 'backfill'
         type: choice
@@ -168,7 +168,7 @@ jobs:
           # never a silent cross-substitution (GitHub Actions treats an unset
           # secret as falsy empty-string, which would otherwise fall through the
           # WRONG side of a naive `token_source == 'fallback' && X || Y` chain).
-          SELECTED_TOKEN: ${{ (inputs.token_source == 'fallback' && secrets.GH_PAT) || (inputs.token_source == 'backfill' && secrets.BACKFILL_GITHUB_TOKEN) }}
+          SELECTED_TOKEN: ${{ (inputs.token_source == 'fallback' && secrets.GH_PAT_SKILLSMITH) || (inputs.token_source == 'backfill' && secrets.BACKFILL_GITHUB_TOKEN) }}
           TOKEN_SOURCE: ${{ inputs.token_source }}
         run: |
           # Fail fast with clear error if secrets not configured.
@@ -185,7 +185,7 @@ jobs:
             exit 1
           fi
           if [ -z "$SELECTED_TOKEN" ]; then
-            echo "::error::token_source='$TOKEN_SOURCE' selected but its secret (BACKFILL_GITHUB_TOKEN or GH_PAT) is not provisioned. See docs/internal/runbooks/indexer-backfill.md for provisioning steps."
+            echo "::error::token_source='$TOKEN_SOURCE' selected but its secret (BACKFILL_GITHUB_TOKEN or GH_PAT_SKILLSMITH) is not provisioned. See docs/internal/runbooks/indexer-backfill.md for provisioning steps."
             exit 1
           fi
           echo "::add-mask::$SELECTED_TOKEN"


### PR DESCRIPTION
## Business Summary

**What shipped:** The SMI-5334 backfill workflow's manual fallback token (`token_source=fallback`) now points at a newly-provisioned, dedicated secret (`GH_PAT_SKILLSMITH`) instead of the previously-wired `GH_PAT`, which turned out to be invalid (caught live by the fail-closed `/user` probe added in #2415 — HTTP 401).

**Quality bar:** Mechanical follow-up to already-reviewed work (#2415) — a secret-name substitution, not a new design decision. Runbook updated to match.

**Net result:** Fully shipped. The fallback token is now usable and verified. `GH_PAT` itself (used separately by `batch-transform.yml`/`website-deploy-staging.yml`) still needs its own rotation — tracked as SMI-6068, not fixed by this PR.

---

## Technical detail

`.github/workflows/indexer-backfill.yml` — all 4 `GH_PAT` references (header comment, input description, secret-selection expression, error message) updated to `GH_PAT_SKILLSMITH`. `docs/internal/runbooks/indexer-backfill.md` updated to match, with a note on why this secret is separate from the shared `GH_PAT`.