### PR TITLE
fix(website): guard team-gated account pages against stale async navigation (SMI-6112)

### DIFF
--- a/packages/website/src/lib/account-nav.ts
+++ b/packages/website/src/lib/account-nav.ts
@@ -6,6 +6,8 @@
  * src/components/AccountSidebar.astro.
  */
 
+import { normalizeAccountPath } from './account-page-path'
+
 export interface AccountNavItem {
   href: string
   label: string
@@ -46,19 +48,16 @@ export const ACCOUNT_NAV_SECTIONS: AccountNavSection[] = [
   },
 ]
 
-function stripTrailingSlash(path: string): string {
-  return path.length > 1 ? path.replace(/\/+$/, '') : path
-}
-
 /**
  * Whether a sidebar item should render as active for the current path.
  *
  * Every retained item is an exact match after trailing-slash normalization,
  * so `/account/cli-token/` matches both slash forms and no item lights up
- * on subpages it doesn't own.
+ * on subpages it doesn't own. Normalization is shared with
+ * `isCurrentAccountPath()` (`account-page-path.ts`) so the sidebar's
+ * active-link matching and the page-load entry guards can never drift into
+ * accepting different slash forms.
  */
 export function isActiveAccountNav(href: string, currentPath: string): boolean {
-  const current = stripTrailingSlash(currentPath)
-  const target = stripTrailingSlash(href)
-  return current === target
+  return normalizeAccountPath(currentPath) === normalizeAccountPath(href)
 }

--- a/packages/website/src/lib/account-navigation-epoch.test.ts
+++ b/packages/website/src/lib/account-navigation-epoch.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the navigation-epoch guard (SMI-6112).
+ *
+ * `packages/website/vitest.config.ts` runs the `node` environment (no
+ * `document`), so these tests drive the guard via the directly-exported
+ * `advanceNavigationEpoch()` rather than a real `astro:page-load` DOM event
+ * — see the module's own doc comment for why that export exists.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { advanceNavigationEpoch, createNavigationEpochGuard } from './account-navigation-epoch'
+
+describe('createNavigationEpochGuard', () => {
+  it('reports fresh (not stale) immediately after capture', () => {
+    const guard = createNavigationEpochGuard()
+    expect(guard.isStale()).toBe(false)
+  })
+
+  it('reports stale once a newer astro:page-load fires', () => {
+    const guard = createNavigationEpochGuard()
+    advanceNavigationEpoch()
+    expect(guard.isStale()).toBe(true)
+  })
+
+  it('stays fresh across repeated isStale() calls when no navigation occurred', () => {
+    const guard = createNavigationEpochGuard()
+    expect(guard.isStale()).toBe(false)
+    expect(guard.isStale()).toBe(false)
+    expect(guard.isStale()).toBe(false)
+  })
+
+  it('remains stale after multiple subsequent advances, not just the first', () => {
+    const guard = createNavigationEpochGuard()
+    advanceNavigationEpoch()
+    advanceNavigationEpoch()
+    advanceNavigationEpoch()
+    expect(guard.isStale()).toBe(true)
+  })
+
+  it('a guard captured AFTER an advance is fresh relative to that advance', () => {
+    advanceNavigationEpoch()
+    const guard = createNavigationEpochGuard()
+    expect(guard.isStale()).toBe(false)
+  })
+
+  it('models the A-B-A case: an older guard stays stale even after a newer guard is also stale', () => {
+    // First navigation: page mounts, captures its epoch.
+    const first = createNavigationEpochGuard()
+
+    // User navigates away, then back to the same route: two more
+    // astro:page-load events fire, and the page mounts again, capturing a
+    // second, fresher guard.
+    advanceNavigationEpoch()
+    advanceNavigationEpoch()
+    const second = createNavigationEpochGuard()
+
+    expect(first.isStale()).toBe(true)
+    expect(second.isStale()).toBe(false)
+
+    // A third navigation invalidates both.
+    advanceNavigationEpoch()
+    expect(first.isStale()).toBe(true)
+    expect(second.isStale()).toBe(true)
+  })
+
+  it('independent guards captured at the same epoch share staleness', () => {
+    const guardA = createNavigationEpochGuard()
+    const guardB = createNavigationEpochGuard()
+    expect(guardA.epoch).toBe(guardB.epoch)
+    advanceNavigationEpoch()
+    expect(guardA.isStale()).toBe(true)
+    expect(guardB.isStale()).toBe(true)
+  })
+})

--- a/packages/website/src/lib/account-navigation-epoch.ts
+++ b/packages/website/src/lib/account-navigation-epoch.ts
@@ -1,0 +1,81 @@
+/**
+ * Navigation-epoch guard for stale async continuations on team-gated account
+ * pages (SMI-6112).
+ *
+ * Problem: an `astro:page-load` handler on a gated account page validates
+ * its pathname once at entry, then `await`s a tier-check RPC (and, on some
+ * pages, a session lookup and/or a further data load) before applying a
+ * redirect or writing to the DOM. Because `astro:page-load` listeners
+ * persist across Astro ClientRouter view transitions, the user can navigate
+ * away — or away and back to the SAME route (the A-B-A case) — while any of
+ * those `await`s is still in flight. A single pathname recheck placed after
+ * only the first `await` cannot close either case: it doesn't protect later
+ * continuations, and on a return visit it would wrongly let an older,
+ * slower-resolving check win a race against a newer, faster one for the
+ * same route.
+ *
+ * Fix: every genuine `astro:page-load` event (each one represents a
+ * completed navigation, including the initial load) advances a single
+ * module-level epoch counter. A gated page captures the epoch once, right
+ * after its entry pathname guard passes and before its first `await`. Every
+ * continuation that would otherwise mutate state — a redirect, a
+ * `data-team-entitled`/`setTeamEntitled` write, an error/not-member render,
+ * or a DOM write of loaded data — checks `isStale()` immediately beforehand
+ * and returns without acting if a newer navigation has since occurred.
+ *
+ * Testability: `packages/website/vitest.config.ts` runs the `node`
+ * environment (see `vitest.preset.ts`), not `jsdom` — there is no real
+ * `document` to dispatch events against in unit tests. `advanceNavigationEpoch()`
+ * is exported directly (not only reachable via a DOM event) so unit tests
+ * can simulate a fresh `astro:page-load` firing without a DOM; it is also
+ * the function wired to the real event below for production use.
+ */
+
+let currentEpoch = 0
+let listenerRegistered = false
+
+/**
+ * Advance the shared navigation epoch. Any `NavigationEpochGuard` captured
+ * before this call reports `isStale() === true` afterward. Wired to the
+ * real `astro:page-load` event via `registerNavigationEpochListener()`
+ * below; exported directly so it can also be invoked from unit tests that
+ * have no DOM to dispatch a real event against.
+ */
+export function advanceNavigationEpoch(): void {
+  currentEpoch += 1
+}
+
+/**
+ * Register the module's `astro:page-load` listener on `document`, guarded
+ * so it registers at most once even if this module is imported from
+ * multiple page scripts within the same browser session. No-ops outside a
+ * browser (e.g. under the `node` vitest environment) — `advanceNavigationEpoch()`
+ * remains directly callable there for tests.
+ */
+function registerNavigationEpochListener(): void {
+  if (listenerRegistered || typeof document === 'undefined') return
+  document.addEventListener('astro:page-load', advanceNavigationEpoch)
+  listenerRegistered = true
+}
+
+registerNavigationEpochListener()
+
+export interface NavigationEpochGuard {
+  /** The epoch captured at creation time. Exposed for debugging/tests. */
+  readonly epoch: number
+  /** True once a newer `astro:page-load` has fired since this guard was created. */
+  isStale: () => boolean
+}
+
+/**
+ * Capture the current navigation epoch. Call once per `astro:page-load`
+ * invocation, immediately after the entry pathname guard
+ * (`isCurrentAccountPath`) passes and before the handler's first `await`.
+ */
+export function createNavigationEpochGuard(): NavigationEpochGuard {
+  const epoch = currentEpoch
+  return {
+    epoch,
+    isStale: () => epoch !== currentEpoch,
+  }
+}

--- a/packages/website/src/lib/account-navigation-epoch.ts
+++ b/packages/website/src/lib/account-navigation-epoch.ts
@@ -51,6 +51,18 @@ export function advanceNavigationEpoch(): void {
  * multiple page scripts within the same browser session. No-ops outside a
  * browser (e.g. under the `node` vitest environment) — `advanceNavigationEpoch()`
  * remains directly callable there for tests.
+ *
+ * Why `listenerRegistered` is sufficient here (and the usual
+ * `window.__xInited` idempotency pattern for `astro:page-load` binds isn't
+ * needed): this call happens once at MODULE top-level, not from inside a
+ * page-load handler. Astro's ClientRouter swaps the DOM without a full page
+ * reload, so the browser's ES-module cache — which dedupes module
+ * evaluation by resolved URL within a single document — evaluates this
+ * module's top-level code (including this call) exactly once per SPA
+ * session, no matter how many pages import it across however many view
+ * transitions. `listenerRegistered` guards the reverse case (calling this
+ * function more than once within that single evaluation), not repeated
+ * evaluation across transitions.
  */
 function registerNavigationEpochListener(): void {
   if (listenerRegistered || typeof document === 'undefined') return

--- a/packages/website/src/lib/account-page-path.test.ts
+++ b/packages/website/src/lib/account-page-path.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the shared account-area path normalization (SMI-6112).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { isCurrentAccountPath, normalizeAccountPath } from './account-page-path'
+
+/** The five team-gated account pages this predicate guards (SMI-6112). */
+const CANONICAL_PATHS = [
+  '/account',
+  '/account/team/members',
+  '/account/team/workspaces',
+  '/account/team/registry',
+  '/account/team/analytics',
+] as const
+
+describe('normalizeAccountPath', () => {
+  it('strips a single trailing slash', () => {
+    expect(normalizeAccountPath('/account/')).toBe('/account')
+  })
+
+  it('strips multiple trailing slashes', () => {
+    expect(normalizeAccountPath('/account///')).toBe('/account')
+  })
+
+  it('leaves a path with no trailing slash unchanged', () => {
+    expect(normalizeAccountPath('/account/team/members')).toBe('/account/team/members')
+  })
+
+  it('leaves the root path as-is rather than stripping it to an empty string', () => {
+    expect(normalizeAccountPath('/')).toBe('/')
+  })
+})
+
+describe('isCurrentAccountPath', () => {
+  it('accepts every canonical path against itself', () => {
+    for (const path of CANONICAL_PATHS) {
+      expect(isCurrentAccountPath(path, path), path).toBe(true)
+    }
+  })
+
+  it('accepts every canonical path with a trailing slash on the actual path', () => {
+    for (const path of CANONICAL_PATHS) {
+      expect(isCurrentAccountPath(`${path}/`, path), path).toBe(true)
+    }
+  })
+
+  it('accepts every canonical path with a trailing slash on the expected path', () => {
+    for (const path of CANONICAL_PATHS) {
+      expect(isCurrentAccountPath(path, `${path}/`), path).toBe(true)
+    }
+  })
+
+  it('accepts a trailing slash on both sides', () => {
+    for (const path of CANONICAL_PATHS) {
+      expect(isCurrentAccountPath(`${path}/`, `${path}/`), path).toBe(true)
+    }
+  })
+
+  it('rejects every other route', () => {
+    expect(isCurrentAccountPath('/account/summary', '/account')).toBe(false)
+    expect(isCurrentAccountPath('/account/team', '/account')).toBe(false)
+    expect(isCurrentAccountPath('/account/team/members', '/account/team/workspaces')).toBe(false)
+    expect(isCurrentAccountPath('/account/team/registry', '/account/team/analytics')).toBe(false)
+    expect(isCurrentAccountPath('/login', '/account')).toBe(false)
+    expect(isCurrentAccountPath('/', '/account')).toBe(false)
+  })
+
+  it('rejects a subpath of the expected route', () => {
+    expect(isCurrentAccountPath('/account/team/members/1', '/account/team/members')).toBe(false)
+  })
+
+  it('is not fooled by a shared prefix', () => {
+    expect(isCurrentAccountPath('/account/team/membersextra', '/account/team/members')).toBe(false)
+  })
+})

--- a/packages/website/src/lib/account-page-path.ts
+++ b/packages/website/src/lib/account-page-path.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared account-area path normalization (SMI-6112).
+ *
+ * Trailing-slash normalization used to live only inside `account-nav.ts`'s
+ * private `stripTrailingSlash()`, scoped to the sidebar's active-link
+ * matcher. `isCurrentAccountPath()` below needs the identical semantics for
+ * the `astro:page-load` entry guard on the five team-gated account pages, so
+ * this module is the single shared source — `account-nav.ts`'s
+ * `isActiveAccountNav()` imports `normalizeAccountPath()` from here rather
+ * than keeping its own copy, so the two can never drift into accepting
+ * different slash forms.
+ */
+
+/**
+ * Normalize a path for exact-match comparison: strip one or more trailing
+ * slashes, except for the root path `/` itself (which stays as `/`).
+ */
+export function normalizeAccountPath(path: string): string {
+  return path.length > 1 ? path.replace(/\/+$/, '') : path
+}
+
+/**
+ * Whether `actualPath` (typically `window.location.pathname`) is the same
+ * route as `expectedPath`, treating `/path` and `/path/` as equivalent and
+ * rejecting every other route.
+ *
+ * Used as the entry guard in each of the five team-gated account pages'
+ * `astro:page-load` handlers — a stale handler that fired for a different
+ * route (because `astro:page-load` listeners persist across ClientRouter
+ * view transitions and re-fire on every navigation) must never proceed past
+ * this check. This is the FIRST line of defense; the navigation-epoch guard
+ * (`account-navigation-epoch.ts`) covers the remaining suspend points a
+ * single entry check cannot close on its own (SMI-6112 plan review Finding
+ * #1 — a handler that passed the entry guard can still go stale mid-flight,
+ * across an `await`, or in the A-B-A case where the user leaves and returns
+ * to the same route before the first check resolves).
+ */
+export function isCurrentAccountPath(actualPath: string, expectedPath: string): boolean {
+  return normalizeAccountPath(actualPath) === normalizeAccountPath(expectedPath)
+}

--- a/packages/website/src/pages/account/index.astro
+++ b/packages/website/src/pages/account/index.astro
@@ -333,6 +333,8 @@ const supabaseConfig = getSupabaseConfig()
     isTeamEntitled,
   } from '../../lib/account-overview-data'
   import { resyncStripeEmailIfPending } from '../../lib/account-flags'
+  import { isCurrentAccountPath } from '../../lib/account-page-path'
+  import { createNavigationEpochGuard } from '../../lib/account-navigation-epoch'
 
   const config = window.__SUPABASE_CONFIG__ || { url: '', anonKey: '' }
 
@@ -368,7 +370,17 @@ const supabaseConfig = getSupabaseConfig()
     // Only run on this page. L13: this guard used to accept /account/team
     // and /account/team/ — it now accepts /account and /account/ since this
     // page moved here (Decision #1).
-    if (window.location.pathname !== '/account' && window.location.pathname !== '/account/') return
+    if (!isCurrentAccountPath(window.location.pathname, '/account')) return
+
+    // SMI-6112: navigation-epoch guard. The entry pathname check above only
+    // protects against a handler that fired for a route the user has
+    // already left. It cannot protect the continuations below — each
+    // crosses an `await`, during which a ClientRouter view transition can
+    // complete (including the A-B-A case: leaving and returning to /account
+    // before an earlier check resolves). Capture the epoch now, and check
+    // `nav.isStale()` immediately before every subsequent redirect,
+    // entitlement write, error render, or DOM write of loaded data.
+    const nav = createNavigationEpochGuard()
 
     // Bind CSP-safe reload handler (SMI-4311)
     document.querySelectorAll<HTMLButtonElement>('[data-action="reload"]').forEach((btn) => {
@@ -390,6 +402,7 @@ const supabaseConfig = getSupabaseConfig()
     // profiles/subscriptions at request time. Frozen per the plan; only
     // this call site's branching on the result changed (Decision #4/C1).
     const gate = await checkTeamAccess(supabase)
+    if (nav.isStale()) return
     setTeamEntitled(isTeamEntitled(gate))
 
     if (!gate.ok) {
@@ -411,6 +424,7 @@ const supabaseConfig = getSupabaseConfig()
     const {
       data: { session },
     } = await supabase.auth.getSession()
+    if (nav.isStale()) return
     if (!session) {
       // L13: this literal used to read /account/team.
       window.location.href = '/login?redirect=/account'
@@ -423,6 +437,7 @@ const supabaseConfig = getSupabaseConfig()
 
     try {
       const data = await loadTeamOverviewData(supabase, teamId)
+      if (nav.isStale()) return
 
       document.getElementById('team-name')!.textContent = data.teamName
       document.getElementById('member-count')!.textContent = String(data.memberCount)
@@ -452,6 +467,7 @@ const supabaseConfig = getSupabaseConfig()
 
       showState('content')
     } catch (err) {
+      if (nav.isStale()) return
       console.error('Team dashboard load failed:', err)
       showState('error', err instanceof Error ? err.message : 'Unexpected error.')
     }

--- a/packages/website/src/pages/account/team/analytics.astro
+++ b/packages/website/src/pages/account/team/analytics.astro
@@ -184,6 +184,8 @@ const supabaseConfig = getSupabaseConfig()
   import { createClient } from '@supabase/supabase-js'
   import { checkTeamAccess, resolveGateRedirect } from '../../../lib/team-access'
   import { isTeamEntitled } from '../../../lib/account-overview-data'
+  import { isCurrentAccountPath } from '../../../lib/account-page-path'
+  import { createNavigationEpochGuard } from '../../../lib/account-navigation-epoch'
 
   const config = window.__SUPABASE_CONFIG__ || { url: '', anonKey: '' }
 
@@ -210,11 +212,14 @@ const supabaseConfig = getSupabaseConfig()
   }
 
   document.addEventListener('astro:page-load', async () => {
-    if (
-      window.location.pathname !== '/account/team/analytics' &&
-      window.location.pathname !== '/account/team/analytics/'
-    )
-      return
+    if (!isCurrentAccountPath(window.location.pathname, '/account/team/analytics')) return
+
+    // SMI-6112: see account/index.astro's identical comment for the full
+    // rationale — a single entry-path check cannot protect the
+    // continuation below (it crosses an `await`), nor close the A-B-A case
+    // (leaving and returning to this route before an earlier check
+    // resolves).
+    const nav = createNavigationEpochGuard()
 
     document.querySelectorAll<HTMLButtonElement>('[data-action="reload"]').forEach((btn) => {
       btn.addEventListener('click', () => {
@@ -230,6 +235,7 @@ const supabaseConfig = getSupabaseConfig()
     const supabase = createClient(config.url, config.anonKey)
 
     const gate = await checkTeamAccess(supabase)
+    if (nav.isStale()) return
     setTeamEntitled(isTeamEntitled(gate))
     if (!gate.ok) {
       const redirect = resolveGateRedirect(gate, '/account/team/analytics')

--- a/packages/website/src/pages/account/team/members.astro
+++ b/packages/website/src/pages/account/team/members.astro
@@ -384,6 +384,8 @@ const supabaseConfig = getSupabaseConfig()
     wireMemberManagement,
     type Viewer,
   } from '../../../lib/team-invite-ui'
+  import { isCurrentAccountPath } from '../../../lib/account-page-path'
+  import { createNavigationEpochGuard } from '../../../lib/account-navigation-epoch'
 
   const config = window.__SUPABASE_CONFIG__ || { url: '', anonKey: '' }
 
@@ -410,11 +412,14 @@ const supabaseConfig = getSupabaseConfig()
   }
 
   document.addEventListener('astro:page-load', async () => {
-    if (
-      window.location.pathname !== '/account/team/members' &&
-      window.location.pathname !== '/account/team/members/'
-    )
-      return
+    if (!isCurrentAccountPath(window.location.pathname, '/account/team/members')) return
+
+    // SMI-6112: see account/index.astro's identical comment for the full
+    // rationale — a single entry-path check cannot protect the
+    // continuations below (they each cross an `await`), nor close the
+    // A-B-A case (leaving and returning to this route before an earlier
+    // check resolves).
+    const nav = createNavigationEpochGuard()
 
     // Bind CSP-safe reload handler (SMI-4311)
     document.querySelectorAll<HTMLButtonElement>('[data-action="reload"]').forEach((btn) => {
@@ -432,6 +437,7 @@ const supabaseConfig = getSupabaseConfig()
 
     // SMI-4321: authoritative tier-gate via check_team_tier_access RPC.
     const gate = await checkTeamAccess(supabase)
+    if (nav.isStale()) return
     setTeamEntitled(isTeamEntitled(gate))
     if (!gate.ok) {
       const redirect = resolveGateRedirect(gate, '/account/team/members')
@@ -465,13 +471,21 @@ const supabaseConfig = getSupabaseConfig()
       }
       const viewer: Viewer = { role: viewerRole, userId: viewerUserId }
 
+      // Guard once before the first DOM-writing continuation: it covers
+      // staleness accumulated across all three prior awaits (getUser, the
+      // role RPC) in one check, matching how /account treats its own
+      // multi-query loadTeamOverviewData() as a single suspend point.
+      if (nav.isStale()) return
       await refreshMembersList(supabase, teamId, viewer)
+      if (nav.isStale()) return
       await refreshPendingList(supabase, teamId)
+      if (nav.isStale()) return
       wireInviteFlow(supabase, teamId)
       wireMemberManagement(supabase, teamId, viewer)
 
       showState('content')
     } catch (err) {
+      if (nav.isStale()) return
       console.error('Members load failed:', err)
       showState('error', err instanceof Error ? err.message : 'Unexpected error.')
     }

--- a/packages/website/src/pages/account/team/registry.astro
+++ b/packages/website/src/pages/account/team/registry.astro
@@ -470,6 +470,8 @@ const supabaseConfig = getSupabaseConfig()
     setRegistryVersionDeprecated,
     type PrivateRegistryDashboardRow,
   } from '../../../lib/private-registry-dashboard'
+  import { isCurrentAccountPath } from '../../../lib/account-page-path'
+  import { createNavigationEpochGuard } from '../../../lib/account-navigation-epoch'
 
   const config = window.__SUPABASE_CONFIG__ || { url: '', anonKey: '' }
 
@@ -527,11 +529,14 @@ const supabaseConfig = getSupabaseConfig()
   }
 
   document.addEventListener('astro:page-load', async () => {
-    if (
-      window.location.pathname !== '/account/team/registry' &&
-      window.location.pathname !== '/account/team/registry/'
-    )
-      return
+    if (!isCurrentAccountPath(window.location.pathname, '/account/team/registry')) return
+
+    // SMI-6112: see account/index.astro's identical comment for the full
+    // rationale — a single entry-path check cannot protect the
+    // continuations below (they each cross an `await`), nor close the
+    // A-B-A case (leaving and returning to this route before an earlier
+    // check resolves).
+    const nav = createNavigationEpochGuard()
 
     document.querySelectorAll<HTMLButtonElement>('[data-action="reload"]').forEach((btn) => {
       btn.addEventListener('click', () => {
@@ -547,6 +552,7 @@ const supabaseConfig = getSupabaseConfig()
     const supabase = createClient(config.url, config.anonKey)
 
     const gate = await checkTeamAccess(supabase)
+    if (nav.isStale()) return
     setTeamEntitled(isTeamEntitled(gate))
     if (!gate.ok) {
       const redirect = resolveGateRedirect(gate, '/account/team/registry')
@@ -563,6 +569,7 @@ const supabaseConfig = getSupabaseConfig()
     const {
       data: { session },
     } = await supabase.auth.getSession()
+    if (nav.isStale()) return
 
     if (!session) {
       window.location.href = '/login?redirect=/account/team/registry'
@@ -588,6 +595,9 @@ const supabaseConfig = getSupabaseConfig()
         // pending/rejected via the get_private_registry_submissions RPC —
         // see loadRegistryDashboardData's invariant note.
         const registryData = await loadRegistryDashboardData(supabase, teamId)
+        // Local closure (not an external lib call), so the stale-navigation
+        // guard can sit right next to the DOM writes it protects (SMI-6112).
+        if (nav.isStale()) return
 
         const namespaceEl = document.getElementById('registry-namespace')!
         namespaceEl.textContent = registryData.namespace
@@ -850,8 +860,10 @@ const supabaseConfig = getSupabaseConfig()
       }
 
       await loadRegistry()
+      if (nav.isStale()) return
       showState('content')
     } catch (error) {
+      if (nav.isStale()) return
       console.error('Private registry load failed:', error)
       showState('error', error instanceof Error ? error.message : 'Unexpected error.')
     }

--- a/packages/website/src/pages/account/team/workspaces.astro
+++ b/packages/website/src/pages/account/team/workspaces.astro
@@ -412,6 +412,8 @@ const supabaseConfig = getSupabaseConfig()
   import { createClient } from '@supabase/supabase-js'
   import { checkTeamAccess, resolveGateRedirect } from '../../../lib/team-access'
   import { isTeamEntitled } from '../../../lib/account-overview-data'
+  import { isCurrentAccountPath } from '../../../lib/account-page-path'
+  import { createNavigationEpochGuard } from '../../../lib/account-navigation-epoch'
 
   const config = window.__SUPABASE_CONFIG__ || { url: '', anonKey: '' }
 
@@ -444,11 +446,14 @@ const supabaseConfig = getSupabaseConfig()
   }
 
   document.addEventListener('astro:page-load', async () => {
-    if (
-      window.location.pathname !== '/account/team/workspaces' &&
-      window.location.pathname !== '/account/team/workspaces/'
-    )
-      return
+    if (!isCurrentAccountPath(window.location.pathname, '/account/team/workspaces')) return
+
+    // SMI-6112: see account/index.astro's identical comment for the full
+    // rationale — a single entry-path check cannot protect the
+    // continuations below (they each cross an `await`), nor close the
+    // A-B-A case (leaving and returning to this route before an earlier
+    // check resolves).
+    const nav = createNavigationEpochGuard()
 
     // Bind CSP-safe reload handler (SMI-4311)
     document.querySelectorAll<HTMLButtonElement>('[data-action="reload"]').forEach((btn) => {
@@ -466,6 +471,7 @@ const supabaseConfig = getSupabaseConfig()
 
     // SMI-4321: authoritative tier-gate via check_team_tier_access RPC.
     const gate = await checkTeamAccess(supabase)
+    if (nav.isStale()) return
     setTeamEntitled(isTeamEntitled(gate))
     if (!gate.ok) {
       const redirect = resolveGateRedirect(gate, '/account/team/workspaces')
@@ -484,6 +490,7 @@ const supabaseConfig = getSupabaseConfig()
     const {
       data: { session },
     } = await supabase.auth.getSession()
+    if (nav.isStale()) return
     if (!session) {
       window.location.href = '/login?redirect=/account/team/workspaces'
       return
@@ -496,6 +503,9 @@ const supabaseConfig = getSupabaseConfig()
         .eq('team_id', teamId)
         .order('created_at', { ascending: false })
       if (error) throw new Error(error.message)
+      // Local closure (not an external lib call), so the stale-navigation
+      // guard can sit right next to the DOM writes it protects (SMI-6112).
+      if (nav.isStale()) return
 
       const grid = document.getElementById('ws-grid')!
       const empty = document.getElementById('empty-state')!
@@ -518,6 +528,7 @@ const supabaseConfig = getSupabaseConfig()
           return count ?? 0
         })
       )
+      if (nav.isStale()) return
 
       empty.style.display = 'none'
       grid.innerHTML = workspaces
@@ -555,7 +566,9 @@ const supabaseConfig = getSupabaseConfig()
 
       const role = String(myMembership?.role ?? '').toLowerCase()
 
+      if (nav.isStale()) return
       await loadWorkspaces(teamId)
+      if (nav.isStale()) return
 
       // Wire create-workspace flow (admins/owners only per RLS)
       const createBtn = document.getElementById('create-workspace-btn') as HTMLButtonElement
@@ -619,6 +632,7 @@ const supabaseConfig = getSupabaseConfig()
 
       showState('content')
     } catch (err) {
+      if (nav.isStale()) return
       console.error('Workspaces load failed:', err)
       showState('error', err instanceof Error ? err.message : 'Unexpected error.')
     }

--- a/packages/website/tests/e2e/account-page-load-guards.spec.ts
+++ b/packages/website/tests/e2e/account-page-load-guards.spec.ts
@@ -20,8 +20,13 @@
  * (no staging/prod network — prod ref vrcnzpmndtroqxxoqkzy, see CLAUDE.md).
  */
 
-import { test, expect, type Page } from '@playwright/test'
-import { buildSessionToken, injectSupabaseStub, mockSupabase } from './complete-profile.helpers'
+import { test, expect, type Page, type Route } from '@playwright/test'
+import {
+  buildSessionToken,
+  injectSupabaseStub,
+  mockSupabase,
+  SUPABASE_HOST,
+} from './complete-profile.helpers'
 import { refireAstroPageLoad } from './astro-helpers'
 
 // The bug surfaces as a null property access, phrased differently per engine.
@@ -119,5 +124,217 @@ test.describe('account pages — astro:page-load path guards (SMI-5158)', () => 
     await refireAstroPageLoad(page)
 
     expect(hits, hits.join('\n')).toEqual([])
+  })
+})
+
+// ─── SMI-6112: navigation-epoch guard against stale async continuations ──
+//
+// Each `astro:page-load` handler on the five team-gated account pages now
+// captures a navigation epoch after its entry-path guard and rechecks
+// `isStale()` before every redirect / entitlement write / DOM write that
+// follows an `await` (packages/website/src/lib/account-navigation-epoch.ts).
+// These specs drive the real ClientRouter race the fix closes: holding the
+// `check_team_tier_access` RPC response open, navigating away mid-flight,
+// then releasing it — pre-fix, the stale handler would still redirect or
+// write onto a page the user already left.
+
+interface Deferred {
+  promise: Promise<void>
+  resolve: () => void
+}
+
+function makeDeferred(): Deferred {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+/**
+ * Route every Supabase call, holding each successive `check_team_tier_access`
+ * RPC response behind its own release gate (`gates[0]` for the first call
+ * made on the page, `gates[1]` for the second, and so on) so a test can
+ * control exactly when a tier-check resolves relative to a real navigation.
+ * Every other request (auth, REST) answers with the same closed-default
+ * `mockSupabase()` uses (200/`{}`/`[]`) — these specs only care about
+ * tier-check timing, not downstream data.
+ */
+async function mockDelayedTierCheck(
+  page: Page,
+  gateResponses: unknown[]
+): Promise<{ gates: Deferred[]; callCount: () => number }> {
+  const gates = gateResponses.map(() => makeDeferred())
+  let callCount = 0
+
+  await page.route(`${SUPABASE_HOST}/**`, async (route: Route) => {
+    const url = new URL(route.request().url())
+    const rpcMatch = url.pathname.match(/\/rest\/v1\/rpc\/([^/]+)/)
+
+    if (rpcMatch && rpcMatch[1] === 'check_team_tier_access') {
+      const index = callCount
+      callCount += 1
+      const gate = gates[index]
+      const body = gateResponses[index]
+      if (!gate || body === undefined) {
+        await route.fulfill({
+          status: 500,
+          body: `mockDelayedTierCheck: unexpected extra check_team_tier_access call #${index + 1}`,
+        })
+        return
+      }
+      await gate.promise
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      })
+      return
+    }
+
+    if (rpcMatch) {
+      await route.fulfill({ status: 404, body: 'rpc not mocked: ' + rpcMatch[1] })
+      return
+    }
+
+    if (url.pathname.startsWith('/auth/v1/')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+      return
+    }
+
+    // REST — closed-default empty array (keeps unrelated selects from
+    // crashing whichever page the browser lands on).
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  })
+
+  return { gates, callCount: () => callCount }
+}
+
+/**
+ * Instrument the page to count real `astro:page-load` firings, independent
+ * of any application code. `page.waitForURL()` resolves as soon as
+ * ClientRouter updates `location.href`, which can happen before the
+ * destination page's own `astro:page-load` has actually fired — under
+ * `astro dev` a route's first-hit SSR compile can add multi-second lag
+ * between those two moments (the same lag the real CI workflow pre-warms
+ * routes for; see .github/workflows/website-account-e2e.yml). The
+ * navigation-epoch guard only advances on the real event, so these
+ * regressions must wait for the event itself, not just the URL, before
+ * releasing a held response — otherwise a slow-to-fire destination
+ * `astro:page-load` would make a genuinely-stale response look "not yet
+ * stale" by coincidence of timing, independent of the guard's own logic.
+ */
+async function injectPageLoadCounter(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    ;(window as unknown as { __e2ePageLoadCount: number }).__e2ePageLoadCount = 0
+    document.addEventListener('astro:page-load', () => {
+      ;(window as unknown as { __e2ePageLoadCount: number }).__e2ePageLoadCount += 1
+    })
+  })
+}
+
+async function waitForPageLoadCount(page: Page, expected: number): Promise<void> {
+  await expect
+    .poll(() =>
+      page.evaluate(() => (window as unknown as { __e2ePageLoadCount: number }).__e2ePageLoadCount)
+    )
+    .toBeGreaterThanOrEqual(expected)
+}
+
+test.describe('SMI-6112 — navigation-epoch guard against stale async continuations', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectPageLoadCounter(page)
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
+  })
+
+  test('a stale /account tier-check never applies its Summary redirect after navigating away', async ({
+    page,
+  }) => {
+    const { gates, callCount } = await mockDelayedTierCheck(page, [
+      { ok: false, reason: 'not_team_tier', team_id: null, tier: 'community' },
+    ])
+
+    await page.goto('/account')
+    await expect.poll(callCount).toBe(1)
+    await waitForPageLoadCount(page, 1)
+
+    // Real ClientRouter transition away from /account while the tier-check
+    // is still in flight. Wait for the DESTINATION page's own
+    // astro:page-load to have fired — not just for the URL to update — so
+    // the epoch guard has actually advanced before we release the stale
+    // response below.
+    await clickAccountNav(page, '/account/billing', 'sidebar')
+    await expect(page).toHaveURL(/\/account\/billing\/?$/)
+    await waitForPageLoadCount(page, 2)
+
+    // Release the stale response. Pre-fix, /account's Decision #4 redirect
+    // (not_team_tier -> /account/summary) would still fire here even though
+    // the browser is on /account/billing.
+    gates[0].resolve()
+    await page.waitForTimeout(300)
+
+    await expect(page).toHaveURL(/\/account\/billing\/?$/)
+  })
+
+  test('a stale team-admin page tier-check never applies its Subscription redirect after navigating away', async ({
+    page,
+  }) => {
+    const { gates, callCount } = await mockDelayedTierCheck(page, [
+      { ok: false, reason: 'not_team_tier', team_id: null, tier: 'community' },
+    ])
+
+    await page.goto('/account/team/members')
+    await expect.poll(callCount).toBe(1)
+    await waitForPageLoadCount(page, 1)
+
+    await clickAccountNav(page, '/account/billing', 'sidebar')
+    await expect(page).toHaveURL(/\/account\/billing\/?$/)
+    await waitForPageLoadCount(page, 2)
+
+    // Pre-fix, members.astro's handler would still redirect to
+    // /account/subscription?gated=not_team_tier even though the user left.
+    gates[0].resolve()
+    await page.waitForTimeout(300)
+
+    await expect(page).toHaveURL(/\/account\/billing\/?$/)
+  })
+
+  test('A-B-A: a stale first check never applies once a fresher check has resolved for the same route', async ({
+    page,
+  }) => {
+    const { gates, callCount } = await mockDelayedTierCheck(page, [
+      { ok: false, reason: 'not_team_tier', team_id: null, tier: 'community' },
+      { ok: true, reason: null, team_id: 'team_aba', tier: 'team' },
+    ])
+
+    await page.goto('/account')
+    await expect.poll(callCount).toBe(1)
+    await waitForPageLoadCount(page, 1)
+
+    // Leave, then return to /account before the first check resolves — the
+    // return visit issues a second, fresher check. Each wait is on the real
+    // astro:page-load count, not just the URL, for the same reason as above.
+    await clickAccountNav(page, '/account/billing', 'sidebar')
+    await expect(page).toHaveURL(/\/account\/billing\/?$/)
+    await waitForPageLoadCount(page, 2)
+
+    await page.goBack()
+    await expect(page).toHaveURL(/\/account\/?$/)
+    await waitForPageLoadCount(page, 3)
+    await expect.poll(callCount).toBe(2)
+
+    // Release the stale FIRST response. It must never apply — no redirect
+    // to /account/summary triggered by the first, now-superseded check.
+    gates[0].resolve()
+    await page.waitForTimeout(300)
+    await expect(page).toHaveURL(/\/account\/?$/)
+
+    // Release the fresh SECOND (ok:true) response — this is the current
+    // handler's own continuation, so it is free to proceed. The page
+    // settles normally; nothing about the epoch guard blocks its own
+    // non-stale check.
+    gates[1].resolve()
+    await page.waitForTimeout(300)
+    await expect(page).toHaveURL(/\/account\/?$/)
   })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a bug where leaving a team account page (Overview, Members, Workspaces, Registry, or Analytics) while it was still checking your team access could bounce you back to it, or overwrite the page you'd already navigated to, once that stale check finally resolved. Every one of those five pages now confirms you're still on it before applying any redirect or updating the screen.

**Quality bar:** Implementation reviewed line-by-line against every suspend point in all five handlers (not just the common case), independently re-run — typecheck, lint, format, and the full 659-test website suite all pass clean, plus 18 new unit tests for the two new shared guard modules. New Playwright regression coverage for both the simple stale-redirect case and the trickier "leave and come back to the same page" race. Governance review found one Low-severity documentation gap, fixed in the same PR.

**Net result:** Fully shipped — this closes SMI-6112. It's Wave 1 of a two-wave account-navigation plan (`docs/internal/implementation/account-nav-admin-tools-reorg.md`); Wave 2, the Admin/Tools navigation reorganization, is a separate follow-up PR that builds on top of this fix.

---

## Technical detail

**Root cause:** each of the five `astro:page-load` handlers checked the browser's pathname once at entry, then `await`ed a tier-check RPC (and, on some pages, a session lookup and/or a data load) before applying a redirect or writing to the DOM — with no recheck that the user was still on the guarded route after any of those awaits. A single post-`checkTeamAccess()` recheck wouldn't have covered the later suspend points, and couldn't close the "leave and return to the same route before the first check resolves" race either.

**Fix:** a shared navigation-epoch guard (`packages/website/src/lib/account-navigation-epoch.ts`) plus a trailing-slash-normalized entry predicate (`packages/website/src/lib/account-page-path.ts`). Each handler captures the epoch right after its entry guard and checks `isStale()` before every subsequent redirect, entitlement write, error render, or DOM write — including inside page-local data-loading closures (`workspaces.astro`, `registry.astro`), not just at their call sites.

**Files:**
- `packages/website/src/lib/account-page-path.ts` (new) + `.test.ts`
- `packages/website/src/lib/account-navigation-epoch.ts` (new) + `.test.ts`
- `packages/website/src/lib/account-nav.ts` — now shares the extracted path normalizer instead of a private copy
- `packages/website/src/pages/account/index.astro`, `team/{members,workspaces,registry,analytics}.astro`
- `packages/website/tests/e2e/account-page-load-guards.spec.ts` — new delayed-response and A-B-A regressions

**CI notes:** local Playwright run (desktop + mobile projects) against `astro dev` — the `vercel dev`-based CI harness needs Vercel env vars not available in this worktree, and the shadow "Website Account E2E" workflow is independently broken by SMI-6119 (unrelated, ADR-109-gated infra fix, tracked separately — not touched here). One pre-existing, unmodified `account-page-load-guards.spec.ts` test fails identically with or without this PR's changes (confirmed via `git stash`) — a pre-existing test-timing race unrelated to this fix.

No RPC calls, gate reasons, or redirect destinations were changed — this is purely a staleness guard around existing logic.
