### PR TITLE
chore(release): bump mcp-server 0.7.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34066,7 +34066,7 @@
       },
       "devDependencies": {
         "@skillsmith/core": "^0.11.7",
-        "@skillsmith/mcp-server": "^0.7.9",
+        "@skillsmith/mcp-server": "^0.7.10",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
         "vitest": "4.1.10"
@@ -34329,7 +34329,7 @@
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.7.9",
+        "@skillsmith/mcp-server": "^0.7.10",
         "@smithy/config-resolver": "4.6.16",
         "@smithy/core": "3.31.1",
         "@smithy/middleware-endpoint": "4.6.16",
@@ -34344,7 +34344,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.7.9"
+        "@skillsmith/mcp-server": "^0.7.10"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -34380,7 +34380,7 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "Elastic-2.0",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "10.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@skillsmith/core": "^0.11.7",
-    "@skillsmith/mcp-server": "^0.7.9",
+    "@skillsmith/mcp-server": "^0.7.10",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",
     "vitest": "4.1.10"

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -50,7 +50,7 @@
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.7.9",
+    "@skillsmith/mcp-server": "^0.7.10",
     "@smithy/config-resolver": "4.6.16",
     "@smithy/core": "3.31.1",
     "@smithy/middleware-endpoint": "4.6.16",
@@ -62,7 +62,7 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.7.9"
+    "@skillsmith/mcp-server": "^0.7.10"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.7.10
+
+- **Fix**: remove SUPABASE_SERVICE_ROLE_KEY from registry install path (#2494)
+- **Fix**: remove SUPABASE_SERVICE_ROLE_KEY from customer-facing private registry reads (#2472)
 - **Security**: `private_registry_manage`'s `list`, `get`, and `namespace` actions no longer
   require `SUPABASE_SERVICE_ROLE_KEY` on the MCP host. They previously ran on the Supabase
   service-role client — the backend's most powerful credential, which bypasses row-level security

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -8,12 +8,12 @@ Part of Skillsmith: a lifecycle layer for agent skills across teams.
 
 ## What's New in v0.7.10
 
-- **`search`'s `limit` parameter actually works now**: previously advertised in the tool description but silently dropped — no `limit` field existed in the input schema at all. Now threaded through both the API and local-fallback paths, clamped to `[1, 100]`.
-- **`skill_compare` and `skill_recommend` fixed**: compare now resolves any skill `search`/`get_skill` can find (was local-cache-only); recommend no longer 400s or silently zeroes on an empty derived stack — both return a structured, actionable result instead.
-- **`skill_updates` scoped to your installed skills**: was running an unfiltered registry-wide scan (`updatesAvailable: 2833` for a handful of installs); now bounded to the local manifest, sharing derivation with `skill_outdated` so the two can't drift apart again.
-- **Trust-tier vocabulary fixed**: `mapTrustTierFromDb` was silently collapsing `official` and `unverified` to `unknown`; all `TrustTier` values now round-trip correctly across `search`, `get_skill`, `skill_recommend`, `skill_compare`, and `skill_suggest`.
-- **New local security-acceptance allowlist**: mark a reviewed false-positive finding as accepted so it stops re-surfacing in future audits, without affecting rug-pull/hostile-update detection.
-- **`private_registry_manage` gains `install`**: installs a previously-published private-registry skill to disk, closing the publish→install gap.
+- **Security: `SUPABASE_SERVICE_ROLE_KEY` removed from every MCP-host code path**: `private_registry_manage`'s `list`, `get`, `namespace`, and `install` actions — plus the registry-install path — no longer run on the Supabase service-role client. They now run as the signed-in user (`skillsmith login`) or through a narrowly-scoped `SECURITY DEFINER` RPC, so there's no admin credential left to configure or distribute (SMI-6109/SMI-6111).
+- **Session-login users now get their real subscription tier**: callers authenticated only via `skillsmith login` (no separately-configured `SKILLSMITH_API_KEY`) previously fell back to `community` regardless of actual entitlement, silently blocking Enterprise-gated tools like `private_registry_manage`/`private_registry_publish` (SMI-6098).
+- **`skill_validate` now flags likely typosquats**: warns (non-blocking) when a candidate skill's name is suspiciously close to a high-trust author or top-starred skill (SMI-6033).
+- **`get_skill`/`search`/`skill_recommend` surface a partial-scan caveat**: an informational note when the registry's extended scan couldn't cover every file for a skill — never affects the Security/Installable verdict.
+- **Pricing and quota numbers corrected**: several bundled skills, tool descriptions, and error messages were off by 10x or referenced the unpublished Enterprise price; now consistent with the actual tier table (SMI-5893).
+- **Auto-update notification no longer silently drops** on an invalid `SKILLSMITH_CLIENT` value.
 
 See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,7 +6,7 @@ MCP (Model Context Protocol) server for agent skill publishing, installation, an
 
 Part of Skillsmith: a lifecycle layer for agent skills across teams.
 
-## What's New in v0.7.9
+## What's New in v0.7.10
 
 - **`search`'s `limit` parameter actually works now**: previously advertised in the tool description but silently dropped — no `limit` field existed in the input schema at all. Now threaded through both the API and local-fallback paths, clamped to `[1, 100]`.
 - **`skill_compare` and `skill_recommend` fixed**: compare now resolves any skill `search`/`get_skill` can find (was local-cache-only); recommend no longer 400s or silently zeroes on an empty derived stack — both return a structured, actionable result instead.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
   "type": "module",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.7.9",
+  "version": "0.7.10",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": ["claude-code", "agent-skills", "autonomous-agents", "openclaw"]
@@ -17,7 +17,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.startup-helpers.ts
+++ b/packages/mcp-server/src/index.startup-helpers.ts
@@ -4,7 +4,13 @@
  * @module @skillsmith/mcp-server/index.startup-helpers
  *
  * Extracted to keep index.ts under the `audit:standards` 500-LOC gate. No
- * behavior change from the prior in-file versions.
+ * behavior change from the prior in-file versions — in particular, both
+ * logging functions below take `version` explicitly rather than creating a
+ * module-scope `logger` here, so their log records keep the real
+ * `PACKAGE_VERSION` stamp index.ts's own logger uses instead of silently
+ * downgrading to `createLogger`'s `'unknown'` default (caught in review of
+ * SMI-6111 — a prior, still-live instance of the same drop dates back to this
+ * file's SMI-5639 origin, in `ensureSkillsmithSkillInstalled`).
  */
 
 import { exec } from 'child_process'
@@ -12,7 +18,6 @@ import { createRequire } from 'node:module'
 import { createLogger } from '@skillsmith/core/logging'
 import { installBundledSkills, getUserGuidePath } from './onboarding/install-assets.js'
 
-const logger = createLogger('mcp')
 // ESM-compatible require for dynamic module resolution (native-module probe below)
 const require = createRequire(import.meta.url)
 
@@ -46,8 +51,13 @@ export function handleDocsFlag(): void {
  *
  * Quiet by design: `installBundledSkills()` only logs when it actually copies
  * a skill or hits an error, so happy-path startup adds zero stderr.
+ *
+ * @param version - Host package's `PACKAGE_VERSION` (index.ts), stamped on
+ *   any log record emitted here. Defaults to `'unknown'` only for callers
+ *   that genuinely don't have a version (e.g. direct unit tests).
  */
-export function ensureSkillsmithSkillInstalled(): void {
+export function ensureSkillsmithSkillInstalled(version = 'unknown'): void {
+  const logger = createLogger('mcp', { version })
   try {
     installBundledSkills()
   } catch (error) {
@@ -60,8 +70,13 @@ export function ensureSkillsmithSkillInstalled(): void {
 /**
  * SMI-2163: Startup diagnostics for common installation issues
  * Detects native module problems and provides actionable error messages
+ *
+ * @param version - Host package's `PACKAGE_VERSION` (index.ts), stamped on
+ *   any log record emitted here. Defaults to `'unknown'` only for callers
+ *   that genuinely don't have a version (e.g. direct unit tests).
  */
-export function runStartupDiagnostics(): void {
+export function runStartupDiagnostics(version = 'unknown'): void {
+  const logger = createLogger('mcp', { version })
   // Check for native module issues by attempting dynamic import simulation
   // The actual check happens when @skillsmith/core loads better-sqlite3
   try {

--- a/packages/mcp-server/src/index.startup-helpers.ts
+++ b/packages/mcp-server/src/index.startup-helpers.ts
@@ -1,17 +1,20 @@
 /**
- * @fileoverview Startup-flag and bundled-skill helpers extracted from index.ts (SMI-5639).
+ * @fileoverview Startup-flag, bundled-skill, and diagnostics helpers extracted
+ * from index.ts (SMI-5639; runStartupDiagnostics added SMI-6111).
  * @module @skillsmith/mcp-server/index.startup-helpers
  *
- * Extracted to keep index.ts under the `audit:standards` 500-LOC gate after
- * SMI-5639's shutdown-hook fix. No behavior change from the prior in-file
- * versions.
+ * Extracted to keep index.ts under the `audit:standards` 500-LOC gate. No
+ * behavior change from the prior in-file versions.
  */
 
 import { exec } from 'child_process'
+import { createRequire } from 'node:module'
 import { createLogger } from '@skillsmith/core/logging'
 import { installBundledSkills, getUserGuidePath } from './onboarding/install-assets.js'
 
 const logger = createLogger('mcp')
+// ESM-compatible require for dynamic module resolution (native-module probe below)
+const require = createRequire(import.meta.url)
 
 /**
  * Handle --docs flag to open user documentation
@@ -51,5 +54,87 @@ export function ensureSkillsmithSkillInstalled(): void {
     // Fail-soft: never block MCP startup on bundled-skill install failure.
     const msg = error instanceof Error ? error.message : 'Unknown error'
     logger.warn(`[skillsmith] Bundled skill install failed (non-fatal): ${msg}`, { err: error })
+  }
+}
+
+/**
+ * SMI-2163: Startup diagnostics for common installation issues
+ * Detects native module problems and provides actionable error messages
+ */
+export function runStartupDiagnostics(): void {
+  // Check for native module issues by attempting dynamic import simulation
+  // The actual check happens when @skillsmith/core loads better-sqlite3
+  try {
+    // Verify core module can be loaded (will fail if native modules broken)
+    require.resolve('@skillsmith/core')
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+
+    if (msg.includes('NODE_MODULE_VERSION')) {
+      logger.error(`
+╔══════════════════════════════════════════════════════════════╗
+║  Skillsmith: Native Module Version Mismatch                  ║
+╠══════════════════════════════════════════════════════════════╣
+║                                                              ║
+║  Your Node.js version (${process.version.padEnd(10)}) doesn't match the       ║
+║  pre-compiled native modules.                                ║
+║                                                              ║
+║  To fix, run one of:                                         ║
+║                                                              ║
+║    SKILLSMITH_FORCE_WASM=true to use WASM SQLite fallback    ║
+║                                                              ║
+║  Or reinstall completely:                                    ║
+║                                                              ║
+║    npm uninstall @skillsmith/mcp-server                      ║
+║    npm install @skillsmith/mcp-server                        ║
+║                                                              ║
+╚══════════════════════════════════════════════════════════════╝
+`)
+      process.exit(1)
+    }
+
+    if (msg.includes('GLIBC') || msg.includes('libc') || msg.includes('GLIBCXX')) {
+      logger.error(`
+╔══════════════════════════════════════════════════════════════╗
+║  Skillsmith: Missing System Library (glibc)                  ║
+╠══════════════════════════════════════════════════════════════╣
+║                                                              ║
+║  Native modules require glibc which is not available on      ║
+║  Alpine Linux or some minimal containers.                    ║
+║                                                              ║
+║  Options:                                                    ║
+║    1. Use a Debian/Ubuntu-based environment                  ║
+║    2. Use Docker: docker run -it node:22 npx @skillsmith/... ║
+║                                                              ║
+╚══════════════════════════════════════════════════════════════╝
+`)
+      process.exit(1)
+    }
+
+    if (msg.includes('invalid ELF header')) {
+      logger.error(`
+╔══════════════════════════════════════════════════════════════╗
+║  Skillsmith: Architecture Mismatch                           ║
+╠══════════════════════════════════════════════════════════════╣
+║                                                              ║
+║  Native modules were compiled for a different architecture.  ║
+║                                                              ║
+║  This can happen when:                                       ║
+║    - Copying node_modules between machines                   ║
+║    - Running x86 modules on ARM (or vice versa)              ║
+║                                                              ║
+║  To fix, reinstall:                                          ║
+║                                                              ║
+║    rm -rf node_modules                                       ║
+║    npm install                                               ║
+║                                                              ║
+╚══════════════════════════════════════════════════════════════╝
+`)
+      process.exit(1)
+    }
+
+    // Unknown module resolution error - log but don't exit
+    // The actual error will surface when the module is used
+    logger.warn(`[Skillsmith] Warning: Could not resolve @skillsmith/core: ${msg}`)
   }
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -251,7 +251,9 @@ export { maybeInstallMissingTier1Skills }
 
 // SMI-2163: Startup diagnostics (native module errors) extracted to
 // index.startup-helpers.ts's runStartupDiagnostics() to keep this file under
-// the 500-LOC gate (SMI-6111). Call site unchanged, in main() below.
+// the 500-LOC gate (SMI-6111). Call site in main() below now passes
+// PACKAGE_VERSION explicitly so the extracted logger keeps the real version
+// stamp instead of createLogger's 'unknown' default.
 
 // SMI-5009 (origin) / SMI-5039 (extraction): the embedding capability probe
 // now lives in @skillsmith/core/embeddings/probe. See that file for the
@@ -295,7 +297,7 @@ async function main() {
   }
 
   // SMI-2163: Run startup diagnostics before anything else
-  runStartupDiagnostics()
+  runStartupDiagnostics(PACKAGE_VERSION)
 
   // Handle --docs flag
   if (process.argv.includes('--docs') || process.argv.includes('-d')) {
@@ -341,7 +343,7 @@ async function main() {
     // idempotent — it skips skills already present at the runtime path resolved
     // by `SKILLSMITH_CLIENT`. Opt out via SKILLSMITH_SKIP_SKILL_INSTALL=1.
     if (process.env.SKILLSMITH_SKIP_SKILL_INSTALL !== '1') {
-      ensureSkillsmithSkillInstalled()
+      ensureSkillsmithSkillInstalled(PACKAGE_VERSION)
     }
   }
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -7,10 +7,6 @@
  * @see SMI-XXXX: First-run integration and documentation delivery
  */
 
-import { createRequire } from 'node:module'
-
-// ESM-compatible require for dynamic module resolution
-const require = createRequire(import.meta.url)
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
@@ -120,11 +116,15 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.7.9'
+const PACKAGE_VERSION = '0.7.10'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 const logger = createLogger('mcp', { version: PACKAGE_VERSION }) // SMI-5615
 import { installBundledSkills, installUserDocs } from './onboarding/install-assets.js'
-import { handleDocsFlag, ensureSkillsmithSkillInstalled } from './index.startup-helpers.js'
+import {
+  handleDocsFlag,
+  ensureSkillsmithSkillInstalled,
+  runStartupDiagnostics,
+} from './index.startup-helpers.js'
 
 // SMI-2679: Quota enforcement middleware — module-level singletons, initialized once
 // licenseMiddleware uses a cache (TTL) so the first-call @smith-horn/enterprise lazy-load
@@ -249,87 +249,9 @@ export async function runFirstTimeSetup(): Promise<string[]> {
 // SMI-5582 (plan G): re-export so integration tests can drive it directly.
 export { maybeInstallMissingTier1Skills }
 
-/**
- * SMI-2163: Startup diagnostics for common installation issues
- * Detects native module problems and provides actionable error messages
- */
-function runStartupDiagnostics(): void {
-  // Check for native module issues by attempting dynamic import simulation
-  // The actual check happens when @skillsmith/core loads better-sqlite3
-  try {
-    // Verify core module can be loaded (will fail if native modules broken)
-    require.resolve('@skillsmith/core')
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e)
-
-    if (msg.includes('NODE_MODULE_VERSION')) {
-      logger.error(`
-╔══════════════════════════════════════════════════════════════╗
-║  Skillsmith: Native Module Version Mismatch                  ║
-╠══════════════════════════════════════════════════════════════╣
-║                                                              ║
-║  Your Node.js version (${process.version.padEnd(10)}) doesn't match the       ║
-║  pre-compiled native modules.                                ║
-║                                                              ║
-║  To fix, run one of:                                         ║
-║                                                              ║
-║    SKILLSMITH_FORCE_WASM=true to use WASM SQLite fallback    ║
-║                                                              ║
-║  Or reinstall completely:                                    ║
-║                                                              ║
-║    npm uninstall @skillsmith/mcp-server                      ║
-║    npm install @skillsmith/mcp-server                        ║
-║                                                              ║
-╚══════════════════════════════════════════════════════════════╝
-`)
-      process.exit(1)
-    }
-
-    if (msg.includes('GLIBC') || msg.includes('libc') || msg.includes('GLIBCXX')) {
-      logger.error(`
-╔══════════════════════════════════════════════════════════════╗
-║  Skillsmith: Missing System Library (glibc)                  ║
-╠══════════════════════════════════════════════════════════════╣
-║                                                              ║
-║  Native modules require glibc which is not available on      ║
-║  Alpine Linux or some minimal containers.                    ║
-║                                                              ║
-║  Options:                                                    ║
-║    1. Use a Debian/Ubuntu-based environment                  ║
-║    2. Use Docker: docker run -it node:22 npx @skillsmith/... ║
-║                                                              ║
-╚══════════════════════════════════════════════════════════════╝
-`)
-      process.exit(1)
-    }
-
-    if (msg.includes('invalid ELF header')) {
-      logger.error(`
-╔══════════════════════════════════════════════════════════════╗
-║  Skillsmith: Architecture Mismatch                           ║
-╠══════════════════════════════════════════════════════════════╣
-║                                                              ║
-║  Native modules were compiled for a different architecture.  ║
-║                                                              ║
-║  This can happen when:                                       ║
-║    - Copying node_modules between machines                   ║
-║    - Running x86 modules on ARM (or vice versa)              ║
-║                                                              ║
-║  To fix, reinstall:                                          ║
-║                                                              ║
-║    rm -rf node_modules                                       ║
-║    npm install                                               ║
-║                                                              ║
-╚══════════════════════════════════════════════════════════════╝
-`)
-      process.exit(1)
-    }
-
-    // Unknown module resolution error - log but don't exit
-    // The actual error will surface when the module is used
-    logger.warn(`[Skillsmith] Warning: Could not resolve @skillsmith/core: ${msg}`)
-  }
-}
+// SMI-2163: Startup diagnostics (native module errors) extracted to
+// index.startup-helpers.ts's runStartupDiagnostics() to keep this file under
+// the 500-LOC gate (SMI-6111). Call site unchanged, in main() below.
 
 // SMI-5009 (origin) / SMI-5039 (extraction): the embedding capability probe
 // now lives in @skillsmith/core/embeddings/probe. See that file for the


### PR DESCRIPTION
## Business Summary

**What shipped**: This PR is the actual publish step for the security fix merged in #2494 (SMI-6111) — it bumps `@skillsmith/mcp-server` from 0.7.9 to 0.7.10 so the fix reaches real users, not just `main`. Without this, the removal of `SUPABASE_SERVICE_ROLE_KEY` from the customer-facing install path stays sitting on `main`, unpublished, and design partners doing hands-on testing this week would still be running the old, less-safe version.

**Quality bar**: Standard `prepare-release.ts` bump — package.json, server.json, README "What's New", and CHANGELOG.md all auto-updated to describe both SMI-6109's and SMI-6111's fixes under the new `v0.7.10` heading. `npm run typecheck`/`lint`/`test`/security checks all pass.

**Found along the way**: `packages/mcp-server/src/index.ts` was sitting exactly at the 500-line CI gate — this bump's one-line `PACKAGE_VERSION` edit tripped it. Fixed immediately (not deferred): extracted `runStartupDiagnostics()` into the existing `index.startup-helpers.ts` sibling (same extraction pattern SMI-5639 already established for this exact gate), no behavior change. `index.ts` is now 426 lines.

**Net result**: Merging this to `main` and then running the publish workflow ships 0.7.10 to npm — the last step before design partners can do a real end-to-end walkthrough without `SUPABASE_SERVICE_ROLE_KEY` anywhere in their environment.

## Technical detail

- `packages/mcp-server/package.json`, `server.json`: version 0.7.9 → 0.7.10
- `packages/cli/package.json`, `packages/enterprise/package.json`: devDependency/peerDependency pin bumped to match
- `package-lock.json`: internal workspace version strings only, no external dependency changes
- `packages/mcp-server/README.md`: "What's New" section retitled to v0.7.10
- `packages/mcp-server/CHANGELOG.md`: `[Unreleased]` content (SMI-6109 + SMI-6111 security fixes) moved under new `## v0.7.10` heading
- `packages/mcp-server/src/index.ts` / `index.startup-helpers.ts`: extracted `runStartupDiagnostics()` (native-module error diagnostics) to the sibling helpers file to stay under the 500-LOC `audit:standards` gate — pure move, no logic change

Refs SMI-6111