### PR TITLE
feat(scripts): add export-surface coherence check (Check 63, SMI-6146)

### DIFF
--- a/scripts/audit-export-surface-consumer-helpers.mjs
+++ b/scripts/audit-export-surface-consumer-helpers.mjs
@@ -158,6 +158,22 @@ export function extractWorkspaceImportsFromSource(filePath, sourceText, scopePre
           kind: 'named',
         })
       }
+      // A combined `import Default, { Named } from 'pkg'` still carries a
+      // default import alongside the named bindings handled above — without
+      // this, `clause.name` here is silently dropped from both `named` and
+      // `unchecked` (the standalone-default branch below requires
+      // `!clause.namedBindings`, which is false in the combined case),
+      // undercounting the informational unchecked-import tally.
+      if (clause.name) {
+        unchecked.push({
+          file: filePath,
+          line,
+          packageName: split.packageName,
+          subpath: split.subpath,
+          specifier,
+          kind: 'default',
+        })
+      }
     } else if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
       unchecked.push({
         file: filePath,

--- a/scripts/audit-export-surface-consumer-helpers.mjs
+++ b/scripts/audit-export-surface-consumer-helpers.mjs
@@ -1,0 +1,479 @@
+/**
+ * SMI-6146: consumer-side import extractor + comparison/violation logic for
+ * the export-surface coherence check (audit:standards Check 63).
+ *
+ * Parses a consumer package's `src/**\/*.ts` (non-test) source with
+ * `ts.createSourceFile` — syntactic AST only, no `Program`, no
+ * type-checker — matching the established repo idiom in
+ * scripts/tests/indexer/run-gate-ast-helpers.ts. This is the one place in
+ * the export-surface-coherence design that introduces AST-based parsing
+ * rather than reusing audit-standards-helpers.mjs's regex-based
+ * `parseTsExports` — deliberately, since the `import('pkg').Type` inline
+ * type-query form (live today in
+ * packages/mcp-server/src/tools/get-skill.ts:173,238) is exactly the
+ * construct AST walking handles far more reliably than regex.
+ *
+ * Pure: takes already-read source text in, produces structured records
+ * out. No fs I/O — mirrors the `srcByPath` convention used throughout
+ * audit-standards-helpers.mjs (e.g. `findFunctionDefinitions`,
+ * `findRelativeFunctionsV1Urls`).
+ *
+ * See docs/internal/implementation/smi-6146-export-surface-coherence-check.md
+ * for the full design and the SMI-6143 incident this check exists to catch.
+ */
+import * as ts from 'typescript'
+
+/**
+ * Split a workspace-scoped module specifier into its package name and
+ * export subpath, e.g.:
+ *   '@skillsmith/core'            -> { packageName: '@skillsmith/core', subpath: '.' }
+ *   '@skillsmith/core/telemetry'  -> { packageName: '@skillsmith/core', subpath: './telemetry' }
+ *
+ * Returns null for a specifier that doesn't start with any of
+ * `scopePrefixes` (e.g. ['@skillsmith/', '@smith-horn/']).
+ *
+ * @param {string} specifier
+ * @param {string[]} scopePrefixes
+ * @returns {{ packageName: string, subpath: string } | null}
+ */
+export function splitWorkspaceSpecifier(specifier, scopePrefixes) {
+  const scope = scopePrefixes.find((p) => specifier.startsWith(p))
+  if (!scope) return null
+  const rest = specifier.slice(scope.length) // e.g. 'core/telemetry' or 'core'
+  const slashIdx = rest.indexOf('/')
+  if (slashIdx === -1) {
+    return { packageName: scope + rest, subpath: '.' }
+  }
+  const pkgSuffix = rest.slice(0, slashIdx)
+  const subpathRest = rest.slice(slashIdx) // includes leading '/'
+  return { packageName: scope + pkgSuffix, subpath: `.${subpathRest}` }
+}
+
+/**
+ * For an `ImportTypeNode`'s `.qualifier` (an EntityName: Identifier or
+ * QualifiedName, e.g. `TrustTier` or `Foo.Bar`), return the BASE name — the
+ * symbol that must actually exist in the referenced module's export set.
+ * For a nested access like `import('pkg').Foo.Bar`, that's `Foo` (`Bar` is
+ * a member access on the already-resolved `Foo`, not itself an export of
+ * `pkg`).
+ */
+function baseQualifierName(qualifier) {
+  let q = qualifier
+  while (q && ts.isQualifiedName(q)) q = q.left
+  return q && ts.isIdentifier(q) ? q.text : undefined
+}
+
+/** True if `node` is a runtime dynamic `import(...)` call expression. */
+function isDynamicImportCall(node) {
+  return ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword
+}
+
+/**
+ * Walk UP through any wrapping ParenthesizedExpression / AsExpression /
+ * NonNullExpression nodes around `node`, returning the outermost node
+ * reachable that way. Used twice while classifying a dynamic import call:
+ * once to see past `(import(...))`-style parens to find an enclosing
+ * `await`, and once past `(await import(...)) as Foo`-style casts to find
+ * what actually consumes the awaited value (a destructuring
+ * VariableDeclaration, a PropertyAccessExpression, or neither).
+ */
+function skipOuterWrappers(node) {
+  let n = node
+  while (
+    n.parent &&
+    (ts.isParenthesizedExpression(n.parent) ||
+      ts.isAsExpression(n.parent) ||
+      ts.isNonNullExpression(n.parent))
+  ) {
+    n = n.parent
+  }
+  return n
+}
+
+/**
+ * Parse one consumer TS file's source text and extract every workspace-
+ * sibling symbol import — `ImportDeclaration` named imports (handling
+ * `X as Y` aliasing, per-specifier `type X`, and clause-level
+ * `import type`), `ImportTypeNode` inline type queries
+ * (`import('@skillsmith/core').TrustTier`), AND runtime dynamic
+ * `import('@skillsmith/*')`/`import('@smith-horn/*')` CALL expressions
+ * (`const { X, Y: Z } = await import('@skillsmith/core')` or
+ * `(await import('@skillsmith/core')).X` — live today in
+ * packages/enterprise/src/audit/scheduled-scan.ts) — plus every
+ * default/namespace import (static or dynamic) from a workspace-sibling
+ * specifier that cannot be symbol-checked this way, reported separately
+ * for the rollup tally rather than silently dropped. A dynamic import
+ * whose namespace object is bound to a plain identifier and used
+ * elsewhere (the scheduled-scan.ts shape: `const mod = await import(...);
+ * ...; mod.runInventoryAudit`) is exactly this unresolvable case — this
+ * function does not track identifier references across statements, so it
+ * is counted into `unchecked` (kind `'dynamic-unresolved'`), not silently
+ * skipped.
+ *
+ * @param {string} filePath - repo-relative path, used only for reporting.
+ * @param {string} sourceText
+ * @param {string[]} scopePrefixes - e.g. ['@skillsmith/', '@smith-horn/']
+ * @returns {{
+ *   named: Array<{ file: string, line: number, packageName: string, subpath: string, specifier: string, name: string, kind: 'named' | 'type-query' | 'dynamic-named' | 'dynamic-property-access' }>,
+ *   unchecked: Array<{ file: string, line: number, packageName: string, subpath: string, specifier: string, kind: 'default' | 'namespace' | 'dynamic-unresolved' | 'dynamic-default' }>
+ * }}
+ */
+export function extractWorkspaceImportsFromSource(filePath, sourceText, scopePrefixes) {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  )
+  const named = []
+  const unchecked = []
+
+  const lineOf = (pos) => sourceFile.getLineAndCharacterOfPosition(pos).line + 1
+
+  // ImportDeclarations are always top-level module statements — no need to
+  // descend for these.
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    const specifier = stmt.moduleSpecifier.text
+    const split = splitWorkspaceSpecifier(specifier, scopePrefixes)
+    if (!split) continue
+    const line = lineOf(stmt.getStart(sourceFile))
+    const clause = stmt.importClause
+    if (!clause) continue // side-effect-only import (`import '@skillsmith/x'`) — nothing to check
+
+    if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+      for (const el of clause.namedBindings.elements) {
+        // `X as Y` -> propertyName is the pre-`as` name ('X'); plain `X` (or
+        // `type X`) -> propertyName is undefined, name.text is 'X' either way.
+        const name = el.propertyName ? el.propertyName.text : el.name.text
+        named.push({
+          file: filePath,
+          line,
+          packageName: split.packageName,
+          subpath: split.subpath,
+          specifier,
+          name,
+          kind: 'named',
+        })
+      }
+    } else if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
+      unchecked.push({
+        file: filePath,
+        line,
+        packageName: split.packageName,
+        subpath: split.subpath,
+        specifier,
+        kind: 'namespace',
+      })
+    } else if (clause.name && !clause.namedBindings) {
+      unchecked.push({
+        file: filePath,
+        line,
+        packageName: split.packageName,
+        subpath: split.subpath,
+        specifier,
+        kind: 'default',
+      })
+    }
+  }
+
+  // ImportTypeNode (`import('pkg').Foo`) and dynamic `import('pkg')` CALL
+  // expressions can appear anywhere a type/expression is written, not just
+  // at the top level — walk the whole tree.
+  function visit(node) {
+    if (ts.isImportTypeNode(node)) {
+      const argument = node.argument
+      const specifier =
+        ts.isLiteralTypeNode(argument) && ts.isStringLiteral(argument.literal)
+          ? argument.literal.text
+          : undefined
+      if (specifier) {
+        const split = splitWorkspaceSpecifier(specifier, scopePrefixes)
+        if (split) {
+          const name = baseQualifierName(node.qualifier)
+          // A qualifier-less `import('pkg')` type query (used as a whole
+          // module-namespace type, e.g. `typeof import('pkg')`) names no
+          // specific symbol — nothing to check, nothing to roll up either
+          // (it isn't a default/namespace VALUE import).
+          if (name) {
+            named.push({
+              file: filePath,
+              line: lineOf(node.getStart(sourceFile)),
+              packageName: split.packageName,
+              subpath: split.subpath,
+              specifier,
+              name,
+              kind: 'type-query',
+            })
+          }
+        }
+      }
+    } else if (isDynamicImportCall(node)) {
+      const [argNode] = node.arguments
+      const specifier = argNode && ts.isStringLiteral(argNode) ? argNode.text : undefined
+      const split = specifier ? splitWorkspaceSpecifier(specifier, scopePrefixes) : null
+      if (split) {
+        const line = lineOf(node.getStart(sourceFile))
+        const pushNamed = (name, kind) =>
+          named.push({
+            file: filePath,
+            line,
+            packageName: split.packageName,
+            subpath: split.subpath,
+            specifier,
+            name,
+            kind,
+          })
+        const pushUnchecked = (kind) =>
+          unchecked.push({
+            file: filePath,
+            line,
+            packageName: split.packageName,
+            subpath: split.subpath,
+            specifier,
+            kind,
+          })
+
+        // See past any `(import(...))`-style wrapping parens to find an
+        // enclosing `await` — an un-awaited dynamic import (e.g.
+        // `import('pkg').then(...)`, or the bare Promise passed around) has
+        // no statically-resolvable destructuring/property-access shape.
+        const afterCallWrappers = skipOuterWrappers(node)
+        const awaitNode =
+          afterCallWrappers.parent && ts.isAwaitExpression(afterCallWrappers.parent)
+            ? afterCallWrappers.parent
+            : null
+
+        if (!awaitNode) {
+          pushUnchecked('dynamic-unresolved')
+        } else {
+          // See past `(await import(...)) as Foo`-style casts to find what
+          // actually consumes the awaited namespace object.
+          const afterAwaitWrappers = skipOuterWrappers(awaitNode)
+          const consumer = afterAwaitWrappers.parent
+
+          if (
+            consumer &&
+            ts.isVariableDeclaration(consumer) &&
+            consumer.initializer === afterAwaitWrappers
+          ) {
+            // `const { X, Y: Z } = await import('pkg')` (optionally cast) —
+            // every destructured property is a statically-known name.
+            // `const mod = await import('pkg')` (a plain identifier, not a
+            // destructuring pattern) binds the WHOLE namespace object —
+            // this function doesn't track identifier references across
+            // later statements (the scheduled-scan.ts shape:
+            // `mod.runInventoryAudit` used in a separate `return`), so
+            // that shape is genuinely unresolvable here and must be
+            // counted, not silently dropped.
+            if (ts.isObjectBindingPattern(consumer.name)) {
+              for (const el of consumer.name.elements) {
+                if (el.dotDotDotToken) {
+                  // `const { ...rest } = await import('pkg')` captures an
+                  // unknown breadth of the namespace.
+                  pushUnchecked('dynamic-unresolved')
+                  continue
+                }
+                const exportedName = el.propertyName
+                  ? ts.isIdentifier(el.propertyName)
+                    ? el.propertyName.text
+                    : undefined
+                  : ts.isIdentifier(el.name)
+                    ? el.name.text
+                    : undefined
+                if (!exportedName) {
+                  pushUnchecked('dynamic-unresolved')
+                } else if (exportedName === 'default') {
+                  // The namespace object's `default` property is the
+                  // module's default export, not a named export to look
+                  // up — same reasoning as an unchecked default import.
+                  pushUnchecked('dynamic-default')
+                } else {
+                  pushNamed(exportedName, 'dynamic-named')
+                }
+              }
+            } else {
+              pushUnchecked('dynamic-unresolved')
+            }
+          } else if (
+            consumer &&
+            ts.isPropertyAccessExpression(consumer) &&
+            consumer.expression === afterAwaitWrappers
+          ) {
+            // `(await import('pkg')).X` (optionally cast) — direct
+            // property access on the awaited namespace object. Only the
+            // FIRST accessed property is the symbol that must exist in the
+            // sibling's export set (mirrors ImportTypeNode's
+            // baseQualifierName reasoning for a chained `.X.Y`).
+            if (ts.isIdentifier(consumer.name)) {
+              const exportedName = consumer.name.text
+              if (exportedName === 'default') {
+                pushUnchecked('dynamic-default')
+              } else {
+                pushNamed(exportedName, 'dynamic-property-access')
+              }
+            } else {
+              pushUnchecked('dynamic-unresolved')
+            }
+          } else {
+            // Awaited but consumed some other way not statically resolved
+            // here (passed to a function, returned bare, spread, etc.).
+            pushUnchecked('dynamic-unresolved')
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+
+  return { named, unchecked }
+}
+
+/**
+ * Run extractWorkspaceImportsFromSource across every file in `srcByPath`
+ * (repo-relative path -> source text; caller is responsible for filtering
+ * to non-test `.ts` files under a package's `src/**`) and group the named
+ * results by (siblingPackageName, subpath) — the shape SMI-6146's design
+ * calls for grouping into before comparison, while retaining
+ * per-occurrence file/line for reporting.
+ *
+ * @param {Record<string, string>} srcByPath
+ * @param {string[]} scopePrefixes
+ * @returns {{
+ *   groups: Map<string, { packageName: string, subpath: string, specifier: string, occurrences: Array<{ name: string, file: string, line: number, kind: string }> }>,
+ *   unchecked: Array<{ file: string, line: number, packageName: string, subpath: string, specifier: string, kind: 'default' | 'namespace' }>
+ * }}
+ */
+export function groupConsumerWorkspaceImports(srcByPath, scopePrefixes) {
+  const groups = new Map()
+  const unchecked = []
+  for (const [file, text] of Object.entries(srcByPath)) {
+    const { named, unchecked: fileUnchecked } = extractWorkspaceImportsFromSource(
+      file,
+      text,
+      scopePrefixes
+    )
+    for (const rec of named) {
+      const key = `${rec.packageName}::${rec.subpath}`
+      if (!groups.has(key)) {
+        groups.set(key, {
+          packageName: rec.packageName,
+          subpath: rec.subpath,
+          specifier: rec.specifier,
+          occurrences: [],
+        })
+      }
+      groups.get(key).occurrences.push({
+        name: rec.name,
+        file: rec.file,
+        line: rec.line,
+        kind: rec.kind,
+      })
+    }
+    unchecked.push(...fileUnchecked)
+  }
+  return { groups, unchecked }
+}
+
+/**
+ * Compare grouped consumer imports against resolved export surfaces and
+ * produce structured violations. `resolveExportSet(packageName, subpath)`
+ * is expected to return the same result shape as
+ * audit-export-surface-resolver-helpers.mjs's `resolveExportSetForSubpath`:
+ * `{ status: 'ok', names: Set<string>, entrySourcePath: string }` |
+ * `{ status: 'no-exports-surface' }` | `{ status: 'subpath-not-declared' }` |
+ * `{ status: 'unmappable-dist-path', ... }`.
+ *
+ * @param {Map<string, { packageName: string, subpath: string, specifier: string, occurrences: Array<{ name: string, file: string, line: number, kind: string }> }>} groups
+ * @param {(packageName: string, subpath: string) => object} resolveExportSet
+ * @returns {{
+ *   missingExportViolations: Array<{ file: string, line: number, name: string, packageName: string, subpath: string, specifier: string, exportCount: number, entrySourcePath: string }>,
+ *   subpathViolations: Array<{ packageName: string, subpath: string, specifier: string, occurrences: Array<{ file: string, line: number, name: string }> }>,
+ *   unresolvableSurfaceWarnings: Array<{ packageName: string, subpath: string, specifier: string, status: string, occurrences: Array<{ file: string, line: number, name: string }> }>,
+ * }}
+ */
+export function evaluateExportSurfaceCoherence(groups, resolveExportSet) {
+  const missingExportViolations = []
+  const subpathViolations = []
+  const unresolvableSurfaceWarnings = []
+
+  for (const group of groups.values()) {
+    const result = resolveExportSet(group.packageName, group.subpath)
+
+    if (result.status === 'subpath-not-declared') {
+      subpathViolations.push({
+        packageName: group.packageName,
+        subpath: group.subpath,
+        specifier: group.specifier,
+        occurrences: group.occurrences.map(({ file, line, name }) => ({ file, line, name })),
+      })
+      continue
+    }
+
+    if (result.status === 'no-exports-surface' || result.status === 'unmappable-dist-path') {
+      unresolvableSurfaceWarnings.push({
+        packageName: group.packageName,
+        subpath: group.subpath,
+        specifier: group.specifier,
+        status: result.status,
+        occurrences: group.occurrences.map(({ file, line, name }) => ({ file, line, name })),
+      })
+      continue
+    }
+
+    // status === 'ok'
+    for (const occ of group.occurrences) {
+      if (!result.names.has(occ.name)) {
+        missingExportViolations.push({
+          file: occ.file,
+          line: occ.line,
+          name: occ.name,
+          packageName: group.packageName,
+          subpath: group.subpath,
+          specifier: group.specifier,
+          exportCount: result.names.size,
+          entrySourcePath: result.entrySourcePath,
+        })
+      }
+    }
+  }
+
+  return { missingExportViolations, subpathViolations, unresolvableSurfaceWarnings }
+}
+
+/**
+ * Pure decision logic for Check 63's shadow-burn-in + opt-out-marker gate,
+ * extracted out of audit-standards.mjs's inline Check 63 driver block so
+ * the gate/marker behavior is unit-testable without spawning the whole
+ * audit-standards.mjs script. Matches the inline pattern already used by
+ * Check 59/60 in audit-standards.mjs (`CHECK_N_SHADOW_END_DATE` /
+ * `inShadow` / `shadowSuffix` / `skipAcknowledged`) — factored out here
+ * specifically for Check 63's own driver rather than touching those
+ * existing inline blocks.
+ *
+ * @param {object} params
+ * @param {string} params.shadowEndDate - ISO date string, e.g. '2026-09-01'
+ * @param {Date} params.now
+ * @param {string} params.prBody
+ * @param {string} params.skipMarker - e.g. '[skip-export-surface-check]'
+ * @returns {{
+ *   inShadow: boolean,
+ *   report: 'warn' | 'fail',
+ *   shadowSuffix: string,
+ *   skipAcknowledged: boolean,
+ * }}
+ */
+export function evaluateExportSurfaceShadowGate({ shadowEndDate, now, prBody, skipMarker }) {
+  const inShadow = now < new Date(shadowEndDate)
+  const shadowSuffix = inShadow ? ` [shadow mode through ${shadowEndDate} — advisory only]` : ''
+  // Matches Check 60's precedent: the marker is only meaningful once the
+  // gate can actually fail — during shadow mode every finding is already
+  // warn-level regardless, so checking the marker then would add a
+  // confusing "acknowledged" suffix implying something was blocked when
+  // nothing was.
+  const skipAcknowledged = !inShadow && (prBody || '').includes(skipMarker)
+  return { inShadow, report: inShadow ? 'warn' : 'fail', shadowSuffix, skipAcknowledged }
+}

--- a/scripts/audit-export-surface-resolver-helpers.mjs
+++ b/scripts/audit-export-surface-resolver-helpers.mjs
@@ -158,8 +158,12 @@ function matchWildcardSubpath(pattern, subpath) {
  * Resolve a requested subpath against a package's wildcard export entries
  * (e.g. `"./*": "./dist/*.js"`), substituting the captured segment into
  * the target template's own '*'. When more than one wildcard pattern
- * matches, the pattern with the longest literal prefix wins (most
- * specific), matching Node's own precedence rule.
+ * matches, Node's own precedence rule (PATTERN_KEY_COMPARE) applies: the
+ * pattern with the longest literal PREFIX (before '*') wins; when two
+ * patterns tie on prefix length, the one with the longer literal SUFFIX
+ * (after '*') wins as the tiebreak -- e.g. './features/*' vs
+ * './features/*.json' both have prefix 'features/', but the latter is
+ * more specific and must win for a subpath like './features/x.json'.
  *
  * @param {Array<{ pattern: string, targetTemplate: string }>} wildcardEntries
  * @param {string} subpath
@@ -170,9 +174,15 @@ function resolveWildcardTarget(wildcardEntries, subpath) {
   for (const { pattern, targetTemplate } of wildcardEntries) {
     const captured = matchWildcardSubpath(pattern, subpath)
     if (captured === null) continue
-    const prefixLen = pattern.indexOf('*')
-    if (!best || prefixLen > best.prefixLen) {
-      best = { prefixLen, target: targetTemplate.replaceAll('*', captured) }
+    const starIdx = pattern.indexOf('*')
+    const prefixLen = starIdx
+    const suffixLen = pattern.length - starIdx - 1
+    const isMoreSpecific =
+      !best ||
+      prefixLen > best.prefixLen ||
+      (prefixLen === best.prefixLen && suffixLen > best.suffixLen)
+    if (isMoreSpecific) {
+      best = { prefixLen, suffixLen, target: targetTemplate.replaceAll('*', captured) }
     }
   }
   return best ? best.target : null
@@ -221,7 +231,22 @@ export function getPackageExportEntries(pkgJson) {
     }
   }
 
-  if (rawExports && typeof rawExports === 'object' && !Array.isArray(rawExports)) {
+  if (Array.isArray(rawExports)) {
+    // Node's array-exports form for the root '.' entry (fallback targets in
+    // preference order, e.g. `"exports": ["./dist/index.js"]`) -- a
+    // legitimate shape pickDistTarget() already knows how to walk; without
+    // this branch it fell through to the object-shape check below (which
+    // explicitly excludes arrays) and degraded to a main/types fallback or
+    // hasExportsSurface: false, silently skipping validation.
+    const target = pickDistTarget(rawExports)
+    return {
+      hasExportsSurface: true,
+      entries: target ? new Map([['.', target]]) : new Map(),
+      wildcardEntries: [],
+    }
+  }
+
+  if (rawExports && typeof rawExports === 'object') {
     const keys = Object.keys(rawExports)
     const dotKeys = keys.filter((k) => k.startsWith('.'))
 

--- a/scripts/audit-export-surface-resolver-helpers.mjs
+++ b/scripts/audit-export-surface-resolver-helpers.mjs
@@ -172,7 +172,7 @@ function resolveWildcardTarget(wildcardEntries, subpath) {
     if (captured === null) continue
     const prefixLen = pattern.indexOf('*')
     if (!best || prefixLen > best.prefixLen) {
-      best = { prefixLen, target: targetTemplate.replace('*', captured) }
+      best = { prefixLen, target: targetTemplate.replaceAll('*', captured) }
     }
   }
   return best ? best.target : null

--- a/scripts/audit-export-surface-resolver-helpers.mjs
+++ b/scripts/audit-export-surface-resolver-helpers.mjs
@@ -1,0 +1,348 @@
+/**
+ * SMI-6146: export-surface resolver — resolves a workspace package's full
+ * exported-symbol set across its ENTIRE package.json `exports` map (not
+ * just the root `.` entry), reusing the existing `parseTsExports`/
+ * `collectTsEntryExports` helpers (scripts/audit-standards-helpers.mjs,
+ * Check 29 / SMI-4193) rather than re-implementing TS export parsing.
+ *
+ * Background: SMI-6143 shipped `@skillsmith/mcp-server@0.7.10` depending on
+ * `@skillsmith/core` exports that core's *published* version didn't yet
+ * have — every fresh install broke. Two existing checks (verify-publish-
+ * deps.mjs Check 2, audit:standards Check 58) both reason only about
+ * version-range strings, never about what a package actually exports, so
+ * neither could have caught it. This module is the "what does a sibling
+ * actually export, from source, across every entry point" half of the fix
+ * that powers audit:standards Check 63. See
+ * docs/internal/implementation/smi-6146-export-surface-coherence-check.md
+ * for the full design.
+ *
+ * Pure decision/orchestration layer: no direct fs I/O. Callers inject
+ * `readFile(absPath)` and `resolveModule(fromAbsFile, relSpec)` — the exact
+ * same shape Check 29 already uses (scripts/audit-standards.mjs's own
+ * `readFileIfExists`/`resolveModule` in the Check 29 block) — so this
+ * module and its tests never touch the real filesystem directly.
+ */
+import { join } from 'node:path'
+import { collectTsEntryExports } from './audit-standards-helpers.mjs'
+
+/** Strip a leading './' and any trailing '/' from an outDir/path segment. */
+function normalizeDirSegment(seg) {
+  return seg.replace(/^\.\//, '').replace(/\/+$/, '')
+}
+
+/**
+ * Read `compilerOptions.outDir` from a parsed tsconfig.json, normalized
+ * (leading './' stripped, trailing '/' stripped). Returns null if
+ * absent/unparseable — callers must not assume a default of 'dist': per
+ * SMI-6146's design, a package whose tsconfig doesn't declare `outDir` is a
+ * build shape this resolver has never seen, and must fail loud (an
+ * `unmappable-dist-path` result), not silently guess.
+ *
+ * @param {{ compilerOptions?: { outDir?: string } }} tsconfigJson
+ * @returns {string | null}
+ */
+export function getPackageOutDir(tsconfigJson) {
+  const outDir = tsconfigJson?.compilerOptions?.outDir
+  if (typeof outDir !== 'string' || outDir.trim() === '') return null
+  return normalizeDirSegment(outDir)
+}
+
+/**
+ * Map a dist-relative path (as it appears in an `exports`/`main`/`types`
+ * entry, e.g. './dist/src/index.js' or './dist/tests/testkit.js') back to
+ * its TypeScript source file, GENERICALLY: strip the package's own
+ * `outDir` prefix, then swap the compiled extension for `.ts`.
+ *
+ * Deliberately NOT the narrower "dist/src/X.js -> src/X.ts" rule — that
+ * breaks on @skillsmith/core's own `./testkit` export entry, which
+ * resolves to `dist/tests/testkit.js` (real source
+ * `packages/core/tests/testkit.ts`) because packages/core/tsconfig.json's
+ * `outDir: dist` covers both `src/**` and `tests/**` under one outDir. The
+ * generic strip-prefix rule handles both shapes identically, and any
+ * future sibling directory nested directly under the same outDir.
+ *
+ * Returns null (a "fails loud" signal the caller must surface, not a
+ * silent guess) when:
+ *   - `distRelPath` doesn't start with `${outDir}/` after normalization, or
+ *   - the extension isn't one this function knows how to map
+ *     (`.js` / `.mjs` / `.cjs` / `.d.ts`).
+ *
+ * @param {string} distRelPath
+ * @param {string} outDir - already normalized via getPackageOutDir
+ * @returns {string | null}
+ */
+export function mapDistPathToSourcePath(distRelPath, outDir) {
+  if (typeof distRelPath !== 'string' || typeof outDir !== 'string' || outDir === '') return null
+  const normalized = normalizeDirSegment(distRelPath.replace(/^\.\//, ''))
+  const prefix = `${outDir}/`
+  if (!normalized.startsWith(prefix)) return null
+  const rest = normalized.slice(prefix.length)
+  if (rest.endsWith('.d.ts')) return `${rest.slice(0, -'.d.ts'.length)}.ts`
+  const jsExtMatch = rest.match(/\.(m?js|cjs)$/)
+  if (jsExtMatch) return `${rest.slice(0, -jsExtMatch[0].length)}.ts`
+  return null
+}
+
+/**
+ * Pick the dist-relative target from one `exports` map condition entry.
+ * Accepts a bare string (`"exports": { ".": "./dist/index.js" }`), a
+ * conditions object (preferring `import` > `default` > `require` > `types`
+ * — an `import`/`default`/`require` `.js` target maps to source more
+ * reliably via mapDistPathToSourcePath than a `.d.ts`-only `types` target,
+ * but `types` is accepted as a last resort), or an array of fallback
+ * targets (Node's array-exports form, e.g. `["./dist/index.js"]`).
+ * Recurses through nested conditions/arrays — a shape like
+ * `{ node: { import: "./x.js" } }` (no top-level `import`/`default`/etc)
+ * — until a string is found or every branch is exhausted, so callers only
+ * ever receive a string or null and never reach string operations on a
+ * bare object (which would crash downstream in mapDistPathToSourcePath).
+ *
+ * @param {unknown} conditionEntry
+ * @param {number} [depth] - recursion guard against pathological nesting
+ * @returns {string | null}
+ */
+function pickDistTarget(conditionEntry, depth = 0) {
+  if (depth > 10) return null
+  if (typeof conditionEntry === 'string') return conditionEntry
+  if (Array.isArray(conditionEntry)) {
+    for (const item of conditionEntry) {
+      const result = pickDistTarget(item, depth + 1)
+      if (result) return result
+    }
+    return null
+  }
+  if (!conditionEntry || typeof conditionEntry !== 'object') return null
+  const PREFERRED_CONDITION_KEYS = ['import', 'default', 'require', 'types', 'node']
+  for (const key of PREFERRED_CONDITION_KEYS) {
+    if (key in conditionEntry) {
+      const result = pickDistTarget(conditionEntry[key], depth + 1)
+      if (result) return result
+    }
+  }
+  // No preferred key matched (or all resolved to null) — fall back to any
+  // remaining condition (e.g. a custom condition name) in declaration
+  // order, rather than giving up on an entry that genuinely has a usable
+  // string target under a condition name this function doesn't special-case.
+  for (const key of Object.keys(conditionEntry)) {
+    if (PREFERRED_CONDITION_KEYS.includes(key)) continue
+    const result = pickDistTarget(conditionEntry[key], depth + 1)
+    if (result) return result
+  }
+  return null
+}
+
+/**
+ * Match a requested subpath (e.g. './foo') against a wildcard export key
+ * (e.g. './*') per Node's pattern-matching exports algorithm: the '*' in
+ * the pattern captures the corresponding segment of the requested
+ * subpath. Returns the captured text, or null if the pattern doesn't match
+ * (wrong prefix/suffix) or matches with an empty capture (Node requires a
+ * non-empty match — an empty capture is treated as no match).
+ *
+ * @param {string} pattern - e.g. './*' or './features/*.js'
+ * @param {string} subpath - e.g. './foo'
+ * @returns {string | null}
+ */
+function matchWildcardSubpath(pattern, subpath) {
+  const starIdx = pattern.indexOf('*')
+  if (starIdx === -1) return null
+  const prefix = pattern.slice(0, starIdx)
+  const suffix = pattern.slice(starIdx + 1)
+  if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) return null
+  const captured = subpath.slice(prefix.length, subpath.length - suffix.length)
+  if (captured === '' || captured.includes('*')) return null
+  return captured
+}
+
+/**
+ * Resolve a requested subpath against a package's wildcard export entries
+ * (e.g. `"./*": "./dist/*.js"`), substituting the captured segment into
+ * the target template's own '*'. When more than one wildcard pattern
+ * matches, the pattern with the longest literal prefix wins (most
+ * specific), matching Node's own precedence rule.
+ *
+ * @param {Array<{ pattern: string, targetTemplate: string }>} wildcardEntries
+ * @param {string} subpath
+ * @returns {string | null}
+ */
+function resolveWildcardTarget(wildcardEntries, subpath) {
+  let best = null
+  for (const { pattern, targetTemplate } of wildcardEntries) {
+    const captured = matchWildcardSubpath(pattern, subpath)
+    if (captured === null) continue
+    const prefixLen = pattern.indexOf('*')
+    if (!best || prefixLen > best.prefixLen) {
+      best = { prefixLen, target: targetTemplate.replace('*', captured) }
+    }
+  }
+  return best ? best.target : null
+}
+
+/**
+ * Resolve a package.json's export entry points to dist-relative targets.
+ *
+ * Handles every legitimate Node `exports` field shape:
+ *   - A bare string (`"exports": "./dist/index.js"`) — no subpath keys at
+ *     all, an implicit single `.` entry.
+ *   - A subpath-keyed object (`{ ".": ..., "./foo": ... }`, every key
+ *     starting with `.`, or `{}`) — the common case.
+ *   - A root conditional object (`{ "import": "...", "types": "..." }`,
+ *     NO key starting with `.`) — describes the `.` entry only; the keys
+ *     are condition names, not subpaths, and must not be misread as such.
+ *   - A wildcard subpath key (`"./*": "./dist/*.js"`) — kept separate from
+ *     `entries` (exact-match subpaths) as a pattern to be resolved against
+ *     the actual requested subpath by resolveWildcardTarget, rather than
+ *     stored as a literal (and never-matching) `'./*'` key.
+ *   - Mixed dot/non-dot keys — invalid per Node's own exports validation
+ *     (it throws at resolution time); rather than guess, only the
+ *     dot-prefixed subpath keys are honored so a malformed package.json
+ *     degrades to a partial, non-crashing surface instead of silently
+ *     misreading a condition name as a subpath.
+ *   - `main`/`types` fallback, or none of the three (`hasExportsSurface:
+ *     false` — the caller must warn(), not crash, e.g. `packages/cli`
+ *     today: bin-only, no library surface at all).
+ *
+ * @param {{ exports?: unknown, main?: string, types?: string }} pkgJson
+ * @returns {{
+ *   hasExportsSurface: boolean,
+ *   entries: Map<string, string>,
+ *   wildcardEntries: Array<{ pattern: string, targetTemplate: string }>,
+ * }}
+ *   entries maps subpath ('.', './telemetry', ...) -> dist-relative target.
+ */
+export function getPackageExportEntries(pkgJson) {
+  const rawExports = pkgJson && pkgJson.exports
+
+  if (typeof rawExports === 'string') {
+    return {
+      hasExportsSurface: true,
+      entries: new Map([['.', rawExports]]),
+      wildcardEntries: [],
+    }
+  }
+
+  if (rawExports && typeof rawExports === 'object' && !Array.isArray(rawExports)) {
+    const keys = Object.keys(rawExports)
+    const dotKeys = keys.filter((k) => k.startsWith('.'))
+
+    if (dotKeys.length === 0 && keys.length > 0) {
+      // Root conditional-exports object: every key is a condition name
+      // (`import`/`types`/...), not a subpath — describes the '.' entry.
+      const target = pickDistTarget(rawExports)
+      return {
+        hasExportsSurface: true,
+        entries: target ? new Map([['.', target]]) : new Map(),
+        wildcardEntries: [],
+      }
+    }
+
+    // Subpath-keyed object (every key starts with '.', or {}), OR a mixed
+    // dot/non-dot object degraded to its dot-prefixed keys only (see
+    // docstring above).
+    const entries = new Map()
+    const wildcardEntries = []
+    const subpathKeys = dotKeys.length === keys.length ? keys : dotKeys
+    for (const subpath of subpathKeys) {
+      const target = pickDistTarget(rawExports[subpath])
+      if (!target) continue
+      if (subpath.includes('*')) {
+        wildcardEntries.push({ pattern: subpath, targetTemplate: target })
+      } else {
+        entries.set(subpath, target)
+      }
+    }
+    return { hasExportsSurface: true, entries, wildcardEntries }
+  }
+
+  if (typeof pkgJson?.main === 'string') {
+    return {
+      hasExportsSurface: true,
+      entries: new Map([['.', pkgJson.main]]),
+      wildcardEntries: [],
+    }
+  }
+  if (typeof pkgJson?.types === 'string') {
+    return {
+      hasExportsSurface: true,
+      entries: new Map([['.', pkgJson.types]]),
+      wildcardEntries: [],
+    }
+  }
+  return { hasExportsSurface: false, entries: new Map(), wildcardEntries: [] }
+}
+
+/**
+ * Resolve the dist-relative target for one requested subpath, checking
+ * exact-match `entries` first, then falling back to wildcard pattern
+ * matching (resolveWildcardTarget) — so a legitimate import through a
+ * wildcard subpath (e.g. `pkg/foo` against `"./*": "./dist/*.js"`) is
+ * actually resolved rather than reported as undeclared.
+ *
+ * @param {{ entries: Map<string, string>, wildcardEntries: Array<{ pattern: string, targetTemplate: string }> }} exportInfo
+ * @param {string} subpath
+ * @returns {string | null}
+ */
+function resolveDistTargetForSubpath(exportInfo, subpath) {
+  if (exportInfo.entries.has(subpath)) return exportInfo.entries.get(subpath)
+  return resolveWildcardTarget(exportInfo.wildcardEntries, subpath)
+}
+
+/**
+ * Resolve the full exported-symbol set for one (package, subpath) pair,
+ * reusing `collectTsEntryExports` (same `export *`-recursion, same
+ * visited-file cycle guard Check 29 already relies on).
+ *
+ * `cache` (a plain Map the caller owns and reuses across the whole
+ * audit-standards run) is keyed by the resolved absolute entry-source
+ * path — so a run touching multiple consumers of the same sibling only
+ * parses that sibling's source once. Lazy by construction: this function
+ * only ever resolves the specific (package, subpath) pair a caller asks
+ * for — a run whose consumers only ever touch 3 of core's 23 export
+ * entries never parses the other 20.
+ *
+ * @param {object} params
+ * @param {string} params.pkgDirAbs - absolute path to the sibling package's directory
+ * @param {object} params.pkgJson - the sibling's parsed package.json
+ * @param {object} params.tsconfigJson - the sibling's parsed tsconfig.json (or null if missing)
+ * @param {string} params.subpath - e.g. '.' or './telemetry'
+ * @param {(absPath: string) => string | null} params.readFile
+ * @param {(fromAbsFile: string, relSpec: string) => string | null} params.resolveModule
+ * @param {Map<string, Set<string>>} [params.cache]
+ * @returns {
+ *   { status: 'ok', names: Set<string>, entrySourcePath: string } |
+ *   { status: 'no-exports-surface' } |
+ *   { status: 'subpath-not-declared' } |
+ *   { status: 'unmappable-dist-path', distRelPath: string, outDir: string | null }
+ * }
+ */
+export function resolveExportSetForSubpath({
+  pkgDirAbs,
+  pkgJson,
+  tsconfigJson,
+  subpath,
+  readFile,
+  resolveModule,
+  cache,
+}) {
+  const exportInfo = getPackageExportEntries(pkgJson)
+  if (!exportInfo.hasExportsSurface) return { status: 'no-exports-surface' }
+  const distRelPath = resolveDistTargetForSubpath(exportInfo, subpath)
+  if (distRelPath === null || distRelPath === undefined) {
+    return { status: 'subpath-not-declared' }
+  }
+
+  const outDir = getPackageOutDir(tsconfigJson)
+  const sourceRelPath = outDir ? mapDistPathToSourcePath(distRelPath, outDir) : null
+  if (!sourceRelPath) {
+    return { status: 'unmappable-dist-path', distRelPath, outDir }
+  }
+
+  const entrySourcePath = join(pkgDirAbs, sourceRelPath)
+  if (cache && cache.has(entrySourcePath)) {
+    return { status: 'ok', names: cache.get(entrySourcePath), entrySourcePath }
+  }
+
+  const names = collectTsEntryExports(entrySourcePath, readFile, resolveModule)
+  if (cache) cache.set(entrySourcePath, names)
+  return { status: 'ok', names, entrySourcePath }
+}

--- a/scripts/audit-standards.mjs
+++ b/scripts/audit-standards.mjs
@@ -52,6 +52,12 @@ import { findUnpinnedActionUses } from './audit-workflow-sha-pin-helpers.mjs'
 import { countToolDefinitions } from './audit-mcp-tool-count-helpers.mjs'
 import { extractWhatsNewVersion } from './audit-readme-whats-new-helpers.mjs'
 import { evaluateInternalVersionCoherence } from './audit-internal-version-coherence-helpers.mjs'
+import { resolveExportSetForSubpath } from './audit-export-surface-resolver-helpers.mjs'
+import {
+  groupConsumerWorkspaceImports,
+  evaluateExportSurfaceCoherence,
+  evaluateExportSurfaceShadowGate,
+} from './audit-export-surface-consumer-helpers.mjs'
 import { findGitCryptUnsetRemediations } from './audit-git-crypt-remediation-helpers.mjs'
 import {
   findFloatingSupabaseCliInstalls,
@@ -5339,6 +5345,265 @@ console.log(`\n${BOLD}Check 62: MCP server service-role usage lockdown (SMI-6109
       )
     }
   }
+}
+
+// Check 63: Export-surface coherence for @skillsmith/*/@smith-horn/*
+// workspace-sibling imports (SMI-6146)
+//
+// Background: SMI-6143 shipped @skillsmith/mcp-server@0.7.10 depending on
+// @skillsmith/core exports (getApiBaseUrl, resolveSessionTier,
+// SessionTierAuthError, SessionTierTransientError) that core's *published*
+// version didn't yet have — every fresh install broke immediately. Both
+// verify-publish-deps.mjs Check 2 and this file's own Check 58 were
+// supposed to catch exactly this and didn't, for the same reason: at that
+// point core's *local* package.json version was still unchanged, so both
+// checks compared the same version string to itself and passed. Neither
+// check has ever opened a source file, a dist/, or a declaration file —
+// they reason only about version-range STRINGS.
+//
+// Version-range coherence (Checks 2/58) proves the DECLARED RANGES are
+// internally consistent with each other. Export-surface coherence (this
+// check) proves the IMPORTED SYMBOLS actually exist in the sibling's
+// source, independent of what either package's version field says — the
+// two are complementary, not redundant: a consumer can have a perfectly
+// satisfied version range (Check 58 green) while still importing a name
+// the sibling's source has never exported (this check, red), which is
+// exactly the SMI-6143 shape. See
+// docs/internal/implementation/smi-6146-export-surface-coherence-check.md
+// for the full design, including why scripts/smoke-test-published.ts was
+// the only existing mechanism that actually caught SMI-6143 in practice
+// (it's the only thing that installs and imports the real published npm
+// tarball) — and only after `npm publish` had already run. This check
+// closes that gap earlier: it reads source, not dist/ or a published
+// tarball, so it runs pre-merge in the existing `quality-checks` job with
+// no new CI job and no new install/build step.
+//
+// Reuses the existing parseTsExports/collectTsEntryExports helpers
+// (scripts/audit-standards-helpers.mjs, Check 29/SMI-4193) via the new
+// scripts/audit-export-surface-resolver-helpers.mjs (sibling export-surface
+// resolution across a package's full `exports` map, generic dist->src
+// mapping) and scripts/audit-export-surface-consumer-helpers.mjs (consumer
+// import extraction — ImportDeclaration + ImportTypeNode — plus the
+// comparison/violation logic).
+//
+// Ships warn-level through a shadow burn-in (CHECK_63_SHADOW_END_DATE
+// below, matching Check 59/60's convention) — this is genuinely new
+// detection logic (multi-entry-point resolution, alias/type-query
+// handling, dist->src path convention) with real false-positive surface,
+// unlike Check 58's immediate fail(). Shortened to 1 week (not the usual
+// 2) given the incident's severity — leaving the exact SMI-6143 failure
+// class undetected for longer than necessary isn't the right default.
+console.log(
+  `\n${BOLD}Check 63: Export-surface coherence for workspace-sibling imports (SMI-6146)${RESET}`
+)
+{
+  const CHECK_63_SHADOW_END_DATE = '2026-09-01'
+  // [skip-export-surface-check] — a DEDICATED marker, deliberately not a
+  // reuse of [skip-version-coherence-check]: a legitimate reason to skip
+  // version-range coherence (e.g. an intentional pre-release range) says
+  // nothing about whether the actual import target exists, so conflating
+  // the two escape hatches would let a real missing-export bug hide behind
+  // an unrelated skip marker. Registered in
+  // docs/internal/process/guards-and-opt-outs.md.
+  const SKIP_MARKER = '[skip-export-surface-check]'
+  const PR_BODY = process.env.PR_BODY || ''
+
+  // Gate/marker decision logic lives in evaluateExportSurfaceShadowGate
+  // (audit-export-surface-consumer-helpers.mjs) — extracted out of this
+  // inline block so it's unit-testable in isolation, matching the pattern
+  // already inlined for Check 59/60 above but factored out here.
+  const {
+    report: reportLevel,
+    shadowSuffix,
+    skipAcknowledged,
+  } = evaluateExportSurfaceShadowGate({
+    shadowEndDate: CHECK_63_SHADOW_END_DATE,
+    now: new Date(),
+    prBody: PR_BODY,
+    skipMarker: SKIP_MARKER,
+  })
+  const report = reportLevel === 'warn' ? warn : fail
+  if (skipAcknowledged) {
+    console.log(
+      `::notice::${SKIP_MARKER} opt-out found in PR body — Check 63 will report findings but not fail.`
+    )
+  }
+
+  const WORKSPACE_SCOPE_PREFIXES = ['@skillsmith/', '@smith-horn/']
+
+  const pkgDirs = existsSync('packages')
+    ? readdirSync('packages').filter((d) => existsSync(join('packages', d, 'package.json')))
+    : []
+
+  // packageName -> { dir, pkgJson, tsconfigJson } for every workspace
+  // package with a scoped @skillsmith/*/@smith-horn/* name — the set of
+  // resolvable "siblings" a consumer's import can be checked against.
+  const packageInfoByName = new Map()
+  for (const d of pkgDirs) {
+    let pkgJson
+    try {
+      pkgJson = JSON.parse(readFileSync(join('packages', d, 'package.json'), 'utf8'))
+    } catch (e) {
+      warn(`Check 63: could not parse packages/${d}/package.json: ${e.message}`)
+      continue
+    }
+    if (typeof pkgJson.name !== 'string') continue
+    let tsconfigJson = null
+    const tsconfigPath = join('packages', d, 'tsconfig.json')
+    if (existsSync(tsconfigPath)) {
+      try {
+        tsconfigJson = JSON.parse(readFileSync(tsconfigPath, 'utf8'))
+      } catch (e) {
+        warn(`Check 63: could not parse packages/${d}/tsconfig.json: ${e.message}`)
+      }
+    }
+    packageInfoByName.set(pkgJson.name, { dir: d, pkgJson, tsconfigJson })
+  }
+
+  const readFileIfExists = (absPath) => (existsSync(absPath) ? readFileSync(absPath, 'utf8') : null)
+  // Same .js-in-source convention as Check 29's resolveModule
+  // (scripts/audit-standards.mjs's own Check 29 block) — generic across
+  // every package since it only ever resolves relative to the CURRENT
+  // file's own directory.
+  const resolveModule = (fromFile, spec) => {
+    if (!spec.startsWith('.')) return null
+    const base = resolvePath(dirname(fromFile), spec.replace(/\.(m?js)$/, ''))
+    for (const candidate of [`${base}.ts`, `${base}.tsx`, `${base}/index.ts`]) {
+      if (existsSync(candidate)) return candidate
+    }
+    return null
+  }
+
+  // Per (package, export-entry) cache, shared across every consumer
+  // processed in this run — a run touching multiple consumers of the same
+  // sibling+subpath only parses that sibling's source once.
+  const exportSetCache = new Map()
+  const resolveExportSet = (packageName, subpath) => {
+    const info = packageInfoByName.get(packageName)
+    if (!info) return { status: 'no-exports-surface' }
+    return resolveExportSetForSubpath({
+      pkgDirAbs: resolvePath('packages', info.dir),
+      pkgJson: info.pkgJson,
+      tsconfigJson: info.tsconfigJson,
+      subpath,
+      readFile: readFileIfExists,
+      resolveModule,
+      cache: exportSetCache,
+    })
+  }
+
+  let filesChecked = 0
+  let importsChecked = 0
+  let missingExportCount = 0
+  let subpathViolationCount = 0
+  let unresolvableSurfaceCount = 0
+  let uncheckedTotal = 0
+  const uncheckedFiles = new Set()
+
+  for (const consumerDir of pkgDirs) {
+    const srcDir = join('packages', consumerDir, 'src')
+    if (!existsSync(srcDir)) continue
+    const tsFiles = getFilesRecursive(srcDir, ['.ts']).filter(
+      (f) => !f.endsWith('.test.ts') && !f.endsWith('.spec.ts')
+    )
+    if (tsFiles.length === 0) continue
+
+    const srcByPath = {}
+    for (const f of tsFiles) {
+      srcByPath[f] = readFileSync(f, 'utf8')
+      filesChecked++
+    }
+
+    const { groups, unchecked } = groupConsumerWorkspaceImports(srcByPath, WORKSPACE_SCOPE_PREFIXES)
+
+    // Only compare against KNOWN workspace siblings — an
+    // @skillsmith/*/@smith-horn/* specifier that doesn't resolve to any
+    // packages/* package.json `name` is out of this check's scope (not
+    // currently possible in this monorepo; the filter is defensive).
+    const resolvableGroups = new Map()
+    for (const [key, group] of groups) {
+      if (packageInfoByName.has(group.packageName)) {
+        resolvableGroups.set(key, group)
+        importsChecked += group.occurrences.length
+      }
+    }
+
+    uncheckedTotal += unchecked.length
+    for (const u of unchecked) uncheckedFiles.add(u.file)
+
+    const { missingExportViolations, subpathViolations, unresolvableSurfaceWarnings } =
+      evaluateExportSurfaceCoherence(resolvableGroups, resolveExportSet)
+
+    for (const v of missingExportViolations) {
+      missingExportCount++
+      const relEntry = relative(process.cwd(), v.entrySourcePath)
+      const msg =
+        `Check 63: ${v.file}:${v.line} imports '${v.name}' from '${v.specifier}', which does not export it${shadowSuffix}\n` +
+        `  (checked ${relEntry} and its export * chain — ${v.exportCount} name(s) found, '${v.name}' not among them)`
+      const fix =
+        `Three likely causes, in order: (1) typo in the import name — fix it; ` +
+        `(2) '${v.packageName}' genuinely needs to export '${v.name}' yet (the SMI-6143 shape) — add the export to its source in this PR, ` +
+        `or land a preceding PR that does, before this one merges; ` +
+        `(3) known false-positive (e.g. an unchecked default/namespace import misclassified, or a Known Limitation) — ` +
+        `add '[skip-export-surface-check]' plus a reason paragraph to the PR body — see docs/internal/process/guards-and-opt-outs.md.`
+      if (skipAcknowledged) {
+        warn(msg + ' — [skip-export-surface-check] acknowledged', fix)
+      } else {
+        report(msg, fix)
+      }
+    }
+
+    for (const v of subpathViolations) {
+      for (const occ of v.occurrences) {
+        subpathViolationCount++
+        const msg = `Check 63: ${occ.file}:${occ.line} imports from '${v.specifier}', but ${v.packageName}'s package.json declares no '${v.subpath}' export entry${shadowSuffix}`
+        const fix =
+          `Either fix the import path to a subpath '${v.packageName}' actually declares in its 'exports' map, ` +
+          `or add the '${v.subpath}' entry to ${v.packageName}'s package.json 'exports' map if it's meant to be public. ` +
+          `Known false-positive: add '[skip-export-surface-check]' plus a reason paragraph to the PR body.`
+        if (skipAcknowledged) {
+          warn(msg + ' — [skip-export-surface-check] acknowledged', fix)
+        } else {
+          report(msg, fix)
+        }
+      }
+    }
+
+    for (const w of unresolvableSurfaceWarnings) {
+      for (const occ of w.occurrences) {
+        unresolvableSurfaceCount++
+        warn(
+          `Check 63: ${occ.file}:${occ.line} imports from '${w.specifier}', but ${w.packageName}'s export surface could not be resolved (${w.status})`,
+          w.status === 'no-exports-surface'
+            ? `'${w.packageName}' has no 'exports'/'main'/'types' field in its package.json — this check cannot verify imports from it (see Known Limitations).`
+            : `'${w.packageName}'s tsconfig.json outDir doesn't match its declared dist path for '${w.subpath}' — check that package's build config.`
+        )
+      }
+    }
+  }
+
+  if (missingExportCount === 0 && subpathViolationCount === 0) {
+    pass(
+      `Check 63: all ${importsChecked} workspace-sibling import(s) across ${filesChecked} checked file(s) resolve in their sibling's export surface` +
+        (unresolvableSurfaceCount > 0
+          ? ` (${unresolvableSurfaceCount} unresolvable-surface warning(s) above)`
+          : '')
+    )
+  }
+
+  // Default/namespace/unresolved-dynamic-import rollup tally — plain
+  // console.log, matching Check 54's M7 precedent: NOT a second
+  // pass()/warn()/fail() call, which would double-increment the global
+  // counters and let an earlier per-violation pass/fail be misread as the
+  // overall verdict. Includes dynamic `import(...)` occurrences whose
+  // imported names can't be determined statically (e.g. the whole
+  // namespace object bound to a plain identifier and used elsewhere, the
+  // packages/enterprise/src/audit/scheduled-scan.ts shape) alongside
+  // static default/namespace imports — same reporting treatment, not
+  // silently dropped.
+  console.log(
+    `Check 63: ${uncheckedTotal} default/namespace/dynamic-import unchecked import(s) across ${uncheckedFiles.size} file(s) not symbol-checked — see Known Limitations`
+  )
 }
 
 // Summary

--- a/scripts/tests/audit-export-surface-coherence.test.ts
+++ b/scripts/tests/audit-export-surface-coherence.test.ts
@@ -235,6 +235,15 @@ describe('getPackageExportEntries: Node exports-field shape normalization (Findi
     expect(entries.get('.')).toBe('./dist/index.js')
   })
 
+  it('a top-level array-form exports field ("exports": [...]) resolves the "." entry, not degraded to main/types fallback', () => {
+    const { hasExportsSurface, entries } = getPackageExportEntries({
+      exports: ['./dist/index.js', './dist/index.cjs'],
+      main: './dist/wrong-fallback.js',
+    })
+    expect(hasExportsSurface).toBe(true)
+    expect(entries.get('.')).toBe('./dist/index.js')
+  })
+
   it('a wildcard subpath key ("./*") is kept separate from exact-match entries, not stored as a literal "./*" key', () => {
     const { entries, wildcardEntries } = getPackageExportEntries({
       exports: { '.': './dist/index.js', './*': './dist/src/*.js' },
@@ -401,6 +410,39 @@ describe('resolveExportSetForSubpath: export * recursion, subpath resolution, an
     expect([...result.names]).toEqual(['X'])
   })
 
+  it('when two wildcard patterns tie on prefix length, the one with the longer literal suffix wins (Node PATTERN_KEY_COMPARE)', () => {
+    const pkgJson = {
+      name: '@skillsmith/wildcard-suffix-tiebreak',
+      exports: {
+        // Both patterns share the identical './features/' prefix; only the
+        // second has a literal suffix after '*', making it more specific.
+        // A prefix-length-only comparator picks whichever was declared
+        // first regardless of suffix -- Node's real rule requires the
+        // longer-suffix pattern to win the tie.
+        './features/*': './dist/features/*.js',
+        './features/*.json': './dist/features/*-data.js',
+      },
+    }
+    const files: Record<string, string> = {
+      [join(PKG_DIR_ABS, 'features/x-data.ts')]: `export { Y }`,
+    }
+    const result = resolveExportSetForSubpath({
+      pkgDirAbs: PKG_DIR_ABS,
+      pkgJson,
+      tsconfigJson: outDirTsconfig,
+      subpath: './features/x.json',
+      readFile: (p: string) => files[p] ?? null,
+      resolveModule: () => null,
+    })
+    // A prefix-only tiebreak would resolve via the less-specific pattern
+    // (declared first) to '.../features/x.json.ts', which this test doesn't
+    // provide -- so the bug surfaces as a status other than 'ok' or an
+    // empty export set, not just a wrong-but-plausible path.
+    expect(result.status).toBe('ok')
+    expect(result.entrySourcePath).toContain('features/x-data.ts')
+    expect([...result.names]).toEqual(['Y'])
+  })
+
   it('an unmatched wildcard subpath is still "subpath-not-declared", not silently accepted', () => {
     const pkgJson = {
       name: '@skillsmith/wildcard-sibling',
@@ -559,6 +601,17 @@ describe('extractWorkspaceImportsFromSource: static ImportDeclaration + ImportTy
     const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
     expect(named).toEqual([])
     expect(unchecked.map((u: { kind: string }) => u.kind).sort()).toEqual(['default', 'namespace'])
+  })
+
+  it('a combined default+named import (import Default, { Named } from pkg) checks Named AND counts Default unchecked, not silently dropped', () => {
+    const src = "import Foo, { Bar } from '@skillsmith/sibling'\n"
+    const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    // A bug that only fires the standalone-default branch when there are NO
+    // named bindings would drop 'Foo' from both buckets entirely -- it
+    // would neither appear in 'named' (correct, defaults aren't checked)
+    // nor in 'unchecked' (wrong -- it silently vanishes from the tally).
+    expect(named.map((n: { name: string }) => n.name)).toEqual(['Bar'])
+    expect(unchecked.map((u: { kind: string }) => u.kind)).toEqual(['default'])
   })
 
   it('a side-effect-only import (no clause) is neither checked nor counted', () => {

--- a/scripts/tests/audit-export-surface-coherence.test.ts
+++ b/scripts/tests/audit-export-surface-coherence.test.ts
@@ -377,6 +377,30 @@ describe('resolveExportSetForSubpath: export * recursion, subpath resolution, an
     expect([...result.names]).toEqual(['X'])
   })
 
+  it('substitutes every "*" occurrence in a wildcard target template, not just the first (CodeQL js/incomplete-string-escaping)', () => {
+    const pkgJson = {
+      name: '@skillsmith/wildcard-multi-star',
+      exports: { './*': './dist/*/index-*.js' },
+    }
+    const files: Record<string, string> = {
+      [join(PKG_DIR_ABS, 'foo/index-foo.ts')]: `export { X }`,
+    }
+    const result = resolveExportSetForSubpath({
+      pkgDirAbs: PKG_DIR_ABS,
+      pkgJson,
+      tsconfigJson: outDirTsconfig,
+      subpath: './foo',
+      readFile: (p: string) => files[p] ?? null,
+      resolveModule: () => null,
+    })
+    expect(result.status).toBe('ok')
+    // A single-'*'-replace bug would resolve to '.../foo/index-*.js' (second '*'
+    // left literal), missing this file entirely and falling through to a
+    // different status or an empty export set instead of reading it.
+    expect(result.entrySourcePath).not.toContain('*')
+    expect([...result.names]).toEqual(['X'])
+  })
+
   it('an unmatched wildcard subpath is still "subpath-not-declared", not silently accepted', () => {
     const pkgJson = {
       name: '@skillsmith/wildcard-sibling',

--- a/scripts/tests/audit-export-surface-coherence.test.ts
+++ b/scripts/tests/audit-export-surface-coherence.test.ts
@@ -1,0 +1,726 @@
+/**
+ * Regression test for SMI-6146 (audit:standards Check 63, export-surface
+ * coherence).
+ *
+ * Reproduces the exact SMI-6143 shape: a consumer imports a symbol ('bar')
+ * from a workspace sibling that the sibling's SOURCE does NOT actually
+ * export — the sibling's `src/index.ts` exports `foo` only — while every
+ * version-range STRING involved stays internally consistent: the
+ * consumer's own package.json version is bumped (as it legitimately would
+ * be in a real release PR), and the sibling's package.json version is left
+ * UNCHANGED (per AC3's literal wording: "consumer's package.json version
+ * bumped, sibling's package.json version NOT yet bumped"). The fixture's
+ * whole point is that the sibling's source deliberately does NOT export
+ * 'bar' — that missing export, invisible to any version-string comparison,
+ * is exactly what Check 63 must catch by actually reading source.
+ *
+ * The fixture proves two things:
+ *   1. `evaluateInternalVersionCoherence` (Check 58,
+ *      scripts/audit-internal-version-coherence-helpers.mjs) reports `ok`
+ *      on this exact fixture — the version-arithmetic gap SMI-6146 exists
+ *      to close is real, not hypothetical. Check 58 never opens a source
+ *      file, so it structurally cannot see that the consumer imports a
+ *      name ('bar') the sibling doesn't export.
+ *   2. The new Check 63 logic (resolveExportSetForSubpath +
+ *      groupConsumerWorkspaceImports + evaluateExportSurfaceCoherence)
+ *      reports a violation naming 'bar' on the identical fixture — proving
+ *      the new check catches exactly what the old one structurally can't.
+ *
+ * Matches the pure-function-testing style of
+ * scripts/tests/audit-standards-internal-version-coherence.test.ts: no fs
+ * I/O, everything injected (in-memory "filesystem" map + readFile/
+ * resolveModule callbacks), so this test never touches real files.
+ */
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+// @ts-expect-error - .mjs helper has no typings
+import { evaluateInternalVersionCoherence } from '../audit-internal-version-coherence-helpers.mjs'
+// @ts-expect-error - .mjs helper has no typings
+import {
+  resolveExportSetForSubpath,
+  getPackageExportEntries,
+  getPackageOutDir,
+  mapDistPathToSourcePath,
+} from '../audit-export-surface-resolver-helpers.mjs'
+// @ts-expect-error - .mjs helper has no typings
+import {
+  groupConsumerWorkspaceImports,
+  evaluateExportSurfaceCoherence,
+  extractWorkspaceImportsFromSource,
+  evaluateExportSurfaceShadowGate,
+} from '../audit-export-surface-consumer-helpers.mjs'
+
+const SCOPE_PREFIXES = ['@skillsmith/', '@smith-horn/']
+
+describe('SMI-6146 Check 63 regression: export-surface coherence catches what Check 58 cannot', () => {
+  // --- Fixture ---------------------------------------------------------
+  // sibling: exports `foo` only. package.json version UNCHANGED.
+  const SIBLING_PKG_DIR_ABS = '/fake/repo/packages/sibling'
+  const siblingPkgJson = {
+    name: '@skillsmith/sibling',
+    version: '1.0.0',
+    exports: {
+      '.': {
+        types: './dist/src/index.d.ts',
+        import: './dist/src/index.js',
+        default: './dist/src/index.js',
+      },
+    },
+  }
+  const siblingTsconfigJson = { compilerOptions: { outDir: 'dist', rootDir: '.' } }
+  const siblingEntrySourcePath = join(SIBLING_PKG_DIR_ABS, 'src/index.ts')
+
+  // consumer: imports { foo, bar } from sibling. package.json version BUMPED.
+  const consumerPkgJson = {
+    name: '@skillsmith/consumer',
+    version: '2.0.0', // bumped from a hypothetical 1.0.0, per AC3's literal wording
+    dependencies: { '@skillsmith/sibling': '^1.0.0' },
+  }
+  const CONSUMER_SOURCE_PATH = 'packages/consumer/src/x.ts'
+  const consumerSourceText = "import { foo, bar } from '@skillsmith/sibling'\n"
+
+  // In-memory "filesystem" — only the sibling's entry file exists.
+  const fakeFs: Record<string, string> = {
+    [siblingEntrySourcePath]: 'export const foo = 1\n',
+  }
+  const readFile = (absPath: string): string | null => fakeFs[absPath] ?? null
+  // No `export * from` chains in this fixture — never actually invoked.
+  const resolveModule = (): string | null => null
+
+  it('Check 58 (evaluateInternalVersionCoherence) reports ok — the version-range gap is real, not hypothetical', () => {
+    const packagesByDir = {
+      sibling: siblingPkgJson,
+      consumer: consumerPkgJson,
+    }
+
+    const results = evaluateInternalVersionCoherence(packagesByDir)
+
+    expect(results).toEqual([
+      {
+        dir: 'consumer',
+        section: 'dependencies',
+        depName: '@skillsmith/sibling',
+        range: '^1.0.0',
+        actualVersion: '1.0.0',
+        status: 'ok',
+      },
+    ])
+  })
+
+  it('Check 63 (export-surface coherence) reports a violation naming "bar" on the identical fixture', () => {
+    const { groups } = groupConsumerWorkspaceImports(
+      { [CONSUMER_SOURCE_PATH]: consumerSourceText },
+      ['@skillsmith/', '@smith-horn/']
+    )
+
+    const cache = new Map<string, Set<string>>()
+    const resolveExportSet = (packageName: string, subpath: string) => {
+      expect(packageName).toBe('@skillsmith/sibling')
+      return resolveExportSetForSubpath({
+        pkgDirAbs: SIBLING_PKG_DIR_ABS,
+        pkgJson: siblingPkgJson,
+        tsconfigJson: siblingTsconfigJson,
+        subpath,
+        readFile,
+        resolveModule,
+        cache,
+      })
+    }
+
+    const { missingExportViolations, subpathViolations, unresolvableSurfaceWarnings } =
+      evaluateExportSurfaceCoherence(groups, resolveExportSet)
+
+    expect(subpathViolations).toEqual([])
+    expect(unresolvableSurfaceWarnings).toEqual([])
+    expect(missingExportViolations).toEqual([
+      {
+        file: CONSUMER_SOURCE_PATH,
+        line: 1,
+        name: 'bar',
+        packageName: '@skillsmith/sibling',
+        subpath: '.',
+        specifier: '@skillsmith/sibling',
+        exportCount: 1,
+        entrySourcePath: siblingEntrySourcePath,
+      },
+    ])
+    // 'foo' — the name the sibling DOES export — must not be flagged.
+    expect(missingExportViolations.some((v: { name: string }) => v.name === 'foo')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getPackageOutDir + mapDistPathToSourcePath — generic dist->src mapping
+// ---------------------------------------------------------------------------
+
+describe('getPackageOutDir + mapDistPathToSourcePath: generic dist->src mapping (Finding 1)', () => {
+  it('reads and normalizes compilerOptions.outDir, stripping leading "./" and trailing "/"', () => {
+    expect(getPackageOutDir({ compilerOptions: { outDir: './dist/' } })).toBe('dist')
+    expect(getPackageOutDir({ compilerOptions: { outDir: 'dist' } })).toBe('dist')
+  })
+
+  it('returns null when outDir is absent/unparseable — callers must not assume a "dist" default', () => {
+    expect(getPackageOutDir({})).toBeNull()
+    expect(getPackageOutDir(null)).toBeNull()
+    expect(getPackageOutDir({ compilerOptions: {} })).toBeNull()
+    expect(getPackageOutDir({ compilerOptions: { outDir: '' } })).toBeNull()
+  })
+
+  it.each([
+    // standard src/ shape
+    ['./dist/src/index.js', 'dist', 'src/index.ts'],
+    ['./dist/src/index.d.ts', 'dist', 'src/index.ts'],
+    ['./dist/src/foo/bar.mjs', 'dist', 'src/foo/bar.ts'],
+    ['./dist/src/foo/bar.cjs', 'dist', 'src/foo/bar.ts'],
+    // core's actual ./testkit exception: the dist path sits under a
+    // DIFFERENT top-level dir than src/ (tests/, not src/) — the generic
+    // strip-outDir-prefix rule must handle this identically to the src/
+    // case, not the narrower "dist/src/X.js -> src/X.ts" rule the original
+    // draft used (which crashed/misresolved on exactly this entry).
+    ['./dist/tests/testkit.js', 'dist', 'tests/testkit.ts'],
+    ['./dist/tests/testkit.d.ts', 'dist', 'tests/testkit.ts'],
+  ])('%s (outDir=%s) -> %s', (distRelPath, outDir, expected) => {
+    expect(mapDistPathToSourcePath(distRelPath, outDir)).toBe(expected)
+  })
+
+  it('returns null (fails loud) when the dist path does not start with the outDir prefix', () => {
+    expect(mapDistPathToSourcePath('./build/src/index.js', 'dist')).toBeNull()
+  })
+
+  it('returns null (fails loud) for an unrecognized extension', () => {
+    expect(mapDistPathToSourcePath('./dist/src/index.json', 'dist')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getPackageExportEntries — Node `exports` field shape normalization
+// ---------------------------------------------------------------------------
+
+describe('getPackageExportEntries: Node exports-field shape normalization (Finding 1)', () => {
+  it('bare string form ("exports": "./dist/index.js") -> single "." entry, no subpath keys at all', () => {
+    const { hasExportsSurface, entries, wildcardEntries } = getPackageExportEntries({
+      exports: './dist/index.js',
+    })
+    expect(hasExportsSurface).toBe(true)
+    expect(entries.get('.')).toBe('./dist/index.js')
+    expect(wildcardEntries).toEqual([])
+  })
+
+  it('root conditional object ("exports": { import, types, default }) describes "." only — NOT literal "import"/"types" subpaths', () => {
+    const { entries } = getPackageExportEntries({
+      exports: {
+        import: './dist/index.js',
+        types: './dist/index.d.ts',
+        default: './dist/index.js',
+      },
+    })
+    expect(entries.get('.')).toBe('./dist/index.js')
+    expect(entries.has('import')).toBe(false)
+    expect(entries.has('types')).toBe(false)
+  })
+
+  it('nested/nonstandard conditions recurse to a string target instead of reaching string ops on an object', () => {
+    const { entries } = getPackageExportEntries({
+      exports: {
+        '.': { node: { import: './dist/index.js' }, default: './dist/index.js' },
+      },
+    })
+    expect(entries.get('.')).toBe('./dist/index.js')
+  })
+
+  it('an array-of-fallback-targets condition value recurses to the first string found', () => {
+    const { entries } = getPackageExportEntries({
+      exports: { '.': ['./dist/index.js', './dist/index.cjs'] },
+    })
+    expect(entries.get('.')).toBe('./dist/index.js')
+  })
+
+  it('a wildcard subpath key ("./*") is kept separate from exact-match entries, not stored as a literal "./*" key', () => {
+    const { entries, wildcardEntries } = getPackageExportEntries({
+      exports: { '.': './dist/index.js', './*': './dist/src/*.js' },
+    })
+    expect(entries.has('./*')).toBe(false)
+    expect(wildcardEntries).toEqual([{ pattern: './*', targetTemplate: './dist/src/*.js' }])
+  })
+
+  it('a sibling with none of exports/main/types resolves to hasExportsSurface: false, not a crash', () => {
+    expect(getPackageExportEntries({}).hasExportsSurface).toBe(false)
+    expect(getPackageExportEntries({ name: '@skillsmith/cli' }).hasExportsSurface).toBe(false)
+  })
+
+  it('falls back to "main" then "types" when exports is absent', () => {
+    expect(getPackageExportEntries({ main: './dist/index.js' }).entries.get('.')).toBe(
+      './dist/index.js'
+    )
+    expect(getPackageExportEntries({ types: './dist/index.d.ts' }).entries.get('.')).toBe(
+      './dist/index.d.ts'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveExportSetForSubpath — export * recursion, subpath resolution,
+// wildcard resolution, and every non-'ok' status
+// ---------------------------------------------------------------------------
+
+describe('resolveExportSetForSubpath: export * recursion, subpath resolution, and failure-mode statuses', () => {
+  const PKG_DIR_ABS = '/fake/repo/packages/multi-entry-sibling'
+  const outDirTsconfig = { compilerOptions: { outDir: 'dist', rootDir: '.' } }
+
+  it('recurses through export * chains, unioning all names (delegates to collectTsEntryExports)', () => {
+    const pkgJson = {
+      name: '@skillsmith/multi-entry-sibling',
+      exports: { '.': { types: './dist/src/index.d.ts', import: './dist/src/index.js' } },
+    }
+    const files: Record<string, string> = {
+      [join(PKG_DIR_ABS, 'src/index.ts')]: `export * from './barrel.js'\nexport { Direct }`,
+      [join(PKG_DIR_ABS, 'src/barrel.ts')]: `export { Nested }`,
+    }
+    const readFile = (p: string) => files[p] ?? null
+    const resolveModule = (from: string, spec: string) =>
+      from === join(PKG_DIR_ABS, 'src/index.ts') && spec === './barrel.js'
+        ? join(PKG_DIR_ABS, 'src/barrel.ts')
+        : null
+
+    const result = resolveExportSetForSubpath({
+      pkgDirAbs: PKG_DIR_ABS,
+      pkgJson,
+      tsconfigJson: outDirTsconfig,
+      subpath: '.',
+      readFile,
+      resolveModule,
+    })
+
+    expect(result.status).toBe('ok')
+    expect([...result.names].sort()).toEqual(['Direct', 'Nested'])
+  })
+
+  it('guards against a CIRCULAR export * chain — proves the cycle guard actually prevents infinite recursion through THIS resolver, not just in the underlying helper tested in isolation', () => {
+    const pkgJson = { name: '@skillsmith/circular-sibling', exports: { '.': './dist/src/a.js' } }
+    const files: Record<string, string> = {
+      [join(PKG_DIR_ABS, 'src/a.ts')]: `export * from './b.js'\nexport { FromA }`,
+      [join(PKG_DIR_ABS, 'src/b.ts')]: `export * from './a.js'\nexport { FromB }`,
+    }
+    const readFile = (p: string) => files[p] ?? null
+    const resolveModule = (_from: string, spec: string) => {
+      if (spec === './a.js') return join(PKG_DIR_ABS, 'src/a.ts')
+      if (spec === './b.js') return join(PKG_DIR_ABS, 'src/b.ts')
+      return null
+    }
+
+    const run = () =>
+      resolveExportSetForSubpath({
+        pkgDirAbs: PKG_DIR_ABS,
+        pkgJson,
+        tsconfigJson: outDirTsconfig,
+        subpath: '.',
+        readFile,
+        resolveModule,
+      })
+
+    expect(run).not.toThrow()
+    const result = run()
+    expect(result.status).toBe('ok')
+    expect([...result.names].sort()).toEqual(['FromA', 'FromB'])
+  })
+
+  it('resolves a DECLARED subpath successfully, and reports an UNDECLARED subpath as a distinct violation status', () => {
+    const pkgJson = {
+      name: '@skillsmith/multi-entry-sibling',
+      exports: {
+        '.': { types: './dist/src/index.d.ts', import: './dist/src/index.js' },
+        './telemetry': { types: './dist/src/telemetry.d.ts', import: './dist/src/telemetry.js' },
+      },
+    }
+    const files: Record<string, string> = {
+      [join(PKG_DIR_ABS, 'src/telemetry.ts')]: `export { trackEvent }`,
+    }
+    const readFile = (p: string) => files[p] ?? null
+    const resolveModule = () => null
+
+    const declared = resolveExportSetForSubpath({
+      pkgDirAbs: PKG_DIR_ABS,
+      pkgJson,
+      tsconfigJson: outDirTsconfig,
+      subpath: './telemetry',
+      readFile,
+      resolveModule,
+    })
+    expect(declared.status).toBe('ok')
+    expect([...declared.names]).toEqual(['trackEvent'])
+
+    const undeclared = resolveExportSetForSubpath({
+      pkgDirAbs: PKG_DIR_ABS,
+      pkgJson,
+      tsconfigJson: outDirTsconfig,
+      subpath: './nope',
+      readFile,
+      resolveModule,
+    })
+    expect(undeclared.status).toBe('subpath-not-declared')
+  })
+
+  it('resolves a wildcard subpath ("./*": "./dist/src/*.js") against the actual requested subpath, not as a literal never-matching key', () => {
+    const pkgJson = { name: '@skillsmith/wildcard-sibling', exports: { './*': './dist/src/*.js' } }
+    const files: Record<string, string> = {
+      [join(PKG_DIR_ABS, 'src/foo.ts')]: `export { X }`,
+    }
+    const result = resolveExportSetForSubpath({
+      pkgDirAbs: PKG_DIR_ABS,
+      pkgJson,
+      tsconfigJson: outDirTsconfig,
+      subpath: './foo',
+      readFile: (p: string) => files[p] ?? null,
+      resolveModule: () => null,
+    })
+    expect(result.status).toBe('ok')
+    expect([...result.names]).toEqual(['X'])
+  })
+
+  it('an unmatched wildcard subpath is still "subpath-not-declared", not silently accepted', () => {
+    const pkgJson = {
+      name: '@skillsmith/wildcard-sibling',
+      exports: { './features/*': './dist/src/features/*.js' },
+    }
+    const result = resolveExportSetForSubpath({
+      pkgDirAbs: PKG_DIR_ABS,
+      pkgJson,
+      tsconfigJson: outDirTsconfig,
+      subpath: './other/thing',
+      readFile: () => null,
+      resolveModule: () => null,
+    })
+    expect(result.status).toBe('subpath-not-declared')
+  })
+
+  it('reports "no-exports-surface" (not a crash) for a sibling with none of exports/main/types — the packages/cli shape', () => {
+    const result = resolveExportSetForSubpath({
+      pkgDirAbs: PKG_DIR_ABS,
+      pkgJson: { name: '@skillsmith/cli-like' },
+      tsconfigJson: outDirTsconfig,
+      subpath: '.',
+      readFile: () => null,
+      resolveModule: () => null,
+    })
+    expect(result.status).toBe('no-exports-surface')
+  })
+
+  it('reports "unmappable-dist-path" (not a crash) when the entry target does not match the sibling\'s own outDir', () => {
+    const result = resolveExportSetForSubpath({
+      pkgDirAbs: PKG_DIR_ABS,
+      pkgJson: { name: '@skillsmith/weird-build', exports: { '.': './build/index.js' } },
+      tsconfigJson: outDirTsconfig, // outDir 'dist', but the entry targets 'build/'
+      subpath: '.',
+      readFile: () => null,
+      resolveModule: () => null,
+    })
+    expect(result.status).toBe('unmappable-dist-path')
+  })
+
+  it('returns an empty (not thrown) export set when the resolved entry FILE itself is missing', () => {
+    const result = resolveExportSetForSubpath({
+      pkgDirAbs: PKG_DIR_ABS,
+      pkgJson: { name: '@skillsmith/missing-entry', exports: { '.': './dist/src/index.js' } },
+      tsconfigJson: outDirTsconfig,
+      subpath: '.',
+      readFile: () => null, // entry file does not exist
+      resolveModule: () => null,
+    })
+    expect(result.status).toBe('ok')
+    expect(result.names.size).toBe(0)
+  })
+
+  it('end-to-end: an import from an undeclared subpath produces a subpathViolations entry via evaluateExportSurfaceCoherence', () => {
+    const pkgJson = {
+      name: '@skillsmith/multi-entry-sibling',
+      exports: { '.': './dist/src/index.js' },
+    }
+    const { groups } = groupConsumerWorkspaceImports(
+      {
+        'packages/consumer/src/x.ts':
+          "import { Foo } from '@skillsmith/multi-entry-sibling/nope'\n",
+      },
+      SCOPE_PREFIXES
+    )
+    const resolveExportSet = () =>
+      resolveExportSetForSubpath({
+        pkgDirAbs: PKG_DIR_ABS,
+        pkgJson,
+        tsconfigJson: outDirTsconfig,
+        subpath: './nope',
+        readFile: () => null,
+        resolveModule: () => null,
+      })
+    const { subpathViolations, missingExportViolations } = evaluateExportSurfaceCoherence(
+      groups,
+      resolveExportSet
+    )
+    expect(missingExportViolations).toEqual([])
+    expect(subpathViolations).toEqual([
+      {
+        packageName: '@skillsmith/multi-entry-sibling',
+        subpath: './nope',
+        specifier: '@skillsmith/multi-entry-sibling/nope',
+        occurrences: [{ file: 'packages/consumer/src/x.ts', line: 1, name: 'Foo' }],
+      },
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractWorkspaceImportsFromSource — static ImportDeclaration + ImportTypeNode
+// ---------------------------------------------------------------------------
+
+describe('extractWorkspaceImportsFromSource: static ImportDeclaration + ImportTypeNode extraction', () => {
+  it('symbol aliasing "X as Y" checks the PRE-alias name (X), not the local alias (Y)', () => {
+    const src = "import { X as Y } from '@skillsmith/sibling'\nconsole.log(Y)\n"
+    const { named } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named).toEqual([
+      {
+        file: 'f.ts',
+        line: 1,
+        packageName: '@skillsmith/sibling',
+        subpath: '.',
+        specifier: '@skillsmith/sibling',
+        name: 'X',
+        kind: 'named',
+      },
+    ])
+  })
+
+  it('"import type { X }" and per-specifier "type X" are both still checked as named imports', () => {
+    const src = [
+      "import type { X } from '@skillsmith/sibling'",
+      "import { type Y } from '@skillsmith/sibling'",
+    ].join('\n')
+    const { named } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named.map((n: { name: string }) => n.name).sort()).toEqual(['X', 'Y'])
+    expect(named.every((n: { kind: string }) => n.kind === 'named')).toBe(true)
+  })
+
+  it("ImportTypeNode inline type query import('pkg').Foo — the live get-skill.ts pattern", () => {
+    const src = "type T = import('@skillsmith/core').TrustTier\n"
+    const { named } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named).toEqual([
+      {
+        file: 'f.ts',
+        line: 1,
+        packageName: '@skillsmith/core',
+        subpath: '.',
+        specifier: '@skillsmith/core',
+        name: 'TrustTier',
+        kind: 'type-query',
+      },
+    ])
+  })
+
+  it("a nested ImportTypeNode qualifier (import('pkg').Foo.Bar) checks only the BASE name (Foo)", () => {
+    const src = "type T = import('@skillsmith/core').Foo.Bar\n"
+    const { named } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named.map((n: { name: string }) => n.name)).toEqual(['Foo'])
+  })
+
+  it("a qualifier-less ImportTypeNode (typeof import('pkg')) names no symbol — nothing to check, nothing to roll up", () => {
+    const src = "type T = typeof import('@skillsmith/core')\n"
+    const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named).toEqual([])
+    expect(unchecked).toEqual([])
+  })
+
+  it('default and namespace imports are counted into "unchecked" for the rollup tally, not silently dropped', () => {
+    const src = [
+      "import Foo from '@skillsmith/sibling'",
+      "import * as Bar from '@smith-horn/other'",
+    ].join('\n')
+    const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named).toEqual([])
+    expect(unchecked.map((u: { kind: string }) => u.kind).sort()).toEqual(['default', 'namespace'])
+  })
+
+  it('a side-effect-only import (no clause) is neither checked nor counted', () => {
+    const src = "import '@skillsmith/sibling'\n"
+    const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named).toEqual([])
+    expect(unchecked).toEqual([])
+  })
+
+  it('a non-workspace specifier is ignored entirely', () => {
+    const src = "import { readFile } from 'node:fs'\n"
+    const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named).toEqual([])
+    expect(unchecked).toEqual([])
+  })
+
+  it('an empty source file is skipped cleanly — no throw, no findings', () => {
+    expect(() => extractWorkspaceImportsFromSource('f.ts', '', SCOPE_PREFIXES)).not.toThrow()
+    const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', '', SCOPE_PREFIXES)
+    expect(named).toEqual([])
+    expect(unchecked).toEqual([])
+  })
+
+  it("a malformed/unparseable source file is tolerated — TS's syntactic parser recovers rather than throwing", () => {
+    const malformed = "import { X from '@skillsmith/sibling'\nfunction broken( {\n"
+    expect(() => extractWorkspaceImportsFromSource('f.ts', malformed, SCOPE_PREFIXES)).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractWorkspaceImportsFromSource — dynamic import(...) call expressions
+// (Finding 2 / SMI-6146 gap: the same failure class as SMI-6143 via a
+// different AST shape, CallExpression rather than ImportDeclaration)
+// ---------------------------------------------------------------------------
+
+describe('extractWorkspaceImportsFromSource: dynamic import(...) call expressions (Finding 2)', () => {
+  it('destructured awaited dynamic import — const { X, Y: Z } = await import(pkg) checks pre-alias names', () => {
+    const src = [
+      'async function f() {',
+      "  const { X, Y: Z } = await import('@skillsmith/sibling')",
+      '  return X + Z',
+      '}',
+    ].join('\n')
+    const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(
+      named.map((n: { name: string; kind: string }) => ({ name: n.name, kind: n.kind }))
+    ).toEqual([
+      { name: 'X', kind: 'dynamic-named' },
+      { name: 'Y', kind: 'dynamic-named' },
+    ])
+    expect(unchecked).toEqual([])
+  })
+
+  it('direct property access on the awaited namespace object — (await import(pkg)).X', () => {
+    const src = [
+      'async function f() {',
+      "  return (await import('@skillsmith/sibling')).trackEvent",
+      '}',
+    ].join('\n')
+    const { named } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(
+      named.map((n: { name: string; kind: string }) => ({ name: n.name, kind: n.kind }))
+    ).toEqual([{ name: 'trackEvent', kind: 'dynamic-property-access' }])
+  })
+
+  it('the whole-namespace-object-passed-around shape — live in packages/enterprise/src/audit/scheduled-scan.ts — is counted UNCHECKED, not silently dropped and not incorrectly resolved', () => {
+    // Reproduces the actual loadRunInventoryAudit() shape in
+    // scheduled-scan.ts: `const mod = (await import(...)) as {...}` then,
+    // in a SEPARATE later statement, `return mod.runInventoryAudit`. This
+    // function does not track identifier references across statements, so
+    // this is genuinely unresolvable here and must be counted into the
+    // rollup tally, not skipped uncounted.
+    const src = [
+      'async function loadRunInventoryAudit() {',
+      "  const mod = (await import('@skillsmith/mcp-server/audit')) as {",
+      '    runInventoryAudit: RunInventoryAuditFn',
+      '  }',
+      '  return mod.runInventoryAudit',
+      '}',
+    ].join('\n')
+    const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named).toEqual([])
+    expect(unchecked).toEqual([
+      {
+        file: 'f.ts',
+        line: 2,
+        packageName: '@skillsmith/mcp-server',
+        subpath: './audit',
+        specifier: '@skillsmith/mcp-server/audit',
+        kind: 'dynamic-unresolved',
+      },
+    ])
+  })
+
+  it('an un-awaited dynamic import (import(pkg).then(...)) is counted unchecked, not resolved', () => {
+    const src = "import('@skillsmith/sibling').then((mod) => mod.trackEvent)\n"
+    const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named).toEqual([])
+    expect(unchecked.map((u: { kind: string }) => u.kind)).toEqual(['dynamic-unresolved'])
+  })
+
+  it('destructuring the namespace object\'s "default" property is unchecked — module default export, not a named export to look up', () => {
+    const src = [
+      'async function f() {',
+      "  const { default: Foo } = await import('@skillsmith/sibling')",
+      '  return Foo',
+      '}',
+    ].join('\n')
+    const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named).toEqual([])
+    expect(unchecked.map((u: { kind: string }) => u.kind)).toEqual(['dynamic-default'])
+  })
+
+  it('a rest-binding destructure (const { ...rest } = await import(pkg)) is unchecked — unknown breadth', () => {
+    const src = [
+      'async function f() {',
+      "  const { ...rest } = await import('@skillsmith/sibling')",
+      '  return rest',
+      '}',
+    ].join('\n')
+    const { unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(unchecked.map((u: { kind: string }) => u.kind)).toEqual(['dynamic-unresolved'])
+  })
+
+  it('a non-workspace dynamic import specifier is ignored entirely', () => {
+    const src = "async function f() { const { readFile } = await import('node:fs/promises') }\n"
+    const { named, unchecked } = extractWorkspaceImportsFromSource('f.ts', src, SCOPE_PREFIXES)
+    expect(named).toEqual([])
+    expect(unchecked).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluateExportSurfaceShadowGate — Check 63 driver's shadow-burn-in +
+// opt-out-marker gate (Finding 3: driver-level coverage)
+// ---------------------------------------------------------------------------
+
+describe('evaluateExportSurfaceShadowGate: Check 63 driver shadow-burn-in + opt-out-marker gate', () => {
+  const SKIP_MARKER = '[skip-export-surface-check]'
+
+  it('in-shadow-warn: now before shadowEndDate -> inShadow true, report "warn", marker never checked even if present', () => {
+    const result = evaluateExportSurfaceShadowGate({
+      shadowEndDate: '2026-09-01',
+      now: new Date('2026-08-15T00:00:00Z'),
+      prBody: `some PR body with ${SKIP_MARKER} in it`,
+      skipMarker: SKIP_MARKER,
+    })
+    expect(result.inShadow).toBe(true)
+    expect(result.report).toBe('warn')
+    expect(result.shadowSuffix).toContain('shadow mode through 2026-09-01')
+    expect(result.skipAcknowledged).toBe(false)
+  })
+
+  it('post-shadow-fail: now on/after shadowEndDate, no marker -> inShadow false, report "fail", not acknowledged', () => {
+    const result = evaluateExportSurfaceShadowGate({
+      shadowEndDate: '2026-09-01',
+      now: new Date('2026-09-02T00:00:00Z'),
+      prBody: 'no marker here',
+      skipMarker: SKIP_MARKER,
+    })
+    expect(result.inShadow).toBe(false)
+    expect(result.report).toBe('fail')
+    expect(result.shadowSuffix).toBe('')
+    expect(result.skipAcknowledged).toBe(false)
+  })
+
+  it('marker-present-suppresses-failure: post-shadow + marker in PR body -> skipAcknowledged true (the driver downgrades to warn() when acknowledged)', () => {
+    const result = evaluateExportSurfaceShadowGate({
+      shadowEndDate: '2026-09-01',
+      now: new Date('2026-09-02T00:00:00Z'),
+      prBody: `Reason paragraph. ${SKIP_MARKER}`,
+      skipMarker: SKIP_MARKER,
+    })
+    expect(result.inShadow).toBe(false)
+    expect(result.report).toBe('fail')
+    expect(result.skipAcknowledged).toBe(true)
+  })
+
+  it('a missing/undefined PR body does not throw and is treated as no marker present', () => {
+    const params = {
+      shadowEndDate: '2026-09-01',
+      now: new Date('2026-09-02T00:00:00Z'),
+      prBody: undefined,
+      skipMarker: SKIP_MARKER,
+    }
+    expect(() => evaluateExportSurfaceShadowGate(params)).not.toThrow()
+    expect(evaluateExportSurfaceShadowGate(params).skipAcknowledged).toBe(false)
+  })
+})

--- a/scripts/verify-publish-deps.mjs
+++ b/scripts/verify-publish-deps.mjs
@@ -14,6 +14,18 @@
  *   node scripts/verify-publish-deps.mjs          # Check all packages
  *   node scripts/verify-publish-deps.mjs --ci     # CI mode (GitHub annotations)
  *
+ * SMI-6146 note: this script (and audit:standards Check 58) prove
+ * VERSION-RANGE coherence — that a consumer's declared dependency range is
+ * internally consistent with its sibling's version string. Neither opens a
+ * source file, so neither can prove the imported symbols actually EXIST in
+ * the sibling — that's a structurally different question, answered by
+ * audit:standards Check 63 (export-surface coherence,
+ * scripts/audit-export-surface-resolver-helpers.mjs /
+ * scripts/audit-export-surface-consumer-helpers.mjs), which reads source
+ * and reasons about the real export surface independent of what either
+ * package's version field says. See
+ * docs/internal/implementation/smi-6146-export-surface-coherence-check.md.
+ *
  * @see docs/internal/retros/2026-03-19-mcp-server-0.4.5-hotfix.md
  */
 import { readFileSync, existsSync } from 'fs'


### PR DESCRIPTION
## Business Summary

**What shipped:** A new automated check that catches a package depending on code a sibling package hasn't actually built yet — the exact bug that broke every fresh install of `@skillsmith/mcp-server@0.7.10` last week (SMI-6143). The two checks that were supposed to catch this only ever compared version numbers between packages, never what either package's code actually contains, so they passed cleanly on the commit that shipped the outage. This one reads the actual source.

**Quality bar:** Reviewed three separate times before merge — a three-perspective plan review (Product/Engineering/Design) before any code was written, an independent code review from a different AI model (GPT-5.6-Sol) after implementation, and a final internal governance pass. Every finding from all three passes was fixed in this same PR, none deferred. 49 regression tests added; the check itself was run against the real, current codebase and confirmed to pass cleanly (672 real cross-package imports checked, zero false alarms).

**Net result:** Fully shipped, no follow-up needed.

---

## Technical detail

Linear: SMI-6146. Full design record: `docs/internal/implementation/smi-6146-export-surface-coherence-check.md`.

Adds `audit:standards` Check 63. Resolves a workspace sibling package's real exported-symbol set from source — reusing the existing `parseTsExports`/`collectTsEntryExports` helpers (Check 29, SMI-4193) rather than duplicating them — across the sibling's entire `package.json` `exports` map (root plus every subpath), then compares it against every symbol a consumer package actually imports via `ImportDeclaration`, `ImportTypeNode`, and statically-resolvable dynamic `import()` calls.

Runs inside the existing `quality-checks` CI job (already installs dependencies for lint/typecheck, so no new CI wiring or install step needed) on every PR, not just version-bump PRs — this is a pre-merge gate, stronger than the pre-publish gate SMI-6146 originally asked about, since it doesn't depend on publish state at all.

Files:
- `scripts/audit-export-surface-resolver-helpers.mjs` (new)
- `scripts/audit-export-surface-consumer-helpers.mjs` (new)
- `scripts/tests/audit-export-surface-coherence.test.ts` (new, 49 cases)
- `scripts/audit-standards.mjs` (Check 63 driver)
- `scripts/verify-publish-deps.mjs` (header comment documenting the version-range-coherence vs. export-surface-coherence distinction)
- `docs/internal/process/guards-and-opt-outs.md` (new registry row)

Ships with a 1-week shadow burn-in (`CHECK_63_SHADOW_END_DATE`, warn-only) before promoting to a blocking failure, and a dedicated `[skip-export-surface-check]` opt-out marker — deliberately separate from the existing `[skip-version-coherence-check]` marker, since the two checks catch different risk classes.

**CI**: `npm run typecheck`, `npm run audit:standards`, and the new test file all verified independently in this worktree's own container before every commit.
