### PR TITLE
fix(website): SMI-6134 make Supabase e2e stub config immutable

### DIFF
--- a/packages/website/tests/e2e/account-page-load-guards.spec.ts
+++ b/packages/website/tests/e2e/account-page-load-guards.spec.ts
@@ -92,12 +92,59 @@ function collectNullDerefs(page: Page): string[] {
   return hits
 }
 
+// SMI-6134 regression guard: populated by mockSupabase() whenever a request
+// reaches a real (non-stub) Supabase-shaped host — see mockSupabase()'s
+// catch-all route in complete-profile.helpers.ts. Reset before every test;
+// asserted empty after every test, file-wide (a top-level test.afterEach()
+// applies to every test in this file, including inside test.describe()
+// blocks below). Tests in this file that never call mockSupabase() directly
+// (the SMI-6112 block, which uses its own mockDelayedTierCheck() route
+// instead) leave this at its reset [] and the assertion passes vacuously —
+// their coverage against this bug comes from Step 1's immutable-injection
+// fix itself, not from this collector.
+let unexpectedSupabaseRequests: string[] = []
+
+test.beforeEach(() => {
+  unexpectedSupabaseRequests = []
+})
+
+test.afterEach(() => {
+  expect(
+    unexpectedSupabaseRequests,
+    `Unexpected request(s) reached a real (non-stub) Supabase host instead of the test stub — ` +
+      `window.__SUPABASE_CONFIG__ should be immutable (SMI-6134); something bypassed it. ` +
+      `Captured URL(s):\n${unexpectedSupabaseRequests.join('\n')}`
+  ).toEqual([])
+})
+
 test.describe('account pages — astro:page-load path guards (SMI-5158)', () => {
   test.beforeEach(async ({ page }) => {
     await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
-    // Closed-default mocks: tables resolve to [] and RPCs 404 — enough for each
-    // page's inline script (and thus its astro:page-load listener) to register.
-    await mockSupabase(page, {})
+    // SMI-6134 correction: previously `mockSupabase(page, {})` (fully
+    // closed-default — check_team_tier_access unmocked, 404) was enough
+    // because the pre-fix bug (this very file's regression target) meant
+    // /account's own inline script silently emptied window.__SUPABASE_CONFIG__
+    // before its astro:page-load handler ran, so index.astro's own
+    // `if (!config.url || !config.anonKey)` guard (index.astro:390) bailed
+    // out before ever calling checkTeamAccess() — masking that this mock was
+    // always missing a check_team_tier_access response. Now that the stub
+    // config correctly survives (the fix under test here), /account's
+    // astro:page-load handler actually reaches checkTeamAccess(); an
+    // unmocked (404) RPC response there degrades to `not_authenticated`
+    // (team-access.ts) and immediately redirects to /login, which this
+    // test's own navigation loop never expects. An entitled response keeps
+    // /account rendering normally, matching account-sidebar.spec.ts's first
+    // describe block, which already does this for the same reason.
+    ;({ unexpectedSupabaseRequests } = await mockSupabase(page, {
+      rpcResponses: {
+        check_team_tier_access: {
+          ok: true,
+          reason: null,
+          team_id: 'team_smi5158_fixture',
+          tier: 'team',
+        },
+      },
+    }))
   })
 
   test('no leaked handler throws null-deref when navigating /account → siblings → back', async ({

--- a/packages/website/tests/e2e/account-sidebar.spec.ts
+++ b/packages/website/tests/e2e/account-sidebar.spec.ts
@@ -66,6 +66,27 @@ const TEAM_GATED_HREFS = [
   '/account/team/workspaces',
 ]
 
+// SMI-6134 regression guard: populated by mockSupabase() whenever a request
+// reaches a real (non-stub) Supabase-shaped host — see mockSupabase()'s
+// catch-all route in complete-profile.helpers.ts. Reset before every test;
+// asserted empty after every test, file-wide (a top-level test.afterEach()
+// applies to every test in this file, including inside test.describe()
+// blocks below).
+let unexpectedSupabaseRequests: string[] = []
+
+test.beforeEach(() => {
+  unexpectedSupabaseRequests = []
+})
+
+test.afterEach(() => {
+  expect(
+    unexpectedSupabaseRequests,
+    `Unexpected request(s) reached a real (non-stub) Supabase host instead of the test stub — ` +
+      `window.__SUPABASE_CONFIG__ should be immutable (SMI-6134); something bypassed it. ` +
+      `Captured URL(s):\n${unexpectedSupabaseRequests.join('\n')}`
+  ).toEqual([])
+})
+
 test.describe('account navigation — Account/Admin/Tools/Preferences/Resources (SMI-6128)', () => {
   test.beforeEach(async ({ page }) => {
     await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
@@ -76,7 +97,7 @@ test.describe('account navigation — Account/Admin/Tools/Preferences/Resources 
     // to `not_authenticated` (team-access.ts), which races /account's own
     // async redirect-to-login against this suite's assertions — an
     // unrelated flake source, not a structural nav regression.
-    await mockSupabase(page, {
+    ;({ unexpectedSupabaseRequests } = await mockSupabase(page, {
       rpcResponses: {
         check_team_tier_access: {
           ok: true,
@@ -85,7 +106,7 @@ test.describe('account navigation — Account/Admin/Tools/Preferences/Resources 
           tier: 'team',
         },
       },
-    })
+    }))
   })
 
   test('renders on /account with the Quick Links grid gone and no duplicate tab row', async ({
@@ -318,9 +339,9 @@ test.describe('team-gated lock affordance (SMI-6128, preserves SMI-6110 Decision
   test('confirmed non-entitled: Registry/Analytics/Members/Workspaces render locked; Overview never does', async ({
     page,
   }) => {
-    await mockSupabase(page, {
+    ;({ unexpectedSupabaseRequests } = await mockSupabase(page, {
       rpcResponses: { get_effective_subscription_summary: [{ tier: 'community' }] },
-    })
+    }))
 
     await page.goto('/account/summary')
     await expect(page.locator('.account-sidebar')).toHaveAttribute('data-team-entitled', 'false')
@@ -338,9 +359,9 @@ test.describe('team-gated lock affordance (SMI-6128, preserves SMI-6110 Decision
   })
 
   test('entitled: no lock styling, no stale lock announcement', async ({ page }) => {
-    await mockSupabase(page, {
+    ;({ unexpectedSupabaseRequests } = await mockSupabase(page, {
       rpcResponses: { get_effective_subscription_summary: [{ tier: 'team' }] },
-    })
+    }))
 
     await page.goto('/account/summary')
     await expect(page.locator('.account-sidebar')).toHaveAttribute('data-team-entitled', 'true')
@@ -358,7 +379,7 @@ test.describe('team-gated lock affordance (SMI-6128, preserves SMI-6110 Decision
   test('missing entitlement signal fails open: no producer page visited, no lock ever applied', async ({
     page,
   }) => {
-    await mockSupabase(page, {})
+    ;({ unexpectedSupabaseRequests } = await mockSupabase(page, {}))
 
     // Profile never calls setAccountNavTeamEntitled (pre-decided non-producer).
     await page.goto('/account/profile')
@@ -373,9 +394,9 @@ test.describe('team-gated lock affordance (SMI-6128, preserves SMI-6110 Decision
   test('activating a locked link still navigates — the lock is an affordance, not a disabled control', async ({
     page,
   }) => {
-    await mockSupabase(page, {
+    ;({ unexpectedSupabaseRequests } = await mockSupabase(page, {
       rpcResponses: { get_effective_subscription_summary: [{ tier: 'community' }] },
-    })
+    }))
 
     await page.goto('/account/summary')
     await expect(page.locator('.account-sidebar')).toHaveAttribute('data-team-entitled', 'false')

--- a/packages/website/tests/e2e/complete-profile.helpers.ts
+++ b/packages/website/tests/e2e/complete-profile.helpers.ts
@@ -49,6 +49,17 @@ export function buildSessionToken(
 /**
  * Inject the `__SUPABASE_CONFIG__` stub + optional session before the page
  * script runs. Mirrors the pattern used by team-tier-gate.spec.ts.
+ *
+ * SMI-6134: every account page's own inline SSR script assigns
+ * `window.__SUPABASE_CONFIG__ = supabaseConfig` in its `<head>` — under real
+ * CI (`vercel dev`) that assigns CI's real preview Supabase project config,
+ * silently overwriting this stub (plain writable properties allow later
+ * assignments to win) before the page's client module reads it. RPC/auth
+ * calls then go to the real project instead of the intercepted stub host, so
+ * `mockSupabase()`'s route interception never fires. Defining the property as
+ * immutable makes that later same-key assignment a silent no-op in
+ * non-strict inline scripts (Astro's `is:inline` scripts aren't
+ * `'use strict'`) instead of a real overwrite.
  */
 export async function injectSupabaseStub(
   page: Page,
@@ -56,10 +67,12 @@ export async function injectSupabaseStub(
 ): Promise<void> {
   await page.addInitScript(
     ({ url, anonKey, ref, session }) => {
-      ;(window as unknown as Record<string, unknown>).__SUPABASE_CONFIG__ = {
-        url,
-        anonKey,
-      }
+      Object.defineProperty(window, '__SUPABASE_CONFIG__', {
+        value: { url, anonKey },
+        writable: false,
+        configurable: false,
+        enumerable: true,
+      })
       if (session) {
         try {
           window.localStorage.setItem(`sb-${ref}-auth-token`, session)
@@ -93,8 +106,40 @@ export interface MockShape {
   onRequest?: (url: string) => void
 }
 
-export async function mockSupabase(page: Page, shape: MockShape): Promise<void> {
+export interface MockSupabaseResult {
+  /**
+   * Populated by the SMI-6134 regression guard below when a request reaches a
+   * real (non-stub) Supabase-shaped host instead of `SUPABASE_HOST`. Should
+   * always stay empty — a non-empty array means something bypassed
+   * `injectSupabaseStub()`'s immutable `__SUPABASE_CONFIG__` injection.
+   */
+  unexpectedSupabaseRequests: string[]
+}
+
+export async function mockSupabase(page: Page, shape: MockShape): Promise<MockSupabaseResult> {
   const { rpcResponses = {}, restResponses = {}, functionsResponses = {}, onRequest } = shape
+  const unexpectedSupabaseRequests: string[] = []
+
+  // SMI-6134 regression guard: if the immutable __SUPABASE_CONFIG__ injection
+  // in injectSupabaseStub() is ever weakened, bypassed, or a new page
+  // introduces a different overwrite path, requests silently go to a real
+  // Supabase project instead of this stub — and the original bug's confusing
+  // downstream symptom (an unrelated assertion failing for reasons that have
+  // nothing to do with what it appears to test) recurs. Catch that here
+  // instead: collect the URL and abort the request so it can never actually
+  // reach a real project, regardless of whether anything reads the array.
+  //
+  // Registered BEFORE the stub-host route below on purpose: Playwright checks
+  // routes in the reverse of registration order (the most-recently-registered
+  // matching route runs first), so the stub-host route registered second
+  // below still wins for legitimate stub traffic — this catch-all only
+  // actually fires for a request to a genuinely different host, since
+  // `stub.supabase.co` matches both patterns and the later registration wins
+  // the tie.
+  await page.route('https://*.supabase.co/**', async (route: Route) => {
+    unexpectedSupabaseRequests.push(route.request().url())
+    await route.abort()
+  })
 
   await page.route(`${SUPABASE_HOST}/**`, async (route: Route) => {
     const url = new URL(route.request().url())
@@ -174,4 +219,6 @@ export async function mockSupabase(page: Page, shape: MockShape): Promise<void> 
       body: '{}',
     })
   })
+
+  return { unexpectedSupabaseRequests }
 }


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed the 12 real test failures that showed up the first time our account-page test suite ran against the real CI environment instead of a developer's laptop — every account page was silently swapping the test's fake login credentials for real ones mid-test, so the test's mocked responses never got used. The test's fake config now can't be swapped out.

**Quality bar:** Root cause independently investigated by a second AI model, then independently re-verified against the actual source code rather than taken on trust. Design reviewed by a simulated VP Product/Engineering panel (1 High, 4 Medium, 1 Low finding, all addressed). Implementation independently re-verified line-by-line post-commit (0 findings) and the full affected test suite re-run a second time by a different pass, matching the original results exactly.

**Found along the way:** a `vercel build` command destructively deleted a development workspace's files during verification — filed separately as SMI-6136 (dev-tooling hazard, not a website bug, needs its own review before fixing). One other test file was silently relying on the very bug this PR fixes to mask a missing test setup step — that's fixed here too, since leaving it would have broken that test the moment this PR's real fix landed.

**Net result:** Fully shipped, pending this PR's own real CI run against `website-account-e2e.yml` confirming all 12 previously-failing checks now pass — that's the actual proof this works, not a separate follow-up step.

---

## Technical detail

Implements the plan-reviewed plan at `docs/internal/implementation/smi-6134-account-e2e-supabase-stub-immutable-fix.md`. Root cause: `injectSupabaseStub()` (`packages/website/tests/e2e/complete-profile.helpers.ts`) sets `window.__SUPABASE_CONFIG__` as a normal writable property; every account page's own inline `define:vars` script (`window.__SUPABASE_CONFIG__ = supabaseConfig`) then overwrites it with CI's real preview Supabase project config, since the page's SSR-rendered values differ under real `vercel dev` from the stub values a local `astro dev` run happened to have. Requests then silently miss `mockSupabase()`'s route interception (scoped to the stub host).

**Fix:**
- `injectSupabaseStub()` now defines `__SUPABASE_CONFIG__` via `Object.defineProperty(..., { writable: false, configurable: false })` — the page's later same-key assignment becomes a silent no-op instead of a real overwrite.
- `mockSupabase()` gains a regression guard: a catch-all `page.route()` for any non-stub Supabase-shaped host `route.abort()`s the request and records the URL; both affected specs assert the collector is empty in `afterEach()` (not a throw inside the route handler — verified that's unreliable, since route handlers run off the test's own await chain).
- Companion fix: `account-page-load-guards.spec.ts`'s SMI-5158 describe block's `beforeEach` was missing a `check_team_tier_access` RPC mock response — invisible pre-fix because the bug itself emptied the page's config before `checkTeamAccess()` was ever reached. Fixing Step 1 alone would have made this a *new* CI failure without this correction.

**Investigation & review trail:** root-caused via a NEEDLE/Codex (`gpt-5.6-sol`, read-only analysis) dispatch, independently re-verified line-by-line against real source before the plan was written. Plan reviewed by `plan-review-skill` (VP Engineering + VP Product, Fable/low effort): 0 Critical / 1 High / 4 Medium / 1 Low, all applied — redesigned the regression guard, added a verification pass over 6 non-CI-wired sibling specs, turned a dormant-duplicate-fixture referral into an explicit fix mandate. Post-commit code review (`docs/internal/code_review/2026-08-23-smi6134-supabase-stub-immutable-fix-review.md`): 0 findings.

**Files**: `packages/website/tests/e2e/complete-profile.helpers.ts`, `packages/website/tests/e2e/account-page-load-guards.spec.ts`, `packages/website/tests/e2e/account-sidebar.spec.ts`, plus a `docs/internal` gitlink pointer bump. No production code, no infra/CI-workflow files touched.

**Out of scope, tracked separately**: `team-tier-gate.spec.ts` and `team-members-page.helpers.ts` implement their own separate, un-consolidated copies of the same mutable-stub pattern — neither is currently wired into any CI workflow (confirmed dormant), so this is not an active regression. Routed to the session's end-of-session `code-health-auditor` pass with an explicit fix mandate, per the plan's "Known related-but-out-of-scope finding" section.

**Verification**: typecheck/lint/format/audit:standards all independently re-run and clean. Full affected test suite (`account-page-load-guards.spec.ts` + `account-sidebar.spec.ts`) independently re-run against a real local dev server: 42 passed, 2 expected skips — matches the implementing pass's own report exactly. This PR self-triggers `website-account-e2e.yml` (its `pull_request.paths` filter includes `complete-profile.helpers.ts` directly) — that real run is the actual proof the fix works; watching it go green is this PR's own merge gate, not a follow-up.