### PR TITLE
fix(enterprise,mcp-server,cli): unpublish Enterprise price from runtime surfaces

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: the CLI's tier-gating messages (`require-tier.ts`) and `ab-test`'s upgrade prompt
+  (console and JSON `price` field) hardcoded the literal unpublished Enterprise price
+  (`$55/user/month`) — now `Custom pricing — Contact Sales`, matching the documented "unpublished"
+  pricing policy (SMI-6069, GH#2368-adjacent follow-up from SMI-5893)
+
 - **Fix**: The Cursor MCP snippet (root README, `@skillsmith/mcp-server`'s README, and the website) no longer defaults to `npx`, which failed inside Cursor on two separate live UAT passes (a real Cursor-bundled-Node ENOENT). The copied `command` is now a resolved-path placeholder (`which`/`where skillsmith-mcp`) that can never point at a wrong path; `npx` stays documented as an explicit, clearly-labeled fallback. Also fixed in the canonical CLI snippet matrix (`templates/mcp-server.template.snippets.ts`, used to scaffold non-Skillsmith MCP servers via `skillsmith author mcp-init`): its Cursor placeholder was hardcoding the literal binary name `skillsmith-mcp` instead of deriving it from the scaffolded server's own package name, and `{{name}}` was never interpolated in a snippet's `notes` text at all — either bug would leak Skillsmith-specific text into a scaffolded (non-Skillsmith) server's generated README (SMI-5893 Wave 11, GH#2368 C-01)
 - **Fix**: Community-tier quota corrected from a stale `1,000` to the actual `100` API calls/month in `displayLicenseStatus` (SMI-5893 Wave 11, GH#2368 C-19)
 - **Fix**: `list`/`manage`'s footer "local: ..." segment, and `inventory status`'s

--- a/packages/cli/src/commands/ab-test.ts
+++ b/packages/cli/src/commands/ab-test.ts
@@ -81,7 +81,9 @@ function showUpgradePrompt(currentTier: LicenseTier): void {
   console.log('    \u2022 Team workspaces & private skills')
   console.log('    \u2022 Usage analytics & priority support')
   console.log()
-  console.log('  ' + chalk.magenta('Enterprise tier') + chalk.dim(' ($55/user/mo)'))
+  console.log(
+    '  ' + chalk.magenta('Enterprise tier') + chalk.dim(' (Custom pricing — Contact Sales)')
+  )
   console.log('    \u2022 Everything in Team, plus:')
   console.log('    \u2022 SSO/SAML, RBAC, audit logging')
   console.log('    \u2022 Private registry & custom integrations')
@@ -113,7 +115,7 @@ function showUpgradePromptJson(currentTier: LicenseTier): void {
         ],
       },
       enterprise: {
-        price: '$55/user/mo',
+        price: 'Custom pricing — Contact Sales',
         features: [
           'Everything in Team',
           'SSO/SAML, RBAC, audit logging',

--- a/packages/cli/src/utils/license-types.ts
+++ b/packages/cli/src/utils/license-types.ts
@@ -11,7 +11,7 @@
  * - community: Free tier (100 API calls/month)
  * - individual: Solo developers ($9.99/mo, 1,000 API calls/month)
  * - team: Teams ($25/user/mo, 10,000 API calls/month)
- * - enterprise: Full enterprise ($55/user/mo, unlimited)
+ * - enterprise: Full enterprise (Custom pricing — Contact Sales, unlimited)
  */
 export type LicenseTier = 'community' | 'individual' | 'team' | 'enterprise'
 

--- a/packages/cli/src/utils/require-tier.ts
+++ b/packages/cli/src/utils/require-tier.ts
@@ -30,7 +30,7 @@ const TIER_PRICING: Record<LicenseTier, string> = {
   community: '$0/month',
   individual: '$9.99/month',
   team: '$25/user/month',
-  enterprise: '$55/user/month',
+  enterprise: 'Custom pricing — Contact Sales',
 }
 
 /**

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: the shared `TIER_PRICING` runtime constant (`license/degradation-types.ts`), consumed
+  by both the MCP server's and CLI's own tier-gating/upgrade-nudge messages, plus several TSDoc
+  comments repeating the same figure, hardcoded the literal unpublished Enterprise price
+  (`$55/user/month`) — now `Custom pricing — Contact Sales`. This is the runtime-surface follow-up
+  to the README-only fix below (SMI-6069, GH#2368-adjacent follow-up from SMI-5893)
 - **Fix**: README's Enterprise Tier heading exposed a specific unpublished price
   (`$55/user/month`) contradicting the "Custom (Contact Sales)" pricing policy — now
   `Custom pricing — Contact Sales` (SMI-5893 Wave 11, GH#2368 C-19)

--- a/packages/enterprise/src/billing/types.ts
+++ b/packages/enterprise/src/billing/types.ts
@@ -17,7 +17,7 @@
  * - community: Free tier (1,000 API calls/month)
  * - individual: Solo developers ($9.99/mo, 10,000 API calls/month)
  * - team: Teams ($25/user/mo, 100,000 API calls/month)
- * - enterprise: Full enterprise ($55/user/mo, unlimited)
+ * - enterprise: Full enterprise (Custom pricing — Contact Sales, unlimited)
  */
 export type LicenseTier = 'community' | 'individual' | 'team' | 'enterprise'
 

--- a/packages/enterprise/src/license/FeatureFlags.ts
+++ b/packages/enterprise/src/license/FeatureFlags.ts
@@ -46,7 +46,7 @@ export type FeatureFlag = IndividualFeatureFlag | TeamFeatureFlag | EnterpriseFe
  * - community: Free tier with no paid features (1,000 API calls/month)
  * - individual: Individual tier for solo developers ($9.99/mo, 10,000 API calls/month)
  * - team: Team tier with collaboration features ($25/user/mo, 100,000 API calls/month)
- * - enterprise: Full enterprise tier with all features ($55/user/mo, unlimited)
+ * - enterprise: Full enterprise tier with all features (Custom pricing — Contact Sales, unlimited)
  */
 export type LicenseTier = 'community' | 'individual' | 'team' | 'enterprise'
 

--- a/packages/enterprise/src/license/GracefulDegradation.ts
+++ b/packages/enterprise/src/license/GracefulDegradation.ts
@@ -59,7 +59,7 @@ import {
  * ```typescript
  * const result = handleFeatureDenied('audit_logging', 'team');
  * console.log(result.message);
- * // "Audit Logging requires Enterprise tier ($55/user/month). Upgrade at https://skillsmith.app/upgrade?tier=enterprise&feature=audit_logging"
+ * // "Audit Logging requires Enterprise tier (Custom pricing — Contact Sales). Upgrade at https://skillsmith.app/upgrade?tier=enterprise&feature=audit_logging"
  * ```
  */
 export function handleFeatureDenied(

--- a/packages/enterprise/src/license/degradation-strategies.ts
+++ b/packages/enterprise/src/license/degradation-strategies.ts
@@ -89,7 +89,7 @@ export function getPricingUrl(options?: {
  * @example
  * ```typescript
  * createUpgradePrompt('sso_saml');
- * // "SSO/SAML Integration requires Enterprise tier ($55/user/month). Upgrade at https://skillsmith.app/upgrade?tier=enterprise&feature=sso_saml"
+ * // "SSO/SAML Integration requires Enterprise tier (Custom pricing — Contact Sales). Upgrade at https://skillsmith.app/upgrade?tier=enterprise&feature=sso_saml"
  * ```
  */
 export function createUpgradePrompt(feature: FeatureFlag, options?: UpgradePromptOptions): string {

--- a/packages/enterprise/src/license/degradation-types.ts
+++ b/packages/enterprise/src/license/degradation-types.ts
@@ -23,7 +23,7 @@ export const TIER_PRICING: Readonly<Record<LicenseTier, string>> = {
   individual: '$9.99/month',
   community: '$0/month',
   team: '$25/user/month',
-  enterprise: '$55/user/month',
+  enterprise: 'Custom pricing — Contact Sales',
 }
 
 /**

--- a/packages/enterprise/src/license/types.ts
+++ b/packages/enterprise/src/license/types.ts
@@ -87,7 +87,7 @@ export const ENTERPRISE_FEATURES: readonly EnterpriseFeatureFlag[] = [
  * - community: Free tier (1,000 API calls/month)
  * - individual: Solo developers ($9.99/mo, 10,000 API calls/month)
  * - team: Teams ($25/user/mo, 100,000 API calls/month)
- * - enterprise: Full enterprise ($55/user/mo, unlimited)
+ * - enterprise: Full enterprise (Custom pricing — Contact Sales, unlimited)
  */
 export type LicenseTier = 'community' | 'individual' | 'team' | 'enterprise'
 

--- a/packages/enterprise/tests/license/GracefulDegradation.test.ts
+++ b/packages/enterprise/tests/license/GracefulDegradation.test.ts
@@ -33,7 +33,7 @@ describe('Constants', () => {
     it('should have pricing for all tiers', () => {
       expect(TIER_PRICING.community).toBe('$0/month')
       expect(TIER_PRICING.team).toBe('$25/user/month')
-      expect(TIER_PRICING.enterprise).toBe('$55/user/month')
+      expect(TIER_PRICING.enterprise).toBe('Custom pricing — Contact Sales')
     })
   })
 
@@ -169,7 +169,7 @@ describe('Upgrade Prompts', () => {
       const prompt = createUpgradePrompt('sso_saml')
       expect(prompt).toContain('SSO/SAML Integration')
       expect(prompt).toContain('Enterprise tier')
-      expect(prompt).toContain('$55/user/month')
+      expect(prompt).toContain('Custom pricing — Contact Sales')
     })
 
     it('should include description when requested', () => {
@@ -179,7 +179,7 @@ describe('Upgrade Prompts', () => {
 
     it('should exclude pricing when requested', () => {
       const prompt = createUpgradePrompt('rbac', { includePricing: false })
-      expect(prompt).not.toContain('$55/user/month')
+      expect(prompt).not.toContain('Custom pricing — Contact Sales')
     })
 
     it('should include alternatives when requested', () => {
@@ -198,7 +198,7 @@ describe('Upgrade Prompts', () => {
       expect(prompt).toContain('Feature Unavailable: Audit Logging')
       expect(prompt).toContain('Comprehensive audit trail')
       expect(prompt).toContain('Current tier: Team ($25/user/month)')
-      expect(prompt).toContain('Required tier: Enterprise ($55/user/month)')
+      expect(prompt).toContain('Required tier: Enterprise (Custom pricing — Contact Sales)')
       expect(prompt).toContain('Upgrade to unlock')
       expect(prompt).toContain('Compare plans')
     })
@@ -224,7 +224,7 @@ describe('Tier Comparison', () => {
       expect(message).toContain('Skillsmith Pricing Tiers')
       expect(message).toContain('Community ($0/month)')
       expect(message).toContain('Team ($25/user/month)')
-      expect(message).toContain('Enterprise ($55/user/month)')
+      expect(message).toContain('Enterprise (Custom pricing — Contact Sales)')
       expect(message).toContain('search, install, recommend, validate, compare')
       expect(message).toContain('https://skillsmith.app/pricing')
     })
@@ -254,7 +254,7 @@ describe('Tier Comparison', () => {
 
       expect(comparison[0]!.pricing).toBe('$0/month')
       expect(comparison[1]!.pricing).toBe('$25/user/month')
-      expect(comparison[2]!.pricing).toBe('$55/user/month')
+      expect(comparison[2]!.pricing).toBe('Custom pricing — Contact Sales')
     })
 
     it('should have no features for community tier', () => {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Fix**: the upgrade-nudge message shown to a non-Enterprise user hitting a gated feature
+  (`getTierComparisonMessage`, `middleware/degradation.ts`) hardcoded the literal unpublished
+  Enterprise price (`$55/user/month`) — told a prospect the number before they ever talk to
+  sales, contradicting CLAUDE.md's "Custom (unpublished, 'Contact Sales')" pricing policy. Now
+  `Custom pricing — Contact Sales` (SMI-6069, GH#2368-adjacent follow-up from SMI-5893)
+
 - **Feature**: `get_skill`, `search`, and `skill_recommend` now surface a partial-scan caveat
   ("Note: partial scan — some files could not be analyzed (...)") when the registry's extended
   operational-code scan (SMI-6033 Wave 2, Gap 8) couldn't cover every candidate file for a skill.

--- a/packages/mcp-server/src/middleware/degradation.ts
+++ b/packages/mcp-server/src/middleware/degradation.ts
@@ -38,7 +38,7 @@ const TIER_PRICING: Record<DegradationLicenseTier, string> = {
   community: '$0/month',
   individual: '$9.99/month',
   team: '$25/user/month',
-  enterprise: '$55/user/month',
+  enterprise: 'Custom pricing — Contact Sales',
 }
 
 /**
@@ -217,7 +217,7 @@ export function getTierComparisonMessage(): string {
     '  - Team Workspaces',
     '  - Priority Support',
     '',
-    'Enterprise ($55/user/month)',
+    'Enterprise (Custom pricing — Contact Sales)',
     '----------------------------------------',
     '  - SSO/SAML Integration',
     '  - Role-Based Access Control',

--- a/packages/website/public/llms-full.txt
+++ b/packages/website/public/llms-full.txt
@@ -141,7 +141,7 @@ Note: Shell `export` does NOT work for MCP servers. They run as subprocesses and
 | Community | Free | 100 | 30/min |
 | Individual | $9.99/month | 1,000 | 60/min |
 | Team | $25/user/month | 10,000 | 120/min |
-| Enterprise | $55/user/month | Unlimited | 300/min |
+| Enterprise | Custom (Contact Sales) | Unlimited | 300/min |
 
 Annual billing saves 17% (pay for 10 months, get 12).
 

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -32,7 +32,7 @@ skillsmith list
 - [Home](https://www.skillsmith.app/): Product overview and features
 - [Quickstart](https://www.skillsmith.app/docs/quickstart): First-time setup guide with two paths (MCP client recommended, CLI alternative)
 - [Skills Browser](https://www.skillsmith.app/skills): Browse and search available skills
-- [Pricing](https://www.skillsmith.app/pricing): Four tiers - Community (free, 100 API calls), Individual ($9.99, 1k), Team ($25/user, 10k), Enterprise ($55/user, unlimited)
+- [Pricing](https://www.skillsmith.app/pricing): Four tiers - Community (free, 100 API calls), Individual ($9.99, 1k), Team ($25/user, 10k), Enterprise (custom pricing, unlimited)
 - [CLI Reference](https://www.skillsmith.app/docs/cli): Complete CLI command documentation
 - [MCP Server](https://www.skillsmith.app/docs/mcp-server): MCP integration configuration
 - [API Reference](https://www.skillsmith.app/docs/api): REST API documentation


### PR DESCRIPTION
## Business Summary

**What shipped:** The unpublished Enterprise price ($55/user/mo) was hardcoded and shown directly to non-Enterprise users — in the CLI's and MCP server's upgrade-nudge messages, and in the two static files served at skillsmith.app that LLM crawlers read for pricing research. That told a prospect the exact number before they ever talked to sales, undermining the "Custom, Contact Sales" pricing policy. Every one of those surfaces now says "Custom pricing — Contact Sales" instead.

**Quality bar:** Found and fixed 2 more leaks beyond the ticket's original list (the two `llms.txt` files) via a systematic repo-wide grep, not just the named files. Deliberately left 2 dead-code sites untouched (zero live consumers, one already `@deprecated`) rather than churning code nobody runs. Full test suite (4,673 tests across cli/mcp-server/enterprise) green, typecheck/lint/format/audit:standards all clean.

**Found along the way:** nothing structural — this was a pure string-literal fix, no logic changes.

**Net result:** Fully shipped, ready to merge.

## Technical detail

Fixes SMI-6069. Fixed the shared `TIER_PRICING` constant (`packages/enterprise/src/license/degradation-types.ts`) plus 3 independent copies that don't import it (mcp-server's own `TIER_PRICING`, CLI's `require-tier.ts`, `ab-test.ts`), TSDoc comments repeating the figure, and `packages/website/public/llms{,-full}.txt`.

Left untouched: `quotas.ts`'s `getTierPriceDisplay()` and `terminology.ts`'s `@deprecated PRICING_TIERS` (both self-documented as having zero live consumers), the website's own account/billing page (an already-paying customer's own bill, not a leak), and `CHANGELOG.md`'s historical entry.

CHANGELOG entries added for `mcp-server`, `cli`, and `enterprise`.