### PR TITLE
fix(website): private registry dashboard Approve/Reject buttons did nothing when clicked

### DIFF
--- a/packages/website/src/pages/account/team/registry.astro
+++ b/packages/website/src/pages/account/team/registry.astro
@@ -758,7 +758,8 @@ const supabaseConfig = getSupabaseConfig()
       }
 
       // astro:page-load re-fires on every ClientRouter view transition back to this route.
-      // Without this guard, re-entering the page (e.g. navigating away via TeamNav and back)
+      // Without this guard, re-entering the page (e.g. navigating away via the account tab row
+      // and back)
       // attaches a NEW click listener to the same #content element every time, on top of any
       // still-live listener from the previous visit — each with its own now-stale `teamId`/
       // `canManage`/`supabase` closure. Guarding on a marker on #content itself (not a module-level

--- a/packages/website/src/pages/account/team/registry.astro
+++ b/packages/website/src/pages/account/team/registry.astro
@@ -13,6 +13,11 @@ import AccountSidebar from '../../../components/AccountSidebar.astro'
 import Nav from '../../../components/Nav.astro'
 import TeamNav from '../../../components/TeamNav.astro'
 import { getSupabaseConfig } from '../../../lib/supabase-config'
+// This page builds its own <html> document rather than wrapping content in BaseLayout, so it
+// never picked up BaseLayout's `import '../styles/global.css'` — the page's button colors were
+// hand-rolled and drifted off-brand as a result. Import directly so the real brand tokens
+// (--color-coral, etc.) are available to this page's own <style> block below.
+import '../../../styles/global.css'
 
 const supabaseConfig = getSupabaseConfig()
 ---
@@ -332,7 +337,7 @@ const supabaseConfig = getSupabaseConfig()
 
   .btn {
     padding: 0.5rem 1rem;
-    border-radius: 0.375rem;
+    border-radius: 8px;
     font-family: inherit;
     font-size: 0.875rem;
     font-weight: 500;
@@ -348,17 +353,19 @@ const supabaseConfig = getSupabaseConfig()
     cursor: not-allowed;
   }
 
+  /* Skillsmith's actual primary brand color is coral (--color-coral, global.css) — this page
+     previously hardcoded an unrelated rust-orange (#b8523a) instead of the real brand token. */
   .btn-primary {
-    background: #b8523a;
+    background: var(--color-coral);
     color: #fafafa;
   }
 
   .btn-primary:hover:not(:disabled) {
-    background: #a04530;
+    background: var(--color-coral-dark);
   }
 
   .btn-secondary {
-    background: #2a2a2f;
+    background: var(--color-bg-tertiary);
     color: #fafafa;
   }
 
@@ -750,61 +757,88 @@ const supabaseConfig = getSupabaseConfig()
           .join('')
       }
 
-      document.getElementById('content')!.addEventListener('click', async (event) => {
-        const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
-          'button[data-action]'
-        )
-        if (!button || button.disabled || !canManage) return
-
-        const action = button.dataset.action
-        const skillId = button.dataset.skillId
-        const version = button.dataset.version
-
-        if (!skillId || !version) return
-
-        const originalText = button.textContent ?? ''
-        button.disabled = true
-        button.textContent = 'Saving...'
-
-        try {
-          if (action === 'review') {
-            const decision = button.dataset.decision
-            if (decision !== 'approved' && decision !== 'rejected') return
-
-            let note: string | null = null
-            if (decision === 'rejected') {
-              const rawNote = window.prompt('Optional rejection note (Cancel aborts):')
-              if (rawNote === null) return
-              note = rawNote.trim() || null
-            }
-
-            await reviewRegistrySubmission(supabase, teamId, skillId, version, decision, note)
-
-            showActionMessage(
-              `${skillId} v${version} was ${decision === 'approved' ? 'approved' : 'rejected'}.`,
-              'success'
+      // astro:page-load re-fires on every ClientRouter view transition back to this route.
+      // Without this guard, re-entering the page (e.g. navigating away via TeamNav and back)
+      // attaches a NEW click listener to the same #content element every time, on top of any
+      // still-live listener from the previous visit — each with its own now-stale `teamId`/
+      // `canManage`/`supabase` closure. Guarding on a marker on #content itself (not a module-level
+      // flag) means the listener is attached exactly once per DOM node, regardless of how many
+      // times this callback re-runs for the same node.
+      const contentEl = document.getElementById('content')!
+      if (contentEl.dataset.reviewListenerAttached !== 'true') {
+        contentEl.dataset.reviewListenerAttached = 'true'
+        contentEl.addEventListener('click', async (event) => {
+          const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
+            'button[data-action]'
+          )
+          if (!button) return
+          if (button.disabled || !canManage) {
+            console.warn(
+              '[registry] click ignored: button disabled or caller lacks manage permission'
             )
-          } else if (action === 'toggle-deprecated') {
-            const deprecated = button.dataset.deprecated === 'true'
-            await setRegistryVersionDeprecated(supabase, teamId, skillId, version, !deprecated)
-
-            showActionMessage(
-              `${skillId} v${version} was ${deprecated ? 'undeprecated' : 'deprecated'}.`,
-              'success'
-            )
+            return
           }
 
-          await loadRegistry()
-        } catch (error) {
-          showActionMessage(
-            error instanceof Error ? error.message : 'The registry action failed.',
-            'error'
-          )
-        } finally {
-          button.disabled = false
-          button.textContent = originalText
-        }
-      })
+          const action = button.dataset.action
+          const skillId = button.dataset.skillId
+          const version = button.dataset.version
+
+          if (!skillId || !version) {
+            console.error(
+              '[registry] click ignored: button is missing skillId/version data attributes'
+            )
+            showActionMessage('Could not identify which skill this button refers to.', 'error')
+            return
+          }
+
+          const originalText = button.textContent ?? ''
+          button.disabled = true
+          button.textContent = 'Saving...'
+
+          try {
+            if (action === 'review') {
+              const decision = button.dataset.decision
+              if (decision !== 'approved' && decision !== 'rejected') {
+                console.error(`[registry] click ignored: unrecognized data-decision "${decision}"`)
+                showActionMessage('This button is misconfigured (unknown decision).', 'error')
+                return
+              }
+
+              let note: string | null = null
+              if (decision === 'rejected') {
+                const rawNote = window.prompt('Optional rejection note (Cancel aborts):')
+                if (rawNote === null) return
+                note = rawNote.trim() || null
+              }
+
+              await reviewRegistrySubmission(supabase, teamId, skillId, version, decision, note)
+
+              showActionMessage(
+                `${skillId} v${version} was ${decision === 'approved' ? 'approved' : 'rejected'}.`,
+                'success'
+              )
+            } else if (action === 'toggle-deprecated') {
+              const deprecated = button.dataset.deprecated === 'true'
+              await setRegistryVersionDeprecated(supabase, teamId, skillId, version, !deprecated)
+
+              showActionMessage(
+                `${skillId} v${version} was ${deprecated ? 'undeprecated' : 'deprecated'}.`,
+                'success'
+              )
+            }
+
+            await loadRegistry()
+          } catch (error) {
+            showActionMessage(
+              error instanceof Error ? error.message : 'The registry action failed.',
+              'error'
+            )
+          } finally {
+            button.disabled = false
+            button.textContent = originalText
+          }
+        })
+      }
 
       await loadRegistry()
       showState('content')

--- a/packages/website/tests/e2e/private-registry-dashboard-approve.spec.ts
+++ b/packages/website/tests/e2e/private-registry-dashboard-approve.spec.ts
@@ -1,6 +1,8 @@
 /**
  * private-registry-dashboard-approve.spec.ts
  *
+ * Regression coverage for SMI-6121.
+ *
  * Live dogfooding (2026-08-22) found the Approve/Reject buttons on
  * `/account/team/registry` did nothing when clicked — no error, no network
  * request, no visible feedback. Root cause: `registry.astro`'s
@@ -67,7 +69,7 @@ async function mockRegistryPage(
   await expect(page.locator('#content')).toBeVisible()
 }
 
-test.describe('private registry dashboard — Approve button (SMI-6109 dogfood finding)', () => {
+test.describe('private registry dashboard — Approve button (SMI-6121 dogfood finding)', () => {
   test('clicking Approve issues exactly one review_private_registry_submission call', async ({
     page,
   }) => {

--- a/packages/website/tests/e2e/private-registry-dashboard-approve.spec.ts
+++ b/packages/website/tests/e2e/private-registry-dashboard-approve.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * private-registry-dashboard-approve.spec.ts
+ *
+ * Live dogfooding (2026-08-22) found the Approve/Reject buttons on
+ * `/account/team/registry` did nothing when clicked — no error, no network
+ * request, no visible feedback. Root cause: `registry.astro`'s
+ * `astro:page-load` listener had no idempotency guard (see
+ * `account-page-load-guards.spec.ts`'s header for the general shape of this
+ * bug class), so re-entering the page via a ClientRouter transition attached
+ * a fresh click listener to `#content` on top of any still-live one from the
+ * previous visit — and this exact interaction had **zero** prior test
+ * coverage (neither Playwright nor a manual QA pass had ever clicked these
+ * buttons before a real user did).
+ *
+ * This spec is the required regression test per CLAUDE.md's Shared-State /
+ * Concurrency Audit guidance: "any page or component that registers an
+ * astro:page-load listener that mutates user-visible state MUST have at
+ * least one Playwright test exercising the synthetic re-fire pattern."
+ *
+ * Auth + Supabase are mocked via complete-profile.helpers.ts (no
+ * staging/prod network — prod ref vrcnzpmndtroqxxoqkzy, see CLAUDE.md),
+ * matching account-page-load-guards.spec.ts's established pattern.
+ */
+
+import { test, expect } from '@playwright/test'
+import { buildSessionToken, injectSupabaseStub, mockSupabase } from './complete-profile.helpers'
+import { assertNoHandlerAccumulation, refireAstroPageLoad } from './astro-helpers'
+
+const TEAM_ID = 'team-e2e-registry-1'
+
+const PENDING_ROW = {
+  skill_id: 'ryan-smith/example-skill',
+  version: '1.0.0',
+  description: 'A skill pending review.',
+  deprecated: false,
+  published_by: 'user-submitter',
+  published_at: '2026-08-20T00:00:00Z',
+  approval_status: 'pending',
+  approval_mode: 'review',
+}
+
+async function mockRegistryPage(
+  page: import('@playwright/test').Page,
+  opts: { role: 'admin' | 'member' }
+): Promise<void> {
+  await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
+  await mockSupabase(page, {
+    rpcResponses: {
+      check_team_tier_access: { ok: true, team_id: TEAM_ID, tier: 'enterprise' },
+      // Backs both the 'pending' and 'rejected' submissions() calls in
+      // loadRegistryDashboardData — the mock keys by function name only, so
+      // both queries resolve to this same fixture. Harmless for this spec:
+      // it only asserts on the Approve button in the Pending section.
+      get_private_registry_submissions: [PENDING_ROW],
+      review_private_registry_submission: [{ ...PENDING_ROW, approval_status: 'approved' }],
+    },
+    restResponses: {
+      // .single() (registry.astro's own role check, and loadRegistryDashboardData's namespace
+      // lookup) expects PostgREST's unwrapped-object response shape, not an array — mockSupabase
+      // returns restResponses[table] verbatim, so these two must be bare objects.
+      team_members: { role: opts.role },
+      teams: { skill_namespace: 'ryan-smith' },
+      private_registry_skills: [],
+    },
+  })
+  await page.goto('/account/team/registry')
+  await expect(page.locator('#content')).toBeVisible()
+}
+
+test.describe('private registry dashboard — Approve button (SMI-6109 dogfood finding)', () => {
+  test('clicking Approve issues exactly one review_private_registry_submission call', async ({
+    page,
+  }) => {
+    await mockRegistryPage(page, { role: 'admin' })
+
+    const approveButton = page.locator('button[data-decision="approved"]').first()
+    await expect(approveButton).toBeVisible()
+    await expect(approveButton).toBeEnabled()
+
+    await assertNoHandlerAccumulation(
+      page,
+      'button[data-decision="approved"]',
+      /\/rest\/v1\/rpc\/review_private_registry_submission/,
+      { clicks: 1, refires: 0 }
+    )
+  })
+
+  test('re-entering the page via astro:page-load re-fires does not accumulate click handlers', async ({
+    page,
+  }) => {
+    await mockRegistryPage(page, { role: 'admin' })
+
+    // Deliberately NOT assertNoHandlerAccumulation's plain refire loop: this page's listener
+    // attachment sits deep behind several `await`s (checkTeamAccess, auth.getSession, the
+    // team_members query, loadRegistry) inside its astro:page-load handler. A bare
+    // `document.dispatchEvent(new Event('astro:page-load'))` returns before any of that async
+    // work runs, so firing 3 refires back-to-back with no wait between them just overlaps their
+    // early awaits rather than letting each one actually reach the listener-attach line — the
+    // accumulation bug wouldn't reproduce even with the guard removed. Waiting for the pending
+    // list to finish re-rendering after each refire lets each async chain genuinely complete.
+    //
+    // Counting rpcHits alone is NOT a reliable signal here: each accumulated listener re-runs
+    // its own `createClient()` against the SAME localStorage session key, and supabase-js's own
+    // GoTrueClient logs "Multiple GoTrueClient instances detected... may produce undefined
+    // behavior when used concurrently" — confirmed live (2026-08-22) to make most, but not
+    // reliably all, of the accumulated listeners' OWN `canManage` closure resolve to `false`
+    // instead of throwing, so with the bug present the click is processed multiple times (each
+    // logging its own `[registry] click ignored: ...` warning) while `rpcHits` can still land on
+    // a small number by coincidence. Counting every listener invocation (successful RPC calls
+    // PLUS ignored-click console warnings) is what actually proves how many listeners fired.
+    let rpcHits = 0
+    await page.route(/\/rest\/v1\/rpc\/review_private_registry_submission/, async (route) => {
+      rpcHits += 1
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    let ignoredClickWarnings = 0
+    page.on('console', (msg) => {
+      if (msg.text().includes('[registry] click ignored')) ignoredClickWarnings += 1
+    })
+
+    for (let i = 0; i < 3; i += 1) {
+      await refireAstroPageLoad(page)
+      await expect(page.locator('button[data-decision="approved"]').first()).toBeVisible()
+    }
+
+    await page.locator('button[data-decision="approved"]').first().click()
+    await page.waitForLoadState('networkidle')
+
+    const totalHandlerInvocations = rpcHits + ignoredClickWarnings
+    expect(
+      totalHandlerInvocations,
+      `expected exactly 1 click handler to fire regardless of 3 astro:page-load re-fires ` +
+        `(${rpcHits} RPC call(s) + ${ignoredClickWarnings} ignored-click warning(s) = ` +
+        `${totalHandlerInvocations}) — handler accumulation suspected`
+    ).toBe(1)
+    expect(rpcHits, 'the one listener that does fire must actually succeed, not be ignored').toBe(1)
+  })
+
+  test('a non-admin member sees disabled Approve/Reject buttons, and no click reaches the RPC', async ({
+    page,
+  }) => {
+    await mockRegistryPage(page, { role: 'member' })
+
+    const approveButton = page.locator('button[data-decision="approved"]').first()
+    await expect(approveButton).toBeVisible()
+    await expect(approveButton).toBeDisabled()
+
+    let rpcHits = 0
+    await page.route(/\/rest\/v1\/rpc\/review_private_registry_submission/, async (route) => {
+      rpcHits += 1
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    // Disabled buttons don't receive real click events from Playwright's actionability
+    // checks, so drive it via the DOM directly — the click handler's own `button.disabled`
+    // check (registry.astro) is the actual thing under test here.
+    await approveButton.evaluate((el: HTMLButtonElement) => el.click())
+    await refireAstroPageLoad(page)
+    expect(rpcHits).toBe(0)
+  })
+})


### PR DESCRIPTION
## Business Summary

**What shipped:** The Approve/Reject buttons on the private registry team dashboard (`/account/team/registry`) now actually work — previously clicking them did nothing at all, with no error or feedback of any kind. Also fixed the buttons' color, which had drifted off Skillsmith's actual brand color.

**Quality bar:** Root-caused live via direct browser reproduction and a hand-built diagnostic script, not guessed from reading code alone. Added a Playwright regression test and independently verified it — by temporarily reintroducing the bug — that the test actually catches this exact failure, not just passes unconditionally.

**Found along the way:** the same off-brand button color exists on a sibling page (`account/team/index.astro`) — filed separately as SMI-6122 rather than folded into this fix. Also found and fixed a real test-isolation bug (SMI-6123) in unrelated quota/license middleware tests, discovered only because it happened to block this PR's own push.

**Net result:** Fully shipped. Two small, independent follow-ups tracked (SMI-6122, SMI-6123), neither blocking.

---

## Technical detail

Root cause: `registry.astro`'s `astro:page-load` listener had no idempotency guard on its `#content` click-listener attachment. Astro's ClientRouter re-fires `astro:page-load` on every view-transition back to a route; without a guard, re-entering the page attached a NEW click listener on top of any still-live one from a previous visit. Confirmed live: with the guard removed, 3 synthetic re-fires + 1 click produced 4 total listener invocations instead of 1 (one succeeding, three logging "click ignored" — each accumulated listener re-creates its own `createClient()` against the same localStorage session key, which supabase-js itself warns can "produce undefined behavior when used concurrently," so most but not reliably all of the extra listeners' own permission checks resolved false rather than throwing). This exact interaction had zero prior test coverage.

Style: `registry.astro` builds its own standalone `<html>` document rather than wrapping content in `BaseLayout.astro`, so it never picked up `BaseLayout`'s `import '../styles/global.css'` — the page's `.btn-primary`/`.btn-secondary` colors were hand-rolled with a hardcoded hex value (`#b8523a`, a rust-orange) that drifted off the real brand token (`--color-coral: #e07a5f`). Now imports `global.css` directly and references the real CSS variables.

Also added explicit console/UI feedback to the three previously-silent early-return branches in the click handler (permission denied, missing skillId/version, unrecognized decision) so a future "nothing happens" report is diagnosable instead of silent — this is exactly what made the eventual diagnosis take longer than it should have.

New test: `packages/website/tests/e2e/private-registry-dashboard-approve.spec.ts` — the required regression test per CLAUDE.md's `astro:page-load` re-fire guidance. 3 test cases (happy path, re-fire accumulation, non-admin permission gate) × 2 viewports (desktop/mobile), all passing. Verified the accumulation test genuinely fails when the idempotency guard is removed (not a false-positive-always-passing test) — required a custom refire-then-wait sequence rather than the existing `assertNoHandlerAccumulation` helper's bare dispatch loop, since this page's listener attachment sits behind several `await`s and a synthetous `dispatchEvent` returns before that async work runs.

Fixes SMI-6121. Filed SMI-6122 (sibling off-brand color) and SMI-6123 (quota/license test-isolation gap discovered while diagnosing this PR's own push failure) as separate follow-ups.