### PR TITLE
fix(indexer): SMI-6073 incomplete_results_ranges never reached the persisted checkpoint

### DIFF
--- a/scripts/indexer/backfill-checkpoint.ts
+++ b/scripts/indexer/backfill-checkpoint.ts
@@ -247,6 +247,14 @@ export interface BackfillCheckpointPayload {
   /** Repos skipped because their Trees response truncated (cap or API). */
   truncated_repo_count: number
   /**
+   * SMI-6073: count of ranges this dispatch where at least one page carried
+   * `incomplete_results: true` — GitHub's own query-timeout signal. Mirrors
+   * {@link BackfillCrawlOutcome.incomplete_results_ranges}; persisted here (not
+   * just logged) so `audit_logs`-based monitoring queries (runbook §3.1) can
+   * surface it, not only the GHA run log.
+   */
+  incomplete_results_ranges: number
+  /**
    * Whether this checkpoint was written by a DRY_RUN dispatch. Tagged so live
    * resumes can skip dry-run checkpoints via {@link readLatestCheckpoint}
    * `excludeDryRun: true`.
@@ -285,6 +293,7 @@ export async function writeCheckpoint(
         facets_total: payload.facets_total,
         cap_saturated: payload.cap_saturated,
         truncated_repo_count: payload.truncated_repo_count,
+        incomplete_results_ranges: payload.incomplete_results_ranges,
         dry_run: payload.dry_run,
       },
     })

--- a/scripts/indexer/run.ts
+++ b/scripts/indexer/run.ts
@@ -222,11 +222,9 @@ async function runDiscoveryBranch(
   })
 
   // SMI-5286 1c (§#5): persist the advanced facet cursor so the next dispatch
-  // (resume_from=latest) continues mid-facet. Written even in DRY_RUN so the
-  // operator can verify the resume loop before flipping to a live write
-  // (audit_logs is append-only telemetry, not the skills registry).
-  // SMI-5319 (W3): stamp dry_run so a subsequent live resume_from=latest can
-  // skip these rows via readLatestCheckpoint's excludeDryRun: true option.
+  // continues mid-facet; written even in DRY_RUN so the resume loop is
+  // verifiable pre-live. SMI-5319 (W3): dry_run tag lets resume_from=latest
+  // skip these via readLatestCheckpoint's excludeDryRun option.
   if (env.BACKFILL_MODE && result.backfill_crawl) {
     const bc = result.backfill_crawl
     const wrote = await writeCheckpoint(supabase, {
@@ -236,6 +234,7 @@ async function runDiscoveryBranch(
       facets_total: bc.facets_total,
       cap_saturated: bc.cap_saturated,
       truncated_repo_count: bc.truncated_repo_count,
+      incomplete_results_ranges: bc.incomplete_results_ranges, // SMI-6073
       dry_run: env.DRY_RUN,
     })
     if (wrote) checkpointId = backfillRunId

--- a/scripts/tests/indexer/backfill-checkpoint.dry-run.test.ts
+++ b/scripts/tests/indexer/backfill-checkpoint.dry-run.test.ts
@@ -33,6 +33,7 @@ function makePayload(
     facets_total: 8,
     cap_saturated: false,
     truncated_repo_count: 0,
+    incomplete_results_ranges: 0,
     dry_run: false,
     ...overrides,
   }

--- a/scripts/tests/indexer/backfill-checkpoint.test.ts
+++ b/scripts/tests/indexer/backfill-checkpoint.test.ts
@@ -34,6 +34,7 @@ function makePayload(
     facets_total: 10,
     cap_saturated: false,
     truncated_repo_count: 2,
+    incomplete_results_ranges: 0,
     dry_run: false,
     ...overrides,
   }
@@ -205,6 +206,7 @@ describe('writeCheckpoint', () => {
       facets_total: 15,
       cap_saturated: true,
       truncated_repo_count: 5,
+      incomplete_results_ranges: 4,
       dry_run: false,
     })
 
@@ -217,6 +219,12 @@ describe('writeCheckpoint', () => {
     expect(metadata.facets_total).toBe(15)
     expect(metadata.cap_saturated).toBe(true)
     expect(metadata.truncated_repo_count).toBe(5)
+    // SMI-6073: regression guard for the gap found validating the first live
+    // .github/skills cold-start dispatch -- this field was computed and
+    // logged but silently never reached the persisted checkpoint. A non-zero
+    // value here (not just the makePayload default of 0) proves the field is
+    // genuinely threaded through, not just present-but-always-0.
+    expect(metadata.incomplete_results_ranges).toBe(4)
     expect(metadata.dry_run).toBe(false)
   })
 
@@ -419,6 +427,7 @@ describe('backfill checkpoint round-trip (SPARC AC §#5)', () => {
       facets_total: 20,
       cap_saturated: true,
       truncated_repo_count: 3,
+      incomplete_results_ranges: 2,
       dry_run: false,
     }
 
@@ -445,6 +454,8 @@ describe('backfill checkpoint round-trip (SPARC AC §#5)', () => {
     expect(readBack?.facets_total).toBe(20)
     expect(readBack?.cap_saturated).toBe(true)
     expect(readBack?.truncated_repo_count).toBe(3)
+    // SMI-6073: survives the round-trip too, not just the direct-write assertion
+    expect(readBack?.incomplete_results_ranges).toBe(2)
     expect(readBack?.run_id).toBe('roundtrip-run-001')
     // SMI-5319 W3: dry_run tag survives the round-trip
     expect(readBack?.dry_run).toBe(false)


### PR DESCRIPTION
## Business Summary

**What shipped:** A follow-up fix for the SMI-6073 hardening merged earlier today (#2432). One of the new diagnostic fields (a count of ranges where GitHub's search API reported a timeout-related partial result) was computed correctly and showed up in the GitHub Actions run log, but never actually reached the database row an operator queries to monitor a backfill dispatch — the field was silently missing, not just zero. Found immediately after merge, while validating the first live dispatch on the next target directory (`.github/skills`) with the new fix in place.

**Quality bar:** Root-caused by directly querying the live checkpoint row rather than trusting the GHA run log output — confirmed the field was genuinely absent, not a display artifact. Fix is a small, mechanical three-point wiring change (the type, the write call, and the one call site that had the data in hand but didn't pass it). Full test suite (17,046 tests), typecheck, and lint independently verified in the worktree's own container. Also caught and fixed a separate, unrelated line-budget gate this file has (tighter than the general 500-line standard) that my comment addition briefly tripped.

**Net result:** Fully shipped. Unblocks trusting the `incomplete_results_ranges` field for post-dispatch monitoring going forward (existing rows written before this fix simply don't have it — no backfill needed, the field is purely additive diagnostics).

---

## Technical detail

- `scripts/indexer/backfill-checkpoint.ts` — `BackfillCheckpointPayload` gains `incomplete_results_ranges: number`; `writeCheckpoint()`'s `metadata` insert object now includes `payload.incomplete_results_ranges`.
- `scripts/indexer/run.ts` — the `writeCheckpoint()` call site now passes `bc.incomplete_results_ranges` (the value was already available on the `BackfillCrawlOutcome` in hand, just never threaded through). Trimmed adjacent comments to stay under this file's own 498-line Gate C budget (`run-gate-line-budget.test.ts`).
- `scripts/tests/indexer/backfill-checkpoint.test.ts` / `backfill-checkpoint.dry-run.test.ts` — fixture updated; the direct-write assertion and the write→read round-trip test both now assert a non-zero value (not just the fixture default) so a regression here is caught by a real assertion.

Confirmed the pre-fix gap empirically: `SELECT metadata ? 'incomplete_results_ranges' FROM audit_logs WHERE ...` on the live `.github/skills` cold-start DRY_RUN checkpoint (run `32156988573`) returned `false` before this fix.
