### PR TITLE
chore(website): code-health consolidation follow-up (SMI-6134)

### DIFF
--- a/packages/website/src/lib/skills-page-render.ts
+++ b/packages/website/src/lib/skills-page-render.ts
@@ -14,6 +14,9 @@ import {
   computeDeviceBatchTip,
 } from './inventory-view'
 import type { SkillState, DeviceView, SkillView } from './inventory-view'
+import { escapeHtml } from './skills-utils'
+
+export { escapeHtml }
 
 // ─── Badge config (mirrors InventoryStateBadge.astro) ─────────────────────────
 // Distinct icon shape + WCAG-AA color pair per state — not color alone (WCAG 1.4.1).
@@ -78,22 +81,6 @@ export const BADGE_CONFIG: Record<SkillState, BadgeEntry> = {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/**
- * XSS-safe HTML escape for user-supplied strings placed in innerHTML.
- * Pure string-replace (no DOM) so it is safe in both browser and test/SSR
- * contexts and unit-testable. Escapes the five HTML-significant characters,
- * `&` first, covering both element-text and double/single-quoted attribute
- * contexts (the only two contexts the builders below use).
- */
-export function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
 
 /**
  * Returns an HTML string for a WCAG-compliant skill-state badge.

--- a/packages/website/tests/e2e/team-members-page.helpers.ts
+++ b/packages/website/tests/e2e/team-members-page.helpers.ts
@@ -14,13 +14,26 @@ import type { Page, Route } from '@playwright/test'
 export const SUPABASE_HOST = 'https://stub.supabase.co'
 export const SUPABASE_ANON = 'stub-anon-key'
 
+/**
+ * SMI-6134 (code-health consolidation follow-up): every account page's own
+ * inline SSR script assigns `window.__SUPABASE_CONFIG__ = supabaseConfig` in
+ * its `<head>` — under a real CI harness that overwrites this stub with the
+ * page's own SSR-rendered environment config (a different Supabase project),
+ * silently defeating the mock below. Not yet observed failing here because
+ * this spec family isn't currently wired into any GitHub Actions workflow,
+ * but this is the exact same latent bug complete-profile.helpers.ts's
+ * injectSupabaseStub() had. Defining the property as immutable makes the
+ * page's later same-key assignment a silent no-op instead of a real overwrite.
+ */
 export async function injectSupabaseStub(page: Page): Promise<void> {
   await page.addInitScript(
     ({ url, anonKey }) => {
-      ;(window as unknown as Record<string, unknown>).__SUPABASE_CONFIG__ = {
-        url,
-        anonKey,
-      }
+      Object.defineProperty(window, '__SUPABASE_CONFIG__', {
+        value: { url, anonKey },
+        writable: false,
+        configurable: false,
+        enumerable: true,
+      })
     },
     { url: SUPABASE_HOST, anonKey: SUPABASE_ANON }
   )

--- a/packages/website/tests/e2e/team-tier-gate.spec.ts
+++ b/packages/website/tests/e2e/team-tier-gate.spec.ts
@@ -42,14 +42,26 @@ const SUPABASE_ANON = 'stub-anon-key'
 /**
  * Inject a fake __SUPABASE_CONFIG__ before Astro's page script runs.
  * Must run via addInitScript so it's available by the time astro:page-load fires.
+ *
+ * SMI-6134 (code-health consolidation follow-up): every account page's own
+ * inline SSR script assigns `window.__SUPABASE_CONFIG__ = supabaseConfig` in
+ * its `<head>` — under a real CI harness that overwrites this stub with the
+ * page's own SSR-rendered environment config (a different Supabase project),
+ * silently defeating the mock below. Not yet observed failing here because
+ * this spec isn't currently wired into any GitHub Actions workflow, but this
+ * is the exact same latent bug complete-profile.helpers.ts's injectSupabaseStub()
+ * had. Defining the property as immutable makes the page's later same-key
+ * assignment a silent no-op instead of a real overwrite.
  */
 async function injectSupabaseStub(page: Page): Promise<void> {
   await page.addInitScript(
     ({ url, anonKey }) => {
-      ;(window as unknown as Record<string, unknown>).__SUPABASE_CONFIG__ = {
-        url,
-        anonKey,
-      }
+      Object.defineProperty(window, '__SUPABASE_CONFIG__', {
+        value: { url, anonKey },
+        writable: false,
+        configurable: false,
+        enumerable: true,
+      })
     },
     { url: SUPABASE_HOST, anonKey: SUPABASE_ANON }
   )


### PR DESCRIPTION
## Business Summary

**What shipped:** Merged two duplicate copies of the same HTML-escaping function into one. Applied the same test-fixture security fix from this session's earlier work to two other test files that had the identical latent bug, before it could ever bite them.

**Quality bar:** Ran `code-health-auditor` (dead-code/consolidation scanner) against the whole website package, checked all 13 findings by hand, applied the two that were safe and real, and confirmed by direct code-reading that the other 3 "duplicate name" flags were false alarms (different behavior, not actually duplicated). Independently re-verified: full test suite for the escaped-HTML merge (38/38 pass), full Playwright run for both test-fixture fixes (15/15 pass), and confirmed via a controlled before/after comparison that neither change caused any new test failures.

**Found along the way:** 5 unrelated, pre-existing failures in a dormant (not CI-connected) test file — filed as SMI-6138, not caused by this change (confirmed by testing with and without this change). 4 dependencies flagged as possibly-unused that need a deeper investigation before removal (this repo has a pattern of deliberately keeping some dependencies pinned for reasons a simple scan can't see) — filed as SMI-6139.

**Net result:** Fully shipped, no follow-up blocking this PR.

---

## Technical detail

code-health-auditor scan of `packages/website` (13 consolidation candidates, 0 safe-to-delete — website is EXPERIMENTAL/uncalibrated for this skill). Full curated outcome: `docs/internal/code-health/index.md`.

**Applied**:
- `packages/website/src/lib/skills-page-render.ts` — removed a byte-identical duplicate `escapeHtml()`, now imports + re-exports the canonical version from `skills-utils.ts`. Verified all 10 existing call sites were already truthy-narrowed to `string` before calling it, so the widened `string | null | undefined` signature is behaviorally identical for every caller.
- `packages/website/tests/e2e/team-tier-gate.spec.ts`, `team-members-page.helpers.ts` — applied SMI-6134's `Object.defineProperty` immutable-injection fix to their own local `injectSupabaseStub()` implementations, per the SMI-6134 plan-review's explicit fix mandate. Neither file is wired into any CI workflow, so this closes a latent bug rather than an active regression. Diff confirmed byte-consistent with the pattern already shipped in PR #2491.

**Investigated, correctly left alone**: `formatPrice` (a genuine adapter delegating to a differently-named function, not a duplicate), `formatRelativeTime` (two deliberately different contracts — SSR timezone-safety guarantee vs. locale formatting, different pluralization, different thresholds), the two `.xml.ts` `GET` route handlers (Astro's own required per-route export convention, not a real duplicate).

**Dependency audit**: 9 flagged "unused" deps investigated. 5 confirmed false positives — `tailwindcss`/`@tailwindcss/typography` (CSS `@import`/`@plugin` directives), `web-vitals` (dynamic script import), `prettier-plugin-astro` (`.prettierrc` plugin entry), `strip-ansi` (a Playwright test-helper import) — all outside Knip's static JS/TS import graph. 4 (`cookie`, `loupe`, `picomatch`, `strip-literal`) have zero found first-party usage but weren't removed without a lockfile-reason investigation — filed as SMI-6139 rather than risking a blind removal.

**Files**: `packages/website/src/lib/skills-page-render.ts`, `packages/website/tests/e2e/{team-tier-gate.spec.ts,team-members-page.helpers.ts}`, plus a `docs/internal` gitlink bump.

**Verification**: typecheck/lint/format independently re-run and clean. Local vitest for the `escapeHtml` consolidation: 38/38 pass. Local Playwright for the two fixture fixes: 15/15 pass. Git-stash A/B isolation confirmed the 5 `team-invitations.spec.ts` failures (SMI-6138) are pre-existing, not caused by this change (7 failures without this fix, 5 with it — a net improvement).