### PR TITLE
fix(indexer): SMI-6157 route census-known-dead repos to unfetchable regardless of embedded ref

### DIFF
--- a/scripts/indexer/smi5879-simulate-full.helpers.ts
+++ b/scripts/indexer/smi5879-simulate-full.helpers.ts
@@ -259,24 +259,53 @@ export async function processRow(
     }
   }
 
+  // SMI-6015 rehearsal finding (unevaluable-routing bug — SMI-6157): the
+  // census's branch-resolution
+  // table is consulted for EVERY row's repo, regardless of whether `repo_url`
+  // embeds its own ref (`/tree/<ref>/`) — a `not-found`/`unparseable`
+  // resolution means the census already confirmed the REPO itself is gone or
+  // its branch-resolution response was structurally unusable, a fact that has
+  // nothing to do with which ref within that (now nonexistent/unusable) repo
+  // a given row's URL happens to name. This check previously ran ONLY inside
+  // the `!parsed.ref` branch below — an unreconsidered "JUDGMENT CALL" carve-out
+  // made at implementation time and never reconsidered against real base
+  // rates. An embedded-ref row whose repo the census already knew was dead
+  // fell straight through to a live fetch attempt, 404'd, and landed in the
+  // primary-fetch-404 `unevaluable` branch further down instead of here. A
+  // rehearsal run measured 7,538 of 12,867 C4 primary-404 rows were exactly
+  // this already-known-dead-repo case, wrongly blocking G-2 on a false
+  // positive.
+  //
+  // `transient` is deliberately NOT checked here (it still is, unchanged,
+  // inside the `!parsed.ref` branch below): an embedded-ref row never needs
+  // `default_branch` to be resolved at all — it already names its own ref —
+  // so a census-side transient failure resolving some OTHER attribute of the
+  // repo must not newly block a row it was never relevant to. Widening this
+  // check to `transient` would convert previously-successful embedded-ref
+  // rows into newly-blocked ones, the opposite of this fix's intent. A
+  // missing `branchMap` entry is likewise not an error here (unlike the
+  // `!parsed.ref` branch's I-5 assertion below) — an embedded-ref row doesn't
+  // depend on that entry to determine its fetch target, only (when present)
+  // to short-circuit an already-known-dead repo.
+  const info = branchMap.get(`${parsed.owner}/${parsed.repo}`)
+  if (info && (info.resolution === 'not-found' || info.resolution === 'unparseable')) {
+    return {
+      ...base,
+      outcome: 'unfetchable',
+      reason: `default_branch resolution=${info.resolution}`,
+    }
+  }
+
   let branch: string
   if (parsed.ref) {
     branch = parsed.ref
   } else {
-    const info = branchMap.get(`${parsed.owner}/${parsed.repo}`)
     if (!info) {
       throw new Error(
         `SMI-5879 simulator bug: no smi5879_repo_branch row for ${parsed.owner}/${parsed.repo} ` +
           `(row id=${row.id}) — I-5 branch coverage should have refused the census before this ` +
           `generation could be sealed. Never silently falls back to 'main'.`
       )
-    }
-    if (info.resolution === 'not-found' || info.resolution === 'unparseable') {
-      return {
-        ...base,
-        outcome: 'unfetchable',
-        reason: `default_branch resolution=${info.resolution}`,
-      }
     }
     if (info.resolution === 'transient') {
       return { ...base, outcome: 'unevaluable', reason: 'default_branch resolution=transient' }

--- a/scripts/tests/indexer/smi5879-simulate-full.classification.test.ts
+++ b/scripts/tests/indexer/smi5879-simulate-full.classification.test.ts
@@ -92,6 +92,70 @@ describe('processRow — tier-2 outcome classification', () => {
     expect(result.outcome).toBe('unevaluable')
   })
 
+  // -------------------------------------------------------------------------
+  // Census-known-dead-repo routing for embedded-ref `repo_url`s (regression
+  // coverage for the not-found-with-embedded-ref routing bug, SMI-6015
+  // rehearsal finding — see `processRow`'s own doc comment for the fix).
+  // `makeRow()`'s default `repo_url` is `.../${id}/tree/main` — an
+  // embedded-ref URL (`parsed.ref = 'main'`) — so these tests use the default
+  // row shape rather than the bare-repo shape the three tests above use.
+  // -------------------------------------------------------------------------
+
+  it('unfetchable: repo_url embeds a ref but census already confirmed the repo not-found (bypass fix)', async () => {
+    const row = makeRow()
+    const branchMap: BranchMap = new Map([
+      [`acme/${row.id}`, { resolution: 'not-found', default_branch: null }],
+    ])
+    // No registerPrimary() call: if the bypass bug regressed, this row would
+    // fall through to a live fetch attempt and the fetch mock would throw on
+    // an unregistered URL, failing this test before the outcome assertion
+    // even runs.
+    const result = await processRow(row, branchMap, baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unfetchable')
+    expect(result.reason).toMatch(/not-found/)
+  })
+
+  it('unfetchable: repo_url embeds a ref but census found the branch-resolution response unparseable (same terminal treatment as not-found)', async () => {
+    const row = makeRow()
+    const branchMap: BranchMap = new Map([
+      [`acme/${row.id}`, { resolution: 'unparseable', default_branch: null }],
+    ])
+    const result = await processRow(row, branchMap, baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unfetchable')
+    expect(result.reason).toMatch(/unparseable/)
+  })
+
+  it('unevaluable: repo_url embeds a ref, census resolved the repo fine, but SKILL.md itself still 404s (file-level absence is NOT reclassified by this fix)', async () => {
+    const row = makeRow()
+    const branchMap: BranchMap = new Map([
+      [`acme/${row.id}`, { resolution: 'resolved', default_branch: 'main' }],
+    ])
+    registerPrimary(row, [new Response('Not Found', { status: 404 })])
+    const result = await processRow(row, branchMap, baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unevaluable')
+    expect(result.reason).toMatch(/confirmed absent/)
+  })
+
+  it('unchanged_clean: repo_url embeds a ref and census reports transient — transient does not block an embedded-ref row (it never needed default_branch)', async () => {
+    const row = makeRow()
+    const branchMap: BranchMap = new Map([
+      [`acme/${row.id}`, { resolution: 'transient', default_branch: null }],
+    ])
+    registerPrimary(row, [contentsApiResponse('# SKILL')])
+    const result = await processRow(row, branchMap, baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unchanged_clean')
+  })
+
+  it('unfetchable: repo_url has NO embedded ref and census reports not-found — existing no-ref behavior is unchanged by this fix', async () => {
+    const row = makeRow({ repo_url: 'https://github.com/acme/bare-repo4' })
+    const branchMap: BranchMap = new Map([
+      ['acme/bare-repo4', { resolution: 'not-found', default_branch: null }],
+    ])
+    const result = await processRow(row, branchMap, baseDeps(cleanScanner, cleanScanner))
+    expect(result.outcome).toBe('unfetchable')
+    expect(result.reason).toMatch(/not-found/)
+  })
+
   it('unevaluable: primary fetch exhausts retries', async () => {
     const row = makeRow()
     registerPrimary(row, [


### PR DESCRIPTION
## Business Summary

**What shipped:** Fixed a bug in the SMI-6015 security-scan comparison tool that was quietly guaranteeing its production safety gate could never pass. When a skill's source repo was already known to be gone or unreachable, the tool was supposed to skip it cleanly — but for repos whose URL happened to reference a specific branch, that skip check never ran, so the tool tried to fetch anyway, got a 404, and logged it as "couldn't verify" instead of "known dead." The safety gate treats "couldn't verify" as an automatic block, no exceptions. A rehearsal run measured that this misclassification alone accounted for the large majority of blocking cases in one cohort, and the same pattern would produce enough of these across the full population to guarantee the gate fails regardless of how much of the population actually gets scanned.

**Quality bar:** Full governance review (0 findings) — independently re-verified the fix's rationale directly against the design document rather than trusting the commit's own claim, confirmed no other code path has the same bug needing a parallel fix, and confirmed the new regression test actually proves the fix (it fails loudly on a reversion rather than silently passing either way). Typecheck/lint/format/`audit:standards` all clean; 31 tests in the affected file, all passing.

**Found along the way:** Two related, similar-looking cases were deliberately left untouched, each with its own test proving the boundary was respected: a file that's genuinely missing from an otherwise-live repo (a different situation, not part of this bug), and repos that consistently return "forbidden" on every attempt (a real, separate policy question — block on those or not — intentionally deferred until this fix's real-world impact can be measured on a fresh run).

**Net result:** Fully shipped, no follow-up needed for this specific bug. The deferred "forbidden repos" policy question remains open as its own decision.

---

## Technical detail

`scripts/indexer/smi5879-simulate-full.helpers.ts` — `processRow`'s census branch-resolution check (`resolution === 'not-found' || resolution === 'unparseable'` → non-blocking `unfetchable`) previously ran only inside the branch handling `repo_url` values with no embedded ref. Hoisted to run unconditionally before the ref-parsing branch, so it applies to every row's repo lookup regardless of URL shape. Deliberately does not extend the `transient` check or the missing-`branchMap`-entry hard-throw to the embedded-ref path — an embedded-ref row never needs `default_branch` resolved to fetch, so widening either would newly block rows the original bug never affected.

New tests in `scripts/tests/indexer/smi5879-simulate-full.classification.test.ts`: the regression case (embedded-ref + census-confirmed-dead → now `unfetchable`), an `unparseable` parity case, a negative case proving the fix wasn't over-broadened (embedded-ref + resolved repo + file-level 404 → still `unevaluable`), a negative case proving `transient` wasn't touched, and a no-regression check on the existing no-ref path.

Governance review: `docs/internal/code_review/2026-08-24-smi6157-unevaluable-routing-fix-review.md` (0 findings). Commits: `6d0ec4d2c` (the fix), `192dec0e0` (docs/internal pointer bump for the review).

Refs SMI-6157, SMI-6015.