### PR TITLE
feat(website): private skill registry docs, tutorial, and launch content

### DIFF
--- a/packages/website/src/content/blog/private-registry-walkthrough.md
+++ b/packages/website/src/content/blog/private-registry-walkthrough.md
@@ -1,0 +1,82 @@
+---
+title: "Publishing a Skill Your Whole Team Can Trust: A Private Registry Walkthrough"
+description: "Publish, approve, and install a skill in Skillsmith's Enterprise-tier private registry, step by step, with real screenshots."
+author: "Skillsmith Team"
+date: 2026-08-23
+category: "Tutorials"
+tags: ["private-registry", "enterprise", "tutorial", "skills"]
+featured: false
+ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/private-registry/01-skills-list-approved"
+schemaType: "HowTo"
+howToSteps:
+  - name: "Find your namespace"
+    text: "Every team gets one fixed registry namespace. Skill IDs you publish must start with it."
+  - name: "Publish a version"
+    text: "Call the private_registry_publish MCP tool with your skill ID, version, and files. It lands as a pending submission."
+  - name: "A teammate reviews it"
+    text: "A different team admin approves or rejects it on the dashboard. You can't approve your own submission."
+  - name: "Install it"
+    text: "Run skillsmith registry install <skillId> in your terminal."
+---
+
+You just wrote a skill your whole team should be using. Not a folder you forked and half-remember editing, an actual shared source of truth: one registry, versioned, with a real person's name on every publish and every approval. Here's exactly what that looks like, start to finish.
+
+## Find your namespace first
+
+Every team on the Enterprise tier gets one fixed namespace, a short prefix like `your-team/` shown at the top of the private registry dashboard under your account settings. Think of it as your team's own shelf in a shared library: you can only put books on your own shelf, and the system checks the label on every single book before it goes up, not just when the shelf was first built.
+
+## Publish a version
+
+Publishing goes through the `private_registry_publish` MCP tool: your skill ID (in `your-team/skill-name` format), a version number, and the packaged files. Here's a real response from a publish tonight:
+
+```json
+{
+  "success": true,
+  "skill": {
+    "skillId": "your-team/skill-name",
+    "version": "0.1.0",
+    "approvalStatus": "pending",
+    "approvalMode": "review"
+  },
+  "message": "Submitted your-team/skill-name@0.1.0 for review — an admin must approve it before teammates can install it."
+}
+```
+
+That version is now a pending submission. It doesn't show up in search, it doesn't come back from a lookup, and you can't install it, not even you, the person who just published it. Publishing puts the version on the shelf; nobody can check it out yet.
+
+## A teammate has to say yes
+
+This is the part that makes the registry worth trusting: the submission shows up on the dashboard under "Pending Submissions," with an Approve button and a Reject button sitting right next to it.
+
+![Pending submission on the private registry dashboard, with Approve and Reject buttons](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/private-registry/02-pending-submission)
+
+Neither button works for the person who published the submission, even if that person is a team admin. It's the same reason a restaurant doesn't let the cook also sign off on their own health inspection: the check only means something if it comes from someone else. A different admin has to click one of those two buttons, and the decision is final. A rejected version can't be reopened, only replaced by publishing a new one.
+
+Once a teammate approves it, the skill moves into the "Skills" section with an "Approved" badge, ready for the whole team.
+
+![Approved skill in the private registry, with version, badge, and description](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/private-registry/01-skills-list-approved)
+
+## Install it with the CLI
+
+For installing, reach for your terminal, not the MCP tool:
+
+```
+skillsmith registry install your-team/skill-name
+```
+
+A real run looks like this:
+
+```
+- Fetching skill from private registry...
+✔ Skill installed
+
+Skill installed successfully!
+  Path: /Users/you/.claude/skills/skill-name
+  Trust tier: community
+```
+
+Your own signed-in session is all it takes. Nobody needs to hand you an admin key or drop a credential on your machine to get a skill installed, your regular login carries the whole request.
+
+## What you get out of it
+
+One published version, one real approver, one shared shelf your whole team reads from. No more "which copy of this skill is the current one," no more skills living in someone's personal folder that only they remember to update. If you want the full reference, including how deprecation and access control work underneath all of this, the [Private Registry docs](/docs/private-registry) cover it, and the [step-by-step tutorial](/docs/tutorials/private-registry) walks the same path this post just did.

--- a/packages/website/src/content/blog/private-skill-registry-launch.md
+++ b/packages/website/src/content/blog/private-skill-registry-launch.md
@@ -1,0 +1,37 @@
+---
+title: "Your Team's Skills Don't Have to Go Public to Get Shared"
+description: "Skillsmith's private skill registry is live for Enterprise teams: publish internal skills to your own team's shelf, review each one before it's installable, and keep every detail off the public index."
+author: "Skillsmith Team"
+date: 2026-08-23
+category: "News"
+tags: ["private-registry", "enterprise", "product-launch"]
+featured: true
+draft: false
+ogImage: "https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200,h_630,c_fill/blog/private-registry/01-skills-list-approved"
+---
+
+Picture a platform engineer who spends an afternoon writing a Claude skill that walks through her team's exact deploy runbook: which Terraform workspace to touch first, which Slack channel gets the rollback plan, who to page when the database owner is asleep. It's a genuinely useful skill. It's also full of internal service names, channel handles, and a company acronym that means nothing outside her building. Publishing it to Skillsmith's public registry was never an option, so it would have sat on her laptop, shared the old way: a Slack message with a zip file attached, hoping the next person remembered to ask for it.
+
+That gap is closed today. Skillsmith's private skill registry is live for Enterprise teams: your team gets a registry of its own, invisible to anyone outside the company, and every skill that lands in it gets checked by a second person before a single teammate can install it.
+
+Picture a supply closet with a lock on the door. Everyone on the team has a key. Nothing that goes in ever leaves the building. And before a new box lands on the shelf, someone else with a key has to open it and check what's inside first. That's the private registry: a shelf that's yours, gated by a review step that's mandatory, not optional.
+
+Each team gets its own namespace, a short prefix like `acme-corp/`, so a skill published there can never collide with anything on the public index and can't even be seen by anyone outside the company.
+
+Here's what changed on the day-to-day: a team member writes a skill and submits it through Claude. It doesn't go live. It lands on the team admin's dashboard as a pending submission, sitting in a waiting room until someone reviews it.
+
+![The private registry dashboard showing an approved skill listing](https://res.cloudinary.com/diqcbcmaq/image/upload/f_auto,q_auto,w_1200/blog/private-registry/01-skills-list-approved)
+
+An admin reads the description, checks the version, and approves it. Only then does the skill move from submitted to installable. Reject it, and it never reaches a single laptop. Nobody, not even the person who wrote it, can approve their own submission: a second set of eyes is built into the door, not bolted on after the fact.
+
+Once a skill is approved, installing it is one line from a terminal:
+
+```
+skillsmith registry install acme-corp/deploy-runbook
+```
+
+The skill lands in the same place a public one would, ready to use in Claude Code, with none of the internal detail ever touching a public index.
+
+Your team's skills don't have to choose between staying on one laptop and going fully public anymore. There's a shelf in between now, and it has a lock.
+
+That deploy runbook could be on the shelf today, reviewed once, installed by every teammate who needs it, with nobody messaging the person who wrote it at 2am to ask how the rollback works.

--- a/packages/website/src/content/blog/private-skill-registry-launch.md
+++ b/packages/website/src/content/blog/private-skill-registry-launch.md
@@ -14,7 +14,7 @@ Picture a platform engineer who spends an afternoon writing a Claude skill that 
 
 That gap is closed today. Skillsmith's private skill registry is live for Enterprise teams: your team gets a registry of its own, invisible to anyone outside the company, and every skill that lands in it gets checked by a second person before a single teammate can install it.
 
-Picture a supply closet with a lock on the door. Everyone on the team has a key. Nothing that goes in ever leaves the building. And before a new box lands on the shelf, someone else with a key has to open it and check what's inside first. That's the private registry: a shelf that's yours, gated by a review step that's mandatory, not optional.
+Picture a supply closet with a lock on the door. Everyone on the team has a key. Nothing that goes on the shelf is visible to anyone outside your team, and it never reaches the public index. And before a new box lands on the shelf, someone else with a key has to open it and check what's inside first. That's the private registry: a shelf that's yours, gated by a review step that's mandatory, not optional.
 
 Each team gets its own namespace, a short prefix like `acme-corp/`, so a skill published there can never collide with anything on the public index and can't even be seen by anyone outside the company.
 

--- a/packages/website/src/pages/docs/private-registry.astro
+++ b/packages/website/src/pages/docs/private-registry.astro
@@ -109,7 +109,11 @@ const howToSchema = {
     <li>
       <strong>Installing a skill's actual content</strong> runs as the signed-in member's own
       account instead, so row-level security applies directly; a service-role check afterward
-      confirms the owning team still holds an Enterprise entitlement.
+      confirms the owning team still holds an Enterprise entitlement. That service-role step is
+      wired up for the MCP tool's own install action only, and it isn't reliable there today
+      because a required credential is intentionally absent from the MCP server's environment.
+      Use <code>skillsmith registry install</code> instead: the CLI reaches a separate endpoint
+      under your own signed-in session, with no service-role step involved at all.
     </li>
     <li>
       <strong>Publishing, reviewing, and admin actions</strong> (<code>publish</code>,
@@ -191,6 +195,10 @@ const howToSchema = {
   <h2>Related Documentation</h2>
 
   <ul>
+    <li>
+      <a href="/docs/tutorials/private-registry">Tutorial: Publish to your team's private registry</a>
+      - the hands-on, step-by-step version of this page
+    </li>
     <li><a href="/docs/private-skills">Private Skills</a> - the lighter, single-device alternative</li>
     <li><a href="/docs/governance">Governance</a> - deprecation, audit trail, and compliance reporting</li>
     <li><a href="/docs/trust-tiers">Trust Tiers</a> - how skill trust is evaluated</li>

--- a/packages/website/src/pages/docs/private-registry.astro
+++ b/packages/website/src/pages/docs/private-registry.astro
@@ -166,12 +166,23 @@ const howToSchema = {
         <td>Install a skill from your team's private registry</td>
         <td>Enterprise</td>
       </tr>
+      <tr>
+        <td>Web</td>
+        <td>Private Registry dashboard (account settings)</td>
+        <td>
+          Review pending submissions and approve or reject them with a click; also shows every
+          approved skill and its status
+        </td>
+        <td>Enterprise</td>
+      </tr>
     </tbody>
   </table>
 
   <p>
-    Publishing, listing, and review are MCP-only today — there's no CLI command for any of them
-    yet, only for install.
+    Publishing and listing are MCP-only today — there's no CLI command for either yet, only for
+    install. Review can be done either way: the <code>private_registry_manage</code> MCP tool's
+    <code>approve</code>/<code>reject</code> actions, or the dashboard's Approve and Reject
+    buttons, which call the same underlying check.
   </p>
 
   <h2>Versioning</h2>

--- a/packages/website/src/pages/docs/tutorials/index.astro
+++ b/packages/website/src/pages/docs/tutorials/index.astro
@@ -16,8 +16,8 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
 
   <p>
     This is a different sequence from the org-level registry lifecycle (publish, version,
-    deprecate) — that lifecycle covers how a team publishes and versions skills into a shared
-    registry, and has its own walkthrough: <a href="/docs/tutorials/private-registry">Publish to your
+    deprecate), which covers how a team publishes and versions skills into a shared
+    registry and has its own walkthrough: <a href="/docs/tutorials/private-registry">Publish to your
     team's private registry</a>. These tutorials cover what you do with skills once they exist:
     finding, evaluating, installing, running, maintaining, authoring, auditing, and uninstalling
     them.

--- a/packages/website/src/pages/docs/tutorials/index.astro
+++ b/packages/website/src/pages/docs/tutorials/index.astro
@@ -16,11 +16,11 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
 
   <p>
     This is a different sequence from the org-level registry lifecycle (publish, version,
-    deprecate) described on the <a href="/">homepage</a> and in the
-    <a href="https://github.com/smith-horn/skillsmith#readme">README</a> — that lifecycle covers
-    how a team publishes and versions skills into a shared registry. These tutorials cover what you
-    do with skills once they exist: finding, evaluating, installing, running, maintaining,
-    authoring, auditing, and uninstalling them.
+    deprecate) — that lifecycle covers how a team publishes and versions skills into a shared
+    registry, and has its own walkthrough: <a href="/docs/tutorials/private-registry">Publish to your
+    team's private registry</a>. These tutorials cover what you do with skills once they exist:
+    finding, evaluating, installing, running, maintaining, authoring, auditing, and uninstalling
+    them.
   </p>
 
   <p>
@@ -91,6 +91,23 @@ import DocsLayout from '../../../layouts/DocsLayout.astro'
       <p>
         Uninstall a skill cleanly. One command, one outcome — but worth doing deliberately so you do
         not leave orphaned references behind.
+      </p>
+    </a>
+  </div>
+
+  <h2>Team &amp; Organization</h2>
+
+  <p>
+    One tutorial covers the org-level lifecycle instead of the personal one above: publishing a
+    skill to your team's shared registry, getting it approved, and installing it.
+  </p>
+
+  <div class="card-grid">
+    <a href="/docs/tutorials/private-registry" class="doc-card">
+      <h3>Private Registry</h3>
+      <p>
+        Publish a skill to your Enterprise-tier team registry, have a teammate approve it, then
+        install it. Different from the seven personal stages above.
       </p>
     </a>
   </div>

--- a/packages/website/src/pages/docs/tutorials/private-registry.astro
+++ b/packages/website/src/pages/docs/tutorials/private-registry.astro
@@ -1,0 +1,178 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro'
+---
+
+<DocsLayout
+  title="Tutorial: Publish to your team's private registry"
+  description="Walk through publishing a skill to your Enterprise-tier private registry, getting it approved by a teammate, and installing it."
+>
+  <script
+    is:inline
+    type="application/ld+json"
+    slot="head"
+    set:html={JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'HowTo',
+      name: "How to Publish, Approve, and Install a Skill in Your Team's Private Registry",
+      description:
+        "Publish a versioned skill to your organization's Enterprise-tier private registry, have a teammate approve it, then install it with the Skillsmith CLI.",
+      totalTime: 'PT10M',
+      tool: [
+        { '@type': 'HowToTool', name: 'Skillsmith CLI' },
+        { '@type': 'HowToTool', name: 'Skillsmith MCP server' },
+      ],
+      step: [
+        {
+          '@type': 'HowToStep',
+          position: 1,
+          name: 'Sign in and check your namespace',
+          text: 'Run skillsmith login, then ask the private_registry_manage MCP tool for your namespace. Every skill ID you publish must start with it.',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 2,
+          name: 'Publish a version',
+          text: 'Use the private_registry_publish MCP tool with your skill ID, version, and packaged files. This creates a pending submission.',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 3,
+          name: 'A teammate reviews it',
+          text: 'A different team admin sees the submission on the private registry dashboard and approves or rejects it. The publisher cannot approve their own submission.',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 4,
+          name: 'Install it',
+          text: 'Once approved, run skillsmith registry install <skillId> in your terminal.',
+        },
+      ],
+    })}
+  />
+
+  <h1>Tutorial: Publish to your team's private registry</h1>
+
+  <p class="lead">
+    This walks through the full loop for Skillsmith's Enterprise-tier private registry: publish a
+    skill under your team's namespace, have a teammate approve it, then install it. Reference
+    documentation for the underlying concepts and access-control model lives on the
+    <a href="/docs/private-registry">Private Registry</a> page; this tutorial is the hands-on version.
+  </p>
+
+  <p>
+    These tutorials show Skillsmith in Claude Code. For installation in your preferred runtime
+    (Cursor, Continue, Copilot, Windsurf), see <a href="/docs/getting-started">Getting Started</a>.
+  </p>
+
+  <h2>What you will do</h2>
+
+  <ul>
+    <li>Sign in personally and look up your team's registry namespace</li>
+    <li>Publish a skill version as a pending submission</li>
+    <li>See how a teammate reviews and approves it on the dashboard</li>
+    <li>Install the approved skill with the CLI</li>
+  </ul>
+
+  <h2>Prerequisites</h2>
+
+  <ul>
+    <li>An Enterprise-tier team subscription with the private registry feature enabled.</li>
+    <li>
+      A personal, signed-in identity: run <code>skillsmith login</code>. Publishing and reviewing
+      both require this, so every submission and every approval is tied to a real person, not just
+      "the team."
+    </li>
+    <li>At least one other team admin available to review your submission (see step 3 below).</li>
+  </ul>
+
+  <h2 id="step-1-namespace">Step 1: Find your namespace</h2>
+
+  <p>
+    Every team gets one fixed registry namespace. Ask the <code>private_registry_manage</code> MCP
+    tool for it with <code>action: "namespace"</code>, or open the private registry dashboard under
+    your account settings, which shows it at the top of the page as a short prefix, something like
+    <code>your-team/</code>. Every skill ID you publish has to start with that exact prefix, checked
+    at the database level on every publish, so there's no accidentally landing in someone else's
+    namespace.
+  </p>
+
+  <h2 id="step-2-publish">Step 2: Publish a version</h2>
+
+  <p>
+    Call the <code>private_registry_publish</code> MCP tool with your skill ID in
+    <code>your-team/skill-name</code> format, a semver version, and the packaged files as a
+    <code>{'{ path: text }'}</code> map (must include <code>SKILL.md</code>). A real publish looks
+    like this:
+  </p>
+
+  <pre><code>{`{
+  "success": true,
+  "skill": {
+    "skillId": "your-team/skill-name",
+    "version": "0.1.0",
+    "approvalStatus": "pending",
+    "approvalMode": "review"
+  },
+  "message": "Submitted your-team/skill-name@0.1.0 for review — an admin must approve it before teammates can install it."
+}`}</code></pre>
+
+  <p>
+    The version is now a <strong>pending submission</strong>. It's invisible to search,
+    <code>get</code>, and install, even to you, the person who just published it, until a teammate
+    reviews it.
+  </p>
+
+  <h2 id="step-3-review">Step 3: A teammate reviews it</h2>
+
+  <p>
+    The submission shows up in the "Pending Submissions" section of the private registry dashboard
+    (under your account's Team tools), with the skill ID, version, description, and two buttons:
+    Approve and Reject. Only team admins and owners can act on either button, and critically,
+    <strong>the person who published a submission cannot approve or reject it themselves</strong>,
+    even if they hold an admin role. This is enforced at the database level, not just hidden in the
+    interface, so it can't be worked around by calling the underlying tool directly either. A
+    different admin has to make the call.
+  </p>
+
+  <p>
+    Once a teammate approves it, the version becomes immediately visible and installable to the
+    whole team, and it shows up under "Skills" on the dashboard with an "Approved" badge. Both
+    approve and reject are terminal decisions: a rejected version can't be re-reviewed, only
+    superseded by publishing a new version under a new version number.
+  </p>
+
+  <h2 id="step-4-install">Step 4: Install it</h2>
+
+  <p>
+    Install approved private-registry skills with the CLI, not the MCP install tool: the MCP
+    server's own install action for private-registry content is still catching up to a backend
+    change and isn't reliable yet. In your terminal:
+  </p>
+
+  <pre><code>skillsmith registry install your-team/skill-name</code></pre>
+
+  <p>A successful install looks like this:</p>
+
+  <pre><code>{`- Fetching skill from private registry...
+✔ Skill installed
+
+Skill installed successfully!
+  Path: /Users/you/.claude/skills/skill-name
+  Trust tier: community`}</code></pre>
+
+  <p>
+    The CLI authenticates with your own signed-in session (the same one from <code>skillsmith
+    login</code>), reaches a dedicated private-registry endpoint, and writes the skill straight to
+    your skills directory. No admin credentials are ever needed on your machine for this: your own
+    login is enough.
+  </p>
+
+  <h2>Where to next</h2>
+
+  <p>
+    For the full access-control model, how versioning and deprecation work, and every tool this
+    tutorial touched, see the <a href="/docs/private-registry">Private Registry</a> reference page.
+    If you want the lighter, single-device alternative with no team sharing at all, see
+    <a href="/docs/private-skills">Private Skills</a>.
+  </p>
+</DocsLayout>

--- a/packages/website/src/pages/pricing.astro
+++ b/packages/website/src/pages/pricing.astro
@@ -240,13 +240,13 @@ const jsonLdData = generateJsonLd(pricingTiers, pricingFaqs)
             <td><span class="roadmap" aria-label="On roadmap">&#128336;</span></td>
           </tr>
           <tr>
-            <td>Private Skills</td>
+            <td>Private Skill Registry</td>
             <td><span class="dash" aria-label="No">&mdash;</span></td>
             <td><span class="dash" aria-label="No">&mdash;</span></td>
             <td class="highlighted"
               ><span class="roadmap" aria-label="On roadmap">&#128336;</span></td
             >
-            <td><span class="roadmap" aria-label="On roadmap">&#128336;</span></td>
+            <td><span class="check" aria-label="Yes">&#10003;</span></td>
           </tr>
           <tr>
             <td>SSO / SAML</td>
@@ -325,7 +325,6 @@ const jsonLdData = generateJsonLd(pricingTiers, pricingFaqs)
           <li>SSO / SAML integration</li>
           <li>Role-based access control</li>
           <li>Custom integrations</li>
-          <li>Private skill registry</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Business Summary

**What shipped:** The private skill registry now has real public-facing content instead of a gap: a hands-on tutorial (publish → get approved → install), a companion blog walkthrough, a launch announcement, and a pricing page update that shows Private Skill Registry as live for Enterprise (it was previously listed as roadmap-only).

**Quality bar:** Content is built from verified reality, not invented UI: two real production screenshots (dashboard pending-review state and approved-skill card), and real terminal output from an actual `skillsmith registry install` run tonight. Along the way, found and fixed a pre-existing inaccuracy in the private-registry reference doc — it described the MCP tool's own install action as reliable, which it currently isn't (a separate, already-tracked issue). Both the reference doc and the new tutorial now correctly point readers at the CLI install path instead, which was independently verified working end-to-end. Build, lint, Prettier, and `audit:standards` all pass clean on the changed files.

**Found along the way:** the MCP tool's `install` action for private-registry content is still broken pending its own fix (tracked separately, not part of this PR) — the docs steer around it rather than paper over it.

**Net result:** Fully shipped, no follow-up blocking merge.

---

## Technical detail

- `packages/website/src/pages/docs/tutorials/private-registry.astro` (new) — HowTo-schema tutorial: namespace lookup, publish, teammate-approval (self-review blocked), CLI install.
- `packages/website/src/pages/docs/private-registry.astro` (edited) — added a "Related Documentation" link to the new tutorial; corrected the Access Control section's claim about the MCP install path's entitlement check to note it isn't currently reliable and point at the CLI instead.
- `packages/website/src/pages/docs/tutorials/index.astro` (edited) — added a "Team & Organization" section linking the new tutorial, replacing a stale homepage/README reference for the org-level lifecycle.
- `packages/website/src/content/blog/private-registry-walkthrough.md` (new) — Tutorials-category companion post with both real screenshots embedded.
- `packages/website/src/content/blog/private-skill-registry-launch.md` (new) — News-category launch post. Screenshots hosted on Cloudinary under `blog/private-registry/`.
- `packages/website/src/pages/pricing.astro` (edited) — renamed "Private Skills" → "Private Skill Registry", flipped the Enterprise column from roadmap to checked (Team column untouched — different, unrelated feature), removed it from the Enterprise roadmap list.
- Verified via `npm run build --workspace=packages/website` that both new docs pages and both new blog posts compile; `npm run lint`, `npx prettier --check`, and `npm run audit:standards` all clean (pre-existing unrelated warnings only, none in touched files).

Refs SMI-5819, SMI-5820.