### PR TITLE
fix(mcp-server,website): SMI-6088 fix namespace-wording gaps GPT-5.6-Sol found

### DIFF
--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Docs**: `private_registry_publish`'s description also qualified "your team namespace" to
+  "your team's registry namespace", closing a gap the previous SMI-6088 wording pass missed in
+  the same file. Wording-only. (SMI-6088)
 - **Docs**: `private_registry_manage`'s `namespace` action, `skill_inventory_audit`, and
   `apply_namespace_rename` tool descriptions now disambiguate the three previously-conflated
   meanings of "namespace" — the private registry's per-team publish prefix vs. the local

--- a/packages/mcp-server/src/tools/registry-tools.schemas.ts
+++ b/packages/mcp-server/src/tools/registry-tools.schemas.ts
@@ -113,7 +113,7 @@ export const privateRegistryPublishToolSchema = {
   description:
     "Publish a skill to your organization's private registry. " +
     'Requires Enterprise tier (private_registry feature). ' +
-    'Skills are scoped to your team namespace and published versions are immutable. ' +
+    "Skills are scoped to your team's registry namespace and published versions are immutable. " +
     'A published version is not installable by teammates until a team admin approves it — ' +
     'see private_registry_manage action "submissions" to check its status.',
   inputSchema: {

--- a/packages/website/src/pages/docs/mcp-server.astro
+++ b/packages/website/src/pages/docs/mcp-server.astro
@@ -491,7 +491,7 @@ EOF`}</code></pre>
 
   <h3>skill_inventory_audit</h3>
 
-  <p>Audit the local <code>~/.claude/</code> inventory for local namespace collisions; returns rename and edit suggestions.</p>
+  <p>Audit every installed AI coding client's skill inventory (Claude Code, Cursor, Copilot, and every other Skillsmith-supported client) — plus Claude Code's own commands, agents, and <code>CLAUDE.md</code> trigger rules — for local namespace collisions; returns rename and edit suggestions.</p>
 
   <pre><code>{`// Tool: skill_inventory_audit
 // Parameters:

--- a/packages/website/src/pages/docs/tutorials/maintain.astro
+++ b/packages/website/src/pages/docs/tutorials/maintain.astro
@@ -185,8 +185,10 @@ skillsmith pin --list                     # See all currently pinned skills`}</c
   </ul>
 
   <p>
-    The MCP tool <code>skill_inventory_audit</code> walks your local
-    <code>~/.claude/</code> tree (skills, commands, agents, CLAUDE.md contents) and returns:
+    The MCP tool <code>skill_inventory_audit</code> walks every installed AI coding client's
+    skill inventory (Claude Code, Cursor, Copilot, and every other Skillsmith-supported client) —
+    plus Claude Code's own <code>~/.claude/</code> commands, agents, and CLAUDE.md contents — and
+    returns:
   </p>
 
   <ul>

--- a/packages/website/src/pages/docs/tutorials/maintain.astro
+++ b/packages/website/src/pages/docs/tutorials/maintain.astro
@@ -58,7 +58,8 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
         <td>MCP</td>
         <td><code>skill_inventory_audit</code></td>
         <td
-          >Audit local <code>~/.claude/</code> for namespace collisions; returns rename + edit suggestions</td
+          >Audit every installed AI coding client's skill inventory for local namespace
+          collisions; returns rename + edit suggestions</td
         >
         <td>All (results scoped by audit_mode)</td>
       </tr>


### PR DESCRIPTION
## Business Summary

**What shipped:** A follow-up to the just-merged namespace-wording clarity PR (#2455). We ran an independent second-opinion review using GPT-5.6-Sol — a different model family from the one that did the original wording pass and its post-merge check — specifically because a same-family review can share blind spots with the work it's reviewing. Sol found two real gaps the Claude-based passes missed: one leftover ambiguous "namespace" reference in the exact file the original PR touched, and a documentation page that understated what the `skill_inventory_audit` tool actually covers (it checks every supported AI coding client, not just Claude Code).

**Quality bar:** Both fixes verified against the actual current file content and the tool's real behavior (the ground-truth description in `skill-inventory-audit.ts`) before editing — not applied on the reviewer's word alone. Full pre-push suite (security tests, typecheck, lint, format, test suite) passed clean.

**Found along the way:** none.

**Net result:** Fully shipped. Confirms the value of routing PR review through GPT-5.6-Sol rather than a same-family Claude pass — this is exactly the kind of miss an independent model catches.

---

## Technical detail

- `packages/mcp-server/src/tools/registry-tools.schemas.ts`: `private_registry_publish`'s description said "your team namespace" (bare) — the same file's `private_registry_manage` description was already correctly qualified as "registry namespace" a few lines down. Fixed for consistency.
- `packages/website/src/pages/docs/mcp-server.astro` and `packages/website/src/pages/docs/tutorials/maintain.astro`: both said `skill_inventory_audit` only audits the local `~/.claude/` tree. The tool actually audits every installed AI coding client's skill inventory (Claude Code, Cursor, Copilot, and every other Skillsmith-supported client), with only commands/agents/CLAUDE.md rule-scanning restricted to Claude Code. Fixed both to state the real scope.

Reviewer: GPT-5.6-Sol via NEEDLE (`scripts/needle/dispatch.sh --model gpt-5.6-sol`), read-only sandbox — findings applied by the coordinating session after independent verification against ground truth.

Linear: SMI-6088 (follow-up), SMI-6085 (parent tracking issue).

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)