### PR TITLE
feat(indexer): SMI-6015 Wave 1 — deadline + cohort scope for simulate-full

### DIFF
--- a/scripts/indexer/smi5879-simulate-full.checkpoint.ts
+++ b/scripts/indexer/smi5879-simulate-full.checkpoint.ts
@@ -1,0 +1,290 @@
+/**
+ * Checkpoint I/O for smi5879-simulate-full.ts: on-disk read/write, shape
+ * validation for a checkpoint read off disk, and the two identity guards
+ * that refuse to resume a checkpoint that doesn't actually belong to this
+ * invocation. Split out of smi5879-simulate-full.sweep.ts (CLAUDE.md's
+ * <500-line-per-file convention — SMI-6015 Wave 1's `cohorts` field pushed
+ * the combined file over budget). Coverage aggregation and the tier-3 sweep
+ * loop stay in `.sweep.ts`; `processRow`'s per-row logic stays in
+ * `.helpers.ts` — this file owns everything about persisting/resuming
+ * progress on disk.
+ * @module scripts/indexer/smi5879-simulate-full.checkpoint
+ *
+ * Plan: docs/internal/implementation/smi-5879-wave3-census-simulation-plan.md §3c
+ * Design: docs/internal/implementation/smi-5879-edge-twin-parity-design.md §8.3.5.2.4
+ */
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { ALL_SIMULATED_COHORTS, isValidSimRowOutcome } from './smi5879-simulate-full.types.ts'
+import type {
+  SimSnapshotRow,
+  SimulatedCohort,
+  Smi5879SimulateCheckpoint,
+  SweepHardStopReason,
+  TokenSource,
+} from './smi5879-simulate-full.types.ts'
+import type { Smi5879Purpose } from './smi5879-census.types.ts'
+
+export function checkpointPathFor(runId: string): string {
+  return `smi5879-simulate-checkpoint-${runId}.json`
+}
+
+const VALID_PURPOSES_FOR_SHAPE_CHECK: readonly Smi5879Purpose[] = [
+  'rehearsal',
+  'decision',
+  'window',
+]
+const VALID_TOKEN_SOURCES_FOR_SHAPE_CHECK: readonly TokenSource[] = ['app', 'pat']
+const VALID_HARD_STOP_REASONS_FOR_SHAPE_CHECK: readonly SweepHardStopReason[] = [
+  'non_convergence',
+  'max_passes',
+  null,
+]
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Runtime shape validation for a checkpoint read off disk — a bare
+ * `JSON.parse(raw) as Smi5879SimulateCheckpoint` casts arbitrary JSON
+ * straight to the type with zero verification, so a wrong
+ * `--checkpoint-path` or a hand-edited file could silently carry an
+ * unrecognised `outcome` value (or the wrong overall shape) straight into
+ * `runSimulateFull` (SMI-5879 review finding 1). Throws — never returns a
+ * best-effort partial object — because a checkpoint that fails shape
+ * validation means real prior progress may exist in a form we can no
+ * longer trust, which is categorically different from "no checkpoint yet"
+ * (cold start) and must not be treated the same way.
+ */
+function assertValidCheckpointShape(
+  value: unknown,
+  path: string
+): asserts value is Smi5879SimulateCheckpoint {
+  if (!isPlainObject(value)) {
+    throw new Error(`SMI-5879: checkpoint at ${path} is not a JSON object.`)
+  }
+  const errors: string[] = []
+
+  // Bracket notation throughout this function is required, not stylistic —
+  // `value`/`rawResult`/`sweep` are `Record<string, unknown>` (from the
+  // `isPlainObject` guard), which `noPropertyAccessFromIndexSignature`
+  // (tsconfig.base.json) refuses to let dot-notation read.
+  const runId = value['run_id']
+  const purpose = value['purpose']
+  const baselineCommit = value['baseline_commit']
+  const tokenSource = value['token_source']
+  const cohorts = value['cohorts']
+  const cleanShutdown = value['clean_shutdown']
+  const startedAt = value['started_at']
+  const updatedAt = value['updated_at']
+  const rowResults = value['row_results']
+  const sweepRaw = value['sweep']
+
+  if (typeof runId !== 'string' || runId.length === 0) errors.push('run_id')
+  if (
+    typeof purpose !== 'string' ||
+    !VALID_PURPOSES_FOR_SHAPE_CHECK.includes(purpose as Smi5879Purpose)
+  ) {
+    errors.push(`purpose=${String(purpose)}`)
+  }
+  if (typeof baselineCommit !== 'string' || baselineCommit.length === 0) {
+    errors.push('baseline_commit')
+  }
+  if (
+    typeof tokenSource !== 'string' ||
+    !VALID_TOKEN_SOURCES_FOR_SHAPE_CHECK.includes(tokenSource as TokenSource)
+  ) {
+    errors.push(`token_source=${String(tokenSource)}`)
+  }
+  // SMI-6015 Wave 1: `cohorts` must be a non-empty array of valid cohort
+  // values — always the explicit resolved scope, never omitted (see the
+  // field's own doc comment in smi5879-simulate-full.types.ts).
+  if (
+    !Array.isArray(cohorts) ||
+    cohorts.length === 0 ||
+    !cohorts.every((c) => ALL_SIMULATED_COHORTS.includes(c as SimulatedCohort))
+  ) {
+    errors.push(`cohorts=${JSON.stringify(cohorts)}`)
+  }
+  if (typeof cleanShutdown !== 'boolean') errors.push('clean_shutdown')
+  if (typeof startedAt !== 'string') errors.push('started_at')
+  if (typeof updatedAt !== 'string') errors.push('updated_at')
+
+  if (!isPlainObject(rowResults)) {
+    errors.push('row_results')
+  } else {
+    for (const [id, rawResult] of Object.entries(rowResults)) {
+      if (!isPlainObject(rawResult)) {
+        errors.push(`row_results.${id} (not an object)`)
+        continue
+      }
+      const resultId = rawResult['id']
+      const cohort = rawResult['cohort']
+      const outcome = rawResult['outcome']
+      if (typeof resultId !== 'string') errors.push(`row_results.${id}.id`)
+      if (
+        typeof cohort !== 'string' ||
+        !ALL_SIMULATED_COHORTS.includes(cohort as SimulatedCohort)
+      ) {
+        errors.push(`row_results.${id}.cohort=${String(cohort)}`)
+      }
+      if (!isValidSimRowOutcome(outcome)) {
+        errors.push(`row_results.${id}.outcome=${String(outcome)}`)
+      }
+    }
+  }
+
+  if (!isPlainObject(sweepRaw)) {
+    errors.push('sweep')
+  } else {
+    const pass = sweepRaw['pass']
+    const residualHistory = sweepRaw['residual_history']
+    const nonDecreaseStreak = sweepRaw['non_decrease_streak']
+    const hardStopped = sweepRaw['hard_stopped']
+    if (typeof pass !== 'number') errors.push('sweep.pass')
+    if (!Array.isArray(residualHistory) || !residualHistory.every((n) => typeof n === 'number')) {
+      errors.push('sweep.residual_history')
+    }
+    if (typeof nonDecreaseStreak !== 'number') errors.push('sweep.non_decrease_streak')
+    if (!VALID_HARD_STOP_REASONS_FOR_SHAPE_CHECK.includes(hardStopped as SweepHardStopReason)) {
+      errors.push(`sweep.hard_stopped=${String(hardStopped)}`)
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `SMI-5879: checkpoint at ${path} failed shape validation — invalid/missing field(s): ` +
+        `${errors.join(', ')}. Refusing to trust a malformed checkpoint file — fix or remove it ` +
+        'before resuming (removing it is a COLD START, not a safe default: confirm no real ' +
+        'progress is being discarded first).'
+    )
+  }
+}
+
+export function readCheckpoint(path: string): Smi5879SimulateCheckpoint | null {
+  if (!existsSync(path)) return null
+  const raw = readFileSync(path, 'utf8')
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    // A parse failure is NOT "no checkpoint" — it's "a checkpoint existed and
+    // may hold real progress we can no longer read." Silently falling back to
+    // cold start here would be the destructive choice (SMI-5879 review finding 3).
+    throw new Error(
+      `SMI-5879: checkpoint at ${path} exists but is not valid JSON (${(err as Error).message}). ` +
+        'This is NOT the same as "no checkpoint" — a prior run may have written real progress to ' +
+        'this file before crashing mid-write. Inspect the file (and any `.tmp` sibling left by an ' +
+        'interrupted write) before deciding whether to delete it and cold-start.'
+    )
+  }
+  assertValidCheckpointShape(parsed, path)
+  return parsed
+}
+
+/** Order-insensitive equality for a resolved cohort scope — `['C2','C4']` and `['C4','C2']` are the same scope. */
+function sameCohorts(a: readonly SimulatedCohort[], b: readonly SimulatedCohort[]): boolean {
+  if (a.length !== b.length) return false
+  const sortedA = [...a].sort()
+  const sortedB = [...b].sort()
+  return sortedA.every((c, i) => c === sortedB[i])
+}
+
+/**
+ * Refuses to reuse a checkpoint whose identity doesn't match THIS
+ * invocation — a wrong `--checkpoint-path` pointing at another
+ * generation's checkpoint could otherwise silently skip rows that are
+ * still live-unattempted for the current run (SMI-5879 review finding 1).
+ * `baseline_commit` is checked separately by the caller (pre-existing).
+ *
+ * SMI-6015 Wave 1 (plan-review Medium finding #9): `cohorts` is checked the
+ * same way — a resumed dispatch with a DIFFERENT `--cohorts` filter than the
+ * checkpoint was written with must be refused loudly, not silently accepted
+ * (a cohort-scoped rehearsal checkpoint resumed as if it were the full
+ * population, or vice versa, would silently corrupt that generation's
+ * coverage accounting).
+ */
+export function assertCheckpointIdentity(
+  checkpoint: Smi5879SimulateCheckpoint,
+  expected: {
+    runId: string
+    purpose: Smi5879Purpose
+    tokenSource: TokenSource
+    cohorts: SimulatedCohort[]
+  },
+  path: string
+): void {
+  const mismatches: string[] = []
+  if (checkpoint.run_id !== expected.runId) {
+    mismatches.push(`run_id (checkpoint=${checkpoint.run_id}, this run=${expected.runId})`)
+  }
+  if (checkpoint.purpose !== expected.purpose) {
+    mismatches.push(`purpose (checkpoint=${checkpoint.purpose}, this run=${expected.purpose})`)
+  }
+  if (checkpoint.token_source !== expected.tokenSource) {
+    mismatches.push(
+      `token_source (checkpoint=${checkpoint.token_source}, this run=${expected.tokenSource})`
+    )
+  }
+  if (!sameCohorts(checkpoint.cohorts, expected.cohorts)) {
+    mismatches.push(
+      `cohorts (checkpoint=${checkpoint.cohorts.join(',')}, this run=${expected.cohorts.join(',')})`
+    )
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      `SMI-5879: checkpoint at ${path} does not match this invocation — ${mismatches.join('; ')}. ` +
+        'A resume must reuse a checkpoint from the SAME run_id/purpose/token_source/cohorts — use a ' +
+        'fresh --checkpoint-path for a different generation or cohort scope instead of pointing at this one.'
+    )
+  }
+}
+
+/**
+ * Refuses to reuse a checkpoint whose `row_results` keys reference row ids
+ * outside the CURRENT generation's loaded row set — e.g. a stale checkpoint
+ * from a different generation whose row ids happen to overlap with
+ * globally-stable skill ids from this one. Must be called only after the
+ * real row set for this generation has been loaded (SMI-5879 review finding 1).
+ */
+export function assertCheckpointRowsBelongToGeneration(
+  checkpoint: Smi5879SimulateCheckpoint,
+  rows: readonly SimSnapshotRow[],
+  path: string
+): void {
+  const validIds = new Set(rows.map((r) => r.id))
+  const staleIds = Object.keys(checkpoint.row_results).filter((id) => !validIds.has(id))
+  if (staleIds.length > 0) {
+    throw new Error(
+      `SMI-5879: checkpoint at ${path} has ${staleIds.length} row_results key(s) that are not in ` +
+        `this generation's row set (e.g. ${staleIds.slice(0, 5).join(', ')}) — this checkpoint was ` +
+        'likely written for a different generation. Refusing to reuse stale verdicts; use a fresh ' +
+        '--checkpoint-path for this generation instead.'
+    )
+  }
+}
+
+/**
+ * Atomic replace: write to a temp file in the SAME directory as `path`,
+ * then `renameSync` over the real path. `renameSync` on the same
+ * filesystem is atomic on POSIX, so a crash mid-write (OOM-kill, host
+ * reboot) can never leave `path` itself truncated/corrupt — it is always
+ * either the previous complete checkpoint or the new one (SMI-5879 review
+ * finding 3). A `.bak` of the prior checkpoint was considered and
+ * deliberately skipped: the atomic rename already guarantees `path` is
+ * never syntactically corrupt, which was the actual failure mode observed;
+ * a backup would only help against a LOGICALLY wrong-but-valid checkpoint
+ * (an application bug writing bad data), which a single stale `.bak` isn't
+ * a reliable defense against either.
+ */
+export function writeCheckpoint(path: string, checkpoint: Smi5879SimulateCheckpoint): void {
+  const tmpPath = `${path}.tmp-${process.pid}`
+  writeFileSync(tmpPath, JSON.stringify(checkpoint, null, 2))
+  renameSync(tmpPath, path)
+}
+
+/** True when the on-disk checkpoint represents an abnormal prior termination (design 8.3.5.2.4 point 2). */
+export function isAbnormalResume(checkpoint: Smi5879SimulateCheckpoint | null): boolean {
+  return checkpoint !== null && checkpoint.clean_shutdown === false
+}

--- a/scripts/indexer/smi5879-simulate-full.cli.ts
+++ b/scripts/indexer/smi5879-simulate-full.cli.ts
@@ -1,0 +1,115 @@
+/**
+ * CLI argument parsing for smi5879-simulate-full.ts, split out per CLAUDE.md's
+ * <500-line-per-file convention (the orchestration file was approaching the
+ * budget once SMI-6015 Wave 1 added the wall-clock deadline and cohort-scope
+ * flags below).
+ * @module scripts/indexer/smi5879-simulate-full.cli
+ *
+ * Plan: docs/internal/implementation/smi-6015-wave3-simulate-full-ci-workflow-plan.md Wave 1
+ */
+
+import { BASELINE_COMMIT_SHA } from './smi5879-simulate-full.baseline.ts'
+import { ALL_SIMULATED_COHORTS, type SimulatedCohort } from './smi5879-simulate-full.types.ts'
+import type { Smi5879Purpose } from './smi5879-census.types.ts'
+
+const VALID_PURPOSES: readonly Smi5879Purpose[] = ['rehearsal', 'decision', 'window']
+
+export interface CliArgs {
+  runId: string
+  purpose: Smi5879Purpose
+  apply: boolean
+  checkpointPath?: string
+  reportPath?: string
+  baselineCommit: string
+  /**
+   * SMI-6015 Wave 1: wall-clock self-checkpoint-and-exit budget for THIS
+   * invocation, in minutes. Undefined means no deadline (the pre-existing
+   * behavior) — a CI workflow dispatch always sets this so a GHA
+   * `timeout-minutes` kill never arrives before the process has had a
+   * chance to checkpoint and exit gracefully on its own terms.
+   */
+  maxElapsedMinutes?: number
+  /**
+   * SMI-6015 Wave 1: restrict this dispatch to a subset of cohorts.
+   * Undefined means all four (the pre-existing, gate-eligible behavior) —
+   * exists to enable a cheap, non-gating rehearsal dispatch (e.g. C4 alone)
+   * before committing to the full, multi-day `purpose=decision` run. Never
+   * valid combined with `purpose=decision` (see the check below) — G-2
+   * requires ALL FOUR cohorts fully simulated in one decision-purpose
+   * report, so a cohort-scoped decision dispatch could never satisfy the
+   * gate no matter what it found.
+   */
+  cohorts?: SimulatedCohort[]
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const find = (name: string): string | undefined => {
+    const prefix = `--${name}=`
+    const hit = argv.find((a) => a.startsWith(prefix))
+    return hit ? hit.slice(prefix.length) : undefined
+  }
+  const runId = find('run-id')
+  if (!runId) throw new Error('SMI-5879: --run-id=<generation run_id> is required.')
+  const purpose = find('purpose')
+  if (!purpose || !VALID_PURPOSES.includes(purpose as Smi5879Purpose)) {
+    throw new Error(
+      `SMI-5879: --purpose=<${VALID_PURPOSES.join('|')}> is required, got ${purpose ?? '(missing)'}.`
+    )
+  }
+
+  const maxElapsedMinutesRaw = find('max-elapsed-minutes')
+  let maxElapsedMinutes: number | undefined
+  if (maxElapsedMinutesRaw !== undefined) {
+    const parsed = Number(maxElapsedMinutesRaw)
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(
+        `SMI-6015: --max-elapsed-minutes=<N> must be a positive number, got "${maxElapsedMinutesRaw}".`
+      )
+    }
+    maxElapsedMinutes = parsed
+  }
+
+  const cohortsRaw = find('cohorts')
+  let cohorts: SimulatedCohort[] | undefined
+  if (cohortsRaw !== undefined && cohortsRaw !== '') {
+    const parts = cohortsRaw.split(',').map((s) => s.trim())
+    const invalid = parts.filter((p) => !ALL_SIMULATED_COHORTS.includes(p as SimulatedCohort))
+    if (invalid.length > 0) {
+      throw new Error(
+        `SMI-5879: --cohorts=<comma-list> contains invalid cohort(s): ${invalid.join(', ')}. ` +
+          `Valid: ${ALL_SIMULATED_COHORTS.join(', ')}.`
+      )
+    }
+    cohorts = parts as SimulatedCohort[]
+    // SMI-6015 Wave 1 plan-review Medium finding #10: reject at parse time,
+    // not silently at runtime — a cohort-scoped `decision` dispatch would
+    // burn a multi-hour run against a population that CANNOT satisfy G-2 no
+    // matter what it finds (G-2 requires ALL FOUR cohorts fully simulated
+    // in one decision-purpose report; see smi5879-gate-check.gates.ts).
+    if (purpose === 'decision') {
+      throw new Error(
+        'SMI-5879: --cohorts=<subset> cannot be combined with --purpose=decision — G-2 requires ' +
+          'ALL FOUR cohorts (C1-C4) fully simulated in one decision-purpose report; a cohort-scoped ' +
+          'dispatch can never satisfy that gate. Use --purpose=rehearsal for a cohort-scoped run.'
+      )
+    }
+  }
+
+  // `checkpointPath`/`reportPath` are genuinely optional (downstream defaults via
+  // `?? checkpointPathFor(...)` / `?? 'smi5879-simulate-report-...'`) — under
+  // `exactOptionalPropertyTypes`, an optional property means "may be omitted",
+  // not "may be omitted OR explicitly `undefined`", so the key must be left off
+  // entirely when the flag wasn't passed rather than assigned `undefined`.
+  const checkpointPath = find('checkpoint-path')
+  const reportPath = find('report-path')
+  return {
+    runId,
+    purpose: purpose as Smi5879Purpose,
+    apply: argv.includes('--apply'),
+    ...(checkpointPath !== undefined ? { checkpointPath } : {}),
+    ...(reportPath !== undefined ? { reportPath } : {}),
+    baselineCommit: find('baseline-commit') ?? BASELINE_COMMIT_SHA,
+    ...(maxElapsedMinutes !== undefined ? { maxElapsedMinutes } : {}),
+    ...(cohorts !== undefined ? { cohorts } : {}),
+  }
+}

--- a/scripts/indexer/smi5879-simulate-full.helpers.ts
+++ b/scripts/indexer/smi5879-simulate-full.helpers.ts
@@ -381,6 +381,20 @@ export async function processRow(
 // Main pass (moved from smi5879-simulate-full.ts — 500-line budget)
 // ---------------------------------------------------------------------------
 
+/** Return value of {@link runMainPass} — see `deadlineExceeded`'s doc comment there. */
+export interface RunMainPassResult {
+  /**
+   * True iff the pass stopped because `deadlineAtMs` was reached — an
+   * EXPECTED, non-fatal way to stop (mirrors `runCancellablePool`'s own
+   * `deadlineExceeded`/`abortedBy` distinction and
+   * `smi5879-census.branches.ts`'s `sweepTransientRepos` pattern). The
+   * caller decides what to do next (write a final checkpoint and exit with
+   * partial coverage for re-dispatch); never rethrown the way a fatal
+   * `abortedBy` condition is.
+   */
+  deadlineExceeded: boolean
+}
+
 /**
  * Run the main pass over every not-yet-attempted row (from the checkpoint, if
  * resuming), in concurrency-bounded batches, checkpointing after each batch.
@@ -395,6 +409,17 @@ export async function processRow(
  * before AND after each item, so an abort actually stops new work; whatever
  * partial progress a batch made before the abort is checkpointed via
  * `onBatchDone` BEFORE rethrowing (durable partial write, never data loss).
+ *
+ * SMI-6015 Wave 1 (plan-review High finding #6): `deadlineAtMs` (optional)
+ * threads straight into `runCancellablePool`'s own built-in deadline support
+ * — the SAME mechanism `smi5879-census.branches.ts`'s `sweepTransientRepos`
+ * already uses for its per-pass wall-clock cap, reused here rather than
+ * inventing a second, fatal-`abortedBy`-based mechanism (the original design
+ * for this Wave 1 item, corrected during plan review). A deadline hit between
+ * batches (checked at the top of the next `runCancellablePool` call) or
+ * mid-batch (checked per-worker) stops pulling new work; whatever the current
+ * batch completed is still checkpointed via `onBatchDone` before returning,
+ * exactly like a normal batch boundary — never a partial/corrupt write.
  */
 export async function runMainPass(
   rows: SimSnapshotRow[],
@@ -410,22 +435,26 @@ export async function runMainPass(
     // the census's own frozen-header bug.
     getHeaders: () => Promise<Record<string, string>>
   },
-  onBatchDone: (results: Map<string, SimRowResult>) => Promise<void>
-): Promise<void> {
+  onBatchDone: (results: Map<string, SimRowResult>) => Promise<void>,
+  deadlineAtMs?: number
+): Promise<RunMainPassResult> {
   const pending = rows.filter((r) => !alreadyResults.has(r.id))
   for (let i = 0; i < pending.length; i += CHECKPOINT_BATCH_SIZE) {
     const batch = pending.slice(i, i + CHECKPOINT_BATCH_SIZE)
     const outcomes: SimRowResult[] = []
-    const { abortedBy } = await runCancellablePool(
+    const { abortedBy, deadlineExceeded } = await runCancellablePool(
       batch,
       (row) => processRow(row, branchMap, scanDeps),
       (outcome) => {
         outcomes.push(outcome)
       },
-      PROCESS_CONCURRENCY
+      PROCESS_CONCURRENCY,
+      deadlineAtMs
     )
     for (const outcome of outcomes) alreadyResults.set(outcome.id, outcome)
     await onBatchDone(alreadyResults)
     if (abortedBy) throw abortedBy
+    if (deadlineExceeded) return { deadlineExceeded: true }
   }
+  return { deadlineExceeded: false }
 }

--- a/scripts/indexer/smi5879-simulate-full.sweep.ts
+++ b/scripts/indexer/smi5879-simulate-full.sweep.ts
@@ -1,30 +1,35 @@
 /**
- * Coverage aggregation, checkpoint I/O, and the tier-3 sweep loop for
+ * Coverage aggregation and the tier-3 sweep loop for
  * smi5879-simulate-full.ts. Split out of smi5879-simulate-full.helpers.ts
  * (CLAUDE.md's <500-line-per-file convention — helpers.ts plus this file
  * together are still one logical unit; `processRow`'s per-row tier-1/tier-2
  * logic stays in helpers.ts, and everything ABOVE the per-row level — how
- * many rows got what outcome, how to persist/resume progress, and how to
- * re-sweep the unevaluable residual — lives here).
+ * many rows got what outcome and how to re-sweep the unevaluable residual —
+ * lives here). Checkpoint I/O (read/write/shape-validation/identity guards)
+ * moved to the sibling `smi5879-simulate-full.checkpoint.ts` (SMI-6015 Wave
+ * 1's `cohorts` field pushed the combined file over the 500-line budget).
  * @module scripts/indexer/smi5879-simulate-full.sweep
  *
  * Plan: docs/internal/implementation/smi-5879-wave3-census-simulation-plan.md §3b (tier 3) / §3c
  * Design: docs/internal/implementation/smi-5879-edge-twin-parity-design.md §8.3.5.2.4/§8.4
  */
 
-import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { runCancellablePool, type RateLimitTelemetry } from './_shared/rate-limit.ts'
+import { processRow, PROCESS_CONCURRENCY } from './smi5879-simulate-full.helpers.ts'
+import { writeCheckpoint } from './smi5879-simulate-full.checkpoint.ts'
+import { EMPTY_OUTCOME_COUNTS } from './smi5879-simulate-full.types.ts'
 import type {
+  BranchMap,
   CohortCoverage,
   CoverageByCohort,
+  ScanSkillBundleFn,
   SimRowOutcome,
   SimRowResult,
   SimSnapshotRow,
   SimulatedCohort,
   Smi5879SimulateCheckpoint,
   SweepHardStopReason,
-  TokenSource,
 } from './smi5879-simulate-full.types.ts'
-import type { Smi5879Purpose } from './smi5879-census.types.ts'
 
 // ---------------------------------------------------------------------------
 // Constants (design doc 8.3.5.2.5's interval table + plan §3b tier 3)
@@ -62,31 +67,10 @@ export function computeCoverage(
   return coverage
 }
 
-/**
- * Single source of truth for the closed `SimRowOutcome` vocabulary at
- * runtime — `summarizeCounts`'s zeroed accumulator doubles as the
- * membership set `assertValidCheckpointShape` checks a resumed
- * checkpoint's recorded outcomes against (SMI-5879 review finding 1), so
- * the two can never drift apart.
- */
-const EMPTY_OUTCOME_COUNTS: Record<SimRowOutcome, number> = {
-  newly_quarantined: 0,
-  newly_cleared: 0,
-  unchanged_clean: 0,
-  unchanged_quarantined: 0,
-  content_drifted: 0,
-  bundle_absent: 0,
-  unevaluable: 0,
-  unfetchable: 0,
-}
-
-export const SIM_ROW_OUTCOMES: readonly SimRowOutcome[] = Object.keys(
-  EMPTY_OUTCOME_COUNTS
-) as SimRowOutcome[]
-
-function isValidSimRowOutcome(value: unknown): value is SimRowOutcome {
-  return typeof value === 'string' && (SIM_ROW_OUTCOMES as readonly string[]).includes(value)
-}
+// Outcome-vocabulary constants (SIM_ROW_OUTCOMES, isValidSimRowOutcome) moved
+// to smi5879-simulate-full.types.ts (SMI-6015 Wave 1) to avoid a circular
+// import once this file needed writeCheckpoint from .checkpoint.ts, which
+// itself needs the outcome validator — see that file's own doc comment.
 
 export function summarizeCounts(results: Iterable<SimRowResult>): Record<SimRowOutcome, number> {
   const counts: Record<SimRowOutcome, number> = { ...EMPTY_OUTCOME_COUNTS }
@@ -124,239 +108,6 @@ export function estimateCompletionAt(
   if (remaining <= 0) return now.toISOString()
   const msPerRow = elapsedMs / scannedRows
   return new Date(now.getTime() + remaining * msPerRow).toISOString()
-}
-
-// ---------------------------------------------------------------------------
-// Checkpoint I/O
-// ---------------------------------------------------------------------------
-
-export function checkpointPathFor(runId: string): string {
-  return `smi5879-simulate-checkpoint-${runId}.json`
-}
-
-const VALID_COHORTS_FOR_SHAPE_CHECK: readonly SimulatedCohort[] = ['C1', 'C2', 'C3', 'C4']
-const VALID_PURPOSES_FOR_SHAPE_CHECK: readonly Smi5879Purpose[] = [
-  'rehearsal',
-  'decision',
-  'window',
-]
-const VALID_TOKEN_SOURCES_FOR_SHAPE_CHECK: readonly TokenSource[] = ['app', 'pat']
-const VALID_HARD_STOP_REASONS_FOR_SHAPE_CHECK: readonly SweepHardStopReason[] = [
-  'non_convergence',
-  'max_passes',
-  null,
-]
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-/**
- * Runtime shape validation for a checkpoint read off disk — a bare
- * `JSON.parse(raw) as Smi5879SimulateCheckpoint` casts arbitrary JSON
- * straight to the type with zero verification, so a wrong
- * `--checkpoint-path` or a hand-edited file could silently carry an
- * unrecognised `outcome` value (or the wrong overall shape) straight into
- * `runSimulateFull` (SMI-5879 review finding 1). Throws — never returns a
- * best-effort partial object — because a checkpoint that fails shape
- * validation means real prior progress may exist in a form we can no
- * longer trust, which is categorically different from "no checkpoint yet"
- * (cold start) and must not be treated the same way.
- */
-function assertValidCheckpointShape(
-  value: unknown,
-  path: string
-): asserts value is Smi5879SimulateCheckpoint {
-  if (!isPlainObject(value)) {
-    throw new Error(`SMI-5879: checkpoint at ${path} is not a JSON object.`)
-  }
-  const errors: string[] = []
-
-  // Bracket notation throughout this function is required, not stylistic —
-  // `value`/`rawResult`/`sweep` are `Record<string, unknown>` (from the
-  // `isPlainObject` guard), which `noPropertyAccessFromIndexSignature`
-  // (tsconfig.base.json) refuses to let dot-notation read.
-  const runId = value['run_id']
-  const purpose = value['purpose']
-  const baselineCommit = value['baseline_commit']
-  const tokenSource = value['token_source']
-  const cleanShutdown = value['clean_shutdown']
-  const startedAt = value['started_at']
-  const updatedAt = value['updated_at']
-  const rowResults = value['row_results']
-  const sweepRaw = value['sweep']
-
-  if (typeof runId !== 'string' || runId.length === 0) errors.push('run_id')
-  if (
-    typeof purpose !== 'string' ||
-    !VALID_PURPOSES_FOR_SHAPE_CHECK.includes(purpose as Smi5879Purpose)
-  ) {
-    errors.push(`purpose=${String(purpose)}`)
-  }
-  if (typeof baselineCommit !== 'string' || baselineCommit.length === 0) {
-    errors.push('baseline_commit')
-  }
-  if (
-    typeof tokenSource !== 'string' ||
-    !VALID_TOKEN_SOURCES_FOR_SHAPE_CHECK.includes(tokenSource as TokenSource)
-  ) {
-    errors.push(`token_source=${String(tokenSource)}`)
-  }
-  if (typeof cleanShutdown !== 'boolean') errors.push('clean_shutdown')
-  if (typeof startedAt !== 'string') errors.push('started_at')
-  if (typeof updatedAt !== 'string') errors.push('updated_at')
-
-  if (!isPlainObject(rowResults)) {
-    errors.push('row_results')
-  } else {
-    for (const [id, rawResult] of Object.entries(rowResults)) {
-      if (!isPlainObject(rawResult)) {
-        errors.push(`row_results.${id} (not an object)`)
-        continue
-      }
-      const resultId = rawResult['id']
-      const cohort = rawResult['cohort']
-      const outcome = rawResult['outcome']
-      if (typeof resultId !== 'string') errors.push(`row_results.${id}.id`)
-      if (
-        typeof cohort !== 'string' ||
-        !VALID_COHORTS_FOR_SHAPE_CHECK.includes(cohort as SimulatedCohort)
-      ) {
-        errors.push(`row_results.${id}.cohort=${String(cohort)}`)
-      }
-      if (!isValidSimRowOutcome(outcome)) {
-        errors.push(`row_results.${id}.outcome=${String(outcome)}`)
-      }
-    }
-  }
-
-  if (!isPlainObject(sweepRaw)) {
-    errors.push('sweep')
-  } else {
-    const pass = sweepRaw['pass']
-    const residualHistory = sweepRaw['residual_history']
-    const nonDecreaseStreak = sweepRaw['non_decrease_streak']
-    const hardStopped = sweepRaw['hard_stopped']
-    if (typeof pass !== 'number') errors.push('sweep.pass')
-    if (!Array.isArray(residualHistory) || !residualHistory.every((n) => typeof n === 'number')) {
-      errors.push('sweep.residual_history')
-    }
-    if (typeof nonDecreaseStreak !== 'number') errors.push('sweep.non_decrease_streak')
-    if (!VALID_HARD_STOP_REASONS_FOR_SHAPE_CHECK.includes(hardStopped as SweepHardStopReason)) {
-      errors.push(`sweep.hard_stopped=${String(hardStopped)}`)
-    }
-  }
-
-  if (errors.length > 0) {
-    throw new Error(
-      `SMI-5879: checkpoint at ${path} failed shape validation — invalid/missing field(s): ` +
-        `${errors.join(', ')}. Refusing to trust a malformed checkpoint file — fix or remove it ` +
-        'before resuming (removing it is a COLD START, not a safe default: confirm no real ' +
-        'progress is being discarded first).'
-    )
-  }
-}
-
-export function readCheckpoint(path: string): Smi5879SimulateCheckpoint | null {
-  if (!existsSync(path)) return null
-  const raw = readFileSync(path, 'utf8')
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(raw)
-  } catch (err) {
-    // A parse failure is NOT "no checkpoint" — it's "a checkpoint existed and
-    // may hold real progress we can no longer read." Silently falling back to
-    // cold start here would be the destructive choice (SMI-5879 review finding 3).
-    throw new Error(
-      `SMI-5879: checkpoint at ${path} exists but is not valid JSON (${(err as Error).message}). ` +
-        'This is NOT the same as "no checkpoint" — a prior run may have written real progress to ' +
-        'this file before crashing mid-write. Inspect the file (and any `.tmp` sibling left by an ' +
-        'interrupted write) before deciding whether to delete it and cold-start.'
-    )
-  }
-  assertValidCheckpointShape(parsed, path)
-  return parsed
-}
-
-/**
- * Refuses to reuse a checkpoint whose identity doesn't match THIS
- * invocation — a wrong `--checkpoint-path` pointing at another
- * generation's checkpoint could otherwise silently skip rows that are
- * still live-unattempted for the current run (SMI-5879 review finding 1).
- * `baseline_commit` is checked separately by the caller (pre-existing).
- */
-export function assertCheckpointIdentity(
-  checkpoint: Smi5879SimulateCheckpoint,
-  expected: { runId: string; purpose: Smi5879Purpose; tokenSource: TokenSource },
-  path: string
-): void {
-  const mismatches: string[] = []
-  if (checkpoint.run_id !== expected.runId) {
-    mismatches.push(`run_id (checkpoint=${checkpoint.run_id}, this run=${expected.runId})`)
-  }
-  if (checkpoint.purpose !== expected.purpose) {
-    mismatches.push(`purpose (checkpoint=${checkpoint.purpose}, this run=${expected.purpose})`)
-  }
-  if (checkpoint.token_source !== expected.tokenSource) {
-    mismatches.push(
-      `token_source (checkpoint=${checkpoint.token_source}, this run=${expected.tokenSource})`
-    )
-  }
-  if (mismatches.length > 0) {
-    throw new Error(
-      `SMI-5879: checkpoint at ${path} does not match this invocation — ${mismatches.join('; ')}. ` +
-        'A resume must reuse a checkpoint from the SAME run_id/purpose/token_source — use a fresh ' +
-        '--checkpoint-path for a different generation instead of pointing at this one.'
-    )
-  }
-}
-
-/**
- * Refuses to reuse a checkpoint whose `row_results` keys reference row ids
- * outside the CURRENT generation's loaded row set — e.g. a stale checkpoint
- * from a different generation whose row ids happen to overlap with
- * globally-stable skill ids from this one. Must be called only after the
- * real row set for this generation has been loaded (SMI-5879 review finding 1).
- */
-export function assertCheckpointRowsBelongToGeneration(
-  checkpoint: Smi5879SimulateCheckpoint,
-  rows: readonly SimSnapshotRow[],
-  path: string
-): void {
-  const validIds = new Set(rows.map((r) => r.id))
-  const staleIds = Object.keys(checkpoint.row_results).filter((id) => !validIds.has(id))
-  if (staleIds.length > 0) {
-    throw new Error(
-      `SMI-5879: checkpoint at ${path} has ${staleIds.length} row_results key(s) that are not in ` +
-        `this generation's row set (e.g. ${staleIds.slice(0, 5).join(', ')}) — this checkpoint was ` +
-        'likely written for a different generation. Refusing to reuse stale verdicts; use a fresh ' +
-        '--checkpoint-path for this generation instead.'
-    )
-  }
-}
-
-/**
- * Atomic replace: write to a temp file in the SAME directory as `path`,
- * then `renameSync` over the real path. `renameSync` on the same
- * filesystem is atomic on POSIX, so a crash mid-write (OOM-kill, host
- * reboot) can never leave `path` itself truncated/corrupt — it is always
- * either the previous complete checkpoint or the new one (SMI-5879 review
- * finding 3). A `.bak` of the prior checkpoint was considered and
- * deliberately skipped: the atomic rename already guarantees `path` is
- * never syntactically corrupt, which was the actual failure mode observed;
- * a backup would only help against a LOGICALLY wrong-but-valid checkpoint
- * (an application bug writing bad data), which a single stale `.bak` isn't
- * a reliable defense against either.
- */
-export function writeCheckpoint(path: string, checkpoint: Smi5879SimulateCheckpoint): void {
-  const tmpPath = `${path}.tmp-${process.pid}`
-  writeFileSync(tmpPath, JSON.stringify(checkpoint, null, 2))
-  renameSync(tmpPath, path)
-}
-
-/** True when the on-disk checkpoint represents an abnormal prior termination (design 8.3.5.2.4 point 2). */
-export function isAbnormalResume(checkpoint: Smi5879SimulateCheckpoint | null): boolean {
-  return checkpoint !== null && checkpoint.clean_shutdown === false
 }
 
 // ---------------------------------------------------------------------------
@@ -477,4 +228,109 @@ export async function runTier3Sweep(
     finalResidualSize: residual.length,
     nonDecreaseStreak,
   }
+}
+
+// ---------------------------------------------------------------------------
+// Sweep phase orchestration (SMI-6015 Wave 1 — moved out of
+// smi5879-simulate-full.ts's runSimulateFull to stay under the 500-line
+// budget once the wall-clock deadline / cohorts additions landed there)
+// ---------------------------------------------------------------------------
+
+export async function runSweepPhase(
+  rows: SimSnapshotRow[],
+  branchMap: BranchMap,
+  scanDeps: {
+    scanPostPort: ScanSkillBundleFn
+    scanPrePort: ScanSkillBundleFn
+    telemetry: RateLimitTelemetry
+    getHeaders: () => Promise<Record<string, string>>
+  },
+  results: Map<string, SimRowResult>,
+  checkpointIn: Smi5879SimulateCheckpoint,
+  checkpointPath: string
+): Promise<{ checkpoint: Smi5879SimulateCheckpoint; hardStopped: SweepHardStopReason }> {
+  let checkpoint = checkpointIn
+  // Resume state threaded into the sweep (SMI-5879 review finding 2a) — a
+  // crash mid-sweep must not reset the MAX_SWEEP_PASSES budget or the
+  // non-decrease hard-stop streak. `priorResidualHistory` is captured ONCE
+  // and `sweepResidualHistory` grows it incrementally via `onPass` as the
+  // single source of truth for every per-pass checkpoint write (finding 2b).
+  const priorResidualHistory = [...checkpoint.sweep.residual_history]
+  const sweepResidualHistory: number[] = [...priorResidualHistory]
+
+  const residual = [...results.values()].filter((r) => r.outcome === 'unevaluable')
+  const sweep = await runTier3Sweep(
+    residual,
+    async (residualIds) => {
+      const idSet = new Set(residualIds)
+      const targets = rows.filter((r) => idSet.has(r.id))
+      const outcomes: SimRowResult[] = []
+      // SMI-6015: same cooperative-cancellation fix as runMainPass — see
+      // smi5879-simulate-full.helpers.ts's own comment for the rationale.
+      const { abortedBy } = await runCancellablePool(
+        targets,
+        (row) => processRow(row, branchMap, scanDeps),
+        (outcome) => {
+          outcomes.push(outcome)
+        },
+        PROCESS_CONCURRENCY
+      )
+      const updated = new Map(outcomes.map((o) => [o.id, o]))
+      for (const [id, result] of updated) results.set(id, result)
+      if (abortedBy) {
+        // SMI-6015 (GPT-5.6-Sol review round 2, 2026-08-14): throwing here
+        // rejects runTier3Sweep's own `await runPass(...)` before it ever
+        // reaches `options.onPass` — the ONLY place that normally writes a
+        // checkpoint after a pass. Write the partial progress explicitly,
+        // matching onPass's shape but WITHOUT advancing
+        // pass/residual_history/non_decrease_streak — this pass never
+        // cleanly completed, so it must not be counted as if it had.
+        checkpoint = {
+          ...checkpoint,
+          clean_shutdown: false,
+          row_results: Object.fromEntries(results),
+          updated_at: new Date().toISOString(),
+        }
+        writeCheckpoint(checkpointPath, checkpoint)
+        throw abortedBy
+      }
+      return updated
+    },
+    {
+      startingPass: checkpoint.sweep.pass,
+      startingNonDecreaseStreak: checkpoint.sweep.non_decrease_streak,
+      onPass: (pass, residualSize, nonDecreaseStreak) => {
+        sweepResidualHistory.push(residualSize)
+        checkpoint = {
+          ...checkpoint,
+          clean_shutdown: false,
+          row_results: Object.fromEntries(results),
+          sweep: {
+            pass,
+            residual_history: [...sweepResidualHistory],
+            non_decrease_streak: nonDecreaseStreak,
+            hard_stopped: null,
+          },
+          updated_at: new Date().toISOString(),
+        }
+        writeCheckpoint(checkpointPath, checkpoint)
+      },
+    }
+  )
+
+  checkpoint = {
+    ...checkpoint,
+    clean_shutdown: true,
+    row_results: Object.fromEntries(results),
+    sweep: {
+      pass: sweep.passesRun,
+      residual_history: [...priorResidualHistory, ...sweep.residualHistory],
+      non_decrease_streak: sweep.nonDecreaseStreak,
+      hard_stopped: sweep.hardStopped,
+    },
+    updated_at: new Date().toISOString(),
+  }
+  writeCheckpoint(checkpointPath, checkpoint)
+
+  return { checkpoint, hardStopped: sweep.hardStopped }
 }

--- a/scripts/indexer/smi5879-simulate-full.ts
+++ b/scripts/indexer/smi5879-simulate-full.ts
@@ -27,10 +27,15 @@
  * report/checkpoint files, plus the generation's own claim/heartbeat/release
  * fields" — never a `skills` row.
  *
+ * SMI-6015 Wave 1 added `--max-elapsed-minutes=<N>` (wall-clock
+ * self-checkpoint-and-exit) and `--cohorts=<comma-list>` (cohort-scoped
+ * rehearsal dispatches) — see `smi5879-simulate-full.cli.ts` for parsing.
+ *
  * Usage:
  *   varlock run -- npx tsx scripts/indexer/smi5879-simulate-full.ts \
  *     --run-id=<sealed generation run_id> --purpose=<decision|window|rehearsal> \
- *     [--apply] [--checkpoint-path=<path>] [--report-path=<path>] [--baseline-commit=<sha>]
+ *     [--apply] [--checkpoint-path=<path>] [--report-path=<path>] [--baseline-commit=<sha>] \
+ *     [--max-elapsed-minutes=<N>] [--cohorts=<comma-list>]
  */
 
 import { hostname } from 'node:os'
@@ -38,35 +43,36 @@ import { randomUUID } from 'node:crypto'
 import { execFileSync } from 'node:child_process'
 import { writeFileSync } from 'node:fs'
 import { buildGitHubHeaders } from './_shared/github-auth.ts'
-import { newRateLimitTelemetry, runCancellablePool } from './_shared/rate-limit.ts'
+import { newRateLimitTelemetry } from './_shared/rate-limit.ts'
 import { poolerSessionConnParams, runPsql } from './smi5879-census.pg.ts'
 import { createSmi5879SimulateFullDbDeps } from './smi5879-simulate-full.db.ts'
 import {
   materializeBaseline,
   importBaselineScanSkillBundle,
-  BASELINE_COMMIT_SHA,
 } from './smi5879-simulate-full.baseline.ts'
 import { scanSkillBundle as headScanSkillBundle } from './skill-processor.security.ts'
+import { parseArgs, type CliArgs } from './smi5879-simulate-full.cli.ts'
 import {
-  processRow,
   runMainPass,
   assertPatTokenSource,
-  PROCESS_CONCURRENCY,
   HEARTBEAT_INTERVAL_MS,
 } from './smi5879-simulate-full.helpers.ts'
 import {
   computeCoverage,
   summarizeCounts,
   estimateCompletionAt,
+  runSweepPhase,
+  decideExitCode,
+} from './smi5879-simulate-full.sweep.ts'
+import {
   checkpointPathFor,
   readCheckpoint,
   writeCheckpoint,
   isAbnormalResume,
-  runTier3Sweep,
-  decideExitCode,
   assertCheckpointIdentity,
   assertCheckpointRowsBelongToGeneration,
-} from './smi5879-simulate-full.sweep.ts'
+} from './smi5879-simulate-full.checkpoint.ts'
+import { ALL_SIMULATED_COHORTS } from './smi5879-simulate-full.types.ts'
 import type {
   Smi5879SimulateFullDbDeps,
   Smi5879SimulateCheckpoint,
@@ -75,50 +81,8 @@ import type {
   SimulatedCohort,
   ScanSkillBundleFn,
 } from './smi5879-simulate-full.types.ts'
-import type { Smi5879Purpose } from './smi5879-census.types.ts'
 
-const SIMULATED_COHORTS: readonly SimulatedCohort[] = ['C1', 'C2', 'C3', 'C4']
-const VALID_PURPOSES: readonly Smi5879Purpose[] = ['rehearsal', 'decision', 'window']
-
-export interface CliArgs {
-  runId: string
-  purpose: Smi5879Purpose
-  apply: boolean
-  checkpointPath?: string
-  reportPath?: string
-  baselineCommit: string
-}
-
-export function parseArgs(argv: string[]): CliArgs {
-  const find = (name: string): string | undefined => {
-    const prefix = `--${name}=`
-    const hit = argv.find((a) => a.startsWith(prefix))
-    return hit ? hit.slice(prefix.length) : undefined
-  }
-  const runId = find('run-id')
-  if (!runId) throw new Error('SMI-5879: --run-id=<generation run_id> is required.')
-  const purpose = find('purpose')
-  if (!purpose || !VALID_PURPOSES.includes(purpose as Smi5879Purpose)) {
-    throw new Error(
-      `SMI-5879: --purpose=<${VALID_PURPOSES.join('|')}> is required, got ${purpose ?? '(missing)'}.`
-    )
-  }
-  // `checkpointPath`/`reportPath` are genuinely optional (downstream defaults via
-  // `?? checkpointPathFor(...)` / `?? 'smi5879-simulate-report-...'`) — under
-  // `exactOptionalPropertyTypes`, an optional property means "may be omitted",
-  // not "may be omitted OR explicitly `undefined`", so the key must be left off
-  // entirely when the flag wasn't passed rather than assigned `undefined`.
-  const checkpointPath = find('checkpoint-path')
-  const reportPath = find('report-path')
-  return {
-    runId,
-    purpose: purpose as Smi5879Purpose,
-    apply: argv.includes('--apply'),
-    ...(checkpointPath !== undefined ? { checkpointPath } : {}),
-    ...(reportPath !== undefined ? { reportPath } : {}),
-    baselineCommit: find('baseline-commit') ?? BASELINE_COMMIT_SHA,
-  }
-}
+export { parseArgs, type CliArgs }
 
 /** `host:pid:git-head`, for `smi5879_run.runner_holder` — mirrors smi5879-census.ts's buildHolder(). */
 function buildHolder(): string {
@@ -161,6 +125,11 @@ export async function runSimulateFull(
     )
   }
 
+  // SMI-6015 Wave 1: the resolved cohort scope for THIS invocation — always
+  // explicit (never left as an implicit "undefined means all four"), so
+  // checkpoint identity/coverage code never has to special-case "omitted."
+  const cohorts: SimulatedCohort[] = args.cohorts ?? [...ALL_SIMULATED_COHORTS]
+
   const checkpointPath = args.checkpointPath ?? checkpointPathFor(args.runId)
   const existingCheckpoint = readCheckpoint(checkpointPath)
   const isColdStart = existingCheckpoint === null
@@ -172,7 +141,7 @@ export async function runSimulateFull(
     // trusted (SMI-5879 review finding 1).
     assertCheckpointIdentity(
       existingCheckpoint,
-      { runId: args.runId, purpose: args.purpose, tokenSource },
+      { runId: args.runId, purpose: args.purpose, tokenSource, cohorts },
       checkpointPath
     )
     if (existingCheckpoint.baseline_commit !== args.baselineCommit) {
@@ -194,12 +163,20 @@ export async function runSimulateFull(
   }
 
   const startedAt = new Date(existingCheckpoint?.started_at ?? new Date().toISOString())
+  // SMI-6015 Wave 1: THIS invocation's own deadline (Date.now() now +
+  // --max-elapsed-minutes) — deliberately independent of `startedAt` above
+  // (the checkpoint's persisted, cross-dispatch start, used only for ETA).
+  // Mirrors `smi5879-census.branches.ts`'s `sweepTransientRepos`: a GHA
+  // `timeout-minutes` ceiling bounds THIS dispatch, not the whole effort.
+  const deadlineAtMs =
+    args.maxElapsedMinutes !== undefined ? Date.now() + args.maxElapsedMinutes * 60_000 : undefined
 
   let checkpoint: Smi5879SimulateCheckpoint = existingCheckpoint ?? {
     run_id: args.runId,
     purpose: args.purpose,
     baseline_commit: args.baselineCommit,
     token_source: tokenSource,
+    cohorts,
     clean_shutdown: false,
     row_results: {},
     sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
@@ -270,6 +247,7 @@ export async function runSimulateFull(
     }
 
     const rows = await db.loadCohortRows(args.runId)
+    const totalRows = rows.length
     if (existingCheckpoint) {
       // Must run only after the real row set for this generation is loaded
       // (SMI-5879 review finding 1) — refuses a checkpoint whose row_results
@@ -277,11 +255,17 @@ export async function runSimulateFull(
       assertCheckpointRowsBelongToGeneration(existingCheckpoint, rows, checkpointPath)
     }
     const branchMap = await db.loadBranchMap(args.runId)
+    // SMI-6015 Wave 1 correctness guard-rail: `rowsByCohort` stays built
+    // from the FULL `rows` regardless of `--cohorts` — an excluded cohort
+    // must report its real `total` (scanned: 0, status: 'partial'), never a
+    // spuriously-`full` total: 0. Only `rowsForMainPass` is filtered.
     const rowsByCohort = { C1: [], C2: [], C3: [], C4: [] } as Record<
       SimulatedCohort,
       SimSnapshotRow[]
     >
     for (const row of rows) rowsByCohort[row.cohort].push(row)
+    const rowsForMainPass =
+      args.cohorts !== undefined ? rows.filter((r) => cohorts.includes(r.cohort)) : rows
 
     const telemetry = newRateLimitTelemetry()
     // SMI-6015: getHeaders is invoked fresh on every fetch attempt (inside
@@ -293,124 +277,109 @@ export async function runSimulateFull(
 
     const results = new Map(Object.entries(checkpoint.row_results))
 
-    await runMainPass(rows, results, branchMap, scanDeps, async (current) => {
-      checkpoint = {
-        ...checkpoint,
-        clean_shutdown: false,
-        row_results: Object.fromEntries(current),
-        updated_at: new Date().toISOString(),
+    /** Assemble the gate-eligible report from current state — shared by the normal-completion and deadline-exit paths. */
+    const buildReport = (
+      scannedRows: number,
+      sweepInfo: {
+        passes_run: number
+        hard_stopped: Smi5879SimulateFullReport['sweep']['hard_stopped']
       }
-      writeCheckpoint(checkpointPath, checkpoint)
-    })
-
-    // Resume state threaded into the sweep (SMI-5879 review finding 2a) —
-    // a crash mid-sweep must not reset the MAX_SWEEP_PASSES budget or the
-    // non-decrease hard-stop streak. `priorResidualHistory` is captured ONCE
-    // here and `sweepResidualHistory` grows it incrementally via `onPass`
-    // (below) as the single source of truth for every per-pass checkpoint
-    // write — the final write after the sweep returns reuses the exact same
-    // running total rather than re-deriving/re-adding it (finding 2b).
-    const priorSweepPass = checkpoint.sweep.pass
-    const priorNonDecreaseStreak = checkpoint.sweep.non_decrease_streak
-    const priorResidualHistory = [...checkpoint.sweep.residual_history]
-    const sweepResidualHistory: number[] = [...priorResidualHistory]
-
-    const residual = [...results.values()].filter((r) => r.outcome === 'unevaluable')
-    const sweep = await runTier3Sweep(
-      residual,
-      async (residualIds) => {
-        const idSet = new Set(residualIds)
-        const targets = rows.filter((r) => idSet.has(r.id))
-        const outcomes: import('./smi5879-simulate-full.types.ts').SimRowResult[] = []
-        // SMI-6015: same cooperative-cancellation fix as runMainPass above —
-        // see that call site's comment for the full rationale.
-        const { abortedBy } = await runCancellablePool(
-          targets,
-          (row) => processRow(row, branchMap, scanDeps),
-          (outcome) => {
-            outcomes.push(outcome)
-          },
-          PROCESS_CONCURRENCY
-        )
-        const updated = new Map(outcomes.map((o) => [o.id, o]))
-        for (const [id, result] of updated) results.set(id, result)
-        if (abortedBy) {
-          // SMI-6015 (GPT-5.6-Sol review round 2, 2026-08-14): throwing here
-          // rejects runTier3Sweep's own `await runPass(...)` before it ever
-          // reaches `options.onPass` — the ONLY place that normally writes a
-          // checkpoint after a pass. Without this, `results` above is
-          // updated in memory but the process is about to exit on this
-          // thrown error, so that partial progress would be lost on disk.
-          // Write it explicitly, matching onPass's shape but WITHOUT
-          // advancing pass/residual_history/non_decrease_streak — this pass
-          // never cleanly completed, so it must not be counted as if it had.
-          checkpoint = {
-            ...checkpoint,
-            clean_shutdown: false,
-            row_results: Object.fromEntries(results),
-            updated_at: new Date().toISOString(),
-          }
-          writeCheckpoint(checkpointPath, checkpoint)
-          throw abortedBy
-        }
-        return updated
-      },
-      {
-        startingPass: priorSweepPass,
-        startingNonDecreaseStreak: priorNonDecreaseStreak,
-        onPass: (pass, residualSize, nonDecreaseStreak) => {
-          sweepResidualHistory.push(residualSize)
-          checkpoint = {
-            ...checkpoint,
-            clean_shutdown: false,
-            row_results: Object.fromEntries(results),
-            sweep: {
-              pass,
-              residual_history: [...sweepResidualHistory],
-              non_decrease_streak: nonDecreaseStreak,
-              hard_stopped: null,
-            },
-            updated_at: new Date().toISOString(),
-          }
-          writeCheckpoint(checkpointPath, checkpoint)
-        },
-      }
-    )
-
-    const coverage = computeCoverage(rowsByCohort, results)
-    const counts = summarizeCounts(results.values())
-    const totalRows = rows.length
-    const scannedRows = results.size
-
-    checkpoint = {
-      ...checkpoint,
-      clean_shutdown: true,
-      row_results: Object.fromEntries(results),
-      sweep: {
-        pass: sweep.passesRun,
-        residual_history: [...priorResidualHistory, ...sweep.residualHistory],
-        non_decrease_streak: sweep.nonDecreaseStreak,
-        hard_stopped: sweep.hardStopped,
-      },
-      updated_at: new Date().toISOString(),
-    }
-    writeCheckpoint(checkpointPath, checkpoint)
-
-    const report: Smi5879SimulateFullReport = {
+    ): Smi5879SimulateFullReport => ({
       report_kind: 'full_simulation',
       run_id: args.runId,
       purpose: args.purpose,
       status: summary.status,
       token_source: tokenSource,
       baseline_commit: args.baselineCommit,
-      coverage,
+      coverage: computeCoverage(rowsByCohort, results),
       estimated_completion_at: estimateCompletionAt(startedAt, new Date(), totalRows, scannedRows),
-      sweep: { passes_run: checkpoint.sweep.pass, hard_stopped: sweep.hardStopped },
+      sweep: sweepInfo,
       rows: [...results.values()],
-      counts,
+      counts: summarizeCounts(results.values()),
       generated_at: new Date().toISOString(),
+    })
+
+    const mainPassResult = await runMainPass(
+      rowsForMainPass,
+      results,
+      branchMap,
+      scanDeps,
+      async (current) => {
+        checkpoint = {
+          ...checkpoint,
+          clean_shutdown: false,
+          row_results: Object.fromEntries(current),
+          updated_at: new Date().toISOString(),
+        }
+        writeCheckpoint(checkpointPath, checkpoint)
+      },
+      deadlineAtMs
+    )
+
+    // SMI-6015 Wave 1: a deadline hit is an EXPECTED, non-fatal stop, never
+    // a crash — `clean_shutdown: true` is correct (the checkpoint is fully
+    // consistent, so a resume should not pay the abnormal-resume digest
+    // re-verification cost for something that isn't actually suspect).
+    // `decideExitCode` naturally returns 1 on the resulting partial
+    // coverage, which the workflow interprets as "continues, re-dispatch."
+    const exitOnDeadline = (reason: string): Smi5879SimulateFullReport => {
+      console.log(
+        `[smi5879-simulate-full] run_id=${args.runId} ${reason} — ${results.size}/${totalRows} ` +
+          'rows scanned. Writing checkpoint and exiting for re-dispatch (never a hard failure).'
+      )
+      checkpoint = {
+        ...checkpoint,
+        clean_shutdown: true,
+        row_results: Object.fromEntries(results),
+        updated_at: new Date().toISOString(),
+      }
+      writeCheckpoint(checkpointPath, checkpoint)
+      return buildReport(results.size, {
+        passes_run: checkpoint.sweep.pass,
+        hard_stopped: checkpoint.sweep.hard_stopped,
+      })
     }
-    return report
+
+    if (mainPassResult.deadlineExceeded) {
+      return exitOnDeadline(
+        `wall-clock deadline (--max-elapsed-minutes=${args.maxElapsedMinutes}) reached mid-main-pass`
+      )
+    }
+    // Deadline reached exactly as the main pass finished — skip the tier-3
+    // sweep this dispatch (its own SWEEP_COOLDOWN_MS cooldown is not itself
+    // deadline-aware; a documented Wave 1 bound, not a silent gap — the
+    // sweep only reprocesses the smaller `unevaluable` residual and stays
+    // separately bounded by MAX_SWEEP_PASSES/SWEEP_COOLDOWN_MS).
+    // TESTING NOTE: this exact branch shares 100% of its behavior with the
+    // `mainPassResult.deadlineExceeded` branch above (the same `exitOnDeadline`
+    // helper) — only the triggering condition differs. It sits in the same
+    // synchronous continuation as that check (no `await` between them), so a
+    // black-box test cannot advance the clock into the narrow window between
+    // them without mocking `runMainPass` itself; deliberately not covered by
+    // a dedicated test for that reason — reviewed by inspection instead.
+    if (deadlineAtMs !== undefined && Date.now() >= deadlineAtMs) {
+      return exitOnDeadline(
+        'wall-clock deadline reached after the main pass — skipping the tier-3 sweep'
+      )
+    }
+
+    // Tier-3 sweep phase — extracted to smi5879-simulate-full.sweep.ts's
+    // `runSweepPhase` (SMI-6015 Wave 1: 500-line budget). See its own doc
+    // comments for the resume/finding-2a/2b and abort-checkpoint rationale.
+    const sweepResult = await runSweepPhase(
+      rows,
+      branchMap,
+      scanDeps,
+      results,
+      checkpoint,
+      checkpointPath
+    )
+    checkpoint = sweepResult.checkpoint
+
+    return buildReport(results.size, {
+      passes_run: checkpoint.sweep.pass,
+      hard_stopped: sweepResult.hardStopped,
+    })
   } finally {
     heartbeatStopped = true
     if (heartbeatTimer) clearTimeout(heartbeatTimer)
@@ -427,7 +396,7 @@ function printSummary(report: Smi5879SimulateFullReport): void {
       `  token_source:      ${report.token_source}\n` +
       `  baseline_commit:   ${report.baseline_commit}\n` +
       `  sweep:             ${report.sweep.passes_run} pass(es), hard_stopped=${report.sweep.hard_stopped ?? 'none'}\n` +
-      SIMULATED_COHORTS.map(
+      ALL_SIMULATED_COHORTS.map(
         (c) =>
           `  coverage.${c}:       ${report.coverage[c].status} (${report.coverage[c].scanned}/${report.coverage[c].total}, unevaluable=${report.coverage[c].unevaluable}, unfetchable=${report.coverage[c].unfetchable})`
       ).join('\n') +

--- a/scripts/indexer/smi5879-simulate-full.types.ts
+++ b/scripts/indexer/smi5879-simulate-full.types.ts
@@ -15,6 +15,16 @@ import type { Smi5879Purpose, Smi5879RunStatus } from './smi5879-census.types.ts
 export type SimulatedCohort = 'C1' | 'C2' | 'C3' | 'C4'
 
 /**
+ * Canonical "all four cohorts" list — single source of truth for CLI
+ * validation/defaulting (smi5879-simulate-full.cli.ts), checkpoint identity
+ * defaulting, and report-summary printing (smi5879-simulate-full.ts),
+ * so a --cohorts= scope always resolves to an EXPLICIT list, never an
+ * implicit "undefined means all four" left to each call site to reinvent
+ * (SMI-6015 Wave 1).
+ */
+export const ALL_SIMULATED_COHORTS: readonly SimulatedCohort[] = ['C1', 'C2', 'C3', 'C4']
+
+/**
  * Closed tier-2 outcome vocabulary (plan §3b). `gate-check.ts` refuses an
  * unrecognised value — this union is the enforcement point on our side.
  */
@@ -27,6 +37,35 @@ export type SimRowOutcome =
   | 'bundle_absent'
   | 'unevaluable'
   | 'unfetchable'
+
+/**
+ * Single source of truth for the closed {@link SimRowOutcome} vocabulary at
+ * runtime — shared by `smi5879-simulate-full.sweep.ts`'s `summarizeCounts`
+ * and `smi5879-simulate-full.checkpoint.ts`'s shape validator (SMI-5879
+ * review finding 1), so the two can never drift apart. Lives here (not in
+ * either of those files) specifically to avoid a circular import between
+ * them (SMI-6015 Wave 1: `.sweep.ts` needs `writeCheckpoint` from
+ * `.checkpoint.ts`, so `.checkpoint.ts` cannot import anything back from
+ * `.sweep.ts`).
+ */
+export const EMPTY_OUTCOME_COUNTS: Record<SimRowOutcome, number> = {
+  newly_quarantined: 0,
+  newly_cleared: 0,
+  unchanged_clean: 0,
+  unchanged_quarantined: 0,
+  content_drifted: 0,
+  bundle_absent: 0,
+  unevaluable: 0,
+  unfetchable: 0,
+}
+
+export const SIM_ROW_OUTCOMES: readonly SimRowOutcome[] = Object.keys(
+  EMPTY_OUTCOME_COUNTS
+) as SimRowOutcome[]
+
+export function isValidSimRowOutcome(value: unknown): value is SimRowOutcome {
+  return typeof value === 'string' && (SIM_ROW_OUTCOMES as readonly string[]).includes(value)
+}
 
 /** One row read from the sealed generation's population (`smi5879_snapshot_pre`), cohort-tagged. */
 export interface SimSnapshotRow {
@@ -96,6 +135,16 @@ export interface Smi5879SimulateCheckpoint {
   purpose: Smi5879Purpose
   baseline_commit: string
   token_source: TokenSource
+  /**
+   * SMI-6015 Wave 1: the resolved cohort scope for this run — ALWAYS the
+   * explicit list (never left implicit; "all four" is stored as
+   * `ALL_SIMULATED_COHORTS`, not omitted), so a resumed dispatch with a
+   * DIFFERENT --cohorts filter than the original checkpoint is refused
+   * loudly (`assertCheckpointIdentity`) rather than silently accepted — a
+   * cohort-scoped rehearsal checkpoint must never be resumed as if it were
+   * a full-population run, or vice versa.
+   */
+  cohorts: SimulatedCohort[]
   /** True only immediately before a graceful exit; false at every interim write. */
   clean_shutdown: boolean
   /** Per-row outcomes recorded so far (main pass + all sweep passes), keyed by row id. */

--- a/scripts/tests/indexer/smi5879-simulate-full.checkpoint.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.checkpoint.test.ts
@@ -20,7 +20,8 @@ import {
   readCheckpoint,
   writeCheckpoint,
   isAbnormalResume,
-} from '../../indexer/smi5879-simulate-full.sweep.ts'
+  assertCheckpointIdentity,
+} from '../../indexer/smi5879-simulate-full.checkpoint.ts'
 import type { Smi5879SimulateCheckpoint } from '../../indexer/smi5879-simulate-full.types.ts'
 
 // ---------------------------------------------------------------------------
@@ -47,6 +48,7 @@ describe('checkpoint I/O', () => {
       purpose: 'decision',
       baseline_commit: 'abc123',
       token_source: 'pat',
+      cohorts: ['C1', 'C2', 'C3', 'C4'],
       clean_shutdown: true,
       row_results: {},
       sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
@@ -64,6 +66,7 @@ describe('checkpoint I/O', () => {
       purpose: 'decision',
       baseline_commit: 'x',
       token_source: 'pat',
+      cohorts: ['C1', 'C2', 'C3', 'C4'],
       clean_shutdown: true,
       row_results: {},
       sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
@@ -93,6 +96,7 @@ describe('checkpoint I/O', () => {
       purpose: 'decision',
       baseline_commit: 'abc123',
       token_source: 'pat',
+      cohorts: ['C1', 'C2', 'C3', 'C4'],
       clean_shutdown: true,
       row_results: {
         'row-1': {
@@ -118,6 +122,34 @@ describe('checkpoint I/O', () => {
   })
 
   // -------------------------------------------------------------------------
+  // SMI-6015 Wave 1: `cohorts` is a new required field — shape validation
+  // must reject a missing/empty/invalid value, not silently accept it.
+  // -------------------------------------------------------------------------
+
+  it.each([
+    ['missing', undefined],
+    ['empty array', []],
+    ['containing an invalid cohort', ['C1', 'C99']],
+    ['not an array', 'C1'],
+  ])('readCheckpoint rejects a checkpoint with cohorts %s', (_label, cohorts) => {
+    const path = join(dir, 'bad-cohorts.json')
+    const raw: Record<string, unknown> = {
+      run_id: 'run-1',
+      purpose: 'decision',
+      baseline_commit: 'abc123',
+      token_source: 'pat',
+      clean_shutdown: true,
+      row_results: {},
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    if (cohorts !== undefined) raw['cohorts'] = cohorts
+    writeFileSync(path, JSON.stringify(raw))
+    expect(() => readCheckpoint(path)).toThrow(/cohorts=/)
+  })
+
+  // -------------------------------------------------------------------------
   // SMI-5879 review finding 3: a corrupted checkpoint file is NOT the same
   // as "no checkpoint" (cold start) — it must fail loudly, since real
   // progress may have been lost, not be silently treated as absent.
@@ -138,6 +170,7 @@ describe('checkpoint I/O', () => {
       purpose: 'decision',
       baseline_commit: 'abc123',
       token_source: 'pat',
+      cohorts: ['C1', 'C2', 'C3', 'C4'],
       clean_shutdown: true,
       row_results: {},
       sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
@@ -152,5 +185,50 @@ describe('checkpoint I/O', () => {
     expect(loaded?.clean_shutdown).toBe(false)
     expect(() => readCheckpoint(`${path}.tmp-${process.pid}`)).not.toThrow()
     expect(readCheckpoint(`${path}.tmp-${process.pid}`)).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // SMI-6015 Wave 1: assertCheckpointIdentity's cohorts comparison
+  // -------------------------------------------------------------------------
+
+  describe('assertCheckpointIdentity — cohorts', () => {
+    function identityCheckpoint(
+      cohorts: Smi5879SimulateCheckpoint['cohorts']
+    ): Smi5879SimulateCheckpoint {
+      return {
+        run_id: 'run-1',
+        purpose: 'decision',
+        baseline_commit: 'abc123',
+        token_source: 'pat',
+        cohorts,
+        clean_shutdown: true,
+        row_results: {},
+        sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+        started_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }
+    }
+
+    it('treats the same cohorts in a different order as identical (not a mismatch)', () => {
+      const checkpoint = identityCheckpoint(['C4', 'C2'])
+      expect(() =>
+        assertCheckpointIdentity(
+          checkpoint,
+          { runId: 'run-1', purpose: 'decision', tokenSource: 'pat', cohorts: ['C2', 'C4'] },
+          'path'
+        )
+      ).not.toThrow()
+    })
+
+    it('refuses a genuinely different cohorts scope', () => {
+      const checkpoint = identityCheckpoint(['C1', 'C2', 'C3', 'C4'])
+      expect(() =>
+        assertCheckpointIdentity(
+          checkpoint,
+          { runId: 'run-1', purpose: 'decision', tokenSource: 'pat', cohorts: ['C4'] },
+          'path'
+        )
+      ).toThrow(/cohorts \(checkpoint=C1,C2,C3,C4, this run=C4\)/)
+    })
   })
 })

--- a/scripts/tests/indexer/smi5879-simulate-full.cli.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.cli.test.ts
@@ -1,0 +1,95 @@
+/**
+ * SMI-6015 Wave 1: smi5879-simulate-full.cli.ts — `parseArgs` tests,
+ * including the new `--max-elapsed-minutes` and `--cohorts` flags added
+ * this Wave (previously untested — extracted from smi5879-simulate-full.ts
+ * as part of the same 500-line-budget split that added these flags).
+ * @module scripts/tests/indexer/smi5879-simulate-full.cli
+ */
+
+import { describe, it, expect } from 'vitest'
+import { parseArgs } from '../../indexer/smi5879-simulate-full.cli.ts'
+
+const REQUIRED = ['--run-id=run-1', '--purpose=decision']
+
+describe('parseArgs', () => {
+  it('throws when --run-id is missing', () => {
+    expect(() => parseArgs(['--purpose=decision'])).toThrow(/--run-id/)
+  })
+
+  it('throws when --purpose is missing or invalid', () => {
+    expect(() => parseArgs(['--run-id=run-1'])).toThrow(/--purpose/)
+    expect(() => parseArgs(['--run-id=run-1', '--purpose=bogus'])).toThrow(/--purpose/)
+  })
+
+  it('parses required fields with sensible defaults for everything else', () => {
+    const args = parseArgs(REQUIRED)
+    expect(args.runId).toBe('run-1')
+    expect(args.purpose).toBe('decision')
+    expect(args.apply).toBe(false)
+    expect(args.checkpointPath).toBeUndefined()
+    expect(args.reportPath).toBeUndefined()
+    expect(args.maxElapsedMinutes).toBeUndefined()
+    expect(args.cohorts).toBeUndefined()
+  })
+
+  it('--apply sets apply: true', () => {
+    expect(parseArgs([...REQUIRED, '--apply']).apply).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------
+  // SMI-6015 Wave 1: --max-elapsed-minutes
+  // ---------------------------------------------------------------------
+
+  it('parses a valid --max-elapsed-minutes', () => {
+    expect(parseArgs([...REQUIRED, '--max-elapsed-minutes=310']).maxElapsedMinutes).toBe(310)
+  })
+
+  it.each(['0', '-5', 'not-a-number', ''])('rejects an invalid --max-elapsed-minutes=%s', (bad) => {
+    expect(() => parseArgs([...REQUIRED, `--max-elapsed-minutes=${bad}`])).toThrow(
+      /--max-elapsed-minutes/
+    )
+  })
+
+  // ---------------------------------------------------------------------
+  // SMI-6015 Wave 1: --cohorts
+  // ---------------------------------------------------------------------
+
+  it('parses a valid single-cohort --cohorts with a non-decision purpose', () => {
+    const args = parseArgs(['--run-id=run-1', '--purpose=rehearsal', '--cohorts=C4'])
+    expect(args.cohorts).toEqual(['C4'])
+  })
+
+  it('parses a valid multi-cohort comma-list, trimming whitespace', () => {
+    const args = parseArgs(['--run-id=run-1', '--purpose=rehearsal', '--cohorts=C2, C4'])
+    expect(args.cohorts).toEqual(['C2', 'C4'])
+  })
+
+  it('rejects an invalid cohort name', () => {
+    expect(() => parseArgs(['--run-id=run-1', '--purpose=rehearsal', '--cohorts=C4,C99'])).toThrow(
+      /invalid cohort.*C99/
+    )
+  })
+
+  it('an empty --cohorts= is treated as omitted (all four)', () => {
+    const args = parseArgs(['--run-id=run-1', '--purpose=rehearsal', '--cohorts='])
+    expect(args.cohorts).toBeUndefined()
+  })
+
+  // -----------------------------------------------------------------------
+  // SMI-6015 Wave 1 plan-review Medium finding #10: --cohorts can never be
+  // combined with --purpose=decision — G-2 requires all four cohorts fully
+  // simulated in one decision-purpose report, so a cohort-scoped decision
+  // dispatch could never satisfy the gate no matter what it found.
+  // -----------------------------------------------------------------------
+
+  it('rejects --cohorts combined with --purpose=decision', () => {
+    expect(() => parseArgs([...REQUIRED, '--cohorts=C4'])).toThrow(
+      /--cohorts.*cannot be combined with --purpose=decision/
+    )
+  })
+
+  it('allows --cohorts with --purpose=window (not just rehearsal)', () => {
+    const args = parseArgs(['--run-id=run-1', '--purpose=window', '--cohorts=C1,C2'])
+    expect(args.cohorts).toEqual(['C1', 'C2'])
+  })
+})

--- a/scripts/tests/indexer/smi5879-simulate-full.deadline-cohorts.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.deadline-cohorts.test.ts
@@ -1,0 +1,128 @@
+/**
+ * SMI-6015 Wave 1: smi5879-simulate-full — wall-clock deadline
+ * (`--max-elapsed-minutes`) and cohort scoping (`--cohorts`) end-to-end
+ * tests. Split out of `smi5879-simulate-full.test.ts` (grew past the
+ * 500-line-per-file gate, `scripts/check-file-length.mjs`) — shared
+ * fixtures live in `./smi5879-simulate-full.fixtures.ts`.
+ * @module scripts/tests/indexer/smi5879-simulate-full.deadline-cohorts
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { readCheckpoint, writeCheckpoint } from '../../indexer/smi5879-simulate-full.checkpoint.ts'
+import { runSimulateFull, type CliArgs } from '../../indexer/smi5879-simulate-full.ts'
+import type { Smi5879SimulateCheckpoint } from '../../indexer/smi5879-simulate-full.types.ts'
+import {
+  makeRow,
+  makeFakeDb,
+  makeVerdictScanner,
+  registerPrimary,
+  contentsApiResponse,
+  resetRowCounter,
+  installFetchMock,
+  restoreFetchMock,
+} from './smi5879-simulate-full.fixtures.ts'
+
+beforeEach(() => {
+  resetRowCounter()
+  installFetchMock()
+})
+
+afterEach(() => {
+  restoreFetchMock()
+})
+
+describe('runSimulateFull — SMI-6015 Wave 1 (deadline + cohorts)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'smi5879-sim-wave1-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function wave1Args(overrides: Partial<CliArgs> = {}): CliArgs {
+    return {
+      runId: 'run-wave1',
+      purpose: 'decision',
+      apply: true,
+      baselineCommit: 'deadbeef',
+      checkpointPath: join(dir, 'checkpoint.json'),
+      reportPath: join(dir, 'report.json'),
+      ...overrides,
+    }
+  }
+
+  it('stops the main pass before any row and writes a partial-coverage checkpoint when the deadline is already past', async () => {
+    const rows = [makeRow({ cohort: 'C2' }), makeRow({ cohort: 'C2' })]
+    registerPrimary(rows[0], [contentsApiResponse('# a')])
+    registerPrimary(rows[1], [contentsApiResponse('# b')])
+    const db = makeFakeDb({ loadCohortRows: async () => rows })
+    const scanner = makeVerdictScanner(new Map())
+    // A negative budget makes deadlineAtMs already in the past the instant
+    // it's computed — deterministic, no fake-timer choreography needed.
+    const args = wave1Args({ maxElapsedMinutes: -1 })
+
+    const report = await runSimulateFull(db, scanner, scanner, args, {})
+
+    expect(report.coverage.C2.status).toBe('partial')
+    expect(report.coverage.C2.scanned).toBe(0)
+    expect(report.rows).toHaveLength(0)
+    const checkpoint = readCheckpoint(args.checkpointPath as string)
+    // Graceful, expected stop — never treated as an abnormal/suspect state.
+    expect(checkpoint?.clean_shutdown).toBe(true)
+  })
+
+  it('an excluded cohort reports partial with scanned:0, never a spurious full/total:0 (correctness guard-rail)', async () => {
+    const included = makeRow({ cohort: 'C4', id: 'included-row' })
+    const excluded = makeRow({ cohort: 'C2', id: 'excluded-row' })
+    registerPrimary(included, [contentsApiResponse('# included')])
+    const db = makeFakeDb({
+      getRunSummary: async () => ({ purpose: 'rehearsal', status: 'sealed' }),
+      loadCohortRows: async () => [included, excluded],
+    })
+    const scanner = makeVerdictScanner(new Map())
+    const args = wave1Args({ purpose: 'rehearsal', cohorts: ['C4'] })
+
+    const report = await runSimulateFull(db, scanner, scanner, args, {})
+
+    expect(report.coverage.C4.status).toBe('full')
+    expect(report.coverage.C4.scanned).toBe(1)
+    // The excluded cohort's row was never fetched (no registerPrimary call
+    // for it — an unregistered-URL fetch would have thrown and failed this
+    // test), and its coverage reflects the REAL total, not a vacuous 'full'.
+    expect(report.coverage.C2.status).toBe('partial')
+    expect(report.coverage.C2.total).toBe(1)
+    expect(report.coverage.C2.scanned).toBe(0)
+    expect(report.rows).toHaveLength(1)
+    expect(report.rows[0]?.id).toBe('included-row')
+  })
+
+  it('refuses to resume a checkpoint written with a different --cohorts scope', async () => {
+    const rows = [makeRow({ cohort: 'C4', id: 'c4-row' })]
+    const args = wave1Args({ purpose: 'rehearsal', cohorts: ['C4'] })
+    const seeded: Smi5879SimulateCheckpoint = {
+      run_id: args.runId,
+      purpose: args.purpose,
+      baseline_commit: args.baselineCommit,
+      token_source: 'pat',
+      cohorts: ['C2'], // different scope than this invocation's ['C4']
+      clean_shutdown: true,
+      row_results: {},
+      sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    writeCheckpoint(args.checkpointPath as string, seeded)
+    const db = makeFakeDb({
+      getRunSummary: async () => ({ purpose: 'rehearsal', status: 'sealed' }),
+      loadCohortRows: async () => rows,
+    })
+    const scanner = makeVerdictScanner(new Map())
+    await expect(runSimulateFull(db, scanner, scanner, args, {})).rejects.toThrow(
+      /does not match this invocation.*cohorts/s
+    )
+  })
+})

--- a/scripts/tests/indexer/smi5879-simulate-full.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.test.ts
@@ -11,6 +11,9 @@
  *   - `smi5879-simulate-full.sweep.test.ts` — `runTier3Sweep` (termination
  *     conditions + resume durability, review finding 2a).
  *   - `smi5879-simulate-full.checkpoint.test.ts` — checkpoint I/O.
+ *   - `smi5879-simulate-full.cli.test.ts` — `parseArgs` (SMI-6015 Wave 1).
+ *   - `smi5879-simulate-full.deadline-cohorts.test.ts` — `--max-elapsed-minutes`
+ *     / `--cohorts` end-to-end behavior (SMI-6015 Wave 1).
  *   - `smi5879-simulate-full.fixtures.ts` — shared fixtures/fakes.
  * @module scripts/tests/indexer/smi5879-simulate-full
  *
@@ -30,11 +33,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { HEARTBEAT_INTERVAL_MS } from '../../indexer/smi5879-simulate-full.helpers.ts'
-import {
-  readCheckpoint,
-  writeCheckpoint,
-  SWEEP_COOLDOWN_MS,
-} from '../../indexer/smi5879-simulate-full.sweep.ts'
+import { SWEEP_COOLDOWN_MS } from '../../indexer/smi5879-simulate-full.sweep.ts'
+import { readCheckpoint, writeCheckpoint } from '../../indexer/smi5879-simulate-full.checkpoint.ts'
 import { runSimulateFull, type CliArgs } from '../../indexer/smi5879-simulate-full.ts'
 import type {
   BranchMap,
@@ -152,6 +152,7 @@ describe('runSimulateFull', () => {
       purpose: args.purpose,
       baseline_commit: args.baselineCommit,
       token_source: 'pat',
+      cohorts: ['C1', 'C2', 'C3', 'C4'],
       clean_shutdown: true,
       row_results: {
         'resume-a': {
@@ -204,6 +205,7 @@ describe('runSimulateFull', () => {
       purpose: args.purpose,
       baseline_commit: args.baselineCommit,
       token_source: 'pat',
+      cohorts: ['C1', 'C2', 'C3', 'C4'],
       clean_shutdown: false, // abnormal prior termination
       row_results: {},
       sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
@@ -246,6 +248,7 @@ describe('runSimulateFull', () => {
       purpose: args.purpose,
       baseline_commit: args.baselineCommit,
       token_source: 'pat',
+      cohorts: ['C1', 'C2', 'C3', 'C4'],
       clean_shutdown: true,
       row_results: {},
       sweep: { pass: 0, residual_history: [], non_decrease_streak: 0, hard_stopped: null },
@@ -268,6 +271,7 @@ describe('runSimulateFull', () => {
       purpose: args.purpose,
       baseline_commit: args.baselineCommit,
       token_source: 'pat',
+      cohorts: ['C1', 'C2', 'C3', 'C4'],
       clean_shutdown: true,
       row_results: {
         'row-from-a-different-generation': {


### PR DESCRIPTION
## Business Summary

**What shipped:** Two prerequisite changes to the production skill-validation simulator, ahead of building the CI workflow that will run it: it can now be told to stop and checkpoint cleanly after a time budget instead of getting killed mid-work, and it can be scoped to a small subset of the population for a cheap trial run before committing to the full multi-day pass.

**Quality bar:** Implementation reviewed against a prior multi-perspective plan review's requirements (the correctness guard-rail for cohort-scoped coverage reporting, reuse of an existing proven deadline mechanism rather than a new one). A dedicated governance code review pass followed, plus the full indexer test suite (1,485 tests). Two real issues — a circular import risk and two file-size-budget overages introduced by the refactor — were caught and fixed during implementation itself, before either review pass.

**Found along the way:** two pre-existing, unrelated issues surfaced while running standard verification commands — a different file already over the repo's line-count budget (SMI-6099) and three false-positive "missing dependency" reports from an unrelated tooling script (SMI-6100). Both filed, neither touched here.

**Net result:** Fully shipped. This is prerequisite work — the CI workflow itself that uses these two flags is a separate, larger, infra-gated piece of work not yet started.

---

## Technical detail

**Files**: `scripts/indexer/smi5879-simulate-full.ts` (orchestration), two new files split out to stay under the 500-line-per-file budget (`smi5879-simulate-full.cli.ts` for CLI parsing, `smi5879-simulate-full.checkpoint.ts` for checkpoint I/O), plus `.helpers.ts`, `.sweep.ts`, `.types.ts`, and their test files.

- `--max-elapsed-minutes=<N>`: wires into `runCancellablePool`'s existing `deadlineAtMs`/`deadlineExceeded` support — the same mechanism `smi5879-census.branches.ts`'s `sweepTransientRepos` already uses — rather than a new fatal-abort path. A deadline hit writes a checkpoint with `clean_shutdown: true` and returns a report with partial coverage; `decideExitCode` naturally returns 1, which a future CI workflow interprets as "re-dispatch," never as a crash.
- `--cohorts=<comma-list>`: rejected at parse time when combined with `--purpose=decision` (the gate requires all four cohorts in one report, so a cohort-scoped decision run could never satisfy it). Filters only what feeds the main processing pass — `computeCoverage`'s input (`rowsByCohort`) stays built from the full population, so an excluded cohort correctly reports `partial` with its real row count rather than a vacuous `full`/`total: 0`.
- `cohorts` is now part of checkpoint identity (`assertCheckpointIdentity`) and checkpoint shape validation — a resume with a different `--cohorts` scope than the checkpoint was written with is refused loudly.
- One deliberately-scoped testing gap, documented in-code: the "deadline reached exactly between the main pass and the sweep phase" branch sits in the same synchronous JS continuation as the main-pass check above it, with no `await` boundary between them — not independently testable via black-box behavioral testing without mocking `runMainPass` itself. Both branches share the same tested helper; only the triggering condition differs.

**Verification**: `docker exec` (worktree container) `typecheck`/`lint`/`format:check`/`audit:standards` all clean; `npx vitest run scripts/tests/indexer` — 1,485 passed, 72 pre-existing skips (no live test Postgres, unrelated). 39 new/updated tests specifically covering the new deadline and cohorts behavior.

**Governance review**: `docs/internal/code_review/2026-08-21-smi6015-wave1-simulate-full-deadline-cohorts.md` (skillsmith-docs PR #803).

Refs SMI-6015.