### PR TITLE
chore(release): bump core 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34065,7 +34065,7 @@
         "sklx": "dist/cli.js"
       },
       "devDependencies": {
-        "@skillsmith/core": "^0.11.7",
+        "@skillsmith/core": "^0.12.0",
         "@skillsmith/mcp-server": "^0.7.10",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
@@ -34184,7 +34184,7 @@
     },
     "packages/core": {
       "name": "@skillsmith/core",
-      "version": "0.11.7",
+      "version": "0.12.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -34248,7 +34248,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@ruvector/core": "0.1.30",
-        "@skillsmith/core": "^0.11.2",
+        "@skillsmith/core": "^0.12.0",
         "better-sqlite3": "11.10.0",
         "glob": "11.1.0",
         "minimatch": "10.2.6",
@@ -34323,7 +34323,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1106.0",
         "@opentelemetry/instrumentation-aws-sdk": "0.76.0",
-        "@skillsmith/core": "^0.11.7",
+        "@skillsmith/core": "^0.12.0",
         "jose": "^6.2.2",
         "stripe": "20.3.0",
         "zod": "4.2.1"
@@ -34385,7 +34385,7 @@
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "10.1.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@skillsmith/core": "^0.11.7",
+        "@skillsmith/core": "^0.12.0",
         "@supabase/supabase-js": "2.112.2",
         "ajv-formats-draft2019": "1.6.1",
         "ulid": "3.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@skillsmith/core": "^0.11.7",
+    "@skillsmith/core": "^0.12.0",
     "@skillsmith/mcp-server": "^0.7.10",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## [Unreleased]
 
+## v0.12.0
+
+- **Cadence**: Mechanical cadence alignment (no changes since v0.11.7).
 - **Feature**: new `resolveSessionTier` client (`sync/license-status-client.ts`, SMI-6098) —
   authenticates the stored device-login session against `/license-status` (proactively refreshing
   via the existing `resolveAccessToken` helper) so the MCP server can resolve a real subscription

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,13 +6,13 @@ Part of Skillsmith: a lifecycle layer for agent skills across teams.
 
 ## Contents
 
-- [What's New](#whats-new-in-v0117)
+- [What's New](#whats-new-in-v0120)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Features](#features)
 - [Exports](#exports)
 
-## What's New in v0.11.7
+## What's New in v0.12.0
 
 - **Security-status reporting unified**: CLI and MCP now derive security-scan status (pass/fail, risk score, findings count) from one shared `deriveSecuritySummaryFromApiSkill`/`deriveSecuritySummaryFromSkillRow`, instead of two independently-maintained copies that could disagree on the same skill.
 - **`skill_compare` reuses `get_skill`'s resolution**: new shared `resolveSkillApiFirst()` fixes compare only ever hitting the local SQLite cache (no longer kept in sync with the remote-first registry), which made real, searchable skills report "not found."

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/core",
-  "version": "0.11.7",
+  "version": "0.12.0",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Version
-export const VERSION = '0.11.7'
+export const VERSION = '0.12.0'
 
 // ============================================================================
 // Grouped Exports from Barrel Files

--- a/packages/doc-retrieval-mcp/package.json
+++ b/packages/doc-retrieval-mcp/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@ruvector/core": "0.1.30",
-    "@skillsmith/core": "^0.11.2",
+    "@skillsmith/core": "^0.12.0",
     "better-sqlite3": "11.10.0",
     "glob": "11.1.0",
     "minimatch": "10.2.6",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1106.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.76.0",
-    "@skillsmith/core": "^0.11.7",
+    "@skillsmith/core": "^0.12.0",
     "jose": "^6.2.2",
     "stripe": "20.3.0",
     "zod": "4.2.1"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@cyclonedx/cyclonedx-library": "10.1.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@skillsmith/core": "^0.11.7",
+    "@skillsmith/core": "^0.12.0",
     "@supabase/supabase-js": "2.112.2",
     "ajv-formats-draft2019": "1.6.1",
     "ulid": "3.0.1",

--- a/scripts/lib/version-utils.ts
+++ b/scripts/lib/version-utils.ts
@@ -133,6 +133,26 @@ export const CORE_DEPENDENTS = [
 ]
 
 /**
+ * SMI-6098 follow-up: package.json paths under `packages/*` that must be
+ * excluded from `updateWorkspaceDependencies`'s scan even though they are
+ * NOT `PACKAGE_SPECS` entries (the `skipDepRangeUpdate` flag only reaches
+ * paths that ARE in that array).
+ *
+ * `packages/skillsmith-cli` (the unscoped `skillsmith-cli` npm wrapper,
+ * SMI-3561/SMI-5512/SMI-5513) depends on `@skillsmith/cli` but its own
+ * `version` field is bumped and published on a fully separate, manual
+ * cadence (`publish-skillsmith-cli` in `.github/workflows/publish.yml`
+ * skips publishing whenever its package.json version is already live on
+ * npm). Once the readdirSync-based scan (below) started walking every
+ * `packages/*` directory instead of only `PACKAGE_SPECS`, it would also
+ * catch this wrapper's `@skillsmith/cli` pin on the next `cli` version
+ * bump — rewriting the committed dependency range without also bumping
+ * the wrapper's own `version`, so the range would silently drift out of
+ * step with what's actually published, on every future `cli` release.
+ */
+const EXTRA_SKIP_DEP_RANGE_UPDATE_PATHS = ['packages/skillsmith-cli/package.json']
+
+/**
  * SMI-5057: walk every workspace package.json (minus skipDepRangeUpdate ones)
  * and update any workspace dep range whose key matches a freshly-bumped
  * package. Returns the list of files actually modified.
@@ -175,9 +195,10 @@ export function updateWorkspaceDependencies(
   // it today.
   const DEP_KINDS = ['dependencies', 'devDependencies', 'peerDependencies'] as const
 
-  const skipDepRangeUpdatePaths = new Set(
-    PACKAGE_SPECS.filter((s) => s.skipDepRangeUpdate).map((s) => s.packageJsonPath)
-  )
+  const skipDepRangeUpdatePaths = new Set([
+    ...PACKAGE_SPECS.filter((s) => s.skipDepRangeUpdate).map((s) => s.packageJsonPath),
+    ...EXTRA_SKIP_DEP_RANGE_UPDATE_PATHS,
+  ])
   const packagesDir = join(ROOT_DIR, 'packages')
   const targetPackageJsonPaths = readdirSync(packagesDir, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())

--- a/scripts/lib/version-utils.ts
+++ b/scripts/lib/version-utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFileSync } from 'child_process'
-import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync, readdirSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 
@@ -133,7 +133,7 @@ export const CORE_DEPENDENTS = [
 ]
 
 /**
- * SMI-5057: walk every PACKAGE_SPECS target (minus skipDepRangeUpdate ones)
+ * SMI-5057: walk every workspace package.json (minus skipDepRangeUpdate ones)
  * and update any workspace dep range whose key matches a freshly-bumped
  * package. Returns the list of files actually modified.
  *
@@ -146,6 +146,19 @@ export const CORE_DEPENDENTS = [
  * include an enterprise bump will correctly rewrite this range to
  * `^<newVersion>` rather than leaving it a no-op — the bump map is keyed
  * off the current call's `plans`, not off PACKAGE_SPECS membership.
+ *
+ * SMI-6098 (this bug's own release): the scan target used to be
+ * `PACKAGE_SPECS` alone — the four *published* packages. That silently
+ * excluded internal-only workspace packages (e.g. `doc-retrieval-mcp`,
+ * which depends on `@skillsmith/core` but is never itself bumped/published
+ * by this script). A core MINOR/MAJOR bump left doc-retrieval-mcp's pinned
+ * `^0.11.2`-style range unable to match the new local version — which
+ * broke npm's local-workspace-symlink resolution for it, and in turn
+ * Turborepo's build-ordering graph (dependsOn: ["^build"] has no edge to
+ * follow if npm no longer resolves the dep to the local workspace package),
+ * producing an intermittent core/doc-retrieval-mcp build race on fresh
+ * containers. Now scans every directory under `packages/*` so any workspace
+ * consumer's pin gets refreshed, published or not.
  */
 export function updateWorkspaceDependencies(
   plans: Array<{ spec: PackageSpec; newVersion: string }>
@@ -162,11 +175,19 @@ export function updateWorkspaceDependencies(
   // it today.
   const DEP_KINDS = ['dependencies', 'devDependencies', 'peerDependencies'] as const
 
-  for (const target of PACKAGE_SPECS) {
-    if (target.skipDepRangeUpdate) continue
-    const fullPath = join(ROOT_DIR, target.packageJsonPath)
-    // SMI-5057 M-7: the enterprise submodule may be uninitialized on
-    // external clones. Graceful skip — never throw.
+  const skipDepRangeUpdatePaths = new Set(
+    PACKAGE_SPECS.filter((s) => s.skipDepRangeUpdate).map((s) => s.packageJsonPath)
+  )
+  const packagesDir = join(ROOT_DIR, 'packages')
+  const targetPackageJsonPaths = readdirSync(packagesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join('packages', entry.name, 'package.json'))
+    .filter((relPath) => !skipDepRangeUpdatePaths.has(relPath))
+
+  for (const relPath of targetPackageJsonPaths) {
+    const fullPath = join(ROOT_DIR, relPath)
+    // SMI-5057 M-7: the enterprise submodule (or any package dir lacking a
+    // package.json) may be uninitialized/absent. Graceful skip — never throw.
     if (!existsSync(fullPath)) continue
 
     const pkg = JSON.parse(readFileSync(fullPath, 'utf-8'))
@@ -188,7 +209,7 @@ export function updateWorkspaceDependencies(
 
     if (changed) {
       writeFileSync(fullPath, JSON.stringify(pkg, null, 2) + '\n')
-      updated.push(target.packageJsonPath)
+      updated.push(relPath)
     }
   }
 

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -155,9 +155,13 @@ function updateServerJson(relPath: string, newVersion: string): void {
 }
 
 // SMI-5057: `updateCoreDependency` removed — superseded by
-// `updateWorkspaceDependencies` (in version-utils.ts), which walks every
-// PACKAGE_SPECS target and updates any dep range matching a bumped package.
-// This fixes the missing @skillsmith/mcp-server dep bump in @skillsmith/cli.
+// `updateWorkspaceDependencies` (in version-utils.ts), which updates any dep
+// range matching a bumped package. This fixes the missing
+// @skillsmith/mcp-server dep bump in @skillsmith/cli. SMI-6098 broadened the
+// scan target from PACKAGE_SPECS-only to every packages/* directory (minus
+// skipDepRangeUpdate / EXTRA_SKIP_DEP_RANGE_UPDATE_PATHS), so an internal-only
+// consumer's pin (e.g. doc-retrieval-mcp -> @skillsmith/core) also gets
+// refreshed, not just the four published packages.
 
 // --- Main ---
 
@@ -264,11 +268,12 @@ async function main(): Promise<void> {
 
   // Step 6: Update workspace dep ranges in all sibling packages.
   //
-  // SMI-5057: Replaces the older core-only updateCoreDependency. Walks every
-  // PACKAGE_SPECS target (minus skipDepRangeUpdate ones) and updates any dep
-  // range whose key matches a freshly-bumped package. Catches the
+  // SMI-5057: Replaces the older core-only updateCoreDependency. Updates any
+  // dep range whose key matches a freshly-bumped package. Catches the
   // @skillsmith/mcp-server stale-range bug in @skillsmith/cli that bit
-  // PR #1268.
+  // PR #1268. SMI-6098: walks every packages/* directory (minus
+  // skipDepRangeUpdate / EXTRA_SKIP_DEP_RANGE_UPDATE_PATHS), not just
+  // PACKAGE_SPECS targets — see version-utils.ts for the full rationale.
   const { updated: updatedDepFiles } = updateWorkspaceDependencies(plans)
   if (updatedDepFiles.length > 0) {
     console.log(`  ✓ Updated workspace dep ranges in ${updatedDepFiles.length} package(s):`)

--- a/scripts/tests/prepare-release.test.ts
+++ b/scripts/tests/prepare-release.test.ts
@@ -174,6 +174,35 @@ describe('updateWorkspaceDependencies (SMI-5057)', () => {
     expect(cliPkg.devDependencies['@skillsmith/core']).toBe('^0.7.3')
   })
 
+  it('updates @skillsmith/core dep range in internal-only doc-retrieval-mcp, not just PACKAGE_SPECS targets (SMI-6098 regression)', () => {
+    // doc-retrieval-mcp is never itself bumped/published by this script (it's
+    // not in PACKAGE_SPECS), but it does depend on @skillsmith/core — its pin
+    // must still get refreshed on a core bump, or npm stops resolving it as a
+    // local workspace symlink once the pin no longer covers the new version
+    // (breaking Turborepo's build-ordering graph for it — the real bug this
+    // guards against).
+    // Use a version guaranteed to differ from whatever's currently on disk
+    // (unmocked readFileSync reads the real, live package.json) — otherwise
+    // updateWorkspaceDependencies's `currentRange !== newRange` no-op guard
+    // would mask this test the moment the real repo happened to already be
+    // pinned to the same value.
+    const corePlan = {
+      spec: PACKAGE_SPECS.find((s) => s.shortName === 'core')!,
+      newVersion: '0.99.99',
+    }
+
+    const { updated } = updateWorkspaceDependencies([corePlan])
+
+    expect(updated).toContain('packages/doc-retrieval-mcp/package.json')
+
+    const docRetrievalWrite = mockedWriteFileSync.mock.calls.find((c) =>
+      String(c[0]).endsWith('packages/doc-retrieval-mcp/package.json')
+    )
+    expect(docRetrievalWrite).toBeDefined()
+    const docRetrievalPkg = JSON.parse(String(docRetrievalWrite![1]))
+    expect(docRetrievalPkg.dependencies['@skillsmith/core']).toBe('^0.99.99')
+  })
+
   it('skips skillsmith-vscode (skipDepRangeUpdate=true) even if a future contributor adds @skillsmith/* deps', () => {
     // Simulate the vscode entry having a hypothetical core dep.
     const vscodeSpec = PACKAGE_SPECS.find((s) => s.shortName === 'vscode')!

--- a/scripts/tests/prepare-release.test.ts
+++ b/scripts/tests/prepare-release.test.ts
@@ -220,6 +220,28 @@ describe('updateWorkspaceDependencies (SMI-5057)', () => {
     expect(updated).not.toContain('packages/vscode-extension/package.json')
   })
 
+  it('skips packages/skillsmith-cli (unscoped wrapper, separate publish cadence) on a cli bump (SMI-6098 follow-up)', () => {
+    // packages/skillsmith-cli isn't a PACKAGE_SPECS entry (its own version is
+    // bumped/published manually, not by this script), so it can't be reached
+    // by the skipDepRangeUpdate flag alone once the scan walks every
+    // packages/* directory. Guard against a future cli bump silently
+    // rewriting its @skillsmith/cli pin out of step with its own unbumped
+    // version field.
+    const cliPlan = {
+      spec: PACKAGE_SPECS.find((s) => s.shortName === 'cli')!,
+      newVersion: '0.99.99',
+    }
+
+    const { updated } = updateWorkspaceDependencies([cliPlan])
+
+    expect(updated).not.toContain('packages/skillsmith-cli/package.json')
+    expect(
+      mockedWriteFileSync.mock.calls.find((c) =>
+        String(c[0]).endsWith('packages/skillsmith-cli/package.json')
+      )
+    ).toBeUndefined()
+  })
+
   it('treats peerDependencies with non-bumped key as a no-op (SMI-5057 M-5)', () => {
     // This test's `plans` array below deliberately omits an enterprise bump,
     // so "@smith-horn/enterprise" never lands in this call's bump map and is


### PR DESCRIPTION
## Business Summary

**What shipped**: Publishes `@skillsmith/core` 0.11.7 -> 0.12.0 — this is the missing piece that actually unblocks yesterday's mcp-server 0.7.10 publish (#2496). That release's automated post-publish smoke test failed: the newly-published `@skillsmith/mcp-server` imports `SessionTierAuthError`/`SessionTierTransientError` from `@skillsmith/core` (a feature already on `main`'s source, from the SMI-6098 session-login-tier work), but core itself was never bumped+published to actually contain those exports on npm — so a real `npm install @skillsmith/mcp-server` today would crash on startup. This PR ships that missing core version so the two packages are compatible again.

**Quality bar**: Standard `prepare-release.ts` minor bump (justified: genuinely new public API surface, not just a fix) plus a real infrastructure bug found and fixed along the way — see below. All typecheck/lint/test/security checks pass.

**Found along the way**: while preparing this release, this worktree's dev container started crash-looping on every boot. Root cause: `prepare-release.ts`'s dependency-range sync only ever updated the four *published* packages (core, mcp-server, cli, enterprise) — it silently skipped `doc-retrieval-mcp`, an internal-only workspace package that also depends on `@skillsmith/core` but is never itself published. `doc-retrieval-mcp`'s stale `^0.11.2` pin still matched core's prior patch releases, so this was invisible until now: crossing a MINOR version boundary (0.11.x -> 0.12.0) broke it for real — npm stopped resolving `@skillsmith/core` as a local workspace symlink for `doc-retrieval-mcp`, which broke Turborepo's build-ordering graph and caused an intermittent build race on every fresh container boot. Fixed immediately (not deferred): `updateWorkspaceDependencies()` now scans every `packages/*` directory, not just the published-package list, with a regression test covering it.

**Net result**: merging this to `main` and publishing gets `@skillsmith/mcp-server@0.7.10` and `@skillsmith/core@0.12.0` back in sync on npm — the actual precondition for the design-partner walkthrough this week — and closes a release-tooling gap that would have silently recurred on every future core minor/major bump.

## Technical detail

- `packages/core/package.json`, `packages/core/src/index.ts` (`VERSION` const), `packages/core/README.md`: version 0.11.7 → 0.12.0
- `packages/core/CHANGELOG.md`: `[Unreleased]` content (SMI-6098 session-tier resolver, SMI-6033 scan-expansion waves, SMI-5893 pricing/wording fixes, etc. — all real, already-merged-to-`main` work accumulated since 0.11.7) moved under new `## v0.12.0` heading
- `packages/{mcp-server,cli,enterprise,doc-retrieval-mcp}/package.json`: `@skillsmith/core` dependency bumped to `^0.12.0`
- `package-lock.json`: regenerated to match
- `scripts/lib/version-utils.ts`: `updateWorkspaceDependencies()` now scans every directory under `packages/*` (still honoring `skipDepRangeUpdate` for `vscode-extension`'s separate publish cadence) instead of only `PACKAGE_SPECS` targets
- `scripts/tests/prepare-release.test.ts`: new regression test asserting `doc-retrieval-mcp`'s `@skillsmith/core` pin gets refreshed on a core bump

Refs SMI-6098, SMI-6111