### PR TITLE
chore(env): register GH_PAT for SMI-6061 backfill token redundancy

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -43,6 +43,15 @@ LINEAR_PROJECT_TEAM=
 # @type=string(startsWith=gh) @sensitive
 # GITHUB_TOKEN=
 
+# GitHub PAT (redundant/fallback token) - mirrors the `GH_PAT` GitHub Actions
+# repo secret used by batch-transform.yml/website-deploy-staging.yml. Not
+# consumed by any script yet; registered so a local diagnostic run (e.g.
+# probing GitHub code-search behavior) can use it via `varlock run --` without
+# ever needing GITHUB_TOKEN above. Populate locally only if you hold a copy of
+# the same PAT value used for the GH_PAT Actions secret.
+# @type=string(startsWith=gh) @required=false @sensitive
+# GH_PAT=
+
 # =============================================================================
 # GITHUB APP - For high-rate skill discovery (15K req/hr)
 # Created: January 4, 2026


### PR DESCRIPTION
## Summary
- Documents the `GH_PAT` env var in `.env.schema` (docs-only, 1 file) — a real, currently-used GitHub Actions secret (`batch-transform.yml`, `website-deploy-staging.yml`, `release-cadence.yml`) that had no local documentation entry.
- Cherry-picked from the abandoned local branch `smi-6061-gh-pat-redundancy` during session cleanup (branch itself had no PR); content verified as not superseded by the separate `GH_PAT_SKILLSMITH` fallback token work (SMI-6061, already merged).

[skip-impl-check]