### PR TITLE
docs(mcp-server): SMI-6088 clarify namespace terminology

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,8 +194,8 @@ Vitest only runs tests matching these patterns. Tests elsewhere are **silently i
 | `skill_diff` | Diff two installed skill versions side-by-side |
 | `skill_pack_audit` | Audit all skills in a directory (Individual+) |
 | `skill_audit` | Audit skill for security advisories (Team+) |
-| `skill_inventory_audit` | Audit every installed AI coding client's skill inventory (plus Claude Code's own commands/agents/CLAUDE.md rules) for namespace collisions; returns rename + edit suggestions (SMI-4590; multi-client SMI-6077) |
-| `apply_namespace_rename` | Apply a rename suggestion from an audit (`apply` / `custom` / `skip`) (SMI-4590) |
+| `skill_inventory_audit` | Audit every installed AI coding client's skill inventory (plus Claude Code's own commands/agents/CLAUDE.md rules) for local namespace collisions; returns rename + edit suggestions (SMI-4590; multi-client SMI-6077) |
+| `apply_namespace_rename` | Apply a rename suggestion from a local namespace-collision audit (`apply` / `custom` / `skip`) (SMI-4590) |
 | `apply_recommended_edit` | Apply a recommended prose edit; gated on `APPLY_TEMPLATE_REGISTRY` (SMI-4590) |
 | `undo_apply` | Session-scoped undo of the most recent apply_namespace_rename/apply_recommended_edit changeset(s), restored from the apply tool's own backup (SMI-5456/SMI-5470) |
 | `team_workspace` | Manage team workspaces: create, list, get, delete (Team+) |

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Docs**: `private_registry_manage`'s `namespace` action, `skill_inventory_audit`, and
+  `apply_namespace_rename` tool descriptions now disambiguate the three previously-conflated
+  meanings of "namespace" — the private registry's per-team publish prefix vs. the local
+  single-machine naming-collision audit vs. the public registry's author-prefix convention.
+  Wording-only; no identifier, RPC, column, or error code renamed. (SMI-6088)
 - **Fix**: the upgrade-nudge message shown to a non-Enterprise user hitting a gated feature
   (`getTierComparisonMessage`, `middleware/degradation.ts`) hardcoded the literal unpublished
   Enterprise price (`$55/user/month`) — told a prospect the number before they ever talk to

--- a/packages/mcp-server/src/tools/apply-namespace-rename.ts
+++ b/packages/mcp-server/src/tools/apply-namespace-rename.ts
@@ -111,7 +111,7 @@ export const applyNamespaceRenameInputSchema = z
 export const applyNamespaceRenameToolSchema = {
   name: 'apply_namespace_rename',
   description:
-    "[Skillsmith — Maintain stage] Apply a rename suggestion from a prior `skill_inventory_audit`, or revert one already applied. MUTATES `~/.claude` (renames a skill/command/agent file) — but ONLY when `confirmed: true`. Without `confirmed`, returns a non-mutating preview ({ preview: true, before, after, applied: false, direction }) so the agent can show the change before committing. `action: 'apply'` uses the suggested name; `'custom'` uses `customName`; `'skip'` records a no-op; `'revert'` undoes a previously applied rename for the same auditId + collisionId — this is the durable, cross-session undo path (a fresh MCP server process, e.g. a new session, can still revert a rename applied by an earlier process, since the ledger persists to disk).",
+    "[Skillsmith — Maintain stage] Apply a rename suggestion from a prior local namespace-collision audit (`skill_inventory_audit`), or revert one already applied. MUTATES `~/.claude` (renames a skill/command/agent file) — but ONLY when `confirmed: true`. Without `confirmed`, returns a non-mutating preview ({ preview: true, before, after, applied: false, direction }) so the agent can show the change before committing. `action: 'apply'` uses the suggested name; `'custom'` uses `customName`; `'skip'` records a no-op; `'revert'` undoes a previously applied rename for the same auditId + collisionId — this is the durable, cross-session undo path (a fresh MCP server process, e.g. a new session, can still revert a rename applied by an earlier process, since the ledger persists to disk).",
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/mcp-server/src/tools/registry-tools.schemas.ts
+++ b/packages/mcp-server/src/tools/registry-tools.schemas.ts
@@ -166,7 +166,7 @@ export const privateRegistryManageToolSchema = {
           'reject',
         ],
         description:
-          'Registry operation to perform. "namespace" returns your team\'s publish ' +
+          'Registry operation to perform. "namespace" returns your team\'s registry ' +
           'namespace (the required skill_id prefix) without attempting a publish. ' +
           '"install" downloads the skill and writes it to your skills directory. ' +
           '"submissions" lists review-gate items awaiting or already given a decision — ' +

--- a/packages/mcp-server/src/tools/skill-inventory-audit.ts
+++ b/packages/mcp-server/src/tools/skill-inventory-audit.ts
@@ -66,7 +66,7 @@ export type SkillInventoryAuditValidatedInput = z.infer<typeof skillInventoryAud
 export const skillInventoryAuditToolSchema = {
   name: 'skill_inventory_audit',
   description:
-    "[Skillsmith — Maintain stage] Audit your installed AI coding clients' skill inventories (Claude Code, Cursor, Copilot, and every other Skillsmith-supported client) — plus Claude Code's own commands, agents, and CLAUDE.md trigger rules — for namespace collisions. Returns rename + prose-edit suggestions keyed by a fresh `auditId`. Read-only — performs no file mutations. Feed the returned suggestions into `apply_namespace_rename` / `apply_recommended_edit`.",
+    "[Skillsmith — Maintain stage] Audit your installed AI coding clients' skill inventories (Claude Code, Cursor, Copilot, and every other Skillsmith-supported client) — plus Claude Code's own commands, agents, and CLAUDE.md trigger rules — for local namespace-collision audit findings. Returns rename + prose-edit suggestions keyed by a fresh `auditId`. Read-only — performs no file mutations. Feed the returned suggestions into `apply_namespace_rename` / `apply_recommended_edit`.",
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/mcp-server/src/tools/skill-inventory-audit.ts
+++ b/packages/mcp-server/src/tools/skill-inventory-audit.ts
@@ -66,7 +66,7 @@ export type SkillInventoryAuditValidatedInput = z.infer<typeof skillInventoryAud
 export const skillInventoryAuditToolSchema = {
   name: 'skill_inventory_audit',
   description:
-    "[Skillsmith — Maintain stage] Audit your installed AI coding clients' skill inventories (Claude Code, Cursor, Copilot, and every other Skillsmith-supported client) — plus Claude Code's own commands, agents, and CLAUDE.md trigger rules — for local namespace-collision audit findings. Returns rename + prose-edit suggestions keyed by a fresh `auditId`. Read-only — performs no file mutations. Feed the returned suggestions into `apply_namespace_rename` / `apply_recommended_edit`.",
+    "[Skillsmith — Maintain stage] Audit your installed AI coding clients' skill inventories (Claude Code, Cursor, Copilot, and every other Skillsmith-supported client) — plus Claude Code's own commands, agents, and CLAUDE.md trigger rules — for local namespace collisions. Returns rename + prose-edit suggestions keyed by a fresh `auditId`. Read-only — performs no file mutations. Feed the returned suggestions into `apply_namespace_rename` / `apply_recommended_edit`.",
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -491,7 +491,7 @@ EOF`}</code></pre>
 
   <h3>skill_inventory_audit</h3>
 
-  <p>Audit the local <code>~/.claude/</code> inventory for local namespace-collision findings; returns rename and edit suggestions.</p>
+  <p>Audit the local <code>~/.claude/</code> inventory for local namespace collisions; returns rename and edit suggestions.</p>
 
   <pre><code>{`// Tool: skill_inventory_audit
 // Parameters:

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -459,9 +459,10 @@ EOF`}</code></pre>
   <h3 id="private-registry-manage">private_registry_manage</h3>
 
   <p>
-    List, get, install, deprecate, and review skills in your organization's private registry —
-    the <code>action</code> parameter selects the operation (including <code>submissions</code>,
-    <code>approve</code>, and <code>reject</code> for reviewing pending publishes). Enterprise
+    Manage your organization's private registry — list, get, install, deprecate, and review skills
+    via the <code>action</code> parameter (including <code>submissions</code>, <code>approve</code>,
+    and <code>reject</code> for reviewing pending publishes). The <code>namespace</code> action
+    returns your team's registry namespace (the required skill_id publish prefix). Enterprise
     tier. Full tool reference: <a href="/docs/private-registry">Private Registry</a>.
   </p>
 
@@ -479,7 +480,7 @@ EOF`}</code></pre>
     <li>"Use Skillsmith to approve my-org/deploy-helper version 1.0.0"</li>
   </ul>
 
-  <h2 id="namespace-audit-tools-team">Namespace Audit Tools</h2>
+  <h2 id="namespace-collision-tools-team">Local Namespace-Collision Audit Tools</h2>
 
   <p>
     These tools detect and resolve namespace collisions across your local skills, commands, agents, and CLAUDE.md files.
@@ -490,7 +491,7 @@ EOF`}</code></pre>
 
   <h3>skill_inventory_audit</h3>
 
-  <p>Audit the local <code>~/.claude/</code> inventory for namespace collisions; returns rename and edit suggestions.</p>
+  <p>Audit the local <code>~/.claude/</code> inventory for local namespace-collision findings; returns rename and edit suggestions.</p>
 
   <pre><code>{`// Tool: skill_inventory_audit
 // Parameters:
@@ -511,13 +512,13 @@ EOF`}</code></pre>
 
   <p><strong>Example prompts:</strong></p>
   <ul>
-    <li>"Use Skillsmith to audit my installed skills for namespace conflicts"</li>
-    <li>"Ask Skillsmith to run a deep namespace audit on my ~/.claude inventory"</li>
+    <li>"Use Skillsmith to audit my installed skills for local namespace collisions"</li>
+    <li>"Ask Skillsmith to run a deep collision audit on my ~/.claude inventory"</li>
   </ul>
 
   <h3>apply_namespace_rename</h3>
 
-  <p>Apply a rename suggestion from a prior <code>skill_inventory_audit</code> result; persists overrides via the namespace-overrides ledger.</p>
+  <p>Apply a rename suggestion from a prior local namespace-collision audit (<code>skill_inventory_audit</code>); persists overrides via the namespace-overrides ledger.</p>
 
   <pre><code>{`// Tool: apply_namespace_rename
 // Parameters:

--- a/packages/website/src/pages/docs/trust-tiers.astro
+++ b/packages/website/src/pages/docs/trust-tiers.astro
@@ -95,7 +95,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
 
     <h3>Requirements</h3>
     <ul>
-      <li>Published under <code>anthropic/</code> namespace</li>
+      <li>Published under <code>anthropic/</code> author prefix</li>
       <li>Full code review by the platform security team</li>
       <li>Cryptographic signing (planned)</li>
       <li>Automatic updates deployed</li>
@@ -168,7 +168,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
 
     <h3>Examples</h3>
     <p>
-      <code>zapier/</code>, <code>stripe/</code>, <code>notion/</code> namespaces and other vendor
+      <code>zapier/</code>, <code>stripe/</code>, <code>notion/</code> author prefixes and other vendor
       orgs that publish first-party skills.
     </p>
 

--- a/packages/website/src/pages/docs/tutorials/govern.astro
+++ b/packages/website/src/pages/docs/tutorials/govern.astro
@@ -4,7 +4,7 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
 
 <DocsLayout
   title="Tutorial: Govern at scale"
-  description="Skillsmith Govern stage — audit logs, SIEM export, namespace enforcement, and team roles."
+  description="Skillsmith Govern stage — audit logs, SIEM export, local namespace-collision audit, and team roles."
 >
   <h1>Tutorial: Govern at scale</h1>
 

--- a/packages/website/src/pages/docs/tutorials/govern.astro
+++ b/packages/website/src/pages/docs/tutorials/govern.astro
@@ -360,7 +360,7 @@ skillsmith audit advisories --all   # Audit every installed skill`}</code></pre>
 
   <p>
     Reference:
-    <a href="/docs/mcp-server#namespace-audit-tools-team">MCP audit tools</a>
+    <a href="/docs/mcp-server#namespace-collision-tools-team">MCP audit tools</a>
     · <a href="/docs/cli">CLI reference</a>
     · <a href="/docs/api">API reference</a>
     · <a href="/pricing">Tier pricing</a>.

--- a/packages/website/src/pages/docs/tutorials/maintain.astro
+++ b/packages/website/src/pages/docs/tutorials/maintain.astro
@@ -240,7 +240,7 @@ skillsmith config set audit_mode power_user`}</code></pre>
   <p>
     Free and Individual tiers cannot select <code>power_user</code> or
     <code>governance</code>; the CLI rejects the change with a typed error. See the <a
-      href="/docs/mcp-server#namespace-audit-tools-team">MCP namespace-audit tools reference</a
+      href="/docs/mcp-server#namespace-collision-tools-team">MCP namespace-audit tools reference</a
     > for the full schema.
   </p>
 


### PR DESCRIPTION
## Business Summary

**What shipped:** Three unrelated concepts in Skillsmith's docs and tool descriptions all used the bare word "namespace" — the private registry's per-team publish prefix, a local single-machine naming-collision scanner, and the public registry's author-prefix convention. All three now read unambiguously, both for a human skimming the docs and for an LLM choosing between MCP tools.

**Quality bar:** Wording-only change — no identifier, RPC, column, or error code renamed, matching the scoped decision from the SMI-6085 plan. Full repo typecheck/lint clean; changed files verified individually against the actual current file content before editing (not a blind find-and-replace).

**Found along the way:** none.

**Net result:** Fully shipped, lowest-risk of the three SMI-6085 waves.

---

## Technical detail

- `packages/mcp-server/src/tools/registry-tools.schemas.ts` — `private_registry_manage`'s `namespace` action description now says "registry namespace".
- `packages/mcp-server/src/tools/skill-inventory-audit.ts`, `apply-namespace-rename.ts` — tool descriptions now say "local namespace collisions" / "local namespace-collision audit" instead of bare "namespace".
- `CLAUDE.md` — MCP tools table rows for the same three tools, same qualifier.
- `packages/website/src/pages/docs/mcp-server.astro` — the `private_registry_manage` section explicitly explains the registry namespace; the sibling section's heading changed from "Namespace Audit Tools" to "Local Namespace-Collision Audit Tools".
- `packages/website/src/pages/docs/tutorials/govern.astro` — meta description changed from "namespace enforcement" (read like the registry) to "local namespace-collision audit" (what the page body is actually about).
- `packages/website/src/pages/docs/trust-tiers.astro` — "namespace" → "author prefix" for the public registry's `anthropic/`, `zapier/`-style prefix convention (a third, previously-unlabeled meaning).

Plan doc: `docs/internal/implementation/smi-6085-private-registry-demo-readiness.md`. Linear: SMI-6088 (this PR), SMI-6085 (parent tracking issue).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)