### PR TITLE
docs: SMI-6161 require dedicated ADR for genuine architecture decisions in plans

### DIFF
--- a/.claude/templates/implementation-plan.md
+++ b/.claude/templates/implementation-plan.md
@@ -137,6 +137,7 @@ If the audit surfaces a producer/consumer pair without an explicit invariant, **
 - [ ] PL/pgSQL name-collision audit (P-3) completed _if_ plan touches a `RETURNS TABLE` function
 - [ ] Smoke path (P-4) specified and run post-deploy (or `scripts/smoke-prod.sh` invoked once it exists)
 - [ ] Shared-state audit (P-5) completed _if_ plan touches browser/Node globals, event listeners on shared targets, computed-key caches, row-shape extensions, or new async producer/consumer pairs
+- [ ] If this plan includes a genuine architecture decision (not just an implementation detail), flag it and confirm whether it warrants its own `docs/internal/adr/` entry — routed via `harness-governance`'s VP Engineering rubric too (standing rule since 2026-08-24, see CLAUDE.md § Infrastructure Change Policy)
 - [ ] **If this change targets a non-Docker CI workflow** (e.g. `post-merge-verify.yml`,
       any workflow running on `ubuntu-latest` without the Docker dev container):
       verify in a clean-install environment — `npm ci` in a fresh clone or after

--- a/.claude/templates/implementation-plan.md
+++ b/.claude/templates/implementation-plan.md
@@ -137,7 +137,7 @@ If the audit surfaces a producer/consumer pair without an explicit invariant, **
 - [ ] PL/pgSQL name-collision audit (P-3) completed _if_ plan touches a `RETURNS TABLE` function
 - [ ] Smoke path (P-4) specified and run post-deploy (or `scripts/smoke-prod.sh` invoked once it exists)
 - [ ] Shared-state audit (P-5) completed _if_ plan touches browser/Node globals, event listeners on shared targets, computed-key caches, row-shape extensions, or new async producer/consumer pairs
-- [ ] If this plan includes a genuine architecture decision (not just an implementation detail), flag it and confirm whether it warrants its own `docs/internal/adr/` entry — routed via `harness-governance`'s VP Engineering rubric too (standing rule since 2026-08-24, see CLAUDE.md § Infrastructure Change Policy)
+- [ ] If this plan includes a genuine architecture decision (not just an implementation detail), flag it and confirm whether it warrants its own `docs/internal/adr/` entry — `plan-review-skill`'s VP Engineering rubric checks for this (standing rule since 2026-08-24, see CLAUDE.md § Infrastructure Change Policy)
 - [ ] **If this change targets a non-Docker CI workflow** (e.g. `post-merge-verify.yml`,
       any workflow running on `ubuntu-latest` without the Docker dev container):
       verify in a clean-install environment — `npm ci` in a fresh clone or after

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,6 +411,8 @@ Trigger paths: `docker-entrypoint.sh`, `Dockerfile`, `docker-compose.yml`, `.git
 
 Application code (`packages/*/src/**`) and docs do not require this. See [ADR-109](docs/internal/adr/109-sparc-plan-review-for-infra-changes.md).
 
+**Architecture decisions get their own ADR (standing rule since 2026-08-24, prospective only).** A plan doc capturing *what* changed isn't the same as an ADR capturing *why one structurally different approach was chosen over another*. When a plan's own architecture decision is genuine (not just an implementation detail), flag it and ask whether it warrants a dedicated `docs/internal/adr/` entry — `plan-review-skill`'s VP Engineering rubric checks for this.
+
 ---
 
 ## Important Instruction Reminders


### PR DESCRIPTION
## Business Summary

**What shipped:** CLAUDE.md and the implementation-plan template now say that a genuine architecture decision inside a plan (not just an implementation detail) needs its own dedicated ADR, not just a mention in the plan doc.

**Quality bar:** Docs-only change; pre-push format/test checks passed.

**Net result:** Done, no follow-up. Re-creates an edit from earlier in this session that a separate automated docs-pointer-bump routine appears to have silently discarded via a hard reset on the shared main checkout — no functional change beyond restoring it.

---

## Technical detail

- `CLAUDE.md` — one paragraph added to the "Infrastructure Change Policy (ADR-109)" section.
- `.claude/templates/implementation-plan.md` — one Verification checklist item added, mirroring the existing P-1–P-5 items.

SMI-6161.


[skip-impl-check] — genuinely docs-only change (CLAUDE.md + template prose), no application source, no tests to add.
