### PR TITLE
fix(smoke-prod): update stale /product page content fingerprints

### DIFF
--- a/scripts/smoke-prod/website.sh
+++ b/scripts/smoke-prod/website.sh
@@ -563,11 +563,11 @@ check_product_page_renders() {
     report_fail "website-product-page" "check_product_page_renders" "$url" "200" "$status" "$ms"
     return 1
   fi
-  if ! assert_contains "$body" 'MCP for any agent. CLI for the terminal.' "product-hero"; then
+  if ! assert_contains "$body" 'Author, version, deprecate, and govern' "product-hero"; then
     report_fail "website-product-page" "check_product_page_renders" "$url" "hero-fingerprint" "missing" "$ms"
     return 1
   fi
-  if ! assert_contains "$body" 'Capability comparison' "product-matrix"; then
+  if ! assert_contains "$body" 'One lifecycle, four surfaces' "product-matrix"; then
     report_fail "website-product-page" "check_product_page_renders" "$url" "matrix-fingerprint" "missing" "$ms"
     return 1
   fi


### PR DESCRIPTION
## Business Summary

**What shipped:** The production smoke check for `/product` was asserting on marketing copy ("MCP for any agent. CLI for the terminal.") that hasn't existed on the page since PR #2261 (SMI-5966, weeks ago) — so it's been failing on unrelated merges. Updated to match the page's actual current content.

**Quality bar:** Both new fingerprint strings verified present on the live production page via direct curl before committing.

**Net result:** Fully shipped. Closes GitHub issue #2475 (the false-positive failure this PR fixes). Filed SMI-6124 separately for the broader observation that 9+ smoke-prod GitHub issues are currently open and appear untriaged — out of scope for this one-line content fix.

---

## Technical detail

`scripts/smoke-prod/website.sh`'s `check_product_page_renders()` — two `assert_contains` fingerprints updated: hero H1 fingerprint → `'Author, version, deprecate, and govern'`, comparison-section fingerprint → `'One lifecycle, four surfaces'`. No logic change.

SMI-6124: https://linear.app/smith-horn-group/issue/SMI-6124

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)