### PR TITLE
fix(core,mcp-server): SMI-6143 correct publish-order break in @skillsmith/mcp-server@0.7.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34066,7 +34066,7 @@
       },
       "devDependencies": {
         "@skillsmith/core": "^0.12.0",
-        "@skillsmith/mcp-server": "^0.7.10",
+        "@skillsmith/mcp-server": "^0.7.11",
         "@types/node": "^25.9.3",
         "esbuild": "0.28.1",
         "vitest": "4.1.10"
@@ -34267,31 +34267,6 @@
         "node": ">=22.22.0"
       }
     },
-    "packages/doc-retrieval-mcp/node_modules/@skillsmith/core/node_modules/better-sqlite3": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-      }
-    },
-    "packages/doc-retrieval-mcp/node_modules/@skillsmith/core/node_modules/zod": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
-      "extraneous": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "packages/doc-retrieval-mcp/node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -34329,7 +34304,7 @@
         "zod": "4.2.1"
       },
       "devDependencies": {
-        "@skillsmith/mcp-server": "^0.7.10",
+        "@skillsmith/mcp-server": "^0.7.11",
         "@smithy/config-resolver": "4.6.16",
         "@smithy/core": "3.31.1",
         "@smithy/middleware-endpoint": "4.6.16",
@@ -34344,7 +34319,7 @@
         "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "@skillsmith/mcp-server": "^0.7.10"
+        "@skillsmith/mcp-server": "^0.7.11"
       },
       "peerDependenciesMeta": {
         "@skillsmith/mcp-server": {
@@ -34380,7 +34355,7 @@
     },
     "packages/mcp-server": {
       "name": "@skillsmith/mcp-server",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "Elastic-2.0",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "10.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@skillsmith/core": "^0.12.0",
-    "@skillsmith/mcp-server": "^0.7.10",
+    "@skillsmith/mcp-server": "^0.7.11",
     "@types/node": "^25.9.3",
     "esbuild": "0.28.1",
     "vitest": "4.1.10"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to `@skillsmith/core` are documented here.
 
 ## v0.12.0
 
-- **Cadence**: Mechanical cadence alignment (no changes since v0.11.7).
 - **Feature**: new `resolveSessionTier` client (`sync/license-status-client.ts`, SMI-6098) —
   authenticates the stored device-login session against `/license-status` (proactively refreshing
   via the existing `resolveAccessToken` helper) so the MCP server can resolve a real subscription

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -14,11 +14,10 @@ Part of Skillsmith: a lifecycle layer for agent skills across teams.
 
 ## What's New in v0.12.0
 
-- **Security-status reporting unified**: CLI and MCP now derive security-scan status (pass/fail, risk score, findings count) from one shared `deriveSecuritySummaryFromApiSkill`/`deriveSecuritySummaryFromSkillRow`, instead of two independently-maintained copies that could disagree on the same skill.
-- **`skill_compare` reuses `get_skill`'s resolution**: new shared `resolveSkillApiFirst()` fixes compare only ever hitting the local SQLite cache (no longer kept in sync with the remote-first registry), which made real, searchable skills report "not found."
-- **New two-level owned-lock primitive** (`config/owned-lock`) replacing the single-level, age-based config lock — closes a case where two concurrent reclaimers could both treat a stale lock as safe to unlink.
-- **Private-registry install support**: `SkillInstallationService.installFromContent()` installs an already-resolved skill (e.g. from a private registry) through the same scan/write/manifest pipeline as a GitHub-fetched install.
-- **Quiet mode covers one more warning path**: `SKILLSMITH_QUIET` now also suppresses the WASM-SQLite-driver fallback notice, previously printed unconditionally.
+- **New `resolveSessionTier` client** (`sync/license-status-client.ts`): authenticates a stored `skillsmith login` session against `/license-status` so the MCP server can resolve a real subscription tier without a separately-configured `SKILLSMITH_API_KEY`, instead of silently falling back to `community`.
+- **Scanner: bundled-file scan expanded to operational code** (Gap 8 of the ClawHavoc remediation): the indexer now reads `scripts/`, `src/`, and `bin/` alongside `SKILL.md`, closing a blind spot where a backdoor buried mid-function in working operational code was structurally invisible.
+- **Scanner fix**: the markdown indented-code-block heuristic was silently downgrading real non-markdown source findings from `high` to `medium` — `analyzeMarkdownContext`/`SecurityScanner.scan()` now take an explicit `isMarkdown` parameter instead of assuming every scanned file is documentation.
+- **Five new scanner detectors** (SMI-6033 Waves 3–4): `gatekeeper_bypass` (macOS quarantine-attribute stripping), `archive_evasion` (password-protected archives correlated with a fetch), a paste/snippet-host reputation detector, an encoded-payload decode-and-recursively-rescan detector, and `decoy_misdirection` (a fetch domain that doesn't match a nearby vendor-authority claim) — plus a stronger multi-signal co-signal escalation model so several individually sub-threshold findings can now jointly escalate a weak `code_execution` finding to critical.
 
 See [CHANGELOG.md](./CHANGELOG.md) for previous releases.
 

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -50,7 +50,7 @@
     "zod": "4.2.1"
   },
   "devDependencies": {
-    "@skillsmith/mcp-server": "^0.7.10",
+    "@skillsmith/mcp-server": "^0.7.11",
     "@smithy/config-resolver": "4.6.16",
     "@smithy/core": "3.31.1",
     "@smithy/middleware-endpoint": "4.6.16",
@@ -62,7 +62,7 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@skillsmith/mcp-server": "^0.7.10"
+    "@skillsmith/mcp-server": "^0.7.11"
   },
   "peerDependenciesMeta": {
     "@skillsmith/mcp-server": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `@skillsmith/mcp-server` are documented here.
 
 ## [Unreleased]
 
+## v0.7.11
+
+- **Fix**: 0.7.10 was uninstallable — `npx @skillsmith/mcp-server@latest --version` threw
+  `SyntaxError: The requested module '@skillsmith/core' does not provide an export named
+  'SessionTierAuthError'`. Root cause: 0.7.10's source imported `getApiBaseUrl`,
+  `resolveSessionTier`, `SessionTierAuthError`, and `SessionTierTransientError` from
+  `@skillsmith/core`, but core's published version was never bumped past 0.11.7 — the release
+  that predates those exports. This package's `@skillsmith/core` dependency floor is corrected to
+  `^0.12.0`, the first core release that actually contains them (SMI-6143).
+
 ## v0.7.10
 
 - **Fix**: remove SUPABASE_SERVICE_ROLE_KEY from registry install path (#2494)

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,7 +6,11 @@ MCP (Model Context Protocol) server for agent skill publishing, installation, an
 
 Part of Skillsmith: a lifecycle layer for agent skills across teams.
 
-## What's New in v0.7.10
+## What's New in v0.7.11
+
+- **Fix: 0.7.10 was uninstallable** — it imported `@skillsmith/core` exports (`SessionTierAuthError`, `SessionTierTransientError`, `resolveSessionTier`, `getApiBaseUrl`) that only shipped in core 0.12.0, but this package's own dependency floor still allowed the older, broken-for-this-purpose 0.11.7. The `@skillsmith/core` dependency is now `^0.12.0` (SMI-6143). No other changes in this release.
+
+### What's New in v0.7.10
 
 - **Security: `SUPABASE_SERVICE_ROLE_KEY` removed from every MCP-host code path**: `private_registry_manage`'s `list`, `get`, `namespace`, and `install` actions — plus the registry-install path — no longer run on the Supabase service-role client. They now run as the signed-in user (`skillsmith login`) or through a narrowly-scoped `SECURITY DEFINER` RPC, so there's no admin credential left to configure or distribute (SMI-6109/SMI-6111).
 - **Session-login users now get their real subscription tier**: callers authenticated only via `skillsmith login` (no separately-configured `SKILLSMITH_API_KEY`) previously fell back to `community` regardless of actual entitlement, silently blocking Enterprise-gated tools like `private_registry_manage`/`private_registry_publish` (SMI-6098).

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsmith/mcp-server",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "mcpName": "io.github.smith-horn/skillsmith",
   "description": "Publish versioned agent skills to a team-scoped registry, catch drift across installs, and deprecate what's gone stale.",
   "type": "module",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/smith-horn/skillsmith",
     "source": "github"
   },
-  "version": "0.7.10",
+  "version": "0.7.11",
   "_meta": {
     "io.skillsmith/categories": ["developer-tools", "ai-agents", "skill-management"],
     "io.skillsmith/keywords": ["claude-code", "agent-skills", "autonomous-agents", "openclaw"]
@@ -17,7 +17,7 @@
     {
       "registryType": "npm",
       "identifier": "@skillsmith/mcp-server",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -116,7 +116,7 @@ export type {
 } from './webhooks/stripe-webhook-endpoint.js'
 
 // Package version - keep in sync with package.json
-const PACKAGE_VERSION = '0.7.10'
+const PACKAGE_VERSION = '0.7.11'
 const PACKAGE_NAME = '@skillsmith/mcp-server'
 const logger = createLogger('mcp', { version: PACKAGE_VERSION }) // SMI-5615
 import { installBundledSkills, installUserDocs } from './onboarding/install-assets.js'


### PR DESCRIPTION
## Business Summary

**What shipped:** `@skillsmith/mcp-server@0.7.10`, published a short time ago, was completely broken — every fresh install or update failed immediately with a syntax error. This fixes it by publishing the missing piece it actually depended on.

**Quality bar:** Root-caused and reproduced locally (not just from the CI log, which truncates the real error). Implemented by one pass, then independently re-verified by a second, adversarial pass before this PR opened — which caught a real additional bug the first pass missed: a third package's dependency range was stale in a way that would have quietly swapped a shared library for a duplicate copy with its own native dependencies, and misleading changelog entries that would have shipped to npm. Both fixed here. Full build, typecheck, lint, and test suite (506 test files, 9,248 tests) green; the standards audit that would have caught the dependency-range gap now passes with zero failures.

**Found along the way:** the internal check meant to catch exactly this class of bug (a consumer package depending on exports its dependency hasn't actually published yet) exists in the repo — and, corrected during pre-merge review, *is* already wired into `ci.yml` (SMI-4530, strict-mode on version-bump PRs). It still didn't catch this: both it and `audit:standards` Check 58 only compare declared dependency ranges against the sibling's local `package.json` *version field*, never against the sibling's actual exported symbols, so a source-level export that predates its own version bump slips through undetected. Filed as SMI-6146 rather than fixing the check itself here, to keep this hotfix narrowly scoped to unblocking real installs.

**Net result:** Ready to publish. Once this merges, `@skillsmith/core` and `@skillsmith/mcp-server` both need a new version published (in that order) to actually resolve the outage — merging this PR alone doesn't fix anything live yet.

---

## Technical detail

Root cause: `@skillsmith/mcp-server@0.7.10`'s source imports `getApiBaseUrl`, `resolveSessionTier`, `SessionTierAuthError`, `SessionTierTransientError` from `@skillsmith/core` (added in commit 618c3f600, SMI-6098). But core's own `package.json` version was never bumped past 0.11.7 — the version already published, which predates that commit. mcp-server's dependency `"@skillsmith/core": "^0.11.7"` resolved to the old core version at install time. A publish-order violation: mcp-server shipped depending on core functionality core itself never shipped.

- `packages/core`: 0.11.7 → 0.12.0 (minor — core's own CHANGELOG already labeled the `resolveSessionTier` addition a Feature).
- `packages/mcp-server`: 0.7.10 → 0.7.11 (patch), `@skillsmith/core` dependency `^0.11.7` → `^0.12.0` — the actual fix.
- `packages/doc-retrieval-mcp`: `@skillsmith/core` `^0.11.2` → `^0.12.0`. This package isn't tracked by `scripts/prepare-release.ts`'s `PACKAGE_SPECS`, so the automated version bump missed it — caught by the adversarial review pass, which also found the stale range had silently de-linked the workspace symlink for `@skillsmith/core` in `package-lock.json`, substituting a nested registry tarball (0.11.7) with its own nested native `better-sqlite3` — the same class of regression SMI-5715/SMI-5451 were. Lockfile regenerated and the orphaned nested entries removed.
- `packages/cli`, `packages/enterprise`: workspace dependency ranges bumped by `prepare-release.ts`'s `updateWorkspaceDependencies` — neither package is affected itself (cli's core dependency is dev-only and its published dist doesn't reference the broken symbols; enterprise isn't on the public npm registry).
- Both packages' CHANGELOG entries corrected — the auto-generated "Cadence: no changes" placeholders were misleading (core's sat next to 8 commits of real unreleased work; mcp-server's obscured the actual fix during an active outage). READMEs' "What's New" sections refreshed to match — headings had been bumped but bodies still described the prior release.

**Verification performed:**
- Built dist confirmed to actually export all four symbols (grepped; confirmed absent from the previously-published `core@0.11.7` npm tarball).
- Full `core` + `mcp-server` + `doc-retrieval-mcp` build/typecheck/lint/test suite green.
- `npm run audit:standards`: 0 failures (Check 58, the internal dependency-coherence gate, was failing before the `doc-retrieval-mcp` fix).
- `node scripts/verify-publish-deps.mjs` (run on host — it needs `origin/main` access the worktree container doesn't have): exit 0, all workspace dependency versions consistent.

**Root cause of why no pre-publish gate caught this** (SMI-6146): `audit:standards` Check 58 validates package.json dependency ranges against local workspace *versions*, not against what's actually exported — it passed at commit time because core's local version was also still 0.11.7. `scripts/verify-publish-deps.mjs` exists specifically for this failure class and **is** wired into `ci.yml` (SMI-4530) in strict-blocking mode on exactly this kind of version-bump PR — corrected from an earlier draft of this PR body, which incorrectly claimed it was never CI-wired. It still didn't catch this, for a more specific reason: at the commit that published mcp-server 0.7.10, mcp-server's own `package.json` version bump triggered the strict check, but core's local `package.json` version was *also* still 0.11.7 (core's bump hadn't happened), so the range-vs-local-version comparison passed cleanly — the check has no way to know core's *source* had already added the new exports ahead of its own version bump. The only thing that actually caught this in practice was `smoke-test-published.yml`, which runs *after* `npm publish` — too late to prevent the outage, only able to report it. SMI-6146 tracks building an actual export-surface check to close this for real.

**Publish sequence after merge** (core must be live before mcp-server is published — the existing `publish.yml` workflow already enforces this ordering and verifies core's presence on npm before starting the mcp-server job):
```bash
gh workflow run publish.yml -f dry_run=false
# verify core@0.12.0 live and exports correct, THEN confirm mcp-server@0.7.11 resolves it:
npx -y @skillsmith/mcp-server@latest --version
```

Linear: SMI-6143 (urgent). GitHub issue: #2498 (auto-filed by smoke-prod).

