### PR TITLE
fix(vscode-extension): npm test false-green — 0 tests silently discovered

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -89,6 +89,8 @@ Worktree-local vscode tests (host-only, resolving through symlinked node_modules
 npm run test:vscode
 ```
 
+`npm test` run from inside this package (`cd packages/vscode-extension && npm test`) now runs the same suite via the shared config (SMI-6084) — it previously silently discovered 0 tests and exited green.
+
 Unit tests run inside the Skillsmith Docker dev container:
 
 ```bash

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -373,7 +373,7 @@
     "watch": "npm run build -- --watch",
     "lint": "eslint src --ext ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run -c ../../vitest.config.vscode.ts",
     "test:integration": "vscode-test",
     "test:e2e": "npm run test:e2e:setup && wdio run ./e2e/wdio.conf.ts",
     "test:e2e:setup": "node e2e/scripts/fix-minimatch-esm.mjs",

--- a/vitest.config.vscode.ts
+++ b/vitest.config.vscode.ts
@@ -1,13 +1,18 @@
 // SMI-5344 #2: standalone vscode-extension test config — the worktree-local path.
 //
-// Invoked ONLY by the root `test:vscode` script via `vitest run -c
-// vitest.config.vscode.ts`. It is intentionally NOT named `vitest.config.ts`
-// inside the package, so it never becomes the config that
-// `npm test --workspace=packages/vscode-extension` (CI matrix job) resolves —
-// that invocation keeps discovering 0 files (`--passWithNoTests`), and the
-// real vscode unit run stays in the `Test (root colocated)` job via
-// `vitest.config.colocated.ts`. CI discovery is therefore byte-identical to
-// `main`; this config only adds a host-runnable, worktree-correct convenience.
+// Invoked by BOTH the root `test:vscode` script (`vitest run -c
+// vitest.config.vscode.ts`) AND, as of SMI-6084, the vscode-extension
+// package's own `test` script (`vitest run -c ../../vitest.config.vscode.ts`)
+// — it is intentionally NOT named `vitest.config.ts` inside the package so
+// package-relative `-c` and root-relative `-c` both resolve to this single
+// file rather than a second, drifting copy. Before SMI-6084, `npm test
+// --workspace=packages/vscode-extension` (the CI matrix job) fell through to
+// the root `vitest.config.ts`'s root-relative globs and silently discovered 0
+// files (`--passWithNoTests`); the matrix job now genuinely runs this suite
+// (78 files / 896 tests), same as `publish-vscode.yml`'s pre-publish
+// validation step. This duplicates the `Test (root colocated)` job's
+// coverage of the same files — the same matrix+colocated duplication shape
+// every other package already has, not new drift.
 //
 // Worktree correctness: unlike the root `vitest.config.ts`, this config does
 // NOT exclude `.worktrees/**`. `root` is pinned to this file's own directory


### PR DESCRIPTION
## Business Summary

**What shipped:** The VS Code extension's own test command (`npm test`, run from inside `packages/vscode-extension`) was silently discovering and running zero tests, then reporting success — 78 test files covering 896 tests were never actually executed by that invocation. This affected the same command in CI (the `Test (vscode-extension)` matrix job) and in the pre-publish validation step, both of which are now genuine test runs instead of no-ops.

**Quality bar:** Investigated by a low-effort research pass, then the fix plan was independently reviewed by GPT-5.6-Sol (a different model provider) before implementation, which caught and corrected two inaccuracies in the plan's first draft. After implementing, verified by hand: the fixed command now runs all 78/896 tests, a deliberately-broken test causes it to fail as expected (then removed), the existing correct invocation (`npm run test:vscode`) is unaffected, and a simulated future regression fails loudly instead of silently passing. Full pre-push governance review: 0 findings.

**Net result:** Fully shipped, no follow-up.

---

## Technical detail

- `packages/vscode-extension/package.json` — `test` script: `vitest run --passWithNoTests` → `vitest run -c ../../vitest.config.vscode.ts`. The shared config already resolves its test-file glob against the repo root regardless of invocation directory, so pointing at it directly fixes discovery; dropping `--passWithNoTests` makes a future discovery break fail the build instead of passing silently.
- `vitest.config.vscode.ts` — header comment updated to describe the new reality (comment-only, no behavior change — independently confirmed by the GPT-5.6-Sol review).
- `packages/vscode-extension/README.md` — one-line note on the new in-package `npm test` behavior.
- CI impact: `ci.yml`'s `Test (vscode-extension)` matrix job and `publish-vscode.yml`'s pre-publish validation step both now run the real suite instead of a 0-test no-op.

Full context: `docs/internal/implementation/smi-6084-vscode-test-false-green.md` and pre-push review `docs/internal/code_review/2026-08-18-smi6084-vscode-test-false-green.md`.