### PR TITLE
fix(website): close two account-nav navigation-race gaps (SMI-6137, SMI-6154)

### DIFF
--- a/packages/website/src/lib/account-navigation-epoch.ts
+++ b/packages/website/src/lib/account-navigation-epoch.ts
@@ -1,34 +1,87 @@
 /**
  * Navigation-epoch guard for stale async continuations on team-gated account
- * pages (SMI-6112).
+ * pages (SMI-6112, hardened by SMI-6137).
  *
  * Problem: an `astro:page-load` handler on a gated account page validates
  * its pathname once at entry, then `await`s a tier-check RPC (and, on some
  * pages, a session lookup and/or a further data load) before applying a
  * redirect or writing to the DOM. Because `astro:page-load` listeners
- * persist across Astro ClientRouter view transitions, the user can navigate
- * away — or away and back to the SAME route (the A-B-A case) — while any of
- * those `await`s is still in flight. A single pathname recheck placed after
- * only the first `await` cannot close either case: it doesn't protect later
- * continuations, and on a return visit it would wrongly let an older,
- * slower-resolving check win a race against a newer, faster one for the
- * same route.
+ * persist across Astro ClientRouter view transitions (SMI-5158, still
+ * open), the user can navigate away — or away and back to the SAME route
+ * (the A-B-A case) — while any of those `await`s is still in flight. A
+ * single pathname recheck placed after only the first `await` cannot close
+ * either case: it doesn't protect later continuations, and on a return
+ * visit it would wrongly let an older, slower-resolving check win a race
+ * against a newer, faster one for the same route.
  *
- * Fix: every genuine `astro:page-load` event (each one represents a
- * completed navigation, including the initial load) advances a single
- * module-level epoch counter. A gated page captures the epoch once, right
- * after its entry pathname guard passes and before its first `await`. Every
- * continuation that would otherwise mutate state — a redirect, a
- * `data-team-entitled`/`setAccountNavTeamEntitled` write, an error/not-member render,
- * or a DOM write of loaded data — checks `isStale()` immediately beforehand
- * and returns without acting if a newer navigation has since occurred.
+ * Fix (SMI-6112): every genuine navigation-lifecycle event advances a
+ * single module-level epoch counter. A gated page captures the epoch once,
+ * right after its entry pathname guard passes and before its first
+ * `await`. Every continuation that would otherwise mutate state — a
+ * redirect, a `data-team-entitled`/`setAccountNavTeamEntitled` write, an
+ * error/not-member render, or a DOM write of loaded data — checks
+ * `isStale()` immediately beforehand and returns without acting if a
+ * newer navigation has since occurred.
+ *
+ * Which event(s) advance the epoch, and why both (SMI-6137): the counter
+ * originally advanced on `astro:page-load` only. That event fires *after*
+ * Astro's ClientRouter has already swapped the destination page's `<body>`
+ * into the document AND re-executed its scripts
+ * (`node_modules/astro/dist/transitions/router.js`, as of `astro@7.2.0`:
+ * `doSwap()`/`event.swap()` in `events.js:116-124` does the DOM swap;
+ * `runScripts()` + `onPageLoad()` in `router.js:72-101` and `:350-354` run
+ * afterward, awaiting any external-`src` script's own load first). That left
+ * a real window — bounded by however long script re-execution takes —
+ * where the DOM already belonged to the destination page but the epoch
+ * hadn't advanced yet: a stale continuation resolving in that window passed
+ * `isStale()` and wrote onto a DOM it no longer owned (SMI-6137, reproduced
+ * without any artificial delay by ordinary async RPC scheduling — WebKit's
+ * CI timing happened to land in the window reliably; the gap itself is
+ * browser-agnostic).
+ *
+ * `astro:before-swap` closes that gap: it's the event Astro dispatches
+ * immediately before `event.swap()` runs (`events.js:116-124`), so a
+ * listener on it (this module has one) advances the epoch strictly before
+ * any DOM mutation — nothing after that dispatch can prevent, cancel, or
+ * reorder the swap (`TransitionBeforeSwapEvent` is constructed non-
+ * cancelable, `events.js:59-85`). `astro:page-load` remains wired too and
+ * is NOT redundant: it's the only lifecycle event that fires on the very
+ * first, non-SPA page load, which never dispatches `astro:before-swap` at
+ * all (that event only exists inside Astro's SPA-transition machinery,
+ * `router.js:221-368`) — without it, a guard captured during the first
+ * page's own load would have no epoch bump to have ever occurred relative
+ * to. On every SPA transition the two listeners both fire (before-swap
+ * first, page-load later) and both advance the same counter; the second,
+ * later increment is harmless since guards only ever compare for strict
+ * inequality.
+ *
+ * Deliberate trade-off, not a bug: `doSwap()` still `await`s
+ * `afterDispatch` (`events.js:116-124`) between dispatching
+ * `astro:before-swap` and actually swapping the DOM — a no-op on
+ * Chromium's real View-Transitions path, but on WebKit's default
+ * fallback-animate path (`getFallback()` defaulting to `"animate"`,
+ * `router.js:65-71`) a genuine wait for the outgoing page's own CSS exit
+ * animation to finish (`router.js:178-192`). So on WebKit specifically, the
+ * epoch can advance a meaningful amount of real time *before* the DOM is
+ * actually swapped. A still-technically-valid write from the outgoing page
+ * that resolves during that window is now suppressed as "stale" even
+ * though its target element technically still exists for a little longer
+ * — a false-stale costing at most one already-being-torn-down frame of
+ * work, which is the correct fail-safe direction: strictly preferable to
+ * ever landing a write on a DOM that no longer belongs to the page that
+ * produced it. Do not "fix" this by moving the listener to a later event
+ * (e.g. `astro:after-swap`) — that reopens a version of the exact gap this
+ * module exists to close, since `updateDOM()` still `await`s `doSwap(...)`
+ * (`router.js:202`) before dispatching `astro:after-swap`, meaning the DOM
+ * would already belong to the destination page for a stretch before that
+ * event fires too.
  *
  * Testability: `packages/website/vitest.config.ts` runs the `node`
  * environment (see `vitest.preset.ts`), not `jsdom` — there is no real
  * `document` to dispatch events against in unit tests. `advanceNavigationEpoch()`
  * is exported directly (not only reachable via a DOM event) so unit tests
- * can simulate a fresh `astro:page-load` firing without a DOM; it is also
- * the function wired to the real event below for production use.
+ * can simulate either real event firing without a DOM; it is also the
+ * function wired to both real events below for production use.
  */
 
 let currentEpoch = 0
@@ -36,21 +89,23 @@ let listenerRegistered = false
 
 /**
  * Advance the shared navigation epoch. Any `NavigationEpochGuard` captured
- * before this call reports `isStale() === true` afterward. Wired to the
- * real `astro:page-load` event via `registerNavigationEpochListener()`
- * below; exported directly so it can also be invoked from unit tests that
- * have no DOM to dispatch a real event against.
+ * before this call reports `isStale() === true` afterward. Wired to both
+ * the real `astro:before-swap` and `astro:page-load` events via
+ * `registerNavigationEpochListener()` below (see the module doc comment
+ * above for why both); exported directly so it can also be invoked from
+ * unit tests that have no DOM to dispatch a real event against.
  */
 export function advanceNavigationEpoch(): void {
   currentEpoch += 1
 }
 
 /**
- * Register the module's `astro:page-load` listener on `document`, guarded
- * so it registers at most once even if this module is imported from
- * multiple page scripts within the same browser session. No-ops outside a
- * browser (e.g. under the `node` vitest environment) — `advanceNavigationEpoch()`
- * remains directly callable there for tests.
+ * Register the module's `astro:before-swap` and `astro:page-load`
+ * listeners on `document`, guarded so they register at most once even if
+ * this module is imported from multiple page scripts within the same
+ * browser session. No-ops outside a browser (e.g. under the `node` vitest
+ * environment) — `advanceNavigationEpoch()` remains directly callable
+ * there for tests.
  *
  * Why `listenerRegistered` is sufficient here (and the usual
  * `window.__xInited` idempotency pattern for `astro:page-load` binds isn't
@@ -66,6 +121,7 @@ export function advanceNavigationEpoch(): void {
  */
 function registerNavigationEpochListener(): void {
   if (listenerRegistered || typeof document === 'undefined') return
+  document.addEventListener('astro:before-swap', advanceNavigationEpoch)
   document.addEventListener('astro:page-load', advanceNavigationEpoch)
   listenerRegistered = true
 }
@@ -75,7 +131,7 @@ registerNavigationEpochListener()
 export interface NavigationEpochGuard {
   /** The epoch captured at creation time. Exposed for debugging/tests. */
   readonly epoch: number
-  /** True once a newer `astro:page-load` has fired since this guard was created. */
+  /** True once a newer navigation (`astro:before-swap` or `astro:page-load`) has occurred since this guard was created. */
   isStale: () => boolean
 }
 

--- a/packages/website/src/lib/account-page-path.test.ts
+++ b/packages/website/src/lib/account-page-path.test.ts
@@ -2,8 +2,12 @@
  * Tests for the shared account-area path normalization (SMI-6112).
  */
 
-import { describe, expect, it } from 'vitest'
-import { isCurrentAccountPath, normalizeAccountPath } from './account-page-path'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  isAccountPageMounted,
+  isCurrentAccountPath,
+  normalizeAccountPath,
+} from './account-page-path'
 
 /** The five team-gated account pages this predicate guards (SMI-6112). */
 const CANONICAL_PATHS = [
@@ -72,5 +76,53 @@ describe('isCurrentAccountPath', () => {
 
   it('is not fooled by a shared prefix', () => {
     expect(isCurrentAccountPath('/account/team/membersextra', '/account/team/members')).toBe(false)
+  })
+})
+
+describe('isAccountPageMounted', () => {
+  /** Minimal `{ querySelector }` stub — no real DOM in the `node` vitest environment. */
+  function fakeDoc(present: string[]): Pick<Document, 'querySelector'> {
+    return {
+      querySelector: vi.fn((selector: string) => {
+        for (const path of present) {
+          if (selector === `[data-account-page="${path}"]`) return {} as Element
+        }
+        return null
+      }),
+    }
+  }
+
+  it('reports true when the marker for the expected path is present', () => {
+    for (const path of CANONICAL_PATHS) {
+      expect(isAccountPageMounted(path, fakeDoc([path])), path).toBe(true)
+    }
+  })
+
+  it('reports false when the live document has no marker at all', () => {
+    expect(isAccountPageMounted('/account', fakeDoc([]))).toBe(false)
+  })
+
+  it('reports false when the live document has a DIFFERENT page marker (SMI-6154 core case: DOM belongs to another route)', () => {
+    expect(isAccountPageMounted('/account', fakeDoc(['/account/team/members']))).toBe(false)
+  })
+
+  it('queries the exact attribute selector, not a substring or prefix match', () => {
+    const doc = fakeDoc(['/account/team/members'])
+    expect(isAccountPageMounted('/account/team', doc)).toBe(false)
+    expect(doc.querySelector).toHaveBeenCalledWith('[data-account-page="/account/team"]')
+  })
+
+  it('defaults to the global document when none is injected', () => {
+    // No real DOM in the `node` vitest environment — stub a global
+    // `document` for the duration of this test so the omitted-second-arg
+    // call shape (the real production call site: `isAccountPageMounted('/account')`)
+    // is genuinely exercised, not just documented.
+    vi.stubGlobal('document', fakeDoc(['/account']))
+    try {
+      expect(isAccountPageMounted('/account')).toBe(true)
+      expect(isAccountPageMounted('/account/team/members')).toBe(false)
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })

--- a/packages/website/src/lib/account-page-path.ts
+++ b/packages/website/src/lib/account-page-path.ts
@@ -34,7 +34,57 @@ export function normalizeAccountPath(path: string): string {
  * #1 — a handler that passed the entry guard can still go stale mid-flight,
  * across an `await`, or in the A-B-A case where the user leaves and returns
  * to the same route before the first check resolves).
+ *
+ * Pathname alone is NOT sufficient, though (SMI-6154): on a browser
+ * back/forward (`popstate`/"traverse") navigation, the browser reverts
+ * `location.href` to the destination URL *before* Astro's ClientRouter has
+ * actually swapped the DOM to match — a brief window where
+ * `window.location.pathname` already reads the destination route but the
+ * live document is still the page being navigated away from. An orphaned
+ * `astro:page-load` dispatch (the delayed tail of an EARLIER, already-
+ * superseded transition — see `isAccountPageMounted()` below) can land in
+ * exactly that window and pass this check on a false pretense. Callers
+ * MUST pair this with `isAccountPageMounted()` for a real entry guard;
+ * see that function's doc comment for why pathname alone can't close this.
  */
 export function isCurrentAccountPath(actualPath: string, expectedPath: string): boolean {
   return normalizeAccountPath(actualPath) === normalizeAccountPath(expectedPath)
+}
+
+/**
+ * Whether the live document actually contains the DOM marker for
+ * `expectedPath` (SMI-6154) — a `data-account-page="<expectedPath>"`
+ * attribute each of the five team-gated account pages sets on their own
+ * `<main>` element, always present regardless of loading/content/error
+ * state (never removed, only ever loading/content/error panels toggle
+ * visibility inside it).
+ *
+ * Root cause this closes: `isCurrentAccountPath()` alone is fooled by the
+ * `popstate` pathname-updates-before-DOM-swap window (see that function's
+ * doc comment). Astro's ClientRouter can also leave a PRIOR transition's
+ * `astro:page-load` dispatch pending — its own `runScripts()` →
+ * `onPageLoad()` continuation is a separately-chained promise that nothing
+ * awaits, cancels, or checks against a newer navigation
+ * (`node_modules/astro/dist/transitions/router.js`, as of `astro@7.2.0`,
+ * `updateCallbackDone.finally(...)` in `transition()`) — so that orphaned
+ * dispatch can fire well after a NEWER navigation has already started,
+ * landing squarely in the popstate desync window on the wrong page's DOM.
+ * `isCurrentAccountPath()` passes (the URL already reverted); the
+ * navigation-epoch guard (`account-navigation-epoch.ts`, SMI-6112/SMI-6137)
+ * also can't catch this — the orphaned dispatch's OWN firing is itself the
+ * most recent epoch-advancing event, so a guard captured inside it is
+ * fresh by construction. Only checking what's ACTUALLY live in the DOM
+ * closes the gap.
+ *
+ * `doc` defaults to the global `document` for production use; accepts an
+ * injected value so unit tests (this package's vitest config runs the
+ * `node` environment — no real `document`, see
+ * `account-navigation-epoch.ts`'s header comment) can pass a minimal
+ * `{ querySelector }` stub instead of standing up a real DOM.
+ */
+export function isAccountPageMounted(
+  expectedPath: string,
+  doc: Pick<Document, 'querySelector'> = document
+): boolean {
+  return doc.querySelector(`[data-account-page="${expectedPath}"]`) !== null
 }

--- a/packages/website/src/pages/account/index.astro
+++ b/packages/website/src/pages/account/index.astro
@@ -52,7 +52,7 @@ const supabaseConfig = getSupabaseConfig()
     <div class="account-shell">
       <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <main class="dashboard-container">
+      <main class="dashboard-container" data-account-page="/account">
         <h1>Account</h1>
 
         <!-- Renders outside/above loading, error, and gated states —
@@ -336,7 +336,7 @@ const supabaseConfig = getSupabaseConfig()
     isTeamEntitled,
   } from '../../lib/account-overview-data'
   import { resyncStripeEmailIfPending } from '../../lib/account-flags'
-  import { isCurrentAccountPath } from '../../lib/account-page-path'
+  import { isAccountPageMounted, isCurrentAccountPath } from '../../lib/account-page-path'
   import { createNavigationEpochGuard } from '../../lib/account-navigation-epoch'
   import { setAccountNavTeamEntitled } from '../../lib/account-nav-entitlement'
 
@@ -368,7 +368,14 @@ const supabaseConfig = getSupabaseConfig()
     // Only run on this page. L13: this guard used to accept /account/team
     // and /account/team/ — it now accepts /account and /account/ since this
     // page moved here (Decision #1).
+    //
+    // SMI-6154: pathname alone isn't enough — on a browser back/forward
+    // navigation, `location.pathname` can already read `/account` before
+    // Astro's ClientRouter has actually swapped the DOM to match (see
+    // isCurrentAccountPath()'s doc comment). isAccountPageMounted() checks
+    // that this page's own DOM marker is actually live before proceeding.
     if (!isCurrentAccountPath(window.location.pathname, '/account')) return
+    if (!isAccountPageMounted('/account')) return
 
     // SMI-6112: navigation-epoch guard. The entry pathname check above only
     // protects against a handler that fired for a route the user has

--- a/packages/website/src/pages/account/team/analytics.astro
+++ b/packages/website/src/pages/account/team/analytics.astro
@@ -47,7 +47,7 @@ const supabaseConfig = getSupabaseConfig()
     <div class="account-shell">
       <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <main class="analytics-container">
+      <main class="analytics-container" data-account-page="/account/team/analytics">
         <h1>Team Analytics</h1>
 
         <AccountMobileNav currentPath="/account/team/analytics" />
@@ -184,7 +184,7 @@ const supabaseConfig = getSupabaseConfig()
   import { createClient } from '@supabase/supabase-js'
   import { checkTeamAccess, resolveGateRedirect } from '../../../lib/team-access'
   import { isTeamEntitled } from '../../../lib/account-overview-data'
-  import { isCurrentAccountPath } from '../../../lib/account-page-path'
+  import { isAccountPageMounted, isCurrentAccountPath } from '../../../lib/account-page-path'
   import { createNavigationEpochGuard } from '../../../lib/account-navigation-epoch'
   import { setAccountNavTeamEntitled } from '../../../lib/account-nav-entitlement'
 
@@ -207,7 +207,10 @@ const supabaseConfig = getSupabaseConfig()
   }
 
   document.addEventListener('astro:page-load', async () => {
+    // SMI-6154: pathname alone isn't enough on a browser back/forward
+    // navigation — see account/index.astro's identical comment.
     if (!isCurrentAccountPath(window.location.pathname, '/account/team/analytics')) return
+    if (!isAccountPageMounted('/account/team/analytics')) return
 
     // SMI-6112: see account/index.astro's identical comment for the full
     // rationale — a single entry-path check cannot protect the

--- a/packages/website/src/pages/account/team/members.astro
+++ b/packages/website/src/pages/account/team/members.astro
@@ -45,7 +45,7 @@ const supabaseConfig = getSupabaseConfig()
     <div class="account-shell">
       <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <main class="members-container">
+      <main class="members-container" data-account-page="/account/team/members">
         <h1>Team Members</h1>
 
         <AccountMobileNav currentPath="/account/team/members" />
@@ -384,7 +384,7 @@ const supabaseConfig = getSupabaseConfig()
     wireMemberManagement,
     type Viewer,
   } from '../../../lib/team-invite-ui'
-  import { isCurrentAccountPath } from '../../../lib/account-page-path'
+  import { isAccountPageMounted, isCurrentAccountPath } from '../../../lib/account-page-path'
   import { createNavigationEpochGuard } from '../../../lib/account-navigation-epoch'
   import { setAccountNavTeamEntitled } from '../../../lib/account-nav-entitlement'
 
@@ -407,7 +407,10 @@ const supabaseConfig = getSupabaseConfig()
   }
 
   document.addEventListener('astro:page-load', async () => {
+    // SMI-6154: pathname alone isn't enough on a browser back/forward
+    // navigation — see account/index.astro's identical comment.
     if (!isCurrentAccountPath(window.location.pathname, '/account/team/members')) return
+    if (!isAccountPageMounted('/account/team/members')) return
 
     // SMI-6112: see account/index.astro's identical comment for the full
     // rationale — a single entry-path check cannot protect the

--- a/packages/website/src/pages/account/team/registry.astro
+++ b/packages/website/src/pages/account/team/registry.astro
@@ -47,7 +47,7 @@ const supabaseConfig = getSupabaseConfig()
     <div class="account-shell">
       <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <main class="registry-container">
+      <main class="registry-container" data-account-page="/account/team/registry">
         <h1>Private Registry</h1>
 
         <AccountMobileNav currentPath="/account/team/registry" />
@@ -482,7 +482,7 @@ const supabaseConfig = getSupabaseConfig()
     setRegistryVersionDeprecated,
     type PrivateRegistryDashboardRow,
   } from '../../../lib/private-registry-dashboard'
-  import { isCurrentAccountPath } from '../../../lib/account-page-path'
+  import { isAccountPageMounted, isCurrentAccountPath } from '../../../lib/account-page-path'
   import { createNavigationEpochGuard } from '../../../lib/account-navigation-epoch'
   import { setAccountNavTeamEntitled } from '../../../lib/account-nav-entitlement'
 
@@ -536,7 +536,10 @@ const supabaseConfig = getSupabaseConfig()
   }
 
   document.addEventListener('astro:page-load', async () => {
+    // SMI-6154: pathname alone isn't enough on a browser back/forward
+    // navigation — see account/index.astro's identical comment.
     if (!isCurrentAccountPath(window.location.pathname, '/account/team/registry')) return
+    if (!isAccountPageMounted('/account/team/registry')) return
 
     // SMI-6112: see account/index.astro's identical comment for the full
     // rationale — a single entry-path check cannot protect the

--- a/packages/website/src/pages/account/team/workspaces.astro
+++ b/packages/website/src/pages/account/team/workspaces.astro
@@ -43,7 +43,7 @@ const supabaseConfig = getSupabaseConfig()
     <div class="account-shell">
       <AccountSidebar currentPath={Astro.url.pathname} />
 
-      <main class="workspaces-container">
+      <main class="workspaces-container" data-account-page="/account/team/workspaces">
         <h1>Team Workspaces</h1>
 
         <AccountMobileNav currentPath="/account/team/workspaces" />
@@ -412,7 +412,7 @@ const supabaseConfig = getSupabaseConfig()
   import { createClient } from '@supabase/supabase-js'
   import { checkTeamAccess, resolveGateRedirect } from '../../../lib/team-access'
   import { isTeamEntitled } from '../../../lib/account-overview-data'
-  import { isCurrentAccountPath } from '../../../lib/account-page-path'
+  import { isAccountPageMounted, isCurrentAccountPath } from '../../../lib/account-page-path'
   import { createNavigationEpochGuard } from '../../../lib/account-navigation-epoch'
   import { setAccountNavTeamEntitled } from '../../../lib/account-nav-entitlement'
 
@@ -441,7 +441,10 @@ const supabaseConfig = getSupabaseConfig()
   }
 
   document.addEventListener('astro:page-load', async () => {
+    // SMI-6154: pathname alone isn't enough on a browser back/forward
+    // navigation — see account/index.astro's identical comment.
     if (!isCurrentAccountPath(window.location.pathname, '/account/team/workspaces')) return
+    if (!isAccountPageMounted('/account/team/workspaces')) return
 
     // SMI-6112: see account/index.astro's identical comment for the full
     // rationale — a single entry-path check cannot protect the

--- a/packages/website/tests/e2e/account-page-load-guards.spec.ts
+++ b/packages/website/tests/e2e/account-page-load-guards.spec.ts
@@ -41,8 +41,19 @@ import {
 } from './complete-profile.helpers'
 import { refireAstroPageLoad } from './astro-helpers'
 
-// The bug surfaces as a null property access, phrased differently per engine.
-const NULL_DEREF = /Cannot read properties of null|null is not an object|reading 'style'/
+// The bug surfaces as a null property access, phrased differently per
+// engine AND per read-vs-write (SMI-6154 discovery: V8/Chromium phrases a
+// null property WRITE — e.g. `document.getElementById(x)!.textContent =
+// ...` — as "Cannot set properties of null (setting '...')", distinct from
+// its own "Cannot read properties of null (reading '...')" wording for a
+// null property READ; WebKit uses "null is not an object (evaluating
+// '...')" for both. Every null-deref this file's tests were written
+// against before SMI-6154 happened to be WebKit-only or a read, so this
+// gap went undetected — a Chromium-side null-property-WRITE crash would
+// have silently passed collectNullDerefs() as "no hits" instead of
+// failing loudly.
+const NULL_DEREF =
+  /Cannot read properties of null|Cannot set properties of null|null is not an object|reading 'style'/
 
 // Sibling pages reachable via a real `<a>` in the account sidebar (SMI-5475
 // — replaced the Quick Links grid; SMI-6128 — reorganized into Account /
@@ -589,6 +600,107 @@ test.describe('SMI-6112 — navigation-epoch guard against stale async continuat
     // above. #billing-content starts `display: none` and only becomes
     // visible once billing.astro's own astro:page-load handler completes
     // (`billing.astro:97`, `showState('content')`).
+    await expect(page.locator('#billing-content')).toBeVisible()
+  })
+})
+
+// ─── SMI-6154: orphaned astro:page-load dispatch during a URL/DOM desync ──
+//
+// Distinct from SMI-6137 (a stale continuation racing a completed
+// navigation) and from SMI-5158 (leaked listeners re-firing on a foreign
+// route). Root cause (see the SMI-6154 Linear issue for the full traced
+// investigation): on a browser back/forward navigation, `location.href`
+// reverts to the destination URL natively, before Astro's ClientRouter has
+// swapped the DOM to match. Astro's own `updateCallbackDone.finally(...)`
+// continuation (`runScripts()` + `onPageLoad()`,
+// `node_modules/astro/dist/transitions/router.js` as of `astro@7.2.0`) is
+// never awaited, cancelled, or checked against a newer navigation — so an
+// EARLIER, already-superseded transition's `astro:page-load` dispatch can
+// arrive late and land squarely in that desync window: `location.pathname`
+// already reads the destination route, but the live DOM still belongs to
+// whatever page the user was leaving. `isCurrentAccountPath()` passes on
+// the reverted URL; the SMI-6112/SMI-6137 navigation-epoch guard also can't
+// catch it, since the orphaned dispatch's own firing is itself the most
+// recent epoch-advancing event — a guard captured inside it is fresh by
+// construction. Fixed by `isAccountPageMounted()` (`account-page-path.ts`):
+// each of the five gated pages also checks a `data-account-page` DOM
+// marker is actually live before proceeding, closing the gap the pathname-
+// only entry check cannot.
+test.describe('SMI-6154 — orphaned astro:page-load dispatch during URL/DOM desync', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSupabaseStub(page, { session: buildSessionToken({ provider: 'email' }) })
+    await mockSupabase(page, {
+      rpcResponses: {
+        check_team_tier_access: {
+          ok: true,
+          reason: null,
+          team_id: 'team_smi6154_fixture',
+          tier: 'team',
+        },
+        // billing.astro's own astro:page-load handler makes these two RPC
+        // calls independently of /account's — mockSupabase()'s closed-
+        // default is a 404 for any unmocked RPC, which billing.astro's
+        // `if (effectiveError) throw effectiveError` / `if (subscriptionError)
+        // throw` turn into its error state (not a bug — just this test's
+        // own fixture needing to cover the destination page's requests
+        // too, since the test navigates there and asserts its content
+        // rendered).
+        get_effective_subscription_summary: [],
+        get_user_subscription: [],
+      },
+    })
+  })
+
+  test('an orphaned dispatch landing while the URL already reads /account but the DOM is still a sibling page is rejected', async ({
+    page,
+  }) => {
+    const hits = collectNullDerefs(page)
+
+    await page.goto('/account')
+    await expect(page).toHaveURL(/\/account\/?$/)
+    // Confirm /account's own handler actually ran successfully first —
+    // otherwise a false pass below could just mean nothing ever loaded.
+    await expect(page.locator('#team-name')).not.toHaveText('—')
+
+    // Real ClientRouter transition away — the DOM is now billing's, and
+    // index.astro's leaked `astro:page-load` listener persists (SMI-5158).
+    await clickAccountNav(page, '/account/billing')
+    await expect(page).toHaveURL(/\/account\/billing\/?$/)
+    // Confirm billing's own handler actually finished rendering before we
+    // manipulate anything below — checked here, right after the real
+    // navigation, rather than after the pushState maneuver next: under
+    // `astro dev` a route's first-hit SSR compile can add lag (see
+    // `injectPageLoadCounter()`'s doc comment above), and this is a real
+    // async load worth giving room to settle on its own timeline.
+    await expect(page.locator('#billing-content')).toBeVisible()
+
+    // Engineer the exact desync state deterministically, rather than
+    // racing the real timing that produces it in the wild (a page.goBack()
+    // colliding with a still-in-flight forward transition's orphaned
+    // page-load tail — flaky by nature, and already covered non-
+    // deterministically by the SMI-5158 test above). history.pushState()
+    // updates location.href WITHOUT firing `popstate` or triggering any
+    // Astro transition — exactly the "URL says /account, DOM is billing's"
+    // state a real orphaned dispatch lands in, isolated from the timing
+    // that produces it.
+    await page.evaluate(() => history.pushState({}, '', '/account'))
+    await expect(page).toHaveURL(/\/account\/?$/)
+
+    // Fire the orphaned dispatch itself. Pre-fix, index.astro's leaked
+    // handler passes isCurrentAccountPath() (pathname already reverted)
+    // and crashes on `document.getElementById('team-name')` being null —
+    // billing's DOM has no such element.
+    await refireAstroPageLoad(page)
+    await page.waitForTimeout(300)
+
+    expect(hits, hits.join('\n')).toEqual([])
+    // Still genuinely showing billing's own content, undisturbed by the
+    // orphaned dispatch — the URL itself stays at /account (this test's
+    // own history.pushState() call above set it there and nothing reverts
+    // it; that's expected, not a bug: pushState never triggered a real
+    // Astro transition, so the DOM was never touched by anything other
+    // than the orphaned dispatch this test fires next).
+    await expect(page).toHaveURL(/\/account\/?$/)
     await expect(page.locator('#billing-content')).toBeVisible()
   })
 })

--- a/packages/website/tests/e2e/account-page-load-guards.spec.ts
+++ b/packages/website/tests/e2e/account-page-load-guards.spec.ts
@@ -290,6 +290,130 @@ async function waitForPageLoadCount(page: Page, expected: number): Promise<void>
     .toBeGreaterThanOrEqual(expected)
 }
 
+/**
+ * SMI-6137: instrument the page to count real `astro:before-swap`
+ * firings — mirrors `injectPageLoadCounter()` above but for the earlier
+ * lifecycle event the SMI-6137 fix also advances the navigation epoch on.
+ * `astro:before-swap` fires once per real SPA transition, strictly before
+ * `astro:page-load` (never after, and never on the very first non-SPA
+ * `page.goto()` load — see `account-navigation-epoch.ts`'s module doc
+ * comment). Used to release a held response inside the specific
+ * pre-`astro:page-load` window SMI-6137 closes, rather than after it
+ * (which is what the existing SMI-6112 tests below do via
+ * `waitForPageLoadCount`, and why they don't exercise this gap).
+ */
+async function injectBeforeSwapCounter(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    ;(window as unknown as { __e2eBeforeSwapCount: number }).__e2eBeforeSwapCount = 0
+    document.addEventListener('astro:before-swap', () => {
+      ;(window as unknown as { __e2eBeforeSwapCount: number }).__e2eBeforeSwapCount += 1
+    })
+  })
+}
+
+async function waitForBeforeSwapCount(page: Page, expected: number): Promise<void> {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as unknown as { __e2eBeforeSwapCount: number }).__e2eBeforeSwapCount
+      )
+    )
+    .toBeGreaterThanOrEqual(expected)
+}
+
+/**
+ * SMI-6137: route Supabase calls so `check_team_tier_access` resolves
+ * immediately with an entitled response (getting `/account`'s handler
+ * past the tier gate quickly) while the `team_members` REST call —
+ * `loadTeamOverviewData()`'s own first network request
+ * (`account-overview-data.ts`) — is held open behind a release gate. This
+ * targets the DOM-write path specifically (`index.astro:440`,
+ * `document.getElementById('team-name')!.textContent = data.teamName`),
+ * unlike `mockDelayedTierCheck()` above, which targets the redirect path
+ * by holding the tier check itself. Every other REST/RPC call gets a
+ * fixed, immediate closed-default response — this test only cares about
+ * timing the one call that gates the DOM write.
+ */
+async function mockDelayedTeamData(
+  page: Page
+): Promise<{ release: () => void; callCount: () => number }> {
+  const gate = makeDeferred()
+  let callCount = 0
+
+  await page.route(`${SUPABASE_HOST}/**`, async (route: Route) => {
+    const url = new URL(route.request().url())
+    const rpcMatch = url.pathname.match(/\/rest\/v1\/rpc\/([^/]+)/)
+
+    if (rpcMatch && rpcMatch[1] === 'check_team_tier_access') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          reason: null,
+          team_id: 'team_smi6137_fixture',
+          tier: 'team',
+        }),
+      })
+      return
+    }
+
+    if (rpcMatch) {
+      // Closed-default `[]`, not `{}`: every RPC this route doesn't
+      // special-case (e.g. `get_effective_subscription_summary`,
+      // `get_user_subscription` on /account/billing's own handler) is
+      // consumed as an array (`rows?.[0]`) by its caller — `[]` makes that
+      // access resolve to `undefined` explicitly, same as a real "no rows"
+      // response, rather than relying on `{}[0]` coincidentally doing the
+      // same thing.
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+      return
+    }
+
+    if (url.pathname.startsWith('/auth/v1/')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+      return
+    }
+
+    const restMatch = url.pathname.match(/\/rest\/v1\/([^/?]+)/)
+    // Scoped to /account's own loadTeamOverviewData() query specifically
+    // (`select=team_id,role&team_id=eq.<id>`, no `user_id` filter) — NOT
+    // /account/billing's own, differently-shaped `team_members` query
+    // (`.eq('team_id', ...).eq('user_id', ...).maybeSingle()`), which must
+    // reach its own closed-default below undisturbed so the destination
+    // page's own handler isn't accidentally held by this gate too.
+    if (restMatch && restMatch[1] === 'team_members' && !url.searchParams.has('user_id')) {
+      callCount += 1
+      await gate.promise
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ team_id: 'team_smi6137_fixture', role: 'member' }]),
+      })
+      return
+    }
+
+    if (restMatch && restMatch[1] === 'teams') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'team_smi6137_fixture',
+          name: 'SMI-6137 Fixture Team',
+          slug: 'smi-6137-fixture',
+          max_members: 10,
+        }),
+      })
+      return
+    }
+
+    // Closed-default: empty array for any other REST table.
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  })
+
+  return { release: () => gate.resolve(), callCount: () => callCount }
+}
+
 test.describe('SMI-6112 — navigation-epoch guard against stale async continuations', () => {
   test.beforeEach(async ({ page }) => {
     await injectPageLoadCounter(page)
@@ -385,5 +509,86 @@ test.describe('SMI-6112 — navigation-epoch guard against stale async continuat
     gates[1].resolve()
     await page.waitForTimeout(300)
     await expect(page).toHaveURL(/\/account\/?$/)
+  })
+
+  test('SMI-6137: a stale team-data write never lands on the destination DOM after navigating away', async ({
+    page,
+  }) => {
+    await injectBeforeSwapCounter(page)
+    const hits = collectNullDerefs(page)
+    const { release, callCount } = await mockDelayedTeamData(page)
+
+    // In-page-triggered release, not expect.poll(): `expect.poll()`'s
+    // ~100ms default interval is real wall-clock latency between the
+    // moment `astro:before-swap` actually fires and the moment Node
+    // observes it and calls `release()` — on this route, `runScripts()`
+    // has no external-`src` script to await (verified via grep, see the
+    // plan doc), so the in-page `runScripts()` -> `astro:page-load` chain
+    // has no I/O of its own and could plausibly complete inside that
+    // ~100ms window regardless of which counter a poll waited on, making
+    // the test pass vacuously even against the pre-fix code. Exposing the
+    // release directly to an `astro:before-swap` listener cuts that gap
+    // to a single CDP round-trip instead.
+    let released = false
+    await page.exposeFunction('__smi6137ReleaseGate', () => {
+      released = true
+      release()
+    })
+    await page.addInitScript(() => {
+      document.addEventListener(
+        'astro:before-swap',
+        () => {
+          ;(window as unknown as { __smi6137ReleaseGate: () => void }).__smi6137ReleaseGate()
+        },
+        { once: true }
+      )
+    })
+
+    await page.goto('/account')
+    await waitForPageLoadCount(page, 1)
+    await expect.poll(callCount).toBe(1)
+
+    // Real ClientRouter transition away from /account while
+    // loadTeamOverviewData()'s team_members query is still held open. The
+    // in-page listener above releases it the instant astro:before-swap
+    // fires for this transition — the earlier point in the window
+    // SMI-6137's fix closes (contrast with the three tests above, which
+    // correctly target the redirect path by waiting for the later
+    // astro:page-load count instead).
+    await clickAccountNav(page, '/account/billing')
+    await expect(page).toHaveURL(/\/account\/billing\/?$/)
+    await expect
+      .poll(() => released, {
+        message: 'astro:before-swap never fired for this transition (release never triggered)',
+      })
+      .toBe(true)
+
+    // Independent sanity check that the release really was tied to a real
+    // astro:before-swap firing (not, say, a typo'd event name that
+    // happened to leave `released` stuck false in a way `expect.poll`
+    // above would already have caught, but this pins the specific event
+    // rather than only the exposeFunction side effect).
+    await waitForBeforeSwapCount(page, 1)
+
+    // Give the released response's network round-trip and the handler's
+    // remaining continuation a moment to actually run before asserting.
+    await page.waitForTimeout(300)
+
+    // Pre-fix, /account's handler would still reach
+    // `document.getElementById('team-name')!.textContent = data.teamName`
+    // (index.astro:440) here — even though the browser is already on
+    // /account/billing — throwing because #team-name no longer exists in
+    // the live document, caught and logged at index.astro:467-471
+    // (`console.error('Team dashboard load failed:', err)`, matched by
+    // `NULL_DEREF` above).
+    expect(hits, hits.join('\n')).toEqual([])
+    await expect(page).toHaveURL(/\/account\/billing\/?$/)
+    // Destination page's own content actually rendered (plan review, VP
+    // Design) — guards against a self-invalidation timing bug on
+    // /account/billing's own handler going uncaught by the assertions
+    // above. #billing-content starts `display: none` and only becomes
+    // visible once billing.astro's own astro:page-load handler completes
+    // (`billing.astro:97`, `showState('content')`).
+    await expect(page.locator('#billing-content')).toBeVisible()
   })
 })


### PR DESCRIPTION
## Business Summary

**What shipped:** team-tier users clicking through their account pages (Overview, Workspaces, Members, Registry, Analytics) could occasionally land on a page whose team data never rendered — a caught-and-logged error rather than a crash, but the same suppressed-write mechanism protects against actually-wrong data ever painting, which is the more serious version of the same risk. This PR closes two distinct, sequentially-discovered gaps behind that risk.

**Quality bar:** Both root causes independently confirmed via source inspection — SMI-6137 via a Codex/gpt-5.6-sol dispatch, SMI-6154 via a Fable (low effort) investigation, both grounded in real diagnostic evidence (live local repro + temporary instrumentation), not speculation. SMI-6137's plan reviewed by VP Product/Engineering/Design with all findings applied. Both fixes verified empirically with clean pre-fix-fails/post-fix-passes flips on real Playwright runs against both browser engines — not just asserted, actually run, repeatedly.

**Found along the way:** while empirically verifying SMI-6137's fix, discovered it measurably reduced but didn't fully eliminate the flakiness in the original regression test it was meant to close — traced that residual to a second, genuinely distinct bug (SMI-6154) rather than assuming the first fix was "close enough." Also found and fixed a real, independently-valuable gap the SMI-6154 investigation exposed: this test file's shared null-deref detection regex only matched V8/Chromium's phrasing for a null property *read*, never its phrasing for a *write* — meaning a whole class of Chromium-side crash could have silently passed as "no hits" in every test in this file.

**Net result:** Fully shipped. With both fixes applied, the original flaky regression test (`account-page-load-guards.spec.ts:150`, the one that surfaced both bugs) passes 15/15 in a local WebKit burn-in.

---

## Technical detail

### SMI-6137 — swap-to-page-load gap

`packages/website/src/lib/account-navigation-epoch.ts`'s navigation-epoch guard (SMI-6112) only advanced its counter on `astro:page-load`, which Astro's ClientRouter fires *after* it has already swapped the destination page's DOM and re-run its scripts. That left a real window where a stale continuation from any of the five gated account pages could pass `isStale()` and write into a DOM it no longer owned — browser-agnostic in the underlying Astro source (confirmed via inspection), not a WebKit-specific divergence; WebKit's CI timing just happened to land in the window reliably.

**Fix**: also advance the epoch counter on `astro:before-swap`, which fires synchronously *before* the DOM swap. `astro:page-load` stays wired too (the only lifecycle event firing on the very first, non-SPA page load).

### SMI-6154 — orphaned dispatch during a URL/DOM desync window

Distinct root cause, found while verifying SMI-6137's fix: on a browser back/forward navigation, `location.href` reverts to the destination URL *natively*, before Astro's ClientRouter has swapped the DOM to match. An earlier, already-superseded transition's own `astro:page-load` dispatch — never awaited, cancelled, or checked against a newer navigation by Astro itself — can arrive late and land squarely in that window: the URL already says `/account`, but the DOM still belongs to whatever page was being navigated away from. Neither the pathname check nor the SMI-6137 epoch guard can catch this — the corrupting event happened *before* capture, and capture happens inside the very dispatch that most recently advanced the epoch.

**Fix**: `isAccountPageMounted()` (`account-page-path.ts`) checks a `data-account-page` DOM marker is actually live, not just that the URL claims to match. Each of the five gated pages' entry guard now checks both pathname AND DOM identity.

### Regression tests

Both fixes ship with deterministic regression tests (not just relying on the original non-deterministic navigation-loop test), each verified with a real pre-fix-fails/post-fix-passes flip on both Playwright projects:
- SMI-6137: holds a data query open via an in-page `astro:before-swap`-triggered release (avoids `expect.poll()`'s latency floor, which risked landing outside the actual race window).
- SMI-6154: engineers the exact URL/DOM desync state directly via `history.pushState()` + a synthetic `astro:page-load` re-fire, rather than racing the real (non-deterministic) timing that produces it in the wild.

### Plan doc

`docs/internal/implementation/smi-6137-account-nav-epoch-before-swap-fix.md` — full root cause, VP review summary, and empirical verification results for both issues.

### Linear

SMI-6137, SMI-6154 (both closed by this PR).