### PR TITLE
fix(website): scope registry dashboard's dynamic styles with :global()

### DIFF
--- a/packages/website/src/pages/account/team/registry.astro
+++ b/packages/website/src/pages/account/team/registry.astro
@@ -218,33 +218,42 @@ const supabaseConfig = getSupabaseConfig()
     gap: 1rem;
   }
 
-  .skill-card,
-  .submission-card {
+  /* Astro's scoped-style attribute is only ever stamped onto elements that exist in THIS
+     component's static template. Everything below is built as an HTML string in the <script>
+     block (renderSkills/renderPending/renderRejected) and inserted via innerHTML — Astro never
+     sees those elements, so a plain scoped selector like `.version-row { ... }` silently never
+     matches them. :global() is the documented escape hatch: it emits the selector without the
+     scope attribute, so it still applies to this same client-rendered markup. Confirmed live
+     (2026-08-23): without :global(), .version-row computed to `display: block; gap: normal`
+     instead of the grid/gap declared here — the exact cause of a reported "no space between the
+     text and the button" bug, since every spacing rule in this block was silently inert. */
+  :global(.skill-card),
+  :global(.submission-card) {
     background: #1a1a1f;
     border: 1px solid #2a2a2f;
     border-radius: 0.75rem;
     padding: 1.25rem;
   }
 
-  .skill-card:hover,
-  .submission-card:hover {
+  :global(.skill-card:hover),
+  :global(.submission-card:hover) {
     border-color: #3a3a42;
   }
 
-  .skill-name,
-  .submission-name {
+  :global(.skill-name),
+  :global(.submission-name) {
     font-size: 1rem;
     font-weight: 600;
     overflow-wrap: anywhere;
   }
 
-  .version-list {
+  :global(.version-list) {
     display: flex;
     flex-direction: column;
     margin-top: 0.75rem;
   }
 
-  .version-row {
+  :global(.version-row) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 1rem;
@@ -253,32 +262,32 @@ const supabaseConfig = getSupabaseConfig()
     border-top: 1px solid #2a2a2f;
   }
 
-  .version-details {
+  :global(.version-details) {
     min-width: 0;
   }
 
-  .version-heading,
-  .badge-row,
-  .submission-header,
-  .submission-actions {
+  :global(.version-heading),
+  :global(.badge-row),
+  :global(.submission-header),
+  :global(.submission-actions) {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
     gap: 0.5rem;
   }
 
-  .submission-header {
+  :global(.submission-header) {
     justify-content: space-between;
     margin-bottom: 0.5rem;
   }
 
-  .submission-actions {
+  :global(.submission-actions) {
     margin-top: 1rem;
   }
 
-  .version-description,
-  .submission-description,
-  .review-note {
+  :global(.version-description),
+  :global(.submission-description),
+  :global(.review-note) {
     color: #9ca3af;
     font-size: 0.875rem;
     line-height: 1.5;
@@ -286,16 +295,16 @@ const supabaseConfig = getSupabaseConfig()
     overflow-wrap: anywhere;
   }
 
-  .version-meta,
-  .submission-meta {
+  :global(.version-meta),
+  :global(.submission-meta) {
     color: #6b7280;
     font-size: 0.8125rem;
     margin-top: 0.5rem;
   }
 
-  .status-badge,
-  .version-badge,
-  .deprecated-badge {
+  :global(.status-badge),
+  :global(.version-badge),
+  :global(.deprecated-badge) {
     display: inline-flex;
     align-items: center;
     padding: 0.25rem 0.625rem;
@@ -304,38 +313,41 @@ const supabaseConfig = getSupabaseConfig()
     font-weight: 500;
   }
 
-  .version-badge {
+  :global(.version-badge) {
     color: #d1d5db;
     background: #2a2a2f;
   }
 
-  .status-approved {
+  :global(.status-approved) {
     color: #6ee7b7;
     background: rgba(16, 185, 129, 0.12);
   }
 
-  .status-pending {
+  :global(.status-pending) {
     color: #fcd34d;
     background: rgba(245, 158, 11, 0.12);
   }
 
-  .status-rejected {
+  :global(.status-rejected) {
     color: #fca5a5;
     background: rgba(239, 68, 68, 0.12);
   }
 
-  .deprecated-badge,
-  .status-deprecated {
+  :global(.deprecated-badge),
+  :global(.status-deprecated) {
     color: #c4b5fd;
     background: rgba(139, 92, 246, 0.14);
   }
 
-  .status-unknown {
+  :global(.status-unknown) {
     color: #d1d5db;
     background: #2a2a2f;
   }
 
-  .btn {
+  /* .btn/.btn-primary are also used by the static "Try Again" button in #error-state — :global()
+     matches that element too (it only drops the attribute requirement, never excludes anything),
+     so this is safe for both the static and client-rendered usages. */
+  :global(.btn) {
     padding: 0.5rem 1rem;
     border-radius: 8px;
     font-family: inherit;
@@ -348,41 +360,41 @@ const supabaseConfig = getSupabaseConfig()
       opacity 0.15s;
   }
 
-  .btn:disabled {
+  :global(.btn:disabled) {
     opacity: 0.5;
     cursor: not-allowed;
   }
 
   /* Skillsmith's actual primary brand color is coral (--color-coral, global.css) — this page
      previously hardcoded an unrelated rust-orange (#b8523a) instead of the real brand token. */
-  .btn-primary {
+  :global(.btn-primary) {
     background: var(--color-coral);
     color: #fafafa;
   }
 
-  .btn-primary:hover:not(:disabled) {
+  :global(.btn-primary:hover:not(:disabled)) {
     background: var(--color-coral-dark);
   }
 
-  .btn-secondary {
+  :global(.btn-secondary) {
     background: var(--color-bg-tertiary);
     color: #fafafa;
   }
 
-  .btn-secondary:hover:not(:disabled) {
+  :global(.btn-secondary:hover:not(:disabled)) {
     background: #3a3a42;
   }
 
-  .btn-danger {
+  :global(.btn-danger) {
     color: #fca5a5;
     background: rgba(239, 68, 68, 0.14);
   }
 
-  .btn-danger:hover:not(:disabled) {
+  :global(.btn-danger:hover:not(:disabled)) {
     background: rgba(239, 68, 68, 0.24);
   }
 
-  .btn-small {
+  :global(.btn-small) {
     padding: 0.375rem 0.75rem;
     white-space: nowrap;
   }
@@ -442,16 +454,16 @@ const supabaseConfig = getSupabaseConfig()
   }
 
   @media (max-width: 640px) {
-    .version-row {
+    :global(.version-row) {
       grid-template-columns: 1fr;
     }
 
-    .version-row > .btn {
+    :global(.version-row) > :global(.btn) {
       justify-self: start;
     }
 
     .section-header,
-    .submission-header {
+    :global(.submission-header) {
       align-items: flex-start;
       flex-direction: column;
     }


### PR DESCRIPTION
## Business Summary

**What shipped:** After fixing the private registry dashboard's Approve/Reject buttons (#2477), a follow-up bug report found no visible spacing between description text and the action buttons. The real cause was bigger than a missing margin: this page builds its skill cards, submission cards, and version rows as HTML strings in a script and inserts them into the page directly, and Astro's per-page style scoping never reaches content built that way — so every spacing/layout rule meant for those elements was silently being ignored, not just the ones for margins.

**Quality bar:** Verified by reading the browser's actual computed styles in production, not just re-reading the CSS: the `.version-row` element was measured to compute `display: block` instead of the declared `display: grid`, confirming the scoping was the real cause before writing a fix. Confirmed the fix compiles correctly by inspecting the built CSS output directly.

**Found along the way:** This scoping gap affects every dynamically-rendered class on this page (cards, badges, buttons, spacing) — not just the one that was reported. Fixed all of them in the same pass rather than patching only the reported symptom.

**Net result:** The dashboard's skill/submission cards, badges, and buttons now render with their intended spacing and layout everywhere on the page, not just where someone happened to report it.

## Technical detail

Root cause: `registry.astro` renders `.skill-card`/`.submission-card`/`.version-row` and their children as template-literal HTML strings in a `<script>` block (`renderSkills`/`renderPending`/`renderRejected`), inserted via `innerHTML`. Astro's compiler never sees that markup, so it never stamps the `data-astro-cid-*` scope attribute onto it — every scoped `<style>` rule targeting those classes silently never matched.

Confirmed live via `getComputedStyle()`: `.version-row` computed to `display: block; gap: normal` instead of the declared `display: grid; gap: 1rem` — the actual cause of the reported "no space between text and button" bug.

Fix: wrap every selector exclusively used by the dynamically-rendered markup in `:global(...)`, Astro's documented escape hatch for exactly this case. `.section-header` (used only in the static template) stays scoped; split it from its dynamic-only sibling `.submission-header` in their shared media-query rule.

Verified against the compiled build output: `.version-row` now compiles without the `[data-astro-cid-*]` attribute requirement, while `.section-header` still correctly carries it.

## Test plan

- [x] `npx astro check` — 0 errors
- [x] `npx astro build` — compiled CSS inspected directly, confirms `:global()` selectors dropped the scope attribute and `.section-header` retained it
- [ ] CI

Pushed with `--no-verify` (explicit user sign-off) — an unrelated, actively-running background process (another session's SMI-6015 rehearsal, ~4h dispatch) was writing a large checkpoint file to the repo root that tripped the repo-wide prettier pre-push check; the file has nothing to do with this diff, and touching it further risked disrupting that other process. Security tests, secrets scan, and format-check on this actual diff were all independently verified clean beforehand.