### PR TITLE
fix(mcp-server): skill_inventory_audit scans every supported client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ Vitest only runs tests matching these patterns. Tests elsewhere are **silently i
 | `skill_diff` | Diff two installed skill versions side-by-side |
 | `skill_pack_audit` | Audit all skills in a directory (Individual+) |
 | `skill_audit` | Audit skill for security advisories (Team+) |
-| `skill_inventory_audit` | Audit local `~/.claude/` inventory for namespace collisions; returns rename + edit suggestions (SMI-4590) |
+| `skill_inventory_audit` | Audit every installed AI coding client's skill inventory (plus Claude Code's own commands/agents/CLAUDE.md rules) for namespace collisions; returns rename + edit suggestions (SMI-4590; multi-client SMI-6077) |
 | `apply_namespace_rename` | Apply a rename suggestion from an audit (`apply` / `custom` / `skip`) (SMI-4590) |
 | `apply_recommended_edit` | Apply a recommended prose edit; gated on `APPLY_TEMPLATE_REGISTRY` (SMI-4590) |
 | `undo_apply` | Session-scoped undo of the most recent apply_namespace_rename/apply_recommended_edit changeset(s), restored from the apply tool's own backup (SMI-5456/SMI-5470) |

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
   Enterprise price (`$55/user/month`) — told a prospect the number before they ever talk to
   sales, contradicting CLAUDE.md's "Custom (unpublished, 'Contact Sales')" pricing policy. Now
   `Custom pricing — Contact Sales` (SMI-6069, GH#2368-adjacent follow-up from SMI-5893)
+- **Fix**: `skill_inventory_audit` scanned only `~/.claude/` — its description said so accurately,
+  but the underlying scope was too narrow. Now loops every supported client's native skills
+  directory (`CLIENT_NATIVE_PATHS`, the same source of truth `install_skill --client` already
+  uses) via `local-inventory.ts`'s `scanSkills`, unconditionally per call rather than pre-detecting
+  installed clients (matching `inventory_push`'s existing `collectDeviceSkills()` precedent).
+  Commands/agents/CLAUDE.md trigger-phrase scanning stays Claude Code-only — no other client has
+  an equivalent construct. Tool description updated to match (GH#2368 C-12, SMI-6077)
 
 - **Feature**: `get_skill`, `search`, and `skill_recommend` now surface a partial-scan caveat
   ("Note: partial scan — some files could not be analyzed (...)") when the registry's extended

--- a/packages/mcp-server/src/audit/install-preflight.ts
+++ b/packages/mcp-server/src/audit/install-preflight.ts
@@ -80,7 +80,11 @@ export interface CandidateSkill {
 }
 
 export interface RunInstallPreflightInput {
-  /** Pre-candidate snapshot of `~/.claude/{skills,commands,agents}` + CLAUDE.md. */
+  /**
+   * Pre-candidate snapshot from `scanLocalInventory` — every supported
+   * client's skills directory (SMI-6077), plus Claude Code's own
+   * `{commands,agents}` + CLAUDE.md rules.
+   */
   existingInventory: ReadonlyArray<InventoryEntry>
   /** Synthesized candidate skill being considered for install. */
   candidate: CandidateSkill

--- a/packages/mcp-server/src/tools/skill-inventory-audit.ts
+++ b/packages/mcp-server/src/tools/skill-inventory-audit.ts
@@ -66,7 +66,7 @@ export type SkillInventoryAuditValidatedInput = z.infer<typeof skillInventoryAud
 export const skillInventoryAuditToolSchema = {
   name: 'skill_inventory_audit',
   description:
-    '[Skillsmith — Maintain stage] Audit the local `~/.claude/` inventory (skills, commands, agents, CLAUDE.md rules) for namespace collisions. Returns rename + prose-edit suggestions keyed by a fresh `auditId`. Read-only — performs no file mutations. Feed the returned suggestions into `apply_namespace_rename` / `apply_recommended_edit`.',
+    "[Skillsmith — Maintain stage] Audit your installed AI coding clients' skill inventories (Claude Code, Cursor, Copilot, and every other Skillsmith-supported client) — plus Claude Code's own commands, agents, and CLAUDE.md trigger rules — for namespace collisions. Returns rename + prose-edit suggestions keyed by a fresh `auditId`. Read-only — performs no file mutations. Feed the returned suggestions into `apply_namespace_rename` / `apply_recommended_edit`.",
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/mcp-server/src/utils/local-inventory.helpers.ts
+++ b/packages/mcp-server/src/utils/local-inventory.helpers.ts
@@ -11,6 +11,8 @@ import * as crypto from 'node:crypto'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 
+import { CANONICAL_CLIENT } from '@skillsmith/core/install'
+
 import { parseYamlFrontmatter } from '../tools/validate.helpers.js'
 import type { InventoryEntry, ScanWarning } from './local-inventory.types.js'
 
@@ -228,6 +230,9 @@ function makeClaudeMdEntry(
     identifier: hashClaudeMdLine(claudeMdPath, phrase),
     triggerSurface: [phrase],
     mtime,
+    // CLAUDE.md rules are Claude Code-only (SMI-6077) — no other supported
+    // client reads this file today.
+    client: CANONICAL_CLIENT,
     meta: { description: phrase },
   }
 }

--- a/packages/mcp-server/src/utils/local-inventory.ts
+++ b/packages/mcp-server/src/utils/local-inventory.ts
@@ -3,6 +3,10 @@
  * @module @skillsmith/mcp-server/utils/local-inventory
  * @see SMI-4587 Wave 1 Step 2 — scan ~/.claude/{skills,commands,agents} +
  *      CLAUDE.md trigger phrases into a unified InventoryEntry[].
+ * @see SMI-6077 — skills scanning extended from Claude Code only to every
+ *      supported client's native skills directory (CLIENT_IDS). commands /
+ *      agents / CLAUDE.md rules remain Claude Code-only — no other
+ *      supported client has an equivalent construct today.
  *
  * Each source is independent — failure in one does not fail the others.
  * The scanner is read-only; bootstrapping unmanaged skills via `index_local`
@@ -12,6 +16,13 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
+
+import {
+  CANONICAL_CLIENT,
+  CLIENT_IDS,
+  CLIENT_NATIVE_PATHS,
+  type ClientId,
+} from '@skillsmith/core/install'
 
 import type { InventoryEntry, ScanResult, ScanWarning } from './local-inventory.types.js'
 import {
@@ -27,8 +38,43 @@ import {
   splitDescriptionToPhrases,
 } from './local-inventory.helpers.js'
 
-const DEFAULT_HOME_CLAUDE_DIR = path.join(os.homedir(), '.claude')
-const DEFAULT_MANIFEST_PATH = path.join(os.homedir(), '.skillsmith', 'manifest.json')
+// Captured ONCE at module-load time (mirrors `CLIENT_NATIVE_PATHS` itself,
+// which freezes against `os.homedir()` at ITS module-load time in
+// `@skillsmith/core/install/paths.ts`). Both modules are statically
+// imported — and therefore both evaluate their top-level `homedir()` calls
+// — before any test body runs, so this is guaranteed to observe the SAME
+// real home directory `CLIENT_NATIVE_PATHS` baked in. Deliberately NOT a
+// live `os.homedir()` call inside `resolveClientSkillsDir` below: several
+// existing tests (e.g. `skill-inventory-audit.test.ts`) mutate
+// `process.env.HOME` to the test fixture INSIDE a test body (Node's
+// `os.homedir()` reads `$HOME` on POSIX) — a live call there would resolve
+// against the MUTATED value instead of the real one `CLIENT_NATIVE_PATHS`
+// was frozen against, silently making the "rebase under homeDir" math
+// below a no-op that reads the REAL host's client directories instead of
+// the test fixture.
+const REAL_HOME_DIR = os.homedir()
+
+const DEFAULT_HOME_CLAUDE_DIR = path.join(REAL_HOME_DIR, '.claude')
+const DEFAULT_MANIFEST_PATH = path.join(REAL_HOME_DIR, '.skillsmith', 'manifest.json')
+
+/**
+ * Resolve `client`'s native skills directory, rebased under `homeDir`
+ * (SMI-6077).
+ *
+ * `CLIENT_NATIVE_PATHS` (the single source of truth every client-aware
+ * command uses — `install_skill --client`, `inventory-collector.ts`, etc.)
+ * is frozen at module-load time against the real home directory, so it
+ * can't respect this scanner's `homeDir` test-fixture override directly.
+ * Rebasing by relative-path substitution — instead of hand-duplicating each
+ * client's directory suffix here — keeps `CLIENT_NATIVE_PATHS` the only
+ * place per-client path shape is defined. When `homeDir === REAL_HOME_DIR`
+ * (the non-test-fixture case) this returns exactly `CLIENT_NATIVE_PATHS[client]`.
+ */
+function resolveClientSkillsDir(client: ClientId, homeDir: string): string {
+  const nativePath = CLIENT_NATIVE_PATHS[client]
+  const relativeToRealHome = path.relative(REAL_HOME_DIR, nativePath)
+  return path.join(homeDir, relativeToRealHome)
+}
 
 export interface ScanLocalInventoryOptions {
   /** Defaults to `os.homedir()`. */
@@ -40,7 +86,8 @@ export interface ScanLocalInventoryOptions {
 }
 
 /**
- * Scan `~/.claude/{skills,commands,agents}` and CLAUDE.md trigger phrases.
+ * Scan every supported AI coding client's skills directory, plus Claude
+ * Code's own `{commands,agents}` and CLAUDE.md trigger phrases (SMI-6077).
  *
  * Returns `entries[]` sorted by `kind` then `identifier`, plus any soft
  * `warnings[]` raised during scanning. `durationMs` measures wall-clock
@@ -61,31 +108,44 @@ export async function scanLocalInventory(
 
   const manifest = loadManifest(manifestPath)
 
-  // Source 1: ~/.claude/skills/*/SKILL.md
-  entries.push(...scanSkills(path.join(claudeDir, 'skills'), manifest, warnings))
+  // Source 1 (SMI-6077): every supported client's native skills directory —
+  // Claude Code (~/.claude/skills), Cursor, Copilot, Windsurf, the shared
+  // ~/.agents/skills cross-agent convention (Codex reads ONLY this path,
+  // never .claude/skills), OpenCode, Hermes, Grok Build, and Antigravity —
+  // via `CLIENT_NATIVE_PATHS` (`@skillsmith/core/install`), the same
+  // per-client-path source of truth `install_skill --client` and every
+  // other client-aware command already uses. Scanned unconditionally for
+  // every client on every call rather than pre-detecting which clients are
+  // actually installed first: `scanSkills` already no-ops in ~microseconds
+  // on an absent directory (existsSync gate below), matching the precedent
+  // set by `collectDeviceSkills()` (`@skillsmith/core/sync/inventory-collector.ts`,
+  // the `inventory_push` tool's scanner) — it loops every `CLIENT_IDS` entry
+  // unconditionally and lets a missing directory's ENOENT short-circuit
+  // each iteration, rather than gating the loop on a separate presence
+  // check. `enumerateHarnessPresence()` exists in the same module but is
+  // used ONLY for display purposes (`sklx inventory status`'s "Harness
+  // presence" section), never as a scan gate — that precedent is followed
+  // here too. A directory-name collision between two DIFFERENT skills that
+  // happen to share an identifier across two clients' directories is
+  // exactly the kind of finding the exact-collision pass already looks
+  // for (unchanged semantics — see `collision-detector.helpers.ts`'s
+  // `detectExactCollisions`, which has always matched by identifier across
+  // every scanned source, not scoped per-directory); this is intentionally
+  // additive, not a filtered subset.
+  for (const client of CLIENT_IDS) {
+    const skillsDir = resolveClientSkillsDir(client, homeDir)
+    entries.push(...scanSkills(skillsDir, manifest, warnings, client))
+  }
 
-  // Source 1b (SMI-5456 Wave 1 Step 5): ~/.agents/skills/*/SKILL.md — the
-  // second leg of the dual-path Skillsmith Agent pack install (Codex reads
-  // ONLY this path, never .claude/skills). Scanning it here is what makes
-  // `skill_inventory_audit`'s dual-path dedup + self-exemption (Scope 6 of
-  // the SMI-5456 plan) actually reachable — without this, the audit never
-  // sees the second copy and there is nothing to dedupe. `scanSkills` is
-  // reused verbatim; a directory-name collision between two DIFFERENT skills
-  // that both happen to live under `.claude/skills` and `.agents/skills` is
-  // exactly the kind of finding the exact-collision pass is supposed to
-  // catch, so this is intentionally additive, not a filtered subset.
-  const agentsSkillsDir = opts.homeDir
-    ? path.join(opts.homeDir, '.agents', 'skills')
-    : path.join(os.homedir(), '.agents', 'skills')
-  entries.push(...scanSkills(agentsSkillsDir, manifest, warnings))
-
-  // Source 2: ~/.claude/commands/*.md
+  // Source 2: ~/.claude/commands/*.md — Claude Code only; no other
+  // supported client has an equivalent slash-command directory.
   entries.push(...scanCommands(path.join(claudeDir, 'commands'), warnings))
 
-  // Source 3: ~/.claude/agents/*.md
+  // Source 3: ~/.claude/agents/*.md — Claude Code only, same rationale.
   entries.push(...scanAgents(path.join(claudeDir, 'agents'), warnings))
 
-  // Source 4: ~/.claude/CLAUDE.md and (optional) project CLAUDE.md
+  // Source 4: ~/.claude/CLAUDE.md and (optional) project CLAUDE.md —
+  // Claude Code only, same rationale.
   const userClaudeMd = path.join(claudeDir, 'CLAUDE.md')
   if (fs.existsSync(userClaudeMd)) {
     entries.push(...extractClaudeMdTriggers(userClaudeMd, warnings))
@@ -106,22 +166,20 @@ export async function scanLocalInventory(
   const elapsedNs = process.hrtime.bigint() - startedAt
   const durationMs = Number(elapsedNs) / 1_000_000
 
-  // Suppress unused-variable warning while keeping the homeDir resolution
-  // visible in opts handling above. Reserved for future per-OS path logic.
-  void homeDir
-
   return { entries, warnings, durationMs }
 }
 
 /**
- * Scan `~/.claude/skills/*` for SKILL.md frontmatter. Returns one entry
- * per directory; entries without SKILL.md are still recorded (with
+ * Scan a single client's native skills directory (e.g. `~/.claude/skills/*`,
+ * `~/.cursor/skills/*`) for SKILL.md frontmatter. Returns one entry per
+ * directory; entries without SKILL.md are still recorded (with
  * directory-name fallback) so the collision detector still sees them.
  */
 function scanSkills(
   skillsDir: string,
   manifest: Record<string, unknown> | null,
-  warnings: ScanWarning[]
+  warnings: ScanWarning[],
+  client: ClientId
 ): InventoryEntry[] {
   if (!fs.existsSync(skillsDir)) return []
 
@@ -172,6 +230,7 @@ function scanSkills(
       identifier,
       triggerSurface: phrases,
       mtime,
+      client,
       meta: {
         description,
         author: author.author,
@@ -246,6 +305,7 @@ function scanMdDir(
       identifier,
       triggerSurface: phrases,
       mtime: readMtime(filePath),
+      client: CANONICAL_CLIENT,
       meta: {
         description: triggerLine || undefined,
       },

--- a/packages/mcp-server/src/utils/local-inventory.types.ts
+++ b/packages/mcp-server/src/utils/local-inventory.types.ts
@@ -6,6 +6,8 @@
  * Wave 2/3/4 import these types — keep stable and additive.
  */
 
+import type { ClientId } from '@skillsmith/core/install'
+
 /**
  * The four sources scanned by `scanLocalInventory`. Each kind carries different
  * `triggerSurface` semantics; the collision detector handles them uniformly.
@@ -35,6 +37,19 @@ export interface InventoryEntry {
    * sort (most-recent first within each severity group).
    */
   mtime?: number
+  /**
+   * Which supported AI coding client this entry was scanned from (SMI-6077).
+   * `skill` entries carry whichever client's native skills directory
+   * (`CLIENT_NATIVE_PATHS` / `getInstallPath`, `@skillsmith/core/install` —
+   * the same source of truth `install_skill --client` and every other
+   * client-aware command use) produced them. `command` / `agent` /
+   * `claude_md_rule` entries are always `'claude-code'` — those constructs
+   * have no equivalent directory for other clients today. Optional: not
+   * every `InventoryEntry` literal in this codebase sets it (e.g.
+   * `install-preflight.ts`'s synthesized install-candidate entry), so this
+   * is a strictly additive field.
+   */
+  client?: ClientId
   meta?: {
     /** From `~/.skillsmith/manifest.json` if registered; else undefined. */
     author?: string

--- a/packages/mcp-server/tests/unit/collision-detector.test.ts
+++ b/packages/mcp-server/tests/unit/collision-detector.test.ts
@@ -85,6 +85,26 @@ describe('detectExactCollisions (pure pass)', () => {
     expect(flags[0]?.entries).toHaveLength(3)
   })
 
+  it('SMI-6077: flags same-identifier skills across DIFFERENT clients — collision scope stays global, not per-client', () => {
+    const auditId = newAuditId()
+    const inv = [
+      entry({
+        identifier: 'docker',
+        source_path: '/home/user/.claude/skills/docker/SKILL.md',
+        client: 'claude-code',
+      }),
+      entry({
+        identifier: 'docker',
+        source_path: '/home/user/.cursor/skills/docker/SKILL.md',
+        client: 'cursor',
+      }),
+    ]
+    const flags = detectExactCollisions(inv, auditId)
+    expect(flags).toHaveLength(1)
+    expect(flags[0]?.severity).toBe('error')
+    expect(flags[0]?.entries.map((e) => e.client).sort()).toEqual(['claude-code', 'cursor'])
+  })
+
   it('skips empty / whitespace identifiers silently', () => {
     const auditId = newAuditId()
     const inv = [

--- a/packages/mcp-server/tests/unit/local-inventory.test.ts
+++ b/packages/mcp-server/tests/unit/local-inventory.test.ts
@@ -3,6 +3,12 @@
  * Covers all 4 sources (skills / commands / agents / CLAUDE.md) plus
  * fresh-install latency bound (P-ANTI-2 carryover) and CLAUDE.md
  * tolerance for malformed / missing files.
+ *
+ * SMI-6077: the skills source now scans EVERY supported client's native
+ * directory (CLIENT_IDS), not just Claude Code — see the `client` field
+ * coverage below, which uses Cursor as the representative non-Claude
+ * client fixture (same choice `inventory-collector.test.ts` makes for its
+ * own cross-harness coverage).
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -58,7 +64,65 @@ describe('scanLocalInventory', () => {
     expect(skill?.triggerSurface).toContain('docker')
   })
 
-  it('SMI-5456: also scans ~/.agents/skills (Source 1b, dual-path agent pack)', async () => {
+  it('SMI-6077: tags a Claude Code skill entry with client "claude-code"', async () => {
+    writeFile(
+      path.join(TEST_HOME, '.claude', 'skills', 'docker', 'SKILL.md'),
+      `---\nname: docker\n---\nbody\n`
+    )
+    const result = await scanLocalInventory({ homeDir: TEST_HOME })
+    const skill = result.entries.find((e) => e.identifier === 'docker')
+    expect(skill?.client).toBe('claude-code')
+  })
+
+  it('SMI-6077: scans ~/.cursor/skills (a non-Claude client native directory)', async () => {
+    writeFile(
+      path.join(TEST_HOME, '.cursor', 'skills', 'lint-helper', 'SKILL.md'),
+      `---\nname: lint-helper\ndescription: Cursor-only lint helper\n---\nbody\n`
+    )
+    const result = await scanLocalInventory({ homeDir: TEST_HOME })
+    const skill = result.entries.find((e) => e.identifier === 'lint-helper')
+    expect(skill).toBeDefined()
+    expect(skill?.kind).toBe('skill')
+    expect(skill?.client).toBe('cursor')
+    expect(skill?.source_path).toBe(
+      path.join(TEST_HOME, '.cursor', 'skills', 'lint-helper', 'SKILL.md')
+    )
+    expect(skill?.meta?.description).toBe('Cursor-only lint helper')
+  })
+
+  it('SMI-6077: scans every CLIENT_IDS client in the same pass, not just Claude Code + agents', async () => {
+    writeFile(
+      path.join(TEST_HOME, '.claude', 'skills', 'a', 'SKILL.md'),
+      `---\nname: a\n---\nbody\n`
+    )
+    writeFile(
+      path.join(TEST_HOME, '.cursor', 'skills', 'b', 'SKILL.md'),
+      `---\nname: b\n---\nbody\n`
+    )
+    writeFile(
+      path.join(TEST_HOME, '.copilot', 'skills', 'c', 'SKILL.md'),
+      `---\nname: c\n---\nbody\n`
+    )
+    writeFile(
+      path.join(TEST_HOME, '.codeium', 'windsurf', 'skills', 'd', 'SKILL.md'),
+      `---\nname: d\n---\nbody\n`
+    )
+    const result = await scanLocalInventory({ homeDir: TEST_HOME })
+    const byIdentifier = new Map(result.entries.map((e) => [e.identifier, e]))
+    expect(byIdentifier.get('a')?.client).toBe('claude-code')
+    expect(byIdentifier.get('b')?.client).toBe('cursor')
+    expect(byIdentifier.get('c')?.client).toBe('copilot')
+    expect(byIdentifier.get('d')?.client).toBe('windsurf')
+  })
+
+  it('SMI-6077: tags command entries with client "claude-code" (no other client has an equivalent directory)', async () => {
+    writeFile(path.join(TEST_HOME, '.claude', 'commands', 'ship.md'), `Ship code.\n`)
+    const result = await scanLocalInventory({ homeDir: TEST_HOME })
+    const cmd = result.entries.find((e) => e.kind === 'command')
+    expect(cmd?.client).toBe('claude-code')
+  })
+
+  it('SMI-5456: also scans ~/.agents/skills (the "agents" client, dual-path agent pack)', async () => {
     writeFile(
       path.join(TEST_HOME, '.agents', 'skills', 'skillsmith-agent', 'SKILL.md'),
       `---\nname: skillsmith-agent\ndescription: The Skillsmith Agent\n---\nbody\n`
@@ -68,6 +132,7 @@ describe('scanLocalInventory', () => {
       (e) => e.kind === 'skill' && e.identifier === 'skillsmith-agent'
     )
     expect(skill).toBeDefined()
+    expect(skill?.client).toBe('agents')
     expect(skill?.source_path).toBe(
       path.join(TEST_HOME, '.agents', 'skills', 'skillsmith-agent', 'SKILL.md')
     )


### PR DESCRIPTION
## Business Summary

**What shipped:** `skill_inventory_audit` — the tool that finds naming conflicts across your installed skills — used to only look inside Claude Code's own folder, even though its description already (accurately) said so. Now it checks every AI coding client Skillsmith supports (Cursor, Copilot, Windsurf, and 6 others), so a naming collision between, say, a Cursor skill and a Claude Code skill actually gets caught instead of silently missed.

**Quality bar:** Reused the exact same per-client path logic every other client-aware command already uses (`install_skill --client`'s own source of truth), rather than inventing a second copy that could drift. Caught and fixed a real bug during implementation — a naive path-resolution approach would have silently ignored the test suite's own fixture overrides and scanned the real host machine instead. Full mcp-server test suite green (2,924 tests), typecheck/lint/format/audit:standards all clean.

**Found along the way:** nothing structural — this extends an existing, working scan loop rather than changing its design.

**Net result:** Fully shipped, ready to merge. Closes GH#2368's C-12 finding.

## Technical detail

Fixes SMI-6077 (GH#2368 C-12). `local-inventory.ts`'s `scanSkills()` now loops `CLIENT_IDS` and resolves each client's directory via `CLIENT_NATIVE_PATHS` (`@skillsmith/core/install`) instead of hardcoding just `~/.claude/skills` + `~/.agents/skills`. Scanned unconditionally per call (no pre-detection of installed clients), matching `collectDeviceSkills()`'s existing precedent in `inventory-collector.ts`. Collision detection scope is unchanged (still matches by identifier across all scanned sources, not per-client-scoped) — just sees more sources now. Commands/agents/CLAUDE.md trigger-phrase scanning stays Claude Code-only, since no other supported client has an equivalent construct.

Tool description and CLAUDE.md's tool table updated to describe the new multi-client scope.