### PR TITLE
fix(smoke-prod): SMI-6142 update stale tutorials fingerprint checks (retire->uninstall)

### DIFF
--- a/scripts/smoke-prod/surfaces.json
+++ b/scripts/smoke-prod/surfaces.json
@@ -216,7 +216,7 @@
         "check_website_docs_tutorials_maintain_renders",
         "check_website_docs_tutorials_author_renders",
         "check_website_docs_tutorials_govern_renders",
-        "check_website_docs_tutorials_retire_renders",
+        "check_website_docs_tutorials_uninstall_renders",
         "check_website_docs_vscode_extension_renders",
         "check_website_docs_authoring_redirect"
       ]

--- a/scripts/smoke-prod/website.sh
+++ b/scripts/smoke-prod/website.sh
@@ -594,7 +594,7 @@ check_website_docs_tutorials_index_renders() {
     return 1
   fi
   if ! assert_contains "$body" 'How you use a skill, day to day' "tutorials-landing"; then
-    report_fail "website-docs-tutorials" "check_website_docs_tutorials_index_renders" "$url" "lifecycle-fingerprint" "missing" "$ms"
+    report_fail "website-docs-tutorials" "check_website_docs_tutorials_index_renders" "$url" "tutorials-landing" "missing" "$ms"
     return 1
   fi
   report_pass "website-docs-tutorials" "check_website_docs_tutorials_index_renders" "$url" "$ms"

--- a/scripts/smoke-prod/website.sh
+++ b/scripts/smoke-prod/website.sh
@@ -593,7 +593,7 @@ check_website_docs_tutorials_index_renders() {
     report_fail "website-docs-tutorials" "check_website_docs_tutorials_index_renders" "$url" "200" "$status" "$ms"
     return 1
   fi
-  if ! assert_contains "$body" 'The Skillsmith lifecycle' "tutorials-landing"; then
+  if ! assert_contains "$body" 'How you use a skill, day to day' "tutorials-landing"; then
     report_fail "website-docs-tutorials" "check_website_docs_tutorials_index_renders" "$url" "lifecycle-fingerprint" "missing" "$ms"
     return 1
   fi
@@ -727,8 +727,8 @@ check_website_docs_tutorials_govern_renders() {
   return 0
 }
 
-check_website_docs_tutorials_retire_renders() {
-  local url="${SMOKE_WEBSITE_URL}/docs/tutorials/retire"
+check_website_docs_tutorials_uninstall_renders() {
+  local url="${SMOKE_WEBSITE_URL}/docs/tutorials/uninstall"
   local t0 t1 ms resp status body
   t0=$(now_ms)
   resp=$(with_retry http_body GET "$url") || true
@@ -737,14 +737,14 @@ check_website_docs_tutorials_retire_renders() {
   status=$(printf '%s' "$resp" | head -n1)
   body=$(printf '%s' "$resp" | tail -n +2)
   if [ "$status" != "200" ]; then
-    report_fail "website-docs-tutorials" "check_website_docs_tutorials_retire_renders" "$url" "200" "$status" "$ms"
+    report_fail "website-docs-tutorials" "check_website_docs_tutorials_uninstall_renders" "$url" "200" "$status" "$ms"
     return 1
   fi
-  if ! assert_contains "$body" 'Tutorial: Retire skills' "retire-fingerprint"; then
-    report_fail "website-docs-tutorials" "check_website_docs_tutorials_retire_renders" "$url" "retire-fingerprint" "missing" "$ms"
+  if ! assert_contains "$body" 'Tutorial: Uninstall skills' "uninstall-fingerprint"; then
+    report_fail "website-docs-tutorials" "check_website_docs_tutorials_uninstall_renders" "$url" "uninstall-fingerprint" "missing" "$ms"
     return 1
   fi
-  report_pass "website-docs-tutorials" "check_website_docs_tutorials_retire_renders" "$url" "$ms"
+  report_pass "website-docs-tutorials" "check_website_docs_tutorials_uninstall_renders" "$url" "$ms"
   return 0
 }
 


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed two production smoke checks that have been failing on every deploy since 2026-08-09 — they were still checking for a "retire" tutorial page and a lifecycle heading that a prior rename removed from the live site weeks ago. The website itself was never broken; only the check was stale.

**Quality bar:** Root-caused via git history and confirmed against the live production site with curl before writing the fix; independently cross-checked with a Codex (GPT-5.6-Sol) second-opinion pass, which caught an additional gap my own diff missed (the check's registry entry in `surfaces.json`). Verified the fix end-to-end with a full smoke dry-run against real prod — all 10 tutorials checks now pass.

**Found along the way:** Investigated all 10 currently-open `ci-failure`-tagged GitHub issues, not just this one. Four of them (#2421, #2428, #2436, #2467) are a separate, already-resolved transient infrastructure blip from 2026-08-17/18 (corroborated by a same-night Supabase pooler DNS incident documented in PR #2431/SMI-6015) — recommending those close with a note rather than further code changes. This PR only fixes the still-live false-positive.

**Net result:** Fully shipped. Once merged, will close the 6 false-positive GitHub issues this bug filed (#2430, #2456, #2459, #2461, #2489, #2495) referencing this commit.

---

## Technical detail

`scripts/smoke-prod/website.sh`:
- `check_website_docs_tutorials_index_renders` — fingerprint updated from the removed "The Skillsmith lifecycle" string to the current index heading, "How you use a skill, day to day".
- `check_website_docs_tutorials_retire_renders` renamed to `check_website_docs_tutorials_uninstall_renders`, URL changed from `/docs/tutorials/retire` (404) to `/docs/tutorials/uninstall` (the page's actual current path since PR #2221), fingerprint updated to "Tutorial: Uninstall skills".

`scripts/smoke-prod/surfaces.json` — updated the `website-docs-tutorials` surface's check-name registry entry to match the renamed function (the dispatcher resolves checks by function name, so a bare rename without this would leave the check undispatchable).

Root cause: PR #2221 (2026-08-09) renamed `retire.astro` → `uninstall.astro` and reworded the tutorials index page; the smoke script was never updated. A companion PR (#2478) fixed similarly-stale fingerprints on the `/product` page in this same file a week later but missed this pair.

Linear: SMI-6142 (this fix), umbrella triage tracked under SMI-6124.

No logic changes — string/URL/function-name updates only. `shellcheck -S warning` clean, `surfaces.json` validated as JSON, full typecheck passed in pre-commit.
