### PR TITLE
chore(release): weekly cadence bump — 2026-08-23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34034,7 +34034,7 @@
     },
     "packages/cli": {
       "name": "@skillsmith/cli",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "Elastic-2.0",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
@@ -34065,8 +34065,8 @@
         "sklx": "dist/cli.js"
       },
       "devDependencies": {
-        "@skillsmith/core": "^0.11.7",
-        "@skillsmith/mcp-server": "^0.7.9",
+        "@skillsmith/core": "^0.11.8",
+        "@skillsmith/mcp-server": "^0.7.10",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
         "vitest": "4.1.10"
@@ -34075,7 +34075,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@smith-horn/enterprise": "^0.3.7"
+        "@smith-horn/enterprise": "^0.3.8"
       },
       "peerDependenciesMeta": {
         "@smith-horn/enterprise": {
@@ -34184,7 +34184,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.11.7",
+      "version": "0.11.8",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -34318,18 +34318,18 @@
     },
     "packages/enterprise": {
       "name": "@smith-horn/enterprise",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1106.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.76.0",
-        "@skillsmith/core": "^0.11.7",
+        "@skillsmith/core": "^0.11.8",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.7.9",
+        "@skillsmith/mcp-server": "^0.7.10",
         "@smithy/config-resolver": "4.6.16",
         "@smithy/core": "3.31.1",
         "@smithy/middleware-endpoint": "4.6.16",
@@ -34344,7 +34344,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.7.9"
+        "@skillsmith/mcp-server": "^0.7.10"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -34380,12 +34380,12 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "Elastic-2.0",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "10.1.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.11.7",
+        "@skillsmith/core": "^0.11.8",
         "@supabase/supabase-js": "2.112.2",
         "ajv-formats-draft2019": "1.6.1",
         "ulid": "3.0.1",
@@ -34435,7 +34435,7 @@
     },
     "packages/vscode-extension": {
       "name": "skillsmith-vscode",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "Elastic-2.0",
       "dependencies": {
         "cross-spawn": "7.0.6",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/cli` are documented here.
 
 ## [Unreleased]
 
+## v0.8.8
+
+- **Fix**: reject bare-name registry match without author confirmation (#2465)
 - **Fix**: `skillsmith update` no longer force-installs an unrelated same-named registry skill
   over a locally-authored one it was never asked to replace. `getSkillDiff()` now reads the
   installed skill's own claimed author from its `SKILL.md` front-matter (`readClaimedAuthor()`)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@ Part of Skillsmith: a lifecycle layer for agent skills across teams.
 
 ## Contents
 
-- [What's New](#whats-new-in-v087)
+- [What's New](#whats-new-in-v088)
 - [Installation](#installation)
 - [Commands](#commands)
   - [inventory](#inventory)
@@ -16,7 +16,7 @@ Part of Skillsmith: a lifecycle layer for agent skills across teams.
 - [Examples](#examples)
 - [Privacy & Data Handling](#privacy--data-handling)
 
-## What's New in v0.8.7
+## What's New in v0.8.8
 
 - **Multi-client targeting fixed across the board**: `install`, `list`, `remove`, `update`, `sync`, and `search -i`'s install action now all honor `SKILLSMITH_CLIENT`/`--client` consistently — previously several of these silently acted on the Claude Code directory regardless of the flag or env var.
 - **`update` no longer fails after a fresh install**: now resolves the installed skill's registry source from the manifest `install` already writes, instead of a dead-code path that could never find it.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/cli",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
   "type": "module",
   "bin": {
@@ -39,14 +39,14 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@skillsmith/core": "^0.11.7",
-    "@skillsmith/mcp-server": "^0.7.9",
+    "@skillsmith/core": "^0.11.8",
+    "@skillsmith/mcp-server": "^0.7.10",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@smith-horn/enterprise": "^0.3.7"
+    "@smith-horn/enterprise": "^0.3.8"
   },
   "peerDependenciesMeta": {
     "@smith-horn/enterprise": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.11.8
+
+- **Fix**: resolve real tier for device-login sessions (#2463)
 - **Feature**: new `resolveSessionTier` client (`sync/license-status-client.ts`, SMI-6098) —
   authenticates the stored device-login session against `/license-status` (proactively refreshing
   via the existing `resolveAccessToken` helper) so the MCP server can resolve a real subscription

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,13 +6,13 @@ Part of Skillsmith: a lifecycle layer for agent skills across teams.
 
 ## Contents
 
-- [What's New](#whats-new-in-v0117)
+- [What's New](#whats-new-in-v0118)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Features](#features)
 - [Exports](#exports)
 
-## What's New in v0.11.7
+## What's New in v0.11.8
 
 - **Security-status reporting unified**: CLI and MCP now derive security-scan status (pass/fail, risk score, findings count) from one shared `deriveSecuritySummaryFromApiSkill`/`deriveSecuritySummaryFromSkillRow`, instead of two independently-maintained copies that could disagree on the same skill.
 - **`skill_compare` reuses `get_skill`'s resolution**: new shared `resolveSkillApiFirst()` fixes compare only ever hitting the local SQLite cache (no longer kept in sync with the remote-first registry), which made real, searchable skills report "not found."

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.11.7'
+export const VERSION = '0.11.8'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/enterprise/CHANGELOG.md
+++ b/packages/enterprise/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@smith-horn/enterprise` are documented here.
 
 ## [Unreleased]
 
+## v0.3.8
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.3.7).
 - **Fix**: the shared `TIER_PRICING` runtime constant (`license/degradation-types.ts`), consumed
   by both the MCP server's and CLI's own tier-gating/upgrade-nudge messages, plus several TSDoc
   comments repeating the same figure, hardcoded the literal unpublished Enterprise price

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smith-horn/enterprise",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
   "type": "module",
   "main": "./dist/src/index.js",
@@ -44,13 +44,13 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1106.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.76.0",
-    "@skillsmith/core": "^0.11.7",
+    "@skillsmith/core": "^0.11.8",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.7.9",
+    "@skillsmith/mcp-server": "^0.7.10",
     "@smithy/config-resolver": "4.6.16",
     "@smithy/core": "3.31.1",
     "@smithy/middleware-endpoint": "4.6.16",
@@ -62,7 +62,7 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.7.9"
+    "@skillsmith/mcp-server": "^0.7.10"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.7.10
+
+- **Fix**: remove SUPABASE_SERVICE_ROLE_KEY from customer-facing private registry reads (#2472)
+- **Fix**: resolve real tier for device-login sessions (#2463)
+- **Fix**: SMI-6088 fix namespace-wording gaps GPT-5.6-Sol found (#2457)
 - **Security**: `private_registry_manage`'s `list`, `get`, and `namespace` actions no longer
   require `SUPABASE_SERVICE_ROLE_KEY` on the MCP host. They previously ran on the Supabase
   service-role client — the backend's most powerful credential, which bypasses row-level security

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,7 +6,7 @@ MCP (Model Context Protocol) server for agent skill publishing, installation, an
 
 Part of Skillsmith: a lifecycle layer for agent skills across teams.
 
-## What's New in v0.7.9
+## What's New in v0.7.10
 
 - **`search`'s `limit` parameter actually works now**: previously advertised in the tool description but silently dropped — no `limit` field existed in the input schema at all. Now threaded through both the API and local-fallback paths, clamped to `[1, 100]`.
 - **`skill_compare` and `skill_recommend` fixed**: compare now resolves any skill `search`/`get_skill` can find (was local-cache-only); recommend no longer 400s or silently zeroes on an empty derived stack — both return a structured, actionable result instead.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
   "type": "module",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@cyclonedx/cyclonedx-library": "10.1.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.11.7",
+    "@skillsmith/core": "^0.11.8",
     "@supabase/supabase-js": "2.112.2",
     "ajv-formats-draft2019": "1.6.1",
     "ulid": "3.0.1",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.7.9",
+  "version": "0.7.10",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": ["claude-code", "agent-skills", "autonomous-agents", "openclaw"]
@@ -17,7 +17,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -120,7 +120,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.7.9'
+const PACKAGE_VERSION = '0.7.10'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 const logger = createLogger('mcp', { version: PACKAGE_VERSION }) // SMI-5615
 import { installBundledSkills, installUserDocs } from './onboarding/install-assets.js'

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## v0.7.8
+
+- **Docs**: SMI-6088 governance retro sweep — 4 more namespace-wording gaps (#2458)
 - **Docs**: `McpClient.skillInventoryAudit`'s JSDoc comment and the README's "Audit Skill
   Inventory" row now state the tool's actual scope (every installed AI coding client's skill
   inventory, not just `~/.claude/`), and use the "local namespace collisions" qualifier

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "skillsmith-vscode",
   "displayName": "Skillsmith",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "publisher": "skillsmith",
   "engines": {
     "vscode": "^1.110.0"


### PR DESCRIPTION
Automated weekly release cadence PR opened by `release-cadence.yml` (SMI-4191).

## What this PR does

Runs `scripts/prepare-release.ts --all=patch` to bump all packages by one patch version and drain per-package CHANGELOG `[Unreleased]` sections into the new versions.

## What to check before merging

1. The bumped versions match what you want to ship (patch/minor/major). If minor or major is needed, close this PR, run `prepare-release.ts` with the right flags locally, and open a manual PR.
2. The CHANGELOG entries read cleanly and reference the right Linear issues.
3. CI is green.

## After merging

Trigger publish: `gh workflow run publish.yml -f dry_run=false`. The `create-gh-release` job will create matching GitHub Releases automatically.

Parent: SMI-4144. See [ADR-114](docs/internal/adr/114-release-cadence-and-gh-release-alignment.md).