### PR TITLE
fix(mcp-server): remove SUPABASE_SERVICE_ROLE_KEY from customer-facing private registry reads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34386,6 +34386,7 @@
         "@cyclonedx/cyclonedx-library": "10.1.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@skillsmith/core": "^0.11.7",
+        "@supabase/supabase-js": "2.112.2",
         "ajv-formats-draft2019": "1.6.1",
         "ulid": "3.0.1",
         "zod": "3.25.76"

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+- **Security**: `private_registry_manage`'s `list`, `get`, and `namespace` actions no longer
+  require `SUPABASE_SERVICE_ROLE_KEY` on the MCP host. They previously ran on the Supabase
+  service-role client — the backend's most powerful credential, which bypasses row-level security
+  entirely — and this package's own README instructed customers to configure it on their own
+  machines and distribute it via 1Password. Both the code path and that instruction are gone.
+  The three reads now run as the signed-in user (`skillsmith login`) via new audited wrappers
+  (`registry-tools.live.member-reads.ts`), the same `getMemberUserClient()` pattern already proven
+  by `publish`/`deprecate`/`undeprecate`/`getContent`. Every existing `team_id` /
+  `approval_status = 'approved'` / `deprecated = FALSE` query predicate is preserved byte-for-byte
+  — RLS does not enforce the latter two, so dropping them would have silently widened what a
+  member can read. All three now also write a `recordRegistryAudit()` row, making a
+  license-key-team-vs-signed-in-user mismatch observable instead of invisible. `@supabase/supabase-js`
+  is now a real dependency of this package (previously only a private root devDependency, so even
+  a fully-configured install failed with "Supabase client unavailable"), and the anon-key client
+  paths fall back to the production Supabase URL/anon key when those env vars are unset — an
+  explicit override still always wins. A new `audit:standards` Check 62 fails CI if a
+  service-role dependency reappears anywhere under `packages/mcp-server/src/**` outside a named,
+  justified allowlist. `install`/`getContent` still needs the service-role key for its Enterprise
+  entitlement check until SMI-6111 lands. (SMI-6109)
 - **Fix**: the license middleware never resolved a real subscription tier for a caller
   authenticated only via `skillsmith login` (device-session, no separately-configured
   `SKILLSMITH_API_KEY`) — SMI-1953 covered the API-key path only, so every such caller silently

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -451,7 +451,7 @@ Index local skills from `~/.claude/skills/` directory.
 
 The `webhook_configure` and `api_key_manage` tools hash secrets server-side via HMAC-SHA-256 before persisting to the shared `api_keys` table. The HMAC key lives in `SKILLSMITH_API_KEY_HMAC_SECRET` rather than as a hardcoded constant — defense-in-depth so a leaked DB cannot be reverse-cracked offline.
 
-**Distribution model**: identical to `SUPABASE_SERVICE_ROLE_KEY`. The same secret value must be set on every MCP host that creates or verifies Custom Integration API keys, otherwise hashes computed on host A won't match hashes verified on host B.
+**Distribution model**: a single shared secret. The same secret value must be set on every MCP host that creates or verifies Custom Integration API keys, otherwise hashes computed on host A won't match hashes verified on host B.
 
 ### Error Logging (SMI-5615)
 
@@ -508,7 +508,7 @@ before integration tools can be used. Generate one via: openssl rand -base64 48
 openssl rand -base64 48
 ```
 
-Distribute that value through the same secure channel used for `SUPABASE_SERVICE_ROLE_KEY` (e.g., 1Password vault, encrypted onboarding email). Each Team-tier admin sets it on their own MCP host alongside their other secrets:
+Distribute that value through a secure channel (e.g., 1Password vault, encrypted onboarding email). Each Team-tier admin sets it on their own MCP host alongside their other secrets — no Supabase credential of any kind is required here; the private registry and Custom Integration tools authenticate as the signed-in user (`skillsmith login`) plus your personal/team key, never a shared database credential:
 
 ```jsonc
 // ~/.claude/settings.json
@@ -520,7 +520,6 @@ Distribute that value through the same secure channel used for `SUPABASE_SERVICE
       "env": {
         "SKILLSMITH_API_KEY": "sk_live_your_personal_key",
         "SKILLSMITH_LICENSE_KEY": "sklic_your_team_license",
-        "SUPABASE_SERVICE_ROLE_KEY": "eyJ...your_service_role_jwt",
         "SKILLSMITH_API_KEY_HMAC_SECRET": "<the shared 32+ char secret>"
       }
     }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -37,6 +37,7 @@
     "@cyclonedx/cyclonedx-library": "10.1.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@skillsmith/core": "^0.11.7",
+    "@supabase/supabase-js": "2.112.2",
     "ajv-formats-draft2019": "1.6.1",
     "ulid": "3.0.1",
     "zod": "3.25.76"

--- a/packages/mcp-server/src/supabase-client.ts
+++ b/packages/mcp-server/src/supabase-client.ts
@@ -2,26 +2,63 @@
  * @fileoverview Supabase client singleton for MCP server
  * @module @skillsmith/mcp-server/tools/supabase-client
  * @see SMI-3914: Wave 0 Shared Infrastructure
+ * @see SMI-6109: env-override-with-fallback for the anon-key client paths
  *
  * @supabase/supabase-js is an optional peer dep — dynamic import.
  * Clients are lazy-initialized on first use and cached for the process lifetime.
  * Call resetSupabaseClients() in tests to clear cached instances.
  */
 
+/**
+ * Production Supabase project URL (ref `vrcnzpmndtroqxxoqkzy` — CLAUDE.md's "Project refs" table).
+ * Fallback only, for the anon-key client paths below — an explicit SUPABASE_URL env var always
+ * wins. Never used for getSupabaseAdminClient(), which stays strictly env-var-only (SMI-6109).
+ */
+const PRODUCTION_SUPABASE_URL = 'https://vrcnzpmndtroqxxoqkzy.supabase.co'
+
+/**
+ * Production Supabase anon key. Safe to ship in source — it grants only RLS-scoped access, never
+ * admin access (byte-identical to packages/core/src/api/utils.ts's PRODUCTION_ANON_KEY;
+ * duplicated rather than imported cross-package to avoid widening @skillsmith/core's public
+ * export surface for this fix — keep both in sync if this key is ever rotated).
+ */
+const PRODUCTION_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZyY256cG1uZHRyb3F4eG9xa3p5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njc4MzgwNzQsImV4cCI6MjA4MzQxNDA3NH0.WNK5jaNG3twxApOva5A1ZlCaZb5hVqBYtNJezRrR4t8'
+
+/**
+ * Resolve the Supabase URL/anon key for the anon-key client paths: an explicit env var always
+ * wins, falling back to the hardcoded production values only when unset (SMI-6109). Mirrors
+ * packages/core/src/api/utils.ts's DEFAULT_BASE_URL pattern — an explicit override (e.g.
+ * private-registry-e2e.yml's `mcp-live` leg pointing SUPABASE_URL/SUPABASE_ANON_KEY at staging)
+ * keeps working exactly as before; only a genuinely-unset var reaches the fallback.
+ *
+ * Deliberately NOT applied to isSupabaseConfigured() below: that flag also gates several unrelated
+ * tool families' own live/stub selection (sso-tools, team-workspace, compliance-tools,
+ * integration-tools, rbac-tools, team-resolver), each of which still needs real Supabase config
+ * for its own (unrelated, still service-role-backed) live path — flipping it here would silently
+ * move all of them from a working stub to a broken "live" attempt, well outside SMI-6109's scope
+ * (removing SUPABASE_SERVICE_ROLE_KEY from the *customer-facing* surface, not making every tool
+ * family Supabase-config-optional).
+ */
+function resolveSupabaseUrl(): string {
+  return process.env.SUPABASE_URL || PRODUCTION_SUPABASE_URL
+}
+
+function resolveSupabaseAnonKey(): string {
+  return process.env.SUPABASE_ANON_KEY || PRODUCTION_ANON_KEY
+}
+
 let _client: unknown = null
 let _adminClient: unknown = null
 
 /**
  * Get the Supabase anon-key client (lazy singleton).
- * Requires SUPABASE_URL and SUPABASE_ANON_KEY env vars.
+ * Uses SUPABASE_URL/SUPABASE_ANON_KEY when set, else the production defaults (SMI-6109).
  */
 export async function getSupabaseClient(): Promise<unknown> {
   if (_client) return _client
-  const url = process.env.SUPABASE_URL
-  const anonKey = process.env.SUPABASE_ANON_KEY
-  if (!url || !anonKey) {
-    throw new Error('Supabase not configured: SUPABASE_URL and SUPABASE_ANON_KEY required')
-  }
+  const url = resolveSupabaseUrl()
+  const anonKey = resolveSupabaseAnonKey()
   try {
     const { createClient } = await import('@supabase/supabase-js')
     _client = createClient(url, anonKey)
@@ -33,7 +70,8 @@ export async function getSupabaseClient(): Promise<unknown> {
 
 /**
  * Get the Supabase service-role client (lazy singleton).
- * Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY env vars.
+ * Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY env vars. No fallback (SMI-6109) — unlike
+ * the anon-key paths above, this credential must never default to a value baked into source.
  */
 export async function getSupabaseAdminClient(): Promise<unknown> {
   if (_adminClient) return _adminClient
@@ -62,14 +100,14 @@ export async function getSupabaseAdminClient(): Promise<unknown> {
  * from the token, so row-level security (e.g. `private_registry_skills_admin_update`) is the thing
  * that authorizes them, rather than app-level logic that can drift from the policy.
  *
+ * Uses SUPABASE_URL/SUPABASE_ANON_KEY when set, else the production defaults (SMI-6109) — same
+ * fallback as getSupabaseClient() above.
+ *
  * @param accessToken - a Supabase user access token (from `skillsmith login`)
  */
 export async function getSupabaseUserClient(accessToken: string): Promise<unknown> {
-  const url = process.env.SUPABASE_URL
-  const anonKey = process.env.SUPABASE_ANON_KEY
-  if (!url || !anonKey) {
-    throw new Error('Supabase not configured: SUPABASE_URL and SUPABASE_ANON_KEY required')
-  }
+  const url = resolveSupabaseUrl()
+  const anonKey = resolveSupabaseAnonKey()
   if (!accessToken) {
     throw new Error('Supabase user client requires a non-empty access token')
   }
@@ -86,7 +124,14 @@ export async function getSupabaseUserClient(accessToken: string): Promise<unknow
   }
 }
 
-/** Check if Supabase is configured (env vars present) */
+/**
+ * Check if Supabase is configured (real SUPABASE_URL + SUPABASE_ANON_KEY env vars present).
+ *
+ * Deliberately NOT affected by the anon-key fallback above (SMI-6109) — see that comment for why.
+ * Only the private registry's list/get/getNamespace calls (registry-tools.live.ts) benefit from
+ * the fallback, by calling getSupabaseClient()/getSupabaseUserClient() directly rather than
+ * gating on this flag first.
+ */
 export function isSupabaseConfigured(): boolean {
   return !!(process.env.SUPABASE_URL && process.env.SUPABASE_ANON_KEY)
 }

--- a/packages/mcp-server/src/supabase-client.ts
+++ b/packages/mcp-server/src/supabase-client.ts
@@ -128,9 +128,19 @@ export async function getSupabaseUserClient(accessToken: string): Promise<unknow
  * Check if Supabase is configured (real SUPABASE_URL + SUPABASE_ANON_KEY env vars present).
  *
  * Deliberately NOT affected by the anon-key fallback above (SMI-6109) — see that comment for why.
- * Only the private registry's list/get/getNamespace calls (registry-tools.live.ts) benefit from
- * the fallback, by calling getSupabaseClient()/getSupabaseUserClient() directly rather than
- * gating on this flag first.
+ *
+ * Cross-provider review correction (SMI-6109): this means the fallback does NOT make the private
+ * registry usable with zero Supabase config. `registry-tools.ts`'s own module-load service
+ * selection AND its `resolveTeamId()` both still gate on this exact flag, so a customer with
+ * neither `SUPABASE_URL` nor `SUPABASE_ANON_KEY` set gets the in-memory STUB service, never
+ * reaching `getMemberUserClient()`/the fallback at all — by design, so a genuinely unconfigured
+ * host still gets fast, offline-safe stub behavior instead of a live network call against a
+ * license key that was never set up. The fallback's real, narrower benefit: once a customer HAS
+ * set both vars (the expected Team/Enterprise setup — see the README), a *later* drift where one
+ * of the two is missing in some specific execution context (e.g. propagated inconsistently to an
+ * MCP subprocess) degrades gracefully instead of failing, and — matching
+ * packages/core/src/api/utils.ts's identical DEFAULT_BASE_URL pattern — the anon-key surface never
+ * needs a bespoke "not configured" error path of its own.
  */
 export function isSupabaseConfigured(): boolean {
   return !!(process.env.SUPABASE_URL && process.env.SUPABASE_ANON_KEY)

--- a/packages/mcp-server/src/tools/registry-tools.live.audit.ts
+++ b/packages/mcp-server/src/tools/registry-tools.live.audit.ts
@@ -56,16 +56,25 @@ import { readLicenseKey } from './team-resolver.js'
 /**
  * Registry operations worth an audit row.
  *
- * Metadata reads (`list`/`get`) are still deliberately not audited — they carry no file bytes.
- * `content_read` (SMI-5905 Wave 3) is: it is the operation that hands a team's packaged skill
- * content to a caller, so it gets the same coverage the mutations do. `event_type` and `action`
- * are byte-identical to what the `private-registry-get` Edge Function writes
- * (supabase/functions/private-registry-get/access.ts), so both transports land in one queryable
- * stream and neither can be audited without the other showing up in the same query.
+ * `content_read` (SMI-5905 Wave 3) hands a team's packaged skill content to a caller, so it gets
+ * the same coverage the mutations do. `event_type` and `action` are byte-identical to what the
+ * `private-registry-get` Edge Function writes (supabase/functions/private-registry-get/access.ts),
+ * so both transports land in one queryable stream and neither can be audited without the other
+ * showing up in the same query.
+ *
+ * `list`/`get`/`namespace` (SMI-6109) were previously NOT audited here — "metadata reads carry no
+ * file bytes" was true, but stopped being the whole story once these three moved off the
+ * license-key-scoped service-role client onto the signed-in user's own JWT
+ * (`getMemberUserClient()`, `registry-tools.live.ts`). That move introduces a real dual-identity-
+ * signal gap: the license key resolves one team, the signed-in user's own membership can silently
+ * point at a different one (or none), and RLS fails closed on the mismatch indistinguishably from
+ * "genuinely not found." Recording `authRole`/`actorUserId` here is what makes that mismatch
+ * observable in the audit stream rather than invisible. `submissions` remains unaudited — it is a
+ * metadata read like the pre-SMI-6109 `list`/`get` were, with no comparable identity-mismatch
+ * concern (D-5's RPC already evaluates `auth.uid()` itself).
  *
  * `approve`/`reject` (SMI-5949 Wave 2 Step 4, D-5) are the two terminal decisions
- * `review_private_registry_submission()` can write. `submissions` (the read side, D-5's other RPC)
- * is deliberately NOT here — it is a metadata read like `list`/`get`, not a mutation.
+ * `review_private_registry_submission()` can write.
  */
 export type RegistryAuditOperation =
   | 'publish'
@@ -74,6 +83,9 @@ export type RegistryAuditOperation =
   | 'content_read'
   | 'approve'
   | 'reject'
+  | 'list'
+  | 'get'
+  | 'namespace'
 
 /**
  * Which credential authorized the call.
@@ -85,7 +97,9 @@ export type RegistryAuditAuthPath = 'license_key' | 'user_jwt'
 export interface RegistryAuditEvent {
   operation: RegistryAuditOperation
   teamId: string
-  skillId: string
+  /** Omitted for team-wide operations with no single skill in scope (SMI-6109) — `list` (bulk)
+   *  and `namespace` (queries the `teams` table, not `private_registry_skills` at all). */
+  skillId?: string
   version?: string
   result: 'success' | 'denied' | 'not_found' | 'error'
   authPath: RegistryAuditAuthPath
@@ -206,9 +220,15 @@ export async function recordRegistryAudit(event: RegistryAuditEvent): Promise<vo
   try {
     const fingerprint = licenseKeyFingerprint()
     const client = (await getSupabaseAdminClient()) as AuditInsertClient
-    const resource = event.version
-      ? `private_registry_skills/${event.teamId}/${event.skillId}@${event.version}`
-      : `private_registry_skills/${event.teamId}/${event.skillId}`
+    // SMI-6109: list/namespace carry no single skillId — fall back to a team-wide (or, for
+    // namespace, teams-table) resource string rather than embedding "undefined" in it.
+    const resource = !event.skillId
+      ? event.operation === 'namespace'
+        ? `teams/${event.teamId}`
+        : `private_registry_skills/${event.teamId}`
+      : event.version
+        ? `private_registry_skills/${event.teamId}/${event.skillId}@${event.version}`
+        : `private_registry_skills/${event.teamId}/${event.skillId}`
 
     const { error } = await client.from('audit_logs').insert({
       event_type: `private_registry:${event.operation}`,
@@ -218,7 +238,7 @@ export async function recordRegistryAudit(event: RegistryAuditEvent): Promise<vo
       result: event.result,
       metadata: {
         team_id: event.teamId,
-        skill_id: event.skillId,
+        skill_id: event.skillId ?? null,
         version: event.version ?? null,
         auth_path: event.authPath,
         // Kept on BOTH paths: on the user_jwt path the key is no longer the actor, but "which key

--- a/packages/mcp-server/src/tools/registry-tools.live.audit.ts
+++ b/packages/mcp-server/src/tools/registry-tools.live.audit.ts
@@ -12,25 +12,29 @@
  * `auth.uid()` resolves to a person and `published_by` lands non-NULL. That is a deliberate
  * credential move, not an incidental one: D-6's self-approval check (`review_private_registry_
  * submission()`) can only refuse a submitter approving their own work if it can name the
- * submitter, and a shared team license key never could. `license`/`content_read` still exist as
- * distinct auth paths on OTHER private-registry operations — `list`/`get`/`getNamespace` remain
- * license-key (team-scoped, no person needed); `deprecate`/`undeprecate`/`getContent` were already
- * `user_jwt` before this change (SMI-5822/SMI-5905).
+ * submitter, and a shared team license key never could. `deprecate`/`undeprecate`/`getContent`
+ * were already `user_jwt` before that change (SMI-5822/SMI-5905), and SMI-6109 moved the last
+ * three holdouts — `list`/`get`/`getNamespace` — over as well. **As of SMI-6109 no MCP-path
+ * private-registry operation is license-key-scoped any more**: every `recordRegistryAudit()` call
+ * site in this package now passes `authPath: 'user_jwt'`. The `'license_key'` arm of
+ * `RegistryAuditAuthPath`/`resolveActor()` is kept deliberately — `audit_logs` still holds
+ * historical rows written on that path, and the type is what makes reading them unambiguous — but
+ * nothing writes it today.
  *
  * A pre-D-7 service-role publish (an old client, or any path that still presented only a license
  * key) left `published_by` NULL, and this module's job was to record what WAS known — the team,
  * plus a one-way fingerprint of which license key was presented — rather than fabricate a
- * plausible-looking actor. That reasoning still holds for every operation that remains
- * license-key-scoped; it just no longer describes `publish`. `license_keys.user_id` was never a
- * usable substitute either way: a team's resolvable key is the single row the checkout webhook
- * created for the *purchaser*, then shared with the team, so it names the buyer rather than the
- * caller.
+ * plausible-looking actor. That reasoning is what the `'license_key'` arm still exists to explain
+ * for those historical rows; it no longer describes any operation this package writes today.
+ * `license_keys.user_id` was never a usable substitute either way: a team's resolvable key is the
+ * single row the checkout webhook created for the *purchaser*, then shared with the team, so it
+ * names the buyer rather than the caller.
  *
  * Before this module existed, there were zero `audit_logs` writes on any private-registry path,
- * so an Enterprise customer asking "who published this" had no answer at all. `publish` now has
- * an exact one (a real `actorUserId`, same as `deprecate`/`undeprecate`); the license-key-scoped
- * operations still have the bounded one this module was built for: which key, which team, which
- * skill, when.
+ * so an Enterprise customer asking "who published this" had no answer at all. Every operation now
+ * has an exact one (a real `actorUserId`); historical rows written before their operation moved to
+ * the JWT path carry only the bounded answer this module was originally built for: which key,
+ * which team, which skill, when.
  *
  * ONE ACTOR PER PATH, NEVER THE WRONG ONE (cross-provider review finding #3).
  *

--- a/packages/mcp-server/src/tools/registry-tools.live.malformed-input.test.ts
+++ b/packages/mcp-server/src/tools/registry-tools.live.malformed-input.test.ts
@@ -169,10 +169,13 @@ function createRecordingClient(): { client: unknown; calls: Recorded[] } {
 /**
  * Point BOTH client factories at the same recorder.
  *
- * The service now uses two credentials (SMI-5822): service-role for reads/publish, the
- * signed-in user's JWT for deprecate/undeprecate. Wiring both to one recorder keeps every
- * `teamId` assertion below phrased in terms of what reaches the query builder, which is the
- * property this suite is about, independent of which credential carried it.
+ * As of SMI-6109, every method here runs on the signed-in user's own JWT — `list`/`get`/
+ * `getNamespace` moved off the service-role client in that wave, joining `publish` (SMI-5949) and
+ * `deprecate`/`undeprecate` (SMI-5822), which had already made the same move. Wiring both client
+ * factories to one recorder keeps every `teamId` assertion below phrased in terms of what reaches
+ * the query builder, which is the property this suite is about, independent of which credential
+ * carried it — and future-proofs this fixture against a subsequent method making the same move
+ * without needing another rewrite here.
  */
 async function mockClient(client: unknown): Promise<void> {
   const { getSupabaseAdminClient, getSupabaseUserClient } = await import('../supabase-client.js')

--- a/packages/mcp-server/src/tools/registry-tools.live.manage.test.ts
+++ b/packages/mcp-server/src/tools/registry-tools.live.manage.test.ts
@@ -11,10 +11,15 @@
  *     target another team — the service-layer half of cross-tenant isolation; the
  *     DB/RLS half is asserted in scripts/tests/private-registry-rls.test.ts);
  *   - SMI-5949 Wave 2 Step 3 (D-4 surfaces 3/4): list/get carry a mandatory
- *     approval_status='approved' in-query predicate, since service-role bypasses the RLS
- *     policy that would otherwise enforce it;
+ *     approval_status='approved' in-query predicate, since RLS does not enforce it either
+ *     (still true post-SMI-6109 — see the class doc comment below);
  *   - deprecate/undeprecate require a real representation (`.select()`) so a successful
- *     update is never misreported as not-found.
+ *     update is never misreported as not-found;
+ *   - SMI-6109: list/get/getNamespace moved off the service-role client onto the signed-in
+ *     user's own JWT (member-level, `getMemberUserClient()`) — every test below now mocks
+ *     `getSupabaseUserClient` via `mockBothClients()` (both credential getters point at one
+ *     recorder) rather than `getSupabaseAdminClient()` alone, and a new describe block covers
+ *     the not-logged-in path these three now share with `getContent`/`publish`.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
@@ -69,8 +74,7 @@ describe('private_registry_manage namespace action — SMI-5852 AC-11', () => {
     const { client } = createFakeClient({
       singleResponder: () => ({ data: { skill_namespace: 'myteam' }, error: null }),
     })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     const result = await executePrivateRegistryManage({ action: 'namespace' }, makeContext())
 
@@ -82,8 +86,7 @@ describe('private_registry_manage namespace action — SMI-5852 AC-11', () => {
     const { client } = createFakeClient({
       singleResponder: () => ({ data: null, error: { message: 'not found' } }),
     })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     const result = await executePrivateRegistryManage({ action: 'namespace' }, makeContext())
 
@@ -99,8 +102,7 @@ describe('private_registry_manage namespace action — SMI-5852 AC-11', () => {
 describe('private_registry_manage live mode — team scoping — SMI-5816', () => {
   it('list filters by the resolved team_id AND approval_status=approved (SMI-5949 D-4 surface 3)', async () => {
     const { client, calls } = createFakeClient({ thenResponder: () => ({ data: [], error: null }) })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     const result = await executePrivateRegistryManage({ action: 'list' }, makeContext())
 
@@ -117,8 +119,7 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
     const { client, calls } = createFakeClient({
       singleResponder: () => ({ data: publishedRow(), error: null }),
     })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     const result = await executePrivateRegistryManage(
       { action: 'get', skillId: 'myteam/skill-a', version: '1.0.0' },
@@ -142,8 +143,7 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
     const { client, calls } = createFakeClient({
       thenResponder: () => ({ data: [publishedRow()], error: null }),
     })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     const result = await executePrivateRegistryManage(
       { action: 'get', skillId: 'myteam/skill-a' },
@@ -221,8 +221,7 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
         error: { code: '08006', message: 'connection failure' },
       }),
     })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     const result = await executePrivateRegistryManage(
       { action: 'get', skillId: 'myteam/skill-a', version: '1.0.0' },
@@ -242,8 +241,7 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
 
   it('list filters by deprecated=false by default (SMI-5949 Wave 3)', async () => {
     const { client, calls } = createFakeClient({ thenResponder: () => ({ data: [], error: null }) })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     const result = await executePrivateRegistryManage({ action: 'list' }, makeContext())
 
@@ -254,8 +252,7 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
 
   it('list with includeDeprecated:true skips the deprecated predicate (SMI-5949 Wave 3)', async () => {
     const { client, calls } = createFakeClient({ thenResponder: () => ({ data: [], error: null }) })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     const result = await executePrivateRegistryManage(
       { action: 'list', includeDeprecated: true },
@@ -269,8 +266,7 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
 
   it('list with includeDeprecated:false still filters deprecated=false (explicit false is the same as omitted)', async () => {
     const { client, calls } = createFakeClient({ thenResponder: () => ({ data: [], error: null }) })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     const result = await executePrivateRegistryManage(
       { action: 'list', includeDeprecated: false },
@@ -286,8 +282,7 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
     const { client, calls } = createFakeClient({
       singleResponder: () => ({ data: publishedRow(), error: null }),
     })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     // `get` has no `includeDeprecated` field at all — passing extra input is not possible through
     // the typed handler, so this asserts the predicate is present unconditionally.
@@ -305,8 +300,7 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
     const { client, calls } = createFakeClient({
       thenResponder: () => ({ data: [publishedRow()], error: null }),
     })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     const result = await executePrivateRegistryManage(
       { action: 'get', skillId: 'myteam/skill-a' },
@@ -328,8 +322,7 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
         },
       }),
     })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
-    vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    await mockBothClients(client)
 
     const result = await executePrivateRegistryManage(
       { action: 'get', skillId: 'myteam/ghost', version: '1.0.0' },
@@ -338,5 +331,62 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
 
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/not found/i)
+  })
+})
+
+// ============================================================================
+// SMI-6109: list/get/getNamespace now require a signed-in user (member-level), not just a
+// license key — mirrors registry-tools.live.admin-auth.test.ts's pattern for the admin-gated
+// deprecate/undeprecate pair.
+// ============================================================================
+
+describe('private_registry_manage live mode — SMI-6109 member-credential requirement', () => {
+  it('list refuses — and issues no query — when no user is signed in', async () => {
+    const { resolveUserAccessToken } = await import('./team-resolver.js')
+    vi.mocked(resolveUserAccessToken).mockResolvedValueOnce(null)
+    const { client, calls } = createFakeClient()
+    await mockBothClients(client)
+
+    const result = await executePrivateRegistryManage({ action: 'list' }, makeContext())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/skillsmith login/i)
+    // Any team member may list — this is not an admin-only error.
+    expect(result.error).not.toMatch(/only team admins/i)
+    expect(calls.find((c) => c.table === 'private_registry_skills')).toBeUndefined()
+  })
+
+  it('get refuses — and issues no query — when no user is signed in', async () => {
+    const { resolveUserAccessToken } = await import('./team-resolver.js')
+    vi.mocked(resolveUserAccessToken).mockResolvedValueOnce(null)
+    const { client, calls } = createFakeClient()
+    await mockBothClients(client)
+
+    const result = await executePrivateRegistryManage(
+      { action: 'get', skillId: 'myteam/skill-a' },
+      makeContext()
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/skillsmith login/i)
+    expect(calls.find((c) => c.table === 'private_registry_skills')).toBeUndefined()
+  })
+
+  // getNamespace's documented contract (registry-tools.ts's PrivateRegistryService interface) is
+  // "or null if it could not be resolved" — it never throws, unlike list/get above, so a
+  // not-logged-in caller sees the same typed {success:false} response as any other unresolvable
+  // namespace, not a distinguishable "please log in" error. See
+  // registry-tools.live.member-reads.ts's header comment for why this asymmetry is deliberate.
+  it('namespace resolves to "unable to resolve", not a login error, when no user is signed in', async () => {
+    const { resolveUserAccessToken } = await import('./team-resolver.js')
+    vi.mocked(resolveUserAccessToken).mockResolvedValueOnce(null)
+    const { client, calls } = createFakeClient()
+    await mockBothClients(client)
+
+    const result = await executePrivateRegistryManage({ action: 'namespace' }, makeContext())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/unable to resolve/i)
+    expect(calls.find((c) => c.table === 'teams')).toBeUndefined()
   })
 })

--- a/packages/mcp-server/src/tools/registry-tools.live.manage.test.ts
+++ b/packages/mcp-server/src/tools/registry-tools.live.manage.test.ts
@@ -82,9 +82,11 @@ describe('private_registry_manage namespace action — SMI-5852 AC-11', () => {
     expect(result.namespace).toBe('myteam')
   })
 
-  it('surfaces a typed error when the namespace cannot be resolved', async () => {
-    const { client } = createFakeClient({
-      singleResponder: () => ({ data: null, error: { message: 'not found' } }),
+  it('surfaces a typed error when the namespace cannot be resolved, and audits a genuine query error as error (not success)', async () => {
+    const { client, calls } = createFakeClient({
+      // No `code` field, so this is NOT PGRST116 (genuine no-rows) — a real query failure
+      // (e.g. connection error, RLS denial surfaced as an error), not "no namespace configured".
+      singleResponder: () => ({ data: null, error: { message: 'connection failure' } }),
     })
     await mockBothClients(client)
 
@@ -92,6 +94,13 @@ describe('private_registry_manage namespace action — SMI-5852 AC-11', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/unable to resolve/i)
+
+    // Cross-provider review finding (SMI-6109): the original draft collapsed this into `null` and
+    // audited it as 'success' — a real outage reported as a successful read, in a log whose whole
+    // purpose is security observability.
+    const auditInsert = calls.find((c) => c.table === 'audit_logs')
+    expect(auditInsert).toBeDefined()
+    expect(auditInsert!.payload?.result).toBe('error')
   })
 })
 
@@ -312,8 +321,8 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
     expect(q!.filters.some((f) => f.column === 'deprecated' && f.value === false)).toBe(true)
   })
 
-  it('get returns null (not-found) for PostgREST’s genuine no-rows code', async () => {
-    const { client } = createFakeClient({
+  it('get returns null (not-found) for PostgREST’s genuine no-rows code, and audits it as not_found (not success)', async () => {
+    const { client, calls } = createFakeClient({
       singleResponder: () => ({
         data: null,
         error: {
@@ -328,6 +337,12 @@ describe('private_registry_manage live mode — team scoping — SMI-5816', () =
       { action: 'get', skillId: 'myteam/ghost', version: '1.0.0' },
       makeContext()
     )
+
+    // Cross-provider review finding (SMI-6109): a not-found get() was previously audited as
+    // 'success', which is misleading in a log whose purpose is security observability.
+    const auditInsert = calls.find((c) => c.table === 'audit_logs')
+    expect(auditInsert).toBeDefined()
+    expect(auditInsert!.payload?.result).toBe('not_found')
 
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/not found/i)
@@ -374,10 +389,13 @@ describe('private_registry_manage live mode — SMI-6109 member-credential requi
 
   // getNamespace's documented contract (registry-tools.ts's PrivateRegistryService interface) is
   // "or null if it could not be resolved" — it never throws, unlike list/get above, so a
-  // not-logged-in caller sees the same typed {success:false} response as any other unresolvable
-  // namespace, not a distinguishable "please log in" error. See
-  // registry-tools.live.member-reads.ts's header comment for why this asymmetry is deliberate.
-  it('namespace resolves to "unable to resolve", not a login error, when no user is signed in', async () => {
+  // not-logged-in caller cannot get the same loud, distinguishable "run skillsmith login" error
+  // list/get surface. Cross-provider review (SMI-6109) flagged the resulting UX gap: the generic
+  // "unable to resolve" message the caller CAN get is now required to at least hint at login
+  // (registry-tools.ts's namespace handler), a partial fix that keeps getNamespace()'s own
+  // never-throws contract intact. See registry-tools.live.member-reads.ts's header comment for
+  // why that contract itself is deliberate.
+  it('namespace resolves to an "unable to resolve" message that hints at login, when no user is signed in', async () => {
     const { resolveUserAccessToken } = await import('./team-resolver.js')
     vi.mocked(resolveUserAccessToken).mockResolvedValueOnce(null)
     const { client, calls } = createFakeClient()
@@ -387,6 +405,7 @@ describe('private_registry_manage live mode — SMI-6109 member-credential requi
 
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/unable to resolve/i)
+    expect(result.error).toMatch(/skillsmith login/i)
     expect(calls.find((c) => c.table === 'teams')).toBeUndefined()
   })
 })

--- a/packages/mcp-server/src/tools/registry-tools.live.member-reads.ts
+++ b/packages/mcp-server/src/tools/registry-tools.live.member-reads.ts
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview Audited, member-JWT-authenticated wrappers for list()/get()/getNamespace()
+ * @module @skillsmith/mcp-server/tools/registry-tools.live.member-reads
+ * @see SMI-6109: moved these three off the Supabase service-role client
+ *
+ * Split out of registry-tools.live.ts (580/500 lines after the SMI-6109 credential move) — the
+ * established `.live.auth.ts`/`.live.audit.ts`/`.live.content.ts`/`.live.submissions.ts`
+ * companion-module convention. Each function here: binds the signed-in user's own JWT via
+ * getMemberUserClient() (registry-tools.live.auth.ts — MEMBER, not admin: any team member may
+ * list/get/discover-namespace), runs the actual query (listSkills()/getSkill() from
+ * registry-tools.live.reads.ts for the first two; getNamespace's own inline `teams` table query,
+ * which belongs here rather than in reads.ts since that file is scoped to
+ * `private_registry_skills` predicates specifically, not `teams`), and records a
+ * recordRegistryAudit() row (registry-tools.live.audit.ts) so the license-key-team-vs-signed-in-
+ * user dual-identity-signal gap this credential move introduces is observable rather than
+ * invisible: the license key resolves one team, the signed-in user's own membership can silently
+ * point at a different one (or none), and RLS fails closed on the mismatch indistinguishably from
+ * "genuinely not found."
+ *
+ * getNamespace()'s wrapper deliberately swallows a getMemberUserClient() failure and returns null
+ * rather than throwing — its documented contract (registry-tools.ts's PrivateRegistryService
+ * interface) is "or null if it could not be resolved," and two callers (the
+ * manage(action:'namespace') handler, and the publish namespace pre-check) depend on that
+ * never-throws contract staying true. list()/get() have no such contract and throw normally on
+ * failure — registry-tools.ts's dispatcher already wraps every service call to convert a thrown
+ * error into a typed {success:false} result (see its own comment there: "Wrap service calls so
+ * live-mode errors ... surface as typed results instead of propagating as unhandled exceptions"),
+ * the same path `deprecate`/`undeprecate`/`getContent`/`publish` already rely on.
+ */
+
+import { recordRegistryAudit } from './registry-tools.live.audit.js'
+import { getMemberUserClient } from './registry-tools.live.auth.js'
+import { listSkills, getSkill } from './registry-tools.live.reads.js'
+import type { RegistrySkill } from './registry-tools.js'
+
+/** D-4 surface 3 + SMI-5949 Wave 3 (deprecated read-filter closure) + SMI-6109 (this file). */
+export async function auditedList(
+  teamId: string,
+  version?: string,
+  includeDeprecated?: boolean
+): Promise<RegistrySkill[]> {
+  let actorUserId: string | null = null
+  try {
+    const { client, actorUserId: uid } = await getMemberUserClient('list')
+    actorUserId = uid
+    const skills = await listSkills(client, teamId, version, includeDeprecated)
+    await recordRegistryAudit({
+      operation: 'list',
+      teamId,
+      result: 'success',
+      authPath: 'user_jwt',
+      authRole: 'member',
+      actorUserId,
+    })
+    return skills
+  } catch (err) {
+    await recordRegistryAudit({
+      operation: 'list',
+      teamId,
+      result: 'error',
+      authPath: 'user_jwt',
+      authRole: 'member',
+      actorUserId,
+      detail: err instanceof Error ? err.message : 'unknown error',
+    })
+    throw err
+  }
+}
+
+/**
+ * D-4 surface 4 + SMI-5949 Wave 3 + SMI-6109 (this file) — see registry-tools.live.reads.ts's
+ * getSkill() for why this one carries no includeDeprecated opt-in, unlike auditedList() above.
+ */
+export async function auditedGet(
+  teamId: string,
+  skillId: string,
+  version?: string
+): Promise<RegistrySkill | null> {
+  let actorUserId: string | null = null
+  try {
+    const { client, actorUserId: uid } = await getMemberUserClient('get')
+    actorUserId = uid
+    const skill = await getSkill(client, teamId, skillId, version)
+    await recordRegistryAudit({
+      operation: 'get',
+      teamId,
+      skillId,
+      version,
+      result: 'success',
+      authPath: 'user_jwt',
+      authRole: 'member',
+      actorUserId,
+    })
+    return skill
+  } catch (err) {
+    await recordRegistryAudit({
+      operation: 'get',
+      teamId,
+      skillId,
+      version,
+      result: 'error',
+      authPath: 'user_jwt',
+      authRole: 'member',
+      actorUserId,
+      detail: err instanceof Error ? err.message : 'unknown error',
+    })
+    throw err
+  }
+}
+
+/** SMI-6109. Never throws — see this file's header comment for why. */
+export async function auditedGetNamespace(teamId: string): Promise<string | null> {
+  let actorUserId: string | null = null
+  try {
+    const { client, actorUserId: uid } = await getMemberUserClient('namespace')
+    actorUserId = uid
+    const resp = await client
+      .from<{ skill_namespace: string }>('teams')
+      .select('skill_namespace')
+      .eq('id', teamId)
+      .single()
+    const namespace = resp.error || !resp.data ? null : (resp.data.skill_namespace ?? null)
+    await recordRegistryAudit({
+      operation: 'namespace',
+      teamId,
+      result: 'success',
+      authPath: 'user_jwt',
+      authRole: 'member',
+      actorUserId,
+    })
+    return namespace
+  } catch (err) {
+    await recordRegistryAudit({
+      operation: 'namespace',
+      teamId,
+      result: 'error',
+      authPath: 'user_jwt',
+      authRole: 'member',
+      actorUserId,
+      detail: err instanceof Error ? err.message : 'unknown error',
+    })
+    return null
+  }
+}

--- a/packages/mcp-server/src/tools/registry-tools.live.member-reads.ts
+++ b/packages/mcp-server/src/tools/registry-tools.live.member-reads.ts
@@ -33,6 +33,17 @@ import { getMemberUserClient } from './registry-tools.live.auth.js'
 import { listSkills, getSkill } from './registry-tools.live.reads.js'
 import type { RegistrySkill } from './registry-tools.js'
 
+/**
+ * PostgREST's code for "no rows" (or >1 row) via `.single()` — a real absence, not a failure.
+ * Duplicated from registry-tools.live.ts's/registry-tools.live.reads.ts's own copies (same
+ * convention — see reads.ts's header for why this isn't a shared import) — only
+ * auditedGetNamespace() below needs it, to distinguish a genuine "no namespace configured" from a
+ * real query failure when auditing (cross-provider review finding, SMI-6109).
+ */
+function isNoRowsError(error: { code?: string } | null): boolean {
+  return error?.code === 'PGRST116'
+}
+
 /** D-4 surface 3 + SMI-5949 Wave 3 (deprecated read-filter closure) + SMI-6109 (this file). */
 export async function auditedList(
   teamId: string,
@@ -81,12 +92,15 @@ export async function auditedGet(
     const { client, actorUserId: uid } = await getMemberUserClient('get')
     actorUserId = uid
     const skill = await getSkill(client, teamId, skillId, version)
+    // Cross-provider review finding (SMI-6109): a null (genuinely not found / cross-team /
+    // pending-and-RLS-invisible) result was previously audited as 'success', which is misleading
+    // for a security-observability log — 'not_found' is an available, more accurate result value.
     await recordRegistryAudit({
       operation: 'get',
       teamId,
       skillId,
       version,
-      result: 'success',
+      result: skill ? 'success' : 'not_found',
       authPath: 'user_jwt',
       authRole: 'member',
       actorUserId,
@@ -119,11 +133,29 @@ export async function auditedGetNamespace(teamId: string): Promise<string | null
       .select('skill_namespace')
       .eq('id', teamId)
       .single()
+    // Cross-provider review finding (SMI-6109): the original draft collapsed EVERY resp.error —
+    // a genuine "no such team" (PGRST116) AND a real outage/RLS-denial — into `null` and then
+    // audited it as 'success'. That misreports an outage or a denial as a successful read in a
+    // log whose whole purpose is security observability. Only a genuine no-rows error is
+    // "success, no namespace" territory; anything else is a real error and must be audited (and
+    // returned) as such — matching this file's own not-found/error distinction on auditedGet().
+    if (resp.error && !isNoRowsError(resp.error)) {
+      await recordRegistryAudit({
+        operation: 'namespace',
+        teamId,
+        result: 'error',
+        authPath: 'user_jwt',
+        authRole: 'member',
+        actorUserId,
+        detail: resp.error.code ?? 'query_error',
+      })
+      return null
+    }
     const namespace = resp.error || !resp.data ? null : (resp.data.skill_namespace ?? null)
     await recordRegistryAudit({
       operation: 'namespace',
       teamId,
-      result: 'success',
+      result: namespace ? 'success' : 'not_found',
       authPath: 'user_jwt',
       authRole: 'member',
       actorUserId,

--- a/packages/mcp-server/src/tools/registry-tools.live.test.ts
+++ b/packages/mcp-server/src/tools/registry-tools.live.test.ts
@@ -152,8 +152,14 @@ describe('private_registry_publish live mode — SMI-5816', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/2 MB|limit/i)
-    // Size guard runs before any insert.
-    expect(calls.find((c) => c.op === 'insert')).toBeUndefined()
+    // Size guard runs before any skill-row insert. Scoped to `private_registry_skills`
+    // specifically (not "any insert") since SMI-6109: the namespace pre-check's getNamespace()
+    // call still runs first regardless of the eventual size-cap rejection, and — with no
+    // getSupabaseUserClient mock configured in this test — fails internally and records its own
+    // (unrelated, expected) `audit_logs` insert via the fail-soft recordRegistryAudit() path.
+    expect(
+      calls.find((c) => c.op === 'insert' && c.table === 'private_registry_skills')
+    ).toBeUndefined()
   })
 
   it('rejects content missing a SKILL.md entry', async () => {
@@ -195,7 +201,14 @@ describe('private_registry_publish live mode — SMI-5816', () => {
 
   it('publish fails with an actionable error, and writes nothing, when no user is signed in (D-7)', async () => {
     const { resolveUserAccessToken } = await import('./team-resolver.js')
-    vi.mocked(resolveUserAccessToken).mockResolvedValueOnce(null)
+    // SMI-6109: the namespace pre-check (registry-tools.ts) now calls getNamespace(), which itself
+    // resolves a user token before publish() gets its own turn. A genuinely-not-signed-in caller
+    // has no token for EITHER call, so both of this test's two calls need to see null — queuing
+    // two `Once` responses (not a persistent mockResolvedValue(null), which would outlive this
+    // test: vi.clearAllMocks() in afterEach clears call history, not a configured implementation,
+    // so a persistent override here would silently leak "not logged in" into every later test in
+    // this file).
+    vi.mocked(resolveUserAccessToken).mockResolvedValueOnce(null).mockResolvedValueOnce(null)
     const { client } = createFakeClient()
     const { getSupabaseAdminClient, getSupabaseUserClient } = await import('../supabase-client.js')
     vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
@@ -225,8 +238,12 @@ describe('private_registry_publish namespace pre-check — SMI-5852', () => {
     const { client, calls } = createFakeClient({
       singleResponder: () => ({ data: { skill_namespace: 'myteam' }, error: null }),
     })
-    const { getSupabaseAdminClient } = await import('../supabase-client.js')
+    // SMI-6109: the pre-check's getNamespace() call now runs on the signed-in user's own JWT
+    // (getMemberUserClient), not the service-role client — both getters need mocking now, matching
+    // this describe block's other two tests below.
+    const { getSupabaseAdminClient, getSupabaseUserClient } = await import('../supabase-client.js')
     vi.mocked(getSupabaseAdminClient).mockResolvedValue(client)
+    vi.mocked(getSupabaseUserClient).mockResolvedValue(client)
 
     const result = await executePrivateRegistryPublish(
       { skillId: 'anthropic/commit', version: '1.0.0', content: SAMPLE_CONTENT },
@@ -235,8 +252,13 @@ describe('private_registry_publish namespace pre-check — SMI-5852', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/myteam/)
-    // The UX pre-check short-circuits — the DB trigger never needs to reject it.
-    expect(calls.find((c) => c.op === 'insert')).toBeUndefined()
+    // The UX pre-check short-circuits — the DB trigger never needs to reject it. Scoped to
+    // `private_registry_skills` specifically (not "any insert"): SMI-6109 added audit logging to
+    // getNamespace() itself, so a successful pre-check now legitimately writes one `audit_logs`
+    // row (recordRegistryAudit, fail-soft) even though the skill row is never inserted.
+    expect(
+      calls.find((c) => c.op === 'insert' && c.table === 'private_registry_skills')
+    ).toBeUndefined()
   })
 
   it('includes the team namespace on a successful publish (AC-11)', async () => {

--- a/packages/mcp-server/src/tools/registry-tools.live.ts
+++ b/packages/mcp-server/src/tools/registry-tools.live.ts
@@ -3,73 +3,94 @@
  * @module @skillsmith/mcp-server/tools/registry-tools.live
  * @see SMI-5816: Private skill registry — real implementation
  * @see ADR-129: Postgres-native (JSONB) storage, real team-auth (migration 071)
- * @see ADR-116: MCP service-role client + explicit tenant filter
+ * @see ADR-116: MCP service-role client + explicit tenant filter — SUPERSEDED for this file's
+ *   team-scoped reads by SMI-6109 (see the addendum in docs/internal/adr/116-*.md). Still current
+ *   for `team-workspace.live.ts`, deliberately not touched by that change.
  *
  * Backs `private_registry_publish` / `private_registry_manage` with the real
  * `private_registry_skills` table (migration 20260724000000).
  *
- * THREE CREDENTIALS, FOUR PATHS (SMI-5822 fix, SMI-5882 Wave 3; `getContent` added SMI-5905
- * Wave 3; `publish` moved off service-role SMI-5949 Wave 2 Step 2, D-7):
+ * TWO CREDENTIALS, EVERY PATH ON A REAL PERSON (SMI-5822 fix, SMI-5882 Wave 3; `getContent` added
+ * SMI-5905 Wave 3; `publish` moved off service-role SMI-5949 Wave 2 Step 2, D-7; `list`/`get`/
+ * `getNamespace` moved off service-role SMI-6109):
  *
- * - **Team-scoped reads** (`list`, `get`, `getNamespace`) use the Supabase service-role client.
- *   Service-role bypasses RLS, so **tenant isolation is enforced here**, in-query, via an explicit
- *   `team_id = <resolved>` filter on every request (ADR-116). `teamId` always comes from
- *   `resolve_team_from_license` — never from tool input — so a caller can only ever touch their
- *   own team's rows. This is correct for these operations: the team's license key genuinely
- *   authorizes team-scoped reads, which RLS also grants to any member (`_member_read`). `list`/
- *   `get` also carry a second mandatory in-query predicate, `approval_status = 'approved'`
- *   (SMI-5949 D-4 surfaces 3/4) — service-role bypasses the RLS policy that would otherwise
- *   enforce this, so it must be explicit here, under the same already-documented invariant as the
- *   `team_id` filter. Since SMI-5949 Wave 3, both also carry a third predicate, `deprecated =
- *   FALSE` — a gap the approval-gate work surfaced (`deprecated` was documented as hiding a skill
- *   but no read path enforced it); `list` gains an explicit `includeDeprecated` opt-in, `get` does
- *   not. The actual query logic for both lives in `registry-tools.live.reads.ts`.
+ * - **Member-level operations** (`list`, `get`, `getNamespace`, `getContent`, `publish`,
+ *   `submissions`, `approve`/`reject`) run through the signed-in user's own Supabase JWT
+ *   (`getMemberUserClient()`, `registry-tools.live.auth.ts`) — `skillsmith login`, not the shared
+ *   team license key. `teamId` still always comes from `resolve_team_from_license` (never from
+ *   tool input), and `list`/`get` still carry the same explicit, mandatory `team_id` /
+ *   `approval_status = 'approved'` / `deprecated = FALSE` in-query predicates as before (ADR-116's
+ *   tenant-isolation invariant — RLS does not enforce `approval_status`/`deprecated` at all, so
+ *   dropping these predicates would silently widen what a signed-in member can read, not just
+ *   change which credential reads it). Query logic for `list`/`get` lives in
+ *   `registry-tools.live.reads.ts`.
  *
- * - **Admin-level writes** (`deprecate`, `undeprecate`) do NOT use service-role. They run through
- *   the signed-in user's own Supabase JWT (`skillsmith login`, SMI-4402), so PostgREST evaluates
+ *   SMI-6109: before this change, `list`/`get`/`getNamespace` ran on the Supabase service-role
+ *   client — the single most powerful credential in the backend, required as
+ *   `SUPABASE_SERVICE_ROLE_KEY` on every MCP host that used these tools. The published
+ *   `@skillsmith/mcp-server` README instructed real customers to configure exactly that key on
+ *   their own machines, in an open-core repo whose source (including this file) is public — a
+ *   documented, live threat vector, not a hypothetical. These three are member-level reads (any
+ *   team member may run them), not admin-level, so `getMemberUserClient()` is the correct getter
+ *   — never `getAdminUserClient()`. A license-key-team-vs-logged-in-user-membership mismatch is a
+ *   real, pre-existing dual-identity-signal gap this move inherits (the license key resolves one
+ *   team; the signed-in user's own membership can silently point at a different one, or none) —
+ *   RLS fails closed on the mismatch indistinguishably from "genuinely not found," and the
+ *   `recordRegistryAudit()` calls added to all three make that mismatch observable rather than
+ *   invisible (`registry-tools.live.audit.ts`). Reconciling the two identity signals directly is a
+ *   separate, broader design question, tracked as a follow-up, not fixed here.
+ *
+ * - **Admin-level writes** (`deprecate`, `undeprecate`) also run through the signed-in user's own
+ *   Supabase JWT (`getAdminUserClient()`), so PostgREST evaluates
  *   `private_registry_skills_admin_update` with a real `auth.uid()` and the database — not this
  *   file — decides whether the caller is a team admin.
  *
- *   Why the change: a team's license key is shared, and `resolve_team_from_license` is
- *   `(p_license_key TEXT) RETURNS TEXT` — it resolves a *team*, never a *person*. Running these
- *   two operations as service-role therefore made the shared key an effective admin credential:
- *   SMI-5882's staging run proved the asymmetry directly (a team *member* reaches 0 rows over the
- *   authenticated path, while the identical UPDATE as service-role deprecated 2 rows). Re-checking
- *   the role in application code was rejected as the fix — it would duplicate a policy that
- *   already exists and can silently drift from it. Letting the existing, proven policy do the work
- *   cannot drift.
+ *   Why the change (pre-dates SMI-6109): a team's license key is shared, and
+ *   `resolve_team_from_license` is `(p_license_key TEXT) RETURNS TEXT` — it resolves a *team*,
+ *   never a *person*. Running these two operations as service-role therefore made the shared key
+ *   an effective admin credential: SMI-5882's staging run proved the asymmetry directly (a team
+ *   *member* reaches 0 rows over the authenticated path, while the identical UPDATE as
+ *   service-role deprecated 2 rows). Re-checking the role in application code was rejected as the
+ *   fix — it would duplicate a policy that already exists and can silently drift from it. Letting
+ *   the existing, proven policy do the work cannot drift.
  *
- *   Cost, stated plainly: deprecate/undeprecate now require `skillsmith login` in addition to
- *   SKILLSMITH_LICENSE_KEY (or SKILLSMITH_API_KEY, SMI-6080), and surface an actionable error
- *   when no user credential is present.
+ *   Cost, stated plainly: deprecate/undeprecate (and, since SMI-6109, list/get/getNamespace too)
+ *   require `skillsmith login` in addition to SKILLSMITH_LICENSE_KEY (or SKILLSMITH_API_KEY,
+ *   SMI-6080), and surface an actionable error when no user credential is present.
  *
- * - **Content reads** (`getContent`, SMI-5905 Wave 3) are a third path: the signed-in user's own
- *   JWT (so `_member_read` decides visibility against a real `auth.uid()`), but MEMBER-level, not
- *   admin. `getAdminUserClient()` / `getMemberUserClient()` (`registry-tools.live.auth.ts`) are two
- *   explicitly-named getters for exactly this reason — the choice cannot be defaulted or omitted at
- *   a call site. What decides whether a content read is *entitled* is in
+ * - **Content reads** (`getContent`, SMI-5905 Wave 3) are member-level like the operations above:
+ *   the signed-in user's own JWT (so `_member_read` decides visibility against a real
+ *   `auth.uid()`). `getAdminUserClient()` / `getMemberUserClient()` (`registry-tools.live.auth.ts`)
+ *   are two explicitly-named getters for exactly this reason — the choice cannot be defaulted or
+ *   omitted at a call site. What decides whether a content read is *entitled* is in
  *   `registry-tools.live.content.ts`, and is scoped to the row's own team, not the caller's tier.
  *
- * - **`publish`** (SMI-5949 Wave 2 Step 2, D-7) is the fourth path, and MEMBER-level like
- *   `getContent` — not admin: any team member may submit a version, not only admins.
- *   `published_by` is `DEFAULT auth.uid()` (migration 20260729000000), which stays NULL on the
- *   service-role path this method used before — and an unconditional BEFORE INSERT trigger (Wave
- *   1) now hard-rejects a NULL `published_by`, so a service-role publish fails outright. Beyond
- *   that trigger, a real submitter identity is also the prerequisite for D-6's self-approval
- *   check: `review_private_registry_submission()` can only refuse a submitter approving their own
- *   work if it can name the submitter, and a shared license key never can. Two consequences the
- *   D-4 RLS gate forces on this method specifically (a `pending` row is invisible even to its own
- *   submitter): the INSERT can no longer request a representation (`.select()`/`RETURNING`) — see
- *   the empirically-confirmed D-4(a) note on `publish()` below — and the freshly-published row is
- *   read back through the metadata-only `get_private_registry_submissions` RPC (D-5) instead.
+ * - **`publish`** (SMI-5949 Wave 2 Step 2, D-7) is member-level like `getContent` — not admin: any
+ *   team member may submit a version, not only admins. `published_by` is `DEFAULT auth.uid()`
+ *   (migration 20260729000000), which stays NULL on the service-role path this method used before
+ *   — and an unconditional BEFORE INSERT trigger (Wave 1) now hard-rejects a NULL `published_by`,
+ *   so a service-role publish fails outright. Beyond that trigger, a real submitter identity is
+ *   also the prerequisite for D-6's self-approval check: `review_private_registry_submission()`
+ *   can only refuse a submitter approving their own work if it can name the submitter, and a
+ *   shared license key never can. Two consequences the D-4 RLS gate forces on this method
+ *   specifically (a `pending` row is invisible even to its own submitter): the INSERT can no
+ *   longer request a representation (`.select()`/`RETURNING`) — see the empirically-confirmed
+ *   D-4(a) note on `publish()` below — and the freshly-published row is read back through the
+ *   metadata-only `get_private_registry_submissions` RPC (D-5) instead.
  *
  * Single-phase write: metadata + content land in one INSERT (ADR-129) — no two-phase
  * Supabase+S3 write/rollback. Published (team_id, skill_id, version) triples are
  * immutable; a re-publish raises a unique violation surfaced as a clear error.
+ *
+ * NOT touched by SMI-6109, deliberately (see docs/internal/implementation, SMI-6109 plan,
+ * "Explicitly out of scope"): `team-workspace.live.ts`'s identical service-role pattern across 8
+ * methods (writes, not just reads, with no existing member-client precedent to reuse);
+ * `registry-tools.live.audit.ts`'s own audit-log write path (a system-table insert, fail-soft,
+ * structurally different from a tenant-data read); `SKILLSMITH_API_KEY_HMAC_SECRET`'s
+ * distribution (an unrelated secret, not consumed by any Supabase call).
  */
 
 import { sha256Hex } from '@skillsmith/core'
-import { getSupabaseAdminClient } from '../supabase-client.js'
 import { recordRegistryAudit } from './registry-tools.live.audit.js'
 import { getAdminUserClient, getMemberUserClient } from './registry-tools.live.auth.js'
 import {
@@ -78,7 +99,7 @@ import {
   type RegistrySkillContent,
 } from './registry-tools.content.types.js'
 import { getSkillContent } from './registry-tools.live.content.js'
-import { listSkills, getSkill } from './registry-tools.live.reads.js'
+import { auditedList, auditedGet, auditedGetNamespace } from './registry-tools.live.member-reads.js'
 import {
   mapSubmissionRow,
   readBackSubmission,
@@ -157,22 +178,6 @@ function isUniqueViolation(error: SupabaseError | null): boolean {
   if (error.code === '23505') return true
   const haystack = `${error.message ?? ''} ${error.details ?? ''}`.toLowerCase()
   return haystack.includes('duplicate key') || haystack.includes('unique constraint')
-}
-
-/**
- * Get the Supabase service-role client. Throws a typed error if
- * SUPABASE_SERVICE_ROLE_KEY is not configured on the MCP host — handlers surface
- * this to the caller instead of leaking a 42501.
- */
-async function getClient(): Promise<MinimalSupabaseClient> {
-  try {
-    return (await getSupabaseAdminClient()) as MinimalSupabaseClient
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'unknown error'
-    throw new Error(
-      `Private registry operations require SUPABASE_SERVICE_ROLE_KEY on the MCP host: ${message}`
-    )
-  }
 }
 
 /**
@@ -318,8 +323,10 @@ function prepareContent(content: SkillContent): { contentHash: string } {
 /**
  * Create a live Supabase-backed PrivateRegistryService.
  *
- * Every DB call explicitly filters by `team_id = <resolved teamId>`. Service-role
- * bypasses RLS — tenant isolation lives here, not in the database (ADR-116).
+ * Every DB call explicitly filters by `team_id = <resolved teamId>`. `list`/`get`/`getNamespace`
+ * run on the signed-in user's own JWT (SMI-6109) — RLS is the real authorization boundary, but the
+ * explicit `team_id`/`approval_status`/`deprecated` predicates stay, since RLS does not enforce
+ * the latter two at all (ADR-116's invariant, still load-bearing after the credential change).
  */
 export function createLiveRegistryService(): PrivateRegistryService {
   return {
@@ -421,18 +428,16 @@ export function createLiveRegistryService(): PrivateRegistryService {
       return mapSubmissionRow(teamId, submission)
     },
 
-    // D-4 surface 3 + SMI-5949 Wave 3 (deprecated read-filter closure). Query logic lives in
-    // registry-tools.live.reads.ts (this file's own 500-line audit:standards budget).
+    // D-4 surface 3 + SMI-5949 Wave 3 (deprecated read-filter closure) + SMI-6109 (moved off
+    // service-role onto the signed-in user's own JWT). Implementation, audit logging, and the
+    // never-throws-vs-throws contract rationale live in registry-tools.live.member-reads.ts (this
+    // file's own 500-line budget) — see that file's header comment.
     async list(teamId, version, includeDeprecated): Promise<RegistrySkill[]> {
-      const client = await getClient()
-      return listSkills(client, teamId, version, includeDeprecated)
+      return auditedList(teamId, version, includeDeprecated)
     },
 
-    // D-4 surface 4 + SMI-5949 Wave 3 — see registry-tools.live.reads.ts's getSkill() for why this
-    // one carries no includeDeprecated opt-in, unlike list() above.
     async get(teamId, skillId, version): Promise<RegistrySkill | null> {
-      const client = await getClient()
-      return getSkill(client, teamId, skillId, version)
+      return auditedGet(teamId, skillId, version)
     },
 
     // SMI-5905 Wave 3. MEMBER getter — never getAdminUserClient(): reading a skill you may
@@ -456,15 +461,10 @@ export function createLiveRegistryService(): PrivateRegistryService {
       return setDeprecated(teamId, skillId, true)
     },
 
+    // SMI-6109: moved off service-role — see registry-tools.live.member-reads.ts for the
+    // implementation and why this one never throws, unlike list()/get() above.
     async getNamespace(teamId): Promise<string | null> {
-      const client = await getClient()
-      const resp = await client
-        .from<{ skill_namespace: string }>('teams')
-        .select('skill_namespace')
-        .eq('id', teamId)
-        .single()
-      if (resp.error || !resp.data) return null
-      return resp.data.skill_namespace ?? null
+      return auditedGetNamespace(teamId)
     },
 
     // Admin-gated — see deprecate()'s comment above.

--- a/packages/mcp-server/src/tools/registry-tools.ts
+++ b/packages/mcp-server/src/tools/registry-tools.ts
@@ -5,10 +5,9 @@
  * @see SMI-5816: Private skill registry — real implementation
  * @see ADR-129: Postgres-native (JSONB) storage + real team-auth (migration 071)
  *
- * Enables enterprise teams to publish and manage skills in a private registry
- * scoped to their organization. Both metadata and packaged content live in the
- * `private_registry_skills` Postgres table (JSONB content, not S3 — ADR-129);
- * team-scoped RLS + an in-query team_id filter (ADR-116, SMI-6109 addendum).
+ * Enables enterprise teams to publish and manage skills in a private registry scoped to their
+ * organization. Metadata + packaged content live in `private_registry_skills` (JSONB, not S3 —
+ * ADR-129); team-scoped RLS + an in-query team_id filter (ADR-116, SMI-6109 addendum).
  *
  * Backing service is selected at module load: the live Supabase-backed service
  * (registry-tools.live.ts) when Supabase is configured, else an in-memory stub
@@ -144,10 +143,9 @@ export interface PrivateRegistryManageResult {
 /**
  * PrivateRegistryService — team-scoped private registry CRUD.
  *
- * **Invariant (ADR-116, addendum SMI-6109)**: every method MUST treat `teamId` as the
- * authoritative scoping key and include an explicit `team_id = <teamId>` filter — still true even
- * though every live method now runs on the signed-in user's own JWT, not service-role (ADR
- * addendum: RLS alone isn't enough on `list`/`get`).
+ * **Invariant (ADR-116, addendum SMI-6109)**: every method MUST filter explicitly on `teamId` —
+ * still true though every live method now runs on the caller's own JWT, not service-role (RLS
+ * alone isn't enough on `list`/`get`, per the addendum).
  *
  * @see packages/mcp-server/src/tools/registry-tools.live.ts
  * @see docs/internal/adr/129-private-skill-registry-real-implementation.md
@@ -262,12 +260,9 @@ async function executePrivateRegistryPublishImpl(
     }
   }
 
-  // SMI-5852 UX pre-check: the DB trigger (enforce_private_skill_namespace) is the
-  // actual security boundary — this only surfaces a namespace mismatch as an
-  // actionable typed error instead of a raw 23514. getNamespace() never throws (its
-  // documented contract, registry-tools.live.member-reads.ts, SMI-6109) — a lookup
-  // failure resolves to `null` internally, so this pre-check is simply skipped and
-  // the DB trigger remains the sole gate, same as before SMI-6109 — no try/catch needed.
+  // SMI-5852 UX pre-check: the DB trigger (enforce_private_skill_namespace) is the actual
+  // security boundary. getNamespace() never throws (SMI-6109) — a lookup failure resolves to
+  // `null`, so this pre-check is simply skipped and the trigger remains the sole gate.
   let skillNamespace: string | undefined
   const namespace = await service.getNamespace(teamId)
   if (namespace) {
@@ -454,10 +449,15 @@ async function executePrivateRegistryManageImpl(
       case 'namespace': {
         const namespace = await service.getNamespace(teamId)
         if (!namespace) {
+          // getNamespace() never throws, so "not logged in" and "genuinely unconfigured" both
+          // collapse to this one message (unlike list/get's actionable login error) — hinting at
+          // login here is a partial fix for that UX gap (SMI-6109 cross-provider review).
           return {
             success: false,
             dataSource,
-            error: "Unable to resolve this team's private registry namespace.",
+            error:
+              "Unable to resolve this team's private registry namespace. If you haven't run " +
+              '`skillsmith login` yet, do that and try again.',
           }
         }
         return {

--- a/packages/mcp-server/src/tools/registry-tools.ts
+++ b/packages/mcp-server/src/tools/registry-tools.ts
@@ -8,7 +8,7 @@
  * Enables enterprise teams to publish and manage skills in a private registry
  * scoped to their organization. Both metadata and packaged content live in the
  * `private_registry_skills` Postgres table (JSONB content, not S3 — ADR-129);
- * team-scoped RLS + an in-query team_id filter on the service-role path (ADR-116).
+ * team-scoped RLS + an in-query team_id filter (ADR-116, SMI-6109 addendum).
  *
  * Backing service is selected at module load: the live Supabase-backed service
  * (registry-tools.live.ts) when Supabase is configured, else an in-memory stub
@@ -144,13 +144,14 @@ export interface PrivateRegistryManageResult {
 /**
  * PrivateRegistryService — team-scoped private registry CRUD.
  *
- * **Invariant (ADR-116)**: every method MUST treat `teamId` as the authoritative
- * scoping key and include an explicit `team_id = <teamId>` filter in the query.
- * The live Supabase implementation uses the service-role client, which bypasses
- * RLS — tenant isolation is enforced in the service, not the database.
+ * **Invariant (ADR-116, addendum SMI-6109)**: every method MUST treat `teamId` as the
+ * authoritative scoping key and include an explicit `team_id = <teamId>` filter — still true even
+ * though every live method now runs on the signed-in user's own JWT, not service-role (ADR
+ * addendum: RLS alone isn't enough on `list`/`get`).
  *
  * @see packages/mcp-server/src/tools/registry-tools.live.ts
  * @see docs/internal/adr/129-private-skill-registry-real-implementation.md
+ * @see docs/internal/adr/116-mcp-server-service-role-for-team-scoped-tools.md (SMI-6109 addendum)
  */
 export interface PrivateRegistryService extends PrivateRegistryReviewService {
   publish(
@@ -263,25 +264,22 @@ async function executePrivateRegistryPublishImpl(
 
   // SMI-5852 UX pre-check: the DB trigger (enforce_private_skill_namespace) is the
   // actual security boundary — this only surfaces a namespace mismatch as an
-  // actionable typed error instead of a raw 23514. A lookup failure (M3, known and
-  // accepted gap — not applied this round) does NOT block the publish attempt; the
-  // trigger still enforces correctness either way.
+  // actionable typed error instead of a raw 23514. getNamespace() never throws (its
+  // documented contract, registry-tools.live.member-reads.ts, SMI-6109) — a lookup
+  // failure resolves to `null` internally, so this pre-check is simply skipped and
+  // the DB trigger remains the sole gate, same as before SMI-6109 — no try/catch needed.
   let skillNamespace: string | undefined
-  try {
-    const namespace = await service.getNamespace(teamId)
-    if (namespace) {
-      skillNamespace = namespace
-      const requestedNamespace = input.skillId.split('/')[0]
-      if (requestedNamespace !== namespace) {
-        return {
-          success: false,
-          dataSource,
-          error: `skill_id must start with "${namespace}/" for this team's private registry namespace.`,
-        }
+  const namespace = await service.getNamespace(teamId)
+  if (namespace) {
+    skillNamespace = namespace
+    const requestedNamespace = input.skillId.split('/')[0]
+    if (requestedNamespace !== namespace) {
+      return {
+        success: false,
+        dataSource,
+        error: `skill_id must start with "${namespace}/" for this team's private registry namespace.`,
       }
     }
-  } catch {
-    // Lookup failure — skip the pre-check, let the DB trigger be the sole gate.
   }
 
   // Service errors (immutability conflict, size cap, missing SKILL.md, missing
@@ -416,11 +414,13 @@ async function executePrivateRegistryManageImpl(
           // affects this skillId's currently-APPROVED row(s) — a `pending`/`rejected` sibling
           // version, if one exists, is untouched by this call and can still be independently
           // approved and installed later, regardless of this deprecation. And the
-          // `includeDeprecated:true` opt-in is NOT admin-gated — `list()` runs on the
-          // service-role/license-key path with no `auth.uid()` at all (see
-          // `registry-tools.live.reads.ts`'s own doc comment on `listSkills()`), so any team member
-          // holding the shared license key can pass it, not only a team admin.
-          message: `Skill "${input.skillId}" has been deprecated. Its approved version(s) will no longer be returned by list, get, or install — even by an exact version — for any team member; a separate pending or rejected version of this skillId, if one exists, is unaffected. Anyone holding this team's license key can still see deprecated versions via private_registry_manage {action:'list', includeDeprecated:true} — this is not restricted to team admins.`,
+          // `includeDeprecated:true` opt-in is NOT admin-gated — it is a plain, unauthenticated
+          // query parameter on `list()`, checked nowhere against role (see
+          // `registry-tools.live.reads.ts`'s own doc comment on `listSkills()`), so any team
+          // member can pass it, not only a team admin. Since SMI-6109, `list()` runs on the
+          // signed-in user's own JWT, not the shared license key — so the message below says
+          // "signed-in team member," not "anyone holding the license key."
+          message: `Skill "${input.skillId}" has been deprecated. Its approved version(s) will no longer be returned by list, get, or install — even by an exact version — for any team member; a separate pending or rejected version of this skillId, if one exists, is unaffected. Any signed-in team member can still see deprecated versions via private_registry_manage {action:'list', includeDeprecated:true} — this is not restricted to team admins.`,
         }
       }
 

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -5208,6 +5208,100 @@ console.log(`\n${BOLD}Check 61: git-crypt filter --unset remediation ban (SMI-57
   }
 }
 
+// Check 62: MCP server service-role usage lockdown (SMI-6109)
+//
+// SMI-6109 removed the customer-facing README instructions to configure
+// SUPABASE_SERVICE_ROLE_KEY on an MCP host, and moved list()/get()/
+// getNamespace() (registry-tools.live.ts) off the service-role client onto
+// the signed-in user's own JWT. This check is the mechanical backstop that
+// keeps a NEW customer-facing service-role dependency from silently
+// reappearing under packages/mcp-server/src/** — the exact class of gap
+// SMI-6109 itself was created to close.
+//
+// Matches only real usage (a getSupabaseAdminClient(...) CALL, or a literal
+// process.env.SUPABASE_SERVICE_ROLE_KEY read) — not narrative mentions of
+// the string in a doc comment (e.g. registry-tools.live.ts's own header,
+// explaining the history of this exact fix), which would otherwise
+// false-positive on the very file that fixed this.
+console.log(`\n${BOLD}Check 62: MCP server service-role usage lockdown (SMI-6109)${RESET}`)
+{
+  // Every CURRENT, pre-existing, deliberately-out-of-scope service-role usage under
+  // packages/mcp-server/src/**, each with its own one-line justification — see
+  // docs/internal/implementation (SMI-6109 plan)'s "Explicitly out of scope" section for the
+  // full rationale on each. supabase-client.ts itself is excluded from the scan below (it is
+  // the legitimate definition site for both the function and the env read), not allowlisted.
+  const MCP_SERVICE_ROLE_ALLOWLIST = new Set([
+    'team-workspace.live.ts', // identical list/get-shaped pattern across 8 methods, writes included — needs its own design (SMI-6109 plan)
+    'registry-tools.live.audit.ts', // audit-log write path — a system-table insert, fail-soft, structurally different from a tenant-data read
+    'registry-tools.live.content.ts', // getContent()/install's Enterprise-entitlement check — subscriptions RLS blocks non-purchasers; needs a new SECURITY DEFINER RPC (SMI-6111)
+    'integration-tools.service.ts', // Custom Integration API-key hashing backend — unrelated credential family (SKILLSMITH_API_KEY_HMAC_SECRET)
+  ])
+
+  const MCP_SERVER_SRC = join('packages', 'mcp-server', 'src')
+  const SERVICE_ROLE_CALL = /getSupabaseAdminClient\s*\(/
+  const SERVICE_ROLE_ENV_READ = /process\.env\.SUPABASE_SERVICE_ROLE_KEY/
+
+  function listMcpServerSourceFiles(dir) {
+    const out = []
+    if (!existsSync(dir)) return out
+    const stack = [dir]
+    while (stack.length) {
+      const cur = stack.pop()
+      let entries
+      try {
+        entries = readdirSync(cur, { withFileTypes: true })
+      } catch {
+        continue
+      }
+      for (const ent of entries) {
+        const full = join(cur, ent.name)
+        if (ent.isDirectory()) {
+          if (ent.name === 'node_modules' || ent.name === 'dist') continue
+          stack.push(full)
+        } else if (
+          ent.isFile() &&
+          ent.name.endsWith('.ts') &&
+          !ent.name.endsWith('.test.ts') &&
+          !ent.name.endsWith('.spec.ts') &&
+          !ent.name.endsWith('.test-helpers.ts') &&
+          ent.name !== 'supabase-client.ts'
+        ) {
+          out.push(full)
+        }
+      }
+    }
+    return out
+  }
+
+  const mcpServiceRoleFindings = []
+  for (const file of listMcpServerSourceFiles(MCP_SERVER_SRC)) {
+    const baseName = file.split('/').pop()
+    if (MCP_SERVICE_ROLE_ALLOWLIST.has(baseName)) continue
+    const content = readFileSync(file, 'utf8')
+    if (SERVICE_ROLE_CALL.test(content) || SERVICE_ROLE_ENV_READ.test(content)) {
+      mcpServiceRoleFindings.push(file)
+    }
+  }
+
+  if (mcpServiceRoleFindings.length === 0) {
+    pass(
+      'Check 62: no new service-role usage outside the SMI-6109 allowlist under packages/mcp-server/src/**'
+    )
+  } else {
+    for (const f of mcpServiceRoleFindings) {
+      fail(
+        `Check 62: ${f} calls getSupabaseAdminClient()/reads SUPABASE_SERVICE_ROLE_KEY directly`,
+        'Use getMemberUserClient()/getAdminUserClient() (registry-tools.live.auth.ts) instead, so the ' +
+          "operation runs on the signed-in user's own JWT with RLS as the authorization boundary " +
+          '(SMI-6109) — or, if this usage is genuinely a new, deliberately-scoped exception, add the ' +
+          "file's basename to MCP_SERVICE_ROLE_ALLOWLIST in scripts/audit-standards.mjs with a " +
+          "one-line justification, matching this repo's other named-allowlist conventions " +
+          '(e.g. NO_VERIFY_JWT_FUNCTIONS, SECDEF_ANON_ALLOWLIST).'
+      )
+    }
+  }
+}
+
 // Summary
 console.log('\n' + '━'.repeat(50))
 console.log(`\n${BOLD}📊 Summary${RESET}\n`)

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -5230,12 +5230,22 @@ console.log(`\n${BOLD}Check 62: MCP server service-role usage lockdown (SMI-6109
   // docs/internal/implementation (SMI-6109 plan)'s "Explicitly out of scope" section for the
   // full rationale on each. supabase-client.ts itself is excluded from the scan below (it is
   // the legitimate definition site for both the function and the env read), not allowlisted.
-  const MCP_SERVICE_ROLE_ALLOWLIST = new Set([
-    'team-workspace.live.ts', // identical list/get-shaped pattern across 8 methods, writes included — needs its own design (SMI-6109 plan)
-    'registry-tools.live.audit.ts', // audit-log write path — a system-table insert, fail-soft, structurally different from a tenant-data read
-    'registry-tools.live.content.ts', // getContent()/install's Enterprise-entitlement check — subscriptions RLS blocks non-purchasers; needs a new SECURITY DEFINER RPC (SMI-6111)
-    'integration-tools.service.ts', // Custom Integration API-key hashing backend — unrelated credential family (SKILLSMITH_API_KEY_HMAC_SECRET)
-  ])
+  //
+  // Keyed by full repo-relative path, not basename (cross-provider review finding, SMI-6109):
+  // a basename-only allowlist would silently exempt any FUTURE file sharing one of these names in
+  // a different subdirectory. `integration-tools.service.ts` was deliberately dropped from an
+  // earlier draft of this list — it only has a narrative comment mentioning
+  // SUPABASE_SERVICE_ROLE_KEY, which neither pattern below actually matches, so it never needed
+  // an entry; keeping it would itself have been a silent, unnecessary allowlist grant.
+  const MCP_SERVICE_ROLE_ALLOWLIST_JUSTIFICATIONS = {
+    'packages/mcp-server/src/tools/team-workspace.live.ts':
+      'identical list/get-shaped pattern across 8 methods, writes included — needs its own design (SMI-6109 plan)',
+    'packages/mcp-server/src/tools/registry-tools.live.audit.ts':
+      'audit-log write path — a system-table insert, fail-soft, structurally different from a tenant-data read',
+    'packages/mcp-server/src/tools/registry-tools.live.content.ts':
+      "getContent()/install's Enterprise-entitlement check — subscriptions RLS blocks non-purchasers; needs a new SECURITY DEFINER RPC (SMI-6111)",
+  }
+  const MCP_SERVICE_ROLE_ALLOWLIST = new Set(Object.keys(MCP_SERVICE_ROLE_ALLOWLIST_JUSTIFICATIONS))
 
   const MCP_SERVER_SRC = join('packages', 'mcp-server', 'src')
   const SERVICE_ROLE_CALL = /getSupabaseAdminClient\s*\(/
@@ -5274,16 +5284,31 @@ console.log(`\n${BOLD}Check 62: MCP server service-role usage lockdown (SMI-6109
   }
 
   const mcpServiceRoleFindings = []
+  // Cross-provider review finding (SMI-6109): an allowlist entry whose file no longer actually
+  // matches either pattern is itself worth catching — it means the entry is stale (either the
+  // usage was since removed, a la integration-tools.service.ts's comment-only mention which never
+  // matched at all, or the file was renamed/moved). A silently-stale entry can mask a REAL future
+  // regression at that same path if the pattern's match state flips back later unnoticed.
+  const staleAllowlistEntries = []
+  const seenAllowlistPaths = new Set()
   for (const file of listMcpServerSourceFiles(MCP_SERVER_SRC)) {
-    const baseName = file.split('/').pop()
-    if (MCP_SERVICE_ROLE_ALLOWLIST.has(baseName)) continue
+    const relPath = relative(process.cwd(), file)
     const content = readFileSync(file, 'utf8')
-    if (SERVICE_ROLE_CALL.test(content) || SERVICE_ROLE_ENV_READ.test(content)) {
-      mcpServiceRoleFindings.push(file)
+    const matchesServiceRole =
+      SERVICE_ROLE_CALL.test(content) || SERVICE_ROLE_ENV_READ.test(content)
+    if (MCP_SERVICE_ROLE_ALLOWLIST.has(relPath)) {
+      seenAllowlistPaths.add(relPath)
+      if (!matchesServiceRole) staleAllowlistEntries.push(relPath)
+      continue
     }
+    if (matchesServiceRole) mcpServiceRoleFindings.push(relPath)
+  }
+  // An allowlisted path that was never visited at all (renamed/deleted) is equally stale.
+  for (const allowed of MCP_SERVICE_ROLE_ALLOWLIST) {
+    if (!seenAllowlistPaths.has(allowed)) staleAllowlistEntries.push(allowed)
   }
 
-  if (mcpServiceRoleFindings.length === 0) {
+  if (mcpServiceRoleFindings.length === 0 && staleAllowlistEntries.length === 0) {
     pass(
       'Check 62: no new service-role usage outside the SMI-6109 allowlist under packages/mcp-server/src/**'
     )
@@ -5294,9 +5319,20 @@ console.log(`\n${BOLD}Check 62: MCP server service-role usage lockdown (SMI-6109
         'Use getMemberUserClient()/getAdminUserClient() (registry-tools.live.auth.ts) instead, so the ' +
           "operation runs on the signed-in user's own JWT with RLS as the authorization boundary " +
           '(SMI-6109) — or, if this usage is genuinely a new, deliberately-scoped exception, add the ' +
-          "file's basename to MCP_SERVICE_ROLE_ALLOWLIST in scripts/audit-standards.mjs with a " +
-          "one-line justification, matching this repo's other named-allowlist conventions " +
-          '(e.g. NO_VERIFY_JWT_FUNCTIONS, SECDEF_ANON_ALLOWLIST).'
+          "file's full repo-relative path to MCP_SERVICE_ROLE_ALLOWLIST_JUSTIFICATIONS in " +
+          "scripts/audit-standards.mjs with a one-line justification, matching this repo's other " +
+          'named-allowlist conventions (e.g. NO_VERIFY_JWT_FUNCTIONS, SECDEF_ANON_ALLOWLIST).'
+      )
+    }
+    for (const stale of staleAllowlistEntries) {
+      fail(
+        `Check 62: ${stale} is allowlisted in MCP_SERVICE_ROLE_ALLOWLIST_JUSTIFICATIONS but no ` +
+          'longer contains a matching getSupabaseAdminClient()/SUPABASE_SERVICE_ROLE_KEY usage ' +
+          '(or the file no longer exists at that path)',
+        `Remove the stale entry for '${stale}' from MCP_SERVICE_ROLE_ALLOWLIST_JUSTIFICATIONS in ` +
+          'scripts/audit-standards.mjs — an unnecessary allowlist grant is itself a finding, not a ' +
+          'harmless no-op (SMI-6109 cross-provider review: integration-tools.service.ts was ' +
+          'allowlisted for a comment-only mention that never matched either pattern).'
       )
     }
   }


### PR DESCRIPTION
## Business Summary

**What shipped:** Skillsmith's private-registry `list`/`get`/`namespace` MCP tools no longer require customers to configure `SUPABASE_SERVICE_ROLE_KEY` — the single most powerful backend credential — on their own machine. That instruction was live in the published `@skillsmith/mcp-server` README, in a repo whose source is public; it's now gone, and the code no longer needs it for these three operations. They now run as the signed-in user (`skillsmith login`), the same pattern already proven by publish/deprecate/undeprecate/install in this same file.

**Quality bar:** Full unit test suite (238 tests across the touched files, all green, including new "not logged in" regression cases), clean typecheck/build/lint, and a new automated guardrail (`audit:standards` Check 62) that fails CI if this exact pattern ever creeps back in anywhere else under the MCP server. Also fixed two pre-existing docs/comments that had gone stale describing the old credential shape, and two test assertions that were too broad and would have silently passed even if the fix leaked an unrelated database write.

**Found along the way:** one more instance of the same underlying problem — `getContent()` (backs the `install` action) still needs the service-role client for its Enterprise-entitlement check, because the `subscriptions` table's own row-level security only lets the purchaser read their own subscription. Fixing that needs a new database function, not just a code change, so it's filed separately as SMI-6111 rather than folded in here.

**Net result:** `list`, `get`, and `namespace` are fully fixed and shipped. `install`/`getContent` still needs the service-role key until SMI-6111 lands — that's the one remaining gap before "customers only need a Skillsmith key, Supabase is fully invisible" is completely true end to end.

---

## Technical detail

- `packages/mcp-server/src/tools/registry-tools.live.ts` — `list()`/`get()`/`getNamespace()` now delegate to new audited wrappers (below) instead of the removed `getClient()`/service-role helper. Header doc comment rewritten to match the new credential shape; ADR-116 cited as superseded-for-this-file with the addendum in `docs/internal/adr/116-*.md`.
- `packages/mcp-server/src/tools/registry-tools.live.member-reads.ts` (new) — `auditedList`/`auditedGet`/`auditedGetNamespace`: bind `getMemberUserClient()`, run the existing query logic unchanged (same `team_id`/`approval_status`/`deprecated` predicates as before — RLS doesn't enforce the latter two), record a `recordRegistryAudit()` row. Split out to keep `registry-tools.live.ts` under the 500-line budget. `getNamespace()`'s wrapper deliberately swallows a not-logged-in failure and returns `null` (its documented "never throws" contract), unlike `list`/`get` which throw and let the existing dispatcher-level try/catch convert it to a typed error.
- `packages/mcp-server/src/tools/registry-tools.live.audit.ts` — extended `RegistryAuditOperation`/`RegistryAuditEvent.skillId` (now optional) to support auditing team-wide operations that have no single skill in scope.
- `packages/mcp-server/src/supabase-client.ts` — `getSupabaseClient()`/`getSupabaseUserClient()` fall back to a hardcoded production `SUPABASE_URL`/anon key (same publishable-key pattern as `packages/core`'s `DEFAULT_BASE_URL`) only when the env var is unset — an explicit override (e.g. `private-registry-e2e.yml`'s staging env) still always wins. `isSupabaseConfigured()` itself is untouched on purpose: it also gates `sso-tools`/`team-workspace`/`compliance-tools`/`integration-tools`/`team-resolver`, all of which still genuinely need real Supabase config for their own (unrelated, still service-role-backed) paths — flipping it would have silently moved all of them from a working stub to a broken "live" attempt.
- `packages/mcp-server/package.json` — added `@supabase/supabase-js` as a real dependency (it was previously only a private root devDependency, so even a fully-configured customer install would fail with "Supabase client unavailable").
- `packages/mcp-server/README.md` — removed the `SUPABASE_SERVICE_ROLE_KEY` config example and its "distribute via 1Password" instruction.
- `scripts/audit-standards.mjs` — new Check 62: fails on any new `getSupabaseAdminClient()`/`SUPABASE_SERVICE_ROLE_KEY` reference under `packages/mcp-server/src/**`, with a named allowlist for the four pre-existing, deliberately-out-of-scope usages (`team-workspace.live.ts`, the audit-write path, `getContent()`'s entitlement check, the unrelated Custom Integration secret).
- `packages/mcp-server/src/tools/registry-tools.ts` — fixed two now-stale comments/messages describing `list()` as still running on the shared license key, and simplified the namespace pre-check now that `getNamespace()` never throws.
- Tests: rewrote `registry-tools.live.manage.test.ts` (every list/get/namespace case now mocks the user-JWT client too, plus three new not-logged-in cases); fixed a missing mock and a now-too-broad "no insert happened" assertion in `registry-tools.live.test.ts` (my new audit-logging on `getNamespace()` legitimately writes an `audit_logs` row even on the success path, which the old assertion didn't anticipate); fixed a stale comment in `registry-tools.live.malformed-input.test.ts`.
- `docs/internal/adr/116-mcp-server-service-role-for-team-scoped-tools.md` — addendum note (separate PR against `smith-horn/skillsmith-docs`, since `docs/internal` is its own submodule).
- Verified: `npm run build`, `npm run lint`, `npm run audit:standards`, and the full `packages/mcp-server` test suite (178 files / 2948 tests) all pass in the worktree container. `private-registry-e2e.yml`'s `mcp-live` leg will run in CI on this PR as the live-staging regression check.

Refs SMI-6109. Filed SMI-6111 as a follow-up.