### PR TITLE
feat(website): SMI-6087 private-registry dashboard page

### DIFF
--- a/packages/website/src/components/TeamNav.astro
+++ b/packages/website/src/components/TeamNav.astro
@@ -19,6 +19,7 @@ const tabs = [
   { href: '/account/team', label: 'Overview' },
   { href: '/account/team/members', label: 'Members' },
   { href: '/account/team/workspaces', label: 'Workspaces' },
+  { href: '/account/team/registry', label: 'Registry' },
   { href: '/account/team/analytics', label: 'Analytics' },
 ]
 ---

--- a/packages/website/src/lib/private-registry-dashboard.test.ts
+++ b/packages/website/src/lib/private-registry-dashboard.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  badgeForRegistryVersion,
+  groupRegistryVersions,
+  type PrivateRegistryDashboardRow,
+} from './private-registry-dashboard'
+
+function registryRow(
+  skillId: string,
+  version: string,
+  overrides: Partial<PrivateRegistryDashboardRow> = {}
+): PrivateRegistryDashboardRow {
+  return {
+    skill_id: skillId,
+    version,
+    description: null,
+    approval_status: 'approved',
+    deprecated: false,
+    published_by: '00000000-0000-0000-0000-000000000001',
+    published_at: '2026-08-19T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('groupRegistryVersions', () => {
+  it('groups multiple versions of the same skill together', () => {
+    const rows = [
+      registryRow('acme/code-review', '1.0.0'),
+      registryRow('acme/code-review', '1.1.0'),
+      registryRow('acme/release-notes', '2.0.0'),
+    ]
+
+    expect(groupRegistryVersions(rows)).toEqual([
+      {
+        skillId: 'acme/code-review',
+        versions: [rows[0], rows[1]],
+      },
+      {
+        skillId: 'acme/release-notes',
+        versions: [rows[2]],
+      },
+    ])
+  })
+
+  it('returns an empty list for no registry rows', () => {
+    expect(groupRegistryVersions([])).toEqual([])
+  })
+})
+
+describe('badgeForRegistryVersion', () => {
+  it('badges a deprecated approved version distinctly from a non-deprecated one', () => {
+    expect(badgeForRegistryVersion('approved', false)).toEqual({
+      label: 'Approved',
+      className: 'status-approved',
+    })
+    expect(badgeForRegistryVersion('approved', true)).toEqual({
+      label: 'Deprecated',
+      className: 'status-deprecated',
+    })
+  })
+
+  it.each([
+    ['pending', 'Pending', 'status-pending'],
+    ['approved', 'Approved', 'status-approved'],
+    ['rejected', 'Rejected', 'status-rejected'],
+  ])('maps %s to the expected badge', (status, label, className) => {
+    expect(badgeForRegistryVersion(status, false)).toEqual({
+      label,
+      className,
+    })
+  })
+})

--- a/packages/website/src/lib/private-registry-dashboard.test.ts
+++ b/packages/website/src/lib/private-registry-dashboard.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import {
   badgeForRegistryVersion,
   groupRegistryVersions,
+  loadRegistryDashboardData,
+  reviewRegistrySubmission,
+  setRegistryVersionDeprecated,
   type PrivateRegistryDashboardRow,
 } from './private-registry-dashboard'
 
@@ -68,5 +72,199 @@ describe('badgeForRegistryVersion', () => {
       label,
       className,
     })
+  })
+})
+
+/**
+ * Mock SupabaseClient covering the two query shapes the dashboard uses
+ * (chained .from() builders and .rpc()), same idiom as team-access.test.ts.
+ * Every builder method call is recorded so tests can pin the read-path
+ * invariant: pending/rejected via RPC, approved via RLS-scoped select.
+ */
+interface MockResult {
+  data: unknown
+  error: { message: string } | null
+}
+
+interface RecordedCall {
+  method: string
+  args: unknown[]
+}
+
+function chainableBuilder(result: MockResult, calls: RecordedCall[]) {
+  const builder: Record<string, unknown> = {}
+  for (const method of ['select', 'update', 'eq', 'order']) {
+    builder[method] = (...args: unknown[]) => {
+      calls.push({ method, args })
+      return builder
+    }
+  }
+  builder.single = () => {
+    calls.push({ method: 'single', args: [] })
+    return Promise.resolve(result)
+  }
+  builder.then = (
+    onFulfilled: (value: MockResult) => unknown,
+    onRejected?: (reason: unknown) => unknown
+  ) => Promise.resolve(result).then(onFulfilled, onRejected)
+  return builder
+}
+
+function mockRegistryClient(results: {
+  teams?: MockResult
+  registry?: MockResult
+  rpc?: (fn: string, args: Record<string, unknown>) => MockResult
+}) {
+  const tableCalls: Record<string, RecordedCall[]> = {}
+  const rpcCalls: Array<{ fn: string; args: Record<string, unknown> }> = []
+
+  const client = {
+    from(table: string) {
+      tableCalls[table] = tableCalls[table] ?? []
+      const result =
+        table === 'teams'
+          ? (results.teams ?? { data: null, error: null })
+          : (results.registry ?? { data: [], error: null })
+      return chainableBuilder(result, tableCalls[table])
+    },
+    rpc(fn: string, args: Record<string, unknown>) {
+      rpcCalls.push({ fn, args })
+      return Promise.resolve(results.rpc?.(fn, args) ?? { data: [], error: null })
+    },
+  }
+
+  return { client: client as unknown as SupabaseClient, tableCalls, rpcCalls }
+}
+
+describe('loadRegistryDashboardData (read-path invariant, plan P-5)', () => {
+  it('reads pending and rejected ONLY via get_private_registry_submissions, approved ONLY via the RLS-scoped select', async () => {
+    const pendingRow = registryRow('acme/pending-skill', '0.1.0', { approval_status: 'pending' })
+    const rejectedRow = registryRow('acme/rejected-skill', '0.2.0', {
+      approval_status: 'rejected',
+    })
+    const approvedRow = registryRow('acme/approved-skill', '1.0.0')
+
+    const { client, tableCalls, rpcCalls } = mockRegistryClient({
+      teams: { data: { skill_namespace: 'acme' }, error: null },
+      registry: { data: [approvedRow], error: null },
+      rpc: (_fn, args) => ({
+        data: args.p_status === 'pending' ? [pendingRow] : [rejectedRow],
+        error: null,
+      }),
+    })
+
+    const result = await loadRegistryDashboardData(client, 'team_1')
+
+    // Pending/rejected: exactly two RPC calls, both to the submissions RPC.
+    expect(rpcCalls).toEqual([
+      {
+        fn: 'get_private_registry_submissions',
+        args: { p_team_id: 'team_1', p_status: 'pending' },
+      },
+      {
+        fn: 'get_private_registry_submissions',
+        args: { p_team_id: 'team_1', p_status: 'rejected' },
+      },
+    ])
+
+    // Approved: a plain select on private_registry_skills, explicitly
+    // scoped to approval_status='approved' (matching what RLS exposes).
+    const registryCalls = tableCalls['private_registry_skills'] ?? []
+    expect(registryCalls.some((c) => c.method === 'select')).toBe(true)
+    expect(registryCalls).toContainEqual({
+      method: 'eq',
+      args: ['approval_status', 'approved'],
+    })
+    expect(registryCalls.some((c) => c.method === 'update')).toBe(false)
+
+    expect(result).toEqual({
+      namespace: 'acme',
+      approved: [approvedRow],
+      pending: [pendingRow],
+      rejected: [rejectedRow],
+    })
+  })
+
+  it('maps a missing namespace to the empty string', async () => {
+    const { client } = mockRegistryClient({
+      teams: { data: { skill_namespace: null }, error: null },
+    })
+
+    const result = await loadRegistryDashboardData(client, 'team_1')
+    expect(result.namespace).toBe('')
+    expect(result.approved).toEqual([])
+  })
+
+  it('throws when the submissions RPC errors instead of silently blanking the queue', async () => {
+    const { client } = mockRegistryClient({
+      teams: { data: { skill_namespace: 'acme' }, error: null },
+      rpc: () => ({ data: null, error: { message: 'submissions unavailable' } }),
+    })
+
+    await expect(loadRegistryDashboardData(client, 'team_1')).rejects.toThrow(
+      'submissions unavailable'
+    )
+  })
+})
+
+describe('reviewRegistrySubmission', () => {
+  it('calls review_private_registry_submission with the exact RPC parameter names', async () => {
+    const { client, rpcCalls } = mockRegistryClient({
+      rpc: () => ({ data: [], error: null }),
+    })
+
+    await reviewRegistrySubmission(client, 'team_1', 'acme/skill', '1.0.0', 'rejected', 'nope')
+
+    expect(rpcCalls).toEqual([
+      {
+        fn: 'review_private_registry_submission',
+        args: {
+          p_team_id: 'team_1',
+          p_skill_id: 'acme/skill',
+          p_version: '1.0.0',
+          p_decision: 'rejected',
+          p_note: 'nope',
+        },
+      },
+    ])
+  })
+
+  it('surfaces server-side refusals (e.g. self-approval) as thrown errors', async () => {
+    const { client } = mockRegistryClient({
+      rpc: () => ({ data: null, error: { message: 'submitter cannot review their own' } }),
+    })
+
+    await expect(
+      reviewRegistrySubmission(client, 'team_1', 'acme/skill', '1.0.0', 'approved', null)
+    ).rejects.toThrow('submitter cannot review their own')
+  })
+})
+
+describe('setRegistryVersionDeprecated', () => {
+  it('updates only the deprecated column, fully scoped, and calls the load-bearing .select()', async () => {
+    const { client, tableCalls } = mockRegistryClient({
+      registry: { data: [registryRow('acme/skill', '1.0.0', { deprecated: true })], error: null },
+    })
+
+    await setRegistryVersionDeprecated(client, 'team_1', 'acme/skill', '1.0.0', true)
+
+    const calls = tableCalls['private_registry_skills'] ?? []
+    expect(calls).toContainEqual({ method: 'update', args: [{ deprecated: true }] })
+    expect(calls).toContainEqual({ method: 'eq', args: ['team_id', 'team_1'] })
+    expect(calls).toContainEqual({ method: 'eq', args: ['skill_id', 'acme/skill'] })
+    expect(calls).toContainEqual({ method: 'eq', args: ['version', '1.0.0'] })
+    // Without .select(), Supabase reports success with null data even when
+    // RLS matched zero rows — the next assertion's zero-row test depends on it.
+    expect(calls.some((c) => c.method === 'select')).toBe(true)
+  })
+
+  it('throws when RLS filtered the update to zero rows (non-admin silent no-op)', async () => {
+    const { client } = mockRegistryClient({
+      registry: { data: [], error: null },
+    })
+
+    await expect(
+      setRegistryVersionDeprecated(client, 'team_1', 'acme/skill', '1.0.0', true)
+    ).rejects.toThrow('The skill version could not be updated.')
   })
 })

--- a/packages/website/src/lib/private-registry-dashboard.ts
+++ b/packages/website/src/lib/private-registry-dashboard.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure formatting helpers for the private-registry dashboard.
+ *
+ * Supabase queries and mutations remain in registry.astro; this module
+ * contains only logic that can be unit-tested without a browser or client.
+ */
+
+export type RegistryApprovalStatus = 'pending' | 'approved' | 'rejected'
+
+export interface PrivateRegistryDashboardRow {
+  id?: string
+  skill_id: string
+  version: string
+  description: string | null
+  approval_status?: string
+  approval_mode?: string
+  deprecated?: boolean
+  published_by: string
+  published_at: string
+  approved_by?: string | null
+  approved_at?: string | null
+  review_note?: string | null
+}
+
+export interface RegistrySkillGroup {
+  skillId: string
+  versions: PrivateRegistryDashboardRow[]
+}
+
+export interface RegistryBadge {
+  label: string
+  className: string
+}
+
+/**
+ * Group flat registry rows by skill_id while preserving the input order of
+ * both skill groups and versions.
+ */
+export function groupRegistryVersions(
+  rows: readonly PrivateRegistryDashboardRow[]
+): RegistrySkillGroup[] {
+  const groups = new Map<string, PrivateRegistryDashboardRow[]>()
+
+  for (const row of rows) {
+    const versions = groups.get(row.skill_id)
+    if (versions) {
+      versions.push(row)
+    } else {
+      groups.set(row.skill_id, [row])
+    }
+  }
+
+  return Array.from(groups, ([skillId, versions]) => ({
+    skillId,
+    versions,
+  }))
+}
+
+/**
+ * Deprecated state takes precedence over approval status for approved-list
+ * versions so deprecated releases remain visually distinct.
+ */
+export function badgeForRegistryVersion(
+  approvalStatus: string,
+  deprecated: boolean
+): RegistryBadge {
+  if (deprecated) {
+    return {
+      label: 'Deprecated',
+      className: 'status-deprecated',
+    }
+  }
+
+  switch (approvalStatus.toLowerCase()) {
+    case 'pending':
+      return {
+        label: 'Pending',
+        className: 'status-pending',
+      }
+    case 'approved':
+      return {
+        label: 'Approved',
+        className: 'status-approved',
+      }
+    case 'rejected':
+      return {
+        label: 'Rejected',
+        className: 'status-rejected',
+      }
+    default:
+      return {
+        label: 'Unknown',
+        className: 'status-unknown',
+      }
+  }
+}

--- a/packages/website/src/lib/private-registry-dashboard.ts
+++ b/packages/website/src/lib/private-registry-dashboard.ts
@@ -1,11 +1,22 @@
 /**
- * Pure formatting helpers for the private-registry dashboard.
+ * Formatting helpers + Supabase data access for the private-registry
+ * dashboard (registry.astro). Extracted so the read-path invariant and the
+ * mutation calls can be unit-tested with a mocked client, the same way
+ * team-access.test.ts mocks `.rpc()` (SMI-6087 plan, Wave 2 Step 2).
  *
- * Supabase queries and mutations remain in registry.astro; this module
- * contains only logic that can be unit-tested without a browser or client.
+ * READ-PATH INVARIANT (plan P-5): approved rows come from a plain RLS-scoped
+ * select on private_registry_skills — the member_read policy only exposes
+ * approval_status='approved' rows. Pending/rejected rows MUST come from the
+ * get_private_registry_submissions RPC: a plain select silently returns zero
+ * non-approved rows (even for admins), so swapping these paths would blank
+ * the pending queue without any error.
  */
 
+import type { SupabaseClient } from '@supabase/supabase-js'
+
 export type RegistryApprovalStatus = 'pending' | 'approved' | 'rejected'
+
+export type RegistryReviewDecision = Extract<RegistryApprovalStatus, 'approved' | 'rejected'>
 
 export interface PrivateRegistryDashboardRow {
   id?: string
@@ -92,5 +103,110 @@ export function badgeForRegistryVersion(
         label: 'Unknown',
         className: 'status-unknown',
       }
+  }
+}
+
+export interface RegistryDashboardData {
+  namespace: string
+  approved: PrivateRegistryDashboardRow[]
+  pending: PrivateRegistryDashboardRow[]
+  rejected: PrivateRegistryDashboardRow[]
+}
+
+/**
+ * Load the four dashboard datasets in parallel.
+ *
+ * See the module-level READ-PATH INVARIANT: only the approved list may use a
+ * plain select; the submissions helper's parameter type forbids routing
+ * 'approved' through the RPC path and nothing else may query the table.
+ */
+export async function loadRegistryDashboardData(
+  supabase: SupabaseClient,
+  teamId: string
+): Promise<RegistryDashboardData> {
+  const submissions = (status: Exclude<RegistryApprovalStatus, 'approved'>) =>
+    supabase.rpc('get_private_registry_submissions', {
+      p_team_id: teamId,
+      p_status: status,
+    })
+
+  const [namespaceRes, approvedRes, pendingRes, rejectedRes] = await Promise.all([
+    supabase.from('teams').select('skill_namespace').eq('id', teamId).single(),
+    supabase
+      .from('private_registry_skills')
+      .select('skill_id, version, description, deprecated, published_by, published_at')
+      .eq('team_id', teamId)
+      .eq('approval_status', 'approved')
+      .order('skill_id')
+      .order('version'),
+    submissions('pending'),
+    submissions('rejected'),
+  ])
+
+  if (namespaceRes.error) throw new Error(namespaceRes.error.message)
+  if (approvedRes.error) throw new Error(approvedRes.error.message)
+  if (pendingRes.error) throw new Error(pendingRes.error.message)
+  if (rejectedRes.error) throw new Error(rejectedRes.error.message)
+
+  const namespaceRow = namespaceRes.data as { skill_namespace?: string | null } | null
+
+  return {
+    namespace: String(namespaceRow?.skill_namespace ?? ''),
+    approved: (approvedRes.data ?? []) as PrivateRegistryDashboardRow[],
+    pending: (pendingRes.data ?? []) as PrivateRegistryDashboardRow[],
+    rejected: (rejectedRes.data ?? []) as PrivateRegistryDashboardRow[],
+  }
+}
+
+/**
+ * Approve or reject a pending submission via the
+ * review_private_registry_submission RPC. Admin/owner requirement and the
+ * self-approval block are enforced server-side (SMI-5949 D-6) — this
+ * function surfaces those refusals as thrown Errors.
+ */
+export async function reviewRegistrySubmission(
+  supabase: SupabaseClient,
+  teamId: string,
+  skillId: string,
+  version: string,
+  decision: RegistryReviewDecision,
+  note: string | null
+): Promise<void> {
+  const { error } = await supabase.rpc('review_private_registry_submission', {
+    p_team_id: teamId,
+    p_skill_id: skillId,
+    p_version: version,
+    p_decision: decision,
+    p_note: note,
+  })
+
+  if (error) throw new Error(error.message)
+}
+
+/**
+ * Toggle deprecation via a plain RLS-protected update (admin_update policy,
+ * column-scoped GRANT UPDATE (deprecated)). The trailing .select() is
+ * load-bearing: without it Supabase reports success with null data even when
+ * RLS matched zero rows, so a non-admin (or a stale row) would look like a
+ * successful update.
+ */
+export async function setRegistryVersionDeprecated(
+  supabase: SupabaseClient,
+  teamId: string,
+  skillId: string,
+  version: string,
+  deprecated: boolean
+): Promise<void> {
+  const { data, error } = await supabase
+    .from('private_registry_skills')
+    .update({ deprecated })
+    .eq('team_id', teamId)
+    .eq('skill_id', skillId)
+    .eq('version', version)
+    .select()
+
+  if (error) throw new Error(error.message)
+  if (!data || data.length === 0) {
+    throw new Error('The skill version could not be updated.')
   }
 }

--- a/packages/website/src/pages/account/team/registry.astro
+++ b/packages/website/src/pages/account/team/registry.astro
@@ -457,15 +457,27 @@ const supabaseConfig = getSupabaseConfig()
   import {
     badgeForRegistryVersion,
     groupRegistryVersions,
+    loadRegistryDashboardData,
+    reviewRegistrySubmission,
+    setRegistryVersionDeprecated,
     type PrivateRegistryDashboardRow,
   } from '../../../lib/private-registry-dashboard'
 
   const config = window.__SUPABASE_CONFIG__ || { url: '', anonKey: '' }
 
   function escapeHtml(text: string): string {
-    const div = document.createElement('div')
-    div.textContent = text
-    return div.innerHTML
+    // Replace-based rather than the DOM textContent/innerHTML idiom the
+    // sibling pages use: this page interpolates into quoted HTML attributes
+    // (data-skill-id, data-version, title), and the DOM idiom leaves quotes
+    // unescaped — an attribute-injection vector, since the DB CHECKs on
+    // skill_id/version don't forbid '"' and direct authenticated PostgREST
+    // inserts into private_registry_skills are possible (SMI-5882).
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
   }
 
   function formatDate(value: string): string {
@@ -557,42 +569,19 @@ const supabaseConfig = getSupabaseConfig()
       const canManage = role === 'admin' || role === 'owner'
 
       async function loadRegistry() {
-        const [
-          { data: namespaceRow, error: namespaceError },
-          { data: approvedRows, error: approvedError },
-          { data: pendingRows, error: pendingError },
-          { data: rejectedRows, error: rejectedError },
-        ] = await Promise.all([
-          supabase.from('teams').select('skill_namespace').eq('id', teamId).single(),
-          supabase
-            .from('private_registry_skills')
-            .select('skill_id, version, description, deprecated, published_by, published_at')
-            .eq('team_id', teamId)
-            .eq('approval_status', 'approved')
-            .order('skill_id')
-            .order('version'),
-          supabase.rpc('get_private_registry_submissions', {
-            p_team_id: teamId,
-            p_status: 'pending',
-          }),
-          supabase.rpc('get_private_registry_submissions', {
-            p_team_id: teamId,
-            p_status: 'rejected',
-          }),
-        ])
-
-        if (namespaceError) throw new Error(namespaceError.message)
-        if (approvedError) throw new Error(approvedError.message)
-        if (pendingError) throw new Error(pendingError.message)
-        if (rejectedError) throw new Error(rejectedError.message)
+        // Read-path split (SMI-6087): approved via RLS-scoped select,
+        // pending/rejected via the get_private_registry_submissions RPC —
+        // see loadRegistryDashboardData's invariant note.
+        const registryData = await loadRegistryDashboardData(supabase, teamId)
 
         const namespaceEl = document.getElementById('registry-namespace')!
-        const namespace = String(namespaceRow?.skill_namespace ?? '')
-        namespaceEl.textContent = namespace ? `${namespace}/` : 'Not configured'
+        namespaceEl.textContent = registryData.namespace
+          ? `${registryData.namespace}/`
+          : 'Not configured'
 
-        renderSkills((approvedRows ?? []) as PrivateRegistryDashboardRow[], canManage)
-        renderPending((pendingRows ?? []) as PrivateRegistryDashboardRow[], canManage)
-        renderRejected((rejectedRows ?? []) as PrivateRegistryDashboardRow[])
+        renderSkills(registryData.approved, canManage)
+        renderPending(registryData.pending, canManage)
+        renderRejected(registryData.rejected)
       }
 
       function renderSkills(rows: PrivateRegistryDashboardRow[], userCanManage: boolean) {
@@ -784,18 +773,12 @@ const supabaseConfig = getSupabaseConfig()
 
             let note: string | null = null
             if (decision === 'rejected') {
-              note = window.prompt('Optional rejection note:')?.trim() || null
+              const rawNote = window.prompt('Optional rejection note (Cancel aborts):')
+              if (rawNote === null) return
+              note = rawNote.trim() || null
             }
 
-            const { error } = await supabase.rpc('review_private_registry_submission', {
-              p_team_id: teamId,
-              p_skill_id: skillId,
-              p_version: version,
-              p_decision: decision,
-              p_note: note,
-            })
-
-            if (error) throw new Error(error.message)
+            await reviewRegistrySubmission(supabase, teamId, skillId, version, decision, note)
 
             showActionMessage(
               `${skillId} v${version} was ${decision === 'approved' ? 'approved' : 'rejected'}.`,
@@ -803,18 +786,7 @@ const supabaseConfig = getSupabaseConfig()
             )
           } else if (action === 'toggle-deprecated') {
             const deprecated = button.dataset.deprecated === 'true'
-            const { data, error } = await supabase
-              .from('private_registry_skills')
-              .update({ deprecated: !deprecated })
-              .eq('team_id', teamId)
-              .eq('skill_id', skillId)
-              .eq('version', version)
-              .select()
-
-            if (error) throw new Error(error.message)
-            if (!data || data.length === 0) {
-              throw new Error('The skill version could not be updated.')
-            }
+            await setRegistryVersionDeprecated(supabase, teamId, skillId, version, !deprecated)
 
             showActionMessage(
               `${skillId} v${version} was ${deprecated ? 'undeprecated' : 'deprecated'}.`,

--- a/packages/website/src/pages/account/team/registry.astro
+++ b/packages/website/src/pages/account/team/registry.astro
@@ -1,0 +1,844 @@
+---
+/**
+ * Private Registry Dashboard
+ *
+ * @see SMI-6087: Private registry website dashboard
+ */
+
+export const prerender = false
+
+import { ClientRouter } from 'astro:transitions'
+import Footer from '../../../components/Footer.astro'
+import AccountSidebar from '../../../components/AccountSidebar.astro'
+import Nav from '../../../components/Nav.astro'
+import TeamNav from '../../../components/TeamNav.astro'
+import { getSupabaseConfig } from '../../../lib/supabase-config'
+
+const supabaseConfig = getSupabaseConfig()
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/logo-icon.svg" />
+    <meta name="description" content="Manage your team's private skill registry" />
+    <title>Private Registry | Skillsmith</title>
+    <link rel="preconnect" href="https://api.fontshare.com" crossorigin />
+    <link
+      href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,700,900&display=swap"
+      rel="stylesheet"
+    />
+    <script is:inline define:vars={{ supabaseConfig }}>
+      window.__SUPABASE_CONFIG__ = supabaseConfig
+    </script>
+    <ClientRouter />
+  </head>
+  <body>
+    <Nav activePath="/account/team" />
+
+    <div class="account-shell">
+      <AccountSidebar currentPath={Astro.url.pathname} />
+
+      <main class="registry-container">
+        <h1>Private Registry</h1>
+
+        <TeamNav activePath="/account/team/registry" />
+
+        <div id="loading-state" class="loading-state">
+          <p>Loading private registry...</p>
+        </div>
+
+        <div
+          id="error-state"
+          class="error-state"
+          style="display: none;"
+          role="alert"
+          aria-live="polite"
+        >
+          <h3>Failed to load private registry</h3>
+          <p id="error-message">Something went wrong.</p>
+          <button type="button" data-action="reload" class="btn btn-primary">Try Again</button>
+        </div>
+
+        <div id="content" style="display: none;">
+          <p class="namespace-text">
+            Your team's registry namespace:
+            <code id="registry-namespace">—</code>
+          </p>
+
+          <p
+            id="action-message"
+            class="action-message"
+            style="display: none;"
+            role="status"
+            aria-live="polite"
+          >
+          </p>
+
+          <section class="section" aria-labelledby="skills-heading">
+            <div class="section-header">
+              <h2 id="skills-heading">Skills</h2>
+              <span id="skills-count" class="count-text"></span>
+            </div>
+
+            <div id="skills-list" class="skill-list"></div>
+
+            <div id="skills-empty" class="empty-state" style="display: none;">
+              <h3>No approved skills yet</h3>
+              <p>Published and approved skills will appear here.</p>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="pending-heading">
+            <div class="section-header">
+              <h2 id="pending-heading">Pending Submissions</h2>
+              <span id="pending-count" class="count-text"></span>
+            </div>
+
+            <div id="pending-list" class="submission-list"></div>
+
+            <div id="pending-empty" class="empty-state" style="display: none;">
+              <h3>No pending submissions</h3>
+              <p>New submissions awaiting review will appear here.</p>
+            </div>
+          </section>
+
+          <section class="section" aria-labelledby="rejected-heading">
+            <div class="section-header">
+              <h2 id="rejected-heading">Rejected Submissions</h2>
+              <span id="rejected-count" class="count-text"></span>
+            </div>
+
+            <div id="rejected-list" class="submission-list"></div>
+
+            <div id="rejected-empty" class="empty-state" style="display: none;">
+              <h3>No rejected submissions</h3>
+              <p>Rejected submission history will appear here.</p>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+
+    <Footer compact />
+  </body>
+</html>
+
+<style>
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  body {
+    font-family:
+      'Satoshi',
+      -apple-system,
+      BlinkMacSystemFont,
+      'Segoe UI',
+      Roboto,
+      sans-serif;
+    line-height: 1.6;
+    color: #fafafa;
+    background: #0d0d0f;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .registry-container {
+    flex: 1;
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 2rem;
+    width: 100%;
+  }
+
+  .registry-container h1 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin-bottom: 1.5rem;
+  }
+
+  .namespace-text {
+    color: #9ca3af;
+    font-size: 0.875rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .namespace-text code {
+    color: #e07a5f;
+    background: #1a1a1f;
+    border: 1px solid #2a2a2f;
+    border-radius: 0.375rem;
+    padding: 0.25rem 0.5rem;
+  }
+
+  .section {
+    background: #121214;
+    border: 1px solid #2a2a2f;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .section h2 {
+    font-size: 1.125rem;
+    font-weight: 600;
+  }
+
+  .count-text {
+    color: #9ca3af;
+    font-size: 0.8125rem;
+  }
+
+  .skill-list,
+  .submission-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .skill-card,
+  .submission-card {
+    background: #1a1a1f;
+    border: 1px solid #2a2a2f;
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+  }
+
+  .skill-card:hover,
+  .submission-card:hover {
+    border-color: #3a3a42;
+  }
+
+  .skill-name,
+  .submission-name {
+    font-size: 1rem;
+    font-weight: 600;
+    overflow-wrap: anywhere;
+  }
+
+  .version-list {
+    display: flex;
+    flex-direction: column;
+    margin-top: 0.75rem;
+  }
+
+  .version-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1rem;
+    align-items: center;
+    padding: 0.875rem 0;
+    border-top: 1px solid #2a2a2f;
+  }
+
+  .version-details {
+    min-width: 0;
+  }
+
+  .version-heading,
+  .badge-row,
+  .submission-header,
+  .submission-actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .submission-header {
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+  }
+
+  .submission-actions {
+    margin-top: 1rem;
+  }
+
+  .version-description,
+  .submission-description,
+  .review-note {
+    color: #9ca3af;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    margin-top: 0.5rem;
+    overflow-wrap: anywhere;
+  }
+
+  .version-meta,
+  .submission-meta {
+    color: #6b7280;
+    font-size: 0.8125rem;
+    margin-top: 0.5rem;
+  }
+
+  .status-badge,
+  .version-badge,
+  .deprecated-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.625rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+
+  .version-badge {
+    color: #d1d5db;
+    background: #2a2a2f;
+  }
+
+  .status-approved {
+    color: #6ee7b7;
+    background: rgba(16, 185, 129, 0.12);
+  }
+
+  .status-pending {
+    color: #fcd34d;
+    background: rgba(245, 158, 11, 0.12);
+  }
+
+  .status-rejected {
+    color: #fca5a5;
+    background: rgba(239, 68, 68, 0.12);
+  }
+
+  .deprecated-badge,
+  .status-deprecated {
+    color: #c4b5fd;
+    background: rgba(139, 92, 246, 0.14);
+  }
+
+  .status-unknown {
+    color: #d1d5db;
+    background: #2a2a2f;
+  }
+
+  .btn {
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    font-family: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: none;
+    cursor: pointer;
+    transition:
+      background 0.15s,
+      opacity 0.15s;
+  }
+
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .btn-primary {
+    background: #b8523a;
+    color: #fafafa;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background: #a04530;
+  }
+
+  .btn-secondary {
+    background: #2a2a2f;
+    color: #fafafa;
+  }
+
+  .btn-secondary:hover:not(:disabled) {
+    background: #3a3a42;
+  }
+
+  .btn-danger {
+    color: #fca5a5;
+    background: rgba(239, 68, 68, 0.14);
+  }
+
+  .btn-danger:hover:not(:disabled) {
+    background: rgba(239, 68, 68, 0.24);
+  }
+
+  .btn-small {
+    padding: 0.375rem 0.75rem;
+    white-space: nowrap;
+  }
+
+  .loading-state {
+    padding: 4rem 2rem;
+    text-align: center;
+    color: #9ca3af;
+  }
+
+  .error-state {
+    background: rgba(239, 68, 68, 0.08);
+    border-left: 3px solid #ef4444;
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .error-state h3 {
+    color: #f87171;
+    margin-bottom: 0.5rem;
+  }
+
+  .error-state p {
+    color: #9ca3af;
+    margin-bottom: 1rem;
+  }
+
+  .action-message {
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.875rem;
+  }
+
+  .action-message.success {
+    color: #6ee7b7;
+    background: rgba(16, 185, 129, 0.1);
+    border-left: 3px solid #10b981;
+  }
+
+  .action-message.error {
+    color: #fca5a5;
+    background: rgba(239, 68, 68, 0.08);
+    border-left: 3px solid #ef4444;
+  }
+
+  .empty-state {
+    text-align: center;
+    padding: 2rem;
+    color: #9ca3af;
+  }
+
+  .empty-state h3 {
+    color: #fafafa;
+    margin-bottom: 0.5rem;
+  }
+
+  @media (max-width: 640px) {
+    .version-row {
+      grid-template-columns: 1fr;
+    }
+
+    .version-row > .btn {
+      justify-self: start;
+    }
+
+    .section-header,
+    .submission-header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+</style>
+
+<script>
+  import { createClient } from '@supabase/supabase-js'
+  import { checkTeamAccess, resolveGateRedirect } from '../../../lib/team-access'
+  import {
+    badgeForRegistryVersion,
+    groupRegistryVersions,
+    type PrivateRegistryDashboardRow,
+  } from '../../../lib/private-registry-dashboard'
+
+  const config = window.__SUPABASE_CONFIG__ || { url: '', anonKey: '' }
+
+  function escapeHtml(text: string): string {
+    const div = document.createElement('div')
+    div.textContent = text
+    return div.innerHTML
+  }
+
+  function formatDate(value: string): string {
+    return new Date(value).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  }
+
+  function showState(state: 'loading' | 'content' | 'error', message?: string) {
+    const loading = document.getElementById('loading-state') as HTMLDivElement
+    const content = document.getElementById('content') as HTMLDivElement
+    const errorEl = document.getElementById('error-state') as HTMLDivElement
+    const errorMsg = document.getElementById('error-message') as HTMLParagraphElement
+
+    if (loading) loading.style.display = 'none'
+    if (content) content.style.display = 'none'
+    if (errorEl) errorEl.style.display = 'none'
+    if (state === 'loading' && loading) loading.style.display = 'block'
+    if (state === 'content' && content) content.style.display = 'block'
+    if (state === 'error' && errorEl) {
+      errorEl.style.display = 'block'
+      if (message && errorMsg) errorMsg.textContent = message
+    }
+  }
+
+  function showActionMessage(message: string, kind: 'success' | 'error') {
+    const messageEl = document.getElementById('action-message') as HTMLParagraphElement
+    messageEl.textContent = message
+    messageEl.className = `action-message ${kind}`
+    messageEl.style.display = 'block'
+  }
+
+  document.addEventListener('astro:page-load', async () => {
+    if (
+      window.location.pathname !== '/account/team/registry' &&
+      window.location.pathname !== '/account/team/registry/'
+    )
+      return
+
+    document.querySelectorAll<HTMLButtonElement>('[data-action="reload"]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        window.location.reload()
+      })
+    })
+
+    if (!config.url || !config.anonKey) {
+      showState('error', 'Configuration error.')
+      return
+    }
+
+    const supabase = createClient(config.url, config.anonKey)
+
+    const gate = await checkTeamAccess(supabase)
+    if (!gate.ok) {
+      const redirect = resolveGateRedirect(gate, '/account/team/registry')
+      if (redirect) {
+        window.location.href = redirect
+        return
+      }
+      showState('error', 'You are not a member of any team yet.')
+      return
+    }
+
+    const teamId = gate.teamId as string
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+
+    if (!session) {
+      window.location.href = '/login?redirect=/account/team/registry'
+      return
+    }
+
+    try {
+      const { data: myMembership, error: membershipError } = await supabase
+        .from('team_members')
+        .select('role')
+        .eq('team_id', teamId)
+        .eq('user_id', session.user.id)
+        .limit(1)
+        .single()
+
+      if (membershipError) throw new Error(membershipError.message)
+
+      const role = String(myMembership?.role ?? '').toLowerCase()
+      const canManage = role === 'admin' || role === 'owner'
+
+      async function loadRegistry() {
+        const [
+          { data: namespaceRow, error: namespaceError },
+          { data: approvedRows, error: approvedError },
+          { data: pendingRows, error: pendingError },
+          { data: rejectedRows, error: rejectedError },
+        ] = await Promise.all([
+          supabase.from('teams').select('skill_namespace').eq('id', teamId).single(),
+          supabase
+            .from('private_registry_skills')
+            .select('skill_id, version, description, deprecated, published_by, published_at')
+            .eq('team_id', teamId)
+            .eq('approval_status', 'approved')
+            .order('skill_id')
+            .order('version'),
+          supabase.rpc('get_private_registry_submissions', {
+            p_team_id: teamId,
+            p_status: 'pending',
+          }),
+          supabase.rpc('get_private_registry_submissions', {
+            p_team_id: teamId,
+            p_status: 'rejected',
+          }),
+        ])
+
+        if (namespaceError) throw new Error(namespaceError.message)
+        if (approvedError) throw new Error(approvedError.message)
+        if (pendingError) throw new Error(pendingError.message)
+        if (rejectedError) throw new Error(rejectedError.message)
+
+        const namespaceEl = document.getElementById('registry-namespace')!
+        const namespace = String(namespaceRow?.skill_namespace ?? '')
+        namespaceEl.textContent = namespace ? `${namespace}/` : 'Not configured'
+
+        renderSkills((approvedRows ?? []) as PrivateRegistryDashboardRow[], canManage)
+        renderPending((pendingRows ?? []) as PrivateRegistryDashboardRow[], canManage)
+        renderRejected((rejectedRows ?? []) as PrivateRegistryDashboardRow[])
+      }
+
+      function renderSkills(rows: PrivateRegistryDashboardRow[], userCanManage: boolean) {
+        const groups = groupRegistryVersions(rows)
+        const list = document.getElementById('skills-list')!
+        const empty = document.getElementById('skills-empty')!
+        const count = document.getElementById('skills-count')!
+
+        count.textContent = `${groups.length} skill${groups.length === 1 ? '' : 's'}`
+
+        if (groups.length === 0) {
+          list.innerHTML = ''
+          empty.style.display = 'block'
+          return
+        }
+
+        empty.style.display = 'none'
+        list.innerHTML = groups
+          .map(
+            (group) => `<article class="skill-card">
+              <h3 class="skill-name">${escapeHtml(group.skillId)}</h3>
+              <div class="version-list">
+                ${group.versions
+                  .map((version) => {
+                    const badge = badgeForRegistryVersion('approved', Boolean(version.deprecated))
+                    const description = version.description || 'No description provided.'
+                    const actionLabel = version.deprecated ? 'Undeprecate' : 'Deprecate'
+                    const title = userCanManage
+                      ? `${actionLabel} ${version.skill_id} ${version.version}`
+                      : 'Only team admins and owners can change deprecation state.'
+                    return `<div class="version-row">
+                      <div class="version-details">
+                        <div class="version-heading">
+                          <span class="version-badge">v${escapeHtml(version.version)}</span>
+                          <span class="status-badge ${escapeHtml(badge.className)}">${escapeHtml(
+                            badge.label
+                          )}</span>
+                        </div>
+                        <p class="version-description">${escapeHtml(description)}</p>
+                        <p class="version-meta">Published ${escapeHtml(
+                          formatDate(version.published_at)
+                        )}</p>
+                      </div>
+                      <button
+                        type="button"
+                        class="btn btn-secondary btn-small"
+                        data-action="toggle-deprecated"
+                        data-skill-id="${escapeHtml(version.skill_id)}"
+                        data-version="${escapeHtml(version.version)}"
+                        data-deprecated="${String(Boolean(version.deprecated))}"
+                        title="${escapeHtml(title)}"
+                        ${userCanManage ? '' : 'disabled'}
+                      >
+                        ${actionLabel}
+                      </button>
+                    </div>`
+                  })
+                  .join('')}
+              </div>
+            </article>`
+          )
+          .join('')
+      }
+
+      function renderPending(rows: PrivateRegistryDashboardRow[], userCanManage: boolean) {
+        const list = document.getElementById('pending-list')!
+        const empty = document.getElementById('pending-empty')!
+        const count = document.getElementById('pending-count')!
+        const badge = badgeForRegistryVersion('pending', false)
+
+        count.textContent = `${rows.length} submission${rows.length === 1 ? '' : 's'}`
+
+        if (rows.length === 0) {
+          list.innerHTML = ''
+          empty.style.display = 'block'
+          return
+        }
+
+        empty.style.display = 'none'
+        list.innerHTML = rows
+          .map((row) => {
+            const title = userCanManage ? '' : 'Only team admins and owners can review submissions.'
+            return `<article class="submission-card">
+              <div class="submission-header">
+                <h3 class="submission-name">${escapeHtml(row.skill_id)}</h3>
+                <div class="badge-row">
+                  <span class="version-badge">v${escapeHtml(row.version)}</span>
+                  <span class="status-badge ${escapeHtml(badge.className)}">${escapeHtml(
+                    badge.label
+                  )}</span>
+                </div>
+              </div>
+              <p class="submission-description">${escapeHtml(
+                row.description || 'No description provided.'
+              )}</p>
+              <p class="submission-meta">Submitted ${escapeHtml(formatDate(row.published_at))}</p>
+              <div class="submission-actions">
+                <button
+                  type="button"
+                  class="btn btn-primary btn-small"
+                  data-action="review"
+                  data-decision="approved"
+                  data-skill-id="${escapeHtml(row.skill_id)}"
+                  data-version="${escapeHtml(row.version)}"
+                  title="${escapeHtml(title)}"
+                  ${userCanManage ? '' : 'disabled'}
+                >
+                  Approve
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-danger btn-small"
+                  data-action="review"
+                  data-decision="rejected"
+                  data-skill-id="${escapeHtml(row.skill_id)}"
+                  data-version="${escapeHtml(row.version)}"
+                  title="${escapeHtml(title)}"
+                  ${userCanManage ? '' : 'disabled'}
+                >
+                  Reject
+                </button>
+              </div>
+            </article>`
+          })
+          .join('')
+      }
+
+      function renderRejected(rows: PrivateRegistryDashboardRow[]) {
+        const list = document.getElementById('rejected-list')!
+        const empty = document.getElementById('rejected-empty')!
+        const count = document.getElementById('rejected-count')!
+        const badge = badgeForRegistryVersion('rejected', false)
+
+        count.textContent = `${rows.length} submission${rows.length === 1 ? '' : 's'}`
+
+        if (rows.length === 0) {
+          list.innerHTML = ''
+          empty.style.display = 'block'
+          return
+        }
+
+        empty.style.display = 'none'
+        list.innerHTML = rows
+          .map(
+            (row) => `<article class="submission-card">
+              <div class="submission-header">
+                <h3 class="submission-name">${escapeHtml(row.skill_id)}</h3>
+                <div class="badge-row">
+                  <span class="version-badge">v${escapeHtml(row.version)}</span>
+                  <span class="status-badge ${escapeHtml(badge.className)}">${escapeHtml(
+                    badge.label
+                  )}</span>
+                </div>
+              </div>
+              <p class="submission-description">${escapeHtml(
+                row.description || 'No description provided.'
+              )}</p>
+              <p class="submission-meta">Submitted ${escapeHtml(formatDate(row.published_at))}</p>
+              ${
+                row.review_note
+                  ? `<p class="review-note">Review note: ${escapeHtml(row.review_note)}</p>`
+                  : ''
+              }
+            </article>`
+          )
+          .join('')
+      }
+
+      document.getElementById('content')!.addEventListener('click', async (event) => {
+        const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
+          'button[data-action]'
+        )
+        if (!button || button.disabled || !canManage) return
+
+        const action = button.dataset.action
+        const skillId = button.dataset.skillId
+        const version = button.dataset.version
+
+        if (!skillId || !version) return
+
+        const originalText = button.textContent ?? ''
+        button.disabled = true
+        button.textContent = 'Saving...'
+
+        try {
+          if (action === 'review') {
+            const decision = button.dataset.decision
+            if (decision !== 'approved' && decision !== 'rejected') return
+
+            let note: string | null = null
+            if (decision === 'rejected') {
+              note = window.prompt('Optional rejection note:')?.trim() || null
+            }
+
+            const { error } = await supabase.rpc('review_private_registry_submission', {
+              p_team_id: teamId,
+              p_skill_id: skillId,
+              p_version: version,
+              p_decision: decision,
+              p_note: note,
+            })
+
+            if (error) throw new Error(error.message)
+
+            showActionMessage(
+              `${skillId} v${version} was ${decision === 'approved' ? 'approved' : 'rejected'}.`,
+              'success'
+            )
+          } else if (action === 'toggle-deprecated') {
+            const deprecated = button.dataset.deprecated === 'true'
+            const { data, error } = await supabase
+              .from('private_registry_skills')
+              .update({ deprecated: !deprecated })
+              .eq('team_id', teamId)
+              .eq('skill_id', skillId)
+              .eq('version', version)
+              .select()
+
+            if (error) throw new Error(error.message)
+            if (!data || data.length === 0) {
+              throw new Error('The skill version could not be updated.')
+            }
+
+            showActionMessage(
+              `${skillId} v${version} was ${deprecated ? 'undeprecated' : 'deprecated'}.`,
+              'success'
+            )
+          }
+
+          await loadRegistry()
+        } catch (error) {
+          showActionMessage(
+            error instanceof Error ? error.message : 'The registry action failed.',
+            'error'
+          )
+        } finally {
+          button.disabled = false
+          button.textContent = originalText
+        }
+      })
+
+      await loadRegistry()
+      showState('content')
+    } catch (error) {
+      console.error('Private registry load failed:', error)
+      showState('error', error instanceof Error ? error.message : 'Unexpected error.')
+    }
+  })
+</script>

--- a/packages/website/tests/e2e/team-tier-gate.spec.ts
+++ b/packages/website/tests/e2e/team-tier-gate.spec.ts
@@ -193,6 +193,7 @@ test.describe('Team tier-gate — applies identically to sibling pages', () => {
   for (const path of [
     '/account/team/members',
     '/account/team/workspaces',
+    '/account/team/registry',
     '/account/team/analytics',
   ] as const) {
     test(`${path} redirects on not_team_tier`, async ({ page }) => {


### PR DESCRIPTION
## Business Summary

**What shipped:** Enterprise team admins can now see their team's private skill registry in a browser at `/account/team/registry` — every approved skill and its versions, a pending-submissions queue with Approve/Reject buttons, and rejected-submission history.

**Quality bar:** Implementation reviewed by an independent pr-reviewer pass (Fable) that caught and fixed a real stored-XSS/attribute-injection issue — the page's escaping helper didn't escape quotes, and this is the first `/account/*` page that interpolates user-controlled data (skill_id, version) into quoted HTML attributes rather than text content; a crafted skill_id/version could have injected an event-handler attribute that fired in the reviewing admin's own session. Also extracted the registry data-access calls into a testable module with 7 new tests that pin the two-read-path invariant (approved rows via a plain RLS-scoped select; pending/rejected rows only via the dedicated RPC — mixing these up would either leak content or silently blank the pending queue) using a TypeScript type constraint that makes routing "approved" through the RPC a compile error. Full repo typecheck/lint clean, all 633 website Vitest tests pass (13 new across both review passes).

**Found along the way:** none new — SMI-6089 (CI wiring for this test area) was already filed during SMI-6086.

**Net result:** Fully shipped, independently reviewed and fixed. Verifying the browser view matches the terminal/MCP view live is the recommended manual check before considering this wave closed.

---

## Technical detail

- `packages/website/src/pages/account/team/registry.astro` — new page. Gating via `checkTeamAccess`/`resolveGateRedirect` (`lib/team-access.ts`), same as every other `/account/team/*` page. Admin/owner role fetched separately to disable Approve/Reject/Deprecate controls for non-admins (the RPCs' own server-side checks are the real enforcement). Replace-based `escapeHtml` (`&amp; &lt; &gt; " '`) — fixed post-review from the DOM textContent/innerHTML idiom the sibling pages use, which leaves quotes unescaped and is unsafe once you interpolate into a quoted attribute.
- `packages/website/src/lib/private-registry-dashboard.ts` — `loadRegistryDashboardData` / `reviewRegistrySubmission` / `setRegistryVersionDeprecated`, extracted for testability. Approved skills via a plain `.from('private_registry_skills').select(...)` (RLS exposes approved rows to any team member, no column restriction); pending/rejected via `get_private_registry_submissions` RPC (the only way to see non-approved rows). Approve/reject via `review_private_registry_submission`; deprecate/undeprecate via a plain RLS-protected update with a load-bearing trailing `.select()`.
- `packages/website/src/lib/private-registry-dashboard.test.ts` — 13 tests: version-grouping/badge formatting plus the read-path-invariant pins added in review.
- `packages/website/src/components/TeamNav.astro` — new "Registry" tab between Workspaces and Analytics.
- `packages/website/tests/e2e/team-tier-gate.spec.ts` — added the new route to the existing sibling-page gate coverage.

Plan doc: `docs/internal/implementation/smi-6085-private-registry-demo-readiness.md`. Full pr-reviewer report: `docs/internal/pr-reviews/2026-08-19-smi-6087-private-registry-dashboard.md`. Linear: SMI-6087 (this PR), SMI-6085 (parent tracking issue).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)