### PR TITLE
feat(indexer): SMI-6073 GHA code-search degraded-response hardening

### DIFF
--- a/scripts/indexer/_shared/rate-limit.ts
+++ b/scripts/indexer/_shared/rate-limit.ts
@@ -281,6 +281,20 @@ export interface RateLimitTelemetry {
   secondary_rate_limit_hits: number
   /** Max `retry-after` header value observed, in seconds. */
   retry_after_max_seconds: number
+  /**
+   * SMI-6073: true once ANY metered response for the `core` bucket carried an
+   * `x-ratelimit-remaining` header this run. Distinguishes "never observed"
+   * (this stays false, `core_remaining_min` resolves to 0 via the
+   * POSITIVE_INFINITY sentinel below) from "observed and genuinely 0" (this
+   * is true AND `core_remaining_min` is 0) — a single global flag would read
+   * true as soon as ANY of the three buckets was metered, misleadingly
+   * implying every bucket's `0` is genuine.
+   */
+  core_observed: boolean
+  /** SMI-6073: same disambiguation as {@link core_observed}, for `search`. */
+  search_observed: boolean
+  /** SMI-6073: same disambiguation as {@link core_observed}, for `code_search`. */
+  code_search_observed: boolean
 }
 
 export function newRateLimitTelemetry(): RateLimitTelemetry {
@@ -291,6 +305,9 @@ export function newRateLimitTelemetry(): RateLimitTelemetry {
     code_search_remaining_min: Number.POSITIVE_INFINITY,
     secondary_rate_limit_hits: 0,
     retry_after_max_seconds: 0,
+    core_observed: false,
+    search_observed: false,
+    code_search_observed: false,
   }
 }
 
@@ -306,12 +323,24 @@ const BUCKET_FIELD: Record<RateLimitBucket, BucketRemainingField> = {
   code_search: 'code_search_remaining_min',
 }
 
+/** SMI-6073: the telemetry field holding the observation flag for a bucket. */
+type BucketObservedField = 'core_observed' | 'search_observed' | 'code_search_observed'
+
+const BUCKET_OBSERVED_FIELD: Record<RateLimitBucket, BucketObservedField> = {
+  core: 'core_observed',
+  search: 'search_observed',
+  code_search: 'code_search_observed',
+}
+
 /**
  * Convert telemetry into the shape stored in `audit_logs.metadata`.
  * Resolves the POSITIVE_INFINITY sentinel to 0 (the "no calls observed" case
  * means we never saw any remaining, which we surface as 0 — the
  * `v_indexer_health` view casts to int). SMI-4918: the per-bucket minimums
- * are resolved the same way.
+ * are resolved the same way. SMI-6073: the per-bucket `*_observed` flags are
+ * passed through unresolved (they're already booleans) so a stored `0` for
+ * e.g. `code_search_remaining_min` can be read together with
+ * `code_search_observed` to disambiguate "never observed" from "genuinely 0".
  */
 export function summarizeRateLimitTelemetry(t: RateLimitTelemetry): {
   rate_limit_remaining_min: number
@@ -320,6 +349,9 @@ export function summarizeRateLimitTelemetry(t: RateLimitTelemetry): {
   code_search_remaining_min: number
   secondary_rate_limit_hits: number
   retry_after_max_seconds: number
+  core_observed: boolean
+  search_observed: boolean
+  code_search_observed: boolean
 } {
   const resolve = (v: number): number => (Number.isFinite(v) ? v : 0)
   return {
@@ -329,6 +361,9 @@ export function summarizeRateLimitTelemetry(t: RateLimitTelemetry): {
     code_search_remaining_min: resolve(t.code_search_remaining_min),
     secondary_rate_limit_hits: t.secondary_rate_limit_hits,
     retry_after_max_seconds: t.retry_after_max_seconds,
+    core_observed: t.core_observed,
+    search_observed: t.search_observed,
+    code_search_observed: t.code_search_observed,
   }
 }
 
@@ -400,11 +435,16 @@ export async function withRateLimitTracking(
         if (remaining < telemetry.rate_limit_remaining_min) {
           telemetry.rate_limit_remaining_min = remaining
         }
-        const bucketField =
-          BUCKET_FIELD[classifyRateLimitBucket(response.headers.get('x-ratelimit-resource'))]
+        const bucket = classifyRateLimitBucket(response.headers.get('x-ratelimit-resource'))
+        const bucketField = BUCKET_FIELD[bucket]
         if (remaining < telemetry[bucketField]) {
           telemetry[bucketField] = remaining
         }
+        // SMI-6073: mark this bucket observed UNCONDITIONALLY (not gated on
+        // beating the running minimum) — the whole point is to record that a
+        // metered response for this bucket was seen at all this run, so a
+        // later `0` minimum can be disambiguated from "never observed".
+        telemetry[BUCKET_OBSERVED_FIELD[bucket]] = true
       }
     }
   }

--- a/scripts/indexer/backfill-checkpoint.ts
+++ b/scripts/indexer/backfill-checkpoint.ts
@@ -213,6 +213,14 @@ export interface BackfillCrawlOutcome {
   facets_completed: number
   facets_total: number
   ranges_crawled: number
+  /**
+   * SMI-6073: count of ranges this dispatch where at least one page carried
+   * `incomplete_results: true` (GitHub's own documented query-timeout signal
+   * — see `docs.github.com/en/rest/search/search`). Aggregated per range (not
+   * per page) to avoid per-page log noise; surfaced in the
+   * `[Backfill] Facet crawl:` summary line (`subdirectory-search.ts`).
+   */
+  incomplete_results_ranges: number
 }
 
 /**

--- a/scripts/indexer/code-search.ts
+++ b/scripts/indexer/code-search.ts
@@ -67,6 +67,30 @@ interface CodeSearchResponse {
 const RETRY_DELAYS = [1000, 2000, 4000]
 
 /**
+ * GitHub code-search retrievable-results ceiling per query (any query caps
+ * here, regardless of `total_count`). SMI-5286 1c originally defined this
+ * locally in `subdirectory-search.helpers.ts` for bisection triggering;
+ * exported from here (SMI-6073) and re-imported there so both the bisection
+ * trigger and the degraded-response pagination-bounds check below share one
+ * source of truth instead of two independently-maintained copies.
+ */
+export const CODE_SEARCH_RESULT_CAP = 1000
+
+/**
+ * SMI-6073: retry delay (ms) for a SINGLE degraded-response retry —
+ * deliberately distinct from `RETRY_DELAYS` (the 403/429 exponential-backoff
+ * ladder, 1s/2s/4s). That ladder's cadence is tuned for a RATE-LIMIT signal;
+ * retrying a CONTENT anomaly (200 + `total_count > 0` + `items: []`) on the
+ * same aggressive cadence risks tripping the very 10-req/min code-search
+ * bucket this is trying to avoid. Matches the bucket's own established
+ * inter-page cadence instead (10 code-search req/min -> 6s between pages,
+ * `subdirectory-search.helpers.ts`). Exported so tests can derive a
+ * deadline-imminent scenario from the real value instead of a guessed magic
+ * number (see `code-search.test.ts`).
+ */
+export const DEGRADED_RESPONSE_RETRY_DELAY_MS = 6000
+
+/**
  * Search GitHub Code Search API for repositories containing SKILL.md files.
  *
  * SMI-4852: Threads `telemetry` and wraps each fetch in
@@ -225,7 +249,15 @@ export async function searchCodeForSkillMdInSubdirectory(
   // `size:0..127`) appended to the query so the broad backfill can partition the
   // 1000-result-capped query by file size. The caller (the facet driver) formats
   // it via code-search.facets.ts; this file stays free of the facet dependency.
-  sizeQualifier?: string
+  sizeQualifier?: string,
+  // SMI-6073: absolute wall-clock deadline (ms, `Date.now()`-comparable) for
+  // the SMI-5964 per-dispatch elapsed budget. When supplied, the degraded-
+  // response retry below is skipped (falls straight to the error return)
+  // once fewer than one retry-delay's worth of budget remains — a wasted
+  // retry this close to a hard timeout would only shrink the window left to
+  // checkpoint cleanly. `undefined` = no deadline (byte-identical to the
+  // pre-SMI-6073 unbounded case).
+  deadlineAtMs?: number
 ): Promise<{
   repos: GitHubRepository[]
   total: number
@@ -256,8 +288,18 @@ export async function searchCodeForSkillMdInSubdirectory(
   const url = `https://api.github.com/search/code?q=${query}&per_page=${perPage}&page=${page}`
 
   let retries = 0
+  // SMI-6073: the degraded retry's ENTIRE budget (at most one use), tracked
+  // fully independently of `rateLimitAttempt` below. GPT-5.6-Sol review
+  // (2026-08-17): an earlier version shared one `for`-loop counter between
+  // the two, so a degraded retry could silently steal one of the 403/429
+  // ladder's 3 retries (and its "after N retries" message would then lie
+  // about what actually happened) — neither counter reads or writes the other.
+  let degradedRetryUsed = false
+  // SMI-6073: the 403/429 (+ network-error, pre-existing shared semantics —
+  // unchanged here) retry ladder's own counter, independent of the above.
+  let rateLimitAttempt = 0
 
-  for (let attempt = 0; attempt <= RETRY_DELAYS.length; attempt++) {
+  while (true) {
     try {
       const response = await withRateLimitTracking(telemetry, url, {
         headers: await buildGitHubHeaders(),
@@ -268,6 +310,51 @@ export async function searchCodeForSkillMdInSubdirectory(
         const data = (await response.json()) as CodeSearchResponse
 
         const pathLabel = pathPrefix ? `path:${sanitizeForLog(pathPrefix)}` : 'broad'
+
+        // SMI-6073: degraded-response detection. GitHub's code-search endpoint
+        // can return HTTP 200 with a nonzero `total_count` but empty `items`
+        // (the documented query-timeout-degrades-to-partial-results behavior —
+        // see the SMI-6073 plan's Context section). Checked against the RAW
+        // `data.items` array, NEVER the post-filter `repos` built below — a
+        // page where GitHub returned real items but every one was a
+        // fork/duplicate/invalid entry is a legitimate empty result, not
+        // degradation. Also requires the requested page to be within GitHub's
+        // retrievable range (`(page-1)*perPage` under `min(total_count, cap)`)
+        // — a page requested past the actual result count is legitimately
+        // empty too, not degraded.
+        const pageWithinRetrievableRange =
+          (page - 1) * perPage < Math.min(data.total_count, CODE_SEARCH_RESULT_CAP)
+        const isDegradedResponse =
+          data.items.length === 0 && data.total_count > 0 && pageWithinRetrievableRange
+
+        if (isDegradedResponse) {
+          const deadlineImminent =
+            deadlineAtMs !== undefined &&
+            Date.now() + DEGRADED_RESPONSE_RETRY_DELAY_MS >= deadlineAtMs
+          if (!degradedRetryUsed && !deadlineImminent) {
+            degradedRetryUsed = true
+            console.warn(
+              `[CodeSearch] Degraded response for ${pathLabel} p${page} (total_count=${data.total_count}, items=0) -- retrying once in ${DEGRADED_RESPONSE_RETRY_DELAY_MS}ms`
+            )
+            await delay(DEGRADED_RESPONSE_RETRY_DELAY_MS)
+            retries++
+            continue
+          }
+          const requestId = response.headers.get('x-github-request-id')
+          const reason = deadlineImminent
+            ? 'elapsed-budget deadline imminent, retry skipped'
+            : 'retried once, still degraded'
+          console.warn(
+            `[CodeSearch] Degraded response persisted for ${pathLabel} p${page} (${reason}) (x-github-request-id: ${requestId ?? 'unknown'})`
+          )
+          return {
+            repos: [],
+            total: 0,
+            retries,
+            incomplete_results: false,
+            error: `Code search degraded response for ${pathLabel} p${page}: total_count=${data.total_count} but items=0 (${reason}) (x-github-request-id: ${requestId ?? 'unknown'})`,
+          }
+        }
 
         if (data.incomplete_results) {
           console.warn(
@@ -346,39 +433,55 @@ export async function searchCodeForSkillMdInSubdirectory(
 
       // Rate limit or secondary rate limit
       if (response.status === 403 || response.status === 429) {
-        if (attempt < RETRY_DELAYS.length) {
-          const delayMs = RETRY_DELAYS[attempt]
+        if (rateLimitAttempt < RETRY_DELAYS.length) {
+          const delayMs = RETRY_DELAYS[rateLimitAttempt]
           console.log(
-            `[CodeSearch] Rate limited (${response.status}) for ${pathLabel}, retrying in ${delayMs}ms (attempt ${attempt + 1}/${RETRY_DELAYS.length})`
+            `[CodeSearch] Rate limited (${response.status}) for ${pathLabel}, retrying in ${delayMs}ms (attempt ${rateLimitAttempt + 1}/${RETRY_DELAYS.length})`
           )
           await delay(delayMs)
           retries++
+          rateLimitAttempt++
           continue
         }
         const remaining = response.headers.get('X-RateLimit-Remaining')
+        // SMI-6073: capture x-github-request-id at the point of the outcome —
+        // read directly off THIS Response, not threaded through shared
+        // telemetry, so it can't be misattributed under concurrent calls.
+        const requestId = response.headers.get('x-github-request-id')
+        console.warn(
+          `[CodeSearch] Rate limit exhausted for ${pathLabel} (x-github-request-id: ${requestId ?? 'unknown'})`
+        )
         return {
           repos: [],
           total: 0,
           retries,
           incomplete_results: false,
-          error: `Code search rate limit exhausted for ${pathLabel} after ${RETRY_DELAYS.length} retries. Remaining: ${remaining}`,
+          error: `Code search rate limit exhausted for ${pathLabel} after ${RETRY_DELAYS.length} retries. Remaining: ${remaining} (x-github-request-id: ${requestId ?? 'unknown'})`,
         }
       }
 
-      return {
-        repos: [],
-        total: 0,
-        retries,
-        incomplete_results: false,
-        error: `Code search error for ${pathLabel}: ${response.status}`,
+      {
+        // SMI-6073: same request-id capture for any other non-ok status.
+        const requestId = response.headers.get('x-github-request-id')
+        console.warn(
+          `[CodeSearch] Error for ${pathLabel}: ${response.status} (x-github-request-id: ${requestId ?? 'unknown'})`
+        )
+        return {
+          repos: [],
+          total: 0,
+          retries,
+          incomplete_results: false,
+          error: `Code search error for ${pathLabel}: ${response.status} (x-github-request-id: ${requestId ?? 'unknown'})`,
+        }
       }
     } catch (error) {
       const pathLabel = pathPrefix ? `path:${sanitizeForLog(pathPrefix)}` : 'broad'
-      if (attempt < RETRY_DELAYS.length) {
-        const delayMs = RETRY_DELAYS[attempt]
+      if (rateLimitAttempt < RETRY_DELAYS.length) {
+        const delayMs = RETRY_DELAYS[rateLimitAttempt]
         console.log(`[CodeSearch] Network error for ${pathLabel}, retrying in ${delayMs}ms`)
         await delay(delayMs)
         retries++
+        rateLimitAttempt++
         continue
       }
       return {
@@ -390,6 +493,4 @@ export async function searchCodeForSkillMdInSubdirectory(
       }
     }
   }
-
-  return { repos: [], total: 0, retries, incomplete_results: false, error: 'Unexpected code path' }
 }

--- a/scripts/indexer/subdirectory-search.helpers.ts
+++ b/scripts/indexer/subdirectory-search.helpers.ts
@@ -16,7 +16,7 @@
  */
 
 import { delay, type RateLimitTelemetry } from './_shared/rate-limit.ts'
-import { searchCodeForSkillMdInSubdirectory } from './code-search.ts'
+import { searchCodeForSkillMdInSubdirectory, CODE_SEARCH_RESULT_CAP } from './code-search.ts'
 import {
   buildSizeFacets,
   facetId,
@@ -124,9 +124,6 @@ export interface BackfillFacetPlan {
   acceptTruncation?: boolean
 }
 
-/** GitHub code-search retrievable-results ceiling per query (any query caps here). */
-const CODE_SEARCH_RESULT_CAP = 1000
-
 /**
  * SMI-5286 1c: depth-first size-faceted crawl of the broad `filename:SKILL.md`
  * query (or a single `path:` prefix). Pages each size (sub)range to the 1000-cap;
@@ -177,6 +174,10 @@ export async function runBackfillFacetCrawl(
   let capSaturated = false
   let truncatedRanges = 0
   let rangesCrawled = 0
+  // SMI-6073: ranges where any page had `incomplete_results: true` (GitHub's
+  // timeout-degraded-read signal); aggregated per range, logged in
+  // subdirectory-search.ts's `[Backfill] Facet crawl:` summary line.
+  let incompleteResultRanges = 0
   // SMI-5448: per-dispatch wall-clock anchor for the elapsed-budget guard.
   const startedAt = Date.now()
   // SMI-5964 §1a/§1b: absolute deadline threaded into `processSearchResults` so
@@ -235,18 +236,26 @@ export async function runBackfillFacetCrawl(
     // SMI-5321: capture page-1 repos during saturation detection so the
     // acceptTruncation floor can reuse them without a second code-search fetch.
     let saturatedPageRepos: GitHubRepository[] | null = null
+    // SMI-6073: reset per range; aggregated once at the range boundary below.
+    let rangeHadIncompleteResults = false
     for (let page = state.lastPage + 1; page <= plan.maxPagesPerRange; page++) {
       const result = await searchCodeForSkillMdInSubdirectory(
         plan.pathPrefix,
         page,
         plan.perPage,
         telemetry,
-        qualifier
+        qualifier,
+        // SMI-6073: thread the SMI-5964 deadline so the degraded-response
+        // retry can skip itself when the budget is nearly exhausted.
+        deadlineAt ?? undefined
       )
       if (result.error) {
         errors.push(`[backfill ${pathLabel} ${facetId(range)} p${page}] ${result.error}`)
         errored = true
         break
+      }
+      if (result.incomplete_results) {
+        rangeHadIncompleteResults = true
       }
       // The 1000-cap is detected from total_count on the first page: rather than
       // waste pages on the unreachable tail, bisect immediately -- the sub-ranges
@@ -309,6 +318,9 @@ export async function runBackfillFacetCrawl(
     }
 
     rangesCrawled++
+    if (rangeHadIncompleteResults) {
+      incompleteResultRanges++
+    }
 
     if (errored) {
       // M-1: a page error (rate-limiter already retried transient 403/429, so a
@@ -477,5 +489,6 @@ export async function runBackfillFacetCrawl(
     facets_completed: state.facetIndex,
     facets_total: facets.length,
     ranges_crawled: rangesCrawled,
+    incomplete_results_ranges: incompleteResultRanges,
   }
 }

--- a/scripts/indexer/subdirectory-search.ts
+++ b/scripts/indexer/subdirectory-search.ts
@@ -186,7 +186,7 @@ export async function runSubdirectorySearch(
     )
     console.log(
       `[Backfill] Facet crawl: ${repos.length} skills added, ${backfill.facets_completed}/${backfill.facets_total} facets, ${backfill.ranges_crawled} ranges this dispatch, ` +
-        `admitted=${stats.admitted}, licenseNull=${stats.licenseNull}, noDefaultBranch=${stats.noDefaultBranch}, ${stats.licenseFiltered} license-filtered, cap_saturated=${backfill.cap_saturated}, truncated=${backfill.truncated_repo_count}, done=${backfill.done}`
+        `admitted=${stats.admitted}, licenseNull=${stats.licenseNull}, noDefaultBranch=${stats.noDefaultBranch}, ${stats.licenseFiltered} license-filtered, cap_saturated=${backfill.cap_saturated}, truncated=${backfill.truncated_repo_count}, incomplete_results_ranges=${backfill.incomplete_results_ranges}, done=${backfill.done}`
     )
     console.log(
       `[Backfill] Per-skill extraction: ${enumeratedRepos.size} repos enumerated, ${enumerateTelemetry.denylistSkipped ?? 0} denylist-skipped, ${enumerateTelemetry.cappedRepoCount ?? 0} capped, ${enumerateTelemetry.truncatedRepoCount ?? 0} api-truncated`

--- a/scripts/tests/indexer/backfill-facet-crawl.test.ts
+++ b/scripts/tests/indexer/backfill-facet-crawl.test.ts
@@ -438,4 +438,108 @@ describe('runSubdirectorySearch — size-faceted backfill crawl (SMI-5286 1c)', 
     expect(backfill.done).toBe(true)
     expect(result.errors.some((e) => e.includes('rate limited'))).toBe(true)
   })
+
+  it('SMI-6073: a degraded-and-exhausted first-page response is handled via the errored branch, never bisected', async () => {
+    // searchCodeForSkillMdInSubdirectory runs its own degraded-response retry
+    // INTERNALLY (SMI-6073) -- once exhausted, the caller only ever sees the
+    // terminal `error` shape, never an intermediate degraded 200. This proves
+    // the ordering requirement: a degraded first page (with `total: 5000` --
+    // NOT just embedded in the error string, see GPT-5.6-Sol review below --
+    // which would otherwise exceed CODE_SEARCH_RESULT_CAP) must be routed
+    // through the pre-existing `errored` branch (truncate + advance), and
+    // must NEVER reach the `page === 1 && total > CODE_SEARCH_RESULT_CAP`
+    // bisection check.
+    //
+    // GPT-5.6-Sol review (2026-08-17): the original fixture set `total: 0`
+    // here (only the error STRING mentioned 5000), which meant this test
+    // would have passed even if the caller's ordering were WRONG (checking
+    // saturation before `result.error`) -- `page === 1 && 0 > CAP` is false
+    // either way, so it never actually exercised the ordering guard. `total`
+    // must genuinely exceed CODE_SEARCH_RESULT_CAP so an ordering regression
+    // (checking `result.total` before `result.error`) would incorrectly
+    // bisect and this test would catch it.
+    let firstCall = true
+    mockSearchCode.mockImplementation(async (_pathPrefix: unknown, page: number) => {
+      if (firstCall) {
+        firstCall = false
+        return {
+          repos: [],
+          total: 5000,
+          retries: 1,
+          incomplete_results: false,
+          error:
+            'Code search degraded response for broad p1: total_count=5000 but items=0 ' +
+            '(retried once, still degraded) (x-github-request-id: req-degraded)',
+        }
+      }
+      return nonSaturatingPage(page)
+    })
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100 })
+    )
+    const backfill = result.backfill!
+
+    // Bisection did NOT occur for the degraded facet -- cap_saturated is only
+    // ever set by the `saturated` branch, never the `errored` branch.
+    expect(backfill.cap_saturated).toBe(false)
+    // The errored branch always ADVANCES (never bisects) -- exactly one range
+    // per top-level facet, same as Case 1's clean run. If the degraded
+    // response had incorrectly reached the bisection check instead, this
+    // would be LADDER_SIZE + 1 (the split facet contributing 2 ranges).
+    expect(backfill.ranges_crawled).toBe(LADDER_SIZE)
+    expect(backfill.done).toBe(true)
+    expect(backfill.facets_completed).toBe(LADDER_SIZE)
+    expect(backfill.cursor.facet).toBe('done')
+    expect(backfill.cursor.pending_subranges).toEqual([])
+    // Surfaced (counted + in errors[]), not silently dropped.
+    expect(backfill.truncated_repo_count).toBeGreaterThanOrEqual(1)
+    expect(result.errors.some((e) => e.includes('degraded response'))).toBe(true)
+  })
+
+  it('SMI-6073: incomplete_results_ranges aggregates per RANGE (not per page) into the crawl outcome', async () => {
+    // Facet 0 spans TWO pages, BOTH carrying incomplete_results: true -- must
+    // be counted as ONE range, not two. Every other facet is a clean
+    // single-page range with incomplete_results: false (via nonSaturatingPage).
+    const perPage = 2
+    let callCount = 0
+    mockSearchCode.mockImplementation(async (_pathPrefix: unknown, page: number) => {
+      callCount++
+      if (callCount === 1) {
+        // Facet 0, page 1: a FULL page (repos.length === perPage) -> the range
+        // keeps paginating instead of exhausting.
+        return {
+          repos: [makeCodeSearchRepo(), makeCodeSearchRepo()],
+          total: 3,
+          retries: 0,
+          incomplete_results: true,
+        }
+      }
+      if (callCount === 2) {
+        // Facet 0, page 2: short page -> range exhausts. Also incomplete.
+        return { repos: [makeCodeSearchRepo()], total: 3, retries: 0, incomplete_results: true }
+      }
+      return nonSaturatingPage(page)
+    })
+
+    const result = await runSubdirectorySearch(
+      new Set<string>(),
+      new Map(),
+      {},
+      1,
+      noTelemetry,
+      makePlan({ maxRangesPerDispatch: 100, perPage })
+    )
+    const backfill = result.backfill!
+    expect(backfill.done).toBe(true)
+    expect(backfill.ranges_crawled).toBe(LADDER_SIZE)
+    // Exactly ONE range (facet 0) had incomplete_results, despite TWO pages
+    // each reporting it -- proves per-range aggregation, not per-page.
+    expect(backfill.incomplete_results_ranges).toBe(1)
+  })
 })

--- a/scripts/tests/indexer/code-search.test.ts
+++ b/scripts/tests/indexer/code-search.test.ts
@@ -1,0 +1,276 @@
+/**
+ * SMI-6073: degraded-response detection + bounded retry tests for
+ * `searchCodeForSkillMdInSubdirectory` (scripts/indexer/code-search.ts).
+ *
+ * GitHub's code-search endpoint can return HTTP 200 with a nonzero
+ * `total_count` but empty `items` (see the SMI-6073 plan's Context section —
+ * the documented query-timeout-degrades-to-partial-results behavior). Prior
+ * to this change that was indistinguishable from a genuine "zero results"
+ * page. These tests exercise the new detection + bounded retry + error-return
+ * logic added to `searchCodeForSkillMdInSubdirectory`.
+ *
+ * Mocking approach mirrors `rate-limit-tracking.test.ts` (the existing test
+ * for this module's shared 403/429 retry wrapper): `global.fetch` is mocked
+ * directly and the REAL `withRateLimitTracking` implementation is left in
+ * place (only `delay` is stubbed to a no-op via a partial `importOriginal`
+ * override, matching the pattern already used in
+ * `subdirectory-search.helpers.test.ts` for the same module), so these tests
+ * exercise the actual header-parsing + retry control flow, not a stand-in.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  searchCodeForSkillMdInSubdirectory,
+  CODE_SEARCH_RESULT_CAP,
+  DEGRADED_RESPONSE_RETRY_DELAY_MS,
+} from '../../indexer/code-search.ts'
+import { newRateLimitTelemetry } from '../../indexer/_shared/rate-limit.ts'
+
+// `delay` stubbed to a no-op so the 6s degraded-retry delay (and the
+// pre-existing 403/429 RETRY_DELAYS ladder) cost no real wall-clock time.
+// Everything else (withRateLimitTracking, RateLimitError, etc.) stays real.
+vi.mock('../../indexer/_shared/rate-limit.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../indexer/_shared/rate-limit.ts')>()
+  return {
+    ...actual,
+    delay: vi.fn(async () => undefined),
+  }
+})
+
+vi.mock('../../indexer/_shared/github-auth.ts', () => ({
+  buildGitHubHeaders: vi.fn(async () => ({})),
+}))
+
+/** A minimal, realistic code-search item (matches `CodeSearchResponse['items'][number]`). */
+function makeItem(overrides: { fork?: boolean; owner?: string; name?: string } = {}) {
+  const owner = overrides.owner ?? 'owner1'
+  const name = overrides.name ?? 'repo1'
+  return {
+    name: 'SKILL.md',
+    path: 'skills/x/SKILL.md',
+    repository: {
+      id: 1,
+      full_name: `${owner}/${name}`,
+      name,
+      owner: { login: owner },
+      description: null,
+      html_url: `https://github.com/${owner}/${name}`,
+      stargazers_count: 1,
+      forks_count: 0,
+      fork: overrides.fork ?? false,
+      topics: [],
+      default_branch: 'main',
+    },
+  }
+}
+
+function jsonResponse(
+  body: unknown,
+  opts: { status?: number; headers?: Record<string, string> } = {}
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: opts.status ?? 200,
+    headers: { 'content-type': 'application/json', ...(opts.headers ?? {}) },
+  })
+}
+
+/** A 403/429 rate-limit response (no JSON body -- code-search.ts never parses one on this path). */
+function rateLimitResponse(status: 403 | 429, headers: Record<string, string> = {}): Response {
+  return new Response('rate limited', { status, headers })
+}
+
+describe('searchCodeForSkillMdInSubdirectory — SMI-6073 degraded-response handling', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalFetch: typeof global.fetch
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+    fetchMock = vi.fn()
+    // @ts-expect-error overriding global for test
+    global.fetch = fetchMock
+  })
+  afterEach(() => {
+    global.fetch = originalFetch
+    vi.clearAllMocks()
+  })
+
+  it('retries once on a degraded response (raw items empty, total_count > 0, page in range), then returns error if still degraded', async () => {
+    const telemetry = newRateLimitTelemetry()
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { total_count: 50, incomplete_results: false, items: [] },
+          { headers: { 'x-github-request-id': 'req-1' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { total_count: 50, incomplete_results: false, items: [] },
+          { headers: { 'x-github-request-id': 'req-2' } }
+        )
+      )
+
+    const result = await searchCodeForSkillMdInSubdirectory(undefined, 1, 100, telemetry)
+
+    // Initial fetch + exactly ONE degraded retry -- not the full RETRY_DELAYS ladder.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result.repos).toEqual([])
+    expect(result.error).toBeDefined()
+    expect(result.error).toContain('degraded response')
+    // The error names the LAST response's request id (retried once, still degraded).
+    expect(result.error).toContain('req-2')
+  })
+
+  it('does NOT treat an all-filtered-out page (forks) as degraded -- raw items non-empty, no retry, repos: []', async () => {
+    const telemetry = newRateLimitTelemetry()
+    // GitHub returned 3 real items (total_count matches), but every single one
+    // is a fork -- a legitimate empty `repos` result, not degradation.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        total_count: 3,
+        incomplete_results: false,
+        items: [makeItem({ fork: true }), makeItem({ fork: true }), makeItem({ fork: true })],
+      })
+    )
+
+    const result = await searchCodeForSkillMdInSubdirectory(undefined, 1, 100, telemetry)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1) // no retry
+    expect(result.error).toBeUndefined()
+    expect(result.repos).toEqual([])
+    expect(result.total).toBe(3)
+  })
+
+  it('does NOT treat a page requested past min(total_count, CODE_SEARCH_RESULT_CAP) as degraded (legitimate empty page)', async () => {
+    const telemetry = newRateLimitTelemetry()
+    const perPage = 100
+    // total_count (5000) exceeds the cap, so the retrievable ceiling is
+    // CODE_SEARCH_RESULT_CAP (1000), not total_count. Request the page
+    // immediately past that ceiling (page 11 * 100 = 1000..1100, entirely
+    // beyond the retrievable range).
+    const pageJustPastCap = CODE_SEARCH_RESULT_CAP / perPage + 1
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ total_count: 5000, incomplete_results: false, items: [] })
+    )
+
+    const result = await searchCodeForSkillMdInSubdirectory(
+      undefined,
+      pageJustPastCap,
+      perPage,
+      telemetry
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1) // no retry -- legitimate empty page
+    expect(result.error).toBeUndefined()
+    expect(result.repos).toEqual([])
+    expect(result.total).toBe(5000)
+  })
+
+  it('skips the retry when the elapsed-budget deadline is imminent -- returns error immediately, single fetch', async () => {
+    const telemetry = newRateLimitTelemetry()
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        { total_count: 10, incomplete_results: false, items: [] },
+        { headers: { 'x-github-request-id': 'req-deadline' } }
+      )
+    )
+
+    // Deadline is closer than the degraded-retry delay -- retry must be skipped
+    // rather than wasting a retry this close to a hard timeout.
+    const deadlineAtMs = Date.now() + DEGRADED_RESPONSE_RETRY_DELAY_MS - 1000
+
+    const result = await searchCodeForSkillMdInSubdirectory(
+      undefined,
+      1,
+      100,
+      telemetry,
+      undefined,
+      deadlineAtMs
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1) // no retry attempted
+    expect(result.error).toBeDefined()
+    expect(result.error).toContain('deadline imminent')
+    expect(result.error).toContain('req-deadline')
+  })
+
+  it('a successful (non-degraded) response is unaffected -- real items returned normally, single fetch', async () => {
+    const telemetry = newRateLimitTelemetry()
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        total_count: 1,
+        incomplete_results: false,
+        items: [makeItem()],
+      })
+    )
+
+    const result = await searchCodeForSkillMdInSubdirectory(undefined, 1, 100, telemetry)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(result.error).toBeUndefined()
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0].fullName).toBe('owner1/repo1')
+  })
+
+  it('SMI-6073: degraded-then-rate-limited -- the degraded retry and the FULL 403/429 ladder are independently budgeted', async () => {
+    // Response sequence: 1 degraded (consumes the degraded retry's ONE
+    // allowance) -> 4 rate-limited responses (3 real retries + a 4th that
+    // finds the ladder exhausted). Regression guard for the BLOCKING bug
+    // (GPT-5.6-Sol review, 2026-08-17): an earlier version shared a single
+    // loop-iteration counter between the degraded retry and the 403/429
+    // ladder, so the degraded retry silently stole one of the ladder's 3
+    // retries -- only 4 total fetches would occur (not 5) and the "after 3
+    // retries" message would be inaccurate (only 2 real 403/429 retries
+    // would have actually happened).
+    const telemetry = newRateLimitTelemetry()
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ total_count: 50, incomplete_results: false, items: [] })
+      )
+      .mockResolvedValueOnce(rateLimitResponse(429))
+      .mockResolvedValueOnce(rateLimitResponse(429))
+      .mockResolvedValueOnce(rateLimitResponse(429))
+      .mockResolvedValueOnce(rateLimitResponse(429, { 'x-github-request-id': 'req-exhausted' }))
+
+    const result = await searchCodeForSkillMdInSubdirectory(undefined, 1, 100, telemetry)
+
+    // 1 (degraded) + 4 (rate-limited: 3 retried + 1 exhausted) = 5 fetches.
+    expect(fetchMock).toHaveBeenCalledTimes(5)
+    expect(result.error).toBeDefined()
+    expect(result.error).toContain('rate limit exhausted')
+    // The FULL 3-retry ladder was honored -- not reduced by the degraded retry.
+    expect(result.error).toContain('after 3 retries')
+    expect(result.error).toContain('req-exhausted')
+    // Combined retry count: 1 degraded retry + 3 rate-limit retries.
+    expect(result.retries).toBe(4)
+  })
+
+  it('SMI-6073: rate-limited-then-degraded -- a degraded response interleaved MID-ladder does not shrink the 403/429 budget', async () => {
+    // Response sequence: 2 rate-limited (2 real retries) -> 1 degraded
+    // (consumes the degraded retry's ONE allowance, interleaved BETWEEN
+    // rate-limit retries) -> 2 more rate-limited (the 3rd retry, then a 4th
+    // that finds the ladder exhausted). Proves independence in the OPPOSITE
+    // ordering from the test above -- the ladder must still get its full 3
+    // retries even though a degraded response occupied a fetch slot in the
+    // middle of it.
+    const telemetry = newRateLimitTelemetry()
+    fetchMock
+      .mockResolvedValueOnce(rateLimitResponse(429))
+      .mockResolvedValueOnce(rateLimitResponse(429))
+      .mockResolvedValueOnce(
+        jsonResponse({ total_count: 50, incomplete_results: false, items: [] })
+      )
+      .mockResolvedValueOnce(rateLimitResponse(429))
+      .mockResolvedValueOnce(rateLimitResponse(429, { 'x-github-request-id': 'req-exhausted-2' }))
+
+    const result = await searchCodeForSkillMdInSubdirectory(undefined, 1, 100, telemetry)
+
+    // 4 rate-limited (3 retried + 1 exhausted) + 1 degraded (retried) = 5 fetches.
+    expect(fetchMock).toHaveBeenCalledTimes(5)
+    expect(result.error).toBeDefined()
+    expect(result.error).toContain('rate limit exhausted')
+    expect(result.error).toContain('after 3 retries')
+    expect(result.error).toContain('req-exhausted-2')
+    expect(result.retries).toBe(4)
+  })
+})

--- a/scripts/tests/indexer/rate-limit-tracking.test.ts
+++ b/scripts/tests/indexer/rate-limit-tracking.test.ts
@@ -163,6 +163,83 @@ describe('withRateLimitTracking', () => {
     expect(summary.code_search_remaining_min).toBe(0)
   })
 
+  it('SMI-6073: newRateLimitTelemetry starts every bucket unobserved', () => {
+    const telemetry = newRateLimitTelemetry()
+    expect(telemetry.core_observed).toBe(false)
+    expect(telemetry.search_observed).toBe(false)
+    expect(telemetry.code_search_observed).toBe(false)
+  })
+
+  it('SMI-6073: marks only the metered bucket observed -- mixed case (one bucket observed, another not)', async () => {
+    const telemetry = newRateLimitTelemetry()
+    // Only a `core`-bucket response is ever seen this run.
+    fetchMock.mockResolvedValueOnce(
+      new Response('ok', {
+        status: 200,
+        headers: { 'x-ratelimit-remaining': '4500', 'x-ratelimit-resource': 'core' },
+      })
+    )
+
+    await withRateLimitTracking(telemetry, 'https://api.github.com/repos/o/r/git/trees/main')
+
+    expect(telemetry.core_observed).toBe(true)
+    // Mixed case: search/code_search were never metered this run -- they must
+    // stay false, not be misread as "observed" just because SOME bucket was.
+    expect(telemetry.search_observed).toBe(false)
+    expect(telemetry.code_search_observed).toBe(false)
+  })
+
+  it('SMI-6073: the observed flag is set even when the observed remaining does NOT beat the running minimum', async () => {
+    const telemetry = newRateLimitTelemetry()
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response('ok', {
+          status: 200,
+          headers: { 'x-ratelimit-remaining': '10', 'x-ratelimit-resource': 'code_search' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response('ok', {
+          status: 200,
+          headers: { 'x-ratelimit-remaining': '20', 'x-ratelimit-resource': 'code_search' },
+        })
+      )
+
+    await withRateLimitTracking(telemetry, 'https://api.github.com/search/code')
+    await withRateLimitTracking(telemetry, 'https://api.github.com/search/code')
+
+    // The second call's remaining (20) doesn't beat the running min (10), but
+    // the bucket WAS observed on both calls.
+    expect(telemetry.code_search_remaining_min).toBe(10)
+    expect(telemetry.code_search_observed).toBe(true)
+  })
+
+  it('SMI-6073: summarizeRateLimitTelemetry distinguishes never-observed from observed-and-genuinely-zero, per bucket', () => {
+    // "Never observed": the POSITIVE_INFINITY sentinel resolves to 0, but the
+    // observed flag stays false for every bucket.
+    const neverObserved = newRateLimitTelemetry()
+    const neverSummary = summarizeRateLimitTelemetry(neverObserved)
+    expect(neverSummary.core_remaining_min).toBe(0)
+    expect(neverSummary.core_observed).toBe(false)
+    expect(neverSummary.search_remaining_min).toBe(0)
+    expect(neverSummary.search_observed).toBe(false)
+    expect(neverSummary.code_search_remaining_min).toBe(0)
+    expect(neverSummary.code_search_observed).toBe(false)
+
+    // "Observed and genuinely 0": same numeric summary (0), but the observed
+    // flag disambiguates it from the never-observed case above. Mixed across
+    // buckets -- only `core` was actually metered this run.
+    const genuinelyZero = newRateLimitTelemetry()
+    genuinelyZero.core_remaining_min = 0
+    genuinelyZero.core_observed = true
+    const zeroSummary = summarizeRateLimitTelemetry(genuinelyZero)
+    expect(zeroSummary.core_remaining_min).toBe(0)
+    expect(zeroSummary.core_observed).toBe(true)
+    // code_search: never metered this run -- must still read as unobserved.
+    expect(zeroSummary.code_search_remaining_min).toBe(0)
+    expect(zeroSummary.code_search_observed).toBe(false)
+  })
+
   it('withBackoff retries on RateLimitError up to maxRetries', async () => {
     let attempts = 0
     const fn = async (): Promise<string> => {


### PR DESCRIPTION
## Business Summary

**What shipped:** The SMI-5334 skill backfill was hitting a GitHub Actions-specific failure mode — code-search would report matches exist (`total_count > 0`) but return zero of them, only on GHA runners, not from a local machine with the same token and query at the same moment. The backfill now detects this specific degraded-response shape and automatically retries once before giving up, instead of silently treating it as "no results here." It also now records, per rate-limit bucket, whether a real API response was ever observed — previously "never checked" and "definitely exhausted" looked identical in the telemetry, which made past incidents harder to diagnose. A documented manual fallback procedure (run the crawl by hand, off GitHub Actions, for one path) is now written up in the runbook for the rare case the automatic retry doesn't clear it.

**Quality bar:** Investigated by an independent research pass (Fable) that confirmed the GitHub-documented precedent for this failure class; the fix plan and the code were each separately reviewed by a different model (GPT-5.6-Sol/Codex) than the one that wrote them. The plan review caught 3 issues before implementation started; the code review caught 1 real bug (the new retry was accidentally sharing its retry budget with an unrelated existing rate-limit retry mechanism) and 2 minor issues, all fixed. Full test suite (1,362 tests), typecheck, lint, and format all verified independently after the fixes, not just taken on the reviewing agent's word.

**Found along the way:** two pre-existing issues were spotted but filed separately rather than bundled in here — SMI-6068 (the original `GH_PAT` GitHub secret is invalid and needs manual rotation) and SMI-6075 (a `BACKFILL_MAX_SKILLS_PER_REPO` environment variable is set by the workflow but never actually read by the code it's meant to configure).

**Net result:** Fully shipped. The runbook documentation for this change already merged separately (`docs/internal` PR #789). This clears the way to resume the SMI-5334 backfill's next target prefix (`.github/skills`).

---

## Technical detail

Implements items 1–2 of the SMI-6073 plan (`docs/internal/implementation/2026-08-17-smi-6073-gha-code-search-degradation.md`; item 3, the runbook break-glass procedure, already merged via the `docs/internal` submodule).

- `scripts/indexer/_shared/rate-limit.ts` — `RateLimitTelemetry` gains per-bucket `core_observed`/`search_observed`/`code_search_observed` booleans, set whenever any finite `x-ratelimit-remaining` header is seen for that bucket, independent of whether it beats the running minimum.
- `scripts/indexer/code-search.ts` — `searchCodeForSkillMdInSubdirectory` detects a degraded response (raw `items.length === 0`, `total_count > 0`, requested page within the retrievable range) *before* the existing fork/dedup/validation filter chain, and retries once via a new deadline-aware `deadlineAtMs` param. The retry uses its own independent one-shot counter, fully decoupled from the existing 403/429 rate-limit retry ladder — two new mixed-order tests (`code-search.test.ts`) assert the two budgets never interfere in either ordering.
- `scripts/indexer/subdirectory-search.helpers.ts` / `subdirectory-search.ts` / `backfill-checkpoint.ts` — per-range `incomplete_results` tracking threaded through to a new `incomplete_results_ranges` field, surfaced in the `[Backfill] Facet crawl:` summary log line.
- Tests: new `scripts/tests/indexer/code-search.test.ts`, plus extensions to `backfill-facet-crawl.test.ts` and `rate-limit-tracking.test.ts`.

Docker pre-push suite (security tests, npm audit, format, full test check) passed on push. `docs/internal` pointer bump included (already-merged `docs/internal` PR #789).
