### PR TITLE
fix(ci): relocate Playwright output outside vercel dev's watched tree (SMI-6119)

### DIFF
--- a/.claude/development/e2e-staging-runbook.md
+++ b/.claude/development/e2e-staging-runbook.md
@@ -72,9 +72,11 @@ All scoped to the `e2e-staging` environment. Other workflows cannot read them.
 - No `set -x` or `echo` of secret-bearing commands. GitHub Actions log masking
   redacts the keys themselves but env vars in `set -x` traces can still leak
   surface (e.g. URL host paths). Never trace.
-- Artifact upload allowlist: `playwright-report/`, `test-results/cli-*.log`,
+- Artifact upload allowlist: `test-results/playwright/`, `test-results/cli-*.log`,
   `test-results/preview.log`. Never `*.env`, never the bare `test-results/**`
-  glob.
+  glob. (SMI-6119: Playwright's own output relocated to `test-results/playwright/`;
+  this workflow passes `--reporter=list`, so no HTML report is ever produced
+  and there is no `playwright-report/` entry to list.)
 - Prod-ref grep gate: workflow refuses to run if
   `vrcnzpmndtroqxxoqkzy` appears anywhere in the test surface.
 - Migration drift preflight: refuses to run if the staging

--- a/.github/workflows/cross-harness-inventory-e2e.yml
+++ b/.github/workflows/cross-harness-inventory-e2e.yml
@@ -293,8 +293,7 @@ jobs:
         with:
           name: cross-harness-inventory-${{ github.run_id }}
           path: |
-            packages/website/playwright-report/
-            test-results/inventory-*.log
+            test-results/playwright/
           retention-days: 7
           if-no-files-found: ignore
 

--- a/.github/workflows/device-login-roundtrip.yml
+++ b/.github/workflows/device-login-roundtrip.yml
@@ -267,8 +267,7 @@ jobs:
         with:
           name: device-login-roundtrip-${{ github.run_id }}
           path: |
-            packages/website/playwright-report/
-            packages/website/test-results/
+            test-results/playwright/
             test-results/cli-*.log
             test-results/preview.log
           retention-days: 7

--- a/.github/workflows/website-account-e2e.yml
+++ b/.github/workflows/website-account-e2e.yml
@@ -207,8 +207,8 @@ jobs:
         with:
           name: website-account-e2e-${{ github.run_id }}
           path: |
-            packages/website/playwright-report/
-            packages/website/test-results/
+            test-results/playwright-report/
+            test-results/playwright/
             test-results/preview.log
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/website-skills-e2e.yml
+++ b/.github/workflows/website-skills-e2e.yml
@@ -179,8 +179,8 @@ jobs:
         with:
           name: website-skills-e2e-${{ github.run_id }}
           path: |
-            packages/website/playwright-report/
-            packages/website/test-results/
+            test-results/playwright-report/
+            test-results/playwright/
             test-results/preview.log
           retention-days: 7
           if-no-files-found: ignore

--- a/packages/website/playwright.config.ts
+++ b/packages/website/playwright.config.ts
@@ -11,6 +11,26 @@ export default defineConfig({
   testDir: 'tests',
   testMatch: '**/*.spec.ts',
 
+  /* SMI-6119: relocate Playwright's own output outside packages/website/ so
+   * neither this directory nor its per-worker `.playwright-artifacts-N/`
+   * scratch subdirectory (created/torn down at every project boundary --
+   * see WorkerHost in node_modules/playwright/lib/runner/index.js) ever
+   * falls inside the tree the watcher in the `vercel dev` process tree
+   * covers. That watcher's routine scandir of the default in-tree outputDir
+   * (`packages/website/test-results/`) could race the worker-teardown
+   * `removeFolders()` call at the desktop -> mobile project transition,
+   * crash `astro dev` with `ENOENT: no such file or directory, scandir
+   * '.../test-results/.playwright-artifacts-0/traces'`, and fail every
+   * subsequent test with `page.goto: Could not connect ... Connection
+   * refused` -- see SMI-6119 for the full CI-run evidence trail. Resolved
+   * relative to this file's directory (Playwright's own
+   * `path.resolve(configDir, outputDir)` rule), so this lands at
+   * `<repo-root>/test-results/playwright/` -- a sibling of the
+   * `test-results/preview.log` / `test-results/*.log` convention every
+   * vercel-dev-based e2e workflow already uses, already covered by root
+   * .gitignore, and already devcontainer-bind-mounted. */
+  outputDir: '../../test-results/playwright',
+
   /* Snapshot settings */
   snapshotPathTemplate: '{testDir}/visual/__snapshots__/{arg}-{projectName}{ext}',
 
@@ -27,7 +47,20 @@ export default defineConfig({
   workers: 1,
 
   /* Reporter */
-  reporter: [['list'], ['html', { open: 'never' }]],
+  /* HTML report folder relocated alongside outputDir above (SMI-6119) --
+   * both resolve relative to this config file's directory, land as
+   * siblings under <repo-root>/test-results/, and are never nested inside
+   * each other (Playwright's html reporter warns -- prints a Configuration
+   * Error and continues, does not fail the run -- if it detects that
+   * shape; see the `_isSubdirectory` check in
+   * node_modules/playwright/lib/runner/index.js). Note: two of the four
+   * CI workflows sharing this config pass --reporter=list on their
+   * `playwright test` invocation, which overrides this array entirely --
+   * this outputFolder only takes effect for invocations that don't. */
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: '../../test-results/playwright-report' }],
+  ],
 
   /* Shared settings for all projects */
   use: {
@@ -59,11 +92,13 @@ export default defineConfig({
   ],
 
   /* Start the preview server automatically when no server is already
-   * listening on the port. The device-login round-trip CI workflow
-   * (`.github/workflows/device-login-roundtrip.yml`) starts http-server
-   * against `dist/client` before invoking playwright (SMI-4494: the
-   * vercel adapter makes `astro preview` 404 every request, so the
-   * workflow can't rely on Playwright spinning up `npm run preview`).
+   * listening on the port. Every CI workflow that runs these specs
+   * (website-account-e2e.yml, website-skills-e2e.yml,
+   * cross-harness-inventory-e2e.yml, device-login-roundtrip.yml) instead
+   * starts `vercel dev` itself before invoking playwright (SMI-4508;
+   * device-login-roundtrip.yml switched to this from an earlier
+   * http-server/dist/client approach documented at SMI-4494 -- this
+   * comment previously described that superseded approach).
    * `reuseExistingServer: true` lets Playwright detect the externally-
    * started server and skip its own webServer command entirely. */
   webServer: {


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a CI flake that's been resetting a test workflow's stability streak — a shadow (non-blocking) end-to-end test workflow that reliably crashed on its mobile browser tests whenever both browser projects ran back to back. The cause: the test framework wrote its own temporary scratch files into a folder the dev server was watching for source-code changes, and every so often the two collided and crashed the server mid-run.

**Quality bar:** Full SPARC research + a VP Product/Engineering/Design review pass, both already merged and gating this implementation (root cause independently re-verified against real CI failure logs and the installed test-framework source, not just asserted). Implementation independently re-verified against the reviewed plan's exact specified diffs — all 6 files match byte-for-byte, zero scope creep, zero new error-suppression anywhere.

**Net result:** Fully shipped, pending this PR's own CI run confirming the fix actually works (the fix's own effectiveness is only provable by watching this workflow run for real — that's the smoke check happening as part of merging this PR, not a separate later step).

---

## Technical detail

Implements the plan at `docs/internal/implementation/smi-6119-website-account-e2e-infra-stabilization.md` (Wave 3 of the account-nav-admin-tools-reorg initiative; Waves 1-2 already merged). Root cause: Playwright's default `outputDir`/HTML-report folder resolve inside `packages/website/`, which `vercel dev`'s spawned dev server watches. Worker teardown between the desktop and mobile Playwright projects deletes a scratch subdirectory of `outputDir` at every project boundary; the watcher's routine directory scan can race that deletion and crash the dev server with an unhandled `ENOENT`, failing every subsequent test with a connection-refused error.

**Fix:** relocates `outputDir`/`outputFolder` to `<repo-root>/test-results/playwright{,-report}/`, outside the watched tree, and updates the four affected workflows' failure-artifact upload paths to match. Two of the four workflows (`cross-harness-inventory-e2e.yml`, `device-login-roundtrip.yml`) pass `--reporter=list`, which overrides the config's reporter array — their path blocks correctly omit the now-dead `playwright-report/` entry rather than adding a path nothing will ever populate. Also closes an independent pre-existing gap where `cross-harness-inventory-e2e.yml` never captured Playwright's own trace/screenshot artifacts on failure, and deletes a vestigial dead log glob in the same touched block. No watcher config changes, no retries, no new error suppression anywhere.

**Files**: `packages/website/playwright.config.ts` (config relocation + comment fixes), `.github/workflows/{website-account-e2e,website-skills-e2e,device-login-roundtrip,cross-harness-inventory-e2e}.yml` (artifact-upload `path:` blocks only), `.claude/development/e2e-staging-runbook.md` (one stale line).

**Verification**: typecheck/lint/format/YAML-validity/`audit:standards` (78/9/0, matches pre-existing baseline exactly) all independently re-run and clean. A completeness grep confirms zero live references to the old paths remain anywhere in the repo. This PR self-triggers `website-account-e2e.yml` — its real run is the actual proof the fix works (both desktop and mobile Playwright projects should complete without the `ENOENT`/connection-refused crash signature); watching that run to green is this PR's own merge gate, not a follow-up.
